### PR TITLE
feat(analytics): emit $ai_generation per model turn to light up the AI Usage dashboard

### DIFF
--- a/app/src/hooks/use-analytics-subscriber.ts
+++ b/app/src/hooks/use-analytics-subscriber.ts
@@ -1,7 +1,65 @@
 import type { HoustonEvent } from "@houston-ai/core";
 import { useEffect, useRef } from "react";
+import { readAgentModelOverrides } from "../lib/agent-model-overrides";
+import { buildAiGenerationProps } from "../lib/ai-generation";
 import { analytics, classifyAnalyticsError } from "../lib/analytics";
 import { subscribeHoustonEvents } from "../lib/events";
+import { tauriConfig } from "../lib/tauri";
+
+/** What the `final_result` feed frame carries (ui/chat FeedEntry). */
+interface FinalResultData {
+  cost_usd: number | null;
+  duration_ms: number | null;
+  usage?: {
+    context_tokens: number;
+    output_tokens: number;
+    cached_tokens: number;
+  } | null;
+}
+
+/**
+ * The agent's configured brain, cached briefly so one config read serves the
+ * turns of a sit-down instead of one read per turn. 60s keeps a model-picker
+ * change from being stale for long.
+ */
+const OVERRIDES_TTL_MS = 60_000;
+type CachedOverrides = {
+  at: number;
+  value: { providerOverride?: string; modelOverride?: string };
+};
+const overridesCache = new Map<string, CachedOverrides>();
+
+async function agentBrain(agentPath: string) {
+  const hit = overridesCache.get(agentPath);
+  if (hit && Date.now() - hit.at < OVERRIDES_TTL_MS) return hit.value;
+  const value = await readAgentModelOverrides(agentPath, tauriConfig.read);
+  overridesCache.set(agentPath, { at: Date.now(), value });
+  return value;
+}
+
+/**
+ * One `$ai_generation` per finished turn, feeding the AI Usage dashboard
+ * (cost / latency / tokens by model). Async because the model/provider come
+ * from the agent config; fire-and-forget like every analytics path — a failed
+ * capture must never touch the event pipeline.
+ */
+async function trackGeneration(
+  agentPath: string,
+  sessionKey: string,
+  data: FinalResultData,
+) {
+  const brain = await agentBrain(agentPath);
+  analytics.trackAiGeneration(
+    buildAiGenerationProps({
+      usage: data.usage,
+      costUsd: data.cost_usd,
+      durationMs: data.duration_ms,
+      provider: brain.providerOverride,
+      model: brain.modelOverride,
+      sessionKey,
+    }),
+  );
+}
 
 /**
  * Subscribes to the HoustonEvent firehose and fires analytics for events
@@ -27,6 +85,18 @@ export function useAnalyticsSubscriber() {
             if (repliesRef.current.has(key)) break;
             repliesRef.current.add(key);
             analytics.track("chat_message_received");
+          }
+          // Terminal frame of a model turn: exactly one per turn (NOT
+          // deduped like the activation signal above — every generation
+          // counts for the AI Usage dashboard).
+          if (p.data.item.feed_type === "final_result") {
+            trackGeneration(
+              p.data.agent_path,
+              p.data.session_key,
+              p.data.item.data as FinalResultData,
+            ).catch(() => {
+              // Analytics unavailable — never disturb the event pipeline.
+            });
           }
           break;
         }

--- a/app/src/lib/ai-generation.ts
+++ b/app/src/lib/ai-generation.ts
@@ -1,0 +1,60 @@
+/**
+ * Builds the PostHog LLM-observability `$ai_generation` payload from a turn's
+ * `final_result` feed item. Pure — no posthog import — so the mapping is unit
+ * testable and the privacy rule is structural: ONLY the metadata fields below
+ * can ever leave the app. Prompt/response content has no code path in.
+ *
+ * Property names follow PostHog's LLM-observability convention ($ai_*), which
+ * is what the "Houston / 7. AI Usage" dashboard tiles (cost, latency, error
+ * rate by model) are built on.
+ */
+
+export interface AiGenerationInput {
+  /** Normalized per-turn token usage, absent when the provider reports none. */
+  usage?: {
+    context_tokens: number;
+    output_tokens: number;
+    cached_tokens: number;
+  } | null;
+  /** Estimated turn cost, when the backend computed one. */
+  costUsd?: number | null;
+  /** Wall-clock turn duration. */
+  durationMs?: number | null;
+  /**
+   * The agent's configured brain. An approximation of the model that served
+   * THIS turn (a per-send override or a mid-session provider switch can
+   * diverge); omitted entirely when the config has no pins.
+   */
+  provider?: string;
+  model?: string;
+  /** Groups the turn's generation under its conversation. */
+  sessionKey: string;
+}
+
+export type AiGenerationProps = Record<string, string | number | boolean>;
+
+export function buildAiGenerationProps(
+  input: AiGenerationInput,
+): AiGenerationProps {
+  const props: AiGenerationProps = {
+    $ai_trace_id: input.sessionKey,
+    $ai_is_error: false,
+  };
+  if (input.provider) props.$ai_provider = input.provider;
+  if (input.model) props.$ai_model = input.model;
+  if (input.usage) {
+    // `context_tokens` is the full prompt of the last request
+    // (cache-inclusive) — what the provider bills as input.
+    props.$ai_input_tokens = input.usage.context_tokens;
+    props.$ai_output_tokens = input.usage.output_tokens;
+    props.$ai_cache_read_input_tokens = input.usage.cached_tokens;
+  }
+  if (typeof input.durationMs === "number" && input.durationMs >= 0) {
+    // PostHog expects seconds.
+    props.$ai_latency = Math.round(input.durationMs) / 1000;
+  }
+  if (typeof input.costUsd === "number" && input.costUsd >= 0) {
+    props.$ai_total_cost_usd = input.costUsd;
+  }
+  return props;
+}

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -467,6 +467,24 @@ export const analytics = {
   },
 
   /**
+   * PostHog LLM-observability event, one per finished model turn. Bypasses
+   * the AnalyticsEventName/ALLOWED_PROPS whitelist deliberately: `$ai_*`
+   * names are PostHog's canonical LLM schema (the AI Usage dashboard reads
+   * them), and the payload is built EXCLUSIVELY by `buildAiGenerationProps`
+   * (app/src/lib/ai-generation.ts), whose input type structurally excludes
+   * prompt/response content — only model, tokens, latency, and cost leave
+   * the app.
+   */
+  trackAiGeneration: (props: Record<string, string | number | boolean>) => {
+    if (!KEY) return;
+    try {
+      posthog.capture("$ai_generation", props);
+    } catch {
+      // Analytics unavailable
+    }
+  },
+
+  /**
    * Tie the signed-in user's Firebase identity to their PostHog person.
    * Call on sign-in. Does two complementary things:
    *

--- a/app/tests/ai-generation.test.ts
+++ b/app/tests/ai-generation.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildAiGenerationProps } from "../src/lib/ai-generation.ts";
+
+describe("buildAiGenerationProps", () => {
+  it("maps a full turn to the PostHog $ai_* schema", () => {
+    const props = buildAiGenerationProps({
+      usage: {
+        context_tokens: 12_000,
+        output_tokens: 850,
+        cached_tokens: 9_000,
+      },
+      costUsd: 0.042,
+      durationMs: 5_432,
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      sessionKey: "sess-1",
+    });
+    assert.deepEqual(props, {
+      $ai_trace_id: "sess-1",
+      $ai_is_error: false,
+      $ai_provider: "anthropic",
+      $ai_model: "claude-sonnet-5",
+      $ai_input_tokens: 12_000,
+      $ai_output_tokens: 850,
+      $ai_cache_read_input_tokens: 9_000,
+      $ai_latency: 5.432,
+      $ai_total_cost_usd: 0.042,
+    });
+  });
+
+  it("still emits a minimal event when the provider reports no usage", () => {
+    const props = buildAiGenerationProps({
+      usage: null,
+      costUsd: null,
+      durationMs: 1_000,
+      sessionKey: "sess-2",
+    });
+    assert.deepEqual(props, {
+      $ai_trace_id: "sess-2",
+      $ai_is_error: false,
+      $ai_latency: 1,
+    });
+  });
+
+  it("omits cost/latency when absent or negative, keeps zero cost", () => {
+    const props = buildAiGenerationProps({
+      usage: { context_tokens: 1, output_tokens: 2, cached_tokens: 0 },
+      costUsd: 0,
+      durationMs: -5,
+      sessionKey: "sess-3",
+    });
+    assert.equal(props.$ai_total_cost_usd, 0);
+    assert.equal("$ai_latency" in props, false);
+  });
+
+  it("never carries prompt or response content keys", () => {
+    const props = buildAiGenerationProps({
+      usage: { context_tokens: 10, output_tokens: 5, cached_tokens: 0 },
+      costUsd: 0.01,
+      durationMs: 100,
+      provider: "openai",
+      model: "gpt-5.5",
+      sessionKey: "sess-4",
+    });
+    for (const key of Object.keys(props)) {
+      assert.equal(key.startsWith("$ai_"), true, `unexpected key ${key}`);
+    }
+    assert.equal("$ai_input" in props, false);
+    assert.equal("$ai_output_choices" in props, false);
+  });
+});


### PR DESCRIPTION
## Why

The PostHog **AI Usage** dashboard (cost / latency / tokens / error rate by model) has been empty since May: its 9 tiles read PostHog LLM-observability events (`$ai_generation`) that nothing in Houston emitted. The per-turn data already exists - the `final_result` feed frame carries `TokenUsage`, `cost_usd` and `duration_ms` (metered since #926) - it just never left the app.

## What

- **`app/src/lib/ai-generation.ts`** - pure builder mapping a turn to the canonical `$ai_*` props. **Privacy is structural**: the input type has no field for prompt/response content; only model, tokens, latency and cost can ever leave the app.
- **`analytics.trackAiGeneration`** - capture path for the `$ai_*` schema. Deliberately outside the `AnalyticsEventName`/`ALLOWED_PROPS` whitelist (documented in code): these are PostHog canonical LLM props and the payload is built exclusively by the whitelisting builder above.
- **`use-analytics-subscriber`** - one `$ai_generation` per `final_result` (every turn; deliberately NOT deduped like the activation signal). Model/provider come from the agent configured brain via `readAgentModelOverrides`, cached 60s per agent - an approximation when a per-send override or mid-session provider switch diverges, noted in code.

## Tests / checks

- `app/tests/ai-generation.test.ts` - 4 cases (full mapping, minimal event without usage, zero-cost kept / negative latency dropped, and a guard that no content key can appear). Passing via the node test runner.
- `pnpm tsgo --noEmit` exit 0 - Biome clean on touched files.

## After release

The AI Usage dashboard fills itself (its tiles are the standard PostHog LLM template). Ships with the cloud line; legacy 0.4.x stays as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)