### PR TITLE
fix(runtime): Claude context fill sized from per-request usage, not the turn aggregate

### DIFF
--- a/packages/runtime/src/backends/claude/translate.test.ts
+++ b/packages/runtime/src/backends/claude/translate.test.ts
@@ -72,6 +72,18 @@ function result(
   } as unknown as SDKMessage;
 }
 
+function assistantUsage(
+  usage: unknown,
+  over: Record<string, unknown> = {},
+): SDKMessage {
+  return {
+    type: "assistant",
+    message: { role: "assistant", model: "m", content: [], usage },
+    parent_tool_use_id: null,
+    ...over,
+  } as unknown as SDKMessage;
+}
+
 function collect(msgs: SDKMessage[]): { events: WireEvent[]; ctx: number[] } {
   const ctx: number[] = [];
   const t = createStreamTranslator({ onContextTokens: (n) => ctx.push(n) });
@@ -212,6 +224,92 @@ test("a success result yields a usage frame and updates context tokens", () => {
     },
   ]);
   expect(ctx).toEqual([450]);
+});
+
+test("an agentic turn's usage frame is the LAST request's usage, never the result's turn aggregate", () => {
+  // Two API requests (a tool round-trip): the context is re-sent each time, so
+  // the result's aggregate (~sum of both) reads far above the real fill. The
+  // frame + context tokens must follow the per-request numbers.
+  const { events, ctx } = collect([
+    assistantUsage({
+      input_tokens: 1_000,
+      output_tokens: 50,
+      cache_read_input_tokens: 30_000,
+      cache_creation_input_tokens: 2_000,
+    }),
+    assistantUsage({
+      input_tokens: 500,
+      output_tokens: 40,
+      cache_read_input_tokens: 33_000,
+      cache_creation_input_tokens: 1_000,
+    }),
+    result({
+      input_tokens: 1_500,
+      output_tokens: 90,
+      cache_read_input_tokens: 63_000,
+      cache_creation_input_tokens: 3_000,
+    }),
+  ]);
+  expect(events).toEqual([
+    {
+      type: "usage",
+      data: {
+        context_tokens: 34_500,
+        output_tokens: 40,
+        cached_tokens: 33_000,
+      },
+    },
+  ]);
+  expect(ctx).toEqual([33_000, 34_500, 34_500]);
+});
+
+test("subagent and errored assistant usage never count toward the context fill", () => {
+  const sub = assistantUsage(
+    { input_tokens: 400_000, output_tokens: 10, cache_read_input_tokens: 0 },
+    { parent_tool_use_id: "task-1" },
+  );
+  const errored = assistantUsage(
+    { input_tokens: 500_000, output_tokens: 0 },
+    { error: "overloaded" },
+  );
+  const { events, ctx } = collect([
+    sub,
+    errored,
+    result({ input_tokens: 100, output_tokens: 5 }),
+  ]);
+  // The errored assistant emits its provider_error; the usage frame falls back
+  // to the result (one clean request never happened this turn).
+  expect(events.filter((e) => e.type === "usage")).toEqual([
+    {
+      type: "usage",
+      data: { context_tokens: 100, output_tokens: 5, cached_tokens: 0 },
+    },
+  ]);
+  expect(ctx).toEqual([100]);
+});
+
+test("a compact_boundary after the last request re-anchors the turn's usage frame", () => {
+  const boundary = {
+    type: "system",
+    subtype: "compact_boundary",
+    compact_metadata: { trigger: "auto", pre_tokens: 900, post_tokens: 120 },
+  } as unknown as SDKMessage;
+  const { events, ctx } = collect([
+    assistantUsage({
+      input_tokens: 800,
+      output_tokens: 30,
+      cache_read_input_tokens: 100,
+    }),
+    boundary,
+    result({ input_tokens: 800, output_tokens: 30 }),
+  ]);
+  expect(events).toEqual([
+    {
+      type: "usage",
+      data: { context_tokens: 120, output_tokens: 30, cached_tokens: 0 },
+    },
+  ]);
+  expect(ctx).toEqual([900, 120, 120]);
 });
 
 test("an error result classifies to a provider_error (with usage first when present)", () => {

--- a/packages/runtime/src/backends/claude/translate.ts
+++ b/packages/runtime/src/backends/claude/translate.ts
@@ -1,5 +1,9 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
-import { clipToolResult, type WireEvent } from "@houston/runtime-client";
+import {
+  clipToolResult,
+  type TokenUsage,
+  type WireEvent,
+} from "@houston/runtime-client";
 import { classifyText, mapSdkError } from "./errors";
 import {
   type EventLike,
@@ -37,6 +41,13 @@ export function createStreamTranslator(cb: TranslatorCallbacks) {
   // At most one provider_error per turn: an errored assistant message and an
   // error result can both describe the same failure — never double-terminal.
   let emittedError = false;
+  // The newest PER-REQUEST usage seen this turn (main thread only). This — not
+  // the result message's turn-cumulative aggregate — is what sizes the context
+  // window: each tool round-trip re-sends the whole context (mostly cache
+  // reads), so the aggregate over an agentic turn reads ~N× the real fill and
+  // once made a 3-message Claude chat report a full 1M window. Mirrors pi,
+  // whose turn_end usage is the final assistant message's own request.
+  let lastRequestUsage: TokenUsage | null = null;
 
   function translate(msg: SDKMessage): WireEvent[] {
     switch (msg.type) {
@@ -54,7 +65,19 @@ export function createStreamTranslator(cb: TranslatorCallbacks) {
       case "system":
         if (msg.subtype === "compact_boundary") {
           const post = msg.compact_metadata?.post_tokens;
-          if (typeof post === "number") cb.onContextTokens(post);
+          if (typeof post === "number") {
+            cb.onContextTokens(post);
+            // The compaction just shrank the context: a request usage seen
+            // BEFORE the boundary no longer describes the fill, so re-anchor
+            // it — else a boundary arriving as the turn's last signal would
+            // resurrect the pre-compaction fill on the result's usage frame.
+            if (lastRequestUsage)
+              lastRequestUsage = {
+                ...lastRequestUsage,
+                context_tokens: post,
+                cached_tokens: 0,
+              };
+          }
         }
         return [];
       default:
@@ -124,6 +147,19 @@ export function createStreamTranslator(cb: TranslatorCallbacks) {
   }
 
   function onAssistant(msg: AssistantMsg): WireEvent[] {
+    // Per-request usage: each assistant message carries ITS API call's usage,
+    // whose input + cache reads/writes = the context size of that request —
+    // the live fill. Track the newest one so the turn's usage frame reports
+    // the real window occupancy. Skipped for subagent messages (a subagent
+    // fills its OWN context, not this conversation's) and for errored
+    // responses (pi likewise only trusts clean assistant usage).
+    if (!msg.error && msg.parent_tool_use_id === null) {
+      const requestUsage = normalizeUsage(msg.message?.usage);
+      if (requestUsage) {
+        lastRequestUsage = requestUsage;
+        cb.onContextTokens(requestUsage.context_tokens);
+      }
+    }
     if (!msg.error || emittedError) return [];
     emittedError = true;
     const content = msg.message?.content;
@@ -149,7 +185,11 @@ export function createStreamTranslator(cb: TranslatorCallbacks) {
 
   function onResult(msg: ResultMsg): WireEvent[] {
     const out: WireEvent[] = [];
-    const usage = normalizeUsage(msg.usage);
+    // The turn's usage frame is the LAST request's usage (the current context
+    // fill — pi parity), never the result's turn-cumulative aggregate. The
+    // aggregate is only the fallback when no assistant usage arrived, where
+    // the two coincide (a turn of exactly one request).
+    const usage = lastRequestUsage ?? normalizeUsage(msg.usage);
     if (usage) {
       out.push({ type: "usage", data: usage });
       cb.onContextTokens(usage.context_tokens);


### PR DESCRIPTION
## Problem

A user reported that after **three messages** with an Anthropic Claude model, Houston showed the **1M-token context window as already full**.

## Root cause

The Claude SDK backend derived the context fill (`context_tokens`) from the SDK **`result` message's `usage`** — which is **cumulative across every API request in the turn** (it sits next to `total_cost_usd` / `num_turns`). Every tool round-trip re-sends the whole context (mostly cache reads), so an agentic turn with N requests reported roughly **N× the real fill**.

Consequences chained:
- The inflated observation exceeded the 200k default in the `MODEL_WINDOW_OVERRIDES` snap-up rule, falsely "proving" the plan-gated 1M window → the bar's denominator snapped to 1M.
- The same inflated number kept growing until the bar read ~full after a handful of agentic messages.
- The runtime's autocompact (93% threshold) fired on the same wrong number every turn — and `ClaudeSession.compact()` is a no-op (the SDK self-compacts), so it published a spurious `context_compacted` divider each turn without ever lowering the reading.

## Survey of the other backends/providers (all verified sound)

- **pi backend** (OpenAI/Codex, Google, OpenRouter, OpenCode, Bedrock, custom endpoints): `turn_end` usage and `getContextUsage()` come from the **final assistant message's own request** — per-request, correct. pi also skips aborted/errored messages and re-anchors after compaction.
- **openai-compatible custom endpoints**: window learned from `context_overflow` rejections (`learnCustomContextWindow`) — unaffected.
- **Shared window rule**: `effectiveModelWindow` (`@houston/protocol/model-windows`) and the frontend's `effectiveContextWindow` share the same table + math — the rule was fine; it was being fed a corrupted observation.

## Fix

In the Claude stream translator:
- Track the **newest per-request usage** from main-thread `assistant` messages (a `BetaMessage.usage` is that single API call's usage; `input + cache_read + cache_creation` **is** the live fill) and use it for the turn's `usage` frame and `onContextTokens` — mirroring pi's contract.
- **Exclude** subagent messages (`parent_tool_use_id != null` — they fill their own window) and errored responses (same rule as pi).
- Keep the `result` aggregate only as **fallback** when no assistant usage arrived — a one-request turn, where the two coincide, so existing behavior for simple turns is byte-identical.
- A `compact_boundary` arriving after the last request **re-anchors** the tracked usage to `post_tokens`, so the turn's frame can't resurrect the pre-compaction fill.

## Tests

New regression tests in `translate.test.ts`:
- agentic turn (2 requests): frame = last request's usage, never the aggregate;
- subagent + errored assistant usage never count toward the fill;
- trailing `compact_boundary` re-anchors the turn's usage frame.

`pnpm --filter @houston/runtime test`: **696 passed**. Biome clean, full workspace typecheck passes (pre-push hook).