### PR TITLE
fix: stop a double-fired first send from losing a mission (activity doc write race)

### DIFF
--- a/packages/host/src/routes/agent-data-activities-race.test.ts
+++ b/packages/host/src/routes/agent-data-activities-race.test.ts
@@ -1,0 +1,117 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { docKey, type TextStore } from "@houston/domain";
+import type { Activity } from "@houston/protocol";
+import { expect, test } from "vitest";
+import { handleActivitiesData } from "./agent-data-activities";
+
+/**
+ * Concurrent mutations of one agent's activity doc must serialize. Before the
+ * doc lock, two simultaneous creates both loaded the same base list and the
+ * last save dropped the other's entry — a double-fired first-message submit
+ * lost a mission's board entry this way in production (its conversation
+ * persisted fine but became unreachable in the UI).
+ */
+
+const ROOT = "ws/agent";
+const KEY = docKey(ROOT, "activity");
+
+/** In-memory TextStore that snapshots the value at read START and only
+ * returns it after yielding to the event loop — the remote-store shape
+ * (GCS/fs) where a concurrent writer's save lands between a reader's
+ * snapshot and its continuation. Without serialization, two load→save
+ * mutations interleave on this store and the last save deterministically
+ * drops the other's entry. */
+function slowStore(): TextStore & { data: Map<string, string> } {
+  const data = new Map<string, string>();
+  return {
+    data,
+    async readText(key) {
+      const snapshot = data.get(key) ?? null;
+      await new Promise((r) => setTimeout(r, 5));
+      return snapshot;
+    },
+    async writeText(key, content) {
+      data.set(key, content);
+    },
+  };
+}
+
+function request(body: unknown): IncomingMessage {
+  const req = Readable.from([
+    Buffer.from(JSON.stringify(body)),
+  ]) as unknown as IncomingMessage;
+  (req as { headers: Record<string, string> }).headers = {};
+  return req;
+}
+
+function response(): ServerResponse & { status: number; body: unknown } {
+  const res = {
+    status: 0,
+    body: undefined as unknown,
+    writeHead(status: number) {
+      res.status = status;
+      return res;
+    },
+    end(buf?: Buffer) {
+      if (buf) res.body = JSON.parse(buf.toString("utf8"));
+    },
+  };
+  return res as unknown as ServerResponse & { status: number; body: unknown };
+}
+
+function post(store: TextStore, body: Record<string, unknown>) {
+  const res = response();
+  return handleActivitiesData(
+    store,
+    ROOT,
+    "agent-1",
+    "POST",
+    null,
+    request(body),
+    res,
+  ).then(() => res);
+}
+
+function patch(store: TextStore, id: string, body: Record<string, unknown>) {
+  const res = response();
+  return handleActivitiesData(
+    store,
+    ROOT,
+    "agent-1",
+    "PATCH",
+    id,
+    request(body),
+    res,
+  ).then(() => res);
+}
+
+const storedItems = (store: { data: Map<string, string> }): Activity[] =>
+  JSON.parse(store.data.get(KEY) ?? "[]");
+
+test("two concurrent creates both land in the doc", async () => {
+  const store = slowStore();
+  const [a, b] = await Promise.all([
+    post(store, { id: "id-a", title: "Mission A" }),
+    post(store, { id: "id-b", title: "Mission B" }),
+  ]);
+  expect(a.status).toBe(201);
+  expect(b.status).toBe(201);
+  const ids = storedItems(store).map((i) => i.id);
+  expect(ids).toContain("id-a");
+  expect(ids).toContain("id-b");
+});
+
+test("a concurrent patch never erases a concurrent create", async () => {
+  const store = slowStore();
+  await post(store, { id: "id-a", title: "Mission A" });
+  const [created, patched] = await Promise.all([
+    post(store, { id: "id-b", title: "Mission B" }),
+    patch(store, "id-a", { status: "done" }),
+  ]);
+  expect(created.status).toBe(201);
+  expect(patched.status).toBe(200);
+  const items = storedItems(store);
+  expect(items.map((i) => i.id).sort()).toEqual(["id-a", "id-b"]);
+  expect(items.find((i) => i.id === "id-a")?.status).toBe("done");
+});

--- a/packages/host/src/routes/agent-data-activities.ts
+++ b/packages/host/src/routes/agent-data-activities.ts
@@ -13,6 +13,7 @@ import type {
   HoustonEvent,
   NewActivity,
 } from "@houston/protocol";
+import { withDocLock } from "./doc-lock";
 import { json, readJson } from "./http";
 
 export async function handleActivitiesData(
@@ -33,6 +34,11 @@ export async function handleActivitiesData(
   const fireChange = () =>
     emit?.({ type: "ActivityChanged", agentPath: agentId });
   const nowIso = new Date().toISOString();
+  // Every mutation below is a load→save over the whole activity doc;
+  // serialize them per agent so concurrent requests can't drop each other's
+  // entries (see doc-lock.ts). Reads stay lock-free.
+  const locked = <T>(fn: () => Promise<T>) =>
+    withDocLock(`${root}#activity`, fn);
 
   if (method === "GET" && !itemId) {
     json(res, 200, await loadActivities(store, root));
@@ -56,46 +62,54 @@ export async function handleActivitiesData(
       json(res, 400, { error: "invalid 'id'" });
       return;
     }
-    const { items } = await loadActivities(store, root);
     const activity = createActivity(
       body as unknown as NewActivity,
       (body.id as string | undefined) ?? crypto.randomUUID(),
       nowIso,
       author ?? undefined,
     );
-    await saveActivities(store, root, upsertById(items, activity));
+    await locked(async () => {
+      const { items } = await loadActivities(store, root);
+      await saveActivities(store, root, upsertById(items, activity));
+    });
     fireChange();
     json(res, 201, activity);
     return;
   }
 
   if (method === "PATCH" && itemId) {
-    const { items } = await loadActivities(store, root);
-    const current = items.find((a) => a.id === itemId);
-    if (!current) {
+    const update = await readJson(req);
+    const next = await locked(async () => {
+      const { items } = await loadActivities(store, root);
+      const current = items.find((a) => a.id === itemId);
+      if (!current) return null;
+      const applied = applyActivityUpdate(
+        current,
+        update,
+        nowIso,
+        author ?? undefined,
+      );
+      await saveActivities(store, root, upsertById(items, applied));
+      return applied;
+    });
+    if (!next) {
       json(res, 404, { error: "activity not found" });
       return;
     }
-    const next = applyActivityUpdate(
-      current,
-      await readJson(req),
-      nowIso,
-      author ?? undefined,
-    );
-    await saveActivities(store, root, upsertById(items, next));
     fireChange();
     json(res, 200, next);
     return;
   }
 
   if (method === "DELETE" && itemId) {
-    const { items } = await loadActivities(store, root);
-    const removed = removeById(items, itemId);
-    if (removed.removed) {
-      await saveActivities(store, root, removed.items);
-      fireChange();
-    }
-    json(res, 200, { ok: true, deleted: removed.removed });
+    const removed = await locked(async () => {
+      const { items } = await loadActivities(store, root);
+      const result = removeById(items, itemId);
+      if (result.removed) await saveActivities(store, root, result.items);
+      return result.removed;
+    });
+    if (removed) fireChange();
+    json(res, 200, { ok: true, deleted: removed });
     return;
   }
 

--- a/packages/host/src/routes/agent-data.ts
+++ b/packages/host/src/routes/agent-data.ts
@@ -26,6 +26,7 @@ import type { WorkspacePaths } from "../paths";
 import { hostProvider } from "../providers";
 import type { Vfs } from "../vfs";
 import { handleActivitiesData } from "./agent-data-activities";
+import { withDocLock } from "./doc-lock";
 import { json, readJson } from "./http";
 
 // The cloud-layout root, kept as a convenience for cloud tests + callers that
@@ -188,74 +189,86 @@ export async function handleAgentData(
         json(res, 400, { error: providerErr });
         return true;
       }
-      const { items } = await loadRoutines(vfs, root);
       const routine = createRoutine(
         input,
         crypto.randomUUID(),
         nowIso,
         createdBy,
       );
-      await saveRoutines(vfs, root, upsertById(items, routine));
+      // Load→save under the per-doc lock so concurrent routine writes can't
+      // drop each other's entries (same hazard as activities; see doc-lock.ts).
+      await withDocLock(`${root}#routines`, async () => {
+        const { items } = await loadRoutines(vfs, root);
+        await saveRoutines(vfs, root, upsertById(items, routine));
+      });
       fireChange();
       json(res, 201, routine);
       return true;
     }
     if ((method === "PATCH" || method === "DELETE") && itemId) {
-      const { items } = await loadRoutines(vfs, root);
-      const current = items.find((r) => r.id === itemId);
-      if (!current) {
-        json(res, 404, { error: "routine not found" });
-        return true;
-      }
-      if (method === "PATCH") {
-        const update = await readJson(req);
-        // A PATCH may switch a routine to an event trigger; reject a malformed
-        // binding before it is persisted (normalizeRoutines would drop it).
-        if (update.trigger != null && !isValidTriggerBinding(update.trigger)) {
-          json(res, 400, { error: "invalid 'trigger' binding" });
+      // The whole load→validate→save runs under the doc lock: validation
+      // reads `current`, so re-loading inside the lock is what makes the
+      // final save apply to the list a concurrent writer just produced.
+      return await withDocLock(`${root}#routines`, async () => {
+        const { items } = await loadRoutines(vfs, root);
+        const current = items.find((r) => r.id === itemId);
+        if (!current) {
+          json(res, 404, { error: "routine not found" });
           return true;
         }
-        const next = applyRoutineUpdate(current, update, nowIso, createdBy);
-        // The APPLIED result must still hold the exactly-one-wake invariant —
-        // e.g. `{trigger: null}` on a trigger routine clears its only wake.
-        // Persisting such a routine loses it silently: normalizeRoutines drops
-        // it from every read and the next save purges it from disk.
-        const nextWakeErr = wakeMechanismError(
-          next as unknown as Record<string, unknown>,
-        );
-        if (nextWakeErr) {
-          json(res, 400, { error: nextWakeErr });
-          return true;
-        }
-        // A PATCH may change the schedule; validate it against the account-wide
-        // zone (HOU-470: no per-routine timezone). A trigger routine (or a PATCH
-        // that switched to a trigger) has no cron to validate.
-        if (typeof next.schedule === "string") {
-          const accountTz = await getPreference(
-            vfs,
-            ctx.workspace.id,
-            "timezone",
-          );
-          const scheduleErr = validateSchedule(next.schedule, accountTz);
-          if (scheduleErr) {
-            json(res, 400, { error: `invalid schedule: ${scheduleErr}` });
+        if (method === "PATCH") {
+          const update = await readJson(req);
+          // A PATCH may switch a routine to an event trigger; reject a malformed
+          // binding before it is persisted (normalizeRoutines would drop it).
+          if (
+            update.trigger != null &&
+            !isValidTriggerBinding(update.trigger)
+          ) {
+            json(res, 400, { error: "invalid 'trigger' binding" });
             return true;
           }
+          const next = applyRoutineUpdate(current, update, nowIso, createdBy);
+          // The APPLIED result must still hold the exactly-one-wake invariant —
+          // e.g. `{trigger: null}` on a trigger routine clears its only wake.
+          // Persisting such a routine loses it silently: normalizeRoutines drops
+          // it from every read and the next save purges it from disk.
+          const nextWakeErr = wakeMechanismError(
+            next as unknown as Record<string, unknown>,
+          );
+          if (nextWakeErr) {
+            json(res, 400, { error: nextWakeErr });
+            return true;
+          }
+          // A PATCH may change the schedule; validate it against the account-wide
+          // zone (HOU-470: no per-routine timezone). A trigger routine (or a PATCH
+          // that switched to a trigger) has no cron to validate.
+          if (typeof next.schedule === "string") {
+            const accountTz = await getPreference(
+              vfs,
+              ctx.workspace.id,
+              "timezone",
+            );
+            const scheduleErr = validateSchedule(next.schedule, accountTz);
+            if (scheduleErr) {
+              json(res, 400, { error: `invalid schedule: ${scheduleErr}` });
+              return true;
+            }
+          }
+          const providerErr = pinError(update);
+          if (providerErr) {
+            json(res, 400, { error: providerErr });
+            return true;
+          }
+          await saveRoutines(vfs, root, upsertById(items, next));
+          fireChange();
+          json(res, 200, next);
+        } else {
+          await saveRoutines(vfs, root, removeById(items, itemId).items);
+          fireChange();
+          json(res, 200, { ok: true });
         }
-        const providerErr = pinError(update);
-        if (providerErr) {
-          json(res, 400, { error: providerErr });
-          return true;
-        }
-        await saveRoutines(vfs, root, upsertById(items, next));
-        fireChange();
-        json(res, 200, next);
-      } else {
-        await saveRoutines(vfs, root, removeById(items, itemId).items);
-        fireChange();
-        json(res, 200, { ok: true });
-      }
-      return true;
+        return true;
+      });
     }
   }
 

--- a/packages/host/src/routes/doc-lock.test.ts
+++ b/packages/host/src/routes/doc-lock.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "vitest";
+import { withDocLock } from "./doc-lock";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+test("same-key writers run strictly one after another", async () => {
+  const order: string[] = [];
+  const slow = withDocLock("k", async () => {
+    order.push("a:start");
+    await tick();
+    await tick();
+    order.push("a:end");
+  });
+  const fast = withDocLock("k", async () => {
+    order.push("b:start");
+    order.push("b:end");
+  });
+  await Promise.all([slow, fast]);
+  expect(order).toEqual(["a:start", "a:end", "b:start", "b:end"]);
+});
+
+test("different keys never contend", async () => {
+  const order: string[] = [];
+  let release: () => void = () => {};
+  const gate = new Promise<void>((r) => {
+    release = r;
+  });
+  const blocked = withDocLock("k1", async () => {
+    await gate;
+    order.push("k1");
+  });
+  await withDocLock("k2", async () => {
+    order.push("k2");
+  });
+  release();
+  await blocked;
+  expect(order).toEqual(["k2", "k1"]);
+});
+
+test("a rejection propagates to its caller but never wedges the chain", async () => {
+  const boom = withDocLock("k", async () => {
+    throw new Error("boom");
+  });
+  await expect(boom).rejects.toThrow("boom");
+  await expect(withDocLock("k", async () => "after")).resolves.toBe("after");
+});

--- a/packages/host/src/routes/doc-lock.ts
+++ b/packages/host/src/routes/doc-lock.ts
@@ -1,0 +1,33 @@
+/**
+ * Per-document write serialization for the typed `.houston` families.
+ *
+ * Every mutation of a whole-file JSON doc (activities, routines) is a
+ * load → modify → save: two concurrent requests for the same agent both load
+ * the same base list and the last save silently drops the other's entry. This
+ * is not theoretical — a double-fired first-message submit created two
+ * missions ~70ms apart and the losing create's board entry vanished, leaving
+ * its (fully persisted) conversation unreachable in the UI.
+ *
+ * Same chain-of-promises shape as the runtime's `withWorkdirLock`: same-key
+ * writers queue, different keys never contend, a rejection propagates to its
+ * caller but never wedges the chain. In-process serialization is sufficient —
+ * this host process is the only writer of a given agent's docs.
+ */
+
+const chains = new Map<string, Promise<void>>();
+
+export function withDocLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const prev = chains.get(key) ?? Promise.resolve();
+  const run = prev.then(fn);
+  const settled = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  chains.set(key, settled);
+  // Drop the entry once this run is the tail and done, so the map never
+  // accumulates one promise per doc the process ever touched.
+  void settled.then(() => {
+    if (chains.get(key) === settled) chains.delete(key);
+  });
+  return run;
+}

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -15,6 +15,7 @@ import type { KanbanCardLabels } from "./kanban-card";
 import { KanbanDetailPanel } from "./kanban-detail-panel";
 import { KanbanList } from "./kanban-list";
 import { type ResolvedSelection, resolvePanelState } from "./panel-state";
+import { shouldDropComposerSend } from "./submit-gate";
 import type { BoardSearchSnippet, KanbanColumn, KanbanItem } from "./types";
 
 export interface NewPanelOptions {
@@ -492,34 +493,52 @@ export function AIBoard({
       : rawActiveFeed;
 
   // Unified send handler: creates conversation on first message, sends follow-ups after
+  const sendInFlightRef = useRef(false);
   const handleSend = useCallback(
     async (text: string, files: File[]) => {
-      const handled = await onComposerSubmit?.({
-        sessionKey: activeSessionKey,
-        text,
-        files,
-        hasMessages: activeFeed.length > 0,
-      });
-      if (handled) {
-        onDraftChange?.(activeDraftKey, "");
+      // A repeated submit (Enter auto-repeat, double click) that lands while
+      // the first send is still creating its conversation has no session key
+      // to route to — letting it through would mint a duplicate mission and
+      // run the same prompt twice (see submit-gate.ts).
+      if (
+        shouldDropComposerSend({
+          activeSessionKey,
+          sendInFlight: sendInFlightRef.current,
+        })
+      ) {
         return;
       }
-      if (activeSessionKey && onSendMessage) {
-        // Keyed off `activeSessionKey` (derived from `selectedId`), not
-        // `selectedItem`: a send fired while the created activity is
-        // still absent from `items` must go to the existing session,
-        // never fall through and create a duplicate conversation.
-        await onSendMessage(activeSessionKey, text, files);
-        onDraftChange?.(activeDraftKey, "");
-      } else if (newPanelOpen && onCreateConversation) {
-        const activityId = await onCreateConversation(text, files);
-        onDraftChange?.(activeDraftKey, "");
-        // Select the new activity so the feed renders. The freshly-created
-        // activity may take a while to appear in `items` (the parent
-        // invalidates the activity query asynchronously; against a warming
-        // engine the row only lands when it wakes) — the panel stays open
-        // regardless, keyed off this selection (see resolvePanelState).
-        setSelectedId(activityId);
+      sendInFlightRef.current = true;
+      try {
+        const handled = await onComposerSubmit?.({
+          sessionKey: activeSessionKey,
+          text,
+          files,
+          hasMessages: activeFeed.length > 0,
+        });
+        if (handled) {
+          onDraftChange?.(activeDraftKey, "");
+          return;
+        }
+        if (activeSessionKey && onSendMessage) {
+          // Keyed off `activeSessionKey` (derived from `selectedId`), not
+          // `selectedItem`: a send fired while the created activity is
+          // still absent from `items` must go to the existing session,
+          // never fall through and create a duplicate conversation.
+          await onSendMessage(activeSessionKey, text, files);
+          onDraftChange?.(activeDraftKey, "");
+        } else if (newPanelOpen && onCreateConversation) {
+          const activityId = await onCreateConversation(text, files);
+          onDraftChange?.(activeDraftKey, "");
+          // Select the new activity so the feed renders. The freshly-created
+          // activity may take a while to appear in `items` (the parent
+          // invalidates the activity query asynchronously; against a warming
+          // engine the row only lands when it wakes) — the panel stays open
+          // regardless, keyed off this selection (see resolvePanelState).
+          setSelectedId(activityId);
+        }
+      } finally {
+        sendInFlightRef.current = false;
       }
     },
     [

--- a/ui/board/src/submit-gate.ts
+++ b/ui/board/src/submit-gate.ts
@@ -1,0 +1,17 @@
+/**
+ * Gate for the composer's unified send (AIBoard `handleSend`).
+ *
+ * A double-fired submit — Enter key auto-repeat, a second Enter before React
+ * re-renders, a double click — arrives while the first send is still in
+ * flight. With no active session key yet, BOTH invocations take the
+ * create-conversation branch and mint two missions from one message: the user
+ * pays for two turns and the board ends up with a shadow duplicate. Drop the
+ * repeat. Sends into an existing session are never dropped — the send queue
+ * already serializes those.
+ */
+export function shouldDropComposerSend(args: {
+  activeSessionKey: string | null;
+  sendInFlight: boolean;
+}): boolean {
+  return args.sendInFlight && !args.activeSessionKey;
+}

--- a/ui/board/tests/submit-gate.test.ts
+++ b/ui/board/tests/submit-gate.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { shouldDropComposerSend } from "../src/submit-gate.ts";
+
+test("drops a repeat submit while the create is still in flight", () => {
+  assert.equal(
+    shouldDropComposerSend({ activeSessionKey: null, sendInFlight: true }),
+    true,
+  );
+});
+
+test("first submit of a new conversation goes through", () => {
+  assert.equal(
+    shouldDropComposerSend({ activeSessionKey: null, sendInFlight: false }),
+    false,
+  );
+});
+
+test("follow-ups into an existing session are never dropped", () => {
+  assert.equal(
+    shouldDropComposerSend({
+      activeSessionKey: "activity-1",
+      sendInFlight: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldDropComposerSend({
+      activeSessionKey: "activity-1",
+      sendInFlight: false,
+    }),
+    false,
+  );
+});


### PR DESCRIPTION
## What happened (production incident, 2026-07-17)

A beta user "lost" a conversation: mid-mission they switched to another agent, came back, and the thread had reverted to an earlier answer. Restarting the app didn't help, yet the provider had billed the full work.

Pod data + gateway logs told the real story:

1. The **first message of the mission was submitted twice ~70 ms apart** (Enter auto-repeat / double-fire): two full create pipelines, two client-generated conversation ids, two turns running the same prompt.
2. The host's `POST /agents/:id/activities` is a `loadActivities -> saveActivities` over the whole `activity.json` with **no serialization**. The two concurrent creates both loaded the same base list; the last save won and **silently dropped the other mission's board entry**.
3. The dropped entry belonged to the conversation the user kept working in. Its data persisted perfectly (final answer, `stopReason: "stop"`) — but with no board entry there was no card, so every later open resolved to the duplicate, which had stopped 8 minutes earlier. To the user, the work vanished.

## Fixes

**Host — `withDocLock` (`packages/host/src/routes/doc-lock.ts`):** a per-key promise-chain mutex (same shape as the runtime's `withWorkdirLock`). All read-modify-write mutations of the typed whole-file `.houston` docs now serialize per agent: activities (POST/PATCH/DELETE) and routines (POST/PATCH/DELETE, whose load->validate->save moved inside the lock since validation reads `current`). Reads stay lock-free. In-process serialization is sufficient — the host process is the only writer of an agent's docs.

**ui/board — submit gate (`ui/board/src/submit-gate.ts`):** `AIBoard`'s unified `handleSend` now drops a repeat submit that arrives while the first send is still in flight *and* there is no active session key yet — the exact window where a second Enter would mint a second conversation. Follow-ups into an existing session are never dropped (the send queue already serializes those).

## Tests

- `doc-lock.test.ts` — same-key serialization order, distinct-key independence, rejection doesn't wedge the chain.
- `agent-data-activities-race.test.ts` — drives `handleActivitiesData` with a store that snapshots at read-start and yields before returning (the remote-store shape where the race manifests). Verified the test **fails with the lock neutered** and passes with it: concurrent create+create and create+patch both preserve every entry.
- `ui/board/tests/submit-gate.test.ts` — gate semantics.

Gates: full `@houston/host` vitest suite (962 passed), `ui/board` node tests, `pnpm typecheck` (all 25 projects), `pnpm check` clean, `pnpm check:boundaries` clean.

## Not in this PR

The desktop data layer still does client-side whole-file read-modify-writes of `activity.json` over the raw agentfile PUT (`app/src/data/activity.ts` via `readAgentFile`/`writeAgentFile`), which a concurrent typed write can still cross. Moving those writes onto the typed routes is a follow-up.
