### PR TITLE
feat(chat): toast when a mode change lands on the next message

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -132,6 +132,7 @@ import {
 } from "../lib/tauri";
 import {
   DEFAULT_TURN_MODE,
+  modeChangeAppliesNextTurn,
   normalizeTurnMode,
   type TurnMode,
 } from "../lib/turn-mode";
@@ -435,6 +436,9 @@ export function useAgentChatPanel({
   // the card) and `pendingInteraction` is the live source the derivation
   // prefers over the persisted activity fallback.
   const conversationVm = useConversationVm(path, selectedSessionKey);
+  // Plain boolean so callbacks can depend on "is a turn running" without
+  // re-creating on every VM tick (the VM reference churns while streaming).
+  const turnRunning = conversationVm?.running ?? false;
 
   // Whether the open conversation already has turns. Once it does, the chat's
   // provider is frozen (see resolveEffectiveProvider): a provider that logs out
@@ -671,10 +675,33 @@ export function useAgentChatPanel({
     [path, addToast, t],
   );
   const handleModeSelect = useCallback(
-    async (mode: TurnMode) => {
+    async (mode: TurnMode, opts?: { silent?: boolean }) => {
       // Mode is per-agent composer memory (never synced to engine Settings):
       // persist it so the pill reopens where the user left it. Optimistic flip;
       // the actual plan/execute pin rides each send as `modeOverride`.
+      //
+      // A pick while a turn is streaming can't touch that turn (its pin was
+      // stamped at send), so say so: a transient toast tells the user the new
+      // mode rides the NEXT message. `silent` is for programmatic flips whose
+      // send carries the mode explicitly (the plan-ready card), where the
+      // note would be a lie.
+      if (
+        !opts?.silent &&
+        modeChangeAppliesNextTurn(turnRunning, turnMode, mode)
+      ) {
+        const modeLabels: Record<TurnMode, string> = {
+          execute: t("chat:modeSelector.coworker"),
+          plan: t("chat:modeSelector.planner"),
+          auto: t("chat:modeSelector.autopilot"),
+        };
+        addToast({
+          title: t("chat:modeSelector.nextTurnToastTitle", {
+            mode: modeLabels[mode],
+          }),
+          description: t("chat:modeSelector.nextTurnToastBody"),
+          variant: "info",
+        });
+      }
       setTurnMode(mode);
       try {
         if (path) {
@@ -689,7 +716,7 @@ export function useAgentChatPanel({
         });
       }
     },
-    [path, addToast, t],
+    [path, addToast, t, turnRunning, turnMode],
   );
 
   // Route a composer model / effort pick. In personal (Teams) mode it writes the
@@ -958,7 +985,7 @@ export function useAgentChatPanel({
   // one (reload / observer). Gated on `running` so a fresh turn's composer wins
   // and the card disappears the instant the user answers.
   const activeInteraction = deriveActiveInteraction({
-    running: conversationVm?.running ?? false,
+    running: turnRunning,
     live: conversationVm?.pendingInteraction,
     persisted: selectedActivity?.pending_interaction,
   });
@@ -1110,7 +1137,7 @@ export function useAgentChatPanel({
   const startPlan = useCallback(
     (mode: TurnMode, text: string) => {
       if (!path || !selectedSessionKey) return;
-      void handleModeSelect(mode);
+      void handleModeSelect(mode, { silent: true });
       tauriChat
         .send(path, text, selectedSessionKey, {
           providerOverride: effectiveProvider,

--- a/app/src/lib/turn-mode.ts
+++ b/app/src/lib/turn-mode.ts
@@ -28,6 +28,22 @@ export function normalizeTurnMode(value: unknown): TurnMode {
 }
 
 /**
+ * Whether a Mode-pill pick deserves the "applies to your next message" note.
+ * True only when a turn is running AND the pick actually changes the mode:
+ * the in-flight turn keeps the mode it was sent with (the pin rides each send
+ * as `modeOverride`), so a mid-turn change is real but deferred, and the user
+ * needs to hear that. Re-picking the current mode changes nothing, and a pick
+ * with no turn running applies immediately — neither warrants a note.
+ */
+export function modeChangeAppliesNextTurn(
+  turnRunning: boolean,
+  current: TurnMode,
+  next: TurnMode,
+): boolean {
+  return turnRunning && next !== current;
+}
+
+/**
  * The agent's remembered turn mode, for send paths that assemble their own
  * overrides (Mission Control, archived resumes) instead of holding the chat
  * panel's live pill state. A failed config read falls back to

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -147,7 +147,9 @@
     "planner": "Planner",
     "plannerDescription": "Writes a plan for you to approve first. Makes no changes.",
     "autopilot": "Autopilot",
-    "autopilotDescription": "Finishes the task on its own with what it has. No questions asked."
+    "autopilotDescription": "Finishes the task on its own with what it has. No questions asked.",
+    "nextTurnToastTitle": "{{mode}} mode is set",
+    "nextTurnToastBody": "It will apply to your next message. The current reply keeps going."
   },
   "modelSelector": {
     "selectModel": "Select model",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -147,7 +147,9 @@
     "planner": "Planificador",
     "plannerDescription": "Primero escribe un plan para que lo apruebes. No hace cambios.",
     "autopilot": "Piloto automático",
-    "autopilotDescription": "Termina la tarea por su cuenta con lo que tiene. No hace preguntas."
+    "autopilotDescription": "Termina la tarea por su cuenta con lo que tiene. No hace preguntas.",
+    "nextTurnToastTitle": "Modo {{mode}} seleccionado",
+    "nextTurnToastBody": "Se aplicará a tu próximo mensaje. La respuesta actual continúa."
   },
   "modelSelector": {
     "selectModel": "Elige un modelo",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -147,7 +147,9 @@
     "planner": "Planejador",
     "plannerDescription": "Primeiro escreve um plano para você aprovar. Não faz alterações.",
     "autopilot": "Piloto automático",
-    "autopilotDescription": "Conclui a tarefa sozinho com o que tem. Não faz perguntas."
+    "autopilotDescription": "Conclui a tarefa sozinho com o que tem. Não faz perguntas.",
+    "nextTurnToastTitle": "Modo {{mode}} selecionado",
+    "nextTurnToastBody": "Será aplicado à sua próxima mensagem. A resposta atual continua."
   },
   "modelSelector": {
     "selectModel": "Escolha um modelo",

--- a/app/tests/turn-mode.test.ts
+++ b/app/tests/turn-mode.test.ts
@@ -2,6 +2,7 @@ import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
   DEFAULT_TURN_MODE,
+  modeChangeAppliesNextTurn,
   normalizeTurnMode,
   readAgentTurnMode,
 } from "../src/lib/turn-mode.ts";
@@ -35,6 +36,27 @@ describe("normalizeTurnMode", () => {
 
   it("defaults to plan (fresh agents open in Planner)", () => {
     strictEqual(DEFAULT_TURN_MODE, "plan");
+  });
+});
+
+// A Mode-pill pick can't touch the in-flight turn (its pin was stamped at
+// send), so the composer shows an "applies to your next message" toast — but
+// ONLY when a turn is actually running and the pick changes the mode.
+describe("modeChangeAppliesNextTurn", () => {
+  it("announces a real change while a turn is running", () => {
+    strictEqual(modeChangeAppliesNextTurn(true, "execute", "plan"), true);
+    strictEqual(modeChangeAppliesNextTurn(true, "plan", "auto"), true);
+    strictEqual(modeChangeAppliesNextTurn(true, "auto", "execute"), true);
+  });
+
+  it("stays quiet when no turn is running (the pick applies immediately)", () => {
+    strictEqual(modeChangeAppliesNextTurn(false, "execute", "plan"), false);
+    strictEqual(modeChangeAppliesNextTurn(false, "plan", "auto"), false);
+  });
+
+  it("stays quiet when the pick re-selects the current mode", () => {
+    strictEqual(modeChangeAppliesNextTurn(true, "plan", "plan"), false);
+    strictEqual(modeChangeAppliesNextTurn(false, "auto", "auto"), false);
   });
 });
 


### PR DESCRIPTION
## What

The composer Mode selector (Planner / Coworker / Autopilot) stays enabled while a turn is streaming, but a mid-turn pick never touches the in-flight turn: the mode pin rides each send as `modeOverride`, so it only takes effect on the next message. Nothing told the user that.

Now, changing the mode while a turn is running shows a transient info toast: "**Planner mode is set** - It will apply to your next message. The current reply keeps going."

## How

- `app/src/lib/turn-mode.ts`: new pure helper `modeChangeAppliesNextTurn(running, current, next)` - true only when a turn is running AND the pick actually changes the mode. Re-picking the current mode, or picking with no turn running, stays quiet.
- `app/src/components/use-agent-chat-panel.tsx`: `handleModeSelect` fires the toast, using `conversationVm.running` as the in-flight signal (hoisted to a plain `turnRunning` boolean so callbacks do not churn on every VM tick). The plan-ready card path passes `{ silent: true }` since its send carries the mode explicitly.
- i18n: new `modeSelector.nextTurnToastTitle/Body` keys in en / es / pt.

## Tests

- `app/tests/turn-mode.test.ts`: coverage for the helper (announce on real mid-turn change; quiet when idle or re-selecting). 9 tests pass.
- `pnpm tsgo --noEmit` (app), `pnpm --filter houston-web typecheck`, `pnpm check-locales`, `pnpm check` all clean.
