### PR TITLE
fix(chat): block image attachments when the active model has no vision

### DIFF
--- a/app/src/components/attachment-rejection-dialog.tsx
+++ b/app/src/components/attachment-rejection-dialog.tsx
@@ -12,6 +12,7 @@ import { AlertTriangle } from "lucide-react";
 import { type ReactNode, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  type ComposerAttachmentPolicy,
   type ComposerAttachmentRejectReason,
   formatBytes,
   splitComposerAttachments,
@@ -23,15 +24,20 @@ interface AttachmentValidationDialogApi {
   dialog: ReactNode;
 }
 
-export function useAttachmentRejectionDialog(): AttachmentValidationDialogApi {
+export function useAttachmentRejectionDialog(
+  policy?: ComposerAttachmentPolicy,
+): AttachmentValidationDialogApi {
   const { t } = useTranslation("chat");
   const [rejections, setRejections] = useState<AttachmentRejection[]>([]);
   const open = rejections.length > 0;
   const close = useCallback(() => setRejections([]), []);
 
+  // Keyed on the policy VALUE (not the object identity) so callers may build
+  // the policy inline without re-creating prepareAttachments every render.
+  const modelAcceptsImages = policy?.modelAcceptsImages;
   const prepareAttachments = useCallback<PrepareAttachments>(
     (incoming) => {
-      const result = splitComposerAttachments(incoming);
+      const result = splitComposerAttachments(incoming, { modelAcceptsImages });
       return {
         accepted: result.accepted,
         rejected: result.rejected.map((rejection) => ({
@@ -40,7 +46,7 @@ export function useAttachmentRejectionDialog(): AttachmentValidationDialogApi {
         })),
       };
     },
-    [t],
+    [t, modelAcceptsImages],
   );
 
   const onAttachmentRejections = useCallback(
@@ -98,6 +104,9 @@ function formatReason(
     return t("attachmentIssues.reasons.tooLarge", {
       maxSize: formatBytes(reason.maxBytes),
     });
+  }
+  if (reason.kind === "modelCannotViewImages") {
+    return t("attachmentIssues.reasons.modelCannotViewImages");
   }
   if (reason.extension) {
     return t("attachmentIssues.reasons.blockedTypeWithExtension", {

--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -2,6 +2,7 @@ import { AIBoard } from "@houston-ai/board";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useOpenAgentHref } from "../../hooks/use-open-agent-file";
+import { modelAcceptsImages } from "../../lib/providers";
 import { useUIStore } from "../../stores/ui";
 import { useAttachmentRejectionDialog } from "../attachment-rejection-dialog";
 import { buildMissionBoardColumns } from "../mission-board-columns";
@@ -116,7 +117,12 @@ export function MissionBoard({ source }: { source: BoardSource }) {
     source.activeAgent?.folderPath ?? null,
   );
 
-  const attachmentValidation = useAttachmentRejectionDialog();
+  const attachmentValidation = useAttachmentRejectionDialog({
+    modelAcceptsImages: modelAcceptsImages(
+      panel.effectiveProvider,
+      panel.effectiveModel,
+    ),
+  });
 
   return (
     <>

--- a/app/src/components/board/mission-control-archived.tsx
+++ b/app/src/components/board/mission-control-archived.tsx
@@ -2,6 +2,7 @@ import { AIBoard } from "@houston-ai/board";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useOpenAgentHref } from "../../hooks/use-open-agent-file";
+import { modelAcceptsImages } from "../../lib/providers";
 import type { Agent } from "../../lib/types";
 import { useAgentCatalogStore } from "../../stores/agent-catalog";
 import { useUIStore } from "../../stores/ui";
@@ -36,7 +37,6 @@ export function MissionControlArchived({
   const missionPanelOpen = useUIStore((s) => s.missionPanelOpen);
 
   const data = useMissionControlArchived(agents);
-  const attachmentValidation = useAttachmentRejectionDialog();
 
   const [filterPath, setFilterPath] = useState("");
   const [search, setSearch] = useState("");
@@ -80,6 +80,12 @@ export function MissionControlArchived({
     agentDef: activeAgentDef,
     selectedSessionKey,
     onSelectSession: data.setSelectedId,
+  });
+  const attachmentValidation = useAttachmentRejectionDialog({
+    modelAcceptsImages: modelAcceptsImages(
+      panel.effectiveProvider,
+      panel.effectiveModel,
+    ),
   });
   const clearSelection = useCallback(() => data.setSelectedId(null), [data]);
   const openHref = useOpenAgentHref(activeAgent?.folderPath ?? null);

--- a/app/src/components/tabs/archived-tab.tsx
+++ b/app/src/components/tabs/archived-tab.tsx
@@ -8,6 +8,7 @@ import { useActivity, useDeleteActivity } from "../../hooks/queries";
 import { useConversationFeed } from "../../hooks/use-conversation-vm";
 import { useOpenAgentHref } from "../../hooks/use-open-agent-file";
 import { selectArchived } from "../../lib/mission-selection";
+import { modelAcceptsImages } from "../../lib/providers";
 import type { TabProps } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 import { useAttachmentRejectionDialog } from "../attachment-rejection-dialog";
@@ -35,7 +36,6 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
   const deleteActivity = useDeleteActivity(path);
   const setMissionPanelOpen = useUIStore((s) => s.setMissionPanelOpen);
   const viewMode = useUIStore((s) => s.viewMode);
-  const attachmentValidation = useAttachmentRejectionDialog();
 
   const archived = useMemo(() => selectArchived(rawItems ?? []), [rawItems]);
   const items: KanbanItem[] = useMemo(
@@ -77,6 +77,9 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
     onSelectSession: setSelectedId,
   });
   const { effectiveProvider, effectiveModel } = panel;
+  const attachmentValidation = useAttachmentRejectionDialog({
+    modelAcceptsImages: modelAcceptsImages(effectiveProvider, effectiveModel),
+  });
 
   // The open conversation's reactive feed from the SDK conversation VM
   // (history seeded by the adapter's loadHistory).

--- a/app/src/components/tabs/routine-setup-chat-board.tsx
+++ b/app/src/components/tabs/routine-setup-chat-board.tsx
@@ -12,6 +12,7 @@ import type { Activity } from "@houston-ai/engine-client";
 import { type ReactNode, useCallback, useMemo } from "react";
 import { useConversationFeed } from "../../hooks/use-conversation-vm";
 import { useOpenAgentHref } from "../../hooks/use-open-agent-file";
+import { modelAcceptsImages } from "../../lib/providers";
 import { type HistoryLoadOptions, tauriChat } from "../../lib/tauri";
 import type { TabProps } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
@@ -64,7 +65,6 @@ export function RoutineSetupChatBoard({
   const openHref = useOpenAgentHref(path);
   const queuedLabels = useQueuedMessageLabels();
   const { composerLabels } = useBoardLabels();
-  const attachmentValidation = useAttachmentRejectionDialog();
   const addToast = useUIStore((s) => s.addToast);
 
   const panel = useAgentChatPanel({
@@ -76,6 +76,12 @@ export function RoutineSetupChatBoard({
     // needs ask_user and must never open read-only in Planner — so the live
     // composer opens on Coworker too. The user can still switch modes here.
     initialTurnMode: "execute",
+  });
+  const attachmentValidation = useAttachmentRejectionDialog({
+    modelAcceptsImages: modelAcceptsImages(
+      panel.effectiveProvider,
+      panel.effectiveModel,
+    ),
   });
   const overrides = useMemo(
     () => ({

--- a/app/src/lib/attachment-validation.ts
+++ b/app/src/lib/attachment-validation.ts
@@ -8,7 +8,20 @@ export interface ComposerAttachmentFile {
 
 export type ComposerAttachmentRejectReason =
   | { kind: "blockedType"; extension?: string }
-  | { kind: "tooLarge"; maxBytes: number };
+  | { kind: "tooLarge"; maxBytes: number }
+  | { kind: "modelCannotViewImages" };
+
+/**
+ * What the active chat allows, threaded from the composer's effective model.
+ * `modelAcceptsImages: false` = the model that will run this turn cannot take
+ * image input, so image files are rejected LOUDLY at attach time — without
+ * this, the agent gets a file path it can never see and burns the mission
+ * planning OCR forever. `true`/`undefined` (unknown) both permit images:
+ * only a definitive "no vision" from the catalog blocks.
+ */
+export interface ComposerAttachmentPolicy {
+  modelAcceptsImages?: boolean;
+}
 
 export interface ComposerAttachmentRejection<T extends ComposerAttachmentFile> {
   file: T;
@@ -58,6 +71,7 @@ const BLOCKED_MIME_TYPES = new Set([
 
 export function splitComposerAttachments<T extends ComposerAttachmentFile>(
   incoming: readonly T[],
+  policy?: ComposerAttachmentPolicy,
 ): {
   accepted: T[];
   rejected: ComposerAttachmentRejection<T>[];
@@ -65,7 +79,7 @@ export function splitComposerAttachments<T extends ComposerAttachmentFile>(
   const accepted: T[] = [];
   const rejected: ComposerAttachmentRejection<T>[] = [];
   for (const file of incoming) {
-    const reason = validateComposerAttachment(file);
+    const reason = validateComposerAttachment(file, policy);
     if (reason) rejected.push({ file, reason });
     else accepted.push(file);
   }
@@ -74,6 +88,7 @@ export function splitComposerAttachments<T extends ComposerAttachmentFile>(
 
 export function validateComposerAttachment(
   file: ComposerAttachmentFile,
+  policy?: ComposerAttachmentPolicy,
 ): ComposerAttachmentRejectReason | null {
   const extension = extensionOf(file.name);
   if (extension && BLOCKED_EXTENSIONS.has(extension)) {
@@ -87,10 +102,39 @@ export function validateComposerAttachment(
   ) {
     return { kind: "blockedType", extension };
   }
+  if (policy?.modelAcceptsImages === false && isImageAttachment(file)) {
+    return { kind: "modelCannotViewImages" };
+  }
   if (file.size > MAX_COMPOSER_ATTACHMENT_BYTES) {
     return { kind: "tooLarge", maxBytes: MAX_COMPOSER_ATTACHMENT_BYTES };
   }
   return null;
+}
+
+// Raster/photo formats only: these are opaque to a no-vision model (its Read
+// tool can't show them, which is what sends the agent into the OCR spiral).
+// SVG is deliberately NOT here — it's text/XML any model can read.
+const IMAGE_EXTENSIONS = new Set([
+  "avif",
+  "bmp",
+  "gif",
+  "heic",
+  "heif",
+  "ico",
+  "jpeg",
+  "jpg",
+  "png",
+  "tif",
+  "tiff",
+  "webp",
+]);
+
+function isImageAttachment(file: ComposerAttachmentFile): boolean {
+  const mime = (file.type ?? "").toLowerCase();
+  if (mime === "image/svg+xml") return false;
+  if (mime.startsWith("image/")) return true;
+  const extension = extensionOf(file.name);
+  return !!extension && IMAGE_EXTENSIONS.has(extension);
 }
 
 export function formatBytes(bytes: number): string {

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -47,6 +47,12 @@ export interface ModelOption {
   label: string;
   description: string;
   /**
+   * Whether the model accepts image INPUT (the catalog's `vision` flag).
+   * Absent on seed/override-only entries (pre-hydration) = unknown — the
+   * composer's image gate only blocks on a definitive `false`.
+   */
+  acceptsImages?: boolean;
+  /**
    * Reasoning-effort levels this model accepts, ordered low→high. Omitted
    * or empty means the model has no effort control and the picker hides the
    * effort row (e.g. Haiku).
@@ -217,6 +223,7 @@ function buildProvider(
         id: entry.id,
         label: mo?.label ?? entry.name,
         description: mo?.description ?? "",
+        acceptsImages: entry.vision === true,
         contextWindow: window.default,
         // Omit when there is no upward gating, matching the "absent = no snap"
         // contract `getContextWindowConfig` reads.
@@ -554,6 +561,20 @@ export function validModelOrNull(
   // silently reverts a live OpenRouter pick to the provider default.
   if (isOpenCatalogProvider(providerId)) return modelId;
   return getModel(providerId, modelId) ? modelId : null;
+}
+
+/**
+ * Whether a model accepts image input, from the hydrated catalog. `undefined`
+ * when the model isn't in `PROVIDERS` (pre-hydration, local/BYO, or an
+ * open-catalog id) = unknown — callers must treat unknown as permitted, so a
+ * missing catalog can never block an attachment the model might handle.
+ */
+export function modelAcceptsImages(
+  providerId: string | null | undefined,
+  modelId: string | null | undefined,
+): boolean | undefined {
+  if (!providerId || !modelId) return undefined;
+  return getModel(providerId, modelId)?.acceptsImages;
 }
 
 /**

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -115,7 +115,8 @@
     "reasons": {
       "blockedType": "This file type cannot be used here.",
       "blockedTypeWithExtension": ".{{extension}} files cannot be used here.",
-      "tooLarge": "This file is larger than {{maxSize}}."
+      "tooLarge": "This file is larger than {{maxSize}}.",
+      "modelCannotViewImages": "The current AI model can't view images. Switch to a model with vision or remove the image."
     }
   },
   "composio": {

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -115,7 +115,8 @@
     "reasons": {
       "blockedType": "Este tipo de archivo no se puede usar aquí.",
       "blockedTypeWithExtension": "Los archivos .{{extension}} no se pueden usar aquí.",
-      "tooLarge": "Este archivo supera {{maxSize}}."
+      "tooLarge": "Este archivo supera {{maxSize}}.",
+      "modelCannotViewImages": "El modelo de IA actual no puede ver imágenes. Cambia a un modelo con visión o quita la imagen."
     }
   },
   "composio": {

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -115,7 +115,8 @@
     "reasons": {
       "blockedType": "Este tipo de arquivo não pode ser usado aqui.",
       "blockedTypeWithExtension": "Arquivos .{{extension}} não podem ser usados aqui.",
-      "tooLarge": "Este arquivo é maior que {{maxSize}}."
+      "tooLarge": "Este arquivo é maior que {{maxSize}}.",
+      "modelCannotViewImages": "O modelo de IA atual não consegue ver imagens. Troque para um modelo com visão ou remova a imagem."
     }
   },
   "composio": {

--- a/app/tests/attachment-validation.test.ts
+++ b/app/tests/attachment-validation.test.ts
@@ -44,3 +44,66 @@ describe("composer attachment validation", () => {
     });
   });
 });
+
+describe("composer image gate (model without vision)", () => {
+  const noVision = { modelAcceptsImages: false };
+
+  it("rejects an image when the active model cannot view images", () => {
+    const reason = validateComposerAttachment(
+      { name: "screenshot.png", size: 1024, type: "image/png" },
+      noVision,
+    );
+    deepStrictEqual(reason, { kind: "modelCannotViewImages" });
+  });
+
+  it("detects images by extension when the mime type is missing", () => {
+    const reason = validateComposerAttachment(
+      { name: "photo.HEIC", size: 1024, type: "" },
+      noVision,
+    );
+    deepStrictEqual(reason, { kind: "modelCannotViewImages" });
+  });
+
+  it("allows images when the model has vision or capability is unknown", () => {
+    const file = { name: "screenshot.png", size: 1024, type: "image/png" };
+    strictEqual(
+      validateComposerAttachment(file, { modelAcceptsImages: true }),
+      null,
+    );
+    strictEqual(validateComposerAttachment(file, {}), null);
+    strictEqual(validateComposerAttachment(file), null);
+  });
+
+  it("lets SVG through: it is text any model can read", () => {
+    const reason = validateComposerAttachment(
+      { name: "diagram.svg", size: 1024, type: "image/svg+xml" },
+      noVision,
+    );
+    strictEqual(reason, null);
+  });
+
+  it("leaves non-image files untouched by the gate", () => {
+    const reason = validateComposerAttachment(
+      { name: "notes.pdf", size: 1024, type: "application/pdf" },
+      noVision,
+    );
+    strictEqual(reason, null);
+  });
+
+  it("splits a mixed batch: images rejected, documents kept", () => {
+    const result = splitComposerAttachments(
+      [
+        { name: "brief.pdf", size: 1024, type: "application/pdf" },
+        { name: "receipt.jpg", size: 1024, type: "image/jpeg" },
+      ],
+      noVision,
+    );
+    deepStrictEqual(
+      result.accepted.map((f) => f.name),
+      ["brief.pdf"],
+    );
+    deepStrictEqual(result.rejected[0]?.reason, {
+      kind: "modelCannotViewImages",
+    });
+  });
+});

--- a/app/tests/provider-catalog.test.ts
+++ b/app/tests/provider-catalog.test.ts
@@ -8,6 +8,7 @@ import {
   getModel,
   getProvider,
   hydrateProviderCatalog,
+  modelAcceptsImages,
   normalizeEffort,
   normalizeLegacyModel,
   PROVIDERS,
@@ -56,6 +57,16 @@ describe("hydrateProviderCatalog: model metadata", () => {
     const sonnet = getModel("anthropic", "claude-sonnet-5");
     strictEqual(sonnet?.label, "Sonnet 5");
     ok(sonnet && sonnet.description.length > 0);
+  });
+
+  it("keeps the catalog's vision flag as acceptsImages (the composer image gate reads it)", () => {
+    strictEqual(getModel("openai", "gpt-5.6-sol")?.acceptsImages, true);
+    strictEqual(getModel("openai", "gpt-5.6-luna")?.acceptsImages, false);
+    strictEqual(modelAcceptsImages("openai", "gpt-5.6-sol"), true);
+    strictEqual(modelAcceptsImages("openai", "gpt-5.6-luna"), false);
+    // Unknown model / provider = unknown, never a definitive block.
+    strictEqual(modelAcceptsImages("openai", "no-such-model"), undefined);
+    strictEqual(modelAcceptsImages(null, null), undefined);
   });
 
   it("takes the model window from pi, and the snap-up ceiling from the override", () => {


### PR DESCRIPTION
## What

Fixes the "agent loops forever planning OCR" bug: when a user attaches an image and the active model can't read images (e.g. Mistral), the agent used to spiral through "Planning image text extraction with OCR" indefinitely. Now the composer rejects the image at attach time with a clear, translated explanation.

## Why the loop happened

Attachments never reach the model as image input: they're uploaded to the agent's workspace and the message tells the agent to Read them. A model without vision can never see what Read returns for a raster image, so it keeps improvising (metadata, convert, OCR, repeat).

## How

- **`providers.ts`**: catalog hydration now keeps each model's `vision` flag as `acceptsImages`; a new `modelAcceptsImages(provider, model)` lookup returns `undefined` (unknown) for uncataloged models — and unknown never blocks, so a missing catalog can't reject an attachment the model might handle.
- **`attachment-validation.ts`**: new `modelCannotViewImages` reject reason for raster images (png/jpg/heic/…) when the policy says the active model has no vision. SVG is exempt: it's text any model can read.
- **The four composer surfaces** (mission board, routine setup chat, per-agent archived, mission-control archived) thread the **effective** provider/model — the one the turn will actually run — into the validator; the existing rejection dialog explains it in en/es/pt: "The current AI model can't view images. Switch to a model with vision or remove the image."

## Verification

- Biome clean, `tsgo --noEmit` clean, `check-locales` clean (en/es/pt parity).
- Full app suite: 1945 tests pass, including 7 new ones (image gate cases: reject on no-vision, extension-based detection, vision/unknown pass-through, SVG exemption, non-image untouched, mixed-batch split; plus hydration keeping the vision flag).

## Notes

- Runtime hardening (Read tool answering "this model can't view images" instead of letting the agent improvise) is a possible follow-up in the pi runtime; this PR kills the loop at its source for the real-world path.
