### PR TITLE
fix(analytics): identify the person before emitting user_signed_up

### DIFF
--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -75,14 +75,15 @@ async function guardAuthCall(
 }
 
 async function establishDesktopSession(
-  { session, isNewUser }: SignInOutcome,
+  outcome: SignInOutcome,
   analyticsProvider: string,
 ): Promise<void> {
+  const { session } = outcome;
   await saveSession(session);
   cacheSession(session);
   rememberLastSignIn(session);
   startProactiveRefresh();
-  trackSignIn(analyticsProvider, isNewUser);
+  trackSignIn(analyticsProvider, outcome);
   logger.info(`[auth] signed in (${session.provider}) as ${session.email}`);
 }
 
@@ -94,14 +95,28 @@ function establishWebSession(
   if (!outcome) return; // popup cancelled — no error, no cache write
   cacheSession(outcome.session);
   rememberLastSignIn(outcome.session);
-  trackSignIn(analyticsProvider, outcome.isNewUser);
+  trackSignIn(analyticsProvider, outcome);
 }
 
 // A sign-in that CREATED the account also emits `user_signed_up` — the
 // once-per-account event the PostHog → Slack new-user notification and the
 // activation funnel key on. `user_signed_in` still fires on every sign-in.
-function trackSignIn(provider: string, isNewUser: boolean): void {
-  if (isNewUser) analytics.track("user_signed_up", { provider });
+function trackSignIn(
+  provider: string,
+  { session, isNewUser }: SignInOutcome,
+): void {
+  if (isNewUser) {
+    // Identify BEFORE the sign-up event: the Slack destination renders
+    // person.properties.name/email from the person snapshot AT event
+    // ingestion (person-on-events), so the $set must precede the event on
+    // the wire — App.tsx's identify effect runs a render later, too late.
+    analytics.identifyUser(session.uid, {
+      email: session.email,
+      name: session.displayName,
+      signupDate: null,
+    });
+    analytics.track("user_signed_up", { provider });
+  }
   analytics.track("user_signed_in", { provider });
 }
 


### PR DESCRIPTION
## Problem

The PostHog → Slack new-user notification (destination "Slack: new user signup (Houston Cloud)", triggered on `user_signed_up`) posted with both fields empty on a real Google sign-up:

> Complete name: Not provided
> Email: Not provided

The destination renders `person.properties.name` / `person.properties.email` from the person snapshot taken **at event ingestion** (person-on-events). #1023 captures `user_signed_up` immediately at sign-in in `trackSignIn`, but `identifyUser` (which stamps email + name as person properties) runs a render later, in App.tsx's identify effect, so the event was ingested against a still-anonymous person.

## Fix

Scoped to the sign-up moment only. When `isNewUser` is true, `trackSignIn` (now receiving the full `SignInOutcome`) calls `analytics.identifyUser(session.uid, { email, name: displayName })` right before capturing `user_signed_up`. The `$create_alias` / `$set` / `user_signed_up` messages leave in order under the same `distinct_id`, so PostHog ingests the `$set` first and the event's person snapshot carries both fields.

Regular sign-ins are unchanged: their identify still comes from App.tsx's effect. No PostHog-side changes needed, the destination template is correct.

## Notes

- Email-OTP sign-ups have no `displayName`, so "Complete name: Not provided" is still expected for those; email will render.
- The destination filters internal/test accounts, so verify with an external account.

## Verification

- `pnpm check:fix` clean
- `app` `tsgo --noEmit` clean
- `houston-web` typecheck (shim parity + tsgo) clean
- `app` test suite: 1945 pass, 0 fail
