### PR TITLE
fix(host): stop exhausting the Linux inotify watch budget (HOU-841)

### DIFF
--- a/packages/host/src/store-sync/daemon.ts
+++ b/packages/host/src/store-sync/daemon.ts
@@ -1,4 +1,3 @@
-import { type FSWatcher, watch } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import {
   type HydrateManifest,
@@ -6,7 +5,7 @@ import {
   type ObjectStore,
   syncBack,
 } from "@houston/runtime-client/object-sync";
-import { isBenignRecursiveWatchRace } from "../watch/watcher-race";
+import { type TreeWatch, watchTree } from "../watch/watch-tree";
 
 const DEFAULT_QUIET_MS = 3_000;
 const DEFAULT_INTERVAL_MS = 300_000;
@@ -50,7 +49,7 @@ export class StoreSyncDaemon {
   private stopping = false;
   private dirty = false;
   private dirtyVersion = 0;
-  private watcher: FSWatcher | undefined;
+  private watcher: TreeWatch | undefined;
   private quietTimer: ReturnType<typeof setTimeout> | undefined;
   private intervalTimer: ReturnType<typeof setInterval> | undefined;
   private syncPromise: Promise<void> | undefined;
@@ -83,24 +82,15 @@ export class StoreSyncDaemon {
     if (this.started) return;
     this.started = true;
     try {
-      this.watcher = watch(this.opts.rootDir, { recursive: true }, () =>
-        this.markDirty(),
-      );
-      this.watcher.on("error", (err) => {
-        // The Linux recursive-watcher ENOENT race on a transient dir (see
-        // watch/watcher-race.ts) is harmless AND recoverable — the watcher
-        // keeps serving events, so closing it here would silently degrade
-        // reactivity to periodic-only over noise. Log-and-keep instead.
-        if (isBenignRecursiveWatchRace(err)) {
-          this.opts.log("[store-sync] transient fs-watch race (watcher kept)");
-          return;
-        }
-        this.opts.log(
-          "[store-sync] filesystem watcher failed; using periodic sync",
-          err,
-        );
-        this.watcher?.close();
-        this.watcher = undefined;
+      this.watcher = watchTree(this.opts.rootDir, () => this.markDirty(), {
+        // Fires at most once (ENOSPC on the pod's inotify budget — HOU-841);
+        // the tree watch keeps whatever coverage it already has, and the
+        // periodic pass guarantees eventual sync regardless.
+        onError: (err) =>
+          this.opts.log(
+            "[store-sync] filesystem watcher degraded; periodic sync covers changes",
+            err,
+          ),
       });
     } catch (err) {
       this.opts.log(

--- a/packages/host/src/watch/watch-tree.test.ts
+++ b/packages/host/src/watch/watch-tree.test.ts
@@ -1,0 +1,167 @@
+import {
+  type FSWatcher,
+  mkdirSync,
+  mkdtempSync,
+  watch,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test, vi } from "vitest";
+import { type TreeWatch, type WatchDirFn, watchTree } from "./watch-tree";
+
+/**
+ * The Linux directory-only strategy, exercised on any platform by forcing
+ * `platform: "linux"` — per-directory `fs.watch` is portable even though the
+ * strategy only ships on Linux (HOU-841).
+ */
+
+function linuxWatch(
+  root: string,
+  events: Array<{ type: string; rel: string }>,
+  onError: (err: unknown) => void = () => {},
+  watchDir?: WatchDirFn,
+): TreeWatch {
+  return watchTree(root, (type, rel) => events.push({ type, rel }), {
+    onError,
+    platform: "linux",
+    watchDir,
+  });
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  budgetMs = 3000,
+): Promise<void> {
+  const deadline = Date.now() + budgetMs;
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+test("a write deep in the tree surfaces with a root-relative path", async () => {
+  const root = mkdtempSync(join(tmpdir(), "houston-tree-"));
+  mkdirSync(join(root, "Work", "Sales", ".houston"), { recursive: true });
+  const events: Array<{ type: string; rel: string }> = [];
+  const watcher = linuxWatch(root, events);
+  try {
+    await new Promise((r) => setTimeout(r, 100));
+    writeFileSync(join(root, "Work", "Sales", ".houston", "a.json"), "{}");
+    const expected = join("Work", "Sales", ".houston", "a.json");
+    await waitFor(() => events.some((e) => e.rel === expected));
+    expect(events.map((e) => e.rel)).toContain(expected);
+  } finally {
+    watcher.close();
+  }
+});
+
+test("a directory created after start is watched too", async () => {
+  const root = mkdtempSync(join(tmpdir(), "houston-tree-"));
+  const events: Array<{ type: string; rel: string }> = [];
+  const watcher = linuxWatch(root, events);
+  try {
+    await new Promise((r) => setTimeout(r, 100));
+    mkdirSync(join(root, "late", "nested"), { recursive: true });
+    // Wait until the new dirs are armed, then write inside the deepest one.
+    await waitFor(() => events.some((e) => e.rel === join("late", "nested")));
+    await new Promise((r) => setTimeout(r, 100));
+    writeFileSync(join(root, "late", "nested", "file.txt"), "x");
+    const expected = join("late", "nested", "file.txt");
+    await waitFor(() => events.some((e) => e.rel === expected));
+    expect(events.map((e) => e.rel)).toContain(expected);
+  } finally {
+    watcher.close();
+  }
+});
+
+test("an exhausted watch budget degrades once and keeps existing coverage", async () => {
+  const root = mkdtempSync(join(tmpdir(), "houston-tree-"));
+  mkdirSync(join(root, "sub-a"));
+  mkdirSync(join(root, "sub-b"));
+  const onError = vi.fn();
+  // The root watch succeeds; every further add hits the ENOSPC the kernel
+  // throws when the inotify budget is spent.
+  let calls = 0;
+  const watchDir: WatchDirFn = (dir, cb) => {
+    calls += 1;
+    if (calls > 1) {
+      throw Object.assign(new Error("ENOSPC: watchers exhausted"), {
+        code: "ENOSPC",
+      });
+    }
+    return watch(dir, cb);
+  };
+  const events: Array<{ type: string; rel: string }> = [];
+  const watcher = linuxWatch(root, events, onError, watchDir);
+  try {
+    expect(onError).toHaveBeenCalledTimes(1);
+    // Later renames re-attempt addDir; the degraded flag must not re-report.
+    await new Promise((r) => setTimeout(r, 100));
+    mkdirSync(join(root, "sub-c"));
+    writeFileSync(join(root, "root-file.txt"), "x");
+    await waitFor(() => events.some((e) => e.rel === "root-file.txt"));
+    expect(events.map((e) => e.rel)).toContain("root-file.txt");
+    expect(onError).toHaveBeenCalledTimes(1);
+  } finally {
+    watcher.close();
+  }
+});
+
+test("close() halts delivery", async () => {
+  const root = mkdtempSync(join(tmpdir(), "houston-tree-"));
+  const events: Array<{ type: string; rel: string }> = [];
+  const watcher = linuxWatch(root, events);
+  watcher.close();
+  writeFileSync(join(root, "file.txt"), "x");
+  await new Promise((r) => setTimeout(r, 200));
+  expect(events).toHaveLength(0);
+});
+
+test("an unwatchable root throws to the caller", () => {
+  const missing = join(mkdtempSync(join(tmpdir(), "houston-tree-")), "nope");
+  expect(() => linuxWatch(missing, [])).toThrow();
+});
+
+test("a removed subtree releases its watchers", async () => {
+  const root = mkdtempSync(join(tmpdir(), "houston-tree-"));
+  mkdirSync(join(root, "gone", "deep"), { recursive: true });
+  const opened = new Map<string, FSWatcher>();
+  const watchDir: WatchDirFn = (dir, cb) => {
+    const w = watch(dir, cb);
+    opened.set(dir, w);
+    return w;
+  };
+  const closeSpies = () =>
+    [...opened.entries()].filter(([, w]) => {
+      // FSWatcher has no public "closed" flag; track via patched close.
+      return (w as unknown as { __closed?: boolean }).__closed === true;
+    });
+  const events: Array<{ type: string; rel: string }> = [];
+  const watcher = linuxWatch(
+    root,
+    events,
+    () => {},
+    (dir, cb) => {
+      const w = watchDir(dir, cb);
+      const origClose = w.close.bind(w);
+      w.close = () => {
+        (w as unknown as { __closed?: boolean }).__closed = true;
+        return origClose();
+      };
+      return w;
+    },
+  );
+  try {
+    await new Promise((r) => setTimeout(r, 100));
+    const { rmSync } = await import("node:fs");
+    rmSync(join(root, "gone"), { recursive: true, force: true });
+    await waitFor(() =>
+      closeSpies().some(([dir]) => dir === join(root, "gone")),
+    );
+    expect(closeSpies().map(([dir]) => dir)).toEqual(
+      expect.arrayContaining([join(root, "gone"), join(root, "gone", "deep")]),
+    );
+  } finally {
+    watcher.close();
+  }
+});

--- a/packages/host/src/watch/watch-tree.ts
+++ b/packages/host/src/watch/watch-tree.ts
@@ -1,0 +1,181 @@
+import {
+  type Dirent,
+  type FSWatcher,
+  readdirSync,
+  statSync,
+  watch,
+} from "node:fs";
+import { join, relative, sep } from "node:path";
+import { isBenignRecursiveWatchRace } from "./watcher-race";
+
+export type TreeWatchListener = (eventType: string, relPath: string) => void;
+
+/** Minimal shape of `fs.watch` on a single directory — injectable for tests. */
+export type WatchDirFn = (
+  dir: string,
+  cb: (eventType: string, filename: string | Buffer | null) => void,
+) => FSWatcher;
+
+export interface TreeWatchOptions {
+  /**
+   * Called AT MOST ONCE per watcher lifetime, on the first non-transient
+   * failure (ENOSPC on the inotify budget is the expected one — HOU-841).
+   * After it fires the watcher keeps serving whatever watches it already
+   * holds (best-effort); callers with a stronger guarantee need their own
+   * fallback (the store-sync daemon's periodic sync).
+   */
+  onError: (err: unknown) => void;
+  /** Test override; defaults to `process.platform`. */
+  platform?: NodeJS.Platform;
+  /** Test override for the per-directory watch (Linux strategy only). */
+  watchDir?: WatchDirFn;
+}
+
+export interface TreeWatch {
+  close(): void;
+}
+
+/**
+ * Recursive tree watch without the Linux per-file inotify explosion.
+ *
+ * macOS/Windows: native `fs.watch(root, { recursive: true })` (FSEvents /
+ * ReadDirectoryChangesW) — one OS handle for the whole tree.
+ *
+ * Linux: Node has no native recursive watch; its userland fallback
+ * (`internal/fs/recursive_watch`) registers one inotify watch per FILE and
+ * re-registers on every file that appears — atomic-write temp files included.
+ * inotify watches are a kernel budget shared by every pod on the node, so a
+ * busy tree exhausts it and every later file op throws ENOSPC (HOU-841).
+ * A directory inotify watch already reports create/modify/delete of its
+ * direct children, so this strategy watches DIRECTORIES only: watch count
+ * drops from files+dirs to dirs, and file churn registers nothing new.
+ */
+export function watchTree(
+  root: string,
+  listener: TreeWatchListener,
+  opts: TreeWatchOptions,
+): TreeWatch {
+  const platform = opts.platform ?? process.platform;
+  if (platform !== "linux") return watchNative(root, listener, opts.onError);
+  return new DirTreeWatcher(root, listener, opts.onError, opts.watchDir);
+}
+
+function watchNative(
+  root: string,
+  listener: TreeWatchListener,
+  onError: (err: unknown) => void,
+): TreeWatch {
+  const watcher = watch(root, { recursive: true }, (eventType, filename) => {
+    if (filename) listener(eventType, filename.toString());
+  });
+  let errored = false;
+  watcher.on("error", (err) => {
+    // Defensive: only a platform on Node's userland fallback produces this
+    // race, and those route to DirTreeWatcher above — but a kept watcher
+    // beats a spurious degradation if the dispatch ever widens.
+    if (isBenignRecursiveWatchRace(err)) return;
+    watcher.close();
+    if (errored) return;
+    errored = true;
+    onError(err);
+  });
+  return { close: () => watcher.close() };
+}
+
+class DirTreeWatcher implements TreeWatch {
+  private readonly watchers = new Map<string, FSWatcher>();
+  private closed = false;
+  /** Set on the first failed watch-add: stop consuming budget, keep serving. */
+  private degraded = false;
+  private errored = false;
+
+  constructor(
+    private readonly root: string,
+    private readonly listener: TreeWatchListener,
+    private readonly onError: (err: unknown) => void,
+    private readonly watchDir: WatchDirFn = (dir, cb) => watch(dir, cb),
+  ) {
+    // Parity with fs.watch: an unwatchable root throws to the caller.
+    this.addDir(root, true);
+  }
+
+  close(): void {
+    this.closed = true;
+    for (const w of this.watchers.values()) w.close();
+    this.watchers.clear();
+  }
+
+  private reportOnce(err: unknown): void {
+    if (this.errored) return;
+    this.errored = true;
+    this.onError(err);
+  }
+
+  private addDir(dir: string, isRoot = false): void {
+    if (this.closed || this.degraded || this.watchers.has(dir)) return;
+    let watcher: FSWatcher;
+    try {
+      watcher = this.watchDir(dir, (eventType, filename) =>
+        this.onDirEvent(dir, eventType, filename),
+      );
+    } catch (err) {
+      if (isRoot) throw err;
+      // A dir deleted between the parent event and this watch is the normal
+      // transient-dir race (see watcher-race.ts) — just skip it.
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      this.degraded = true;
+      this.reportOnce(err);
+      return;
+    }
+    watcher.on("error", (err) => {
+      watcher.close();
+      this.watchers.delete(dir);
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        this.reportOnce(err);
+      }
+    });
+    this.watchers.set(dir, watcher);
+    // Scan AFTER watching so subdirs created mid-scan surface as events
+    // instead of falling in a gap.
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return; // vanished — its own error handler cleans up
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) this.addDir(join(dir, entry.name));
+    }
+  }
+
+  private onDirEvent(
+    dir: string,
+    eventType: string,
+    filename: string | Buffer | null,
+  ): void {
+    if (this.closed || !filename) return;
+    const abs = join(dir, filename.toString());
+    this.listener(eventType, relative(this.root, abs));
+    if (eventType !== "rename") return;
+    // rename = an entry appeared or disappeared: a new dir needs a watch, a
+    // removed dir needs its subtree's watches released.
+    let isDir = false;
+    try {
+      isDir = statSync(abs).isDirectory();
+    } catch {
+      // gone already — fall through to the removal branch
+    }
+    if (isDir) this.addDir(abs);
+    else this.removeSubtree(abs);
+  }
+
+  private removeSubtree(abs: string): void {
+    const prefix = abs + sep;
+    for (const [path, watcher] of this.watchers) {
+      if (path === abs || path.startsWith(prefix)) {
+        watcher.close();
+        this.watchers.delete(path);
+      }
+    }
+  }
+}

--- a/packages/host/src/watch/watcher.ts
+++ b/packages/host/src/watch/watcher.ts
@@ -1,6 +1,6 @@
-import { type FSWatcher, watch } from "node:fs";
 import type { HoustonEvent } from "@houston/protocol";
 import { classifyChange } from "./classify";
+import { type TreeWatch, watchTree } from "./watch-tree";
 
 /**
  * Watches the local `~/.houston/workspaces` tree and emits reactivity events for
@@ -8,11 +8,15 @@ import { classifyChange } from "./classify";
  * with no write going through the host. The local counterpart of the cloud's
  * post-mutation emits; same HoustonEvent vocabulary, different detection.
  *
+ * The recursion strategy (native on macOS/Windows, directory-only inotify on
+ * Linux so a busy pod tree cannot exhaust the kernel watch budget — HOU-841)
+ * lives in watch-tree.ts.
+ *
  * Events are coalesced per (agentPath, type) over a short debounce so a burst of
  * writes (a routine run rewriting several files) yields one invalidation each.
  */
 export class FsWatcher {
-  private fsWatcher: FSWatcher | undefined;
+  private treeWatch: TreeWatch | undefined;
   private readonly pending = new Map<string, ReturnType<typeof setTimeout>>();
 
   constructor(
@@ -22,16 +26,22 @@ export class FsWatcher {
   ) {}
 
   start(): void {
-    if (this.fsWatcher) return;
-    // Recursive watch (supported on macOS + Windows + Node on Linux). A missing
-    // root simply yields no events until the supervisor creates it.
-    this.fsWatcher = watch(
+    if (this.treeWatch) return;
+    this.treeWatch = watchTree(
       this.root,
-      { recursive: true },
-      (_type, filename) => {
-        if (!filename) return;
-        const event = classifyChange(filename.toString());
+      (_type, relPath) => {
+        const event = classifyChange(relPath);
         if (event) this.schedule(event);
+      },
+      {
+        // Fires at most once; the watch keeps best-effort coverage after.
+        // File-watcher callback = the no-silent-failures policy's one carve-out
+        // (no UI thread to toast on): log loudly and stay up.
+        onError: (err) =>
+          console.error(
+            "[fs-watch] tree watch degraded; direct file edits may not refresh the UI until restart:",
+            err,
+          ),
       },
     );
   }
@@ -49,8 +59,8 @@ export class FsWatcher {
   }
 
   stop(): void {
-    this.fsWatcher?.close();
-    this.fsWatcher = undefined;
+    this.treeWatch?.close();
+    this.treeWatch = undefined;
     for (const t of this.pending.values()) clearTimeout(t);
     this.pending.clear();
   }

--- a/packages/web/e2e/sign-in.spec.ts
+++ b/packages/web/e2e/sign-in.spec.ts
@@ -170,12 +170,13 @@ test.describe("returning user (last sign-in continue)", () => {
   }) => {
     await seedLastSignIn(page, "google.com", "jane@gethouston.ai");
     await page.goto("/");
-    // The prominent continue button carries the masked address in its name,
-    // distinguishing it from the plain "Continue with Google" pill below.
+    // The prominent continue button carries the full address in its name
+    // (PR #1041: no masking on the user's own device), distinguishing it from
+    // the plain "Continue with Google" pill below.
     await expect(
       page.getByRole("button", { name: /^Continue with Google \(/ }),
     ).toBeVisible();
-    await expect(page.getByText("j…@gethouston.ai")).toBeVisible();
+    await expect(page.getByText("jane@gethouston.ai")).toBeVisible();
     // The pills + email form stay below the "another way" divider.
     await expect(page.getByText("or use another way")).toBeVisible();
     await expect(page.getByPlaceholder("you@example.com")).toBeVisible();
@@ -189,8 +190,8 @@ test.describe("returning user (last sign-in continue)", () => {
     await page
       .getByRole("button", { name: /^Continue with your email \(/ })
       .click();
-    // One click lands straight on the 6-digit entry, naming the FULL stored
-    // email (masked on the button, real value used to send the code).
+    // One click lands straight on the 6-digit entry, naming the same full
+    // stored email the button carries.
     await expect(page.locator('[data-slot="input-otp-slot"]')).toHaveCount(6);
     await expect(
       page.getByText("We sent a 6-digit code to pilot@example.com"),


### PR DESCRIPTION
Fixes HOU-841 (Sentry issue 7623722002: `ENOSPC: System limit for number of file watchers reached` — 5.6k events / 130 users on managed pods).

## Root cause

Managed pods (Linux, Node 22) ran **two** recursive `fs.watch` calls over overlapping trees: `FsWatcher` on `/data/workspaces` and `StoreSyncDaemon` on `/data`. Linux has no native recursive watch, so Node falls back to `internal/fs/recursive_watch`, which registers one inotify watch **per file and directory** and adds a new watch for every file that appears — including every atomic-write temp file (the Sentry title names `routine_runs.json.1.hddm3p.tmp`). inotify watches are a kernel budget shared by every pod on a node, so busy trees exhausted it; from then on **every** new file threw ENOSPC. `FsWatcher` had no `error` listener, so each throw became an `uncaughtException` → one Sentry event, while UI reactivity for direct agent writes silently died. `StoreSyncDaemon` closed its watcher entirely on the first error, dropping to periodic-only sync.

## Fix

New `packages/host/src/watch/watch-tree.ts` — `watchTree()` picks the recursion strategy per platform:

- **macOS/Windows** (desktop): native `fs.watch(root, { recursive: true })` — one OS handle, behavior unchanged.
- **Linux** (pods): directory-only inotify watches. A directory watch already reports create/modify/delete of its direct children, so per-file watches are pure waste: watch count drops from files+dirs to **dirs only** (~10×+ fewer), and file churn (temp files) registers **zero** new watches.

Degradation contract: a failed watch-add (ENOSPC) reports **once** per watcher lifetime and keeps serving all watches it already holds, instead of erroring per file. `FsWatcher` and `StoreSyncDaemon` both consume it; the daemon's 5-minute periodic sync remains the eventual-consistency net. Transient ENOENT races (a dir deleted between event and watch, previously special-cased via `isBenignRecursiveWatchRace`) are absorbed inside the Linux strategy.

## Reproduction (before the fix)

1. On a Linux box/container, lower the budget: `sudo sysctl fs.inotify.max_user_watches=512`.
2. Start the host over a data dir with >512 files (any populated `/data/workspaces` tree).
3. Have anything create files under the tree (e.g. a routine run writing `routine_runs.json`).
4. Observe repeated `Error: ENOSPC: System limit for number of file watchers reached, watch '….tmp'` uncaught exceptions (→ Sentry), one per new file, and file-driven UI invalidations stop.

## Verification (after the fix)

1. Same lowered limit, same tree: the host boots, watch consumption is proportional to the *directory* count (`find /data -type d | wc -l`), and file creation raises no ENOSPC.
2. Editing a file under `<Workspace>/<Agent>/.houston/` still emits the reactivity event (covered by `watcher.test.ts` + `reactivity.test.ts`); store-sync still marks dirty on writes (daemon tests).
3. If the budget is still exceeded (dirs alone > limit), exactly **one** `[fs-watch] tree watch degraded…` / `[store-sync] filesystem watcher degraded; periodic sync covers changes` log per process, and sync still converges via the periodic pass.
4. `pnpm --filter @houston/host test` — full suite green (1046 passed; new `watch-tree.test.ts` covers deep-write relative paths, late-created dirs, injected ENOSPC degrade-once with kept coverage, subtree-removal watcher release, close semantics, unwatchable root).

Cluster-side follow-up (separate repo): raising `fs.inotify.max_user_watches` on GKE nodes would add headroom, but with dir-only watching the default budget should no longer be approached.
