### PR TITLE
fix(onboarding): sign-in, idioma, provider connect y pulido del flujo

### DIFF
--- a/app/src-tauri/src/auth.rs
+++ b/app/src-tauri/src/auth.rs
@@ -237,6 +237,17 @@ pub fn emit_deep_link(handle: &AppHandle, url: &str) {
     }
 }
 
+/// True iff a real OS deep link is the OAuth-callback shape the identity layer
+/// consumes (`houston://auth-callback?...`) — the Apple bridge's return path.
+/// Everything else (`houston://open`, unknown paths) stays a focus affordance
+/// only, so an arbitrary link can never inject noise onto the auth channel.
+pub fn is_auth_callback_deep_link(url: &str) -> bool {
+    match url.strip_prefix("houston://auth-callback") {
+        Some(rest) => rest.is_empty() || rest.starts_with('?') || rest.starts_with('/'),
+        None => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,6 +259,22 @@ mod tests {
         assert!(validate_key("a\\b").is_err());
         assert!(validate_key("a\0b").is_err());
         assert!(validate_key("").is_err());
+    }
+
+    #[test]
+    fn auth_callback_deep_links_are_recognized() {
+        assert!(is_auth_callback_deep_link(
+            "houston://auth-callback?code=c&state=s"
+        ));
+        assert!(is_auth_callback_deep_link("houston://auth-callback"));
+        assert!(is_auth_callback_deep_link("houston://auth-callback/"));
+    }
+
+    #[test]
+    fn non_callback_deep_links_are_ignored() {
+        assert!(!is_auth_callback_deep_link("houston://open"));
+        assert!(!is_auth_callback_deep_link("houston://auth-callbackevil?x=1"));
+        assert!(!is_auth_callback_deep_link("https://gethouston.ai/auth-callback"));
     }
 
     #[test]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -240,19 +240,28 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_deep_link::init())
         .setup(move |app| {
-            // Deep-link handler. The only `houston://` URL Houston emits today
-            // is the sign-in success page's "Open Houston" button
-            // (`houston://open`) — purely a focus affordance. The old
-            // `houston://auth-callback` OAuth path is retired: desktop sign-in
-            // now runs entirely over the loopback listener, which forwards the
-            // callback via the `auth://deep-link` event, and OAuth providers
-            // reject custom-scheme redirect URIs anyway. So any deep link just
-            // brings Houston to the front.
+            // Deep-link handler. Two `houston://` URLs matter today:
+            //  - `houston://auth-callback?<query>` — the Apple sign-in return.
+            //    Apple rejects `127.0.0.1` redirects, so Apple's callback comes
+            //    back through the gateway's HTTPS bridge, which deep-links the
+            //    query here; forward it onto the SAME `auth://deep-link` event
+            //    the loopback listener uses (Google/Microsoft still run over
+            //    the loopback — those providers accept it and reject custom
+            //    schemes). CSRF `state` is enforced webview-side, so a forged
+            //    link can never complete a sign-in it didn't start.
+            //  - `houston://open` (the loopback success page's "Open Houston"
+            //    button) and anything else — purely a focus affordance.
             {
                 use tauri_plugin_deep_link::DeepLinkExt;
                 let handle = app.handle().clone();
-                app.deep_link()
-                    .on_open_url(move |_event| window_focus::bring_to_front(&handle));
+                app.deep_link().on_open_url(move |event| {
+                    for url in event.urls() {
+                        if auth::is_auth_callback_deep_link(url.as_str()) {
+                            auth::emit_deep_link(&handle, url.as_str());
+                        }
+                    }
+                    window_focus::bring_to_front(&handle);
+                });
             }
 
             // One-shot loopback listener state (cancel channel for the current

--- a/app/src/components/onboarding/missions/email-action-row.tsx
+++ b/app/src/components/onboarding/missions/email-action-row.tsx
@@ -19,7 +19,7 @@ interface EmailActionRowProps {
 
 /**
  * A one-click brand action row for the connect-email step. Reads as a real
- * button (filled `bg-chip` row + a recessed `bg-input` media tile +
+ * button (filled `bg-chip` row + the brand mark floating directly on it +
  * label + a trailing "go" chevron), rhyming with the AI step's provider rows.
  *
  * Three states:
@@ -48,11 +48,13 @@ export function EmailActionRow({
       aria-label={loading ? cancelLabel : undefined}
       onClick={onClick}
       className={cn(
-        "group/row flex w-full items-center gap-4 rounded-2xl bg-chip px-5 py-4 text-left transition-colors",
+        "group/row flex w-full items-center gap-4 rounded-2xl bg-chip px-6 py-6 text-left transition-colors",
         disabled ? "cursor-not-allowed opacity-50" : "hover:bg-hover",
       )}
     >
-      <span className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-input">
+      {/* The brand mark floats directly on the row — no recessed tile behind
+          it (the dark box read as a second surface inside the card). */}
+      <span className="flex size-11 shrink-0 items-center justify-center">
         {icon}
       </span>
       {loading ? (

--- a/app/src/components/onboarding/missions/email-offer-action.tsx
+++ b/app/src/components/onboarding/missions/email-offer-action.tsx
@@ -8,9 +8,12 @@ interface EmailOfferActionProps {
 }
 
 /**
- * The one deliberate action that starts the live email demonstration. It uses
- * a quiet focus-token halo so the CTA is discoverable without borrowing the
- * animated running glow, which is reserved for work already in progress.
+ * The one deliberate action that starts the live email demonstration — and,
+ * since the reply composer stays hidden until the mission starts, the ONLY
+ * action on the step. It sits directly on the card (no boxed sub-surface,
+ * which read as a detached widget) with a quiet focus-token halo so the CTA
+ * is discoverable without borrowing the animated running glow, which is
+ * reserved for work already in progress.
  */
 export function EmailOfferAction({
   description,
@@ -18,11 +21,8 @@ export function EmailOfferAction({
   onStart,
 }: EmailOfferActionProps) {
   return (
-    <div
-      className="rounded-xl border border-line/60 bg-input p-3"
-      data-onboarding-email-offer
-    >
-      <p className="mb-3 text-sm text-ink">{description}</p>
+    <div data-onboarding-email-offer>
+      <p className="mb-4 text-center text-sm text-ink-muted">{description}</p>
       <div className="relative">
         <span
           aria-hidden
@@ -33,7 +33,7 @@ export function EmailOfferAction({
           className="pointer-events-none absolute -inset-1 rounded-full ring-1 ring-focus/30"
         />
         <Button
-          className="relative h-11 w-full justify-between rounded-full px-4"
+          className="relative h-12 w-full justify-between rounded-full px-5"
           onClick={onStart}
           size="lg"
           type="button"

--- a/app/src/components/onboarding/missions/email.tsx
+++ b/app/src/components/onboarding/missions/email.tsx
@@ -144,6 +144,10 @@ export function EmailMission({
             queuedMessages={session.queuedMessages}
             onRemoveQueuedMessage={session.removeQueuedMessage}
             queuedLabels={queuedLabels}
+            // Until the mission starts, the offer is the ONLY action: the
+            // reply input stays hidden ("replace") so nothing competes with
+            // the one button that kicks off the real email.
+            composerOverrideMode="replace"
             composerOverride={
               session.started ? undefined : (
                 <EmailOfferAction

--- a/app/src/components/onboarding/option-card.tsx
+++ b/app/src/components/onboarding/option-card.tsx
@@ -15,6 +15,9 @@ interface OptionCardProps {
   trailing?: ReactNode;
   /** Extra content revealed inside the row (e.g. a sign-in hint when picked). */
   children?: ReactNode;
+  /** `lg` gives short lists (e.g. the language gate) taller rows + larger
+   *  labels so three options don't float in a mostly-empty card. */
+  size?: "md" | "lg";
 }
 
 /**
@@ -33,6 +36,7 @@ export function OptionCard({
   disabled,
   trailing,
   children,
+  size = "md",
 }: OptionCardProps) {
   // The right-side radio only carries selection when nothing on the left does
   // (the plain label rows). Leading-media rows carry it via their own visuals.
@@ -44,7 +48,8 @@ export function OptionCard({
       disabled={disabled}
       aria-pressed={selected}
       className={cn(
-        "flex w-full flex-col gap-3 rounded-lg border-l-2 py-3 pr-3 pl-3 text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-focus",
+        "flex w-full flex-col gap-3 rounded-lg border-l-2 text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-focus",
+        size === "lg" ? "px-4 py-5" : "py-3 pr-3 pl-3",
         disabled
           ? "cursor-not-allowed border-transparent opacity-50"
           : "border-transparent hover:bg-ink/[0.04]",
@@ -54,7 +59,14 @@ export function OptionCard({
       <div className="flex items-center gap-3">
         {leading && <span className="shrink-0">{leading}</span>}
         <div className="min-w-0 flex-1">
-          <p className="text-sm font-medium text-ink">{label}</p>
+          <p
+            className={cn(
+              "font-medium text-ink",
+              size === "lg" ? "text-base" : "text-sm",
+            )}
+          >
+            {label}
+          </p>
           {description && (
             <p className="mt-0.5 text-xs text-ink-muted">{description}</p>
           )}

--- a/app/src/components/shell/language-gate.tsx
+++ b/app/src/components/shell/language-gate.tsx
@@ -2,17 +2,21 @@ import { Loader2 } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import { useLocalePreference } from "../../hooks/use-locale-preference";
 import { analytics } from "../../lib/analytics";
-import { SUPPORTED_LOCALES, type SupportedLocale } from "../../lib/i18n";
+import {
+  normalizeLocale,
+  SUPPORTED_LOCALES,
+  type SupportedLocale,
+} from "../../lib/i18n";
 import { OptionCard, SetupCard } from "../onboarding/setup-card";
 import { SpaceScreen } from "../space/space-screen";
 
 /**
  * First-run language flow, styled like the rest of setup. A single beat: the
  * language picker, floated on the shared `SpaceScreen` space backdrop so it reads as
- * the same continuous space as sign-in and onboarding. Picking a language
- * applies + persists it and advances immediately — no separate Continue button
- * (the whole row is one large, keyboard-operable target, so a click is a
- * deliberate choice; language is changeable later from Settings).
+ * the same continuous space as sign-in and onboarding. The OS locale is
+ * detected and PRESELECTED, so the common case is one click on Continue (or on
+ * the already-marked row); picking any row applies + persists it and advances
+ * immediately. Language is changeable later from Settings.
  *
  * This is the TRUE first screen of the app. Shown before the disclaimer so a
  * Spanish/Portuguese speaker reads the agreement in their own language. Skipped
@@ -50,16 +54,48 @@ const DISPLAY_NAMES: Record<SupportedLocale, string> = {
   pt: "Português",
 };
 
+// No locale preference exists yet, so this screen deliberately does NOT go
+// through t() (see the i18n KB: the gate predates the choice). Instead the
+// few strings render in the OS-DETECTED language — the honest counterpart of
+// preselecting it — with English as the fallback.
+const COPY: Record<
+  SupportedLocale,
+  { title: string; continueLabel: string; error: string }
+> = {
+  en: {
+    title: "Choose your language",
+    continueLabel: "Continue",
+    error: "Something went wrong. Please try again.",
+  },
+  es: {
+    title: "Elige tu idioma",
+    continueLabel: "Continuar",
+    error: "Algo salió mal. Inténtalo de nuevo.",
+  },
+  pt: {
+    title: "Escolha seu idioma",
+    continueLabel: "Continuar",
+    error: "Algo deu errado. Tente novamente.",
+  },
+};
+
 function LanguagePicker({
   onPick,
 }: {
   onPick: (locale: SupportedLocale) => Promise<void>;
 }) {
+  // The OS-detected locale arrives preselected; the user either confirms it
+  // with Continue (or by clicking its row) or picks another row directly.
+  const [detected] = useState<SupportedLocale | null>(() =>
+    normalizeLocale(navigator.language),
+  );
+  const preselected = detected ?? "en";
   // Which row is mid-apply (its choice is being applied + persisted). Null once
   // idle. On success the gate swaps to the next screen, so this never resets to
   // idle on the happy path.
   const [pending, setPending] = useState<SupportedLocale | null>(null);
   const [failed, setFailed] = useState(false);
+  const copy = COPY[preselected];
 
   const handlePick = async (loc: SupportedLocale) => {
     if (pending) return;
@@ -69,12 +105,14 @@ function LanguagePicker({
       await onPick(loc);
       // Funnel step 5: language chosen (fires only after the choice is applied,
       // so a failed-then-retried pick isn't double counted).
-      analytics.track("onboarding_language_selected", { locale: loc });
+      analytics.track("onboarding_language_selected", {
+        locale: loc,
+        detected_locale: detected ?? "none",
+      });
     } catch {
       // Applying the language failed (a genuinely unexpected in-memory i18n
       // swap failure — the account write is best-effort and doesn't reject).
-      // Re-enable the rows so the user can retry. No localized copy is possible
-      // yet (no locale), so the retry hint stays language-agnostic.
+      // Re-enable the rows so the user can retry.
       setPending(null);
       setFailed(true);
     }
@@ -83,15 +121,19 @@ function LanguagePicker({
   return (
     <SetupCard
       onSpace
-      title="Choose your language"
+      title={copy.title}
       subtitle="English · Español · Português"
+      onNext={() => void handlePick(preselected)}
+      nextLabel={copy.continueLabel}
+      nextLoading={pending !== null}
     >
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-3">
         {SUPPORTED_LOCALES.map((loc) => (
           <OptionCard
             key={loc}
             label={DISPLAY_NAMES[loc]}
-            selected={false}
+            size="lg"
+            selected={loc === preselected}
             disabled={pending !== null && pending !== loc}
             trailing={
               pending === loc ? (
@@ -104,7 +146,7 @@ function LanguagePicker({
       </div>
       {failed && (
         <p className="mt-4 text-xs text-danger" role="alert">
-          Something went wrong. Please try again.
+          {copy.error}
         </p>
       )}
     </SetupCard>

--- a/app/src/hooks/use-onboarding-segment.ts
+++ b/app/src/hooks/use-onboarding-segment.ts
@@ -4,20 +4,62 @@ import {
   ONBOARDING_SEGMENT_PREF_KEY,
   type OnboardingSegmentChoice,
   type OnboardingSegmentPreference,
+  onboardingSegmentLocalKey,
   parseOnboardingSegmentPreference,
 } from "../lib/onboarding-segment";
 import { tauriPreferences } from "../lib/tauri";
+import { useSession } from "./use-session";
 
 const queryKey = ["onboarding-segment"] as const;
 
+// Device-local mirror of the answered segment (per signed-in uid). The engine
+// preference lives on the user's pod in hosted mode, so a pod blip or a failed
+// write used to re-prompt the question on every launch — the mirror guarantees
+// the screen shows AT MOST ONCE per user per device even when the engine pref
+// is unreachable. localStorage failures are non-fatal (behaves as before).
+function readLocalMirror(
+  uid: string | null,
+): OnboardingSegmentPreference | null {
+  try {
+    return parseOnboardingSegmentPreference(
+      localStorage.getItem(onboardingSegmentLocalKey(uid)),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function writeLocalMirror(uid: string | null, serialized: string): void {
+  try {
+    localStorage.setItem(onboardingSegmentLocalKey(uid), serialized);
+  } catch {
+    /* quota / disabled storage — the engine pref still carries the answer */
+  }
+}
+
 export function useOnboardingSegment(enabled: boolean) {
   const qc = useQueryClient();
+  const { data: session } = useSession();
+  const uid = session?.uid ?? null;
+
   const query = useQuery({
-    queryKey,
+    queryKey: [...queryKey, uid],
     enabled,
     queryFn: async (): Promise<OnboardingSegmentPreference | null> => {
-      const raw = await tauriPreferences.get(ONBOARDING_SEGMENT_PREF_KEY);
-      return parseOnboardingSegmentPreference(raw);
+      let fromEngine: OnboardingSegmentPreference | null = null;
+      let raw: string | null = null;
+      try {
+        raw = await tauriPreferences.get(ONBOARDING_SEGMENT_PREF_KEY);
+        fromEngine = parseOnboardingSegmentPreference(raw);
+      } catch {
+        // Engine unreachable (hosted pod waking / provisioning) — fall through
+        // to the local mirror rather than re-prompting an answered question.
+      }
+      if (fromEngine) {
+        if (raw) writeLocalMirror(uid, raw); // refresh the mirror
+        return fromEngine;
+      }
+      return readLocalMirror(uid);
     },
     staleTime: 30_000,
   });
@@ -25,23 +67,41 @@ export function useOnboardingSegment(enabled: boolean) {
   const mutation = useMutation({
     mutationFn: async (segment: OnboardingSegmentChoice) => {
       const record = createOnboardingSegmentPreference(segment);
-      await tauriPreferences.set(
-        ONBOARDING_SEGMENT_PREF_KEY,
-        JSON.stringify(record),
-      );
+      const serialized = JSON.stringify(record);
+      // The local mirror is written FIRST: once the user answered, the screen
+      // must never re-prompt on this device even if the engine write fails.
+      writeLocalMirror(uid, serialized);
+      try {
+        await tauriPreferences.set(ONBOARDING_SEGMENT_PREF_KEY, serialized);
+      } catch (e) {
+        // Best-effort: the answer is kept locally; the engine pref catches up
+        // on a later save or stays device-local. Logged, never blocks the flow.
+        console.error("[onboarding-segment] engine pref write failed", e);
+      }
       return record;
     },
     onSuccess: (record) => {
-      qc.setQueryData<OnboardingSegmentPreference | null>(queryKey, record);
+      qc.setQueryData<OnboardingSegmentPreference | null>(
+        [...queryKey, uid],
+        record,
+      );
     },
   });
 
   const clearMutation = useMutation({
     mutationFn: async () => {
+      try {
+        localStorage.removeItem(onboardingSegmentLocalKey(uid));
+      } catch {
+        /* disabled storage */
+      }
       await tauriPreferences.set(ONBOARDING_SEGMENT_PREF_KEY, null);
     },
     onSuccess: () => {
-      qc.setQueryData<OnboardingSegmentPreference | null>(queryKey, null);
+      qc.setQueryData<OnboardingSegmentPreference | null>(
+        [...queryKey, uid],
+        null,
+      );
     },
   });
 

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -126,6 +126,7 @@ type AnalyticsProperty =
   | "to_version"
   // Onboarding funnel
   | "locale"
+  | "detected_locale"
   | "step"
   // Cloud migration (payload sizes, where already known)
   | "bytes"

--- a/app/src/lib/auth-gateway.ts
+++ b/app/src/lib/auth-gateway.ts
@@ -7,7 +7,9 @@
 // that file stays a thin sign-in dispatcher.
 
 import { resolveEngine } from "./engine-mode";
-import { IdentityError } from "./identity";
+// Imported from the concrete module (not the ./identity barrel): the barrel
+// pulls in apple-authorize, which imports THIS module for the bridge URL.
+import { IdentityError } from "./identity/errors.ts";
 
 export function gatewayUrl(): string {
   const env = import.meta.env as unknown as Parameters<typeof resolveEngine>[0];

--- a/app/src/lib/identity/apple-authorize.ts
+++ b/app/src/lib/identity/apple-authorize.ts
@@ -1,27 +1,45 @@
-// Desktop Apple sign-in: the GCIP-BROKERED loopback flow.
+// Desktop Apple sign-in: GCIP authorize → gateway HTTPS bridge → `houston://`
+// deep link.
 //
-// Apple rejects `127.0.0.1` redirect URIs on direct OAuth, so the desktop can't
-// run the Google/Microsoft loopback+PKCE shape against Apple itself. Instead
-// GCIP is the broker: `createAuthUri` mints an Apple authorize URL whose
-// redirect is GCIP's OWN handler (`https://<authDomain>/__/auth/handler`, the
-// Services-ID-registered return URL that also serves the web popup), and the
-// handler bounces the browser back to our loopback `continueUri` with the
-// callback params. `signInWithIdpSession` then redeems the pair — the Apple
-// client secret lives only in the identity project's provider config, never on
-// the client.
+// Apple rejects `http://127.0.0.1` redirect URIs outright (HTTP 403 at the
+// authorize endpoint), and GCIP's `createAuthUri` passes the `continueUri` to
+// the provider VERBATIM as `redirect_uri` — it does NOT broker through its own
+// `/__/auth/handler`. So the desktop can never receive Apple's callback on the
+// loopback listener. Instead the `continueUri` is the cloud gateway's Apple
+// return bridge — the pinned contract the gateway implements:
 //
-// CSRF: GCIP embeds a `state` in the authorize URL it mints; we extract it and
-// enforce it on the callback exactly like the PKCE flows (stale/foreign
-// callbacks are ignored, the attempt keeps waiting).
+//   POST {gateway}/v1/auth/apple/return
+//     body: Apple's form_post params (`code`, `state`, and on first consent
+//           `user`) — GCIP always forces `response_mode=form_post` for
+//           apple.com, so the bridge's job is converting that POST into a GET
+//           the app can receive.
+//     response: navigate the browser to
+//           `houston://auth-callback?<the same params re-encoded as a query>`
+//           (a redirect or an interstitial page with a visible "Open Houston"
+//           fallback link — some browsers block cross-scheme redirects on POST
+//           responses). Stateless; the bridge never sees a secret.
+//
+// The OS routes `houston://auth-callback` to the app (deep-link plugin;
+// single-instance forwards secondary argv on Windows/Linux), the Rust shell
+// re-emits it on the same `auth://deep-link` channel the loopback flows use
+// (`app/src-tauri/src/lib.rs`), and the attempt lifecycle + CSRF handling are
+// IDENTICAL to PKCE: the `state` GCIP embedded in the authorize URL it minted
+// is enforced on the callback; stale/foreign callbacks are ignored.
+// `signInWithIdpSession` then redeems (`requestUri` = bridge URL + `?` +
+// callback query, `sessionId`) — the Apple client secret lives only in the
+// identity project's provider config, never on the client.
 //
 // Setup (human, one-time): the Apple provider enabled on the identity project
-// (Services ID + team ID + key), and `127.0.0.1` added to the project's
-// authorized domains so the loopback `continueUri` is accepted.
+// (Services ID + team ID + key), the bridge URL registered as a return URL on
+// the Services ID, and the gateway domain added to the project's authorized
+// domains so `createAuthUri` accepts the `continueUri`.
 
+import { gatewayUrl } from "../auth-gateway";
+import { appleReturnUrl } from "./apple-return.ts";
 import { identityConfig } from "./config.ts";
 import {
   type LoopbackAuthorizeOptions,
-  runBrokeredLoopbackAuthorize,
+  runBrokeredDeepLinkAuthorize,
 } from "./desktop-oauth.ts";
 import { IdentityError } from "./errors.ts";
 import { createAuthUri } from "./firebase-rest.ts";
@@ -30,7 +48,7 @@ import { createAuthUri } from "./firebase-rest.ts";
 const APPLE_SCOPES = "name email";
 
 export interface AppleAuthorizeResult {
-  /** The full loopback callback URL (continueUri + query) for `requestUri`. */
+  /** The full bridge callback URL (bridge URL + query) for `requestUri`. */
   requestUri: string;
   /** The `createAuthUri` session that pairs with the callback. */
   sessionId: string;
@@ -44,12 +62,13 @@ export interface AppleAuthorizeResult {
 export async function authorizeAppleDesktop(
   opts?: LoopbackAuthorizeOptions,
 ): Promise<AppleAuthorizeResult | null> {
+  const bridgeUrl = appleReturnUrl(gatewayUrl());
   let sessionId = "";
-  const result = await runBrokeredLoopbackAuthorize(async (redirectUri) => {
+  const result = await runBrokeredDeepLinkAuthorize(async () => {
     const minted = await createAuthUri({
       apiKey: identityConfig.apiKey,
       providerId: "apple.com",
-      continueUri: redirectUri,
+      continueUri: bridgeUrl,
       oauthScope: APPLE_SCOPES,
     });
     sessionId = minted.sessionId;
@@ -65,7 +84,7 @@ export async function authorizeAppleDesktop(
   }, opts);
   if (!result) return null; // benign cancel
   return {
-    requestUri: `${result.redirectUri}?${result.callbackQuery}`,
+    requestUri: `${bridgeUrl}?${result.callbackQuery}`,
     sessionId,
   };
 }

--- a/app/src/lib/identity/apple-return.ts
+++ b/app/src/lib/identity/apple-return.ts
@@ -1,0 +1,10 @@
+// The gateway's Apple return-bridge URL (pure + Tauri-free so the unit runner
+// can import it). The full bridge contract is pinned in `apple-authorize.ts`.
+
+/** Gateway bridge path Apple's `form_post` lands on (contract of record). */
+export const APPLE_RETURN_PATH = "/v1/auth/apple/return";
+
+/** The HTTPS bridge URL used as the `createAuthUri` `continueUri`. */
+export function appleReturnUrl(gatewayBaseUrl: string): string {
+  return `${gatewayBaseUrl.replace(/\/+$/, "")}${APPLE_RETURN_PATH}`;
+}

--- a/app/src/lib/identity/desktop-oauth.ts
+++ b/app/src/lib/identity/desktop-oauth.ts
@@ -126,62 +126,31 @@ export async function runLoopbackAuthorize(
   return { code, redirectUri, codeVerifier };
 }
 
-/** A GCIP-brokered authorize round-trip's redemption inputs. */
+/** A GCIP-brokered authorize round-trip's redemption input. */
 export interface BrokeredAuthorizeResult {
-  /** The full callback query GCIP's handler redirected with (no leading `?`). */
+  /** The full callback query the bridge deep-linked back (no leading `?`). */
   callbackQuery: string;
-  /** The loopback redirect URI the callback landed on (the `continueUri`). */
-  redirectUri: string;
 }
 
 /**
- * Run one GCIP-BROKERED loopback authorize round-trip (Apple). Unlike
- * {@link runLoopbackAuthorize}, the authorize URL is minted by GCIP
- * (`createAuthUri`) AFTER the loopback is bound — GCIP's handler is the
- * provider-registered redirect and it bounces back to our loopback
- * `continueUri` — and the redemption input is the WHOLE callback query (fed to
+ * Run one GCIP-BROKERED authorize round-trip (Apple). Unlike
+ * {@link runLoopbackAuthorize} there is NO loopback listener: Apple rejects
+ * `127.0.0.1` redirects, so the authorize URL minted by GCIP (`createAuthUri`)
+ * redirects to the gateway's HTTPS bridge, which navigates the browser to a
+ * real `houston://auth-callback?<query>` deep link the OS routes to the app —
+ * the Rust shell re-emits it on the same `auth://deep-link` channel the
+ * loopback flows use (see `apple-authorize.ts` for the pinned bridge
+ * contract). The redemption input is the WHOLE callback query (fed to
  * `signInWithIdp` as the `requestUri`), not a PKCE code. CSRF: the `state`
  * GCIP embedded in its authorize URL is extracted by the caller and enforced
  * on the callback exactly like the PKCE flows. Resolves `null` on a benign
  * cancel (superseded / unmount / timeout).
  */
-export async function runBrokeredLoopbackAuthorize(
-  mintAuthorizeUrl: (
-    redirectUri: string,
-  ) => Promise<{ url: string; expectedState: string }>,
+export async function runBrokeredDeepLinkAuthorize(
+  mintAuthorizeUrl: () => Promise<{ url: string; expectedState: string }>,
   opts?: LoopbackAuthorizeOptions,
 ): Promise<BrokeredAuthorizeResult | null> {
-  let redirectUri: string;
-  try {
-    redirectUri = await osStartOauthLoopback();
-  } catch (e) {
-    // Same no-custom-scheme-fallback rationale as runLoopbackAuthorize.
-    throw new IdentityError("unknown", {
-      rawCode: "loopback_bind_failed",
-      cause: e,
-    });
-  }
-
-  const freeLoopback = () => {
-    void osCancelOauthLoopback().catch((e) =>
-      identityLog(
-        "warn",
-        `failed to free loopback port: ${String(e)}`,
-        "identity/desktop-oauth",
-      ),
-    );
-  };
-
-  let minted: { url: string; expectedState: string };
-  try {
-    minted = await mintAuthorizeUrl(redirectUri);
-  } catch (e) {
-    // The GCIP mint failed before any browser opened — free the port now
-    // rather than letting it idle until Rust's 300s self-timeout.
-    freeLoopback();
-    throw e;
-  }
-
+  const minted = await mintAuthorizeUrl();
   const callbackQuery = await awaitLoopbackCallback({
     expectedState: minted.expectedState,
     authorizeUrl: minted.url,
@@ -189,10 +158,10 @@ export async function runBrokeredLoopbackAuthorize(
     openUrl: tauriSystem.openUrl,
     onBrowserOpened: opts?.onBrowserOpened,
     parsePayload: parseCallbackQuery,
-    abandonLoopback: freeLoopback,
+    // No loopback port to free — the callback arrives as an OS deep link.
   });
   if (callbackQuery === null) return null; // benign cancel — no error, no session
-  return { callbackQuery, redirectUri };
+  return { callbackQuery };
 }
 
 /**

--- a/app/src/lib/onboarding-segment.ts
+++ b/app/src/lib/onboarding-segment.ts
@@ -82,3 +82,14 @@ export function createOnboardingSegmentPreference(
     sourceScreen: ONBOARDING_SEGMENT_SOURCE_SCREEN,
   };
 }
+
+/**
+ * Per-user localStorage key for the device-local mirror of the answer. The
+ * engine preference is the source of truth, but in hosted mode it lives on the
+ * user's pod — a pod blip (or a failed write) made the question re-prompt on
+ * the next launch. The mirror is keyed by the signed-in uid so switching
+ * accounts on one machine still asks each user exactly once.
+ */
+export function onboardingSegmentLocalKey(uid: string | null): string {
+  return `houston.onboarding-segment.${uid ?? "local"}`;
+}

--- a/app/tests/identity-desktop-oauth.test.ts
+++ b/app/tests/identity-desktop-oauth.test.ts
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
+import {
+  APPLE_RETURN_PATH,
+  appleReturnUrl,
+} from "../src/lib/identity/apple-return.ts";
 import { IdentityError } from "../src/lib/identity/errors.ts";
 import {
   awaitLoopbackCallback,
@@ -328,6 +332,18 @@ test("parseCallbackQuery returns the WHOLE query when state matches (brokered fl
     "st-1",
   );
   assert.equal(query, "state=st-1&code=c&providerId=apple.com");
+});
+
+test("appleReturnUrl joins the gateway base and the pinned bridge path", () => {
+  assert.equal(
+    appleReturnUrl("https://engine.gethouston.ai"),
+    `https://engine.gethouston.ai${APPLE_RETURN_PATH}`,
+  );
+  // Trailing slashes on the gateway base never double up.
+  assert.equal(
+    appleReturnUrl("https://engine.gethouston.ai//"),
+    `https://engine.gethouston.ai${APPLE_RETURN_PATH}`,
+  );
 });
 
 test("parseCallbackQuery enforces CSRF state and provider errors like parseCallbackUrl", () => {

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,15 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v28 - 2026-07-16
+
+`composer` gains a `replaced-by-override` state: the existing override card
+(previously always rendered ABOVE the input, both visible) can now REPLACE the
+input while present (`composerOverrideMode="replace"` on ChatPanel). Used by
+onboarding's watch-your-agent step, where the "send an email to myself" offer
+is the only intended action and a live reply input competed with it. Default
+behavior is unchanged ("above": typing abandons the pending card).
+
 ## v27 - 2026-07-16
 
 `interaction-approval-card` sheds its technical body. The two-column param

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 27
+version: 28
 
 components:
   - id: agent-avatar
@@ -183,11 +183,14 @@ components:
     title: Composer
     purpose: The signature message-input surface -- text, attachments, send/stop.
     anatomy: [leading-attach, textarea, footer-slot, queued-list, trailing-send-stop]
-    states: [ready, submitted, streaming, has-attachments, drag-over, disabled]
+    states: [ready, submitted, streaming, has-attachments, drag-over, disabled, replaced-by-override]
     variants: [single-line, multiline-expanded]
     behavior: >-
       Send is gated on non-empty text/attachments; while streaming the trailing
-      button becomes Stop. Queued messages show when sending mid-turn.
+      button becomes Stop. Queued messages show when sending mid-turn. A host
+      surface may pass an override card that renders above the input (default)
+      or replaces it outright while present (replaced-by-override) when that
+      card is the only intended action, e.g. onboarding's one-button offer.
     a11y: labeled textarea; send/stop button state-labeled; drop zone announced.
     since: 1
 

--- a/knowledge-base/auth-migration.md
+++ b/knowledge-base/auth-migration.md
@@ -82,6 +82,13 @@ now lives in git).
   client (PKCE) with the `127.0.0.1` loopback ports as authorized redirect URIs; and an
   Azure app registration for the `microsoft.com` provider whose redirect includes those
   loopback ports (public PKCE client, no secret).
+  **CONFIRMED LIVE (2026-07-16):** the Azure app (`78465f4b-…`) has the GCIP handler
+  registered but NOT the desktop loopback URIs — personal (MSA) accounts fail after the
+  account picker with "We're unable to complete your request / invalid_request:
+  redirect_uri is not valid" on `login.live.com`. Fix: Azure Portal → the app →
+  Authentication → **Mobile and desktop applications** → add all four exact URIs
+  `http://127.0.0.1:8975/auth/callback` … `:8978` (login.live.com matches exactly;
+  it does not do Entra's port-agnostic loopback matching).
 - **[HIGH — coord] Gateway verifier.** The issuer/JWKS swap to Firebase is a `cloud`
   Go change + `cloud/INTEGRATION.md`; the gateway must accept Firebase tokens before or
   with the client cutover. The email-OTP `POST /v1/auth/email-otp/{start,verify}`
@@ -90,17 +97,22 @@ now lives in git).
   retired Supabase `profiles` table) and an account-level migration flag (restores the
   coarse cross-machine "never offer again").
 - **[SHIPPED client-side] Apple SSO** — the client now offers "Continue with
-  Apple" on ALL surfaces: web (popup), desktop (GCIP-brokered loopback; Apple
-  rejects `127.0.0.1` redirects, so `createAuthUri`/`signInWithIdp(sessionId)`
-  broker through GCIP's handler), and **native on iOS**
+  Apple" on ALL surfaces: web (popup), desktop, and **native on iOS**
   (`SignInWithAppleButton` + nonce → `signInWithIdp(apple.com)`, guideline 4.8
   makes it mandatory next to Google — see `knowledge-base/auth.md`). The
   `apple.com` IdP enablement is terraform in `cloud/infra/terraform/identity.tf`
   (client id = the iOS bundle id for the native flow; swap in the Services ID +
-  key-derived secret when wiring the web/desktop flows). Human config still
-  owed: Apple Developer Services ID + key (web/desktop only), the Sign in with
-  Apple capability on App ID `com.gethouston.Houston`, and `127.0.0.1` in
-  authorized domains (desktop broker).
+  key-derived secret when wiring the web/desktop flows).
+  **REWORKED (2026-07-16):** the original desktop design ("GCIP-brokered
+  loopback") never worked — `createAuthUri` passes the `continueUri` verbatim
+  as Apple's `redirect_uri` (it does NOT broker through the handler), and Apple
+  403s any `127.0.0.1` redirect. Desktop now returns through a gateway HTTPS
+  bridge → `houston://auth-callback` deep link (contract pinned in
+  `identity/apple-authorize.ts`). Still owed: **[HIGH — cloud] the gateway
+  `POST /v1/auth/apple/return` bridge endpoint**, the bridge URL added as a
+  Services ID return URL (Apple Developer), the gateway domain in GCIP
+  authorized domains, the Sign in with Apple capability on App ID
+  `com.gethouston.Houston`.
 - **[HIGH — human] iOS registrations** — the iOS app moved to GCIP too
   (`mobile/ios/Houston/Core/Auth/`, same REST approach as desktop; see
   `knowledge-base/auth.md` "iOS (native app)"). Outstanding human steps:

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -97,24 +97,32 @@ matching state, unreadable payload, missing code) or a failure to open the brows
 fallback** — Google/Microsoft reject custom-scheme redirects on direct OAuth, so a
 loopback-bind failure surfaces a typed error for the generic retry UI.
 
-### Apple — web (popup) + desktop (GCIP-BROKERED loopback)
+### Apple — web (popup) + desktop (gateway bridge + `houston://` deep link)
 
-Apple **rejects `127.0.0.1` redirect URIs on direct OAuth**, so the desktop
-can't run the Google/Microsoft loopback+PKCE shape against Apple itself.
-Instead GCIP is the broker (`identity/apple-authorize.ts`):
+Apple **rejects `127.0.0.1` redirect URIs on direct OAuth** (HTTP 403 at the
+authorize endpoint), so the desktop can't run the Google/Microsoft
+loopback+PKCE shape against Apple. And GCIP's `createAuthUri` passes the
+`continueUri` to the provider **verbatim** as `redirect_uri` — it does NOT
+broker through its `/__/auth/handler` (an earlier version of this doc claimed
+it did; that was wrong and shipped a desktop Apple button that always 403'd).
+The desktop flow instead returns through the cloud gateway's HTTPS bridge
+(`identity/apple-authorize.ts`, the pinned contract of record):
 
 ```
-1. bind the loopback (osStartOauthLoopback → 127.0.0.1:<8975-8978>/auth/callback)
-2. GCIP REST accounts:createAuthUri({ providerId: "apple.com",
-   continueUri: <loopback>, oauthScope: "name email" }) → { authUri, sessionId }
-   (the authorize URL's redirect is GCIP's OWN handler,
-    https://gethouston.firebaseapp.com/__/auth/handler — the Services-ID
-    return URL that also serves the web popup)
-3. open authUri in the system browser → Apple consent → GCIP handler →
-   302 back to the loopback continueUri with the callback params
+1. GCIP REST accounts:createAuthUri({ providerId: "apple.com",
+   continueUri: {gateway}/v1/auth/apple/return, oauthScope: "name email" })
+   → { authUri, sessionId }   (redirect_uri = the bridge URL, which is a
+     registered Services-ID return URL; GCIP forces response_mode=form_post)
+2. open authUri in the system browser → Apple consent →
+   form_post to the gateway bridge
+3. the bridge navigates the browser to houston://auth-callback?<the same
+   params as a query> (stateless POST→GET conversion; no secrets) → the OS
+   routes the deep link to the app; the Rust shell forwards it onto the same
+   `auth://deep-link` event the loopback flows use (lib.rs →
+   auth::is_auth_callback_deep_link)
 4. CSRF: the `state` GCIP embedded in authUri is enforced on the callback
    (parseCallbackQuery), stale/foreign callbacks are ignored, exactly like PKCE
-5. accounts:signInWithIdp({ requestUri: <full callback URL>, sessionId })
+5. accounts:signInWithIdp({ requestUri: <bridge URL>?<query>, sessionId })
    → Firebase session (the Apple client secret lives ONLY in the identity
    project's provider config, never on the client)
 ```
@@ -122,18 +130,20 @@ Instead GCIP is the broker (`identity/apple-authorize.ts`):
 Web uses the ordinary popup: `signInWithPopup(new OAuthProvider("apple.com"))`
 with `email` + `name` scopes (`packages/web/src/identity/firebase-popup.ts`).
 Apple returns the user's name/email only on the FIRST consent per Services ID.
-No new baked env vars — everything rides the existing `FIREBASE_*` config.
+No new baked env vars — the bridge URL derives from the gateway URL the client
+already has (`auth-gateway.ts` `gatewayUrl()`).
 
 **One-time human setup:** enable the Apple provider on the identity project
-(Apple Developer: App ID + **Services ID** whose return URL is the GCIP
-handler, team ID, key ID + private key → GCIP console / terraform), and add
-`127.0.0.1` to the project's **authorized domains** so the desktop loopback
-`continueUri` is accepted by `createAuthUri`.
+(Apple Developer: App ID + **Services ID** whose return URLs are the GCIP
+handler (web popup) AND the gateway bridge (desktop), team ID, key ID +
+private key → GCIP console / terraform), add the gateway domain to the
+project's **authorized domains** so `createAuthUri` accepts the bridge
+`continueUri`, and ship the gateway bridge endpoint
+(`POST /v1/auth/apple/return` — contract pinned in `apple-authorize.ts`).
 
-That one-time setup is done, and the button renders UNCONDITIONALLY, exactly
-like Google and Microsoft — no flag (the old Apple sign-in enable gate was
-deleted per the "Features default ON — no dark switches" rule; it kept the
-shipped button invisible for months).
+The button renders UNCONDITIONALLY, exactly like Google and Microsoft — no
+flag (the old Apple sign-in enable gate was deleted per the "Features default
+ON — no dark switches" rule; it kept the shipped button invisible for months).
 
 ### Google / Microsoft — web (firebase-js-sdk popup)
 
@@ -417,9 +427,11 @@ the full checklist and open human tasks. In brief:
    non-confidential installed-app secret (baked via env, never a literal).
 3. **Microsoft** — an Azure app registration (`microsoft.com` GCIP provider) whose
    redirect includes the desktop loopback ports; public PKCE client, no secret.
-4. **Apple** — Apple Developer App ID + Services ID (return URL = the GCIP
-   handler) + key; enable the `apple.com` provider in GCIP; add `127.0.0.1`
-   to authorized domains (desktop brokered loopback).
+4. **Apple** — Apple Developer App ID + Services ID (return URLs = the GCIP
+   handler for the web popup AND the gateway bridge for desktop) + key; enable
+   the `apple.com` provider in GCIP; add the gateway domain to authorized
+   domains; ship the gateway `POST /v1/auth/apple/return` bridge (contract in
+   `identity/apple-authorize.ts`).
 5. **Email OTP** — the `POST /v1/auth/email-otp/{start,verify}` endpoints are a
    `cloud/` gateway build (contract pinned in `identity/otp.ts`).
 6. **Gateway verifier** — issuer/JWKS swap to Firebase is a `cloud` Go change; the

--- a/packages/web/e2e/onboarding-language.spec.ts
+++ b/packages/web/e2e/onboarding-language.spec.ts
@@ -13,10 +13,12 @@ import { expect, test } from "./support/fixtures";
  *
  *   1. the picker floats on the shared SpaceScreen space backdrop (same as
  *      sign-in and the rest of onboarding — the landing page's Milky Way
- *      photograph painted behind the card), and
- *   2. picking a language ADVANCES IMMEDIATELY — there is no Continue button, so
- *      a single click both persists the choice and moves past the gate. This is
- *      the regression guard for the dead-end where clicking a language did
+ *      photograph painted behind the card),
+ *   2. the OS-detected locale arrives PRESELECTED with a Continue button to
+ *      confirm it (the common case is one click), and
+ *   3. clicking any language row ADVANCES IMMEDIATELY — a single click both
+ *      persists the choice and moves past the gate, no Continue required. This
+ *      is the regression guard for the dead-end where clicking a language did
  *      nothing because the (best-effort) preference write was awaited-then-
  *      swallowed before the flow could advance.
  */
@@ -27,7 +29,7 @@ const ACCEPTED_DISCLAIMER = JSON.stringify({
   acceptedAt: "2024-01-01T00:00:00.000Z",
 });
 
-test("first-run language gate: space backdrop, and a single click advances (no Continue)", async ({
+test("first-run language gate: space backdrop, preselected Continue, and a single row click advances", async ({
   page,
 }) => {
   // Seed the engine + the later gates, but NOT the locale, so the LanguageGate
@@ -73,12 +75,14 @@ test("first-run language gate: space backdrop, and a single click advances (no C
   // The shared space backdrop paints behind the card (the Milky Way photo).
   expect(await page.locator('img[src*="milkyway"]').count()).toBeGreaterThan(0);
 
-  // No Continue button — the row itself is the action.
+  // The OS-detected locale (en in CI) arrives preselected, with a Continue
+  // button to confirm it in one click.
   await expect(
     page.getByRole("button", { name: /Continue|Continuar/ }),
-  ).toHaveCount(0);
+  ).toBeVisible();
 
-  // A single click on a language advances past the gate.
+  // But the rows are still actions themselves: a single click on a language
+  // advances past the gate without touching Continue.
   await page.getByText("Español", { exact: true }).click();
   await expect(
     page.getByRole("heading", { name: "Choose your language" }),

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -18,6 +18,7 @@
  */
 export type { HoustonClientOptions } from "./client/context";
 export { HoustonEngineError, isHoustonEngineError } from "./client/errors";
+export { isProviderLoginComplete } from "./client/provider-login-poll";
 
 import { ActivitiesMixin } from "./client/activities-mixin";
 import { AgentFilesMixin } from "./client/agent-files-mixin";

--- a/packages/web/src/engine-adapter/client/provider-login-poll.ts
+++ b/packages/web/src/engine-adapter/client/provider-login-poll.ts
@@ -31,6 +31,23 @@ export function benignCancelMiss(e: unknown): void {
 }
 
 /**
+ * True iff this provider's login is genuinely DONE — not merely `configured`.
+ * A stale stored credential leaves `configured: true` while the just-launched
+ * OAuth is still `awaiting_user`, and treating that as success completed the
+ * login dialog (and onboarding's "your AI is connected" beat) the instant the
+ * poll first ticked, without the user ever finishing in the browser. A login
+ * counts as complete only when the runtime reports no in-flight login (null)
+ * or its login reached `complete`.
+ */
+export function isProviderLoginComplete(pr: {
+  configured: boolean;
+  login: { status: string } | null;
+}): boolean {
+  if (!pr.configured) return false;
+  return pr.login === null || pr.login.status === "complete";
+}
+
+/**
  * Poll auth status until the in-flight login for `pid` resolves, then emit
  * `ProviderLoginComplete` so the legacy dialog closes and the card flips.
  * Covers all three flows: loopback auto-catch, pasted headless code, and
@@ -52,7 +69,7 @@ export function watchLoginCompletion(
       try {
         const status = await ctx.engine.authStatus();
         const pr = status.providers.find((p) => p.provider === pid);
-        if (pr?.configured) finish(true, null);
+        if (pr && isProviderLoginComplete(pr)) finish(true, null);
         else if (pr?.login?.status === "error")
           finish(false, pr?.login?.error ?? "Login failed");
         else if (Date.now() - startedAt > 10 * 60 * 1000)
@@ -102,15 +119,28 @@ export async function pollProviderConnect(
     while (Date.now() < deadline) {
       await new Promise((r) => setTimeout(r, 4000));
       if (!ctx.activeLogins.has(key)) return; // cancelled
-      let configured = false;
+      let completed = false;
       try {
         const s = await engine.authStatus();
-        configured =
-          s.providers.find((p) => p.provider === pid)?.configured ?? false;
+        const pr = s.providers.find((p) => p.provider === pid);
+        if (pr?.login?.status === "error") {
+          // The runtime's login flow died (denied consent, provider outage).
+          // Surface it now — waiting out the 5-minute timeout hid the reason.
+          emitEvent("ProviderLoginComplete", {
+            provider: oldProvider,
+            success: false,
+            error: pr.login.error ?? "Login failed",
+          });
+          return;
+        }
+        // NOT bare `configured`: a stale stored credential reports configured
+        // while the just-launched OAuth is still awaiting the user, and that
+        // false success completed onboarding with an AI that never connected.
+        completed = pr ? isProviderLoginComplete(pr) : false;
       } catch {
         /* transient — keep polling */
       }
-      if (configured) {
+      if (completed) {
         // CLAIM (don't set) the active provider: it becomes active only for
         // a first connect on a fresh agent — a connect never moves an agent
         // that already has a provider, so no open chat switches (HOU-695).
@@ -131,6 +161,23 @@ export async function pollProviderConnect(
             await captureSetupCredential(cp, pid);
           }
         } catch (e) {
+          if (!agentId) {
+            // Pre-agent (first-run) the captured credential is the ONLY thing
+            // the agent created next inherits — reporting success here let
+            // onboarding celebrate "your AI is connected" and then fail the
+            // send-email step with "no AI provider". Surface the failure.
+            emitEvent("ProviderLoginComplete", {
+              provider: oldProvider,
+              success: false,
+              error:
+                e instanceof Error
+                  ? e.message
+                  : "Saving the connected AI failed",
+            });
+            return;
+          }
+          // With an agent, the credential already lives in ITS runtime — the
+          // connect works for this agent; only workspace-wide sharing failed.
           console.error("[connect] workspace credential capture failed", e);
         }
         emitEvent("ProviderLoginComplete", {

--- a/packages/web/tests/provider-login-completion.test.ts
+++ b/packages/web/tests/provider-login-completion.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "vitest";
+import { isProviderLoginComplete } from "../src/engine-adapter/client";
+
+test("does not treat a stale stored credential as a completed OAuth login", () => {
+  expect(
+    isProviderLoginComplete({
+      configured: true,
+      login: { status: "awaiting_user" },
+    }),
+  ).toBe(false);
+});
+
+test("captures a credential only after OAuth completes", () => {
+  expect(
+    isProviderLoginComplete({
+      configured: true,
+      login: { status: "complete" },
+    }),
+  ).toBe(true);
+  expect(isProviderLoginComplete({ configured: true, login: null })).toBe(true);
+});

--- a/ui/chat/src/chat-panel-types.ts
+++ b/ui/chat/src/chat-panel-types.ts
@@ -92,6 +92,11 @@ export interface ChatPanelProps {
   onOpenLink?: (url: string) => void;
   renderLink?: ChatMessagesProps["renderLink"];
   composerOverride?: ReactNode;
+  /** How `composerOverride` composes with the input. `"above"` (default) keeps
+   *  the input usable below the card so typing abandons the pending
+   *  interaction; `"replace"` hides the input entirely while the override is
+   *  present — for surfaces whose override is the ONLY intended action. */
+  composerOverrideMode?: "above" | "replace";
   composerLabels?: ChatComposerLabels;
   /** Prop-driven dictation control for the composer. Omit to hide the mic
    *  affordance entirely (e.g. the web build with no speech capture). */

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -63,6 +63,7 @@ export function ChatPanel({
   queuedLabels,
   canSendEmpty,
   composerOverride,
+  composerOverrideMode = "above",
   composerLabels,
   dictation,
   currentUserId,
@@ -171,38 +172,43 @@ export function ChatPanel({
         </div>
       )}
 
-      {/* The composer stays mounted at all times. A pending interaction renders
-          its card ABOVE the input (both visible) rather than replacing it, so the
-          user can always type a fresh message — doing so abandons the card. The
-          override block drops the input's own top padding for its gap, avoiding
-          doubled spacing between the two. */}
+      {/* Default ("above"): the composer stays mounted at all times. A pending
+          interaction renders its card ABOVE the input (both visible) rather
+          than replacing it, so the user can always type a fresh message —
+          doing so abandons the card. The override block drops the input's own
+          top padding for its gap, avoiding doubled spacing between the two.
+          "replace" hides the input entirely while the override is present, for
+          surfaces whose override is the ONLY intended action (onboarding's
+          one-button offer). */}
       {composerOverride && (
-        <div className="shrink-0 px-4 pt-2">
+        <div className="shrink-0 px-4 pt-2 pb-3">
           <div className="max-w-3xl mx-auto">{composerOverride}</div>
         </div>
       )}
-      <ChatInput
-        onSend={handleSend}
-        onStop={onStop}
-        status={status}
-        placeholder={placeholder}
-        value={value}
-        onValueChange={onValueChange}
-        attachments={files}
-        onAttachmentsChange={setFiles}
-        onNotice={onNotice}
-        prepareAttachments={prepareAttachments}
-        onAttachmentRejections={onAttachmentRejections}
-        footer={footer}
-        header={composerHeader}
-        attachMenu={attachMenu}
-        queuedMessages={queuedMessages}
-        onRemoveQueuedMessage={onRemoveQueuedMessage}
-        queuedLabels={queuedLabels}
-        canSendEmpty={canSendEmpty}
-        labels={composerLabels}
-        dictation={dictation}
-      />
+      {!(composerOverride && composerOverrideMode === "replace") && (
+        <ChatInput
+          onSend={handleSend}
+          onStop={onStop}
+          status={status}
+          placeholder={placeholder}
+          value={value}
+          onValueChange={onValueChange}
+          attachments={files}
+          onAttachmentsChange={setFiles}
+          onNotice={onNotice}
+          prepareAttachments={prepareAttachments}
+          onAttachmentRejections={onAttachmentRejections}
+          footer={footer}
+          header={composerHeader}
+          attachMenu={attachMenu}
+          queuedMessages={queuedMessages}
+          onRemoveQueuedMessage={onRemoveQueuedMessage}
+          queuedLabels={queuedLabels}
+          canSendEmpty={canSendEmpty}
+          labels={composerLabels}
+          dictation={dictation}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Qué arregla

Cinco fixes del onboarding, en el orden del flujo:

### 1. Sign-in con Apple (desktop) — 403 Forbidden
Apple rechaza cualquier `redirect_uri` de loopback `127.0.0.1` (403 en el authorize), y `createAuthUri` de GCIP pasa el `continueUri` **verbatim** como `redirect_uri` (nunca brokereó por el handler como asumía el flujo), así que el botón de Apple en desktop moría siempre. Ahora el retorno va por un puente HTTPS del gateway (`POST {gateway}/v1/auth/apple/return`, contrato pinneado en `apple-authorize.ts`) que convierte el `form_post` de Apple en una navegación `houston://auth-callback?<query>`; el shell Rust reenvía ese deep link al canal `auth://deep-link` existente, así que el lifecycle del attempt y el CSRF quedan idénticos a los flujos PKCE.

**Pendiente fuera de este repo:** el endpoint del puente en el gateway, registrar la URL del puente como return URL del Services ID de Apple, y el dominio del gateway en los authorized domains de GCIP.

**Microsoft** (verificado en vivo): no es código — al app registration de Azure le faltan los redirect URIs de loopback del desktop bajo *Mobile and desktop applications* (`http://127.0.0.1:8975-8978/auth/callback`, los cuatro exactos: `login.live.com` hace match exacto). Las cuentas personales fallan después del picker con `invalid_request: redirect_uri is not valid`. Documentado en `knowledge-base/auth-migration.md`.

### 2. Pantalla de idioma
Detecta el locale del OS y lo preselecciona (fila marcada + botón Continuar = un click); el título/copy renderiza en el idioma detectado en vez de solo inglés; filas más grandes para llenar el espacio muerto. `onboarding_language_selected` ahora lleva `detected_locale`.

### 3. Connect AI decía "conectado" sin estarlo
Dos caminos de falso éxito: (a) los polls de login trataban `configured: true` a secas como completado — una credencial vieja completaba el OAuth que el usuario nunca terminó (nuevo predicado `isProviderLoginComplete`, con test); (b) en el connect pre-agente, si fallaba la captura de la credencial al workspace (los 503 del gateway vistos en logs) se emitía éxito igual — ahora surface como login fallido. El poll también reporta un login `error` del runtime al instante en vez de esconderlo hasta el timeout de 5 min.

### 4. Pantalla "¿Cuál describe mejor tu trabajo?" repetida
La respuesta solo vivía como preferencia del engine (en el pod, en hosted) — un blip del pod la re-preguntaba. Ahora hay espejo local por uid: se pregunta máximo una vez por usuario por dispositivo aunque el engine no responda.

### 5. Pasos 2 y 3 del tutorial (visual)
- Cards Gmail/Outlook más grandes y sin el tile oscuro detrás del icono (la marca flota sobre la card).
- Paso 3: el composer de reply queda oculto hasta que arranca la misión — la oferta "Enviar un correo a mí mismo" es la única acción, integrada a la card (sin caja despegada). `ChatPanel` gana `composerOverrideMode="replace"` (inventory v28 + changelog).

## Auditoría del funnel de PostHog (pendiente de aplicar)

Todas las pantallas del onboarding emiten eventos, pero el **Activation Funnel** (insight 10095295, dashboard 1631629) no tiene el paso de la pantalla de segmento: hay que insertar la action 289125 `segment_screen_done` entre `user_signed_in` y `ai_provider_connected` (la action ya existe para esto). Opcional: añadir `first_email_sent` al final. El intento de editarlo por API fue bloqueado por permisos de la sesión.

## Verificación

- `pnpm test` (app): 1618 ✓ · vitest web: pasa (el único rojo es `host-workspaces.test.ts`, archivo huérfano pre-existente sin commitear, no tocado)
- `pnpm tsgo --noEmit` (app) ✓ · `pnpm --filter houston-web typecheck` ✓ · `cargo check` (shell) ✓
- `pnpm check` (Biome) ✓ · `pnpm check:parity` ✓
