### PR TITLE
feat(create-agent): model picker in the Create-with-AI step

### DIFF
--- a/app/src/components/shell/ai-assist-step.tsx
+++ b/app/src/components/shell/ai-assist-step.tsx
@@ -1,15 +1,25 @@
-import { DialogTitle } from "@houston-ai/core";
+import {
+  cn,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@houston-ai/core";
 import type { SuggestedRoutine } from "@houston-ai/engine-client";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { genericErrorDescription } from "../../lib/error-toast";
 import { tauriAgents } from "../../lib/tauri";
+import { ChatModelSelector } from "../chat-model-selector";
 import { AgentBriefForm } from "./agent-brief-form";
 import { AiStepFooter } from "./ai-step-footer";
 
 interface AiAssistStepProps {
   provider: string;
   model: string;
+  /** Picker changes lift to the dialog: the pair drives this generation turn
+   * AND becomes the created agent's brain. Effort has no control here — the
+   * engine runs reasoning models at its default (medium). */
+  onModelChange: (provider: string, model: string) => void;
   /** The consultant brief lives in the dialog so navigating back from the
    * routine/review steps doesn't wipe the user's typed text. */
   brief: string;
@@ -26,6 +36,7 @@ interface AiAssistStepProps {
 export function AiAssistStep({
   provider,
   model,
+  onModelChange,
   brief,
   onBriefChange,
   onBack,
@@ -77,19 +88,40 @@ export function AiAssistStep({
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <DialogTitle className="sr-only">{t("aiAssist.stepTitle")}</DialogTitle>
+      {/* Fixed header, the same pattern as the picker step: the title never
+          scrolls away and renders at the dialog's standard size. The model
+          row sits right under it — the user picks the generation brain
+          before writing the brief. */}
+      <DialogHeader className="shrink-0 px-6 pt-6 pb-4 border-b border-ink/[0.06]">
+        <div className="max-w-2xl mx-auto w-full space-y-2">
+          <DialogTitle>{t("aiAssist.stepTitle")}</DialogTitle>
+          <DialogDescription>{t("aiAssist.stepDescription")}</DialogDescription>
+          <div className="flex items-center gap-2.5 pt-1">
+            <span className="text-sm text-ink-muted">
+              {t("aiAssist.modelLabel")}
+            </span>
+            {/* ChatModelSelector has no disabled prop; gate interaction while a
+                generation is in flight so the request's brain can't drift. The
+                border gives the bare pill a visible select affordance. */}
+            <div
+              className={cn(
+                "rounded-lg border border-line bg-chip",
+                generating && "pointer-events-none opacity-50",
+              )}
+            >
+              <ChatModelSelector
+                provider={provider}
+                model={model}
+                onSelect={onModelChange}
+                agent={null}
+              />
+            </div>
+          </div>
+        </div>
+      </DialogHeader>
 
       <div className="flex-1 min-h-0 overflow-y-auto px-6 pb-6 pt-6">
         <div className="max-w-2xl mx-auto space-y-6">
-          <div>
-            <h2 className="text-base font-semibold">
-              {t("aiAssist.stepTitle")}
-            </h2>
-            <p className="text-sm text-ink-muted">
-              {t("aiAssist.stepDescription")}
-            </p>
-          </div>
-
           <AgentBriefForm
             value={brief}
             onChange={onBriefChange}

--- a/app/src/components/shell/create-workspace-dialog.tsx
+++ b/app/src/components/shell/create-workspace-dialog.tsx
@@ -72,10 +72,10 @@ export function CreateAgentDialog() {
   const [model, setModel] = useState<string>(getDefaultModel("anthropic"));
 
   // Reset form on close. On open, load the sticky last-used provider/model —
-  // there is no picker in this flow anymore; the pair silently becomes the new
-  // agent's brain (and the generation brain on the AI path). Reading on open
-  // (not mount) prevents the old "stale workspace default baked into the new
-  // agent's config" bug.
+  // the pair becomes the new agent's brain (and the generation brain on the AI
+  // path, where the ai-assist step shows a picker to change it). Reading on
+  // open (not mount) prevents the old "stale workspace default baked into the
+  // new agent's config" bug.
   useEffect(() => {
     if (!open) {
       setStep(1);
@@ -108,6 +108,16 @@ export function CreateAgentDialog() {
 
   const handleClose = () => {
     setOpen(false);
+  };
+
+  // A pick in the ai-assist step drives the generation turn, becomes the new
+  // agent's brain, and sticks as the next dialog's default. `setLastUsed`
+  // surfaces its own error toast (the `call` wrapper), so the local state —
+  // which is what this create actually uses — is applied regardless.
+  const handleModelChange = (nextProvider: string, nextModel: string) => {
+    setProvider(nextProvider);
+    setModel(nextModel);
+    tauriProvider.setLastUsed(nextProvider, nextModel).catch(() => {});
   };
 
   const handleCreateAgent = async () => {
@@ -257,6 +267,7 @@ export function CreateAgentDialog() {
           <AiAssistStep
             provider={provider}
             model={model}
+            onModelChange={handleModelChange}
             brief={brief}
             onBriefChange={setBrief}
             onBack={() => setStep(1)}

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -252,6 +252,7 @@
       "reports": "Every Friday I compile a team status report from scattered updates and sheets",
       "research": "I need market and competitor research summarized into briefs I can share"
     },
+    "modelLabel": "AI model",
     "generateButton": "Design my agent",
     "generatingMessage": "Your consultant is designing the agent...",
     "cancelButton": "Cancel",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -252,6 +252,7 @@
       "reports": "Cada viernes armo un informe de estado del equipo a partir de actualizaciones y hojas dispersas",
       "research": "Necesito investigación de mercado y de la competencia resumida en informes que pueda compartir"
     },
+    "modelLabel": "Modelo de IA",
     "generateButton": "Diseñar mi agente",
     "generatingMessage": "Tu consultor está diseñando el agente...",
     "cancelButton": "Cancelar",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -252,6 +252,7 @@
       "reports": "Toda sexta eu monto um relatório de status da equipe a partir de atualizações e planilhas espalhadas",
       "research": "Preciso de pesquisa de mercado e da concorrência resumida em briefings que eu possa compartilhar"
     },
+    "modelLabel": "Modelo de IA",
     "generateButton": "Projetar meu agente",
     "generatingMessage": "Seu consultor está desenhando o agente...",
     "cancelButton": "Cancelar",

--- a/packages/runtime/src/session/generate-agent.test.ts
+++ b/packages/runtime/src/session/generate-agent.test.ts
@@ -1,5 +1,20 @@
 import { expect, test } from "vitest";
+import { generateThinkingLevel } from "./generate-agent";
 import { buildRoutine, parseGenerateResult } from "./generate-agent-parse";
+
+// --- generateThinkingLevel: the create dialog has no effort control, so a
+// reasoning model is pinned to "medium" and everything else omits the level. ---
+
+test("reasoning models generate at medium effort", () => {
+  expect(generateThinkingLevel({ reasoning: true })).toBe("medium");
+});
+
+test("non-reasoning models omit the thinking level", () => {
+  expect(generateThinkingLevel({ reasoning: false })).toBeUndefined();
+  expect(generateThinkingLevel({})).toBeUndefined();
+  expect(generateThinkingLevel(null)).toBeUndefined();
+  expect(generateThinkingLevel(undefined)).toBeUndefined();
+});
 
 // Ported from the Rust engine's generate_instructions.rs + suggested_routine.rs
 // unit tests, so the TS parser accepts exactly what the Rust one did.

--- a/packages/runtime/src/session/generate-agent.ts
+++ b/packages/runtime/src/session/generate-agent.ts
@@ -1,4 +1,5 @@
 import type { GenerateAgentResponse } from "@houston/runtime-client";
+import { DEFAULT_REASONING_EFFORT, type PiThinkingLevel } from "../ai/effort";
 import {
   buildActiveCustomModel,
   OPENAI_COMPATIBLE,
@@ -70,6 +71,20 @@ export function resolveGenerateModel(provider?: string, model?: string) {
 }
 
 /**
+ * The generation turn's reasoning level. The create dialog's picker offers no
+ * effort control, so a reasoning-capable model always runs at "medium" (the
+ * same default a chat turn applies when the user chose nothing; pi clamps it
+ * to the model). Non-reasoning models omit the level entirely.
+ */
+export function generateThinkingLevel(
+  model: unknown,
+): PiThinkingLevel | undefined {
+  const reasons =
+    (model as { reasoning?: boolean } | null | undefined)?.reasoning === true;
+  return reasons ? DEFAULT_REASONING_EFFORT : undefined;
+}
+
+/**
  * Generate agent instructions from a plain-language description. `provider` /
  * `model` are pi ids (the adapter migrates legacy ids before calling).
  */
@@ -77,13 +92,15 @@ export async function generateAgentInstructions(
   description: string,
   opts: { provider?: string; model?: string } = {},
 ): Promise<GenerateAgentResponse> {
+  const model = resolveGenerateModel(opts.provider, opts.model);
   const raw = await oneShotText({
     cwd: config.workspaceDir,
-    model: resolveGenerateModel(opts.provider, opts.model),
+    model,
     authStorage,
     modelRegistry,
     systemPrompt: GENERATE_PROMPT,
     prompt: description,
+    thinkingLevel: generateThinkingLevel(model),
   });
   return parseGenerateResult(raw);
 }

--- a/packages/runtime/src/session/one-shot.ts
+++ b/packages/runtime/src/session/one-shot.ts
@@ -6,6 +6,7 @@ import {
   type ModelRegistry,
   SessionManager,
 } from "@earendil-works/pi-coding-agent";
+import type { PiThinkingLevel } from "../ai/effort";
 
 export interface OneShotOptions {
   cwd: string;
@@ -14,6 +15,9 @@ export interface OneShotOptions {
   modelRegistry: ModelRegistry;
   systemPrompt: string;
   prompt: string;
+  /** Reasoning level for the turn. Omit to leave pi's own default in place
+   *  (settings-dependent), pass one to pin it — pi clamps to the model. */
+  thinkingLevel?: PiThinkingLevel;
 }
 
 /**
@@ -45,6 +49,7 @@ export async function oneShotText(opts: OneShotOptions): Promise<string> {
     sessionManager: SessionManager.inMemory(opts.cwd),
     resourceLoader: loader,
     tools: [],
+    ...(opts.thinkingLevel ? { thinkingLevel: opts.thinkingLevel } : {}),
   });
 
   let text = "";


### PR DESCRIPTION
## What

The Create-with-AI step of the new-agent dialog now shows a model picker, so the user chooses which provider/model designs their agent. Until now the pair was taken silently from the last-used selection, with no visible control.

### UI (`app/src`)
- `ai-assist-step.tsx`: the step now uses the dialog's standard fixed header (`DialogHeader`/`DialogTitle` + description) instead of a small `h2` inside the scroll area, so the title renders at full size and never scrolls away. The **AI model** row sits directly under the title, before the brief form: the shared `ChatModelSelector` pill on a bordered chip background so it reads as a control. It locks (dimmed, non-interactive) while a generation is in flight so the request's brain can't drift.
- `create-workspace-dialog.tsx`: a pick updates the dialog's provider/model state (which already drives both the generation request and the created agent's brain) and persists via `setLastUsed`, so it sticks as the next default.
- Locales: new `aiAssist.modelLabel` in en/es/pt.

### Runtime (`packages/runtime`)
- The generation one-shot previously set no thinking level, so reasoning-capable models ran with reasoning off. `generateAgentInstructions` now pins reasoning models to `medium` (`DEFAULT_REASONING_EFFORT`, same default as a chat turn; pi clamps to the model). Non-reasoning models are untouched. Effort is decided runtime-side, so there is no effort control in the dialog and no wire change — identical on desktop and cloud pods.

## Tests
- New unit tests for `generateThinkingLevel` (medium for reasoning models, omitted otherwise); runtime suite 658/658 green.
- Biome, app/web tsgo, `check-locales`, boundary check all clean.