### PR TITLE
fix(app): guard agent-JSON reads against wrong top-level container shape

### DIFF
--- a/app/src/data/agent-file.ts
+++ b/app/src/data/agent-file.ts
@@ -6,21 +6,10 @@
  * and over the engine REST route tomorrow.
  */
 
-import Ajv, { type Schema, type ValidateFunction } from "ajv";
+import type { Schema } from "ajv";
 import { logger } from "../lib/logger";
 import { tauriAgent } from "../lib/tauri";
-
-const ajv = new Ajv({ allErrors: true, strict: false });
-const validators = new Map<string, ValidateFunction>();
-
-function getValidator(name: string, schema: Schema): ValidateFunction {
-  let v = validators.get(name);
-  if (!v) {
-    v = ajv.compile(schema);
-    validators.set(name, v);
-  }
-  return v;
-}
+import { getValidator, parseAgentJson } from "./agent-json";
 
 /** Relative path convention: `.houston/<name>/<name>.json`. */
 export function relPath(name: string): string {
@@ -29,9 +18,9 @@ export function relPath(name: string): string {
 
 /**
  * Read + parse `.houston/<name>/<name>.json`. Returns `fallback` when the file
- * is missing or empty. Validates against the JSON Schema and logs (but doesn't
- * throw) on mismatch — validation failures should surface data bugs, not block
- * the UI.
+ * is missing, empty, unparseable, or has the wrong top-level container shape
+ * (agents write these files directly). Item-level schema mismatches only log —
+ * they should surface data bugs, not block the UI.
  */
 export async function readAgentJson<T>(
   agentPath: string,
@@ -41,21 +30,9 @@ export async function readAgentJson<T>(
 ): Promise<T> {
   const raw = await tauriAgent.readFile(agentPath, relPath(name));
   if (!raw) return fallback;
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (e) {
-    logger.warn(`[agent-file] ${name}: invalid JSON, falling back`, String(e));
-    return fallback;
-  }
-  const validate = getValidator(name, schema);
-  if (!validate(parsed)) {
-    logger.warn(
-      `[agent-file] ${name}: schema validation failed`,
-      JSON.stringify(validate.errors),
-    );
-  }
-  return parsed as T;
+  return parseAgentJson(name, raw, schema, fallback, (message, detail) =>
+    logger.warn(`[agent-file] ${message}`, detail),
+  );
 }
 
 /** Serialize + atomically write `.houston/<name>/<name>.json`. */

--- a/app/src/data/agent-json.ts
+++ b/app/src/data/agent-json.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure parse/validate half of `readAgentJson` — kept free of Tauri imports so
+ * it can be unit-tested (see `tests/agent-json.test.ts`).
+ *
+ * Agents edit `.houston/<name>/<name>.json` files directly, so any shape can
+ * land on disk. Item-level schema mismatches only warn (surface data bugs, not
+ * block the UI), but a wrong top-level container (an object where an array
+ * belongs) falls back: callers do `data.map(...)` and would crash the app.
+ */
+
+import Ajv, { type Schema, type ValidateFunction } from "ajv";
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+const validators = new Map<string, ValidateFunction>();
+
+export function getValidator(name: string, schema: Schema): ValidateFunction {
+  let v = validators.get(name);
+  if (!v) {
+    v = ajv.compile(schema);
+    validators.set(name, v);
+  }
+  return v;
+}
+
+/** True when `parsed` has the same top-level container kind as `fallback`. */
+function matchesContainerShape(parsed: unknown, fallback: unknown): boolean {
+  if (Array.isArray(fallback)) return Array.isArray(parsed);
+  if (fallback !== null && typeof fallback === "object")
+    return (
+      typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    );
+  return true;
+}
+
+export function parseAgentJson<T>(
+  name: string,
+  raw: string,
+  schema: Schema,
+  fallback: T,
+  warn: (message: string, detail?: string) => void,
+): T {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    warn(`${name}: invalid JSON, falling back`, String(e));
+    return fallback;
+  }
+  if (!matchesContainerShape(parsed, fallback)) {
+    warn(
+      `${name}: wrong top-level shape (expected ${
+        Array.isArray(fallback) ? "array" : "object"
+      }), falling back`,
+      JSON.stringify(parsed).slice(0, 200),
+    );
+    return fallback;
+  }
+  const validate = getValidator(name, schema);
+  if (!validate(parsed)) {
+    warn(`${name}: schema validation failed`, JSON.stringify(validate.errors));
+  }
+  return parsed as T;
+}

--- a/app/tests/agent-json.test.ts
+++ b/app/tests/agent-json.test.ts
@@ -1,0 +1,87 @@
+import { deepStrictEqual, ok, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import learningsSchema from "@houston-ai/agent-schemas/learnings.schema.json" with {
+  type: "json",
+};
+import { parseAgentJson } from "../src/data/agent-json.ts";
+
+const schema = learningsSchema as Parameters<typeof parseAgentJson>[2];
+const configSchema = { type: "object" } as Parameters<typeof parseAgentJson>[2];
+
+function collect() {
+  const warnings: string[] = [];
+  return { warnings, warn: (m: string) => warnings.push(m) };
+}
+
+const ENTRY = { id: "a", text: "hi", created_at: "2026-07-21T00:00:00Z" };
+
+describe("parseAgentJson", () => {
+  it("passes a valid array through without warnings", () => {
+    const { warnings, warn } = collect();
+    const out = parseAgentJson(
+      "learnings",
+      JSON.stringify([ENTRY]),
+      schema,
+      [],
+      warn,
+    );
+    deepStrictEqual(out, [ENTRY]);
+    deepStrictEqual(warnings, []);
+  });
+
+  // Regression: an agent wrote `{"learnings": [...]}` instead of a bare array;
+  // `(q.data ?? []).map` then crashed the whole app on every render.
+  it("falls back when an object lands where an array belongs", () => {
+    const { warnings, warn } = collect();
+    const out = parseAgentJson(
+      "learnings",
+      JSON.stringify({ learnings: [ENTRY] }),
+      schema,
+      [],
+      warn,
+    );
+    deepStrictEqual(out, []);
+    ok(warnings.some((w) => w.includes("wrong top-level shape")));
+  });
+
+  it("falls back on scalar top-level values", () => {
+    const { warn } = collect();
+    deepStrictEqual(
+      parseAgentJson("learnings", '"oops"', schema, [], warn),
+      [],
+    );
+    deepStrictEqual(parseAgentJson("learnings", "42", schema, [], warn), []);
+    deepStrictEqual(parseAgentJson("learnings", "null", schema, [], warn), []);
+  });
+
+  it("falls back when an array lands where an object belongs", () => {
+    const { warnings, warn } = collect();
+    const out = parseAgentJson("config", "[1,2]", configSchema, {}, warn);
+    deepStrictEqual(out, {});
+    ok(warnings.some((w) => w.includes("wrong top-level shape")));
+  });
+
+  it("falls back on invalid JSON", () => {
+    const { warnings, warn } = collect();
+    deepStrictEqual(
+      parseAgentJson("learnings", "{not json", schema, [], warn),
+      [],
+    );
+    ok(warnings.some((w) => w.includes("invalid JSON")));
+  });
+
+  it("keeps schema-invalid items but warns (data bugs surface, UI survives)", () => {
+    const { warnings, warn } = collect();
+    const items = [{ id: "a", text: "hi" }]; // missing created_at
+    const out = parseAgentJson(
+      "learnings",
+      JSON.stringify(items),
+      schema,
+      [],
+      warn,
+    );
+    deepStrictEqual(out, items);
+    strictEqual(warnings.length, 1);
+    ok(warnings[0].includes("schema validation failed"));
+  });
+});


### PR DESCRIPTION
## What

An agent wrote `.houston/learnings/learnings.json` as `{"learnings": [...]}` instead of the schema's bare array. `readAgentJson` warns-but-returns on schema mismatch, so the object flowed into `useLearnings`, where `(q.data ?? []).map` threw (`??` only guards null/undefined) and hard-crashed the app on every launch. Hit by a real user in production; the same hazard existed for `activity.json` (board) and `config.json`.

## Fix

- Extract the parse/validate step of `readAgentJson` into a pure module, `app/src/data/agent-json.ts` (`parseAgentJson`), free of Tauri imports so it's unit-testable.
- Add a **top-level container-shape guard**: if the file holds an object where the caller's fallback is an array (or vice versa), warn and return the fallback instead of the poison value.
- Item-level schema mismatches still only warn — the existing "surface data bugs, don't block the UI" intent is preserved. Only the shape that makes callers crash falls back.
- Covers all three `readAgentJson` callers (`learnings`, `activity`, `config`) in one place, on both desktop and web (shared code).

## Recovery behavior

A malformed file is now ignored (empty list in the UI); the next write overwrites it — same as the pre-existing invalid-JSON path. Agents writing these files directly is by design (`houston-prompt.ts` instructs it), so wrong shapes will recur; the UI must never crash on them.

## Tests

`app/tests/agent-json.test.ts` — regression for the exact crash shape (object-where-array against the real learnings schema), scalar top-levels, array-where-object, invalid JSON, and the warn-but-keep path for item-level mismatches.

- 1901 app tests pass (6 new)
- `pnpm tsgo --noEmit` (app) and `pnpm --filter houston-web typecheck` clean
- `pnpm check` (Biome) clean