### PR TITLE
perf(host): parallelize store hydration — cuts managed-pod wake by ~10s

### DIFF
--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -481,6 +481,15 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
   return {
     server,
     async start() {
+      // Boot-phase stamps. Everything before the listening banner used to be
+      // silent, which made a 15 s managed-pod wake unattributable from logs;
+      // process.uptime() in the first stamp exposes module-eval cost, and the
+      // banner's own timestamp closes the ledger.
+      const bootStamp = (phase: string) =>
+        console.log(
+          `[local-host] boot: ${phase} at +${process.uptime().toFixed(1)}s`,
+        );
+      bootStamp("module eval done");
       // The object store is authoritative in managed server mode. Hydration is
       // readiness-critical and must finish before migrations or HTTP listening;
       // failure propagates so the pod restarts without ever syncing an empty tree.
@@ -522,6 +531,7 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
           );
         }
       }
+      bootStamp("hydration + migrations done");
       const bind = opts.bind ?? "127.0.0.1";
       await new Promise<void>((resolve) =>
         server.listen(opts.port, bind, () => resolve()),

--- a/packages/host/src/store-sync/daemon.ts
+++ b/packages/host/src/store-sync/daemon.ts
@@ -59,6 +59,7 @@ export class StoreSyncDaemon {
 
   async hydrate(): Promise<void> {
     this.hydrated = false;
+    const startedAt = Date.now();
     await mkdir(this.opts.rootDir, { recursive: true });
     const manifest = await hydrate(this.opts.store, "", this.opts.rootDir, {
       excludes: this.excludes,
@@ -66,6 +67,12 @@ export class StoreSyncDaemon {
     });
     this.manifest = manifest;
     this.hydrated = true;
+    // Hydration gates the pod's readiness probe, so its cost must be visible
+    // in the boot log — a wake-latency regression should point here, not to a
+    // silent gap before the listening banner.
+    this.opts.log(
+      `[store-sync] hydrated ${manifest.size} objects in ${Date.now() - startedAt}ms`,
+    );
   }
 
   start(): void {

--- a/packages/runtime-client/src/object-sync/hydrate.test.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.test.ts
@@ -159,6 +159,18 @@ test("hydrate materializes many files faithfully under concurrency", async () =>
   }
 });
 
+test("a non-finite concurrency override still hydrates everything", async () => {
+  const { storeRoot, store, work } = setup();
+  seed(storeRoot, PREFIX, { "workspace/a.txt": "a", "workspace/b.txt": "b" });
+  // NaN would size the worker pool to zero and return a successful EMPTY
+  // manifest — the partial-manifest state the hydration latch must prevent.
+  const manifest = await hydrate(store, PREFIX, work, {
+    concurrency: Number.NaN,
+  });
+  expect(manifest.size).toBe(2);
+  expect(readFileSync(join(work, "workspace", "a.txt"), "utf8")).toBe("a");
+});
+
 test("a download failure rejects hydrate with that error, workers stop", async () => {
   const { storeRoot, store, work } = setup();
   const files: Record<string, string> = {};

--- a/packages/runtime-client/src/object-sync/hydrate.test.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.test.ts
@@ -143,3 +143,43 @@ test("missing prefix hydrates to an empty manifest", async () => {
   const { store, work } = setup();
   expect((await hydrate(store, "ws/none/agent-x", work)).size).toBe(0);
 });
+
+test("hydrate materializes many files faithfully under concurrency", async () => {
+  const { storeRoot, store, work } = setup();
+  const files: Record<string, string> = {};
+  for (let i = 0; i < 60; i++) files[`workspace/f${i}.txt`] = `content-${i}`;
+  seed(storeRoot, PREFIX, files);
+
+  const manifest = await hydrate(store, PREFIX, work, { concurrency: 16 });
+  expect(manifest.size).toBe(60);
+  for (let i = 0; i < 60; i++) {
+    expect(readFileSync(join(work, "workspace", `f${i}.txt`), "utf8")).toBe(
+      `content-${i}`,
+    );
+  }
+});
+
+test("a download failure rejects hydrate with that error, workers stop", async () => {
+  const { storeRoot, store, work } = setup();
+  const files: Record<string, string> = {};
+  for (let i = 0; i < 30; i++) files[`workspace/f${i}.txt`] = `content-${i}`;
+  seed(storeRoot, PREFIX, files);
+
+  let downloads = 0;
+  const flaky = {
+    list: (prefix: string) => store.list(prefix),
+    download: async (key: string, dest: string) => {
+      downloads += 1;
+      if (key.endsWith("f7.txt")) throw new Error("store download exploded");
+      return store.download(key, dest);
+    },
+    upload: (src: string, key: string) => store.upload(src, key),
+    delete: (key: string) => store.delete(key),
+  };
+  await expect(
+    hydrate(flaky, PREFIX, work, { concurrency: 8 }),
+  ).rejects.toThrow("store download exploded");
+  // The failure parks the pool: no worker takes new work afterwards, so at
+  // most the in-flight batch (< concurrency) follows the failing download.
+  expect(downloads).toBeLessThan(30);
+});

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -57,10 +57,14 @@ export async function hydrate(
 ): Promise<HydrateManifest> {
   const excludes = opts.excludes ?? DEFAULT_EXCLUDES;
   const maxBytes = opts.maxBytes ?? 512 * 1024 * 1024;
-  const concurrency = Math.max(
-    1,
-    opts.concurrency ?? DEFAULT_HYDRATE_CONCURRENCY,
-  );
+  // Guard against a non-finite override (NaN sizes the worker array to ZERO,
+  // which would return a successful empty manifest for a non-empty store —
+  // the exact partial-manifest state the hydration latch exists to prevent).
+  const requested = opts.concurrency ?? DEFAULT_HYDRATE_CONCURRENCY;
+  const concurrency =
+    Number.isFinite(requested) && requested >= 1
+      ? Math.floor(requested)
+      : DEFAULT_HYDRATE_CONCURRENCY;
   const manifest: HydrateManifest = new Map();
   const entries: { key: string; rel: string }[] = [];
   for (const key of await store.list(prefix)) {
@@ -77,7 +81,10 @@ export async function hydrate(
   let failed = false;
   let firstError: unknown;
   const worker = async () => {
-    while (!failed) {
+    // The cap check also gates NEW downloads (not only completed ones), so an
+    // over-cap workspace overshoots by at most the in-flight batch — the
+    // pooled analogue of the sequential loop's one-object overshoot.
+    while (!failed && total <= maxBytes) {
       const entry = entries[next++];
       if (!entry) return;
       const { key, rel } = entry;

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -37,7 +37,16 @@ export interface HydrateOptions {
   /** Reject prefixes whose total size exceeds this (default 512 MiB). */
   maxBytes?: number;
   excludes?: string[];
+  /**
+   * Concurrent downloads (default 16). Hydration gates the managed pod's
+   * readiness, and one store round-trip per object (~80 ms through the pod
+   * store) dominates cold wake time when it runs sequentially: a routine
+   * 133-object workspace measured 10.5 s sequential vs 0.4 s at 16.
+   */
+  concurrency?: number;
 }
+
+const DEFAULT_HYDRATE_CONCURRENCY = 16;
 
 /** Download everything under `prefix` into `destDir`. Returns the manifest. */
 export async function hydrate(
@@ -48,22 +57,54 @@ export async function hydrate(
 ): Promise<HydrateManifest> {
   const excludes = opts.excludes ?? DEFAULT_EXCLUDES;
   const maxBytes = opts.maxBytes ?? 512 * 1024 * 1024;
+  const concurrency = Math.max(
+    1,
+    opts.concurrency ?? DEFAULT_HYDRATE_CONCURRENCY,
+  );
   const manifest: HydrateManifest = new Map();
-  let total = 0;
+  const entries: { key: string; rel: string }[] = [];
   for (const key of await store.list(prefix)) {
     const rel = prefix ? key.slice(prefix.length + 1) : key;
     if (!rel || excluded(rel, excludes)) continue;
-    const dest = join(destDir, ...rel.split("/"));
-    await store.download(key, dest);
-    const buf = await readFile(dest);
-    total += buf.byteLength;
-    if (total > maxBytes) {
-      throw new Error(
-        `workspace exceeds the ${Math.round(maxBytes / 1024 / 1024)} MiB hydration limit`,
-      );
-    }
-    manifest.set(rel, sha256(buf));
+    entries.push({ key, rel });
   }
+  // Workers pull from a shared cursor. The first failure (download error or
+  // the size cap) parks every worker before it takes new work, and only that
+  // first error is thrown — workers themselves never reject, so a second
+  // failure can never become an unhandled rejection behind Promise.all.
+  let total = 0;
+  let next = 0;
+  let failed = false;
+  let firstError: unknown;
+  const worker = async () => {
+    while (!failed) {
+      const entry = entries[next++];
+      if (!entry) return;
+      const { key, rel } = entry;
+      try {
+        const dest = join(destDir, ...rel.split("/"));
+        await store.download(key, dest);
+        const buf = await readFile(dest);
+        total += buf.byteLength;
+        if (total > maxBytes) {
+          throw new Error(
+            `workspace exceeds the ${Math.round(maxBytes / 1024 / 1024)} MiB hydration limit`,
+          );
+        }
+        manifest.set(rel, sha256(buf));
+      } catch (err) {
+        if (!failed) {
+          failed = true;
+          firstError = err;
+        }
+        return;
+      }
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, entries.length) }, worker),
+  );
+  if (failed) throw firstError;
   return manifest;
 }
 


### PR DESCRIPTION
## The mystery

A managed engine pod's 0→1 wake takes ~15–17s to k8s-ready, with **zero log output** between container start and the `HOUSTON_HOST_LISTENING` banner. Traced in prod (2026-07-13, loadtest agents on `houston-prod`):

| Stage | t |
|---|---|
| Container running (image cached) | +0.7s |
| *(silence)* | |
| First log line + listening | +15.5s |
| ReadyReplicas visible | +17.0s |

## The diagnosis

Eliminated in order (all measured in prod): node scale-up (warm node), image pull (cached), DNS (3ms from a fresh pod), NetworkPolicy programming (fresh-pod probe connects in 47ms at t+0.06s), store server latency (authenticated manifest GET: 94ms), CPU-limited module eval (full `main.mjs` boot with hydration disabled: **2.8s**, identical warm/cold).

What remained: `hydrate()` downloads every object **sequentially** (`hydrate.ts` for-loop) and gates listening (`host.ts` — hydration is deliberately readiness-critical). Each object GET costs ~80ms through the pod store (control-plane → GCS). A routine loadtest workspace is 133 objects / 180KB total:

- sequential (today): **10.55s**
- 16-way concurrent (this PR): **0.43s**

0.7 (container) + 2.8 (eval) + 10.5 (hydrate) ≈ the observed 15.5s. And it scales with file count, so real users with bigger workspaces are *worse* today.

## The change

- `hydrate()` uses a bounded worker pool (default 16, `concurrency` option). Same manifest result, same size-cap enforcement (running total), first error wins and parks the pool — workers never reject behind `Promise.all`, so no unhandled rejections.
- Boot instrumentation: `[local-host] boot: module eval done at +Xs` and `boot: hydration + migrations done at +Xs` stamps in `host.start()`, plus `[store-sync] hydrated N objects in Yms` from the daemon. The silent window is gone — the next wake regression is attributable from pod logs alone.

## Expected effect

Managed-pod 0→1 wake: ~17s → **~6–7s** to k8s-ready (0.7 container + 2.8 eval + ~0.5 hydrate + probe/propagation). Gateway-side detection tuning (direct-dial) is the follow-up that shaves the remaining ~2–4s.

## Testing

- New: many-file concurrency correctness test; download-failure propagation test (error surfaces, pool stops, no unhandled rejections). Existing cap/exclusion/symlink tests now exercise the parallel path (default 16).
- `@houston/runtime-client`: 90 tests pass; `@houston/host`: 943 pass; typecheck + biome clean.
- Prod measurement methodology in the trace: sequential vs parallel downloads replicated from inside a running engine pod.