### PR TITLE
fix(sentry): stop expected operational failures from spamming error events

### DIFF
--- a/packages/host/src/channel/fire-error.test.ts
+++ b/packages/host/src/channel/fire-error.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "vitest";
+import { errorCodeFrom, TurnFireError } from "./fire-error";
+
+test("errorCodeFrom reads the code out of a runtime JSON error body", () => {
+  expect(
+    errorCodeFrom('{"error":"No provider connected.","code":"no_provider"}'),
+  ).toBe("no_provider");
+});
+
+test("errorCodeFrom is null for a code-less JSON body", () => {
+  expect(errorCodeFrom('{"error":"boom"}')).toBeNull();
+});
+
+test("errorCodeFrom is null for non-JSON and empty bodies", () => {
+  expect(errorCodeFrom("<html>502 Bad Gateway</html>")).toBeNull();
+  expect(errorCodeFrom("")).toBeNull();
+});
+
+test("errorCodeFrom ignores a non-string or empty code", () => {
+  expect(errorCodeFrom('{"code":7}')).toBeNull();
+  expect(errorCodeFrom('{"code":""}')).toBeNull();
+});
+
+test("TurnFireError carries status and code alongside the verbatim message", () => {
+  const err = new TurnFireError("runtime 409: nope", 409, "no_provider");
+  expect(err).toBeInstanceOf(Error);
+  expect(err.status).toBe(409);
+  expect(err.code).toBe("no_provider");
+  expect(err.message).toBe("runtime 409: nope");
+});

--- a/packages/host/src/channel/fire-error.ts
+++ b/packages/host/src/channel/fire-error.ts
@@ -1,0 +1,32 @@
+/**
+ * Typed non-2xx from the runtime's fire-turn POST, so callers branch on the
+ * runtime's verdict instead of parsing a flat "runtime 409: {...}" string.
+ * `code` is the runtime's machine-readable reason when its JSON body carried
+ * one (e.g. "no_provider" from the 409 provider gate) — the scheduler uses it
+ * to tell an expected user state apart from a real failure.
+ */
+export class TurnFireError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code: string | null,
+  ) {
+    super(message);
+    this.name = "TurnFireError";
+  }
+}
+
+/** The `code` field of a runtime error body, when the body is JSON with one. */
+export function errorCodeFrom(body: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (parsed && typeof parsed === "object" && "code" in parsed) {
+      const code = (parsed as { code: unknown }).code;
+      if (typeof code === "string" && code) return code;
+    }
+  } catch {
+    // Not JSON — an HTML error page, a bare string. No code to extract; the
+    // caller still gets the verbatim body in the error message.
+  }
+  return null;
+}

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -11,6 +11,7 @@ import type {
   TurnPin,
 } from "../ports";
 import { MAX_JSON_BYTES, readBody } from "../routes/read-body";
+import { errorCodeFrom, TurnFireError } from "./fire-error";
 
 /**
  * Forwards one authorized request to a standing runtime and streams the reply
@@ -149,8 +150,11 @@ export class ProxyChannel implements RuntimeChannel {
       },
     );
     if (!res.ok) {
-      throw new Error(
-        `runtime ${res.status}: ${await res.text().catch(() => "")}`,
+      const body = await res.text().catch(() => "");
+      throw new TurnFireError(
+        `runtime ${res.status}: ${body}`,
+        res.status,
+        errorCodeFrom(body),
       );
     }
   }

--- a/packages/host/src/schedule/scheduler.test.ts
+++ b/packages/host/src/schedule/scheduler.test.ts
@@ -175,6 +175,10 @@ test("a no-provider 409 fire records the errored run but logs a warning, not an 
   try {
     s.start();
     await s.tick(DUE);
+    // Expected user state (nothing connected) → warning breadcrumb, no Sentry
+    // event. Asserted BEFORE mockRestore — restoring resets recorded calls.
+    expect(warn).toHaveBeenCalledOnce();
+    expect(error).not.toHaveBeenCalled();
   } finally {
     warn.mockRestore();
     error.mockRestore();
@@ -187,9 +191,6 @@ test("a no-provider 409 fire records the errored run but logs a warning, not an 
   );
   expect(items).toHaveLength(1);
   expect((items[0] as RoutineRun).status).toBe("error");
-  // Expected user state (nothing connected) → warning breadcrumb, no Sentry event.
-  expect(warn).toHaveBeenCalledOnce();
-  expect(error).not.toHaveBeenCalled();
 });
 
 test("the workspace timezone preference re-times routines (account-wide zone)", async () => {

--- a/packages/host/src/schedule/scheduler.test.ts
+++ b/packages/host/src/schedule/scheduler.test.ts
@@ -5,7 +5,8 @@ import {
   setPreference,
 } from "@houston/domain";
 import type { Routine, RoutineRun } from "@houston/protocol";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
+import { TurnFireError } from "../channel/fire-error";
 import { CloudPaths } from "../paths";
 import { workspaceRoot } from "../routes/agent-data";
 import { MemoryWorkspaceStore } from "../store/memory";
@@ -25,10 +26,11 @@ const ENABLED = "0 14 * * *"; // 14:00 UTC daily
 /** A capturing firer; optionally throws to exercise the error path. */
 class CaptureFirer implements RoutineFirer {
   jobs: FiringJob[] = [];
-  constructor(private readonly throwMessage?: string) {}
+  constructor(private readonly throwWith?: string | Error) {}
   async fire(job: FiringJob): Promise<void> {
     this.jobs.push(job);
-    if (this.throwMessage) throw new Error(this.throwMessage);
+    if (this.throwWith instanceof Error) throw this.throwWith;
+    if (this.throwWith) throw new Error(this.throwWith);
   }
 }
 
@@ -156,6 +158,38 @@ test("a fire failure marks the run errored — never stuck running, never silent
   expect(run.status).toBe("error");
   expect(run.summary).toContain("runtime unreachable");
   expect(run.completed_at).toBeTruthy();
+});
+
+test("a no-provider 409 fire records the errored run but logs a warning, not an error", async () => {
+  const env = await setup([routine({ schedule: ENABLED })]);
+  const firer = new CaptureFirer(
+    new TurnFireError(
+      'runtime 409: {"error":"No provider connected."}',
+      409,
+      "no_provider",
+    ),
+  );
+  const s = makeScheduler(env, firer);
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    s.start();
+    await s.tick(DUE);
+  } finally {
+    warn.mockRestore();
+    error.mockRestore();
+  }
+
+  // The run record still carries the real reason — user-visible, never silent.
+  const { items } = await loadRoutineRuns(
+    env.vfs,
+    workspaceRoot(env.ws, env.agent),
+  );
+  expect(items).toHaveLength(1);
+  expect((items[0] as RoutineRun).status).toBe("error");
+  // Expected user state (nothing connected) → warning breadcrumb, no Sentry event.
+  expect(warn).toHaveBeenCalledOnce();
+  expect(error).not.toHaveBeenCalled();
 });
 
 test("the workspace timezone preference re-times routines (account-wide zone)", async () => {

--- a/packages/host/src/schedule/scheduler.ts
+++ b/packages/host/src/schedule/scheduler.ts
@@ -1,5 +1,6 @@
 import { dueAt, getPreference, loadRoutines } from "@houston/domain";
 import type { Routine } from "@houston/protocol";
+import { TurnFireError } from "../channel/fire-error";
 import type { Agent, Workspace } from "../domain/types";
 import type { EventHub } from "../events/hub";
 import type { WorkspacePaths } from "../paths";
@@ -169,6 +170,16 @@ export class Scheduler {
       // Expected when the previous run is still in flight — the instant is
       // skipped (its dedup lock is already burned), not an error.
       if (err instanceof RoutineBusyError) return;
+      // A routine firing while the workspace has no provider connected is an
+      // expected user state, not an engine fault (HOUSTON-APP-4XM): the run is
+      // already recorded errored with the real reason (user-visible in the
+      // routine's history), so a warning breadcrumb suffices here.
+      if (err instanceof TurnFireError && err.code === "no_provider") {
+        console.warn(
+          `[scheduler] routine ${routine.id} skipped: ${err.message}`,
+        );
+        return;
+      }
       console.error(
         `[scheduler] routine ${routine.id} fire failed:`,
         err instanceof Error ? err.message : err,

--- a/packages/runtime/src/ai/provider-error-log.ts
+++ b/packages/runtime/src/ai/provider-error-log.ts
@@ -1,0 +1,47 @@
+import type { ProviderError } from "@houston/runtime-client";
+
+/**
+ * Kinds that are expected operational states of an EXTERNAL provider (or of
+ * the user's plan) — a 429, a 503, an exhausted quota, an over-long prompt.
+ * The chat already renders each as its matching inline card, so a Sentry
+ * ERROR event adds no signal; captured as warning breadcrumbs they still
+ * document the turn that led to a real error. `unauthenticated` and `unknown`
+ * stay errors: on a managed pod an auth failure means the central credential
+ * custody broke (the storm behind HOUSTON-APP-4XG), and an unclassified
+ * failure is by definition something we have not seen and triaged yet.
+ */
+const EXPECTED_KINDS: ReadonlySet<ProviderError["kind"]> = new Set([
+  "rate_limited",
+  "quota_exhausted",
+  "model_unavailable",
+  "context_overflow",
+  "provider_internal",
+  "network_unreachable",
+]);
+
+export interface ProviderErrorLogContext {
+  model?: string | null;
+  status?: number | null;
+  /** The Claude Agent SDK's own error enum, when that backend classified it. */
+  sdkError?: string;
+}
+
+/**
+ * The single log site for a classified provider failure — every backend logs
+ * the VERBATIM provider text through here exactly once, after classification,
+ * so the raw reason (an opencode.ai 401 body, an entitlement 403) is never
+ * lost once collapsed into a typed card, and so severity follows the taxonomy
+ * instead of blanket console.error.
+ */
+export function logProviderError(
+  error: ProviderError,
+  ctx: ProviderErrorLogContext = {},
+): void {
+  const verbatim = error.kind === "unknown" ? error.raw_excerpt : error.message;
+  const line =
+    `[provider_error] provider=${error.provider} model=${ctx.model ?? "?"} ` +
+    `status=${ctx.status ?? "?"}${ctx.sdkError ? ` error=${ctx.sdkError}` : ""} ` +
+    `kind=${error.kind} :: ${verbatim}`;
+  if (EXPECTED_KINDS.has(error.kind)) console.warn(line);
+  else console.error(line);
+}

--- a/packages/runtime/src/auth/serve-log.test.ts
+++ b/packages/runtime/src/auth/serve-log.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import {
+  logServeProbeFailure,
+  noteServeProbeOk,
+  resetServeProbeLog,
+} from "./serve-log";
+
+let error: ReturnType<typeof vi.spyOn>;
+let warn: ReturnType<typeof vi.spyOn>;
+let info: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  resetServeProbeLog();
+  error = vi.spyOn(console, "error").mockImplementation(() => {});
+  warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  info = vi.spyOn(console, "info").mockImplementation(() => {});
+});
+
+test("the first failure logs an error; identical repeats demote to warnings", () => {
+  logServeProbeFailure("anthropic", "502: credential expired");
+  logServeProbeFailure("anthropic", "502: credential expired");
+  logServeProbeFailure("anthropic", "502: credential expired");
+  expect(error).toHaveBeenCalledOnce();
+  expect(warn).toHaveBeenCalledTimes(2);
+});
+
+test("a CHANGED failure detail logs a fresh error", () => {
+  logServeProbeFailure("anthropic", "502: credential expired");
+  logServeProbeFailure("anthropic", "fetch failed");
+  expect(error).toHaveBeenCalledTimes(2);
+});
+
+test("failures dedup per provider, not globally", () => {
+  logServeProbeFailure("anthropic", "502: credential expired");
+  logServeProbeFailure("openai-codex", "502: credential expired");
+  expect(error).toHaveBeenCalledTimes(2);
+});
+
+test("recovery logs once and re-arms the error for the next incident", () => {
+  logServeProbeFailure("anthropic", "502: credential expired");
+  noteServeProbeOk("anthropic");
+  expect(info).toHaveBeenCalledWith("[serve] credential anthropic recovered");
+  logServeProbeFailure("anthropic", "502: credential expired");
+  expect(error).toHaveBeenCalledTimes(2);
+});
+
+test("a clean probe with no prior failure stays silent", () => {
+  noteServeProbeOk("anthropic");
+  expect(info).not.toHaveBeenCalled();
+});

--- a/packages/runtime/src/auth/serve-log.ts
+++ b/packages/runtime/src/auth/serve-log.ts
@@ -1,0 +1,30 @@
+/**
+ * Serve-probe failure log dedup. A failing central credential (a gateway 502,
+ * a control-plane blip) is re-probed by EVERY hydrating route and every turn,
+ * so logging each repeat at error level turned one incident into hundreds of
+ * Sentry events (HOUSTON-APP-4XG and its six sibling groupings). Only a
+ * TRANSITION logs as an error — the first failure, or a failure whose detail
+ * changed; identical repeats demote to warning breadcrumbs, and recovery is
+ * logged so an incident's span is readable from the log alone.
+ */
+const lastFailureDetail = new Map<string, string>();
+
+export function logServeProbeFailure(provider: string, detail: string): void {
+  if (lastFailureDetail.get(provider) === detail) {
+    console.warn(`[serve] credential ${provider} still failing: ${detail}`);
+    return;
+  }
+  lastFailureDetail.set(provider, detail);
+  console.error(`[serve] credential ${provider}: ${detail}`);
+}
+
+/** Called when a probe answers cleanly (served or authoritative not-connected). */
+export function noteServeProbeOk(provider: string): void {
+  if (lastFailureDetail.delete(provider))
+    console.info(`[serve] credential ${provider} recovered`);
+}
+
+/** Test seam: the dedup state is module-global, one runtime process = one serve loop. */
+export function resetServeProbeLog(): void {
+  lastFailureDetail.clear();
+}

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -9,6 +9,7 @@ import {
   scrubRefreshTokensAt,
   writeServedProvidersAt,
 } from "./auth-file";
+import { logServeProbeFailure, noteServeProbeOk } from "./serve-log";
 import { authStorage } from "./storage";
 
 /**
@@ -161,6 +162,7 @@ async function runServedSync(): Promise<string[]> {
   const manifest = new Set(readServedProvidersAt(servedManifestPathFor()));
   let manifestDirty = false;
   for (const probe of probes) {
+    if (probe.state !== "error") noteServeProbeOk(probe.id);
     if (probe.state === "served") {
       applyServedCredential(authPathFor(), probe.cred);
       applied.push(probe.id);
@@ -176,7 +178,9 @@ async function runServedSync(): Promise<string[]> {
       manifest.delete(probe.id);
       manifestDirty = true;
     } else if (probe.state === "error") {
-      console.error(`[serve] credential ${probe.id}: ${probe.detail}`);
+      // Dedup lives in serve-log.ts: every turn and hydrating route re-probes,
+      // so a persistent gateway failure must not emit one Sentry error each.
+      logServeProbeFailure(probe.id, probe.detail);
     }
   }
   if (manifestDirty)

--- a/packages/runtime/src/backends/claude/errors.test.ts
+++ b/packages/runtime/src/backends/claude/errors.test.ts
@@ -1,8 +1,29 @@
 import { beforeEach, expect, test, vi } from "vitest";
 import { classifyText, mapSdkError } from "./errors";
 
+let consoleError: ReturnType<typeof vi.spyOn>;
+let consoleWarn: ReturnType<typeof vi.spyOn>;
+
 beforeEach(() => {
-  vi.spyOn(console, "error").mockImplementation(() => {});
+  consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+test("expected external kinds log as warnings; auth and unknown stay errors", () => {
+  mapSdkError("rate_limit", { message: "429 slow down", model: "m" });
+  mapSdkError("overloaded", { message: "529 overloaded", model: "m" });
+  expect(consoleWarn).toHaveBeenCalledTimes(2);
+  expect(consoleError).not.toHaveBeenCalled();
+
+  mapSdkError("authentication_failed", { message: "401 expired", model: "m" });
+  expect(consoleError).toHaveBeenCalledOnce();
+});
+
+test("a fall-through enum logs exactly once (via the text classifier)", () => {
+  mapSdkError("unknown", { message: "something odd", model: null });
+  expect(consoleError.mock.calls.length + consoleWarn.mock.calls.length).toBe(
+    1,
+  );
 });
 
 test("authentication_failed → unauthenticated, cause read from the message text", () => {
@@ -148,8 +169,16 @@ test("classifyText passes provider + status through the shared classifier", () =
   });
 });
 
-test("the verbatim provider text is logged before it is reduced to a card", () => {
-  const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+test("the verbatim provider text is logged once it is reduced to a card", () => {
+  // An expected external kind (rate_limited) logs as a warning breadcrumb —
+  // the verbatim provider text must still be in the line.
   mapSdkError("rate_limit", { message: "429 slow down", model: "m" });
-  expect(spy).toHaveBeenCalledWith(expect.stringContaining("429 slow down"));
+  expect(consoleWarn).toHaveBeenCalledWith(
+    expect.stringContaining("429 slow down"),
+  );
+  // A bug-signaling kind keeps the verbatim text on the error path.
+  mapSdkError("authentication_failed", { message: "401 expired", model: "m" });
+  expect(consoleError).toHaveBeenCalledWith(
+    expect.stringContaining("401 expired"),
+  );
 });

--- a/packages/runtime/src/backends/claude/errors.ts
+++ b/packages/runtime/src/backends/claude/errors.ts
@@ -4,6 +4,7 @@ import {
   classifyProviderError,
   extractRetryAfterSeconds,
 } from "../../ai/provider-error";
+import { logProviderError } from "../../ai/provider-error-log";
 
 /** The pi provider id this backend runs as — every error is attributed to it. */
 const PROVIDER = "anthropic";
@@ -26,8 +27,10 @@ export interface SdkErrorContext {
  * already classified the failure, so `rate_limit` is always a rate-limit card
  * regardless of the message text (unlike the pi path, which parses a flat string).
  *
- * The verbatim provider text is logged before it is reduced to a typed card
- * (parity with `pi/wire.ts`) — the raw reason is otherwise lost once collapsed.
+ * The verbatim provider text is logged AFTER it is reduced to a typed card
+ * (parity with `pi/wire.ts`), through the severity-aware `logProviderError` —
+ * the raw reason is otherwise lost once collapsed, and each failure logs
+ * exactly once (the fall-through to `classifyText` used to double-log).
  *
  * `invalid_request` / `max_output_tokens` / `unknown` have no clean card of their
  * own, so they fall through to the shared text classifier with the status the SDK
@@ -40,12 +43,20 @@ export function mapSdkError(
   const message = ctx.message.trim() || "Unknown provider error";
   const model = ctx.model;
   const status = ctx.status ?? null;
-  console.error(
-    `[provider_error] provider=${PROVIDER} model=${model ?? "?"} status=${
-      status ?? "?"
-    } error=${error} :: ${message}`,
-  );
+  const mapped = mapSdkEnum(error, message, model, status, ctx);
+  // Fall-through cases delegate to classifyText, which logs for itself.
+  if (mapped) logProviderError(mapped, { model, status, sdkError: error });
+  return mapped ?? classifyText(message, model, status);
+}
 
+/** The enum-determined mappings; null falls through to the text classifier. */
+function mapSdkEnum(
+  error: SDKAssistantMessageError,
+  message: string,
+  model: string | null,
+  status: number | null,
+  ctx: SdkErrorContext,
+): ProviderError | null {
   switch (error) {
     case "authentication_failed":
     case "oauth_org_not_allowed":
@@ -93,9 +104,9 @@ export function mapSdkError(
           suggested_fallback: null,
           message,
         };
-      return classifyText(message, model, status);
+      return null;
     default:
-      return classifyText(message, model, status);
+      return null;
   }
 }
 
@@ -105,12 +116,14 @@ export function classifyText(
   model: string | null,
   status: number | null,
 ): ProviderError {
-  console.error(
-    `[provider_error] provider=${PROVIDER} model=${model ?? "?"} status=${
-      status ?? "?"
-    } :: ${message}`,
-  );
-  return classifyProviderError({ provider: PROVIDER, model, message, status });
+  const classified = classifyProviderError({
+    provider: PROVIDER,
+    model,
+    message,
+    status,
+  });
+  logProviderError(classified, { model, status });
+  return classified;
 }
 
 /**

--- a/packages/runtime/src/backends/pi/wire.ts
+++ b/packages/runtime/src/backends/pi/wire.ts
@@ -6,6 +6,7 @@ import {
   type WireEvent,
 } from "@houston/runtime-client";
 import { classifyProviderError } from "../../ai/provider-error";
+import { logProviderError } from "../../ai/provider-error-log";
 
 /**
  * Normalize pi's per-message `Usage` into our provider-agnostic `TokenUsage`.
@@ -118,27 +119,22 @@ export function toWire(e: AgentSessionEvent): WireEvent | null {
         msg.stopReason === "error" &&
         msg.errorMessage
       ) {
-        // Log the provider's VERBATIM failure text before it's reduced to a typed
-        // card. The classifier collapses it into "unauthenticated" / "rate_limited"
-        // / etc., but the raw reason (an opencode.ai 401 body, an entitlement 403,
-        // a misclassified non-auth error) is otherwise never recorded — leaving
-        // production provider failures undiagnosable from the engine logs.
-        console.error(
-          `[provider_error] provider=${msg.provider} model=${
-            msg.model ?? "?"
-          } status=${diagnosticStatus(msg.diagnostics) ?? "?"} :: ${
-            msg.errorMessage
-          }`,
-        );
-        return {
-          type: "provider_error",
-          data: classifyProviderError({
-            provider: msg.provider,
-            model: msg.model ?? null,
-            message: msg.errorMessage,
-            status: diagnosticStatus(msg.diagnostics),
-          }),
-        };
+        // Log the provider's VERBATIM failure text once it's reduced to a typed
+        // card (severity follows the classified kind — an expected 429/503 is a
+        // warning breadcrumb, not a Sentry error). The classifier collapses it
+        // into "unauthenticated" / "rate_limited" / etc., but the raw reason (an
+        // opencode.ai 401 body, an entitlement 403, a misclassified non-auth
+        // error) is otherwise never recorded — leaving production provider
+        // failures undiagnosable from the engine logs.
+        const status = diagnosticStatus(msg.diagnostics);
+        const classified = classifyProviderError({
+          provider: msg.provider,
+          model: msg.model ?? null,
+          message: msg.errorMessage,
+          status,
+        });
+        logProviderError(classified, { model: msg.model ?? null, status });
+        return { type: "provider_error", data: classified };
       }
       // Otherwise its usage carries the latest request's context size = the
       // current context fill. Only an assistant message carries `usage`; other

--- a/packages/runtime/src/transport/conversation-routes.ts
+++ b/packages/runtime/src/transport/conversation-routes.ts
@@ -187,8 +187,12 @@ async function handleStartTurn(ctx: RouteContext, id: string) {
   const pinnedProvider =
     typeof provider === "string" && provider ? provider : undefined;
   if (!(await ensureProviderForTurn()) && !pinnedProvider) {
+    // `code` is the machine-readable half: the host's scheduler reads it to
+    // demote a routine firing into this expected user state (nothing connected
+    // yet) to a warning instead of a Sentry error (HOUSTON-APP-4XM).
     json(ctx.res, 409, {
       error: "No provider connected. Connect an AI provider first.",
+      code: "no_provider",
     });
     return;
   }


### PR DESCRIPTION
## What

Three severity-correctness follow-ups to #937/#957, driven by the remaining unresolved `deployment:managed-cloud` Sentry clusters:

1. **Serve-probe failure dedup** (HOUSTON-APP-4XG, 4XB, 4XH, 4W0, 4XC, 4XK, 4XF — ~150 events): every turn and hydrating route re-probes the credential gateway, so one incident logged hundreds of identical `[serve] credential anthropic: 500 …` errors across seven issue groupings. New `serve-log.ts`: only a state **transition** logs as an error; identical repeats demote to warning breadcrumbs, and recovery is logged so an incident's span is readable from the log alone.

2. **Typed `TurnFireError` + `no_provider` code** (HOUSTON-APP-4XM, 4WK): a routine firing while the workspace has nothing connected is an expected user state — the run record already surfaces the real reason in the routine's history. The runtime's 409 now carries `code: "no_provider"`, `ProxyChannel.fireTurn` throws a typed error, and the scheduler demotes exactly that case to a warning. Other fire failures stay loud.

3. **`[provider_error]` severity by taxonomy kind** (HOUSTON-APP-4WY, 4XN, 4WF, 4WT, 4W7, 4WM, 4WC, 4WB): expected external states (`rate_limited`, `quota_exhausted`, `model_unavailable`, `context_overflow`, `provider_internal`, `network_unreachable`) log as warning breadcrumbs — the chat already renders each as its inline card. `unauthenticated` and `unknown` stay errors: on a managed pod an auth failure means central credential custody broke (that signal is what surfaced the 4XG storm), and an unclassified failure is by definition untriaged. Also fixes a latent double-log on `mapSdkError` fall-through.

No user-visible behavior changes: every failure still surfaces to the user exactly as before (cards, run records); only the crash-report severity changes.

## Tests

- `serve-log.test.ts` — transition/repeat/recovery/per-provider dedup semantics.
- `fire-error.test.ts` — `errorCodeFrom` parsing (JSON code, code-less, non-JSON, non-string).
- `scheduler.test.ts` — no-provider 409 records the errored run but warns instead of erroring; generic failures still error.
- `errors.test.ts` — severity per kind, verbatim text preserved on both paths, fall-through logs exactly once.
- Full suites green: runtime 700/700, host all passed, `pnpm check` exits 0, `pnpm -r typecheck` all 25 projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)