### PR TITLE
fix(app): paint sidebar needs-you badges through a pod cold start

### DIFF
--- a/app/src/components/shell/agent-activity-summary-model.ts
+++ b/app/src/components/shell/agent-activity-summary-model.ts
@@ -18,6 +18,34 @@ export interface AgentActivitySummary {
   runningCount: number;
 }
 
+/** One agent's board rows (`.houston/activity`), the summary-relevant bits. */
+export interface ActivitySummaryInput {
+  status?: string | null;
+  /** Agent-mode id; routine-setup chats never count toward badges. */
+  agent?: string | null;
+}
+
+/**
+ * Summarize one agent's own activity list — the SAME source (and the same
+ * counting rule) as the "Activity N" tab badge in workspace-shell.tsx, used
+ * as the sidebar fallback while the all-conversations aggregate has not
+ * fetched for the current roster key (cold boot, pods still waking).
+ */
+export function summarizeActivities(
+  activities: ActivitySummaryInput[],
+): AgentActivitySummary {
+  const summary: AgentActivitySummary = { needsYouCount: 0, runningCount: 0 };
+  for (const activity of activities) {
+    if (isSetupChatMode(activity.agent)) continue;
+    if (activity.status === "needs_you") {
+      summary.needsYouCount += 1;
+    } else if (activity.status === "running") {
+      summary.runningCount += 1;
+    }
+  }
+  return summary;
+}
+
 export function buildAgentActivitySummaries(
   agents: AgentActivitySummaryInput[],
   conversations: ActivityConversationSummaryInput[],

--- a/app/src/components/shell/use-agent-activity-summaries.ts
+++ b/app/src/components/shell/use-agent-activity-summaries.ts
@@ -1,7 +1,13 @@
+import { skipToken, useQueries } from "@tanstack/react-query";
 import { useMemo } from "react";
+import type { Activity } from "../../data/activity";
 import { useAllConversations } from "../../hooks/queries";
+import { queryKeys } from "../../lib/query-keys";
 import type { Agent } from "../../lib/types";
-import { buildAgentActivitySummaries } from "./agent-activity-summary-model";
+import {
+  buildAgentActivitySummaries,
+  summarizeActivities,
+} from "./agent-activity-summary-model";
 
 export function useAgentActivitySummaries(
   agents: Pick<Agent, "id" | "folderPath">[],
@@ -10,10 +16,35 @@ export function useAgentActivitySummaries(
     () => agents.map((agent) => agent.folderPath),
     [agents],
   );
-  const { data: conversations } = useAllConversations(agentPaths);
+  const aggregate = useAllConversations(agentPaths);
+  const conversations = aggregate.data;
+  // Placeholder = a disk-restored older roster variant (or the previous key's
+  // data), not a fetch for THIS roster — good enough to paint, but each
+  // agent's own restored board query is at least as fresh, so it wins below.
+  const aggregateIsAuthoritative =
+    conversations !== undefined && !aggregate.isPlaceholderData;
 
-  return useMemo(
-    () => buildAgentActivitySummaries(agents, conversations ?? []),
-    [agents, conversations],
-  );
+  // Cache-only subscription to every agent's own board query (skipToken —
+  // fetching stays owned by the per-agent board, so this never wakes a pod).
+  // While the aggregate has not fetched for the current roster key (cold
+  // boot, pods still waking), an agent with restored/live board data gets its
+  // badge from the SAME rows the board and the "Activity N" tab render.
+  const cachedActivities = useQueries({
+    queries: agents.map((agent) => ({
+      queryKey: queryKeys.activity(agent.folderPath),
+      queryFn: skipToken,
+    })),
+    combine: (results) => results.map((r) => r.data as Activity[] | undefined),
+  });
+
+  return useMemo(() => {
+    const summaries = buildAgentActivitySummaries(agents, conversations ?? []);
+    if (!aggregateIsAuthoritative) {
+      agents.forEach((agent, index) => {
+        const activities = cachedActivities[index];
+        if (activities) summaries[agent.id] = summarizeActivities(activities);
+      });
+    }
+    return summaries;
+  }, [agents, conversations, aggregateIsAuthoritative, cachedActivities]);
 }

--- a/app/src/components/shell/use-agent-activity-summaries.ts
+++ b/app/src/components/shell/use-agent-activity-summaries.ts
@@ -1,5 +1,5 @@
-import { skipToken, useQueries } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
 import type { Activity } from "../../data/activity";
 import { useAllConversations } from "../../hooks/queries";
 import { queryKeys } from "../../lib/query-keys";
@@ -24,27 +24,51 @@ export function useAgentActivitySummaries(
   const aggregateIsAuthoritative =
     conversations !== undefined && !aggregate.isPlaceholderData;
 
-  // Cache-only subscription to every agent's own board query (skipToken —
-  // fetching stays owned by the per-agent board, so this never wakes a pod).
-  // While the aggregate has not fetched for the current roster key (cold
-  // boot, pods still waking), an agent with restored/live board data gets its
-  // badge from the SAME rows the board and the "Activity N" tab render.
-  const cachedActivities = useQueries({
-    queries: agents.map((agent) => ({
-      queryKey: queryKeys.activity(agent.folderPath),
-      queryFn: skipToken,
-    })),
-    combine: (results) => results.map((r) => r.data as Activity[] | undefined),
+  // Re-render when any agent's own board query (`["activity", path]`) changes
+  // in the cache, WITHOUT attaching query observers: a per-render useQueries
+  // subscription here re-synced its observers on every sidebar render and the
+  // resulting notification churn kept the whole shell re-rendering (the
+  // auto-opened chat panel could no longer be Escape-closed — caught by the
+  // web e2e suite). A raw QueryCache subscription has no options to re-sync,
+  // and it can never trigger a fetch, so it also can't wake a pod.
+  const queryClient = useQueryClient();
+  const activityCacheVersion = useRef(0);
+  const subscribe = useCallback(
+    (onStoreChange: () => void) =>
+      queryClient.getQueryCache().subscribe((event) => {
+        if (event.query.queryKey[0] !== "activity") return;
+        activityCacheVersion.current += 1;
+        onStoreChange();
+      }),
+    [queryClient],
+  );
+  const cacheVersion = useSyncExternalStore(subscribe, () => {
+    return activityCacheVersion.current;
   });
 
   return useMemo(() => {
+    // The version stamp is not read below — it is a dependency so the memo
+    // recomputes when a board query lands/updates in the cache.
+    void cacheVersion;
     const summaries = buildAgentActivitySummaries(agents, conversations ?? []);
     if (!aggregateIsAuthoritative) {
-      agents.forEach((agent, index) => {
-        const activities = cachedActivities[index];
+      // While the aggregate has not fetched for the current roster key (cold
+      // boot, pods still waking), an agent with restored/live board data gets
+      // its badge from the SAME rows the board and the "Activity N" tab
+      // render — cache reads only, never a fetch.
+      for (const agent of agents) {
+        const activities = queryClient.getQueryData<Activity[]>(
+          queryKeys.activity(agent.folderPath),
+        );
         if (activities) summaries[agent.id] = summarizeActivities(activities);
-      });
+      }
     }
     return summaries;
-  }, [agents, conversations, aggregateIsAuthoritative, cachedActivities]);
+  }, [
+    agents,
+    conversations,
+    aggregateIsAuthoritative,
+    queryClient,
+    cacheVersion,
+  ]);
 }

--- a/app/src/hooks/queries/use-conversations.ts
+++ b/app/src/hooks/queries/use-conversations.ts
@@ -1,4 +1,5 @@
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { latestCachedAllConversations } from "../../lib/all-conversations-cache";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriChat, tauriConversations } from "../../lib/tauri";
 
@@ -14,11 +15,21 @@ export function useConversations(agentPath: string | undefined) {
 }
 
 export function useAllConversations(agentPaths: string[]) {
+  const queryClient = useQueryClient();
   return useQuery({
     queryKey: queryKeys.allConversations(agentPaths),
     queryFn: () => tauriConversations.listAll(agentPaths),
     enabled: agentPaths.length > 0,
-    placeholderData: keepPreviousData,
+    // keepPreviousData, PLUS the newest disk-restored roster variant: the key
+    // embeds every agent's folderPath, so the IndexedDB-restored entry only
+    // re-attaches on an exact roster match — any drift would blank the sidebar
+    // badges / Mission Control until the live fan-out returns (held for every
+    // asleep pod's wake). See lib/all-conversations-cache.ts.
+    placeholderData: (previousData) =>
+      previousData ??
+      latestCachedAllConversations<
+        Awaited<ReturnType<typeof tauriConversations.listAll>>
+      >(queryClient),
     // Fetched ONCE per key (mount / roster change / engine restart), then kept
     // fresh by single-agent cache patches from the push events stream
     // (use-agent-invalidation.ts patchAllConversations). Never refetched on

--- a/app/src/lib/all-conversations-cache.ts
+++ b/app/src/lib/all-conversations-cache.ts
@@ -1,0 +1,42 @@
+/**
+ * Cache-variant fallback for the all-conversations aggregate.
+ *
+ * The aggregate's query key embeds EVERY agent's folderPath from the async,
+ * non-persisted agents roster (`["all-conversations", ...agentPaths]`), so the
+ * IndexedDB-restored entry (query-persist.ts) only re-attaches when the roster
+ * resolves byte-identical — same paths, same order. Any drift (roster still
+ * loading, an agent added/removed/reordered since the persist) strands the
+ * restored lists under a stale key, and everything derived from the aggregate
+ * (sidebar needs-you badges, Mission Control, the command palette) blanks
+ * until the live fan-out returns — which a cold pod holds for its whole wake.
+ *
+ * This helper serves the NEWEST successfully-fetched variant of the key as
+ * PLACEHOLDER data: painted immediately, marked `isPlaceholderData`, never
+ * persisted, and always replaced by the real fetch when it lands.
+ *
+ * Kept dependency-free (QueryClient only) so `node --test` exercises it.
+ */
+
+import type { QueryClient } from "@tanstack/react-query";
+import { queryKeys } from "./query-keys.ts";
+
+/** Newest successful data under any `["all-conversations", ...]` key. */
+export function latestCachedAllConversations<T>(
+  queryClient: QueryClient,
+): T | undefined {
+  let bestData: T | undefined;
+  let bestUpdatedAt = -1;
+  const queries = queryClient
+    .getQueryCache()
+    // Prefix match: every roster variant of the aggregate key.
+    .findAll({ queryKey: queryKeys.allConversations([]) });
+  for (const query of queries) {
+    const { status, data, dataUpdatedAt } = query.state;
+    if (status !== "success" || data === undefined) continue;
+    if (dataUpdatedAt > bestUpdatedAt) {
+      bestUpdatedAt = dataUpdatedAt;
+      bestData = data as T;
+    }
+  }
+  return bestData;
+}

--- a/app/tests/agent-activity-summary-model.test.ts
+++ b/app/tests/agent-activity-summary-model.test.ts
@@ -1,6 +1,9 @@
 import { deepStrictEqual } from "node:assert";
 import { describe, it } from "node:test";
-import { buildAgentActivitySummaries } from "../src/components/shell/agent-activity-summary-model.ts";
+import {
+  buildAgentActivitySummaries,
+  summarizeActivities,
+} from "../src/components/shell/agent-activity-summary-model.ts";
 
 describe("agent activity summary model", () => {
   it("counts needs-you and running activity rows by agent", () => {
@@ -30,5 +33,28 @@ describe("agent activity summary model", () => {
       "agent-b": { needsYouCount: 0, runningCount: 1 },
       "agent-c": { needsYouCount: 0, runningCount: 0 },
     });
+  });
+
+  it("summarizes one agent's own board rows with the same counting rule", () => {
+    deepStrictEqual(
+      summarizeActivities([
+        { status: "needs_you" },
+        { status: "needs_you" },
+        { status: "running" },
+        { status: "done" },
+        { status: "archived" },
+      ]),
+      { needsYouCount: 2, runningCount: 1 },
+    );
+  });
+
+  it("summarizeActivities skips routine-setup chats, like the aggregate path", () => {
+    deepStrictEqual(
+      summarizeActivities([
+        { status: "needs_you", agent: "houston:routine-setup" },
+        { status: "needs_you" },
+      ]),
+      { needsYouCount: 1, runningCount: 0 },
+    );
   });
 });

--- a/app/tests/all-conversations-cache.test.ts
+++ b/app/tests/all-conversations-cache.test.ts
@@ -1,0 +1,37 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { QueryClient } from "@tanstack/react-query";
+import { latestCachedAllConversations } from "../src/lib/all-conversations-cache.ts";
+import { queryKeys } from "../src/lib/query-keys.ts";
+
+describe("latestCachedAllConversations", () => {
+  it("returns undefined with no cached aggregate", () => {
+    const qc = new QueryClient();
+    strictEqual(latestCachedAllConversations(qc), undefined);
+  });
+
+  it("serves the newest successful roster variant", () => {
+    const qc = new QueryClient();
+    const older = [{ id: "old" }];
+    const newer = [{ id: "new" }];
+    qc.setQueryData(queryKeys.allConversations(["/w/a", "/w/b"]), older, {
+      updatedAt: 1_000,
+    });
+    qc.setQueryData(
+      queryKeys.allConversations(["/w/a", "/w/b", "/w/c"]),
+      newer,
+      {
+        updatedAt: 2_000,
+      },
+    );
+    deepStrictEqual(latestCachedAllConversations(qc), newer);
+  });
+
+  it("ignores unrelated query keys", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(queryKeys.activity("/w/a"), [{ id: "board-row" }], {
+      updatedAt: 5_000,
+    });
+    strictEqual(latestCachedAllConversations(qc), undefined);
+  });
+});


### PR DESCRIPTION
Follow-up to #911. With the mission cards now painting from the restored caches during a pod cold start, the sidebar's per-agent needs-you badges were still blank until the pods woke (the "Activity 25" tab badge showed, the sidebar pill next to the agent name didn't).

## Root cause

The two badges compute the same number from **different queries**:

- The Activity tab uses the per-agent `["activity", path]` query — a simple, stable key that restores from IndexedDB reliably.
- The sidebar pill derives from the aggregate `["all-conversations", ...agentPaths]` query — and its key embeds **every agent's folderPath**, supplied by the async, **non-persisted** agents roster. TanStack re-attaches a restored entry only on exact serialized-key equality, so while the roster loads (and after any agent add/remove/reorder since the persist) the restored lists sit stranded under a stale key. `NeedsYouChip` renders nothing at count 0, so the sidebar blanks until the live fan-out returns — which a cold pod holds for its whole wake.

## Fix — two placeholder-only layers (the real fetch is untouched)

1. **`useAllConversations`**: when the current key has no data, serve the newest successfully-fetched roster **variant** of the aggregate from the query cache as `placeholderData` (marked `isPlaceholderData`, never persisted, always replaced by the live result). Restored lists now paint regardless of how the roster resolves.
2. **Sidebar summaries**: while the aggregate is not authoritative for the current key, overlay each agent's own cached `["activity", path]` rows via a cache-only `skipToken` subscription (never fetches, so it can't wake a pod), using the same counting rule as the tab badge. The sidebar pill, the board, and the Activity tab then agree by construction during the wake window.

Once the live aggregate lands for the current roster key, it is authoritative again for every agent — behavior after wake is byte-identical to today, including the deliberate never-refetch-on-focus fleet-protection.

## Tests

- `latestCachedAllConversations`: picks the newest successful variant, ignores unrelated keys, empty cache → undefined.
- `summarizeActivities`: same counting rule as the aggregate path (needs_you/running, setup-chat modes excluded).
- Full suite: app 1531 pass, web 187 pass, workspace typecheck + Biome clean.

Verification note: exercised via unit tests + typecheck; the live cold-start window (badges painting while pods wake) needs a hosted build to observe end-to-end.