### PR TITLE
fix(app): keep cached mission cards painted while an asleep pod wakes

### DIFF
--- a/app/src/lib/agent-provisioning.ts
+++ b/app/src/lib/agent-provisioning.ts
@@ -131,6 +131,18 @@ export interface ProvisioningEntry {
   agentPath: string;
   /** Epoch ms of the create call — the TTL anchor. */
   since: number;
+  /**
+   * Why the agent is warming. `"create"` = a just-created agent (HOU-693):
+   * it has no data by definition, so per-agent reads may answer "nothing
+   * yet" instantly. `"asleep"` = an EXISTING agent whose pod was detected
+   * scaled-to-zero on open (HOU-730): it HAS data — the locally persisted
+   * list/transcript caches are already painting it — so reads must NOT
+   * short-circuit to empty (an instant empty success wipes the painted
+   * cards AND the on-disk cache); they ride the gateway hold instead and
+   * settle when the pod wakes. Absent on entries persisted by older builds:
+   * treated as `"create"` (the pre-split behavior).
+   */
+  reason?: "create" | "asleep";
   /** Messages queued while warming, flushed on ready (in order). */
   pendingSends?: PendingWarmingSend[];
   /**
@@ -142,6 +154,16 @@ export interface ProvisioningEntry {
    * false; a fresh entry (new create/rename) replaces it instead.
    */
   timedOut?: boolean;
+}
+
+/**
+ * Whether per-agent READS may answer "nothing yet" for this warming entry
+ * instead of riding the gateway hold. Only a just-created agent qualifies —
+ * see the `reason` doc above. Writes are unaffected (they always park or
+ * block, whatever the reason).
+ */
+export function warmingReadsAnswerEmpty(entry: ProvisioningEntry): boolean {
+  return entry.reason !== "asleep";
 }
 
 /**

--- a/app/src/lib/agent-warming-guard.ts
+++ b/app/src/lib/agent-warming-guard.ts
@@ -12,6 +12,7 @@
 
 import { useAgentProvisioningStore } from "../stores/agent-provisioning";
 import { useUIStore } from "../stores/ui";
+import { warmingReadsAnswerEmpty } from "./agent-provisioning";
 import i18n from "./i18n";
 
 export interface WarmingWriteOptions {
@@ -37,6 +38,23 @@ export function isAgentPathWarming(agentPath: string): boolean {
   const entries = useAgentProvisioningStore.getState().provisioning;
   for (const entry of Object.values(entries)) {
     if (entry.agentPath === agentPath) return true;
+  }
+  return false;
+}
+
+/**
+ * True when this route key belongs to a JUST-CREATED warming agent — the only
+ * case where per-agent READS may answer "nothing yet" instantly (a fresh agent
+ * has no data by definition, HOU-693). An EXISTING agent detected asleep
+ * (HOU-730) must NOT short-circuit reads: it HAS data, and the locally
+ * persisted list/transcript caches are already painting it — an instant empty
+ * success would wipe the painted cards and overwrite the on-disk cache with
+ * `[]`. Its reads ride the gateway hold instead and settle on pod wake.
+ */
+export function isAgentPathCreating(agentPath: string): boolean {
+  const entries = useAgentProvisioningStore.getState().provisioning;
+  for (const entry of Object.values(entries)) {
+    if (entry.agentPath === agentPath) return warmingReadsAnswerEmpty(entry);
   }
   return false;
 }

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -26,7 +26,7 @@ import { shouldUseClaudeDesktopLogin } from "../components/shell/provider-login-
 import {
   blockWriteWhileWarming,
   blockWriteWhileWarmingById,
-  isAgentPathWarming,
+  isAgentPathCreating,
   type WarmingWriteOptions,
 } from "./agent-warming-guard";
 import { isKeyGoneError, isKeyLimitError } from "./api-keys-model";
@@ -417,10 +417,13 @@ export const tauriChat = {
     sessionKey: string,
     opts?: HistoryLoadOptions,
   ) =>
-    // Warming agent: nothing is persisted yet and the read (plus the observer
-    // stream it attaches) would be held for the whole warm-up. The open
-    // conversation renders from the local VM (queued bubbles) meanwhile.
-    isAgentPathWarming(agentPath)
+    // JUST-CREATED agent: nothing is persisted yet and the read (plus the
+    // observer stream it attaches) would be held for the whole warm-up. The
+    // open conversation renders from the local VM (queued bubbles) meanwhile.
+    // An EXISTING asleep agent (HOU-730) passes through: the engine client's
+    // transcript cache (HOU-712) paints the chat instantly and the held read
+    // revalidates on pod wake — answering [] here would blank a cached chat.
+    isAgentPathCreating(agentPath)
       ? Promise.resolve<Array<{ feed_type: string; data: unknown }>>([])
       : call<Array<{ feed_type: string; data: unknown }>>(
           "load_chat_history",
@@ -446,12 +449,16 @@ export const tauriAttachments = {
 // ─── Agent-data files (`.houston/**`) ─────────────────────────────────
 
 export const tauriAgent = {
-  // Warming agent (HOU-693): every per-agent request is held until its
+  // JUST-CREATED agent (HOU-693): every per-agent request is held until its
   // engine wakes. Reads answer instantly with "nothing yet" (a fresh agent
   // has no data; the ready-time events refetch the real state); writes open
-  // the "almost ready" dialog and reject typed (never toasted).
+  // the "almost ready" dialog and reject typed (never toasted). An EXISTING
+  // asleep agent (HOU-730) does NOT short-circuit reads: it has data, and an
+  // instant "" resolves the board/list queries as successful-empty — wiping
+  // the restored mission cards AND persisting [] over the on-disk cache.
+  // Its reads ride the gateway hold instead.
   readFile: (agentPath: string, relPath: string) =>
-    isAgentPathWarming(agentPath)
+    isAgentPathCreating(agentPath)
       ? Promise.resolve("")
       : call<string>("read_agent_file", () =>
           getEngine().readAgentFile(agentPath, relPath),
@@ -485,7 +492,7 @@ export const tauriAgent = {
 
 export const tauriSkills = {
   list: (agentPath: string) =>
-    isAgentPathWarming(agentPath)
+    isAgentPathCreating(agentPath)
       ? Promise.resolve<SkillSummary[]>([])
       : call<SkillSummary[]>("list_skills", async () =>
           (await getEngine().listSkills(agentPath)).map((s) => ({
@@ -760,7 +767,7 @@ import { osOpenFile, osRevealAgent, osRevealFile } from "./os-bridge";
 
 export const tauriFiles = {
   list: (agentPath: string) =>
-    isAgentPathWarming(agentPath)
+    isAgentPathCreating(agentPath)
       ? Promise.resolve<FileEntry[]>([])
       : call<FileEntry[]>("list_project_files", async () =>
           (await getEngine().listProjectFiles(agentPath)).map((f) => ({
@@ -859,7 +866,7 @@ interface RawConversation {
 
 export const tauriConversations = {
   list: (agentPath: string) =>
-    isAgentPathWarming(agentPath)
+    isAgentPathCreating(agentPath)
       ? Promise.resolve<RawConversation[]>([])
       : call<RawConversation[]>("list_conversations", async () =>
           (await getEngine().listConversations(agentPath)).map(
@@ -867,9 +874,13 @@ export const tauriConversations = {
           ),
         ),
   listAll: (agentPaths: string[]) => {
-    // A warming agent has no conversations yet and its read would hold the
-    // whole bulk scan — sweep only the reachable agents.
-    const reachable = agentPaths.filter((p) => !isAgentPathWarming(p));
+    // A JUST-CREATED agent has no conversations yet and its read would hold
+    // the whole bulk scan — sweep only past those. An EXISTING asleep agent
+    // stays IN the sweep: dropping it resolves Mission Control without its
+    // missions (a successful partial list that overwrites the restored cache);
+    // keeping it holds the sweep until its pod wakes while the cached rows
+    // keep painting.
+    const reachable = agentPaths.filter((p) => !isAgentPathCreating(p));
     if (reachable.length === 0) return Promise.resolve<RawConversation[]>([]);
     return call<RawConversation[]>("list_all_conversations", async () =>
       (await getEngine().listAllConversations(reachable)).map(
@@ -911,7 +922,7 @@ import * as configData from "../data/config";
 
 export const tauriRoutines = {
   list: (agentPath: string) =>
-    isAgentPathWarming(agentPath)
+    isAgentPathCreating(agentPath)
       ? Promise.resolve([])
       : call("list_routines", () => getEngine().listRoutines(agentPath)),
   create: (
@@ -941,7 +952,7 @@ export const tauriRoutines = {
     );
   },
   listRuns: (agentPath: string, routineId?: string) =>
-    isAgentPathWarming(agentPath)
+    isAgentPathCreating(agentPath)
       ? Promise.resolve([])
       : call("list_routine_runs", () =>
           getEngine().listRoutineRuns(agentPath, routineId),

--- a/app/src/stores/agent-provisioning.ts
+++ b/app/src/stores/agent-provisioning.ts
@@ -128,6 +128,7 @@ export const useAgentProvisioningStore = create<AgentProvisioningState>(
         agentId: agent.id,
         agentPath: agent.folderPath,
         since: Date.now(),
+        reason: "create",
       });
     },
 
@@ -143,10 +144,15 @@ export const useAgentProvisioningStore = create<AgentProvisioningState>(
         .then((asleep) => {
           // Re-check: a create/rename may have marked the id while we probed.
           if (!asleep || get().provisioning[agent.id]) return;
+          // "asleep", never "create": an existing agent's reads must keep
+          // riding the gateway hold so its locally cached lists/transcripts
+          // stay painted (see warmingReadsAnswerEmpty); sends still park and
+          // writes still block, exactly like a just-created agent.
           startEntry({
             agentId: agent.id,
             agentPath: agent.folderPath,
             since: Date.now(),
+            reason: "asleep",
           });
         })
         .finally(() => asleepChecks.delete(agent.id));
@@ -166,6 +172,7 @@ export const useAgentProvisioningStore = create<AgentProvisioningState>(
         since: previous.since,
         pendingSends: previous.pendingSends,
         timedOut: previous.timedOut,
+        reason: previous.reason,
       });
     },
 

--- a/app/tests/agent-provisioning.test.ts
+++ b/app/tests/agent-provisioning.test.ts
@@ -7,6 +7,7 @@ import {
   parsePersistedProvisioning,
   probeSaysStillStarting,
   runProvisioningProbe,
+  warmingReadsAnswerEmpty,
 } from "../src/lib/agent-provisioning.ts";
 
 const httpError = (status: number) => Object.assign(new Error("x"), { status });
@@ -158,6 +159,31 @@ describe("parsePersistedProvisioning", () => {
       now,
     );
     deepStrictEqual(parsed[0].pendingSends, [send]);
+  });
+
+  it("round-trips the warming reason across a relaunch", () => {
+    const asleep = { ...fresh, agentId: "a4", reason: "asleep" };
+    const created = { ...fresh, agentId: "a5", reason: "create" };
+    deepStrictEqual(
+      parsePersistedProvisioning(JSON.stringify([asleep, created]), now),
+      [asleep, created],
+    );
+  });
+});
+
+describe("warmingReadsAnswerEmpty", () => {
+  const base = { agentId: "a1", agentPath: "/w/a1", since: 0 };
+
+  it("just-created agents answer reads with 'nothing yet'", () => {
+    strictEqual(warmingReadsAnswerEmpty({ ...base, reason: "create" }), true);
+  });
+
+  it("entries persisted by older builds keep the pre-split behavior", () => {
+    strictEqual(warmingReadsAnswerEmpty(base), true);
+  });
+
+  it("an existing asleep agent's reads ride the hold — an instant empty success would wipe the cached board (HOU-730)", () => {
+    strictEqual(warmingReadsAnswerEmpty({ ...base, reason: "asleep" }), false);
   });
 });
 


### PR DESCRIPTION
## Problem

On the desktop app connected to cloud, mission cards (and the sidebar conversation lists + open chat) blank for ~10 seconds on open — the whole pod cold start — even though the local IndexedDB caches (#754, #748, #881) restore them instantly.

## Root cause

Opening an agent whose pod is scaled to zero runs the asleep detection (HOU-730), which marks the agent with the same warming state a just-created agent gets (HOU-693). All the per-agent READ guards in `lib/tauri.ts` then answer instantly with "nothing yet":

1. `tauriAgent.readFile` resolves `""` → the `["activity", path]` query settles as a **successful empty list**, replacing the cache-restored cards on the board.
2. Because it's a *success* on a persisted key, the persister mirrors `[]` to disk — destroying the on-disk cache for the next launch too.
3. `loadHistory` short-circuits before reaching the engine client, bypassing the transcript cache (HOU-712) — the open chat blanks.
4. `listAll` drops the asleep agent from the Mission Control sweep — its missions vanish from the cross-agent board and that partial list is persisted as well.

The "answer empty" behavior is only correct for a **just-created** agent, which has no data by definition. An **existing** asleep agent has data — and the caches are already painting it.

## Fix

`ProvisioningEntry` now records *why* the agent is warming: `reason: "create" | "asleep"` (absent = `create`, the pre-split behavior, so entries persisted by older builds are unaffected). The eight read short-circuits switch from `isAgentPathWarming` to the new `isAgentPathCreating`:

- **Just-created** agents keep the instant empty reads (HOU-693 unchanged).
- **Asleep existing** agents' reads pass through and ride the gateway hold: the restored caches keep painting the board/sidebar/chat, and the held reads settle with real data the moment the pod wakes (the ready-time invalidate still runs).
- Sends still park and writes still block for both reasons — HOU-730's actual goal is untouched.

Users who already had their disk cache clobbered by the old behavior self-heal after one successful wake (the refetch re-persists the real lists).

## Tests

- `warmingReadsAnswerEmpty`: create/legacy entries answer empty, asleep entries don't.
- `parsePersistedProvisioning` round-trips the new `reason` field across a relaunch.
- Full suite: app 1524 pass, web 187 pass, `pnpm typecheck` + `pnpm check` clean.