### PR TITLE
fix(teams): personal spaces offer create-a-team instead of a doomed invite

### DIFF
--- a/app/src/components/organization/admin-index.tsx
+++ b/app/src/components/organization/admin-index.tsx
@@ -7,6 +7,12 @@ import type { OrgTabId } from "./org-view-model";
 interface AdminIndexProps {
   /** The sections visible for this caller + space, from `orgTabIds`. */
   visibleIds: readonly OrgTabId[];
+  /**
+   * True when the active space is the caller's personal one (C8 `spaceKind`).
+   * A personal space is non-invitable, so the People row's caption reads as
+   * the create-a-team path instead of promising invites the gateway rejects.
+   */
+  personalSpace?: boolean;
   /** Roster size from the loaded `GET /org`; undefined while it loads. */
   memberCount?: number;
   onSelect: (id: OrgTabId) => void;
@@ -27,6 +33,7 @@ interface AdminIndexProps {
  */
 export function AdminIndex({
   visibleIds,
+  personalSpace = false,
   memberCount,
   onSelect,
 }: AdminIndexProps) {
@@ -46,7 +53,11 @@ export function AdminIndex({
           <SettingsRow
             icon={Users}
             title={t("org.tabs.people")}
-            description={t("org.index.rows.people")}
+            description={t(
+              personalSpace
+                ? "org.index.rows.peoplePersonal"
+                : "org.index.rows.people",
+            )}
             value={
               memberCount === undefined
                 ? undefined

--- a/app/src/components/organization/members-tab.tsx
+++ b/app/src/components/organization/members-tab.tsx
@@ -1,7 +1,10 @@
 import { useTranslation } from "react-i18next";
+import { useCapabilities } from "../../hooks/use-capabilities";
 import { useSession } from "../../hooks/use-session";
+import { isPersonalSpace } from "../../lib/org-roles";
 import type { OrgTabProps } from "./organization-view";
 import { PeopleAddRow } from "./people-add-row";
+import { PeopleCreateTeamCta } from "./people-create-team-cta";
 import { PendingInvites } from "./people-invites";
 import { PeopleRoster } from "./people-roster";
 
@@ -14,14 +17,30 @@ import { PeopleRoster } from "./people-roster";
  * owner/admin, so it never mounts in single-player or for a plain member. All
  * mutations route through hooks whose `call()` wrapper toasts on failure, so
  * there are no silent failures here.
+ *
+ * In a PERSONAL space (C8 `spaceKind`) the whole membership surface is replaced
+ * by the create-a-team CTA: personal spaces are non-invitable (every member-add
+ * answers `403 personal_space`) and the roster is definitionally just the
+ * caller, so the add form, pending invites, and roster would only offer a dead
+ * end. A host that predates `spaceKind` omits it and keeps today's surface —
+ * see `isPersonalSpace`.
  */
 export default function MembersTab({ ctx }: OrgTabProps) {
   const { t } = useTranslation("teams");
   const { data: session } = useSession();
+  const { capabilities } = useCapabilities();
   const selfId = session?.uid ?? null;
   const canManage = ctx.isOwner;
   const members = ctx.org.members ?? [];
   const invites = ctx.org.invites ?? [];
+
+  if (isPersonalSpace(capabilities)) {
+    return (
+      <div className="flex flex-col gap-8 py-6">
+        <PeopleCreateTeamCta />
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-8 py-6">

--- a/app/src/components/organization/organization-view.tsx
+++ b/app/src/components/organization/organization-view.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useOrg } from "../../hooks/queries";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { analytics } from "../../lib/analytics";
-import { canSeeBillingTab } from "../../lib/org-roles";
+import { canSeeBillingTab, isPersonalSpace } from "../../lib/org-roles";
 import { isTeamWorkspace } from "../../lib/space-id";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { AdminDetailScreen } from "./admin-detail-screen";
@@ -98,6 +98,7 @@ export function OrganizationView() {
       <div className="flex-1 overflow-y-auto [scrollbar-gutter:stable]">
         <AdminIndex
           visibleIds={visibleIds}
+          personalSpace={isPersonalSpace(capabilities)}
           memberCount={org?.members?.length}
           onSelect={setActive}
         />

--- a/app/src/components/organization/people-create-team-cta.tsx
+++ b/app/src/components/organization/people-create-team-cta.tsx
@@ -1,0 +1,31 @@
+import { Button } from "@houston-ai/core";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { CreateTeamDialog } from "../shell/create-team-dialog";
+
+/**
+ * The People body for a PERSONAL space (C8). A personal space is non-invitable
+ * (the gateway answers `403 personal_space` on any member-add), so instead of
+ * an "Add someone" form that can only fail we offer the one path that works:
+ * create a team and invite people there. `CreateTeamDialog` switches straight
+ * into the new team on success, capabilities refetch with `spaceKind: "team"`,
+ * and the People tab re-renders as the real roster + invite surface — the
+ * user's invite journey continues without a dead end.
+ */
+export function PeopleCreateTeamCta() {
+  const { t } = useTranslation("teams");
+  const [createOpen, setCreateOpen] = useState(false);
+
+  return (
+    <section className="rounded-2xl border border-ink/5 bg-chip p-4">
+      <h2 className="mb-1 text-sm font-medium text-ink">
+        {t("people.personal.title")}
+      </h2>
+      <p className="mb-3 text-xs text-ink-muted">{t("people.personal.body")}</p>
+      <Button className="rounded-full" onClick={() => setCreateOpen(true)}>
+        {t("people.personal.cta")}
+      </Button>
+      <CreateTeamDialog open={createOpen} onOpenChange={setCreateOpen} />
+    </section>
+  );
+}

--- a/app/src/lib/org-roles.ts
+++ b/app/src/lib/org-roles.ts
@@ -28,6 +28,23 @@ export function hasSpaces(caps: Capabilities | null | undefined): boolean {
 }
 
 /**
+ * Is the ACTIVE space the caller's personal one (C8 `spaceKind`)? A personal
+ * space is non-invitable — the gateway answers `403 personal_space` on any
+ * member-add — so the People/invite surface swaps to the create-a-team path
+ * when this is true (every user is `owner` of their personal space, so the
+ * role gates alone cannot tell it apart from a team). TOLERANT READER: true
+ * only when the host explicitly advertises `spaceKind: "personal"`; a gateway
+ * that predates the field omits it and this stays false, so hosted team users
+ * on a stale gateway keep the invite surface unchanged. The gateway is the
+ * sole enforcer; this only routes an affordance.
+ */
+export function isPersonalSpace(
+  caps: Capabilities | null | undefined,
+): boolean {
+  return caps?.spaceKind === "personal";
+}
+
+/**
  * The caller's org role, or null in single-player mode. A multiplayer host
  * always advertises a role; treat a missing one as the least-privileged `user`
  * so a stale/absent field never widens power.

--- a/app/src/locales/en/teams.json
+++ b/app/src/locales/en/teams.json
@@ -91,6 +91,7 @@
       },
       "rows": {
         "people": "Invite teammates, set roles, remove members.",
+        "peoplePersonal": "It's just you here. Create a team to invite people.",
         "activity": "What happened in this workspace, newest first.",
         "usage": "How much each agent and person is messaging.",
         "billing": "Seats, plan, and payment."
@@ -166,6 +167,11 @@
   },
   "people": {
     "adminNotice": "You can view your team. Only the owner can add or remove people.",
+    "personal": {
+      "title": "Create a team to invite people",
+      "body": "It's just you here for now. Teams let you invite people, share agents, and work together.",
+      "cta": "Create a team"
+    },
     "add": {
       "title": "Add someone",
       "subtitle": "Invite a teammate by email. If they don't have Houston yet, we'll send an invitation.",

--- a/app/src/locales/es/teams.json
+++ b/app/src/locales/es/teams.json
@@ -91,6 +91,7 @@
       },
       "rows": {
         "people": "Invita compañeros, asigna roles y quita miembros.",
+        "peoplePersonal": "Por ahora solo estás tú aquí. Crea un equipo para invitar a personas.",
         "activity": "Lo que pasó en este espacio de trabajo, lo más reciente primero.",
         "usage": "Cuántos mensajes envía cada agente y persona.",
         "billing": "Asientos, plan y pago."
@@ -166,6 +167,11 @@
   },
   "people": {
     "adminNotice": "Puedes ver a tu equipo. Solo el propietario puede agregar o quitar personas.",
+    "personal": {
+      "title": "Crea un equipo para invitar a personas",
+      "body": "Por ahora solo estás tú aquí. Los equipos te permiten invitar a personas, compartir agentes y trabajar en conjunto.",
+      "cta": "Crear un equipo"
+    },
     "add": {
       "title": "Agregar a alguien",
       "subtitle": "Invita a un compañero por correo. Si aún no tiene Houston, le enviaremos una invitación.",

--- a/app/src/locales/pt/teams.json
+++ b/app/src/locales/pt/teams.json
@@ -91,6 +91,7 @@
       },
       "rows": {
         "people": "Convide colegas, defina funções e remova membros.",
+        "peoplePersonal": "Por enquanto é só você aqui. Crie uma equipe para convidar pessoas.",
         "activity": "O que aconteceu neste espaço de trabalho, do mais recente ao mais antigo.",
         "usage": "Quantas mensagens cada agente e pessoa está enviando.",
         "billing": "Assentos, plano e pagamento."
@@ -166,6 +167,11 @@
   },
   "people": {
     "adminNotice": "Você pode ver sua equipe. Apenas o proprietário pode adicionar ou remover pessoas.",
+    "personal": {
+      "title": "Crie uma equipe para convidar pessoas",
+      "body": "Por enquanto é só você aqui. As equipes permitem convidar pessoas, compartilhar agentes e trabalhar em conjunto.",
+      "cta": "Criar uma equipe"
+    },
     "add": {
       "title": "Adicionar alguém",
       "subtitle": "Convide um colega por e-mail. Se ainda não tiver o Houston, enviaremos um convite.",

--- a/app/tests/org-roles.test.ts
+++ b/app/tests/org-roles.test.ts
@@ -10,6 +10,7 @@ import {
   canSeeMembers,
   GRANTABLE_ROLES,
   isMultiplayer,
+  isPersonalSpace,
   orgRole,
 } from "../src/lib/org-roles.ts";
 
@@ -133,6 +134,37 @@ describe("canSeeBillingTab (C8)", () => {
     strictEqual(canSeeBillingTab(multiplayer("owner"), true), false); // no spaces flag
     strictEqual(canSeeBillingTab(caps(), true), false);
     strictEqual(canSeeBillingTab(null, true), false);
+  });
+});
+
+describe("isPersonalSpace (C8 spaceKind)", () => {
+  const hosted = (spaceKind?: Capabilities["spaceKind"]): Capabilities =>
+    caps({
+      multiplayer: true,
+      role: "owner",
+      teams: true,
+      spaces: true,
+      spaceKind,
+    });
+
+  it("personal: the host explicitly says the active space is personal", () => {
+    // Every user is `owner` of their personal space, so the role gates alone
+    // cannot tell it apart from a team — only the explicit spaceKind can.
+    strictEqual(isPersonalSpace(hosted("personal")), true);
+  });
+
+  it("team: the invite surface stays", () => {
+    strictEqual(isPersonalSpace(hosted("team")), false);
+  });
+
+  it("absent (older gateway): never hides the invite surface", () => {
+    // Tolerant reader — a gateway that predates spaceKind omits it, and hosted
+    // team users there MUST keep today's members/invite surface unchanged.
+    strictEqual(isPersonalSpace(hosted(undefined)), false);
+    strictEqual(isPersonalSpace(multiplayer("owner")), false);
+    strictEqual(isPersonalSpace(caps()), false);
+    strictEqual(isPersonalSpace(null), false);
+    strictEqual(isPersonalSpace(undefined), false);
   });
 });
 

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -39,6 +39,17 @@ Two flags on `/v1/capabilities` (`Capabilities` in `ui/engine-client`):
   seat billing). Absent/false on desktop/self-host, where the switcher's create
   action stays "create a local workspace". Read via `hasSpaces(caps)`
   (`app/src/lib/org-roles.ts`). See the **Spaces** section below.
+- **`spaceKind?: "personal" | "team"`** — the ACTIVE space's kind, re-fetched
+  on every space switch exactly like `role`. The server-truth signal the
+  members/invite surface gates on: a personal space is non-invitable (every
+  member-add answers `403 personal_space`), and every user is `owner` of their
+  personal space, so the role gates alone can't tell it apart from a team.
+  Read via `isPersonalSpace(caps)` (`app/src/lib/org-roles.ts`) — a TOLERANT
+  reader: true only on an explicit `"personal"`, so a gateway that predates
+  the field keeps today's surface (a stale gateway never hides a team's invite
+  surface). When personal, the Organization > People body is replaced by a
+  create-a-team CTA (`people-create-team-cta.tsx`) and the Admin index People
+  caption follows (`org.index.rows.peoplePersonal`).
 
 Optional so every existing single-player/self-host profile stays valid.
 
@@ -445,6 +456,9 @@ restores members.
 
 - `caps.spaces` = the whole surface feature-detect (`hasSpaces`).
 - `caps.role` is the ACTIVE space's role; re-fetched on every switch (cache drop).
+- `caps.spaceKind` is the ACTIVE space's kind (`isPersonalSpace`); same
+  refetch-on-switch contract. Personal = non-invitable → the People surface
+  swaps to the create-team CTA (see **Feature detection**).
 - Growth beats, all Spaces-gated: an onboarding "invite your team" finish card
   (`onboarding/missions/onboarding-flow.ts` `showsInviteTeamCard`), a
   space-switcher tour step, and the personal-space person-filter teaser on the
@@ -566,7 +580,12 @@ hides the "Add models" list, all copy passed in.
 ## Invites, members, audit, usage
 
 - **Invites**: `addOrgMember(email, role)` → `POST /org/members` (targets the
-  ACTIVE space; `403 personal_space` on a personal one). A known user is added
+  ACTIVE space; `403 personal_space` on a personal one — which is why the
+  People tab never renders the add form in a personal space: `MembersTab`
+  branches on `isPersonalSpace(caps)` (`caps.spaceKind`) and shows the
+  create-a-team CTA instead, whose `CreateTeamDialog` switches into the new
+  team on success so the real invite surface appears right after). A known
+  user is added
   directly (`AddOrgMemberResult.userId`); an unknown email creates a pending
   invite and the host answers **202 `{invited:true}`**. `OrgInvite` rows surface
   on `GET /org` for owner/admin; `deleteOrgInvite` revokes (owner only).

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -112,6 +112,17 @@ export interface Capabilities {
    */
   spaces?: boolean;
   /**
+   * The kind of the ACTIVE space (C8). A `personal` space is non-invitable —
+   * the gateway answers `403 personal_space` on any member-add — while a
+   * `team` space is the invitable per-seat product. Server truth for the
+   * members/invite surface, re-fetched on every space switch exactly like
+   * `role` (the switch drops the query cache). Additive: absent on gateways
+   * that predate it, and readers MUST treat absent as "unknown" and keep the
+   * pre-spaceKind behavior so hosted team users on a stale gateway never lose
+   * the invite surface. The gateway is the sole enforcer either way.
+   */
+  spaceKind?: "personal" | "team";
+  /**
    * Whether this deployment can wake routines on external Composio events (C9
    * event-driven routines). Requires a Composio project key AND a public webhook
    * URL, so it is on for managed cloud + self-host and OFF on desktop (no public


### PR DESCRIPTION
Client half of the Teams invite fix (server half: gethouston/cloud#156). Fixes the confirmed production bug where users invited teammates from their PERSONAL space, the gateway answered `403 personal_space` by design, and the client showed a generic red failure toast — because the People surface only gated on `multiplayer` + role, and everyone owns their personal space.

## What

- **Capabilities type (additive)**: `spaceKind?: "personal" | "team"` on `ui/engine-client` `Capabilities` — the gateway's server-truth signal for the ACTIVE space, refetched on space switch. Tolerant reader: absent (older gateway) keeps today's behavior byte-identical.
- **Pure gate**: `isPersonalSpace(caps)` in `app/src/lib/org-roles.ts`, beside the other capability-only gates.
- **Surface**: one branch at the top of the Organization → People tab. In a personal space, the add-member form, pending invites, and roster are replaced by a "create a team to invite people" CTA that reuses `CreateTeamDialog`; on success the app switches into the new team, capabilities refetch as `team`, and the real invite surface appears — the journey continues instead of dead-ending. Admin index People caption follows suit.
- Deliberately narrow: `canSeeMembers`/`canSeeOrganization` untouched — Admin (Activity/Usage) and Permissions stay reachable in personal spaces; only the invite affordance is replaced. `share-via-team-flow` was already personal-aware.
- Copy in en/es/pt (`teams:people.personal.*`), teams-and-inviting language only.

## Decision table

| `capabilities.spaceKind` | People tab |
|---|---|
| `"personal"` | Create-team CTA replaces invite surface |
| `"team"` | Unchanged |
| absent (older gateway) | Unchanged — no regression on stale gateways |

## Tests

App suite 1950/1950 (new cases for the three states in `org-roles.test.ts`), `tsgo --noEmit` clean, `check-locales` in sync, `houston-web` typecheck + shim parity OK, engine-client typecheck/tests clean, Biome clean.

## Notes

- The CTA only ever shows once cloud#156 is deployed (clients read `spaceKind` absent until then).
- Follow-up (cheap, optional): extend the fake host with `spaceKind` to add a personal-space Playwright e2e; existing e2e exercise the absent path.
