### PR TITLE
Release prep 0.5.8: version bump + notes

### DIFF
--- a/.github/release-notes/0.5.8.es.md
+++ b/.github/release-notes/0.5.8.es.md
@@ -1,0 +1,28 @@
+## Houston 0.5.8
+
+### Más rápido y más fluido
+
+- **Los agentes en la nube despiertan más rápido.** Abrir un agente que estaba
+  dormido ahora toma unos diez segundos menos en estar listo para conversar.
+
+### Correcciones y detalles
+
+- **La aplicación de Linux vuelve a iniciar.** Al paquete anterior de Linux le
+  faltaba una pieza de su motor y no podía iniciar. Este viene completo.
+- **Reconecta tus aplicaciones al mudarte a la nube.** El asistente de
+  migración ahora muestra una lista de las aplicaciones que tenías conectadas,
+  para que reconectes cada una en su nuevo hogar sin tener que buscarlas.
+- **La barra lateral se comporta en ventanas bajas.** Una lista larga de
+  agentes ya no se encima sobre el área de tu cuenta en la parte inferior.
+
+### Antes de actualizar
+
+- **Mac:** cierra Houston antes de instalar. macOS no siempre reemplaza bien
+  una aplicación abierta. Ante la duda, elimina `/Applications/Houston.app` y
+  arrastra la copia nueva.
+- **Windows x64:** la actualización automática desde 0.4.7 o posterior te trae
+  al día sola. El MSI aún no tiene firma de código del sistema, así que
+  SmartScreen puede advertir en una instalación nueva.
+- **Windows ARM64:** no hay actualización automática desde una instalación x64
+  emulada. Descarga el MSI ARM64 manualmente, desinstala primero la versión
+  x64 y luego instala la ARM64.

--- a/.github/release-notes/0.5.8.md
+++ b/.github/release-notes/0.5.8.md
@@ -1,0 +1,28 @@
+## Houston 0.5.8
+
+### Faster and smoother
+
+- **Cloud agents wake up faster.** Opening an agent that was asleep now takes
+  about ten seconds less before it is ready to chat.
+
+### Fixes and polish
+
+- **The Linux app starts again.** The previous Linux package was missing a
+  piece of its engine and could not start. This one is complete.
+- **Reconnect your apps after moving to the cloud.** The migration assistant
+  now shows a checklist of the apps you had connected before, so you can
+  reconnect each one in its new home instead of hunting for them.
+- **The sidebar behaves in short windows.** A long list of agents no longer
+  spills over your account area at the bottom.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a
+  running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag
+  the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward
+  automatically. The MSI is still not OS-code-signed, so Windows SmartScreen may
+  warn on a fresh install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install.
+  Download the ARM64 MSI manually, uninstall the x64 build first, then install
+  the ARM64 one.

--- a/.github/release-notes/0.5.8.pt.md
+++ b/.github/release-notes/0.5.8.pt.md
@@ -1,0 +1,29 @@
+## Houston 0.5.8
+
+### Mais rápido e mais fluido
+
+- **Os agentes na nuvem acordam mais rápido.** Abrir um agente que estava
+  dormindo agora leva uns dez segundos a menos para ficar pronto para
+  conversar.
+
+### Correções e ajustes
+
+- **O aplicativo de Linux volta a iniciar.** O pacote anterior de Linux estava
+  sem uma peça do motor e não conseguia iniciar. Este vem completo.
+- **Reconecte seus aplicativos ao se mudar para a nuvem.** O assistente de
+  migração agora mostra uma lista dos aplicativos que você tinha conectados,
+  para que você reconecte cada um no novo lugar sem precisar procurá-los.
+- **A barra lateral se comporta em janelas baixas.** Uma lista longa de
+  agentes não invade mais a área da sua conta na parte de baixo.
+
+### Antes de atualizar
+
+- **Mac:** feche o Houston antes de instalar. O macOS nem sempre substitui bem
+  um aplicativo aberto. Na dúvida, remova `/Applications/Houston.app` e
+  arraste a cópia nova.
+- **Windows x64:** a atualização automática a partir da 0.4.7 ou posterior te
+  traz para frente sozinha. O MSI ainda não tem assinatura de código do
+  sistema, então o SmartScreen pode avisar em uma instalação nova.
+- **Windows ARM64:** não há atualização automática a partir de uma instalação
+  x64 emulada. Baixe o MSI ARM64 manualmente, desinstale primeiro a versão x64
+  e depois instale a ARM64.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "chrono",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Bumps every Houston-versioned package to 0.5.8 (`scripts/version.sh 0.5.8`, Cargo.lock regenerated) and adds authored release notes (en/es/pt).

Cut for the cloud channel: tag `cloud-v0.5.8` points at this commit and its Release run builds the draft.

Changes since cloud-v0.5.7 covered by the notes: managed-pod wake ~10s faster (#901), Linux AppImage sidecar fix (#897), migration reconnect checklist (#895), sidebar overflow fix (#898).