### PR TITLE
fix(ci): sign codex-code-mode-host with V8 JIT entitlements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,8 +409,13 @@ jobs:
         run: |
           set -euo pipefail
           BIN=app/src-tauri/resources/bin
+          # codex-code-mode-host embeds V8: re-signing it WITHOUT the JIT
+          # entitlements upstream signs it with makes V8's Isolate::Init
+          # abort (fatal OOM) under the hardened runtime — the host dies
+          # on its first real session and codex logs "code-mode host
+          # closed its stdout". Sign it with the mirrored entitlements
+          # and fail the build if they didn't stick.
           for f in "$BIN/codex" \
-                   "$BIN/codex-code-mode-host" \
                    "$BIN/composio-aarch64/composio" \
                    "$BIN/composio-x86_64/composio" \
                    "$BIN/gemini-aarch64/gemini" \
@@ -420,6 +425,14 @@ jobs:
               --sign "$APPLE_SIGNING_IDENTITY" "$f"
             codesign -dvv "$f" 2>&1 | grep -E '^(Authority|TeamIdentifier|Timestamp|CodeDirectory)' || true
           done
+
+          echo "=== Signing $BIN/codex-code-mode-host (with JIT entitlements) ==="
+          codesign --force --options runtime --timestamp \
+            --entitlements app/src-tauri/entitlements-jit.plist \
+            --sign "$APPLE_SIGNING_IDENTITY" "$BIN/codex-code-mode-host"
+          codesign -dvv "$BIN/codex-code-mode-host" 2>&1 | grep -E '^(Authority|TeamIdentifier|Timestamp|CodeDirectory)' || true
+          codesign -d --entitlements - "$BIN/codex-code-mode-host" 2>/dev/null | grep -q 'allow-jit' \
+            || { echo "::error::codex-code-mode-host signed without allow-jit entitlement — V8 init will abort at runtime"; exit 1; }
 
       # Build the engine sidecar for BOTH macOS architectures BEFORE the
       # Tauri app build.

--- a/app/src-tauri/entitlements-jit.plist
+++ b/app/src-tauri/entitlements-jit.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+      Entitlements for bundled CLI binaries that embed a JS engine
+      (codex-code-mode-host embeds V8). Under the hardened runtime,
+      V8's Isolate::Init aborts with a fatal OOM unless the process may
+      allocate JIT / unsigned-executable memory — the host then dies
+      instantly and codex reports "code-mode host closed its stdout".
+      These two keys mirror the entitlements upstream openai/codex signs
+      the binary with; the pre-sign step in release.yml MUST pass this
+      file when re-signing it, or the shipped host is dead on arrival.
+    -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>

--- a/knowledge-base/cli-bundling.md
+++ b/knowledge-base/cli-bundling.md
@@ -203,6 +203,19 @@ codesign --force --options runtime --timestamp \
 
 on `codex`, `codex-code-mode-host`, `composio-aarch64/composio`,
 `composio-x86_64/composio`.
+
+**codex-code-mode-host needs JIT entitlements when re-signed.** The host
+embeds V8; under the hardened runtime V8's `Isolate::Init` aborts with a
+fatal OOM unless the process carries `com.apple.security.cs.allow-jit` +
+`com.apple.security.cs.allow-unsigned-executable-memory` (upstream signs
+it with exactly those). A plain `codesign --force --options runtime`
+strips them and the host dies on its first real session — codex then logs
+`code-mode host closed its stdout` and every code-mode call fails. The
+pre-sign step signs this one binary with
+`app/src-tauri/entitlements-jit.plist` and fails the build if the
+entitlement didn't stick. The crash signature to recognize: user crash
+reports for `codex-code-mode-host` with `v8::internal::Heap::SetUp` →
+`FatalProcessOutOfMemory` in the stack.
 Tauri's later deep sign leaves these alone (it doesn't visit nested
 Resources subdirs), so the pre-applied signature carries through to
 notarization.


### PR DESCRIPTION
Caught testing the **unpublished** v0.4.28 draft build: the code-mode spawn error is gone, but the host now dies instantly with `code-mode host closed its stdout` (3 retries per call).

**Root cause.** The pre-sign step re-signed `codex-code-mode-host` like every other bundled CLI — Developer ID + hardened runtime, **no entitlements**. Upstream openai/codex signs it with `com.apple.security.cs.allow-jit` + `com.apple.security.cs.allow-unsigned-executable-memory`; our `codesign --force` stripped both. The host embeds V8, and under the hardened runtime without those entitlements `v8::internal::Isolate::Init` aborts with a fatal OOM on the first real session (confirmed via macOS crash reports: `Heap::SetUp → FatalProcessOutOfMemory`, SIGTRAP). It doesn't crash on plain launch — V8 only initializes when a session starts — which is why a simple spawn check passes.

**Fix.**
- `app/src-tauri/entitlements-jit.plist`: mirrors upstream's two entitlements.
- `release.yml` pre-sign step: signs `codex-code-mode-host` with that file, and **fails the build** if `allow-jit` is missing from the resulting signature (the failure mode is invisible until runtime otherwise).
- `knowledge-base/cli-bundling.md`: documented, including the crash signature to recognize.

**Verified locally:** re-signing the broken installed binary with these entitlements restores the upstream entitlement set exactly; the diff (upstream entitled vs our stripped binary) was confirmed with `codesign -d --entitlements` on both.

**After merge:** the v0.4.28 draft was never published, so: delete the draft + tag, re-tag `v0.4.28` on the merge commit, let the workflow rebuild. Version number stays 0.4.28.