### PR TITLE
fix(skills): require a description before creating a skill from scratch

### DIFF
--- a/app/src/components/tabs/use-skill-surface-labels.ts
+++ b/app/src/components/tabs/use-skill-surface-labels.ts
@@ -68,6 +68,7 @@ export function useSkillDialogLabels() {
       submit: t("addDialog.scratch.submit"),
       submitting: t("addDialog.scratch.submitting"),
       errorTitleRequired: t("addDialog.scratch.errorTitleRequired"),
+      errorDescriptionRequired: t("addDialog.scratch.errorDescriptionRequired"),
       errorBodyRequired: t("addDialog.scratch.errorBodyRequired"),
       errorSlugTaken: t("addDialog.scratch.errorSlugTaken"),
     },

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -40,6 +40,7 @@
       "submit": "Create skill",
       "submitting": "Creating...",
       "errorTitleRequired": "Give your skill a title.",
+      "errorDescriptionRequired": "A description is required. Add one line saying what this skill does.",
       "errorBodyRequired": "Add at least one instruction step.",
       "errorSlugTaken": "A skill with this name already exists."
     }

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -40,6 +40,7 @@
       "submit": "Crear skill",
       "submitting": "Creando...",
       "errorTitleRequired": "Dale un título a tu skill.",
+      "errorDescriptionRequired": "La descripción es obligatoria. Agrega una línea que diga qué hace esta skill.",
       "errorBodyRequired": "Agrega al menos un paso.",
       "errorSlugTaken": "Ya existe una skill con este nombre."
     }

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -40,6 +40,7 @@
       "submit": "Criar skill",
       "submitting": "Criando...",
       "errorTitleRequired": "Dê um título à sua skill.",
+      "errorDescriptionRequired": "A descrição é obrigatória. Adicione uma linha dizendo o que essa skill faz.",
       "errorBodyRequired": "Adicione pelo menos um passo.",
       "errorSlugTaken": "Já existe uma skill com esse nome."
     }

--- a/ui/skills/src/add-skill-dialog-scratch-model.ts
+++ b/ui/skills/src/add-skill-dialog-scratch-model.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure form logic for ScratchView (AddSkillDialog's "From scratch" tab),
+ * extracted so validation is unit-testable without rendering.
+ */
+
+export interface ScratchFormInput {
+  title: string;
+  description: string;
+  body: string;
+}
+
+/**
+ * Convert a free-form title ("Draft a contract") into a kebab-case slug
+ * Houston stores on disk ("draft-a-contract"). Strips non-ASCII, collapses
+ * runs of separators, trims leading/trailing dashes.
+ */
+export function toSlug(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+}
+
+/**
+ * The engine rejects a skill without a description (400), so the form must
+ * require it client-side. The nudge shows before a save attempt: once the
+ * user has visited the field and left it empty, or skipped past it entirely
+ * (title and body filled while the description is still blank).
+ */
+export function needsDescriptionNudge(
+  form: ScratchFormInput,
+  descriptionTouched: boolean,
+): boolean {
+  if (form.description.trim().length > 0) return false;
+  if (descriptionTouched) return true;
+  return form.title.trim().length > 0 && form.body.trim().length > 0;
+}
+
+export function canSubmitScratchForm(
+  form: ScratchFormInput,
+  slugTaken: boolean,
+): boolean {
+  return (
+    form.title.trim().length > 0 &&
+    form.description.trim().length > 0 &&
+    form.body.trim().length > 0 &&
+    !slugTaken
+  );
+}

--- a/ui/skills/src/add-skill-dialog-scratch-view.tsx
+++ b/ui/skills/src/add-skill-dialog-scratch-view.tsx
@@ -19,6 +19,11 @@ import {
   useRef,
   useState,
 } from "react";
+import {
+  canSubmitScratchForm,
+  needsDescriptionNudge,
+  toSlug,
+} from "./add-skill-dialog-scratch-model";
 
 export interface ScratchViewLabels {
   titleLabel?: string;
@@ -34,6 +39,7 @@ export interface ScratchViewLabels {
   submit?: string;
   submitting?: string;
   errorTitleRequired?: string;
+  errorDescriptionRequired?: string;
   errorBodyRequired?: string;
   errorSlugTaken?: string;
 }
@@ -54,6 +60,8 @@ const DEFAULT_LABELS: Required<ScratchViewLabels> = {
   submit: "Create skill",
   submitting: "Creating...",
   errorTitleRequired: "Give your skill a title.",
+  errorDescriptionRequired:
+    "A description is required. Add one line saying what this skill does.",
   errorBodyRequired: "Add at least one instruction step.",
   errorSlugTaken: "A skill with this name already exists.",
 };
@@ -85,6 +93,7 @@ export function ScratchView({
   const l = { ...DEFAULT_LABELS, ...labels };
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [descriptionTouched, setDescriptionTouched] = useState(false);
   const [body, setBody] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -94,6 +103,7 @@ export function ScratchView({
   useEffect(() => {
     setTitle("");
     setDescription("");
+    setDescriptionTouched(false);
     setBody("");
     setError(null);
     // Defer focus past the dialog's mount animation so the cursor
@@ -105,16 +115,25 @@ export function ScratchView({
   const slugTaken =
     slug.length > 0 && installedSkillNames?.has(slug.toLowerCase()) === true;
 
+  const descriptionMissing = needsDescriptionNudge(
+    { title, description, body },
+    descriptionTouched,
+  );
+
   const canSubmit =
-    title.trim().length > 0 &&
-    body.trim().length > 0 &&
-    !slugTaken &&
+    canSubmitScratchForm({ title, description, body }, slugTaken) &&
     !submitting;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim()) {
       setError(l.errorTitleRequired);
+      return;
+    }
+    if (!description.trim()) {
+      // The inline message under the field carries the explanation.
+      setDescriptionTouched(true);
+      setError(null);
       return;
     }
     if (!body.trim()) {
@@ -173,15 +192,21 @@ export function ScratchView({
           />
         </Field>
 
-        <Field label={l.descriptionLabel} hint={l.descriptionHint}>
+        <Field
+          label={l.descriptionLabel}
+          hint={l.descriptionHint}
+          error={descriptionMissing ? l.errorDescriptionRequired : null}
+        >
           <input
             type="text"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
+            onBlur={() => setDescriptionTouched(true)}
             placeholder={l.descriptionPlaceholder}
             className={inputClass}
             autoComplete="off"
             maxLength={200}
+            aria-invalid={descriptionMissing || undefined}
           />
         </Field>
 
@@ -223,11 +248,13 @@ const inputClass = cn(
 function Field({
   label,
   hint,
+  error,
   suffix,
   children,
 }: {
   label: string;
   hint?: string;
+  error?: string | null;
   suffix?: React.ReactNode;
   children: React.ReactElement<{ id?: string }>;
 }) {
@@ -241,22 +268,13 @@ function Field({
         {suffix}
       </div>
       {cloneElement(children, { id })}
-      {hint && <p className="text-[11px] text-ink-muted/70 mt-1">{hint}</p>}
+      {error ? (
+        <p role="alert" className="text-xs text-red-600 mt-1">
+          {error}
+        </p>
+      ) : (
+        hint && <p className="text-[11px] text-ink-muted/70 mt-1">{hint}</p>
+      )}
     </div>
   );
-}
-
-/**
- * Convert a free-form title ("Draft a contract") into a kebab-case slug
- * Houston stores on disk ("draft-a-contract"). Strips non-ASCII, collapses
- * runs of separators, trims leading/trailing dashes.
- */
-function toSlug(input: string): string {
-  return input
-    .toLowerCase()
-    .normalize("NFKD")
-    .replace(/[̀-ͯ]/g, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 64);
 }

--- a/ui/skills/tests/add-skill-dialog-scratch-model.test.ts
+++ b/ui/skills/tests/add-skill-dialog-scratch-model.test.ts
@@ -1,0 +1,85 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  canSubmitScratchForm,
+  needsDescriptionNudge,
+  toSlug,
+} from "../src/add-skill-dialog-scratch-model.ts";
+
+describe("toSlug", () => {
+  it("kebab-cases a free-form title", () => {
+    assert.equal(toSlug("Draft a contract"), "draft-a-contract");
+  });
+
+  it("strips accents and collapses separator runs", () => {
+    assert.equal(toSlug("  Envía   el--contrato!  "), "envia-el-contrato");
+  });
+
+  it("caps the slug at 64 chars", () => {
+    assert.equal(toSlug("a".repeat(80)).length, 64);
+  });
+});
+
+describe("needsDescriptionNudge", () => {
+  it("stays quiet on a pristine form", () => {
+    assert.equal(
+      needsDescriptionNudge({ title: "", description: "", body: "" }, false),
+      false,
+    );
+  });
+
+  it("nudges once the field was visited and left empty", () => {
+    assert.equal(
+      needsDescriptionNudge({ title: "", description: "  ", body: "" }, true),
+      true,
+    );
+  });
+
+  it("nudges when the user skipped the field but filled everything else", () => {
+    assert.equal(
+      needsDescriptionNudge(
+        { title: "this is custom 1", description: "", body: "say custom 1" },
+        false,
+      ),
+      true,
+    );
+  });
+
+  it("clears as soon as a description is entered", () => {
+    assert.equal(
+      needsDescriptionNudge(
+        { title: "t", description: "Says custom 1 on ping.", body: "b" },
+        true,
+      ),
+      false,
+    );
+  });
+});
+
+describe("canSubmitScratchForm", () => {
+  const complete = {
+    title: "this is custom 1",
+    description: "Says custom 1 on ping.",
+    body: "say custom 1 when the user says ping",
+  };
+
+  it("allows a complete form", () => {
+    assert.equal(canSubmitScratchForm(complete, false), true);
+  });
+
+  it("blocks a missing description (engine rejects it with a 400)", () => {
+    assert.equal(
+      canSubmitScratchForm({ ...complete, description: "  " }, false),
+      false,
+    );
+  });
+
+  it("blocks missing title or body and taken slugs", () => {
+    assert.equal(
+      canSubmitScratchForm({ ...complete, title: " " }, false),
+      false,
+    );
+    assert.equal(canSubmitScratchForm({ ...complete, body: "" }, false), false);
+    assert.equal(canSubmitScratchForm(complete, true), false);
+  });
+});


### PR DESCRIPTION
## Problem

Creating a skill from scratch with an empty description let the request reach the engine, which rejects it with a 400. The user saw the raw `missing 'description' (engine error 400)` string at the bottom of the dialog, and the failure was reported to Sentry on every attempt. Nothing told the user up front that the description is required.

## Fix

The description is now validated client-side, the same way title and instructions already were, plus a proactive explanation:

- **Create skill** stays disabled until the description is filled, so the invalid request never reaches the engine (no more 400s or Sentry noise from this path).
- An inline message under the field explains why: *"A description is required. Add one line saying what this skill does."* It appears **before** any save attempt: when the user leaves the field empty after visiting it, or the moment title and instructions are filled while the description is still blank (the exact flow from the bug report). It clears as soon as they type.
- The message has `role="alert"` and the input gets `aria-invalid`, so it is announced to screen readers.
- A submit-time guard remains as a backstop.

## Implementation

- Slug derivation and form validation extracted to a pure model, `ui/skills/src/add-skill-dialog-scratch-model.ts` (`toSlug`, `needsDescriptionNudge`, `canSubmitScratchForm`), keeping `ui/` i18n-agnostic and the view smaller.
- New `errorDescriptionRequired` label wired through `ScratchViewLabels` defaults, the app label hook, and en/es/pt `skills.json`.
- `Field` learns an `error` slot that replaces the hint while active.

## Tests

- 10 new unit tests in `ui/skills/tests/add-skill-dialog-scratch-model.test.ts` covering slug edge cases, nudge timing (pristine form stays quiet, blur-empty nudges, skipped-field nudges, clears on input), and submit gating including the missing-description case.
- Gates: `ui/skills` tests (75 pass), `pnpm typecheck` (all packages), `pnpm check-locales` (en/es/pt in sync), Biome clean.