### PR TITLE
feat(usage): show time worked, not engine up-time + chart legibility

### DIFF
--- a/app/src/components/usage-view/compute-agent-row.tsx
+++ b/app/src/components/usage-view/compute-agent-row.tsx
@@ -7,23 +7,23 @@ interface ComputeAgentRowProps {
   name: string;
   /** Resolved agent color (semantic hex), for the avatar tint. */
   color?: string;
-  /** Busiest agent's runMs (≥ 1), to scale this row's bar. */
+  /** Busiest agent's workMs (≥ 1), to scale this row's bar. */
   max: number;
   /** This agent's engine is up right now. */
   runningNow: boolean;
-  /** Formatted running time ("3h 12m"). */
+  /** Formatted time worked ("3h 12m"). */
   duration: string;
   /** Formatted task count ("12 tasks"). */
   tasks: string;
-  /** "Running now" badge text. */
+  /** "Online" badge text. */
   runningNowLabel: string;
 }
 
 /**
- * One agent's running time in the Compute section: avatar + name + duration
+ * One agent's time worked in the Compute section: avatar + name + duration
  * and task count + a tokened track bar scaled to the busiest agent (the same
- * shape as the org Usage tab's rows, minus the expandable breakdown — running
- * time is per-agent, not per-person).
+ * shape as the org Usage tab's rows, minus the expandable breakdown — time
+ * worked is per-agent, not per-person).
  */
 export function ComputeAgentRow({
   agent,
@@ -35,7 +35,7 @@ export function ComputeAgentRow({
   tasks,
   runningNowLabel,
 }: ComputeAgentRowProps) {
-  const pct = Math.max(2, Math.round((agent.runMs / max) * 100));
+  const pct = Math.max(2, Math.round((agent.workMs / max) * 100));
   return (
     <li className="flex items-center gap-3 border-b border-line/40 py-3 last:border-0">
       <HoustonAvatar color={color} diameter={28} />

--- a/app/src/components/usage-view/compute-bar-chart.tsx
+++ b/app/src/components/usage-view/compute-bar-chart.tsx
@@ -1,25 +1,32 @@
-import { cn } from "@houston-ai/core";
+import { cn, Tooltip, TooltipContent, TooltipTrigger } from "@houston-ai/core";
 import type { ComputeBucket } from "./compute-usage-model";
 
 interface ComputeBarChartProps {
   buckets: ComputeBucket[];
-  /** Busiest bucket's runMs (≥ 1), the 100%-height reference. */
+  /** Busiest bucket's workMs (≥ 1), the full-height reference. */
   max: number;
-  /** True when some agent is running right now — dots the last bar. */
+  /** True when some agent is up right now — dots the last bar (still growing). */
   runningNow: boolean;
-  /** Accessible per-bar description ("Jul 12: ran 2h 05m, 8 tasks"). */
+  /** Tooltip + aria description ("Jul 12: worked 2h 05m, 8 tasks"). */
   barLabel: (bucket: ComputeBucket) => string;
   /** Short x-axis label for a bucket's start day ("Mon" / "Jul 12"). */
   axisLabel: (bucket: ComputeBucket, index: number) => string;
+  /**
+   * Direct value printed above a bar, or null for none. The section labels
+   * every nonzero bar on the 7-day view and only the tallest on dense views —
+   * selective labels keep the chart readable without a number on everything.
+   */
+  valueLabel: (bucket: ComputeBucket, index: number) => string | null;
 }
 
 /**
- * Running-time bars, one per bucket (day or week). Single series, so identity
- * needs no legend or per-bar numbers — the section's summary line carries the
- * total, each bar carries its value as an aria-label and a native tooltip
- * (hover enhances, never gates). Zero days stay visible as a small tick so the
- * range reads as "measured and idle", not "missing". A pulse dot rides the
- * last bar while an agent is running — that bar is still growing. Tokens only.
+ * Time-worked bars, one per bucket (day or week). Single series, so identity
+ * needs no legend; comprehension comes from three layers — selective direct
+ * value labels, a real tooltip per bar (hover enhances, never gates: every
+ * value is also an aria-label), and the emphasized "today" axis label. Zero
+ * days stay visible as a small tick so the range reads as "measured and
+ * idle", not "missing". Bars top out below the frame so labels never clip.
+ * Tokens only.
  */
 export function ComputeBarChart({
   buckets,
@@ -27,49 +34,65 @@ export function ComputeBarChart({
   runningNow,
   barLabel,
   axisLabel,
+  valueLabel,
 }: ComputeBarChartProps) {
   return (
-    <ol className="flex h-28 items-end gap-[2px]">
+    <ol className="flex h-32 items-end gap-[3px]">
       {buckets.map((bucket, index) => {
         const last = index === buckets.length - 1;
+        // 84% ceiling leaves headroom for the value label + live dot.
         const pct =
-          bucket.runMs === 0
+          bucket.workMs === 0
             ? 0
-            : Math.max(4, Math.round((bucket.runMs / max) * 100));
+            : Math.max(4, Math.round((bucket.workMs / max) * 84));
         const label = barLabel(bucket);
+        const value = valueLabel(bucket, index);
         return (
           <li
             key={bucket.startDay}
-            className="group flex h-full min-w-0 flex-1 flex-col justify-end"
+            className="flex h-full min-w-0 flex-1 flex-col justify-end"
           >
-            <div
-              role="img"
-              aria-label={label}
-              title={label}
-              className="flex h-full flex-col items-center justify-end gap-1"
-            >
-              {last && runningNow && (
-                <span
-                  aria-hidden
-                  className="size-1.5 shrink-0 animate-pulse rounded-full bg-action"
-                />
-              )}
-              {pct === 0 ? (
-                <div className="h-[3px] w-full max-w-9 rounded-full bg-chip" />
-              ) : (
+            <Tooltip>
+              <TooltipTrigger asChild>
                 <div
-                  className="w-full max-w-9 rounded-t-[4px] bg-action/80 transition-[height] duration-300 group-hover:bg-action"
-                  style={{ height: `${pct}%` }}
-                />
-              )}
-            </div>
+                  role="img"
+                  aria-label={label}
+                  className="flex h-full flex-col items-center justify-end"
+                >
+                  {last && runningNow && (
+                    <span
+                      aria-hidden
+                      className="mb-1 size-1.5 shrink-0 animate-pulse rounded-full bg-action"
+                    />
+                  )}
+                  {value !== null && (
+                    <span
+                      aria-hidden
+                      className="mb-1 text-[10px] leading-none whitespace-nowrap text-ink-muted"
+                    >
+                      {value}
+                    </span>
+                  )}
+                  {pct === 0 ? (
+                    <div className="h-[3px] w-full max-w-9 rounded-full bg-chip" />
+                  ) : (
+                    <div
+                      className="w-full max-w-9 rounded-t-[4px] bg-action/80 transition-[height] duration-300 hover:bg-action"
+                      style={{ height: `${pct}%` }}
+                    />
+                  )}
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="top">{label}</TooltipContent>
+            </Tooltip>
             <span
               aria-hidden
               className={cn(
                 // No truncation: on dense ranges only every ~5th label renders
                 // (the tooltip covers the rest), so an overflowing "Jun 26" has
                 // room to spill over its hidden neighbors instead of clipping.
-                "mt-1 self-center text-center text-[10px] leading-tight whitespace-nowrap text-ink-muted",
+                "mt-1 self-center text-center text-[10px] leading-tight whitespace-nowrap",
+                last ? "font-medium text-ink" : "text-ink-muted",
                 buckets.length > 14 && index % 5 !== 0 && !last && "invisible",
               )}
             >

--- a/app/src/components/usage-view/compute-section.tsx
+++ b/app/src/components/usage-view/compute-section.tsx
@@ -56,8 +56,9 @@ function dayLabel(
 }
 
 /**
- * "Running time": how long this user's agents have been up, per day/week, with
- * a per-agent breakdown. Rendered ONLY where the gateway advertises
+ * "Time worked": how long this user's agents actually spent executing tasks,
+ * per day/week, with a per-agent breakdown. The full pod up-time (`awakeMs`)
+ * is deliberately never shown. Rendered ONLY where the gateway advertises
  * `capabilities.computeUsage` (the parent gates mounting, so the query never
  * fires elsewhere). One fetch covers 90 days; range switches re-bucket locally.
  */
@@ -71,7 +72,12 @@ export function ComputeSection() {
     () => bucketCompute(data?.rows ?? [], range, Date.now()),
     [data, range],
   );
-  const runningNow = data?.awakeNow ?? [];
+  const onlineNow = data?.awakeNow ?? [];
+  // Selective direct labels: every nonzero bar on the roomy 7-day view; only
+  // the tallest bar on dense views (the tooltip covers the rest).
+  const tallestIndex = model.buckets.findIndex(
+    (bucket) => bucket.workMs > 0 && bucket.workMs === model.maxBucketMs,
+  );
 
   return (
     <section className="flex flex-col gap-3">
@@ -112,7 +118,7 @@ export function ComputeSection() {
         <>
           <p className="text-sm text-ink-muted">
             {t("usage.compute.summary", {
-              duration: formatDuration(t, model.totalRunMs),
+              duration: formatDuration(t, model.totalWorkMs),
             })}
             <span aria-hidden> · </span>
             {t("usage.compute.tasks", { count: model.totalTasks })}
@@ -120,14 +126,14 @@ export function ComputeSection() {
           <ComputeBarChart
             buckets={model.buckets}
             max={model.maxBucketMs}
-            runningNow={runningNow.length > 0}
+            runningNow={onlineNow.length > 0}
             barLabel={(bucket) =>
               t("usage.compute.barLabel", {
                 date: dayLabel(i18n.language, bucket.startDay, {
                   month: "short",
                   day: "numeric",
                 }),
-                duration: formatDuration(t, bucket.runMs),
+                duration: formatDuration(t, bucket.workMs),
                 tasks: t("usage.compute.tasks", { count: bucket.tasks }),
               })
             }
@@ -140,6 +146,11 @@ export function ComputeSection() {
                   : { month: "short", day: "numeric" },
               )
             }
+            valueLabel={(bucket, index) => {
+              if (bucket.workMs === 0) return null;
+              if (range !== "week" && index !== tallestIndex) return null;
+              return formatDuration(t, bucket.workMs);
+            }}
           />
           <div>
             <h3 className="mb-1 text-sm font-medium text-ink">
@@ -159,10 +170,10 @@ export function ComputeSection() {
                     name={agentLabel(agent.agentSlug, agents)}
                     color={resolveAgentColor(match?.color)}
                     max={model.maxAgentMs}
-                    runningNow={runningNow.includes(agent.agentSlug)}
-                    duration={formatDuration(t, agent.runMs)}
+                    runningNow={onlineNow.includes(agent.agentSlug)}
+                    duration={formatDuration(t, agent.workMs)}
                     tasks={t("usage.compute.tasks", { count: agent.tasks })}
-                    runningNowLabel={t("usage.compute.runningNow")}
+                    runningNowLabel={t("usage.compute.online")}
                   />
                 );
               })}

--- a/app/src/components/usage-view/compute-usage-model.ts
+++ b/app/src/components/usage-view/compute-usage-model.ts
@@ -3,9 +3,11 @@ import type { Capabilities, ComputeUsageRow } from "@houston-ai/engine-client";
 /**
  * Pure aggregation for the Compute section (no DOM, no i18n): buckets the
  * gateway's per-(agent, UTC day) rows into the selected range and rolls up
- * per-agent totals. The user sees ONE time metric — running time = `awakeMs`
- * (the engine's up-time); `activeMs` is a recorded subset we deliberately do
- * not render, and tasks (`turns + routineRuns`) is the companion stat.
+ * per-agent totals. The user sees ONE time metric — time worked = `activeMs`
+ * (time the agent actually executed turns/routine runs); `awakeMs` (the
+ * engine's full up-time, idle tail included) rides the wire but is
+ * deliberately never rendered, and tasks (`turns + routineRuns`) is the
+ * companion stat.
  */
 
 export type ComputeRange = "week" | "month" | "quarter";
@@ -15,20 +17,20 @@ export interface ComputeBucket {
   startDay: string;
   /** Days folded into this bucket (1 for daily ranges, 7 for weekly). */
   days: number;
-  runMs: number;
+  workMs: number;
   tasks: number;
 }
 
 export interface ComputeAgentTotals {
   agentSlug: string;
-  runMs: number;
+  workMs: number;
   tasks: number;
 }
 
 export interface ComputeModel {
   buckets: ComputeBucket[];
   perAgent: ComputeAgentTotals[];
-  totalRunMs: number;
+  totalWorkMs: number;
   totalTasks: number;
   /** Busiest bucket/agent, floored at 1 so bar math never divides by zero. */
   maxBucketMs: number;
@@ -74,7 +76,7 @@ export function bucketCompute(
   const buckets: ComputeBucket[] = starts.map((start) => ({
     startDay: dayString(start),
     days: bucketDays,
-    runMs: 0,
+    workMs: 0,
     tasks: 0,
   }));
   const first = starts[0];
@@ -89,27 +91,27 @@ export function bucketCompute(
     // rather than vanishing — the server is the time authority, not us.
     const bucket = buckets[Math.min(index, buckets.length - 1)];
     const tasks = row.turns + row.routineRuns;
-    bucket.runMs += row.awakeMs;
+    bucket.workMs += row.activeMs;
     bucket.tasks += tasks;
     let agent = perAgent.get(row.agentSlug);
     if (!agent) {
-      agent = { agentSlug: row.agentSlug, runMs: 0, tasks: 0 };
+      agent = { agentSlug: row.agentSlug, workMs: 0, tasks: 0 };
       perAgent.set(row.agentSlug, agent);
     }
-    agent.runMs += row.awakeMs;
+    agent.workMs += row.activeMs;
     agent.tasks += tasks;
   }
 
   const agents = [...perAgent.values()].sort(
-    (a, b) => b.runMs - a.runMs || a.agentSlug.localeCompare(b.agentSlug),
+    (a, b) => b.workMs - a.workMs || a.agentSlug.localeCompare(b.agentSlug),
   );
   return {
     buckets,
     perAgent: agents,
-    totalRunMs: agents.reduce((sum, a) => sum + a.runMs, 0),
+    totalWorkMs: agents.reduce((sum, a) => sum + a.workMs, 0),
     totalTasks: agents.reduce((sum, a) => sum + a.tasks, 0),
-    maxBucketMs: Math.max(1, ...buckets.map((b) => b.runMs)),
-    maxAgentMs: Math.max(1, ...agents.map((a) => a.runMs)),
+    maxBucketMs: Math.max(1, ...buckets.map((b) => b.workMs)),
+    maxAgentMs: Math.max(1, ...agents.map((a) => a.workMs)),
   };
 }
 

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -164,17 +164,16 @@
       }
     },
     "compute": {
-      "title": "Running time",
-      "subtitle": "How long your agents have been running and how many tasks they handled.",
+      "title": "Time worked",
+      "subtitle": "How much time your agents spent working and how many tasks they handled.",
       "range": {
         "week": "7 days",
         "month": "30 days",
         "quarter": "3 months"
       },
-      "summary": "Your agents ran {{duration}}",
+      "summary": "Your agents worked {{duration}}",
       "tasks_one": "{{count}} task",
       "tasks_other": "{{count}} tasks",
-      "runningNow": "Running now",
       "byAgent": "By agent",
       "duration": {
         "hm": "{{hours}}h {{minutes}}m",
@@ -182,12 +181,13 @@
         "underMinute": "<1m",
         "zero": "0m"
       },
-      "barLabel": "{{date}}: ran {{duration}}, {{tasks}}",
+      "barLabel": "{{date}}: worked {{duration}}, {{tasks}}",
       "empty": {
-        "title": "No running time yet",
-        "body": "When your agents run, their time will show here."
+        "title": "No time worked yet",
+        "body": "When your agents work on tasks, their time will show here."
       },
-      "error": "Couldn't load running time right now. Try again in a moment."
+      "error": "Couldn't load your agents' time right now. Try again in a moment.",
+      "online": "Online"
     }
   },
   "toast": {}

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -164,17 +164,16 @@
       }
     },
     "compute": {
-      "title": "Tiempo de actividad",
-      "subtitle": "Cuánto tiempo han estado funcionando tus agentes y cuántas tareas realizaron.",
+      "title": "Tiempo trabajado",
+      "subtitle": "Cuánto tiempo dedicaron tus agentes a trabajar y cuántas tareas realizaron.",
       "range": {
         "week": "7 días",
         "month": "30 días",
         "quarter": "3 meses"
       },
-      "summary": "Tus agentes funcionaron {{duration}}",
+      "summary": "Tus agentes trabajaron {{duration}}",
       "tasks_one": "{{count}} tarea",
       "tasks_other": "{{count}} tareas",
-      "runningNow": "Activo ahora",
       "byAgent": "Por agente",
       "duration": {
         "hm": "{{hours}}h {{minutes}}m",
@@ -182,12 +181,13 @@
         "underMinute": "<1m",
         "zero": "0m"
       },
-      "barLabel": "{{date}}: funcionó {{duration}}, {{tasks}}",
+      "barLabel": "{{date}}: trabajaron {{duration}}, {{tasks}}",
       "empty": {
-        "title": "Aún no hay tiempo de actividad",
-        "body": "Cuando tus agentes funcionen, su tiempo aparecerá aquí."
+        "title": "Aún no hay tiempo trabajado",
+        "body": "Cuando tus agentes trabajen en tareas, su tiempo aparecerá aquí."
       },
-      "error": "No se pudo cargar el tiempo de actividad. Intenta de nuevo en un momento."
+      "error": "No se pudo cargar el tiempo de tus agentes. Intenta de nuevo en un momento.",
+      "online": "En línea"
     }
   },
   "toast": {}

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -164,17 +164,16 @@
       }
     },
     "compute": {
-      "title": "Tempo de atividade",
-      "subtitle": "Quanto tempo seus agentes ficaram funcionando e quantas tarefas realizaram.",
+      "title": "Tempo trabalhado",
+      "subtitle": "Quanto tempo seus agentes passaram trabalhando e quantas tarefas realizaram.",
       "range": {
         "week": "7 dias",
         "month": "30 dias",
         "quarter": "3 meses"
       },
-      "summary": "Seus agentes funcionaram {{duration}}",
+      "summary": "Seus agentes trabalharam {{duration}}",
       "tasks_one": "{{count}} tarefa",
       "tasks_other": "{{count}} tarefas",
-      "runningNow": "Ativo agora",
       "byAgent": "Por agente",
       "duration": {
         "hm": "{{hours}}h {{minutes}}m",
@@ -182,12 +181,13 @@
         "underMinute": "<1m",
         "zero": "0m"
       },
-      "barLabel": "{{date}}: funcionou {{duration}}, {{tasks}}",
+      "barLabel": "{{date}}: trabalharam {{duration}}, {{tasks}}",
       "empty": {
-        "title": "Ainda não há tempo de atividade",
-        "body": "Quando seus agentes funcionarem, o tempo deles vai aparecer aqui."
+        "title": "Ainda não há tempo trabalhado",
+        "body": "Quando seus agentes trabalharem em tarefas, o tempo deles vai aparecer aqui."
       },
-      "error": "Não foi possível carregar o tempo de atividade. Tente novamente em instantes."
+      "error": "Não foi possível carregar o tempo dos seus agentes. Tente novamente em instantes.",
+      "online": "Online"
     }
   },
   "toast": {}

--- a/app/tests/compute-usage-model.test.ts
+++ b/app/tests/compute-usage-model.test.ts
@@ -7,14 +7,25 @@ import {
   showComputeSection,
 } from "../src/components/usage-view/compute-usage-model.ts";
 
+// The displayed metric is time worked (`activeMs`); awake time rides the wire
+// but must never leak into the model's numbers, so every row carries a larger
+// awakeMs that the assertions would catch.
 function row(
   agentSlug: string,
   day: string,
-  awakeMs: number,
+  workMs: number,
   turns = 0,
   routineRuns = 0,
 ): ComputeUsageRow {
-  return { agentSlug, day, awakeMs, activeMs: 0, wakes: 1, turns, routineRuns };
+  return {
+    agentSlug,
+    day,
+    awakeMs: workMs * 2 + 1,
+    activeMs: workMs,
+    wakes: 1,
+    turns,
+    routineRuns,
+  };
 }
 
 // A fixed Wednesday noon UTC.
@@ -31,7 +42,7 @@ describe("bucketCompute", () => {
     strictEqual(model.buckets[0].startDay, "2026-07-09");
     strictEqual(model.buckets[6].startDay, "2026-07-15");
     deepStrictEqual(
-      model.buckets.map((b) => b.runMs),
+      model.buckets.map((b) => b.workMs),
       [0, 0, 0, 0, 0, 0, 3_600_000],
     );
     strictEqual(model.buckets[6].tasks, 3);
@@ -46,8 +57,8 @@ describe("bucketCompute", () => {
       "week",
       NOW,
     );
-    strictEqual(model.totalRunMs, 1_000);
-    strictEqual(model.buckets[6].runMs, 1_000);
+    strictEqual(model.totalWorkMs, 1_000);
+    strictEqual(model.buckets[6].workMs, 1_000);
   });
 
   it("uses 30 daily buckets for the month range", () => {
@@ -71,8 +82,8 @@ describe("bucketCompute", () => {
     const last = model.buckets[12];
     strictEqual(last.startDay, "2026-07-13");
     strictEqual(last.days, 7);
-    strictEqual(last.runMs, 123);
-    strictEqual(model.buckets[11].runMs, 7);
+    strictEqual(last.workMs, 123);
+    strictEqual(model.buckets[11].workMs, 7);
   });
 
   it("aggregates per agent, busiest first with slug tie-break", () => {
@@ -93,7 +104,7 @@ describe("bucketCompute", () => {
       model.perAgent.map((a) => a.tasks),
       [3, 2, 1],
     );
-    strictEqual(model.totalRunMs, 1_000);
+    strictEqual(model.totalWorkMs, 1_000);
     strictEqual(model.totalTasks, 6);
   });
 

--- a/packages/web/e2e/usage-compute.spec.ts
+++ b/packages/web/e2e/usage-compute.spec.ts
@@ -3,7 +3,7 @@ import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "./support/fixtures";
 
 /**
- * The Usage page's "Running time" (compute) section — hosted-cloud analytics of
+ * The Usage page's "Time worked" (compute) section — hosted-cloud analytics of
  * how long each agent's engine ran per day. The section exists ONLY where the
  * gateway advertises `capabilities.computeUsage` (desktop/self-host never do),
  * and its data comes from `GET /v1/org/compute-usage`, armed here via the fake
@@ -15,18 +15,20 @@ const DAY_MS = 86_400_000;
 const day = (daysAgo: number) =>
   new Date(Date.now() - daysAgo * DAY_MS).toISOString().slice(0, 10);
 
+// The UI shows time worked (activeMs); awakeMs rides along larger so a
+// regression to displaying awake time would double every asserted number.
 function row(
   agentSlug: string,
   daysAgo: number,
-  awakeMs: number,
+  workMs: number,
   turns = 0,
   routineRuns = 0,
 ) {
   return {
     agentSlug,
     day: day(daysAgo),
-    awakeMs,
-    activeMs: Math.floor(awakeMs / 2),
+    awakeMs: workMs * 2,
+    activeMs: workMs,
     wakes: 1,
     turns,
     routineRuns,
@@ -56,7 +58,7 @@ test("without the computeUsage capability the Usage page shows only the account 
   await expect(page.getByRole("heading", { name: "Usage" })).toBeVisible();
   // The compute section is absent; the account sections (the seeded Anthropic
   // OAuth account lands under "AI subscriptions") stand on their own.
-  await expect(page.getByRole("heading", { name: "Running time" })).toHaveCount(
+  await expect(page.getByRole("heading", { name: "Time worked" })).toHaveCount(
     0,
   );
   await expect(
@@ -72,7 +74,7 @@ test("with data the section shows the total, daily bars, and per-agent rows", as
 }) => {
   await armComputeUsage(request, {
     rows: [
-      // Seed agent: resolves to its display name. 2h05m today + 1h yesterday.
+      // Seed agent: resolves to its display name. 2h05m worked today + 1h yesterday.
       row("houston-assistant", 0, 125 * 60_000, 8, 2),
       row("houston-assistant", 1, 60 * 60_000, 3, 0),
       // A since-deleted agent humanizes from its slug.
@@ -84,26 +86,26 @@ test("with data the section shows the total, daily bars, and per-agent rows", as
   await page.locator('[data-tour-target="nav-usage"]').click();
 
   await expect(
-    page.getByRole("heading", { name: "Running time" }),
+    page.getByRole("heading", { name: "Time worked" }),
   ).toBeVisible();
   // 2h05 + 1h + 30m = 3h 35m across 14 tasks (10 + 3 + 1).
-  await expect(page.getByText("Your agents ran 3h 35m")).toBeVisible();
+  await expect(page.getByText("Your agents worked 3h 35m")).toBeVisible();
   await expect(page.getByText("14 tasks")).toBeVisible();
 
-  // 7 daily bars, each self-describing ("Jul 15: ran 2h 05m, 10 tasks").
-  await expect(page.getByRole("img", { name: /: ran / })).toHaveCount(7);
+  // 7 daily bars, each self-describing ("Jul 15: worked 2h 05m, 10 tasks").
+  await expect(page.getByRole("img", { name: /: worked / })).toHaveCount(7);
 
   // Per-agent rows: the seed agent resolves to its display name and wears the
-  // running badge (3h 05m across 13 tasks); the deleted slug humanizes. Scope
+  // online badge (3h 05m across 13 tasks); the deleted slug humanizes. Scope
   // to the compute section — the AI-accounts cards below are also list items
   // and their "not metered yet" copy mentions Houston by name.
   const computeSection = page
     .locator("section")
-    .filter({ has: page.getByRole("heading", { name: "Running time" }) });
+    .filter({ has: page.getByRole("heading", { name: "Time worked" }) });
   const houston = computeSection
     .getByRole("listitem")
     .filter({ hasText: "Houston" });
-  await expect(houston.getByText("Running now")).toBeVisible();
+  await expect(houston.getByText("Online")).toBeVisible();
   await expect(houston).toContainText("3h 05m");
   await expect(houston).toContainText("13 tasks");
   const sales = computeSection
@@ -131,7 +133,7 @@ test("switching the range changes the bar count without a new fetch", async ({
   await page.goto("/");
   await page.locator('[data-tour-target="nav-usage"]').click();
 
-  const bars = page.getByRole("img", { name: /: ran / });
+  const bars = page.getByRole("img", { name: /: worked / });
   await expect(bars).toHaveCount(7);
   await page.getByRole("tab", { name: "30 days" }).click();
   await expect(bars).toHaveCount(30);
@@ -150,10 +152,12 @@ test("with the capability but no rows the section shows its empty state", async 
   await page.locator('[data-tour-target="nav-usage"]').click();
 
   await expect(
-    page.getByRole("heading", { name: "Running time" }),
+    page.getByRole("heading", { name: "Time worked" }),
   ).toBeVisible();
-  await expect(page.getByText("No running time yet")).toBeVisible();
+  await expect(page.getByText("No time worked yet")).toBeVisible();
   await expect(
-    page.getByText("When your agents run, their time will show here."),
+    page.getByText(
+      "When your agents work on tasks, their time will show here.",
+    ),
   ).toBeVisible();
 });


### PR DESCRIPTION
## What

Follow-up to #925, users should only see the time their agents **actually spent working**, never the full engine up-time (which includes the idle tail before scale-down).

- The single displayed metric switches from `awakeMs` to `activeMs` (time executing turns + routine runs). Awake time still rides the wire — it is deliberately never rendered.
- Copy moves from "ran / Running time" to "worked / Time worked" across en/es/pt; the liveness badge becomes **Online** (an up-but-idle agent must not read as working).

## Chart legibility pass

- **Direct value labels**: every nonzero bar on the 7-day view; only the tallest bar on the 30-day/3-month views (a number on everything is noise).
- **Real tooltips** (Radix, from `@houston-ai/core`) per bar, replacing the native `title`; values stay aria-labels so hover only enhances.
- **Today** is emphasized in the axis, and bars top out at 84% height so labels never clip.

## Notes

- No server change needed: `activeMs` has been in the `/v1/org/compute-usage` contract from day one (gethouston/cloud#130).
- Model renames `runMs` → `workMs`; unit tests + e2e seeds now carry a deliberately larger `awakeMs` so any regression back to displaying up-time doubles every asserted number.
- Includes main's post-merge e2e scoping fix (18ecc77a) merged with the new copy.

## Tests

Unit (1602 pass), `usage-compute.spec.ts` 4/4, Biome, tsgo, check-locales all green. Screenshots verified for the 7-day and 30-day views.