### PR TITLE
ci(website): pass POSTHOG_KEY to the site build and fail loudly when absent

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -29,8 +29,14 @@ name: Website Deploy
 # ── Required repo secrets ─────────────────────────────────────────────────────
 #   SUPABASE_ANON_KEY   - public (RLS-protected) Supabase anon key for the
 #                         /waitlist form. Still Supabase, intentionally unchanged.
+#   POSTHOG_KEY         - public PostHog ingest token (phc_...). base.njk omits
+#                         the whole analytics snippet when it is empty, so a
+#                         guard step fails the build loudly instead of shipping
+#                         a blind site (this exact miss cost 2026-05-25 →
+#                         2026-07-21 of website analytics when builds moved off
+#                         Cloudflare Pages, which held the key in its dashboard).
 # Optional (committed defaults exist):
-#   SUPABASE_URL, WAITLIST_SHEET_ENDPOINT
+#   SUPABASE_URL, WAITLIST_SHEET_ENDPOINT, POSTHOG_HOST
 
 on:
   push:
@@ -64,6 +70,18 @@ jobs:
         working-directory: website
         run: npm ci
 
+      # env.js falls back to an empty posthogKey and base.njk then silently
+      # omits the whole PostHog snippet, so a missing secret would ship a site
+      # with no analytics and a green build. Fail loudly instead.
+      - name: Fail if POSTHOG_KEY is missing
+        env:
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+        run: |
+          if [ -z "$POSTHOG_KEY" ]; then
+            echo "::error::POSTHOG_KEY secret is not set — refusing to deploy the site without analytics. Create it in Settings → Secrets and variables → Actions (public phc_ ingest token)."
+            exit 1
+          fi
+
       - name: Build site
         working-directory: website
         run: npx @11ty/eleventy
@@ -71,6 +89,8 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           WAITLIST_SHEET_ENDPOINT: ${{ secrets.WAITLIST_SHEET_ENDPOINT }}
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
 
       - name: Auth to GCP
         uses: google-github-actions/auth@v2


### PR DESCRIPTION
## Root cause

Website analytics died silently on **2026-05-25**. The next day, #308 moved website builds from Cloudflare Pages (where `POSTHOG_KEY` lived as a dashboard variable) to GitHub Actions - and the Build site step never received the key. `env.js` falls back to an empty `posthogKey`, `base.njk` omits the entire PostHog snippet when it is empty, and every deploy shipped green with a blind site. Zero `$pageview` events for 8 weeks (954 visitors were being tracked in the 4 weeks before the cutover).

GA survived because `gaMeasurementId` has a committed default; PostHog does not.

## Fix

- Pass `POSTHOG_KEY` (and optional `POSTHOG_HOST`) to the Eleventy build step.
- Add a guard step that **fails the build in red** with the remedy when the secret is missing - per the repo rule that a credential is the switch and key-absent must be a loud OFF, never a hidden surface. This exact failure mode can never ship silently again.
- Document the secret in the workflow header.

The `POSTHOG_KEY` repo secret (public `phc_` ingest token, same class as the committed GA measurement id) is already created in Actions secrets.

## Impact once deployed

Website `$pageview` + UTM capture revive, which un-blanks the web tiles on the Acquisition dashboard, the retention-by-UTM tile, and re-enables the full campaign attribution bridge (landing -> `/welcome` -> install identity merge) documented in `growth/utm-conventions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)