### PR TITLE
fix(app): paint cached mission cards on cold open while the pod wakes

### DIFF
--- a/app/src/hooks/queries/use-activity.ts
+++ b/app/src/hooks/queries/use-activity.ts
@@ -1,9 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { latestCachedAgentActivities } from "../../lib/all-conversations-cache";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriActivity } from "../../lib/tauri";
 import { useDraftStore } from "../../stores/drafts";
 
 export function useActivity(agentPath: string | undefined) {
+  const queryClient = useQueryClient();
   return useQuery({
     queryKey: queryKeys.activity(agentPath ?? ""),
     queryFn: () => {
@@ -20,6 +22,22 @@ export function useActivity(agentPath: string | undefined) {
     // until the real data lands lets consumers distinguish "loading"
     // from "loaded and genuinely empty". All call sites already guard
     // reads with `(activities ?? []).map(...)`.
+    //
+    // Cold-open seeding: on a cloud boot this read is held for the whole
+    // pod wake, and the disk-restored `["activity", X]` entry only exists
+    // for agents whose board was open in a session that outlived the wake
+    // plus the persist throttle — often not the very agent being looked
+    // at. Conversations are derived 1:1 from activities, so the freshest
+    // cached conversation rows (per-agent list or the always-swept
+    // aggregate the sidebar badges paint from) ARE this board's missions.
+    // Placeholder semantics keep the contract above: never persisted,
+    // replaced by the held read when the pod answers, and `undefined`
+    // (still loading) when nothing is cached — never a fabricated `[]`.
+    placeholderData: (previousData) =>
+      previousData ??
+      (agentPath
+        ? latestCachedAgentActivities(queryClient, agentPath)
+        : undefined),
   });
 }
 

--- a/app/src/lib/all-conversations-cache.ts
+++ b/app/src/lib/all-conversations-cache.ts
@@ -40,3 +40,98 @@ export function latestCachedAllConversations<T>(
   }
   return bestData;
 }
+
+/**
+ * A cached conversation row as the board-seeding fallback reads it. Mirrors
+ * `RawConversation` (lib/tauri.ts) structurally — conversations are derived
+ * 1:1 from board activities (`activityToConversation`), so the row carries
+ * everything a mission card renders.
+ */
+interface CachedConversationRow {
+  id: string;
+  title: string;
+  description: string;
+  status: string;
+  session_key?: string;
+  updated_at?: string;
+  agent_path: string;
+  agent?: string;
+  routine_id?: string;
+}
+
+/** A board activity recovered from a cached conversation row. */
+export interface CachedBoardActivity {
+  id: string;
+  title: string;
+  description: string;
+  status: string;
+  session_key?: string;
+  updated_at?: string;
+  agent?: string;
+  routine_id?: string;
+}
+
+/**
+ * One agent's board rows, recovered from the freshest cached conversation
+ * list that has any (the per-agent list, or any roster variant of the
+ * aggregate — both restored from disk at boot).
+ *
+ * Why the board needs this: the per-agent `["activity", X]` query is only
+ * fetched while X's board is open AND only reaches the disk mirror when that
+ * session outlives the pod wake plus the persister's write throttle — so on a
+ * cold open it is often absent for the very agent being looked at. The
+ * aggregate, by contrast, is swept every session for every agent (the sidebar
+ * always mounts it): whenever the sidebar can paint its badges, this can
+ * paint the same missions as cards instead of empty columns held for the
+ * whole pod wake.
+ *
+ * Empty is not evidence: rows can be missing because the agent truly has no
+ * missions OR because a cached sweep skipped it, so no-rows returns
+ * `undefined` — preserving the caller's "still loading" state — never `[]`.
+ */
+export function latestCachedAgentActivities(
+  queryClient: QueryClient,
+  agentPath: string,
+): CachedBoardActivity[] | undefined {
+  let bestRows: CachedConversationRow[] | undefined;
+  let bestUpdatedAt = -1;
+  const consider = (
+    rows: CachedConversationRow[] | undefined,
+    updatedAt: number,
+  ) => {
+    if (!rows || rows.length === 0 || updatedAt <= bestUpdatedAt) return;
+    bestUpdatedAt = updatedAt;
+    bestRows = rows;
+  };
+
+  const own = queryClient.getQueryState<CachedConversationRow[]>(
+    queryKeys.conversations(agentPath),
+  );
+  if (own?.status === "success" && own.data)
+    consider(own.data, own.dataUpdatedAt);
+
+  const aggregates = queryClient
+    .getQueryCache()
+    .findAll({ queryKey: queryKeys.allConversations([]) });
+  for (const query of aggregates) {
+    const { status, data, dataUpdatedAt } = query.state;
+    if (status !== "success" || !Array.isArray(data)) continue;
+    consider(
+      (data as CachedConversationRow[]).filter(
+        (row) => row.agent_path === agentPath,
+      ),
+      dataUpdatedAt,
+    );
+  }
+
+  return bestRows?.map((row) => ({
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    status: row.status,
+    session_key: row.session_key,
+    updated_at: row.updated_at,
+    agent: row.agent,
+    routine_id: row.routine_id,
+  }));
+}

--- a/app/tests/all-conversations-cache.test.ts
+++ b/app/tests/all-conversations-cache.test.ts
@@ -1,7 +1,10 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import { QueryClient } from "@tanstack/react-query";
-import { latestCachedAllConversations } from "../src/lib/all-conversations-cache.ts";
+import {
+  latestCachedAgentActivities,
+  latestCachedAllConversations,
+} from "../src/lib/all-conversations-cache.ts";
 import { queryKeys } from "../src/lib/query-keys.ts";
 
 describe("latestCachedAllConversations", () => {
@@ -33,5 +36,101 @@ describe("latestCachedAllConversations", () => {
       updatedAt: 5_000,
     });
     strictEqual(latestCachedAllConversations(qc), undefined);
+  });
+});
+
+describe("latestCachedAgentActivities", () => {
+  const row = (id: string, agentPath: string, extra?: object) => ({
+    id,
+    title: `Mission ${id}`,
+    description: `About ${id}`,
+    status: "needs_you",
+    type: "activity",
+    session_key: `activity-${id}`,
+    updated_at: "2026-01-01T00:00:00.000Z",
+    agent_path: agentPath,
+    agent_name: "Agent",
+    ...extra,
+  });
+
+  it("returns undefined with nothing cached", () => {
+    const qc = new QueryClient();
+    strictEqual(latestCachedAgentActivities(qc, "agent-a"), undefined);
+  });
+
+  it("recovers this agent's board rows from the cached aggregate", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(
+      queryKeys.allConversations(["agent-a", "agent-b"]),
+      [
+        row("m1", "agent-a", { routine_id: "r1", agent: "researcher" }),
+        row("m2", "agent-b"),
+      ],
+      { updatedAt: 1_000 },
+    );
+    deepStrictEqual(latestCachedAgentActivities(qc, "agent-a"), [
+      {
+        id: "m1",
+        title: "Mission m1",
+        description: "About m1",
+        status: "needs_you",
+        session_key: "activity-m1",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        agent: "researcher",
+        routine_id: "r1",
+      },
+    ]);
+  });
+
+  it("prefers the newest source that actually has rows", () => {
+    const qc = new QueryClient();
+    // Older per-agent list with a row the newer aggregate is missing: the
+    // aggregate has NO rows for this agent, so it is not evidence of empty.
+    qc.setQueryData(
+      queryKeys.conversations("agent-a"),
+      [row("m1", "agent-a")],
+      {
+        updatedAt: 1_000,
+      },
+    );
+    qc.setQueryData(
+      queryKeys.allConversations(["agent-a", "agent-b"]),
+      [row("m2", "agent-b")],
+      { updatedAt: 2_000 },
+    );
+    const rows = latestCachedAgentActivities(qc, "agent-a");
+    deepStrictEqual(
+      rows?.map((r) => r.id),
+      ["m1"],
+    );
+  });
+
+  it("serves the newest rows when both sources have some", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(
+      queryKeys.conversations("agent-a"),
+      [row("stale", "agent-a")],
+      { updatedAt: 1_000 },
+    );
+    qc.setQueryData(
+      queryKeys.allConversations(["agent-a"]),
+      [row("fresh", "agent-a")],
+      { updatedAt: 2_000 },
+    );
+    const rows = latestCachedAgentActivities(qc, "agent-a");
+    deepStrictEqual(
+      rows?.map((r) => r.id),
+      ["fresh"],
+    );
+  });
+
+  it("returns undefined, never [], when no source has rows for the agent", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(
+      queryKeys.allConversations(["agent-a", "agent-b"]),
+      [row("m2", "agent-b")],
+      { updatedAt: 2_000 },
+    );
+    strictEqual(latestCachedAgentActivities(qc, "agent-a"), undefined);
   });
 });

--- a/packages/fake-host/src/router.ts
+++ b/packages/fake-host/src/router.ts
@@ -106,6 +106,14 @@ export async function handle(req: Request): Promise<Response> {
       advanced: turnBoundary(String(body?.nextText ?? "next turn")),
     });
   }
+  // Stall every per-agent read (`GET /agents/:id/*`) by `ms` — the cloud
+  // gateway's `ensureAwake` hold: an asleep pod's reads hang until it wakes.
+  // `{ ms: 0 }` (and the per-test reset) answers instantly again.
+  if (path === "/__test__/hold-agent-reads" && method === "POST") {
+    const body = await parseBody(req);
+    state.setAgentReadHoldMs(Number(body?.ms ?? 0));
+    return json({ ms: state.state.agentReadHoldMs });
+  }
   // Toggle Composio readiness: "ready" | "unavailable" (503) | "signin" |
   // "absent" (not registered at all — only the custom provider, when armed).
   if (path === "/__test__/integrations-mode" && method === "POST") {
@@ -217,6 +225,20 @@ export async function handle(req: Request): Promise<Response> {
 
   // --- everything under /agents/* ---
   if (segs[0] === "agents") {
+    // Armed cold-start hold: per-agent READS stall like they do behind the
+    // cloud gateway while a pod wakes. The agent LIST (`GET /agents`) stays
+    // instant — in the real deployment it is a gateway answer, not a pod one.
+    // The runtime-proxy `providers` probes are exempt too: they are not what
+    // this control models, and holding them exhausts the browser's HTTP/1.1
+    // six-connection budget against the dev server, stalling even unheld
+    // boot routes — an artifact the real HTTP/2 gateway doesn't have.
+    if (
+      state.state.agentReadHoldMs > 0 &&
+      method === "GET" &&
+      segs.length > 1 &&
+      segs[2] !== "providers"
+    )
+      await new Promise((r) => setTimeout(r, state.state.agentReadHoldMs));
     return handleAgents(
       method,
       segs.slice(1).map(decodeURIComponent),

--- a/packages/fake-host/src/state-store.ts
+++ b/packages/fake-host/src/state-store.ts
@@ -198,6 +198,14 @@ export interface HostState {
   /** Composio readiness, toggled by the `/__test__/integrations-mode` control. */
   integrationsMode: IntegrationsMode;
   /**
+   * Cold-start hold (ms) on per-agent reads, armed by
+   * `/__test__/hold-agent-reads`. Models the cloud gateway's `ensureAwake`
+   * hold: every `GET /agents/:id/*` stalls this long before answering, the
+   * way an asleep pod's reads stall until it wakes. `0` (the default and the
+   * reset state) answers instantly.
+   */
+  agentReadHoldMs: number;
+  /**
    * Custom integrations (HOU-550), armed by `/__test__/custom-integrations`.
    * `null` (the default) = the host does not serve the feature at all: no
    * `custom` entry in the readiness list and the definitions routes 404 (the
@@ -282,6 +290,7 @@ function freshState(): HostState {
     teamsSettings: { ...DEFAULT_TEAMS_SETTINGS },
     computeUsage: null,
     integrationsMode: "ready",
+    agentReadHoldMs: 0,
     customIntegrations: null,
     connections,
     // No seeded grants record: the seed agent starts "grants unsupported" (404 →
@@ -295,6 +304,11 @@ function freshState(): HostState {
 }
 
 export let state: HostState = freshState();
+
+/** Arm (or clear, with 0) the cold-start hold on per-agent reads. */
+export function setAgentReadHoldMs(ms: number): void {
+  state.agentReadHoldMs = Math.max(0, ms);
+}
 
 /** Restore the seed. Called by the harness before each test. */
 export function reset(): void {

--- a/packages/web/e2e/board.spec.ts
+++ b/packages/web/e2e/board.spec.ts
@@ -1,4 +1,60 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import type { Page } from "@playwright/test";
 import { expect, test } from "./support/fixtures";
+
+/**
+ * The persisted query mirror's query-key heads, or null while no mirror
+ * exists. Read via `page.evaluate`, which awaits the returned Promise —
+ * `page.waitForFunction` does NOT (a pending Promise object is truthy), so a
+ * wait built on it resolves instantly and asserts nothing.
+ */
+function persistedMirrorHeads(page: Page): Promise<string[] | null> {
+  return page.evaluate(
+    () =>
+      new Promise<string[] | null>((resolve) => {
+        const open = indexedDB.open("houston-query-cache", 1);
+        open.onsuccess = () => {
+          const request = open.result
+            .transaction("kv", "readonly")
+            .objectStore("kv")
+            .get("houston.list-queries");
+          request.onsuccess = () => {
+            try {
+              const raw = request.result as string | undefined;
+              if (typeof raw !== "string") return resolve(null);
+              const parsed = JSON.parse(raw) as {
+                clientState: { queries: { queryKey: unknown[] }[] };
+              };
+              resolve(
+                parsed.clientState.queries.map((q) => String(q.queryKey[0])),
+              );
+            } catch {
+              resolve(null);
+            }
+          };
+          request.onerror = () => resolve(null);
+        };
+        open.onerror = () => resolve(null);
+      }),
+  );
+}
+
+/** Give the page a JWT-shaped per-user token: the fake host accepts any
+ *  bearer, while the query/transcript caches scope themselves to `e2e-user`
+ *  (the standard non-JWT token deliberately turns persistence off). */
+async function seedUserScopedToken(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const key = "houston.web.engine.new";
+    const config = JSON.parse(localStorage.getItem(key) ?? "{}");
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        ...config,
+        token: "e30.eyJzdWIiOiJlMmUtdXNlciJ9.sig",
+      }),
+    );
+  });
+}
 
 /**
  * The mission board is "files-first": it reads `.houston/activity/activity.json`
@@ -16,41 +72,20 @@ test("renders the seeded missions on the board", async ({ page }) => {
 test("restores cached missions before starting fresh board reads", async ({
   page,
 }) => {
-  // The standard fake-host token is deliberately non-user-scoped, which turns
-  // persistence off. Give this test a JWT-shaped per-user token; the fake host
-  // accepts it, while the cache correctly scopes itself to `e2e-user`.
-  await page.addInitScript(() => {
-    const key = "houston.web.engine.new";
-    const config = JSON.parse(localStorage.getItem(key) ?? "{}");
-    localStorage.setItem(
-      key,
-      JSON.stringify({
-        ...config,
-        token: "e30.eyJzdWIiOiJlMmUtdXNlciJ9.sig",
-      }),
-    );
-  });
+  await seedUserScopedToken(page);
   await page.goto("/");
   await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible();
 
-  // Let the async persister commit this populated board, then make its next
-  // IndexedDB read visibly slow. This pins the startup race: no activity read
-  // may start while the older, populated cache is still being restored.
-  await page.waitForFunction(
-    () =>
-      new Promise<boolean>((resolve) => {
-        const open = indexedDB.open("houston-query-cache", 1);
-        open.onsuccess = () => {
-          const request = open.result
-            .transaction("kv", "readonly")
-            .objectStore("kv")
-            .get("houston.list-queries");
-          request.onsuccess = () => resolve(typeof request.result === "string");
-          request.onerror = () => resolve(false);
-        };
-        open.onerror = () => resolve(false);
-      }),
-  );
+  // Let the async persister commit this populated board (the write throttle
+  // lags the fetch by a second or more — wait for the CONTENT, not just the
+  // store), then make its next IndexedDB read visibly slow. This pins the
+  // startup race: no activity read may start while the older, populated cache
+  // is still being restored.
+  await expect
+    .poll(async () => (await persistedMirrorHeads(page)) ?? [], {
+      timeout: 15_000,
+    })
+    .toContain("activity");
   await page.addInitScript(() => {
     const nativeGet = IDBObjectStore.prototype.get;
     IDBObjectStore.prototype.get = function delayedGet(query) {
@@ -91,6 +126,90 @@ test("restores cached missions before starting fresh board reads", async ({
 
   expect(activityReads).toBe(0);
   await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible();
+});
+
+/**
+ * The cold-open reality check: on a real cloud boot every per-agent read
+ * hangs behind the gateway for the whole pod wake (~seconds), so the ONLY
+ * thing that can paint the board immediately is what's cached locally. The
+ * restore test above can't prove that — its live read answers instantly and
+ * would paint the card even if the restored data never reached the board.
+ *
+ * This models the exact production failure: the per-agent `["activity", X]`
+ * mirror entry is MISSING (it only lands when a session with X's board open
+ * outlives the pod wake plus the persist throttle), while the aggregate the
+ * sidebar badges paint from is present (it's swept every session). The board
+ * must seed its cards from that aggregate instead of showing empty columns
+ * for the whole wake — the badge says 2 missions, the columns must agree.
+ */
+test("paints cached missions immediately while cold-start reads are held", async ({
+  page,
+  request,
+}) => {
+  await seedUserScopedToken(page);
+  await page.goto("/");
+  await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible();
+
+  // Let the async persister commit both list surfaces to IndexedDB.
+  await expect
+    .poll(
+      async () => {
+        const heads = (await persistedMirrorHeads(page)) ?? [];
+        return (
+          heads.includes("activity") && heads.includes("all-conversations")
+        );
+      },
+      { timeout: 15_000 },
+    )
+    .toBe(true);
+
+  // Drop the per-agent board entries, keeping the aggregate — the mirror a
+  // real cold open typically finds. The app is idle here (no cache events →
+  // no persister rewrites), so the strip sticks until the reload.
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        const open = indexedDB.open("houston-query-cache", 1);
+        open.onsuccess = () => {
+          const store = open.result
+            .transaction("kv", "readwrite")
+            .objectStore("kv");
+          const get = store.get("houston.list-queries");
+          get.onsuccess = () => {
+            const parsed = JSON.parse(get.result as string) as {
+              clientState: { queries: { queryKey: unknown[] }[] };
+            };
+            parsed.clientState.queries = parsed.clientState.queries.filter(
+              (q) => q.queryKey[0] !== "activity",
+            );
+            const put = store.put(
+              JSON.stringify(parsed),
+              "houston.list-queries",
+            );
+            put.onsuccess = () => resolve();
+            put.onerror = () => reject(put.error);
+          };
+          get.onerror = () => reject(get.error);
+        };
+        open.onerror = () => reject(open.error);
+      }),
+  );
+  const stripped = (await persistedMirrorHeads(page)) ?? [];
+  expect(stripped).toContain("all-conversations");
+  expect(stripped).not.toContain("activity");
+
+  // Cold open: every per-agent read now stalls the way an asleep pod's do.
+  await request.post(`${FAKE_HOST_URL}/__test__/hold-agent-reads`, {
+    data: { ms: 8_000 },
+  });
+  await page.reload();
+
+  // The cards must come from the locally cached aggregate — well before any
+  // held read can answer. 4s of grace for the reload+restore, far under the
+  // 8s hold.
+  await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible({
+    timeout: 4_000,
+  });
 });
 
 test("opens a mission's chat when its card is clicked", async ({ page }) => {


### PR DESCRIPTION
## Symptom

Opening the app shows the sidebar needs-attention badges immediately, but the selected agent's Kanban board renders empty columns for the ~7-8 seconds it takes the pod to wake. The cards only appear once the gateway-held activity read finally answers. Badge says 2 missions; columns say nothing.

## Root cause

The cold-open paint was supposed to come from the disk-persisted `["activity", X]` query (HOU-712 follow-up), and the restore -> paint pipeline does work. The gap is structural, in **which entries actually reach the disk mirror**:

- The **aggregate** (`all-conversations`) is swept every session for every agent, because the sidebar always mounts it. It is virtually always restorable, so the badges always paint.
- The **per-agent** `["activity", X]` query is only fetched while X's board is open, and only reaches the mirror if that session outlives the pod wake **plus** the async persister's write throttle (the throttled write can land seconds after the data does; a quick open-glance-quit never commits it). Short sessions, first visits, and post-sign-out mirrors (sign-out wipes; account switches bust) leave the selected agent's entry missing, so the next boot has nothing to paint the board with while the read rides the gateway hold.

Verified end to end: the prod IndexedDB mirror on the affected machine had healthy aggregate rows for all 13 agents (hence the badges) while the board waited on the live read; a hermetic-harness reproduction confirmed both the failure and that a present activity entry paints instantly under held reads.

## Fix

Conversations are derived 1:1 from board activities (`activityToConversation`), so the cached conversation rows ARE the board's missions. `useActivity` now seeds `placeholderData` from the freshest cached conversation list scoped to the agent (its own `conversations` entry, or any roster variant of the aggregate): **the board can paint whenever the sidebar can**. Placeholder semantics preserve the existing contract: never persisted, replaced by the held read when the pod answers, and `undefined` (still loading) when nothing is cached, never a fabricated `[]`.

The provider pauses query fetches until hydration settles and the board only mounts after the agents list resolves, so the placeholder always evaluates against the already-restored cache.

## Tests

- Unit: `latestCachedAgentActivities` (aggregate scoping, newest-source-with-rows preference, no-rows -> `undefined`).
- Harness: `@houston/fake-host` gains `POST /__test__/hold-agent-reads` (ms), stalling per-agent GETs the way the gateway's `ensureAwake` hold does. Agent list and runtime `providers` probes are exempt: the list is a gateway answer in prod, and holding the probes exhausts the HTTP/1.1 dev harness's six-connection budget, stalling even unheld boot routes (an artifact prod's HTTP/2 gateway doesn't have).
- E2E regression: warms the mirror, strips the per-agent `activity` entries (the mirror a real cold open typically finds), arms an 8s hold, reloads, and asserts the cards paint from the aggregate within 4s.
- Repaired the existing restore spec's wait: `page.waitForFunction` never awaits an async predicate (a pending Promise object is truthy), so the old existence check resolved instantly and asserted nothing. Both specs now poll mirror CONTENT via `page.evaluate`.

Gates: biome, full workspace typecheck, app unit tests (1612), fake-host vitest, boundaries, full web e2e suite (126/126).