### PR TITLE
fix(chat): unwedge the reconnect auto-continue from the send queue

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -1765,17 +1765,22 @@ export function useAgentChatPanel({
               // nudge (the transcript filters its bubble, see
               // `mapFeedItems`). Both fire automatically on reconnect;
               // other failures keep the generic visible retry prompt.
-              const text = continuesTaskAfterReconnect(providerError)
-                ? encodeAutoContinueMessage(
-                    reconnectContinueText(
-                      providerError,
-                      t("chat:providerError.reconnectedContinue"),
-                    ),
-                  )
+              const continues = continuesTaskAfterReconnect(providerError);
+              const continueText = reconnectContinueText(
+                providerError,
+                t("chat:providerError.reconnectedContinue"),
+              );
+              const text = continues
+                ? encodeAutoContinueMessage(continueText)
                 : providerErrorRetryText(
                     providerError,
                     t("chat:toolRuntimeError.retryPrompt"),
                   );
+              // The reconnect resume fires WITHOUT the user typing, so it is an
+              // `autoResume` send: if the conversation shows a running turn it
+              // is held at most once (several mounted cards can fire the same
+              // resume) and dropped when redundant — and its queued bubble
+              // shows the human text, never the auto-continue marker.
               await tauriChat.send(path, text, selectedSessionKey, {
                 providerOverride: effectiveProvider,
                 modelOverride: effectiveModel,
@@ -1784,6 +1789,8 @@ export function useAgentChatPanel({
                 // A refused not-connected send left its prompt's bubble in
                 // the feed already — resending it must not add a second one.
                 suppressUserBubble: resendsOriginalPrompt(providerError),
+                autoResume: providerError.kind === "unauthenticated",
+                ...(continues ? { queuedPreview: { text: continueText } } : {}),
               });
             }}
             // "Pick another model" pops the MODEL picker (not the Skills picker);

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -365,6 +365,9 @@ export const tauriChat = {
       suppressUserBubble?: boolean;
       /** Queue display (user's words + attachment names) if the send is held (see SessionStartRequest). */
       queuedPreview?: { text: string; attachmentNames?: string[] };
+      /** Houston resuming after an out-of-band completion, not user-typed —
+       *  deduped/droppable in the send queue (see SessionStartRequest). */
+      autoResume?: boolean;
       /**
        * What the user's bubble renders when it must differ from `prompt` — a
        * hidden setup-mission directive or appended attachment paths. The engine
@@ -391,6 +394,7 @@ export const tauriChat = {
         suppressUserBubble: opts?.suppressUserBubble,
         queuedPreview: opts?.queuedPreview,
         displayText: opts?.displayText,
+        autoResume: opts?.autoResume,
       });
       return res.sessionKey;
     }),

--- a/packages/sdk/src/modules/turns/feed-output.ts
+++ b/packages/sdk/src/modules/turns/feed-output.ts
@@ -67,6 +67,15 @@ export interface FeedOutput {
     status: BoardStatus,
     pendingInteraction?: PendingInteraction | null,
   ): Promise<void>;
+  /**
+   * The server confirmed this conversation is IDLE (an observer attached and
+   * its sync reported no turn in flight). Lets an output reconcile state that
+   * says otherwise — a `running` VM whose stream was torn down without a settle
+   * (client teardown keeps live state by design) would otherwise stay "running"
+   * forever, wedging everything keyed on it (the send queue, the spinner).
+   * Optional and additive: outputs with no such state simply omit it.
+   */
+  confirmIdle?(agentPath: string, sessionKey: string): void;
 }
 
 /**
@@ -103,5 +112,9 @@ export class MultiplexFeedOutput implements FeedOutput {
         o.persistBoardStatus(agentPath, sessionKey, status, pendingInteraction),
       ),
     );
+  }
+
+  confirmIdle(agentPath: string, sessionKey: string): void {
+    for (const o of this.outputs) o.confirmIdle?.(agentPath, sessionKey);
   }
 }

--- a/packages/sdk/src/modules/turns/turn-sink.ts
+++ b/packages/sdk/src/modules/turns/turn-sink.ts
@@ -177,6 +177,10 @@ export class TurnSink {
       // we saw it and arm the pre-settled poll, which settles conclusively from
       // history if no stream evidence follows.
       if (this.o.mode === "observer") {
+        // Server-confirmed idle: reconcile any output whose state still says
+        // "running" — a stream torn down without a settle (client teardown)
+        // leaves the VM stale, and nothing else ever corrects it.
+        this.o.output.confirmIdle?.(this.o.agentPath, this.o.sessionKey);
         this.o.stop();
       } else {
         this.sawFreshIdleSync = true;
@@ -187,7 +191,10 @@ export class TurnSink {
       // complete once a turn ends — settle from it, not from partial text.
       this.settleFromHistorySoon();
     } else {
-      this.o.stop(); // observer that never saw the turn run: nothing to settle
+      // Observer that never saw the turn run: nothing to settle, but the sync
+      // confirms the conversation is idle — reconcile stale state (as above).
+      this.o.output.confirmIdle?.(this.o.agentPath, this.o.sessionKey);
+      this.o.stop();
     }
   }
 

--- a/packages/sdk/src/modules/turns/turn-stream.test.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.test.ts
@@ -96,6 +96,8 @@ function makeOutput() {
   // The interaction each board persist carried (parallel to `board`): null on
   // the "running" start-clear, the captured interaction (or null) on settle.
   const boardInteractions: Array<PendingInteraction | null | undefined> = [];
+  // Conversations the observer confirmed idle (the stale-running reconcile).
+  const idleConfirms: string[] = [];
   const output: FeedOutput = {
     pushFeedItem: (_a, _s, item) => {
       items.push(item as Item);
@@ -107,8 +109,18 @@ function makeOutput() {
       board.push(status);
       boardInteractions.push(pendingInteraction);
     },
+    confirmIdle: (_a, s) => {
+      idleConfirms.push(s);
+    },
   };
-  return { items, sessionStatuses, board, boardInteractions, output };
+  return {
+    items,
+    sessionStatuses,
+    board,
+    boardInteractions,
+    idleConfirms,
+    output,
+  };
 }
 
 async function waitFor(cond: () => boolean, ms = 2_000): Promise<void> {
@@ -497,7 +509,7 @@ test("observer mode closes silently on an idle conversation", async () => {
       o.onEvent(sync(false, "", 3));
     },
   ]);
-  const { items, sessionStatuses, board, output } = makeOutput();
+  const { items, sessionStatuses, board, idleConfirms, output } = makeOutput();
 
   observeConversation(
     engine,
@@ -515,6 +527,11 @@ test("observer mode closes silently on an idle conversation", async () => {
   expect(items).toEqual([]);
   expect(sessionStatuses).toEqual([]);
   expect(board).toEqual([]); // nothing persisted for an idle attach
+  // The server-confirmed idle reconciles any output whose state still says
+  // "running" — a stream torn down without a settle leaves the VM stale, and
+  // this attach is the only correction point (the reconnect auto-continue
+  // wedged behind exactly that stale flag).
+  expect(idleConfirms).toEqual(["activity-idle"]);
 });
 
 test("a turn we send supersedes an active observer — no double subscription", async () => {

--- a/packages/sdk/src/modules/turns/vm-output.test.ts
+++ b/packages/sdk/src/modules/turns/vm-output.test.ts
@@ -387,3 +387,25 @@ test("the same session key on two agents never collides (agent-qualified scope)"
   expect(ada.feed).toHaveLength(1);
   expect(ada.feed[0]?.data).toBe("ada's");
 });
+
+test("confirmIdle clears a STALE running flag (stream died without a settle)", () => {
+  const { vm, snap } = harness();
+  vm.sessionStatus("a", "c1", "running");
+  expect(snap().running).toBe(true);
+
+  // The stream was torn down externally (client teardown settles nothing);
+  // an observer later attaches and the server confirms the conversation idle.
+  vm.confirmIdle("a", "c1");
+  expect(snap().running).toBe(false);
+  expect(snap().sessionStatus).toBe("idle");
+});
+
+test("confirmIdle leaves a settled conversation untouched", () => {
+  const { vm, snap } = harness();
+  vm.sessionStatus("a", "c1", "running");
+  vm.sessionStatus("a", "c1", "error");
+
+  vm.confirmIdle("a", "c1");
+  // The terminal truth stays — only a stale "running" is reconciled.
+  expect(snap().sessionStatus).toBe("error");
+});

--- a/packages/sdk/src/modules/turns/vm-output.ts
+++ b/packages/sdk/src/modules/turns/vm-output.ts
@@ -366,6 +366,21 @@ export class ConversationVmOutput implements FeedOutput {
     this.publish(agentPath, sessionKey, s);
   }
 
+  /**
+   * The server confirmed this conversation is idle. A VM still saying
+   * "running" is STALE — its stream died without a settle (external teardown
+   * keeps live state by design) — so clear the flag; a settled/idle VM is
+   * left untouched (the truth is already terminal, and re-publishing would
+   * churn subscribers for nothing).
+   */
+  confirmIdle(agentPath: string, sessionKey: string): void {
+    const s = this.state(agentPath, sessionKey);
+    if (s.sessionStatus !== "running") return;
+    s.sessionStatus = "idle";
+    s.streaming.clear();
+    this.publish(agentPath, sessionKey, s);
+  }
+
   /** Replace the conversation's queued-message list (the send queue's seam). */
   setQueued(
     agentPath: string,

--- a/packages/web/src/engine-adapter/client/chat-send-mixin.ts
+++ b/packages/web/src/engine-adapter/client/chat-send-mixin.ts
@@ -6,10 +6,12 @@ import * as controlPlane from "../control-plane";
 import {
   flushQueuedSends,
   maybeQueueSend,
+  noteAutoResumeEnded,
+  noteAutoResumeStarted,
   removeQueuedSend,
 } from "../send-queue";
 import { DEFAULT_AGENT_PATH, wireTurnPin } from "../synthetic";
-import { streamTurn } from "../turn-stream";
+import { observeConversation, streamTurn } from "../turn-stream";
 import { setActivityStatus } from "./activity-status";
 import type { BaseCtor } from "./mixin";
 
@@ -28,14 +30,46 @@ export function ChatSendMixin<TBase extends BaseCtor>(Base: TBase) {
         : this.ctx.engine;
       // Queue-while-running: a send into a conversation whose turn is still
       // streaming is held and flushed as ONE combined send at settle (see
-      // send-queue.ts). Every send path inherits this here.
-      if (maybeQueueSend(path, req)) return { sessionKey: req.sessionKey };
+      // send-queue.ts). Every send path inherits this here. The dispatch
+      // callback serves the queue's settle watcher — the flush path for turns
+      // settled by an observer or the stale-running heal, which never pass
+      // through the `.finally` below.
+      const redispatch = (r: SessionStartRequest) => {
+        void this.startSession(path, r);
+      };
+      if (maybeQueueSend(path, req, redispatch)) {
+        // The VM says a turn is running, but nothing may actually be streaming
+        // it (a `running` flag left behind by a torn-down stream). Attach the
+        // passive observer so the SERVER arbitrates: a genuinely running turn
+        // renders live and settles the queue when it ends; an idle conversation
+        // heals the flag (`confirmIdle`), which fires the settle watcher and
+        // flushes the held send immediately. No-op while a live turn/observer
+        // already owns this conversation.
+        observeConversation(
+          engine,
+          path,
+          req.sessionKey,
+          (status, pendingInteraction) =>
+            setActivityStatus(
+              this.ctx,
+              path,
+              req.sessionKey,
+              status,
+              pendingInteraction,
+            ),
+          0,
+        );
+        return { sessionKey: req.sessionKey };
+      }
       // Fire-and-stream: events flow to the feed store over the bus/WS adapter.
       // The board-status setter is cloud-aware (writes land where the board reads).
       // The request's provider/model/effort (the chat's OWN pick, app dialect)
       // ride the send as a per-turn wire pin in engine ids (wireTurnPin), so the
       // turn runs on this conversation's provider — not the agent-wide settings
       // some other chat or connect flow last wrote (HOU-695).
+      // A dispatched auto-resume is bracketed so a duplicate resume (another
+      // mounted reconnect card, same login event) is swallowed while it runs.
+      if (req.autoResume) noteAutoResumeStarted(path, req.sessionKey);
       void streamTurn(
         engine,
         path,
@@ -56,9 +90,8 @@ export function ChatSendMixin<TBase extends BaseCtor>(Base: TBase) {
         req.displayText,
       ).finally(() => {
         // The turn settled (or failed): release anything queued behind it.
-        flushQueuedSends(path, req.sessionKey, (r) => {
-          void this.startSession(path, r);
-        });
+        if (req.autoResume) noteAutoResumeEnded(path, req.sessionKey);
+        flushQueuedSends(path, req.sessionKey, redispatch);
       });
       return { sessionKey: req.sessionKey };
     }

--- a/packages/web/src/engine-adapter/send-queue.ts
+++ b/packages/web/src/engine-adapter/send-queue.ts
@@ -4,6 +4,7 @@ import {
   type QueuedMessageVM,
 } from "@houston/sdk";
 import type { SessionStartRequest } from "../../../../ui/engine-client/src/types";
+import { armSettleWatcher, disarmSettleWatcher } from "./settle-watcher";
 import { conversationStore, conversationVm } from "./vm";
 
 /**
@@ -18,6 +19,19 @@ import { conversationStore, conversationVm } from "./vm";
  * call site re-deriving "is a turn active". The queue holds fully BUILT
  * requests (attachments already saved, prompt final); `queuedPreview` carries
  * the user's words + attachment names for the composer's queued-bubble UI.
+ *
+ * Flushing has two triggers, because a settle has two shapes: the dispatched
+ * turn's own settle (the `.finally` in `chat-send-mixin`), and — for a turn
+ * settled by anything else — the settle watcher armed at queue time (see
+ * settle-watcher.ts; HOU-718's reconnect auto-continue was the canonical
+ * victim of its absence).
+ *
+ * `autoResume` sends (Houston resuming after a provider reconnect — not
+ * user-typed) get special handling: one resume per conversation at a time —
+ * a duplicate is swallowed while another is queued OR dispatched-and-running
+ * (several reconnect surfaces fire the same resume off one login event) — and
+ * a held one is dropped at flush when the user queued their own follow-up
+ * (their message resumes the conversation by itself).
  */
 
 interface QueuedSend {
@@ -26,6 +40,8 @@ interface QueuedSend {
 }
 
 const queues = new Map<string, QueuedSend[]>();
+/** Conversations with a DISPATCHED auto-resume turn still in flight. */
+const resumesInFlight = new Set<string>();
 
 const queueKey = (agentPath: string, sessionKey: string) =>
   conversationScope(agentPath, sessionKey);
@@ -48,17 +64,44 @@ function conversationRunning(agentPath: string, sessionKey: string): boolean {
 }
 
 /**
+ * Bracket a DISPATCHED auto-resume turn's lifetime: while one is in flight, a
+ * duplicate resume (another mounted reconnect card firing off the same login
+ * event) is swallowed instead of queued — queueing it would re-send the same
+ * "please continue" the moment the first one settles.
+ */
+export function noteAutoResumeStarted(
+  agentPath: string,
+  sessionKey: string,
+): void {
+  resumesInFlight.add(queueKey(agentPath, sessionKey));
+}
+export function noteAutoResumeEnded(
+  agentPath: string,
+  sessionKey: string,
+): void {
+  resumesInFlight.delete(queueKey(agentPath, sessionKey));
+}
+
+/**
  * Hold `req` when its conversation has a turn in flight. Returns true when the
  * send was queued (the caller returns without dispatching); false means the
- * conversation is idle and the caller dispatches normally.
+ * conversation is idle and the caller dispatches normally. An `autoResume`
+ * send is held at most once per conversation — a duplicate (one already queued
+ * or dispatched-and-running) is swallowed, reported as handled.
  */
 export function maybeQueueSend(
   agentPath: string,
   req: SessionStartRequest,
+  dispatch: (req: SessionStartRequest) => void,
 ): boolean {
   if (!conversationRunning(agentPath, req.sessionKey)) return false;
   const k = queueKey(agentPath, req.sessionKey);
   const entries = queues.get(k) ?? [];
+  if (
+    req.autoResume &&
+    (resumesInFlight.has(k) || entries.some((e) => e.req.autoResume))
+  )
+    return true;
   entries.push({
     vm: {
       id: crypto.randomUUID(),
@@ -72,6 +115,9 @@ export function maybeQueueSend(
   });
   queues.set(k, entries);
   publishQueued(agentPath, req.sessionKey);
+  armSettleWatcher(k, () =>
+    flushQueuedSends(agentPath, req.sessionKey, dispatch),
+  );
   return true;
 }
 
@@ -83,17 +129,24 @@ export function removeQueuedSend(
 ): void {
   const k = queueKey(agentPath, sessionKey);
   const entries = (queues.get(k) ?? []).filter((e) => e.vm.id !== id);
-  if (entries.length === 0) queues.delete(k);
-  else queues.set(k, entries);
+  if (entries.length === 0) {
+    queues.delete(k);
+    disarmSettleWatcher(k);
+  } else queues.set(k, entries);
   publishQueued(agentPath, sessionKey);
 }
 
 /**
  * Flush the conversation's queue as ONE combined send once its turn settled.
- * Called from the settle path of every dispatched turn; a no-op when nothing
- * is queued or another turn already took the conversation over. Prompts are
- * trimmed and joined blank-line-separated (the shape the old app-side queue
- * produced); the LAST entry's overrides win (the most recent picker state).
+ * Called from the settle path of every dispatched turn AND from the settle
+ * watcher; a no-op when nothing is queued or another turn already took the
+ * conversation over. Prompts are trimmed and joined blank-line-separated (the
+ * shape the old app-side queue produced); the LAST entry's overrides win (the
+ * most recent picker state).
+ *
+ * A held `autoResume` entry is dropped (not sent) when user-typed entries are
+ * queued alongside it: their message resumes the conversation by itself, and
+ * combining the marker-tagged resume prompt into their bubble would corrupt it.
  */
 export function flushQueuedSends(
   agentPath: string,
@@ -102,9 +155,12 @@ export function flushQueuedSends(
 ): void {
   if (conversationRunning(agentPath, sessionKey)) return;
   const k = queueKey(agentPath, sessionKey);
-  const entries = queues.get(k);
-  if (!entries || entries.length === 0) return;
+  const all = queues.get(k);
+  if (!all || all.length === 0) return;
+  const hasUserEntries = all.some((e) => !e.req.autoResume);
+  const entries = hasUserEntries ? all.filter((e) => !e.req.autoResume) : all;
   queues.delete(k);
+  disarmSettleWatcher(k);
   publishQueued(agentPath, sessionKey);
   const last = entries[entries.length - 1];
   const prompt = entries

--- a/packages/web/src/engine-adapter/settle-watcher.ts
+++ b/packages/web/src/engine-adapter/settle-watcher.ts
@@ -1,0 +1,29 @@
+import type { ConversationVM } from "@houston/sdk";
+import { conversationStore } from "./vm";
+
+/**
+ * The send queue's second flush trigger: a per-conversation store subscription
+ * that fires `onSettled` the moment the VM's `running` flips false. Needed
+ * because a settle has two shapes — a turn THIS client dispatched (its
+ * `.finally` flushes directly) and a turn settled by anything else (a passive
+ * observer, the SDK's stale-running heal), which never passes through that
+ * path. Without this, a send queued against an observed turn sat in the queue
+ * forever.
+ */
+
+const watchers = new Map<string, () => void>();
+
+/** Arm once per key; re-arming while armed is a no-op. */
+export function armSettleWatcher(scope: string, onSettled: () => void): void {
+  if (watchers.has(scope)) return;
+  const unsub = conversationStore.subscribe(scope, (snapshot) => {
+    if ((snapshot as ConversationVM | undefined)?.running === true) return;
+    onSettled();
+  });
+  watchers.set(scope, unsub);
+}
+
+export function disarmSettleWatcher(scope: string): void {
+  watchers.get(scope)?.();
+  watchers.delete(scope);
+}

--- a/packages/web/tests/send-queue.test.ts
+++ b/packages/web/tests/send-queue.test.ts
@@ -4,6 +4,8 @@ import type { SessionStartRequest } from "../src/engine-adapter";
 import {
   flushQueuedSends,
   maybeQueueSend,
+  noteAutoResumeEnded,
+  noteAutoResumeStarted,
   removeQueuedSend,
 } from "../src/engine-adapter/send-queue";
 import { conversationStore, conversationVm } from "../src/engine-adapter/vm";
@@ -11,8 +13,12 @@ import { conversationStore, conversationVm } from "../src/engine-adapter/vm";
 /**
  * Queue-while-running: sends into a RUNNING conversation are held (visible as
  * VM `queued` entries), flushed as ONE combined send at settle, and removable
- * before they go out. The adapter's module-scoped VM is shared across tests,
- * so each case uses its own conversation key.
+ * before they go out. Settling has two triggers — the dispatched turn's own
+ * flush call, and the store watcher that fires when the VM's `running` flips
+ * false (observer settles, the stale-running heal). Auto-resume sends (a
+ * provider-reconnect continue) are deduped and dropped when redundant. The
+ * adapter's module-scoped VM is shared across tests, so each case uses its own
+ * conversation key.
  */
 
 const AGENT = "Houston/Bo";
@@ -32,8 +38,12 @@ const queuedOf = (sessionKey: string) =>
 
 let n = 0;
 let key: string;
+let dispatched: SessionStartRequest[];
+const dispatch = (r: SessionStartRequest) => dispatched.push(r);
+
 beforeEach(() => {
   key = `q-${n++}`;
+  dispatched = [];
 });
 
 const setRunning = (running: boolean) =>
@@ -41,7 +51,7 @@ const setRunning = (running: boolean) =>
 
 describe("maybeQueueSend", () => {
   it("dispatches immediately when the conversation is idle", () => {
-    expect(maybeQueueSend(AGENT, req(key, "hi"))).toBe(false);
+    expect(maybeQueueSend(AGENT, req(key, "hi"), dispatch)).toBe(false);
     expect(queuedOf(key)).toBeUndefined();
   });
 
@@ -53,21 +63,69 @@ describe("maybeQueueSend", () => {
         req(key, "<!--marker-->built prompt", {
           queuedPreview: { text: "the user's words" },
         }),
+        dispatch,
       ),
     ).toBe(true);
     expect(queuedOf(key)?.map((q) => q.text)).toEqual(["the user's words"]);
+  });
+
+  it("holds at most ONE auto-resume per conversation", () => {
+    setRunning(true);
+    const resume = () =>
+      req(key, "<!--houston:auto_continue-->\n\ncontinue", {
+        autoResume: true,
+        queuedPreview: { text: "continue" },
+      });
+    expect(maybeQueueSend(AGENT, resume(), dispatch)).toBe(true);
+    // A second mounted reconnect card firing the same resume is swallowed:
+    // reported as handled, but never queued twice.
+    expect(maybeQueueSend(AGENT, resume(), dispatch)).toBe(true);
+    expect(queuedOf(key)).toHaveLength(1);
+  });
+});
+
+describe("settle watcher", () => {
+  it("flushes when running flips false WITHOUT an explicit flush call", () => {
+    // An observed turn's settle (or the SDK's stale-running heal) never passes
+    // through the dispatched-turn flush path — the watcher must fire instead.
+    setRunning(true);
+    maybeQueueSend(AGENT, req(key, "queued behind an observed turn"), dispatch);
+    expect(dispatched).toHaveLength(0);
+
+    setRunning(false);
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0]?.prompt).toBe("queued behind an observed turn");
+    expect(queuedOf(key) ?? []).toEqual([]);
+  });
+
+  it("flushes a held auto-resume after the stale-running heal", () => {
+    // The reconnect auto-continue queued against a STALE running flag (its
+    // stream was torn down without a settle). The heal (`confirmIdle`) flips
+    // running false — the resume must go out, or the agent never continues.
+    setRunning(true);
+    maybeQueueSend(
+      AGENT,
+      req(key, "<!--houston:auto_continue-->\n\ncontinue", {
+        autoResume: true,
+      }),
+      dispatch,
+    );
+    conversationVm.confirmIdle(AGENT, key);
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0]?.autoResume).toBe(true);
   });
 });
 
 describe("flushQueuedSends", () => {
   it("flushes held sends as ONE combined dispatch once idle", () => {
     setRunning(true);
-    maybeQueueSend(AGENT, req(key, "Wait"));
-    maybeQueueSend(AGENT, req(key, "No no, about cars", { model: "m2" }));
-    setRunning(false);
-
-    const dispatched: SessionStartRequest[] = [];
-    flushQueuedSends(AGENT, key, (r) => dispatched.push(r));
+    maybeQueueSend(AGENT, req(key, "Wait"), dispatch);
+    maybeQueueSend(
+      AGENT,
+      req(key, "No no, about cars", { model: "m2" }),
+      dispatch,
+    );
+    setRunning(false); // the watcher flushes right here
 
     expect(dispatched).toHaveLength(1);
     expect(dispatched[0]?.prompt).toBe("Wait\n\nNo no, about cars");
@@ -78,21 +136,61 @@ describe("flushQueuedSends", () => {
 
   it("stays held while the conversation is still running", () => {
     setRunning(true);
-    maybeQueueSend(AGENT, req(key, "hold me"));
+    maybeQueueSend(AGENT, req(key, "hold me"), dispatch);
 
-    const dispatched: SessionStartRequest[] = [];
-    flushQueuedSends(AGENT, key, (r) => dispatched.push(r));
+    flushQueuedSends(AGENT, key, dispatch);
 
     expect(dispatched).toHaveLength(0);
     expect(queuedOf(key)).toHaveLength(1);
+  });
+
+  it("drops a held auto-resume when the user queued their own follow-up", () => {
+    setRunning(true);
+    maybeQueueSend(
+      AGENT,
+      req(key, "<!--houston:auto_continue-->\n\ncontinue", {
+        autoResume: true,
+      }),
+      dispatch,
+    );
+    maybeQueueSend(AGENT, req(key, "my own message"), dispatch);
+    setRunning(false);
+
+    // The user's message resumes the conversation by itself — the synthetic
+    // nudge riding along would read as noise (and its marker would corrupt
+    // the combined bubble).
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0]?.prompt).toBe("my own message");
+    expect(dispatched[0]?.autoResume).toBeUndefined();
+  });
+
+  it("swallows a resume while a dispatched resume is still in flight", () => {
+    // Card A's resume dispatched (running, bracketed in flight); card B fires
+    // the same resume off the same login event — it must not queue, or it
+    // would re-send "please continue" the moment A settles.
+    noteAutoResumeStarted(AGENT, key);
+    setRunning(true);
+    expect(
+      maybeQueueSend(
+        AGENT,
+        req(key, "<!--houston:auto_continue-->\n\ncontinue", {
+          autoResume: true,
+        }),
+        dispatch,
+      ),
+    ).toBe(true);
+    expect(queuedOf(key) ?? []).toEqual([]);
+    noteAutoResumeEnded(AGENT, key);
+    setRunning(false);
+    expect(dispatched).toHaveLength(0);
   });
 });
 
 describe("removeQueuedSend", () => {
   it("drops one held send by id and updates the VM", () => {
     setRunning(true);
-    maybeQueueSend(AGENT, req(key, "keep me"));
-    maybeQueueSend(AGENT, req(key, "drop me"));
+    maybeQueueSend(AGENT, req(key, "keep me"), dispatch);
+    maybeQueueSend(AGENT, req(key, "drop me"), dispatch);
     const drop = queuedOf(key)?.find((q) => q.text === "drop me");
     expect(drop).toBeDefined();
 
@@ -100,8 +198,6 @@ describe("removeQueuedSend", () => {
     expect(queuedOf(key)?.map((q) => q.text)).toEqual(["keep me"]);
 
     setRunning(false);
-    const dispatched: SessionStartRequest[] = [];
-    flushQueuedSends(AGENT, key, (r) => dispatched.push(r));
     expect(dispatched[0]?.prompt).toBe("keep me");
   });
 });

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -1279,6 +1279,16 @@ export interface SessionStartRequest {
    * are no per-send fields for them.)
    */
   queuedPreview?: { text: string; attachmentNames?: string[] };
+  /**
+   * This send is Houston resuming the conversation on the user's behalf after
+   * an out-of-band completion (a provider reconnect) — not something the user
+   * typed. The adapter's send queue treats it specially: at most ONE is held
+   * per conversation (several reconnect surfaces can fire the same resume),
+   * and a held one is dropped rather than flushed when it would be redundant —
+   * the user queued their own follow-up, or the turn that just settled was
+   * itself a resume.
+   */
+  autoResume?: boolean;
 }
 
 export interface SessionStartResponse {


### PR DESCRIPTION
## Problem

After reconnecting a provider (reported with Anthropic), the agent did not continue the interrupted task. The hidden auto-continue message sat visibly in the composer's **Queued** list, raw `<!--houston:auto_continue-->` marker included, and never went out.

## Root cause

The reconnect card's auto-resume goes through `startSession`, and the adapter's queue-while-running seam holds any send while the conversation VM reports `running: true`. That flag can go **stale**: a stream torn down without a settle (the client-teardown path deliberately settles nothing) leaves the VM at `running: true` forever, and a passive observer that later attaches and finds the server idle just closed without correcting it. From then on every send queued, and nothing ever flushed the queue, because the flush only ran from a **dispatched** turn's settle path. A turn settled by an observer never flushed either, so even the legitimate queue-while-observed case could strand messages.

## Fix (three layers, each independently useful)

**SDK** — new optional `FeedOutput.confirmIdle`: when the passive observer's sync confirms the conversation is idle, the conversation VM reconciles a stale `running` flag (only a `running -> idle` transition; settled conversations are untouched). Both observer-idle sync paths call it.

**Adapter** — two send-queue changes:
- A settle watcher is armed whenever a send is held: the queue now flushes the moment `running` flips false, regardless of who settled the turn (dispatched turn, observer, or the heal). Previously only the dispatched turn's `.finally` flushed.
- Queuing a send also attaches the passive observer, so the server arbitrates a `running` flag nothing is streaming: a genuinely running turn renders live and settles the queue when it ends; an idle conversation heals immediately and the held send goes out.

**App + adapter** — the reconnect resume is tagged `autoResume` on the wire request:
- held at most once per conversation, and swallowed while a dispatched resume is still running (several mounted reconnect cards can fire off one login event);
- dropped at flush when the user queued their own follow-up (their message resumes the conversation by itself, and combining the marker-tagged prompt into their bubble would corrupt it);
- its queued bubble shows the human text ("I'm signed in again..."), never the marker.

## All providers

The auto-resume trigger is provider-agnostic; the only coupling is the provider id match between the card and the `ProviderLoginComplete` event. Verified the dialects line up everywhere: Anthropic (desktop relay `announce` + background reconcile + poll paths), OpenAI/Codex (`openai` on both sides via `toOldProvider`), API-key providers (verbatim ids), and `openai-compatible`.

## Tests

- SDK: `confirmIdle` heals a stale running flag / leaves settled conversations untouched; the idle-observer attach calls it.
- Adapter: watcher flush without an explicit flush call; auto-resume flushes after the stale-running heal; one resume held per conversation; in-flight resume swallows duplicates; a held resume is dropped when the user queued their own follow-up.
- Full suites green: `@houston/sdk` (365), `houston-web` (196), `@houston/host` (967), typechecks (ui/app/web + shim parity), Biome, boundaries.

Note: the local Playwright e2e boot fails identically on a clean checkout in this workspace (environment issue), so e2e coverage rides CI.