### PR TITLE
fix: never sign users out on secure-storage read faults

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,6 +2,7 @@ import "./styles/globals.css";
 import type { Toast } from "@houston-ai/core";
 import { useEffect, useRef } from "react";
 import { SignInScreen } from "./components/auth/sign-in-screen";
+import { StorageUnavailableScreen } from "./components/auth/storage-unavailable-screen";
 import { CloudMigrationGate } from "./components/onboarding/cloud-migration/cloud-migration-gate";
 import { MigrationReconnectScreen } from "./components/onboarding/migration-reconnect-screen";
 import {
@@ -25,7 +26,7 @@ import { useOnboardingCompleted } from "./hooks/use-onboarding-completed";
 import { useOnboardingPending } from "./hooks/use-onboarding-pending";
 import { useOnboardingSegment } from "./hooks/use-onboarding-segment";
 import { useProviderCatalog } from "./hooks/use-provider-catalog";
-import { useSession } from "./hooks/use-session";
+import { SessionUnavailableError, useSession } from "./hooks/use-session";
 import { useSessionEvents } from "./hooks/use-session-events";
 import { analytics } from "./lib/analytics";
 import { shouldAllowNativeContextMenu } from "./lib/context-menu";
@@ -101,7 +102,12 @@ export default function App() {
     };
   }, []);
 
-  const { data: session, isLoading: sessionLoading } = useSession();
+  const {
+    data: session,
+    isLoading: sessionLoading,
+    error: sessionError,
+    refetch: refetchSession,
+  } = useSession();
 
   // Desktop boot: if this machine owns a local-model tunnel whose cloud endpoint
   // is still active, quietly re-establish frpc (dead after a restart). Gated on a
@@ -272,6 +278,15 @@ export default function App() {
   // the web SDK holds `isLoading` until it resolves persistence.
   if (isIdentityConfigured() && sessionLoading) {
     return <WorkspaceLoading />;
+  }
+  // Secure-storage read fault (retries exhausted): the device's store couldn't
+  // be read, which is NOT a signed-out user. Show a retryable storage-error
+  // screen, never SignInScreen — a spurious sign-in here reads as a logout.
+  if (
+    isIdentityConfigured() &&
+    sessionError instanceof SessionUnavailableError
+  ) {
+    return <StorageUnavailableScreen onRetry={() => void refetchSession()} />;
   }
   if (isIdentityConfigured() && !session) {
     // Local account login. Dev builds sign in with the passwordless email code

--- a/app/src/components/auth/storage-unavailable-screen.tsx
+++ b/app/src/components/auth/storage-unavailable-screen.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@houston-ai/core";
+import i18n from "../../lib/i18n";
+import { SpaceScreen } from "../space/space-screen";
+
+/**
+ * Full-screen state shown when the device's secure storage can't be read
+ * (locked, denied, or a stale post-update ACL) — distinct from a signed-out
+ * user, so we NEVER show the sign-in screen here (that would read as a spurious
+ * logout). Renders on the same {@link SpaceScreen} space backdrop as the boot
+ * splash and the sign-in screen, so the moment reads as one continuous space,
+ * with a Retry button that refetches the session query.
+ *
+ * Reads the i18n singleton directly (not useTranslation), matching
+ * WorkspaceLoading: the web EngineGate renders these gate states OUTSIDE
+ * <I18nextProvider>. Copy is deliberately non-technical (no mention of the
+ * keychain, tokens, or files) for our non-technical audience.
+ */
+export function StorageUnavailableScreen({ onRetry }: { onRetry: () => void }) {
+  return (
+    <SpaceScreen>
+      {/* The space canvas is theme-invariant DARK, but `action` follows the
+          ambient app theme — in light mode the default Button would be a
+          near-black pill on the near-black canvas. Pin the dark palette on
+          this subtree (the design-system's sanctioned subtree-pin) so the
+          Retry button always resolves against the backdrop. */}
+      <div
+        data-theme="dark"
+        className="flex flex-1 items-center justify-center px-6"
+      >
+        <div className="flex max-w-md flex-col items-center gap-4 text-center text-[var(--ht-space-foreground)]">
+          <h1 className="text-lg font-medium">
+            {i18n.t("errors:auth.storageUnavailableTitle")}
+          </h1>
+          <p className="text-sm text-[var(--ht-space-foreground-muted)]">
+            {i18n.t("errors:auth.storageUnavailableBody")}
+          </p>
+          <Button className="mt-2" onClick={onRetry}>
+            {i18n.t("errors:auth.storageUnavailableRetry")}
+          </Button>
+        </div>
+      </div>
+    </SpaceScreen>
+  );
+}

--- a/app/src/components/shell/engine-gate.tsx
+++ b/app/src/components/shell/engine-gate.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useState } from "react";
-import { useSession } from "../../hooks/use-session";
+import { SessionUnavailableError, useSession } from "../../hooks/use-session";
 import {
   hostedOauthGateActive,
   installHostedSessionRefresh,
@@ -12,6 +12,7 @@ import i18n from "../../lib/i18n";
 import { isIdentityConfigured, refreshNow } from "../../lib/identity";
 import { logger } from "../../lib/logger";
 import { SignInScreen } from "../auth/sign-in-screen";
+import { StorageUnavailableScreen } from "../auth/storage-unavailable-screen";
 import { WorkspaceLoading } from "./workspace-loading";
 
 /**
@@ -29,7 +30,12 @@ export function EngineGate({ children }: { children: ReactNode }) {
 
 function HostedEngineGate({ children }: { children: ReactNode }) {
   const [ready, setReady] = useState(isEngineReady());
-  const { data: session, isLoading: sessionLoading } = useSession();
+  const {
+    data: session,
+    isLoading: sessionLoading,
+    error: sessionError,
+    refetch: refetchSession,
+  } = useSession();
 
   useEffect(() => {
     if (!isIdentityConfigured()) return;
@@ -55,6 +61,16 @@ function HostedEngineGate({ children }: { children: ReactNode }) {
     setHostedEngineSessionToken(token);
     if (token) setReady(true);
   }, [session?.idToken]);
+
+  // Secure-storage read fault (retries exhausted): the store couldn't be read,
+  // which is NOT a signed-out user. Show the retryable storage-error screen,
+  // never SignInScreen (a spurious sign-in here reads as a logout).
+  if (
+    isIdentityConfigured() &&
+    sessionError instanceof SessionUnavailableError
+  ) {
+    return <StorageUnavailableScreen onRetry={() => void refetchSession()} />;
+  }
 
   const state = hostedGateState({
     authConfigured: isIdentityConfigured(),

--- a/app/src/components/space/space-screen.tsx
+++ b/app/src/components/space/space-screen.tsx
@@ -8,9 +8,10 @@ import { SpaceBackground } from "./space-background";
  * The shared full-screen space layout: the theme-invariant `--ht-space-canvas`
  * base, the {@link SpaceBackground} deep-space backdrop (the landing page's
  * Milky Way photograph under its readability scrim) as an aria-hidden layer
- * behind everything, and a `z-10` content slot that floats on top. Both the sign-in screen and the workspace-loading
- * splash render inside this so the boot experience reads as one continuous
- * space (Mercury pattern: dark backdrop, light card). Content is passed as
+ * behind everything, and a `z-10` content slot that floats on top. The
+ * workspace-loading splash and the storage-unavailable gate render inside this
+ * so the boot experience reads as one continuous space (Mercury pattern: dark
+ * backdrop, light card). Content is passed as
  * `children`; the wrapper already supplies the `relative z-10` stacking, so
  * children never need to re-declare it.
  */

--- a/app/src/hooks/use-session.ts
+++ b/app/src/hooks/use-session.ts
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import {
   identityConfig,
   isIdentityConfigured,
-  loadSession,
+  loadSessionState,
   SESSION_QUERY_KEY,
   type Session,
   startProactiveRefresh,
@@ -12,10 +12,29 @@ import {
 import { identityLog } from "../lib/identity/log";
 import { osIsTauri } from "../lib/os-bridge";
 
+/**
+ * Thrown by the desktop session query when the device's secure storage can't be
+ * READ (locked keychain, denied prompt, or a stale post-update ACL) — distinct
+ * from a signed-out `null`. It puts the query into its error state so the gate
+ * renders a retryable storage-error screen, NEVER the sign-in screen (which
+ * would look like a spurious logout). The query retries it a few times first.
+ */
+export class SessionUnavailableError extends Error {
+  constructor(detail: string) {
+    super(`session storage unavailable: ${detail}`);
+    this.name = "SessionUnavailableError";
+  }
+}
+
 // Belt-and-suspenders bound on the first web `onIdTokenChanged` emission.
 // firebase-js-sdk reliably emits (with a user or null) once persistence settles,
 // but a wedged init must never pin the splash on `isLoading` forever.
 const WEB_SESSION_TIMEOUT_MS = 10_000;
+
+// Bound on the timeout path's `webCurrentSession()` probe: it may hit the
+// network (`getIdToken`), and the escape hatch itself must never re-pin the
+// splash the 10s timeout exists to unpin.
+const WEB_PROBE_TIMEOUT_MS = 3_000;
 
 // Start the proactive-refresh timer exactly once on boot when a persisted
 // desktop session loads. The queryFn is the single place it runs: React Query
@@ -25,7 +44,13 @@ const WEB_SESSION_TIMEOUT_MS = 10_000;
 let proactiveStarted = false;
 
 async function loadDesktopSession(): Promise<Session | null> {
-  const session = await loadSession();
+  const state = await loadSessionState();
+  if (state.kind === "unavailable") {
+    // Secure storage couldn't be read — surface it as a typed error (retried
+    // by the query) so the gate shows a storage-error screen, not sign-in.
+    throw new SessionUnavailableError(state.error);
+  }
+  const session = state.kind === "session" ? state.session : null;
   if (session && !proactiveStarted) {
     proactiveStarted = true;
     startProactiveRefresh();
@@ -51,12 +76,42 @@ async function loadWebSession(): Promise<Session | null> {
       resolve(session);
     };
     const timer = setTimeout(() => {
-      identityLog(
-        "warn",
-        "web session load timed out waiting for onIdTokenChanged; resolving null",
-        "identity/use-session",
-      );
-      finish(null);
+      // Don't blindly fall to signed-out: a returning user's persisted session
+      // may still be settling. Ask the SDK directly — resolve the real session
+      // when one exists, and only resolve null when the SDK confirms no user.
+      Promise.race([
+        web.webCurrentSession(),
+        new Promise<"probe-timeout">((r) => {
+          setTimeout(() => r("probe-timeout"), WEB_PROBE_TIMEOUT_MS);
+        }),
+      ])
+        .then((current) => {
+          if (current === "probe-timeout") {
+            identityLog(
+              "error",
+              "web session timeout probe itself timed out; resolving null",
+              "identity/use-session",
+            );
+            finish(null);
+            return;
+          }
+          identityLog(
+            "warn",
+            current
+              ? "web session load timed out but the SDK has a persisted user; resolving it"
+              : "web session load timed out; the SDK reports no user, resolving null",
+            "identity/use-session",
+          );
+          finish(current);
+        })
+        .catch((e) => {
+          identityLog(
+            "error",
+            `web session timeout probe failed, resolving null: ${String(e)}`,
+            "identity/use-session",
+          );
+          finish(null);
+        });
     }, WEB_SESSION_TIMEOUT_MS);
     // Guard a synchronous emission: if the callback settled before assignment,
     // tear the subscription down immediately so it never leaks.
@@ -68,9 +123,12 @@ async function loadWebSession(): Promise<Session | null> {
 
 /**
  * Current identity `Session | null` on both surfaces (the `["session"]` query
- * key). Desktop reads the Keychain via `loadSession` and mirrors `session-store`
- * changes; web reads the firebase-js-sdk session and mirrors `onIdTokenChanged`.
- * Returns `null` (never a spinner) when identity isn't configured.
+ * key). Desktop reads the Keychain via `loadSessionState` and mirrors
+ * `session-store` changes; web reads the firebase-js-sdk session and mirrors
+ * `onIdTokenChanged`. Returns `null` (never a spinner) when identity isn't
+ * configured. On a desktop secure-storage READ fault the query enters its error
+ * state with a {@link SessionUnavailableError} (retried a few times first) — the
+ * gate renders a storage-error screen for that, never the sign-in screen.
  */
 export function useSession() {
   const qc = useQueryClient();
@@ -99,6 +157,10 @@ export function useSession() {
       return osIsTauri() ? loadDesktopSession() : loadWebSession();
     },
     staleTime: Number.POSITIVE_INFINITY,
-    retry: false,
+    // Only a transient secure-storage read fault is worth retrying (a locked
+    // keychain often unlocks moments later); everything else resolves, so this
+    // never loops. 4 attempts total (initial + 3 retries, 1s/2s/4s backoff).
+    retry: (count, err) => err instanceof SessionUnavailableError && count < 3,
+    retryDelay: (attempt) => 1000 * 2 ** attempt,
   });
 }

--- a/app/src/lib/identity/firebase-popup-stub.ts
+++ b/app/src/lib/identity/firebase-popup-stub.ts
@@ -67,6 +67,10 @@ export function webRefreshIdToken(): Promise<string | null> {
   return notOnDesktop();
 }
 
+export function webCurrentSession(): Promise<Session | null> {
+  return notOnDesktop();
+}
+
 export function toSession(_user: FirebaseUserLike): Promise<Session> {
   return notOnDesktop();
 }

--- a/app/src/lib/identity/index.ts
+++ b/app/src/lib/identity/index.ts
@@ -36,9 +36,11 @@ export {
   stopProactiveRefresh,
 } from "./refresh.ts";
 export type { AuthProvider, Session, SignInOutcome } from "./session.ts";
+export type { SessionLoadState } from "./session-load.ts";
 export {
   clearSession,
   loadSession,
+  loadSessionState,
   SESSION_QUERY_KEY,
   saveSession,
   subscribeSession,

--- a/app/src/lib/identity/session-load.ts
+++ b/app/src/lib/identity/session-load.ts
@@ -1,0 +1,98 @@
+// Pure, storage-agnostic orchestration of a session load. It turns a raw
+// `ReadResult` into a `SessionLoadState`, decides whether to broadcast, and
+// drives the once-per-run keychain ACL rebind — all through injected seams so
+// it is unit-testable under `node:test` without Tauri (mirrors oauth-attempt.ts).
+// session-store.ts binds the real keychain/browser adapter into it.
+
+import { identityLog } from "./log.ts";
+import { deserializeSession, type Session } from "./session.ts";
+import type { ReadResult } from "./session-storage-kv.ts";
+
+/**
+ * The outcome of reading the persisted session, keeping a storage READ FAULT
+ * distinct from a real signed-out. `unavailable` must never be collapsed to
+ * `null` at the UI layer — that is exactly the spurious-logout bug.
+ */
+export type SessionLoadState =
+  | { kind: "session"; session: Session }
+  | { kind: "none" }
+  | { kind: "unavailable"; error: string };
+
+export interface SessionLoadDeps {
+  /** Read the persisted blob (present/absent) or a read FAULT. */
+  read: () => Promise<ReadResult>;
+  /** Broadcast the resolved session to subscribers. Called ONLY on a
+   *  non-fault load — a `null` broadcast on a fault would flip every
+   *  subscriber to signed-out. */
+  notify: (session: Session | null) => void;
+  /** Whether this is desktop keychain mode (gates the ACL rebind write). */
+  keychainMode: boolean;
+  /** Re-save the exact blob to rebind the macOS keychain item's ACL to the
+   *  current code signature. Its failure is swallowed inside the loader. */
+  rewrite: (blob: string) => Promise<void>;
+  /** The current auth epoch (`sessionEpoch`). Captured around the rebind write
+   *  so a sign-out racing it can be compensated, mirroring refresh.ts. */
+  epoch: () => number;
+  /** Remove the persisted blob — the compensation when a sign-out raced the
+   *  rebind write, so the rebind can never resurrect a signed-out session. */
+  remove: () => Promise<void>;
+}
+
+/**
+ * Build a session loader closing over a once-per-run rebind flag. Each call
+ * reads storage and returns a `SessionLoadState`; on the FIRST successful
+ * keychain read of an existing blob it re-saves that blob so the keychain
+ * item's ACL rebinds to the current code signature — the permanent fix for the
+ * "logged out after update" logout (an auto-update changes the signature and
+ * the old ACL entry then rejects reads). The rebind is maintenance only: its
+ * failure is logged, never thrown, and never changes the state we return.
+ */
+export function createSessionLoader(
+  deps: SessionLoadDeps,
+): () => Promise<SessionLoadState> {
+  let rebound = false;
+
+  async function rebindAcl(blob: string): Promise<void> {
+    if (rebound || !deps.keychainMode) return;
+    rebound = true;
+    const epochAtWrite = deps.epoch();
+    try {
+      await deps.rewrite(blob);
+      if (deps.epoch() !== epochAtWrite) {
+        // A sign-out (clearSession) landed while the maintenance write was in
+        // flight; re-clear so the rebind can never resurrect a signed-out
+        // session on the next boot.
+        await deps.remove();
+      }
+    } catch (e) {
+      identityLog(
+        "error",
+        `keychain ACL rebind write failed (session still valid): ${String(e)}`,
+        "identity/session-store",
+      );
+    }
+  }
+
+  return async function load(): Promise<SessionLoadState> {
+    const read = await deps.read();
+    if (!read.ok) {
+      // A read FAULT is NOT a signed-out user. Do NOT notify — a null
+      // broadcast would flip every subscriber to signed-out and drop the user
+      // on the sign-in screen. Log it once here and report `unavailable` so
+      // the UI shows a retryable storage-error state instead.
+      identityLog(
+        "error",
+        `session storage unavailable (read fault): ${read.error}`,
+        "identity/session-store",
+      );
+      return { kind: "unavailable", error: read.error };
+    }
+    const session = deserializeSession(read.value);
+    deps.notify(session);
+    // Fire-and-forget: the rebind is maintenance whose outcome never changes
+    // the returned state, so boot must not wait on a keychain WRITE (a hung
+    // write would otherwise pin the splash). Its errors are handled inside.
+    if (session && read.value) void rebindAcl(read.value);
+    return session ? { kind: "session", session } : { kind: "none" };
+  };
+}

--- a/app/src/lib/identity/session-storage-kv.ts
+++ b/app/src/lib/identity/session-storage-kv.ts
@@ -1,0 +1,130 @@
+// Low-level key/value persistence for the identity `Session` blob — the storage
+// adapter half of session-store.ts, split out so each file stays inside the
+// 200-line limit. Keychain mode round-trips the os-bridge `osAuth*` wrappers
+// (never `invoke` directly); browser mode uses `localStorage`.
+//
+// Reads return a discriminated `ReadResult` so the session store can tell a
+// genuine "no entry yet" (`value: null`) from a storage READ FAULT
+// (`{ ok: false }`). That distinction is the whole point: a locked keychain, a
+// denied prompt, or a stale post-update ACL must NOT masquerade as a
+// signed-out user (which would drop the user on the sign-in screen). Writes
+// still RETHROW on failure so a dropped save becomes a visible toast upstream.
+
+import { resolveAuthStorageConfig } from "../auth-storage.ts";
+import {
+  osAuthGetItem,
+  osAuthRemoveItem,
+  osAuthSetItem,
+} from "../os-bridge.ts";
+import { identityLog } from "./log.ts";
+
+const config = resolveAuthStorageConfig({
+  storageMode:
+    typeof __HOUSTON_AUTH_STORAGE_MODE__ !== "undefined"
+      ? __HOUSTON_AUTH_STORAGE_MODE__
+      : "browser",
+  storageScope:
+    typeof __HOUSTON_AUTH_STORAGE_SCOPE__ !== "undefined"
+      ? __HOUSTON_AUTH_STORAGE_SCOPE__
+      : "",
+});
+
+/** The blob key both surfaces persist the session under. */
+export const storageKey = config.storageKey;
+
+/** True in desktop keychain mode — drives the once-per-run ACL rebind. */
+export const isKeychainMode = config.mode === "keychain";
+
+/**
+ * A storage read: a present/absent value, or a read FAULT kept distinct from
+ * absence. `value: null` means "no entry" (a real signed-out); `ok: false`
+ * means the store could not be read at all (locked / denied / stale ACL).
+ */
+export type ReadResult =
+  | { ok: true; value: string | null }
+  | { ok: false; error: string };
+
+export interface KVStorage {
+  getItem(key: string): Promise<ReadResult>;
+  setItem(key: string, value: string): Promise<void>;
+  removeItem(key: string): Promise<void>;
+}
+
+const keychainStorage: KVStorage = {
+  async getItem(key) {
+    try {
+      return { ok: true, value: await osAuthGetItem(key) };
+    } catch (e) {
+      // A rejected read is a FAULT, not an absent entry — the os-bridge
+      // resolves `null` for a real miss (auth.rs maps `NoEntry → Ok(None)`).
+      // Keep it distinct; loadSessionState logs it once and reports
+      // `unavailable` instead of a spurious signed-out.
+      return { ok: false, error: String(e) };
+    }
+  },
+  async setItem(key, value) {
+    try {
+      await osAuthSetItem(key, value);
+    } catch (e) {
+      identityLog(
+        "error",
+        `keychain setItem(${key}) failed: ${String(e)}`,
+        "identity/session-store",
+      );
+      throw new Error(`Sign-in storage failed: ${String(e)}`);
+    }
+  },
+  async removeItem(key) {
+    try {
+      await osAuthRemoveItem(key);
+    } catch (e) {
+      identityLog(
+        "error",
+        `keychain removeItem(${key}) failed: ${String(e)}`,
+        "identity/session-store",
+      );
+      throw new Error(`Sign-out storage failed: ${String(e)}`);
+    }
+  },
+};
+
+const browserStorage: KVStorage = {
+  async getItem(key) {
+    try {
+      return { ok: true, value: globalThis.localStorage?.getItem(key) ?? null };
+    } catch (e) {
+      // localStorage read faults are near-impossible, but map them to a fault
+      // too (symmetry with keychain) rather than a silent null.
+      return { ok: false, error: String(e) };
+    }
+  },
+  async setItem(key, value) {
+    try {
+      globalThis.localStorage?.setItem(key, value);
+    } catch (e) {
+      identityLog(
+        "error",
+        `localStorage setItem(${key}) failed: ${String(e)}`,
+        "identity/session-store",
+      );
+      throw new Error(`Sign-in storage failed: ${String(e)}`);
+    }
+  },
+  async removeItem(key) {
+    try {
+      globalThis.localStorage?.removeItem(key);
+    } catch (e) {
+      identityLog(
+        "error",
+        `localStorage removeItem(${key}) failed: ${String(e)}`,
+        "identity/session-store",
+      );
+      throw new Error(`Sign-out storage failed: ${String(e)}`);
+    }
+  },
+};
+
+/** The active adapter for this build (keychain on desktop, browser in dev/web). */
+export const storage: KVStorage = isKeychainMode
+  ? keychainStorage
+  : browserStorage;

--- a/app/src/lib/identity/session-store.ts
+++ b/app/src/lib/identity/session-store.ts
@@ -1,136 +1,31 @@
 // Desktop/web persistence for the identity `Session` — one JSON blob.
 //
-// The blob key is the `storageKey` from `resolveAuthStorageConfig` (the SAME
-// derivation supabase.ts used, so an upgrading user's stale blob sits under the
-// reused `houston-auth` key and `deserializeSession` discards it). Keychain
-// mode round-trips through the os-bridge `osAuth*` wrappers (never `invoke`
-// directly); browser mode uses `localStorage`.
+// The KV adapter (keychain vs browser) and the read-fault-vs-absence contract
+// live in session-storage-kv.ts; the pure load orchestration (state mapping,
+// notify decision, once-per-run ACL rebind) lives in session-load.ts. This
+// module owns the app-facing API: the load/save/clear surface, the auth epoch,
+// and the `subscribeSession` pub/sub.
 //
-// Error policy (mirrors supabase.ts, tightened for no-silent-failures): `get`
-// returns null on not-found or a read fault (a "no entry yet" is the common
-// case, logged not thrown); `set`/`remove` RETHROW on failure so a Keychain
-// write that silently dropped the session becomes a visible toast upstream.
+// Error policy (no-silent-failures): `loadSessionState` keeps a storage READ
+// FAULT distinct from absence so the UI never treats an unreadable store as
+// signed-out (the "logged out after update" bug); `save`/`clear` RETHROW on
+// failure so a dropped write becomes a visible toast upstream.
 //
 // Reactive seam: this module is storage-only and never imports react-query. It
-// exposes (1) `subscribeSession` — a tiny pub/sub that broadcasts the current
-// session after every load/save/clear, which Wave B's `useSession` subscribes
-// to and mirrors into the TanStack cache, and (2) `SESSION_QUERY_KEY`, the
-// shared `["session"]` cache key those callers write. Keeping cache writes out
-// of here preserves testability and the storage/UI boundary.
+// exposes (1) `subscribeSession` — a tiny pub/sub broadcasting the current
+// session after every non-fault load/save/clear, which `useSession` mirrors
+// into the TanStack cache, and (2) `SESSION_QUERY_KEY`, the shared `["session"]`
+// cache key those callers write.
 
-import { resolveAuthStorageConfig } from "../auth-storage.ts";
-import {
-  osAuthGetItem,
-  osAuthRemoveItem,
-  osAuthSetItem,
-} from "../os-bridge.ts";
 import { identityLog } from "./log.ts";
-import {
-  deserializeSession,
-  type Session,
-  serializeSession,
-} from "./session.ts";
+import { type Session, serializeSession } from "./session.ts";
+import { createSessionLoader, type SessionLoadState } from "./session-load.ts";
+import { isKeychainMode, storage, storageKey } from "./session-storage-kv.ts";
+
+export type { SessionLoadState } from "./session-load.ts";
 
 /** The TanStack Query key holding `Session | null` on both surfaces. */
 export const SESSION_QUERY_KEY = ["session"] as const;
-
-const config = resolveAuthStorageConfig({
-  storageMode:
-    typeof __HOUSTON_AUTH_STORAGE_MODE__ !== "undefined"
-      ? __HOUSTON_AUTH_STORAGE_MODE__
-      : "browser",
-  storageScope:
-    typeof __HOUSTON_AUTH_STORAGE_SCOPE__ !== "undefined"
-      ? __HOUSTON_AUTH_STORAGE_SCOPE__
-      : "",
-});
-
-interface KVStorage {
-  getItem(key: string): Promise<string | null>;
-  setItem(key: string, value: string): Promise<void>;
-  removeItem(key: string): Promise<void>;
-}
-
-const keychainStorage: KVStorage = {
-  async getItem(key) {
-    try {
-      return await osAuthGetItem(key);
-    } catch (e) {
-      identityLog(
-        "warn",
-        `keychain getItem(${key}) failed: ${String(e)}`,
-        "identity/session-store",
-      );
-      return null;
-    }
-  },
-  async setItem(key, value) {
-    try {
-      await osAuthSetItem(key, value);
-    } catch (e) {
-      identityLog(
-        "error",
-        `keychain setItem(${key}) failed: ${String(e)}`,
-        "identity/session-store",
-      );
-      throw new Error(`Sign-in storage failed: ${String(e)}`);
-    }
-  },
-  async removeItem(key) {
-    try {
-      await osAuthRemoveItem(key);
-    } catch (e) {
-      identityLog(
-        "error",
-        `keychain removeItem(${key}) failed: ${String(e)}`,
-        "identity/session-store",
-      );
-      throw new Error(`Sign-out storage failed: ${String(e)}`);
-    }
-  },
-};
-
-const browserStorage: KVStorage = {
-  async getItem(key) {
-    try {
-      return globalThis.localStorage?.getItem(key) ?? null;
-    } catch (e) {
-      identityLog(
-        "warn",
-        `localStorage getItem(${key}) failed: ${String(e)}`,
-        "identity/session-store",
-      );
-      return null;
-    }
-  },
-  async setItem(key, value) {
-    try {
-      globalThis.localStorage?.setItem(key, value);
-    } catch (e) {
-      identityLog(
-        "error",
-        `localStorage setItem(${key}) failed: ${String(e)}`,
-        "identity/session-store",
-      );
-      throw new Error(`Sign-in storage failed: ${String(e)}`);
-    }
-  },
-  async removeItem(key) {
-    try {
-      globalThis.localStorage?.removeItem(key);
-    } catch (e) {
-      identityLog(
-        "error",
-        `localStorage removeItem(${key}) failed: ${String(e)}`,
-        "identity/session-store",
-      );
-      throw new Error(`Sign-out storage failed: ${String(e)}`);
-    }
-  },
-};
-
-const storage: KVStorage =
-  config.mode === "keychain" ? keychainStorage : browserStorage;
 
 // Monotonic auth epoch, bumped every time the session is cleared (sign-out /
 // terminal refresh). An in-flight refresh captures it before its network call
@@ -170,17 +65,38 @@ function notify(session: Session | null): void {
   }
 }
 
-/** Read + parse the persisted session (null when absent/stale/corrupt). */
+const loadSessionStateImpl = createSessionLoader({
+  read: () => storage.getItem(storageKey),
+  notify,
+  keychainMode: isKeychainMode,
+  rewrite: (blob) => storage.setItem(storageKey, blob),
+  epoch: sessionEpoch,
+  remove: () => storage.removeItem(storageKey),
+});
+
+/**
+ * Read the persisted session, keeping a storage read fault (`unavailable`)
+ * distinct from a real signed-out (`none`). UI gating uses this so a locked /
+ * denied / stale-ACL store never renders the sign-in screen.
+ */
+export function loadSessionState(): Promise<SessionLoadState> {
+  return loadSessionStateImpl();
+}
+
+/**
+ * Collapsed load: `Session | null` (a read fault maps to `null`). The refresh
+ * paths use this — they only care "is there a usable session to refresh right
+ * now"; a transient fault correctly resolves to "none to refresh". UI gating
+ * must use `loadSessionState` instead so a fault is not mistaken for signed-out.
+ */
 export async function loadSession(): Promise<Session | null> {
-  const raw = await storage.getItem(config.storageKey);
-  const session = deserializeSession(raw);
-  notify(session);
-  return session;
+  const state = await loadSessionState();
+  return state.kind === "session" ? state.session : null;
 }
 
 /** Persist the session. Rethrows if the write fails (no silent drop). */
 export async function saveSession(session: Session): Promise<void> {
-  await storage.setItem(config.storageKey, serializeSession(session));
+  await storage.setItem(storageKey, serializeSession(session));
   notify(session);
 }
 
@@ -189,6 +105,6 @@ export async function clearSession(): Promise<void> {
   // Bump the epoch FIRST so a refresh already awaiting its network call sees the
   // change the moment sign-out begins, even if the keychain delete is slow.
   epoch += 1;
-  await storage.removeItem(config.storageKey);
+  await storage.removeItem(storageKey);
   notify(null);
 }

--- a/app/src/locales/en/errors.json
+++ b/app/src/locales/en/errors.json
@@ -11,6 +11,9 @@
     "tooManyAttempts": "Too many attempts. Wait a few minutes, then try again.",
     "userDisabled": "This account has been disabled. Contact support.",
     "configError": "Sign-in isn't set up correctly. Please contact support.",
-    "generic": "Sign-in failed. Please try again."
+    "generic": "Sign-in failed. Please try again.",
+    "storageUnavailableTitle": "Can't reach this device's secure storage",
+    "storageUnavailableBody": "Houston couldn't open the secure storage on this device where your sign-in is kept. This usually clears up on its own. Try again, and if it keeps happening, restart your computer.",
+    "storageUnavailableRetry": "Try again"
   }
 }

--- a/app/src/locales/es/errors.json
+++ b/app/src/locales/es/errors.json
@@ -11,6 +11,9 @@
     "tooManyAttempts": "Demasiados intentos. Espera unos minutos y vuelve a intentarlo.",
     "userDisabled": "Esta cuenta ha sido deshabilitada. Contacta a soporte.",
     "configError": "El inicio de sesión no está configurado correctamente. Contacta a soporte.",
-    "generic": "El inicio de sesión falló. Inténtalo de nuevo."
+    "generic": "El inicio de sesión falló. Inténtalo de nuevo.",
+    "storageUnavailableTitle": "No podemos acceder al almacenamiento seguro de este dispositivo",
+    "storageUnavailableBody": "Houston no pudo abrir el almacenamiento seguro de este dispositivo donde se guarda tu inicio de sesión. Normalmente se soluciona solo. Vuelve a intentarlo y, si sigue pasando, reinicia tu computador.",
+    "storageUnavailableRetry": "Reintentar"
   }
 }

--- a/app/src/locales/pt/errors.json
+++ b/app/src/locales/pt/errors.json
@@ -11,6 +11,9 @@
     "tooManyAttempts": "Muitas tentativas. Espere alguns minutos e tente novamente.",
     "userDisabled": "Esta conta foi desativada. Entre em contato com o suporte.",
     "configError": "O login não está configurado corretamente. Entre em contato com o suporte.",
-    "generic": "O login falhou. Tente novamente."
+    "generic": "O login falhou. Tente novamente.",
+    "storageUnavailableTitle": "Não foi possível acessar o armazenamento seguro deste dispositivo",
+    "storageUnavailableBody": "O Houston não conseguiu abrir o armazenamento seguro deste dispositivo onde o seu login fica guardado. Isso costuma se resolver sozinho. Tente novamente e, se continuar acontecendo, reinicie o computador.",
+    "storageUnavailableRetry": "Tentar novamente"
   }
 }

--- a/app/tests/identity-session-load.test.ts
+++ b/app/tests/identity-session-load.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import {
+  type IdentityLogLevel,
+  setIdentityLogSink,
+} from "../src/lib/identity/log.ts";
+import type { Session } from "../src/lib/identity/session.ts";
+import { serializeSession } from "../src/lib/identity/session.ts";
+import {
+  createSessionLoader,
+  type SessionLoadDeps,
+} from "../src/lib/identity/session-load.ts";
+import type { ReadResult } from "../src/lib/identity/session-storage-kv.ts";
+
+// Pure orchestration tests: createSessionLoader is dependency-injected, so the
+// read-fault / ACL-rebind logic is exercised WITHOUT Tauri or keychain mode
+// (which the real singleton bakes in at build time and can't reach under
+// node:test). Mirrors the oauth-attempt.ts unit-test seam.
+
+const SESSION: Session = {
+  idToken: "id-token-abc",
+  refreshToken: "refresh-token-xyz",
+  uid: "uid-1",
+  email: "grace@example.com",
+  emailVerified: true,
+  displayName: "Grace Hopper",
+  photoUrl: "https://example.com/grace.png",
+  provider: "google.com",
+  expiresAt: 1_900_000_000_000,
+};
+const BLOB = serializeSession(SESSION);
+
+interface Recorder {
+  notified: Array<Session | null>;
+  rewrites: string[];
+  removes: number;
+}
+
+function deps(
+  read: ReadResult | (() => Promise<ReadResult>),
+  overrides: Partial<SessionLoadDeps> = {},
+): { deps: SessionLoadDeps; rec: Recorder } {
+  const rec: Recorder = { notified: [], rewrites: [], removes: 0 };
+  return {
+    rec,
+    deps: {
+      read: typeof read === "function" ? read : async () => read,
+      notify: (s) => rec.notified.push(s),
+      keychainMode: true,
+      rewrite: async (blob) => {
+        rec.rewrites.push(blob);
+      },
+      epoch: () => 0,
+      remove: async () => {
+        rec.removes += 1;
+      },
+      ...overrides,
+    },
+  };
+}
+
+/** Let the fire-and-forget rebind promise settle. */
+const settle = () => new Promise((r) => setImmediate(r));
+
+afterEach(() => setIdentityLogSink(null));
+
+test("read fault → unavailable, subscribers are NOT notified", async () => {
+  const { deps: d, rec } = deps({ ok: false, error: "keychain locked" });
+  const state = await createSessionLoader(d)();
+  assert.deepEqual(state, { kind: "unavailable", error: "keychain locked" });
+  assert.equal(rec.notified.length, 0, "a fault must never broadcast null");
+  assert.equal(rec.rewrites.length, 0);
+});
+
+test("absent → none, notifies null, no rebind write", async () => {
+  const { deps: d, rec } = deps({ ok: true, value: null });
+  const state = await createSessionLoader(d)();
+  assert.deepEqual(state, { kind: "none" });
+  assert.deepEqual(rec.notified, [null]);
+  assert.equal(rec.rewrites.length, 0);
+});
+
+test("corrupt blob → none, notifies null, no rebind write", async () => {
+  const { deps: d, rec } = deps({ ok: true, value: "{not json" });
+  const state = await createSessionLoader(d)();
+  assert.deepEqual(state, { kind: "none" });
+  assert.deepEqual(rec.notified, [null]);
+  assert.equal(rec.rewrites.length, 0);
+});
+
+test("valid session → session + notify + ONE ACL rebind write of the same blob", async () => {
+  const { deps: d, rec } = deps({ ok: true, value: BLOB });
+  const load = createSessionLoader(d);
+  const state = await load();
+  assert.deepEqual(state, { kind: "session", session: SESSION });
+  assert.deepEqual(rec.notified, [SESSION]);
+  assert.deepEqual(rec.rewrites, [BLOB], "rebinds the ACL with the exact blob");
+
+  // The rebind is once-per-run: a second load must not rewrite again.
+  await load();
+  assert.deepEqual(rec.rewrites, [BLOB]);
+});
+
+test("load resolves without waiting on the rebind write (fire-and-forget)", async () => {
+  let resolveWrite!: () => void;
+  const { deps: d } = deps(
+    { ok: true, value: BLOB },
+    {
+      rewrite: () =>
+        new Promise<void>((resolve) => {
+          resolveWrite = resolve;
+        }),
+    },
+  );
+  // A hung keychain WRITE must never pin boot: load resolves while pending.
+  const state = await createSessionLoader(d)();
+  assert.deepEqual(state, { kind: "session", session: SESSION });
+  resolveWrite();
+});
+
+test("a sign-out racing the rebind write re-clears the blob", async () => {
+  let epoch = 0;
+  let resolveWrite!: () => void;
+  const { deps: d, rec } = deps(
+    { ok: true, value: BLOB },
+    {
+      epoch: () => epoch,
+      rewrite: () =>
+        new Promise<void>((resolve) => {
+          resolveWrite = resolve;
+        }),
+    },
+  );
+  const state = await createSessionLoader(d)();
+  assert.deepEqual(state, { kind: "session", session: SESSION });
+  epoch += 1; // clearSession() lands while the maintenance write is in flight
+  resolveWrite();
+  await settle();
+  assert.equal(rec.removes, 1, "the rebind must compensate a raced sign-out");
+});
+
+test("ACL rebind is skipped off keychain mode", async () => {
+  const { deps: d, rec } = deps(
+    { ok: true, value: BLOB },
+    { keychainMode: false },
+  );
+  const state = await createSessionLoader(d)();
+  assert.deepEqual(state, { kind: "session", session: SESSION });
+  assert.equal(rec.rewrites.length, 0, "browser mode never rebinds");
+});
+
+test("ACL rebind write failure is swallowed (session still returned) and logged", async () => {
+  const logged: Array<{ level: IdentityLogLevel; message: string }> = [];
+  setIdentityLogSink((level, message) => logged.push({ level, message }));
+  const { deps: d } = deps(
+    { ok: true, value: BLOB },
+    {
+      rewrite: async () => {
+        throw new Error("keychain write denied");
+      },
+    },
+  );
+  const state = await createSessionLoader(d)();
+  // The maintenance write failing must NOT affect the returned session.
+  assert.deepEqual(state, { kind: "session", session: SESSION });
+  await settle();
+  assert.ok(
+    logged.some(
+      (l) =>
+        l.level === "error" && l.message.includes("ACL rebind write failed"),
+    ),
+    "the swallowed rebind failure must be logged",
+  );
+});

--- a/app/tests/identity-session-store.test.ts
+++ b/app/tests/identity-session-store.test.ts
@@ -89,6 +89,42 @@ test("subscribeSession is notified on save (session) and clear (null)", async ()
   assert.deepEqual(seen, [SESSION, null]);
 });
 
+test("loadSessionState maps a read fault to `unavailable` WITHOUT notifying", async () => {
+  const { loadSessionState, subscribeSession } = await import(
+    "../src/lib/identity/session-store.ts"
+  );
+  // A store whose read throws: the wiring must surface a FAULT, not a null that
+  // would flip every subscriber to signed-out (the spurious-logout bug).
+  globalThis.localStorage = {
+    getItem: () => {
+      throw new Error("storage read blew up");
+    },
+    setItem: () => {},
+    removeItem: () => {},
+  } as unknown as Storage;
+  const seen: Array<Session | null> = [];
+  const unsub = subscribeSession((s) => seen.push(s));
+  const state = await loadSessionState();
+  unsub();
+  assert.equal(state.kind, "unavailable");
+  assert.deepEqual(seen, [], "a read fault must never broadcast");
+});
+
+test("loadSessionState reports `none` for an absent entry", async () => {
+  const { loadSessionState } = await import(
+    "../src/lib/identity/session-store.ts"
+  );
+  assert.deepEqual(await loadSessionState(), { kind: "none" });
+});
+
+test("loadSessionState reports `none` for a corrupt blob", async () => {
+  const { loadSessionState } = await import(
+    "../src/lib/identity/session-store.ts"
+  );
+  fake.store.set(STORAGE_KEY, "{not json");
+  assert.deepEqual(await loadSessionState(), { kind: "none" });
+});
+
 test("saveSession rethrows when the underlying storage write fails", async () => {
   const { saveSession } = await import("../src/lib/identity/session-store.ts");
   globalThis.localStorage = {

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -245,16 +245,47 @@ apple.com | password | custom` (`identity/session.ts`).
 `session-store.ts` reuses the `houston-auth` key, so an upgrading user may have a
 stale **Supabase** blob under it — `deserializeSession` treats any non-Firebase
 shape (legacy blob / corrupt JSON) as signed-out: discard + log, never throw, never
-silently accept (`identity/session.ts`). If the Keychain is locked, the in-memory
-session on the current run still works but nothing persists across launches —
-degraded mode, not failure. Override the storage backend with
+silently accept (`identity/session.ts`). Override the storage backend with
 `HOUSTON_AUTH_STORAGE=keychain|browser`.
 
+**Read fault ≠ signed out (HOU spurious-logout fix).** A keychain READ that
+*fails* (locked keychain, denied prompt, or a stale item ACL after an
+auto-update re-signs the app) is NOT the same as "no entry". The KV adapter
+(`session-storage-kv.ts`) returns a discriminated `ReadResult` (`{ ok:true,
+value }` vs `{ ok:false, error }`) — the Rust side already distinguishes
+`NoEntry → Ok(None)` from `Err(...)` (`auth.rs`), so a rejected `osAuthGetItem`
+is a fault, never absence — on macOS/Windows. (Linux caveat: `auth.rs` catches a
+secret-service fault and falls back to the file store, so a daemon fault with no
+fallback file still reads as absence there.) The pure loader (`session-load.ts`
+`createSessionLoader`) maps a fault to `loadSessionState() → { kind:
+"unavailable" }` and — critically — does **NOT** `notify(...)` (a null broadcast
+would flip every `subscribeSession` subscriber to signed-out). `loadSession()`
+stays a collapsed `Session | null` wrapper for the refresh paths (fault → null,
+no broadcast). On a **successful** keychain read, once per app run, the loader
+re-saves the same blob so the macOS keychain item's ACL **rebinds to the current
+code signature** — the permanent fix for "logged out after update"; that
+maintenance write's failure is logged, never thrown, never affects the result.
+`loadSessionState` splits across three files to stay inside the 200-line limit:
+`session-storage-kv.ts` (adapters + `ReadResult`), `session-load.ts` (pure
+orchestration, unit-tested via injected deps like `oauth-attempt.ts`),
+`session-store.ts` (app API + epoch + pub/sub).
+
 `useSession` (`app/src/hooks/use-session.ts`) is the TanStack source of truth
-(`SESSION_QUERY_KEY = ["session"]`): desktop reads the Keychain via `loadSession`
-and mirrors `subscribeSession` broadcasts; web awaits the first `onIdTokenChanged`
-so a returning user never flashes signed-out. `App.tsx` renders `SignInScreen`
-when `isIdentityConfigured() && !session`.
+(`SESSION_QUERY_KEY = ["session"]`): desktop reads the Keychain via
+`loadSessionState` and mirrors `subscribeSession` broadcasts; web awaits the
+first `onIdTokenChanged` so a returning user never flashes signed-out. A desktop
+read fault throws `SessionUnavailableError` into the query (retried up to 3× on a
+1s/2s/4s backoff); once retries exhaust, `App.tsx` and `HostedEngineGate` render
+`StorageUnavailableScreen` (a retryable full-screen state on the space backdrop,
+copy in `errors:auth.storageUnavailable*`) instead of `SignInScreen` — a fault
+must never look like a logout. `App.tsx` still renders `SignInScreen` only when
+`isIdentityConfigured() && !session` with no error.
+
+**Web boot timeout (returning-user flash fix).** `loadWebSession`'s 10s
+belt-and-suspenders timeout no longer blindly resolves `null`: it asks the SDK
+via `webCurrentSession()` (`getAuth().currentUser → toSession`, mirrored in the
+desktop stub) and resolves the real persisted session when one exists, only
+resolving `null` when the SDK confirms no user.
 
 ## Refresh
 
@@ -289,7 +320,9 @@ cleanup. The desktop hosted-mode **engine bearer clears reactively**: `cacheSess
 | `id-token.ts` | `decodeIdTokenClaims` (decode-only, for the custom-token OTP path) |
 | `otp.ts` | `startEmailOtp` / `verifyEmailOtp` (gateway contract; module header is the pinned contract) |
 | `session.ts` | `Session` shape + shape-tolerant serialize/deserialize + `sessionExpiresWithin` |
-| `session-store.ts` | Keychain/browser persistence + `subscribeSession` + `SESSION_QUERY_KEY` |
+| `session-storage-kv.ts` | Keychain/browser KV adapter; `ReadResult` (read fault ≠ absence); `storageKey` / `isKeychainMode` |
+| `session-load.ts` | Pure `createSessionLoader` — `ReadResult` → `SessionLoadState`, notify decision, once-per-run ACL rebind (unit-tested via injected deps) |
+| `session-store.ts` | App persistence API (`loadSessionState`/`loadSession`/`save`/`clear`) + `subscribeSession` + epoch + `SESSION_QUERY_KEY` |
 | `refresh.ts` | Proactive timer, `refreshNow` (401 seam), `setSessionSink`, `start/stopProactiveRefresh` |
 | `desktop-oauth.ts` | Loopback+PKCE driver (Tauri wiring); shared by Google + Microsoft |
 | `oauth-attempt.ts` | Tauri-free attempt lifecycle (supersede / cancel / timeout / ignore-foreign-state) — unit-testable |

--- a/knowledge-base/design-system.md
+++ b/knowledge-base/design-system.md
@@ -271,14 +271,18 @@ the space/galaxy look is OUT for first-run.
   forced-update dialog title was the casualty that exposed it). Never
   reintroduce a colour token named `base`.
 
-### Space screen backdrop (workspace-loading only)
+### Space screen backdrop (boot gate states)
 `SpaceScreen` (`app/src/components/space/space-screen.tsx`) is the **shared
 full-screen space layout**: the `--ht-space-canvas` base, the `SpaceBackground`
 backdrop (the landing page's Milky Way photograph under its readability scrim),
-and a `z-10` content slot on top. Its ONE remaining consumer is the
-**workspace-loading splash** (`components/shell/workspace-loading.tsx`) — the
-`OrbitLoader` + status line sit directly on the dark backdrop, using the
-space-foreground token family (`--ht-space-foreground` / `-foreground-muted`).
+and a `z-10` content slot on top. Its consumers are the **workspace-loading
+splash** (`components/shell/workspace-loading.tsx`) and the **storage-unavailable
+gate** (`components/auth/storage-unavailable-screen.tsx`) — content sits
+directly on the dark backdrop, using the space-foreground token family
+(`--ht-space-foreground` / `-foreground-muted`). The canvas is theme-invariant
+DARK while `action` follows the app theme, so any themed control placed on it
+(e.g. the storage gate's Retry `Button`) must pin `data-theme="dark"` on its
+subtree or it turns near-black-on-black in light mode.
 The whole space rendering cluster lives in **`app/src/components/space/`**.
 
 **`OrbitLoader`** (`space/orbit-loader.tsx` + geometry/trail constants in

--- a/packages/web/src/identity/firebase-popup.ts
+++ b/packages/web/src/identity/firebase-popup.ts
@@ -156,6 +156,17 @@ export async function webRefreshIdToken(): Promise<string | null> {
   return user ? await user.getIdToken(true) : null;
 }
 
+/**
+ * The persisted SDK session right now, or null when the SDK confirms no user.
+ * Used on the web boot timeout to resolve a returning user directly instead of
+ * blindly falling to signed-out (which flashed the sign-in screen on a slow
+ * `onIdTokenChanged`).
+ */
+export async function webCurrentSession(): Promise<Session | null> {
+  const user = requireAuth().currentUser;
+  return user ? await toSession(user) : null;
+}
+
 function toAuthProvider(providerId: string | undefined): AuthProvider {
   switch (providerId) {
     case "google.com":


### PR DESCRIPTION
## Problem
Users report being spuriously logged out of the desktop app. Diagnosis: the refresh/401 machinery is correctly transient-safe, but a **keychain READ fault** (locked store, denied prompt, or a stale item ACL after an auto-update re-signs the app on macOS) was collapsed to "no session" in `session-store.ts`, dropping the user on the sign-in screen. The classic "logged out after an update" report.

## Fix
- `session-storage-kv.ts` (new): discriminated `ReadResult` — a rejected `osAuthGetItem` is a fault, never absence (the Rust side already distinguishes `NoEntry` from real errors).
- `session-load.ts` (new): pure DI'd loader mapping faults to `{kind: "unavailable"}` **without** broadcasting (a null broadcast flipped every subscriber to signed-out).
- `useSession` throws typed `SessionUnavailableError`; the query retries 4 attempts (1s/2s/4s); `App.tsx` + `HostedEngineGate` render a retryable **StorageUnavailableScreen** (dark-pinned on the space canvas), never `SignInScreen`.
- **ACL rebind**: on the first successful keychain read per run, the blob is re-saved (fire-and-forget, epoch-compensated against a racing sign-out) so the keychain item ACL rebinds to the current code signature — the permanent fix for post-update logouts.
- Web: the 10s session-load timeout now probes `webCurrentSession()` (itself bounded at 3s) instead of blindly resolving signed-out on slow init.

## Verification
- 94 identity `node --test` tests pass (9 new loader tests incl. fault→no-notify, once-per-run rebind, fire-and-forget liveness, raced-sign-out compensation).
- Full workspace typecheck, Biome, `check-locales` (new `errors:auth.storageUnavailable*` in en/es/pt), web shim parity all green.
- Adversarially reviewed (3 independent passes); all confirmed findings fixed.

## Follow-ups (not in this PR)
- Rust `stored_session_json()` still conflates fault/absence for sidecar identity env (frontend gate unaffected).
- A boot-safe "Report bug" affordance on `StorageUnavailableScreen` (feedback pipeline lives behind the engine gate today).

No Linear issue — fix built directly from user reports relayed in-session; if a HOU issue tracks these logout reports, link it on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)