### PR TITLE
fix(providers): repair the Windows shell env for Claude sign-in and turns

### DIFF
--- a/app/src-tauri/src/claude_login/resolve.rs
+++ b/app/src-tauri/src/claude_login/resolve.rs
@@ -63,6 +63,23 @@ pub(super) fn build_login_command(bin: &Path, config_dir: &Path) -> Command {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
+    // The CLI's Windows startup gate needs a resolvable shell (Git Bash or
+    // PowerShell); repair the child env so it can't miss (HOUSTON-APP-4YP).
+    for (key, value) in crate::shell_env::claude_shell_env() {
+        cmd.env(key, value);
+    }
+    #[cfg(windows)]
+    {
+        // `claude.exe` is a console binary and this GUI app has no console:
+        // without CREATE_NO_WINDOW every sign-in pops a visible console
+        // window, and a user closing it hangs up the child — the CLI then
+        // dies with SIGHUP semantics, exit 129 (HOUSTON-APP-4YQ).
+        // CREATE_NEW_PROCESS_GROUP keeps console control events aimed at the
+        // parent from propagating, mirroring the engine sidecar spawn.
+        cmd.creation_flags(
+            crate::child_guard::CREATE_NEW_PROCESS_GROUP | crate::child_guard::CREATE_NO_WINDOW,
+        );
+    }
     cmd
 }
 

--- a/app/src-tauri/src/engine_supervisor.rs
+++ b/app/src-tauri/src/engine_supervisor.rs
@@ -180,6 +180,13 @@ impl EngineSubprocess {
         ] {
             cmd.env_remove(key);
         }
+        // The runtime spawns the bundled Claude Code CLI for chat turns, and
+        // on Windows that CLI refuses to start without a resolvable shell.
+        // Repair the env BEFORE the caller-provided pairs so an explicit
+        // override still wins (see `shell_env`).
+        for (key, value) in crate::shell_env::claude_shell_env() {
+            cmd.env(key, value);
+        }
         for (k, v) in env {
             cmd.env(k, v);
         }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod logging;
 mod loopback_util;
 mod notification;
 mod oauth_loopback;
+mod shell_env;
 mod store_deep_link;
 mod window_focus;
 

--- a/app/src-tauri/src/shell_env.rs
+++ b/app/src-tauri/src/shell_env.rs
@@ -1,0 +1,171 @@
+//! Windows shell-environment hardening for children that run the bundled
+//! Claude Code CLI — the `claude auth login` helper and the engine sidecar
+//! (whose runtime spawns the same binary for chat turns).
+//!
+//! The CLI refuses to start on Windows unless it can find Git Bash or
+//! PowerShell: it probes `pwsh` on PATH, three well-known pwsh install dirs,
+//! and finally plain `powershell` on PATH, then exits 1 with an install-Git
+//! message when all miss (HOUSTON-APP-4YP). Every Windows machine HAS
+//! Windows PowerShell 5.1 at `%SystemRoot%\System32\WindowsPowerShell\v1.0`,
+//! but that only helps if the dir is actually on the child's PATH — and
+//! end-user PATHs are routinely mangled by installers. So before spawning:
+//!
+//! 1. If a Git for Windows `bash.exe` exists at a standard install location,
+//!    point `CLAUDE_CODE_GIT_BASH_PATH` at it (the CLI's documented escape
+//!    hatch; an inherited value that resolves is left alone).
+//! 2. Append the built-in PowerShell dir (and `System32`, which `where`-style
+//!    lookups need) to the child's PATH when missing, so the CLI's
+//!    `powershell` fallback can never miss.
+//!
+//! On non-Windows this contributes nothing — the CLI has no shell gate there.
+
+use std::ffi::OsString;
+
+/// Env pairs to merge into a child that will execute the Claude Code CLI.
+/// Empty on non-Windows and on Windows machines that need no repair.
+pub fn claude_shell_env() -> Vec<(String, OsString)> {
+    #[cfg(not(windows))]
+    {
+        Vec::new()
+    }
+    #[cfg(windows)]
+    {
+        windows::claude_shell_env()
+    }
+}
+
+/// Append `dirs` (Windows `;`-separated PATH semantics) to `path` unless an
+/// equivalent entry is already present — case-insensitive, ignoring trailing
+/// separators. Returns `None` when nothing is missing. Pure string logic so
+/// the behavior is unit-testable on every host platform.
+fn append_missing_dirs(path: &str, dirs: &[String]) -> Option<String> {
+    let normalize = |s: &str| s.trim_end_matches(['\\', '/']).to_ascii_lowercase();
+    let present: Vec<String> = path
+        .split(';')
+        .filter(|p| !p.is_empty())
+        .map(normalize)
+        .collect();
+    let missing: Vec<&String> = dirs
+        .iter()
+        .filter(|d| !present.contains(&normalize(d)))
+        .collect();
+    if missing.is_empty() {
+        return None;
+    }
+    let mut out = path.trim_end_matches(';').to_string();
+    for dir in missing {
+        if !out.is_empty() {
+            out.push(';');
+        }
+        out.push_str(dir);
+    }
+    Some(out)
+}
+
+#[cfg(windows)]
+mod windows {
+    use super::append_missing_dirs;
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+
+    /// The CLI's documented override for a bash that is not on PATH.
+    const GIT_BASH_ENV: &str = "CLAUDE_CODE_GIT_BASH_PATH";
+
+    pub(super) fn claude_shell_env() -> Vec<(String, OsString)> {
+        let mut env = Vec::new();
+        if let Some(bash) = resolve_git_bash() {
+            env.push((GIT_BASH_ENV.to_string(), bash.into_os_string()));
+        }
+        if let Some(path) = hardened_path() {
+            env.push(("PATH".to_string(), OsString::from(path)));
+        }
+        env
+    }
+
+    /// Find a Git for Windows `bash.exe`. An inherited `GIT_BASH_ENV` that
+    /// points at a real file wins (respect the user's override — the child
+    /// inherits it, nothing to add). A stale override, or none, falls through
+    /// to the standard machine- and user-scope install locations. No PATH
+    /// scan: `C:\Windows\System32\bash.exe` is WSL, not Git Bash, and would
+    /// wedge the CLI.
+    fn resolve_git_bash() -> Option<PathBuf> {
+        if let Ok(existing) = std::env::var(GIT_BASH_ENV) {
+            if PathBuf::from(&existing).is_file() {
+                return None;
+            }
+        }
+        let roots = [
+            std::env::var("ProgramFiles").ok(),
+            std::env::var("ProgramFiles(x86)").ok(),
+            std::env::var("LOCALAPPDATA")
+                .ok()
+                .map(|l| format!("{l}\\Programs")),
+        ];
+        roots
+            .into_iter()
+            .flatten()
+            .map(|root| PathBuf::from(root).join("Git").join("bin").join("bash.exe"))
+            .find(|candidate| candidate.is_file())
+    }
+
+    /// The child's PATH with the built-in Windows PowerShell 5.1 dir (the
+    /// CLI's last-resort shell) and `System32` guaranteed present.
+    fn hardened_path() -> Option<String> {
+        let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| "C:\\Windows".into());
+        let required = [
+            format!("{system_root}\\System32\\WindowsPowerShell\\v1.0"),
+            format!("{system_root}\\System32"),
+        ];
+        let current = std::env::var("PATH").unwrap_or_default();
+        append_missing_dirs(&current, &required)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn append_missing_dirs_appends_absent_entries() {
+        let path = "C:\\Users\\u\\bin;D:\\tools";
+        let dirs = vec![
+            "C:\\Windows\\System32\\WindowsPowerShell\\v1.0".to_string(),
+            "C:\\Windows\\System32".to_string(),
+        ];
+        assert_eq!(
+            append_missing_dirs(path, &dirs).as_deref(),
+            Some(
+                "C:\\Users\\u\\bin;D:\\tools;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Windows\\System32"
+            )
+        );
+    }
+
+    #[test]
+    fn append_missing_dirs_is_case_insensitive_and_ignores_trailing_slashes() {
+        let path = "c:\\windows\\system32\\;C:\\WINDOWS\\System32\\WindowsPowerShell\\V1.0";
+        let dirs = vec![
+            "C:\\Windows\\System32\\WindowsPowerShell\\v1.0".to_string(),
+            "C:\\Windows\\System32".to_string(),
+        ];
+        assert_eq!(append_missing_dirs(path, &dirs), None);
+    }
+
+    #[test]
+    fn append_missing_dirs_handles_empty_and_trailing_separator_paths() {
+        let dirs = vec!["C:\\Windows\\System32".to_string()];
+        assert_eq!(
+            append_missing_dirs("", &dirs).as_deref(),
+            Some("C:\\Windows\\System32")
+        );
+        assert_eq!(
+            append_missing_dirs("D:\\x;", &dirs).as_deref(),
+            Some("D:\\x;C:\\Windows\\System32")
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn claude_shell_env_is_inert_off_windows() {
+        assert!(claude_shell_env().is_empty());
+    }
+}

--- a/app/src-tauri/src/shell_env.rs
+++ b/app/src-tauri/src/shell_env.rs
@@ -37,7 +37,9 @@ pub fn claude_shell_env() -> Vec<(String, OsString)> {
 /// Append `dirs` (Windows `;`-separated PATH semantics) to `path` unless an
 /// equivalent entry is already present — case-insensitive, ignoring trailing
 /// separators. Returns `None` when nothing is missing. Pure string logic so
-/// the behavior is unit-testable on every host platform.
+/// the behavior is unit-testable on every host platform (hence compiled — but
+/// unused outside tests — on non-Windows).
+#[cfg_attr(not(windows), allow(dead_code))]
 fn append_missing_dirs(path: &str, dirs: &[String]) -> Option<String> {
     let normalize = |s: &str| s.trim_end_matches(['\\', '/']).to_ascii_lowercase();
     let present: Vec<String> = path
@@ -116,7 +118,15 @@ mod windows {
             format!("{system_root}\\System32\\WindowsPowerShell\\v1.0"),
             format!("{system_root}\\System32"),
         ];
-        let current = std::env::var("PATH").unwrap_or_default();
+        let current = match std::env::var("PATH") {
+            Ok(path) => path,
+            Err(std::env::VarError::NotPresent) => String::new(),
+            // A non-Unicode PATH must be left alone: emitting a repaired
+            // value here would REPLACE the inherited PATH with only what we
+            // could parse, dropping every real entry — strictly worse than
+            // not repairing. The Git Bash override above still applies.
+            Err(std::env::VarError::NotUnicode(_)) => return None,
+        };
         append_missing_dirs(&current, &required)
     }
 }

--- a/knowledge-base/anthropic-credentials.md
+++ b/knowledge-base/anthropic-credentials.md
@@ -5,7 +5,7 @@ Anthropic is the one provider whose turns run through the **Claude Agent SDK**
 every other provider. This file is the map. History: the July 2026 "Anthropic
 is unusable" cluster (reconnect card after every send locally, cloud connect
 timing out into the setup-token paste dialog, mid-session sign-outs) came from
-the four traps at the bottom — read them before touching any of this.
+the traps at the bottom — read them before touching any of this.
 
 ## Where the credential lives, per deployment
 
@@ -39,7 +39,7 @@ the four traps at the bottom — read them before touching any of this.
   (`backends/claude/read-token.ts`). This is what survives pod recycles:
   `/data` is an emptyDir in prod and store-sync EXCLUDES both credential files.
 
-## The four traps (each was a live bug)
+## The five traps (each was a live bug)
 
 1. **`USER` must reach the SDK subprocess.** The CLI names its Keychain
    *account* after the username; `buildClaudeEnv`'s allowlist passes
@@ -61,3 +61,16 @@ the four traps at the bottom — read them before touching any of this.
    central-store copy on a desktop host is an inert marker (never served,
    never refreshed — TS `credentials/refresh.ts` deliberately has no anthropic
    entry).
+5. **Windows: the CLI needs a shell BEFORE it does anything — even
+   `auth login`.** At startup on Windows the CLI exits 1 unless it finds Git
+   Bash or PowerShell (`pwsh` on PATH → three pwsh install dirs → plain
+   `powershell` on PATH). Stock machines always have PowerShell 5.1 under
+   `System32`, but mangled user PATHs made the probe miss (HOUSTON-APP-4YP,
+   v0.5.20 launch day). And as a console binary spawned from a GUI app it
+   pops a visible console window; the user closing it hangs up the child →
+   exit 129 / SIGHUP (HOUSTON-APP-4YQ). Both spawn sites (login helper +
+   engine sidecar) route through `app/src-tauri/src/shell_env.rs`, which sets
+   `CLAUDE_CODE_GIT_BASH_PATH` when a Git for Windows bash exists, guarantees
+   the built-in PowerShell dir on the child PATH, and the login spawn adds
+   `CREATE_NO_WINDOW`. Never PATH-scan for `bash.exe` there —
+   `System32\bash.exe` is WSL and wedges the CLI.

--- a/packages/runtime/src/backends/claude/backend.test.ts
+++ b/packages/runtime/src/backends/claude/backend.test.ts
@@ -65,6 +65,25 @@ test("operational ambient env (PATH) is preserved", () => {
   expect(env.PATH).toBe(process.env.PATH);
 });
 
+test("the Windows Git Bash override reaches the subprocess", () => {
+  // The desktop shell repairs CLAUDE_CODE_GIT_BASH_PATH into the engine's env
+  // on Windows (app/src-tauri shell_env.rs) so the CLI's shell gate passes.
+  // If the allowlist drops it, sign-in works but every turn exits at startup
+  // on machines that need the override.
+  const saved = process.env.CLAUDE_CODE_GIT_BASH_PATH;
+  process.env.CLAUDE_CODE_GIT_BASH_PATH =
+    "C:\\Program Files\\Git\\bin\\bash.exe";
+  try {
+    const env = buildClaudeEnv("/cfg", oauth);
+    expect(env.CLAUDE_CODE_GIT_BASH_PATH).toBe(
+      "C:\\Program Files\\Git\\bin\\bash.exe",
+    );
+  } finally {
+    if (saved === undefined) delete process.env.CLAUDE_CODE_GIT_BASH_PATH;
+    else process.env.CLAUDE_CODE_GIT_BASH_PATH = saved;
+  }
+});
+
 test("the username (USER/LOGNAME) reaches the subprocess", () => {
   // The Claude CLI derives its macOS Keychain item's ACCOUNT from the
   // username. Scrubbing USER made the SDK resolve "unknown" and read a

--- a/packages/runtime/src/backends/claude/claude-env.ts
+++ b/packages/runtime/src/backends/claude/claude-env.ts
@@ -70,6 +70,12 @@ const PASSTHROUGH_ENV_VARS: ReadonlySet<string> = new Set(
     "TMPDIR",
     "TMP",
     "TEMP",
+    // Windows shell override (non-secret, a filesystem path): the CLI refuses
+    // to start on Windows without Git Bash or PowerShell, and the desktop
+    // shell repairs this var into our own env at spawn (app/src-tauri
+    // shell_env.rs). Dropping it here would make sign-in work but every turn
+    // fail on machines that need the override.
+    "CLAUDE_CODE_GIT_BASH_PATH",
     // Windows process bootstrap — Node and child processes fail to start without
     // these on native Windows.
     "SYSTEMROOT",


### PR DESCRIPTION
## Problem

Within an hour of the v0.5.20 Windows launch, two Sentry issues appeared (all events Windows 11, `houston-app@0.5.20`, disjoint user sets):

- **HOUSTON-APP-4YP** (13 ev / 5 machines): `Claude sign-in failed (exit 1): Claude Code on Windows requires either Git for Windows (for bash) or PowerShell…` — the bundled Claude Code CLI runs a shell gate at startup, before `auth login` does anything. It probes `pwsh` on PATH, three pwsh install dirs, then plain `powershell` on PATH. Stock Windows always has PowerShell 5.1 under `System32`, but mangled end-user PATHs make the last probe miss → exit 1.
- **HOUSTON-APP-4YQ** (17 ev / 7 machines): `Claude sign-in failed (exit 129)` — 129 = 128+SIGHUP from the CLI's relaunch wrapper. `claude.exe` is a console binary and the login spawn had no `CREATE_NO_WINDOW`, so sign-in pops a visible console window; the user closing it hangs up the child.

The same CLI is spawned by the runtime for chat turns, so an affected machine can't use Anthropic at all in local mode — this is not just a sign-in bug.

## Fix

New `app/src-tauri/src/shell_env.rs`, applied at both spawn sites (`claude_login` helper + engine sidecar):

1. Set `CLAUDE_CODE_GIT_BASH_PATH` when a Git for Windows `bash.exe` exists at a standard machine/user install location. An inherited valid override is respected. Deliberately no PATH scan: `System32\bash.exe` is WSL and would wedge the CLI.
2. Append the built-in PowerShell 5.1 dir (+ `System32`) to the child PATH when missing, so the CLI's `powershell` fallback can never miss.
3. Spawn the login helper with `CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP`, mirroring the engine sidecar spawn.

Inert on non-Windows.

## Testing

- `cargo test` (app/src-tauri): 166 passed, incl. new unit tests for the PATH-repair logic (pure string fn, testable cross-platform).
- `cargo check --target x86_64-pc-windows-gnu`: clean (Windows-only code paths compile).
- Follow-ups tracked separately: Windows VM verification of the exit-129 theory, and the durable bundle-PortableGit stage.