### PR TITLE
test(routines): adapt stale e2e specs to the chat-first Routines redesign

### DIFF
--- a/packages/web/e2e/routine-agent-edit-sync.spec.ts
+++ b/packages/web/e2e/routine-agent-edit-sync.spec.ts
@@ -4,9 +4,9 @@ import { expect, test } from "./support/fixtures";
 /**
  * Agent edits land live in the Routines list (AI-native reactivity). Here the
  * "agent" is a REST PATCH against the fake host — the same RoutinesChanged
- * event path a real agent edit rides. The row refreshes in place, and an open
- * "Edit manually" panel with NO local edits adopts the new values; a panel the
- * user is mid-edit in keeps their typing (local edits win until save/cancel).
+ * event path a real agent edit rides. The row's title and schedule summary
+ * refresh in place, and an OPEN inline schedule editor is never closed or
+ * clobbered by the refetch: the user's in-progress edit survives.
  */
 
 async function seedAgentId(): Promise<string> {
@@ -43,58 +43,66 @@ async function patchRoutine(
   });
 }
 
-async function openEditPanel(page: import("@playwright/test").Page) {
-  await page.locator('[data-tour-target="tab-routines"]').click();
-  await expect(page.getByText("Morning digest")).toBeVisible();
-  await page.getByRole("button", { name: "More actions" }).click();
-  await page.getByRole("menuitem", { name: "Edit manually" }).click();
+async function routineSchedules(agentId: string): Promise<string[]> {
+  const { items } = (await (
+    await fetch(`${FAKE_HOST_URL}/agents/${agentId}/routines`)
+  ).json()) as { items: { schedule: string }[] };
+  return items.map((r) => r.schedule);
 }
 
-test("an agent edit refreshes the row and an untouched open editor adopts it", async ({
+async function openRoutinesTab(page: import("@playwright/test").Page) {
+  await page.locator('[data-tour-target="tab-routines"]').click();
+  await expect(
+    page.getByRole("button", { name: "New routine" }).first(),
+  ).toBeVisible();
+}
+
+test("an agent edit refreshes the row's title and schedule summary live", async ({
   page,
 }) => {
   const agentId = await seedAgentId();
   const routineId = await seedRoutine(agentId);
 
   await page.goto("/");
-  await openEditPanel(page);
-  const nameField = page.getByPlaceholder("e.g. Morning standup");
-  await expect(nameField).toHaveValue("Morning digest");
-  // The 9 AM summary shows twice: the row's meta line AND the open panel's
-  // schedule picker.
-  await expect(page.getByText("Runs every day at 9:00 AM")).toHaveCount(2);
+  await openRoutinesTab(page);
+  await expect(page.getByText("Morning digest")).toBeVisible();
+  await expect(page.getByText("Runs every day at 9:00 AM")).toBeVisible();
 
-  // The "agent" renames the routine and moves it to 6 PM while the panel is
-  // open. No local edits, so the fields adopt the new values live…
+  // The "agent" renames the routine and moves it to 6 PM. The row refreshes
+  // in place — no reload, no tab switch.
   await patchRoutine(agentId, routineId, {
     name: "Evening digest",
     schedule: "0 18 * * *",
   });
-  await expect(nameField).toHaveValue("Evening digest", { timeout: 15_000 });
-  // …and BOTH the row meta and the panel's picker re-derive from the new
-  // cron — neither may keep showing the pre-edit time.
-  await expect(page.getByText("Runs every day at 6:00 PM")).toHaveCount(2);
+  await expect(page.getByText("Evening digest")).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByText("Runs every day at 6:00 PM")).toBeVisible();
   await expect(page.getByText("Runs every day at 9:00 AM")).toHaveCount(0);
-  await expect(page.getByText("Evening digest")).toBeVisible();
+  await expect(page.getByText("Morning digest")).toHaveCount(0);
 });
 
-test("a mid-edit panel keeps the user's typing over an agent edit", async ({
-  page,
-}) => {
+test("an open schedule editor survives an agent edit", async ({ page }) => {
   const agentId = await seedAgentId();
   const routineId = await seedRoutine(agentId);
 
   await page.goto("/");
-  await openEditPanel(page);
-  const nameField = page.getByPlaceholder("e.g. Morning standup");
-  await expect(nameField).toHaveValue("Morning digest");
+  await openRoutinesTab(page);
+  await expect(page.getByText("Morning digest")).toBeVisible();
 
-  // The user is mid-rename when the agent's edit lands: their local value
-  // must win until they save or cancel — never clobbered by the refetch.
-  await nameField.fill("My own name");
+  // The user opens the inline schedule editor…
+  await page.getByRole("button", { name: "Edit schedule" }).click();
+  const save = page.getByRole("button", { name: "Save" });
+  await expect(save).toBeVisible();
+
+  // …and the agent's rename lands while it is open. The row title adopts the
+  // new name live, but the editor stays open — the refetch never closes the
+  // user's in-progress edit.
   await patchRoutine(agentId, routineId, { name: "Agent name" });
-
-  // The row title shows the agent's change; the panel keeps the user's.
   await expect(page.getByText("Agent name")).toBeVisible({ timeout: 15_000 });
-  await expect(nameField).toHaveValue("My own name");
+  await expect(save).toBeVisible();
+
+  // Saving the untouched draft is a no-op: the host keeps the same cron.
+  await save.click();
+  expect(await routineSchedules(agentId)).toEqual(["0 9 * * *"]);
 });

--- a/packages/web/e2e/routine-quick-actions.spec.ts
+++ b/packages/web/e2e/routine-quick-actions.spec.ts
@@ -2,11 +2,11 @@ import { FAKE_HOST_URL } from "@houston/fake-host";
 import { expect, test } from "./support/fixtures";
 
 /**
- * The routine row's three-dot menu ("More actions", always visible, never
- * hover-gated). Rows aren't clickable — the menu is the only way in: Edit
- * manually expands the inline name/schedule/instruction panel right in the
- * list (renaming happens there), and Delete is confirmed in a dialog before
- * anything is removed.
+ * The routine row's inline schedule editor. The redesigned row has no
+ * "Edit manually" panel: the schedule-summary line itself is the edit
+ * affordance (always visible, never hover-gated). Clicking it opens a
+ * popover with the ScheduleBuilder over a Save / Cancel footer. Save
+ * commits the new cron to the host; Cancel discards the draft.
  */
 
 async function seedAgentId(): Promise<string> {
@@ -24,21 +24,21 @@ async function seedRoutine(agentId: string, name: string): Promise<void> {
   });
 }
 
-async function routineNames(agentId: string): Promise<string[]> {
+async function routineSchedules(agentId: string): Promise<string[]> {
   const { items } = (await (
     await fetch(`${FAKE_HOST_URL}/agents/${agentId}/routines`)
-  ).json()) as { items: { name: string }[] };
-  return items.map((r) => r.name);
+  ).json()) as { items: { schedule: string }[] };
+  return items.map((r) => r.schedule);
 }
 
 async function openRoutinesTab(page: import("@playwright/test").Page) {
   await page.locator('[data-tour-target="tab-routines"]').click();
   await expect(
-    page.getByRole("button", { name: "New automation" }).first(),
+    page.getByRole("button", { name: "New routine" }).first(),
   ).toBeVisible();
 }
 
-test("renaming happens in the inline Edit manually panel and persists", async ({
+test("the schedule summary opens the inline editor and Save persists the cron", async ({
   page,
 }) => {
   const agentId = await seedAgentId();
@@ -48,57 +48,48 @@ test("renaming happens in the inline Edit manually panel and persists", async ({
   await openRoutinesTab(page);
   await expect(page.getByText("Morning digest")).toBeVisible();
 
-  // The three-dot trigger is visible without hovering the row.
-  await page.getByRole("button", { name: "More actions" }).click();
-  await page.getByRole("menuitem", { name: "Edit manually" }).click();
-
-  // The inline panel opens pre-filled; a new name saves through it.
-  const nameField = page.getByPlaceholder("e.g. Morning standup");
-  await expect(nameField).toHaveValue("Morning digest");
-  await nameField.fill("Evening digest");
+  // The summary line is the edit affordance, visible without hovering.
+  await page.getByRole("button", { name: "Edit schedule" }).click();
+  await page.getByRole("button", { name: "Every hour" }).click();
   await page.getByRole("button", { name: "Save" }).click();
 
-  await expect(page.getByText("Evening digest")).toBeVisible();
-  await expect.poll(() => routineNames(agentId)).toEqual(["Evening digest"]);
-  // The panel closed on save.
-  await expect(nameField).toHaveCount(0);
+  // The row re-derives its summary from the new cron, and the host has it.
+  await expect(
+    page.getByText("Runs at the start of every hour").first(),
+  ).toBeVisible();
+  await expect.poll(() => routineSchedules(agentId)).toEqual(["0 * * * *"]);
 
   await page.screenshot({
     path: test.info().outputPath("routine-row-quick-actions.png"),
   });
 });
 
-test("delete from the row menu confirms first, then removes the routine", async ({
+test("Cancel discards the schedule draft and keeps the saved cron", async ({
   page,
 }) => {
   const agentId = await seedAgentId();
-  await seedRoutine(agentId, "Doomed digest");
+  await seedRoutine(agentId, "Morning digest");
 
   await page.goto("/");
   await openRoutinesTab(page);
-  await expect(page.getByText("Doomed digest")).toBeVisible();
+  await expect(page.getByText("Morning digest")).toBeVisible();
 
-  await page.getByRole("button", { name: "More actions" }).click();
-  await page.getByRole("menuitem", { name: "Delete" }).click();
+  await page.getByRole("button", { name: "Edit schedule" }).click();
+  await page.getByRole("button", { name: "Every hour" }).click();
+  await page.getByRole("button", { name: "Cancel" }).click();
 
-  // Nothing is deleted before the dialog confirms.
-  const dialog = page.getByRole("alertdialog");
-  await expect(dialog).toBeVisible();
-  await expect(dialog.getByText("Delete Doomed digest?")).toBeVisible();
-  expect(await routineNames(agentId)).toEqual(["Doomed digest"]);
+  // Nothing changed: the row keeps the 9 AM summary and the host the old cron.
+  await expect(
+    page.getByText("Runs every day at 9:00 AM").first(),
+  ).toBeVisible();
+  expect(await routineSchedules(agentId)).toEqual(["0 9 * * *"]);
 
-  // Cancel keeps it…
-  await dialog.getByRole("button", { name: "Cancel" }).click();
-  await expect(page.getByText("Doomed digest")).toBeVisible();
-
-  // …confirm removes it.
-  await page.getByRole("button", { name: "More actions" }).click();
-  await page.getByRole("menuitem", { name: "Delete" }).click();
-  await page
-    .getByRole("alertdialog")
-    .getByRole("button", { name: "Delete" })
-    .click();
-
-  await expect(page.getByText("Doomed digest")).toHaveCount(0);
-  await expect.poll(() => routineNames(agentId)).toEqual([]);
+  // Reopening reseeds from the live cron, so the cancelled draft never leaks:
+  // an immediate Save is a no-op.
+  await page.getByRole("button", { name: "Edit schedule" }).click();
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect(
+    page.getByText("Runs every day at 9:00 AM").first(),
+  ).toBeVisible();
+  expect(await routineSchedules(agentId)).toEqual(["0 9 * * *"]);
 });

--- a/packages/web/e2e/routine-setup-chat.spec.ts
+++ b/packages/web/e2e/routine-setup-chat.spec.ts
@@ -226,6 +226,14 @@ test("the row menu deletes the routine after confirming", async ({ page }) => {
   await expect(dialog.getByText("Delete Doomed?")).toBeVisible();
   expect(await listRoutines(agentId)).toHaveLength(1);
 
+  // Cancel keeps it…
+  await dialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(page.getByText("Doomed")).toBeVisible();
+  expect(await listRoutines(agentId)).toHaveLength(1);
+
+  // …confirm removes it.
+  await page.getByRole("button", { name: "More actions" }).click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
   await dialog.getByRole("button", { name: "Delete" }).click();
   await expect(page.getByText("Doomed")).toHaveCount(0);
   await expect.poll(async () => (await listRoutines(agentId)).length).toBe(0);


### PR DESCRIPTION
## Why

Main's Web CI job is red (e.g. [run 29798003317](https://github.com/gethouston/houston/actions/runs/29798003317)): PR #1008 redesigned the Routines tab but left two e2e specs targeting the removed UI. `routine-quick-actions.spec.ts` and `routine-agent-edit-sync.spec.ts` still wait for the old **New automation** button and the **Edit manually** panel, so their 4 tests time out. (#1008's own Web check was already failing with the same 4 tests when it merged.)

This is test staleness, not a product defect — but it leaves main red, masking any real regression that lands on top.

## What

- **routine-agent-edit-sync.spec.ts** — same AI-native reactivity invariant, rewritten against the new row UI: an agent PATCH (the RoutinesChanged event path) refreshes the row's title and schedule summary live, and an open inline schedule editor is never closed or clobbered by the refetch.
- **routine-quick-actions.spec.ts** — now covers the row's inline schedule popover, which had no coverage: the schedule-summary line opens the ScheduleBuilder popover, Save persists the new cron to the host, Cancel discards the draft, and reopening reseeds from the live cron.
- **routine-setup-chat.spec.ts** — the delete test additionally asserts Cancel keeps the routine before confirming removes it (coverage the old quick-actions spec had).

## Verification

All three specs pass locally against the same harness CI uses (fake host + vite, `--fail-on-flaky-tests`): **10 passed (33s)**. `pnpm --filter houston-web typecheck`, `typecheck:e2e`, and Biome are clean.