### PR TITLE
feat(integrations): 'Most used' section above the catalog categories

### DIFF
--- a/app/src/components/integrations-view/category-catalog.tsx
+++ b/app/src/components/integrations-view/category-catalog.tsx
@@ -13,8 +13,8 @@ import {
   type ConnectFlow,
   ConnectWaitingPanel,
   categoryLabel,
-  FEATURED,
   groupCatalogByCategory,
+  MOST_USED,
   type PermissionsFix,
   SECTION_PREVIEW_CAP,
   SectionHeader,
@@ -146,8 +146,8 @@ export function CategoryCatalog({
                   // <h3>: nested under the Available section's lg <h2> heading.
                   as="h3"
                   title={
-                    section.category === FEATURED
-                      ? t("home.featured")
+                    section.category === MOST_USED
+                      ? t("home.mostUsed")
                       : section.category === UNCATEGORIZED
                         ? t("home.otherCategory")
                         : categoryLabel(section.category)

--- a/app/src/components/integrations/browse-sections.ts
+++ b/app/src/components/integrations/browse-sections.ts
@@ -9,61 +9,76 @@ import { categoryRank } from "./category-priority.ts";
 
 /**
  * The catalog-BROWSE section layer: grouping the connectable catalog into the
- * size-ranked category sections of the "plane" page, plus the curated Featured
- * spotlight pinned above them. Split from `browse-model.ts` (the filter/category
- * layer) so each file stays within the file-size law; both are pure and share
- * the same matching/ordering helpers.
+ * size-ranked category sections of the "plane" page, plus the curated "Most
+ * used" spotlight pinned above them. Split from `browse-model.ts` (the
+ * filter/category layer) so each file stays within the file-size law; both are
+ * pure and share the same matching/ordering helpers.
  */
 
-/** The section slug for the curated "Featured" spotlight, pinned FIRST on the
+/** The section slug for the curated "Most used" spotlight, pinned FIRST on the
  * at-rest landing view (before any search or category narrowing). */
-export const FEATURED = "__featured";
+export const MOST_USED = "__mostUsed";
 
 /**
- * The curated, ORDERED everyday-app spotlight for our non-technical audience —
- * the apps most people already live in, pinned above the size-ranked category
- * sections so "Developer tools" never greets a first-time user. These are
- * Composio toolkit slugs (lowercase, no separators); matched case-insensitively
- * and any that aren't in the live catalog simply drop out. Order here IS the
- * display order (curated, not A-Z).
+ * The curated, ORDERED "Most used" spotlight for our non-technical audience —
+ * the everyday apps most people already live in, pinned above the size-ranked
+ * category sections so "Developer tools" never greets a first-time user.
+ *
+ * Committed data on purpose, NOT the live API sort. Composio's toolkits
+ * endpoint DOES expose a usage sort (`GET /api/v3/toolkits?sort_by=usage`,
+ * verified 2026-07-22 — it is also the endpoint's default order), but it ranks
+ * by usage across Composio's whole customer base, which is developers: its top
+ * ten includes github, supabase and perplexityai — exactly the apps this
+ * catalog's curated ordering exists to bury for our audience (see
+ * `category-priority.ts`). Membership therefore stays hand-picked, while the
+ * ORDER follows those same apps' relative ranks from that verified usage data,
+ * so the section is honestly "most used" without the developer-heavy tail.
+ *
+ * These are Composio toolkit slugs (lowercase, no separators); matched
+ * case-insensitively and any that aren't in the live catalog simply drop out.
+ * Order here IS the display order (curated, not A-Z). The trailing numbers are
+ * each app's rank in Composio's usage-sorted catalog on 2026-07-22.
  */
-export const FEATURED_SLUGS: readonly string[] = [
-  "gmail",
-  "googlecalendar",
-  "googledrive",
-  "googledocs",
-  "googlesheets",
-  "notion",
-  "slack",
-  "whatsapp",
-  "outlook",
-  "dropbox",
-  "canva",
-  "trello",
-  "asana",
-  "zoom",
-  "calendly",
-  "shopify",
+export const MOST_USED_SLUGS: readonly string[] = [
+  "gmail", // 0
+  "googlecalendar", // 3
+  "notion", // 4
+  "googlesheets", // 5
+  "slack", // 6
+  "outlook", // 8
+  "twitter", // 10 (X)
+  "googledrive", // 11
+  "googledocs", // 12
+  "asana", // 38
+  "shopify", // 40
+  "linkedin", // 41
+  "calendly", // 47
+  "trello", // 48
+  "dropbox", // 66
+  "whatsapp", // 88
+  "zoom", // 103
+  "canva", // 142
+  "instagram", // 608
 ];
 
 /**
- * The catalog's featured toolkits: those whose slug is in {@link FEATURED_SLUGS}
- * and not already connected, in FEATURED_SLUGS order (curated, NOT A-Z). Missing
- * apps drop out. Featured apps still appear in their own category sections too —
- * this is a spotlight, not a move.
+ * The catalog's most-used toolkits: those whose slug is in
+ * {@link MOST_USED_SLUGS} and not already connected, in MOST_USED_SLUGS order
+ * (curated usage rank, NOT A-Z). Missing apps drop out. Most-used apps still
+ * appear in their own category sections too — this is a spotlight, not a move.
  */
-function featuredToolkits(
+function mostUsedToolkits(
   catalog: IntegrationToolkit[],
   connected: ReadonlySet<string>,
 ): IntegrationToolkit[] {
   const bySlug = new Map<string, IntegrationToolkit>();
   for (const t of catalog) bySlug.set(t.slug.toLowerCase(), t);
-  const featured: IntegrationToolkit[] = [];
-  for (const slug of FEATURED_SLUGS) {
+  const mostUsed: IntegrationToolkit[] = [];
+  for (const slug of MOST_USED_SLUGS) {
     const tk = bySlug.get(slug);
-    if (tk && !connected.has(tk.slug)) featured.push(tk);
+    if (tk && !connected.has(tk.slug)) mostUsed.push(tk);
   }
-  return featured;
+  return mostUsed;
 }
 
 /**
@@ -102,9 +117,10 @@ export interface CatalogSection {
  * Empty sections drop.
  *
  * On the at-rest landing view (NO search query AND NO single-category narrowing) a
- * curated {@link FEATURED} section is pinned FIRST when non-empty, so everyday apps
- * greet a first-time user instead of the size-ranked "Developer tools". Featured
- * apps stay in their normal category sections too (a spotlight, not a move).
+ * curated {@link MOST_USED} section is pinned FIRST when non-empty, so everyday
+ * apps greet a first-time user instead of the size-ranked "Developer tools".
+ * Most-used apps stay in their normal category sections too (a spotlight, not a
+ * move).
  */
 export function groupCatalogByCategory(opts: {
   catalog: IntegrationToolkit[];
@@ -160,9 +176,9 @@ export function groupCatalogByCategory(opts: {
   // Spotlight only on the at-rest landing view — a search or category pick is a
   // deliberate narrowing the curated list would fight.
   if (!q && !only) {
-    const featured = featuredToolkits(opts.catalog, opts.connected);
-    if (featured.length > 0) {
-      sections.unshift({ category: FEATURED, connectable: featured });
+    const mostUsed = mostUsedToolkits(opts.catalog, opts.connected);
+    if (mostUsed.length > 0) {
+      sections.unshift({ category: MOST_USED, connectable: mostUsed });
     }
   }
   return sections;
@@ -173,7 +189,7 @@ export function groupCatalogByCategory(opts: {
  * excluded), sorted A-Z by display label with {@link UNCATEGORIZED} pinned
  * last — the option set for the category filter beside the search field. The
  * dropdown orders alphabetically (a user LOOKS UP a category by name there)
- * even though the page's sections order by size. The curated {@link FEATURED}
+ * even though the page's sections order by size. The curated {@link MOST_USED}
  * spotlight is not a real category, so it never leaks into the options. The
  * consumer prepends its "all" entry and labels {@link UNCATEGORIZED} itself.
  */
@@ -183,7 +199,7 @@ export function catalogCategorySlugs(opts: {
 }): string[] {
   return groupCatalogByCategory({ ...opts, query: "" })
     .map((s) => s.category)
-    .filter((c) => c !== FEATURED)
+    .filter((c) => c !== MOST_USED)
     .sort((a, b) => {
       if (a === UNCATEGORIZED) return 1;
       if (b === UNCATEGORIZED) return -1;

--- a/app/src/components/integrations/index.ts
+++ b/app/src/components/integrations/index.ts
@@ -27,8 +27,8 @@ export {
 export {
   type CatalogSection,
   catalogCategorySlugs,
-  FEATURED,
   groupCatalogByCategory,
+  MOST_USED,
   SECTION_PREVIEW_CAP,
 } from "./browse-sections";
 export { CatalogLockedSection } from "./catalog-locked-section";

--- a/app/src/locales/en/integrations.json
+++ b/app/src/locales/en/integrations.json
@@ -86,7 +86,7 @@
     "connectApp": "Connect {{name}}",
     "installedTitle": "Installed",
     "availableTitle": "Available",
-    "featured": "Featured",
+    "mostUsed": "Most used",
     "otherCategory": "Other",
     "showAllApps": "Show all {{count}} apps"
   },

--- a/app/src/locales/es/integrations.json
+++ b/app/src/locales/es/integrations.json
@@ -86,7 +86,7 @@
     "connectApp": "Conectar {{name}}",
     "installedTitle": "Instaladas",
     "availableTitle": "Disponibles",
-    "featured": "Destacadas",
+    "mostUsed": "Más usadas",
     "otherCategory": "Otras",
     "showAllApps": "Ver las {{count}} aplicaciones"
   },

--- a/app/src/locales/pt/integrations.json
+++ b/app/src/locales/pt/integrations.json
@@ -86,7 +86,7 @@
     "connectApp": "Conectar {{name}}",
     "installedTitle": "Instaladas",
     "availableTitle": "Disponíveis",
-    "featured": "Destaques",
+    "mostUsed": "Mais usadas",
     "otherCategory": "Outras",
     "showAllApps": "Ver todos os {{count}} aplicativos"
   },

--- a/app/tests/integrations-category-sections.test.ts
+++ b/app/tests/integrations-category-sections.test.ts
@@ -7,8 +7,8 @@ import {
 } from "../src/components/integrations/browse-model.ts";
 import {
   catalogCategorySlugs,
-  FEATURED,
   groupCatalogByCategory,
+  MOST_USED,
 } from "../src/components/integrations/browse-sections.ts";
 
 const tk = (
@@ -34,11 +34,11 @@ const shape = (
   sections: { category: string; connectable: IntegrationToolkit[] }[],
 ) => sections.map((s) => [s.category, s.connectable.map((t) => t.slug)]);
 
-/** The category grid alone — the {@link FEATURED} spotlight (asserted on its
+/** The category grid alone — the {@link MOST_USED} spotlight (asserted on its
  *  own below) is orthogonal to how the size-ranked category buckets form. */
 const categoryShape = (
   sections: { category: string; connectable: IntegrationToolkit[] }[],
-) => shape(sections.filter((s) => s.category !== FEATURED));
+) => shape(sections.filter((s) => s.category !== MOST_USED));
 
 describe("groupCatalogByCategory (new module)", () => {
   it("groups by PRIMARY category and orders sections by size desc", () => {
@@ -178,37 +178,59 @@ describe("groupCatalogByCategory (new module)", () => {
   });
 });
 
-describe("groupCatalogByCategory featured spotlight", () => {
-  const featuredSlugs = (
+describe("groupCatalogByCategory most-used spotlight", () => {
+  const mostUsedSlugs = (
     sections: { category: string; connectable: IntegrationToolkit[] }[],
   ) =>
     sections
-      .find((s) => s.category === FEATURED)
+      .find((s) => s.category === MOST_USED)
       ?.connectable.map((t) => t.slug);
 
-  it("pins Featured first at rest, in curated FEATURED_SLUGS order (not A-Z)", () => {
+  it("pins Most used first at rest, in curated MOST_USED_SLUGS order (not A-Z)", () => {
     const sections = groupCatalogByCategory({
       catalog: CATALOG,
       query: "",
       connected: new Set(),
     });
-    // First section is the spotlight; slugs follow the curated order
+    // First section is the spotlight; slugs follow the curated usage order
     // (gmail, googlecalendar, notion, slack, asana), NOT A-Z (which would open
-    // with asana).
-    deepStrictEqual(sections[0].category, FEATURED);
+    // with asana). Curated apps missing from this catalog (googledrive,
+    // whatsapp…) simply drop out — the fallback for a shrunken catalog.
+    deepStrictEqual(sections[0].category, MOST_USED);
     deepStrictEqual(
       sections[0].connectable.map((t) => t.slug),
       ["gmail", "googlecalendar", "notion", "slack", "asana"],
     );
   });
 
-  it("keeps featured apps in their own category sections too (a spotlight, not a move)", () => {
+  it("orders members by curated usage rank, never alphabetically", () => {
+    // All four are in MOST_USED_SLUGS; A-Z would open with instagram. The
+    // curated usage ranks (twitter < linkedin < whatsapp < instagram) win.
+    const sections = groupCatalogByCategory({
+      catalog: [
+        tk("instagram", "Instagram", ["social-media-accounts"]),
+        tk("linkedin", "LinkedIn", ["social-media-accounts"]),
+        tk("twitter", "Twitter", ["social-media-accounts"]),
+        tk("whatsapp", "WhatsApp", ["team-chat"]),
+      ],
+      query: "",
+      connected: new Set(),
+    });
+    deepStrictEqual(mostUsedSlugs(sections), [
+      "twitter",
+      "linkedin",
+      "whatsapp",
+      "instagram",
+    ]);
+  });
+
+  it("keeps most-used apps in their own category sections too (a spotlight, not a move)", () => {
     const sections = groupCatalogByCategory({
       catalog: CATALOG,
       query: "",
       connected: new Set(),
     });
-    // gmail is featured AND still present in Productivity, A-Z.
+    // gmail is in the spotlight AND still present in Productivity, A-Z.
     const productivity = sections.find((s) => s.category === "productivity");
     deepStrictEqual(
       productivity?.connectable.map((t) => t.slug),
@@ -216,39 +238,39 @@ describe("groupCatalogByCategory featured spotlight", () => {
     );
   });
 
-  it("omits Featured while a search query is active", () => {
+  it("omits Most used while a search query is active", () => {
     const sections = groupCatalogByCategory({
       catalog: CATALOG,
       query: "gmail",
       connected: new Set(),
     });
-    deepStrictEqual(featuredSlugs(sections), undefined);
+    deepStrictEqual(mostUsedSlugs(sections), undefined);
   });
 
-  it("omits Featured when narrowed to a single category", () => {
+  it("omits Most used when narrowed to a single category", () => {
     const sections = groupCatalogByCategory({
       catalog: CATALOG,
       query: "",
       connected: new Set(),
       category: "productivity",
     });
-    deepStrictEqual(featuredSlugs(sections), undefined);
+    deepStrictEqual(mostUsedSlugs(sections), undefined);
   });
 
-  it("excludes already-connected apps from Featured", () => {
+  it("excludes already-connected apps from Most used", () => {
     const sections = groupCatalogByCategory({
       catalog: CATALOG,
       query: "",
       connected: new Set(["gmail", "slack"]),
     });
-    deepStrictEqual(featuredSlugs(sections), [
+    deepStrictEqual(mostUsedSlugs(sections), [
       "googlecalendar",
       "notion",
       "asana",
     ]);
   });
 
-  it("omits Featured entirely when no featured app is in the catalog", () => {
+  it("omits Most used entirely when no curated app is in the catalog", () => {
     const sections = groupCatalogByCategory({
       catalog: [
         tk("serpapi", "SerpApi", ["developer-tools"]),
@@ -257,13 +279,13 @@ describe("groupCatalogByCategory featured spotlight", () => {
       query: "",
       connected: new Set(),
     });
-    deepStrictEqual(featuredSlugs(sections), undefined);
+    deepStrictEqual(mostUsedSlugs(sections), undefined);
   });
 
-  it("never leaks FEATURED into the category dropdown options", () => {
+  it("never leaks MOST_USED into the category dropdown options", () => {
     deepStrictEqual(
       catalogCategorySlugs({ catalog: CATALOG, connected: new Set() }).filter(
-        (c) => c === FEATURED,
+        (c) => c === MOST_USED,
       ),
       [],
     );

--- a/knowledge-base/integrations.md
+++ b/knowledge-base/integrations.md
@@ -487,14 +487,20 @@ integrations** tab (§2, `teams.md`).
   "Developer tools" instead of the raw size ranking floating dev/AI apps up. Each section header carries its count chip
   (`CatalogSectionHeader` `count` — the chevron accent is GONE from the section-header
   idiom). At REST ONLY (no search query AND no single-category narrowing) a curated
-  **Featured** spotlight (`FEATURED = "__featured"`, an ordered `FEATURED_SLUGS` list
-  of everyday apps — gmail, calendar, drive, notion, slack…) is pinned FIRST above the
-  category sections, so a first-time user meets familiar apps instead of
-  "Developer tools"; it renders under `t("home.featured")`. Featured apps still appear
-  in their own category sections too (a spotlight, not a move), already-connected apps
-  drop out, and `FEATURED` never leaks into `catalogCategorySlugs` (the dropdown
-  options). A search or a category pick suppresses it (the curated list would fight a
-  deliberate narrowing). Each row is the split `CatalogRow`
+  **Most used** spotlight (`MOST_USED = "__mostUsed"`, an ordered `MOST_USED_SLUGS`
+  list of everyday apps — gmail, calendar, notion, sheets, slack, twitter, linkedin,
+  whatsapp, instagram…) is pinned FIRST above the category sections, so a first-time
+  user meets familiar apps instead of "Developer tools"; it renders under
+  `t("home.mostUsed")` ("Most used" / "Más usadas" / "Mais usadas"). Membership is
+  COMMITTED data, deliberately not Composio's live usage sort: the API does expose
+  `GET /api/v3/toolkits?sort_by=usage` (verified 2026-07-22; it is also the default
+  order), but it ranks global Composio (developer) usage — github/supabase/
+  perplexityai in the top ten — so the list stays hand-picked, ordered by those same
+  apps' relative ranks from that verified data (rank comments in
+  `browse-sections.ts`). Most-used apps still appear in their own category sections
+  too (a spotlight, not a move), already-connected apps drop out, and `MOST_USED`
+  never leaks into `catalogCategorySlugs` (the dropdown options). A search or a
+  category pick suppresses it (the curated list would fight a deliberate narrowing). Each row is the split `CatalogRow`
   (`ui/core/src/components/catalog-row.tsx`): the row BODY opens the app's
   "more info" modal (`app-info-dialog.tsx` over the generic `CatalogDetailDialog` —
   art, name, category `Badge` chips, the FULL description, a Connect CTA), while


### PR DESCRIPTION
## What

User feedback: people never click "see more" in the integrations catalog, so they don't discover which apps Houston can connect. This PR turns the existing "Featured" spotlight (already pinned above the category sections) into a **"Most used"** section, ordered by real usage, shown up front. The "see more / show all" behavior stays exactly as it was, for this section and for every category below.

## Where the order comes from

Composio's toolkits endpoint does support `sort_by=usage` (verified live; it's also the endpoint's default). But that ranking spans Composio's whole customer base — developers — so the raw top-20 leads with GitHub, Supabase, Linear, Jira: exactly what this catalog's curation exists to keep away from non-technical users. So: **membership stays curated, the order inside the section follows those apps' relative ranks from the verified usage pull** (rank evidence commented inline). Added X/Twitter, LinkedIn, and Instagram (all verified present and connectable in the live catalog); WhatsApp was already in.

## Behavior

- Section renders first, at rest only (search or a category pick suppresses it, as before); previews 6 rows behind the existing "Show all N apps" expander.
- Apps still appear in their own category sections (spotlight, not a move); connected apps drop out; curated apps missing from the catalog silently drop.
- Label via `t("integrations:home.mostUsed")`: "Most used" / "Más usadas" / "Mais usadas".

## Verification

App suite 1946/1946, `tsgo --noEmit` clean, `check-locales` in sync (en/es/pt), `houston-web` typecheck + shim parity OK, Biome clean. Tests strengthened: usage-rank ordering distinct from A-Z, and explicit missing-app fallback.

## Open call for review

Instagram ranks low in real usage (included per the product ask, placed last). Membership is one committed array (`MOST_USED_SLUGS`) if you want a tighter list.
