### PR TITLE
fix(runtime-client): tolerate files vanishing mid-walk in syncBack

### DIFF
--- a/packages/runtime-client/src/object-sync/hydrate.test.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.test.ts
@@ -123,6 +123,44 @@ test("an unchanged workspace uploads nothing and remains in the manifest", async
   expect(result.manifest).toEqual(manifest);
 });
 
+test("a file deleted mid-walk is reconciled as deleted, not a failed sync", async () => {
+  const { storeRoot, store, work } = setup();
+  seed(storeRoot, PREFIX, {
+    "workspace/a.txt": "a",
+    "workspace/b.txt": "b",
+    "workspace/c.txt": "c",
+  });
+  const manifest = await hydrate(store, PREFIX, work);
+  for (const name of ["a.txt", "b.txt", "c.txt"]) {
+    writeFileSync(join(work, "workspace", name), `changed-${name}`);
+  }
+  // The first upload deletes every other local file — whichever file the walk
+  // visits first, the rest vanish between the walk and their stat/read, the
+  // exact race an agent rewriting session files during a sync pass produces.
+  let firstUpload = true;
+  const racing = {
+    list: (prefix: string) => store.list(prefix),
+    download: (key: string, dest: string) => store.download(key, dest),
+    upload: (src: string, key: string) => {
+      if (firstUpload) {
+        firstUpload = false;
+        for (const name of ["a.txt", "b.txt", "c.txt"]) {
+          const abs = join(work, "workspace", name);
+          if (abs !== src) rmSync(abs);
+        }
+      }
+      return store.upload(src, key);
+    },
+    delete: (key: string) => store.delete(key),
+  };
+  const result = await syncBack(racing, PREFIX, work, manifest);
+  expect(result.uploaded.length).toBe(1);
+  expect(result.deleted.length).toBe(2);
+  expect(result.manifest.size).toBe(1);
+  const remaining = await store.list(PREFIX);
+  expect(remaining.length).toBe(1);
+});
+
 test("symlinks created locally are never persisted", async () => {
   const { storeRoot, store, work } = setup();
   seed(storeRoot, PREFIX, { "workspace/a.txt": "a" });

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -158,10 +158,24 @@ export async function syncBack(
   for (const rel of await walkFiles(dir, dir)) {
     if (excluded(rel, excludes)) continue;
     const abs = join(dir, ...rel.split("/"));
-    const fileStat = await stat(abs);
-    if (!fileStat.isFile()) continue;
-    totalBytes += fileStat.size;
-    const hash = sha256(await readFile(abs));
+    // The agent keeps writing during a sync pass, so a walked file may vanish
+    // before it is read (runtime session files are rewritten constantly). A
+    // vanished file is indistinguishable from one deleted before the walk:
+    // leave it out of the next manifest and let the delete pass reconcile the
+    // store, instead of aborting the whole pass mid-upload.
+    let buf: Buffer;
+    let size: number;
+    try {
+      const fileStat = await stat(abs);
+      if (!fileStat.isFile()) continue;
+      size = fileStat.size;
+      buf = await readFile(abs);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw err;
+    }
+    totalBytes += size;
+    const hash = sha256(buf);
     nextManifest.set(rel, hash);
     if (manifest.get(rel) !== hash) {
       await store.upload(abs, prefix ? posix.join(prefix, rel) : rel);


### PR DESCRIPTION
Fixes [issue 7614630766](https://houston-cd.sentry.io/issues/7614630766/): `ENOENT: no such file or directory, stat '/data/claude-login/sessions/34.json'` in `syncBack`, 6 events / 3 users on managed-cloud (latest on `engine-pod@c24508f9`).

Same ENOENT-race family as #970/#981, but on the store-sync **write-back** path rather than the watcher: `syncBack` walks the tree up front, then stat+reads each file — and the agent keeps writing while a sync pass is in flight, so a walked file (runtime session files are rewritten constantly) can vanish before its stat. The ENOENT aborted the whole pass mid-upload: the daemon logged "sync failed; will retry" (→ Sentry event) and threw away the partial pass; on the per-turn runtime path (`turn/server.ts`) the same race would fail the turn's sync outright.

A file that vanishes mid-walk is indistinguishable from one deleted before the walk, and the delete pass already handles that case: it drops manifest entries with no local file and deletes them from the store. So the fix is to skip the vanished file (ENOENT on stat OR read) and let that existing pass reconcile — the pass now completes, uploads everything that still exists, and converges in one run instead of aborting and hoping the retry wins the race. Every other stat/read error still propagates: a failed sync is data loss the owning lifecycle must surface.

New test reproduces the race deterministically (first upload deletes the other walked files) and asserts the pass completes with the vanished files reconciled as deletions. runtime-client 120 + host 972 passing, typecheck + Biome clean.