### PR TITLE
feat(app): send app-version header to the gateway + blocking required-update screen

### DIFF
--- a/app/src/components/shell/update-checker.tsx
+++ b/app/src/components/shell/update-checker.tsx
@@ -3,13 +3,36 @@ import { useTranslation } from "react-i18next";
 import houstonBlack from "../../assets/houston-black.svg";
 import houstonWhite from "../../assets/houston-icon-white.svg";
 import { useUpdateChecker } from "../../hooks/use-update-checker";
+import { isHostedGatewayEngine } from "../../lib/engine";
 import { selectUpdateNotes } from "../../lib/update-details";
 import { UpdateNotes } from "./update-notes";
+import { UpdateRequired } from "./update-required";
 
 export function UpdateChecker() {
   const { t, i18n } = useTranslation("shell");
-  const { status, installAndRelaunch, relaunchInstalledApp, dismiss } =
-    useUpdateChecker();
+  const {
+    status,
+    required,
+    installAndRelaunch,
+    relaunchInstalledApp,
+    dismiss,
+  } = useUpdateChecker();
+
+  // Hard floor: the hosted gateway refused this build, so gateway calls are
+  // failing 426 — replace the dismissible card with the blocking screen.
+  // Scoped to hosted-gateway builds: on a local/sidecar build every feature is
+  // served by the co-located host (the gateway is never on the request path),
+  // so even a stray floor signal must not lock the user out of local work.
+  if (required && isHostedGatewayEngine()) {
+    return (
+      <UpdateRequired
+        required={required}
+        status={status}
+        onInstall={installAndRelaunch}
+        onRelaunch={relaunchInstalledApp}
+      />
+    );
+  }
 
   if (status.state === "idle") return null;
 

--- a/app/src/components/shell/update-required.tsx
+++ b/app/src/components/shell/update-required.tsx
@@ -1,0 +1,164 @@
+import {
+  AlertCircle,
+  DownloadCloud,
+  ExternalLink,
+  Loader2,
+  RotateCw,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import houstonBlack from "../../assets/houston-black.svg";
+import houstonWhite from "../../assets/houston-icon-white.svg";
+import type { UpdateStatus } from "../../hooks/use-update-checker";
+import { osOpenUrl } from "../../lib/os-bridge";
+import {
+  currentAppVersion,
+  type UpdateRequiredSignal,
+} from "../../lib/update-floor";
+
+/**
+ * The hard-floor screen: the hosted gateway refused this build (app-update
+ * floor), so every gateway call is failing with 426 and the app is unusable
+ * until updated. A full-window, NON-dismissible overlay — unlike the
+ * UpdateChecker card there is no X and no way back — that drives the same
+ * updater flow the card does (install → progress → relaunch, via the shared
+ * useUpdateChecker instance in UpdateChecker, which renders this).
+ *
+ * When the updater has nothing to install (dev build, feed unreachable) the
+ * screen falls back to the gateway-provided `updateUrl`, and to a plain
+ * re-check when even that is absent — never a dead end without a button.
+ */
+export function UpdateRequired({
+  required,
+  status,
+  onInstall,
+  onRelaunch,
+}: {
+  required: UpdateRequiredSignal;
+  status: UpdateStatus;
+  onInstall: () => void;
+  onRelaunch: () => void;
+}) {
+  const { t } = useTranslation("shell");
+
+  const downloading = status.state === "downloading";
+  const ready = status.state === "ready";
+  const error = status.state === "error";
+  const relaunchOnly = ready || (error && status.phase === "relaunch");
+  const progress = downloading ? status.progress : null;
+  // `idle` here means the post-426 check found nothing to install (the hook
+  // kicks one on the first signal) — the updater can't serve, so fall back.
+  const updaterServes = status.state !== "idle";
+  const fallbackUrl = !updaterServes ? required.updateUrl : null;
+
+  const currentVersion = currentAppVersion();
+  const message = (() => {
+    if (downloading) {
+      return progress === null
+        ? t("updateChecker.downloading")
+        : t("updateChecker.downloadingProgress", { progress });
+    }
+    if (ready) return t("updateChecker.ready");
+    if (error && status.phase === "install")
+      return t("updateChecker.errorInstall");
+    if (error && status.phase === "relaunch")
+      return t("updateChecker.errorRelaunch");
+    return required.minVersion
+      ? t("updateRequired.description", {
+          currentVersion,
+          minVersion: required.minVersion,
+        })
+      : t("updateRequired.descriptionNoVersion", { currentVersion });
+  })();
+
+  const onAction = fallbackUrl
+    ? () => void osOpenUrl(fallbackUrl)
+    : relaunchOnly
+      ? onRelaunch
+      : onInstall;
+  const actionLabel = fallbackUrl
+    ? t("updateRequired.downloadAction")
+    : error
+      ? t("updateChecker.retryAction")
+      : relaunchOnly
+        ? t("updateChecker.relaunchAction")
+        : updaterServes
+          ? t("updateChecker.primaryAction")
+          : t("updateRequired.checkAction");
+
+  return (
+    <div
+      role="alertdialog"
+      aria-modal="true"
+      aria-label={t("updateRequired.cardLabel")}
+      aria-live={downloading ? "polite" : "assertive"}
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-ink/45 p-4"
+    >
+      <div className="w-[420px] max-w-full rounded-2xl border border-line bg-card p-6 text-card-text shadow-[0_16px_60px_rgba(0,0,0,0.16)]">
+        <div className="flex items-start gap-3">
+          <div className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-input ring-1 ring-line">
+            <img
+              src={houstonBlack}
+              alt=""
+              aria-hidden="true"
+              className="houston-update-logo-light size-8 object-contain"
+            />
+            <img
+              src={houstonWhite}
+              alt=""
+              aria-hidden="true"
+              className="houston-update-logo-dark hidden size-8 object-contain"
+            />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <h2 className="text-base font-semibold leading-tight">
+                {t("updateRequired.title")}
+              </h2>
+              {error && <AlertCircle className="size-4 shrink-0 text-danger" />}
+            </div>
+            <p className="mt-1 text-sm leading-snug text-ink-muted">
+              {message}
+            </p>
+          </div>
+        </div>
+
+        {required.minVersion && (
+          <div className="mt-4 flex items-center justify-center gap-2 rounded-xl bg-chip-subtle p-3 text-xs font-medium">
+            <span className="text-ink-muted">v{currentVersion}</span>
+            <span aria-hidden="true" className="text-ink-muted">
+              →
+            </span>
+            <span className="text-ink">v{required.minVersion}</span>
+          </div>
+        )}
+
+        {downloading && (
+          <div className="mt-4 h-1.5 overflow-hidden rounded-full bg-chip-subtle">
+            <div
+              className={`h-full rounded-full bg-action transition-[width] duration-200 ${progress === null ? "animate-pulse" : ""}`}
+              style={{ width: `${progress ?? 35}%` }}
+            />
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={onAction}
+          disabled={downloading}
+          className="mt-4 flex h-10 w-full items-center justify-center gap-2 rounded-full bg-action px-4 text-sm font-medium text-action-text transition-opacity hover:opacity-90 disabled:cursor-default disabled:opacity-70"
+        >
+          {downloading ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : fallbackUrl ? (
+            <ExternalLink className="size-4" />
+          ) : relaunchOnly ? (
+            <RotateCw className="size-4" />
+          ) : (
+            <DownloadCloud className="size-4" />
+          )}
+          {downloading ? t("updateChecker.installingAction") : actionLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/hooks/use-update-checker.ts
+++ b/app/src/hooks/use-update-checker.ts
@@ -2,9 +2,21 @@ import { check } from "@tauri-apps/plugin-updater";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { analytics } from "../lib/analytics";
 import {
+  getEngine,
+  isHostedGatewayEngine,
+  whenEngineReady,
+} from "../lib/engine";
+import {
   osCurrentAppBundlePath,
   osRelaunchAppFromPath,
 } from "../lib/os-bridge";
+import {
+  currentAppVersion,
+  emitUpdateRequired,
+  minVersionSignal,
+  onUpdateRequired,
+  type UpdateRequiredSignal,
+} from "../lib/update-floor";
 
 export interface UpdateInfo {
   currentVersion: string;
@@ -14,7 +26,7 @@ export interface UpdateInfo {
 
 type UpdateErrorPhase = "install" | "relaunch";
 
-type UpdateStatus =
+export type UpdateStatus =
   | { state: "idle" }
   | { state: "available"; info: UpdateInfo }
   | { state: "downloading"; info: UpdateInfo; progress: number | null }
@@ -26,6 +38,14 @@ type AvailableUpdate = NonNullable<Awaited<ReturnType<typeof check>>>;
 
 export function useUpdateChecker() {
   const [status, setStatus] = useState<UpdateStatus>({ state: "idle" });
+  // Hard floor (app-update floor): non-null once the hosted gateway said this
+  // build is too old — via a 426 on any request, or a `minAppVersion` on
+  // `/v1/version`. Kept BESIDE `status`, not as another status state, so the
+  // blocking screen can stay up while the normal updater machine underneath it
+  // runs through available → downloading → ready. Never cleared: only an
+  // installed update (relaunch) can satisfy the floor.
+  const [required, setRequired] = useState<UpdateRequiredSignal | null>(null);
+  const requiredRef = useRef<UpdateRequiredSignal | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const updateRef = useRef<AvailableUpdate | null>(null);
   const infoRef = useRef<UpdateInfo | null>(null);
@@ -154,6 +174,57 @@ export function useUpdateChecker() {
     setStatus({ state: "idle" });
   }, []);
 
+  // Trigger 1 — the transport saw a gateway `426 Upgrade Required` (forwarded
+  // through the update-floor bus). Merge rather than replace: a later signal
+  // with an omitted field (e.g. the /v1/version probe has no updateUrl) must
+  // not erase a value an earlier 426 body carried.
+  useEffect(() => {
+    return onUpdateRequired((signal) => {
+      const prev = requiredRef.current;
+      const next: UpdateRequiredSignal = {
+        minVersion: signal.minVersion ?? prev?.minVersion ?? null,
+        updateUrl: signal.updateUrl ?? prev?.updateUrl ?? null,
+      };
+      requiredRef.current = next;
+      setRequired(next);
+      if (!prev) {
+        analytics.track("update_required", {
+          from_version: currentAppVersion(),
+          min_version: next.minVersion ?? "unknown",
+        });
+        // Kick a check right away so the blocking screen can offer the
+        // one-click install instead of waiting for the 30-min tick. In dev /
+        // with the updater unable to serve, this rejects into runCheck's catch
+        // and the screen falls back to the gateway-provided updateUrl.
+        void runCheck();
+      }
+    });
+  }, [runCheck]);
+
+  // Trigger 2 — early warning: the gateway's `/v1/version` (exempt from the
+  // floor's 426) names a `minAppVersion` only when a floor is enforced for
+  // this channel. One probe per app run, at connect: a floor raised
+  // mid-session is caught by the 426 path on the next request anyway. Hosted
+  // gateway only — the local sidecar's /v1/version never carries the field,
+  // so skipping it saves a wasted request on every desktop launch.
+  useEffect(() => {
+    if (!isHostedGatewayEngine()) return;
+    let cancelled = false;
+    void whenEngineReady()
+      .then(() => getEngine().version())
+      .then((v) => {
+        if (cancelled) return;
+        const signal = minVersionSignal(v, currentAppVersion());
+        if (signal) emitUpdateRequired(signal);
+      })
+      .catch(() => {
+        /* meta probe only — a failure must not surface; the 426 path covers */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   useEffect(() => {
     // The updater pings the production release feed and would offer the shipped
     // build over a local dev build (e.g. `pnpm tauri dev`) — there's nothing
@@ -168,5 +239,11 @@ export function useUpdateChecker() {
     };
   }, [runCheck]);
 
-  return { status, installAndRelaunch, relaunchInstalledApp, dismiss };
+  return {
+    status,
+    required,
+    installAndRelaunch,
+    relaunchInstalledApp,
+    dismiss,
+  };
 }

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -102,6 +102,8 @@ export type AnalyticsEventName =
   | "update_offered"
   | "update_accepted"
   | "update_dismissed"
+  // Gateway app-update floor tripped → blocking update screen shown
+  | "update_required"
   // Reliability
   | "session_completed"
   | "session_failed"
@@ -128,6 +130,8 @@ type AnalyticsProperty =
   | "file_kind"
   | "from_version"
   | "to_version"
+  // The gateway's enforced app-version floor (update_required)
+  | "min_version"
   // Onboarding funnel
   | "locale"
   | "detected_locale"
@@ -174,6 +178,7 @@ const ALLOWED_PROPS = new Set<AnalyticsProperty>([
   "file_kind",
   "from_version",
   "to_version",
+  "min_version",
   "locale",
   "detected_locale",
   "step",

--- a/app/src/lib/engine.ts
+++ b/app/src/lib/engine.ts
@@ -4,6 +4,7 @@ import { EngineWebSocket, HoustonClient } from "@houston-ai/engine-client";
 import { pullEngineHandshakeWithRetry } from "./engine-handshake";
 import { isLoopbackHostUrl, resolveEngine } from "./engine-mode";
 import { installEngineLifecycleListeners } from "./engine-tauri-events";
+import { osIsTauri } from "./os-bridge";
 import {
   appUpdateChannel,
   currentAppVersion,
@@ -100,7 +101,11 @@ if (typeof window !== "undefined") {
 // gateway request already carries `X-Houston-App-Version`. The channel rides
 // the same env flags RESOLVED above is built from: a baked hosted gateway ⇒
 // `cloud`, everything else (sidecar, dev, external host) ⇒ `local`.
-if (typeof window !== "undefined") {
+// Tauri-gated, not just window-gated: the WEB bundle loads this module too
+// (the app-tree is shared), but the floor is a desktop-only contract — a
+// browser tab must never identify as an app build, and the header would turn
+// every fetch into a CORS preflight the target has to allow.
+if (typeof window !== "undefined" && osIsTauri()) {
   installUpdateFloorBridge({
     version: currentAppVersion(),
     channel: appUpdateChannel(_env),

--- a/app/src/lib/engine.ts
+++ b/app/src/lib/engine.ts
@@ -4,6 +4,11 @@ import { EngineWebSocket, HoustonClient } from "@houston-ai/engine-client";
 import { pullEngineHandshakeWithRetry } from "./engine-handshake";
 import { isLoopbackHostUrl, resolveEngine } from "./engine-mode";
 import { installEngineLifecycleListeners } from "./engine-tauri-events";
+import {
+  appUpdateChannel,
+  currentAppVersion,
+  installUpdateFloorBridge,
+} from "./update-floor";
 
 declare global {
   interface Window {
@@ -86,6 +91,20 @@ const REMOTE_HOST_MODE = Boolean(STATIC_HOST_URL || HOSTED_ENGINE_URL);
 // delivery paths. HOU-546.
 if (typeof window !== "undefined") {
   (window as unknown as { __HOUSTON_CP__?: boolean }).__HOUSTON_CP__ = true;
+}
+
+// App-update floor: bake this build's identity (`<semver>+<channel>`) and the
+// 426 forwarder onto the window globals the shared adapter transport reads
+// (`__HOUSTON_SESSION_REFRESH__` idiom — the adapter can't import desktop
+// code). At module load, before any client is constructed, so the very first
+// gateway request already carries `X-Houston-App-Version`. The channel rides
+// the same env flags RESOLVED above is built from: a baked hosted gateway ⇒
+// `cloud`, everything else (sidecar, dev, external host) ⇒ `local`.
+if (typeof window !== "undefined") {
+  installUpdateFloorBridge({
+    version: currentAppVersion(),
+    channel: appUpdateChannel(_env),
+  });
 }
 
 function resolveConfig(): { baseUrl: string; token: string } | null {

--- a/app/src/lib/update-floor.ts
+++ b/app/src/lib/update-floor.ts
@@ -1,0 +1,174 @@
+/**
+ * App-update floor (hosted gateway): the gateway may enforce an OPTIONAL
+ * per-channel minimum app version. This module is the desktop half of that
+ * contract:
+ *
+ * - It bakes the identity header value `<semver>+<channel>` the shared
+ *   adapter transport (`packages/web/src/engine-adapter/cp/fetch.ts`) sends as
+ *   `X-Houston-App-Version` on every gateway request.
+ * - It is the listener registry a gateway `426 Upgrade Required` (or a
+ *   `minAppVersion` on `/v1/version`) is broadcast through — the same tiny
+ *   pub/sub shape as `auth-error-bus.ts`. `useUpdateChecker` subscribes and
+ *   renders the blocking update screen.
+ *
+ * The adapter must not import desktop code (it is bundled into the web app
+ * too), so both directions ride window globals — the `__HOUSTON_SESSION_REFRESH__`
+ * idiom. `installUpdateFloorBridge` (called from `engine.ts` at module load,
+ * before any client is built) installs them; the web build never does, so web
+ * requests carry no header and can never trip the blocking screen.
+ */
+
+import { resolveEngine } from "./engine-mode.ts";
+
+/** The release channel baked into a desktop build — the gateway keys its
+ *  version floor on exactly these two strings. */
+export type AppUpdateChannel = "cloud" | "local";
+
+/** What a floor violation tells the app. Either field may be unknown: a 426
+ *  body can omit them, and the `/v1/version` probe has no updateUrl. */
+export interface UpdateRequiredSignal {
+  minVersion: string | null;
+  updateUrl: string | null;
+}
+
+declare global {
+  interface Window {
+    /** Full header value `<semver>+<channel>` (e.g. `0.5.9+cloud`), read live
+     *  by the adapter's gatewayAuthFetch. Desktop-only — web never sets it. */
+    __HOUSTON_APP_VERSION__?: string;
+    /** The adapter's 426 forwarder — points at {@link emitUpdateRequired}. */
+    __HOUSTON_UPDATE_REQUIRED__?: (signal: {
+      minVersion: string | null;
+      updateUrl: string | null;
+    }) => void;
+  }
+}
+
+/**
+ * This build's release channel. Derived from the SAME build-time flag that
+ * makes a build a cloud build: release.yml bakes `VITE_HOSTED_ENGINE_URL` into
+ * exactly the `cloud-*` tag builds — the ones whose updater
+ * scripts/ci/point-updater-at-cloud-manifest.sh points at the cloud manifest —
+ * so channel and updater feed cannot drift and no extra baked flag is needed.
+ * Routed through `resolveEngine` so a dev override (`VITE_NEW_ENGINE_URL`,
+ * which wins there and bypasses the gateway) reads as `local` here too.
+ * Dev with no flags → sidecar → `local`.
+ */
+export function appUpdateChannel(env: {
+  VITE_NEW_ENGINE_URL?: string;
+  VITE_HOSTED_ENGINE_URL?: string;
+  VITE_HOSTED_ENGINE_AUTH?: string;
+}): AppUpdateChannel {
+  const kind = resolveEngine(env).kind;
+  return kind === "hosted-oauth" || kind === "hosted-static"
+    ? "cloud"
+    : "local";
+}
+
+/** The `X-Houston-App-Version` value: `<semver>+<channel>`. The version may
+ *  carry a `-dev` prerelease (vite dev builds) — the gateway parses semver
+ *  with prerelease and fails open on anything it can't read. */
+export function formatAppVersionHeader(
+  version: string,
+  channel: AppUpdateChannel,
+): string {
+  return `${version}+${channel}`;
+}
+
+/** This build's own version (`__APP_VERSION__`, baked by app/vite.config.ts
+ *  from package.json — `<x.y.z>` in production, `<x.y.z>-dev` in dev). The
+ *  typeof guard keeps the module importable under plain node (unit tests). */
+export function currentAppVersion(): string {
+  return typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "0.0.0";
+}
+
+/** `major.minor.patch` as numbers, or null when `v` isn't semver-shaped.
+ *  Prerelease/build suffixes are accepted and ignored — see isBelowMinVersion. */
+function versionTriple(v: string): [number, number, number] | null {
+  const m = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(v.trim());
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/**
+ * True when `current` is semver-below `min`. Compares the numeric triple only:
+ * a `-dev` prerelease whose numbers meet the floor must not self-block a
+ * developer (strict semver would order 0.5.9-dev < 0.5.9), and the gateway's
+ * own 426 stays the authority for edge cases. Unparseable input reads as NOT
+ * below — fail open, matching the gateway's treatment of malformed headers.
+ */
+export function isBelowMinVersion(current: string, min: string): boolean {
+  const c = versionTriple(current);
+  const m = versionTriple(min);
+  if (!c || !m) return false;
+  for (let i = 0; i < 3; i++) {
+    if (c[i] !== m[i]) return c[i] < m[i];
+  }
+  return false;
+}
+
+/**
+ * The early-warning trigger: a gateway `/v1/version` payload names a
+ * `minAppVersion` ONLY when a floor is enforced for this channel (the route
+ * itself is exempt from the 426, so it answers even below the floor). Returns
+ * the update-required signal when this build is below that floor, else null —
+ * including for local hosts and floor-less gateways, which omit the field.
+ */
+export function minVersionSignal(
+  payload: unknown,
+  currentVersion: string,
+): UpdateRequiredSignal | null {
+  const min = (payload as { minAppVersion?: unknown } | null)?.minAppVersion;
+  if (typeof min !== "string" || !min) return null;
+  if (!isBelowMinVersion(currentVersion, min)) return null;
+  return { minVersion: min, updateUrl: null };
+}
+
+type UpdateRequiredListener = (signal: UpdateRequiredSignal) => void;
+const updateRequiredListeners = new Set<UpdateRequiredListener>();
+/** Latched last signal: boot-time gateway calls can 426 BEFORE the shell (and
+ *  useUpdateChecker's subscription) has mounted, and a floor never un-trips
+ *  within a process — so late subscribers get the signal replayed instead of
+ *  a silently lost broadcast. */
+let lastSignal: UpdateRequiredSignal | null = null;
+
+const deliver = (cb: UpdateRequiredListener, signal: UpdateRequiredSignal) => {
+  try {
+    cb(signal);
+  } catch (e) {
+    console.warn("[updater] update-required listener threw", e);
+  }
+};
+
+/** Subscribe to update-required signals (replaying a pre-subscription one).
+ *  Returns an unsubscribe fn. */
+export function onUpdateRequired(cb: UpdateRequiredListener): () => void {
+  updateRequiredListeners.add(cb);
+  if (lastSignal) deliver(cb, lastSignal);
+  return () => updateRequiredListeners.delete(cb);
+}
+
+/** Broadcast a floor violation to every subscriber (a throwing one is logged). */
+export function emitUpdateRequired(signal: UpdateRequiredSignal): void {
+  lastSignal = signal;
+  for (const cb of updateRequiredListeners) {
+    deliver(cb, signal);
+  }
+}
+
+/**
+ * Install the window globals the shared adapter reads: the baked header value
+ * and the 426 forwarder. Must run before any gateway request fires — engine.ts
+ * calls it at module load, alongside the `__HOUSTON_CP__` bake.
+ */
+export function installUpdateFloorBridge(opts: {
+  version: string;
+  channel: AppUpdateChannel;
+}): void {
+  if (typeof window === "undefined") return;
+  window.__HOUSTON_APP_VERSION__ = formatAppVersionHeader(
+    opts.version,
+    opts.channel,
+  );
+  window.__HOUSTON_UPDATE_REQUIRED__ = emitUpdateRequired;
+}

--- a/app/src/lib/update-floor.ts
+++ b/app/src/lib/update-floor.ts
@@ -14,8 +14,10 @@
  * The adapter must not import desktop code (it is bundled into the web app
  * too), so both directions ride window globals — the `__HOUSTON_SESSION_REFRESH__`
  * idiom. `installUpdateFloorBridge` (called from `engine.ts` at module load,
- * before any client is built) installs them; the web build never does, so web
- * requests carry no header and can never trip the blocking screen.
+ * before any client is built) installs them — gated on `osIsTauri()`, because
+ * the web bundle loads `engine.ts` too and a browser tab must never identify
+ * as an app build: web requests carry no header (which would force CORS
+ * preflights) and can never trip the blocking screen.
  */
 
 import { resolveEngine } from "./engine-mode.ts";

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -224,6 +224,14 @@
     "retryAction": "Try again",
     "dismissAction": "Dismiss update for now"
   },
+  "updateRequired": {
+    "cardLabel": "Houston update required",
+    "title": "Update required",
+    "description": "Houston {{minVersion}} or newer is required to keep using Houston Cloud. You're on v{{currentVersion}}.",
+    "descriptionNoVersion": "A newer version of Houston is required to keep using Houston Cloud. You're on v{{currentVersion}}.",
+    "downloadAction": "Download the update",
+    "checkAction": "Check for updates"
+  },
   "store": {
     "searchPlaceholder": "Search the library...",
     "noResults": "No agents match your search"

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -224,6 +224,14 @@
     "retryAction": "Intentar otra vez",
     "dismissAction": "Descartar actualización por ahora"
   },
+  "updateRequired": {
+    "cardLabel": "Actualización de Houston requerida",
+    "title": "Actualización requerida",
+    "description": "Se necesita Houston {{minVersion}} o más reciente para seguir usando Houston Cloud. Estás en v{{currentVersion}}.",
+    "descriptionNoVersion": "Se necesita una versión más reciente de Houston para seguir usando Houston Cloud. Estás en v{{currentVersion}}.",
+    "downloadAction": "Descargar la actualización",
+    "checkAction": "Buscar actualizaciones"
+  },
   "store": {
     "searchPlaceholder": "Buscar en la biblioteca...",
     "noResults": "Ningún agente coincide con tu búsqueda"

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -224,6 +224,14 @@
     "retryAction": "Tentar de novo",
     "dismissAction": "Dispensar atualização por enquanto"
   },
+  "updateRequired": {
+    "cardLabel": "Atualização do Houston obrigatória",
+    "title": "Atualização obrigatória",
+    "description": "É necessário o Houston {{minVersion}} ou mais recente para continuar usando o Houston Cloud. Você está na v{{currentVersion}}.",
+    "descriptionNoVersion": "É necessária uma versão mais recente do Houston para continuar usando o Houston Cloud. Você está na v{{currentVersion}}.",
+    "downloadAction": "Baixar a atualização",
+    "checkAction": "Buscar atualizações"
+  },
   "store": {
     "searchPlaceholder": "Buscar na biblioteca...",
     "noResults": "Nenhum agente corresponde à sua busca"

--- a/app/tests/update-floor.test.ts
+++ b/app/tests/update-floor.test.ts
@@ -1,0 +1,141 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  appUpdateChannel,
+  emitUpdateRequired,
+  formatAppVersionHeader,
+  isBelowMinVersion,
+  minVersionSignal,
+  onUpdateRequired,
+} from "../src/lib/update-floor.ts";
+
+// The channel must mirror the release channel exactly: release.yml bakes
+// VITE_HOSTED_ENGINE_URL into precisely the cloud-tag builds whose updater is
+// repointed at the cloud manifest — so a baked hosted gateway IS the cloud
+// channel, and everything else reports local.
+describe("appUpdateChannel", () => {
+  it("reports cloud for a baked hosted gateway (managed-cloud default, oauth)", () => {
+    strictEqual(
+      appUpdateChannel({ VITE_HOSTED_ENGINE_URL: "https://gw.example" }),
+      "cloud",
+    );
+  });
+
+  it("reports cloud for a hosted gateway with oauth toggled off (static)", () => {
+    strictEqual(
+      appUpdateChannel({
+        VITE_HOSTED_ENGINE_URL: "https://gw.example",
+        VITE_HOSTED_ENGINE_AUTH: "static",
+      }),
+      "cloud",
+    );
+  });
+
+  it("reports local for the default sidecar build and dev", () => {
+    strictEqual(appUpdateChannel({}), "local");
+  });
+
+  it("reports local when a dev VITE_NEW_ENGINE_URL wins over the gateway", () => {
+    // resolveEngine gives the external-host flag precedence; the app then
+    // never talks to the gateway, so the cloud channel would be a lie.
+    strictEqual(
+      appUpdateChannel({
+        VITE_NEW_ENGINE_URL: "http://127.0.0.1:8787",
+        VITE_HOSTED_ENGINE_URL: "https://gw.example",
+      }),
+      "local",
+    );
+  });
+});
+
+describe("formatAppVersionHeader", () => {
+  it("joins version and channel with the + separator the gateway parses", () => {
+    strictEqual(formatAppVersionHeader("0.5.9", "cloud"), "0.5.9+cloud");
+    strictEqual(
+      formatAppVersionHeader("0.5.9-dev", "local"),
+      "0.5.9-dev+local",
+    );
+  });
+});
+
+describe("isBelowMinVersion", () => {
+  it("orders by major, minor, patch", () => {
+    strictEqual(isBelowMinVersion("0.5.9", "0.6.0"), true);
+    strictEqual(isBelowMinVersion("0.5.9", "0.5.10"), true);
+    strictEqual(isBelowMinVersion("0.5.9", "1.0.0"), true);
+    strictEqual(isBelowMinVersion("0.6.0", "0.5.9"), false);
+    strictEqual(isBelowMinVersion("1.0.0", "0.99.99"), false);
+    strictEqual(isBelowMinVersion("0.5.9", "0.5.9"), false);
+  });
+
+  it("ignores prerelease/build suffixes — a -dev build meeting the floor numerically must not self-block", () => {
+    strictEqual(isBelowMinVersion("0.5.9-dev", "0.5.9"), false);
+    strictEqual(isBelowMinVersion("0.5.8-dev", "0.5.9"), true);
+    strictEqual(isBelowMinVersion("0.5.9+cloud", "0.5.9"), false);
+  });
+
+  it("fails open on unparseable input, like the gateway does", () => {
+    strictEqual(isBelowMinVersion("garbage", "0.5.9"), false);
+    strictEqual(isBelowMinVersion("0.5.9", "garbage"), false);
+    strictEqual(isBelowMinVersion("", ""), false);
+  });
+});
+
+describe("minVersionSignal", () => {
+  it("signals when /v1/version names a floor above the running build", () => {
+    deepStrictEqual(
+      minVersionSignal(
+        { engine: "houston-gateway", minAppVersion: "0.6.0" },
+        "0.5.9",
+      ),
+      { minVersion: "0.6.0", updateUrl: null },
+    );
+  });
+
+  it("is silent when the build meets the floor", () => {
+    strictEqual(minVersionSignal({ minAppVersion: "0.5.9" }, "0.5.9"), null);
+    strictEqual(minVersionSignal({ minAppVersion: "0.5.0" }, "0.5.9"), null);
+  });
+
+  it("is silent when no floor is enforced (field omitted — the dark default)", () => {
+    strictEqual(minVersionSignal({ engine: "houston-gateway" }, "0.5.9"), null);
+    strictEqual(minVersionSignal(null, "0.5.9"), null);
+    strictEqual(minVersionSignal({ minAppVersion: "" }, "0.5.9"), null);
+    strictEqual(minVersionSignal({ minAppVersion: 42 }, "0.5.9"), null);
+  });
+});
+
+// NOTE: the bus latches the last signal across the module's lifetime (a floor
+// never un-trips within a process), so these tests run against one shared
+// history — each subscribes AFTER the previous emits and asserts the replay.
+describe("update-required bus", () => {
+  it("delivers to subscribers and honors unsubscribe (nothing latched yet)", () => {
+    const seen: unknown[] = [];
+    const off = onUpdateRequired((s) => seen.push(s));
+    deepStrictEqual(seen, []); // no pre-subscription signal to replay
+    emitUpdateRequired({ minVersion: "0.6.0", updateUrl: null });
+    off();
+    emitUpdateRequired({ minVersion: "0.7.0", updateUrl: "https://dl" });
+    deepStrictEqual(seen, [{ minVersion: "0.6.0", updateUrl: null }]);
+  });
+
+  it("replays the latched signal to a late subscriber (426 before the shell mounted)", () => {
+    const seen: unknown[] = [];
+    const off = onUpdateRequired((s) => seen.push(s));
+    off();
+    deepStrictEqual(seen, [{ minVersion: "0.7.0", updateUrl: "https://dl" }]);
+  });
+
+  it("keeps delivering past a throwing listener", () => {
+    const seen: string[] = [];
+    const offBad = onUpdateRequired(() => {
+      throw new Error("boom");
+    });
+    const offGood = onUpdateRequired((s) => seen.push(s.minVersion ?? ""));
+    emitUpdateRequired({ minVersion: "0.8.0", updateUrl: null });
+    offBad();
+    offGood();
+    // One replay of the latched 0.7.0 signal at subscribe, then the live 0.8.0.
+    deepStrictEqual(seen, ["0.7.0", "0.8.0"]);
+  });
+});

--- a/packages/fake-host/src/http.ts
+++ b/packages/fake-host/src/http.ts
@@ -2,7 +2,8 @@
 export const CORS: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET,POST,PATCH,PUT,DELETE,OPTIONS",
-  "Access-Control-Allow-Headers": "Authorization,Content-Type,Accept",
+  "Access-Control-Allow-Headers":
+    "Authorization,Content-Type,Accept,X-Houston-App-Version",
 };
 
 export function json(data: unknown, status = 200): Response {

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -193,7 +193,13 @@ export interface ControlPlaneDeps {
 
 function applyCors(deps: ControlPlaneDeps, res: ServerResponse): void {
   res.setHeader("Access-Control-Allow-Origin", deps.corsOrigin || "*");
-  res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
+  // X-Houston-App-Version: the desktop app's update-floor identity header
+  // (app-update floor) — sent by its shared gateway transport to this host
+  // too, so the preflight must allow it even though the host ignores it.
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    "Authorization, Content-Type, X-Houston-App-Version",
+  );
   res.setHeader(
     "Access-Control-Allow-Methods",
     "GET, POST, PUT, PATCH, DELETE, OPTIONS",

--- a/packages/web/src/engine-adapter/cp/fetch.ts
+++ b/packages/web/src/engine-adapter/cp/fetch.ts
@@ -1,5 +1,6 @@
 import { HoustonEngineError } from "../client/errors";
 import { refreshLiveToken } from "../session-refresh";
+import { appVersionHeader, noteUpgradeRequired } from "../update-floor";
 
 /**
  * Control-plane mode for the web adapter.
@@ -64,13 +65,23 @@ export function gatewayAuthFetch(
       // the bearer. Absent → the gateway resolves the personal org.
       const org = getOrg?.();
       if (org) headers.set("x-houston-org", org);
+      // App-update floor: identify the build (`<semver>+<channel>`) on every
+      // gateway request so the gateway can enforce a per-channel minimum
+      // version. Read live off the desktop-installed global — absent (web,
+      // tests) means no header; the gateway fails open on a missing header
+      // and the local sidecar ignores it.
+      const appVersion = appVersionHeader();
+      if (appVersion) headers.set("X-Houston-App-Version", appVersion);
       return fetch(input, { ...init, headers });
     };
+    // Every returned response passes noteUpgradeRequired: a gateway that
+    // enforces the version floor answers ANY request with 426, and the desktop
+    // shell must learn about it from whichever call happens to hit it first.
     const res = await send(liveToken(fallbackToken));
-    if (res.status !== 401) return res;
+    if (res.status !== 401) return noteUpgradeRequired(res);
     const fresh = await refreshLiveToken();
     if (!fresh) return res;
-    return send(fresh);
+    return noteUpgradeRequired(await send(fresh));
   };
 }
 

--- a/packages/web/src/engine-adapter/update-floor.ts
+++ b/packages/web/src/engine-adapter/update-floor.ts
@@ -10,10 +10,13 @@
  * `__HOUSTON_SESSION_REFRESH__` — because this adapter is bundled into the web
  * app too and must not import desktop code: the desktop shell
  * (`app/src/lib/update-floor.ts` via `engine.ts`) installs the header value and
- * the 426 forwarder; the web build installs neither, so web requests carry no
- * header and can never trip the blocking update screen. The local sidecar host
- * ignores the unknown header, so a shared transport sending it there is
- * harmless.
+ * the 426 forwarder, gated on `osIsTauri()` — the web bundle loads the same
+ * shell module, so the gate (not bundle separation) is what keeps a browser
+ * tab from ever sending the header or tripping the blocking update screen.
+ * That matters beyond scope hygiene: the custom header makes every fetch
+ * CORS-preflighted, so each target that may receive it (gateway, engine host,
+ * fake host) must allow it explicitly — a browser client sending it to a host
+ * that doesn't would lose ALL requests, not just the header.
  */
 
 declare global {

--- a/packages/web/src/engine-adapter/update-floor.ts
+++ b/packages/web/src/engine-adapter/update-floor.ts
@@ -1,0 +1,70 @@
+/**
+ * The app-update-floor seam: the hosted gateway may enforce a per-channel
+ * minimum app version. The desktop identifies its build with
+ * `X-Houston-App-Version: <semver>+<channel>` on every gateway request, and a
+ * gateway that decides the caller is below the floor answers ANY request
+ * (except `/v1/version` and health) with `426 Upgrade Required` +
+ * `{error, minVersion, updateUrl}`.
+ *
+ * Both directions ride window globals — the same global-injection idiom as
+ * `__HOUSTON_SESSION_REFRESH__` — because this adapter is bundled into the web
+ * app too and must not import desktop code: the desktop shell
+ * (`app/src/lib/update-floor.ts` via `engine.ts`) installs the header value and
+ * the 426 forwarder; the web build installs neither, so web requests carry no
+ * header and can never trip the blocking update screen. The local sidecar host
+ * ignores the unknown header, so a shared transport sending it there is
+ * harmless.
+ */
+
+declare global {
+  interface Window {
+    /** Full header value `<semver>+<channel>` (e.g. `0.5.9+cloud`), baked by
+     *  the desktop shell at module load. Absent → no header (web, tests). */
+    __HOUSTON_APP_VERSION__?: string;
+    /** Desktop-installed sink for a gateway `426 Upgrade Required`; feeds the
+     *  blocking update screen. Absent → the 426 just surfaces as an error. */
+    __HOUSTON_UPDATE_REQUIRED__?: (signal: {
+      minVersion: string | null;
+      updateUrl: string | null;
+    }) => void;
+  }
+}
+
+/** The `X-Houston-App-Version` value to send, or null to send no header. */
+export function appVersionHeader(): string | null {
+  if (typeof window === "undefined") return null;
+  return window.__HOUSTON_APP_VERSION__ ?? null;
+}
+
+/**
+ * Forward a gateway `426 Upgrade Required` to the desktop shell's sink (when
+ * one is installed) and hand the response back unchanged, so callers keep
+ * their normal error path — the blocking screen takes over the UI; the failed
+ * call itself still fails. Parsing is fire-and-forget on a clone: the caller's
+ * own body read must not be consumed here.
+ */
+export function noteUpgradeRequired(res: Response): Response {
+  if (res.status !== 426) return res;
+  const notify =
+    typeof window !== "undefined"
+      ? window.__HOUSTON_UPDATE_REQUIRED__
+      : undefined;
+  if (!notify) return res;
+  void res
+    .clone()
+    .json()
+    .catch(() => null)
+    .then((body: unknown) => {
+      const b = body as { minVersion?: unknown; updateUrl?: unknown } | null;
+      notify({
+        minVersion:
+          typeof b?.minVersion === "string" && b.minVersion
+            ? b.minVersion
+            : null,
+        // `updateUrl` may be empty by contract — normalize that to null.
+        updateUrl:
+          typeof b?.updateUrl === "string" && b.updateUrl ? b.updateUrl : null,
+      });
+    });
+  return res;
+}

--- a/packages/web/tests/update-floor-transport.test.ts
+++ b/packages/web/tests/update-floor-transport.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { gatewayAuthFetch } from "../src/engine-adapter/control-plane";
+
+/**
+ * App-update floor, transport half: gatewayAuthFetch must (a) attach
+ * `X-Houston-App-Version` on every request when the desktop shell installed
+ * `window.__HOUSTON_APP_VERSION__`, and (b) forward a gateway
+ * `426 Upgrade Required` to `window.__HOUSTON_UPDATE_REQUIRED__`. Neither
+ * global exists on web — then no header is sent and a 426 just returns.
+ */
+
+const originalFetch = globalThis.fetch;
+type FloorWindow = {
+  __HOUSTON_APP_VERSION__?: string;
+  __HOUSTON_UPDATE_REQUIRED__?: (signal: {
+    minVersion: string | null;
+    updateUrl: string | null;
+  }) => void;
+};
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete (globalThis as { window?: unknown }).window;
+  vi.clearAllMocks();
+});
+
+/** Simulate the desktop shell's globals (no jsdom here — tests run in node). */
+function installWindow(w: FloorWindow) {
+  (globalThis as { window?: FloorWindow }).window = w;
+}
+
+function stubFetch(response: Response) {
+  const seen: { url: string; headers: Headers }[] = [];
+  globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    seen.push({ url: String(input), headers: new Headers(init?.headers) });
+    return response;
+  }) as unknown as typeof fetch;
+  return seen;
+}
+
+test("attaches X-Houston-App-Version when the desktop shell baked it", async () => {
+  installWindow({ __HOUSTON_APP_VERSION__: "0.5.9+cloud" });
+  const seen = stubFetch(new Response("{}", { status: 200 }));
+
+  await gatewayAuthFetch("t")("https://gw.example/v1/capabilities");
+
+  expect(seen[0].headers.get("X-Houston-App-Version")).toBe("0.5.9+cloud");
+  expect(seen[0].headers.get("Authorization")).toBe("Bearer t");
+});
+
+test("sends no version header when the global is absent (web build)", async () => {
+  const seen = stubFetch(new Response("{}", { status: 200 }));
+
+  await gatewayAuthFetch("t")("https://gw.example/v1/capabilities");
+
+  expect(seen[0].headers.get("X-Houston-App-Version")).toBeNull();
+});
+
+test("forwards a 426 body to the desktop update-required sink", async () => {
+  const notify = vi.fn();
+  installWindow({ __HOUSTON_UPDATE_REQUIRED__: notify });
+  stubFetch(
+    new Response(
+      JSON.stringify({
+        error: "app update required",
+        minVersion: "0.6.0",
+        updateUrl: "https://gethouston.ai/download",
+      }),
+      { status: 426 },
+    ),
+  );
+
+  const res = await gatewayAuthFetch("t")("https://gw.example/v1/agents");
+
+  // The caller keeps its normal error path — the response is returned as-is.
+  expect(res.status).toBe(426);
+  await vi.waitFor(() =>
+    expect(notify).toHaveBeenCalledWith({
+      minVersion: "0.6.0",
+      updateUrl: "https://gethouston.ai/download",
+    }),
+  );
+});
+
+test("normalizes an empty updateUrl and a missing minVersion to null", async () => {
+  const notify = vi.fn();
+  installWindow({ __HOUSTON_UPDATE_REQUIRED__: notify });
+  stubFetch(
+    new Response(
+      JSON.stringify({ error: "app update required", updateUrl: "" }),
+      {
+        status: 426,
+      },
+    ),
+  );
+
+  await gatewayAuthFetch("t")("https://gw.example/v1/agents");
+
+  await vi.waitFor(() =>
+    expect(notify).toHaveBeenCalledWith({ minVersion: null, updateUrl: null }),
+  );
+});
+
+test("does not notify on non-426 responses", async () => {
+  const notify = vi.fn();
+  installWindow({ __HOUSTON_UPDATE_REQUIRED__: notify });
+  stubFetch(new Response("{}", { status: 500 }));
+
+  await gatewayAuthFetch("t")("https://gw.example/v1/agents");
+
+  // Give the (nonexistent) fire-and-forget parse a tick to run.
+  await new Promise((r) => setTimeout(r, 0));
+  expect(notify).not.toHaveBeenCalled();
+});

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -69,6 +69,14 @@ export interface VersionResponse {
    * field (treat as `false`).
    */
   chatHistoryMigrated?: boolean;
+  /**
+   * Present ONLY when the answering gateway enforces an app-version floor for
+   * the requesting channel (read from `X-Houston-App-Version`): the minimum
+   * app semver that channel must run. `/v1/version` is exempt from the floor's
+   * 426, so this is how an app below the floor can warn/act BEFORE being
+   * locked out. Local hosts and floor-less gateways omit it.
+   */
+  minAppVersion?: string;
 }
 
 export interface Capabilities {


### PR DESCRIPTION
Client half of the hosted gateway's minimum-app-version floor (PR 3 of the update-management rollout; the server side is already live and dark — no floor configured).

## What

- **Identity header.** Every gateway request carries `X-Houston-App-Version: <semver>+<channel>`, injected at `gatewayAuthFetch` — the single choke point all gateway HTTP rides (authFetch, cpFetch, SDK, per-agent + setup-runtime clients, boot probes). Channel (`cloud`/`local`) derives from the **same** baked flag that makes a build a cloud build (`VITE_HOSTED_ENGINE_URL` via `resolveEngine`) — the exact builds whose updater `point-updater-at-cloud-manifest.sh` repoints — so channel and updater feed cannot drift. No build-script or Rust changes.
- **Web stays out of scope structurally.** The shared adapter reads window globals (`__HOUSTON_APP_VERSION__`, `__HOUSTON_UPDATE_REQUIRED__` — the `__HOUSTON_SESSION_REFRESH__` idiom) that only the desktop shell installs at module load; the web bundle installs neither, so it never sends the header and can never trip the blocking screen. The local sidecar ignores the unknown header.
- **Required-update state.** Two triggers feed a latched pub/sub bus: any gateway **426** (body's `minVersion`/`updateUrl` parsed off a clone; the response is returned unchanged so callers keep their error path), and a `minAppVersion` on gateway `/v1/version` above this build (one probe per run at connect; the route is 426-exempt so a locked-out app can still read its floor). Signals merge — a later signal can't erase a known `minVersion`/`updateUrl` — and never clear: only installing + relaunching satisfies the floor. The bus latches so a 426 during boot is replayed to the late-mounting shell.
- **Blocking screen.** `UpdateRequired` replaces the dismissible card when required: full-window, non-dismissible (`role="alertdialog"`), shows current → minimum version, drives the existing updater flow (install → progress → relaunch → error/retry), falls back to opening the gateway-provided `updateUrl` when the updater can't serve (dev/feed unreachable), and to a re-check button when even that is absent — never a dead end. Shown on hosted-gateway builds only: a local/sidecar build never has the gateway on its request path, so local-only work can't be soft-locked.
- Version compare is numeric-triple-only, fail-open on anything unparseable (a `0.5.9-dev` build whose numbers meet the floor must not self-block; the gateway's 426 stays the authority). Added an `update_required` analytics event alongside the existing update funnel.

## Tests

19 new tests: channel/header derivation per build flavor, triple-compare semantics (incl. prerelease + fail-open), bus latching/merging, `gatewayAuthFetch` header injection + 426 forwarding on both auth attempts with the body left unconsumed, `minAppVersion` extraction. Full app suite 1676/1676, web suite 207/207, repo-wide typecheck, biome, and en/es/pt locale parity all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)