### PR TITLE
feat(store): extract @houston/agentstore-client SDK and migrate both frontends

### DIFF
--- a/agentstore/package.json
+++ b/agentstore/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@houston-ai/core": "workspace:*",
+    "@houston/agentstore-client": "workspace:*",
     "@houston/agentstore-contract": "workspace:*",
     "@houston/design-tokens": "workspace:*",
     "class-variance-authority": "0.7.1",

--- a/agentstore/src/app/admin/admin-console.tsx
+++ b/agentstore/src/app/admin/admin-console.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { StoreApiError } from "@houston/agentstore-client";
 import {
   Alert,
   AlertDescription,
@@ -15,7 +16,6 @@ import { Brush, LogIn } from "lucide-react";
 import * as React from "react";
 import { useSession } from "@/lib/auth/session";
 import { runPurge } from "@/lib/store-admin-client";
-import { StoreApiError } from "@/lib/store-client";
 import { QueueTab } from "./queue-tab";
 import { ReportsTab } from "./reports-tab";
 

--- a/agentstore/src/app/admin/queue-tab.tsx
+++ b/agentstore/src/app/admin/queue-tab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type AdminQueueItem, StoreApiError } from "@houston/agentstore-client";
 import {
   Alert,
   AlertDescription,
@@ -13,12 +14,7 @@ import {
 import { Check, ExternalLink, X } from "lucide-react";
 import * as React from "react";
 import { shareUrlForSlug } from "@/lib/site-config";
-import {
-  type AdminQueueItem,
-  actOnQueueItem,
-  listAdminQueue,
-} from "@/lib/store-admin-client";
-import { StoreApiError } from "@/lib/store-client";
+import { actOnQueueItem, listAdminQueue } from "@/lib/store-admin-client";
 
 type Load =
   | { status: "loading" }

--- a/agentstore/src/app/admin/report-group-card.tsx
+++ b/agentstore/src/app/admin/report-group-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { AdminReport } from "@houston/agentstore-client";
 import {
   Badge,
   Button,
@@ -9,7 +10,6 @@ import {
   CardTitle,
 } from "@houston-ai/core";
 import { ExternalLink } from "lucide-react";
-import type { AdminReport } from "@/lib/store-admin-client";
 
 const REASON_LABEL: Record<AdminReport["reason"], string> = {
   spam: "Spam",

--- a/agentstore/src/app/admin/reports-tab.test.tsx
+++ b/agentstore/src/app/admin/reports-tab.test.tsx
@@ -1,5 +1,5 @@
+import type { AdminReport } from "@houston/agentstore-client";
 import { describe, expect, it } from "vitest";
-import type { AdminReport } from "@/lib/store-admin-client";
 import { groupByAgent } from "./reports-tab";
 
 /** A report in the gateway's flat wire shape (no nested agent object). */

--- a/agentstore/src/app/admin/reports-tab.tsx
+++ b/agentstore/src/app/admin/reports-tab.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { Alert, AlertDescription, Button, Spinner } from "@houston-ai/core";
-import * as React from "react";
 import {
   type AdminReport,
-  actOnReport,
-  listAdminReports,
   type ReportStatus,
-} from "@/lib/store-admin-client";
-import { StoreApiError } from "@/lib/store-client";
+  StoreApiError,
+} from "@houston/agentstore-client";
+import { Alert, AlertDescription, Button, Spinner } from "@houston-ai/core";
+import * as React from "react";
+import { actOnReport, listAdminReports } from "@/lib/store-admin-client";
 import { type AgentGroup, ReportGroupCard } from "./report-group-card";
 
 const FILTERS: { value: ReportStatus; label: string }[] = [

--- a/agentstore/src/app/api/agents/[agent]/bundle/route.ts
+++ b/agentstore/src/app/api/agents/[agent]/bundle/route.ts
@@ -7,6 +7,7 @@
  * attributed to the real downloader. Published + non-deleted only.
  */
 
+import type { StoreInstallTarget } from "@houston/agentstore-client";
 import {
   defaultExportTarget,
   type ExportResult,
@@ -21,7 +22,6 @@ import {
   corsPreflight,
 } from "@/lib/proxy-headers";
 import { getAgentBySlug, recordInstall } from "@/lib/store-api";
-import type { InstallTarget } from "@/lib/store-api-types";
 
 export const dynamic = "force-dynamic";
 
@@ -41,7 +41,7 @@ function jsonError(error: string, status: number): Response {
 }
 
 /** Map an export-target id (hyphenated) to the gateway install target. */
-const INSTALL_TARGET_BY_EXPORT: Record<ExportTargetId, InstallTarget> = {
+const INSTALL_TARGET_BY_EXPORT: Record<ExportTargetId, StoreInstallTarget> = {
   "claude-skill-zip": "claude_skill_zip",
   "copy-paste": "copy_paste",
 };

--- a/agentstore/src/app/claim/claim-client.tsx
+++ b/agentstore/src/app/claim/claim-client.tsx
@@ -1,16 +1,15 @@
 "use client";
 
+import {
+  type StoreAgentSummary,
+  StoreApiError,
+} from "@houston/agentstore-client";
 import { Button, Spinner } from "@houston-ai/core";
 import { LogIn } from "lucide-react";
 import * as React from "react";
 import { useSession } from "@/lib/auth/session";
 import { shareUrlForSlug } from "@/lib/site-config";
-import {
-  type AgentSummary,
-  claimAgent,
-  listMyAgents,
-  StoreApiError,
-} from "@/lib/store-client";
+import { claimAgent, listMyAgents } from "@/lib/store-client";
 import { ClaimManage } from "./claim-manage";
 import { ClaimNotice, ClaimSuccess } from "./claim-notices";
 
@@ -27,7 +26,7 @@ type ViewState =
   | { status: "signed-out" }
   | { status: "claiming" }
   | { status: "error"; message: string }
-  | { status: "ready"; agent: AgentSummary }
+  | { status: "ready"; agent: StoreAgentSummary }
   | { status: "success"; shareUrl: string };
 
 function readParams(): ClaimParams | null {

--- a/agentstore/src/app/claim/claim-manage.tsx
+++ b/agentstore/src/app/claim/claim-manage.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import {
+  type StoreAgentSummary,
+  StoreApiError,
+} from "@houston/agentstore-client";
+import {
   Alert,
   AlertDescription,
   AlertTitle,
@@ -13,12 +17,7 @@ import { AlertTriangle } from "lucide-react";
 import * as React from "react";
 import { normalizeCreatorUrl } from "@/lib/agents/creator-url";
 import { shareUrlForSlug } from "@/lib/site-config";
-import {
-  type AgentSummary,
-  listMyAgents,
-  patchAgent,
-  StoreApiError,
-} from "@/lib/store-client";
+import { listMyAgents, patchAgent } from "@/lib/store-client";
 
 /** Friendly message for a publish failure, keyed on the gateway error code. */
 function publishError(err: unknown): string {
@@ -37,7 +36,7 @@ function publishError(err: unknown): string {
 export interface ClaimManageProps {
   /** Mints a fresh bearer per operation (tokens expire between renders). */
   getToken: () => Promise<string | null>;
-  agent: AgentSummary;
+  agent: StoreAgentSummary;
   onPublished: (shareUrl: string) => void;
 }
 

--- a/agentstore/src/app/me/me-agent-card.tsx
+++ b/agentstore/src/app/me/me-agent-card.tsx
@@ -1,17 +1,17 @@
 "use client";
 
+import type { AgentPatch, StoreAgentSummary } from "@houston/agentstore-client";
 import { Badge, Button, ConfirmDialog } from "@houston-ai/core";
 import { ExternalLink, Trash2 } from "lucide-react";
 import * as React from "react";
 import { AgentIcon } from "@/components/agent-icon";
 import { shareUrlForSlug } from "@/lib/site-config";
 import { toDisplayIcon } from "@/lib/store-api-types";
-import type { AgentPatch, AgentSummary } from "@/lib/store-client";
 
 const compact = new Intl.NumberFormat("en", { notation: "compact" });
 
 /** Human label + badge tone for an agent's publish state. */
-function stateBadge(agent: AgentSummary): {
+function stateBadge(agent: StoreAgentSummary): {
   label: string;
   tone: "default" | "secondary" | "outline";
 } {
@@ -23,7 +23,7 @@ function stateBadge(agent: AgentSummary): {
 }
 
 export interface MeAgentCardProps {
-  agent: AgentSummary;
+  agent: StoreAgentSummary;
   categoryLabel?: string;
   /** True while any mutation on this row is in flight. */
   busy: boolean;

--- a/agentstore/src/app/me/me-client.tsx
+++ b/agentstore/src/app/me/me-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { AgentPatch, StoreAgentSummary } from "@houston/agentstore-client";
 import {
   Alert,
   AlertDescription,
@@ -10,20 +11,14 @@ import {
 import { AlertTriangle, LogIn } from "lucide-react";
 import * as React from "react";
 import { useSession } from "@/lib/auth/session";
-import {
-  type AgentPatch,
-  type AgentSummary,
-  deleteAgent,
-  listMyAgents,
-  patchAgent,
-} from "@/lib/store-client";
+import { deleteAgent, listMyAgents, patchAgent } from "@/lib/store-client";
 import { MeAgentCard } from "./me-agent-card";
 import { MeEmpty, MeNotice } from "./me-empty";
 
 type LoadState =
   | { status: "loading" }
   | { status: "error"; message: string }
-  | { status: "ready"; agents: AgentSummary[] };
+  | { status: "ready"; agents: StoreAgentSummary[] };
 
 function errorText(err: unknown): string {
   return err instanceof Error ? err.message : "Something went wrong.";

--- a/agentstore/src/components/agent-card.tsx
+++ b/agentstore/src/components/agent-card.tsx
@@ -1,7 +1,8 @@
+import type { StoreAgentSummary } from "@houston/agentstore-client";
 import { Badge, cn } from "@houston-ai/core";
 import { Download } from "lucide-react";
 import Link from "next/link";
-import { type AgentSummary, toDisplayIcon } from "@/lib/store-api-types";
+import { toDisplayIcon } from "@/lib/store-api-types";
 import { AgentIcon } from "./agent-icon";
 
 const compactNumber = new Intl.NumberFormat("en", { notation: "compact" });
@@ -13,7 +14,7 @@ function labelFromSlug(slug: string): string {
 }
 
 export interface AgentCardProps {
-  agent: AgentSummary;
+  agent: StoreAgentSummary;
   /** Human category label; falls back to a prettified slug. */
   categoryLabel?: string;
 }

--- a/agentstore/src/components/agent-grid.tsx
+++ b/agentstore/src/components/agent-grid.tsx
@@ -1,8 +1,8 @@
-import type { AgentSummary } from "@/lib/store-api-types";
+import type { StoreAgentSummary } from "@houston/agentstore-client";
 import { AgentCard } from "./agent-card";
 
 export interface AgentGridProps {
-  agents: AgentSummary[];
+  agents: StoreAgentSummary[];
   /** Maps a category slug to its display label (from the categories table). */
   categoryLabels?: Map<string, string>;
 }

--- a/agentstore/src/components/category-chips.tsx
+++ b/agentstore/src/components/category-chips.tsx
@@ -1,4 +1,4 @@
-import type { StoreCategory } from "@/lib/store-api-types";
+import type { StoreCategory } from "@houston/agentstore-client";
 import { ChipLink } from "./chip";
 
 export interface CategoryChipsProps {

--- a/agentstore/src/components/explore/explore-filters.tsx
+++ b/agentstore/src/components/explore/explore-filters.tsx
@@ -1,3 +1,4 @@
+import type { StoreCategory } from "@houston/agentstore-client";
 import { Plug } from "lucide-react";
 import {
   buildExploreHref,
@@ -8,7 +9,6 @@ import { CategoryChips } from "@/components/category-chips";
 import { ChipLink } from "@/components/chip";
 import { SearchForm } from "@/components/search-form";
 import type { CatalogIntegration } from "@/lib/agents/integrations";
-import type { StoreCategory } from "@/lib/store-api-types";
 
 const SORTS: { value: ExploreSort; label: string }[] = [
   { value: "recent", label: "Recent" },

--- a/agentstore/src/components/report-dialog.tsx
+++ b/agentstore/src/components/report-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { StoreApiError } from "@houston/agentstore-client";
 import {
   Alert,
   AlertDescription,
@@ -16,7 +17,7 @@ import {
 } from "@houston-ai/core";
 import { Flag } from "lucide-react";
 import * as React from "react";
-import { reportAgent, StoreApiError } from "@/lib/store-client";
+import { reportAgent } from "@/lib/store-client";
 import {
   ERROR_COPY,
   ReasonRadioGroup,

--- a/agentstore/src/lib/store-admin-client.ts
+++ b/agentstore/src/lib/store-admin-client.ts
@@ -1,79 +1,39 @@
 /**
- * Client-side calls for the moderation console (`/v1/agentstore/admin/*`). Every
- * call carries the signed-in user's bearer; the gateway authorizes by matching
- * the caller's UID against `GW_STORE_ADMIN_UIDS` and fail-closes to 404 when the
- * env is empty, so a non-admin sees the same "not found" a stranger does.
+ * Client-side facade over the Agent Store SDK for the moderation console
+ * (`/v1/agentstore/admin/*`). Every call carries the signed-in user's bearer;
+ * the gateway authorizes by matching the caller's UID against
+ * `GW_STORE_ADMIN_UIDS` and fail-closes to 404 when the env is empty, so a
+ * non-admin sees the same "not found" a stranger does.
  *
- * The admin response shapes are not pinned in the public contract; these types
- * are the shapes the gateway admin handlers emit, kept in one place so both sides
- * agree. Errors map to `StoreApiError` and are surfaced, never swallowed.
+ * This module owns only the browser-specific concerns: the public gateway
+ * origin, wrapping the caller's bearer into the SDK's `getToken`, and forcing
+ * `cache: "no-store"` on the admin reads. All HTTP and error plumbing lives in
+ * `@houston/agentstore-client`.
  */
 import {
-  clientGatewayBase,
-  STORE_API_PREFIX,
-  toStoreApiError,
-} from "./store-api-types";
-import type { ReportReason } from "./store-client";
+  type AdminQueueItem,
+  type AdminReport,
+  AgentStoreClient,
+  type PurgeResult,
+  type ReportStatus,
+  type StoreRequestOptions,
+} from "@houston/agentstore-client";
+import { clientGatewayBase } from "./store-api-types";
 
-/** An agent awaiting a public-visibility decision (`GET /admin/queue`). */
-export interface AdminQueueItem {
-  id: string;
-  slug: string | null;
-  name: string;
-  tagline: string | null;
-  description: string;
-  category: string;
-  creator: { displayName: string; url?: string };
-  publicRequestedAt: string | null;
-}
+/** Admin calls must never be served from the browser HTTP cache. */
+const NO_STORE: StoreRequestOptions = { init: { cache: "no-store" } };
 
-/** Status of a moderation report. */
-export type ReportStatus = "open" | "resolved" | "dismissed";
-
-/**
- * One abuse report in the moderation console (`GET /admin/reports`). The gateway
- * emits a flat shape: the reported agent is referenced by `agentId`/`agentSlug`,
- * with no denormalized name and no `resolvedAt`.
- */
-export interface AdminReport {
-  id: string;
-  reason: ReportReason;
-  details: string | null;
-  contact: string | null;
-  status: ReportStatus;
-  createdAt: string;
-  agentId: string;
-  agentSlug: string | null;
-}
-
-/** Result of the retention purge (`POST /admin/purge`). */
-export interface PurgeResult {
-  draftsDeleted: number;
-  softDeletedPurged: number;
-}
-
-function url(path: string): string {
-  return `${clientGatewayBase()}${STORE_API_PREFIX}${path}`;
-}
-
-async function adminFetch(
-  token: string,
-  path: string,
-  init?: RequestInit,
-): Promise<Response> {
-  const headers = new Headers(init?.headers);
-  headers.set("authorization", `Bearer ${token}`);
-  if (init?.body) headers.set("content-type", "application/json");
-  const res = await fetch(url(path), { ...init, headers, cache: "no-store" });
-  if (!res.ok) throw await toStoreApiError(res);
-  return res;
+/** An SDK client that authorizes every admin call with the caller's bearer. */
+function admin(token: string): AgentStoreClient {
+  return new AgentStoreClient({
+    baseUrl: clientGatewayBase(),
+    getToken: () => token,
+  });
 }
 
 /** The public-visibility review queue. */
-export async function listAdminQueue(token: string): Promise<AdminQueueItem[]> {
-  const res = await adminFetch(token, "/admin/queue");
-  const body = (await res.json()) as { items: AdminQueueItem[] };
-  return body.items;
+export function listAdminQueue(token: string): Promise<AdminQueueItem[]> {
+  return admin(token).adminListQueue(NO_STORE);
 }
 
 /** Approve (make public) or reject a queued agent. */
@@ -82,21 +42,15 @@ export async function actOnQueueItem(
   id: string,
   action: "approve" | "reject",
 ): Promise<void> {
-  await adminFetch(token, `/admin/queue/${encodeURIComponent(id)}`, {
-    method: "POST",
-    body: JSON.stringify({ action }),
-  });
+  await admin(token).adminActOnQueueItem(id, action, NO_STORE);
 }
 
 /** The abuse reports, optionally filtered by status. */
-export async function listAdminReports(
+export function listAdminReports(
   token: string,
   status?: ReportStatus,
 ): Promise<AdminReport[]> {
-  const query = status ? `?status=${encodeURIComponent(status)}` : "";
-  const res = await adminFetch(token, `/admin/reports${query}`);
-  const body = (await res.json()) as { items: AdminReport[] };
-  return body.items;
+  return admin(token).adminListReports(status, NO_STORE);
 }
 
 /** Resolve or dismiss a report. */
@@ -105,14 +59,10 @@ export async function actOnReport(
   id: string,
   action: "resolve" | "dismiss",
 ): Promise<void> {
-  await adminFetch(token, `/admin/reports/${encodeURIComponent(id)}`, {
-    method: "POST",
-    body: JSON.stringify({ action }),
-  });
+  await admin(token).adminActOnReport(id, action, NO_STORE);
 }
 
 /** Run the retention purge of stale drafts and expired soft-deletes. */
-export async function runPurge(token: string): Promise<PurgeResult> {
-  const res = await adminFetch(token, "/admin/purge", { method: "POST" });
-  return (await res.json()) as PurgeResult;
+export function runPurge(token: string): Promise<PurgeResult> {
+  return admin(token).adminPurge(NO_STORE);
 }

--- a/agentstore/src/lib/store-api-types.test.ts
+++ b/agentstore/src/lib/store-api-types.test.ts
@@ -1,18 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   clientGatewayBase,
-  StoreApiError,
   serverGatewayBase,
   toDisplayIcon,
-  toStoreApiError,
 } from "./store-api-types";
-
-function jsonResponse(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
-}
 
 describe("gateway base URLs", () => {
   afterEach(() => {
@@ -36,43 +27,6 @@ describe("gateway base URLs", () => {
   it("treats a blank env value as unset", () => {
     process.env.AGENTSTORE_GATEWAY_URL = "   ";
     expect(serverGatewayBase()).toBe("https://gateway.gethouston.ai");
-  });
-});
-
-describe("toStoreApiError", () => {
-  it("derives the machine code from the gateway's error token", async () => {
-    // The Go gateway carries the machine token in `error` only (no `code`
-    // field): edge.WriteError writes `{"error": token}`. The token must reach
-    // callers as `code` so they can branch on it.
-    const err = await toStoreApiError(
-      jsonResponse({ error: "not_owner" }, 403),
-    );
-    expect(err).toBeInstanceOf(StoreApiError);
-    expect(err.status).toBe(403);
-    expect(err.message).toBe("not_owner");
-    expect(err.code).toBe("not_owner");
-  });
-
-  it("prefers an explicit code over the error token when present", async () => {
-    const err = await toStoreApiError(
-      jsonResponse({ error: "human readable", code: "machine_code" }, 400),
-    );
-    expect(err.message).toBe("human readable");
-    expect(err.code).toBe("machine_code");
-  });
-
-  it("keeps a status-based message when the body has no error field", async () => {
-    const err = await toStoreApiError(jsonResponse({ other: 1 }, 500));
-    expect(err.message).toContain("500");
-    expect(err.code).toBeUndefined();
-  });
-
-  it("survives a non-JSON body", async () => {
-    const err = await toStoreApiError(
-      new Response("<html>502</html>", { status: 502 }),
-    );
-    expect(err.status).toBe(502);
-    expect(err.message).toContain("502");
   });
 });
 

--- a/agentstore/src/lib/store-api-types.ts
+++ b/agentstore/src/lib/store-api-types.ts
@@ -1,17 +1,15 @@
 /**
- * Shared types and helpers for talking to the Houston gateway's Agent Store API
- * (`/v1/agentstore/*`). The Next frontend is a pure SSR client of that Go API:
- * server components read the public catalog through `store-api.ts`, client
- * components make authed/anonymous mutations through `store-client.ts`. Both
- * import their wire types and error mapping from here.
+ * Site-local helpers for the Houston Agent Store frontend: gateway base-URL
+ * resolution (server vs client env), the AgentIR schema link, and the icon
+ * adapter the `AgentIcon` component renders. The wire types, the `StoreApiError`
+ * class, and the HTTP client itself live in `@houston/agentstore-client`; this
+ * module carries only what is specific to this Next.js deployment.
  *
- * This module is client-safe (no `server-only`, no Node built-ins) so the browser
- * bundle can reuse the types and the `StoreApiError` mapping.
+ * Client-safe (no `server-only`, no Node built-ins) so both server and client
+ * components can read the base helpers and the icon adapter.
  */
-import type { AgentIdentity, AgentIR } from "@houston/agentstore-contract";
-
-/** The Agent Store API path prefix on the gateway. */
-export const STORE_API_PREFIX = "/v1/agentstore";
+import { STORE_API_PREFIX, type StoreIcon } from "@houston/agentstore-client";
+import type { AgentIdentity } from "@houston/agentstore-contract";
 
 /** Default gateway origin when no env override is set. */
 const DEFAULT_GATEWAY_URL = "https://gateway.gethouston.ai";
@@ -45,113 +43,6 @@ export function clientGatewayBase(): string {
  */
 export function agentSchemaUrl(): string {
   return `${clientGatewayBase()}${STORE_API_PREFIX}/schema/agent`;
-}
-
-/** The gateway's icon shape: a single `{kind,value}` pair, or null. */
-export interface StoreIcon {
-  kind: "emoji" | "url";
-  value: string;
-}
-
-/** Publish state of an agent, mirrored from the gateway's `store_agents.state`. */
-export type AgentState = "draft" | "published" | "archived";
-
-/** Visibility of an agent, mirrored from `store_agents.visibility`. */
-export type AgentVisibility = "unlisted" | "public";
-
-/** One agent as returned by every list/detail endpoint (the wire `AgentSummary`). */
-export interface AgentSummary {
-  id: string;
-  slug: string | null;
-  name: string;
-  tagline: string | null;
-  description: string;
-  icon: StoreIcon | null;
-  color: string | null;
-  category: string;
-  tags: string[];
-  integrations: string[];
-  creator: { displayName: string; url?: string };
-  state: AgentState;
-  visibility: AgentVisibility;
-  installsCount: number;
-  publishedAt: string | null;
-  updatedAt: string;
-}
-
-/** A single agent page payload: the summary plus its full IR snapshot. */
-export interface AgentDetail {
-  agent: AgentSummary;
-  ir: AgentIR;
-}
-
-/** One page of the public catalog. */
-export interface CatalogPage {
-  items: AgentSummary[];
-  hasMore: boolean;
-}
-
-/** A category from `GET /categories`. */
-export interface StoreCategory {
-  slug: string;
-  name: string;
-}
-
-/** Catalog list/query parameters accepted by `GET /agents`. */
-export interface ListAgentsParams {
-  q?: string;
-  category?: string;
-  integration?: string;
-  sort?: "recent" | "installs";
-  page?: number;
-}
-
-/** The install targets the gateway counts (`POST /agents/{slug}/installs`). */
-export type InstallTarget = "claude_skill_zip" | "copy_paste" | "houston";
-
-/**
- * A typed gateway failure. Carries the HTTP status plus the parsed `error`
- * token and a machine `code`. The Go gateway's envelope is `{ "error": token }`
- * — the machine token lives in `error` (e.g. "not_owner", "invalid_input",
- * "invalid_reason"); a separate `code` field is optional and rarely sent. So
- * `code` is derived from `error` unless an explicit `code` is present, letting
- * callers branch on `status`/`code` instead of string-matching prose.
- */
-export class StoreApiError extends Error {
-  readonly status: number;
-  readonly code?: string;
-  constructor(status: number, message: string, code?: string) {
-    super(message);
-    this.name = "StoreApiError";
-    this.status = status;
-    this.code = code;
-  }
-}
-
-/**
- * Read the error envelope from a non-OK gateway response into a `StoreApiError`.
- * The machine token lives in `error`, so `code` is derived from it; an explicit
- * `code` field (rarely sent) wins when present. A non-JSON or bodyless response
- * yields a generic message keyed on the status — the failure is always
- * surfaced, never swallowed.
- */
-export async function toStoreApiError(res: Response): Promise<StoreApiError> {
-  const raw = await res.text();
-  let message = `Gateway request failed (${res.status}).`;
-  let code: string | undefined;
-  if (raw) {
-    try {
-      const body = JSON.parse(raw) as { error?: unknown; code?: unknown };
-      if (typeof body.error === "string" && body.error) {
-        message = body.error;
-        code = body.error;
-      }
-      if (typeof body.code === "string" && body.code) code = body.code;
-    } catch {
-      // Non-JSON error bodies (proxies, gateways) keep the status-based message.
-    }
-  }
-  return new StoreApiError(res.status, message, code);
 }
 
 /**

--- a/agentstore/src/lib/store-api.test.ts
+++ b/agentstore/src/lib/store-api.test.ts
@@ -1,3 +1,4 @@
+import { StoreApiError } from "@houston/agentstore-client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getAgentBySlug,
@@ -7,7 +8,6 @@ import {
   listCategories,
   recordInstall,
 } from "./store-api";
-import { StoreApiError } from "./store-api-types";
 
 /** A JSON `Response` factory. */
 function json(body: unknown, status = 200): Response {
@@ -127,8 +127,7 @@ describe("recordInstall", () => {
     expect(JSON.parse(init.body as string)).toEqual({
       target: "claude_skill_zip",
     });
-    const headers = init.headers as Record<string, string>;
-    expect(headers["x-forwarded-for"]).toBe("9.9.9.9");
+    expect(new Headers(init.headers).get("x-forwarded-for")).toBe("9.9.9.9");
     expect(new URL(calledUrl()).pathname).toBe(
       "/v1/agentstore/agents/agent-x/installs",
     );

--- a/agentstore/src/lib/store-api.ts
+++ b/agentstore/src/lib/store-api.ts
@@ -1,29 +1,30 @@
 /**
- * Server-side client for the Houston gateway's PUBLIC Agent Store API. Called
- * only from server components (home, explore, agent page, sitemap) and the two
- * server route handlers (bundle, install-instructions). Never imported by client
- * code — it reads the private `AGENTSTORE_GATEWAY_URL` and sends no credentials
- * (all routes here are public/anonymous).
+ * Server-side facade over the Agent Store SDK for the gateway's PUBLIC catalog
+ * API. Called only from server components (home, explore, agent page, sitemap)
+ * and the server route handlers (bundle, install-instructions, ir). Never
+ * imported by client code — it reads the private `AGENTSTORE_GATEWAY_URL` and
+ * sends no credentials (all routes here are public/anonymous).
  *
- * Caching is explicit per call: catalog + agent reads use `next.revalidate = 60`,
- * the category list uses a long revalidate (it is a static Go list), and the
- * install write is uncacheable. No route relies on the fetch default.
+ * This module owns only the server-specific concerns: which gateway origin to
+ * hit, and the explicit per-call `next.revalidate` caching (60s catalog + agent
+ * reads, 3600s categories; the install write is uncacheable). All HTTP and error
+ * plumbing lives in `@houston/agentstore-client`.
  *
  * SERVER ONLY: reads the private `AGENTSTORE_GATEWAY_URL` (undefined in the
  * browser) and is imported exclusively by server components + route handlers.
  */
-import type { AgentIR } from "@houston/agentstore-contract";
 import {
-  type AgentDetail,
-  type AgentSummary,
-  type CatalogPage,
-  type InstallTarget,
-  type ListAgentsParams,
-  STORE_API_PREFIX,
+  AgentStoreClient,
+  type StoreAgentDetail,
+  StoreApiError,
+  type StoreCatalogPage,
+  type StoreCatalogQuery,
   type StoreCategory,
-  serverGatewayBase,
-  toStoreApiError,
-} from "./store-api-types";
+  type StoreInstallTarget,
+  type StoreRequestOptions,
+} from "@houston/agentstore-client";
+import type { AgentIR } from "@houston/agentstore-contract";
+import { serverGatewayBase } from "./store-api-types";
 
 /** Revalidate window (seconds) for catalog + agent-page reads. */
 const CATALOG_REVALIDATE = 60;
@@ -32,46 +33,49 @@ const CATEGORIES_REVALIDATE = 3600;
 /** Hard cap on sitemap enumeration so a huge catalog cannot fan out unbounded. */
 const SITEMAP_MAX_PAGES = 50;
 
-/** Absolute URL for a store API path (already prefixed by the caller). */
-function apiUrl(path: string): string {
-  return `${serverGatewayBase()}${STORE_API_PREFIX}${path}`;
+/**
+ * A fresh SDK client bound to the private server gateway origin. Read per call
+ * so a `next build` with no env still succeeds; the base is only needed at
+ * request time.
+ */
+function client(): AgentStoreClient {
+  return new AgentStoreClient({ baseUrl: serverGatewayBase() });
 }
 
-/** GET a JSON resource with an explicit revalidate window, mapping errors. */
-async function getJson<T>(path: string, revalidate: number): Promise<T> {
-  const res = await fetch(apiUrl(path), { next: { revalidate } });
-  if (!res.ok) throw await toStoreApiError(res);
-  return (await res.json()) as T;
+/** Per-call Next caching options for a read with the given revalidate window. */
+function revalidate(seconds: number): StoreRequestOptions {
+  return { init: { next: { revalidate: seconds } } };
 }
 
-/** Encode catalog list params into a query string, dropping empty values. */
-function catalogQuery(params: ListAgentsParams): string {
-  const qs = new URLSearchParams();
-  if (params.q?.trim()) qs.set("q", params.q.trim());
-  if (params.category?.trim()) qs.set("category", params.category.trim());
-  if (params.integration?.trim())
-    qs.set("integration", params.integration.trim().toUpperCase());
-  if (params.sort === "installs") qs.set("sort", "installs");
-  if (params.page && params.page > 1) qs.set("page", String(params.page));
-  const query = qs.toString();
-  return query ? `?${query}` : "";
+/**
+ * Normalize catalog params to the gateway's expectations: UPPERCASE the
+ * integration toolkit slug, and omit the default `recent` sort so it never
+ * appears in the query string.
+ */
+function toCatalogQuery(params: StoreCatalogQuery): StoreCatalogQuery {
+  const integration = params.integration?.trim();
+  return {
+    q: params.q,
+    category: params.category,
+    integration: integration ? integration.toUpperCase() : undefined,
+    sort: params.sort === "installs" ? "installs" : undefined,
+    page: params.page,
+  };
 }
 
 /** One page of published, public agents for the browsable catalog. */
-export function listAgents(params: ListAgentsParams): Promise<CatalogPage> {
-  return getJson<CatalogPage>(
-    `/agents${catalogQuery(params)}`,
-    CATALOG_REVALIDATE,
+export function listAgents(
+  params: StoreCatalogQuery,
+): Promise<StoreCatalogPage> {
+  return client().listAgents(
+    toCatalogQuery(params),
+    revalidate(CATALOG_REVALIDATE),
   );
 }
 
 /** The controlled category vocabulary for the filter/chips rows. */
-export async function listCategories(): Promise<StoreCategory[]> {
-  const { items } = await getJson<{ items: StoreCategory[] }>(
-    "/categories",
-    CATEGORIES_REVALIDATE,
-  );
-  return items;
+export function listCategories(): Promise<StoreCategory[]> {
+  return client().listCategories(revalidate(CATEGORIES_REVALIDATE));
 }
 
 /**
@@ -81,15 +85,15 @@ export async function listCategories(): Promise<StoreCategory[]> {
  */
 export async function getAgentBySlug(
   slug: string,
-): Promise<AgentDetail | null> {
+): Promise<StoreAgentDetail | null> {
   const clean = slug.trim();
   if (!clean) return null;
-  const res = await fetch(apiUrl(`/agents/${encodeURIComponent(clean)}`), {
-    next: { revalidate: CATALOG_REVALIDATE },
-  });
-  if (res.status === 404) return null;
-  if (!res.ok) throw await toStoreApiError(res);
-  return (await res.json()) as AgentDetail;
+  try {
+    return await client().getAgent(clean, revalidate(CATALOG_REVALIDATE));
+  } catch (err) {
+    if (err instanceof StoreApiError && err.status === 404) return null;
+    throw err;
+  }
 }
 
 /**
@@ -116,23 +120,15 @@ export async function listAllPublicSlugs(): Promise<string[]> {
  */
 export async function recordInstall(
   slug: string,
-  target: InstallTarget,
+  target: StoreInstallTarget,
   opts: { clientIp?: string } = {},
 ): Promise<void> {
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-  };
+  const headers: Record<string, string> = {};
   if (opts.clientIp) headers["x-forwarded-for"] = opts.clientIp;
-  const res = await fetch(
-    apiUrl(`/agents/${encodeURIComponent(slug)}/installs`),
-    {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ target }),
-      cache: "no-store",
-    },
-  );
-  if (!res.ok) throw await toStoreApiError(res);
+  await client().recordInstall(slug, target, {
+    headers,
+    init: { cache: "no-store" },
+  });
 }
 
 /** Fetch just the IR of a published agent (thin proxy target). Null on 404. */
@@ -140,5 +136,3 @@ export async function getAgentIr(slug: string): Promise<AgentIR | null> {
   const detail = await getAgentBySlug(slug);
   return detail ? detail.ir : null;
 }
-
-export type { AgentDetail, AgentIR, AgentSummary, CatalogPage, StoreCategory };

--- a/agentstore/src/lib/store-client.test.ts
+++ b/agentstore/src/lib/store-client.test.ts
@@ -1,5 +1,5 @@
+import { StoreApiError } from "@houston/agentstore-client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { StoreApiError } from "./store-api-types";
 import {
   claimAgent,
   deleteAgent,
@@ -54,7 +54,7 @@ describe("listMyAgents", () => {
 
 describe("patchAgent", () => {
   it("PATCHes the intent with a JSON content-type", async () => {
-    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    fetchMock.mockResolvedValue(json({ agent: { id: "id-1" } }));
     await patchAgent("t", "id-1", { publish: true });
     expect(lastInit().method).toBe("PATCH");
     expect(lastHeaders().get("content-type")).toBe("application/json");

--- a/agentstore/src/lib/store-client.ts
+++ b/agentstore/src/lib/store-client.ts
@@ -1,123 +1,73 @@
 /**
- * Client-side gateway calls that carry a user bearer or are anonymous mutations.
- * Runs in the browser (client components only): server components never see a
- * token. Reads the build-time-inlined `NEXT_PUBLIC_AGENTSTORE_GATEWAY_URL`, so
- * these requests are cross-origin to the gateway and rely on the gateway's CORS
- * grant for the store origin.
+ * Client-side facade over the Agent Store SDK for calls that carry a user bearer
+ * or are anonymous mutations. Runs in the browser (client components only):
+ * server components never see a token. Reads the build-time-inlined
+ * `NEXT_PUBLIC_AGENTSTORE_GATEWAY_URL`, so these requests are cross-origin to the
+ * gateway and rely on the gateway's CORS grant for the store origin.
  *
- * Every call maps a non-OK response to `StoreApiError` (status + `code`) so UIs
- * branch on the code, and no failure is swallowed.
+ * This module owns only the browser-specific concerns: the public gateway
+ * origin, wrapping the caller's freshly-minted bearer into the SDK's `getToken`,
+ * and forcing `cache: "no-store"` on the authed reads. All HTTP and error
+ * plumbing — including the `StoreApiError` every UI branches on — lives in
+ * `@houston/agentstore-client`.
  */
 import {
-  type AgentSummary,
-  type CatalogPage,
-  clientGatewayBase,
-  STORE_API_PREFIX,
-  toStoreApiError,
-} from "./store-api-types";
+  type AgentPatch,
+  AgentStoreClient,
+  type ClaimInput,
+  type ClaimResult,
+  type ReportInput,
+  type StoreAgentSummary,
+  type StoreRequestOptions,
+} from "@houston/agentstore-client";
+import { clientGatewayBase } from "./store-api-types";
 
-export { StoreApiError } from "./store-api-types";
-export type { AgentSummary };
+/** Authed calls must never be served from the browser HTTP cache. */
+const NO_STORE: StoreRequestOptions = { init: { cache: "no-store" } };
 
-/** Absolute gateway URL for a store API path. */
-function url(path: string): string {
-  return `${clientGatewayBase()}${STORE_API_PREFIX}${path}`;
+/** An SDK client that authorizes every call with the caller's bearer. */
+function authed(token: string): AgentStoreClient {
+  return new AgentStoreClient({
+    baseUrl: clientGatewayBase(),
+    getToken: () => token,
+  });
 }
 
-/** Fetch with a bearer token, JSON content-type for bodied calls, no caching. */
-async function authed(
-  token: string,
-  path: string,
-  init?: RequestInit,
-): Promise<Response> {
-  const headers = new Headers(init?.headers);
-  headers.set("authorization", `Bearer ${token}`);
-  if (init?.body) headers.set("content-type", "application/json");
-  const res = await fetch(url(path), { ...init, headers, cache: "no-store" });
-  if (!res.ok) throw await toStoreApiError(res);
-  return res;
+/** An SDK client for anonymous mutations (no bearer). */
+function anon(): AgentStoreClient {
+  return new AgentStoreClient({ baseUrl: clientGatewayBase() });
 }
 
 /** The caller's agents in every state (`GET /me/agents`). */
-export async function listMyAgents(token: string): Promise<AgentSummary[]> {
-  const res = await authed(token, "/me/agents");
-  const body = (await res.json()) as { items: AgentSummary[] };
-  return body.items;
-}
-
-/** Result of claiming an unclaimed agent. */
-export interface ClaimResult {
-  agentId: string;
-  slug?: string;
+export function listMyAgents(token: string): Promise<StoreAgentSummary[]> {
+  return authed(token).listMyAgents(NO_STORE);
 }
 
 /** Claim an unclaimed agent with the code from the claim link (`POST /claim`). */
-export async function claimAgent(
+export function claimAgent(
   token: string,
-  input: { agentId: string; code: string },
+  input: ClaimInput,
 ): Promise<ClaimResult> {
-  const res = await authed(token, "/claim", {
-    method: "POST",
-    body: JSON.stringify(input),
-  });
-  return (await res.json()) as ClaimResult;
-}
-
-/** The mutations `PATCH /agents/{id}` accepts. Exactly one intent per call. */
-export type AgentPatch =
-  | { identity: AgentIdentityPatch }
-  | { publish: true }
-  | { unpublish: true }
-  | { visibility: "unlisted" }
-  | { requestPublic: true };
-
-/** The editable identity fields on a `PATCH … {identity}` call. */
-export interface AgentIdentityPatch {
-  name?: string;
-  tagline?: string;
-  description?: string;
-  category?: string;
-  tags?: string[];
-  creator?: { displayName: string; url?: string };
+  return authed(token).claimAgent(input, NO_STORE);
 }
 
 /**
- * Apply a patch to an owned agent. Returns nothing: the gateway's PATCH response
- * body is not part of the pinned contract, so callers re-read `listMyAgents`
- * after a successful mutation rather than trusting a response shape. A failure
- * (403 not_owner, 409 version_conflict, …) throws `StoreApiError`.
+ * Apply a patch to an owned agent. Returns nothing: callers re-read
+ * `listMyAgents` after a successful mutation rather than trusting the PATCH
+ * response shape. A failure (403 not_owner, 409 version_conflict, …) throws
+ * `StoreApiError`.
  */
 export async function patchAgent(
   token: string,
   id: string,
   patch: AgentPatch,
 ): Promise<void> {
-  await authed(token, `/agents/${encodeURIComponent(id)}`, {
-    method: "PATCH",
-    body: JSON.stringify(patch),
-  });
+  await authed(token).patchAgent(id, patch, NO_STORE);
 }
 
 /** Soft-delete an owned agent (`DELETE /agents/{id}`). */
 export async function deleteAgent(token: string, id: string): Promise<void> {
-  await authed(token, `/agents/${encodeURIComponent(id)}`, {
-    method: "DELETE",
-  });
-}
-
-/** The moderation reasons accepted by `POST /agents/{slug}/reports`. */
-export type ReportReason =
-  | "spam"
-  | "malicious"
-  | "impersonation"
-  | "inappropriate"
-  | "other";
-
-/** An abuse report body. `details`/`contact` are optional free text. */
-export interface ReportInput {
-  reason: ReportReason;
-  details?: string;
-  contact?: string;
+  await authed(token).deleteAgent(id, NO_STORE);
 }
 
 /** File an anonymous abuse report against a published agent. */
@@ -125,13 +75,5 @@ export async function reportAgent(
   slug: string,
   input: ReportInput,
 ): Promise<void> {
-  const res = await fetch(url(`/agents/${encodeURIComponent(slug)}/reports`), {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(input),
-  });
-  if (!res.ok) throw await toStoreApiError(res);
+  await anon().reportAgent(slug, input);
 }
-
-/** Re-export the catalog page type for parity with server reads. */
-export type { CatalogPage };

--- a/knowledge-base/agent-store.md
+++ b/knowledge-base/agent-store.md
@@ -27,9 +27,7 @@ The authoritative wire/DB surface is the gateway's contract
 | App UI (browse) | `app/src/components/store-view/` | The in-app Agent Store page (sidebar + ⌘K destination, view id `agent-store`): catalog-family rows over the public API, category chips + search + sort, detail modal, one-click install. |
 
 The tie to `cloud/` is the gateway API + a shared Firebase project; the AgentIR
-contract is a byte-copy relationship, not a runtime import. (The standalone
-`gethouston/theagentlibrary` repo was retired in July 2026 — this store
-supersedes it; they never shared code.)
+contract is a byte-copy relationship, not a runtime import.
 
 ## AgentIR 2.0.0 (the schema of record)
 

--- a/packages/agentstore-client/package.json
+++ b/packages/agentstore-client/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@houston/agentstore-client",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "build": "tsgo -p tsconfig.json",
+    "test": "vitest run",
+    "typecheck": "tsgo -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@houston/agentstore-contract": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "22.20.0",
+    "@typescript/native-preview": "7.0.0-dev.20260607.1",
+    "typescript": "6.0.3",
+    "vitest": "3.2.6"
+  }
+}

--- a/packages/agentstore-client/src/client.test.ts
+++ b/packages/agentstore-client/src/client.test.ts
@@ -1,0 +1,408 @@
+import { describe, expect, it } from "vitest";
+import { AgentStoreClient, STORE_API_PREFIX } from "./client";
+import { StoreApiError } from "./errors";
+
+const BASE = "https://gw.example.com";
+
+interface RecordedCall {
+  url: string;
+  init: RequestInit;
+}
+
+/**
+ * A fetch stub that records every call and returns a queued Response (or the
+ * single default). `bodyOf`/`headersOf` read back what the client sent.
+ */
+function stubFetch(responses: Response | Response[]): {
+  fetchImpl: typeof fetch;
+  calls: RecordedCall[];
+} {
+  const queue = Array.isArray(responses) ? [...responses] : [responses];
+  const calls: RecordedCall[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), init: init ?? {} });
+    const next = queue.length > 1 ? queue.shift() : queue[0];
+    return next as Response;
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+/** A throwing fetch, to exercise the network-failure path. */
+function rejectingFetch(err: unknown): typeof fetch {
+  return (async () => {
+    throw err;
+  }) as unknown as typeof fetch;
+}
+
+function jsonRes(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function textRes(text: string, status: number): Response {
+  return new Response(text, {
+    status,
+    headers: { "content-type": "text/plain" },
+  });
+}
+
+function headersOf(call: RecordedCall): Headers {
+  return new Headers(call.init.headers);
+}
+
+function client(
+  fetchImpl: typeof fetch,
+  getToken?: () => string | null,
+): AgentStoreClient {
+  return new AgentStoreClient({ baseUrl: BASE, fetchImpl, getToken });
+}
+
+describe("AgentStoreClient — URL and query construction", () => {
+  it("prefixes the store API path and trims a trailing slash from baseUrl", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonRes({ items: [], hasMore: false }),
+    );
+    const c = new AgentStoreClient({ baseUrl: `${BASE}///`, fetchImpl });
+    await c.listAgents();
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/agents`);
+  });
+
+  it("encodes catalog query params and omits empty/absent ones", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonRes({ items: [], hasMore: false }),
+    );
+    await client(fetchImpl).listAgents({
+      q: "  inbox triage  ",
+      category: "productivity",
+      integration: "GMAIL",
+      sort: "installs",
+      page: 3,
+    });
+    const url = new URL(calls[0].url);
+    expect(url.pathname).toBe(`${STORE_API_PREFIX}/agents`);
+    expect(url.searchParams.get("q")).toBe("inbox triage");
+    expect(url.searchParams.get("category")).toBe("productivity");
+    expect(url.searchParams.get("integration")).toBe("GMAIL");
+    expect(url.searchParams.get("sort")).toBe("installs");
+    expect(url.searchParams.get("page")).toBe("3");
+  });
+
+  it("omits page=1 and blank filters", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonRes({ items: [], hasMore: false }),
+    );
+    await client(fetchImpl).listAgents({ q: "   ", page: 1 });
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/agents`);
+  });
+
+  it("percent-encodes path segments", async () => {
+    const { fetchImpl, calls } = stubFetch(jsonRes({ agent: {}, ir: {} }));
+    await client(fetchImpl).getAgent("a/b c");
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/agents/a%2Fb%20c`);
+  });
+});
+
+describe("AgentStoreClient — bearer injection", () => {
+  it("attaches Authorization from a sync getToken on authed calls", async () => {
+    const { fetchImpl, calls } = stubFetch(jsonRes({ items: [] }));
+    await client(fetchImpl, () => "tok-123").listMyAgents();
+    expect(headersOf(calls[0]).get("authorization")).toBe("Bearer tok-123");
+  });
+
+  it("awaits an async getToken", async () => {
+    const { fetchImpl, calls } = stubFetch(jsonRes({ items: [] }));
+    const c = new AgentStoreClient({
+      baseUrl: BASE,
+      fetchImpl,
+      getToken: async () => "async-tok",
+    });
+    await c.listMyAgents();
+    expect(headersOf(calls[0]).get("authorization")).toBe("Bearer async-tok");
+  });
+
+  it("throws a 401-shaped StoreApiError when getToken yields null, before fetching", async () => {
+    const { fetchImpl, calls } = stubFetch(jsonRes({ items: [] }));
+    await expect(
+      client(fetchImpl, () => null).listMyAgents(),
+    ).rejects.toMatchObject({
+      status: 401,
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws 401 when no getToken is configured at all", async () => {
+    const { fetchImpl } = stubFetch(jsonRes({ items: [] }));
+    await expect(client(fetchImpl).listMyAgents()).rejects.toBeInstanceOf(
+      StoreApiError,
+    );
+  });
+
+  it("does not attach Authorization on anonymous calls", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonRes({ items: [], hasMore: false }),
+    );
+    await client(fetchImpl, () => "tok").listAgents();
+    expect(headersOf(calls[0]).has("authorization")).toBe(false);
+  });
+});
+
+describe("AgentStoreClient — per-call init/header merge", () => {
+  it("shallow-merges init (e.g. Next revalidate) into the fetch call", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonRes({ items: [], hasMore: false }),
+    );
+    await client(fetchImpl).listAgents({}, { init: { cache: "no-store" } });
+    expect(calls[0].init.cache).toBe("no-store");
+    expect(calls[0].init.method).toBe("GET");
+  });
+
+  it("merges convenience headers on top of computed headers", async () => {
+    const { fetchImpl, calls } = stubFetch(new Response(null, { status: 204 }));
+    await client(fetchImpl).recordInstall("slug", "houston", {
+      headers: { "x-forwarded-for": "1.2.3.4" },
+    });
+    const h = headersOf(calls[0]);
+    expect(h.get("x-forwarded-for")).toBe("1.2.3.4");
+    expect(h.get("content-type")).toBe("application/json");
+  });
+
+  it("lets init.headers win over both computed and convenience headers", async () => {
+    const { fetchImpl, calls } = stubFetch(new Response(null, { status: 204 }));
+    await client(fetchImpl).recordInstall("slug", "houston", {
+      headers: { "x-trace": "conv" },
+      init: { headers: { "x-trace": "init" } },
+    });
+    expect(headersOf(calls[0]).get("x-trace")).toBe("init");
+  });
+});
+
+describe("AgentStoreClient — error mapping", () => {
+  it("maps a JSON {error} envelope to status + code + message", async () => {
+    const { fetchImpl } = stubFetch(jsonRes({ error: "not_owner" }, 403));
+    const err = await client(fetchImpl, () => "t")
+      .deleteAgent("id")
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(StoreApiError);
+    expect(err.status).toBe(403);
+    expect(err.code).toBe("not_owner");
+    expect(err.message).toBe("not_owner");
+    expect(err.body).toEqual({ error: "not_owner" });
+  });
+
+  it("prefers an explicit code field over the error token", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonRes({ error: "bad", code: "version_conflict" }, 409),
+    );
+    const err = await client(fetchImpl)
+      .getAgent("s")
+      .catch((e) => e);
+    expect(err.code).toBe("version_conflict");
+  });
+
+  it("keeps raw text as body and a status message on a non-JSON error", async () => {
+    const { fetchImpl } = stubFetch(textRes("Bad Gateway", 502));
+    const err = await client(fetchImpl)
+      .getAgent("s")
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(StoreApiError);
+    expect(err.status).toBe(502);
+    expect(err.code).toBeNull();
+    expect(err.body).toBe("Bad Gateway");
+    expect(err.message).toBe("Gateway request failed (502).");
+  });
+
+  it("maps a network rejection to status 0 with the cause on body", async () => {
+    const cause = new TypeError("Failed to fetch");
+    const err = await client(rejectingFetch(cause))
+      .getAgent("s")
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(StoreApiError);
+    expect(err.status).toBe(0);
+    expect(err.body).toBe(cause);
+    expect(err.message).toBe("Failed to fetch");
+  });
+
+  it("throws StoreApiError when a 2xx body is not valid JSON", async () => {
+    const { fetchImpl } = stubFetch(textRes("not json", 200));
+    const err = await client(fetchImpl)
+      .getAgent("s")
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(StoreApiError);
+    expect(err.status).toBe(200);
+    expect(err.code).toBeNull();
+  });
+});
+
+describe("AgentStoreClient — method path + verb coverage", () => {
+  const token = () => "tok";
+
+  it("listAgents → GET /agents", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonRes({ items: [{ id: "1" }], hasMore: true }),
+    );
+    const page = await client(fetchImpl).listAgents();
+    expect(page).toEqual({ items: [{ id: "1" }], hasMore: true });
+    expect(calls[0].init.method).toBe("GET");
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/agents`);
+  });
+
+  it("getAgent → GET /agents/{slug}", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonRes({ agent: { id: "1" }, ir: { irVersion: "2.0.0" } }),
+    );
+    const detail = await client(fetchImpl).getAgent("cool-agent");
+    expect(detail.agent.id).toBe("1");
+    expect(calls[0].init.method).toBe("GET");
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/agents/cool-agent`);
+  });
+
+  it("listCategories → GET /categories, unwrapping items", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonRes({ items: [{ slug: "x", name: "X" }] }),
+    );
+    const cats = await client(fetchImpl).listCategories();
+    expect(cats).toEqual([{ slug: "x", name: "X" }]);
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/categories`);
+  });
+
+  it("recordInstall → POST /agents/{slug}/installs with the target body", async () => {
+    const { fetchImpl, calls } = stubFetch(new Response(null, { status: 204 }));
+    await client(fetchImpl).recordInstall("s", "claude_skill_zip");
+    expect(calls[0].init.method).toBe("POST");
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/agents/s/installs`);
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({
+      target: "claude_skill_zip",
+    });
+  });
+
+  it("reportAgent → POST /agents/{slug}/reports with the report body", async () => {
+    const { fetchImpl, calls } = stubFetch(new Response(null, { status: 201 }));
+    await client(fetchImpl).reportAgent("s", { reason: "spam", details: "d" });
+    expect(calls[0].init.method).toBe("POST");
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/agents/s/reports`);
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({
+      reason: "spam",
+      details: "d",
+    });
+  });
+
+  it("listMyAgents → GET /me/agents, unwrapping items", async () => {
+    const { fetchImpl, calls } = stubFetch(jsonRes({ items: [{ id: "1" }] }));
+    const mine = await client(fetchImpl, token).listMyAgents();
+    expect(mine).toEqual([{ id: "1" }]);
+    expect(calls[0].init.method).toBe("GET");
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/me/agents`);
+  });
+
+  it("createAgent → POST /agents with the publish body", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonRes({ agentId: "a1", slug: "s1", shareUrl: "https://x/a/s1" }, 201),
+    );
+    const res = await client(fetchImpl, token).createAgent({
+      ir: { irVersion: "2.0.0" } as never,
+      publish: true,
+    });
+    expect(res).toEqual({
+      agentId: "a1",
+      slug: "s1",
+      shareUrl: "https://x/a/s1",
+    });
+    expect(calls[0].init.method).toBe("POST");
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/agents`);
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({
+      ir: { irVersion: "2.0.0" },
+      publish: true,
+    });
+  });
+
+  it("patchAgent → PATCH /agents/{id} returning the agent", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonRes({ agent: { id: "a1", state: "published" } }),
+    );
+    const res = await client(fetchImpl, token).patchAgent("a1", {
+      publish: true,
+    });
+    expect(res.agent.state).toBe("published");
+    expect(calls[0].init.method).toBe("PATCH");
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/agents/a1`);
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ publish: true });
+  });
+
+  it("deleteAgent → DELETE /agents/{id}", async () => {
+    const { fetchImpl, calls } = stubFetch(new Response(null, { status: 204 }));
+    await client(fetchImpl, token).deleteAgent("a1");
+    expect(calls[0].init.method).toBe("DELETE");
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/agents/a1`);
+  });
+
+  it("claimAgent → POST /claim with the claim body", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonRes({ agentId: "a1", slug: "s1" }),
+    );
+    const res = await client(fetchImpl, token).claimAgent({
+      agentId: "a1",
+      code: "c",
+    });
+    expect(res).toEqual({ agentId: "a1", slug: "s1" });
+    expect(calls[0].init.method).toBe("POST");
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/claim`);
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({
+      agentId: "a1",
+      code: "c",
+    });
+  });
+
+  it("adminListQueue → GET /admin/queue, unwrapping items", async () => {
+    const { fetchImpl, calls } = stubFetch(jsonRes({ items: [{ id: "q1" }] }));
+    const queue = await client(fetchImpl, token).adminListQueue();
+    expect(queue).toEqual([{ id: "q1" }]);
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/admin/queue`);
+  });
+
+  it("adminActOnQueueItem → POST /admin/queue/{id} with the action", async () => {
+    const { fetchImpl, calls } = stubFetch(jsonRes({ ok: true }));
+    await client(fetchImpl, token).adminActOnQueueItem("q1", "approve");
+    expect(calls[0].init.method).toBe("POST");
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/admin/queue/q1`);
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({
+      action: "approve",
+    });
+  });
+
+  it("adminListReports → GET /admin/reports?status= when filtered", async () => {
+    const { fetchImpl, calls } = stubFetch(jsonRes({ items: [{ id: "r1" }] }));
+    const reports = await client(fetchImpl, token).adminListReports("open");
+    expect(reports).toEqual([{ id: "r1" }]);
+    expect(calls[0].url).toBe(
+      `${BASE}${STORE_API_PREFIX}/admin/reports?status=open`,
+    );
+  });
+
+  it("adminListReports → GET /admin/reports with no query when unfiltered", async () => {
+    const { fetchImpl, calls } = stubFetch(jsonRes({ items: [] }));
+    await client(fetchImpl, token).adminListReports();
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/admin/reports`);
+  });
+
+  it("adminActOnReport → POST /admin/reports/{id} with the action", async () => {
+    const { fetchImpl, calls } = stubFetch(jsonRes({ ok: true }));
+    await client(fetchImpl, token).adminActOnReport("r1", "dismiss");
+    expect(calls[0].init.method).toBe("POST");
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/admin/reports/r1`);
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({
+      action: "dismiss",
+    });
+  });
+
+  it("adminPurge → POST /admin/purge returning the counts", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonRes({ draftsDeleted: 2, softDeletedPurged: 5 }),
+    );
+    const res = await client(fetchImpl, token).adminPurge();
+    expect(res).toEqual({ draftsDeleted: 2, softDeletedPurged: 5 });
+    expect(calls[0].init.method).toBe("POST");
+    expect(calls[0].url).toBe(`${BASE}${STORE_API_PREFIX}/admin/purge`);
+  });
+});

--- a/packages/agentstore-client/src/client.ts
+++ b/packages/agentstore-client/src/client.ts
@@ -1,0 +1,386 @@
+/**
+ * The single HTTP client for the Houston gateway's Agent Store REST API,
+ * mounted under `/v1/agentstore`. It replaces the hand-rolled `fetch` code in
+ * `agentstore/src/lib/store-*.ts`, `ui/engine-client/src/store-catalog.ts`, and
+ * `packages/web/src/engine-adapter/portable-store.ts`.
+ *
+ * The client is isomorphic: it reads no environment and touches no `window`,
+ * `document`, or Node built-in. Consumer-specific concerns (which gateway origin
+ * to hit, Next.js `next.revalidate` caching, forwarded XFF headers) are injected
+ * per call — `baseUrl` at construction, and `StoreRequestOptions.init`/`headers`
+ * on every method.
+ */
+import { StoreApiError } from "./errors.ts";
+import type {
+  AdminQueueItem,
+  AdminReport,
+  AgentPatch,
+  ClaimInput,
+  ClaimResult,
+  CreateAgentRequest,
+  CreateAgentResponse,
+  MyAgent,
+  PatchAgentResponse,
+  PurgeResult,
+  ReportInput,
+  ReportStatus,
+  StoreAgentDetail,
+  StoreCatalogPage,
+  StoreCatalogQuery,
+  StoreCategory,
+  StoreInstallTarget,
+} from "./types.ts";
+
+/** The Agent Store API path prefix on the gateway. */
+export const STORE_API_PREFIX = "/v1/agentstore";
+
+/** Construction options for {@link AgentStoreClient}. */
+export interface StoreClientOptions {
+  /** The gateway origin (e.g. `https://gateway.gethouston.ai`); path prefix is added. */
+  baseUrl: string;
+  /** Fetch implementation to use; defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+  /**
+   * Supplies the bearer token for authenticated calls. Returning `null` (or the
+   * option being absent) makes every authed method throw a 401-shaped
+   * {@link StoreApiError} before any request is sent.
+   */
+  getToken?: () => string | null | Promise<string | null>;
+}
+
+/**
+ * Per-call request options, the trailing optional argument on every method.
+ * `init` is shallow-merged into the underlying `fetch` call (letting Next.js
+ * callers pass `{ next: { revalidate } }` and server callers forward XFF via a
+ * `signal`/`cache`), while `headers` is a convenience map merged on top of the
+ * client-computed headers; `init.headers`, when present, wins over both.
+ */
+export interface StoreRequestOptions {
+  init?: RequestInit;
+  headers?: Record<string, string>;
+}
+
+/** Internal shape describing one outgoing request. */
+interface SendSpec {
+  query?: URLSearchParams;
+  body?: unknown;
+  auth?: boolean;
+  options?: StoreRequestOptions;
+}
+
+export class AgentStoreClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly getToken?: () => string | null | Promise<string | null>;
+
+  constructor(options: StoreClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.getToken = options.getToken;
+  }
+
+  // ── Anonymous ─────────────────────────────────────────────────────────────
+
+  /** One page of published, public agents for the browsable catalog. */
+  listAgents(
+    query: StoreCatalogQuery = {},
+    options?: StoreRequestOptions,
+  ): Promise<StoreCatalogPage> {
+    return this.requestJson<StoreCatalogPage>("GET", "/agents", {
+      query: catalogQuery(query),
+      options,
+    });
+  }
+
+  /** A published agent by slug, with its full IR snapshot. */
+  getAgent(
+    slug: string,
+    options?: StoreRequestOptions,
+  ): Promise<StoreAgentDetail> {
+    return this.requestJson<StoreAgentDetail>(
+      "GET",
+      `/agents/${encodeURIComponent(slug)}`,
+      { options },
+    );
+  }
+
+  /** The controlled category vocabulary for the filter chips. */
+  async listCategories(
+    options?: StoreRequestOptions,
+  ): Promise<StoreCategory[]> {
+    const body = await this.requestJson<{ items: StoreCategory[] }>(
+      "GET",
+      "/categories",
+      { options },
+    );
+    return body.items;
+  }
+
+  /** Record an anonymous install of a published agent. */
+  async recordInstall(
+    slug: string,
+    target: StoreInstallTarget,
+    options?: StoreRequestOptions,
+  ): Promise<void> {
+    await this.send("POST", `/agents/${encodeURIComponent(slug)}/installs`, {
+      body: { target },
+      options,
+    });
+  }
+
+  /** File an anonymous abuse report against a published agent. */
+  async reportAgent(
+    slug: string,
+    input: ReportInput,
+    options?: StoreRequestOptions,
+  ): Promise<void> {
+    await this.send("POST", `/agents/${encodeURIComponent(slug)}/reports`, {
+      body: input,
+      options,
+    });
+  }
+
+  // ── Authenticated ─────────────────────────────────────────────────────────
+
+  /** The caller's agents in every lifecycle state (`GET /me/agents`). */
+  async listMyAgents(options?: StoreRequestOptions): Promise<MyAgent[]> {
+    const body = await this.requestJson<{ items: MyAgent[] }>(
+      "GET",
+      "/me/agents",
+      {
+        auth: true,
+        options,
+      },
+    );
+    return body.items;
+  }
+
+  /** Create (and optionally publish) an owned agent (`POST /agents`). */
+  createAgent(
+    body: CreateAgentRequest,
+    options?: StoreRequestOptions,
+  ): Promise<CreateAgentResponse> {
+    return this.requestJson<CreateAgentResponse>("POST", "/agents", {
+      auth: true,
+      body,
+      options,
+    });
+  }
+
+  /** Apply one edit intent to an owned agent (`PATCH /agents/{id}`). */
+  patchAgent(
+    id: string,
+    patch: AgentPatch,
+    options?: StoreRequestOptions,
+  ): Promise<PatchAgentResponse> {
+    return this.requestJson<PatchAgentResponse>(
+      "PATCH",
+      `/agents/${encodeURIComponent(id)}`,
+      { auth: true, body: patch, options },
+    );
+  }
+
+  /** Soft-delete an owned agent (`DELETE /agents/{id}`). */
+  async deleteAgent(id: string, options?: StoreRequestOptions): Promise<void> {
+    await this.send("DELETE", `/agents/${encodeURIComponent(id)}`, {
+      auth: true,
+      options,
+    });
+  }
+
+  /** Claim an unclaimed agent with the code from the claim link (`POST /claim`). */
+  claimAgent(
+    input: ClaimInput,
+    options?: StoreRequestOptions,
+  ): Promise<ClaimResult> {
+    return this.requestJson<ClaimResult>("POST", "/claim", {
+      auth: true,
+      body: input,
+      options,
+    });
+  }
+
+  // ── Admin ─────────────────────────────────────────────────────────────────
+
+  /** The public-visibility review queue (`GET /admin/queue`). */
+  async adminListQueue(
+    options?: StoreRequestOptions,
+  ): Promise<AdminQueueItem[]> {
+    const body = await this.requestJson<{ items: AdminQueueItem[] }>(
+      "GET",
+      "/admin/queue",
+      { auth: true, options },
+    );
+    return body.items;
+  }
+
+  /** Approve (make public) or reject a queued agent (`POST /admin/queue/{id}`). */
+  async adminActOnQueueItem(
+    id: string,
+    action: "approve" | "reject",
+    options?: StoreRequestOptions,
+  ): Promise<void> {
+    await this.send("POST", `/admin/queue/${encodeURIComponent(id)}`, {
+      auth: true,
+      body: { action },
+      options,
+    });
+  }
+
+  /** The abuse reports, optionally filtered by status (`GET /admin/reports`). */
+  async adminListReports(
+    status?: ReportStatus,
+    options?: StoreRequestOptions,
+  ): Promise<AdminReport[]> {
+    const query = new URLSearchParams();
+    if (status) query.set("status", status);
+    const body = await this.requestJson<{ items: AdminReport[] }>(
+      "GET",
+      "/admin/reports",
+      { auth: true, query, options },
+    );
+    return body.items;
+  }
+
+  /** Resolve or dismiss a report (`POST /admin/reports/{id}`). */
+  async adminActOnReport(
+    id: string,
+    action: "resolve" | "dismiss",
+    options?: StoreRequestOptions,
+  ): Promise<void> {
+    await this.send("POST", `/admin/reports/${encodeURIComponent(id)}`, {
+      auth: true,
+      body: { action },
+      options,
+    });
+  }
+
+  /** Run the retention purge of stale drafts and expired soft-deletes. */
+  adminPurge(options?: StoreRequestOptions): Promise<PurgeResult> {
+    return this.requestJson<PurgeResult>("POST", "/admin/purge", {
+      auth: true,
+      options,
+    });
+  }
+
+  // ── Internals ─────────────────────────────────────────────────────────────
+
+  /** Absolute URL for a store API path, with the query string appended. */
+  private url(path: string, query?: URLSearchParams): string {
+    const qs = query?.toString();
+    return `${this.baseUrl}${STORE_API_PREFIX}${path}${qs ? `?${qs}` : ""}`;
+  }
+
+  /** Resolve the `Authorization` header value, throwing 401-shaped when absent. */
+  private async authorization(): Promise<string> {
+    const token = this.getToken ? await this.getToken() : null;
+    if (!token) {
+      throw new StoreApiError(401, "authentication required", null, null);
+    }
+    return `Bearer ${token}`;
+  }
+
+  /** Issue a request, mapping every failure to a {@link StoreApiError}. */
+  private async send(
+    method: string,
+    path: string,
+    spec: SendSpec,
+  ): Promise<Response> {
+    const headers = new Headers();
+    let body: string | undefined;
+    if (spec.body !== undefined) {
+      headers.set("content-type", "application/json");
+      body = JSON.stringify(spec.body);
+    }
+    if (spec.auth) headers.set("authorization", await this.authorization());
+    if (spec.options?.headers) {
+      for (const [key, value] of Object.entries(spec.options.headers)) {
+        headers.set(key, value);
+      }
+    }
+    if (spec.options?.init?.headers) {
+      new Headers(spec.options.init.headers).forEach((value, key) => {
+        headers.set(key, value);
+      });
+    }
+
+    const url = this.url(path, spec.query);
+    const doFetch = this.fetchImpl;
+    let res: Response;
+    try {
+      res = await doFetch(url, {
+        ...spec.options?.init,
+        method,
+        headers,
+        ...(body !== undefined ? { body } : {}),
+      });
+    } catch (err) {
+      throw new StoreApiError(
+        0,
+        err instanceof Error ? err.message : "network request failed",
+        null,
+        err,
+      );
+    }
+    if (!res.ok) throw await toStoreApiError(res);
+    return res;
+  }
+
+  /** Issue a request and parse a JSON body, mapping a parse failure to an error. */
+  private async requestJson<T>(
+    method: string,
+    path: string,
+    spec: SendSpec,
+  ): Promise<T> {
+    const res = await this.send(method, path, spec);
+    const raw = await res.text();
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      throw new StoreApiError(
+        res.status,
+        "invalid JSON in gateway response",
+        null,
+        raw,
+      );
+    }
+  }
+}
+
+/** Encode catalog list params into a query string, dropping empty values. */
+function catalogQuery(query: StoreCatalogQuery): URLSearchParams {
+  const params = new URLSearchParams();
+  if (query.q?.trim()) params.set("q", query.q.trim());
+  if (query.category?.trim()) params.set("category", query.category.trim());
+  if (query.integration?.trim())
+    params.set("integration", query.integration.trim());
+  if (query.sort) params.set("sort", query.sort);
+  if (query.page && query.page > 1) params.set("page", String(query.page));
+  return params;
+}
+
+/** Read a non-OK gateway response into a {@link StoreApiError}. */
+async function toStoreApiError(res: Response): Promise<StoreApiError> {
+  const raw = await res.text().catch(() => "");
+  let message = `Gateway request failed (${res.status}).`;
+  let code: string | null = null;
+  let body: unknown = raw;
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      body = parsed;
+      if (parsed && typeof parsed === "object") {
+        const envelope = parsed as { error?: unknown; code?: unknown };
+        if (typeof envelope.error === "string" && envelope.error) {
+          message = envelope.error;
+          code = envelope.error;
+        }
+        if (typeof envelope.code === "string" && envelope.code)
+          code = envelope.code;
+      }
+    } catch {
+      // Non-JSON error bodies keep the status-based message and raw text body.
+    }
+  }
+  return new StoreApiError(res.status, message, code, body);
+}

--- a/packages/agentstore-client/src/errors.ts
+++ b/packages/agentstore-client/src/errors.ts
@@ -1,0 +1,34 @@
+/**
+ * The single error class the Agent Store SDK throws. Every consumer imports it
+ * from this one module so `err instanceof StoreApiError` holds across bundles
+ * (identity diverges the moment the class is duplicated). It carries the machine
+ * fields a UI branches on — the HTTP `status`, the gateway `{error}` `code` token
+ * when present, and the raw parsed `body` — so callers never string-match prose.
+ */
+export class StoreApiError extends Error {
+  /** The HTTP status of the failed response; `0` marks a network-level failure. */
+  readonly status: number;
+  /**
+   * The gateway's machine token, taken from the `{error}` (or explicit `code`)
+   * field of a JSON error envelope; `null` when the body carried no such token.
+   */
+  readonly code: string | null;
+  /**
+   * The response payload as observed: the parsed JSON object when the body was
+   * JSON, the raw text otherwise, or the thrown error on a network failure.
+   */
+  readonly body: unknown;
+
+  constructor(
+    status: number,
+    message: string,
+    code: string | null,
+    body: unknown,
+  ) {
+    super(message);
+    this.name = "StoreApiError";
+    this.status = status;
+    this.code = code;
+    this.body = body;
+  }
+}

--- a/packages/agentstore-client/src/index.ts
+++ b/packages/agentstore-client/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * @houston/agentstore-client — the single, isomorphic HTTP client for the
+ * Houston gateway's Agent Store REST API (`/v1/agentstore`). It carries the
+ * unified wire types (reconciled against the authoritative Go handlers), the one
+ * {@link StoreApiError} class every consumer branches on, and the
+ * {@link AgentStoreClient} that all three consumers (the Next.js catalog, the
+ * desktop/web engine client, and the publish adapter) call through. No
+ * environment reads, no `window`/Node built-ins — consumer-specific origin and
+ * caching are injected per call.
+ */
+
+export type { StoreClientOptions, StoreRequestOptions } from "./client.ts";
+export { AgentStoreClient, STORE_API_PREFIX } from "./client.ts";
+export { StoreApiError } from "./errors.ts";
+export type {
+  AdminQueueItem,
+  AdminReport,
+  AgentIdentityPatch,
+  AgentPatch,
+  AgentState,
+  AgentVisibility,
+  ClaimInput,
+  ClaimResult,
+  CreateAgentRequest,
+  CreateAgentResponse,
+  MyAgent,
+  PatchAgentResponse,
+  PurgeResult,
+  ReportInput,
+  ReportReason,
+  ReportStatus,
+  StoreAgentDetail,
+  StoreAgentSummary,
+  StoreCatalogPage,
+  StoreCatalogQuery,
+  StoreCatalogSort,
+  StoreCategory,
+  StoreCreator,
+  StoreIcon,
+  StoreInstallTarget,
+} from "./types.ts";

--- a/packages/agentstore-client/src/types.ts
+++ b/packages/agentstore-client/src/types.ts
@@ -1,0 +1,209 @@
+/**
+ * The wire types for the Houston gateway's Agent Store REST API
+ * (`/v1/agentstore/*`). These are reconciled against the authoritative Go
+ * handlers (`cloud/internal/edge/agentstoreroutes` + `cloud/internal/agentstore`)
+ * and unify the previously divergent shapes carried by the Next.js frontend
+ * (`agentstore/src/lib/*`) and the desktop/web engine client
+ * (`ui/engine-client/src/*`). Pure types only — this module is isomorphic and
+ * reads no environment.
+ */
+import type { AgentIR } from "@houston/agentstore-contract";
+
+/** The gateway's icon shape: an emoji or an https URL, both under `value`. */
+export interface StoreIcon {
+  kind: "emoji" | "url";
+  value: string;
+}
+
+/** Who is credited on a listing. */
+export interface StoreCreator {
+  displayName: string;
+  url?: string;
+}
+
+/**
+ * A listing's lifecycle state (the Go `agentstore.State*` closed set). Owners
+ * move `draft → published`; the gateway retires to `archived`.
+ */
+export type AgentState = "draft" | "published" | "archived";
+
+/**
+ * A listing's visibility (the Go `agentstore.Visibility*` closed set). Owners
+ * may only set `unlisted`; `public` is reached solely through admin approval.
+ */
+export type AgentVisibility = "unlisted" | "public";
+
+/**
+ * The denormalized agent projection returned by every list/detail/owner/queue
+ * endpoint (the Go `agentstore.AgentSummary`). `state`/`visibility` are always
+ * present on the wire but marked optional here so browse-only consumers that
+ * ignore them stay decoupled from the owner surface.
+ */
+export interface StoreAgentSummary {
+  id: string;
+  slug: string | null;
+  name: string;
+  tagline: string | null;
+  description: string;
+  icon: StoreIcon | null;
+  color: string | null;
+  category: string;
+  tags: string[];
+  integrations: string[];
+  creator: StoreCreator;
+  installsCount: number;
+  publishedAt: string | null;
+  updatedAt: string;
+  state?: AgentState;
+  visibility?: AgentVisibility;
+}
+
+/** One page of the public catalog (server page size is fixed at 24). */
+export interface StoreCatalogPage {
+  items: StoreAgentSummary[];
+  hasMore: boolean;
+}
+
+/** Catalog sort modes; anything but `installs` is the recent default. */
+export type StoreCatalogSort = "recent" | "installs";
+
+/** Query parameters accepted by `GET /agents`. */
+export interface StoreCatalogQuery {
+  /** Full-text search (websearch syntax). */
+  q?: string;
+  /** A store category slug; omit for all categories. */
+  category?: string;
+  /** An UPPERCASE Composio toolkit slug the agent must declare. */
+  integration?: string;
+  sort?: StoreCatalogSort;
+  /** 1-based page number. */
+  page?: number;
+}
+
+/** A single agent page: its summary plus the full published-version IR. */
+export interface StoreAgentDetail {
+  agent: StoreAgentSummary;
+  ir: AgentIR;
+}
+
+/** One entry of the controlled category vocabulary (`GET /categories`). */
+export interface StoreCategory {
+  slug: string;
+  name: string;
+}
+
+/** The install targets the gateway counts (`POST /agents/{slug}/installs`). */
+export type StoreInstallTarget = "houston" | "claude_skill_zip" | "copy_paste";
+
+/** The moderation reasons accepted by `POST /agents/{slug}/reports`. */
+export type ReportReason =
+  | "spam"
+  | "malicious"
+  | "impersonation"
+  | "inappropriate"
+  | "other";
+
+/** An anonymous abuse report body. `details`/`contact` are optional free text. */
+export interface ReportInput {
+  reason: ReportReason;
+  details?: string;
+  contact?: string;
+}
+
+/** The body of `POST /claim`. */
+export interface ClaimInput {
+  agentId: string;
+  code: string;
+}
+
+/** The result of claiming an unclaimed agent (`POST /claim`). */
+export interface ClaimResult {
+  agentId: string;
+  /** Set when the claimed agent already carries a published slug. */
+  slug?: string;
+}
+
+/**
+ * One of the caller's agents (`GET /me/agents`). The gateway returns the same
+ * `AgentSummary` projection here as the catalog, in every lifecycle state, so
+ * `state`/`visibility` are populated on this surface.
+ */
+export type MyAgent = StoreAgentSummary;
+
+/** The editable identity fields on a `PATCH … {identity}` call. */
+export interface AgentIdentityPatch {
+  name?: string;
+  tagline?: string;
+  description?: string;
+  category?: string;
+  tags?: string[];
+  creator?: StoreCreator;
+}
+
+/**
+ * The mutations `PATCH /agents/{id}` accepts. The gateway applies every present
+ * intent in a fixed order, but callers send exactly one per call. `ir` replaces
+ * the stored IR (re-validated + secret-scanned server-side).
+ */
+export type AgentPatch =
+  | { identity: AgentIdentityPatch }
+  | { ir: AgentIR }
+  | { publish: true }
+  | { unpublish: true }
+  | { visibility: "unlisted" }
+  | { requestPublic: true };
+
+/** The response of a successful `PATCH /agents/{id}`. */
+export interface PatchAgentResponse {
+  agent: StoreAgentSummary;
+}
+
+/**
+ * The body of the authenticated (owned) `POST /agents` publish call. `publish`
+ * finalizes a share slug and marks the new agent published.
+ */
+export interface CreateAgentRequest {
+  ir: AgentIR;
+  publish?: boolean;
+}
+
+/**
+ * The response of the authenticated `POST /agents`. `slug`/`shareUrl` are set
+ * only when `publish` finalized a share slug.
+ */
+export interface CreateAgentResponse {
+  agentId: string;
+  slug?: string;
+  shareUrl?: string;
+}
+
+/**
+ * An agent awaiting a public-visibility decision (`GET /admin/queue`). The
+ * gateway emits the same `AgentSummary` projection as every other listing.
+ */
+export type AdminQueueItem = StoreAgentSummary;
+
+/** Status of a moderation report. */
+export type ReportStatus = "open" | "resolved" | "dismissed";
+
+/**
+ * One abuse report in the moderation console (`GET /admin/reports`). The gateway
+ * emits a flat shape: the reported agent is referenced by `agentId`/`agentSlug`,
+ * with no denormalized name and no `resolvedAt`.
+ */
+export interface AdminReport {
+  id: string;
+  agentId: string;
+  agentSlug: string | null;
+  reason: ReportReason;
+  details: string | null;
+  contact: string | null;
+  status: ReportStatus;
+  createdAt: string;
+}
+
+/** Result of the retention purge (`POST /admin/purge`). */
+export interface PurgeResult {
+  draftsDeleted: number;
+  softDeletedPurged: number;
+}

--- a/packages/agentstore-client/tsconfig.json
+++ b/packages/agentstore-client/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": false,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -30,6 +30,7 @@
     "@houston-ai/review": "workspace:*",
     "@houston-ai/routines": "workspace:*",
     "@houston-ai/skills": "workspace:*",
+    "@houston/agentstore-client": "workspace:*",
     "@houston/domain": "workspace:*",
     "@houston/protocol": "workspace:*",
     "@houston/runtime-client": "workspace:*",

--- a/packages/web/src/engine-adapter/portable-store.test.ts
+++ b/packages/web/src/engine-adapter/portable-store.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import type { StorePublishRequest } from "../../../../ui/engine-client/src/types";
+import { HoustonEngineError } from "./client";
 import type { ControlPlaneConfig } from "./control-plane";
 import {
   getPublication,
@@ -159,6 +160,68 @@ test("getPublication on a never-published agent needs no store call", async () =
     linked: false,
     storeUrl: "https://agents.gethouston.ai",
   });
+});
+
+test("a gateway HTTP failure re-maps to a HoustonEngineError", async () => {
+  // Host gather + pointer routes succeed; the store POST answers non-OK, so
+  // `asEngineError` must translate the SDK's StoreApiError onto the engine
+  // error class publish callers branch on — carrying the same status.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      if (url.endsWith("/agents/A/portable/store-ir")) {
+        return jsonResponse({ ir: { irVersion: "2.0.0", from: body } });
+      }
+      if (
+        url.endsWith("/agents/A/portable/store-publication") &&
+        method === "GET"
+      ) {
+        return jsonResponse({ pointer: null });
+      }
+      if (url.endsWith("/v1/agentstore/agents") && method === "POST") {
+        return jsonResponse({ error: "over_quota" }, 429);
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    }),
+  );
+  const err = await publishToStore(cfg, "A", req).then(
+    () => null,
+    (e: unknown) => e,
+  );
+  expect(err).toBeInstanceOf(HoustonEngineError);
+  expect((err as HoustonEngineError).status).toBe(429);
+});
+
+test("a network failure rethrows the underlying cause verbatim (status 0)", async () => {
+  // A thrown fetch surfaces as StoreApiError(status 0, body: cause); the shim's
+  // status-0 branch must re-raise that original cause unchanged, exactly as the
+  // former hand-rolled fetch propagated it.
+  const cause = new Error("connection refused");
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      if (url.endsWith("/agents/A/portable/store-ir")) {
+        return jsonResponse({ ir: { irVersion: "2.0.0", from: body } });
+      }
+      if (
+        url.endsWith("/agents/A/portable/store-publication") &&
+        method === "GET"
+      ) {
+        return jsonResponse({ pointer: null });
+      }
+      if (url.endsWith("/v1/agentstore/agents") && method === "POST") {
+        throw cause;
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    }),
+  );
+  await expect(publishToStore(cfg, "A", req)).rejects.toBe(cause);
 });
 
 test("unpublish PATCHes the gateway and keeps the pointer", async () => {

--- a/packages/web/src/engine-adapter/portable-store.ts
+++ b/packages/web/src/engine-adapter/portable-store.ts
@@ -3,12 +3,20 @@
  *
  * The host is credential-free: it gathers the IR (`portable/store-ir`) and
  * records a token-free pointer (`portable/store-publication`) — those calls live
- * in `portable-store-pointer.ts`. The APP owns the network: it POSTs the IR to
- * the gateway `/v1/agentstore` API with the user's OWN bearer via
- * `storeAuthFetch` (which targets the store gateway even when the engine is a
- * local sidecar). Pure request-body mapping lives in `portable-map.ts`.
+ * in `portable-store-pointer.ts`. The APP owns the network: it drives the gateway
+ * `/v1/agentstore` API through the shared {@link AgentStoreClient}, with the
+ * user's OWN bearer + the 401-refresh/replay discipline riding the injected
+ * `storeAuthFetch` seam (which targets the store gateway even when the engine is
+ * a local sidecar). Pure request-body mapping lives in `portable-map.ts`.
  */
 
+import {
+  type AgentPatch,
+  AgentStoreClient,
+  type CreateAgentRequest,
+  type CreateAgentResponse,
+  StoreApiError,
+} from "@houston/agentstore-client";
 import type {
   StorePublicationStatus,
   StorePublishRequest,
@@ -27,35 +35,40 @@ import {
 } from "./portable-store-pointer";
 import { STORE_SITE_URL, storeApiBase, storeAuthFetch } from "./store-gateway";
 
-/** The subset of a `me/agents` item the manage view needs (see the wire contract). */
-interface StoreMeAgent {
-  id: string;
-  slug: string | null;
-  name: string;
-  tagline?: string | null;
-  description?: string | null;
-  category?: string | null;
-  tags?: string[];
-  state: string;
+/**
+ * The store-gateway client for the publish flow. Authorization is owned by the
+ * injected {@link storeAuthFetch}: it sets the final `Authorization` header from
+ * the live session bearer and carries the single 401 refresh/replay, overriding
+ * whatever the client sends. `getToken` mirrors that seam's bearer resolution so
+ * the client's own pre-flight auth guard passes exactly when a request would be
+ * sent (the value itself is superseded by the fetch seam).
+ */
+function storeClient(cfg: ControlPlaneConfig): AgentStoreClient {
+  return new AgentStoreClient({
+    baseUrl: storeApiBase(cfg),
+    fetchImpl: storeAuthFetch(cfg.token),
+    getToken: () =>
+      (typeof window !== "undefined" && window.__HOUSTON_STORE__?.token) ||
+      cfg.token,
+  });
 }
 
-/** A store gateway call with the user's own bearer; non-2xx surfaces verbatim. */
-async function storeFetch(
-  cfg: ControlPlaneConfig,
-  path: string,
-  init?: RequestInit,
-): Promise<Response> {
-  const res = await storeAuthFetch(cfg.token)(`${storeApiBase(cfg)}${path}`, {
-    ...init,
-    headers: { "Content-Type": "application/json", ...init?.headers },
-  });
-  if (!res.ok) {
-    throw new HoustonEngineError(
-      res.status,
-      await res.json().catch(() => ({})),
-    );
+/**
+ * Run a store-client call, re-mapping the SDK's {@link StoreApiError} onto the
+ * adapter's {@link HoustonEngineError} so publish callers keep branching on the
+ * one engine-error class. A network-level failure (status `0`) rethrows its
+ * underlying cause verbatim — exactly as the hand-rolled `fetch` propagated it.
+ */
+async function asEngineError<T>(op: () => Promise<T>): Promise<T> {
+  try {
+    return await op();
+  } catch (err) {
+    if (err instanceof StoreApiError) {
+      if (err.status === 0) throw err.body;
+      throw new HoustonEngineError(err.status, err.body);
+    }
+    throw err;
   }
-  return res;
 }
 
 /** Publish the agent to the store; returns the public share URL. */
@@ -66,13 +79,17 @@ export async function publishToStore(
 ): Promise<StorePublishResponse> {
   const ir = await gatherStoreIr(cfg, agentId, req);
   const existing = await readPointer(cfg, agentId);
+  const client = storeClient(cfg);
   // A kept pointer (e.g. left by an unpublish) re-publishes the SAME store agent
   // so a re-publish never duplicates the listing.
   if (existing) {
-    await storeFetch(
-      cfg,
-      `/v1/agentstore/agents/${encodeURIComponent(existing.storeAgentId)}`,
-      { method: "PATCH", body: JSON.stringify({ ir, publish: true }) },
+    // The single-intent `AgentPatch` union does not model the combined
+    // {ir, publish} body the gateway applies in order; the wire is unchanged.
+    await asEngineError(() =>
+      client.patchAgent(existing.storeAgentId, {
+        ir,
+        publish: true,
+      } as AgentPatch),
     );
     await writePointer(cfg, agentId, existing);
     return {
@@ -81,15 +98,9 @@ export async function publishToStore(
       storeAgentId: existing.storeAgentId,
     };
   }
-  const res = await storeFetch(cfg, "/v1/agentstore/agents", {
-    method: "POST",
-    body: JSON.stringify({ ir, publish: true }),
-  });
-  const created = (await res.json()) as {
-    agentId: string;
-    slug: string;
-    shareUrl: string;
-  };
+  const created = (await asEngineError(() =>
+    client.createAgent({ ir, publish: true } as CreateAgentRequest),
+  )) as Required<CreateAgentResponse>;
   const pointer: StorePointer = {
     storeAgentId: created.agentId,
     slug: created.slug,
@@ -115,13 +126,12 @@ export async function updatePublication(
     throw new HoustonEngineError(404, { error: "this agent is not published" });
   }
   const ir = await gatherStoreIr(cfg, agentId, req);
-  await storeFetch(
-    cfg,
-    `/v1/agentstore/agents/${encodeURIComponent(pointer.storeAgentId)}`,
-    {
-      method: "PATCH",
-      body: JSON.stringify({ ir, identity: req.identity }),
-    },
+  // Combined {ir, identity} patch — see the note in `publishToStore`.
+  await asEngineError(() =>
+    storeClient(cfg).patchAgent(pointer.storeAgentId, {
+      ir,
+      identity: req.identity,
+    } as AgentPatch),
   );
   return { shareUrl: pointer.shareUrl, slug: pointer.slug };
 }
@@ -133,10 +143,8 @@ export async function unpublishFromStore(
 ): Promise<StoreUnpublishResponse> {
   const pointer = await readPointer(cfg, agentId);
   if (!pointer) return { ok: true };
-  await storeFetch(
-    cfg,
-    `/v1/agentstore/agents/${encodeURIComponent(pointer.storeAgentId)}`,
-    { method: "PATCH", body: JSON.stringify({ unpublish: true }) },
+  await asEngineError(() =>
+    storeClient(cfg).patchAgent(pointer.storeAgentId, { unpublish: true }),
   );
   return { ok: true };
 }
@@ -150,8 +158,7 @@ export async function getPublication(
   if (!pointer) {
     return { published: false, linked: false, storeUrl: STORE_SITE_URL };
   }
-  const res = await storeFetch(cfg, "/v1/agentstore/me/agents");
-  const { items } = (await res.json()) as { items: StoreMeAgent[] };
+  const items = await asEngineError(() => storeClient(cfg).listMyAgents());
   const item = items.find((a) => a.id === pointer.storeAgentId);
   if (!item) {
     // The store agent is gone (deleted upstream) — drop the stale pointer.
@@ -168,10 +175,10 @@ export async function getPublication(
     storeUrl: STORE_SITE_URL,
     identity: {
       name: item.name,
-      description: item.description ?? "",
+      description: item.description,
       ...(item.tagline ? { tagline: item.tagline } : {}),
-      category: item.category ?? "",
-      tags: item.tags ?? [],
+      category: item.category,
+      tags: item.tags,
     },
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@houston-ai/core':
         specifier: workspace:*
         version: link:../ui/core
+      '@houston/agentstore-client':
+        specifier: workspace:*
+        version: link:../packages/agentstore-client
       '@houston/agentstore-contract':
         specifier: workspace:*
         version: link:../packages/agentstore-contract
@@ -254,6 +257,25 @@ importers:
       vite:
         specifier: 6.4.3
         version: 6.4.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
+
+  packages/agentstore-client:
+    dependencies:
+      '@houston/agentstore-contract':
+        specifier: workspace:*
+        version: link:../agentstore-contract
+    devDependencies:
+      '@types/node':
+        specifier: 22.20.0
+        version: 22.20.0
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260607.1
+        version: 7.0.0-dev.20260607.1
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 3.2.6
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/agentstore-contract:
     dependencies:
@@ -572,6 +594,9 @@ importers:
       '@houston-ai/skills':
         specifier: workspace:*
         version: link:../../ui/skills
+      '@houston/agentstore-client':
+        specifier: workspace:*
+        version: link:../agentstore-client
       '@houston/domain':
         specifier: workspace:*
         version: link:../domain
@@ -817,6 +842,10 @@ importers:
         version: 4.3.2
 
   ui/engine-client:
+    dependencies:
+      '@houston/agentstore-client':
+        specifier: workspace:*
+        version: link:../../packages/agentstore-client
     devDependencies:
       typescript:
         specifier: 5.9.3

--- a/ui/engine-client/package.json
+++ b/ui/engine-client/package.json
@@ -12,6 +12,9 @@
     "test": "node --experimental-strip-types --test tests/*.test.ts",
     "typecheck": "tsgo --noEmit"
   },
+  "dependencies": {
+    "@houston/agentstore-client": "workspace:*"
+  },
   "devDependencies": {
     "typescript": "5.9.3"
   }

--- a/ui/engine-client/src/store-catalog.ts
+++ b/ui/engine-client/src/store-catalog.ts
@@ -3,14 +3,18 @@
  *
  * These routes are anonymous by design (the gateway serves them with
  * `Access-Control-Allow-Origin: *`), so unlike the publish flow there is no
- * bearer and no 401 discipline here: plain `fetch` against the store gateway.
+ * bearer and no 401 discipline here: plain reads against the store gateway.
  * Works signed-out, on every deployment shape.
  *
- * The API base mirrors the publish adapter's resolution: the desktop shell's
- * `window.__HOUSTON_STORE__` target when installed (local-sidecar mode, signed
- * in), else the build-time `VITE_AGENTSTORE_GATEWAY_URL`, else production.
+ * The transport is the shared {@link AgentStoreClient}
+ * (`@houston/agentstore-client`), constructed per call with the resolved
+ * gateway base and the caller-supplied `fetchImpl`. The API base mirrors the
+ * publish adapter's resolution: the desktop shell's `window.__HOUSTON_STORE__`
+ * target when installed (local-sidecar mode, signed in), else the build-time
+ * `VITE_AGENTSTORE_GATEWAY_URL`, else production.
  */
 
+import { AgentStoreClient, StoreApiError } from "@houston/agentstore-client";
 import type {
   StoreCatalogAgentDetail,
   StoreCatalogPage,
@@ -41,6 +45,9 @@ declare global {
 
 const DEFAULT_STORE_GATEWAY = "https://gateway.gethouston.ai";
 
+/** GET reads announce JSON, matching the former plain-fetch requests. */
+const ACCEPT_JSON = { headers: { Accept: "application/json" } };
+
 /** The gateway base the public catalog reads go to. */
 export function storeCatalogApiBase(): string {
   const installed =
@@ -51,39 +58,47 @@ export function storeCatalogApiBase(): string {
   return (installed || built || DEFAULT_STORE_GATEWAY).replace(/\/+$/, "");
 }
 
-async function storeGet<T>(path: string, fetchImpl: typeof fetch): Promise<T> {
-  const res = await fetchImpl(`${storeCatalogApiBase()}${path}`, {
-    headers: { Accept: "application/json" },
-  });
-  if (!res.ok) {
-    throw new StoreCatalogError(res.status, await res.json().catch(() => ({})));
+/** A store client bound to the resolved gateway base and the given fetch. */
+function catalogClient(fetchImpl: typeof fetch): AgentStoreClient {
+  return new AgentStoreClient({ baseUrl: storeCatalogApiBase(), fetchImpl });
+}
+
+/**
+ * Map the SDK's {@link StoreApiError} back onto the structural
+ * {@link StoreCatalogError} this module's callers switch on. A network-level
+ * failure (status `0`) carries no HTTP status, so its original thrown cause is
+ * re-raised unchanged — exactly as the former plain-fetch code let it propagate.
+ */
+function asCatalogError(err: unknown): unknown {
+  if (err instanceof StoreApiError) {
+    if (err.status === 0) return err.body instanceof Error ? err.body : err;
+    return new StoreCatalogError(err.status, err.body);
   }
-  return (await res.json()) as T;
+  return err;
 }
 
 /** One page of published + public listings (server page size 24). */
-export function fetchStoreCatalog(
+export async function fetchStoreCatalog(
   query: StoreCatalogQuery = {},
   fetchImpl: typeof fetch = fetch,
 ): Promise<StoreCatalogPage> {
-  const params = new URLSearchParams();
-  if (query.q?.trim()) params.set("q", query.q.trim());
-  if (query.category) params.set("category", query.category);
-  if (query.sort) params.set("sort", query.sort);
-  if (query.page && query.page > 1) params.set("page", String(query.page));
-  const qs = params.toString();
-  return storeGet(`/v1/agentstore/agents${qs ? `?${qs}` : ""}`, fetchImpl);
+  try {
+    return await catalogClient(fetchImpl).listAgents(query, ACCEPT_JSON);
+  } catch (err) {
+    throw asCatalogError(err);
+  }
 }
 
 /** A listing's summary + renderable IR parts. 404s when not published. */
-export function fetchStoreAgent(
+export async function fetchStoreAgent(
   slug: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<StoreCatalogAgentDetail> {
-  return storeGet(
-    `/v1/agentstore/agents/${encodeURIComponent(slug)}`,
-    fetchImpl,
-  );
+  try {
+    return await catalogClient(fetchImpl).getAgent(slug, ACCEPT_JSON);
+  } catch (err) {
+    throw asCatalogError(err);
+  }
 }
 
 /**
@@ -95,15 +110,9 @@ export async function pingStoreInstall(
   slug: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<void> {
-  const res = await fetchImpl(
-    `${storeCatalogApiBase()}/v1/agentstore/agents/${encodeURIComponent(slug)}/installs`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ target: "houston" }),
-    },
-  );
-  if (!res.ok) {
-    throw new StoreCatalogError(res.status, await res.json().catch(() => ({})));
+  try {
+    await catalogClient(fetchImpl).recordInstall(slug, "houston");
+  } catch (err) {
+    throw asCatalogError(err);
   }
 }

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -7,6 +7,11 @@
  * source of truth.
  */
 
+import type {
+  StoreAgentDetail,
+  StoreAgentSummary,
+} from "@houston/agentstore-client";
+
 export const PROTOCOL_VERSION = 1 as const;
 
 export type EnvelopeKind = "event" | "req" | "res" | "ping" | "pong";
@@ -1729,52 +1734,24 @@ export interface StorePublicationStatus {
   identity?: StorePublishIdentity;
 }
 
+// The public catalog wire types are the unified Agent Store SDK shapes
+// (`@houston/agentstore-client`), reconciled against the authoritative Go
+// handlers. The historical `StoreCatalog*` names are kept as aliases/re-exports
+// so existing importers (the desktop store-view, the runtime adapter) compile
+// unchanged. `StoreCatalogAgentDetail.ir` widens from the former
+// `{ skills, learnings }` projection to the full `AgentIR` the gateway serves;
+// the app still reads only `ir.skills`/`ir.learnings`.
+export type {
+  StoreCatalogPage,
+  StoreCatalogQuery,
+  StoreCatalogSort,
+} from "@houston/agentstore-client";
+
 /** One public Agent Store listing, exactly as the catalog API serializes it. */
-export interface StoreCatalogAgent {
-  id: string;
-  /** Null only while a listing is a draft; always set for published agents. */
-  slug: string | null;
-  name: string;
-  tagline: string | null;
-  description: string;
-  icon: { kind: string; value: string } | null;
-  color: string | null;
-  category: string;
-  tags: string[];
-  /** UPPERCASE Composio toolkit slugs the agent uses. */
-  integrations: string[];
-  creator: { displayName: string; url?: string };
-  installsCount: number;
-  publishedAt: string | null;
-  updatedAt: string;
-}
+export type StoreCatalogAgent = StoreAgentSummary;
 
-/** One page of the public catalog (page size is server-fixed at 24). */
-export interface StoreCatalogPage {
-  items: StoreCatalogAgent[];
-  hasMore: boolean;
-}
-
-export type StoreCatalogSort = "recent" | "installs";
-
-export interface StoreCatalogQuery {
-  /** Full-text search (websearch syntax). */
-  q?: string;
-  /** A store category slug; omit for all categories. */
-  category?: string;
-  sort?: StoreCatalogSort;
-  /** 1-based. */
-  page?: number;
-}
-
-/** A listing's detail: the summary plus the parts of its IR the app renders. */
-export interface StoreCatalogAgentDetail {
-  agent: StoreCatalogAgent;
-  ir: {
-    skills?: Array<{ slug: string }>;
-    learnings?: unknown[];
-  };
-}
+/** A listing's detail: the summary plus the full published-version IR. */
+export type StoreCatalogAgentDetail = StoreAgentDetail;
 
 // ── integrations (Composio, platform mode) ───────────────────────────────────
 // User-level: no provider account — the user only connects apps (Gmail, Slack…)

--- a/ui/engine-client/tests/store-catalog.test.ts
+++ b/ui/engine-client/tests/store-catalog.test.ts
@@ -88,6 +88,19 @@ describe("fetchStoreCatalog", () => {
         typeof err.body === "object",
     );
   });
+
+  it("re-raises the underlying cause on a network failure (status 0)", async () => {
+    // A thrown fetch surfaces as a status-0 StoreApiError carrying the original
+    // cause; that cause must propagate unchanged (never wrapped as a
+    // StoreCatalogError), exactly as the former plain-fetch code let it bubble.
+    const cause = new Error("connection refused");
+    const fetchImpl = (() => Promise.reject(cause)) as typeof fetch;
+    await rejects(fetchStoreCatalog({}, fetchImpl), (err: unknown) => {
+      ok(!(err instanceof StoreCatalogError));
+      strictEqual(err, cause);
+      return true;
+    });
+  });
 });
 
 describe("fetchStoreAgent", () => {


### PR DESCRIPTION
## What

Extracts a single shared HTTP client for the Agent Store gateway (`/v1/agentstore`) into a new workspace package **`packages/agentstore-client`** and migrates all three consumers onto it:

- `agentstore/` (Next.js site): `store-api.ts` / `store-client.ts` / `store-admin-client.ts` are now thin facades owning only env/base-URL resolution, Next revalidate, Firebase token wiring, and XFF forwarding.
- `ui/engine-client`: `store-catalog.ts` reimplemented over the SDK; public surface (`fetchStoreCatalog`, `fetchStoreAgent`, `pingStoreInstall`, `StoreCatalogError`) unchanged; store wire types in `types.ts` are now re-exports of the SDK types.
- `packages/web` engine-adapter: publish/update/unpublish/getPublication flow via the SDK, with the 401 refresh/replay seam preserved inside the injected fetch.

## Why

The two store frontends (in-app store view and agents.gethouston.ai) had independently hand-rolled clients whose wire types had already diverged (state/visibility fields, integration filter, full-vs-partial IR detail, two error classes, three base-URL resolvers). Wire types are now reconciled once against the authoritative Go handlers in `cloud/internal/agentstore`.

Zero behavior change on the wire. Also drops the retired `theagentlibrary` note from the KB.

## Verification

- SDK vitest 33/33 (injected fetch stubs: URLs, auth, error mapping, init merge)
- agentstore 75/75, engine-client 71/71, web 190/190, app typecheck clean
- Repo-wide `pnpm check` (Biome, 2453 files) + `pnpm check:boundaries` green
- Adversarial multi-agent review: 4 confirmed findings (error-copy regression, undeclared workspace dep, enum widening, untested error shims) — all fixed with tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)