### PR TITLE
feat(chat): preview + download files the agent created from chat

### DIFF
--- a/app/src/components/agent-file-preview-host.tsx
+++ b/app/src/components/agent-file-preview-host.tsx
@@ -1,0 +1,22 @@
+import { useUIStore } from "../stores/ui";
+import { FilePreviewDialog } from "./file-preview-dialog";
+
+/**
+ * The single, globally mounted instance of the workspace-file preview dialog,
+ * fed by `useUIStore.filePreview` (set by `useOpenAgentFile` from chat file
+ * cards, turn summaries, and prose file pills). Mounted once per app tree —
+ * app/src/main.tsx and packages/web/src/app-tree.tsx — so it works on every
+ * screen, onboarding included. The Files tab keeps its own local instance.
+ */
+export function AgentFilePreviewHost() {
+  const preview = useUIStore((s) => s.filePreview);
+  const setFilePreview = useUIStore((s) => s.setFilePreview);
+  return (
+    <FilePreviewDialog
+      agentPath={preview?.agentPath ?? ""}
+      filePath={preview?.filePath ?? null}
+      fileName={preview?.fileName ?? ""}
+      onClose={() => setFilePreview(null)}
+    />
+  );
+}

--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -1,7 +1,7 @@
 import { AIBoard } from "@houston-ai/board";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { openAgentHref } from "../../lib/open-href";
+import { useOpenAgentHref } from "../../hooks/use-open-agent-file";
 import { useUIStore } from "../../stores/ui";
 import { useAttachmentRejectionDialog } from "../attachment-rejection-dialog";
 import { buildMissionBoardColumns } from "../mission-board-columns";
@@ -113,12 +113,8 @@ export function MissionBoard({ source }: { source: BoardSource }) {
     (message: string) => addToast({ title: message }),
     [addToast],
   );
-  const handleOpenLink = useCallback(
-    (url: string) => {
-      const path = source.activeAgent?.folderPath;
-      if (path) openAgentHref(url, path);
-    },
-    [source.activeAgent],
+  const handleOpenLink = useOpenAgentHref(
+    source.activeAgent?.folderPath ?? null,
   );
 
   const attachmentValidation = useAttachmentRejectionDialog();

--- a/app/src/components/board/mission-control-archived.tsx
+++ b/app/src/components/board/mission-control-archived.tsx
@@ -1,7 +1,7 @@
 import { AIBoard } from "@houston-ai/board";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { openAgentHref } from "../../lib/open-href";
+import { useOpenAgentHref } from "../../hooks/use-open-agent-file";
 import type { Agent } from "../../lib/types";
 import { useAgentCatalogStore } from "../../stores/agent-catalog";
 import { useUIStore } from "../../stores/ui";
@@ -82,6 +82,7 @@ export function MissionControlArchived({
     onSelectSession: data.setSelectedId,
   });
   const clearSelection = useCallback(() => data.setSelectedId(null), [data]);
+  const openHref = useOpenAgentHref(activeAgent?.folderPath ?? null);
   const handleSendMessage = useMissionControlArchivedSend({
     activeAgent,
     activeAgentDef,
@@ -134,9 +135,7 @@ export function MissionControlArchived({
             />
           }
           onPanelOpenChange={setMissionPanelOpen}
-          onOpenLink={(url) =>
-            activeAgent && openAgentHref(url, activeAgent.folderPath)
-          }
+          onOpenLink={openHref}
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
           thinkingIndicator={panel.thinkingIndicator}

--- a/app/src/components/file-card.tsx
+++ b/app/src/components/file-card.tsx
@@ -1,13 +1,14 @@
 import {
   ExternalLinkIcon,
+  EyeIcon,
   FileCodeIcon,
   FileIcon,
   FileTextIcon,
   ImageIcon,
 } from "lucide-react";
 import type { ComponentType } from "react";
-import { useCallback } from "react";
-import { tauriFiles } from "../lib/tauri";
+import { useOpenAgentFile } from "../hooks/use-open-agent-file";
+import { fileNameOf } from "../lib/agent-file-paths";
 
 type LucideIcon = ComponentType<{ className?: string }>;
 
@@ -71,25 +72,25 @@ interface FileCardProps {
 }
 
 export function FileCard({ filePath, agentPath }: FileCardProps) {
-  const fileName = filePath.split("/").pop() ?? filePath;
+  const fileName = fileNameOf(filePath);
   const ext = fileName.includes(".")
     ? fileName.split(".").pop()?.toLowerCase()
     : undefined;
   const Icon = getFileIcon(ext);
-
-  const handleOpen = useCallback(() => {
-    tauriFiles.open(agentPath, filePath).catch(console.error);
-  }, [agentPath, filePath]);
+  const { openFile, opensLocally } = useOpenAgentFile(agentPath);
+  // The affordance mirrors what the click does: hand off to the OS
+  // (external-link) or open the in-app preview dialog (eye).
+  const ActionIcon = opensLocally ? ExternalLinkIcon : EyeIcon;
 
   return (
     <button
       type="button"
-      onClick={handleOpen}
+      onClick={() => openFile(filePath)}
       className="inline-flex items-center gap-2 rounded-lg border border-line/50 bg-chip px-3 py-2 text-sm hover:bg-hover transition-colors cursor-pointer"
     >
       <Icon className="h-4 w-4 text-ink-muted shrink-0" />
       <span className="truncate max-w-[240px]">{fileName}</span>
-      <ExternalLinkIcon className="h-3.5 w-3.5 text-ink-muted shrink-0 ml-1" />
+      <ActionIcon className="h-3.5 w-3.5 text-ink-muted shrink-0 ml-1" />
     </button>
   );
 }

--- a/app/src/components/file-preview-dialog.tsx
+++ b/app/src/components/file-preview-dialog.tsx
@@ -9,15 +9,17 @@ import {
 } from "@houston-ai/core";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSaveDownload } from "../../hooks/use-save-download";
-import { genericErrorDescription } from "../../lib/error-toast";
-import { tauriFiles } from "../../lib/tauri";
+import { useSaveDownload } from "../hooks/use-save-download";
+import { genericErrorDescription } from "../lib/error-toast";
+import { tauriFiles } from "../lib/tauri";
 
 /**
- * In-browser preview for a workspace file (web build). Images, PDFs and
- * text-ish files render inline; everything else (pptx, xlsx, …) gets a
- * "download to open" fallback. Bytes come over the authenticated download
- * route, so nothing here assumes a local filesystem.
+ * In-app preview for a workspace file (web build, cloud pods, remote hosts).
+ * Images, PDFs and text-ish files render inline; everything else (pptx,
+ * xlsx, …) gets a "download to open" fallback. Bytes come over the
+ * authenticated download route, so nothing here assumes a local filesystem.
+ * Opened from the Files tab and from chat file surfaces (file cards, turn
+ * summaries, prose file pills) via `useOpenAgentFile`.
  */
 
 const TEXT_PREVIEW_LIMIT = 256 * 1024;

--- a/app/src/components/tabs/archived-tab.tsx
+++ b/app/src/components/tabs/archived-tab.tsx
@@ -6,8 +6,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useActivity, useDeleteActivity } from "../../hooks/queries";
 import { useConversationFeed } from "../../hooks/use-conversation-vm";
+import { useOpenAgentHref } from "../../hooks/use-open-agent-file";
 import { selectArchived } from "../../lib/mission-selection";
-import { openAgentHref } from "../../lib/open-href";
 import type { TabProps } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 import { useAttachmentRejectionDialog } from "../attachment-rejection-dialog";
@@ -29,6 +29,7 @@ import { useArchivedSendMessage } from "./use-archived-send-message";
 export default function ArchivedTab({ agent, agentDef }: TabProps) {
   const { t } = useTranslation("board");
   const path = agent.folderPath;
+  const openHref = useOpenAgentHref(path);
   const panelContainer = useDetailPanelContainer();
   const { data: rawItems } = useActivity(path);
   const deleteActivity = useDeleteActivity(path);
@@ -137,7 +138,7 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
           onLoadHistory={archivedSearch.loadHistory}
           emptyState={emptyState}
           onPanelOpenChange={setMissionPanelOpen}
-          onOpenLink={(url) => openAgentHref(url, path)}
+          onOpenLink={openHref}
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
           cardAvatar={<AgentCardAvatar color={agent.color} />}

--- a/app/src/components/tabs/files-tab.tsx
+++ b/app/src/components/tabs/files-tab.tsx
@@ -16,7 +16,7 @@ import { useSaveDownload } from "../../hooks/use-save-download";
 import { isCoLocatedEngine, newEngineActive } from "../../lib/engine";
 import { tauriFiles } from "../../lib/tauri";
 import type { TabProps } from "../../lib/types";
-import { FilePreviewDialog } from "./file-preview-dialog";
+import { FilePreviewDialog } from "../file-preview-dialog";
 
 export default function FilesTab({ agent }: TabProps) {
   const { t } = useTranslation("agents");

--- a/app/src/components/tabs/routine-setup-chat-board.tsx
+++ b/app/src/components/tabs/routine-setup-chat-board.tsx
@@ -12,7 +12,7 @@ import type { FeedItem } from "@houston-ai/chat";
 import type { Activity } from "@houston-ai/engine-client";
 import { type ReactNode, useCallback, useMemo } from "react";
 import { useConversationFeed } from "../../hooks/use-conversation-vm";
-import { openAgentHref } from "../../lib/open-href";
+import { useOpenAgentHref } from "../../hooks/use-open-agent-file";
 import { type HistoryLoadOptions, tauriChat } from "../../lib/tauri";
 import type { TabProps } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
@@ -55,6 +55,7 @@ export function RoutineSetupChatBoard({
   panelActions,
 }: Props) {
   const path = agent.folderPath;
+  const openHref = useOpenAgentHref(path);
   const queuedLabels = useQueuedMessageLabels();
   const { composerLabels } = useBoardLabels();
   const attachmentValidation = useAttachmentRejectionDialog();
@@ -150,7 +151,7 @@ export function RoutineSetupChatBoard({
         queuedLabels={queuedLabels}
         onLoadHistory={loadHistory}
         onStopSession={send.stopSession}
-        onOpenLink={(url) => openAgentHref(url, path)}
+        onOpenLink={openHref}
         onNotice={(message) => addToast({ title: message })}
         // The ask_user question card that replaces the composer when the
         // turn settles needs_you — the interview IS this card, so dropping

--- a/app/src/components/turn-file-summary.tsx
+++ b/app/src/components/turn-file-summary.tsx
@@ -5,7 +5,8 @@ import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { isVisibleAgentTab } from "../agents/standard-tabs";
 import { useCapabilities } from "../hooks/use-capabilities";
-import { tauriFiles } from "../lib/tauri";
+import { useOpenAgentFile } from "../hooks/use-open-agent-file";
+import { fileNameOf } from "../lib/agent-file-paths";
 import {
   groupTurnSummaryItems,
   type SemanticUpdateKind,
@@ -27,12 +28,7 @@ export function TurnFileSummary({ items, agentPath }: TurnFileSummaryProps) {
   const [openUpdates, setOpenUpdates] = useState(false);
   const [openFiles, setOpenFiles] = useState(false);
 
-  const handleOpen = useCallback(
-    (path: string) => {
-      tauriFiles.open(agentPath, path).catch(console.error);
-    },
-    [agentPath],
-  );
+  const { openFile: handleOpen } = useOpenAgentFile(agentPath);
 
   const handleOpenSemantic = useCallback(
     (kind: SemanticUpdateKind) => {
@@ -151,13 +147,6 @@ function semanticIcon(kind: SemanticUpdateKind) {
   if (kind === "instructions") return ScrollText;
   if (kind === "skills") return Play;
   return Lightbulb;
-}
-
-/** Last path segment, separator-agnostic. See `turn-summary-items.ts`
- * for why `.split("/")` alone is wrong on Windows. */
-function fileNameOf(path: string): string {
-  const segments = path.split(/[\\/]/);
-  return segments[segments.length - 1] || path;
 }
 
 function itemIcon(item: TurnSummaryItem) {

--- a/app/src/hooks/use-file-tool-renderer.tsx
+++ b/app/src/hooks/use-file-tool-renderer.tsx
@@ -29,7 +29,8 @@ export function useFileToolRenderer(agentPath: string) {
   const renderToolResult = useCallback(
     (tool: ToolEntry, index: number) => {
       const inp = tool.input as Record<string, unknown> | null | undefined;
-      const filePath = inp?.file_path as string | undefined;
+      // Claude tools carry `file_path`; pi tools carry `path`.
+      const filePath = (inp?.file_path ?? inp?.path) as string | undefined;
       const isError = tool.result?.is_error ?? false;
 
       return (

--- a/app/src/hooks/use-open-agent-file.tsx
+++ b/app/src/hooks/use-open-agent-file.tsx
@@ -1,0 +1,111 @@
+import { isTauri } from "@tauri-apps/api/core";
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { fileNameOf, toWorkspaceRelative } from "../lib/agent-file-paths";
+import { isCoLocatedEngine, newEngineActive } from "../lib/engine";
+import { genericErrorDescription } from "../lib/error-toast";
+import { logger } from "../lib/logger";
+import { looksLikeUrl } from "../lib/open-href";
+import { tauriFiles, tauriSystem } from "../lib/tauri";
+import { useAgentStore } from "../stores/agents";
+import { useUIStore } from "../stores/ui";
+import { useCapabilities } from "./use-capabilities";
+
+/**
+ * Open a workspace file the agent mentioned in chat (file cards, turn
+ * summaries, prose file pills). Same gating as the Files tab (HOU-677):
+ *
+ *   - Co-located desktop engine → hand the file to the OS's default app,
+ *     rooted at the host-reported REAL directory (on the TS engine
+ *     `folderPath` is a route key, never a path).
+ *   - Everything else (web build, cloud pods, remote hosts) → the in-app
+ *     preview dialog, whose footer offers Download (native save dialog on
+ *     desktop, browser download on web). Before this hook, these clicks
+ *     dead-ended: the web shim rejects `open_file` outright.
+ *
+ * Accepts every path shape the engine emits (absolute native, workspace-
+ * relative, bare) — see lib/agent-file-paths.ts.
+ */
+export function useOpenAgentFile(agentPath: string | null): {
+  openFile: (rawPath: string) => void;
+  /** True when clicks hand off to the OS (used to pick the card affordance icon). */
+  opensLocally: boolean;
+} {
+  const { t } = useTranslation("agents");
+  const { capabilities } = useCapabilities();
+  const addToast = useUIStore((s) => s.addToast);
+  const setFilePreview = useUIStore((s) => s.setFilePreview);
+  const agent = useAgentStore((s) =>
+    s.agents.find((a) => a.folderPath === agentPath),
+  );
+
+  const osDir =
+    agent?.localDir ??
+    (newEngineActive() ? undefined : (agentPath ?? undefined));
+  const opensLocally =
+    isTauri() &&
+    isCoLocatedEngine() &&
+    (capabilities?.revealInOs ?? true) &&
+    osDir !== undefined;
+
+  const openFile = useCallback(
+    (rawPath: string) => {
+      if (!agentPath) return;
+      if (opensLocally && osDir !== undefined) {
+        tauriFiles.open(osDir, rawPath).catch((err) => {
+          addToast({
+            variant: "error",
+            title: t("files.toasts.openFailedTitle"),
+            description: genericErrorDescription("open_chat_file", err),
+          });
+        });
+        return;
+      }
+      const filePath = toWorkspaceRelative(rawPath, {
+        folderPath: agentPath,
+        localDir: agent?.localDir,
+      });
+      setFilePreview({ agentPath, filePath, fileName: fileNameOf(filePath) });
+    },
+    [
+      agentPath,
+      agent?.localDir,
+      opensLocally,
+      osDir,
+      addToast,
+      setFilePreview,
+      t,
+    ],
+  );
+
+  return useMemo(() => ({ openFile, opensLocally }), [openFile, opensLocally]);
+}
+
+/**
+ * Open a link the agent emitted in chat prose. Two shapes land here:
+ *
+ *   1. Absolute URLs (`https://…`, `mailto:…`, `houston://…`) → the system
+ *      browser.
+ *   2. Relative or bare file paths (`perfil.md`, `./report.pdf`) — the
+ *      agent's prompt structure encourages dropping these right after
+ *      writing a file → `useOpenAgentFile` (OS open or in-app preview).
+ */
+export function useOpenAgentHref(
+  agentPath: string | null,
+): (href: string) => void {
+  const { openFile } = useOpenAgentFile(agentPath);
+  return useCallback(
+    (href: string) => {
+      const trimmed = href.trim();
+      if (!trimmed) return;
+      if (looksLikeUrl(trimmed)) {
+        tauriSystem.openUrl(trimmed).catch((e) => {
+          logger.warn(`[open-href] openUrl(${trimmed}) failed: ${e}`);
+        });
+        return;
+      }
+      openFile(trimmed);
+    },
+    [openFile],
+  );
+}

--- a/app/src/lib/agent-file-paths.ts
+++ b/app/src/lib/agent-file-paths.ts
@@ -1,0 +1,66 @@
+/**
+ * File paths reach the chat UI in three shapes:
+ *
+ *   1. Absolute, in the ENGINE host's native separator — Write/Edit tool
+ *      inputs (`/Users/jo/.houston/workspaces/W/A/report.pdf` on macOS,
+ *      `C:\Users\jo\...\W\A\report.pdf` on Windows engines).
+ *   2. Workspace-relative with `/` — `file_changes` frames (see
+ *      packages/runtime/src/session/file-changes.ts).
+ *   3. Bare or `./`-prefixed relative — prose the agent drops right after
+ *      writing a file (`perfil.md`, `./out/report.pdf`).
+ *
+ * The host's files routes (preview/download) accept only workspace-RELATIVE
+ * paths, so everything funnels through `toWorkspaceRelative`. Deliberately
+ * separator-agnostic: the engine may run on Windows while the viewer is a
+ * browser anywhere.
+ */
+
+export interface AgentPathContext {
+  /** The agent's route key on the TS engine (`Workspace/Agent`); the real
+   * absolute directory on the legacy engine (HOU-677). */
+  folderPath: string;
+  /** Host-reported real directory (co-located hosts only). */
+  localDir?: string;
+}
+
+/** Replace `\` with `/` so prefix comparisons work regardless of the engine OS. */
+export function toPosixSeparator(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+/** Last path segment, separator-agnostic (`a\b\c.md` and `a/b/c.md` → `c.md`). */
+export function fileNameOf(path: string): string {
+  const segments = path.split(/[\\/]/);
+  return segments[segments.length - 1] || path;
+}
+
+/**
+ * Best-effort conversion of any engine-emitted path to workspace-relative.
+ *
+ * Strips, in order: the host-reported real directory (`localDir`), then the
+ * `folderPath` as a prefix (legacy engine, where it IS the directory), then
+ * `folderPath` as an infix — the TS engine's route key (`Workspace/Agent`)
+ * appears verbatim inside every engine-side absolute path
+ * (`~/.houston/workspaces/W/A/…` locally, `/data/workspaces/W/A/…` on cloud
+ * pods). Already-relative paths pass through unchanged; an absolute path that
+ * matches no root is returned as-is and left to the host to reject visibly.
+ */
+export function toWorkspaceRelative(
+  rawPath: string,
+  agent: AgentPathContext,
+): string {
+  let path = toPosixSeparator(rawPath.trim());
+  while (path.startsWith("./")) path = path.slice(2);
+
+  const roots = [agent.localDir, agent.folderPath]
+    .filter((root): root is string => Boolean(root))
+    .map((root) => toPosixSeparator(root).replace(/\/+$/, ""));
+
+  for (const root of roots) {
+    if (path.startsWith(`${root}/`)) return path.slice(root.length + 1);
+    const marker = `/${root}/`;
+    const at = path.indexOf(marker);
+    if (at !== -1) return path.slice(at + marker.length);
+  }
+  return path;
+}

--- a/app/src/lib/open-href.ts
+++ b/app/src/lib/open-href.ts
@@ -1,41 +1,14 @@
-import { logger } from "./logger";
-import { tauriFiles, tauriSystem } from "./tauri";
-
 /**
- * Open a link the agent emitted in chat. Two shapes land here:
+ * URL-vs-file-path detection for links the agent emits in chat. The click
+ * handling itself lives in `hooks/use-open-agent-file.tsx` (`useOpenAgentHref`);
+ * this stays a pure predicate so non-React code can share it.
  *
- *   1. Absolute URLs — `https://...`, `http://...`, `mailto:...`, `houston://...`,
- *      etc. These go to the system browser via `tauriSystem.openUrl`.
- *
- *   2. Relative or bare paths — e.g. `perfil.md`, `subfolder/output.docx`,
- *      `./report.pdf`. The agent's prompt structure encourages it to drop
- *      these straight after writing a file. They are NOT URLs; calling
- *      `openUrl("perfil.md")` on Windows silently does nothing
- *      (a real user reported "perfil.md pill doesn't open"). Resolve
- *      them against the current agent's working directory via
- *      `tauriFiles.open`, which goes through the engine's
- *      `open_file_in_agent` route and ends up at the OS's
- *      default-app handler.
- *
- * The detection is "does it look like a URL" — anything with a scheme
- * (`<word>:`) or starting with `//` is treated as a URL. Everything
- * else is a path.
+ * Anything with a scheme (`<word>:`) or starting with `//` is a URL.
+ * Everything else is a workspace file path — e.g. `perfil.md`,
+ * `subfolder/output.docx`, `./report.pdf` — which the agent's prompt
+ * structure encourages dropping straight after writing a file.
  */
-export function openAgentHref(href: string, agentPath: string): void {
-  const trimmed = href.trim();
-  if (!trimmed) return;
-  if (looksLikeUrl(trimmed)) {
-    tauriSystem.openUrl(trimmed).catch((e) => {
-      logger.warn(`[open-href] openUrl(${trimmed}) failed: ${e}`);
-    });
-    return;
-  }
-  tauriFiles.open(agentPath, trimmed).catch((e) => {
-    logger.warn(`[open-href] openFile(${trimmed}) failed: ${e}`);
-  });
-}
-
-function looksLikeUrl(value: string): boolean {
+export function looksLikeUrl(value: string): boolean {
   if (value.startsWith("//")) return true;
   // Scheme: a leading run of letters / digits / + - . followed by `:`.
   // Catches http, https, mailto, file, houston (deep-link),

--- a/app/src/lib/turn-summary-items.ts
+++ b/app/src/lib/turn-summary-items.ts
@@ -1,4 +1,5 @@
 import type { FileChangeEntry, ToolEntry } from "@houston-ai/chat";
+import { fileNameOf, toWorkspaceRelative } from "./agent-file-paths";
 
 export type SemanticUpdateKind = "instructions" | "skills" | "learnings";
 export type FileUpdateKind = "created" | "modified";
@@ -46,44 +47,26 @@ function shortName(name: string): string {
   return name.includes("__") ? (name.split("__").pop() ?? name) : name;
 }
 
-/**
- * Path separators on Windows are `\`; on macOS / Linux they're `/`. The
- * engine emits absolute paths in the native separator of the host
- * (`C:\Users\jul\.houston\…\perfil.md` on Windows, `/Users/jul/…` on Mac),
- * so any code that did `path.split("/").pop()` to get a filename
- * returned the WHOLE path on Windows — that's why the "New files"
- * section never rendered correctly and CLAUDE.md / SKILL.md never
- * classified as semantic updates. Use this helper everywhere a
- * separator-aware split is needed.
- */
-function fileNameOf(path: string): string {
-  const segments = path.split(/[\\/]/);
-  return segments[segments.length - 1] || path;
-}
-
-/** Replace `\` with `/` so prefix comparisons work regardless of OS. */
-function toPosixSeparator(path: string): string {
-  return path.replace(/\\/g, "/");
-}
-
-function normalizePath(path: string, agentPath: string): string {
-  const trimmed = toPosixSeparator(path.trim());
-  const root = toPosixSeparator(agentPath);
-  if (trimmed.startsWith(`${root}/`)) return trimmed.slice(root.length + 1);
-  return trimmed;
-}
-
 function classifyPath(
   path: string,
   agentPath: string,
 ): SemanticUpdateKind | null {
-  const relative = normalizePath(path, agentPath).toLowerCase();
+  // Separator handling matters here: the engine emits absolute paths in the
+  // HOST's native separator, so a plain `path.split("/").pop()` returned the
+  // whole path on Windows — the "New files" section never rendered correctly
+  // and CLAUDE.md / SKILL.md never classified as semantic updates. The shared
+  // helpers in agent-file-paths.ts are separator-agnostic.
+  const relative = toWorkspaceRelative(path, {
+    folderPath: agentPath,
+  }).toLowerCase();
   const fileName = fileNameOf(relative);
 
   if (fileName === "claude.md" || fileName === "agents.md")
     return "instructions";
   if (relative === ".houston/learnings/learnings.json") return "learnings";
   if (
+    relative.startsWith(".agents/skills/") ||
+    relative.startsWith(".claude/skills/") ||
     relative.includes("/.agents/skills/") ||
     relative.includes("/.claude/skills/")
   ) {
@@ -173,7 +156,8 @@ export function buildTurnSummaryItems(
 
     if (FILE_TOOLS.has(sn)) {
       const inp = tool.input as Record<string, unknown> | null | undefined;
-      const fp = inp?.file_path as string | undefined;
+      // Claude tools carry `file_path`; pi tools carry `path`.
+      const fp = (inp?.file_path ?? inp?.path) as string | undefined;
       if (fp) addPath(fp, sn === "Write" ? "created" : "modified");
     } else if (sn === "Bash") {
       for (const fp of extractPathsFromBashOutput(tool.result.content)) {

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -167,7 +167,8 @@
       "savedDescription": "{{name}} was saved to your computer.",
       "revealAction": "Show in File Manager",
       "revealFailed": "Couldn't show the file",
-      "saveFailedTitle": "Couldn't save the file"
+      "saveFailedTitle": "Couldn't save the file",
+      "openFailedTitle": "Couldn't open the file"
     }
   }
 }

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -167,7 +167,8 @@
       "savedDescription": "{{name}} se guardó en tu computador.",
       "revealAction": "Mostrar en el Explorador de Archivos",
       "revealFailed": "No se pudo mostrar el archivo",
-      "saveFailedTitle": "No se pudo guardar el archivo"
+      "saveFailedTitle": "No se pudo guardar el archivo",
+      "openFailedTitle": "No se pudo abrir el archivo"
     }
   }
 }

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -167,7 +167,8 @@
       "savedDescription": "{{name}} foi salvo no seu computador.",
       "revealAction": "Mostrar no Explorador de Arquivos",
       "revealFailed": "Não foi possível mostrar o arquivo",
-      "saveFailedTitle": "Não foi possível salvar o arquivo"
+      "saveFailedTitle": "Não foi possível salvar o arquivo",
+      "openFailedTitle": "Não foi possível abrir o arquivo"
     }
   }
 }

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -6,6 +6,7 @@ import { I18nextProvider } from "react-i18next";
 import App from "./App";
 import { queryClient } from "./lib/query-client";
 import "./styles/globals.css";
+import { AgentFilePreviewHost } from "./components/agent-file-preview-host";
 import { DisclaimerGate } from "./components/shell/disclaimer-gate";
 import { EngineGate } from "./components/shell/engine-gate";
 import { LanguageGate } from "./components/shell/language-gate";
@@ -156,6 +157,10 @@ createRoot(rootElement).render(
                 <LanguageGate>
                   <DisclaimerGate>
                     <App />
+                    {/* Global workspace-file preview (chat file clicks) — a
+                        sibling of App so it overlays every screen, onboarding
+                        included. Mirrored in packages/web/src/app-tree.tsx. */}
+                    <AgentFilePreviewHost />
                   </DisclaimerGate>
                 </LanguageGate>
               </QueryPersistenceProvider>

--- a/app/src/stores/ui.ts
+++ b/app/src/stores/ui.ts
@@ -15,6 +15,16 @@ export interface ToastItem {
 
 export type JobDescriptionTarget = "instructions" | "skills" | "learnings";
 
+/** A workspace file queued for the global in-app preview dialog (chat file
+ * cards, turn summaries, prose file pills — HOU: preview files from chat). */
+export interface FilePreviewTarget {
+  /** The agent's `folderPath` (route key / directory, per engine). */
+  agentPath: string;
+  /** Workspace-relative path of the file. */
+  filePath: string;
+  fileName: string;
+}
+
 interface UIState {
   viewMode: string;
   /** A one-shot deep-link consumed by SettingsView on mount: other surfaces set
@@ -93,6 +103,8 @@ interface UIState {
   storeFocusSlug: string | null;
   /** Whether the left rail is collapsed to an icon-only strip. Persisted. */
   sidebarCollapsed: boolean;
+  /** File shown by the global preview dialog, or null when closed. */
+  filePreview: FilePreviewTarget | null;
   setViewMode: (mode: string) => void;
   setSettingsSection: (section: SettingsSectionId | null) => void;
   setAssistantPanelOpen: (open: boolean) => void;
@@ -133,6 +145,7 @@ interface UIState {
   setStoreFocusSlug: (slug: string | null) => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
   toggleSidebarCollapsed: () => void;
+  setFilePreview: (preview: FilePreviewTarget | null) => void;
 }
 
 let toastCounter = 0;
@@ -175,6 +188,7 @@ export const useUIStore = create<UIState>()(
       importSeedPreview: null,
       storeFocusSlug: null,
       sidebarCollapsed: false,
+      filePreview: null,
 
       setViewMode: (viewMode) => set({ viewMode }),
       setSettingsSection: (settingsSection) => set({ settingsSection }),
@@ -299,6 +313,7 @@ export const useUIStore = create<UIState>()(
       setSidebarCollapsed: (sidebarCollapsed) => set({ sidebarCollapsed }),
       toggleSidebarCollapsed: () =>
         set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
+      setFilePreview: (filePreview) => set({ filePreview }),
     }),
     {
       name: "houston-ui",

--- a/app/tests/agent-file-paths.test.ts
+++ b/app/tests/agent-file-paths.test.ts
@@ -1,0 +1,107 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  fileNameOf,
+  toWorkspaceRelative,
+} from "../src/lib/agent-file-paths.ts";
+
+// The TS engine's folderPath is a route key (`Workspace/Agent`); the legacy
+// engine's is the real absolute directory.
+const TS_ENGINE = { folderPath: "Personal/Assistant" };
+const TS_ENGINE_LOCAL = {
+  folderPath: "Personal/Assistant",
+  localDir: "/Users/jo/.houston/workspaces/Personal/Assistant",
+};
+const LEGACY = { folderPath: "/Users/jo/Documents/Houston/Personal/Assistant" };
+
+describe("toWorkspaceRelative", () => {
+  it("passes workspace-relative paths through unchanged", () => {
+    strictEqual(
+      toWorkspaceRelative("out/report.pdf", TS_ENGINE),
+      "out/report.pdf",
+    );
+    strictEqual(toWorkspaceRelative("perfil.md", TS_ENGINE), "perfil.md");
+  });
+
+  it("strips ./ prefixes from prose paths", () => {
+    strictEqual(toWorkspaceRelative("./report.pdf", TS_ENGINE), "report.pdf");
+    strictEqual(
+      toWorkspaceRelative("./out/report.pdf", TS_ENGINE),
+      "out/report.pdf",
+    );
+  });
+
+  it("strips the host-reported localDir prefix", () => {
+    strictEqual(
+      toWorkspaceRelative(
+        "/Users/jo/.houston/workspaces/Personal/Assistant/out/report.pdf",
+        TS_ENGINE_LOCAL,
+      ),
+      "out/report.pdf",
+    );
+  });
+
+  it("strips through the route key inside a macOS absolute path", () => {
+    strictEqual(
+      toWorkspaceRelative(
+        "/Users/jo/.houston/workspaces/Personal/Assistant/perfil.md",
+        TS_ENGINE,
+      ),
+      "perfil.md",
+    );
+  });
+
+  it("strips through the route key inside a cloud pod path", () => {
+    strictEqual(
+      toWorkspaceRelative(
+        "/data/workspaces/Personal/Assistant/out/report.pdf",
+        TS_ENGINE,
+      ),
+      "out/report.pdf",
+    );
+  });
+
+  it("strips through the route key inside a Windows absolute path", () => {
+    strictEqual(
+      toWorkspaceRelative(
+        "C:\\Users\\jo\\.houston\\workspaces\\Personal\\Assistant\\docs\\perfil.md",
+        TS_ENGINE,
+      ),
+      "docs/perfil.md",
+    );
+  });
+
+  it("strips the legacy engine's absolute folderPath prefix", () => {
+    strictEqual(
+      toWorkspaceRelative(
+        "/Users/jo/Documents/Houston/Personal/Assistant/report.pdf",
+        LEGACY,
+      ),
+      "report.pdf",
+    );
+  });
+
+  it("returns an unmatchable absolute path as-is (host rejects it visibly)", () => {
+    strictEqual(
+      toWorkspaceRelative("/tmp/elsewhere/report.pdf", TS_ENGINE),
+      "/tmp/elsewhere/report.pdf",
+    );
+  });
+
+  it("ignores a trailing slash on the configured roots", () => {
+    strictEqual(
+      toWorkspaceRelative("/data/workspaces/Personal/Assistant/a.md", {
+        folderPath: "Personal/Assistant/",
+      }),
+      "a.md",
+    );
+  });
+});
+
+describe("fileNameOf", () => {
+  it("takes the last segment on both separators", () => {
+    strictEqual(fileNameOf("out/report.pdf"), "report.pdf");
+    strictEqual(fileNameOf("C:\\Users\\jo\\perfil.md"), "perfil.md");
+    strictEqual(fileNameOf("perfil.md"), "perfil.md");
+  });
+});

--- a/packages/web/src/app-tree.tsx
+++ b/packages/web/src/app-tree.tsx
@@ -14,6 +14,7 @@
  */
 
 import App from "@houston/app/App";
+import { AgentFilePreviewHost } from "@houston/app/components/agent-file-preview-host";
 import { DisclaimerGate } from "@houston/app/components/shell/disclaimer-gate";
 import { LanguageGate } from "@houston/app/components/shell/language-gate";
 import { QueryPersistenceProvider } from "@houston/app/components/shell/query-persistence-provider";
@@ -146,6 +147,9 @@ export default function AppTree() {
                 <LanguageGate>
                   <DisclaimerGate>
                     <App />
+                    {/* Global workspace-file preview (chat file clicks) —
+                        mirrors app/src/main.tsx. */}
+                    <AgentFilePreviewHost />
                   </DisclaimerGate>
                 </LanguageGate>
               </I18nextProvider>

--- a/ui/chat/test/markdown-link.test.mjs
+++ b/ui/chat/test/markdown-link.test.mjs
@@ -36,7 +36,7 @@ test("non-string children (React nodes) never match a string href → labeled", 
 });
 
 test("relative path the agent dropped (perfil.md) classifies as autolink when shown bare", () => {
-  // openAgentHref resolves non-URL hrefs against the agent dir; classification
+  // useOpenAgentHref resolves non-URL hrefs against the agent dir; classification
   // only cares whether the visible text equals the href.
   assert.equal(classifyMarkdownLink("perfil.md", "perfil.md"), "autolink");
 });


### PR DESCRIPTION
## What

Files the agent creates are now clickable **in chat** — the per-tool file card, the end-of-turn "New files" summary rows, and bare file paths the agent drops in prose (`perfil.md`). Clicking opens the **same preview dialog the Files tab uses** (images / PDFs / text inline, "download to open" fallback for the rest), and its **Download** button opens the native choose-location save dialog on desktop (browser download on web).

Gating mirrors the Files tab: on a **co-located desktop engine** clicks still hand the file to the OS default app (rooted at the host-reported real directory, per HOU-677 — which also fixes relative prose paths that previously joined against the TS engine's route key). The file card's affordance icon reflects the action: external-link for OS open, eye for in-app preview.

## Why

On web/cloud these clicks were a **silent no-op**: they invoked the desktop-only `open_file` command, which the web shim rejects. Users had no way to see or save a file the agent just made without leaving the chat for the Files tab.

## How

- `app/src/hooks/use-open-agent-file.tsx` — `useOpenAgentFile` / `useOpenAgentHref`: the single decision point for all chat file clicks (OS open vs preview), wired into `FileCard`, `TurnFileSummary`, and the four `onOpenLink` consumers.
- `app/src/lib/agent-file-paths.ts` — normalizes every engine-emitted path shape (absolute macOS/Windows/pod paths, `./`-relative, bare) to the workspace-relative path the authenticated download route requires, by stripping `localDir` or the `Workspace/Agent` route key. `turn-summary-items.ts` now shares these helpers — side effect: semantic classification (CLAUDE.md / skills / learnings) now works for TS-engine absolute paths.
- `FilePreviewDialog` moved out of `tabs/`; one global instance (`AgentFilePreviewHost`, new `filePreview` ui-store state) mounted in both app trees (`app/src/main.tsx`, `packages/web/src/app-tree.tsx`) so it works on every screen, onboarding included. The Files tab keeps its local instance.
- Extras: pi tool inputs (`path`) now render file cards like Claude's (`file_path`); separator-aware filename split in `FileCard` (Windows paths); failed OS opens toast (`files.toasts.openFailedTitle`, en/es/pt) instead of `console.error`.

## Testing

- 10 new unit tests for the path normalization (`app/tests/agent-file-paths.test.ts`); full app suite green (1546 tests).
- `pnpm check` (Biome), app `tsgo --noEmit`, `check-locales`, `houston-web` typecheck + Tauri shim-parity guard, `check:boundaries` — all pass.