### PR TITLE
feat(usage): switch the compute/models panes with a button toggle

### DIFF
--- a/app/src/components/usage-view/usage-view.tsx
+++ b/app/src/components/usage-view/usage-view.tsx
@@ -1,4 +1,4 @@
-import { Tabs, TabsList, TabsTrigger } from "@houston-ai/core";
+import { Button, ButtonGroup } from "@houston-ai/core";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCapabilities } from "../../hooks/use-capabilities";
@@ -63,18 +63,25 @@ export function UsageView() {
           subtitle={t("usage.pageSubtitle")}
         />
         {/* The compute/models split only exists where the gateway meters
-            compute; elsewhere the account sections stand alone, untoggled. */}
+            compute; elsewhere the account sections stand alone, untoggled. A
+            segmented button toggle switches between the two panes. */}
         {showCompute && (
-          <Tabs value={pane} onValueChange={(v) => setPane(v as UsagePaneKey)}>
-            <TabsList className="grid w-full grid-cols-2 sm:w-auto sm:min-w-80 sm:self-start">
-              <TabsTrigger value="compute">
-                {t("usage.panes.compute")}
-              </TabsTrigger>
-              <TabsTrigger value="models">
-                {t("usage.panes.models")}
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
+          <ButtonGroup className="self-start">
+            <Button
+              variant={pane === "compute" ? "default" : "outline"}
+              aria-pressed={pane === "compute"}
+              onClick={() => setPane("compute")}
+            >
+              {t("usage.panes.compute")}
+            </Button>
+            <Button
+              variant={pane === "models" ? "default" : "outline"}
+              aria-pressed={pane === "models"}
+              onClick={() => setPane("models")}
+            >
+              {t("usage.panes.models")}
+            </Button>
+          </ButtonGroup>
         )}
         {showCompute && pane === "compute" ? (
           <ComputeSection />

--- a/packages/web/e2e/usage-compute.spec.ts
+++ b/packages/web/e2e/usage-compute.spec.ts
@@ -62,7 +62,9 @@ test("without the computeUsage capability the Usage page shows only the account 
   await expect(page.getByRole("heading", { name: "Time worked" })).toHaveCount(
     0,
   );
-  await expect(page.getByRole("tab", { name: "Compute usage" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Compute usage" })).toHaveCount(
+    0,
+  );
   await expect(
     page.getByRole("heading", { name: "AI subscriptions" }),
   ).toBeVisible();
@@ -145,14 +147,14 @@ test("with data the section shows the total, daily bars, and per-agent rows", as
   await expect(
     page.getByRole("heading", { name: "AI subscriptions" }),
   ).toHaveCount(0);
-  await page.getByRole("tab", { name: "Model usage" }).click();
+  await page.getByRole("button", { name: "Model usage" }).click();
   await expect(
     page.getByRole("heading", { name: "AI subscriptions" }),
   ).toBeVisible();
   await expect(page.getByRole("heading", { name: "Time worked" })).toHaveCount(
     0,
   );
-  await page.getByRole("tab", { name: "Compute usage" }).click();
+  await page.getByRole("button", { name: "Compute usage" }).click();
   await expect(
     page.getByRole("heading", { name: "Time worked" }),
   ).toBeVisible();


### PR DESCRIPTION
## What

Replaces the `Tabs` control at the top of the Usage page with a segmented `ButtonGroup` toggle (**Compute usage** / **Model usage**).

## Details

- Same pane state (`pane` / `setPane`) and same gating (`showCompute`) as before — only the visual control changed from tabs to a button toggle.
- The active pane's button uses `variant=default`; the inactive one `variant=outline`, with `aria-pressed` for accessibility.
- Reuses the existing `usage.panes.compute` / `usage.panes.models` translation keys — no en/es/pt changes needed.

## Notes

The toggle only renders where `capabilities.computeUsage === true` (hosted cloud / gateway). On desktop/self-host the Usage page shows the account sections directly, with no selector — unchanged behavior. Covered by the existing `packages/web/e2e/usage-compute.spec.ts` gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)