### PR TITLE
fix(app): keep the Codex sign-in relay off for a loopback hosted gateway

### DIFF
--- a/app/src/lib/engine-mode.ts
+++ b/app/src/lib/engine-mode.ts
@@ -46,25 +46,32 @@ export function isLoopbackHostUrl(url: string | undefined): boolean {
  * client's only job is opening the authorize URL in the user's browser. A
  * Tauri desktop pointed at a truly remote host is still a remote client for
  * provider auth (the runtime's localhost callback is on the remote host) and
- * must use the device-code flow — but a `VITE_NEW_ENGINE_URL` at a loopback
- * address IS co-located (the dev two-terminal setup), so it keeps the
- * seamless browser flow, exactly like the packaged host-sidecar build.
+ * must use the device-code flow — but an engine URL at a loopback address IS
+ * co-located, so it keeps the seamless browser flow, exactly like the packaged
+ * host-sidecar build. That applies to BOTH env flags: a loopback
+ * `VITE_NEW_ENGINE_URL` (the dev two-terminal setup) and a loopback
+ * `VITE_HOSTED_ENGINE_URL` (the dev cloud profile's local gateway, whose
+ * "pods" are runtimes on this same machine).
  */
 export function providerLoginUsesDeviceAuthByDefault(
   env: Pick<EngineModeEnv, "VITE_NEW_ENGINE_URL" | "VITE_HOSTED_ENGINE_URL">,
   client: { isTauri: boolean },
 ): boolean {
   if (!client.isTauri) return true;
-  if (env.VITE_HOSTED_ENGINE_URL) return true;
+  if (env.VITE_HOSTED_ENGINE_URL)
+    return !isLoopbackHostUrl(env.VITE_HOSTED_ENGINE_URL);
   if (env.VITE_NEW_ENGINE_URL)
     return !isLoopbackHostUrl(env.VITE_NEW_ENGINE_URL);
   return false;
 }
 
 /** Gate for the desktop Codex/OpenAI zero-code loopback relay: ON only for a
- * REMOTE engine, where pi's own 1455 is in the pod so the desktop's LOCAL 1455
- * can't collide. Co-located/web keep existing flows; collision rationale
- * (#615/#620) is at the relay call sites (codex-loopback.ts). */
+ * TRULY remote engine, where pi's own 1455 is in the pod so the desktop's
+ * LOCAL 1455 can't collide. Co-located/web keep existing flows — including a
+ * loopback hosted gateway (the dev cloud profile), whose runtime binds 1455 on
+ * THIS machine: a relay bind there fails EADDRINUSE and kills the sign-in.
+ * Collision rationale (#615/#620) is at the relay call sites
+ * (codex-loopback.ts). */
 export function codexUsesLoopbackRelay(
   env: Pick<EngineModeEnv, "VITE_NEW_ENGINE_URL" | "VITE_HOSTED_ENGINE_URL">,
   client: { isTauri: boolean },

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1306,13 +1306,19 @@ export const tauriProvider = {
                 // the client only opens the URL. A truly remote engine (hosted
                 // cloud, a VPS, or the HOU-621 runtime `remote` choice with no
                 // baked env — hence the isRemoteEngine() OR) must use device
-                // code instead. A LOOPBACK `VITE_NEW_ENGINE_URL` (the dev
-                // two-terminal setup) is co-located despite being URL-configured,
-                // so it keeps the browser flow like the packaged host-sidecar
-                // build.
+                // code instead. A LOOPBACK engine URL is co-located despite
+                // being URL-configured — `VITE_NEW_ENGINE_URL` (the dev
+                // two-terminal setup) and `VITE_HOSTED_ENGINE_URL` (the dev
+                // cloud profile's local gateway) alike — so it keeps the
+                // browser flow like the packaged host-sidecar build.
                 (isRemoteEngine() &&
                   !isLoopbackHostUrl(
                     import.meta.env?.VITE_NEW_ENGINE_URL as string | undefined,
+                  ) &&
+                  !isLoopbackHostUrl(
+                    import.meta.env?.VITE_HOSTED_ENGINE_URL as
+                      | string
+                      | undefined,
                   )) ||
                 providerLoginUsesDeviceAuthByDefault(
                   (import.meta.env ?? {}) as {

--- a/app/tests/engine-mode.test.ts
+++ b/app/tests/engine-mode.test.ts
@@ -52,6 +52,16 @@ describe("providerLoginUsesDeviceAuthByDefault", () => {
     );
   });
 
+  it("uses browser loopback for a LOOPBACK hosted gateway (dev cloud profile)", () => {
+    strictEqual(
+      providerLoginUsesDeviceAuthByDefault(
+        { VITE_HOSTED_ENGINE_URL: "http://localhost:9080" },
+        { isTauri: true },
+      ),
+      false,
+    );
+  });
+
   it("uses device code for browser clients", () => {
     strictEqual(
       providerLoginUsesDeviceAuthByDefault({}, { isTauri: false }),
@@ -118,6 +128,16 @@ describe("codexUsesLoopbackRelay (B2 truth table)", () => {
         { isTauri: true },
       ),
       true,
+    );
+  });
+
+  it("relay OFF for a LOOPBACK hosted gateway (dev cloud profile — pi's 1455 is on THIS machine)", () => {
+    strictEqual(
+      codexUsesLoopbackRelay(
+        { VITE_HOSTED_ENGINE_URL: "http://localhost:9080" },
+        { isTauri: true },
+      ),
+      false,
     );
   });
 


### PR DESCRIPTION
## Problem

Connecting OpenAI from the dev desktop app in the cloud profile (`DEV_DESKTOP_PROFILE=cloud`) fails instantly with the toast **"Couldn't open OpenAI sign-in"**. The frontend log has the real error:

```
[codex_loopback_login] Could not start the Codex sign-in listener: port 1455 is
unavailable (Address already in use (os error 48))
```

The zero-code Codex loopback relay is gated on `codexUsesLoopbackRelay`, which read "a hosted gateway URL is set" as "the engine is remote". The dev cloud profile bakes `VITE_HOSTED_ENGINE_URL=http://localhost:9080` — a **loopback** gateway whose runtimes live on the same machine. The runtime is asked for the browser flow (`deviceAuth:false`), so pi binds OpenAI's fixed callback port 1455 in-process; the app-side relay then tries to bind the same port and dies with EADDRINUSE, killing the sign-in. Same collision class as #615 (reverted in #620), reached through the hosted-URL branch, which lacked the loopback exception `VITE_NEW_ENGINE_URL` already had.

## Fix

A loopback engine URL is co-located regardless of which env flag carries it:

- `providerLoginUsesDeviceAuthByDefault` applies the `isLoopbackHostUrl` exception to `VITE_HOSTED_ENGINE_URL` too — flipping `codexUsesLoopbackRelay` off for a loopback gateway, so the app never binds 1455 there.
- `launchLogin`'s `isRemoteEngine()` deviceAuth fallback (tauri.ts) gets the matching exception, so the runtime keeps the seamless browser flow (pi owns 1455 on this machine; the app just opens the URL) instead of degrading to a device code.

Production shape unchanged: real cloud desktops bake a non-loopback gateway URL and keep the relay; web clients keep device-code; the packaged sidecar build was never affected.

## Tests

- Two new `engine-mode.test.ts` cases pin the loopback-gateway behavior: predicate → browser flow, relay → OFF.
- All engine-mode + provider-login suites pass; `tsgo --noEmit` (app + web) and Biome clean.