### PR TITLE
fix(chat): make pasted links readable inside the user message bubble

### DIFF
--- a/ui/chat/src/ai-elements/message.tsx
+++ b/ui/chat/src/ai-elements/message.tsx
@@ -435,7 +435,7 @@ export const MessageResponse = memo(
                   e.preventDefault();
                   onOpen();
                 }}
-                className="text-action underline-offset-4 hover:underline [overflow-wrap:anywhere]"
+                className="text-action underline-offset-4 hover:underline [overflow-wrap:anywhere] group-[.is-user]:text-input group-[.is-user]:underline dark:group-[.is-user]:text-ink"
               >
                 {children}
               </a>


### PR DESCRIPTION
## Problem

Pasting a bare URL in chat rendered it as an unreadable dark box inside the user message bubble (see screenshot in the report): the autolink anchor uses `text-action`, which resolves to near-black in light mode, while the user bubble background is `bg-ink` (dark). Dark text on a dark bubble.

## Fix

One-line change in `ui/chat/src/ai-elements/message.tsx`: inside the `.is-user` group, the autolink now inherits the bubble's own foreground tokens (`text-input` in light mode, `text-ink` in dark mode) and stays underlined so it still reads as a link. Links in assistant messages are unchanged (`text-action` contrasts correctly there).

## Verification

- `pnpm check` (Biome) clean
- `pnpm typecheck` green across the workspace
- Existing link-classification tests (`ui/chat/test/markdown-link.test.mjs`) unaffected; no logic changed, styling only.
