### PR TITLE
feat(providers): hide regional duplicate deployments (China / Singapore / Amsterdam)

### DIFF
--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -223,8 +223,13 @@ export const FEATURED_PROVIDER_IDS = [
   "openai-compatible",
 ] as const;
 
-/** Regional-deployment id suffixes (China / Singapore / Amsterdam). */
-const REGIONAL_SUFFIX = /-(cn|sgp|ams)$/;
+/**
+ * Regional-deployment id suffixes (China / Singapore / Amsterdam). Providers
+ * carrying one are hidden from the catalog whenever their standard (unsuffixed)
+ * deployment also ships — one card per provider, no regional duplicates (see
+ * `buildCatalog`).
+ */
+export const REGIONAL_SUFFIX = /-(cn|sgp|ams)$/;
 
 export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
   openai: {
@@ -658,45 +663,6 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     cost: "Pay as you go",
     installUrl: "https://platform.xiaomimimo.com",
     apiKeyUrl: "https://platform.xiaomimimo.com",
-  },
-  "xiaomi-token-plan-cn": {
-    name: "Xiaomi MiMo Token Plan (China)",
-    subtitle: "MiMo on a Token Plan",
-    cost: "Your MiMo Token Plan",
-    billing: "subscription",
-    installUrl: "https://platform.xiaomimimo.com",
-    apiKeyUrl: "https://platform.xiaomimimo.com",
-  },
-  "xiaomi-token-plan-sgp": {
-    name: "Xiaomi MiMo Token Plan (Singapore)",
-    subtitle: "MiMo on a Token Plan",
-    cost: "Your MiMo Token Plan",
-    billing: "subscription",
-    installUrl: "https://platform.xiaomimimo.com",
-    apiKeyUrl: "https://platform.xiaomimimo.com",
-  },
-  "xiaomi-token-plan-ams": {
-    name: "Xiaomi MiMo Token Plan (Amsterdam)",
-    subtitle: "MiMo on a Token Plan",
-    cost: "Your MiMo Token Plan",
-    billing: "subscription",
-    installUrl: "https://platform.xiaomimimo.com",
-    apiKeyUrl: "https://platform.xiaomimimo.com",
-  },
-  "minimax-cn": {
-    name: "MiniMax (China)",
-    subtitle: "China endpoint",
-    cost: "Pay-as-you-go on your MiniMax account",
-    installUrl: "https://platform.minimaxi.com",
-    apiKeyUrl: "https://platform.minimaxi.com",
-  },
-  "zai-coding-cn": {
-    name: "Z.ai Coding (China)",
-    subtitle: "GLM coding plan, China",
-    cost: "Your GLM Coding plan",
-    billing: "subscription",
-    installUrl: "https://open.bigmodel.cn",
-    apiKeyUrl: "https://open.bigmodel.cn/usercenter/apikeys",
   },
 };
 

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -12,6 +12,7 @@ import {
   PROVIDER_ID_RENAME,
   PROVIDER_OVERRIDES,
   type ProviderOverride,
+  REGIONAL_SUFFIX,
 } from "./provider-overrides.ts";
 
 /**
@@ -249,10 +250,22 @@ function buildProvider(
  * concept of.
  */
 function buildCatalog(catalog: ProviderCatalog): ProviderInfo[] {
+  // Ids present after drops/renames, so the regional filter below can tell a
+  // duplicate deployment apart from a provider whose ONLY deployment is
+  // regional (which stays visible rather than vanishing entirely).
+  const finalIds = new Set(
+    catalog
+      .filter((p) => !DROP_PI_PROVIDERS.has(p.id))
+      .map((p) => PROVIDER_ID_RENAME[p.id] ?? p.id),
+  );
   const built: ProviderInfo[] = [];
   for (const piProvider of catalog) {
     if (DROP_PI_PROVIDERS.has(piProvider.id)) continue;
     const finalId = PROVIDER_ID_RENAME[piProvider.id] ?? piProvider.id;
+    // Regional duplicates (…-cn / -sgp / -ams) of a provider that also ships
+    // its standard deployment are hidden — one card per provider.
+    const parent = finalId.replace(REGIONAL_SUFFIX, "");
+    if (parent !== finalId && finalIds.has(parent)) continue;
     built.push(buildProvider(piProvider, finalId, PROVIDER_OVERRIDES[finalId]));
   }
   built.push({ ...LOCAL_PROVIDER });


### PR DESCRIPTION
## What

pi's catalog ships some providers several times as regional deployments — `-cn` (China), `-sgp` (Singapore), `-ams` (Amsterdam): Xiaomi MiMo Token Plan ×3, MiniMax (China), Z.ai Coding (China). They showed as duplicate cards in the connect surfaces, the chat model picker, and the AI hub.

`buildCatalog` now drops a regional-suffixed provider whenever its **standard unsuffixed deployment is also in the catalog** — one card per provider, the standard version only. A provider whose ONLY deployment is regional stays visible (nothing vanishes entirely).

Also removes the now-dead regional entries from `PROVIDER_OVERRIDES` (so the pre-hydration seed doesn't show them either). `providerDescription` keeps its parent-description fallback for any stray regional id.

## Verification
- `pnpm check` clean (Biome)
- `app` `pnpm tsgo --noEmit` ✅
- Provider unit tests: 65/65 pass (`provider-overrides`, `provider-catalog`, `provider-logo-map`, `hub-catalog`, `card-unification`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
