### PR TITLE
feat(usage): Running time analytics for hosted-cloud agents

### DIFF
--- a/app/src/components/usage-view/compute-agent-row.tsx
+++ b/app/src/components/usage-view/compute-agent-row.tsx
@@ -1,0 +1,69 @@
+import { Badge, HoustonAvatar } from "@houston-ai/core";
+import type { ComputeAgentTotals } from "./compute-usage-model";
+
+interface ComputeAgentRowProps {
+  agent: ComputeAgentTotals;
+  /** Display name resolved from the slug. */
+  name: string;
+  /** Resolved agent color (semantic hex), for the avatar tint. */
+  color?: string;
+  /** Busiest agent's runMs (≥ 1), to scale this row's bar. */
+  max: number;
+  /** This agent's engine is up right now. */
+  runningNow: boolean;
+  /** Formatted running time ("3h 12m"). */
+  duration: string;
+  /** Formatted task count ("12 tasks"). */
+  tasks: string;
+  /** "Running now" badge text. */
+  runningNowLabel: string;
+}
+
+/**
+ * One agent's running time in the Compute section: avatar + name + duration
+ * and task count + a tokened track bar scaled to the busiest agent (the same
+ * shape as the org Usage tab's rows, minus the expandable breakdown — running
+ * time is per-agent, not per-person).
+ */
+export function ComputeAgentRow({
+  agent,
+  name,
+  color,
+  max,
+  runningNow,
+  duration,
+  tasks,
+  runningNowLabel,
+}: ComputeAgentRowProps) {
+  const pct = Math.max(2, Math.round((agent.runMs / max) * 100));
+  return (
+    <li className="flex items-center gap-3 border-b border-line/40 py-3 last:border-0">
+      <HoustonAvatar color={color} diameter={28} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between gap-3">
+          <span className="flex min-w-0 items-baseline gap-2">
+            <span className="truncate text-sm font-medium text-ink">
+              {name}
+            </span>
+            {runningNow && (
+              <Badge variant="secondary" className="shrink-0">
+                {runningNowLabel}
+              </Badge>
+            )}
+          </span>
+          <span className="shrink-0 text-sm text-ink-muted">
+            {duration}
+            <span aria-hidden> · </span>
+            {tasks}
+          </span>
+        </div>
+        <div className="mt-1.5 h-2 overflow-hidden rounded-full bg-chip">
+          <div
+            className="h-full rounded-full bg-action"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/app/src/components/usage-view/compute-bar-chart.tsx
+++ b/app/src/components/usage-view/compute-bar-chart.tsx
@@ -1,0 +1,83 @@
+import { cn } from "@houston-ai/core";
+import type { ComputeBucket } from "./compute-usage-model";
+
+interface ComputeBarChartProps {
+  buckets: ComputeBucket[];
+  /** Busiest bucket's runMs (≥ 1), the 100%-height reference. */
+  max: number;
+  /** True when some agent is running right now — dots the last bar. */
+  runningNow: boolean;
+  /** Accessible per-bar description ("Jul 12: ran 2h 05m, 8 tasks"). */
+  barLabel: (bucket: ComputeBucket) => string;
+  /** Short x-axis label for a bucket's start day ("Mon" / "Jul 12"). */
+  axisLabel: (bucket: ComputeBucket, index: number) => string;
+}
+
+/**
+ * Running-time bars, one per bucket (day or week). Single series, so identity
+ * needs no legend or per-bar numbers — the section's summary line carries the
+ * total, each bar carries its value as an aria-label and a native tooltip
+ * (hover enhances, never gates). Zero days stay visible as a small tick so the
+ * range reads as "measured and idle", not "missing". A pulse dot rides the
+ * last bar while an agent is running — that bar is still growing. Tokens only.
+ */
+export function ComputeBarChart({
+  buckets,
+  max,
+  runningNow,
+  barLabel,
+  axisLabel,
+}: ComputeBarChartProps) {
+  return (
+    <ol className="flex h-28 items-end gap-[2px]">
+      {buckets.map((bucket, index) => {
+        const last = index === buckets.length - 1;
+        const pct =
+          bucket.runMs === 0
+            ? 0
+            : Math.max(4, Math.round((bucket.runMs / max) * 100));
+        const label = barLabel(bucket);
+        return (
+          <li
+            key={bucket.startDay}
+            className="group flex h-full min-w-0 flex-1 flex-col justify-end"
+          >
+            <div
+              role="img"
+              aria-label={label}
+              title={label}
+              className="flex h-full flex-col items-center justify-end gap-1"
+            >
+              {last && runningNow && (
+                <span
+                  aria-hidden
+                  className="size-1.5 shrink-0 animate-pulse rounded-full bg-action"
+                />
+              )}
+              {pct === 0 ? (
+                <div className="h-[3px] w-full max-w-9 rounded-full bg-chip" />
+              ) : (
+                <div
+                  className="w-full max-w-9 rounded-t-[4px] bg-action/80 transition-[height] duration-300 group-hover:bg-action"
+                  style={{ height: `${pct}%` }}
+                />
+              )}
+            </div>
+            <span
+              aria-hidden
+              className={cn(
+                // No truncation: on dense ranges only every ~5th label renders
+                // (the tooltip covers the rest), so an overflowing "Jun 26" has
+                // room to spill over its hidden neighbors instead of clipping.
+                "mt-1 self-center text-center text-[10px] leading-tight whitespace-nowrap text-ink-muted",
+                buckets.length > 14 && index % 5 !== 0 && !last && "invisible",
+              )}
+            >
+              {axisLabel(bucket, index)}
+            </span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/app/src/components/usage-view/compute-section.tsx
+++ b/app/src/components/usage-view/compute-section.tsx
@@ -1,0 +1,175 @@
+import {
+  Empty,
+  EmptyDescription,
+  EmptyTitle,
+  resolveAgentColor,
+  Spinner,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@houston-ai/core";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useComputeUsage } from "../../hooks/queries";
+import { useAgentStore } from "../../stores/agents";
+import { agentLabel } from "../organization/org-roster";
+import { ComputeAgentRow } from "./compute-agent-row";
+import { ComputeBarChart } from "./compute-bar-chart";
+import {
+  bucketCompute,
+  type ComputeRange,
+  durationParts,
+} from "./compute-usage-model";
+
+const RANGES: ComputeRange[] = ["week", "month", "quarter"];
+
+type Translate = ReturnType<typeof useTranslation>["t"];
+
+/** Compose a duration from locale templates ("2h 05m" / "45m" / "<1m"). */
+function formatDuration(t: Translate, ms: number): string {
+  const parts = durationParts(ms);
+  switch (parts.kind) {
+    case "zero":
+      return t("usage.compute.duration.zero");
+    case "underMinute":
+      return t("usage.compute.duration.underMinute");
+    case "minutes":
+      return t("usage.compute.duration.m", { minutes: parts.minutes });
+    case "hoursMinutes":
+      return t("usage.compute.duration.hm", {
+        hours: parts.hours,
+        minutes: parts.minutes,
+      });
+  }
+}
+
+/** Localized calendar label for a bucket's UTC start day. */
+function dayLabel(
+  language: string,
+  day: string,
+  options: Intl.DateTimeFormatOptions,
+): string {
+  return new Intl.DateTimeFormat(language, {
+    ...options,
+    timeZone: "UTC",
+  }).format(new Date(`${day}T00:00:00Z`));
+}
+
+/**
+ * "Running time": how long this user's agents have been up, per day/week, with
+ * a per-agent breakdown. Rendered ONLY where the gateway advertises
+ * `capabilities.computeUsage` (the parent gates mounting, so the query never
+ * fires elsewhere). One fetch covers 90 days; range switches re-bucket locally.
+ */
+export function ComputeSection() {
+  const { t, i18n } = useTranslation("aiHub");
+  const agents = useAgentStore((s) => s.agents);
+  const [range, setRange] = useState<ComputeRange>("week");
+  const { data, isLoading, isError } = useComputeUsage(true);
+
+  const model = useMemo(
+    () => bucketCompute(data?.rows ?? [], range, Date.now()),
+    [data, range],
+  );
+  const runningNow = data?.awakeNow ?? [];
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-medium text-ink">
+            {t("usage.compute.title")}
+          </h2>
+          <p className="text-sm text-ink-muted">
+            {t("usage.compute.subtitle")}
+          </p>
+        </div>
+        <Tabs value={range} onValueChange={(v) => setRange(v as ComputeRange)}>
+          <TabsList>
+            {RANGES.map((key) => (
+              <TabsTrigger key={key} value={key}>
+                {t(`usage.compute.range.${key}`)}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-16">
+          <Spinner />
+        </div>
+      ) : isError ? (
+        <p className="py-6 text-sm text-ink-muted">
+          {t("usage.compute.error")}
+        </p>
+      ) : (data?.rows.length ?? 0) === 0 ? (
+        <Empty className="mt-2">
+          <EmptyTitle>{t("usage.compute.empty.title")}</EmptyTitle>
+          <EmptyDescription>{t("usage.compute.empty.body")}</EmptyDescription>
+        </Empty>
+      ) : (
+        <>
+          <p className="text-sm text-ink-muted">
+            {t("usage.compute.summary", {
+              duration: formatDuration(t, model.totalRunMs),
+            })}
+            <span aria-hidden> · </span>
+            {t("usage.compute.tasks", { count: model.totalTasks })}
+          </p>
+          <ComputeBarChart
+            buckets={model.buckets}
+            max={model.maxBucketMs}
+            runningNow={runningNow.length > 0}
+            barLabel={(bucket) =>
+              t("usage.compute.barLabel", {
+                date: dayLabel(i18n.language, bucket.startDay, {
+                  month: "short",
+                  day: "numeric",
+                }),
+                duration: formatDuration(t, bucket.runMs),
+                tasks: t("usage.compute.tasks", { count: bucket.tasks }),
+              })
+            }
+            axisLabel={(bucket) =>
+              dayLabel(
+                i18n.language,
+                bucket.startDay,
+                range === "week"
+                  ? { weekday: "short" }
+                  : { month: "short", day: "numeric" },
+              )
+            }
+          />
+          <div>
+            <h3 className="mb-1 text-sm font-medium text-ink">
+              {t("usage.compute.byAgent")}
+            </h3>
+            <ul className="flex flex-col">
+              {model.perAgent.map((agent) => {
+                const match = agents.find(
+                  (a) =>
+                    a.folderPath === agent.agentSlug ||
+                    a.id === agent.agentSlug,
+                );
+                return (
+                  <ComputeAgentRow
+                    key={agent.agentSlug}
+                    agent={agent}
+                    name={agentLabel(agent.agentSlug, agents)}
+                    color={resolveAgentColor(match?.color)}
+                    max={model.maxAgentMs}
+                    runningNow={runningNow.includes(agent.agentSlug)}
+                    duration={formatDuration(t, agent.runMs)}
+                    tasks={t("usage.compute.tasks", { count: agent.tasks })}
+                    runningNowLabel={t("usage.compute.runningNow")}
+                  />
+                );
+              })}
+            </ul>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/app/src/components/usage-view/compute-usage-model.ts
+++ b/app/src/components/usage-view/compute-usage-model.ts
@@ -1,0 +1,143 @@
+import type { Capabilities, ComputeUsageRow } from "@houston-ai/engine-client";
+
+/**
+ * Pure aggregation for the Compute section (no DOM, no i18n): buckets the
+ * gateway's per-(agent, UTC day) rows into the selected range and rolls up
+ * per-agent totals. The user sees ONE time metric — running time = `awakeMs`
+ * (the engine's up-time); `activeMs` is a recorded subset we deliberately do
+ * not render, and tasks (`turns + routineRuns`) is the companion stat.
+ */
+
+export type ComputeRange = "week" | "month" | "quarter";
+
+export interface ComputeBucket {
+  /** First UTC day of the bucket (`YYYY-MM-DD`) — the bar's identity/label. */
+  startDay: string;
+  /** Days folded into this bucket (1 for daily ranges, 7 for weekly). */
+  days: number;
+  runMs: number;
+  tasks: number;
+}
+
+export interface ComputeAgentTotals {
+  agentSlug: string;
+  runMs: number;
+  tasks: number;
+}
+
+export interface ComputeModel {
+  buckets: ComputeBucket[];
+  perAgent: ComputeAgentTotals[];
+  totalRunMs: number;
+  totalTasks: number;
+  /** Busiest bucket/agent, floored at 1 so bar math never divides by zero. */
+  maxBucketMs: number;
+  maxAgentMs: number;
+}
+
+const DAY_MS = 86_400_000;
+
+const dayString = (ts: number) => new Date(ts).toISOString().slice(0, 10);
+const dayStart = (day: string) => Date.parse(`${day}T00:00:00Z`);
+
+/** Monday of the UTC week containing `ts` (ISO weeks, like the gateway's days). */
+function weekStart(ts: number): number {
+  const weekday = new Date(ts).getUTCDay(); // 0 = Sunday
+  const sinceMonday = (weekday + 6) % 7;
+  return Math.floor(ts / DAY_MS) * DAY_MS - sinceMonday * DAY_MS;
+}
+
+/** The range's bucket starts, oldest first, always ending at "now"'s bucket. */
+function bucketStarts(range: ComputeRange, nowMs: number): number[] {
+  if (range === "quarter") {
+    const current = weekStart(nowMs);
+    return Array.from(
+      { length: 13 },
+      (_, i) => current - (12 - i) * 7 * DAY_MS,
+    );
+  }
+  const days = range === "week" ? 7 : 30;
+  const today = Math.floor(nowMs / DAY_MS) * DAY_MS;
+  return Array.from(
+    { length: days },
+    (_, i) => today - (days - 1 - i) * DAY_MS,
+  );
+}
+
+export function bucketCompute(
+  rows: readonly ComputeUsageRow[],
+  range: ComputeRange,
+  nowMs: number,
+): ComputeModel {
+  const starts = bucketStarts(range, nowMs);
+  const bucketDays = range === "quarter" ? 7 : 1;
+  const buckets: ComputeBucket[] = starts.map((start) => ({
+    startDay: dayString(start),
+    days: bucketDays,
+    runMs: 0,
+    tasks: 0,
+  }));
+  const first = starts[0];
+  const spanMs = bucketDays * DAY_MS;
+  const perAgent = new Map<string, ComputeAgentTotals>();
+
+  for (const row of rows) {
+    const ts = dayStart(row.day);
+    if (Number.isNaN(ts) || ts < first) continue;
+    const index = Math.floor((ts - first) / spanMs);
+    // Rows dated past "now"'s bucket (clock skew) fold into the last bar
+    // rather than vanishing — the server is the time authority, not us.
+    const bucket = buckets[Math.min(index, buckets.length - 1)];
+    const tasks = row.turns + row.routineRuns;
+    bucket.runMs += row.awakeMs;
+    bucket.tasks += tasks;
+    let agent = perAgent.get(row.agentSlug);
+    if (!agent) {
+      agent = { agentSlug: row.agentSlug, runMs: 0, tasks: 0 };
+      perAgent.set(row.agentSlug, agent);
+    }
+    agent.runMs += row.awakeMs;
+    agent.tasks += tasks;
+  }
+
+  const agents = [...perAgent.values()].sort(
+    (a, b) => b.runMs - a.runMs || a.agentSlug.localeCompare(b.agentSlug),
+  );
+  return {
+    buckets,
+    perAgent: agents,
+    totalRunMs: agents.reduce((sum, a) => sum + a.runMs, 0),
+    totalTasks: agents.reduce((sum, a) => sum + a.tasks, 0),
+    maxBucketMs: Math.max(1, ...buckets.map((b) => b.runMs)),
+    maxAgentMs: Math.max(1, ...agents.map((a) => a.runMs)),
+  };
+}
+
+/**
+ * Decompose a duration for i18n composition ("2h 05m" / "45m" / "<1m" / "0m").
+ * Locale templates own the unit text; this owns the arithmetic only.
+ */
+export type DurationParts =
+  | { kind: "zero" }
+  | { kind: "underMinute" }
+  | { kind: "minutes"; minutes: number }
+  | { kind: "hoursMinutes"; hours: number; minutes: string };
+
+export function durationParts(ms: number): DurationParts {
+  if (ms <= 0) return { kind: "zero" };
+  if (ms < 60_000) return { kind: "underMinute" };
+  const totalMinutes = Math.round(ms / 60_000);
+  if (totalMinutes < 60) return { kind: "minutes", minutes: totalMinutes };
+  return {
+    kind: "hoursMinutes",
+    hours: Math.floor(totalMinutes / 60),
+    minutes: String(totalMinutes % 60).padStart(2, "0"),
+  };
+}
+
+/** The section renders only where the gateway advertises the endpoint. */
+export function showComputeSection(
+  capabilities: Capabilities | null | undefined,
+): boolean {
+  return capabilities?.computeUsage === true;
+}

--- a/app/src/components/usage-view/usage-view.tsx
+++ b/app/src/components/usage-view/usage-view.tsx
@@ -11,6 +11,8 @@ import {
 import { useUIStore } from "../../stores/ui";
 import { groupProviders } from "../provider-browser/provider-grouping";
 import { PageContainer, PageHeader } from "../shell/page-shell";
+import { ComputeSection } from "./compute-section";
+import { showComputeSection } from "./compute-usage-model";
 import { UsagePane } from "./usage-pane";
 
 /**
@@ -44,6 +46,10 @@ export function UsageView() {
     () => groupProviders(connectProviders, connections.isConnected),
     [connectProviders, connections.isConnected],
   );
+  // Hosted cloud meters how long each agent's engine runs; only gateways that
+  // serve the data advertise it. Mount-gating here also gates the query, so
+  // desktop/self-host never fetch a route that doesn't exist.
+  const showCompute = showComputeSection(capabilities);
 
   return (
     <div className="h-full overflow-y-auto [scrollbar-gutter:stable]">
@@ -52,11 +58,19 @@ export function UsageView() {
           title={t("usage.pageTitle")}
           subtitle={t("usage.pageSubtitle")}
         />
-        <UsagePane
-          providers={connected}
-          ready={connections.ready}
-          onConnect={() => setViewMode("ai-hub")}
-        />
+        {showCompute && <ComputeSection />}
+        <div>
+          {showCompute && (
+            <h2 className="text-sm font-medium text-ink">
+              {t("usage.accounts.title")}
+            </h2>
+          )}
+          <UsagePane
+            providers={connected}
+            ready={connections.ready}
+            onConnect={() => setViewMode("ai-hub")}
+          />
+        </div>
       </PageContainer>
     </div>
   );

--- a/app/src/hooks/queries/index.ts
+++ b/app/src/hooks/queries/index.ts
@@ -16,6 +16,7 @@ export {
   useSetAgentAllowedModels,
   useSetAgentSettings,
 } from "./use-agent-settings";
+export { COMPUTE_USAGE_DAYS, useComputeUsage } from "./use-compute-usage";
 export {
   useAllConversations,
   useChatHistory,

--- a/app/src/hooks/queries/use-compute-usage.ts
+++ b/app/src/hooks/queries/use-compute-usage.ts
@@ -1,0 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "../../lib/query-keys";
+import { tauriOrg } from "../../lib/tauri";
+
+/**
+ * One fetch covers every client-side range (7d / 30d / 13w); the gateway
+ * clamps `days` to ≤ 90 anyway, so the model buckets locally and range
+ * switches never refetch.
+ */
+export const COMPUTE_USAGE_DAYS = 90;
+
+/**
+ * Per-agent compute usage (engine running time) over the last 90 days.
+ *
+ * Cloud-only: the caller passes `enabled` from `capabilities.computeUsage`,
+ * so no request can ever fire on desktop/self-host (where the route does not
+ * exist). Scoping is server-side — members get only their assigned agents.
+ *
+ * Closed days never change, but an agent that is running right now grows
+ * "today" continuously — while `awakeNow` is non-empty the query ticks every
+ * minute so the current bar visibly accrues, otherwise it relaxes to five.
+ * There is no pod wake/sleep `HoustonEvent` to invalidate on (same as
+ * {@link useOrgUsage}); space switches already drop the whole query cache.
+ * Failures surface via `tauriOrg.computeUsage` → `call()` (toast + Report bug).
+ */
+export function useComputeUsage(enabled: boolean) {
+  return useQuery({
+    queryKey: queryKeys.computeUsage(COMPUTE_USAGE_DAYS),
+    queryFn: () => tauriOrg.computeUsage(COMPUTE_USAGE_DAYS),
+    enabled,
+    staleTime: 60_000,
+    refetchInterval: (query) =>
+      (query.state.data?.awakeNow.length ?? 0) > 0 ? 60_000 : 5 * 60_000,
+    refetchOnWindowFocus: true,
+  });
+}

--- a/app/src/lib/query-keys.ts
+++ b/app/src/lib/query-keys.ts
@@ -116,6 +116,9 @@ export const queryKeys = {
   /** Teams v2: per-agent/user usage counters over a `days` window. Keyed by the
    *  window so 7- vs 30-day reads don't collide. */
   orgUsage: (days: number) => ["org-usage", days] as const,
+  /** Per-agent compute usage (engine running time) over a `days` window.
+   *  Cloud-only (gated on `capabilities.computeUsage`); keyed by the window. */
+  computeUsage: (days: number) => ["compute-usage", days] as const,
   agentGrants: (agentId: string) => ["agent-grants", agentId] as const,
   /**
    * Teams v2: an agent's allowed-toolkit settings (agent + org ceilings +

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1623,6 +1623,11 @@ export const tauriOrg = {
   /** Per-agent/user usage counters over the last `days` (owner org-wide; admin
    *  their managed agents; plain members 403). */
   usage: (days: number) => call("org_usage", () => getEngine().orgUsage(days)),
+  /** Per-agent compute usage (engine running time) over the last `days`,
+   *  scoped server-side to the agents the caller can access. Cloud-only:
+   *  callers gate on `capabilities.computeUsage`. */
+  computeUsage: (days: number) =>
+    call("org_compute_usage", () => getEngine().computeUsage(days)),
   /** C8 spaces: the caller's spaces + pending invites. Degrades to an empty
    *  result off-spaces (the switcher then shows only the personal workspace). */
   listOrgs: () => call("list_orgs", () => getEngine().listOrgs()),

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -151,6 +151,35 @@
       "title": "No accounts connected",
       "body": "Connect an AI provider to see how much of its limits you've used.",
       "connect": "Connect a provider"
+    },
+    "accounts": {
+      "title": "AI accounts"
+    },
+    "compute": {
+      "title": "Running time",
+      "subtitle": "How long your agents have been running and how many tasks they handled.",
+      "range": {
+        "week": "7 days",
+        "month": "30 days",
+        "quarter": "3 months"
+      },
+      "summary": "Your agents ran {{duration}}",
+      "tasks_one": "{{count}} task",
+      "tasks_other": "{{count}} tasks",
+      "runningNow": "Running now",
+      "byAgent": "By agent",
+      "duration": {
+        "hm": "{{hours}}h {{minutes}}m",
+        "m": "{{minutes}}m",
+        "underMinute": "<1m",
+        "zero": "0m"
+      },
+      "barLabel": "{{date}}: ran {{duration}}, {{tasks}}",
+      "empty": {
+        "title": "No running time yet",
+        "body": "When your agents run, their time will show here."
+      },
+      "error": "Couldn't load running time right now. Try again in a moment."
     }
   },
   "toast": {}

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -151,6 +151,35 @@
       "title": "No hay cuentas conectadas",
       "body": "Conecta un proveedor de IA para ver cuánto de sus límites has usado.",
       "connect": "Conectar un proveedor"
+    },
+    "accounts": {
+      "title": "Cuentas de IA"
+    },
+    "compute": {
+      "title": "Tiempo de actividad",
+      "subtitle": "Cuánto tiempo han estado funcionando tus agentes y cuántas tareas realizaron.",
+      "range": {
+        "week": "7 días",
+        "month": "30 días",
+        "quarter": "3 meses"
+      },
+      "summary": "Tus agentes funcionaron {{duration}}",
+      "tasks_one": "{{count}} tarea",
+      "tasks_other": "{{count}} tareas",
+      "runningNow": "Activo ahora",
+      "byAgent": "Por agente",
+      "duration": {
+        "hm": "{{hours}}h {{minutes}}m",
+        "m": "{{minutes}}m",
+        "underMinute": "<1m",
+        "zero": "0m"
+      },
+      "barLabel": "{{date}}: funcionó {{duration}}, {{tasks}}",
+      "empty": {
+        "title": "Aún no hay tiempo de actividad",
+        "body": "Cuando tus agentes funcionen, su tiempo aparecerá aquí."
+      },
+      "error": "No se pudo cargar el tiempo de actividad. Intenta de nuevo en un momento."
     }
   },
   "toast": {}

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -151,6 +151,35 @@
       "title": "Nenhuma conta conectada",
       "body": "Conecte um provedor de IA para ver quanto dos limites você já usou.",
       "connect": "Conectar um provedor"
+    },
+    "accounts": {
+      "title": "Contas de IA"
+    },
+    "compute": {
+      "title": "Tempo de atividade",
+      "subtitle": "Quanto tempo seus agentes ficaram funcionando e quantas tarefas realizaram.",
+      "range": {
+        "week": "7 dias",
+        "month": "30 dias",
+        "quarter": "3 meses"
+      },
+      "summary": "Seus agentes funcionaram {{duration}}",
+      "tasks_one": "{{count}} tarefa",
+      "tasks_other": "{{count}} tarefas",
+      "runningNow": "Ativo agora",
+      "byAgent": "Por agente",
+      "duration": {
+        "hm": "{{hours}}h {{minutes}}m",
+        "m": "{{minutes}}m",
+        "underMinute": "<1m",
+        "zero": "0m"
+      },
+      "barLabel": "{{date}}: funcionou {{duration}}, {{tasks}}",
+      "empty": {
+        "title": "Ainda não há tempo de atividade",
+        "body": "Quando seus agentes funcionarem, o tempo deles vai aparecer aqui."
+      },
+      "error": "Não foi possível carregar o tempo de atividade. Tente novamente em instantes."
     }
   },
   "toast": {}

--- a/app/tests/compute-usage-model.test.ts
+++ b/app/tests/compute-usage-model.test.ts
@@ -1,0 +1,144 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { ComputeUsageRow } from "@houston-ai/engine-client";
+import {
+  bucketCompute,
+  durationParts,
+  showComputeSection,
+} from "../src/components/usage-view/compute-usage-model.ts";
+
+function row(
+  agentSlug: string,
+  day: string,
+  awakeMs: number,
+  turns = 0,
+  routineRuns = 0,
+): ComputeUsageRow {
+  return { agentSlug, day, awakeMs, activeMs: 0, wakes: 1, turns, routineRuns };
+}
+
+// A fixed Wednesday noon UTC.
+const NOW = Date.UTC(2026, 6, 15, 12, 0, 0);
+
+describe("bucketCompute", () => {
+  it("zero-fills 7 daily buckets ending today (UTC) for the week range", () => {
+    const model = bucketCompute(
+      [row("sales", "2026-07-15", 3_600_000, 2, 1)],
+      "week",
+      NOW,
+    );
+    strictEqual(model.buckets.length, 7);
+    strictEqual(model.buckets[0].startDay, "2026-07-09");
+    strictEqual(model.buckets[6].startDay, "2026-07-15");
+    deepStrictEqual(
+      model.buckets.map((b) => b.runMs),
+      [0, 0, 0, 0, 0, 0, 3_600_000],
+    );
+    strictEqual(model.buckets[6].tasks, 3);
+  });
+
+  it("excludes rows before the range and folds future-dated rows into the last bucket", () => {
+    const model = bucketCompute(
+      [
+        row("sales", "2026-07-08", 999), // day before the 7-day window
+        row("sales", "2026-07-16", 1_000), // clock-skewed "tomorrow"
+      ],
+      "week",
+      NOW,
+    );
+    strictEqual(model.totalRunMs, 1_000);
+    strictEqual(model.buckets[6].runMs, 1_000);
+  });
+
+  it("uses 30 daily buckets for the month range", () => {
+    const model = bucketCompute([], "month", NOW);
+    strictEqual(model.buckets.length, 30);
+    strictEqual(model.buckets[0].startDay, "2026-06-16");
+    strictEqual(model.buckets[29].startDay, "2026-07-15");
+  });
+
+  it("rolls the quarter range into 13 Monday-aligned weekly buckets", () => {
+    const model = bucketCompute(
+      [
+        row("sales", "2026-07-13", 100), // Monday of the current week
+        row("sales", "2026-07-15", 23), // same week -> same bucket
+        row("sales", "2026-07-12", 7), // Sunday -> the PREVIOUS week
+      ],
+      "quarter",
+      NOW,
+    );
+    strictEqual(model.buckets.length, 13);
+    const last = model.buckets[12];
+    strictEqual(last.startDay, "2026-07-13");
+    strictEqual(last.days, 7);
+    strictEqual(last.runMs, 123);
+    strictEqual(model.buckets[11].runMs, 7);
+  });
+
+  it("aggregates per agent, busiest first with slug tie-break", () => {
+    const model = bucketCompute(
+      [
+        row("b-agent", "2026-07-14", 50, 1, 0),
+        row("a-agent", "2026-07-14", 50, 0, 2),
+        row("big", "2026-07-15", 900, 3, 0),
+      ],
+      "week",
+      NOW,
+    );
+    deepStrictEqual(
+      model.perAgent.map((a) => a.agentSlug),
+      ["big", "a-agent", "b-agent"],
+    );
+    deepStrictEqual(
+      model.perAgent.map((a) => a.tasks),
+      [3, 2, 1],
+    );
+    strictEqual(model.totalRunMs, 1_000);
+    strictEqual(model.totalTasks, 6);
+  });
+
+  it("floors bar maxima at 1 so empty data never divides by zero", () => {
+    const model = bucketCompute([], "week", NOW);
+    strictEqual(model.maxBucketMs, 1);
+    strictEqual(model.maxAgentMs, 1);
+  });
+});
+
+describe("durationParts", () => {
+  it("classifies zero, sub-minute, minutes, and hours with padded minutes", () => {
+    deepStrictEqual(durationParts(0), { kind: "zero" });
+    deepStrictEqual(durationParts(30_000), { kind: "underMinute" });
+    deepStrictEqual(durationParts(45 * 60_000), {
+      kind: "minutes",
+      minutes: 45,
+    });
+    deepStrictEqual(durationParts(125 * 60_000), {
+      kind: "hoursMinutes",
+      hours: 2,
+      minutes: "05",
+    });
+    // No day rollover: 25h stays hours.
+    deepStrictEqual(durationParts(25 * 3_600_000), {
+      kind: "hoursMinutes",
+      hours: 25,
+      minutes: "00",
+    });
+  });
+
+  it("rounds 59.6 minutes up into the hours form, never '60m'", () => {
+    deepStrictEqual(durationParts(59 * 60_000 + 36_000), {
+      kind: "hoursMinutes",
+      hours: 1,
+      minutes: "00",
+    });
+  });
+});
+
+describe("showComputeSection", () => {
+  it("is on only when the gateway advertises computeUsage: true", () => {
+    strictEqual(showComputeSection(null), false);
+    strictEqual(showComputeSection(undefined), false);
+    strictEqual(showComputeSection({ computeUsage: false } as never), false);
+    strictEqual(showComputeSection({ computeUsage: true } as never), true);
+  });
+});

--- a/packages/fake-host/src/router.ts
+++ b/packages/fake-host/src/router.ts
@@ -140,6 +140,16 @@ export async function handle(req: Request): Promise<Response> {
       state.setCapabilities((body ?? {}) as Partial<FakeCapabilities>),
     );
   }
+  // Arm the compute-usage dataset `GET /v1/org/compute-usage` serves (pair with
+  // `/__test__/capabilities` `{computeUsage:true}`); `{seed:null}` disarms.
+  if (path === "/__test__/compute-usage" && method === "POST") {
+    const body = await parseBody(req);
+    return json({
+      seed: state.setComputeUsage(
+        (body?.seed ?? null) as state.ComputeUsageSeed | null,
+      ),
+    });
+  }
   // Arm the Teams settings the gateway serves at the settings routes below:
   // the agent + org integration ceilings, the model ceiling, and agent access.
   if (path === "/__test__/agent-settings" && method === "POST") {

--- a/packages/fake-host/src/routes-teams.ts
+++ b/packages/fake-host/src/routes-teams.ts
@@ -83,6 +83,25 @@ export function handleTeamsRoutes(
     return json({ error: "not found" }, 404);
   }
 
+  // /v1/org/compute-usage — per-agent running time (awake/active ms per UTC
+  // day). Served only when a spec armed a dataset via `/__test__/compute-usage`;
+  // unarmed it 404s like a desktop host or a pre-feature gateway. `asOf` is
+  // minted at read time — the wire promises a server clock, not a fixed seed.
+  if (
+    segs[0] === "v1" &&
+    segs[1] === "org" &&
+    segs[2] === "compute-usage" &&
+    segs.length === 3
+  ) {
+    const seed = state.getComputeUsage();
+    if (method !== "GET" || !seed) return json({ error: "not found" }, 404);
+    return json({
+      asOf: new Date().toISOString(),
+      awakeNow: seed.awakeNow,
+      rows: seed.rows,
+    });
+  }
+
   // /v1/org/settings — the org-wide app + AI-model ceilings.
   if (
     segs[0] === "v1" &&

--- a/packages/fake-host/src/state-store.ts
+++ b/packages/fake-host/src/state-store.ts
@@ -75,7 +75,29 @@ export interface CustomIntegrationSeed {
 export type FakeCapabilities = Capabilities & {
   teams?: boolean;
   spaces?: boolean;
+  computeUsage?: boolean;
 };
+
+/**
+ * A `GET /v1/org/compute-usage` row — one (agent, UTC day)'s engine running
+ * time. Mirrors `@houston-ai/engine-client`'s `ComputeUsageRow` exactly so the
+ * mock can't drift from the wire.
+ */
+export interface ComputeUsageSeedRow {
+  agentSlug: string;
+  day: string;
+  awakeMs: number;
+  activeMs: number;
+  wakes: number;
+  turns: number;
+  routineRuns: number;
+}
+
+/** The armed compute-usage dataset (`/__test__/compute-usage`). */
+export interface ComputeUsageSeed {
+  rows: ComputeUsageSeedRow[];
+  awakeNow: string[];
+}
 
 /** A caller's effective per-agent access (Teams v2). Mirrors the wire enum. */
 export type AgentAccess = "manager" | "user";
@@ -167,6 +189,12 @@ export interface HostState {
   capabilities: FakeCapabilities;
   /** Teams v2 integration/model ceilings, armed by `/__test__/agent-settings`. */
   teamsSettings: TeamsSettings;
+  /**
+   * Compute usage (running time), armed by `/__test__/compute-usage`. `null`
+   * (the default) = the gateway does not serve the feature: the route 404s,
+   * mirroring desktop/self-host and pre-feature gateways.
+   */
+  computeUsage: ComputeUsageSeed | null;
   /** Composio readiness, toggled by the `/__test__/integrations-mode` control. */
   integrationsMode: IntegrationsMode;
   /**
@@ -252,6 +280,7 @@ function freshState(): HostState {
     routineSeq: 0,
     capabilities: { ...DEFAULT_CAPABILITIES },
     teamsSettings: { ...DEFAULT_TEAMS_SETTINGS },
+    computeUsage: null,
     integrationsMode: "ready",
     customIntegrations: null,
     connections,

--- a/packages/fake-host/src/state-teams.ts
+++ b/packages/fake-host/src/state-teams.ts
@@ -11,7 +11,11 @@
  * surface, mirroring how `state-integrations.ts` operates on the shared `state`.
  */
 
-import type { FakeCapabilities, TeamsSettings } from "./state-store";
+import type {
+  ComputeUsageSeed,
+  FakeCapabilities,
+  TeamsSettings,
+} from "./state-store";
 import { state } from "./state-store";
 
 /** The capabilities served at `GET /v1/capabilities`. */
@@ -44,4 +48,21 @@ export function getTeamsSettings(): TeamsSettings {
 export function setTeamsSettings(patch: Partial<TeamsSettings>): TeamsSettings {
   state.teamsSettings = { ...state.teamsSettings, ...patch };
   return state.teamsSettings;
+}
+
+/** The armed compute-usage dataset; `null` = the route 404s (feature off). */
+export function getComputeUsage(): ComputeUsageSeed | null {
+  return state.computeUsage;
+}
+
+/**
+ * Arm (or disarm with `null`) the compute-usage dataset the gateway serves at
+ * `GET /v1/org/compute-usage` (the `/__test__/compute-usage` control). Specs
+ * usually pair it with `/__test__/capabilities` `{ computeUsage: true }`.
+ */
+export function setComputeUsage(
+  seed: ComputeUsageSeed | null,
+): ComputeUsageSeed | null {
+  state.computeUsage = seed;
+  return state.computeUsage;
 }

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -1,6 +1,7 @@
 import { existsSync, rmSync } from "node:fs";
 import type { Server } from "node:http";
 import { basename, dirname, join } from "node:path";
+import { loadRoutineRuns } from "@houston/domain";
 import type { Capabilities } from "@houston/protocol";
 import type { ObjectStore } from "@houston/runtime-client/object-sync";
 import { SingleUserVerifier } from "../auth/verify";
@@ -28,6 +29,7 @@ import { RuntimeProcessSpawner } from "../launcher/runtime-spawner";
 import { migrateAgentLayouts } from "../migrate/agent-layout";
 import { migrateChatHistory } from "../migrate/chat-history";
 import { LocalPaths } from "../paths";
+import type { ChannelCtx } from "../ports";
 import { forward } from "../proxy/route";
 import { ChannelRoutineFirer } from "../schedule/firer";
 import { Scheduler } from "../schedule/scheduler";
@@ -36,6 +38,7 @@ import { syncSharedEndpoint } from "../shared-endpoint/sync";
 import { LocalWorkspaceStore } from "../store/local";
 import { StoreSyncDaemon } from "../store-sync";
 import { MemoryTurnBus } from "../turn/bus";
+import { UsageSampler } from "../usage/sampler";
 import { FsVfs } from "../vfs";
 import { FsWatcher } from "../watch/watcher";
 import { formatHostListeningBanner } from "./banner";
@@ -168,6 +171,17 @@ export interface LocalHostOptions {
     quietMs?: number;
     intervalMs?: number;
     maxHydrateBytes?: number;
+  };
+  /**
+   * Managed-pod active-time reporting: sample this pod's busy state and report
+   * per-day totals to the gateway's compute-usage ingest. Same env quadruple as
+   * `credentials` — absent on desktop/self-host, where no sampler ever runs.
+   */
+  usageReporting?: {
+    url: string;
+    orgSlug: string;
+    agentSlug: string;
+    podToken: string;
   };
 }
 
@@ -476,6 +490,35 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
         log: (message, err) => console.error(message, err ?? ""),
       })
     : undefined;
+  // Managed pods sample their own busy state (the gateway can only see AWAKE
+  // from outside) and report per-day active totals to the compute-usage ingest.
+  const usageSampler = opts.usageReporting
+    ? new UsageSampler({
+        report: opts.usageReporting,
+        listAgents: async () => {
+          const out: ChannelCtx[] = [];
+          for (const ws of await store.listWorkspaces()) {
+            for (const agent of await store.listAgents(ws.id)) {
+              out.push({ workspace: ws, agent });
+            }
+          }
+          return out;
+        },
+        // The activityStatus busy logic MINUS activeRequests: an open UI tab's
+        // SSE subscription keeps the pod awake but is not the agent working.
+        turnBusy: (ctx) => channel.busy(ctx),
+        runningRoutineRuns: async (ctx) => {
+          const runs = await loadRoutineRuns(
+            vfs,
+            paths.agentRoot(ctx.workspace, ctx.agent),
+          );
+          return runs.items
+            .filter((run) => run.status === "running")
+            .map((run) => run.id);
+        },
+        log: (message, err) => console.error(message, err ?? ""),
+      })
+    : undefined;
   let stopPromise: Promise<void> | undefined;
 
   return {
@@ -542,6 +585,7 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
         watcher.start();
         syncDaemon?.start();
         scheduler.start();
+        usageSampler?.start();
       }
       console.log(formatIntegrationsModeLog(opts.integrations));
       // The banner the Tauri supervisor parses (mirrors the runtime's contract).
@@ -580,6 +624,9 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
       stopPromise = (async () => {
         scheduler.stop();
         watcher.stop();
+        // Drain the last accrued stretch before the runtimes go down; the
+        // sampler swallows report failures, so this never blocks a shutdown.
+        await usageSampler?.stop();
         // Await actual child exit (bounded): the final sync below must not
         // walk /data while a runtime is still flushing its last writes.
         await launcher.shutdownAllAndWait();

--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -168,6 +168,9 @@ const host = buildLocalHost({
   gatewayFronted: process.env.HOUSTON_MANAGED_CLOUD === "1",
   credentials: remoteGateway,
   sharedEndpoints: remoteGateway,
+  // Active-time reporting rides the same managed-pod gateway quadruple: the
+  // env being present IS the switch (desktop/self-host never set it).
+  usageReporting: remoteGateway,
   // Migration-source spawns (HOU-719): serve + migrate on boot, but never fire
   // routines or churn watch events while the cloud app reads the old tree.
   passive: process.env.HOUSTON_PASSIVE === "1",

--- a/packages/host/src/usage/sampler.test.ts
+++ b/packages/host/src/usage/sampler.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import type { ChannelCtx } from "../ports";
+import { UsageSampler, type UsageSamplerOptions } from "./sampler";
+
+const CTX = {
+  workspace: { id: "Personal" },
+  agent: { id: "Personal/Alfred" },
+} as unknown as ChannelCtx;
+
+/** Noon UTC on a fixed day — far from midnight unless a test wants it. */
+const NOON = Date.UTC(2026, 6, 15, 12, 0, 0);
+
+function build(overrides: Partial<UsageSamplerOptions> = {}) {
+  const state = {
+    now: NOON,
+    turnBusy: false,
+    runIds: [] as string[],
+    requests: [] as { url: string; body: unknown }[],
+    responseStatus: 200,
+    fetchError: null as Error | null,
+    logs: [] as string[],
+  };
+  const sampler = new UsageSampler({
+    report: {
+      url: "https://gw.example/",
+      orgSlug: "org1",
+      agentSlug: "agent1",
+      podToken: "tok",
+    },
+    listAgents: async () => [CTX],
+    turnBusy: async () => state.turnBusy,
+    runningRoutineRuns: async () => state.runIds,
+    now: () => state.now,
+    fetchImpl: (async (url: string, init: RequestInit) => {
+      if (state.fetchError) throw state.fetchError;
+      state.requests.push({ url, body: JSON.parse(init.body as string) });
+      return { ok: state.responseStatus < 400, status: state.responseStatus };
+    }) as unknown as typeof fetch,
+    log: (message) => state.logs.push(message),
+    ...overrides,
+  });
+  return { sampler, state };
+}
+
+interface ReportBody {
+  bootId: string;
+  days: { day: string; activeMs: number; turns: number; routineRuns: number }[];
+}
+
+function body(state: { requests: { body: unknown }[] }, index: number) {
+  const request = state.requests.at(index);
+  if (!request) throw new Error(`no request at index ${index}`);
+  return request.body as ReportBody;
+}
+
+const lastBody = (state: { requests: { body: unknown }[] }) => body(state, -1);
+
+function lastDay(state: { requests: { body: unknown }[] }) {
+  const day = lastBody(state).days[0];
+  if (!day) throw new Error("report carried no days");
+  return day;
+}
+
+describe("UsageSampler", () => {
+  it("accrues busy time and caps a late tick at twice the sample interval", async () => {
+    const { sampler, state } = build();
+    await sampler.tick(); // establishes lastTickAt, idle
+    state.turnBusy = true;
+    state.now += 5_000;
+    await sampler.tick();
+    // A starved loop: 60s since the last tick must credit at most 10s.
+    state.now += 60_000;
+    await sampler.tick();
+    await sampler.flush();
+    expect(lastBody(state).days).toEqual([
+      { day: "2026-07-15", activeMs: 15_000, turns: 1, routineRuns: 0 },
+    ]);
+  });
+
+  it("does not accrue while idle", async () => {
+    const { sampler, state } = build();
+    await sampler.tick();
+    state.now += 5_000;
+    await sampler.tick();
+    await sampler.flush();
+    expect(state.requests).toHaveLength(0);
+  });
+
+  it("splits a busy stretch across the UTC midnight boundary", async () => {
+    const { sampler, state } = build();
+    state.now = Date.UTC(2026, 6, 15, 23, 59, 58);
+    await sampler.tick();
+    state.turnBusy = true;
+    state.now += 5_000; // 23:59:58 -> 00:00:03 next day
+    await sampler.tick();
+    await sampler.flush();
+    expect(lastBody(state).days).toEqual([
+      { day: "2026-07-15", activeMs: 2_000, turns: 0, routineRuns: 0 },
+      { day: "2026-07-16", activeMs: 3_000, turns: 1, routineRuns: 0 },
+    ]);
+  });
+
+  it("counts rising edges once per turn and per routine run", async () => {
+    const { sampler, state } = build();
+    await sampler.tick();
+    state.turnBusy = true;
+    state.runIds = ["run-a"];
+    state.now += 5_000;
+    await sampler.tick();
+    state.now += 5_000;
+    await sampler.tick(); // same turn + run still going: no new counts
+    state.turnBusy = false;
+    state.runIds = [];
+    state.now += 5_000;
+    await sampler.tick();
+    state.turnBusy = true;
+    state.runIds = ["run-b"];
+    state.now += 5_000;
+    await sampler.tick();
+    await sampler.flush();
+    expect(lastDay(state).turns).toBe(2);
+    expect(lastDay(state).routineRuns).toBe(2);
+  });
+
+  it("reports cumulative totals so a replayed flush is idempotent server-side", async () => {
+    const { sampler, state } = build();
+    await sampler.tick();
+    state.turnBusy = true;
+    state.now += 5_000;
+    await sampler.tick();
+    await sampler.flush();
+    state.now += 5_000;
+    await sampler.tick();
+    await sampler.flush();
+    expect(state.requests).toHaveLength(2);
+    expect(body(state, 0).days[0]?.activeMs).toBe(5_000);
+    expect(lastDay(state).activeMs).toBe(10_000);
+    // Same boot: the gateway GREATEST-upserts on (bootId, day).
+    expect(body(state, 0).bootId).toBe(lastBody(state).bootId);
+  });
+
+  it("keeps the accumulator through rejected and failed reports, logging each failure once", async () => {
+    const { sampler, state } = build();
+    await sampler.tick();
+    state.turnBusy = true;
+    state.now += 5_000;
+    await sampler.tick();
+    state.responseStatus = 404;
+    await sampler.flush();
+    await sampler.flush();
+    expect(state.logs.filter((l) => l.includes("404"))).toHaveLength(1);
+    state.fetchError = new Error("network down");
+    await sampler.flush();
+    expect(state.logs.some((l) => l.includes("network down"))).toBe(true);
+    state.fetchError = null;
+    state.responseStatus = 200;
+    await sampler.flush();
+    expect(lastDay(state).activeMs).toBe(5_000);
+  });
+
+  it("stop() drains a final sample and flush", async () => {
+    const { sampler, state } = build();
+    await sampler.tick();
+    state.turnBusy = true;
+    state.now += 5_000;
+    await sampler.stop();
+    expect(lastDay(state).activeMs).toBe(5_000);
+    await sampler.stop(); // idempotent
+    expect(state.requests).toHaveLength(1);
+  });
+
+  it("never accrues or reports after a failed sample", async () => {
+    const { sampler, state } = build({
+      turnBusy: async () => {
+        throw new Error("runtime probe exploded");
+      },
+    });
+    await sampler.tick();
+    state.now += 5_000;
+    await sampler.tick();
+    await sampler.flush();
+    expect(state.requests).toHaveLength(0);
+    expect(state.logs.some((l) => l.includes("sample failed"))).toBe(true);
+  });
+});

--- a/packages/host/src/usage/sampler.ts
+++ b/packages/host/src/usage/sampler.ts
@@ -1,0 +1,196 @@
+import { randomUUID } from "node:crypto";
+import type { ChannelCtx } from "../ports";
+
+/**
+ * Managed-pod active-time sampler.
+ *
+ * The gateway meters how long this pod is AWAKE from the outside; what it
+ * cannot see is how much of that time the agent spent actually executing
+ * (turns run inside the runtime subprocess — this host only has the `/busy`
+ * probe). So the pod samples its own busy state every few seconds, accrues
+ * per-UTC-day totals, and reports them CUMULATIVELY (per boot, per day) to the
+ * gateway's pod-usage ingest. Cumulative + GREATEST-upsert server-side makes
+ * at-least-once flushing exact: a lost response self-heals on the next flush
+ * and a crash loses at most one flush interval.
+ *
+ * Constructed ONLY on managed cloud pods (the HOUSTON_CREDENTIALS_URL env
+ * quadruple); desktop and self-host never build one. Reporting is accounting,
+ * never load-bearing: every failure is logged and swallowed — this daemon has
+ * no user action to surface to (the beta silent-failure rule's watcher/daemon
+ * exception) and must never take a pod down.
+ */
+
+interface DayTotals {
+  activeMs: number;
+  turns: number;
+  routineRuns: number;
+}
+
+export interface UsageSamplerOptions {
+  /** Gateway ingest target — the managed-pod env quadruple. */
+  report: { url: string; orgSlug: string; agentSlug: string; podToken: string };
+  /** Every (workspace, agent) this host serves (a managed pod hosts one). */
+  listAgents(): Promise<ChannelCtx[]>;
+  /**
+   * Whether a turn is executing in this agent's runtime right now. Must not
+   * wake anything (ProxyChannel.busy short-circuits on a non-running runtime).
+   */
+  turnBusy(ctx: ChannelCtx): Promise<boolean>;
+  /** Ids of this agent's routine runs currently in "running" state. */
+  runningRoutineRuns(ctx: ChannelCtx): Promise<string[]>;
+  sampleMs?: number;
+  flushMs?: number;
+  /** Test seams. */
+  now?: () => number;
+  fetchImpl?: typeof fetch;
+  log?: (message: string, err?: unknown) => void;
+}
+
+const DAY_MS = 86_400_000;
+const dayOf = (ts: number) => new Date(ts).toISOString().slice(0, 10);
+
+export class UsageSampler {
+  private readonly bootId = randomUUID();
+  private readonly days = new Map<string, DayTotals>();
+  private readonly prevTurnBusy = new Map<string, boolean>();
+  private readonly prevRunIds = new Map<string, Set<string>>();
+  private readonly sampleMs: number;
+  private readonly flushMs: number;
+  private readonly now: () => number;
+  private readonly log: (message: string, err?: unknown) => void;
+  private lastTickAt = 0;
+  private lastFailure: string | null = null;
+  private timers: ReturnType<typeof setInterval>[] = [];
+  private stopped = false;
+
+  constructor(private readonly opts: UsageSamplerOptions) {
+    this.sampleMs = opts.sampleMs ?? 5_000;
+    this.flushMs = opts.flushMs ?? 60_000;
+    this.now = opts.now ?? Date.now;
+    this.log = opts.log ?? ((m, e) => console.error(m, e ?? ""));
+  }
+
+  start(): void {
+    this.lastTickAt = this.now();
+    this.timers = [
+      setInterval(() => void this.tick(), this.sampleMs),
+      setInterval(() => void this.flush(), this.flushMs),
+    ];
+  }
+
+  /** Final sample + flush; used as the pod's SIGTERM drain hook. */
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    for (const t of this.timers) clearInterval(t);
+    await this.tick();
+    await this.flush();
+  }
+
+  /** One busy sample. Exposed for tests; production runs it on the interval. */
+  async tick(): Promise<void> {
+    const now = this.now();
+    // Cap the credited stretch so a suspended/starved event loop (or a missed
+    // tick) never counts dead time as active — bounded undercount, like the
+    // gateway's awake accounting.
+    const elapsed = Math.min(
+      Math.max(0, now - this.lastTickAt),
+      2 * this.sampleMs,
+    );
+    this.lastTickAt = now;
+    let busy = false;
+    try {
+      for (const ctx of await this.opts.listAgents()) {
+        const id = ctx.agent.id;
+        const turnBusy = await this.opts.turnBusy(ctx);
+        if (turnBusy && !this.prevTurnBusy.get(id)) {
+          this.totals(dayOf(now)).turns += 1;
+        }
+        this.prevTurnBusy.set(id, turnBusy);
+        const running = new Set(await this.opts.runningRoutineRuns(ctx));
+        const prev = this.prevRunIds.get(id);
+        for (const runId of running) {
+          if (!prev?.has(runId)) this.totals(dayOf(now)).routineRuns += 1;
+        }
+        this.prevRunIds.set(id, running);
+        busy ||= turnBusy || running.size > 0;
+      }
+    } catch (err) {
+      // A failed sample loses ≤ one sampleMs of attribution; never crash a pod
+      // over accounting.
+      this.log("[usage-sampler] sample failed (skipping tick):", err);
+      return;
+    }
+    if (busy && elapsed > 0) this.credit(now - elapsed, now);
+  }
+
+  /** Report today's (± yesterday's) cumulative totals. Never throws. */
+  async flush(): Promise<void> {
+    const today = dayOf(this.now());
+    const yesterday = dayOf(this.now() - DAY_MS);
+    // Days that scrolled out of the reporting window are done — the gateway
+    // rejects them anyway; drop them so a long-lived pod stays bounded.
+    for (const day of this.days.keys()) {
+      if (day !== today && day !== yesterday) this.days.delete(day);
+    }
+    const entries = [yesterday, today]
+      .filter((day, i, all) => all.indexOf(day) === i)
+      .map((day) => ({ day, ...this.days.get(day) }))
+      .filter((e) => e.activeMs !== undefined) as Array<
+      { day: string } & DayTotals
+    >;
+    if (entries.length === 0) return;
+    const { url, orgSlug, agentSlug, podToken } = this.opts.report;
+    const target = `${url.replace(/\/+$/, "")}/v1/pod/usage/${encodeURIComponent(orgSlug)}/${encodeURIComponent(agentSlug)}`;
+    try {
+      const fetchImpl = this.opts.fetchImpl ?? fetch;
+      const res = await fetchImpl(target, {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${podToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ bootId: this.bootId, days: entries }),
+      });
+      if (!res.ok) {
+        // A 404 is an older gateway that doesn't serve the ingest yet
+        // (deploy-order tolerance); anything else is worth a look. Either way
+        // keep accumulating — totals are cumulative, the next flush self-heals.
+        this.failure(`[usage-sampler] report rejected: ${res.status}`);
+        return;
+      }
+      this.lastFailure = null;
+    } catch (err) {
+      this.failure(
+        `[usage-sampler] report failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private totals(day: string): DayTotals {
+    let t = this.days.get(day);
+    if (!t) {
+      t = { activeMs: 0, turns: 0, routineRuns: 0 };
+      this.days.set(day, t);
+    }
+    return t;
+  }
+
+  /** Attribute a busy stretch to UTC days, splitting at midnight. */
+  private credit(fromTs: number, toTs: number): void {
+    let from = fromTs;
+    while (from < toTs) {
+      const nextMidnight = Math.floor(from / DAY_MS + 1) * DAY_MS;
+      const end = Math.min(toTs, nextMidnight);
+      this.totals(dayOf(from)).activeMs += end - from;
+      from = end;
+    }
+  }
+
+  /** Log each distinct failure once, not every 60s forever. */
+  private failure(message: string): void {
+    if (this.lastFailure === message) return;
+    this.lastFailure = message;
+    this.log(message);
+  }
+}

--- a/packages/web/e2e/usage-compute.spec.ts
+++ b/packages/web/e2e/usage-compute.spec.ts
@@ -1,0 +1,150 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * The Usage page's "Running time" (compute) section — hosted-cloud analytics of
+ * how long each agent's engine ran per day. The section exists ONLY where the
+ * gateway advertises `capabilities.computeUsage` (desktop/self-host never do),
+ * and its data comes from `GET /v1/org/compute-usage`, armed here via the fake
+ * host's `/__test__/compute-usage` control. See `@houston/fake-host` README +
+ * `knowledge-base/ui-testing.md`.
+ */
+
+const DAY_MS = 86_400_000;
+const day = (daysAgo: number) =>
+  new Date(Date.now() - daysAgo * DAY_MS).toISOString().slice(0, 10);
+
+function row(
+  agentSlug: string,
+  daysAgo: number,
+  awakeMs: number,
+  turns = 0,
+  routineRuns = 0,
+) {
+  return {
+    agentSlug,
+    day: day(daysAgo),
+    awakeMs,
+    activeMs: Math.floor(awakeMs / 2),
+    wakes: 1,
+    turns,
+    routineRuns,
+  };
+}
+
+async function armComputeUsage(
+  request: APIRequestContext,
+  seed: { rows: unknown[]; awakeNow: string[] } | null,
+): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/capabilities`, {
+    data: { computeUsage: seed !== null },
+  });
+  await request.post(`${FAKE_HOST_URL}/__test__/compute-usage`, {
+    data: { seed },
+  });
+}
+
+// ── 1. Desktop/self-host guard: no capability, no section, no fetch ────────
+
+test("without the computeUsage capability the Usage page shows only AI accounts", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.locator('[data-tour-target="nav-usage"]').click();
+
+  await expect(page.getByRole("heading", { name: "Usage" })).toBeVisible();
+  // The compute section and its companion "AI accounts" sub-heading are both
+  // absent — the page is byte-identical to the pre-feature layout.
+  await expect(page.getByRole("heading", { name: "Running time" })).toHaveCount(
+    0,
+  );
+  await expect(page.getByRole("heading", { name: "AI accounts" })).toHaveCount(
+    0,
+  );
+});
+
+// ── 2. Armed + seeded: summary, bars, per-agent rows ────────────────────────
+
+test("with data the section shows the total, daily bars, and per-agent rows", async ({
+  page,
+  request,
+}) => {
+  await armComputeUsage(request, {
+    rows: [
+      // Seed agent: resolves to its display name. 2h05m today + 1h yesterday.
+      row("houston-assistant", 0, 125 * 60_000, 8, 2),
+      row("houston-assistant", 1, 60 * 60_000, 3, 0),
+      // A since-deleted agent humanizes from its slug.
+      row("sales-bot", 1, 30 * 60_000, 1, 0),
+    ],
+    awakeNow: ["houston-assistant"],
+  });
+  await page.goto("/");
+  await page.locator('[data-tour-target="nav-usage"]').click();
+
+  await expect(
+    page.getByRole("heading", { name: "Running time" }),
+  ).toBeVisible();
+  // 2h05 + 1h + 30m = 3h 35m across 14 tasks (10 + 3 + 1).
+  await expect(page.getByText("Your agents ran 3h 35m")).toBeVisible();
+  await expect(page.getByText("14 tasks")).toBeVisible();
+
+  // 7 daily bars, each self-describing ("Jul 15: ran 2h 05m, 10 tasks").
+  await expect(page.getByRole("img", { name: /: ran / })).toHaveCount(7);
+
+  // Per-agent rows: the seed agent resolves to its display name and wears the
+  // running badge (3h 05m across 13 tasks); the deleted slug humanizes.
+  const houston = page.getByRole("listitem").filter({ hasText: "Houston" });
+  await expect(houston.getByText("Running now")).toBeVisible();
+  await expect(houston).toContainText("3h 05m");
+  await expect(houston).toContainText("13 tasks");
+  const sales = page.getByRole("listitem").filter({ hasText: "Sales bot" });
+  await expect(sales).toContainText("30m");
+  await expect(sales).toContainText("1 task");
+
+  // The AI-accounts half keeps its own sub-heading below the compute section.
+  await expect(
+    page.getByRole("heading", { name: "AI accounts" }),
+  ).toBeVisible();
+});
+
+// ── 3. Range switch re-buckets locally ──────────────────────────────────────
+
+test("switching the range changes the bar count without a new fetch", async ({
+  page,
+  request,
+}) => {
+  await armComputeUsage(request, {
+    rows: [row("houston-assistant", 0, 60 * 60_000, 1, 0)],
+    awakeNow: [],
+  });
+  await page.goto("/");
+  await page.locator('[data-tour-target="nav-usage"]').click();
+
+  const bars = page.getByRole("img", { name: /: ran / });
+  await expect(bars).toHaveCount(7);
+  await page.getByRole("tab", { name: "30 days" }).click();
+  await expect(bars).toHaveCount(30);
+  await page.getByRole("tab", { name: "3 months" }).click();
+  await expect(bars).toHaveCount(13);
+});
+
+// ── 4. Armed but no data yet: the honest empty state ───────────────────────
+
+test("with the capability but no rows the section shows its empty state", async ({
+  page,
+  request,
+}) => {
+  await armComputeUsage(request, { rows: [], awakeNow: [] });
+  await page.goto("/");
+  await page.locator('[data-tour-target="nav-usage"]').click();
+
+  await expect(
+    page.getByRole("heading", { name: "Running time" }),
+  ).toBeVisible();
+  await expect(page.getByText("No running time yet")).toBeVisible();
+  await expect(
+    page.getByText("When your agents run, their time will show here."),
+  ).toBeVisible();
+});

--- a/packages/web/src/engine-adapter/client/teams-mixin.ts
+++ b/packages/web/src/engine-adapter/client/teams-mixin.ts
@@ -82,6 +82,13 @@ export function TeamsMixin<TBase extends BaseCtor>(Base: TBase) {
         throw new Error("multiplayer requires the hosted gateway");
       return controlPlane.orgUsage(this.ctx.cp, days);
     }
+    // Tripwire only: the UI gates the compute section (and its query) on
+    // `capabilities.computeUsage`, which no gateway-less deployment advertises.
+    async computeUsage(days: number): Promise<controlPlane.ComputeUsage> {
+      if (!this.ctx.cp)
+        throw new Error("compute usage requires the hosted gateway");
+      return controlPlane.computeUsage(this.ctx.cp, days);
+    }
 
     // Grants degrade gracefully: `null` means "this deployment has no grants
     // model" (the legacy engine path, or a host that 404s the route), which the UI

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -29,6 +29,8 @@ export type {
   AuditEntry,
   BillingCheckout,
   BillingSummary,
+  ComputeUsage,
+  ComputeUsageRow,
   CustomIntegrationView,
   IntegrationConnection,
   IntegrationProviderStatus,

--- a/packages/web/src/engine-adapter/cp/orgs.ts
+++ b/packages/web/src/engine-adapter/cp/orgs.ts
@@ -1,6 +1,7 @@
 import type {
   AddOrgMemberResult,
   AuditEntry,
+  ComputeUsage,
   OrgInfo,
   OrgRole,
   OrgSettings,
@@ -95,4 +96,15 @@ export async function orgUsage(
     `/v1/org/usage?days=${encodeURIComponent(days.toString())}`,
   );
   return ((await res.json()) as { rows: UsageRow[] }).rows;
+}
+
+export async function computeUsage(
+  cfg: ControlPlaneConfig,
+  days: number,
+): Promise<ComputeUsage> {
+  const res = await cpFetch(
+    cfg,
+    `/v1/org/compute-usage?days=${encodeURIComponent(days.toString())}`,
+  );
+  return (await res.json()) as ComputeUsage;
 }

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -39,6 +39,7 @@ import type {
   ComposioStartLinkResponse,
   ComposioStartLoginResponse,
   ComposioStatus,
+  ComputeUsage,
   ConversationEntry,
   CreateAgent,
   CreateAgentResult,
@@ -1616,6 +1617,19 @@ export class HoustonClient {
         days: days.toString(),
       })
     ).rows;
+  }
+  /**
+   * Per-agent compute usage (engine running time) over the last `days`, scoped
+   * server-side to the agents the caller can access. Only deployments that
+   * advertise `capabilities.computeUsage` serve it. Host clamps `days` to ≤ 90.
+   */
+  async computeUsage(days: number): Promise<ComputeUsage> {
+    return await this.request<ComputeUsage>(
+      "GET",
+      "/org/compute-usage",
+      undefined,
+      { days: days.toString() },
+    );
   }
   /**
    * The integration toolkit slugs granted to this agent, or `null` when the host

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -115,6 +115,13 @@ export interface Capabilities {
    * that predate the public API. The gateway is the sole enforcer.
    */
   apiKeys?: boolean;
+  /**
+   * Whether this deployment serves per-agent compute analytics — how long each
+   * agent's engine was running (`GET /v1/org/compute-usage`). Gateway-injected,
+   * hosted-cloud only; absent/false on desktop/self-host and on gateways that
+   * predate it. Feature-detect flag only — the gateway is the sole enforcer.
+   */
+  computeUsage?: boolean;
 }
 
 // ---------- Org / roles (multiplayer) ----------
@@ -404,6 +411,33 @@ export interface UsageRow {
   userId: string;
   day: string;
   messages: number;
+}
+
+/**
+ * One compute-usage row from `GET /org/compute-usage`: engine running time for
+ * an (agent, day) tuple. `day` is a `YYYY-MM-DD` UTC date. `awakeMs` is the
+ * wall-clock the agent's engine was up that day (today's row includes the
+ * currently-open stretch up to `ComputeUsage.asOf`); `activeMs` is the subset
+ * spent actually executing turns/routine runs (recorded for later use, not
+ * rendered yet — never sum it with `awakeMs`).
+ */
+export interface ComputeUsageRow {
+  agentSlug: string;
+  day: string;
+  awakeMs: number;
+  activeMs: number;
+  wakes: number;
+  turns: number;
+  routineRuns: number;
+}
+
+/** Response of `GET /org/compute-usage`. Days with no data have no row. */
+export interface ComputeUsage {
+  /** Server clock when the snapshot was taken (RFC 3339). */
+  asOf: string;
+  /** Slugs of agents whose engine is up right now — their "today" still grows. */
+  awakeNow: string[];
+  rows: ComputeUsageRow[];
 }
 
 // ---------- Workspaces ----------


### PR DESCRIPTION
## What

The Usage page gains a **Running time** section on hosted cloud: how long each agent's engine ran per day (7-day / 30-day / 13-week views), a task count (turns + routine runs), and a per-agent breakdown with a live "Running now" badge. Desktop/self-host are untouched.

One time metric is shown to the user (running time = engine up-time, in plain language). The wire also carries `activeMs` (time actually executing) — recorded for a later efficiency/billing view, deliberately not rendered so non-technical users see a single number.

## How

- **Capability**: new optional `computeUsage` flag on the engine-client `Capabilities` (gateway-injected, `apiKeys` precedent). The section mounts only when advertised, which also gates the query — no fetch can fire on deployments without the endpoint.
- **Client chain**: `ComputeUsage` types + `computeUsage(days)` in `@houston-ai/engine-client` → `teams-mixin` → `cpFetch` `GET /v1/org/compute-usage?days=N`. One 90-day fetch, bucketed client-side (`compute-usage-model.ts`, pure + unit-tested); refresh every minute while an agent is running, else every five.
- **UI**: app-local tokened bar chart (single series, aria-labeled bars, native tooltips, zero-days render as ticks) + per-agent rows mirroring the org Usage tab's bar style. `aiHub` `usage.compute.*` strings in en/es/pt (no "awake"/"compute"/"pod" in user copy).
- **Pod sampler** (`packages/host/src/usage/sampler.ts`): managed pods sample turn-busy + running routine runs every 5s (open SSE tabs excluded), accrue per-UTC-day totals, and PUT cumulative reports to the gateway pod-usage ingest every 60s + on drain. Constructed only under the managed-cloud env quadruple; desktop/self-host build no sampler. Reporting failures log once and never surface — accounting must never take a pod down.
- **fake-host**: `/v1/org/compute-usage` + `/__test__/compute-usage` seed control.

## Tests

- `app/tests/compute-usage-model.test.ts` — bucketing (UTC boundaries, zero-fill, ISO weeks), per-agent aggregation, duration parts, capability gate.
- `packages/host/src/usage/sampler.test.ts` — accrual cap, midnight split, rising-edge counters, cumulative/idempotent flush, 404 + network resilience, drain, never-throws.
- `packages/web/e2e/usage-compute.spec.ts` — no capability → unchanged page; seeded → summary/bars/rows; range switch re-buckets; empty state. Full suite: 125/125.
- Gates: `pnpm check`, `pnpm typecheck`, app `tsgo` + `check-locales`, `check:boundaries`, host/runtime/domain vitest all green.

## Rollout

Ships dark: the section appears once the gateway serves `/v1/org/compute-usage` and advertises `computeUsage: true` (same deploy). The sampler tolerates a 404 from older gateways, so deploy order is free.

