### PR TITLE
Curate AI model lists: one shared visibility table for picker + AI hub

### DIFF
--- a/app/src/lib/ai-hub/catalog-pi.ts
+++ b/app/src/lib/ai-hub/catalog-pi.ts
@@ -15,6 +15,7 @@
 import type { CatalogModelEntry, ProviderCatalog } from "@houston/protocol";
 import {
   DROP_PI_PROVIDERS,
+  isModelVisible,
   PROVIDER_ID_RENAME,
 } from "../provider-overrides.ts";
 import { normalizeKey } from "./catalog-key.ts";
@@ -53,14 +54,12 @@ function entryToRaw(entry: CatalogModelEntry): RawModel {
  * the picker render exactly the same providers (a coming-soon or otherwise-gated
  * provider in the raw catalog never becomes a hub model the picker can't offer).
  *
- * Every provider carries its FULL pi model list — subscription/OAuth providers
- * included. The hub, the provider modal, and the chat model picker must offer
- * the SAME runnable set: the picker maps the hydrated `PROVIDERS` (pi's full
- * per-provider list, deduped) directly, so filtering OAuth providers down to
- * `PROVIDER_OVERRIDES[id].models` here made the hub show 3 Anthropic models
- * while the chat picker offered 10. The overrides remain presentation-only
- * (labels/descriptions); pi's catalog is the single existence source, and pi
- * ≥0.80 already prunes retired ids upstream.
+ * Model curation: the hub, the provider modal, and the chat model picker must
+ * offer the SAME set, so both apply the ONE shared gate — `isModelVisible`
+ * (`VISIBLE_MODELS` in `provider-overrides.ts`), the same table `buildProvider`
+ * filters the hydrated `PROVIDERS` with. A provider without a `VISIBLE_MODELS`
+ * entry carries its full pi model list. Hidden ids stay runnable on the wire;
+ * pi's catalog remains the single existence source.
  */
 export function piCatalogToCandidates(
   catalog: ProviderCatalog,
@@ -73,6 +72,7 @@ export function piCatalogToCandidates(
     if (visibleIds && !visibleIds.has(providerId)) continue;
     const subscription = provider.auth === "oauth";
     for (const entry of provider.models) {
+      if (!isModelVisible(providerId, entry.id)) continue;
       const raw = entryToRaw(entry);
       candidates.push({
         providerId,

--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -141,6 +141,52 @@ export function toCanonicalProviderId(id: string): string {
 export const DROP_PI_PROVIDERS: ReadonlySet<string> = new Set(["openai"]);
 
 /**
+ * Curated per-provider VISIBLE model sets, keyed by Houston (display) provider
+ * id. A provider WITH an entry surfaces only these pi model ids; a provider
+ * without one shows its full pi catalog. Both model surfaces read this one
+ * table — the chat model picker (via `buildProvider` in `providers.ts`) and the
+ * AI-hub models directory (via `piCatalogToCandidates`) — so the two can never
+ * drift apart. Curation is presentation-only: a hidden id stays runnable on the
+ * wire (an existing conversation pinned to one keeps working); it just can't be
+ * picked anymore.
+ *
+ * Every id here must exist in the shipped pi-ai catalog — the drift guard
+ * (`provider-overrides-drift.test.ts`) rejects orphans.
+ */
+export const VISIBLE_MODELS: Readonly<Record<string, ReadonlySet<string>>> = {
+  openai: new Set([
+    "gpt-5.5",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.3-codex-spark",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+  ]),
+  anthropic: new Set([
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+  ]),
+  // NOTE: pi-ai ships no plain `gemini-3.1-flash` (only the Lite tier), so the
+  // 3.1 line is represented by Flash Lite here.
+  google: new Set([
+    "gemini-3.5-flash",
+    "gemini-3.1-flash-lite",
+    "gemma-4-26b-a4b-it",
+    "gemma-4-31b-it",
+  ]),
+};
+
+/** Whether `modelId` may surface for `providerId` (a Houston display id). */
+export function isModelVisible(providerId: string, modelId: string): boolean {
+  const visible = VISIBLE_MODELS[providerId];
+  return !visible || visible.has(modelId);
+}
+
+/**
  * The local OpenAI-compatible provider (Ollama / LM Studio / vLLM, direct or via
  * a tunnel). pi-ai has no such provider — the user supplies a base URL + model id
  * at runtime — so it is appended to the hydrated catalog verbatim. Gated by the
@@ -195,16 +241,28 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
         description: "OpenAI's frontier model.",
       },
       "gpt-5.6-sol": {
-        label: "Sol",
+        label: "GPT-5.6 Sol",
         description: "OpenAI's newest frontier model.",
       },
       "gpt-5.6-terra": {
-        label: "Terra",
+        label: "GPT-5.6 Terra",
         description: "Balanced mid-tier model.",
       },
       "gpt-5.6-luna": {
-        label: "Luna",
+        label: "GPT-5.6 Luna",
         description: "Fast and cost-efficient for simpler tasks.",
+      },
+      "gpt-5.3-codex-spark": {
+        label: "GPT-5.3 Codex Spark",
+        description: "Ultra-fast coding model.",
+      },
+      "gpt-5.4": {
+        label: "GPT-5.4",
+        description: "Strong model for everyday coding.",
+      },
+      "gpt-5.4-mini": {
+        label: "GPT-5.4 mini",
+        description: "Small, fast, and cost-efficient for simpler tasks.",
       },
     },
   },
@@ -219,16 +277,25 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     models: {
       "claude-sonnet-5": {
         label: "Sonnet 5",
-        description: "Best balance of speed and quality.",
-      },
-      "claude-opus-4-8": {
-        label: "Opus 4.8",
-        description:
-          "Anthropic's flagship. Strong agentic coding and alignment.",
+        description: "Newest Sonnet. Stronger agentic coding and tool use.",
       },
       "claude-fable-5": {
         label: "Fable 5",
         description: "Most capable model. Costs 2x more credits than Opus 4.8.",
+      },
+      "claude-opus-4-8": {
+        label: "Opus 4.8",
+        description:
+          "Latest Opus. Better alignment and agentic coding than 4.7.",
+      },
+      "claude-opus-4-7": {
+        label: "Opus 4.7",
+        description:
+          "Previous flagship. Strong coding autonomy and complex reasoning.",
+      },
+      "claude-sonnet-4-6": {
+        label: "Sonnet 4.6",
+        description: "Best balance of speed and quality.",
       },
     },
   },
@@ -405,23 +472,23 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     cost: "Free tier on your Google account",
     installUrl: "https://ai.google.dev",
     apiKeyUrl: "https://aistudio.google.com/apikey",
-    defaultModel: "gemini-3-flash-preview",
+    defaultModel: "gemini-3.5-flash",
     models: {
-      "gemini-3-flash-preview": {
-        label: "Gemini 3 Flash",
+      "gemini-3.5-flash": {
+        label: "Gemini 3.5 Flash",
         description: "Fast and capable. Best default.",
       },
-      "gemini-3-pro-preview": {
-        label: "Gemini 3 Pro",
-        description: "Google's most capable, slower.",
+      "gemini-3.1-flash-lite": {
+        label: "Gemini 3.1 Flash Lite",
+        description: "Lightweight and quick for simpler tasks.",
       },
-      "gemini-2.5-flash": {
-        label: "Gemini 2.5 Flash",
-        description: "Previous fast model.",
+      "gemma-4-26b-a4b-it": {
+        label: "Gemma 4 26B A4B IT",
+        description: "Google's open Gemma model. Fast and efficient.",
       },
-      "gemini-2.5-pro": {
-        label: "Gemini 2.5 Pro",
-        description: "Previous flagship.",
+      "gemma-4-31b-it": {
+        label: "Gemma 4 31B IT",
+        description: "Google's open Gemma model. More capable.",
       },
     },
   },

--- a/app/src/lib/providers.test.mjs
+++ b/app/src/lib/providers.test.mjs
@@ -94,9 +94,11 @@ const SAMPLE_CATALOG = [
     rm("deepseek-v4-pro", 1000000),
   ]),
   prov("google", "apiKey", [
-    rm("gemini-3-flash-preview", 1048576),
-    rm("gemini-3-pro-preview", 1048576),
-    rm("gemini-2.5-flash", 1048576),
+    rm("gemini-3.5-flash", 1048576),
+    rm("gemini-3.1-flash-lite", 1048576),
+    tm("gemma-4-26b-a4b-it", 131072),
+    tm("gemma-4-31b-it", 131072),
+    // Runnable but NOT in VISIBLE_MODELS.google — hidden from both surfaces.
     rm("gemini-2.5-pro", 1048576),
   ]),
   prov("amazon-bedrock", "apiKey", [
@@ -577,10 +579,34 @@ test("model contextWindow: the Anthropic flagships credit-gate 1M behind a 200k 
   }
   // Gemini via the native google provider is already correct in pi (1,048,576),
   // so it gets NO override — the bar and the engine both divide by the full 1M.
-  assert.deepEqual(getContextWindowConfig("google", "gemini-3-flash-preview"), {
+  assert.deepEqual(getContextWindowConfig("google", "gemini-3.5-flash"), {
     default: 1_048_576,
     max: 1_048_576,
   });
+});
+
+test("VISIBLE_MODELS curation filters the hydrated catalog per provider", () => {
+  // A curated provider hydrates to EXACTLY its visible set (fixture carries the
+  // hidden gemini-2.5-pro), in pi catalog order.
+  assert.deepEqual(
+    getProvider("google").models.map((m) => m.id),
+    [
+      "gemini-3.5-flash",
+      "gemini-3.1-flash-lite",
+      "gemma-4-26b-a4b-it",
+      "gemma-4-31b-it",
+    ],
+  );
+  // A hidden id resolves like any unknown model: not pickable, nulled by
+  // validModelOrNull (curation is presentation-only; the wire still runs it).
+  assert.equal(validModelOrNull("google", "gemini-2.5-pro"), null);
+  // An uncurated provider keeps its full pi list.
+  assert.equal(getProvider("github-copilot").models.length, 7);
+  assert.ok(
+    getProvider("github-copilot").models.some(
+      (m) => m.id === "gemini-3-flash-preview",
+    ),
+  );
 });
 
 test("buildProvider dedupes models that fold to one hub key within a provider", () => {

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -7,6 +7,7 @@ import type { Capabilities } from "@houston-ai/engine-client";
 import { normalizeKey } from "./ai-hub/catalog-key.ts";
 import {
   DROP_PI_PROVIDERS,
+  isModelVisible,
   LOCAL_PROVIDER,
   PROVIDER_ID_RENAME,
   PROVIDER_OVERRIDES,
@@ -190,7 +191,13 @@ function buildProvider(
   finalId: string,
   override: ProviderOverride | undefined,
 ): ProviderInfo {
-  const models: ModelOption[] = dedupeModelEntries(piProvider.models).map(
+  // Curated providers (`VISIBLE_MODELS`) surface only their curated ids; the
+  // AI-hub directory applies the same gate (`piCatalogToCandidates`), so the
+  // picker and the hub always show the identical set.
+  const visibleEntries = piProvider.models.filter((entry) =>
+    isModelVisible(finalId, entry.id),
+  );
+  const models: ModelOption[] = dedupeModelEntries(visibleEntries).map(
     (entry) => {
       const mo = override?.models?.[entry.id];
       const effort =

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -182,6 +182,9 @@
     },
     "modelDescriptions": {
       "gpt-5_5": "OpenAI's frontier model.",
+      "gpt-5_6-sol": "OpenAI's newest frontier model.",
+      "gpt-5_6-terra": "Balanced mid-tier model.",
+      "gpt-5_6-luna": "Fast and cost-efficient for simpler tasks.",
       "gpt-5_4": "Strong model for everyday coding.",
       "gpt-5_4-mini": "Small, fast, and cost-efficient for simpler tasks.",
       "gpt-5_3-codex-spark": "Ultra-fast coding model.",
@@ -189,7 +192,11 @@
       "claude-sonnet-4-6": "Best balance of speed and quality.",
       "claude-opus-4-8": "Latest Opus. Better alignment and agentic coding than 4.7.",
       "claude-fable-5": "Most capable model. Costs 2x more credits than Opus 4.8.",
-      "claude-opus-4-7": "Previous flagship. Strong coding autonomy and complex reasoning."
+      "claude-opus-4-7": "Previous flagship. Strong coding autonomy and complex reasoning.",
+      "gemini-3_5-flash": "Fast and capable. Best default.",
+      "gemini-3_1-flash-lite": "Lightweight and quick for simpler tasks.",
+      "gemma-4-26b-a4b-it": "Google's open Gemma model. Fast and efficient.",
+      "gemma-4-31b-it": "Google's open Gemma model. More capable."
     }
   },
   "reasoning": {

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -182,6 +182,9 @@
     },
     "modelDescriptions": {
       "gpt-5_5": "El modelo más avanzado de OpenAI.",
+      "gpt-5_6-sol": "El modelo más reciente y avanzado de OpenAI.",
+      "gpt-5_6-terra": "Modelo intermedio equilibrado.",
+      "gpt-5_6-luna": "Rápido y económico para tareas más simples.",
       "gpt-5_4": "Modelo potente para programar a diario.",
       "gpt-5_4-mini": "Pequeño, rápido y económico para tareas más simples.",
       "gpt-5_3-codex-spark": "Modelo de programación ultrarrápido.",
@@ -189,7 +192,11 @@
       "claude-sonnet-4-6": "Mejor equilibrio entre velocidad y calidad.",
       "claude-opus-4-8": "Opus mas reciente. Mejor alineamiento y codigo agente que 4.7.",
       "claude-fable-5": "El modelo mas capaz. Consume el doble de creditos que Opus 4.8.",
-      "claude-opus-4-7": "Modelo anterior. Autonomia de codigo y razonamiento complejo."
+      "claude-opus-4-7": "Modelo anterior. Autonomia de codigo y razonamiento complejo.",
+      "gemini-3_5-flash": "Rápido y capaz. La mejor opción por defecto.",
+      "gemini-3_1-flash-lite": "Ligero y veloz para tareas más simples.",
+      "gemma-4-26b-a4b-it": "Modelo abierto Gemma de Google. Rápido y eficiente.",
+      "gemma-4-31b-it": "Modelo abierto Gemma de Google. Más capaz."
     }
   },
   "reasoning": {

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -182,6 +182,9 @@
     },
     "modelDescriptions": {
       "gpt-5_5": "O modelo mais avançado da OpenAI.",
+      "gpt-5_6-sol": "O modelo mais recente e avançado da OpenAI.",
+      "gpt-5_6-terra": "Modelo intermediário equilibrado.",
+      "gpt-5_6-luna": "Rápido e econômico para tarefas mais simples.",
       "gpt-5_4": "Modelo forte para programação do dia a dia.",
       "gpt-5_4-mini": "Pequeno, rápido e econômico para tarefas mais simples.",
       "gpt-5_3-codex-spark": "Modelo de programação ultrarrápido.",
@@ -189,7 +192,11 @@
       "claude-sonnet-4-6": "Melhor equilibrio entre velocidade e qualidade.",
       "claude-opus-4-8": "Opus mais recente. Melhor alinhamento e codigo agente que 4.7.",
       "claude-fable-5": "O modelo mais capaz. Consome o dobro de creditos que Opus 4.8.",
-      "claude-opus-4-7": "Modelo anterior. Autonomia de codigo e raciocinio complexo."
+      "claude-opus-4-7": "Modelo anterior. Autonomia de codigo e raciocinio complexo.",
+      "gemini-3_5-flash": "Rápido e capaz. A melhor opção padrão.",
+      "gemini-3_1-flash-lite": "Leve e veloz para tarefas mais simples.",
+      "gemma-4-26b-a4b-it": "Modelo aberto Gemma do Google. Rápido e eficiente.",
+      "gemma-4-31b-it": "Modelo aberto Gemma do Google. Mais capaz."
     }
   },
   "reasoning": {

--- a/app/tests/catalog-pi.test.ts
+++ b/app/tests/catalog-pi.test.ts
@@ -117,39 +117,46 @@ describe("piCatalogToCandidates maps the pi-ai catalog to merge candidates", () 
   });
 });
 
-describe("piCatalogToCandidates never filters a provider's model list", () => {
-  // The hub and the chat model picker must offer the SAME runnable set. The
-  // picker maps the hydrated PROVIDERS (pi's full per-provider list) directly,
-  // so the hub must not trim OAuth providers to the curated override set —
-  // that skew showed 3 Anthropic models in the hub against 10 in the picker.
+describe("piCatalogToCandidates applies the shared VISIBLE_MODELS curation", () => {
+  // The hub and the chat model picker must offer the SAME set, so both apply
+  // the ONE `isModelVisible` gate (`VISIBLE_MODELS` in provider-overrides.ts):
+  // a curated provider surfaces only its curated ids, an uncurated provider
+  // keeps its full pi list. Hidden ids stay runnable on the wire.
   const catalog: ProviderCatalog = [
     provider("anthropic", "oauth", [
-      // Has a PROVIDER_OVERRIDES.anthropic.models entry (label/description).
+      // In VISIBLE_MODELS.anthropic — surfaces.
       entry("claude-sonnet-5"),
-      // No override entry — still runnable, must still surface.
+      // Runnable but NOT in VISIBLE_MODELS.anthropic — hidden.
       entry("claude-haiku-4-5"),
+    ]),
+    provider("google", "apiKey", [
+      entry("gemini-3.5-flash"),
+      // Runnable but NOT in VISIBLE_MODELS.google — hidden.
+      entry("gemini-2.5-pro"),
     ]),
     provider("groq", "apiKey", [entry("llama-4-scout")]),
   ];
   const candidates = piCatalogToCandidates(catalog);
 
-  it("keeps an OAuth model with a curated override", () => {
+  it("keeps a curated provider's visible models", () => {
     ok(
       candidates.some(
         (c) => c.providerId === "anthropic" && c.raw.id === "claude-sonnet-5",
       ),
     );
-  });
-
-  it("keeps an OAuth model without any override entry", () => {
     ok(
       candidates.some(
-        (c) => c.providerId === "anthropic" && c.raw.id === "claude-haiku-4-5",
+        (c) => c.providerId === "google" && c.raw.id === "gemini-3.5-flash",
       ),
     );
   });
 
-  it("keeps an API-key gateway's full list", () => {
+  it("drops a curated provider's hidden models", () => {
+    ok(!candidates.some((c) => c.raw.id === "claude-haiku-4-5"));
+    ok(!candidates.some((c) => c.raw.id === "gemini-2.5-pro"));
+  });
+
+  it("keeps an uncurated provider's full list", () => {
     ok(
       candidates.some(
         (c) => c.providerId === "groq" && c.raw.id === "llama-4-scout",

--- a/app/tests/fixtures/sample-catalog.ts
+++ b/app/tests/fixtures/sample-catalog.ts
@@ -79,9 +79,10 @@ export const SAMPLE_CATALOG: ProviderCatalog = [
       // Non-vision fixture entry (`leaves a non-vision model without the image
       // modality` reads this one).
       reasoningModel("gpt-5.6-luna", { contextWindow: 372_000 }),
-      // Uncurated: pi still runs the retired 5.4 line, but the curated set
-      // moved on to the 5.6 family — must be filtered out of the hub.
       reasoningModel("gpt-5.4", { contextWindow: 272_000 }),
+      // NOT in VISIBLE_MODELS.openai: pi still runs it, but the curated set
+      // hides it from the picker AND the hub.
+      reasoningModel("gpt-5.2", { contextWindow: 272_000 }),
     ],
     "ChatGPT subscription",
   ),
@@ -92,10 +93,11 @@ export const SAMPLE_CATALOG: ProviderCatalog = [
     }),
     reasoningModel("claude-opus-4-8", { contextWindow: 1_000_000 }),
     reasoningModel("claude-fable-5", { contextWindow: 1_000_000 }),
-    // Uncurated: pi still runs these prior-generation ids, but the curated
-    // set moved on to Sonnet 5 — must be filtered out of the hub.
     reasoningModel("claude-sonnet-4-6", { contextWindow: 200_000 }),
     reasoningModel("claude-opus-4-7", { contextWindow: 1_000_000 }),
+    // NOT in VISIBLE_MODELS.anthropic: runnable, but curated out of both
+    // model surfaces.
+    reasoningModel("claude-haiku-4-5", { contextWindow: 200_000 }),
   ]),
   provider("github-copilot", "oauth", [
     m("gpt-4.1", { contextWindow: 200_000 }),
@@ -136,9 +138,13 @@ export const SAMPLE_CATALOG: ProviderCatalog = [
     reasoningModel("deepseek-v4-pro", { contextWindow: 1_000_000 }),
   ]),
   provider("google", "apiKey", [
+    reasoningModel("gemini-3.5-flash", { contextWindow: 1_048_576 }),
+    reasoningModel("gemini-3.1-flash-lite", { contextWindow: 1_048_576 }),
+    m("gemma-4-26b-a4b-it", { contextWindow: 131_072 }),
+    m("gemma-4-31b-it", { contextWindow: 131_072 }),
+    // NOT in VISIBLE_MODELS.google: pi runs them (and Copilot / OpenRouter
+    // still offer the 3-flash line), but the native google provider hides them.
     reasoningModel("gemini-3-flash-preview", { contextWindow: 1_048_576 }),
-    reasoningModel("gemini-3-pro-preview", { contextWindow: 1_048_576 }),
-    reasoningModel("gemini-2.5-flash", { contextWindow: 1_048_576 }),
     reasoningModel("gemini-2.5-pro", { contextWindow: 1_048_576 }),
   ]),
   provider("amazon-bedrock", "apiKey", [

--- a/app/tests/hub-catalog.test.ts
+++ b/app/tests/hub-catalog.test.ts
@@ -103,12 +103,11 @@ describe("pricing and subscription flags come from pi", () => {
     strictEqual(opencode?.costOutput, 2);
   });
 
-  it("offers an OAuth provider's FULL pi model list (no curation gate)", () => {
-    // The hub must mirror the chat model picker, which maps the hydrated
-    // PROVIDERS (pi's full per-provider list) directly. The fixture's
-    // `anthropic` provider also runs the prior-generation `claude-sonnet-4-6` /
-    // `claude-opus-4-7` ids with no PROVIDER_OVERRIDES.anthropic.models entry —
-    // they are runnable, so the hub offers them too.
+  it("offers a curated provider EXACTLY its VISIBLE_MODELS set", () => {
+    // The hub must mirror the chat model picker: both apply the shared
+    // `isModelVisible` gate. The fixture's `anthropic` provider also runs
+    // `claude-haiku-4-5`, which is NOT in VISIBLE_MODELS.anthropic — it must
+    // never surface, while the five curated ids all do.
     const ids = new Set<string>();
     for (const model of all.models)
       for (const offer of model.offers)
@@ -119,6 +118,26 @@ describe("pricing and subscription flags come from pi", () => {
       "claude-opus-4-8",
       "claude-sonnet-4-6",
       "claude-sonnet-5",
+    ]);
+  });
+
+  it("hides a curated google model from google while other providers still offer it", () => {
+    // `gemini-3-flash-preview` is in the fixture's google list but NOT in
+    // VISIBLE_MODELS.google — the model survives in the hub only through the
+    // uncurated Copilot / OpenRouter offers.
+    const gemini = all.byKey.get("gemini 3 flash preview");
+    ok(gemini, "expected 'gemini 3 flash preview' via copilot/openrouter");
+    ok(!gemini?.offers.some((o) => o.providerId === "google"));
+    // google's own visible set is exactly the curated one.
+    const ids = new Set<string>();
+    for (const model of all.models)
+      for (const offer of model.offers)
+        if (offer.providerId === "google") ids.add(offer.modelId);
+    deepStrictEqual([...ids].sort(), [
+      "gemini-3.1-flash-lite",
+      "gemini-3.5-flash",
+      "gemma-4-26b-a4b-it",
+      "gemma-4-31b-it",
     ]);
   });
 

--- a/app/tests/provider-overrides-drift.test.ts
+++ b/app/tests/provider-overrides-drift.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   PROVIDER_ID_RENAME,
   PROVIDER_OVERRIDES,
+  VISIBLE_MODELS,
 } from "../src/lib/provider-overrides.ts";
 
 /**
@@ -56,6 +57,24 @@ describe("PROVIDER_OVERRIDES stay in sync with the shipped pi-ai catalog", () =>
         ok(
           pi.getModel(piId, modelId) != null,
           `PROVIDER_OVERRIDES["${houstonId}"].models["${modelId}"] is an orphan: pi-ai (provider "${piId}") ships no such model. Remove it or fix the id.`,
+        );
+      });
+    }
+  }
+});
+
+describe("VISIBLE_MODELS stay in sync with the shipped pi-ai catalog", () => {
+  // A curated visible id pi doesn't ship is a silent hole in the picker AND the
+  // hub (the model simply never appears); an id typo would hide a model the
+  // curation meant to show. Same real-registry read as the overrides guard.
+  for (const [houstonId, visible] of Object.entries(VISIBLE_MODELS)) {
+    const piId = houstonToPi[houstonId] ?? houstonId;
+
+    for (const modelId of visible) {
+      it(`${houstonId}/${modelId} exists in pi-ai`, () => {
+        ok(
+          pi.getModel(piId, modelId) != null,
+          `VISIBLE_MODELS["${houstonId}"] lists "${modelId}", which pi-ai (provider "${piId}") does not ship. Remove it or fix the id.`,
         );
       });
     }

--- a/packages/domain/src/provider-model-catalog.ts
+++ b/packages/domain/src/provider-model-catalog.ts
@@ -70,7 +70,7 @@ export const DEFAULT_MODEL: Partial<Record<ProviderId, string>> = {
   "opencode-go": "glm-5.1",
   openrouter: "anthropic/claude-sonnet-4.6",
   deepseek: "deepseek-v4-flash",
-  google: "gemini-3-flash-preview",
+  google: "gemini-3.5-flash",
   "amazon-bedrock": "anthropic.claude-sonnet-4-6",
   minimax: "MiniMax-M3",
   // No catalog default — the model is whatever the user's local server serves.

--- a/packages/host/src/providers.ts
+++ b/packages/host/src/providers.ts
@@ -115,12 +115,12 @@ export const PROVIDERS: readonly HostProvider[] = [
     // everywhere else (desktop AND the managed pod, via the full pi-ai catalog).
     cloud: false,
     models: [
-      "gemini-3-flash-preview",
-      "gemini-3-pro-preview",
-      "gemini-2.5-flash",
-      "gemini-2.5-pro",
+      "gemini-3.5-flash",
+      "gemini-3.1-flash-lite",
+      "gemma-4-26b-a4b-it",
+      "gemma-4-31b-it",
     ],
-    defaultModel: "gemini-3-flash-preview",
+    defaultModel: "gemini-3.5-flash",
   },
   {
     id: "amazon-bedrock",

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -54,7 +54,7 @@ export const config = {
    */
   githubCopilotModel: env.HOUSTON_GITHUB_COPILOT_MODEL || "gpt-4.1",
   /** Default Google Gemini model (API-key provider). A pi-ai `google` model id. */
-  geminiModel: env.HOUSTON_GEMINI_MODEL || "gemini-3-flash-preview",
+  geminiModel: env.HOUSTON_GEMINI_MODEL || "gemini-3.5-flash",
   /** Default Amazon Bedrock model (API-key provider). A pi-ai `amazon-bedrock` model id. */
   bedrockModel: env.HOUSTON_BEDROCK_MODEL || "anthropic.claude-sonnet-4-6",
   /** Default MiniMax global model (API-key provider). A pi-ai `minimax` model id. */


### PR DESCRIPTION
## What

Synchronizes and curates the model lists shown in the **AI models** section and the **chat model picker**. Both surfaces now read a single `VISIBLE_MODELS` allowlist (`app/src/lib/provider-overrides.ts`), applied in `buildProvider` (picker path) and `piCatalogToCandidates` (hub path) — so the two can never drift apart again.

### Curated lists

| Provider | Models |
|---|---|
| OpenAI | GPT-5.5, GPT-5.6 Sol, GPT-5.6 Terra, GPT-5.6 Luna, GPT-5.3 Codex Spark, GPT-5.4, GPT-5.4 mini |
| Anthropic | Sonnet 5, Fable 5, Opus 4.8, Opus 4.7, Sonnet 4.6 |
| Google Gemini | Gemini 3.5 Flash (new default), Gemini 3.1 Flash Lite, Gemma 4 26B A4B IT, Gemma 4 31B IT |

Providers without an allowlist entry (Copilot, OpenRouter, OpenCode, …) keep their full pi catalog.

> Note: pi-ai ships no plain `gemini-3.1-flash` (only the Lite tier, verified on 0.80.6 and 0.80.7), so the 3.1 line is represented by Flash Lite.

## Details

- Curation is **presentation-only**: hidden ids stay runnable on the wire, so existing conversations pinned to a hidden model keep working.
- GPT-5.6 variants relabeled from bare "Sol"/"Terra"/"Luna" to "GPT-5.6 Sol" etc.
- Google's default model moves off the retired `gemini-3-flash-preview` in the runtime config, the domain migration table, and the host's legacy catalog entry.
- Picker descriptions localized for the newly-surfaced models (en/es/pt).
- Drift guard extended: every `VISIBLE_MODELS` id is validated against the real shipped pi-ai registry, so a typo or retired id fails CI.

## Tests

- `catalog-pi.test.ts` / `hub-catalog.test.ts`: the old "no curation gate" assertions flip to assert the shared gate on both surfaces; fixtures carry hidden models to prove filtering.
- `providers.test.mjs`: hydrated-catalog curation test (curated provider = exact visible set, uncurated provider = full list).
- All gates green: 1,595 app tests, host/runtime/domain vitest, tsgo (app+web), check-locales, Biome, boundaries.