### PR TITLE
feat(files): transparent files panel + move-conflict dialog

### DIFF
--- a/app/src/components/move-conflict-dialog.tsx
+++ b/app/src/components/move-conflict-dialog.tsx
@@ -1,0 +1,57 @@
+/**
+ * Shown when a drag-move would land on an existing name: offer Replace
+ * (delete the occupant, then move) or Keep both (move under a "name (n)"),
+ * instead of surfacing the host's 409 as an error toast.
+ */
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@houston-ai/core";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  /** The colliding file/folder name, or null when the dialog is closed. */
+  name: string | null;
+  onReplace: () => void;
+  onKeepBoth: () => void;
+  onCancel: () => void;
+}
+
+export function MoveConflictDialog({
+  name,
+  onReplace,
+  onKeepBoth,
+  onCancel,
+}: Props) {
+  const { t } = useTranslation("agents");
+  return (
+    <Dialog open={name !== null} onOpenChange={(open) => !open && onCancel()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {t("files.conflict.title", { name: name ?? "" })}
+          </DialogTitle>
+          <DialogDescription>
+            {t("files.conflict.description", { name: name ?? "" })}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onCancel}>
+            {t("files.conflict.cancel")}
+          </Button>
+          <Button type="button" variant="secondary" onClick={onKeepBoth}>
+            {t("files.conflict.keepBoth")}
+          </Button>
+          <Button type="button" variant="destructive" onClick={onReplace}>
+            {t("files.conflict.replace")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/tabs/files-tab.tsx
+++ b/app/src/components/tabs/files-tab.tsx
@@ -7,18 +7,19 @@ import {
   useCreateFolder,
   useDeleteFile,
   useFiles,
-  useMoveFile,
   useRenameFile,
   useUploadFiles,
 } from "../../hooks/queries";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { useFilePreviewLoader } from "../../hooks/use-file-preview-loader";
+import { useMoveWithConflict } from "../../hooks/use-move-with-conflict";
 import { useSaveDownload } from "../../hooks/use-save-download";
 import { isCoLocatedEngine, newEngineActive } from "../../lib/engine";
 import { tauriFiles } from "../../lib/tauri";
 import type { TabProps } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 import { FilePreviewDialog } from "../file-preview-dialog";
+import { MoveConflictDialog } from "../move-conflict-dialog";
 import { buildBrowserLabels, buildMenuLabels } from "./files-tab-labels";
 
 export default function FilesTab({ agent }: TabProps) {
@@ -52,7 +53,7 @@ export default function FilesTab({ agent }: TabProps) {
   const renameFile = useRenameFile(path);
   const createFolder = useCreateFolder(path);
   const uploadFiles = useUploadFiles(path);
-  const moveFile = useMoveFile(path);
+  const move = useMoveWithConflict(path, files);
 
   // save() surfaces its own success/failure toasts and never rejects; the
   // empty catch below only silences the fetch failure call() already toasted.
@@ -122,13 +123,7 @@ export default function FilesTab({ agent }: TabProps) {
         }
         onMove={
           // Drag-move needs the TS host's move route; the legacy engine has none.
-          newEngineActive()
-            ? (sourcePath, targetFolder) =>
-                moveFile.mutate({
-                  relativePath: sourcePath,
-                  toDir: targetFolder,
-                })
-            : undefined
+          newEngineActive() ? move.requestMove : undefined
         }
         onBrowse={pickFiles}
         emptyTitle={t("files.emptyTitle")}
@@ -163,6 +158,12 @@ export default function FilesTab({ agent }: TabProps) {
         filePath={preview?.path ?? null}
         fileName={preview?.name ?? ""}
         onClose={() => setPreview(null)}
+      />
+      <MoveConflictDialog
+        name={move.pending?.name ?? null}
+        onReplace={() => void move.replace()}
+        onKeepBoth={() => void move.keepBoth()}
+        onCancel={move.cancel}
       />
     </div>
   );

--- a/app/src/hooks/use-move-with-conflict.ts
+++ b/app/src/hooks/use-move-with-conflict.ts
@@ -1,0 +1,90 @@
+/**
+ * Move-with-conflict flow for the Files tab: a drop that would collide with
+ * an existing entry opens a Replace / Keep both dialog instead of hitting
+ * the host's 409. Replace deletes the occupant then moves; Keep both renames
+ * the moved item to a free "name (n)" first. Step failures surface through
+ * the tauriFiles call() toasts like every other files op.
+ */
+import type { FileEntry } from "@houston-ai/agent";
+import { useCallback, useState } from "react";
+import { detectMoveConflict, keepBothName } from "../lib/file-conflicts";
+import { useDeleteFile, useMoveFile, useRenameFile } from "./queries";
+
+export interface PendingMove {
+  sourcePath: string;
+  toDir: string | null;
+  /** The colliding name shown in the dialog. */
+  name: string;
+  targetPath: string;
+}
+
+export function useMoveWithConflict(
+  agentPath: string | undefined,
+  files: readonly FileEntry[] | undefined,
+) {
+  const moveFile = useMoveFile(agentPath);
+  const deleteFile = useDeleteFile(agentPath);
+  const renameFile = useRenameFile(agentPath);
+  const [pending, setPending] = useState<PendingMove | null>(null);
+
+  const requestMove = useCallback(
+    (sourcePath: string, toDir: string | null) => {
+      const conflict = detectMoveConflict(files ?? [], sourcePath, toDir);
+      if (conflict.kind === "noop") return;
+      if (conflict.kind === "conflict") {
+        setPending({
+          sourcePath,
+          toDir,
+          name: conflict.name,
+          targetPath: conflict.targetPath,
+        });
+        return;
+      }
+      moveFile.mutate({ relativePath: sourcePath, toDir });
+    },
+    [files, moveFile],
+  );
+
+  const replace = useCallback(async () => {
+    if (!pending) return;
+    setPending(null);
+    try {
+      await deleteFile.mutateAsync(pending.targetPath);
+    } catch {
+      return; // call() toasted; nothing was moved
+    }
+    moveFile.mutate({ relativePath: pending.sourcePath, toDir: pending.toDir });
+  }, [pending, deleteFile, moveFile]);
+
+  const keepBoth = useCallback(async () => {
+    if (!pending) return;
+    setPending(null);
+    const newName = keepBothName(
+      files ?? [],
+      pending.sourcePath,
+      pending.toDir,
+    );
+    try {
+      await renameFile.mutateAsync({
+        relativePath: pending.sourcePath,
+        newName,
+      });
+    } catch {
+      return; // call() toasted; the item keeps its old name and place
+    }
+    const slash = pending.sourcePath.lastIndexOf("/");
+    const renamedPath =
+      slash === -1
+        ? newName
+        : `${pending.sourcePath.slice(0, slash)}/${newName}`;
+    moveFile.mutate({ relativePath: renamedPath, toDir: pending.toDir });
+  }, [pending, files, renameFile, moveFile]);
+
+  return {
+    requestMove,
+    pending,
+    cancel: () => setPending(null),
+    replace,
+    keepBoth,
+  };
+}

--- a/app/src/lib/file-conflicts.ts
+++ b/app/src/lib/file-conflicts.ts
@@ -1,0 +1,75 @@
+/**
+ * Client-side move-conflict detection for the Files tab. The listing already
+ * holds the whole workspace, so a name collision is known before calling the
+ * host's `files/move` (which 409s on clobber) — letting the UI offer
+ * Replace / Keep both instead of surfacing an error toast.
+ */
+import type { FileEntry } from "@houston-ai/agent";
+
+/** Where `sourcePath` would land when moved into `toDir` (null = root). */
+export function moveTargetPath(
+  sourcePath: string,
+  toDir: string | null,
+): string {
+  const name = sourcePath.split("/").pop() ?? "";
+  return toDir ? `${toDir}/${name}` : name;
+}
+
+/** True when the listing has `path` itself or anything nested under it. */
+function hasEntry(files: readonly FileEntry[], path: string): boolean {
+  return files.some((f) => f.path === path || f.path.startsWith(`${path}/`));
+}
+
+export type MoveConflict =
+  /** Same place (or a folder into itself/descendant): silently do nothing. */
+  | { kind: "noop" }
+  /** The destination already has an entry with this name. */
+  | { kind: "conflict"; targetPath: string; name: string }
+  /** Free to move. */
+  | { kind: "clear" };
+
+export function detectMoveConflict(
+  files: readonly FileEntry[],
+  sourcePath: string,
+  toDir: string | null,
+): MoveConflict {
+  if (toDir === sourcePath || toDir?.startsWith(`${sourcePath}/`)) {
+    return { kind: "noop" };
+  }
+  const targetPath = moveTargetPath(sourcePath, toDir);
+  if (targetPath === sourcePath) return { kind: "noop" };
+  if (hasEntry(files, targetPath)) {
+    return {
+      kind: "conflict",
+      targetPath,
+      name: targetPath.split("/").pop() ?? "",
+    };
+  }
+  return { kind: "clear" };
+}
+
+/**
+ * "Keep both" name: the first `stem (n)[.ext]` free in BOTH the source folder
+ * (the item is renamed there first) and the destination folder (it moves next).
+ * Mirrors the host's upload dedupe convention.
+ */
+export function keepBothName(
+  files: readonly FileEntry[],
+  sourcePath: string,
+  toDir: string | null,
+): string {
+  const name = sourcePath.split("/").pop() ?? "";
+  const slash = sourcePath.lastIndexOf("/");
+  const sourceDir = slash === -1 ? null : sourcePath.slice(0, slash);
+  const dot = name.lastIndexOf(".");
+  const stem = dot > 0 ? name.slice(0, dot) : name;
+  const ext = dot > 0 ? name.slice(dot) : "";
+  const inDir = (dir: string | null, candidate: string) =>
+    hasEntry(files, dir ? `${dir}/${candidate}` : candidate);
+  for (let n = 1; ; n++) {
+    const candidate = `${stem} (${n})${ext}`;
+    if (!inDir(sourceDir, candidate) && !inDir(toDir, candidate)) {
+      return candidate;
+    }
+  }
+}

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -148,6 +148,13 @@
     "itemPlural": "items",
     "menuButton": "More actions",
     "breadcrumbs": "Folder path",
+    "conflict": {
+      "title": "“{{name}}” already exists",
+      "description": "The destination folder already has an item named “{{name}}”. You can replace it or keep both.",
+      "replace": "Replace",
+      "keepBoth": "Keep both",
+      "cancel": "Cancel"
+    },
     "uploadFiles": "Upload files",
     "downloadAll": "Download all",
     "columns": {

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -148,6 +148,13 @@
     "itemPlural": "elementos",
     "menuButton": "Más acciones",
     "breadcrumbs": "Ruta de carpetas",
+    "conflict": {
+      "title": "“{{name}}” ya existe",
+      "description": "La carpeta de destino ya tiene un elemento llamado “{{name}}”. Puedes reemplazarlo o conservar ambos.",
+      "replace": "Reemplazar",
+      "keepBoth": "Conservar ambos",
+      "cancel": "Cancelar"
+    },
     "uploadFiles": "Subir archivos",
     "downloadAll": "Descargar todo",
     "columns": {

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -148,6 +148,13 @@
     "itemPlural": "itens",
     "menuButton": "Mais ações",
     "breadcrumbs": "Caminho de pastas",
+    "conflict": {
+      "title": "“{{name}}” já existe",
+      "description": "A pasta de destino já tem um item chamado “{{name}}”. Você pode substituí-lo ou manter os dois.",
+      "replace": "Substituir",
+      "keepBoth": "Manter os dois",
+      "cancel": "Cancelar"
+    },
     "uploadFiles": "Enviar arquivos",
     "downloadAll": "Baixar tudo",
     "columns": {

--- a/app/tests/file-conflicts.test.ts
+++ b/app/tests/file-conflicts.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { FileEntry } from "@houston-ai/agent";
+import {
+  detectMoveConflict,
+  keepBothName,
+  moveTargetPath,
+} from "../src/lib/file-conflicts.ts";
+
+const entry = (path: string, is_directory = false): FileEntry => ({
+  path,
+  name: path.split("/").pop() ?? path,
+  extension: is_directory ? "" : (path.split(".").pop() ?? ""),
+  size: 1,
+  is_directory,
+});
+
+const files = [
+  entry("report.pdf"),
+  entry("Docs", true),
+  entry("Docs/report.pdf"),
+  entry("Docs/notes.txt"),
+  // An implied folder: no explicit entry, only a child.
+  entry("Archive/old/report.pdf"),
+];
+
+test("moveTargetPath joins the name onto the destination", () => {
+  assert.equal(moveTargetPath("Docs/report.pdf", null), "report.pdf");
+  assert.equal(moveTargetPath("report.pdf", "Docs"), "Docs/report.pdf");
+});
+
+test("moving onto an occupied name is a conflict in both directions", () => {
+  assert.deepEqual(detectMoveConflict(files, "report.pdf", "Docs"), {
+    kind: "conflict",
+    targetPath: "Docs/report.pdf",
+    name: "report.pdf",
+  });
+  assert.deepEqual(detectMoveConflict(files, "Docs/report.pdf", null), {
+    kind: "conflict",
+    targetPath: "report.pdf",
+    name: "report.pdf",
+  });
+});
+
+test("a folder that exists only through children still conflicts", () => {
+  // Moving a file named like the implied "Archive" folder's sibling is clear,
+  // but a folder named "old" into Archive collides with the implied dir.
+  assert.equal(
+    detectMoveConflict([entry("stuff/old", true)], "stuff/old", "Archive").kind,
+    "clear",
+  );
+  assert.equal(
+    detectMoveConflict(
+      [...files, entry("stuff/old", true)],
+      "stuff/old",
+      "Archive",
+    ).kind,
+    "conflict",
+  );
+});
+
+test("same-place and into-own-subtree moves are noops", () => {
+  assert.equal(detectMoveConflict(files, "report.pdf", null).kind, "noop");
+  assert.equal(
+    detectMoveConflict(files, "Docs/notes.txt", "Docs").kind,
+    "noop",
+  );
+  assert.equal(detectMoveConflict(files, "Docs", "Docs").kind, "noop");
+  assert.equal(
+    detectMoveConflict([...files, entry("Docs/sub", true)], "Docs", "Docs/sub")
+      .kind,
+    "noop",
+  );
+});
+
+test("non-colliding moves are clear", () => {
+  assert.equal(detectMoveConflict(files, "Docs/notes.txt", null).kind, "clear");
+});
+
+test("keepBothName picks the first free numbered name in both folders", () => {
+  assert.equal(keepBothName(files, "report.pdf", "Docs"), "report (1).pdf");
+  // "report (1).pdf" taken in the destination: skip to (2).
+  assert.equal(
+    keepBothName(
+      [...files, entry("Docs/report (1).pdf")],
+      "report.pdf",
+      "Docs",
+    ),
+    "report (2).pdf",
+  );
+  // Taken in the SOURCE folder also skips (the item renames there first).
+  assert.equal(
+    keepBothName([...files, entry("report (1).pdf")], "report.pdf", "Docs"),
+    "report (2).pdf",
+  );
+  // Folders have no extension: suffix goes at the end.
+  assert.equal(
+    keepBothName([...files, entry("stuff/Docs", true)], "stuff/Docs", null),
+    "Docs (1)",
+  );
+});

--- a/packages/web/e2e/files.spec.ts
+++ b/packages/web/e2e/files.spec.ts
@@ -151,6 +151,42 @@ test("the toolbar's new-folder button creates a folder in the open folder", asyn
   await expect(page.getByText("Drafts", { exact: true })).toBeVisible();
 });
 
+test("a move that collides on a name offers Keep both instead of erroring", async ({
+  page,
+}) => {
+  await openFilesTab(page);
+
+  // Move the root PDF into Docs (no conflict yet).
+  await page
+    .getByText("Q3 report.pdf")
+    .dragTo(page.getByText("Docs", { exact: true }));
+  await expect(page.getByText("Q3 report.pdf")).toHaveCount(0);
+
+  // Re-create the same name at the root.
+  const [chooser] = await Promise.all([
+    page.waitForEvent("filechooser"),
+    page.getByRole("button", { name: "Upload files" }).click(),
+  ]);
+  await chooser.setFiles({
+    name: "Q3 report.pdf",
+    mimeType: "application/pdf",
+    buffer: Buffer.from("%PDF-1.4 second"),
+  });
+  await expect(page.getByText("Q3 report.pdf")).toBeVisible();
+
+  // Dropping it onto Docs now collides: the dialog offers choices, no toast.
+  await page
+    .getByText("Q3 report.pdf")
+    .dragTo(page.getByText("Docs", { exact: true }));
+  await expect(page.getByRole("dialog")).toContainText("already exists");
+  await page.getByRole("button", { name: "Keep both" }).click();
+
+  // Both live in Docs, the newcomer under a numbered name.
+  await page.getByText("Docs", { exact: true }).click();
+  await expect(page.getByText("Q3 report.pdf")).toBeVisible();
+  await expect(page.getByText("Q3 report (1).pdf")).toBeVisible();
+});
+
 test("a folder downloads as its own zip from the context menu", async ({
   page,
   browserName,

--- a/ui/agent/src/files-browser.tsx
+++ b/ui/agent/src/files-browser.tsx
@@ -86,7 +86,7 @@ export function FilesBrowser(props: FilesBrowserProps) {
 
   return (
     <div
-      className="relative flex h-full flex-col overflow-hidden rounded-xl border border-line bg-input"
+      className="relative flex h-full flex-col overflow-hidden rounded-xl border border-line bg-transparent"
       {...(props.onFilesDropped || props.onMove ? b.dragHandlers : {})}
     >
       <FilesToolbar
@@ -182,7 +182,7 @@ export function FilesBrowser(props: FilesBrowserProps) {
         )}
       </div>
 
-      <div className="flex h-[22px] shrink-0 select-none items-center justify-between rounded-b-xl border-t border-line bg-chip-subtle/40 px-3">
+      <div className="flex h-[22px] shrink-0 select-none items-center justify-between rounded-b-xl border-t border-line px-3">
         <span className="text-[11px] text-ink-muted">
           {b.fileCount} {b.fileCount === 1 ? l.itemSingular : l.itemPlural}
         </span>


### PR DESCRIPTION
Follow-ups to #960, two changes:

### Transparent files panel
The files section painted an opaque `bg-input` panel — in dark mode a solid black slab over the app's themed background. The panel container and its status bar are now transparent so the normal app background shows through, while the file/folder cards keep their filled chip surfaces and paper preview panels.

### Move name collisions: Replace / Keep both dialog
Dropping a file or folder onto a destination that already has an entry with the same name used to surface the host's 409 as an error toast. The client detects the collision from the listing before calling `files/move` and opens a dialog:
- **Replace**: deletes the occupant, then moves.
- **Keep both**: renames the moved item to the first free `name (n)` (both source and destination folders considered, matching the host's upload dedupe convention), then moves.
- Same-place drops and folder-into-itself drops are now silent no-ops.

New strings ship in en/es/pt.

### Tests
- Unit: `app/tests/file-conflicts.test.ts` (conflict detection incl. implied folders, noop guards, keep-both naming).
- Playwright: a real drag-and-drop collision opens the dialog and "Keep both" lands the numbered copy — Files suite 9/9.
- Gates: Biome, typechecks, `check-locales`, full app unit suite (1649 passing).