### PR TITLE
Force desktop updates (auto-install at launch, countdown mid-session)

### DIFF
--- a/app/src/components/onboarding/cloud-migration/wizard-frame.tsx
+++ b/app/src/components/onboarding/cloud-migration/wizard-frame.tsx
@@ -52,10 +52,6 @@ export function WizardFrame({
           </h1>
         </div>
         {body && (
-          // `text-base` is BOTH a font-size and a colour utility here
-          // (`--color-base` exists), so it is paired with a NAMED colour
-          // utility (`text-ink-muted`), which wins the colour while text-base
-          // keeps the 1rem size — the design-system-documented safe pattern.
           <p className="max-w-lg text-pretty text-base leading-relaxed text-ink-muted">
             {body}
           </p>

--- a/app/src/components/onboarding/first-run-screen.tsx
+++ b/app/src/components/onboarding/first-run-screen.tsx
@@ -6,7 +6,7 @@ import { isMac } from "../../lib/platform";
 /**
  * The shared full-screen layout for every first-run / migration surface (the
  * language + disclaimer gates, sign-in, onboarding, and the cloud-migration
- * wizard). A flat, calm page: the app's light-mode gutter grey (`bg-base`, the
+ * wizard). A flat, calm page: the app's light-mode gutter grey (`bg-gutter`, the
  * same tone the sidebar melts into) under white cards, no space photo, no glass.
  *
  * `data-theme="light"` is pinned so the first-run flow reads as a bright light
@@ -26,7 +26,7 @@ export function FirstRunScreen({
     <div
       data-theme="light"
       className={cn(
-        "relative flex h-screen flex-col bg-base text-ink",
+        "relative flex h-screen flex-col bg-gutter text-ink",
         className,
       )}
     >

--- a/app/src/components/shell/update-checker.tsx
+++ b/app/src/components/shell/update-checker.tsx
@@ -1,154 +1,60 @@
-import { AlertCircle, DownloadCloud, Loader2, RotateCw, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import houstonBlack from "../../assets/houston-black.svg";
-import houstonWhite from "../../assets/houston-icon-white.svg";
 import { useUpdateChecker } from "../../hooks/use-update-checker";
 import { isHostedGatewayEngine } from "../../lib/engine";
 import { selectUpdateNotes } from "../../lib/update-details";
-import { UpdateNotes } from "./update-notes";
+import { UpdateForced } from "./update-forced";
+import { useUpdateForcedPreview } from "./update-forced-preview";
 import { UpdateRequired } from "./update-required";
 
+/**
+ * Mounts the update policy and renders whichever blocking surface applies.
+ * Updates are forced — there is no dismissible "later" card:
+ *
+ * 1. Gateway hard floor tripped (hosted builds) → UpdateRequired. Scoped to
+ *    hosted-gateway builds: on a local/sidecar build every feature is served
+ *    by the co-located host (the gateway is never on the request path), so
+ *    even a stray floor signal must not lock the user out of local work.
+ * 2. An update was found → UpdateForced (auto-install at launch, countdown
+ *    mid-session).
+ */
 export function UpdateChecker() {
-  const { t, i18n } = useTranslation("shell");
+  const { i18n } = useTranslation("shell");
   const {
     status,
     required,
+    forcedMode,
     installAndRelaunch,
     relaunchInstalledApp,
-    dismiss,
   } = useUpdateChecker();
 
-  // Hard floor: the hosted gateway refused this build, so gateway calls are
-  // failing 426 — replace the dismissible card with the blocking screen.
-  // Scoped to hosted-gateway builds: on a local/sidecar build every feature is
-  // served by the co-located host (the gateway is never on the request path),
-  // so even a stray floor signal must not lock the user out of local work.
+  // Dev-only console harness (`__HOUSTON_UPDATE_PREVIEW__`); null in prod.
+  const preview = useUpdateForcedPreview();
+  if (preview) return <UpdateForced {...preview} />;
+
   if (required && isHostedGatewayEngine()) {
     return (
       <UpdateRequired
         required={required}
         status={status}
-        onInstall={installAndRelaunch}
-        onRelaunch={relaunchInstalledApp}
+        onInstall={() => void installAndRelaunch("user")}
+        onRelaunch={() => void relaunchInstalledApp()}
       />
     );
   }
 
-  if (status.state === "idle") return null;
+  if (status.state === "idle" || !forcedMode) return null;
 
-  const info = status.info;
   // The release ships en/es/pt notes in one updater string; pick the one for
   // the active UI language (which already honors the workspace locale override).
-  const notes = selectUpdateNotes(info.body, i18n.language);
-  const downloading = status.state === "downloading";
-  const ready = status.state === "ready";
-  const error = status.state === "error";
-  const relaunchOnly = ready || (error && status.phase === "relaunch");
-  const progress = downloading ? status.progress : null;
-
-  const message = (() => {
-    if (downloading) {
-      return progress === null
-        ? t("updateChecker.downloading")
-        : t("updateChecker.downloadingProgress", { progress });
-    }
-    if (ready) return t("updateChecker.ready");
-    if (error && status.phase === "install")
-      return t("updateChecker.errorInstall");
-    if (error && status.phase === "relaunch")
-      return t("updateChecker.errorRelaunch");
-    return t("updateChecker.availableDescription", {
-      currentVersion: info.currentVersion,
-      version: info.version,
-    });
-  })();
-
-  const onAction = relaunchOnly ? relaunchInstalledApp : installAndRelaunch;
-  const actionLabel = error
-    ? t("updateChecker.retryAction")
-    : relaunchOnly
-      ? t("updateChecker.relaunchAction")
-      : t("updateChecker.primaryAction");
+  const notes = selectUpdateNotes(status.info.body, i18n.language);
 
   return (
-    <aside
-      aria-label={t("updateChecker.cardLabel")}
-      aria-live={downloading ? "polite" : "assertive"}
-      className="fixed bottom-4 left-4 z-50 w-[360px] max-w-[calc(100vw-2rem)] rounded-2xl border border-line bg-card p-4 text-card-text shadow-[0_16px_60px_rgba(0,0,0,0.16)]"
-    >
-      <div className="flex items-start gap-3">
-        <div className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-input ring-1 ring-line">
-          <img
-            src={houstonBlack}
-            alt=""
-            aria-hidden="true"
-            className="houston-update-logo-light size-8 object-contain"
-          />
-          <img
-            src={houstonWhite}
-            alt=""
-            aria-hidden="true"
-            className="houston-update-logo-dark hidden size-8 object-contain"
-          />
-        </div>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <h2 className="text-base font-semibold leading-tight">
-              {t("updateChecker.title")}
-            </h2>
-            {error && <AlertCircle className="size-4 shrink-0 text-danger" />}
-          </div>
-          <p className="mt-1 text-sm leading-snug text-ink-muted">{message}</p>
-        </div>
-        {!downloading && !ready && (
-          <button
-            type="button"
-            onClick={dismiss}
-            aria-label={t("updateChecker.dismissAction")}
-            className="shrink-0 rounded-md p-1 text-ink-muted transition-colors hover:bg-hover hover:text-ink"
-          >
-            <X className="size-4" />
-          </button>
-        )}
-      </div>
-
-      <div className="mt-4 rounded-xl bg-chip-subtle p-3">
-        <p className="text-xs font-medium text-ink">
-          {t("updateChecker.detailsHeading")}
-        </p>
-        <div className="mt-1 max-h-28 overflow-y-auto break-words text-xs leading-relaxed text-ink-muted">
-          {notes ? (
-            <UpdateNotes notes={notes} />
-          ) : (
-            <p>{t("updateChecker.noDetails")}</p>
-          )}
-        </div>
-      </div>
-
-      {downloading && (
-        <div className="mt-4 h-1.5 overflow-hidden rounded-full bg-chip-subtle">
-          <div
-            className={`h-full rounded-full bg-action transition-[width] duration-200 ${progress === null ? "animate-pulse" : ""}`}
-            style={{ width: `${progress ?? 35}%` }}
-          />
-        </div>
-      )}
-
-      <button
-        type="button"
-        onClick={onAction}
-        disabled={downloading}
-        className="mt-4 flex h-10 w-full items-center justify-center gap-2 rounded-full bg-action px-4 text-sm font-medium text-action-text transition-opacity hover:opacity-90 disabled:cursor-default disabled:opacity-70"
-      >
-        {downloading ? (
-          <Loader2 className="size-4 animate-spin" />
-        ) : relaunchOnly ? (
-          <RotateCw className="size-4" />
-        ) : (
-          <DownloadCloud className="size-4" />
-        )}
-        {downloading ? t("updateChecker.installingAction") : actionLabel}
-      </button>
-    </aside>
+    <UpdateForced
+      mode={forcedMode}
+      status={status}
+      notes={notes}
+      onInstall={(source) => void installAndRelaunch(source)}
+      onRelaunch={() => void relaunchInstalledApp()}
+    />
   );
 }

--- a/app/src/components/shell/update-forced-preview.ts
+++ b/app/src/components/shell/update-forced-preview.ts
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  InstallSource,
+  UpdateInfo,
+  UpdateStatus,
+} from "../../hooks/use-update-machine";
+import type { ForcedUpdateMode } from "../../lib/update-force";
+
+/**
+ * DEV-ONLY preview harness for the forced-update dialog (the sentry-smoke
+ * idiom: gated on `import.meta.env.DEV`, so release builds tree-shake it).
+ * The real flow only runs in packaged PROD builds against the live release
+ * feed; this drives the same `UpdateForced` component with simulated status
+ * from the DevTools console:
+ *
+ *   __HOUSTON_UPDATE_PREVIEW__("countdown")  mid-session dialog, live timer
+ *   __HOUSTON_UPDATE_PREVIEW__("launch")     launch overlay, auto-"installs"
+ *   __HOUSTON_UPDATE_PREVIEW__("error")      failed-install state
+ *   __HOUSTON_UPDATE_PREVIEW__(null)         close the preview
+ *
+ * "Update now" / countdown expiry run a fake progress ramp to "ready";
+ * nothing downloads and the relaunch button just closes the preview.
+ * English-only by design — it's for us, never a real user.
+ */
+
+type PreviewStatus = Exclude<UpdateStatus, { state: "idle" }>;
+
+export interface ForcedUpdatePreview {
+  mode: ForcedUpdateMode;
+  status: PreviewStatus;
+  notes: string | null;
+  onInstall: (source: InstallSource) => void;
+  onRelaunch: () => void;
+}
+
+declare global {
+  interface Window {
+    __HOUSTON_UPDATE_PREVIEW__?: (
+      scene: ForcedUpdateMode | "error" | null,
+    ) => void;
+  }
+}
+
+const PREVIEW_INFO: UpdateInfo = {
+  currentVersion: "0.5.9",
+  version: "0.6.0",
+  body: null,
+};
+
+const PREVIEW_NOTES = [
+  "**Forced-update preview** (dev harness, nothing downloads).",
+  "- Progress is simulated; the auto-close after it is the stand-in for the real relaunch",
+  "- `__HOUSTON_UPDATE_PREVIEW__(null)` closes it",
+].join("\n");
+
+export function useUpdateForcedPreview(): ForcedUpdatePreview | null {
+  const [scene, setScene] = useState<{
+    mode: ForcedUpdateMode;
+    status: PreviewStatus;
+  } | null>(null);
+  const rampRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const delayRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const stopTimers = useCallback(() => {
+    if (rampRef.current) clearInterval(rampRef.current);
+    if (delayRef.current) clearTimeout(delayRef.current);
+    rampRef.current = null;
+    delayRef.current = null;
+  }, []);
+
+  const simulateInstall = useCallback(
+    (mode: ForcedUpdateMode) => {
+      stopTimers();
+      let progress = 0;
+      setScene({
+        mode,
+        status: { state: "downloading", info: PREVIEW_INFO, progress: null },
+      });
+      rampRef.current = setInterval(() => {
+        progress += 4;
+        if (progress >= 100) {
+          stopTimers();
+          setScene({ mode, status: { state: "ready", info: PREVIEW_INFO } });
+          // The real flow relaunches into the new version by itself right
+          // after the install; mirror that by closing the preview.
+          delayRef.current = setTimeout(() => setScene(null), 1500);
+          return;
+        }
+        setScene({
+          mode,
+          status: { state: "downloading", info: PREVIEW_INFO, progress },
+        });
+      }, 120);
+    },
+    [stopTimers],
+  );
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    window.__HOUSTON_UPDATE_PREVIEW__ = (scene) => {
+      stopTimers();
+      if (scene === null) {
+        setScene(null);
+        return;
+      }
+      if (scene === "error") {
+        setScene({
+          mode: "countdown",
+          status: { state: "error", info: PREVIEW_INFO, phase: "install" },
+        });
+        return;
+      }
+      setScene({
+        mode: scene,
+        status: {
+          state: "available",
+          info: PREVIEW_INFO,
+          origin: scene === "launch" ? "launch" : "poll",
+        },
+      });
+      // The real launch flow auto-installs; mirror it after a beat so the
+      // overlay's resting state is visible before progress takes over.
+      if (scene === "launch") {
+        delayRef.current = setTimeout(() => simulateInstall("launch"), 1500);
+      }
+    };
+    return () => {
+      stopTimers();
+      delete window.__HOUSTON_UPDATE_PREVIEW__;
+    };
+  }, [simulateInstall, stopTimers]);
+
+  if (!scene) return null;
+  return {
+    ...scene,
+    notes: PREVIEW_NOTES,
+    onInstall: () => simulateInstall(scene.mode),
+    onRelaunch: () => {
+      stopTimers();
+      setScene(null);
+    },
+  };
+}

--- a/app/src/components/shell/update-forced.tsx
+++ b/app/src/components/shell/update-forced.tsx
@@ -1,0 +1,194 @@
+import { AlertCircle, DownloadCloud, Loader2, RotateCw } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import houstonBlack from "../../assets/houston-black.svg";
+import houstonWhite from "../../assets/houston-icon-white.svg";
+import type {
+  InstallSource,
+  UpdateStatus,
+} from "../../hooks/use-update-checker";
+import {
+  FORCED_UPDATE_COUNTDOWN_SECONDS,
+  type ForcedUpdateMode,
+  tickCountdown,
+} from "../../lib/update-force";
+import { UpdateNotes } from "./update-notes";
+
+/**
+ * The forced-update dialog. Full-window and non-dismissible — updating is not
+ * optional, only its timing is:
+ *
+ * - `launch` mode: the update was found the moment the app opened. The
+ *   install is already running; this is a calm "upgrading Houston" overlay
+ *   that ends in a relaunch.
+ * - `countdown` mode: the update was found mid-session. A visible countdown
+ *   installs it automatically at zero; the one button installs it now. The
+ *   copy makes explicit that agents keep working and nothing is lost.
+ */
+export function UpdateForced({
+  mode,
+  status,
+  notes,
+  onInstall,
+  onRelaunch,
+}: {
+  mode: ForcedUpdateMode;
+  status: Exclude<UpdateStatus, { state: "idle" }>;
+  notes: string | null;
+  onInstall: (source: InstallSource) => void;
+  onRelaunch: () => void;
+}) {
+  const { t } = useTranslation("shell");
+
+  const downloading = status.state === "downloading";
+  const ready = status.state === "ready";
+  const error = status.state === "error";
+  const relaunchOnly = ready || (error && status.phase === "relaunch");
+  const progress = downloading ? status.progress : null;
+  const info = status.info;
+
+  // Mid-session countdown: ticks only while the update sits in "available";
+  // once the download starts (either trigger) the timer is done. The ref
+  // guards the expiry so re-renders can't fire the install twice.
+  const counting = mode === "countdown" && status.state === "available";
+  const [seconds, setSeconds] = useState(FORCED_UPDATE_COUNTDOWN_SECONDS);
+  const expiredRef = useRef(false);
+  useEffect(() => {
+    if (!counting) return;
+    const id = setInterval(() => setSeconds(tickCountdown), 1000);
+    return () => clearInterval(id);
+  }, [counting]);
+  useEffect(() => {
+    if (!counting || seconds > 0 || expiredRef.current) return;
+    expiredRef.current = true;
+    onInstall("countdown");
+  }, [counting, seconds, onInstall]);
+
+  const message = (() => {
+    if (downloading) {
+      return progress === null
+        ? t("updateChecker.downloading")
+        : t("updateChecker.downloadingProgress", { progress });
+    }
+    if (ready) return t("updateChecker.ready");
+    if (error && status.phase === "install")
+      return t("updateChecker.errorInstall");
+    if (error && status.phase === "relaunch")
+      return t("updateChecker.errorRelaunch");
+    return mode === "launch"
+      ? t("updateForced.launchDescription", { version: info.version })
+      : t("updateForced.countdownDescription", {
+          count: seconds,
+          version: info.version,
+        });
+  })();
+
+  // In launch mode the install auto-starts, so outside of an error there is
+  // nothing to click — the button just shows the busy state.
+  const busy =
+    downloading || (mode === "launch" && status.state === "available");
+  const onAction = relaunchOnly ? onRelaunch : () => onInstall("user");
+  const actionLabel = error
+    ? t("updateChecker.retryAction")
+    : relaunchOnly
+      ? t("updateChecker.relaunchAction")
+      : t("updateForced.updateNowAction");
+
+  return (
+    <div
+      role="alertdialog"
+      aria-modal="true"
+      aria-label={t("updateForced.cardLabel")}
+      aria-live={downloading ? "polite" : "assertive"}
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-black/25 p-4"
+    >
+      {/* `bg-dialog`, not `bg-card`: the modal surface token is SOLID in both
+          themes — the card token is glass and bleeds the page through. */}
+      <div className="max-h-[calc(100vh-2rem)] w-[420px] max-w-full overflow-y-auto rounded-2xl border border-line/50 bg-dialog p-6 text-ink shadow-[0_4px_4px_rgba(0,0,0,0.04),0_4px_80px_8px_rgba(0,0,0,0.04),0_0_1px_rgba(0,0,0,0.62)] dark:shadow-[0_4px_4px_rgba(0,0,0,0.1),0_4px_80px_8px_rgba(0,0,0,0.2),0_0_1px_rgba(255,255,255,0.1)]">
+        <div className="flex items-start gap-3">
+          <div className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-input ring-1 ring-line">
+            <img
+              src={houstonBlack}
+              alt=""
+              aria-hidden="true"
+              className="houston-update-logo-light size-8 object-contain"
+            />
+            <img
+              src={houstonWhite}
+              alt=""
+              aria-hidden="true"
+              className="houston-update-logo-dark hidden size-8 object-contain"
+            />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <h2 className="text-base font-semibold leading-tight">
+                {mode === "launch"
+                  ? t("updateForced.launchTitle")
+                  : t("updateForced.countdownTitle")}
+              </h2>
+              {error && <AlertCircle className="size-4 shrink-0 text-danger" />}
+            </div>
+            <p className="mt-1 text-sm leading-snug text-ink-muted">
+              {message}
+            </p>
+          </div>
+        </div>
+
+        {!error && (
+          <p className="mt-3 text-xs leading-relaxed text-ink-muted">
+            {t("updateForced.reassurance")}
+          </p>
+        )}
+
+        <div className="mt-4 flex items-center justify-center gap-2 rounded-xl bg-chip-subtle p-3 text-xs font-medium">
+          <span className="text-ink-muted">v{info.currentVersion}</span>
+          <span aria-hidden="true" className="text-ink-muted">
+            →
+          </span>
+          <span className="text-ink">v{info.version}</span>
+        </div>
+
+        {mode === "countdown" && (
+          <div className="mt-4 rounded-xl bg-chip-subtle p-3">
+            <p className="text-xs font-medium text-ink">
+              {t("updateChecker.detailsHeading")}
+            </p>
+            <div className="mt-1 max-h-28 overflow-y-auto break-words text-xs leading-relaxed text-ink-muted">
+              {notes ? (
+                <UpdateNotes notes={notes} />
+              ) : (
+                <p>{t("updateChecker.noDetails")}</p>
+              )}
+            </div>
+          </div>
+        )}
+
+        {busy && (
+          <div className="mt-4 h-1.5 overflow-hidden rounded-full bg-chip-subtle">
+            <div
+              className={`h-full rounded-full bg-action transition-[width] duration-200 ${progress === null ? "animate-pulse" : ""}`}
+              style={{ width: `${progress ?? 35}%` }}
+            />
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={onAction}
+          disabled={busy}
+          className="mt-4 flex h-10 w-full items-center justify-center gap-2 rounded-full bg-action px-4 text-sm font-medium text-action-text transition-opacity hover:opacity-90 disabled:cursor-default disabled:opacity-70"
+        >
+          {busy ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : relaunchOnly ? (
+            <RotateCw className="size-4" />
+          ) : (
+            <DownloadCloud className="size-4" />
+          )}
+          {busy ? t("updateChecker.installingAction") : actionLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/shell/update-required.tsx
+++ b/app/src/components/shell/update-required.tsx
@@ -91,9 +91,11 @@ export function UpdateRequired({
       aria-modal="true"
       aria-label={t("updateRequired.cardLabel")}
       aria-live={downloading ? "polite" : "assertive"}
-      className="fixed inset-0 z-[70] flex items-center justify-center bg-ink/45 p-4"
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-black/25 p-4"
     >
-      <div className="w-[420px] max-w-full rounded-2xl border border-line bg-card p-6 text-card-text shadow-[0_16px_60px_rgba(0,0,0,0.16)]">
+      {/* `bg-dialog`, not `bg-card`: the modal surface token is SOLID in both
+          themes — the card token is glass and bleeds the page through. */}
+      <div className="max-h-[calc(100vh-2rem)] w-[420px] max-w-full overflow-y-auto rounded-2xl border border-line/50 bg-dialog p-6 text-ink shadow-[0_4px_4px_rgba(0,0,0,0.04),0_4px_80px_8px_rgba(0,0,0,0.04),0_0_1px_rgba(0,0,0,0.62)] dark:shadow-[0_4px_4px_rgba(0,0,0,0.1),0_4px_80px_8px_rgba(0,0,0,0.2),0_0_1px_rgba(255,255,255,0.1)]">
         <div className="flex items-start gap-3">
           <div className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-input ring-1 ring-line">
             <img

--- a/app/src/hooks/use-update-checker.ts
+++ b/app/src/hooks/use-update-checker.ts
@@ -1,249 +1,97 @@
-import { check } from "@tauri-apps/plugin-updater";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { analytics } from "../lib/analytics";
 import {
-  getEngine,
-  isHostedGatewayEngine,
-  whenEngineReady,
-} from "../lib/engine";
-import {
-  osCurrentAppBundlePath,
-  osRelaunchAppFromPath,
-} from "../lib/os-bridge";
-import {
-  currentAppVersion,
-  emitUpdateRequired,
-  minVersionSignal,
-  onUpdateRequired,
-  type UpdateRequiredSignal,
-} from "../lib/update-floor";
+  type ForcedUpdateMode,
+  forcedUpdateMode,
+  shouldRecheckOnFocus,
+  UPDATE_CHECK_INTERVAL_MS,
+} from "../lib/update-force";
+import { useUpdateMachine } from "./use-update-machine";
+import { useUpdateRequired } from "./use-update-required";
 
-export interface UpdateInfo {
-  currentVersion: string;
-  version: string;
-  body: string | null;
-}
+export type {
+  InstallSource,
+  UpdateInfo,
+  UpdateStatus,
+} from "./use-update-machine";
 
-type UpdateErrorPhase = "install" | "relaunch";
-
-export type UpdateStatus =
-  | { state: "idle" }
-  | { state: "available"; info: UpdateInfo }
-  | { state: "downloading"; info: UpdateInfo; progress: number | null }
-  | { state: "ready"; info: UpdateInfo }
-  | { state: "error"; info: UpdateInfo; phase: UpdateErrorPhase };
-
-const CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
-type AvailableUpdate = NonNullable<Awaited<ReturnType<typeof check>>>;
-
+/**
+ * Update policy: updates are forced. The machine (use-update-machine) knows
+ * HOW to install; this hook decides WHEN — a launch check plus a short
+ * interval plus a focus re-check — and latches the forced presentation the
+ * moment an update is found:
+ *
+ * - found by the launch check → install immediately (blocking overlay),
+ * - found mid-session → the countdown dialog installs it when the timer runs
+ *   out unless the user updates sooner.
+ *
+ * The hosted gateway's hard version floor (`required`) rides beside this and
+ * takes precedence in the UI.
+ */
 export function useUpdateChecker() {
-  const [status, setStatus] = useState<UpdateStatus>({ state: "idle" });
-  // Hard floor (app-update floor): non-null once the hosted gateway said this
-  // build is too old — via a 426 on any request, or a `minAppVersion` on
-  // `/v1/version`. Kept BESIDE `status`, not as another status state, so the
-  // blocking screen can stay up while the normal updater machine underneath it
-  // runs through available → downloading → ready. Never cleared: only an
-  // installed update (relaunch) can satisfy the floor.
-  const [required, setRequired] = useState<UpdateRequiredSignal | null>(null);
-  const requiredRef = useRef<UpdateRequiredSignal | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const updateRef = useRef<AvailableUpdate | null>(null);
-  const infoRef = useRef<UpdateInfo | null>(null);
-  const statusRef = useRef<UpdateStatus>(status);
-  const installingRef = useRef(false);
-  const appPathRef = useRef<string | null>(null);
+  const { status, runCheck, installAndRelaunch, relaunchInstalledApp } =
+    useUpdateMachine();
+  const lastCheckAtRef = useRef<number | null>(null);
 
-  useEffect(() => {
-    statusRef.current = status;
-  }, [status]);
-
-  const runCheck = useCallback(async () => {
-    if (installingRef.current || statusRef.current.state === "ready") return;
-
-    try {
-      const update = await check();
-      if (!update) {
-        updateRef.current = null;
-        infoRef.current = null;
-        setStatus({ state: "idle" });
-        return;
-      }
-
-      const info: UpdateInfo = {
-        currentVersion: update.currentVersion,
-        version: update.version,
-        body: update.body ?? null,
-      };
-
-      updateRef.current = update;
-      infoRef.current = info;
-      // Only fire `update_offered` on the transition into "available" so a
-      // 30-min recheck of the same version doesn't double-count.
-      if (statusRef.current.state !== "available") {
-        analytics.track("update_offered", {
-          from_version: info.currentVersion,
-          to_version: info.version,
-        });
-      }
-      setStatus({ state: "available", info });
-    } catch (error) {
-      console.warn("[updater] check failed", error);
-    }
-  }, []);
-
-  const relaunchInstalledApp = useCallback(async () => {
-    const info = infoRef.current;
-    if (!info) return;
-
-    try {
-      const appPath = appPathRef.current ?? (await osCurrentAppBundlePath());
-      await osRelaunchAppFromPath(appPath);
-    } catch (error) {
-      console.error("[updater] relaunch failed", error);
-      setStatus({ state: "error", info, phase: "relaunch" });
-    }
-  }, []);
-
-  const installAndRelaunch = useCallback(async () => {
-    if (installingRef.current) return;
-
-    let update = updateRef.current;
-    let info = infoRef.current;
-    if (!update || !info) {
-      await runCheck();
-      update = updateRef.current;
-      info = infoRef.current;
-    }
-    if (!update || !info) return;
-
-    installingRef.current = true;
-    analytics.track("update_accepted", {
-      from_version: info.currentVersion,
-      to_version: info.version,
-    });
-    try {
-      appPathRef.current = await osCurrentAppBundlePath();
-      let totalLength = 0;
-      let downloaded = 0;
-
-      setStatus({ state: "downloading", info, progress: null });
-      await update.downloadAndInstall((event) => {
-        if (event.event === "Started") {
-          totalLength = event.data.contentLength ?? 0;
-          downloaded = 0;
-          setStatus({ state: "downloading", info, progress: null });
-        } else if (event.event === "Progress") {
-          downloaded += event.data.chunkLength;
-          const progress =
-            totalLength > 0
-              ? Math.min(100, Math.round((downloaded / totalLength) * 100))
-              : null;
-          setStatus({ state: "downloading", info, progress });
-        } else if (event.event === "Finished") {
-          setStatus({ state: "downloading", info, progress: 100 });
-        }
-      });
-
-      setStatus({ state: "ready", info });
-    } catch (error) {
-      console.error("[updater] install failed", error);
-      setStatus({ state: "error", info, phase: "install" });
-      return;
-    } finally {
-      installingRef.current = false;
-    }
-
-    await relaunchInstalledApp();
-  }, [relaunchInstalledApp, runCheck]);
-
-  /**
-   * User clicked the X on the update card. Hide it for THIS session and
-   * record the dismissal so the funnel `update_offered → {accepted | dismissed}`
-   * tells us how many users actively wave the update away vs how many just
-   * never see the card. The interval still re-checks every 30 min, so a
-   * fresh dismissal sticks only until the next check runs.
-   */
-  const dismiss = useCallback(() => {
-    const info = infoRef.current;
-    if (info) {
-      analytics.track("update_dismissed", {
-        from_version: info.currentVersion,
-        to_version: info.version,
-      });
-    }
-    setStatus({ state: "idle" });
-  }, []);
-
-  // Trigger 1 — the transport saw a gateway `426 Upgrade Required` (forwarded
-  // through the update-floor bus). Merge rather than replace: a later signal
-  // with an omitted field (e.g. the /v1/version probe has no updateUrl) must
-  // not erase a value an earlier 426 body carried.
-  useEffect(() => {
-    return onUpdateRequired((signal) => {
-      const prev = requiredRef.current;
-      const next: UpdateRequiredSignal = {
-        minVersion: signal.minVersion ?? prev?.minVersion ?? null,
-        updateUrl: signal.updateUrl ?? prev?.updateUrl ?? null,
-      };
-      requiredRef.current = next;
-      setRequired(next);
-      if (!prev) {
-        analytics.track("update_required", {
-          from_version: currentAppVersion(),
-          min_version: next.minVersion ?? "unknown",
-        });
-        // Kick a check right away so the blocking screen can offer the
-        // one-click install instead of waiting for the 30-min tick. In dev /
-        // with the updater unable to serve, this rejects into runCheck's catch
-        // and the screen falls back to the gateway-provided updateUrl.
-        void runCheck();
-      }
-    });
+  const check = useCallback(() => {
+    lastCheckAtRef.current = Date.now();
+    return runCheck();
   }, [runCheck]);
 
-  // Trigger 2 — early warning: the gateway's `/v1/version` (exempt from the
-  // floor's 426) names a `minAppVersion` only when a floor is enforced for
-  // this channel. One probe per app run, at connect: a floor raised
-  // mid-session is caught by the 426 path on the next request anyway. Hosted
-  // gateway only — the local sidecar's /v1/version never carries the field,
-  // so skipping it saves a wasted request on every desktop launch.
-  useEffect(() => {
-    if (!isHostedGatewayEngine()) return;
-    let cancelled = false;
-    void whenEngineReady()
-      .then(() => getEngine().version())
-      .then((v) => {
-        if (cancelled) return;
-        const signal = minVersionSignal(v, currentAppVersion());
-        if (signal) emitUpdateRequired(signal);
-      })
-      .catch(() => {
-        /* meta probe only — a failure must not surface; the 426 path covers */
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const required = useUpdateRequired(check);
 
+  // The forced presentation, latched on the first transition into
+  // "available" and kept for the rest of the run (the process relaunches to
+  // clear it). PROD-only: in dev the only way runCheck fires is the 426 kick,
+  // and auto-installing the shipped build over a dev bundle would be hostile —
+  // the UpdateRequired screen already covers that path with a manual button.
+  const [forcedMode, setForcedMode] = useState<ForcedUpdateMode | null>(null);
+  const forcedModeRef = useRef<ForcedUpdateMode | null>(null);
   useEffect(() => {
-    // The updater pings the production release feed and would offer the shipped
-    // build over a local dev build (e.g. `pnpm tauri dev`) — there's nothing
-    // sensible to install over a dev bundle, so it just nags. Only run in
-    // packaged production builds. (Matches App.tsx's `import.meta.env.PROD`
-    // gating idiom; on web the updater is shimmed to a no-op regardless.)
     if (!import.meta.env.PROD) return;
-    runCheck();
-    intervalRef.current = setInterval(runCheck, CHECK_INTERVAL_MS);
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
+    if (status.state !== "available" || forcedModeRef.current) return;
+    const mode = forcedUpdateMode(status.origin);
+    forcedModeRef.current = mode;
+    setForcedMode(mode);
+    analytics.track("update_forced", {
+      source: mode,
+      from_version: status.info.currentVersion,
+      to_version: status.info.version,
+    });
+    // Launch-time find: the user hasn't started working, install right away.
+    // Mid-session the countdown dialog owns the trigger.
+    if (mode === "launch") void installAndRelaunch("launch");
+  }, [status, installAndRelaunch]);
+
+  useEffect(() => {
+    // The updater pings the production release feed and would offer the
+    // shipped build over a local dev build (e.g. `pnpm tauri dev`) — there's
+    // nothing sensible to install over a dev bundle, so it just nags. Only
+    // run in packaged production builds. (Matches App.tsx's
+    // `import.meta.env.PROD` gating idiom; on web the updater is shimmed to a
+    // no-op regardless.)
+    if (!import.meta.env.PROD) return;
+    void check();
+    const interval = setInterval(check, UPDATE_CHECK_INTERVAL_MS);
+    // Returning to the app is the moment a forced update is least disruptive
+    // and most expected — re-check then, throttled against focus bursts.
+    const onFocus = () => {
+      if (shouldRecheckOnFocus(lastCheckAtRef.current, Date.now())) {
+        void check();
+      }
     };
-  }, [runCheck]);
+    window.addEventListener("focus", onFocus);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [check]);
 
   return {
     status,
     required,
+    forcedMode,
     installAndRelaunch,
     relaunchInstalledApp,
-    dismiss,
   };
 }

--- a/app/src/hooks/use-update-machine.ts
+++ b/app/src/hooks/use-update-machine.ts
@@ -1,0 +1,159 @@
+import { check } from "@tauri-apps/plugin-updater";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { analytics } from "../lib/analytics";
+import {
+  osCurrentAppBundlePath,
+  osRelaunchAppFromPath,
+} from "../lib/os-bridge";
+import type { UpdateOrigin } from "../lib/update-force";
+
+export interface UpdateInfo {
+  currentVersion: string;
+  version: string;
+  body: string | null;
+}
+
+type UpdateErrorPhase = "install" | "relaunch";
+
+/** What set the install off — the funnel needs to tell a click from the
+ *  countdown expiring from the silent launch-time install. */
+export type InstallSource = "user" | "countdown" | "launch";
+
+export type UpdateStatus =
+  | { state: "idle" }
+  | { state: "available"; info: UpdateInfo; origin: UpdateOrigin }
+  | { state: "downloading"; info: UpdateInfo; progress: number | null }
+  | { state: "ready"; info: UpdateInfo }
+  | { state: "error"; info: UpdateInfo; phase: UpdateErrorPhase };
+
+type AvailableUpdate = NonNullable<Awaited<ReturnType<typeof check>>>;
+
+/**
+ * The updater state machine: check → available → downloading → ready →
+ * relaunch (or error). Scheduling (when checks run) and policy (forcing the
+ * install) live in `useUpdateChecker`; this hook only moves between states.
+ */
+export function useUpdateMachine() {
+  const [status, setStatus] = useState<UpdateStatus>({ state: "idle" });
+  const updateRef = useRef<AvailableUpdate | null>(null);
+  const infoRef = useRef<UpdateInfo | null>(null);
+  const statusRef = useRef<UpdateStatus>(status);
+  const installingRef = useRef(false);
+  const appPathRef = useRef<string | null>(null);
+  const firstCheckRef = useRef(true);
+
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
+  const runCheck = useCallback(async () => {
+    // The first check of a run is the launch check: a find there means the
+    // user just opened the app and hasn't started working. Everything after
+    // (interval, focus, 426 kick) is mid-session. The origin rides on the
+    // available state so the policy layer can pick the forced presentation.
+    const origin: UpdateOrigin = firstCheckRef.current ? "launch" : "poll";
+    firstCheckRef.current = false;
+    if (installingRef.current || statusRef.current.state === "ready") return;
+
+    try {
+      const update = await check();
+      if (!update) {
+        updateRef.current = null;
+        infoRef.current = null;
+        setStatus({ state: "idle" });
+        return;
+      }
+
+      const info: UpdateInfo = {
+        currentVersion: update.currentVersion,
+        version: update.version,
+        body: update.body ?? null,
+      };
+
+      updateRef.current = update;
+      infoRef.current = info;
+      // Only fire `update_offered` on the transition into "available" so a
+      // recheck of the same version doesn't double-count.
+      if (statusRef.current.state !== "available") {
+        analytics.track("update_offered", {
+          from_version: info.currentVersion,
+          to_version: info.version,
+        });
+      }
+      setStatus({ state: "available", info, origin });
+    } catch (error) {
+      console.warn("[updater] check failed", error);
+    }
+  }, []);
+
+  const relaunchInstalledApp = useCallback(async () => {
+    const info = infoRef.current;
+    if (!info) return;
+
+    try {
+      const appPath = appPathRef.current ?? (await osCurrentAppBundlePath());
+      await osRelaunchAppFromPath(appPath);
+    } catch (error) {
+      console.error("[updater] relaunch failed", error);
+      setStatus({ state: "error", info, phase: "relaunch" });
+    }
+  }, []);
+
+  const installAndRelaunch = useCallback(
+    async (source: InstallSource = "user") => {
+      if (installingRef.current) return;
+
+      let update = updateRef.current;
+      let info = infoRef.current;
+      if (!update || !info) {
+        await runCheck();
+        update = updateRef.current;
+        info = infoRef.current;
+      }
+      if (!update || !info) return;
+
+      installingRef.current = true;
+      analytics.track("update_accepted", {
+        from_version: info.currentVersion,
+        to_version: info.version,
+        source,
+      });
+      try {
+        appPathRef.current = await osCurrentAppBundlePath();
+        let totalLength = 0;
+        let downloaded = 0;
+
+        setStatus({ state: "downloading", info, progress: null });
+        await update.downloadAndInstall((event) => {
+          if (event.event === "Started") {
+            totalLength = event.data.contentLength ?? 0;
+            downloaded = 0;
+            setStatus({ state: "downloading", info, progress: null });
+          } else if (event.event === "Progress") {
+            downloaded += event.data.chunkLength;
+            const progress =
+              totalLength > 0
+                ? Math.min(100, Math.round((downloaded / totalLength) * 100))
+                : null;
+            setStatus({ state: "downloading", info, progress });
+          } else if (event.event === "Finished") {
+            setStatus({ state: "downloading", info, progress: 100 });
+          }
+        });
+
+        setStatus({ state: "ready", info });
+      } catch (error) {
+        console.error("[updater] install failed", error);
+        setStatus({ state: "error", info, phase: "install" });
+        return;
+      } finally {
+        installingRef.current = false;
+      }
+
+      await relaunchInstalledApp();
+    },
+    [relaunchInstalledApp, runCheck],
+  );
+
+  return { status, runCheck, installAndRelaunch, relaunchInstalledApp };
+}

--- a/app/src/hooks/use-update-required.ts
+++ b/app/src/hooks/use-update-required.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from "react";
+import { analytics } from "../lib/analytics";
+import {
+  getEngine,
+  isHostedGatewayEngine,
+  whenEngineReady,
+} from "../lib/engine";
+import {
+  currentAppVersion,
+  emitUpdateRequired,
+  minVersionSignal,
+  onUpdateRequired,
+  type UpdateRequiredSignal,
+} from "../lib/update-floor";
+
+/**
+ * The hard app-update floor (hosted gateway): non-null once the gateway said
+ * this build is too old — via a 426 on any request, or a `minAppVersion` on
+ * `/v1/version`. Kept BESIDE the updater status, not as another status state,
+ * so the blocking screen can stay up while the normal updater machine
+ * underneath it runs through available → downloading → ready. Never cleared:
+ * only an installed update (relaunch) can satisfy the floor.
+ */
+export function useUpdateRequired(
+  runCheck: () => void | Promise<void>,
+): UpdateRequiredSignal | null {
+  const [required, setRequired] = useState<UpdateRequiredSignal | null>(null);
+  const requiredRef = useRef<UpdateRequiredSignal | null>(null);
+
+  // Trigger 1 — the transport saw a gateway `426 Upgrade Required` (forwarded
+  // through the update-floor bus). Merge rather than replace: a later signal
+  // with an omitted field (e.g. the /v1/version probe has no updateUrl) must
+  // not erase a value an earlier 426 body carried.
+  useEffect(() => {
+    return onUpdateRequired((signal) => {
+      const prev = requiredRef.current;
+      const next: UpdateRequiredSignal = {
+        minVersion: signal.minVersion ?? prev?.minVersion ?? null,
+        updateUrl: signal.updateUrl ?? prev?.updateUrl ?? null,
+      };
+      requiredRef.current = next;
+      setRequired(next);
+      if (!prev) {
+        analytics.track("update_required", {
+          from_version: currentAppVersion(),
+          min_version: next.minVersion ?? "unknown",
+        });
+        // Kick a check right away so the blocking screen can offer the
+        // one-click install instead of waiting for the next tick. In dev /
+        // with the updater unable to serve, this rejects into runCheck's catch
+        // and the screen falls back to the gateway-provided updateUrl.
+        void runCheck();
+      }
+    });
+  }, [runCheck]);
+
+  // Trigger 2 — early warning: the gateway's `/v1/version` (exempt from the
+  // floor's 426) names a `minAppVersion` only when a floor is enforced for
+  // this channel. One probe per app run, at connect: a floor raised
+  // mid-session is caught by the 426 path on the next request anyway. Hosted
+  // gateway only — the local sidecar's /v1/version never carries the field,
+  // so skipping it saves a wasted request on every desktop launch.
+  useEffect(() => {
+    if (!isHostedGatewayEngine()) return;
+    let cancelled = false;
+    void whenEngineReady()
+      .then(() => getEngine().version())
+      .then((v) => {
+        if (cancelled) return;
+        const signal = minVersionSignal(v, currentAppVersion());
+        if (signal) emitUpdateRequired(signal);
+      })
+      .catch(() => {
+        /* meta probe only — a failure must not surface; the 426 path covers */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return required;
+}

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -134,10 +134,13 @@ export type AnalyticsEventName =
   | "org_member_removed"
   | "org_role_changed"
   | "org_invite_revoked"
-  // Update lifecycle (closes the symbolication-coverage feedback loop)
+  // Update lifecycle (closes the symbolication-coverage feedback loop).
+  // Updates are forced: update_forced marks the blocking surface appearing
+  // (`source`: launch | countdown) and update_accepted the install starting
+  // (`source`: user | countdown | launch — click vs timer vs launch-auto).
   | "update_offered"
+  | "update_forced"
   | "update_accepted"
-  | "update_dismissed"
   // Gateway app-update floor tripped → blocking update screen shown
   | "update_required"
   // Reliability

--- a/app/src/lib/update-force.ts
+++ b/app/src/lib/update-force.ts
@@ -1,0 +1,53 @@
+/**
+ * Forced-update model (pure logic; `useUpdateChecker` + the dialog consume it).
+ *
+ * Houston updates are not optional: every release the updater finds gets
+ * installed. The only question is presentation, keyed on WHEN it was found:
+ *
+ * - `launch` — the launch check found it. The user has not started working
+ *   yet, so install immediately behind a blocking "upgrading Houston" overlay
+ *   and relaunch into the new version.
+ * - `countdown` — a background re-check found it mid-session. Show a blocking
+ *   dialog with a visible countdown: update now, or it installs itself when
+ *   the timer runs out. The copy reassures that agents keep working and
+ *   chats/settings survive the restart.
+ *
+ * Detection stays pull-based: the Tauri updater polls `latest.json` on the
+ * release feed. There is no push channel to a desktop build (the hosted
+ * gateway's 426 version floor covers the must-update-NOW case per request),
+ * so freshness comes from cadence: a launch check, a short interval, and a
+ * re-check when the window regains focus.
+ */
+
+export type UpdateOrigin = "launch" | "poll";
+export type ForcedUpdateMode = "launch" | "countdown";
+
+/** Seconds the mid-session dialog counts down before installing on its own. */
+export const FORCED_UPDATE_COUNTDOWN_SECONDS = 60;
+
+/** Background re-check cadence. Short enough that an active user is on the
+ *  new version within minutes of publish; long enough not to hammer the
+ *  release feed from every install all day. */
+export const UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Minimum gap before a window-focus re-check fires — focus events come in
+ *  bursts (Cmd-Tab flurries) and must not turn into a request storm. */
+export const FOCUS_RECHECK_MIN_GAP_MS = 60 * 1000;
+
+/** Which forced presentation a found update gets. */
+export function forcedUpdateMode(origin: UpdateOrigin): ForcedUpdateMode {
+  return origin === "launch" ? "launch" : "countdown";
+}
+
+/** True when a focus-triggered re-check is due. */
+export function shouldRecheckOnFocus(
+  lastCheckAt: number | null,
+  now: number,
+): boolean {
+  return lastCheckAt === null || now - lastCheckAt >= FOCUS_RECHECK_MIN_GAP_MS;
+}
+
+/** One countdown tick. Floors at zero so a late timer can never go negative. */
+export function tickCountdown(seconds: number): number {
+  return Math.max(0, seconds - 1);
+}

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -208,9 +208,6 @@
     }
   },
   "updateChecker": {
-    "cardLabel": "Houston update available",
-    "title": "Houston, we have an update!",
-    "availableDescription": "Version {{version}} is ready. You're on v{{currentVersion}}.",
     "downloading": "Downloading and installing update...",
     "downloadingProgress": "Downloading and installing... {{progress}}%",
     "ready": "Update installed. Relaunch Houston to finish.",
@@ -221,8 +218,17 @@
     "primaryAction": "Update and relaunch",
     "installingAction": "Installing update...",
     "relaunchAction": "Relaunch Houston",
-    "retryAction": "Try again",
-    "dismissAction": "Dismiss update for now"
+    "retryAction": "Try again"
+  },
+  "updateForced": {
+    "cardLabel": "Houston update in progress",
+    "launchTitle": "Upgrading Houston",
+    "launchDescription": "Houston is updating to version {{version}}. The app will restart in a moment.",
+    "countdownTitle": "Houston, we have an update!",
+    "countdownDescription_one": "Version {{version}} will install in {{count}} second.",
+    "countdownDescription_other": "Version {{version}} will install in {{count}} seconds.",
+    "reassurance": "Your agents keep working in the background, and your chats and settings are saved. You'll pick up right where you left off.",
+    "updateNowAction": "Update now"
   },
   "updateRequired": {
     "cardLabel": "Houston update required",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -208,9 +208,6 @@
     }
   },
   "updateChecker": {
-    "cardLabel": "Actualización de Houston disponible",
-    "title": "¡Houston, tenemos una actualización!",
-    "availableDescription": "La versión {{version}} está lista. Estás en v{{currentVersion}}.",
     "downloading": "Descargando e instalando la actualización...",
     "downloadingProgress": "Descargando e instalando... {{progress}}%",
     "ready": "Actualización instalada. Reinicia Houston para terminar.",
@@ -221,8 +218,17 @@
     "primaryAction": "Actualizar y reiniciar",
     "installingAction": "Instalando actualización...",
     "relaunchAction": "Reiniciar Houston",
-    "retryAction": "Intentar otra vez",
-    "dismissAction": "Descartar actualización por ahora"
+    "retryAction": "Intentar otra vez"
+  },
+  "updateForced": {
+    "cardLabel": "Actualización de Houston en curso",
+    "launchTitle": "Actualizando Houston",
+    "launchDescription": "Houston se está actualizando a la versión {{version}}. La aplicación se reiniciará en un momento.",
+    "countdownTitle": "¡Houston, tenemos una actualización!",
+    "countdownDescription_one": "La versión {{version}} se instalará en {{count}} segundo.",
+    "countdownDescription_other": "La versión {{version}} se instalará en {{count}} segundos.",
+    "reassurance": "Tus agentes siguen trabajando en segundo plano y tus chats y configuraciones quedan guardados. Vas a retomar justo donde lo dejaste.",
+    "updateNowAction": "Actualizar ahora"
   },
   "updateRequired": {
     "cardLabel": "Actualización de Houston requerida",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -208,9 +208,6 @@
     }
   },
   "updateChecker": {
-    "cardLabel": "Atualização do Houston disponível",
-    "title": "Houston, temos uma atualização!",
-    "availableDescription": "A versão {{version}} está pronta. Você está na v{{currentVersion}}.",
     "downloading": "Baixando e instalando a atualização...",
     "downloadingProgress": "Baixando e instalando... {{progress}}%",
     "ready": "Atualização instalada. Reinicie o Houston para concluir.",
@@ -221,8 +218,17 @@
     "primaryAction": "Atualizar e reiniciar",
     "installingAction": "Instalando atualização...",
     "relaunchAction": "Reiniciar Houston",
-    "retryAction": "Tentar de novo",
-    "dismissAction": "Dispensar atualização por enquanto"
+    "retryAction": "Tentar de novo"
+  },
+  "updateForced": {
+    "cardLabel": "Atualização do Houston em andamento",
+    "launchTitle": "Atualizando o Houston",
+    "launchDescription": "O Houston está sendo atualizado para a versão {{version}}. O aplicativo vai reiniciar em instantes.",
+    "countdownTitle": "Houston, temos uma atualização!",
+    "countdownDescription_one": "A versão {{version}} será instalada em {{count}} segundo.",
+    "countdownDescription_other": "A versão {{version}} será instalada em {{count}} segundos.",
+    "reassurance": "Seus agentes continuam trabalhando em segundo plano e seus chats e configurações ficam salvos. Você vai retomar de onde parou.",
+    "updateNowAction": "Atualizar agora"
   },
   "updateRequired": {
     "cardLabel": "Atualização do Houston obrigatória",

--- a/app/tests/update-force.test.ts
+++ b/app/tests/update-force.test.ts
@@ -1,0 +1,67 @@
+import { ok, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  FOCUS_RECHECK_MIN_GAP_MS,
+  FORCED_UPDATE_COUNTDOWN_SECONDS,
+  forcedUpdateMode,
+  shouldRecheckOnFocus,
+  tickCountdown,
+  UPDATE_CHECK_INTERVAL_MS,
+} from "../src/lib/update-force.ts";
+
+// The forced presentation follows the find, not the release: a launch-check
+// find auto-installs behind the upgrading overlay, anything later gets the
+// countdown so the user is never yanked out of work without warning.
+describe("forcedUpdateMode", () => {
+  it("installs immediately for a launch-check find", () => {
+    strictEqual(forcedUpdateMode("launch"), "launch");
+  });
+
+  it("counts down for a mid-session find", () => {
+    strictEqual(forcedUpdateMode("poll"), "countdown");
+  });
+});
+
+describe("shouldRecheckOnFocus", () => {
+  it("checks when no check has run yet", () => {
+    strictEqual(shouldRecheckOnFocus(null, 1_000), true);
+  });
+
+  it("suppresses a focus burst right after a check", () => {
+    strictEqual(
+      shouldRecheckOnFocus(10_000, 10_000 + FOCUS_RECHECK_MIN_GAP_MS - 1),
+      false,
+    );
+  });
+
+  it("checks once the gap has fully elapsed", () => {
+    strictEqual(
+      shouldRecheckOnFocus(10_000, 10_000 + FOCUS_RECHECK_MIN_GAP_MS),
+      true,
+    );
+  });
+});
+
+describe("tickCountdown", () => {
+  it("counts down by one second", () => {
+    strictEqual(tickCountdown(FORCED_UPDATE_COUNTDOWN_SECONDS), 59);
+  });
+
+  it("reaches zero", () => {
+    strictEqual(tickCountdown(1), 0);
+  });
+
+  it("floors at zero so a late timer never goes negative", () => {
+    strictEqual(tickCountdown(0), 0);
+  });
+});
+
+describe("cadence sanity", () => {
+  it("gives the user a real countdown", () => {
+    ok(FORCED_UPDATE_COUNTDOWN_SECONDS >= 20);
+  });
+
+  it("polls more often than it throttles focus rechecks", () => {
+    ok(UPDATE_CHECK_INTERVAL_MS > FOCUS_RECHECK_MIN_GAP_MS);
+  });
+});

--- a/knowledge-base/design-system.md
+++ b/knowledge-base/design-system.md
@@ -234,7 +234,7 @@ Rules: `layout` prop on reordering items. `AnimatePresence mode="popLayout"` for
 The language + disclaimer gates, **sign-in**, **onboarding**, and the
 **cloud-migration wizard** all render on **`FirstRunScreen`**
 (`components/onboarding/first-run-screen.tsx`): a flat, calm full-screen page in
-the app's light-mode gutter grey (`bg-base` — the tone the sidebar melts into)
+the app's light-mode gutter grey (`bg-gutter` — the tone the sidebar melts into)
 under plain **white cards**. It pins `data-theme="light"`, so a dark-mode user
 still gets a bright light first-run (that decision stands) and every `--ht-*`
 token inside resolves light. **No space photo, no glass, no `backdrop-blur`** —
@@ -262,10 +262,14 @@ the space/galaxy look is OUT for first-run.
   light tokens. The progress `OrbitLoader` is remapped to ink (`ORBIT_INK_VARS`,
   see `--ht-space-*` above). The done congrats keeps the one colour accent, the
   `SuccessCheck`.
-- **Gotcha (still true): `text-base` is BOTH a font-size AND a colour utility**
-  here (a `--color-base` token exists) — pair it only with a NAMED colour
-  utility (`text-ink…`), or set the colour inline; an arbitrary
-  `text-[var(...)]` loses the cascade.
+- **Gotcha RESOLVED (2026-07): `text-base` is a plain font-size utility
+  again.** The gutter token's Tailwind alias was renamed `--color-base` →
+  `--color-gutter` (`ui/core/src/globals.css`) precisely because a colour
+  named `base` made Tailwind also emit `text-base` as a COLOUR utility —
+  any `text-base` heading without its own colour class rendered
+  background-coloured (invisible on a matching surface, both themes; the
+  forced-update dialog title was the casualty that exposed it). Never
+  reintroduce a colour token named `base`.
 
 ### Space screen backdrop (workspace-loading only)
 `SpaceScreen` (`app/src/components/space/space-screen.tsx`) is the **shared

--- a/ui/core/src/globals.css
+++ b/ui/core/src/globals.css
@@ -53,8 +53,12 @@
   /* The standard main-canvas surface: the light gray the content panes float
      cards on (dark = the frosted "screen" glass). Backs the Arc `.canvas-screen`
      panes; `bg-background` lets any surface that lives ON the canvas (e.g. the chat
-     panel) reference the SAME tone as one source of truth. */
-  --color-base: var(--ht-base);
+     panel) reference the SAME tone as one source of truth.
+     Named `gutter`, NEVER `base`: a `base` color makes Tailwind emit
+     `text-base` as a COLOR utility, shadowing the standard 16px font-size
+     utility and painting every `text-base` heading background-colored
+     (invisible on a matching surface, both themes). */
+  --color-gutter: var(--ht-base);
   --color-background: var(--ht-background);
   --color-card: var(--ht-card);
   --color-card-hover: var(--ht-card-hover);


### PR DESCRIPTION
## What

Desktop updates are no longer optional. The dismissible update card is replaced by a forced flow, keyed on when the update is found:

- **Found at launch** (first check after boot): install starts automatically behind a blocking "Upgrading Houston" overlay with progress, then the app relaunches itself into the new version.
- **Found mid-session** (interval/focus check): a non-dismissible dialog counts down **60 seconds** with an **Update now** button and the what's-new notes. At zero it installs itself. Copy reassures the user: agents keep working in the background, chats and settings are saved (en/es/pt).

Errors never loop: failed download/relaunch shows the existing error copy with a manual Retry/Relaunch button. The gateway 426 hard-floor screen is unchanged and takes precedence.

## Detection

Still pull-based against the release feed's `latest.json` (no push channel exists to a desktop build; the gateway 426 floor covers must-update-NOW for the cloud channel):
- poll interval tightened 30 min → **5 min**
- new **window-focus re-check**, throttled to once per 60s

Publishing a release is unchanged and is what triggers the fleet-wide rollout.

## Load-bearing fix found on the way: `base` colour token collision

Since #865, a colour token named `base` made Tailwind emit `text-base` as a **colour** utility (the gutter grey) shadowing the standard 16px font-size utility — any `text-base` heading without its own colour class rendered background-coloured, i.e. invisible on a matching surface, in **both** themes. First commit renames the alias `--color-base` → `--color-gutter`, moves the one `bg-base` consumer, and retires the documented gotcha + workaround comment. 26 files use `text-base`; sizes are unchanged (both rules were emitted), only the wrong colour is gone.

Both update dialogs also move onto the solid `bg-dialog` modal surface (they were on glass `bg-card`, bleeding the page through) with a viewport-bounded scroll guard; the notes box scrolls at `max-h-28`.

## Code shape

- `app/src/lib/update-force.ts` — pure model (mode decision, countdown, cadence) + tests
- old 250-line hook split: `use-update-machine.ts` (state machine, finds tagged launch/poll), `use-update-required.ts` (426 floor triggers, moved verbatim), `use-update-checker.ts` (policy: scheduling + forced-mode latch + launch auto-install)
- `update-forced.tsx` — the dialog; `update-checker.tsx` picks floor vs forced
- `update-forced-preview.ts` — DEV-only console harness (`__HOUSTON_UPDATE_PREVIEW__("launch"|"countdown"|"error"|null)`), tree-shaken from release builds
- Analytics: new `update_forced` (`source`: launch|countdown); `update_accepted` gains `source` (user|countdown|launch); `update_dismissed` retired with the card

## Testing

- `app` tests 1905 pass (incl. new `update-force.test.ts`), `check-locales` green, Biome clean, full workspace typecheck + web shim-parity green
- Dialog verified in the browser in both themes via the dev preview harness (computed-style probe confirmed the title fix)