### PR TITLE
feat(migration): reconnect checklist from the legacy Composio consumer account

### DIFF
--- a/app/src/components/onboarding/cloud-migration/done-followups.tsx
+++ b/app/src/components/onboarding/cloud-migration/done-followups.tsx
@@ -2,9 +2,14 @@ import { Button } from "@houston-ai/core";
 import confetti from "canvas-confetti";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useIntegrationToolkits } from "../../../hooks/queries";
+import {
+  useIntegrationConnections,
+  useIntegrationToolkits,
+} from "../../../hooks/queries";
 import { appDisplay } from "../../integrations/app-display";
 import { AppRow } from "../../integrations/app-row";
+import { INTEGRATION_PROVIDER } from "../../integrations/model";
+import { useConnectFlow } from "../../integrations/use-connect-flow";
 import { ProviderBrowser } from "../../provider-browser/provider-browser";
 import { useProviderBrowserData } from "../../provider-browser/use-provider-browser-data";
 import { SuccessCheck } from "../success-check";
@@ -95,16 +100,12 @@ export function DoneCongrats({ onFinish }: { onFinish: () => void }) {
   );
 }
 
-/** TODO(HOU-719): wire real per-app OAuth; today this is a visual placeholder
- *  and the row itself links out to the Apps section for the real flow. */
-function noopConnect() {}
-
 /**
- * Step 2: the apps the legacy agents had connected before, one row per
- * toolkit via the shared `<AppRow>` (real logo, real name, from the
- * Composio toolkit catalog). Connecting for real happens later in the
- * integrations surface; the Connect pill here is a placeholder so the row
- * doesn't read as dead.
+ * Step 2: the apps the legacy account had connected before, one row per
+ * toolkit via the shared `<AppRow>` (real logo, real name, from the Composio
+ * toolkit catalog). Connect is the REAL account-level OAuth hand-off — the
+ * same `useConnectFlow` the Integrations tab runs (mint link, open browser,
+ * poll until active, invalidate, toast failures) with no agent context.
  */
 export function DoneStepApps({ integrations }: { integrations: string[] }) {
   const { t } = useTranslation("migration");
@@ -121,27 +122,50 @@ export function DoneStepApps({ integrations }: { integrations: string[] }) {
     (toolkitCatalog.data ?? []).map((tk) => [tk.slug, tk]),
   );
 
+  // Live account connections, so a toolkit the user already reconnected (or
+  // connects right here) renders as Connected instead of a dead Connect.
+  const connections = useIntegrationConnections(
+    INTEGRATION_PROVIDER,
+    integrations.length > 0,
+  );
+  const activeToolkits = new Set(
+    (connections.data ?? [])
+      .filter((c) => c.status === "active")
+      .map((c) => c.toolkit),
+  );
+
+  const flow = useConnectFlow({ autoGrant: false });
+
   if (integrations.length === 0) return null;
 
   return (
     <ul className="flex flex-col gap-2">
-      {integrations.map((slug) => (
-        <li key={slug}>
-          <AppRow
-            display={appDisplay(slug, bySlug.get(slug))}
-            trailing={
-              <Button
-                variant="secondary"
-                size="sm"
-                className="rounded-full"
-                onClick={noopConnect}
-              >
-                {t("done.connect")}
-              </Button>
-            }
-          />
-        </li>
-      ))}
+      {integrations.map((slug) => {
+        const isConnected = activeToolkits.has(slug);
+        const isBusy = flow.state?.toolkit === slug;
+        return (
+          <li key={slug}>
+            <AppRow
+              display={appDisplay(slug, bySlug.get(slug))}
+              trailing={
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="rounded-full"
+                  disabled={isConnected || flow.state !== null}
+                  onClick={() => void flow.connect(slug)}
+                >
+                  {isConnected
+                    ? t("done.connected")
+                    : isBusy
+                      ? t("done.connecting")
+                      : t("done.connect")}
+                </Button>
+              }
+            />
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/app/src/lib/cloud-migration-prepare.ts
+++ b/app/src/lib/cloud-migration-prepare.ts
@@ -17,7 +17,7 @@ import {
 } from "./cloud-migration";
 import {
   agentMigrationStatus,
-  fetchSourceAgents,
+  fetchSourceScan,
   type SourceHostHandshake,
 } from "./cloud-migration-transport";
 import { osStartMigrationSourceHost } from "./os-bridge";
@@ -58,11 +58,13 @@ export async function prepareMigration(
   existingAgents: Array<{ id: string; name: string }>,
 ): Promise<PreparedMigration> {
   const source = await osStartMigrationSourceHost();
-  const sourceAgents = await fetchSourceAgents(source);
-  const existing = await probeExistingAgents(existingAgents, sourceAgents);
+  const scan = await fetchSourceScan(source);
+  const existing = await probeExistingAgents(existingAgents, scan.agents);
   return {
     source,
-    tasks: buildMigrationPlan(sourceAgents, existing),
-    integrations: collectIntegrations(sourceAgents),
+    tasks: buildMigrationPlan(scan.agents, existing),
+    // Per-agent records (ancient installs) ∪ the account-level Composio
+    // list (the v0.4.x consumer account) — one deduped, sorted checklist.
+    integrations: collectIntegrations(scan.agents, scan.accountIntegrations),
   };
 }

--- a/app/src/lib/cloud-migration-transport.ts
+++ b/app/src/lib/cloud-migration-transport.ts
@@ -61,14 +61,28 @@ function sourceFetch(
   });
 }
 
-/** Every legacy agent across every workspace, with its migration manifest. */
-export async function fetchSourceAgents(
+export interface SourceScan {
+  agents: SourceAgent[];
+  /** The legacy Composio account's connected toolkit slugs (`~/.composio`),
+   *  best-effort — absent on an older source host reads as none. */
+  accountIntegrations: string[];
+}
+
+/** Every legacy agent across every workspace, with its migration manifest,
+ *  plus the account-level connected integrations. */
+export async function fetchSourceScan(
   src: SourceHostHandshake,
-): Promise<SourceAgent[]> {
+): Promise<SourceScan> {
   const res = await sourceFetch(src, "/v1/migration/source");
   if (!res.ok) await throwHttpError("migration source scan", res);
-  const body = (await res.json()) as { agents: SourceAgent[] };
-  return body.agents;
+  const body = (await res.json()) as {
+    agents: SourceAgent[];
+    accountIntegrations?: string[];
+  };
+  return {
+    agents: body.agents,
+    accountIntegrations: body.accountIntegrations ?? [],
+  };
 }
 
 /** Zip the given paths of one legacy agent on the source host. */

--- a/app/src/lib/cloud-migration.ts
+++ b/app/src/lib/cloud-migration.ts
@@ -184,10 +184,13 @@ export function isPlausibleMigrationTarget(
   });
 }
 
-/** Union of every source agent's connected toolkit slugs, sorted, for the
- *  "reconnect your apps" checklist on the done screen. */
-export function collectIntegrations(sourceAgents: SourceAgent[]): string[] {
-  const all = new Set<string>();
+/** Union of every source agent's connected toolkit slugs plus the legacy
+ *  account-level list, sorted, for the "reconnect your apps" checklist. */
+export function collectIntegrations(
+  sourceAgents: SourceAgent[],
+  accountIntegrations: string[] = [],
+): string[] {
+  const all = new Set<string>(accountIntegrations);
   for (const a of sourceAgents) {
     for (const slug of a.manifest.integrations) all.add(slug);
   }

--- a/app/src/locales/en/migration.json
+++ b/app/src/locales/en/migration.json
@@ -49,6 +49,8 @@
     "continue": "Continue",
     "back": "Back",
     "connect": "Connect",
+    "connecting": "Connecting…",
+    "connected": "Connected",
     "finish": "Start building",
     "congratsTitle": "You're all set",
     "congratsBody": "Your assistants are in the cloud and ready. Let's build something."

--- a/app/src/locales/es/migration.json
+++ b/app/src/locales/es/migration.json
@@ -49,6 +49,8 @@
     "continue": "Continuar",
     "back": "Atrás",
     "connect": "Conectar",
+    "connecting": "Conectando…",
+    "connected": "Conectado",
     "finish": "Empezar a crear",
     "congratsTitle": "Todo listo",
     "congratsBody": "Tus asistentes están en la nube y listos. Vamos a crear algo."

--- a/app/src/locales/pt/migration.json
+++ b/app/src/locales/pt/migration.json
@@ -49,6 +49,8 @@
     "continue": "Continuar",
     "back": "Voltar",
     "connect": "Conectar",
+    "connecting": "Conectando…",
+    "connected": "Conectado",
     "finish": "Começar a criar",
     "congratsTitle": "Tudo pronto",
     "congratsBody": "Seus assistentes estão na nuvem e prontos. Vamos criar algo."

--- a/app/tests/cloud-migration.test.ts
+++ b/app/tests/cloud-migration.test.ts
@@ -157,6 +157,23 @@ test("collects the sorted union of toolkit slugs across agents", () => {
   assert.deepEqual(slugs, ["gmail", "googlecalendar", "slack"]);
 });
 
+test("account-level legacy Composio slugs union into the checklist", () => {
+  // The v0.4.x cohort: no per-agent records, connections only in the
+  // consumer account probed via ~/.composio.
+  assert.deepEqual(collectIntegrations([], ["googledrive", "gmail"]), [
+    "gmail",
+    "googledrive",
+  ]);
+  // Both sources present: dedupe across them.
+  assert.deepEqual(
+    collectIntegrations(
+      [agent("Work", "Sales", ["gmail"])],
+      ["gmail", "slack"],
+    ),
+    ["gmail", "slack"],
+  );
+});
+
 // ── hasReconnectAppsStep ──────────────────────────────────────────────
 
 test("the apps step is skipped when there is nothing to show", () => {

--- a/packages/host/src/routes/migration-legacy-composio.test.ts
+++ b/packages/host/src/routes/migration-legacy-composio.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "vitest";
+import {
+  legacyConnectedToolkits,
+  normalizeToolkitSlugs,
+  parseLegacyComposioConfig,
+} from "./migration-legacy-composio";
+
+/**
+ * The legacy `~/.composio` consumer-account probe feeding the wizard's
+ * reconnect checklist. Everything is injected (file read + fetch), so these
+ * run hermetically; the REST shapes mirror the Rust engine's cli.rs calls.
+ */
+
+const CONFIG = JSON.stringify({
+  api_key: "uak_test",
+  base_url: "https://backend.composio.dev/",
+  org_id: "ok_test",
+});
+
+function fakeFetch(
+  handler: (url: string) => { status: number; body: unknown } | null,
+): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const hit = handler(url);
+    if (!hit) throw new Error(`unexpected fetch: ${url}`);
+    return new Response(JSON.stringify(hit.body), { status: hit.status });
+  }) as typeof fetch;
+}
+
+test("parses the user_data.json shapes (trailing-slash base, defaults)", () => {
+  expect(parseLegacyComposioConfig(CONFIG)).toEqual({
+    apiKey: "uak_test",
+    baseUrl: "https://backend.composio.dev",
+    orgId: "ok_test",
+  });
+  // Minimal file: base_url + org_id default.
+  expect(parseLegacyComposioConfig('{"api_key":"k"}')).toEqual({
+    apiKey: "k",
+    baseUrl: "https://backend.composio.dev",
+    orgId: "",
+  });
+  expect(parseLegacyComposioConfig('{"api_key":""}')).toBeNull();
+  expect(parseLegacyComposioConfig("not json")).toBeNull();
+});
+
+test("normalizes slugs like the Rust engine (trim, lowercase, dedupe, sort)", () => {
+  expect(
+    normalizeToolkitSlugs(["GMAIL", " googledrive ", "gmail", "", 42]),
+  ).toEqual(["gmail", "googledrive"]);
+  expect(normalizeToolkitSlugs("nope")).toEqual([]);
+});
+
+test("resolves the consumer project then lists its connected toolkits", async () => {
+  const seen: string[] = [];
+  const slugs = await legacyConnectedToolkits({
+    readTextFile: async () => CONFIG,
+    homeDir: () => "/home/u",
+    fetchFn: fakeFetch((url) => {
+      seen.push(url);
+      if (url.endsWith("/api/v3/org/consumer/project/resolve")) {
+        return {
+          status: 200,
+          body: { consumer_user_id: "consumer-1-ok_test" },
+        };
+      }
+      if (url.includes("/api/v3/org/consumer/connected_toolkits")) {
+        return { status: 200, body: { toolkits: ["GMAIL", "googledrive"] } };
+      }
+      return null;
+    }),
+  });
+  expect(slugs).toEqual(["gmail", "googledrive"]);
+  expect(seen[1]).toContain("user_id=consumer-1-ok_test");
+});
+
+test("every failure mode reads as no legacy account, never a throw", async () => {
+  // No file on disk (fresh machine / never connected).
+  expect(
+    await legacyConnectedToolkits({
+      readTextFile: async () => {
+        throw new Error("ENOENT");
+      },
+      fetchFn: fakeFetch(() => null),
+    }),
+  ).toEqual([]);
+  // Expired/revoked key: resolve answers 401.
+  expect(
+    await legacyConnectedToolkits({
+      readTextFile: async () => CONFIG,
+      fetchFn: fakeFetch(() => ({ status: 401, body: {} })),
+    }),
+  ).toEqual([]);
+  // Network down.
+  expect(
+    await legacyConnectedToolkits({
+      readTextFile: async () => CONFIG,
+      fetchFn: (async () => {
+        throw new Error("network down");
+      }) as typeof fetch,
+    }),
+  ).toEqual([]);
+});

--- a/packages/host/src/routes/migration-legacy-composio.ts
+++ b/packages/host/src/routes/migration-legacy-composio.ts
@@ -1,0 +1,121 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Account-level integrations of the LEGACY desktop app, for the migration
+ * wizard's reconnect checklist (HOU-719). The Rust app connected apps through
+ * the user's own Composio consumer account ("Composio for You"): the
+ * credential persists at `~/.composio/user_data.json` and outlives the app
+ * upgrade, so the migration source host can list the connected toolkits with
+ * the same two REST calls the old engine made (houston-composio/cli.rs).
+ *
+ * Strictly best-effort and read-only: any failure (no file, expired key,
+ * offline, API change) yields `[]` — the wizard then simply skips the
+ * reconnect step. Only toolkit SLUGS ever leave this module; the API key is
+ * read, used against Composio, and forgotten. Nothing here is uploaded.
+ */
+
+const DEFAULT_BASE_URL = "https://backend.composio.dev";
+/** Per-request budget. The scan runs alongside the manifest walk; a slow or
+ *  dead Composio must never hold the wizard's offer screen hostage. */
+const REQUEST_TIMEOUT_MS = 8_000;
+
+export interface LegacyComposioConfig {
+  apiKey: string;
+  baseUrl: string;
+  orgId: string;
+}
+
+/** Parse `~/.composio/user_data.json` content. Null when unusable. */
+export function parseLegacyComposioConfig(
+  content: string,
+): LegacyComposioConfig | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const record = parsed as Record<string, unknown>;
+  const apiKey = typeof record.api_key === "string" ? record.api_key : "";
+  if (!apiKey) return null;
+  return {
+    apiKey,
+    baseUrl:
+      typeof record.base_url === "string" && record.base_url
+        ? record.base_url.replace(/\/+$/, "")
+        : DEFAULT_BASE_URL,
+    orgId: typeof record.org_id === "string" ? record.org_id : "",
+  };
+}
+
+/** Slug hygiene, mirroring the Rust engine's normalize_toolkit_slugs. */
+export function normalizeToolkitSlugs(slugs: unknown): string[] {
+  if (!Array.isArray(slugs)) return [];
+  const cleaned = slugs
+    .filter((s): s is string => typeof s === "string")
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0);
+  return [...new Set(cleaned)].sort();
+}
+
+export interface LegacyComposioDeps {
+  readTextFile?: (path: string) => Promise<string>;
+  fetchFn?: typeof fetch;
+  homeDir?: () => string;
+}
+
+/**
+ * The legacy consumer account's connected toolkit slugs, `[]` on any failure.
+ * Two calls, ported verbatim from the Rust engine: resolve the consumer
+ * project, then list its connected toolkits.
+ */
+export async function legacyConnectedToolkits(
+  deps: LegacyComposioDeps = {},
+): Promise<string[]> {
+  const read = deps.readTextFile ?? ((p: string) => readFile(p, "utf8"));
+  const fetchFn = deps.fetchFn ?? fetch;
+  const home = (deps.homeDir ?? homedir)();
+  try {
+    const raw = await read(join(home, ".composio", "user_data.json"));
+    const config = parseLegacyComposioConfig(raw);
+    if (!config) return [];
+    const headers = {
+      "x-user-api-key": config.apiKey,
+      "x-org-id": config.orgId,
+      Accept: "application/json",
+    };
+
+    const resolveRes = await fetchFn(
+      `${config.baseUrl}/api/v3/org/consumer/project/resolve`,
+      {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      },
+    );
+    if (!resolveRes.ok) return [];
+    const resolved = (await resolveRes.json()) as {
+      consumer_user_id?: string;
+    };
+    if (!resolved.consumer_user_id) return [];
+
+    const listRes = await fetchFn(
+      `${config.baseUrl}/api/v3/org/consumer/connected_toolkits?user_id=${encodeURIComponent(resolved.consumer_user_id)}`,
+      { headers, signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) },
+    );
+    if (!listRes.ok) return [];
+    const body = (await listRes.json()) as { toolkits?: unknown };
+    return normalizeToolkitSlugs(body.toolkits);
+  } catch (err) {
+    // Best-effort by contract: an unreadable file or a dead API reads as "no
+    // legacy account". Logged so a cohort-wide breakage is still visible.
+    console.warn(
+      "[migration] legacy Composio toolkit scan skipped:",
+      err instanceof Error ? err.message : err,
+    );
+    return [];
+  }
+}

--- a/packages/host/src/routes/migration-source.ts
+++ b/packages/host/src/routes/migration-source.ts
@@ -5,6 +5,7 @@ import { CloudPaths } from "../paths";
 import type { WorkspaceStore } from "../ports";
 import type { Vfs } from "../vfs";
 import { json } from "./http";
+import { legacyConnectedToolkits } from "./migration-legacy-composio";
 import {
   classifyMigrationPath,
   MAX_MIGRATION_FILE_BYTES,
@@ -74,9 +75,12 @@ export interface MigrationSourceDeps {
   store: WorkspaceStore;
   vfs?: Vfs;
   paths?: WorkspacePaths;
+  /** Injectable for tests; defaults to the real `~/.composio` REST probe. */
+  accountIntegrations?: () => Promise<string[]>;
 }
 
-/** `GET /v1/migration/source` — every agent, every workspace, with manifests. */
+/** `GET /v1/migration/source` — every agent, every workspace, with manifests,
+ *  plus the legacy Composio account's connected toolkits (best-effort). */
 export async function handleMigrationSource(
   deps: MigrationSourceDeps,
   _userId: UserId,
@@ -89,7 +93,12 @@ export async function handleMigrationSource(
     json(res, 503, { error: "agent data not configured" });
     return true;
   }
+  const vfs = deps.vfs;
   const paths = deps.paths ?? new CloudPaths();
+  // The account-level probe (network) runs alongside the manifest walk (disk).
+  const accountIntegrationsPromise = (
+    deps.accountIntegrations ?? legacyConnectedToolkits
+  )();
   const agents = [];
   for (const agent of await deps.store.listAllAgents()) {
     const ws = await deps.store.getWorkspace(agent.workspaceId);
@@ -98,12 +107,12 @@ export async function handleMigrationSource(
       id: agent.id,
       workspaceId: agent.workspaceId,
       name: agent.name,
-      manifest: await buildMigrationManifest(
-        deps.vfs,
-        paths.agentRoot(ws, agent),
-      ),
+      manifest: await buildMigrationManifest(vfs, paths.agentRoot(ws, agent)),
     });
   }
-  json(res, 200, { agents });
+  json(res, 200, {
+    agents,
+    accountIntegrations: await accountIntegrationsPromise,
+  });
   return true;
 }


### PR DESCRIPTION
## Context

#893 skipped the empty Reconnect-your-apps step after concluding the legacy connections couldn't be enumerated. That conclusion was wrong: the v0.4.x app connected apps through the **user's own Composio consumer account** ("Composio for You"), and that credential persists at `~/.composio/user_data.json` — outliving the app upgrade. The old engine listed connections with two plain REST calls; the migration source host can do exactly the same.

## What this does

- New `migration-legacy-composio.ts` in the host: reads `~/.composio/user_data.json`, resolves the consumer project (`POST /api/v3/org/consumer/project/resolve`), lists its connected toolkits (`GET /api/v3/org/consumer/connected_toolkits`), and normalizes the slugs — a direct port of the legacy engine's own calls.
- `GET /v1/migration/source` now carries `accountIntegrations` alongside the per-agent manifests (probe runs concurrently with the manifest walk; 8s per-request timeout).
- The wizard unions account-level and per-agent slugs into one checklist. #893's empty-step skip stays as the fallback for users who never connected anything.

## Safety

Best-effort by contract: no file / expired key / offline / API change all read as "no legacy account" (`[]`), logged, never blocking the scan. Only toolkit **slugs** leave the module — the API key is read, used against Composio, and forgotten; nothing from `~/.composio` is ever uploaded.

## Verification

- Unit tests: config parsing (both file shapes), slug normalization, the two-call flow, and every failure mode (hermetic, injected fetch).
- Live: the two REST calls verified against the real Composio API with an actual `~/.composio` credential (resolve → consumer id → toolkit list round-trips).
- `@houston/host` vitest + app `node --test` + `tsgo` + Biome all green.