### PR TITLE
fix(chat): pin the agent's configured model on setup-chat kickoffs

### DIFF
--- a/app/src/components/integrations/use-integration-chat-setup.ts
+++ b/app/src/components/integrations/use-integration-chat-setup.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useActivity, useAllConversations } from "../../hooks/queries";
+import { readAgentModelOverrides } from "../../lib/agent-model-overrides";
 import { analytics } from "../../lib/analytics";
 import { createMission } from "../../lib/create-mission";
 import { genericErrorDescription } from "../../lib/error-toast";
@@ -139,6 +140,13 @@ export function useIntegrationChatSetup() {
               agent.folderPath,
               tauriConfig.read,
             ),
+            // Pin the agent's configured brain onto the kickoff turn — an
+            // unpinned send resolves inside the runtime and lands on the
+            // provider default (Sonnet), not the model the user picked.
+            ...(await readAgentModelOverrides(
+              agent.folderPath,
+              tauriConfig.read,
+            )),
             buildPrompt: () => encodeIntegrationSetupMessage(),
           },
         );

--- a/app/src/components/tabs/use-routine-chat-setup.ts
+++ b/app/src/components/tabs/use-routine-chat-setup.ts
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useActivity } from "../../hooks/queries";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { useProviderStatuses } from "../../hooks/use-provider-statuses";
+import { readAgentModelOverrides } from "../../lib/agent-model-overrides";
 import { analytics } from "../../lib/analytics";
 import { createMission } from "../../lib/create-mission";
 import { providerName } from "../../lib/providers";
@@ -92,6 +93,10 @@ export function useRoutineChatSetup(
         title: missionTitle,
         agentMode: mode,
         modeOverride: await readAgentTurnMode(path, tauriConfig.read),
+        // Pin the agent's configured brain onto the kickoff turn — an unpinned
+        // send resolves inside the runtime and lands on the provider default
+        // (Sonnet), not the model the user picked.
+        ...(await readAgentModelOverrides(path, tauriConfig.read)),
         buildPrompt: (activityId) =>
           encodeRoutineSetupMessage(
             activityId,
@@ -129,6 +134,8 @@ export function useRoutineChatSetup(
             title: routine.name,
             agentMode: mode,
             modeOverride: await readAgentTurnMode(path, tauriConfig.read),
+            // Same brain pin as startDraft — see the comment there.
+            ...(await readAgentModelOverrides(path, tauriConfig.read)),
           },
         );
         await Promise.all([

--- a/app/src/lib/agent-model-overrides.ts
+++ b/app/src/lib/agent-model-overrides.ts
@@ -1,0 +1,77 @@
+/**
+ * The agent's configured brain, as per-turn wire pins for send paths that
+ * assemble their own overrides (the routine and custom-integration setup-chat
+ * kickoffs) instead of holding the chat panel's live state.
+ *
+ * A send WITHOUT provider/model pins does not run on the agent's configured
+ * model: the runtime resolves an unpinned turn from its OWN `settings.json`
+ * (`activeProvider` + `models[provider]`), never from the agent config the
+ * model picker writes (`.houston/config/config.json`) — so it lands on the
+ * provider default (Sonnet). The config only reaches a turn as the pins each
+ * send forwards, which is exactly what the chat panel's `effectiveProvider` /
+ * `effectiveModel` do; this is the same resolution for kickoffs created
+ * outside a panel.
+ */
+
+import {
+  getDefaultModel,
+  normalizeLegacyModel,
+  validEffortOrDefault,
+  validModelOrNull,
+  validProviderOrNull,
+} from "./providers.ts";
+
+export interface AgentModelOverrides {
+  providerOverride?: string;
+  modelOverride?: string;
+  effortOverride?: string;
+}
+
+interface BrainConfig {
+  provider?: string;
+  model?: string;
+  effort?: string;
+}
+
+/**
+ * Resolve the kickoff pins from a loaded agent config, mirroring the chat
+ * panel's chain: a stored provider counts only while it's still offered; the
+ * stored model (legacy aliases normalized) must belong to it, else the
+ * provider's catalog default; effort is clamped to what that model accepts.
+ * No valid stored provider → no pins at all, so the runtime resolves the turn
+ * exactly as before (its active provider), never a half-pin the runtime would
+ * reject.
+ */
+export function resolveAgentModelOverrides(
+  cfg: BrainConfig,
+): AgentModelOverrides {
+  const provider = validProviderOrNull(cfg.provider);
+  if (!provider) return {};
+  const model =
+    validModelOrNull(provider, normalizeLegacyModel(cfg.model)) ??
+    getDefaultModel(provider);
+  const effort = cfg.effort
+    ? validEffortOrDefault(provider, model, cfg.effort)
+    : undefined;
+  return {
+    providerOverride: provider,
+    modelOverride: model,
+    ...(effort ? { effortOverride: effort } : {}),
+  };
+}
+
+/**
+ * Read + resolve in one step (the send-path convenience, mirrors
+ * `readAgentTurnMode`). A failed config read falls back to no pins — the safe
+ * default for a preference lookup; the send itself still surfaces its errors.
+ */
+export async function readAgentModelOverrides(
+  agentPath: string,
+  readConfig: (path: string) => Promise<BrainConfig>,
+): Promise<AgentModelOverrides> {
+  try {
+    return resolveAgentModelOverrides(await readConfig(agentPath));
+  } catch {
+    return {};
+  }
+}

--- a/app/tests/agent-model-overrides.test.ts
+++ b/app/tests/agent-model-overrides.test.ts
@@ -1,0 +1,91 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { before, describe, it } from "node:test";
+import {
+  readAgentModelOverrides,
+  resolveAgentModelOverrides,
+} from "../src/lib/agent-model-overrides.ts";
+import { hydrateProviderCatalog } from "../src/lib/providers.ts";
+import { SAMPLE_CATALOG } from "./fixtures/sample-catalog.ts";
+
+before(() => hydrateProviderCatalog(SAMPLE_CATALOG));
+
+describe("resolveAgentModelOverrides", () => {
+  it("pins the agent's configured provider + model (the reported bug: a setup-chat kickoff must run the configured model, not the Sonnet default)", () => {
+    deepStrictEqual(
+      resolveAgentModelOverrides({
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+      }),
+      { providerOverride: "anthropic", modelOverride: "claude-opus-4-8" },
+    );
+  });
+
+  it("forwards a stored effort the model accepts", () => {
+    deepStrictEqual(
+      resolveAgentModelOverrides({
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+        effort: "high",
+      }),
+      {
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-8",
+        effortOverride: "high",
+      },
+    );
+  });
+
+  it("returns no pins when the config names no provider (the runtime keeps resolving the turn itself)", () => {
+    deepStrictEqual(resolveAgentModelOverrides({}), {});
+    deepStrictEqual(
+      resolveAgentModelOverrides({ model: "claude-opus-4-8" }),
+      {},
+    );
+  });
+
+  it("returns no pins for a provider Houston no longer offers", () => {
+    deepStrictEqual(
+      resolveAgentModelOverrides({ provider: "gemini-cli", model: "x" }),
+      {},
+    );
+  });
+
+  it("falls a stale model back to the provider's catalog default", () => {
+    const pins = resolveAgentModelOverrides({
+      provider: "anthropic",
+      model: "claude-9-imaginary",
+    });
+    strictEqual(pins.providerOverride, "anthropic");
+    strictEqual(pins.modelOverride, "claude-sonnet-5");
+  });
+
+  it("normalizes a legacy alias at the same tier (no Opus→Sonnet downgrade)", () => {
+    const pins = resolveAgentModelOverrides({
+      provider: "anthropic",
+      model: "opus",
+    });
+    strictEqual(pins.modelOverride, "claude-opus-4-7");
+  });
+});
+
+describe("readAgentModelOverrides", () => {
+  it("reads the config and resolves it", async () => {
+    const pins = await readAgentModelOverrides("/a", async (path) => {
+      strictEqual(path, "/a");
+      return { provider: "anthropic", model: "claude-opus-4-8" };
+    });
+    deepStrictEqual(pins, {
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-8",
+    });
+  });
+
+  it("falls back to no pins when the config read fails", async () => {
+    deepStrictEqual(
+      await readAgentModelOverrides("/a", async () => {
+        throw new Error("boom");
+      }),
+      {},
+    );
+  });
+});


### PR DESCRIPTION
## Problem

When setting up an AI integration (the "Add custom integration" guided chat), the first turn always ran on `claude-sonnet-5` instead of the model the user configured for the agent. The routine setup chat kickoffs had the same bug.

## Root cause

Both setup-chat kickoffs create their mission via `createMission` **without provider/model pins**. An unpinned turn is resolved inside the pi runtime from its own `settings.json` (`activeProvider` + `models[provider]`), never from the agent config the model picker writes (`.houston/config/config.json`) — so it lands on the provider built-in default (`claude-sonnet-5`, `packages/runtime/src/config.ts`). The configured model only reaches a turn as per-send wire pins, which every board send forwards from the chat panel — these kickoff paths assembled their own options and forwarded none.

## Fix

- New `app/src/lib/agent-model-overrides.ts`: `readAgentModelOverrides(agentPath, readConfig)` reads the agent config and resolves it the same way the chat panel does (`validProviderOrNull` → `normalizeLegacyModel` + `validModelOrNull` → `getDefaultModel` fallback, effort clamped via `validEffortOrDefault`). No valid stored provider → no pins at all, so the runtime keeps resolving the turn exactly as before — never a half-pin it would reject.
- `use-integration-chat-setup.ts` and `use-routine-chat-setup.ts` (`startDraft` + `startForRoutine`) forward those pins through `createMission`, which also stamps them onto the activity so the panel shows the right model from the start.

## Tests

- New `app/tests/agent-model-overrides.test.ts` (8 cases: configured pin, effort forwarding, no-provider / retired-provider fallthrough, stale-model fallback to provider default, legacy alias at same tier — no Opus→Sonnet downgrade).
- Full app suite: 1610 pass, 0 fail. `tsgo --noEmit` clean on `app/` and `packages/web` (shim parity OK). Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
