### PR TITLE
fix(ai-hub): show a provider's full model list — hub now matches the chat picker

### DIFF
--- a/app/src/lib/ai-hub/catalog-pi.ts
+++ b/app/src/lib/ai-hub/catalog-pi.ts
@@ -16,7 +16,6 @@ import type { CatalogModelEntry, ProviderCatalog } from "@houston/protocol";
 import {
   DROP_PI_PROVIDERS,
   PROVIDER_ID_RENAME,
-  PROVIDER_OVERRIDES,
 } from "../provider-overrides.ts";
 import { normalizeKey } from "./catalog-key.ts";
 import { detectLab } from "./catalog-lab.ts";
@@ -54,12 +53,14 @@ function entryToRaw(entry: CatalogModelEntry): RawModel {
  * the picker render exactly the same providers (a coming-soon or otherwise-gated
  * provider in the raw catalog never becomes a hub model the picker can't offer).
  *
- * Subscription/OAuth providers (Anthropic, OpenAI/Codex, GitHub Copilot) run
- * ONLY their curated `PROVIDER_OVERRIDES[id].models` set — the plan can't run
- * anything outside it — so pi's full runnable list (pi ships every historical
- * model id it can still talk to, ~24 for Anthropic alone) is filtered down to
- * that curated set here. API-key gateways are unaffected: their full snapshot
- * list is a legitimate "any model this key can run" offer.
+ * Every provider carries its FULL pi model list — subscription/OAuth providers
+ * included. The hub, the provider modal, and the chat model picker must offer
+ * the SAME runnable set: the picker maps the hydrated `PROVIDERS` (pi's full
+ * per-provider list, deduped) directly, so filtering OAuth providers down to
+ * `PROVIDER_OVERRIDES[id].models` here made the hub show 3 Anthropic models
+ * while the chat picker offered 10. The overrides remain presentation-only
+ * (labels/descriptions); pi's catalog is the single existence source, and pi
+ * ≥0.80 already prunes retired ids upstream.
  */
 export function piCatalogToCandidates(
   catalog: ProviderCatalog,
@@ -71,11 +72,7 @@ export function piCatalogToCandidates(
     const providerId = PROVIDER_ID_RENAME[provider.id] ?? provider.id;
     if (visibleIds && !visibleIds.has(providerId)) continue;
     const subscription = provider.auth === "oauth";
-    const curatedIds = subscription
-      ? PROVIDER_OVERRIDES[providerId]?.models
-      : undefined;
     for (const entry of provider.models) {
-      if (curatedIds && !(entry.id in curatedIds)) continue;
       const raw = entryToRaw(entry);
       candidates.push({
         providerId,

--- a/app/tests/catalog-pi.test.ts
+++ b/app/tests/catalog-pi.test.ts
@@ -117,23 +117,23 @@ describe("piCatalogToCandidates maps the pi-ai catalog to merge candidates", () 
   });
 });
 
-describe("piCatalogToCandidates curates subscription providers", () => {
+describe("piCatalogToCandidates never filters a provider's model list", () => {
+  // The hub and the chat model picker must offer the SAME runnable set. The
+  // picker maps the hydrated PROVIDERS (pi's full per-provider list) directly,
+  // so the hub must not trim OAuth providers to the curated override set —
+  // that skew showed 3 Anthropic models in the hub against 10 in the picker.
   const catalog: ProviderCatalog = [
     provider("anthropic", "oauth", [
-      // Curated: a PROVIDER_OVERRIDES.anthropic.models entry.
+      // Has a PROVIDER_OVERRIDES.anthropic.models entry (label/description).
       entry("claude-sonnet-5"),
-      // Uncurated: pi runs it (an old id like claude-3-opus), but the plan's
-      // curated set doesn't list it — must be filtered out of the hub.
-      entry("claude-3-opus"),
+      // No override entry — still runnable, must still surface.
+      entry("claude-haiku-4-5"),
     ]),
-    provider("groq", "apiKey", [
-      // API-key gateways are NEVER curation-filtered: their full list stands.
-      entry("llama-4-scout"),
-    ]),
+    provider("groq", "apiKey", [entry("llama-4-scout")]),
   ];
   const candidates = piCatalogToCandidates(catalog);
 
-  it("keeps a curated OAuth model", () => {
+  it("keeps an OAuth model with a curated override", () => {
     ok(
       candidates.some(
         (c) => c.providerId === "anthropic" && c.raw.id === "claude-sonnet-5",
@@ -141,15 +141,15 @@ describe("piCatalogToCandidates curates subscription providers", () => {
     );
   });
 
-  it("drops an OAuth model absent from the curated set", () => {
+  it("keeps an OAuth model without any override entry", () => {
     ok(
-      !candidates.some(
-        (c) => c.providerId === "anthropic" && c.raw.id === "claude-3-opus",
+      candidates.some(
+        (c) => c.providerId === "anthropic" && c.raw.id === "claude-haiku-4-5",
       ),
     );
   });
 
-  it("never curation-filters an API-key gateway", () => {
+  it("keeps an API-key gateway's full list", () => {
     ok(
       candidates.some(
         (c) => c.providerId === "groq" && c.raw.id === "llama-4-scout",

--- a/app/tests/hub-catalog.test.ts
+++ b/app/tests/hub-catalog.test.ts
@@ -103,25 +103,26 @@ describe("pricing and subscription flags come from pi", () => {
     strictEqual(opencode?.costOutput, 2);
   });
 
-  it("curates an OAuth provider down to PROVIDER_OVERRIDES.<id>.models", () => {
-    // The fixture's `anthropic` provider also runs the prior-generation
-    // `claude-sonnet-4-6` / `claude-opus-4-7` ids, which have no
-    // PROVIDER_OVERRIDES.anthropic.models entry — the plan can't actually pick
-    // them, so the hub must not offer them (HOU curation gate).
+  it("offers an OAuth provider's FULL pi model list (no curation gate)", () => {
+    // The hub must mirror the chat model picker, which maps the hydrated
+    // PROVIDERS (pi's full per-provider list) directly. The fixture's
+    // `anthropic` provider also runs the prior-generation `claude-sonnet-4-6` /
+    // `claude-opus-4-7` ids with no PROVIDER_OVERRIDES.anthropic.models entry —
+    // they are runnable, so the hub offers them too.
     const ids = new Set<string>();
     for (const model of all.models)
       for (const offer of model.offers)
         if (offer.providerId === "anthropic") ids.add(offer.modelId);
     deepStrictEqual([...ids].sort(), [
       "claude-fable-5",
+      "claude-opus-4-7",
       "claude-opus-4-8",
+      "claude-sonnet-4-6",
       "claude-sonnet-5",
     ]);
-    ok(!ids.has("claude-sonnet-4-6"), "uncurated OAuth model must be filtered");
-    ok(!ids.has("claude-opus-4-7"), "uncurated OAuth model must be filtered");
   });
 
-  it("never curation-gates an API-key gateway", () => {
+  it("keeps an API-key gateway's full list", () => {
     // groq has no PROVIDER_OVERRIDES entry at all, and opencode is api-key —
     // both must expose every pi model they run.
     ok(all.byKey.get("llama 4 scout"));


### PR DESCRIPTION
## Problem

The AI hub's provider modal and the chat model picker disagreed about what a connected subscription can run: Anthropic showed **3 models** in the hub (Sonnet 5, Fable 5, Opus 4.8) but **10** in the chat picker (plus Haiku 4.5, Opus 4.1–4.7, Sonnet 4.5/4.6).

`piCatalogToCandidates` filtered subscription/OAuth providers down to the curated `PROVIDER_OVERRIDES[id].models` set (#810), while the chat picker maps the hydrated `PROVIDERS` — pi's full per-provider list, deduped — with no such gate. Two surfaces, two answers.

## Fix

Remove the hub-side curation gate. pi's catalog is the single existence source everywhere (and pi ≥0.80 already prunes the retired `claude-3-*` ids that motivated the gate in #810). The overrides stay presentation-only: curated labels/descriptions still enrich the models that have entries; the rest render pi's name, exactly as the chat picker always has. Dated duplicates (`claude-haiku-4-5` vs `-20251001`) still fold via the existing name-key dedupe.

After this, hub, provider modal, and chat picker all derive from the same `/v1/catalog`: 10 Anthropic / 7 OpenAI models on pi-ai 0.80.6 (verified by running the full pipeline end-to-end).

## Tests

- `catalog-pi.test.ts` / `hub-catalog.test.ts` rewritten to lock in the new invariant (an OAuth provider's full pi list surfaces, same as API-key gateways).
- Full app suite: 1520 pass. `pnpm tsgo --noEmit`, `houston-web` typecheck (shim parity), and `pnpm check` clean.

Companion to the cloud-side catalog snapshot fix (the hosted gateway was additionally serving a stale pi-ai 0.79 catalog; fixed separately in the cloud repo).