### PR TITLE
fix(sidebar): stop agent list overflowing onto the user footer in short windows

### DIFF
--- a/ui/layout/src/sidebar.tsx
+++ b/ui/layout/src/sidebar.tsx
@@ -324,7 +324,7 @@ export function AppSidebar({
 
           {/* Items list */}
           <ScrollArea
-            className={cn("flex-1", collapsed ? "px-2 pt-2" : "px-2")}
+            className={cn("min-h-0 flex-1", collapsed ? "px-2 pt-2" : "px-2")}
           >
             {!collapsed && groups !== undefined ? (
               <SidebarGroupedList
@@ -352,8 +352,9 @@ export function AppSidebar({
           </ScrollArea>
         </div>
 
-        {/* Footer slot (e.g., update notification) */}
-        {footer}
+        {/* Footer slot (e.g., update notification). shrink-0 so a short
+            window squeezes the scrollable list, never the footer row. */}
+        {footer && <div className="shrink-0">{footer}</div>}
       </aside>
 
       {children}


### PR DESCRIPTION
## Problem

When the window is short, the sidebar's agent list paints over the user footer row, so the last agent rows and the signed-in email overlap each other instead of the list scrolling.

## Root cause

In `ui/layout/src/sidebar.tsx` the agent list's `ScrollArea` had `flex-1` but no `min-h-0`. A flex item's default `min-height: auto` keeps it from shrinking below its intrinsic content height, and since the Radix scroll viewport is `height: 100%` of the root, the root's intrinsic height was the full list. In a short window the list never scrolled; it overflowed downward across the footer.

## Fix

- `min-h-0` on the `ScrollArea` so it shrinks with the window and the viewport actually scrolls.
- `shrink-0` wrapper around the footer slot so a short window squeezes the scrollable list, never the user row.

Both surfaces (web and desktop) get the fix since it's in the shared layout package.

## Verification

Headless Playwright replica of the sidebar structure (including Radix's inline viewport styles) at a 380px-tall window:

- before: list not scrollable, visible list content extends 260px past the footer top (the reported overlap)
- after: viewport is scrollable and clips exactly at the footer top, zero overlap

`pnpm check` and `pnpm typecheck` pass (also enforced by the pre-commit hook).