### PR TITLE
perf(chat): open chats on the transcript tail + scroll-up lazy-load (HOU-819)

### DIFF
--- a/app/src/components/board/board-source.ts
+++ b/app/src/components/board/board-source.ts
@@ -119,6 +119,11 @@ export interface BoardSource {
     sessionKey: string,
     opts?: HistoryLoadOptions,
   ) => Promise<FeedItem[]>;
+  /** Scroll-up lazy-load for the OPEN chat (HOU-819): prepend the previous
+   *  transcript page of the active conversation. */
+  onLoadOlderMessages?: () => Promise<unknown>;
+  /** Older messages exist beyond the open chat's loaded window. */
+  hasOlderMessages?: boolean;
   /** Raw send (no queue). `overrides` carry the composer's effective
    *  provider/model; the per-agent source uses them, Mission Control resolves
    *  its own from the target activity. */

--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -146,6 +146,8 @@ export function MissionBoard({ source }: { source: BoardSource }) {
           onRemoveQueuedMessage={sendQueue.onRemoveQueuedMessage}
           queuedLabels={queuedLabels}
           onLoadHistory={source.loadHistory}
+          onLoadOlderMessages={source.onLoadOlderMessages}
+          hasOlderMessages={source.hasOlderMessages}
           onNewPanelOpenerReady={source.registerOpener}
           onPanelCloserReady={handleCloserReady}
           emptyState={source.emptyState}

--- a/app/src/components/board/mission-control-archived.tsx
+++ b/app/src/components/board/mission-control-archived.tsx
@@ -134,6 +134,8 @@ export function MissionControlArchived({
           onSendMessage={handleSendMessage}
           onComposerSubmit={panel.onComposerSubmit}
           onLoadHistory={data.loadHistory}
+          onLoadOlderMessages={data.onLoadOlderMessages}
+          hasOlderMessages={data.hasOlderMessages}
           emptyState={
             <ArchivedEmptyState
               hasQuery={missionSearch.hasQuery}

--- a/app/src/components/board/use-agent-board-data.ts
+++ b/app/src/components/board/use-agent-board-data.ts
@@ -9,7 +9,7 @@ import {
   useDeleteActivity,
   useUpdateActivity,
 } from "../../hooks/queries";
-import { useConversationFeed } from "../../hooks/use-conversation-vm";
+import { useConversationVm } from "../../hooks/use-conversation-vm";
 import { useWarmingBoardRows } from "../../hooks/use-warming-board-rows";
 import { missionCardTags } from "../../lib/mission-card";
 import { canDropMission, selectActive } from "../../lib/mission-selection";
@@ -22,6 +22,8 @@ import type { Agent, AgentDefinition } from "../../lib/types";
 import { mergeWarmingRows } from "../../lib/warming-board-rows";
 import { useUIStore } from "../../stores/ui";
 import { missionColumnIdForStatus } from "../mission-board-columns";
+
+const EMPTY_FEED: FeedItem[] = [];
 
 /**
  * Per-agent board data: maps this agent's activities to kanban items, exposes
@@ -107,11 +109,21 @@ export function useAgentBoardData({
     activeSessionKey ? path : undefined,
     activeSessionKey ?? undefined,
   );
-  const activeFeed = useConversationFeed(path, activeSessionKey);
+  const activeVm = useConversationVm(path, activeSessionKey);
+  const activeFeed = activeVm?.feed ?? EMPTY_FEED;
   const feedItems = useMemo<Record<string, FeedItem[]>>(
     () => (activeSessionKey ? { [activeSessionKey]: activeFeed } : {}),
     [activeSessionKey, activeFeed],
   );
+  // Scroll-up lazy-load (HOU-819): the open chat renders only the transcript's
+  // tail window; when older messages exist server-side the panel prepends the
+  // previous page as the user scrolls up. `hasOlderMessages` comes off the
+  // VM's stamped window, so it flips as pages land.
+  const hasOlderMessages = (activeVm?.historyWindow?.earliestLoaded ?? 0) > 0;
+  const onLoadOlderMessages = useCallback(async () => {
+    if (!activeSessionKey) return;
+    await tauriChat.loadOlderHistory(path, activeSessionKey);
+  }, [path, activeSessionKey]);
 
   const loadHistory = useCallback(
     async (sessionKey: string, opts?: HistoryLoadOptions) => {
@@ -174,6 +186,8 @@ export function useAgentBoardData({
     feedItems,
     sessionKeyFor,
     loadHistory,
+    onLoadOlderMessages,
+    hasOlderMessages,
     handleDelete,
     handleApprove,
     handleItemMove,

--- a/app/src/components/board/use-agent-board-source.tsx
+++ b/app/src/components/board/use-agent-board-source.tsx
@@ -173,6 +173,8 @@ export function useAgentBoardSource(
     onApprove: data.handleApprove,
     onRename: data.onRename,
     loadHistory: data.loadHistory,
+    onLoadOlderMessages: data.onLoadOlderMessages,
+    hasOlderMessages: data.hasOlderMessages,
     sendMessageNow: send.sendMessageNow,
     createConversation: send.createConversation,
     stopSession: send.stopSession,

--- a/app/src/components/board/use-mission-control-archived.ts
+++ b/app/src/components/board/use-mission-control-archived.ts
@@ -4,7 +4,7 @@ import { messagePreviewText } from "@houston-ai/chat";
 import { createElement, useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAllConversations } from "../../hooks/queries";
-import { useConversationFeed } from "../../hooks/use-conversation-vm";
+import { useConversationVm } from "../../hooks/use-conversation-vm";
 import { isSetupChatMode } from "../../lib/integration-chat-setup";
 import { missionCardTags } from "../../lib/mission-card";
 import {
@@ -15,6 +15,8 @@ import {
 import type { Agent } from "../../lib/types";
 import { useAgentCatalogStore } from "../../stores/agent-catalog";
 import { AgentCardAvatar } from "../shell/agent-card-avatar";
+
+const EMPTY_FEED: FeedItem[] = [];
 
 /**
  * Cross-agent archived data: every agent's *archived* missions on one list,
@@ -120,11 +122,18 @@ export function useMissionControlArchived(agents: Agent[]) {
   const activeAgentPath = activeSessionKey
     ? (sessionMapRef.current[activeSessionKey]?.agentPath ?? null)
     : null;
-  const activeFeed = useConversationFeed(activeAgentPath, activeSessionKey);
+  const activeVm = useConversationVm(activeAgentPath, activeSessionKey);
+  const activeFeed = activeVm?.feed ?? EMPTY_FEED;
   const feedItems = useMemo<Record<string, FeedItem[]>>(
     () => (activeSessionKey ? { [activeSessionKey]: activeFeed } : {}),
     [activeSessionKey, activeFeed],
   );
+  // Scroll-up lazy-load (HOU-819): see use-agent-board-data.
+  const hasOlderMessages = (activeVm?.historyWindow?.earliestLoaded ?? 0) > 0;
+  const onLoadOlderMessages = useCallback(async () => {
+    if (!activeAgentPath || !activeSessionKey) return;
+    await tauriChat.loadOlderHistory(activeAgentPath, activeSessionKey);
+  }, [activeAgentPath, activeSessionKey]);
 
   const loadHistory = useCallback(
     async (
@@ -161,6 +170,8 @@ export function useMissionControlArchived(agents: Agent[]) {
     setSelectedId,
     sessionKeyFor,
     loadHistory,
+    onLoadOlderMessages,
+    hasOlderMessages,
     handleDelete,
     agentMap,
   };

--- a/app/src/components/board/use-mission-control-source.tsx
+++ b/app/src/components/board/use-mission-control-source.tsx
@@ -180,6 +180,8 @@ export function useMissionControlSource(
     onApprove: mc.handleApprove,
     onRename: mc.handleRename,
     loadHistory: mc.loadHistory,
+    onLoadOlderMessages: mc.onLoadOlderMessages,
+    hasOlderMessages: mc.hasOlderMessages,
     sendMessageNow: actions.sendMessageNow,
     createConversation: actions.createConversation,
     stopSession: actions.stopSession,

--- a/app/src/components/tabs/archived-tab.tsx
+++ b/app/src/components/tabs/archived-tab.tsx
@@ -5,10 +5,11 @@ import { messagePreviewText } from "@houston-ai/chat";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useActivity, useDeleteActivity } from "../../hooks/queries";
-import { useConversationFeed } from "../../hooks/use-conversation-vm";
+import { useConversationVm } from "../../hooks/use-conversation-vm";
 import { useOpenAgentHref } from "../../hooks/use-open-agent-file";
 import { selectArchived } from "../../lib/mission-selection";
 import { modelAcceptsImages } from "../../lib/providers";
+import { tauriChat } from "../../lib/tauri";
 import type { TabProps } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 import { useAttachmentRejectionDialog } from "../attachment-rejection-dialog";
@@ -19,6 +20,8 @@ import { useAgentChatPanel } from "../use-agent-chat-panel";
 import { ArchivedEmptyState, ArchivedSearchBar } from "./archived-tab-search";
 import { useArchivedMissionSearch } from "./use-archived-mission-search";
 import { useArchivedSendMessage } from "./use-archived-send-message";
+
+const EMPTY_FEED: FeedItem[] = [];
 
 /**
  * Archived missions: a column-less list of the agent's archived missions.
@@ -84,11 +87,20 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
 
   // The open conversation's reactive feed from the SDK conversation VM
   // (history seeded by the adapter's loadHistory).
-  const activeFeed = useConversationFeed(path, selectedSessionKey);
+  const activeVm = useConversationVm(path, selectedSessionKey);
+  const activeFeed = activeVm?.feed ?? EMPTY_FEED;
   const feedItems = useMemo<Record<string, FeedItem[]>>(
     () => (selectedSessionKey ? { [selectedSessionKey]: activeFeed } : {}),
     [selectedSessionKey, activeFeed],
   );
+  // Scroll-up lazy-load (HOU-819): archived missions can be the longest
+  // transcripts of all — the open chat shows the tail window and prepends
+  // older pages on scroll.
+  const hasOlderMessages = (activeVm?.historyWindow?.earliestLoaded ?? 0) > 0;
+  const onLoadOlderMessages = useCallback(async () => {
+    if (!selectedSessionKey) return;
+    await tauriChat.loadOlderHistory(path, selectedSessionKey);
+  }, [path, selectedSessionKey]);
 
   const archivedSearch = useArchivedMissionSearch(path, items);
 
@@ -140,6 +152,8 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
           onSendMessage={handleSendMessage}
           onComposerSubmit={panel.onComposerSubmit}
           onLoadHistory={archivedSearch.loadHistory}
+          onLoadOlderMessages={onLoadOlderMessages}
+          hasOlderMessages={hasOlderMessages}
           emptyState={emptyState}
           onPanelOpenChange={setMissionPanelOpen}
           onOpenLink={openHref}

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -162,6 +162,13 @@ export function useMissionControl(agents: Agent[]) {
       activeSessionKey ? { [activeSessionKey]: activeVm?.feed ?? [] } : {},
     [activeSessionKey, activeVm],
   );
+  // Scroll-up lazy-load (HOU-819): the open chat renders the transcript's
+  // tail window; older pages prepend on scroll. See use-agent-board-data.
+  const hasOlderMessages = (activeVm?.historyWindow?.earliestLoaded ?? 0) > 0;
+  const onLoadOlderMessages = useCallback(async () => {
+    if (!activeAgentPath || !activeSessionKey) return;
+    await tauriChat.loadOlderHistory(activeAgentPath, activeSessionKey);
+  }, [activeAgentPath, activeSessionKey]);
 
   const loadHistory = useCallback(
     async (
@@ -390,6 +397,8 @@ export function useMissionControl(agents: Agent[]) {
     isLoaded: isFetched,
     feedItems,
     loadHistory,
+    onLoadOlderMessages,
+    hasOlderMessages,
     handleDelete,
     handleApprove,
     handleRename,

--- a/app/src/hooks/use-conversation-vm.ts
+++ b/app/src/hooks/use-conversation-vm.ts
@@ -46,6 +46,10 @@ export interface ConversationView {
    *  request_connection), or null. Set on settle, cleared on the next turn
    *  start — drives the composer-replacing interaction card. */
   pendingInteraction: ConversationVM["pendingInteraction"];
+  /** The server-transcript window the feed was seeded from (HOU-819):
+   *  `earliestLoaded > 0` means older messages exist server-side and the chat
+   *  offers scroll-up lazy-load. Absent before any windowed read. */
+  historyWindow: ConversationVM["historyWindow"];
 }
 
 const EMPTY_FEED: FeedItem[] = [];
@@ -58,6 +62,7 @@ function toView(vm: ConversationVM): ConversationView {
     boardStatus: vm.boardStatus,
     queued: vm.queued,
     pendingInteraction: vm.pendingInteraction,
+    historyWindow: vm.historyWindow,
   };
 }
 

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -441,6 +441,12 @@ export const tauriChat = {
           "load_chat_history",
           () => getEngine().loadChatHistory(agentPath, sessionKey, opts),
         ),
+  /** Prepend the previous transcript page before the loaded window (HOU-819):
+   *  the scroll-up lazy-load. Resolves whether even older messages remain. */
+  loadOlderHistory: (agentPath: string, sessionKey: string) =>
+    call<{ hasOlder: boolean }>("load_older_chat_history", () =>
+      getEngine().loadOlderChatHistory(agentPath, sessionKey),
+    ),
   summarize: (message: string) =>
     call<{ title: string; description: string }>("summarize_activity", () =>
       getEngine().summarizeActivity(message),

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,22 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v34 - 2026-07-23
+
+Refine `conversation-feed` (no new component, no `since` change): the transcript
+now opens on its TAIL window instead of the full history, and gains a
+`load-older-trigger` at the top of the scroll viewport plus a `loading-older`
+state (HOU-819). When the view-model reports messages beyond the loaded window
+(`historyWindow.earliestLoaded > 0` on the conversation VM), scrolling the top
+of the feed into view fetches the previous page and prepends it, scroll-anchored
+(same distance from the bottom) so on-screen content never jumps; a quiet
+spinner shows while the page loads and the trigger retires at the transcript
+start. Web ships it in `ui/chat` (`ConversationLoadOlder`, threaded through
+`ChatPanel`/`ChatMessages` as `onLoadOlder` + `hasOlderMessages` and through
+`AIBoard` as `onLoadOlderMessages` + `hasOlderMessages`); the windowed reads
+ride the additive protocol params (`?limit`/`?before` on the runtime's
+messages route) and the SDK VM's additive `historyWindow` + `prependHistory`.
+
 ## v33 - 2026-07-22
 
 Add `status-badge`: the shared connected/live-status indicator (a colored dot,

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 33
+version: 34
 
 components:
   - id: agent-avatar
@@ -67,12 +67,17 @@ components:
   - id: conversation-feed
     title: Conversation feed
     purpose: The scrolling transcript that hosts every message/tool/system item.
-    anatomy: [scroll-viewport, item-list, stick-to-bottom-anchor, scroll-to-bottom-button]
-    states: [empty, loading-history, streaming, idle, error]
+    anatomy: [scroll-viewport, load-older-trigger, item-list, stick-to-bottom-anchor, scroll-to-bottom-button]
+    states: [empty, loading-history, loading-older, streaming, idle, error]
     variants: [single-player, multiplayer]
     behavior: >-
       Renders an ordered FeedItem stream; auto-sticks to bottom while streaming
       unless the user scrolled up. Item ordering/merge is view-model driven.
+      Opens on the transcript's TAIL window (v34): when the view-model reports
+      older messages beyond the loaded window, scrolling the top of the feed
+      into view fetches and prepends the previous page (quiet spinner while
+      loading), anchored so on-screen content never jumps; the trigger retires
+      when the window reaches the transcript start.
     a11y: log role with aria-live=polite for appended items; preserves scroll on prepend.
     since: 1
 

--- a/packages/fake-host/src/chat-stream.ts
+++ b/packages/fake-host/src/chat-stream.ts
@@ -65,7 +65,8 @@ export function sendMessage(
   cid: string,
   text: string,
   nonce: string | undefined,
+  displayText?: string,
 ): Response {
-  streamReplySafe(agentId, cid, text, nonce);
+  streamReplySafe(agentId, cid, text, nonce, displayText);
   return noContent(202);
 }

--- a/packages/fake-host/src/chat-turn.ts
+++ b/packages/fake-host/src/chat-turn.ts
@@ -68,6 +68,7 @@ async function streamReply(
   cid: string,
   userText: string,
   nonce: string | undefined,
+  displayText: string | undefined,
 ): Promise<void> {
   const ch = channel(chatKey(agentId, cid));
   const epoch = ch.epoch;
@@ -75,7 +76,7 @@ async function streamReply(
   const reply = cannedReply(userText);
   ch.pending = { turnId, remaining: replyDeltas(reply) };
   // The user message persists at turn START (the dead-turn history shape).
-  state.appendUserMessage(agentId, cid, userText, turnId);
+  state.appendUserMessage(agentId, cid, userText, turnId, displayText);
   publish(ch, {
     type: "user",
     data: { content: userText, ts: Date.now(), nonce },
@@ -125,8 +126,9 @@ export function streamReplySafe(
   cid: string,
   text: string,
   nonce: string | undefined,
+  displayText?: string,
 ): void {
-  streamReply(agentId, cid, text, nonce).catch((err: unknown) => {
+  streamReply(agentId, cid, text, nonce, displayText).catch((err: unknown) => {
     console.error("[fake-host] streamReply failed:", err);
     queueMicrotask(() => {
       throw err;

--- a/packages/fake-host/src/routes.ts
+++ b/packages/fake-host/src/routes.ts
@@ -220,6 +220,9 @@ export function handleAgents(
             cid,
             String(body?.text ?? ""),
             typeof body?.nonce === "string" ? body.nonce : undefined,
+            typeof body?.displayText === "string"
+              ? body.displayText
+              : undefined,
           );
       }
       if (action === "cancel") {

--- a/packages/fake-host/src/state-history.ts
+++ b/packages/fake-host/src/state-history.ts
@@ -23,10 +23,22 @@ export function appendUserMessage(
   conversationId: string,
   userText: string,
   turnId: string,
+  displayText?: string,
 ): void {
   const key = `${agentId}:${conversationId}`;
   const list = state.histories.get(key) ?? [];
-  list.push({ role: "user", content: userText, ts: EPOCH, turnId });
+  // `displayText` mirrors the real runtime's contract: the model ran on
+  // `content` (a kickoff send carries the full hidden directive there), while
+  // a history reload renders `displayText ?? content`. Dropping it here made
+  // the served fold DIFFER from the live bubble — a windowed reseed
+  // (HOU-819) then replaced the pretty bubble with the raw directive.
+  list.push({
+    role: "user",
+    content: userText,
+    ts: EPOCH,
+    turnId,
+    ...(displayText !== undefined ? { displayText } : {}),
+  });
   state.histories.set(key, list);
   emitDomain("ConversationsChanged", agentId);
 }

--- a/packages/protocol/src/conversation.ts
+++ b/packages/protocol/src/conversation.ts
@@ -375,6 +375,19 @@ export interface ConversationHistory {
   id: string;
   title: string;
   messages: ChatMessage[];
+  /**
+   * Absolute index of `messages[0]` in the full transcript — `0` when the
+   * response starts at the beginning. Non-zero only on a windowed read
+   * (`?limit=` / `?before=`): older messages exist below this index and are
+   * fetched with `before: offset`. Absent on pre-windowing servers (treat as
+   * `0` — the response is the whole transcript).
+   */
+  offset?: number;
+  /**
+   * Total messages stored in the conversation, regardless of the window
+   * returned. Absent on pre-windowing servers (treat as `messages.length`).
+   */
+  totalMessages?: number;
 }
 
 /**

--- a/packages/runtime-client/src/client.ts
+++ b/packages/runtime-client/src/client.ts
@@ -231,9 +231,21 @@ export class HoustonEngineClient {
   listConversations() {
     return this.json<ConversationSummary[]>("/conversations");
   }
-  getHistory(id: string) {
+  /**
+   * Read a conversation's transcript. `limit` fetches only the LAST N messages
+   * (the chat-open window, HOU-819); `before` fetches the window ENDING at
+   * that absolute index (the response's `offset`) — the load-older page. No
+   * options = the full transcript. A pre-windowing server ignores the params
+   * and returns everything — callers must treat `offset`/`totalMessages` as
+   * optional.
+   */
+  getHistory(id: string, opts: { limit?: number; before?: number } = {}) {
+    const params = new URLSearchParams();
+    if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+    if (opts.before !== undefined) params.set("before", String(opts.before));
+    const qs = params.toString();
     return this.json<ConversationHistory>(
-      `/conversations/${encodeURIComponent(id)}/messages`,
+      `/conversations/${encodeURIComponent(id)}/messages${qs ? `?${qs}` : ""}`,
     );
   }
   /**

--- a/packages/runtime/src/store/conversation-file.test.ts
+++ b/packages/runtime/src/store/conversation-file.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "vitest";
@@ -318,4 +318,64 @@ test("before at the transcript start returns an empty page (nothing older)", () 
   expect(h.messages).toHaveLength(0);
   expect(h.offset).toBe(0);
   expect(h.totalMessages).toBe(4);
+});
+
+// ── Parse cache (HOU-819) ───────────────────────────────────────────────────
+
+test("a cached read returns the appended state written through save", () => {
+  const dir = freshDir();
+  appendUserMessageAt(dir, "c1", "first");
+  expect(getHistoryAt(dir, "c1")?.messages).toHaveLength(1); // warm the cache
+  appendAssistantMessageAt(dir, "c1", "reply");
+
+  const h = getHistoryAt(dir, "c1");
+  expect(h?.messages.map((m) => m.content)).toEqual(["first", "reply"]);
+});
+
+test("an EXTERNAL rewrite (bypassing save) is picked up on the next read", () => {
+  const dir = freshDir();
+  appendUserMessageAt(dir, "c1", "original");
+  expect(getHistoryAt(dir, "c1")?.messages[0]?.content).toBe("original");
+
+  // The cloud store-sync (and any manual edit) writes files directly — the
+  // mtime/size validation must invalidate the cached parse.
+  const f = join(dir, "c1.json");
+  const replaced = {
+    id: "c1",
+    title: "Replaced",
+    createdAt: 1,
+    updatedAt: 2,
+    messages: [
+      { role: "user", content: "hydrated from the object store", ts: 3 },
+    ],
+  };
+  writeFileSync(f, JSON.stringify(replaced));
+
+  const h = getHistoryAt(dir, "c1");
+  expect(h?.title).toBe("Replaced");
+  expect(h?.messages[0]?.content).toBe("hydrated from the object store");
+});
+
+test("a deleted conversation reads null even when its parse was cached", () => {
+  const dir = freshDir();
+  appendUserMessageAt(dir, "c1", "hello");
+  expect(getHistoryAt(dir, "c1")).not.toBeNull(); // cached
+  deleteConversationAt(dir, "c1");
+  expect(getHistoryAt(dir, "c1")).toBeNull();
+});
+
+test("list reflects an external rewrite (per-file cache validated by stat)", () => {
+  const dir = freshDir();
+  appendUserMessageAt(dir, "c1", "one");
+  appendUserMessageAt(dir, "c2", "two");
+  expect(listConversationsAt(dir)).toHaveLength(2); // warm both
+
+  const f = join(dir, "c2.json");
+  const conv = JSON.parse(readFileSync(f, "utf8"));
+  conv.title = "Externally renamed";
+  conv.updatedAt = Date.now() + 60_000;
+  writeFileSync(f, JSON.stringify(conv));
+
+  const list = listConversationsAt(dir);
+  expect(list[0]?.title).toBe("Externally renamed");
 });

--- a/packages/runtime/src/store/conversation-file.test.ts
+++ b/packages/runtime/src/store/conversation-file.test.ts
@@ -238,3 +238,84 @@ test("a user message with no acting-as token stays author-free (byte-identical t
   const raw = readFileSync(join(dir, "c1.json"), "utf8");
   expect(raw).not.toContain("author");
 });
+
+// ── Transcript windowing (HOU-819) ──────────────────────────────────────────
+
+function seedConversation(dir: string, count: number) {
+  for (let i = 0; i < count; i++) {
+    if (i % 2 === 0) appendUserMessageAt(dir, "c1", `user ${i}`);
+    else appendAssistantMessageAt(dir, "c1", `reply ${i}`);
+  }
+}
+
+test("no window returns the full transcript with offset 0 and the total", () => {
+  const dir = freshDir();
+  seedConversation(dir, 5);
+
+  const h = getHistoryAt(dir, "c1");
+  if (!h) throw new Error("getHistoryAt returned null");
+  expect(h.messages).toHaveLength(5);
+  expect(h.offset).toBe(0);
+  expect(h.totalMessages).toBe(5);
+});
+
+test("limit returns the LAST N messages and where they start", () => {
+  const dir = freshDir();
+  seedConversation(dir, 10);
+
+  const h = getHistoryAt(dir, "c1", { limit: 3 });
+  if (!h) throw new Error("getHistoryAt returned null");
+  expect(h.messages.map((m) => m.content)).toEqual([
+    "reply 7",
+    "user 8",
+    "reply 9",
+  ]);
+  expect(h.offset).toBe(7);
+  expect(h.totalMessages).toBe(10);
+});
+
+test("before + limit returns the previous page, ending at the cursor", () => {
+  const dir = freshDir();
+  seedConversation(dir, 10);
+
+  const h = getHistoryAt(dir, "c1", { limit: 3, before: 7 });
+  if (!h) throw new Error("getHistoryAt returned null");
+  expect(h.messages.map((m) => m.content)).toEqual([
+    "user 4",
+    "reply 5",
+    "user 6",
+  ]);
+  expect(h.offset).toBe(4);
+  expect(h.totalMessages).toBe(10);
+});
+
+test("a limit larger than the transcript clamps to the start (offset 0)", () => {
+  const dir = freshDir();
+  seedConversation(dir, 4);
+
+  const h = getHistoryAt(dir, "c1", { limit: 100 });
+  if (!h) throw new Error("getHistoryAt returned null");
+  expect(h.messages).toHaveLength(4);
+  expect(h.offset).toBe(0);
+});
+
+test("a before cursor past the end clamps to the transcript's tail", () => {
+  const dir = freshDir();
+  seedConversation(dir, 4);
+
+  const h = getHistoryAt(dir, "c1", { limit: 2, before: 999 });
+  if (!h) throw new Error("getHistoryAt returned null");
+  expect(h.messages.map((m) => m.content)).toEqual(["user 2", "reply 3"]);
+  expect(h.offset).toBe(2);
+});
+
+test("before at the transcript start returns an empty page (nothing older)", () => {
+  const dir = freshDir();
+  seedConversation(dir, 4);
+
+  const h = getHistoryAt(dir, "c1", { limit: 2, before: 0 });
+  if (!h) throw new Error("getHistoryAt returned null");
+  expect(h.messages).toHaveLength(0);
+  expect(h.offset).toBe(0);
+  expect(h.totalMessages).toBe(4);
+});

--- a/packages/runtime/src/store/conversation-file.ts
+++ b/packages/runtime/src/store/conversation-file.ts
@@ -174,13 +174,35 @@ export function deleteConversationAt(dir: string, id: string): boolean {
   return true;
 }
 
+/**
+ * A transcript window request: `limit` = max messages returned, `before` = the
+ * absolute index the window must end at (exclusive) — the caller's current
+ * `offset`, for fetching the previous page. Both optional; absent = full
+ * history (the pre-windowing contract, unchanged for old clients).
+ */
+export interface HistoryWindow {
+  limit?: number;
+  before?: number;
+}
+
 export function getHistoryAt(
   dir: string,
   id: string,
+  window: HistoryWindow = {},
 ): ConversationHistory | null {
   const conv = loadConversation(dir, id);
   if (!conv) return null;
-  return { id: conv.id, title: conv.title, messages: conv.messages };
+  const total = conv.messages.length;
+  const end = Math.min(Math.max(window.before ?? total, 0), total);
+  const start =
+    window.limit === undefined ? 0 : Math.max(0, end - window.limit);
+  return {
+    id: conv.id,
+    title: conv.title,
+    messages: conv.messages.slice(start, end),
+    offset: start,
+    totalMessages: total,
+  };
 }
 
 export function listConversationsAt(dir: string): ConversationSummary[] {

--- a/packages/runtime/src/store/conversation-file.ts
+++ b/packages/runtime/src/store/conversation-file.ts
@@ -2,7 +2,6 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
-  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
@@ -15,6 +14,11 @@ import type {
   TokenUsage,
   ToolCallRecord,
 } from "@houston/runtime-client";
+import {
+  dropParsedFile,
+  readParsedFile,
+  stampParsedFile,
+} from "./conversation-parse-cache";
 
 /**
  * Pure, dir-parameterized conversation file logic: one JSON file per
@@ -34,17 +38,19 @@ export type StoredConversation = {
 const fileFor = (dir: string, id: string) =>
   join(dir, `${encodeURIComponent(id)}.json`);
 
+/**
+ * Reads go through the mtime/size-validated parse cache
+ * (`conversation-parse-cache.ts`, HOU-819): a hit costs a stat instead of a
+ * whole-file JSON.parse on the event loop; writers that bypass {@link save}
+ * (the cloud store-sync hydrating `/data`, a manual edit) are picked up on
+ * the next read. The cached object is the SAME reference the appenders
+ * mutate-then-save — never mutate a loaded conversation without saving it.
+ */
 export function loadConversation(
   dir: string,
   id: string,
 ): StoredConversation | null {
-  const f = fileFor(dir, id);
-  if (!existsSync(f)) return null;
-  try {
-    return JSON.parse(readFileSync(f, "utf8")) as StoredConversation;
-  } catch {
-    return null;
-  }
+  return readParsedFile(fileFor(dir, id));
 }
 
 function save(dir: string, conv: StoredConversation) {
@@ -53,6 +59,7 @@ function save(dir: string, conv: StoredConversation) {
   const tmp = `${f}.tmp`;
   writeFileSync(tmp, JSON.stringify(conv));
   renameSync(tmp, f); // atomic swap; never leaves a half-written file
+  stampParsedFile(f, conv);
 }
 
 /** Optional fields of a persisted user message. */
@@ -169,6 +176,7 @@ export function renameConversationAt(
 
 export function deleteConversationAt(dir: string, id: string): boolean {
   const f = fileFor(dir, id);
+  dropParsedFile(f);
   if (!existsSync(f)) return false;
   rmSync(f);
   return true;
@@ -210,21 +218,19 @@ export function listConversationsAt(dir: string): ConversationSummary[] {
   const out: ConversationSummary[] = [];
   for (const f of readdirSync(dir)) {
     if (!f.endsWith(".json")) continue;
-    try {
-      const conv = JSON.parse(
-        readFileSync(join(dir, f), "utf8"),
-      ) as StoredConversation;
-      const last = conv.messages[conv.messages.length - 1];
-      out.push({
-        id: conv.id,
-        title: conv.title,
-        createdAt: conv.createdAt,
-        updatedAt: conv.updatedAt,
-        lastMessage: last?.content.slice(0, 80),
-      });
-    } catch {
-      // skip unreadable files
-    }
+    // Path-keyed cached read: a list pass costs one stat per file and parses
+    // only files that actually changed since the last read — it used to
+    // re-parse EVERY transcript on every call.
+    const conv = readParsedFile(join(dir, f));
+    if (!conv) continue; // unreadable/foreign file — skip, as before
+    const last = conv.messages[conv.messages.length - 1];
+    out.push({
+      id: conv.id,
+      title: conv.title,
+      createdAt: conv.createdAt,
+      updatedAt: conv.updatedAt,
+      lastMessage: last?.content.slice(0, 80),
+    });
   }
   return out.sort((a, b) => b.updatedAt - a.updatedAt);
 }

--- a/packages/runtime/src/store/conversation-parse-cache.ts
+++ b/packages/runtime/src/store/conversation-parse-cache.ts
@@ -1,0 +1,65 @@
+import { readFileSync, statSync } from "node:fs";
+import { LruCache } from "../lru";
+import type { StoredConversation } from "./conversation-file";
+
+/**
+ * Parse cache (HOU-819): every history/list read used to re-read and
+ * re-JSON.parse whole conversation files on the single event loop — the list
+ * route parsed EVERY file per request, re-fired by each ActivityChanged /
+ * ConversationsChanged invalidation while a turn ran. Entries are validated
+ * against the file's (mtimeMs, size) on every access, so writers that bypass
+ * the store's `save` — the cloud store-sync hydrating `/data`, a manual
+ * edit — are picked up on the next read; a hit costs a stat instead of a
+ * parse.
+ *
+ * The cached object is the SAME reference the appenders mutate-then-save
+ * (read-modify-write stays one object); a caller must never mutate a loaded
+ * conversation without saving it. Bounded: parsed transcripts can be MBs.
+ */
+interface ParsedFile {
+  mtimeMs: number;
+  size: number;
+  conv: StoredConversation;
+}
+
+const parseCache = new LruCache<string, ParsedFile>({ capacity: 64 });
+
+/** Read + parse `f` through the cache; null on missing/unreadable (evicts). */
+export function readParsedFile(f: string): StoredConversation | null {
+  let st: ReturnType<typeof statSync>;
+  try {
+    st = statSync(f);
+  } catch {
+    parseCache.delete(f);
+    return null;
+  }
+  const hit = parseCache.get(f);
+  if (hit && hit.mtimeMs === st.mtimeMs && hit.size === st.size)
+    return hit.conv;
+  try {
+    const conv = JSON.parse(readFileSync(f, "utf8")) as StoredConversation;
+    parseCache.set(f, { mtimeMs: st.mtimeMs, size: st.size, conv });
+    return conv;
+  } catch {
+    parseCache.delete(f);
+    return null;
+  }
+}
+
+/**
+ * Stamp the cache with what `save` just wrote — the next read is a stat-hit,
+ * never a re-parse of a file this process itself produced.
+ */
+export function stampParsedFile(f: string, conv: StoredConversation): void {
+  try {
+    const st = statSync(f);
+    parseCache.set(f, { mtimeMs: st.mtimeMs, size: st.size, conv });
+  } catch {
+    parseCache.delete(f);
+  }
+}
+
+/** Drop a file's cached parse (the delete path). */
+export function dropParsedFile(f: string): void {
+  parseCache.delete(f);
+}

--- a/packages/runtime/src/store/conversations.ts
+++ b/packages/runtime/src/store/conversations.ts
@@ -11,6 +11,7 @@ import {
   appendUserMessageAt,
   deleteConversationAt,
   getHistoryAt,
+  type HistoryWindow,
   listConversationsAt,
   renameConversationAt,
   type UserMessageMeta,
@@ -54,8 +55,11 @@ export function markConversationStopped(id: string): void {
   appendAssistantMessage(id, "", { stopped: true });
 }
 
-export function getHistory(id: string): ConversationHistory | null {
-  return getHistoryAt(dir, id);
+export function getHistory(
+  id: string,
+  window?: HistoryWindow,
+): ConversationHistory | null {
+  return getHistoryAt(dir, id, window);
 }
 
 export function listConversations(): ConversationSummary[] {

--- a/packages/runtime/src/transport/conversation-routes.ts
+++ b/packages/runtime/src/transport/conversation-routes.ts
@@ -48,7 +48,15 @@ export async function handleConversationRoute(
   const action = convMatch[2];
 
   if (method === "GET" && action === "messages") {
-    const history = getHistory(id);
+    // Optional transcript window (HOU-819): `limit` = tail size, `before` =
+    // the caller's current `offset` (fetch the previous page). Absent or
+    // malformed params fall back to the full history — the pre-windowing
+    // contract — so an old client (or a proxy that strips query strings)
+    // keeps working, just without the windowing win.
+    const history = getHistory(id, {
+      limit: positiveInt(ctx.url.searchParams.get("limit")),
+      before: positiveInt(ctx.url.searchParams.get("before"), 0),
+    });
     history
       ? json(res, 200, history)
       : json(res, 404, { error: "conversation not found" });
@@ -217,6 +225,13 @@ async function handleStartTurn(ctx: RouteContext, id: string) {
     typeof displayText === "string" ? displayText : undefined,
   );
   json(ctx.res, 202, { ok: true, id });
+}
+
+/** Parse an integer query param ≥ `min` (default 1); anything else → undefined. */
+function positiveInt(raw: string | null, min = 1): number | undefined {
+  if (raw === null) return undefined;
+  const n = Number.parseInt(raw, 10);
+  return Number.isInteger(n) && n >= min ? n : undefined;
 }
 
 /** Extract the C2 acting-as identity from a message request's headers, or undefined. */

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -154,6 +154,7 @@ export {
   type FeedFrame,
   type FeedItemVM,
   type FeedOutput,
+  type HistoryWindowVM,
   historyToFeed,
   isNotConnectedError,
   isStoppedByUser,

--- a/packages/sdk/src/modules/turns/index.ts
+++ b/packages/sdk/src/modules/turns/index.ts
@@ -191,5 +191,6 @@ export {
   conversationScope,
   DEFAULT_CONVERSATION_CACHE_MAX,
   type FeedItemVM,
+  type HistoryWindowVM,
   type QueuedMessageVM,
 } from "./vm-output";

--- a/packages/sdk/src/modules/turns/vm-output.test.ts
+++ b/packages/sdk/src/modules/turns/vm-output.test.ts
@@ -409,3 +409,95 @@ test("confirmIdle leaves a settled conversation untouched", () => {
   // The terminal truth stays — only a stale "running" is reconciled.
   expect(snap().sessionStatus).toBe("error");
 });
+
+// ── Transcript windowing (HOU-819) ──────────────────────────────────────────
+
+test("seedHistory with a window stamps historyWindow on the snapshot", () => {
+  const { vm, snap } = harness();
+  vm.seedHistory(
+    "a",
+    "c1",
+    [{ feed_type: "user_message", data: "hi", ts: 100 }],
+    { earliestLoaded: 380, total: 381 },
+  );
+
+  expect(snap().historyWindow).toEqual({ earliestLoaded: 380, total: 381 });
+});
+
+test("seedHistory without a window CLEARS a stale stamp (feed no longer maps to it)", () => {
+  const { vm, snap } = harness();
+  vm.seedHistory("a", "c1", [{ feed_type: "user_message", data: "hi" }], {
+    earliestLoaded: 10,
+    total: 11,
+  });
+  vm.seedHistory("a", "c1", [{ feed_type: "user_message", data: "hi" }]);
+
+  expect(snap().historyWindow).toBeUndefined();
+});
+
+test("prependHistory inserts older frames BEFORE the feed and updates the window", () => {
+  const { vm, snap } = harness();
+  vm.seedHistory(
+    "a",
+    "c1",
+    [{ feed_type: "user_message", data: "newer", ts: 200 }],
+    { earliestLoaded: 80, total: 81 },
+  );
+  vm.prependHistory(
+    "a",
+    "c1",
+    [
+      { feed_type: "user_message", data: "oldest", ts: 50 },
+      { feed_type: "assistant_text", data: "older reply", ts: 60 },
+    ],
+    { earliestLoaded: 0, total: 81 },
+  );
+
+  expect(snap().feed.map((f) => f.data)).toEqual([
+    "oldest",
+    "older reply",
+    "newer",
+  ]);
+  expect(snap().historyWindow).toEqual({ earliestLoaded: 0, total: 81 });
+});
+
+test("prependHistory keeps the existing entries' ids (no remount churn below)", () => {
+  const { vm, snap } = harness();
+  vm.seedHistory(
+    "a",
+    "c1",
+    [{ feed_type: "user_message", data: "kept", ts: 200 }],
+    { earliestLoaded: 5, total: 6 },
+  );
+  const keptId = snap().feed[0]?.id;
+  vm.prependHistory(
+    "a",
+    "c1",
+    [{ feed_type: "user_message", data: "older", ts: 10 }],
+    { earliestLoaded: 0, total: 6 },
+  );
+
+  expect(snap().feed[1]?.id).toBe(keptId);
+});
+
+test("stampHistoryWindow records the window without touching the feed", () => {
+  const { vm, snap } = harness();
+  vm.seedHistory("a", "c1", [
+    { feed_type: "user_message", data: "painted", ts: 100 },
+  ]);
+  const feedBefore = snap().feed;
+  vm.stampHistoryWindow("a", "c1", { earliestLoaded: 42, total: 142 });
+
+  expect(snap().historyWindow).toEqual({ earliestLoaded: 42, total: 142 });
+  expect(snap().feed).toEqual(feedBefore);
+});
+
+test("stampHistoryWindow with an unchanged window does not republish", () => {
+  const { store, vm } = harness();
+  vm.stampHistoryWindow("a", "c1", { earliestLoaded: 1, total: 2 });
+  const listener = vi.fn();
+  store.subscribe(conversationScope("a", "c1"), listener);
+  vm.stampHistoryWindow("a", "c1", { earliestLoaded: 1, total: 2 });
+
+  expect(listener).not.toHaveBeenCalled();
+});

--- a/packages/sdk/src/modules/turns/vm-output.ts
+++ b/packages/sdk/src/modules/turns/vm-output.ts
@@ -98,6 +98,21 @@ export interface ConversationVM {
    * flushes them as ONE combined send when the turn settles.
    */
   queued?: QueuedMessageVM[];
+  /**
+   * The server-transcript window this feed was seeded from (additive; absent
+   * until a WINDOWED history read seeds it — a cache paint or a full-history
+   * seed carries none). `earliestLoaded` is the absolute index of the oldest
+   * loaded message; `> 0` means older messages exist server-side and a surface
+   * may offer/trigger load-older (HOU-819). `total` is the transcript's full
+   * message count at the last read.
+   */
+  historyWindow?: HistoryWindowVM;
+}
+
+/** See {@link ConversationVM.historyWindow}. */
+export interface HistoryWindowVM {
+  earliestLoaded: number;
+  total: number;
 }
 
 interface ConvState {
@@ -109,6 +124,7 @@ interface ConvState {
   /** Open streaming run: its streaming feed_type -> the feed entry id it updates. */
   streaming: Map<string, string>;
   queued: QueuedMessageVM[];
+  historyWindow?: HistoryWindowVM;
 }
 
 /** Final feed_type -> the streaming feed_type it finalizes. */
@@ -219,6 +235,7 @@ export class ConversationVmOutput implements FeedOutput {
     agentPath: string,
     sessionKey: string,
     frames: readonly { feed_type: string; data: unknown; ts?: number }[],
+    window?: HistoryWindowVM,
   ): void {
     const s = this.state(agentPath, sessionKey);
     // History frames carry their source `ChatMessage.ts` (absent for a pre-`ts`
@@ -231,6 +248,37 @@ export class ConversationVmOutput implements FeedOutput {
       ...(f.ts !== undefined ? { ts: f.ts } : {}),
     }));
     s.streaming.clear();
+    // A windowed server read stamps its window; a cache paint / full-history
+    // seed passes none and CLEARS any prior stamp — the feed no longer maps to
+    // a known server window, so load-older must not trust a stale one.
+    s.historyWindow = window;
+    this.publish(agentPath, sessionKey, s);
+  }
+
+  /**
+   * Prepend an OLDER transcript window before the current feed — the
+   * scroll-up lazy-load seam (HOU-819). The existing entries (including any
+   * open streaming bubble) keep their ids and order; only the new frames are
+   * minted. The caller is the same windowed-history reader that seeds, so the
+   * frames are final history — never streaming state.
+   */
+  prependHistory(
+    agentPath: string,
+    sessionKey: string,
+    frames: readonly { feed_type: string; data: unknown; ts?: number }[],
+    window: HistoryWindowVM,
+  ): void {
+    const s = this.state(agentPath, sessionKey);
+    s.feed = [
+      ...frames.map((f) => ({
+        id: `f${s.seq++}`,
+        feed_type: f.feed_type,
+        data: f.data,
+        ...(f.ts !== undefined ? { ts: f.ts } : {}),
+      })),
+      ...s.feed,
+    ];
+    s.historyWindow = window;
     this.publish(agentPath, sessionKey, s);
   }
 
@@ -381,6 +429,28 @@ export class ConversationVmOutput implements FeedOutput {
     this.publish(agentPath, sessionKey, s);
   }
 
+  /**
+   * Record the server-transcript window WITHOUT reseeding the feed — the
+   * identical-content revalidation path (HOU-819): the windowed read's fold
+   * matched what is already on screen, so replacing would only churn entry
+   * ids, but load-older still needs to know where the loaded feed starts.
+   */
+  stampHistoryWindow(
+    agentPath: string,
+    sessionKey: string,
+    window: HistoryWindowVM,
+  ): void {
+    const s = this.state(agentPath, sessionKey);
+    if (
+      s.historyWindow?.earliestLoaded === window.earliestLoaded &&
+      s.historyWindow?.total === window.total
+    ) {
+      return;
+    }
+    s.historyWindow = window;
+    this.publish(agentPath, sessionKey, s);
+  }
+
   /** Replace the conversation's queued-message list (the send queue's seam). */
   setQueued(
     agentPath: string,
@@ -400,6 +470,7 @@ export class ConversationVmOutput implements FeedOutput {
       boardStatus: s.boardStatus,
       pendingInteraction: s.pendingInteraction,
       ...(s.queued.length ? { queued: s.queued.map((q) => ({ ...q })) } : {}),
+      ...(s.historyWindow ? { historyWindow: { ...s.historyWindow } } : {}),
     };
     const scope = conversationScope(agentPath, sessionKey);
     this.store.publish(scope, snapshot);

--- a/packages/web/src/engine-adapter/cache-persist.ts
+++ b/packages/web/src/engine-adapter/cache-persist.ts
@@ -1,0 +1,38 @@
+import { conversationScope, type FeedOutput } from "@houston/sdk";
+import { writeCachedConversation } from "./conversation-cache";
+import { conversationStore } from "./vm";
+
+/**
+ * Persist the VM's folded feed to the local conversation cache when a turn
+ * (or observed turn) settles, so the transcript a cold reopen paints includes
+ * everything sent THIS session — not just the state at the last history read
+ * (HOU-712). Frames were already folded by the VM (first in the multiplex);
+ * this just snapshots them. Cloud-only by construction: the cache no-ops
+ * without a gateway identity. Fire-and-forget — a cache write must never
+ * delay a settle.
+ */
+export function cachePersistOutput(): FeedOutput {
+  return {
+    pushFeedItem() {},
+    sessionStatus() {},
+    async persistBoardStatus(agentPath, sessionKey, status) {
+      if (status === "running") return;
+      const snapshot = conversationStore.getSnapshot(
+        conversationScope(agentPath, sessionKey),
+      ) as
+        | { feed?: { feed_type: string; data: unknown; ts?: number }[] }
+        | undefined;
+      const frames = snapshot?.feed;
+      if (!frames || frames.length === 0) return;
+      void writeCachedConversation(
+        agentPath,
+        sessionKey,
+        frames.map((f) => ({
+          feed_type: f.feed_type,
+          data: f.data,
+          ...(f.ts !== undefined ? { ts: f.ts } : {}),
+        })),
+      );
+    },
+  };
+}

--- a/packages/web/src/engine-adapter/client/chat-history-mixin.ts
+++ b/packages/web/src/engine-adapter/client/chat-history-mixin.ts
@@ -6,9 +6,11 @@ import {
   readCachedConversation,
   writeCachedConversation,
 } from "../conversation-cache";
+import { CHAT_OPEN_WINDOW } from "../history-window";
 import { historyToFeed, isConversationNotFound } from "../translate";
 import { observeConversation, seedConversationVm } from "../turn-stream";
 import { setActivityStatus } from "./activity-status";
+import { loadOlderPage } from "./load-older";
 import type { BaseCtor } from "./mixin";
 
 export function ChatHistoryMixin<TBase extends BaseCtor>(Base: TBase) {
@@ -35,8 +37,21 @@ export function ChatHistoryMixin<TBase extends BaseCtor>(Base: TBase) {
         const engine = this.ctx.cp
           ? controlPlane.runtimeClientFor(this.ctx.cp, agentPath)
           : this.ctx.engine;
-        const history = await engine.getHistory(sessionKey);
+        // A conversation OPEN reads only the tail window (HOU-819) — long
+        // missions used to fetch and fold their entire transcript here, the
+        // main "chat hangs before opening" cost. Bulk reads (mission search
+        // needs full text to match against) keep the full fetch. A
+        // pre-windowing server ignores `limit` and returns everything —
+        // `offset`/`totalMessages` then default to the full-transcript shape.
+        const history = await engine.getHistory(
+          sessionKey,
+          opts.observe !== false ? { limit: CHAT_OPEN_WINDOW } : {},
+        );
         const sdkFeed = sdkHistoryToFeed(history.messages);
+        const window = {
+          earliestLoaded: history.offset ?? 0,
+          total: history.totalMessages ?? history.messages.length,
+        };
         // Refresh the local copy on EVERY successful read (bulk scans too), so
         // the next cold open paints the freshest transcript we ever saw.
         if (this.ctx.cp) {
@@ -58,7 +73,7 @@ export function ChatHistoryMixin<TBase extends BaseCtor>(Base: TBase) {
           // seedConversationVm) — its feed IS the VM. The VM seed is the SDK's
           // UNMAPPED fold: the VM carries engine provider ids uniformly (seeded
           // and live alike); the app's binding hook owns the old-id remap.
-          seedConversationVm(agentPath, sessionKey, sdkFeed);
+          seedConversationVm(agentPath, sessionKey, sdkFeed, window);
           observeConversation(
             engine,
             agentPath,
@@ -71,7 +86,9 @@ export function ChatHistoryMixin<TBase extends BaseCtor>(Base: TBase) {
                 status,
                 pendingInteraction,
               ),
-            history.messages.length,
+            // The legacy settle guard compares against a FULL history reload,
+            // so hand it the transcript's total, not the window's length.
+            window.total,
           );
         }
         return historyToFeed(history.messages);
@@ -96,6 +113,20 @@ export function ChatHistoryMixin<TBase extends BaseCtor>(Base: TBase) {
         }
         throw err;
       }
+    }
+
+    /**
+     * Prepend the previous transcript page before the loaded window — the
+     * scroll-up lazy-load (HOU-819). See {@link loadOlderPage}.
+     */
+    loadOlderChatHistory(
+      agentPath: string,
+      sessionKey: string,
+    ): Promise<{ hasOlder: boolean }> {
+      const engine = this.ctx.cp
+        ? controlPlane.runtimeClientFor(this.ctx.cp, agentPath)
+        : this.ctx.engine;
+      return loadOlderPage(engine, agentPath, sessionKey);
     }
 
     /**

--- a/packages/web/src/engine-adapter/client/chat-history-mixin.ts
+++ b/packages/web/src/engine-adapter/client/chat-history-mixin.ts
@@ -13,9 +13,36 @@ import { setActivityStatus } from "./activity-status";
 import { loadOlderPage } from "./load-older";
 import type { BaseCtor } from "./mixin";
 
+/**
+ * Single-flight for OBSERVED chat-open reads (HOU-819): opening a chat fires
+ * this read twice — the board's hydrate call and the chat-history query's
+ * fetch land in the same tick — and both want the identical windowed read +
+ * VM seed. Sharing the in-flight promise halves the open traffic; bulk reads
+ * (`observe: false`) never join it (mission search needs its own full fetch).
+ */
+const openLoadsInFlight = new Map<string, Promise<ChatHistoryEntry[]>>();
+
 export function ChatHistoryMixin<TBase extends BaseCtor>(Base: TBase) {
   class ChatHistory extends Base {
-    async loadChatHistory(
+    loadChatHistory(
+      agentPath: string,
+      sessionKey: string,
+      opts: { observe?: boolean } = {},
+    ): Promise<ChatHistoryEntry[]> {
+      if (opts.observe === false) {
+        return this.loadChatHistoryNow(agentPath, sessionKey, opts);
+      }
+      const key = `${agentPath}|${sessionKey}`;
+      const inFlight = openLoadsInFlight.get(key);
+      if (inFlight) return inFlight;
+      const load = this.loadChatHistoryNow(agentPath, sessionKey, opts).finally(
+        () => openLoadsInFlight.delete(key),
+      );
+      openLoadsInFlight.set(key, load);
+      return load;
+    }
+
+    private async loadChatHistoryNow(
       agentPath: string,
       sessionKey: string,
       opts: { observe?: boolean } = {},

--- a/packages/web/src/engine-adapter/client/load-older.ts
+++ b/packages/web/src/engine-adapter/client/load-older.ts
@@ -1,0 +1,70 @@
+import type { HoustonEngineClient } from "@houston/runtime-client";
+import {
+  conversationScope,
+  type HistoryWindowVM,
+  historyToFeed as sdkHistoryToFeed,
+} from "@houston/sdk";
+import { CHAT_OLDER_PAGE } from "../history-window";
+import { conversationStore, conversationVm } from "../vm";
+
+/** Per-conversation single-flight guard for scroll-up load-older reads. */
+const inFlight = new Set<string>();
+
+/** The conversation's stamped server window, or undefined (no windowed read yet). */
+function historyWindowOf(scope: string): HistoryWindowVM | undefined {
+  const snap = conversationStore.getSnapshot(scope) as
+    | { historyWindow?: HistoryWindowVM }
+    | undefined;
+  return snap?.historyWindow;
+}
+
+/**
+ * Prepend the previous transcript page before the loaded window — the
+ * scroll-up lazy-load (HOU-819). Reads the conversation's `historyWindow`
+ * off the VM (stamped by the windowed open read), fetches the
+ * {@link CHAT_OLDER_PAGE} messages ending at `earliestLoaded`, and prepends
+ * their fold. Single-flight per conversation; a reseed racing the fetch (a
+ * fresh tail replacing the feed mid-load) drops the fetched page rather than
+ * prepending it against the wrong window.
+ */
+export async function loadOlderPage(
+  engine: HoustonEngineClient,
+  agentPath: string,
+  sessionKey: string,
+): Promise<{ hasOlder: boolean }> {
+  const scope = conversationScope(agentPath, sessionKey);
+  const win = historyWindowOf(scope);
+  if (!win || win.earliestLoaded <= 0) return { hasOlder: false };
+  if (inFlight.has(scope)) return { hasOlder: true };
+  inFlight.add(scope);
+  try {
+    const history = await engine.getHistory(sessionKey, {
+      limit: CHAT_OLDER_PAGE,
+      before: win.earliestLoaded,
+    });
+    const offset = history.offset ?? 0;
+    // A pre-windowing server (or a proxy that dropped the params) returns
+    // the FULL transcript — cut it to the part below our cursor.
+    const messages =
+      offset === 0 && history.messages.length > win.earliestLoaded
+        ? history.messages.slice(0, win.earliestLoaded)
+        : history.messages;
+    const nowWin = historyWindowOf(scope);
+    if (nowWin?.earliestLoaded !== win.earliestLoaded) {
+      return { hasOlder: (nowWin?.earliestLoaded ?? 0) > 0 };
+    }
+    if (messages.length === 0) return { hasOlder: false };
+    conversationVm.prependHistory(
+      agentPath,
+      sessionKey,
+      sdkHistoryToFeed(messages),
+      {
+        earliestLoaded: offset,
+        total: history.totalMessages ?? history.messages.length,
+      },
+    );
+    return { hasOlder: offset > 0 };
+  } finally {
+    inFlight.delete(scope);
+  }
+}

--- a/packages/web/src/engine-adapter/conversation-cache.ts
+++ b/packages/web/src/engine-adapter/conversation-cache.ts
@@ -20,7 +20,7 @@
  */
 
 import { createIdbBackend } from "./conversation-cache-idb";
-import { CHAT_OPEN_WINDOW } from "./history-window";
+import { trimForCache } from "./history-window";
 
 export {
   conversationCacheScope,
@@ -32,10 +32,11 @@ export interface CachedFrame {
   feed_type: string;
   data: unknown;
   /**
-   * The frame's source-message timestamp, when the fold carried one. Persisted
-   * so the windowed-history revalidation (HOU-819) can compare a cache-painted
-   * feed against a fresh server tail by recency; absent on records written
-   * before this field existed (comparisons then degrade to the length guard).
+   * The frame's timestamp, when the source fold carried one — preserved so a
+   * cache-painted bubble keeps its real time instead of losing it (HOU-819).
+   * Display metadata only: seed/replace decisions never compare timestamps
+   * (live pushes and history folds are stamped by different clocks). Absent
+   * on records written before this field existed.
    */
   ts?: number;
 }
@@ -145,11 +146,10 @@ export async function writeCachedConversation(
   if (!key || !b || frames.length === 0) return;
   try {
     await b.set(key, {
-      // Cap at the open window (HOU-819): the cache exists to paint a cold
-      // open instantly, and a cold open shows exactly the tail window — a
-      // longer record would only make the revalidating tail read look poorer
-      // than the paint and suppress the load-older affordance.
-      frames: frames.slice(-CHAT_OPEN_WINDOW).map((f) => ({
+      // Bounded (HOU-819): the cache exists to paint a cold open instantly,
+      // so it keeps a recent-window snapshot, trimmed at a TURN boundary —
+      // never mid-turn, which would paint a reply missing its own prompt.
+      frames: trimForCache(frames).map((f) => ({
         feed_type: f.feed_type,
         data: f.data,
         ...(f.ts !== undefined ? { ts: f.ts } : {}),

--- a/packages/web/src/engine-adapter/conversation-cache.ts
+++ b/packages/web/src/engine-adapter/conversation-cache.ts
@@ -20,6 +20,7 @@
  */
 
 import { createIdbBackend } from "./conversation-cache-idb";
+import { CHAT_OPEN_WINDOW } from "./history-window";
 
 export {
   conversationCacheScope,
@@ -30,6 +31,13 @@ export {
 export interface CachedFrame {
   feed_type: string;
   data: unknown;
+  /**
+   * The frame's source-message timestamp, when the fold carried one. Persisted
+   * so the windowed-history revalidation (HOU-819) can compare a cache-painted
+   * feed against a fresh server tail by recency; absent on records written
+   * before this field existed (comparisons then degrade to the length guard).
+   */
+  ts?: number;
 }
 
 /** A stored transcript: its frames plus a write stamp (prune order). */
@@ -137,7 +145,15 @@ export async function writeCachedConversation(
   if (!key || !b || frames.length === 0) return;
   try {
     await b.set(key, {
-      frames: frames.map((f) => ({ feed_type: f.feed_type, data: f.data })),
+      // Cap at the open window (HOU-819): the cache exists to paint a cold
+      // open instantly, and a cold open shows exactly the tail window — a
+      // longer record would only make the revalidating tail read look poorer
+      // than the paint and suppress the load-older affordance.
+      frames: frames.slice(-CHAT_OPEN_WINDOW).map((f) => ({
+        feed_type: f.feed_type,
+        data: f.data,
+        ...(f.ts !== undefined ? { ts: f.ts } : {}),
+      })),
       updatedAt: Date.now(),
     });
     const keys = await b.keysOldestFirst();

--- a/packages/web/src/engine-adapter/history-window.ts
+++ b/packages/web/src/engine-adapter/history-window.ts
@@ -17,35 +17,129 @@ export const CHAT_OPEN_WINDOW = 120;
 /** Messages fetched per scroll-up load-older page. */
 export const CHAT_OLDER_PAGE = 80;
 
+/** The minimal frame shape the seed decision reads. */
+export interface SeedFrame {
+  feed_type: string;
+  data: unknown;
+  pending?: boolean;
+}
+
 /**
  * What to do with a WINDOWED server fold arriving over the current VM feed.
  *
- * - `replace`: the fold is strictly newer (or richer at the same last
- *   message) than what is on screen — reseed the feed from it.
- * - `stamp`: the fold matches the feed exactly (same last-message time, same
- *   length) — keep the feed (reseeding would churn every entry id and force a
- *   full remount) but record the server window so load-older knows where the
- *   loaded feed starts.
- * - `skip`: the fold is poorer/older than the feed (a raced read resolving
- *   after a settle, or a tail shorter than a locally cached paint) — keep
- *   everything as is.
+ * - `replace`: the fold is newer or richer — reseed the feed from it.
+ * - `stamp`: the fold matches the feed exactly — keep the feed (reseeding
+ *   would churn every entry id and force a full remount) but record the
+ *   server window so load-older knows where the loaded feed starts.
+ * - `skip`: the feed holds something the fold lacks (an unconfirmed
+ *   optimistic send, a raced read resolving after a settle, or pages already
+ *   loaded below the fold's window) — keep everything as is.
  *
- * Missing timestamps (pre-`ts` transcripts, legacy cache entries) fall back
- * to the historical richer-wins length guard.
+ * The comparison anchors on USER-MESSAGE CONTENT (the turn skeleton), never
+ * on frame timestamps: live pushes are stamped with the CLIENT clock while
+ * history folds carry the runtime's `ChatMessage.ts` — two different clock
+ * domains that cannot be ordered against each other (a cache written at
+ * settle time would routinely compare "newer" than the authoritative tail).
+ *
+ * `currentHasWindow` = the feed already carries a stamped `historyWindow`
+ * (a prior windowed seed / loaded pages): a same-content, shorter fold then
+ * skips instead of discarding the loaded pages, while an UNSTAMPED longer
+ * paint (a cache) is replaced so the on-screen feed maps to real server
+ * indices before load-older arms.
  */
 export function decideServerSeed(
-  current: readonly { ts?: number }[],
-  incoming: readonly { ts?: number }[],
+  current: readonly SeedFrame[],
+  incoming: readonly SeedFrame[],
+  currentHasWindow: boolean,
 ): "replace" | "stamp" | "skip" {
   if (current.length === 0) return incoming.length > 0 ? "replace" : "skip";
   if (incoming.length === 0) return "skip";
-  const curLast = current[current.length - 1]?.ts;
-  const inLast = incoming[incoming.length - 1]?.ts;
-  if (curLast === undefined || inLast === undefined) {
-    return incoming.length > current.length ? "replace" : "skip";
+  // Never clobber an optimistic bubble the engine has not confirmed — the
+  // fold cannot contain it yet by definition.
+  if (current.some((f) => f.pending === true)) return "skip";
+
+  const curU = lastUserIndex(current);
+  const incU = lastUserIndex(incoming);
+  if (curU === -1 || incU === -1) {
+    // No turn anchor on one side (a window sliced mid-turn, odd folds):
+    // fall back to richer-wins.
+    if (incoming.length > current.length) return "replace";
+    if (incoming.length === current.length) return "stamp";
+    return currentHasWindow ? "skip" : "replace";
   }
-  if (inLast > curLast) return "replace";
-  if (inLast < curLast) return "skip";
+
+  const curLastUser = frameText(current[curU]);
+  const incLastUser = frameText(incoming[incU]);
+  if (curLastUser !== incLastUser) {
+    // Different latest turns: the side CONTAINING the other's latest turn is
+    // the newer superset.
+    if (containsUser(incoming, curLastUser)) return "replace";
+    if (containsUser(current, incLastUser)) return "skip";
+    // Disjoint (the tail window starts beyond everything on screen): the
+    // server is authoritative for a feed no stream owns.
+    return "replace";
+  }
+
+  // Same latest turn on both sides: compare what followed it.
+  const curAfter = current.length - 1 - curU;
+  const incAfter = incoming.length - 1 - incU;
+  if (incAfter > curAfter) return "replace"; // fold has settled content the feed lacks
+  if (incAfter < curAfter) return "skip"; // feed has settled content the fold missed
+  // Identical latest turn; only the OLDER region can differ.
+  if (incoming.length === current.length) return "stamp";
   if (incoming.length > current.length) return "replace";
-  return incoming.length === current.length ? "stamp" : "skip";
+  return currentHasWindow ? "skip" : "replace";
+}
+
+function lastUserIndex(frames: readonly SeedFrame[]): number {
+  for (let i = frames.length - 1; i >= 0; i--) {
+    if (frames[i]?.feed_type === "user_message") return i;
+  }
+  return -1;
+}
+
+/** A frame's comparable text — user bubbles carry plain strings both live and folded. */
+function frameText(frame: SeedFrame | undefined): string {
+  const data = frame?.data;
+  return typeof data === "string" ? data : JSON.stringify(data ?? null);
+}
+
+function containsUser(frames: readonly SeedFrame[], text: string): boolean {
+  return frames.some(
+    (f) => f.feed_type === "user_message" && frameText(f) === text,
+  );
+}
+
+/**
+ * Frame budget for the local conversation cache — sized to comfortably cover
+ * an open window's fold (one MESSAGE folds to several frames).
+ */
+export const CACHE_FRAME_BUDGET = 360;
+
+/** Absolute cache ceiling when a single turn overflows the budget. */
+export const CACHE_FRAME_HARD_MAX = 600;
+
+/**
+ * Trim a feed snapshot for the cache WITHOUT cutting a turn apart: past the
+ * budget, the cut walks back to the previous `user_message` boundary so a
+ * cold-open paint never starts mid-turn (a tool-heavy reply alone can exceed
+ * a naive frame cap, which would paint a transcript missing its own prompt).
+ * A single turn larger than {@link CACHE_FRAME_HARD_MAX} is cut mid-turn —
+ * the ceiling wins.
+ */
+export function trimForCache<T extends { feed_type: string }>(
+  frames: readonly T[],
+  budget: number = CACHE_FRAME_BUDGET,
+  hardMax: number = CACHE_FRAME_HARD_MAX,
+): readonly T[] {
+  if (frames.length <= budget) return frames;
+  let start = frames.length - budget;
+  while (
+    start > 0 &&
+    frames[start]?.feed_type !== "user_message" &&
+    frames.length - start < hardMax
+  ) {
+    start--;
+  }
+  return frames.slice(start);
 }

--- a/packages/web/src/engine-adapter/history-window.ts
+++ b/packages/web/src/engine-adapter/history-window.ts
@@ -1,0 +1,51 @@
+/**
+ * Chat transcript windowing (HOU-819).
+ *
+ * Opening a chat used to fetch and fold the ENTIRE conversation transcript —
+ * on long missions that meant a multi-hundred-message JSON payload (held for
+ * the whole pod cold start on cloud), a full markdown parse/render of every
+ * bubble, and the same full fetch re-fired by every `ConversationsChanged`
+ * invalidation while a turn ran. The chat "hung" before opening or accepting
+ * input. Now a chat opens on the LAST {@link CHAT_OPEN_WINDOW} messages and
+ * lazily prepends {@link CHAT_OLDER_PAGE}-message pages as the user scrolls
+ * up (the VM's `historyWindow` tracks where the loaded feed starts).
+ */
+
+/** Messages fetched when a chat opens — the tail window. */
+export const CHAT_OPEN_WINDOW = 120;
+
+/** Messages fetched per scroll-up load-older page. */
+export const CHAT_OLDER_PAGE = 80;
+
+/**
+ * What to do with a WINDOWED server fold arriving over the current VM feed.
+ *
+ * - `replace`: the fold is strictly newer (or richer at the same last
+ *   message) than what is on screen — reseed the feed from it.
+ * - `stamp`: the fold matches the feed exactly (same last-message time, same
+ *   length) — keep the feed (reseeding would churn every entry id and force a
+ *   full remount) but record the server window so load-older knows where the
+ *   loaded feed starts.
+ * - `skip`: the fold is poorer/older than the feed (a raced read resolving
+ *   after a settle, or a tail shorter than a locally cached paint) — keep
+ *   everything as is.
+ *
+ * Missing timestamps (pre-`ts` transcripts, legacy cache entries) fall back
+ * to the historical richer-wins length guard.
+ */
+export function decideServerSeed(
+  current: readonly { ts?: number }[],
+  incoming: readonly { ts?: number }[],
+): "replace" | "stamp" | "skip" {
+  if (current.length === 0) return incoming.length > 0 ? "replace" : "skip";
+  if (incoming.length === 0) return "skip";
+  const curLast = current[current.length - 1]?.ts;
+  const inLast = incoming[incoming.length - 1]?.ts;
+  if (curLast === undefined || inLast === undefined) {
+    return incoming.length > current.length ? "replace" : "skip";
+  }
+  if (inLast > curLast) return "replace";
+  if (inLast < curLast) return "skip";
+  if (incoming.length > current.length) return "replace";
+  return incoming.length === current.length ? "stamp" : "skip";
+}

--- a/packages/web/src/engine-adapter/turn-stream.ts
+++ b/packages/web/src/engine-adapter/turn-stream.ts
@@ -3,7 +3,7 @@ import {
   type BoardStatus,
   conversationScope,
   type FeedFrame,
-  type FeedOutput,
+  type HistoryWindowVM,
   MultiplexFeedOutput,
   type PendingInteraction,
   StreamRegistry,
@@ -13,8 +13,9 @@ import {
   streamKey,
   type TurnWirePin,
 } from "@houston/sdk";
-import { writeCachedConversation } from "./conversation-cache";
+import { cachePersistOutput } from "./cache-persist";
 import { createBusFeedOutput } from "./feed-output";
+import { decideServerSeed } from "./history-window";
 import { conversationStore, conversationVm } from "./vm";
 
 export type { StreamTuning } from "@houston/sdk";
@@ -30,35 +31,6 @@ const registry = new StreamRegistry();
 /** Abort every live conversation stream this adapter owns (WS teardown seam). */
 export function disposeAllStreams(): void {
   registry.disposeAll();
-}
-
-/**
- * Persist the VM's folded feed to the local conversation cache when a turn
- * (or observed turn) settles, so the transcript a cold reopen paints includes
- * everything sent THIS session — not just the state at the last history read
- * (HOU-712). Frames were already folded by the VM (first in the multiplex);
- * this just snapshots them. Cloud-only by construction: the cache no-ops
- * without a gateway identity. Fire-and-forget — a cache write must never
- * delay a settle.
- */
-function cachePersistOutput(): FeedOutput {
-  return {
-    pushFeedItem() {},
-    sessionStatus() {},
-    async persistBoardStatus(agentPath, sessionKey, status) {
-      if (status === "running") return;
-      const snapshot = conversationStore.getSnapshot(
-        conversationScope(agentPath, sessionKey),
-      ) as { feed?: { feed_type: string; data: unknown }[] } | undefined;
-      const frames = snapshot?.feed;
-      if (!frames || frames.length === 0) return;
-      void writeCachedConversation(
-        agentPath,
-        sessionKey,
-        frames.map((f) => ({ feed_type: f.feed_type, data: f.data })),
-      );
-    },
-  };
 }
 
 /**
@@ -86,25 +58,43 @@ function composedOutput(
 /**
  * Seed the conversation VM from a loaded history fold — unless a live turn or
  * observer already owns the conversation (that stream's feed IS the VM;
- * re-seeding would clobber its in-flight bubble), or the VM already holds at
- * least as much as the fold. The second guard is what makes a RACED history
+ * re-seeding would clobber its in-flight bubble), or the VM already holds a
+ * feed the fold would make poorer. The guard is what makes a RACED history
  * read harmless: a load fired mid-turn can resolve just after settle (the
  * registry entry already released) carrying a fold persisted BEFORE the reply
- * — replacing the settled live feed with it would eat the reply. History only
- * ever seeds a poorer VM (cold open, or turns that landed while this chat was
- * closed).
+ * — replacing the settled live feed with it would eat the reply.
+ *
+ * Two seed shapes (HOU-819):
+ * - Cache paint (no `window`): the historical richer-wins length guard — the
+ *   paint only ever fills an emptier VM.
+ * - Windowed server read (`window` set): the fold is a TAIL, so it can be
+ *   shorter than the feed yet strictly newer (a teammate's turn landed while
+ *   this chat was closed and cache-painted) — {@link decideServerSeed}
+ *   compares by last-message recency, replaces on newer/richer, stamps the
+ *   window without reseeding on identical content, and skips on poorer.
  */
 export function seedConversationVm(
   agentPath: string,
   sessionKey: string,
   frames: FeedFrame[],
+  window?: HistoryWindowVM,
 ): void {
   if (registry.get(streamKey(agentPath, sessionKey))) return;
   const current = conversationStore.getSnapshot(
     conversationScope(agentPath, sessionKey),
-  ) as { feed?: unknown[] } | undefined;
-  if ((current?.feed?.length ?? 0) >= frames.length) return;
-  conversationVm.seedHistory(agentPath, sessionKey, frames);
+  ) as { feed?: { ts?: number }[] } | undefined;
+  const curFeed = current?.feed ?? [];
+  if (!window) {
+    if (curFeed.length >= frames.length) return;
+    conversationVm.seedHistory(agentPath, sessionKey, frames);
+    return;
+  }
+  const decision = decideServerSeed(curFeed, frames);
+  if (decision === "replace") {
+    conversationVm.seedHistory(agentPath, sessionKey, frames, window);
+  } else if (decision === "stamp") {
+    conversationVm.stampHistoryWindow(agentPath, sessionKey, window);
+  }
 }
 
 /**

--- a/packages/web/src/engine-adapter/turn-stream.ts
+++ b/packages/web/src/engine-adapter/turn-stream.ts
@@ -15,7 +15,7 @@ import {
 } from "@houston/sdk";
 import { cachePersistOutput } from "./cache-persist";
 import { createBusFeedOutput } from "./feed-output";
-import { decideServerSeed } from "./history-window";
+import { decideServerSeed, type SeedFrame } from "./history-window";
 import { conversationStore, conversationVm } from "./vm";
 
 export type { StreamTuning } from "@houston/sdk";
@@ -70,8 +70,10 @@ function composedOutput(
  * - Windowed server read (`window` set): the fold is a TAIL, so it can be
  *   shorter than the feed yet strictly newer (a teammate's turn landed while
  *   this chat was closed and cache-painted) — {@link decideServerSeed}
- *   compares by last-message recency, replaces on newer/richer, stamps the
- *   window without reseeding on identical content, and skips on poorer.
+ *   anchors on user-message content (never cross-clock timestamps), replaces
+ *   on newer/richer, stamps the window without reseeding on identical
+ *   content, and skips on poorer (or when the feed holds loaded pages /
+ *   unconfirmed sends the fold lacks).
  */
 export function seedConversationVm(
   agentPath: string,
@@ -82,14 +84,18 @@ export function seedConversationVm(
   if (registry.get(streamKey(agentPath, sessionKey))) return;
   const current = conversationStore.getSnapshot(
     conversationScope(agentPath, sessionKey),
-  ) as { feed?: { ts?: number }[] } | undefined;
+  ) as { feed?: SeedFrame[]; historyWindow?: HistoryWindowVM } | undefined;
   const curFeed = current?.feed ?? [];
   if (!window) {
     if (curFeed.length >= frames.length) return;
     conversationVm.seedHistory(agentPath, sessionKey, frames);
     return;
   }
-  const decision = decideServerSeed(curFeed, frames);
+  const decision = decideServerSeed(
+    curFeed,
+    frames,
+    current?.historyWindow !== undefined,
+  );
   if (decision === "replace") {
     conversationVm.seedHistory(agentPath, sessionKey, frames, window);
   } else if (decision === "stamp") {

--- a/packages/web/tests/history-window.test.ts
+++ b/packages/web/tests/history-window.test.ts
@@ -1,48 +1,168 @@
 import { expect, test } from "vitest";
-import { decideServerSeed } from "../src/engine-adapter/history-window";
+import {
+  CACHE_FRAME_HARD_MAX,
+  decideServerSeed,
+  type SeedFrame,
+  trimForCache,
+} from "../src/engine-adapter/history-window";
 
 /**
- * The windowed-seed decision (HOU-819): a server TAIL can be shorter than the
- * on-screen feed yet strictly newer (teammate turns landed while the chat was
- * closed and cache-painted), so recency — the last message's `ts` — decides,
- * with the historical richer-wins length guard as the no-timestamp fallback.
+ * The windowed-seed decision (HOU-819) anchors on USER-MESSAGE CONTENT (the
+ * turn skeleton), never on frame timestamps — live pushes are stamped by the
+ * client clock while history folds carry the runtime's clock, so recency
+ * comparisons across the two domains are meaningless. A server TAIL can be
+ * shorter than the on-screen feed yet strictly newer (teammate turns landed
+ * while the chat was closed and cache-painted).
  */
 
-const at = (ts: number) => ({ ts });
-const noTs = () => ({}) as { ts?: number };
+const user = (text: string): SeedFrame => ({
+  feed_type: "user_message",
+  data: text,
+});
+const reply = (text: string): SeedFrame => ({
+  feed_type: "assistant_text",
+  data: text,
+});
+const pendingUser = (text: string): SeedFrame => ({
+  feed_type: "user_message",
+  data: text,
+  pending: true,
+});
 
 test("an empty feed is always seeded", () => {
-  expect(decideServerSeed([], [at(10)])).toBe("replace");
+  expect(decideServerSeed([], [user("hi")], false)).toBe("replace");
 });
 
 test("an empty fold never blanks a painted feed", () => {
-  expect(decideServerSeed([at(10)], [])).toBe("skip");
+  expect(decideServerSeed([user("hi")], [], false)).toBe("skip");
 });
 
-test("a newer tail replaces a longer, older feed (the stale-cache case)", () => {
-  expect(decideServerSeed([at(1), at(2), at(3)], [at(2), at(9)])).toBe(
+test("an unconfirmed optimistic send is never clobbered", () => {
+  expect(
+    decideServerSeed(
+      [user("old"), reply("done"), pendingUser("parked send")],
+      [user("old"), reply("done")],
+      false,
+    ),
+  ).toBe("skip");
+});
+
+test("a tail containing newer turns replaces a stale cache paint", () => {
+  // Teammate turn "t2" landed while this chat was closed; the cache painted
+  // through "t1" only. The fold still contains t1, so it supersedes the feed.
+  expect(
+    decideServerSeed(
+      [user("t1"), reply("r1")],
+      [user("t1"), reply("r1"), user("t2"), reply("r2")],
+      false,
+    ),
+  ).toBe("replace");
+});
+
+test("a raced stale fold (feed's latest turn missing from it) is skipped", () => {
+  // The feed settled turn "t2" live; a read fired mid-turn resolves late
+  // carrying only through "t1" — replacing would eat the reply.
+  expect(
+    decideServerSeed(
+      [user("t1"), reply("r1"), user("t2"), reply("r2")],
+      [user("t1"), reply("r1")],
+      false,
+    ),
+  ).toBe("skip");
+});
+
+test("same latest turn, fold carries its settled reply the feed lacks", () => {
+  expect(decideServerSeed([user("t1")], [user("t1"), reply("r1")], false)).toBe(
     "replace",
   );
 });
 
-test("an older fold never replaces a newer feed (the raced-read case)", () => {
-  expect(decideServerSeed([at(5), at(9)], [at(5)])).toBe("skip");
+test("same latest turn, feed carries settled content the fold missed", () => {
+  expect(decideServerSeed([user("t1"), reply("r1")], [user("t1")], false)).toBe(
+    "skip",
+  );
 });
 
-test("identical content (same last ts, same length) stamps without reseeding", () => {
-  expect(decideServerSeed([at(1), at(9)], [at(1), at(9)])).toBe("stamp");
+test("identical content stamps without reseeding (no id churn)", () => {
+  expect(
+    decideServerSeed(
+      [user("t1"), reply("r1")],
+      [user("t1"), reply("r1")],
+      false,
+    ),
+  ).toBe("stamp");
 });
 
-test("same last message but a richer fold replaces (more of the transcript)", () => {
-  expect(decideServerSeed([at(9)], [at(1), at(9)])).toBe("replace");
+test("an UNSTAMPED longer cache paint is replaced by the authoritative window", () => {
+  // The cache painted more older content than the tail window covers, but the
+  // feed has no server indices — replace so load-older arms correctly.
+  expect(
+    decideServerSeed(
+      [user("t0"), reply("r0"), user("t1"), reply("r1")],
+      [user("t1"), reply("r1")],
+      false,
+    ),
+  ).toBe("replace");
 });
 
-test("same last message but a poorer fold skips (no stamp — indices unknown)", () => {
-  expect(decideServerSeed([at(1), at(2), at(9)], [at(9)])).toBe("skip");
+test("a STAMPED wider feed (loaded pages) survives a same-content tail refetch", () => {
+  // The user loaded older pages; a ConversationsChanged revalidation refetches
+  // the tail — discarding the prepended pages would throw away their work.
+  expect(
+    decideServerSeed(
+      [user("t0"), reply("r0"), user("t1"), reply("r1")],
+      [user("t1"), reply("r1")],
+      true,
+    ),
+  ).toBe("skip");
 });
 
-test("no timestamps falls back to richer-wins; ties keep the current feed", () => {
-  expect(decideServerSeed([noTs()], [noTs(), noTs()])).toBe("replace");
-  expect(decideServerSeed([noTs(), noTs()], [noTs(), noTs()])).toBe("skip");
-  expect(decideServerSeed([noTs(), noTs()], [noTs()])).toBe("skip");
+test("disjoint tails: the server window wins over an unowned ancient feed", () => {
+  expect(
+    decideServerSeed(
+      [user("ancient"), reply("r")],
+      [user("recent-a"), reply("ra"), user("recent-b"), reply("rb")],
+      false,
+    ),
+  ).toBe("replace");
+});
+
+test("no user anchor on either side falls back to richer-wins", () => {
+  expect(decideServerSeed([reply("a")], [reply("a"), reply("b")], false)).toBe(
+    "replace",
+  );
+  expect(decideServerSeed([reply("a")], [reply("a")], false)).toBe("stamp");
+});
+
+// ── Cache trim (turn-aligned) ───────────────────────────────────────────────
+
+test("trimForCache keeps a small feed untouched", () => {
+  const frames = [user("t1"), reply("r1")];
+  expect(trimForCache(frames, 10, 20)).toBe(frames);
+});
+
+test("trimForCache cuts at a turn boundary, never mid-turn", () => {
+  // 3 turns of 4 frames each; a budget of 6 lands mid-turn-2 and must walk
+  // back to turn 2's user message.
+  const frames = [1, 2, 3].flatMap((n) => [
+    user(`t${n}`),
+    reply(`a${n}`),
+    reply(`b${n}`),
+    reply(`c${n}`),
+  ]);
+  const trimmed = trimForCache(frames, 6, 100);
+  expect(trimmed[0]?.data).toBe("t2");
+  expect(trimmed).toHaveLength(8);
+});
+
+test("trimForCache falls back to the hard ceiling on a single oversized turn", () => {
+  const frames: SeedFrame[] = [
+    user("t1"),
+    ...Array.from({ length: CACHE_FRAME_HARD_MAX + 50 }, (_, i) =>
+      reply(`tool ${i}`),
+    ),
+  ];
+  const trimmed = trimForCache(frames);
+  expect(trimmed.length).toBeLessThanOrEqual(CACHE_FRAME_HARD_MAX);
+  expect(trimmed[0]?.feed_type).not.toBe("user_message");
 });

--- a/packages/web/tests/history-window.test.ts
+++ b/packages/web/tests/history-window.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "vitest";
+import { decideServerSeed } from "../src/engine-adapter/history-window";
+
+/**
+ * The windowed-seed decision (HOU-819): a server TAIL can be shorter than the
+ * on-screen feed yet strictly newer (teammate turns landed while the chat was
+ * closed and cache-painted), so recency — the last message's `ts` — decides,
+ * with the historical richer-wins length guard as the no-timestamp fallback.
+ */
+
+const at = (ts: number) => ({ ts });
+const noTs = () => ({}) as { ts?: number };
+
+test("an empty feed is always seeded", () => {
+  expect(decideServerSeed([], [at(10)])).toBe("replace");
+});
+
+test("an empty fold never blanks a painted feed", () => {
+  expect(decideServerSeed([at(10)], [])).toBe("skip");
+});
+
+test("a newer tail replaces a longer, older feed (the stale-cache case)", () => {
+  expect(decideServerSeed([at(1), at(2), at(3)], [at(2), at(9)])).toBe(
+    "replace",
+  );
+});
+
+test("an older fold never replaces a newer feed (the raced-read case)", () => {
+  expect(decideServerSeed([at(5), at(9)], [at(5)])).toBe("skip");
+});
+
+test("identical content (same last ts, same length) stamps without reseeding", () => {
+  expect(decideServerSeed([at(1), at(9)], [at(1), at(9)])).toBe("stamp");
+});
+
+test("same last message but a richer fold replaces (more of the transcript)", () => {
+  expect(decideServerSeed([at(9)], [at(1), at(9)])).toBe("replace");
+});
+
+test("same last message but a poorer fold skips (no stamp — indices unknown)", () => {
+  expect(decideServerSeed([at(1), at(2), at(9)], [at(9)])).toBe("skip");
+});
+
+test("no timestamps falls back to richer-wins; ties keep the current feed", () => {
+  expect(decideServerSeed([noTs()], [noTs(), noTs()])).toBe("replace");
+  expect(decideServerSeed([noTs(), noTs()], [noTs(), noTs()])).toBe("skip");
+  expect(decideServerSeed([noTs(), noTs()], [noTs()])).toBe("skip");
+});

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -69,6 +69,11 @@ export interface AIBoardProps {
    *  internal `newPanelOpen` state, which `setSelectedId(null)` does
    *  not touch. */
   onPanelCloserReady?: (close: () => void) => void;
+  /** Scroll-up lazy-load for the OPEN chat (HOU-819): the parent resolves it
+   *  for the active conversation; prepends the previous transcript page. */
+  onLoadOlderMessages?: () => Promise<unknown>;
+  /** Older messages exist beyond the open chat's loaded window. */
+  hasOlderMessages?: boolean;
   /** Custom empty state for the chat panel when no messages exist. */
   chatEmptyState?: ReactNode;
   /** Custom thinking indicator for the chat panel. */
@@ -284,6 +289,8 @@ export function AIBoard({
   onHistoryLoaded,
   onNewPanelOpenerReady,
   onPanelCloserReady,
+  onLoadOlderMessages,
+  hasOlderMessages,
   chatEmptyState,
   thinkingIndicator,
   cardAvatar,
@@ -689,6 +696,8 @@ export function AIBoard({
               : "What should the agent work on?"
           }
           emptyState={activeFeed.length === 0 ? chatEmptyState : undefined}
+          onLoadOlder={activeSessionKey ? onLoadOlderMessages : undefined}
+          hasOlderMessages={hasOlderMessages}
           thinkingIndicator={thinkingIndicator}
           value={drafts ? (drafts[activeDraftKey] ?? "") : undefined}
           onValueChange={

--- a/ui/chat/src/ai-elements/conversation-load-older.tsx
+++ b/ui/chat/src/ai-elements/conversation-load-older.tsx
@@ -46,9 +46,9 @@ export const ConversationLoadOlder = ({
         // upward, so restoring that distance keeps the visible messages still.
         // Known limitation: content APPENDED during the fetch (an actively
         // streaming turn) is indistinguishable from prepended growth here, so
-        // the viewport shifts by that delta — message React keys are
-        // position-based today, so no DOM node above survives the prepend to
-        // anchor on. Fix rides on stable feed-entry keys (follow-up).
+        // the viewport shifts by that delta. Message keys are stable now
+        // (feed-entry ids), so a follow-up can anchor on a surviving DOM node
+        // instead of this pane-level measurement.
         const bottomGap = pane.scrollHeight - pane.scrollTop;
         void onLoadOlder()
           .catch(() => {

--- a/ui/chat/src/ai-elements/conversation-load-older.tsx
+++ b/ui/chat/src/ai-elements/conversation-load-older.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { cn } from "@houston-ai/core";
+import { Loader2Icon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useStickToBottomContext } from "use-stick-to-bottom";
+
+export type ConversationLoadOlderProps = {
+  /** Older messages exist server-side (the loaded window has a start > 0). */
+  hasOlder: boolean;
+  /** Prepend the previous page; resolves once the feed carries it. */
+  onLoadOlder: () => Promise<unknown>;
+};
+
+/**
+ * Scroll-up lazy-load trigger (HOU-819). Mount as the FIRST child of
+ * <ConversationContent>: when the user scrolls the top of the loaded window
+ * into view, the previous transcript page is fetched and prepended, and the
+ * viewport is anchored (same distance from the bottom) so the content on
+ * screen never jumps. Guarded against the initial stick-to-bottom animation
+ * (which sweeps the sentinel past the viewport while pinned to bottom) and
+ * against overlapping loads.
+ */
+export const ConversationLoadOlder = ({
+  hasOlder,
+  onLoadOlder,
+}: ConversationLoadOlderProps) => {
+  const { scrollRef, isAtBottom } = useStickToBottomContext();
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const loadingRef = useRef(false);
+  const [loading, setLoading] = useState(false);
+  const isAtBottomRef = useRef(isAtBottom);
+  isAtBottomRef.current = isAtBottom;
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    const pane = scrollRef.current;
+    if (!el || !pane || !hasOlder) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((e) => e.isIntersecting)) return;
+        if (loadingRef.current || isAtBottomRef.current) return;
+        loadingRef.current = true;
+        setLoading(true);
+        // Anchor by distance-from-bottom: prepended content grows the pane
+        // upward, so restoring that distance keeps the visible messages still.
+        const bottomGap = pane.scrollHeight - pane.scrollTop;
+        void onLoadOlder()
+          .catch(() => {
+            // The parent's loader surfaces its own failure (toast path); here
+            // only the trigger state must recover so a retry can fire.
+          })
+          .finally(() => {
+            requestAnimationFrame(() => {
+              requestAnimationFrame(() => {
+                pane.scrollTop = pane.scrollHeight - bottomGap;
+                loadingRef.current = false;
+                setLoading(false);
+              });
+            });
+          });
+      },
+      { root: pane, rootMargin: "160px 0px 0px 0px" },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [hasOlder, onLoadOlder, scrollRef]);
+
+  if (!hasOlder) return null;
+  return (
+    <div aria-hidden className="flex justify-center py-1" ref={sentinelRef}>
+      <Loader2Icon
+        className={cn(
+          "size-4 text-ink-muted",
+          loading ? "animate-spin opacity-100" : "opacity-0",
+        )}
+      />
+    </div>
+  );
+};

--- a/ui/chat/src/ai-elements/conversation-load-older.tsx
+++ b/ui/chat/src/ai-elements/conversation-load-older.tsx
@@ -44,6 +44,11 @@ export const ConversationLoadOlder = ({
         setLoading(true);
         // Anchor by distance-from-bottom: prepended content grows the pane
         // upward, so restoring that distance keeps the visible messages still.
+        // Known limitation: content APPENDED during the fetch (an actively
+        // streaming turn) is indistinguishable from prepended growth here, so
+        // the viewport shifts by that delta — message React keys are
+        // position-based today, so no DOM node above survives the prepend to
+        // anchor on. Fix rides on stable feed-entry keys (follow-up).
         const bottomGap = pane.scrollHeight - pane.scrollTop;
         void onLoadOlder()
           .catch(() => {

--- a/ui/chat/src/chat-message-item.tsx
+++ b/ui/chat/src/chat-message-item.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@houston-ai/core";
 import type { ReactNode } from "react";
 import type { RenderLinkProps } from "./ai-elements/message";
 import {
@@ -14,6 +15,7 @@ import type { ChatDisplayItem } from "./chat-process-groups";
 import { ChatProcessMessage } from "./chat-process-message";
 import { ChatSystemMessage } from "./chat-system-message";
 import type { ChatMessage } from "./feed-to-messages";
+import { OFFSCREEN_RENDER_SKIP } from "./offscreen-render";
 import type { TurnEndSummary } from "./turn-tools";
 
 interface ChatMessageItemProps {
@@ -69,6 +71,9 @@ export function ChatMessageItem({
   if (item.kind === "process") {
     return (
       <ChatProcessMessage
+        // An ACTIVE (streaming) block is at the viewport bottom and renders
+        // normally either way; settled blocks off-screen skip layout/paint.
+        className={OFFSCREEN_RENDER_SKIP}
         getThinkingMessage={getThinkingMessage}
         isSpecialTool={isSpecialTool}
         item={item}
@@ -86,9 +91,11 @@ export function ChatMessageItem({
   const highlighted = highlightedMessageKey === message.key;
   const sharedProps = {
     "aria-label": highlighted ? selectedLabel : undefined,
-    className: highlighted
-      ? "rounded-xl bg-accent/70 px-2 py-1 outline outline-2 outline-ring"
-      : undefined,
+    className: cn(
+      OFFSCREEN_RENDER_SKIP,
+      highlighted &&
+        "rounded-xl bg-accent/70 px-2 py-1 outline outline-2 outline-ring",
+    ),
     "data-conversation-message-key": message.key,
   };
 

--- a/ui/chat/src/chat-messages-types.ts
+++ b/ui/chat/src/chat-messages-types.ts
@@ -45,6 +45,11 @@ export interface ChatMessagesProps {
   /** Node rendered after the last message (inside the scroll container).
    *  Useful for inline end-of-feed cards like auth reconnect prompts. */
   afterMessages?: ReactNode;
+  /** Scroll-up lazy-load (HOU-819): prepend the previous transcript page.
+   *  Rendered as a top-of-feed trigger only when `hasOlderMessages`. */
+  onLoadOlder?: () => Promise<unknown>;
+  /** Older messages exist beyond the loaded window (the trigger shows). */
+  hasOlderMessages?: boolean;
   onOpenLink?: (url: string) => void;
   /** Custom renderer for markdown links. See `RenderLinkProps`. */
   renderLink?: (props: RenderLinkProps) => ReactNode;

--- a/ui/chat/src/chat-messages.tsx
+++ b/ui/chat/src/chat-messages.tsx
@@ -8,6 +8,7 @@ import {
   ConversationScrollButton,
   ConversationTopFade,
 } from "./ai-elements/conversation";
+import { ConversationLoadOlder } from "./ai-elements/conversation-load-older";
 import { Message, MessageContent } from "./ai-elements/message";
 import { ChatMessageItem } from "./chat-message-item";
 import type { ChatMessagesProps } from "./chat-messages-types";
@@ -40,6 +41,8 @@ export function ChatMessages({
   contextCompactedLabel,
   renderUserMessage,
   afterMessages,
+  onLoadOlder,
+  hasOlderMessages,
   onOpenLink,
   renderLink,
   currentUserId,
@@ -90,6 +93,12 @@ export function ChatMessages({
       <ConversationAutoScroll status={status} />
       <ConversationTopFade />
       <ConversationContent className="max-w-3xl mx-auto">
+        {onLoadOlder ? (
+          <ConversationLoadOlder
+            hasOlder={hasOlderMessages === true}
+            onLoadOlder={onLoadOlder}
+          />
+        ) : null}
         {displayItems.map((item) => (
           <ChatMessageItem
             authorLabels={authorLabels}

--- a/ui/chat/src/chat-panel-types.ts
+++ b/ui/chat/src/chat-panel-types.ts
@@ -98,6 +98,9 @@ export interface ChatPanelProps {
   contextCompactedLabel?: string;
   renderUserMessage?: (msg: ChatMessage) => ReactNode | undefined;
   afterMessages?: ReactNode;
+  /** Scroll-up lazy-load (HOU-819): see `ChatMessagesProps.onLoadOlder`. */
+  onLoadOlder?: ChatMessagesProps["onLoadOlder"];
+  hasOlderMessages?: ChatMessagesProps["hasOlderMessages"];
   renderTurnSummary?: ChatMessagesProps["renderTurnSummary"];
   onOpenLink?: (url: string) => void;
   renderLink?: ChatMessagesProps["renderLink"];

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -48,6 +48,8 @@ export function ChatPanel({
   contextCompactedLabel,
   renderUserMessage,
   afterMessages,
+  onLoadOlder,
+  hasOlderMessages,
   renderTurnSummary,
   onOpenLink,
   renderLink,
@@ -186,6 +188,8 @@ export function ChatPanel({
           contextCompactedLabel={contextCompactedLabel}
           renderUserMessage={renderUserMessage}
           afterMessages={afterMessages}
+          onLoadOlder={onLoadOlder}
+          hasOlderMessages={hasOlderMessages}
           renderTurnSummary={renderTurnSummary}
           onOpenLink={onOpenLink}
           renderLink={renderLink}

--- a/ui/chat/src/chat-process-message.tsx
+++ b/ui/chat/src/chat-process-message.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@houston-ai/core";
 import type { ReactNode } from "react";
 import { Message } from "./ai-elements/message";
 import type { ReasoningTriggerProps } from "./ai-elements/reasoning";
@@ -12,6 +13,8 @@ type ProcessItem = Extract<ChatDisplayItem, { kind: "process" }>;
 
 interface ChatProcessMessageProps {
   item: ProcessItem;
+  /** Merged onto the root Message (the offscreen render-skip classes). */
+  className?: string;
   turnEndSummaries: Map<number, TurnEndSummary>;
   renderMessageAvatar?: (msg: ChatMessage) => ReactNode | undefined;
   renderTurnSummary?: (summary: TurnEndSummary) => ReactNode;
@@ -24,6 +27,7 @@ interface ChatProcessMessageProps {
 
 export function ChatProcessMessage({
   item,
+  className,
   turnEndSummaries,
   renderMessageAvatar,
   renderTurnSummary,
@@ -41,7 +45,7 @@ export function ChatProcessMessage({
   return (
     <Message
       from="assistant"
-      className="-my-6"
+      className={cn("-my-6", className)}
       avatar={renderMessageAvatar?.(item.segments[0].message)}
     >
       <div>

--- a/ui/chat/src/feed-to-messages.ts
+++ b/ui/chat/src/feed-to-messages.ts
@@ -101,11 +101,20 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
     }
   };
 
-  const ensureAssistant = (): ChatMessage => {
+  // Message keys prefer the feed item's stable VM id (`kind-fA7`) over the
+  // positional fallback (`kind-3`): prepending older history (HOU-819) shifts
+  // every position, and positional keys would remount the whole list below —
+  // reusing Streamdown instances against different messages' content (#364's
+  // failure class). The id of the item that STARTS a message keys it; a
+  // streaming entry keeps its id across deltas, so live keys are stable too.
+  const keyFor = (kind: string, item: { id?: string }): string =>
+    `${kind}-${item.id ?? messages.length}`;
+
+  const ensureAssistant = (item: { id?: string }): ChatMessage => {
     if (cur?.from !== "assistant") {
       flush();
       cur = {
-        key: `assistant-${messages.length}`,
+        key: keyFor("assistant", item),
         from: "assistant",
         content: "",
         isStreaming: false,
@@ -140,7 +149,7 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
         turnHadErrorCard = false;
         const { source, text } = extractSource(item.data);
         messages.push({
-          key: `user-${messages.length}`,
+          key: keyFor("user", item),
           from: "user",
           content: text,
           isStreaming: false,
@@ -153,7 +162,7 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
       }
 
       case "assistant_text": {
-        const msg = ensureAssistant();
+        const msg = ensureAssistant(item);
         msg.content = item.data;
         msg.isStreaming = false;
         flush();
@@ -161,7 +170,7 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
       }
 
       case "assistant_text_streaming": {
-        const msg = ensureAssistant();
+        const msg = ensureAssistant(item);
         msg.content = item.data;
         msg.isStreaming = true;
         break;
@@ -178,7 +187,7 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
         ) {
           flush();
         }
-        const msg = ensureAssistant();
+        const msg = ensureAssistant(item);
         msg.reasoning = { content: item.data, isStreaming: isStream };
         if (isStream) msg.isStreaming = true;
         if (!isStream) flush();
@@ -186,7 +195,7 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
       }
 
       case "tool_call": {
-        const msg = ensureAssistant();
+        const msg = ensureAssistant(item);
         // Deduplicate: the parser emits two tool_calls per tool (null input
         // on block start, real input on block stop). Replace the placeholder.
         const lastTool = msg.tools[msg.tools.length - 1];
@@ -245,7 +254,7 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
         flush();
         turnHadErrorCard = true;
         messages.push({
-          key: `tool-runtime-error-${messages.length}`,
+          key: keyFor("tool-runtime-error", item),
           from: "system",
           content: "A local tool failed to start.",
           isStreaming: false,
@@ -270,7 +279,7 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
         seenProviderErrors.add(providerErrorKey);
         flush();
         messages.push({
-          key: `provider-error-${messages.length}-${item.data.kind}`,
+          key: `${keyFor("provider-error", item)}-${item.data.kind}`,
           from: "system",
           // Empty content so the rendered message body collapses to the
           // typed card. The consumer (renderSystemMessage in the app)
@@ -291,7 +300,7 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
         if (turnHadErrorCard && isSessionErrorEcho(item.data)) break;
         flush();
         messages.push({
-          key: `system-${messages.length}`,
+          key: keyFor("system", item),
           from: "system",
           content: item.data,
           isStreaming: false,
@@ -304,7 +313,7 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
       case "context_compacted": {
         flush();
         messages.push({
-          key: `context-compacted-${messages.length}`,
+          key: keyFor("context-compacted", item),
           from: "system",
           // Empty content — the renderer shows a localized divider keyed off
           // `compaction`, not this string.
@@ -324,7 +333,7 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
       case "provider_switched": {
         flush();
         messages.push({
-          key: `provider-switched-${messages.length}`,
+          key: keyFor("provider-switched", item),
           from: "system",
           // Empty content — the renderer shows a localized divider keyed off
           // `compaction`, not this string.

--- a/ui/chat/src/offscreen-render.ts
+++ b/ui/chat/src/offscreen-render.ts
@@ -1,0 +1,14 @@
+/**
+ * Native rendering virtualization (HOU-819): `content-visibility: auto` lets
+ * the browser skip layout/paint for messages outside the viewport — a long
+ * loaded window costs its on-screen slice, not its full markdown render.
+ * `contain-intrinsic-size`'s `auto` keeps the last rendered height once
+ * measured (the 9rem estimate only sizes never-rendered items), so scroll
+ * geometry stays stable. Engines without support simply ignore both — the
+ * list renders exactly as before.
+ *
+ * Apply on each message ROOT, never a wrapper: containment clips descendant
+ * outlines, and the search highlight draws an outline on that very element.
+ */
+export const OFFSCREEN_RENDER_SKIP =
+  "[content-visibility:auto] [contain-intrinsic-size:auto_9rem]";

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -12,7 +12,20 @@ export interface MessageAuthor {
   name?: string;
 }
 
-export type FeedItem =
+/**
+ * Optional stable identity for a feed item, carried from the conversation
+ * view-model's feed entries. When present it keys the rendered message, so
+ * PREPENDING older items (scroll-up lazy-load, HOU-819) never re-keys the
+ * items below — positional keys would hand every existing Streamdown
+ * instance a different message's content (the #364 stale-render class).
+ * Absent on id-less feeds (tests, standalone consumers): keys fall back to
+ * positional and behave exactly as before.
+ */
+type FeedItemIdentity = { id?: string };
+
+export type FeedItem = FeedItemVariant & FeedItemIdentity;
+
+type FeedItemVariant =
   | { feed_type: "assistant_text"; data: string }
   | { feed_type: "assistant_text_streaming"; data: string }
   | { feed_type: "thinking"; data: string }

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -1974,6 +1974,18 @@ export class HoustonClient {
       `/agents/${this.seg(agentPath)}/sessions/${this.seg(sessionKey)}/history`,
     );
   }
+  /**
+   * Prepend the previous transcript page before the loaded window (HOU-819).
+   * Implemented by the v3 host adapter (which owns the conversation VM the
+   * page prepends into); this legacy client loads full histories, so there is
+   * never an older page to fetch.
+   */
+  loadOlderChatHistory(
+    _agentPath: string,
+    _sessionKey: string,
+  ): Promise<{ hasOlder: boolean }> {
+    return Promise.resolve({ hasOlder: false });
+  }
   summarizeActivity(
     message: string,
     opts: SummarizeOptions = {},


### PR DESCRIPTION
Fixes HOU-819 — "Chats hang for a while before opening or accepting input."

## Root cause

Opening a chat fetched, folded, and rendered the **entire conversation transcript**, every time:

- `GET /conversations/:id/messages` had no pagination anywhere in protocol v3 — the runtime reads and JSON-parses the whole per-conversation file and ships every message.
- The frontend folded and rendered all of it at once (no windowing, no virtualization), blocking the main thread — the composer isn't disabled during this, but the UI can't respond, which reads as "won't accept input."
- Worst amplifier: every `ConversationsChanged` event invalidates the open chat's history query, so **during a live turn the full-history fetch + fold re-fired repeatedly**.
- On cloud, that unpaginated read is also the request the gateway holds for the whole engine-pod cold start.

## Fix — window the transcript

- **protocol**: `ConversationHistory` gains additive `offset` + `totalMessages`.
- **runtime**: `GET /conversations/:id/messages?limit=N&before=M` serves the tail (or the page ending at absolute index `M`). No params → full history, byte-compatible for old clients; a proxy that strips query strings degrades to today's behavior, never breaks.
- **sdk**: the conversation VM gains additive `historyWindow` state plus `prependHistory` / `stampHistoryWindow` seams.
- **web adapter**: chat opens fetch the **last 120 messages** (bulk/mission-search reads keep the full fetch); a recency-based seed guard (`decideServerSeed`) replaces the old length guard so a shorter-but-newer server tail still lands over a stale cache paint; the local cache now carries frame timestamps and caps at the open window; `loadOlderChatHistory` prepends 80-message pages (single-flight, drops a page that raced a reseed).
- **ui/chat + ui/board + app**: a `ConversationLoadOlder` sentinel at the top of the feed auto-loads older pages as the user scrolls up, viewport-anchored so on-screen content never jumps. Wired on the per-agent mission board, Mission Control, and both archived surfaces.
- **inventory v34**: `conversation-feed` gains `load-older-trigger` / `loading-older`.

The invalidation storm is defanged as a side effect: each refetch is now a bounded tail read, and identical-content revalidations stamp the window without reseeding (no feed id churn / remount).

## Reproduce (before)

1. Use an agent with a long mission (several hundred messages — long tool-heavy runs get there fast).
2. Click its mission card: the panel opens but the transcript takes seconds to paint, and the window is unresponsive to typing while the full transcript folds/renders.
3. Send a message and watch the network: every `ConversationsChanged` during the turn re-fires the full `GET …/messages` for the open chat.
4. On cloud with a cold pod, the first open additionally hangs on the held full-history read.

## Verify (after)

1. Same long-mission card: the chat opens on the last 120 messages near-instantly and typing works immediately.
2. Scroll to the top of the feed: a quiet spinner appears and the previous 80 messages prepend with no viewport jump; repeat until the transcript start, where the trigger disappears.
3. During a live turn, network shows only bounded `?limit=120` reads (and only when the fold actually changed does the feed reseed).
4. Old client ↔ new server and new client ↔ old server both still work (params ignored / fields absent → full-history behavior).

Gates: `pnpm check` clean, `pnpm typecheck` (ui/sdk/app/web + shim parity), `pnpm check:boundaries`, `pnpm check:parity` (inventory v34), vitest: runtime 743, sdk 375, web 218 — all passing.