### PR TITLE
fix(host): agent renames no longer revert + migrated agents recover their colors

### DIFF
--- a/packages/host/src/channel/proxy-quiesce.test.ts
+++ b/packages/host/src/channel/proxy-quiesce.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "vitest";
+import { MemoryCredentialStore } from "../credentials/store";
+import type { Agent, Workspace } from "../domain/types";
+import { ProxyChannel } from "./proxy";
+
+/**
+ * quiesce — the rename precondition. Idempotence regression: quiescing an
+ * agent whose runtime is ABSENT (never woken, or already torn down) must be a
+ * no-op success, NOT a launcher sleep. The launcher's sleep contract rejects
+ * sleeping an unknown sandbox (FakeLauncher throws "cannot sleep sandbox for
+ * unknown agent"), and the dual-profile suite proved a blind sleep turns a
+ * plain rename into a 500 on the cloud profile while local answered 200.
+ */
+
+const ws: Workspace = {
+  id: "w1",
+  ownerUserId: "alice",
+  kind: "personal",
+  name: "Personal",
+  slug: "alice",
+  runtime: "gke",
+  createdAt: 1,
+};
+const agent: Agent = {
+  id: "agent-1",
+  workspaceId: "w1",
+  name: "Sales",
+  createdAt: 1,
+};
+const ctx = { workspace: ws, agent };
+
+function channelWith(state: "running" | "asleep" | "absent", calls: string[]) {
+  return new ProxyChannel({
+    launcher: {
+      async ensureAwake() {
+        calls.push("ensureAwake");
+        return { baseUrl: "http://runtime.local", token: "sbx-token" };
+      },
+      async sleep(agentId: string) {
+        if (state === "absent")
+          throw new Error(`cannot sleep sandbox for unknown agent ${agentId}`);
+        calls.push(`sleep:${agentId}`);
+      },
+      async destroy() {},
+      async status() {
+        calls.push("status");
+        return state;
+      },
+    },
+    proxy: { async forward() {} },
+    credentials: new MemoryCredentialStore(),
+    forwardActingHeader: false,
+  });
+}
+
+test("quiesce of an absent runtime is a no-op success (never calls sleep)", async () => {
+  const calls: string[] = [];
+  await expect(
+    channelWith("absent", calls).quiesce(ctx),
+  ).resolves.toBeUndefined();
+  expect(calls).toEqual(["status"]);
+});
+
+test("quiesce sleeps a running runtime", async () => {
+  const calls: string[] = [];
+  await channelWith("running", calls).quiesce(ctx);
+  expect(calls).toEqual(["status", "sleep:agent-1"]);
+});
+
+test("quiesce sleeps an asleep runtime too (sleep is idempotent for existing sandboxes)", async () => {
+  const calls: string[] = [];
+  await channelWith("asleep", calls).quiesce(ctx);
+  expect(calls).toEqual(["status", "sleep:agent-1"]);
+});

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -252,6 +252,13 @@ export class ProxyChannel implements RuntimeChannel {
     // dispatch respawns it (pi's continueRecent restores its sessions). The
     // launcher's sleep waits for the child to ACTUALLY exit, so a caller that
     // needs the agent's directory quiet (rename) can rely on it.
+    //
+    // Quiesce is idempotent by contract: an absent runtime is ALREADY quiet.
+    // The launcher's sleep deliberately rejects sleeping an unknown sandbox
+    // (a genuine sleep-of-absent elsewhere is a bug it must not paper over),
+    // so only an existing runtime is slept — renaming a never-woken agent
+    // must succeed, not 500.
+    if ((await this.opts.launcher.status(ctx.agent.id)) === "absent") return;
     await this.opts.launcher.sleep(ctx.agent.id);
   }
 

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -247,6 +247,14 @@ export class ProxyChannel implements RuntimeChannel {
     return this.opts.launcher.status(ctx.agent.id);
   }
 
+  async quiesce(ctx: ChannelCtx): Promise<void> {
+    // Sleep, not destroy: the runtime's state stays on disk and the next
+    // dispatch respawns it (pi's continueRecent restores its sessions). The
+    // launcher's sleep waits for the child to ACTUALLY exit, so a caller that
+    // needs the agent's directory quiet (rename) can rely on it.
+    await this.opts.launcher.sleep(ctx.agent.id);
+  }
+
   async teardown(ctx: ChannelCtx): Promise<void> {
     await this.opts.launcher.destroy(ctx.agent.id, { dropVolume: true });
   }

--- a/packages/host/src/launcher/process.test.ts
+++ b/packages/host/src/launcher/process.test.ts
@@ -138,6 +138,54 @@ test("sleep kills the process; the next ensureAwake spawns a fresh one", async (
   expect(spawns).toHaveLength(2);
 });
 
+test("sleep resolves only after the child has ACTUALLY exited", async () => {
+  // A rename moves the agent's directory right after sleeping it — resolving
+  // on SIGTERM alone would let the move race the still-flushing child (and on
+  // Windows the live child's cwd locks the directory outright).
+  let exitCb: (() => void) | undefined;
+  const spawner: RuntimeSpawner = {
+    spawn() {
+      return {
+        port: 5000,
+        kill: () => {}, // the "process" ignores SIGTERM for a while
+        onExit: (cb) => {
+          exitCb = cb;
+        },
+      };
+    },
+  };
+  const launcher = new ProcessLauncher(opts(spawner));
+  await launcher.ensureAwake(agent("slow"));
+
+  let slept = false;
+  const sleeping = launcher.sleep("slow").then(() => {
+    slept = true;
+  });
+  await new Promise((r) => setTimeout(r, 10));
+  expect(slept).toBe(false); // still waiting on the real exit
+
+  exitCb?.(); // now the child actually dies
+  await sleeping;
+  expect(slept).toBe(true);
+  expect(await launcher.status("slow")).toBe("asleep");
+});
+
+test("sleep gives up waiting after its bound when a child hangs on SIGTERM", async () => {
+  const spawner: RuntimeSpawner = {
+    spawn() {
+      return {
+        port: 5000,
+        kill: () => {},
+        onExit: () => {}, // exit never fires — a truly hung process
+      };
+    },
+  };
+  const launcher = new ProcessLauncher(opts(spawner));
+  await launcher.ensureAwake(agent("hung"));
+  await launcher.sleep("hung", 20); // bounded — resolves despite no exit
+  expect(await launcher.status("hung")).toBe("asleep");
+});
+
 test("a runtime that never becomes healthy is killed and not cached (the turn errors visibly)", async () => {
   const { spawner, killed } = recordingSpawner();
   const launcher = new ProcessLauncher(

--- a/packages/host/src/launcher/process.ts
+++ b/packages/host/src/launcher/process.ts
@@ -220,11 +220,29 @@ export class ProcessLauncher implements RuntimeLauncher {
     return endpoint;
   }
 
-  async sleep(agentId: AgentId): Promise<void> {
+  async sleep(agentId: AgentId, timeoutMs = 5_000): Promise<void> {
     const r = this.running.get(agentId);
     if (!r) return; // already asleep — pi's continueRecent restores on next wake
+    // Subscribe to the exit BEFORE killing, then wait (bounded) for the child
+    // to ACTUALLY be gone: callers sleep an agent to get its directory quiet
+    // (a rename is about to move it; on Windows a live child's cwd even locks
+    // it), and SIGTERM alone resolves while the process is still flushing.
+    // Handles without onExit (test stubs) count as already exited — same
+    // posture as shutdownAllAndWait.
+    const exited = r.handle.onExit
+      ? new Promise<void>((resolve) => r.handle.onExit?.(() => resolve()))
+      : undefined;
     r.handle.kill();
     this.running.delete(agentId);
+    if (exited) {
+      await Promise.race([
+        exited,
+        new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, timeoutMs);
+          timer.unref?.();
+        }),
+      ]);
+    }
   }
 
   async destroy(agentId: AgentId): Promise<void> {

--- a/packages/host/src/local/migration-roundtrip.test.ts
+++ b/packages/host/src/local/migration-roundtrip.test.ts
@@ -67,6 +67,16 @@ function buildSourceTree() {
   const agentRoot = join(workspacesRoot, "Work", "Sales");
   mkdirSync(join(agentRoot, ".houston"), { recursive: true });
   writeFileSync(join(agentRoot, "CLAUDE.md"), "# Sales agent");
+  // Rust-era per-agent metadata: the engine stored the picked COLOR here.
+  writeFileSync(
+    join(agentRoot, ".houston", "agent.json"),
+    JSON.stringify({
+      id: "legacy-uuid",
+      config_id: "personal-assistant",
+      color: "crimson",
+      created_at: "2025-01-01T00:00:00Z",
+    }),
+  );
   mkdirSync(join(agentRoot, ".agents", "skills", "crm"), { recursive: true });
   writeFileSync(
     join(agentRoot, ".agents", "skills", "crm", "SKILL.md"),
@@ -124,13 +134,18 @@ test("source→target round trip: convert on boot, export, import, resume marker
     ).json()) as {
       agents: {
         id: string;
+        color?: string;
         manifest: { entries: { path: string }[]; integrations: string[] };
       }[];
     };
     expect(listing.agents.map((a) => a.id)).toEqual(["Work/Sales"]);
+    // The Rust-era color rides the scan so the wizard can seed it on the
+    // created cloud agent (the everything-turned-purple bug).
+    expect(listing.agents[0]?.color).toBe("crimson");
     const manifest = listing.agents[0]?.manifest;
     const paths = manifest?.entries.map((e) => e.path) ?? [];
     expect(paths).toContain("CLAUDE.md");
+    expect(paths).toContain(".houston/agent.json"); // legacy color survives the move
     expect(paths).toContain(".houston/learnings/learnings.json"); // md → json on boot
     expect(paths).toContain(".houston/runtime/conversations/activity-1.json"); // db → transcript on boot
     expect(paths.some((p) => p.startsWith(".houston/sessions/"))).toBe(false);
@@ -193,6 +208,18 @@ test("source→target round trip: convert on boot, export, import, resume marker
         join(targetAgentDir, ".houston", "runtime", "sessions", "activity-1"),
       ),
     ).toBe(true);
+    // The imported legacy metadata is on the target AND its color is served on
+    // the agent list — this is what heals already-migrated installs on their
+    // next list, no re-migration needed.
+    expect(existsSync(join(targetAgentDir, ".houston", "agent.json"))).toBe(
+      true,
+    );
+    const targetAgents = (await (
+      await fetch(`${target.base}/agents`, { headers: auth })
+    ).json()) as { id: string; color?: string }[];
+    expect(targetAgents.find((a) => a.id === created.id)?.color).toBe(
+      "crimson",
+    );
 
     // Completion marker round-trips for resume.
     await fetch(`${agentUrl}/migration/complete`, {

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -225,6 +225,18 @@ export interface RuntimeChannel {
     ctx: ChannelCtx,
     items: { id: string; text: string }[],
   ): Promise<{ id: string; text: string; summary: string }[]>;
+  /**
+   * Stop the agent's STANDING runtime (kill / scale to zero), persisting its
+   * state — destroying nothing; the runtime respawns on the next dispatch.
+   * Called before operations that move the agent's on-disk identity (rename):
+   * a live local runtime holds absolute paths into the old directory (cwd,
+   * data dir) and its next write would resurrect the old-named folder, which
+   * the directory-derived local store re-lists as an agent with the OLD name.
+   * On Windows the live child's cwd also locks the directory against the
+   * rename itself. Optional: channels with no standing runtime (per-turn)
+   * have nothing to quiesce and omit it.
+   */
+  quiesce?(ctx: ChannelCtx): Promise<void>;
   /** Tear down the agent's runtime-side state (volume / object prefix) before record deletion. */
   teardown(ctx: ChannelCtx): Promise<void>;
   /**

--- a/packages/host/src/routes/agent-legacy-color.test.ts
+++ b/packages/host/src/routes/agent-legacy-color.test.ts
@@ -1,0 +1,50 @@
+import { expect, test, vi } from "vitest";
+import { MemoryVfs } from "../vfs";
+import { legacyAgentColor } from "./agent-legacy-color";
+
+/**
+ * The Rust-era engine persisted each agent's color in
+ * `<agentRoot>/.houston/agent.json` (AgentMeta.color). The v3 host serves it
+ * as a read-only legacy passthrough; every failure mode must read as "no
+ * color" (the client falls back to its default), never as an error.
+ */
+
+const ROOT = "Personal/Sales";
+
+async function withMeta(meta: unknown): Promise<string | undefined> {
+  const vfs = new MemoryVfs();
+  await vfs.writeText(
+    `${ROOT}/.houston/agent.json`,
+    typeof meta === "string" ? meta : JSON.stringify(meta),
+  );
+  return legacyAgentColor(vfs, ROOT);
+}
+
+test("reads the Rust-era color out of agent.json", async () => {
+  await expect(
+    withMeta({ id: "u1", config_id: "blank", color: "forest" }),
+  ).resolves.toBe("forest");
+});
+
+test("absent agent.json reads as no color (post-cutover agents)", async () => {
+  await expect(
+    legacyAgentColor(new MemoryVfs(), ROOT),
+  ).resolves.toBeUndefined();
+});
+
+test("a null / empty / non-string color reads as no color", async () => {
+  await expect(withMeta({ color: null })).resolves.toBeUndefined();
+  await expect(withMeta({ color: "" })).resolves.toBeUndefined();
+  await expect(withMeta({ color: 7 })).resolves.toBeUndefined();
+  await expect(withMeta({})).resolves.toBeUndefined();
+});
+
+test("corrupt agent.json is logged and read as no color, never thrown", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    await expect(withMeta("{not json")).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledOnce();
+  } finally {
+    warn.mockRestore();
+  }
+});

--- a/packages/host/src/routes/agent-legacy-color.ts
+++ b/packages/host/src/routes/agent-legacy-color.ts
@@ -1,0 +1,39 @@
+import type { Vfs } from "../vfs";
+
+/**
+ * Reader for the Rust-era per-agent color (`<agentRoot>/.houston/agent.json`).
+ *
+ * The deleted Rust engine persisted each agent's picked color server-side, in
+ * `AgentMeta.color` inside `agent.json` (see the historical
+ * `engine/houston-engine-core/src/agents_crud.rs`). The v3 host's own agent
+ * model is deliberately id/name only — color became a client-side cosmetic
+ * overlay — so after the engine cutover nothing read this file and every
+ * upgraded agent silently fell back to the client's default purple.
+ *
+ * The host serves this value as a read-only legacy passthrough on agent
+ * payloads (GET /agents, the rename response, the migration source scan). The
+ * client's own overlay — the user's current pick — always outranks it, and the
+ * host never writes the file, so the read is idempotent by construction:
+ * already-migrated users get their colors back on the next agent list.
+ */
+export async function legacyAgentColor(
+  vfs: Vfs,
+  agentRoot: string,
+): Promise<string | undefined> {
+  const raw = await vfs.readText(`${agentRoot}/.houston/agent.json`);
+  if (raw === null) return undefined; // no Rust-era metadata — nothing to serve
+  try {
+    const meta = JSON.parse(raw) as { color?: unknown };
+    return typeof meta.color === "string" && meta.color
+      ? meta.color
+      : undefined;
+  } catch {
+    // A hand-edited/corrupt legacy file must not fail the whole agent list
+    // over a cosmetic — the agent just renders the client default. Logged so
+    // the breadcrumb reaches the app logs, never thrown.
+    console.warn(
+      `[agents] unreadable legacy agent.json under ${agentRoot} — ignoring its color`,
+    );
+    return undefined;
+  }
+}

--- a/packages/host/src/routes/agents-rename.test.ts
+++ b/packages/host/src/routes/agents-rename.test.ts
@@ -1,0 +1,268 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { beforeEach, expect, test } from "vitest";
+import type {
+  CaptureResult,
+  ChannelCtx,
+  RuntimeChannel,
+  RuntimeLauncher,
+  WorkspaceStore,
+} from "../ports";
+import { MemoryWorkspaceStore } from "../store/memory";
+import { MemoryVfs } from "../vfs";
+import { handleAgents } from "./agents";
+
+/**
+ * PATCH /agents/:id (rename) — the runtime-quiesce contract.
+ *
+ * The reported bug: a rename moved the agent's directory while its warm local
+ * runtime kept running with absolute paths into the OLD directory; the
+ * runtime's next write resurrected the old-named folder, which the
+ * directory-derived store re-listed as an agent with the old name ("my rename
+ * reverted"). The route must quiesce the standing runtime BEFORE the store
+ * rename — and surface a quiesce failure instead of renaming under a live
+ * runtime. Also covers the legacy Rust-era color riding rename/list payloads.
+ */
+
+class SpyChannel implements RuntimeChannel {
+  constructor(private readonly calls: string[]) {}
+  quiesceError: Error | null = null;
+
+  async dispatch(
+    _ctx: ChannelCtx,
+    _method: string,
+    _rest: string,
+    _url: URL,
+    _req: IncomingMessage,
+    res: ServerResponse,
+  ) {
+    res.writeHead(500, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "unexpected dispatch" }));
+  }
+  async fireTurn() {}
+  async cancelTurn() {
+    return false;
+  }
+  async busy() {
+    return false;
+  }
+  async quiesce(ctx: ChannelCtx) {
+    if (this.quiesceError) throw this.quiesceError;
+    this.calls.push(`quiesce:${ctx.agent.id}`);
+  }
+  async teardown() {}
+  async captureCredential(): Promise<CaptureResult> {
+    return { ok: true, provider: "anthropic" };
+  }
+  async forgetCredential() {}
+  async saveApiKeyCredential() {}
+  async saveClaudeOAuthCredential() {}
+  async saveCustomEndpoint() {}
+}
+
+/** The same channel with `quiesce` absent — a per-turn channel's shape. */
+function withoutQuiesce(channel: SpyChannel): RuntimeChannel {
+  return {
+    dispatch: channel.dispatch.bind(channel),
+    fireTurn: channel.fireTurn.bind(channel),
+    cancelTurn: channel.cancelTurn.bind(channel),
+    busy: channel.busy.bind(channel),
+    teardown: channel.teardown.bind(channel),
+    captureCredential: channel.captureCredential.bind(channel),
+    forgetCredential: channel.forgetCredential.bind(channel),
+    saveApiKeyCredential: channel.saveApiKeyCredential.bind(channel),
+    saveClaudeOAuthCredential: channel.saveClaudeOAuthCredential.bind(channel),
+    saveCustomEndpoint: channel.saveCustomEndpoint.bind(channel),
+  };
+}
+
+/** Delegating store that records rename calls into the shared ledger. */
+function recordingStore(
+  inner: MemoryWorkspaceStore,
+  calls: string[],
+): WorkspaceStore {
+  return {
+    getOrCreatePersonalWorkspace: (u) => inner.getOrCreatePersonalWorkspace(u),
+    getWorkspace: (id) => inner.getWorkspace(id),
+    getAgent: (id) => inner.getAgent(id),
+    listAgents: (id) => inner.listAgents(id),
+    listWorkspaces: () => inner.listWorkspaces(),
+    listWorkspacesForUser: (u) => inner.listWorkspacesForUser(u),
+    listAllAgents: () => inner.listAllAgents(),
+    createAgent: (input) => inner.createAgent(input),
+    renameAgent: (id, name) => {
+      calls.push(`rename:${id}:${name}`);
+      return inner.renameAgent(id, name);
+    },
+    deleteAgent: (id) => inner.deleteAgent(id),
+    setWorkspaceRuntime: (id, runtime) =>
+      inner.setWorkspaceRuntime(id, runtime),
+  };
+}
+
+let memory: MemoryWorkspaceStore;
+let calls: string[];
+let channel: SpyChannel;
+let vfs: MemoryVfs;
+let agentId = "";
+let workspaceId = "";
+
+beforeEach(async () => {
+  memory = new MemoryWorkspaceStore();
+  calls = [];
+  channel = new SpyChannel(calls);
+  vfs = new MemoryVfs();
+  const ws = await memory.getOrCreatePersonalWorkspace("alice");
+  workspaceId = ws.id;
+  const agent = await memory.createAgent({ workspaceId: ws.id, name: "Sales" });
+  agentId = agent.id;
+});
+
+function deps(channelImpl: RuntimeChannel | null = channel) {
+  return {
+    store: recordingStore(memory, calls),
+    channels: channelImpl ? { gke: channelImpl } : {},
+    vfs,
+  };
+}
+
+function reqWithBody(body: unknown): IncomingMessage {
+  const stream = Readable.from([Buffer.from(JSON.stringify(body))]);
+  return Object.assign(stream, { headers: {} }) as IncomingMessage;
+}
+
+function res() {
+  const out = {
+    status: 0,
+    body: "",
+    writeHead(status: number) {
+      this.status = status;
+      return this;
+    },
+    end(chunk?: unknown) {
+      this.body = chunk ? String(chunk) : "";
+      return this;
+    },
+  };
+  return out as unknown as ServerResponse & typeof out;
+}
+
+async function rename(
+  name: string,
+  d: ReturnType<typeof deps> = deps(),
+): Promise<{ status: number; json: Record<string, unknown> }> {
+  const path = `/agents/${encodeURIComponent(agentId)}`;
+  const response = res();
+  const handled = await handleAgents(
+    d,
+    "alice",
+    "PATCH",
+    path,
+    new URL(path, "http://host.local"),
+    reqWithBody({ name }),
+    response,
+  );
+  expect(handled).toBe(true);
+  return { status: response.status, json: JSON.parse(response.body || "{}") };
+}
+
+test("rename quiesces the standing runtime BEFORE the store moves the directory", async () => {
+  const { status, json } = await rename("Marketing");
+  expect(status).toBe(200);
+  expect(json.name).toBe("Marketing");
+  expect(calls).toEqual([`quiesce:${agentId}`, `rename:${agentId}:Marketing`]);
+});
+
+test("a same-name PATCH never kills the runtime (no-op rename)", async () => {
+  const { status } = await rename("Sales");
+  expect(status).toBe(200);
+  // The store still gets the (no-op) rename; only the quiesce is skipped.
+  expect(calls).toEqual([`rename:${agentId}:Sales`]);
+});
+
+test("a quiesce failure surfaces and the rename does NOT run", async () => {
+  channel.quiesceError = new Error("runtime refused to die");
+  await expect(rename("Marketing")).rejects.toThrow("runtime refused to die");
+  expect(calls).toEqual([]); // no rename recorded
+  const agent = await memory.getAgent(agentId);
+  expect(agent?.name).toBe("Sales");
+});
+
+test("rename still works over a channel with no quiesce (per-turn runtimes)", async () => {
+  const { status, json } = await rename(
+    "Marketing",
+    deps(withoutQuiesce(channel)),
+  );
+  expect(status).toBe(200);
+  expect(json.name).toBe("Marketing");
+  expect(calls).toEqual([`rename:${agentId}:Marketing`]);
+});
+
+test("rename still works when the workspace has no channel wired", async () => {
+  const { status, json } = await rename("Marketing", deps(null));
+  expect(status).toBe(200);
+  expect(json.name).toBe("Marketing");
+  expect(calls).toEqual([`rename:${agentId}:Marketing`]);
+});
+
+test("the rename response and the agent list carry the legacy agent.json color", async () => {
+  // CloudPaths (the deps default): agentRoot = ws/<wsId>/<agentId>/workspace.
+  await vfs.writeText(
+    `ws/${workspaceId}/${agentId}/workspace/.houston/agent.json`,
+    JSON.stringify({ id: "legacy", config_id: "blank", color: "forest" }),
+  );
+
+  const { json } = await rename("Marketing");
+  expect(json.color).toBe("forest");
+
+  const response = res();
+  await handleAgents(
+    deps(),
+    "alice",
+    "GET",
+    "/agents",
+    new URL("/agents", "http://host.local"),
+    reqWithBody({}),
+    response,
+  );
+  const list = JSON.parse(response.body) as Array<Record<string, unknown>>;
+  expect(list).toHaveLength(1);
+  expect(list[0]?.color).toBe("forest");
+});
+
+test("an agent with no legacy metadata serves no color at all", async () => {
+  const { json } = await rename("Marketing");
+  expect("color" in json).toBe(false);
+});
+
+test("ProxyChannel.quiesce sleeps the agent's runtime without destroying it", async () => {
+  const { ProxyChannel } = await import("../channel/proxy");
+  const slept: string[] = [];
+  const destroyed: string[] = [];
+  const launcher: RuntimeLauncher = {
+    ensureAwake: async () => ({ baseUrl: "http://127.0.0.1:1", token: "t" }),
+    sleep: async (id) => {
+      slept.push(id);
+    },
+    destroy: async (id) => {
+      destroyed.push(id);
+    },
+    status: async () => "running" as const,
+  };
+  const proxy = new ProxyChannel({
+    launcher,
+    proxy: { forward: async () => {} },
+    credentials: {
+      put: async () => {},
+      get: async () => null,
+      remove: async () => {},
+    },
+    forwardActingHeader: false,
+  });
+  const ws = await memory.getWorkspace(workspaceId);
+  const agent = await memory.getAgent(agentId);
+  if (!ws || !agent) throw new Error("fixture agent missing");
+  await proxy.quiesce({ workspace: ws, agent });
+  expect(slept).toEqual([agentId]);
+  expect(destroyed).toEqual([]);
+});

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -32,6 +32,7 @@ import {
 } from "./agent-authz";
 import { handleAgentData } from "./agent-data";
 import { handleAgentFile } from "./agent-file";
+import { legacyAgentColor } from "./agent-legacy-color";
 import { asSeedRecord, writeAgentSeeds } from "./agent-seed";
 import { json, readJson } from "./http";
 import { handleMigration } from "./migration";
@@ -48,9 +49,20 @@ import { handleTriggerStatus } from "./trigger-status";
 // routine-runs.ts); re-exported so existing importers keep working.
 export type { AgentRouteDeps } from "./agent-authz";
 
-/** Attach the agent's real directory (`dir`) when this deployment has one. */
-function withAgentDir(deps: AgentRouteDeps, ws: Workspace, agent: Agent) {
-  return deps.agentDir ? { ...agent, dir: deps.agentDir(ws, agent) } : agent;
+/**
+ * The agent as the wire serves it: the record plus the deployment extras — the
+ * real directory (`dir`, local profile only) and the Rust-era legacy `color`
+ * (read from `.houston/agent.json`; the client overlay outranks it, see
+ * agent-legacy-color.ts). Color is attached only where a vfs is wired.
+ */
+async function agentPayload(deps: AgentRouteDeps, ws: Workspace, agent: Agent) {
+  const base = deps.agentDir
+    ? { ...agent, dir: deps.agentDir(ws, agent) }
+    : agent;
+  if (!deps.vfs) return base;
+  const paths = deps.paths ?? DEFAULT_PATHS;
+  const color = await legacyAgentColor(deps.vfs, paths.agentRoot(ws, agent));
+  return color ? { ...base, color } : base;
 }
 
 /**
@@ -183,7 +195,7 @@ export async function handleAgents(
     json(
       res,
       200,
-      agents.map((a) => withAgentDir(deps, ws, a)),
+      await Promise.all(agents.map((a) => agentPayload(deps, ws, a))),
     );
     return true;
   }
@@ -246,7 +258,7 @@ export async function handleAgents(
       type: "AgentsChanged",
       workspaceId: ws.id,
     });
-    json(res, 201, withAgentDir(deps, ws, agent));
+    json(res, 201, await agentPayload(deps, ws, agent));
     return true;
   }
 
@@ -284,7 +296,7 @@ export async function handleAgents(
         type: "AgentsChanged",
         workspaceId: authz.workspace.id,
       });
-      json(res, 200, withAgentDir(deps, authz.workspace, renamed));
+      json(res, 200, await agentPayload(deps, authz.workspace, renamed));
       return true;
     }
 

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -282,6 +282,26 @@ export async function handleAgents(
         json(res, 400, { error: "missing 'name'" });
         return true;
       }
+      // Quiesce the agent's standing runtime BEFORE the rename moves its
+      // directory. A warm local runtime holds absolute paths into the OLD
+      // directory (cwd + HOUSTON_DATA_DIR) and stays keyed under the OLD id in
+      // the launcher, so a rename under it leaks the process and its next
+      // write (conversation store, usage ledger, logs — all mkdir-recursive)
+      // RESURRECTS the old-named folder, which the directory-derived local
+      // store then re-lists as an agent with the old name ("my rename
+      // reverted"). On Windows the live child's cwd even locks the directory
+      // against the rename itself. The runtime respawns on the next dispatch
+      // (pi's continueRecent restores its sessions from the renamed tree). A
+      // quiesce failure surfaces — never rename under a live runtime.
+      if (name !== authz.agent.name) {
+        const channel = channelFor(deps, authz.workspace);
+        if (channel?.quiesce) {
+          await channel.quiesce({
+            workspace: authz.workspace,
+            agent: authz.agent,
+          });
+        }
+      }
       let renamed: Agent;
       try {
         renamed = await deps.store.renameAgent(agentId, name);

--- a/packages/host/src/routes/migration-source.ts
+++ b/packages/host/src/routes/migration-source.ts
@@ -4,6 +4,7 @@ import type { WorkspacePaths } from "../paths";
 import { CloudPaths } from "../paths";
 import type { WorkspaceStore } from "../ports";
 import type { Vfs } from "../vfs";
+import { legacyAgentColor } from "./agent-legacy-color";
 import { json } from "./http";
 import { legacyConnectedToolkits } from "./migration-legacy-composio";
 import {
@@ -103,11 +104,17 @@ export async function handleMigrationSource(
   for (const agent of await deps.store.listAllAgents()) {
     const ws = await deps.store.getWorkspace(agent.workspaceId);
     if (!ws) continue; // deleted between list and read — nothing to migrate
+    const root = paths.agentRoot(ws, agent);
     agents.push({
       id: agent.id,
       workspaceId: agent.workspaceId,
       name: agent.name,
-      manifest: await buildMigrationManifest(vfs, paths.agentRoot(ws, agent)),
+      // The Rust-era color from `.houston/agent.json`, so the wizard seeds it
+      // onto the created cloud agent (SourceAgent.color; the localStorage
+      // overlay reader stays the fallback for TS-era local installs).
+      // JSON.stringify drops it when absent.
+      color: await legacyAgentColor(vfs, root),
+      manifest: await buildMigrationManifest(vfs, root),
     });
   }
   json(res, 200, {

--- a/packages/sdk/src/modules/agents/types.ts
+++ b/packages/sdk/src/modules/agents/types.ts
@@ -10,15 +10,22 @@
 
 /**
  * One agent exactly as the host's `GET /agents` returns it (protocol v3, the
- * `Agent` record in `packages/host/src/domain/types.ts`). No cosmetic overlay
- * fields (color, assignment) — those are hosted-gateway extras the base host
- * route does not serve, so the SDK does not invent them.
+ * `Agent` record in `packages/host/src/domain/types.ts`). Assignment fields
+ * are hosted-gateway extras the base host route does not serve, so the SDK
+ * does not invent them.
  */
 export interface WireAgent {
   id: string;
   workspaceId: string;
   name: string;
   createdAt: number;
+  /**
+   * Rust-era legacy color, read by the host from the agent's
+   * `.houston/agent.json` (local/self-host profiles only; the hosted gateway
+   * omits it). A client's own color overlay outranks it — this only fills the
+   * gap for agents whose color was picked before the engine cutover.
+   */
+  color?: string;
 }
 
 /** A single agent inside the `agents` scope snapshot. */

--- a/packages/web/src/engine-adapter/cp/agents.ts
+++ b/packages/web/src/engine-adapter/cp/agents.ts
@@ -18,6 +18,12 @@ interface CpAgent {
   /** Absolute on-disk directory — present only when the host is co-located
    * with the files (local profile). Feeds the OS reveal/open commands. */
   dir?: string;
+  /** Rust-era legacy color the host reads from the agent's
+   * `.houston/agent.json` (local profiles only; the gateway omits it). The
+   * client overlay — the user's current pick — outranks it; this only fills
+   * the gap for colors picked before the engine cutover, which the overlay
+   * never held (they lived engine-side). */
+  color?: string;
   assigned?: boolean;
   assignedUserIds?: string[];
   /** Teams v2: the caller's effective access to this agent. */
@@ -26,7 +32,8 @@ interface CpAgent {
   assignments?: AgentAssignment[];
 }
 
-function toUiAgent(a: CpAgent, colors = colorOverlay()): Agent {
+/** Exported for unit tests (the color precedence is the load-bearing bit). */
+export function toUiAgent(a: CpAgent, colors = colorOverlay()): Agent {
   const iso = new Date(a.createdAt).toISOString();
   return {
     id: a.id,
@@ -36,7 +43,12 @@ function toUiAgent(a: CpAgent, colors = colorOverlay()): Agent {
     // folderPath here is a route key, not a path (HOU-677).
     localDir: a.dir,
     configId: DEFAULT_AGENT_CONFIG_ID,
-    color: colors[a.id] ?? DEFAULT_AGENT_COLOR,
+    // Overlay (the user's current pick) → the host's legacy Rust-era color
+    // (`.houston/agent.json`) → the default. Before the wire fallback every
+    // pre-cutover color rendered as the default purple: the Rust engine stored
+    // colors server-side, so the overlay never held them (the reported
+    // everything-turned-purple migration bug).
+    color: colors[a.id] ?? a.color ?? DEFAULT_AGENT_COLOR,
     createdAt: iso,
     lastOpenedAt: iso,
     assigned: a.assigned,

--- a/packages/web/tests/agent-color-overlay.test.ts
+++ b/packages/web/tests/agent-color-overlay.test.ts
@@ -2,7 +2,9 @@ import { expect, test } from "vitest";
 import {
   removeColorOverlay,
   renameColorOverlay,
+  toUiAgent,
 } from "../src/engine-adapter/control-plane";
+import { DEFAULT_AGENT_COLOR } from "../src/engine-adapter/synthetic";
 
 /**
  * In host mode an agent's color lives in a client-side overlay keyed by
@@ -47,4 +49,32 @@ test("delete drops the agent's overlay entry so a reused path-id can't inherit i
 test("delete is a no-op when the agent had no color", () => {
   const overlay = { "Home/Ada": "#5b21b6" };
   expect(removeColorOverlay(overlay, "Home/Bob")).toBe(overlay);
+});
+
+// ── legacy wire color (Rust-era `.houston/agent.json`, served by the host) ──
+
+const wireAgent = (color?: string) => ({
+  id: "Home/Bob",
+  workspaceId: "Home",
+  name: "Bob",
+  createdAt: 0,
+  ...(color ? { color } : {}),
+});
+
+test("the overlay (the user's current pick) outranks the host's legacy color", () => {
+  const ui = toUiAgent(wireAgent("forest"), { "Home/Bob": "#5b21b6" });
+  expect(ui.color).toBe("#5b21b6");
+});
+
+test("without an overlay entry, the host's legacy Rust-era color is used", () => {
+  // Pre-cutover colors lived engine-side (`.houston/agent.json`), so the
+  // overlay never held them — falling straight to the default was the
+  // everything-turned-purple migration bug.
+  const ui = toUiAgent(wireAgent("forest"), {});
+  expect(ui.color).toBe("forest");
+});
+
+test("no overlay and no legacy color falls back to the default", () => {
+  const ui = toUiAgent(wireAgent(), {});
+  expect(ui.color).toBe(DEFAULT_AGENT_COLOR);
 });


### PR DESCRIPTION
Fixes two user-reported bugs from the 2026-07-21 batch, one commit each.

## 1. Agent renames revert after a while

**Root cause.** On the local host an agent's name IS its directory and its id is `<Workspace>/<Agent>`. `PATCH /agents/:id` renamed the directory while the agent's warm runtime subprocess kept running: the launcher keeps it keyed under the OLD id and the process was spawned with absolute `HOUSTON_WORKSPACE_DIR`/`HOUSTON_DATA_DIR` env pointing into the OLD directory. The runtime's stores `mkdirSync(..., {recursive:true})` on write, so the leaked runtime's next write resurrected the old-named folder; the directory-scan store re-listed it and the UI painted the old name back. On Windows the live child's cwd can additionally fail the rename outright.

**Fix.** `RuntimeChannel` gains optional `quiesce(ctx)`; `ProxyChannel.quiesce` sleeps the launcher entry; `ProcessLauncher.sleep` now waits (bounded, 5s) for the child's actual exit; the PATCH handler quiesces before `store.renameAgent`, skips same-name no-ops, and surfaces a quiesce failure instead of renaming under a live runtime. Per-turn channels omit `quiesce`; no-channel workspaces still rename.

**Caveat.** The resurrect mechanism is verified from code (paths, launcher lifecycle, mkdir-recursive writers), not reproduced on a packaged build. Other candidate writers (scheduler, boot migrations, SDK/query caches, onboarding provisioner) were ruled out explicitly. Hosted-cloud renames go through the gateway's own agent records — untouched here.

## 2. All agents turned the same purple after the migration

**Root cause.** The Rust engine persisted each agent's color server-side in `<agent>/.houston/agent.json` (`AgentMeta.color`). The v3 host serves id/name only, and the frontend reads colors from a localStorage overlay Rust-era installs never wrote — so every upgraded agent fell back to `DEFAULT_AGENT_COLOR = "#7a5cff"`, the reported purple. The colors were never lost; nothing read them.

**Fix.** New fail-soft reader (`agent-legacy-color.ts`); `GET /agents`, create, and rename responses attach the legacy color; the migration source scan carries it (the wizard already threaded color end to end — zero app changes); the web adapter resolves overlay → wire legacy color → default; SDK `WireAgent` gains the optional passthrough. **Idempotent healing:** already-migrated desktop/self-host users get their colors back on the next agent list — no boot migration needed, `.houston/agent.json` was never deleted. A cloud pod serves the color too (the migration round-trip test proves `agent.json` rides the import); already-migrated HOSTED users additionally need the closed gateway to pass the pod's color through.

## Tests

- Host: the 3 new suites 24/24; adjacent 8 suites 95/95; full suite 948 pass with 6 failures verified identical on a clean tree (Windows-environment: POSIX perms, `/dev/null` stdin, libuv fs-watcher native assert — CI is the clean signal, including the migration round-trip's new color assertions).
- Web adapter 210/210, SDK 369/369, domain 147/147, app 1945/1945.
- Biome clean, `check:boundaries` clean, typechecks clean (`@houston/host`, `@houston/sdk`, `houston-web` incl. shim parity, app tsgo).
