### PR TITLE
fix(onboarding): require initial email action

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -27,7 +27,6 @@ import { analytics } from "./lib/analytics";
 import { shouldAllowNativeContextMenu } from "./lib/context-menu";
 import { newEngineActive } from "./lib/engine";
 import { isIdentityConfigured } from "./lib/identity";
-import { ONBOARDING_SEGMENT_SKIPPED } from "./lib/onboarding-segment";
 import {
   clearUser as clearSentryUser,
   setUser as setSentryUser,
@@ -305,9 +304,6 @@ export default function App() {
             saving={onboardingSegment.isSaving}
             onContinue={async (segment) => {
               await onboardingSegment.saveSegment(segment);
-            }}
-            onSkip={async () => {
-              await onboardingSegment.saveSegment(ONBOARDING_SEGMENT_SKIPPED);
             }}
           />
         )

--- a/app/src/components/onboarding/missions/connect-email.tsx
+++ b/app/src/components/onboarding/missions/connect-email.tsx
@@ -1,4 +1,3 @@
-import { Button, ConfirmDialog } from "@houston-ai/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -13,43 +12,30 @@ import { GoogleIcon, MicrosoftIcon } from "../../auth/provider-brand-icons";
 import { INTEGRATION_PROVIDER, useConnectFlow } from "../../integrations";
 import { SetupCard } from "../setup-card";
 import { EmailActionRow } from "./email-action-row";
-import { isToolkitConnected, shouldOfferConnectSkip } from "./onboarding-flow";
+import { isToolkitConnected } from "./onboarding-flow";
 
-/** A click within this window of a connect starting is a stray double-tap, not
- *  an intent to cancel — ignore it so a double click can't start-then-abort. */
+/** Ignore a second click immediately after OAuth begins. */
 const CANCEL_GUARD_MS = 300;
 
 interface ConnectEmailMissionProps {
   eyebrow: string;
-  /** The agent created in the previous step — connect is scoped to it. */
+  /** The agent created in the previous step, connect is scoped to it. */
   agent: Agent;
   onBack: () => void;
   /** Fires once the chosen email toolkit is connected and active. */
   onConnected: (toolkit: string, label: string) => void;
-  /** Escape hatch for a dead end (gateway unready, OAuth failed): skip the
-   *  email steps rather than strand first-run with no way forward. */
-  onSkip: () => void;
 }
 
 /**
- * Onboarding: give the agent access to the user's email. Two one-click brand
- * ACTION rows (Gmail, Outlook) — tap one and the app's own OAuth on the
- * integrations provider starts immediately (platform mode — no Composio
- * account, no sign-in step; see `integrations/model.ts`). No
- * select-then-Connect two-step, no selection state: these are buttons. While a
- * connect is in flight its row becomes a CANCEL control (mirrors the AI step's
- * Connect pill); the other disables. `useConnectFlow` mints the hosted link,
- * opens the browser, and polls until the connection turns active; we hand off
- * the moment the tapped toolkit shows up connected. Other providers connect
- * later from Integrations (the skip hint says so) — a free-text row here fed
- * raw slugs to Composio and mostly failed, so it was removed.
+ * Give the agent access to email through one of two direct OAuth actions. This
+ * step intentionally has no exit path: the first live email message is the
+ * onboarding proof point, and its conversation owns the only later exit.
  */
 export function ConnectEmailMission({
   eyebrow,
   agent,
   onBack,
   onConnected,
-  onSkip,
 }: ConnectEmailMissionProps) {
   const { t } = useTranslation("setup");
   const { capabilities } = useCapabilities();
@@ -57,16 +43,7 @@ export function ConnectEmailMission({
     toolkit: string;
     label: string;
   } | null>(null);
-  // Once the user has kicked off a connect, keep the detection query enabled
-  // regardless of the cached ready flag: `useConnectFlow` invalidates it when
-  // its OAuth poll resolves, and we must refetch to see the new connection
-  // even if the status cache still lags on `ready`.
   const [attempted, setAttempted] = useState(false);
-  const [skipConfirmOpen, setSkipConfirmOpen] = useState(false);
-
-  // The gateway is "ready" only once it has the Houston session (App's session
-  // sync pushes it). Gate the connection poll on it so we never fire a failing
-  // call while the provider is still warming up (before any connect attempt).
   const status = useIntegrationStatus();
   const ready = !!status.data?.find((p) => p.provider === INTEGRATION_PROVIDER)
     ?.ready;
@@ -74,9 +51,6 @@ export function ConnectEmailMission({
     INTEGRATION_PROVIDER,
     ready || attempted,
   );
-
-  // Multiplayer: a connection made from this agent's flow is auto-granted to it
-  // (mirrors the integrations tab). Single-player has no grants — this is false.
   const autoGrant = canManageAgentGrants(capabilities, agent);
   const {
     state: connectState,
@@ -88,14 +62,6 @@ export function ConnectEmailMission({
   });
   const connecting = connectState !== null;
 
-  // Advance the moment the tapped toolkit lands active. `useIntegrationConnect`
-  // invalidates the connections query when its OAuth poll resolves, so the
-  // refetch drives this. Guarded by a ref so the hand-off fires exactly once —
-  // so a "connected" that lands in the same beat as a cancel click still wins.
-  // `chosen` records which toolkit was last tapped so the match still holds.
-  // Intended: if the user goes Back and returns, this remounts with a fresh ref,
-  // so re-tapping an already-connected toolkit auto-advances immediately (no
-  // second OAuth) — that's the right outcome, they already granted access.
   const handedOff = useRef(false);
   useEffect(() => {
     if (handedOff.current) return;
@@ -105,13 +71,6 @@ export function ConnectEmailMission({
     }
   }, [chosen, connections.data, onConnected]);
 
-  // One-click connect. Record the toolkit so the auto-advance effect matches it,
-  // then kick off OAuth — unless it is already connected (a return after Back),
-  // in which case the effect advances with no second OAuth. `busyRef` is the
-  // synchronous rage-click guard (HOU-465): `connecting` only flips on the next
-  // render, so two fast taps could both pass a `disabled` check; the ref blocks
-  // the second before it can setChosen a different toolkit or mint a second
-  // OAuth flow (useConnectFlow also single-flights internally).
   const busyRef = useRef(false);
   const startedAtRef = useRef(0);
   const startConnect = useCallback(
@@ -129,17 +88,11 @@ export function ConnectEmailMission({
     [connect, connections.data],
   );
 
-  // Cancel the in-flight OAuth wait: stops the poll loop and resets the flow so
-  // `connecting` clears (the already-opened browser tab can't be closed from
-  // here — same as the AI step's cancel). A cancel is a user action, not an
-  // error, so no toast. Guarded so a stray double-tap on a just-started row
-  // can't read as an instant cancel.
   const tryCancel = useCallback(() => {
     if (Date.now() - startedAtRef.current < CANCEL_GUARD_MS) return;
     cancel();
   }, [cancel]);
 
-  // A brand row: cancel its own in-flight connect, or start one.
   const onBrandRow = useCallback(
     (toolkit: string, label: string) => {
       if (connectState?.toolkit === toolkit) {
@@ -151,18 +104,9 @@ export function ConnectEmailMission({
     [connectState, tryCancel, startConnect],
   );
 
-  // Always offered (bar an in-flight connect): the route can exist
-  // (capabilities) while the gateway is unready or the OAuth hop failed, and a
-  // first-run with no Continue strands the user. A confirm dialog is the
-  // actual friction — see `skipConfirmOpen` below — so hiding the affordance
-  // itself would just relocate the dead end.
-  const showSkip = shouldOfferConnectSkip({ connecting });
-
   const busyLabel = t("tutorial.missions.connectEmail.connecting");
   const cancelLabel = t("tutorial.missions.connectEmail.cancel");
   const isLoading = (toolkit: string) => connectState?.toolkit === toolkit;
-  // Other rows disable while any connect is in flight; the in-flight one stays
-  // enabled as its own cancel control.
   const disabledExcept = (toolkit: string) =>
     connecting && connectState?.toolkit !== toolkit;
 
@@ -175,7 +119,7 @@ export function ConnectEmailMission({
       onBack={onBack}
       backLabel={t("tutorial.nav.back")}
     >
-      <div className="flex flex-1 flex-col items-center justify-center gap-4">
+      <div className="flex flex-1 flex-col items-center justify-center">
         <div className="flex w-full max-w-md flex-col gap-3">
           <EmailActionRow
             icon={<GoogleIcon />}
@@ -196,33 +140,7 @@ export function ConnectEmailMission({
             onClick={() => onBrandRow("outlook", "Outlook")}
           />
         </div>
-        {showSkip && (
-          <div className="flex items-center justify-center gap-3">
-            <p className="min-w-0 text-xs text-ink-muted">
-              {t("tutorial.missions.connectEmail.skipHint")}
-            </p>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="shrink-0"
-              onClick={() => setSkipConfirmOpen(true)}
-            >
-              {t("tutorial.missions.connectEmail.skip")}
-            </Button>
-          </div>
-        )}
       </div>
-      <ConfirmDialog
-        open={skipConfirmOpen}
-        onOpenChange={setSkipConfirmOpen}
-        title={t("tutorial.missions.connectEmail.skipConfirmTitle")}
-        description={t("tutorial.missions.connectEmail.skipConfirmBody")}
-        confirmLabel={t("tutorial.missions.connectEmail.skipConfirmAction")}
-        cancelLabel={t("tutorial.missions.connectEmail.skipConfirmCancel")}
-        variant="default"
-        onConfirm={onSkip}
-      />
     </SetupCard>
   );
 }

--- a/app/src/components/onboarding/missions/email-mission-setup.ts
+++ b/app/src/components/onboarding/missions/email-mission-setup.ts
@@ -1,0 +1,67 @@
+import type { FeedItem } from "@houston-ai/chat";
+import { useEffect, useMemo } from "react";
+import { logger } from "../../../lib/logger";
+import { tauriAgent } from "../../../lib/tauri";
+import {
+  appendSetupSection,
+  stripSetupSection,
+} from "../tutorial-system-prompt";
+
+/** The agent emits this once the email actually sent. */
+const SETUP_END_RE = /\[\s*\\?TUTORIAL[_\s\\]+COMPLETED?\s*\]/i;
+
+interface PrepareEmailSetupArgs {
+  agentPath: string;
+  emailToolkit: string;
+  emailToolkitLabel: string;
+}
+
+/** Removes the temporary onboarding directive when the email mission leaves. */
+export function useEmailSetupCleanup(agentPath: string) {
+  useEffect(() => {
+    return () => {
+      void (async () => {
+        try {
+          const current = await tauriAgent.readFile(agentPath, "CLAUDE.md");
+          const stripped = stripSetupSection(current);
+          if (stripped !== current) {
+            await tauriAgent.writeFile(agentPath, "CLAUDE.md", stripped);
+          }
+        } catch (error) {
+          logger.warn(`[email-setup] could not strip setup section: ${error}`);
+        }
+      })();
+    };
+  }, [agentPath]);
+}
+
+/** Whether the agent's live feed contains the onboarding completion marker. */
+export function useEmailSetupCompleted(feed: FeedItem[] | undefined): boolean {
+  return useMemo(() => {
+    for (let i = (feed?.length ?? 0) - 1; i >= 0; i--) {
+      const item = feed?.[i];
+      if (item?.feed_type !== "assistant_text") continue;
+      if (typeof item.data === "string" && SETUP_END_RE.test(item.data)) {
+        return true;
+      }
+    }
+    return false;
+  }, [feed]);
+}
+
+/** Adds the email-specific directive before the agent receives its first turn. */
+export async function prepareEmailMissionSetup({
+  agentPath,
+  emailToolkit,
+  emailToolkitLabel,
+}: PrepareEmailSetupArgs) {
+  const current = await tauriAgent.readFile(agentPath, "CLAUDE.md");
+  const updated = appendSetupSection(current, {
+    toolkit: emailToolkit,
+    toolkitLabel: emailToolkitLabel,
+    toMyself: true,
+  });
+  if (updated !== current) {
+    await tauriAgent.writeFile(agentPath, "CLAUDE.md", updated);
+  }
+}

--- a/app/src/components/onboarding/missions/email-offer-action.tsx
+++ b/app/src/components/onboarding/missions/email-offer-action.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@houston-ai/core";
+import { ArrowRight } from "lucide-react";
+
+interface EmailOfferActionProps {
+  description: string;
+  label: string;
+  onStart: () => void;
+}
+
+/**
+ * The one deliberate action that starts the live email demonstration. It uses
+ * a quiet focus-token halo so the CTA is discoverable without borrowing the
+ * animated running glow, which is reserved for work already in progress.
+ */
+export function EmailOfferAction({
+  description,
+  label,
+  onStart,
+}: EmailOfferActionProps) {
+  return (
+    <div
+      className="rounded-xl border border-line/60 bg-input p-3"
+      data-onboarding-email-offer
+    >
+      <p className="mb-3 text-sm text-ink">{description}</p>
+      <div className="relative">
+        <span
+          aria-hidden
+          className="pointer-events-none absolute -inset-1 rounded-full bg-focus/10 blur-sm"
+        />
+        <span
+          aria-hidden
+          className="pointer-events-none absolute -inset-1 rounded-full ring-1 ring-focus/30"
+        />
+        <Button
+          className="relative h-11 w-full justify-between rounded-full px-4"
+          onClick={onStart}
+          size="lg"
+          type="button"
+        >
+          <span>{label}</span>
+          <ArrowRight className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/onboarding/missions/email-skip.ts
+++ b/app/src/components/onboarding/missions/email-skip.ts
@@ -2,19 +2,14 @@
  * Whether to offer the "skip" escape hatch on the final email onboarding step.
  *
  * The step normally auto-advances when the agent emits the
- * `[TUTORIAL_COMPLETED]` marker. Some models (e.g. gpt-5.5) send the email but
- * never emit the marker, leaving the user stuck with no forward affordance
- * (HOU-555). We surface the skip ONLY once the agent has actually run and gone
- * idle WITHOUT confirming completion, so we never nudge people to bail
- * mid-send or before they have even tried.
+ * `[TUTORIAL_COMPLETED]` marker. The only escape is the live conversation,
+ * and it becomes available only after the offer has sent its first message.
  */
 export function shouldOfferSkip(args: {
-  /** The mission session has gone active at least once (the agent ran). */
-  hasRun: boolean;
-  /** The agent's session is currently working. */
-  isActive: boolean;
+  /** The email offer successfully started the agent conversation. */
+  hasFirstMessage: boolean;
   /** The completion marker was seen (the happy path auto-advances instead). */
   setupDone: boolean;
 }): boolean {
-  return args.hasRun && !args.isActive && !args.setupDone;
+  return args.hasFirstMessage && !args.setupDone;
 }

--- a/app/src/components/onboarding/missions/email.tsx
+++ b/app/src/components/onboarding/missions/email.tsx
@@ -1,10 +1,6 @@
-import {
-  ChatInteractionCard,
-  type ChatInteractionStep,
-  ChatPanel,
-} from "@houston-ai/chat";
+import { ChatPanel } from "@houston-ai/chat";
 import { Button, HoustonAvatar, resolveAgentColor } from "@houston-ai/core";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFileToolRenderer } from "../../../hooks/use-file-tool-renderer";
 import { tauriSystem } from "../../../lib/tauri";
@@ -12,6 +8,7 @@ import type { Agent } from "../../../lib/types";
 import { useChatDisplayLabels } from "../../use-chat-display-labels";
 import { useQueuedMessageLabels } from "../../use-queued-message-labels";
 import { SetupCard } from "../setup-card";
+import { EmailOfferAction } from "./email-offer-action";
 import { useEmailMissionSession } from "./use-email-mission-session";
 
 /** Strip the completion marker (with optional surrounding bold) from a reply. */
@@ -30,17 +27,15 @@ interface EmailMissionProps {
   onBack: () => void;
   /** Advance to the success screen once the email is sent. */
   onContinue: () => void;
-  /** Escape hatch: leave onboarding and go straight into the app. Shown only
-   *  once the agent ran but never confirmed completion (HOU-555). */
+  /** Leave onboarding after the first message has started the AI conversation. */
   onSkip: () => void;
 }
 
 /**
  * Final onboarding step: the agent sends one real email to the user themselves.
- * The email is already connected (previous step), so this is just a single
- * "Send an email to myself" card; the agent reads the directive from CLAUDE.md
- * and sends. The session lifecycle + auto-advance live in
- * `useEmailMissionSession`; this component only renders the chat surface.
+ * The email is already connected, so this starts with one explicit action. The
+ * session lifecycle + auto-advance live in `useEmailMissionSession`; this
+ * component only renders the chat surface.
  */
 export function EmailMission({
   eyebrow,
@@ -54,19 +49,15 @@ export function EmailMission({
   onContinue,
   onSkip,
 }: EmailMissionProps) {
-  const { t } = useTranslation(["setup", "chat"]);
+  const { t } = useTranslation("setup");
   const [composerText, setComposerText] = useState("");
   const [composerFiles, setComposerFiles] = useState<File[]>([]);
-
-  // The same chat-rendering hooks the real agent chat uses, so the onboarding
-  // chat shows the agent's actual tool calls/results + the proper in-flight
-  // indicator, not just a bare "thinking".
+  const [openLinkError, setOpenLinkError] = useState<string | null>(null);
   const { processLabels, getThinkingMessage, thinkingIndicator } =
     useChatDisplayLabels();
   const { isSpecialTool, renderToolResult, renderTurnSummary } =
     useFileToolRenderer(agent.folderPath);
   const queuedLabels = useQueuedMessageLabels();
-
   const session = useEmailMissionSession({
     agent,
     provider,
@@ -88,8 +79,9 @@ export function EmailMission({
   );
 
   const handleOpenLink = useCallback((url: string) => {
-    // A failed open surfaces via `call()`; swallow the re-throw here.
-    tauriSystem.openUrl(url).catch(() => {});
+    void tauriSystem.openUrl(url).catch((error) => {
+      setOpenLinkError(error instanceof Error ? error.message : String(error));
+    });
   }, []);
 
   const transformContent = useCallback(
@@ -101,68 +93,21 @@ export function EmailMission({
     [],
   );
 
-  // The offer renders through the SAME component chat uses for ask-user
-  // interactions (ChatInteractionCard), so this onboarding step reads exactly
-  // like a real in-chat question. Labels mirror the real consumer
-  // (use-agent-chat-panel.tsx) key-for-key so the two surfaces stay word-
-  // identical.
-  const interactionLabels = useMemo(
-    () => ({
-      placeholder: t("chat:questionCard.placeholder"),
-      escapePlaceholder: t("chat:questionCard.escapePlaceholder"),
-      back: t("chat:questionCard.back"),
-      forward: t("chat:questionCard.forward"),
-      skip: t("chat:interaction.skip"),
-      esc: t("chat:interaction.esc"),
-      dismiss: t("chat:questionCard.dismiss"),
-      recommended: t("chat:interaction.recommended"),
-      progress: (current: number, total: number) =>
-        t("chat:questionCard.progress", { current, total }),
-    }),
-    [t],
-  );
-
-  // ONE question step: the mission body is the prompt, the single preselected
-  // action ("Send an email to myself") is its only option. Completing it hands
-  // off to `session.handleSend`, which sends the real email; the answer content
-  // is ignored (the mission already knows what to send).
-  const offerSteps = useMemo<ChatInteractionStep[]>(
-    () => [
-      {
-        kind: "question",
-        id: "email-offer",
-        question: t("setup:tutorial.missions.email.body"),
-        // No free-text escape row: the single preselected action is the only
-        // answer (typing here would suggest the user can redirect the email).
-        hideFreeText: true,
-        options: [
-          {
-            id: "send",
-            label: t("setup:tutorial.missions.email.offer.option"),
-          },
-        ],
-      },
-    ],
-    [t],
-  );
-
   return (
     <SetupCard
       onSpace
       eyebrow={eyebrow}
-      title={t("setup:tutorial.missions.email.title")}
-      // The mission body now lives IN the offer card as its question prompt (see
-      // `offerSteps`), so no subtitle here — that would just duplicate it.
-      // Back disappears once the mission is running: leaving mid-turn drops the
-      // completion-marker listener while the agent still sends, and returning
-      // would kick off a SECOND session (and a second real email). The HOU-555
-      // skip hatch is the exit for a stuck run.
+      title={t("tutorial.missions.email.title")}
+      // The mission body lives in the offer card, so no subtitle duplicates it.
+      // Back disappears once the mission runs: returning would start a second
+      // session and a second real email. The conversation exit below appears
+      // after its first message instead.
       onBack={session.started ? undefined : onBack}
-      backLabel={t("setup:tutorial.nav.back")}
+      backLabel={t("tutorial.nav.back")}
     >
-      {session.error && (
+      {(session.error || openLinkError) && (
         <p className="mb-3 rounded-xl border border-danger/30 bg-danger/5 px-3 py-2 text-sm text-danger">
-          {session.error}
+          {session.error ?? openLinkError}
         </p>
       )}
       <div className="flex min-h-0 flex-1 flex-col">
@@ -183,7 +128,7 @@ export function EmailMission({
             onSend={handleComposerSend}
             onStop={session.onStop}
             isLoading={session.isLoading}
-            placeholder={t("setup:tutorial.missions.email.placeholder")}
+            placeholder={t("tutorial.missions.email.placeholder")}
             processLabels={processLabels}
             getThinkingMessage={getThinkingMessage}
             thinkingIndicator={thinkingIndicator}
@@ -201,35 +146,10 @@ export function EmailMission({
             queuedLabels={queuedLabels}
             composerOverride={
               session.started ? undefined : (
-                <ChatInteractionCard
-                  steps={offerSteps}
-                  labels={interactionLabels}
-                  // Completing the lone step ALSO fires on the card's Skip
-                  // (the stepper completes a skipped last step with no
-                  // answers), so route on the answers: picked the option →
-                  // send the real email; skipped → leave onboarding. The
-                  // answer content itself is ignored (the mission already
-                  // knows what to send).
-                  onComplete={(answers) => {
-                    if (answers.length === 0) {
-                      onSkip();
-                      return;
-                    }
-                    void session.handleSend();
-                  }}
-                  // No onDismiss: the tutorial's own skip affordance (below) is
-                  // the exit; the card must not offer an ambiguous X that
-                  // abandons onboarding.
-                  //
-                  // renderConnect/renderSignin/renderApproval/renderCredential
-                  // are never reached — this is a question-only sequence (one
-                  // option step), so the stepper never advances to a connect,
-                  // signin, approval, or credential step. They exist only to
-                  // satisfy the card's required props.
-                  renderConnect={() => null}
-                  renderSignin={() => null}
-                  renderApproval={() => null}
-                  renderCredential={() => null}
+                <EmailOfferAction
+                  description={t("tutorial.missions.email.body")}
+                  label={t("tutorial.missions.email.offer.option")}
+                  onStart={() => void session.handleSend()}
                 />
               )
             }
@@ -238,7 +158,7 @@ export function EmailMission({
         {session.showSkip && (
           <div className="flex shrink-0 items-center justify-between gap-3 pt-3">
             <p className="min-w-0 text-xs text-ink-muted">
-              {t("setup:tutorial.missions.email.skipHint")}
+              {t("tutorial.missions.email.skipHint")}
             </p>
             <Button
               type="button"
@@ -247,7 +167,7 @@ export function EmailMission({
               className="shrink-0"
               onClick={onSkip}
             >
-              {t("setup:tutorial.missions.email.skip")}
+              {t("tutorial.missions.email.skip")}
             </Button>
           </div>
         )}

--- a/app/src/components/onboarding/missions/finished.tsx
+++ b/app/src/components/onboarding/missions/finished.tsx
@@ -44,11 +44,8 @@ function fireConfetti() {
 interface FinishedMissionProps {
   /** Which finish this is:
    *  - "sent": the assistant actually sent a real email (the full email path).
-   *  - "ready": the email steps were skipped or the deployment has no
-   *    integrations, so no email was sent — the copy must not claim one.
-   *  The orchestrator reaches this screen three ways and only one of them
-   *  genuinely sent an email, so the payoff copy is variant-driven to stay
-   *  honest. */
+   *  - "ready": the deployment has no integrations, so no email was sent and
+   *    the copy must not claim one. */
   variant: "sent" | "ready";
   /** The one action on this screen: arm the guided tour and jump into the
    *  assistant's Routines surface so the freshly-seeded content is immediately
@@ -57,10 +54,10 @@ interface FinishedMissionProps {
 }
 
 /**
- * The single onboarding payoff screen. Reached three ways — after the assistant
- * sent a real email ("sent"), or after the email detour was skipped / is
- * unavailable ("ready"). It celebrates and offers exactly ONE primary action, no
- * secondary escape hatch (design principle: one obvious action per screen) — an
+ * The single onboarding payoff screen. Reached after the assistant sent a real
+ * email ("sent"), or when the email detour is unavailable ("ready"). It
+ * celebrates and offers exactly ONE primary action, no secondary escape hatch
+ * (design principle: one obvious action per screen) — an
  * inspiring send-off, not a decision. The `variant` keeps the copy truthful: it
  * only claims a real email was sent on the path that actually sent one.
  *

--- a/app/src/components/onboarding/missions/onboarding-flow.ts
+++ b/app/src/components/onboarding/missions/onboarding-flow.ts
@@ -65,19 +65,6 @@ export function stepAfterAgentCreated(
 }
 
 /**
- * Whether the connect-email screen should offer its "skip for now" escape
- * hatch. Always available (a confirm dialog is the actual friction, see
- * `ConnectEmailMission`) except while a connect flow is in flight — the OAuth
- * hop + poll owns the screen until it resolves.
- */
-export function shouldOfferConnectSkip(opts: {
-  /** A connect flow (OAuth hop + poll) is currently in flight. */
-  connecting: boolean;
-}): boolean {
-  return !opts.connecting;
-}
-
-/**
  * Whether the finish screen offers the "Invite your team" growth card. Only on
  * a deployment that serves C8 Spaces (self-serve team creation) — desktop /
  * self-host / legacy hosts have no team to create, so the card would dead-end.

--- a/app/src/components/onboarding/missions/use-email-mission-session.ts
+++ b/app/src/components/onboarding/missions/use-email-mission-session.ts
@@ -1,21 +1,18 @@
 import type { FeedItem, QueuedChatMessage } from "@houston-ai/chat";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useConversationVm } from "../../../hooks/use-conversation-vm";
 import { useSessionMessageQueue } from "../../../hooks/use-session-message-queue";
 import { analytics } from "../../../lib/analytics";
 import { createMission } from "../../../lib/create-mission";
-import { logger } from "../../../lib/logger";
-import { tauriAgent, tauriChat } from "../../../lib/tauri";
+import { tauriChat } from "../../../lib/tauri";
 import type { Agent } from "../../../lib/types";
 import {
-  appendSetupSection,
-  stripSetupSection,
-} from "../tutorial-system-prompt";
+  prepareEmailMissionSetup,
+  useEmailSetupCleanup,
+  useEmailSetupCompleted,
+} from "./email-mission-setup";
 import { shouldOfferSkip } from "./email-skip";
-
-/** The agent emits this once the email actually sent. */
-const SETUP_END_RE = /\[\s*\\?TUTORIAL[_\s\\]+COMPLETED?\s*\]/i;
 
 interface UseEmailMissionSessionArgs {
   agent: Agent;
@@ -36,7 +33,7 @@ export interface EmailMissionSession {
   error: string | null;
   feedItems: FeedItem[];
   sessionKey: string;
-  /** HOU-555 escape hatch: the agent ran, went idle, never confirmed. */
+  /** Available only after the opening message starts the AI conversation. */
   showSkip: boolean;
   onStop: (() => void) | undefined;
   handleSend: () => Promise<void>;
@@ -45,13 +42,6 @@ export interface EmailMissionSession {
   removeQueuedMessage: (id: string) => void;
 }
 
-/**
- * Owns the final onboarding step's session lifecycle: kicking off the agent
- * (append the setup directive to CLAUDE.md, then `createMission`), tracking the
- * feed for the `[TUTORIAL_COMPLETE]` marker to auto-advance, the live composer
- * queue, and stripping the directive on unmount. Presentation-free so the
- * `EmailMission` component stays under the file cap and purely renders.
- */
 export function useEmailMissionSession({
   agent,
   provider,
@@ -69,22 +59,7 @@ export function useEmailMissionSession({
   );
   const [error, setError] = useState<string | null>(null);
 
-  // Strip the setup directive from CLAUDE.md on unmount (idempotent).
-  useEffect(() => {
-    return () => {
-      void (async () => {
-        try {
-          const current = await tauriAgent.readFile(agentPath, "CLAUDE.md");
-          const stripped = stripSetupSection(current);
-          if (stripped !== current) {
-            await tauriAgent.writeFile(agentPath, "CLAUDE.md", stripped);
-          }
-        } catch (e) {
-          logger.warn(`[email-setup] could not strip setup section: ${e}`);
-        }
-      })();
-    };
-  }, [agentPath]);
+  useEmailSetupCleanup(agentPath);
 
   const sessionKeyForHooks = missionSessionKey ?? "";
   // This conversation's reactive state, straight from the SDK conversation VM.
@@ -92,28 +67,14 @@ export function useEmailMissionSession({
   const realFeed = vm?.feed;
   const isActive = vm?.running ?? false;
 
-  // The mission session has gone active at least once (the agent actually ran).
-  // Gates the skip escape hatch so we only offer it after a real attempt.
-  const [hasRun, setHasRun] = useState(false);
-  useEffect(() => {
-    if (isActive) setHasRun(true);
-  }, [isActive]);
+  const setupDone = useEmailSetupCompleted(realFeed);
 
-  const setupDone = useMemo(() => {
-    const items = realFeed ?? [];
-    for (let i = items.length - 1; i >= 0; i--) {
-      const item = items[i];
-      if (item.feed_type !== "assistant_text") continue;
-      if (typeof item.data === "string" && SETUP_END_RE.test(item.data)) {
-        return true;
-      }
-    }
-    return false;
-  }, [realFeed]);
-
-  // Offer the skip escape hatch only when the agent ran, went idle, and never
-  // emitted the completion marker — the "stuck" state from HOU-555.
-  const showSkip = shouldOfferSkip({ hasRun, isActive, setupDone });
+  // The conversation becomes skippable only after its first message creates
+  // a mission session. Until then, the email action is the sole path forward.
+  const showSkip = shouldOfferSkip({
+    hasFirstMessage: missionSessionKey !== null,
+    setupDone,
+  });
 
   // Conversion + auto-advance to the success screen the moment it sends.
   const doneFired = useRef(false);
@@ -133,30 +94,20 @@ export function useEmailMissionSession({
     startedRef.current = true;
     setStarted(true);
     setError(null);
-    // Pre-feed the agent (send to self via the already-connected toolkit). The
-    // directive IS the mission (which toolkit, send to self, the completion
-    // marker) — starting without it would run the agent blind and strand the
-    // user on the skip hatch, so a failed write aborts the kickoff instead of
-    // logging and continuing. The engine call already toasted the real error
-    // via `call()`; the inline error keeps it visible on the card for retry.
+    // A failed setup write aborts the kickoff, so the inline error stays
+    // visible on the card for retry rather than sending the agent blind.
     try {
-      const current = await tauriAgent.readFile(agentPath, "CLAUDE.md");
-      const updated = appendSetupSection(current, {
-        toolkit: emailToolkit,
-        toolkitLabel: emailToolkitLabel,
-        toMyself: true,
+      await prepareEmailMissionSetup({
+        agentPath,
+        emailToolkit,
+        emailToolkitLabel,
       });
-      if (updated !== current) {
-        await tauriAgent.writeFile(agentPath, "CLAUDE.md", updated);
-      }
     } catch (e) {
-      logger.warn(`[email-setup] could not append setup section: ${e}`);
       startedRef.current = false;
       setStarted(false);
       setError(e instanceof Error ? e.message : String(e));
       return;
     }
-    analytics.track("first_message_sent");
     try {
       // The kickoff IS the user-visible message (the session echoes it into the
       // feed), so use the button's text — the directive in CLAUDE.md tells the
@@ -177,6 +128,7 @@ export function useEmailMissionSession({
         },
       );
       setMissionSessionKey(result.sessionKey);
+      analytics.track("first_message_sent");
     } catch (e) {
       startedRef.current = false;
       setStarted(false);
@@ -222,9 +174,9 @@ export function useEmailMissionSession({
 
   const handleStop = useCallback(() => {
     if (!missionSessionKey) return;
-    // A stop failure surfaces via `call()` (toast + report); swallow the
-    // re-throw so the handler never leaks an unhandled rejection.
-    tauriChat.stop(agentPath, missionSessionKey).catch(() => {});
+    void tauriChat.stop(agentPath, missionSessionKey).catch((error) => {
+      setError(error instanceof Error ? error.message : String(error));
+    });
   }, [agentPath, missionSessionKey]);
 
   const isLoading = started && isActive;

--- a/app/src/components/onboarding/personal-assistant-onboarding.tsx
+++ b/app/src/components/onboarding/personal-assistant-onboarding.tsx
@@ -49,8 +49,8 @@ export function PersonalAssistantOnboarding({
   // outright failure so a hung create can't strand the user forever.
   const [waitTimedOut, setWaitTimedOut] = useState(false);
   // The assistant actually SENT a real email (only the full email path sets it).
-  // Drives the honest finished-screen variant: skipped/no-integrations finishes
-  // must not claim an email was sent.
+  // Drives the honest finished-screen variant: no-integrations finishes must not
+  // claim an email was sent.
   const [emailSent, setEmailSent] = useState(false);
   // The email toolkit connected in the "give access to your email" step.
   const [emailTool, setEmailTool] = useState<{
@@ -87,7 +87,7 @@ export function PersonalAssistantOnboarding({
   // forever after that point — so quitting mid-flow would permanently skip the
   // rest of setup. The flag is the durable resume contract: SET on mount (below,
   // the flow has begun), CLEARED in every terminal path (`finishOnboarding` and
-  // the `skipOnboarding` escape). App.tsx re-enters onboarding while it's set.
+  // the `skipConversation` exit). App.tsx re-enters onboarding while it's set.
   const { markPending, clearPending } = useOnboardingPending();
 
   // `tutorialActive` pins the orchestrator in front of the workspace shell so
@@ -184,37 +184,20 @@ export function PersonalAssistantOnboarding({
   const missionProvider = provider ?? "anthropic";
   const missionModel = model ?? getDefaultModel(missionProvider);
 
-  // Escape hatch (HOU-555): the final email step auto-advances on a marker the
-  // agent must emit, but some models send the email and never emit it, stranding
-  // the user with no way forward. Let them bail into the app. This is NOT a
-  // completion: it fires `onboarding_skipped` (not `onboarding_completed`) with
-  // the model, so analytics can separate "stuck and skipped" from a normal
-  // finish and surface which models strand users.
-  const skipOnboarding = (fromStep: OnboardingStep) => {
+  // After the first message begins the AI conversation, the user can leave
+  // onboarding and start using Houston. This is not a completion, so analytics
+  // preserves it as a conversation exit instead of a completed email mission.
+  const skipConversation = (fromStep: OnboardingStep) => {
     analytics.track("onboarding_skipped", {
       step: fromStep,
       provider: missionProvider,
       model: missionModel,
-      source: "stuck",
+      source: "conversation",
     });
-    // Terminal path (the stuck-escape): clear the resume flag so the next boot
-    // doesn't drop the user back into onboarding.
+    // Terminal conversation exit: clear the resume flag so the next boot
+    // does not return the user to onboarding.
     void clearPending();
     setTutorialActive(false);
-  };
-
-  // Softer escape for the connect-email dead ends (gateway unready, OAuth
-  // failed): skip ONLY the email steps and land on the finish screen, keeping
-  // the tour hand-off. Fires `onboarding_skipped` so analytics can see the
-  // email detour was abandoned even though `onboarding_completed` follows.
-  const skipEmailSteps = () => {
-    analytics.track("onboarding_skipped", {
-      step: "connectEmail",
-      provider: missionProvider,
-      model: missionModel,
-      source: "stuck",
-    });
-    setStep("finished");
   };
 
   // Flat step eyebrow: "Step 1 of 3". Empty for screens that aren't numbered
@@ -280,7 +263,6 @@ export function PersonalAssistantOnboarding({
               setEmailTool({ toolkit, label });
               setStep("emailConnected");
             }}
-            onSkip={skipEmailSteps}
           />
         ) : createFailed || waitTimedOut ? (
           // Background provisioning failed or hung: recoverable error, not an
@@ -345,7 +327,7 @@ export function PersonalAssistantOnboarding({
             setEmailSent(true);
             setStep("finished");
           }}
-          onSkip={() => skipOnboarding("emailChat")}
+          onSkip={() => skipConversation("emailChat")}
         />
       )}
 

--- a/app/src/components/onboarding/segment-screen.tsx
+++ b/app/src/components/onboarding/segment-screen.tsx
@@ -20,13 +20,11 @@ interface SegmentOption {
 
 interface OnboardingSegmentScreenProps {
   onContinue: (segment: OnboardingSegment) => Promise<void>;
-  onSkip: () => Promise<void>;
   saving: boolean;
 }
 
 export function OnboardingSegmentScreen({
   onContinue,
-  onSkip,
   saving,
 }: OnboardingSegmentScreenProps) {
   const { t } = useTranslation(["setup", "common"]);
@@ -64,22 +62,6 @@ export function OnboardingSegmentScreen({
       await onContinue(selected);
       analytics.track("onboarding_segment_continued", {
         selected_segment: selected,
-        source_screen: ONBOARDING_SEGMENT_SOURCE_SCREEN,
-      });
-    } catch (err) {
-      setError(genericErrorDescription("save_onboarding_segment", err));
-    }
-  };
-
-  const skip = async () => {
-    if (saving) return;
-    setError(null);
-    try {
-      await onSkip();
-      // Tracked AFTER the persist succeeds, mirroring `continued`: the event
-      // means "this install left the screen segmented as a skipper", not
-      // "the user clicked skip and maybe saw an error".
-      analytics.track("onboarding_segment_skipped", {
         source_screen: ONBOARDING_SEGMENT_SOURCE_SCREEN,
       });
     } catch (err) {
@@ -125,7 +107,7 @@ export function OnboardingSegmentScreen({
             </p>
           )}
 
-          <div className="flex flex-col items-center gap-3">
+          <div className="flex flex-col items-center">
             <Button
               type="button"
               size="lg"
@@ -136,17 +118,6 @@ export function OnboardingSegmentScreen({
               {saving && <Loader2 className="size-4 animate-spin" />}
               {t("common:actions.continue")}
             </Button>
-            <p className="text-xs text-ink-muted">
-              {t("setup:onboardingSegment.helper")}
-            </p>
-            <button
-              type="button"
-              onClick={() => void skip()}
-              disabled={saving}
-              className="text-xs text-ink-muted underline underline-offset-2 transition-colors outline-none hover:text-ink focus-visible:ring-2 focus-visible:ring-focus disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {t("setup:onboardingSegment.skip")}
-            </button>
           </div>
         </div>
       </SetupCard>

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -37,7 +37,6 @@ export type AnalyticsEventName =
   | "onboarding_segment_screen_viewed"
   | "onboarding_segment_selected"
   | "onboarding_segment_continued"
-  | "onboarding_segment_skipped"
   // One-time "reconnect your AI" moment after upgrading from the legacy build.
   | "migration_reconnect_completed"
   // First-run cloud-migration wizard (HOU-719): the cloud desktop build offers
@@ -388,9 +387,6 @@ export const analytics = {
         typeof props?.selected_segment === "string"
       ) {
         posthog.people.set({ onboarding_segment: props.selected_segment });
-      }
-      if (event === "onboarding_segment_skipped") {
-        posthog.people.set({ onboarding_segment: "skipped" });
       }
     } catch {
       // Analytics unavailable

--- a/app/src/locales/en/setup.json
+++ b/app/src/locales/en/setup.json
@@ -19,9 +19,7 @@
   "onboardingSegment": {
     "eyebrow": "Personalize Houston",
     "title": "What best describes your work?",
-    "subtitle": "Pick one so Houston can tailor agents, templates, and recommendations for you.",
-    "helper": "You can change this later as Houston learns what helps you.",
-    "skip": "Skip for now",
+    "subtitle": "Help us tailor Houston.",
     "options": {
       "marketing": "Marketing",
       "product": "Product",
@@ -89,7 +87,7 @@
         "placeholder": "Reply to your agent...",
         "body": "Your agent will send a real email to you, so you can watch it work.",
         "skip": "Skip for now",
-        "skipHint": "Your agent finished but didn't confirm. You can skip and start using Houston."
+        "skipHint": "You can continue in Houston after your first message."
       },
       "aiConnected": {
         "title": "Your AI is connected!",
@@ -101,13 +99,7 @@
         "body": "Pick your email so your agent can send on your behalf. You connect it once, securely.",
         "connecting": "Connecting...",
         "cancel": "Cancel",
-        "skipHint": "Can't connect right now? You can do this anytime from Integrations.",
-        "skip": "Skip for now",
-        "preparing": "Getting your assistant ready...",
-        "skipConfirmTitle": "Skip connecting your email?",
-        "skipConfirmBody": "You can connect it anytime from Integrations. Your agent won't be able to send or read email until you do.",
-        "skipConfirmAction": "Skip for now",
-        "skipConfirmCancel": "Keep connecting"
+        "preparing": "Getting your assistant ready..."
       },
       "emailConnected": {
         "title": "Email connected!",

--- a/app/src/locales/es/setup.json
+++ b/app/src/locales/es/setup.json
@@ -19,9 +19,7 @@
   "onboardingSegment": {
     "eyebrow": "Personaliza Houston",
     "title": "¿Cuál describe mejor tu trabajo?",
-    "subtitle": "Elige una opción para que Houston adapte agentes, plantillas y recomendaciones para ti.",
-    "helper": "Puedes cambiarlo más tarde a medida que Houston aprenda qué te ayuda.",
-    "skip": "Omitir por ahora",
+    "subtitle": "Personaliza Houston para tu trabajo.",
     "options": {
       "marketing": "Marketing",
       "product": "Producto",
@@ -89,7 +87,7 @@
         "placeholder": "Responde a tu agente...",
         "body": "Tu agente te enviará un correo real, para que lo veas funcionar.",
         "skip": "Omitir por ahora",
-        "skipHint": "Tu agente terminó pero no confirmó. Puedes omitir y empezar a usar Houston."
+        "skipHint": "Puedes continuar en Houston después de tu primer mensaje."
       },
       "aiConnected": {
         "title": "¡Tu IA está conectada!",
@@ -101,13 +99,7 @@
         "body": "Elige tu correo para que tu agente pueda enviar por ti. Lo conectas una vez, de forma segura.",
         "connecting": "Conectando...",
         "cancel": "Cancelar",
-        "skipHint": "¿No puedes conectar ahora? Puedes hacerlo cuando quieras desde Integraciones.",
-        "skip": "Omitir por ahora",
-        "preparing": "Preparando a tu asistente...",
-        "skipConfirmTitle": "¿Omitir la conexión de tu correo?",
-        "skipConfirmBody": "Puedes conectarlo cuando quieras desde Integraciones. Tu agente no podrá enviar ni leer correo hasta que lo hagas.",
-        "skipConfirmAction": "Omitir por ahora",
-        "skipConfirmCancel": "Seguir conectando"
+        "preparing": "Preparando a tu asistente..."
       },
       "emailConnected": {
         "title": "¡Correo conectado!",

--- a/app/src/locales/pt/setup.json
+++ b/app/src/locales/pt/setup.json
@@ -19,9 +19,7 @@
   "onboardingSegment": {
     "eyebrow": "Personalize o Houston",
     "title": "Qual descreve melhor o seu trabalho?",
-    "subtitle": "Escolha uma opção para o Houston adaptar agentes, modelos e recomendações para você.",
-    "helper": "Você pode mudar isso depois conforme o Houston aprende o que ajuda você.",
-    "skip": "Pular por enquanto",
+    "subtitle": "Personalize o Houston agora.",
     "options": {
       "marketing": "Marketing",
       "product": "Produto",
@@ -89,7 +87,7 @@
         "placeholder": "Responda ao seu agente...",
         "body": "Seu agente vai enviar um e-mail de verdade para você, para você vê-lo funcionar.",
         "skip": "Pular por enquanto",
-        "skipHint": "Seu agente terminou, mas não confirmou. Você pode pular e começar a usar o Houston."
+        "skipHint": "Você pode continuar no Houston depois da primeira mensagem."
       },
       "aiConnected": {
         "title": "Sua IA está conectada!",
@@ -101,13 +99,7 @@
         "body": "Escolha seu e-mail para o agente poder enviar por você. Você conecta uma vez, com segurança.",
         "connecting": "Conectando...",
         "cancel": "Cancelar",
-        "skipHint": "Não consegue conectar agora? Você pode fazer isso quando quiser em Integrações.",
-        "skip": "Pular por enquanto",
-        "preparing": "Preparando seu assistente...",
-        "skipConfirmTitle": "Pular a conexão do seu e-mail?",
-        "skipConfirmBody": "Você pode conectar quando quiser em Integrações. Seu agente não vai poder enviar nem ler e-mails até você fazer isso.",
-        "skipConfirmAction": "Pular por enquanto",
-        "skipConfirmCancel": "Continuar conectando"
+        "preparing": "Preparando seu assistente..."
       },
       "emailConnected": {
         "title": "E-mail conectado!",

--- a/app/tests/email-skip.test.ts
+++ b/app/tests/email-skip.test.ts
@@ -4,31 +4,24 @@ import { describe, it } from "node:test";
 import { shouldOfferSkip } from "../src/components/onboarding/missions/email-skip.ts";
 
 describe("shouldOfferSkip (HOU-555 onboarding escape hatch)", () => {
-  it("hidden before the agent has run", () => {
+  it("hidden before the first message starts the AI conversation", () => {
     strictEqual(
-      shouldOfferSkip({ hasRun: false, isActive: false, setupDone: false }),
+      shouldOfferSkip({ hasFirstMessage: false, setupDone: false }),
       false,
     );
   });
 
-  it("hidden while the agent is still working", () => {
+  it("appears as soon as the first message starts the AI conversation", () => {
     strictEqual(
-      shouldOfferSkip({ hasRun: true, isActive: true, setupDone: false }),
-      false,
+      shouldOfferSkip({ hasFirstMessage: true, setupDone: false }),
+      true,
     );
   });
 
   it("hidden on the happy path (completion marker seen)", () => {
     strictEqual(
-      shouldOfferSkip({ hasRun: true, isActive: false, setupDone: true }),
+      shouldOfferSkip({ hasFirstMessage: true, setupDone: true }),
       false,
-    );
-  });
-
-  it("shown once the agent ran, went idle, and never confirmed (the stuck case)", () => {
-    strictEqual(
-      shouldOfferSkip({ hasRun: true, isActive: false, setupDone: false }),
-      true,
     );
   });
 });

--- a/app/tests/onboarding-flow.test.ts
+++ b/app/tests/onboarding-flow.test.ts
@@ -8,7 +8,6 @@ import {
   integrationsAvailable,
   isFirstRun,
   isToolkitConnected,
-  shouldOfferConnectSkip,
   shouldOfferTeamInvite,
   stepAfterAgentCreated,
 } from "../src/components/onboarding/missions/onboarding-flow.ts";
@@ -100,16 +99,6 @@ describe("stepAfterAgentCreated", () => {
   it("routes straight to finish when integrations are unavailable", () => {
     strictEqual(stepAfterAgentCreated(caps([])), "finished");
     strictEqual(stepAfterAgentCreated(null), "finished");
-  });
-});
-
-describe("shouldOfferConnectSkip (dead-end escape hatch)", () => {
-  it("offered on the happy path (gateway ready, nothing attempted) — the confirm dialog is the friction", () => {
-    strictEqual(shouldOfferConnectSkip({ connecting: false }), true);
-  });
-
-  it("never offered while a connect flow is in flight", () => {
-    strictEqual(shouldOfferConnectSkip({ connecting: true }), false);
   });
 });
 

--- a/app/tests/onboarding-required-email.test.ts
+++ b/app/tests/onboarding-required-email.test.ts
@@ -1,0 +1,75 @@
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+const read = (relativePath: string) =>
+  readFileSync(new URL(relativePath, import.meta.url), "utf8");
+
+type SegmentCopy = {
+  subtitle: string;
+  helper?: unknown;
+  skip?: unknown;
+};
+
+describe("required onboarding email path", () => {
+  it("renders one focused email action before the first agent message", () => {
+    const offer = read(
+      "../src/components/onboarding/missions/email-offer-action.tsx",
+    );
+    const mission = read("../src/components/onboarding/missions/email.tsx");
+
+    assert.match(offer, /type="button"/);
+    assert.equal((offer.match(/<Button\b/g) ?? []).length, 1);
+    assert.match(offer, /onClick={onStart}/);
+    assert.match(offer, /ring-focus/);
+    assert.doesNotMatch(offer, /<(?:input|textarea)\b/i);
+    assert.doesNotMatch(offer, /\b(?:skip|onSkip|omit)\b/i);
+    assert.match(mission, /<EmailOfferAction/);
+    assert.doesNotMatch(mission, /<ChatInteractionCard/);
+  });
+
+  it("removes every pre-conversation skip route", () => {
+    const connectEmail = read(
+      "../src/components/onboarding/missions/connect-email.tsx",
+    );
+    const flow = read(
+      "../src/components/onboarding/missions/onboarding-flow.ts",
+    );
+    const onboarding = read(
+      "../src/components/onboarding/personal-assistant-onboarding.tsx",
+    );
+    const session = read(
+      "../src/components/onboarding/missions/use-email-mission-session.ts",
+    );
+
+    assert.doesNotMatch(connectEmail, /\b(?:onSkip|ConfirmDialog)\b/);
+    assert.doesNotMatch(connectEmail, /\b(?:skip|omit)\b/i);
+    assert.doesNotMatch(flow, /shouldOfferConnectSkip/);
+    assert.doesNotMatch(onboarding, /skipEmailSteps/);
+    assert.match(session, /hasFirstMessage: missionSessionKey !== null/);
+  });
+});
+
+describe("required onboarding role selection", () => {
+  it("removes the helper and skip, and keeps every subtitle to five words", () => {
+    const screen = read("../src/components/onboarding/segment-screen.tsx");
+    const locales = ["en", "es", "pt"] as const;
+
+    assert.doesNotMatch(screen, /\bonSkip\b/);
+    assert.doesNotMatch(screen, /onboardingSegment\.(?:helper|skip)/);
+
+    for (const locale of locales) {
+      const setup = JSON.parse(read(`../src/locales/${locale}/setup.json`)) as {
+        onboardingSegment: SegmentCopy;
+      };
+      const segment = setup.onboardingSegment;
+
+      assert.equal(segment.helper, undefined, `${locale} has no helper copy`);
+      assert.equal(segment.skip, undefined, `${locale} has no skip copy`);
+      assert.ok(
+        segment.subtitle.trim().split(/\s+/u).length <= 5,
+        `${locale} subtitle has at most five words`,
+      );
+    }
+  });
+});

--- a/packages/web/e2e/onboarding-connect.spec.ts
+++ b/packages/web/e2e/onboarding-connect.spec.ts
@@ -58,10 +58,11 @@ test("onboarding connect step shows the curated view, searches, expands, and ope
 
   await page.goto("/");
 
-  // First-run now asks the work-segmentation question before the
-  // create-your-assistant flow; this spec is about the connect step, so skip it
-  // (the segment flow itself is covered by onboarding-segment.spec.ts).
-  await page.getByRole("button", { name: "Skip for now" }).click();
+  // First-run asks the work-segmentation question before the
+  // create-your-assistant flow. The selection is required, so make one
+  // explicit choice before exercising the connect step.
+  await page.getByRole("button", { name: /Operations/ }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
 
   // Onboarding opens directly on the connect step (the welcome/intro screen
   // was removed).


### PR DESCRIPTION
## Summary

- Make the initial email onboarding step a single explicit action, with no free-text input or pre-conversation skip.
- Allow the only onboarding exit after the first AI message begins the live conversation.
- Remove role and email-connection skip paths, and simplify role-selection copy in en, es, and pt.

## Surface impact

- [x] Web / desktop
- [ ] iOS
- [ ] Android

## Validation

- [x] `pnpm check:fix`
- [x] `pnpm check`
- [x] Targeted onboarding tests, 26 passing
- [x] `pnpm check-locales`
- [ ] `pnpm tsgo --noEmit`, blocked locally by the missing `@houston/design-tokens` worktree link