### PR TITLE
fix: Codex null-field parse errors (HOUSTON-APP-4PF) + bundle codex-code-mode-host

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,18 +340,21 @@ jobs:
           du -sh app/src-tauri/resources/bin/*
 
           # Sanity: every shippable artifact must be present and the
-          # codex binary must be a fat (universal) Mach-O.
+          # codex-family binaries must be fat (universal) Mach-Os.
           test -x app/src-tauri/resources/bin/codex
+          test -x app/src-tauri/resources/bin/codex-code-mode-host
           test -x app/src-tauri/resources/bin/composio-aarch64/composio
           test -x app/src-tauri/resources/bin/composio-x86_64/composio
           test -f app/src-tauri/resources/bin/cli-deps.json
 
-          LIPO_INFO=$(lipo -info app/src-tauri/resources/bin/codex)
-          echo "$LIPO_INFO"
-          echo "$LIPO_INFO" | grep -q 'arm64' \
-            || { echo "::error::bundled codex missing arm64 slice"; exit 1; }
-          echo "$LIPO_INFO" | grep -q 'x86_64' \
-            || { echo "::error::bundled codex missing x86_64 slice"; exit 1; }
+          for bin in codex codex-code-mode-host; do
+            LIPO_INFO=$(lipo -info "app/src-tauri/resources/bin/$bin")
+            echo "$LIPO_INFO"
+            echo "$LIPO_INFO" | grep -q 'arm64' \
+              || { echo "::error::bundled $bin missing arm64 slice"; exit 1; }
+            echo "$LIPO_INFO" | grep -q 'x86_64' \
+              || { echo "::error::bundled $bin missing x86_64 slice"; exit 1; }
+          done
 
       # Import the Developer ID certificate into a temporary keychain so
       # we can pre-sign the bundled CLI binaries (codex + composio) BEFORE
@@ -407,6 +410,7 @@ jobs:
           set -euo pipefail
           BIN=app/src-tauri/resources/bin
           for f in "$BIN/codex" \
+                   "$BIN/codex-code-mode-host" \
                    "$BIN/composio-aarch64/composio" \
                    "$BIN/composio-x86_64/composio" \
                    "$BIN/gemini-aarch64/gemini" \
@@ -1148,6 +1152,7 @@ jobs:
 
           # Sanity: every Windows artifact must be present.
           test -f app/src-tauri/resources/bin/codex.exe
+          test -f app/src-tauri/resources/bin/codex-code-mode-host.exe
           test -f app/src-tauri/resources/bin/composio-${{ matrix.arch }}/composio.exe
           test -f app/src-tauri/resources/bin/composio-${{ matrix.arch }}/run-helpers-runtime.mjs
           test -f app/src-tauri/resources/bin/composio-${{ matrix.arch }}/acp-adapters/codex/win32-${{ matrix.bun_arch }}/codex-acp.exe

--- a/cli-deps.json
+++ b/cli-deps.json
@@ -40,6 +40,23 @@
       "darwin-x64": "bd9748c1cf7a755fdd7b73a90ca944640f7b01113872181db8a5e278902d2331",
       "windows-x64": "8c977e31dc2696e00e9a6c61f7e5d2dbda4b2df544fca4ce3a5a0fed07b71c25",
       "windows-arm64": "7f16480c428a39937690cd3f69ca12552541e4fa790af95cdbeeae105788d711"
+    },
+    "companions": {
+      "codex-code-mode-host": {
+        "$comment": "The code-mode JS host (V8, jitless). codex >= 0.144 spawns it for the code-mode tool (GPT-5.6 family) and resolves it as a SIBLING binary next to the `codex` executable (or via CODEX_CODE_MODE_HOST_PATH). Shipping codex without it makes every code-mode tool call fail with 'failed to spawn code-mode host ... (os error 2)'. Published under the same rust-v{version} release tag as codex; nesting it here (no version field of its own) keeps the two in lockstep by construction — bump-cli.sh clears these checksums together with codex's.",
+        "urls": {
+          "darwin-arm64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-code-mode-host-aarch64-apple-darwin.tar.gz",
+          "darwin-x64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-code-mode-host-x86_64-apple-darwin.tar.gz",
+          "windows-x64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-code-mode-host-x86_64-pc-windows-msvc.exe.zst",
+          "windows-arm64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-code-mode-host-aarch64-pc-windows-msvc.exe.zst"
+        },
+        "checksums": {
+          "darwin-arm64": "6cf9282430befe541369c7cb2804604a7f0dd9416f3a3241e3676db22022a246",
+          "darwin-x64": "6fd2b21d9737f90d9cd047da717d378e58009c0c069b5ecd4fb86ebcfef52d1f",
+          "windows-x64": "c83182c43fd7dcf1b67f0d01b3152dd32ed75b04a15139a4bb293bb4029a14b2",
+          "windows-arm64": "1520ddd21b8abf6149eac2adbfb0fd4c5cef654113912c340e23394e63199c5e"
+        }
+      }
     }
   },
   "composio": {

--- a/engine/houston-terminal-manager/src/codex_parser.rs
+++ b/engine/houston-terminal-manager/src/codex_parser.rs
@@ -119,11 +119,19 @@ impl<'de> Deserialize<'de> for CodexItem {
                 // stops serde from rejecting the line (HOUSTON-APP-31). Applied
                 // to every field so any future duplicate key is tolerated
                 // rather than discarding the whole event.
+                //
+                // Values deserialize through `Option` because Codex emits
+                // explicit `null` for not-yet-populated fields — every
+                // `command_execution` item.started/item.updated carries
+                // `"exit_code": null` while the command runs. A bare
+                // `next_value()` would type the slot as `i32` and reject the
+                // whole line ("invalid type: null, expected i32",
+                // HOUSTON-APP-4PF); `null` must read as absent instead.
                 macro_rules! keep_first {
                     ($slot:ident) => {{
-                        let value = map.next_value()?;
+                        let value: Option<_> = map.next_value()?;
                         if $slot.is_none() {
-                            $slot = Some(value);
+                            $slot = value;
                         }
                     }};
                 }
@@ -693,6 +701,38 @@ mod tests {
             }
             other => panic!("expected ToolResult, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_command_execution_started_with_null_exit_code() {
+        // Codex 0.144 emits `"exit_code": null` on every command_execution
+        // item.started/item.updated while the command is still running. The
+        // manual Deserialize impl typed the slot as bare `i32`, so the whole
+        // line was rejected ("invalid type: null, expected i32") and the
+        // in-progress tool call never reached the feed
+        // (Sentry HOUSTON-APP-4PF, 55k+ events). Null must read as absent.
+        let mut a = acc();
+        let started = r#"{"type":"item.started","item":{"id":"item_12","type":"command_execution","command":"/bin/zsh -lc \"node -e \\\"JSON.parse(require('fs').readFileSync('.houston/learnings/learnings.json','utf8')); console.log('valid')\\\"\"","aggregated_output":"","exit_code":null,"status":"in_progress"}}"#;
+        let items = parse_codex_event(started, &mut a);
+        assert_eq!(items.len(), 1);
+        match &items[0] {
+            FeedItem::ToolCall { name, input } => {
+                assert_eq!(name, "Bash");
+                assert!(input["command"].as_str().unwrap().starts_with("/bin/zsh"));
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_item_with_null_fields_is_tolerated() {
+        // Any field Codex sends as an explicit `null` (not just exit_code)
+        // must deserialize as absent rather than poisoning the line.
+        let mut a = acc();
+        let line = r#"{"type":"item.updated","item":{"id":"item_5","type":"command_execution","command":"bash -lc ls","aggregated_output":null,"exit_code":null,"status":null,"text":null}}"#;
+        let items = parse_codex_event(line, &mut a);
+        assert_eq!(items.len(), 1);
+        assert!(matches!(&items[0], FeedItem::ToolCall { name, .. } if name == "Bash"));
     }
 
     #[test]

--- a/knowledge-base/cli-bundling.md
+++ b/knowledge-base/cli-bundling.md
@@ -13,6 +13,7 @@ opening a shell.
 | CLI         | License       | Distribution      | Where it lives                                                        |
 |-------------|---------------|-------------------|------------------------------------------------------------------------|
 | codex       | Apache-2.0    | Bundled (universal) | `Houston.app/Contents/Resources/bin/codex` — single Mach-O fat binary |
+| codex-code-mode-host | Apache-2.0 | Bundled (universal) | `Resources/bin/codex-code-mode-host` — code-mode JS host (V8, jitless); codex ≥ 0.144 spawns it as a SIBLING of the `codex` binary for the code-mode tool (GPT-5.6 family). Missing sibling = every code-mode call fails with `failed to spawn code-mode host ... (os error 2)`. Pinned as a `companion` inside cli-deps.json's `codex` entry — shares codex's `version`, cannot drift. |
 | composio    | MIT           | Bundled (per-arch)  | `Resources/bin/composio-aarch64/`, `Resources/bin/composio-x86_64/`   |
 | gemini      | Apache-2.0    | Bundled (per-arch)  | `Resources/bin/gemini-aarch64/gemini`, `Resources/bin/gemini-x86_64/gemini` (Node SEA, single Mach-O each) |
 | claude-code | PROPRIETARY   | Runtime download    | `~/.local/bin/claude`                                                  |
@@ -22,6 +23,7 @@ opening a shell.
 | CLI         | License       | Distribution                       | Where it lives                                                                          |
 |-------------|---------------|------------------------------------|------------------------------------------------------------------------------------------|
 | codex       | Apache-2.0    | Bundled (single arch)              | `<install>\resources\bin\codex.exe` — downloaded + zstd-decoded from upstream            |
+| codex-code-mode-host | Apache-2.0 | Bundled (single arch)       | `<install>\resources\bin\codex-code-mode-host.exe` — same sibling rule as macOS          |
 | composio    | MIT           | **Built from source (fork)**       | `<install>\resources\bin\composio-x86_64\composio.exe`                                   |
 | gemini      | Apache-2.0    | **NOT BUNDLED in v1**              | No upstream Windows binary published by google-gemini/gemini-cli (verified across last 100 releases). Phase 2 will mirror the composio fork-build pattern using upstream's `scripts/build_binary.js` (already has win32 branches via Node SEA + postject). Until then, Gemini-backed agents are macOS-only. |
 | claude-code | PROPRIETARY   | Runtime download                   | `%LOCALAPPDATA%\Programs\claude\claude.exe`                                              |
@@ -86,7 +88,11 @@ bundle it on either OS. Instead the engine downloads + sha256-verifies
 on first launch using a manifest pinned in `cli-deps.json`.
 
 codex is a Rust binary so we `lipo -create` the two arch tarballs into
-one universal binary on macOS. composio is a Bun-bundled JS app whose
+one universal binary on macOS. Its companion `codex-code-mode-host`
+(published under the same `rust-v{version}` release tag since 0.144)
+ships the same way and MUST sit next to `codex` — codex resolves it as
+a sibling of its own executable (env override: `CODEX_CODE_MODE_HOST_PATH`).
+composio is a Bun-bundled JS app whose
 runtime is arch-specific — `lipo` can't combine them, so we ship per-
 arch directories on macOS and a single x64 directory on Windows.
 
@@ -132,7 +138,8 @@ mode arg selects the OS:
 
 1. Downloads each bundled CLI for both arches using URLs from the manifest.
 2. Verifies sha256 against pinned checksums (mismatch is fatal).
-3. `lipo -create`s the two codex slices into a single universal Mach-O.
+3. `lipo -create`s the two codex slices into a single universal Mach-O
+   (same for each codex companion, e.g. `codex-code-mode-host`).
 4. Stages each composio arch under `composio-aarch64/` / `composio-x86_64/`.
 5. Prunes cross-platform `acp-adapters/codex/<plat>/` directories that the
    resolved arch can never execute (~580 MB savings).
@@ -140,9 +147,10 @@ mode arg selects the OS:
 
 ### Windows (`windows-x64` mode)
 
-1. Downloads `codex-x86_64-pc-windows-msvc.exe.zst` from openai/codex,
-   verifies SHA-256, decompresses with `zstd`, stages as
-   `resources/bin/codex.exe`. No lipo step.
+1. Downloads `codex-x86_64-pc-windows-msvc.exe.zst` (and each companion,
+   e.g. `codex-code-mode-host-x86_64-pc-windows-msvc.exe.zst`) from
+   openai/codex, verifies SHA-256, decompresses with `zstd`, stages as
+   `resources/bin/codex.exe` / `codex-code-mode-host.exe`. No lipo step.
 2. Clones the gethouston/composio fork at the pinned commit SHA
    (verified after clone — drift fails the build), runs
    `pnpm install + pnpm exec tsdown + pnpm run build:binary:cross --
@@ -193,7 +201,8 @@ codesign --force --options runtime --timestamp \
   --sign "$APPLE_SIGNING_IDENTITY" "$f"
 ```
 
-on `codex`, `composio-aarch64/composio`, `composio-x86_64/composio`.
+on `codex`, `codex-code-mode-host`, `composio-aarch64/composio`,
+`composio-x86_64/composio`.
 Tauri's later deep sign leaves these alone (it doesn't visit nested
 Resources subdirs), so the pre-applied signature carries through to
 notarization.

--- a/scripts/bump-cli.sh
+++ b/scripts/bump-cli.sh
@@ -31,8 +31,16 @@ OLD_VERSION=$(jq -r --arg cli "$CLI" '.[$cli].version' "$DEPS_FILE")
 # trailing CR makes the output byte-identical on macOS, Linux, and Windows
 # git-bash (and keeps the repo's LF-only rule). On macOS/Linux the perl
 # filter is a no-op (no CR present).
+#
+# Companions (e.g. codex's codex-code-mode-host) share the parent's version
+# field and ship from the same release tag, so their checksums go stale on
+# the same bump — clear them in the same pass.
 jq --arg cli "$CLI" --arg v "$VERSION" \
-  '.[$cli].version = $v | .[$cli].checksums = {}' "$DEPS_FILE" \
+  '.[$cli].version = $v
+   | .[$cli].checksums = {}
+   | (if .[$cli].companions
+      then .[$cli].companions |= with_entries(.value.checksums = {})
+      else . end)' "$DEPS_FILE" \
   | perl -pe 's/\r$//' > tmp.json && mv tmp.json "$DEPS_FILE"
 
 echo "Bumped $CLI: $OLD_VERSION -> $VERSION"

--- a/scripts/fetch-cli-deps.sh
+++ b/scripts/fetch-cli-deps.sh
@@ -8,6 +8,9 @@
 #
 #   app/src-tauri/resources/bin/
 #     codex                          # universal Mach-O (arm64 + x86_64)
+#     codex-code-mode-host           # universal Mach-O — code-mode JS host;
+#                                    # codex spawns it as a SIBLING binary,
+#                                    # so it must sit next to `codex`
 #     composio-aarch64/              # Apple Silicon Bun bundle
 #       composio
 #       services/
@@ -24,6 +27,7 @@
 #
 #   app/src-tauri/resources/bin/
 #     codex.exe                      # Windows x64 single-arch binary
+#     codex-code-mode-host.exe       # code-mode JS host, sibling of codex.exe
 #     composio-x86_64/               # Bun-compiled Windows bundle
 #       composio.exe
 #       services/
@@ -38,6 +42,10 @@
 #   - codex is a Rust binary — on macOS we `lipo -create` the two slices
 #     into a single fat binary; on Windows there is no lipo equivalent
 #     and we simply stage the per-arch binary alongside the rest.
+#     codex-code-mode-host (codex >= 0.144) ships the same way and MUST
+#     land next to `codex`: codex resolves it as a sibling of its own
+#     executable when the model calls the code-mode tool (GPT-5.6 family);
+#     a missing sibling fails every code-mode call with os error 2.
 #   - composio is a Bun-bundled JavaScript runtime — CANNOT be lipo'd; the
 #     binary contains an arch-specific Bun runtime + sibling .mjs/services
 #     files. Both arches must be shipped side-by-side under a per-arch dir
@@ -215,97 +223,118 @@ prune_acp_adapters() {
 # macOS code path — unchanged from the pre-Windows release pipeline
 # ---------------------------------------------------------------------------
 
+# The codex family: the `codex` CLI itself plus the companion binaries
+# published under the same rust-v{version} release tag (currently
+# codex-code-mode-host, which codex spawns as a SIBLING binary for the
+# code-mode tool). Companions live under `.codex.companions` in
+# cli-deps.json — same `version` field as codex, so they can never drift.
+CODEX_FAMILY=(codex codex-code-mode-host)
+
+# jq lookup for a codex-family binary's url/checksum field.
+#   $1 = binary name, $2 = field (urls|checksums), $3 = platform
+codex_family_field() {
+  local name="$1" field="$2" platform="$3"
+  if [ "$name" = "codex" ]; then
+    jq -r ".codex.${field}[\"$platform\"] // empty" "$DEPS_FILE"
+  else
+    jq -r ".codex.companions[\"$name\"].${field}[\"$platform\"] // empty" "$DEPS_FILE"
+  fi
+}
+
 stage_codex_arch_darwin() {
-  local arch="$1"
+  local name="$1"
+  local arch="$2"
   local platform="darwin-$arch"
   local version url_template expected url tmp extract_dir bin_path
   version=$(jq -r '.codex.version' "$DEPS_FILE")
-  url_template=$(jq -r ".codex.urls[\"$platform\"] // empty" "$DEPS_FILE")
-  expected=$(jq -r ".codex.checksums[\"$platform\"] // empty" "$DEPS_FILE")
+  url_template=$(codex_family_field "$name" urls "$platform")
+  expected=$(codex_family_field "$name" checksums "$platform")
 
   if [ -z "$url_template" ]; then
-    echo "ERROR: cli-deps.json missing codex URL for $platform" >&2
+    echo "ERROR: cli-deps.json missing $name URL for $platform" >&2
     exit 1
   fi
 
   url="${url_template//\{version\}/$version}"
-  echo "FETCH codex v$version ($platform)"
+  echo "FETCH $name v$version ($platform)"
   echo "  URL: $url"
 
   tmp=$(mktemp)
-  download "$url" "$tmp" || { echo "ERROR: codex download failed for $platform" >&2; rm -f "$tmp"; exit 1; }
-  verify_or_print_checksum "$tmp" "$expected" "codex/$platform" || { rm -f "$tmp"; exit 1; }
+  download "$url" "$tmp" || { echo "ERROR: $name download failed for $platform" >&2; rm -f "$tmp"; exit 1; }
+  verify_or_print_checksum "$tmp" "$expected" "$name/$platform" || { rm -f "$tmp"; exit 1; }
 
   extract_dir=$(mktemp -d)
   case "$url" in
     *.tar.gz|*.tgz) tar xzf "$tmp" -C "$extract_dir" ;;
     *.zip)          unzip -q "$tmp" -d "$extract_dir" ;;
-    *)              cp "$tmp" "$extract_dir/codex" ;;
+    *)              cp "$tmp" "$extract_dir/$name" ;;
   esac
   rm -f "$tmp"
 
-  bin_path=$(find_binary "$extract_dir" "codex")
+  bin_path=$(find_binary "$extract_dir" "$name")
   if [ -z "$bin_path" ]; then
-    echo "ERROR: codex binary not found in archive for $platform" >&2
+    echo "ERROR: $name binary not found in archive for $platform" >&2
     find "$extract_dir" -type f | head -20 >&2
     rm -rf "$extract_dir"
     exit 1
   fi
 
-  local stage_dir="$OUT_DIR/.staging/codex"
+  local stage_dir="$OUT_DIR/.staging/$name"
   mkdir -p "$stage_dir"
-  cp "$bin_path" "$stage_dir/codex-$arch"
-  chmod +x "$stage_dir/codex-$arch"
+  cp "$bin_path" "$stage_dir/$name-$arch"
+  chmod +x "$stage_dir/$name-$arch"
   rm -rf "$extract_dir"
 
   # Verify the binary has the expected slice — protects against a
   # mislabelled URL (Apple silicon binary served from x64 URL, etc.).
   local lipo_info
-  lipo_info=$(lipo -info "$stage_dir/codex-$arch" 2>&1 || echo "")
+  lipo_info=$(lipo -info "$stage_dir/$name-$arch" 2>&1 || echo "")
   case "$arch" in
     arm64)
       echo "$lipo_info" | grep -q 'arm64' \
-        || { echo "ERROR: codex-$arch is not an arm64 binary: $lipo_info" >&2; exit 1; } ;;
+        || { echo "ERROR: $name-$arch is not an arm64 binary: $lipo_info" >&2; exit 1; } ;;
     x64)
       echo "$lipo_info" | grep -q 'x86_64' \
-        || { echo "ERROR: codex-$arch is not an x86_64 binary: $lipo_info" >&2; exit 1; } ;;
+        || { echo "ERROR: $name-$arch is not an x86_64 binary: $lipo_info" >&2; exit 1; } ;;
   esac
 
-  echo "  Staged: $stage_dir/codex-$arch"
+  echo "  Staged: $stage_dir/$name-$arch"
 }
 
 lipo_codex_universal_darwin() {
-  local stage_dir="$OUT_DIR/.staging/codex"
-  if [ ! -f "$stage_dir/codex-arm64" ] || [ ! -f "$stage_dir/codex-x64" ]; then
-    echo "ERROR: cannot lipo codex — both arches not staged" >&2
+  local name="$1"
+  local stage_dir="$OUT_DIR/.staging/$name"
+  if [ ! -f "$stage_dir/$name-arm64" ] || [ ! -f "$stage_dir/$name-x64" ]; then
+    echo "ERROR: cannot lipo $name — both arches not staged" >&2
     ls -la "$stage_dir" >&2 || true
     exit 1
   fi
-  echo "LIPO codex universal (arm64 + x86_64)"
+  echo "LIPO $name universal (arm64 + x86_64)"
   lipo -create \
-    "$stage_dir/codex-arm64" \
-    "$stage_dir/codex-x64" \
-    -output "$OUT_DIR/codex"
-  chmod +x "$OUT_DIR/codex"
+    "$stage_dir/$name-arm64" \
+    "$stage_dir/$name-x64" \
+    -output "$OUT_DIR/$name"
+  chmod +x "$OUT_DIR/$name"
   rm -rf "$stage_dir"
   local lipo_info
-  lipo_info=$(lipo -info "$OUT_DIR/codex" 2>&1)
+  lipo_info=$(lipo -info "$OUT_DIR/$name" 2>&1)
   echo "  $lipo_info"
-  echo "  Installed: $OUT_DIR/codex ($(du -sh "$OUT_DIR/codex" | cut -f1))"
+  echo "  Installed: $OUT_DIR/$name ($(du -sh "$OUT_DIR/$name" | cut -f1))"
 }
 
 finalize_codex_single_arch_darwin() {
-  local arch="$1"
-  local stage_dir="$OUT_DIR/.staging/codex"
-  if [ ! -f "$stage_dir/codex-$arch" ]; then
-    echo "ERROR: codex-$arch not staged" >&2
+  local name="$1"
+  local arch="$2"
+  local stage_dir="$OUT_DIR/.staging/$name"
+  if [ ! -f "$stage_dir/$name-$arch" ]; then
+    echo "ERROR: $name-$arch not staged" >&2
     exit 1
   fi
-  echo "FINALIZE codex (single arch: $arch — dev build, NOT shippable)"
-  cp "$stage_dir/codex-$arch" "$OUT_DIR/codex"
-  chmod +x "$OUT_DIR/codex"
+  echo "FINALIZE $name (single arch: $arch — dev build, NOT shippable)"
+  cp "$stage_dir/$name-$arch" "$OUT_DIR/$name"
+  chmod +x "$OUT_DIR/$name"
   rm -rf "$stage_dir"
-  echo "  Installed: $OUT_DIR/codex (single $arch)"
+  echo "  Installed: $OUT_DIR/$name (single $arch)"
 }
 
 fetch_composio_arch_darwin() {
@@ -456,40 +485,41 @@ stage_gemini_arch_darwin() {
 # release — we just download, decompress, and stage at the single
 # location resources/bin/codex.exe (no lipo equivalent on Windows).
 stage_codex_windows() {
-  local arch="$1"
+  local name="$1"
+  local arch="$2"
   local platform="windows-$arch"
   local version url_template expected url tmp out_path
   version=$(jq -r '.codex.version' "$DEPS_FILE")
-  url_template=$(jq -r ".codex.urls[\"$platform\"] // empty" "$DEPS_FILE")
-  expected=$(jq -r ".codex.checksums[\"$platform\"] // empty" "$DEPS_FILE")
+  url_template=$(codex_family_field "$name" urls "$platform")
+  expected=$(codex_family_field "$name" checksums "$platform")
 
   if [ -z "$url_template" ]; then
-    echo "ERROR: cli-deps.json missing codex URL for $platform" >&2
+    echo "ERROR: cli-deps.json missing $name URL for $platform" >&2
     exit 1
   fi
 
   url="${url_template//\{version\}/$version}"
-  echo "FETCH codex v$version ($platform)"
+  echo "FETCH $name v$version ($platform)"
   echo "  URL: $url"
 
   tmp=$(mktemp)
-  download "$url" "$tmp" || { echo "ERROR: codex download failed for $platform" >&2; rm -f "$tmp"; exit 1; }
-  verify_or_print_checksum "$tmp" "$expected" "codex/$platform" || { rm -f "$tmp"; exit 1; }
+  download "$url" "$tmp" || { echo "ERROR: $name download failed for $platform" >&2; rm -f "$tmp"; exit 1; }
+  verify_or_print_checksum "$tmp" "$expected" "$name/$platform" || { rm -f "$tmp"; exit 1; }
 
   if ! command -v zstd >/dev/null 2>&1; then
-    echo "ERROR: zstd is required to decompress the codex Windows artifact" >&2
+    echo "ERROR: zstd is required to decompress the $name Windows artifact" >&2
     echo "  brew install zstd | choco install zstandard" >&2
     rm -f "$tmp"
     exit 1
   fi
 
-  out_path="$OUT_DIR/codex.exe"
+  out_path="$OUT_DIR/$name.exe"
   rm -f "$out_path"
   zstd -d "$tmp" -o "$out_path" >/dev/null 2>&1
   rm -f "$tmp"
 
   if [ ! -s "$out_path" ]; then
-    echo "ERROR: zstd decompression produced empty output for codex/$platform" >&2
+    echo "ERROR: zstd decompression produced empty output for $name/$platform" >&2
     exit 1
   fi
   echo "  Installed: $out_path ($(du -sh "$out_path" | cut -f1))"
@@ -678,6 +708,7 @@ build_composio_windows() {
 # ---------------------------------------------------------------------------
 rm -rf "$OUT_DIR/.staging" \
        "$OUT_DIR/codex" "$OUT_DIR/codex.exe" \
+       "$OUT_DIR/codex-code-mode-host" "$OUT_DIR/codex-code-mode-host.exe" \
        "$OUT_DIR/composio-"* \
        "$OUT_DIR/gemini-"* \
        "$OUT_DIR/cli-deps.json"
@@ -689,20 +720,26 @@ rm -rf "$OUT_DIR/.staging" \
 case "$TARGET_OS" in
   darwin)
     for arch in "${ARCHES[@]}"; do
-      stage_codex_arch_darwin "$arch"
+      for bin in "${CODEX_FAMILY[@]}"; do
+        stage_codex_arch_darwin "$bin" "$arch"
+      done
       fetch_composio_arch_darwin "$arch"
       stage_gemini_arch_darwin "$arch"
     done
 
-    if [ "${#ARCHES[@]}" -eq 2 ]; then
-      lipo_codex_universal_darwin
-    else
-      finalize_codex_single_arch_darwin "${ARCHES[0]}"
-    fi
+    for bin in "${CODEX_FAMILY[@]}"; do
+      if [ "${#ARCHES[@]}" -eq 2 ]; then
+        lipo_codex_universal_darwin "$bin"
+      else
+        finalize_codex_single_arch_darwin "$bin" "${ARCHES[0]}"
+      fi
+    done
     ;;
   windows)
     for arch in "${ARCHES[@]}"; do
-      stage_codex_windows "$arch"
+      for bin in "${CODEX_FAMILY[@]}"; do
+        stage_codex_windows "$bin" "$arch"
+      done
       build_composio_windows "$arch"
       stage_git_bash_windows "$arch"
     done
@@ -730,6 +767,7 @@ missing=()
 case "$TARGET_OS" in
   darwin)
     [ -x "$OUT_DIR/codex" ] || missing+=("codex")
+    [ -x "$OUT_DIR/codex-code-mode-host" ] || missing+=("codex-code-mode-host")
     if [ "${#ARCHES[@]}" -eq 2 ]; then
       [ -x "$OUT_DIR/composio-aarch64/composio" ] || missing+=("composio-aarch64/composio")
       [ -x "$OUT_DIR/composio-x86_64/composio" ]  || missing+=("composio-x86_64/composio")
@@ -739,6 +777,7 @@ case "$TARGET_OS" in
     ;;
   windows)
     [ -f "$OUT_DIR/codex.exe" ] || missing+=("codex.exe")
+    [ -f "$OUT_DIR/codex-code-mode-host.exe" ] || missing+=("codex-code-mode-host.exe")
     # Verify only the arches that were actually requested. Previously
     # this hardcoded composio-x86_64/... paths which made
     # `windows-arm64` (and any future single-arch mode) fail at the


### PR DESCRIPTION
Two Codex-provider fixes for the legacy Rust-engine line, to ship as v0.4.28. Base is `release-0.4.26` (the Rust-engine release line; `main` has moved to the TS engine).

---

## 1. HOUSTON-APP-4PF — "Failed to parse Codex event: invalid type: null, expected i32"

[Sentry issue](https://houston-cd.sentry.io/issues/7555741060/) — 55,649 events since 2026-06-16, logger `houston_terminal_manager::codex_parser`, every release v0.4.20 → v0.4.26. **Verified still present in the shipped v0.4.27 code** (tag `v0.4.27` contains the same parser; no 0.4.27 events in Sentry yet only because the release is days old — reproduced locally on a v0.4.27 install).

Codex's `--json` NDJSON emits an explicit `"exit_code": null` on every `command_execution` `item.started` / `item.updated` while the command is still running:

```json
{"type":"item.started","item":{"id":"item_12","type":"command_execution","command":"/bin/zsh -lc ...","aggregated_output":"","exit_code":null,"status":"in_progress"}}
```

**Root cause.** The hand-written `Deserialize` impl for `CodexItem` (added for the duplicate-`id` `web_search` payload, HOUSTON-APP-31) reads each field with a bare `map.next_value()?`. Type inference resolves that to the inner type (`i32` for `exit_code`), not `Option<i32>`, so a JSON `null` rejects the whole line. The event is dropped: the in-progress tool call never reaches the chat feed and one Sentry error fires per command the agent runs. The chat still LOOKS fine — `item.completed` carries a non-null exit code and parses — which is why 55k events produced zero user reports.

**Fix.** Deserialize every field through `Option<_>` inside the `keep_first!` macro so an explicit `null` reads as absent. First-key-wins semantics for the HOUSTON-APP-31 duplicate-key case are preserved.

**Steps to reproduce on v0.4.27**
1. Install Houston v0.4.27 and connect an OpenAI account.
2. Open any agent chat, pick any GPT model, and send a prompt that makes the agent run a shell command, e.g. *"run `ls` in my folder"*.
3. The chat completes normally, but `~/.houston/logs/engine.log.<date>` logs `Failed to parse Codex event: invalid type: null, expected i32 ...` and a Sentry event fires — one per command executed. The command's in-progress state never appears in the feed.

**Tests.** `parse_command_execution_started_with_null_exit_code` (the exact Sentry payload shape) + `parse_item_with_null_fields_is_tolerated`. Both fail on the old code with the exact Sentry error and pass with the fix. Full crate: `cargo test` in `engine/houston-terminal-manager` → 274 passed.

---

## 2. Bundle `codex-code-mode-host` (code-mode spawn failure on GPT-5.6)

```
failed to spawn code-mode host
/Applications/Houston.app/Contents/Resources/bin/codex-code-mode-host: No such file or directory (os error 2)
```

codex ≥ 0.144 ships the code-mode JS host (V8, jitless) as a **separate binary** published under the same `rust-v{version}` release tag, and spawns it as a **sibling of its own executable** (env override: `CODEX_CODE_MODE_HOST_PATH`) when the model invokes the code-mode tool — which the GPT-5.6 family does. Houston bundles only `codex`, so every code-mode call fails with os error 2 on both macOS (`Resources/bin/`) and Windows (`resources\bin\`). Confirmed in local engine logs on v0.4.26/v0.4.27 installs (`codex_core::tools::router` stderr).

**Steps to reproduce on v0.4.27**
1. Connect an OpenAI account and pick a GPT-5.6 model (Sol/Terra/Luna).
2. Send a prompt that makes the model use the code-mode tool (any multi-step task that runs code).
3. `~/.houston/logs/engine.log.<date>` logs the `failed to spawn code-mode host` error; the code-mode tool call fails.

**Fix.**
- `cli-deps.json`: the host is pinned as a `companion` **inside the codex entry** — it shares codex's `version` field, so the pair can never drift; checksums for all four platforms pinned.
- `scripts/fetch-cli-deps.sh`: the codex staging functions are parameterized over the codex family (`codex`, `codex-code-mode-host`) — same download/sha256-verify/lipo path on macOS (universal Mach-O at `Resources/bin/codex-code-mode-host`), same zstd-decode path on Windows (`resources\bin\codex-code-mode-host.exe`). Preflight cleanup + tail assertions cover the new artifact.
- `scripts/bump-cli.sh`: bumping codex clears companion checksums in the same jq pass.
- `.github/workflows/release.yml`: the new binary is pre-signed (Developer ID + hardened runtime + timestamp) alongside codex/composio/gemini, and the staging sanity checks assert its presence + universal slices on macOS and presence on Windows.
- `knowledge-base/cli-bundling.md` updated.

**Verification.** Full `./scripts/fetch-cli-deps.sh both` run: all checksums verified, `codex-code-mode-host` staged as a fat Mach-O (x86_64 + arm64, 91 MB) next to `codex`, tail assertions pass. The staged binary executes and waits for its handshake ("failed to read code-mode client hello" on empty stdin). The sibling location is exactly the path codex printed in the error message. `bump-cli.sh` jq logic dry-run: bumping codex clears both checksum sets; bumping composio touches neither and adds no stray `companions` key.