### PR TITLE
fix(ci): green-main guard must ignore the cut's own failed runs

### DIFF
--- a/.github/workflows/daily-cloud-cut.yml
+++ b/.github/workflows/daily-cloud-cut.yml
@@ -177,7 +177,10 @@ jobs:
       #    merges land green through PR gates, and a still-running post-merge job
       #    must not starve the cut. Zero check-runs is treated as green. On red,
       #    name the failing checks and (if configured) ping Slack before the
-      #    08:30 daily, then fail.
+      #    08:30 daily, then fail. This workflow's OWN job ("cut") is excluded
+      #    from the sweep: a dispatch run's check-runs attach to the main tip,
+      #    so a failed cut attempt would otherwise read as "main is red" and
+      #    deadlock every subsequent cut against its own history.
       - name: Guard — main is green
         if: ${{ steps.newcommits.outputs.proceed == 'true' }}
         env:
@@ -188,7 +191,7 @@ jobs:
           set -euo pipefail
           FAILING=$(gh api --paginate \
             "repos/${{ github.repository }}/commits/${MAIN_TIP}/check-runs" \
-            -q '.check_runs[] | select(.status == "completed") | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled") | .name' \
+            -q '.check_runs[] | select(.status == "completed") | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled") | select(.name != "cut") | .name' \
             | sort -u)
 
           if [ -z "$FAILING" ]; then


### PR DESCRIPTION
Failed cut dispatches attach failed check-runs named `cut` to the main tip; the green-main guard then reads main as red and blocks every subsequent cut — a self-deadlock (hit live today after the token-config failures). The sweep now excludes this workflow's own job name.

No Linear issue — CI infrastructure fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)