### PR TITLE
fix(providers): report unknown, not signed-out, when the engine is unreachable

### DIFF
--- a/app/src/components/provider-browser/auto-select.ts
+++ b/app/src/components/provider-browser/auto-select.ts
@@ -12,7 +12,7 @@
 
 import type { ProviderInfo } from "../../lib/providers.ts";
 import type { ProviderStatus } from "../../lib/tauri.ts";
-import { providerAppearsConnected } from "../shell/provider-reconnect-state.ts";
+import { providerIsAuthenticated } from "../shell/provider-reconnect-state.ts";
 
 /** A per-card status snapshot: card id -> merged status (or undefined). */
 export type StatusSnapshot = Record<string, ProviderStatus | undefined>;
@@ -24,7 +24,9 @@ export interface AutoSelection {
 }
 
 function isConnected(status: ProviderStatus | undefined): boolean {
-  return status ? providerAppearsConnected(status) : false;
+  // Confirmed-only: an "unknown" probe (engine unreachable / still waking)
+  // must never auto-advance onboarding as if the provider just connected.
+  return status ? providerIsAuthenticated(status) : false;
 }
 
 /**

--- a/app/src/hooks/provider-connections/unreachable-scan.ts
+++ b/app/src/hooks/provider-connections/unreachable-scan.ts
@@ -1,0 +1,19 @@
+import type { ProviderStatus } from "../../lib/tauri";
+
+/**
+ * Whether a `checkAllStatuses` scan carries no information because the engine
+ * was unreachable (the adapter reports every gateway as `auth_state:
+ * "unknown"` — a cold pod still waking after a relaunch/update, a network
+ * drop). Such a scan must not overwrite the painted last-known snapshot or
+ * the persisted status cache, and must not drive connect-transition
+ * analytics.
+ */
+export function scanIsUnreachable(
+  gatewayIds: readonly string[],
+  byId: Record<string, ProviderStatus>,
+): boolean {
+  return (
+    gatewayIds.length > 0 &&
+    gatewayIds.every((id) => byId[id]?.auth_state === "unknown")
+  );
+}

--- a/app/src/hooks/provider-connections/use-provider-statuses.ts
+++ b/app/src/hooks/provider-connections/use-provider-statuses.ts
@@ -11,6 +11,7 @@ import {
   type ProviderStatus,
   tauriProvider,
 } from "../../lib/tauri";
+import { scanIsUnreachable } from "./unreachable-scan";
 
 export interface ProviderStatusState {
   statuses: Record<string, ProviderStatus>;
@@ -72,6 +73,15 @@ export function useProviderStatuses(
       ...new Set(visibleProviders.flatMap((p) => providerGatewayIds(p))),
     ];
     const byId = await tauriProvider.checkAllStatuses(gatewayIds);
+    if (scanIsUnreachable(gatewayIds, byId)) {
+      // The engine was unreachable — the scan carries no information. Keep
+      // painting the last-known snapshot (never overwrite it, or the persisted
+      // cache, with "unknown"s) and skip transition analytics. `probed` still
+      // flips so mount-time decisions proceed on the cached confirmed state.
+      setLoading(false);
+      setProbed(true);
+      return;
+    }
     const next: Record<string, ProviderStatus> = {};
     for (const p of visibleProviders) {
       const merged = mergeGatewayStatus(providerGatewayIds(p), byId);

--- a/app/src/hooks/use-local-bridge-autoreconnect.ts
+++ b/app/src/hooks/use-local-bridge-autoreconnect.ts
@@ -52,12 +52,18 @@ export function useLocalBridgeAutoReconnect(enabled: boolean): void {
       if (status?.status === "online" || status?.status === "connecting")
         return;
 
-      // Only reconnect if the agent still points at our local-model endpoint;
-      // otherwise the tunnel is stale and reconnecting it would be surprising.
+      // Skip the reconnect only when the engine CONFIRMS the endpoint is gone
+      // (disconnected from another machine/web — the tunnel would be stale).
+      // An unreachable or still-waking engine reports "unknown" (or the probe
+      // fails): reconnect anyway. The saved descriptor only exists while the
+      // endpoint is registered (explicit disconnect deletes it), and the cold
+      // boot right after an app update is exactly when the pod is asleep — a
+      // fabricated "not connected" here silently killed the tunnel for good
+      // (this hook runs once per session).
       const provider = await tauriProvider
         .checkStatus(LOCAL_PROVIDER_ID)
         .catch(() => null);
-      if (!provider || !providerAppearsConnected(provider)) return;
+      if (provider && !providerAppearsConnected(provider)) return;
 
       await reconnectLocalModel().catch(() => {
         // reconnectLocalModel already toasted the real reason (Report-bug).

--- a/app/src/hooks/use-provider-connections.ts
+++ b/app/src/hooks/use-provider-connections.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { providerAppearsConnected } from "../components/shell/provider-reconnect-state";
+import {
+  providerAppearsConnected,
+  providerIsAuthenticated,
+} from "../components/shell/provider-reconnect-state";
 import { useCopilotConnect } from "../components/shell/use-copilot-connect";
 import { newEngineActive } from "../lib/engine";
 import { osIsTauri } from "../lib/os-bridge";
@@ -95,7 +98,9 @@ export function useProviderConnections(): ProviderConnections {
   useEffect(() => {
     if (!pending) return;
     const status = statuses[pending.id];
-    if (status && providerAppearsConnected(status)) {
+    // Confirmed-only: an "unknown" probe (engine unreachable mid-poll) must
+    // not clear a pending connect as if it had completed.
+    if (status && providerIsAuthenticated(status)) {
       setPending(null);
     }
   }, [pending, statuses]);

--- a/app/tests/provider-auto-select.test.ts
+++ b/app/tests/provider-auto-select.test.ts
@@ -128,4 +128,46 @@ describe("resolveAutoSelect", () => {
       null,
     );
   });
+
+  // "unknown" = the engine was unreachable (cold pod waking after a
+  // relaunch/update). Auto-select needs a CONFIRMED authenticated state: an
+  // unknown probe must never advance onboarding as if the provider connected.
+  function unknown(id: string): ProviderStatus {
+    return {
+      provider: id,
+      cli_installed: true,
+      auth_state: "unknown",
+      authenticated: false,
+      cli_name: "",
+    };
+  }
+
+  it("does not fire for an unknown status on first load, even with selectOnMount", () => {
+    const anthropic = provider("anthropic", "claude-sonnet-4-6");
+    const next: StatusSnapshot = { anthropic: unknown("anthropic") };
+    strictEqual(
+      resolveAutoSelect(null, next, [anthropic], { selectOnMount: true }),
+      null,
+    );
+  });
+
+  it("does not fire on an unauthenticated -> unknown transition", () => {
+    const anthropic = provider("anthropic", "claude-sonnet-4-6");
+    const prev: StatusSnapshot = { anthropic: disconnected("anthropic") };
+    const next: StatusSnapshot = { anthropic: unknown("anthropic") };
+    strictEqual(
+      resolveAutoSelect(prev, next, [anthropic], { selectOnMount: false }),
+      null,
+    );
+  });
+
+  it("fires on an unknown -> authenticated transition (engine woke up connected)", () => {
+    const anthropic = provider("anthropic", "claude-sonnet-4-6");
+    const prev: StatusSnapshot = { anthropic: unknown("anthropic") };
+    const next: StatusSnapshot = { anthropic: connected("anthropic") };
+    deepStrictEqual(
+      resolveAutoSelect(prev, next, [anthropic], { selectOnMount: false }),
+      { providerId: "anthropic", model: "claude-sonnet-4-6" },
+    );
+  });
 });

--- a/app/tests/unreachable-scan.test.ts
+++ b/app/tests/unreachable-scan.test.ts
@@ -1,0 +1,61 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { scanIsUnreachable } from "../src/hooks/provider-connections/unreachable-scan.ts";
+import type { ProviderStatus } from "../src/lib/tauri.ts";
+
+function status(
+  id: string,
+  auth_state: ProviderStatus["auth_state"],
+): ProviderStatus {
+  return {
+    provider: id,
+    cli_installed: true,
+    auth_state,
+    authenticated: auth_state === "authenticated",
+    cli_name: "",
+  };
+}
+
+describe("scanIsUnreachable", () => {
+  it("flags a scan where every gateway reports unknown (engine unreachable)", () => {
+    strictEqual(
+      scanIsUnreachable(["anthropic", "opencode"], {
+        anthropic: status("anthropic", "unknown"),
+        opencode: status("opencode", "unknown"),
+      }),
+      true,
+    );
+  });
+
+  it("does not flag a scan with any confirmed answer", () => {
+    strictEqual(
+      scanIsUnreachable(["anthropic", "opencode"], {
+        anthropic: status("anthropic", "unknown"),
+        opencode: status("opencode", "unauthenticated"),
+      }),
+      false,
+    );
+  });
+
+  it("does not flag an all-confirmed scan", () => {
+    strictEqual(
+      scanIsUnreachable(["anthropic"], {
+        anthropic: status("anthropic", "authenticated"),
+      }),
+      false,
+    );
+  });
+
+  it("does not flag an empty scan (no gateways requested)", () => {
+    strictEqual(scanIsUnreachable([], {}), false);
+  });
+
+  it("does not flag when a gateway is simply missing from the result", () => {
+    strictEqual(
+      scanIsUnreachable(["anthropic", "opencode"], {
+        anthropic: status("anthropic", "unknown"),
+      }),
+      false,
+    );
+  });
+});

--- a/packages/web/src/engine-adapter/client/provider-status-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-status-mixin.ts
@@ -31,13 +31,20 @@ export function ProviderStatusMixin<TBase extends BaseCtor>(Base: TBase) {
         string,
         { configured?: boolean; activeModel?: string }
       >();
+      // "unauthenticated" is only ever a CONFIRMED answer from the engine. An
+      // unreachable engine (cold pod still waking after a relaunch/update, a
+      // network drop) reports "unknown" instead: fabricating "unauthenticated"
+      // flips every provider card to Connect and blocks the local-model tunnel
+      // auto-reconnect, for connections that are still registered server-side.
+      let reachable = false;
       try {
         const engine = this.ctx.providerEngine();
         if (engine) {
           for (const p of await engine.listProviders()) byId.set(p.id, p);
+          reachable = true;
         }
       } catch {
-        /* sandbox unreachable / no agent selected → all report not-connected */
+        /* engine unreachable → every card reports "unknown" below */
       }
       return names.map((name) => {
         const pid = toNewProvider(name);
@@ -45,7 +52,11 @@ export function ProviderStatusMixin<TBase extends BaseCtor>(Base: TBase) {
         return {
           provider: name,
           cliInstalled: true,
-          authState: p?.configured ? "authenticated" : "unauthenticated",
+          authState: reachable
+            ? p?.configured
+              ? "authenticated"
+              : "unauthenticated"
+            : "unknown",
           cliName: name,
           installSource: "managed",
           cliPath: null,

--- a/packages/web/tests/provider-statuses-batch.test.ts
+++ b/packages/web/tests/provider-statuses-batch.test.ts
@@ -91,13 +91,25 @@ test("providerStatus delegates to the batch (one fetch, correct entry)", async (
   expect(status.provider).toBe("anthropic");
 });
 
-test("an unreachable runtime reports every card not-connected without throwing", async () => {
+test("an unreachable runtime reports every card UNKNOWN without throwing", async () => {
+  // Never a fabricated "unauthenticated": a cold pod waking after an app
+  // relaunch/update must not flip connected providers to "Connect" or block
+  // the local-model tunnel auto-reconnect (which skips only on a CONFIRMED
+  // signed-out state).
   listProviders.mockRejectedValue(new Error("sandbox unreachable"));
 
   const statuses = await client().providerStatuses(["anthropic", "opencode"]);
 
+  expect(statuses.map((s) => s.authState)).toEqual(["unknown", "unknown"]);
+});
+
+test("a reachable runtime still gives a confirmed unauthenticated for absent providers", async () => {
+  listProviders.mockResolvedValue([{ id: "anthropic", configured: true }]);
+
+  const statuses = await client().providerStatuses(["anthropic", "opencode"]);
+
   expect(statuses.map((s) => s.authState)).toEqual([
-    "unauthenticated",
+    "authenticated",
     "unauthenticated",
   ]);
 });


### PR DESCRIPTION
## Problem

Reopening the app after it had been closed for a while (e.g. a manual update install) finds the agent's cloud pod still asleep. During that wake-up window the provider status adapter fabricated `unauthenticated` for every provider, which caused two user-visible failures:

1. Every provider card painted as disconnected, even though all credentials (OAuth, API keys, the local-model endpoint) were intact server-side.
2. The local-model tunnel auto-reconnect, which runs once per session at boot, read the fabricated state as "the endpoint was removed" and silently bailed, so the tunnel to the user's machine never came back. The user had to reconnect the local LLM by hand after every update.

## Fix

- **Adapter** (`provider-status-mixin.ts`): an unreachable engine now reports `authState: "unknown"`; `unauthenticated` is only ever a confirmed answer from the engine. The UI already treats `unknown` as still-connected (the #76 rule); the adapter just never emitted it.
- **Tunnel auto-reconnect** (`use-local-bridge-autoreconnect.ts`): skip only on a CONFIRMED signed-out endpoint. An unknown or failed probe reconnects anyway: the saved bridge descriptor is deleted on explicit disconnect, so its presence means the endpoint is still registered.
- **Confirmed-only where `unknown` must not count as connected**: onboarding auto-select (`auto-select.ts`) and the pending-connect spinner clear (`use-provider-connections.ts`) now require `authenticated`.
- **Cache protection** (`use-provider-statuses.ts` + new `unreachable-scan.ts`): a scan taken while the engine is unreachable carries no information, so it no longer overwrites the painted last-known snapshot or the persisted status cache, and fires no `provider_configured` transition analytics.

## Tests

- Flipped the batch-status contract test that pinned the fabrication (`provider-statuses-batch.test.ts`): unreachable now expects `unknown`, plus a case pinning that a reachable engine still answers a confirmed `unauthenticated`.
- New `unknown` transition cases for onboarding auto-select (no advance on unknown, advance on unknown -> authenticated).
- New `unreachable-scan.test.ts` for the scan guard.
- All suites green: app tsgo + 1660 node tests, web typecheck (shim parity) + 191 vitest tests, Biome clean, onboarding-connect Playwright spec.

## Verification recipe

Connect a local model through the relay, quit the app long enough for the pod to sleep (or reinstall the app over itself), reopen: the tunnel pill goes connecting -> online on its own and no provider card flashes disconnected while the pod wakes.