### PR TITLE
fix(usage): hide system/ghost agents from the Time worked list

### DIFF
--- a/app/src/components/usage-view/compute-agent-row.tsx
+++ b/app/src/components/usage-view/compute-agent-row.tsx
@@ -1,4 +1,4 @@
-import { Badge, HoustonAvatar } from "@houston-ai/core";
+import { HoustonAvatar } from "@houston-ai/core";
 import type { ComputeAgentTotals } from "./compute-usage-model";
 
 interface ComputeAgentRowProps {
@@ -9,31 +9,26 @@ interface ComputeAgentRowProps {
   color?: string;
   /** Busiest agent's workMs (≥ 1), to scale this row's bar. */
   max: number;
-  /** This agent's engine is up right now. */
-  runningNow: boolean;
   /** Formatted time worked ("3h 12m"). */
   duration: string;
   /** Formatted task count ("12 tasks"). */
   tasks: string;
-  /** "Online" badge text. */
-  runningNowLabel: string;
 }
 
 /**
  * One agent's time worked in the Compute section: avatar + name + duration
  * and task count + a tokened track bar scaled to the busiest agent (the same
  * shape as the org Usage tab's rows, minus the expandable breakdown — time
- * worked is per-agent, not per-person).
+ * worked is per-agent, not per-person). Deliberately no liveness badge: the
+ * pod's up/idle state is infrastructure the user never needs to see.
  */
 export function ComputeAgentRow({
   agent,
   name,
   color,
   max,
-  runningNow,
   duration,
   tasks,
-  runningNowLabel,
 }: ComputeAgentRowProps) {
   const pct = Math.max(2, Math.round((agent.workMs / max) * 100));
   return (
@@ -41,16 +36,7 @@ export function ComputeAgentRow({
       <HoustonAvatar color={color} diameter={28} />
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline justify-between gap-3">
-          <span className="flex min-w-0 items-baseline gap-2">
-            <span className="truncate text-sm font-medium text-ink">
-              {name}
-            </span>
-            {runningNow && (
-              <Badge variant="secondary" className="shrink-0">
-                {runningNowLabel}
-              </Badge>
-            )}
-          </span>
+          <span className="truncate text-sm font-medium text-ink">{name}</span>
           <span className="shrink-0 text-sm text-ink-muted">
             {duration}
             <span aria-hidden> · </span>

--- a/app/src/components/usage-view/compute-section.tsx
+++ b/app/src/components/usage-view/compute-section.tsx
@@ -177,10 +177,8 @@ export function ComputeSection() {
                     name={name}
                     color={resolveAgentColor(match?.color)}
                     max={model.maxAgentMs}
-                    runningNow={onlineNow.includes(agent.agentSlug)}
                     duration={formatDuration(t, agent.workMs)}
                     tasks={t("usage.compute.tasks", { count: agent.tasks })}
-                    runningNowLabel={t("usage.compute.online")}
                   />
                 );
               })}

--- a/app/src/components/usage-view/compute-section.tsx
+++ b/app/src/components/usage-view/compute-section.tsx
@@ -19,6 +19,7 @@ import {
   bucketCompute,
   type ComputeRange,
   durationParts,
+  isOpaqueSlug,
 } from "./compute-usage-model";
 
 const RANGES: ComputeRange[] = ["week", "month", "quarter"];
@@ -163,11 +164,17 @@ export function ComputeSection() {
                     a.folderPath === agent.agentSlug ||
                     a.id === agent.agentSlug,
                 );
+                // A slug with no matching agent and no words in it is a
+                // deleted agent's wire id — say so instead of showing hex.
+                const name =
+                  !match && isOpaqueSlug(agent.agentSlug)
+                    ? t("usage.compute.removedAgent")
+                    : agentLabel(agent.agentSlug, agents);
                 return (
                   <ComputeAgentRow
                     key={agent.agentSlug}
                     agent={agent}
-                    name={agentLabel(agent.agentSlug, agents)}
+                    name={name}
                     color={resolveAgentColor(match?.color)}
                     max={model.maxAgentMs}
                     runningNow={onlineNow.includes(agent.agentSlug)}

--- a/app/src/components/usage-view/compute-usage-model.ts
+++ b/app/src/components/usage-view/compute-usage-model.ts
@@ -102,9 +102,14 @@ export function bucketCompute(
     agent.tasks += tasks;
   }
 
-  const agents = [...perAgent.values()].sort(
-    (a, b) => b.workMs - a.workMs || a.agentSlug.localeCompare(b.agentSlug),
-  );
+  // Agents with nothing to show in the selected range are pure noise: an
+  // awake-but-never-working engine (rows carry awakeMs we don't render) or a
+  // deleted agent's residual zero days would list as "0m · 0 tasks".
+  const agents = [...perAgent.values()]
+    .filter((agent) => agent.workMs > 0 || agent.tasks > 0)
+    .sort(
+      (a, b) => b.workMs - a.workMs || a.agentSlug.localeCompare(b.agentSlug),
+    );
   return {
     buckets,
     perAgent: agents,
@@ -135,6 +140,15 @@ export function durationParts(ms: number): DurationParts {
     hours: Math.floor(totalMinutes / 60),
     minutes: String(totalMinutes % 60).padStart(2, "0"),
   };
+}
+
+/**
+ * A wire agent slug with no human content (the gateway's 16-hex ids). When it
+ * resolves to no known agent, the view shows "Removed agent" instead of raw
+ * hex — `agentLabel`'s humanizer only helps slugs with real words in them.
+ */
+export function isOpaqueSlug(slug: string): boolean {
+  return /^[0-9a-f]{12,}$/i.test(slug);
 }
 
 /** The section renders only where the gateway advertises the endpoint. */

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -187,7 +187,8 @@
         "body": "When your agents work on tasks, their time will show here."
       },
       "error": "Couldn't load your agents' time right now. Try again in a moment.",
-      "online": "Online"
+      "online": "Online",
+      "removedAgent": "Removed agent"
     }
   },
   "toast": {}

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -187,7 +187,6 @@
         "body": "When your agents work on tasks, their time will show here."
       },
       "error": "Couldn't load your agents' time right now. Try again in a moment.",
-      "online": "Online",
       "removedAgent": "Removed agent"
     }
   },

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -187,7 +187,8 @@
         "body": "Cuando tus agentes trabajen en tareas, su tiempo aparecerá aquí."
       },
       "error": "No se pudo cargar el tiempo de tus agentes. Intenta de nuevo en un momento.",
-      "online": "En línea"
+      "online": "En línea",
+      "removedAgent": "Agente eliminado"
     }
   },
   "toast": {}

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -187,7 +187,6 @@
         "body": "Cuando tus agentes trabajen en tareas, su tiempo aparecerá aquí."
       },
       "error": "No se pudo cargar el tiempo de tus agentes. Intenta de nuevo en un momento.",
-      "online": "En línea",
       "removedAgent": "Agente eliminado"
     }
   },

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -187,7 +187,6 @@
         "body": "Quando seus agentes trabalharem em tarefas, o tempo deles vai aparecer aqui."
       },
       "error": "Não foi possível carregar o tempo dos seus agentes. Tente novamente em instantes.",
-      "online": "Online",
       "removedAgent": "Agente removido"
     }
   },

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -187,7 +187,8 @@
         "body": "Quando seus agentes trabalharem em tarefas, o tempo deles vai aparecer aqui."
       },
       "error": "Não foi possível carregar o tempo dos seus agentes. Tente novamente em instantes.",
-      "online": "Online"
+      "online": "Online",
+      "removedAgent": "Agente removido"
     }
   },
   "toast": {}

--- a/app/tests/compute-usage-model.test.ts
+++ b/app/tests/compute-usage-model.test.ts
@@ -4,6 +4,7 @@ import type { ComputeUsageRow } from "@houston-ai/engine-client";
 import {
   bucketCompute,
   durationParts,
+  isOpaqueSlug,
   showComputeSection,
 } from "../src/components/usage-view/compute-usage-model.ts";
 
@@ -112,6 +113,37 @@ describe("bucketCompute", () => {
     const model = bucketCompute([], "week", NOW);
     strictEqual(model.maxBucketMs, 1);
     strictEqual(model.maxAgentMs, 1);
+  });
+
+  it("drops agents with no work and no tasks in range (awake-only ghosts)", () => {
+    const ghost: ComputeUsageRow = {
+      agentSlug: "5e70000000000000",
+      day: "2026-07-15",
+      awakeMs: 600_000, // awake the whole time...
+      activeMs: 0, // ...but never worked
+      wakes: 3,
+      turns: 0,
+      routineRuns: 0,
+    };
+    const model = bucketCompute(
+      [ghost, row("real", "2026-07-15", 1_000, 1)],
+      "week",
+      NOW,
+    );
+    deepStrictEqual(
+      model.perAgent.map((a) => a.agentSlug),
+      ["real"],
+    );
+  });
+});
+
+describe("isOpaqueSlug", () => {
+  it("matches bare wire ids but not nameable slugs", () => {
+    strictEqual(isOpaqueSlug("40e4d673e72e86df"), true);
+    strictEqual(isOpaqueSlug("5e70000000000000"), true);
+    strictEqual(isOpaqueSlug("sales-bot"), false);
+    strictEqual(isOpaqueSlug("deadbeef"), false); // too short to be a wire id
+    strictEqual(isOpaqueSlug("my_agent_2"), false);
   });
 });
 

--- a/packages/web/e2e/usage-compute.spec.ts
+++ b/packages/web/e2e/usage-compute.spec.ts
@@ -109,8 +109,8 @@ test("with data the section shows the total, daily bars, and per-agent rows", as
   // 7 daily bars, each self-describing ("Jul 15: worked 2h 05m, 10 tasks").
   await expect(page.getByRole("img", { name: /: worked / })).toHaveCount(7);
 
-  // Per-agent rows: the seed agent resolves to its display name and wears the
-  // online badge (3h 05m across 13 tasks); the deleted slug humanizes. Scope
+  // Per-agent rows: the seed agent resolves to its display name (3h 05m
+  // across 13 tasks); the deleted slug humanizes. Scope
   // to the compute section — the AI-accounts cards below are also list items
   // and their "not metered yet" copy mentions Houston by name.
   const computeSection = page
@@ -119,9 +119,10 @@ test("with data the section shows the total, daily bars, and per-agent rows", as
   const houston = computeSection
     .getByRole("listitem")
     .filter({ hasText: "Houston" });
-  await expect(houston.getByText("Online")).toBeVisible();
   await expect(houston).toContainText("3h 05m");
   await expect(houston).toContainText("13 tasks");
+  // No liveness badge: pod up/idle state is infrastructure the user never sees.
+  await expect(houston.getByText("Online")).toHaveCount(0);
   const sales = computeSection
     .getByRole("listitem")
     .filter({ hasText: "Sales bot" });

--- a/packages/web/e2e/usage-compute.spec.ts
+++ b/packages/web/e2e/usage-compute.spec.ts
@@ -79,6 +79,19 @@ test("with data the section shows the total, daily bars, and per-agent rows", as
       row("houston-assistant", 1, 60 * 60_000, 3, 0),
       // A since-deleted agent humanizes from its slug.
       row("sales-bot", 1, 30 * 60_000, 1, 0),
+      // A deleted agent's bare wire id, with real work: labels "Removed agent".
+      row("40e4d673e72e86df", 1, 5 * 60_000, 1, 0),
+      // An awake-but-never-working ghost (e.g. residual zero days): the row
+      // carries only awakeMs, so the by-agent list must not show it at all.
+      {
+        agentSlug: "1dee000000000000",
+        day: day(0),
+        awakeMs: 10 * 60_000,
+        activeMs: 0,
+        wakes: 2,
+        turns: 0,
+        routineRuns: 0,
+      },
     ],
     awakeNow: ["houston-assistant"],
   });
@@ -88,9 +101,10 @@ test("with data the section shows the total, daily bars, and per-agent rows", as
   await expect(
     page.getByRole("heading", { name: "Time worked" }),
   ).toBeVisible();
-  // 2h05 + 1h + 30m = 3h 35m across 14 tasks (10 + 3 + 1).
-  await expect(page.getByText("Your agents worked 3h 35m")).toBeVisible();
-  await expect(page.getByText("14 tasks")).toBeVisible();
+  // 2h05 + 1h + 30m + 5m = 3h 40m across 15 tasks (10 + 3 + 1 + 1); the
+  // awake-only ghost contributes nothing.
+  await expect(page.getByText("Your agents worked 3h 40m")).toBeVisible();
+  await expect(page.getByText("15 tasks")).toBeVisible();
 
   // 7 daily bars, each self-describing ("Jul 15: worked 2h 05m, 10 tasks").
   await expect(page.getByRole("img", { name: /: worked / })).toHaveCount(7);
@@ -113,6 +127,15 @@ test("with data the section shows the total, daily bars, and per-agent rows", as
     .filter({ hasText: "Sales bot" });
   await expect(sales).toContainText("30m");
   await expect(sales).toContainText("1 task");
+
+  // The deleted agent's bare wire id reads "Removed agent", never raw hex...
+  const removed = computeSection
+    .getByRole("listitem")
+    .filter({ hasText: "Removed agent" });
+  await expect(removed).toContainText("5m");
+  await expect(page.getByText("40e4d673e72e86df")).toHaveCount(0);
+  // ...and the awake-only ghost is not listed at all.
+  await expect(page.getByText("1dee000000000000")).toHaveCount(0);
 
   // The account half keeps its own section heading below the compute section.
   await expect(


### PR DESCRIPTION
## What

Daniel hit this testing desktop 0.5.14: the Usage page's by-agent list showed `5e70000000000000` (Online, 0m) and `40e4d673e72e86df` (0m) alongside the real Personal Assistant.

- `5e70000000000000` is the hidden per-org **Setup pod** (hosts provider sign-in; it woke on his Google login — hence "Online"). The gateway metered and served it like a real agent; it's now filtered server-side at the source (companion gateway fix, deployed separately).
- `40e4d673e72e86df` is a **deleted agent** whose history legitimately survives — but the app rendered its raw wire id.

## Client fix (defense in depth, works even against un-fixed gateways)

- The by-agent list drops agents with **zero work and zero tasks** in the selected range — awake-only rows carry `awakeMs` the UI never renders, so they'd read as pure noise ("0m · 0 tasks"). This alone removes both ghosts from the screenshot.
- A slug that resolves to no known agent and contains no words (bare 16-hex wire id) now labels **"Removed agent"** (en/es/pt) instead of raw hex — covering a deleted agent that DID work in the range.

## Tests

- Model: awake-only ghost dropped from `perAgent`; `isOpaqueSlug` matrix.
- E2E: the data spec seeds both ghost shapes and asserts the "Removed agent" label renders, raw hex never does, and the awake-only ghost is absent entirely.
- Gates: Biome, tsgo, check-locales, 1622 unit tests, 4/4 compute e2e, full workspace typecheck.


## Update: Online badge removed

Per Daniel: the per-agent "Online" badge is gone entirely — pod liveness (awake, not necessarily working) is infrastructure the user never needs to see. The awake set still silently drives the chart's live-today dot and the query's faster refresh; nothing user-facing names it anymore.