### PR TITLE
fix(providers): friendly toast for a GitHub account without Copilot access

### DIFF
--- a/app/src/lib/provider-login-error.ts
+++ b/app/src/lib/provider-login-error.ts
@@ -11,6 +11,7 @@
 
 import {
   PROVIDER_CONNECT_TIMEOUT_ERROR,
+  PROVIDER_COPILOT_NO_ACCESS_ERROR,
   PROVIDER_LOGIN_PORT_BUSY_ERROR,
   PROVIDER_LOGIN_TIMEOUT_ERROR,
 } from "@houston-ai/core";
@@ -41,5 +42,7 @@ export function localizedProviderLoginError(error: string): string {
     return i18n.t("providers:toast.loginTimedOut");
   if (error === PROVIDER_LOGIN_PORT_BUSY_ERROR)
     return i18n.t("providers:toast.signInPortBusy");
+  if (error === PROVIDER_COPILOT_NO_ACCESS_ERROR)
+    return i18n.t("providers:toast.copilotNoAccess");
   return error;
 }

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -19,6 +19,7 @@
     "connectTimedOut": "The connection didn't complete in time. Please try connecting again.",
     "loginTimedOut": "The sign-in didn't complete in time. Please try again.",
     "signInPortBusy": "Another app on this computer is using the sign-in port. Close other AI coding tools and try again.",
+    "copilotNoAccess": "Your GitHub account doesn't have Copilot access yet. Enable GitHub Copilot on github.com (the Free plan works), then try connecting again.",
     "signOutFailed": "Couldn't sign out of {{provider}}",
     "signInSucceeded": "Signed in to {{provider}}",
     "cancelFailed": "Couldn't cancel {{provider}} sign-in",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -19,6 +19,7 @@
     "connectTimedOut": "La conexión no se completó a tiempo. Intenta conectarte de nuevo.",
     "loginTimedOut": "El inicio de sesión no se completó a tiempo. Intenta de nuevo.",
     "signInPortBusy": "Otra aplicación de este computador está usando el puerto de inicio de sesión. Cierra otras herramientas de IA e intenta de nuevo.",
+    "copilotNoAccess": "Tu cuenta de GitHub todavía no tiene acceso a Copilot. Activa GitHub Copilot en github.com (el plan gratuito sirve) y vuelve a intentar la conexión.",
     "signOutFailed": "No se pudo cerrar sesión de {{provider}}",
     "signInSucceeded": "Sesión iniciada en {{provider}}",
     "cancelFailed": "No se pudo cancelar el inicio de sesión de {{provider}}",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -19,6 +19,7 @@
     "connectTimedOut": "A conexão não foi concluída a tempo. Tente conectar de novo.",
     "loginTimedOut": "O login não foi concluído a tempo. Tente de novo.",
     "signInPortBusy": "Outro aplicativo deste computador está usando a porta de login. Feche outras ferramentas de IA e tente de novo.",
+    "copilotNoAccess": "Sua conta do GitHub ainda não tem acesso ao Copilot. Ative o GitHub Copilot em github.com (o plano gratuito funciona) e tente conectar de novo.",
     "signOutFailed": "Não foi possível sair de {{provider}}",
     "signInSucceeded": "Conectado a {{provider}}",
     "cancelFailed": "Não foi possível cancelar o login de {{provider}}",

--- a/app/tests/provider-login-error-sentinels.test.ts
+++ b/app/tests/provider-login-error-sentinels.test.ts
@@ -6,6 +6,7 @@ import { describe, it } from "node:test";
 // barrel's extension-less sibling imports don't resolve under bare node:test.
 import {
   PROVIDER_CONNECT_TIMEOUT_ERROR,
+  PROVIDER_COPILOT_NO_ACCESS_ERROR,
   PROVIDER_LOGIN_PORT_BUSY_ERROR,
   PROVIDER_LOGIN_TIMEOUT_ERROR,
 } from "../../ui/core/src/provider-login.ts";
@@ -20,6 +21,7 @@ const SENTINEL_TO_KEY: Record<string, string> = {
   [PROVIDER_CONNECT_TIMEOUT_ERROR]: "connectTimedOut",
   [PROVIDER_LOGIN_TIMEOUT_ERROR]: "loginTimedOut",
   [PROVIDER_LOGIN_PORT_BUSY_ERROR]: "signInPortBusy",
+  [PROVIDER_COPILOT_NO_ACCESS_ERROR]: "copilotNoAccess",
 };
 
 describe("provider login error sentinels", () => {
@@ -27,6 +29,20 @@ describe("provider login error sentinels", () => {
     join(import.meta.dirname, "../src/lib/provider-login-error.ts"),
     "utf8",
   );
+
+  it("the runtime mirrors the Copilot no-access sentinel by value", () => {
+    // The runtime is frontend-agnostic and cannot import @houston-ai/core, so
+    // COPILOT_NO_ACCESS_ERROR (packages/runtime/src/auth/login.ts) duplicates
+    // this sentinel by value; drift breaks the toast's value-match silently.
+    const runtime = readFileSync(
+      join(import.meta.dirname, "../../packages/runtime/src/auth/login.ts"),
+      "utf8",
+    );
+    ok(
+      runtime.includes(PROVIDER_COPILOT_NO_ACCESS_ERROR),
+      "packages/runtime/src/auth/login.ts must contain the exact sentinel string",
+    );
+  });
 
   for (const [sentinel, key] of Object.entries(SENTINEL_TO_KEY)) {
     it(`maps the "${key}" sentinel in provider-login-error.ts`, () => {

--- a/packages/runtime/src/auth/login.test.ts
+++ b/packages/runtime/src/auth/login.test.ts
@@ -10,12 +10,14 @@ import {
 } from "./codex-port-preflight";
 import {
   autoPromptAnswer,
+  COPILOT_NO_ACCESS_ERROR,
   cancelLogin,
   codexLoginMethod,
   getAuthStatus,
   LOCAL_PLACEHOLDER_KEY,
   LOGIN_TIMEOUT_ERROR,
   LOGIN_TIMEOUT_MS,
+  loginFailureMessage,
   setApiKey,
   startLogin,
 } from "./login";
@@ -274,6 +276,54 @@ test("reusing an in-flight login re-arms the abandonment clock", async () => {
     expect(row?.login?.error).toBe(LOGIN_TIMEOUT_ERROR);
   } finally {
     vi.useRealTimers();
+  }
+});
+
+// GitHub's real 403 for an account with no Copilot subscription (device flow
+// SUCCEEDED; the copilot_internal token exchange refused). Synthetic handle —
+// the body always carries the signed-in user's, which must never reach a toast.
+const NO_ACCESS_403 =
+  '403 Forbidden: {"error_details":{"message":"No access to GitHub Copilot found. You are currently logged in as octocat.","notification_id":"no_copilot_access","title":"Sign up for GitHub Copilot","url":"https://github.com/github-copilot/signup?editor={EDITOR}"},"message":"Resource not accessible by integration","can_signup_for_limited":true}';
+
+test("loginFailureMessage: copilot no_copilot_access collapses to the friendly sentinel, everything else passes through", () => {
+  expect(loginFailureMessage("github-copilot", NO_ACCESS_403)).toBe(
+    COPILOT_NO_ACCESS_ERROR,
+  );
+  // An unrelated Copilot failure keeps its real message (beta policy).
+  expect(
+    loginFailureMessage("github-copilot", "Device flow failed: expired_token"),
+  ).toBe("Device flow failed: expired_token");
+  // Another provider never matches, even with a lookalike body.
+  expect(loginFailureMessage("openai-codex", NO_ACCESS_403)).toBe(
+    NO_ACCESS_403,
+  );
+});
+
+test("github-copilot: a no-Copilot-subscription 403 surfaces the sentinel in auth status, never the raw GitHub body", async () => {
+  // The user authorized the device flow, then GitHub's token exchange answered
+  // 403 no_copilot_access. The raw JSON (with the user's GitHub handle) used to
+  // land verbatim in the failure toast; status must now carry the sentinel.
+  const piLogin = vi
+    .spyOn(authStorage, "login")
+    .mockImplementation((_provider, opts) => {
+      opts.onDeviceCode?.({
+        userCode: "ABCD-1234",
+        verificationUri: "https://github.com/login/device",
+      });
+      return Promise.reject(new Error(NO_ACCESS_403));
+    });
+  try {
+    const info = await startLogin("github-copilot", true);
+    expect(info.kind).toBe("device_code");
+    await new Promise((r) => setTimeout(r, 20));
+    const row = (await getAuthStatus()).providers.find(
+      (p) => p.provider === "github-copilot",
+    );
+    expect(row?.login?.status).toBe("error");
+    expect(row?.login?.error).toBe(COPILOT_NO_ACCESS_ERROR);
+  } finally {
+    piLogin.mockRestore();
+    cancelLogin("github-copilot");
   }
 });
 

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -74,6 +74,35 @@ export const LOGIN_TIMEOUT_MS = 10 * 60_000;
  */
 export const LOGIN_TIMEOUT_ERROR = "Login timed out";
 
+/**
+ * Stable sentinel for a GitHub account that finished the device flow but has
+ * no Copilot subscription: GitHub's token exchange answers 403
+ * `no_copilot_access` (with `can_signup_for_limited: true` — the user can
+ * enable Copilot Free themselves). The raw body is a JSON blob that includes
+ * the user's GitHub handle, so it must never reach the toast. Mirrors
+ * `PROVIDER_COPILOT_NO_ACCESS_ERROR` in `@houston-ai/core` (ui/core/src/
+ * provider-login.ts) — duplicated by value like LOGIN_TIMEOUT_ERROR above;
+ * keep the two in sync.
+ */
+export const COPILOT_NO_ACCESS_ERROR =
+  "Your GitHub account doesn't have Copilot access yet. Enable GitHub Copilot on github.com (the Free plan works), then try connecting again.";
+
+/**
+ * Collapse a provider login failure to a stable sentinel where the raw
+ * message is unfit for the failure toast; every other message passes through
+ * verbatim (beta policy: the real reason, never a generic swallow). The raw
+ * text is still logged by the caller for the bug-report log tail.
+ */
+export function loginFailureMessage(provider: ProviderId, raw: string): string {
+  if (
+    provider === "github-copilot" &&
+    (raw.includes("no_copilot_access") ||
+      raw.includes("No access to GitHub Copilot"))
+  )
+    return COPILOT_NO_ACCESS_ERROR;
+  return raw;
+}
+
 function clearLoginExpiry(state: LoginState): void {
   if (state.timer) clearTimeout(state.timer);
   state.timer = undefined;
@@ -322,8 +351,9 @@ export async function startLogin(
         return;
       }
       state.status = "error";
-      state.error = e instanceof Error ? e.message : String(e);
-      console.error(`[oauth:${provider}] failed:`, state.error);
+      const raw = e instanceof Error ? e.message : String(e);
+      state.error = loginFailureMessage(provider, raw);
+      console.error(`[oauth:${provider}] failed:`, raw);
     });
 
   return Promise.race([

--- a/ui/core/src/provider-login.ts
+++ b/ui/core/src/provider-login.ts
@@ -14,3 +14,10 @@ export const PROVIDER_CONNECT_TIMEOUT_ERROR =
  *  preflight), so the app can localize it like the timeouts above. */
 export const PROVIDER_LOGIN_PORT_BUSY_ERROR =
   "Another app on this computer is using the sign-in port. Close other AI coding tools and try again.";
+/** Substituted by the runtime when GitHub's Copilot token exchange answers
+ *  403 `no_copilot_access` after the device flow (an account with no Copilot
+ *  subscription; GitHub's raw body carries the user's handle and must never
+ *  reach the toast). Mirrors `COPILOT_NO_ACCESS_ERROR` in
+ *  packages/runtime/src/auth/login.ts — matched by value, keep in sync. */
+export const PROVIDER_COPILOT_NO_ACCESS_ERROR =
+  "Your GitHub account doesn't have Copilot access yet. Enable GitHub Copilot on github.com (the Free plan works), then try connecting again.";


### PR DESCRIPTION
## Problem

Users connecting GitHub Copilot from an account with **no Copilot subscription** got GitHub's raw 403 JSON dumped into the failure toast, including their signed-in GitHub handle:

> No se pudo abrir el inicio de sesión de GitHub Copilot 403 Forbidden: {"error_details":{"message":"No access to GitHub Copilot found. ...","notification_id":"no_copilot_access", ...}

The connect flow itself is healthy (verified live: the device-flow start accepts our client id and returns codes). The failure happens after the user authorizes, when GitHub's Copilot token exchange (`copilot_internal/v2/token`) answers `no_copilot_access` — the account has no Copilot plan. `can_signup_for_limited: true` in the body means the user can enable Copilot Free themselves and then connect fine. So the bug is purely how we surface it: raw JSON, personal data in a toast, and a misleading "couldn't open the sign-in" framing for a non-technical audience.

## Fix

Follows the existing sentinel pattern (port-busy / timeouts):

- **`packages/runtime/src/auth/login.ts`** — new `loginFailureMessage()` classifier: a `github-copilot` login failure matching `no_copilot_access` collapses to a stable `COPILOT_NO_ACCESS_ERROR` sentinel. The raw body still goes to the runtime log for bug reports; every other failure passes through verbatim (beta policy).
- **`ui/core/src/provider-login.ts`** — mirrored `PROVIDER_COPILOT_NO_ACCESS_ERROR` (the runtime is frontend-agnostic, so the value is duplicated like the login-timeout sentinel).
- **`app/src/lib/provider-login-error.ts` + `providers.json` (en/es/pt)** — value-matched to localized copy: enable GitHub Copilot on github.com (the Free plan works), then try connecting again.

## Tests

- Runtime: classifier unit test + an end-to-end `startLogin` test where the stubbed pi login rejects with GitHub's real 403 shape (synthetic handle) — auth status must carry the sentinel, never the raw body.
- App: sentinel contract test extended (mapping line + usable copy in all three locales, no em dashes), plus a drift guard asserting the runtime's mirrored sentinel stays byte-identical to core's.

Runtime vitest 18/18, app node:test 17/17, `check-locales`, full workspace typecheck, and Biome all green.