### PR TITLE
feat(app): legacy→cloud migration offer for the final local release

### DIFF
--- a/app/src-tauri/src/commands/update.rs
+++ b/app/src-tauri/src/commands/update.rs
@@ -6,6 +6,101 @@
 //! asks this module to open that path after install.
 
 use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Emitter};
+use tauri_plugin_updater::UpdaterExt;
+
+/// The CLOUD channel's rolling updater manifest (kept current by
+/// cloud-updater-manifest.yml on every published cloud-v* release). The
+/// local build's baked endpoint is the LOCAL feed (latest.json); migration
+/// deliberately crosses channels, so the endpoint is overridden here — the
+/// JS `check()` cannot do that (no `endpoints` in CheckOptions).
+const CLOUD_MANIFEST_URL: &str =
+    "https://github.com/gethouston/houston/releases/download/cloud-latest/latest-cloud.json";
+
+/// Remote migration policy: `{"mode":"optional"}` or `{"mode":"required"}`.
+/// Lives as an asset on the fixed `migration-policy` release so the mode can
+/// be flipped later with one `gh release upload --clobber` — this is the LAST
+/// local-channel build, so any future behavior change must ride a remote
+/// value baked in today. Absent/unreachable/malformed ⇒ optional (fail-open).
+const MIGRATION_POLICY_URL: &str =
+    "https://github.com/gethouston/houston/releases/download/migration-policy/migration-policy.json";
+
+/// Progress channel for the cloud-migration download (mirrors
+/// `dictation-model-progress`).
+const MIGRATION_PROGRESS_EVENT: &str = "cloud-migration-progress";
+
+#[derive(Clone, serde::Serialize)]
+struct MigrationProgress {
+    downloaded: u64,
+    total: Option<u64>,
+}
+
+/// Download and install the CLOUD build over this local install, using the
+/// updater plugin against the cloud manifest. The version comparator is
+/// forced to `true`: the two channels are versioned independently, and this
+/// final local release intentionally sits BELOW the cloud line (0.4.x) so
+/// the Windows MSI upgrade guard also allows the switch. Signature
+/// verification still applies — the builder inherits the tauri.conf pubkey,
+/// which is shared by both channels.
+#[tauri::command(rename_all = "snake_case")]
+pub async fn install_cloud_migration(app: AppHandle) -> Result<(), String> {
+    let url = tauri::Url::parse(CLOUD_MANIFEST_URL).map_err(|e| e.to_string())?;
+    let updater = app
+        .updater_builder()
+        .endpoints(vec![url])
+        .map_err(|e| format!("cloud migration: endpoint rejected: {e}"))?
+        .version_comparator(|_current, _remote| true)
+        .build()
+        .map_err(|e| format!("cloud migration: updater build failed: {e}"))?;
+
+    let update = updater
+        .check()
+        .await
+        .map_err(|e| format!("cloud migration: manifest check failed: {e}"))?
+        .ok_or_else(|| "cloud migration: no cloud build available".to_string())?;
+
+    let mut downloaded: u64 = 0;
+    let progress_app = app.clone();
+    update
+        .download_and_install(
+            move |chunk, total| {
+                downloaded += chunk as u64;
+                let _ = progress_app.emit(
+                    MIGRATION_PROGRESS_EVENT,
+                    MigrationProgress { downloaded, total },
+                );
+            },
+            || {},
+        )
+        .await
+        .map_err(|e| format!("cloud migration: install failed: {e}"))?;
+    Ok(())
+}
+
+/// Fetch the remote migration policy mode. Always resolves — every failure
+/// path degrades to "optional" so a network outage can never lock a user
+/// into a forced migration they can't evaluate.
+#[tauri::command(rename_all = "snake_case")]
+pub async fn fetch_migration_policy() -> Result<String, String> {
+    let mode = async {
+        let resp = reqwest::Client::new()
+            .get(MIGRATION_POLICY_URL)
+            .timeout(std::time::Duration::from_secs(10))
+            .send()
+            .await
+            .ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+        let body: serde_json::Value = resp.json().await.ok()?;
+        match body.get("mode")?.as_str()? {
+            "required" => Some("required".to_string()),
+            _ => Some("optional".to_string()),
+        }
+    }
+    .await;
+    Ok(mode.unwrap_or_else(|| "optional".to_string()))
+}
 
 #[tauri::command(rename_all = "snake_case")]
 pub fn current_app_bundle_path() -> Result<String, String> {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -416,6 +416,8 @@ pub fn run() {
             commands::save_file::save_download,
             commands::update::current_app_bundle_path,
             commands::update::relaunch_app_from_path,
+            commands::update::install_cloud_migration,
+            commands::update::fetch_migration_policy,
             // Hidden Sentry smoke command for native stack verification.
             commands::diagnostics::sentry_native_stack_smoke_test,
             // Logging (writes to local log files).

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -8,6 +8,7 @@ import { isFirstRun } from "./components/onboarding/missions/onboarding-flow";
 import { PersonalAssistantOnboarding } from "./components/onboarding/personal-assistant-onboarding";
 import { OnboardingSegmentScreen } from "./components/onboarding/segment-screen";
 import { ClaudeBrowserLogin } from "./components/shell/claude-browser-login";
+import { MigrateToCloudOffer } from "./components/shell/migrate-to-cloud";
 import { ProviderLoginFallback } from "./components/shell/provider-login-fallback";
 import { WorkspaceLoading } from "./components/shell/workspace-loading";
 import { WorkspaceShell } from "./components/shell/workspace-shell";
@@ -304,6 +305,10 @@ export default function App() {
 
   return (
     <CloudMigrationGate>
+      {/* Legacy→cloud upgrade offer: local builds only (renders null on
+          cloud), overlays every shell state including onboarding — a fresh
+          install of an old download should meet the offer immediately. */}
+      <MigrateToCloudOffer />
       {segmentPending ? (
         onboardingSegment.isLoading ? (
           <WorkspaceLoading />

--- a/app/src/components/settings/settings-index.tsx
+++ b/app/src/components/settings/settings-index.tsx
@@ -8,9 +8,12 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useWorkspaceContext } from "../../hooks/queries/use-workspace-context";
+import { isHostedGatewayEngine } from "../../lib/engine";
 import { genericErrorDescription } from "../../lib/error-toast";
+import { osIsTauri } from "../../lib/os-bridge";
 import type { SettingsSectionId } from "../../lib/settings-sections";
 import { useAgentStore } from "../../stores/agents";
+import { useMigrateToCloudStore } from "../../stores/migrate-to-cloud";
 import { useUIStore } from "../../stores/ui";
 import { PageContainer, PageHeader } from "../shell/page-shell";
 import { AccountSection } from "./sections/account";
@@ -120,6 +123,17 @@ export function SettingsIndex({
               title={t("settings:migration.title")}
               description={t("settings:index.rows.migration")}
               onClick={() => onSelect("migration")}
+            />
+          )}
+          {/* Local (sidecar) builds: reopen the legacy→cloud upgrade offer.
+              The cloud-build counterpart above re-runs the DATA import; this
+              one installs the cloud APP — mutually exclusive gates. */}
+          {!isHostedGatewayEngine() && osIsTauri() && (
+            <SettingsRow
+              icon={CloudUpload}
+              title={t("settings:migrateToCloud.title")}
+              description={t("settings:index.rows.migrateToCloud")}
+              onClick={() => useMigrateToCloudStore.getState().open("settings")}
             />
           )}
         </SettingsCard>

--- a/app/src/components/shell/migrate-to-cloud.tsx
+++ b/app/src/components/shell/migrate-to-cloud.tsx
@@ -1,0 +1,141 @@
+import { AlertCircle, CloudUpload, Loader2, RotateCw, X } from "lucide-react";
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import houstonWhite from "../../assets/houston-icon-white.svg";
+import { isHostedGatewayEngine } from "../../lib/engine";
+import { osIsTauri } from "../../lib/os-bridge";
+import { useMigrateToCloudStore } from "../../stores/migrate-to-cloud";
+
+/**
+ * The legacy→cloud upgrade offer: an announcement-style modal (hero image,
+ * centered copy, single pill CTA) shown on LOCAL (sidecar) builds only — the
+ * final feature of the local channel. It greets EVERY launch; the X only
+ * hides it for the session, and the sidebar's "Migrate to cloud" entry
+ * reopens it, which the copy itself points at so nobody feels rushed. A
+ * remote policy of "required" removes the X and it becomes a hard gate.
+ *
+ * The actual install is `install_cloud_migration` (Rust): a cross-channel,
+ * signature-verified updater run against the cloud manifest, after which the
+ * relaunch boots the CLOUD build — whose existing first-run migration wizard
+ * (HOU-719) imports `~/.houston` data and walks through reconnecting
+ * integrations. This component only has to get that build installed.
+ */
+export function MigrateToCloudOffer() {
+  const { t } = useTranslation("shell");
+  const {
+    visible,
+    policy,
+    status,
+    progress,
+    initialize,
+    dismiss,
+    install,
+    relaunch,
+  } = useMigrateToCloudStore();
+
+  // Local Tauri builds only: cloud builds have nothing to migrate to, and the
+  // browser dev shell has no updater.
+  const eligible = !isHostedGatewayEngine() && osIsTauri();
+
+  useEffect(() => {
+    if (eligible) void initialize();
+  }, [eligible, initialize]);
+
+  if (!eligible || !visible) return null;
+
+  const downloading = status === "downloading";
+  const ready = status === "ready";
+  const error = status === "error";
+  const dismissible = policy !== "required" && !downloading && !ready;
+
+  const message = downloading
+    ? progress === null
+      ? t("updateChecker.downloading")
+      : t("updateChecker.downloadingProgress", { progress })
+    : ready
+      ? t("migrateToCloud.ready")
+      : error
+        ? t("migrateToCloud.error")
+        : t("migrateToCloud.description");
+
+  return (
+    <div
+      role="alertdialog"
+      aria-modal="true"
+      aria-label={t("migrateToCloud.cardLabel")}
+      aria-live={downloading ? "polite" : "assertive"}
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-ink/45 p-4"
+    >
+      <div className="w-[480px] max-w-full overflow-hidden rounded-2xl border border-line bg-card text-card-text shadow-[0_16px_60px_rgba(0,0,0,0.16)]">
+        {/* Hero: pure CSS gradient (no bundled artwork) with the Houston mark. */}
+        <div className="relative flex h-44 items-center justify-center bg-gradient-to-br from-indigo-600 via-violet-500 to-purple-400">
+          <img
+            src={houstonWhite}
+            alt=""
+            aria-hidden="true"
+            className="size-16 object-contain drop-shadow-[0_4px_16px_rgba(0,0,0,0.25)]"
+          />
+          {dismissible && (
+            <button
+              type="button"
+              onClick={dismiss}
+              aria-label={t("migrateToCloud.closeLabel")}
+              className="absolute right-3 top-3 flex size-8 items-center justify-center rounded-full bg-black/20 text-white transition-colors hover:bg-black/35"
+            >
+              <X className="size-4" />
+            </button>
+          )}
+        </div>
+
+        <div className="p-6 text-center">
+          <div className="flex items-center justify-center gap-2">
+            <h2 className="text-lg font-semibold leading-tight">
+              {t("migrateToCloud.title")}
+            </h2>
+            {error && <AlertCircle className="size-4 shrink-0 text-danger" />}
+          </div>
+          <p className="mx-auto mt-2 max-w-[380px] text-sm leading-relaxed text-ink-muted">
+            {message}
+          </p>
+
+          {downloading && (
+            <div className="mx-auto mt-4 h-1.5 max-w-[380px] overflow-hidden rounded-full bg-chip-subtle">
+              <div
+                className={`h-full rounded-full bg-action transition-[width] duration-200 ${progress === null ? "animate-pulse" : ""}`}
+                style={{ width: `${progress ?? 35}%` }}
+              />
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={ready ? () => void relaunch() : () => void install()}
+            disabled={downloading}
+            className="mt-5 inline-flex h-10 items-center justify-center gap-2 rounded-full bg-action px-6 text-sm font-medium text-action-text transition-opacity hover:opacity-90 disabled:cursor-default disabled:opacity-70"
+          >
+            {downloading ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : ready ? (
+              <RotateCw className="size-4" />
+            ) : (
+              <CloudUpload className="size-4" />
+            )}
+            {downloading
+              ? t("updateChecker.installingAction")
+              : ready
+                ? t("updateChecker.relaunchAction")
+                : error
+                  ? t("updateChecker.retryAction")
+                  : t("migrateToCloud.installAction")}
+          </button>
+
+          {dismissible && (
+            <p className="mx-auto mt-4 max-w-[380px] text-xs leading-snug text-ink-muted">
+              {t("migrateToCloud.anytimeNote")}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/shell/sidebar-chrome.tsx
+++ b/app/src/components/shell/sidebar-chrome.tsx
@@ -5,6 +5,7 @@ import {
   Blocks,
   Boxes,
   Building2,
+  CloudUpload,
   Gauge,
   LayoutDashboard,
   Settings,
@@ -13,7 +14,10 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { useCapabilities } from "../../hooks/use-capabilities";
+import { isHostedGatewayEngine } from "../../lib/engine";
 import { hasSpaces } from "../../lib/org-roles";
+import { osIsTauri } from "../../lib/os-bridge";
+import { useMigrateToCloudStore } from "../../stores/migrate-to-cloud";
 import { INTEGRATIONS_VIEW_ID } from "../integrations-view";
 import { ORGANIZATION_VIEW_ID } from "../organization";
 import { PERMISSIONS_VIEW_ID } from "../permissions";
@@ -89,6 +93,20 @@ export function buildSidebarNavItems(args: {
             icon: <Building2 className="h-4 w-4" />,
             onClick: () => setViewMode(ORGANIZATION_VIEW_ID),
             dataAttrs: { "data-tour-target": "nav-organization" },
+          },
+        ]
+      : []),
+    // Local (sidecar) builds only: the always-available way back into the
+    // legacy→cloud upgrade offer, so dismissing the launch modal never
+    // strands anyone. Opens the same modal — no separate surface to design.
+    ...(!isHostedGatewayEngine() && osIsTauri()
+      ? [
+          {
+            id: "migrate-to-cloud",
+            label: t("shell:sidebar.migrateToCloud"),
+            icon: <CloudUpload className="h-4 w-4" />,
+            onClick: () => useMigrateToCloudStore.getState().open("sidebar"),
+            dataAttrs: { "data-tour-target": "nav-migrate-to-cloud" },
           },
         ]
       : []),

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -133,6 +133,10 @@ export type AnalyticsEventName =
   | "update_offered"
   | "update_accepted"
   | "update_dismissed"
+  | "migrate_to_cloud_offered"
+  | "migrate_to_cloud_accepted"
+  | "migrate_to_cloud_dismissed"
+  | "migrate_to_cloud_installed"
   // Gateway app-update floor tripped → blocking update screen shown
   | "update_required"
   // Reliability

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -237,6 +237,39 @@ export function osRelaunchAppFromPath(appPath: string): Promise<void> {
   return invoke<void>("relaunch_app_from_path", { app_path: appPath });
 }
 
+/** Progress tick for {@link osInstallCloudMigration} downloads. */
+export interface CloudMigrationProgress {
+  downloaded: number;
+  total: number | null;
+}
+
+/** Download + install the CLOUD build over this local install (cross-channel
+ *  updater run against the cloud manifest; signature-verified). Capture
+ *  {@link osCurrentAppBundlePath} BEFORE calling, then relaunch with
+ *  {@link osRelaunchAppFromPath} — same choreography as the normal updater. */
+export function osInstallCloudMigration(): Promise<void> {
+  return invoke<void>("install_cloud_migration");
+}
+
+/** Subscribe to `cloud-migration-progress` ticks emitted while
+ *  {@link osInstallCloudMigration} runs. Mirrors {@link onDictationModelProgress}. */
+export function onCloudMigrationProgress(
+  handler: (progress: CloudMigrationProgress) => void,
+): Promise<UnlistenFn> {
+  return listen<CloudMigrationProgress>("cloud-migration-progress", (ev) =>
+    handler(ev.payload),
+  );
+}
+
+/** Remote migration policy for the legacy→cloud offer: "required" makes the
+ *  offer non-dismissible; anything else (including fetch failure) is
+ *  "optional". Resolved Rust-side to dodge webview CORS. */
+export function osFetchMigrationPolicy(): Promise<"optional" | "required"> {
+  return invoke<string>("fetch_migration_policy").then((mode) =>
+    mode === "required" ? "required" : "optional",
+  );
+}
+
 /** Append a line to `~/Library/Application Support/houston/logs/frontend.log`. */
 export function osWriteFrontendLog(
   level: "error" | "warn" | "info" | "debug",

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -127,7 +127,8 @@
       "userContext": "What every agent knows about you",
       "shortcuts": "Run Houston without the mouse",
       "reportBug": "Something broke? Tell us",
-      "migration": "Pick up your move to the cloud"
+      "migration": "Pick up your move to the cloud",
+      "migrateToCloud": "Upgrade this app to Houston Cloud"
     },
     "values": {
       "set": "Set"
@@ -175,5 +176,8 @@
       "confirm": "Revoke",
       "cancel": "Cancel"
     }
+  },
+  "migrateToCloud": {
+    "title": "Migrate to cloud"
   }
 }

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -46,7 +46,8 @@
         "cancel": "Cancel"
       }
     },
-    "permissions": "Permissions"
+    "permissions": "Permissions",
+    "migrateToCloud": "Migrate to cloud"
   },
   "tabActions": {
     "newMission": "New mission",
@@ -231,6 +232,16 @@
     "descriptionNoVersion": "A newer version of Houston is required to keep using Houston Cloud. You're on v{{currentVersion}}.",
     "downloadAction": "Download the update",
     "checkAction": "Check for updates"
+  },
+  "migrateToCloud": {
+    "cardLabel": "Upgrade to Houston Cloud",
+    "title": "Upgrade to Houston Cloud",
+    "description": "Houston is moving to the cloud: your agents keep working even when your computer is off. Houston Cloud is in early beta. Your agents and data are imported automatically, and you'll sign in and reconnect your integrations after the upgrade.",
+    "anytimeNote": "No need to decide now. You can start the upgrade anytime from “Migrate to cloud” in the sidebar.",
+    "installAction": "Upgrade now",
+    "ready": "The upgrade is installed. Relaunch to open Houston Cloud.",
+    "error": "The upgrade couldn't be installed. Check your connection and try again.",
+    "closeLabel": "Not now"
   },
   "store": {
     "searchPlaceholder": "Search the library...",

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -127,7 +127,8 @@
       "userContext": "Lo que cada agente sabe sobre ti",
       "shortcuts": "Usa Houston sin el mouse",
       "reportBug": "¿Algo falló? Cuéntanos",
-      "migration": "Retoma tu mudanza a la nube"
+      "migration": "Retoma tu mudanza a la nube",
+      "migrateToCloud": "Actualiza esta app a Houston Cloud"
     },
     "values": {
       "set": "Definido"
@@ -175,5 +176,8 @@
       "confirm": "Revocar",
       "cancel": "Cancelar"
     }
+  },
+  "migrateToCloud": {
+    "title": "Migrar a la nube"
   }
 }

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -46,7 +46,8 @@
         "cancel": "Cancelar"
       }
     },
-    "permissions": "Permisos"
+    "permissions": "Permisos",
+    "migrateToCloud": "Migrar a la nube"
   },
   "tabActions": {
     "newMission": "Nueva misión",
@@ -231,6 +232,16 @@
     "descriptionNoVersion": "Se necesita una versión más reciente de Houston para seguir usando Houston Cloud. Estás en v{{currentVersion}}.",
     "downloadAction": "Descargar la actualización",
     "checkAction": "Buscar actualizaciones"
+  },
+  "migrateToCloud": {
+    "cardLabel": "Actualiza a Houston Cloud",
+    "title": "Actualiza a Houston Cloud",
+    "description": "Houston se muda a la nube: tus agentes siguen trabajando aunque tu computadora esté apagada. Houston Cloud está en beta temprana; tus agentes y datos se importan automáticamente, y después de actualizar deberás iniciar sesión y reconectar tus integraciones.",
+    "anytimeNote": "No hace falta decidir ahora: puedes iniciar la actualización cuando quieras desde “Migrar a la nube” en la barra lateral.",
+    "installAction": "Actualizar ahora",
+    "ready": "La actualización está instalada; relanza la app para abrir Houston Cloud.",
+    "error": "No se pudo instalar la actualización. Revisa tu conexión e inténtalo de nuevo.",
+    "closeLabel": "Ahora no"
   },
   "store": {
     "searchPlaceholder": "Buscar en la biblioteca...",

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -127,7 +127,8 @@
       "userContext": "O que todo agente sabe sobre você",
       "shortcuts": "Use o Houston sem o mouse",
       "reportBug": "Algo quebrou? Conte para nós",
-      "migration": "Retome sua mudança para a nuvem"
+      "migration": "Retome sua mudança para a nuvem",
+      "migrateToCloud": "Atualize este app para o Houston Cloud"
     },
     "values": {
       "set": "Definido"
@@ -175,5 +176,8 @@
       "confirm": "Revogar",
       "cancel": "Cancelar"
     }
+  },
+  "migrateToCloud": {
+    "title": "Migrar para a nuvem"
   }
 }

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -46,7 +46,8 @@
     "runningCount_other": "{{count}} assuntos em execução",
     "integrations": "Integrações",
     "agentStore": "Loja de agentes",
-    "permissions": "Permissões"
+    "permissions": "Permissões",
+    "migrateToCloud": "Migrar para a nuvem"
   },
   "tabActions": {
     "newMission": "Nova missão",
@@ -231,6 +232,16 @@
     "descriptionNoVersion": "É necessária uma versão mais recente do Houston para continuar usando o Houston Cloud. Você está na v{{currentVersion}}.",
     "downloadAction": "Baixar a atualização",
     "checkAction": "Buscar atualizações"
+  },
+  "migrateToCloud": {
+    "cardLabel": "Atualize para o Houston Cloud",
+    "title": "Atualize para o Houston Cloud",
+    "description": "O Houston está migrando para a nuvem: seus agentes continuam trabalhando mesmo com o computador desligado. O Houston Cloud está em beta inicial; seus agentes e dados são importados automaticamente e, após a atualização, você fará login e reconectará suas integrações.",
+    "anytimeNote": "Não precisa decidir agora: você pode iniciar a atualização quando quiser em “Migrar para a nuvem” na barra lateral.",
+    "installAction": "Atualizar agora",
+    "ready": "A atualização está instalada; reinicie o app para abrir o Houston Cloud.",
+    "error": "Não foi possível instalar a atualização. Verifique sua conexão e tente novamente.",
+    "closeLabel": "Agora não"
   },
   "store": {
     "searchPlaceholder": "Buscar na biblioteca...",

--- a/app/src/stores/migrate-to-cloud.ts
+++ b/app/src/stores/migrate-to-cloud.ts
@@ -1,0 +1,127 @@
+/**
+ * Legacy→cloud migration offer (the FINAL local-channel feature).
+ *
+ * Local (sidecar) builds stopped receiving feature updates after this
+ * release; this store drives the one thing that ships in it — the offer to
+ * install the CLOUD build in place. The install itself is a cross-channel
+ * updater run done Rust-side (`install_cloud_migration`): the JS updater
+ * API cannot override endpoints, and the cloud manifest lives on a
+ * different feed than this build's baked `latest.json`.
+ *
+ * Policy is remote (`fetch_migration_policy`): "optional" renders a
+ * dismissible offer; "required" removes dismissal. This build is the last
+ * one on its channel, so the flip must work without shipping anything —
+ * hence a release-asset JSON, not a compile-time flag. Every failure path
+ * degrades to "optional".
+ *
+ * The offer shows on EVERY app launch (product decision — this is the
+ * channel's sunset message, not a nag to tune down); dismissal only hides
+ * it for the running session, and the Settings row reopens it on demand.
+ */
+
+import { create } from "zustand";
+import { analytics } from "../lib/analytics";
+import { reportError } from "../lib/error-toast";
+import {
+  onCloudMigrationProgress,
+  osCurrentAppBundlePath,
+  osFetchMigrationPolicy,
+  osInstallCloudMigration,
+  osIsTauri,
+  osRelaunchAppFromPath,
+} from "../lib/os-bridge";
+
+export type MigrateToCloudStatus = "idle" | "downloading" | "ready" | "error";
+
+interface MigrateToCloudState {
+  visible: boolean;
+  policy: "optional" | "required";
+  status: MigrateToCloudStatus;
+  /** 0-100, or null while the total is unknown. */
+  progress: number | null;
+  initialize: () => Promise<void>;
+  open: (source: "launch" | "settings" | "sidebar") => void;
+  dismiss: () => void;
+  install: () => Promise<void>;
+  relaunch: () => Promise<void>;
+}
+
+/** The pre-install bundle path: captured before the updater moves the app,
+ *  module-scoped like the ref in use-update-checker. */
+let appPathBeforeInstall: string | null = null;
+
+export const useMigrateToCloudStore = create<MigrateToCloudState>(
+  (set, get) => ({
+    visible: false,
+    policy: "optional",
+    status: "idle",
+    progress: null,
+
+    /** Called once at mount from the offer component (local builds only).
+     *  Opens unconditionally: the offer greets every launch. */
+    initialize: async () => {
+      if (!osIsTauri()) return;
+      const policy = await osFetchMigrationPolicy().catch(
+        () => "optional" as const,
+      );
+      set({ policy });
+      get().open("launch");
+    },
+
+    open: (source) => {
+      if (get().visible) return;
+      set({ visible: true });
+      analytics.track("migrate_to_cloud_offered", { source });
+    },
+
+    dismiss: () => {
+      if (get().policy === "required") return;
+      set({ visible: false });
+      analytics.track("migrate_to_cloud_dismissed", {});
+    },
+
+    install: async () => {
+      if (get().status === "downloading") return;
+      analytics.track("migrate_to_cloud_accepted", {});
+      set({ status: "downloading", progress: null });
+      let unlisten: (() => void) | null = null;
+      try {
+        appPathBeforeInstall = await osCurrentAppBundlePath();
+        unlisten = await onCloudMigrationProgress(({ downloaded, total }) => {
+          set({
+            progress:
+              total && total > 0
+                ? Math.min(100, Math.round((downloaded / total) * 100))
+                : null,
+          });
+        });
+        await osInstallCloudMigration();
+        set({ status: "ready", progress: 100 });
+        analytics.track("migrate_to_cloud_installed", {});
+      } catch (e) {
+        reportError(
+          "migrate_to_cloud_install",
+          e instanceof Error ? e.message : String(e),
+          e,
+        );
+        set({ status: "error" });
+      } finally {
+        unlisten?.();
+      }
+    },
+
+    relaunch: async () => {
+      try {
+        const path = appPathBeforeInstall ?? (await osCurrentAppBundlePath());
+        await osRelaunchAppFromPath(path);
+      } catch (e) {
+        reportError(
+          "migrate_to_cloud_relaunch",
+          e instanceof Error ? e.message : String(e),
+          e,
+        );
+        set({ status: "error" });
+      }
+    },
+  }),
+);

--- a/packages/web/src/shims/tauri-core.ts
+++ b/packages/web/src/shims/tauri-core.ts
@@ -247,6 +247,11 @@ export async function invoke<T = unknown>(
     case "open_file":
     case "current_app_bundle_path":
     case "relaunch_app_from_path":
+    // The legacy→cloud migration offer is desktop-only (it swaps the
+    // installed app bundle); the offer UI gates on osIsTauri() so neither
+    // command runs on web.
+    case "install_cloud_migration":
+    case "fetch_migration_policy":
     case "sentry_native_stack_smoke_test":
       return notAvailable(cmd);
 


### PR DESCRIPTION
Implements the migration plan for legacy (local-engine) users: this is intended to ship as the **final local-channel release** — its whole feature is the offer to upgrade to Houston Cloud.

## What users see (local/sidecar builds only; cloud builds render nothing)

- **Announcement modal on every launch** (per product decision): hero header, centered copy, single pill CTA — modeled on the reference screenshot. Copy states it's an upgrade, that Houston Cloud is **early beta**, that agents/data **import automatically**, and that integrations must be **reconnected** after signing in.
- **Not pushy**: the X only hides it for the session, and the copy points at the always-available reopen paths — a **sidebar entry "Migrate to cloud"** and a **settings row** — both of which just reopen the same modal.
- Install shows progress → "Relaunch" boots the cloud build → the existing HOU-719 first-run wizard handles data import + integration reconnect. Nothing new to design post-install.

## How the cross-channel install works

- New Rust command `install_cloud_migration`: `UpdaterBuilder` pointed at the **cloud** manifest (`cloud-latest/latest-cloud.json`) with `version_comparator` forced true (channels are versioned independently). JS `check()` can't override endpoints, hence Rust. Signature verification is inherited — both channels sign with the same key. Progress rides a `cloud-migration-progress` event (same pattern as the dictation model download).
- Relaunch reuses the existing `current_app_bundle_path` / `relaunch_app_from_path` choreography.

## The future "force" lever (built now, because there is no later)

`fetch_migration_policy` (Rust, CORS-free) reads `releases/download/migration-policy/migration-policy.json`. `{"mode":"required"}` removes the X and the offer becomes a hard gate; anything else — including 404/network failure — is **optional** (fail-open). Flipping it later is one `gh release upload --clobber`, no build.

## Also

- `migrate_to_cloud_{offered,accepted,dismissed,installed}` analytics events (adoption funnel measurable in PostHog).
- Web-build shims for both new commands (parity check enforced by pre-commit).
- en/es/pt strings; locale parity check passes; typecheck, biome, and `cargo check` green.

## Release sequencing (after merge — separate step, needs sign-off)

Cut as `v0.4.29` (**below** the cloud line's 0.5.19): local users on 0.4.28 auto-update into it via the normal published-release flow, and the Windows MSI upgrade guard can never block the subsequent legacy→cloud install (cloud version stays higher). Publishing a `v*` release also promotes the web bundle to production (`web-promote`) — flagged so it's a conscious side effect.