### PR TITLE
fix(runtime-client): retry transient object-store failures instead of failing hydrate/sync

### DIFF
--- a/packages/runtime-client/src/object-sync/http-store.test.ts
+++ b/packages/runtime-client/src/object-sync/http-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "vitest";
@@ -87,6 +87,7 @@ test("propagates response details and rejects malformed success bodies", async (
     baseUrl: "https://store.test/base",
     token: "token",
     fetchImpl: async () => new Response("gateway exploded", { status: 503 }),
+    retryDelaysMs: [0, 0],
   });
   await expect(failed.list("workspace")).rejects.toThrow(
     "object store GET manifest failed (503): gateway exploded",
@@ -107,4 +108,110 @@ test("tolerates delete 404", async () => {
     fetchImpl: async () => new Response("missing", { status: 404 }),
   });
   await expect(store.delete("missing.txt")).resolves.toBeUndefined();
+});
+
+const flaky = (
+  failures: Array<Error | Response>,
+  then: () => Response,
+): { fetchImpl: typeof fetch; calls: () => number } => {
+  let calls = 0;
+  return {
+    fetchImpl: async () => {
+      calls += 1;
+      const failure = failures.shift();
+      if (failure === undefined) return then();
+      if (failure instanceof Error) throw failure;
+      return failure;
+    },
+    calls: () => calls,
+  };
+};
+
+const retryStore = (fetchImpl: typeof fetch) =>
+  new HttpObjectStore({
+    baseUrl: "https://store.test/base",
+    token: "token",
+    fetchImpl,
+    retryDelaysMs: [0, 0],
+  });
+
+test("retries a thrown network error and succeeds", async () => {
+  const { fetchImpl, calls } = flaky([new TypeError("fetch failed")], () =>
+    Response.json({ objects: [metadata("a.txt", 1)] }),
+  );
+  expect(await retryStore(fetchImpl).list("")).toEqual(["a.txt"]);
+  expect(calls()).toBe(2);
+});
+
+test("retries a 503 response and succeeds", async () => {
+  const { fetchImpl, calls } = flaky(
+    [new Response("gateway restarting", { status: 503 })],
+    () => Response.json({ objects: [] }),
+  );
+  expect(await retryStore(fetchImpl).list("")).toEqual([]);
+  expect(calls()).toBe(2);
+});
+
+test("does not retry deterministic statuses", async () => {
+  for (const status of [400, 401, 404, 500]) {
+    const { fetchImpl, calls } = flaky(
+      [],
+      () => new Response("nope", { status }),
+    );
+    await expect(retryStore(fetchImpl).list("")).rejects.toThrow(
+      `object store GET manifest failed (${status})`,
+    );
+    expect(calls()).toBe(1);
+  }
+});
+
+test("rethrows the last error once retries are exhausted", async () => {
+  const { fetchImpl, calls } = flaky(
+    [
+      new TypeError("fetch failed"),
+      new TypeError("fetch failed"),
+      new TypeError("fetch failed again"),
+    ],
+    () => Response.json({ objects: [] }),
+  );
+  await expect(retryStore(fetchImpl).list("")).rejects.toThrow(
+    "fetch failed again",
+  );
+  expect(calls()).toBe(3);
+});
+
+test("retries upload and delete through transient failures", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "http-object-store-retry-"));
+  const source = join(dir, "source.txt");
+  writeFileSync(source, "hello");
+
+  const put = flaky([new TypeError("fetch failed")], () =>
+    Response.json(metadata("file.txt", 5)),
+  );
+  await expect(
+    retryStore(put.fetchImpl).upload(source, "file.txt"),
+  ).resolves.toBeUndefined();
+  expect(put.calls()).toBe(2);
+
+  const del = flaky(
+    [new Response("bad gateway", { status: 502 })],
+    () => new Response(null, { status: 204 }),
+  );
+  await expect(
+    retryStore(del.fetchImpl).delete("file.txt"),
+  ).resolves.toBeUndefined();
+  expect(del.calls()).toBe(2);
+});
+
+test("retries download and still writes the file atomically", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "http-object-store-retry-dl-"));
+  const destination = join(dir, "nested", "dest.txt");
+  const { fetchImpl, calls } = flaky(
+    [new Response("unavailable", { status: 503 })],
+    () => new Response("payload"),
+  );
+  await retryStore(fetchImpl).download("file.txt", destination);
+  expect(readFileSync(destination, "utf8")).toBe("payload");
+  expect(calls()).toBe(2);
+  expect(readdirSync(join(dir, "nested"))).toEqual(["dest.txt"]);
 });

--- a/packages/runtime-client/src/object-sync/http-store.ts
+++ b/packages/runtime-client/src/object-sync/http-store.ts
@@ -6,12 +6,15 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import type { ObjectStore } from "./object-store";
+import { fetchWithRetry } from "./retry";
 
 export interface HttpObjectStoreOptions {
   /** Full agent-scoped base URL ending in `/v1/pod/store/<org>/<agent>`. */
   baseUrl: string;
   token: string;
   fetchImpl?: typeof fetch;
+  /** One delay per retry of a transient failure; override to speed up tests. */
+  retryDelaysMs?: number[];
 }
 
 interface ObjectMetadata {
@@ -30,16 +33,18 @@ export class HttpObjectStore implements ObjectStore {
   private readonly baseUrl: string;
   private readonly token: string;
   private readonly fetchImpl: typeof fetch;
+  private readonly retryDelaysMs: number[] | undefined;
 
   constructor(opts: HttpObjectStoreOptions) {
     this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
     this.token = opts.token;
     this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.retryDelaysMs = opts.retryDelaysMs;
   }
 
   async list(prefix: string): Promise<string[]> {
     const query = prefix ? `?prefix=${encodeURIComponent(prefix)}` : "";
-    const res = await this.fetchImpl(`${this.baseUrl}/manifest${query}`, {
+    const res = await this.fetch(`${this.baseUrl}/manifest${query}`, {
       headers: this.authHeaders(),
     });
     if (!res.ok) throw await this.responseError(res, "GET", "manifest");
@@ -53,7 +58,7 @@ export class HttpObjectStore implements ObjectStore {
   }
 
   async download(key: string, destFile: string): Promise<void> {
-    const res = await this.fetchImpl(this.objectUrl(key), {
+    const res = await this.fetch(this.objectUrl(key), {
       headers: this.authHeaders(),
     });
     if (!res.ok) throw await this.responseError(res, "GET", key);
@@ -76,7 +81,7 @@ export class HttpObjectStore implements ObjectStore {
   }
 
   async upload(srcFile: string, key: string): Promise<void> {
-    const res = await this.fetchImpl(this.objectUrl(key), {
+    const res = await this.fetch(this.objectUrl(key), {
       method: "PUT",
       headers: this.authHeaders(),
       body: await readFile(srcFile),
@@ -89,13 +94,24 @@ export class HttpObjectStore implements ObjectStore {
   }
 
   async delete(key: string): Promise<void> {
-    const res = await this.fetchImpl(this.objectUrl(key), {
+    const res = await this.fetch(this.objectUrl(key), {
       method: "DELETE",
       headers: this.authHeaders(),
     });
     if (!res.ok && res.status !== 404) {
       throw await this.responseError(res, "DELETE", key);
     }
+  }
+
+  /**
+   * All four operations are safe to re-issue: GETs are read-only and PUT /
+   * DELETE of a single object are idempotent, so transient gateway failures
+   * retry here instead of failing readiness-gating hydration or sync-back.
+   */
+  private fetch(url: string, init?: RequestInit): Promise<Response> {
+    return fetchWithRetry(this.fetchImpl, url, init, {
+      delaysMs: this.retryDelaysMs,
+    });
   }
 
   private objectUrl(key: string): string {

--- a/packages/runtime-client/src/object-sync/retry.test.ts
+++ b/packages/runtime-client/src/object-sync/retry.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "vitest";
+import { DEFAULT_RETRY_DELAYS_MS, fetchWithRetry } from "./retry";
+
+test("waits the default 500ms/2000ms schedule between transient attempts", async () => {
+  const waits: number[] = [];
+  let calls = 0;
+  const fetchImpl: typeof fetch = async () => {
+    calls += 1;
+    throw new TypeError("fetch failed");
+  };
+  await expect(
+    fetchWithRetry(fetchImpl, "https://store.test", undefined, {
+      sleep: async (ms) => {
+        waits.push(ms);
+      },
+    }),
+  ).rejects.toThrow("fetch failed");
+  expect(calls).toBe(3);
+  expect(waits).toEqual(DEFAULT_RETRY_DELAYS_MS);
+  expect(DEFAULT_RETRY_DELAYS_MS).toEqual([500, 2000]);
+});
+
+test("returns a transient status untouched on the final attempt", async () => {
+  const waits: number[] = [];
+  const fetchImpl: typeof fetch = async () =>
+    new Response("still down", { status: 504 });
+  const res = await fetchWithRetry(fetchImpl, "https://store.test", undefined, {
+    delaysMs: [1, 2],
+    sleep: async (ms) => {
+      waits.push(ms);
+    },
+  });
+  expect(res.status).toBe(504);
+  expect(waits).toEqual([1, 2]);
+});
+
+test("an empty delay list disables retries entirely", async () => {
+  let calls = 0;
+  const fetchImpl: typeof fetch = async () => {
+    calls += 1;
+    throw new TypeError("fetch failed");
+  };
+  await expect(
+    fetchWithRetry(fetchImpl, "https://store.test", undefined, {
+      delaysMs: [],
+    }),
+  ).rejects.toThrow("fetch failed");
+  expect(calls).toBe(1);
+});

--- a/packages/runtime-client/src/object-sync/retry.ts
+++ b/packages/runtime-client/src/object-sync/retry.ts
@@ -1,0 +1,43 @@
+/**
+ * Managed pods reach the object store through the gateway, so a single
+ * transient blip (gateway restart, DNS hiccup) must not fail a whole boot
+ * hydrate or sync-back. Retries are bounded and limited to failures that carry
+ * no deterministic answer: network-level rejections thrown by fetch itself and
+ * 502/503/504 responses. Every other status is the server's real answer and is
+ * returned to the caller unretried.
+ */
+
+const TRANSIENT_STATUSES = new Set([502, 503, 504]);
+
+/** One delay per retry, so attempts = delays + 1. */
+export const DEFAULT_RETRY_DELAYS_MS = [500, 2000];
+
+export interface FetchRetryOptions {
+  /** Override to shrink delays (or drop retries) in tests. */
+  delaysMs?: number[];
+  /** Injectable so tests can observe waits without real timers. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const realSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export async function fetchWithRetry(
+  fetchImpl: typeof fetch,
+  url: string,
+  init: RequestInit | undefined,
+  opts: FetchRetryOptions = {},
+): Promise<Response> {
+  const delays = opts.delaysMs ?? DEFAULT_RETRY_DELAYS_MS;
+  const sleep = opts.sleep ?? realSleep;
+  for (let attempt = 0; ; attempt += 1) {
+    const lastAttempt = attempt >= delays.length;
+    try {
+      const res = await fetchImpl(url, init);
+      if (lastAttempt || !TRANSIENT_STATUSES.has(res.status)) return res;
+    } catch (err) {
+      if (lastAttempt) throw err;
+    }
+    await sleep(delays[attempt] ?? 0);
+  }
+}


### PR DESCRIPTION
## What

HOUSTON-APP-4WP / 4WN / 4XP: managed engine pods fail with `TypeError: fetch failed` (undici network error) out of `HttpObjectStore` — during **boot-time hydrate** (`list` from `StoreSyncDaemon.hydrate`, which gates the pod's readiness probe) and during `syncBack` uploads. A single transient blip (gateway restart during a deploy, DNS) currently fails the whole operation; boot hydrate has no retry at all, so one lost packet delays a pod wake.

New `object-sync/retry.ts`: bounded `fetchWithRetry` — 3 attempts total with 500ms/2s backoff, retrying **only** (a) errors thrown by fetch (network-level) and (b) 502/503/504 responses. Any other status is the server's deterministic answer and returns immediately. On exhaustion the last error is rethrown / the transient status returned untouched, so callers produce exactly today's errors — no catch-and-continue anywhere. All four ops (`list`, `download`, `upload`, `delete`) route through it; retry sits at the fetch layer, before `download` streams its body, so the atomic temp-file rename/cleanup runs at most once per successful response. `upload`'s body is a Buffer, safe to resend.

`retryDelaysMs` is injectable (tests run with zero delays).

## Tests

- Thrown network error then success; 503 then success; 400/401/404/500 never retried; exhausted retries rethrow the last error after exactly 3 calls; upload/delete retry paths; download stays atomic with no leftover temp file across attempts.
- `pnpm --filter @houston/runtime-client test`: 15 files, 129/129 passed. `pnpm check` exits 0; full-workspace typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)