### PR TITLE
fix(integrations): pin Composio tool version to latest on search + execute

### DIFF
--- a/knowledge-base/integrations.md
+++ b/knowledge-base/integrations.md
@@ -32,7 +32,13 @@ code everywhere, no drift.
 - `ComposioProvider` (`composio.ts`) — the **direct** adapter. Speaks Composio v3
   REST directly (`x-api-key`), no CLI/SDK. Used by cloud + self-host, which hold
   the key. `userId` scopes each user's connections. Connect uses
-  `POST /api/v3.1/connected_accounts/link`.
+  `POST /api/v3.1/connected_accounts/link`. Every `/tools` read and execute pins
+  Composio's TOOL VERSION to `latest` (`TOOL_VERSION`): the v3 endpoints default
+  to the frozen base snapshot `00000000_00`, whose connector code ages until the
+  third-party API retires what it depends on (prod: LinkedIn create-post 426
+  NONEXISTENT_VERSION from a retired `Linkedin-Version` header) and which hides
+  every tool added since the snapshot. Search and execute pin TOGETHER so the
+  schema the model read and the connector that runs are the same version.
 - `RemoteIntegrationProvider` (`remote.ts`) — the **gateway** adapter, the
   desktop's provider. The desktop holds NO key: every port call is forwarded to
   Houston's cloud host `/v1/integrations/*` with the user's Firebase (GCIP) session

--- a/packages/host/src/integrations/composio.test.ts
+++ b/packages/host/src/integrations/composio.test.ts
@@ -740,6 +740,7 @@ test("execute posts user_id + arguments and maps success and failure", async () 
   expect(ok.calls[0]?.body).toEqual({
     user_id: USER,
     arguments: { to: "a@b.com" },
+    version: "latest",
   });
 
   const failed = harness(() => ({
@@ -750,6 +751,54 @@ test("execute posts user_id + arguments and maps success and failure", async () 
     data: undefined,
     error: "no connected account found",
   });
+});
+
+test("every tools read + execute pins version 'latest', never the frozen base snapshot", async () => {
+  // Composio's v3 endpoints default to the base snapshot (00000000_00) when no
+  // version is sent. That snapshot's connectors age until the third-party API
+  // retires what they depend on — prod: LINKEDIN_CREATE_LINKED_IN_POST kept
+  // sending the retired `Linkedin-Version: 20241101` header, so every post
+  // failed 426 NONEXISTENT_VERSION while auth still worked. Pinning `latest`
+  // on search AND execute keeps the schema the model read and the connector
+  // that runs the same, current version.
+  const { provider, calls } = harness((url) => {
+    if (url.pathname === "/api/v3/connected_accounts")
+      return {
+        body: {
+          items: [
+            { toolkit: { slug: "linkedin" }, id: "ca_1", status: "ACTIVE" },
+          ],
+        },
+      };
+    if (url.pathname === "/api/v3/toolkits") return { body: { items: [] } };
+    // Zero-hit query-bearing calls force the scoped LISTING fallback too, so
+    // all three /tools request shapes (scoped, global, listing) are exercised.
+    if (url.searchParams.has("query")) return { body: { items: [] } };
+    return {
+      body: {
+        items: [
+          {
+            slug: "LINKEDIN_CREATE_LINKED_IN_POST",
+            toolkit: { slug: "linkedin" },
+            description: "Create a post",
+          },
+        ],
+      },
+    };
+  });
+  await provider.search(USER, "post on linkedin for me");
+  const toolReads = calls.filter((c) => c.path.startsWith("/api/v3/tools?"));
+  expect(toolReads.length).toBeGreaterThanOrEqual(3);
+  for (const c of toolReads) {
+    expect(c.path).toContain("toolkit_versions=latest");
+  }
+
+  const exec = harness(() => ({ body: { successful: true, data: {} } }));
+  await exec.provider.execute(USER, "LINKEDIN_CREATE_LINKED_IN_POST", {
+    author: "urn:li:person:1",
+    commentary: "hello",
+  });
+  expect(exec.calls[0]?.body).toMatchObject({ version: "latest" });
 });
 
 test("a non-2xx response surfaces as an error with the status + detail", async () => {

--- a/packages/host/src/integrations/composio.ts
+++ b/packages/host/src/integrations/composio.ts
@@ -45,6 +45,21 @@ const DEFAULT_BASE_URL = "https://backend.composio.dev";
  *  for search's name resolution so a hot session does not refetch ~1000 apps. */
 const CATALOG_TTL_MS = 60 * 60 * 1000;
 
+/**
+ * Which Composio TOOL VERSION every /tools read and execute requests. The v3
+ * endpoints default to the FROZEN base snapshot (`00000000_00`), not the newest
+ * release, so an unversioned call runs connector code from before versioning
+ * launched — which ages until the third-party API retires what it depends on.
+ * Prod bug: LINKEDIN_CREATE_LINKED_IN_POST at the base snapshot still sent
+ * LinkedIn the retired `Linkedin-Version: 20241101` header → HTTP 426
+ * NONEXISTENT_VERSION on every post, unfixable by reconnecting. `latest` is
+ * Composio's own recommendation for agent consumers (the model re-reads each
+ * action's schema from search every turn, so schema drift self-corrects), and
+ * pinning search AND execute together keeps the schema the model read and the
+ * connector that runs the SAME version.
+ */
+const TOOL_VERSION = "latest";
+
 export interface ComposioOptions {
   /** Houston's Composio PROJECT API key (dashboard → Project Settings). */
   apiKey: string;
@@ -210,10 +225,12 @@ export class ComposioProvider implements IntegrationProvider {
       {
         listConnections: () => this.listConnections(userId),
         // GET /api/v3/tools?query=… (the older `search` param is deprecated).
+        // toolkit_versions pins the CURRENT tool set — unversioned, this
+        // endpoint serves only the base snapshot's tools (4 of LinkedIn's 22).
         queryTools: async (q) => {
           const body = await this.http.call<{ items?: RawTool[] }>(
             "/api/v3/tools",
-            { query: q },
+            { query: { ...q, toolkit_versions: TOOL_VERSION } },
           );
           return (body?.items ?? []).map(mapTool);
         },
@@ -230,9 +247,13 @@ export class ComposioProvider implements IntegrationProvider {
     _acting?: ActingContext,
   ): Promise<ActionResult> {
     // Acting context ignored — see search(): identity is the verified userId.
+    // `version` pins the connector build that runs — see TOOL_VERSION.
     const body = await this.http.call<RawExecute>(
       `/api/v3/tools/execute/${encodeURIComponent(action)}`,
-      { method: "POST", body: { user_id: userId, arguments: params } },
+      {
+        method: "POST",
+        body: { user_id: userId, arguments: params, version: TOOL_VERSION },
+      },
     );
     return mapExecute(body);
   }


### PR DESCRIPTION
## What

Fixes the user-reported LinkedIn failure: `LINKEDIN_CREATE_LINKED_IN_POST` returned `426 NONEXISTENT_VERSION ("Requested version 20241101 is not active")` on every post, and reconnecting OAuth didn't help.

## Root cause (verified against the live Composio API)

Composio's v3 `/tools` endpoints default to the **frozen base snapshot `00000000_00`** when no version is sent. Our `ComposioProvider` never sent one, so every execute ran the original connector build — the one sending LinkedIn the retired `Linkedin-Version: 20241101` header. The connector has 46 newer versions (up to `20260721_00`) with a compatible superset schema. Bonus latent bug: the frozen snapshot also hid post-launch tools — only 4 of LinkedIn's 22 tools were discoverable.

## Fix

Pin `version: "latest"` on the execute body and `toolkit_versions=latest` on every `/tools` query (scoped, global, and listing-fallback) in `packages/host/src/integrations/composio.ts`. Search and execute stay on the same version — Composio's own recommendation for agent consumers — and future connector fixes reach users the moment Composio ships them, with no Houston release needed.

## Verification

- `composio.test.ts`: updated request-shaping assertion + new regression test pinning the version on all request shapes — 31/31 pass.
- Live-verified against the Composio API with the dev key (tools listing shapes + a harmless no-auth execute).
- Biome clean, `@houston/host` typecheck clean. KB note added to `knowledge-base/integrations.md`.
- Pre-existing Windows-only failures (`custom/secrets` chmod, `local/host` fs-watcher) verified identical on clean HEAD — unrelated.

## Notes

- Could not run a real LinkedIn post end to end (needs a user with a connected account). If 426 somehow persists on `20260721_00`, escalate to Composio: the latest connector would still be sending a retired `Linkedin-Version` header.
- If the cloud gateway calls Composio with its own client, it needs the same `version: "latest"` pin in a sibling cloud PR; if it proxies to engine pods running this host, the next pod deploy covers it.
