### PR TITLE
fix(usage): only show the user's own agents, count messages not tasks

### DIFF
--- a/app/src/components/usage-view/compute-agent-row.tsx
+++ b/app/src/components/usage-view/compute-agent-row.tsx
@@ -11,13 +11,13 @@ interface ComputeAgentRowProps {
   max: number;
   /** Formatted time worked ("3h 12m"). */
   duration: string;
-  /** Formatted task count ("12 tasks"). */
-  tasks: string;
+  /** Formatted message count ("12 messages"). */
+  messages: string;
 }
 
 /**
  * One agent's time worked in the Compute section: avatar + name + duration
- * and task count + a tokened track bar scaled to the busiest agent (the same
+ * and message count + a tokened track bar scaled to the busiest agent (the same
  * shape as the org Usage tab's rows, minus the expandable breakdown — time
  * worked is per-agent, not per-person). Deliberately no liveness badge: the
  * pod's up/idle state is infrastructure the user never needs to see.
@@ -28,7 +28,7 @@ export function ComputeAgentRow({
   color,
   max,
   duration,
-  tasks,
+  messages,
 }: ComputeAgentRowProps) {
   const pct = Math.max(2, Math.round((agent.workMs / max) * 100));
   return (
@@ -40,7 +40,7 @@ export function ComputeAgentRow({
           <span className="shrink-0 text-sm text-ink-muted">
             {duration}
             <span aria-hidden> · </span>
-            {tasks}
+            {messages}
           </span>
         </div>
         <div className="mt-1.5 h-2 overflow-hidden rounded-full bg-chip">

--- a/app/src/components/usage-view/compute-section.tsx
+++ b/app/src/components/usage-view/compute-section.tsx
@@ -19,7 +19,7 @@ import {
   bucketCompute,
   type ComputeRange,
   durationParts,
-  isOpaqueSlug,
+  onlyKnownAgents,
 } from "./compute-usage-model";
 
 const RANGES: ComputeRange[] = ["week", "month", "quarter"];
@@ -69,9 +69,16 @@ export function ComputeSection() {
   const [range, setRange] = useState<ComputeRange>("week");
   const { data, isLoading, isError } = useComputeUsage(true);
 
+  // The user sees exactly the agents they have (the sidebar roster) — deleted
+  // agents' history and anything a gateway might still leak are dropped before
+  // any number is computed, so the list, chart, and totals always agree.
+  const rows = useMemo(
+    () => onlyKnownAgents(data?.rows ?? [], agents),
+    [data, agents],
+  );
   const model = useMemo(
-    () => bucketCompute(data?.rows ?? [], range, Date.now()),
-    [data, range],
+    () => bucketCompute(rows, range, Date.now()),
+    [rows, range],
   );
   const onlineNow = data?.awakeNow ?? [];
   // Selective direct labels: every nonzero bar on the roomy 7-day view; only
@@ -110,7 +117,7 @@ export function ComputeSection() {
         <p className="py-6 text-sm text-ink-muted">
           {t("usage.compute.error")}
         </p>
-      ) : (data?.rows.length ?? 0) === 0 ? (
+      ) : rows.length === 0 ? (
         <Empty className="mt-2">
           <EmptyTitle>{t("usage.compute.empty.title")}</EmptyTitle>
           <EmptyDescription>{t("usage.compute.empty.body")}</EmptyDescription>
@@ -122,7 +129,7 @@ export function ComputeSection() {
               duration: formatDuration(t, model.totalWorkMs),
             })}
             <span aria-hidden> · </span>
-            {t("usage.compute.tasks", { count: model.totalTasks })}
+            {t("usage.compute.messages", { count: model.totalMessages })}
           </p>
           <ComputeBarChart
             buckets={model.buckets}
@@ -135,7 +142,9 @@ export function ComputeSection() {
                   day: "numeric",
                 }),
                 duration: formatDuration(t, bucket.workMs),
-                tasks: t("usage.compute.tasks", { count: bucket.tasks }),
+                messages: t("usage.compute.messages", {
+                  count: bucket.messages,
+                }),
               })
             }
             axisLabel={(bucket) =>
@@ -159,26 +168,24 @@ export function ComputeSection() {
             </h3>
             <ul className="flex flex-col">
               {model.perAgent.map((agent) => {
+                // Every row survived onlyKnownAgents, so the slug always
+                // resolves to a real sidebar agent.
                 const match = agents.find(
                   (a) =>
                     a.folderPath === agent.agentSlug ||
                     a.id === agent.agentSlug,
                 );
-                // A slug with no matching agent and no words in it is a
-                // deleted agent's wire id — say so instead of showing hex.
-                const name =
-                  !match && isOpaqueSlug(agent.agentSlug)
-                    ? t("usage.compute.removedAgent")
-                    : agentLabel(agent.agentSlug, agents);
                 return (
                   <ComputeAgentRow
                     key={agent.agentSlug}
                     agent={agent}
-                    name={name}
+                    name={agentLabel(agent.agentSlug, agents)}
                     color={resolveAgentColor(match?.color)}
                     max={model.maxAgentMs}
                     duration={formatDuration(t, agent.workMs)}
-                    tasks={t("usage.compute.tasks", { count: agent.tasks })}
+                    messages={t("usage.compute.messages", {
+                      count: agent.messages,
+                    })}
                   />
                 );
               })}

--- a/app/src/components/usage-view/compute-section.tsx
+++ b/app/src/components/usage-view/compute-section.tsx
@@ -20,6 +20,7 @@ import {
   type ComputeRange,
   durationParts,
   onlyKnownAgents,
+  withRosterAgents,
 } from "./compute-usage-model";
 
 const RANGES: ComputeRange[] = ["week", "month", "quarter"];
@@ -80,6 +81,13 @@ export function ComputeSection() {
     () => bucketCompute(rows, range, Date.now()),
     [rows, range],
   );
+  // Roster-driven list: a just-created agent appears immediately at
+  // "0m · 0 messages" — the roster updates on creation, no fetch needed.
+  const perAgent = useMemo(
+    () => withRosterAgents(agents, model.perAgent),
+    [agents, model],
+  );
+  const maxAgentMs = Math.max(1, ...perAgent.map((agent) => agent.workMs));
   const onlineNow = data?.awakeNow ?? [];
   // Selective direct labels: every nonzero bar on the roomy 7-day view; only
   // the tallest bar on dense views (the tooltip covers the rest).
@@ -117,7 +125,9 @@ export function ComputeSection() {
         <p className="py-6 text-sm text-ink-muted">
           {t("usage.compute.error")}
         </p>
-      ) : rows.length === 0 ? (
+      ) : perAgent.length === 0 ? (
+        // Only a roster with no agents at all is empty — agents without data
+        // still render (at zero), so a new agent is visible immediately.
         <Empty className="mt-2">
           <EmptyTitle>{t("usage.compute.empty.title")}</EmptyTitle>
           <EmptyDescription>{t("usage.compute.empty.body")}</EmptyDescription>
@@ -167,9 +177,9 @@ export function ComputeSection() {
               {t("usage.compute.byAgent")}
             </h3>
             <ul className="flex flex-col">
-              {model.perAgent.map((agent) => {
-                // Every row survived onlyKnownAgents, so the slug always
-                // resolves to a real sidebar agent.
+              {perAgent.map((agent) => {
+                // Every entry came from the roster (or survived
+                // onlyKnownAgents), so the slug always resolves.
                 const match = agents.find(
                   (a) =>
                     a.folderPath === agent.agentSlug ||
@@ -181,7 +191,7 @@ export function ComputeSection() {
                     agent={agent}
                     name={agentLabel(agent.agentSlug, agents)}
                     color={resolveAgentColor(match?.color)}
-                    max={model.maxAgentMs}
+                    max={maxAgentMs}
                     duration={formatDuration(t, agent.workMs)}
                     messages={t("usage.compute.messages", {
                       count: agent.messages,

--- a/app/src/components/usage-view/compute-usage-model.ts
+++ b/app/src/components/usage-view/compute-usage-model.ts
@@ -126,14 +126,9 @@ export function bucketCompute(
     agent.messages += messages;
   }
 
-  // Agents with nothing to show in the selected range are pure noise: an
-  // awake-but-never-working engine (rows carry awakeMs we never render) would
-  // list as "0m · 0 messages".
-  const agents = [...perAgent.values()]
-    .filter((agent) => agent.workMs > 0 || agent.messages > 0)
-    .sort(
-      (a, b) => b.workMs - a.workMs || a.agentSlug.localeCompare(b.agentSlug),
-    );
+  const agents = [...perAgent.values()].sort(
+    (a, b) => b.workMs - a.workMs || a.agentSlug.localeCompare(b.agentSlug),
+  );
   return {
     buckets,
     perAgent: agents,
@@ -142,6 +137,33 @@ export function bucketCompute(
     maxBucketMs: Math.max(1, ...buckets.map((b) => b.workMs)),
     maxAgentMs: Math.max(1, ...agents.map((a) => a.workMs)),
   };
+}
+
+/**
+ * The by-agent list is ROSTER-driven: every agent the user has appears the
+ * moment it exists (a just-created agent shows "0m · 0 messages" immediately),
+ * merged with whatever totals the range holds. Busiest first, zeros last in
+ * roster order. `agentSlug` for a row-less agent is its folderPath (the wire
+ * key rows will use once data lands) falling back to its id.
+ */
+export function withRosterAgents(
+  roster: readonly KnownAgentRef[],
+  perAgent: readonly ComputeAgentTotals[],
+): ComputeAgentTotals[] {
+  const bySlug = new Map(perAgent.map((agent) => [agent.agentSlug, agent]));
+  const merged = roster.map((agent) => {
+    const totals =
+      (agent.folderPath ? bySlug.get(agent.folderPath) : undefined) ??
+      bySlug.get(agent.id);
+    return (
+      totals ?? {
+        agentSlug: agent.folderPath ?? agent.id,
+        workMs: 0,
+        messages: 0,
+      }
+    );
+  });
+  return merged.sort((a, b) => b.workMs - a.workMs);
 }
 
 /**

--- a/app/src/components/usage-view/compute-usage-model.ts
+++ b/app/src/components/usage-view/compute-usage-model.ts
@@ -6,8 +6,8 @@ import type { Capabilities, ComputeUsageRow } from "@houston-ai/engine-client";
  * per-agent totals. The user sees ONE time metric — time worked = `activeMs`
  * (time the agent actually executed turns/routine runs); `awakeMs` (the
  * engine's full up-time, idle tail included) rides the wire but is
- * deliberately never rendered, and tasks (`turns + routineRuns`) is the
- * companion stat.
+ * deliberately never rendered. The companion stat is messages: turns plus
+ * routine runs, i.e. every exchange the agent handled.
  */
 
 export type ComputeRange = "week" | "month" | "quarter";
@@ -18,20 +18,20 @@ export interface ComputeBucket {
   /** Days folded into this bucket (1 for daily ranges, 7 for weekly). */
   days: number;
   workMs: number;
-  tasks: number;
+  messages: number;
 }
 
 export interface ComputeAgentTotals {
   agentSlug: string;
   workMs: number;
-  tasks: number;
+  messages: number;
 }
 
 export interface ComputeModel {
   buckets: ComputeBucket[];
   perAgent: ComputeAgentTotals[];
   totalWorkMs: number;
-  totalTasks: number;
+  totalMessages: number;
   /** Busiest bucket/agent, floored at 1 so bar math never divides by zero. */
   maxBucketMs: number;
   maxAgentMs: number;
@@ -41,6 +41,30 @@ const DAY_MS = 86_400_000;
 
 const dayString = (ts: number) => new Date(ts).toISOString().slice(0, 10);
 const dayStart = (day: string) => Date.parse(`${day}T00:00:00Z`);
+
+/** The slug/id shape the agent store exposes for matching wire rows. */
+export interface KnownAgentRef {
+  id: string;
+  folderPath?: string;
+}
+
+/**
+ * Keep only rows belonging to agents the user actually has (the sidebar's
+ * roster). Everything else — deleted agents' history, any system pod an
+ * unpatched gateway still serves — must not exist for the user: not in the
+ * list, not in the chart, not in the totals.
+ */
+export function onlyKnownAgents(
+  rows: readonly ComputeUsageRow[],
+  agents: readonly KnownAgentRef[],
+): ComputeUsageRow[] {
+  const known = new Set<string>();
+  for (const agent of agents) {
+    known.add(agent.id);
+    if (agent.folderPath) known.add(agent.folderPath);
+  }
+  return rows.filter((row) => known.has(row.agentSlug));
+}
 
 /** Monday of the UTC week containing `ts` (ISO weeks, like the gateway's days). */
 function weekStart(ts: number): number {
@@ -77,7 +101,7 @@ export function bucketCompute(
     startDay: dayString(start),
     days: bucketDays,
     workMs: 0,
-    tasks: 0,
+    messages: 0,
   }));
   const first = starts[0];
   const spanMs = bucketDays * DAY_MS;
@@ -90,23 +114,23 @@ export function bucketCompute(
     // Rows dated past "now"'s bucket (clock skew) fold into the last bar
     // rather than vanishing — the server is the time authority, not us.
     const bucket = buckets[Math.min(index, buckets.length - 1)];
-    const tasks = row.turns + row.routineRuns;
+    const messages = row.turns + row.routineRuns;
     bucket.workMs += row.activeMs;
-    bucket.tasks += tasks;
+    bucket.messages += messages;
     let agent = perAgent.get(row.agentSlug);
     if (!agent) {
-      agent = { agentSlug: row.agentSlug, workMs: 0, tasks: 0 };
+      agent = { agentSlug: row.agentSlug, workMs: 0, messages: 0 };
       perAgent.set(row.agentSlug, agent);
     }
     agent.workMs += row.activeMs;
-    agent.tasks += tasks;
+    agent.messages += messages;
   }
 
   // Agents with nothing to show in the selected range are pure noise: an
-  // awake-but-never-working engine (rows carry awakeMs we don't render) or a
-  // deleted agent's residual zero days would list as "0m · 0 tasks".
+  // awake-but-never-working engine (rows carry awakeMs we never render) would
+  // list as "0m · 0 messages".
   const agents = [...perAgent.values()]
-    .filter((agent) => agent.workMs > 0 || agent.tasks > 0)
+    .filter((agent) => agent.workMs > 0 || agent.messages > 0)
     .sort(
       (a, b) => b.workMs - a.workMs || a.agentSlug.localeCompare(b.agentSlug),
     );
@@ -114,7 +138,7 @@ export function bucketCompute(
     buckets,
     perAgent: agents,
     totalWorkMs: agents.reduce((sum, a) => sum + a.workMs, 0),
-    totalTasks: agents.reduce((sum, a) => sum + a.tasks, 0),
+    totalMessages: agents.reduce((sum, a) => sum + a.messages, 0),
     maxBucketMs: Math.max(1, ...buckets.map((b) => b.workMs)),
     maxAgentMs: Math.max(1, ...agents.map((a) => a.workMs)),
   };
@@ -140,15 +164,6 @@ export function durationParts(ms: number): DurationParts {
     hours: Math.floor(totalMinutes / 60),
     minutes: String(totalMinutes % 60).padStart(2, "0"),
   };
-}
-
-/**
- * A wire agent slug with no human content (the gateway's 16-hex ids). When it
- * resolves to no known agent, the view shows "Removed agent" instead of raw
- * hex — `agentLabel`'s humanizer only helps slugs with real words in them.
- */
-export function isOpaqueSlug(slug: string): boolean {
-  return /^[0-9a-f]{12,}$/i.test(slug);
 }
 
 /** The section renders only where the gateway advertises the endpoint. */

--- a/app/src/hooks/queries/use-compute-usage.ts
+++ b/app/src/hooks/queries/use-compute-usage.ts
@@ -28,9 +28,12 @@ export function useComputeUsage(enabled: boolean) {
     queryKey: queryKeys.computeUsage(COMPUTE_USAGE_DAYS),
     queryFn: () => tauriOrg.computeUsage(COMPUTE_USAGE_DAYS),
     enabled,
-    staleTime: 60_000,
+    staleTime: 20_000,
+    // The pod flushes its report on every turn start/end (edge-triggered), so
+    // a 30s poll while an agent is up keeps fresh numbers visible within
+    // seconds of work happening; idle agents relax to a 5-minute tick.
     refetchInterval: (query) =>
-      (query.state.data?.awakeNow.length ?? 0) > 0 ? 60_000 : 5 * 60_000,
+      (query.state.data?.awakeNow.length ?? 0) > 0 ? 30_000 : 5 * 60_000,
     refetchOnWindowFocus: true,
   });
 }

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -169,15 +169,13 @@
     },
     "compute": {
       "title": "Time worked",
-      "subtitle": "How much time your agents spent working and how many tasks they handled.",
+      "subtitle": "How much time your agents spent working and how many messages they answered.",
       "range": {
         "week": "7 days",
         "month": "30 days",
         "quarter": "3 months"
       },
       "summary": "Your agents worked {{duration}}",
-      "tasks_one": "{{count}} task",
-      "tasks_other": "{{count}} tasks",
       "byAgent": "By agent",
       "duration": {
         "hm": "{{hours}}h {{minutes}}m",
@@ -185,13 +183,14 @@
         "underMinute": "<1m",
         "zero": "0m"
       },
-      "barLabel": "{{date}}: worked {{duration}}, {{tasks}}",
+      "barLabel": "{{date}}: worked {{duration}}, {{messages}}",
       "empty": {
         "title": "No time worked yet",
-        "body": "When your agents work on tasks, their time will show here."
+        "body": "When your agents work, their time will show here."
       },
       "error": "Couldn't load your agents' time right now. Try again in a moment.",
-      "removedAgent": "Removed agent"
+      "messages_one": "{{count}} message",
+      "messages_other": "{{count}} messages"
     }
   },
   "toast": {}

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -169,15 +169,13 @@
     },
     "compute": {
       "title": "Tiempo trabajado",
-      "subtitle": "Cuánto tiempo dedicaron tus agentes a trabajar y cuántas tareas realizaron.",
+      "subtitle": "Cuánto tiempo dedicaron tus agentes a trabajar y cuántos mensajes respondieron.",
       "range": {
         "week": "7 días",
         "month": "30 días",
         "quarter": "3 meses"
       },
       "summary": "Tus agentes trabajaron {{duration}}",
-      "tasks_one": "{{count}} tarea",
-      "tasks_other": "{{count}} tareas",
       "byAgent": "Por agente",
       "duration": {
         "hm": "{{hours}}h {{minutes}}m",
@@ -185,13 +183,14 @@
         "underMinute": "<1m",
         "zero": "0m"
       },
-      "barLabel": "{{date}}: trabajaron {{duration}}, {{tasks}}",
+      "barLabel": "{{date}}: trabajaron {{duration}}, {{messages}}",
       "empty": {
         "title": "Aún no hay tiempo trabajado",
-        "body": "Cuando tus agentes trabajen en tareas, su tiempo aparecerá aquí."
+        "body": "Cuando tus agentes trabajen, su tiempo aparecerá aquí."
       },
       "error": "No se pudo cargar el tiempo de tus agentes. Intenta de nuevo en un momento.",
-      "removedAgent": "Agente eliminado"
+      "messages_one": "{{count}} mensaje",
+      "messages_other": "{{count}} mensajes"
     }
   },
   "toast": {}

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -169,15 +169,13 @@
     },
     "compute": {
       "title": "Tempo trabalhado",
-      "subtitle": "Quanto tempo seus agentes passaram trabalhando e quantas tarefas realizaram.",
+      "subtitle": "Quanto tempo seus agentes passaram trabalhando e quantas mensagens responderam.",
       "range": {
         "week": "7 dias",
         "month": "30 dias",
         "quarter": "3 meses"
       },
       "summary": "Seus agentes trabalharam {{duration}}",
-      "tasks_one": "{{count}} tarefa",
-      "tasks_other": "{{count}} tarefas",
       "byAgent": "Por agente",
       "duration": {
         "hm": "{{hours}}h {{minutes}}m",
@@ -185,13 +183,14 @@
         "underMinute": "<1m",
         "zero": "0m"
       },
-      "barLabel": "{{date}}: trabalharam {{duration}}, {{tasks}}",
+      "barLabel": "{{date}}: trabalharam {{duration}}, {{messages}}",
       "empty": {
         "title": "Ainda não há tempo trabalhado",
-        "body": "Quando seus agentes trabalharem em tarefas, o tempo deles vai aparecer aqui."
+        "body": "Quando seus agentes trabalharem, o tempo deles vai aparecer aqui."
       },
       "error": "Não foi possível carregar o tempo dos seus agentes. Tente novamente em instantes.",
-      "removedAgent": "Agente removido"
+      "messages_one": "{{count}} mensagem",
+      "messages_other": "{{count}} mensagens"
     }
   },
   "toast": {}

--- a/app/tests/compute-usage-model.test.ts
+++ b/app/tests/compute-usage-model.test.ts
@@ -6,6 +6,7 @@ import {
   durationParts,
   onlyKnownAgents,
   showComputeSection,
+  withRosterAgents,
 } from "../src/components/usage-view/compute-usage-model.ts";
 
 // The displayed metric is time worked (`activeMs`); awake time rides the wire
@@ -115,9 +116,9 @@ describe("bucketCompute", () => {
     strictEqual(model.maxAgentMs, 1);
   });
 
-  it("drops agents with no work and no tasks in range (awake-only ghosts)", () => {
-    const ghost: ComputeUsageRow = {
-      agentSlug: "5e70000000000000",
+  it("keeps zero-work agents in perAgent (the roster merge decides visibility)", () => {
+    const idle: ComputeUsageRow = {
+      agentSlug: "idle-agent",
       day: "2026-07-15",
       awakeMs: 600_000, // awake the whole time...
       activeMs: 0, // ...but never worked
@@ -126,14 +127,40 @@ describe("bucketCompute", () => {
       routineRuns: 0,
     };
     const model = bucketCompute(
-      [ghost, row("real", "2026-07-15", 1_000, 1)],
+      [idle, row("real", "2026-07-15", 1_000, 1)],
       "week",
       NOW,
     );
     deepStrictEqual(
       model.perAgent.map((a) => a.agentSlug),
-      ["real"],
+      ["real", "idle-agent"],
     );
+  });
+});
+
+describe("withRosterAgents", () => {
+  it("lists every roster agent immediately, zeros for those without data", () => {
+    const merged = withRosterAgents(
+      [
+        { id: "Personal/Fresh", folderPath: "fresh" }, // just created, no rows
+        { id: "Personal/Worker", folderPath: "worker" },
+      ],
+      [{ agentSlug: "worker", workMs: 1_000, messages: 3 }],
+    );
+    deepStrictEqual(merged, [
+      { agentSlug: "worker", workMs: 1_000, messages: 3 },
+      { agentSlug: "fresh", workMs: 0, messages: 0 },
+    ]);
+  });
+
+  it("matches totals by folderPath or id and falls back to id as the slug", () => {
+    const merged = withRosterAgents(
+      [{ id: "Personal/ById" }],
+      [{ agentSlug: "Personal/ById", workMs: 42, messages: 1 }],
+    );
+    deepStrictEqual(merged, [
+      { agentSlug: "Personal/ById", workMs: 42, messages: 1 },
+    ]);
   });
 });
 

--- a/app/tests/compute-usage-model.test.ts
+++ b/app/tests/compute-usage-model.test.ts
@@ -4,7 +4,7 @@ import type { ComputeUsageRow } from "@houston-ai/engine-client";
 import {
   bucketCompute,
   durationParts,
-  isOpaqueSlug,
+  onlyKnownAgents,
   showComputeSection,
 } from "../src/components/usage-view/compute-usage-model.ts";
 
@@ -46,7 +46,7 @@ describe("bucketCompute", () => {
       model.buckets.map((b) => b.workMs),
       [0, 0, 0, 0, 0, 0, 3_600_000],
     );
-    strictEqual(model.buckets[6].tasks, 3);
+    strictEqual(model.buckets[6].messages, 3);
   });
 
   it("excludes rows before the range and folds future-dated rows into the last bucket", () => {
@@ -102,11 +102,11 @@ describe("bucketCompute", () => {
       ["big", "a-agent", "b-agent"],
     );
     deepStrictEqual(
-      model.perAgent.map((a) => a.tasks),
+      model.perAgent.map((a) => a.messages),
       [3, 2, 1],
     );
     strictEqual(model.totalWorkMs, 1_000);
-    strictEqual(model.totalTasks, 6);
+    strictEqual(model.totalMessages, 6);
   });
 
   it("floors bar maxima at 1 so empty data never divides by zero", () => {
@@ -137,13 +137,26 @@ describe("bucketCompute", () => {
   });
 });
 
-describe("isOpaqueSlug", () => {
-  it("matches bare wire ids but not nameable slugs", () => {
-    strictEqual(isOpaqueSlug("40e4d673e72e86df"), true);
-    strictEqual(isOpaqueSlug("5e70000000000000"), true);
-    strictEqual(isOpaqueSlug("sales-bot"), false);
-    strictEqual(isOpaqueSlug("deadbeef"), false); // too short to be a wire id
-    strictEqual(isOpaqueSlug("my_agent_2"), false);
+describe("onlyKnownAgents", () => {
+  it("keeps only rows whose slug matches a sidebar agent's id or folderPath", () => {
+    const agents = [
+      { id: "Personal/Assistant", folderPath: "personal-assistant" },
+      { id: "Personal/Scout" },
+    ];
+    const rows = [
+      row("personal-assistant", "2026-07-15", 1_000, 1),
+      row("Personal/Scout", "2026-07-15", 500, 1),
+      row("40e4d673e72e86df", "2026-07-15", 900, 2), // deleted agent
+      row("5e70000000000000", "2026-07-15", 0, 0), // system pod
+    ];
+    deepStrictEqual(
+      onlyKnownAgents(rows, agents).map((r) => r.agentSlug),
+      ["personal-assistant", "Personal/Scout"],
+    );
+  });
+
+  it("returns nothing when the roster is empty", () => {
+    deepStrictEqual(onlyKnownAgents([row("a", "2026-07-15", 1)], []), []);
   });
 });
 

--- a/packages/host/src/usage/sampler.test.ts
+++ b/packages/host/src/usage/sampler.test.ts
@@ -127,16 +127,36 @@ describe("UsageSampler", () => {
     await sampler.tick();
     state.turnBusy = true;
     state.now += 5_000;
-    await sampler.tick();
+    await sampler.tick(); // rising edge: flushes immediately (request #1)
     await sampler.flush();
     state.now += 5_000;
     await sampler.tick();
     await sampler.flush();
-    expect(state.requests).toHaveLength(2);
+    expect(state.requests).toHaveLength(3);
     expect(body(state, 0).days[0]?.activeMs).toBe(5_000);
     expect(lastDay(state).activeMs).toBe(10_000);
     // Same boot: the gateway GREATEST-upserts on (bootId, day).
     expect(body(state, 0).bootId).toBe(lastBody(state).bootId);
+  });
+
+  it("flushes on busy edges with a floor, so turns surface without waiting for the interval", async () => {
+    const { sampler, state } = build();
+    await sampler.tick();
+    state.turnBusy = true;
+    state.now += 5_000;
+    await sampler.tick(); // rising edge -> immediate report
+    expect(state.requests).toHaveLength(1);
+    expect(lastDay(state).turns).toBe(1);
+    state.now += 5_000;
+    await sampler.tick(); // still busy: no edge, no extra report
+    expect(state.requests).toHaveLength(1);
+    state.turnBusy = false;
+    state.now += 5_000;
+    await sampler.tick(); // falling edge -> the finished turn's time reports
+    expect(state.requests).toHaveLength(2);
+    // The idle tick's own stretch is never credited (the turn ended somewhere
+    // inside it — bounded undercount): 2 busy ticks x 5s.
+    expect(lastDay(state).activeMs).toBe(10_000);
   });
 
   it("keeps the accumulator through rejected and failed reports, logging each failure once", async () => {
@@ -166,7 +186,9 @@ describe("UsageSampler", () => {
     await sampler.stop();
     expect(lastDay(state).activeMs).toBe(5_000);
     await sampler.stop(); // idempotent
-    expect(state.requests).toHaveLength(1);
+    // stop() drains via one edge flush (the final sample sees the rising
+    // edge) plus the terminal flush; a second stop adds nothing.
+    expect(state.requests).toHaveLength(2);
   });
 
   it("never accrues or reports after a failed sample", async () => {

--- a/packages/host/src/usage/sampler.ts
+++ b/packages/host/src/usage/sampler.ts
@@ -59,6 +59,8 @@ export class UsageSampler {
   private readonly now: () => number;
   private readonly log: (message: string, err?: unknown) => void;
   private lastTickAt = 0;
+  private lastBusy = false;
+  private lastEdgeFlushAt = 0;
   private lastFailure: string | null = null;
   private timers: ReturnType<typeof setInterval>[] = [];
   private stopped = false;
@@ -122,6 +124,17 @@ export class UsageSampler {
       return;
     }
     if (busy && elapsed > 0) this.credit(now - elapsed, now);
+    // Edge-triggered flush: report the moment work starts or finishes so the
+    // app sees new turns within one poll instead of one flush interval. The
+    // periodic flush stays the backstop for long-running work; a floor keeps
+    // rapid-fire turns from turning every edge into a request.
+    if (busy !== this.lastBusy) {
+      this.lastBusy = busy;
+      if (now - this.lastEdgeFlushAt >= this.sampleMs) {
+        this.lastEdgeFlushAt = now;
+        await this.flush();
+      }
+    }
   }
 
   /** Report today's (± yesterday's) cumulative totals. Never throws. */

--- a/packages/web/e2e/usage-compute.spec.ts
+++ b/packages/web/e2e/usage-compute.spec.ts
@@ -79,9 +79,9 @@ test("with data the section shows the total, daily bars, and per-agent rows", as
       // Seed agent: resolves to its display name. 2h05m worked today + 1h yesterday.
       row("houston-assistant", 0, 125 * 60_000, 8, 2),
       row("houston-assistant", 1, 60 * 60_000, 3, 0),
-      // A since-deleted agent humanizes from its slug.
+      // A since-deleted agent (not in the sidebar roster): invisible, even
+      // with real work — the user only ever sees agents they actually have.
       row("sales-bot", 1, 30 * 60_000, 1, 0),
-      // A deleted agent's bare wire id, with real work: labels "Removed agent".
       row("40e4d673e72e86df", 1, 5 * 60_000, 1, 0),
       // An awake-but-never-working ghost (e.g. residual zero days): the row
       // carries only awakeMs, so the by-agent list must not show it at all.
@@ -103,16 +103,19 @@ test("with data the section shows the total, daily bars, and per-agent rows", as
   await expect(
     page.getByRole("heading", { name: "Time worked" }),
   ).toBeVisible();
-  // 2h05 + 1h + 30m + 5m = 3h 40m across 15 tasks (10 + 3 + 1 + 1); the
-  // awake-only ghost contributes nothing.
-  await expect(page.getByText("Your agents worked 3h 40m")).toBeVisible();
-  await expect(page.getByText("15 tasks")).toBeVisible();
+  // Only the seed agent counts: 2h05 + 1h = 3h 05m across 13 messages
+  // (10 + 3). Deleted agents and ghosts contribute nothing anywhere.
+  // With only one visible agent the summary equals its row, so scope the
+  // message count to the summary paragraph (strict mode would match both).
+  const summary = page.getByText("Your agents worked 3h 05m");
+  await expect(summary).toBeVisible();
+  await expect(summary).toContainText("13 messages");
 
-  // 7 daily bars, each self-describing ("Jul 15: worked 2h 05m, 10 tasks").
+  // 7 daily bars, each self-describing ("Jul 15: worked 2h 05m, 10 messages").
   await expect(page.getByRole("img", { name: /: worked / })).toHaveCount(7);
 
   // Per-agent rows: the seed agent resolves to its display name (3h 05m
-  // across 13 tasks); the deleted slug humanizes. Scope
+  // across 13 messages). Scope
   // to the compute section — the AI-accounts cards below are also list items
   // and their "not metered yet" copy mentions Houston by name.
   const computeSection = page
@@ -122,22 +125,14 @@ test("with data the section shows the total, daily bars, and per-agent rows", as
     .getByRole("listitem")
     .filter({ hasText: "Houston" });
   await expect(houston).toContainText("3h 05m");
-  await expect(houston).toContainText("13 tasks");
+  await expect(houston).toContainText("13 messages");
   // No liveness badge: pod up/idle state is infrastructure the user never sees.
   await expect(houston.getByText("Online")).toHaveCount(0);
-  const sales = computeSection
-    .getByRole("listitem")
-    .filter({ hasText: "Sales bot" });
-  await expect(sales).toContainText("30m");
-  await expect(sales).toContainText("1 task");
-
-  // The deleted agent's bare wire id reads "Removed agent", never raw hex...
-  const removed = computeSection
-    .getByRole("listitem")
-    .filter({ hasText: "Removed agent" });
-  await expect(removed).toContainText("5m");
+  // Nothing outside the sidebar roster exists on the page — no deleted
+  // agents, no "Removed agent" placeholder, no raw wire ids.
+  await expect(page.getByText("Sales bot")).toHaveCount(0);
+  await expect(page.getByText("Removed agent")).toHaveCount(0);
   await expect(page.getByText("40e4d673e72e86df")).toHaveCount(0);
-  // ...and the awake-only ghost is not listed at all.
   await expect(page.getByText("1dee000000000000")).toHaveCount(0);
 
   // The account sections moved behind the "Model usage" half of the pane
@@ -194,8 +189,6 @@ test("with the capability but no rows the section shows its empty state", async 
   ).toBeVisible();
   await expect(page.getByText("No time worked yet")).toBeVisible();
   await expect(
-    page.getByText(
-      "When your agents work on tasks, their time will show here.",
-    ),
+    page.getByText("When your agents work, their time will show here."),
   ).toBeVisible();
 });

--- a/packages/web/e2e/usage-compute.spec.ts
+++ b/packages/web/e2e/usage-compute.spec.ts
@@ -174,12 +174,15 @@ test("switching the range changes the bar count without a new fetch", async ({
   await expect(bars).toHaveCount(13);
 });
 
-// ── 4. Armed but no data yet: the honest empty state ───────────────────────
+// ── 4. No data yet: every roster agent is still visible immediately ────────
 
-test("with the capability but no rows the section shows its empty state", async ({
+test("an agent with no usage rows appears immediately at zero", async ({
   page,
   request,
 }) => {
+  // A just-created agent has NO rows on the wire yet — the list is roster-
+  // driven, so it must show up at "0m · 0 messages" without waiting for the
+  // pod to report anything.
   await armComputeUsage(request, { rows: [], awakeNow: [] });
   await page.goto("/");
   await page.locator('[data-tour-target="nav-usage"]').click();
@@ -187,8 +190,13 @@ test("with the capability but no rows the section shows its empty state", async 
   await expect(
     page.getByRole("heading", { name: "Time worked" }),
   ).toBeVisible();
-  await expect(page.getByText("No time worked yet")).toBeVisible();
-  await expect(
-    page.getByText("When your agents work, their time will show here."),
-  ).toBeVisible();
+  const houston = page
+    .locator("section")
+    .filter({ has: page.getByRole("heading", { name: "Time worked" }) })
+    .getByRole("listitem")
+    .filter({ hasText: "Houston" });
+  await expect(houston).toContainText("0m");
+  await expect(houston).toContainText("0 messages");
+  // The empty state is reserved for a roster with no agents at all.
+  await expect(page.getByText("No time worked yet")).toHaveCount(0);
 });


### PR DESCRIPTION
## What

Two follow-ups from Daniel's 0.5.14 testing (screenshot showed deleted agents alongside the real Personal Assistant, and 'tasks' read ambiguously):

1. **The section shows exactly the sidebar's agents.** `onlyKnownAgents` filters the wire rows against the agent roster before any number is computed — deleted agents' history and anything an unpatched gateway still serves vanish from the list, the chart, and the totals together (no more mismatched numbers). The "Removed agent" placeholder and `isOpaqueSlug` are deleted — nothing unresolvable can render anymore.
2. **"Tasks" → "messages".** One message = one exchange the agent handled: a chat turn (your message + its reply) or a routine run reporting back. Renamed across the model (`messages`/`totalMessages`), components, and en/es/pt locale keys (`messages_one/_other`); subtitle now says "how many messages they answered".

## Notes

- Deleted agents' compute history remains stored server-side and on the wire — this only stops rendering it. If we ever want a "history includes removed agents" toggle, the data is all there.
- Trade-off accepted: an agent deleted mid-week takes its numbers out of the totals, so the week's sum matches what the user can see, not what the org consumed. The org-level truth stays in the gateway tables.

## Tests

- Model: `onlyKnownAgents` (id + folderPath matching, empty roster), renames across the aggregation tests.
- E2E: the data spec seeds a deleted agent with real work + hex ghosts and asserts none of them appear anywhere while totals count only the roster agent; wording assertions moved to "messages".
- Gates: Biome, app tsgo, check-locales, 1644 unit tests, 4/4 compute e2e, web typechecks.


## Update: new agents visible immediately + faster refresh

- **Roster-driven list**: every sidebar agent renders the moment it exists, at "0m · 0 messages" until data lands — creating an agent shows it in the section instantly, no fetch involved.
- **Edge-triggered pod reports**: the sampler flushes on every turn/routine start and end (floored at one sample interval) instead of only on the 60s timer, so a finished turn reaches the gateway within seconds. Ships with the next engine-pod image roll.
- **Faster client poll**: 30s while any agent is up (was 60s), staleTime 20s. Net effect: numbers appear within ~30s of work instead of ~2 minutes; the agent itself appears immediately.