### PR TITLE
fix(usage): honest OpenRouter balance + "not metered yet" copy

### DIFF
--- a/app/src/components/usage-view/usage-provider-card.tsx
+++ b/app/src/components/usage-view/usage-provider-card.tsx
@@ -52,8 +52,10 @@ function CardBody({
   locale: string;
   t: (key: string, options?: Record<string, unknown>) => string;
 }) {
+  // `unsupported` only ever comes from the never-metered fallback (no usage
+  // API + no ledger row yet), so the honest copy is "not measured yet".
   if (!row || row.status === "unsupported") {
-    return <p className="text-xs text-ink-muted">{t("usage.unsupported")}</p>;
+    return <p className="text-xs text-ink-muted">{t("usage.notMeteredYet")}</p>;
   }
   if (row.status === "unauthenticated") {
     return <p className="text-xs text-ink-muted">{t("usage.reconnect")}</p>;

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -147,7 +147,7 @@
     "tokensSplit": "{{input}} in, {{output}} out",
     "meteredSince": "measured by Houston since {{when}}",
     "noData": "This account reports no limits right now.",
-    "unsupported": "This provider doesn't share usage details yet.",
+    "notMeteredYet": "No usage yet. Houston will start measuring with your next message.",
     "reconnect": "Sign in again to see this account's usage.",
     "error": "Couldn't load usage right now. Try again in a moment.",
     "empty": {

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -147,7 +147,7 @@
     "tokensSplit": "{{input}} de entrada, {{output}} de salida",
     "meteredSince": "medido por Houston desde {{when}}",
     "noData": "Esta cuenta no reporta límites por ahora.",
-    "unsupported": "Este proveedor todavía no comparte detalles de uso.",
+    "notMeteredYet": "Aún no hay uso. Houston empezará a medir con tu próximo mensaje.",
     "reconnect": "Inicia sesión de nuevo para ver el uso de esta cuenta.",
     "error": "No pudimos cargar el uso. Intenta de nuevo en un momento.",
     "empty": {

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -147,7 +147,7 @@
     "tokensSplit": "{{input}} de entrada, {{output}} de saída",
     "meteredSince": "medido pela Houston desde {{when}}",
     "noData": "Esta conta não reporta limites no momento.",
-    "unsupported": "Este provedor ainda não compartilha detalhes de uso.",
+    "notMeteredYet": "Ainda não há uso. A Houston vai começar a medir com a sua próxima mensagem.",
     "reconnect": "Entre novamente para ver o uso desta conta.",
     "error": "Não foi possível carregar o uso. Tente de novo em instantes.",
     "empty": {

--- a/packages/runtime/src/ai/usage/credits.ts
+++ b/packages/runtime/src/ai/usage/credits.ts
@@ -51,18 +51,26 @@ export async function fetchOpenRouterUsage(
   const body = (await res.json()) as {
     data?: { total_credits?: unknown; total_usage?: unknown };
   };
-  const total =
-    typeof body.data?.total_credits === "number" ? body.data.total_credits : 0;
-  const used =
-    typeof body.data?.total_usage === "number" ? body.data.total_usage : 0;
+  const total = body.data?.total_credits;
+  const used = body.data?.total_usage;
+  // A missing/renamed field must read as a probe failure, not a $0 balance.
+  if (typeof total !== "number" || typeof used !== "number") {
+    return {
+      provider,
+      status: "error",
+      windows: [],
+      message: "OpenRouter credits response had no readable balance",
+    };
+  }
   return {
     provider,
     status: "ok",
     windows: [],
+    // OpenRouter credits are denominated in USD.
     credits: {
       remaining: Math.max(0, total - used),
       granted: total,
-      unit: "credits",
+      unit: "USD",
     },
     fetchedAt: new Date().toISOString(),
   };

--- a/packages/runtime/src/ai/usage/usage.test.ts
+++ b/packages/runtime/src/ai/usage/usage.test.ts
@@ -189,8 +189,17 @@ describe("credit balances", () => {
     expect(row.credits).toEqual({
       remaining: 19.5,
       granted: 25,
-      unit: "credits",
+      unit: "USD",
     });
+  });
+
+  it("openrouter: an unreadable balance is an error, not a $0 balance", async () => {
+    const row = await fetchOpenRouterUsage(
+      jsonResponse({ data: { credits: 25 } }),
+      keyStore,
+    );
+    expect(row.status).toBe("error");
+    expect(row.credits).toBeUndefined();
   });
 
   it("deepseek: parses the string USD balance", async () => {


### PR DESCRIPTION
- OpenRouter credits are USD: format the remaining balance as currency like DeepSeek instead of a bare number.
- A credits response missing total_credits/total_usage now reports an error row instead of masquerading as a $0 balance.
- The unsupported usage row only ever means "no usage API and nothing metered locally yet", so the card now says Houston will start measuring on the next message instead of blaming the provider.

<!--
Read CONTRIBUTING.md "Before you open a PR" first. PRs that don't fit get closed.
-->

## What this scratches for you

<!-- Required. A bug you hit, or a feature you'll use in Houston. "Thought it would be nice" is not an answer. -->

## Linked issue

<!-- Required for anything >50 LOC or any new tooling/docs/governance. Bug fixes under 50 LOC can skip. -->

Closes #

## Summary

<!-- 1-3 bullets on what changed. -->

-

## Surface impact

<!-- A UI/UX change must not silently skip a surface. Tick what this PR touches.
     Procedure: knowledge-base/client-architecture.md -->

Change type:

- [ ] Behavior (shared SDK view-model — `packages/sdk`)
- [ ] Look (design tokens — `packages/design-tokens`)
- [ ] Structure (a component added/changed → bump `design/inventory/inventory.yaml` + CHANGELOG + update enforced manifests)
- [ ] n-a (no user-facing surface change)

Surfaces updated:

- [ ] Web / desktop
- [ ] iOS
- [ ] Android

<!-- Structural change? `pnpm check:parity` must pass. See design/inventory/README.md. -->

## Checklist

- [ ] I read the diff myself before opening this PR (AI-assisted is fine, AI-unreviewed is not)
- [ ] I have no other open PRs on this repo
- [ ] `pnpm typecheck` passes
- [ ] `cargo check --workspace` passes (if Rust touched)
- [ ] `cargo test --workspace` passes (if Rust touched)
- [ ] No external frameworks/methodology imported into `knowledge-base/` or `docs/`
