### PR TITLE
feat: always-visible connected-state badges across the three catalogs

### DIFF
--- a/app/src/components/ai-hub/connected-providers-strip.tsx
+++ b/app/src/components/ai-hub/connected-providers-strip.tsx
@@ -3,6 +3,7 @@ import {
   CatalogGrid,
   CatalogRow,
   CatalogShowMore,
+  StatusDot,
 } from "@houston-ai/core";
 import { ChevronRight } from "lucide-react";
 import { useState } from "react";
@@ -68,6 +69,9 @@ export function ConnectedProvidersStrip({
               title={provider.name}
               description={description || undefined}
               onClick={() => onOpen(provider)}
+              statusDot={
+                <StatusDot status="active" srLabel={t("card.connected")} />
+              }
               trailing={
                 <ChevronRight
                   aria-hidden

--- a/app/src/components/ai-hub/hub-badges.tsx
+++ b/app/src/components/ai-hub/hub-badges.tsx
@@ -8,9 +8,8 @@
  * coded hex, no `useTranslation` here.
  */
 
-import { cn } from "@houston-ai/core";
+import { cn, StatusBadge } from "@houston-ai/core";
 import type { ReactNode } from "react";
-import { StatusDot } from "../integrations/connection-status-badge";
 
 /** Base neutral pill every hub chip is built from. */
 export function SpecChip({
@@ -47,16 +46,10 @@ export function PriceText({ text }: { text: string }) {
 }
 
 /**
- * The only always-green element: a live dot + label for connected state.
- * Same primitive + proportions as the Integrations tab's `ConnectionStatusBadge`
- * (`StatusDot` + `text-xs`) so "connected" reads identically everywhere in the
- * app, not just here.
+ * The only always-green element: a live dot + label for connected state. A thin
+ * wrapper over the shared `ui/core` {@link StatusBadge} (`active`), so
+ * "connected" reads identically everywhere in the app, not just here.
  */
 export function LiveStatus({ label }: { label: string }) {
-  return (
-    <span className="inline-flex items-center gap-1.5 text-xs font-medium text-success">
-      <StatusDot status="active" />
-      {label}
-    </span>
-  );
+  return <StatusBadge status="active" label={label} />;
 }

--- a/app/src/components/integrations-view/installed-strip.tsx
+++ b/app/src/components/integrations-view/installed-strip.tsx
@@ -3,6 +3,7 @@ import {
   CatalogGrid,
   CatalogRow,
   CatalogShowMore,
+  StatusDot,
 } from "@houston-ai/core";
 import type {
   CustomIntegrationView,
@@ -25,6 +26,9 @@ interface InstalledItem {
   icon: ReactNode;
   title: string;
   description: string;
+  /** The presence-style status dot left of the name ("● Asana"), so connected /
+   *  pending / error reads without opening the row. */
+  statusDot: ReactNode;
   onClick: () => void;
 }
 
@@ -73,6 +77,12 @@ export function InstalledStrip({
       icon: <AppLogo display={row.app} size="lg" className="rounded-lg" />,
       title: row.app.name,
       description: row.app.description,
+      statusDot: (
+        <StatusDot
+          status={row.connection.status}
+          srLabel={t(`status.${row.connection.status}`)}
+        />
+      ),
       onClick: () => onOpen(row.connection),
     })),
     ...custom.map((integration) => ({
@@ -92,6 +102,12 @@ export function InstalledStrip({
       title: integration.name,
       description: t(
         integration.kind === "mcp" ? "custom.badge.mcp" : "custom.badge.api",
+      ),
+      statusDot: (
+        <StatusDot
+          status={integration.state.status}
+          srLabel={t(`status.${integration.state.status}`)}
+        />
       ),
       onClick: () => onOpenCustom(integration),
     })),
@@ -113,6 +129,7 @@ export function InstalledStrip({
             title={item.title}
             description={item.description}
             onClick={item.onClick}
+            statusDot={item.statusDot}
             trailing={
               <ChevronRight
                 aria-hidden

--- a/app/src/components/integrations/connection-status-badge.tsx
+++ b/app/src/components/integrations/connection-status-badge.tsx
@@ -1,40 +1,15 @@
-import { cn } from "@houston-ai/core";
+import { StatusBadge } from "@houston-ai/core";
 import { useTranslation } from "react-i18next";
 
 export type ConnectionStatus = "active" | "pending" | "error";
 
-const DOT: Record<ConnectionStatus, string> = {
-  active: "bg-success",
-  pending: "bg-warning",
-  error: "bg-danger",
-};
-
-const TEXT: Record<ConnectionStatus, string> = {
-  active: "text-success",
-  pending: "text-warning",
-  error: "text-danger",
-};
-
-/** A small colored status dot, sized for inline use next to an app name. */
-export function StatusDot({
-  status,
-  className,
-}: {
-  status: ConnectionStatus;
-  className?: string;
-}) {
-  return (
-    <span
-      aria-hidden
-      className={cn("size-1.5 shrink-0 rounded-full", DOT[status], className)}
-    />
-  );
-}
-
 /**
- * Colored dot + colored, localized label describing a connection's live
- * status — the sober "green thing next to the name" treatment (mirrors the
- * AI Hub's `LiveStatus`), not a tinted card background.
+ * Colored dot + colored, localized label describing a connection's live status
+ * — the sober "green thing next to the name" treatment, not a tinted card
+ * background. A thin i18n wrapper over the shared `ui/core` {@link StatusBadge}:
+ * it maps the connection status to its localized `integrations` label; the dot,
+ * proportions, and color tokens live once in the primitive so "connected" reads
+ * identically across every surface.
  */
 export function ConnectionStatusBadge({
   status,
@@ -42,15 +17,5 @@ export function ConnectionStatusBadge({
   status: ConnectionStatus;
 }) {
   const { t } = useTranslation("integrations");
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1.5 text-xs font-medium",
-        TEXT[status],
-      )}
-    >
-      <StatusDot status={status} />
-      {t(`status.${status}`)}
-    </span>
-  );
+  return <StatusBadge status={status} label={t(`status.${status}`)} />;
 }

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,26 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v33 - 2026-07-22
+
+Add `status-badge`: the shared connected/live-status indicator (a colored dot,
+alone or with a label) that conveys connected / pending / error state beside an
+item name. Web ships it as a props-only, i18n-agnostic `ui/` piece
+(`@houston-ai/core` `StatusBadge` / `StatusDot`, mapping each status to a
+semantic color token), so it lands `implemented`. The app's
+`ConnectionStatusBadge` (Integrations) and `LiveStatus` (AI hub) are now thin
+i18n wrappers over it, so "connected" reads identically everywhere.
+
+Also a refinement to the shared `CatalogRow` (no new component, no `since`
+change; the catalog surfaces stay app/-locked, web `partial`): the row gains an
+optional `statusDot` slot rendered immediately LEFT of the title —
+presence-style, "● Asana" — always visible (no hover gating). The three catalog
+surfaces use it so connected/installed state no longer rides on section
+placement alone: Integrations (green/amber/red per connection status, with an
+sr-only status label), the AI-models hub (green, sr-only "Connected"), and the
+Skills marketplace's installed rows (green, beside the quiet installed check in
+the `action` slot), contrasting with the not-installed `+`.
+
 ## v32 - 2026-07-21
 
 Add `verified-badge`: the verified-creator indicator glyph shown beside a creator

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 32
+version: 33
 
 components:
   - id: agent-avatar
@@ -650,3 +650,25 @@ components:
       design token.
     a11y: img role with the label as its accessible name; conveys meaning by glyph plus label, never color alone.
     since: 32
+
+  - id: status-badge
+    title: Status badge
+    purpose: >-
+      A colored connection/live-status indicator -- a presence-style dot left of
+      an item name ("dot Asana", catalog rows' statusDot slot) or a dot with a
+      visible label (integration and AI-provider detail surfaces) -- so
+      connected/pending/error reads without relying on which section the item
+      sits in.
+    anatomy: [status-dot, status-label]
+    states: [active, pending, error]
+    variants: [dot-only, dot-with-label]
+    behavior: >-
+      Presentational, props-only, i18n-agnostic: the status maps to one semantic
+      color token (success/warning/danger) and the consumer passes the already
+      translated label (visible, or sr-only for dot-only rows). One source of
+      the "connected" treatment reused across the integrations and AI-models
+      hubs so it reads identically everywhere.
+    a11y: >-
+      the dot is decorative; status is carried by the visible label
+      (dot-with-label) or an sr-only label (dot-only rows), never color alone.
+    since: 33

--- a/design/inventory/manifests/android.yaml
+++ b/design/inventory/manifests/android.yaml
@@ -77,3 +77,5 @@ components:
     status: not-started
   verified-badge:
     status: not-started
+  status-badge:
+    status: not-started

--- a/design/inventory/manifests/ios.yaml
+++ b/design/inventory/manifests/ios.yaml
@@ -266,3 +266,6 @@ components:
   verified-badge:
     status: not-started
     notes: Verified-creator glyph; the creator-profiles store surface is not in mobile v1.
+  status-badge:
+    status: not-started
+    notes: Connected/live-status dot+label; the catalog hub surfaces are not in mobile v1.

--- a/design/inventory/manifests/web.yaml
+++ b/design/inventory/manifests/web.yaml
@@ -188,3 +188,7 @@ components:
   verified-badge:
     status: implemented
     ref: "ui/core/src/components/verified-badge.tsx (@houston-ai/core VerifiedBadge)"
+
+  status-badge:
+    status: implemented
+    ref: "ui/core/src/components/status-badge.tsx (@houston-ai/core StatusBadge / StatusDot)"

--- a/knowledge-base/integrations.md
+++ b/knowledge-base/integrations.md
@@ -441,7 +441,12 @@ integrations** tab (§2, `teams.md`).
   integrations as a two-column `CatalogGrid` of `CatalogRow`s (`InstalledStrip`) —
   the SAME row grammar as the browse catalog: brand art via `AppLogo` (custom rows
   get letter avatars), the always-visible name, a one-line description (the app
-  description or a localized custom-kind badge), and a quiet trailing `ChevronRight`
+  description or a localized custom-kind badge), an always-visible
+  presence-style `StatusDot` LEFT of the name ("● Asana" — green/amber/red per
+  connection status, sr-only status label, via the ui/core `CatalogRow`
+  `statusDot` slot — connected state reads on the ROW, not just from section
+  placement; same treatment as the connected-providers strip and the skills
+  marketplace's installed rows), and a quiet trailing `ChevronRight`
   marking each row as an open-affordance (the shared convention with the connected
   providers + installed skills strips). A catalog row opens `AppDetailDialog`; a
   custom row jumps to the Custom tab. At rest the grid caps to the shared

--- a/ui/core/src/components/catalog-row.tsx
+++ b/ui/core/src/components/catalog-row.tsx
@@ -21,6 +21,10 @@ export interface CatalogRowProps
   title: string;
   /** One muted line, truncated. */
   description?: string;
+  /** A tiny, always-visible status dot (e.g. {@link StatusDot}) rendered
+   *  immediately LEFT of the title — presence-style, "● Asana" — so
+   *  connected/installed state reads without hovering. */
+  statusDot?: ReactNode;
   /** Quiet NON-interactive trailing inside the row body (a lock, a badge). */
   trailing?: ReactNode;
   /** Interactive right-edge sibling (its own button — never nested). */
@@ -34,6 +38,7 @@ export function CatalogRow({
   icon,
   title,
   description,
+  statusDot,
   trailing,
   action,
   className,
@@ -59,7 +64,10 @@ export function CatalogRow({
       >
         {icon}
         <div className="min-w-0 flex-1">
-          <p className="truncate font-medium text-ink text-sm">{title}</p>
+          <p className="flex items-center gap-1.5 font-medium text-ink text-sm">
+            {statusDot}
+            <span className="truncate">{title}</span>
+          </p>
           {description && (
             <p className="truncate text-[13px] text-ink-muted">{description}</p>
           )}

--- a/ui/core/src/components/status-badge-styles.ts
+++ b/ui/core/src/components/status-badge-styles.ts
@@ -1,0 +1,23 @@
+/**
+ * Pure, JSX-free style maps for {@link StatusBadge} / {@link StatusDot}: one
+ * status kind maps to one semantic color token. Kept in a `.ts` module so it is
+ * importable by the package's `node --experimental-strip-types --test` runner
+ * (which cannot load `.tsx`); the component re-uses the same maps.
+ */
+
+/** A connection / live-status kind. */
+export type StatusKind = "active" | "pending" | "error";
+
+/** Dot fill per status — the semantic status color tokens. */
+export const STATUS_DOT_CLASS: Record<StatusKind, string> = {
+  active: "bg-success",
+  pending: "bg-warning",
+  error: "bg-danger",
+};
+
+/** Label + dot text color per status. */
+export const STATUS_TEXT_CLASS: Record<StatusKind, string> = {
+  active: "text-success",
+  pending: "text-warning",
+  error: "text-danger",
+};

--- a/ui/core/src/components/status-badge.tsx
+++ b/ui/core/src/components/status-badge.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { cn } from "../utils";
+import {
+  STATUS_DOT_CLASS,
+  STATUS_TEXT_CLASS,
+  type StatusKind,
+} from "./status-badge-styles";
+
+export type { StatusKind };
+
+/**
+ * A small colored status dot, sized for inline use next to an item name — the
+ * sober "green thing beside the name" treatment (success/warning/danger per
+ * status), never a tinted card background. The dot itself is decorative:
+ * either pair it with a visible text label ({@link StatusBadge}) or pass
+ * `srLabel` so screen readers still hear the status when the dot stands alone
+ * (the presence-style "● Asana" catalog rows).
+ */
+export function StatusDot({
+  status,
+  srLabel,
+  className,
+}: {
+  status: StatusKind;
+  /** Visually-hidden status text for dot-only placements. */
+  srLabel?: string;
+  className?: string;
+}) {
+  const dot = (
+    <span
+      aria-hidden
+      className={cn(
+        "size-1.5 shrink-0 rounded-full",
+        STATUS_DOT_CLASS[status],
+        className,
+      )}
+    />
+  );
+  if (!srLabel) return dot;
+  return (
+    <>
+      {dot}
+      <span className="sr-only">{srLabel}</span>
+    </>
+  );
+}
+
+/**
+ * A colored {@link StatusDot} + a colored label describing a connection's live
+ * status. Props-only and i18n-agnostic: the consumer passes the already
+ * translated `label` so `ui/` stays language-agnostic. The single source of the
+ * "connected"/"pending"/"error" indicator reused across catalog rows, the
+ * integrations hub, and the AI models hub so it reads identically everywhere.
+ */
+export function StatusBadge({
+  status,
+  label,
+  className,
+}: {
+  status: StatusKind;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 text-xs font-medium",
+        STATUS_TEXT_CLASS[status],
+        className,
+      )}
+    >
+      <StatusDot status={status} />
+      {label}
+    </span>
+  );
+}

--- a/ui/core/src/index.ts
+++ b/ui/core/src/index.ts
@@ -40,6 +40,7 @@ export * from "./components/sidebar";
 export * from "./components/skeleton";
 export * from "./components/sonner";
 export * from "./components/spinner";
+export * from "./components/status-badge";
 export * from "./components/stepper";
 export * from "./components/switch";
 export * from "./components/tabs";

--- a/ui/core/tests/status-badge.test.ts
+++ b/ui/core/tests/status-badge.test.ts
@@ -1,0 +1,27 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  STATUS_DOT_CLASS,
+  STATUS_TEXT_CLASS,
+  type StatusKind,
+} from "../src/components/status-badge-styles.ts";
+
+describe("status-badge styles", () => {
+  it("maps each status to its semantic dot color token", () => {
+    assert.equal(STATUS_DOT_CLASS.active, "bg-success");
+    assert.equal(STATUS_DOT_CLASS.pending, "bg-warning");
+    assert.equal(STATUS_DOT_CLASS.error, "bg-danger");
+  });
+
+  it("maps each status to its semantic text color token", () => {
+    assert.equal(STATUS_TEXT_CLASS.active, "text-success");
+    assert.equal(STATUS_TEXT_CLASS.pending, "text-warning");
+    assert.equal(STATUS_TEXT_CLASS.error, "text-danger");
+  });
+
+  it("covers exactly the three status kinds", () => {
+    const kinds: StatusKind[] = ["active", "pending", "error"];
+    assert.deepEqual(Object.keys(STATUS_DOT_CLASS).sort(), [...kinds].sort());
+    assert.deepEqual(Object.keys(STATUS_TEXT_CLASS).sort(), [...kinds].sort());
+  });
+});

--- a/ui/skills/src/skill-marketplace-card-labels.ts
+++ b/ui/skills/src/skill-marketplace-card-labels.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure, JSX-free defaults + resolver for {@link SkillMarketplaceCardLabels}, the
+ * i18n-agnostic fallback the `ui/` boundary requires. Kept in a `.ts` module (no
+ * JSX) so it is importable by the package's `node --experimental-strip-types
+ * --test` runner (which cannot load `.tsx`), and so the row component and the
+ * section labels share ONE default set rather than duplicating it.
+ */
+
+import type { SkillMarketplaceCardLabels } from "./skill-marketplace-row";
+
+export const DEFAULT_CARD_LABELS: Required<SkillMarketplaceCardLabels> = {
+  installAria: (name) => `Install ${name}`,
+  installedAria: (name) => `${name} installed`,
+  installsCount: (count, formatted) =>
+    count === 1 ? `${formatted} install` : `${formatted} installs`,
+  bySource: (owner) => `by ${owner}`,
+};
+
+/** Merge caller labels over the English defaults. */
+export function resolveCardLabels(
+  labels?: SkillMarketplaceCardLabels,
+): Required<SkillMarketplaceCardLabels> {
+  return { ...DEFAULT_CARD_LABELS, ...labels };
+}

--- a/ui/skills/src/skill-marketplace-row.tsx
+++ b/ui/skills/src/skill-marketplace-row.tsx
@@ -1,5 +1,6 @@
-import { CatalogAddButton, CatalogRow } from "@houston-ai/core";
+import { CatalogAddButton, CatalogRow, StatusDot } from "@houston-ai/core";
 import { Check } from "lucide-react";
+import { resolveCardLabels } from "./skill-marketplace-card-labels";
 import {
   formatInstalls,
   kebabToTitle,
@@ -15,14 +16,6 @@ export interface SkillMarketplaceCardLabels {
   bySource?: (owner: string) => string;
 }
 
-const DEFAULT_LABELS: Required<SkillMarketplaceCardLabels> = {
-  installAria: (name) => `Install ${name}`,
-  installedAria: (name) => `${name} installed`,
-  installsCount: (count, formatted) =>
-    count === 1 ? `${formatted} install` : `${formatted} installs`,
-  bySource: (owner) => `by ${owner}`,
-};
-
 export interface SkillMarketplaceRowProps {
   skill: CommunitySkill;
   installing: boolean;
@@ -37,7 +30,9 @@ export interface SkillMarketplaceRowProps {
  * avatar + title + `by <owner> · <installs>` subtitle, transparent at rest
  * with the full-row hover fill. The row BODY opens the detail info modal; the
  * ghost `+` ({@link CatalogAddButton}, spinning while THIS skill installs) is
- * the install action — once installed it becomes a quiet check mark.
+ * the install action — once installed the row gains the presence-style green
+ * {@link StatusDot} left of the name and the `+` becomes a quiet check, so
+ * installed and not-installed contrast at a glance.
  */
 export function SkillMarketplaceRow({
   skill,
@@ -47,7 +42,7 @@ export function SkillMarketplaceRow({
   onOpenInfo,
   labels,
 }: SkillMarketplaceRowProps) {
-  const l = { ...DEFAULT_LABELS, ...labels };
+  const l = resolveCardLabels(labels);
   const owner = ownerOf(skill.source);
   const title = kebabToTitle(skill.skillId || skill.name);
   const subtitle =
@@ -64,6 +59,7 @@ export function SkillMarketplaceRow({
       title={title}
       description={subtitle}
       onClick={onOpenInfo}
+      statusDot={installed ? <StatusDot status="active" /> : undefined}
       action={
         installed ? (
           <span
@@ -72,7 +68,7 @@ export function SkillMarketplaceRow({
             title={l.installedAria(title)}
             className="flex size-9 shrink-0 items-center justify-center text-ink-muted"
           >
-            <Check className="size-4" />
+            <Check className="size-4" aria-hidden />
           </span>
         ) : (
           <CatalogAddButton

--- a/ui/skills/src/skill-marketplace-section-labels.ts
+++ b/ui/skills/src/skill-marketplace-section-labels.ts
@@ -1,5 +1,5 @@
+import { DEFAULT_CARD_LABELS } from "./skill-marketplace-card-labels";
 import type { SkillMarketplaceGridLabels } from "./skill-marketplace-grid";
-import type { SkillMarketplaceCardLabels } from "./skill-marketplace-row";
 import {
   DEFAULT_SHELVES,
   type MarketplaceShelf,
@@ -33,14 +33,6 @@ export interface SkillMarketplaceSectionLabels
   /** Curated browse shelves, titles localized; queries stay English. */
   shelves?: MarketplaceShelf[];
 }
-
-const DEFAULT_CARD_LABELS: Required<SkillMarketplaceCardLabels> = {
-  installAria: (name) => `Install ${name}`,
-  installedAria: (name) => `${name} installed`,
-  installsCount: (count, formatted) =>
-    count === 1 ? `${formatted} install` : `${formatted} installs`,
-  bySource: (owner) => `by ${owner}`,
-};
 
 const DEFAULT_PREVIEW_LABELS: Required<SkillPreviewSheetLabels> = {
   install: "Install",

--- a/ui/skills/tests/skill-marketplace-card-labels.test.ts
+++ b/ui/skills/tests/skill-marketplace-card-labels.test.ts
@@ -1,0 +1,27 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  DEFAULT_CARD_LABELS,
+  resolveCardLabels,
+} from "../src/skill-marketplace-card-labels.ts";
+
+describe("resolveCardLabels", () => {
+  it("provides complete English defaults", () => {
+    assert.equal(DEFAULT_CARD_LABELS.installAria("Notion"), "Install Notion");
+    assert.equal(
+      DEFAULT_CARD_LABELS.installedAria("Notion"),
+      "Notion installed",
+    );
+    assert.equal(DEFAULT_CARD_LABELS.installsCount(1, "1"), "1 install");
+    assert.equal(DEFAULT_CARD_LABELS.installsCount(2, "2"), "2 installs");
+    assert.equal(DEFAULT_CARD_LABELS.bySource("acme"), "by acme");
+  });
+
+  it("merges caller overrides over the defaults", () => {
+    const l = resolveCardLabels({ bySource: (owner) => `de ${owner}` });
+    assert.equal(l.bySource("acme"), "de acme");
+    // Unrelated defaults survive the override.
+    assert.equal(l.installAria("Notion"), "Install Notion");
+    assert.equal(l.installedAria("Notion"), "Notion installed");
+  });
+});


### PR DESCRIPTION
## Problem
Users say it's unclear in the catalogs (Integrations, AI models, Skills) whether something is connected. Connected/installed state was conveyed only by *section placement* (top strip vs browse area); the rows themselves showed just a muted chevron.

## Change (reworked per Julian's feedback: dot only, left of the name)
Every connected/installed row now carries a tiny **presence-style dot immediately left of the name** — "🟢 Asana" — instead of a dot+"Connected" label on the right:

- **New ui/core primitive** `StatusDot`/`StatusBadge` (props-only, i18n-agnostic) + an optional `statusDot` slot on `CatalogRow` rendered before the title, always visible.
- **Integrations installed strip**: green/amber/red dot per connection status on catalog and custom rows, with an sr-only status label for screen readers. Detail dialogs/recovery rows keep the fuller dot+label badge.
- **AI hub connected-providers strip**: green dot (sr-only "Connected"). The provider browser/modals keep their labeled `LiveStatus`.
- **Skills marketplace**: installed rows get the green dot beside the existing quiet check; not-installed rows keep the `+`.

## Bookkeeping & verification
- Design inventory v33 + CHANGELOG + manifests; `pnpm check:parity` green.
- ui/core (17) and ui/skills (77) `node --test` suites pass; app + ui typechecks, Biome, `check-locales` all green; `knowledge-base/integrations.md` updated.

No Linear issue — UX-clarity improvement requested directly in-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)