### PR TITLE
feat(host): build identity on /v1/version + pod-level /activity busy probe

### DIFF
--- a/.github/workflows/engine-pod-image.yml
+++ b/.github/workflows/engine-pod-image.yml
@@ -91,6 +91,7 @@ jobs:
             --target engine-pod \
             --build-arg "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" \
             --build-arg "SENTRY_RELEASE=engine-pod@${{ github.sha }}" \
+            --build-arg "BUILD_SHA=${{ github.sha }}" \
             -f selfhost/Dockerfile \
             -t "$SHA_TAG" -t "$POC_TAG" \
             .

--- a/packages/host/src/routes/agents-activity.test.ts
+++ b/packages/host/src/routes/agents-activity.test.ts
@@ -15,7 +15,7 @@ import { type ControlPlaneDeps, createControlPlaneServer } from "../server";
 import { MemoryWorkspaceStore } from "../store/memory";
 import { MemoryVfs } from "../vfs";
 import { workspaceRoot } from "./agent-data";
-import { handleAgents } from "./agents";
+import { handleAgents, podActivityStatus } from "./agents";
 
 /**
  * GET /agents/:id/activity — gateway idle-sleep probe. It reports whether any
@@ -241,6 +241,164 @@ test("unknown or unauthorized agents follow the existing authz statuses", async 
 
   const forbidden = await activity("bob");
   expect(forbidden.response.status).toBe(403);
+});
+
+// --- GET /activity — the pod-level aggregate (server.ts) ---------------------
+//
+// The control plane's pre-roll busy probe: a single answer for the whole pod,
+// no agent enumeration on the caller's side, so busy-aware engine rolls can
+// defer a restart that would kill an in-flight turn. Aggregation semantics are
+// unit-tested against podActivityStatus; the HTTP test below pins auth and
+// the counter wiring (the probe lives outside /agents/, so it never counts
+// itself).
+
+test("pod probe: a genuinely idle host answers busy:false", async () => {
+  expect(await podActivityStatus(deps)).toEqual({
+    busy: false,
+    activeRequests: 0,
+    runningRoutineRuns: 0,
+    busyAgents: 0,
+  });
+});
+
+test("pod probe: any agent with an active turn flips the pod busy", async () => {
+  channel.busyResult = true;
+  expect(await podActivityStatus(deps)).toEqual({
+    busy: true,
+    activeRequests: 0,
+    runningRoutineRuns: 0,
+    busyAgents: 1,
+  });
+});
+
+test("pod probe: sums running routine runs across EVERY workspace, not one user's", async () => {
+  // alice's agent has a running run; so does bob's, in a different workspace —
+  // engine pods are single-tenant, so the pod answer spans the whole store.
+  await seedRun(createRoutineRun(routine, "run-1", "2026-01-01T00:00:00.000Z"));
+  const bobWs = await store.getOrCreatePersonalWorkspace("bob");
+  const bobAgent = await store.createAgent({
+    workspaceId: bobWs.id,
+    name: "BobHelper",
+  });
+  await saveRoutineRuns(vfs, workspaceRoot(bobWs, bobAgent), [
+    createRoutineRun(routine, "run-2", "2026-01-01T00:00:00.000Z"),
+  ]);
+
+  expect(await podActivityStatus(deps)).toEqual({
+    busy: true,
+    activeRequests: 0,
+    runningRoutineRuns: 2,
+    busyAgents: 2,
+  });
+});
+
+test("pod probe: held /agents/* requests count once, with NO self-subtraction", async () => {
+  // Unlike the per-agent probe (which is itself a counted /agents/* request
+  // and subtracts one), /activity is outside the counted prefix — a count of
+  // 1 means one genuinely held per-agent request, and the pod is busy.
+  deps.agentRequestCount = () => 1;
+  expect(await podActivityStatus(deps)).toEqual({
+    busy: true,
+    activeRequests: 1,
+    runningRoutineRuns: 0,
+    busyAgents: 0,
+  });
+});
+
+test("pod probe: an unprobeable agent reads busy, never a false idle", async () => {
+  // No channel wired for the workspace's runtime → conservative busy.
+  expect(await podActivityStatus({ ...deps, channels: {} })).toEqual({
+    busy: true,
+    activeRequests: 0,
+    runningRoutineRuns: 0,
+    busyAgents: 1,
+  });
+
+  // A probe that throws (runtime unreachable) counts the same way.
+  channel.busy = async () => {
+    throw new Error("runtime unreachable");
+  };
+  expect(await podActivityStatus(deps)).toEqual({
+    busy: true,
+    activeRequests: 0,
+    runningRoutineRuns: 0,
+    busyAgents: 1,
+  });
+});
+
+test("GET /activity over HTTP: 401 unauthenticated; a held per-agent stream keeps the pod busy", async () => {
+  deps.verifier = {
+    async verify(bearer: string) {
+      return bearer === "pod-token" ? { userId: "alice" } : null;
+    },
+  };
+  // A dispatch that streams and never ends on its own — an open per-agent SSE
+  // subscription, exactly what a roll must not restart the pod under.
+  let release: (() => void) | undefined;
+  channel.dispatch = async (
+    _ctx: ChannelCtx,
+    _method: string,
+    _rest: string,
+    _url: URL,
+    _req: IncomingMessage,
+    streamRes: ServerResponse,
+  ) => {
+    streamRes.writeHead(200, { "content-type": "text/event-stream" });
+    streamRes.write(": hb\n\n");
+    await new Promise<void>((resolve) => {
+      release = () => {
+        streamRes.end();
+        resolve();
+      };
+    });
+  };
+  const server = createControlPlaneServer(deps);
+  await new Promise<void>((r) => {
+    server.listen(0, "127.0.0.1", () => r());
+  });
+  const { port } = server.address() as AddressInfo;
+  const base = `http://127.0.0.1:${port}`;
+  const auth = { Authorization: "Bearer pod-token" };
+  try {
+    expect((await fetch(`${base}/activity`)).status).toBe(401);
+
+    // Idle, and the probe itself never counts (it is not an /agents/* request).
+    const idle = await fetch(`${base}/activity`, { headers: auth });
+    expect(idle.status).toBe(200);
+    expect(await idle.json()).toEqual({
+      busy: false,
+      activeRequests: 0,
+      runningRoutineRuns: 0,
+      busyAgents: 0,
+    });
+
+    const held = fetch(
+      `${base}/agents/${encodeURIComponent(agentId)}/conversations/c1/events`,
+      { headers: auth },
+    );
+    await vi.waitFor(() => {
+      expect(release).toBeDefined();
+    });
+    const probe = await fetch(`${base}/activity`, { headers: auth });
+    expect(await probe.json()).toMatchObject({
+      busy: true,
+      activeRequests: 1,
+    });
+
+    release?.();
+    await (await held).text();
+    // The stream ended → its count is released and the pod reads idle again.
+    await vi.waitFor(async () => {
+      const after = await fetch(`${base}/activity`, { headers: auth });
+      expect(await after.json()).toMatchObject({
+        busy: false,
+        activeRequests: 0,
+      });
+    });
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((r) => server.close(() => r(null)));
+  }
 });
 
 test("the real server wires the counter: a held stream reads busy over HTTP", async () => {

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -12,10 +12,11 @@ import {
 } from "../auth/acting";
 import { checkPublicHttpsEndpoint } from "../custom-endpoint-validation";
 import type { Agent, UserId, Workspace } from "../domain/types";
-import { AgentNameConflictError } from "../ports";
+import { AgentNameConflictError, type RuntimeChannel } from "../ports";
 import { isApiKeyProvider } from "../providers";
 import { handleAttachments } from "../turn/attachments";
 import { handleFiles } from "../turn/files";
+import type { Vfs } from "../vfs";
 import { handleActionApprovalsDispatch } from "./action-approvals";
 import { stampTurnContributor } from "./activity-attribution";
 import {
@@ -47,6 +48,30 @@ function withAgentDir(deps: AgentRouteDeps, ws: Workspace, agent: Agent) {
   return deps.agentDir ? { ...agent, dir: deps.agentDir(ws, agent) } : agent;
 }
 
+/**
+ * One agent's turn/routine busy inputs — the shared core of the per-agent
+ * probe below and the pod-level `GET /activity` aggregate. The caller resolves
+ * the channel and the vfs first (the two probes answer their absence
+ * differently: 503 per-agent, conservative busy at pod level).
+ */
+async function agentBusyInputs(
+  deps: AgentRouteDeps,
+  vfs: Vfs,
+  channel: RuntimeChannel,
+  ctx: { workspace: Workspace; agent: Agent },
+): Promise<{ turnBusy: boolean; runningRoutineRuns: number }> {
+  const paths = deps.paths ?? DEFAULT_PATHS;
+  const runs = await loadRoutineRuns(
+    vfs,
+    paths.agentRoot(ctx.workspace, ctx.agent),
+  );
+  const runningRoutineRuns = runs.items.filter(
+    (run) => run.status === "running",
+  ).length;
+  const turnBusy = await channel.busy(ctx);
+  return { turnBusy, runningRoutineRuns };
+}
+
 async function activityStatus(
   deps: AgentRouteDeps,
   ctx: { workspace: Workspace; agent: Agent },
@@ -55,15 +80,12 @@ async function activityStatus(
   if (!channel) return null;
   if (!deps.vfs) return { error: "agent data not configured" as const };
 
-  const paths = deps.paths ?? DEFAULT_PATHS;
-  const runs = await loadRoutineRuns(
+  const { turnBusy, runningRoutineRuns } = await agentBusyInputs(
+    deps,
     deps.vfs,
-    paths.agentRoot(ctx.workspace, ctx.agent),
+    channel,
+    ctx,
   );
-  const runningRoutineRuns = runs.items.filter(
-    (run) => run.status === "running",
-  ).length;
-  const turnBusy = await channel.busy(ctx);
   const runtime = channel.runtimeStatus
     ? await channel.runtimeStatus(ctx)
     : "unknown";
@@ -80,6 +102,57 @@ async function activityStatus(
     runtime,
     runningRoutineRuns,
     activeRequests,
+  };
+}
+
+/**
+ * Pod-level busy aggregate for `GET /activity` (server.ts): every agent in
+ * every workspace on this host — engine pods are single-tenant, so the
+ * store-wide enumeration IS the pod's population. The control plane's
+ * pre-roll probe (same parsing rule as the waker's idle sweep) treats
+ * anything but a literal `busy: false` as busy, so `false` must mean
+ * provably idle: an agent whose workspace has no channel wired, whose vfs is
+ * unconfigured, or that throws while probed counts as busy rather than
+ * failing the whole answer.
+ */
+export async function podActivityStatus(deps: AgentRouteDeps): Promise<{
+  busy: boolean;
+  activeRequests: number;
+  runningRoutineRuns: number;
+  busyAgents: number;
+}> {
+  // The counter is pod-global (server.ts counts /agents/*-prefixed requests),
+  // so read it ONCE — and unlike the per-agent probe above, /activity is not
+  // under /agents/, so it never counts itself: no self-subtraction here.
+  const activeRequests = deps.agentRequestCount ? deps.agentRequestCount() : 0;
+  let runningRoutineRuns = 0;
+  let busyAgents = 0;
+  for (const workspace of await deps.store.listWorkspaces()) {
+    const channel = channelFor(deps, workspace);
+    for (const agent of await deps.store.listAgents(workspace.id)) {
+      if (!channel || !deps.vfs) {
+        busyAgents++;
+        continue;
+      }
+      try {
+        const { turnBusy, runningRoutineRuns: running } = await agentBusyInputs(
+          deps,
+          deps.vfs,
+          channel,
+          { workspace, agent },
+        );
+        runningRoutineRuns += running;
+        if (turnBusy || running > 0) busyAgents++;
+      } catch {
+        busyAgents++; // an unprobeable agent must not read as idle
+      }
+    }
+  }
+  return {
+    busy: busyAgents > 0 || activeRequests > 0,
+    activeRequests,
+    runningRoutineRuns,
+    busyAgents,
   };
 }
 

--- a/packages/host/src/server.test.ts
+++ b/packages/host/src/server.test.ts
@@ -1,6 +1,7 @@
 import type { Server } from "node:http";
 import type { Capabilities } from "@houston/protocol";
-import { afterAll, beforeAll, expect, test } from "vitest";
+import { afterAll, beforeAll, expect, test, vi } from "vitest";
+import { version as HOST_VERSION } from "../package.json";
 import { SingleUserVerifier } from "./auth/verify";
 import { ProxyChannel, type RuntimeProxy } from "./channel/proxy";
 import { MemoryCredentialStore } from "./credentials/store";
@@ -647,6 +648,31 @@ test("/v1/version and /v1/capabilities are public and serve the v3 contract", as
   expect(caps.profile).toBe("cloud");
   expect(caps.codeExecution).toBe("remote-sandbox");
   expect(caps.providers).toEqual(["openai-codex"]);
+});
+
+test("/v1/version serves the package semver and the baked build SHA (null when unbaked)", async () => {
+  // Unset/empty BUILD_SHA both read as "not baked" → build is null, never "".
+  vi.stubEnv("BUILD_SHA", "");
+  try {
+    const bare = (await (await fetch(`${base}/v1/version`)).json()) as {
+      version: string;
+      build: string | null;
+    };
+    expect(bare.version).toBe(HOST_VERSION);
+    expect(bare.build).toBeNull();
+
+    // The engine-pod image bakes the git sha (engine-pod-image.yml); the env
+    // is read per request, so the stub is visible without a server restart.
+    vi.stubEnv("BUILD_SHA", "deadbeefcafe");
+    const baked = (await (await fetch(`${base}/v1/version`)).json()) as {
+      version: string;
+      build: string | null;
+    };
+    expect(baked.version).toBe(HOST_VERSION);
+    expect(baked.build).toBe("deadbeefcafe");
+  } finally {
+    vi.unstubAllEnvs();
+  }
 });
 
 test("SingleUserVerifier: the boot token resolves to the owner; anything else is 401", async () => {

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -5,6 +5,10 @@ import {
   type ServerResponse,
 } from "node:http";
 import { type Capabilities, PROTOCOL_VERSION } from "@houston/protocol";
+// Build-time constant: esbuild inlines the JSON import into the bundle (and
+// vitest/tsx resolve it the same way), so the served version can never drift
+// from the package.json that shipped it.
+import { version as HOST_VERSION } from "../package.json";
 import type { SharedEndpointStore } from "./credentials/remote-shared-endpoint-store";
 import type {
   Agent,
@@ -33,7 +37,7 @@ import {
   type AgentConfigsDeps,
   handleAgentConfigs,
 } from "./routes/agent-configs";
-import { handleAgents } from "./routes/agents";
+import { handleAgents, podActivityStatus } from "./routes/agents";
 import { handleCatalog } from "./routes/catalog";
 import { handleSandboxCredential } from "./routes/credential";
 import {
@@ -232,8 +236,14 @@ async function handle(
   if (method === "GET" && path === "/v1/version") {
     return json(res, 200, {
       engine: "houston-host",
+      // The host package's semver — bumped when something meaningful ships,
+      // so the cloud update manager can compare pods against the current release.
+      version: HOST_VERSION,
       protocol: PROTOCOL_VERSION,
-      build: null,
+      // The exact git commit this image was built from (engine-pod-image.yml
+      // bakes BUILD_SHA into the engine-pod target); null on builds that don't
+      // set it (self-host, local dev).
+      build: process.env.BUILD_SHA || null,
       chatHistoryMigrated: deps.chatHistoryMigrated ?? false,
     });
   }
@@ -269,6 +279,16 @@ async function handle(
     return handleEventStream(deps.events, userId, res, (cb) =>
       req.on("close", cb),
     );
+  }
+
+  // Pod-level busy probe: one answer for the whole host, so the control
+  // plane can tell whether this pod is safe to restart (busy-aware engine
+  // rolls) without enumerating agents — the waker's idle sweep stays on the
+  // per-agent route. Deliberately NOT under /agents/ — the agentRequests
+  // counter below counts only that prefix, so this probe never counts itself
+  // (no self-subtraction, unlike the per-agent route).
+  if (method === "GET" && path === "/activity") {
+    return json(res, 200, await podActivityStatus(deps));
   }
 
   if (

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -8,6 +8,7 @@
     "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "skipLibCheck": true,
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": false
   },

--- a/selfhost/Dockerfile
+++ b/selfhost/Dockerfile
@@ -137,4 +137,11 @@ ENV SENTRY_DSN=$SENTRY_DSN \
     SENTRY_RELEASE=$SENTRY_RELEASE \
     SENTRY_ENVIRONMENT=production
 
+# The git commit this image was built from, served on /v1/version as `build`
+# so the cloud update manager can tell exactly what a pod is running. Baked by
+# engine-pod-image.yml; forks/local builds leave it empty → the host serves
+# null. The selfhost target deliberately gets none, same stance as Sentry.
+ARG BUILD_SHA=""
+ENV BUILD_SHA=$BUILD_SHA
+
 FROM host-base AS selfhost


### PR DESCRIPTION
Groundwork for update management on the managed fleet (PR 1 of the rollout sequence).

## What

- **`/v1/version` now identifies the build.** New `version` field (the host package semver, inlined into the bundle at build time so it can never drift from the shipped `package.json`) and a populated `build` field (the git SHA baked into the engine-pod image; `null` on self-host/local builds, exactly as before).
- **New pod-level `GET /activity` (authenticated).** One busy answer for the whole host: aggregates every workspace/agent's turn-busy + running routine runs, plus the live `/agents/*` request count. Lets the managed-cloud control plane ask "is this pod safe to restart?" without enumerating agents.
- **CI/Dockerfile:** `engine-pod-image.yml` passes `BUILD_SHA=${{ github.sha }}`; the `engine-pod` Dockerfile target bakes it as env (self-host target deliberately untouched, same stance as the Sentry args).

## Design notes

- Only a provably idle pod answers `busy: false` — an agent with no wired channel, unconfigured vfs, or a throwing probe counts as busy rather than failing the answer (the caller treats anything but a literal `false` as busy).
- The route deliberately lives **outside** `/agents/`, so the probe is never counted by the `agentRequests` counter and needs no self-subtraction (unlike the per-agent `/agents/:id/activity`, whose behavior is unchanged).
- Shared logic is extracted into `agentBusyInputs()`; the per-agent probe's responses are byte-identical to before.

## Tests

- `/v1/version`: semver served from package.json; `build` echoes `BUILD_SHA`, null when unset/empty.
- `/activity`: idle pod → `busy:false`; turn-busy agent, cross-workspace routine-run aggregation, held request counting with no self-subtraction, unprobeable-agent conservatism; over real HTTP: 401 unauthenticated, probe doesn't count itself, a held per-agent SSE stream flips the pod busy and releases cleanly.
- Full `@houston/host` suite: 977 passed / 2 pre-existing environmental failures (`parent-watchdog.process.test.ts` boot-timeout on the build machine, fails identically on a pristine tree). Repo-wide typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)