### PR TITLE
ci(images): build engine-pod/agentstore on tag push, notify prod sepa…

### DIFF
--- a/.github/workflows/agentstore-image.yml
+++ b/.github/workflows/agentstore-image.yml
@@ -14,10 +14,15 @@
 #   - push to main (paths-filtered, checked in "Determine whether to build"
 #     below): continuous build → dispatches roll-agentstore →
 #     cloud/roll-agentstore-staging.yml rolls staging.
-#   - push of ANY tag (unconditional, no path filter — a tag means "ship
+#   - push of an agentstore-v* tag (no path filter — the tag means "ship
 #     this", and combining paths with a tags trigger is unreliable in GitHub
 #     Actions, since a tag push often carries no commit list to diff against):
 #     dispatches roll-agentstore-prod → cloud/roll-agentstore.yml rolls prod.
+# The tag pattern is deliberately NARROW: this repo's tag namespace already
+# carries other release trains — v*/cloud-v* (desktop, release.yml),
+# cloud-latest (a MOVING pointer that gets re-pushed), ios-v* (TestFlight),
+# engine-v* (self-host host binary), engine-pod-v* (prod engine fleet). Each
+# train versions independently; only agentstore-v* may roll prod agentstore.
 #
 # Publishes two tags per build:
 #   agentstore:<git-sha>  — immutable, by-digest reference used for the roll.
@@ -42,7 +47,7 @@ name: Agent Store Image
 on:
   push:
     branches: [main]
-    tags: ["*"]
+    tags: ["agentstore-v*"]
   workflow_dispatch:
 
 # One build at a time. cancel-in-progress is false so an in-flight build + push +
@@ -68,8 +73,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Any tag or a manual dispatch always builds (a tag IS the release
-      # decision). A push to main only builds when it touched a relevant path
+      # An agentstore-v* tag or a manual dispatch always builds (the tag IS
+      # the release decision; no other tag pattern reaches this workflow).
+      # A push to main only builds when it touched a relevant path
       # — this replaces the old trigger-level `paths:` filter, which can't
       # apply to branch pushes only once the trigger also matches tags.
       #

--- a/.github/workflows/agentstore-image.yml
+++ b/.github/workflows/agentstore-image.yml
@@ -10,6 +10,15 @@
 # by the repository_dispatch fired below. That handoff is the trust boundary and
 # mirrors engine-pod-image.yml → cloud/roll-engine.yml.
 #
+# Two triggers, two audiences:
+#   - push to main (paths-filtered, checked in "Determine whether to build"
+#     below): continuous build → dispatches roll-agentstore →
+#     cloud/roll-agentstore-staging.yml rolls staging.
+#   - push of ANY tag (unconditional, no path filter — a tag means "ship
+#     this", and combining paths with a tags trigger is unreliable in GitHub
+#     Actions, since a tag push often carries no commit list to diff against):
+#     dispatches roll-agentstore-prod → cloud/roll-agentstore.yml rolls prod.
+#
 # Publishes two tags per build:
 #   agentstore:<git-sha>  — immutable, by-digest reference used for the roll.
 #   agentstore:latest     — moving pointer to the newest build (convenience).
@@ -33,10 +42,7 @@ name: Agent Store Image
 on:
   push:
     branches: [main]
-    paths:
-      - "agentstore/**"
-      - "packages/agentstore-contract/**"
-      - ".github/workflows/agentstore-image.yml"
+    tags: ["*"]
   workflow_dispatch:
 
 # One build at a time. cancel-in-progress is false so an in-flight build + push +
@@ -62,44 +68,91 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Any tag or a manual dispatch always builds (a tag IS the release
+      # decision). A push to main only builds when it touched a relevant path
+      # — this replaces the old trigger-level `paths:` filter, which can't
+      # apply to branch pushes only once the trigger also matches tags.
+      #
+      # Diffs github.event.before (main's tip BEFORE this push) against the
+      # new HEAD, NOT just HEAD^ — a single push can carry several commits
+      # (e.g. a non-squash merge), and diffing only the last commit against
+      # its immediate parent would miss relevant paths touched by an EARLIER
+      # commit in the same push. `before` isn't guaranteed to be present in
+      # the shallow clone actions/checkout leaves behind, so it's fetched on
+      # demand; if that fetch fails (or before is the all-zeros SHA GitHub
+      # sends for a branch's first-ever push), fail open and build anyway —
+      # a wasted build is cheap, a silently skipped release isn't.
+      - name: Determine whether to build
+        id: gate
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BASE="${{ github.event.before }}"
+          BUILD=true
+          if [ -n "$BASE" ] && [ "$BASE" != "0000000000000000000000000000000000000000" ] \
+              && git fetch --depth=1 origin "$BASE" 2>/dev/null; then
+            if git diff --name-only "$BASE" "${{ github.sha }}" -- \
+                agentstore packages/agentstore-contract .github/workflows/agentstore-image.yml \
+                | grep -q .; then
+              BUILD=true
+            else
+              BUILD=false
+            fi
+          fi
+          echo "build=$BUILD" >> "$GITHUB_OUTPUT"
+
       - name: Setup pnpm
+        if: steps.gate.outputs.build == 'true'
         uses: pnpm/action-setup@v4
 
       - name: Setup Node
+        if: steps.gate.outputs.build == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
 
       - name: Install
+        if: steps.gate.outputs.build == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Typecheck (contract)
+        if: steps.gate.outputs.build == 'true'
         run: pnpm --filter @houston/agentstore-contract typecheck
 
       - name: Test (contract)
+        if: steps.gate.outputs.build == 'true'
         run: pnpm --filter @houston/agentstore-contract test
 
       - name: Typecheck (agentstore)
+        if: steps.gate.outputs.build == 'true'
         run: pnpm --filter houston-agentstore typecheck
 
       - name: Test (agentstore)
+        if: steps.gate.outputs.build == 'true'
         run: pnpm --filter houston-agentstore test
 
       - name: Auth to GCP
+        if: steps.gate.outputs.build == 'true'
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: projects/1056698080170/locations/global/workloadIdentityPools/github/providers/houston
           service_account: github-deploy-engine@gethouston.iam.gserviceaccount.com
 
       - name: Set up gcloud
+        if: steps.gate.outputs.build == 'true'
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Configure Docker for Artifact Registry
+        if: steps.gate.outputs.build == 'true'
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
       - name: Build & push agentstore
         id: build
+        if: steps.gate.outputs.build == 'true'
         env:
           # The Firebase web config, inlined into the client bundle at build time
           # (NEXT_PUBLIC_*). Public web identifiers by design, sourced from the
@@ -141,6 +194,7 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Published tags
+        if: steps.gate.outputs.build == 'true'
         run: |
           echo "Published:"
           echo "  ${{ env.REGISTRY }}/agentstore:${{ github.sha }}"
@@ -150,16 +204,20 @@ jobs:
       # Notify cloud that a new agentstore image is ready — cloud owns the cluster
       # credentials and performs the actual roll. Payload shape matches
       # cloud/roll-engine.yml's client_payload (image, digest, sha, run_number),
-      # which roll-agentstore.yml consumes there. Only on main: a
-      # workflow_dispatch on a debug branch just publishes the image.
+      # which roll-agentstore.yml consumes there. A tag push notifies prod
+      # (roll-agentstore-prod); a push to main notifies staging
+      # (roll-agentstore, unchanged). A workflow_dispatch on a debug
+      # branch/no ref just publishes the image, same as before.
       - name: Notify cloud repo
-        if: github.ref == 'refs/heads/main'
+        if: steps.gate.outputs.build == 'true' && (github.ref_type == 'tag' || github.ref == 'refs/heads/main')
         env:
           GH_TOKEN: ${{ secrets.CLOUD_DISPATCH_TOKEN }}
         run: |
           IMAGE="${{ env.REGISTRY }}/agentstore@${{ steps.build.outputs.digest }}"
+          EVENT_TYPE="roll-agentstore"
+          [ "${{ github.ref_type }}" = "tag" ] && EVENT_TYPE="roll-agentstore-prod"
           gh api repos/gethouston/cloud/dispatches \
-            -f event_type='roll-agentstore' \
+            -f event_type="$EVENT_TYPE" \
             -F "client_payload[digest]=${{ steps.build.outputs.digest }}" \
             -F "client_payload[image]=$IMAGE" \
             -F "client_payload[sha]=${{ github.sha }}" \

--- a/.github/workflows/engine-pod-image.yml
+++ b/.github/workflows/engine-pod-image.yml
@@ -11,6 +11,20 @@
 # gethouston/cloud repo (.github/workflows/roll-engine.yml there), triggered by
 # the repository_dispatch fired below. That handoff is the trust boundary.
 #
+# Two triggers, two audiences:
+#   - push to main (paths-filtered in "Determine whether to build" below):
+#     continuous build → dispatches engine-pod-published →
+#     cloud/roll-engine-staging.yml rolls staging.
+#   - push of ANY tag (unconditional, no path filter — a tag means "ship
+#     this", and combining paths with a tags trigger is unreliable in GitHub
+#     Actions, since a tag push often carries no commit list to diff against):
+#     dispatches engine-pod-published-prod → cloud/roll-engine.yml rolls prod.
+# The path-relevance check for the main-branch case moved from the `on:`
+# trigger into the "Determine whether to build" step below, since GitHub
+# Actions applies one `paths:` filter to the whole push trigger regardless of
+# which ref pattern (branches vs tags) matched — it can't be tag-exempt at
+# the trigger level.
+#
 # Publishes two tags per build:
 #   engine-pod:<git-sha>  — immutable, by-digest reference used for the roll.
 #   engine-pod:poc        — moving pointer to the latest POC build (convenience).
@@ -32,16 +46,7 @@ name: Engine Pod Image
 on:
   push:
     branches: [main]
-    paths:
-      - "selfhost/Dockerfile"
-      - "packages/protocol/**"
-      - "packages/runtime-client/**"
-      - "packages/domain/**"
-      - "packages/runtime/**"
-      - "packages/host/**"
-      - "ui/agent-schemas/**"
-      - "pnpm-lock.yaml"
-      - ".github/workflows/engine-pod-image.yml"
+    tags: ["*"]
   workflow_dispatch:
 
 concurrency:
@@ -65,20 +70,61 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Any tag or a manual dispatch always builds (a tag IS the release
+      # decision). A push to main only builds when it touched a relevant path
+      # — this replaces the old trigger-level `paths:` filter, which can't
+      # apply to branch pushes only once the trigger also matches tags.
+      #
+      # Diffs github.event.before (main's tip BEFORE this push) against the
+      # new HEAD, NOT just HEAD^ — a single push can carry several commits
+      # (e.g. a non-squash merge), and diffing only the last commit against
+      # its immediate parent would miss relevant paths touched by an EARLIER
+      # commit in the same push. `before` isn't guaranteed to be present in
+      # the shallow clone actions/checkout leaves behind, so it's fetched on
+      # demand; if that fetch fails (or before is the all-zeros SHA GitHub
+      # sends for a branch's first-ever push), fail open and build anyway —
+      # a wasted build is cheap, a silently skipped release isn't.
+      - name: Determine whether to build
+        id: gate
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BASE="${{ github.event.before }}"
+          BUILD=true
+          if [ -n "$BASE" ] && [ "$BASE" != "0000000000000000000000000000000000000000" ] \
+              && git fetch --depth=1 origin "$BASE" 2>/dev/null; then
+            if git diff --name-only "$BASE" "${{ github.sha }}" -- \
+                selfhost/Dockerfile packages/protocol packages/runtime-client \
+                packages/domain packages/runtime packages/host ui/agent-schemas \
+                pnpm-lock.yaml .github/workflows/engine-pod-image.yml | grep -q .; then
+              BUILD=true
+            else
+              BUILD=false
+            fi
+          fi
+          echo "build=$BUILD" >> "$GITHUB_OUTPUT"
+
       - name: Auth to GCP
+        if: steps.gate.outputs.build == 'true'
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: projects/1056698080170/locations/global/workloadIdentityPools/github/providers/houston
           service_account: github-deploy-engine@gethouston.iam.gserviceaccount.com
 
       - name: Set up gcloud
+        if: steps.gate.outputs.build == 'true'
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Configure Docker for Artifact Registry
+        if: steps.gate.outputs.build == 'true'
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
       - name: Build & push engine-pod
         id: build
+        if: steps.gate.outputs.build == 'true'
         run: |
           SHA_TAG="${{ env.REGISTRY }}/engine-pod:${{ github.sha }}"
           POC_TAG="${{ env.REGISTRY }}/engine-pod:poc"
@@ -103,6 +149,7 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Published tags
+        if: steps.gate.outputs.build == 'true'
         run: |
           echo "Published:"
           echo "  ${{ env.REGISTRY }}/engine-pod:${{ github.sha }}"
@@ -110,16 +157,20 @@ jobs:
           echo "  digest ${{ steps.build.outputs.digest }}"
 
       # Notify cloud that a new engine-pod image is ready — cloud owns the
-      # cluster credentials and performs the actual roll. Only on main: a
-      # workflow_dispatch on a debug branch just publishes the image.
+      # cluster credentials and performs the actual roll. A tag push notifies
+      # prod (engine-pod-published-prod); a push to main notifies staging
+      # (engine-pod-published, unchanged). A workflow_dispatch on a debug
+      # branch/no ref just publishes the image, same as before.
       - name: Notify cloud repo
-        if: github.ref == 'refs/heads/main'
+        if: steps.gate.outputs.build == 'true' && (github.ref_type == 'tag' || github.ref == 'refs/heads/main')
         env:
           GH_TOKEN: ${{ secrets.CLOUD_DISPATCH_TOKEN }}
         run: |
           IMAGE="${{ env.REGISTRY }}/engine-pod@${{ steps.build.outputs.digest }}"
+          EVENT_TYPE="engine-pod-published"
+          [ "${{ github.ref_type }}" = "tag" ] && EVENT_TYPE="engine-pod-published-prod"
           gh api repos/gethouston/cloud/dispatches \
-            -f event_type='engine-pod-published' \
+            -f event_type="$EVENT_TYPE" \
             -F "client_payload[digest]=${{ steps.build.outputs.digest }}" \
             -F "client_payload[image]=$IMAGE" \
             -F "client_payload[sha]=${{ github.sha }}" \

--- a/.github/workflows/engine-pod-image.yml
+++ b/.github/workflows/engine-pod-image.yml
@@ -15,10 +15,15 @@
 #   - push to main (paths-filtered in "Determine whether to build" below):
 #     continuous build → dispatches engine-pod-published →
 #     cloud/roll-engine-staging.yml rolls staging.
-#   - push of ANY tag (unconditional, no path filter — a tag means "ship
+#   - push of an engine-pod-v* tag (no path filter — the tag means "ship
 #     this", and combining paths with a tags trigger is unreliable in GitHub
 #     Actions, since a tag push often carries no commit list to diff against):
 #     dispatches engine-pod-published-prod → cloud/roll-engine.yml rolls prod.
+# The tag pattern is deliberately NARROW: this repo's tag namespace already
+# carries other release trains — v*/cloud-v* (desktop, release.yml),
+# cloud-latest (a MOVING pointer that gets re-pushed), ios-v* (TestFlight),
+# engine-v* (self-host host binary, engine-release.yml). Each train versions
+# independently; only engine-pod-v* may roll the prod engine fleet.
 # The path-relevance check for the main-branch case moved from the `on:`
 # trigger into the "Determine whether to build" step below, since GitHub
 # Actions applies one `paths:` filter to the whole push trigger regardless of
@@ -46,7 +51,7 @@ name: Engine Pod Image
 on:
   push:
     branches: [main]
-    tags: ["*"]
+    tags: ["engine-pod-v*"]
   workflow_dispatch:
 
 concurrency:
@@ -70,8 +75,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Any tag or a manual dispatch always builds (a tag IS the release
-      # decision). A push to main only builds when it touched a relevant path
+      # An engine-pod-v* tag or a manual dispatch always builds (the tag IS
+      # the release decision; no other tag pattern reaches this workflow).
+      # A push to main only builds when it touched a relevant path
       # — this replaces the old trigger-level `paths:` filter, which can't
       # apply to branch pushes only once the trigger also matches tags.
       #


### PR DESCRIPTION
…rately

A tag push builds both images and notifies cloud via a distinct *-prod event, so only prod reacts; commits to main still feed staging.

<!--
Read CONTRIBUTING.md "Before you open a PR" first. PRs that don't fit get closed.
-->

## What this scratches for you

<!-- Required. A bug you hit, or a feature you'll use in Houston. "Thought it would be nice" is not an answer. -->

## Linked issue

<!-- Required for anything >50 LOC or any new tooling/docs/governance. Bug fixes under 50 LOC can skip. -->

Closes #

## Summary

<!-- 1-3 bullets on what changed. -->

-

## Surface impact

<!-- A UI/UX change must not silently skip a surface. Tick what this PR touches.
     Procedure: knowledge-base/client-architecture.md -->

Change type:

- [ ] Behavior (shared SDK view-model — `packages/sdk`)
- [ ] Look (design tokens — `packages/design-tokens`)
- [ ] Structure (a component added/changed → bump `design/inventory/inventory.yaml` + CHANGELOG + update enforced manifests)
- [ ] n-a (no user-facing surface change)

Surfaces updated:

- [ ] Web / desktop
- [ ] iOS
- [ ] Android

<!-- Structural change? `pnpm check:parity` must pass. See design/inventory/README.md. -->

## Checklist

- [ ] I read the diff myself before opening this PR (AI-assisted is fine, AI-unreviewed is not)
- [ ] I have no other open PRs on this repo
- [ ] `pnpm typecheck` passes
- [ ] `cargo check --workspace` passes (if Rust touched)
- [ ] `cargo test --workspace` passes (if Rust touched)
- [ ] No external frameworks/methodology imported into `knowledge-base/` or `docs/`
