### PR TITLE
fix(anthropic): repair OAuth connect + credential lifecycle end to end

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Need specific knowledge? Load on demand:
 - Multiplayer Teams (orgs) client surface — roles owner/admin/user + per-agent access manager/user, role matrix v2 (`app/src/lib/org-roles.ts`), org dashboard, Share dialog, allowed-models ceiling + per-user model choice, integration allowlists; **plus C8 Spaces** (personal + team spaces, the `org:<slug>` workspace switcher / `x-houston-org` active-space pin, create-team, share-via-team pipeline, seat billing + trial + degrade states, `capabilities.spaces` + per-space role); the gateway is the sole enforcer → `knowledge-base/teams.md` (server contracts: `cloud/docs/contracts/C3`,`C4`,`C7-teams.md`,`C8-spaces-billing.md`)
 - v3 wire protocol (REST + SSE) → `packages/protocol/` (types + zod). The host is `packages/host` (run: `pnpm --filter @houston/host dev`).
 - Provider error taxonomy → `knowledge-base/provider-errors.md` (the shared taxonomy the host/pi providers map to; the old Rust classifier is gone).
+- Anthropic credential lifecycle (Claude-SDK backend: keychain scoping, cloud push, per-turn access-only serve, single-rotator rule) → `knowledge-base/anthropic-credentials.md`
 - Integrations: Composio is an in-process REST tool behind the `IntegrationProvider` port (`packages/host/src/integrations/`) — no bundled CLI, pi has no provider CLIs.
 - Self-host the TS engine on a VPS (Docker + Caddy TLS) → `selfhost/README.md`
 - Windows testing loop from a Mac (UTM VM, SSH bridge, cross-compile, log fetch) → `knowledge-base/windows-testing.md`

--- a/app/src-tauri/src/claude_login/credential.rs
+++ b/app/src-tauri/src/claude_login/credential.rs
@@ -6,23 +6,53 @@
 //! this machine's Keychain, so after a successful browser login the desktop
 //! extracts the credential here and pushes it over the control plane.
 //!
-//! Read order (first hit wins), scoped to the SAME dir the login wrote to
+//! Read order (first VALID hit wins), scoped to the SAME dir the login wrote to
 //! ([`super::claude_login_config_dir`]):
 //!   1. `<claudeLoginConfigDir>/.credentials.json` — Linux/Windows, and some
 //!      macOS setups. The file contents ARE the `{claudeAiOauth:{...}}` JSON.
-//!   2. macOS Keychain: `security find-generic-password -s "Claude Code-credentials" -w`
-//!      — the returned password IS that same JSON.
+//!   2. macOS Keychain, service `Claude Code-credentials-<sha256(dir)[..8]>`:
+//!      the CLI scopes its Keychain item by `CLAUDE_CONFIG_DIR` — the service
+//!      name carries the first 8 hex chars of the SHA-256 of the dir path, and
+//!      the account is the username. Reading the UNSUFFIXED service
+//!      `Claude Code-credentials` here would grab the credential of the user's
+//!      own `~/.claude` Claude Code install — pushing THAT to a pod makes the
+//!      pod and the user's personal CLI rotate the same refresh-token family
+//!      and sign each other out mid-session. So the dir-scoped item is the ONLY
+//!      Keychain source; if it is absent the caller degrades to the paste flow
+//!      rather than risk stealing an unrelated credential.
 //!
-//! The token is NEVER logged. Not-found and parse failures return a clear `Err`
-//! (→ the frontend falls back to the setup-token paste flow).
+//! A candidate that exists but holds no usable token (the CLI leaves emptied
+//! `{accessToken:""}` husks behind after logouts/failed refreshes) is SKIPPED,
+//! not fatal. The token is NEVER logged. Not-found and parse failures return a
+//! clear `Err` (→ the frontend falls back to the setup-token paste flow).
 
 use std::path::Path;
 use std::process::Command;
 
+use sha2::{Digest, Sha256};
+
 use super::claude_login_config_dir;
 
-/// Keychain service name the `claude` CLI stores its credential under (macOS).
-const KEYCHAIN_SERVICE: &str = "Claude Code-credentials";
+/// Base Keychain service name the `claude` CLI stores credentials under
+/// (macOS). The default `~/.claude` install uses it bare; any other
+/// `CLAUDE_CONFIG_DIR` gets a `-<sha256(dir)[..8]>` suffix.
+const KEYCHAIN_SERVICE_BASE: &str = "Claude Code-credentials";
+
+/// Keychain service name for a specific `CLAUDE_CONFIG_DIR`: the base name
+/// plus the first 8 hex chars of the SHA-256 of the dir path — the CLI's own
+/// scoping scheme, so we read exactly the item `claude auth login` wrote for
+/// Houston's login dir. The hash input is the path string EXACTLY as the CLI
+/// received it in `CLAUDE_CONFIG_DIR` (no normalization), which is the same
+/// `claude_login_config_dir()` string the login spawn passed.
+fn keychain_service_for(config_dir: &Path) -> String {
+    let digest = Sha256::digest(config_dir.to_string_lossy().as_bytes());
+    let prefix: String = digest
+        .iter()
+        .take(4)
+        .map(|b| format!("{b:02x}"))
+        .collect();
+    format!("{KEYCHAIN_SERVICE_BASE}-{prefix}")
+}
 
 /// Read the cached Anthropic credential JSON for Houston's shared login dir and
 /// return it verbatim (the CLI's `.credentials.json` shape). `Err` on
@@ -31,27 +61,36 @@ const KEYCHAIN_SERVICE: &str = "Claude Code-credentials";
 #[tauri::command]
 pub async fn read_claude_credential() -> Result<String, String> {
     let dir = claude_login_config_dir();
-    read_credential(&dir, keychain_credential)
+    read_credential(&dir, |service| keychain_credential(service))
 }
 
 /// Core extraction, split from the command so it is unit-testable with a fake
 /// config dir + injected Keychain reader (no real `security`, no `AppHandle`).
-/// `keychain` yields the stored JSON, `None` when the item is absent, or `Err`
-/// on an unexpected failure.
+/// `keychain` is called with the dir-scoped service name and yields the stored
+/// JSON, `None` when the item is absent, or `Err` on an unexpected failure.
 fn read_credential<F>(config_dir: &Path, keychain: F) -> Result<String, String>
 where
-    F: FnOnce() -> Result<Option<String>, String>,
+    F: FnOnce(&str) -> Result<Option<String>, String>,
 {
-    // 1. File first (Linux/Windows/some macOS).
+    // 1. File first (Linux/Windows/some macOS). A file that exists but is
+    // empty, token-less (a logout husk), or malformed falls through to the
+    // Keychain — on macOS the Keychain is the CLI's source of truth and the
+    // login may have cached a fresh credential there. The file's concrete
+    // problem is kept for the final error so a Linux user (no Keychain) still
+    // sees WHY their file was rejected.
+    let mut file_problem: Option<String> = None;
     let file = config_dir.join(".credentials.json");
     match std::fs::read_to_string(&file) {
         Ok(contents) => {
             let trimmed = contents.trim();
-            if !trimmed.is_empty() {
-                validate_credential(trimmed)?;
-                return Ok(trimmed.to_string());
+            if trimmed.is_empty() {
+                // Treat like an absent file.
+            } else {
+                match validate_credential(trimmed) {
+                    Ok(()) => return Ok(trimmed.to_string()),
+                    Err(e) => file_problem = Some(e),
+                }
             }
-            // Empty file — treat as absent and fall through to the Keychain.
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             // No file on this platform/setup — fall through to the Keychain.
@@ -64,16 +103,17 @@ where
         }
     }
 
-    // 2. macOS Keychain (no-op off macOS).
-    match keychain()? {
+    // 2. macOS Keychain, dir-scoped service only (no-op off macOS).
+    let service = keychain_service_for(config_dir);
+    match keychain(&service)? {
         Some(json) => {
             let trimmed = json.trim();
             validate_credential(trimmed)?;
             Ok(trimmed.to_string())
         }
-        None => {
-            Err("No cached Claude credential was found on this machine after sign-in.".to_string())
-        }
+        None => Err(file_problem.unwrap_or_else(|| {
+            "No cached Claude credential was found on this machine after sign-in.".to_string()
+        })),
     }
 }
 
@@ -94,20 +134,26 @@ fn validate_credential(json: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Build the `security find-generic-password -s "Claude Code-credentials" -w`
-/// command. Split out so the argv is unit-testable without spawning.
-fn build_keychain_command() -> Command {
+/// Build one `security find-generic-password` invocation. `account` narrows
+/// the lookup to the login's Keychain account (the username); without it the
+/// FIRST item under the service wins, which may be an emptied husk written by
+/// an env-scrubbed SDK subprocess. Split out so the argv is unit-testable
+/// without spawning.
+fn build_keychain_command(service: &str, account: Option<&str>) -> Command {
     let mut cmd = Command::new("security");
-    cmd.args(["find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"]);
+    cmd.args(["find-generic-password", "-s", service]);
+    if let Some(account) = account {
+        cmd.args(["-a", account]);
+    }
+    cmd.arg("-w");
     cmd
 }
 
-/// Read the credential from the macOS Keychain. A non-zero exit means the item
-/// is absent (`security` exits 44) — that is `Ok(None)`, not an error; only a
-/// spawn/decoding failure is an `Err`.
+/// Run one Keychain lookup. A non-zero exit means the item is absent
+/// (`security` exits 44) — `Ok(None)`; only a spawn/decoding failure is `Err`.
 #[cfg(target_os = "macos")]
-fn keychain_credential() -> Result<Option<String>, String> {
-    let output = build_keychain_command()
+fn keychain_lookup(service: &str, account: Option<&str>) -> Result<Option<String>, String> {
+    let output = build_keychain_command(service, account)
         .output()
         .map_err(|e| format!("Could not read the macOS Keychain: {e}"))?;
     if !output.status.success() {
@@ -118,9 +164,36 @@ fn keychain_credential() -> Result<Option<String>, String> {
     Ok(Some(value))
 }
 
+/// Read the credential from the macOS Keychain: the current user's account
+/// first (what `claude auth login` writes), then any account under the
+/// service. A hit whose payload has no usable token (an emptied logout husk)
+/// is skipped so it cannot mask the real item under another account.
+#[cfg(target_os = "macos")]
+fn keychain_credential(service: &str) -> Result<Option<String>, String> {
+    let user = std::env::var("USER").ok();
+    let attempts = [user.as_deref(), None];
+    let mut last_err: Option<String> = None;
+    for account in attempts {
+        match keychain_lookup(service, account) {
+            Ok(Some(json)) => {
+                if validate_credential(json.trim()).is_ok() {
+                    return Ok(Some(json));
+                }
+                // Husk (empty tokens) — try the next candidate.
+            }
+            Ok(None) => {}
+            Err(e) => last_err = Some(e),
+        }
+    }
+    match last_err {
+        Some(e) => Err(e),
+        None => Ok(None),
+    }
+}
+
 /// Off macOS there is no Keychain — the file read is the only source.
 #[cfg(not(target_os = "macos"))]
-fn keychain_credential() -> Result<Option<String>, String> {
+fn keychain_credential(_service: &str) -> Result<Option<String>, String> {
     Ok(None)
 }
 
@@ -130,6 +203,7 @@ mod tests {
     use std::path::PathBuf;
 
     const VALID: &str = r#"{"claudeAiOauth":{"accessToken":"tok","refreshToken":"ref","expiresAt":123,"scopes":["a"]}}"#;
+    const HUSK: &str = r#"{"claudeAiOauth":{"accessToken":"","refreshToken":"","expiresAt":0,"scopes":["a"]}}"#;
 
     fn unique_tmp_dir(tag: &str) -> PathBuf {
         let nanos = std::time::SystemTime::now()
@@ -145,11 +219,29 @@ mod tests {
     }
 
     #[test]
+    fn keychain_service_is_scoped_by_config_dir_hash() {
+        // Known vector: the CLI stores the credential for
+        // /Users/daniel/.dev-houston/claude-login under
+        // "Claude Code-credentials-3d1329c5" (sha256 of the path, first 8 hex).
+        let service =
+            keychain_service_for(Path::new("/Users/daniel/.dev-houston/claude-login"));
+        assert_eq!(service, "Claude Code-credentials-3d1329c5");
+    }
+
+    #[test]
+    fn different_dirs_get_different_services() {
+        let a = keychain_service_for(Path::new("/a/claude-login"));
+        let b = keychain_service_for(Path::new("/b/claude-login"));
+        assert_ne!(a, b);
+        assert!(a.starts_with("Claude Code-credentials-"));
+    }
+
+    #[test]
     fn reads_the_credentials_file_when_present() {
         let dir = unique_tmp_dir("file");
         std::fs::write(dir.join(".credentials.json"), VALID).expect("write cred");
         // Keychain must NOT be consulted once the file resolves.
-        let got = read_credential(&dir, || panic!("keychain should not be read"));
+        let got = read_credential(&dir, |_| panic!("keychain should not be read"));
         assert_eq!(got.as_deref(), Ok(VALID));
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
@@ -158,7 +250,18 @@ mod tests {
     fn falls_through_empty_file_to_keychain() {
         let dir = unique_tmp_dir("empty");
         std::fs::write(dir.join(".credentials.json"), "   \n").expect("write empty");
-        let got = read_credential(&dir, || Ok(Some(VALID.to_string())));
+        let got = read_credential(&dir, |_| Ok(Some(VALID.to_string())));
+        assert_eq!(got.as_deref(), Ok(VALID));
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn falls_through_husk_file_to_keychain() {
+        // A logout leaves `{accessToken:""}` behind; the fresh login credential
+        // in the Keychain must still be found.
+        let dir = unique_tmp_dir("huskfile");
+        std::fs::write(dir.join(".credentials.json"), HUSK).expect("write husk");
+        let got = read_credential(&dir, |_| Ok(Some(VALID.to_string())));
         assert_eq!(got.as_deref(), Ok(VALID));
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
@@ -167,7 +270,19 @@ mod tests {
     fn reads_keychain_when_no_file() {
         let dir = unique_tmp_dir("keychain");
         // No .credentials.json written.
-        let got = read_credential(&dir, || Ok(Some(VALID.to_string())));
+        let got = read_credential(&dir, |_| Ok(Some(VALID.to_string())));
+        assert_eq!(got.as_deref(), Ok(VALID));
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn keychain_is_asked_for_the_dir_scoped_service() {
+        let dir = unique_tmp_dir("svc");
+        let expected = keychain_service_for(&dir);
+        let got = read_credential(&dir, |service| {
+            assert_eq!(service, expected);
+            Ok(Some(VALID.to_string()))
+        });
         assert_eq!(got.as_deref(), Ok(VALID));
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
@@ -175,7 +290,7 @@ mod tests {
     #[test]
     fn not_found_errors_when_file_and_keychain_absent() {
         let dir = unique_tmp_dir("missing");
-        let got = read_credential(&dir, || Ok(None));
+        let got = read_credential(&dir, |_| Ok(None));
         let err = got.expect_err("must be not-found");
         assert!(
             err.contains("No cached Claude credential"),
@@ -185,21 +300,40 @@ mod tests {
     }
 
     #[test]
-    fn malformed_file_json_errors() {
+    fn malformed_file_json_falls_through_to_keychain() {
+        // A corrupt file must not dead-end the flow when the Keychain holds the
+        // real credential (the CLI treats the Keychain as its source of truth
+        // on macOS).
         let dir = unique_tmp_dir("garbage");
         std::fs::write(dir.join(".credentials.json"), "not json{").expect("write garbage");
-        let got = read_credential(&dir, || panic!("keychain should not be read"));
-        let err = got.expect_err("must be a parse error");
-        assert!(err.contains("not valid JSON"), "err was: {err}");
+        let got = read_credential(&dir, |_| Ok(Some(VALID.to_string())));
+        assert_eq!(got.as_deref(), Ok(VALID));
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 
     #[test]
-    fn missing_token_field_errors() {
+    fn missing_token_everywhere_reports_the_file_problem() {
+        // With nothing in the Keychain, the file's concrete rejection reason is
+        // what the Linux/self-host user needs to see.
         let dir = unique_tmp_dir("notoken");
         std::fs::write(dir.join(".credentials.json"), r#"{"claudeAiOauth":{}}"#).expect("write");
-        let got = read_credential(&dir, || panic!("keychain should not be read"));
+        let got = read_credential(&dir, |_| Ok(None));
         let err = got.expect_err("must reject missing token");
+        assert!(
+            err.contains("missing its access token"),
+            "err was: {err}"
+        );
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn keychain_husk_from_injected_reader_errors_as_invalid() {
+        // The injected reader models `keychain_credential` AFTER its own
+        // husk-skipping: if it still returns a husk, validation rejects it
+        // loudly rather than pushing an empty token to a pod.
+        let dir = unique_tmp_dir("huskkc");
+        let got = read_credential(&dir, |_| Ok(Some(HUSK.to_string())));
+        let err = got.expect_err("must reject the husk");
         assert!(err.contains("missing its access token"), "err was: {err}");
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
@@ -207,14 +341,14 @@ mod tests {
     #[test]
     fn keychain_error_propagates() {
         let dir = unique_tmp_dir("kcerr");
-        let got = read_credential(&dir, || Err("security blew up".to_string()));
+        let got = read_credential(&dir, |_| Err("security blew up".to_string()));
         assert_eq!(got, Err("security blew up".to_string()));
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 
     #[test]
-    fn keychain_command_argv_is_scoped_to_the_claude_service() {
-        let cmd = build_keychain_command();
+    fn keychain_command_argv_is_scoped_to_service_and_account() {
+        let cmd = build_keychain_command("Claude Code-credentials-3d1329c5", Some("daniel"));
         assert_eq!(cmd.get_program(), "security");
         let args: Vec<_> = cmd
             .get_args()
@@ -225,7 +359,27 @@ mod tests {
             vec![
                 "find-generic-password".to_string(),
                 "-s".to_string(),
-                "Claude Code-credentials".to_string(),
+                "Claude Code-credentials-3d1329c5".to_string(),
+                "-a".to_string(),
+                "daniel".to_string(),
+                "-w".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn keychain_command_argv_without_account() {
+        let cmd = build_keychain_command("Claude Code-credentials-3d1329c5", None);
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            args,
+            vec![
+                "find-generic-password".to_string(),
+                "-s".to_string(),
+                "Claude Code-credentials-3d1329c5".to_string(),
                 "-w".to_string(),
             ]
         );

--- a/app/src/hooks/provider-connections/use-provider-login-events.ts
+++ b/app/src/hooks/provider-connections/use-provider-login-events.ts
@@ -6,6 +6,7 @@ import { tryBeginCodexLoopbackLogin } from "../../lib/codex-loopback";
 import { genericErrorDescription } from "../../lib/error-toast";
 import { subscribeHoustonEvents } from "../../lib/events";
 import { osIsTauri } from "../../lib/os-bridge";
+import { localizedProviderLoginError } from "../../lib/provider-login-error";
 import { PROVIDERS, type ProviderInfo } from "../../lib/providers";
 import { tauriSystem } from "../../lib/tauri";
 import type {
@@ -125,7 +126,7 @@ export function useProviderLoginEvents({
             title: t("toast.signInFailed", {
               provider: prov?.name ?? ev.data.provider,
             }),
-            description: ev.data.error,
+            description: localizedProviderLoginError(ev.data.error),
             variant: "error",
           });
         }

--- a/app/src/lib/provider-login-error.ts
+++ b/app/src/lib/provider-login-error.ts
@@ -9,6 +9,10 @@
 // keeps it. Anything else keeps its real message (beta policy: the real
 // reason, never a generic swallow).
 
+import {
+  PROVIDER_CONNECT_TIMEOUT_ERROR,
+  PROVIDER_LOGIN_TIMEOUT_ERROR,
+} from "@houston-ai/core";
 import i18n from "./i18n";
 import { logger } from "./logger";
 
@@ -20,4 +24,19 @@ export function providerLoginFailureText(err: unknown): string {
     return i18n.t("providers:toast.engineUnavailable");
   }
   return raw;
+}
+
+/**
+ * Localize a `ProviderLoginComplete.error` string for the failure toast. The
+ * engine adapter stays i18n-agnostic and reports its client-side timeouts as
+ * stable English sentinels (`@houston-ai/core`); everything else is a real
+ * server/CLI message and passes through verbatim (beta policy: the real
+ * reason, never a generic swallow).
+ */
+export function localizedProviderLoginError(error: string): string {
+  if (error === PROVIDER_CONNECT_TIMEOUT_ERROR)
+    return i18n.t("providers:toast.connectTimedOut");
+  if (error === PROVIDER_LOGIN_TIMEOUT_ERROR)
+    return i18n.t("providers:toast.loginTimedOut");
+  return error;
 }

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -16,6 +16,8 @@
   "toast": {
     "signInFailed": "Couldn't open {{provider}} sign-in",
     "engineUnavailable": "Houston couldn't reach your workspace. Give it a moment and try again.",
+    "connectTimedOut": "The connection didn't complete in time. Please try connecting again.",
+    "loginTimedOut": "The sign-in didn't complete in time. Please try again.",
     "signOutFailed": "Couldn't sign out of {{provider}}",
     "signInSucceeded": "Signed in to {{provider}}",
     "cancelFailed": "Couldn't cancel {{provider}} sign-in",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -16,6 +16,8 @@
   "toast": {
     "signInFailed": "No se pudo abrir el inicio de sesión de {{provider}}",
     "engineUnavailable": "Houston no pudo conectarse con tu espacio de trabajo. Espera un momento e intenta de nuevo.",
+    "connectTimedOut": "La conexión no se completó a tiempo. Intenta conectarte de nuevo.",
+    "loginTimedOut": "El inicio de sesión no se completó a tiempo. Intenta de nuevo.",
     "signOutFailed": "No se pudo cerrar sesión de {{provider}}",
     "signInSucceeded": "Sesión iniciada en {{provider}}",
     "cancelFailed": "No se pudo cancelar el inicio de sesión de {{provider}}",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -16,6 +16,8 @@
   "toast": {
     "signInFailed": "Não foi possível abrir o login de {{provider}}",
     "engineUnavailable": "O Houston não conseguiu acessar seu espaço de trabalho. Aguarde um instante e tente de novo.",
+    "connectTimedOut": "A conexão não foi concluída a tempo. Tente conectar de novo.",
+    "loginTimedOut": "O login não foi concluído a tempo. Tente de novo.",
     "signOutFailed": "Não foi possível sair de {{provider}}",
     "signInSucceeded": "Conectado a {{provider}}",
     "cancelFailed": "Não foi possível cancelar o login de {{provider}}",

--- a/knowledge-base/anthropic-credentials.md
+++ b/knowledge-base/anthropic-credentials.md
@@ -1,0 +1,63 @@
+# Anthropic credential lifecycle (Claude subscription OAuth)
+
+Anthropic is the one provider whose turns run through the **Claude Agent SDK**
+(a `claude` subprocess), not pi — so its credential plumbing is different from
+every other provider. This file is the map. History: the July 2026 "Anthropic
+is unusable" cluster (reconnect card after every send locally, cloud connect
+timing out into the setup-token paste dialog, mid-session sign-outs) came from
+the four traps at the bottom — read them before touching any of this.
+
+## Where the credential lives, per deployment
+
+| Deployment | Source of truth | Who refreshes |
+|---|---|---|
+| Desktop (macOS) | Keychain item scoped to `<HOUSTON_HOME>/claude-login` (`claude auth login` writes it) | The SDK/CLI, in place |
+| Desktop (Linux/Win) / self-host | `<HOUSTON_HOME>/claude-login/.credentials.json` | The SDK/CLI, in place |
+| Managed cloud pod | Gateway Pg store (`/v1/pod/credentials`), captured at connect | The **gateway only** (single rotator; anthropic entry in `internal/credentials`, JSON grant) |
+| Setup-token paste (any) | `auth.json` `api_key` entry (never expires) | Nobody |
+
+## The flows
+
+- **Desktop browser login** (`app/src-tauri/src/claude_login/`): spawns
+  `claude auth login --claudeai` with `CLAUDE_CONFIG_DIR` pinned to the shared
+  login dir. The CLI opens the browser, catches its own loopback callback, and
+  caches the credential itself. There is NO deep link back to the app — the app
+  just watches the CLI's stdout/exit.
+- **Remote/cloud handoff** (`app/src/lib/claude-login-remote.ts`): after the
+  local login, `read_claude_credential` (Rust) extracts the cached credential —
+  file first, then the Keychain item `Claude Code-credentials-<sha256(dir)[:8]>`
+  (the CLI scopes the service name by config dir; account = username) — and
+  pushes it: host route `POST /agents/:id/credential/claude-oauth` → central
+  store put (access + refresh) + materialize on the pod. Any failure degrades
+  to the setup-token paste dialog (deliberate last resort; also the only path
+  for a pure-web client, which has no local CLI).
+- **Per-turn serve (managed cloud)**: the pod's serve sync
+  (`packages/runtime/src/auth/serve.ts`) probes anthropic like every provider;
+  the pod host serves a gateway-refreshed ACCESS-ONLY token
+  (`routes/credential.ts`), the runtime writes it to `auth.json`
+  (`refresh=""`), and the SDK consumes it via `CLAUDE_CODE_OAUTH_TOKEN`
+  (`backends/claude/read-token.ts`). This is what survives pod recycles:
+  `/data` is an emptyDir in prod and store-sync EXCLUDES both credential files.
+
+## The four traps (each was a live bug)
+
+1. **`USER` must reach the SDK subprocess.** The CLI names its Keychain
+   *account* after the username; `buildClaudeEnv`'s allowlist passes
+   `USER`/`LOGNAME`/`USERNAME` for exactly this. Scrub them and the SDK reads a
+   different, empty Keychain item than the login wrote: connected in the UI,
+   unauthenticated on every turn, unfixable by reconnecting.
+2. **Never read the unsuffixed Keychain service.** `Claude Code-credentials`
+   (no hash suffix) is the user's PERSONAL `~/.claude` credential. Pushing it
+   to a pod makes the pod and the user's own Claude Code rotate one refresh
+   token family and sign each other out mid-session.
+3. **A served env token OUTRANKS the config-dir credential inside the SDK.**
+   That's why serving anthropic is gated to `gatewayFronted` hosts and why a
+   STALE anthropic token is never served best-effort (both in
+   `packages/host/src/routes/credential.ts`) — a desktop host serving its
+   stale durability-marker entry would shadow the working Keychain login.
+4. **One refresh-token family = one rotator.** Anthropic rotates the refresh
+   token on every use and invalidates the old one. The gateway is the single
+   rotator for pods; the desktop CLI is the single rotator locally; the
+   central-store copy on a desktop host is an inert marker (never served,
+   never refreshed — TS `credentials/refresh.ts` deliberately has no anthropic
+   entry).

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -387,18 +387,22 @@ export class ProxyChannel implements RuntimeChannel {
    * Materialize the desktop-pushed Claude subscription OAuth credential onto the
    * standing pod so its Claude Agent SDK authenticates and self-refreshes.
    *
-   * Dual write, mirroring saveApiKeyCredential: store it centrally (durability +
-   * a connected record) AND push it into the standing runtime, which writes the
-   * SDK's own `<CLAUDE_CONFIG_DIR>/.credentials.json` and warms the connected
-   * signal so status flips at once.
+   * Dual write, mirroring saveApiKeyCredential: store it centrally (access +
+   * refresh — the control plane is the single refresher from here on) AND push
+   * it into the standing runtime, which writes the SDK's own
+   * `<CLAUDE_CONFIG_DIR>/.credentials.json` (immediate connect signal) and
+   * warms the connected probe so status flips at once.
    *
-   * DELIBERATE Gate #2 departure, scoped to this SINGLE-TENANT pod: the refresh
-   * token is kept (in the central store AND on the pod). The pod self-refreshes
-   * from it, so anthropic is NEVER served through pi's per-turn access-only
-   * auth.json path (serve.ts excludes it) and is NEVER centrally refreshed —
-   * pulling a stale central access token per turn would fight the pod's file.
-   * The multi-tenant per-turn Cloud Run channel refuses this credential entirely.
-   * The token is never logged.
+   * From the next serve sync onward, a MANAGED pod rides the per-turn
+   * access-only path like every provider (serve.ts + routes/credential.ts):
+   * the gateway refreshes centrally and the pod never rotates the refresh
+   * token — one rotator, no family races, and a recycled pod (emptyDir /data)
+   * reconnects from the central store. The materialized file remains the
+   * fallback when a serve is unavailable; the served env token outranks it
+   * inside the SDK. On a desktop/self-host host this central entry is an inert
+   * durability marker (never served, never refreshed). The multi-tenant
+   * per-turn Cloud Run channel refuses this credential entirely. The token is
+   * never logged. Lifecycle map: knowledge-base/anthropic-credentials.md.
    */
   async saveClaudeOAuthCredential(
     ctx: ChannelCtx,

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -231,17 +231,17 @@ export interface RuntimeChannel {
    * Connect-once for the Anthropic Claude subscription in HOSTED mode. The
    * desktop mints the OAuth credential locally (`claude auth login`), extracts
    * it, and pushes it here (the CLI's `{claudeAiOauth}` shape). A standing-runtime
-   * channel materializes it onto the pod as the SDK's own
-   * `<CLAUDE_CONFIG_DIR>/.credentials.json`, so the pod's Claude Agent SDK
-   * authenticates AND self-refreshes from the refresh token there — NO central
-   * refresh, and the stale-token bug is gone. It is stored centrally too
-   * (durability + a connected marker) but NEVER served through pi's per-turn
-   * auth.json path (serve.ts bypasses anthropic).
-   *
-   * The refresh token deliberately stays on the pod — a documented, EXPLICITLY
-   * gated departure from Gate #2's "sandbox never holds a refresh token", scoped
-   * to the SINGLE-TENANT, network-policied managed pod only. The multi-tenant
-   * per-turn Cloud Run channel REFUSES this (Anthropic is off there).
+   * channel stores it centrally (access + refresh — the control plane is the
+   * SINGLE refresher, Gate #2 shape) and materializes it onto the pod as the
+   * SDK's own `<CLAUDE_CONFIG_DIR>/.credentials.json` for the immediate
+   * connect signal. From the next serve sync onward the managed pod rides
+   * pi's per-turn ACCESS-ONLY auth.json path like every provider
+   * (serve.ts + routes/credential.ts) — the pod never rotates the refresh
+   * token, and a recycled pod reconnects from the central store. On a
+   * desktop/self-host host the central entry is an inert durability marker
+   * (never served, never refreshed). The multi-tenant per-turn Cloud Run
+   * channel REFUSES this (Anthropic is off there). Lifecycle map:
+   * knowledge-base/anthropic-credentials.md.
    */
   saveClaudeOAuthCredential(
     ctx: ChannelCtx,

--- a/packages/host/src/routes/credential.test.ts
+++ b/packages/host/src/routes/credential.test.ts
@@ -6,11 +6,20 @@ import { handleSandboxCredential } from "./credential";
 
 /**
  * The sandbox credential endpoint must keep serving a turn even when the stored
- * credential cannot be refreshed centrally (e.g. anthropic has no refresh config
- * yet, or a refresh is rejected). It serves the existing token best-effort
+ * credential cannot be refreshed centrally (a refresh is rejected, or the
+ * provider has no refresh config). It serves the existing token best-effort
  * instead of 500-ing every turn — otherwise the runtime's multi-provider serve
- * loop spams 500s for a stale, unused credential (a leftover Claude login while
- * the agent runs OpenCode). API-key credentials are served as-is, never refreshed.
+ * loop spams 500s for a stale, unused credential. API-key credentials are
+ * served as-is, never refreshed.
+ *
+ * Anthropic is special-cased twice:
+ *  - it serves ONLY on a gateway-fronted (managed cloud) host — a desktop/
+ *    self-host store may hold a pushed-credential durability marker whose
+ *    served token would SHADOW the working local keychain credential inside
+ *    the Claude Agent SDK (CLAUDE_CODE_OAUTH_TOKEN outranks the config dir);
+ *  - a STALE anthropic token is never served best-effort, for the same
+ *    shadowing reason — the marked 404 lets the runtime fall back to the
+ *    materialized-file path instead.
  */
 
 const vault: CredentialVault = {
@@ -59,9 +68,10 @@ const call = (
   credentials: MemoryCredentialStore,
   provider: string,
   out: ReturnType<typeof mockRes>,
+  opts: { gatewayFronted?: boolean } = {},
 ) =>
   handleSandboxCredential(
-    { vault, credentials },
+    { vault, credentials, gatewayFronted: opts.gatewayFronted },
     "GET",
     "/sandbox/credential",
     new URL(`http://x/sandbox/credential?provider=${provider}`),
@@ -69,21 +79,25 @@ const call = (
     out.res,
   );
 
+/** A far-future expiry: not "expiring" for any test run. */
+const FRESH_EXPIRES = Date.now() + 60 * 60 * 1000;
+
 test("serves the existing token when refresh has no config (no 500)", async () => {
   const credentials = new MemoryCredentialStore();
-  // An EXPIRING anthropic oauth credential — refreshCredential throws (no anthropic
-  // refresh config). Before the fix this returned 500 on every serve.
+  // An EXPIRING oauth credential for a provider without a central refresh
+  // config — refreshCredential throws. Before the fix this returned 500 on
+  // every serve.
   await credentials.put({
     workspaceId: "w1",
-    provider: "anthropic",
+    provider: "kimi-coding",
     accessToken: "stale-AT",
     refreshToken: "RT",
     expiresAt: 1, // long past → "expiring"
   });
   const r = mockRes();
-  expect(await call(credentials, "anthropic", r)).toBe(true);
+  expect(await call(credentials, "kimi-coding", r)).toBe(true);
   expect(r.out.status).toBe(200);
-  expect(r.out.body.provider).toBe("anthropic");
+  expect(r.out.body.provider).toBe("kimi-coding");
   expect(r.out.body.access).toBe("stale-AT"); // existing token served, not a 500
   expect(r.out.body.kind).toBe("oauth");
 });
@@ -131,9 +145,89 @@ test("serves a gateway access-only OAuth credential without local refresh", asyn
 test("404 when the workspace has not connected the provider", async () => {
   const credentials = new MemoryCredentialStore();
   const r = mockRes();
-  expect(await call(credentials, "anthropic", r)).toBe(true);
+  expect(await call(credentials, "openai-codex", r)).toBe(true);
   expect(r.out.status).toBe(404);
   // The authoritative marker: the runtime only drops served credentials on
   // marked 404s, never on a bare route-level 404.
+  expect(r.out.headers?.["x-houston-not-connected"]).toBe("1");
+});
+
+test("anthropic is NOT served off the managed cloud, even when stored", async () => {
+  // A desktop/self-host store can hold the durability marker written when a
+  // credential was pushed to a pod. Serving it locally would shadow the
+  // working keychain credential — the marked 404 keeps the local flow intact.
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "anthropic",
+    accessToken: "sk-ant-oat01-marker",
+    refreshToken: "RT",
+    expiresAt: FRESH_EXPIRES,
+  });
+  const r = mockRes();
+  expect(await call(credentials, "anthropic", r)).toBe(true);
+  expect(r.out.status).toBe(404);
+  expect(r.out.headers?.["x-houston-not-connected"]).toBe("1");
+});
+
+test("anthropic serves access-only on a gateway-fronted host", async () => {
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "anthropic",
+    accessToken: "sk-ant-oat01-fresh",
+    refreshToken: "", // gateway serves access-only; refresh never reaches pods
+    expiresAt: FRESH_EXPIRES,
+    kind: "oauth",
+  });
+  const r = mockRes();
+  expect(
+    await call(credentials, "anthropic", r, { gatewayFronted: true }),
+  ).toBe(true);
+  expect(r.out.status).toBe(200);
+  expect(r.out.body).toMatchObject({
+    provider: "anthropic",
+    access: "sk-ant-oat01-fresh",
+    kind: "oauth",
+  });
+});
+
+test("a STALE anthropic token is never served (marked 404 instead)", async () => {
+  // A stale served token would outrank the pod's materialized file inside the
+  // SDK; degrading to not-connected lets the file path keep working.
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "anthropic",
+    accessToken: "sk-ant-oat01-stale",
+    refreshToken: "", // access-only AND expired: the gateway could not refresh
+    expiresAt: 1,
+    kind: "oauth",
+  });
+  const r = mockRes();
+  expect(
+    await call(credentials, "anthropic", r, { gatewayFronted: true }),
+  ).toBe(true);
+  expect(r.out.status).toBe(404);
+  expect(r.out.headers?.["x-houston-not-connected"]).toBe("1");
+});
+
+test("an expiring anthropic credential whose refresh fails degrades to marked 404", async () => {
+  // refreshCredential throws for anthropic (no TS refresh config — the Go
+  // gateway refreshes upstream). The stale guard must catch the still-expiring
+  // credential instead of best-effort-serving it.
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "anthropic",
+    accessToken: "sk-ant-oat01-stale",
+    refreshToken: "RT",
+    expiresAt: 1,
+  });
+  const r = mockRes();
+  expect(
+    await call(credentials, "anthropic", r, { gatewayFronted: true }),
+  ).toBe(true);
+  expect(r.out.status).toBe(404);
   expect(r.out.headers?.["x-houston-not-connected"]).toBe("1");
 });

--- a/packages/host/src/routes/credential.ts
+++ b/packages/host/src/routes/credential.ts
@@ -16,7 +16,11 @@ import { bearer, json } from "./http";
  * Returns true when the request was handled.
  */
 export async function handleSandboxCredential(
-  deps: { vault: CredentialVault; credentials: CredentialStore },
+  deps: {
+    vault: CredentialVault;
+    credentials: CredentialStore;
+    gatewayFronted?: boolean;
+  },
   method: string,
   path: string,
   url: URL,
@@ -32,6 +36,24 @@ export async function handleSandboxCredential(
     return true;
   }
   const provider = url.searchParams.get("provider") || "openai-codex";
+  // Anthropic serves ONLY on a managed pod (gateway-fronted), where the gateway
+  // is the single refresher and already answers access-only. A desktop/self-host
+  // store may hold an anthropic entry too — the durability marker written when a
+  // credential was pushed to a pod — but serving it locally would hand the SDK a
+  // stale access token that OUTRANKS the working keychain credential
+  // (CLAUDE_CODE_OAUTH_TOKEN wins inside the SDK), and refreshing it here would
+  // make this host a second rotator of a refresh token family the pod already
+  // owns. The marked 404 is the store's authoritative "not served here" answer;
+  // the runtime's provenance manifest keeps it from deleting anything local.
+  if (provider === "anthropic" && !deps.gatewayFronted) {
+    json(
+      res,
+      404,
+      { error: "anthropic is not served on this deployment" },
+      { "x-houston-not-connected": "1" },
+    );
+    return true;
+  }
   let cred = await deps.credentials.get(claim.workspaceId, provider);
   if (!cred) {
     // The marker makes this 404 the store's own authoritative "not connected"
@@ -50,18 +72,34 @@ export async function handleSandboxCredential(
       cred = await refreshCredential(cred);
       await deps.credentials.put(cred);
     } catch (err) {
-      // No refresh path for this provider (e.g. anthropic has no refresh config
-      // yet) or the refresh was rejected. Serve the existing token best-effort
-      // instead of 500-ing every turn: it may still be valid, and a genuinely
-      // expired one surfaces as a clear auth error on the real API call. This
-      // also stops the runtime's multi-provider serve loop from spamming serve
-      // 500s for a stale, unused credential (e.g. a leftover Claude login while
-      // the agent runs OpenCode).
+      // No refresh path for this provider or the refresh was rejected. Serve
+      // the existing token best-effort instead of 500-ing every turn: it may
+      // still be valid, and a genuinely expired one surfaces as a clear auth
+      // error on the real API call. This also stops the runtime's
+      // multi-provider serve loop from spamming serve 500s for a stale, unused
+      // credential (e.g. a leftover Claude login while the agent runs
+      // OpenCode).
       console.error(
         `[sandbox/credential] refresh failed for ${cred.provider}, serving existing token:`,
         err instanceof Error ? err.message : err,
       );
     }
+  }
+  // Never serve a STALE anthropic token. Unlike every other provider, a served
+  // anthropic token doesn't just fail its own API call — inside the Claude
+  // Agent SDK the env token OUTRANKS the materialized `.credentials.json` /
+  // keychain credential, so serving an expired access token would shadow a
+  // still-working self-refreshing credential. Degrading to the marked 404
+  // makes the runtime drop the served entry (provenance-gated) and fall back
+  // to that file path instead.
+  if (cred.provider === "anthropic" && isExpiring(cred)) {
+    json(
+      res,
+      404,
+      { error: "anthropic credential is stale" },
+      { "x-houston-not-connected": "1" },
+    );
+    return true;
   }
   // Access token ONLY (Gate #2): the refresh token never leaves this process.
   // A stolen sandbox credential is then worth minutes, not an account. The

--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "vitest";
@@ -101,28 +101,27 @@ test("concurrent syncServedCredential calls share one in-flight sync (no auth.js
     expect(a).toEqual([]);
     expect(b).toEqual([]);
     expect(c).toEqual([]);
-    // Three concurrent callers, but only ONE batch of per-provider probes ran.
-    // Anthropic is bypassed (materialized as the pod's own .credentials.json, not
-    // served here), so the sweep probes every provider EXCEPT anthropic.
-    expect(calls).toBe(PROVIDERS.filter((p) => p.id !== "anthropic").length);
+    // Three concurrent callers, but only ONE batch of per-provider probes ran —
+    // EVERY provider, anthropic included (the host decides whether to serve it;
+    // routes/credential.ts answers a marked 404 off the managed cloud).
+    expect(calls).toBe(PROVIDERS.length);
   });
 });
 
-test("anthropic is bypassed: a central anthropic credential is never served to auth.json", async () => {
-  // The pod materializes the Claude subscription as its own .credentials.json and
-  // the SDK self-refreshes it there — so serve mode must never probe anthropic nor
-  // write an access-only (refresh-stripped) anthropic entry into auth.json.
-  const requested: string[] = [];
+test("a served anthropic credential lands in auth.json as an access-only oauth entry", async () => {
+  // Managed cloud: the gateway is the single refresher and serves a short-TTL
+  // access token; the runtime writes it to auth.json (refresh="") and the SDK
+  // backend rides it via CLAUDE_CODE_OAUTH_TOKEN. This is what lets a recycled
+  // pod (emptyDir /data, credential files excluded from store-sync) reconnect
+  // anthropic without the user doing anything.
   const fetchImpl = (async (input: RequestInfo | URL) => {
     const provider = new URL(String(input)).searchParams.get("provider");
-    if (provider) requested.push(provider);
     if (provider === "anthropic") {
-      // The host WOULD serve it if asked — prove the runtime never asks.
       return new Response(
         JSON.stringify({
           provider: "anthropic",
           kind: "oauth",
-          access: "AT-anthropic",
+          access: "sk-ant-oat01-served",
           expires: 1_900_000_000_000,
           accountId: null,
         }),
@@ -132,14 +131,18 @@ test("anthropic is bypassed: a central anthropic credential is never served to a
     return notConnected404();
   }) as unknown as typeof globalThis.fetch;
   await withServeMode(fetchImpl, async () => {
-    expect(await syncServedCredential()).toEqual([]);
-    expect(requested).not.toContain("anthropic");
-    // No anthropic entry was written (auth.json may not exist at all).
+    expect(await syncServedCredential()).toEqual(["anthropic"]);
     const path = join(config.dataDir, "auth.json");
-    const auth = existsSync(path)
-      ? (JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>)
-      : {};
-    expect(auth.anthropic).toBeUndefined();
+    const auth = JSON.parse(readFileSync(path, "utf8")) as Record<
+      string,
+      { type: string; access?: string; refresh?: string }
+    >;
+    expect(auth.anthropic).toEqual({
+      type: "oauth",
+      access: "sk-ant-oat01-served",
+      refresh: "",
+      expires: 1_900_000_000_000,
+    });
   });
 });
 

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -138,25 +138,20 @@ async function probeProvider(id: string): Promise<ServeProbe> {
   }
 }
 
-/**
- * Anthropic is deliberately NOT served through this per-turn auth.json path. A
- * hosted pod materializes the Claude subscription credential as the SDK's own
- * `<CLAUDE_CONFIG_DIR>/.credentials.json` (see backends/claude/credentials-file),
- * and the SDK self-refreshes from the refresh token THERE — pulling an
- * access-only central token per turn (Gate #2 shape) would fight that file and
- * strip the refresh token the pod needs. Every OTHER provider serves here.
- */
-const SERVE_EXCLUDED = new Set<string>(["anthropic"]);
-
 async function runServedSync(): Promise<string[]> {
   if (!serveModeOn()) return [];
+  // Anthropic serves through this same per-turn access-only path (Gate #2) —
+  // the served token rides `CLAUDE_CODE_OAUTH_TOKEN` into the Claude Agent SDK
+  // subprocess (backends/claude/read-token), where the env var outranks any
+  // stale materialized `.credentials.json`, so a recycled pod reconnects from
+  // the central store instead of losing the credential with its emptyDir.
+  // WHETHER anthropic serves is the CONTROL PLANE's call, not ours: a managed
+  // pod's host serves it (the gateway is the single refresher), while the
+  // desktop/self-host host answers a marked 404 so the local keychain flow
+  // stays the one credential holder (routes/credential.ts).
   // Probes are independent — run them in parallel so a hydrating route pays one
   // round-trip, not eleven. The auth.json writes below stay serial.
-  const probes = await Promise.all(
-    PROVIDERS.filter((p) => !SERVE_EXCLUDED.has(p.id)).map((p) =>
-      probeProvider(p.id),
-    ),
-  );
+  const probes = await Promise.all(PROVIDERS.map((p) => probeProvider(p.id)));
   const applied: string[] = [];
   const removed: string[] = [];
   // Provenance gate: an authoritative "not connected" may only remove providers

--- a/packages/runtime/src/backends/claude/backend.test.ts
+++ b/packages/runtime/src/backends/claude/backend.test.ts
@@ -65,6 +65,30 @@ test("operational ambient env (PATH) is preserved", () => {
   expect(env.PATH).toBe(process.env.PATH);
 });
 
+test("the username (USER/LOGNAME) reaches the subprocess", () => {
+  // The Claude CLI derives its macOS Keychain item's ACCOUNT from the
+  // username. Scrubbing USER made the SDK resolve "unknown" and read a
+  // DIFFERENT (empty) Keychain item than the one `claude auth login` wrote —
+  // connected in the UI, unauthenticated at every turn, unfixable by
+  // reconnecting.
+  const savedIdentity = {
+    USER: process.env.USER,
+    LOGNAME: process.env.LOGNAME,
+  };
+  process.env.USER = "jane";
+  process.env.LOGNAME = "jane";
+  try {
+    const env = buildClaudeEnv("/cfg", oauth);
+    expect(env.USER).toBe("jane");
+    expect(env.LOGNAME).toBe("jane");
+  } finally {
+    for (const [k, v] of Object.entries(savedIdentity)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+});
+
 test("Houston host secrets never reach the subprocess env", () => {
   // The core of the finding: the SDK subprocess runs model-directed Bash, so any
   // host secret in its env is one `printenv` away from exfiltration. These are the

--- a/packages/runtime/src/backends/claude/claude-env.ts
+++ b/packages/runtime/src/backends/claude/claude-env.ts
@@ -50,6 +50,17 @@ const PASSTHROUGH_ENV_VARS: ReadonlySet<string> = new Set(
     "PATH",
     "HOME",
     "SHELL",
+    // Identity (non-secret). The Claude CLI names its macOS Keychain item's
+    // ACCOUNT after the username, and the bun runtime resolves that from
+    // USER/LOGNAME — with neither present it falls back to "unknown", so the
+    // SDK reads (and writes) a DIFFERENT Keychain item than the one
+    // `claude auth login` created for the same CLAUDE_CONFIG_DIR. The visible
+    // failure is brutal: the login says connected, every turn is
+    // unauthenticated, and reconnecting can never fix it. USERNAME is the
+    // Windows equivalent.
+    "USER",
+    "LOGNAME",
+    "USERNAME",
     // Locale — correct text handling in the subprocess.
     "LANG",
     "LC_ALL",

--- a/packages/runtime/src/backends/claude/credentials-file.ts
+++ b/packages/runtime/src/backends/claude/credentials-file.ts
@@ -6,15 +6,24 @@ import { claudeCredentialsFile } from "./paths";
  * Materialize a pushed Claude subscription OAuth credential as the CLI's own
  * `<CLAUDE_CONFIG_DIR>/.credentials.json` — the exact file the Claude Agent SDK
  * and `claude auth status` read on Linux (the hosted pod). Written verbatim in
- * the CLI envelope (`{claudeAiOauth:{…}}`) so the SDK self-refreshes from the
- * refresh token in place; NO central refresh is needed and the stale-token bug
- * is gone.
+ * the CLI envelope (`{claudeAiOauth:{…}}`) so the SDK can self-refresh from the
+ * refresh token in place.
+ *
+ * Role after the connect-once serve landed: the file is the pod's IMMEDIATE
+ * connected signal at push time and the FALLBACK credential when no served
+ * token is available (control plane briefly unreachable, or it can't refresh
+ * anthropic yet). Steady-state on a managed pod, the per-turn served access
+ * token rides `CLAUDE_CODE_OAUTH_TOKEN` and OUTRANKS this file inside the SDK
+ * (see backends/claude/read-token.ts and knowledge-base/
+ * anthropic-credentials.md) — which is exactly why the host must never serve
+ * a stale anthropic token (routes/credential.ts guards it).
  *
  * Atomic (tmp + rename) at mode 0600 so a concurrent reader never sees a
- * half-written file and the token is owner-only on disk. The refresh token stays
- * HERE on the single-tenant, network-policied pod — a documented, EXPLICITLY
- * scoped departure from Gate #2 (see cloud/INTEGRATION.md); it is never written
- * into the multi-tenant per-turn Cloud Run process, which keeps Anthropic off.
+ * half-written file and the token is owner-only on disk. The refresh token in
+ * this file stays on the single-tenant, network-policied pod — a documented,
+ * EXPLICITLY scoped departure from Gate #2 (see cloud/INTEGRATION.md); it is
+ * never written into the multi-tenant per-turn Cloud Run process, which keeps
+ * Anthropic off there.
  */
 export function writeClaudeOAuthCredentialFile(
   configDir: string,

--- a/packages/runtime/src/backends/claude/read-token.test.ts
+++ b/packages/runtime/src/backends/claude/read-token.test.ts
@@ -51,16 +51,50 @@ test("an unrecognized token prefix returns undefined AND logs the reason", () =>
   );
 });
 
-test("a wrong-variant (oauth) stored credential returns undefined AND logs", () => {
+test("a served oauth credential maps its ACCESS token to an oauth-token", () => {
+  // The connect-once serve path (managed cloud) writes pi's oauth variant with
+  // a short-TTL access token and refresh="" — the SDK consumes the access
+  // token via CLAUDE_CODE_OAUTH_TOKEN exactly like a setup token.
+  const token = readAnthropicToken(
+    store({
+      type: "oauth",
+      access: " sk-ant-oat01-served \n",
+      refresh: "",
+      expires: 123,
+    }),
+  );
+  expect(token).toEqual({ kind: "oauth-token", value: "sk-ant-oat01-served" });
+});
+
+test("an oauth credential with an empty access token returns undefined AND logs", () => {
   const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-  const oauth = {
-    type: "oauth",
-    access: "x",
-    refresh: "",
-    expires: 0,
-  } as unknown as AuthCredential;
-  expect(readAnthropicToken(store(oauth))).toBeUndefined();
+  expect(
+    readAnthropicToken(
+      store({ type: "oauth", access: "  ", refresh: "", expires: 0 }),
+    ),
+  ).toBeUndefined();
   expect(warn).toHaveBeenCalledWith(
-    expect.stringContaining("expected api_key"),
+    expect.stringContaining("empty access token"),
+  );
+});
+
+test("an oauth credential with an unrecognized prefix returns undefined AND logs", () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  expect(
+    readAnthropicToken(
+      store({ type: "oauth", access: "junk", refresh: "", expires: 0 }),
+    ),
+  ).toBeUndefined();
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining("unrecognized prefix"),
+  );
+});
+
+test("an unknown stored variant returns undefined AND logs", () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const bogus = { type: "wat" } as unknown as AuthCredential;
+  expect(readAnthropicToken(store(bogus))).toBeUndefined();
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining("expected api_key or oauth"),
   );
 });

--- a/packages/runtime/src/backends/claude/read-token.test.ts
+++ b/packages/runtime/src/backends/claude/read-token.test.ts
@@ -60,10 +60,34 @@ test("a served oauth credential maps its ACCESS token to an oauth-token", () => 
       type: "oauth",
       access: " sk-ant-oat01-served \n",
       refresh: "",
-      expires: 123,
+      expires: Date.now() + 60 * 60 * 1000,
     }),
   );
   expect(token).toEqual({ kind: "oauth-token", value: "sk-ant-oat01-served" });
+});
+
+test("an EXPIRED served oauth token is refused (falls back to the config dir)", () => {
+  // The env token outranks the config dir's self-refreshing credential inside
+  // the SDK — an expired served token must never shadow a working one.
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  expect(
+    readAnthropicToken(
+      store({
+        type: "oauth",
+        access: "sk-ant-oat01-stale",
+        refresh: "",
+        expires: Date.now() - 1,
+      }),
+    ),
+  ).toBeUndefined();
+  expect(warn).toHaveBeenCalledWith(expect.stringContaining("expired"));
+});
+
+test("an oauth entry with NO recorded expiry (expires=0) is served as-is", () => {
+  const token = readAnthropicToken(
+    store({ type: "oauth", access: "sk-ant-oat01-x", refresh: "", expires: 0 }),
+  );
+  expect(token).toEqual({ kind: "oauth-token", value: "sk-ant-oat01-x" });
 });
 
 test("an oauth credential with an empty access token returns undefined AND logs", () => {

--- a/packages/runtime/src/backends/claude/read-token.ts
+++ b/packages/runtime/src/backends/claude/read-token.ts
@@ -4,19 +4,38 @@ import type { ClaudeToken } from "./backend";
 
 /**
  * Resolve the stored `anthropic` credential into the `ClaudeToken` the Claude
- * Agent SDK backend runs with. The setup-token flow stores the pasted value under
- * `anthropic` as pi's `api_key` variant (see auth/anthropic-setup-token.ts), and
- * the SDK consumes the two token kinds through DIFFERENT env vars — a subscription
- * setup token (`sk-ant-oat01…`) via `CLAUDE_CODE_OAUTH_TOKEN`, a console API key
- * (`sk-ant-api03…`) via `ANTHROPIC_API_KEY` — so the prefix is what selects the
- * env var. Mapped here, once, off the SAME prefix list the login validator uses.
+ * Agent SDK backend runs with. Two stored variants map here:
+ *
+ *  - The setup-token flow stores the pasted value under `anthropic` as pi's
+ *    `api_key` variant (see auth/anthropic-setup-token.ts).
+ *  - The connect-once serve path (managed cloud) writes pi's `oauth` variant
+ *    with a short-TTL ACCESS token and refresh="" (Gate #2) — the control
+ *    plane is the single refresher, the pod never holds the refresh token.
+ *
+ * Either way the SDK consumes the value through env vars, and WHICH var is
+ * selected by the token's prefix: a subscription OAuth/setup token
+ * (`sk-ant-oat01…`) rides `CLAUDE_CODE_OAUTH_TOKEN`, a console API key
+ * (`sk-ant-api03…`) rides `ANTHROPIC_API_KEY`. Mapped here, once, off the SAME
+ * prefix list the login validator uses. The env token deliberately outranks
+ * whatever `.credentials.json`/Keychain state the config dir carries — a stale
+ * materialized file can never shadow a freshly served token.
  *
  * No silent failure: an absent credential returns `undefined` (not connected —
- * expected), but a STORED value we can't classify (wrong PiCred variant, or an
- * unrecognized prefix) returns `undefined` AND logs the concrete reason, so a
- * bad/corrupt entry surfaces in the logs instead of vanishing.
+ * expected), but a STORED value we can't classify (unexpected PiCred variant,
+ * or an unrecognized prefix) returns `undefined` AND logs the concrete reason,
+ * so a bad/corrupt entry surfaces in the logs instead of vanishing.
  */
 const [OAUTH_TOKEN_PREFIX, API_KEY_PREFIX] = ANTHROPIC_TOKEN_PREFIXES;
+
+function classify(value: string): ClaudeToken | undefined {
+  if (value.startsWith(OAUTH_TOKEN_PREFIX))
+    return { kind: "oauth-token", value };
+  if (value.startsWith(API_KEY_PREFIX)) return { kind: "api-key", value };
+  console.warn(
+    `[claude] stored "anthropic" token has an unrecognized prefix (expected ${OAUTH_TOKEN_PREFIX}… or ${API_KEY_PREFIX}…); refusing to use it`,
+  );
+  return undefined;
+}
 
 export function readAnthropicToken(
   store: Pick<AuthStorage, "get">,
@@ -24,20 +43,20 @@ export function readAnthropicToken(
   const cred = store.get("anthropic");
   if (!cred) return undefined; // not connected — no credential to read
 
-  if (cred.type !== "api_key") {
-    console.warn(
-      `[claude] stored "anthropic" credential is a "${cred.type}" entry, expected api_key; ignoring it`,
-    );
-    return undefined;
+  if (cred.type === "api_key") return classify(cred.key.trim());
+  if (cred.type === "oauth") {
+    const access = cred.access?.trim();
+    if (!access) {
+      console.warn(
+        `[claude] stored "anthropic" oauth credential has an empty access token; ignoring it`,
+      );
+      return undefined;
+    }
+    return classify(access);
   }
 
-  const value = cred.key.trim();
-  if (value.startsWith(OAUTH_TOKEN_PREFIX))
-    return { kind: "oauth-token", value };
-  if (value.startsWith(API_KEY_PREFIX)) return { kind: "api-key", value };
-
   console.warn(
-    `[claude] stored "anthropic" token has an unrecognized prefix (expected ${OAUTH_TOKEN_PREFIX}… or ${API_KEY_PREFIX}…); refusing to use it`,
+    `[claude] stored "anthropic" credential is a "${(cred as { type: string }).type}" entry, expected api_key or oauth; ignoring it`,
   );
   return undefined;
 }

--- a/packages/runtime/src/backends/claude/read-token.ts
+++ b/packages/runtime/src/backends/claude/read-token.ts
@@ -52,6 +52,19 @@ export function readAnthropicToken(
       );
       return undefined;
     }
+    // Last line of defense: never hand the SDK an EXPIRED served token. The
+    // env token outranks the config dir's self-refreshing credential, so a
+    // stale entry that slipped past the host's serve guards (a control plane
+    // that can't refresh anthropic yet, an orphaned entry) would shadow a
+    // WORKING file/keychain credential. Returning undefined instead lets the
+    // SDK fall back to the config dir. expires=0 means "no expiry recorded"
+    // (a pasted token stored as oauth) and is served as-is.
+    if (cred.expires > 0 && cred.expires <= Date.now()) {
+      console.warn(
+        `[claude] stored "anthropic" oauth access token is expired; falling back to the config dir credential`,
+      );
+      return undefined;
+    }
     return classify(access);
   }
 

--- a/packages/web/src/engine-adapter/client/provider-login-poll.ts
+++ b/packages/web/src/engine-adapter/client/provider-login-poll.ts
@@ -1,4 +1,8 @@
 import { EngineError, type ProviderId } from "@houston/runtime-client";
+import {
+  PROVIDER_CONNECT_TIMEOUT_ERROR,
+  PROVIDER_LOGIN_TIMEOUT_ERROR,
+} from "@houston-ai/core";
 import { emitEvent } from "../bus";
 import {
   captureCredential,
@@ -52,7 +56,7 @@ export function watchLoginCompletion(
         else if (pr?.login?.status === "error")
           finish(false, pr?.login?.error ?? "Login failed");
         else if (Date.now() - startedAt > 10 * 60 * 1000)
-          finish(false, "Login timed out");
+          finish(false, PROVIDER_LOGIN_TIMEOUT_ERROR);
       } catch {
         /* engine briefly unreachable; keep polling */
       }
@@ -140,7 +144,7 @@ export async function pollProviderConnect(
     emitEvent("ProviderLoginComplete", {
       provider: oldProvider,
       success: false,
-      error: "Connection timed out. Please try connecting again.",
+      error: PROVIDER_CONNECT_TIMEOUT_ERROR,
     });
   } finally {
     ctx.activeLogins.delete(key);

--- a/ui/core/src/index.ts
+++ b/ui/core/src/index.ts
@@ -49,5 +49,6 @@ export * from "./components/tooltip";
 export * from "./hooks/use-houston-event";
 export * from "./hooks/use-mobile";
 export * from "./hooks/use-session-events";
+export * from "./provider-login";
 export * from "./types";
 export * from "./utils";

--- a/ui/core/src/provider-login.ts
+++ b/ui/core/src/provider-login.ts
@@ -1,0 +1,11 @@
+/**
+ * Stable sentinel strings the engine adapter puts in
+ * `ProviderLoginComplete.error` (see `HoustonEvent` in ./types) for its own
+ * client-side timeouts. They double as the English default copy (this package
+ * stays i18n-agnostic); the app maps them to localized toast text — matching
+ * by value, so these are a CONTRACT: change one here and the app-side mapping
+ * (app/src/lib/provider-login-error.ts) must move with it.
+ */
+export const PROVIDER_LOGIN_TIMEOUT_ERROR = "Login timed out";
+export const PROVIDER_CONNECT_TIMEOUT_ERROR =
+  "Connection timed out. Please try connecting again.";

--- a/ui/core/src/types.ts
+++ b/ui/core/src/types.ts
@@ -203,14 +203,3 @@ export type HoustonEvent =
   // HOU-550: a custom (API / MCP) integration was added, credentialed, or
   // removed. Carries no payload — the whole user-level list is refetched.
   | { type: "CustomIntegrationsChanged" };
-
-/**
- * Stable sentinel strings the engine adapter puts in
- * `ProviderLoginComplete.error` for its own client-side timeouts. They double
- * as the English default copy (this package stays i18n-agnostic); the app maps
- * them to localized toast text — matching by value, so these are a CONTRACT:
- * change one here and the app-side mapping must move with it.
- */
-export const PROVIDER_LOGIN_TIMEOUT_ERROR = "Login timed out";
-export const PROVIDER_CONNECT_TIMEOUT_ERROR =
-  "Connection timed out. Please try connecting again.";

--- a/ui/core/src/types.ts
+++ b/ui/core/src/types.ts
@@ -203,3 +203,14 @@ export type HoustonEvent =
   // HOU-550: a custom (API / MCP) integration was added, credentialed, or
   // removed. Carries no payload — the whole user-level list is refetched.
   | { type: "CustomIntegrationsChanged" };
+
+/**
+ * Stable sentinel strings the engine adapter puts in
+ * `ProviderLoginComplete.error` for its own client-side timeouts. They double
+ * as the English default copy (this package stays i18n-agnostic); the app maps
+ * them to localized toast text — matching by value, so these are a CONTRACT:
+ * change one here and the app-side mapping must move with it.
+ */
+export const PROVIDER_LOGIN_TIMEOUT_ERROR = "Login timed out";
+export const PROVIDER_CONNECT_TIMEOUT_ERROR =
+  "Connection timed out. Please try connecting again.";


### PR DESCRIPTION
## Problem

The Anthropic provider was effectively unusable, in three visible ways:

- **Local (`pnpm dev`)**: connecting succeeds, but the very next message shows the *reconnect Anthropic* card — and reconnecting never fixes it.
- **Cloud (desktop → gateway)**: the browser OAuth approval completes, but the app never connects; after a while a *"Couldn't open Anthropic sign-in — Connection timed out"* toast appears, or the legacy **setup-token paste dialog** pops up.
- **Mid-session sign-outs**: users report being disconnected mid-session and having to reconnect.

## Root causes (all verified empirically against the real CLI/Keychain)

1. **`USER` was scrubbed from the SDK subprocess env.** The Claude CLI names its macOS Keychain *account* after the username; without `USER`/`LOGNAME` the bun-compiled CLI resolves `unknown` and reads/writes a **different, empty Keychain item** than the one `claude auth login` wrote for the same `CLAUDE_CONFIG_DIR`. Login says connected; every turn is unauthenticated; reconnecting writes to the account the runtime never reads. (Reproduced: `claude auth status` flips `loggedIn` false→true purely on the presence of `USER`.)

2. **The cloud handoff read the wrong Keychain service.** The CLI scopes its item as `Claude Code-credentials-<sha256(configDir)[:8]>` (verified: all three items on the dev machine match the hash), but `read_claude_credential` queried the **unsuffixed** service. Result: extraction found nothing → every cloud connect degraded to the paste dialog + timeout toast — or worse, it found the user's **personal `~/.claude` credential** and pushed *that* to the pod, making the pod and the user's own Claude Code rotate one refresh-token family and **sign each other out mid-session**.

3. **Pod recycles silently dropped the credential.** Prod pods run emptyDir `/data`, store-sync deliberately excludes `credentials.json` + `claude-login/.credentials.json`, and anthropic was excluded from the connect-once serve path — so nothing re-materialized it after a recycle.

4. The adapter's timeout errors were hardcoded English strings shown verbatim in localized UIs.

## Fixes

- `claude-env.ts`: pass `USER`/`LOGNAME`/`USERNAME` through the allowlist (identity, non-secret). Fixes local turns AND the status probe (same env builder).
- `credential.rs`: read the **dir-scoped** Keychain service (sha256 suffix), prefer the user's account, skip emptied logout husks, never touch the unsuffixed (personal) item. Test vector pins the real hash scheme.
- **Serve anthropic through the connect-once pipeline on managed pods only**: the gateway keeps the refresh token (single rotator) and serves access-only per turn; the runtime writes it to `auth.json` and the SDK rides `CLAUDE_CODE_OAUTH_TOKEN` — which **outranks** any stale materialized file (verified against the real CLI: env token wins even with a bogus `.credentials.json` present). Desktop/self-host hosts answer a marked 404 (`gatewayFronted` gate) so the local keychain flow stays the single credential holder; a **stale** anthropic token is never served best-effort (it would shadow a working file credential — this also makes the engine roll safe before the gateway-side refresh deploys).
- `read-token.ts`: accept the served `oauth` variant alongside the pasted `api_key` one.
- Timeout copy: stable sentinels in `@houston-ai/core`, mapped to localized toasts (en/es/pt).
- New KB: `knowledge-base/anthropic-credentials.md` (lifecycle + the four traps).

The setup-token paste dialog is **kept** as the deliberate last resort (pure-web clients have no local CLI), but desktop users should no longer hit it.

## Deploy note

The gateway needs the anthropic entry in its central refresher for the per-turn serve to work (companion change, shipping separately). This PR is safe to roll first: until the gateway refreshes anthropic, pods fall back to today's materialized-file behavior (the stale-guard 404s instead of serving a dead token).

## Tests

- runtime 648 ✓ / host 949 ✓ / domain 137 ✓ (new: served-anthropic serve-sync, oauth read-token variants, USER passthrough, credential-route gating + stale-guard)
- `cargo test` 22 ✓ in `claude_login` (new: hash scoping, account-scoped argv, husk skipping, fall-through ordering)
- `pnpm check` / `check:boundaries` / `typecheck` (ui, app, web) / `check-locales` all clean