### PR TITLE
fix(host): cover all delivery paths of the recursive-watcher ENOENT race

### DIFF
--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -216,6 +216,15 @@ process.on("uncaughtException", (err) => {
   console.error("[local-host] uncaughtException (staying up):", err);
 });
 process.on("unhandledRejection", (reason) => {
+  // Same benign-race demotion as above: Node's promise-based watcher
+  // internals can surface the ENOENT as a rejection instead of a throw.
+  if (isBenignRecursiveWatchRace(reason)) {
+    console.warn(
+      "[local-host] transient fs-watch race (ignored):",
+      (reason as Error).message,
+    );
+    return;
+  }
   console.error("[local-host] unhandledRejection (staying up):", reason);
 });
 

--- a/packages/host/src/store-sync/daemon.ts
+++ b/packages/host/src/store-sync/daemon.ts
@@ -6,6 +6,7 @@ import {
   type ObjectStore,
   syncBack,
 } from "@houston/runtime-client/object-sync";
+import { isBenignRecursiveWatchRace } from "../watch/watcher-race";
 
 const DEFAULT_QUIET_MS = 3_000;
 const DEFAULT_INTERVAL_MS = 300_000;
@@ -86,6 +87,14 @@ export class StoreSyncDaemon {
         this.markDirty(),
       );
       this.watcher.on("error", (err) => {
+        // The Linux recursive-watcher ENOENT race on a transient dir (see
+        // watch/watcher-race.ts) is harmless AND recoverable — the watcher
+        // keeps serving events, so closing it here would silently degrade
+        // reactivity to periodic-only over noise. Log-and-keep instead.
+        if (isBenignRecursiveWatchRace(err)) {
+          this.opts.log("[store-sync] transient fs-watch race (watcher kept)");
+          return;
+        }
         this.opts.log(
           "[store-sync] filesystem watcher failed; using periodic sync",
           err,


### PR DESCRIPTION
Follow-up to #970, caught by checking [issue 7614029702](https://houston-cd.sentry.io/issues/7614029702/) after the fix rolled: it received an event at 16:03 UTC today on `engine-pod@9c03247c` — a build that INCLUDES #970. The demotion only covered `uncaughtException`; the race has two more delivery paths:

1. **`unhandledRejection`** — Node's promise-based watcher internals can surface the ENOENT as a rejection instead of a synchronous throw. Same narrow demotion added to that handler.
2. **The FSWatcher `error` event** — the store-sync daemon's handler treated ANY watcher error as fatal: log-as-error (→ Sentry event) AND close the watcher, permanently degrading to periodic-only sync. Over this benign, recoverable race that's both noise and a silent reactivity downgrade. The daemon now recognizes the race, logs an info breadcrumb, and KEEPS the watcher; every other watcher error keeps the loud log + periodic fallback exactly as before.

Same classifier as #970 (`isBenignRecursiveWatchRace`, unchanged, already unit-tested against the production event shape). Host suite 972 passing, typecheck + Biome clean.