### PR TITLE
fix(sentry): stop updater poll failures from flooding Sentry

### DIFF
--- a/app/src-tauri/src/logging.rs
+++ b/app/src-tauri/src/logging.rs
@@ -15,6 +15,11 @@ static GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 ///   - `sentry_tracing::layer()` → INFO+ events become Sentry breadcrumbs;
 ///     ERROR events become standalone Sentry events. No-op if `sentry::init`
 ///     hasn't been called (e.g. empty SENTRY_DSN), so safe to always include.
+///     Exception: `tauri_plugin_updater` ERRORs stay breadcrumbs — the plugin
+///     logs one on every failed background update poll (machine offline,
+///     GitHub down, channel manifest not yet published), and the frontend
+///     already owns that failure (30-min retry, update-floor fallback URL,
+///     install-error card), so a standalone Sentry event per poll is noise.
 ///
 /// Result: when a Rust panic or explicit `tracing::error!` lands in Sentry,
 /// the last ~100 INFO/WARN log lines auto-attach as breadcrumbs — the
@@ -52,8 +57,25 @@ pub fn init(data_dir: &Path) {
     tracing_subscriber::registry()
         .with(filter)
         .with(fmt_layer)
-        .with(sentry_tracing::layer())
+        .with(sentry_tracing::layer().event_filter(|metadata| {
+            if demote_error_to_breadcrumb(metadata.target()) {
+                sentry_tracing::EventFilter::Breadcrumb
+            } else {
+                sentry_tracing::default_event_filter(metadata)
+            }
+        }))
         .init();
+}
+
+/// Targets whose ERROR logs must NOT become standalone Sentry events.
+///
+/// `tauri_plugin_updater` fires `log::error!` on every unsuccessful update
+/// check — including the expected ones (offline, GitHub unreachable, the
+/// cloud channel's `cloud-latest` manifest not published yet). The check
+/// failure is fully handled in `use-update-checker.ts`, so Sentry only needs
+/// the breadcrumb trail, not an event per 30-min poll.
+fn demote_error_to_breadcrumb(target: &str) -> bool {
+    target.starts_with("tauri_plugin_updater")
 }
 
 fn logs_dir() -> PathBuf {
@@ -144,6 +166,21 @@ fn tail_file(path: &Path, n: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn updater_plugin_errors_are_demoted_to_breadcrumbs() {
+        assert!(demote_error_to_breadcrumb("tauri_plugin_updater::updater"));
+        assert!(demote_error_to_breadcrumb("tauri_plugin_updater"));
+    }
+
+    #[test]
+    fn app_errors_still_become_sentry_events() {
+        assert!(!demote_error_to_breadcrumb("houston_app"));
+        assert!(!demote_error_to_breadcrumb(
+            "houston_app::engine_supervisor"
+        ));
+        assert!(!demote_error_to_breadcrumb("tauri_plugin_sentry"));
+    }
 
     #[test]
     fn latest_log_matching_uses_newest_rotated_backend_log() {


### PR DESCRIPTION
## Sentry issue

[7512539469 — "update endpoint did not respond with a successful status code"](https://houston-cd.sentry.io/issues/7512539469/) — 485 events since May 28, error level, from `tauri-plugin-updater` (updater.rs:509).

## Root cause

Two layers:

1. **Cloud builds 404 on every update check.** Cloud desktop builds poll the fixed tag `releases/download/cloud-latest/latest-cloud.json`, but the `cloud-latest` pointer release is only created by the cloud-updater-manifest workflow when a `cloud-v*` release is **published** — and every cloud release to date is still a draft, so `cloud-latest` does not exist and the endpoint 404s on every 30-minute poll. That's the bulk of the volume (0.5.9: 197 events, 0.5.18: 99, ...).
2. **The plugin's internal `log::error!` became a Sentry event.** `tauri-plugin-updater` logs at error level on any non-2xx, and our `sentry_tracing` layer promotes every ERROR log to a standalone Sentry event. Local builds contribute a tail of the same noise on offline/transient GitHub failures.

## Fix

Demote `tauri_plugin_updater` ERROR logs to Sentry **breadcrumbs** in the shell's logging setup. The failure is already owned at the right layer: the frontend updater hook catches a failed `check()`, retries every 30 minutes, the update-floor screen falls back to the gateway-provided `updateUrl`, and install failures surface their own error card. Nothing is silenced — the log line still lands in `backend.log` and rides along as a breadcrumb on any real event.

Not fixed here (operational): publishing a `cloud-v*` release so the promote workflow creates `cloud-latest` — until that happens, cloud builds simply see "no update available" behavior on every poll.

## Testing

- `cargo test` in `app/src-tauri`: 162 passed, 0 failed (includes new unit tests for the demotion predicate).