### PR TITLE
feat(chat): upload whole folders as chat attachments (HOU-808)

### DIFF
--- a/app/src/components/board/mission-control-archived.tsx
+++ b/app/src/components/board/mission-control-archived.tsx
@@ -142,6 +142,7 @@ export function MissionControlArchived({
           }
           onPanelOpenChange={setMissionPanelOpen}
           onOpenLink={openHref}
+          onNotice={(message) => addToast({ title: message })}
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
           thinkingIndicator={panel.thinkingIndicator}

--- a/app/src/components/board/use-board-labels.ts
+++ b/app/src/components/board/use-board-labels.ts
@@ -1,4 +1,5 @@
 import type { AIBoardProps } from "@houston-ai/board";
+import { MAX_ATTACHMENT_FILES } from "@houston-ai/chat";
 import { useTranslation } from "react-i18next";
 
 /**
@@ -30,6 +31,12 @@ export function useBoardLabels(): {
       dropTitle: t("chat:composer.dropTitle"),
       dropDescription: t("chat:composer.dropDescription"),
       imagePasteUnavailable: t("chat:composer.imagePasteUnavailable"),
+      tooManyFiles: t("chat:composer.tooManyFiles", {
+        max: MAX_ATTACHMENT_FILES,
+      }),
+      folderReadFailed: t("chat:composer.folderReadFailed"),
+      folderFileCount: (count: number) =>
+        t("chat:composer.folderFileCount", { count }),
     },
   };
 }

--- a/app/src/components/tabs/archived-tab.tsx
+++ b/app/src/components/tabs/archived-tab.tsx
@@ -34,6 +34,7 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
   const panelContainer = useDetailPanelContainer();
   const { data: rawItems } = useActivity(path);
   const deleteActivity = useDeleteActivity(path);
+  const addToast = useUIStore((s) => s.addToast);
   const setMissionPanelOpen = useUIStore((s) => s.setMissionPanelOpen);
   const viewMode = useUIStore((s) => s.viewMode);
 
@@ -142,6 +143,7 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
           emptyState={emptyState}
           onPanelOpenChange={setMissionPanelOpen}
           onOpenLink={openHref}
+          onNotice={(message) => addToast({ title: message })}
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
           cardAvatar={<AgentCardAvatar color={agent.color} />}

--- a/app/src/components/tabs/routine-setup-chat.tsx
+++ b/app/src/components/tabs/routine-setup-chat.tsx
@@ -5,6 +5,7 @@ import { type ReactNode, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import type { TabProps } from "../../lib/types";
+import { useUIStore } from "../../stores/ui";
 import { useBoardLabels } from "../board/use-board-labels";
 import { RoutineActivationChip } from "./routine-activation-chip";
 import { RoutineSetupChatBoard } from "./routine-setup-chat-board";
@@ -156,6 +157,9 @@ export function RoutineSetupChat({
             status={onIntakeSend ? "ready" : "submitted"}
             placeholder={t("chat.intakePlaceholder")}
             labels={composerLabels}
+            onNotice={(message) =>
+              useUIStore.getState().addToast({ title: message })
+            }
           />
         </div>
       );

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -36,7 +36,7 @@ import {
 } from "@houston-ai/chat";
 import { Button } from "@houston-ai/core";
 import { useQueryClient } from "@tanstack/react-query";
-import { Paperclip, Play, Users } from "lucide-react";
+import { FolderUp, Paperclip, Play, Users } from "lucide-react";
 import {
   type ReactNode,
   useCallback,
@@ -2018,7 +2018,7 @@ export function useAgentChatPanel({
 
   const attachMenu = useMemo<AIBoardProps["attachMenu"]>(() => {
     if (!agent) return undefined;
-    return ({ openFilePicker }) => (
+    return ({ openFilePicker, openFolderPicker }) => (
       <div className="flex flex-col gap-0.5">
         <button
           type="button"
@@ -2029,6 +2029,16 @@ export function useAgentChatPanel({
         >
           <Paperclip className="size-4 text-ink-muted" />
           {t("composerAttach.addFiles")}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            openFolderPicker();
+          }}
+          className="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm text-ink hover:bg-hover transition-colors"
+        >
+          <FolderUp className="size-4 text-ink-muted" />
+          {t("composerAttach.addFolder")}
         </button>
       </div>
     );

--- a/app/src/lib/attachment-message.test.mjs
+++ b/app/src/lib/attachment-message.test.mjs
@@ -45,6 +45,28 @@ test("attachment prompt includes display marker and hidden path block", () => {
   );
 });
 
+test("folder uploads collapse to one prompt line with a file count (HOU-808)", () => {
+  assert.equal(
+    withAttachmentPaths("Look at these", [
+      "uploads/brief.pdf",
+      "uploads/docs/a.md",
+      "uploads/docs/guide/b.md",
+      "uploads/data/rows.csv",
+    ]),
+    "Look at these\n\n[User attached these files. Read them with the Read tool if needed:\n" +
+      "- uploads/brief.pdf\n" +
+      "- uploads/docs/ (uploaded folder with 2 files inside)\n" +
+      "- uploads/data/ (uploaded folder with 1 file inside)]",
+  );
+});
+
+test("legacy absolute paths are never mistaken for folder uploads", () => {
+  assert.equal(
+    withAttachmentPaths("", ["/Users/ja/.houston/cache/attachments/brief.pdf"]),
+    "[User attached these files. Read them with the Read tool if needed:\n- /Users/ja/.houston/cache/attachments/brief.pdf]",
+  );
+});
+
 test("attachment references fall back to file name from path", () => {
   assert.deepEqual(attachmentReferences([], ["/tmp/report.csv"]), [
     { name: "report.csv", path: "/tmp/report.csv" },

--- a/app/src/lib/attachment-message.ts
+++ b/app/src/lib/attachment-message.ts
@@ -8,9 +8,42 @@ const MARKER_SUFFIX = "-->";
 
 export function withAttachmentPaths(text: string, paths: string[]): string {
   if (paths.length === 0) return text;
-  const list = paths.map((p) => `- ${p}`).join("\n");
+  const list = groupedAttachmentLines(paths).join("\n");
   const block = `[User attached these files. Read them with the Read tool if needed:\n${list}]`;
   return text.length > 0 ? `${text}\n\n${block}` : block;
+}
+
+/**
+ * Flat uploads land directly under `uploads/`, so any deeper RELATIVE
+ * `uploads/…` path is a folder upload (HOU-808). Listing a 200-file folder
+ * file-by-file would bloat the prompt, so each uploaded folder collapses to
+ * ONE line naming its root and file count — the agent's file tools list the
+ * contents on demand. Order follows first appearance. Anything else (legacy
+ * absolute paths included) stays a plain per-file line.
+ */
+function groupedAttachmentLines(paths: readonly string[]): string[] {
+  const lines: string[] = [];
+  const folders = new Map<string, { line: number; count: number }>();
+  for (const path of paths) {
+    const segments = path.split("/");
+    if (segments[0] !== "uploads" || segments.length <= 2) {
+      lines.push(`- ${path}`);
+      continue;
+    }
+    const root = `${segments[0]}/${segments[1]}`;
+    const folder = folders.get(root);
+    if (folder) {
+      folder.count += 1;
+      continue;
+    }
+    folders.set(root, { line: lines.length, count: 1 });
+    lines.push(""); // placeholder, filled below once the count is final
+  }
+  for (const [root, { line, count }] of folders) {
+    lines[line] =
+      `- ${root}/ (uploaded folder with ${count} ${count === 1 ? "file" : "files"} inside)`;
+  }
+  return lines;
 }
 
 export function buildAttachmentPrompt(

--- a/app/src/locales/en/board.json
+++ b/app/src/locales/en/board.json
@@ -52,7 +52,8 @@
     "browse": "Skills"
   },
   "composerAttach": {
-    "addFiles": "Add files"
+    "addFiles": "Add files",
+    "addFolder": "Add a folder"
   },
   "selectedSkill": {
     "cancel": "Close"

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -8,6 +8,10 @@
     "dropTitle": "Drop your files",
     "dropDescription": "Drop them here to add them to the conversation",
     "imagePasteUnavailable": "Couldn't read the pasted image. Try dragging the file in instead.",
+    "tooManyFiles": "You can attach up to {{max}} files at a time",
+    "folderReadFailed": "Couldn't read that folder. Try the attach button instead.",
+    "folderFileCount_one": "{{count}} file",
+    "folderFileCount_other": "{{count}} files",
     "addFiles": "Add files",
     "dictation": {
       "start": "Start voice typing",

--- a/app/src/locales/es/board.json
+++ b/app/src/locales/es/board.json
@@ -52,7 +52,8 @@
     "browse": "Skills"
   },
   "composerAttach": {
-    "addFiles": "Agregar archivos"
+    "addFiles": "Agregar archivos",
+    "addFolder": "Agregar una carpeta"
   },
   "selectedSkill": {
     "cancel": "Cerrar"

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -8,6 +8,10 @@
     "dropTitle": "Suelta tus archivos",
     "dropDescription": "Suéltalos aquí para añadirlos a la conversación",
     "imagePasteUnavailable": "No se pudo leer la imagen pegada. Prueba a arrastrar el archivo.",
+    "tooManyFiles": "Puedes adjuntar hasta {{max}} archivos a la vez",
+    "folderReadFailed": "No se pudo leer esa carpeta. Prueba con el botón de adjuntar.",
+    "folderFileCount_one": "{{count}} archivo",
+    "folderFileCount_other": "{{count}} archivos",
     "addFiles": "Agregar archivos",
     "dictation": {
       "start": "Iniciar dictado por voz",

--- a/app/src/locales/pt/board.json
+++ b/app/src/locales/pt/board.json
@@ -52,7 +52,8 @@
     "browse": "Skills"
   },
   "composerAttach": {
-    "addFiles": "Adicionar arquivos"
+    "addFiles": "Adicionar arquivos",
+    "addFolder": "Adicionar uma pasta"
   },
   "selectedSkill": {
     "cancel": "Fechar"

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -8,6 +8,10 @@
     "dropTitle": "Solte seus arquivos",
     "dropDescription": "Solte-os aqui para adicioná-los à conversa",
     "imagePasteUnavailable": "Não foi possível ler a imagem colada. Tente arrastar o arquivo.",
+    "tooManyFiles": "Você pode anexar até {{max}} arquivos por vez",
+    "folderReadFailed": "Não foi possível ler essa pasta. Tente o botão de anexar.",
+    "folderFileCount_one": "{{count}} arquivo",
+    "folderFileCount_other": "{{count}} arquivos",
     "addFiles": "Adicionar arquivos",
     "dictation": {
       "start": "Iniciar ditado por voz",

--- a/packages/host/src/turn/attachments.test.ts
+++ b/packages/host/src/turn/attachments.test.ts
@@ -89,6 +89,119 @@ test("uploads are visible in the Files tab listing", async () => {
   expect(listed).toContain("uploads/attached.txt");
 });
 
+test("folder uploads keep their directory structure under uploads/ (HOU-808)", async () => {
+  const vfs = new MemoryVfs();
+  const paths = await saveAttachments(vfs, ROOT, [
+    { name: "intro.md", contentBase64: b64("intro"), relPath: "docs/intro.md" },
+    {
+      name: "api.md",
+      contentBase64: b64("api"),
+      relPath: "docs/guide/api.md",
+    },
+  ]);
+  expect(paths).toEqual(["uploads/docs/intro.md", "uploads/docs/guide/api.md"]);
+  expect(await vfs.readText(`${ROOT}/uploads/docs/guide/api.md`)).toBe("api");
+});
+
+test("same basename in different subfolders is NOT a collision", async () => {
+  const vfs = new MemoryVfs();
+  const paths = await saveAttachments(vfs, ROOT, [
+    { name: "index.ts", contentBase64: b64("a"), relPath: "src/a/index.ts" },
+    { name: "index.ts", contentBase64: b64("b"), relPath: "src/b/index.ts" },
+  ]);
+  expect(paths).toEqual(["uploads/src/a/index.ts", "uploads/src/b/index.ts"]);
+});
+
+test("a colliding file inside a folder dedupes the FILE, keeping the folder", async () => {
+  const vfs = new MemoryVfs();
+  await saveAttachments(vfs, ROOT, [
+    { name: "a.txt", contentBase64: b64("first"), relPath: "docs/a.txt" },
+  ]);
+  // The same folder attached again later merges: no "docs (1)/", the file
+  // inside disambiguates instead — the returned paths stay exact either way.
+  const second = await saveAttachments(vfs, ROOT, [
+    { name: "a.txt", contentBase64: b64("second"), relPath: "docs/a.txt" },
+  ]);
+  expect(second).toEqual(["uploads/docs/a (1).txt"]);
+  expect(await vfs.readText(`${ROOT}/uploads/docs/a.txt`)).toBe("first");
+  expect(await vfs.readText(`${ROOT}/uploads/docs/a (1).txt`)).toBe("second");
+});
+
+test("nested folder-upload files show up in the Files tab listing", async () => {
+  const vfs = new MemoryVfs();
+  await saveAttachments(vfs, ROOT, [
+    { name: "b.csv", contentBase64: b64("x"), relPath: "data/2026/b.csv" },
+  ]);
+  const listed = (await listWorkspace(vfs, ROOT)).map((f) => f.path);
+  expect(listed).toContain("uploads/data/2026/b.csv");
+});
+
+test("hostile relPaths are rejected loudly, never clamped or flattened", async () => {
+  const vfs = new MemoryVfs();
+  const bad = [
+    "../escape.txt", // traversal out of uploads/
+    "docs/../../auth.json", // traversal via inner segment
+    "docs//a.txt", // empty segment
+    "docs/.hidden/a.txt", // hidden dir segment
+    "docs/.env", // hidden file segment
+    "docs\\a.txt/b.txt", // backslash inside a segment
+    "plain.txt", // single segment must arrive as `name`, not relPath
+  ];
+  for (const relPath of bad) {
+    await expect(
+      saveAttachments(vfs, ROOT, [
+        { name: "a.txt", contentBase64: b64("x"), relPath },
+      ]),
+    ).rejects.toThrow(AttachmentError);
+  }
+  // Nothing may have been written by any of the rejected uploads.
+  expect(await vfs.list(ROOT)).toEqual([]);
+});
+
+test("POST with relPath stores nested and returns the nested path", async () => {
+  const vfs = new MemoryVfs();
+  const post = fakeRes();
+  await handleAttachments(
+    vfs,
+    PATHS,
+    CTX,
+    "POST",
+    "attachments",
+    fakeReq({
+      files: [
+        {
+          name: "notes.txt",
+          contentBase64: b64("n"),
+          relPath: "trip/notes.txt",
+        },
+      ],
+    }),
+    post.res,
+  );
+  expect(post.state.status).toBe(200);
+  expect((post.state.body as { paths: string[] }).paths).toEqual([
+    "uploads/trip/notes.txt",
+  ]);
+  expect(await vfs.readText(`${ROOT}/uploads/trip/notes.txt`)).toBe("n");
+});
+
+test("a non-string relPath 400s", async () => {
+  const vfs = new MemoryVfs();
+  const post = fakeRes();
+  await handleAttachments(
+    vfs,
+    PATHS,
+    CTX,
+    "POST",
+    "attachments",
+    fakeReq({
+      files: [{ name: "a.txt", contentBase64: b64("x"), relPath: 7 }],
+    }),
+    post.res,
+  );
+  expect(post.state.status).toBe(400);
+});
+
 test("traversal or dotfile in filename is rejected, never silently clamped", async () => {
   const vfs = new MemoryVfs();
   await expect(

--- a/packages/host/src/turn/attachments.test.ts
+++ b/packages/host/src/turn/attachments.test.ts
@@ -158,6 +158,18 @@ test("hostile relPaths are rejected loudly, never clamped or flattened", async (
   expect(await vfs.list(ROOT)).toEqual([]);
 });
 
+test("a bad path anywhere in a batch rejects the WHOLE batch — no partial persist", async () => {
+  const vfs = new MemoryVfs();
+  await expect(
+    saveAttachments(vfs, ROOT, [
+      { name: "good.txt", contentBase64: b64("good") },
+      { name: "evil", contentBase64: b64("x"), relPath: "../evil" },
+    ]),
+  ).rejects.toThrow(AttachmentError);
+  // The valid file listed BEFORE the invalid one must not have been written.
+  expect(await vfs.list(ROOT)).toEqual([]);
+});
+
 test("POST with relPath stores nested and returns the nested path", async () => {
   const vfs = new MemoryVfs();
   const post = fakeRes();

--- a/packages/host/src/turn/attachments.ts
+++ b/packages/host/src/turn/attachments.ts
@@ -52,10 +52,18 @@ export class AttachmentError extends Error {
   }
 }
 
-/** One uploaded file: original name + its base64-encoded bytes. */
+/**
+ * One uploaded file: original name + its base64-encoded bytes. `relPath` is
+ * set for folder uploads (HOU-808): the file's slash-joined path INSIDE the
+ * dropped folder, including the filename (mirrors `File.webkitRelativePath`,
+ * e.g. `docs/guide/intro.md`) — the file then lands at `uploads/<relPath>` so
+ * the folder's structure survives. Hosts predating folder support ignore the
+ * field and store the flat `name`, which still yields readable paths.
+ */
 interface UploadFile {
   name: string;
   contentBase64: string;
+  relPath?: string;
 }
 
 /**
@@ -77,14 +85,43 @@ function safeFilename(name: string): string {
   return name;
 }
 
+/** Folder uploads can nest, but not absurdly: a runaway path is a client bug. */
+const MAX_RELPATH_SEGMENTS = 32;
+const MAX_RELPATH_LENGTH = 1024;
+
+/**
+ * Validate a folder-upload relative path: 2+ segments (a 1-segment path is a
+ * plain filename and must arrive as `name`), every segment individually held to
+ * the same rules as `safeFilename` — so `..`, `\`, empty segments (`a//b`) and
+ * hidden dot-segments are all rejected loudly, and the joined path can never
+ * escape `uploads/`.
+ */
+function safeRelPath(relPath: string): string {
+  const segments = relPath.split("/");
+  if (
+    segments.length < 2 ||
+    segments.length > MAX_RELPATH_SEGMENTS ||
+    relPath.length > MAX_RELPATH_LENGTH
+  ) {
+    throw new AttachmentError(400, `invalid attachment path: ${relPath}`);
+  }
+  for (const segment of segments) safeFilename(segment);
+  return relPath;
+}
+
 const uploadsKey = (root: string) => `${root}/${UPLOADS_DIR}`;
 
 /**
  * Write each uploaded file under `uploads/` and return the RELATIVE workspace
- * paths the agent will read. Names colliding with anything already in the
- * folder — or with each other within a batch — are disambiguated (`name.ext`,
- * `name (1).ext`, …) so an upload never silently overwrites an earlier one and
- * every returned path resolves to a distinct stored file.
+ * paths the agent will read. Folder uploads (`relPath` set) keep their
+ * directory structure: `docs/a.md` lands at `uploads/docs/a.md`. FILES
+ * colliding with anything already stored — or with each other within a batch —
+ * are disambiguated (`name.ext`, `name (1).ext`, …) so an upload never
+ * silently overwrites an earlier one and every returned path resolves to a
+ * distinct stored file. DIRECTORIES deliberately merge instead of deduping:
+ * the client uploads a folder across several requests (one per size-batch),
+ * so a per-request folder rename would scatter one folder over many — and the
+ * returned per-file paths stay exact either way.
  */
 export async function saveAttachments(
   vfs: Vfs,
@@ -93,33 +130,40 @@ export async function saveAttachments(
 ): Promise<string[]> {
   // Seed the dedup set with what the folder already holds: uploads are durable
   // across conversations, so "report.pdf" attached today must not clobber the
-  // "report.pdf" attached last week.
+  // "report.pdf" attached last week. `vfs.list` is recursive, so the set holds
+  // full `uploads/`-relative paths — nested folder-upload files included.
   const prefix = uploadsKey(root);
   const used = new Set<string>(
     (await vfs.list(prefix)).map((k) => k.slice(prefix.length + 1)),
   );
   const paths: string[] = [];
   for (const f of files) {
-    const filename = dedupe(safeFilename(f.name), used);
+    const target = f.relPath ? safeRelPath(f.relPath) : safeFilename(f.name);
+    const rel = `${UPLOADS_DIR}/${dedupe(target, used)}`;
     const bytes = Buffer.from(f.contentBase64, "base64");
-    const rel = `${UPLOADS_DIR}/${filename}`;
     await vfs.writeBytes(`${root}/${rel}`, bytes);
     paths.push(rel);
   }
   return paths;
 }
 
-/** Pick a unique filename within the folder, appending " (n)" before the extension. */
-function dedupe(name: string, used: Set<string>): string {
-  if (!used.has(name)) {
-    used.add(name);
-    return name;
+/**
+ * Pick a unique path within `uploads/`, appending " (n)" before the FILENAME's
+ * extension (the directory part never changes — see saveAttachments on merge).
+ */
+function dedupe(relPath: string, used: Set<string>): string {
+  if (!used.has(relPath)) {
+    used.add(relPath);
+    return relPath;
   }
+  const slash = relPath.lastIndexOf("/");
+  const dir = slash >= 0 ? relPath.slice(0, slash + 1) : "";
+  const name = slash >= 0 ? relPath.slice(slash + 1) : relPath;
   const dot = name.lastIndexOf(".");
   const stem = dot > 0 ? name.slice(0, dot) : name;
   const ext = dot > 0 ? name.slice(dot) : "";
   for (let n = 1; ; n++) {
-    const candidate = `${stem} (${n})${ext}`;
+    const candidate = `${dir}${stem} (${n})${ext}`;
     if (!used.has(candidate)) {
       used.add(candidate);
       return candidate;
@@ -135,12 +179,19 @@ function parseUploadBody(body: Record<string, unknown>): UploadFile[] {
   }
   let total = 0;
   return body.files.map((raw, i) => {
-    const f = raw as { name?: unknown; contentBase64?: unknown };
+    const f = raw as {
+      name?: unknown;
+      contentBase64?: unknown;
+      relPath?: unknown;
+    };
     if (typeof f.name !== "string" || typeof f.contentBase64 !== "string") {
       throw new AttachmentError(
         400,
         `file[${i}] needs string 'name' and 'contentBase64'`,
       );
+    }
+    if (f.relPath !== undefined && typeof f.relPath !== "string") {
+      throw new AttachmentError(400, `file[${i}] 'relPath' must be a string`);
     }
     // Semantic decoded-size limit (base64 is ~3/4 the byte size). The raw body
     // is already capped DURING draining by readJson(MAX_UPLOAD_BODY_BYTES) — the
@@ -153,7 +204,7 @@ function parseUploadBody(body: Record<string, unknown>): UploadFile[] {
         "attachments exceed the upload size limit",
       );
     }
-    return { name: f.name, contentBase64: f.contentBase64 };
+    return { name: f.name, contentBase64: f.contentBase64, relPath: f.relPath };
   });
 }
 
@@ -162,7 +213,7 @@ function parseUploadBody(body: Record<string, unknown>): UploadFile[] {
  * runtime channel (the runtime has no /attachments route). Returns true when it
  * owns the request. A missing vfs 503s; malformed input 4xxs. Nothing swallowed.
  *
- *   POST attachments  { files: [{ name, contentBase64 }] } → { paths }
+ *   POST attachments  { files: [{ name, contentBase64, relPath? }] } → { paths }
  *
  * DELETE (the legacy per-scope wipe) is gone: uploads are permanent workspace
  * files the user manages through the Files tab. Old clients still fire a

--- a/packages/host/src/turn/attachments.ts
+++ b/packages/host/src/turn/attachments.ts
@@ -136,13 +136,24 @@ export async function saveAttachments(
   const used = new Set<string>(
     (await vfs.list(prefix)).map((k) => k.slice(prefix.length + 1)),
   );
-  const paths: string[] = [];
-  for (const f of files) {
+  // Validate the WHOLE batch before writing anything: one bad path must 400
+  // the request without leaving earlier files half-persisted (their paths
+  // would never be returned and no FilesChanged would fire).
+  const paths = files.map((f) => {
     const target = f.relPath ? safeRelPath(f.relPath) : safeFilename(f.name);
-    const rel = `${UPLOADS_DIR}/${dedupe(target, used)}`;
-    const bytes = Buffer.from(f.contentBase64, "base64");
-    await vfs.writeBytes(`${root}/${rel}`, bytes);
-    paths.push(rel);
+    return `${UPLOADS_DIR}/${dedupe(target, used)}`;
+  });
+  // Path validation is lexical; the Vfs write resolves the path as the
+  // filesystem sees it, symlinks included. A symlinked dir under uploads/
+  // could redirect a write — but only something that already writes to the
+  // workspace (the agent itself) can plant one there, and that principal can
+  // already write wherever the symlink would point. Same posture as the
+  // pre-existing flat uploads (where `uploads` itself could be a symlink).
+  for (const [i, f] of files.entries()) {
+    await vfs.writeBytes(
+      `${root}/${paths[i]}`,
+      Buffer.from(f.contentBase64, "base64"),
+    );
   }
   return paths;
 }

--- a/packages/web/src/engine-adapter/cp/files-context.ts
+++ b/packages/web/src/engine-adapter/cp/files-context.ts
@@ -71,6 +71,12 @@ export async function setContext(
  * files: …"). Binary rides as base64 JSON (the host writes the bytes through
  * its Vfs); the agent resolves each path against its workspace root.
  *
+ * Folder uploads (HOU-808): a file picked or dropped as part of a folder
+ * carries `webkitRelativePath`; we forward it as `relPath` and the host stores
+ * the file nested (`uploads/<folder>/…`) so the folder's structure survives.
+ * Pods predating folder support ignore the field and store the flat filename —
+ * every returned path is still exact, the upload just loses its nesting.
+ *
  * `scopeId` is legacy: current hosts ignore it, but engine pods that predate
  * the durable-uploads layout still 400 without it — keep sending it until no
  * pre-HOU-706 pod remains.
@@ -81,19 +87,17 @@ export async function saveAttachments(
   scopeId: string,
   files: readonly File[],
 ): Promise<string[]> {
-  // One request per file: bounds each request to the client's per-file limit,
-  // so a multi-file drop can't blow past the host's per-request upload cap
-  // (the host dedupes against the scope's existing files across requests).
   const paths: string[] = [];
-  for (const f of files) {
+  for (const batch of planAttachmentBatches(files)) {
     const payload = {
       scopeId,
-      files: [
-        {
+      files: await Promise.all(
+        batch.map(async (f) => ({
           name: f.name,
           contentBase64: bytesToBase64(new Uint8Array(await f.arrayBuffer())),
-        },
-      ],
+          relPath: attachmentRelPath(f),
+        })),
+      ),
     };
     const res = await cpFetch(cfg, `${agentPath(agentId)}/attachments`, {
       method: "POST",
@@ -102,6 +106,47 @@ export async function saveAttachments(
     paths.push(...((await res.json()) as { paths: string[] }).paths);
   }
   return paths;
+}
+
+// A folder can hold hundreds of small files; a request per file would turn one
+// drop into hundreds of round trips. Batch small files together up to a modest
+// byte budget, well under the host's per-request cap, and give anything larger
+// than the budget its own request (the client's per-file limit already bounds
+// it to the host cap). Requests stay sequential so per-file host-side dedupe
+// never races itself.
+const BATCH_BUDGET_BYTES = 8 * 1024 * 1024;
+const BATCH_MAX_FILES = 25;
+
+export function planAttachmentBatches(files: readonly File[]): File[][] {
+  const batches: File[][] = [];
+  let current: File[] = [];
+  let currentBytes = 0;
+  for (const f of files) {
+    const fits =
+      current.length < BATCH_MAX_FILES &&
+      currentBytes + f.size <= BATCH_BUDGET_BYTES;
+    if (current.length > 0 && !fits) {
+      batches.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(f);
+    currentBytes += f.size;
+  }
+  if (current.length > 0) batches.push(current);
+  return batches;
+}
+
+/**
+ * The upload-relative path for a folder-derived file, or undefined for a plain
+ * file. Normalized to forward slashes with no leading slash; a value without a
+ * `/` carries no structure and is treated as plain.
+ */
+function attachmentRelPath(f: File): string | undefined {
+  const raw = f.webkitRelativePath;
+  if (!raw) return undefined;
+  const normalized = raw.replace(/\\/g, "/").replace(/^\/+/, "");
+  return normalized.includes("/") ? normalized : undefined;
 }
 
 /** Base64-encode bytes without blowing the call stack on large files (chunked btoa). */

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -142,14 +142,16 @@ export interface AIBoardProps {
   /** Content rendered inside the composer above the textarea. */
   composerHeader?: ReactNode | ((ctx: { hasMessages: boolean }) => ReactNode);
   /** Popover menu anchored to the composer's paperclip button. When a
-   *  function, called with `{ hasMessages, openFilePicker, close }` — the
-   *  consumer can lock the provider for active conversations, trigger the
-   *  file picker from inside the menu, and close the popover. */
+   *  function, called with `{ hasMessages, openFilePicker, openFolderPicker,
+   *  close }` — the consumer can lock the provider for active conversations,
+   *  trigger the file or folder picker from inside the menu, and close the
+   *  popover. */
   attachMenu?:
     | ReactNode
     | ((ctx: {
         hasMessages: boolean;
         openFilePicker: () => void;
+        openFolderPicker: () => void;
         close: () => void;
       }) => ReactNode);
   /** Enables submit even when the composer has no text or files. */
@@ -807,16 +809,18 @@ export function AIBoard({
           }
           attachMenu={
             typeof attachMenu === "function"
-              ? ({ openFilePicker, close }) =>
+              ? ({ openFilePicker, openFolderPicker, close }) =>
                   (
                     attachMenu as (ctx: {
                       hasMessages: boolean;
                       openFilePicker: () => void;
+                      openFolderPicker: () => void;
                       close: () => void;
                     }) => ReactNode
                   )({
                     hasMessages: activeFeed.length > 0,
                     openFilePicker,
+                    openFolderPicker,
                     close,
                   })
               : attachMenu

--- a/ui/chat/src/attachment-chip.tsx
+++ b/ui/chat/src/attachment-chip.tsx
@@ -7,6 +7,7 @@
 import {
   FileSpreadsheetIcon,
   FileTextIcon,
+  FolderIcon,
   ImageIcon,
   FileIcon as LucideFileIcon,
   MicIcon,
@@ -118,6 +119,47 @@ export function AttachmentChip({ name, onRemove }: AttachmentChipProps) {
         <p className="text-[10px] text-ink-muted leading-tight">
           {getTypeLabel(ext)}
         </p>
+      </div>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="absolute top-1.5 right-1.5 size-4 rounded-full bg-ink/60 text-input flex items-center justify-center hover:bg-ink/80 transition-colors"
+        aria-label={`Remove ${name}`}
+      >
+        <XIcon className="size-2.5" strokeWidth={3} />
+      </button>
+    </div>
+  );
+}
+
+export interface FolderAttachmentChipProps {
+  name: string;
+  /** Localized "N files" line under the folder name (HOU-808). */
+  countLabel: string;
+  onRemove: () => void;
+}
+
+/** A whole attached folder as ONE chip — its files upload together and are
+ *  removed together. Same card anatomy as AttachmentChip. */
+export function FolderAttachmentChip({
+  name,
+  countLabel,
+  onRemove,
+}: FolderAttachmentChipProps) {
+  return (
+    <div className="relative flex items-center gap-2.5 rounded-xl border border-ink/[0.08] bg-input pl-2.5 pr-8 py-2 min-w-0 shrink-0 max-w-[240px] shadow-sm">
+      <div className="size-8 rounded-md bg-[#54A8F0] flex items-center justify-center shrink-0">
+        <FolderIcon
+          className="size-4 text-white"
+          strokeWidth={2}
+          fill="currentColor"
+        />
+      </div>
+      <div className="min-w-0">
+        <p className="text-xs font-medium text-ink truncate leading-tight">
+          {name}
+        </p>
+        <p className="text-[10px] text-ink-muted leading-tight">{countLabel}</p>
       </div>
       <button
         type="button"

--- a/ui/chat/src/attachment-folders.ts
+++ b/ui/chat/src/attachment-folders.ts
@@ -163,7 +163,14 @@ function entryFile(entry: FileSystemFileEntry): Promise<File> {
   return new Promise((resolve, reject) => entry.file(resolve, reject));
 }
 
-/** Drain a directory reader fully — readEntries returns ≤100 per call. */
+/**
+ * Drain a directory reader fully — readEntries returns ≤100 per call. Bails
+ * at the attachment ceiling DURING the drain so a huge flat directory (a
+ * dropped node_modules) fails fast instead of enumerating everything first.
+ * Slightly conservative: the count includes subdirectory and hidden entries
+ * that would never become attachments — past 1000 of anything in one
+ * directory, refusing is the right answer regardless.
+ */
 async function readAllEntries(
   dir: FileSystemDirectoryEntry,
 ): Promise<FileSystemEntry[]> {
@@ -175,5 +182,8 @@ async function readAllEntries(
     );
     if (batch.length === 0) return all;
     all.push(...batch);
+    if (all.length > MAX_ATTACHMENT_FILES) {
+      throw new TooManyAttachmentFilesError();
+    }
   }
 }

--- a/ui/chat/src/attachment-folders.ts
+++ b/ui/chat/src/attachment-folders.ts
@@ -1,0 +1,179 @@
+/**
+ * Folder attachments (HOU-808).
+ *
+ * A folder can enter the composer two ways:
+ *  - the folder picker (`<input webkitdirectory>`): the browser sets each
+ *    File's `webkitRelativePath` natively;
+ *  - drag-and-drop: `DataTransfer.files` flattens a folder to nothing, so the
+ *    drop zone walks `webkitGetAsEntry()` trees and tags each produced File
+ *    with the same `webkitRelativePath` shape (an own property shadowing the
+ *    read-only prototype getter — the react-dropzone technique).
+ *
+ * Downstream, everything keys off `attachmentRelativePath(file)`: chips group
+ * by folder root, dedupe keys include the path, and the upload client forwards
+ * it so the host stores `uploads/<folder>/…` with structure intact.
+ */
+
+/** Hard ceiling on files attachable at once — a dropped `node_modules` must
+ *  fail fast and loudly, not upload for an hour. Shared by the drop traversal
+ *  (aborts early) and the intake (caps picker selections the same way). */
+export const MAX_ATTACHMENT_FILES = 1000;
+
+export class TooManyAttachmentFilesError extends Error {
+  constructor() {
+    super(`too many attachment files (max ${MAX_ATTACHMENT_FILES})`);
+    this.name = "TooManyAttachmentFilesError";
+  }
+}
+
+/**
+ * The folder-relative path (`docs/guide/a.md`) of a folder-derived file, or
+ * null for a plain attachment. Normalized to forward slashes, no leading
+ * slash; a value without a `/` carries no structure and reads as plain.
+ */
+export function attachmentRelativePath(file: File): string | null {
+  const raw = file.webkitRelativePath;
+  if (!raw) return null;
+  const normalized = raw.replace(/\\/g, "/").replace(/^\/+/, "");
+  return normalized.includes("/") ? normalized : null;
+}
+
+/** The dropped/picked folder's name — the first path segment — or null. */
+export function attachmentFolderRoot(file: File): string | null {
+  return attachmentRelativePath(file)?.split("/", 1)[0] ?? null;
+}
+
+/** True when any path segment is hidden (dot-named): `.git/…`, `a/.DS_Store`. */
+function isHiddenRelativePath(relPath: string): boolean {
+  return relPath.split("/").some((segment) => segment.startsWith("."));
+}
+
+/**
+ * Drop the hidden files a folder pick sweeps in (`.DS_Store`, `.git/**`) —
+ * the host refuses dot-named upload segments, and silently failing the whole
+ * send over an invisible file would be worse than skipping it. Plain files
+ * (no relative path) pass through untouched: explicitly picking a dotfile
+ * keeps its existing loud-rejection behavior.
+ */
+export function visibleAttachmentFiles(files: readonly File[]): File[] {
+  return files.filter((file) => {
+    const rel = attachmentRelativePath(file);
+    return rel === null || !isHiddenRelativePath(rel);
+  });
+}
+
+/** Tag a traversal-produced File so it reads exactly like a picker-produced
+ *  one: an own `webkitRelativePath` shadowing the prototype's empty getter. */
+function tagRelativePath(file: File, relPath: string): File {
+  Object.defineProperty(file, "webkitRelativePath", {
+    value: relPath,
+    configurable: true,
+  });
+  return file;
+}
+
+/**
+ * What a drop handed us, captured SYNCHRONOUSLY inside the drop event — the
+ * DataTransfer is neutered once the handler returns, so `webkitGetAsEntry()` /
+ * `getAsFile()` must both run before any await.
+ */
+export type DroppedItem =
+  | { kind: "file"; file: File }
+  | { kind: "entry"; entry: FileSystemEntry };
+
+export function collectDroppedItems(dataTransfer: DataTransfer): DroppedItem[] {
+  const items = dataTransfer.items ? Array.from(dataTransfer.items) : [];
+  const supportsEntries =
+    items.length > 0 && typeof items[0]?.webkitGetAsEntry === "function";
+  if (!supportsEntries) {
+    // No entry API (old engines): folders can't be traversed here — keep the
+    // flat file list, exactly the pre-folder-support behavior.
+    return Array.from(dataTransfer.files).map((file) => ({
+      kind: "file",
+      file,
+    }));
+  }
+  const collected: DroppedItem[] = [];
+  for (const item of items) {
+    if (item.kind !== "file") continue;
+    const entry = item.webkitGetAsEntry();
+    if (entry) {
+      collected.push({ kind: "entry", entry });
+      continue;
+    }
+    const file = item.getAsFile();
+    if (file) collected.push({ kind: "file", file });
+  }
+  return collected;
+}
+
+/**
+ * Expand the captured drop into attachable Files: plain files pass through,
+ * directory entries are walked recursively with each file tagged by its
+ * folder-relative path. Hidden entries are skipped once INSIDE a folder (same
+ * rationale as visibleAttachmentFiles); a top-level file keeps its loud
+ * host-side rejection. Throws TooManyAttachmentFilesError past the ceiling.
+ */
+export async function resolveDroppedFiles(
+  items: readonly DroppedItem[],
+): Promise<File[]> {
+  const out: File[] = [];
+  for (const item of items) {
+    if (item.kind === "file") {
+      appendCapped(out, item.file);
+      continue;
+    }
+    await appendEntry(item.entry, "", out);
+  }
+  return out;
+}
+
+async function appendEntry(
+  entry: FileSystemEntry,
+  parentDir: string,
+  out: File[],
+): Promise<void> {
+  const nested = parentDir !== "";
+  if ((nested || entry.isDirectory) && entry.name.startsWith(".")) return;
+  if (entry.isFile) {
+    const file = await entryFile(entry as FileSystemFileEntry);
+    appendCapped(
+      out,
+      nested ? tagRelativePath(file, `${parentDir}/${file.name}`) : file,
+    );
+    return;
+  }
+  if (entry.isDirectory) {
+    const dir = nested ? `${parentDir}/${entry.name}` : entry.name;
+    for (const child of await readAllEntries(
+      entry as FileSystemDirectoryEntry,
+    )) {
+      await appendEntry(child, dir, out);
+    }
+  }
+}
+
+function appendCapped(out: File[], file: File): void {
+  if (out.length >= MAX_ATTACHMENT_FILES)
+    throw new TooManyAttachmentFilesError();
+  out.push(file);
+}
+
+function entryFile(entry: FileSystemFileEntry): Promise<File> {
+  return new Promise((resolve, reject) => entry.file(resolve, reject));
+}
+
+/** Drain a directory reader fully — readEntries returns ≤100 per call. */
+async function readAllEntries(
+  dir: FileSystemDirectoryEntry,
+): Promise<FileSystemEntry[]> {
+  const reader = dir.createReader();
+  const all: FileSystemEntry[] = [];
+  for (;;) {
+    const batch = await new Promise<FileSystemEntry[]>((resolve, reject) =>
+      reader.readEntries(resolve, reject),
+    );
+    if (batch.length === 0) return all;
+    all.push(...batch);
+  }
+}

--- a/ui/chat/src/chat-input-attachments.tsx
+++ b/ui/chat/src/chat-input-attachments.tsx
@@ -1,22 +1,82 @@
 import { Popover, PopoverContent, PopoverTrigger } from "@houston-ai/core";
 import { Plus } from "lucide-react";
-import type { ChangeEvent, ReactNode, RefObject } from "react";
+import type {
+  ChangeEvent,
+  InputHTMLAttributes,
+  ReactNode,
+  RefObject,
+} from "react";
 import { useState } from "react";
-import { AttachmentChip } from "./attachment-chip";
+import { AttachmentChip, FolderAttachmentChip } from "./attachment-chip";
+import { attachmentFolderRoot } from "./attachment-folders";
+import { fileIdentityKey } from "./clipboard-files";
+
+// Non-standard attribute (WebKit lineage, supported by every engine we ship
+// on): turns the picker into a directory picker. Unknown to React's typings,
+// hence the cast; engines without it fall back to a plain file picker.
+const FOLDER_INPUT_PROPS = {
+  webkitdirectory: "",
+} as InputHTMLAttributes<HTMLInputElement>;
 
 interface ChatInputAttachmentsProps {
   fileInputRef: RefObject<HTMLInputElement | null>;
+  folderInputRef: RefObject<HTMLInputElement | null>;
   files: File[];
   onFileChange: (event: ChangeEvent<HTMLInputElement>) => void;
-  onRemoveFile: (index: number) => void;
+  onRemoveFiles: (indices: readonly number[]) => void;
+  /** Localized "N files" line for a folder chip. English default. */
+  folderCountLabel?: (count: number) => string;
+}
+
+/** One chip per plain file; a whole attached folder collapses into ONE chip
+ *  (removing it removes every file inside). */
+interface ChipGroup {
+  key: string;
+  name: string;
+  indices: number[];
+  folder: boolean;
+}
+
+function groupAttachments(files: File[]): ChipGroup[] {
+  const groups: ChipGroup[] = [];
+  const folders = new Map<string, ChipGroup>();
+  files.forEach((file, index) => {
+    const root = attachmentFolderRoot(file);
+    if (!root) {
+      groups.push({
+        key: `file:${fileIdentityKey(file)}`,
+        name: file.name,
+        indices: [index],
+        folder: false,
+      });
+      return;
+    }
+    const existing = folders.get(root);
+    if (existing) {
+      existing.indices.push(index);
+      return;
+    }
+    const group: ChipGroup = {
+      key: `folder:${root}`,
+      name: root,
+      indices: [index],
+      folder: true,
+    };
+    folders.set(root, group);
+    groups.push(group);
+  });
+  return groups;
 }
 
 export function ChatInputAttachments({
   fileInputRef,
+  folderInputRef,
   files,
   onFileChange,
-  onRemoveFile,
+  onRemoveFiles,
+  folderCountLabel,
 }: ChatInputAttachmentsProps) {
+  const groups = groupAttachments(files);
   return (
     <>
       <input
@@ -27,33 +87,63 @@ export function ChatInputAttachments({
         onChange={onFileChange}
         tabIndex={-1}
       />
+      <input
+        ref={folderInputRef}
+        type="file"
+        multiple
+        className="sr-only"
+        onChange={onFileChange}
+        tabIndex={-1}
+        {...FOLDER_INPUT_PROPS}
+      />
 
-      {files.length > 0 && (
+      {groups.length > 0 && (
         <div
           className="flex gap-2 pb-1 mb-2 overflow-x-auto"
           style={{ scrollbarWidth: "thin" }}
         >
-          {files.map((file, idx) => (
-            <AttachmentChip
-              key={`${file.name}-${file.lastModified}`}
-              name={file.name}
-              onRemove={() => onRemoveFile(idx)}
-            />
-          ))}
+          {groups.map((group) =>
+            group.folder ? (
+              <FolderAttachmentChip
+                key={group.key}
+                name={group.name}
+                countLabel={
+                  folderCountLabel?.(group.indices.length) ??
+                  defaultFolderCount(group.indices.length)
+                }
+                onRemove={() => onRemoveFiles(group.indices)}
+              />
+            ) : (
+              <AttachmentChip
+                key={group.key}
+                name={group.name}
+                onRemove={() => onRemoveFiles(group.indices)}
+              />
+            ),
+          )}
         </div>
       )}
     </>
   );
 }
 
-type AttachMenuApi = { openFilePicker: () => void; close: () => void };
+function defaultFolderCount(count: number): string {
+  return count === 1 ? "1 file" : `${count} files`;
+}
+
+type AttachMenuApi = {
+  openFilePicker: () => void;
+  openFolderPicker: () => void;
+  close: () => void;
+};
 
 interface ChatInputAttachButtonProps {
   onOpenFilePicker: () => void;
+  onOpenFolderPicker: () => void;
   /** Optional popover menu. When provided, clicking the paperclip opens a
    *  popover instead of invoking `onOpenFilePicker` directly. The render-prop
-   *  form receives an API the caller uses to trigger the file picker from
-   *  inside the menu and close the popover. */
+   *  form receives an API the caller uses to trigger the file or folder
+   *  picker from inside the menu and close the popover. */
   attachMenu?: ReactNode | ((api: AttachMenuApi) => ReactNode);
   ariaLabel?: string;
   /** Locks the button inert (keyboard focus survives the composer's
@@ -63,6 +153,7 @@ interface ChatInputAttachButtonProps {
 
 export function ChatInputAttachButton({
   onOpenFilePicker,
+  onOpenFolderPicker,
   attachMenu,
   ariaLabel = "Attach files",
   disabled = false,
@@ -93,6 +184,10 @@ export function ChatInputAttachButton({
           openFilePicker: () => {
             setOpen(false);
             onOpenFilePicker();
+          },
+          openFolderPicker: () => {
+            setOpen(false);
+            onOpenFolderPicker();
           },
           close: () => setOpen(false),
         })

--- a/ui/chat/src/chat-input-types.ts
+++ b/ui/chat/src/chat-input-types.ts
@@ -38,10 +38,15 @@ export interface ChatInputProps {
   /** Optional menu rendered in a popover anchored to the paperclip button.
    *  When provided, clicking the button opens the popover instead of going
    *  straight to the file picker. The render-prop form receives an API the
-   *  caller can use to trigger the file picker from inside the menu. */
+   *  caller can use to trigger the file or folder picker from inside the
+   *  menu. */
   attachMenu?:
     | ReactNode
-    | ((api: { openFilePicker: () => void; close: () => void }) => ReactNode);
+    | ((api: {
+        openFilePicker: () => void;
+        openFolderPicker: () => void;
+        close: () => void;
+      }) => ReactNode);
   /** Messages accepted while a turn is active, waiting to be sent as one turn. */
   queuedMessages?: QueuedChatMessage[];
   onRemoveQueuedMessage?: (id: string) => void;

--- a/ui/chat/src/chat-input.tsx
+++ b/ui/chat/src/chat-input.tsx
@@ -52,10 +52,12 @@ export function ChatInput({
     setFiles,
     isFilesControlled,
     fileInputRef,
+    folderInputRef,
     handleFileChange,
     handlePaste,
     openFilePicker,
-    removeFile,
+    openFolderPicker,
+    removeFiles,
   } = useComposerAttachments({
     attachments,
     onAttachmentsChange,
@@ -146,9 +148,11 @@ export function ChatInput({
       >
         <ChatInputAttachments
           fileInputRef={fileInputRef}
+          folderInputRef={folderInputRef}
           files={files}
           onFileChange={handleFileChange}
-          onRemoveFile={removeFile}
+          onRemoveFiles={removeFiles}
+          folderCountLabel={labels?.folderFileCount}
         />
 
         <QueuedMessageList
@@ -164,6 +168,7 @@ export function ChatInput({
 
           <ChatInputAttachButton
             onOpenFilePicker={openFilePicker}
+            onOpenFolderPicker={openFolderPicker}
             attachMenu={attachMenu}
             disabled={disabled}
           />

--- a/ui/chat/src/chat-panel-types.ts
+++ b/ui/chat/src/chat-panel-types.ts
@@ -35,6 +35,12 @@ export interface ChatComposerLabels {
   /** Shown when an image was on the clipboard but the webview never
    *  handed over the bytes (Linux Wayland WebKitGTK). */
   imagePasteUnavailable?: string;
+  /** Shown when a folder pick/drop exceeds MAX_ATTACHMENT_FILES (HOU-808). */
+  tooManyFiles?: string;
+  /** Shown when expanding a dropped folder's contents fails. */
+  folderReadFailed?: string;
+  /** "N files" line on a folder chip. */
+  folderFileCount?: (count: number) => string;
 }
 
 export interface ChatPanelProps {
@@ -58,10 +64,14 @@ export interface ChatPanelProps {
   footer?: ReactNode;
   composerHeader?: ReactNode;
   /** Popover menu anchored to the paperclip button. Receives `openFilePicker`
-   *  so the menu can trigger the underlying file input. */
+   *  / `openFolderPicker` so the menu can trigger the underlying inputs. */
   attachMenu?:
     | ReactNode
-    | ((api: { openFilePicker: () => void; close: () => void }) => ReactNode);
+    | ((api: {
+        openFilePicker: () => void;
+        openFolderPicker: () => void;
+        close: () => void;
+      }) => ReactNode);
   queuedMessages?: QueuedChatMessage[];
   onRemoveQueuedMessage?: (id: string) => void;
   queuedLabels?: QueuedMessageLabels;

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -102,7 +102,10 @@ export function ChatPanel({
   const folderReadFailedNotice = composerLabels?.folderReadFailed;
   const onDropError = useCallback(
     (error: unknown) => {
-      onNotice?.(
+      // No notice channel → rethrow: the failure surfaces as an unhandled
+      // rejection (Sentry) instead of being silently swallowed.
+      if (!onNotice) throw error;
+      onNotice(
         error instanceof TooManyAttachmentFilesError
           ? (tooManyFilesNotice ?? DEFAULT_TOO_MANY_FILES_NOTICE)
           : (folderReadFailedNotice ??

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -5,13 +5,17 @@
  */
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Shimmer } from "./ai-elements/shimmer";
+import { TooManyAttachmentFilesError } from "./attachment-folders";
 import { ChatDropOverlay } from "./chat-drop-overlay";
 import { feedItemsToMessages } from "./chat-helpers";
 import { ChatInput } from "./chat-input";
 import { ChatMessages } from "./chat-messages";
 import type { ChatPanelProps } from "./chat-panel-types";
 import { deriveStatus } from "./chat-status";
-import { useAttachmentIntake } from "./use-attachment-intake";
+import {
+  DEFAULT_TOO_MANY_FILES_NOTICE,
+  useAttachmentIntake,
+} from "./use-attachment-intake";
 import { useControllable, useFileDropZone } from "./use-file-drop-zone";
 
 export type { ChatPanelProps } from "./chat-panel-types";
@@ -92,8 +96,25 @@ export function ChatPanel({
     onAttachmentRejections,
     onNotice,
     duplicateNotice: composerLabels?.fileAlreadyInChat,
+    tooManyNotice: composerLabels?.tooManyFiles,
   });
-  const { isDraggingOver, dropProps } = useFileDropZone(addDroppedFiles);
+  const tooManyFilesNotice = composerLabels?.tooManyFiles;
+  const folderReadFailedNotice = composerLabels?.folderReadFailed;
+  const onDropError = useCallback(
+    (error: unknown) => {
+      onNotice?.(
+        error instanceof TooManyAttachmentFilesError
+          ? (tooManyFilesNotice ?? DEFAULT_TOO_MANY_FILES_NOTICE)
+          : (folderReadFailedNotice ??
+              "Couldn't read the dropped folder. Try the attach button instead."),
+      );
+    },
+    [onNotice, tooManyFilesNotice, folderReadFailedNotice],
+  );
+  const { isDraggingOver, dropProps } = useFileDropZone(
+    addDroppedFiles,
+    onDropError,
+  );
 
   useEffect(() => {
     if (composerFocusToken === undefined) return;

--- a/ui/chat/src/clipboard-files.ts
+++ b/ui/chat/src/clipboard-files.ts
@@ -2,10 +2,13 @@
  * Stable identity for a user-attached File: name + size + lastModified.
  * Single source of truth so dedupe stays consistent across every entry
  * point (drop, picker, clipboard) and the multiple browser APIs that can
- * surface the same file twice.
+ * surface the same file twice. Folder-derived files identify by their
+ * folder-relative path instead of the bare name — a folder legitimately
+ * holds same-named same-sized files in different subfolders (HOU-808).
  */
 export function fileIdentityKey(file: File): string {
-  return `${file.name}::${file.size}::${file.lastModified}`;
+  const name = file.webkitRelativePath || file.name;
+  return `${name}::${file.size}::${file.lastModified}`;
 }
 
 // `kind`/`type` are loose `string` (not unions) on purpose: a real DOM

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -152,6 +152,12 @@ export type {
 } from "./ai-elements/suggestion";
 // === AI Elements: Suggestion ===
 export { Suggestion, Suggestions } from "./ai-elements/suggestion";
+export {
+  attachmentFolderRoot,
+  attachmentRelativePath,
+  MAX_ATTACHMENT_FILES,
+  TooManyAttachmentFilesError,
+} from "./attachment-folders";
 export type {
   AttachmentInvocation,
   AttachmentReference,

--- a/ui/chat/src/use-attachment-intake.ts
+++ b/ui/chat/src/use-attachment-intake.ts
@@ -1,9 +1,12 @@
 import { useCallback } from "react";
+import { MAX_ATTACHMENT_FILES } from "./attachment-folders";
 import type {
   AttachmentRejection,
   PrepareAttachments,
 } from "./chat-panel-types";
 import { mergeUniqueFiles } from "./use-file-drop-zone";
+
+export const DEFAULT_TOO_MANY_FILES_NOTICE = `You can attach up to ${MAX_ATTACHMENT_FILES} files at a time`;
 
 /**
  * The single ingest path for user-attached files. Every entry point (drop,
@@ -19,6 +22,7 @@ export interface AttachmentIntakeOptions {
   onAttachmentRejections?: (rejections: AttachmentRejection[]) => void;
   onNotice?: (message: string) => void;
   duplicateNotice?: string;
+  tooManyNotice?: string;
 }
 
 export function useAttachmentIntake({
@@ -28,9 +32,17 @@ export function useAttachmentIntake({
   onAttachmentRejections,
   onNotice,
   duplicateNotice,
+  tooManyNotice,
 }: AttachmentIntakeOptions): (incoming: File[]) => void {
   return useCallback(
     (incoming: File[]) => {
+      // A folder pick can sweep in thousands of files (the drop path already
+      // aborts its traversal at the same ceiling). Refuse the whole batch —
+      // attaching a silent subset would misrepresent what the agent gets.
+      if (incoming.length + files.length > MAX_ATTACHMENT_FILES) {
+        onNotice?.(tooManyNotice ?? DEFAULT_TOO_MANY_FILES_NOTICE);
+        return;
+      }
       const prepared = prepareAttachments
         ? prepareAttachments(incoming, files)
         : { accepted: incoming, rejected: [] };
@@ -48,6 +60,7 @@ export function useAttachmentIntake({
       setFiles,
       onNotice,
       duplicateNotice,
+      tooManyNotice,
       prepareAttachments,
       onAttachmentRejections,
     ],

--- a/ui/chat/src/use-composer-attachments.ts
+++ b/ui/chat/src/use-composer-attachments.ts
@@ -1,5 +1,6 @@
 import type { ChangeEvent, ClipboardEvent, RefObject } from "react";
 import { useCallback, useRef } from "react";
+import { visibleAttachmentFiles } from "./attachment-folders";
 import type {
   AttachmentRejection,
   ChatComposerLabels,
@@ -29,10 +30,12 @@ export interface ComposerAttachments {
   setFiles: (files: File[]) => void;
   isFilesControlled: boolean;
   fileInputRef: RefObject<HTMLInputElement | null>;
+  folderInputRef: RefObject<HTMLInputElement | null>;
   handleFileChange: (e: ChangeEvent<HTMLInputElement>) => void;
   handlePaste: (e: ClipboardEvent<HTMLTextAreaElement>) => void;
   openFilePicker: () => void;
-  removeFile: (index: number) => void;
+  openFolderPicker: () => void;
+  removeFiles: (indices: readonly number[]) => void;
 }
 
 export function useComposerAttachments({
@@ -50,6 +53,7 @@ export function useComposerAttachments({
   );
   const isFilesControlled = attachments !== undefined;
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const folderInputRef = useRef<HTMLInputElement>(null);
 
   const addFiles = useAttachmentIntake({
     files,
@@ -58,12 +62,16 @@ export function useComposerAttachments({
     onAttachmentRejections,
     onNotice,
     duplicateNotice: labels?.fileAlreadyInChat,
+    tooManyNotice: labels?.tooManyFiles,
   });
 
   const handleFileChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       if (!e.target.files || e.target.files.length === 0) return;
-      addFiles(Array.from(e.target.files));
+      // A folder pick sweeps in hidden files (.DS_Store, .git/**) the host
+      // refuses — filter them here; plain picks pass through untouched.
+      const picked = visibleAttachmentFiles(Array.from(e.target.files));
+      if (picked.length > 0) addFiles(picked);
       e.target.value = "";
     },
     [addFiles],
@@ -95,8 +103,20 @@ export function useComposerAttachments({
     input.click();
   }, []);
 
-  const removeFile = useCallback(
-    (index: number) => setFiles(files.filter((_, i) => i !== index)),
+  const openFolderPicker = useCallback(() => {
+    const input = folderInputRef.current;
+    if (!input) return;
+    input.value = "";
+    input.click();
+  }, []);
+
+  // Index-set removal (not single-index): a folder chip removes every file of
+  // that folder in ONE state update.
+  const removeFiles = useCallback(
+    (indices: readonly number[]) => {
+      const drop = new Set(indices);
+      setFiles(files.filter((_, i) => !drop.has(i)));
+    },
     [files, setFiles],
   );
 
@@ -105,9 +125,11 @@ export function useComposerAttachments({
     setFiles,
     isFilesControlled,
     fileInputRef,
+    folderInputRef,
     handleFileChange,
     handlePaste,
     openFilePicker,
-    removeFile,
+    openFolderPicker,
+    removeFiles,
   };
 }

--- a/ui/chat/src/use-file-drop-zone.ts
+++ b/ui/chat/src/use-file-drop-zone.ts
@@ -7,7 +7,7 @@
  */
 
 import type { DragEvent, DragEventHandler } from "react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { collectDroppedItems, resolveDroppedFiles } from "./attachment-folders";
 import { fileIdentityKey } from "./clipboard-files";
 
@@ -72,6 +72,16 @@ export function useFileDropZone(
 ): FileDropZone {
   const [isDraggingOver, setIsDraggingOver] = useState(false);
   const dragDepthRef = useRef(0);
+  // Folder expansion is async: by the time it resolves, the attachment state
+  // may have moved on (another drop, a remove, a send). Deliver through a ref
+  // so the LATEST ingest callback runs — never a stale closure that would
+  // overwrite newer state.
+  const onFilesRef = useRef(onFiles);
+  const onDropErrorRef = useRef(onDropError);
+  useEffect(() => {
+    onFilesRef.current = onFiles;
+    onDropErrorRef.current = onDropError;
+  });
 
   const hasFiles = useCallback(
     (e: DragEvent) => e.dataTransfer.types.includes("Files"),
@@ -120,15 +130,16 @@ export function useFileDropZone(
       if (dropped.length === 0) return;
       resolveDroppedFiles(dropped).then(
         (files) => {
-          if (files.length > 0) onFiles(files);
+          if (files.length > 0) onFilesRef.current(files);
         },
         (error) => {
-          if (!onDropError) throw error;
-          onDropError(error);
+          const handler = onDropErrorRef.current;
+          if (!handler) throw error;
+          handler(error);
         },
       );
     },
-    [hasFiles, onFiles, onDropError],
+    [hasFiles],
   );
 
   return {

--- a/ui/chat/src/use-file-drop-zone.ts
+++ b/ui/chat/src/use-file-drop-zone.ts
@@ -8,6 +8,7 @@
 
 import type { DragEvent, DragEventHandler } from "react";
 import { useCallback, useRef, useState } from "react";
+import { collectDroppedItems, resolveDroppedFiles } from "./attachment-folders";
 import { fileIdentityKey } from "./clipboard-files";
 
 /**
@@ -64,6 +65,10 @@ export interface FileDropZone {
 
 export function useFileDropZone(
   onFiles: (files: File[]) => void,
+  /** Called when expanding a dropped folder fails (unreadable directory,
+   *  too many files). Omitting it lets the rejection surface as an unhandled
+   *  rejection — never swallowed. */
+  onDropError?: (error: unknown) => void,
 ): FileDropZone {
   const [isDraggingOver, setIsDraggingOver] = useState(false);
   const dragDepthRef = useRef(0);
@@ -108,10 +113,22 @@ export function useFileDropZone(
       e.preventDefault();
       dragDepthRef.current = 0;
       setIsDraggingOver(false);
-      const dropped = Array.from(e.dataTransfer.files);
-      if (dropped.length > 0) onFiles(dropped);
+      // Capture entries/files SYNCHRONOUSLY — the DataTransfer is neutered
+      // once this handler returns. Expanding folders is async (directory
+      // reads), so the ingest is deferred to the resolved promise.
+      const dropped = collectDroppedItems(e.dataTransfer);
+      if (dropped.length === 0) return;
+      resolveDroppedFiles(dropped).then(
+        (files) => {
+          if (files.length > 0) onFiles(files);
+        },
+        (error) => {
+          if (!onDropError) throw error;
+          onDropError(error);
+        },
+      );
     },
-    [hasFiles, onFiles],
+    [hasFiles, onFiles, onDropError],
   );
 
   return {


### PR DESCRIPTION
Fixes HOU-808 — a user asked to upload folders of files in chat; until now the composer only took individual files, and dropping a folder silently attached nothing.

## Root cause

Three layers each blocked folders:
- the composer's hidden `<input type="file">` had no directory option;
- both drop zones read only `dataTransfer.files`, which flattens a dropped folder to an empty list — the drop did nothing, with no feedback;
- the host's `POST /agents/:id/attachments` rejected any filename containing a path separator, so folder structure had nowhere to go.

## What changed

**Host** (`packages/host/src/turn/attachments.ts`): each uploaded file may carry a `relPath` (mirrors `File.webkitRelativePath`, e.g. `docs/guide/a.md`). Every segment is held to the existing `safeFilename` rules (no traversal, no separators, no dot-names), capped at 32 segments / 1024 chars, and the file lands at `uploads/<relPath>` with the same per-file " (n)" dedupe as before. Folders deliberately **merge** rather than dedupe at the folder level: the client uploads one folder across several batched requests, and the returned per-file paths are exact either way.

**Adapter** (`packages/web/src/engine-adapter/cp/files-context.ts`): forwards `webkitRelativePath` as `relPath` and batches small files (8 MB / 25 files per request) instead of one request per file, so a 200-file folder isn't 200 round trips. Engine pods predating the field ignore it and store flat filenames — graceful degradation, no version gate.

**ui/chat**:
- "Add a folder" entry in the composer attach menu, backed by a second hidden `webkitdirectory` input;
- folder drag-and-drop via `webkitGetAsEntry()` traversal (entries captured synchronously before the `DataTransfer` is neutered; `readEntries` drained in batches); files produced by traversal are tagged with the same `webkitRelativePath` shape the picker produces;
- an attached folder renders as **one chip** (folder icon, "N files", one-click remove of the whole folder);
- hidden files (`.DS_Store`, `.git/**`) are filtered out of folder picks and drops — the host refuses dot-named segments, and failing the whole send over an invisible file would be worse;
- a 1000-file ceiling fails loudly with a notice (dropping `node_modules` must not upload for an hour);
- dedupe identity now includes the relative path, so two same-named files in different subfolders both attach.

**Prompt** (`app/src/lib/attachment-message.ts`): a folder collapses to one line — `- uploads/docs/ (uploaded folder with 12 files inside)` — instead of hundreds of file lines; the agent lists the folder with its file tools on demand. Only relative `uploads/…` paths group; legacy absolute paths keep per-file lines.

i18n: new strings in en/es/pt (`composerAttach.addFolder`, `composer.tooManyFiles`, `composer.folderReadFailed`, `composer.folderFileCount`).

## Reproduce the bug (before)

1. `pnpm dev`, open an agent chat.
2. Click the + attach button → only "Add files"; the picker cannot select a folder.
3. Drag a folder from Finder onto the chat: the overlay shows, the drop does nothing — no chip, no error.

## Verify the fix (after)

1. `pnpm dev`, open an agent chat.
2. Click + → **Add a folder**, pick a folder with subfolders: one folder chip appears with the file count.
3. Send with a prompt like "what's in there?": the message shows "N files attached"; the agent reads `uploads/<folder>/…` with structure intact; the Files tab shows the nested folder.
4. Drag-and-drop a folder onto the chat: same result.
5. Drop a mixed selection (folder + loose files): loose files chip individually, the folder stays one chip.
6. Attach the same folder twice: files inside dedupe as `name (1).ext`, still inside the same folder.
7. Drop a huge folder (>1000 files): loud notice, nothing attached.

Tests: host attachments suite grown to 18 (structure, merge/dedupe, hostile relPaths, HTTP relPath, non-string relPath 400), app prompt-grouping tests. Full gates green: host 1048 / runtime 737 / domain 147 / app 1957 tests, `pnpm typecheck`, `packages/web` typecheck + shim parity, `check-locales`, `check:boundaries`, Biome.