### PR TITLE
feat(analytics): user_signed_up event for new accounts (Slack new-user notification)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -122,7 +122,11 @@ export default function App() {
     const userEmail = session?.email ?? null;
     const signupDate = null;
     if (userId && userId !== prevUserIdRef.current) {
-      analytics.identifyUser(userId, { email: userEmail, signupDate });
+      analytics.identifyUser(userId, {
+        email: userEmail,
+        name: session?.displayName ?? null,
+        signupDate,
+      });
       setSentryUser({
         id: userId,
         email: userEmail,

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -197,6 +197,8 @@ type AnalyticsProperty =
 type Props = Partial<Record<AnalyticsProperty, string | number | boolean>>;
 type UserIdentity = {
   email?: string | null;
+  /** Provider display name — person property (like email, never an event prop). */
+  name?: string | null;
   /**
    * ISO date (YYYY-MM-DD) acquisition cohort. The GCP Identity Platform
    * session carries no created_at, so post-migration callers pass `null`
@@ -517,11 +519,13 @@ export const analytics = {
     if (!KEY) return;
     try {
       const email = cleanEmail(identity?.email);
+      const name = identity?.name?.trim() || undefined;
       posthog.alias(userId);
       posthog.setPersonProperties(
         {
           firebase_uid: userId,
           ...(email ? { email } : {}),
+          ...(name ? { name } : {}),
         },
         identity?.signupDate ? { signup_date: identity.signupDate } : undefined,
       );

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -30,6 +30,10 @@ export type AnalyticsEventName =
   | "session_ended"
   // Auth
   | "user_signed_in"
+  // First sign-in of a brand-new GCIP account (its `isNewUser` flag). Fires
+  // ONCE per account, ever — the PostHog → Slack new-user notification and
+  // the activation funnel key on this single event.
+  | "user_signed_up"
   | "user_signed_out"
   // Onboarding
   | "onboarding_started"

--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -17,6 +17,7 @@ import {
   isIdentityError,
   SESSION_QUERY_KEY,
   type Session,
+  type SignInOutcome,
   saveSession,
   setSessionSink,
   startEmailOtp,
@@ -74,26 +75,34 @@ async function guardAuthCall(
 }
 
 async function establishDesktopSession(
-  session: Session,
+  { session, isNewUser }: SignInOutcome,
   analyticsProvider: string,
 ): Promise<void> {
   await saveSession(session);
   cacheSession(session);
   rememberLastSignIn(session);
   startProactiveRefresh();
-  analytics.track("user_signed_in", { provider: analyticsProvider });
+  trackSignIn(analyticsProvider, isNewUser);
   logger.info(`[auth] signed in (${session.provider}) as ${session.email}`);
 }
 
 // Cache a web session (or a benign null popup-cancel) and track it.
 function establishWebSession(
-  session: Session | null,
+  outcome: SignInOutcome | null,
   analyticsProvider: string,
 ): void {
-  if (!session) return; // popup cancelled — no error, no cache write
-  cacheSession(session);
-  rememberLastSignIn(session);
-  analytics.track("user_signed_in", { provider: analyticsProvider });
+  if (!outcome) return; // popup cancelled — no error, no cache write
+  cacheSession(outcome.session);
+  rememberLastSignIn(outcome.session);
+  trackSignIn(analyticsProvider, outcome.isNewUser);
+}
+
+// A sign-in that CREATED the account also emits `user_signed_up` — the
+// once-per-account event the PostHog → Slack new-user notification and the
+// activation funnel key on. `user_signed_in` still fires on every sign-in.
+function trackSignIn(provider: string, isNewUser: boolean): void {
+  if (isNewUser) analytics.track("user_signed_up", { provider });
+  analytics.track("user_signed_in", { provider });
 }
 
 // Device-local hint for the sign-in screen, stamped at BOTH terminal success
@@ -113,8 +122,8 @@ export function signInWithGoogle(opts?: SignInOptions): Promise<void> {
     if (osIsTauri()) {
       // A `null` session = benign cancel (superseded / unmount / abandoned tab):
       // no session write, no emit, no throw — mirroring the web popup-cancel path.
-      const session = await googleDesktopSession(opts);
-      if (session) await establishDesktopSession(session, "google");
+      const signIn = await googleDesktopSession(opts);
+      if (signIn) await establishDesktopSession(signIn, "google");
       return;
     }
     // Web popup returns focus naturally, so `onBrowserOpened` is not needed here.
@@ -130,8 +139,8 @@ export function signInWithMicrosoft(opts?: SignInOptions): Promise<void> {
     if (osIsTauri()) {
       // "azure" keeps the historical analytics provider value for continuity.
       // A `null` session is a benign cancel (see signInWithGoogle).
-      const session = await microsoftDesktopSession(opts);
-      if (session) await establishDesktopSession(session, "azure");
+      const signIn = await microsoftDesktopSession(opts);
+      if (signIn) await establishDesktopSession(signIn, "azure");
       return;
     }
     const web = await loadWebIdentity();
@@ -147,8 +156,8 @@ export function signInWithApple(opts?: SignInOptions): Promise<void> {
       // GCIP-brokered loopback (Apple rejects 127.0.0.1 redirects on direct
       // OAuth, so GCIP's handler is the registered return URL). A `null`
       // session is a benign cancel (see signInWithGoogle).
-      const session = await appleDesktopSession(opts);
-      if (session) await establishDesktopSession(session, "apple");
+      const signIn = await appleDesktopSession(opts);
+      if (signIn) await establishDesktopSession(signIn, "apple");
       return;
     }
     const web = await loadWebIdentity();
@@ -183,8 +192,8 @@ export function verifyEmailOtp(email: string, code: string): Promise<void> {
         code,
       );
       if (osIsTauri()) {
-        const session = await customTokenDesktopSession(customToken);
-        await establishDesktopSession(session, "email");
+        const signIn = await customTokenDesktopSession(customToken);
+        await establishDesktopSession(signIn, "email");
         return;
       }
       const web = await loadWebIdentity();

--- a/app/src/lib/identity/desktop-signin.ts
+++ b/app/src/lib/identity/desktop-signin.ts
@@ -1,7 +1,8 @@
 // Desktop sign-in orchestration: drive the loopback/PKCE authorize + the GCIP
-// REST exchange, and assemble the app's `Session`. auth.ts calls these on the
-// `osIsTauri()` branch; the web branch uses firebase-js-sdk instead. Kept beside
-// the identity REST modules (not in auth.ts) so auth.ts stays a thin dispatcher.
+// REST exchange, and assemble a `SignInOutcome` (the app's `Session` + GCIP's
+// account-created flag). auth.ts calls these on the `osIsTauri()` branch; the
+// web branch uses firebase-js-sdk instead. Kept beside the identity REST
+// modules (not in auth.ts) so auth.ts stays a thin dispatcher.
 
 import { authorizeAppleDesktop } from "./apple-authorize.ts";
 import { identityConfig } from "./config.ts";
@@ -15,16 +16,17 @@ import {
 import { authorizeGoogleDesktop } from "./google-authorize.ts";
 import { decodeIdTokenClaims } from "./id-token.ts";
 import { authorizeMicrosoftDesktop } from "./microsoft-authorize.ts";
-import type { Session } from "./session.ts";
+import type { SignInOutcome } from "./session.ts";
 import { sessionFromCustomToken, sessionFromIdp } from "./session-from-idp.ts";
 
 /**
- * Google: loopback id_token → `signInWithIdp` → Session (provider "google.com").
- * Returns `null` when the loopback authorize was benignly cancelled.
+ * Google: loopback id_token → `signInWithIdp` → SignInOutcome (provider
+ * "google.com"). Returns `null` when the loopback authorize was benignly
+ * cancelled.
  */
 export async function googleDesktopSession(
   opts?: LoopbackAuthorizeOptions,
-): Promise<Session | null> {
+): Promise<SignInOutcome | null> {
   const idToken = await authorizeGoogleDesktop(opts);
   if (idToken === null) return null; // benign cancel
   const result = await signInWithIdp({
@@ -32,16 +34,20 @@ export async function googleDesktopSession(
     providerId: "google.com",
     idToken,
   });
-  return sessionFromIdp(result, "google.com");
+  return {
+    session: sessionFromIdp(result, "google.com"),
+    isNewUser: result.isNewUser,
+  };
 }
 
 /**
- * Microsoft: loopback tokens → `signInWithIdp` → Session (provider "microsoft.com").
- * Returns `null` when the loopback authorize was benignly cancelled.
+ * Microsoft: loopback tokens → `signInWithIdp` → SignInOutcome (provider
+ * "microsoft.com"). Returns `null` when the loopback authorize was benignly
+ * cancelled.
  */
 export async function microsoftDesktopSession(
   opts?: LoopbackAuthorizeOptions,
-): Promise<Session | null> {
+): Promise<SignInOutcome | null> {
   const authorized = await authorizeMicrosoftDesktop(opts);
   if (authorized === null) return null; // benign cancel
   const { idToken, accessToken } = authorized;
@@ -51,17 +57,20 @@ export async function microsoftDesktopSession(
     idToken,
     accessToken,
   });
-  return sessionFromIdp(result, "microsoft.com");
+  return {
+    session: sessionFromIdp(result, "microsoft.com"),
+    isNewUser: result.isNewUser,
+  };
 }
 
 /**
  * Apple: GCIP-brokered loopback (`createAuthUri` → handler → loopback) →
- * `signInWithIdpSession` → Session (provider "apple.com"). Returns `null` when
- * the authorize was benignly cancelled.
+ * `signInWithIdpSession` → SignInOutcome (provider "apple.com"). Returns `null`
+ * when the authorize was benignly cancelled.
  */
 export async function appleDesktopSession(
   opts?: LoopbackAuthorizeOptions,
-): Promise<Session | null> {
+): Promise<SignInOutcome | null> {
   const authorized = await authorizeAppleDesktop(opts);
   if (authorized === null) return null; // benign cancel
   const result = await signInWithIdpSession({
@@ -69,18 +78,24 @@ export async function appleDesktopSession(
     requestUri: authorized.requestUri,
     sessionId: authorized.sessionId,
   });
-  return sessionFromIdp(result, "apple.com");
+  return {
+    session: sessionFromIdp(result, "apple.com"),
+    isNewUser: result.isNewUser,
+  };
 }
 
-/** Email OTP: gateway custom token → REST exchange → Session from decoded claims. */
+/** Email OTP: gateway custom token → REST exchange → outcome from decoded claims. */
 export async function customTokenDesktopSession(
   customToken: string,
-): Promise<Session> {
+): Promise<SignInOutcome> {
   const tokens = await signInWithCustomToken({
     apiKey: identityConfig.apiKey,
     customToken,
   });
   const claims = decodeIdTokenClaims(tokens.idToken);
   if (!claims) throw new IdentityError("malformed_response");
-  return sessionFromCustomToken(tokens, claims);
+  return {
+    session: sessionFromCustomToken(tokens, claims),
+    isNewUser: tokens.isNewUser,
+  };
 }

--- a/app/src/lib/identity/firebase-popup-stub.ts
+++ b/app/src/lib/identity/firebase-popup-stub.ts
@@ -7,7 +7,7 @@
 // here mirrors that module's signature but throws `operation_not_allowed` — none
 // is ever called on desktop (the flows are `osIsTauri()`-guarded in auth.ts).
 
-import { IdentityError, type Session } from "./index.ts";
+import { IdentityError, type Session, type SignInOutcome } from "./index.ts";
 
 // A firebase-free structural view of the fields `toSession` reads from a
 // Firebase user. The desktop bundle has no firebase types, so the seam's
@@ -35,21 +35,21 @@ export function initWebAuth(_config: {
   notOnDesktop();
 }
 
-export function webSignInWithGoogle(): Promise<Session | null> {
+export function webSignInWithGoogle(): Promise<SignInOutcome | null> {
   return notOnDesktop();
 }
 
-export function webSignInWithMicrosoft(): Promise<Session | null> {
+export function webSignInWithMicrosoft(): Promise<SignInOutcome | null> {
   return notOnDesktop();
 }
 
-export function webSignInWithApple(): Promise<Session | null> {
+export function webSignInWithApple(): Promise<SignInOutcome | null> {
   return notOnDesktop();
 }
 
 export function webSignInWithCustomToken(
   _token: string,
-): Promise<Session | null> {
+): Promise<SignInOutcome | null> {
   return notOnDesktop();
 }
 

--- a/app/src/lib/identity/firebase-rest.ts
+++ b/app/src/lib/identity/firebase-rest.ts
@@ -32,6 +32,8 @@ export interface IdpSignInResult {
   displayName: string | null;
   photoUrl: string | null;
   providerId: string;
+  /** True when THIS exchange created the GCIP account (first sign-in ever). */
+  isNewUser: boolean;
 }
 
 export interface PasswordSignInResult {
@@ -47,6 +49,12 @@ export interface TokenSignInResult {
   idToken: string;
   refreshToken: string;
   expiresAt: number;
+}
+
+/** Custom-token exchange tokens + GCIP's account-creation flag. */
+export interface CustomTokenSignInResult extends TokenSignInResult {
+  /** True when THIS exchange created the GCIP account (first sign-in ever). */
+  isNewUser: boolean;
 }
 
 function reqString(
@@ -105,6 +113,7 @@ export async function signInWithIdp(params: {
     photoUrl: typeof body.photoUrl === "string" ? body.photoUrl : null,
     providerId:
       typeof body.providerId === "string" ? body.providerId : params.providerId,
+    isNewUser: body.isNewUser === true,
   };
 }
 
@@ -140,6 +149,7 @@ export async function signInWithIdpSession(params: {
     displayName: typeof body.displayName === "string" ? body.displayName : null,
     photoUrl: typeof body.photoUrl === "string" ? body.photoUrl : null,
     providerId: typeof body.providerId === "string" ? body.providerId : "",
+    isNewUser: body.isNewUser === true,
   };
 }
 
@@ -195,7 +205,7 @@ export async function signInWithPassword(params: {
 export async function signInWithCustomToken(params: {
   apiKey: string;
   customToken: string;
-}): Promise<TokenSignInResult> {
+}): Promise<CustomTokenSignInResult> {
   const body = await postGcipJson(
     `${IDENTITY_TOOLKIT_BASE}/accounts:signInWithCustomToken?key=${params.apiKey}`,
     { token: params.customToken, returnSecureToken: true },
@@ -204,6 +214,7 @@ export async function signInWithCustomToken(params: {
     idToken: reqString(body, "idToken"),
     refreshToken: reqString(body, "refreshToken"),
     expiresAt: expiresAtFrom(body, "expiresIn"),
+    isNewUser: body.isNewUser === true,
   };
 }
 

--- a/app/src/lib/identity/index.ts
+++ b/app/src/lib/identity/index.ts
@@ -35,7 +35,7 @@ export {
   startProactiveRefresh,
   stopProactiveRefresh,
 } from "./refresh.ts";
-export type { AuthProvider, Session } from "./session.ts";
+export type { AuthProvider, Session, SignInOutcome } from "./session.ts";
 export {
   clearSession,
   loadSession,

--- a/app/src/lib/identity/session.ts
+++ b/app/src/lib/identity/session.ts
@@ -48,6 +48,17 @@ export interface Session {
   expiresAt: number;
 }
 
+/**
+ * A completed interactive sign-in: the session plus whether GCIP created the
+ * account during this exchange (`isNewUser`). Deliberately NOT part of
+ * `Session` — being new is a fact about the sign-up moment, not state to
+ * persist and re-serve on every launch.
+ */
+export interface SignInOutcome {
+  session: Session;
+  isNewUser: boolean;
+}
+
 function isAuthProvider(v: unknown): v is AuthProvider {
   return (
     typeof v === "string" && (AUTH_PROVIDERS as readonly string[]).includes(v)

--- a/app/tests/auth-session-map.test.ts
+++ b/app/tests/auth-session-map.test.ts
@@ -23,6 +23,7 @@ describe("identity/session-from-idp — sessionFromIdp", () => {
       displayName: "Ada Lovelace",
       photoUrl: "https://example.com/a.png",
       providerId: "google.com",
+      isNewUser: false,
     };
     const expected: Session = {
       idToken: "id-token",
@@ -49,12 +50,14 @@ describe("identity/session-from-idp — sessionFromIdp", () => {
       displayName: null,
       photoUrl: null,
       providerId: "microsoft.com",
+      isNewUser: true, // moment-in-time flag: the mapper must NOT leak it into Session
     };
     const session = sessionFromIdp(result, "microsoft.com");
     deepStrictEqual(session.provider, "microsoft.com");
     deepStrictEqual(session.displayName, null);
     deepStrictEqual(session.photoUrl, null);
     deepStrictEqual(session.email, "");
+    deepStrictEqual("isNewUser" in session, false);
   });
 });
 

--- a/app/tests/identity-firebase-rest.test.ts
+++ b/app/tests/identity-firebase-rest.test.ts
@@ -76,6 +76,17 @@ describe("firebase-rest signInWithIdp", () => {
     strictEqual(r.photoUrl, "https://example.com/grace.png");
     strictEqual(r.expiresAt >= before + 3600 * 1000, true);
     strictEqual(r.expiresAt <= Date.now() + 3600 * 1000, true);
+    strictEqual(r.isNewUser, false); // absent in the response → not a signup
+  });
+
+  it("parses isNewUser=true when the exchange created the account", async () => {
+    stubFetch(200, { ...IDP_OK, isNewUser: true });
+    const r = await signInWithIdp({
+      apiKey: "k",
+      providerId: "google.com",
+      idToken: "google-id-token",
+    });
+    strictEqual(r.isNewUser, true);
   });
 
   it("parses photoUrl as null when the GCIP response omits it", async () => {
@@ -184,6 +195,18 @@ describe("firebase-rest signInWithCustomToken", () => {
     const r = await signInWithCustomToken({ apiKey: "k", customToken: "ct" });
     strictEqual(r.idToken, "id-2");
     strictEqual(r.refreshToken, "r-2");
+    strictEqual(r.isNewUser, false); // absent in the response → not a signup
+  });
+
+  it("parses isNewUser=true when the exchange created the account (email-OTP signup)", async () => {
+    stubFetch(200, {
+      idToken: "id-2",
+      refreshToken: "r-2",
+      expiresIn: "3600",
+      isNewUser: true,
+    });
+    const r = await signInWithCustomToken({ apiKey: "k", customToken: "ct" });
+    strictEqual(r.isNewUser, true);
   });
 
   it("maps an invalid custom token", async () => {
@@ -259,7 +282,11 @@ describe("firebase-rest createAuthUri (brokered flow, Apple)", () => {
 
 describe("firebase-rest signInWithIdpSession (brokered flow, Apple)", () => {
   it("posts requestUri + sessionId (no postBody) and normalizes the session", async () => {
-    const { captured } = stubFetch(200, { ...IDP_OK, providerId: "apple.com" });
+    const { captured } = stubFetch(200, {
+      ...IDP_OK,
+      providerId: "apple.com",
+      isNewUser: true,
+    });
     const res = await signInWithIdpSession({
       apiKey: "k",
       requestUri: "http://127.0.0.1:8975/auth/callback?state=st-9&code=c",
@@ -267,6 +294,7 @@ describe("firebase-rest signInWithIdpSession (brokered flow, Apple)", () => {
     });
     strictEqual(res.uid, "uid-1");
     strictEqual(res.providerId, "apple.com");
+    strictEqual(res.isNewUser, true);
     const body = JSON.parse(captured.body);
     strictEqual(body.sessionId, "sess-9");
     strictEqual(

--- a/packages/web/src/admin/use-admin-auth.ts
+++ b/packages/web/src/admin/use-admin-auth.ts
@@ -168,7 +168,7 @@ export function useAdminAuth(): AdminAuth {
     setError(null);
     try {
       const s = await webSignInWithGoogle();
-      if (s) adopt(sessionFromIdentity(s)); // null = popup cancelled (benign)
+      if (s) adopt(sessionFromIdentity(s.session)); // null = popup cancelled (benign)
     } catch (e) {
       setError(adminAuthMessage(e));
     } finally {

--- a/packages/web/src/identity/firebase-popup.ts
+++ b/packages/web/src/identity/firebase-popup.ts
@@ -13,12 +13,14 @@ import {
   decodeIdTokenClaims,
   IdentityError,
   type Session,
+  type SignInOutcome,
 } from "@houston/app/lib/identity";
 import { initializeApp } from "firebase/app";
 import {
   type Auth,
   browserLocalPersistence,
   GoogleAuthProvider,
+  getAdditionalUserInfo,
   getAuth,
   OAuthProvider,
   onIdTokenChanged,
@@ -27,6 +29,7 @@ import {
   signInWithPopup,
   signOut,
   type User,
+  type UserCredential,
 } from "firebase/auth";
 import { isBenignPopupCancel, mapFirebaseError } from "./firebase-errors.ts";
 
@@ -69,13 +72,23 @@ async function ready(): Promise<Auth> {
   return auth;
 }
 
+// Assemble the outcome: the app Session + whether this credential CREATED the
+// GCIP account (`getAdditionalUserInfo(...).isNewUser` — the SDK counterpart of
+// the REST `isNewUser` field the desktop path reads).
+async function toOutcome(cred: UserCredential): Promise<SignInOutcome> {
+  return {
+    session: await toSession(cred.user),
+    isNewUser: getAdditionalUserInfo(cred)?.isNewUser === true,
+  };
+}
+
 async function popupSignIn(
   provider: GoogleAuthProvider | OAuthProvider,
-): Promise<Session | null> {
+): Promise<SignInOutcome | null> {
   const auth = await ready();
   try {
     const cred = await signInWithPopup(auth, provider);
-    return await toSession(cred.user);
+    return await toOutcome(cred);
   } catch (e) {
     if (isBenignPopupCancel(e)) return null; // benign cancel: no toast, no-op
     throw mapFirebaseError(e);
@@ -83,18 +96,18 @@ async function popupSignIn(
 }
 
 /** Google popup sign-in. Resolves `null` if the user cancels the popup. */
-export function webSignInWithGoogle(): Promise<Session | null> {
+export function webSignInWithGoogle(): Promise<SignInOutcome | null> {
   return popupSignIn(new GoogleAuthProvider());
 }
 
 /** Microsoft (Entra) popup sign-in. Resolves `null` on a cancelled popup. */
-export function webSignInWithMicrosoft(): Promise<Session | null> {
+export function webSignInWithMicrosoft(): Promise<SignInOutcome | null> {
   return popupSignIn(new OAuthProvider("microsoft.com"));
 }
 
 /** Apple popup sign-in. Resolves `null` on a cancelled popup. Apple returns
  *  the user's name/email only on the FIRST consent for this Services ID. */
-export function webSignInWithApple(): Promise<Session | null> {
+export function webSignInWithApple(): Promise<SignInOutcome | null> {
   const provider = new OAuthProvider("apple.com");
   provider.addScope("email");
   provider.addScope("name");
@@ -104,11 +117,11 @@ export function webSignInWithApple(): Promise<Session | null> {
 /** Exchange a gateway-minted custom token (email-OTP flow) for a session. */
 export async function webSignInWithCustomToken(
   token: string,
-): Promise<Session | null> {
+): Promise<SignInOutcome | null> {
   const auth = await ready();
   try {
     const cred = await signInWithCustomToken(auth, token);
-    return await toSession(cred.user);
+    return await toOutcome(cred);
   } catch (e) {
     throw mapFirebaseError(e);
   }


### PR DESCRIPTION
## What

Emit a once-per-account **`user_signed_up`** analytics event on the first sign-in of a brand-new GCIP account, and stamp the display name as a PostHog person property. This powers the new-user Slack notification (PostHog destination on `user_signed_up` posting to #new-signup, replacing the old Supabase alert) and gives the activation funnel a real signup anchor.

## How

- **`firebase-rest.ts`**: parse the `isNewUser` flag GCIP already returns from `signInWithIdp`, `signInWithIdpSession`, and `signInWithCustomToken` (new `CustomTokenSignInResult`). It was being discarded during normalization.
- **`desktop-signin.ts`**: the four desktop flows now return a `SignInOutcome` (`Session` + `isNewUser`). `Session` itself is unchanged; being new is a fact about the sign-up moment, not persisted state.
- **`firebase-popup.ts` (web)**: same outcome via `getAdditionalUserInfo(cred).isNewUser`; desktop stub and admin sign-in updated to match.
- **`auth.ts`**: single `trackSignIn` point fires `user_signed_up` only when the account was just created; `user_signed_in` keeps firing on every sign-in, so existing dashboards are untouched.
- **`analytics.ts` / `App.tsx`**: `identifyUser` now also stamps `name` as a person property (same policy as email: person property for lookup, never an event prop). The Slack message renders Complete name / Email from person properties.

## Verification

- Biome clean, `tsgo --noEmit` clean for `app/` and `packages/web` (shim-parity guard OK).
- Full app suite: 1938 tests pass, including new asserts for `isNewUser` parsing across the three GCIP exchanges.
- The PostHog → Slack destination is already live and was verified end-to-end with injected `user_signed_up` test events.

## Notes

- Email-OTP caveat: if the gateway pre-creates the GCIP user before minting the custom token, that exchange would report `isNewUser=false` and email signups would not fire the event. Worth verifying with a real email signup after release.
