### PR TITLE
feat: label Linear issues at the cut, not just at publish

### DIFF
--- a/.github/workflows/linear-release-stamp.yml
+++ b/.github/workflows/linear-release-stamp.yml
@@ -1,12 +1,20 @@
-# Linear release stamp — the release train's bookkeeping step.
+# Linear release stamp — the release train's bookkeeping, at both of its moments.
 #
-# Fires when a cloud-v* release is PUBLISHED (the ship button — same trigger as
-# cloud-updater-manifest.yml and ship-train.yml). It stamps the shipped Linear
-# issues and writes the changelogs; see scripts/linear-release-stamp.mjs for the
-# full behavior. Deliberately an OBSERVER: it needs no build outputs, runs after
-# the ship decision, and the script exits 0 on Linear failures so a tracker
-# outage can never block or taint a release. Re-running is safe (idempotent per
-# issue via the release label).
+#   TAG PUSH (cloud-v*)   = the 07:45 cut. Labels the train's Linear issues
+#                           `cloud-vX.Y.Z` so the 08:30 QA review is a filter
+#                           (App Review + that label). GitHub Actions never fires
+#                           on draft-release creation, but the tag push that
+#                           births the draft does — and it's PAT-authenticated
+#                           (RELEASE_CUT_TOKEN), so it triggers workflows.
+#   RELEASE PUBLISHED     = the ship button (same trigger as
+#                           cloud-updater-manifest.yml / ship-train.yml). Moves
+#                           issues to Released, comments, appends the internal +
+#                           WhatsApp changelogs to the release body.
+#
+# See scripts/linear-release-stamp.mjs for full behavior. Deliberately an
+# OBSERVER: needs no build outputs, runs beside the train, and the script exits
+# 0 on Linear failures so a tracker outage can never block a cut or a ship.
+# Re-running either mode is safe (idempotent per issue).
 #
 # Secrets: LINEAR_API_KEY — a Linear personal API key (workspace houston-ai).
 # contents: write is required to append the changelogs to the release body.
@@ -14,6 +22,8 @@
 name: Linear release stamp
 
 on:
+  push:
+    tags: ["cloud-v*"]
   release:
     types: [published]
 
@@ -22,12 +32,12 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: linear-release-stamp-${{ github.event.release.tag_name }}
+  group: linear-release-stamp-${{ github.event_name == 'push' && github.ref_name || github.event.release.tag_name }}-${{ github.event_name }}
   cancel-in-progress: false
 
 jobs:
   stamp:
-    if: startsWith(github.event.release.tag_name, 'cloud-v')
+    if: github.event_name == 'push' || startsWith(github.event.release.tag_name, 'cloud-v')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -35,12 +45,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Stamp Linear issues + changelogs
+      - name: Stamp Linear issues
         run: node scripts/linear-release-stamp.mjs
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          STAMP_MODE: ${{ github.event_name == 'push' && 'draft' || 'publish' }}
+          RELEASE_TAG: ${{ github.event_name == 'push' && github.ref_name || github.event.release.tag_name }}
           RELEASE_URL: ${{ github.event.release.html_url }}
           RELEASE_ID: ${{ github.event.release.id }}

--- a/scripts/linear-release-stamp.mjs
+++ b/scripts/linear-release-stamp.mjs
@@ -1,27 +1,37 @@
 #!/usr/bin/env node
-// Linear release stamp — runs when a cloud-v* draft release is PUBLISHED (the
-// ship button). Downstream observer only: it must never block or fail a ship.
+// Linear release stamp — two moments of the release train, one script:
 //
-// What it does, per train:
-//   1. Diff this cloud-v* tag against the previous PUBLISHED cloud-v* release.
-//   2. Collect the PRs merged in between; extract `Fixes HOU-N` magic words
-//      from their bodies (the convention in the workspace CLAUDE.md).
-//   3. In Linear: apply a `cloud-vX.Y.Z` label (under the "Release" label
-//      group), move each issue to "Released" (never demoting Done/canceled),
-//      and comment a link to the release. Idempotent: an issue already carrying
-//      the release label is skipped, so re-running the workflow is safe.
-//   4. Append two changelogs to the GitHub release body: an internal list
-//      grouped by Linear project, and a WhatsApp draft with the reporter phone
-//      numbers pulled from User Bug issues (drives the notify-the-reporter
-//      step).
+//   STAMP_MODE=draft    fired by the cloud-v* TAG PUSH (the 07:45 cut; GitHub
+//                       Actions never fires on draft-release creation, but the
+//                       tag push that births the draft does). Applies the
+//                       `cloud-vX.Y.Z` label to every issue in the train so the
+//                       08:30 QA review is a Linear filter (App Review + label).
+//                       No state changes, no comments — the ship decision
+//                       hasn't happened yet.
 //
-// Env: LINEAR_API_KEY, GITHUB_TOKEN, REPO (owner/name), RELEASE_TAG,
-//      RELEASE_URL, RELEASE_ID.
+//   STAMP_MODE=publish  fired when the release is PUBLISHED (the ship button).
+//                       Moves the train's issues to "Released", comments the
+//                       release link, and appends two changelogs to the release
+//                       body: internal (grouped by Linear project) and a
+//                       WhatsApp draft with reporter phones from User Bug
+//                       issues.
+//
+// Idempotency: labels are add-if-missing; the state move + comment happen only
+// when the issue actually transitions (already-completed/canceled issues are
+// never touched); the body append is guarded by a marker. Re-running either
+// mode is safe.
+//
+// Deliberately an OBSERVER: exits 0 on failure so a Linear outage can never
+// block or taint a cut or a ship.
+//
+// Env: LINEAR_API_KEY, GITHUB_TOKEN, REPO (owner/name), STAMP_MODE,
+//      RELEASE_TAG; publish mode only: RELEASE_URL, RELEASE_ID.
 
 const {
   LINEAR_API_KEY,
   GITHUB_TOKEN,
   REPO,
+  STAMP_MODE,
   RELEASE_TAG,
   RELEASE_URL,
   RELEASE_ID,
@@ -69,14 +79,8 @@ function cmp(a, b) {
   return 0;
 }
 
-async function main() {
-  const cur = semver(RELEASE_TAG);
-  if (!cur) {
-    console.log(`Tag ${RELEASE_TAG} is not cloud-v*; nothing to do.`);
-    return;
-  }
-
-  // 1. Previous published cloud-v* release (drafts excluded; prereleases count —
+async function trainIssueKeys(cur) {
+  // Previous published cloud-v* release (drafts excluded; prereleases count —
   // cloud releases are deliberately kept prerelease, see daily-cloud-cut.yml).
   const releases = await gh(`/repos/${REPO}/releases?per_page=100`);
   const prev = releases
@@ -86,14 +90,14 @@ async function main() {
     .sort((a, b) => cmp(semver(b.tag_name), semver(a.tag_name)))[0];
   if (!prev) {
     console.log(
-      "No previous published cloud-v* release found; skipping (first train).",
+      "No previous published cloud-v* release; skipping (first train).",
     );
-    return;
+    return null;
   }
   console.log(`Train: ${prev.tag_name} -> ${RELEASE_TAG}`);
 
-  // 2. PRs merged between the two cut points. The compare API caps at 250
-  // commits; a daily train is far below that, but log loudly if truncated.
+  // PRs merged between the two cut points. The compare API caps at 250 commits;
+  // a daily train is far below that, but log loudly if truncated.
   const compare = await gh(
     `/repos/${REPO}/compare/${prev.tag_name}...${RELEASE_TAG}`,
   );
@@ -122,10 +126,20 @@ async function main() {
     }
   }
   console.log(`Linear issues: ${[...issueKeys].join(", ") || "none"}`);
-  if (issueKeys.size === 0) return;
+  return issueKeys;
+}
 
-  // 3. Linear: Released state + release label (created under the "Release"
-  // group on first use) + comment.
+async function main() {
+  const cur = semver(RELEASE_TAG || "");
+  if (!cur) {
+    console.log(`Tag ${RELEASE_TAG} is not cloud-v*; nothing to do.`);
+    return;
+  }
+  const publish = STAMP_MODE === "publish";
+
+  const issueKeys = await trainIssueKeys(cur);
+  if (!issueKeys || issueKeys.size === 0) return;
+
   const teamData = await lin(
     `query($t: String!) { team(id: $t) {
        states { nodes { id name type } }
@@ -183,30 +197,24 @@ async function main() {
       );
       const issue = d.issue;
       const labelNames = issue.labels.nodes.map((l) => l.name);
-      const alreadyStamped = labelNames.includes(RELEASE_TAG);
-      const isUserBug = labelNames.includes(USER_BUG_LABEL);
-      const phones =
-        (issue.description || "")
-          .match(/Reporter phone\(s\):\*{0,2}\s*([^\n]+)/)?.[1]
-          ?.trim() ?? null;
+      const actions = [];
 
-      if (!alreadyStamped) {
+      if (!labelNames.includes(RELEASE_TAG)) {
         await lin(
           `mutation($id: String!, $l: String!) { issueAddLabel(id: $id, labelId: $l) { success } }`,
-          {
-            id: issue.id,
-            l: tagLabel.id,
-          },
+          { id: issue.id, l: tagLabel.id },
         );
-        if (issue.state.name !== "Done" && issue.state.type !== "canceled") {
-          await lin(
-            `mutation($id: String!, $s: String!) { issueUpdate(id: $id, input: { stateId: $s }) { success } }`,
-            {
-              id: issue.id,
-              s: released.id,
-            },
-          );
-        }
+        actions.push("labeled");
+      }
+      if (
+        publish &&
+        issue.state.type !== "completed" &&
+        issue.state.type !== "canceled"
+      ) {
+        await lin(
+          `mutation($id: String!, $s: String!) { issueUpdate(id: $id, input: { stateId: $s }) { success } }`,
+          { id: issue.id, s: released.id },
+        );
         await lin(
           `mutation($i: CommentCreateInput!) { commentCreate(input: $i) { success } }`,
           {
@@ -216,24 +224,27 @@ async function main() {
             },
           },
         );
+        actions.push("released");
       }
+
+      const phones =
+        (issue.description || "")
+          .match(/Reporter phone\(s\):\*{0,2}\s*([^\n]+)/)?.[1]
+          ?.trim() ?? null;
       stamped.push({
         key: issue.identifier,
         title: issue.title,
         project: issue.project?.name ?? "(no project)",
-        isUserBug,
-        phones: isUserBug ? phones : null,
+        isUserBug: labelNames.includes(USER_BUG_LABEL),
+        phones: labelNames.includes(USER_BUG_LABEL) ? phones : null,
       });
-      console.log(
-        `${issue.identifier}: ${alreadyStamped ? "already stamped" : "stamped"}`,
-      );
+      console.log(`${issue.identifier}: ${actions.join("+") || "no-op"}`);
     } catch (e) {
       console.warn(`${key}: ${e.message}`);
     }
   }
   if (stamped.length === 0) return;
 
-  // 4. Changelogs appended to the release body.
   const byProject = new Map();
   for (const s of stamped) {
     if (!byProject.has(s.project)) byProject.set(s.project, []);
@@ -246,30 +257,32 @@ async function main() {
       internal += `- ${s.key} — ${s.title}${s.isUserBug ? " 🐛" : ""}\n`;
   }
 
-  const bugs = stamped.filter((s) => s.isUserBug);
-  let wa = `\n## WhatsApp draft\n\n\`\`\`\n🚀 Nueva versión de Houston!\n`;
-  for (const s of stamped) wa += `✅ ${s.title}\n`;
-  wa += `Gracias a todos los que reportaron 🙌\n\`\`\`\n`;
-  if (bugs.length) {
-    wa += `\n**Notify reporters** (then clear the \`Notify pending\` label):\n`;
-    for (const b of bugs)
-      wa += `- ${b.key} → ${b.phones ?? "⚠️ no phone on issue"}\n`;
+  let wa = "";
+  if (publish) {
+    const bugs = stamped.filter((s) => s.isUserBug);
+    wa = `\n## WhatsApp draft\n\n\`\`\`\n🚀 Nueva versión de Houston!\n`;
+    for (const s of stamped) wa += `✅ ${s.title}\n`;
+    wa += `Gracias a todos los que reportaron 🙌\n\`\`\`\n`;
+    if (bugs.length) {
+      wa += `\n**Notify reporters** (then clear the \`Notify pending\` label):\n`;
+      for (const b of bugs)
+        wa += `- ${b.key} → ${b.phones ?? "⚠️ no phone on issue"}\n`;
+    }
+
+    const rel = await gh(`/repos/${REPO}/releases/${RELEASE_ID}`);
+    if (!(rel.body || "").includes(`## Linear — ${RELEASE_TAG}`)) {
+      await gh(`/repos/${REPO}/releases/${RELEASE_ID}`, {
+        method: "PATCH",
+        body: JSON.stringify({ body: (rel.body || "") + internal + wa }),
+      });
+    }
   }
 
-  const rel = await gh(`/repos/${REPO}/releases/${RELEASE_ID}`);
-  if (!(rel.body || "").includes(`## Linear — ${RELEASE_TAG}`)) {
-    await gh(`/repos/${REPO}/releases/${RELEASE_ID}`, {
-      method: "PATCH",
-      body: JSON.stringify({ body: (rel.body || "") + internal + wa }),
-    });
-  }
   if (process.env.GITHUB_STEP_SUMMARY) {
     const { appendFileSync } = await import("node:fs");
     appendFileSync(process.env.GITHUB_STEP_SUMMARY, internal + wa);
   }
-  console.log(
-    `Stamped ${stamped.length} issues; changelogs appended to the release.`,
-  );
+  console.log(`${STAMP_MODE}: processed ${stamped.length} issues.`);
 }
 
 main().catch((e) => {


### PR DESCRIPTION
## What

Extends the Linear release stamp with a **draft mode** fired by the `cloud-v*` tag push (the 07:45 cut):

- **Tag push (cut):** applies the `cloud-vX.Y.Z` label to every issue in the train — no state changes. The 08:30 QA review becomes a Linear filter: `App Review` + today's train label.
- **Release published (ship):** unchanged behavior — moves issues to Released, comments, appends internal + WhatsApp changelogs to the release body.

## Why

Reviewing a draft was 'everything in App Review, hope it's all in this train'. Labeling at cut time makes 'what is in this draft' exact, even when something merges after the cut.

## Notes

- GitHub Actions doesn't fire on draft-release creation; the tag push that births the draft does (and it's PAT-authenticated, so workflows trigger — same mechanism release.yml relies on).
- Idempotency reworked: label add-if-missing; state move + comment only on actual transition (publish after draft no longer no-ops the Released move).
- Still an observer: script exits 0 on any failure; can never block a cut or a ship.
- No Linear issue — release-train tooling itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)