### PR TITLE
fix(host): disconnect a terminally-rejected credential instead of retrying its dead refresh token forever

### DIFF
--- a/packages/host/src/credentials/refresh.test.ts
+++ b/packages/host/src/credentials/refresh.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import { isApiKeyCredential, type WorkspaceCredential } from "../ports";
-import { isExpiring, refreshCredential } from "./refresh";
+import { isExpiring, RefreshRejectedError, refreshCredential } from "./refresh";
 
 /**
  * The connect-once refresher is OAuth-only. An API-key credential never expires
@@ -50,6 +50,53 @@ test("isExpiring is true for an already-expired oauth token", () => {
       expiresAt: 1, // long past
     }),
   ).toBe(true);
+});
+
+test("a 401 from the token endpoint throws RefreshRejectedError (terminal)", async () => {
+  // The OAuth server's own verdict on the refresh token (invalid_grant /
+  // refresh_token_invalidated) must be distinguishable from a transient
+  // failure — the serve route disconnects on it instead of retrying forever.
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({ error: { code: "refresh_token_invalidated" } }),
+      { status: 401 },
+    )) as typeof fetch;
+  try {
+    await expect(
+      refreshCredential({
+        workspaceId: "ws_1",
+        provider: "openai-codex",
+        accessToken: "at",
+        refreshToken: "rt.dead",
+        expiresAt: 1,
+      }),
+    ).rejects.toBeInstanceOf(RefreshRejectedError);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("a 5xx from the token endpoint is NOT a terminal rejection", async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response("upstream sad", { status: 503 })) as typeof fetch;
+  try {
+    const err = await refreshCredential({
+      workspaceId: "ws_1",
+      provider: "openai-codex",
+      accessToken: "at",
+      refreshToken: "rt",
+      expiresAt: 1,
+    }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(RefreshRejectedError);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
 });
 
 test("refreshCredential mints a fresh GitHub Copilot token from the stored GitHub token", async () => {

--- a/packages/host/src/credentials/refresh.ts
+++ b/packages/host/src/credentials/refresh.ts
@@ -20,6 +20,22 @@ const OAUTH: Record<string, { tokenUrl: string; clientId: string }> = {
 };
 
 /**
+ * The token endpoint's verdict on the refresh token itself (HTTP 400/401:
+ * `invalid_grant`, `refresh_token_invalidated`, ...). Unlike a network blip or
+ * a 5xx, this never heals on retry — the credential is dead until the user
+ * reconnects the provider.
+ */
+export class RefreshRejectedError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "RefreshRejectedError";
+  }
+}
+
+/**
  * True if the access token is within `skewMs` of expiry (or already expired). An
  * API-key credential never expires, so it is never "expiring".
  */
@@ -84,9 +100,10 @@ export async function refreshCredential(
   });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new Error(
-      `OAuth refresh failed (${res.status}) for ${cred.provider}: ${body.slice(0, 200)}`,
-    );
+    const message = `OAuth refresh failed (${res.status}) for ${cred.provider}: ${body.slice(0, 200)}`;
+    if (res.status === 400 || res.status === 401)
+      throw new RefreshRejectedError(message, res.status);
+    throw new Error(message);
   }
   const json = (await res.json()) as {
     access_token?: string;

--- a/packages/host/src/routes/credential.test.ts
+++ b/packages/host/src/routes/credential.test.ts
@@ -102,6 +102,62 @@ test("serves the existing token when refresh has no config (no 500)", async () =
   expect(r.out.body.kind).toBe("oauth");
 });
 
+test("a terminally-rejected refresh disconnects the credential (marked 404)", async () => {
+  // The token endpoint's 401 (refresh_token_invalidated — session ended
+  // server-side) never heals on retry. Before the fix this logged + served the
+  // expired token on EVERY serve, forever, while turns failed with "No API
+  // key" and the provider still read as connected.
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "openai-codex",
+    accessToken: "expired-AT",
+    refreshToken: "rt.dead",
+    expiresAt: 1,
+  });
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({ error: { code: "refresh_token_invalidated" } }),
+      { status: 401 },
+    )) as typeof fetch;
+  try {
+    const r = mockRes();
+    expect(await call(credentials, "openai-codex", r)).toBe(true);
+    expect(r.out.status).toBe(404);
+    expect(r.out.headers?.["x-houston-not-connected"]).toBe("1");
+    // The dead credential is gone: the next serve answers "not connected"
+    // without another doomed refresh attempt.
+    expect(await credentials.get("w1", "openai-codex")).toBeNull();
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("a transient refresh failure keeps serving the existing token", async () => {
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "openai-codex",
+    accessToken: "maybe-still-good-AT",
+    refreshToken: "rt.fine",
+    expiresAt: 1,
+  });
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response("upstream sad", { status: 503 })) as typeof fetch;
+  try {
+    const r = mockRes();
+    expect(await call(credentials, "openai-codex", r)).toBe(true);
+    expect(r.out.status).toBe(200);
+    expect(r.out.body.access).toBe("maybe-still-good-AT");
+    // A blip must not sign the workspace out.
+    expect(await credentials.get("w1", "openai-codex")).not.toBeNull();
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
 test("serves an api-key credential as kind=api_key without refreshing", async () => {
   const credentials = new MemoryCredentialStore();
   await credentials.put({

--- a/packages/host/src/routes/credential.ts
+++ b/packages/host/src/routes/credential.ts
@@ -1,5 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { isExpiring, refreshCredential } from "../credentials/refresh";
+import {
+  isExpiring,
+  RefreshRejectedError,
+  refreshCredential,
+} from "../credentials/refresh";
 import {
   type CredentialStore,
   type CredentialVault,
@@ -72,10 +76,31 @@ export async function handleSandboxCredential(
       cred = await refreshCredential(cred);
       await deps.credentials.put(cred);
     } catch (err) {
-      // No refresh path for this provider or the refresh was rejected. Serve
-      // the existing token best-effort instead of 500-ing every turn: it may
-      // still be valid, and a genuinely expired one surfaces as a clear auth
-      // error on the real API call. This also stops the runtime's
+      if (err instanceof RefreshRejectedError) {
+        // The OAuth server rejected the refresh token itself (invalid_grant /
+        // refresh_token_invalidated — e.g. the session was ended server-side).
+        // That never heals: retrying every serve loops this error forever
+        // while turns fail on the expired access token. Drop the dead
+        // credential and answer the marked 404 so the runtime removes its
+        // served entry (provenance-gated) and the provider reads signed-out
+        // with the reconnect flow — the credential IS the switch.
+        console.error(
+          `[sandbox/credential] refresh token rejected for ${cred.provider}, disconnecting:`,
+          err.message,
+        );
+        await deps.credentials.remove(claim.workspaceId, cred.provider);
+        json(
+          res,
+          404,
+          { error: `${cred.provider} session ended; reconnect the provider` },
+          { "x-houston-not-connected": "1" },
+        );
+        return true;
+      }
+      // No refresh path for this provider, or a transient failure (network,
+      // 5xx). Serve the existing token best-effort instead of 500-ing every
+      // turn: it may still be valid, and a genuinely expired one surfaces as a
+      // clear auth error on the real API call. This also stops the runtime's
       // multi-provider serve loop from spamming serve 500s for a stale, unused
       // credential (e.g. a leftover Claude login while the agent runs
       // OpenCode).


### PR DESCRIPTION
## Problem

When a provider's OAuth refresh token is invalidated server-side (e.g. OpenAI ends the session after a re-login elsewhere: HTTP 401, `refresh_token_invalidated`), the host's `/sandbox/credential` serve path re-attempted the doomed refresh on **every** serve, logged the failure each time, and served the expired access token anyway:

```
[sandbox/credential] refresh failed for openai-codex, serving existing token: OAuth refresh failed (401) ... "code": "refresh_token_invalidated"
```

Meanwhile every turn on that provider failed with "No API key for provider: openai-codex" (routines failing on every scheduled run), yet the provider still presented as connected. A terminal rejection was being treated like a transient blip, forever.

## Fix

- `refreshCredential` now throws a typed `RefreshRejectedError` when the token endpoint answers **400/401** — the OAuth server's authoritative verdict on the refresh token itself (`invalid_grant` / `refresh_token_invalidated`) — distinct from transient failures (network, 5xx).
- On that terminal rejection the serve route **removes the dead credential** from the store and answers the marked `x-houston-not-connected` 404, so the runtime drops its served entry (provenance-gated, same mechanism as a real sign-out) and the provider reads signed-out with the reconnect flow. The credential IS the switch: a dead key becomes a loud, named OFF with a remedy instead of an error loop behind a "connected" facade.
- Transient failures keep the existing best-effort serve (no 500s for a stale, unused credential).
- Gateway-fronted pods are untouched: served credentials there carry no refresh token, so this path never fires.

## Tests

- `refresh.test.ts`: 401 → `RefreshRejectedError`; 5xx → plain error (not terminal).
- `credential.test.ts`: terminal rejection → marked 404 + credential removed (next serve answers "not connected" without another doomed refresh); transient 503 → existing token still served, workspace not signed out.

Full host suite (973 tests), Biome, boundaries, and workspace typecheck pass.