### PR TITLE
fix(e2e): scope usage-compute agent rows to the Running time section

### DIFF
--- a/packages/web/e2e/usage-compute.spec.ts
+++ b/packages/web/e2e/usage-compute.spec.ts
@@ -94,12 +94,21 @@ test("with data the section shows the total, daily bars, and per-agent rows", as
   await expect(page.getByRole("img", { name: /: ran / })).toHaveCount(7);
 
   // Per-agent rows: the seed agent resolves to its display name and wears the
-  // running badge (3h 05m across 13 tasks); the deleted slug humanizes.
-  const houston = page.getByRole("listitem").filter({ hasText: "Houston" });
+  // running badge (3h 05m across 13 tasks); the deleted slug humanizes. Scope
+  // to the compute section — the AI-accounts cards below are also list items
+  // and their "not metered yet" copy mentions Houston by name.
+  const computeSection = page
+    .locator("section")
+    .filter({ has: page.getByRole("heading", { name: "Running time" }) });
+  const houston = computeSection
+    .getByRole("listitem")
+    .filter({ hasText: "Houston" });
   await expect(houston.getByText("Running now")).toBeVisible();
   await expect(houston).toContainText("3h 05m");
   await expect(houston).toContainText("13 tasks");
-  const sales = page.getByRole("listitem").filter({ hasText: "Sales bot" });
+  const sales = computeSection
+    .getByRole("listitem")
+    .filter({ hasText: "Sales bot" });
   await expect(sales).toContainText("30m");
   await expect(sales).toContainText("1 task");
 


### PR DESCRIPTION
## Problem

`usage-compute.spec.ts` fails on `main` with a Playwright strict-mode violation:

```
getByRole('listitem').filter({ hasText: 'Houston' }) resolved to 2 elements
```

This is a semantic merge conflict between two PRs that were each green on their own:

- **#925** added the test, locating the agent row by filtering **every** listitem on the Usage page for the text "Houston".
- **#929** (commit `2757ad17`) added the AI-accounts "not metered yet" copy, which mentions Houston by name: *"No usage yet. Houston will start measuring with your next message."* — and the account cards are also `<li>` elements.

The first CI run that contained both changes was the `main` run after merge (`860c39a7`), which is why no PR check caught it.

## Fix

Scope the per-agent row lookups to the "Running time" `<section>` so the AI-accounts cards below can never match. Test-only change.

Verified locally: all 4 tests in `usage-compute.spec.ts` pass, including the previously failing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
