### PR TITLE
fix(providers): verify Google keys against the models list and surface typed connect errors

### DIFF
--- a/app/src/components/shell/provider-api-key-dialog.tsx
+++ b/app/src/components/shell/provider-api-key-dialog.tsx
@@ -10,6 +10,10 @@ import {
 import { ExternalLink, Eye, EyeOff } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  type ApiKeyConnectReason,
+  apiKeyConnectReason,
+} from "../../lib/api-key-connect-error";
 import { genericErrorDescription } from "../../lib/error-toast";
 import type { ProviderInfo } from "../../lib/providers";
 import { tauriProvider, tauriSystem } from "../../lib/tauri";
@@ -29,6 +33,18 @@ interface Props {
   provider: ProviderInfo | null;
   onClose: () => void;
 }
+
+/** Verification verdicts (from the engine's typed `reason`) → inline copy. */
+const REASON_COPY: Record<
+  ApiKeyConnectReason,
+  | "apiKey.errorInvalidKey"
+  | "apiKey.errorKeyRestricted"
+  | "apiKey.errorProviderUnavailable"
+> = {
+  invalid_key: "apiKey.errorInvalidKey",
+  key_restricted: "apiKey.errorKeyRestricted",
+  provider_unavailable: "apiKey.errorProviderUnavailable",
+};
 
 export function ProviderApiKeyDialog({ provider, onClose }: Props) {
   const { t } = useTranslation("providers");
@@ -65,7 +81,16 @@ export function ProviderApiKeyDialog({ provider, onClose }: Props) {
       // toasts. Close here so the dialog doesn't linger over the connected state.
       onClose();
     } catch (err) {
-      setError(genericErrorDescription("provider_api_key_submit", err));
+      // The engine sends a typed verdict with the failure (bad key, key
+      // blocked by its own settings, provider unreachable) — show the matching
+      // actionable copy; only a reason-less failure falls back to the generic
+      // line. Sentry capture already happened in the tauri call wrapper.
+      const reason = apiKeyConnectReason(err);
+      setError(
+        reason
+          ? t(REASON_COPY[reason], { name: provider.name })
+          : genericErrorDescription("provider_api_key_submit", err),
+      );
       setSubmitting(false);
     }
   };

--- a/app/src/lib/api-key-connect-error.ts
+++ b/app/src/lib/api-key-connect-error.ts
@@ -1,0 +1,42 @@
+/**
+ * The typed reason a pasted API key failed to connect, carried end-to-end from
+ * the runtime's live verification (`ApiKeyVerifyError.reason`) through the
+ * host's error body (`{error, reason}`) to the connect dialog, which maps it
+ * to actionable copy — a bad key, a key blocked by its own settings (Google:
+ * API not enabled on the project, referrer allowlist), or a provider outage
+ * where the key may be fine.
+ */
+export type ApiKeyConnectReason =
+  | "invalid_key"
+  | "key_restricted"
+  | "provider_unavailable";
+
+const REASONS: readonly string[] = [
+  "invalid_key",
+  "key_restricted",
+  "provider_unavailable",
+];
+
+/**
+ * Read the typed reason off a thrown connect error, or null when none rode
+ * along (older engines, transport failures). Duck-typed on the error's `body`
+ * because the two adapters throw different classes with different body shapes
+ * — the cloud control plane a `HoustonEngineError` (body: parsed JSON), the
+ * local runtime-client an `EngineError` (body: raw response text) — and this
+ * app-level helper must not import either.
+ */
+export function apiKeyConnectReason(err: unknown): ApiKeyConnectReason | null {
+  if (!err || typeof err !== "object" || !("body" in err)) return null;
+  let body = (err as { body?: unknown }).body;
+  if (typeof body === "string") {
+    try {
+      body = JSON.parse(body);
+    } catch {
+      return null;
+    }
+  }
+  const reason = (body as { reason?: unknown } | null)?.reason;
+  return typeof reason === "string" && REASONS.includes(reason)
+    ? (reason as ApiKeyConnectReason)
+    : null;
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1406,8 +1406,15 @@ export const tauriProvider = {
    * `newEngineActive()`.
    */
   setApiKey: (provider: string, apiKey: string) =>
-    call<void>("set_provider_api_key", () =>
-      getEngine().setProviderApiKey(provider, apiKey),
+    call<void>(
+      "set_provider_api_key",
+      () => getEngine().setProviderApiKey(provider, apiKey),
+      undefined,
+      // The connect dialog surfaces the failure inline with the engine's typed
+      // reason (bad key / restricted key / provider outage) — a red bug toast
+      // on top double-surfaces a user-fixable state. Capture stays on so
+      // verification failures keep reaching Sentry.
+      { toast: false },
     ),
   /**
    * Connect an OpenAI-compatible (local / BYO model) server: a base URL + model

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -66,7 +66,10 @@
     "hide": "Hide key",
     "save": "Connect",
     "saving": "Connecting...",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "errorInvalidKey": "{{name}} didn't accept this key. Check it and paste it again.",
+    "errorKeyRestricted": "This key is blocked by settings in your {{name}} account. Create a new key without restrictions using the button above, then paste it here.",
+    "errorProviderUnavailable": "We couldn't reach {{name}} to check your key, so nothing was saved. Please try again in a moment."
   },
   "copilot": {
     "title": "Connect GitHub Copilot",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -66,7 +66,10 @@
     "hide": "Ocultar clave",
     "save": "Conectar",
     "saving": "Conectando...",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "errorInvalidKey": "{{name}} no aceptó esta clave. Revísala y pégala de nuevo.",
+    "errorKeyRestricted": "Esta clave está bloqueada por la configuración de tu cuenta de {{name}}. Crea una clave nueva sin restricciones con el botón de arriba y pégala aquí.",
+    "errorProviderUnavailable": "No pudimos conectar con {{name}} para verificar tu clave, así que no se guardó nada. Inténtalo de nuevo en un momento."
   },
   "copilot": {
     "title": "Conectar GitHub Copilot",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -66,7 +66,10 @@
     "hide": "Ocultar chave",
     "save": "Conectar",
     "saving": "Conectando...",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "errorInvalidKey": "{{name}} não aceitou esta chave. Confira e cole de novo.",
+    "errorKeyRestricted": "Esta chave está bloqueada pelas configurações da sua conta {{name}}. Crie uma chave nova sem restrições usando o botão acima e cole aqui.",
+    "errorProviderUnavailable": "Não conseguimos acessar {{name}} para verificar sua chave, então nada foi salvo. Tente de novo em instantes."
   },
   "copilot": {
     "title": "Conectar GitHub Copilot",

--- a/app/tests/api-key-connect-error.test.ts
+++ b/app/tests/api-key-connect-error.test.ts
@@ -1,0 +1,54 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { apiKeyConnectReason } from "../src/lib/api-key-connect-error.ts";
+
+// The two adapter error shapes the connect dialog can catch: the cloud control
+// plane throws with a PARSED JSON body (HoustonEngineError), the local
+// runtime-client with the RAW response text (EngineError). Both must yield the
+// engine's typed reason; anything else must yield null (generic copy).
+
+const cloudError = (body: unknown) => Object.assign(new Error("x"), { body });
+const localError = (text: string) =>
+  Object.assign(new Error("x"), { body: text });
+
+describe("apiKeyConnectReason", () => {
+  it("reads the reason off a parsed cloud error body", () => {
+    strictEqual(
+      apiKeyConnectReason(
+        cloudError({ error: "blocked", reason: "key_restricted" }),
+      ),
+      "key_restricted",
+    );
+  });
+
+  it("reads the reason out of a raw local error body", () => {
+    strictEqual(
+      apiKeyConnectReason(
+        localError('{"error":"rejected","reason":"invalid_key"}'),
+      ),
+      "invalid_key",
+    );
+    strictEqual(
+      apiKeyConnectReason(
+        localError('{"error":"down","reason":"provider_unavailable"}'),
+      ),
+      "provider_unavailable",
+    );
+  });
+
+  it("yields null when no reason rode along", () => {
+    strictEqual(apiKeyConnectReason(cloudError({ error: "nope" })), null);
+    strictEqual(apiKeyConnectReason(localError('{"error":"nope"}')), null);
+  });
+
+  it("yields null for unknown reasons, non-JSON bodies, and non-errors", () => {
+    strictEqual(
+      apiKeyConnectReason(cloudError({ reason: "made_up_reason" })),
+      null,
+    );
+    strictEqual(apiKeyConnectReason(localError("Bad Gateway")), null);
+    strictEqual(apiKeyConnectReason(new Error("plain")), null);
+    strictEqual(apiKeyConnectReason(undefined), null);
+    strictEqual(apiKeyConnectReason("string error"), null);
+  });
+});

--- a/packages/host/src/channel/contract.test.ts
+++ b/packages/host/src/channel/contract.test.ts
@@ -4,7 +4,12 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { MemoryCredentialStore } from "../credentials/store";
 import type { Agent, Workspace } from "../domain/types";
 import { FakeLauncher } from "../launcher/fake";
-import type { ChannelCtx, RuntimeChannel, WorkspaceCredential } from "../ports";
+import {
+  ApiKeyRejectedError,
+  type ChannelCtx,
+  type RuntimeChannel,
+  type WorkspaceCredential,
+} from "../ports";
 import { forward } from "../proxy/route";
 import { ConnectManager } from "../turn/connect";
 import type { TurnDeps } from "../turn/deps";
@@ -187,6 +192,8 @@ let proxyConnected = false; // flips when connect() succeeds (export exposes a c
 let proxyCustomEndpointBody: unknown = null;
 /** Last body the fake runtime received on POST /auth/anthropic/oauth-credential. */
 let proxyClaudeOAuthBody: unknown = null;
+/** When set, the fake runtime rejects /auth/:provider/api-key with this reply. */
+let proxyApiKeyRejection: { status: number; body: unknown } | null = null;
 
 beforeAll(async () => {
   proxyRuntime = createServer((req, res) => {
@@ -237,7 +244,11 @@ beforeAll(async () => {
     }
     if (path === "/auth/scrub-refresh") return reply(200, { ok: true });
     // API-key connect pushes the pasted key into the standing runtime.
-    if (path.match(/^\/auth\/[^/]+\/api-key$/)) return reply(200, { ok: true });
+    if (path.match(/^\/auth\/[^/]+\/api-key$/)) {
+      return proxyApiKeyRejection
+        ? reply(proxyApiKeyRejection.status, proxyApiKeyRejection.body)
+        : reply(200, { ok: true });
+    }
     if (path === "/providers")
       return reply(200, [{ id: "openai-codex", configured: proxyConnected }]);
     if (path.match(/^\/conversations\/[^/]+\/messages$/))
@@ -254,6 +265,7 @@ afterAll(() => proxyRuntime.close());
 
 function makeProxyFixture(): ChannelFixture {
   proxyConnected = false; // each fixture starts disconnected
+  proxyApiKeyRejection = null;
   const credentials = new MemoryCredentialStore();
   const launcher = new FakeLauncher({ baseUrl: proxyRuntimeUrl, token: "sbx" });
   const proxy: RuntimeProxy = { forward };
@@ -346,6 +358,44 @@ function makeTurnFixture(): ChannelFixture {
 
 runRuntimeChannelContract("ProxyChannel", makeProxyFixture);
 runRuntimeChannelContract("TurnChannel", makeTurnFixture);
+
+// The runtime's live key verification can REFUSE a pasted key; the typed
+// `reason` on its 401 body must survive the proxy hop so the route (and from
+// there the connect dialog) can show actionable copy — and a refused key must
+// never land in the central store.
+describe("saveApiKeyCredential rejection (ProxyChannel)", () => {
+  test("forwards the runtime's message + typed reason, stores nothing", async () => {
+    const { channel, credentials } = makeProxyFixture();
+    proxyApiKeyRejection = {
+      status: 401,
+      body: {
+        error:
+          "this google API key is blocked by its own settings: enable the API",
+        reason: "key_restricted",
+      },
+    };
+    const err = await channel
+      .saveApiKeyCredential(ctx, "google", "AIza-restricted")
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiKeyRejectedError);
+    expect((err as ApiKeyRejectedError).reason).toBe("key_restricted");
+    expect((err as ApiKeyRejectedError).message).toContain(
+      "blocked by its own settings",
+    );
+    expect(await credentials.get(ws.id, "google")).toBeNull();
+  });
+
+  test("a reason-less rejection still surfaces the runtime's message", async () => {
+    const { channel } = makeProxyFixture();
+    proxyApiKeyRejection = { status: 401, body: { error: "nope" } };
+    const err = await channel
+      .saveApiKeyCredential(ctx, "openrouter", "sk-bad")
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiKeyRejectedError);
+    expect((err as ApiKeyRejectedError).reason).toBeUndefined();
+    expect((err as ApiKeyRejectedError).message).toBe("nope");
+  });
+});
 
 // saveCustomEndpoint is the ONE asymmetric channel op (not part of the shared
 // contract): the standing runtime is POSTed the endpoint live; the per-turn

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -1,14 +1,15 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ClaudeOAuthCredential, CustomEndpoint } from "@houston/protocol";
-import type {
-  CaptureResult,
-  ChannelCtx,
-  CredentialStore,
-  ForwardRequest,
-  RuntimeChannel,
-  RuntimeEndpoint,
-  RuntimeLauncher,
-  TurnPin,
+import {
+  ApiKeyRejectedError,
+  type CaptureResult,
+  type ChannelCtx,
+  type CredentialStore,
+  type ForwardRequest,
+  type RuntimeChannel,
+  type RuntimeEndpoint,
+  type RuntimeLauncher,
+  type TurnPin,
 } from "../ports";
 import { MAX_JSON_BYTES, readBody } from "../routes/read-body";
 import { errorCodeFrom, TurnFireError } from "./fire-error";
@@ -374,13 +375,16 @@ export class ProxyChannel implements RuntimeChannel {
       },
     );
     if (!res.ok) {
-      const detail = await res
-        .json()
-        .then((b) => (b as { error?: string }).error)
-        .catch(() => undefined);
-      throw new Error(
-        detail ??
+      const body = (await res.json().catch(() => undefined)) as
+        | { error?: string; reason?: string }
+        | undefined;
+      // The runtime's typed verification reason (invalid_key / key_restricted /
+      // provider_unavailable) must survive to the connect dialog's copy — keep
+      // it on the error so the route can put it back on the wire.
+      throw new ApiKeyRejectedError(
+        body?.error ??
           `the agent runtime did not accept the key (${res.status}) — try connecting again`,
+        body?.reason,
       );
     }
     await this.opts.credentials.put({

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -31,6 +31,24 @@ export class AgentNameConflictError extends Error {
   }
 }
 
+/**
+ * A pasted API key the runtime's live verification refused
+ * (`saveApiKeyCredential`). `reason` is the runtime's typed verdict
+ * (`ApiKeyVerifyReason`: invalid_key / key_restricted / provider_unavailable),
+ * forwarded on the route's error body so the connect dialog can show
+ * actionable copy instead of a generic failure; undefined when the runtime
+ * predates typed reasons.
+ */
+export class ApiKeyRejectedError extends Error {
+  constructor(
+    message: string,
+    public readonly reason?: string,
+  ) {
+    super(message);
+    this.name = "ApiKeyRejectedError";
+  }
+}
+
 /** Persistence for workspaces + agents. Impls: MemoryWorkspaceStore, PgWorkspaceStore. */
 export interface WorkspaceStore {
   /** The user's personal workspace, creating it on first access (lazy provisioning). */

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -12,7 +12,11 @@ import {
 } from "../auth/acting";
 import { checkPublicHttpsEndpoint } from "../custom-endpoint-validation";
 import type { Agent, UserId, Workspace } from "../domain/types";
-import { AgentNameConflictError, type RuntimeChannel } from "../ports";
+import {
+  AgentNameConflictError,
+  ApiKeyRejectedError,
+  type RuntimeChannel,
+} from "../ports";
 import { isApiKeyProvider } from "../providers";
 import { handleAttachments } from "../turn/attachments";
 import { handleFiles } from "../turn/files";
@@ -435,8 +439,13 @@ export async function handleAgents(
       );
       json(res, 200, { ok: true, provider });
     } catch (err) {
+      // Forward the runtime's typed verification reason so the connect
+      // dialog can show actionable copy (bad key vs restricted key vs outage).
       json(res, 502, {
         error: err instanceof Error ? err.message : String(err),
+        ...(err instanceof ApiKeyRejectedError && err.reason
+          ? { reason: err.reason }
+          : {}),
       });
     }
     return true;

--- a/packages/host/src/routes/setup-runtime.ts
+++ b/packages/host/src/routes/setup-runtime.ts
@@ -1,7 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { parseClaudeOAuthEnvelope } from "@houston/protocol";
 import type { Agent, UserId, WorkspaceRuntime } from "../domain/types";
-import type { RuntimeChannel, WorkspaceStore } from "../ports";
+import {
+  ApiKeyRejectedError,
+  type RuntimeChannel,
+  type WorkspaceStore,
+} from "../ports";
 import { json, readJson } from "./http";
 
 /**
@@ -110,8 +114,19 @@ export async function handleSetupRuntime(
       json(res, 400, { error: "missing 'apiKey'" });
       return true;
     }
-    await channel.saveApiKeyCredential(ctx, provider, apiKey);
-    json(res, 200, { ok: true });
+    try {
+      await channel.saveApiKeyCredential(ctx, provider, apiKey);
+      json(res, 200, { ok: true });
+    } catch (err) {
+      // Mirror the per-agent route: the runtime's typed verification reason
+      // rides the body so the connect dialog can show actionable copy.
+      json(res, 502, {
+        error: err instanceof Error ? err.message : String(err),
+        ...(err instanceof ApiKeyRejectedError && err.reason
+          ? { reason: err.reason }
+          : {}),
+      });
+    }
     return true;
   }
 

--- a/packages/runtime/src/auth/verify-api-key.test.ts
+++ b/packages/runtime/src/auth/verify-api-key.test.ts
@@ -1,10 +1,13 @@
-import { beforeEach, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
 /**
  * verify-api-key.ts decision table: which provider outcomes prove a pasted key
- * authenticates (store it) vs reject it (never store). The live request is
- * mocked at the pi-ai `completeSimple` seam; classification runs the REAL
- * `classifyProviderError`, so these tests pin the taxonomy wiring too.
+ * authenticates (store it) vs reject it (never store), and the typed `reason`
+ * each rejection carries to the connect dialog. The generic path is mocked at
+ * the pi-ai `completeSimple` seam; classification runs the REAL
+ * `classifyProviderError`, so these tests pin the taxonomy wiring too. Google
+ * rides the models-LIST probe instead (a completion probe let Google's
+ * "high demand" 503 fail a perfectly good key), mocked at global fetch.
  */
 
 const completeSimple = vi.fn();
@@ -14,10 +17,18 @@ vi.mock("@earendil-works/pi-ai/compat", async (importOriginal) => ({
 }));
 vi.mock("../ai/providers", () => ({
   modelFor: () => "test-model",
-  safeGetModel: () => ({ id: "test-model", provider: "openrouter" }),
+  safeGetModel: (provider: string) =>
+    provider === "google"
+      ? {
+          id: "gemini-3.5-flash",
+          provider: "google",
+          api: "google-generative-ai",
+          baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        }
+      : { id: "test-model", provider: "openrouter" },
 }));
 
-import { verifyApiKey } from "./verify-api-key";
+import { ApiKeyVerifyError, verifyApiKey } from "./verify-api-key";
 
 const reply = (over: Record<string, unknown>) => ({
   role: "assistant",
@@ -27,7 +38,14 @@ const reply = (over: Record<string, unknown>) => ({
   ...over,
 });
 
-beforeEach(() => completeSimple.mockReset());
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  completeSimple.mockReset();
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+afterEach(() => vi.unstubAllGlobals());
 
 test("a successful completion verifies the key", async () => {
   completeSimple.mockResolvedValue(reply({}));
@@ -53,9 +71,11 @@ test("a 401 rejection reads as an invalid key", async () => {
         '401 {"error":{"message":"invalid api key","code":"invalid_api_key"}}',
     }),
   );
-  await expect(verifyApiKey("openrouter", "aa")).rejects.toThrow(
-    /rejected this API key/,
-  );
+  await expect(verifyApiKey("openrouter", "aa")).rejects.toMatchObject({
+    name: "ApiKeyVerifyError",
+    reason: "invalid_key",
+    message: expect.stringMatching(/rejected this API key/),
+  });
 });
 
 test("a rate limit proves the key authenticated — verified", async () => {
@@ -79,11 +99,100 @@ test("insufficient balance proves the key authenticated — verified", async () 
   await expect(verifyApiKey("opencode", "sk-broke")).resolves.toBeUndefined();
 });
 
-test("a network failure rejects without storing", async () => {
+test("a network failure rejects without storing, as provider_unavailable", async () => {
   completeSimple.mockResolvedValue(
     reply({ stopReason: "error", errorMessage: "fetch failed" }),
   );
-  await expect(verifyApiKey("openrouter", "sk-any")).rejects.toThrow(
-    /could not verify/,
+  await expect(verifyApiKey("openrouter", "sk-any")).rejects.toMatchObject({
+    reason: "provider_unavailable",
+    message: expect.stringMatching(/could not verify/),
+  });
+});
+
+// --- Google: verified against the models-list endpoint, never a completion ---
+
+const googleRes = (status: number, message?: string) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  text: () =>
+    Promise.resolve(
+      message ? JSON.stringify({ error: { code: status, message } }) : "{}",
+    ),
+});
+
+test("google: a 200 from the models list verifies — no completion is sent", async () => {
+  fetchMock.mockResolvedValue(googleRes(200));
+  await expect(verifyApiKey("google", "AIza-good")).resolves.toBeUndefined();
+  expect(completeSimple).not.toHaveBeenCalled();
+  const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+  expect(url).toBe(
+    "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1",
   );
+  // The key rides a header (never the query string, which lands in logs).
+  expect((init.headers as Record<string, string>)["x-goog-api-key"]).toBe(
+    "AIza-good",
+  );
+});
+
+test("google: 400 API_KEY_INVALID rejects as invalid_key", async () => {
+  fetchMock.mockResolvedValue(
+    googleRes(400, "API key not valid. Please pass a valid API key."),
+  );
+  await expect(verifyApiKey("google", "AIza-bad")).rejects.toMatchObject({
+    reason: "invalid_key",
+    message: expect.stringMatching(/rejected this API key.*API key not valid/),
+  });
+});
+
+test("google: 403 API-disabled-on-project rejects as key_restricted with Google's remedy", async () => {
+  const detail =
+    "Gemini API has not been used in project 444578952321 before or it is disabled.";
+  fetchMock.mockResolvedValue(googleRes(403, detail));
+  const err = await verifyApiKey("google", "AIza-noapi").catch((e) => e);
+  expect(err).toBeInstanceOf(ApiKeyVerifyError);
+  expect(err.reason).toBe("key_restricted");
+  expect(err.message).toContain(detail);
+});
+
+test("google: 403 referrer-blocked rejects as key_restricted", async () => {
+  fetchMock.mockResolvedValue(
+    googleRes(403, "Requests from referer <empty> are blocked."),
+  );
+  await expect(verifyApiKey("google", "AIza-ref")).rejects.toMatchObject({
+    reason: "key_restricted",
+  });
+});
+
+test("google: 429 proves the key authenticated — verified", async () => {
+  fetchMock.mockResolvedValue(googleRes(429, "Resource has been exhausted"));
+  await expect(verifyApiKey("google", "AIza-busy")).resolves.toBeUndefined();
+});
+
+test("google: a 503 leaves no verdict — provider_unavailable, key not saved", async () => {
+  fetchMock.mockResolvedValue(
+    googleRes(503, "This model is currently experiencing high demand."),
+  );
+  await expect(verifyApiKey("google", "AIza-maybe")).rejects.toMatchObject({
+    reason: "provider_unavailable",
+    message: expect.stringMatching(/could not verify.*high demand/),
+  });
+});
+
+test("google: a network failure rejects as provider_unavailable", async () => {
+  fetchMock.mockRejectedValue(new Error("fetch failed"));
+  await expect(verifyApiKey("google", "AIza-any")).rejects.toMatchObject({
+    reason: "provider_unavailable",
+  });
+});
+
+test("google: a non-JSON error body still surfaces, with the raw text", async () => {
+  fetchMock.mockResolvedValue({
+    ok: false,
+    status: 502,
+    text: () => Promise.resolve("Bad Gateway"),
+  });
+  await expect(verifyApiKey("google", "AIza-any")).rejects.toMatchObject({
+    reason: "provider_unavailable",
+    message: expect.stringMatching(/Bad Gateway/),
+  });
 });

--- a/packages/runtime/src/auth/verify-api-key.ts
+++ b/packages/runtime/src/auth/verify-api-key.ts
@@ -7,7 +7,8 @@ import { modelFor, safeGetModel } from "../ai/providers";
  * pasted string — even "aa" — used to read "connected" and only fail on the
  * first chat turn). One 1-token completion against the model a chat would use,
  * with the CANDIDATE key passed per-request (`StreamOptions.apiKey`) so nothing
- * touches auth.json until the provider accepts it.
+ * touches auth.json until the provider accepts it. Google is the exception —
+ * see `verifyGoogleApiKey`.
  *
  * Accept/reject is decided on the shared `ProviderError` taxonomy:
  *  - the completion succeeds → verified;
@@ -29,6 +30,32 @@ const PROVES_AUTH = new Set([
   "context_overflow",
 ]);
 
+/**
+ * Why a key failed verification, carried on the wire (`/auth/:provider/api-key`
+ * 401 body `reason`) so the connect dialog can show actionable copy instead of
+ * a generic failure:
+ *  - `invalid_key` — the provider rejected the credential itself; re-paste.
+ *  - `key_restricted` — the key authenticates but its OWN settings block
+ *    Houston (Google: the Gemini API is not enabled on the key's Cloud
+ *    project, or a referrer/IP allowlist a server-side call can never
+ *    satisfy); the fix is a new unrestricted key, not re-pasting this one.
+ *  - `provider_unavailable` — no verdict (5xx / network / timeout); retry.
+ */
+export type ApiKeyVerifyReason =
+  | "invalid_key"
+  | "key_restricted"
+  | "provider_unavailable";
+
+export class ApiKeyVerifyError extends Error {
+  constructor(
+    message: string,
+    public readonly reason: ApiKeyVerifyReason,
+  ) {
+    super(message);
+    this.name = "ApiKeyVerifyError";
+  }
+}
+
 export async function verifyApiKey(
   providerId: string,
   key: string,
@@ -36,6 +63,11 @@ export async function verifyApiKey(
   const model = safeGetModel(providerId, modelFor(providerId), false);
   if (!model)
     throw new Error(`${providerId} offers no model to verify the key against`);
+
+  if (model.api === "google-generative-ai" && model.baseUrl) {
+    await verifyGoogleApiKey(providerId, model.baseUrl, key);
+    return;
+  }
 
   let message: string;
   try {
@@ -64,12 +96,72 @@ export async function verifyApiKey(
     message,
   });
   if (PROVES_AUTH.has(classified.kind)) return;
-  if (classified.kind === "unauthenticated") {
-    throw new Error(
-      `${providerId} rejected this API key — check the key and paste it again (${message})`,
+  if (classified.kind === "unauthenticated")
+    throw rejected(providerId, message);
+  throw noVerdict(providerId, message);
+}
+
+/**
+ * Google keys are verified against the cheap models-LIST endpoint instead of a
+ * completion. A completion probe hits a real model, so Google's "high demand"
+ * 503 used to fail verification of a perfectly good key; the list endpoint
+ * exercises ONLY the credential. It also keeps Google's actionable 403s
+ * distinguishable — API-not-enabled-on-the-project and referrer-restricted
+ * keys (the two failures Windows beta users actually hit) are `key_restricted`,
+ * never a generic "try again". The key rides a header, not the query string,
+ * so it can't leak into request logs.
+ */
+async function verifyGoogleApiKey(
+  providerId: string,
+  baseUrl: string,
+  key: string,
+): Promise<void> {
+  let res: Response;
+  try {
+    res = await fetch(`${baseUrl}/models?pageSize=1`, {
+      headers: { "x-goog-api-key": key },
+      signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
+    });
+  } catch (e) {
+    throw noVerdict(providerId, e instanceof Error ? e.message : String(e));
+  }
+  if (res.ok) return;
+  // Throttled = the key authenticated; a garbage key can't be rate-limited.
+  if (res.status === 429) return;
+  const message = await googleErrorMessage(res);
+  if (res.status === 400 || res.status === 401)
+    throw rejected(providerId, message);
+  if (res.status === 403) {
+    throw new ApiKeyVerifyError(
+      `this ${providerId} API key is blocked by its own settings: ${message}`,
+      "key_restricted",
     );
   }
-  throw new Error(
+  throw noVerdict(providerId, message);
+}
+
+/** Google's error body is `{error:{message,…}}`; fall back to raw text/status. */
+async function googleErrorMessage(res: Response): Promise<string> {
+  const text = await res.text().catch(() => "");
+  try {
+    const parsed = JSON.parse(text) as { error?: { message?: string } };
+    if (parsed.error?.message) return parsed.error.message;
+  } catch {
+    // Not JSON — surface the raw body below.
+  }
+  return text || `status ${res.status}`;
+}
+
+function rejected(providerId: string, message: string): ApiKeyVerifyError {
+  return new ApiKeyVerifyError(
+    `${providerId} rejected this API key — check the key and paste it again (${message})`,
+    "invalid_key",
+  );
+}
+
+function noVerdict(providerId: string, message: string): ApiKeyVerifyError {
+  return new ApiKeyVerifyError(
     `could not verify the ${providerId} API key: ${message} — the key was not saved; try again`,
+    "provider_unavailable",
   );
 }

--- a/packages/runtime/src/transport/provider-routes.ts
+++ b/packages/runtime/src/transport/provider-routes.ts
@@ -18,7 +18,7 @@ import {
   startLogin,
 } from "../auth/login";
 import { scrubRefreshTokens, syncServedCredentialSafe } from "../auth/serve";
-import { verifyApiKey } from "../auth/verify-api-key";
+import { ApiKeyVerifyError, verifyApiKey } from "../auth/verify-api-key";
 import { refreshAnthropicCredential } from "../backends/claude/credential-status";
 import { writeClaudeOAuthCredentialFile } from "../backends/claude/credentials-file";
 import { claudeLoginConfigDir } from "../backends/claude/paths";
@@ -186,7 +186,12 @@ async function handleApiKey(ctx: RouteContext, provider: string) {
   try {
     await verifyApiKey(provider, key);
   } catch (e) {
-    json(ctx.res, 401, { error: e instanceof Error ? e.message : String(e) });
+    // `reason` rides the body to the connect dialog, which maps it to
+    // actionable copy (bad key vs restricted key vs provider outage).
+    json(ctx.res, 401, {
+      error: e instanceof Error ? e.message : String(e),
+      ...(e instanceof ApiKeyVerifyError ? { reason: e.reason } : {}),
+    });
     return;
   }
   setApiKey(provider, key);


### PR DESCRIPTION
## Problem

Users connecting Google Gemini (all on Windows, v0.5.20 — Sentry issue 7623765440, 12 events / 4 users in 24h) hit three distinct Google-side failures, and every one surfaced as the generic **"Something unexpected went wrong. Please try again."** with no way to tell a fixable key problem from an outage:

1. **403** "Gemini API has not been used in project N before or it is disabled" — key created in a Cloud project without the Generative Language API enabled (Cloud Console key instead of an AI Studio key).
2. **403** "Requests from referer \<empty\> are blocked" — a referrer-restricted (website) key; Houston's server-side verification call sends no Referer, so it can never pass.
3. **503** "This model is currently experiencing high demand" — verification sent a 1-token completion to `gemini-3.5-flash`, so a **valid** key failed to connect whenever the model was overloaded.

The runtime produced specific messages and the host forwarded them, but the connect dialog's catch discarded them (`genericErrorDescription`), and users just retried in a loop.

## Fix

**Runtime — credential-only verification for Google** (`packages/runtime/src/auth/verify-api-key.ts`)
Google keys (any `google-generative-ai` model) are verified with `GET {baseUrl}/models?pageSize=1` instead of a completion, key in the `x-goog-api-key` header (never the query string, which lands in request logs). This exercises only the credential: the high-demand 503 class disappears, invalid keys are a clean 400, 429 proves auth, and the two actionable 403s stay distinguishable. Every other provider keeps the generic completion probe unchanged.

**Typed reasons end to end**
Verification failures now throw `ApiKeyVerifyError` with a `reason` (`invalid_key` / `key_restricted` / `provider_unavailable`) that rides the runtime's 401 body → host proxy (`ApiKeyRejectedError` in `ports.ts`) → the per-agent and setup-runtime connect routes → the dialog. The local desktop path passes the runtime body through untouched, so both deployments carry it.

**Dialog — actionable copy instead of the generic line** (`provider-api-key-dialog.tsx`)
The reason maps to localized copy (en/es/pt): bad key → re-paste; restricted key → create a new unrestricted key via the existing "Get your API key" button (AI Studio keys auto-enable the API); provider unreachable → key not saved, retry. Reason-less failures keep the generic fallback. The redundant red bug toast on this flow is suppressed (`toast: false`) since the dialog surfaces the failure inline — Sentry capture stays on.

## Tests

- Runtime: Google decision table (200 / 400 / 403 API-disabled / 403 referrer / 429-proves-auth / 503 / network failure / non-JSON body), pinning that no completion is sent and the key rides the header; generic-path reasons.
- Host: proxy forwards message + typed reason on rejection and never stores a refused key centrally; reason-less rejections still surface.
- App: unit tests for the reason extractor over both adapter error shapes (parsed cloud body, raw local text).
- Gates: runtime 720 ✓, host 1007 ✓, app `tsgo` + `check-locales` ✓, web/ui typechecks ✓, `check:boundaries` ✓, Biome ✓.