### PR TITLE
ci(release): staging QA DMG per cloud release + automated weekday cut

### DIFF
--- a/.github/workflows/daily-cloud-cut.yml
+++ b/.github/workflows/daily-cloud-cut.yml
@@ -1,0 +1,240 @@
+# Daily Cloud Cut — automate the desktop cloud release train's first step.
+#
+# THE RELEASE TRAIN (what this workflow kicks off, and what a human still does):
+#   1. CUT (this workflow)  — branch from main tip, run scripts/version.sh to
+#      bump the ~12 version-bearing files, commit `release: v<version>`, and push
+#      an annotated `cloud-v<version>` tag. The release commit intentionally
+#      lives ONLY under that tag; it is never pushed to main (main is protected).
+#   2. DRAFT (release.yml)  — the `cloud-v*` tag push triggers .github/workflows/
+#      release.yml, which builds + signs + notarizes the macOS DMG (+ Windows/
+#      Linux) and uploads them to a DRAFT GitHub Release marked PRERELEASE. A
+#      cloud release is kept prerelease so it never becomes GitHub's "latest" and
+#      shadows the local channel's latest.json updater feed.
+#   3. QA         — the team downloads the staging DMG in the 08:30 (Bogotá)
+#      daily and smoke-tests it against the managed gateway.
+#   4. ROLL PROD  — once QA passes, an operator pushes an `engine-pod-v*` tag to
+#      roll the production engine pod image to match the app being shipped.
+#   5. PUBLISH    — the operator publishes the draft release (still a prerelease),
+#      which flips the `cloud-latest` pointer the cloud app's auto-updater polls.
+#
+# This workflow owns ONLY step 1, on a schedule, so a fresh draft is waiting when
+# the team opens the 08:30 daily.
+#
+# WHY A PAT (RELEASE_CUT_TOKEN), NOT GITHUB_TOKEN:
+#   A tag pushed with the default GITHUB_TOKEN does NOT trigger other workflows —
+#   GitHub's recursive-workflow guard suppresses `push` events raised by the
+#   built-in token to stop a workflow from endlessly re-triggering itself. If we
+#   cut with GITHUB_TOKEN, release.yml (step 2) would never fire and no draft
+#   would build. So the tag push here uses a fine-grained PAT stored as the
+#   RELEASE_CUT_TOKEN secret; a push authenticated by a real token DOES trigger
+#   release.yml. `permissions: contents: read` below is therefore deliberate —
+#   the write we need is the PAT's, not the job token's. (Read-only check-run
+#   queries still use GITHUB_TOKEN; those don't need to trigger anything.)
+#
+# WHY WEEKDAYS-ONLY AT 12:45 UTC:
+#   The team QAs in the 08:30 America/Bogota daily, which runs Mon–Fri. Bogotá is
+#   UTC-5 all year (Colombia observes no DST), so 12:45 UTC == 07:45 Bogotá. The
+#   release build takes ~30 min, so cutting at 07:45 leaves the draft ready
+#   before 08:30. `cron: '1-5'` skips weekends — no daily, no cut.
+#
+# WHY TAG-ONLY PUSH:
+#   main is a protected branch; the automation cannot (and must not) push commits
+#   to it. The release commit is created locally on the runner and referenced
+#   solely by the annotated tag we push. release.yml checks out the tag, so it
+#   sees the bumped versions without the commit ever landing on main. This
+#   mirrors the manual cut exactly.
+#
+# workflow_dispatch is the manual / off-schedule path: run it by hand to cut a
+# release outside the morning window, or pass an explicit `version` to override
+# the computed next patch (e.g. to jump a minor). Same guards apply.
+
+name: Daily cloud cut
+
+on:
+  schedule:
+    # 12:45 UTC, Mon–Fri == 07:45 America/Bogota (UTC-5, no DST). ~30-min build
+    # finishes before the 08:30 daily. See the header for the full rationale.
+    - cron: "45 12 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Override the computed next version (semver, e.g. 0.5.18). Leave blank to auto-bump the patch of the latest cloud-v* tag."
+        required: false
+        type: string
+
+# Read-only for the JOB token on purpose: the tag push is authenticated by the
+# RELEASE_CUT_TOKEN PAT (see header — a GITHUB_TOKEN push wouldn't trigger
+# release.yml). Check-run reads below use GITHUB_TOKEN and need only read.
+permissions:
+  contents: read
+
+# Never overlap or cancel a cut in flight — two cuts racing could push conflicting
+# tags. Queue, don't cancel: a running cut must finish cleanly.
+concurrency:
+  group: daily-cloud-cut
+  cancel-in-progress: false
+
+jobs:
+  cut:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # 1. Token guard — fail loudly if the PAT is missing, explaining WHY it's
+      #    required (a GITHUB_TOKEN tag push wouldn't trigger release.yml).
+      - name: Verify RELEASE_CUT_TOKEN is set
+        env:
+          RELEASE_CUT_TOKEN: ${{ secrets.RELEASE_CUT_TOKEN }}
+        run: |
+          if [ -z "${RELEASE_CUT_TOKEN}" ]; then
+            echo "::error::RELEASE_CUT_TOKEN is empty. The daily cut pushes the cloud-v* tag with this PAT because a tag pushed with the default GITHUB_TOKEN does NOT trigger other workflows (GitHub's recursive-workflow guard), so release.yml would never build the draft. Create a fine-grained PAT with contents:read/write on gethouston/houston and save it as the RELEASE_CUT_TOKEN repository secret."
+            exit 1
+          fi
+          echo "RELEASE_CUT_TOKEN is present."
+
+      # 2. Checkout main with the PAT so the persisted push credential is the PAT
+      #    (that's what makes the tag push trigger release.yml). Full history +
+      #    tags: the guards below resolve tags and walk the release commit's
+      #    first parent.
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.RELEASE_CUT_TOKEN }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      # 3. No-new-commits guard. Pick the highest cloud-v* tag by SEMVER (sort -V
+      #    on the numeric part — creation order is not version order). The tag
+      #    points at a release commit whose FIRST PARENT is the main tip it was
+      #    cut from; if that parent equals today's main tip, nothing merged since
+      #    the last cut, so there's nothing to release. A quiet morning is normal,
+      #    so this is success (proceed=false), not a failure.
+      - name: Guard — new commits on main since last cut
+        id: newcommits
+        run: |
+          set -euo pipefail
+          LAST_VER=$(git tag --list 'cloud-v*' \
+            | sed -n 's/^cloud-v\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)$/\1/p' \
+            | sort -V | tail -1)
+          if [ -z "$LAST_VER" ]; then
+            # Bootstrap: no cloud-v* tag exists yet. There's no base to auto-bump
+            # from and no parent to compare against, so require an explicit
+            # version via workflow_dispatch rather than guess.
+            echo "::error::No existing cloud-v* tag found. Cut the first cloud release manually, or run this workflow via 'Run workflow' with an explicit version input."
+            exit 1
+          fi
+          LAST_TAG="cloud-v$LAST_VER"
+          echo "Latest cloud tag: $LAST_TAG"
+
+          LAST_BASE=$(git rev-parse "${LAST_TAG}^")   # first parent of the release commit
+          MAIN_TIP=$(git rev-parse HEAD)              # current main tip
+          echo "last cut was based on $LAST_BASE; main tip is $MAIN_TIP"
+
+          if [ "$LAST_BASE" = "$MAIN_TIP" ]; then
+            echo "::notice::no new commits on main since $LAST_TAG; skipping today's cut"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "last_ver=$LAST_VER" >> "$GITHUB_OUTPUT"
+          echo "main_tip=$MAIN_TIP" >> "$GITHUB_OUTPUT"
+
+      # 4. Green-main guard. Don't cut a red tree. Inspect the main tip's
+      #    check-runs: block only on COMPLETED runs that FAILED (failure /
+      #    timed_out / cancelled). In-progress / queued runs are acceptable —
+      #    merges land green through PR gates, and a still-running post-merge job
+      #    must not starve the cut. Zero check-runs is treated as green. On red,
+      #    name the failing checks and (if configured) ping Slack before the
+      #    08:30 daily, then fail.
+      - name: Guard — main is green
+        if: ${{ steps.newcommits.outputs.proceed == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          MAIN_TIP: ${{ steps.newcommits.outputs.main_tip }}
+        run: |
+          set -euo pipefail
+          FAILING=$(gh api --paginate \
+            "repos/${{ github.repository }}/commits/${MAIN_TIP}/check-runs" \
+            -q '.check_runs[] | select(.status == "completed") | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled") | .name' \
+            | sort -u)
+
+          if [ -z "$FAILING" ]; then
+            echo "main tip ${MAIN_TIP} is green (no completed check-run failed)."
+            exit 0
+          fi
+
+          NAMES=$(echo "$FAILING" | paste -sd ', ' -)
+          CHECKS_URL="https://github.com/${{ github.repository }}/commit/${MAIN_TIP}/checks"
+          echo "::error::Daily cloud cut skipped: main is red — failing checks: ${NAMES}. See ${CHECKS_URL}"
+
+          if [ -n "${SLACK_RELEASE_WEBHOOK_URL}" ]; then
+            PAYLOAD=$(jq -n --arg t "Daily cloud cut skipped: main is red — ${NAMES}, ${CHECKS_URL}" '{text: $t}')
+            curl -sS -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "${SLACK_RELEASE_WEBHOOK_URL}" \
+              || echo "::warning::failed to post the red-main notice to Slack"
+          fi
+          exit 1
+
+      # 5. Compute the next version. Default: bump the PATCH of the latest tag.
+      #    A workflow_dispatch `version` input overrides it (validated semver).
+      #    Fail if the resulting tag already exists.
+      - name: Compute next version
+        id: version
+        if: ${{ steps.newcommits.outputs.proceed == 'true' }}
+        env:
+          LAST_VER: ${{ steps.newcommits.outputs.last_ver }}
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -n "${VERSION_INPUT}" ]; then
+            if ! [[ "${VERSION_INPUT}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::version input '${VERSION_INPUT}' is not semver (expected N.N.N, e.g. 0.5.18)."
+              exit 1
+            fi
+            VERSION="${VERSION_INPUT}"
+            echo "Using override version ${VERSION} from workflow_dispatch input."
+          else
+            IFS=. read -r MAJOR MINOR PATCH <<< "${LAST_VER}"
+            VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+            echo "Auto-bumped patch: ${LAST_VER} -> ${VERSION}"
+          fi
+
+          if git rev-parse -q --verify "refs/tags/cloud-v${VERSION}" >/dev/null; then
+            echo "::error::tag cloud-v${VERSION} already exists. Pick a different version."
+            exit 1
+          fi
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      # 6. Cut: bump every version-bearing file, commit the release, tag it, and
+      #    push ONLY the tag. version.sh edits tracked files in place; `git add -u`
+      #    stages exactly those. The push is tag-only — main is protected and the
+      #    release commit is meant to live solely under the tag (see header). The
+      #    persisted PAT credential from checkout authenticates the push, which is
+      #    what makes release.yml fire.
+      - name: Cut release commit + tag
+        id: cut
+        if: ${{ steps.newcommits.outputs.proceed == 'true' }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "houston-release-bot"
+          git config user.email "release-bot@users.noreply.github.com"
+
+          ./scripts/version.sh "${VERSION}"
+
+          git add -u
+          git commit -m "release: v${VERSION}"
+          git tag -a "cloud-v${VERSION}" -m "Houston Cloud v${VERSION} — daily cut"
+          git push origin "refs/tags/cloud-v${VERSION}"
+
+          echo "Pushed tag cloud-v${VERSION}."
+
+      # 7. Summarize what shipped and hand off to release.yml.
+      - name: Summary
+        if: ${{ steps.newcommits.outputs.proceed == 'true' }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          echo "::notice::Cut cloud-v${VERSION} (release: v${VERSION}) from the current main tip. release.yml is now building the draft PRERELEASE — it should be ready for the 08:30 daily. See https://github.com/${{ github.repository }}/releases/tag/cloud-v${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,14 @@ jobs:
   prep:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # macos_flavors drives the build-macos matrix. A `cloud-v*` tag builds TWO
+    # macOS DMGs from the SAME commit/pipeline/signing — the prod cloud DMG and a
+    # `staging` QA sibling — so downstream fans out over ["prod","staging"]. A
+    # local `v*` tag builds only ["prod"], leaving that channel byte-identical to
+    # before this output existed (the matrix collapses to a single leg). See the
+    # build-macos header for the full staging contract.
+    outputs:
+      macos_flavors: ${{ steps.flavors.outputs.macos_flavors }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -131,6 +139,36 @@ jobs:
             exit 1
           fi
           echo "HOSTED_ENGINE_URL secret is present — cloud gateway will be baked in."
+
+      # A `cloud-v*` build ALSO produces a `staging` QA DMG that bakes the staging
+      # gateway URL from HOSTED_ENGINE_URL_STAGING. If that secret is empty the
+      # flavor-conditional env in build-macos would silently fall back to the PROD
+      # gateway, producing a "staging" DMG that actually talks to prod — the exact
+      # wrong-target build QA is trying to avoid. Fail loudly HERE (channel is
+      # known, ~1 min in) rather than after ~25 min of signing + notarization on
+      # the staging matrix leg. Mirrors the prod-gateway guard above.
+      - name: Verify staging gateway secret is set (cloud channel)
+        if: ${{ startsWith(github.ref_name, 'cloud-') }}
+        env:
+          HOSTED_ENGINE_URL_STAGING: ${{ secrets.HOSTED_ENGINE_URL_STAGING }}
+        run: |
+          if [ -z "${HOSTED_ENGINE_URL_STAGING}" ]; then
+            echo "::error::A cloud-v* tag was pushed but the HOSTED_ENGINE_URL_STAGING secret is empty. It bakes into the staging QA DMG; set it (repo → Settings → Secrets) before releasing a cloud build."
+            exit 1
+          fi
+          echo "HOSTED_ENGINE_URL_STAGING secret is present — staging QA DMG will bake the staging gateway."
+
+      # Emit the macOS build fan-out consumed by build-macos's matrix. Cloud
+      # releases build prod + staging DMGs; local releases build prod only. The
+      # array is a JSON string parsed downstream with fromJSON().
+      - name: Compute macOS build flavors
+        id: flavors
+        run: |
+          if [[ "$GITHUB_REF_NAME" == cloud-* ]]; then
+            echo 'macos_flavors=["prod","staging"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'macos_flavors=["prod"]' >> "$GITHUB_OUTPUT"
+          fi
 
       # Resolve `release-notes.md`. Two paths:
       #
@@ -324,10 +362,38 @@ jobs:
           path: update-notes.txt
           retention-days: 1
 
+  # ============================================================================
+  # macOS universal DMG. Matrix over `flavor` so a single job definition builds
+  # both cloud DMGs from ONE commit.
+  #
+  # Staging contract (cloud channel only — the local `v*` matrix is ["prod"], a
+  # single leg identical to the pre-matrix job):
+  #   * SAME commit, SAME pipeline, SAME signing + notarization as the prod cloud
+  #     DMG. The staging leg diverges in exactly TWO places:
+  #       1. VITE_HOSTED_ENGINE_URL / HOUSTON_INTEGRATIONS_URL bake the STAGING
+  #          gateway (HOSTED_ENGINE_URL_STAGING) instead of the prod gateway.
+  #       2. Its in-app updater is neutralized — pointed at a never-created tag so
+  #          the launch-time update check 404s forever and never replaces the
+  #          staging install with the published prod build
+  #          (point-updater-at-staging-noop.sh).
+  #   * Staging artifacts NEVER enter an updater manifest (latest-cloud.json), the
+  #     checksums file, or a Sentry upload. The staging leg skips all of those and
+  #     uploads exactly ONE asset: the DMG, renamed
+  #     `Houston_staging_<version>_universal.dmg`.
+  #   * Purpose: let QA test the EXACT shipped binary against the staging engine
+  #     fleet before that engine is promoted to prod and the draft is published.
   build-macos:
     needs: prep
+    name: Build macOS (${{ matrix.flavor }})
     runs-on: macos-latest
     timeout-minutes: 60
+    strategy:
+      # fail-fast=false so a staging-leg failure never kills the prod DMG that
+      # actually ships (mirrors build-windows). macos_flavors is ["prod"] on the
+      # local channel (single leg) and ["prod","staging"] on the cloud channel.
+      fail-fast: false
+      matrix:
+        flavor: ${{ fromJSON(needs.prep.outputs.macos_flavors) }}
     # Job-level env so the per-step `if: ${{ env.SENTRY_AUTH_TOKEN != '' }}`
     # gate can actually SEE the secret. A step's OWN `env:` block is NOT in
     # scope for that same step's `if:` — GitHub evaluates `if:` before the
@@ -338,7 +404,17 @@ jobs:
     # Hoisting to job scope fixes the gate while still resolving to '' on forks
     # without the secret, so forks keep skipping the upload.
     env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      # Prod flavor gets the Sentry token; the staging flavor deliberately does
+      # NOT — its symbols/sourcemaps must never reach Sentry (a QA build is not a
+      # shipped release). Resolving to '' on the staging leg makes the upload
+      # step's `if: ${{ env.SENTRY_AUTH_TOKEN != '' }}` gate skip it, reusing the
+      # same mechanism forks use. The condition is `!= 'staging'` (not
+      # `== 'staging' && '' || …`) on purpose: GitHub's `&&/||` return the operand
+      # value, and an empty-string "true" branch is falsy, so the `== 'staging'`
+      # form would fall through to the token and leak it to staging. Keeping the
+      # secret as the truthy branch avoids that footgun (forks with no secret still
+      # get '' → skip).
+      SENTRY_AUTH_TOKEN: ${{ matrix.flavor != 'staging' && secrets.SENTRY_AUTH_TOKEN || '' }}
       # CLOUD channel (tag `cloud-v*`): bake the managed gateway URL so the
       # packaged app talks to Houston Cloud and the user just signs in with
       # Google — no URL to enter (resolveEngine → hosted-oauth, chooser skipped).
@@ -347,18 +423,26 @@ jobs:
       # VITE_HOSTED_ENGINE_AUTH=oauth is the managed-cloud default anyway; set it
       # explicitly so the Google-login gate is unambiguous. Baked as VITE_* build
       # constants (consumed by app/vite.config.ts), so job-level like the flag above.
+      #
+      # Flavor split (cloud channel only): the `staging` leg bakes the STAGING
+      # gateway (HOSTED_ENGINE_URL_STAGING) so QA hits the staging engine fleet;
+      # the `prod` leg bakes the prod gateway. Both fall back to '' on the local
+      # channel, so a `v*` build is byte-identical to before. prep's staging-secret
+      # guard fails the run if HOSTED_ENGINE_URL_STAGING is empty, so the staging
+      # leg can never silently degrade to the prod URL via this fallback.
       IS_CLOUD: ${{ startsWith(github.ref_name, 'cloud-') }}
-      VITE_HOSTED_ENGINE_URL: ${{ startsWith(github.ref_name, 'cloud-') && secrets.HOSTED_ENGINE_URL || '' }}
+      VITE_HOSTED_ENGINE_URL: ${{ startsWith(github.ref_name, 'cloud-') && (matrix.flavor == 'staging' && secrets.HOSTED_ENGINE_URL_STAGING || secrets.HOSTED_ENGINE_URL) || '' }}
       VITE_HOSTED_ENGINE_AUTH: ${{ startsWith(github.ref_name, 'cloud-') && 'oauth' || '' }}
       # Integrations for the LOCAL engine: compile-time bake read by
       # app/src-tauri (option_env! in lib.rs) and handed to the spawned host
       # sidecar, so a signed-in desktop user gets connected apps (and the
       # onboarding email step) on the local engine too — not only on cloud
       # pods. Same base URL as the hosted gateway (it serves /v1/integrations/*
-      # publicly), hence the same secret. Cloud-channel gated: a non-cloud
-      # build has no gateway to authenticate against, so it stays '' and
-      # lib.rs's empty-filter keeps integrations off there.
-      HOUSTON_INTEGRATIONS_URL: ${{ startsWith(github.ref_name, 'cloud-') && secrets.HOSTED_ENGINE_URL || '' }}
+      # publicly), hence the same secret — and the same staging/prod split, so the
+      # staging DMG's integrations resolve against the staging gateway too. Cloud-
+      # channel gated: a non-cloud build has no gateway to authenticate against, so
+      # it stays '' and lib.rs's empty-filter keeps integrations off there.
+      HOUSTON_INTEGRATIONS_URL: ${{ startsWith(github.ref_name, 'cloud-') && (matrix.flavor == 'staging' && secrets.HOSTED_ENGINE_URL_STAGING || secrets.HOSTED_ENGINE_URL) || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -602,9 +686,20 @@ jobs:
       # a local build and drop the baked gateway). Local `v*` builds skip this
       # and keep the default `latest.json` endpoint untouched. Edits only the
       # runner's checkout — never committed.
-      - name: Point updater at cloud manifest (cloud channel)
-        if: ${{ env.IS_CLOUD == 'true' }}
+      # PROD cloud flavor: repoint the updater at `latest-cloud.json` so the app
+      # tracks the cloud release channel.
+      - name: Point updater at cloud manifest (prod cloud flavor)
+        if: ${{ env.IS_CLOUD == 'true' && matrix.flavor == 'prod' }}
         run: bash scripts/ci/point-updater-at-cloud-manifest.sh
+
+      # STAGING flavor: neutralize the updater instead — point it at a
+      # never-created tag so the launch-time check 404s forever and the staging
+      # install is never force-updated into the published prod build (the app's
+      # update check is fail-open; see the script header). `staging` only ever
+      # appears on the cloud channel, so this leg implies IS_CLOUD.
+      - name: Neutralize updater (staging flavor)
+        if: ${{ matrix.flavor == 'staging' }}
+        run: bash scripts/ci/point-updater-at-staging-noop.sh
 
       - name: Build Tauri app (universal)
         uses: tauri-apps/tauri-action@v0
@@ -969,7 +1064,10 @@ jobs:
 
           echo "=== All checks passed ==="
 
+      # Staging is a QA-only DMG: it must never enter the checksums file (nor any
+      # updater manifest or Sentry upload — see the job header). Prod flavor only.
       - name: Generate checksums
+        if: ${{ matrix.flavor != 'staging' }}
         run: |
           shasum -a 256 \
             "${{ steps.artifacts.outputs.dmg }}" \
@@ -982,12 +1080,17 @@ jobs:
       # embeds it verbatim into latest.json's `notes` so existing users see the
       # new-version description on the auto-update prompt, in their own language
       # (English body + the trailing houston-i18n comment carrying es/pt).
+      # Prod flavor only — the staging leg builds no manifest, so it needs no notes.
       - name: Download updater-notes artifact
+        if: ${{ matrix.flavor != 'staging' }}
         uses: actions/download-artifact@v8
         with:
           name: update-notes
 
+      # Prod flavor only: the staging DMG must never be advertised for
+      # auto-update, so it produces no manifest fragment for finalize to merge.
       - name: Generate updater manifest
+        if: ${{ matrix.flavor != 'staging' }}
         run: |
           VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
           # Channel-specific updater manifest name so the cloud + local feeds
@@ -1052,7 +1155,10 @@ jobs:
       # Note: latest.json uploaded here advertises macOS only. The
       # `finalize` job pulls it back down after `build-windows` finishes
       # and extends it with the Windows entry.
+      # Prod flavor only: the full macOS asset set (DMG + updater tarball + sig +
+      # manifest + checksums) that feeds the auto-updater and the published draft.
       - name: Upload macOS artifacts to draft release
+        if: ${{ matrix.flavor != 'staging' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -1065,6 +1171,25 @@ jobs:
             --clobber
 
           echo "::notice::macOS artifacts uploaded to draft https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME"
+
+      # Staging flavor only: upload EXACTLY the DMG, renamed so it's unmistakable
+      # in the draft's asset list — no tarball, no .sig, no manifest, no checksums
+      # entry (staging must never enter the auto-updater feed). The rename is a
+      # pure `mv` AFTER notarization + stapling, so the signature/staple stay
+      # valid. Uploading into the same draft from a parallel job is already this
+      # workflow's established pattern (mac/win/linux all do it).
+      - name: Upload staging QA DMG to draft release (staging flavor)
+        if: ${{ matrix.flavor == 'staging' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
+          SRC="${{ steps.artifacts.outputs.dmg }}"
+          DEST="$(dirname "$SRC")/Houston_staging_${VERSION}_universal.dmg"
+          mv "$SRC" "$DEST"
+          gh release upload "$GITHUB_REF_NAME" "$DEST" --clobber
+          echo "::notice::Staging QA DMG (Houston_staging_${VERSION}_universal.dmg) uploaded to draft https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME — it talks to the staging gateway and is NOT in any updater manifest."
 
   # ============================================================================
   # Windows MSI build — runs IN PARALLEL with build-macos. Both jobs only
@@ -1953,7 +2078,6 @@ jobs:
 
           VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${GITHUB_REF_NAME}"
-          DMG_URL=$(gh release view "$GITHUB_REF_NAME" --json assets --jq '[.assets[] | select(.name | endswith(".dmg")) | .url] | first // empty')
 
           # First ~700 chars of the release-notes body, skipping the leading "## Houston X.Y.Z" header line.
           NOTES_PREVIEW=$(tail -n +2 release-notes.md | head -c 700)
@@ -1961,27 +2085,56 @@ jobs:
             NOTES_PREVIEW="${NOTES_PREVIEW}…"
           fi
 
-          # Build action buttons: always include "View on GitHub", add "Download DMG" only when we found one.
-          if [ -n "$DMG_URL" ]; then
-            ACTIONS=$(jq -n --arg dmg "$DMG_URL" --arg url "$RELEASE_URL" '[
-              { type: "button", text: { type: "plain_text", text: "Download DMG", emoji: true }, url: $dmg, style: "primary" },
-              { type: "button", text: { type: "plain_text", text: "View on GitHub", emoji: true }, url: $url }
-            ]')
-          else
-            ACTIONS=$(jq -n --arg url "$RELEASE_URL" '[
-              { type: "button", text: { type: "plain_text", text: "View on GitHub", emoji: true }, url: $url }
-            ]')
-          fi
+          # Button + context selection is channel-specific because a cloud draft
+          # now carries TWO DMGs (prod + staging QA), which makes "the first .dmg"
+          # ambiguous.
+          case "$GITHUB_REF_NAME" in
+            cloud-*)
+              # Cloud channel: the STAGING DMG is the one to test in the daily — it
+              # talks to the staging gateway, which is what we're QA'ing before the
+              # engine is promoted and the draft published. Make it the PRIMARY
+              # button; add a non-primary button for the prod DMG. Staging assets
+              # are named `Houston_staging_*.dmg`; the prod DMG is the other .dmg.
+              STAGING_DMG_URL=$(gh release view "$GITHUB_REF_NAME" --json assets --jq '[.assets[] | select(.name | startswith("Houston_staging")) | .url] | first // empty')
+              PROD_DMG_URL=$(gh release view "$GITHUB_REF_NAME" --json assets --jq '[.assets[] | select((.name | endswith(".dmg")) and (.name | startswith("Houston_staging") | not)) | .url] | first // empty')
+              CONTEXT_TEXT="Draft cloud release · the *staging DMG* talks to the staging gateway — it's the one to test in the daily before we publish"
+              ACTIONS=$(jq -n \
+                --arg staging "$STAGING_DMG_URL" \
+                --arg prod "$PROD_DMG_URL" \
+                --arg url "$RELEASE_URL" \
+                '[
+                  ( if $staging != "" then { type: "button", text: { type: "plain_text", text: "Download staging DMG (QA)", emoji: true }, url: $staging, style: "primary" } else empty end ),
+                  ( if $prod != "" then { type: "button", text: { type: "plain_text", text: "Prod DMG", emoji: true }, url: $prod } else empty end ),
+                  { type: "button", text: { type: "plain_text", text: "View on GitHub", emoji: true }, url: $url }
+                ]')
+              ;;
+            *)
+              # Local channel: unchanged — one DMG, primary "Download DMG" button.
+              DMG_URL=$(gh release view "$GITHUB_REF_NAME" --json assets --jq '[.assets[] | select(.name | endswith(".dmg")) | .url] | first // empty')
+              CONTEXT_TEXT="Draft release · grab the DMG and try it before we publish"
+              if [ -n "$DMG_URL" ]; then
+                ACTIONS=$(jq -n --arg dmg "$DMG_URL" --arg url "$RELEASE_URL" '[
+                  { type: "button", text: { type: "plain_text", text: "Download DMG", emoji: true }, url: $dmg, style: "primary" },
+                  { type: "button", text: { type: "plain_text", text: "View on GitHub", emoji: true }, url: $url }
+                ]')
+              else
+                ACTIONS=$(jq -n --arg url "$RELEASE_URL" '[
+                  { type: "button", text: { type: "plain_text", text: "View on GitHub", emoji: true }, url: $url }
+                ]')
+              fi
+              ;;
+          esac
 
           jq -n \
             --arg ver "$VERSION" \
             --arg notes "$NOTES_PREVIEW" \
+            --arg context "$CONTEXT_TEXT" \
             --argjson actions "$ACTIONS" \
             '{
               text: ("Houston v" + $ver + " is ready to test"),
               blocks: [
                 { type: "header", text: { type: "plain_text", text: ("Houston v" + $ver + " is ready to test"), emoji: true } },
-                { type: "context", elements: [ { type: "mrkdwn", text: "Draft release · grab the DMG and try it before we publish" } ] },
+                { type: "context", elements: [ { type: "mrkdwn", text: $context } ] },
                 { type: "section", text: { type: "mrkdwn", text: $notes } },
                 { type: "actions", elements: $actions }
               ]

--- a/knowledge-base/production-infra.md
+++ b/knowledge-base/production-infra.md
@@ -229,10 +229,18 @@ CI also needs as Secrets:
 - **Duration:** ~25-30 min wall-clock (mac + win + linux run in parallel; mac is the long pole at ~25 min including Apple notarization).
 - **Draft = QA gate.** Users don't see until published on GitHub.
 
+### Staging QA DMG (cloud channel)
+
+Every `cloud-v*` release builds a SECOND macOS DMG, `Houston_staging_<version>_universal.dmg`, via a `flavor: [prod, staging]` matrix on `build-macos` (prep outputs the flavor list; local `v*` tags stay a single `prod` leg). Same commit, same pipeline, same signing + notarization — the staging leg differs in exactly two bakes: the gateway URL comes from secret `HOSTED_ENGINE_URL_STAGING` (staging gateway, guarded non-empty in `prep`), and the updater endpoint is rewritten to a never-created tag by `scripts/ci/point-updater-at-staging-noop.sh` so the forced-update-at-launch flow can never replace a staging install with the published prod build (update checks are fail-open — warn-and-continue). Staging artifacts never enter `latest-cloud.json`, checksums, or Sentry; the leg uploads exactly the one renamed DMG. Purpose: QA the exact shipped binary against the staging engine fleet (which auto-rolls on every merge to main) before pushing `engine-pod-v*` to roll prod and publishing the draft. The finalize Slack message's primary button is the staging DMG on the cloud channel.
+
+### Daily cloud cut (`daily-cloud-cut.yml`)
+
+Cuts the `cloud-v*` release automatically at 12:45 UTC Mon–Fri (07:45 America/Bogota, no DST) so the draft is built before the 08:30 daily. Replicates the manual cut: branch from main tip → `scripts/version.sh` → `release: v<version>` commit (lives only under the tag, never pushed to protected main) → annotated `cloud-v<version>` tag pushed with the `RELEASE_CUT_TOKEN` fine-grained PAT (a default-GITHUB_TOKEN tag push would not trigger `release.yml` — recursive-workflow guard). Guards: skips quietly when main has no new commits since the last cut; refuses to cut a red main (failed completed check-runs) and pings the release Slack webhook. Manual/off-schedule cuts: `workflow_dispatch`, optional `version` override.
+
 ### Job graph
 ```
 prep (ubuntu, ~30s)               creates empty draft + release-notes.md artifact
-  ├── build-macos (mac, ~25m)     bun-compiles host sidecar (both arches) → signs, notarizes, uploads DMG/tar/sig/latest.json
+  ├── build-macos (mac, ~25m)     matrix [prod, staging on cloud-v*] — bun-compiles host sidecar (both arches) → signs, notarizes, uploads DMG/tar/sig/latest.json (staging leg: one renamed DMG only)
   ├── build-windows (win, ~15m)   bun-compiles host sidecar per arch → uploads MSI + .sig (x64 + arm64)
   ├── build-linux (ubuntu, ~15m)  bun-compiles host sidecar → uploads AppImage (download-only, not in latest.json)
   ├── build-web (ubuntu, ~5m)     builds packages/web → uploads web-dist.tar.gz + Sentry maps, deploys PREVIEW site

--- a/scripts/ci/point-updater-at-staging-noop.sh
+++ b/scripts/ci/point-updater-at-staging-noop.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Neutralize the in-app updater for the STAGING QA flavor of a cloud build.
+#
+# The staging macOS DMG is a QA-only sibling of the prod cloud DMG: same commit,
+# same build pipeline, same signing + notarization — it differs ONLY in the baked
+# gateway URL (HOSTED_ENGINE_URL_STAGING instead of HOSTED_ENGINE_URL) and in this
+# updater rewrite. It exists so we can test the EXACT shipped binary against the
+# staging engine fleet before that engine is promoted to prod and the draft is
+# published. It must NEVER enter any updater manifest (latest-cloud.json),
+# checksums file, or Sentry upload.
+#
+# Why point the updater at a tag that will never exist:
+#   The prod cloud flavor repoints the updater at `latest-cloud.json` (see
+#   point-updater-at-cloud-manifest.sh), which the app checks AT LAUNCH. If the
+#   staging build kept that endpoint, its first launch would find the published
+#   PROD build advertised there and force-update the staging install straight into
+#   prod — the staging install would evaporate before anyone could QA it. So we
+#   instead point the updater at the fixed tag `staging-noop`, a release that is
+#   NEVER created. Every update check 404s forever, so the staging install stays
+#   put.
+#
+#   This is safe because the app's update check is fail-open:
+#   app/src/hooks/use-update-machine.ts catches check errors and only
+#   console.warns — a 404 never blocks launch, it just means "no update found".
+#   The staging DMG therefore keeps talking to the staging gateway for the whole
+#   QA session, exactly as intended.
+#
+# Edits ONLY the runner's checkout of tauri.conf.json — never committed. Uses Node
+# (present on every GitHub runner, including windows-11-arm where jq is not),
+# mirroring point-updater-at-cloud-manifest.sh + configure-ts-engine-unsigned.sh.
+set -euo pipefail
+
+CONF="app/src-tauri/tauri.conf.json"
+[ -f "$CONF" ] || { echo "::error::$CONF not found (run this from the repo root)"; exit 1; }
+
+node -e '
+const fs = require("fs");
+const p = process.argv[1];
+const c = JSON.parse(fs.readFileSync(p, "utf8"));
+const eps = c && c.plugins && c.plugins.updater && c.plugins.updater.endpoints;
+if (!Array.isArray(eps) || eps.length === 0) {
+  console.error("::error::plugins.updater.endpoints missing — cannot neutralize the staging updater");
+  process.exit(1);
+}
+const DEAD = "https://github.com/gethouston/houston/releases/download/staging-noop/latest-staging.json";
+const next = eps.map((u) =>
+  u.replace(/releases\/latest\/download\/latest\.json$/, "releases/download/staging-noop/latest-staging.json")
+);
+if (next.every((u, i) => u === eps[i])) {
+  console.error("::error::no endpoint matched releases/latest/download/latest.json — refusing to ship a staging build on the live updater feed");
+  process.exit(1);
+}
+c.plugins.updater.endpoints = next;
+fs.writeFileSync(p, JSON.stringify(c, null, 2) + "\n");
+console.log("Staging updater neutralized — endpoints point at the never-created tag: " + DEAD);
+' "$CONF"


### PR DESCRIPTION
## What

Two CI additions to the cloud release train:

1. **Staging QA DMG** — every `cloud-v*` release now also builds `Houston_staging_<version>_universal.dmg` via a `flavor: [prod, staging]` matrix on `build-macos`. Same commit, pipeline, signing, and notarization; the staging leg differs only in (a) baking `HOSTED_ENGINE_URL_STAGING` instead of the prod gateway and (b) a neutralized updater endpoint (`point-updater-at-staging-noop.sh`, never-created tag, fail-open check) so forced updates can't replace a QA install with the prod build. Staging artifacts never enter `latest-cloud.json`, checksums, or Sentry. The finalize Slack message's primary button is now the staging DMG on the cloud channel.

2. **Daily cloud cut** — `daily-cloud-cut.yml` cuts `cloud-v<next-patch>` at 12:45 UTC Mon–Fri (07:45 Bogotá) so the draft is ready before the 08:30 daily. Tag-only push with the `RELEASE_CUT_TOKEN` PAT (default-token tag pushes don't trigger `release.yml`). Skips quiet mornings; refuses a red main and pings Slack.

## Why

QA could never test the exact shipped binary against staging: cloud builds bake the prod gateway, and prod's engine fleet only rolls on `engine-pod-v*` tags. New flow: staging DMG + staging engine (auto-rolled per merge) in the daily → push `engine-pod-v*` → publish draft.

## Verification

- YAML parse clean on both workflows; `bash -n` + functional test of the endpoint-rewrite script (rewrites to staging-noop, refuses on no match, worktree conf untouched).
- Local `v*` channel verified byte-identical: single `prod` matrix leg, all staging steps skipped, unchanged Slack branch.
- Semver tag selection tested against the 0.5.9/0.5.10/0.5.22 lexicographic trap; cron verified 07:45 America/Bogota year-round (no DST).
- Sentry-token flavor expression written secret-as-truthy-branch to avoid GitHub's empty-string-ternary fallthrough (would have leaked the token into the staging leg).

Requires repo secrets: `HOSTED_ENGINE_URL_STAGING` (set), `RELEASE_CUT_TOKEN` (fine-grained PAT, pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)