### PR TITLE
fix(onboarding): email mission en Autopilot y skip solo en fallo

### DIFF
--- a/app/src/components/onboarding/missions/email-skip.ts
+++ b/app/src/components/onboarding/missions/email-skip.ts
@@ -1,15 +1,35 @@
+import type { FeedItem } from "@houston-ai/chat";
+
+/**
+ * Whether the agent has visibly replied in the mission conversation: its
+ * first text (streaming counts — the reply is on screen) or a surfaced turn
+ * error. The user's own kickoff message does NOT count.
+ */
+export function feedShowsAgentReply(feed: readonly FeedItem[]): boolean {
+  return feed.some(
+    (item) =>
+      item.feed_type === "assistant_text" ||
+      item.feed_type === "assistant_text_streaming" ||
+      item.feed_type === "provider_error" ||
+      item.feed_type === "tool_runtime_error",
+  );
+}
+
 /**
  * Whether to offer the "skip" escape hatch on the final email onboarding step.
  *
  * The step normally auto-advances when the agent emits the
- * `[TUTORIAL_COMPLETED]` marker. The only escape is the live conversation,
- * and it becomes available only after the offer has sent its first message.
+ * `[TUTORIAL_COMPLETED]` marker. The escape appears once the AGENT has replied
+ * (not merely once the user's kickoff went out) — or once anything has
+ * errored, so a failure never strands the user with retry as the only exit.
  */
 export function shouldOfferSkip(args: {
-  /** The email offer successfully started the agent conversation. */
-  hasFirstMessage: boolean;
+  /** The agent's first reply (or an in-feed error) is on screen. */
+  agentReplied: boolean;
+  /** The kickoff (or a follow-up send) surfaced an app-level error. */
+  hasError: boolean;
   /** The completion marker was seen (the happy path auto-advances instead). */
   setupDone: boolean;
 }): boolean {
-  return args.hasFirstMessage && !args.setupDone;
+  return (args.agentReplied || args.hasError) && !args.setupDone;
 }

--- a/app/src/components/onboarding/missions/email-skip.ts
+++ b/app/src/components/onboarding/missions/email-skip.ts
@@ -1,15 +1,13 @@
 import type { FeedItem } from "@houston-ai/chat";
 
 /**
- * Whether the agent has visibly replied in the mission conversation: its
- * first text (streaming counts — the reply is on screen) or a surfaced turn
- * error. The user's own kickoff message does NOT count.
+ * Whether the mission conversation has surfaced a turn failure: a provider
+ * error or a tool runtime error in the feed. Normal agent replies do NOT
+ * count — the happy path auto-advances and needs no escape hatch.
  */
-export function feedShowsAgentReply(feed: readonly FeedItem[]): boolean {
+export function feedShowsTurnError(feed: readonly FeedItem[]): boolean {
   return feed.some(
     (item) =>
-      item.feed_type === "assistant_text" ||
-      item.feed_type === "assistant_text_streaming" ||
       item.feed_type === "provider_error" ||
       item.feed_type === "tool_runtime_error",
   );
@@ -19,17 +17,16 @@ export function feedShowsAgentReply(feed: readonly FeedItem[]): boolean {
  * Whether to offer the "skip" escape hatch on the final email onboarding step.
  *
  * The step normally auto-advances when the agent emits the
- * `[TUTORIAL_COMPLETED]` marker. The escape appears once the AGENT has replied
- * (not merely once the user's kickoff went out) — or once anything has
- * errored, so a failure never strands the user with retry as the only exit.
+ * `[TUTORIAL_COMPLETED]` marker, so mid-conversation there is nothing to skip.
+ * The escape appears ONLY when something failed — a kickoff error or an
+ * in-feed turn error — so a failure never strands the user with retry as the
+ * only exit.
  */
 export function shouldOfferSkip(args: {
-  /** The agent's first reply (or an in-feed error) is on screen. */
-  agentReplied: boolean;
-  /** The kickoff (or a follow-up send) surfaced an app-level error. */
+  /** The kickoff, a follow-up send, or the turn itself surfaced an error. */
   hasError: boolean;
   /** The completion marker was seen (the happy path auto-advances instead). */
   setupDone: boolean;
 }): boolean {
-  return (args.agentReplied || args.hasError) && !args.setupDone;
+  return args.hasError && !args.setupDone;
 }

--- a/app/src/components/onboarding/missions/email.tsx
+++ b/app/src/components/onboarding/missions/email.tsx
@@ -27,7 +27,7 @@ interface EmailMissionProps {
   onBack: () => void;
   /** Advance to the success screen once the email is sent. */
   onContinue: () => void;
-  /** Leave onboarding once the agent has replied (or the mission errored). */
+  /** Leave onboarding when the mission errored (the only time skip shows). */
   onSkip: () => void;
 }
 
@@ -100,8 +100,8 @@ export function EmailMission({
       title={t("tutorial.missions.email.title")}
       // The mission body lives in the offer card, so no subtitle duplicates it.
       // Back disappears once the mission runs: returning would start a second
-      // session and a second real email. The conversation exit below appears
-      // once the agent replies (or errors) instead.
+      // session and a second real email. The skip exit below appears only if
+      // the mission errors.
       onBack={session.started ? undefined : onBack}
       backLabel={t("tutorial.nav.back")}
     >

--- a/app/src/components/onboarding/missions/email.tsx
+++ b/app/src/components/onboarding/missions/email.tsx
@@ -27,7 +27,7 @@ interface EmailMissionProps {
   onBack: () => void;
   /** Advance to the success screen once the email is sent. */
   onContinue: () => void;
-  /** Leave onboarding after the first message has started the AI conversation. */
+  /** Leave onboarding once the agent has replied (or the mission errored). */
   onSkip: () => void;
 }
 
@@ -101,7 +101,7 @@ export function EmailMission({
       // The mission body lives in the offer card, so no subtitle duplicates it.
       // Back disappears once the mission runs: returning would start a second
       // session and a second real email. The conversation exit below appears
-      // after its first message instead.
+      // once the agent replies (or errors) instead.
       onBack={session.started ? undefined : onBack}
       backLabel={t("tutorial.nav.back")}
     >

--- a/app/src/components/onboarding/missions/use-email-mission-session.ts
+++ b/app/src/components/onboarding/missions/use-email-mission-session.ts
@@ -12,7 +12,7 @@ import {
   useEmailSetupCleanup,
   useEmailSetupCompleted,
 } from "./email-mission-setup";
-import { shouldOfferSkip } from "./email-skip";
+import { feedShowsAgentReply, shouldOfferSkip } from "./email-skip";
 
 interface UseEmailMissionSessionArgs {
   agent: Agent;
@@ -33,7 +33,7 @@ export interface EmailMissionSession {
   error: string | null;
   feedItems: FeedItem[];
   sessionKey: string;
-  /** Available only after the opening message starts the AI conversation. */
+  /** Available once the agent has replied (or something errored). */
   showSkip: boolean;
   onStop: (() => void) | undefined;
   handleSend: () => Promise<void>;
@@ -69,10 +69,13 @@ export function useEmailMissionSession({
 
   const setupDone = useEmailSetupCompleted(realFeed);
 
-  // The conversation becomes skippable only after its first message creates
-  // a mission session. Until then, the email action is the sole path forward.
+  // The conversation becomes skippable only once the AGENT has replied (the
+  // user's kickoff alone doesn't count) — or once something errored, so a
+  // failure never strands the user. Until then, the email action is the sole
+  // path forward.
   const showSkip = shouldOfferSkip({
-    hasFirstMessage: missionSessionKey !== null,
+    agentReplied: feedShowsAgentReply((realFeed ?? []) as FeedItem[]),
+    hasError: error !== null,
     setupDone,
   });
 
@@ -125,6 +128,9 @@ export function useEmailMissionSession({
           providerOverride: provider,
           modelOverride: model,
           effortOverride: "medium",
+          // Autopilot: the onboarding turn must SEND the email on the first
+          // message, not pause on ask_user/request_connection questions.
+          modeOverride: "auto",
         },
       );
       setMissionSessionKey(result.sessionKey);
@@ -148,6 +154,9 @@ export function useEmailMissionSession({
           providerOverride: provider,
           modelOverride: model,
           effortOverride: "medium",
+          // Follow-ups stay in Autopilot too: the whole onboarding chat runs
+          // without blocking questions.
+          modeOverride: "auto",
           queuedPreview: { text: trimmed },
         });
       } catch (e) {

--- a/app/src/components/onboarding/missions/use-email-mission-session.ts
+++ b/app/src/components/onboarding/missions/use-email-mission-session.ts
@@ -12,7 +12,7 @@ import {
   useEmailSetupCleanup,
   useEmailSetupCompleted,
 } from "./email-mission-setup";
-import { feedShowsAgentReply, shouldOfferSkip } from "./email-skip";
+import { feedShowsTurnError, shouldOfferSkip } from "./email-skip";
 
 interface UseEmailMissionSessionArgs {
   agent: Agent;
@@ -33,7 +33,7 @@ export interface EmailMissionSession {
   error: string | null;
   feedItems: FeedItem[];
   sessionKey: string;
-  /** Available once the agent has replied (or something errored). */
+  /** Available only when something failed (kickoff or turn error). */
   showSkip: boolean;
   onStop: (() => void) | undefined;
   handleSend: () => Promise<void>;
@@ -69,13 +69,12 @@ export function useEmailMissionSession({
 
   const setupDone = useEmailSetupCompleted(realFeed);
 
-  // The conversation becomes skippable only once the AGENT has replied (the
-  // user's kickoff alone doesn't count) — or once something errored, so a
-  // failure never strands the user. Until then, the email action is the sole
-  // path forward.
+  // The skip escape hatch exists ONLY for failure: a kickoff error or a turn
+  // error in the feed. On the happy path the step auto-advances, so nothing
+  // competes with the running conversation.
   const showSkip = shouldOfferSkip({
-    agentReplied: feedShowsAgentReply((realFeed ?? []) as FeedItem[]),
-    hasError: error !== null,
+    hasError:
+      error !== null || feedShowsTurnError((realFeed ?? []) as FeedItem[]),
     setupDone,
   });
 

--- a/app/src/locales/en/setup.json
+++ b/app/src/locales/en/setup.json
@@ -87,7 +87,7 @@
         "placeholder": "Reply to your agent...",
         "body": "Your agent will send a real email to you, so you can watch it work.",
         "skip": "Skip for now",
-        "skipHint": "You can continue in Houston after your first message."
+        "skipHint": "Something went wrong? You can continue in Houston and try again later."
       },
       "aiConnected": {
         "title": "Your AI is connected!",
@@ -107,7 +107,7 @@
         "cta": "Continue"
       },
       "finished": {
-        "title": "You're all set!",
+        "title": "Check your inbox!",
         "body": "Your Personal Assistant just proved it can act for you, for real.",
         "readyTitle": "You're all set!",
         "readyBody": "Your Personal Assistant is ready to get to work for you.",

--- a/app/src/locales/es/setup.json
+++ b/app/src/locales/es/setup.json
@@ -87,7 +87,7 @@
         "placeholder": "Responde a tu agente...",
         "body": "Tu agente te enviará un correo real, para que lo veas funcionar.",
         "skip": "Omitir por ahora",
-        "skipHint": "Puedes continuar en Houston después de tu primer mensaje."
+        "skipHint": "¿Algo salió mal? Puedes continuar en Houston e intentarlo más tarde."
       },
       "aiConnected": {
         "title": "¡Tu IA está conectada!",
@@ -107,7 +107,7 @@
         "cta": "Continuar"
       },
       "finished": {
-        "title": "¡Ya está todo listo!",
+        "title": "¡Revisa tu correo!",
         "body": "Tu asistente personal acaba de demostrar que puede actuar por ti, de verdad.",
         "readyTitle": "¡Ya está todo listo!",
         "readyBody": "Tu asistente personal está listo para ponerse a trabajar por ti.",

--- a/app/src/locales/pt/setup.json
+++ b/app/src/locales/pt/setup.json
@@ -87,7 +87,7 @@
         "placeholder": "Responda ao seu agente...",
         "body": "Seu agente vai enviar um e-mail de verdade para você, para você vê-lo funcionar.",
         "skip": "Pular por enquanto",
-        "skipHint": "Você pode continuar no Houston depois da primeira mensagem."
+        "skipHint": "Algo deu errado? Você pode continuar no Houston e tentar de novo mais tarde."
       },
       "aiConnected": {
         "title": "Sua IA está conectada!",
@@ -107,7 +107,7 @@
         "cta": "Continuar"
       },
       "finished": {
-        "title": "Tudo pronto!",
+        "title": "Confira seu e-mail!",
         "body": "Seu assistente pessoal acabou de provar que pode agir por você, de verdade.",
         "readyTitle": "Tudo pronto!",
         "readyBody": "Seu assistente pessoal está pronto para trabalhar por você.",

--- a/app/tests/email-skip.test.ts
+++ b/app/tests/email-skip.test.ts
@@ -1,26 +1,92 @@
 import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 
-import { shouldOfferSkip } from "../src/components/onboarding/missions/email-skip.ts";
+import type { FeedItem } from "@houston-ai/chat";
+import {
+  feedShowsAgentReply,
+  shouldOfferSkip,
+} from "../src/components/onboarding/missions/email-skip.ts";
+
+describe("feedShowsAgentReply (HOU-555 onboarding escape hatch)", () => {
+  it("an empty feed has no agent reply", () => {
+    strictEqual(feedShowsAgentReply([]), false);
+  });
+
+  it("the user's own kickoff message does not count", () => {
+    const feed: FeedItem[] = [
+      { feed_type: "user_message", data: "Send an email to myself" },
+      { feed_type: "tool_call", data: { name: "COMPOSIO", input: {} } },
+    ];
+    strictEqual(feedShowsAgentReply(feed), false);
+  });
+
+  it("the agent's first text counts, streaming included", () => {
+    strictEqual(
+      feedShowsAgentReply([{ feed_type: "assistant_text", data: "On it." }]),
+      true,
+    );
+    strictEqual(
+      feedShowsAgentReply([
+        { feed_type: "assistant_text_streaming", data: "On" },
+      ]),
+      true,
+    );
+  });
+
+  it("a surfaced turn error counts as a reply", () => {
+    strictEqual(
+      feedShowsAgentReply([
+        {
+          feed_type: "provider_error",
+          data: { type: "RateLimited" } as never,
+        },
+      ]),
+      true,
+    );
+  });
+});
 
 describe("shouldOfferSkip (HOU-555 onboarding escape hatch)", () => {
-  it("hidden before the first message starts the AI conversation", () => {
+  it("hidden until the agent replies — the user's kickoff alone is not enough", () => {
     strictEqual(
-      shouldOfferSkip({ hasFirstMessage: false, setupDone: false }),
+      shouldOfferSkip({
+        agentReplied: false,
+        hasError: false,
+        setupDone: false,
+      }),
       false,
     );
   });
 
-  it("appears as soon as the first message starts the AI conversation", () => {
+  it("appears once the agent's first reply lands", () => {
     strictEqual(
-      shouldOfferSkip({ hasFirstMessage: true, setupDone: false }),
+      shouldOfferSkip({
+        agentReplied: true,
+        hasError: false,
+        setupDone: false,
+      }),
+      true,
+    );
+  });
+
+  it("appears when the kickoff errored, even with no reply", () => {
+    strictEqual(
+      shouldOfferSkip({
+        agentReplied: false,
+        hasError: true,
+        setupDone: false,
+      }),
       true,
     );
   });
 
   it("hidden on the happy path (completion marker seen)", () => {
     strictEqual(
-      shouldOfferSkip({ hasFirstMessage: true, setupDone: true }),
+      shouldOfferSkip({
+        agentReplied: true,
+        hasError: false,
+        setupDone: true,
+      }),
       false,
     );
   });

--- a/app/tests/email-skip.test.ts
+++ b/app/tests/email-skip.test.ts
@@ -3,39 +3,27 @@ import { describe, it } from "node:test";
 
 import type { FeedItem } from "@houston-ai/chat";
 import {
-  feedShowsAgentReply,
+  feedShowsTurnError,
   shouldOfferSkip,
 } from "../src/components/onboarding/missions/email-skip.ts";
 
-describe("feedShowsAgentReply (HOU-555 onboarding escape hatch)", () => {
-  it("an empty feed has no agent reply", () => {
-    strictEqual(feedShowsAgentReply([]), false);
+describe("feedShowsTurnError (HOU-555 onboarding escape hatch)", () => {
+  it("an empty feed has no error", () => {
+    strictEqual(feedShowsTurnError([]), false);
   });
 
-  it("the user's own kickoff message does not count", () => {
+  it("a normal conversation (user + agent + tools) is NOT an error", () => {
     const feed: FeedItem[] = [
       { feed_type: "user_message", data: "Send an email to myself" },
+      { feed_type: "assistant_text", data: "On it." },
       { feed_type: "tool_call", data: { name: "COMPOSIO", input: {} } },
     ];
-    strictEqual(feedShowsAgentReply(feed), false);
+    strictEqual(feedShowsTurnError(feed), false);
   });
 
-  it("the agent's first text counts, streaming included", () => {
+  it("a provider error in the feed counts", () => {
     strictEqual(
-      feedShowsAgentReply([{ feed_type: "assistant_text", data: "On it." }]),
-      true,
-    );
-    strictEqual(
-      feedShowsAgentReply([
-        { feed_type: "assistant_text_streaming", data: "On" },
-      ]),
-      true,
-    );
-  });
-
-  it("a surfaced turn error counts as a reply", () => {
-    strictEqual(
-      feedShowsAgentReply([
+      feedShowsTurnError([
         {
           feed_type: "provider_error",
           data: { type: "RateLimited" } as never,
@@ -44,50 +32,34 @@ describe("feedShowsAgentReply (HOU-555 onboarding escape hatch)", () => {
       true,
     );
   });
+
+  it("a tool runtime error in the feed counts", () => {
+    strictEqual(
+      feedShowsTurnError([
+        {
+          feed_type: "tool_runtime_error",
+          data: { message: "boom" } as never,
+        },
+      ]),
+      true,
+    );
+  });
 });
 
 describe("shouldOfferSkip (HOU-555 onboarding escape hatch)", () => {
-  it("hidden until the agent replies — the user's kickoff alone is not enough", () => {
-    strictEqual(
-      shouldOfferSkip({
-        agentReplied: false,
-        hasError: false,
-        setupDone: false,
-      }),
-      false,
-    );
+  it("hidden while the mission runs normally — mid-conversation has no skip", () => {
+    strictEqual(shouldOfferSkip({ hasError: false, setupDone: false }), false);
   });
 
-  it("appears once the agent's first reply lands", () => {
-    strictEqual(
-      shouldOfferSkip({
-        agentReplied: true,
-        hasError: false,
-        setupDone: false,
-      }),
-      true,
-    );
-  });
-
-  it("appears when the kickoff errored, even with no reply", () => {
-    strictEqual(
-      shouldOfferSkip({
-        agentReplied: false,
-        hasError: true,
-        setupDone: false,
-      }),
-      true,
-    );
+  it("appears when something failed", () => {
+    strictEqual(shouldOfferSkip({ hasError: true, setupDone: false }), true);
   });
 
   it("hidden on the happy path (completion marker seen)", () => {
-    strictEqual(
-      shouldOfferSkip({
-        agentReplied: true,
-        hasError: false,
-        setupDone: true,
-      }),
-      false,
-    );
+    strictEqual(shouldOfferSkip({ hasError: false, setupDone: true }), false);
+  });
+
+  it("hidden even after an error once the mission completed anyway", () => {
+    strictEqual(shouldOfferSkip({ hasError: true, setupDone: true }), false);
   });
 });

--- a/app/tests/onboarding-required-email.test.ts
+++ b/app/tests/onboarding-required-email.test.ts
@@ -46,7 +46,10 @@ describe("required onboarding email path", () => {
     assert.doesNotMatch(connectEmail, /\b(?:skip|omit)\b/i);
     assert.doesNotMatch(flow, /shouldOfferConnectSkip/);
     assert.doesNotMatch(onboarding, /skipEmailSteps/);
-    assert.match(session, /hasFirstMessage: missionSessionKey !== null/);
+    // The skip escape hatch is failure-gated: the session derives `showSkip`
+    // from shouldOfferSkip (behavior covered in email-skip.test.ts), so no
+    // standalone pre-conversation skip route exists.
+    assert.match(session, /showSkip = shouldOfferSkip\(\{/);
   });
 });
 


### PR DESCRIPTION
## Qué cambia

Dos fixes de onboarding que quedaron pusheados en la rama después de que se mergeara el PR #958:

- `7cde1f9a` fix(onboarding): email mission runs in Autopilot; skip waits for the agent's reply
- `0fc91a64` fix(onboarding): skip only on failure; the sent payoff says check your inbox

La misión de email del onboarding corre en Autopilot, el botón de skip espera la respuesta del agente y solo aparece cuando la misión falla; el payoff de envío dice que revises tu inbox.
