### PR TITLE
fix(chat): flush a stranded reconnect auto-continue with a history-probe watchdog (HOU-849)

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -1794,8 +1794,9 @@ export function useAgentChatPanel({
               // The reconnect resume fires WITHOUT the user typing, so it is an
               // `autoResume` send: if the conversation shows a running turn it
               // is held at most once (several mounted cards can fire the same
-              // resume) and dropped when redundant — and its queued bubble
-              // shows the human text, never the auto-continue marker.
+              // resume), dropped when redundant, and held INVISIBLY — no
+              // queued bubble; the adapter's watchdog probes immediately so a
+              // stale hold clears within one round-trip (HOU-849).
               await tauriChat.send(path, text, selectedSessionKey, {
                 providerOverride: effectiveProvider,
                 modelOverride: effectiveModel,
@@ -1805,7 +1806,6 @@ export function useAgentChatPanel({
                 // the feed already — resending it must not add a second one.
                 suppressUserBubble: resendsOriginalPrompt(providerError),
                 autoResume: providerError.kind === "unauthenticated",
-                ...(continues ? { queuedPreview: { text: continueText } } : {}),
               });
             }}
             // "Pick another model" pops the MODEL picker (not the Skills picker);

--- a/packages/web/src/engine-adapter/client/chat-send-mixin.ts
+++ b/packages/web/src/engine-adapter/client/chat-send-mixin.ts
@@ -33,11 +33,15 @@ export function ChatSendMixin<TBase extends BaseCtor>(Base: TBase) {
       // send-queue.ts). Every send path inherits this here. The dispatch
       // callback serves the queue's settle watcher — the flush path for turns
       // settled by an observer or the stale-running heal, which never pass
-      // through the `.finally` below.
+      // through the `.finally` below. The history probe backs the queue
+      // watchdog, the ground-truth flush trigger for a hold whose observer
+      // stream died silently (HOU-849).
       const redispatch = (r: SessionStartRequest) => {
         void this.startSession(path, r);
       };
-      if (maybeQueueSend(path, req, redispatch)) {
+      const probe = async () =>
+        (await engine.getHistory(req.sessionKey)).messages;
+      if (maybeQueueSend(path, req, redispatch, probe)) {
         // The VM says a turn is running, but nothing may actually be streaming
         // it (a `running` flag left behind by a torn-down stream). Attach the
         // passive observer so the SERVER arbitrates: a genuinely running turn

--- a/packages/web/src/engine-adapter/queue-watchdog.ts
+++ b/packages/web/src/engine-adapter/queue-watchdog.ts
@@ -28,6 +28,10 @@ import { conversationVm } from "./vm";
 
 /** Backoff between probes: quick first check, settling at a gentle idle poll. */
 const PROBE_DELAYS_MS = [2_000, 4_000, 8_000, 15_000];
+/** An `immediate` arm probes NOW, then falls onto the normal backoff — the
+ *  reconnect auto-resume's cadence: a stale hold must clear within one
+ *  round-trip, not after a visible pause. */
+const IMMEDIATE_DELAYS_MS = [0, ...PROBE_DELAYS_MS];
 
 /** One live watchdog per scope. The session OBJECT is the arm's identity: a
  *  tick that resumes after an await reschedules only while its own session
@@ -55,15 +59,18 @@ export function armQueueWatchdog(
   probe: () => Promise<ChatMessage[]>,
   stillHeld: () => boolean,
   flush: () => void,
+  /** Probe immediately instead of after the first backoff step — for holds
+   *  that should clear within one round-trip (the reconnect auto-resume). */
+  immediate = false,
 ): void {
   if (sessions.has(scope)) return;
   const session: WatchdogSession = {};
   sessions.set(scope, session);
+  const delays = immediate ? IMMEDIATE_DELAYS_MS : PROBE_DELAYS_MS;
   let attempt = 0;
   const owns = (): boolean => sessions.get(scope) === session;
   const schedule = (): void => {
-    const delay =
-      PROBE_DELAYS_MS[Math.min(attempt, PROBE_DELAYS_MS.length - 1)] ?? 0;
+    const delay = delays[Math.min(attempt, delays.length - 1)] ?? 0;
     attempt++;
     session.timer = setTimeout(() => {
       void tick();

--- a/packages/web/src/engine-adapter/queue-watchdog.ts
+++ b/packages/web/src/engine-adapter/queue-watchdog.ts
@@ -1,0 +1,99 @@
+import type { ChatMessage } from "@houston/runtime-client";
+import { conversationVm } from "./vm";
+
+/**
+ * The send queue's LAST-RESORT flush trigger: a periodic ground-truth probe of
+ * the conversation's persisted history.
+ *
+ * A held send normally flushes off the settle watcher, which fires when the
+ * VM's `running` flips false — via the dispatched turn's own settle or the
+ * passive observer's `confirmIdle` heal. But that whole chain hangs off ONE
+ * stream attach, and the attach can die silently: a fatal refusal (the agent
+ * moved, an auth hiccup) disposes the observer without healing anything, an
+ * exhausted reconnect budget (asleep pod, ~6 min of holds) does the same, and
+ * a registry slot held by a hung stream makes the attach a no-op outright.
+ * When that happened, the reconnect auto-continue sat "Queued" forever and the
+ * agent never resumed (HOU-849).
+ *
+ * The watchdog is the trigger that cannot die: while anything is queued, poll
+ * the conversation's history on a backoff. A trailing ASSISTANT message (or an
+ * empty transcript) proves no turn is half-open server-side — a running turn
+ * persists its user message first and its reply only at the end — so the
+ * `running` flag the queue is waiting on is stale: heal it (`confirmIdle`) and
+ * flush. A trailing USER message is inconclusive (a genuinely running turn
+ * looks exactly like that), so keep waiting; an unreachable engine just means
+ * the next tick retries. Each verdict is judged at tick time, so the watchdog
+ * needs no arming-time state beyond its closure.
+ */
+
+/** Backoff between probes: quick first check, settling at a gentle idle poll. */
+const PROBE_DELAYS_MS = [2_000, 4_000, 8_000, 15_000];
+
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+/** True when the server transcript shows no half-open turn. */
+const provesIdle = (messages: ChatMessage[]): boolean =>
+  messages.length === 0 || messages[messages.length - 1]?.role === "assistant";
+
+/**
+ * Arm the watchdog for one conversation's queue. Re-arming while armed is a
+ * no-op (the running timer keeps its backoff position). `stillHeld` is read at
+ * every tick so a queue emptied by any other path stops the watchdog without a
+ * disarm call racing it.
+ */
+export function armQueueWatchdog(
+  scope: string,
+  agentPath: string,
+  sessionKey: string,
+  probe: () => Promise<ChatMessage[]>,
+  stillHeld: () => boolean,
+  flush: () => void,
+): void {
+  if (timers.has(scope)) return;
+  let attempt = 0;
+  const schedule = (): void => {
+    const delay =
+      PROBE_DELAYS_MS[Math.min(attempt, PROBE_DELAYS_MS.length - 1)] ?? 0;
+    attempt++;
+    timers.set(
+      scope,
+      setTimeout(() => {
+        void tick();
+      }, delay),
+    );
+  };
+  const tick = async (): Promise<void> => {
+    timers.delete(scope);
+    if (!stillHeld()) return;
+    let idle: boolean;
+    try {
+      idle = provesIdle(await probe());
+    } catch {
+      // Engine unreachable (waking pod, mid-move gateway): the next tick
+      // retries — an unreachable probe must never strand the queue for good.
+      if (stillHeld()) schedule();
+      return;
+    }
+    if (!stillHeld()) return;
+    if (!idle) {
+      // A turn is genuinely half-open server-side — the settle watcher owns
+      // the normal flush; keep watching in case ITS trigger dies too.
+      schedule();
+      return;
+    }
+    // Server-confirmed idle: heal the stale running flag (publishes running:
+    // false, which fires the settle watcher) and flush directly as well —
+    // `flushQueuedSends` re-checks the VM and no-ops when already handled.
+    conversationVm.confirmIdle(agentPath, sessionKey);
+    flush();
+    if (stillHeld()) schedule();
+  };
+  schedule();
+}
+
+/** Stop the watchdog for one conversation's queue (flushed or emptied). */
+export function disarmQueueWatchdog(scope: string): void {
+  const timer = timers.get(scope);
+  if (timer !== undefined) clearTimeout(timer);
+  timers.delete(scope);
+}

--- a/packages/web/src/engine-adapter/queue-watchdog.ts
+++ b/packages/web/src/engine-adapter/queue-watchdog.ts
@@ -29,7 +29,14 @@ import { conversationVm } from "./vm";
 /** Backoff between probes: quick first check, settling at a gentle idle poll. */
 const PROBE_DELAYS_MS = [2_000, 4_000, 8_000, 15_000];
 
-const timers = new Map<string, ReturnType<typeof setTimeout>>();
+/** One live watchdog per scope. The session OBJECT is the arm's identity: a
+ *  tick that resumes after an await reschedules only while its own session
+ *  still owns the scope, so a disarm-then-rearm racing an in-flight probe can
+ *  never leave two probe chains running for one conversation. */
+interface WatchdogSession {
+  timer?: ReturnType<typeof setTimeout>;
+}
+const sessions = new Map<string, WatchdogSession>();
 
 /** True when the server transcript shows no half-open turn. */
 const provesIdle = (messages: ChatMessage[]): boolean =>
@@ -37,7 +44,7 @@ const provesIdle = (messages: ChatMessage[]): boolean =>
 
 /**
  * Arm the watchdog for one conversation's queue. Re-arming while armed is a
- * no-op (the running timer keeps its backoff position). `stillHeld` is read at
+ * no-op (the running chain keeps its backoff position). `stillHeld` is read at
  * every tick so a queue emptied by any other path stops the watchdog without a
  * disarm call racing it.
  */
@@ -49,32 +56,39 @@ export function armQueueWatchdog(
   stillHeld: () => boolean,
   flush: () => void,
 ): void {
-  if (timers.has(scope)) return;
+  if (sessions.has(scope)) return;
+  const session: WatchdogSession = {};
+  sessions.set(scope, session);
   let attempt = 0;
+  const owns = (): boolean => sessions.get(scope) === session;
   const schedule = (): void => {
     const delay =
       PROBE_DELAYS_MS[Math.min(attempt, PROBE_DELAYS_MS.length - 1)] ?? 0;
     attempt++;
-    timers.set(
-      scope,
-      setTimeout(() => {
-        void tick();
-      }, delay),
-    );
+    session.timer = setTimeout(() => {
+      void tick();
+    }, delay);
   };
   const tick = async (): Promise<void> => {
-    timers.delete(scope);
-    if (!stillHeld()) return;
+    if (!owns()) return;
+    if (!stillHeld()) {
+      sessions.delete(scope);
+      return;
+    }
     let idle: boolean;
     try {
       idle = provesIdle(await probe());
     } catch {
       // Engine unreachable (waking pod, mid-move gateway): the next tick
       // retries — an unreachable probe must never strand the queue for good.
-      if (stillHeld()) schedule();
+      if (owns()) schedule();
       return;
     }
-    if (!stillHeld()) return;
+    if (!owns()) return;
+    if (!stillHeld()) {
+      sessions.delete(scope);
+      return;
+    }
     if (!idle) {
       // A turn is genuinely half-open server-side — the settle watcher owns
       // the normal flush; keep watching in case ITS trigger dies too.
@@ -84,16 +98,18 @@ export function armQueueWatchdog(
     // Server-confirmed idle: heal the stale running flag (publishes running:
     // false, which fires the settle watcher) and flush directly as well —
     // `flushQueuedSends` re-checks the VM and no-ops when already handled.
+    // The flush disarms this watchdog via `disarmQueueWatchdog`.
     conversationVm.confirmIdle(agentPath, sessionKey);
     flush();
-    if (stillHeld()) schedule();
+    if (owns() && stillHeld()) schedule();
   };
   schedule();
 }
 
 /** Stop the watchdog for one conversation's queue (flushed or emptied). */
 export function disarmQueueWatchdog(scope: string): void {
-  const timer = timers.get(scope);
-  if (timer !== undefined) clearTimeout(timer);
-  timers.delete(scope);
+  const session = sessions.get(scope);
+  if (!session) return;
+  if (session.timer !== undefined) clearTimeout(session.timer);
+  sessions.delete(scope);
 }

--- a/packages/web/src/engine-adapter/send-queue.ts
+++ b/packages/web/src/engine-adapter/send-queue.ts
@@ -35,9 +35,11 @@ import { conversationStore, conversationVm } from "./vm";
  * `autoResume` sends (Houston resuming after a provider reconnect — not
  * user-typed) get special handling: one resume per conversation at a time —
  * a duplicate is swallowed while another is queued OR dispatched-and-running
- * (several reconnect surfaces fire the same resume off one login event) — and
- * a held one is dropped at flush when the user queued their own follow-up
- * (their message resumes the conversation by itself).
+ * (several reconnect surfaces fire the same resume off one login event) — a
+ * held one is dropped at flush when the user queued their own follow-up
+ * (their message resumes the conversation by itself), it never renders a
+ * queued bubble (a hidden system message stays hidden while held), and its
+ * watchdog probes immediately so a stale hold clears within one round-trip.
  */
 
 interface QueuedSend {
@@ -57,7 +59,11 @@ function publishQueued(agentPath: string, sessionKey: string): void {
   conversationVm.setQueued(
     agentPath,
     sessionKey,
-    entries.map((e) => e.vm),
+    // A held auto-resume stays INVISIBLE: it is a hidden system message (the
+    // transcript filters its bubble too), and surfacing it as a queued row
+    // read as a stuck send when a stale hold made it wait (HOU-849). The
+    // reconnected card's "continuing where you left off" is its only surface.
+    entries.filter((e) => !e.req.autoResume).map((e) => e.vm),
   );
 }
 
@@ -135,6 +141,10 @@ export function maybeQueueSend(
       probe,
       () => queues.has(k),
       flush,
+      // An auto-resume probes IMMEDIATELY: the reconnect promised "Houston is
+      // continuing where you left off", so a stale hold must clear within one
+      // round-trip, not after a visible pause.
+      req.autoResume === true,
     );
   return true;
 }

--- a/packages/web/src/engine-adapter/send-queue.ts
+++ b/packages/web/src/engine-adapter/send-queue.ts
@@ -1,9 +1,11 @@
+import type { ChatMessage } from "@houston/runtime-client";
 import {
   type ConversationVM,
   conversationScope,
   type QueuedMessageVM,
 } from "@houston/sdk";
 import type { SessionStartRequest } from "../../../../ui/engine-client/src/types";
+import { armQueueWatchdog, disarmQueueWatchdog } from "./queue-watchdog";
 import { armSettleWatcher, disarmSettleWatcher } from "./settle-watcher";
 import { conversationStore, conversationVm } from "./vm";
 
@@ -20,11 +22,15 @@ import { conversationStore, conversationVm } from "./vm";
  * requests (attachments already saved, prompt final); `queuedPreview` carries
  * the user's words + attachment names for the composer's queued-bubble UI.
  *
- * Flushing has two triggers, because a settle has two shapes: the dispatched
- * turn's own settle (the `.finally` in `chat-send-mixin`), and — for a turn
- * settled by anything else — the settle watcher armed at queue time (see
- * settle-watcher.ts; HOU-718's reconnect auto-continue was the canonical
- * victim of its absence).
+ * Flushing has three triggers, because a settle has two shapes and one
+ * failure mode: the dispatched turn's own settle (the `.finally` in
+ * `chat-send-mixin`); for a turn settled by anything else, the settle watcher
+ * armed at queue time (see settle-watcher.ts; HOU-718's reconnect
+ * auto-continue was the canonical victim of its absence); and the queue
+ * watchdog (queue-watchdog.ts), the ground-truth history probe that flushes a
+ * queue whose settle-watcher trigger silently died — a fatal or exhausted
+ * observer stream left the stale `running` flag unhealed and the queued
+ * resume sat forever (HOU-849).
  *
  * `autoResume` sends (Houston resuming after a provider reconnect — not
  * user-typed) get special handling: one resume per conversation at a time —
@@ -88,11 +94,15 @@ export function noteAutoResumeEnded(
  * conversation is idle and the caller dispatches normally. An `autoResume`
  * send is held at most once per conversation — a duplicate (one already queued
  * or dispatched-and-running) is swallowed, reported as handled.
+ *
+ * `probe` (the conversation's history read) arms the queue watchdog alongside
+ * the settle watcher, so the hold survives a silently-dead observer stream.
  */
 export function maybeQueueSend(
   agentPath: string,
   req: SessionStartRequest,
   dispatch: (req: SessionStartRequest) => void,
+  probe?: () => Promise<ChatMessage[]>,
 ): boolean {
   if (!conversationRunning(agentPath, req.sessionKey)) return false;
   const k = queueKey(agentPath, req.sessionKey);
@@ -115,9 +125,17 @@ export function maybeQueueSend(
   });
   queues.set(k, entries);
   publishQueued(agentPath, req.sessionKey);
-  armSettleWatcher(k, () =>
-    flushQueuedSends(agentPath, req.sessionKey, dispatch),
-  );
+  const flush = () => flushQueuedSends(agentPath, req.sessionKey, dispatch);
+  armSettleWatcher(k, flush);
+  if (probe)
+    armQueueWatchdog(
+      k,
+      agentPath,
+      req.sessionKey,
+      probe,
+      () => queues.has(k),
+      flush,
+    );
   return true;
 }
 
@@ -132,6 +150,7 @@ export function removeQueuedSend(
   if (entries.length === 0) {
     queues.delete(k);
     disarmSettleWatcher(k);
+    disarmQueueWatchdog(k);
   } else queues.set(k, entries);
   publishQueued(agentPath, sessionKey);
 }
@@ -161,6 +180,7 @@ export function flushQueuedSends(
   const entries = hasUserEntries ? all.filter((e) => !e.req.autoResume) : all;
   queues.delete(k);
   disarmSettleWatcher(k);
+  disarmQueueWatchdog(k);
   publishQueued(agentPath, sessionKey);
   const last = entries[entries.length - 1];
   const prompt = entries

--- a/packages/web/tests/queue-watchdog.test.ts
+++ b/packages/web/tests/queue-watchdog.test.ts
@@ -1,0 +1,142 @@
+import type { ChatMessage } from "@houston/runtime-client";
+import { conversationScope } from "@houston/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionStartRequest } from "../src/engine-adapter";
+import {
+  maybeQueueSend,
+  removeQueuedSend,
+} from "../src/engine-adapter/send-queue";
+import { conversationStore, conversationVm } from "../src/engine-adapter/vm";
+
+/**
+ * The queue watchdog (HOU-849): the ground-truth flush trigger for a held send
+ * whose settle-watcher chain silently died — a fatal or budget-exhausted
+ * observer stream never healed the stale `running` flag, so the reconnect
+ * auto-continue sat "Queued" forever. The watchdog probes persisted history on
+ * a backoff: a trailing assistant message (or an empty transcript) proves no
+ * turn is half-open server-side, so it heals the flag and flushes; a trailing
+ * user message means a turn IS half-open, so it keeps waiting; a failed probe
+ * retries. Driven through `maybeQueueSend`, the seam the adapter uses.
+ */
+
+const AGENT = "Houston/Bo";
+
+const msg = (role: "user" | "assistant", content: string): ChatMessage =>
+  ({ role, content }) as ChatMessage;
+
+const req = (
+  sessionKey: string,
+  prompt: string,
+  extra: Partial<SessionStartRequest> = {},
+): SessionStartRequest => ({ sessionKey, prompt, ...extra });
+
+const queuedOf = (sessionKey: string) =>
+  (
+    conversationStore.getSnapshot(conversationScope(AGENT, sessionKey)) as
+      | { queued?: { id: string; text: string }[] }
+      | undefined
+  )?.queued;
+
+let n = 0;
+let key: string;
+let dispatched: SessionStartRequest[];
+const dispatch = (r: SessionStartRequest) => dispatched.push(r);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  key = `wd-${n++}`;
+  dispatched = [];
+  conversationVm.sessionStatus(AGENT, key, "running");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const queueResume = (probe: () => Promise<ChatMessage[]>) =>
+  maybeQueueSend(
+    AGENT,
+    req(key, "<!--houston:auto_continue-->\n\ncontinue", { autoResume: true }),
+    dispatch,
+    probe,
+  );
+
+describe("queue watchdog", () => {
+  it("flushes a held resume when the probe proves the server is idle", async () => {
+    // The observer heal never fires (its stream died silently); history shows
+    // the failed turn's persisted reply — no half-open turn server-side.
+    queueResume(async () => [msg("user", "hrey"), msg("assistant", "")]);
+    expect(dispatched).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0]?.autoResume).toBe(true);
+    expect(queuedOf(key) ?? []).toEqual([]);
+    // The stale running flag was healed, not bypassed.
+    expect(
+      (
+        conversationStore.getSnapshot(conversationScope(AGENT, key)) as {
+          running: boolean;
+        }
+      ).running,
+    ).toBe(false);
+  });
+
+  it("keeps holding while the server shows a half-open turn, flushes when it settles", async () => {
+    let history = [msg("user", "still running")];
+    queueResume(async () => history);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(dispatched).toHaveLength(0);
+    expect(queuedOf(key)).toHaveLength(1);
+
+    history = [msg("user", "still running"), msg("assistant", "done now")];
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(dispatched).toHaveLength(1);
+  });
+
+  it("retries after a failed probe instead of stranding the queue", async () => {
+    let calls = 0;
+    queueResume(async () => {
+      calls++;
+      if (calls === 1) throw new Error("engine unreachable");
+      return [msg("assistant", "")];
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(dispatched).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(calls).toBe(2);
+    expect(dispatched).toHaveLength(1);
+  });
+
+  it("treats an empty transcript as idle", async () => {
+    queueResume(async () => []);
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(dispatched).toHaveLength(1);
+  });
+
+  it("stops probing once the queued send is removed by the user", async () => {
+    const probe = vi.fn(async () => [msg("assistant", "")]);
+    queueResume(probe);
+    const id = queuedOf(key)?.[0]?.id ?? "";
+    removeQueuedSend(AGENT, key, id);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(probe).not.toHaveBeenCalled();
+    expect(dispatched).toHaveLength(0);
+  });
+
+  it("stands down when the settle watcher already flushed", async () => {
+    const probe = vi.fn(async () => [msg("assistant", "")]);
+    queueResume(probe);
+    // The normal trigger fires first (observer heal / turn settle).
+    conversationVm.confirmIdle(AGENT, key);
+    expect(dispatched).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(probe).not.toHaveBeenCalled();
+    expect(dispatched).toHaveLength(1);
+  });
+});

--- a/packages/web/tests/queue-watchdog.test.ts
+++ b/packages/web/tests/queue-watchdog.test.ts
@@ -12,11 +12,14 @@ import { conversationStore, conversationVm } from "../src/engine-adapter/vm";
  * The queue watchdog (HOU-849): the ground-truth flush trigger for a held send
  * whose settle-watcher chain silently died — a fatal or budget-exhausted
  * observer stream never healed the stale `running` flag, so the reconnect
- * auto-continue sat "Queued" forever. The watchdog probes persisted history on
- * a backoff: a trailing assistant message (or an empty transcript) proves no
- * turn is half-open server-side, so it heals the flag and flushes; a trailing
- * user message means a turn IS half-open, so it keeps waiting; a failed probe
- * retries. Driven through `maybeQueueSend`, the seam the adapter uses.
+ * auto-continue sat "Queued" forever. The watchdog probes persisted history: a
+ * trailing assistant message (or an empty transcript) proves no turn is
+ * half-open server-side, so it heals the flag and flushes; a trailing user
+ * message means a turn IS half-open, so it keeps waiting; a failed probe
+ * retries. An auto-resume hold probes IMMEDIATELY (a stale hold must clear
+ * within one round-trip) and renders no queued bubble; user-typed holds start
+ * on the 2s backoff. Driven through `maybeQueueSend`, the seam the adapter
+ * uses.
  */
 
 const AGENT = "Houston/Bo";
@@ -62,16 +65,17 @@ const queueResume = (probe: () => Promise<ChatMessage[]>) =>
   );
 
 describe("queue watchdog", () => {
-  it("flushes a held resume when the probe proves the server is idle", async () => {
+  it("flushes a held resume IMMEDIATELY when the probe proves the server is idle", async () => {
     // The observer heal never fires (its stream died silently); history shows
-    // the failed turn's persisted reply — no half-open turn server-side.
+    // the failed turn's persisted reply — no half-open turn server-side. The
+    // resume hold is invisible and clears within one probe round-trip.
     queueResume(async () => [msg("user", "hrey"), msg("assistant", "")]);
+    expect(queuedOf(key) ?? []).toEqual([]);
     expect(dispatched).toHaveLength(0);
 
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(0);
     expect(dispatched).toHaveLength(1);
     expect(dispatched[0]?.autoResume).toBe(true);
-    expect(queuedOf(key) ?? []).toEqual([]);
     // The stale running flag was healed, not bypassed.
     expect(
       (
@@ -88,7 +92,6 @@ describe("queue watchdog", () => {
 
     await vi.advanceTimersByTimeAsync(2_000);
     expect(dispatched).toHaveLength(0);
-    expect(queuedOf(key)).toHaveLength(1);
 
     history = [msg("user", "still running"), msg("assistant", "done now")];
     await vi.advanceTimersByTimeAsync(4_000);
@@ -103,23 +106,39 @@ describe("queue watchdog", () => {
       return [msg("assistant", "")];
     });
 
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls).toBe(1);
     expect(dispatched).toHaveLength(0);
 
-    await vi.advanceTimersByTimeAsync(4_000);
+    await vi.advanceTimersByTimeAsync(2_000);
     expect(calls).toBe(2);
     expect(dispatched).toHaveLength(1);
   });
 
   it("treats an empty transcript as idle", async () => {
     queueResume(async () => []);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(dispatched).toHaveLength(1);
+  });
+
+  it("watches user-typed holds too, on the gentler backoff", async () => {
+    const probe = vi.fn(async () => [msg("assistant", "")]);
+    maybeQueueSend(AGENT, req(key, "my own message"), dispatch, probe);
+    expect(queuedOf(key)).toHaveLength(1);
+
+    // No immediate probe for a user-typed hold — the observer heal owns the
+    // fast path; the watchdog is the backstop.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(probe).not.toHaveBeenCalled();
+
     await vi.advanceTimersByTimeAsync(2_000);
     expect(dispatched).toHaveLength(1);
+    expect(dispatched[0]?.prompt).toBe("my own message");
   });
 
   it("stops probing once the queued send is removed by the user", async () => {
     const probe = vi.fn(async () => [msg("assistant", "")]);
-    queueResume(probe);
+    maybeQueueSend(AGENT, req(key, "remove me"), dispatch, probe);
     const id = queuedOf(key)?.[0]?.id ?? "";
     removeQueuedSend(AGENT, key, id);
 

--- a/packages/web/tests/reconnect-resume-flow.test.ts
+++ b/packages/web/tests/reconnect-resume-flow.test.ts
@@ -1,0 +1,71 @@
+import {
+  FAKE_TOKEN,
+  type FakeHost,
+  SEED_AGENT_ID,
+  startFakeHost,
+} from "@houston/fake-host";
+import { afterAll, beforeAll, expect, test, vi } from "vitest";
+import { HoustonClient } from "../src/engine-adapter/client";
+import { conversationVm } from "../src/engine-adapter/vm";
+
+/**
+ * Real-chain guard for the reconnect auto-continue (HOU-849): the REAL
+ * `startSession` against the REAL fake host, with the conversation VM wedged
+ * on a stale `running` flag — the state a provider-reconnect resume finds
+ * when the failed turn's stream died without a settle. The resume must be
+ * HELD (queued), then actually reach the engine once the passive observer
+ * confirms the conversation is idle. The unit tests in send-queue.test.ts
+ * drive `confirmIdle` by hand; this drives the whole wiring.
+ */
+
+let host: FakeHost;
+
+beforeAll(async () => {
+  host = await startFakeHost(0);
+});
+
+afterAll(async () => {
+  await host.stop();
+});
+
+const historyOf = async (sessionKey: string): Promise<string[]> => {
+  const res = await fetch(
+    `${host.url}/agents/${SEED_AGENT_ID}/conversations/${sessionKey}/messages`,
+    { headers: { authorization: `Bearer ${FAKE_TOKEN}` } },
+  );
+  const body = (await res.json()) as {
+    messages: { role: string; content: string }[];
+  };
+  return body.messages.filter((m) => m.role === "user").map((m) => m.content);
+};
+
+test("a resume held against a stale running flag still reaches the engine", async () => {
+  const client = new HoustonClient({
+    baseUrl: host.url,
+    token: FAKE_TOKEN,
+    controlPlane: true,
+  });
+  const sessionKey = "resume-wedge-1";
+  const resumeText =
+    "<!--houston:auto_continue-->\n\nI'm signed in again. Please continue where you left off.";
+
+  // The wedge: the VM says a turn is running, but nothing is streaming it —
+  // the failed turn's stream was torn down without a settle.
+  conversationVm.sessionStatus(SEED_AGENT_ID, sessionKey, "running");
+
+  await client.startSession(SEED_AGENT_ID, {
+    sessionKey,
+    prompt: resumeText,
+    autoResume: true,
+    queuedPreview: { text: "I'm signed in again." },
+  });
+
+  // The held resume must flush once the observer confirms idle — the message
+  // actually lands in the engine's transcript.
+  await vi.waitFor(
+    async () => {
+      expect(await historyOf(sessionKey)).toContain(resumeText);
+    },
+    { timeout: 10_000, interval: 250 },
+  );
+});

--- a/packages/web/tests/send-queue.test.ts
+++ b/packages/web/tests/send-queue.test.ts
@@ -69,18 +69,23 @@ describe("maybeQueueSend", () => {
     expect(queuedOf(key)?.map((q) => q.text)).toEqual(["the user's words"]);
   });
 
-  it("holds at most ONE auto-resume per conversation", () => {
+  it("holds at most ONE auto-resume per conversation, invisibly", () => {
     setRunning(true);
     const resume = () =>
       req(key, "<!--houston:auto_continue-->\n\ncontinue", {
         autoResume: true,
-        queuedPreview: { text: "continue" },
       });
     expect(maybeQueueSend(AGENT, resume(), dispatch)).toBe(true);
     // A second mounted reconnect card firing the same resume is swallowed:
-    // reported as handled, but never queued twice.
+    // reported as handled, but never held twice.
     expect(maybeQueueSend(AGENT, resume(), dispatch)).toBe(true);
-    expect(queuedOf(key)).toHaveLength(1);
+    // A held resume is a hidden system message — it never renders a queued
+    // bubble (the flash read as a stuck send, HOU-849).
+    expect(queuedOf(key) ?? []).toEqual([]);
+    // Exactly one resume flushes at settle.
+    setRunning(false);
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0]?.autoResume).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Problem

After a provider reconnect, the hidden "I'm signed in again. Please continue where you left off." message could sit in the composer's **Queued** state forever and never reach the agent — the conversation silently never resumed.


## Root cause

A send into a conversation whose VM still shows a running turn is held in the adapter's send queue. Its flush had exactly two triggers:

1. the dispatched turn's own settle (`.finally` in `chat-send-mixin`), and
2. the settle watcher, which fires when the VM's `running` flips false — normally via the passive observer's `confirmIdle` heal (PR #979).

Both hang off **one** observer stream attach. That attach can die silently:

- a fatal stream refusal (401/403/404/410 — e.g. the agent moved) disposes the observer without healing anything,
- an exhausted reconnect budget (~6 min against a waking/held pod) does the same, and
- a registry slot held by a hung stream makes the attach a no-op outright.

When any of those happened while the failed turn's `running` flag was stale, nothing ever flipped it back — the queued auto-resume was stranded forever. (Verified the healthy chain works end-to-end with a new real-chain test; the wedge is exclusively the silent-death modes.)

## Fix

Add a third flush trigger that cannot die: a **queue watchdog** (`queue-watchdog.ts`). While anything is queued, it probes the conversation's persisted history on a backoff (2s → 4s → 8s → 15s):

- **Trailing assistant message (or empty transcript)** → no turn is half-open server-side (a running turn persists its user message first, its reply only at the end), so the `running` flag is provably stale: heal it (`confirmIdle`) and flush.
- **Trailing user message** → a turn is genuinely half-open; keep waiting.
- **Probe failed** (waking pod, mid-move gateway) → retry on the next tick.

The watchdog disarms with the queue (flush or user removal) and stands down instantly when the normal triggers fire first — the settle watcher's synchronous flush wins and the watchdog's own flush no-ops.

## Tests

- `queue-watchdog.test.ts` — held resume flushes when the probe proves idle; keeps holding across a half-open turn; retries a failed probe; empty transcript counts as idle; disarms on user removal; stands down when the settle watcher flushed first.
- `reconnect-resume-flow.test.ts` — real-chain guard: the REAL `startSession` against the REAL fake host with a wedged `running` flag; the resume must land in the engine transcript.
- Full `houston-web` suite (217 tests), tsgo across the workspace, Biome, and `check:boundaries` all green.

Fixes HOU-849.


## Follow-up: instant and invisible

Testing showed the resume could still flash as a "Queued" bubble for the watchdog's first backoff step (~2s). Two refinements:

- **An auto-resume hold probes IMMEDIATELY** (0ms first tick, then the normal backoff) — a stale hold clears within one round-trip, so the resume effectively fires the moment the reconnect completes.
- **A held auto-resume renders no queued bubble.** It is a hidden system message (the transcript filters its bubble too); surfacing it in the queue leaked internals and read as a stuck send. If a turn is genuinely running it waits invisibly, and the reconnect card's "Houston is continuing where you left off" is the only surface. User-typed holds keep the visible, removable queue and the gentle backoff.
