### PR TITLE
release: v0.4.28 — Codex null-field parse fix + code-mode host

### DIFF
--- a/.github/release-notes/0.4.28.es.md
+++ b/.github/release-notes/0.4.28.es.md
@@ -1,0 +1,23 @@
+## Houston 0.4.28
+
+### Correcciones
+
+- **Los modelos GPT-5.6 pueden usar su herramienta de código otra vez.** Las
+  misiones donde Sol, Terra o Luna intentaban ejecutar código fallaban con un
+  error. Una pieza que faltaba ahora viene incluida con la app en Mac y
+  Windows, así que esas misiones se completan con normalidad.
+- **Los comandos aparecen mientras se ejecutan.** Cuando un agente con un
+  modelo GPT ejecuta un comando, el registro de misión ahora lo muestra en
+  progreso, en lugar de mostrar solo el resultado al final.
+
+### Antes de actualizar
+
+- **Mac:** cierra Houston antes de instalar. macOS no siempre reemplaza
+  limpiamente una app en ejecución. Ante la duda, elimina
+  `/Applications/Houston.app` y arrastra la copia nueva.
+- **Windows x64:** la actualización automática desde 0.4.7 o posterior te lleva
+  adelante sola. El MSI todavía no tiene firma de código del sistema, así que
+  Windows SmartScreen puede advertir en una instalación nueva.
+- **Windows ARM64:** no hay ruta de actualización automática desde una
+  instalación x64 emulada. Descarga el MSI ARM64 manualmente, desinstala
+  primero la versión x64 y luego instala la ARM64.

--- a/.github/release-notes/0.4.28.md
+++ b/.github/release-notes/0.4.28.md
@@ -1,0 +1,22 @@
+## Houston 0.4.28
+
+### Fixes
+
+- **GPT-5.6 models can use their code tool again.** Missions where Sol, Terra,
+  or Luna tried to run code failed with an error. A missing piece now ships
+  with the app on Mac and Windows, so those missions complete normally.
+- **Commands show up while they run.** When an agent on a GPT model runs a
+  command, the mission log now shows it in progress instead of only showing
+  the result at the end.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a
+  running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag
+  the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward
+  automatically. The MSI is still not OS-code-signed, so Windows SmartScreen may
+  warn on a fresh install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install.
+  Download the ARM64 MSI manually, uninstall the x64 build first, then install
+  the ARM64 one.

--- a/.github/release-notes/0.4.28.pt.md
+++ b/.github/release-notes/0.4.28.pt.md
@@ -1,0 +1,23 @@
+## Houston 0.4.28
+
+### Correções
+
+- **Os modelos GPT-5.6 podem usar a ferramenta de código de novo.** Missões em
+  que Sol, Terra ou Luna tentavam executar código falhavam com um erro. Uma
+  peça que faltava agora vem incluída com o app no Mac e no Windows, então
+  essas missões terminam normalmente.
+- **Os comandos aparecem enquanto rodam.** Quando um agente com um modelo GPT
+  executa um comando, o registro de missão agora mostra o andamento, em vez de
+  mostrar só o resultado no final.
+
+### Antes de atualizar
+
+- **Mac:** feche o Houston antes de instalar. O macOS nem sempre substitui
+  corretamente um app em execução. Na dúvida, remova
+  `/Applications/Houston.app` e arraste a cópia nova.
+- **Windows x64:** a atualização automática a partir da 0.4.7 ou posterior
+  acontece sozinha. O MSI ainda não tem assinatura de código do sistema, então
+  o Windows SmartScreen pode alertar em uma instalação nova.
+- **Windows ARM64:** não há caminho de atualização automática a partir de uma
+  instalação x64 emulada. Baixe o MSI ARM64 manualmente, desinstale primeiro a
+  versão x64 e depois instale a ARM64.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "chrono",
  "serde",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-portable"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "chrono",
  "serde",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2498,7 +2498,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "futures-util",
  "hex",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "serde",
  "serde_json",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "dirs 5.0.1",
  "houston-agent-files",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "houston-terminal-manager",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,24 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.27", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.27", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.27", path = "app/houston-tauri" }
-houston-events = { version = "0.4.27", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.27", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.27", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.27", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.27", path = "engine/houston-agent-files" }
-houston-agent-portable = { version = "0.4.27", path = "engine/houston-agent-portable" }
-houston-ui-events = { version = "0.4.27", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.27", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.27", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.27", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.27", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.27", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.27", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.27", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.27", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.28", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.28", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.28", path = "app/houston-tauri" }
+houston-events = { version = "0.4.28", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.28", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.28", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.28", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.28", path = "engine/houston-agent-files" }
+houston-agent-portable = { version = "0.4.28", path = "engine/houston-agent-portable" }
+houston-ui-events = { version = "0.4.28", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.28", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.28", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.28", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.28", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.28", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.28", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.28", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.28", path = "engine/houston-engine-server" }
 
 # Keep line-table debug info in release binaries so Sentry can symbolicate
 # Rust panics to file:line. Costs ~10-15% binary size; full debug info is

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agent-portable/Cargo.toml
+++ b/engine/houston-agent-portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-portable"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Portable agent package format — share an agent's CLAUDE.md, skills, routines, and learnings as a single .houstonagent file."
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.27"
+version = "0.4.28"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Cuts **v0.4.28** on the Rust-engine release line, shipping the two fixes from #916:

1. **HOUSTON-APP-4PF** ([Sentry](https://houston-cd.sentry.io/issues/7555741060/), 55k+ events): the hand-written `CodexItem` Deserialize rejected Codex's explicit `"exit_code": null` on in-progress `command_execution` items, dropping the event and firing one Sentry error per command an agent ran. Null now reads as absent; the in-progress command state reaches the feed again.
2. **`codex-code-mode-host` bundled**: codex ≥ 0.144 spawns the code-mode JS host as a sibling binary (used by the GPT-5.6 family). It now ships next to `codex` — universal Mach-O on macOS, `.exe` on Windows — pinned as a `companion` in cli-deps.json (shares codex's version, cannot drift), pre-signed in the release workflow.

This PR: version bump `0.4.27 → 0.4.28` across all version-line packages + `Cargo.lock` (regenerated and committed — version.sh skips it), release notes en/es/pt at `.github/release-notes/0.4.28.*`.

**Verification**
- `cargo check --workspace --exclude houston-app` clean at 0.4.28 (houston-app needs the staged engine sidecar, which the release workflow builds first).
- `cargo build --release -p houston-engine-server` compiles clean — the same first-compile the tag build runs.
- Cargo.lock diff is version-lines only.

**After merge**
1. Tag `v0.4.28` on the merge commit → release workflow builds, notarizes, and drafts the GitHub release with these notes (first full compile happens there — watch it).
2. Publish the draft → updater serves v0.4.2x users.