### PR TITLE
fix: keep the open chat when clicking outside the board panel

### DIFF
--- a/app/src/components/mission-control-toolbar.tsx
+++ b/app/src/components/mission-control-toolbar.tsx
@@ -172,7 +172,6 @@ export function MissionControlToolbar({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
-                    data-keep-panel-open
                     size={collapsed ? "icon" : "default"}
                     className={cn(collapsed && "rounded-full")}
                     onClick={onNewMission}

--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -256,10 +256,7 @@ export function WorkspaceShell({
                           activeTab={viewMode}
                           onTabChange={setViewMode}
                           actions={
-                            <div
-                              data-keep-panel-open
-                              className="flex min-w-0 flex-1 items-center justify-end gap-2"
-                            >
+                            <div className="flex min-w-0 flex-1 items-center justify-end gap-2">
                               {currentAgent && (
                                 <MissionSearchInput
                                   value={agentMissionSearchQuery}

--- a/app/src/components/tabs/routine-setup-chat-board.tsx
+++ b/app/src/components/tabs/routine-setup-chat-board.tsx
@@ -149,10 +149,7 @@ export function RoutineSetupChatBoard({
         selectedId={activity.id}
         onSelect={onPanelClose ? handlePanelSelect : noop}
         panelContainer={panelContainer}
-        // Clicks on app chrome or the persistent list must NOT dismiss the pane;
-        // only the close X (or Escape) deselects it. The X shows only when a
-        // deselect handler is wired (`onPanelClose`).
-        disableOutsideClose
+        // The close X shows only when a deselect handler is wired (`onPanelClose`).
         hidePanelClose={onPanelClose ? undefined : true}
         feedItems={feedItems}
         isLoading={send.effectiveLoading}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -1967,7 +1967,6 @@ export function useAgentChatPanel({
         <button
           type="button"
           onClick={() => setPickerOpen(true)}
-          data-keep-panel-open
           className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full text-xs font-medium text-ink-muted hover:text-ink hover:bg-hover transition-colors"
         >
           <Play className="size-3 fill-current" />

--- a/packages/web/e2e/board.spec.ts
+++ b/packages/web/e2e/board.spec.ts
@@ -223,6 +223,24 @@ test("opens a mission's chat when its card is clicked", async ({ page }) => {
   await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
 });
 
+/**
+ * Clicks on app chrome (sidebar, titlebar, toolbar) must NOT dismiss an open
+ * chat — only an explicit close (the X, Escape, delete, agent switch) does.
+ * The board once closed the panel on any outside pointerdown; a stray click
+ * anywhere silently dropped the conversation the user was reading.
+ */
+test("keeps the open chat when clicking app chrome outside the panel", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByText("Plan a trip to Tokyo").click();
+  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
+
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
+
+  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
+});
+
 /** The "Search missions" box filters the board client-side. */
 test("filters the board with the search box", async ({ page }) => {
   await page.goto("/");

--- a/packages/web/e2e/sign-in.spec.ts
+++ b/packages/web/e2e/sign-in.spec.ts
@@ -170,12 +170,12 @@ test.describe("returning user (last sign-in continue)", () => {
   }) => {
     await seedLastSignIn(page, "google.com", "jane@gethouston.ai");
     await page.goto("/");
-    // The prominent continue button carries the masked address in its name,
-    // distinguishing it from the plain "Continue with Google" pill below.
+    // The prominent continue button carries the full stored address in its
+    // name, distinguishing it from the plain "Continue with Google" pill below.
     await expect(
       page.getByRole("button", { name: /^Continue with Google \(/ }),
     ).toBeVisible();
-    await expect(page.getByText("j…@gethouston.ai")).toBeVisible();
+    await expect(page.getByText("jane@gethouston.ai")).toBeVisible();
     // The pills + email form stay below the "another way" divider.
     await expect(page.getByText("or use another way")).toBeVisible();
     await expect(page.getByPlaceholder("you@example.com")).toBeVisible();
@@ -189,8 +189,8 @@ test.describe("returning user (last sign-in continue)", () => {
     await page
       .getByRole("button", { name: /^Continue with your email \(/ })
       .click();
-    // One click lands straight on the 6-digit entry, naming the FULL stored
-    // email (masked on the button, real value used to send the code).
+    // One click lands straight on the 6-digit entry, naming the stored
+    // email the code was sent to.
     await expect(page.locator('[data-slot="input-otp-slot"]')).toHaveCount(6);
     await expect(
       page.getByText("We sent a 6-digit code to pilot@example.com"),

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -174,15 +174,6 @@ export interface AIBoardProps {
    */
   panelContainer?: HTMLElement | null;
   /**
-   * Keep the detail panel open on clicks outside the board/panel. For a
-   * board whose panel is a transient overlay, outside clicks dismiss it
-   * (the default); a panel that is a persistent companion of its host view
-   * (e.g. the routine setup chat living beside the routine form) sets this
-   * so only an explicit close (the X, tab switch, unmount) dismisses it —
-   * otherwise any click on app chrome (sidebar, titlebar) silently drops it.
-   */
-  disableOutsideClose?: boolean;
-  /**
    * Skip the automatic composer focus when a selection hydrates. The board
    * bumps the composer focus token so keyboard users can type immediately —
    * but when the panel is a side companion of a form (the routine editor's
@@ -194,7 +185,7 @@ export interface AIBoardProps {
   /**
    * Hide the detail panel's close button. For a panel that is a permanent
    * part of its host view (the routine editor's chat), there is nothing for
-   * an X to mean — combine with `disableOutsideClose`.
+   * an X to mean.
    */
   hidePanelClose?: boolean;
   /**
@@ -307,7 +298,6 @@ export function AIBoard({
   actions,
   panelActions,
   panelContainer,
-  disableOutsideClose,
   disableComposerAutoFocus,
   hidePanelClose,
   drafts,
@@ -605,78 +595,10 @@ export function AIBoard({
     onPanelCloserReady?.(closePanel);
   }, [onPanelCloserReady, closePanel]);
 
-  // Refs for outside-click detection.
-  const boardRef = useRef<HTMLDivElement | null>(null);
-  const panelRef = useRef<HTMLDivElement | null>(null);
-
-  // Close the panel when the user clicks anywhere outside the board or
-  // the detail panel (sidebar, tab bar, other app chrome, etc.).
-  //
-  // We listen for `pointerdown` at the CAPTURE phase rather than
-  // `mousedown` at bubble. Two reasons:
-  //  1. Radix DismissableLayer (used by every popover / dropdown /
-  //     select / menu) dismisses on `pointerdown`. By the time a
-  //     bubble-phase `mousedown` fires, Radix has already called
-  //     `onOpenChange(false)`, flipped `data-state` to "closed", and —
-  //     when the component has no exit animation — unmounted the
-  //     popper wrapper entirely. Any "is a popper currently open"
-  //     check we run from `mousedown` is too late: the DOM no longer
-  //     shows one.
-  //  2. Capture phase runs root → target. By listening at capture on
-  //     `document`, we see the event before any descendant handler
-  //     (including Radix's, which is registered later on the layer
-  //     after the popper opens). At that moment the popper is still
-  //     open with `data-state="open"`, so we can detect it reliably.
-  useEffect(() => {
-    if (!showPanel || disableOutsideClose) return;
-    const handler = (e: PointerEvent) => {
-      const target = e.target as Node | null;
-      if (!target) return;
-      if (boardRef.current?.contains(target)) return;
-      if (panelRef.current?.contains(target)) return;
-      if (target instanceof Element) {
-        // Clicks INSIDE a Radix popper (its portal lives outside the
-        // panel DOM) — the user is interacting with a menu we opened
-        // from the panel, not dismissing the panel itself.
-        if (target.closest("[data-radix-popper-content-wrapper]")) return;
-        // Any Radix popper currently open (anywhere in the document)
-        // intercepts this pointerdown as its own dismiss gesture. The
-        // panel should not also close — Radix dismisses the popper,
-        // user can decide whether to dismiss the panel with a follow-
-        // up click. Because we're at capture phase + pointerdown,
-        // Radix hasn't flipped `data-state` yet, so the open selector
-        // matches.
-        if (
-          document.querySelector('[data-state="open"][data-slot$="-content"]')
-        )
-          return;
-        // Belt-and-suspenders fallback for non-shadcn-styled poppers
-        // that don't carry the `data-slot$="-content"` marker but
-        // still use Radix Popper under the hood.
-        if (document.querySelector("[data-radix-popper-content-wrapper]"))
-          return;
-        // Radix Dialog content + overlay also live in a portal outside
-        // both refs. Clicking inside a dialog (or its overlay) is the
-        // user interacting with a modal we just opened FROM the panel,
-        // not an intent to dismiss the panel.
-        if (target.closest("[data-slot='dialog-content']")) return;
-        if (target.closest("[data-slot='dialog-overlay']")) return;
-        // Generic opt-out: any ancestor with `data-keep-panel-open` is
-        // treated as part of the panel's interaction surface (e.g. the
-        // top-bar "New mission" button which transitions the panel
-        // between selected-chat and new-conversation states).
-        if (target.closest("[data-keep-panel-open]")) return;
-      }
-      closePanel();
-    };
-    document.addEventListener("pointerdown", handler, true);
-    return () => document.removeEventListener("pointerdown", handler, true);
-  }, [showPanel, disableOutsideClose, closePanel]);
-
   const showBulkBar = selectable && bulkActions && (selectedIds?.size ?? 0) > 0;
 
   const board = (
-    <div ref={boardRef} className="relative flex flex-col h-full">
+    <div className="relative flex flex-col h-full">
       {layout === "list" ? (
         <KanbanList
           items={items}
@@ -730,7 +652,6 @@ export function AIBoard({
 
   const detailPanel = (
     <KanbanDetailPanel
-      ref={panelRef}
       title={panelTitle}
       onClose={hidePanelClose ? undefined : closePanel}
       leading={panelLeading}

--- a/ui/board/src/bulk-action-bar.tsx
+++ b/ui/board/src/bulk-action-bar.tsx
@@ -101,10 +101,7 @@ export function BulkActionBar({
 
   return (
     <>
-      <div
-        data-keep-panel-open
-        className="absolute bottom-6 left-1/2 z-20 flex -translate-x-1/2 items-center gap-1 rounded-full border border-line/60 bg-popover px-2 py-1.5 shadow-lg"
-      >
+      <div className="absolute bottom-6 left-1/2 z-20 flex -translate-x-1/2 items-center gap-1 rounded-full border border-line/60 bg-popover px-2 py-1.5 shadow-lg">
         <span className="px-2 text-xs font-medium tabular-nums text-ink-muted">
           {labels.selected(count)}
         </span>

--- a/ui/board/src/panel-state.ts
+++ b/ui/board/src/panel-state.ts
@@ -16,8 +16,8 @@ export interface ResolvedSelection {
  * an item-presence check unmounted the whole chat panel for that window and
  * remounted it a beat later (a visible close/reopen flicker of an open chat,
  * HOU-693/HOU-730). The open conversation must outlive its card: only an
- * explicit deselect (close button, outside click, Escape, delete, agent
- * switch) closes the panel.
+ * explicit deselect (close button, Escape, delete, agent switch) closes
+ * the panel.
  *
  * While the card is absent, `panelItem` falls back to the same selection's
  * last resolved card, so the header (title, people, actions) doesn't flash


### PR DESCRIPTION
## Problem

With a conversation open, clicking anywhere on app chrome outside the board/panel (sidebar, titlebar, tab bar, toolbar) silently closed the chat. The board's detail panel had a document-level `pointerdown` capture listener that treated it as a transient overlay and dismissed it on any outside click.

## Fix

The panel is a persistent companion of the board, so the outside-click close mechanism is removed entirely rather than opted out per surface:

- `ui/board/src/ai-board.tsx`: delete the capture-phase `pointerdown` effect, its two detection refs, the `disableOutsideClose` prop, and all the Radix popper/dialog special-casing that existed only to keep menus from double-dismissing the panel.
- Remove the four `data-keep-panel-open` opt-out markers (mission toolbar, workspace shell actions, chat skill button, bulk-action bar) that fed the deleted check.
- `routine-setup-chat-board.tsx`: drop the now-gone `disableOutsideClose` prop.

Explicit closes are untouched: the X button, Escape, mission delete, and agent switch still dismiss the panel.

## Drive-by

`packages/web/e2e/sign-in.spec.ts` was red on `main`: #1041 switched the returning-user continue button to show the full stored email, but the spec still asserted the old masked `j…@gethouston.ai`. Assertion updated to the full address.

## Tests

- New e2e regression in `board.spec.ts`: open a mission chat, click app chrome (collapse-sidebar button, which previously closed the chat), assert the composer stays visible.
- Biome clean, full workspace typecheck green, board unit tests 34/34, full web e2e suite passes (133 including the new test).