### PR TITLE
fix(ui): dark-mode modals use the app's blue-tinted background, not flat black

### DIFF
--- a/app/src/styles/futuristic.css
+++ b/app/src/styles/futuristic.css
@@ -111,7 +111,8 @@ body::before {
 }
 
 /* Modal surface (`bg-dialog`). SOLID in both themes (the `dialog` token:
-   neutral.800 dark, white light) — no glass, no backdrop-filter. Modals sit
+   cool.gutter-dark dark — the app-background blue-tinted tone — white
+   light) — no glass, no backdrop-filter. Modals sit
    over arbitrary content and must never bleed it through; WebView2 in the
    desktop shell doesn't reliably composite backdrop-filter anyway (the dark
    "New agent" modal bled the Settings page through, and light washed out

--- a/packages/design-tokens/test/legacy-resolved.json
+++ b/packages/design-tokens/test/legacy-resolved.json
@@ -82,7 +82,7 @@
     "ht-card": "rgba(40, 40, 40, 0.5)",
     "ht-card-hover": "rgba(50, 50, 52, 0.58)",
     "ht-card-text": "#e5e5e5",
-    "ht-dialog": "#1e1e1e",
+    "ht-dialog": "#141416",
     "ht-card-solid": "#2c2c2b",
     "ht-danger": "#ef4444",
     "ht-danger-text": "#ffffff",

--- a/packages/design-tokens/tokens/semantic/color.dark.json
+++ b/packages/design-tokens/tokens/semantic/color.dark.json
@@ -10,7 +10,7 @@
     "card-text": { "$value": "{color.neutral.150}" },
     "popover": { "$value": "{color.neutral.800}" },
     "popover-text": { "$value": "{color.neutral.150}" },
-    "dialog": { "$value": "{color.neutral.800}" },
+    "dialog": { "$value": "{color.cool.gutter-dark}" },
     "ink": { "$value": "{color.neutral.150}" },
     "ink-muted": { "$value": "{color.neutral.450}" },
     "action": { "$value": "{color.neutral.150}" },

--- a/ui/core/src/components/dialog.tsx
+++ b/ui/core/src/components/dialog.tsx
@@ -65,9 +65,9 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           // Modal surface token `bg-dialog`: SOLID in both modes (white in
-          // light, neutral.800 in dark) — modals sit over arbitrary content
-          // and must never bleed it through. Not `bg-card` (glass in both
-          // modes).
+          // light, cool.gutter-dark in dark — the app-background blue-tinted
+          // tone) — modals sit over arbitrary content and must never bleed it
+          // through. Not `bg-card` (glass in both modes).
           "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-5 rounded-2xl border border-line/50 bg-dialog p-6 shadow-[0_4px_4px_rgba(0,0,0,0.04),0_4px_80px_8px_rgba(0,0,0,0.04),0_0_1px_rgba(0,0,0,0.62)] dark:shadow-[0_4px_4px_rgba(0,0,0,0.1),0_4px_80px_8px_rgba(0,0,0,0.2),0_0_1px_rgba(255,255,255,0.1)] duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
           className,
         )}


### PR DESCRIPTION
## Qué cambia

En modo oscuro los modales (crear agente, alert dialogs, sheets, AI hub) usaban `neutral.800` (`#1e1e1e`), un negro plano sin tinte. Ahora el token semántico `dialog` (dark) apunta a `cool.gutter-dark` (`#141416`), el mismo fondo azulado de la aplicación, así el modal se integra con el resto de la UI oscura.

- `packages/design-tokens/tokens/semantic/color.dark.json`: `dialog` → `{color.cool.gutter-dark}`
- `packages/design-tokens/test/legacy-resolved.json`: fixture del zero-diff actualizado (cambio visual deliberado)
- Comentarios actualizados en `ui/core/src/components/dialog.tsx` y `app/src/styles/futuristic.css`

Light mode no cambia (sigue blanco sólido). El modal sigue siendo sólido, sin glass ni backdrop-filter.

## Tests

- `pnpm --filter @houston/design-tokens build` + `test`: 128 tests pasan
- `pnpm check`: Biome limpio