### PR TITLE
fix(chat): make the in-chat integration approval card work on hosted cloud + stop the footer overflowing

### DIFF
--- a/packages/fake-host/src/routes-action-approvals.ts
+++ b/packages/fake-host/src/routes-action-approvals.ts
@@ -1,14 +1,16 @@
 /**
  * Per-agent integration action-approval USER routes for the fake host, mirroring
- * the real host `routes/action-approvals.ts` (mounted at `/v1/agents/:id/
- * action-approvals[...]`, authed as the signed-in owner in both deployments).
+ * the real host `routes/action-approvals.ts` — BOTH surfaces: the top-level
+ * `/v1/agents/:id/action-approvals[...]` and the per-agent dispatch
+ * `/agents/:id/action-approvals[...]` (the one the shipped clients call, since
+ * it is the only per-agent surface the hosted gateway proxies to a pod).
  * The interaction card's "Always allow" appends the action slug; "Allow once"
  * writes a one-shot ticket for the params-fingerprint hash. Shapes + validation
  * match the real route exactly.
  *
- *   GET  /v1/agents/:agentId/action-approvals          -> {always}
- *   POST /v1/agents/:agentId/action-approvals/always    {action} -> {always}
- *   POST /v1/agents/:agentId/action-approvals/tickets   {hash}   -> {ok:true}
+ *   GET  …/action-approvals          -> {always}
+ *   POST …/action-approvals/always    {action} -> {always}
+ *   POST …/action-approvals/tickets   {hash}   -> {ok:true}
  *
  * Returns a `Response` when a route matched, or `undefined` to fall through.
  */
@@ -22,24 +24,26 @@ const ACTION = /^[A-Za-z0-9_-]+$/;
 /** A params fingerprint from hashActionParams: sha256 truncated to 16 hex chars. */
 const HASH = /^[a-f0-9]{16}$/;
 
-/** Route `/v1/agents/:agentId/action-approvals[...]`; `segs` is the full path
- *  split (not decoded). */
+/** Route `/v1/agents/:agentId/action-approvals[...]` AND the dispatch form
+ *  `/agents/:agentId/action-approvals[...]`; `segs` is the full path split
+ *  (not decoded). */
 export function handleActionApprovals(
   method: string,
   segs: string[],
   body: Record<string, unknown> | undefined,
 ): Response | undefined {
+  // Normalize the two surfaces to one shape: drop the optional leading "v1".
+  const rel = segs[0] === "v1" ? segs.slice(1) : segs;
   if (
-    segs[0] !== "v1" ||
-    segs[1] !== "agents" ||
-    segs.length < 4 ||
-    segs.length > 5 ||
-    segs[3] !== "action-approvals"
+    rel[0] !== "agents" ||
+    rel.length < 3 ||
+    rel.length > 4 ||
+    rel[2] !== "action-approvals"
   ) {
     return undefined;
   }
-  const agentId = decodeURIComponent(segs[2]);
-  const sub = segs[4]; // undefined | "always" | "tickets"
+  const agentId = decodeURIComponent(rel[1]);
+  const sub = rel[3]; // undefined | "always" | "tickets"
 
   if (!sub && method === "GET") {
     return json({ always: state.alwaysAllowed(agentId) });

--- a/packages/host/src/routes/action-approvals.test.ts
+++ b/packages/host/src/routes/action-approvals.test.ts
@@ -11,7 +11,10 @@ import { MemoryWorkspaceStore } from "../store/memory";
 
 /**
  * The user-facing action-approvals routes over real HTTP: ownership, body
- * validation, the always-allow + ticket writes, and the unwired-dep 404.
+ * validation, the always-allow + ticket writes, and the unwired-dep 404 —
+ * on BOTH surfaces: the top-level `/v1/agents/:id/action-approvals/*` and the
+ * per-agent dispatch `/agents/:id/action-approvals/*` (the one the hosted
+ * gateway proxies to a pod, so the shipped clients call it).
  */
 
 const USER = "alice";
@@ -68,6 +71,9 @@ const auth = {
 };
 const url = (base: string, agentId: string, sub = "") =>
   `${base}/v1/agents/${encodeURIComponent(agentId)}/action-approvals${sub}`;
+/** The dispatch-surface form of the same routes (what the shipped clients call). */
+const dispatchUrl = (base: string, agentId: string, sub = "") =>
+  `${base}/agents/${encodeURIComponent(agentId)}/action-approvals${sub}`;
 
 test("GET returns the always list; POST /always appends (deduped)", async () => {
   const { base, agent, stop } = await setup();
@@ -154,6 +160,88 @@ test("unknown agent → 404", async () => {
   try {
     const res = await fetch(url(base, `${ws.id}/Ghost`), { headers: auth });
     expect(res.status).toBe(404);
+  } finally {
+    stop();
+  }
+});
+
+test("dispatch surface serves the same three routes (GET / always / tickets)", async () => {
+  const { base, agent, approvalStore, stop } = await setup();
+  try {
+    const empty = await fetch(dispatchUrl(base, agent.id), { headers: auth });
+    expect(empty.status).toBe(200);
+    expect((await empty.json()).always).toEqual([]);
+
+    const always = await fetch(dispatchUrl(base, agent.id, "/always"), {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({ action: "GMAIL_SEND" }),
+    });
+    expect(always.status).toBe(200);
+    expect((await always.json()).always).toEqual(["GMAIL_SEND"]);
+
+    const ticket = await fetch(dispatchUrl(base, agent.id, "/tickets"), {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({ hash: "0123456789abcdef" }),
+    });
+    expect(ticket.status).toBe(200);
+    expect((await ticket.json()).ok).toBe(true);
+    const record = await approvalStore.get(agent.id);
+    expect(record.tickets.map((t) => t.hash)).toEqual(["0123456789abcdef"]);
+
+    // Both surfaces read the SAME store.
+    const get = await fetch(url(base, agent.id), { headers: auth });
+    expect((await get.json()).always).toEqual(["GMAIL_SEND"]);
+  } finally {
+    stop();
+  }
+});
+
+test("dispatch surface validates bodies like the /v1 surface", async () => {
+  const { base, agent, stop } = await setup();
+  try {
+    const always = await fetch(dispatchUrl(base, agent.id, "/always"), {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({ action: "bad slug!" }),
+    });
+    expect(always.status).toBe(400);
+    const ticket = await fetch(dispatchUrl(base, agent.id, "/tickets"), {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({ hash: "SHORT" }),
+    });
+    expect(ticket.status).toBe(400);
+  } finally {
+    stop();
+  }
+});
+
+test("dispatch surface enforces the same ownership check (403)", async () => {
+  const { base, agent, stop } = await setup();
+  try {
+    const res = await fetch(dispatchUrl(base, agent.id), {
+      headers: { Authorization: "Bearer other" },
+    });
+    expect(res.status).toBe(403);
+  } finally {
+    stop();
+  }
+});
+
+test("unwired dep → dispatch requests fall through past the approval routes", async () => {
+  const { base, agent, stop } = await setup({ withApprovals: false });
+  try {
+    // With no approval store the family is not served here; the request keeps
+    // falling toward the runtime channel (none wired in this harness → 503),
+    // never a 200 pretending the write landed.
+    const res = await fetch(dispatchUrl(base, agent.id, "/tickets"), {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({ hash: "0123456789abcdef" }),
+    });
+    expect(res.status).toBe(503);
   } finally {
     stop();
   }

--- a/packages/host/src/routes/action-approvals.ts
+++ b/packages/host/src/routes/action-approvals.ts
@@ -6,20 +6,26 @@ import type { WorkspaceStore } from "../ports";
 import { json, readJson } from "./http";
 
 /**
- * Per-agent integration action approvals — the USER routes (`/v1/agents/
- * :agentId/action-approvals/*`, authed as the signed-in owner). The app writes
+ * Per-agent integration action approvals — the USER routes. The app writes
  * here after the runtime surfaces an approval step on the interaction card:
  * "Always allow" appends the action slug; "Allow once" writes a one-shot ticket
  * for the params-fingerprint hash. Then the model re-issues the same execute and
  * the sandbox gate (integrations-sandbox.ts) lets it through.
  *
- * Mounted only when `deps.actionApprovals` is wired (see local/host.ts). Absent
- * dep → this handler falls through to a 404, which the client reads as
+ * TWO surfaces serve the same three routes (the skills-marketplace precedent):
+ * the top-level `/v1/agents/:agentId/action-approvals/*` for direct API callers,
+ * and the per-agent dispatch `/agents/:agentId/action-approvals/*` — the ONE
+ * per-agent surface the hosted gateway proxies to a pod (it forwards
+ * `/agents/{slug}/<rest>` and mounts no `/v1/agents/*` route for approvals), so
+ * the shipped clients call the dispatch form in both deployments.
+ *
+ * Mounted only when `actionApprovals` is wired (see local/host.ts). Absent
+ * dep → these handlers fall through, which the client reads as
  * "approvals unsupported" and degrades without a toast.
  *
- *   GET  /v1/agents/:agentId/action-approvals          -> {always}
- *   POST /v1/agents/:agentId/action-approvals/always    {action} -> {always}
- *   POST /v1/agents/:agentId/action-approvals/tickets   {hash}   -> {ok:true}
+ *   GET  …/action-approvals          -> {always}
+ *   POST …/action-approvals/always    {action} -> {always}
+ *   POST …/action-approvals/tickets   {hash}   -> {ok:true}
  */
 export interface ActionApprovalsDeps {
   store: WorkspaceStore;
@@ -49,6 +55,47 @@ async function authorize(
   };
 }
 
+/** The surface-agnostic core: serve one action-approvals request for an agent
+ *  the caller is ALREADY authorized on. `sub` is undefined (the always-set
+ *  read), "always", or "tickets". Returns false when method+sub name no route
+ *  in this family (the caller falls through). */
+async function serve(
+  approvals: LocalActionApprovals,
+  agentId: string,
+  method: string,
+  sub: string | undefined,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  if (!sub && method === "GET") {
+    json(res, 200, { always: await approvals.always(agentId) });
+    return true;
+  }
+
+  if (sub === "always" && method === "POST") {
+    const { action } = await readJson(req);
+    if (typeof action !== "string" || !action || !ACTION.test(action)) {
+      json(res, 400, { error: "missing or invalid 'action'" });
+      return true;
+    }
+    json(res, 200, { always: await approvals.allowAlways(agentId, action) });
+    return true;
+  }
+
+  if (sub === "tickets" && method === "POST") {
+    const { hash } = await readJson(req);
+    if (typeof hash !== "string" || !hash || !HASH.test(hash)) {
+      json(res, 400, { error: "missing or invalid 'hash'" });
+      return true;
+    }
+    await approvals.addTicket(agentId, hash);
+    json(res, 200, { ok: true });
+    return true;
+  }
+
+  return false;
+}
+
 export async function handleActionApprovals(
   deps: ActionApprovalsDeps,
   userId: UserId,
@@ -63,7 +110,6 @@ export async function handleActionApprovals(
   if (!match) return false;
   // Not wired → fall through to a 404 so the client degrades to "unsupported".
   if (!deps.actionApprovals) return false;
-  const sub = match[2];
 
   const agentId = match[1] ? decodeURIComponent(match[1]) : "";
   const authz = await authorize(deps.store, userId, agentId);
@@ -72,33 +118,27 @@ export async function handleActionApprovals(
     return true;
   }
 
-  if (!sub && method === "GET") {
-    json(res, 200, { always: await deps.actionApprovals.always(agentId) });
-    return true;
-  }
+  return serve(deps.actionApprovals, agentId, method, match[2], req, res);
+}
 
-  if (sub === "always" && method === "POST") {
-    const { action } = await readJson(req);
-    if (typeof action !== "string" || !action || !ACTION.test(action)) {
-      json(res, 400, { error: "missing or invalid 'action'" });
-      return true;
-    }
-    json(res, 200, {
-      always: await deps.actionApprovals.allowAlways(agentId, action),
-    });
-    return true;
-  }
-
-  if (sub === "tickets" && method === "POST") {
-    const { hash } = await readJson(req);
-    if (typeof hash !== "string" || !hash || !HASH.test(hash)) {
-      json(res, 400, { error: "missing or invalid 'hash'" });
-      return true;
-    }
-    await deps.actionApprovals.addTicket(agentId, hash);
-    json(res, 200, { ok: true });
-    return true;
-  }
-
-  return false;
+/**
+ * The SAME three routes on the per-agent dispatch surface
+ * (`/agents/:agentId/action-approvals[...]`), matched on the dispatch `rest`
+ * inside handleAgents — which has ALREADY run the ownership check, so no authz
+ * here. This is the surface the hosted gateway proxies (scope: use), and the
+ * one the shipped clients call in both deployments. Unwired approvals → false,
+ * and the request falls through toward the runtime channel like any unknown
+ * dispatch family.
+ */
+export async function handleActionApprovalsDispatch(
+  approvals: LocalActionApprovals | undefined,
+  agentId: string,
+  method: string,
+  rest: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  const match = rest.match(/^action-approvals(?:\/(always|tickets))?$/);
+  if (!match || !approvals) return false;
+  return serve(approvals, agentId, method, match[1], req, res);
 }

--- a/packages/host/src/routes/agent-authz.ts
+++ b/packages/host/src/routes/agent-authz.ts
@@ -9,6 +9,7 @@ import type {
   WorkspaceRuntime,
 } from "../domain/types";
 import type { EventHub } from "../events/hub";
+import type { LocalActionApprovals } from "../integrations/action-approvals";
 import type { LocalIntegrationGrants } from "../integrations/grants";
 import { CloudPaths, type WorkspacePaths } from "../paths";
 import type { RuntimeChannel, WorkspaceStore } from "../ports";
@@ -67,6 +68,12 @@ export interface AgentRouteDeps {
    * Absent on managed cloud pods, where the gateway owns grant policy.
    */
   integrationGrants?: LocalIntegrationGrants;
+  /**
+   * Per-agent action approvals (mirrors ControlPlaneDeps.actionApprovals) —
+   * the dispatch-surface routes (`/agents/:id/action-approvals/*`) write here.
+   * Absent → those requests fall through toward the runtime channel (404).
+   */
+  actionApprovals?: LocalActionApprovals;
 }
 
 export const DEFAULT_PATHS = new CloudPaths();

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -16,6 +16,7 @@ import { AgentNameConflictError } from "../ports";
 import { isApiKeyProvider } from "../providers";
 import { handleAttachments } from "../turn/attachments";
 import { handleFiles } from "../turn/files";
+import { handleActionApprovalsDispatch } from "./action-approvals";
 import { stampTurnContributor } from "./activity-attribution";
 import {
   type AgentRouteDeps,
@@ -594,6 +595,21 @@ export async function handleAgents(
       ? (event: HoustonEvent) =>
           deps.events?.emit(authz.workspace.ownerUserId, event)
       : undefined;
+
+    // Action approvals are served by the HOST off its approval store — on this
+    // dispatch surface because it is the one per-agent surface the hosted
+    // gateway proxies to a pod (see routes/action-approvals.ts).
+    if (
+      await handleActionApprovalsDispatch(
+        deps.actionApprovals,
+        agentId,
+        method,
+        rest,
+        req,
+        res,
+      )
+    )
+      return true;
 
     // Typed .houston families + skills are served by the HOST off the workspace
     // vfs — the runtime surface (chat, auth, settings, files) goes to the channel.

--- a/packages/web/src/engine-adapter/client/teams-mixin.ts
+++ b/packages/web/src/engine-adapter/client/teams-mixin.ts
@@ -120,16 +120,19 @@ export function TeamsMixin<TBase extends BaseCtor>(Base: TBase) {
     }
 
     // ---- per-agent action approvals ----
-    // Unlike grants, these are HOST routes that work in BOTH deployments: the
-    // local/self-host host and the cloud gateway each serve
-    // `/v1/agents/:id/action-approvals[...]` for the signed-in owner. So they
-    // route through `authFetch` against `baseUrl` (bearer + `x-houston-org`,
-    // live in both) — never cp-gated, or the local approval card would break.
+    // Unlike grants, these are HOST routes that work in BOTH deployments, on
+    // the per-agent DISPATCH surface (`/agents/:id/action-approvals[...]`):
+    // the local/self-host host serves it directly, and the cloud gateway
+    // proxies exactly this surface to the agent's pod (it mounts NO
+    // `/v1/agents/*` route for approvals — calling the `/v1` form 404s at the
+    // gateway and breaks the in-chat approval card). So they route through
+    // `authFetch` against `baseUrl` (bearer + `x-houston-org`, live in both)
+    // — never cp-gated, or the local approval card would break.
     async agentActionApprovals(
       agentSlugOrId: string,
     ): Promise<{ always: string[] }> {
       const res = await this.ctx.authFetch(
-        `${this.ctx.baseUrl}/v1/agents/${encodeURIComponent(agentSlugOrId)}/action-approvals`,
+        `${this.ctx.baseUrl}/agents/${encodeURIComponent(agentSlugOrId)}/action-approvals`,
       );
       // A host that does not serve the gate answers 404 → nothing pre-approved.
       // The card only shows where the gate exists, so degrade rather than throw
@@ -147,7 +150,7 @@ export function TeamsMixin<TBase extends BaseCtor>(Base: TBase) {
       action: string,
     ): Promise<{ always: string[] }> {
       const res = await this.ctx.authFetch(
-        `${this.ctx.baseUrl}/v1/agents/${encodeURIComponent(agentSlugOrId)}/action-approvals/always`,
+        `${this.ctx.baseUrl}/agents/${encodeURIComponent(agentSlugOrId)}/action-approvals/always`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -166,7 +169,7 @@ export function TeamsMixin<TBase extends BaseCtor>(Base: TBase) {
       hash: string,
     ): Promise<void> {
       const res = await this.ctx.authFetch(
-        `${this.ctx.baseUrl}/v1/agents/${encodeURIComponent(agentSlugOrId)}/action-approvals/tickets`,
+        `${this.ctx.baseUrl}/agents/${encodeURIComponent(agentSlugOrId)}/action-approvals/tickets`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/ui/chat/src/interaction-modal.tsx
+++ b/ui/chat/src/interaction-modal.tsx
@@ -176,7 +176,12 @@ export function InteractionModal({
       </div>
 
       {footer && (
-        <div className="mt-5 flex items-center justify-end gap-3">{footer}</div>
+        // flex-wrap: a step with several actions (the approval card's three
+        // decisions, longer in es/pt) must wrap onto a second row in a narrow
+        // panel — the card clips overflow, so an unwrapped row loses buttons.
+        <div className="mt-5 flex flex-wrap items-center justify-end gap-x-3 gap-y-2">
+          {footer}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## The bug (user report)

On hosted cloud, the in-chat approval card for an integration action (Gmail / Google Calendar) could not be resolved: **Allow once**, **Always allow** (and, as perceived, Deny) all ended in the generic \"Houston, we have a problem\" toast, and the card's buttons overflowed the chat panel, clipping \"Always allow\".

## Root cause 1 — approval writes 404 on cloud

The card's decisions write through the adapter to `${baseUrl}/v1/agents/:id/action-approvals[/always|/tickets]`.

- **Desktop/local:** `baseUrl` is the local host, which serves that `/v1` route → worked.
- **Hosted cloud:** `baseUrl` is the gateway, which proxies per-agent traffic **only on the dispatch surface** `/agents/{slug}/<rest>` (it mounts no `/v1/agents/*` route for approvals) → every decision 404ed at the gateway, the card toasted and never advanced, so the pending action could never be approved. Meanwhile the pod only served the family at `/v1/…`, so even the proxied dispatch form would have missed. The two halves never met.

### Fix

- The host now serves the same three approval routes on the per-agent **dispatch surface** (`/agents/:id/action-approvals[...]`), sharing one implementation with the `/v1` form (which stays for direct API callers — the same dual-surface precedent as the skills marketplace routes). Ownership on the dispatch surface is the dispatch's own `authorizeAgent` check.
- The client adapter calls the dispatch form, which works identically in both deployments (local host serves it directly; the gateway proxies it to the pod).
- The fake host mirrors both surfaces, so the approval e2e spec drives the exact path the shipped clients use.

## Root cause 2 — footer clipping

`InteractionModal`'s footer row was `flex … justify-end` with no wrap inside the card's `overflow-clip`; the approval step's three buttons (longer labels in es/pt) ran past the card edge and got clipped. The footer now wraps onto a second row in narrow panels.

## Tests

- `packages/host`: new real-HTTP coverage of the dispatch surface (GET / always / tickets, body validation, ownership 403, unwired-dep fall-through) — full host suite green (951 tests).
- `packages/web` e2e: full Playwright suite green (121 tests), including `approval.spec.ts` now exercising the dispatch surface end-to-end.
- `pnpm typecheck` (workspace), `pnpm check`, `pnpm check:boundaries` all green.

## Notes

- Deny needs no store write; its failure perception came from the card being stuck on the un-writable approve path plus the toast. With the writes fixed, all three decisions resolve and compose the one reply that resumes the agent.
- For members driving a *shared* agent, the gateway must classify `action-approvals` as use-scope (already the case in the current gateway); owners are unaffected either way.