### PR TITLE
Usage: subscription vs per-token sections + honest Copilot quota

### DIFF
--- a/app/src-tauri/gen/schemas/windows-schema.json
+++ b/app/src-tauri/gen/schemas/windows-schema.json
@@ -183,10 +183,10 @@
           "markdownDescription": "Default core plugins set.\n#### This default permission set includes:\n\n- `core:path:default`\n- `core:event:default`\n- `core:window:default`\n- `core:webview:default`\n- `core:app:default`\n- `core:image:default`\n- `core:resources:default`\n- `core:menu:default`\n- `core:tray:default`"
         },
         {
-          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`",
+          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-supports-multiple-windows`",
           "type": "string",
           "const": "core:app:default",
-          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`"
+          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-supports-multiple-windows`"
         },
         {
           "description": "Enables the app_hide command without any pre-configured scope.",
@@ -259,6 +259,12 @@
           "type": "string",
           "const": "core:app:allow-set-dock-visibility",
           "markdownDescription": "Enables the set_dock_visibility command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the supports_multiple_windows command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-supports-multiple-windows",
+          "markdownDescription": "Enables the supports_multiple_windows command without any pre-configured scope."
         },
         {
           "description": "Enables the tauri_version command without any pre-configured scope.",
@@ -343,6 +349,12 @@
           "type": "string",
           "const": "core:app:deny-set-dock-visibility",
           "markdownDescription": "Denies the set_dock_visibility command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the supports_multiple_windows command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-supports-multiple-windows",
+          "markdownDescription": "Denies the supports_multiple_windows command without any pre-configured scope."
         },
         {
           "description": "Denies the tauri_version command without any pre-configured scope.",
@@ -867,10 +879,10 @@
           "markdownDescription": "Denies the close command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-show-menu-on-left-click`",
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-icon-with-as-template`\n- `allow-set-show-menu-on-left-click`",
           "type": "string",
           "const": "core:tray:default",
-          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-show-menu-on-left-click`"
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-icon-with-as-template`\n- `allow-set-show-menu-on-left-click`"
         },
         {
           "description": "Enables the get_by_id command without any pre-configured scope.",
@@ -901,6 +913,12 @@
           "type": "string",
           "const": "core:tray:allow-set-icon-as-template",
           "markdownDescription": "Enables the set_icon_as_template command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_icon_with_as_template command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-icon-with-as-template",
+          "markdownDescription": "Enables the set_icon_with_as_template command without any pre-configured scope."
         },
         {
           "description": "Enables the set_menu command without any pre-configured scope.",
@@ -967,6 +985,12 @@
           "type": "string",
           "const": "core:tray:deny-set-icon-as-template",
           "markdownDescription": "Denies the set_icon_as_template command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_icon_with_as_template command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-icon-with-as-template",
+          "markdownDescription": "Denies the set_icon_with_as_template command without any pre-configured scope."
         },
         {
           "description": "Denies the set_menu command without any pre-configured scope.",
@@ -1227,10 +1251,16 @@
           "markdownDescription": "Denies the webview_size command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-internal-toggle-maximize`",
+          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-activity-name`\n- `allow-scene-identifier`\n- `allow-internal-toggle-maximize`",
           "type": "string",
           "const": "core:window:default",
-          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-internal-toggle-maximize`"
+          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-activity-name`\n- `allow-scene-identifier`\n- `allow-internal-toggle-maximize`"
+        },
+        {
+          "description": "Enables the activity_name command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-activity-name",
+          "markdownDescription": "Enables the activity_name command without any pre-configured scope."
         },
         {
           "description": "Enables the available_monitors command without any pre-configured scope.",
@@ -1423,6 +1453,12 @@
           "type": "string",
           "const": "core:window:allow-scale-factor",
           "markdownDescription": "Enables the scale_factor command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the scene_identifier command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-scene-identifier",
+          "markdownDescription": "Enables the scene_identifier command without any pre-configured scope."
         },
         {
           "description": "Enables the set_always_on_bottom command without any pre-configured scope.",
@@ -1689,6 +1725,12 @@
           "markdownDescription": "Enables the unminimize command without any pre-configured scope."
         },
         {
+          "description": "Denies the activity_name command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-activity-name",
+          "markdownDescription": "Denies the activity_name command without any pre-configured scope."
+        },
+        {
           "description": "Denies the available_monitors command without any pre-configured scope.",
           "type": "string",
           "const": "core:window:deny-available-monitors",
@@ -1879,6 +1921,12 @@
           "type": "string",
           "const": "core:window:deny-scale-factor",
           "markdownDescription": "Denies the scale_factor command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the scene_identifier command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-scene-identifier",
+          "markdownDescription": "Denies the scene_identifier command without any pre-configured scope."
         },
         {
           "description": "Denies the set_always_on_bottom command without any pre-configured scope.",

--- a/app/src/components/usage-view/usage-model.ts
+++ b/app/src/components/usage-view/usage-model.ts
@@ -47,6 +47,33 @@ export function matchUsageToProviders(
   });
 }
 
+/** The Usage page's two billing sections, both in the caller's card order. */
+export interface AccountUsageSections {
+  /** OAuth plan accounts (Claude, ChatGPT, Copilot): limits that reset. */
+  subscriptions: AccountUsage[];
+  /** API-key / self-hosted accounts: billed (or metered) per token. */
+  perToken: AccountUsage[];
+}
+
+/**
+ * Split the paired accounts into the page's two sections by how the account
+ * bills: subscription OAuth providers (auth absent or "oauth") have plan
+ * windows that reset, everything else (pasted keys, OpenAI-compatible
+ * servers) is pay-per-token — the same `auth` axis the hub's connect flow
+ * branches on, so the two surfaces can never disagree about a provider's kind.
+ */
+export function splitAccountsByBilling(
+  accounts: readonly AccountUsage[],
+): AccountUsageSections {
+  const subscriptions: AccountUsage[] = [];
+  const perToken: AccountUsage[] = [];
+  for (const account of accounts) {
+    const subscription = (account.provider.auth ?? "oauth") === "oauth";
+    (subscription ? subscriptions : perToken).push(account);
+  }
+  return { subscriptions, perToken };
+}
+
 /**
  * A localized "in 2 hours" phrase for a window's reset instant, or null when
  * the instant is absent/past/unparseable (the row then omits its reset note;

--- a/app/src/components/usage-view/usage-pane.tsx
+++ b/app/src/components/usage-view/usage-pane.tsx
@@ -76,9 +76,9 @@ export function UsagePane({
 }
 
 /**
- * One labeled billing section (header + subtitle + card grid). An empty
- * section renders nothing — a user with only one kind of account sees one
- * clean section, not an empty shell.
+ * One labeled billing section (header + card grid). An empty section renders
+ * nothing — a user with only one kind of account sees one clean section, not
+ * an empty shell.
  */
 function UsageSection({
   sectionKey,
@@ -94,9 +94,6 @@ function UsageSection({
       <h2 className="text-sm font-medium text-ink">
         {t(`usage.sections.${sectionKey}.title`)}
       </h2>
-      <p className="text-sm text-ink-muted">
-        {t(`usage.sections.${sectionKey}.subtitle`)}
-      </p>
       <ul className="mt-3 grid gap-3 sm:grid-cols-2">
         {accounts.map((account) => (
           <UsageProviderCard key={account.provider.id} account={account} />

--- a/app/src/components/usage-view/usage-pane.tsx
+++ b/app/src/components/usage-view/usage-pane.tsx
@@ -9,17 +9,22 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useProviderUsage } from "../../hooks/queries";
 import type { ProviderInfo } from "../../lib/providers";
-import { matchUsageToProviders } from "./usage-model";
+import {
+  type AccountUsage,
+  matchUsageToProviders,
+  splitAccountsByBilling,
+} from "./usage-model";
 import { UsageProviderCard } from "./usage-provider-card";
 
 /**
- * The Usage page's body: one card per CONNECTED provider account with its
- * live meters — rate-limit windows (Claude 5-hour/weekly, Codex
- * session/weekly, Copilot quotas) and prepaid balances, read from each
- * provider's own usage API and refreshed on an interval (see
- * useProviderUsage). Pairing/formatting is the pure usage-model; this view
- * only renders. A fetch failure shows an honest inline error (the query's
- * `call()` wrapper has already toasted).
+ * The Usage page's body, in TWO billing sections: "AI subscriptions" (OAuth
+ * plan accounts whose rate-limit windows reset — Claude 5-hour/weekly, Codex
+ * session/weekly, Copilot quotas) and "AI per token" (API-key accounts billed
+ * by what they use — prepaid balances or Houston's own token metering). One
+ * card per CONNECTED account, read from each provider's usage API and
+ * refreshed on an interval (see useProviderUsage). Pairing/splitting is the
+ * pure usage-model; this view only renders. A fetch failure shows an honest
+ * inline error (the query's `call()` wrapper has already toasted).
  */
 export function UsagePane({
   providers,
@@ -36,8 +41,8 @@ export function UsagePane({
   const { t } = useTranslation("aiHub");
   const enabled = ready && providers.length > 0;
   const { data: rows, isLoading, isError } = useProviderUsage(enabled);
-  const accounts = useMemo(
-    () => matchUsageToProviders(providers, rows ?? []),
+  const { subscriptions, perToken } = useMemo(
+    () => splitAccountsByBilling(matchUsageToProviders(providers, rows ?? [])),
     [providers, rows],
   );
 
@@ -63,10 +68,40 @@ export function UsagePane({
     return <p className="py-10 text-sm text-ink-muted">{t("usage.error")}</p>;
   }
   return (
-    <ul className="mt-2 grid gap-3 sm:grid-cols-2">
-      {accounts.map((account) => (
-        <UsageProviderCard key={account.provider.id} account={account} />
-      ))}
-    </ul>
+    <div className="flex flex-col gap-6">
+      <UsageSection sectionKey="subscriptions" accounts={subscriptions} />
+      <UsageSection sectionKey="perToken" accounts={perToken} />
+    </div>
+  );
+}
+
+/**
+ * One labeled billing section (header + subtitle + card grid). An empty
+ * section renders nothing — a user with only one kind of account sees one
+ * clean section, not an empty shell.
+ */
+function UsageSection({
+  sectionKey,
+  accounts,
+}: {
+  sectionKey: "subscriptions" | "perToken";
+  accounts: readonly AccountUsage[];
+}) {
+  const { t } = useTranslation("aiHub");
+  if (accounts.length === 0) return null;
+  return (
+    <section>
+      <h2 className="text-sm font-medium text-ink">
+        {t(`usage.sections.${sectionKey}.title`)}
+      </h2>
+      <p className="text-sm text-ink-muted">
+        {t(`usage.sections.${sectionKey}.subtitle`)}
+      </p>
+      <ul className="mt-3 grid gap-3 sm:grid-cols-2">
+        {accounts.map((account) => (
+          <UsageProviderCard key={account.provider.id} account={account} />
+        ))}
+      </ul>
+    </section>
   );
 }

--- a/app/src/components/usage-view/usage-view.tsx
+++ b/app/src/components/usage-view/usage-view.tsx
@@ -59,18 +59,11 @@ export function UsageView() {
           subtitle={t("usage.pageSubtitle")}
         />
         {showCompute && <ComputeSection />}
-        <div>
-          {showCompute && (
-            <h2 className="text-sm font-medium text-ink">
-              {t("usage.accounts.title")}
-            </h2>
-          )}
-          <UsagePane
-            providers={connected}
-            ready={connections.ready}
-            onConnect={() => setViewMode("ai-hub")}
-          />
-        </div>
+        <UsagePane
+          providers={connected}
+          ready={connections.ready}
+          onConnect={() => setViewMode("ai-hub")}
+        />
       </PageContainer>
     </div>
   );

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -157,12 +157,10 @@
     },
     "sections": {
       "subscriptions": {
-        "title": "AI subscriptions",
-        "subtitle": "Plans you signed in with, and how much of their limits you've used."
+        "title": "AI subscriptions"
       },
       "perToken": {
-        "title": "AI per token",
-        "subtitle": "Pay-as-you-go accounts, billed by what you use."
+        "title": "AI per token"
       }
     },
     "compute": {

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -155,8 +155,15 @@
       "body": "Connect an AI provider to see how much of its limits you've used.",
       "connect": "Connect a provider"
     },
-    "accounts": {
-      "title": "AI accounts"
+    "sections": {
+      "subscriptions": {
+        "title": "AI subscriptions",
+        "subtitle": "Plans you signed in with, and how much of their limits you've used."
+      },
+      "perToken": {
+        "title": "AI per token",
+        "subtitle": "Pay-as-you-go accounts, billed by what you use."
+      }
     },
     "compute": {
       "title": "Running time",

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -155,8 +155,15 @@
       "body": "Conecta un proveedor de IA para ver cuánto de sus límites has usado.",
       "connect": "Conectar un proveedor"
     },
-    "accounts": {
-      "title": "Cuentas de IA"
+    "sections": {
+      "subscriptions": {
+        "title": "Suscripciones de IA",
+        "subtitle": "Planes con los que iniciaste sesión y cuánto de sus límites has usado."
+      },
+      "perToken": {
+        "title": "IA por token",
+        "subtitle": "Cuentas de pago por uso, facturadas según lo que usas."
+      }
     },
     "compute": {
       "title": "Tiempo de actividad",

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -157,12 +157,10 @@
     },
     "sections": {
       "subscriptions": {
-        "title": "Suscripciones de IA",
-        "subtitle": "Planes con los que iniciaste sesión y cuánto de sus límites has usado."
+        "title": "Suscripciones de IA"
       },
       "perToken": {
-        "title": "IA por token",
-        "subtitle": "Cuentas de pago por uso, facturadas según lo que usas."
+        "title": "IA por token"
       }
     },
     "compute": {

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -157,12 +157,10 @@
     },
     "sections": {
       "subscriptions": {
-        "title": "Assinaturas de IA",
-        "subtitle": "Planos com os quais você entrou e quanto dos limites deles você usou."
+        "title": "Assinaturas de IA"
       },
       "perToken": {
-        "title": "IA por token",
-        "subtitle": "Contas de pagamento por uso, cobradas pelo que você usa."
+        "title": "IA por token"
       }
     },
     "compute": {

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -155,8 +155,15 @@
       "body": "Conecte um provedor de IA para ver quanto dos limites você já usou.",
       "connect": "Conectar um provedor"
     },
-    "accounts": {
-      "title": "Contas de IA"
+    "sections": {
+      "subscriptions": {
+        "title": "Assinaturas de IA",
+        "subtitle": "Planos com os quais você entrou e quanto dos limites deles você usou."
+      },
+      "perToken": {
+        "title": "IA por token",
+        "subtitle": "Contas de pagamento por uso, cobradas pelo que você usa."
+      }
     },
     "compute": {
       "title": "Tempo de atividade",

--- a/app/tests/ai-hub-usage-model.test.ts
+++ b/app/tests/ai-hub-usage-model.test.ts
@@ -7,6 +7,7 @@ import {
   formatResetWhen,
   formatTokensAmount,
   matchUsageToProviders,
+  splitAccountsByBilling,
 } from "../src/components/usage-view/usage-model.ts";
 import type { ProviderInfo } from "../src/lib/providers.ts";
 
@@ -53,6 +54,37 @@ describe("matchUsageToProviders", () => {
   it("keeps a connected card with no engine row (row: null), never drops it", () => {
     const accounts = matchUsageToProviders([card("google")], []);
     deepStrictEqual(accounts, [{ provider: card("google"), row: null }]);
+  });
+});
+
+describe("splitAccountsByBilling", () => {
+  const account = (id: string, auth?: ProviderInfo["auth"]) => ({
+    provider: { ...card(id), ...(auth ? { auth } : {}) },
+    row: null,
+  });
+
+  it("routes OAuth (and auth-less) accounts to subscriptions, key/compatible to per-token", () => {
+    const { subscriptions, perToken } = splitAccountsByBilling([
+      account("anthropic", "oauth"),
+      account("openrouter", "apiKey"),
+      account("openai"),
+      account("ollama", "openaiCompatible"),
+    ]);
+    deepStrictEqual(
+      subscriptions.map((a) => a.provider.id),
+      ["anthropic", "openai"],
+    );
+    deepStrictEqual(
+      perToken.map((a) => a.provider.id),
+      ["openrouter", "ollama"],
+    );
+  });
+
+  it("answers both sections empty for no accounts", () => {
+    deepStrictEqual(splitAccountsByBilling([]), {
+      subscriptions: [],
+      perToken: [],
+    });
   });
 });
 

--- a/packages/host/src/routes/provider-usage.test.ts
+++ b/packages/host/src/routes/provider-usage.test.ts
@@ -1,0 +1,177 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { expect, test } from "vitest";
+import { MemoryCredentialStore } from "../credentials/store";
+import type { CredentialVault } from "../ports";
+import { handleSandboxProviderUsage } from "./provider-usage";
+
+/**
+ * The central Copilot quota probe: GitHub's quota endpoint authenticates with
+ * the long-lived GitHub OAuth token, which only the host's central store holds
+ * (the runtime's auth.json is scrubbed to access-only — Gate #2). The route
+ * must relay the quota payload without ever leaking the token, answer the
+ * marked 404 for a never-connected workspace, and map GitHub's auth rejection
+ * to a 401 the runtime renders as "sign in again".
+ */
+
+const vault: CredentialVault = {
+  sandboxToken: () => "sbx",
+  validateSandboxToken: (t) =>
+    t === "sbx" ? { workspaceId: "w1", agentId: "a1" } : null,
+};
+
+function mockReq(token = "sbx"): IncomingMessage {
+  return {
+    headers: { authorization: `Bearer ${token}` },
+  } as unknown as IncomingMessage;
+}
+
+function mockRes(): {
+  res: ServerResponse;
+  out: {
+    status?: number;
+    headers?: Record<string, string>;
+    body: Record<string, unknown>;
+  };
+} {
+  const out: {
+    status?: number;
+    headers?: Record<string, string>;
+    body: Record<string, unknown>;
+  } = { body: {} };
+  const res = {
+    writeHead(status: number, headers?: Record<string, string>) {
+      out.status = status;
+      out.headers = headers;
+    },
+    end(buf: Buffer | string) {
+      out.body = JSON.parse(buf.toString());
+    },
+  } as unknown as ServerResponse;
+  return { res, out };
+}
+
+const call = (
+  credentials: MemoryCredentialStore,
+  out: ReturnType<typeof mockRes>,
+  opts: {
+    provider?: string;
+    token?: string;
+    fetchImpl?: typeof fetch;
+  } = {},
+) =>
+  handleSandboxProviderUsage(
+    { vault, credentials, fetchImpl: opts.fetchImpl },
+    "GET",
+    "/sandbox/provider-usage",
+    new URL(
+      `http://x/sandbox/provider-usage?provider=${opts.provider ?? "github-copilot"}`,
+    ),
+    mockReq(opts.token),
+    out.res,
+  );
+
+async function connectedStore(): Promise<MemoryCredentialStore> {
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "github-copilot",
+    accessToken: "copilot-session",
+    refreshToken: "gh-token",
+    expiresAt: Date.now() + 60_000,
+    kind: "oauth",
+  });
+  return credentials;
+}
+
+test("relays GitHub's quota payload, authenticating with the central token", async () => {
+  const credentials = await connectedStore();
+  let url = "";
+  let auth = "";
+  const fetchImpl: typeof fetch = async (input, init) => {
+    url = String(input);
+    auth = (init?.headers as Record<string, string>).Authorization;
+    return new Response(
+      JSON.stringify({ copilot_plan: "pro", quota_snapshots: {} }),
+      { status: 200 },
+    );
+  };
+  const r = mockRes();
+  expect(await call(credentials, r, { fetchImpl })).toBe(true);
+  expect(url).toBe("https://api.github.com/copilot_internal/user");
+  expect(auth).toBe("token gh-token");
+  expect(r.out.status).toBe(200);
+  expect(r.out.body).toEqual({ copilot_plan: "pro", quota_snapshots: {} });
+});
+
+test("targets the enterprise host when the credential pins a domain", async () => {
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "github-copilot",
+    accessToken: "copilot-session",
+    refreshToken: "gh-token",
+    expiresAt: Date.now() + 60_000,
+    kind: "oauth",
+    enterpriseUrl: "acme.ghe.com",
+  });
+  let url = "";
+  const fetchImpl: typeof fetch = async (input) => {
+    url = String(input);
+    return new Response("{}", { status: 200 });
+  };
+  const r = mockRes();
+  expect(await call(credentials, r, { fetchImpl })).toBe(true);
+  expect(url).toBe("https://api.acme.ghe.com/copilot_internal/user");
+});
+
+test("marked 404 when the workspace never connected Copilot", async () => {
+  const r = mockRes();
+  expect(await call(new MemoryCredentialStore(), r)).toBe(true);
+  expect(r.out.status).toBe(404);
+  expect(r.out.headers?.["x-houston-not-connected"]).toBe("1");
+});
+
+test("GitHub's 401/403 relays as our 401 (runtime → sign in again)", async () => {
+  const credentials = await connectedStore();
+  const r = mockRes();
+  expect(
+    await call(credentials, r, {
+      fetchImpl: async () => new Response("{}", { status: 403 }),
+    }),
+  ).toBe(true);
+  expect(r.out.status).toBe(401);
+});
+
+test("any other upstream failure answers 502 with the reason", async () => {
+  const credentials = await connectedStore();
+  const r = mockRes();
+  expect(
+    await call(credentials, r, {
+      fetchImpl: async () => new Response("oops", { status: 500 }),
+    }),
+  ).toBe(true);
+  expect(r.out.status).toBe(502);
+  expect(r.out.body.error).toContain("500");
+
+  const r2 = mockRes();
+  expect(
+    await call(credentials, r2, {
+      fetchImpl: async () => {
+        throw new Error("network down");
+      },
+    }),
+  ).toBe(true);
+  expect(r2.out.status).toBe(502);
+  expect(r2.out.body.error).toBe("network down");
+});
+
+test("rejects a bad sandbox token and a provider with no central probe", async () => {
+  const credentials = await connectedStore();
+  const r = mockRes();
+  expect(await call(credentials, r, { token: "wrong" })).toBe(true);
+  expect(r.out.status).toBe(401);
+
+  const r2 = mockRes();
+  expect(await call(credentials, r2, { provider: "openai-codex" })).toBe(true);
+  expect(r2.out.status).toBe(400);
+});

--- a/packages/host/src/routes/provider-usage.test.ts
+++ b/packages/host/src/routes/provider-usage.test.ts
@@ -89,7 +89,7 @@ test("relays GitHub's quota payload, authenticating with the central token", asy
   let auth = "";
   const fetchImpl: typeof fetch = async (input, init) => {
     url = String(input);
-    auth = (init?.headers as Record<string, string>).Authorization;
+    auth = (init?.headers as Record<string, string>).Authorization ?? "";
     return new Response(
       JSON.stringify({ copilot_plan: "pro", quota_snapshots: {} }),
       { status: 200 },

--- a/packages/host/src/routes/provider-usage.ts
+++ b/packages/host/src/routes/provider-usage.ts
@@ -1,0 +1,107 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { CredentialStore, CredentialVault } from "../ports";
+import { bearer, json } from "./http";
+
+/**
+ * Sandbox-facing central usage probe (connect-once). GitHub Copilot's quota
+ * endpoint (`GET api.<host>/copilot_internal/user`) authenticates with the
+ * LONG-LIVED GitHub OAuth token — which, by design (Gate #2), never leaves
+ * this process: the runtime's auth.json is scrubbed to access-only right
+ * after login, so the runtime cannot run this probe itself and its Usage row
+ * read "sign in again" forever on a perfectly healthy connection. The host
+ * runs the probe against its central credential and relays GitHub's quota
+ * payload (plan, percentages, reset date — never a token); the runtime maps
+ * it onto the wire row exactly as it maps a direct response
+ * (packages/runtime/src/ai/usage/copilot.ts, which mirrors these headers).
+ *
+ * Answers: 200 with GitHub's JSON; 401 when GitHub rejected the stored token
+ * (runtime → "sign in again"); marked 404 when the workspace never connected
+ * Copilot; 502 for any other upstream failure (runtime → honest error row).
+ *
+ * Returns true when the request was handled.
+ */
+
+const COPILOT_QUOTA_HEADERS = {
+  Accept: "application/json",
+  "User-Agent": "GitHubCopilotChat/0.35.0",
+  "Editor-Version": "vscode/1.107.0",
+  "Editor-Plugin-Version": "copilot-chat/0.35.0",
+  "X-GitHub-Api-Version": "2025-04-01",
+};
+
+export async function handleSandboxProviderUsage(
+  deps: {
+    vault: CredentialVault;
+    credentials: CredentialStore;
+    /** Injectable for tests; defaults to global fetch. */
+    fetchImpl?: typeof fetch;
+  },
+  method: string,
+  path: string,
+  url: URL,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  if (method !== "GET" || path !== "/sandbox/provider-usage") return false;
+
+  const sbToken = bearer(req, url);
+  const claim = sbToken ? deps.vault.validateSandboxToken(sbToken) : null;
+  if (!claim) {
+    json(res, 401, { error: "unauthorized" });
+    return true;
+  }
+  const provider = url.searchParams.get("provider");
+  // Copilot is the only provider whose usage needs the centrally-held token;
+  // every other probe runs fine in the runtime with what it already has.
+  if (provider !== "github-copilot") {
+    json(res, 400, { error: `no central usage probe for ${provider}` });
+    return true;
+  }
+  const cred = await deps.credentials.get(claim.workspaceId, provider);
+  if (!cred?.refreshToken) {
+    // Same authoritative marker as /sandbox/credential: the store's own
+    // "not connected" answer, never a bare route-level 404.
+    json(
+      res,
+      404,
+      { error: "workspace not connected" },
+      { "x-houston-not-connected": "1" },
+    );
+    return true;
+  }
+  const apiHost = cred.enterpriseUrl
+    ? `api.${cred.enterpriseUrl}`
+    : "api.github.com";
+  let upstream: Response;
+  try {
+    upstream = await (deps.fetchImpl ?? fetch)(
+      `https://${apiHost}/copilot_internal/user`,
+      {
+        headers: {
+          Authorization: `token ${cred.refreshToken}`,
+          ...COPILOT_QUOTA_HEADERS,
+        },
+        signal: AbortSignal.timeout(15_000),
+      },
+    );
+  } catch (err) {
+    json(res, 502, {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return true;
+  }
+  if (upstream.status === 401 || upstream.status === 403) {
+    // The stored GitHub token is dead — the runtime's honest row is
+    // "sign in again", so relay the auth failure as our own 401.
+    json(res, 401, { error: "GitHub rejected the stored Copilot token" });
+    return true;
+  }
+  if (!upstream.ok) {
+    json(res, 502, {
+      error: `Copilot usage API answered ${upstream.status}`,
+    });
+    return true;
+  }
+  json(res, 200, await upstream.json());
+  return true;
+}

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -53,6 +53,7 @@ import { handleSandboxIntegrations } from "./routes/integrations-sandbox";
 import { handleMigrationSource } from "./routes/migration-source";
 import { handlePortableAccount } from "./routes/portable";
 import { handlePortableFromStore } from "./routes/portable-from-store";
+import { handleSandboxProviderUsage } from "./routes/provider-usage";
 import { BodyTooLargeError } from "./routes/read-body";
 import { handleSetupRuntime } from "./routes/setup-runtime";
 import { handleSkillsDirectory } from "./routes/skills-directory";
@@ -253,6 +254,9 @@ async function handle(
 
   // Sandbox-facing credential serve (HMAC sandbox token, not a user JWT).
   if (await handleSandboxCredential(deps, method, path, url, req, res)) return;
+  // Sandbox-facing central usage probe (Copilot quota needs the host-held token).
+  if (await handleSandboxProviderUsage(deps, method, path, url, req, res))
+    return;
   // Runtime-facing integration proxy (HMAC sandbox token, not a user JWT).
   if (await handleSandboxIntegrations(deps, method, path, url, req, res))
     return;

--- a/packages/runtime/src/ai/usage/copilot.ts
+++ b/packages/runtime/src/ai/usage/copilot.ts
@@ -1,5 +1,7 @@
 import type { AuthStorage } from "@earendil-works/pi-coding-agent";
+import { serveModeOn } from "../../auth/serve";
 import { authStorage } from "../../auth/storage";
+import { config } from "../../config";
 import {
   clampPercent,
   type ProviderUsage,
@@ -18,10 +20,27 @@ import {
  * Enterprise credentials pin a company domain (`enterpriseUrl`); the probe
  * then targets `api.<domain>` like pi's own token exchange does.
  *
+ * Under connect-once serve mode (security Gate #2) the runtime's auth.json is
+ * access-only — the GitHub token lives ONLY in the host's central store and is
+ * scrubbed here right after login — so this runtime CANNOT run the probe
+ * itself (the row read "sign in again" forever on a healthy connection). It
+ * instead asks the host's `GET /sandbox/provider-usage`, which runs the same
+ * GitHub call centrally and relays the quota payload (numbers and dates,
+ * never the token) — mapped below exactly like a direct response.
+ *
  * Response: `quota_snapshots.premium_interactions` / `.chat`, each
  * `{entitlement, remaining, percent_remaining, unlimited}`, plus
  * `copilot_plan` and a shared `quota_reset_date`.
  */
+
+/** Mirrored by the host's central probe (packages/host/src/routes/provider-usage.ts). */
+const COPILOT_QUOTA_HEADERS = {
+  Accept: "application/json",
+  "User-Agent": "GitHubCopilotChat/0.35.0",
+  "Editor-Version": "vscode/1.107.0",
+  "Editor-Plugin-Version": "copilot-chat/0.35.0",
+  "X-GitHub-Api-Version": "2025-04-01",
+};
 
 type QuotaSnapshot = {
   entitlement?: unknown;
@@ -64,31 +83,13 @@ function toWindow(
   return { id, usedPercent: usedPercent(q), resetsAt };
 }
 
-/** Fetch the connected Copilot account's quota snapshot. */
-export async function fetchCopilotUsage(
-  fetchImpl: typeof fetch = fetch,
-  store: Pick<AuthStorage, "get"> = authStorage,
-): Promise<ProviderUsage> {
+/**
+ * Map a quota response onto the wire row — shared by both probe paths (the
+ * direct GitHub call and the host relay, which passes GitHub's payload AND its
+ * 401 through unchanged).
+ */
+async function quotaResponseToUsage(res: Response): Promise<ProviderUsage> {
   const provider = "github-copilot";
-  const cred = store.get(provider);
-  const githubToken = cred?.type === "oauth" ? cred.refresh : null;
-  if (!githubToken) return { provider, status: "unauthenticated", windows: [] };
-  const apiHost =
-    cred?.type === "oauth" && typeof cred.enterpriseUrl === "string"
-      ? `api.${cred.enterpriseUrl}`
-      : "api.github.com";
-
-  const res = await fetchImpl(`https://${apiHost}/copilot_internal/user`, {
-    headers: {
-      Authorization: `token ${githubToken}`,
-      Accept: "application/json",
-      "User-Agent": "GitHubCopilotChat/0.35.0",
-      "Editor-Version": "vscode/1.107.0",
-      "Editor-Plugin-Version": "copilot-chat/0.35.0",
-      "X-GitHub-Api-Version": "2025-04-01",
-    },
-    signal: AbortSignal.timeout(15_000),
-  });
   if (res.status === 401 || res.status === 403)
     return { provider, status: "unauthenticated", windows: [] };
   if (!res.ok) {
@@ -124,4 +125,64 @@ export async function fetchCopilotUsage(
       : {}),
     fetchedAt: new Date().toISOString(),
   };
+}
+
+/** Where the host's central probe lives (serve-mode fallback). Injectable. */
+export interface CopilotServeSource {
+  controlPlaneUrl: string;
+  sandboxToken: string;
+}
+
+function configServeSource(): CopilotServeSource | null {
+  return serveModeOn() && config.controlPlaneUrl && config.sandboxToken
+    ? {
+        controlPlaneUrl: config.controlPlaneUrl,
+        sandboxToken: config.sandboxToken,
+      }
+    : null;
+}
+
+/** Fetch the connected Copilot account's quota snapshot. */
+export async function fetchCopilotUsage(
+  fetchImpl: typeof fetch = fetch,
+  store: Pick<AuthStorage, "get"> = authStorage,
+  serve: CopilotServeSource | null = configServeSource(),
+): Promise<ProviderUsage> {
+  const provider = "github-copilot";
+  const cred = store.get(provider);
+  const githubToken = cred?.type === "oauth" ? cred.refresh : null;
+
+  if (githubToken) {
+    const apiHost =
+      cred?.type === "oauth" && typeof cred.enterpriseUrl === "string"
+        ? `api.${cred.enterpriseUrl}`
+        : "api.github.com";
+    return quotaResponseToUsage(
+      await fetchImpl(`https://${apiHost}/copilot_internal/user`, {
+        headers: {
+          Authorization: `token ${githubToken}`,
+          ...COPILOT_QUOTA_HEADERS,
+        },
+        signal: AbortSignal.timeout(15_000),
+      }),
+    );
+  }
+
+  // No GitHub token locally, but a credential IS stored (the served/scrubbed
+  // access-only entry) → the host holds the token; delegate the probe there.
+  // Its marked 404 means the central store has no Copilot connection either.
+  if (serve && cred) {
+    const res = await fetchImpl(
+      `${serve.controlPlaneUrl}/sandbox/provider-usage?provider=${provider}`,
+      {
+        headers: { Authorization: `Bearer ${serve.sandboxToken}` },
+        signal: AbortSignal.timeout(15_000),
+      },
+    );
+    if (res.status === 404)
+      return { provider, status: "unauthenticated", windows: [] };
+    return quotaResponseToUsage(res);
+  }
+
+  return { provider, status: "unauthenticated", windows: [] };
 }

--- a/packages/runtime/src/ai/usage/usage.test.ts
+++ b/packages/runtime/src/ai/usage/usage.test.ts
@@ -175,6 +175,67 @@ describe("fetchCopilotUsage", () => {
     expect(row.status).toBe("ok");
     expect(row.windows).toEqual([]);
   });
+
+  // Serve mode (Gate #2): the runtime's credential is access-only — the GitHub
+  // token was scrubbed after login — so the probe must delegate to the host's
+  // central endpoint instead of reporting "sign in again" forever.
+  const scrubbedStore = {
+    get: () => ({
+      type: "oauth" as const,
+      access: "copilot-session",
+      refresh: "", // scrubbed by POST /auth/scrub-refresh
+      expires: 0,
+    }),
+  };
+  const serve = { controlPlaneUrl: "http://host.test", sandboxToken: "sbx" };
+
+  it("delegates a scrubbed credential to the host's central probe", async () => {
+    let url = "";
+    let auth = "";
+    const fetchImpl: typeof fetch = async (input, init) => {
+      url = String(input);
+      auth = (init?.headers as Record<string, string>).Authorization;
+      return new Response(
+        JSON.stringify({
+          copilot_plan: "pro",
+          quota_reset_date: "2026-08-01",
+          quota_snapshots: {
+            premium_interactions: { percent_remaining: 40 },
+          },
+        }),
+        { status: 200 },
+      );
+    };
+    const row = await fetchCopilotUsage(fetchImpl, scrubbedStore, serve);
+    expect(url).toBe(
+      "http://host.test/sandbox/provider-usage?provider=github-copilot",
+    );
+    expect(auth).toBe("Bearer sbx"); // the sandbox token, never a GitHub one
+    expect(row.status).toBe("ok");
+    expect(row.plan).toBe("pro");
+    expect(row.windows).toEqual([
+      { id: "premium", usedPercent: 60, resetsAt: "2026-08-01T00:00:00.000Z" },
+    ]);
+  });
+
+  it("maps the host's marked 404 and 401 to unauthenticated, 502 to error", async () => {
+    const respond = (status: number) =>
+      fetchCopilotUsage(
+        async () => new Response(JSON.stringify({ error: "x" }), { status }),
+        scrubbedStore,
+        serve,
+      );
+    expect((await respond(404)).status).toBe("unauthenticated");
+    expect((await respond(401)).status).toBe("unauthenticated");
+    const failed = await respond(502);
+    expect(failed.status).toBe("error");
+    expect(failed.message).toContain("502");
+  });
+
+  it("stays unauthenticated when scrubbed with no serve source (no host to ask)", async () => {
+    const row = await fetchCopilotUsage(jsonResponse({}), scrubbedStore, null);
+    expect(row.status).toBe("unauthenticated");
+  });
 });
 
 describe("credit balances", () => {

--- a/packages/web/e2e/usage-compute.spec.ts
+++ b/packages/web/e2e/usage-compute.spec.ts
@@ -47,21 +47,21 @@ async function armComputeUsage(
 
 // ── 1. Desktop/self-host guard: no capability, no section, no fetch ────────
 
-test("without the computeUsage capability the Usage page shows only AI accounts", async ({
+test("without the computeUsage capability the Usage page shows only the account sections", async ({
   page,
 }) => {
   await page.goto("/");
   await page.locator('[data-tour-target="nav-usage"]').click();
 
   await expect(page.getByRole("heading", { name: "Usage" })).toBeVisible();
-  // The compute section and its companion "AI accounts" sub-heading are both
-  // absent — the page is byte-identical to the pre-feature layout.
+  // The compute section is absent; the account sections (the seeded Anthropic
+  // OAuth account lands under "AI subscriptions") stand on their own.
   await expect(page.getByRole("heading", { name: "Running time" })).toHaveCount(
     0,
   );
-  await expect(page.getByRole("heading", { name: "AI accounts" })).toHaveCount(
-    0,
-  );
+  await expect(
+    page.getByRole("heading", { name: "AI subscriptions" }),
+  ).toBeVisible();
 });
 
 // ── 2. Armed + seeded: summary, bars, per-agent rows ────────────────────────
@@ -112,9 +112,9 @@ test("with data the section shows the total, daily bars, and per-agent rows", as
   await expect(sales).toContainText("30m");
   await expect(sales).toContainText("1 task");
 
-  // The AI-accounts half keeps its own sub-heading below the compute section.
+  // The account half keeps its own section heading below the compute section.
   await expect(
-    page.getByRole("heading", { name: "AI accounts" }),
+    page.getByRole("heading", { name: "AI subscriptions" }),
   ).toBeVisible();
 });
 


### PR DESCRIPTION
## What

Two changes to the Usage page:

1. **Split the accounts into two billing sections.** OAuth plan accounts (Claude, ChatGPT, GitHub Copilot) render under **AI subscriptions**; API-key / OpenAI-compatible accounts (OpenRouter, Gemini, Bedrock, OpenCode, Ollama, ...) under **AI per token**. The split rides `ProviderInfo.auth` (the same axis the hub's connect flow branches on) in the pure usage-model, so the two surfaces can never disagree about a provider's kind. Empty sections hide themselves; titles shipped in en/es/pt.

2. **Fix Copilot usage always reading "sign in again" on a healthy connection.** GitHub's quota endpoint (`GET api.github.com/copilot_internal/user`) authenticates with the long-lived GitHub OAuth token, which pi stores as the credential's `refresh`. Under connect-once serve mode (Gate #2) the runtime's auth.json is scrubbed to access-only right after login, so the runtime's probe found `refresh` empty and answered `unauthenticated` forever.

## How

The token never leaves the host, so the probe now runs where the token lives: the host grows a sandbox-facing `GET /sandbox/provider-usage` (HMAC sandbox token, beside `/sandbox/credential`) that runs the GitHub quota call with its central credential (Enterprise domains included) and relays the quota payload — plan, percentages, reset date, never a token. The runtime's `fetchCopilotUsage` keeps the direct path when it holds the GitHub token (legacy/un-scrubbed installs) and otherwise delegates to the host, mapping the relayed response through the same window mapper. The host's marked 404 / relayed 401 render as "sign in again" only when the workspace truly isn't connected or GitHub rejected the stored token.

## Tests

- Host: 6 new route tests (payload relay + central-token auth, Enterprise host targeting, marked 404, 401/403 relay, 502 with reason, bad sandbox token / unsupported provider).
- Runtime: 4 new `fetchCopilotUsage` tests (scrubbed-credential delegation with the sandbox bearer, 404/401 → unauthenticated and 502 → error mapping, no-serve fallback).
- App: 2 new `splitAccountsByBilling` tests; the `usage-compute` Playwright spec updated for the new section headings (4/4 passing locally against the fake host).
- Biome, app/web typechecks, and `check-locales` all green.
