### PR TITLE
fix(app): sync version to 0.5.21 and surface the update screen above onboarding gates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.5.9"
+version = "0.5.21"
 dependencies = [
  "bytes",
  "chrono",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.5.9",
+  "version": "0.5.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.5.9"
+version = "0.5.21"
 edition = "2021"
 
 [lib]

--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -26,7 +26,6 @@ import {
   buildSidebarNavItems,
   SidebarWorkspaceHeader,
 } from "./sidebar-chrome";
-import { UpdateChecker } from "./update-checker";
 import { useAgentActivitySummaries } from "./use-agent-activity-summaries";
 import { UserMenu } from "./user-menu";
 import { CreateWorkspaceDialog } from "./workspace-dialog";
@@ -232,7 +231,6 @@ export function Sidebar({ children }: { children: ReactNode }) {
           footer={
             <div className="flex flex-col">
               <UserMenu collapsed={collapsed} />
-              <UpdateChecker />
             </div>
           }
         >

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -11,6 +11,7 @@ import { DisclaimerGate } from "./components/shell/disclaimer-gate";
 import { EngineGate } from "./components/shell/engine-gate";
 import { LanguageGate } from "./components/shell/language-gate";
 import { QueryPersistenceProvider } from "./components/shell/query-persistence-provider";
+import { UpdateChecker } from "./components/shell/update-checker";
 import { analytics, classifyAnalyticsError } from "./lib/analytics";
 import { whenEngineReady } from "./lib/engine";
 import { showErrorToast } from "./lib/error-toast";
@@ -154,6 +155,14 @@ createRoot(rootElement).render(
           <StartupEffects>
             <EngineGate>
               <QueryPersistenceProvider>
+                {/* Update surfaces (gateway 426 hard floor + forced updates)
+                    sit ABOVE the language/disclaimer gates: on a below-floor
+                    build those gates' own preference reads 426 too, so a user
+                    stuck in front of them must still get the update screen —
+                    not a wedged first-run flow (the staging 0.5.19 lockout).
+                    Both surfaces render as full-window fixed overlays, so
+                    mounting here covers every screen including the gates. */}
+                <UpdateChecker />
                 <LanguageGate>
                   <DisclaimerGate>
                     <App />

--- a/app/tests/update-gate-mount.test.ts
+++ b/app/tests/update-gate-mount.test.ts
@@ -1,0 +1,63 @@
+import { ok } from "node:assert";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+// Source-structure guard for the update surfaces' mount position. There is no
+// React DOM harness in this suite, and the bug this prevents is purely
+// structural: UpdateChecker (the gateway 426 hard floor + forced updates) once
+// lived in the sidebar footer, INSIDE the shell — so a below-floor build never
+// reached it. The language/disclaimer gates' own preference reads 426 on such
+// a build, wedging the user in a broken first-run flow with no update screen
+// (the staging 0.5.19 lockout). These assertions pin the fix: both entry trees
+// mount UpdateChecker ABOVE the gates, and nowhere else.
+
+const appRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function mountIndex(source: string, file: string): number {
+  const i = source.indexOf("<UpdateChecker />");
+  ok(i >= 0, `${file} must mount <UpdateChecker />`);
+  return i;
+}
+
+function gateIndex(source: string, file: string): number {
+  const i = source.indexOf("<LanguageGate>");
+  ok(i >= 0, `${file} must mount <LanguageGate>`);
+  return i;
+}
+
+describe("update surfaces mount above the onboarding gates", () => {
+  it("desktop entry (main.tsx) renders UpdateChecker before LanguageGate", () => {
+    const src = readFileSync(join(appRoot, "src/main.tsx"), "utf8");
+    ok(
+      mountIndex(src, "main.tsx") < gateIndex(src, "main.tsx"),
+      "UpdateChecker must render BEFORE (above) LanguageGate so a 426-locked " +
+        "build shows the update screen instead of a wedged first-run flow",
+    );
+  });
+
+  it("web entry (app-tree.tsx) mirrors the desktop mount", () => {
+    const src = readFileSync(
+      join(appRoot, "../packages/web/src/app-tree.tsx"),
+      "utf8",
+    );
+    ok(
+      mountIndex(src, "app-tree.tsx") < gateIndex(src, "app-tree.tsx"),
+      "app-tree.tsx must mirror main.tsx: UpdateChecker above LanguageGate",
+    );
+  });
+
+  it("the sidebar no longer mounts UpdateChecker (single top-level mount)", () => {
+    const src = readFileSync(
+      join(appRoot, "src/components/shell/sidebar.tsx"),
+      "utf8",
+    );
+    ok(
+      !src.includes("UpdateChecker"),
+      "sidebar.tsx must not mount UpdateChecker: a second instance would run " +
+        "the update policy twice, and the shell mount is unreachable on a " +
+        "426-locked build",
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.5.9",
+  "version": "0.5.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/web/src/app-tree.tsx
+++ b/packages/web/src/app-tree.tsx
@@ -18,6 +18,7 @@ import { AgentFilePreviewHost } from "@houston/app/components/agent-file-preview
 import { DisclaimerGate } from "@houston/app/components/shell/disclaimer-gate";
 import { LanguageGate } from "@houston/app/components/shell/language-gate";
 import { QueryPersistenceProvider } from "@houston/app/components/shell/query-persistence-provider";
+import { UpdateChecker } from "@houston/app/components/shell/update-checker";
 import { WorkspaceLoading } from "@houston/app/components/shell/workspace-loading";
 import { analytics, classifyAnalyticsError } from "@houston/app/lib/analytics";
 import { isEngineReady, whenEngineReady } from "@houston/app/lib/engine";
@@ -144,6 +145,11 @@ export default function AppTree() {
                     overlays every gate/screen without disturbing layout or clicks.
                     Renders null off the preview deployment. */}
                 <PreviewBadge />
+                {/* Mirrors app/src/main.tsx: update surfaces above the gates.
+                    On web the updater is shimmed and no version header is
+                    sent (no 426 floor), so this renders null — kept so the
+                    two trees can't drift. */}
+                <UpdateChecker />
                 <LanguageGate>
                   <DisclaimerGate>
                     <App />

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.5.9",
+  "version": "0.5.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.5.9",
+  "version": "0.5.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.5.9",
+  "version": "0.5.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.5.9",
+  "version": "0.5.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.5.9",
+  "version": "0.5.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.5.9",
+  "version": "0.5.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.5.9",
+  "version": "0.5.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.5.9",
+  "version": "0.5.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## What happened

Running the desktop app against staging (`pnpm dev:staging`) bounced users into first-run onboarding, and accepting the disclaimer failed with "Something unexpected went wrong." The frontend log showed the real cause: every gateway request was refused with **426 Upgrade Required** (`minVersion 0.5.19`) because the build identified as `0.5.9-dev+cloud`.

Two distinct bugs behind that:

### 1. main's version line had drifted 12 patch releases behind

Release cuts run `scripts/version.sh`, commit the bump **on top of main**, and push only the `cloud-v*` tag (e.g. `cloud-v0.5.21` → `00641ee7 release: v0.5.21`) — the bump commit never lands back on protected main. So `app/package.json` on main still said `0.5.9` while the latest cut is `0.5.21`, and every dev build pointed at a hosted gateway sent a 12-releases-old version header straight into the 426 floor.

**Fix:** `./scripts/version.sh 0.5.21` (all package.jsons + Cargo.toml + Cargo.lock regen), matching the latest cut release — 0.5.20/0.5.21 tags already exist, so 0.5.19 would be stale on publish.

**Not fixed here (process):** the drift will recur on the next release cut unless the release flow also lands the bump on main (e.g. the release run opens a version-bump PR alongside the tag). Flagging for a follow-up to `/release` + `skills/release/SKILL.md`.

### 2. A 426-locked build could never reach the update screen

`UpdateChecker` — which renders the non-dismissible `UpdateRequired` floor screen and the forced-update flow (#1018) — mounted in the **sidebar footer**, deep inside the shell. But the language/disclaimer gates in front of `<App/>` read account preferences through the same gateway, which also 426s on a locked-out build: the user gets wedged in a broken first-run flow and the update screen behind it is unreachable. That is exactly the staging symptom.

**Fix:** mount `UpdateChecker` once at the top of both entry trees (`app/src/main.tsx`, `packages/web/src/app-tree.tsx`), ABOVE `LanguageGate`/`DisclaimerGate`, and remove the sidebar mount. Both update surfaces are full-window `fixed inset-0` overlays, so the top mount covers every screen including the gates. Behavior is otherwise unchanged: packaged builds still auto-download + install at launch (the 426 kick runs the updater check; `UpdateRequired` shows install progress), dev builds get the manual download/`updateUrl` fallback instead of hostile auto-install over a dev bundle.

## Tests

- New `app/tests/update-gate-mount.test.ts`: source-structure guard pinning `UpdateChecker` above `LanguageGate` in both entries and out of the sidebar (no React DOM harness in the suite; the bug is purely structural).
- `app` suite: 1927/1927 pass. `pnpm check` (Biome) clean. Full workspace typecheck clean (pre-commit).

## Verification against staging

Root-cause evidence from `~/.dev-houston/logs/frontend.log`:

```
[engine:get_preference] app update required (engine error 426)
[accept_disclaimer] engine request failed (426): {"error":"app update required","minVersion":"0.5.19","updateUrl":""}
```

With the bump, dev builds send `0.5.21-dev+cloud`, which clears staging's 0.5.19 floor. (Separately: staging's `gateway-config` `min-app-version-cloud=0.5.19` with an empty `updateUrl` locks out ALL released builds ≤0.5.19 — worth reviewing whether that floor should stay.)