### PR TITLE
fix(release): give the vite build 4GB of Node heap on low-RAM runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,12 @@ permissions:
 # keep engine-release.yml's BUN_VERSION in sync when bumping.
 env:
   BUN_VERSION: "1.3.10"
+  # The frontend `vite build` peaks past Node's default old-space ceiling on
+  # low-RAM runners (the arm64 macOS image sizes the heap at ~2 GB and the
+  # 0.5.7 build OOM'd exactly there; windows-11-arm is similarly tight).
+  # Workflow-wide so every platform's Tauri beforeBuildCommand gets the same
+  # headroom.
+  NODE_OPTIONS: --max-old-space-size=4096
 
 jobs:
   # Lightweight orchestration job that runs before the heavy builds. It


### PR DESCRIPTION
The cloud-v0.5.7 release run failed on build-macos: `vite build` (Tauri's `beforeBuildCommand`) hit Node's default old-space ceiling and aborted with "FATAL ERROR: Reached heap limit Allocation failed" at ~2 GB. The arm64 macOS runner has ~7 GB of RAM, so Node sizes its default heap at ~2 GB, and the 0.5.x frontend now peaks past it; windows-11-arm has the same tight sizing. build-linux passed only because its runner gets a bigger default.

Fix: set `NODE_OPTIONS: --max-old-space-size=4096` at the workflow level so every platform's frontend build gets the same headroom.

Failed run: https://github.com/gethouston/houston/actions/runs/29272869227/job/86894693147

After merge: re-tag `cloud-v0.5.7` on the fixed commit (the current tag points at a commit without this fix).