### PR TITLE
fix(host): demote the Linux recursive-watcher ENOENT race to a warning

### DIFF
--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -12,6 +12,7 @@ import {
 } from "../capabilities";
 import { houstonSystemPrompt } from "../houston-prompt";
 import { installParentWatchdog } from "../parent-watchdog";
+import { isBenignRecursiveWatchRace } from "../watch/watcher-race";
 import { buildLocalHost } from "./host";
 import { runtimeCommand } from "./runtime-command";
 
@@ -197,6 +198,16 @@ const host = buildLocalHost({
 // dropped SSE socket, or a transient fetch. Log loudly and stay up — the user
 // would otherwise see "NetworkError" on the next request.
 process.on("uncaughtException", (err) => {
+  // One narrow demotion: Node's Linux recursive-watcher ENOENT race on a
+  // transient dir (see watch/watcher-race.ts). Warning breadcrumb, not a
+  // Sentry error event; every other uncaught error stays loud.
+  if (isBenignRecursiveWatchRace(err)) {
+    console.warn(
+      "[local-host] transient fs-watch race (ignored):",
+      err.message,
+    );
+    return;
+  }
   console.error("[local-host] uncaughtException (staying up):", err);
 });
 process.on("unhandledRejection", (reason) => {

--- a/packages/host/src/watch/watcher-race.test.ts
+++ b/packages/host/src/watch/watcher-race.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isBenignRecursiveWatchRace } from "./watcher-race";
+
+/** An ENOENT shaped exactly like the production events (issue 7614029702). */
+function recursiveWatchEnoent(): Error {
+  const err = new Error(
+    "ENOENT: no such file or directory, scandir '/data/workspaces/Personal/Personal Assistant/.houston/runtime/auth.json.lock'",
+  ) as NodeJS.ErrnoException;
+  err.code = "ENOENT";
+  err.syscall = "scandir";
+  err.stack = [
+    "Error: ENOENT: no such file or directory, scandir '…/auth.json.lock'",
+    "    at readdirSync (node:fs:1590:26)",
+    "    at #watchFolder (node:internal/fs/recursive_watch:111:24)",
+    "    at #watchFolder (node:internal/fs/recursive_watch:132:33)",
+    "    at FSWatcher.<anonymous> (node:internal/fs/recursive_watch:191:24)",
+  ].join("\n");
+  return err;
+}
+
+describe("isBenignRecursiveWatchRace", () => {
+  it("matches the Linux recursive-watcher ENOENT race", () => {
+    expect(isBenignRecursiveWatchRace(recursiveWatchEnoent())).toBe(true);
+  });
+
+  it("stays loud for ENOENT from application code", () => {
+    const err = new Error(
+      "ENOENT: no such file or directory",
+    ) as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    // A normal stack — no recursive_watch frames.
+    expect(isBenignRecursiveWatchRace(err)).toBe(false);
+  });
+
+  it("stays loud for non-ENOENT errors inside the watcher", () => {
+    const err = recursiveWatchEnoent() as NodeJS.ErrnoException;
+    err.code = "EMFILE";
+    expect(isBenignRecursiveWatchRace(err)).toBe(false);
+  });
+
+  it("stays loud for non-Error values", () => {
+    expect(isBenignRecursiveWatchRace("ENOENT string")).toBe(false);
+    expect(isBenignRecursiveWatchRace(undefined)).toBe(false);
+  });
+});

--- a/packages/host/src/watch/watcher-race.ts
+++ b/packages/host/src/watch/watcher-race.ts
@@ -1,0 +1,25 @@
+/**
+ * Node's recursive `fs.watch` on Linux is implemented in JS
+ * (`node:internal/fs/recursive_watch`): it re-scans directories with
+ * `readdirSync` when entries change. A transient directory deleted between the
+ * change event and the scan — pi's `auth.json.lock` lock dir (created/removed
+ * around every credential refresh by `@earendil-works/pi-coding-agent`
+ * AuthStorage, not configurable) is the frequent case — throws ENOENT from
+ * inside Node's internals: no app frame, and no watcher `error` handler ever
+ * sees it, so it can only surface as an uncaughtException
+ * (HOUSTON-APP issue 7614029702, ~10/day across pods).
+ *
+ * The race is harmless — the watcher re-scans on the next event and the
+ * store-sync daemon additionally has a periodic-sync fallback — so the host
+ * demotes exactly this signature to a warning breadcrumb instead of a Sentry
+ * error event. Everything else stays loud (beta no-silent-failures policy).
+ */
+export function isBenignRecursiveWatchRace(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const code = (err as NodeJS.ErrnoException).code;
+  return (
+    code === "ENOENT" &&
+    typeof err.stack === "string" &&
+    err.stack.includes("internal/fs/recursive_watch")
+  );
+}


### PR DESCRIPTION
Fixes [HOUSTON-APP issue 7614029702] — `ENOENT: scandir '…/.houston/runtime/auth.json.lock'`, 20 events across 4 orgs in 2 days, still firing on today's newest engine build.

**Root cause** (readable straight off the improved Sentry event): pi's `AuthStorage` (`@earendil-works/pi-coding-agent`) locks `auth.json` with proper-lockfile, which creates and deletes the `auth.json.lock` directory around every credential refresh — inside the tree the host watches recursively. On Linux, Node implements recursive `fs.watch` in JS (`node:internal/fs/recursive_watch`): it re-scans changed directories with `readdirSync`. When the lock dir vanishes between the change event and the scan, ENOENT is thrown from Node internals — every stack frame is `node:internal/*`, no watcher `error` handler receives it, and it surfaces as the host's uncaughtException.

**Why demote instead of eliminate:** the lock path isn't configurable upstream (`AuthStorage.create` exposes no `lockfilePath`), and the race is harmless — the watcher re-scans on the next event and the store-sync daemon additionally has a periodic-sync fallback. The demotion is deliberately narrow: `code === ENOENT` **and** `recursive_watch` frames in the stack (`packages/host/src/watch/watcher-race.ts`). It still lands in logs and rides as a warning breadcrumb; every other uncaught error keeps firing Sentry events (beta no-silent-failures policy intact).

Unit tests cover the exact production error shape plus the stay-loud cases (app-code ENOENT, non-ENOENT watcher errors, non-Error values). Host suite 962+4 passing, typecheck + Biome clean.

Follow-up candidate (not this PR): expose a lock-path option upstream in pi-coding-agent so the lock can live outside the watched tree, eliminating the trigger entirely.