### PR TITLE
fix(agentstore): pin folder-entry timestamps — reproducible skill zips

### DIFF
--- a/agentstore/src/lib/export/claude-skill-zip.ts
+++ b/agentstore/src/lib/export/claude-skill-zip.ts
@@ -76,6 +76,15 @@ export async function buildClaudeSkillZip(
     zip.file(`${folder}/SKILL.md`, agentSkill, { date: REPRODUCIBLE_DATE });
   }
 
+  // JSZip auto-creates the parent FOLDER entries stamped with the current
+  // wall clock — the per-file `date` option doesn't cover them. Zip DOS
+  // times have 2-second granularity, so two builds straddling a boundary
+  // produced different bytes (the reproducibility test flaked on exactly
+  // this). Pin every entry, folders included.
+  zip.forEach((_, entry) => {
+    entry.date = REPRODUCIBLE_DATE;
+  });
+
   const bytes = await zip.generateAsync({
     type: "uint8array",
     compression: "DEFLATE",

--- a/agentstore/src/lib/export/export.test.ts
+++ b/agentstore/src/lib/export/export.test.ts
@@ -79,6 +79,22 @@ describe("claude-skill-zip", () => {
     expect(Buffer.from(a.bytes).equals(Buffer.from(b.bytes))).toBe(true);
   });
 
+  it("pins every entry timestamp, folders included", async () => {
+    // The byte-comparison above only flakes when two builds straddle a
+    // 2-second zip-time boundary; this catches the bug deterministically.
+    // JSZip auto-creates folder entries whose date defaults to NOW — every
+    // entry must carry the fixed reproducible date instead.
+    const { bytes } = await buildClaudeSkillZip(exampleAgentIr);
+    const zip = await JSZip.loadAsync(bytes);
+    const entries = Object.values(zip.files);
+    expect(entries.length).toBeGreaterThan(1); // files AND folder entries
+    for (const entry of entries) {
+      expect
+        .soft(entry.date.toISOString(), entry.name)
+        .toBe("2020-01-01T00:00:00.000Z");
+    }
+  });
+
   it("omits the agent skill when there are no instructions", async () => {
     const ir = { ...exampleAgentIr, instructions: "   " };
     expect(buildAgentSkillMarkdown(ir)).toBeNull();


### PR DESCRIPTION
Fixes the main CI failure in [run 29576412859](https://github.com/gethouston/houston/actions/runs/29576412859) — `claude-skill-zip > produces byte-reproducible archives`.

**Not a regression from #957** (which touched no agentstore code) — a latent flake that finally hit: `buildClaudeSkillZip` pins each file's timestamp, but JSZip auto-creates parent **folder** entries stamped with the current wall clock. Zip DOS times have 2-second granularity, so two back-to-back builds almost always matched — unless the test straddled a 2-second boundary, which is exactly what happened on this run. Reproduced the mechanism directly:

```
a/          (folder) 2026-07-17T11:43:51.718Z   ← wall clock
a/SKILL.md  (file)   2020-01-01T00:00:00.000Z   ← pinned
```

Fix: pin every entry (folders included) to `REPRODUCIBLE_DATE` before generating. Added a deterministic test asserting all round-tripped entry dates equal the fixed date — that fails on the old code every run, not one run in thousands.

Tests: agentstore suite 79/79, Biome clean.