### PR TITLE
fix(integrations): secure credential card saves through the per-agent surface (HOU-823)

### DIFF
--- a/app/src/components/chat-credential-interaction-card.tsx
+++ b/app/src/components/chat-credential-interaction-card.tsx
@@ -8,7 +8,7 @@ import { Check, CornerDownLeft, KeyRound, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  useCustomIntegrations,
+  useAgentCustomIntegrations,
   useSubmitCustomCredential,
 } from "../hooks/queries";
 import { useUIStore } from "../stores/ui";
@@ -20,6 +20,11 @@ interface ChatCredentialInteractionCardProps extends StepChrome {
   /** The credential step's stable id — fades the modal body on a step swap and
    *  scopes the form id so parallel credential steps never collide. */
   stepId: string;
+  /** The agent whose chat raised this step. Both the list read and the save
+   *  ride the per-agent surface (HOU-823) — the ONE route a gateway-fronted
+   *  deployment proxies to the agent's pod; the top-level form 404s at the
+   *  gateway, which failed every managed-cloud save. */
+  agentId: string;
   /** The custom integration's slug the agent asked the user to credential. */
   toolkit: string;
   /** Why the agent needs the key, rendered as the body's foreground "why" line.
@@ -67,6 +72,7 @@ interface ChatCredentialInteractionCardProps extends StepChrome {
  */
 export function ChatCredentialInteractionCard({
   stepId,
+  agentId,
   toolkit,
   reason,
   onSaved,
@@ -79,8 +85,8 @@ export function ChatCredentialInteractionCard({
 }: ChatCredentialInteractionCardProps) {
   const { t } = useTranslation("chat");
   const addToast = useUIStore((s) => s.addToast);
-  const list = useCustomIntegrations();
-  const submit = useSubmitCustomCredential();
+  const list = useAgentCustomIntegrations(agentId);
+  const submit = useSubmitCustomCredential(agentId);
   const [ready, setReady] = useState(false);
 
   const view = list.data?.find((v) => v.slug === toolkit);

--- a/app/src/components/tabs/automation-intake/connect-inline.tsx
+++ b/app/src/components/tabs/automation-intake/connect-inline.tsx
@@ -2,7 +2,7 @@ import { Button } from "@houston-ai/core";
 import { ArrowLeft, Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
-  useCustomIntegrations,
+  useAgentCustomIntegrations,
   useSubmitCustomCredential,
 } from "../../../hooks/queries";
 import { ConnectWaitingPanel } from "../../integrations/connect-waiting-panel";
@@ -34,7 +34,10 @@ interface ConnectInlineProps {
  * returns to the app grid so this is never a dead end.
  */
 export function ConnectInline(props: ConnectInlineProps) {
-  const list = useCustomIntegrations();
+  // Per-agent surface (HOU-823): this intake runs on managed cloud (triggers
+  // are cloud-only), where the top-level custom-integrations read 404s at the
+  // gateway — only the agent-scoped form reaches the pod.
+  const list = useAgentCustomIntegrations(props.agentId);
   const view = list.data?.find((v) => v.slug === props.toolkit);
   const needsKey = !!view && isPendingCredential(view);
 
@@ -95,12 +98,13 @@ function OAuthConnect({
 function CredentialConnect({
   toolkit,
   appName,
+  agentId,
   onConnected,
   onBack,
 }: ConnectInlineProps) {
   const { t } = useTranslation("routines");
-  const list = useCustomIntegrations();
-  const submit = useSubmitCustomCredential();
+  const list = useAgentCustomIntegrations(agentId);
+  const submit = useSubmitCustomCredential(agentId);
   const view = list.data?.find((v) => v.slug === toolkit);
   const authMethod = view ? customAuthMethod(view) : null;
 

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -1628,6 +1628,7 @@ export function useAgentChatPanel({
           <ChatCredentialInteractionCard
             key={step.id}
             stepId={step.id}
+            agentId={agent.id}
             pager={api.pager}
             onDismiss={api.onDismiss}
             dismissLabel={api.dismissLabel}

--- a/app/src/hooks/queries/index.ts
+++ b/app/src/hooks/queries/index.ts
@@ -33,6 +33,7 @@ export {
 export { useInstructions, useSaveInstructions } from "./use-instructions";
 export {
   useAgentActionApprovals,
+  useAgentCustomIntegrations,
   useCustomIntegrations,
   useDisconnectIntegration,
   useIntegrationConnections,

--- a/app/src/hooks/queries/use-integrations.ts
+++ b/app/src/hooks/queries/use-integrations.ts
@@ -107,6 +107,22 @@ export function useCustomIntegrations() {
 }
 
 /**
+ * The SAME list through the per-agent surface (HOU-823) — the one form a
+ * gateway-fronted deployment proxies to the agent's pod, so the in-chat
+ * credential card resolves the integration's name + auth fields on managed
+ * cloud too (where the top-level read 404s at the gateway → `null` → the card
+ * would degrade to its generic fallback field).
+ */
+export function useAgentCustomIntegrations(agentId: string) {
+  const { capabilities } = useCapabilities();
+  return useQuery<CustomIntegrationView[] | null>({
+    queryKey: queryKeys.agentCustomIntegrations(agentId),
+    queryFn: () => tauriIntegrations.customListForAgent(agentId),
+    enabled: integrationsSupported(capabilities),
+  });
+}
+
+/**
  * Remove a custom integration entirely. Carries no `onError` for the same reason
  * as the mutations above — the `call()` wrapper surfaces + reports once. On
  * success both the custom list and the merged connections view drop it.
@@ -127,8 +143,15 @@ export function useRemoveCustomIntegration() {
 /**
  * Provide the secret for a `pending` custom integration. Returns the refreshed
  * view so a caller can read the new `active` state. No `onError` (see above).
+ *
+ * With `agentId` the save rides the per-agent surface (HOU-823) — REQUIRED
+ * wherever a gateway may front the host (the in-chat credential card): the
+ * top-level route 404s at the gateway, which failed every managed-cloud save.
+ * Without it (the global Integrations page, a direct-host-only surface) the
+ * top-level route serves as before. The invalidation targets the shared
+ * "custom-integrations" prefix, so both reads refresh either way.
  */
-export function useSubmitCustomCredential() {
+export function useSubmitCustomCredential(agentId?: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({
@@ -137,7 +160,10 @@ export function useSubmitCustomCredential() {
     }: {
       slug: string;
       values: Record<string, string>;
-    }) => tauriIntegrations.customCredential(slug, values),
+    }) =>
+      agentId
+        ? tauriIntegrations.customCredentialForAgent(agentId, slug, values)
+        : tauriIntegrations.customCredential(slug, values),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.customIntegrations() });
       qc.invalidateQueries({

--- a/app/src/lib/query-keys.ts
+++ b/app/src/lib/query-keys.ts
@@ -95,6 +95,10 @@ export const queryKeys = {
     ["integration-toolkits", provider] as const,
   /** HOU-550: the user's custom (API / MCP) integrations. User-level, one list. */
   customIntegrations: () => ["custom-integrations"] as const,
+  /** The per-agent read of the same list (HOU-823) — shares the
+   *  "custom-integrations" prefix so one invalidation refreshes both. */
+  agentCustomIntegrations: (agentId: string) =>
+    ["custom-integrations", agentId] as const,
 
   // Multiplayer (org). The current user's org + roster is app-scoped (one org
   // per user).

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1614,6 +1614,20 @@ export const tauriIntegrations = {
     call("custom_integration_credential", () =>
       getEngine().submitCustomIntegrationCredential(slug, values),
     ),
+  // The per-agent forms (HOU-823): same user-global data, addressed through
+  // the ONE per-agent surface a gateway-fronted deployment proxies to the
+  // agent's pod — the in-chat credential card uses these so a save works on
+  // managed cloud (the top-level form 404s at the gateway there).
+  customListForAgent: (agentId: string) =>
+    getEngine().agentCustomIntegrations(agentId),
+  customCredentialForAgent: (
+    agentId: string,
+    slug: string,
+    values: Record<string, string>,
+  ) =>
+    call("custom_integration_credential", () =>
+      getEngine().submitAgentCustomIntegrationCredential(agentId, slug, values),
+    ),
 };
 
 /**

--- a/knowledge-base/integrations.md
+++ b/knowledge-base/integrations.md
@@ -819,7 +819,8 @@ management routes: `/sandbox/integrations/custom/{detect,add}`, HMAC-authed),
 and `request_credential` — records a `{kind:"credential", toolkit, reason?}`
 interaction step (protocol `interaction.ts`, ids `k1..kN`, auto-excluded from
 Autopilot) that replaces the composer with a SECURE key-entry card. The secret
-travels UI → `POST /v1/integrations/custom/definitions/:slug/credential` →
+travels UI → `POST .../integrations/custom/definitions/:slug/credential` on the
+**per-agent surface** (`/agents/:id/...` — HOU-823, see User routes below) →
 validate (`connections.validate`, fail-open on `unknown`) → secret store →
 connection rewire. It NEVER enters the transcript; the prompt (houston-prompt.ts
 + the Rust mirror) forbids asking for keys in chat.
@@ -843,12 +844,26 @@ on POSIX; on Windows (no POSIX modes — NTFS ACLs under the user profile are th
 protection) the write skips chmod and clears a stray read-only attribute before
 its rename-replace.
 
-**User routes** (`routes/custom-integrations.ts`, mounted BEFORE the generic
-`/v1/integrations/:provider/*` catch-all): GET/DELETE
-`/v1/integrations/custom/definitions[/:slug]` + the credential POST. Errors
-carry stable `code`s (`not_found`, `duplicate_slug`, `credential_invalid`,
-`compile_failed`…). Mutations emit `CustomIntegrationsChanged` (protocol
-events.ts) → query invalidation.
+**User routes** (`routes/custom-integrations-user.ts`; the sandbox detect/add
+routes stay in `routes/custom-integrations.ts`): GET/DELETE
+`definitions[/:slug]` + the credential POST, on THREE surfaces (the
+action-approvals precedent): top-level `/v1/integrations/custom/*` (mounted
+BEFORE the generic `/v1/integrations/:provider/*` catch-all), the `/v1/agents/
+:id/integrations/custom/*` wrapper, and the per-agent dispatch `/agents/:id/
+integrations/custom/*`. **The dispatch form is the one the shipped clients
+call** (HOU-823): the hosted gateway proxies ONLY per-agent routes to a pod and
+its own `/v1/integrations` subtree is Composio-only, so the top-level POST 404ed
+at the gateway — every managed-cloud secure-card save failed
+(`custom_integration_credential: not found (engine error 404)` in Sentry). The
+data stays user-global; the agent id authorizes and routes. Note the gateway's
+dispatch-scope classifier treats this family as configure-scope (fail-closed),
+so in a Teams org only agent managers can save/remove — a member-facing
+use-scope carve-out is a gateway follow-up. Errors carry stable `code`s
+(`not_found`, `duplicate_slug`, `credential_invalid`, `compile_failed`…).
+Mutations emit `CustomIntegrationsChanged` (protocol events.ts) → query
+invalidation. The agent tab + global page still read the top-level list (hidden
+behind the 404→null degrade on managed cloud); moving those management surfaces
+to the per-agent form is a follow-up.
 
 **UI**: a "Custom integrations" section on the global Integrations page (between
 Connected apps and the catalog) listing defs with kind badge/status/delete plus

--- a/packages/fake-host/src/routes-integrations.ts
+++ b/packages/fake-host/src/routes-integrations.ts
@@ -139,6 +139,21 @@ export function handleUserRoutes(
   segs: string[],
   body: Record<string, unknown> | undefined,
 ): Response | undefined {
+  // Per-agent custom-integration surface (HOU-823), BOTH forms like
+  // action-approvals: `/v1/agents/:id/integrations/custom/*` and the dispatch
+  // `/agents/:id/integrations/custom/*` — the one form the hosted gateway
+  // proxies to a pod, so the shipped in-chat credential card calls it. Same
+  // user-global data as the top-level routes; the agent id only routes.
+  const rel = segs[0] === "v1" ? segs.slice(1) : segs;
+  if (
+    rel[0] === "agents" &&
+    rel.length >= 5 &&
+    rel[2] === "integrations" &&
+    rel[3] === "custom"
+  ) {
+    if (state.integrationsMode() === "unavailable") return unavailable();
+    return handleCustom(method, rel.slice(4), body);
+  }
   // /v1/integrations[/composio/...]
   if (segs[0] === "v1" && segs[1] === "integrations") {
     return handleIntegrations(method, segs, body);

--- a/packages/host/src/routes/agent-authz.ts
+++ b/packages/host/src/routes/agent-authz.ts
@@ -10,6 +10,7 @@ import type {
 } from "../domain/types";
 import type { EventHub } from "../events/hub";
 import type { LocalActionApprovals } from "../integrations/action-approvals";
+import type { CustomIntegrationManager } from "../integrations/custom/manager";
 import { CloudPaths, type WorkspacePaths } from "../paths";
 import type { RuntimeChannel, WorkspaceStore } from "../ports";
 import type { Vfs } from "../vfs";
@@ -77,6 +78,13 @@ export interface AgentRouteDeps {
    * Absent → those requests fall through toward the runtime channel (404).
    */
   actionApprovals?: LocalActionApprovals;
+  /**
+   * Custom-integration manager (mirrors ControlPlaneDeps.customIntegrations) —
+   * the dispatch-surface user routes (`/agents/:id/integrations/custom/*`)
+   * serve off it (HOU-823: the hosted gateway proxies only this per-agent
+   * form). Absent → those requests fall through toward the runtime channel.
+   */
+  customIntegrations?: CustomIntegrationManager;
   /**
    * Whether this deployment can fire event-driven routines: a trigger backend
    * (a Composio project key + a public webhook URL) exists, so a routine's

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -34,6 +34,7 @@ import { handleAgentData } from "./agent-data";
 import { handleAgentFile } from "./agent-file";
 import { legacyAgentColor } from "./agent-legacy-color";
 import { asSeedRecord, writeAgentSeeds } from "./agent-seed";
+import { handleCustomIntegrationsDispatch } from "./custom-integrations-user";
 import { json, readJson } from "./http";
 import { handleMigration } from "./migration";
 import { handlePortableExport } from "./portable";
@@ -720,6 +721,22 @@ export async function handleAgents(
       await handleActionApprovalsDispatch(
         deps.actionApprovals,
         agentId,
+        method,
+        rest,
+        req,
+        res,
+      )
+    )
+      return true;
+
+    // Custom-integration user routes (list / remove / provide-credential) on
+    // the dispatch surface — the hosted gateway proxies ONLY this per-agent
+    // form to the pod (its own /v1/integrations subtree is Composio-only), so
+    // the in-chat secure credential card calls it in both deployments
+    // (HOU-823). See routes/custom-integrations-user.ts.
+    if (
+      await handleCustomIntegrationsDispatch(
+        deps.customIntegrations,
         method,
         rest,
         req,

--- a/packages/host/src/routes/custom-integrations-user.test.ts
+++ b/packages/host/src/routes/custom-integrations-user.test.ts
@@ -1,0 +1,192 @@
+import type { Server } from "node:http";
+import type { Capabilities } from "@houston/protocol";
+import { expect, test, vi } from "vitest";
+import { MemoryCredentialStore } from "../credentials/store";
+import { EnvCredentialVault } from "../credentials/vault";
+import type { CustomIntegrationManager } from "../integrations/custom/manager";
+import {
+  CustomIntegrationError,
+  type CustomIntegrationView,
+} from "../integrations/custom/types";
+import type { TokenVerifier } from "../ports";
+import { type ControlPlaneDeps, createControlPlaneServer } from "../server";
+import { MemoryWorkspaceStore } from "../store/memory";
+
+/**
+ * The custom-integration USER routes on their per-agent surfaces (HOU-823),
+ * over the FULL server so the real mounting order and ownership checks run:
+ * the `/v1/agents/:id/integrations/custom/*` wrapper and the per-agent
+ * dispatch `/agents/:id/integrations/custom/*` — the ONE form the hosted
+ * gateway proxies to a pod, so the shipped in-chat credential card calls it
+ * in both deployments (the gateway's own /v1/integrations subtree is
+ * Composio-only, and the top-level form 404s there).
+ */
+
+const USER = "alice";
+const OTHER = "mallory";
+const CAPS: Capabilities = {
+  profile: "cloud",
+  revealInOs: false,
+  terminal: false,
+  tunnel: false,
+  codeExecution: "remote-sandbox",
+  providers: ["openai-codex"],
+  openaiCompatible: false,
+  integrations: ["custom"],
+};
+
+const VIEW: CustomIntegrationView = {
+  slug: "acme",
+  name: "Acme",
+  kind: "openapi",
+  addedAtMs: 1,
+  state: { status: "active", toolCount: 1 },
+};
+
+function fakeManager(
+  overrides: Partial<
+    Pick<CustomIntegrationManager, "list" | "setCredential" | "remove">
+  > = {},
+): CustomIntegrationManager {
+  return {
+    list: vi.fn(async () => [VIEW]),
+    setCredential: vi.fn(async () => VIEW),
+    remove: vi.fn(async () => {}),
+    ...overrides,
+  } as unknown as CustomIntegrationManager;
+}
+
+async function setup(manager: CustomIntegrationManager = fakeManager()) {
+  const verifier: TokenVerifier = {
+    async verify(b) {
+      if (b === "tok") return { userId: USER };
+      if (b === "other") return { userId: OTHER };
+      return null;
+    },
+  };
+  const store = new MemoryWorkspaceStore({ defaultRuntime: "gke" });
+  const deps: ControlPlaneDeps = {
+    verifier,
+    store,
+    credentials: new MemoryCredentialStore(),
+    vault: new EnvCredentialVault({ secret: "test-secret" }),
+    channels: {},
+    capabilities: CAPS,
+    customIntegrations: manager,
+    corsOrigin: "*",
+  };
+  const server: Server = createControlPlaneServer(deps);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const addr = server.address();
+  const base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+  const ws = await store.getOrCreatePersonalWorkspace(USER);
+  const agent = await store.createAgent({
+    workspaceId: ws.id,
+    name: "Assistant",
+  });
+  return { base, agent, stop: () => server.close() };
+}
+
+const auth = (token = "tok") => ({
+  Authorization: `Bearer ${token}`,
+  "Content-Type": "application/json",
+});
+const dispatchUrl = (base: string, agentId: string, sub = "") =>
+  `${base}/agents/${encodeURIComponent(agentId)}/integrations/custom/definitions${sub}`;
+const v1Url = (base: string, agentId: string, sub = "") =>
+  `${base}/v1/agents/${encodeURIComponent(agentId)}/integrations/custom/definitions${sub}`;
+
+test("dispatch surface: GET lists; POST credential validates and saves (the in-chat card's path)", async () => {
+  const setCredential = vi.fn(async () => VIEW);
+  const { base, agent, stop } = await setup(fakeManager({ setCredential }));
+  try {
+    const list = await fetch(dispatchUrl(base, agent.id), {
+      headers: auth(),
+    });
+    expect(list.status).toBe(200);
+    expect(await list.json()).toEqual({ items: [VIEW] });
+
+    const bad = await fetch(dispatchUrl(base, agent.id, "/acme/credential"), {
+      method: "POST",
+      headers: auth(),
+      body: JSON.stringify({ values: "nope" }),
+    });
+    expect(bad.status).toBe(400);
+    expect(setCredential).not.toHaveBeenCalled();
+
+    const ok = await fetch(dispatchUrl(base, agent.id, "/acme/credential"), {
+      method: "POST",
+      headers: auth(),
+      body: JSON.stringify({ values: { token: "secret" } }),
+    });
+    expect(ok.status).toBe(200);
+    expect(await ok.json()).toEqual(VIEW);
+    expect(setCredential).toHaveBeenCalledWith("acme", { token: "secret" });
+  } finally {
+    stop();
+  }
+});
+
+test("dispatch surface relays manager errors as stable {error, code} bodies", async () => {
+  const { base, agent, stop } = await setup(
+    fakeManager({
+      setCredential: vi.fn(async () => {
+        throw new CustomIntegrationError(
+          "credential_invalid",
+          "the credential value is empty",
+        );
+      }),
+    }),
+  );
+  try {
+    const res = await fetch(dispatchUrl(base, agent.id, "/acme/credential"), {
+      method: "POST",
+      headers: auth(),
+      body: JSON.stringify({ values: { token: "" } }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "the credential value is empty",
+      code: "credential_invalid",
+    });
+  } finally {
+    stop();
+  }
+});
+
+test("/v1 agent-scoped form: owner passes; another user is refused; DELETE removes", async () => {
+  const remove = vi.fn(async () => {});
+  const { base, agent, stop } = await setup(fakeManager({ remove }));
+  try {
+    const list = await fetch(v1Url(base, agent.id), { headers: auth() });
+    expect(list.status).toBe(200);
+    expect(await list.json()).toEqual({ items: [VIEW] });
+
+    const denied = await fetch(v1Url(base, agent.id), {
+      headers: auth("other"),
+    });
+    expect([403, 404]).toContain(denied.status);
+
+    const del = await fetch(v1Url(base, agent.id, "/acme"), {
+      method: "DELETE",
+      headers: auth(),
+    });
+    expect(del.status).toBe(200);
+    expect(remove).toHaveBeenCalledWith("acme");
+  } finally {
+    stop();
+  }
+});
+
+test("top-level /v1 form still serves against the full server (regression)", async () => {
+  const { base, stop } = await setup();
+  try {
+    const res = await fetch(`${base}/v1/integrations/custom/definitions`, {
+      headers: auth(),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ items: [VIEW] });
+  } finally {
+    stop();
+  }
+});

--- a/packages/host/src/routes/custom-integrations-user.ts
+++ b/packages/host/src/routes/custom-integrations-user.ts
@@ -1,0 +1,164 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { canUseAgent } from "../domain/access";
+import type { UserId } from "../domain/types";
+import type { CustomIntegrationManager } from "../integrations/custom/manager";
+import type { WorkspaceStore } from "../ports";
+import { relayCustomError } from "./custom-integrations";
+import { json, readJson } from "./http";
+
+/**
+ * Custom-integration USER routes (HOU-550): list / remove / provide-credential
+ * — what the Integrations page and the in-chat credential card call. The
+ * credential value crosses ONLY here (HTTPS body → secret store); it never
+ * rides the chat transcript.
+ *
+ * THREE surfaces serve the same routes (the action-approvals precedent):
+ *
+ *  - `/v1/integrations/custom/definitions*` — the original top-level form, for
+ *    the global Integrations page against a direct host.
+ *  - `/v1/agents/:agentId/integrations/custom/definitions*` — the agent-scoped
+ *    wrapper for direct API callers (ownership-checked here).
+ *  - the per-agent dispatch `/agents/:agentId/integrations/custom/definitions*`
+ *    — the ONE per-agent surface the hosted gateway proxies to a pod. The
+ *    gateway mounts NO `/v1/integrations/custom/*` route (its integrations
+ *    subtree is Composio-only), so a client fronted by it MUST call this form:
+ *    the top-level POST 404ed at the gateway and broke the in-chat secure
+ *    credential card on every managed-cloud save (HOU-823).
+ *
+ * The definitions and their secrets are user-global on this single-user host —
+ * the agent id on the scoped forms authorizes and routes (it is how the
+ * gateway finds the pod), it does not scope the data.
+ */
+export interface CustomIntegrationUserDeps {
+  customIntegrations?: CustomIntegrationManager;
+  store: WorkspaceStore;
+}
+
+const TOP =
+  /^\/v1\/integrations\/custom\/definitions(?:\/([^/]+)(\/credential)?)?$/;
+const AGENT =
+  /^\/v1\/agents\/([^/]+)\/integrations\/custom\/definitions(?:\/([^/]+)(\/credential)?)?$/;
+const DISPATCH =
+  /^integrations\/custom\/definitions(?:\/([^/]+)(\/credential)?)?$/;
+
+/** Ownership check mirroring the other agent routes (personal tier = owner-only). */
+async function authorize(
+  store: WorkspaceStore,
+  userId: UserId,
+  agentId: string,
+): Promise<{ ok: true } | { ok: false; status: number; reason: string }> {
+  const agent = await store.getAgent(agentId);
+  const workspace = agent ? await store.getWorkspace(agent.workspaceId) : null;
+  const access = canUseAgent({ userId, agent, workspace });
+  if (access.ok) return { ok: true };
+  return {
+    ok: false,
+    status: access.reason === "agent not found" ? 404 : 403,
+    reason: access.reason,
+  };
+}
+
+/** The surface-agnostic core: serve one user request against the manager.
+ *  Returns false when method+shape name no route in this family. */
+async function serve(
+  manager: CustomIntegrationManager,
+  method: string,
+  slug: string | undefined,
+  credential: boolean,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  try {
+    if (!slug && method === "GET") {
+      json(res, 200, { items: await manager.list() });
+      return true;
+    }
+    if (slug && !credential && method === "DELETE") {
+      await manager.remove(slug);
+      json(res, 200, { ok: true });
+      return true;
+    }
+    if (slug && credential && method === "POST") {
+      const body = await readJson(req);
+      const values = body.values;
+      if (
+        !values ||
+        typeof values !== "object" ||
+        Array.isArray(values) ||
+        !Object.values(values).every((v) => typeof v === "string")
+      ) {
+        json(res, 400, { error: "missing 'values' (object of strings)" });
+        return true;
+      }
+      json(
+        res,
+        200,
+        await manager.setCredential(slug, values as Record<string, string>),
+      );
+      return true;
+    }
+  } catch (err) {
+    if (relayCustomError(res, err)) return true;
+    throw err;
+  }
+  return false;
+}
+
+/** The two `/v1` forms (top-level + agent-scoped). Mounted BEFORE the generic
+ *  `/v1/integrations/:provider/*` handler in server.ts (its catch-all would
+ *  404 the `custom/definitions` subpaths). */
+export async function handleCustomIntegrations(
+  deps: CustomIntegrationUserDeps,
+  userId: UserId,
+  method: string,
+  path: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  const top = path.match(TOP);
+  const scoped = top ? null : path.match(AGENT);
+  if (!top && !scoped) return false;
+  const manager = deps.customIntegrations;
+  if (!manager) {
+    json(res, 404, { error: "custom integrations not available here" });
+    return true;
+  }
+  let slugRaw: string | undefined = top?.[1];
+  let credential = !!top?.[2];
+  if (scoped) {
+    const authz = await authorize(
+      deps.store,
+      userId,
+      decodeURIComponent(scoped[1] ?? ""),
+    );
+    if (!authz.ok) {
+      json(res, authz.status, { error: authz.reason });
+      return true;
+    }
+    slugRaw = scoped[2];
+    credential = !!scoped[3];
+  }
+  const slug = slugRaw ? decodeURIComponent(slugRaw) : undefined;
+  return serve(manager, method, slug, credential, req, res);
+}
+
+/**
+ * The SAME routes on the per-agent dispatch surface, matched on the dispatch
+ * `rest` inside handleAgents — which has ALREADY run the ownership check, so
+ * no authz here. This is the surface the hosted gateway proxies to the pod,
+ * and the one the shipped clients call in both deployments. Unwired manager →
+ * false, and the request falls through toward the runtime channel like any
+ * unknown dispatch family.
+ */
+export async function handleCustomIntegrationsDispatch(
+  manager: CustomIntegrationManager | undefined,
+  method: string,
+  rest: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  const m = rest.match(DISPATCH);
+  if (!m || !manager) return false;
+  const slug = m[1] ? decodeURIComponent(m[1]) : undefined;
+  return serve(manager, method, slug, !!m[2], req, res);
+}

--- a/packages/host/src/routes/custom-integrations.test.ts
+++ b/packages/host/src/routes/custom-integrations.test.ts
@@ -6,11 +6,12 @@ import {
   CustomIntegrationError,
   type CustomIntegrationView,
 } from "../integrations/custom/types";
+import { MemoryWorkspaceStore } from "../store/memory";
 import {
   type CustomIntegrationDeps,
-  handleCustomIntegrations,
   handleSandboxCustomIntegrations,
 } from "./custom-integrations";
+import { handleCustomIntegrations } from "./custom-integrations-user";
 import { json } from "./http";
 
 /**
@@ -51,15 +52,29 @@ function fakeManager(
 
 type Deps = CustomIntegrationDeps & { vault: EnvCredentialVault };
 
+/** The mini harness serves as user "u1"; the agent-scoped `/v1` form and the
+ *  dispatch surface are covered by custom-integrations-user.test.ts against
+ *  the FULL server (real mounting order + ownership checks). */
 async function startServer(
   deps: Deps,
 ): Promise<{ server: Server; base: string }> {
+  const store = new MemoryWorkspaceStore({ defaultRuntime: "gke" });
   const server = createServer((req, res) => {
     const url = new URL(req.url || "/", "http://test.local");
     const method = req.method || "GET";
     const path = url.pathname;
     (async () => {
-      if (await handleCustomIntegrations(deps, method, path, req, res)) return;
+      if (
+        await handleCustomIntegrations(
+          { ...deps, store },
+          "u1",
+          method,
+          path,
+          req,
+          res,
+        )
+      )
+        return;
       if (
         await handleSandboxCustomIntegrations(deps, method, path, url, req, res)
       )

--- a/packages/host/src/routes/custom-integrations.ts
+++ b/packages/host/src/routes/custom-integrations.ts
@@ -8,17 +8,11 @@ import type { CredentialVault } from "../ports";
 import { bearer, json, readJson } from "./http";
 
 /**
- * Custom-integration management routes (HOU-550), split by caller:
- *
- *  - USER routes (`/v1/integrations/custom/definitions*`, signed-in user):
- *    list / remove / provide-credential — what the Integrations page and the
- *    in-chat credential card call. The credential value crosses ONLY here
- *    (HTTPS body → secret store); it never rides the chat transcript.
- *  - SANDBOX routes (`/sandbox/integrations/custom/*`, per-sandbox HMAC): what
- *    the agent's setup tools call — detect a pasted URL, add an integration.
- *
- * Both mounted BEFORE the generic `/v1/integrations/:provider/*` handler in
- * server.ts (its catch-all would 404 the `custom/definitions` subpaths).
+ * Custom-integration SANDBOX routes (HOU-550) — `/sandbox/integrations/custom/*`
+ * (per-sandbox HMAC): what the agent's setup tools call — detect a pasted URL,
+ * add an integration. The USER routes (list / remove / provide-credential, on
+ * three surfaces incl. the per-agent dispatch the hosted gateway proxies) live
+ * in custom-integrations-user.ts.
  */
 export interface CustomIntegrationDeps {
   customIntegrations?: CustomIntegrationManager;
@@ -29,67 +23,10 @@ const httpStatusOf = (code: CustomIntegrationError["code"]): number =>
 
 /** Map manager failures to stable JSON bodies (the runtime tools + UI classify
  *  on `code`, never bare statuses); rethrow anything unrecognized. */
-function relayCustomError(res: ServerResponse, err: unknown): boolean {
+export function relayCustomError(res: ServerResponse, err: unknown): boolean {
   if (!(err instanceof CustomIntegrationError)) return false;
   json(res, httpStatusOf(err.code), { error: err.message, code: err.code });
   return true;
-}
-
-export async function handleCustomIntegrations(
-  deps: CustomIntegrationDeps,
-  method: string,
-  path: string,
-  req: IncomingMessage,
-  res: ServerResponse,
-): Promise<boolean> {
-  if (!path.startsWith("/v1/integrations/custom/definitions")) return false;
-  const manager = deps.customIntegrations;
-  if (!manager) {
-    json(res, 404, { error: "custom integrations not available here" });
-    return true;
-  }
-
-  try {
-    if (path === "/v1/integrations/custom/definitions" && method === "GET") {
-      json(res, 200, { items: await manager.list() });
-      return true;
-    }
-
-    const m = path.match(
-      /^\/v1\/integrations\/custom\/definitions\/([^/]+)(\/credential)?$/,
-    );
-    if (!m) return false;
-    const slug = decodeURIComponent(m[1] ?? "");
-
-    if (!m[2] && method === "DELETE") {
-      await manager.remove(slug);
-      json(res, 200, { ok: true });
-      return true;
-    }
-    if (m[2] && method === "POST") {
-      const body = await readJson(req);
-      const values = body.values;
-      if (
-        !values ||
-        typeof values !== "object" ||
-        Array.isArray(values) ||
-        !Object.values(values).every((v) => typeof v === "string")
-      ) {
-        json(res, 400, { error: "missing 'values' (object of strings)" });
-        return true;
-      }
-      json(
-        res,
-        200,
-        await manager.setCredential(slug, values as Record<string, string>),
-      );
-      return true;
-    }
-  } catch (err) {
-    if (relayCustomError(res, err)) return true;
-    throw err;
-  }
-  return false;
 }
 
 // ── Sandbox (agent-initiated) routes ─────────────────────────────────────────

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -42,9 +42,9 @@ import { handleCatalog } from "./routes/catalog";
 import { handleSandboxCredential } from "./routes/credential";
 import {
   type CustomIntegrationDeps,
-  handleCustomIntegrations,
   handleSandboxCustomIntegrations,
 } from "./routes/custom-integrations";
+import { handleCustomIntegrations } from "./routes/custom-integrations-user";
 import { handleEventStream } from "./routes/events-stream";
 import { bearer, json, readJson } from "./routes/http";
 import {
@@ -360,7 +360,8 @@ async function handle(
   if (await handleAgentConfigs(deps, userId, method, path, req, res)) return;
   // Custom-integration definitions — BEFORE the generic provider routes, whose
   // `/v1/integrations/:provider/*` catch-all would 404 these subpaths.
-  if (await handleCustomIntegrations(deps, method, path, req, res)) return;
+  if (await handleCustomIntegrations(deps, userId, method, path, req, res))
+    return;
   if (await handleIntegrations(deps, userId, method, path, req, res)) return;
   if (await handleActionApprovals(deps, userId, method, path, req, res)) return;
   // Pre-agent provider connect (first-run onboarding): a hidden setup runtime

--- a/packages/web/e2e/interaction.spec.ts
+++ b/packages/web/e2e/interaction.spec.ts
@@ -1058,7 +1058,10 @@ test("pressing Esc declines a lone connect step", async ({ page, request }) => {
  * `slug === step.toolkit`), the agent's reason over a muted "stored securely"
  * subtitle, the secure key form (one password input per auth field), and the
  * unified "Skip" (Esc) + "Save key" (Enter) footer. Saving POSTs the secret to
- * `/v1/integrations/custom/definitions/:slug/credential` and resumes the agent
+ * the per-agent surface `/agents/:id/integrations/custom/definitions/:slug/
+ * credential` (HOU-823 — the one form the hosted gateway proxies to the pod;
+ * the old top-level form 404ed there and failed every managed-cloud save) and
+ * resumes the agent
  * with a hidden auto-continue ("I've added the {name} key. Please continue.");
  * skipping resumes it with "Skipped adding the {name} key." — a decline the agent
  * MUST hear, or it waits on a key that never comes. These arm the SAME

--- a/packages/web/src/engine-adapter/client/integrations-mixin.ts
+++ b/packages/web/src/engine-adapter/client/integrations-mixin.ts
@@ -1,5 +1,6 @@
 import { EngineError } from "@houston/runtime-client";
 import * as controlPlane from "../control-plane";
+import { HoustonEngineError } from "./errors";
 import type { BaseCtor } from "./mixin";
 
 export function IntegrationsMixin<TBase extends BaseCtor>(Base: TBase) {
@@ -112,6 +113,54 @@ export function IntegrationsMixin<TBase extends BaseCtor>(Base: TBase) {
         slug,
         values,
       );
+    }
+
+    // ---- custom integrations, per-agent surface (HOU-823) ----
+    // HOST routes that work in BOTH deployments, on the per-agent DISPATCH
+    // surface (`/agents/:id/integrations/custom/definitions[...]`): the
+    // local/self-host host serves it directly, and the cloud gateway proxies
+    // exactly this surface to the agent's pod. Its own `/v1/integrations`
+    // subtree is Composio-only, so the top-level form above 404s there — that
+    // 404 broke every in-chat secure credential card save on managed cloud.
+    // Like the action-approvals family they route through `authFetch` against
+    // `baseUrl` (bearer + `x-houston-org`, live in both) — never cp-gated.
+    async agentCustomIntegrations(
+      agentSlugOrId: string,
+    ): Promise<controlPlane.CustomIntegrationView[] | null> {
+      const res = await this.ctx.authFetch(
+        `${this.ctx.baseUrl}/agents/${encodeURIComponent(agentSlugOrId)}/integrations/custom/definitions`,
+      );
+      // A host that does not serve the feature answers 404 → the caller hides
+      // the custom UI (mirrors `customIntegrations`' null degrade).
+      if (res.status === 404) return null;
+      if (!res.ok)
+        throw new HoustonEngineError(
+          res.status,
+          await res.json().catch(() => ({})),
+        );
+      return (
+        (await res.json()) as { items: controlPlane.CustomIntegrationView[] }
+      ).items;
+    }
+    async submitAgentCustomIntegrationCredential(
+      agentSlugOrId: string,
+      slug: string,
+      values: Record<string, string>,
+    ): Promise<controlPlane.CustomIntegrationView> {
+      const res = await this.ctx.authFetch(
+        `${this.ctx.baseUrl}/agents/${encodeURIComponent(agentSlugOrId)}/integrations/custom/definitions/${encodeURIComponent(slug)}/credential`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ values }),
+        },
+      );
+      if (!res.ok)
+        throw new HoustonEngineError(
+          res.status,
+          await res.json().catch(() => ({})),
+        );
+      return (await res.json()) as controlPlane.CustomIntegrationView;
     }
   }
   return Integrations;

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -1262,6 +1262,46 @@ export class HoustonClient {
       { values },
     );
   }
+  /**
+   * The custom-integration list through the per-agent surface — the ONE form a
+   * gateway-fronted deployment proxies to the agent's pod (the gateway's own
+   * `/v1/integrations` subtree is Composio-only, so the top-level form 404s
+   * there — HOU-823). The list is user-global; the agent id authorizes and
+   * routes. `null` on 404, mirroring `customIntegrations`.
+   */
+  async agentCustomIntegrations(
+    agentSlugOrId: string,
+  ): Promise<CustomIntegrationView[] | null> {
+    try {
+      return (
+        await this.request<{ items: CustomIntegrationView[] }>(
+          "GET",
+          `/agents/${this.seg(agentSlugOrId)}/integrations/custom/definitions`,
+        )
+      ).items;
+    } catch (err) {
+      if (isHoustonEngineError(err) && err.status === 404) return null;
+      throw err;
+    }
+  }
+  /**
+   * Provide the secret through the per-agent surface (see
+   * `agentCustomIntegrations`) — what the in-chat credential card calls, so
+   * the save reaches the agent's pod on a gateway-fronted deployment instead
+   * of 404ing at the gateway (HOU-823). Same contract as
+   * `submitCustomIntegrationCredential` otherwise.
+   */
+  submitAgentCustomIntegrationCredential(
+    agentSlugOrId: string,
+    slug: string,
+    values: Record<string, string>,
+  ): Promise<CustomIntegrationView> {
+    return this.request(
+      "POST",
+      `/agents/${this.seg(agentSlugOrId)}/integrations/custom/definitions/${this.seg(slug)}/credential`,
+      { values },
+    );
+  }
 
   // ---------- triggers (C9 event-driven routines) ----------
   //


### PR DESCRIPTION
## Summary

Fixes the client/host half of **HOU-823**: the in-chat secure credential card failed every save on managed cloud.

### Root cause: every managed-cloud secure-card save 404ed

The in-chat secure key card (`request_credential`) saved via the **top-level** `POST /v1/integrations/custom/definitions/:slug/credential`. The hosted gateway proxies **only per-agent routes** (`/agents/:slug/*`) to a pod, and its own `/v1/integrations` subtree is Composio-only — so the save died with 404 on every attempt, while the agent (running on the pod) could add the integration and show the card just fine. Sentry confirms it in production: `custom_integration_credential: not found (engine error 404)` (HOUSTON-APP-4Z5 + HOUSTON-APP-4Y6, 28 events / 12 users in 14 days, `deployment=managed-cloud`, breadcrumb shows the POST to `gateway.gethouston.ai/v1/integrations/custom/definitio…` → 404).

**Fix** — the action-approvals precedent, end to end:
- **Host**: the custom-integration user routes (list / remove / provide-credential) now serve on three surfaces (`routes/custom-integrations-user.ts`): top-level `/v1`, the `/v1/agents/:id` wrapper (ownership-checked), and the per-agent dispatch `/agents/:id/integrations/custom/*` — the one form the gateway proxies to the pod. **No gateway change needed.**
- **Client**: `agentCustomIntegrations` / `submitAgentCustomIntegrationCredential` on the engine client + web adapter, riding `authFetch` against `baseUrl` (live in both deployments). The chat credential card and the routine-intake inline key form (a cloud-only surface) now use them; the card also resolves the integration name + auth fields through the per-agent read, so it no longer degrades to the generic fallback field on cloud.
- **fake-host** serves the per-agent form; the credential e2e specs pass against it.

### Context: the Tally half of HOU-823 was fixed separately

Tally itself was invisible to the AGENT (not the catalog UI) because Composio's unversioned `/tools` reads serve the frozen base snapshot, which predates the Tally toolkit — fixed by the Go gateway's tool-version pin (cloud PR #166, HOU-826, deployed 2026-07-23 15:19 UTC). Verified live against prod after that deploy: search resolves 10 `TALLY_*` tools as `connectable`, and `POST /connect {toolkit:"tally"}` mints a hosted link. This PR's custom-flow fix covers the fallback path users were pushed into while that was broken.

### Known follow-ups (out of scope)
- Gateway: the dispatch-scope classifier treats this new family as configure-scope (fail-closed) — fine for personal orgs (owner = manager); a member-facing use-scope carve-out like `action-approvals` is a gateway decision.
- The agent tab + global Integrations page still read the top-level custom list (hidden on managed cloud via the 404→null degrade); moving those management surfaces to the per-agent form would light them up on cloud.
- Observed while probing prod: the toolkit catalog fetch (`limit=1000`, TS host and Go gateway alike) returns exactly 1000 items — the truncation boundary — so toolkits past the cap are invisible. Not Tally's problem; pagination is a possible separate follow-up.

## Reproduction (before the fix)
1. On managed cloud (web or desktop signed into a cloud agent), get the agent to set up a custom integration (e.g. PriceLabs): it shows the secure key card.
2. Paste any key and press **Save key** → red toast `custom_integration_credential: not found (engine error 404)`, every time.

## Verification (after the fix)
1. Same flow: **Save key** now returns the refreshed view; the card shows "Key saved", the agent resumes, and the integration flips to active.
2. `pnpm --filter @houston/host test` — full suite passes, incl. new `custom-integrations-user.test.ts` (dispatch + `/v1` wrapper + ownership).
3. `pnpm --filter houston-web test:e2e e2e/interaction.spec.ts -g credential` — the card saves + skips against the fake host's per-agent route (2 passed); neighboring specs (custom-integrations, integration-setup-chat, approval, routine-setup-chat: 25 passed).
4. `pnpm check`, `pnpm check:boundaries`, app + web + ui typechecks all clean.

Linear: HOU-823