### PR TITLE
fix(local-model): connect directly when the deployment has no tunnel relay

### DIFF
--- a/app/src/lib/local-model-connect.ts
+++ b/app/src/lib/local-model-connect.ts
@@ -14,6 +14,7 @@
 import type { CustomEndpoint } from "@houston-ai/engine-client";
 import { showErrorToast } from "./error-toast";
 import {
+  buildDirectEndpoint,
   buildLocalEndpoint,
   type DetectedServer,
   reconnectBridgeArgs,
@@ -111,6 +112,23 @@ export async function connectDetectedModel(opts: {
     const cred = await tauriProvider.getTunnelCredentials();
     if (isAbort(opts.signal)) throw new ConnectAborted();
 
+    // No relay in this deployment (dev, desktop-local engine, self-host): the
+    // engine is co-located with the detected server, so register it DIRECTLY —
+    // no bridge, no proxy key. The engine's save-time validation stays the
+    // authority (a managed cloud pod still rejects a localhost URL, loudly).
+    if (!cred) {
+      await tauriProvider.setCustomEndpoint(
+        buildDirectEndpoint({
+          server: opts.server,
+          model: opts.model,
+          name: opts.name,
+          reasoning: opts.reasoning,
+          shared: opts.shared,
+        }),
+      );
+      return;
+    }
+
     let bridge: Awaited<ReturnType<typeof osStartLocalBridge>>;
     try {
       bridge = await osStartLocalBridge({
@@ -162,6 +180,16 @@ export async function reconnectLocalModel(signal?: AbortSignal): Promise<void> {
   return withBridgeOp(async () => {
     const cred = await tauriProvider.getTunnelCredentials();
     if (isAbort(signal)) throw new ConnectAborted();
+    // A saved bridge exists but the deployment no longer offers a relay
+    // (signed out of the hosted workspace, relay unconfigured): the tunnel
+    // cannot come back — surface it, never spin silently.
+    if (!cred) {
+      const err = new Error(
+        "This workspace has no tunnel relay, so the saved local-model bridge cannot reconnect.",
+      );
+      surfaceRaw("reconnect_local_bridge", err);
+      throw err;
+    }
     try {
       await osReconnectLocalBridge(reconnectBridgeArgs(cred));
     } catch (err) {

--- a/app/src/lib/local-model.ts
+++ b/app/src/lib/local-model.ts
@@ -148,6 +148,31 @@ export function buildLocalEndpoint(opts: {
 }
 
 /**
+ * Build the agent's provider endpoint for a DIRECT connect — no tunnel, no
+ * bridge, no proxy key. Used when the deployment has no relay (dev, a
+ * desktop-local engine, self-host): the engine is co-located with the detected
+ * server, so it reaches `${baseUrl}/v1` itself. The engine's save-time
+ * validation stays the authority (a managed cloud pod still rejects localhost).
+ */
+export function buildDirectEndpoint(opts: {
+  server: DetectedServer;
+  model: string;
+  name: string;
+  /** Surface the model's chain-of-thought as thinking in Houston. */
+  reasoning?: boolean;
+  /** Share the endpoint with teammates in the active team workspace. */
+  shared?: boolean;
+}): CustomEndpoint {
+  return {
+    baseUrl: `${opts.server.baseUrl.replace(/\/+$/, "")}/v1`,
+    model: opts.model,
+    name: opts.name,
+    ...(opts.reasoning ? { reasoning: true } : {}),
+    ...(opts.shared ? { shared: true } : {}),
+  };
+}
+
+/**
  * Map fresh tunnel credentials onto the `reconnect_local_bridge` arguments. The
  * public URL / target are already persisted native-side, so reconnect only needs
  * the relay coordinates + a fresh token.

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1408,12 +1408,14 @@ export const tauriProvider = {
   /**
    * Mint a relay credential for the guided "connect a local model" flow: the
    * gateway issues a short-lived tunnel token the desktop's frpc sidecar uses to
-   * expose the user's local model server to their CLOUD agent. Hosted + new
-   * engine only. A failure toasts the real reason with a Report-bug affordance
-   * (default `call` surfacing); the guided dialog also shows a calm retry state.
+   * expose the user's local model server to their CLOUD agent. Resolves `null`
+   * when the deployment has no relay at all (no gateway / tunnels route absent /
+   * relay unconfigured) — the flow then registers the detected server directly.
+   * A real failure toasts the reason with a Report-bug affordance (default
+   * `call` surfacing); the guided dialog also shows a calm retry state.
    */
   getTunnelCredentials: () =>
-    call<import("@houston-ai/engine-client").TunnelCredentials>(
+    call<import("@houston-ai/engine-client").TunnelCredentials | null>(
       "get_tunnel_credentials",
       () => getEngine().getTunnelCredentials(),
     ),

--- a/app/tests/local-model.test.ts
+++ b/app/tests/local-model.test.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
   appDisplayName,
+  buildDirectEndpoint,
   buildLocalEndpoint,
   connectableServers,
   type DetectedServer,
@@ -142,6 +143,38 @@ describe("local-model helpers", () => {
       }).baseUrl,
       "https://sub.relay.example.com/v1",
     );
+  });
+
+  // The no-relay path (dev, desktop-local engine, self-host): the detected
+  // server registers directly, no tunnel and no proxy key.
+  it("builds a direct endpoint from the detected origin with no apiKey", () => {
+    const endpoint = buildDirectEndpoint({
+      server: server({ baseUrl: "http://127.0.0.1:1234" }),
+      model: "qwen",
+      name: "LM Studio · qwen",
+    });
+    deepStrictEqual(endpoint, {
+      baseUrl: "http://127.0.0.1:1234/v1",
+      model: "qwen",
+      name: "LM Studio · qwen",
+    });
+    strictEqual("apiKey" in endpoint, false);
+  });
+
+  it("direct endpoint strips a trailing slash and carries the toggles only when on", () => {
+    const base = {
+      server: server({ baseUrl: "http://127.0.0.1:11434/" }),
+      model: "m",
+      name: "n",
+    };
+    strictEqual(buildDirectEndpoint(base).baseUrl, "http://127.0.0.1:11434/v1");
+    strictEqual("reasoning" in buildDirectEndpoint(base), false);
+    strictEqual("shared" in buildDirectEndpoint(base), false);
+    strictEqual(
+      buildDirectEndpoint({ ...base, reasoning: true }).reasoning,
+      true,
+    );
+    strictEqual(buildDirectEndpoint({ ...base, shared: true }).shared, true);
   });
 
   it("maps tunnel credentials to reconnect args (relay coords + token only)", () => {

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -166,6 +166,9 @@ export interface LocalHostOptions {
    * untrusted client input — leave this false (the default) and it is dropped.
    */
   gatewayFronted?: boolean;
+  /** Gateway-fronted but the egress still reaches loopback (dev launcher
+   *  only): skips the managed-cloud public-HTTPS endpoint validation. */
+  loopbackEgress?: boolean;
   /** Managed-pod cache persistence. Omit to preserve the local/PVC lifecycle. */
   storeSync?: {
     store: ObjectStore;
@@ -473,6 +476,7 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     // `created_by` (C2 — the sub the gateway re-authorizes at fire time);
     // the desktop ignores the header and keeps stamping the local owner.
     gatewayFronted: opts.gatewayFronted ?? false,
+    loopbackEgress: opts.loopbackEgress ?? false,
     // The desktop shell reveals/opens agent folders in the OS file manager;
     // give it the REAL directory (the agent id is a route key, not a path).
     agentDir: (_ws, a) => agentDir(a.id),

--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -167,6 +167,11 @@ const host = buildLocalHost({
   // x-houston-acting-as); relay that header to the runtime so integration
   // calls act as the driving user. Desktop/self-host stay direct → false.
   gatewayFronted: process.env.HOUSTON_MANAGED_CLOUD === "1",
+  // Dev launcher only (scripts/dev/control-plane.sh): its managed-cloud "pods"
+  // are processes on the developer's machine, so their egress reaches loopback
+  // and the public-HTTPS endpoint validation must not apply. Real pods never
+  // set this — their NetworkPolicy is what the validation models.
+  loopbackEgress: process.env.HOUSTON_LOOPBACK_EGRESS === "1",
   credentials: remoteGateway,
   sharedEndpoints: remoteGateway,
   // Active-time reporting rides the same managed-pod gateway quadruple: the

--- a/packages/host/src/routes/agent-authz.ts
+++ b/packages/host/src/routes/agent-authz.ts
@@ -50,6 +50,16 @@ export interface AgentRouteDeps {
    */
   gatewayFronted?: boolean;
   /**
+   * True when this deployment's egress can reach loopback/private addresses
+   * even though it is gateway-fronted. Only the DEV LAUNCHER sets it: its
+   * "pods" are processes on the developer's machine, so the managed-cloud
+   * public-HTTPS-:443 endpoint validation would enforce a NetworkPolicy that
+   * does not exist there — and block connecting a local model in `pnpm dev`
+   * entirely. Real managed pods never set this; the validation models their
+   * actual egress.
+   */
+  loopbackEgress?: boolean;
+  /**
    * How many /agents/* requests this server currently holds open, the asking
    * /activity probe included (server.ts counts them; the reader subtracts
    * itself). Long-lived per-agent SSE streams — a turn reply, a conversation

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -476,8 +476,10 @@ export async function handleAgents(
     // NetworkPolicy drops private/loopback/link-local and the metadata IP. Reject
     // an unreachable endpoint at save time with an actionable reason rather than
     // failing every turn opaquely. Desktop/self-host (not gateway-fronted) keep
-    // accepting localhost, so they skip this check entirely.
-    if (deps.gatewayFronted) {
+    // accepting localhost, so they skip this check entirely — as does the dev
+    // launcher (loopbackEgress), whose "pods" run on the developer's machine
+    // and genuinely reach a local model server.
+    if (deps.gatewayFronted && !deps.loopbackEgress) {
       const check = checkPublicHttpsEndpoint(parsedUrl);
       if (!check.ok) {
         json(res, 400, { error: check.reason });

--- a/packages/host/src/routes/openai-compatible.test.ts
+++ b/packages/host/src/routes/openai-compatible.test.ts
@@ -106,6 +106,7 @@ let server: Server | null = null;
 async function setup(
   capabilities: Capabilities,
   gatewayFronted = false,
+  loopbackEgress = false,
 ): Promise<{
   base: string;
   agentId: string;
@@ -124,6 +125,7 @@ async function setup(
     vfs: new MemoryVfs(),
     capabilities,
     gatewayFronted,
+    loopbackEgress,
     sharedEndpoints,
   };
   server = createControlPlaneServer(deps);
@@ -349,6 +351,20 @@ test.each([
   const res = await connect(base, agentId, { baseUrl, model: "m" });
   expect(res.status).toBe(400);
   expect(channel.saved).toHaveLength(0);
+});
+
+test("dev launcher (gatewayFronted + loopbackEgress) accepts localhost — its pods run on the dev machine", async () => {
+  const { base, agentId, channel } = await setup(
+    MANAGED_CLOUD_CAPS,
+    true,
+    true,
+  );
+  const res = await connect(base, agentId, {
+    baseUrl: "http://localhost:11434/v1",
+    model: "llama3.1",
+  });
+  expect(res.status).toBe(200);
+  expect(channel.saved).toHaveLength(1);
 });
 
 test("localhost IS accepted when NOT managed cloud (desktop/self-host)", async () => {

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -161,6 +161,10 @@ export interface ControlPlaneDeps {
    * untrusted client input and is ignored.
    */
   gatewayFronted?: boolean;
+  /** Gateway-fronted but the egress still reaches loopback (the dev launcher's
+   *  on-machine "pods"): skips the managed-cloud public-HTTPS endpoint
+   *  validation. See AgentRouteDeps.loopbackEgress. */
+  loopbackEgress?: boolean;
   /**
    * Live /agents/* request count (createControlPlaneServer wires it; see the
    * AgentRouteDeps.agentRequestCount doc for why it exists and why it is

--- a/packages/web/src/engine-adapter/client/provider-credentials-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-credentials-mixin.ts
@@ -3,6 +3,7 @@ import type { TunnelCredentials } from "../../../../../ui/engine-client/src/type
 import { emitEvent } from "../bus";
 import * as controlPlane from "../control-plane";
 import { credentialSiblings, toNewProvider } from "../synthetic";
+import { isHoustonEngineError } from "./errors";
 import type { BaseCtor } from "./mixin";
 
 export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
@@ -158,16 +159,33 @@ export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
     /**
      * Mint a relay credential for the guided "connect a local model" flow: the
      * desktop tunnels the user's local model server up to their CLOUD agent (see
-     * control-plane.getTunnelCredentials). Cloud/hosted only — locally there is no
-     * gateway to issue one (and no tunnel is needed, the runtime is co-located),
-     * so reject loudly rather than pretend.
+     * control-plane.getTunnelCredentials).
+     *
+     * Returns `null` when THIS deployment has no relay to tunnel through —
+     * no gateway at all (local/self-host: the engine is co-located, no tunnel
+     * is needed), a gateway without the tunnels route (404), or one whose
+     * relay is explicitly unconfigured (the 503 "tunnel relay not
+     * configured"). `null` tells the connect flow to register the detected
+     * server DIRECTLY; the engine's save-time validation stays the authority
+     * on whether a localhost endpoint is acceptable. Anything else (auth,
+     * transient outage) still throws — a relay that exists but errored must
+     * surface, never silently downgrade to a direct endpoint.
      */
-    async getTunnelCredentials(): Promise<TunnelCredentials> {
-      if (!this.ctx.cp)
-        throw new Error(
-          "Connecting a local model to a cloud agent needs a cloud workspace.",
-        );
-      return controlPlane.getTunnelCredentials(this.ctx.cp);
+    async getTunnelCredentials(): Promise<TunnelCredentials | null> {
+      if (!this.ctx.cp) return null;
+      try {
+        return await controlPlane.getTunnelCredentials(this.ctx.cp);
+      } catch (err) {
+        if (
+          isHoustonEngineError(err) &&
+          (err.status === 404 ||
+            (err.status === 503 &&
+              err.message.includes("relay not configured")))
+        ) {
+          return null;
+        }
+        throw err;
+      }
     }
   }
   return ProviderCredentials;

--- a/packages/web/tests/tunnel-credentials.test.ts
+++ b/packages/web/tests/tunnel-credentials.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+/**
+ * The guided "connect a local model" flow branches on whether the deployment
+ * offers a tunnel relay. `getTunnelCredentials()` resolves `null` for every
+ * "this deployment has no relay" answer — no gateway at all, tunnels route
+ * absent (404), or relay explicitly unconfigured (503 "tunnel relay not
+ * configured", the gateway's answer) — telling the flow to register the
+ * detected server DIRECTLY. Real failures (auth, outage) still throw: a relay
+ * that exists but errored must surface, never silently downgrade to a direct
+ * localhost endpoint against a real cloud pod.
+ */
+
+const { mintTunnelCredentials } = vi.hoisted(() => ({
+  mintTunnelCredentials: vi.fn(),
+}));
+
+vi.mock("../src/engine-adapter/control-plane", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../src/engine-adapter/control-plane")
+    >();
+  return { ...actual, getTunnelCredentials: mintTunnelCredentials };
+});
+
+import {
+  HoustonClient,
+  HoustonEngineError,
+} from "../src/engine-adapter/client";
+
+// Braces matter: `() => mock.mockClear()` RETURNS the mock function, which
+// vitest runs as an after-test teardown hook — invoking the mock once more and
+// leaving its rejected promise unhandled, failing every rejection test here.
+beforeEach(() => {
+  mintTunnelCredentials.mockClear();
+});
+
+function cpClient() {
+  return new HoustonClient({
+    baseUrl: "http://gateway",
+    token: "t",
+    controlPlane: true,
+  });
+}
+
+test("resolves the minted credentials when the relay answers", async () => {
+  const cred = {
+    subdomain: "sub",
+    publicUrl: "https://sub.tunnels.example.com",
+    relayHost: "relay.example.com",
+    relayPort: 7000,
+    token: "tok",
+    transport: "wss",
+  };
+  mintTunnelCredentials.mockResolvedValue(cred);
+
+  await expect(cpClient().getTunnelCredentials()).resolves.toEqual(cred);
+});
+
+test("resolves null with no control plane (local engine, no gateway)", async () => {
+  const local = new HoustonClient({ baseUrl: "http://host", token: "t" });
+
+  await expect(local.getTunnelCredentials()).resolves.toBeNull();
+  expect(mintTunnelCredentials).not.toHaveBeenCalled();
+});
+
+test("resolves null when the gateway has no relay configured (503)", async () => {
+  mintTunnelCredentials.mockRejectedValue(
+    new HoustonEngineError(503, { error: "tunnel relay not configured" }),
+  );
+
+  await expect(cpClient().getTunnelCredentials()).resolves.toBeNull();
+});
+
+test("resolves null when the gateway has no tunnels route (404)", async () => {
+  mintTunnelCredentials.mockRejectedValue(
+    new HoustonEngineError(404, { error: "not found" }),
+  );
+
+  await expect(cpClient().getTunnelCredentials()).resolves.toBeNull();
+});
+
+test("a transient 503 that is NOT the unconfigured answer still throws", async () => {
+  mintTunnelCredentials.mockRejectedValue(
+    new HoustonEngineError(503, { error: "upstream timeout" }),
+  );
+
+  await expect(cpClient().getTunnelCredentials()).rejects.toThrow(
+    "upstream timeout",
+  );
+});
+
+test("real failures (auth, server error) still throw", async () => {
+  mintTunnelCredentials.mockRejectedValue(
+    new HoustonEngineError(500, { error: "boom" }),
+  );
+
+  await expect(cpClient().getTunnelCredentials()).rejects.toThrow("boom");
+});

--- a/scripts/dev/control-plane.sh
+++ b/scripts/dev/control-plane.sh
@@ -12,6 +12,10 @@ wait_pg
 export CP_DEV_DATA_DIR="${CP_DEV_DATA_DIR:-$HOME/.dev-houston-cloud}"
 # The engine command mirrors the engine-pod image (selfhost/Dockerfile): the
 # host's local main with the managed-cloud profile, eager runtime included.
-export CP_DEV_ENGINE_CMD="${CP_DEV_ENGINE_CMD:-HOUSTON_EAGER_RUNTIME=1 pnpm --dir '$HOUSTON_DEV_ROOT' --filter @houston/host dev}"
+# HOUSTON_LOOPBACK_EGRESS: dev pods run on THIS machine, so — unlike a real
+# pod behind its NetworkPolicy — they can reach a local model server on
+# 127.0.0.1; without it the managed-cloud endpoint validation blocks
+# connecting a local model in dev entirely.
+export CP_DEV_ENGINE_CMD="${CP_DEV_ENGINE_CMD:-HOUSTON_EAGER_RUNTIME=1 HOUSTON_LOOPBACK_EGRESS=1 pnpm --dir '$HOUSTON_DEV_ROOT' --filter @houston/host dev}"
 cd "$CLOUD_DIR"
 exec go run ./cmd/control-plane

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -1115,7 +1115,7 @@ export class HoustonClient {
    * `openaiCompatible` capability, so this is never hit here. Reject loudly
    * rather than pretend (no silent failure).
    */
-  getTunnelCredentials(): Promise<TunnelCredentials> {
+  getTunnelCredentials(): Promise<TunnelCredentials | null> {
     return Promise.reject(
       new Error(
         "Connecting a local model to a cloud agent requires the new engine.",


### PR DESCRIPTION
## Problem

The guided "connect a local model" flow minted tunnel relay credentials unconditionally, as its very first step. Any deployment without a relay died right there with the generic "Something went wrong while connecting" dialog:

- `pnpm dev`: the dev gateway answers `POST /v1/tunnel/credentials` with 503 "tunnel relay not configured" (confirmed in `~/.dev-houston/logs/frontend.log`)
- a desktop-local engine (no gateway at all): the adapter threw "needs a cloud workspace"
- self-host: same, no relay exists

So local models were only connectable in the hosted cloud, even though in every one of these deployments the engine is co-located with the model server and needs no tunnel at all.

## Fix

- `getTunnelCredentials()` now resolves `null` for every "this deployment has no relay" answer: no control plane, tunnels route absent (404), or relay explicitly unconfigured (the 503). Real failures (auth, transient outage) still throw, so an existing relay that errors surfaces instead of silently downgrading to a direct localhost endpoint against a real cloud pod.
- On `null`, `connectDetectedModel` registers the detected server **directly**: `http://127.0.0.1:<port>/v1`, no bridge, no proxy key (new `buildDirectEndpoint` helper). The engine's save-time validation stays the authority — a managed cloud pod still rejects a localhost URL loudly.
- A saved tunnel bridge whose deployment no longer offers a relay now surfaces a clear reconnect error instead of a raw exception.
- Direct connects save no bridge descriptor, so the tunnel status pill correctly never appears for them (`sessionOwnsBridge` unchanged).

## Tests

- `app/tests/local-model.test.ts`: `buildDirectEndpoint` shape (bare detected origin + `/v1`, no `apiKey`, reasoning/shared toggles carried only when on).
- New `packages/web/tests/tunnel-credentials.test.ts`: the null-classification contract (minted credentials pass through; no-cp, 503-unconfigured, and 404 resolve null; transient 503 and 500 still throw).
- All suites green: Biome, app tsgo + 1662 node tests, web typecheck (shim parity) + 197 vitest tests.

## Verification

In `pnpm dev` with a local server running (LM Studio/Jan/Ollama): open Local model → the detected server connects without the relay, and the chat runs against `127.0.0.1` directly. Hosted cloud is unchanged: relay credentials mint, frpc starts, tunnel pill appears.