### PR TITLE
fix(integrations): secure credential save works for schemeless specs + platform-correct secret permissions

### DIFF
--- a/knowledge-base/integrations.md
+++ b/knowledge-base/integrations.md
@@ -819,6 +819,25 @@ validate (`connections.validate`, fail-open on `unknown`) → secret store →
 connection rewire. It NEVER enters the transcript; the prompt (houston-prompt.ts
 + the Rust mirror) forbids asking for keys in chat.
 
+**A spec with no security scheme still takes a key (the PriceLabs fix).** Many
+real specs (and agent-authored ones) declare NO `securitySchemes` — the key is
+just a documented header. That used to dead-end the secure save with
+`credential_invalid` on every attempt while pasting the key in chat worked (the
+worst possible incentive). Compile now injects a synthesized `houston_fallback`
+method for credential-mode OpenAPI defs with no collectible method
+(`custom/fallback-auth.ts` → `executor.openapi.configure`): the placement is
+derived from the spec's own api-key-shaped header/query parameter
+(`X-API-Key`-like names; an `Authorization` param gets `Bearer `), else the
+`Authorization: Bearer` default the MCP path already uses. The executor is
+in-memory, so every rebuild re-injects the SAME slug before the stored
+credential's connection re-renders through it. `setCredential` also heals defs
+added as `auth:"none"` (a later `request_credential` upgrades them), and its
+residual failures (uncompiled def; MCP def with no declared method) carry
+actionable messages. The secret FILE write is platform-correct: 0600 asserted
+on POSIX; on Windows (no POSIX modes — NTFS ACLs under the user profile are the
+protection) the write skips chmod and clears a stray read-only attribute before
+its rename-replace.
+
 **User routes** (`routes/custom-integrations.ts`, mounted BEFORE the generic
 `/v1/integrations/:provider/*` catch-all): GET/DELETE
 `/v1/integrations/custom/definitions[/:slug]` + the credential POST. Errors

--- a/packages/host/src/integrations/custom/executor-host.ts
+++ b/packages/host/src/integrations/custom/executor-host.ts
@@ -6,6 +6,7 @@ import { mcpPlugin } from "@executor-js/plugin-mcp/core";
 import { openApiPlugin } from "@executor-js/plugin-openapi/core";
 import { createExecutor } from "@executor-js/sdk";
 import { authMethodsOf, TOKEN_VARIABLE } from "./auth-methods";
+import { fallbackAuthTemplate } from "./fallback-auth";
 import type { CustomSecretStore } from "./secrets";
 import { HOUSTON_PROVIDER_KEY, houstonCredentialProvider } from "./secrets";
 import type {
@@ -127,6 +128,12 @@ export class CustomExecutorHost {
             : {}),
         });
       }
+      if (def.kind === "openapi" && def.auth === "credential") {
+        // BEFORE the pending/connect fork: a pending def's card needs the
+        // (possibly synthesized) fields, and a stored credential's template
+        // must exist before connections.create renders through it.
+        await this.ensureCollectibleAuth(executor, def);
+      }
       if (def.auth === "credential" && !def.credential) {
         return {
           status: "pending",
@@ -217,6 +224,34 @@ export class CustomExecutorHost {
   async toolCount(executor: CustomExecutor, slug: string): Promise<number> {
     const tools = await executor.tools.list();
     return tools.filter((t) => t.integration === slug).length;
+  }
+
+  /**
+   * A compiled OpenAPI integration with NO collectible auth method (a spec
+   * that models its key as a plain header parameter, or declares no auth at
+   * all) would dead-end the secure credential save: the key has nowhere to
+   * go, so `setCredential` could only fail — the reported PriceLabs bug,
+   * where the secure card errored on every attempt while pasting the key in
+   * chat worked. Synthesize a stable fallback method from the spec's own
+   * api-key-shaped parameter (else `Authorization: Bearer`, the MCP path's
+   * default). The executor is an in-memory view, so every rebuild re-injects
+   * the same `houston_fallback` template; a def whose stored credential
+   * references it therefore reconnects across restarts. No-op when the
+   * integration failed to compile or already declares a collectible method.
+   */
+  async ensureCollectibleAuth(
+    executor: CustomExecutor,
+    def: CustomIntegrationDef,
+  ): Promise<void> {
+    if (def.kind !== "openapi") return;
+    const integration = await executor.integrations.get(def.slug);
+    if (!integration) return;
+    const methods = integration.authMethods ?? [];
+    if (methods.some((m) => m.kind !== "oauth")) return;
+    await executor.openapi.configure(def.slug, {
+      authenticationTemplate: [fallbackAuthTemplate(def)],
+      mode: "merge",
+    });
   }
 
   /** The integration's declared auth methods, reduced to collectible fields. */

--- a/packages/host/src/integrations/custom/fallback-auth.test.ts
+++ b/packages/host/src/integrations/custom/fallback-auth.test.ts
@@ -1,0 +1,205 @@
+import { expect, test } from "vitest";
+import { FALLBACK_AUTH_SLUG, fallbackAuthTemplate } from "./fallback-auth";
+import type { CustomIntegrationDef } from "./types";
+
+/**
+ * fallbackAuthTemplate derives the synthesized placement for a spec that
+ * declares NO security scheme — the PriceLabs class of failure, where the
+ * key's placement must come from the spec's own parameters or a safe default.
+ */
+
+function openapiDef(spec: object | string): CustomIntegrationDef {
+  return {
+    kind: "openapi",
+    slug: "acme",
+    name: "Acme",
+    spec: {
+      kind: "blob",
+      value: typeof spec === "string" ? spec : JSON.stringify(spec),
+    },
+    auth: "credential",
+    addedAtMs: 0,
+  };
+}
+
+const doc = (extra: object) => ({
+  openapi: "3.0.0",
+  info: { title: "Acme", version: "1.0.0" },
+  servers: [{ url: "https://api.acme.test" }],
+  ...extra,
+});
+
+const TOKEN_PART = { type: "variable", name: "token" };
+
+test("an api-key-shaped header parameter becomes a header placement (PriceLabs shape)", () => {
+  const def = openapiDef(
+    doc({
+      paths: {
+        "/listings": {
+          get: {
+            operationId: "getListings",
+            parameters: [
+              { name: "X-API-Key", in: "header", required: true },
+              { name: "limit", in: "query" },
+            ],
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+    }),
+  );
+  expect(fallbackAuthTemplate(def)).toEqual({
+    slug: FALLBACK_AUTH_SLUG,
+    type: "apiKey",
+    headers: { "X-API-Key": [TOKEN_PART] },
+  });
+});
+
+test("path-level shared parameters and component parameters are seen", () => {
+  const shared = openapiDef(
+    doc({
+      paths: {
+        "/a": {
+          parameters: [{ name: "Api-Token", in: "header" }],
+          get: { operationId: "a", responses: {} },
+        },
+      },
+    }),
+  );
+  expect(fallbackAuthTemplate(shared).headers).toEqual({
+    "Api-Token": [TOKEN_PART],
+  });
+
+  const viaRef = openapiDef(
+    doc({
+      components: {
+        parameters: { key: { name: "X-Auth-Token", in: "header" } },
+      },
+      paths: {
+        "/a": {
+          get: {
+            operationId: "a",
+            parameters: [{ $ref: "#/components/parameters/key" }],
+            responses: {},
+          },
+        },
+      },
+    }),
+  );
+  expect(fallbackAuthTemplate(viaRef).headers).toEqual({
+    "X-Auth-Token": [TOKEN_PART],
+  });
+});
+
+test("an Authorization header parameter gets the Bearer prefix", () => {
+  const def = openapiDef(
+    doc({
+      paths: {
+        "/a": {
+          get: {
+            operationId: "a",
+            parameters: [{ name: "Authorization", in: "header" }],
+            responses: {},
+          },
+        },
+      },
+    }),
+  );
+  expect(fallbackAuthTemplate(def).headers).toEqual({
+    Authorization: ["Bearer ", TOKEN_PART],
+  });
+});
+
+test("a specific api-key header outranks a generic Authorization header", () => {
+  const def = openapiDef(
+    doc({
+      paths: {
+        "/a": {
+          get: {
+            operationId: "a",
+            parameters: [
+              { name: "Authorization", in: "header" },
+              { name: "X-API-Key", in: "header" },
+            ],
+            responses: {},
+          },
+        },
+      },
+    }),
+  );
+  expect(fallbackAuthTemplate(def).headers).toEqual({
+    "X-API-Key": [TOKEN_PART],
+  });
+});
+
+test("an api-key query parameter becomes a query placement when no header hints", () => {
+  const def = openapiDef(
+    doc({
+      paths: {
+        "/a": {
+          get: {
+            operationId: "a",
+            parameters: [{ name: "api_key", in: "query" }],
+            responses: {},
+          },
+        },
+      },
+    }),
+  );
+  expect(fallbackAuthTemplate(def)).toEqual({
+    slug: FALLBACK_AUTH_SLUG,
+    type: "apiKey",
+    queryParams: { api_key: [TOKEN_PART] },
+  });
+});
+
+test("no hints at all falls back to Authorization: Bearer", () => {
+  const def = openapiDef(doc({ paths: {} }));
+  expect(fallbackAuthTemplate(def)).toEqual({
+    slug: FALLBACK_AUTH_SLUG,
+    type: "apiKey",
+    headers: { Authorization: ["Bearer ", TOKEN_PART] },
+  });
+});
+
+test("unparsable (YAML) blobs and url-sourced specs fall back to Bearer", () => {
+  const yaml = openapiDef("openapi: 3.0.0\npaths: {}\n");
+  expect(fallbackAuthTemplate(yaml).headers).toEqual({
+    Authorization: ["Bearer ", TOKEN_PART],
+  });
+
+  const urlDef: CustomIntegrationDef = {
+    kind: "openapi",
+    slug: "acme",
+    name: "Acme",
+    spec: { kind: "url", url: "https://api.acme.test/openapi.json" },
+    auth: "credential",
+    addedAtMs: 0,
+  };
+  expect(fallbackAuthTemplate(urlDef).headers).toEqual({
+    Authorization: ["Bearer ", TOKEN_PART],
+  });
+});
+
+test("unrelated parameters never match (no false-positive placements)", () => {
+  const def = openapiDef(
+    doc({
+      paths: {
+        "/a": {
+          get: {
+            operationId: "a",
+            parameters: [
+              { name: "X-Request-Id", in: "header" },
+              { name: "page", in: "query" },
+              { name: "id", in: "path", required: true },
+            ],
+            responses: {},
+          },
+        },
+      },
+    }),
+  );
+  expect(fallbackAuthTemplate(def).headers).toEqual({
+    Authorization: ["Bearer ", TOKEN_PART],
+  });
+});

--- a/packages/host/src/integrations/custom/fallback-auth.ts
+++ b/packages/host/src/integrations/custom/fallback-auth.ts
@@ -1,0 +1,152 @@
+import type { ApiKeyAuthTemplate } from "@executor-js/plugin-openapi/core";
+import { variable } from "@executor-js/plugin-openapi/core";
+import type { CustomIntegrationDef } from "./types";
+
+/**
+ * Synthesized auth method for credential-mode OpenAPI defs whose spec declares
+ * NO collectible security scheme. Real-world specs frequently model the API
+ * key as a plain header parameter (or omit auth entirely — agent-authored
+ * minimal specs), which used to dead-end the secure credential save with
+ * `credential_invalid` while pasting the key in chat worked. The fallback
+ * gives the key a placement: the spec's own api-key-shaped parameter when one
+ * exists, else the `Authorization: Bearer` default (the same default the MCP
+ * path already uses).
+ */
+
+/** Stable method slug — persisted as `def.credential.template`, so every
+ *  executor rebuild must re-inject the SAME slug before reconnecting. */
+export const FALLBACK_AUTH_SLUG = "houston_fallback";
+
+/** Api-key-shaped parameter names, compared with separators stripped and an
+ *  optional leading `x` removed (`X-API-Key` → `apikey`). */
+const KEY_NAMES = new Set([
+  "apikey",
+  "apitoken",
+  "authtoken",
+  "accesstoken",
+  "token",
+  "key",
+]);
+
+function isKeyName(name: string): boolean {
+  const normalized = name.toLowerCase().replace(/[-_]/g, "");
+  if (KEY_NAMES.has(normalized)) return true;
+  return normalized.startsWith("x") && KEY_NAMES.has(normalized.slice(1));
+}
+
+interface ParamHint {
+  in: "header" | "query";
+  name: string;
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+
+/** Read one OpenAPI parameter object (or a `#/components/parameters/…` ref,
+ *  resolved against the doc) down to the `{in, name}` pair we care about. */
+function paramOf(
+  entry: unknown,
+  componentParams: Record<string, unknown>,
+): ParamHint | null {
+  if (!isRecord(entry)) return null;
+  const resolved =
+    typeof entry.$ref === "string"
+      ? componentParams[entry.$ref.split("/").at(-1) ?? ""]
+      : entry;
+  if (!isRecord(resolved)) return null;
+  const where = resolved.in;
+  const name = resolved.name;
+  if ((where !== "header" && where !== "query") || typeof name !== "string") {
+    return null;
+  }
+  return { in: where, name };
+}
+
+const HTTP_METHODS = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "patch",
+  "head",
+  "options",
+  "trace",
+];
+
+/** Every header/query parameter the document declares, in document order:
+ *  component-level, then per-path shared, then per-operation. */
+function collectParams(doc: Record<string, unknown>): ParamHint[] {
+  const components = isRecord(doc.components) ? doc.components : {};
+  const componentParams = isRecord(components.parameters)
+    ? components.parameters
+    : {};
+  const out: ParamHint[] = [];
+  const push = (entries: unknown) => {
+    if (!Array.isArray(entries)) return;
+    for (const entry of entries) {
+      const hint = paramOf(entry, componentParams);
+      if (hint) out.push(hint);
+    }
+  };
+  for (const value of Object.values(componentParams)) push([value]);
+  const paths = isRecord(doc.paths) ? doc.paths : {};
+  for (const item of Object.values(paths)) {
+    if (!isRecord(item)) continue;
+    push(item.parameters);
+    for (const method of HTTP_METHODS) {
+      const op = item[method];
+      if (isRecord(op)) push(op.parameters);
+    }
+  }
+  return out;
+}
+
+/** The best placement hint an inline JSON spec offers, or null. Priority: a
+ *  specific api-key header, then an `Authorization` header, then an api-key
+ *  query param. YAML blobs and url-sourced specs offer none (null). */
+function specKeyHint(def: CustomIntegrationDef): ParamHint | null {
+  if (def.kind !== "openapi" || def.spec.kind !== "blob") return null;
+  let doc: unknown;
+  try {
+    doc = JSON.parse(def.spec.value);
+  } catch {
+    return null;
+  }
+  if (!isRecord(doc)) return null;
+  const params = collectParams(doc);
+  const headerKey = params.find((p) => p.in === "header" && isKeyName(p.name));
+  if (headerKey) return headerKey;
+  const authHeader = params.find(
+    (p) => p.in === "header" && p.name.toLowerCase() === "authorization",
+  );
+  if (authHeader) return authHeader;
+  return params.find((p) => p.in === "query" && isKeyName(p.name)) ?? null;
+}
+
+/**
+ * The fallback method in the plugin's request-shaped authoring dialect, ready
+ * for `executor.openapi.configure(slug, {authenticationTemplate: [...]})`.
+ * Renders the single `token` variable into the derived placement; an
+ * `Authorization` header (hinted or default) gets the `Bearer ` prefix.
+ */
+export function fallbackAuthTemplate(
+  def: CustomIntegrationDef,
+): ApiKeyAuthTemplate {
+  const hint = specKeyHint(def);
+  if (hint && hint.in === "query") {
+    return {
+      slug: FALLBACK_AUTH_SLUG,
+      type: "apiKey",
+      queryParams: { [hint.name]: [variable("token")] },
+    };
+  }
+  const header = hint?.name ?? "Authorization";
+  const bearer = header.toLowerCase() === "authorization";
+  return {
+    slug: FALLBACK_AUTH_SLUG,
+    type: "apiKey",
+    headers: {
+      [header]: bearer ? ["Bearer ", variable("token")] : [variable("token")],
+    },
+  };
+}

--- a/packages/host/src/integrations/custom/manager.test.ts
+++ b/packages/host/src/integrations/custom/manager.test.ts
@@ -72,6 +72,32 @@ const AUTH_SPEC = JSON.stringify({
   },
 });
 
+// The reported PriceLabs shape: NO securitySchemes at all — the key exists
+// only as a header parameter the docs describe per operation. The secure save
+// used to dead-end on this (`credential_invalid: declares no credential-based
+// auth method`) while pasting the key in chat worked.
+const HEADER_PARAM_SPEC = JSON.stringify({
+  openapi: "3.0.0",
+  info: { title: "PriceLabs", version: "1.0.0" },
+  servers: [{ url: "https://api.pricelabs.example" }],
+  paths: {
+    "/listings": {
+      get: {
+        operationId: "getListings",
+        parameters: [
+          {
+            name: "X-API-Key",
+            in: "header",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "200": { description: "ok" } },
+      },
+    },
+  },
+});
+
 function setup() {
   const store = new MemoryCustomIntegrationStore();
   const secrets = new MemoryCustomSecretStore();
@@ -178,6 +204,100 @@ test("add(openapi, auth:credential) is pending until setCredential(); then activ
     template: expect.any(String),
     secretIds: { token: `ci_${added.slug}_token` },
   });
+});
+
+test("a spec with NO security scheme still takes a key: the fallback method places it (PriceLabs regression)", async () => {
+  const { manager, secrets, store } = setup();
+  const added = await manager.add({
+    kind: "openapi",
+    name: "PriceLabs",
+    spec: { kind: "blob", value: HEADER_PARAM_SPEC },
+    auth: "credential",
+  });
+  // The pending card must offer a REAL field (the synthesized method naming
+  // the spec's own X-API-Key header), never an empty method list.
+  expect(added.state.status).toBe("pending");
+  if (added.state.status === "pending") {
+    expect(added.state.authMethods).toHaveLength(1);
+    expect(added.state.authMethods[0]?.label).toContain("X-API-Key");
+  }
+
+  const updated = await manager.setCredential(added.slug, {
+    token: "plk_live_123",
+  });
+  expect(updated.state.status).toBe("active");
+  expect(await secrets.get(`ci_${added.slug}_token`)).toBe("plk_live_123");
+  const def = (await store.list()).find((d) => d.slug === added.slug);
+  expect(def?.credential).toEqual({
+    template: "houston_fallback",
+    secretIds: { token: `ci_${added.slug}_token` },
+  });
+});
+
+test("a spec with no auth hints at all falls back to Bearer and still saves", async () => {
+  const { manager } = setup();
+  // OPENAPI_SPEC declares neither securitySchemes nor key-shaped parameters.
+  const added = await manager.add({
+    kind: "openapi",
+    name: "Widgets",
+    spec: { kind: "blob", value: OPENAPI_SPEC },
+    auth: "credential",
+  });
+  expect(added.state.status).toBe("pending");
+  if (added.state.status === "pending") {
+    expect(added.state.authMethods[0]?.label).toContain("Authorization");
+  }
+  const updated = await manager.setCredential(added.slug, { token: "k" });
+  expect(updated.state.status).toBe("active");
+});
+
+test("setCredential on a def added as auth:'none' upgrades it (request_credential after the fact)", async () => {
+  const { manager, store } = setup();
+  const added = await manager.add({
+    kind: "openapi",
+    name: "PriceLabs",
+    spec: { kind: "blob", value: HEADER_PARAM_SPEC },
+    auth: "none",
+  });
+  expect(added.state.status).toBe("active");
+
+  const updated = await manager.setCredential(added.slug, { token: "k" });
+  expect(updated.state.status).toBe("active");
+  const def = (await store.list()).find((d) => d.slug === added.slug);
+  expect(def?.auth).toBe("credential");
+  expect(def?.credential?.template).toBe("houston_fallback");
+});
+
+test("a fallback-credential def survives a restart: fresh host reconnects through the re-injected template", async () => {
+  const store = new MemoryCustomIntegrationStore();
+  const secrets = new MemoryCustomSecretStore();
+  const host1 = new CustomExecutorHost(secrets, () => store.list());
+  const manager1 = new CustomIntegrationManager(
+    store,
+    secrets,
+    host1,
+    () => {},
+  );
+  const added = await manager1.add({
+    kind: "openapi",
+    name: "PriceLabs",
+    spec: { kind: "blob", value: HEADER_PARAM_SPEC },
+    auth: "credential",
+  });
+  await manager1.setCredential(added.slug, { token: "plk_live_123" });
+
+  // The executor is in-memory: a fresh host must re-inject `houston_fallback`
+  // BEFORE re-creating the stored connection that renders through it, or every
+  // restart would break the integration.
+  const host2 = new CustomExecutorHost(secrets, () => store.list());
+  const manager2 = new CustomIntegrationManager(
+    store,
+    secrets,
+    host2,
+    () => {},
+  );
+  const views = await manager2.list();
+  expect(views[0]?.state.status).toBe("active");
 });
 
 test("setCredential on an unknown slug is not_found; an empty value is credential_invalid", async () => {

--- a/packages/host/src/integrations/custom/manager.ts
+++ b/packages/host/src/integrations/custom/manager.ts
@@ -86,12 +86,20 @@ export class CustomIntegrationManager {
   ): Promise<CustomIntegrationView> {
     const def = await this.defOr404(slug);
     const { executor, states } = await this.host.ensure();
+    // Providing a key IS declaring the service needs one: heal an OpenAPI def
+    // with no collectible method (spec without a security scheme) instead of
+    // dead-ending the save — covers defs added as `auth: "none"` too, which
+    // compileDef's own ensure call never sees.
+    await this.host.ensureCollectibleAuth(executor, def);
     const methods = await this.host.authMethods(executor, slug);
     const method = methods[0];
     if (!method) {
+      const state = states.get(slug);
       throw new CustomIntegrationError(
         "credential_invalid",
-        `'${slug}' declares no credential-based auth method`,
+        state?.status === "error"
+          ? `'${slug}' is not working right now (${state.message}), so the key cannot be saved. Fix or re-add the integration first.`
+          : `'${slug}' does not say where an API key goes. Remove it and add it again as a service that needs a key.`,
       );
     }
     const token = values[TOKEN_VARIABLE] ?? Object.values(values)[0];

--- a/packages/host/src/integrations/custom/secrets.test.ts
+++ b/packages/host/src/integrations/custom/secrets.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, expect, test } from "vitest";
@@ -56,12 +56,40 @@ test("multiple ids coexist independently", async () => {
   expect(await store.get("ci_beta_token")).toBe("b");
 });
 
-test("the secret file is written 0600, not world/group readable", async () => {
-  const store = new FileCustomSecretStore(path);
-  await store.set("ci_acme_token", "sk-live-123");
-  const mode = statSync(path).mode & 0o777;
-  expect(mode).toBe(0o600);
-});
+// POSIX custody: the 0600 file mode IS the protection. Windows has no POSIX
+// modes (stat reports a synthesized 0666; NTFS ACLs under the user profile
+// are the user-scoped protection there), so this assertion is POSIX-only.
+test.runIf(process.platform !== "win32")(
+  "the secret file is written 0600, not world/group readable",
+  async () => {
+    const store = new FileCustomSecretStore(path);
+    await store.set("ci_acme_token", "sk-live-123");
+    const mode = statSync(path).mode & 0o777;
+    expect(mode).toBe(0o600);
+
+    // A later write over an EXISTING file re-asserts 0600 even if the file's
+    // mode was widened out-of-band.
+    chmodSync(path, 0o644);
+    await store.set("ci_acme_token", "sk-live-456");
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  },
+);
+
+// Windows custody: no chmod on the write path (POSIX-only concept), and a
+// destination some backup/AV tool marked read-only must not break the save
+// (rename-replace over a read-only file fails EPERM unless cleared first).
+test.runIf(process.platform === "win32")(
+  "windows: writes succeed, including over a read-only destination",
+  async () => {
+    const store = new FileCustomSecretStore(path);
+    await store.set("ci_acme_token", "sk-live-123");
+    expect(await store.get("ci_acme_token")).toBe("sk-live-123");
+
+    chmodSync(path, 0o400); // sets the read-only attribute on Windows
+    await store.set("ci_acme_token", "sk-live-456");
+    expect(await store.get("ci_acme_token")).toBe("sk-live-456");
+  },
+);
 
 test("secretIdFor is stable and namespaced per slug+variable", () => {
   expect(secretIdFor("acme", "token")).toBe("ci_acme_token");

--- a/packages/host/src/integrations/custom/secrets.ts
+++ b/packages/host/src/integrations/custom/secrets.ts
@@ -45,9 +45,18 @@ export class MemoryCustomSecretStore implements CustomSecretStore {
 }
 
 /**
- * File-backed store: one JSON object, 0600, atomic tmp+rename. A corrupt file
- * throws (a vanished credential must surface as an error the user can act on,
- * never silently degrade to "not connected").
+ * File-backed store: one JSON object, owner-only, atomic tmp+rename. A corrupt
+ * file throws (a vanished credential must surface as an error the user can act
+ * on, never silently degrade to "not connected").
+ *
+ * Owner-only is PLATFORM-SPECIFIC. On POSIX (macOS desktop, self-host, cloud
+ * pods) the 0600 file mode is the protection, asserted after every write. On
+ * Windows there are no POSIX modes: files under the user's profile inherit
+ * user-scoped NTFS ACLs, `mode`/`chmod` map onto nothing but the read-only
+ * attribute — so the write path must NOT chmod (a POSIX-only concept), and it
+ * clears a stray read-only attribute on the destination first, because
+ * rename-replace over a read-only file fails EPERM on Windows (backup/AV
+ * tools set that attribute in the wild).
  */
 export class FileCustomSecretStore implements CustomSecretStore {
   constructor(private readonly path: string) {}
@@ -64,8 +73,17 @@ export class FileCustomSecretStore implements CustomSecretStore {
     mkdirSync(dirname(this.path), { recursive: true });
     const tmp = `${this.path}.tmp`;
     writeFileSync(tmp, JSON.stringify(map), { encoding: "utf8", mode: 0o600 });
+    if (process.platform === "win32" && existsSync(this.path)) {
+      // Clears the read-only attribute (the one thing chmod maps to on
+      // Windows) so the rename below can replace the file.
+      chmodSync(this.path, 0o600);
+    }
     renameSync(tmp, this.path);
-    chmodSync(this.path, 0o600);
+    if (process.platform !== "win32") {
+      // The tmp file was created 0600; re-assert on the destination in case a
+      // pre-existing file carried a wider mode.
+      chmodSync(this.path, 0o600);
+    }
   }
 
   async get(id: string): Promise<string | null> {


### PR DESCRIPTION
Fixes the user-reported "PriceLabs secure API-key save fails (pasting the key in chat works)" bug, plus a latent Windows hazard found on the way. Two commits.

## 1. Never dead-end the secure credential save on schemeless specs

**Root cause.** `setCredential` hard-failed with `credential_invalid` whenever the compiled def derived zero auth methods, and auth methods derive ONLY from the spec's `securitySchemes`. Agent-authored OpenAPI specs — the normal path for services like PriceLabs that publish no OpenAPI document — routinely omit `securitySchemes`. The secure card still rendered a key field, so the user typed their key and every save deterministically 400'd, while pasting the key in chat worked (the model passes it as the operation's header parameter, skipping the store). Platform-independent: identical on Windows/macOS desktop, self-host, and cloud pods. Reproduced against the real embedded executor engine.

**Fix.**
- `fallback-auth.ts` (new): synthesizes a stable `houston_fallback` auth method — placement derived from the spec's own api-key-shaped header/query parameter (`X-API-Key` etc.; `Authorization` gets the `Bearer ` prefix), else `Authorization: Bearer`, matching the MCP path's existing default.
- `executor-host.ts`: `ensureCollectibleAuth()` injects it during `compileDef`, before the pending/connect fork — the card shows the real field label, and every rebuild re-injects the template before the stored credential's connection re-renders through it (restart-safe).
- `manager.ts`: also heals defs added as `auth:"none"`; residual failures now carry actionable messages that reach the user through the existing toast path.

## 2. Platform-correct custom-secret file permissions

The Windows-0600 suspicion was real for the TEST, not the production write (verified under Node 24 and Bun 1.3.3). But a real hazard surfaced: rename-replace over a destination carrying the read-only attribute (backup/AV tools set it) fails EPERM on Windows. Now: 0600 asserted on POSIX after every write; on Windows no chmod (NTFS ACLs under the profile are the protection) and a stray read-only attribute is cleared before rename-replace.

## Tally (investigated in the same pass, no code here)

Tally IS in the Composio catalog and this repo's direct adapter connects it fine (live-verified: minted a hosted connect link with the dev key). The desktop forwards connects to the closed cloud gateway, whose auth-config resolution appears to lack the API_KEY custom-auth fallback this repo has — sibling fix belongs in the cloud repo. Bug 1's fix also repairs Tally's fallback path through custom integrations.

## Tests

Custom-integrations tree: 42 passed, 1 platform-skipped (POSIX 0600 assertion); 4 new PriceLabs regression tests + 8 fallback-auth unit tests + a Windows read-only-destination test, all against the real executor engine. Full `src/integrations` + routes: 145 passed. Domain 147. Host typecheck, Biome, boundaries: clean. Known pre-existing Windows-env failures verified identical on a clean tree at the base commit.
