### PR TITLE
fix(teams): resume abandoned agent moves so a wedged move can't brick the agent (HOU-817)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -22,6 +22,7 @@ import { useHoustonInit } from "./hooks/use-houston-init";
 import { useIntegrationSessionSync } from "./hooks/use-integration-session-sync";
 import { useLocalBridgeAutoReconnect } from "./hooks/use-local-bridge-autoreconnect";
 import { useMigrationReconnect } from "./hooks/use-migration-reconnect";
+import { useMoveResume } from "./hooks/use-move-resume";
 import { useOnboardingCompleted } from "./hooks/use-onboarding-completed";
 import { useOnboardingPending } from "./hooks/use-onboarding-pending";
 import { useOnboardingSegment } from "./hooks/use-onboarding-segment";
@@ -113,6 +114,11 @@ export default function App() {
   // is still active, quietly re-establish frpc (dead after a restart). Gated on a
   // signed-in session — the reconnect mints hosted tunnel credentials.
   useLocalBridgeAutoReconnect(Boolean(session));
+
+  // Re-drive any share-via-team agent move whose driver vanished mid-move
+  // (HOU-817): the gateway keeps the agent locked until the move finishes.
+  // Gated on a signed-in session — every move call is authenticated.
+  useMoveResume(Boolean(session));
 
   // Tag the user in PostHog AND Sentry on sign-in; reset on sign-out. The
   // install_id stays PostHog's distinct_id (the website UTM bridge + onboarding

--- a/app/src/components/tabs/share-via-team-flow.tsx
+++ b/app/src/components/tabs/share-via-team-flow.tsx
@@ -14,6 +14,12 @@ import {
 } from "../../hooks/queries";
 import { useCreateTeam } from "../../hooks/queries/use-orgs";
 import {
+  claimMove,
+  clearPendingMove,
+  recordPendingMove,
+  releaseMove,
+} from "../../lib/pending-move";
+import {
   addInviteEmails,
   applyMovePoll,
   assertInviteReady,
@@ -94,19 +100,28 @@ export function ShareViaTeamFlow({
   );
   const polled = moveStatus.data;
 
-  // Reset when the dialog closes so a reopen always starts clean.
+  // Reset when the dialog closes so a reopen always starts clean. Also release
+  // the pending-move claim: the record itself stays until the move reaches
+  // `done`, so an abandoned move is resumed by `useMoveResume` on next boot
+  // (HOU-817) instead of leaving the agent locked behind the gateway's
+  // "agent is being moved" guard forever.
   useEffect(() => {
     if (!open) {
       setState(initialState());
       setSending(false);
+      releaseMove(agent.id);
     }
-  }, [open]);
+  }, [open, agent.id]);
+  useEffect(() => () => releaseMove(agent.id), [agent.id]);
 
   // Fold each move-status poll into the machine (moving -> switching | failed).
+  // Terminal `done` retires the durable pending-move record — the ONLY event
+  // that does; every other exit leaves it for the boot-time resume.
   useEffect(() => {
     if (!polled) return;
+    if (polled.status === "done") clearPendingMove(agent.id);
     setState((s) => applyMovePoll(s, polled));
-  }, [polled]);
+  }, [polled, agent.id]);
 
   // Wall-clock ceiling on the non-dismissable `moving` step: without it a gateway
   // move that never reaches done/failed strands the user on an un-closable
@@ -172,11 +187,24 @@ export function ShareViaTeamFlow({
   const handleMove = async () => {
     if (state.step !== "confirm" && state.step !== "moveFailed") return;
     const toSlug = state.team.slug;
+    const teamName = state.team.name;
     try {
       const { moveId: id } = await moveAgent.mutateAsync({
         agentSlugOrId: agent.id,
         toSlug,
       });
+      // Persist the accepted move BEFORE polling: from here on the gateway
+      // holds a durable lock only a completed move releases, so the ticket
+      // must survive a closed dialog or app quit for `useMoveResume`.
+      recordPendingMove({
+        agentId: agent.id,
+        agentName: agent.name,
+        teamSlug: toSlug,
+        teamName,
+        moveId: id,
+        startedAt: Date.now(),
+      });
+      claimMove(agent.id);
       setState((s) => startMove(s, id));
     } catch (err) {
       setState((s) => moveRejected(s, shareErrorCode(err)));

--- a/app/src/hooks/use-move-resume.ts
+++ b/app/src/hooks/use-move-resume.ts
@@ -1,0 +1,125 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { getEngine, newEngineActive } from "../lib/engine";
+import { resumePendingMove } from "../lib/move-resume";
+import {
+  claimMove,
+  clearPendingMove,
+  readPendingMoves,
+  releaseMove,
+  updatePendingMoveId,
+} from "../lib/pending-move";
+import { queryKeys } from "../lib/query-keys";
+import { isExpectedShareError, shareErrorCode } from "../lib/share-via-team";
+import { tauriOrg } from "../lib/tauri";
+import { useAgentStore } from "../stores/agents";
+import { useUIStore } from "../stores/ui";
+import { useWorkspaceStore } from "../stores/workspaces";
+
+/**
+ * Boot-time healer for abandoned C8 agent moves (HOU-817).
+ *
+ * A move whose driver vanished (dialog closed, app quit, poll timed out)
+ * leaves the gateway's durable lock in place, and a locked agent cannot wake:
+ * every request answers 503 "agent is being moved", which reads as a fully
+ * broken app. On each boot of a spaces-capable host this re-drives every
+ * persisted pending move to terminal: poll the recorded ticket, re-POST to
+ * stale-adopt when it reads failed, and clear the record only on `done`.
+ * Success and failure both toast — a silently healed (or still-stuck) agent
+ * would hide what happened to it.
+ *
+ * `enabled` MUST be the signed-in state: the capabilities probe (and every
+ * move call) is authenticated on hosted deployments, so firing it on the
+ * sign-in screen would only produce 401 noise.
+ */
+export function useMoveResume(enabled: boolean): void {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation("teams");
+  const ranRef = useRef(false);
+
+  // A record can only have been written by a spaces-capable host, so with no
+  // records this observes nothing and fetches nothing. The shared query key
+  // means the shell's own `useCapabilities` consumers dedupe against this.
+  const hasPending = readPendingMoves().length > 0;
+  const capsQuery = useQuery({
+    queryKey: queryKeys.capabilities(),
+    queryFn: () => getEngine().capabilities(),
+    enabled: enabled && hasPending && newEngineActive(),
+    staleTime: Number.POSITIVE_INFINITY,
+    retry: 3,
+  });
+  const spaces = capsQuery.data?.spaces === true;
+
+  useEffect(() => {
+    if (!spaces || ranRef.current) return;
+    if (readPendingMoves().length === 0) return;
+    ranRef.current = true;
+
+    const addToast = useUIStore.getState().addToast;
+    void (async () => {
+      for (const pending of readPendingMoves()) {
+        if (!claimMove(pending.agentId)) continue; // a dialog is driving it
+        try {
+          // `toast: false` on both wire calls: transient poll blips are
+          // retried (a red toast per blip would spam boot), and a terminal
+          // failure gets ONE `moveResume.failed` toast below. Unexpected
+          // errors are still logged + captured to Sentry; only the expected
+          // C8 business states (incl. `move_in_progress`, a normal resume
+          // answer when a fresh move owns the agent) skip capture too.
+          const result = await resumePendingMove(pending, {
+            moveStatus: (agentId, moveId) =>
+              tauriOrg.moveStatus(agentId, moveId, { toast: false }),
+            moveAgent: (agentId, toSlug) =>
+              tauriOrg.moveAgent(agentId, toSlug, {
+                toast: false,
+                silence: (err) =>
+                  isExpectedShareError(err) ||
+                  shareErrorCode(err) === "move_in_progress",
+              }),
+          });
+          if (result.outcome === "done") {
+            clearPendingMove(pending.agentId);
+            addToast({
+              title: t("moveResume.done", {
+                agent: pending.agentName,
+                team: pending.teamName,
+              }),
+              variant: "success",
+            });
+            // The agent changed spaces: refresh the switcher, the team list,
+            // and the active workspace's sidebar.
+            await useWorkspaceStore.getState().loadWorkspaces();
+            await queryClient.invalidateQueries({
+              queryKey: queryKeys.orgs(),
+            });
+            const current = useWorkspaceStore.getState().current;
+            if (current) {
+              await useAgentStore
+                .getState()
+                .loadAgents(current.id, { silent: true });
+            }
+          } else if (result.outcome === "inProgress") {
+            // A live move already owns the agent (another window or a fresh
+            // dialog is driving it) — leave the record; its driver settles it.
+          } else {
+            // Keep the record: the lock is still held and only a finished move
+            // frees the agent, so the next boot tries again.
+            if ("moveId" in result && result.moveId) {
+              updatePendingMoveId(pending.agentId, result.moveId);
+            }
+            addToast({
+              title: t("moveResume.failed", {
+                agent: pending.agentName,
+                team: pending.teamName,
+              }),
+              variant: "error",
+            });
+          }
+        } finally {
+          releaseMove(pending.agentId);
+        }
+      }
+    })();
+  }, [spaces, queryClient, t]);
+}

--- a/app/src/lib/move-resume.ts
+++ b/app/src/lib/move-resume.ts
@@ -1,0 +1,121 @@
+import type {
+  AgentMoveStart,
+  AgentMoveStatus,
+} from "@houston-ai/engine-client";
+import type { PendingAgentMove } from "./pending-move";
+import { MOVE_POLL_TIMEOUT_MS, shareErrorCode } from "./share-via-team.ts";
+
+/**
+ * Pure resume algorithm for an abandoned C8 agent move (HOU-817). Wire calls
+ * and sleep are injected so every path unit-tests under bare Node.
+ *
+ * The gateway contract this rests on: a failed/crashed move leaves its durable
+ * lock, the locked agent cannot wake (every request 503s "agent is being
+ * moved"), and a re-POST of the same move stale-adopts the lock and resumes
+ * the relocation. So the ONLY way back to a usable agent is to finish the
+ * move: poll the recorded ticket first (the server may still be on it, or may
+ * have quietly succeeded), and only re-POST when that ticket reads terminal
+ * `failed` (which also covers "move not found" after gateway retention).
+ */
+
+export interface MoveWire {
+  moveStatus(agentId: string, moveId: string): Promise<AgentMoveStatus>;
+  moveAgent(agentId: string, toSlug: string): Promise<AgentMoveStart>;
+}
+
+export type ResumeOutcome =
+  /** The move reached terminal `done` — the record must be cleared. */
+  | { outcome: "done" }
+  /** The move reached terminal `failed` again. Keep the record for next boot. */
+  | { outcome: "failed"; error?: string; moveId?: string }
+  /** A fresh move already owns the agent (another driver). Keep the record. */
+  | { outcome: "inProgress" }
+  /** The re-POST was rejected (roles/target changed, gateway down). Keep. */
+  | { outcome: "rejected"; code?: string }
+  /** Still `moving` when the budget ran out. Keep the record. */
+  | { outcome: "timeout"; moveId?: string };
+
+export interface ResumeOptions {
+  pollIntervalMs?: number;
+  budgetMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** Resume one pending move to a terminal outcome. Never throws. */
+export async function resumePendingMove(
+  pending: PendingAgentMove,
+  wire: MoveWire,
+  options: ResumeOptions = {},
+): Promise<ResumeOutcome> {
+  const pollIntervalMs = options.pollIntervalMs ?? 1_500;
+  const budgetMs = options.budgetMs ?? MOVE_POLL_TIMEOUT_MS;
+  const sleep = options.sleep ?? defaultSleep;
+  const deadline = Date.now() + budgetMs;
+
+  // Phase 1: the recorded ticket. `done` means the server finished after the
+  // client vanished — nothing to redo. `moving` means it is still running.
+  let status: AgentMoveStatus;
+  try {
+    status = await wire.moveStatus(pending.agentId, pending.moveId);
+  } catch (err) {
+    return { outcome: "rejected", code: shareErrorCode(err) };
+  }
+  if (status.status === "moving") {
+    const settled = await pollToTerminal(
+      pending.agentId,
+      pending.moveId,
+      wire,
+      { pollIntervalMs, deadline, sleep },
+    );
+    if (settled === null) return { outcome: "timeout" };
+    status = settled;
+  }
+  if (status.status === "done") return { outcome: "done" };
+
+  // Phase 2: terminal `failed` (or an unknown ticket reading as failed) — the
+  // lock is still held, so re-POST to stale-adopt and resume the relocation.
+  let start: AgentMoveStart;
+  try {
+    start = await wire.moveAgent(pending.agentId, pending.teamSlug);
+  } catch (err) {
+    const code = shareErrorCode(err);
+    return code === "move_in_progress"
+      ? { outcome: "inProgress" }
+      : { outcome: "rejected", code };
+  }
+  const settled = await pollToTerminal(pending.agentId, start.moveId, wire, {
+    pollIntervalMs,
+    deadline,
+    sleep,
+  });
+  if (settled === null) return { outcome: "timeout", moveId: start.moveId };
+  if (settled.status === "done") return { outcome: "done" };
+  return { outcome: "failed", error: settled.error, moveId: start.moveId };
+}
+
+/** Poll one ticket until `done`/`failed`, or `null` when the deadline passes. */
+async function pollToTerminal(
+  agentId: string,
+  moveId: string,
+  wire: MoveWire,
+  opts: {
+    pollIntervalMs: number;
+    deadline: number;
+    sleep: (ms: number) => Promise<void>;
+  },
+): Promise<AgentMoveStatus | null> {
+  while (Date.now() < opts.deadline) {
+    await opts.sleep(opts.pollIntervalMs);
+    let status: AgentMoveStatus;
+    try {
+      status = await wire.moveStatus(agentId, moveId);
+    } catch {
+      continue; // transient poll blip; the deadline bounds the retries
+    }
+    if (status.status !== "moving") return status;
+  }
+  return null;
+}

--- a/app/src/lib/pending-move.ts
+++ b/app/src/lib/pending-move.ts
@@ -1,0 +1,124 @@
+/**
+ * Durable record of an in-flight C8 agent move (share-via-team).
+ *
+ * The gateway's move lock is deliberately left in place when a move fails or
+ * its mover crashes: only a re-POST of the same move can adopt and resume it,
+ * and while the lock exists the control plane refuses to wake the agent, so
+ * every agent request answers 503 "agent is being moved". The share dialog
+ * used to hold the move only in React state, so closing it (or quitting the
+ * app) abandoned the move with no way back and the agent stayed unusable
+ * (HOU-817). Persisting the (agent, team, moveId) triple here lets
+ * `useMoveResume` re-POST and finish the move on the next boot.
+ *
+ * Pure + DOM-free (storage injected) so it unit-tests under bare Node.
+ */
+
+export interface PendingAgentMove {
+  /** The moved agent's id/slug, as passed to `POST /v1/agents/:slug/move`. */
+  agentId: string;
+  /** Display name for the resume toasts. */
+  agentName: string;
+  /** Target team space (16-hex slug), the `to` of the re-POST. */
+  teamSlug: string;
+  teamName: string;
+  /** The last known move ticket; a resume polls it before re-POSTing. */
+  moveId: string;
+  /** Epoch ms when the move was accepted. */
+  startedAt: number;
+}
+
+const STORAGE_KEY = "houston.pendingAgentMoves";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+function defaultStorage(): StorageLike | null {
+  return typeof localStorage === "undefined" ? null : localStorage;
+}
+
+function isPendingMove(v: unknown): v is PendingAgentMove {
+  const m = v as PendingAgentMove | null;
+  return (
+    typeof m?.agentId === "string" &&
+    typeof m.agentName === "string" &&
+    typeof m.teamSlug === "string" &&
+    typeof m.teamName === "string" &&
+    typeof m.moveId === "string" &&
+    typeof m.startedAt === "number"
+  );
+}
+
+/** Every persisted pending move. Tolerant: unreadable state reads as none. */
+export function readPendingMoves(
+  storage: StorageLike | null = defaultStorage(),
+): PendingAgentMove[] {
+  const raw = storage?.getItem(STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter(isPendingMove) : [];
+  } catch {
+    return [];
+  }
+}
+
+function write(moves: PendingAgentMove[], storage: StorageLike | null): void {
+  if (!storage) return;
+  if (moves.length === 0) storage.removeItem(STORAGE_KEY);
+  else storage.setItem(STORAGE_KEY, JSON.stringify(moves));
+}
+
+/** Upsert the pending move for its agent (one in-flight move per agent). */
+export function recordPendingMove(
+  move: PendingAgentMove,
+  storage: StorageLike | null = defaultStorage(),
+): void {
+  const rest = readPendingMoves(storage).filter(
+    (m) => m.agentId !== move.agentId,
+  );
+  write([...rest, move], storage);
+}
+
+/** Re-key an adopted move to its new ticket so the next poll targets it. */
+export function updatePendingMoveId(
+  agentId: string,
+  moveId: string,
+  storage: StorageLike | null = defaultStorage(),
+): void {
+  write(
+    readPendingMoves(storage).map((m) =>
+      m.agentId === agentId ? { ...m, moveId } : m,
+    ),
+    storage,
+  );
+}
+
+/** Drop the record — call ONLY when the move reached terminal `done`. */
+export function clearPendingMove(
+  agentId: string,
+  storage: StorageLike | null = defaultStorage(),
+): void {
+  write(
+    readPendingMoves(storage).filter((m) => m.agentId !== agentId),
+    storage,
+  );
+}
+
+// In-memory claims: whichever surface is actively driving a move (the share
+// dialog's poll, or the boot resume) claims the agent so the other leaves it
+// alone. Deliberately NOT persisted — a crash must release every claim.
+const activeClaims = new Set<string>();
+
+/** Mark a move as actively driven. Returns false if already claimed. */
+export function claimMove(agentId: string): boolean {
+  if (activeClaims.has(agentId)) return false;
+  activeClaims.add(agentId);
+  return true;
+}
+
+export function releaseMove(agentId: string): void {
+  activeClaims.delete(agentId);
+}
+
+export function isMoveClaimed(agentId: string): boolean {
+  return activeClaims.has(agentId);
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1682,9 +1682,16 @@ export const tauriOrg = {
       options,
     ),
   /** C8 spaces: poll one agent-move's progress. */
-  moveStatus: (agentSlugOrId: string, moveId: string) =>
-    call("agent_move_status", () =>
-      getEngine().getMoveStatus(agentSlugOrId, moveId),
+  moveStatus: (
+    agentSlugOrId: string,
+    moveId: string,
+    options?: EngineCallOptions,
+  ) =>
+    call(
+      "agent_move_status",
+      () => getEngine().getMoveStatus(agentSlugOrId, moveId),
+      undefined,
+      options,
     ),
   /** C8 billing: the active team's billing summary (owner/admin, team space).
    *  Degrades to null off-entitlement so the billing UI renders nothing. */

--- a/app/src/locales/en/teams.json
+++ b/app/src/locales/en/teams.json
@@ -338,6 +338,10 @@
       "heading": "Shared with {{team}}"
     }
   },
+  "moveResume": {
+    "done": "{{agent}} finished moving to {{team}}.",
+    "failed": "{{agent}} could not finish moving to {{team}}. Houston will try again the next time it starts."
+  },
   "billing": {
     "unavailable": "We couldn't load billing for this team.",
     "status": {

--- a/app/src/locales/es/teams.json
+++ b/app/src/locales/es/teams.json
@@ -338,6 +338,10 @@
       "heading": "Compartido con {{team}}"
     }
   },
+  "moveResume": {
+    "done": "{{agent}} terminó de moverse a {{team}}.",
+    "failed": "{{agent}} no pudo terminar de moverse a {{team}}. Houston lo intentará de nuevo la próxima vez que inicie."
+  },
   "billing": {
     "unavailable": "No pudimos cargar la facturación de este equipo.",
     "status": {

--- a/app/src/locales/pt/teams.json
+++ b/app/src/locales/pt/teams.json
@@ -338,6 +338,10 @@
       "heading": "Compartilhado com {{team}}"
     }
   },
+  "moveResume": {
+    "done": "{{agent}} terminou de ser movido para {{team}}.",
+    "failed": "{{agent}} não conseguiu terminar de ser movido para {{team}}. O Houston vai tentar de novo na próxima vez que abrir."
+  },
   "billing": {
     "unavailable": "Não foi possível carregar a cobrança desta equipe.",
     "status": {

--- a/app/tests/move-resume.test.ts
+++ b/app/tests/move-resume.test.ts
@@ -1,0 +1,165 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { AgentMoveStatus } from "@houston-ai/engine-client";
+import { type MoveWire, resumePendingMove } from "../src/lib/move-resume.ts";
+import type { PendingAgentMove } from "../src/lib/pending-move.ts";
+
+const PENDING: PendingAgentMove = {
+  agentId: "7af3d710003ad396",
+  agentName: "Nova",
+  teamSlug: "abcdef0123456789",
+  teamName: "Acme",
+  moveId: "op-old",
+  startedAt: 1_000,
+};
+
+const instant = { pollIntervalMs: 1, sleep: async () => {} };
+
+/** A wire whose statuses play back per moveId; moveAgent yields `op-new`. */
+function wire(over: {
+  statuses: Record<string, AgentMoveStatus[]>;
+  moveAgent?: MoveWire["moveAgent"];
+}): MoveWire & { posts: string[] } {
+  const posts: string[] = [];
+  return {
+    posts,
+    moveStatus: async (_agent, moveId) => {
+      const queue = over.statuses[moveId];
+      if (!queue || queue.length === 0)
+        throw new Error(`unexpected poll of ${moveId}`);
+      return queue.length > 1 ? (queue.shift() as AgentMoveStatus) : queue[0];
+    },
+    moveAgent:
+      over.moveAgent ??
+      (async (_agent, toSlug) => {
+        posts.push(toSlug);
+        return { moveId: "op-new" };
+      }),
+  };
+}
+
+describe("resumePendingMove", () => {
+  it("recognizes a move that quietly succeeded: done, no re-POST", async () => {
+    const w = wire({ statuses: { "op-old": [{ status: "done" }] } });
+    deepStrictEqual(await resumePendingMove(PENDING, w, instant), {
+      outcome: "done",
+    });
+    deepStrictEqual(w.posts, []);
+  });
+
+  it("waits out a still-running move to its terminal state", async () => {
+    const w = wire({
+      statuses: {
+        "op-old": [
+          { status: "moving" },
+          { status: "moving" },
+          { status: "done" },
+        ],
+      },
+    });
+    deepStrictEqual(await resumePendingMove(PENDING, w, instant), {
+      outcome: "done",
+    });
+    deepStrictEqual(w.posts, []);
+  });
+
+  it("re-POSTs a failed move and follows the adopted ticket to done", async () => {
+    const w = wire({
+      statuses: {
+        "op-old": [{ status: "failed", error: "pod evicted" }],
+        "op-new": [{ status: "moving" }, { status: "done" }],
+      },
+    });
+    deepStrictEqual(await resumePendingMove(PENDING, w, instant), {
+      outcome: "done",
+    });
+    deepStrictEqual(w.posts, ["abcdef0123456789"]);
+  });
+
+  it("surfaces a re-failed resume with the new ticket for re-keying", async () => {
+    const w = wire({
+      statuses: {
+        "op-old": [{ status: "failed" }],
+        "op-new": [{ status: "failed", error: "unmovable_volume" }],
+      },
+    });
+    deepStrictEqual(await resumePendingMove(PENDING, w, instant), {
+      outcome: "failed",
+      error: "unmovable_volume",
+      moveId: "op-new",
+    });
+  });
+
+  it("treats a lost ticket ('move not found' reads failed) as resumable", async () => {
+    const w = wire({
+      statuses: {
+        "op-old": [{ status: "failed", error: "move not found" }],
+        "op-new": [{ status: "done" }],
+      },
+    });
+    deepStrictEqual(await resumePendingMove(PENDING, w, instant), {
+      outcome: "done",
+    });
+    deepStrictEqual(w.posts, ["abcdef0123456789"]);
+  });
+
+  it("yields inProgress when a fresh move already owns the agent", async () => {
+    const w = wire({
+      statuses: { "op-old": [{ status: "failed" }] },
+      moveAgent: async () => {
+        throw { code: "move_in_progress" };
+      },
+    });
+    deepStrictEqual(await resumePendingMove(PENDING, w, instant), {
+      outcome: "inProgress",
+    });
+  });
+
+  it("yields rejected (with the code) when the re-POST is refused", async () => {
+    const w = wire({
+      statuses: { "op-old": [{ status: "failed" }] },
+      moveAgent: async () => {
+        throw { body: { error: "not_member" } };
+      },
+    });
+    deepStrictEqual(await resumePendingMove(PENDING, w, instant), {
+      outcome: "rejected",
+      code: "not_member",
+    });
+  });
+
+  it("yields rejected when even the first status read throws", async () => {
+    const w = wire({ statuses: {} });
+    w.moveStatus = async () => {
+      throw { code: "unauthorized" };
+    };
+    deepStrictEqual(await resumePendingMove(PENDING, w, instant), {
+      outcome: "rejected",
+      code: "unauthorized",
+    });
+  });
+
+  it("times out a move that never settles, keeping the record", async () => {
+    const w = wire({ statuses: { "op-old": [{ status: "moving" }] } });
+    const result = await resumePendingMove(PENDING, w, {
+      ...instant,
+      budgetMs: 5,
+    });
+    deepStrictEqual(result, { outcome: "timeout" });
+  });
+
+  it("rides through transient poll errors within the budget", async () => {
+    let polls = 0;
+    const w = wire({ statuses: {} });
+    w.moveStatus = async () => {
+      polls += 1;
+      if (polls === 1) return { status: "moving" };
+      if (polls === 2) throw new Error("gateway blip");
+      return { status: "done" };
+    };
+    deepStrictEqual(await resumePendingMove(PENDING, w, instant), {
+      outcome: "done",
+    });
+    strictEqual(polls, 3);
+  });
+});

--- a/app/tests/pending-move.test.ts
+++ b/app/tests/pending-move.test.ts
@@ -1,0 +1,89 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  claimMove,
+  clearPendingMove,
+  isMoveClaimed,
+  type PendingAgentMove,
+  readPendingMoves,
+  recordPendingMove,
+  releaseMove,
+  updatePendingMoveId,
+} from "../src/lib/pending-move.ts";
+
+function fakeStorage(seed?: string) {
+  const map = new Map<string, string>();
+  if (seed !== undefined) map.set("houston.pendingAgentMoves", seed);
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    dump: () => map.get("houston.pendingAgentMoves") ?? null,
+  };
+}
+
+function move(over: Partial<PendingAgentMove> = {}): PendingAgentMove {
+  return {
+    agentId: "7af3d710003ad396",
+    agentName: "Nova",
+    teamSlug: "abcdef0123456789",
+    teamName: "Acme",
+    moveId: "op-1",
+    startedAt: 1_000,
+    ...over,
+  };
+}
+
+describe("pending-move persistence", () => {
+  it("records, reads back, and clears", () => {
+    const s = fakeStorage();
+    recordPendingMove(move(), s);
+    deepStrictEqual(readPendingMoves(s), [move()]);
+    clearPendingMove("7af3d710003ad396", s);
+    deepStrictEqual(readPendingMoves(s), []);
+    // Emptying removes the key entirely rather than storing "[]".
+    strictEqual(s.dump(), null);
+  });
+
+  it("upserts per agent: a re-record replaces the old ticket", () => {
+    const s = fakeStorage();
+    recordPendingMove(move({ moveId: "op-1" }), s);
+    recordPendingMove(move({ moveId: "op-2" }), s);
+    deepStrictEqual(readPendingMoves(s), [move({ moveId: "op-2" })]);
+  });
+
+  it("keeps other agents' records independent", () => {
+    const s = fakeStorage();
+    recordPendingMove(move(), s);
+    recordPendingMove(move({ agentId: "b".repeat(16), moveId: "op-9" }), s);
+    clearPendingMove("7af3d710003ad396", s);
+    deepStrictEqual(readPendingMoves(s), [
+      move({ agentId: "b".repeat(16), moveId: "op-9" }),
+    ]);
+  });
+
+  it("re-keys an adopted move to its new ticket", () => {
+    const s = fakeStorage();
+    recordPendingMove(move({ moveId: "op-1" }), s);
+    updatePendingMoveId("7af3d710003ad396", "op-2", s);
+    deepStrictEqual(readPendingMoves(s), [move({ moveId: "op-2" })]);
+  });
+
+  it("reads unreadable or malformed state as no pending moves", () => {
+    deepStrictEqual(readPendingMoves(fakeStorage("not json")), []);
+    deepStrictEqual(readPendingMoves(fakeStorage('{"a":1}')), []);
+    deepStrictEqual(readPendingMoves(fakeStorage('[{"agentId":1}]')), []);
+    deepStrictEqual(readPendingMoves(null), []);
+  });
+
+  it("claims are exclusive per agent and releasable", () => {
+    strictEqual(claimMove("agent-x"), true);
+    strictEqual(claimMove("agent-x"), false);
+    strictEqual(isMoveClaimed("agent-x"), true);
+    strictEqual(isMoveClaimed("agent-y"), false);
+    releaseMove("agent-x");
+    strictEqual(isMoveClaimed("agent-x"), false);
+    strictEqual(claimMove("agent-x"), true);
+    releaseMove("agent-x");
+  });
+});


### PR DESCRIPTION
Fixes HOU-817 ("App unusable: starting a mission fails").

## Root cause

Sentry event `ccd6598049884b2897e97937d6dd1ea3` shows every gateway request for the user's agent answering `503 {"detail":"control-plane answered 409: agent is being moved","error":"engine unavailable"}` — for 7+ hours across two sessions. The agent was wedged behind the gateway's **move wake-guard**.

The C8 share-via-team pipeline moves a personal agent into a team space. The gateway contract is: a failed/crashed move deliberately leaves its durable lock so a re-POST of the move can stale-adopt and resume it, and while the lock exists the control plane refuses to wake the agent (two writers on one volume would be worse). The client, however, held the in-flight move **only in React state**. If the move failed and the user closed the dialog, hit the 5-minute poll timeout, or quit the app, nothing ever re-POSTed: the lock stayed forever, the agent could never wake again, and every surface (chat history, agent files, starting a mission) surfaced raw "engine unavailable" errors. The app read as fully broken.

## Fix

Make the accepted move durable and re-drive it to terminal on the next boot:

- **`app/src/lib/pending-move.ts`** — persists the `(agent, team, moveId)` triple to localStorage the moment the gateway accepts a move (202), plus in-memory claims so the dialog and the boot resume never drive the same move concurrently. The record is retired **only** when a move reaches terminal `done` (the only event that releases the server lock).
- **`app/src/lib/move-resume.ts`** — pure resume algorithm: poll the recorded ticket first (the server may still be running it, or may have quietly succeeded), re-POST to stale-adopt only when it reads terminal `failed` (which also covers "move not found" after ledger retention), then poll the adopted ticket to terminal. Injected wire + sleep; never throws.
- **`app/src/hooks/use-move-resume.ts`** — boot-time driver mounted in `App`, gated on a signed-in session and `capabilities.spaces`. On `done`: clears the record, toasts, reloads workspaces/orgs/agents. On any other outcome: keeps the record (next boot retries) and toasts that the move didn't finish. Wire-level toasts are suppressed in favor of the single resume toast; unexpected errors still reach Sentry.
- **`share-via-team-flow.tsx`** — records the pending move on 202, clears it on the terminal `done` poll, releases the claim when the dialog closes.
- i18n: `teams:moveResume.*` in en/es/pt.

## Not covered here (needs ops / gateway)

Users already wedged on 0.5.x have no persisted record, so the client cannot know the move target; their locks need an ops unwedge (re-POST the move as the mover, or clear the `gateway.agent_moves` row after verifying no relocation is in flight). A gateway-side reconciler for orphaned moves would remove that class entirely; tracked separately.

## Reproduction (before)

1. On a spaces-capable host, open Share on a personal agent, pick a team, confirm the move.
2. Make the move fail server-side (kill the relocation mid-flight) or just quit the app while "Moving…" is up.
3. Relaunch: the agent's chats and files 503 with "agent is being moved" forever; sending a message / starting a mission fails; there is no recovery affordance.

## Verification (after)

1. Repeat steps 1–2.
2. Relaunch and sign in: within seconds the app re-POSTs the move, polls it to `done`, toasts "«Agent» finished moving to «Team»", the team appears in the space switcher, and the agent is usable again.
3. If the resume fails, a toast says the move could not finish and the next launch retries; nothing is silently swallowed.

## Tests

- `app/tests/pending-move.test.ts` — record/upsert/clear/re-key semantics, malformed-state tolerance, claim exclusivity.
- `app/tests/move-resume.test.ts` — all resume paths: quiet success, still-running, failed→adopt→done, re-failed with re-key, lost ticket, `move_in_progress`, rejection codes, first-poll throw, budget timeout, transient poll blips.

Gates: `app` tests 1973/1973 pass, `tsgo --noEmit` (app + houston-web + full workspace via pre-commit), `check-locales`, Biome clean.