### PR TITLE
feat(chat): apply AI Mode changes to the running turn (Claude Code shift+tab)

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -131,7 +131,6 @@ import {
 } from "../lib/tauri";
 import {
   DEFAULT_TURN_MODE,
-  modeChangeAppliesNextTurn,
   normalizeTurnMode,
   type TurnMode,
 } from "../lib/turn-mode";
@@ -730,34 +729,34 @@ export function useAgentChatPanel({
     [path, addToast, t],
   );
   const handleModeSelect = useCallback(
-    async (mode: TurnMode, opts?: { silent?: boolean }) => {
+    async (mode: TurnMode) => {
       // Mode is per-agent composer memory (never synced to engine Settings):
       // persist it so the pill reopens where the user left it. Optimistic flip;
-      // the actual plan/execute pin rides each send as `modeOverride`.
+      // each send pins the pick as `modeOverride`.
       //
-      // A pick while a turn is streaming can't touch that turn (its pin was
-      // stamped at send), so say so: a transient toast tells the user the new
-      // mode rides the NEXT message. `silent` is for programmatic flips whose
-      // send carries the mode explicitly (the plan-ready card), where the
-      // note would be a lie.
-      if (
-        !opts?.silent &&
-        modeChangeAppliesNextTurn(turnRunning, turnMode, mode)
-      ) {
+      // A pick while a turn is STREAMING also applies to that turn (Claude
+      // Code's shift+tab): the runtime mutates the executing turn's live-mode
+      // ref, so the agent adopts the new mode at its next tool decision.
+      // `applied: false` (the turn settled while the request flew) is benign —
+      // the next send pins the mode anyway — but a transport failure is
+      // surfaced, with the honest "your next message still gets it" note.
+      setTurnMode(mode);
+      if (turnRunning && path && selectedSessionKey && mode !== turnMode) {
         const modeLabels: Record<TurnMode, string> = {
           execute: t("chat:modeSelector.coworker"),
           plan: t("chat:modeSelector.planner"),
           auto: t("chat:modeSelector.autopilot"),
         };
-        addToast({
-          title: t("chat:modeSelector.nextTurnToastTitle", {
-            mode: modeLabels[mode],
-          }),
-          description: t("chat:modeSelector.nextTurnToastBody"),
-          variant: "info",
+        tauriChat.setLiveTurnMode(path, selectedSessionKey, mode).catch(() => {
+          addToast({
+            title: t("chat:modeSelector.liveApplyFailedTitle", {
+              mode: modeLabels[mode],
+            }),
+            description: t("chat:modeSelector.liveApplyFailedBody"),
+            variant: "error",
+          });
         });
       }
-      setTurnMode(mode);
       try {
         if (path) {
           const cfg = await tauriConfig.read(path);
@@ -771,7 +770,7 @@ export function useAgentChatPanel({
         });
       }
     },
-    [path, addToast, t, turnRunning, turnMode],
+    [path, selectedSessionKey, addToast, t, turnRunning, turnMode],
   );
 
   // Route a composer model / effort pick. In personal (Teams) mode it writes the
@@ -1191,7 +1190,7 @@ export function useAgentChatPanel({
   const startPlan = useCallback(
     (mode: TurnMode, text: string) => {
       if (!path || !selectedSessionKey) return;
-      void handleModeSelect(mode, { silent: true });
+      void handleModeSelect(mode);
       tauriChat
         .send(path, text, selectedSessionKey, {
           providerOverride: effectiveProvider,

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -405,6 +405,15 @@ export const tauriChat = {
     call<void>("stop_session", async () => {
       await getEngine().cancelSession(agentPath, sessionKey);
     }),
+  /** Apply a Mode-pill switch to the conversation's EXECUTING turn (Claude
+   *  Code's shift+tab): the running turn adopts the new mode at its next tool
+   *  decision. `applied: false` = no turn was running (benign — the next send
+   *  pins the mode itself). */
+  setLiveTurnMode: (
+    agentPath: string,
+    sessionKey: string,
+    mode: "execute" | "plan" | "auto",
+  ) => getEngine().setLiveTurnMode(agentPath, sessionKey, mode),
   /** Retire a conversation's pending interaction (stepper X / abandon): appends
    *  a durable stop marker, like a real Stop — the model learns nothing. */
   dismissInteraction: (agentPath: string, conversationId: string) =>

--- a/app/src/lib/turn-mode.ts
+++ b/app/src/lib/turn-mode.ts
@@ -8,7 +8,10 @@
  * tools (ask_user, request_connection) so the agent finishes the task with
  * what it has instead of pausing to ask, then reports back. An UNPINNED turn
  * is always `execute`, so `plan`/`auto` only take effect on sends that forward
- * the pin as `modeOverride`.
+ * the pin as `modeOverride`. A pick while a turn is RUNNING additionally
+ * applies to that turn live (`tauriChat.setLiveTurnMode` — Claude Code's
+ * shift+tab semantics): the runtime's executing turn adopts it at its next
+ * tool decision.
  *
  * The user's last pick is remembered per-agent in `.houston/config` (composer
  * memory only — never synced to engine Settings), so unknown/legacy values on
@@ -25,22 +28,6 @@ export function normalizeTurnMode(value: unknown): TurnMode {
   if (value === "auto") return "auto";
   if (value === "execute") return "execute";
   return DEFAULT_TURN_MODE;
-}
-
-/**
- * Whether a Mode-pill pick deserves the "applies to your next message" note.
- * True only when a turn is running AND the pick actually changes the mode:
- * the in-flight turn keeps the mode it was sent with (the pin rides each send
- * as `modeOverride`), so a mid-turn change is real but deferred, and the user
- * needs to hear that. Re-picking the current mode changes nothing, and a pick
- * with no turn running applies immediately — neither warrants a note.
- */
-export function modeChangeAppliesNextTurn(
-  turnRunning: boolean,
-  current: TurnMode,
-  next: TurnMode,
-): boolean {
-  return turnRunning && next !== current;
 }
 
 /**

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -146,8 +146,8 @@
     "plannerDescription": "Writes a plan for you to approve first. Makes no changes.",
     "autopilot": "Autopilot",
     "autopilotDescription": "Finishes the task on its own with what it has. No questions asked.",
-    "nextTurnToastTitle": "{{mode}} mode is set",
-    "nextTurnToastBody": "It will apply to your next message. The current reply keeps going."
+    "liveApplyFailedTitle": "Couldn't switch the running reply to {{mode}}",
+    "liveApplyFailedBody": "The mode will still apply to your next message."
   },
   "modelSelector": {
     "selectModel": "Select model",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -146,8 +146,8 @@
     "plannerDescription": "Primero escribe un plan para que lo apruebes. No hace cambios.",
     "autopilot": "Piloto automático",
     "autopilotDescription": "Termina la tarea por su cuenta con lo que tiene. No hace preguntas.",
-    "nextTurnToastTitle": "Modo {{mode}} seleccionado",
-    "nextTurnToastBody": "Se aplicará a tu próximo mensaje. La respuesta actual continúa."
+    "liveApplyFailedTitle": "No se pudo cambiar la respuesta en curso a {{mode}}",
+    "liveApplyFailedBody": "El modo se aplicará igualmente a tu próximo mensaje."
   },
   "modelSelector": {
     "selectModel": "Elige un modelo",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -146,8 +146,8 @@
     "plannerDescription": "Primeiro escreve um plano para você aprovar. Não faz alterações.",
     "autopilot": "Piloto automático",
     "autopilotDescription": "Conclui a tarefa sozinho com o que tem. Não faz perguntas.",
-    "nextTurnToastTitle": "Modo {{mode}} selecionado",
-    "nextTurnToastBody": "Será aplicado à sua próxima mensagem. A resposta atual continua."
+    "liveApplyFailedTitle": "Não foi possível mudar a resposta em andamento para {{mode}}",
+    "liveApplyFailedBody": "O modo ainda será aplicado à sua próxima mensagem."
   },
   "modelSelector": {
     "selectModel": "Escolha um modelo",

--- a/app/tests/turn-mode.test.ts
+++ b/app/tests/turn-mode.test.ts
@@ -2,7 +2,6 @@ import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
   DEFAULT_TURN_MODE,
-  modeChangeAppliesNextTurn,
   normalizeTurnMode,
   readAgentTurnMode,
 } from "../src/lib/turn-mode.ts";
@@ -36,27 +35,6 @@ describe("normalizeTurnMode", () => {
 
   it("defaults to plan (fresh agents open in Planner)", () => {
     strictEqual(DEFAULT_TURN_MODE, "plan");
-  });
-});
-
-// A Mode-pill pick can't touch the in-flight turn (its pin was stamped at
-// send), so the composer shows an "applies to your next message" toast — but
-// ONLY when a turn is actually running and the pick changes the mode.
-describe("modeChangeAppliesNextTurn", () => {
-  it("announces a real change while a turn is running", () => {
-    strictEqual(modeChangeAppliesNextTurn(true, "execute", "plan"), true);
-    strictEqual(modeChangeAppliesNextTurn(true, "plan", "auto"), true);
-    strictEqual(modeChangeAppliesNextTurn(true, "auto", "execute"), true);
-  });
-
-  it("stays quiet when no turn is running (the pick applies immediately)", () => {
-    strictEqual(modeChangeAppliesNextTurn(false, "execute", "plan"), false);
-    strictEqual(modeChangeAppliesNextTurn(false, "plan", "auto"), false);
-  });
-
-  it("stays quiet when the pick re-selects the current mode", () => {
-    strictEqual(modeChangeAppliesNextTurn(true, "plan", "plan"), false);
-    strictEqual(modeChangeAppliesNextTurn(false, "auto", "auto"), false);
   });
 });
 

--- a/packages/fake-host/src/routes.ts
+++ b/packages/fake-host/src/routes.ts
@@ -227,6 +227,11 @@ export function handleAgents(
         // the client settles the stuck card itself (the orphan path).
         return json({ ok: true, cancelled: cancelChat(id, cid) });
       }
+      if (action === "mode" && method === "POST") {
+        // Live Mode-pill switch passthrough. No turn ever runs in the fake
+        // host, so it always answers the benign "nothing to apply" shape.
+        return json({ ok: true, applied: false });
+      }
       if (action === "dismiss-interaction" && method === "POST") {
         // Runtime passthrough: append the durable stop marker to the transcript
         // AND retire the bound activity's pending interaction (mirrors the real

--- a/packages/runtime-client/src/client.ts
+++ b/packages/runtime-client/src/client.ts
@@ -249,6 +249,22 @@ export class HoustonEngineClient {
     );
   }
   /**
+   * Apply a Mode-pill switch to the conversation's EXECUTING turn (Claude
+   * Code's shift+tab semantics): the running turn's tools adopt the new mode at
+   * their next decision point. `applied: false` is benign — no turn was
+   * running, and the next send pins the mode itself.
+   */
+  setMode(id: string, mode: "execute" | "plan" | "auto") {
+    return this.json<{ ok: boolean; applied: boolean }>(
+      `/conversations/${encodeURIComponent(id)}/mode`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode }),
+      },
+    );
+  }
+  /**
    * Append the durable stop marker to retire a pending interaction (the stepper
    * X / abandon). Answers 409 if a turn is running — the card is never shown
    * mid-turn, so a race means the user should Stop instead.

--- a/packages/runtime/src/backends/claude/tool-policy.ts
+++ b/packages/runtime/src/backends/claude/tool-policy.ts
@@ -5,6 +5,7 @@ import type {
 } from "@anthropic-ai/claude-agent-sdk";
 import type { TurnMode } from "@houston/protocol";
 import { WorkspaceGuard } from "../../session/tools/fs-guard";
+import { currentTurnMode } from "../../session/turn-mode-context";
 
 /**
  * The Claude Agent SDK tool policy for a Houston session. pi exposes only a
@@ -107,9 +108,24 @@ export function buildToolPolicy(input: ToolPolicyInput): ToolPolicy {
  * with a clear message. Bash is approved unless its command names a path token
  * that escapes (absolute, `~`, or a `..` segment climbing out of cwd).
  */
+/** The mutating/executing built-ins a LIVE flip to plan mode must stop. */
+const PLAN_DENIED_TOOLS = new Set(["Edit", "Write", "Bash"]);
+
 export function makeCanUseTool(workspaceDir: string): CanUseTool {
   const guard = new WorkspaceGuard(workspaceDir);
   return async (toolName, input, options): Promise<PermissionResult> => {
+    // Live plan-mode gate for the mid-turn Mode-pill switch (Claude Code's
+    // shift+tab): a session BUILT at execute/auto still exposes Edit/Write/Bash,
+    // so when the user switches to Plan while the turn runs, deny them here at
+    // permission time with the switch-to-planning instruction. A plan-BUILT
+    // session never offers these tools, so this only fires on a mid-turn switch.
+    if (currentTurnMode() === "plan" && PLAN_DENIED_TOOLS.has(toolName)) {
+      return {
+        behavior: "deny",
+        message:
+          "The user just switched this conversation to Plan mode, so you can no longer make changes or run commands. Stop acting now: summarize what you already did, then lay out the remaining work as a clear step-by-step plan in plain language for the user to approve, and end your turn.",
+      };
+    }
     try {
       const paths = targetPaths(toolName, input);
       // The SDK flags a Bash command that reaches outside the allowed dirs via

--- a/packages/runtime/src/session/chat.ts
+++ b/packages/runtime/src/session/chat.ts
@@ -1,5 +1,6 @@
 import { rmSync } from "node:fs";
 import { join } from "node:path";
+import type { TurnMode } from "@houston/protocol";
 import { activeProvider, resolveModel } from "../ai/providers";
 import { syncServedCredentialSafe } from "../auth/serve";
 import { cleanupClaudeConversation } from "../backends/claude/cleanup";
@@ -156,6 +157,24 @@ export async function runTurn(
   } finally {
     conv.pending--;
   }
+}
+
+/**
+ * Apply a Mode-pill switch to a conversation's EXECUTING turn (Claude Code's
+ * shift+tab semantics): mutate the live-mode ref exec-turn parked on the
+ * Conversation, so the running turn's tools adopt the new mode at their next
+ * decision point — an auto flip un-gates integration actions immediately, a
+ * plan flip starts refusing writes with a message that tells the model why.
+ *
+ * Returns whether a live turn actually adopted it: `false` means no turn is
+ * executing (or the conversation isn't cached), which is benign — the client's
+ * next send pins the mode itself, so there is nothing to apply here.
+ */
+export function setLiveTurnMode(id: string, mode: TurnMode): boolean {
+  const conv = conversations.get(id);
+  if (!conv?.liveMode) return false;
+  conv.liveMode.current = mode;
+  return true;
 }
 
 /**

--- a/packages/runtime/src/session/conversation-cache.ts
+++ b/packages/runtime/src/session/conversation-cache.ts
@@ -23,6 +23,7 @@ import { makeIntegrationTools } from "./tools/integrations";
 import { makePlanReadyTool } from "./tools/plan-ready";
 import { makeRunCodeTool } from "./tools/run-code";
 import { makeSuggestReusableTool } from "./tools/suggest-reusable";
+import type { TurnModeRef } from "./turn-mode-context";
 import type { ProvidedContext } from "./workspace-context";
 
 /**
@@ -182,6 +183,15 @@ export type Conversation = {
    * See `switchModeIfNeeded`.
    */
   mode: TurnMode;
+  /**
+   * The EXECUTING turn's live-mode ref (set by exec-turn for the turn's
+   * duration, cleared when it settles). `POST /conversations/:id/mode` mutates
+   * `liveMode.current` so the running turn's tools adopt the user's mid-turn
+   * Mode-pill switch at their next decision — Claude Code's shift+tab
+   * semantics. Undefined between turns: with no turn running there is nothing
+   * to apply live; the next turn's pin carries the mode instead.
+   */
+  liveMode?: TurnModeRef;
   /**
    * The workspace + user context the session was FIRST built with (HOU-711,
    * cloud). Reused verbatim when a mode/backend switch rebuilds the session, so a

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -42,7 +42,7 @@ import {
 import { newInteractionHolder, runWithInteractionCapture } from "./interaction";
 import { switchNeedsCompaction } from "./provider-switch";
 import { createStallWatchdog } from "./stall-watchdog";
-import { runWithTurnMode } from "./turn-mode-context";
+import { runWithTurnMode, type TurnModeRef } from "./turn-mode-context";
 
 /** A turn's pinned provider/model/effort/mode. Absent = keep current/default. */
 export interface TurnPin {
@@ -211,7 +211,12 @@ export async function execTurn(
     const model = resolveModel(pin?.model, pin?.provider);
     // The turn's execution mode: the pin's, else execute. Never inherited from
     // Settings. Routine fire paths pin auto; an actually unpinned turn is execute.
-    const mode = pin?.mode ?? DEFAULT_TURN_MODE;
+    // Held in a MUTABLE ref: a mid-turn Mode-pill switch (`POST
+    // /conversations/:id/mode`) reaches it through `conv.liveMode` and the
+    // running turn's tools adopt the new mode at their next decision point.
+    const liveMode: TurnModeRef = { current: pin?.mode ?? DEFAULT_TURN_MODE };
+    conv.liveMode = liveMode;
+    const mode = liveMode.current;
     const providerChanged = model.provider !== conv.provider;
     const modelChanged = model.id !== conv.model;
     // COMPLIANCE GATE: when this turn's model crosses a BACKEND boundary
@@ -364,7 +369,7 @@ export async function execTurn(
     watchdog.arm();
     try {
       await runWithActingContext(acting, () =>
-        runWithTurnMode(mode, () =>
+        runWithTurnMode(liveMode, () =>
           runWithInteractionCapture(interaction, () =>
             conv.session.prompt(promptText),
           ),
@@ -539,6 +544,9 @@ export async function execTurn(
       });
   } finally {
     conv.turnId = undefined;
+    // Retire the live-mode ref with the turn: a Mode-pill switch between turns
+    // has nothing to apply to (the next turn's pin carries it instead).
+    conv.liveMode = undefined;
     // Clear the stop marker alongside the turn id so it never bleeds into the
     // next turn on this conversation (read above to stamp `stopped`).
     conv.stoppedTurnId = undefined;

--- a/packages/runtime/src/session/live-mode-gate.ts
+++ b/packages/runtime/src/session/live-mode-gate.ts
@@ -1,0 +1,39 @@
+import { currentTurnMode } from "./turn-mode-context";
+
+/**
+ * Execute-time mode gates for the mid-turn Mode-pill switch (Claude Code's
+ * shift+tab semantics). A session's TOOLSET is fixed at build time
+ * (tool-selection.ts / the Claude tool policy), so when the user switches mode
+ * WHILE the agent works, the model still sees the old mode's tools — these
+ * gates are how the new mode takes effect anyway: each restricted tool checks
+ * the LIVE mode when it actually runs and refuses with a message that tells
+ * the model what changed and what to do instead.
+ *
+ * Only the RESTRICTIVE direction is enforceable mid-turn (execute/auto → plan
+ * blocks acting; execute → auto blocks waiting). The permissive direction
+ * (plan → execute) cannot conjure tools into a running session — it takes
+ * full effect on the next turn, when the pin rebuilds the session. Same
+ * trade-off Claude Code makes.
+ *
+ * Outside a turn (unit tests calling a tool directly) `currentTurnMode()` is
+ * undefined and every gate is a no-op. Known hole: pi's built-in `bash` runs
+ * outside our custom-tool wrappers, so a mid-turn flip to plan cannot stop an
+ * in-flight bash-capable session from running commands until the turn ends —
+ * the next turn's rebuilt session drops bash entirely.
+ */
+
+/** Throw when the LIVE mode is plan: the model must stop acting and plan. */
+export function assertNotPlanMode(couldNot: string): void {
+  if (currentTurnMode() !== "plan") return;
+  throw new Error(
+    `The user just switched this conversation to Plan mode, so you can no longer ${couldNot}. Stop acting now: summarize what you already did, then lay out the remaining work as a clear step-by-step plan in plain language for the user to approve, and end your turn.`,
+  );
+}
+
+/** Throw when the LIVE mode is auto: the model must not wait on the user. */
+export function assertNotAutoMode(couldNot: string): void {
+  if (currentTurnMode() !== "auto") return;
+  throw new Error(
+    `The user just switched this conversation to Autopilot mode, so you can no longer ${couldNot}. Do not wait on the user: make the most sensible choice yourself and keep going, note any important assumptions, and finish with a short report of what you did and anything that needs their attention.`,
+  );
+}

--- a/packages/runtime/src/session/live-mode.test.ts
+++ b/packages/runtime/src/session/live-mode.test.ts
@@ -1,0 +1,145 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { TurnMode } from "@houston/protocol";
+import { afterEach, expect, test, vi } from "vitest";
+import type { HarnessSession, ResolvedModel } from "../backends/types";
+
+/**
+ * LIVE MODE SWITCH — the user changes the Mode pill WHILE the agent works
+ * (Claude Code's shift+tab): `setLiveTurnMode` mutates the executing turn's
+ * live-mode ref, `currentTurnMode()` sees the flip mid-prompt, and the
+ * execute-time gates (live-mode-gate.ts) start/stop firing accordingly.
+ * Between turns there is no ref — the switch reports `applied: false` and the
+ * next turn's pin carries the mode instead.
+ */
+
+process.env.HOUSTON_DATA_DIR = mkdtempSync(
+  join(tmpdir(), "houston-livemode-data-"),
+);
+process.env.HOUSTON_WORKSPACE_DIR = mkdtempSync(
+  join(tmpdir(), "houston-livemode-ws-"),
+);
+
+const modelState = vi.hoisted(() => ({ model: null as ResolvedModel | null }));
+vi.mock("../ai/providers", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../ai/providers")>();
+  return {
+    ...real,
+    resolveModel: () => modelState.model,
+    activeEffort: () => null,
+  };
+});
+
+await import("./conversation-cache");
+const { execTurn } = await import("./exec-turn");
+const { conversations } = await import("./conversation-cache");
+const { setLiveTurnMode } = await import("./chat");
+const { currentTurnMode, runWithTurnMode } = await import(
+  "./turn-mode-context"
+);
+const { assertNotAutoMode, assertNotPlanMode } = await import(
+  "./live-mode-gate"
+);
+type Conversation = import("./conversation-cache").Conversation;
+
+class FakeSession implements HarnessSession {
+  constructor(readonly onPrompt: () => Promise<void> | void) {}
+  subscribe(): () => void {
+    return () => {};
+  }
+  async prompt(): Promise<void> {
+    await this.onPrompt();
+  }
+  async abort(): Promise<void> {}
+  dispose(): void {}
+  async setModel(): Promise<void> {}
+  async compact(): Promise<void> {}
+  setThinkingLevel(): void {}
+  getContextUsage(): { tokens: number | null } {
+    return { tokens: 0 };
+  }
+}
+
+const OPENAI: ResolvedModel = {
+  provider: "openai-codex",
+  id: "gpt-5-codex",
+  contextWindow: 400_000,
+};
+
+function makeConv(session: HarnessSession): Conversation {
+  return {
+    session,
+    queue: Promise.resolve(),
+    provider: "openai-codex",
+    model: "gpt-5-codex",
+    backendId: "pi",
+    mode: "execute",
+    pending: 0,
+  } as unknown as Conversation;
+}
+
+afterEach(() => {
+  modelState.model = null;
+  conversations.clear();
+});
+
+test("currentTurnMode reads the live ref, so a mid-flight mutation is visible", () => {
+  const ref = { current: "execute" as TurnMode };
+  runWithTurnMode(ref, () => {
+    expect(currentTurnMode()).toBe("execute");
+    ref.current = "plan";
+    expect(currentTurnMode()).toBe("plan");
+  });
+  expect(currentTurnMode()).toBeUndefined();
+});
+
+test("the plan/auto gates fire from the LIVE mode and are no-ops outside a turn", () => {
+  // Outside a turn: no ambient mode, no gate.
+  expect(() => assertNotPlanMode("act")).not.toThrow();
+  expect(() => assertNotAutoMode("wait")).not.toThrow();
+
+  const ref = { current: "execute" as TurnMode };
+  runWithTurnMode(ref, () => {
+    expect(() => assertNotPlanMode("act")).not.toThrow();
+    expect(() => assertNotAutoMode("wait")).not.toThrow();
+    ref.current = "plan";
+    expect(() => assertNotPlanMode("act")).toThrow(/Plan mode/);
+    expect(() => assertNotAutoMode("wait")).not.toThrow();
+    ref.current = "auto";
+    expect(() => assertNotPlanMode("act")).not.toThrow();
+    expect(() => assertNotAutoMode("wait")).toThrow(/Autopilot mode/);
+  });
+});
+
+test("setLiveTurnMode flips the EXECUTING turn's ambient mode mid-prompt", async () => {
+  const seen: Array<TurnMode | undefined> = [];
+  const session = new FakeSession(() => {
+    // Inside the turn: the ambient mode is the pin's, then the user's live
+    // switch (the route's call) is visible to the SAME running prompt.
+    seen.push(currentTurnMode());
+    expect(setLiveTurnMode("conv-live", "plan")).toBe(true);
+    seen.push(currentTurnMode());
+  });
+  const conv = makeConv(session);
+  conversations.set("conv-live", conv);
+  modelState.model = OPENAI;
+
+  await execTurn(
+    conv,
+    "conv-live",
+    "turn-1",
+    "do the thing",
+    { author: undefined, priorAuthors: [] },
+    { mode: "execute" },
+  );
+
+  expect(seen).toEqual(["execute", "plan"]);
+  // The ref retires with the turn: nothing left to apply live between turns.
+  expect(conv.liveMode).toBeUndefined();
+  expect(setLiveTurnMode("conv-live", "auto")).toBe(false);
+});
+
+test("setLiveTurnMode is benign for an unknown conversation", () => {
+  expect(setLiveTurnMode("no-such-conversation", "plan")).toBe(false);
+});

--- a/packages/runtime/src/session/tools/ask-user.ts
+++ b/packages/runtime/src/session/tools/ask-user.ts
@@ -2,6 +2,7 @@ import { defineTool } from "@earendil-works/pi-coding-agent";
 import type { InteractionStep } from "@houston/runtime-client";
 import { type Static, Type } from "typebox";
 import { recordQuestions } from "../interaction";
+import { assertNotAutoMode } from "../live-mode-gate";
 
 /**
  * The blocking-question tool. Any time the model needs the user to answer,
@@ -76,6 +77,9 @@ export function makeAskUserTool() {
     parameters: AskUserParams,
     executionMode: "sequential",
     async execute(_id: string, params: AskUserParams) {
+      // Live gate for the mid-turn Mode-pill switch: a turn built with ask_user
+      // available may now be running in Autopilot — never wait on the user.
+      assertNotAutoMode("ask the user questions or wait for their input");
       if (
         params.questions.length < 1 ||
         params.questions.length > MAX_QUESTIONS

--- a/packages/runtime/src/session/tools/clamped-fs.ts
+++ b/packages/runtime/src/session/tools/clamped-fs.ts
@@ -17,6 +17,7 @@ import {
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import type { TSchema } from "typebox";
+import { assertNotPlanMode } from "../live-mode-gate";
 import { WorkspaceGuard } from "./fs-guard";
 
 /**
@@ -54,6 +55,23 @@ export const CLAMPED_FILE_TOOL_NAMES = [
 ] as const;
 
 type AnyToolDefinition = ToolDefinition<TSchema, unknown, unknown>;
+
+/**
+ * Live plan-mode gate for the two MUTATING file tools (edit/write): when the
+ * user switches the Mode pill to Plan WHILE the agent works, the running turn
+ * still carries the execute-built toolset, so the gate refuses at execute time
+ * with the switch-to-planning instruction. A session BUILT in plan mode never
+ * exposes edit/write at all, so this only ever fires on a mid-turn switch.
+ */
+function withPlanGate(def: AnyToolDefinition): AnyToolDefinition {
+  return {
+    ...def,
+    async execute(toolCallId, params, signal, onUpdate, ctx) {
+      assertNotPlanMode("create, edit, or delete the user's files");
+      return def.execute(toolCallId, params, signal, onUpdate, ctx);
+    },
+  };
+}
 
 function withClampedPath(
   def: AnyToolDefinition,
@@ -125,13 +143,17 @@ export function makeClampedFileTools(
       guard,
     ),
     withClampedPath(createFindToolDefinition(workspaceDir), guard),
-    withClampedPath(
-      createEditToolDefinition(workspaceDir, { operations: editOps }),
-      guard,
+    withPlanGate(
+      withClampedPath(
+        createEditToolDefinition(workspaceDir, { operations: editOps }),
+        guard,
+      ),
     ),
-    withClampedPath(
-      createWriteToolDefinition(workspaceDir, { operations: writeOps }),
-      guard,
+    withPlanGate(
+      withClampedPath(
+        createWriteToolDefinition(workspaceDir, { operations: writeOps }),
+        guard,
+      ),
     ),
   ];
 }

--- a/packages/runtime/src/session/tools/custom-integrations.ts
+++ b/packages/runtime/src/session/tools/custom-integrations.ts
@@ -1,5 +1,6 @@
 import { defineTool } from "@earendil-works/pi-coding-agent";
 import { type Static, Type } from "typebox";
+import { assertNotPlanMode } from "../live-mode-gate";
 import {
   makeRequestCredentialTool,
   REQUEST_CREDENTIAL_TOOL_NAME,
@@ -160,6 +161,9 @@ export function makeCustomIntegrationTools(opts: CustomIntegrationToolOptions) {
       params: AddParams,
       signal: AbortSignal | undefined,
     ) {
+      // Live gate for the mid-turn Mode-pill switch: adding an integration
+      // changes the user's setup — off-limits once they switched to Plan.
+      assertNotPlanMode("add or change the user's integrations");
       const r = await post<AddResponse>(
         "add",
         {

--- a/packages/runtime/src/session/tools/integrations.test.ts
+++ b/packages/runtime/src/session/tools/integrations.test.ts
@@ -469,18 +469,45 @@ test("a malformed approval payload falls through to the generic error throw", as
 test("the turn-mode header is sent iff the turn is Autopilot", async () => {
   // Inside an "auto" turn, the host is told to run the action un-gated.
   const auto = mockFetch(() => ({ body: { successful: true } }));
-  await runWithTurnMode("auto", () => run(execute, { action: "X" }));
+  await runWithTurnMode({ current: "auto" }, () =>
+    run(execute, { action: "X" }),
+  );
   expect(auto[0]?.headers["x-houston-turn-mode"]).toBe("auto");
 
   // A normal "execute" turn omits the header (the host gates un-approved actions).
   const exec = mockFetch(() => ({ body: { successful: true } }));
-  await runWithTurnMode("execute", () => run(execute, { action: "X" }));
+  await runWithTurnMode({ current: "execute" }, () =>
+    run(execute, { action: "X" }),
+  );
   expect(exec[0]?.headers["x-houston-turn-mode"]).toBeUndefined();
 
   // Outside any turn the header is absent too.
   const bare = mockFetch(() => ({ body: { successful: true } }));
   await run(execute, { action: "X" });
   expect(bare[0]?.headers["x-houston-turn-mode"]).toBeUndefined();
+});
+
+test("live mode gates: a turn switched to Plan refuses execute; Autopilot refuses request_connection", async () => {
+  // The user flipped the Mode pill to Plan while the turn ran: acting on the
+  // user's apps refuses BEFORE any network call, with the planning instruction.
+  const calls = mockFetch(() => ({ body: { successful: true } }));
+  await expect(
+    runWithTurnMode({ current: "plan" }, () => run(execute, { action: "X" })),
+  ).rejects.toThrow(/Plan mode/);
+  expect(calls).toHaveLength(0);
+
+  // A flip to Autopilot mid-turn: waiting on the user to connect an app refuses.
+  await expect(
+    runWithTurnMode({ current: "auto" }, () =>
+      run(requestConnection, { toolkit: "gmail" }),
+    ),
+  ).rejects.toThrow(/Autopilot mode/);
+  // And Plan refuses the connect hand-off too (setup while planning).
+  await expect(
+    runWithTurnMode({ current: "plan" }, () =>
+      run(requestConnection, { toolkit: "gmail" }),
+    ),
+  ).rejects.toThrow(/Plan mode/);
 });
 
 test("C2: attaches the turn's acting-as header inside a turn, and nothing outside one", async () => {

--- a/packages/runtime/src/session/tools/integrations.ts
+++ b/packages/runtime/src/session/tools/integrations.ts
@@ -2,6 +2,7 @@ import { defineTool } from "@earendil-works/pi-coding-agent";
 import { type Static, Type } from "typebox";
 import { currentActingContext } from "../acting-context";
 import { recordApproval, recordConnection, recordSignin } from "../interaction";
+import { assertNotAutoMode, assertNotPlanMode } from "../live-mode-gate";
 import { currentTurnMode } from "../turn-mode-context";
 
 /**
@@ -412,6 +413,11 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
       params: ExecuteParams,
       signal: AbortSignal | undefined,
     ) {
+      // Live gate for the mid-turn Mode-pill switch: an execute/auto-built turn
+      // may now be running in Plan — acting on the user's apps is off-limits.
+      // The `x-houston-turn-mode: auto` header in post() reads the SAME live
+      // mode, so a mid-turn flip to/from Autopilot re-gates approvals at once.
+      assertNotPlanMode("take real-world actions on the user's connected apps");
       let result: ActionResult;
       try {
         result = await post<ActionResult>(
@@ -489,6 +495,11 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
     parameters: ConnectParams,
     executionMode: "sequential",
     async execute(_id: string, params: ConnectParams) {
+      // Live gates for the mid-turn Mode-pill switch: connecting an app both
+      // waits on the user (never in Autopilot) and sets up a real-world
+      // capability (not while planning).
+      assertNotAutoMode("wait for the user to connect an app");
+      assertNotPlanMode("ask the user to connect an app");
       const toolkit = normalizeToolkitSlug(params.toolkit);
       if (!toolkit)
         throw new Error("request_connection needs a non-empty toolkit slug.");

--- a/packages/runtime/src/session/tools/run-code.ts
+++ b/packages/runtime/src/session/tools/run-code.ts
@@ -11,6 +11,7 @@ import {
 } from "node:path";
 import { defineTool } from "@earendil-works/pi-coding-agent";
 import { type Static, Type } from "typebox";
+import { assertNotPlanMode } from "../live-mode-gate";
 import { RunCodeLimiter, type RunCodeLimits } from "./run-code-limiter";
 
 /**
@@ -116,6 +117,9 @@ export function makeRunCodeTool(opts: RunCodeOptions) {
       params: RunCodeParams,
       signal: AbortSignal | undefined,
     ) {
+      // Live gate for the mid-turn Mode-pill switch: an execute/auto-built turn
+      // may now be running in Plan — no code runs, no files get produced.
+      assertNotPlanMode("run code or produce files");
       // 1. Gather requested input files (missing/escaping paths throw → surfaced
       //    as a tool error, never silently skipped). Declared inputs may be
       //    overwritten by artifacts of the same path (see step 3).

--- a/packages/runtime/src/session/turn-mode-context.test.ts
+++ b/packages/runtime/src/session/turn-mode-context.test.ts
@@ -1,31 +1,40 @@
+import type { TurnMode } from "@houston/protocol";
 import { expect, test } from "vitest";
 import { currentTurnMode, runWithTurnMode } from "./turn-mode-context";
 
 /**
- * The per-turn mode ambient: an AsyncLocalStorage the integration tools read to
- * decide whether to forward `x-houston-turn-mode: auto`. These pin: the mode is
- * present inside the capture, undefined outside a turn, and two nested captures
- * stay isolated (the inner value never leaks back out).
+ * The per-turn mode ambient: an AsyncLocalStorage holding a MUTABLE ref the
+ * tools read at decision time (the integration `auto` header, the live mode
+ * gates). These pin: the mode is present inside the capture, undefined outside
+ * a turn, nested captures stay isolated, ALS survives async work, and a
+ * mid-capture mutation of the ref is immediately visible (the mid-turn
+ * Mode-pill switch).
  */
 
 test("the mode is present inside runWithTurnMode and undefined outside", () => {
   expect(currentTurnMode()).toBeUndefined();
-  const seen = runWithTurnMode("auto", () => currentTurnMode());
+  const seen = runWithTurnMode({ current: "auto" }, () => currentTurnMode());
   expect(seen).toBe("auto");
   // The store is unwound once the callback returns.
   expect(currentTurnMode()).toBeUndefined();
 });
 
 test("each mode value flows through independently", () => {
-  expect(runWithTurnMode("execute", () => currentTurnMode())).toBe("execute");
-  expect(runWithTurnMode("plan", () => currentTurnMode())).toBe("plan");
-  expect(runWithTurnMode("auto", () => currentTurnMode())).toBe("auto");
+  expect(runWithTurnMode({ current: "execute" }, () => currentTurnMode())).toBe(
+    "execute",
+  );
+  expect(runWithTurnMode({ current: "plan" }, () => currentTurnMode())).toBe(
+    "plan",
+  );
+  expect(runWithTurnMode({ current: "auto" }, () => currentTurnMode())).toBe(
+    "auto",
+  );
 });
 
 test("nested captures stay isolated — the inner value never leaks out", () => {
-  runWithTurnMode("execute", () => {
+  runWithTurnMode({ current: "execute" }, () => {
     expect(currentTurnMode()).toBe("execute");
-    runWithTurnMode("auto", () => {
+    runWithTurnMode({ current: "auto" }, () => {
       expect(currentTurnMode()).toBe("auto");
     });
     // Back in the outer capture, the outer mode is restored.
@@ -34,9 +43,19 @@ test("nested captures stay isolated — the inner value never leaks out", () => 
 });
 
 test("the mode survives async work inside the capture (ALS propagation)", async () => {
-  const seen = await runWithTurnMode("auto", async () => {
+  const seen = await runWithTurnMode({ current: "auto" }, async () => {
     await Promise.resolve();
     return currentTurnMode();
   });
   expect(seen).toBe("auto");
+});
+
+test("a mid-capture ref mutation is visible at once (live Mode-pill switch)", async () => {
+  const ref: { current: TurnMode } = { current: "execute" };
+  await runWithTurnMode(ref, async () => {
+    expect(currentTurnMode()).toBe("execute");
+    ref.current = "plan";
+    await Promise.resolve();
+    expect(currentTurnMode()).toBe("plan");
+  });
 });

--- a/packages/runtime/src/session/turn-mode-context.ts
+++ b/packages/runtime/src/session/turn-mode-context.ts
@@ -3,30 +3,43 @@ import type { TurnMode } from "@houston/protocol";
 
 /**
  * The execution mode THIS turn is running in ("execute" / "plan" / "auto"),
- * captured from the per-turn pin and made available to the integration tools
- * while the turn runs. The one consumer today: the integration `execute` proxy,
- * which forwards `x-houston-turn-mode: auto` on `/sandbox/integrations/execute`
- * ONLY on an Autopilot turn, so the host's action-approval gate lets an auto
- * turn act un-gated while a normal turn is gated.
+ * captured from the per-turn pin and made available to the tools while the turn
+ * runs. Consumers: the integration `execute` proxy (forwards
+ * `x-houston-turn-mode: auto` so the host's action-approval gate lets an auto
+ * turn act un-gated) and the live mode gates in the mutating/blocking tools
+ * (clamped-fs write/edit, run_code, ask_user, …).
+ *
+ * The store holds a MUTABLE ref, not a value: the user can switch the Mode
+ * pill WHILE the agent works (`POST /conversations/:id/mode`), and the running
+ * turn adopts the new mode at its next tool decision — Claude Code's
+ * shift+tab semantics. exec-turn.ts creates one ref per turn, parks it on the
+ * Conversation record so the route can reach it, and establishes it here for
+ * the DURATION of `session.prompt()`.
  *
  * Turn-scoping mechanism + assumption: an `AsyncLocalStorage` whose store is
- * established for the DURATION of `session.prompt()` (see exec-turn.ts). The
- * tool `execute` callbacks run inside that same async context, so they read the
- * correct value with NO process-global mutation — this stays race-free even
+ * established for the duration of the prompt (see exec-turn.ts). The tool
+ * `execute` callbacks run inside that same async context, so they read the
+ * correct ref with NO process-global mutation — this stays race-free even
  * when two conversations run concurrently in one runtime (a plain module-level
  * "current mode" would leak across them). Outside a turn (e.g. unit tests
- * calling a tool directly) the store is undefined, so no header is attached and
+ * calling a tool directly) the store is undefined, so no gate fires and
  * behavior is unchanged.
  */
 
-const store = new AsyncLocalStorage<TurnMode>();
-
-/** Run `fn` with `mode` as the ambient turn mode for its whole async subtree. */
-export function runWithTurnMode<T>(mode: TurnMode, fn: () => T): T {
-  return store.run(mode, fn);
+/** One turn's live mode. `current` is mutated by a mid-turn Mode-pill switch. */
+export interface TurnModeRef {
+  current: TurnMode;
 }
 
-/** The current turn's execution mode, or undefined outside a turn. */
+const store = new AsyncLocalStorage<TurnModeRef>();
+
+/** Run `fn` with `ref` as the ambient turn-mode ref for its whole async subtree. */
+export function runWithTurnMode<T>(ref: TurnModeRef, fn: () => T): T {
+  return store.run(ref, fn);
+}
+
+/** The current turn's LIVE execution mode, or undefined outside a turn. Reads
+ *  the ref at call time, so a mid-turn switch is visible immediately. */
 export function currentTurnMode(): TurnMode | undefined {
-  return store.getStore();
+  return store.getStore()?.current;
 }

--- a/packages/runtime/src/transport/conversation-routes.ts
+++ b/packages/runtime/src/transport/conversation-routes.ts
@@ -6,6 +6,7 @@ import {
   disposeConversation,
   ensureProviderForTurn,
   runTurn,
+  setLiveTurnMode,
 } from "../session/chat";
 import { summarizeTitle, titleFromText } from "../session/summarize";
 import {
@@ -39,7 +40,7 @@ export async function handleConversationRoute(
   }
 
   const convMatch = path.match(
-    /^\/conversations\/([^/]+)\/(messages|events|cancel|dismiss-interaction|title)$/,
+    /^\/conversations\/([^/]+)\/(messages|events|cancel|dismiss-interaction|title|mode)$/,
   );
   if (!convMatch) return false;
 
@@ -74,6 +75,18 @@ export async function handleConversationRoute(
     }
     markConversationStopped(id);
     json(res, 200, { ok: true });
+    return true;
+  }
+  if (method === "POST" && action === "mode") {
+    // The Mode pill switched WHILE the agent works: apply it to the executing
+    // turn's live-mode ref (Claude Code's shift+tab). `applied: false` is
+    // benign — no turn is running, and the next send pins the mode itself.
+    // Never trust the wire: unknown values normalize to "execute".
+    const { mode } = await readJson(ctx.req);
+    json(res, 200, {
+      ok: true,
+      applied: setLiveTurnMode(id, normalizeTurnMode(mode)),
+    });
     return true;
   }
   if (method === "POST" && action === "title") {

--- a/packages/web/e2e/chat.spec.ts
+++ b/packages/web/e2e/chat.spec.ts
@@ -229,7 +229,10 @@ test("sends a follow-up inside an existing mission", async ({ page }) => {
   });
 });
 
-test("navigates a long conversation with the conversation map", async ({
+// Skipped while the conversation map is deliberately hidden (see
+// ui/chat/src/conversation-map-panel.tsx CONVERSATION_MAP_VISIBLE) — the
+// feature stays wired; un-skip when the panel is re-shown.
+test.skip("navigates a long conversation with the conversation map", async ({
   page,
 }) => {
   await page.goto("/");

--- a/packages/web/src/engine-adapter/client/chat-send-mixin.ts
+++ b/packages/web/src/engine-adapter/client/chat-send-mixin.ts
@@ -98,6 +98,23 @@ export function ChatSendMixin<TBase extends BaseCtor>(Base: TBase) {
       return { cancelled: cancelled === true };
     }
 
+    /**
+     * Apply a Mode-pill switch to a conversation's EXECUTING turn (Claude
+     * Code's shift+tab): the runtime mutates the running turn's live-mode ref
+     * so its tools adopt the new mode at their next decision. `applied: false`
+     * is benign — no turn was running, and the next send pins the mode itself.
+     */
+    async setLiveTurnMode(
+      agentPath: string,
+      conversationId: string,
+      mode: "execute" | "plan" | "auto",
+    ): Promise<{ ok: boolean; applied: boolean }> {
+      const engine = this.ctx.cp
+        ? controlPlane.runtimeClientFor(this.ctx.cp, agentPath)
+        : this.ctx.engine;
+      return engine.setMode(conversationId, mode);
+    }
+
     async dismissInteraction(
       agentPath: string,
       conversationId: string,

--- a/ui/chat/src/conversation-map-panel.tsx
+++ b/ui/chat/src/conversation-map-panel.tsx
@@ -13,6 +13,15 @@ interface ConversationMapPanelProps {
   onSelectMoment: (moment: ConversationMoment) => void;
 }
 
+/**
+ * DELIBERATELY HIDDEN (2026-07-17, product call): the conversation map must
+ * not be visible in the chat yet — neither the "View map" trigger nor the
+ * panel. Everything behind it (moment derivation, the IntersectionObserver
+ * tracking, analytics wiring, this panel) is kept intact and compiled so
+ * re-showing it is exactly deleting the early `return null` below.
+ */
+const CONVERSATION_MAP_VISIBLE = false;
+
 export function ConversationMapPanel({
   activeMessageKey,
   labels,
@@ -22,6 +31,7 @@ export function ConversationMapPanel({
   onOpenChange,
   onSelectMoment,
 }: ConversationMapPanelProps) {
+  if (!CONVERSATION_MAP_VISIBLE) return null;
   if (moments.length < 3) return null;
 
   return (

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -1689,6 +1689,24 @@ export class HoustonClient {
       `/agents/${this.seg(agentSlugOrId)}/conversations/${this.seg(conversationId)}/dismiss-interaction`,
     );
   }
+  /**
+   * Apply a Mode-pill switch to a conversation's EXECUTING turn (Claude Code's
+   * shift+tab semantics): the running turn adopts the new mode at its next tool
+   * decision. `applied: false` is benign — no turn was running, and the next
+   * send pins the mode itself. A runtime passthrough via the host's channel
+   * dispatch, like `dismissInteraction`.
+   */
+  setLiveTurnMode(
+    agentSlugOrId: string,
+    conversationId: string,
+    mode: "execute" | "plan" | "auto",
+  ): Promise<{ ok: boolean; applied: boolean }> {
+    return this.request(
+      "POST",
+      `/agents/${this.seg(agentSlugOrId)}/conversations/${this.seg(conversationId)}/mode`,
+      { mode },
+    );
+  }
 
   // ---------- store ----------
 


### PR DESCRIPTION
## What

The AI Mode pill now applies **while the agent is working**, not just on the next message — matching Claude Code's shift+tab behavior. Switch to Planner / Coworker / Autopilot mid-turn and the running turn adopts it at its next tool decision.

## How

- The runtime holds each executing turn's mode in a **mutable ref** (`TurnModeRef` in AsyncLocalStorage), parked on the `Conversation` for the turn's duration. A new `POST /conversations/:id/mode` mutates it.
- Every restricted tool checks the **live** mode when it runs:
  - **Plan:** `edit`/`write` (clamped-fs), `run_code`, `integration_execute`, `request_connection`, and `custom_integration_add` refuse with a switch-to-planning instruction; the Claude backend denies `Edit`/`Write`/`Bash` in `canUseTool` the same way.
  - **Autopilot:** `ask_user` and `request_connection` refuse with a keep-going instruction; the integration proxy's `x-houston-turn-mode` header reads the same live ref, so approval gating re-evaluates immediately.
- Client stack: `runtime-client.setMode`, host passthrough (channel dispatch), engine-client + web adapter `setLiveTurnMode`, `tauriChat` wrapper, and the composer pill fires it when a turn is streaming.

## Cleanup

The old deferred-mode implementation is gone: the "applies to your next message" toast, `modeChangeAppliesNextTurn`, and its tests/i18n keys are replaced by an error-only toast for when the live apply fails.

## Also

The conversation map is deliberately **hidden** for now (trigger + panel; all wiring kept) via `CONVERSATION_MAP_VISIBLE` in `ui/chat/src/conversation-map-panel.tsx`; its e2e spec is skipped with a pointer.

## Known limits (same trade-off Claude Code makes)

- Only the **restrictive** direction is enforceable mid-turn (execute/auto → plan blocks acting; execute → auto blocks waiting). The permissive direction (plan → execute) can't conjure tools into a running session; it takes full effect on the next turn's rebuild.
- pi's built-in `bash` runs outside the custom-tool wrappers, so a mid-turn flip to plan can't stop an in-flight bash-capable session until the turn ends; the next turn's rebuilt session drops bash entirely.

## Testing

- Runtime vitest: live-switch tests (`live-mode.test.ts`), tool gates flip mid-turn (`integrations.test.ts`), mutable-ref ambient (`turn-mode-context.test.ts`), existing mode-switch tests still pass.
- Biome clean; typecheck green (runtime / app / web / ui, Tauri shim-parity OK); `check-locales` OK; `app/tests/turn-mode` pass.
