### PR TITLE
feat(integrations): surface connected-but-ungranted apps on the agent tab

### DIFF
--- a/app/src/components/integrations/effective-access.ts
+++ b/app/src/components/integrations/effective-access.ts
@@ -1,0 +1,45 @@
+/**
+ * THE single answer to "can agent X use app Y right now, and if not why". One
+ * pure classifier so no surface re-derives the rule from scratch: the
+ * agent-integrations view model buckets every connection through this, and the
+ * exported states name each reason a user might see.
+ *
+ * Precedence is deliberate (first match wins): an admin ceiling outranks
+ * everything (a blocked app reads as "your admin turned this off", never "not
+ * connected"), then a missing connection, then a missing per-agent grant, then
+ * usable. Toolkit matching is exact slug equality — slugs are already
+ * normalized lowercase across this codebase (see `splitByGrant`), so no
+ * case-folding here. DOM-free + dependency-free so it's trivially unit-testable.
+ */
+
+/** Why an agent can or cannot use an app, as a discriminated union. */
+export type EffectiveAccess =
+  | { state: "usable" }
+  | { state: "notConnected" }
+  | { state: "notGrantedToAgent" }
+  | { state: "blockedByAdmin" };
+
+/** The bare state tag, for callers that only need the classification. */
+export type EffectiveAccessState = EffectiveAccess["state"];
+
+export function effectiveAccess(input: {
+  toolkit: string;
+  /** Active-or-recovering connections of the acting user (any toolkit). */
+  connections: readonly { toolkit: string }[];
+  /** Per-agent grant record; `null` = grants unsupported (treat as granted). */
+  grants: readonly string[] | null;
+  /** Effective allowlist (org ∩ agent); `null` = unrestricted. */
+  allowlist: readonly string[] | null;
+}): EffectiveAccess {
+  const { toolkit, connections, grants, allowlist } = input;
+  if (allowlist !== null && !allowlist.includes(toolkit)) {
+    return { state: "blockedByAdmin" };
+  }
+  if (!connections.some((c) => c.toolkit === toolkit)) {
+    return { state: "notConnected" };
+  }
+  if (grants !== null && !grants.includes(toolkit)) {
+    return { state: "notGrantedToAgent" };
+  }
+  return { state: "usable" };
+}

--- a/app/src/components/tabs/agent-integrations/agent-catalog-sections.tsx
+++ b/app/src/components/tabs/agent-integrations/agent-catalog-sections.tsx
@@ -1,0 +1,39 @@
+import { AgentDisallowedAppsSection } from "./agent-disallowed-apps-section";
+import { AgentUngrantedAppsSection } from "./agent-ungranted-apps-section";
+import type { AgentIntegrationsView } from "./model";
+
+interface AgentCatalogSectionsProps {
+  view: AgentIntegrationsView;
+  agentId: string;
+  canEdit: boolean;
+}
+
+/**
+ * The agent-only sections that hang below the shared browse catalog (rendered
+ * as the {@link CatalogPane}'s children): first the connected-but-off apps with
+ * an inline turn-on toggle, then the read-only admin-blocked apps. Each renders
+ * only when it has rows; in degraded mode neither exists so nothing shows.
+ * Extracted from the body to keep it under the file-size ceiling.
+ */
+export function AgentCatalogSections({
+  view,
+  agentId,
+  canEdit,
+}: AgentCatalogSectionsProps) {
+  const available = view.mode === "grants" ? view.availableRows : [];
+  const disallowed = view.mode === "grants" ? view.disallowedRows : [];
+  return (
+    <>
+      {available.length > 0 && (
+        <AgentUngrantedAppsSection
+          rows={available}
+          agentId={agentId}
+          canEdit={canEdit}
+        />
+      )}
+      {disallowed.length > 0 && (
+        <AgentDisallowedAppsSection rows={disallowed} />
+      )}
+    </>
+  );
+}

--- a/app/src/components/tabs/agent-integrations/agent-integrations-body.tsx
+++ b/app/src/components/tabs/agent-integrations/agent-integrations-body.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../integrations";
 import { CatalogPane } from "../../integrations-view/catalog-pane";
 import { InstalledStrip } from "../../integrations-view/installed-strip";
-import { AgentDisallowedAppsSection } from "./agent-disallowed-apps-section";
+import { AgentCatalogSections } from "./agent-catalog-sections";
 import {
   type AgentAppRow,
   type AgentIntegrationsView,
@@ -23,6 +23,8 @@ import {
 
 interface AgentIntegrationsBodyProps {
   view: AgentIntegrationsView;
+  /** This agent's id, for the inline "turn on for this agent" toggle. */
+  agentId: string;
   canEdit: boolean;
   /** The full toolkit catalog (drives the category filter + browse list). */
   catalog: IntegrationToolkit[];
@@ -57,6 +59,7 @@ interface AgentIntegrationsBodyProps {
  */
 export function AgentIntegrationsBody({
   view,
+  agentId,
   canEdit,
   catalog,
   allowlist,
@@ -84,7 +87,6 @@ export function AgentIntegrationsBody({
     () => usable.filter((r) => r.connection.status !== "active"),
     [usable],
   );
-  const disallowed = view.mode === "grants" ? view.disallowedRows : [];
   const installedCount = active.length + customItems.length;
 
   const tabs: CatalogShellTab[] = [
@@ -103,9 +105,11 @@ export function AgentIntegrationsBody({
           allowlist={allowlist}
           readOnly={!canEdit}
         >
-          {disallowed.length > 0 && (
-            <AgentDisallowedAppsSection rows={disallowed} />
-          )}
+          <AgentCatalogSections
+            view={view}
+            agentId={agentId}
+            canEdit={canEdit}
+          />
         </CatalogPane>
       ),
     },

--- a/app/src/components/tabs/agent-integrations/agent-integrations-tab.tsx
+++ b/app/src/components/tabs/agent-integrations/agent-integrations-tab.tsx
@@ -116,6 +116,7 @@ export default function IntegrationsTab({ agent }: TabProps) {
             <AgentIntegrationsBody
               key={agent.id}
               view={view}
+              agentId={agent.id}
               canEdit={canEdit}
               catalog={catalog.data ?? []}
               allowlist={allowlist}

--- a/app/src/components/tabs/agent-integrations/agent-ungranted-apps-section.tsx
+++ b/app/src/components/tabs/agent-integrations/agent-ungranted-apps-section.tsx
@@ -1,0 +1,66 @@
+import { Switch } from "@houston-ai/core";
+import { useTranslation } from "react-i18next";
+import { useAgentGrantMutation } from "../../../hooks/queries/use-integrations";
+import { AppRow } from "../../integrations";
+import type { AgentAppRow } from "./model";
+
+interface AgentUngrantedAppsSectionProps {
+  /** Connected + active apps NOT yet granted to this agent. */
+  rows: AgentAppRow[];
+  /** This agent, for the per-row grant toggle. */
+  agentId: string;
+  /** Whether the viewer may grant (Switch shown only then). */
+  canEdit: boolean;
+}
+
+/**
+ * Apps connected on the account but not yet turned on for this agent. Instead
+ * of hiding them (which left users staring at a connected app they could not
+ * find), we show them with an inline toggle: flipping it grants the app to this
+ * agent, and the optimistic {@link useAgentGrantMutation} moves the row into
+ * `activeRows` so it migrates to the Installed strip reactively. Viewers who
+ * cannot edit grants see the plain rows (state stays visible, no toggle).
+ * Rendered by the tab only when there is at least one such app.
+ */
+export function AgentUngrantedAppsSection({
+  rows,
+  agentId,
+  canEdit,
+}: AgentUngrantedAppsSectionProps) {
+  const { t } = useTranslation("integrations");
+  const grant = useAgentGrantMutation(agentId);
+
+  return (
+    <section>
+      <h2 className="text-sm font-medium text-ink">
+        {t("agentTab.offForAgent.heading")}
+      </h2>
+      <p className="mb-3 mt-0.5 text-xs text-ink-muted">
+        {t("agentTab.offForAgent.subtitle")}
+      </p>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {rows.map(({ connection, app }) => (
+          <AppRow
+            key={connection.connectionId || connection.toolkit}
+            display={app}
+            description={app.description}
+            trailing={
+              canEdit ? (
+                <Switch
+                  checked={false}
+                  aria-label={t("agentTab.offForAgent.turnOn", {
+                    app: app.name,
+                  })}
+                  onCheckedChange={() =>
+                    grant.mutate({ toolkit: connection.toolkit, op: "add" })
+                  }
+                />
+              ) : undefined
+            }
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/src/components/tabs/agent-integrations/model.ts
+++ b/app/src/components/tabs/agent-integrations/model.ts
@@ -6,7 +6,7 @@ import {
   type AppDisplay,
   connectionRows,
 } from "../../integrations/app-display.ts";
-import { splitByGrant } from "../../integrations/model.ts";
+import { effectiveAccess } from "../../integrations/effective-access.ts";
 
 /** One connected app resolved for display in this agent's list. */
 export interface AgentAppRow {
@@ -22,11 +22,14 @@ export interface AgentAppRow {
  *                 apps this agent can use; `disallowedRows` are connected apps
  *                 the agent's Teams allowlist ceiling forbids (visible,
  *                 non-connectable, for transparency), empty unless a Teams host
- *                 serves a restrictive allowlist. Connected-but-ungranted
- *                 account apps do NOT appear on this tab: activating an existing
- *                 connection for an agent now lives in Settings > Connected
- *                 accounts. This tab is a pure connect surface (connect with
- *                 auto-grant, recover a pending connection, disconnect).
+ *                 serves a restrictive allowlist. `availableRows` are apps
+ *                 connected on the account but NOT yet granted to this agent
+ *                 (only `active` ones — pending/errored are recovered from the
+ *                 global page): they surface with an inline "turn on for this
+ *                 agent" toggle instead of hiding, so a connected app is never
+ *                 invisible here. Beyond that the tab is a connect surface
+ *                 (connect with auto-grant, recover a pending connection,
+ *                 disconnect).
  *  - `degraded` — grants resolved to `null` (host has no grant routes, e.g.
  *                 single-player). There is no per-agent permission, so every
  *                 connected app is usable by this agent; the list shows them all
@@ -37,6 +40,7 @@ export type AgentIntegrationsView =
       mode: "grants";
       activeRows: AgentAppRow[];
       disallowedRows: AgentAppRow[];
+      availableRows: AgentAppRow[];
     }
   | { mode: "degraded"; rows: AgentAppRow[] };
 
@@ -47,10 +51,11 @@ export type AgentIntegrationsView =
  * connected toolkit outside the allowlist is split into `disallowedRows` and
  * never appears as active — the manager restricted it (the gateway also prunes
  * such grants server-side, so this is defence in depth, not the enforcer).
- * Connected-but-ungranted apps are intentionally absent from the grants view:
- * activating an existing connection for an agent lives in Settings > Connected
- * accounts. Pure so the mode split and row derivation are unit-testable without
- * React.
+ * Every connection is classified through the one {@link effectiveAccess}
+ * resolver — usable → `activeRows`, admin-blocked → `disallowedRows`,
+ * connected-but-ungranted (and `active`) → `availableRows` (the inline
+ * turn-on section). Pure so the mode split and row derivation are unit-testable
+ * without React.
  */
 export function agentIntegrationsView(opts: {
   connections: IntegrationConnection[];
@@ -64,24 +69,38 @@ export function agentIntegrationsView(opts: {
       rows: connectionRows(opts.connections, opts.catalog),
     };
   }
-  const grantedToolkits = new Set(opts.grants);
-  const allowed = opts.allowlist == null ? null : new Set(opts.allowlist);
-  const allowedConns: IntegrationConnection[] = [];
-  const disallowedConns: IntegrationConnection[] = [];
+  const allowlist = opts.allowlist ?? null;
+  const usable: IntegrationConnection[] = [];
+  const disallowed: IntegrationConnection[] = [];
+  const available: IntegrationConnection[] = [];
   for (const c of opts.connections) {
-    (allowed === null || allowed.has(c.toolkit)
-      ? allowedConns
-      : disallowedConns
-    ).push(c);
+    const access = effectiveAccess({
+      toolkit: c.toolkit,
+      connections: opts.connections,
+      grants: opts.grants,
+      allowlist,
+    });
+    switch (access.state) {
+      case "usable":
+        usable.push(c);
+        break;
+      case "blockedByAdmin":
+        disallowed.push(c);
+        break;
+      case "notGrantedToAgent":
+        // Only surface an activatable app the user can act on right now; a
+        // pending/errored ungranted connection is recovered from the global
+        // Integrations page, not turned on for an agent mid-OAuth.
+        if (c.status === "active") available.push(c);
+        break;
+      // `notConnected` is unreachable here — we iterate real connections.
+    }
   }
-  const { granted } = splitByGrant({
-    connections: allowedConns,
-    grants: grantedToolkits,
-  });
   return {
     mode: "grants",
-    activeRows: connectionRows(granted, opts.catalog),
-    disallowedRows: connectionRows(disallowedConns, opts.catalog),
+    activeRows: connectionRows(usable, opts.catalog),
+    disallowedRows: connectionRows(disallowed, opts.catalog),
+    availableRows: connectionRows(available, opts.catalog),
   };
 }
 

--- a/app/src/locales/en/integrations.json
+++ b/app/src/locales/en/integrations.json
@@ -106,7 +106,12 @@
     "allAgentsNote": "Every agent can use this app."
   },
   "agentTab": {
-    "manageAll": "Manage all integrations"
+    "manageAll": "Manage all integrations",
+    "offForAgent": {
+      "heading": "Connected, but off for this agent",
+      "subtitle": "These apps are connected to your account. Turn one on to let this agent use it.",
+      "turnOn": "Turn on {{app}} for this agent"
+    }
   },
   "custom": {
     "title": "Custom integrations",

--- a/app/src/locales/es/integrations.json
+++ b/app/src/locales/es/integrations.json
@@ -106,7 +106,12 @@
     "allAgentsNote": "Todos los agentes pueden usar esta app."
   },
   "agentTab": {
-    "manageAll": "Administrar todas las integraciones"
+    "manageAll": "Administrar todas las integraciones",
+    "offForAgent": {
+      "heading": "Conectada, pero desactivada para este agente",
+      "subtitle": "Estas apps están conectadas a tu cuenta. Activa una para que este agente pueda usarla.",
+      "turnOn": "Activar {{app}} para este agente"
+    }
   },
   "custom": {
     "title": "Integraciones personalizadas",

--- a/app/src/locales/pt/integrations.json
+++ b/app/src/locales/pt/integrations.json
@@ -106,7 +106,12 @@
     "allAgentsNote": "Todos os agentes podem usar este app."
   },
   "agentTab": {
-    "manageAll": "Gerenciar todas as integrações"
+    "manageAll": "Gerenciar todas as integrações",
+    "offForAgent": {
+      "heading": "Conectado, mas desligado para este agente",
+      "subtitle": "Estes apps estão conectados à sua conta. Ligue um para que este agente possa usá-lo.",
+      "turnOn": "Ligar {{app}} para este agente"
+    }
   },
   "custom": {
     "title": "Integrações personalizadas",

--- a/app/tests/agent-allowlist.test.ts
+++ b/app/tests/agent-allowlist.test.ts
@@ -129,8 +129,9 @@ describe("agentIntegrationsView (allowlist overlay)", () => {
       allowlist: ["gmail"],
     });
     if (view.mode !== "grants") throw new Error("unreachable");
-    // notion is connected + active + ungranted and disallowed → it appears only
-    // in disallowedRows for transparency, never as a usable active row.
+    // notion is connected + active + ungranted and disallowed → the admin block
+    // outranks the ungranted state (precedence), so it appears only in
+    // disallowedRows for transparency, never as an active or turn-on-able row.
     deepStrictEqual(
       view.activeRows.map((r) => r.connection.toolkit),
       ["gmail"],
@@ -139,6 +140,7 @@ describe("agentIntegrationsView (allowlist overlay)", () => {
       view.disallowedRows.map((r) => r.connection.toolkit),
       ["notion"],
     );
+    deepStrictEqual(view.availableRows, []);
   });
 
   it("an empty allowlist disallows every connected app", () => {

--- a/app/tests/agent-integrations.test.ts
+++ b/app/tests/agent-integrations.test.ts
@@ -70,26 +70,29 @@ describe("agentIntegrationsView", () => {
     );
   });
 
-  it("an ungranted active connection appears in no grants-view row", () => {
+  it("an ungranted active connection surfaces in availableRows", () => {
     const view = agentIntegrationsView({
       connections: [conn("gmail"), conn("slack"), conn("notion")],
       catalog: CATALOG,
       grants: ["gmail"],
     });
     if (view.mode !== "grants") throw new Error("unreachable");
-    // Section 1 has only the granted app. Connected-but-ungranted apps are a
-    // Settings > Connected accounts concern now — absent from active AND
-    // disallowed (there is no allowlist here, so nothing is disallowed).
+    // Only the granted app is usable; the connected-but-ungranted active apps
+    // now surface in availableRows (name-sorted) so the user can turn them on
+    // inline, instead of vanishing. No allowlist here → nothing disallowed.
     deepStrictEqual(
       view.activeRows.map((r) => r.connection.toolkit),
       ["gmail"],
     );
-    deepStrictEqual(view.disallowedRows, []);
-    const shown = [...view.activeRows, ...view.disallowedRows].map(
-      (r) => r.connection.toolkit,
+    deepStrictEqual(
+      view.availableRows.map((r) => r.connection.toolkit),
+      ["notion", "slack"],
     );
-    ok(!shown.includes("slack"), "ungranted active slack is not shown");
-    ok(!shown.includes("notion"), "ungranted active notion is not shown");
+    deepStrictEqual(view.disallowedRows, []);
+    ok(
+      !view.activeRows.some((r) => r.connection.toolkit === "slack"),
+      "ungranted slack is not an active row",
+    );
   });
 
   it("ungranted pending/errored connections appear in no grants-view row", () => {
@@ -101,6 +104,9 @@ describe("agentIntegrationsView", () => {
     if (view.mode !== "grants") throw new Error("unreachable");
     deepStrictEqual(view.activeRows, []);
     deepStrictEqual(view.disallowedRows, []);
+    // Only ACTIVE ungranted connections join availableRows; pending / errored
+    // ones stay hidden (recovered from the global Integrations page).
+    deepStrictEqual(view.availableRows, []);
   });
 
   it("grants mode with an empty grant set yields no active rows", () => {
@@ -112,6 +118,11 @@ describe("agentIntegrationsView", () => {
     strictEqual(view.mode, "grants");
     if (view.mode !== "grants") throw new Error("unreachable");
     deepStrictEqual(view.activeRows, []);
+    // The active-but-ungranted connection is turn-on-able.
+    deepStrictEqual(
+      view.availableRows.map((r) => r.connection.toolkit),
+      ["gmail"],
+    );
   });
 
   it("a granted slug with no matching connection is ignored", () => {
@@ -125,6 +136,18 @@ describe("agentIntegrationsView", () => {
       view.activeRows.map((r) => r.connection.toolkit),
       ["gmail"],
     );
+    // The orphan grant (slack, no connection) surfaces nowhere.
+    deepStrictEqual(view.availableRows, []);
+  });
+
+  it("degraded mode has no availableRows bucket", () => {
+    const view = agentIntegrationsView({
+      connections: [conn("gmail")],
+      catalog: CATALOG,
+      grants: null,
+    });
+    if (view.mode !== "degraded") throw new Error("unreachable");
+    strictEqual("availableRows" in view, false);
   });
 
   it("preserves non-active status on granted rows for the recovery UI", () => {

--- a/app/tests/effective-access.test.ts
+++ b/app/tests/effective-access.test.ts
@@ -1,0 +1,137 @@
+import { deepStrictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  type EffectiveAccess,
+  effectiveAccess,
+} from "../src/components/integrations/effective-access.ts";
+
+const conn = (toolkit: string) => ({ toolkit });
+
+const access = (input: {
+  toolkit: string;
+  connections?: { toolkit: string }[];
+  grants?: string[] | null;
+  allowlist?: string[] | null;
+}): EffectiveAccess =>
+  effectiveAccess({
+    toolkit: input.toolkit,
+    connections: input.connections ?? [],
+    grants: input.grants ?? null,
+    allowlist: input.allowlist ?? null,
+  });
+
+describe("effectiveAccess", () => {
+  it("usable: connected, granted, inside the allowlist", () => {
+    deepStrictEqual(
+      access({
+        toolkit: "slack",
+        connections: [conn("slack")],
+        grants: ["slack"],
+        allowlist: ["slack"],
+      }),
+      { state: "usable" },
+    );
+  });
+
+  it("usable: null grants (unsupported host) counts as granted", () => {
+    deepStrictEqual(
+      access({ toolkit: "slack", connections: [conn("slack")], grants: null }),
+      { state: "usable" },
+    );
+  });
+
+  it("usable: null allowlist (unrestricted) is not blocked", () => {
+    deepStrictEqual(
+      access({
+        toolkit: "slack",
+        connections: [conn("slack")],
+        grants: ["slack"],
+        allowlist: null,
+      }),
+      { state: "usable" },
+    );
+  });
+
+  it("notConnected: no connection for the toolkit", () => {
+    deepStrictEqual(
+      access({ toolkit: "slack", connections: [conn("gmail")], grants: [] }),
+      { state: "notConnected" },
+    );
+  });
+
+  it("notGrantedToAgent: connected but not in the grant set", () => {
+    deepStrictEqual(
+      access({
+        toolkit: "slack",
+        connections: [conn("slack")],
+        grants: ["gmail"],
+      }),
+      { state: "notGrantedToAgent" },
+    );
+  });
+
+  it("notGrantedToAgent: an empty grant record grants nothing", () => {
+    deepStrictEqual(
+      access({ toolkit: "slack", connections: [conn("slack")], grants: [] }),
+      { state: "notGrantedToAgent" },
+    );
+  });
+
+  it("blockedByAdmin: connected + granted but outside the allowlist", () => {
+    deepStrictEqual(
+      access({
+        toolkit: "slack",
+        connections: [conn("slack")],
+        grants: ["slack"],
+        allowlist: ["gmail"],
+      }),
+      { state: "blockedByAdmin" },
+    );
+  });
+
+  it("blockedByAdmin: an empty allowlist ([]) blocks everything", () => {
+    deepStrictEqual(
+      access({
+        toolkit: "slack",
+        connections: [conn("slack")],
+        grants: ["slack"],
+        allowlist: [],
+      }),
+      { state: "blockedByAdmin" },
+    );
+  });
+
+  it("precedence: blocked beats notConnected", () => {
+    // No connection AND outside the allowlist → the admin reason wins.
+    deepStrictEqual(
+      access({ toolkit: "slack", connections: [], allowlist: ["gmail"] }),
+      { state: "blockedByAdmin" },
+    );
+  });
+
+  it("precedence: blocked beats notGrantedToAgent", () => {
+    // Connected, ungranted, AND outside the allowlist → admin reason wins.
+    deepStrictEqual(
+      access({
+        toolkit: "slack",
+        connections: [conn("slack")],
+        grants: [],
+        allowlist: ["gmail"],
+      }),
+      { state: "blockedByAdmin" },
+    );
+  });
+
+  it("precedence: notConnected beats notGrantedToAgent", () => {
+    // Inside the allowlist, ungranted, but no connection → connection wins.
+    deepStrictEqual(
+      access({
+        toolkit: "slack",
+        connections: [],
+        grants: [],
+        allowlist: ["slack"],
+      }),
+      { state: "notConnected" },
+    );
+  });
+});

--- a/knowledge-base/integrations.md
+++ b/knowledge-base/integrations.md
@@ -172,8 +172,19 @@ TWO places so policy is never silently invisible: connected-but-blocked apps und
 `teams:integrations.notAllowed` (the disallowed section, "Not allowed" badge + an
 ask-your-admin line), and NOT-connected blocked apps as **locked rows** in the
 browse catalog (see §3, `integrations:locked.*`). Per-agent GRANT toggles are a
-SEPARATE concept and live in ONE place only — Settings > Connected accounts (§3),
+SEPARATE concept with TWO lenses — by-app in Settings > Connected accounts and
+by-agent on the agent tab's "Connected, but off for this agent" section (§3) —
 never this ceiling editor. Full client surface: `knowledge-base/teams.md`.
+
+### Effective access — the one resolver
+
+`effectiveAccess({toolkit, connections, grants, allowlist})`
+(`app/src/components/integrations/effective-access.ts`, pure, node-tested) is
+THE single answer to "can this agent use this app right now, and if not why":
+`usable | notConnected | notGrantedToAgent | blockedByAdmin`, precedence
+admin-block > not-connected > not-granted. `grants === null` (unsupported host)
+and `allowlist === null` (unrestricted) both read as pass. The agent-tab view
+model classifies every connection through it — no surface re-derives the rule.
 
 ### Local / self-host grants (NEW — desktop + self-host parity)
 `packages/host/src/integrations/grants.ts` (`LocalIntegrationGrants`) +
@@ -440,7 +451,7 @@ Integrations page (now the personal catalog for every member, so the old
 a producer calls `useUIStore.setSettingsSection("connectedAccounts")` + `setViewMode("settings")`;
 `settings-view.tsx` consumes it ONE-SHOT (reads the pending section, then clears it).
 
-**Agent tab (pure connect surface)** — `app/src/components/tabs/agent-integrations/`
+**Agent tab (the by-agent lens)** — `app/src/components/tabs/agent-integrations/`
 (`integrations-tab.tsx` re-exports the orchestrator). The tab body is the SAME
 catalog layout as the global Integrations page, minus the page header (the tab
 label already says Integrations): `agent-integrations-body.tsx` renders the shared
@@ -452,12 +463,19 @@ tab is the SHARED `CatalogPane` (`integrations-view/catalog-pane.tsx`: search +
 A-Z searchable category combobox, recovery rows, the grouped `CategoryCatalog`),
 generalized to plain props (`catalog`/`connections`/`recovering`/`allowlist`/
 `readOnly`/`children`) so both surfaces consume it verbatim — the agent tab passes
-the disallowed-apps section as its `children` and `readOnly` (`!canEditAgentGrants`)
-to strip the recovery rows' actions for Teams viewers. Activate/deactivate GRANT
-affordances stay GONE (grant editing lives only in Settings > Connected accounts);
-the `grants`-mode view is `{activeRows, disallowedRows}` (active rows split into
-strip tiles vs recovery rows by connection status); `degraded` mode (grants `null`)
-treats all connected apps as usable. Recovery **Remove** DISCONNECTS in both modes.
+`AgentCatalogSections` as its `children` and `readOnly` (`!canEditAgentGrants`)
+to strip the recovery rows' actions for Teams viewers. The `grants`-mode view is
+`{activeRows, disallowedRows, availableRows}`, every connection classified through
+the ONE `effectiveAccess` resolver (§2): active rows split into strip tiles vs
+recovery rows by connection status; `availableRows` (connected on the account but
+NOT granted to this agent, `active` status only — pending/errored orphans are
+recovered from the global page) render as the **"Connected, but off for this
+agent"** section (`agent-ungranted-apps-section.tsx`,
+`integrations:agentTab.offForAgent.*`): `AppRow`s with a trailing `Switch` that
+grants via `useAgentGrantMutation` (optimistic — the row migrates to the Installed
+strip); viewers without `canEditAgentGrants` see the rows without the Switch, so
+the state is never invisible. The disallowed section renders below it. `degraded`
+mode (grants `null`) treats all connected apps as usable. Recovery **Remove** DISCONNECTS in both modes.
 Connect still auto-grants to this agent (`useConnectFlow` `autoGrant`). The tab
 count chip excludes locked apps. All lifted view state (tab/search/category/modals)
 lives in the body, remounted per agent via `key={agent.id}`. The bottom link

--- a/packages/web/e2e/integrations-ia.spec.ts
+++ b/packages/web/e2e/integrations-ia.spec.ts
@@ -12,9 +12,15 @@ import { expect, test } from "./support/fixtures";
  *    personal catalog now;
  *  - CATALOG (the caller's personal connected apps) → the global Integrations
  *    page, visible to EVERY role in every mode (a plain member keeps its nav);
- *  - ACCOUNTS (the user's connected apps + the per-agent grants surface) →
- *    Settings > Connected accounts;
- *  - the agent Integrations TAB → a pure connect surface (no grant toggles).
+ *  - ACCOUNTS (the user's connected apps + the arbitrary-agent grants surface)
+ *    → Settings > Connected accounts;
+ *  - the agent Integrations TAB → a connect surface that ALSO surfaces the
+ *    account's connected-but-ungranted apps in a "Connected, but off for this
+ *    agent" section, each with an inline Switch that grants the app to THIS
+ *    agent (turning it on moves it to the Installed strip via a grant PUT).
+ *    Browse excludes connected apps, and the tab's app detail dialog carries no
+ *    per-agent toggles; editing an ARBITRARY agent's grants still lives in
+ *    Settings > Connected accounts.
  *
  * The Teams-shaped state single-player can't reach is armed via the fake host's
  * `/__test__/capabilities` (advertise `multiplayer` + `teams` + a `role`) and
@@ -261,31 +267,93 @@ test("Settings > Connected accounts: a connected app opens the per-agent grant s
   await expect(page.getByRole("switch", { name: "Houston" })).toBeChecked();
 });
 
-// ── 5. Agent tab is a pure connect surface ─────────────────────────────────
+// ── 5. Agent tab surfaces connected-but-off apps and grants them inline ─────
 
-test("Agent Integrations tab: pure connect surface, no per-agent grant affordances", async ({
+test("Agent Integrations tab: a connected-but-ungranted app shows in the off-for-this-agent section", async ({
   page,
   request,
 }) => {
-  // Grants supported (a record exists), so the OLD tab would have shown
-  // activate/deactivate controls. In the IA end-state those moved to Settings,
-  // leaving the tab a connect-only surface.
+  // Grants supported (an empty record EXISTS, so the host is in grants mode), but
+  // the seeded Gmail connection is NOT granted to this agent — the
+  // connected-but-off case. It must surface in its own section, not hide.
   await armCapabilities(request, { integrations: ["composio"] });
-  await seedGrants(request, ["gmail"]);
+  await seedGrants(request, []);
   await page.goto("/");
   await page.locator('[data-tour-target="tab-integrations"]').click();
 
-  // The connect catalog still renders (search box + a connectable app row)...
+  // The connect catalog still renders (search box + a connectable, not-connected
+  // app row)...
   await expect(page.getByPlaceholder("Search integrations...")).toBeVisible();
   await expect(
     page.getByRole("button").filter({ hasText: "Slack" }).first(),
   ).toBeVisible();
 
-  // ...but NO per-agent grant affordances survive anywhere on the tab.
-  await expect(page.getByText("Activate for this agent")).toHaveCount(0);
+  // ...and the connected-but-off section carries Gmail with its turn-on Switch.
   await expect(
-    page.getByRole("button", { name: /Remove from this agent/ }),
+    page.getByRole("heading", { name: "Connected, but off for this agent" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("switch", { name: "Turn on Gmail for this agent" }),
+  ).toBeVisible();
+
+  // Gmail is connected, so browse excludes it, and (ungranted) the Installed
+  // strip has no Gmail tile — Gmail lives ONLY in the off-section, whose row is a
+  // plain, non-button surface. So no button carries its name anywhere on the tab.
+  await expect(page.getByRole("button", { name: "Gmail" })).toHaveCount(0);
+});
+
+test("Agent Integrations tab: turning on a connected-but-off app grants it and it moves to Installed", async ({
+  page,
+  request,
+}) => {
+  await armCapabilities(request, { integrations: ["composio"] });
+  await seedGrants(request, []);
+  await page.goto("/");
+  await page.locator('[data-tour-target="tab-integrations"]').click();
+
+  // Flip the turn-on Switch: the grant PUT round-trips through the host's grant
+  // routes and the optimistic update moves Gmail into the Installed strip (a tile
+  // whose accessible name is the app name)...
+  await page
+    .getByRole("switch", { name: "Turn on Gmail for this agent" })
+    .click();
+  await expect(page.getByRole("button", { name: "Gmail" })).toBeVisible();
+  // ...and with no more off-for-this-agent apps, the section disappears.
+  await expect(
+    page.getByRole("heading", { name: "Connected, but off for this agent" }),
   ).toHaveCount(0);
+
+  // Persistence: a full reload re-reads the grants from the host; Gmail is still
+  // installed and the off-section stays gone — the toggle reached the gateway,
+  // not just the client cache.
+  await page.reload();
+  await page.locator('[data-tour-target="tab-integrations"]').click();
+  await expect(page.getByRole("button", { name: "Gmail" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Connected, but off for this agent" }),
+  ).toHaveCount(0);
+});
+
+test("Agent Integrations tab: the app detail dialog has no per-agent grant toggles", async ({
+  page,
+  request,
+}) => {
+  // Gmail granted → it tiles the Installed strip. Opening its detail dialog on
+  // the tab must NOT expose the per-agent grant block (that lives in Settings),
+  // so the tab never becomes a second grants editor.
+  await armCapabilities(request, { integrations: ["composio"] });
+  await seedGrants(request, ["gmail"]);
+  await page.goto("/");
+  await page.locator('[data-tour-target="tab-integrations"]').click();
+
+  await page.getByRole("button", { name: "Gmail" }).click();
+
+  // The shared detail dialog opens (its Disconnect affordance is present)...
+  await expect(page.getByRole("button", { name: "Disconnect" })).toBeVisible();
+  // ...but the "Agents that can use this" grant block — and any per-agent Switch —
+  // is absent: the tab defers all grant editing to Settings.
+  await expect(page.getByText("Agents that can use this")).toHaveCount(0);
+  await expect(page.getByRole("switch")).toHaveCount(0);
 });
 
 // ── 6. Member manage link → the personal Integrations page ─────────────────


### PR DESCRIPTION
## Element 1 of the permissions-clarity work: one resolver + the by-agent lens

**Problem:** an app could be connected on the account but not granted to an agent, and the agent's Integrations tab simply hid it. Nothing anywhere answered "can this agent use this app right now, and if not why" — users hit unusable integrations with no idea which switch was off.

**This PR:**
- New pure resolver `effectiveAccess({toolkit, connections, grants, allowlist})` → `usable | notConnected | notGrantedToAgent | blockedByAdmin` (`app/src/components/integrations/effective-access.ts`). Admin-block outranks not-connected outranks not-granted. The agent-tab view model now classifies every connection through it — one classifier, no parallel re-derivation.
- The agent Integrations tab shows connected-but-ungranted apps in a new **"Connected, but off for this agent"** section (grants-mode `availableRows`, active connections only) with an inline Switch that grants the app to this agent (optimistic; the row migrates to the Installed strip). Viewers without grant-edit rights see the rows read-only. i18n en/es/pt.
- KB (`knowledge-base/integrations.md`) updated: agent tab is now the by-agent lens; resolver documented.

**Verification:** app node tests 1614/1614 · `pnpm check` (Biome) · `app tsgo --noEmit` · `check-locales` (23 ns in sync) · `houston-web` typecheck + shim parity · Playwright `integrations-ia.spec.ts` 8/8 (Section 5 rewritten for the new behavior + 3 new tests: section shows, toggle grants + persists across reload, detail dialog still toggle-free).

Next elements (separate PRs): fold Settings > Connected accounts into the Integrations page; action-approvals review/revoke UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)