### PR TITLE
docs(website): point developer docs at the real gateway, centralize the URL

### DIFF
--- a/website/src/_data/api.js
+++ b/website/src/_data/api.js
@@ -1,0 +1,12 @@
+// Single source of truth for the public Houston Cloud API gateway origin.
+//
+// Every developer-docs page (base URL, curl examples, MCP config, A2A calls)
+// renders the gateway host from `api.gatewayUrl`. Change it HERE and all of
+// /developers/** updates on the next build. Do not hardcode the gateway host
+// anywhere else. Overridable at build time via PUBLIC_GATEWAY_URL.
+export default function () {
+  return {
+    gatewayUrl:
+      process.env.PUBLIC_GATEWAY_URL || "https://gateway.gethouston.ai",
+  };
+}

--- a/website/src/developers/a2a/index.html
+++ b/website/src/developers/a2a/index.html
@@ -61,7 +61,7 @@ lang: en
           <span class="method get">GET</span>
           <span class="path">/a2a/<b>:org</b>/<b>:agent</b>/.well-known/agent-card.json</span>
         </div>
-        <div class="codeblock"><pre><code>{% raw %}curl https://poc-gateway.gethouston.ai/a2a/acme/revenue-manager/.well-known/agent-card.json \
+        <div class="codeblock"><pre><code>{% raw %}curl {% endraw %}{{ api.gatewayUrl }}{% raw %}/a2a/acme/revenue-manager/.well-known/agent-card.json \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
         <p>
           Feed that card URL to your A2A client. <code>:org</code> is your
@@ -85,7 +85,7 @@ lang: en
           Send a message to the agent and open a task. The response contains
           the task, whose <code>status.state</code> you then poll or stream.
         </p>
-        <div class="codeblock"><pre><code>{% raw %}curl -X POST https://poc-gateway.gethouston.ai/a2a/acme/revenue-manager \
+        <div class="codeblock"><pre><code>{% raw %}curl -X POST {% endraw %}{{ api.gatewayUrl }}{% raw %}/a2a/acme/revenue-manager \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708" \
   -H "Content-Type: application/json" \
   -d '{
@@ -118,7 +118,7 @@ lang: en
           and status updates that ends when the task reaches a terminal state.
           Use this for live progress.
         </p>
-        <div class="codeblock"><pre><code>{% raw %}curl -N -X POST https://poc-gateway.gethouston.ai/a2a/acme/revenue-manager \
+        <div class="codeblock"><pre><code>{% raw %}curl -N -X POST {% endraw %}{{ api.gatewayUrl }}{% raw %}/a2a/acme/revenue-manager \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708" \
   -H "Content-Type: application/json" \
   -d '{

--- a/website/src/developers/index.html
+++ b/website/src/developers/index.html
@@ -75,7 +75,7 @@ lang: en
           All endpoints live on the Houston Cloud gateway:
         </p>
         <div class="endpoint">
-          <span class="path"><b>https://poc-gateway.gethouston.ai</b></span>
+          <span class="path"><b>{{ api.gatewayUrl }}</b></span>
         </div>
         <p>
           Every path below is relative to that origin. All requests and
@@ -131,7 +131,7 @@ lang: en
           <span class="method post">POST</span>
           <span class="path">/v1/agents/<b>:slug</b>/missions</span>
         </div>
-        <div class="codeblock"><pre><code>{% raw %}curl -X POST https://poc-gateway.gethouston.ai/v1/agents/revenue-manager/missions \
+        <div class="codeblock"><pre><code>{% raw %}curl -X POST {% endraw %}{{ api.gatewayUrl }}{% raw %}/v1/agents/revenue-manager/missions \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708" \
   -H "Content-Type: application/json" \
   -d '{
@@ -179,7 +179,7 @@ lang: en
           <span class="method get">GET</span>
           <span class="path">/v1/agents/<b>:slug</b>/missions/<b>:id</b></span>
         </div>
-        <div class="codeblock"><pre><code>{% raw %}curl https://poc-gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b \
+        <div class="codeblock"><pre><code>{% raw %}curl {% endraw %}{{ api.gatewayUrl }}{% raw %}/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
         <div class="codeblock"><pre><code>{% raw %}{
   "id": "msn_7Q4c1a9f2b",
@@ -195,7 +195,7 @@ lang: en
           <span class="method get">GET</span>
           <span class="path">/v1/agents/<b>:slug</b>/missions/<b>:id</b>/events</span>
         </div>
-        <div class="codeblock"><pre><code>{% raw %}curl -N https://poc-gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b/events \
+        <div class="codeblock"><pre><code>{% raw %}curl -N {% endraw %}{{ api.gatewayUrl }}{% raw %}/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b/events \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
         <div class="callout callout-info">
           <div class="callout-label">Streaming in the browser</div>
@@ -216,7 +216,7 @@ lang: en
           <span class="method get">GET</span>
           <span class="path">/agents</span>
         </div>
-        <div class="codeblock"><pre><code>{% raw %}curl https://poc-gateway.gethouston.ai/agents \
+        <div class="codeblock"><pre><code>{% raw %}curl {% endraw %}{{ api.gatewayUrl }}{% raw %}/agents \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
 
         <div class="callout callout-success">

--- a/website/src/developers/mcp/index.html
+++ b/website/src/developers/mcp/index.html
@@ -69,13 +69,13 @@ lang: en
 
         <h2 id="connect">Connect a client</h2>
         <p>
-          Point any MCP client at <code>https://poc-gateway.gethouston.ai/mcp</code>
+          Point any MCP client at <code>{{ api.gatewayUrl }}/mcp</code>
           with your key in the <code>Authorization</code> header.
         </p>
 
         <h3>Claude Code</h3>
         <p>Add it from the CLI:</p>
-        <div class="codeblock"><pre><code>{% raw %}claude mcp add --transport http houston https://poc-gateway.gethouston.ai/mcp \
+        <div class="codeblock"><pre><code>{% raw %}claude mcp add --transport http houston {% endraw %}{{ api.gatewayUrl }}{% raw %}/mcp \
   --header "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
         <p>
           Or add it to your project's <code>.mcp.json</code> (the same shape
@@ -85,7 +85,7 @@ lang: en
   "mcpServers": {
     "houston": {
       "type": "http",
-      "url": "https://poc-gateway.gethouston.ai/mcp",
+      "url": "{% endraw %}{{ api.gatewayUrl }}{% raw %}/mcp",
       "headers": {
         "Authorization": "Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"
       }

--- a/website/src/developers/missions/index.html
+++ b/website/src/developers/missions/index.html
@@ -34,7 +34,7 @@ lang: en
           The REST Missions API is the most direct way to drive a Houston
           agent. Create a mission, then poll it, stream it, or wait for a
           signed webhook. All paths are on
-          <code>https://poc-gateway.gethouston.ai</code> and take
+          <code>{{ api.gatewayUrl }}</code> and take
           <code>Authorization: Bearer hst_...</code>.
         </p>
 
@@ -80,7 +80,7 @@ lang: en
         </table>
         </div>
 
-        <div class="codeblock"><pre><code>{% raw %}curl -X POST https://poc-gateway.gethouston.ai/v1/agents/revenue-manager/missions \
+        <div class="codeblock"><pre><code>{% raw %}curl -X POST {% endraw %}{{ api.gatewayUrl }}{% raw %}/v1/agents/revenue-manager/missions \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708" \
   -H "Content-Type: application/json" \
   -d '{
@@ -116,7 +116,7 @@ lang: en
           </tbody>
         </table>
         </div>
-        <div class="codeblock"><pre><code>{% raw %}curl "https://poc-gateway.gethouston.ai/v1/agents/revenue-manager/missions?limit=20" \
+        <div class="codeblock"><pre><code>{% raw %}curl "{% endraw %}{{ api.gatewayUrl }}{% raw %}/v1/agents/revenue-manager/missions?limit=20" \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
         <div class="codeblock"><pre><code>{% raw %}{
   "missions": [
@@ -144,7 +144,7 @@ lang: en
           <code>webhook</code> block recording when it was delivered, or the
           last error if delivery has not yet succeeded.
         </p>
-        <div class="codeblock"><pre><code>{% raw %}curl https://poc-gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b \
+        <div class="codeblock"><pre><code>{% raw %}curl {% endraw %}{{ api.gatewayUrl }}{% raw %}/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
         <div class="codeblock"><pre><code>{% raw %}{
   "id": "msn_7Q4c1a9f2b",
@@ -171,7 +171,7 @@ lang: en
           <code>Last-Event-ID</code> header to resume without gaps. Native SSE
           clients and curl do this for you.
         </p>
-        <div class="codeblock"><pre><code>{% raw %}curl -N https://poc-gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b/events \
+        <div class="codeblock"><pre><code>{% raw %}curl -N {% endraw %}{{ api.gatewayUrl }}{% raw %}/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b/events \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
         <div class="callout callout-info">
           <div class="callout-label">Browser (EventSource)</div>
@@ -202,7 +202,7 @@ lang: en
           Lists the agents this key can reach, with the slugs you pass to the
           mission endpoints.
         </p>
-        <div class="codeblock"><pre><code>{% raw %}curl https://poc-gateway.gethouston.ai/agents \
+        <div class="codeblock"><pre><code>{% raw %}curl {% endraw %}{{ api.gatewayUrl }}{% raw %}/agents \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
 
         <h2 id="scope">API-key scope &amp; limits</h2>


### PR DESCRIPTION
## What

The public developer docs (`/developers/**` — REST, MCP, A2A) hardcoded the poc gateway host (`poc-gateway.gethouston.ai`) across 17 spots in 4 pages, sending external API users at the wrong origin.

## Change

- Introduce a single source of truth: `website/src/_data/api.js` exposing `api.gatewayUrl` (default `https://gateway.gethouston.ai`, overridable at build time via `PUBLIC_GATEWAY_URL`). Mirrors the existing `pricing.js` pattern.
- Render every gateway host from that variable. Inside `{% raw %}` code blocks this uses the `{% endraw %}{{ api.gatewayUrl }}{% raw %}` splice; the surrounding examples contain no Nunjucks delimiters, so nothing else is affected.
- Net result: the docs now point at the real managed gateway, and future gateway changes are a **one-line edit** in `api.js` instead of a find-and-replace.

## Why `.js` not `.ts`

The `website/` project is a plain Eleventy site with no TypeScript toolchain — every `_data` file and the Eleventy config are already `.js`, and Eleventy loads `_data/*.js` natively. A `.ts` data file would silently not render.

## Verify

- `npx @11ty/eleventy` builds clean.
- Rendered `_site/developers/**` contain `https://gateway.gethouston.ai` (17 occurrences) with no leftover `poc-gateway`, raw-tag leakage, or unrendered variables.

## Note

The desktop **prod build** gateway comes from the `HOSTED_ENGINE_URL` release secret (baked as `VITE_HOSTED_ENGINE_URL` / `HOUSTON_INTEGRATIONS_URL` on `cloud-v*` tags), which has been repointed to the real gateway separately. This PR only covers the website docs.