### PR TITLE
fix(runtime): expire abandoned OAuth logins so they release the callback port

### DIFF
--- a/packages/runtime/src/auth/login.test.ts
+++ b/packages/runtime/src/auth/login.test.ts
@@ -2,13 +2,15 @@ import {
   OPENAI_CODEX_BROWSER_LOGIN_METHOD,
   OPENAI_CODEX_DEVICE_CODE_LOGIN_METHOD,
 } from "@earendil-works/pi-ai/oauth";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import {
   autoPromptAnswer,
   cancelLogin,
   codexLoginMethod,
   getAuthStatus,
   LOCAL_PLACEHOLDER_KEY,
+  LOGIN_TIMEOUT_ERROR,
+  LOGIN_TIMEOUT_MS,
   setApiKey,
   startLogin,
 } from "./login";
@@ -130,4 +132,80 @@ test("LOCAL_PLACEHOLDER_KEY exists for keyless local servers", () => {
   // Ollama/LM Studio ignore the Authorization header, but pi requires SOME key,
   // so a blank key becomes this placeholder.
   expect(LOCAL_PLACEHOLDER_KEY.length).toBeGreaterThan(0);
+});
+
+test("an abandoned login expires: reports 'Login timed out' and frees the flow for a retry", async () => {
+  // An abandoned flow held pi's OAuth callback server bound to the provider's
+  // fixed port (Codex: 1455) FOREVER, blocking every future sign-in for that
+  // provider machine-wide. The expiry tears the flow down like cancelLogin but
+  // records the attempt as a failure so status polls surface it.
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  try {
+    const first = await startLogin("anthropic");
+    expect(first.kind).toBe("auth_code");
+
+    await vi.advanceTimersByTimeAsync(LOGIN_TIMEOUT_MS + 1);
+
+    const row = (await getAuthStatus()).providers.find(
+      (p) => p.provider === "anthropic",
+    );
+    expect(row?.login?.status).toBe("error");
+    expect(row?.login?.error).toBe(LOGIN_TIMEOUT_ERROR);
+
+    // The paste promise was rejected (flow unwound, port freed), so a retry
+    // builds a FRESH login instead of reusing the dead one.
+    const second = await startLogin("anthropic");
+    expect(second).not.toBe(first);
+    cancelLogin("anthropic");
+    await vi.advanceTimersByTimeAsync(100);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("reusing an in-flight login re-arms the abandonment clock", async () => {
+  // A second connect click near the deadline idempotently reuses the live flow
+  // — the user just asked to sign in, so they get the FULL window again, not
+  // the stale remainder of the first click's.
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  try {
+    const first = await startLogin("anthropic");
+    await vi.advanceTimersByTimeAsync(LOGIN_TIMEOUT_MS - 2_000);
+    const again = await startLogin("anthropic");
+    expect(again).toBe(first);
+
+    // Crossing the ORIGINAL deadline must not kill the refreshed flow…
+    await vi.advanceTimersByTimeAsync(4_000);
+    let row = (await getAuthStatus()).providers.find(
+      (p) => p.provider === "anthropic",
+    );
+    expect(row?.login?.status).toBe("awaiting_user");
+
+    // …but the refreshed window still expires on its own schedule.
+    await vi.advanceTimersByTimeAsync(LOGIN_TIMEOUT_MS);
+    row = (await getAuthStatus()).providers.find(
+      (p) => p.provider === "anthropic",
+    );
+    expect(row?.login?.status).toBe("error");
+    expect(row?.login?.error).toBe(LOGIN_TIMEOUT_ERROR);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("a cancelled login's expiry never resurrects an error row", async () => {
+  // Cancel frees the slot (login: null). The expiry firing later must stand
+  // down — not overwrite the clean slate with a phantom timeout error.
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  try {
+    await startLogin("anthropic");
+    cancelLogin("anthropic");
+    await vi.advanceTimersByTimeAsync(LOGIN_TIMEOUT_MS + 1);
+    const row = (await getAuthStatus()).providers.find(
+      (p) => p.provider === "anthropic",
+    );
+    expect(row?.login).toBeNull();
+  } finally {
+    vi.useRealTimers();
+  }
 });

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -49,9 +49,68 @@ type LoginState = {
   resolvePaste?: (code: string) => void;
   rejectPaste?: (err: Error) => void;
   abort?: AbortController;
+  /** Abandoned-login expiry (see `armLoginExpiry`); cleared when the flow settles. */
+  timer?: ReturnType<typeof setTimeout>;
 };
 
 const active = new Map<ProviderId, LoginState>();
+
+/**
+ * Overall cap on an in-flight login. An abandoned flow is not just stale UI
+ * state: the browser/loopback flows hold pi's in-process OAuth callback server
+ * bound to the provider's FIXED port (Codex: 1455) until they settle, which
+ * blocks every future sign-in for that provider MACHINE-WIDE — any other
+ * Houston instance, and the desktop relay's own local bind, all need that
+ * exact port. Matches the local client watcher's own 10-minute cap.
+ */
+export const LOGIN_TIMEOUT_MS = 10 * 60_000;
+
+/**
+ * Stable sentinel the frontend localizes for the failure toast. Mirrors
+ * `PROVIDER_LOGIN_TIMEOUT_ERROR` in `@houston-ai/core` (ui/core/src/
+ * provider-login.ts) — the runtime is frontend-agnostic and cannot import ui
+ * packages, so the string is duplicated by value; keep the two in sync.
+ */
+export const LOGIN_TIMEOUT_ERROR = "Login timed out";
+
+function clearLoginExpiry(state: LoginState): void {
+  if (state.timer) clearTimeout(state.timer);
+  state.timer = undefined;
+}
+
+/**
+ * (Re)start the abandoned-login clock. On expiry the flow is torn down exactly
+ * like `cancelLogin` (abort stops device-code pollers; the rejected paste
+ * promise closes the loopback callback server and frees its port) but the
+ * state stays in `active` as an ERROR, like any other failed login, so status
+ * polls surface "Login timed out" instead of silently forgetting the attempt.
+ * Re-armed when `startLogin` reuses an in-flight login, so every connect click
+ * gets the full window.
+ */
+function armLoginExpiry(provider: ProviderId, state: LoginState): void {
+  clearLoginExpiry(state);
+  const timer = setTimeout(() => {
+    // Stand down if the flow settled or was replaced/cancelled meanwhile.
+    if (active.get(provider) !== state) return;
+    if (state.status !== "starting" && state.status !== "awaiting_user") return;
+    // Record the outcome BEFORE aborting: the login promise's rejection
+    // handler sees the abort as a benign unwind and leaves this in place.
+    state.status = "error";
+    state.error = LOGIN_TIMEOUT_ERROR;
+    console.error(
+      `[oauth:${provider}] abandoned login timed out after ${LOGIN_TIMEOUT_MS / 60_000}min — aborting to free the callback port`,
+    );
+    state.abort?.abort();
+    state.rejectPaste?.(new Error(LOGIN_TIMEOUT_ERROR));
+    // The paste promise is dead: drop the hooks so a late completeLogin gets
+    // a loud "no active login" instead of silently resolving into the void.
+    state.resolvePaste = undefined;
+    state.rejectPaste = undefined;
+  }, LOGIN_TIMEOUT_MS);
+  // Bookkeeping only — never hold the process open for it.
+  timer.unref?.();
+  state.timer = timer;
+}
 
 /**
  * Which Codex OAuth flow to run — decided SOLELY by `deviceAuth`. The
@@ -153,6 +212,8 @@ export async function startLogin(
     (existing.status === "starting" || existing.status === "awaiting_user") &&
     existing.info
   ) {
+    // A fresh connect click deserves the full abandonment window.
+    armLoginExpiry(provider, existing);
     return existing.info;
   }
 
@@ -161,6 +222,7 @@ export async function startLogin(
     abort: new AbortController(),
   };
   active.set(provider, state);
+  armLoginExpiry(provider, state);
 
   let resolveInfo!: (i: LoginInfo) => void;
   const infoReady = new Promise<LoginInfo>((r) => (resolveInfo = r));
@@ -230,14 +292,17 @@ export async function startLogin(
 
   void login
     .then(() => {
+      clearLoginExpiry(state);
       state.status = "complete";
       console.log(`[oauth:${provider}] login complete`);
     })
     .catch((e: unknown) => {
+      clearLoginExpiry(state);
       if (state.abort?.signal.aborted) {
-        // User-initiated cancel (cancelLogin already dropped the state from
-        // `active`): the rejection is the flow unwinding, not a failure.
-        console.log(`[oauth:${provider}] login cancelled`);
+        // The flow unwinding after a user-initiated cancel (cancelLogin
+        // already dropped the state from `active`) or the abandoned-login
+        // expiry (which already recorded its error) — not a new failure.
+        console.log(`[oauth:${provider}] login flow closed`);
         return;
       }
       state.status = "error";
@@ -266,6 +331,8 @@ export async function startLogin(
 export function setApiKey(providerId: string, key: string): void {
   const trimmed = assertApiKeyConnectable(providerId, key);
   authStorage.set(providerId, { type: "api_key", key: trimmed });
+  const state = active.get(providerId as ProviderId);
+  if (state) clearLoginExpiry(state);
   active.delete(providerId as ProviderId);
 }
 
@@ -322,6 +389,7 @@ export function cancelLogin(providerId: string): void {
   const state = active.get(providerId);
   if (!state || state.status === "complete") return;
   active.delete(providerId);
+  clearLoginExpiry(state);
   state.abort?.abort();
   state.rejectPaste?.(new Error("login cancelled"));
 }
@@ -337,6 +405,8 @@ export function completeLogin(providerId: string, code: string): void {
 export async function logout(providerId: string): Promise<void> {
   if (!known(providerId)) throw new Error(`unknown provider: ${providerId}`);
   authStorage.logout(providerId);
+  const state = active.get(providerId);
+  if (state) clearLoginExpiry(state);
   active.delete(providerId);
   // Anthropic's primary credential is the browser-login one cached in the shared
   // dir (Keychain / file), NOT auth.json — so clear it via `claude auth logout`

--- a/packages/web/e2e/usage-compute.spec.ts
+++ b/packages/web/e2e/usage-compute.spec.ts
@@ -95,11 +95,17 @@ test("with data the section shows the total, daily bars, and per-agent rows", as
 
   // Per-agent rows: the seed agent resolves to its display name and wears the
   // running badge (3h 05m across 13 tasks); the deleted slug humanizes.
-  const houston = page.getByRole("listitem").filter({ hasText: "Houston" });
+  // Scoped to the compute section: the AI-accounts cards below are also list
+  // items and their not-metered copy contains "Houston", so a page-wide
+  // listitem filter is ambiguous.
+  const compute = page.locator("section", {
+    has: page.getByRole("heading", { name: "Running time" }),
+  });
+  const houston = compute.getByRole("listitem").filter({ hasText: "Houston" });
   await expect(houston.getByText("Running now")).toBeVisible();
   await expect(houston).toContainText("3h 05m");
   await expect(houston).toContainText("13 tasks");
-  const sales = page.getByRole("listitem").filter({ hasText: "Sales bot" });
+  const sales = compute.getByRole("listitem").filter({ hasText: "Sales bot" });
   await expect(sales).toContainText("30m");
   await expect(sales).toContainText("1 task");
 

--- a/scripts/dev/reap.sh
+++ b/scripts/dev/reap.sh
@@ -14,12 +14,19 @@ set -eu
 MARKER="$HOME/.houston-dev/stack.marker"
 # Every port the stack owns; 1420 is the desktop app's own vite dev server.
 PORTS="5433 9080 8081 4318 1430 1420"
-# Commands that are unambiguously the Houston dev stack.
+# Commands that are unambiguously the Houston dev stack. The host runs as
+# tsx's cli.mjs AND its loader child (both survive their pane independently —
+# a bare "tsx src/local/main.ts" matched neither, so stale hosts piled up
+# across restarts); the per-agent engines the host/control-plane spawn carry
+# the absolute packages/runtime path.
 SIGNATURES="exe/gateway
 exe/control-plane
 go run ./cmd/gateway
 go run ./cmd/control-plane
 tsx src/local/main.ts
+cli.mjs src/local/main.ts
+loader.mjs src/local/main.ts
+packages/runtime/src/main.ts
 --filter @houston/host dev
 --filter houston-web dev"
 # What a Houston-owned port holder may look like (vite/tauri/node stragglers).


### PR DESCRIPTION
## Problem

An abandoned provider sign-in — started but never completed or cancelled — kept pi's in-process OAuth callback server bound to the provider's **fixed** port forever. For Codex/OpenAI that's `127.0.0.1:1455`, which every other Houston instance and the desktop loopback relay also need. One stale login (e.g. in a forgotten dev runtime) blocked ChatGPT sign-in **machine-wide** until that runtime process died: every later connect failed with *"Couldn't open OpenAI sign-in"* because the port bind collided (`Address already in use`).

Nothing in the runtime bounded an in-flight login's lifetime — only an explicit `cancelLogin` or completion freed the port.

## Fix

`startLogin` now arms a 10-minute abandonment expiry (`LOGIN_TIMEOUT_MS`, matching the local client watcher's cap):

- **On expiry the flow is torn down exactly like `cancelLogin`**: the abort stops device-code pollers, and rejecting the paste promise closes the loopback callback server — freeing the port for the next attempt.
- **The attempt is recorded as an error**, not silently forgotten: the state stays in `active` with the stable `"Login timed out"` sentinel that the frontend already localizes (`PROVIDER_LOGIN_TIMEOUT_ERROR` in `@houston-ai/core`; the runtime is frontend-agnostic, so the string is mirrored by value with a keep-in-sync note). Status polls surface a real toast.
- **Idempotent reuse re-arms the clock**: a second connect click near the deadline gets the full window again, and crossing the original deadline can't kill the refreshed flow.
- The timer is cleared on completion, failure, cancel, logout, and API-key connect; guarded so a stale timer can never clobber a settled or replaced login; and `unref`'d so it never holds the process open.
- After expiry the paste hooks are dropped, so a late paste into a dead dialog throws a loud "no active login" instead of silently resolving into the void.

## Tests

Three new fake-timer tests in `login.test.ts`:
- an abandoned login expires, reports the sentinel, and a retry builds a fresh flow;
- reuse re-arms the abandonment clock (original deadline is defused, refreshed window still expires);
- a cancelled login's stale expiry timer stands down instead of resurrecting an error row.

Full `@houston/runtime` suite: 81 files / 668 tests green. Biome + repo typecheck clean.