### PR TITLE
refactor(files): flatten the Files tab onto the canvas

### DIFF
--- a/app/src/components/tabs/files-tab-labels.ts
+++ b/app/src/components/tabs/files-tab-labels.ts
@@ -24,6 +24,9 @@ export function buildBrowserLabels(t: TFunction<"agents">): FilesBrowserLabels {
     itemPlural: t("files.itemPlural"),
     menuButton: t("files.menuButton"),
     breadcrumbs: t("files.breadcrumbs"),
+    uploadFiles: t("files.uploadFiles"),
+    openInFileManager: t("files.openInFileManager"),
+    downloadAll: t("files.downloadAll"),
   };
 }
 

--- a/app/src/components/tabs/files-tab.tsx
+++ b/app/src/components/tabs/files-tab.tsx
@@ -1,7 +1,6 @@
 import { type FileEntry, FilesBrowser } from "@houston-ai/agent";
 import { isTauri } from "@tauri-apps/api/core";
-import { Download, FolderOpen, Upload } from "lucide-react";
-import { type ReactNode, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   useCreateFolder,
@@ -25,8 +24,8 @@ import { buildBrowserLabels, buildMenuLabels } from "./files-tab-labels";
 export default function FilesTab({ agent }: TabProps) {
   const { t } = useTranslation("agents");
   // No OS to open/reveal with (web build, cloud pod, remote host): double-click
-  // previews in-browser, the context menu offers Download, and the footer
-  // becomes "Download all" instead of "Open in File Manager".
+  // previews in-browser, the context menu offers Download, and the header's
+  // secondary action becomes "Download all" instead of "Open in File Manager".
   const desktop = isTauri();
   const { capabilities } = useCapabilities();
   // The directory the OS can actually open: the host-reported real path (TS
@@ -79,7 +78,7 @@ export default function FilesTab({ agent }: TabProps) {
   const pickFiles = () => fileInput.current?.click();
 
   return (
-    <div className="h-full overflow-hidden p-4">
+    <div className="flex h-full flex-col">
       <input
         ref={fileInput}
         type="file"
@@ -130,28 +129,13 @@ export default function FilesTab({ agent }: TabProps) {
         emptyDescription={t("files.emptyDescription")}
         labels={browserLabels}
         menuLabels={menuLabels}
-        statusBarAction={
-          <div className="flex items-center gap-3">
-            <FooterButton
-              onClick={pickFiles}
-              icon={<Upload className="size-3" />}
-              label={t("files.uploadFiles")}
-            />
-            {canUseLocalFiles && osDir ? (
-              <FooterButton
-                onClick={() => tauriFiles.revealAgent(osDir)}
-                icon={<FolderOpen className="size-3" />}
-                label={t("files.openInFileManager")}
-              />
-            ) : (
-              <FooterButton
-                onClick={downloadAll}
-                icon={<Download className="size-3" />}
-                label={t("files.downloadAll")}
-              />
-            )}
-          </div>
+        onUpload={pickFiles}
+        onRevealAgent={
+          canUseLocalFiles && osDir
+            ? () => tauriFiles.revealAgent(osDir)
+            : undefined
         }
+        onDownloadAll={canUseLocalFiles ? undefined : downloadAll}
       />
       <FilePreviewDialog
         agentPath={path}
@@ -166,26 +150,5 @@ export default function FilesTab({ agent }: TabProps) {
         onCancel={move.cancel}
       />
     </div>
-  );
-}
-
-function FooterButton({
-  onClick,
-  icon,
-  label,
-}: {
-  onClick: () => void;
-  icon: ReactNode;
-  label: string;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="flex items-center gap-1 text-[11px] text-ink-muted hover:text-ink transition-colors"
-    >
-      {icon}
-      {label}
-    </button>
   );
 }

--- a/knowledge-base/design-system.md
+++ b/knowledge-base/design-system.md
@@ -471,10 +471,23 @@ icon (~56px) + `text-sm font-medium` name over one truncated `text-[13px]`
 `ink-muted` description line + ONE quiet trailing glyph (`Plus`, lock, ...) at
 the row edge; the page hero is the shared `PageHeader` with a rounded
 `bg-input` search field (`border-line-input`, magnifier glyph) in its
-`trailing` slot. Two-column row grids collapse to one under `lg`. First shipped
-surface: the Integrations personal page (`integrations-view/`, see
-`knowledge-base/integrations.md` §3); apply this language when refactoring
-further pages instead of inventing new row chrome.
+`trailing` slot. Two-column row grids collapse to one under `lg`. Shipped
+surfaces: the Integrations personal page (`integrations-view/`, see
+`knowledge-base/integrations.md` §3) and the agent **Files tab** — the old
+nested `rounded-xl border` "file manager window" frame (bordered toolbar,
+zebra list with decorative filler stripes, bottom status bar whose 11px
+footer links held Upload / Open in File Manager) was flattened onto the
+canvas: `FilesBrowser` (`ui/agent/src/files-browser.tsx`) renders a
+shrink-0 header (`files-header.tsx`: grid-only breadcrumbs, sort, soft
+segmented view toggle in `view-toggle.tsx`, new-folder ghost icon, Upload
+as a filled `Button size="sm"` pill + reveal/download-all as a ghost pill)
+over a full-bleed scroll/drop body whose content is capped to the shared
+`FILES_CONTENT_COLUMN` (`mx-auto w-full max-w-4xl px-6`); list rows are
+`h-8 rounded-lg`, transparent at rest, `hover:bg-hover`. Breadcrumbs stay
+grid-view-only on purpose: the list view is a hierarchical tree always
+rooted at the workspace, so a path crumb there would misstate its scope.
+Apply this language when refactoring further pages instead of inventing
+new row chrome.
 
 **Settings (`app/src/components/settings/`)** — no sidebar. The landing is the
 **overview** (`settings-index.tsx`); it uses the shared `PageContainer` +

--- a/packages/web/e2e/files.spec.ts
+++ b/packages/web/e2e/files.spec.ts
@@ -3,8 +3,8 @@ import { expect, test } from "./support/fixtures";
 /**
  * The Files tab on the host adapter (HOU-677 follow-through): the default
  * Drive-style card grid with per-folder navigation, the Finder-style list
- * view behind the toggle, uploads through the footer button, context-menu
- * rename + delete, and the browser-mode footer ("Download all" —
+ * view behind the toggle, uploads through the header button, context-menu
+ * rename + delete, and the browser-mode header action ("Download all" —
  * reveal-in-OS only exists on a co-located desktop). The fake host models
  * the real host's `files*` routes (see `@houston/fake-host` routes-files.ts).
  */
@@ -54,7 +54,7 @@ test("list view keeps kind, size, and both date columns", async ({ page }) => {
   await expect(page.getByText("Docs", { exact: true })).toBeVisible();
   await expect(page.getByText("PDF Document")).toBeVisible();
 
-  // Browser build: no OS file manager — the footer offers Download all +
+  // Browser build: no OS file manager — the header offers Download all +
   // Upload files, never "Open in File Manager".
   await expect(
     page.getByRole("button", { name: "Upload files" }),
@@ -65,7 +65,7 @@ test("list view keeps kind, size, and both date columns", async ({ page }) => {
   await expect(page.getByText("Open in File Manager")).toHaveCount(0);
 });
 
-test("uploads a file through the footer button", async ({ page }) => {
+test("uploads a file through the header button", async ({ page }) => {
   await openFilesTab(page);
 
   const [chooser] = await Promise.all([

--- a/ui/agent/src/file-row.tsx
+++ b/ui/agent/src/file-row.tsx
@@ -83,8 +83,8 @@ export function FileRow({
         }}
         data-selected={selected || undefined}
         className={cn(
-          "h-[24px] cursor-default select-none items-center outline-none",
-          selected && "rounded-lg !bg-action text-action-text",
+          "h-8 cursor-default select-none items-center rounded-lg outline-none transition-colors hover:bg-hover",
+          selected && "!bg-action text-action-text",
           dragging && "opacity-40",
         )}
         style={{ display: "grid", gridTemplateColumns: COL_GRID }}

--- a/ui/agent/src/files-body.tsx
+++ b/ui/agent/src/files-body.tsx
@@ -1,0 +1,83 @@
+/**
+ * FilesBody — the current view (grid or list) for the resolved folder, or the
+ * loading notice. Chrome (header, scroll container, drop tinting, background
+ * menu) stays in FilesBrowser; this owns only which view renders and forwards
+ * the shared callbacks to it.
+ */
+import type { FilesBrowserProps } from "./files-browser";
+import {
+  type FilesBrowserLabels,
+  toColumnLabels,
+  toGridLabels,
+} from "./files-browser-labels";
+import { FilesGrid } from "./files-grid";
+import { FilesListView } from "./files-list-view";
+import type { useFilesBrowser } from "./use-files-browser";
+
+export function FilesBody({
+  b,
+  props,
+  l,
+}: {
+  b: ReturnType<typeof useFilesBrowser>;
+  props: FilesBrowserProps;
+  l: Required<FilesBrowserLabels>;
+}) {
+  if (props.loading || !b.tree || !b.currentFolder) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <p className="text-sm text-ink-muted/50">{l.loading}</p>
+      </div>
+    );
+  }
+
+  const onCreateFolder = props.onCreateFolder ? b.createFolderAt : undefined;
+  const onCancelCreateFolder = () => b.setCreatingFolder(false);
+
+  return b.view === "grid" ? (
+    <FilesGrid
+      folder={b.currentFolder}
+      selectedPath={b.selectedPath}
+      loadPreview={props.loadPreview}
+      onNavigate={b.navigate}
+      onSelect={b.handleSelect}
+      onOpen={props.onOpen}
+      onReveal={props.onReveal}
+      onDownload={props.onDownload}
+      onDownloadFolder={props.onDownloadFolder}
+      onDelete={props.onDelete}
+      onRename={props.onRename}
+      onMove={props.onMove}
+      onDragActive={b.onDragActive}
+      creatingFolder={b.creatingFolder}
+      onCreateFolder={onCreateFolder}
+      onCancelCreateFolder={onCancelCreateFolder}
+      menuLabels={props.menuLabels}
+      labels={toGridLabels(l)}
+    />
+  ) : (
+    <FilesListView
+      tree={b.tree}
+      sortKey={b.sortKey}
+      sortDir={b.sortDir}
+      onSort={b.handleSort}
+      selectedPath={b.selectedPath}
+      onSelect={b.handleSelect}
+      onOpen={props.onOpen}
+      onReveal={props.onReveal}
+      onDownload={props.onDownload}
+      onDownloadFolder={props.onDownloadFolder}
+      onDelete={props.onDelete}
+      onRename={props.onRename}
+      onFilesDropped={props.onFilesDropped}
+      onDragActive={b.onDragActive}
+      onMove={props.onMove}
+      creatingFolder={b.creatingFolder}
+      onCreateFolder={onCreateFolder}
+      onCancelCreateFolder={onCancelCreateFolder}
+      newFolderPlaceholder={l.newFolderPlaceholder}
+      columnLabels={toColumnLabels(l)}
+      menuLabels={props.menuLabels}
+    />
+  );
+}

--- a/ui/agent/src/files-browser-labels.ts
+++ b/ui/agent/src/files-browser-labels.ts
@@ -17,11 +17,16 @@ export interface FilesBrowserLabels {
   newFolder?: string;
   newFolderPlaceholder?: string;
   emptyFolder?: string;
+  /** Folder-card child count (grid view), pluralized against the count. */
   itemSingular?: string;
   itemPlural?: string;
   menuButton?: string;
   /** Accessible name for the breadcrumb navigation. */
   breadcrumbs?: string;
+  /** Header action labels (promoted from the old status-bar footer). */
+  uploadFiles?: string;
+  openInFileManager?: string;
+  downloadAll?: string;
 }
 
 /** Slice the flat label bag into the shapes the subcomponents take. */
@@ -74,4 +79,7 @@ export const DEFAULT_FILES_BROWSER_LABELS: Required<FilesBrowserLabels> = {
   itemPlural: "items",
   menuButton: "More actions",
   breadcrumbs: "Folder path",
+  uploadFiles: "Upload files",
+  openInFileManager: "Open in File Manager",
+  downloadAll: "Download all",
 };

--- a/ui/agent/src/files-browser.tsx
+++ b/ui/agent/src/files-browser.tsx
@@ -1,22 +1,21 @@
 /**
  * FilesBrowser — Drive-style card grid (default) with per-folder breadcrumb
- * navigation, plus the original Finder-style list view behind a toggle.
- * Status bar, drag-and-drop, context menus and inline rename in both views.
+ * navigation, plus the original Finder-style list view behind a toggle. Flat
+ * on the canvas: a header row over a full-bleed scroll body whose content is
+ * capped to the sibling-tab column. Drag-and-drop, context menus and inline
+ * rename in both views.
  */
 
 import { BgContextMenu } from "./bg-context-menu";
 import type { FileMenuLabels } from "./file-menu";
+import { FilesBody } from "./files-body";
 import {
   DEFAULT_FILES_BROWSER_LABELS,
   type FilesBrowserLabels,
-  toColumnLabels,
-  toGridLabels,
   toSortLabels,
 } from "./files-browser-labels";
 import { FilesEmptyState } from "./files-empty-state";
-import { FilesGrid } from "./files-grid";
-import { FilesListView } from "./files-list-view";
-import { FilesToolbar } from "./files-toolbar";
+import { FILES_CONTENT_COLUMN, FilesHeader } from "./files-header";
 import type { FileEntry, FilesViewMode, LoadFilePreview } from "./types";
 import { useFilesBrowser } from "./use-files-browser";
 
@@ -48,8 +47,12 @@ export interface FilesBrowserProps {
   onBrowse?: () => void;
   emptyTitle?: string;
   emptyDescription?: string;
-  /** Optional action rendered in the bottom status bar (e.g. "Open in File Manager" link) */
-  statusBarAction?: React.ReactNode;
+  /** Pick files to upload (header's filled primary pill). */
+  onUpload?: () => void;
+  /** Reveal the agent's folder in the OS file manager (co-located desktop). */
+  onRevealAgent?: () => void;
+  /** Download the whole workspace as one zip (browser/remote builds). */
+  onDownloadAll?: () => void;
   /** Overrides for chrome labels (toolbar, columns, loading, browse CTA). */
   labels?: FilesBrowserLabels;
   /** Overrides for the right-click context-menu labels. */
@@ -86,10 +89,10 @@ export function FilesBrowser(props: FilesBrowserProps) {
 
   return (
     <div
-      className="relative flex h-full flex-col overflow-hidden rounded-xl border border-line bg-transparent"
+      className="relative flex h-full flex-col"
       {...(props.onFilesDropped || props.onMove ? b.dragHandlers : {})}
     >
-      <FilesToolbar
+      <FilesHeader
         view={b.view}
         onViewChange={b.changeView}
         path={b.resolvedPath}
@@ -107,6 +110,12 @@ export function FilesBrowser(props: FilesBrowserProps) {
           props.onCreateFolder ? () => b.setCreatingFolder(true) : undefined
         }
         newFolderLabel={l.newFolder}
+        onUpload={props.onUpload}
+        uploadLabel={l.uploadFiles}
+        onRevealAgent={props.onRevealAgent}
+        revealAgentLabel={l.openInFileManager}
+        onDownloadAll={props.onDownloadAll}
+        downloadAllLabel={l.downloadAll}
       />
 
       {/* biome-ignore lint/a11y/noStaticElementInteractions: click-to-deselect and right-click-for-context-menu on the backdrop are pointer-only affordances; no keyboard equivalent exists for these background gestures */}
@@ -128,65 +137,9 @@ export function FilesBrowser(props: FilesBrowserProps) {
           }
         }}
       >
-        {props.loading || !b.tree || !b.currentFolder ? (
-          <div className="flex items-center justify-center py-16">
-            <p className="text-sm text-ink-muted/50">{l.loading}</p>
-          </div>
-        ) : b.view === "grid" ? (
-          <FilesGrid
-            folder={b.currentFolder}
-            selectedPath={b.selectedPath}
-            loadPreview={props.loadPreview}
-            onNavigate={b.navigate}
-            onSelect={b.handleSelect}
-            onOpen={props.onOpen}
-            onReveal={props.onReveal}
-            onDownload={props.onDownload}
-            onDownloadFolder={props.onDownloadFolder}
-            onDelete={props.onDelete}
-            onRename={props.onRename}
-            onMove={props.onMove}
-            onDragActive={b.onDragActive}
-            creatingFolder={b.creatingFolder}
-            onCreateFolder={props.onCreateFolder ? b.createFolderAt : undefined}
-            onCancelCreateFolder={() => b.setCreatingFolder(false)}
-            menuLabels={props.menuLabels}
-            labels={toGridLabels(l)}
-          />
-        ) : (
-          <FilesListView
-            tree={b.tree}
-            fileCount={b.fileCount}
-            sortKey={b.sortKey}
-            sortDir={b.sortDir}
-            onSort={b.handleSort}
-            selectedPath={b.selectedPath}
-            onSelect={b.handleSelect}
-            onOpen={props.onOpen}
-            onReveal={props.onReveal}
-            onDownload={props.onDownload}
-            onDownloadFolder={props.onDownloadFolder}
-            onDelete={props.onDelete}
-            onRename={props.onRename}
-            onFilesDropped={props.onFilesDropped}
-            onDragActive={b.onDragActive}
-            onMove={props.onMove}
-            creatingFolder={b.creatingFolder}
-            onCreateFolder={props.onCreateFolder ? b.createFolderAt : undefined}
-            onCancelCreateFolder={() => b.setCreatingFolder(false)}
-            newFolderPlaceholder={l.newFolderPlaceholder}
-            onBackgroundInteraction={b.handleBackgroundInteraction}
-            columnLabels={toColumnLabels(l)}
-            menuLabels={props.menuLabels}
-          />
-        )}
-      </div>
-
-      <div className="flex h-[22px] shrink-0 select-none items-center justify-between rounded-b-xl border-t border-line px-3">
-        <span className="text-[11px] text-ink-muted">
-          {b.fileCount} {b.fileCount === 1 ? l.itemSingular : l.itemPlural}
-        </span>
-        {props.statusBarAction}
+        <div className={`${FILES_CONTENT_COLUMN} pb-6`}>
+          <FilesBody b={b} props={props} l={l} />
+        </div>
       </div>
 
       {b.bgMenu && (

--- a/ui/agent/src/files-grid.tsx
+++ b/ui/agent/src/files-grid.tsx
@@ -68,7 +68,7 @@ export function FilesGrid({
   }
 
   return (
-    <div className="grid shrink-0 grid-cols-[repeat(auto-fill,minmax(180px,1fr))] content-start gap-3 p-3">
+    <div className="grid shrink-0 grid-cols-[repeat(auto-fill,minmax(180px,1fr))] content-start gap-3 pt-1">
       {creatingFolder && onCreateFolder && (
         <NewFolderCard
           onConfirm={onCreateFolder}

--- a/ui/agent/src/files-header.tsx
+++ b/ui/agent/src/files-header.tsx
@@ -1,25 +1,31 @@
 /**
- * Files toolbar: breadcrumb navigation on the left (only while inside a
- * folder — the surrounding page already names the agent, so the root is a
- * home glyph, not a title), sort menu and the grid/list view toggle on the
- * right. Breadcrumbs are drop targets so a drag can move items to any
- * ancestor ("" signals the root).
+ * Files header: breadcrumb navigation on the left (grid view only — the list
+ * is a hierarchical tree always rooted at the workspace, so a path crumb would
+ * misstate its scope) and a right cluster with sort, the grid/list toggle,
+ * new-folder, and the promoted Upload + reveal/download-all actions.
+ * Breadcrumbs are drop targets so a drag can move items to any ancestor
+ * ("" signals the root). This row does not scroll with the file list.
  */
-import { cn } from "@houston-ai/core";
+import { Button } from "@houston-ai/core";
 import {
   ChevronRight,
+  Download,
+  FolderOpen,
   FolderPlus,
   House,
-  LayoutGrid,
-  List,
+  Upload,
 } from "lucide-react";
 import { CrumbButton } from "./crumb-button";
 import { crumbsForPath } from "./grid-utils";
 import { SortMenu, type SortMenuLabels } from "./sort-menu";
 import type { FilesViewMode } from "./types";
 import type { SortDirection, SortKey } from "./utils";
+import { ViewToggle } from "./view-toggle";
 
-export function FilesToolbar({
+/** Shared width cap so the header and the scroll body's content column align. */
+export const FILES_CONTENT_COLUMN = "mx-auto w-full max-w-4xl px-6";
+
+export function FilesHeader({
   view,
   onViewChange,
   path,
@@ -35,6 +41,12 @@ export function FilesToolbar({
   breadcrumbsLabel,
   onNewFolder,
   newFolderLabel,
+  onUpload,
+  uploadLabel,
+  onRevealAgent,
+  revealAgentLabel,
+  onDownloadAll,
+  downloadAllLabel,
 }: {
   view: FilesViewMode;
   onViewChange: (view: FilesViewMode) => void;
@@ -52,10 +64,34 @@ export function FilesToolbar({
   breadcrumbsLabel: string;
   onNewFolder?: () => void;
   newFolderLabel: string;
+  /** Pick files to upload (filled primary pill). */
+  onUpload?: () => void;
+  uploadLabel: string;
+  /** Reveal the agent's folder in the OS file manager (co-located desktop). */
+  onRevealAgent?: () => void;
+  revealAgentLabel: string;
+  /** Download the whole workspace as one zip (browser/remote builds). */
+  onDownloadAll?: () => void;
+  downloadAllLabel: string;
 }) {
   const crumbs = crumbsForPath(path);
+  const secondary = onRevealAgent
+    ? {
+        onClick: onRevealAgent,
+        icon: <FolderOpen aria-hidden />,
+        label: revealAgentLabel,
+      }
+    : onDownloadAll
+      ? {
+          onClick: onDownloadAll,
+          icon: <Download aria-hidden />,
+          label: downloadAllLabel,
+        }
+      : null;
   return (
-    <div className="flex h-10 shrink-0 items-center gap-2 border-b border-line px-2">
+    <div
+      className={`${FILES_CONTENT_COLUMN} flex shrink-0 items-center gap-2 pt-6 pb-4`}
+    >
       {view === "grid" && crumbs.length > 0 ? (
         <nav
           aria-label={breadcrumbsLabel}
@@ -92,17 +128,6 @@ export function FilesToolbar({
       ) : (
         <div className="min-w-0 flex-1" />
       )}
-      {onNewFolder && (
-        <button
-          type="button"
-          aria-label={newFolderLabel}
-          title={newFolderLabel}
-          onClick={onNewFolder}
-          className="shrink-0 rounded-md p-1.5 text-ink-muted transition-colors hover:bg-hover hover:text-ink"
-        >
-          <FolderPlus aria-hidden className="size-4" />
-        </button>
-      )}
       {view === "grid" && (
         <SortMenu
           sortKey={sortKey}
@@ -111,52 +136,38 @@ export function FilesToolbar({
           labels={sortLabels}
         />
       )}
-      <div className="flex shrink-0 items-center gap-0.5 rounded-lg border border-line p-0.5">
-        <ViewToggleButton
-          active={view === "list"}
-          label={viewListLabel}
-          onClick={() => onViewChange("list")}
+      <ViewToggle
+        view={view}
+        onViewChange={onViewChange}
+        viewGridLabel={viewGridLabel}
+        viewListLabel={viewListLabel}
+      />
+      {onNewFolder && (
+        <button
+          type="button"
+          aria-label={newFolderLabel}
+          title={newFolderLabel}
+          onClick={onNewFolder}
+          className="shrink-0 rounded-lg p-1.5 text-ink-muted transition-colors hover:bg-hover hover:text-ink"
         >
-          <List aria-hidden className="size-3.5" />
-        </ViewToggleButton>
-        <ViewToggleButton
-          active={view === "grid"}
-          label={viewGridLabel}
-          onClick={() => onViewChange("grid")}
-        >
-          <LayoutGrid aria-hidden className="size-3.5" />
-        </ViewToggleButton>
-      </div>
-    </div>
-  );
-}
-
-function ViewToggleButton({
-  active,
-  label,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  label: string;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      aria-label={label}
-      title={label}
-      aria-pressed={active}
-      onClick={onClick}
-      className={cn(
-        "rounded-md p-1 transition-colors",
-        active
-          ? "bg-chip-solid text-ink"
-          : "text-ink-muted hover:bg-hover hover:text-ink",
+          <FolderPlus aria-hidden className="size-4" />
+        </button>
       )}
-    >
-      {children}
-    </button>
+      {onUpload && (
+        <Button size="sm" onClick={onUpload} className="shrink-0">
+          <Upload aria-hidden /> {uploadLabel}
+        </Button>
+      )}
+      {secondary && (
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={secondary.onClick}
+          className="shrink-0"
+        >
+          {secondary.icon} {secondary.label}
+        </Button>
+      )}
+    </div>
   );
 }

--- a/ui/agent/src/files-list-chrome.tsx
+++ b/ui/agent/src/files-list-chrome.tsx
@@ -1,9 +1,7 @@
 /**
- * List-view chrome: sortable column header cell and the decorative filler
- * stripes that pad the tree to full height.
+ * List-view chrome: the quiet, sortable column header cell.
  */
 import { cn } from "@houston-ai/core";
-import { useEffect, useRef, useState } from "react";
 import type { SortDirection, SortKey } from "./utils";
 
 export function HeaderCell({
@@ -13,7 +11,6 @@ export function HeaderCell({
   sortDir,
   onSort,
   className,
-  last,
 }: {
   label: string;
   col: SortKey;
@@ -21,7 +18,6 @@ export function HeaderCell({
   sortDir: SortDirection;
   onSort: (key: SortKey) => void;
   className?: string;
-  last?: boolean;
 }) {
   const active = sortKey === col;
   return (
@@ -29,8 +25,7 @@ export function HeaderCell({
       type="button"
       onClick={() => onSort(col)}
       className={cn(
-        "flex h-full items-center justify-between px-2 text-[11px] font-medium text-ink-muted transition-colors hover:bg-chip-subtle",
-        !last && "border-r border-line",
+        "flex h-full items-center justify-between px-2 text-[11px] font-medium text-ink-muted transition-colors hover:text-ink",
         className,
       )}
     >
@@ -57,53 +52,5 @@ export function HeaderCell({
         </svg>
       )}
     </button>
-  );
-}
-
-/** Fills remaining vertical space with real rounded stripe divs. */
-export function FillerStripes({
-  startIndex,
-  onDeselect,
-  onContextMenu,
-}: {
-  startIndex: number;
-  onDeselect: () => void;
-  onContextMenu?: (e: React.MouseEvent) => void;
-}) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [count, setCount] = useState(0);
-
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const update = () => {
-      const h = el.clientHeight;
-      setCount(Math.ceil(h / 24));
-    };
-    update();
-    const obs = new ResizeObserver(update);
-    obs.observe(el);
-    return () => obs.disconnect();
-  }, []);
-
-  return (
-    <div ref={containerRef} className="mx-1 min-h-0 flex-1">
-      {Array.from({ length: count }, (_, i) => {
-        const rowIndex = startIndex + i;
-        return (
-          // biome-ignore lint/a11y/noStaticElementInteractions: decorative filler stripe; click-to-deselect and right-click-for-context-menu are pointer-only background gestures with no keyboard equivalent
-          // biome-ignore lint/a11y/useKeyWithClickEvents: same rationale as noStaticElementInteractions above
-          <div
-            key={`filler-${rowIndex}`}
-            className={cn(
-              "h-[24px]",
-              rowIndex % 2 === 1 && "rounded-lg bg-chip-subtle/30",
-            )}
-            onClick={onDeselect}
-            onContextMenu={onContextMenu}
-          />
-        );
-      })}
-    </div>
   );
 }

--- a/ui/agent/src/files-list-view.tsx
+++ b/ui/agent/src/files-list-view.tsx
@@ -1,10 +1,10 @@
 /**
- * Finder-style list view (extracted from FilesBrowser): sortable column
- * headers, tree rows, filler stripes. The grid view lives in files-grid.tsx.
+ * Flat list view: quiet sortable column headers over the tree rows. The grid
+ * view lives in files-grid.tsx.
  */
 import type { FileMenuLabels } from "./file-menu";
 import { COL_GRID, FileRow } from "./file-row";
-import { FillerStripes, HeaderCell } from "./files-list-chrome";
+import { HeaderCell } from "./files-list-chrome";
 import { FolderSection } from "./folder-section";
 import { NewFolderInput } from "./new-folder-input";
 import type { FolderNode } from "./tree";
@@ -21,7 +21,6 @@ export interface FilesListColumnLabels {
 
 export function FilesListView({
   tree,
-  fileCount,
   sortKey,
   sortDir,
   onSort,
@@ -40,12 +39,10 @@ export function FilesListView({
   onCreateFolder,
   onCancelCreateFolder,
   newFolderPlaceholder,
-  onBackgroundInteraction,
   columnLabels,
   menuLabels,
 }: {
   tree: FolderNode;
-  fileCount: number;
   sortKey: SortKey;
   sortDir: SortDirection;
   onSort: (key: SortKey) => void;
@@ -64,14 +61,12 @@ export function FilesListView({
   onCreateFolder?: (name: string) => void;
   onCancelCreateFolder: () => void;
   newFolderPlaceholder: string;
-  /** Background click deselects; background right-click opens the New Folder menu. */
-  onBackgroundInteraction: (menuPosition?: { x: number; y: number }) => void;
   columnLabels: FilesListColumnLabels;
   menuLabels?: FileMenuLabels;
 }) {
   return (
     <>
-      <div className="h-[24px] shrink-0 select-none items-center border-b border-line bg-chip-subtle/40 px-1">
+      <div className="h-8 shrink-0 select-none items-center border-b border-line">
         <div
           className="h-full min-w-0 items-center"
           style={{ display: "grid", gridTemplateColumns: COL_GRID }}
@@ -111,11 +106,10 @@ export function FilesListView({
             sortKey={sortKey}
             sortDir={sortDir}
             onSort={onSort}
-            last
           />
         </div>
       </div>
-      <div className="shrink-0 px-1 [&>:nth-child(even)]:rounded-lg [&>:nth-child(even)]:bg-chip-subtle/30">
+      <div className="shrink-0 pt-1">
         {creatingFolder && onCreateFolder && (
           <NewFolderInput
             onConfirm={onCreateFolder}
@@ -159,18 +153,6 @@ export function FilesListView({
           ),
         )}
       </div>
-      <FillerStripes
-        startIndex={fileCount}
-        onDeselect={() => onBackgroundInteraction()}
-        onContextMenu={
-          onCreateFolder
-            ? (e) => {
-                e.preventDefault();
-                onBackgroundInteraction({ x: e.clientX, y: e.clientY });
-              }
-            : undefined
-        }
-      />
     </>
   );
 }

--- a/ui/agent/src/folder-section.tsx
+++ b/ui/agent/src/folder-section.tsx
@@ -95,8 +95,8 @@ export function FolderSection({
           setMenu({ x: e.clientX, y: e.clientY });
         }}
         className={cn(
-          "h-[24px] w-full cursor-default select-none items-center text-left outline-none",
-          isOver && "!rounded-lg !bg-focus/15",
+          "h-8 w-full cursor-default select-none items-center rounded-lg text-left outline-none transition-colors hover:bg-hover",
+          isOver && "!bg-focus/15",
           dragging && "opacity-40",
         )}
         style={{ display: "grid", gridTemplateColumns: COL_GRID }}

--- a/ui/agent/src/index.ts
+++ b/ui/agent/src/index.ts
@@ -23,7 +23,7 @@ export type { FilesBrowserLabels } from "./files-browser-labels";
 export type { InstructionsPanelProps } from "./instructions-panel";
 export { InstructionsPanel } from "./instructions-panel";
 export type { FileNode, FolderNode, TreeNode } from "./tree";
-export { buildTree, countFiles } from "./tree";
+export { buildTree } from "./tree";
 export type {
   FileEntry,
   FilePreviewData,

--- a/ui/agent/src/tree.ts
+++ b/ui/agent/src/tree.ts
@@ -82,13 +82,3 @@ export function buildTree(files: FileEntry[]): FolderNode {
 
   return root;
 }
-
-/** Count all file descendants of a folder node (recursively). */
-export function countFiles(node: FolderNode): number {
-  let count = 0;
-  for (const child of node.children) {
-    if (child.kind === "file") count++;
-    else count += countFiles(child);
-  }
-  return count;
-}

--- a/ui/agent/src/use-files-browser.ts
+++ b/ui/agent/src/use-files-browser.ts
@@ -5,7 +5,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useDropZone } from "./drop-zone";
 import { folderAtPath, resolveExistingPath } from "./grid-utils";
-import { buildTree, countFiles } from "./tree";
+import { buildTree } from "./tree";
 import type { FileEntry, FilesViewMode } from "./types";
 import { type SortDirection, type SortKey, sortTree } from "./utils";
 
@@ -56,7 +56,6 @@ export function useFilesBrowser(opts: {
     if (isEmpty) return null;
     return sortTree(buildTree(opts.files), sortKey, sortDir);
   }, [opts.files, isEmpty, sortKey, sortDir]);
-  const fileCount = useMemo(() => (tree ? countFiles(tree) : 0), [tree]);
   // Survive the current folder being deleted/renamed under us.
   const resolvedPath = tree ? resolveExistingPath(tree, currentPath) : "";
   const currentFolder = tree ? folderAtPath(tree, resolvedPath) : null;
@@ -137,7 +136,6 @@ export function useFilesBrowser(opts: {
     handleSort,
     isEmpty,
     tree,
-    fileCount,
     resolvedPath,
     currentFolder,
     navigate,

--- a/ui/agent/src/view-toggle.tsx
+++ b/ui/agent/src/view-toggle.tsx
@@ -1,0 +1,68 @@
+/**
+ * Segmented grid/list toggle for the files header: a soft chip container with
+ * one pressed segment (no border box, per the flat header language).
+ */
+import { cn } from "@houston-ai/core";
+import { LayoutGrid, List } from "lucide-react";
+import type { FilesViewMode } from "./types";
+
+export function ViewToggle({
+  view,
+  onViewChange,
+  viewGridLabel,
+  viewListLabel,
+}: {
+  view: FilesViewMode;
+  onViewChange: (view: FilesViewMode) => void;
+  viewGridLabel: string;
+  viewListLabel: string;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-0.5 rounded-lg bg-chip-subtle p-0.5">
+      <ViewToggleButton
+        active={view === "list"}
+        label={viewListLabel}
+        onClick={() => onViewChange("list")}
+      >
+        <List aria-hidden className="size-3.5" />
+      </ViewToggleButton>
+      <ViewToggleButton
+        active={view === "grid"}
+        label={viewGridLabel}
+        onClick={() => onViewChange("grid")}
+      >
+        <LayoutGrid aria-hidden className="size-3.5" />
+      </ViewToggleButton>
+    </div>
+  );
+}
+
+function ViewToggleButton({
+  active,
+  label,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        "rounded-md p-1 transition-colors",
+        active
+          ? "bg-chip-solid text-ink"
+          : "text-ink-muted hover:bg-hover hover:text-ink",
+      )}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## What

The Files tab was the only agent tab wrapped in a nested `rounded-xl border` frame emulating an OS file manager: bordered toolbar, Finder-style zebra list with decorative filler stripes, and a bottom status bar whose 11px footer links held the primary actions (Upload, Open in File Manager / Download all). This refactors it to the app's flat plane language, matching sibling tabs (Routines, Integrations, Archived).

## Changes

- **Frame removed**: `FilesBrowser` renders flat on the canvas — a shrink-0 header over a full-bleed scroll/drop body, content capped to a shared centered `max-w-4xl` column (`FILES_CONTENT_COLUMN`). Status bar + item count deleted.
- **Actions promoted**: Upload is a filled pill `Button` in the header; Open in File Manager (co-located desktop) / Download all (web/remote) is a ghost pill beside it. The `statusBarAction` footer plumbing is gone.
- **New `files-header.tsx`** (evolves the deleted `files-toolbar.tsx`): breadcrumbs (grid view) · sort · soft segmented view toggle (`view-toggle.tsx`, no border box) · new-folder ghost icon · the two pills. `files-body.tsx` extracts the grid/list switch to keep `files-browser.tsx` under the 200-line cap.
- **List view flattened**: `FillerStripes` and zebra deleted; rows `h-8 rounded-lg`, transparent at rest, `hover:bg-hover`; quiet borderless column headers (still sortable, roles/names unchanged).
- Breadcrumbs stay **grid-view-only** deliberately: the list view is a hierarchical tree always rooted at the workspace, so a path crumb there would misstate its scope.
- Dead `countFiles` export dropped. No locale changes — all labels reuse existing `files.*` keys. Design inventory untracked for these internals, so no parity bump.
- KB: `design-system.md` flat-plane section records Files as a shipped surface.

## Verification

- `pnpm check` (Biome) clean; full workspace `pnpm typecheck` passes
- `@houston-ai/agent` vitest: 8/8
- Playwright `packages/web/e2e/files.spec.ts`: 9/9 (role/name selectors unchanged; only footer→header wording in comments/titles)
- Visual check in light + dark via screenshots (grid, folder navigation, list)
- Adversarial review (correctness + conventions agents); the one real finding (breadcrumb/list-scope mismatch) fixed by restoring the grid-only gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)