### PR TITLE
feat(store): app parity wave — categories, integration filter, reporting, owner dashboard

### DIFF
--- a/app/src/components/agent-integration-chips.tsx
+++ b/app/src/components/agent-integration-chips.tsx
@@ -1,6 +1,5 @@
-import { useMemo, useState } from "react";
-import { useIntegrationStatus, useIntegrationToolkits } from "../hooks/queries";
-import { appDisplay, INTEGRATION_PROVIDER } from "./integrations";
+import { useState } from "react";
+import { appDisplay, useToolkitBySlug } from "./integrations";
 
 interface Props {
   /** Composio toolkit slugs the agent is designed to work with. */
@@ -22,14 +21,7 @@ interface Props {
  * with no integration provider wired — `appDisplay` falls back to the guess.
  */
 export function AgentIntegrationChips({ slugs, max = 6 }: Props) {
-  const status = useIntegrationStatus();
-  const ready = !!status.data?.find((p) => p.provider === INTEGRATION_PROVIDER)
-    ?.ready;
-  const catalog = useIntegrationToolkits(INTEGRATION_PROVIDER, ready);
-  const bySlug = useMemo(
-    () => new Map((catalog.data ?? []).map((tk) => [tk.slug, tk])),
-    [catalog.data],
-  );
+  const bySlug = useToolkitBySlug();
 
   if (slugs.length === 0) return null;
   const shown = slugs.slice(0, max);

--- a/app/src/components/integrations/index.ts
+++ b/app/src/components/integrations/index.ts
@@ -69,3 +69,7 @@ export {
   type IntegrationsGate,
   useIntegrationsGate,
 } from "./use-integrations-gate";
+export {
+  useReadyToolkitCatalog,
+  useToolkitBySlug,
+} from "./use-toolkit-catalog";

--- a/app/src/components/integrations/use-toolkit-catalog.ts
+++ b/app/src/components/integrations/use-toolkit-catalog.ts
@@ -1,0 +1,34 @@
+import type { IntegrationToolkit } from "@houston-ai/engine-client";
+import { useMemo } from "react";
+import {
+  useIntegrationStatus,
+  useIntegrationToolkits,
+} from "../../hooks/queries";
+import { INTEGRATION_PROVIDER } from "./model";
+
+/**
+ * The integration provider's toolkit catalog, gated on the provider being
+ * READY (the Houston session push has landed). The single home for the
+ * readiness predicate every read-only display surface used to repeat inline:
+ * the catalog is fetched only once the status query reports the provider
+ * `ready`, so a still-warming gateway never fires a failing toolkits call.
+ */
+export function useReadyToolkitCatalog() {
+  const status = useIntegrationStatus();
+  const ready = !!status.data?.find((p) => p.provider === INTEGRATION_PROVIDER)
+    ?.ready;
+  return useIntegrationToolkits(INTEGRATION_PROVIDER, ready);
+}
+
+/**
+ * The ready toolkit catalog indexed by slug — the one source for turning a
+ * machine slug into its display identity through {@link appDisplay}. Memoized
+ * on the catalog data so consumers get a stable map across renders.
+ */
+export function useToolkitBySlug(): Map<string, IntegrationToolkit> {
+  const catalog = useReadyToolkitCatalog();
+  return useMemo(
+    () => new Map((catalog.data ?? []).map((tk) => [tk.slug, tk])),
+    [catalog.data],
+  );
+}

--- a/app/src/components/portable/manage-publication.tsx
+++ b/app/src/components/portable/manage-publication.tsx
@@ -72,6 +72,21 @@ export function ManagePublication({
             {t("publish.manage.remove")}
           </Button>
         </div>
+        <div>
+          <Button
+            variant="ghost"
+            className="rounded-full"
+            disabled={busy}
+            onClick={() => {
+              const ui = useUIStore.getState();
+              ui.setShareAgentId(null);
+              ui.setStoreOwnerTab("my");
+              ui.setViewMode(STORE_VIEW_ID);
+            }}
+          >
+            {t("publish.manage.manageAll")}
+          </Button>
+        </div>
         <p className="text-xs text-muted-foreground">
           {t("publish.manage.updateHint")}
         </p>

--- a/app/src/components/store-view/my-agent-row.tsx
+++ b/app/src/components/store-view/my-agent-row.tsx
@@ -1,0 +1,130 @@
+import { Badge, Button } from "@houston-ai/core";
+import type { MyAgent } from "@houston-ai/engine-client";
+import { useTranslation } from "react-i18next";
+import { StoreAgentIcon } from "./store-agent-icon";
+import type { RequestPublicMode } from "./store-view-model";
+
+/** The button label for each non-hidden "request public listing" mode. */
+const REQUEST_PUBLIC_LABEL: Record<
+  Exclude<RequestPublicMode, "hidden">,
+  string
+> = {
+  available: "myAgents.action.requestPublic",
+  pending: "myAgents.action.requestPublicPending",
+  requested: "myAgents.action.requestPublicDone",
+};
+
+/**
+ * One owner-dashboard row: the same catalog grammar the browse tab leads with
+ * (glyph, name, tagline, install count) plus lifecycle badges and the owner's
+ * always-visible action buttons. Every affordance is a real button (no hover-
+ * only reveals); which ones show follows the agent's state/visibility.
+ */
+export function MyAgentRow({
+  agent,
+  busy,
+  requestPublicMode,
+  onRequestPublic,
+  onMakeUnlisted,
+  onUnpublish,
+  onDelete,
+  onSeeInStore,
+}: {
+  agent: MyAgent;
+  busy: boolean;
+  requestPublicMode: RequestPublicMode;
+  onRequestPublic: () => void;
+  onMakeUnlisted: () => void;
+  onUnpublish: () => void;
+  onDelete: () => void;
+  onSeeInStore: () => void;
+}) {
+  const { t } = useTranslation("store");
+  const published = agent.state === "published";
+  const isPublic = agent.visibility === "public";
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-line p-4 sm:flex-row sm:items-center">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <StoreAgentIcon agent={agent} />
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="truncate font-medium text-ink">{agent.name}</span>
+            {agent.state && (
+              <Badge variant="secondary">
+                {t(`myAgents.state.${agent.state}`)}
+              </Badge>
+            )}
+            {published && agent.visibility && (
+              <Badge variant="outline">
+                {t(`myAgents.visibility.${agent.visibility}`)}
+              </Badge>
+            )}
+          </div>
+          {agent.tagline && (
+            <p className="truncate text-sm text-ink-muted">{agent.tagline}</p>
+          )}
+          <p className="mt-0.5 text-xs text-ink-muted tabular-nums">
+            {t("installs", { count: agent.installsCount })}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+        {requestPublicMode !== "hidden" && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="rounded-full"
+            disabled={busy || requestPublicMode !== "available"}
+            onClick={onRequestPublic}
+          >
+            {t(REQUEST_PUBLIC_LABEL[requestPublicMode])}
+          </Button>
+        )}
+        {published && isPublic && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="rounded-full"
+            disabled={busy}
+            onClick={onMakeUnlisted}
+          >
+            {t("myAgents.action.makeUnlisted")}
+          </Button>
+        )}
+        {agent.slug && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="rounded-full"
+            disabled={busy}
+            onClick={onSeeInStore}
+          >
+            {t("myAgents.action.seeInStore")}
+          </Button>
+        )}
+        {published && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="rounded-full"
+            disabled={busy}
+            onClick={onUnpublish}
+          >
+            {t("myAgents.action.unpublish")}
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="rounded-full text-destructive hover:text-destructive"
+          disabled={busy}
+          onClick={onDelete}
+        >
+          {t("myAgents.action.delete")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/store-view/my-agents-panel.tsx
+++ b/app/src/components/store-view/my-agents-panel.tsx
@@ -1,0 +1,140 @@
+import { Button, ConfirmDialog } from "@houston-ai/core";
+import type { MyAgent } from "@houston-ai/engine-client";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useSession } from "../../hooks/use-session";
+import { signInWithGoogle } from "../../lib/auth";
+import { showErrorToast } from "../../lib/error-toast";
+import { useUIStore } from "../../stores/ui";
+import { MyAgentRow } from "./my-agent-row";
+import { requestPublicMode } from "./store-view-model";
+import { useMyStoreAgents } from "./use-my-store-agents";
+
+/** Which confirm-gated action is pending, and on which agent. */
+type Confirm = { kind: "delete" | "unpublish"; agent: MyAgent };
+
+/**
+ * The Agent Store's "my agents" tab: the signed-in owner's published agents in
+ * the catalog row grammar, each with its lifecycle actions (request public,
+ * make unlisted, unpublish, delete, see in store). Fully self-contained — its
+ * own data hook, the ui store for the "see in store" deep link, and the app's
+ * Google sign-in for the signed-out CTA. Destructive actions are confirm-gated.
+ */
+export function MyAgentsPanel() {
+  const { t } = useTranslation("store");
+  const { data: session } = useSession();
+  const signedIn = Boolean(session);
+  const my = useMyStoreAgents(signedIn);
+  const [confirm, setConfirm] = useState<Confirm | null>(null);
+  const [signingIn, setSigningIn] = useState(false);
+
+  const handleSignIn = async () => {
+    setSigningIn(true);
+    try {
+      await signInWithGoogle();
+    } catch (err) {
+      setSigningIn(false);
+      showErrorToast(
+        "store_sign_in",
+        err instanceof Error ? err.message : String(err),
+        err,
+      );
+    }
+  };
+
+  const seeInStore = (agent: MyAgent) => {
+    if (agent.slug) useUIStore.getState().setStoreFocusSlug(agent.slug);
+  };
+
+  if (!signedIn) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-16 text-center">
+        <p className="text-sm text-ink-muted">{t("myAgents.signedOut")}</p>
+        <Button
+          className="rounded-full"
+          disabled={signingIn}
+          onClick={() => void handleSignIn()}
+        >
+          {t("myAgents.signIn")}
+        </Button>
+      </div>
+    );
+  }
+
+  if (my.isPending) return <RowsSkeleton />;
+  if (my.isError) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-16">
+        <p className="text-sm text-ink-muted">{t("loadFailed")}</p>
+        <Button
+          variant="outline"
+          className="rounded-full"
+          onClick={() => void my.refetch()}
+        >
+          {t("retry")}
+        </Button>
+      </div>
+    );
+  }
+  if (my.agents.length === 0) {
+    return (
+      <p className="py-16 text-center text-sm text-ink-muted">
+        {t("myAgents.empty")}
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        {my.agents.map((agent) => (
+          <MyAgentRow
+            key={agent.id}
+            agent={agent}
+            busy={my.isBusy(agent.id)}
+            requestPublicMode={requestPublicMode(agent, {
+              inFlight: my.isRequestingPublic(agent.id),
+              requested: my.wasRequestedPublic(agent.id),
+            })}
+            onRequestPublic={() => my.requestPublic.mutate(agent.id)}
+            onMakeUnlisted={() => my.makeUnlisted.mutate(agent.id)}
+            onUnpublish={() => setConfirm({ kind: "unpublish", agent })}
+            onDelete={() => setConfirm({ kind: "delete", agent })}
+            onSeeInStore={() => seeInStore(agent)}
+          />
+        ))}
+      </div>
+
+      <ConfirmDialog
+        open={confirm !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirm(null);
+        }}
+        title={t(`myAgents.confirm.${confirm?.kind ?? "delete"}Title`)}
+        description={t(`myAgents.confirm.${confirm?.kind ?? "delete"}Body`, {
+          name: confirm?.agent.name ?? "",
+        })}
+        confirmLabel={t(`myAgents.confirm.${confirm?.kind ?? "delete"}Confirm`)}
+        cancelLabel={t("myAgents.confirm.cancel")}
+        onConfirm={() => {
+          if (!confirm) return;
+          const { kind, agent } = confirm;
+          if (kind === "delete") my.remove.mutate(agent.id);
+          else my.unpublish.mutate(agent.id);
+          setConfirm(null);
+        }}
+      />
+    </>
+  );
+}
+
+/** Row placeholders while the owner list settles. Decorative only. */
+function RowsSkeleton() {
+  return (
+    <div aria-hidden className="flex flex-col gap-2">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="h-[76px] animate-pulse rounded-xl bg-chip" />
+      ))}
+    </div>
+  );
+}

--- a/app/src/components/store-view/store-browse.tsx
+++ b/app/src/components/store-view/store-browse.tsx
@@ -1,0 +1,165 @@
+import { CatalogSearchField } from "@houston-ai/core";
+import type {
+  StoreCatalogAgent,
+  StoreCatalogSort,
+} from "@houston-ai/engine-client";
+import { fetchStoreAgent, fetchStoreCatalog } from "@houston-ai/engine-client";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { reportError } from "../../lib/error-toast";
+import { useUIStore } from "../../stores/ui";
+import { StoreCatalogResults } from "./store-catalog-results";
+import { StoreDetailDialog } from "./store-detail-dialog";
+import { StoreCategoryChips, StoreSortToggle } from "./store-filters";
+import { StoreIntegrationFilter } from "./store-integration-filter";
+import { browseIntegrationOptions } from "./store-view-model";
+import { useStoreInstall } from "./use-store-install";
+
+/** The sentinel for "no filter", shared by the category and integration filters. */
+const ALL = "all";
+
+/**
+ * The Agent Store's Browse tab: the public catalog in the app's catalog grammar
+ * (search + category chips + integration filter over the flat row grid, a row
+ * body opening the detail modal, the row's `+` running the one-click install).
+ * All reads are the anonymous CORS-open gateway; nothing here needs an account
+ * until the moment of install. Consumes the one-shot `storeFocusSlug` deep link
+ * to open the detail dialog, so "See it in the store" works from either tab.
+ */
+export function StoreBrowse() {
+  const { t } = useTranslation("store");
+  const [search, setSearch] = useState("");
+  const [q, setQ] = useState("");
+  const [category, setCategory] = useState(ALL);
+  const [integration, setIntegration] = useState(ALL);
+  const [sort, setSort] = useState<StoreCatalogSort>("recent");
+  const [detailAgent, setDetailAgent] = useState<StoreCatalogAgent | null>(
+    null,
+  );
+  const { install, installingSlug } = useStoreInstall();
+
+  // Debounce typing into the server-side full-text query.
+  useEffect(() => {
+    const handle = setTimeout(() => setQ(search.trim()), 300);
+    return () => clearTimeout(handle);
+  }, [search]);
+
+  const catalog = useInfiniteQuery({
+    queryKey: ["store-catalog", q, category, integration, sort],
+    queryFn: ({ pageParam }) =>
+      fetchStoreCatalog({
+        q: q || undefined,
+        category: category === ALL ? undefined : category,
+        integration:
+          integration === ALL ? undefined : integration.toUpperCase(),
+        sort,
+        page: pageParam,
+      }),
+    initialPageParam: 1,
+    getNextPageParam: (last, all) =>
+      last.hasMore ? all.length + 1 : undefined,
+    staleTime: 60_000,
+  });
+
+  // The filter's option vocabulary must not come from the result set it scopes:
+  // selecting a toolkit refetches the catalog to only that toolkit's agents, so
+  // the grid can no longer name the other toolkits a user might switch to. When a
+  // filter is active, read the vocabulary from a dedicated catalog page that omits
+  // the integration filter (still scoped by search/category/sort); with no filter
+  // active the grid is already that unfiltered source. See browseIntegrationOptions.
+  const optionCatalog = useQuery({
+    queryKey: ["store-catalog-options", q, category, sort],
+    queryFn: () =>
+      fetchStoreCatalog({
+        q: q || undefined,
+        category: category === ALL ? undefined : category,
+        sort,
+        page: 1,
+      }),
+    staleTime: 60_000,
+    enabled: integration !== ALL,
+  });
+
+  // One-shot deep link: "See it in the store" surfaces set a slug before
+  // switching views; consume it into the detail dialog (a vanished listing
+  // just reports — the catalog behind it is already the right fallback).
+  const focusSlug = useUIStore((s) => s.storeFocusSlug);
+  useEffect(() => {
+    if (!focusSlug) return;
+    useUIStore.getState().setStoreFocusSlug(null);
+    fetchStoreAgent(focusSlug)
+      .then((detail) => setDetailAgent(detail.agent))
+      .catch((err: unknown) => {
+        reportError(
+          "store_focus",
+          `store focus fetch failed (${focusSlug})`,
+          err,
+        );
+      });
+  }, [focusSlug]);
+
+  const items = catalog.data?.pages.flatMap((page) => page.items) ?? [];
+
+  // The connected apps offered as filter options, sourced so a chosen toolkit
+  // never collapses the set of toolkits a user can switch to: the loaded grid
+  // when unfiltered, else the dedicated unfiltered read. See
+  // browseIntegrationOptions.
+  const integrations = useMemo(
+    () =>
+      browseIntegrationOptions(
+        catalog.data?.pages.flatMap((page) => page.items) ?? [],
+        optionCatalog.data?.items ?? [],
+        integration === ALL ? null : integration,
+      ),
+    [catalog.data, optionCatalog.data, integration],
+  );
+
+  const handleInstall = async (slug: string) => {
+    if (await install(slug)) setDetailAgent(null);
+  };
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <CatalogSearchField
+          value={search}
+          onChange={setSearch}
+          label={t("searchPlaceholder")}
+          className="flex-1"
+        />
+        {integrations.length > 0 && (
+          <StoreIntegrationFilter
+            value={integration}
+            onChange={setIntegration}
+            integrations={integrations}
+          />
+        )}
+        <StoreSortToggle sort={sort} onSortChange={setSort} />
+      </div>
+      <StoreCategoryChips category={category} onCategoryChange={setCategory} />
+
+      <div className="mt-6">
+        <StoreCatalogResults
+          items={items}
+          isPending={catalog.isPending}
+          isError={catalog.isError}
+          hasNextPage={catalog.hasNextPage}
+          isFetchingNextPage={catalog.isFetchingNextPage}
+          installingSlug={installingSlug}
+          onRetry={() => void catalog.refetch()}
+          onShowMore={() => void catalog.fetchNextPage()}
+          onInstall={(slug) => void handleInstall(slug)}
+          onOpenDetail={setDetailAgent}
+        />
+      </div>
+
+      <StoreDetailDialog
+        agent={detailAgent}
+        onClose={() => setDetailAgent(null)}
+        onInstall={(slug) => void handleInstall(slug)}
+        installing={installingSlug !== null}
+      />
+    </div>
+  );
+}

--- a/app/src/components/store-view/store-catalog-results.tsx
+++ b/app/src/components/store-view/store-catalog-results.tsx
@@ -1,0 +1,109 @@
+import {
+  Button,
+  CatalogAddButton,
+  CatalogGrid,
+  CatalogRow,
+  CatalogShowMore,
+} from "@houston-ai/core";
+import type { StoreCatalogAgent } from "@houston-ai/engine-client";
+import { useTranslation } from "react-i18next";
+import { StoreAgentIcon } from "./store-agent-icon";
+import { formatInstalls } from "./store-view-model";
+
+/**
+ * The Browse tab's result region: the load/error/empty/grid state machine over
+ * a page of catalog listings. Purely presentational — the owning
+ * {@link StoreBrowse} holds the query and install state and passes them in.
+ */
+export function StoreCatalogResults({
+  items,
+  isPending,
+  isError,
+  hasNextPage,
+  isFetchingNextPage,
+  installingSlug,
+  onRetry,
+  onShowMore,
+  onInstall,
+  onOpenDetail,
+}: {
+  items: StoreCatalogAgent[];
+  isPending: boolean;
+  isError: boolean;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  installingSlug: string | null;
+  onRetry: () => void;
+  onShowMore: () => void;
+  onInstall: (slug: string) => void;
+  onOpenDetail: (agent: StoreCatalogAgent) => void;
+}) {
+  const { t, i18n } = useTranslation("store");
+
+  if (isPending) return <RowsSkeleton />;
+  if (isError) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-16">
+        <p className="text-sm text-ink-muted">{t("loadFailed")}</p>
+        <Button variant="outline" className="rounded-full" onClick={onRetry}>
+          {t("retry")}
+        </Button>
+      </div>
+    );
+  }
+  if (items.length === 0) {
+    return (
+      <p className="py-16 text-center text-sm text-ink-muted">{t("empty")}</p>
+    );
+  }
+
+  return (
+    <>
+      <CatalogGrid>
+        {items.map((agent) => (
+          <CatalogRow
+            key={agent.id}
+            icon={<StoreAgentIcon agent={agent} />}
+            title={agent.name}
+            description={agent.tagline ?? agent.description}
+            trailing={
+              <span
+                className="shrink-0 text-[12px] text-ink-muted tabular-nums"
+                title={t("installs", { count: agent.installsCount })}
+              >
+                {formatInstalls(agent.installsCount, i18n.language)}
+              </span>
+            }
+            action={
+              agent.slug ? (
+                <CatalogAddButton
+                  label={t("installLabel", { name: agent.name })}
+                  busy={installingSlug === agent.slug}
+                  disabled={installingSlug !== null}
+                  onClick={() => onInstall(agent.slug ?? "")}
+                />
+              ) : undefined
+            }
+            onClick={() => onOpenDetail(agent)}
+          />
+        ))}
+      </CatalogGrid>
+      {hasNextPage && (
+        <CatalogShowMore disabled={isFetchingNextPage} onClick={onShowMore}>
+          {t("showMore")}
+        </CatalogShowMore>
+      )}
+    </>
+  );
+}
+
+/** Row placeholders while the first page settles. Decorative only. */
+function RowsSkeleton() {
+  return (
+    <div aria-hidden className="grid grid-cols-1 gap-1 lg:grid-cols-2">
+      {[0, 1, 2, 3, 4, 5].map((i) => (
+        <div key={i} className="h-[60px] animate-pulse rounded-xl bg-chip" />
+      ))}
+    </div>
+  );
+}

--- a/app/src/components/store-view/store-detail-dialog.tsx
+++ b/app/src/components/store-view/store-detail-dialog.tsx
@@ -2,12 +2,17 @@ import { Badge, Button, CatalogDetailDialog, Spinner } from "@houston-ai/core";
 import type { StoreCatalogAgent } from "@houston-ai/engine-client";
 import { fetchStoreAgent } from "@houston-ai/engine-client";
 import { useQuery } from "@tanstack/react-query";
+import { FlagIcon } from "lucide-react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { reportError } from "../../lib/error-toast";
 import {
   isStoreCategory,
   storeCategoryLabelKey,
 } from "../../lib/store-categories";
+import { AppLogo, appDisplay, useToolkitBySlug } from "../integrations";
 import { StoreAgentIcon } from "./store-agent-icon";
+import { StoreReportDialog } from "./store-report-dialog";
 
 /**
  * A listing's "more info" modal — the catalog family's detail surface. The
@@ -28,6 +33,7 @@ export function StoreDetailDialog({
 }) {
   const { t } = useTranslation("store");
   const { t: tPortable } = useTranslation("portable");
+  const [reportOpen, setReportOpen] = useState(false);
   const slug = agent?.slug ?? null;
 
   const detail = useQuery({
@@ -36,6 +42,20 @@ export function StoreDetailDialog({
     enabled: slug !== null,
     staleTime: 60_000,
   });
+
+  // The IR enrichment degrades gracefully (skills/learnings just don't render),
+  // so a toast would be noise, but the failure must still reach Sentry: a
+  // user-initiated fetch never fails silently. Same path as the sibling
+  // category fetch in store-filters.tsx.
+  useEffect(() => {
+    if (detail.error) {
+      reportError(
+        "store_detail",
+        `store agent detail fetch failed (${slug})`,
+        detail.error,
+      );
+    }
+  }, [detail.error, slug]);
 
   if (!agent || !slug) return null;
 
@@ -46,73 +66,119 @@ export function StoreDetailDialog({
     : agent.category;
 
   return (
-    <CatalogDetailDialog
-      open
-      onOpenChange={(open) => {
-        if (!open) onClose();
-      }}
-      icon={<StoreAgentIcon agent={agent} />}
-      title={agent.name}
-      tags={
-        <>
-          <Badge variant="secondary">{categoryLabel}</Badge>
-          {agent.tags.map((tag) => (
-            <Badge key={tag} variant="outline">
-              {tag}
-            </Badge>
-          ))}
-        </>
-      }
-      description={agent.description}
-      action={
-        <Button
-          onClick={() => onInstall(slug)}
-          disabled={installing}
-          className="rounded-full"
-        >
-          {installing && <Spinner className="size-4" />}
-          {t("install")}
-        </Button>
-      }
-    >
-      <div className="space-y-3 text-sm">
-        <p className="text-ink-muted">
-          {t("detail.by", { name: agent.creator.displayName })}
-          {" · "}
-          {t("installs", { count: agent.installsCount })}
-        </p>
-        {skills.length > 0 && (
-          <div>
-            <p className="mb-1.5 font-medium text-ink">{t("detail.skills")}</p>
-            <div className="flex flex-wrap gap-1.5">
-              {skills.map((skill) => (
-                <Badge key={skill.slug} variant="outline">
-                  {skill.slug}
-                </Badge>
-              ))}
-            </div>
+    <>
+      <CatalogDetailDialog
+        open
+        onOpenChange={(open) => {
+          if (!open) onClose();
+        }}
+        icon={<StoreAgentIcon agent={agent} />}
+        title={agent.name}
+        tags={
+          <>
+            <Badge variant="secondary">{categoryLabel}</Badge>
+            {agent.tags.map((tag) => (
+              <Badge key={tag} variant="outline">
+                {tag}
+              </Badge>
+            ))}
+          </>
+        }
+        description={agent.description}
+        action={
+          <div className="flex w-full items-center justify-between gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setReportOpen(true)}
+              className="text-ink-muted"
+            >
+              <FlagIcon className="size-4" />
+              {t("report.open")}
+            </Button>
+            <Button
+              onClick={() => onInstall(slug)}
+              disabled={installing}
+              className="rounded-full"
+            >
+              {installing && <Spinner className="size-4" />}
+              {t("install")}
+            </Button>
           </div>
-        )}
-        {agent.integrations.length > 0 && (
-          <div>
-            <p className="mb-1.5 font-medium text-ink">
-              {t("detail.integrations")}
-            </p>
-            <div className="flex flex-wrap gap-1.5">
-              {agent.integrations.map((toolkit) => (
-                <Badge key={toolkit} variant="outline">
-                  {toolkit.toLowerCase()}
-                </Badge>
-              ))}
-            </div>
-          </div>
-        )}
-        {learnings.length > 0 && (
+        }
+      >
+        <div className="space-y-3 text-sm">
           <p className="text-ink-muted">
-            {t("detail.learnings", { count: learnings.length })}
+            {t("detail.by", { name: agent.creator.displayName })}
+            {" · "}
+            {t("installs", { count: agent.installsCount })}
           </p>
-        )}
-      </div>
-    </CatalogDetailDialog>
+          {skills.length > 0 && (
+            <div>
+              <p className="mb-1.5 font-medium text-ink">
+                {t("detail.skills")}
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {skills.map((skill) => (
+                  <Badge key={skill.slug} variant="outline">
+                    {skill.slug}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+          {agent.integrations.length > 0 && (
+            <div>
+              <p className="mb-1.5 font-medium text-ink">
+                {t("detail.integrations")}
+              </p>
+              <IntegrationBadges toolkits={agent.integrations} />
+            </div>
+          )}
+          {learnings.length > 0 && (
+            <p className="text-ink-muted">
+              {t("detail.learnings", { count: learnings.length })}
+            </p>
+          )}
+        </div>
+      </CatalogDetailDialog>
+      {slug && (
+        <StoreReportDialog
+          slug={slug}
+          open={reportOpen}
+          onOpenChange={setReportOpen}
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * The "works with" apps, resolved to real names and logos through the Composio
+ * toolkit catalog (the same `appDisplay` path the Integrations tab uses) so the
+ * detail dialog never shows a machine slug. While the catalog hasn't loaded, or
+ * on a deployment with no integration provider wired, `appDisplay` degrades to
+ * a favicon guess and the slug as its name.
+ */
+function IntegrationBadges({ toolkits }: { toolkits: string[] }) {
+  const bySlug = useToolkitBySlug();
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {toolkits.map((toolkit) => {
+        const slug = toolkit.toLowerCase();
+        const display = appDisplay(slug, bySlug.get(slug));
+        return (
+          <Badge
+            key={toolkit}
+            variant="outline"
+            className="gap-1.5 py-0.5 pl-1"
+          >
+            <AppLogo display={display} size="sm" className="size-4" />
+            {display.name}
+          </Badge>
+        );
+      })}
+    </div>
   );
 }

--- a/app/src/components/store-view/store-filters.tsx
+++ b/app/src/components/store-view/store-filters.tsx
@@ -1,12 +1,27 @@
-import type { StoreCatalogSort } from "@houston-ai/engine-client";
-import { useTranslation } from "react-i18next";
 import {
+  fetchStoreCategories,
+  type StoreCatalogSort,
+  type StoreCategory as StoreCategoryEntry,
+} from "@houston-ai/engine-client";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { reportError } from "../../lib/error-toast";
+import {
+  resolveStoreCategoryLabel,
   STORE_CATEGORIES,
-  storeCategoryLabelKey,
 } from "../../lib/store-categories";
 
-/** The category pill strip: "All" plus the store's 14 seeded categories,
- *  labelled from the SAME i18n entries the publish wizard's select uses. */
+/** How long a browse session trusts the fetched vocabulary before refetching:
+ *  the seed changes at most a few times a year, so a day is plenty. */
+const CATEGORIES_STALE_MS = 24 * 60 * 60 * 1000;
+
+/** The category pill strip: "All" plus the store's live category vocabulary,
+ *  fetched from the gateway (`GET /categories`) and labelled from the SAME i18n
+ *  entries the publish wizard's select uses; unknown gateway slugs show the
+ *  gateway-provided name. A fetch failure falls back to the static publish-time
+ *  seed AND reports (the one place a degrade is silent to the user by design —
+ *  the strip still works, so a toast would be noise). */
 export function StoreCategoryChips({
   category,
   onCategoryChange,
@@ -17,12 +32,30 @@ export function StoreCategoryChips({
 }) {
   const { t } = useTranslation("store");
   const { t: tPortable } = useTranslation("portable");
+  const { data, error } = useQuery({
+    queryKey: ["store-categories"],
+    queryFn: () => fetchStoreCategories(),
+    staleTime: CATEGORIES_STALE_MS,
+  });
+  useEffect(() => {
+    if (error) {
+      reportError("store_categories", "store categories fetch failed", error);
+    }
+  }, [error]);
+
+  // Runtime vocabulary from the gateway; while it loads, or after it fails,
+  // render the static seed so the strip is never empty and "All" stays first.
+  const entries: StoreCategoryEntry[] =
+    data ?? STORE_CATEGORIES.map((slug) => ({ slug, name: slug }));
   const chips: Array<{ slug: string; label: string }> = [
     { slug: "all", label: t("allCategories") },
-    ...STORE_CATEGORIES.map((slug) => ({
-      slug,
-      label: tPortable(storeCategoryLabelKey(slug)),
-    })),
+    ...entries.map((entry) => {
+      const label = resolveStoreCategoryLabel(entry);
+      return {
+        slug: entry.slug,
+        label: "i18nKey" in label ? tPortable(label.i18nKey) : label.text,
+      };
+    }),
   ];
   return (
     <div className="flex flex-wrap gap-1.5">

--- a/app/src/components/store-view/store-integration-filter.tsx
+++ b/app/src/components/store-view/store-integration-filter.tsx
@@ -1,0 +1,74 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@houston-ai/core";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { AppLogo, appDisplay, useToolkitBySlug } from "../integrations";
+
+/** Sentinel for "no integration filter"; kept out of the toolkit-slug space so
+ *  it can never collide with a real app. */
+const ALL = "all";
+
+/**
+ * The browse row's integration filter: pick one connected-app the listings must
+ * touch, or "All integrations". Real app names and logos (resolved from the
+ * Composio toolkit catalog via {@link appDisplay}), never machine slugs; falls
+ * back to a prettified slug + favicon when the catalog has not resolved or the
+ * deployment serves no integrations. Sits beside {@link StoreSortToggle} in the
+ * filter row, so it wears the same quiet, rounded-pill chrome.
+ */
+export function StoreIntegrationFilter({
+  value,
+  onChange,
+  integrations,
+}: {
+  /** The selected toolkit slug, or the {@link ALL} sentinel. */
+  value: string;
+  onChange: (value: string) => void;
+  /** The toolkit slugs present across the current catalog, to offer as options. */
+  integrations: string[];
+}) {
+  const { t } = useTranslation("store");
+  const bySlug = useToolkitBySlug();
+
+  const options = useMemo(
+    () =>
+      integrations
+        .map((slug) => appDisplay(slug, bySlug.get(slug)))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [integrations, bySlug],
+  );
+
+  const selected =
+    value === ALL ? null : options.find((o) => o.toolkit === value);
+
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger
+        size="sm"
+        className="shrink-0 gap-1.5 rounded-full border-transparent bg-transparent px-3 text-[13px] text-ink-muted shadow-none hover:bg-hover hover:text-ink data-[state=open]:bg-chip data-[state=open]:text-ink dark:bg-transparent dark:hover:bg-hover"
+      >
+        {selected ? (
+          <span className="flex items-center gap-2">
+            <AppLogo display={selected} size="sm" className="size-4" />
+            <span className="truncate">{selected.name}</span>
+          </span>
+        ) : (
+          <span>{t("allIntegrations")}</span>
+        )}
+      </SelectTrigger>
+      <SelectContent align="end">
+        <SelectItem value={ALL}>{t("allIntegrations")}</SelectItem>
+        {options.map((app) => (
+          <SelectItem key={app.toolkit} value={app.toolkit}>
+            <AppLogo display={app} size="sm" className="size-4" />
+            <span>{app.name}</span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/app/src/components/store-view/store-report-dialog.tsx
+++ b/app/src/components/store-view/store-report-dialog.tsx
@@ -1,0 +1,176 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Spinner,
+  Textarea,
+} from "@houston-ai/core";
+import type { ReportReason } from "@houston-ai/engine-client";
+import { reportStoreAgent } from "@houston-ai/engine-client";
+import { useId, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { reportError } from "../../lib/error-toast";
+import { useUIStore } from "../../stores/ui";
+
+/** The moderation vocabulary the gateway accepts (`POST /agents/{slug}/reports`). */
+const REPORT_REASONS: ReportReason[] = [
+  "spam",
+  "malicious",
+  "impersonation",
+  "inappropriate",
+  "other",
+];
+/** Gateway caps: `details` <= 2000 chars, `contact` <= 320 chars. */
+const MAX_DETAILS = 2000;
+const MAX_CONTACT = 320;
+
+/**
+ * The abuse-report form for a store listing — opened from the detail dialog's
+ * quiet "Report" affordance. Anonymous: a reason is required, free-text details
+ * and a follow-up contact are optional and NEVER prefilled from the session
+ * (the report goes to moderation, not the account). Submission routes through
+ * the anonymous catalog client; the gateway rate-limits at 5/min/IP.
+ */
+export function StoreReportDialog({
+  slug,
+  open,
+  onOpenChange,
+}: {
+  slug: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { t } = useTranslation("store");
+  const addToast = useUIStore((s) => s.addToast);
+  const [reason, setReason] = useState<ReportReason>("spam");
+  const [details, setDetails] = useState("");
+  const [contact, setContact] = useState("");
+  const [pending, setPending] = useState(false);
+  const reasonId = useId();
+  const detailsId = useId();
+  const contactId = useId();
+
+  const reset = () => {
+    setReason("spam");
+    setDetails("");
+    setContact("");
+  };
+
+  /**
+   * Closing the dialog (Cancel, overlay, Escape, X, or a successful submit)
+   * always clears the form. The state lives on this component, which stays
+   * mounted across opens, so without this a reopen would show the previous
+   * report's reason/details/contact — including free text about another agent.
+   */
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const handleSubmit = async () => {
+    setPending(true);
+    try {
+      await reportStoreAgent(slug, {
+        reason,
+        details: details.trim() || undefined,
+        contact: contact.trim() || undefined,
+      });
+      addToast({ title: t("report.success"), variant: "success" });
+      handleOpenChange(false);
+    } catch (err) {
+      reportError(
+        "store_report",
+        err instanceof Error ? err.message : String(err),
+        err,
+      );
+      addToast({ title: t("report.failed"), variant: "error" });
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("report.title")}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <label htmlFor={reasonId} className="text-sm font-medium text-ink">
+              {t("report.reasonLabel")}
+            </label>
+            <Select
+              value={reason}
+              onValueChange={(v) => setReason(v as ReportReason)}
+              disabled={pending}
+            >
+              <SelectTrigger id={reasonId} className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {REPORT_REASONS.map((r) => (
+                  <SelectItem key={r} value={r}>
+                    {t(`report.reason.${r}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor={detailsId} className="text-sm font-medium text-ink">
+              {t("report.detailsLabel")}
+            </label>
+            <Textarea
+              id={detailsId}
+              value={details}
+              maxLength={MAX_DETAILS}
+              rows={4}
+              placeholder={t("report.detailsPlaceholder")}
+              onChange={(e) => setDetails(e.target.value)}
+              disabled={pending}
+              className="resize-none"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor={contactId} className="text-sm font-medium text-ink">
+              {t("report.contactLabel")}
+            </label>
+            <Input
+              id={contactId}
+              type="email"
+              value={contact}
+              maxLength={MAX_CONTACT}
+              placeholder={t("report.contactPlaceholder")}
+              onChange={(e) => setContact(e.target.value)}
+              disabled={pending}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={pending}
+          >
+            {t("report.cancel")}
+          </Button>
+          <Button type="button" onClick={handleSubmit} disabled={pending}>
+            {pending && <Spinner className="size-4" />}
+            {t("report.submit")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/store-view/store-view-model.ts
+++ b/app/src/components/store-view/store-view-model.ts
@@ -3,7 +3,7 @@
  * rules are unit-testable under node:test.
  */
 
-import type { StoreCatalogAgent } from "@houston-ai/engine-client";
+import type { MyAgent, StoreCatalogAgent } from "@houston-ai/engine-client";
 
 /** The art a listing renders: its emoji when it shipped one, else the name's
  *  first grapheme as a letter avatar. URL icons render as letters too — the
@@ -24,6 +24,66 @@ export function formatInstalls(count: number, locale: string): string {
     notation: "compact",
     maximumFractionDigits: 1,
   }).format(count);
+}
+
+/** How the owner row's "request public listing" control presents. */
+export type RequestPublicMode =
+  | "hidden"
+  | "available"
+  | "pending"
+  | "requested";
+
+/** Resolve that control's mode. The gateway does not echo a public-request flag
+ *  on the agent summary, so the owner panel carries two client-side facts: the
+ *  in-flight mutation (`inFlight`) and a request already sent this session
+ *  (`requested`). Without them a successful request would leave the row
+ *  byte-for-byte identical and read as broken, so eligibility alone is not
+ *  enough — a sent request downgrades the button to a disabled acknowledgment. */
+export function requestPublicMode(
+  agent: Pick<MyAgent, "state" | "visibility">,
+  flags: { inFlight: boolean; requested: boolean },
+): RequestPublicMode {
+  const eligible = agent.state === "published" && agent.visibility !== "public";
+  if (!eligible) return "hidden";
+  if (flags.inFlight) return "pending";
+  if (flags.requested) return "requested";
+  return "available";
+}
+
+/** The connected-app options the browse integration filter offers: the deduped,
+ *  lowercased union of toolkit slugs across the given listings (the wire ships
+ *  slugs uppercase; the toolkit catalog resolves names and logos by lowercase
+ *  slug). The active filter's own slug is always kept in the set, so the control
+ *  never vanishes while its filter is still applied and always renders its own
+ *  selection even when no supplied listing happens to carry it. */
+export function catalogIntegrationOptions(
+  items: readonly Pick<StoreCatalogAgent, "integrations">[],
+  active: string | null,
+): string[] {
+  const slugs = new Set(
+    items.flatMap((agent) =>
+      agent.integrations.map((slug) => slug.toLowerCase()),
+    ),
+  );
+  if (active) slugs.add(active.toLowerCase());
+  return [...slugs];
+}
+
+/** The options the browse integration filter offers, sourced so the control
+ *  never scopes its own vocabulary. Selecting a toolkit refetches the catalog to
+ *  only that toolkit's agents, so the loaded `grid` collapses to that toolkit and
+ *  can no longer name the others a user might switch to. `unfiltered` is a catalog
+ *  read that omits the integration filter: with no filter active the grid is
+ *  already that source, but once a toolkit is `active` the vocabulary comes from
+ *  `unfiltered` instead. That independence is what lets a user switch straight
+ *  from toolkit X to toolkit Y instead of round-tripping through "All
+ *  integrations". The active slug is always kept, per catalogIntegrationOptions. */
+export function browseIntegrationOptions(
+  grid: readonly Pick<StoreCatalogAgent, "integrations">[],
+  unfiltered: readonly Pick<StoreCatalogAgent, "integrations">[],
+  active: string | null,
+): string[] {
+  return catalogIntegrationOptions(active ? unfiltered : grid, active);
 }
 
 /** The slug out of a store share URL (`…/a/<slug>`), or null when it isn't one. */

--- a/app/src/components/store-view/store-view.tsx
+++ b/app/src/components/store-view/store-view.tsx
@@ -1,91 +1,43 @@
-import {
-  Button,
-  CatalogAddButton,
-  CatalogGrid,
-  CatalogRow,
-  CatalogSearchField,
-  CatalogShowMore,
-} from "@houston-ai/core";
-import type {
-  StoreCatalogAgent,
-  StoreCatalogSort,
-} from "@houston-ai/engine-client";
-import { fetchStoreAgent, fetchStoreCatalog } from "@houston-ai/engine-client";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@houston-ai/core";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { reportError } from "../../lib/error-toast";
 import { useUIStore } from "../../stores/ui";
 import { PageContainer, PageHeader } from "../shell/page-shell";
-import { StoreAgentIcon } from "./store-agent-icon";
-import { StoreDetailDialog } from "./store-detail-dialog";
-import { StoreCategoryChips, StoreSortToggle } from "./store-filters";
-import { formatInstalls } from "./store-view-model";
-import { useStoreInstall } from "./use-store-install";
+import { MyAgentsPanel } from "./my-agents-panel";
+import { StoreBrowse } from "./store-browse";
+
+/** The two Agent Store destinations. */
+const BROWSE = "browse";
+const MY_AGENTS = "my";
 
 /**
- * The Agent Store page (sidebar destination): the public catalog rendered in
- * the app's own catalog grammar — search + category chips over the flat row
- * grid, a row body opening the detail modal, and the row's `+` running the
- * one-click install (which hands off to the import wizard's scan/name flow).
- * All reads are the anonymous CORS-open gateway API; nothing here needs an
- * account until the moment of install.
+ * The Agent Store page (sidebar destination): a two-tab shell over the public
+ * catalog ({@link StoreBrowse}) and the signed-in owner's dashboard
+ * ({@link MyAgentsPanel}). Browse is kept mounted so its search and filter
+ * state survive tab switches and the `storeFocusSlug` deep link opens the
+ * detail dialog from either tab; the owner dashboard mounts (and queries the
+ * authed `GET /me/agents`) only once its tab is selected.
  */
 export function StoreView() {
-  const { t, i18n } = useTranslation("store");
-  const [search, setSearch] = useState("");
-  const [q, setQ] = useState("");
-  const [category, setCategory] = useState("all");
-  const [sort, setSort] = useState<StoreCatalogSort>("recent");
-  const [detailAgent, setDetailAgent] = useState<StoreCatalogAgent | null>(
-    null,
-  );
-  const { install, installingSlug } = useStoreInstall();
+  const { t } = useTranslation("store");
+  const [tab, setTab] = useState<string>(BROWSE);
 
-  // Debounce typing into the server-side full-text query.
+  // One-shot deep link into the "my agents" tab: "Manage all my agents"
+  // surfaces set the flag before switching views (mirrors storeFocusSlug).
+  const ownerTab = useUIStore((s) => s.storeOwnerTab);
   useEffect(() => {
-    const handle = setTimeout(() => setQ(search.trim()), 300);
-    return () => clearTimeout(handle);
-  }, [search]);
+    if (!ownerTab) return;
+    useUIStore.getState().setStoreOwnerTab(null);
+    setTab(MY_AGENTS);
+  }, [ownerTab]);
 
-  const catalog = useInfiniteQuery({
-    queryKey: ["store-catalog", q, category, sort],
-    queryFn: ({ pageParam }) =>
-      fetchStoreCatalog({
-        q: q || undefined,
-        category: category === "all" ? undefined : category,
-        sort,
-        page: pageParam,
-      }),
-    initialPageParam: 1,
-    getNextPageParam: (last, all) =>
-      last.hasMore ? all.length + 1 : undefined,
-    staleTime: 60_000,
-  });
-
-  // One-shot deep link: "See it in the store" surfaces set a slug before
-  // switching views; consume it into the detail dialog (a vanished listing
-  // just reports — the catalog behind it is already the right fallback).
+  // A "See it in the store" deep link always lands on Browse, where the detail
+  // dialog opens (StoreBrowse consumes and clears the slug). Only switches the
+  // tab here; the fetch and dialog stay owned by Browse.
   const focusSlug = useUIStore((s) => s.storeFocusSlug);
   useEffect(() => {
-    if (!focusSlug) return;
-    useUIStore.getState().setStoreFocusSlug(null);
-    fetchStoreAgent(focusSlug)
-      .then((detail) => setDetailAgent(detail.agent))
-      .catch((err: unknown) => {
-        reportError(
-          "store_focus",
-          `store focus fetch failed (${focusSlug})`,
-          err,
-        );
-      });
+    if (focusSlug) setTab(BROWSE);
   }, [focusSlug]);
-
-  const items = catalog.data?.pages.flatMap((page) => page.items) ?? [];
-
-  const handleInstall = async (slug: string) => {
-    if (await install(slug)) setDetailAgent(null);
-  };
 
   return (
     <div className="h-full overflow-auto">
@@ -96,99 +48,24 @@ export function StoreView() {
           className="mb-7"
         />
 
-        <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center">
-          <CatalogSearchField
-            value={search}
-            onChange={setSearch}
-            label={t("searchPlaceholder")}
-            className="flex-1"
-          />
-          <StoreSortToggle sort={sort} onSortChange={setSort} />
-        </div>
-        <StoreCategoryChips
-          category={category}
-          onCategoryChange={setCategory}
-        />
+        <Tabs value={tab} onValueChange={setTab}>
+          <TabsList className="mb-4">
+            <TabsTrigger value={BROWSE}>{t("tabs.browse")}</TabsTrigger>
+            <TabsTrigger value={MY_AGENTS}>{t("tabs.myAgents")}</TabsTrigger>
+          </TabsList>
 
-        <div className="mt-6">
-          {catalog.isPending ? (
-            <RowsSkeleton />
-          ) : catalog.isError ? (
-            <div className="flex flex-col items-center gap-3 py-16">
-              <p className="text-sm text-ink-muted">{t("loadFailed")}</p>
-              <Button
-                variant="outline"
-                className="rounded-full"
-                onClick={() => void catalog.refetch()}
-              >
-                {t("retry")}
-              </Button>
-            </div>
-          ) : items.length === 0 ? (
-            <p className="py-16 text-center text-sm text-ink-muted">
-              {t("empty")}
-            </p>
-          ) : (
-            <>
-              <CatalogGrid>
-                {items.map((agent) => (
-                  <CatalogRow
-                    key={agent.id}
-                    icon={<StoreAgentIcon agent={agent} />}
-                    title={agent.name}
-                    description={agent.tagline ?? agent.description}
-                    trailing={
-                      <span
-                        className="shrink-0 text-[12px] text-ink-muted tabular-nums"
-                        title={t("installs", { count: agent.installsCount })}
-                      >
-                        {formatInstalls(agent.installsCount, i18n.language)}
-                      </span>
-                    }
-                    action={
-                      agent.slug ? (
-                        <CatalogAddButton
-                          label={t("installLabel", { name: agent.name })}
-                          busy={installingSlug === agent.slug}
-                          disabled={installingSlug !== null}
-                          onClick={() => void handleInstall(agent.slug ?? "")}
-                        />
-                      ) : undefined
-                    }
-                    onClick={() => setDetailAgent(agent)}
-                  />
-                ))}
-              </CatalogGrid>
-              {catalog.hasNextPage && (
-                <CatalogShowMore
-                  disabled={catalog.isFetchingNextPage}
-                  onClick={() => void catalog.fetchNextPage()}
-                >
-                  {t("showMore")}
-                </CatalogShowMore>
-              )}
-            </>
-          )}
-        </div>
-
-        <StoreDetailDialog
-          agent={detailAgent}
-          onClose={() => setDetailAgent(null)}
-          onInstall={(slug) => void handleInstall(slug)}
-          installing={installingSlug !== null}
-        />
+          <TabsContent
+            value={BROWSE}
+            forceMount
+            className="hidden data-[state=active]:block"
+          >
+            <StoreBrowse />
+          </TabsContent>
+          <TabsContent value={MY_AGENTS}>
+            <MyAgentsPanel />
+          </TabsContent>
+        </Tabs>
       </PageContainer>
-    </div>
-  );
-}
-
-/** Row placeholders while the first page settles. Decorative only. */
-function RowsSkeleton() {
-  return (
-    <div aria-hidden className="grid grid-cols-1 gap-1 lg:grid-cols-2">
-      {[0, 1, 2, 3, 4, 5].map((i) => (
-        <div key={i} className="h-[60px] animate-pulse rounded-xl bg-chip" />
-      ))}
     </div>
   );
 }

--- a/app/src/components/store-view/use-my-store-agents.ts
+++ b/app/src/components/store-view/use-my-store-agents.ts
@@ -1,0 +1,99 @@
+import type { MyAgent } from "@houston-ai/engine-client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { getEngine } from "../../lib/engine";
+import { reportError } from "../../lib/error-toast";
+import { useUIStore } from "../../stores/ui";
+
+/** The owner-dashboard query key, invalidated after every owner mutation. */
+const MY_AGENTS_KEY = ["store-my-agents"] as const;
+
+/**
+ * The "my agents" owner dashboard's data + mutations. The list query runs only
+ * when the panel is mounted AND the user is signed in (`enabled`) — the gateway
+ * `GET /me/agents` needs the caller's session bearer. Each mutation invalidates
+ * the list on success so the row's lifecycle badges/actions re-render from the
+ * server truth, and surfaces failure as a visible toast plus a Sentry report
+ * (the same "no silent failures" path the one-click install uses).
+ *
+ * "Request public listing" is the one action the server truth cannot echo — the
+ * gateway stamps `public_requested_at` but never changes the summary's
+ * state/visibility and does not project the flag — so a bare invalidate would
+ * leave the row identical and read as broken. It gets a success toast and a
+ * session-local `requestedPublicIds` acknowledgment (`wasRequestedPublic`) so
+ * the button downgrades to a disabled "pending review" state and cannot be
+ * re-submitted blindly.
+ */
+export function useMyStoreAgents(enabled: boolean) {
+  const qc = useQueryClient();
+  const { t } = useTranslation("store");
+  const addToast = useUIStore((s) => s.addToast);
+  const [requestedPublicIds, setRequestedPublicIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+
+  const query = useQuery({
+    queryKey: MY_AGENTS_KEY,
+    queryFn: () => getEngine().listMyStoreAgents(),
+    enabled,
+    staleTime: 30_000,
+  });
+
+  const invalidate = () => qc.invalidateQueries({ queryKey: MY_AGENTS_KEY });
+
+  const surface = (command: string, err: unknown) => {
+    reportError(command, `${command} failed`, err);
+    addToast({ variant: "error", title: t("myAgents.actionFailed") });
+  };
+
+  const requestPublic = useMutation({
+    mutationFn: (id: string) => getEngine().requestStorePublic(id),
+    onSuccess: (_result, id) => {
+      setRequestedPublicIds((prev) => new Set(prev).add(id));
+      addToast({ variant: "success", title: t("myAgents.requestPublicSent") });
+      invalidate();
+    },
+    onError: (err) => surface("store_request_public", err),
+  });
+
+  const makeUnlisted = useMutation({
+    mutationFn: (id: string) => getEngine().setStoreVisibilityUnlisted(id),
+    onSuccess: invalidate,
+    onError: (err) => surface("store_make_unlisted", err),
+  });
+
+  const unpublish = useMutation({
+    mutationFn: (id: string) => getEngine().unpublishStoreAgentById(id),
+    onSuccess: invalidate,
+    onError: (err) => surface("store_unpublish", err),
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) => getEngine().deleteStoreAgentById(id),
+    onSuccess: invalidate,
+    onError: (err) => surface("store_delete", err),
+  });
+
+  const mutations = [requestPublic, makeUnlisted, unpublish, remove];
+  const isBusy = (id: string): boolean =>
+    mutations.some((m) => m.isPending && m.variables === id);
+  const isRequestingPublic = (id: string): boolean =>
+    requestPublic.isPending && requestPublic.variables === id;
+  const wasRequestedPublic = (id: string): boolean =>
+    requestedPublicIds.has(id);
+
+  return {
+    agents: (query.data ?? []) as MyAgent[],
+    isPending: query.isPending,
+    isError: query.isError,
+    refetch: query.refetch,
+    requestPublic,
+    makeUnlisted,
+    unpublish,
+    remove,
+    isBusy,
+    isRequestingPublic,
+    wasRequestedPublic,
+  };
+}

--- a/app/src/components/use-integration-app-display.ts
+++ b/app/src/components/use-integration-app-display.ts
@@ -1,5 +1,4 @@
 import { prettifyToolkit } from "@houston-ai/chat";
-import { useIntegrationStatus, useIntegrationToolkits } from "../hooks/queries";
 import {
   findCatalogToolkit,
   normalizeToolkitSlug,
@@ -7,7 +6,7 @@ import {
 import {
   type AppDisplay,
   appDisplay,
-  INTEGRATION_PROVIDER,
+  useReadyToolkitCatalog,
 } from "./integrations";
 
 /**
@@ -20,10 +19,7 @@ import {
  * meanwhile).
  */
 export function useIntegrationAppDisplay(toolkit: string): AppDisplay {
-  const status = useIntegrationStatus();
-  const ready = !!status.data?.find((p) => p.provider === INTEGRATION_PROVIDER)
-    ?.ready;
-  const catalog = useIntegrationToolkits(INTEGRATION_PROVIDER, ready);
+  const catalog = useReadyToolkitCatalog();
   const slug = normalizeToolkitSlug(toolkit);
   const resolved = appDisplay(slug, findCatalogToolkit(catalog.data, toolkit));
   return {

--- a/app/src/lib/store-categories.ts
+++ b/app/src/lib/store-categories.ts
@@ -1,7 +1,16 @@
+import type { StoreCategory as StoreCategoryEntry } from "@houston-ai/engine-client";
+
 /**
  * The Agent Store's seeded category vocabulary (see the store's `db/seed.ts`).
  * The publish wizard shows these as a select, labelled from i18n — the slug is
  * the stable contract the store validates against; the label is translated.
+ *
+ * This static list stays the PUBLISH-time contract (the select the wizard
+ * offers). The BROWSE filter's runtime vocabulary now comes from the gateway
+ * (`GET /categories` via `fetchStoreCategories`), which may seed new slugs
+ * ahead of a client release; `resolveStoreCategoryLabel` bridges the two —
+ * seeded slugs reuse these translated labels, unknown gateway slugs fall back
+ * to the gateway-provided display name.
  *
  * Keep this list in lockstep with the store seed. A slug the store hasn't
  * seeded would be rejected at publish time, so drift is a publish-blocking bug,
@@ -37,4 +46,23 @@ export function storeCategoryLabelKey(
   slug: StoreCategory,
 ): `publish.categories.${StoreCategory}` {
   return `publish.categories.${slug}`;
+}
+
+/**
+ * How to label a runtime category entry from the gateway's `GET /categories`.
+ * A seeded slug carries an i18n key (the SAME `portable:publish.categories.*`
+ * entry the publish wizard uses); an unknown gateway slug has no key, so the
+ * caller renders the gateway-provided `name` verbatim. Discriminated so the
+ * consumer never has to guess which branch it got. */
+export type StoreCategoryLabel =
+  | { i18nKey: `publish.categories.${StoreCategory}` }
+  | { text: string };
+
+/** Resolve a gateway category entry to how it should be labelled (per above). */
+export function resolveStoreCategoryLabel(
+  entry: StoreCategoryEntry,
+): StoreCategoryLabel {
+  return isStoreCategory(entry.slug)
+    ? { i18nKey: storeCategoryLabelKey(entry.slug) }
+    : { text: entry.name };
 }

--- a/app/src/locales/en/portable.json
+++ b/app/src/locales/en/portable.json
@@ -231,7 +231,8 @@
       "removeConfirmBody": "{{name}} will no longer be installable from its link. You can publish it again later.",
       "removeConfirm": "Remove",
       "removeCancel": "Keep it up",
-      "seeInStore": "See it in the store"
+      "seeInStore": "See it in the store",
+      "manageAll": "Manage all my agents"
     },
     "errors": {
       "generic": "Something went wrong. Please try again.",

--- a/app/src/locales/en/store.json
+++ b/app/src/locales/en/store.json
@@ -22,5 +22,64 @@
     "learnings_one": "Comes with {{count}} learning from real use",
     "learnings_other": "Comes with {{count}} learnings from real use"
   },
-  "installFailed": "Houston could not fetch that agent from the store. Try again in a moment."
+  "installFailed": "Houston could not fetch that agent from the store. Try again in a moment.",
+  "tabs": {
+    "browse": "Browse",
+    "myAgents": "My agents"
+  },
+  "allIntegrations": "All integrations",
+  "report": {
+    "open": "Report",
+    "title": "Report this agent",
+    "reasonLabel": "Reason",
+    "reason": {
+      "spam": "Spam",
+      "malicious": "Malicious or unsafe",
+      "impersonation": "Impersonation",
+      "inappropriate": "Inappropriate content",
+      "other": "Something else"
+    },
+    "detailsLabel": "Details",
+    "detailsPlaceholder": "Tell us what is wrong (optional)",
+    "contactLabel": "Your email",
+    "contactPlaceholder": "So we can follow up (optional)",
+    "submit": "Send report",
+    "cancel": "Cancel",
+    "success": "Thanks for the report. Our team will take a look.",
+    "failed": "Your report could not be sent. Please try again."
+  },
+  "myAgents": {
+    "empty": "You have not published any agents yet.",
+    "signedOut": "Sign in to see the agents you have published.",
+    "signIn": "Sign in",
+    "state": {
+      "draft": "Draft",
+      "published": "Published",
+      "archived": "Archived"
+    },
+    "visibility": {
+      "unlisted": "Unlisted",
+      "public": "Public"
+    },
+    "action": {
+      "requestPublic": "Request public listing",
+      "requestPublicPending": "Requesting...",
+      "requestPublicDone": "Pending review",
+      "makeUnlisted": "Make unlisted",
+      "unpublish": "Unpublish",
+      "delete": "Delete",
+      "seeInStore": "See in store"
+    },
+    "confirm": {
+      "deleteTitle": "Delete this agent?",
+      "deleteBody": "{{name}} will be removed from the store for good. This cannot be undone.",
+      "deleteConfirm": "Delete",
+      "cancel": "Cancel",
+      "unpublishTitle": "Unpublish this agent?",
+      "unpublishBody": "{{name}} will no longer be installable from its link. You can publish it again later.",
+      "unpublishConfirm": "Unpublish"
+    },
+    "actionFailed": "That action could not be completed. Please try again.",
+    "requestPublicSent": "Public listing requested. We will review it soon."
+  }
 }

--- a/app/src/locales/es/portable.json
+++ b/app/src/locales/es/portable.json
@@ -231,7 +231,8 @@
       "removeConfirmBody": "{{name}} ya no se podrá instalar desde su enlace. Puedes publicarlo de nuevo más adelante.",
       "removeConfirm": "Quitar",
       "removeCancel": "Dejarlo",
-      "seeInStore": "Verlo en la tienda"
+      "seeInStore": "Verlo en la tienda",
+      "manageAll": "Gestionar todos mis agentes"
     },
     "errors": {
       "generic": "Algo salió mal. Inténtalo de nuevo.",

--- a/app/src/locales/es/store.json
+++ b/app/src/locales/es/store.json
@@ -22,5 +22,64 @@
     "learnings_one": "Incluye {{count}} aprendizaje de uso real",
     "learnings_other": "Incluye {{count}} aprendizajes de uso real"
   },
-  "installFailed": "Houston no pudo traer ese agente de la tienda. Intenta de nuevo en un momento."
+  "installFailed": "Houston no pudo traer ese agente de la tienda. Intenta de nuevo en un momento.",
+  "tabs": {
+    "browse": "Explorar",
+    "myAgents": "Mis agentes"
+  },
+  "allIntegrations": "Todas las integraciones",
+  "report": {
+    "open": "Reportar",
+    "title": "Reportar este agente",
+    "reasonLabel": "Motivo",
+    "reason": {
+      "spam": "Spam",
+      "malicious": "Malicioso o inseguro",
+      "impersonation": "Suplantación de identidad",
+      "inappropriate": "Contenido inapropiado",
+      "other": "Otro motivo"
+    },
+    "detailsLabel": "Detalles",
+    "detailsPlaceholder": "Cuéntanos qué está mal (opcional)",
+    "contactLabel": "Tu correo",
+    "contactPlaceholder": "Para poder darte seguimiento (opcional)",
+    "submit": "Enviar reporte",
+    "cancel": "Cancelar",
+    "success": "Gracias por reportarlo. Nuestro equipo lo revisará.",
+    "failed": "No se pudo enviar tu reporte. Inténtalo de nuevo."
+  },
+  "myAgents": {
+    "empty": "Todavía no has publicado ningún agente.",
+    "signedOut": "Inicia sesión para ver los agentes que has publicado.",
+    "signIn": "Iniciar sesión",
+    "state": {
+      "draft": "Borrador",
+      "published": "Publicado",
+      "archived": "Archivado"
+    },
+    "visibility": {
+      "unlisted": "No listado",
+      "public": "Público"
+    },
+    "action": {
+      "requestPublic": "Solicitar listado público",
+      "requestPublicPending": "Solicitando...",
+      "requestPublicDone": "En revisión",
+      "makeUnlisted": "Hacer no listado",
+      "unpublish": "Retirar",
+      "delete": "Eliminar",
+      "seeInStore": "Ver en la tienda"
+    },
+    "confirm": {
+      "deleteTitle": "¿Eliminar este agente?",
+      "deleteBody": "{{name}} se quitará de la tienda de forma permanente. Esto no se puede deshacer.",
+      "deleteConfirm": "Eliminar",
+      "cancel": "Cancelar",
+      "unpublishTitle": "¿Retirar este agente?",
+      "unpublishBody": "{{name}} ya no se podrá instalar desde su enlace. Puedes publicarlo de nuevo más adelante.",
+      "unpublishConfirm": "Retirar"
+    },
+    "actionFailed": "No se pudo completar la acción. Inténtalo de nuevo.",
+    "requestPublicSent": "Listado público solicitado. Lo revisaremos pronto."
+  }
 }

--- a/app/src/locales/pt/portable.json
+++ b/app/src/locales/pt/portable.json
@@ -231,7 +231,8 @@
       "removeConfirmBody": "{{name}} não poderá mais ser instalado pelo link. Você pode publicá-lo de novo depois.",
       "removeConfirm": "Remover",
       "removeCancel": "Manter",
-      "seeInStore": "Ver na loja"
+      "seeInStore": "Ver na loja",
+      "manageAll": "Gerenciar todos os meus agentes"
     },
     "errors": {
       "generic": "Algo deu errado. Tente de novo.",

--- a/app/src/locales/pt/store.json
+++ b/app/src/locales/pt/store.json
@@ -22,5 +22,64 @@
     "learnings_one": "Vem com {{count}} aprendizado de uso real",
     "learnings_other": "Vem com {{count}} aprendizados de uso real"
   },
-  "installFailed": "O Houston não conseguiu buscar esse agente na loja. Tente de novo em instantes."
+  "installFailed": "O Houston não conseguiu buscar esse agente na loja. Tente de novo em instantes.",
+  "tabs": {
+    "browse": "Explorar",
+    "myAgents": "Meus agentes"
+  },
+  "allIntegrations": "Todas as integrações",
+  "report": {
+    "open": "Denunciar",
+    "title": "Denunciar este agente",
+    "reasonLabel": "Motivo",
+    "reason": {
+      "spam": "Spam",
+      "malicious": "Malicioso ou inseguro",
+      "impersonation": "Falsidade de identidade",
+      "inappropriate": "Conteúdo inadequado",
+      "other": "Outro motivo"
+    },
+    "detailsLabel": "Detalhes",
+    "detailsPlaceholder": "Conte para nós o que está errado (opcional)",
+    "contactLabel": "Seu e-mail",
+    "contactPlaceholder": "Para podermos dar retorno (opcional)",
+    "submit": "Enviar denúncia",
+    "cancel": "Cancelar",
+    "success": "Obrigado pela denúncia. Nossa equipe vai analisar.",
+    "failed": "Não foi possível enviar sua denúncia. Tente de novo."
+  },
+  "myAgents": {
+    "empty": "Você ainda não publicou nenhum agente.",
+    "signedOut": "Entre para ver os agentes que você publicou.",
+    "signIn": "Entrar",
+    "state": {
+      "draft": "Rascunho",
+      "published": "Publicado",
+      "archived": "Arquivado"
+    },
+    "visibility": {
+      "unlisted": "Não listado",
+      "public": "Público"
+    },
+    "action": {
+      "requestPublic": "Solicitar listagem pública",
+      "requestPublicPending": "Solicitando...",
+      "requestPublicDone": "Em análise",
+      "makeUnlisted": "Tornar não listado",
+      "unpublish": "Remover da loja",
+      "delete": "Excluir",
+      "seeInStore": "Ver na loja"
+    },
+    "confirm": {
+      "deleteTitle": "Excluir este agente?",
+      "deleteBody": "{{name}} será removido da loja definitivamente. Isso não pode ser desfeito.",
+      "deleteConfirm": "Excluir",
+      "cancel": "Cancelar",
+      "unpublishTitle": "Remover este agente da loja?",
+      "unpublishBody": "{{name}} não poderá mais ser instalado pelo link. Você pode publicá-lo de novo depois.",
+      "unpublishConfirm": "Remover"
+    },
+    "actionFailed": "Não foi possível concluir a ação. Tente de novo.",
+    "requestPublicSent": "Listagem pública solicitada. Vamos analisar em breve."
+  }
 }

--- a/app/src/stores/ui.ts
+++ b/app/src/stores/ui.ts
@@ -101,6 +101,10 @@ interface UIState {
    * "See it in the store" affordances before `setViewMode(STORE_VIEW_ID)`,
    * cleared by the view once consumed. */
   storeFocusSlug: string | null;
+  /** A one-shot flag that opens the Agent Store view on its "my agents" tab —
+   * set by "Manage all my agents" affordances before `setViewMode(STORE_VIEW_ID)`,
+   * cleared by the view once consumed. Ephemeral, never persisted. */
+  storeOwnerTab: "my" | null;
   /** Whether the left rail is collapsed to an icon-only strip. Persisted. */
   sidebarCollapsed: boolean;
   /** Files tab layout: Drive-style card grid or Finder-style list. Persisted. */
@@ -145,6 +149,7 @@ interface UIState {
   setImportFromFriendOpen: (open: boolean) => void;
   setImportSeedPreview: (preview: PortableUploadPreviewResponse | null) => void;
   setStoreFocusSlug: (slug: string | null) => void;
+  setStoreOwnerTab: (v: "my" | null) => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
   toggleSidebarCollapsed: () => void;
   setFilesViewMode: (mode: "grid" | "list") => void;
@@ -190,6 +195,7 @@ export const useUIStore = create<UIState>()(
       importFromFriendOpen: false,
       importSeedPreview: null,
       storeFocusSlug: null,
+      storeOwnerTab: null,
       sidebarCollapsed: false,
       filesViewMode: "grid",
       filePreview: null,
@@ -314,6 +320,7 @@ export const useUIStore = create<UIState>()(
         set({ importFromFriendOpen }),
       setImportSeedPreview: (importSeedPreview) => set({ importSeedPreview }),
       setStoreFocusSlug: (storeFocusSlug) => set({ storeFocusSlug }),
+      setStoreOwnerTab: (storeOwnerTab) => set({ storeOwnerTab }),
       setSidebarCollapsed: (sidebarCollapsed) => set({ sidebarCollapsed }),
       toggleSidebarCollapsed: () =>
         set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),

--- a/app/tests/store-categories.test.ts
+++ b/app/tests/store-categories.test.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual, ok, strictEqual } from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   isStoreCategory,
+  resolveStoreCategoryLabel,
   STORE_CATEGORIES,
   storeCategoryLabelKey,
 } from "../src/lib/store-categories.ts";
@@ -52,6 +53,31 @@ describe("storeCategoryLabelKey", () => {
     strictEqual(
       storeCategoryLabelKey("customer-support"),
       "publish.categories.customer-support",
+    );
+  });
+});
+
+describe("resolveStoreCategoryLabel", () => {
+  it("reuses the publish i18n key for a seeded slug, ignoring the gateway name", () => {
+    // The gateway may send its own English display name; a known slug always
+    // wins with the translated publish label so es/pt render correctly.
+    deepStrictEqual(
+      resolveStoreCategoryLabel({ slug: "finance", name: "Money" }),
+      {
+        i18nKey: "publish.categories.finance",
+      },
+    );
+    deepStrictEqual(
+      resolveStoreCategoryLabel({ slug: "customer-support", name: "Support" }),
+      { i18nKey: "publish.categories.customer-support" },
+    );
+  });
+
+  it("falls back to the gateway name for an unknown slug", () => {
+    // A slug the seed predates has no i18n key, so the gateway's name is shown.
+    deepStrictEqual(
+      resolveStoreCategoryLabel({ slug: "astrology", name: "Astrology" }),
+      { text: "Astrology" },
     );
   });
 });

--- a/app/tests/store-view-model.test.ts
+++ b/app/tests/store-view-model.test.ts
@@ -1,7 +1,10 @@
 import { deepStrictEqual, strictEqual } from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  browseIntegrationOptions,
+  catalogIntegrationOptions,
   formatInstalls,
+  requestPublicMode,
   storeAgentGlyph,
   storeSlugFromShareUrl,
 } from "../src/components/store-view/store-view-model.ts";
@@ -74,6 +77,114 @@ describe("storeSlugFromShareUrl", () => {
     strictEqual(
       storeSlugFromShareUrl("https://agents.gethouston.ai/a/UPPER"),
       null,
+    );
+  });
+});
+
+describe("catalogIntegrationOptions", () => {
+  it("dedupes and lowercases the toolkit slugs across listings", () => {
+    deepStrictEqual(
+      catalogIntegrationOptions(
+        [
+          { integrations: ["GMAIL", "SLACK"] },
+          { integrations: ["gmail", "NOTION"] },
+        ],
+        null,
+      ),
+      ["gmail", "slack", "notion"],
+    );
+  });
+
+  it("keeps the active filter's app even when no listing carries it", () => {
+    // The zero-result trap: an active integration combined with a search that
+    // matches nothing empties the listing union, but the control must stay so
+    // the user can clear it.
+    deepStrictEqual(catalogIntegrationOptions([], "gmail"), ["gmail"]);
+  });
+
+  it("does not duplicate the active app when a listing already carries it", () => {
+    deepStrictEqual(
+      catalogIntegrationOptions([{ integrations: ["GMAIL"] }], "gmail"),
+      ["gmail"],
+    );
+  });
+
+  it("returns an empty list when no filter is active and nothing loaded", () => {
+    deepStrictEqual(catalogIntegrationOptions([], null), []);
+  });
+});
+
+describe("browseIntegrationOptions", () => {
+  it("sources the vocabulary from the grid when no filter is active", () => {
+    const grid = [{ integrations: ["GMAIL"] }, { integrations: ["NOTION"] }];
+    deepStrictEqual(browseIntegrationOptions(grid, [], null), [
+      "gmail",
+      "notion",
+    ]);
+  });
+
+  it("keeps other toolkits offered once a filter collapses the grid", () => {
+    // The finding: selecting GMAIL refetches the grid to gmail-only, so a
+    // grid-derived vocabulary would drop NOTION and force a round trip through
+    // "All integrations". Sourcing from the unfiltered read keeps NOTION.
+    const filteredGrid = [{ integrations: ["GMAIL"] }];
+    const unfiltered = [
+      { integrations: ["GMAIL"] },
+      { integrations: ["NOTION"] },
+    ];
+    deepStrictEqual(
+      browseIntegrationOptions(filteredGrid, unfiltered, "gmail"),
+      ["gmail", "notion"],
+    );
+  });
+
+  it("keeps the active toolkit even before the unfiltered read resolves", () => {
+    deepStrictEqual(browseIntegrationOptions([], [], "gmail"), ["gmail"]);
+  });
+});
+
+describe("requestPublicMode", () => {
+  const idle = { inFlight: false, requested: false };
+
+  it("hides the control unless the agent is published and not public", () => {
+    strictEqual(
+      requestPublicMode({ state: "draft", visibility: "unlisted" }, idle),
+      "hidden",
+    );
+    strictEqual(
+      requestPublicMode({ state: "published", visibility: "public" }, idle),
+      "hidden",
+    );
+    strictEqual(
+      requestPublicMode({ state: "archived", visibility: "unlisted" }, idle),
+      "hidden",
+    );
+  });
+
+  it("offers the request on a published, unlisted agent", () => {
+    strictEqual(
+      requestPublicMode({ state: "published", visibility: "unlisted" }, idle),
+      "available",
+    );
+  });
+
+  it("shows a pending state while the request is in flight", () => {
+    strictEqual(
+      requestPublicMode(
+        { state: "published", visibility: "unlisted" },
+        { inFlight: true, requested: false },
+      ),
+      "pending",
+    );
+  });
+
+  it("acknowledges a sent request so the row is not byte-for-byte identical", () => {
+    strictEqual(
+      requestPublicMode(
+        { state: "published", visibility: "unlisted" },
+        { inFlight: false, requested: true },
+      ),
+      "requested",
     );
   });
 });

--- a/packages/web/src/engine-adapter/client/store-mixin.ts
+++ b/packages/web/src/engine-adapter/client/store-mixin.ts
@@ -1,4 +1,5 @@
 import type {
+  MyAgent,
   StorePublicationStatus,
   StorePublishRequest,
   StorePublishResponse,
@@ -45,6 +46,38 @@ export function StoreMixin<TBase extends BaseCtor>(Base: TBase) {
       if (!this.ctx.cp)
         throw new Error("Publishing an agent needs a connected host.");
       return portableStore.getPublication(this.ctx.cp, agentPath);
+    }
+
+    // ---- Owner management (the "my agents" panel) ----
+    // Act on a listing by its gateway id, read live off `GET /me/agents`. Same
+    // connected-host guard as the publish flow above.
+    async listMyStoreAgents(): Promise<MyAgent[]> {
+      if (!this.ctx.cp)
+        throw new Error("Managing your agents needs a connected host.");
+      return portableStore.listMyStoreAgents(this.ctx.cp);
+    }
+    async requestStorePublic(storeAgentId: string): Promise<void> {
+      if (!this.ctx.cp)
+        throw new Error("Managing your agents needs a connected host.");
+      return portableStore.requestStorePublic(this.ctx.cp, storeAgentId);
+    }
+    async setStoreVisibilityUnlisted(storeAgentId: string): Promise<void> {
+      if (!this.ctx.cp)
+        throw new Error("Managing your agents needs a connected host.");
+      return portableStore.setStoreVisibilityUnlisted(
+        this.ctx.cp,
+        storeAgentId,
+      );
+    }
+    async unpublishStoreAgentById(storeAgentId: string): Promise<void> {
+      if (!this.ctx.cp)
+        throw new Error("Managing your agents needs a connected host.");
+      return portableStore.unpublishStoreAgentById(this.ctx.cp, storeAgentId);
+    }
+    async deleteStoreAgentById(storeAgentId: string): Promise<void> {
+      if (!this.ctx.cp)
+        throw new Error("Managing your agents needs a connected host.");
+      return portableStore.deleteStoreAgentById(this.ctx.cp, storeAgentId);
     }
   }
   return Store;

--- a/packages/web/src/engine-adapter/portable-store.test.ts
+++ b/packages/web/src/engine-adapter/portable-store.test.ts
@@ -3,9 +3,14 @@ import type { StorePublishRequest } from "../../../../ui/engine-client/src/types
 import { HoustonEngineError } from "./client";
 import type { ControlPlaneConfig } from "./control-plane";
 import {
+  deleteStoreAgentById,
   getPublication,
+  listMyStoreAgents,
   publishToStore,
+  requestStorePublic,
+  setStoreVisibilityUnlisted,
   unpublishFromStore,
+  unpublishStoreAgentById,
 } from "./portable-store";
 
 /**
@@ -76,6 +81,9 @@ beforeEach(() => {
       }
       if (url.includes("/v1/agentstore/agents/S1") && method === "PATCH") {
         return jsonResponse({ ok: true });
+      }
+      if (url.includes("/v1/agentstore/agents/S1") && method === "DELETE") {
+        return new Response(null, { status: 204 });
       }
       if (url.endsWith("/v1/agentstore/me/agents")) {
         return jsonResponse({
@@ -236,4 +244,51 @@ test("unpublish PATCHes the gateway and keeps the pointer", async () => {
   const patch = posts.find((p) => p.url.includes("/v1/agentstore/agents/S1"));
   expect((patch?.body as { unpublish: boolean }).unpublish).toBe(true);
   expect(pointer).not.toBeNull();
+});
+
+// ── Owner management (the "my agents" panel) ──────────────────────────────
+
+test("listMyStoreAgents reads the live listing off /me/agents", async () => {
+  const agents = await listMyStoreAgents(cfg);
+  expect(agents).toHaveLength(1);
+  expect(agents[0]?.id).toBe("S1");
+  expect(agents[0]?.state).toBe("published");
+});
+
+test("requestStorePublic PATCHes {requestPublic:true} by store id", async () => {
+  await requestStorePublic(cfg, "S1");
+  const patch = posts.find((p) => p.url.includes("/v1/agentstore/agents/S1"));
+  expect(patch?.url).toContain("/v1/agentstore/agents/S1");
+  expect((patch?.body as { requestPublic: boolean }).requestPublic).toBe(true);
+});
+
+test("setStoreVisibilityUnlisted PATCHes {visibility:'unlisted'}", async () => {
+  await setStoreVisibilityUnlisted(cfg, "S1");
+  const patch = posts.find((p) => p.url.includes("/v1/agentstore/agents/S1"));
+  expect((patch?.body as { visibility: string }).visibility).toBe("unlisted");
+});
+
+test("unpublishStoreAgentById PATCHes {unpublish:true} by store id", async () => {
+  await unpublishStoreAgentById(cfg, "S1");
+  const patch = posts.find((p) => p.url.includes("/v1/agentstore/agents/S1"));
+  expect((patch?.body as { unpublish: boolean }).unpublish).toBe(true);
+});
+
+test("deleteStoreAgentById DELETEs the store agent by id", async () => {
+  await deleteStoreAgentById(cfg, "S1");
+  const del = posts.find((p) => p.url.includes("/v1/agentstore/agents/S1"));
+  expect(del?.url).toContain("/v1/agentstore/agents/S1");
+});
+
+test("an owner-action HTTP failure re-maps to a HoustonEngineError", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => jsonResponse({ error: "forbidden" }, 403)),
+  );
+  const err = await requestStorePublic(cfg, "S1").then(
+    () => null,
+    (e: unknown) => e,
+  );
+  expect(err).toBeInstanceOf(HoustonEngineError);
+  expect((err as HoustonEngineError).status).toBe(403);
 });

--- a/packages/web/src/engine-adapter/portable-store.ts
+++ b/packages/web/src/engine-adapter/portable-store.ts
@@ -18,6 +18,7 @@ import {
   StoreApiError,
 } from "@houston/agentstore-client";
 import type {
+  MyAgent,
   StorePublicationStatus,
   StorePublishRequest,
   StorePublishResponse,
@@ -181,4 +182,55 @@ export async function getPublication(
       tags: item.tags,
     },
   };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Owner management (the "my agents" panel — account-based, no manage tokens)
+//
+// These act on a store agent by its gateway id, read live off `GET /me/agents`,
+// with no host-side pointer involved. Each re-maps the SDK's StoreApiError onto
+// the adapter's HoustonEngineError via `asEngineError`, exactly like publish.
+// ────────────────────────────────────────────────────────────────────────
+
+/** Every listing the caller owns, in all lifecycle states (`GET /me/agents`). */
+export function listMyStoreAgents(cfg: ControlPlaneConfig): Promise<MyAgent[]> {
+  return asEngineError(() => storeClient(cfg).listMyAgents());
+}
+
+/** Ask an admin to make an owned listing public (`PATCH … {requestPublic}`). */
+export async function requestStorePublic(
+  cfg: ControlPlaneConfig,
+  storeAgentId: string,
+): Promise<void> {
+  await asEngineError(() =>
+    storeClient(cfg).patchAgent(storeAgentId, { requestPublic: true }),
+  );
+}
+
+/** Drop a public listing back to unlisted (`PATCH … {visibility:"unlisted"}`). */
+export async function setStoreVisibilityUnlisted(
+  cfg: ControlPlaneConfig,
+  storeAgentId: string,
+): Promise<void> {
+  await asEngineError(() =>
+    storeClient(cfg).patchAgent(storeAgentId, { visibility: "unlisted" }),
+  );
+}
+
+/** Take an owned listing down by its gateway id (`PATCH … {unpublish}`). */
+export async function unpublishStoreAgentById(
+  cfg: ControlPlaneConfig,
+  storeAgentId: string,
+): Promise<void> {
+  await asEngineError(() =>
+    storeClient(cfg).patchAgent(storeAgentId, { unpublish: true }),
+  );
+}
+
+/** Soft-delete an owned listing by its gateway id (`DELETE /agents/{id}`). */
+export async function deleteStoreAgentById(
+  cfg: ControlPlaneConfig,
+  storeAgentId: string,
+): Promise<void> {
+  await asEngineError(() => storeClient(cfg).deleteAgent(storeAgentId));
 }

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -62,6 +62,7 @@ import type {
   IntegrationProviderStatus,
   IntegrationToolkit,
   ListWorktreesRequest,
+  MyAgent,
   NewActivity,
   NewRoutine,
   OrgInfo,
@@ -2274,6 +2275,60 @@ export class HoustonClient {
         tags: item.tags ?? [],
       },
     };
+  }
+
+  // ---------- Agent Store owner management (the "my agents" panel) ----------
+  //
+  // Act on a listing by its gateway id against the `/agentstore` API with the
+  // caller's own bearer (same surface the publish methods above use). Reads live
+  // off `GET /me/agents`; no host-side pointer is involved.
+
+  /** Every listing the caller owns, in all lifecycle states (`GET /me/agents`). */
+  listMyStoreAgents(): Promise<MyAgent[]> {
+    return this.request<{ items: MyAgent[] }>(
+      "GET",
+      "/agentstore/me/agents",
+    ).then((r) => r.items);
+  }
+  /** Ask an admin to make an owned listing public (`PATCH … {requestPublic}`). */
+  async requestStorePublic(storeAgentId: string): Promise<void> {
+    await this.request(
+      "PATCH",
+      `/agentstore/agents/${this.seg(storeAgentId)}`,
+      { requestPublic: true },
+      undefined,
+      undefined,
+      false,
+    );
+  }
+  /** Drop a public listing back to unlisted (`PATCH … {visibility:"unlisted"}`). */
+  async setStoreVisibilityUnlisted(storeAgentId: string): Promise<void> {
+    await this.request(
+      "PATCH",
+      `/agentstore/agents/${this.seg(storeAgentId)}`,
+      { visibility: "unlisted" },
+      undefined,
+      undefined,
+      false,
+    );
+  }
+  /** Take an owned listing down by its gateway id (`PATCH … {unpublish}`). */
+  async unpublishStoreAgentById(storeAgentId: string): Promise<void> {
+    await this.request(
+      "PATCH",
+      `/agentstore/agents/${this.seg(storeAgentId)}`,
+      { unpublish: true },
+      undefined,
+      undefined,
+      false,
+    );
+  }
+  /** Soft-delete an owned listing by its gateway id (`DELETE /agents/{id}`). */
+  async deleteStoreAgentById(storeAgentId: string): Promise<void> {
+    await this.request(
+      "DELETE",
+      `/agentstore/agents/${this.seg(storeAgentId)}`,
+    );
   }
 
   // ---------- WebSocket access (see ws.ts) ----------

--- a/ui/engine-client/src/store-catalog.ts
+++ b/ui/engine-client/src/store-catalog.ts
@@ -16,9 +16,11 @@
 
 import { AgentStoreClient, StoreApiError } from "@houston/agentstore-client";
 import type {
+  ReportInput,
   StoreCatalogAgentDetail,
   StoreCatalogPage,
   StoreCatalogQuery,
+  StoreCategory,
 } from "./types.ts";
 
 /**
@@ -96,6 +98,34 @@ export async function fetchStoreAgent(
 ): Promise<StoreCatalogAgentDetail> {
   try {
     return await catalogClient(fetchImpl).getAgent(slug, ACCEPT_JSON);
+  } catch (err) {
+    throw asCatalogError(err);
+  }
+}
+
+/** The controlled category vocabulary for the browse filter chips (anonymous). */
+export async function fetchStoreCategories(
+  fetchImpl: typeof fetch = fetch,
+): Promise<StoreCategory[]> {
+  try {
+    return await catalogClient(fetchImpl).listCategories(ACCEPT_JSON);
+  } catch (err) {
+    throw asCatalogError(err);
+  }
+}
+
+/**
+ * File an anonymous abuse report against a published listing. The gateway
+ * rate-limits these (5/min/IP); a rejection surfaces as a {@link StoreCatalogError}
+ * the caller toasts.
+ */
+export async function reportStoreAgent(
+  slug: string,
+  input: ReportInput,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  try {
+    await catalogClient(fetchImpl).reportAgent(slug, input);
   } catch (err) {
     throw asCatalogError(err);
   }

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -1741,10 +1741,17 @@ export interface StorePublicationStatus {
 // unchanged. `StoreCatalogAgentDetail.ir` widens from the former
 // `{ skills, learnings }` projection to the full `AgentIR` the gateway serves;
 // the app still reads only `ir.skills`/`ir.learnings`.
+// Owner + moderation wire shapes reused by the store-view surfaces: the "my
+// agents" manage panel (`MyAgent`), the abuse-report dialog (`ReportInput` /
+// `ReportReason`), and the browse filter's category vocabulary (`StoreCategory`).
 export type {
+  MyAgent,
+  ReportInput,
+  ReportReason,
   StoreCatalogPage,
   StoreCatalogQuery,
   StoreCatalogSort,
+  StoreCategory,
 } from "@houston/agentstore-client";
 
 /** One public Agent Store listing, exactly as the catalog API serializes it. */

--- a/ui/engine-client/tests/client-store-owner.test.ts
+++ b/ui/engine-client/tests/client-store-owner.test.ts
@@ -1,0 +1,102 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { HoustonClient } from "../src/client.ts";
+import type { MyAgent } from "../src/types.ts";
+
+/**
+ * Agent Store owner management ("my agents" panel): the front-door
+ * `HoustonClient` methods that act on an owned listing by its gateway id.
+ * `listMyStoreAgents` reads `GET /agentstore/me/agents`; the three lifecycle
+ * mutations all PATCH the IDENTICAL `/agentstore/agents/{id}` URL and differ
+ * ONLY by request body ({requestPublic} / {visibility:"unlisted"} / {unpublish})
+ * — a swapped body would silently perform the wrong action, so each method
+ * asserts its exact outgoing {method, url, body}. `deleteStoreAgentById` DELETEs
+ * the same keyed URL.
+ *
+ * A capturing `fetchImpl` records the outgoing request and parses the JSON body
+ * (all requests are prefixed `${baseUrl}/v1`).
+ */
+
+interface Captured {
+  method: string;
+  url: string;
+  body: unknown;
+}
+
+function makeClient(response: { status?: number; body?: unknown } = {}): {
+  client: HoustonClient;
+  calls: Captured[];
+} {
+  const calls: Captured[] = [];
+  const client = new HoustonClient({
+    baseUrl: "http://127.0.0.1:9999",
+    token: "tok",
+    fetchImpl: async (url, init) => {
+      calls.push({
+        method: init?.method ?? "GET",
+        url: String(url),
+        body:
+          typeof init?.body === "string" ? JSON.parse(init.body) : undefined,
+      });
+      return new Response(JSON.stringify(response.body ?? {}), {
+        status: response.status ?? 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  return { client, calls };
+}
+
+const BASE = "http://127.0.0.1:9999/v1/agentstore";
+
+describe("HoustonClient — store owner: listMyStoreAgents", () => {
+  it("GETs /agentstore/me/agents and unwraps items", async () => {
+    const items = [
+      { id: "a1", name: "Alpha" },
+      { id: "a2", name: "Beta" },
+    ] as unknown as MyAgent[];
+    const { client, calls } = makeClient({ body: { items } });
+    const got = await client.listMyStoreAgents();
+    strictEqual(calls[0].method, "GET");
+    strictEqual(calls[0].url, `${BASE}/me/agents`);
+    strictEqual(calls[0].body, undefined);
+    deepStrictEqual(got, items);
+  });
+});
+
+describe("HoustonClient — store owner: lifecycle mutations (same URL, distinct body)", () => {
+  const ID = "agent 7"; // exercises seg()/URL-encoding
+  const ENC = `${BASE}/agents/agent%207`;
+
+  it("requestStorePublic PATCHes {requestPublic:true}", async () => {
+    const { client, calls } = makeClient();
+    await client.requestStorePublic(ID);
+    strictEqual(calls[0].method, "PATCH");
+    strictEqual(calls[0].url, ENC);
+    deepStrictEqual(calls[0].body, { requestPublic: true });
+  });
+
+  it("setStoreVisibilityUnlisted PATCHes {visibility:'unlisted'}", async () => {
+    const { client, calls } = makeClient();
+    await client.setStoreVisibilityUnlisted(ID);
+    strictEqual(calls[0].method, "PATCH");
+    strictEqual(calls[0].url, ENC);
+    deepStrictEqual(calls[0].body, { visibility: "unlisted" });
+  });
+
+  it("unpublishStoreAgentById PATCHes {unpublish:true}", async () => {
+    const { client, calls } = makeClient();
+    await client.unpublishStoreAgentById(ID);
+    strictEqual(calls[0].method, "PATCH");
+    strictEqual(calls[0].url, ENC);
+    deepStrictEqual(calls[0].body, { unpublish: true });
+  });
+
+  it("deleteStoreAgentById DELETEs the keyed URL with no body", async () => {
+    const { client, calls } = makeClient();
+    await client.deleteStoreAgentById(ID);
+    strictEqual(calls[0].method, "DELETE");
+    strictEqual(calls[0].url, ENC);
+    strictEqual(calls[0].body, undefined);
+  });
+});

--- a/ui/engine-client/tests/store-catalog.test.ts
+++ b/ui/engine-client/tests/store-catalog.test.ts
@@ -3,7 +3,9 @@ import { describe, it } from "node:test";
 import {
   fetchStoreAgent,
   fetchStoreCatalog,
+  fetchStoreCategories,
   pingStoreInstall,
+  reportStoreAgent,
   StoreCatalogError,
   storeCatalogApiBase,
 } from "../src/store-catalog.ts";
@@ -108,6 +110,85 @@ describe("fetchStoreAgent", () => {
     const { calls, fetchImpl } = capture({ agent: {}, ir: {} });
     await fetchStoreAgent("inbox-helper", fetchImpl);
     strictEqual(calls[0].url, `${BASE}/v1/agentstore/agents/inbox-helper`);
+  });
+});
+
+describe("fetchStoreCategories", () => {
+  it("GETs /categories and unwraps the items array", async () => {
+    const cats = [
+      { slug: "productivity", name: "Productivity" },
+      { slug: "research", name: "Research" },
+    ];
+    const { calls, fetchImpl } = capture({ items: cats });
+    deepStrictEqual(await fetchStoreCategories(fetchImpl), cats);
+    strictEqual(calls[0].url, `${BASE}/v1/agentstore/categories`);
+  });
+
+  it("throws a status-carrying StoreCatalogError on a failed read", async () => {
+    const fetchImpl = (() =>
+      Promise.resolve(jsonResponse({ error: "boom" }, 500))) as typeof fetch;
+    await rejects(
+      fetchStoreCategories(fetchImpl),
+      (err: unknown) => err instanceof StoreCatalogError && err.status === 500,
+    );
+  });
+
+  it("re-raises the underlying cause on a network failure (status 0)", async () => {
+    const cause = new Error("connection refused");
+    const fetchImpl = (() => Promise.reject(cause)) as typeof fetch;
+    await rejects(fetchStoreCategories(fetchImpl), (err: unknown) => {
+      ok(!(err instanceof StoreCatalogError));
+      strictEqual(err, cause);
+      return true;
+    });
+  });
+});
+
+describe("reportStoreAgent", () => {
+  it("POSTs the report body to the agent's reports route", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl = ((url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return Promise.resolve(new Response(null, { status: 201 }));
+    }) as typeof fetch;
+    await reportStoreAgent(
+      "inbox-helper",
+      { reason: "spam", details: "unsolicited" },
+      fetchImpl,
+    );
+    strictEqual(
+      calls[0].url,
+      `${BASE}/v1/agentstore/agents/inbox-helper/reports`,
+    );
+    strictEqual(calls[0].init?.method, "POST");
+    deepStrictEqual(JSON.parse(String(calls[0].init?.body)), {
+      reason: "spam",
+      details: "unsolicited",
+    });
+  });
+
+  it("throws a status-carrying StoreCatalogError on HTTP error", async () => {
+    const fetchImpl = (() =>
+      Promise.resolve(
+        jsonResponse({ error: "rate_limited" }, 429),
+      )) as typeof fetch;
+    await rejects(
+      reportStoreAgent("inbox-helper", { reason: "other" }, fetchImpl),
+      (err: unknown) => err instanceof StoreCatalogError && err.status === 429,
+    );
+  });
+
+  it("re-raises the underlying cause on a network failure (status 0)", async () => {
+    const cause = new Error("connection refused");
+    const fetchImpl = (() => Promise.reject(cause)) as typeof fetch;
+    await rejects(
+      reportStoreAgent("inbox-helper", { reason: "spam" }, fetchImpl),
+      (err: unknown) => {
+        ok(!(err instanceof StoreCatalogError));
+        strictEqual(err, cause);
+        return true;
+      },
+    );
   });
 });
 


### PR DESCRIPTION
## What

Brings the in-app Agent Store to feature parity with agents.gethouston.ai (built on the `@houston/agentstore-client` SDK from #965):

- **Gateway-driven categories** — chips source their vocabulary from `GET /categories`; known slugs keep localized labels (en/es/pt), unknown slugs fall back to the gateway name; static seed as offline fallback.
- **Integration filter** on browse — Composio toolkit names/logos reused through a new shared `use-toolkit-catalog` hook (no duplicate catalog copies); options derive from an unfiltered vocabulary so a selection never dead-ends; UPPERCASE slug on the wire.
- **Abuse reporting** — report dialog in the agent detail view (reason/details/contact, anonymous, gateway rate-limited), full toast + Sentry surfacing per no-silent-failures.
- **Owner dashboard** — new "My agents" tab listing every published agent with request-public, make-unlisted, unpublish, delete (both confirm-gated) and see-in-store; powered by five new authed front-door methods (`listMyStoreAgents`, `requestStorePublic`, `setStoreVisibilityUnlisted`, `unpublishStoreAgentById`, `deleteStoreAgentById`) implemented in the engine adapter on the existing `storeAuthFetch` 401-refresh seam. Lazy-mounted: no authed query until the tab is opened.

`store-view` was split into `store-browse` / `store-catalog-results` / panel modules to honor the 200-line rule. No gateway changes needed.

## Verification

- engine-client 83/83, web 190/190, app vitest 1656/1656, app tsgo + check-locales (en/es/pt in sync) green
- Repo-wide Biome + boundaries green
- Adversarial multi-agent review: 10 confirmed findings (silent request-public success, filter dead-ends, swallowed detail fetch error, form-reset, dead keys, missing wire tests, hook duplication) — 8 fixed with tests, 2 correctly refuted; all gates re-run green after fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)