### PR TITLE
fix(app): reconnect card for a disconnected local model + unknown-state polish

### DIFF
--- a/app/src/components/shell/provider-error-cards/auth.tsx
+++ b/app/src/components/shell/provider-error-cards/auth.tsx
@@ -31,10 +31,12 @@ import { CheckCircle2Icon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { subscribeHoustonEvents } from "../../../lib/events";
+import { getProvider } from "../../../lib/providers";
 import { tauriProvider } from "../../../lib/tauri";
 import { useUIStore } from "../../../stores/ui";
 import { RowCard } from "../../cards/row-card";
 import { RowCardButton } from "../../cards/row-card-button";
+import { LocalModelDialog } from "../local-model-dialog";
 import { ProviderGlyph } from "../provider-logos";
 import {
   type AuthCardButton,
@@ -57,6 +59,7 @@ export function UnauthenticatedCard({
   const [launching, setLaunching] = useState(false);
   const [failureDetail, setFailureDetail] = useState<string | null>(null);
   const [retrying, setRetrying] = useState(false);
+  const [showCustomDialog, setShowCustomDialog] = useState(false);
   const relaunchingRef = useRef(false);
   // The auto-resend must fire ONCE per card — a second fire (the provider can
   // complete several logins while the chat stays open) would double-send.
@@ -102,6 +105,17 @@ export function UnauthenticatedCard({
 
   const reconnect = async () => {
     if (launching) return;
+    // A local OpenAI-compatible server has no OAuth flow — reconnect by
+    // re-connecting the local model in its dialog, not launchLogin (which
+    // would throw "does not use OAuth sign-in" and dead-end the card). A
+    // successful connect fires the same `ProviderLoginComplete` event
+    // (`setProviderCustomEndpoint`), so the auto-resume above still runs.
+    if (error.provider === "openai-compatible") {
+      setFailureDetail(null);
+      setShowCustomDialog(true);
+      setPhase("waiting");
+      return;
+    }
     setLaunching(true);
     relaunchingRef.current = true;
     setFailureDetail(null);
@@ -118,6 +132,12 @@ export function UnauthenticatedCard({
   };
 
   const cancelSignIn = async () => {
+    // Local model: nothing engine-side to cancel — close the dialog and re-arm.
+    if (error.provider === "openai-compatible") {
+      setShowCustomDialog(false);
+      setPhase("idle");
+      return;
+    }
     try {
       await tauriProvider.cancelLogin(error.provider);
     } finally {
@@ -172,6 +192,20 @@ export function UnauthenticatedCard({
         title={t(pres.titleKey, { provider })}
         description={t(pres.bodyKey, { provider, detail: failureDetail ?? "" })}
         action={renderButton(pres.button)}
+      />
+
+      {/* The local model's reconnect surface: the same guided dialog the AI
+          Models section opens. A successful connect fires
+          ProviderLoginComplete, which flips this card to done and auto-resumes
+          the task; closing without connecting re-arms the button. */}
+      <LocalModelDialog
+        provider={
+          showCustomDialog ? (getProvider(error.provider) ?? null) : null
+        }
+        onClose={() => {
+          setShowCustomDialog(false);
+          setPhase((p) => (p === "waiting" ? "idle" : p));
+        }}
       />
     </div>
   );

--- a/app/src/components/shell/provider-error-cards/not-connected.ts
+++ b/app/src/components/shell/provider-error-cards/not-connected.ts
@@ -86,18 +86,17 @@ export function providerErrorRetryText(
 }
 
 /**
- * Whether a feed item is the persisted inline reconnect card for THIS chat's
- * provider — the signal that the store-driven (auto-dismissing) card must not
- * also render. An empty provider on the card counts as this chat's: it means
- * NO provider was connected at all, which necessarily includes this one.
+ * Whether a feed item is a persisted inline reconnect card — the signal that
+ * the store-driven (auto-dismissing) card must not also render. One reconnect
+ * surface per chat, and the inline card wins REGARDLESS of which provider it
+ * names: it carries the provider that actually failed (stamped by the runtime
+ * on the turn), which is truer than the chat-provider resolution chain — a
+ * stale activity record once resolved a Jan (openai-compatible) chat to
+ * "anthropic" and rendered a second, WRONG-provider store card next to the
+ * correct inline one.
  */
-export function isInlineAuthCardForChat(
-  item: FeedItem,
-  chatProvider: string,
-): boolean {
+export function isInlineAuthCard(item: FeedItem): boolean {
   return (
-    item.feed_type === "provider_error" &&
-    item.data.kind === "unauthenticated" &&
-    (item.data.provider === chatProvider || item.data.provider === "")
+    item.feed_type === "provider_error" && item.data.kind === "unauthenticated"
   );
 }

--- a/app/src/components/shell/provider-error-cards/transient.tsx
+++ b/app/src/components/shell/provider-error-cards/transient.tsx
@@ -104,12 +104,24 @@ export function NetworkUnreachableCard({
 }) {
   const { t } = useTranslation("shell");
   const provider = providerLabel(error.provider);
+  // The local (OpenAI-compatible) provider is the user's own machine, not a
+  // provider API: "check your internet" is the wrong remedy. Name the real
+  // one — the model app stopped or its server is off.
+  const local = error.provider === "openai-compatible";
   return (
     <div className="w-full px-1 py-2">
       <RowCard
         media={<WifiOffIcon className="size-5" />}
-        title={t("providerError.networkUnreachable.title", { provider })}
-        description={t("providerError.networkUnreachable.body", { provider })}
+        title={
+          local
+            ? t("providerError.networkUnreachable.localTitle")
+            : t("providerError.networkUnreachable.title", { provider })
+        }
+        description={
+          local
+            ? t("providerError.networkUnreachable.localBody")
+            : t("providerError.networkUnreachable.body", { provider })
+        }
         action={
           <>
             {onRetry && (

--- a/app/src/components/tabs/provider-auth-feed.ts
+++ b/app/src/components/tabs/provider-auth-feed.ts
@@ -23,6 +23,14 @@ const AUTH_PATTERNS = [
   // ONLY signal that the chat's provider was logged out — recognizing it here
   // is what surfaces the in-chat reconnect card on the new stack.
   "no provider connected",
+  // The runtime refuses a turn pinned to the OpenAI-compatible provider whose
+  // endpoint was disconnected with a verbatim "No local model configured. Set
+  // a base URL and model for the OpenAI-compatible provider." (runtime
+  // `ai/openai-compatible.ts`). Same situation as "no provider connected":
+  // no AuthRequired event fires, so this feed message is the only signal —
+  // recognizing it is what surfaces the in-chat reconnect card (which routes
+  // openai-compatible to the local-model dialog, not OAuth).
+  "no local model configured",
 ] as const;
 
 /**

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -158,7 +158,7 @@ import { SelectedSkillChip } from "./selected-skill-chip";
 import { ProviderErrorCard } from "./shell/provider-error-card";
 import {
   continuesTaskAfterReconnect,
-  isInlineAuthCardForChat,
+  isInlineAuthCard,
   providerErrorRetryText,
   reconnectContinueText,
   resendsOriginalPrompt,
@@ -1843,14 +1843,13 @@ export function useAgentChatPanel({
       // narrated by the standard in-flight indicator — deriveStatus treats
       // the parked trailing user bubble as "submitted" (HOU-713).
       // The persisted inline `UnauthenticatedCard` (a provider_error feed item)
-      // is the stable reconnect surface. When it's already present for THIS
-      // chat's provider, don't also render the store-driven card — it flickers
-      // (auto-dismisses) when the provider's auth probe is unreliable, e.g.
-      // codex reporting "authenticated" off a stale ~/.codex/auth.json after a
-      // server-side session kill. One card, and it stays put.
-      const hasInlineAuthCard = feedItems.some((it) =>
-        isInlineAuthCardForChat(it, effectiveProvider),
-      );
+      // is the stable reconnect surface. When one is present, don't also
+      // render the store-driven card — it flickers (auto-dismisses) when the
+      // provider's auth probe is unreliable, and when the chat-provider
+      // resolution disagrees with the provider the turn ACTUALLY failed on
+      // (a stale activity record) it would name the wrong provider outright.
+      // One card per chat, and the inline one carries the true provider.
+      const hasInlineAuthCard = feedItems.some(isInlineAuthCard);
       if (hasInlineAuthCard) return null;
       const signalKey = providerAuthSignalKey(feedItems);
       // Always hand the card THIS chat's provider so it can match the global

--- a/app/src/hooks/use-houston-init.ts
+++ b/app/src/hooks/use-houston-init.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { DEFAULT_TAB_ID } from "../agents/standard-tabs";
+import { providerAppearsConnected } from "../components/shell/provider-reconnect-state";
 import { analytics } from "../lib/analytics";
 import { tauriPreferences, tauriProvider, tauriRoutines } from "../lib/tauri";
 import { useAgentCatalogStore } from "../stores/agent-catalog";
@@ -87,7 +88,10 @@ export function useHoustonInit() {
         const defaultProv = await tauriProvider.getDefault();
         if (defaultProv) {
           const status = await tauriProvider.checkStatus(defaultProv);
-          setClaudeAvailable(status.cli_installed && status.authenticated);
+          // appears-connected (not confirmed-authenticated): an "unknown"
+          // probe against a still-waking pod must not degrade first-load
+          // gating for a provider that is in fact connected server-side.
+          setClaudeAvailable(providerAppearsConnected(status));
         } else {
           // No provider configured — track as activation drop-off signal
           analytics.track("provider_not_configured");

--- a/app/src/lib/chat-model-picker-map.test.mjs
+++ b/app/src/lib/chat-model-picker-map.test.mjs
@@ -171,17 +171,17 @@ test("buildPickerModels: a real provider's rows rank curated-first", () => {
     statuses: {},
   });
   // Curated (PROVIDER_OVERRIDES.anthropic.models key order: sonnet-5 [absent
-  // from this provider's rows, so skipped], opus-4-8, fable-5) first, then
-  // legacy (including the now-uncurated sonnet-4-6/opus-4-7) in catalog order.
+  // from this provider's rows, so skipped], fable-5, opus-4-8, opus-4-7,
+  // sonnet-4-6) first, then the uncurated legacy rows in catalog order.
   assert.deepEqual(
     models.map((m) => decodeModelPickerId(m.id).model),
     [
-      "claude-opus-4-8",
       "claude-fable-5",
-      "claude-opus-3",
-      "claude-sonnet-3-5",
+      "claude-opus-4-8",
       "claude-opus-4-7",
       "claude-sonnet-4-6",
+      "claude-opus-3",
+      "claude-sonnet-3-5",
     ],
   );
 });

--- a/app/src/lib/model-picker.test.mjs
+++ b/app/src/lib/model-picker.test.mjs
@@ -23,6 +23,38 @@ test("providerPickerState: missing status is 'checking' only while loading", () 
   assert.equal(providerPickerState(undefined, false), "disconnected");
 });
 
+test("providerPickerState: an 'unknown' probe (engine unreachable) is 'checking', never 'disconnected'", () => {
+  // A cold pod waking after a relaunch/update answers every status probe with
+  // auth_state "unknown". That is not a confirmed disconnect: collapsing to
+  // "Not connected" is the #342 flicker all over again.
+  const unknown = {
+    cli_installed: true,
+    authenticated: false,
+    auth_state: "unknown",
+  };
+  assert.equal(providerPickerState(unknown, false), "checking");
+  assert.equal(providerPickerState(unknown, true), "checking");
+  // Confirmed states keep their meaning when auth_state is present.
+  assert.equal(
+    providerPickerState(
+      { cli_installed: true, authenticated: true, auth_state: "authenticated" },
+      false,
+    ),
+    "connected",
+  );
+  assert.equal(
+    providerPickerState(
+      {
+        cli_installed: true,
+        authenticated: false,
+        auth_state: "unauthenticated",
+      },
+      false,
+    ),
+    "disconnected",
+  );
+});
+
 test("pickerModelRows: a catalogued provider shows its catalog, ignoring the runtime model", () => {
   const catalog = [
     { id: "claude-sonnet-4-6", label: "Sonnet 4.6", description: "Balanced." },

--- a/app/src/lib/model-picker.ts
+++ b/app/src/lib/model-picker.ts
@@ -16,6 +16,10 @@
 export interface ProviderConnection {
   cli_installed: boolean;
   authenticated: boolean;
+  /** Tri-state probe result. "unknown" = the engine was unreachable (a cold
+   *  pod still waking): not confirmable either way. Optional so legacy
+   *  callers that only carry the boolean keep working. */
+  auth_state?: "authenticated" | "unauthenticated" | "unknown";
 }
 
 /**
@@ -41,6 +45,11 @@ export function providerPickerState(
   isLoading: boolean,
 ): ProviderPickerState {
   if (status) {
+    // An "unknown" probe (engine unreachable, cold pod waking) is not a
+    // confirmed disconnect: keep the neutral "checking" state instead of
+    // collapsing every provider to "Not connected" (the #342 flicker, now
+    // reachable in cloud builds whenever the pod is waking).
+    if (status.auth_state === "unknown") return "checking";
     return status.cli_installed && status.authenticated
       ? "connected"
       : "disconnected";

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -355,6 +355,8 @@
     "networkUnreachable": {
       "title": "Cannot reach {{provider}}",
       "body": "Houston could not reach the {{provider}} API. Check your internet, then try again.",
+      "localTitle": "Cannot reach your local model",
+      "localBody": "Houston could not reach the model on your computer. Make sure the model app is open and its server is running, then try again.",
       "retry": "Try again",
       "checkStatus": "Check status page"
     },

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -355,6 +355,8 @@
     "networkUnreachable": {
       "title": "No se puede conectar con {{provider}}",
       "body": "Houston no pudo conectarse a la API de {{provider}}. Verifica tu conexión y vuelve a intentar.",
+      "localTitle": "No se puede conectar con tu modelo local",
+      "localBody": "Houston no pudo conectarse al modelo en tu computador. Asegúrate de que la aplicación del modelo esté abierta y su servidor en ejecución, y vuelve a intentar.",
       "retry": "Reintentar",
       "checkStatus": "Ver página de estado"
     },

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -340,6 +340,8 @@
     "networkUnreachable": {
       "title": "Não foi possível alcançar o {{provider}}",
       "body": "O Houston não conseguiu acessar a API do {{provider}}. Verifique sua internet e tente de novo.",
+      "localTitle": "Não foi possível alcançar seu modelo local",
+      "localBody": "O Houston não conseguiu acessar o modelo no seu computador. Verifique se o aplicativo do modelo está aberto e com o servidor em execução, depois tente de novo.",
       "retry": "Tentar de novo",
       "checkStatus": "Ver página de status"
     },

--- a/app/tests/not-connected-card.test.ts
+++ b/app/tests/not-connected-card.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from "node:test";
 import type { FeedItem, ProviderError } from "@houston-ai/chat";
 import {
   continuesTaskAfterReconnect,
-  isInlineAuthCardForChat,
+  isInlineAuthCard,
   providerErrorRetryText,
   reconnectContinueText,
   resendsOriginalPrompt,
@@ -157,37 +157,32 @@ describe("providerErrorRetryText", () => {
   });
 });
 
-describe("isInlineAuthCardForChat", () => {
+describe("isInlineAuthCard", () => {
   const item = (data: ProviderError): FeedItem => ({
     feed_type: "provider_error",
     data,
   });
 
-  it("matches this chat's provider and the provider-less refusal", () => {
+  it("matches any persisted unauthenticated card, regardless of provider", () => {
+    strictEqual(isInlineAuthCard(item(notConnectedCard)), true);
     strictEqual(
-      isInlineAuthCardForChat(
-        item({ ...notConnectedCard, provider: "openai" }),
-        "openai",
-      ),
+      isInlineAuthCard(item({ ...notConnectedCard, provider: "openai" })),
       true,
     );
-    // Empty provider = NOTHING was connected, which includes this chat's.
+    // The inline card carries the provider the turn ACTUALLY failed on — a
+    // stale chat-provider resolution must never let a second (wrong-provider)
+    // store card render next to it, so the match is provider-agnostic.
     strictEqual(
-      isInlineAuthCardForChat(item(notConnectedCard), "openai"),
+      isInlineAuthCard(
+        item({ ...notConnectedCard, provider: "openai-compatible" }),
+      ),
       true,
     );
   });
 
-  it("never matches a foreign provider's card or other kinds", () => {
+  it("never matches other kinds or non-provider-error items", () => {
     strictEqual(
-      isInlineAuthCardForChat(
-        item({ ...notConnectedCard, provider: "anthropic" }),
-        "openai",
-      ),
-      false,
-    );
-    strictEqual(
-      isInlineAuthCardForChat(
+      isInlineAuthCard(
         item({
           kind: "rate_limited",
           provider: "openai",
@@ -195,15 +190,14 @@ describe("isInlineAuthCardForChat", () => {
           retry_after_seconds: null,
           message: "slow down",
         }),
-        "openai",
       ),
       false,
     );
     strictEqual(
-      isInlineAuthCardForChat(
-        { feed_type: "system_message", data: "hello" } as FeedItem,
-        "openai",
-      ),
+      isInlineAuthCard({
+        feed_type: "system_message",
+        data: "hello",
+      } as FeedItem),
       false,
     );
   });

--- a/app/tests/provider-auth-feed.test.ts
+++ b/app/tests/provider-auth-feed.test.ts
@@ -32,6 +32,19 @@ describe("isProviderAuthMessage", () => {
     strictEqual(isProviderAuthMessage("Your session expired"), true);
   });
 
+  it("recognizes the runtime's disconnected-local-model refusal (surfaces the reconnect card)", () => {
+    // Verbatim from runtime ai/openai-compatible.ts: a chat pinned to the
+    // local provider whose endpoint was disconnected in Settings fails every
+    // send with this message and NO AuthRequired event — the feed pattern is
+    // the only card trigger.
+    strictEqual(
+      isProviderAuthMessage(
+        "No local model configured. Set a base URL and model for the OpenAI-compatible provider.",
+      ),
+      true,
+    );
+  });
+
   it("does not flag ordinary assistant text as an auth problem", () => {
     strictEqual(
       isProviderAuthMessage("Sure! Here is how to connect your database."),

--- a/packages/host/src/shared-endpoint/sync.ts
+++ b/packages/host/src/shared-endpoint/sync.ts
@@ -100,7 +100,17 @@ export async function syncSharedEndpoint(
       runtimeStatus(opts.runtime, fetchImpl),
     ]);
     if (!shared) {
-      if (status.orgShared) await clearRuntime(opts.runtime, fetchImpl);
+      if (status.orgShared) {
+        // Loud on purpose: this clear LOGS OUT the runtime's openai-compatible
+        // provider (wiping custom-endpoint.json). It must only ever remove an
+        // org-hydrated endpoint after the share was withdrawn — if an endpoint
+        // vanishes and this line isn't in the log, the wipe came through the
+        // logout route instead (see the runtime's [auth] logout line).
+        console.log(
+          "[shared-endpoint] org share gone → clearing this runtime's org-hydrated endpoint",
+        );
+        await clearRuntime(opts.runtime, fetchImpl);
+      }
       return;
     }
     if (status.configured && !status.orgShared) return;

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -64,6 +64,33 @@ test("pi prompt-time 'No API key found' → unauthenticated / no_credentials (HO
   if (err.kind === "unauthenticated") expect(err.cause).toBe("no_credentials");
 });
 
+test("runtime 'No local model configured' → unauthenticated / no_credentials", () => {
+  // buildActiveCustomModel's guard, thrown from execTurn's resolveModel on a
+  // CACHED conversation whose custom endpoint was disconnected mid-chat. The
+  // typed classification is what routes the reconnect card (local-model
+  // dialog) + the undelivered-prompt auto-resume; `unknown` rendered only the
+  // generic error card.
+  const err = classifyProviderError({
+    provider: "openai-compatible",
+    model: "Jan-v3.5-4B-Q4_K_XL",
+    message:
+      "No local model configured. Set a base URL and model for the OpenAI-compatible provider.",
+  });
+  expect(err.kind).toBe("unauthenticated");
+  if (err.kind === "unauthenticated") expect(err.cause).toBe("no_credentials");
+});
+
+test("runtime 'No provider connected' → unauthenticated / no_credentials", () => {
+  // resolveModel's connect guard — same cached-conversation path as above.
+  const err = classifyProviderError({
+    provider: "",
+    model: null,
+    message: "No provider connected. Connect an AI provider first.",
+  });
+  expect(err.kind).toBe("unauthenticated");
+  if (err.kind === "unauthenticated") expect(err.cause).toBe("no_credentials");
+});
+
 test("pi prompt-time OAuth guard ('Authentication failed … Run /login') → unauthenticated / token_expired", () => {
   // pi's OAuth flavor of the same prompt-time guard.
   const err = classifyProviderError({

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -55,8 +55,22 @@ const INVALID_KEY_PATTERNS = [
  * `formatNoApiKeyFoundMessage`: "No API key found for <provider>.\n\nUse /login
  * …"), it never arrives as an errored AssistantMessage, so the exec-turn /
  * turn-session catch is where this classification happens (HOU-718).
+ *
+ * The runtime's OWN not-connected guards belong here too: `resolveModel` /
+ * `buildActiveCustomModel` throw "No provider connected. …" and "No local model
+ * configured. …" BEFORE any session exists. On a brand-new conversation
+ * chat.ts's getConversation catch types them directly, but on a CACHED
+ * conversation the throw happens inside execTurn (resolveModel re-runs every
+ * turn) and lands in ITS catch — which classifies through this function. Without
+ * these patterns that path degraded to `unknown` (generic error card, no
+ * reconnect flow, no undelivered-prompt auto-resume) the moment the SECOND
+ * message of a chat hit a disconnected local model.
  */
-const NO_CREDENTIALS_PATTERNS = ["no api key found"];
+const NO_CREDENTIALS_PATTERNS = [
+  "no api key found",
+  "no provider connected",
+  "no local model configured",
+];
 
 /**
  * The gateway rejected the REQUESTED MODEL itself (not the credential): GitHub

--- a/packages/runtime/src/backends/claude/title.test.ts
+++ b/packages/runtime/src/backends/claude/title.test.ts
@@ -36,6 +36,30 @@ function capturingQuery(): {
   return { query, env: () => captured };
 }
 
+test("titleWithClaude carries the title instruction in the PROMPT itself", async () => {
+  // The CLI has been observed running its claude_code preset despite a custom
+  // string systemPrompt — the model then ANSWERED the excerpt and the first
+  // line of the answer became the board title. The instruction must ride the
+  // prompt so the reply is a title whichever system prompt the CLI honors.
+  let prompt = "";
+  const query: ClaudeQuery = (req) => {
+    prompt = String(req.prompt);
+    return (async function* () {})();
+  };
+
+  await titleWithClaude({
+    excerpt: "user: do you have image capabilities?",
+    titlePrompt: "You generate conversation titles.",
+    workspaceDir: "/ws",
+    readToken: () => undefined,
+    query,
+  });
+
+  expect(prompt).toContain("You generate conversation titles.");
+  expect(prompt).toContain("user: do you have image capabilities?");
+  expect(prompt).toContain("Reply with ONLY the title.");
+});
+
 test("titleWithClaude scrubs a stale API key when an OAuth token is connected", async () => {
   process.env.ANTHROPIC_API_KEY = "stale-host-key";
   const oauth: ClaudeToken = { kind: "oauth-token", value: "sk-ant-oat01-x" };

--- a/packages/runtime/src/backends/claude/title.ts
+++ b/packages/runtime/src/backends/claude/title.ts
@@ -32,7 +32,21 @@ export interface ClaudeTitleParams {
 
 export async function titleWithClaude(p: ClaudeTitleParams): Promise<string> {
   const text = await oneShotWithClaude({
-    prompt: p.excerpt,
+    // The title instruction rides the PROMPT, not only `systemPrompt`: the
+    // CLI the SDK spawns has been observed running the full claude_code
+    // preset despite a custom string systemPrompt in the initialize request —
+    // the model then ANSWERED the excerpt, and the first line of that answer
+    // became the board title ("Yes, I have image capabilities. I…"). With the
+    // instruction inline the reply is a title whichever prompt the CLI ends
+    // up honoring.
+    prompt: [
+      p.titlePrompt,
+      "",
+      "Conversation excerpt:",
+      p.excerpt,
+      "",
+      "Reply with ONLY the title.",
+    ].join("\n"),
     systemPrompt: p.titlePrompt,
     workspaceDir: p.workspaceDir,
     readToken: p.readToken,

--- a/packages/runtime/src/session/chat-failure.test.ts
+++ b/packages/runtime/src/session/chat-failure.test.ts
@@ -41,6 +41,31 @@ test("a turn failing before execution persists the user message + typed provider
 });
 
 /**
+ * A NOT-CONNECTED failure (disconnected local model / no provider) is typed
+ * `unauthenticated`, not `unknown`: the typed card is the full reconnect
+ * surface — correct provider label, the provider's own reconnect flow, and the
+ * automatic task resume on reconnect. `undelivered_prompt` carries the turn's
+ * text because the model never received it (the failure precedes the session).
+ */
+test("a disconnected-local-model failure persists a typed unauthenticated error with the undelivered prompt", async () => {
+  await runTurn("conv-fail-3", "everything is okey?", undefined, {
+    provider: "openai-compatible",
+  });
+
+  const history = getHistory("conv-fail-3");
+  const assistant = history?.messages.at(-1);
+  expect(assistant?.providerError).toMatchObject({
+    kind: "unauthenticated",
+    provider: "openai-compatible",
+    cause: "no_credentials",
+    undelivered_prompt: "everything is okey?",
+  });
+  expect((assistant?.providerError as { message?: string }).message).toContain(
+    "No local model configured",
+  );
+});
+
+/**
  * The failure must be RENDERABLE by a live turn stream, not just persisted:
  * the client sink adopts its turnId from the nonce-stamped `user` echo, and a
  * stamped `error` frame with no adopted id classifies as foreign and is

--- a/packages/runtime/src/session/chat-failure.test.ts
+++ b/packages/runtime/src/session/chat-failure.test.ts
@@ -11,6 +11,7 @@ process.env.HOUSTON_DATA_DIR = mkdtempSync(join(tmpdir(), "houston-chat-"));
 process.env.HOUSTON_WORKSPACE_DIR = process.env.HOUSTON_DATA_DIR;
 const { runTurn } = await import("./chat");
 const { getHistory } = await import("../store/conversations");
+const { subscribe } = await import("./bus");
 
 /**
  * A turn that fails BEFORE executing (a pin naming an unknown provider — a
@@ -37,4 +38,44 @@ test("a turn failing before execution persists the user message + typed provider
   expect(
     (assistant?.providerError as { raw_excerpt?: string }).raw_excerpt,
   ).toContain("unknown provider: gemini-cli");
+});
+
+/**
+ * The failure must be RENDERABLE by a live turn stream, not just persisted:
+ * the client sink adopts its turnId from the nonce-stamped `user` echo, and a
+ * stamped `error` frame with no adopted id classifies as foreign and is
+ * dropped — the turn then spins forever with no error and no reconnect card
+ * (the disconnected-local-model repro). So the pre-execution failure path
+ * publishes the SAME echo-then-error sequence as a normal turn, sharing one
+ * turnId, echo first.
+ */
+test("a turn failing before execution publishes the nonce-stamped echo before the error", async () => {
+  const frames: { type: string; turnId?: string; nonce?: string }[] = [];
+  const unsub = subscribe("conv-fail-2", (f) => {
+    frames.push({
+      type: f.type,
+      turnId: f.turnId,
+      nonce: (f.data as { nonce?: string })?.nonce,
+    });
+  });
+  try {
+    await runTurn("conv-fail-2", "hello", "nonce-123", {
+      provider: "openai-compatible",
+    });
+  } finally {
+    unsub();
+  }
+
+  const user = frames.find((f) => f.type === "user");
+  const error = frames.find((f) => f.type === "error");
+  expect(user).toBeDefined();
+  expect(error).toBeDefined();
+  // The echo carries OUR nonce (the sink's adoption key) and the error is
+  // stamped with the SAME turnId, in echo-then-error order.
+  expect(user?.nonce).toBe("nonce-123");
+  expect(user?.turnId).toBeDefined();
+  expect(error?.turnId).toBe(user?.turnId);
+  expect(frames.indexOf(user as never)).toBeLessThan(
+    frames.indexOf(error as never),
+  );
 });

--- a/packages/runtime/src/session/chat.ts
+++ b/packages/runtime/src/session/chat.ts
@@ -116,15 +116,34 @@ export async function runTurn(
       data: { content: text, ts: Date.now(), nonce },
       turnId,
     });
+    // A NOT-CONNECTED failure is typed `unauthenticated`, not `unknown`: the
+    // typed card is the full reconnect surface (correct provider label, the
+    // provider's own reconnect flow — the local-model dialog for
+    // openai-compatible — and the automatic task resume once the reconnect
+    // completes). `undelivered_prompt` carries the turn's text because the
+    // model never received it: the failure precedes the session, so neither
+    // the live context nor a rebuild ever sees this message (HOU-718) — only
+    // the UI transcript above does.
+    const message = errMessage(err);
+    const notConnected =
+      /no local model configured|no provider connected/i.test(message);
     appendAssistantMessage(id, "", {
-      providerError: {
-        kind: "unknown",
-        provider: pin?.provider ?? "unknown",
-        raw_excerpt: errMessage(err),
-      },
+      providerError: notConnected
+        ? {
+            kind: "unauthenticated",
+            provider: pin?.provider ?? "",
+            cause: "no_credentials",
+            message,
+            undelivered_prompt: text,
+          }
+        : {
+            kind: "unknown",
+            provider: pin?.provider ?? "unknown",
+            raw_excerpt: message,
+          },
       turnId,
     });
-    publish(id, { type: "error", data: { message: errMessage(err) }, turnId });
+    publish(id, { type: "error", data: { message }, turnId });
     return;
   }
 

--- a/packages/runtime/src/session/chat.ts
+++ b/packages/runtime/src/session/chat.ts
@@ -106,6 +106,16 @@ export async function runTurn(
     // reader (a routine's reconcile) errors its run with the real message
     // instead of finding no reply and timing out vague.
     appendUserMessage(id, text, { turnId, displayText });
+    // Publish the nonce-stamped `user` echo BEFORE the error, exactly like a
+    // normal turn (recordUserTurn): the client sink adopts its turnId from
+    // this echo, and a stamped `error` frame arriving with no adopted id
+    // classifies as FOREIGN and is dropped — the turn then spins forever with
+    // no error and no reconnect card (the disconnected-local-model repro).
+    publish(id, {
+      type: "user",
+      data: { content: text, ts: Date.now(), nonce },
+      turnId,
+    });
     appendAssistantMessage(id, "", {
       providerError: {
         kind: "unknown",

--- a/packages/runtime/src/session/summarize.test.ts
+++ b/packages/runtime/src/session/summarize.test.ts
@@ -15,6 +15,7 @@ import {
   dispatchTitle,
   generateTitle,
   titleFromText,
+  titlePlan,
 } from "./summarize";
 
 /**
@@ -63,6 +64,39 @@ test("dispatchTitle routes every other provider to the pi runner — Claude is N
     expect(pi).toHaveBeenCalledWith("excerpt");
     expect(claude).not.toHaveBeenCalled();
   }
+});
+
+test("titlePlan routes a live conversation to ITS provider, not the active one", () => {
+  // A local-model chat titles on the local model even when the agent's active
+  // provider is anthropic — dispatching on the active provider burned a full
+  // Claude one-shot to title a chat Claude never ran.
+  const plan = titlePlan(
+    { provider: "openai-compatible", model: "Jan-v3.5-4B-Q4_K_XL" },
+    "anthropic",
+  );
+  expect(plan.provider).toBe("openai-compatible");
+  expect(plan.resolvePin).toEqual({
+    provider: "openai-compatible",
+    model: "Jan-v3.5-4B-Q4_K_XL",
+  });
+  expect(plan.claudeModelId).toBeUndefined();
+});
+
+test("titlePlan keeps an anthropic conversation on the Claude runner with ITS model", () => {
+  const plan = titlePlan(
+    { provider: "anthropic", model: "claude-sonnet-4-6" },
+    "openai-codex",
+  );
+  expect(plan.provider).toBe("anthropic");
+  expect(plan.claudeModelId).toBe("claude-sonnet-4-6");
+  expect(plan.resolvePin).toBeUndefined();
+});
+
+test("titlePlan falls back to the active provider when the session is not cached", () => {
+  const plan = titlePlan(undefined, "anthropic");
+  expect(plan.provider).toBe("anthropic");
+  expect(plan.claudeModelId).toBeUndefined();
+  expect(plan.resolvePin).toBeUndefined();
 });
 
 test("generateTitle runs a faux turn and returns a single trimmed line", async () => {

--- a/packages/runtime/src/session/summarize.ts
+++ b/packages/runtime/src/session/summarize.ts
@@ -10,6 +10,7 @@ import { readAnthropicToken } from "../backends/claude/read-token";
 import { titleWithClaude } from "../backends/claude/title";
 import { config } from "../config";
 import { getHistory, renameConversation } from "../store/conversations";
+import { conversations } from "./conversation-cache";
 import { oneShotText } from "./one-shot";
 
 const errMessage = (err: unknown): string =>
@@ -74,13 +75,44 @@ export function dispatchTitle(
     : runners.pi(excerpt);
 }
 
+/**
+ * How to route ONE conversation's title. Titles run on the CONVERSATION's own
+ * provider when its session is live (it just ran a turn — the moment titles
+ * are requested). Dispatching on the agent-wide active provider titled a
+ * local-model chat through a full Claude one-shot: a different backend the
+ * chat never picked, burning a real Anthropic call (and failing outright when
+ * that provider was the disconnected one). Only when the session is no longer
+ * cached does the active provider decide. Pure, so the routing is unit-tested.
+ */
+export function titlePlan(
+  conv: { provider: string; model: string } | undefined,
+  active: string | null,
+): {
+  provider: string | null;
+  /** Claude model to title with (anthropic conversations only). */
+  claudeModelId?: string;
+  /** Model pin the pi runner must resolve (non-anthropic conversations). */
+  resolvePin?: { provider: string; model: string };
+} {
+  if (!conv) return { provider: active };
+  if (conv.provider === "anthropic")
+    return { provider: "anthropic", claudeModelId: conv.model };
+  return {
+    provider: conv.provider,
+    resolvePin: { provider: conv.provider, model: conv.model },
+  };
+}
+
 /** The concrete runners bound to this workspace's config/credentials. */
-function titleRunners(model?: unknown): {
+function titleRunners(
+  model?: unknown,
+  claudeModelId?: string,
+): {
   claude: TitleRunner;
   pi: TitleRunner;
 } {
   return {
-    claude: (excerpt) => claudeTitle(excerpt),
+    claude: (excerpt) => claudeTitle(excerpt, claudeModelId),
     pi: (excerpt) =>
       generateTitle({
         cwd: config.workspaceDir,
@@ -98,14 +130,14 @@ function titleRunners(model?: unknown): {
  * (the caller truncates) rather than reroute an anthropic title onto pi's client
  * — that reroute is precisely what the compliance gate forbids.
  */
-async function claudeTitle(excerpt: string): Promise<string> {
+async function claudeTitle(excerpt: string, modelId?: string): Promise<string> {
   try {
     return await titleWithClaude({
       excerpt,
       titlePrompt: TITLE_PROMPT,
       workspaceDir: config.workspaceDir,
       readToken: () => readAnthropicToken(authStorage),
-      modelId: resolveModel().id,
+      modelId: modelId ?? resolveModel().id,
     });
   } catch (err) {
     if (err instanceof ClaudeBackendUnavailableError) {
@@ -152,10 +184,30 @@ export async function summarizeTitle(
   const history = getHistory(id);
   if (!history || history.messages.length === 0) return null;
 
-  const title = await dispatchTitle(
+  const conv = conversations.get(id);
+  const plan = titlePlan(
+    conv ? { provider: conv.provider, model: conv.model } : undefined,
     activeProvider(),
+  );
+  let runnerModel = model;
+  if (!model && plan.resolvePin) {
+    try {
+      runnerModel = resolveModel(
+        plan.resolvePin.model,
+        plan.resolvePin.provider,
+      );
+    } catch {
+      // The chat's provider is disconnected (e.g. its local endpoint is
+      // gone): no title rather than silently rerouting onto a provider the
+      // chat never chose — the caller falls back to truncation.
+      return null;
+    }
+  }
+
+  const title = await dispatchTitle(
+    plan.provider,
     buildExcerpt(history.messages),
-    titleRunners(model),
+    titleRunners(runnerModel, plan.claudeModelId),
   );
   if (!title) return null;
   renameConversation(id, title);

--- a/packages/runtime/src/transport/provider-routes.ts
+++ b/packages/runtime/src/transport/provider-routes.ts
@@ -221,6 +221,18 @@ async function handleAuthAction(
       json(ctx.res, 200, { ok: true });
       return;
     }
+    // Attribution for the runtime.log: logout is the ONLY writer that clears a
+    // provider's credential — and for openai-compatible it ALSO forgets the
+    // custom endpoint config (auth/login.ts). A wiped endpoint with no user
+    // sign-out means some caller hit this route; this line is what names the
+    // moment in the log instead of the wipe being silent.
+    console.log(
+      `[auth] logout requested for ${provider} (POST /auth/${provider}/logout)${
+        provider === "openai-compatible"
+          ? " — clearing the custom endpoint config too"
+          : ""
+      }`,
+    );
     await logout(provider);
     json(ctx.res, 200, { ok: true });
   } catch (e) {

--- a/packages/sdk/src/modules/turns/turn-sink.ts
+++ b/packages/sdk/src/modules/turns/turn-sink.ts
@@ -117,6 +117,22 @@ export class TurnSink {
     }
     switch (classifyFrame(this.turnId, ev.turnId)) {
       case "foreign":
+        // Narrow adoption for a stamped TERMINAL frame with no adopted id
+        // after our send was ACCEPTED: a turn that fails before executing
+        // (e.g. a pinned local model whose endpoint was disconnected) may
+        // reach us error-first on a server that doesn't echo the user
+        // message on that path. The one-turn-per-conversation gate makes it
+        // ours in that state — dropping it stranded the turn spinning
+        // forever with no error and no reconnect card. Same rationale as
+        // `classifyRunningSync`'s `adopt`.
+        if (
+          (ev.type === "error" || ev.type === "done") &&
+          this.accepted &&
+          this.turnId === undefined
+        ) {
+          this.turnId = ev.turnId;
+          break;
+        }
         return; // another turn's frame — never fold it into ours
       case "boundary":
         // A new turn owns the stream: OUR turn is over and its terminal frame

--- a/packages/sdk/src/modules/turns/turn-sink.ts
+++ b/packages/sdk/src/modules/turns/turn-sink.ts
@@ -39,10 +39,9 @@ export class TurnSink {
   private sawRunning = false;
   private sawSync = false;
   private settling = false;
-  /** Turn mode: the send was accepted — gates resync turn-id adoption. */
+  /** Turn mode: the send was accepted — gates resync turn-id adoption, and is
+   *  the pre-settled poll's arming trigger. */
   private accepted = false;
-  /** Turn mode: a FRESH idle sync was seen — half the pre-settled poll trigger. */
-  private sawFreshIdleSync = false;
   /** The pre-settled poll timer, live only while armed (see `maybeArmPresettlePoll`). */
   private presettleTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -199,7 +198,8 @@ export class TurnSink {
         this.o.output.confirmIdle?.(this.o.agentPath, this.o.sessionKey);
         this.o.stop();
       } else {
-        this.sawFreshIdleSync = true;
+        // A fresh idle sync in turn mode: the turn may have completed before we
+        // attached. Reinforce the poll (already armed by an accepted send).
         this.maybeArmPresettlePoll();
       }
     } else if (this.o.mode === "turn" || this.sawRunning) {
@@ -325,14 +325,23 @@ export class TurnSink {
   }
 
   /**
-   * Arm the pre-settled poll when BOTH triggers hold — a fresh idle sync was
-   * seen AND the send is accepted — and no evidence/settle already closed the
-   * question. Idempotent: a second call while armed is a no-op. Absent
-   * `presettledPollMs` (observer mode) disables the poll entirely.
+   * Arm the pre-settled poll once the send is ACCEPTED — the poll is the
+   * backstop that settles a turn whose terminal frame we never received on the
+   * stream. It used to also require a fresh idle sync, but that left a hole: a
+   * turn that fails INSTANTLY (fail-before-execute — a disconnected local
+   * model) has its terminal frame published and the replay buffer cleared
+   * before our subscription attaches, and a flaky SSE hop can then deliver NO
+   * frame at all — no sync, so the poll never armed and the turn spun until the
+   * ~6-minute reconnect budget gave up. Arming on acceptance alone closes that:
+   * the poll is CONCLUSIVE-ONLY (`presettleFromHistory` settles solely on a real
+   * reply for our turnId, or a guard-accepted trailing reply), so a turn that is
+   * genuinely still running finds no reply and simply re-arms — and a running
+   * sync cancels the poll outright (`markRunning`), so a normal turn never
+   * pays for it. Idempotent; disabled in observer mode (no `presettledPollMs`).
    */
   private maybeArmPresettlePoll(): void {
     if (this.o.presettledPollMs === undefined) return;
-    if (!this.accepted || !this.sawFreshIdleSync) return;
+    if (!this.accepted) return;
     if (this.sawRunning || this.settling || this.s.settled) return;
     if (this.presettleTimer !== undefined) return;
     this.presettleTimer = setTimeout(() => {

--- a/packages/sdk/src/modules/turns/turn-stream.test.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.test.ts
@@ -1712,3 +1712,75 @@ test("dispose clears an armed pre-settled poll — teardown leaves nothing pendi
   expect(historyCalls).toBe(0);
   expect(sink.settled).toBe(false);
 });
+
+// A turn that fails BEFORE executing may reach us ERROR-FIRST: an older
+// runtime's pre-execution failure path (e.g. a pinned local model whose
+// endpoint was disconnected) published only the stamped `error` frame — no
+// nonce echo — so the sink had no adopted id, classified the error as foreign,
+// and dropped it: the spinner never settled, no error rendered, no reconnect
+// card. Once the send is ACCEPTED, a stamped terminal frame with no adopted id
+// is ours (the one-turn-per-conversation gate).
+test("an accepted send adopts a stamped error-first frame (failed turn settles, never spins)", () => {
+  const { items, sessionStatuses, output } = makeOutput();
+  const sink = new TurnSink({
+    agentPath: "Houston/Bo",
+    sessionKey: "activity-error-first",
+    output,
+    mode: "turn",
+    nonce: "n",
+    prompt: "good",
+    stop: () => {},
+    reloadHistory: async () => [],
+    historyGuard: () => false,
+    presettledPollMs: 10_000,
+  });
+
+  sink.sendAccepted();
+  sink.onFrame(sync(false, "", 0));
+  sink.onFrame({
+    type: "error",
+    data: { message: "No local model configured." },
+    turnId: "t-fail",
+    seq: 1,
+  });
+  sink.dispose();
+
+  expect(sink.settled).toBe(true);
+  expect(sessionStatuses.at(-1)).toBe("error");
+  // The message reaches the feed — this is what the reconnect-card pattern scans.
+  expect(
+    items.some(
+      (i) =>
+        typeof i.data === "string" &&
+        i.data.includes("No local model configured"),
+    ),
+  ).toBe(true);
+});
+
+test("a stamped error BEFORE the send is accepted stays foreign (replay tail is never adopted)", () => {
+  const { output } = makeOutput();
+  const sink = new TurnSink({
+    agentPath: "Houston/Bo",
+    sessionKey: "activity-error-preaccept",
+    output,
+    mode: "turn",
+    nonce: "n",
+    prompt: "good",
+    stop: () => {},
+    reloadHistory: async () => [],
+    historyGuard: () => false,
+    presettledPollMs: 10_000,
+  });
+
+  // No sendAccepted: a stamped error in the pre-send replay tail belongs to a
+  // PREVIOUS turn — adopting it would wrongly fail the turn we haven't sent.
+  sink.onFrame({
+    type: "error",
+    data: { message: "stale failure from an earlier turn" },
+    turnId: "t-old",
+    seq: 1,
+  });
+  sink.dispose();
+
+  expect(sink.settled).toBe(false);
+});

--- a/packages/sdk/src/modules/turns/turn-stream.test.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.test.ts
@@ -1701,7 +1701,8 @@ test("dispose clears an armed pre-settled poll — teardown leaves nothing pendi
     presettledPollMs: 20,
   });
 
-  // Arm the poll: send accepted + a fresh idle sync are its two triggers.
+  // Arm the poll: an accepted send is its trigger (a fresh idle sync only
+  // reinforces it).
   sink.sendAccepted();
   sink.onFrame(sync(false, "", 0));
   // Tear down BEFORE the 20ms timer would fire.
@@ -1711,6 +1712,82 @@ test("dispose clears an armed pre-settled poll — teardown leaves nothing pendi
   // The timer was cleared: history was never reloaded, nothing settled.
   expect(historyCalls).toBe(0);
   expect(sink.settled).toBe(false);
+});
+
+// THE STUCK-CHAT REGRESSION: a turn that fails instantly (fail-before-execute,
+// a disconnected local model) publishes its terminal error and clears the pod's
+// replay buffer before our subscription attaches; a flaky SSE hop can then
+// deliver NO frame at all. With the poll gated on a fresh idle sync this hung
+// until the ~6-minute reconnect budget. Now an accepted send alone arms the
+// conclusive poll, which settles from the persisted providerError reply.
+test("accepted send with ZERO frames delivered still settles from history (stuck-chat fix)", async () => {
+  const { items, sessionStatuses, output } = makeOutput();
+  const sink = new TurnSink({
+    agentPath: "Houston/Bo",
+    sessionKey: "activity-zero-frames",
+    output,
+    mode: "turn",
+    nonce: "n",
+    prompt: "everything is okey?",
+    stop: () => {},
+    reloadHistory: async (): Promise<ChatMessage[]> => [
+      { role: "user", content: "everything is okey?", ts: 1 },
+      {
+        role: "assistant",
+        content: "",
+        ts: 2,
+        providerError: {
+          kind: "unknown",
+          provider: "openai-compatible",
+          raw_excerpt: "No local model configured.",
+        },
+      },
+    ],
+    historyGuard: (messages) =>
+      messages.filter((m) => m.role === "user").at(-1)?.content ===
+      "everything is okey?",
+    presettledPollMs: 20,
+  });
+
+  sink.sendAccepted();
+  // No onFrame — the subscription delivered nothing at all.
+  await waitFor(() => sink.settled);
+
+  expect(sink.settled).toBe(true);
+  expect(sessionStatuses.at(-1)).toBe("error");
+  expect(items.some((i) => i.feed_type === "provider_error")).toBe(true);
+});
+
+// The poll must NOT false-settle a turn that is genuinely still running: with
+// no reply persisted yet, the conclusive poll finds nothing and re-arms.
+test("accepted send that is still running does not false-settle from the poll", async () => {
+  let historyCalls = 0;
+  const { output } = makeOutput();
+  const sink = new TurnSink({
+    agentPath: "Houston/Bo",
+    sessionKey: "activity-still-running",
+    output,
+    mode: "turn",
+    nonce: "n",
+    prompt: "slow one",
+    stop: () => {},
+    reloadHistory: async (): Promise<ChatMessage[]> => {
+      historyCalls++;
+      // History ends on the user prompt — no reply yet (the turn is running).
+      return [{ role: "user", content: "slow one", ts: 1 }];
+    },
+    historyGuard: (messages) =>
+      messages.filter((m) => m.role === "user").at(-1)?.content === "slow one",
+    presettledPollMs: 15,
+  });
+
+  sink.sendAccepted();
+  // Let the poll fire a couple of times against a reply-less history.
+  await new Promise((r) => setTimeout(r, 80));
+
+  expect(sink.settled).toBe(false);
+  expect(historyCalls).toBeGreaterThan(0); // it polled, but never settled
+  sink.dispose();
 });
 
 // A turn that fails BEFORE executing may reach us ERROR-FIRST: an older


### PR DESCRIPTION
Follow-up to #978 (merged mid-stream, so this ships separately).

## The repro (reported in testing)

Start a chat on the local model, disconnect it in AI Models, send a follow-up: the chat shows the raw runtime refusal ("No local model configured. Set a base URL and model for the OpenAI-compatible provider.") and **no reconnect card**.

Root cause: that refusal emits no `AuthRequired` event (same as the TS engine's "No provider connected" refusal), and the feed's auth-signal patterns didn't include it — so the only trigger for the in-chat reconnect card never fired.

## Fixes

- **Feed pattern** (`provider-auth-feed.ts`): recognize the local-model refusal. The card's existing `openai-compatible` special case then opens the LocalModelDialog (never OAuth), and the confirm probe correctly requires a confirmed `unauthenticated` before showing.
- **Chat model picker** (`model-picker.ts`): an `unknown` probe (engine unreachable / cold pod waking) maps to the neutral `checking` state instead of collapsing to "Not connected" — the #342 flicker, reachable in cloud builds now that the adapter reports `unknown` honestly.
- **First-load gating** (`use-houston-init.ts`): `claudeAvailable` uses appears-connected, so an unknown startup probe no longer degrades gating for a provider that is connected server-side.
- **Mid-turn local endpoint failure** (`provider-error-cards/transient.tsx`): `network_unreachable` for `openai-compatible` gets dedicated copy ("make sure the model app is open and its server is running") instead of the provider-API "check your internet" text — en/es/pt, no status-page button (already suppressed for uncatalogued providers).

Also repairs the stale curated-order expectation in `chat-model-picker-map.test.mjs` (Fable 5 was promoted ahead of Opus 4.8 on main; the `.mjs` test sits outside the `tests/` glob, so it rotted silently — pre-existing failure, confirmed on clean HEAD).

## Tests

New cases: the refusal pattern (verbatim string), `unknown` → `checking` picker mapping (plus confirmed states unchanged). All gates green: app tsgo + 1662 node tests + the out-of-glob `.mjs` picker tests, `check-locales` in sync, Biome clean.

---

## Second round (from live-repro diagnosis)

Testing surfaced that the typed card still didn't appear when the endpoint died **mid-conversation**, plus two more defects found while tracing the session files:

- **Classifier gap (runtime)**: the reconnect-card typing only covered a brand-new conversation (the `getConversation` throw in `chat.ts`). On a CACHED conversation — every message after the first — the same "No local model configured" / "No provider connected" throw comes from `execTurn`'s `resolveModel` and fell through `classifyProviderError` to `unknown`: generic error card, no reconnect flow, no auto-resume. Both guard messages are now `NO_CREDENTIALS_PATTERNS` → `unauthenticated`/`no_credentials`, so the cached path gets the identical typed card and the undelivered-prompt auto-resume.
- **Titles ran on the wrong provider (runtime)**: `summarizeTitle` dispatched on the agent-wide ACTIVE provider, so a local-model chat titled through a full Claude one-shot — a backend the chat never picked, burning a real Anthropic call. Titles now route on the conversation's own provider (`titlePlan`, pure + unit-tested); a disconnected chat provider yields no title (truncation fallback) instead of rerouting. The Claude title one-shot also carries the title instruction in the PROMPT itself: the spawned CLI has been observed running its claude_code preset despite a custom string `systemPrompt`, answering the excerpt so the first line of the answer became the board title ("Yes, I have image capabilities. I…").
- **Silent endpoint wipes now attributed (runtime + host)**: `custom-endpoint.json` was found wiped to `{}` mid-session with no user sign-out. Every wiper funnels through the runtime's `logout("openai-compatible")` or the host's org-share clear, and both were silent. Each now logs loudly, so the next wipe names its caller in the runtime log.

Tests: classifier cases for both guard messages, `titlePlan` routing (local chat titles on the local model, anthropic chat keeps its own model, uncached falls back to active), title-instruction-in-prompt. Runtime 693 + host 971 green, Biome clean, workspace typecheck clean.
