### PR TITLE
fix(routines): stop cron routines vanishing after an edit

### DIFF
--- a/packages/domain/src/domain.test.ts
+++ b/packages/domain/src/domain.test.ts
@@ -433,6 +433,57 @@ test("applyRoutineUpdate: switching to a trigger clears the schedule (and vice v
   expect("trigger" in backToCron).toBe(false);
 });
 
+test("applyRoutineUpdate: the editor's cron save shape `{schedule, trigger: null}` keeps the schedule", () => {
+  // The routines editor sends `trigger: null` alongside the schedule on EVERY
+  // cron save. Treating that null as "switching to a trigger" deleted the
+  // schedule too, leaving a wake-less routine that normalizeRoutines dropped on
+  // the next read — every edited cron routine vanished from the list and was
+  // purged from disk by the next save.
+  const cron = createRoutine(
+    { name: "N", prompt: "p", schedule: "0 9 * * *" },
+    "r",
+    NOW,
+  );
+  const saved = applyRoutineUpdate(
+    cron,
+    { name: "N2", prompt: "p2", schedule: "0 10 * * *", trigger: null },
+    NOW,
+  );
+  expect(saved.schedule).toBe("0 10 * * *");
+  expect("trigger" in saved).toBe(false);
+  expect(saved.name).toBe("N2");
+  // The result survives a save → load round-trip (nothing for normalize to drop).
+  const { items, diagnostics } = normalizeRoutines([saved], "k");
+  expect(diagnostics).toEqual([]);
+  expect(items).toHaveLength(1);
+});
+
+test("applyRoutineUpdate: `trigger: null` clears only the trigger, never writes the null", () => {
+  const cron = createRoutine(
+    { name: "N", prompt: "p", schedule: "0 9 * * *" },
+    "r",
+    NOW,
+  );
+  const next = applyRoutineUpdate(cron, { trigger: null }, NOW);
+  expect(next.schedule).toBe("0 9 * * *");
+  expect("trigger" in next).toBe(false);
+
+  // Moving a trigger routine back to cron: the null clears the binding while
+  // the schedule in the same update becomes the wake.
+  const trig = createRoutine(
+    { name: "T", prompt: "p", trigger: TRIGGER },
+    "t",
+    NOW,
+  );
+  const back = applyRoutineUpdate(
+    trig,
+    { schedule: "*/5 * * * *", trigger: null },
+    NOW,
+  );
+  expect(back.schedule).toBe("*/5 * * * *");
+  expect("trigger" in back).toBe(false);
+});
+
 test("routine setup chat link: setup_activity_id round-trips create and update (HOU-725)", () => {
   // Without a chat the key is simply absent (legacy shape, no "" noise)…
   const plain = createRoutine(

--- a/packages/domain/src/portable.test.ts
+++ b/packages/domain/src/portable.test.ts
@@ -159,8 +159,11 @@ test("malformed routine/learning entries are dropped on unpack", () => {
       }),
     ),
     "routines.json": strToU8(
+      // Unpack applies the SAME normalization as the store's read path, so a
+      // "valid" entry here is one normalizeRoutines keeps: identity (id, name,
+      // prompt) plus exactly one wake mechanism.
       JSON.stringify([
-        { id: "ok", name: "R", schedule: "* * * * *" },
+        { id: "ok", name: "R", prompt: "p", schedule: "* * * * *" },
         { junk: true },
       ]),
     ),
@@ -231,4 +234,63 @@ test("packageSeed omits what the package lacks (no empty docs, no CLAUDE.md key)
   const seed = packageSeed({ skills: [], routines: [], learnings: [] });
   expect(seed).toEqual({ seeds: {} });
   expect("claudeMd" in seed).toBe(false);
+});
+
+test("unpack drops an invalid imported routine instead of letting it install-then-vanish", () => {
+  // An entry the store's read path would drop (here: no wake mechanism at all)
+  // must not survive unpack — otherwise it shows in the install preview, gets
+  // seeded to disk, and silently disappears on the first read after install.
+  const wakeLess = {
+    ...createRoutine(
+      { name: "Broken", prompt: "p", schedule: "0 9 * * *" },
+      "r-bad",
+      NOW,
+    ),
+  } as Record<string, unknown>;
+  delete wakeLess.schedule;
+  const bytes = packAgent(
+    {
+      skills: [],
+      learnings: [],
+      routines: [
+        createRoutine(
+          { name: "Good", prompt: "p", schedule: "0 9 * * *" },
+          "r-ok",
+          NOW,
+        ),
+        wakeLess as unknown as Routine,
+      ],
+    },
+    meta,
+    NOW,
+  );
+  const pkg = unpackAgent(bytes);
+  expect(pkg.routines.map((r) => r.id)).toEqual(["r-ok"]);
+  expect(portableInventory(pkg).routines.map((r) => r.id)).toEqual(["r-ok"]);
+});
+
+test("machine/account-local routine keys never cross the share boundary", () => {
+  // `setup_activity_id` points at an activity that only exists on the exporter's
+  // machine; `created_by` is the exporter's account sub (who a fired routine
+  // acts as). Both are stripped at pack AND at unpack (older packs carry them).
+  const local = createRoutine(
+    {
+      name: "Daily",
+      prompt: "check",
+      schedule: "0 9 * * *",
+      setup_activity_id: "act-1",
+    },
+    "r1",
+    NOW,
+    "exporter-sub",
+  );
+  const pkg = unpackAgent(
+    packAgent({ skills: [], learnings: [], routines: [local] }, meta, NOW),
+  );
+  const shared = pkg.routines[0] as unknown as
+    | Record<string, unknown>
+    | undefined;
+  expect(shared?.id).toBe("r1");
+  expect(shared && "setup_activity_id" in shared).toBe(false);
+  expect(shared && "created_by" in shared).toBe(false);
 });

--- a/packages/domain/src/portable.ts
+++ b/packages/domain/src/portable.ts
@@ -6,6 +6,7 @@ import {
   type Routine,
 } from "@houston/protocol";
 import { strFromU8, strToU8, unzipSync, zipSync } from "fflate";
+import { normalizeRoutines } from "./routines";
 
 /**
  * Pack / unpack a `.houstonagent` — a zip of an agent's shareable content. Pure
@@ -66,10 +67,12 @@ export function packAgent(
     files[CLAUDE_MD] = strToU8(content.claudeMd);
   for (const s of content.skills) files[skillPath(s.slug)] = strToU8(s.body);
   if (content.routines.length) {
-    // A setup chat is machine-local: its activity id means nothing on the
-    // importer's side, so shared routines never carry one.
+    // A setup chat is machine-local (its activity id means nothing on the
+    // importer's side) and `created_by` is the exporter's account identity
+    // (who a fired routine acts as — never valid on another account, and not
+    // ours to publish), so shared routines carry neither.
     const shareable = content.routines.map(
-      ({ setup_activity_id: _local, ...r }) => r,
+      ({ setup_activity_id: _local, created_by: _owner, ...r }) => r,
     );
     files[ROUTINES] = strToU8(JSON.stringify(shareable, null, 2));
   }
@@ -123,9 +126,15 @@ export function unpackAgent(bytes: Uint8Array): PortablePackage {
     manifest,
     ...(claude !== undefined ? { claudeMd: strFromU8(claude) } : {}),
     skills,
-    routines: parseArray<Routine>(routinesRaw).filter(
-      (r) => isRecord(r) && typeof r.id === "string",
-    ),
+    // Run imported routines through the SAME normalization the read path uses:
+    // an entry the store would drop (no identity, malformed trigger, not
+    // exactly one wake mechanism) must not reach the install preview only to
+    // silently vanish on the first read after install. Machine/account-local
+    // keys are stripped defensively too — packs from older builds carry them.
+    routines: normalizeRoutines(
+      parseArray<Routine>(routinesRaw),
+      ROUTINES,
+    ).items.map(({ setup_activity_id: _local, created_by: _owner, ...r }) => r),
     learnings: parseArray<Learning>(learningsRaw).filter(
       (l) => isRecord(l) && typeof l.id === "string",
     ),

--- a/packages/domain/src/routines.ts
+++ b/packages/domain/src/routines.ts
@@ -184,6 +184,15 @@ export function applyRoutineUpdate(
       ([k, v]) => v !== undefined && k !== "timezone" && k !== "created_by",
     ),
   );
+  // A null wake key means "clear that mechanism" (the client keeps or moves to
+  // the other one — the UI sends `{schedule, trigger: null}` on every cron
+  // save). The null itself must never be written, and clearing one side must
+  // never delete the other: a routine left with neither wake is dropped by
+  // normalizeRoutines on the next read and purged from disk by the next save.
+  const clearsTrigger = defined.trigger === null;
+  const clearsSchedule = defined.schedule === null;
+  if (clearsTrigger) delete defined.trigger;
+  if (clearsSchedule) delete defined.schedule;
   // `...current` preserves `created_by` when no verified actor is known — a
   // client can never reassign a routine's acting identity through the body.
   const next = {
@@ -192,11 +201,14 @@ export function applyRoutineUpdate(
     ...(actorSub ? { created_by: actorSub } : {}),
     updated_at: nowIso,
   } as Routine;
-  // A routine has exactly one wake mechanism, so setting one clears the other:
+  // A routine has exactly one wake mechanism, so SETTING one clears the other:
   // switching a cron routine to an event wake (or back) must not leave both set,
-  // which normalizeRoutines would drop on the next read.
+  // which normalizeRoutines would drop on the next read. Only a real value
+  // switches — a null cleared itself above, not its counterpart.
   if (defined.schedule !== undefined) delete next.trigger;
   if (defined.trigger !== undefined) delete next.schedule;
+  if (clearsTrigger) delete next.trigger;
+  if (clearsSchedule) delete next.schedule;
   return next;
 }
 

--- a/packages/host/src/routes/agent-data.test.ts
+++ b/packages/host/src/routes/agent-data.test.ts
@@ -321,6 +321,108 @@ test("routines: PATCH switches a cron routine to a trigger wake, clearing the sc
   expect(bad.status).toBe(400);
 });
 
+test("routines: the editor's cron save `{schedule, trigger: null}` keeps the routine alive (regression)", async () => {
+  // The routines editor pairs every cron save with `trigger: null`. This once
+  // deleted the schedule too, persisting a wake-less routine that vanished
+  // from every subsequent list and was purged from disk by the next write.
+  const created = await fetch(`${base}/agents/${agentId}/routines`, {
+    method: "POST",
+    headers: auth("alice"),
+    body: JSON.stringify({
+      name: "Morning brief",
+      prompt: "Summarize the news",
+      schedule: "0 8 * * *",
+    }),
+  });
+  expect(created.status).toBe(201);
+  const routine = (await created.json()) as Routine;
+
+  const patched = await fetch(
+    `${base}/agents/${agentId}/routines/${routine.id}`,
+    {
+      method: "PATCH",
+      headers: auth("alice"),
+      body: JSON.stringify({
+        name: "Morning brief v2",
+        prompt: "Summarize the news, briefly",
+        schedule: "0 9 * * *",
+        trigger: null,
+      }),
+    },
+  );
+  expect(patched.status).toBe(200);
+  const next = (await patched.json()) as Routine;
+  expect(next.schedule).toBe("0 9 * * *");
+  expect("trigger" in next).toBe(false);
+
+  // The routine is still in the list after the save (it used to vanish here).
+  const list = (await (
+    await fetch(`${base}/agents/${agentId}/routines`, {
+      headers: auth("alice"),
+    })
+  ).json()) as { items: Routine[]; diagnostics: unknown[] };
+  const found = list.items.find((r) => r.id === routine.id);
+  expect(found?.name).toBe("Morning brief v2");
+  expect(found?.schedule).toBe("0 9 * * *");
+  expect(list.diagnostics).toEqual([]);
+
+  // And a LATER unrelated PATCH must not purge it either (the old bug's
+  // cascade: every mutation rewrote the file without normalize-dropped rows).
+  const toggled = await fetch(
+    `${base}/agents/${agentId}/routines/${routine.id}`,
+    {
+      method: "PATCH",
+      headers: auth("alice"),
+      body: JSON.stringify({ enabled: false }),
+    },
+  );
+  expect(toggled.status).toBe(200);
+  const after = (await (
+    await fetch(`${base}/agents/${agentId}/routines`, {
+      headers: auth("alice"),
+    })
+  ).json()) as { items: Routine[] };
+  expect(after.items.some((r) => r.id === routine.id)).toBe(true);
+});
+
+test("routines: a PATCH that would leave no wake mechanism is rejected (400), never persisted", async () => {
+  const trigger = {
+    toolkit: "gmail",
+    trigger_slug: "GMAIL_NEW_GMAIL_MESSAGE",
+    trigger_config: { labelIds: ["INBOX"] },
+  };
+  const created = await fetch(`${base}/agents/${agentId}/routines`, {
+    method: "POST",
+    headers: auth("alice"),
+    body: JSON.stringify({ name: "On email", prompt: "Triage", trigger }),
+  });
+  expect(created.status).toBe(201);
+  const routine = (await created.json()) as Routine;
+
+  // Clearing the only wake without supplying the other one → 400. Persisting
+  // it would silently lose the routine (normalizeRoutines drops wake-less rows).
+  const cleared = await fetch(
+    `${base}/agents/${agentId}/routines/${routine.id}`,
+    {
+      method: "PATCH",
+      headers: auth("alice"),
+      body: JSON.stringify({ trigger: null }),
+    },
+  );
+  expect(cleared.status).toBe(400);
+  expect(((await cleared.json()) as { error: string }).error).toContain(
+    "exactly one",
+  );
+
+  // The routine is untouched by the rejected write.
+  const list = (await (
+    await fetch(`${base}/agents/${agentId}/routines`, {
+      headers: auth("alice"),
+    })
+  ).json()) as { items: Routine[] };
+  expect(list.items.find((r) => r.id === routine.id)?.trigger).toEqual(trigger);
+});
+
 test("routines: created_by is server-owned and cannot be spoofed", async () => {
   const created = await fetch(`${base}/agents/${agentId}/routines`, {
     method: "POST",

--- a/packages/host/src/routes/agent-data.ts
+++ b/packages/host/src/routes/agent-data.ts
@@ -216,6 +216,17 @@ export async function handleAgentData(
           return true;
         }
         const next = applyRoutineUpdate(current, update, nowIso, createdBy);
+        // The APPLIED result must still hold the exactly-one-wake invariant —
+        // e.g. `{trigger: null}` on a trigger routine clears its only wake.
+        // Persisting such a routine loses it silently: normalizeRoutines drops
+        // it from every read and the next save purges it from disk.
+        const nextWakeErr = wakeMechanismError(
+          next as unknown as Record<string, unknown>,
+        );
+        if (nextWakeErr) {
+          json(res, 400, { error: nextWakeErr });
+          return true;
+        }
         // A PATCH may change the schedule; validate it against the account-wide
         // zone (HOU-470: no per-routine timezone). A trigger routine (or a PATCH
         // that switched to a trigger) has no cron to validate.

--- a/packages/protocol/src/domain/routine.ts
+++ b/packages/protocol/src/domain/routine.ts
@@ -82,10 +82,12 @@ export interface NewRoutine {
 export interface RoutineUpdate {
   name?: string;
   prompt?: string;
-  /** Switch to (or edit) a cron wake; clears `trigger` when the routine is saved. */
+  /** Switch to (or edit) a cron wake; a real value clears any `trigger`. */
   schedule?: string;
-  /** Switch to (or edit) an event wake; clears `schedule` when the routine is saved. */
-  trigger?: RoutineTriggerBinding;
+  /** Switch to (or edit) an event wake; a real value clears any `schedule`.
+   *  `null` clears only the trigger (pair with `schedule` to move a routine
+   *  back to a cron wake); omit to leave the wake mechanism unchanged. */
+  trigger?: RoutineTriggerBinding | null;
   enabled?: boolean;
   suppress_when_silent?: boolean;
   chat_mode?: RoutineChatMode;

--- a/packages/web/tests/portable-install.test.ts
+++ b/packages/web/tests/portable-install.test.ts
@@ -31,6 +31,8 @@ const CFG = { baseUrl: "https://gateway.example", token: "tok" };
 const ROUTINE = {
   id: "r1",
   name: "Daily",
+  // Stray key from an older build's pack — HOU-725 removed `description`;
+  // unpack normalizes imported routines, so it must not reach the seed.
   description: "",
   prompt: "check the inbox",
   schedule: "0 9 * * *",
@@ -41,6 +43,8 @@ const ROUTINE = {
   created_at: NOW,
   updated_at: NOW,
 };
+
+const { description: _stray, ...SEEDED_ROUTINE } = ROUTINE;
 
 function archive() {
   return packAgent(
@@ -109,7 +113,7 @@ test("install creates the agent with the package as its seed payload", async () 
   expect(JSON.stringify(body)).not.toContain("Prefers brevity");
   expect(
     JSON.parse(body.seeds?.[".houston/routines/routines.json"] ?? ""),
-  ).toEqual([ROUTINE]);
+  ).toEqual([SEEDED_ROUTINE]);
 
   expect(installed).toEqual({
     agentPath: "abcd1234abcd1234",


### PR DESCRIPTION
## The bug

Every save from the routines editor sends `{ name, prompt, schedule, trigger: null }` — the `trigger: null` says "cron routine, clear any event binding" (the engine-client type explicitly blesses this shape). But `applyRoutineUpdate` only filtered out `undefined`, so the `null` slipped through: it was written onto the routine as `trigger: null`, **and** the "setting a trigger clears the schedule" rule fired on it, deleting the schedule too. The saved routine ended up with **no wake mechanism at all**.

Consequences:

1. `normalizeRoutines` drops wake-less entries on every read → the routine vanishes from the list the moment the save lands.
2. Every later mutation (editing/toggling another routine, or opening a routine chat, which PATCHes a `setup_activity_id` stamp) rewrites `routines.json` with only the normalized survivors → each broken routine is then **permanently purged from disk**.

Editing cron routines one after another wiped them all — imported and agent-created alike. Event-trigger routines were unaffected (their saves don't send the null), which made the loss look random.

## The fix

- **domain** — `applyRoutineUpdate` treats a `null` wake key as "clear that mechanism only": the null is never persisted and never deletes its counterpart.
- **host** — PATCH validates the *applied result* and 400s if it would leave a routine with both or neither wake mechanism, so no code path can persist a routine that silently disappears (beta no-silent-loss policy).
- **protocol** — `RoutineUpdate.trigger` is now `RoutineTriggerBinding | null`, matching the engine-client contract the UI already compiles against (the two halves of the wire contract disagreed).
- **portable** (found while auditing the import path):
  - `unpackAgent` runs imported routines through the same normalization as the store's read path, so an invalid entry in a shared pack can't show in the install preview and then vanish on first read after install.
  - Pack and unpack both strip `created_by` alongside `setup_activity_id` — the exporter's account sub (who a fired routine acts as) was leaking into shared `.houstonagent` files.

## Tests

- Domain: the exact editor save shape `{schedule, trigger: null}` keeps the schedule and survives a save → load round-trip; `trigger: null` alone clears only the trigger; unpack drops invalid imported entries and strips machine/account-local keys.
- Host (HTTP): cron save → routine still in the list, and a later unrelated PATCH doesn't purge it (the old cascade); a wake-destroying PATCH gets 400 and leaves the routine untouched.
- Full suites green: domain 141, host 949, workspace typecheck, Biome, boundaries.

## Caveat

Routines already broken by this bug had their cron schedule deleted on disk and cannot be auto-recovered — affected users must recreate or re-import them. (The wake-less rows do surface as diagnostics on the list read until the next write purges them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)