### PR TITLE
feat(store-sync): stream large uploads and hashes so multi-GiB files never hit the heap

### DIFF
--- a/packages/runtime-client/src/object-sync/http-store.test.ts
+++ b/packages/runtime-client/src/object-sync/http-store.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "vitest";
-import { HttpObjectStore } from "./http-store";
+import { HttpObjectStore, STREAM_UPLOAD_THRESHOLD_BYTES } from "./http-store";
 import { ObjectTooLargeError } from "./object-store";
 
 const metadata = (key: string, size: number) => ({
@@ -241,4 +241,55 @@ test("a 413 PUT surfaces as the typed ObjectTooLargeError, with no retry", async
   expect(String(err)).toContain("failed (413)");
   // 413 is deterministic — the retry layer must not re-send the body.
   expect(calls).toBe(1);
+});
+
+test("a large file uploads as a per-attempt stream, never one heap buffer", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "houston-store-stream-"));
+  const big = join(dir, "big.mp4");
+  writeFileSync(big, "V".repeat(STREAM_UPLOAD_THRESHOLD_BYTES));
+  const received: number[] = [];
+  let calls = 0;
+  const fetchImpl = (async (_url: unknown, init?: RequestInit) => {
+    calls += 1;
+    expect((init as { duplex?: string }).duplex).toBe("half");
+    expect(init?.body).toBeInstanceOf(ReadableStream);
+    // Drain the stream — a retried attempt must deliver the FULL body again,
+    // which only works if each attempt opened a fresh stream.
+    let bytes = 0;
+    for await (const chunk of init?.body as ReadableStream<Uint8Array>) {
+      bytes += chunk.byteLength;
+    }
+    received.push(bytes);
+    if (calls === 1) return Response.json({ error: "bad gw" }, { status: 503 });
+    return Response.json(metadata("work/big.mp4", bytes));
+  }) as unknown as typeof fetch;
+  const store = new HttpObjectStore({
+    baseUrl: "https://gw.test/v1/pod/store/o/a",
+    token: "pod-token",
+    fetchImpl,
+    retryDelaysMs: [0],
+  });
+
+  await store.upload(big, "work/big.mp4");
+  expect(received).toEqual([
+    STREAM_UPLOAD_THRESHOLD_BYTES,
+    STREAM_UPLOAD_THRESHOLD_BYTES,
+  ]);
+});
+
+test("a small file still uploads as a single buffered body", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "houston-store-small-"));
+  writeFileSync(join(dir, "notes.txt"), "small");
+  let body: unknown;
+  const fetchImpl = (async (_url: unknown, init?: RequestInit) => {
+    body = init?.body;
+    return Response.json(metadata("notes.txt", 5));
+  }) as unknown as typeof fetch;
+  const store = new HttpObjectStore({
+    baseUrl: "https://gw.test/v1/pod/store/o/a",
+    token: "pod-token",
+    fetchImpl,
+  });
+  await store.upload(join(dir, "notes.txt"), "notes.txt");
+  expect(Buffer.isBuffer(body)).toBe(true);
 });

--- a/packages/runtime-client/src/object-sync/http-store.ts
+++ b/packages/runtime-client/src/object-sync/http-store.ts
@@ -1,12 +1,22 @@
 import { randomUUID } from "node:crypto";
-import { createWriteStream } from "node:fs";
-import { mkdir, readFile, rename, rm } from "node:fs/promises";
+import { createReadStream, createWriteStream } from "node:fs";
+import { mkdir, readFile, rename, rm, stat } from "node:fs/promises";
 import { dirname } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { type ObjectStore, ObjectTooLargeError } from "./object-store";
-import { fetchWithRetry } from "./retry";
+import { type FetchRetryOptions, fetchWithRetry } from "./retry";
+
+/**
+ * Files at or above this size PUT as a stream from disk instead of a single
+ * in-heap Buffer — an agent-rendered multi-GiB video must never materialize in
+ * the host process's memory (the pod's limit is a fraction of that). Below it,
+ * the buffered path stays: the delta sync's bread and butter is many small
+ * files, where one read beats stream setup and keeps the body trivially
+ * reusable across retries.
+ */
+export const STREAM_UPLOAD_THRESHOLD_BYTES = 16 * 1024 * 1024;
 
 export interface HttpObjectStoreOptions {
   /** Full agent-scoped base URL ending in `/v1/pod/store/<org>/<agent>`. */
@@ -81,11 +91,32 @@ export class HttpObjectStore implements ObjectStore {
   }
 
   async upload(srcFile: string, key: string): Promise<void> {
-    const res = await this.fetch(this.objectUrl(key), {
-      method: "PUT",
-      headers: this.authHeaders(),
-      body: await readFile(srcFile),
-    });
+    const { size } = await stat(srcFile);
+    const url = this.objectUrl(key);
+    // Large files stream from disk per attempt (a consumed stream cannot be
+    // re-sent, so the retry layer opens a fresh one). No content-length header:
+    // a stream body goes chunked, and the store's GCS writer already picks its
+    // default resumable chunking for unsized bodies — exactly right for files
+    // this size. The gateway's MaxBytesReader still enforces the object cap.
+    const res =
+      size >= STREAM_UPLOAD_THRESHOLD_BYTES
+        ? await this.fetch(
+            url,
+            {
+              method: "PUT",
+              headers: this.authHeaders(),
+              duplex: "half",
+            } as RequestInit,
+            {
+              body: () =>
+                Readable.toWeb(createReadStream(srcFile)) as ReadableStream,
+            },
+          )
+        : await this.fetch(url, {
+            method: "PUT",
+            headers: this.authHeaders(),
+            body: await readFile(srcFile),
+          });
     if (!res.ok) throw await this.responseError(res, "PUT", key);
     const body: unknown = await res.json();
     if (!this.isObjectMetadata(body)) {
@@ -108,9 +139,14 @@ export class HttpObjectStore implements ObjectStore {
    * DELETE of a single object are idempotent, so transient gateway failures
    * retry here instead of failing readiness-gating hydration or sync-back.
    */
-  private fetch(url: string, init?: RequestInit): Promise<Response> {
+  private fetch(
+    url: string,
+    init?: RequestInit,
+    extra?: Pick<FetchRetryOptions, "body">,
+  ): Promise<Response> {
     return fetchWithRetry(this.fetchImpl, url, init, {
       delaysMs: this.retryDelaysMs,
+      ...extra,
     });
   }
 

--- a/packages/runtime-client/src/object-sync/hydrate.test.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.test.ts
@@ -289,3 +289,37 @@ test("a non-cap upload failure still aborts the pass (data loss stays loud)", as
     "500",
   );
 });
+
+test("a large file round-trips: streamed hash agrees across syncBack and hydrate", async () => {
+  const { storeRoot, store, work } = setup();
+  seed(storeRoot, PREFIX, {});
+  const manifest = await hydrate(store, PREFIX, work);
+  mkdirSync(join(work, "workspace"), { recursive: true });
+  // Over the 16 MiB streaming threshold — both the sync-back hash and the
+  // re-hydration hash take the streamed path and must agree with each other.
+  writeFileSync(
+    join(work, "workspace", "big.bin"),
+    "B".repeat(17 * 1024 * 1024),
+  );
+  const result = await syncBack(store, PREFIX, work, manifest);
+  expect(result.uploaded).toEqual(["workspace/big.bin"]);
+  expect(result.totalBytes).toBe(17 * 1024 * 1024);
+
+  // Unchanged → the next pass re-hashes (streamed) and must NOT re-upload.
+  const again = await syncBack(store, PREFIX, work, result.manifest);
+  expect(again.uploaded).toEqual([]);
+
+  // A fresh hydration (streamed hash of the downloaded copy) produces the
+  // same manifest entry, so the first sync after a wake is also a no-op.
+  const rehydrated = await hydrate(
+    store,
+    PREFIX,
+    mkdtempSync(join(tmpdir(), "houston-rehyd-")),
+    {
+      maxBytes: 64 * 1024 * 1024,
+    },
+  );
+  expect(rehydrated.get("workspace/big.bin")).toBe(
+    result.manifest.get("workspace/big.bin"),
+  );
+});

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { basename, join, posix, relative, sep } from "node:path";
 import { type ObjectStore, ObjectTooLargeError } from "./object-store";
@@ -15,6 +16,18 @@ export type HydrateManifest = Map<string, string>; // rel path -> sha256
 export const DEFAULT_EXCLUDES = ["data/auth.json"];
 
 const sha256 = (buf: Buffer) => createHash("sha256").update(buf).digest("hex");
+
+/**
+ * Mirrors http-store's STREAM_UPLOAD_THRESHOLD_BYTES: the same files that are
+ * too big to buffer for upload are too big to buffer for hashing.
+ */
+const STREAM_HASH_THRESHOLD_BYTES = 16 * 1024 * 1024;
+
+async function streamSha256(abs: string): Promise<string> {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(abs)) hash.update(chunk as Buffer);
+  return hash.digest("hex");
+}
 
 const norm = (rel: string) => rel.split(sep).join("/");
 
@@ -91,14 +104,21 @@ export async function hydrate(
       try {
         const dest = join(destDir, ...rel.split("/"));
         await store.download(key, dest);
-        const buf = await readFile(dest);
-        total += buf.byteLength;
+        // Size from stat, hash streamed for large files: wake-hydrating a
+        // multi-GiB object must not buffer it in heap just to digest it.
+        const { size } = await stat(dest);
+        total += size;
         if (total > maxBytes) {
           throw new Error(
             `workspace exceeds the ${Math.round(maxBytes / 1024 / 1024)} MiB hydration limit`,
           );
         }
-        manifest.set(rel, sha256(buf));
+        manifest.set(
+          rel,
+          size >= STREAM_HASH_THRESHOLD_BYTES
+            ? await streamSha256(dest)
+            : sha256(await readFile(dest)),
+        );
       } catch (err) {
         if (!failed) {
           failed = true;
@@ -173,19 +193,24 @@ export async function syncBack(
     // vanished file is indistinguishable from one deleted before the walk:
     // leave it out of the next manifest and let the delete pass reconcile the
     // store, instead of aborting the whole pass mid-upload.
-    let buf: Buffer;
+    let hash: string;
     let size: number;
     try {
       const fileStat = await stat(abs);
       if (!fileStat.isFile()) continue;
       size = fileStat.size;
-      buf = await readFile(abs);
+      // Large files hash as a stream: reading a multi-GiB video into one heap
+      // Buffer would spike the host past its pod memory limit for a digest
+      // that only ever consumes 64 KiB at a time.
+      hash =
+        size >= STREAM_HASH_THRESHOLD_BYTES
+          ? await streamSha256(abs)
+          : sha256(await readFile(abs));
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
       throw err;
     }
     totalBytes += size;
-    const hash = sha256(buf);
     nextManifest.set(rel, hash);
     if (manifest.get(rel) !== hash) {
       try {

--- a/packages/runtime-client/src/object-sync/retry.test.ts
+++ b/packages/runtime-client/src/object-sync/retry.test.ts
@@ -47,3 +47,21 @@ test("an empty delay list disables retries entirely", async () => {
   ).rejects.toThrow("fetch failed");
   expect(calls).toBe(1);
 });
+
+test("the body factory is called once per attempt, so retries send a fresh body", async () => {
+  const bodies: string[] = [];
+  let calls = 0;
+  const fetchImpl = (async (_url: unknown, init?: RequestInit) => {
+    bodies.push(String(init?.body));
+    calls += 1;
+    return new Response(null, { status: calls < 3 ? 503 : 200 });
+  }) as unknown as typeof fetch;
+  let n = 0;
+  const res = await fetchWithRetry(fetchImpl, "https://x.test/o", undefined, {
+    delaysMs: [0, 0],
+    sleep: async () => {},
+    body: () => `body-${++n}`,
+  });
+  expect(res.status).toBe(200);
+  expect(bodies).toEqual(["body-1", "body-2", "body-3"]);
+});

--- a/packages/runtime-client/src/object-sync/retry.ts
+++ b/packages/runtime-client/src/object-sync/retry.ts
@@ -17,6 +17,13 @@ export interface FetchRetryOptions {
   delaysMs?: number[];
   /** Injectable so tests can observe waits without real timers. */
   sleep?: (ms: number) => Promise<void>;
+  /**
+   * Per-attempt body factory for streaming uploads: a ReadableStream body is
+   * consumed by the attempt that sends it, so a retry must open a FRESH stream
+   * — a reused one would send an empty or locked body. Buffer bodies don't
+   * need this and stay on `init.body`.
+   */
+  body?: () => BodyInit;
 }
 
 const realSleep = (ms: number) =>
@@ -33,7 +40,8 @@ export async function fetchWithRetry(
   for (let attempt = 0; ; attempt += 1) {
     const lastAttempt = attempt >= delays.length;
     try {
-      const res = await fetchImpl(url, init);
+      const attemptInit = opts.body ? { ...init, body: opts.body() } : init;
+      const res = await fetchImpl(url, attemptInit);
       if (lastAttempt || !TRANSIENT_STATUSES.has(res.status)) return res;
     } catch (err) {
       if (lastAttempt) throw err;


### PR DESCRIPTION
## What

Stacked on #989; together they make >256 MiB agent files workable. Companion to the gateway cap raise (cloud PR): the per-object cap goes to **2 GiB**, and this PR removes the pod-side memory bottleneck that made that unsafe.

The gateway→GCS leg already streams (resumable 16 MiB chunking in the GCS writer). The pod side didn't:

- `HttpObjectStore.upload` buffered the entire file (`readFile`) into the host's heap — a multi-GiB agent-rendered video would blow the pod's memory limit. Files ≥ 16 MiB now PUT as a stream from disk (`duplex: "half"`), and the retry layer takes a per-attempt body factory so a retried attempt opens a **fresh** stream (a consumed stream can't be re-sent). Small files keep the buffered path — the delta sync's many small objects shouldn't pay stream setup.
- `syncBack` and `hydrate` hashed every file through one `readFile` buffer; both now stream the sha256 for files ≥ the same threshold, and hydrate sizes from `stat` instead of the read buffer — so a big file is also safe to *re-download and verify* on pod wake.

## Tests

- retry: body factory called once per attempt (fresh body per retry).
- http-store: large file streams with `duplex: "half"`, full body delivered on BOTH attempts across a 503 retry; small file still sends a Buffer.
- hydrate: >16 MiB file round-trips — syncBack (streamed hash) → unchanged pass is a no-op → fresh hydrate (streamed hash of the downloaded copy) produces the identical manifest entry.
- runtime-client 136/136, Biome clean, all workspace typechecks pass (app verified standalone; the hook's parallel run was OOM-killed by unrelated machine load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)