### PR TITLE
fix(app): accept the Claude sign-in code when the browser hand-off is blocked (HOU-839)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "ashpd"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +597,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +773,15 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
 ]
 
 [[package]]
@@ -1370,6 +1405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1436,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1718,6 +1765,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,6 +1980,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,6 +2074,7 @@ dependencies = [
 name = "houston-app"
 version = "0.5.9"
 dependencies = [
+ "arboard",
  "bytes",
  "chrono",
  "dirs 5.0.1",
@@ -2179,7 +2248,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2331,6 +2400,20 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2827,6 +2910,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -3752,6 +3845,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3791,7 +3896,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3828,7 +3933,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5511,6 +5616,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6477,6 +6596,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6498,7 +6623,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7184,6 +7309,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7454,6 +7596,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -23,6 +23,9 @@ dirs = "5"
 percent-encoding = "2"
 chrono = { version = "0.4", features = ["serde"] }
 tauri-plugin-notification = "2"
+# Rust-side clipboard read for the Claude sign-in auto-finish (the webview's
+# navigator.clipboard.readText is permission-gated and flaky across platforms).
+arboard = "3"
 tauri-plugin-updater = "2"
 tauri-plugin-deep-link = "2"
 tauri-plugin-sentry = "0.5"

--- a/app/src-tauri/src/claude_login/code_input.rs
+++ b/app/src-tauri/src/claude_login/code_input.rs
@@ -1,0 +1,138 @@
+//! Relay a pasted authorization code to the running `claude auth login` child.
+//!
+//! The current CLI authorizes with `code=true`: the browser redirect lands on
+//! platform.claude.com, which tries to hand the code to the CLI's local
+//! listener automatically (the seamless path). When that hand-off is blocked
+//! (firewalls, strict browsers — the common case on Windows), the page shows
+//! the user a code and the CLI waits on `Paste code here if prompted >`. The
+//! sign-in dialog collects that code and this command writes it to the child's
+//! piped stdin, letting the CLI finish its own token exchange.
+
+use std::sync::Arc;
+
+use tauri::State;
+use tokio::io::AsyncWriteExt;
+use tokio::process::ChildStdin;
+
+use super::ClaudeLoginState;
+
+/// Shared slot for the login child's stdin. `start_claude_login` fills it per
+/// attempt; the submit command drains writes through it. `None` after the
+/// child was spawned without a pipe (never in production) or the slot was
+/// never armed.
+pub(super) type StdinSlot = Arc<tokio::sync::Mutex<Option<ChildStdin>>>;
+
+/// Write the pasted code (plus newline, as the CLI's readline expects) to the
+/// login child's stdin. Split from the command so the whole paste path is
+/// unit-testable against a fake `claude` script without Tauri state.
+pub(super) async fn write_login_code(slot: &StdinSlot, code: &str) -> Result<(), String> {
+    let trimmed = code.trim();
+    if trimmed.is_empty() {
+        return Err("Enter the code first.".to_string());
+    }
+    let mut guard = slot.lock().await;
+    let stdin = guard.as_mut().ok_or_else(|| {
+        "No Claude sign-in is waiting for a code. Start the connect again.".to_string()
+    })?;
+    let payload = format!("{trimmed}\n");
+    let sent = async {
+        stdin.write_all(payload.as_bytes()).await?;
+        stdin.flush().await
+    }
+    .await;
+    sent.map_err(|e| format!("Could not send the code to the Claude sign-in helper: {e}"))
+}
+
+/// Tauri command: relay the code the user pasted in the sign-in dialog to the
+/// in-flight login child. Errors surface as a toast in the dialog; the actual
+/// outcome (exchange success/failure) still arrives via `claude-login://done`.
+#[tauri::command(rename_all = "snake_case")]
+pub async fn submit_claude_login_code(
+    state: State<'_, ClaudeLoginState>,
+    code: String,
+) -> Result<(), String> {
+    let slot = {
+        let guard = state.0.lock().await;
+        guard
+            .as_ref()
+            .map(|handle| handle.stdin.clone())
+            .ok_or_else(|| {
+                "No Claude sign-in is waiting for a code. Start the connect again.".to_string()
+            })?
+    };
+    write_login_code(&slot, &code).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn write_login_code_rejects_blank_and_unarmed() {
+        let empty: StdinSlot = Arc::new(tokio::sync::Mutex::new(None));
+        assert!(write_login_code(&empty, "   ").await.is_err());
+        assert!(write_login_code(&empty, "abc").await.is_err());
+    }
+
+    /// End-to-end paste path: a fake `claude` prints the visit line, waits for a
+    /// code on stdin (the real CLI's `Paste code here if prompted >` behavior),
+    /// and exits 0 only when the expected code arrives. Exercises the piped
+    /// stdin from `build_login_command`, the stdin slot, and the write helper.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pasted_code_reaches_the_child_and_completes_the_login() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::sync::atomic::AtomicBool;
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "houston-claude-code-input-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir temp");
+        let script = dir.join("claude");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\n\
+             echo \"If the browser didn't open, visit: https://claude.com/cai/oauth/authorize?code=true\"\n\
+             printf 'Paste code here if prompted > '\n\
+             read code\n\
+             [ \"$code\" = \"goodcode#state\" ] && exit 0\n\
+             exit 1\n",
+        )
+        .expect("write fake claude");
+        let mut perms = std::fs::metadata(&script).expect("stat").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).expect("chmod");
+
+        let mut child = super::super::resolve::build_login_command(&script, &dir.join("config"))
+            .spawn()
+            .expect("spawn fake claude");
+        let slot: StdinSlot = Arc::new(tokio::sync::Mutex::new(child.stdin.take()));
+
+        let events = Arc::new(std::sync::Mutex::new(Vec::<(String, serde_json::Value)>::new()));
+        let sink = events.clone();
+        let login = tokio::spawn(super::super::runner::run_login_child(
+            child,
+            Arc::new(AtomicBool::new(false)),
+            move |name: &str, payload: serde_json::Value| {
+                sink.lock().expect("events lock").push((name.to_string(), payload));
+            },
+        ));
+
+        write_login_code(&slot, "  goodcode#state  ")
+            .await
+            .expect("write code");
+        login.await.expect("login task");
+
+        let got = events.lock().expect("events lock");
+        let done = got.last().expect("done event");
+        assert_eq!(done.0, super::super::EVENT_DONE);
+        assert_eq!(done.1["success"], serde_json::json!(true));
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+}

--- a/app/src-tauri/src/claude_login/code_input.rs
+++ b/app/src-tauri/src/claude_login/code_input.rs
@@ -63,6 +63,83 @@ pub async fn submit_claude_login_code(
     write_login_code(&slot, &code).await
 }
 
+/// True for a string shaped like the authorization code the claude.ai approval
+/// page shows (`<code>#<state>`): one line, base64url-ish charset on both
+/// sides of a single `#`, with the state half at least 32 chars (OAuth states
+/// are 43-char base64url). Deliberately strict — this gates what the clipboard
+/// auto-finish is willing to feed the CLI, and ordinary clipboard content
+/// (text, URLs, passwords) must never match.
+pub(super) fn looks_like_login_code(value: &str) -> Option<&str> {
+    let v = value.trim();
+    if v.len() > 512 {
+        return None;
+    }
+    let (code, tail) = v.split_once('#')?;
+    let b64url = |s: &str| {
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '~'))
+    };
+    if b64url(code) && b64url(tail) && tail.len() >= 32 {
+        Some(v)
+    } else {
+        None
+    }
+}
+
+/// Tauri command: opportunistically finish the sign-in from the clipboard.
+/// Called when the app regains focus while a login is pending — the stuck
+/// signature (a completed hand-off closes the dialog before the user returns).
+/// If the clipboard holds a code-shaped string (the approval page's Copy code
+/// button), it is fed to the CLI and `true` returns; anything else — no pending
+/// login, unreadable or non-matching clipboard — returns `false` so the dialog
+/// can fall back to its manual affordance. Background reconciliation, not a
+/// user action: never errors, never logs clipboard contents.
+#[tauri::command(rename_all = "snake_case")]
+pub async fn complete_claude_login_from_clipboard(
+    state: State<'_, ClaudeLoginState>,
+) -> Result<bool, String> {
+    let Some(slot) = ({
+        let guard = state.0.lock().await;
+        guard.as_ref().map(|handle| handle.stdin.clone())
+    }) else {
+        return Ok(false);
+    };
+    // arboard is blocking; keep it off the async runtime's core threads.
+    let text = tokio::task::spawn_blocking(|| {
+        arboard::Clipboard::new().and_then(|mut c| c.get_text())
+    })
+    .await;
+    let text = match text {
+        Ok(Ok(t)) => t,
+        Ok(Err(e)) => {
+            // Empty/non-text clipboard lands here too — expected, stay quiet
+            // beyond a debug trace (contents are never logged, only the error).
+            tracing::debug!("[claude-login] clipboard read unavailable: {e}");
+            return Ok(false);
+        }
+        Err(e) => {
+            tracing::warn!("[claude-login] clipboard probe task failed: {e}");
+            return Ok(false);
+        }
+    };
+    let Some(code) = looks_like_login_code(&text) else {
+        return Ok(false);
+    };
+    match write_login_code(&slot, code).await {
+        Ok(()) => {
+            tracing::info!("[claude-login] finished sign-in from a copied code");
+            Ok(true)
+        }
+        Err(e) => {
+            // The child may have just exited (hand-off won the race) — treat as
+            // "nothing consumed" and let the dialog fall back.
+            tracing::warn!("[claude-login] clipboard code relay failed: {e}");
+            Ok(false)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -72,6 +149,30 @@ mod tests {
         let empty: StdinSlot = Arc::new(tokio::sync::Mutex::new(None));
         assert!(write_login_code(&empty, "   ").await.is_err());
         assert!(write_login_code(&empty, "abc").await.is_err());
+    }
+
+    #[test]
+    fn looks_like_login_code_accepts_only_code_hash_state_shapes() {
+        let state43 = "dC6jOHpzMnxqFPzlziDLuI2idI8uGWL0RlAg1HQ5l78";
+        // Real shape: opaque code, '#', 43-char base64url state (whitespace trimmed).
+        let ok = format!("  ac_7GhK2mPq-x9_zW#{state43}  ");
+        assert_eq!(
+            looks_like_login_code(&ok).map(str::trim),
+            Some(format!("ac_7GhK2mPq-x9_zW#{state43}").trim())
+        );
+        // Ordinary clipboard content must never match.
+        for junk in [
+            "",
+            "hello world",
+            "https://claude.ai/oauth#section",       // short tail
+            "password#hunter2",                      // short tail
+            &format!("has space#{state43}"),         // whitespace inside
+            &format!("multi\nline#{state43}"),       // newline inside
+            state43,                                 // no '#'
+            &format!("a#b#{state43}"),               // '#' in the tail charset? ('#' not allowed)
+        ] {
+            assert_eq!(looks_like_login_code(junk), None, "matched junk: {junk:?}");
+        }
     }
 
     /// End-to-end paste path: a fake `claude` prints the visit line, waits for a

--- a/app/src-tauri/src/claude_login/mod.rs
+++ b/app/src-tauri/src/claude_login/mod.rs
@@ -2,11 +2,17 @@
 //! terminal.
 //!
 //! The installed `claude` CLI's `auth login --claudeai` is a plain readline
-//! stdio flow (NOT an Ink TUI): it starts its OWN loopback, prints
-//! `Opening browser to sign in…` then a line
-//! `If the browser didn't open, visit: <AUTHORIZE_URL>`, auto-opens the
-//! browser, catches its own callback, caches the credential, prints
-//! `Login successful`, and exits 0. On failure it exits non-zero.
+//! stdio flow (NOT an Ink TUI): it prints `Opening browser to sign in…` then a
+//! line `If the browser didn't open, visit: <AUTHORIZE_URL>`, auto-opens the
+//! browser, and waits. The authorize URL carries `code=true` with the redirect
+//! aimed at platform.claude.com (no localhost redirect): after the user
+//! approves, that callback page tries to hand the authorization code to the
+//! CLI's local listener automatically — the seamless path — and when the
+//! hand-off is blocked (firewalls, strict browsers; common on Windows) it shows
+//! the user a code instead, which the CLI awaits on stdin
+//! (`Paste code here if prompted >`; relayed via [`code_input`]). Either way
+//! the CLI caches the credential, prints `Login successful`, and exits 0. On
+//! failure it exits non-zero.
 //!
 //! We run it as a piped child so the app can (1) surface the authorize URL to
 //! the webview (as a copy/paste fallback when the auto-open browser doesn't
@@ -34,6 +40,7 @@
 // defining path (`claude_login::credential::read_claude_credential`) — the macro
 // resolves the sibling `__cmd__*` items in the module where the command lives, so
 // a re-export of just the fn would not carry them.
+pub(crate) mod code_input;
 pub(crate) mod credential;
 mod resolve;
 mod runner;
@@ -69,11 +76,15 @@ pub(super) fn claude_login_config_dir() -> PathBuf {
 #[derive(Default)]
 pub struct ClaudeLoginState(pub tokio::sync::Mutex<Option<ClaudeLoginHandle>>);
 
-/// The cancel side of one in-flight login. `start_claude_login` overwrites this
-/// on each fresh attempt; a stale handle left after a completed login is benign
-/// (nothing polls the flag once the task has finished).
+/// The cancel + code-relay side of one in-flight login. `start_claude_login`
+/// overwrites this on each fresh attempt; a stale handle left after a completed
+/// login is benign (nothing polls the flag once the task has finished, and a
+/// late code write fails loudly on the closed pipe).
 pub struct ClaudeLoginHandle {
     cancel: Arc<AtomicBool>,
+    /// The child's piped stdin, for `submit_claude_login_code` — the CLI's
+    /// `Paste code here if prompted >` fallback (see `code_input`).
+    stdin: code_input::StdinSlot,
 }
 
 /// Start the native Claude sign-in. Returns `Err` (→ frontend toast) only for
@@ -109,7 +120,7 @@ pub async fn start_claude_login(
     let bin = resolve_claude_binary();
     // Spawn synchronously so a launch failure surfaces as a toast (Err) rather
     // than an async `done` event.
-    let child = build_login_command(&bin, &config_dir)
+    let mut child = build_login_command(&bin, &config_dir)
         .spawn()
         .map_err(|e| format!("Could not start the Claude sign-in helper: {e}"))?;
     tracing::info!(
@@ -118,13 +129,15 @@ pub async fn start_claude_login(
         config_dir.display()
     );
 
-    // Publish the cancel flag before the task starts so a Cancel racing the
-    // spawn is honored.
+    // Publish the cancel flag + stdin slot before the task starts so a Cancel
+    // or a pasted code racing the spawn is honored.
     let cancel = Arc::new(AtomicBool::new(false));
+    let stdin: code_input::StdinSlot = Arc::new(tokio::sync::Mutex::new(child.stdin.take()));
     {
         let mut guard = state.0.lock().await;
         *guard = Some(ClaudeLoginHandle {
             cancel: cancel.clone(),
+            stdin,
         });
     }
 

--- a/app/src-tauri/src/claude_login/resolve.rs
+++ b/app/src-tauri/src/claude_login/resolve.rs
@@ -52,14 +52,18 @@ pub(super) fn resolve_claude_binary() -> PathBuf {
 }
 
 /// Build the `claude auth login --claudeai` command with piped stdio and the
-/// shared `CLAUDE_CONFIG_DIR`. `stdin` is null (the flow is browser-only —
-/// there is no terminal to read from) and `kill_on_drop` guarantees the child
+/// shared `CLAUDE_CONFIG_DIR`. `stdin` is PIPED: the current CLI authorizes
+/// with `code=true` (redirect to platform.claude.com, no localhost redirect)
+/// and prints `Paste code here if prompted >` — when the callback page cannot
+/// hand the code to the CLI's local listener (firewalls, strict browsers; the
+/// common case on Windows), the user is shown a code that must reach the CLI's
+/// stdin via `submit_claude_login_code`. `kill_on_drop` guarantees the child
 /// dies if the owning task is dropped (timeout/cancel/panic).
 pub(super) fn build_login_command(bin: &Path, config_dir: &Path) -> Command {
     let mut cmd = Command::new(bin);
     cmd.args(["auth", "login", "--claudeai"])
         .env("CLAUDE_CONFIG_DIR", config_dir)
-        .stdin(Stdio::null())
+        .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
@@ -83,12 +87,39 @@ pub(super) fn build_login_command(bin: &Path, config_dir: &Path) -> Command {
     cmd
 }
 
+/// Remove OSC 8 hyperlink sequences (`ESC]8;;URI BEL|ESC\` … `ESC]8;; BEL|ESC\`)
+/// so only the visible text remains. The current CLI hyperlink-wraps the URL on
+/// its `visit:` line even when stdout is a pipe; without stripping, the token
+/// after `visit:` starts with an escape byte and the parse below misses.
+fn strip_osc8(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut rest = line;
+    while let Some(start) = rest.find("\u{1b}]8;") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start..];
+        // The sequence ends at BEL or ESC-backslash; skip it entirely (the URI
+        // between `]8;;` and the terminator is control data, not visible text).
+        let end = after
+            .find('\u{7}')
+            .map(|i| i + 1)
+            .or_else(|| after.find("\u{1b}\\").map(|i| i + 2));
+        match end {
+            Some(e) => rest = &after[e..],
+            // Unterminated sequence: drop the tail rather than emit raw escapes.
+            None => return out,
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
 /// Parse an authorize URL out of a `visit:` line like
 /// `If the browser didn't open, visit: https://claude.ai/oauth/authorize?...`.
 /// Returns `None` when there is no `visit:` marker or the following token is not
 /// an `http(s)` URL. Dependency-free (no `regex`) — plain string ops.
 pub(super) fn extract_visit_url(line: &str) -> Option<String> {
     const MARKER: &str = "visit:";
+    let line = strip_osc8(line);
     let idx = line.find(MARKER)?;
     let rest = line[idx + MARKER.len()..].trim();
     // The URL is the first whitespace-delimited token after the marker.
@@ -134,6 +165,28 @@ mod tests {
             extract_visit_url(line).as_deref(),
             Some("https://claude.ai/oauth/authorize?code=abc")
         );
+    }
+
+    #[test]
+    fn extract_visit_url_unwraps_osc8_hyperlinks() {
+        // Real shape from CLI 2.1.201: the URL is OSC-8 wrapped (BEL-terminated)
+        // — control URI, visible URL text, then the closing empty hyperlink.
+        let url = "https://claude.com/cai/oauth/authorize?code=true&client_id=abc&state=xyz";
+        let line =
+            format!("If the browser didn't open, visit: \u{1b}]8;;{url}\u{7}{url}\u{1b}]8;;\u{7}");
+        assert_eq!(extract_visit_url(&line).as_deref(), Some(url));
+        // ESC-backslash terminated variant.
+        let line = format!(
+            "If the browser didn't open, visit: \u{1b}]8;;{url}\u{1b}\\{url}\u{1b}]8;;\u{1b}\\"
+        );
+        assert_eq!(extract_visit_url(&line).as_deref(), Some(url));
+    }
+
+    #[test]
+    fn extract_visit_url_drops_an_unterminated_osc8_tail() {
+        // A truncated read mid-sequence must not surface raw escape bytes.
+        let line = "visit: \u{1b}]8;;https://claude.com/cai/oauth/authorize?x=1";
+        assert_eq!(extract_visit_url(line), None);
     }
 
     #[test]

--- a/app/src-tauri/src/claude_login/runner.rs
+++ b/app/src-tauri/src/claude_login/runner.rs
@@ -20,9 +20,13 @@ use super::resolve::{build_login_command, extract_visit_url};
 use super::{EVENT_DONE, EVENT_URL};
 
 /// Give up on the login if the CLI never returns (user closed the consent tab,
-/// bailed on the browser approve, …). Mirrors the loopback's 300s ceiling. The
-/// frontend can start a fresh attempt after this.
-const LOGIN_TIMEOUT: Duration = Duration::from_secs(300);
+/// bailed on the browser approve, …). Generous on purpose: the CLI's local
+/// listener only exists while the child runs, and killing it early FORCES the
+/// approval page onto its show-a-code fallback for anyone who approves late
+/// (HOU-839). The port is random-per-attempt, so holding it is harmless
+/// (unlike Codex's fixed 1455). Mirror `LOGIN_TIMEOUT_MS` in
+/// app/src/lib/claude-login.ts when changing this.
+const LOGIN_TIMEOUT: Duration = Duration::from_secs(900);
 
 /// How often the wait loop wakes to check the cancel flag while the child is
 /// still running. Small enough that Cancel feels instant, large enough not to

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -479,6 +479,7 @@ pub fn run() {
             // `claude-login://url` / `claude-login://done` events.
             claude_login::start_claude_login,
             claude_login::cancel_claude_login,
+            claude_login::code_input::submit_claude_login_code,
             // Extract the cached credential to push to a REMOTE engine pod
             // (a hosted pod can't read this machine's Keychain).
             claude_login::credential::read_claude_credential,

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -480,6 +480,7 @@ pub fn run() {
             claude_login::start_claude_login,
             claude_login::cancel_claude_login,
             claude_login::code_input::submit_claude_login_code,
+            claude_login::code_input::complete_claude_login_from_clipboard,
             // Extract the cached credential to push to a REMOTE engine pod
             // (a hosted pod can't read this machine's Keychain).
             claude_login::credential::read_claude_credential,

--- a/app/src/components/shell/claude-browser-login.tsx
+++ b/app/src/components/shell/claude-browser-login.tsx
@@ -4,21 +4,24 @@ import {
   reconcileClaudeCredentialHandoff,
 } from "../../lib/claude-login";
 import { listenOsEvent } from "../../lib/events";
-import { osIsTauri } from "../../lib/os-bridge";
+import { osIsTauri, osSubmitClaudeLoginCode } from "../../lib/os-bridge";
 import { PROVIDERS } from "../../lib/providers";
-import { ProviderLoginDialog } from "./provider-login-dialog";
+import { ProviderLoginBrowserPending } from "./provider-login-browser-pending";
 
 /**
- * Shell-global spinner for the desktop Claude browser sign-in.
+ * Shell-global dialog for the desktop Claude browser sign-in.
  *
- * The native `claude auth login` runs the whole flow itself (opens the browser,
- * catches its own callback), so there is no per-surface dialog state to thread
- * through — this component just reflects the two Tauri events the command emits:
- * `claude-login://url` (show the dialog + a "didn't open" fallback link) and
- * `claude-login://done` (dismiss). The actual card flip is driven separately by
- * `beginClaudeBrowserLogin`'s synthetic `ProviderLoginComplete`. Mounted once in
- * the shell (like `ProviderLoginFallback`). No-op in the web build (the events
- * never fire there).
+ * The native `claude auth login` runs the whole flow itself (opens the browser;
+ * the approval page normally hands the authorization code straight back to the
+ * CLI), so there is no per-surface dialog state to thread through — this
+ * component just reflects the two Tauri events the command emits:
+ * `claude-login://url` (show the dialog: a "didn't open" fallback link plus the
+ * code paste field for when the approval page shows the user a code instead of
+ * completing automatically) and `claude-login://done` (dismiss). The actual
+ * card flip is driven separately by `beginClaudeBrowserLogin`'s synthetic
+ * `ProviderLoginComplete`. Mounted once in the shell (like
+ * `ProviderLoginFallback`). No-op in the web build (the events never fire
+ * there).
  */
 const ANTHROPIC = PROVIDERS.find((p) => p.id === "anthropic") ?? null;
 
@@ -48,11 +51,10 @@ export function ClaudeBrowserLogin() {
 
   if (!url || !ANTHROPIC) return null;
   return (
-    <ProviderLoginDialog
+    <ProviderLoginBrowserPending
       provider={ANTHROPIC}
       url={url}
-      userCode={null}
-      browserPending
+      onSubmitCode={(code) => osSubmitClaudeLoginCode(code)}
       onClose={() => {
         // Cancel kills the native `claude` child and clears the pending card
         // silently (single cancel path — kills the child + announces a benign

--- a/app/src/components/shell/claude-browser-login.tsx
+++ b/app/src/components/shell/claude-browser-login.tsx
@@ -4,7 +4,11 @@ import {
   reconcileClaudeCredentialHandoff,
 } from "../../lib/claude-login";
 import { listenOsEvent } from "../../lib/events";
-import { osIsTauri, osSubmitClaudeLoginCode } from "../../lib/os-bridge";
+import {
+  osCompleteClaudeLoginFromClipboard,
+  osIsTauri,
+  osSubmitClaudeLoginCode,
+} from "../../lib/os-bridge";
 import { PROVIDERS } from "../../lib/providers";
 import { ProviderLoginBrowserPending } from "./provider-login-browser-pending";
 
@@ -54,6 +58,7 @@ export function ClaudeBrowserLogin() {
     <ProviderLoginBrowserPending
       provider={ANTHROPIC}
       url={url}
+      onClipboardProbe={osCompleteClaudeLoginFromClipboard}
       onSubmitCode={(code) => osSubmitClaudeLoginCode(code)}
       onClose={() => {
         // Cancel kills the native `claude` child and clears the pending card

--- a/app/src/components/shell/provider-login-browser-pending.tsx
+++ b/app/src/components/shell/provider-login-browser-pending.tsx
@@ -135,6 +135,14 @@ export function ProviderLoginBrowserPending({
           </span>
         </div>
 
+        {/* Primes the copy-and-return motion that lets the clipboard
+            auto-finish recover a blocked hand-off with zero typing. */}
+        {stage !== "finishing" && (
+          <p className="text-[12px] text-ink-muted">
+            {t("providerLogin.browserCodeCopyHint")}
+          </p>
+        )}
+
         {stage === "revealed" && (
           <Button
             type="button"

--- a/app/src/components/shell/provider-login-browser-pending.tsx
+++ b/app/src/components/shell/provider-login-browser-pending.tsx
@@ -1,0 +1,135 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@houston-ai/core";
+import { ExternalLink, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { genericErrorDescription } from "../../lib/error-toast";
+import type { ProviderInfo } from "../../lib/providers";
+import { tauriSystem } from "../../lib/tauri";
+
+/**
+ * Desktop Claude BROWSER login dialog: the native `claude auth login` already
+ * opened the browser, so the primary state is a spinner ("approve in your
+ * browser") with a "didn't open" fallback link. The approval page normally
+ * hands its authorization code back to the CLI automatically; when it can't
+ * (firewalls, strict browsers — common on Windows) it shows the user a code
+ * instead, so the dialog always offers a visible paste field that relays the
+ * code to the CLI's stdin via `onSubmitCode`. The dialog stays open after a
+ * submit — completion (or failure) arrives via `claude-login://done`, which
+ * unmounts it from the parent. Closing cancels the sign-in.
+ */
+interface Props {
+  provider: ProviderInfo;
+  url: string;
+  onSubmitCode: (code: string) => Promise<void>;
+  onClose: () => void;
+}
+
+export function ProviderLoginBrowserPending({
+  provider,
+  url,
+  onSubmitCode,
+  onClose,
+}: Props) {
+  const { t } = useTranslation("providers");
+  const [code, setCode] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = code.trim();
+    if (!trimmed) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmitCode(trimmed);
+      // Keep the dialog open: the CLI now finishes its own exchange and the
+      // parent closes on `claude-login://done`.
+    } catch (err) {
+      setError(genericErrorDescription("provider_login_submit_code", err));
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {t("providerLogin.title", { name: provider.name })}
+          </DialogTitle>
+          <DialogDescription>
+            {t("providerLogin.browserDescription")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-3 py-2 text-[13px] text-ink-muted">
+          <Loader2 className="size-4 animate-spin" aria-hidden />
+          <span>
+            {submitting
+              ? t("providerLogin.submitting")
+              : t("providerLogin.deviceWaiting")}
+          </span>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <label
+            htmlFor="provider-login-browser-code"
+            className="block text-[13px] text-ink-muted"
+          >
+            {t("providerLogin.browserCodeHint")}
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="provider-login-browser-code"
+              type="text"
+              autoComplete="off"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder={t("providerLogin.codePlaceholder")}
+              className="w-full rounded-md border bg-input px-3 py-2 text-[13px] font-mono focus:outline-none focus:ring-2 focus:ring-focus"
+              disabled={submitting}
+            />
+            <Button type="submit" disabled={submitting || !code.trim()}>
+              {t("providerLogin.submit")}
+            </Button>
+          </div>
+          {error && (
+            <p className="text-[12px] text-danger" role="alert">
+              {error}
+            </p>
+          )}
+        </form>
+
+        <DialogFooter className="items-center justify-between gap-2 sm:justify-between">
+          <Button
+            type="button"
+            variant="link"
+            size="sm"
+            className="h-auto gap-1.5 p-0 text-ink-muted"
+            onClick={() => void tauriSystem.openUrl(url)}
+          >
+            <ExternalLink className="size-3.5" />
+            {t("providerLogin.browserOpen")}
+          </Button>
+          <Button type="button" variant="outline" onClick={onClose}>
+            {t("providerLogin.cancel")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/shell/provider-login-browser-pending.tsx
+++ b/app/src/components/shell/provider-login-browser-pending.tsx
@@ -8,54 +8,104 @@ import {
   DialogTitle,
 } from "@houston-ai/core";
 import { ExternalLink, Loader2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { genericErrorDescription } from "../../lib/error-toast";
 import type { ProviderInfo } from "../../lib/providers";
 import { tauriSystem } from "../../lib/tauri";
 
 /**
- * Desktop Claude BROWSER login dialog: the native `claude auth login` already
- * opened the browser, so the primary state is a spinner ("approve in your
- * browser") with a "didn't open" fallback link. The approval page normally
- * hands its authorization code back to the CLI automatically; when it can't
- * (firewalls, strict browsers — common on Windows) it shows the user a code
- * instead, so the dialog always offers a visible paste field that relays the
- * code to the CLI's stdin via `onSubmitCode`. The dialog stays open after a
- * submit — completion (or failure) arrives via `claude-login://done`, which
- * unmounts it from the parent. Closing cancels the sign-in.
+ * Desktop Claude BROWSER login dialog. The happy path is fully seamless: the
+ * native `claude auth login` opened the browser, the approval page hands its
+ * authorization code straight back to the CLI, and this dialog is only a
+ * spinner ("approve in your browser") with a "didn't open" fallback link —
+ * no code UI anywhere.
+ *
+ * When the page-to-CLI hand-off is blocked (firewalls, strict browsers —
+ * HOU-839) the approval page shows the user a code instead. That case is
+ * recovered in stages, most seamless first:
+ *   1. Auto-finish: the user copies the code and switches back to Houston;
+ *      on refocus `onClipboardProbe` feeds a code-shaped clipboard string to
+ *      the CLI silently. Zero typing, zero code UI.
+ *   2. Only if the probe finds nothing does a small "Claude showed you a
+ *      code?" link appear; clicking it reveals a paste field (`onSubmitCode`).
+ * Completion always arrives via `claude-login://done`, which unmounts this
+ * dialog from the parent. Closing cancels the sign-in.
  */
 interface Props {
   provider: ProviderInfo;
   url: string;
+  onClipboardProbe: () => Promise<boolean>;
   onSubmitCode: (code: string) => Promise<void>;
   onClose: () => void;
 }
 
+/** Backstop reveal for users who never blur the window (e.g. the browser did
+ * not open): after this long the "Claude showed you a code?" link appears. */
+const REVEAL_FALLBACK_MS = 45_000;
+
+type Stage = "waiting" | "revealed" | "form" | "finishing";
+
 export function ProviderLoginBrowserPending({
   provider,
   url,
+  onClipboardProbe,
   onSubmitCode,
   onClose,
 }: Props) {
   const { t } = useTranslation("providers");
+  const [stage, setStage] = useState<Stage>("waiting");
   const [code, setCode] = useState("");
-  const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const wasAway = useRef(false);
+  const stageRef = useRef(stage);
+  stageRef.current = stage;
+
+  // Refocus after being away is the stuck-hand-off signature (a completed
+  // hand-off closes this dialog before the user returns): silently try to
+  // finish from a copied code; only when that finds nothing, surface the link.
+  useEffect(() => {
+    const onBlur = () => {
+      wasAway.current = true;
+    };
+    const onFocus = () => {
+      if (!wasAway.current || stageRef.current === "finishing") return;
+      wasAway.current = false;
+      void onClipboardProbe()
+        .catch(() => false)
+        .then((consumed) => {
+          if (consumed) {
+            setStage("finishing");
+          } else if (stageRef.current === "waiting") {
+            setStage("revealed");
+          }
+        });
+    };
+    window.addEventListener("blur", onBlur);
+    window.addEventListener("focus", onFocus);
+    const timer = setTimeout(() => {
+      if (stageRef.current === "waiting") setStage("revealed");
+    }, REVEAL_FALLBACK_MS);
+    return () => {
+      window.removeEventListener("blur", onBlur);
+      window.removeEventListener("focus", onFocus);
+      clearTimeout(timer);
+    };
+  }, [onClipboardProbe]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = code.trim();
     if (!trimmed) return;
-    setSubmitting(true);
     setError(null);
+    setStage("finishing");
     try {
       await onSubmitCode(trimmed);
-      // Keep the dialog open: the CLI now finishes its own exchange and the
-      // parent closes on `claude-login://done`.
+      // Stay open: the CLI finishes its own exchange and the parent closes on
+      // `claude-login://done`.
     } catch (err) {
       setError(genericErrorDescription("provider_login_submit_code", err));
-      setSubmitting(false);
+      setStage("form");
     }
   };
 
@@ -79,40 +129,54 @@ export function ProviderLoginBrowserPending({
         <div className="flex items-center gap-3 py-2 text-[13px] text-ink-muted">
           <Loader2 className="size-4 animate-spin" aria-hidden />
           <span>
-            {submitting
+            {stage === "finishing"
               ? t("providerLogin.submitting")
               : t("providerLogin.deviceWaiting")}
           </span>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-2">
-          <label
-            htmlFor="provider-login-browser-code"
-            className="block text-[13px] text-ink-muted"
+        {stage === "revealed" && (
+          <Button
+            type="button"
+            variant="link"
+            size="sm"
+            className="h-auto self-start p-0 text-ink-muted"
+            onClick={() => setStage("form")}
           >
-            {t("providerLogin.browserCodeHint")}
-          </label>
-          <div className="flex gap-2">
-            <input
-              id="provider-login-browser-code"
-              type="text"
-              autoComplete="off"
-              value={code}
-              onChange={(e) => setCode(e.target.value)}
-              placeholder={t("providerLogin.codePlaceholder")}
-              className="w-full rounded-md border bg-input px-3 py-2 text-[13px] font-mono focus:outline-none focus:ring-2 focus:ring-focus"
-              disabled={submitting}
-            />
-            <Button type="submit" disabled={submitting || !code.trim()}>
-              {t("providerLogin.submit")}
-            </Button>
-          </div>
-          {error && (
-            <p className="text-[12px] text-danger" role="alert">
-              {error}
-            </p>
-          )}
-        </form>
+            {t("providerLogin.browserCodeReveal")}
+          </Button>
+        )}
+
+        {stage === "form" && (
+          <form onSubmit={handleSubmit} className="space-y-2">
+            <label
+              htmlFor="provider-login-browser-code"
+              className="block text-[13px] text-ink-muted"
+            >
+              {t("providerLogin.browserCodeHint")}
+            </label>
+            <div className="flex gap-2">
+              <input
+                id="provider-login-browser-code"
+                type="text"
+                autoComplete="off"
+                autoFocus
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder={t("providerLogin.codePlaceholder")}
+                className="w-full rounded-md border bg-input px-3 py-2 text-[13px] font-mono focus:outline-none focus:ring-2 focus:ring-focus"
+              />
+              <Button type="submit" disabled={!code.trim()}>
+                {t("providerLogin.submit")}
+              </Button>
+            </div>
+            {error && (
+              <p className="text-[12px] text-danger" role="alert">
+                {error}
+              </p>
+            )}
+          </form>
+        )}
 
         <DialogFooter className="items-center justify-between gap-2 sm:justify-between">
           <Button

--- a/app/src/components/shell/provider-login-dialog.tsx
+++ b/app/src/components/shell/provider-login-dialog.tsx
@@ -7,7 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@houston-ai/core";
-import { Copy, ExternalLink, Eye, EyeOff, Loader2 } from "lucide-react";
+import { Copy, ExternalLink, Eye, EyeOff } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { genericErrorDescription } from "../../lib/error-toast";
@@ -41,6 +41,8 @@ import { providerLoginUrlHost } from "./provider-login-url";
  * Apart from the setup-token flow above, desktop opens the user's browser
  * directly for the co-located loopback flow (see `shouldOpenLoginUrlDirectly`),
  * so for those the dialog is a remote / headless-only affordance (issue #453).
+ * The desktop Claude BROWSER login has its own dialog with a code paste-back:
+ * see `ProviderLoginBrowserPending` (provider-login-browser-pending.tsx).
  */
 interface Props {
   provider: ProviderInfo | null;
@@ -53,13 +55,6 @@ interface Props {
    * demote the url to a small "Reference" link. Absent for other flows.
    */
   instructions?: string | null;
-  /**
-   * Desktop Claude BROWSER login: the native `claude auth login` already opened
-   * the browser and is catching its own callback, so there is nothing to paste.
-   * We show a spinner + "Approve Claude in your browser" and demote `url` to a
-   * "Didn't open? Open sign-in" fallback link. Closing cancels the sign-in.
-   */
-  browserPending?: boolean;
   onClose: () => void;
 }
 
@@ -68,7 +63,6 @@ export function ProviderLoginDialog({
   url,
   userCode,
   instructions,
-  browserPending,
   onClose,
 }: Props) {
   const { t } = useTranslation("providers");
@@ -100,49 +94,6 @@ export function ProviderLoginDialog({
   }, [provider, url]);
 
   if (!provider || !url) return null;
-
-  // Desktop Claude browser login: the native helper drives the whole flow and
-  // the app just waits. Spinner + a fallback link, no paste/device/URL controls.
-  if (browserPending) {
-    return (
-      <Dialog
-        open
-        onOpenChange={(open) => {
-          if (!open) onClose();
-        }}
-      >
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>
-              {t("providerLogin.title", { name: provider.name })}
-            </DialogTitle>
-            <DialogDescription>
-              {t("providerLogin.browserDescription")}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex items-center gap-3 py-2 text-[13px] text-ink-muted">
-            <Loader2 className="size-4 animate-spin" aria-hidden />
-            <span>{t("providerLogin.deviceWaiting")}</span>
-          </div>
-          <DialogFooter className="items-center justify-between gap-2 sm:justify-between">
-            <Button
-              type="button"
-              variant="link"
-              size="sm"
-              className="h-auto gap-1.5 p-0 text-ink-muted"
-              onClick={() => void tauriSystem.openUrl(url)}
-            >
-              <ExternalLink className="size-3.5" />
-              {t("providerLogin.browserOpen")}
-            </Button>
-            <Button type="button" variant="outline" onClick={onClose}>
-              {t("providerLogin.cancel")}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    );
-  }
 
   // Friendly destination shown in place of the raw URL. Null when the URL
   // isn't parseable; we then just omit the hint.

--- a/app/src/lib/claude-login.ts
+++ b/app/src/lib/claude-login.ts
@@ -43,8 +43,11 @@ import { tauriProvider } from "./tauri";
 /** Native event carrying the login result `{ success, error }`. */
 const CLAUDE_LOGIN_DONE_EVENT = "claude-login://done";
 
-/** Overall guard: the user may sit on the Claude consent screen for a while. */
-const LOGIN_TIMEOUT_MS = 5 * 60_000;
+/** Overall guard: the user may sit on the Claude consent screen for a while.
+ * Mirrors the native helper's `LOGIN_TIMEOUT` (claude_login/runner.rs) — kill
+ * the CLI early and its local listener dies, forcing the approval page onto
+ * its show-a-code fallback for late approvers (HOU-839). */
+const LOGIN_TIMEOUT_MS = 15 * 60_000;
 
 /** After `done: success`, how long to wait for the engine to read the fresh
  *  credential as connected (the /providers probe re-reads `claude auth status`). */

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -163,6 +163,16 @@ export function osSubmitClaudeLoginCode(code: string): Promise<void> {
   return invoke<void>("submit_claude_login_code", { code });
 }
 
+/** Opportunistically finish the in-flight Claude sign-in from the clipboard:
+ * the approval page's "Copy code" + returning to Houston is the stuck-hand-off
+ * signature, so the native side checks the clipboard for a code-shaped string
+ * and, when found, feeds it to the CLI. Resolves true when a code was consumed
+ * (completion still arrives via `claude-login://done`), false otherwise (no
+ * pending login / no matching clipboard text). Never rejects in practice. */
+export function osCompleteClaudeLoginFromClipboard(): Promise<boolean> {
+  return invoke<boolean>("complete_claude_login_from_clipboard");
+}
+
 /** Cancel an in-flight desktop Claude sign-in (kills the `claude` child). The
  * native side then emits `claude-login://done` with `error: null` (a benign
  * dismissal). No-op outside Tauri / when nothing is in flight. */

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -153,6 +153,16 @@ export function osReadClaudeCredential(): Promise<string> {
   return invoke<string>("read_claude_credential");
 }
 
+/** Relay a pasted authorization code to the in-flight desktop Claude sign-in.
+ * The claude.ai approval page shows a code when it cannot hand it to the CLI's
+ * local listener automatically (firewalls, strict browsers; common on Windows);
+ * the native side writes it to the `claude` child's stdin and the CLI finishes
+ * its own exchange — the outcome still arrives via `claude-login://done`.
+ * Rejects with the real reason when nothing is in flight or the write fails. */
+export function osSubmitClaudeLoginCode(code: string): Promise<void> {
+  return invoke<void>("submit_claude_login_code", { code });
+}
+
 /** Cancel an in-flight desktop Claude sign-in (kills the `claude` child). The
  * native side then emits `claude-login://done` with `error: null` (a benign
  * dismissal). No-op outside Tauri / when nothing is in flight. */

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -54,6 +54,7 @@
     "deviceSettingsOpenFailed": "Couldn't open ChatGPT settings",
     "cancel": "Cancel",
     "browserDescription": "Approve Houston in the browser tab that just opened. This window updates on its own when you finish.",
+    "browserCodeHint": "If Claude shows you a code after you approve, paste it here to finish.",
     "browserOpen": "Didn't open? Open sign-in"
   },
   "apiKey": {

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -54,6 +54,7 @@
     "deviceSettingsOpenFailed": "Couldn't open ChatGPT settings",
     "cancel": "Cancel",
     "browserDescription": "Approve Houston in the browser tab that just opened. This window updates on its own when you finish.",
+    "browserCodeCopyHint": "If the Claude page shows you a code, copy it and come back here. Sign-in will finish on its own.",
     "browserCodeReveal": "Claude showed you a code?",
     "browserCodeHint": "If Claude shows you a code after you approve, paste it here to finish.",
     "browserOpen": "Didn't open? Open sign-in"

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -54,6 +54,7 @@
     "deviceSettingsOpenFailed": "Couldn't open ChatGPT settings",
     "cancel": "Cancel",
     "browserDescription": "Approve Houston in the browser tab that just opened. This window updates on its own when you finish.",
+    "browserCodeReveal": "Claude showed you a code?",
     "browserCodeHint": "If Claude shows you a code after you approve, paste it here to finish.",
     "browserOpen": "Didn't open? Open sign-in"
   },

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -54,6 +54,7 @@
     "deviceSettingsOpenFailed": "No se pudo abrir la configuración de ChatGPT",
     "cancel": "Cancelar",
     "browserDescription": "Aprueba Houston en la pestaña del navegador que se abrió. Esta ventana se actualiza sola cuando termines.",
+    "browserCodeCopyHint": "Si la página de Claude te muestra un código, cópialo y vuelve aquí. El inicio de sesión terminará solo.",
     "browserCodeReveal": "¿Claude te mostró un código?",
     "browserCodeHint": "Si Claude te muestra un código después de aprobar, pégalo aquí para terminar.",
     "browserOpen": "¿No se abrió? Abrir inicio de sesión"

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -54,6 +54,7 @@
     "deviceSettingsOpenFailed": "No se pudo abrir la configuración de ChatGPT",
     "cancel": "Cancelar",
     "browserDescription": "Aprueba Houston en la pestaña del navegador que se abrió. Esta ventana se actualiza sola cuando termines.",
+    "browserCodeHint": "Si Claude te muestra un código después de aprobar, pégalo aquí para terminar.",
     "browserOpen": "¿No se abrió? Abrir inicio de sesión"
   },
   "apiKey": {

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -54,6 +54,7 @@
     "deviceSettingsOpenFailed": "No se pudo abrir la configuración de ChatGPT",
     "cancel": "Cancelar",
     "browserDescription": "Aprueba Houston en la pestaña del navegador que se abrió. Esta ventana se actualiza sola cuando termines.",
+    "browserCodeReveal": "¿Claude te mostró un código?",
     "browserCodeHint": "Si Claude te muestra un código después de aprobar, pégalo aquí para terminar.",
     "browserOpen": "¿No se abrió? Abrir inicio de sesión"
   },

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -54,6 +54,7 @@
     "deviceSettingsOpenFailed": "Não foi possível abrir as configurações do ChatGPT",
     "cancel": "Cancelar",
     "browserDescription": "Aprove o Houston na aba do navegador que abriu. Esta janela é atualizada sozinha quando você terminar.",
+    "browserCodeCopyHint": "Se a página do Claude mostrar um código, copie-o e volte aqui. O login será concluído sozinho.",
     "browserCodeReveal": "O Claude mostrou um código?",
     "browserCodeHint": "Se o Claude mostrar um código depois de aprovar, cole-o aqui para concluir.",
     "browserOpen": "Não abriu? Abrir login"

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -54,6 +54,7 @@
     "deviceSettingsOpenFailed": "Não foi possível abrir as configurações do ChatGPT",
     "cancel": "Cancelar",
     "browserDescription": "Aprove o Houston na aba do navegador que abriu. Esta janela é atualizada sozinha quando você terminar.",
+    "browserCodeHint": "Se o Claude mostrar um código depois de aprovar, cole-o aqui para concluir.",
     "browserOpen": "Não abriu? Abrir login"
   },
   "apiKey": {

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -54,6 +54,7 @@
     "deviceSettingsOpenFailed": "Não foi possível abrir as configurações do ChatGPT",
     "cancel": "Cancelar",
     "browserDescription": "Aprove o Houston na aba do navegador que abriu. Esta janela é atualizada sozinha quando você terminar.",
+    "browserCodeReveal": "O Claude mostrou um código?",
     "browserCodeHint": "Se o Claude mostrar um código depois de aprovar, cole-o aqui para concluir.",
     "browserOpen": "Não abriu? Abrir login"
   },

--- a/knowledge-base/anthropic-credentials.md
+++ b/knowledge-base/anthropic-credentials.md
@@ -20,9 +20,18 @@ the traps at the bottom — read them before touching any of this.
 
 - **Desktop browser login** (`app/src-tauri/src/claude_login/`): spawns
   `claude auth login --claudeai` with `CLAUDE_CONFIG_DIR` pinned to the shared
-  login dir. The CLI opens the browser, catches its own loopback callback, and
-  caches the credential itself. There is NO deep link back to the app — the app
-  just watches the CLI's stdout/exit.
+  login dir and PIPED stdin. The CLI opens the browser and authorizes with
+  `code=true` (redirect aimed at platform.claude.com — no localhost redirect):
+  after the user approves, that callback page hands the authorization code to
+  the CLI's random-port local listener automatically (the seamless path) OR,
+  when that hand-off is blocked (firewalls, strict browsers; the common case on
+  Windows — HOU-839), shows the user a code. The sign-in dialog always offers a
+  paste field that relays such a code to the CLI's stdin
+  (`submit_claude_login_code` → the CLI's `Paste code here if prompted >`
+  readline). Either way the CLI caches the credential itself; there is NO deep
+  link back to the app — the app watches the CLI's stdout/exit. The `visit:`
+  URL line is OSC-8 hyperlink-wrapped by current CLIs; `resolve.rs` strips that
+  before parsing.
 - **Remote/cloud handoff** (`app/src/lib/claude-login-remote.ts`): after the
   local login, `read_claude_credential` (Rust) extracts the cached credential —
   file first, then the Keychain item `Claude Code-credentials-<sha256(dir)[:8]>`

--- a/knowledge-base/anthropic-credentials.md
+++ b/knowledge-base/anthropic-credentials.md
@@ -25,8 +25,11 @@ the traps at the bottom — read them before touching any of this.
   after the user approves, that callback page hands the authorization code to
   the CLI's random-port local listener automatically (the seamless path) OR,
   when that hand-off is blocked (firewalls, strict browsers; the common case on
-  Windows — HOU-839), shows the user a code. The sign-in dialog always offers a
-  paste field that relays such a code to the CLI's stdin
+  Windows — HOU-839), shows the user a code. That case recovers in stages so
+  the happy path stays code-free: on app refocus a clipboard probe
+  (`complete_claude_login_from_clipboard`) silently feeds a copied code-shaped
+  string to the CLI's stdin; only when that finds nothing does the dialog
+  surface a "Claude showed you a code?" link revealing a paste field
   (`submit_claude_login_code` → the CLI's `Paste code here if prompted >`
   readline). Either way the CLI caches the credential itself; there is NO deep
   link back to the app — the app watches the CLI's stdout/exit. The `visit:`

--- a/packages/web/src/shims/tauri-core.ts
+++ b/packages/web/src/shims/tauri-core.ts
@@ -213,6 +213,7 @@ export async function invoke<T = unknown>(
     case "start_claude_login": // desktop runs `claude auth login`; web uses the setup-token paste flow
     case "cancel_claude_login": // desktop-only sign-in helper; no web counterpart
     case "submit_claude_login_code": // relays a pasted code to the desktop `claude` child's stdin
+    case "complete_claude_login_from_clipboard": // desktop clipboard probe for the sign-in auto-finish
     case "read_claude_credential": // reads this machine's Keychain/cred file; web has neither
 
     case "get_engine_handshake": // web injects window.__HOUSTON_ENGINE__ directly

--- a/packages/web/src/shims/tauri-core.ts
+++ b/packages/web/src/shims/tauri-core.ts
@@ -212,6 +212,7 @@ export async function invoke<T = unknown>(
     case "start_codex_oauth_loopback": // desktop relays the Codex 1455 callback; web stays on device-code
     case "start_claude_login": // desktop runs `claude auth login`; web uses the setup-token paste flow
     case "cancel_claude_login": // desktop-only sign-in helper; no web counterpart
+    case "submit_claude_login_code": // relays a pasted code to the desktop `claude` child's stdin
     case "read_claude_credential": // reads this machine's Keychain/cred file; web has neither
 
     case "get_engine_handshake": // web injects window.__HOUSTON_ENGINE__ directly


### PR DESCRIPTION
Fixes HOU-839.

## Root cause

Anthropic's updated Claude CLI login flow (including the pinned CLI 2.1.201 we bundle via `@anthropic-ai/claude-agent-sdk@0.3.201`) authorizes with `code=true` and `redirect_uri=https://platform.claude.com/oauth/code/callback`. There is no localhost redirect anymore: after the user approves on claude.ai, the platform.claude.com callback page tries to hand the authorization code to the CLI's random-port local listener automatically. When that hand-off works, sign-in is seamless. When it is blocked (browser local-network protections, ad-blocker LAN filter lists, third-party AV firewalls — disproportionately Windows 10/11 — or the listener already torn down by our old 5-minute timeout), the page shows the user a code and the CLI waits on `Paste code here if prompted >`.

Houston spawned `claude auth login --claudeai` with **null stdin** and a wait-only dialog, so those users saw a code in the browser with nowhere to enter it. The sign-in spun until timeout. The CLI never errors in this state, which is why Sentry showed nothing.

A second, related break: current CLIs wrap the `visit:` authorize URL in OSC 8 hyperlink escape sequences even when stdout is a pipe, which made `extract_visit_url` miss, so the fallback sign-in dialog could fail to appear at all.

## The fix — staged recovery, code-free unless the hand-off already failed

The normal flow is untouched and fully seamless: approve in the browser, done. The dialog shows only the waiting spinner — no code UI. Recovery from a blocked hand-off happens in stages, most seamless first:

1. **Auto-finish from the clipboard.** The approval page tells a stuck user to copy the code. When Houston regains focus while the sign-in is still pending (the stuck-hand-off signature — a successful hand-off closes the dialog before the user returns), a native probe (`complete_claude_login_from_clipboard`, arboard) checks the clipboard for a code-shaped string (`code#state`, base64url charset, 32+ char state — ordinary clipboard content can never match; contents are never logged) and feeds it to the CLI's now-piped stdin. Zero typing, zero code UI.
2. **Last-resort link.** Only when the probe finds nothing does a small "Claude showed you a code?" link appear (also after 45s as a backstop); clicking it reveals a paste field wired to `submit_claude_login_code`. Without this, a user whose browser blocks localhost delivery can never connect at all.
3. **Longer listener window.** Login timeout extended 5 → 15 minutes on both the Rust and TS sides: killing the CLI early destroys its local listener, which *forces* the code page for anyone who approves late.

Also: `extract_visit_url` strips OSC 8 wrapping (tests use the exact line captured from CLI 2.1.201), and the browser-pending dialog is extracted to `provider-login-browser-pending.tsx`. The CLI still performs its own token exchange and caches the credential, so the rest of the lifecycle (Keychain read, remote pod push) is unchanged.

## Tests

- `cargo test` (app/src-tauri): all pass, including an end-to-end test where a fake `claude` prints the real visit line, waits on stdin, and exits 0 only when the relayed code arrives; plus code-shape validator tests (junk clipboard content never matches) and OSC 8 parse tests.
- `pnpm check`, app `tsgo --noEmit`, `pnpm check-locales` (en/es/pt), web typecheck + Tauri shim parity: all green.

## Repro (before the fix)

1. On a machine where the browser cannot deliver to localhost (e.g. uBlock Origin with the "Block Outsider Intrusion into LAN" list, or a third-party firewall filtering loopback), Houston → AI Models → Anthropic → Connect.
2. Approve in the claude.ai tab; the page displays a code. Houston only shows "Waiting for you to authorize in your browser..." — dead end, times out.

## Verify (after the fix)

1. Clean machine: Connect → approve → dialog closes, card flips to connected. No code UI ever appears (unchanged seamless path).
2. Blocked machine: Connect → approve → page shows a code → click its Copy button → switch back to Houston → sign-in completes automatically, still no code UI.
3. Blocked machine, nothing copied: a "Claude showed you a code?" link appears; clicking reveals the paste field; pasting the code completes the sign-in.
4. Slow approval (up to 15 min) now still completes automatically instead of forcing the code page.