### PR TITLE
fix: show the full email on the sign-in continue button

### DIFF
--- a/app/src/components/auth/continue-last-sign-in.tsx
+++ b/app/src/components/auth/continue-last-sign-in.tsx
@@ -15,7 +15,7 @@ const ICON_BY_HIGHLIGHT: Record<SignInHighlight, () => ReactNode> = {
  * The one-click "continue with the account you used last time" action. It IS
  * the returning-user path: a single filled, full-width button pinned above the
  * provider row, carrying the last provider's mark, the "Continue with X" title,
- * and the masked account address as a caption. Clicking it runs exactly the
+ * and the full account address as a caption. Clicking it runs exactly the
  * same sign-in the matching provider pill would (or, for the email path, kicks
  * off the passwordless code flow with the stored address prefilled).
  *
@@ -25,14 +25,14 @@ const ICON_BY_HIGHLIGHT: Record<SignInHighlight, () => ReactNode> = {
 export function ContinueLastSignIn({
   highlight,
   title,
-  maskedEmail,
+  email,
   pending,
   disabled,
   onClick,
 }: {
   highlight: SignInHighlight;
   title: string;
-  maskedEmail: string;
+  email: string;
   pending: boolean;
   disabled: boolean;
   onClick: () => void;
@@ -42,7 +42,7 @@ export function ContinueLastSignIn({
     <Button
       onClick={onClick}
       disabled={disabled}
-      aria-label={maskedEmail ? `${title} (${maskedEmail})` : title}
+      aria-label={email ? `${title} (${email})` : title}
       className="h-auto w-full justify-start gap-3 rounded-2xl px-4 py-3"
     >
       <span className="flex size-5 items-center justify-center">
@@ -50,9 +50,9 @@ export function ContinueLastSignIn({
       </span>
       <span className="flex min-w-0 flex-col items-start leading-tight">
         <span className="text-sm font-medium">{title}</span>
-        {maskedEmail && (
+        {email && (
           <span className="max-w-full truncate text-xs text-action-text/70">
-            {maskedEmail}
+            {email}
           </span>
         )}
       </span>

--- a/app/src/components/auth/sign-in-screen.tsx
+++ b/app/src/components/auth/sign-in-screen.tsx
@@ -68,8 +68,8 @@ export function SignInScreen() {
 
   // Device-local memory of the previous sign-in, read once on mount. Survives
   // sign-out (its own localStorage key), so returning users get a one-click path
-  // back to the account they used last. Keeps the full address for the email
-  // auto-prefill; only the masked form is ever shown.
+  // back to the account they used last. Keeps the raw address for the email
+  // auto-prefill; the button captions the (validated) full address.
   const lastSignIn = useMemo(() => {
     const hint = readLastSignIn();
     return hint ? { ...describeLastSignIn(hint), fullEmail: hint.email } : null;
@@ -153,7 +153,7 @@ export function SignInScreen() {
                 <ContinueLastSignIn
                   highlight={lastSignIn.highlight}
                   title={continueTitle}
-                  maskedEmail={lastSignIn.maskedEmail}
+                  email={lastSignIn.email}
                   pending={pending !== null && pending === lastSignIn.highlight}
                   disabled={pending !== null}
                   onClick={onContinue}

--- a/app/src/lib/last-sign-in.ts
+++ b/app/src/lib/last-sign-in.ts
@@ -98,17 +98,14 @@ export function readLastSignIn(): LastSignIn | null {
 }
 
 /**
- * Mask an email for this low-trust surface: keep only the first character of the
- * local part, hide the rest, keep the full domain.
- * `"jane@gethouston.ai"` → `"j…@gethouston.ai"`.
- * A withheld or malformed address returns `""` so the caller shows no address.
+ * The address shown on the continue button. The hint is device-local on the
+ * user's own machine, so the FULL address renders (masking it read as
+ * confusing, not private). A withheld or malformed address returns `""` so the
+ * caller shows no caption.
  */
-export function maskEmail(email: string): string {
+function displayEmail(email: string): string {
   const at = email.indexOf("@");
-  if (at <= 0 || at === email.length - 1) return "";
-  const local = email.slice(0, at);
-  const domain = email.slice(at);
-  return local.length <= 1 ? `${local}${domain}` : `${local[0]}…${domain}`;
+  return at <= 0 || at === email.length - 1 ? "" : email;
 }
 
 /** Which affordance the sign-in screen highlights for the remembered provider. */
@@ -120,8 +117,8 @@ export interface LastSignInDisplay {
   highlight: SignInHighlight;
   /** Brand name to interpolate into the copy, or null for the email path. */
   providerName: string | null;
-  /** Masked address, or "" when none is known. */
-  maskedEmail: string;
+  /** Full address to caption the button with, or "" when none is known. */
+  email: string;
 }
 
 const PROVIDER_META: Record<
@@ -143,6 +140,6 @@ export function describeLastSignIn(hint: LastSignIn): LastSignInDisplay {
   return {
     highlight: meta.highlight,
     providerName: meta.name,
-    maskedEmail: maskEmail(hint.email),
+    email: displayEmail(hint.email),
   };
 }

--- a/app/tests/last-sign-in.test.ts
+++ b/app/tests/last-sign-in.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, test } from "node:test";
 import {
   describeLastSignIn,
   type LastSignIn,
-  maskEmail,
   readLastSignIn,
   writeLastSignIn,
 } from "../src/lib/last-sign-in.ts";
@@ -97,35 +96,37 @@ test("read swallows a disabled storage and returns null", () => {
   assert.equal(readLastSignIn(), null);
 });
 
-test("maskEmail keeps first local char and full domain", () => {
-  assert.equal(maskEmail("jane@gethouston.ai"), "j…@gethouston.ai");
-});
-
-test("maskEmail keeps a single-char local part as-is", () => {
-  assert.equal(maskEmail("j@gethouston.ai"), "j@gethouston.ai");
-});
-
-test("maskEmail returns empty for withheld or malformed addresses", () => {
-  assert.equal(maskEmail(""), "");
-  assert.equal(maskEmail("nobody"), "");
-  assert.equal(maskEmail("@domain.com"), "");
-  assert.equal(maskEmail("local@"), "");
-});
-
 test("describeLastSignIn maps each provider to its pill and brand name", () => {
   assert.deepEqual(
     describeLastSignIn({ provider: "google.com", email: "jane@x.co" }),
-    { highlight: "google", providerName: "Google", maskedEmail: "j…@x.co" },
+    { highlight: "google", providerName: "Google", email: "jane@x.co" },
   );
   assert.deepEqual(
     describeLastSignIn({ provider: "microsoft.com", email: "" }),
-    { highlight: "azure", providerName: "Microsoft", maskedEmail: "" },
+    { highlight: "azure", providerName: "Microsoft", email: "" },
   );
   assert.deepEqual(describeLastSignIn({ provider: "apple.com", email: "" }), {
     highlight: "apple",
     providerName: "Apple",
-    maskedEmail: "",
+    email: "",
   });
+});
+
+test("describeLastSignIn shows the FULL address (never masked)", () => {
+  assert.equal(
+    describeLastSignIn({ provider: "google.com", email: "jane@gethouston.ai" })
+      .email,
+    "jane@gethouston.ai",
+  );
+});
+
+test("describeLastSignIn hides a withheld or malformed address", () => {
+  for (const bad of ["nobody", "@domain.com", "local@"]) {
+    assert.equal(
+      describeLastSignIn({ provider: "google.com", email: bad }).email,
+      "",
+    );
+  }
 });
 
 test("describeLastSignIn routes email-based providers to the email form", () => {
@@ -133,6 +134,6 @@ test("describeLastSignIn routes email-based providers to the email form", () => 
     const d = describeLastSignIn({ provider, email: "sam@x.co" });
     assert.equal(d.highlight, "email");
     assert.equal(d.providerName, null);
-    assert.equal(d.maskedEmail, "s…@x.co");
+    assert.equal(d.email, "sam@x.co");
   }
 });


### PR DESCRIPTION
The returning-user "Continue with X" button captioned a masked address (`j…@gmail.com`), which read as confusing rather than private on the user's own device. The full address now renders.

- `maskEmail` deleted; `LastSignInDisplay.maskedEmail` → `email` (full address), prop renamed through `ContinueLastSignIn` and `SignInScreen` — no compat keeps.
- A withheld or malformed stored address still hides the caption entirely (guard kept, masking dropped).
- Tests updated: full-address display pinned, malformed-hidden pinned (13 pass).

Verification: Biome, app `tsgo --noEmit`, `node --test` last-sign-in suite all green.

No Linear issue — UX fix requested directly in-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)