### PR TITLE
feat(store): one-click Open in Houston install from the website

### DIFF
--- a/agentstore/package.json
+++ b/agentstore/package.json
@@ -32,6 +32,7 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@typescript/native-preview": "7.0.0-dev.20260607.1",
+    "jsdom": "29.1.1",
     "tailwindcss": "4.3.2",
     "typescript": "6.0.3",
     "vitest": "3.2.6"

--- a/agentstore/src/app/a/[slug]/page.tsx
+++ b/agentstore/src/app/a/[slug]/page.tsx
@@ -176,6 +176,7 @@ export default async function AgentDetailPage({ params }: PageParams) {
           <div className="rounded-2xl border bg-card p-5 shadow-sm">
             <InstallPanel
               agentName={identity.name}
+              slug={slug}
               instructions={instructions}
               skillZipUrl={urls.skillZipUrl}
               copyPasteUrl={urls.copyPasteUrl}

--- a/agentstore/src/components/install-panel.test.tsx
+++ b/agentstore/src/components/install-panel.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { InstallPanel } from "./install-panel";
+
+(
+  globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const props = {
+  agentName: "Cool Agent",
+  slug: "cool-agent",
+  instructions: "do the thing",
+  skillZipUrl: "https://example.com/a.zip",
+  copyPasteUrl: "https://example.com/a.md",
+  shareUrl: "https://example.com/a/cool-agent",
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function clickOpenInHouston() {
+  const button = Array.from(container.querySelectorAll("button")).find((b) =>
+    b.textContent?.includes("Open in Houston"),
+  );
+  if (!button) throw new Error("Open in Houston button not found");
+  act(() => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("OpenInHouston focus-listener hygiene", () => {
+  it("removes its blur/visibilitychange listeners when unmounted before the fallback timer fires", () => {
+    const removeWin = vi.spyOn(window, "removeEventListener");
+    const removeDoc = vi.spyOn(document, "removeEventListener");
+
+    act(() => root.render(<InstallPanel {...props} />));
+    clickOpenInHouston();
+
+    // Unmount before the fallback timer fires and before any blur/visibilitychange.
+    act(() => root.unmount());
+
+    expect(removeWin).toHaveBeenCalledWith("blur", expect.any(Function));
+    expect(removeDoc).toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.any(Function),
+    );
+  });
+
+  it("removes the prior click's listeners when clicked again before the timer fires", () => {
+    const removeWin = vi.spyOn(window, "removeEventListener");
+    const removeDoc = vi.spyOn(document, "removeEventListener");
+
+    act(() => root.render(<InstallPanel {...props} />));
+    clickOpenInHouston();
+    clickOpenInHouston();
+
+    expect(removeWin).toHaveBeenCalledWith("blur", expect.any(Function));
+    expect(removeDoc).toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.any(Function),
+    );
+
+    act(() => root.unmount());
+  });
+});

--- a/agentstore/src/components/install-panel.tsx
+++ b/agentstore/src/components/install-panel.tsx
@@ -1,22 +1,24 @@
 "use client";
 
+import { Button } from "@houston-ai/core";
+import { Download, FileText, Globe, Rocket } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import {
-  Button,
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@houston-ai/core";
-import { Download, FileText, Rocket } from "lucide-react";
+  buildStoreInstallDeepLink,
+  buildWebAppInstallUrl,
+} from "@/lib/houston-launch";
 import { CopyButton } from "./copy-button";
 
 /** Where a visitor without the app goes to get it. */
-const HOUSTON_DOWNLOAD_URL = "https://gethouston.ai";
+const HOUSTON_DOWNLOAD_URL = "https://gethouston.ai/#download";
+
+/** How long we wait for Houston to take focus before offering a fallback. */
+const LAUNCH_FALLBACK_MS = 1500;
 
 export interface InstallPanelProps {
   agentName: string;
+  /** Agent Store slug, used to build the "Open in Houston" deep link. */
+  slug: string;
   /** Pre-built, server-rendered copy-paste install instructions. */
   instructions: string;
   /** Absolute URL to the Claude Skill .zip (target=claude-skill-zip). */
@@ -32,13 +34,15 @@ export interface InstallPanelProps {
  *   1. PRIMARY  copy install instructions for the visitor's own AI assistant.
  *   2. Download the Claude Skill .zip.
  *   3. Download the universal copy-paste markdown.
- *   4. Open in Houston, a dialog with the share link + the three steps.
+ *   4. Open in Houston, a one-click deep link that seeds the desktop import
+ *      wizard, with a non-destructive fallback for visitors without the app.
  *
  * The instructions text is composed on the server and passed in, so this stays a
  * thin interaction shell.
  */
 export function InstallPanel({
   agentName,
+  slug,
   instructions,
   skillZipUrl,
   copyPasteUrl,
@@ -82,70 +86,110 @@ export function InstallPanel({
         </a>
       </Button>
 
-      <OpenInHoustonDialog agentName={agentName} shareUrl={shareUrl} />
+      <OpenInHouston agentName={agentName} slug={slug} shareUrl={shareUrl} />
     </div>
   );
 }
 
-function OpenInHoustonDialog({
+function OpenInHouston({
   agentName,
+  slug,
   shareUrl,
 }: {
   agentName: string;
+  slug: string;
   shareUrl: string;
 }) {
+  const [showFallback, setShowFallback] = useState(false);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    return () => {
+      cleanupRef.current?.();
+    };
+  }, []);
+
+  function openInHouston() {
+    const deepLink = buildStoreInstallDeepLink(slug);
+    if (!deepLink) return;
+
+    // A repeat click supersedes the previous attempt entirely.
+    cleanupRef.current?.();
+
+    // If Houston opens, the browser tab loses focus or is hidden. Track that so
+    // a user who already has the app never sees the "don't have it?" fallback.
+    let launched = false;
+    const markLaunched = () => {
+      launched = true;
+    };
+    window.addEventListener("blur", markLaunched, { once: true });
+    document.addEventListener("visibilitychange", markLaunched, { once: true });
+
+    // A hidden iframe navigates to the custom scheme without a top-level
+    // "unknown protocol" error page when Houston is not installed.
+    if (iframeRef.current) iframeRef.current.src = deepLink;
+
+    const timer = window.setTimeout(() => {
+      cleanupRef.current?.();
+      if (!launched && document.visibilityState === "visible") {
+        setShowFallback(true);
+      }
+    }, LAUNCH_FALLBACK_MS);
+
+    cleanupRef.current = () => {
+      window.clearTimeout(timer);
+      window.removeEventListener("blur", markLaunched);
+      document.removeEventListener("visibilitychange", markLaunched);
+      cleanupRef.current = null;
+    };
+  }
+
+  const webUrl = buildWebAppInstallUrl(slug);
+
   return (
-    <Dialog>
-      <DialogTrigger asChild>
-        <Button variant="outline" size="lg" className="w-full">
-          <Rocket aria-hidden className="size-4" />
-          Open in Houston
-        </Button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Open {agentName} in Houston</DialogTitle>
-          <DialogDescription>
-            Houston is the free desktop app for running agents like this one.
-          </DialogDescription>
-        </DialogHeader>
+    <div className="flex flex-col gap-2">
+      <Button
+        variant="outline"
+        size="lg"
+        className="w-full"
+        onClick={openInHouston}
+      >
+        <Rocket aria-hidden className="size-4" />
+        Open in Houston
+      </Button>
+      <iframe ref={iframeRef} title="Open in Houston" className="hidden" />
 
-        <ol className="flex flex-col gap-3 text-sm">
-          <Step n={1}>
-            Open Houston on your computer. Do not have it yet? Download it
-            below.
-          </Step>
-          <Step n={2}>Go to Add agent, then choose Install from a link.</Step>
-          <Step n={3}>Paste the link below and follow the steps.</Step>
-        </ol>
+      {showFallback && (
+        <div className="flex flex-col gap-2 rounded-lg border border-dashed p-3">
+          <p className="text-sm text-muted-foreground">
+            Do not have Houston yet?
+          </p>
+          <Button asChild variant="outline" size="lg" className="w-full">
+            <a href={HOUSTON_DOWNLOAD_URL} target="_blank" rel="noreferrer">
+              <Download aria-hidden className="size-4" />
+              Download Houston
+            </a>
+          </Button>
+          {webUrl && (
+            <Button asChild variant="outline" size="lg" className="w-full">
+              <a href={webUrl}>
+                <Globe aria-hidden className="size-4" />
+                Open in Houston Web
+              </a>
+            </Button>
+          )}
+        </div>
+      )}
 
-        <CopyButton
-          value={shareUrl}
-          label="Copy share link"
-          copiedLabel="Copied to clipboard"
-          size="lg"
-          className="w-full"
-          aria-label={`Copy the share link for ${agentName}`}
-        />
-
-        <Button asChild variant="outline" size="lg" className="w-full">
-          <a href={HOUSTON_DOWNLOAD_URL} target="_blank" rel="noreferrer">
-            <Download aria-hidden className="size-4" />
-            Download Houston
-          </a>
-        </Button>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function Step({ n, children }: { n: number; children: React.ReactNode }) {
-  return (
-    <li className="flex items-start gap-3">
-      <span className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold">
-        {n}
-      </span>
-      <span className="text-muted-foreground">{children}</span>
-    </li>
+      <CopyButton
+        value={shareUrl}
+        label="Copy share link"
+        copiedLabel="Copied to clipboard"
+        variant="ghost"
+        className="w-full"
+        aria-label={`Copy the share link for ${agentName}`}
+      />
+    </div>
   );
 }

--- a/agentstore/src/lib/houston-launch.test.ts
+++ b/agentstore/src/lib/houston-launch.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildStoreInstallDeepLink,
+  buildWebAppInstallUrl,
+  isValidSlug,
+} from "./houston-launch";
+
+describe("isValidSlug", () => {
+  it("accepts well-formed slugs", () => {
+    expect(isValidSlug("cool-agent")).toBe(true);
+    expect(isValidSlug("a")).toBe(true);
+    expect(isValidSlug("agent123")).toBe(true);
+  });
+
+  it("rejects malformed slugs", () => {
+    expect(isValidSlug("")).toBe(false);
+    expect(isValidSlug("-leading")).toBe(false);
+    expect(isValidSlug("Upper")).toBe(false);
+    expect(isValidSlug("has space")).toBe(false);
+    expect(isValidSlug("has/slash")).toBe(false);
+    expect(isValidSlug("x".repeat(65))).toBe(false);
+  });
+});
+
+describe("buildStoreInstallDeepLink", () => {
+  it("builds the store install deep link for a valid slug", () => {
+    expect(buildStoreInstallDeepLink("cool-agent")).toBe(
+      "houston://store/install?slug=cool-agent",
+    );
+  });
+
+  it("returns null for an invalid slug", () => {
+    expect(buildStoreInstallDeepLink("../evil")).toBeNull();
+    expect(buildStoreInstallDeepLink("")).toBeNull();
+  });
+});
+
+describe("buildWebAppInstallUrl", () => {
+  const original = process.env.NEXT_PUBLIC_WEB_APP_URL;
+  afterEach(() => {
+    if (original === undefined) delete process.env.NEXT_PUBLIC_WEB_APP_URL;
+    else process.env.NEXT_PUBLIC_WEB_APP_URL = original;
+  });
+
+  it("defaults to the production web app", () => {
+    delete process.env.NEXT_PUBLIC_WEB_APP_URL;
+    expect(buildWebAppInstallUrl("cool-agent")).toBe(
+      "https://app.gethouston.ai/?install=cool-agent",
+    );
+  });
+
+  it("honors NEXT_PUBLIC_WEB_APP_URL", () => {
+    process.env.NEXT_PUBLIC_WEB_APP_URL = "https://preview.example.com";
+    expect(buildWebAppInstallUrl("cool-agent")).toBe(
+      "https://preview.example.com/?install=cool-agent",
+    );
+  });
+
+  it("returns null for an invalid slug", () => {
+    expect(buildWebAppInstallUrl("../evil")).toBeNull();
+  });
+});

--- a/agentstore/src/lib/houston-launch.ts
+++ b/agentstore/src/lib/houston-launch.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure URL builders for launching an Agent Store agent into Houston.
+ *
+ * The website never installs an agent itself. The desktop deep link only seeds
+ * Houston's import wizard (threat scan + name + pickers all stay in the app),
+ * and the web fallback seeds the same import in Houston Web. Both builders
+ * validate the slug against the shared contract SLUG_REGEX, so a malformed slug
+ * can never be forged into a launch URL.
+ */
+
+import { SLUG_REGEX } from "@houston/agentstore-contract";
+
+/** Houston Web app, where visitors without the desktop app can install. */
+const DEFAULT_WEB_APP_URL = "https://app.gethouston.ai";
+
+/** True when `slug` is a well-formed Agent Store slug. */
+export function isValidSlug(slug: string): boolean {
+  return SLUG_REGEX.test(slug);
+}
+
+/**
+ * Desktop deep link that seeds Houston's import wizard for `slug`, or `null`
+ * when the slug is malformed (never emit a launch URL for an invalid slug).
+ */
+export function buildStoreInstallDeepLink(slug: string): string | null {
+  return isValidSlug(slug) ? `houston://store/install?slug=${slug}` : null;
+}
+
+/**
+ * Houston Web URL that seeds the same import for a visitor without the desktop
+ * app, or `null` when the slug is malformed. The base is overridable via
+ * `NEXT_PUBLIC_WEB_APP_URL` for preview deploys.
+ */
+export function buildWebAppInstallUrl(slug: string): string | null {
+  if (!isValidSlug(slug)) return null;
+  const base = process.env.NEXT_PUBLIC_WEB_APP_URL ?? DEFAULT_WEB_APP_URL;
+  return `${base}/?install=${encodeURIComponent(slug)}`;
+}

--- a/agentstore/vitest.config.ts
+++ b/agentstore/vitest.config.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  esbuild: { jsx: "automatic" },
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),

--- a/app/package.json
+++ b/app/package.json
@@ -25,6 +25,7 @@
     "@houston-ai/review": "workspace:*",
     "@houston-ai/routines": "workspace:*",
     "@houston-ai/skills": "workspace:*",
+    "@houston/agentstore-contract": "workspace:*",
     "@houston/protocol": "workspace:*",
     "@houston/runtime-client": "workspace:*",
     "@houston/sdk": "workspace:*",

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod logging;
 mod loopback_util;
 mod notification;
 mod oauth_loopback;
+mod store_deep_link;
 mod window_focus;
 
 use engine_supervisor::{
@@ -279,6 +280,14 @@ pub fn run() {
             //    link can never complete a sign-in it didn't start.
             //  - `houston://open` (the loopback success page's "Open Houston"
             //    button) and anything else — purely a focus affordance.
+            //  - `houston://store/install?slug=<slug>` — the Agent Store "Open in
+            //    Houston" button. Forwarded onto the disjoint `store://deep-link`
+            //    event (and stashed for cold-start pull) to seed the import wizard
+            //    preview; never touches the auth channel and never auto-installs.
+            //
+            // Managed BEFORE `on_open_url` is wired so a launch-by-deep-link URL
+            // that arrives immediately has somewhere to land.
+            app.manage(store_deep_link::PendingStoreDeepLinkState::default());
             {
                 use tauri_plugin_deep_link::DeepLinkExt;
                 let handle = app.handle().clone();
@@ -286,6 +295,12 @@ pub fn run() {
                     for url in event.urls() {
                         if auth::is_auth_callback_deep_link(url.as_str()) {
                             auth::emit_deep_link(&handle, url.as_str());
+                        } else if store_deep_link::is_store_install_deep_link(url.as_str()) {
+                            store_deep_link::stash_and_emit(
+                                &handle,
+                                &handle.state::<store_deep_link::PendingStoreDeepLinkState>(),
+                                url.as_str(),
+                            );
                         }
                     }
                     window_focus::bring_to_front(&handle);
@@ -415,6 +430,9 @@ pub fn run() {
             bug_report::report_bug,
             // Engine handshake pull (race-free fallback for `EngineGate`).
             get_engine_handshake,
+            // Cold-start pull for a `houston://store/install` deep link whose
+            // event fired before the webview's listener registered.
+            store_deep_link::take_pending_store_deep_link,
             // Keychain-backed storage for the identity session (GCIP/Firebase).
             auth::auth_get_item,
             auth::auth_set_item,

--- a/app/src-tauri/src/store_deep_link.rs
+++ b/app/src-tauri/src/store_deep_link.rs
@@ -1,0 +1,136 @@
+//! `houston://store/install` deep-link bridge for one-click Agent Store installs.
+//!
+//! The Agent Store website (`agentstore/`) opens `houston://store/install?slug=<slug>`
+//! to hand a store agent's slug to the desktop app. The shell forwards it to the
+//! frontend over the `store://deep-link` event, which seeds the import-from-friend
+//! wizard preview (a scan + name + pickers step — never an auto-install).
+//!
+//! Cold start: when the OS launches the app *by* the deep link, the webview may not
+//! have registered its `store://deep-link` listener yet, so the raw URL is also
+//! stashed in `PendingStoreDeepLinkState`. The frontend drains it once on mount via
+//! `take_pending_store_deep_link` — the same race-free pull pattern that
+//! `EngineHandshakeState` / `get_engine_handshake` use for the engine handshake.
+//!
+//! This channel is intentionally disjoint from the `auth://deep-link` channel: an
+//! arbitrary store link can never inject onto the auth surface, and vice versa.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use tauri::{AppHandle, Emitter};
+
+/// Tauri-managed state for the store-install deep link.
+///
+/// `pending` holds the raw URL captured before the webview's `store://deep-link`
+/// listener was ready (cold start), drained once by `take_pending_store_deep_link`.
+/// `listener_ready` flips true the first time the frontend drains — from then on a
+/// live listener catches the emit, so later deep links must NOT be stashed:
+/// residue in `pending` would be re-drained as a stale slug by a webview reload
+/// (Cmd+R / HMR in dev, or a content-process crash-reload) and re-seed an install
+/// the user already handled.
+#[derive(Default)]
+pub struct PendingStoreDeepLinkState {
+    pending: Mutex<Option<String>>,
+    listener_ready: AtomicBool,
+}
+
+impl PendingStoreDeepLinkState {
+    /// Stash the URL only while cold (no live frontend listener yet). A no-op once
+    /// the frontend has drained, so the warm path leaves no residue.
+    fn stash_if_cold(&self, url: &str) {
+        if self.listener_ready.load(Ordering::Relaxed) {
+            return;
+        }
+        match self.pending.lock() {
+            Ok(mut guard) => *guard = Some(url.to_string()),
+            Err(e) => tracing::error!("[store] pending deep-link stash lock poisoned: {e}"),
+        }
+    }
+
+    /// Drain (return and clear) the stash and mark the frontend listener live: the
+    /// first drain closes the cold-start window, so later deep links only emit.
+    fn drain(&self) -> Result<Option<String>, String> {
+        self.listener_ready.store(true, Ordering::Relaxed);
+        let mut guard = self.pending.lock().map_err(|e| e.to_string())?;
+        Ok(guard.take())
+    }
+}
+
+/// True iff a real OS deep link is the store-install shape the frontend consumes
+/// (`houston://store/install?...`). The trailing char must be a boundary (`?`, `/`,
+/// or end) so `houston://store/installEVIL` can never masquerade as an install —
+/// mirrors `auth::is_auth_callback_deep_link`.
+pub fn is_store_install_deep_link(url: &str) -> bool {
+    match url.strip_prefix("houston://store/install") {
+        Some(rest) => rest.is_empty() || rest.starts_with('?') || rest.starts_with('/'),
+        None => false,
+    }
+}
+
+/// Emit the raw store-install URL onto the `store://deep-link` event for a webview
+/// that is already listening, and stash it for the cold-start pull ONLY while no
+/// listener is live yet. Called from the `on_open_url` handler in `lib.rs`.
+pub fn stash_and_emit(handle: &AppHandle, state: &PendingStoreDeepLinkState, url: &str) {
+    state.stash_if_cold(url);
+    if let Err(e) = handle.emit("store://deep-link", url) {
+        tracing::error!("[store] failed to emit deep-link event: {e}");
+    }
+}
+
+/// Drain (return and clear) the stashed store-install deep-link URL. The frontend
+/// calls this once on mount to catch a cold-start launch whose event fired before
+/// its listener registered; the first call also marks the listener live so later
+/// deep links are no longer stashed.
+#[tauri::command]
+pub fn take_pending_store_deep_link(
+    state: tauri::State<'_, PendingStoreDeepLinkState>,
+) -> Result<Option<String>, String> {
+    state.drain()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn store_install_deep_links_are_recognized() {
+        assert!(is_store_install_deep_link(
+            "houston://store/install?slug=my-agent"
+        ));
+        assert!(is_store_install_deep_link("houston://store/install"));
+        assert!(is_store_install_deep_link("houston://store/install/"));
+    }
+
+    #[test]
+    fn cold_start_stashes_then_drain_clears_and_marks_listener_live() {
+        let state = PendingStoreDeepLinkState::default();
+        // Cold start: URL arrives before the frontend listener is ready → stashed.
+        state.stash_if_cold("houston://store/install?slug=cold");
+        assert_eq!(
+            state.drain().unwrap().as_deref(),
+            Some("houston://store/install?slug=cold"),
+        );
+        // Drain clears the stash.
+        assert_eq!(state.drain().unwrap(), None);
+    }
+
+    #[test]
+    fn warm_deep_link_after_drain_leaves_no_residue() {
+        let state = PendingStoreDeepLinkState::default();
+        // Frontend mounts and drains once — its listener is now live.
+        assert_eq!(state.drain().unwrap(), None);
+        // Warm deep link: the live listener catches the emit, so nothing must be
+        // stashed. Otherwise a webview reload would re-drain this stale slug and
+        // re-seed an install the user already handled.
+        state.stash_if_cold("houston://store/install?slug=warm");
+        assert_eq!(state.drain().unwrap(), None);
+    }
+
+    #[test]
+    fn non_install_deep_links_are_ignored() {
+        assert!(!is_store_install_deep_link("houston://store/installer?x=1"));
+        assert!(!is_store_install_deep_link("houston://open"));
+        assert!(!is_store_install_deep_link(
+            "https://example.com/store/install"
+        ));
+    }
+}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -32,6 +32,7 @@ import {
   setUser as setSentryUser,
 } from "./lib/sentry";
 import { useStoreGatewaySession } from "./lib/store-gateway-session";
+import { useStoreInstallDeepLink } from "./lib/store-install-deeplink";
 import { tauriSystem } from "./lib/tauri";
 import { useAgentStore } from "./stores/agents";
 import { useUIStore } from "./stores/ui";
@@ -50,6 +51,9 @@ export default function App() {
   // Fetch the host's pi-ai catalog once and hydrate the PROVIDERS cache app-wide,
   // so every provider/model surface renders the real runnable set from load.
   useProviderCatalog();
+  // Turn an `houston://store/install` deep link (desktop) or `?install=<slug>`
+  // web param into a seeded import wizard once the shell is live.
+  useStoreInstallDeepLink();
 
   // NOTE: install identity, `install_created`, `session_started`, and theme
   // load run in <StartupEffects> at the top of the tree (main.tsx), NOT here.

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -161,6 +161,15 @@ export function osCancelClaudeLogin(): Promise<void> {
   return invoke<void>("cancel_claude_login");
 }
 
+/** Drain the cold-start `houston://store/install` deep link the Rust shell
+ * stashed before the webview was ready (returns the raw URL and clears the
+ * stash, so a later read gets null). Resolves null when nothing is pending.
+ * Desktop only — a plain browser has no native stash. */
+export function osTakePendingStoreDeepLink(): Promise<string | null> {
+  if (!isTauri()) return Promise.resolve(null);
+  return invoke<string | null>("take_pending_store_deep_link");
+}
+
 /** Pull the Houston window to the front. Used when a flow finishes in the
  * user's browser (e.g. a Composio integration connection lands) and we want
  * the app to surface itself — the same snap-back the sign-in loopback does.

--- a/app/src/lib/store-install-deeplink.ts
+++ b/app/src/lib/store-install-deeplink.ts
@@ -1,0 +1,176 @@
+import { pingStoreInstall } from "@houston-ai/engine-client";
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { useAgentStore } from "../stores/agents";
+import { useUIStore } from "../stores/ui";
+import { useWorkspaceStore } from "../stores/workspaces";
+import { getEngine } from "./engine";
+import { reportError } from "./error-toast";
+import {
+  legacyListen,
+  osIsTauri,
+  osTakePendingStoreDeepLink,
+} from "./os-bridge";
+import {
+  decideStoreInstallDrive,
+  initialStoreInstallDriveState,
+} from "./store-install-drive";
+import { parseStoreInstallSlug } from "./store-install-slug";
+
+export { parseStoreInstallSlug } from "./store-install-slug";
+
+/** Raw Tauri event the Rust shell emits when it receives an
+ * `houston://store/install` deep link while the app is already running. Fully
+ * disjoint from the `auth://deep-link` channel — the two never share state. */
+const STORE_DEEP_LINK_EVENT = "store://deep-link";
+
+/**
+ * Always-on hook that turns an `houston://store/install?slug=<slug>` deep link
+ * (desktop) or a `?install=<slug>` web param into a seeded import wizard — the
+ * SAME preview + scan + name + picker flow every other install uses. It never
+ * auto-installs: the deep link only seeds the wizard, so the user still makes
+ * every choice.
+ *
+ * Three ingress paths, one processing effect:
+ *  1. Warm desktop: the `store://deep-link` Tauri event fires with the raw URL.
+ *  2. Cold desktop: the shell stashed the URL before the webview existed;
+ *     `take_pending_store_deep_link` drains it once on mount.
+ *  3. Web: `?install=<slug>` in the query string, stripped from history so a
+ *     reload does not re-trigger.
+ *
+ * Every path validates the slug (via `parseStoreInstallSlug` / `SLUG_REGEX`)
+ * before it can reach the seed flow, then routes through one pending slug so the
+ * install runs exactly once, only when the shell is live and no wizard is open.
+ */
+export function useStoreInstallDeepLink(): void {
+  const { t } = useTranslation("store");
+  const pendingSlug = useUIStore((s) => s.pendingStoreInstallSlug);
+  const importFromFriendOpen = useUIStore((s) => s.importFromFriendOpen);
+
+  // "Shell is live" — the workspace shell (which mounts the import wizard) is
+  // the rendered branch, so seeding it will actually open something: a
+  // workspace is resolved, agents have loaded with at least one present (a
+  // zero-agent user is still in first-run onboarding, not the shell), and the
+  // tutorial is not held in front. Until then the pending slug simply waits.
+  const workspaceReady = useWorkspaceStore(
+    (s) => !s.loading && Boolean(s.current),
+  );
+  const agentsLoaded = useAgentStore((s) => s.loaded);
+  const hasAgents = useAgentStore((s) => s.agents.length > 0);
+  const tutorialActive = useUIStore((s) => s.tutorialActive);
+  const shellLive =
+    workspaceReady && agentsLoaded && hasAgents && !tutorialActive;
+
+  // ── Ingress: register the listeners + drain the cold-start / web sources ──
+  useEffect(() => {
+    const setPending = (raw: string) => {
+      const slug = parseStoreInstallSlug(raw);
+      if (slug) useUIStore.getState().setPendingStoreInstallSlug(slug);
+    };
+
+    // Warm desktop: the raw URL rides the event payload. The web shim makes
+    // `legacyListen` a no-op, so this is harmless in the browser.
+    let off: (() => void) | undefined;
+    legacyListen<string>(STORE_DEEP_LINK_EVENT, (ev) => setPending(ev.payload))
+      .then((fn) => {
+        off = fn;
+      })
+      .catch((err: unknown) => {
+        reportError(
+          "store_install_deeplink",
+          "failed to register store deep-link listener",
+          err,
+        );
+      });
+
+    // Cold desktop: drain whatever the shell stashed before we could listen.
+    if (osIsTauri()) {
+      osTakePendingStoreDeepLink()
+        .then((raw) => {
+          if (raw) setPending(raw);
+        })
+        .catch((err: unknown) => {
+          reportError(
+            "store_install_deeplink",
+            "failed to drain pending store deep-link",
+            err,
+          );
+        });
+    } else {
+      // Web: read `?install=<slug>` once, then strip it so a reload does not
+      // re-trigger the install (the pending slug lives only in memory).
+      const params = new URLSearchParams(window.location.search);
+      const install = params.get("install");
+      if (install !== null) {
+        params.delete("install");
+        const query = params.toString();
+        window.history.replaceState(
+          window.history.state,
+          "",
+          `${window.location.pathname}${query ? `?${query}` : ""}${window.location.hash}`,
+        );
+        setPending(install);
+      }
+    }
+
+    return () => {
+      off?.();
+    };
+  }, []);
+
+  // ── Processing: seed the wizard exactly once, when it can actually open ──
+  // The decision (drive / drop-duplicate / wait) lives in the pure reducer
+  // `decideStoreInstallDrive`; this effect only carries out the side effect it
+  // names. `driveState` is session state that must survive across ticks, so it
+  // rides a ref rather than React state.
+  const driveState = useRef({ ...initialStoreInstallDriveState });
+  useEffect(() => {
+    const { next, effect, slug } = decideStoreInstallDrive(driveState.current, {
+      pendingSlug,
+      wizardOpen: importFromFriendOpen,
+      shellLive,
+    });
+    driveState.current = next;
+
+    // Duplicate delivery of the slug already driven (website button
+    // double-click, or the cold-start drain and the live event both surfacing
+    // the same URL). Clear it so it can never re-fire when the wizard closes.
+    if (effect === "drop") {
+      useUIStore.getState().setPendingStoreInstallSlug(null);
+      return;
+    }
+    if (effect !== "drive" || !slug) return;
+
+    // Clear the pending slug now that we own this drive; the reducer's
+    // duplicate guard (keyed on the driven slug) blocks any re-delivery.
+    useUIStore.getState().setPendingStoreInstallSlug(null);
+
+    void (async () => {
+      try {
+        const preview = await getEngine().importFromStoreLink(slug);
+        const ui = useUIStore.getState();
+        ui.setImportSeedPreview(preview);
+        ui.setImportFromFriendOpen(true);
+        pingStoreInstall(slug).catch((err: unknown) => {
+          reportError(
+            "store_install_deeplink",
+            `install ping failed (${slug})`,
+            err,
+          );
+        });
+      } catch (err) {
+        reportError(
+          "store_install_deeplink",
+          `store install deep link failed (${slug})`,
+          err,
+        );
+        useUIStore.getState().addToast({
+          variant: "error",
+          title: t("installFailed"),
+        });
+      } finally {
+        driveState.current = { ...driveState.current, running: false };
+      }
+    })();
+  }, [pendingSlug, importFromFriendOpen, shellLive, t]);
+}

--- a/app/src/lib/store-install-drive.ts
+++ b/app/src/lib/store-install-drive.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure decision core for the store-install deep link, factored out of
+ * `useStoreInstallDeepLink` so it can be exhaustively tested without a React
+ * renderer.
+ *
+ * A store-install deep link seeds the import wizard exactly once per intent.
+ * The hazard is a SECOND delivery of the same slug: the website "Open in
+ * Houston" button is never disabled (a double-click fires the
+ * `houston://store/install` deep link twice), and on cold start the shell both
+ * stashes AND emits the URL, so the drain and the live event can both surface
+ * it. Without dedup that second delivery re-arms the pending slug and re-fires
+ * a full drive (double import + double install ping) the moment the wizard
+ * closes.
+ *
+ * This reducer runs once per processing tick. It owns the small amount of
+ * session state that survives across ticks (the refs) so the hook stays a thin
+ * shell that only performs side effects the reducer names.
+ */
+
+/** Session state that persists across processing ticks (held in refs). */
+export interface StoreInstallDriveState {
+  /** A drive is in flight (import fetch awaiting). */
+  running: boolean;
+  /** Slug of the drive currently in flight or whose wizard is still open. */
+  drivenSlug: string | null;
+  /** Whether the import wizard was open on the previous tick. */
+  wizardWasOpen: boolean;
+}
+
+/** Inputs read from the current render. */
+export interface StoreInstallDriveInput {
+  /** Validated slug waiting to be driven, or null. */
+  pendingSlug: string | null;
+  /** The import wizard is currently open. */
+  wizardOpen: boolean;
+  /** The shell can host the wizard (workspace + agents ready, no tutorial). */
+  shellLive: boolean;
+}
+
+/**
+ * - `drive`: begin the import for `slug`; the caller clears the pending slug and
+ *   marks the run in flight.
+ * - `drop`: a duplicate delivery of an already-driven slug; clear the pending
+ *   slug and do nothing else.
+ * - `idle`: nothing to do this tick (retain any pending slug — it is waiting for
+ *   the shell to go live or for an open wizard to close).
+ */
+export type StoreInstallDriveEffect = "drive" | "drop" | "idle";
+
+export interface StoreInstallDriveDecision {
+  next: StoreInstallDriveState;
+  effect: StoreInstallDriveEffect;
+  /** Set only when `effect === "drive"`. */
+  slug?: string;
+}
+
+export const initialStoreInstallDriveState: StoreInstallDriveState = {
+  running: false,
+  drivenSlug: null,
+  wizardWasOpen: false,
+};
+
+/**
+ * Decide what one processing tick should do. Pure: same inputs → same decision,
+ * no side effects, no store reads.
+ */
+export function decideStoreInstallDrive(
+  state: StoreInstallDriveState,
+  input: StoreInstallDriveInput,
+): StoreInstallDriveDecision {
+  let drivenSlug = state.drivenSlug;
+
+  // Wizard just closed (open -> closed): the drive it hosted is finished, so the
+  // same slug may legitimately be requested again by a genuinely new, post-close
+  // deep link. Only the transition clears it — the pre-open window (running but
+  // wizard not yet open) is also "not open" and must NOT clear the guard.
+  if (state.wizardWasOpen && !input.wizardOpen) drivenSlug = null;
+
+  const base: StoreInstallDriveState = {
+    running: state.running,
+    drivenSlug,
+    wizardWasOpen: input.wizardOpen,
+  };
+
+  if (!input.pendingSlug) return { next: base, effect: "idle" };
+
+  // Duplicate delivery of the slug already driven (button double-click, or the
+  // cold-start drain and the live event both surfacing the same URL). Drop it:
+  // never re-drive, never re-ping.
+  if (input.pendingSlug === drivenSlug) return { next: base, effect: "drop" };
+
+  // Not yet drivable — a wizard is open, the shell is not live, or a drive is in
+  // flight. Retain the pending slug and wait for a later tick.
+  if (input.wizardOpen || !input.shellLive || state.running) {
+    return { next: base, effect: "idle" };
+  }
+
+  return {
+    next: {
+      running: true,
+      drivenSlug: input.pendingSlug,
+      wizardWasOpen: input.wizardOpen,
+    },
+    effect: "drive",
+    slug: input.pendingSlug,
+  };
+}

--- a/app/src/lib/store-install-slug.ts
+++ b/app/src/lib/store-install-slug.ts
@@ -1,0 +1,48 @@
+import { SLUG_REGEX } from "@houston/agentstore-contract/ir";
+
+/**
+ * Parse and validate a store-install target into a canonical agent slug, or
+ * `null` when the input is not a safe install request.
+ *
+ * Two accepted shapes, one validator:
+ *  - The desktop deep link `houston://store/install?slug=<slug>` (the raw URL
+ *    the Rust shell stashes + emits on `store://deep-link`, and the cold-start
+ *    `take_pending_store_deep_link` drain returns).
+ *  - A bare slug (the web `?install=<slug>` query param, already decoded by
+ *    `URLSearchParams`).
+ *
+ * The slug is ALWAYS validated against the canonical `SLUG_REGEX` from
+ * `@houston/agentstore-contract` — the same regex the website validates with,
+ * so both sides agree byte-for-byte and nothing but `^[a-z0-9][a-z0-9-]{0,63}$`
+ * ever reaches the seed flow. Path traversal (`../evil`), injected query
+ * (`a&b=c`), uppercase, and empty all fail the regex and return `null`.
+ *
+ * Imported from the `/ir` subpath (not the package barrel) so this stays a pure,
+ * dependency-light module the frontend test can load under `node --test`.
+ */
+export function parseStoreInstallSlug(input: string): string | null {
+  const candidate = input.startsWith("houston://")
+    ? slugFromDeepLink(input)
+    : input;
+  if (candidate === null) return null;
+  return SLUG_REGEX.test(candidate) ? candidate : null;
+}
+
+/**
+ * Pull the `slug` query param out of a `houston://store/install` deep link.
+ * Guards against look-alikes (`houston://store/installEVIL`, other hosts/paths,
+ * other schemes) by matching the exact protocol + host + `/install` path, so a
+ * crafted URL can never smuggle a different action past the install branch.
+ */
+function slugFromDeepLink(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "houston:" || parsed.host !== "store") return null;
+  const path = parsed.pathname.replace(/\/$/, "");
+  if (path !== "/install") return null;
+  return parsed.searchParams.get("slug");
+}

--- a/app/src/stores/ui.ts
+++ b/app/src/stores/ui.ts
@@ -105,6 +105,11 @@ interface UIState {
    * set by "Manage all my agents" affordances before `setViewMode(STORE_VIEW_ID)`,
    * cleared by the view once consumed. Ephemeral, never persisted. */
   storeOwnerTab: "my" | null;
+  /** A one-shot slug queued by an `houston://store/install` deep link (desktop)
+   * or a `?install=<slug>` web param: the always-on deep-link hook seeds the
+   * import wizard with the store listing, then clears it. Ephemeral, never
+   * persisted (a reload must not re-trigger the install). */
+  pendingStoreInstallSlug: string | null;
   /** Whether the left rail is collapsed to an icon-only strip. Persisted. */
   sidebarCollapsed: boolean;
   /** Files tab layout: Drive-style card grid or Finder-style list. Persisted. */
@@ -150,6 +155,7 @@ interface UIState {
   setImportSeedPreview: (preview: PortableUploadPreviewResponse | null) => void;
   setStoreFocusSlug: (slug: string | null) => void;
   setStoreOwnerTab: (v: "my" | null) => void;
+  setPendingStoreInstallSlug: (slug: string | null) => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
   toggleSidebarCollapsed: () => void;
   setFilesViewMode: (mode: "grid" | "list") => void;
@@ -196,6 +202,7 @@ export const useUIStore = create<UIState>()(
       importSeedPreview: null,
       storeFocusSlug: null,
       storeOwnerTab: null,
+      pendingStoreInstallSlug: null,
       sidebarCollapsed: false,
       filesViewMode: "grid",
       filePreview: null,
@@ -321,6 +328,8 @@ export const useUIStore = create<UIState>()(
       setImportSeedPreview: (importSeedPreview) => set({ importSeedPreview }),
       setStoreFocusSlug: (storeFocusSlug) => set({ storeFocusSlug }),
       setStoreOwnerTab: (storeOwnerTab) => set({ storeOwnerTab }),
+      setPendingStoreInstallSlug: (pendingStoreInstallSlug) =>
+        set({ pendingStoreInstallSlug }),
       setSidebarCollapsed: (sidebarCollapsed) => set({ sidebarCollapsed }),
       toggleSidebarCollapsed: () =>
         set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),

--- a/app/tests/store-install-deeplink.test.ts
+++ b/app/tests/store-install-deeplink.test.ts
@@ -1,0 +1,108 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { parseStoreInstallSlug } from "../src/lib/store-install-slug.ts";
+
+// The parser is the single security gate for the store-install deep link: on
+// BOTH the desktop URL path and the web `?install=` path only a canonical slug
+// (`^[a-z0-9][a-z0-9-]{0,63}$`, straight from @houston/agentstore-contract) may
+// reach the seed flow. Everything else must return null.
+
+describe("parseStoreInstallSlug — bare slug (web ?install= param)", () => {
+  it("accepts a valid slug", () => {
+    strictEqual(parseStoreInstallSlug("my-agent"), "my-agent");
+  });
+
+  it("accepts a single-character slug", () => {
+    strictEqual(parseStoreInstallSlug("a"), "a");
+  });
+
+  it("rejects uppercase", () => {
+    strictEqual(parseStoreInstallSlug("My-Agent"), null);
+  });
+
+  it("rejects path traversal", () => {
+    strictEqual(parseStoreInstallSlug("../evil"), null);
+    strictEqual(parseStoreInstallSlug("a/b"), null);
+  });
+
+  it("rejects an injected query", () => {
+    strictEqual(parseStoreInstallSlug("good&install=evil"), null);
+    strictEqual(parseStoreInstallSlug("good?x=1"), null);
+  });
+
+  it("rejects a leading hyphen", () => {
+    strictEqual(parseStoreInstallSlug("-nope"), null);
+  });
+
+  it("rejects empty", () => {
+    strictEqual(parseStoreInstallSlug(""), null);
+  });
+
+  it("rejects a slug over 64 characters", () => {
+    strictEqual(parseStoreInstallSlug("a".repeat(65)), null);
+  });
+});
+
+describe("parseStoreInstallSlug — houston://store/install URL", () => {
+  it("extracts a valid slug", () => {
+    strictEqual(
+      parseStoreInstallSlug("houston://store/install?slug=my-agent"),
+      "my-agent",
+    );
+  });
+
+  it("accepts a trailing slash on the path", () => {
+    strictEqual(
+      parseStoreInstallSlug("houston://store/install/?slug=my-agent"),
+      "my-agent",
+    );
+  });
+
+  it("rejects a missing slug param", () => {
+    strictEqual(parseStoreInstallSlug("houston://store/install"), null);
+    strictEqual(parseStoreInstallSlug("houston://store/install?other=1"), null);
+  });
+
+  it("rejects an invalid slug in the param", () => {
+    strictEqual(
+      parseStoreInstallSlug("houston://store/install?slug=../evil"),
+      null,
+    );
+    strictEqual(
+      parseStoreInstallSlug("houston://store/install?slug=BadCase"),
+      null,
+    );
+  });
+
+  it("rejects a look-alike path (installEVIL guard)", () => {
+    strictEqual(
+      parseStoreInstallSlug("houston://store/installEVIL?slug=my-agent"),
+      null,
+    );
+  });
+
+  it("rejects a different host or path", () => {
+    strictEqual(
+      parseStoreInstallSlug("houston://store/uninstall?slug=my-agent"),
+      null,
+    );
+    strictEqual(
+      parseStoreInstallSlug("houston://evil/install?slug=my-agent"),
+      null,
+    );
+  });
+
+  it("rejects the auth deep-link channel", () => {
+    strictEqual(
+      parseStoreInstallSlug("houston://auth-callback?slug=my-agent"),
+      null,
+    );
+  });
+
+  it("rejects a non-houston scheme carrying a slug", () => {
+    strictEqual(
+      parseStoreInstallSlug("https://evil.com/store/install?slug=my-agent"),
+      null,
+    );
+  });
+});

--- a/app/tests/store-install-drive.test.ts
+++ b/app/tests/store-install-drive.test.ts
@@ -1,0 +1,168 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  decideStoreInstallDrive,
+  initialStoreInstallDriveState,
+  type StoreInstallDriveEffect,
+  type StoreInstallDriveInput,
+  type StoreInstallDriveState,
+} from "../src/lib/store-install-drive.ts";
+
+// The store-install deep link must seed the import wizard exactly ONCE per
+// intent. The reducer below is the guard: a second delivery of the same slug
+// (website "Open in Houston" double-click, or cold-start drain + live event both
+// surfacing the URL) must be dropped, never re-driven — otherwise the wizard
+// spontaneously re-opens and the install ping double-increments when the first
+// wizard is closed.
+
+/**
+ * Minimal driver mirroring the hook's side effects so a full event sequence can
+ * be replayed against the pure reducer. Each `tick` applies one processing pass;
+ * the caller mutates `pending` / `wizardOpen` between ticks to model deliveries,
+ * the async import completing, and the user closing the wizard.
+ */
+class Driver {
+  state: StoreInstallDriveState = { ...initialStoreInstallDriveState };
+  pending: string | null = null;
+  wizardOpen = false;
+  shellLive = true;
+  readonly effects: StoreInstallDriveEffect[] = [];
+
+  tick(): StoreInstallDriveEffect {
+    const input: StoreInstallDriveInput = {
+      pendingSlug: this.pending,
+      wizardOpen: this.wizardOpen,
+      shellLive: this.shellLive,
+    };
+    const { next, effect, slug } = decideStoreInstallDrive(this.state, input);
+    this.state = next;
+    this.effects.push(effect);
+    if (effect === "drop") this.pending = null;
+    if (effect === "drive") {
+      strictEqual(slug, input.pendingSlug);
+      this.pending = null;
+    }
+    return effect;
+  }
+
+  /** Model the async import resolving: wizard opens, run finishes. */
+  completeDrive(): void {
+    this.wizardOpen = true;
+    this.state = { ...this.state, running: false };
+  }
+
+  driveCount(): number {
+    return this.effects.filter((e) => e === "drive").length;
+  }
+}
+
+describe("decideStoreInstallDrive — single delivery", () => {
+  it("drives once when the shell is live", () => {
+    const d = new Driver();
+    d.pending = "my-agent";
+    strictEqual(d.tick(), "drive");
+    strictEqual(d.pending, null);
+    strictEqual(d.driveCount(), 1);
+  });
+
+  it("waits (retains the slug) until the shell is live", () => {
+    const d = new Driver();
+    d.shellLive = false;
+    d.pending = "my-agent";
+    strictEqual(d.tick(), "idle");
+    strictEqual(d.pending, "my-agent", "slug must survive to drive later");
+    d.shellLive = true;
+    strictEqual(d.tick(), "drive");
+    strictEqual(d.driveCount(), 1);
+  });
+});
+
+describe("decideStoreInstallDrive — duplicate delivery (the bug)", () => {
+  it("does not double-drive when a duplicate arrives during the drive", () => {
+    const d = new Driver();
+    d.pending = "my-agent";
+    strictEqual(d.tick(), "drive"); // A drives, pending cleared
+
+    // Second delivery arrives while the import is still awaiting.
+    d.pending = "my-agent";
+    strictEqual(d.tick(), "drop");
+    strictEqual(d.pending, null, "duplicate must be cleared, not retained");
+
+    d.completeDrive(); // wizard opens, run finishes
+    d.tick(); // re-render on wizardOpen change: nothing pending
+
+    // User closes the wizard.
+    d.wizardOpen = false;
+    strictEqual(d.tick(), "idle");
+    strictEqual(d.driveCount(), 1, "must drive exactly once");
+  });
+
+  it("does not double-drive when a duplicate arrives while the wizard is open", () => {
+    const d = new Driver();
+    d.pending = "my-agent";
+    strictEqual(d.tick(), "drive");
+    d.completeDrive();
+    d.tick(); // wizard now open
+
+    // Second delivery arrives while the wizard is open.
+    d.pending = "my-agent";
+    strictEqual(d.tick(), "drop");
+    strictEqual(d.pending, null);
+
+    d.wizardOpen = false;
+    d.tick(); // wizard closed
+    strictEqual(d.driveCount(), 1);
+  });
+});
+
+describe("decideStoreInstallDrive — legitimate flows still work", () => {
+  it("queues a genuinely different agent that arrives while a wizard is open", () => {
+    const d = new Driver();
+    d.pending = "agent-a";
+    strictEqual(d.tick(), "drive");
+    d.completeDrive();
+    d.tick(); // wizard A open
+
+    // A different agent's deep link arrives while wizard A is open.
+    d.pending = "agent-b";
+    strictEqual(d.tick(), "idle");
+    strictEqual(
+      d.pending,
+      "agent-b",
+      "a new agent must be retained, not dropped",
+    );
+
+    d.wizardOpen = false; // user closes wizard A
+    strictEqual(d.tick(), "drive"); // agent B drives after close
+    strictEqual(d.driveCount(), 2);
+  });
+
+  it("allows re-installing the same slug after the wizard is closed", () => {
+    const d = new Driver();
+    d.pending = "my-agent";
+    strictEqual(d.tick(), "drive");
+    d.completeDrive();
+    d.tick(); // wizard open
+    d.wizardOpen = false;
+    d.tick(); // wizard closed -> driven-slug guard released
+
+    // A genuinely new, post-close delivery of the same slug.
+    d.pending = "my-agent";
+    strictEqual(d.tick(), "drive");
+    strictEqual(d.driveCount(), 2);
+  });
+});
+
+describe("decideStoreInstallDrive — the driven-slug guard opens only on close", () => {
+  it("keeps the guard armed through the pre-open window", () => {
+    // Between dispatch and the wizard actually opening, wizardOpen is still
+    // false; that must NOT be mistaken for a close, or the guard releases and a
+    // duplicate re-drives.
+    const before = decideStoreInstallDrive(
+      { running: true, drivenSlug: "my-agent", wizardWasOpen: false },
+      { pendingSlug: "my-agent", wizardOpen: false, shellLive: true },
+    );
+    strictEqual(before.effect, "drop");
+    deepStrictEqual(before.next.drivenSlug, "my-agent");
+  });
+});

--- a/packages/agentstore-contract/package.json
+++ b/packages/agentstore-contract/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./src/index.ts",
       "import": "./src/index.ts"
+    },
+    "./ir": {
+      "types": "./src/ir.ts",
+      "import": "./src/ir.ts"
     }
   },
   "files": [

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -31,6 +31,7 @@
     "@houston-ai/routines": "workspace:*",
     "@houston-ai/skills": "workspace:*",
     "@houston/agentstore-client": "workspace:*",
+    "@houston/agentstore-contract": "workspace:*",
     "@houston/domain": "workspace:*",
     "@houston/protocol": "workspace:*",
     "@houston/runtime-client": "workspace:*",

--- a/packages/web/src/shims/tauri-core.ts
+++ b/packages/web/src/shims/tauri-core.ts
@@ -189,6 +189,12 @@ export async function invoke<T = unknown>(
       // the tunnel-vs-direct pill rule correct: a connected openai-compatible
       // endpoint on web reads as normally connected, not as a bridge.
       return null as T;
+    case "take_pending_store_deep_link":
+      // The web build reads the store-install target from the `?install=<slug>`
+      // query param directly (there is no native deep-link stash), so this
+      // cold-start drain has nothing to return. `osTakePendingStoreDeepLink`
+      // already short-circuits to null off-Tauri; this keeps shim parity intact.
+      return null as T;
     case "detect_legacy_houston":
       // A browser tab has no local `~/.houston` tree to migrate — "nothing
       // found" is the honest answer and keeps the cloud-migration wizard

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
       yaml:
         specifier: 2.9.0
         version: 2.9.0
@@ -109,6 +109,9 @@ importers:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260607.1
         version: 7.0.0-dev.20260607.1
+      jsdom:
+        specifier: 29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       tailwindcss:
         specifier: 4.3.2
         version: 4.3.2
@@ -117,7 +120,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
 
   app:
     dependencies:
@@ -154,6 +157,9 @@ importers:
       '@houston-ai/skills':
         specifier: workspace:*
         version: link:../ui/skills
+      '@houston/agentstore-contract':
+        specifier: workspace:*
+        version: link:../packages/agentstore-contract
       '@houston/protocol':
         specifier: workspace:*
         version: link:../packages/protocol
@@ -275,7 +281,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/agentstore-contract:
     dependencies:
@@ -297,7 +303,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/code-sandbox:
     dependencies:
@@ -313,7 +319,7 @@ importers:
         version: 7.0.0-dev.20260607.1
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/design-tokens:
     devDependencies:
@@ -331,7 +337,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/domain:
     dependencies:
@@ -365,7 +371,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/fake-host:
     dependencies:
@@ -396,7 +402,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/host:
     dependencies:
@@ -451,7 +457,7 @@ importers:
         version: 7.0.0-dev.20260607.1
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/protocol:
     devDependencies:
@@ -497,7 +503,7 @@ importers:
         version: 7.0.0-dev.20260607.1
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
     optionalDependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: 0.3.201
@@ -520,7 +526,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/sdk:
     dependencies:
@@ -557,7 +563,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/web:
     dependencies:
@@ -597,6 +603,9 @@ importers:
       '@houston/agentstore-client':
         specifier: workspace:*
         version: link:../agentstore-client
+      '@houston/agentstore-contract':
+        specifier: workspace:*
+        version: link:../agentstore-contract
       '@houston/domain':
         specifier: workspace:*
         version: link:../domain
@@ -693,7 +702,7 @@ importers:
         version: 6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
 
   ui/agent:
     dependencies:
@@ -1036,6 +1045,21 @@ packages:
       zod:
         optional: true
 
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
   '@aws-crypto/sha256-browser@5.2.0':
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
 
@@ -1280,6 +1304,10 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@bundled-es-modules/deepmerge@4.3.2':
     resolution: {integrity: sha512-q8doe7ndrY2IolUOFIn0A0++JBX38pMhN7kFhTF4cnjIcILf6X6H2yWczInyv8ZFdR0lrE8088X8XS5efxXz8A==}
 
@@ -1302,6 +1330,42 @@ packages:
   '@clack/prompts@1.7.0':
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -1733,6 +1797,15 @@ packages:
       '@effect/platform-node':
         optional: true
       react:
+        optional: true
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
         optional: true
 
   '@firebase/ai@1.4.1':
@@ -4400,6 +4473,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
@@ -4618,6 +4694,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -4781,6 +4861,10 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
@@ -4792,6 +4876,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -4918,6 +5005,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -5304,6 +5395,10 @@ packages:
     resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
@@ -5470,6 +5565,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -5520,6 +5618,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -5813,6 +5920,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -6183,6 +6293,9 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -6314,6 +6427,10 @@ packages:
 
   punycode@1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   pure-rand@8.4.2:
     resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
@@ -6557,6 +6674,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -6789,6 +6910,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
@@ -6873,8 +6997,16 @@ packages:
     resolution: {integrity: sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==}
     engines: {node: '>=20'}
 
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-dump@1.1.0:
     resolution: {integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==}
@@ -6988,6 +7120,10 @@ packages:
   undici@6.27.0:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   undici@8.5.0:
     resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
@@ -7176,6 +7312,10 @@ packages:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -7192,6 +7332,10 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   websocket-driver@0.7.5:
     resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
@@ -7199,6 +7343,14 @@ packages:
   websocket-extensions@0.1.4:
     resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
     engines: {node: '>=0.8.0'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -7248,9 +7400,16 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xml-naming@0.1.0:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -7386,6 +7545,26 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.3
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
@@ -7752,6 +7931,10 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@bundled-es-modules/deepmerge@4.3.2':
     dependencies:
       deepmerge: 4.3.1
@@ -7794,6 +7977,30 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
     dependencies:
@@ -8219,6 +8426,10 @@ snapshots:
     transitivePeerDependencies:
       - drizzle-orm
       - typeorm
+
+  '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
 
   '@firebase/ai@1.4.1(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)':
     dependencies:
@@ -11080,6 +11291,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.42: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   bignumber.js@9.3.1: {}
 
   body-parser@2.3.0:
@@ -11285,6 +11500,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
 
   cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
@@ -11473,11 +11693,20 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  data-urls@7.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   dayjs@1.11.21: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -11595,6 +11824,8 @@ snapshots:
       tapable: 2.3.3
 
   entities@6.0.1: {}
+
+  entities@8.0.0: {}
 
   environment@1.1.0: {}
 
@@ -12206,6 +12437,12 @@ snapshots:
     dependencies:
       lru-cache: 11.5.1
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-entities@2.6.0: {}
 
   html-parse-stringify@3.0.1:
@@ -12361,6 +12598,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regex@1.2.1:
@@ -12405,6 +12644,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1(@noble/hashes@2.2.0):
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -12788,6 +13053,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -13281,6 +13548,10 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   partial-json@0.1.7: {}
@@ -13419,6 +13690,8 @@ snapshots:
   proxy-from-env@1.1.0: {}
 
   punycode@1.4.1: {}
+
+  punycode@2.3.1: {}
 
   pure-rand@8.4.2: {}
 
@@ -13790,6 +14063,10 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -14108,6 +14385,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.2: {}
@@ -14183,7 +14462,15 @@ snapshots:
 
   toml@4.1.2: {}
 
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.8
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-dump@1.1.0(tslib@2.8.1):
     dependencies:
@@ -14252,6 +14539,8 @@ snapshots:
     optional: true
 
   undici@6.27.0: {}
+
+  undici@7.28.0: {}
 
   undici@8.5.0: {}
 
@@ -14449,7 +14738,7 @@ snapshots:
       tsx: 4.23.0
       yaml: 2.9.0
 
-  vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0):
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -14477,6 +14766,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 22.20.0
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -14491,7 +14781,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.6(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0):
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -14519,6 +14809,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 25.6.0
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -14535,6 +14826,10 @@ snapshots:
 
   void-elements@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
@@ -14545,6 +14840,8 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webidl-conversions@8.0.1: {}
+
   websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
@@ -14552,6 +14849,16 @@ snapshots:
       websocket-extensions: 0.1.4
 
   websocket-extensions@0.1.4: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -14605,7 +14912,11 @@ snapshots:
 
   ws@8.21.0: {}
 
+  xml-name-validator@5.0.0: {}
+
   xml-naming@0.1.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## What

Closes the last parity gap between agents.gethouston.ai and the app: the website's **Open in Houston** button now actually opens Houston.

- **Tauri shell**: new `store_deep_link` module handling `houston://store/install?slug=<slug>` — prefix-guarded matcher (rejects `installEVIL`-style lookalikes, unit tested), cold-start stash drained exactly once via a `take_pending_store_deep_link` command (mirrors the engine-handshake pattern), `store://deep-link` event fully disjoint from the auth deep-link channel.
- **App**: shared `useStoreInstallDeepLink` hook consumed by desktop (runtime event + cold-start drain) and web (`app.gethouston.ai/?install=<slug>`, param stripped after first handle so reload can't re-trigger). The slug is `SLUG_REGEX`-validated on ingress, parked in a non-persisted one-shot, and drives the **existing import wizard seed flow** — threat scan, naming, and pickers still gate every install; nothing auto-installs. Double-drive guards for repeat links and open wizards. Install ping fires app-side only (no double count with the website).
- **Website**: install panel fires the deep link via hidden iframe with a 1.5s blur/visibility fallback — "Don't have Houston?" → download / **Open in Houston Web** / copy share link, all non-destructive. URL builders + slug guard extracted to a pure, unit-tested `houston-launch` module.

## Verification

- cargo 160/160 (incl. new deep-link matcher tests) · app 1712/1712 + tsgo + locales in sync · web suite + shim parity (41 commands) · agentstore 84/84 (incl. new jsdom listener-hygiene component tests) · repo-wide Biome + boundaries green
- Security-focused adversarial review (injection, wizard bypass, event spoofing, cold-start races): 3 confirmed findings — deep-link re-arm double-install, warm-path stash re-drain, listener leak — all fixed with reproduction tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)