### PR TITLE
test(e2e): update catalog specs for the unified catalog redesign (fixes red main)

### DIFF
--- a/packages/web/e2e/ai-hub.spec.ts
+++ b/packages/web/e2e/ai-hub.spec.ts
@@ -31,11 +31,11 @@ test("opens the AI hub, browses providers and models via modals", async ({
   );
 
   // The consolidated Connected strip sits OUTSIDE the tabs: the seeded
-  // Anthropic connection is a brand tile, not a row in the browse grid.
+  // Anthropic connection is a brand tile (name + its subscription subtitle),
+  // not a row in the browse grid.
   await expect(page.getByRole("heading", { name: "Connected" })).toBeVisible();
   const anthropicTile = page.getByRole("button", {
-    name: "Anthropic",
-    exact: true,
+    name: "Anthropic Your Claude subscription",
   });
   await expect(anthropicTile).toBeVisible();
 
@@ -56,17 +56,21 @@ test("opens the AI hub, browses providers and models via modals", async ({
     page.getByRole("button", { name: /^Connect / }).first(),
   ).toBeVisible();
 
-  // Switch to the Models directory: a pill search box + the facet comboboxes
-  // (the "Good at" facet always shows) above the catalog-grammar row grid.
+  // Switch to the Models directory: the ONE page-level search (shared across
+  // both tabs) plus the facet comboboxes (the "Good at" facet always shows)
+  // above the catalog-grammar row grid.
   await page.getByRole("tab", { name: /Models/ }).click();
-  const search = page.getByPlaceholder(/Search( \d+\+)? models/);
+  const search = page.getByPlaceholder("Search AI models and providers");
   await expect(search).toBeVisible();
   await expect(page.getByRole("button", { name: "Good at" })).toBeVisible();
   await search.fill("claude");
 
   // A model row (name + lab, whole row is the button) opens the model MODAL:
-  // its specs + the "Get it through" list of providers that offer it.
+  // its specs + the "Get it through" list of providers that offer it. Scope to
+  // the Models tabpanel so the shared search's now-filtered Connected strip
+  // (Anthropic also matches "claude") can't shadow the model row.
   await page
+    .getByRole("tabpanel")
     .getByRole("button", { name: /Claude/i })
     .first()
     .click();
@@ -77,5 +81,7 @@ test("opens the AI hub, browses providers and models via modals", async ({
   // Escape returns to the directory (the search box is back).
   await page.keyboard.press("Escape");
   await expect(page.getByRole("dialog")).toBeHidden();
-  await expect(page.getByPlaceholder(/Search( \d+\+)? models/)).toBeVisible();
+  await expect(
+    page.getByPlaceholder("Search AI models and providers"),
+  ).toBeVisible();
 });

--- a/packages/web/e2e/custom-integrations.spec.ts
+++ b/packages/web/e2e/custom-integrations.spec.ts
@@ -108,9 +108,10 @@ test("ready mode lists a pending custom integration and the enter-key flow activ
   await openIntegrationsPage(page);
 
   // The consolidated Installed strip (OUTSIDE the tabs) carries the custom
-  // integration as a tile alongside the catalog connections.
+  // integration as a tile (name + its API/MCP badge) alongside the catalog
+  // connections.
   await expect(
-    page.getByRole("button", { name: "Acme CRM", exact: true }),
+    page.getByRole("button", { name: "Acme CRM API" }),
   ).toBeVisible();
 
   // Its row (status + actions) lives in the Custom integrations tab.

--- a/packages/web/e2e/integrations-browse.spec.ts
+++ b/packages/web/e2e/integrations-browse.spec.ts
@@ -36,9 +36,10 @@ test("the browse page groups the catalog into category sections with an installe
   await armCapabilities(request, { integrations: ["composio"] });
   await openIntegrationsPage(page);
 
-  // The Installed strip carries the one active connection as a tile.
+  // The Installed strip carries the one active connection as a tile (a catalog
+  // row: name + one-line description).
   await expect(page.getByRole("heading", { name: "Installed" })).toBeVisible();
-  const gmailTile = page.getByRole("button", { name: "Gmail", exact: true });
+  const gmailTile = page.getByRole("button").filter({ hasText: "Gmail" });
   await expect(gmailTile).toBeVisible();
 
   // The catalog is grouped into flat category sections — every seeded category
@@ -55,9 +56,11 @@ test("the browse page groups the catalog into category sections with an installe
   ).toBeVisible();
   await expect(page.getByRole("heading", { name: "Sales" })).toBeVisible();
 
-  // A connectable app renders as a flat row (name + one-line description).
+  // A connectable app renders as a flat row (name + one-line description). Slack
+  // is an everyday app, so at rest it appears in BOTH the curated Featured
+  // spotlight and its Communication section — take the first.
   await expect(
-    page.getByRole("button", { name: /Slack Team messaging/ }),
+    page.getByRole("button", { name: /Slack Team messaging/ }).first(),
   ).toBeVisible();
 
   // Gmail is connected, so it appears ONCE — the installed tile — and never as
@@ -77,7 +80,7 @@ test("searching filters the category sections live", async ({
     page.getByRole("heading", { name: "Productivity" }),
   ).toBeVisible();
 
-  const search = page.getByRole("textbox", { name: "Search integrations..." });
+  const search = page.getByRole("textbox", { name: "Search integrations" });
   await search.fill("slack");
 
   // Only the section holding Slack (Communication) survives; the Slack row
@@ -106,8 +109,9 @@ test("clicking a row's + starts the connect flow", async ({
   await armCapabilities(request, { integrations: ["composio"] });
   await openIntegrationsPage(page);
 
-  // The filled + at the row's right edge is the install affordance.
-  const slackAdd = page.getByRole("button", { name: "Connect Slack" });
+  // The filled + at the row's right edge is the install affordance. Slack is
+  // featured AND in its category section, so take the first + it renders.
+  const slackAdd = page.getByRole("button", { name: "Connect Slack" }).first();
   await expect(slackAdd).toBeVisible();
   await slackAdd.click();
 
@@ -141,7 +145,12 @@ test("clicking a row's body opens the more-info modal, and its CTA connects", as
   await openIntegrationsPage(page);
 
   // The row body (name + description) opens the detail modal, not a connect.
-  await page.getByRole("button", { name: /Slack Team messaging/ }).click();
+  // Slack is featured AND in its category section — either row body opens the
+  // same modal, so take the first.
+  await page
+    .getByRole("button", { name: /Slack Team messaging/ })
+    .first()
+    .click();
   const dialog = page.getByRole("dialog");
   await expect(dialog.getByText("Slack", { exact: true })).toBeVisible();
   await expect(dialog.getByText("Team messaging")).toBeVisible();
@@ -163,7 +172,7 @@ test("an installed tile opens the app detail modal", async ({
   await armCapabilities(request, { integrations: ["composio"] });
   await openIntegrationsPage(page);
 
-  await page.getByRole("button", { name: "Gmail", exact: true }).click();
+  await page.getByRole("button").filter({ hasText: "Gmail" }).click();
 
   // The detail modal is the view + reconnect + disconnect surface.
   await expect(page.getByRole("heading", { name: "Gmail" })).toBeVisible();

--- a/packages/web/e2e/integrations-ia.spec.ts
+++ b/packages/web/e2e/integrations-ia.spec.ts
@@ -120,7 +120,7 @@ test("Agent Integrations tab: connected apps tile the Installed strip with no pe
 
   // The connect catalog still renders (search box + a connectable, not-connected
   // app row)...
-  await expect(page.getByPlaceholder("Search integrations...")).toBeVisible();
+  await expect(page.getByPlaceholder("Search integrations")).toBeVisible();
   await expect(
     page.getByRole("button").filter({ hasText: "Slack" }).first(),
   ).toBeVisible();

--- a/packages/web/e2e/integrations-locked.spec.ts
+++ b/packages/web/e2e/integrations-locked.spec.ts
@@ -115,7 +115,7 @@ test("searching for a blocked app shows its locked row, not the empty state", as
   // A query that matches ONLY a blocked app must surface its locked row rather
   // than the "no matching apps" empty state (the search filters before the
   // connectable/locked partition).
-  await page.getByPlaceholder("Search integrations...").fill("slack");
+  await page.getByPlaceholder("Search integrations").fill("slack");
 
   await expect(page.getByText("Ask your admin to enable Slack")).toBeVisible();
   await expect(page.getByText("No matching apps found.")).toHaveCount(0);


### PR DESCRIPTION
## What

Main's Web job has been red since #1002 merged with its CI run cancelled: 9 Playwright specs still asserted the pre-redesign DOM. Verified against live DOM snapshots that every failure is a **stale spec, not a behavior regression** — the redesign's invariants (no per-agent switches, locked rows, composio-absent Custom section) all still hold. Spec-only change; zero product code.

Details: enriched installed-tile accessible names (name+description), the unified single search field replacing the Models tab search, `"Search integrations..."` → `"Search integrations"` placeholder, and Featured-spotlight duplication needing `.first()`.

## Verification

- Targeted specs then full suite locally: **135 passed, 1 pre-existing skip, 0 failed** (ports pinned — note: local e2e reuses any dev server on the default port, which can silently run against a *different worktree's* code; pin `HOUSTON_E2E_WEB_PORT`/`HOUSTON_E2E_FAKE_HOST_PORT` when re-running)
- `typecheck:e2e` + Biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)