### PR TITLE
fix: cloud-migration wizard recovery — keep the Settings retry after partial runs, escape hatch on errors

### DIFF
--- a/app/src/components/onboarding/cloud-migration/done-screen.tsx
+++ b/app/src/components/onboarding/cloud-migration/done-screen.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { hasReconnectAppsStep } from "../../../lib/cloud-migration";
+import {
+  doneScreenOutcome,
+  hasReconnectAppsStep,
+} from "../../../lib/cloud-migration";
 import { useCloudMigrationStore } from "../../../stores/cloud-migration";
 import { SetupCard } from "../setup-card";
 import { DoneCongrats, DoneStepAi, DoneStepApps } from "./done-followups";
@@ -16,7 +19,9 @@ type Step = "ai" | "apps" | "congrats";
  * move (failed agents, excluded files, rejected items) so nothing is silently
  * dropped. Stamps the persisted outcome on mount (`applyNow: false`, so a
  * relaunch skips the wizard without ripping this screen away); the congrats
- * step's button applies it in-session.
+ * step's button applies it in-session. A run with failed agents stamps
+ * "skipped", not "done", so Settings' "Continue migration" keeps the retry
+ * available (`doneScreenOutcome`).
  */
 export function DoneScreen({
   persistOutcome,
@@ -32,14 +37,16 @@ export function DoneScreen({
   const progress = useCloudMigrationStore((s) => s.progress);
   const integrations = useCloudMigrationStore((s) => s.integrations);
 
-  useEffect(() => {
-    persistOutcome("done", { applyNow: false });
-  }, [persistOutcome]);
-
   const doneTasks = tasks.filter((x) => progress[x.sourceId]?.step === "done");
   const failedTasks = tasks.filter(
     (x) => progress[x.sourceId]?.step !== "done",
   );
+
+  // "skipped" when agents were left behind, so Settings keeps the retry alive.
+  const outcome = doneScreenOutcome(failedTasks.length);
+  useEffect(() => {
+    persistOutcome(outcome, { applyNow: false });
+  }, [persistOutcome, outcome]);
   const excluded = doneTasks.flatMap((x) =>
     x.manifest.excluded.map((e) => e.path),
   );
@@ -59,7 +66,7 @@ export function DoneScreen({
   const afterAi: Step = showAppsStep ? "apps" : "congrats";
 
   if (step === "congrats") {
-    return <DoneCongrats onFinish={() => persistOutcome("done")} />;
+    return <DoneCongrats onFinish={() => persistOutcome(outcome)} />;
   }
 
   if (step === "ai") {

--- a/app/src/components/onboarding/cloud-migration/progress-screen.tsx
+++ b/app/src/components/onboarding/cloud-migration/progress-screen.tsx
@@ -87,6 +87,23 @@ function AgentRow({
   );
 }
 
+/** The quiet "Migrate later" escape hatch — the same `onDefer` everywhere:
+ *  while the run is still going AND on every error state, so a user stuck on
+ *  a failing backup/prepare/agent is never trapped with only Retry (the
+ *  Settings "Continue migration" row keeps the re-run available). */
+function DeferButton({ onDefer }: { onDefer: () => void }) {
+  const { t } = useTranslation("migration");
+  return (
+    <button
+      type="button"
+      onClick={onDefer}
+      className="rounded-full px-3 py-1 text-xs text-[var(--ht-space-foreground-muted)] transition-colors hover:text-[var(--ht-space-foreground)]"
+    >
+      {t("progress.migrateLater")}
+    </button>
+  );
+}
+
 /**
  * Live migration wait screen (HOU-719 redesign): the shared {@link OrbitLoader}
  * (the rocket in transit — the move made literal) over a status line that
@@ -127,24 +144,25 @@ export function ProgressScreen({ onDefer }: { onDefer?: () => void }) {
       mark={waiting ? <OrbitLoader /> : undefined}
       title={t("progress.title")}
       footer={
-        startError ? undefined : anyError && !anyRunning ? (
-          <Button
-            variant="outline"
-            className="rounded-full"
-            onClick={continueAnyway}
-          >
-            {t("progress.continueAnyway")}
-          </Button>
+        startError ? (
+          // Backup/prepare failed: Retry lives in the card; the footer offers
+          // the way out so the error never traps the user in the wizard.
+          onDefer && <DeferButton onDefer={onDefer} />
+        ) : anyError && !anyRunning ? (
+          <div className="flex flex-col items-center gap-2">
+            <Button
+              variant="outline"
+              className="rounded-full"
+              onClick={continueAnyway}
+            >
+              {t("progress.continueAnyway")}
+            </Button>
+            {onDefer && <DeferButton onDefer={onDefer} />}
+          </div>
         ) : onDefer ? (
           // The migration is still running (backup / prepare / uploading): let
           // the user leave and finish later from Settings if it's slow.
-          <button
-            type="button"
-            onClick={onDefer}
-            className="rounded-full px-3 py-1 text-xs text-[var(--ht-space-foreground-muted)] transition-colors hover:text-[var(--ht-space-foreground)]"
-          >
-            {t("progress.migrateLater")}
-          </button>
+          <DeferButton onDefer={onDefer} />
         ) : undefined
       }
     >

--- a/app/src/lib/cloud-migration.ts
+++ b/app/src/lib/cloud-migration.ts
@@ -198,6 +198,16 @@ export function collectIntegrations(
 }
 
 /**
+ * The outcome the done screen persists. A clean run is final ("done"); a run
+ * that left agents behind stamps "skipped", so the wizard stays closed on
+ * relaunch but Settings' "Continue migration" row — which hides only on
+ * "done" (`useMigrationAvailable`) — keeps offering the retry.
+ */
+export function doneScreenOutcome(failedAgents: number): "done" | "skipped" {
+  return failedAgents > 0 ? "skipped" : "done";
+}
+
+/**
  * Whether the done screen's second step ("Reconnect your apps" + the
  * leftovers report) has anything to show. Modern legacy installs (v0.4.2x)
  * connected integrations in PLATFORM mode — account-level in Composio, no

--- a/app/tests/cloud-migration.test.ts
+++ b/app/tests/cloud-migration.test.ts
@@ -4,6 +4,7 @@ import {
   buildMigrationPlan,
   chunkPaths,
   collectIntegrations,
+  doneScreenOutcome,
   hasReconnectAppsStep,
   isPlausibleMigrationTarget,
   type SourceAgent,
@@ -201,4 +202,18 @@ test("the apps step shows for integrations OR any leftover kind", () => {
   assert.equal(hasReconnectAppsStep({ ...none, failedAgents: 1 }), true);
   assert.equal(hasReconnectAppsStep({ ...none, excludedFiles: 1 }), true);
   assert.equal(hasReconnectAppsStep({ ...none, rejectedFiles: 1 }), true);
+});
+
+// ── doneScreenOutcome ─────────────────────────────────────────────────
+
+test("a clean run stamps done — the wizard and Settings row both retire", () => {
+  assert.equal(doneScreenOutcome(0), "done");
+});
+
+test("a run with failed agents stamps skipped so Settings keeps the retry", () => {
+  // Settings' "Continue migration" hides only on "done" (useMigrationAvailable);
+  // stamping "done" here used to strand Continue-anyway users with no UI path
+  // back to their failed agents.
+  assert.equal(doneScreenOutcome(1), "skipped");
+  assert.equal(doneScreenOutcome(5), "skipped");
 });


### PR DESCRIPTION
## What

Two recovery fixes for the first-run cloud-migration wizard (HOU-719):

1. **Partial runs keep the Settings retry alive.** The done screen stamped the per-machine outcome `done` even when agents failed and the user clicked *Continue anyway*. Settings' **Continue migration** row hides on `done` (`useMigrationAvailable`), so exactly the user it was written for lost the retry affordance — their only path back was hand-editing localStorage. A run with failed agents now stamps `skipped` (new pure `doneScreenOutcome`): the wizard still stays closed on relaunch, but Settings keeps offering the re-run, which resumes via the server-side import markers and skips agents that already landed.

2. **"Migrate later" on every error state.** The progress screen's error states trapped the user: a failed backup/prepare showed only *Retry* (no footer at all), and the per-agent failure panel offered only *Retry* + *Continue anyway*. The quiet **Migrate later** button (the same `onDefer` the running state already had — stops the source host, tracks `cloud_migration_deferred`, stamps `skipped`) now shows on both error states, so a user whose backup keeps failing (e.g. the Windows os-error-5 cohort fixed in #905) can always leave and retry later from Settings.

## Why now

The Windows backup failures showed users can get stuck at the very first step; with the outcome fix alone they'd still have been trapped inside the wizard on the failing attempt.

## Testing

- `app/tests/cloud-migration.test.ts`: two new tests for `doneScreenOutcome` (clean run → `done`, failures → `skipped`); 27/27 pass with the trigger suite.
- `pnpm tsgo --noEmit`, `pnpm check-locales` (reuses the existing `progress.migrateLater` key — no new strings), `pnpm check` all green.
- Manual: error states reachable via the wizard's dev demo mode.