### PR TITLE
feat: sign-in referral panel reads Coming soon; localize panel strings

### DIFF
--- a/app/src/components/auth/sign-in-panels.tsx
+++ b/app/src/components/auth/sign-in-panels.tsx
@@ -1,5 +1,4 @@
-import { Button } from "@houston-ai/core";
-import { ArrowUpRight } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { tauriSystem } from "../../lib/tauri";
 
 /** Open an external URL in the system browser (matches sign-in-screen). */
@@ -9,30 +8,23 @@ const openExternal = (url: string) => () => {
 
 /** The sign-in card's right-hand referral pitch panel. */
 export function ReferralPanel() {
+  const { t } = useTranslation("auth");
   return (
     <div className="flex flex-col justify-between gap-6 bg-action p-8 text-action-text sm:col-span-1">
       <div className="flex flex-col gap-3">
-        <h2 className="text-lg font-medium">Share the love</h2>
-        <p className="text-sm text-action-text/70">
-          Know a team that would fly with Houston? Send them our way. When they
-          commit to 5 or more licenses, your team gets $250 in credits.
-        </p>
+        <h2 className="text-lg font-medium">{t("referral.title")}</h2>
+        <p className="text-sm text-action-text/70">{t("referral.body")}</p>
       </div>
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={openExternal("https://gethouston.ai/referrals")}
-        className="-ml-3 gap-1 self-start text-action-text hover:bg-action-text/10 hover:text-action-text dark:hover:bg-action-text/10"
-      >
-        See how it works
-        <ArrowUpRight className="size-4" />
-      </Button>
+      <span className="inline-flex items-center self-start rounded-full border border-action-text/30 px-3 py-1 text-xs font-medium text-action-text/80">
+        {t("referral.comingSoon")}
+      </span>
     </div>
   );
 }
 
 /** The legal footer under the sign-in card (Privacy / Terms). */
 export function LegalFooter() {
+  const { t } = useTranslation("auth");
   return (
     <div className="flex items-center justify-center gap-3 py-6 text-xs text-ink-muted">
       <button
@@ -40,7 +32,7 @@ export function LegalFooter() {
         onClick={openExternal("https://gethouston.ai/privacy")}
         className="underline-offset-4 hover:text-ink hover:underline"
       >
-        Privacy Policy
+        {t("legal.privacy")}
       </button>
       <span aria-hidden="true">·</span>
       <button
@@ -48,7 +40,7 @@ export function LegalFooter() {
         onClick={openExternal("https://gethouston.ai/terms")}
         className="underline-offset-4 hover:text-ink hover:underline"
       >
-        Terms of Service
+        {t("legal.terms")}
       </button>
     </div>
   );

--- a/app/src/locales/en/auth.json
+++ b/app/src/locales/en/auth.json
@@ -6,5 +6,14 @@
   "divider": {
     "or": "or",
     "orAnotherWay": "or use another way"
+  },
+  "referral": {
+    "title": "Share the love",
+    "body": "Our referral program is on its way. Soon, when you send a team our way and they commit to 5 or more licenses, your team will earn $250 in credits.",
+    "comingSoon": "Coming soon"
+  },
+  "legal": {
+    "privacy": "Privacy Policy",
+    "terms": "Terms of Service"
   }
 }

--- a/app/src/locales/es/auth.json
+++ b/app/src/locales/es/auth.json
@@ -6,5 +6,14 @@
   "divider": {
     "or": "o",
     "orAnotherWay": "o usa otra forma"
+  },
+  "referral": {
+    "title": "Comparte lo bueno",
+    "body": "Nuestro programa de referidos está en camino. Pronto, cuando nos recomiendes a un equipo y este contrate 5 o más licencias, tu equipo ganará $250 en créditos.",
+    "comingSoon": "Muy pronto"
+  },
+  "legal": {
+    "privacy": "Política de Privacidad",
+    "terms": "Términos del Servicio"
   }
 }

--- a/app/src/locales/pt/auth.json
+++ b/app/src/locales/pt/auth.json
@@ -6,5 +6,14 @@
   "divider": {
     "or": "ou",
     "orAnotherWay": "ou use outra forma"
+  },
+  "referral": {
+    "title": "Compartilhe o que é bom",
+    "body": "Nosso programa de indicações está a caminho. Em breve, quando você indicar uma equipe e ela contratar 5 ou mais licenças, sua equipe vai ganhar $250 em créditos.",
+    "comingSoon": "Em breve"
+  },
+  "legal": {
+    "privacy": "Política de Privacidade",
+    "terms": "Termos de Serviço"
   }
 }


### PR DESCRIPTION
The referral program is not live yet. The sign-in panel's clickable "See how it works" button (which opened gethouston.ai/referrals) is replaced by a static, non-interactive "Coming soon" chip, and the pitch is rephrased as a forward-looking teaser keeping the offer facts (5+ licenses → $250 in credits).

While touching the file, its hardcoded English (an i18n-rule violation) is fixed: all `ReferralPanel` + `LegalFooter` strings now flow through `t()` (`auth` namespace) with en/es/pt keys (LatAm-neutral es, Brazilian pt, no em dashes).

Verification: Biome clean, `check-locales` in sync, app `tsgo --noEmit` clean. Chip verified non-interactive (no handler, no focus) with adequate contrast on the `bg-action` panel in both themes.

No Linear issue — small copy/UX change requested directly in-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)