### PR TITLE
fix(providers): only show really-connected providers/models in the picker and AI Models page

### DIFF
--- a/app/src/components/shell/provider-error-card.tsx
+++ b/app/src/components/shell/provider-error-card.tsx
@@ -20,6 +20,9 @@
  */
 
 import type { ProviderError } from "@houston-ai/chat";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { queryKeys } from "../../lib/query-keys";
 import { UnauthenticatedCard } from "./provider-error-cards/auth";
 import {
   ContextOverflowCard,
@@ -48,12 +51,34 @@ interface ProviderErrorCardProps {
   onApplyModel?: (model: string) => void;
 }
 
+/**
+ * Error kinds that change what the engine now reports for the provider's
+ * connection status: an auth failure marks the credential broken and an
+ * unreachable endpoint flips the local model's reachability (both computed
+ * engine-side). The picker/AI Hub cache statuses for 30s, so without a nudge
+ * they keep offering the dead provider's models right after the card appears.
+ */
+const STATUS_CHANGING_KINDS: ReadonlySet<ProviderError["kind"]> = new Set([
+  "unauthenticated",
+  "network_unreachable",
+]);
+
 export function ProviderErrorCard({
   error,
   onRetry,
   onSwitchModel,
   onApplyModel,
 }: ProviderErrorCardProps) {
+  const queryClient = useQueryClient();
+  // Refresh the cached provider statuses when a status-changing card lands,
+  // so the model picker and the AI Models page stop showing the provider as
+  // connected while its inline card says otherwise.
+  useEffect(() => {
+    if (!STATUS_CHANGING_KINDS.has(error.kind)) return;
+    void queryClient.invalidateQueries({
+      queryKey: queryKeys.providerStatuses(),
+    });
+  }, [error.kind, queryClient]);
   // Cancellation has no UI surface; feed-to-messages should drop it
   // before we get here, but guard defensively in case it ever sneaks
   // through (e.g. resumed sessions reading from history).

--- a/knowledge-base/anthropic-credentials.md
+++ b/knowledge-base/anthropic-credentials.md
@@ -86,3 +86,34 @@ the traps at the bottom — read them before touching any of this.
    the built-in PowerShell dir on the child PATH, and the login spawn adds
    `CREATE_NO_WINDOW`. Never PATH-scan for `bash.exe` there —
    `System32\bash.exe` is WSL and wedges the CLI.
+
+## "Connected" means USABLE, not present (all providers)
+
+The status surface (`GET /providers` → the AI Models page + the chat model
+picker; the frontend maps `configured` straight to authenticated/
+unauthenticated) reports a provider connected only when its credential can
+actually serve a turn:
+
+- **auth.json entries** (`auth/storage.ts` `credentialUsable`): an API key is
+  always usable (live-verified at connect); an OAuth entry with a refresh
+  token is usable (pi refreshes it); an OAuth entry with refresh="" (the
+  Gate #2 serve shape) is usable only until `expires`. A dead served token
+  left behind by a control-plane outage no longer reads "Connected".
+- **The materialized `.credentials.json`** (`backends/claude/
+  credentials-file.ts` `claudeCredentialFileUsable`): judged by content, not
+  existence — refresh token present, or unexpired access token. A stale file
+  used to short-circuit `anthropicCredentialCached()` to connected even when
+  the `claude auth status` probe correctly said logged-out.
+- **Turn-failure feedback** (`auth/credential-health.ts`): a turn that fails
+  `unauthenticated` marks the provider's CURRENT credential (by fingerprint)
+  as broken — covering deaths invisible on disk (rotated-away refresh token,
+  upstream revocation). The mark auto-heals when the credential changes and
+  on the next clean turn. In-memory only.
+- **Local model reachability** (`ai/endpoint-reachability.ts`): the
+  OpenAI-compatible provider's status row additionally requires a cached
+  `GET <baseUrl>/models` probe to succeed (TTL'd, warmed by `GET /providers`);
+  a configured-but-stopped Ollama/LM Studio/Jan server reads disconnected.
+
+The TURN path deliberately keeps looser gating (`providerConfigured`): a turn
+on a suspect provider should run and surface its REAL typed card (network /
+reconnect), and a clean turn is what heals a stale failure mark.

--- a/packages/runtime/src/ai/endpoint-reachability.test.ts
+++ b/packages/runtime/src/ai/endpoint-reachability.test.ts
@@ -1,0 +1,119 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, expect, test } from "vitest";
+
+// config reads HOUSTON_DATA_DIR at import time, and vitest gives each test
+// file its own module registry — so point the data dir at a tmpdir BEFORE the
+// dynamic import to keep the endpoint writes out of the real ~/.houston-ts.
+process.env.HOUSTON_DATA_DIR = mkdtempSync(join(tmpdir(), "houston-reach-"));
+const { clearCustomEndpointConfig, setCustomEndpointConfig } = await import(
+  "./openai-compatible"
+);
+const {
+  endpointReachableCached,
+  refreshEndpointReachability,
+  resetEndpointReachability,
+} = await import("./endpoint-reachability");
+
+beforeEach(() => {
+  resetEndpointReachability();
+  clearCustomEndpointConfig();
+});
+
+test("no endpoint configured → nothing to probe, not reachable", async () => {
+  expect(await refreshEndpointReachability(async () => true)).toBe(false);
+  expect(endpointReachableCached()).toBe(false);
+});
+
+test("optimistic before the first probe: a configured endpoint reads reachable until a probe says otherwise", () => {
+  setCustomEndpointConfig({ baseUrl: "http://127.0.0.1:1337/v1", model: "m" });
+  // The status routes warm the cache before building rows; an unwarmed read
+  // (boot, config just changed) must not flash a working server as down.
+  expect(endpointReachableCached()).toBe(true);
+});
+
+test("a failed probe flips the endpoint to unreachable; a later success flips it back", async () => {
+  setCustomEndpointConfig({ baseUrl: "http://127.0.0.1:1337/v1", model: "m" });
+  expect(await refreshEndpointReachability(async () => false)).toBe(false);
+  expect(endpointReachableCached()).toBe(false);
+  resetEndpointReachability(); // step past the TTL
+  expect(await refreshEndpointReachability(async () => true)).toBe(true);
+  expect(endpointReachableCached()).toBe(true);
+});
+
+test("rapid refreshes reuse the fresh verdict (one probe per TTL window)", async () => {
+  setCustomEndpointConfig({ baseUrl: "http://127.0.0.1:1337/v1", model: "m" });
+  let calls = 0;
+  const probe = async () => {
+    calls += 1;
+    return true;
+  };
+  await refreshEndpointReachability(probe);
+  await refreshEndpointReachability(probe);
+  expect(calls).toBe(1);
+});
+
+test("concurrent refreshes share one in-flight probe", async () => {
+  setCustomEndpointConfig({ baseUrl: "http://127.0.0.1:1337/v1", model: "m" });
+  let calls = 0;
+  const probe = async () => {
+    calls += 1;
+    await new Promise((r) => setTimeout(r, 10));
+    return true;
+  };
+  await Promise.all([
+    refreshEndpointReachability(probe),
+    refreshEndpointReachability(probe),
+  ]);
+  expect(calls).toBe(1);
+});
+
+test("a base-URL change invalidates the cached verdict (the old server's answer doesn't speak for the new one)", async () => {
+  setCustomEndpointConfig({ baseUrl: "http://127.0.0.1:1337/v1", model: "m" });
+  await refreshEndpointReachability(async () => false);
+  expect(endpointReachableCached()).toBe(false);
+  setCustomEndpointConfig({ baseUrl: "http://127.0.0.1:8080/v1", model: "m" });
+  expect(endpointReachableCached()).toBe(true); // optimistic until probed
+  expect(await refreshEndpointReachability(async () => false)).toBe(false);
+  expect(endpointReachableCached()).toBe(false);
+});
+
+test("a reconfiguration mid-probe does NOT adopt the old URL's in-flight answer", async () => {
+  setCustomEndpointConfig({ baseUrl: "http://127.0.0.1:1337/v1", model: "m" });
+  let release: (() => void) | undefined;
+  const gate = new Promise<void>((r) => {
+    release = r;
+  });
+  const probed: string[] = [];
+  const slowProbe = async (baseUrl: string) => {
+    probed.push(baseUrl);
+    await gate;
+    return false; // the OLD server is down
+  };
+  const oldRefresh = refreshEndpointReachability(slowProbe);
+  // Mid-probe the user points the config at a NEW server that is up.
+  setCustomEndpointConfig({ baseUrl: "http://127.0.0.1:8080/v1", model: "m" });
+  const newRefresh = refreshEndpointReachability(async (baseUrl) => {
+    probed.push(baseUrl);
+    return true;
+  });
+  (release as () => void)();
+  expect(await newRefresh).toBe(true); // fresh probe of the NEW URL, not the old promise
+  await oldRefresh;
+  expect(probed).toEqual([
+    "http://127.0.0.1:1337/v1",
+    "http://127.0.0.1:8080/v1",
+  ]);
+  expect(endpointReachableCached()).toBe(true); // verdict keyed to the new URL
+});
+
+test("probes are keyed to the configured URL", async () => {
+  setCustomEndpointConfig({ baseUrl: "http://127.0.0.1:1337/v1", model: "m" });
+  const seen: string[] = [];
+  await refreshEndpointReachability(async (baseUrl) => {
+    seen.push(baseUrl);
+    return true;
+  });
+  expect(seen).toEqual(["http://127.0.0.1:1337/v1"]);
+});

--- a/packages/runtime/src/ai/endpoint-reachability.ts
+++ b/packages/runtime/src/ai/endpoint-reachability.ts
@@ -1,0 +1,107 @@
+import { customEndpointStatus } from "./openai-compatible";
+
+/**
+ * Reachability signal for the OpenAI-compatible (local model) endpoint.
+ *
+ * The endpoint's "connected" state used to be pure config presence (a base URL
+ * + model in custom-endpoint.json), so a stopped Ollama/LM Studio/vLLM server
+ * still showed "Connected" in the AI Models page and offered its model in the
+ * chat picker — with every turn failing. This module answers "is the server
+ * actually there?" with the same shape as the anthropic credential probe:
+ * an async refresh (TTL'd, coalesced) warmed by the status routes, and a sync
+ * cached read for the row builders.
+ *
+ * The probe hits `GET <baseUrl>/models` — the one endpoint every
+ * OpenAI-compatible server (Ollama, LM Studio, vLLM, llama.cpp, Jan) exposes.
+ * ANY HTTP response counts as reachable, whatever the status: a 401/404 still
+ * proves a server is listening (a key/model problem surfaces as its own typed
+ * turn error). Only a network failure (refused, DNS, timeout) reads
+ * unreachable. The TURN path never consults this cache — an unreachable server
+ * at turn time should fail the real request and surface the network card, not
+ * a fabricated "not connected".
+ */
+
+/** The last probe verdict, keyed by the base URL it probed — a config change
+ *  (new base URL) invalidates it implicitly. */
+let cache: { baseUrl: string; ok: boolean; at: number } | null = null;
+
+/** An in-flight probe, so concurrent status polls share ONE request. Keyed by
+ *  the URL it is probing: a reconfiguration mid-probe must start a fresh probe
+ *  for the NEW URL, not adopt the old server's answer. */
+let inFlight: { baseUrl: string; promise: Promise<boolean> } | null = null;
+
+/** Reuse window for a fresh verdict; the status routes poll far faster than a
+ *  local server's up/down state changes. */
+const PROBE_TTL_MS = 10_000;
+
+/** A local server answers /models in milliseconds; anything slower than this
+ *  is down (and the status route awaits us, so the bound must stay tight). */
+const PROBE_TIMEOUT_MS = 2_000;
+
+export type EndpointProbe = (baseUrl: string) => Promise<boolean>;
+
+async function fetchProbe(baseUrl: string): Promise<boolean> {
+  try {
+    await fetch(`${baseUrl.replace(/\/+$/, "")}/models`, {
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    return true; // any HTTP response — the server is listening
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Re-probe the configured endpoint and update the cache. Never throws. With no
+ * endpoint configured there is nothing to probe (and `configured` is already
+ * false); the cache is dropped so a later config starts fresh. `probe` is
+ * injected in tests.
+ */
+export async function refreshEndpointReachability(
+  probe: EndpointProbe = fetchProbe,
+): Promise<boolean> {
+  const baseUrl = customEndpointStatus().endpoint?.baseUrl;
+  if (!baseUrl) {
+    cache = null;
+    return false;
+  }
+  if (
+    cache &&
+    cache.baseUrl === baseUrl &&
+    Date.now() - cache.at < PROBE_TTL_MS
+  ) {
+    return cache.ok;
+  }
+  if (inFlight && inFlight.baseUrl === baseUrl) return inFlight.promise;
+  const promise = (async () => {
+    const ok = await probe(baseUrl);
+    cache = { baseUrl, ok, at: Date.now() };
+    return ok;
+  })();
+  inFlight = { baseUrl, promise };
+  try {
+    return await promise;
+  } finally {
+    if (inFlight?.promise === promise) inFlight = null;
+  }
+}
+
+/**
+ * The sync verdict for the CURRENTLY configured base URL. Optimistic before the
+ * first probe (or right after a base-URL change): "unknown" must not flash a
+ * working local model as disconnected — the status routes warm the cache before
+ * building rows, so real answers arrive with the first poll.
+ */
+export function endpointReachableCached(): boolean {
+  const baseUrl = customEndpointStatus().endpoint?.baseUrl;
+  if (!baseUrl) return false;
+  if (cache && cache.baseUrl === baseUrl) return cache.ok;
+  return true;
+}
+
+/** Drop the cached verdict (tests; endpoint reconfiguration takes effect via
+ *  the baseUrl key, so production code doesn't need to call this). */
+export function resetEndpointReachability(): void {
+  cache = null;
+  inFlight = null;
+}

--- a/packages/runtime/src/ai/openai-compatible.ts
+++ b/packages/runtime/src/ai/openai-compatible.ts
@@ -32,7 +32,9 @@ interface StoredEndpoint {
   orgShared?: boolean;
 }
 
-const endpointFileIn = (dataDir: string) =>
+/** The endpoint config's on-disk path — exported so credential-health can
+ *  fingerprint the file (a reconfigured endpoint must heal a failure mark). */
+export const endpointFileIn = (dataDir: string) =>
   join(dataDir, "custom-endpoint.json");
 
 /**

--- a/packages/runtime/src/ai/providers.ts
+++ b/packages/runtime/src/ai/providers.ts
@@ -5,8 +5,10 @@ import type { Api, KnownProvider, Model } from "@earendil-works/pi-ai";
 // (the new `Models`/`Provider` collection API needs an instantiated registry
 // we don't otherwise carry here).
 import { getModel } from "@earendil-works/pi-ai/compat";
+import { authFailureActive } from "../auth/credential-health";
 import { authStorage, providerConnected } from "../auth/storage";
 import { config } from "../config";
+import { endpointReachableCached } from "./endpoint-reachability";
 import {
   buildActiveCustomModel,
   customEndpointConfigured,
@@ -221,6 +223,24 @@ export function modelFor(provider: ProviderId): string {
 function providerConfigured(id: ProviderId): boolean {
   if (id === OPENAI_COMPATIBLE) return customEndpointConfigured();
   return providerConnected(authStorage, id);
+}
+
+/**
+ * The STATUS-surface truth: configured AND currently able to serve a turn.
+ * Two health signals layer on top of `providerConfigured`:
+ * - `authFailureActive` — a turn already failed `unauthenticated` on this
+ *   exact credential (auth/credential-health.ts), so "Connected" would be a
+ *   lie until the credential changes or a turn succeeds;
+ * - the local endpoint's reachability probe — a configured but stopped/
+ *   unreachable OpenAI-compatible server must not offer its model.
+ * Deliberately NOT used by the turn path (`activeProvider`): a turn on a
+ * suspect provider should run and surface its REAL typed error (network card,
+ * reconnect card) — and a clean turn is what heals a stale failure mark.
+ */
+function providerUsable(id: ProviderId): boolean {
+  if (!providerConfigured(id)) return false;
+  if (authFailureActive(id)) return false;
+  return id === OPENAI_COMPATIBLE ? endpointReachableCached() : true;
 }
 
 /** The agent's saved reasoning effort for new turns, or null (model default). */
@@ -495,12 +515,16 @@ function safeModelIds(provider: ProviderId): string[] {
   return piModelIds(provider);
 }
 
-/** One /providers status row for a provider id. */
+/** One /providers status row for a provider id. `configured` reports the
+ *  status-surface truth (`providerUsable`): the frontend maps it straight to
+ *  authenticated/unauthenticated for the AI Models page and the chat model
+ *  picker, so it must mean "this provider's models can actually answer",
+ *  not merely "some credential/config artifact exists". */
 function providerRow(id: ProviderId, name: string, active: ProviderId | null) {
   return {
     id,
     name,
-    configured: providerConfigured(id),
+    configured: providerUsable(id),
     isActive: id === active,
     activeModel: modelFor(id),
     models: safeModelIds(id),
@@ -519,7 +543,7 @@ export function listProviders() {
   const curated = new Set(PROVIDERS.map((p) => p.id));
   const rows = PROVIDERS.map((p) => providerRow(p.id, p.name, active));
   for (const id of piProviderIds()) {
-    if (!curated.has(id) && providerConfigured(id))
+    if (!curated.has(id) && providerUsable(id))
       rows.push(providerRow(id, id, active));
   }
   return rows;

--- a/packages/runtime/src/auth/credential-health-fingerprint.test.ts
+++ b/packages/runtime/src/auth/credential-health-fingerprint.test.ts
@@ -1,0 +1,33 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test } from "vitest";
+
+// The REAL (uninjected) fingerprint path: config reads HOUSTON_DATA_DIR at
+// import time, so pin it to a tmpdir before the dynamic imports (same pattern
+// as openai-compatible.test.ts). Kept separate from credential-health.test.ts,
+// which exercises the pure mark/heal logic with injected fingerprints.
+process.env.HOUSTON_DATA_DIR = mkdtempSync(join(tmpdir(), "houston-credfp-"));
+const { setCustomEndpointConfig } = await import("../ai/openai-compatible");
+const { authFailureActive, noteAuthFailure, resetAuthFailures } = await import(
+  "./credential-health"
+);
+
+afterEach(() => resetAuthFailures());
+
+test("reconfiguring the local endpoint heals its failure mark (same placeholder key, new server)", () => {
+  setCustomEndpointConfig({ baseUrl: "http://127.0.0.1:1337/v1", model: "m" });
+  noteAuthFailure("openai-compatible"); // real fingerprint: endpoint A
+  expect(authFailureActive("openai-compatible")).toBe(true);
+  // Pointing the config at a different server is a different "credential" —
+  // the mark must not keep the freshly configured endpoint disconnected.
+  setCustomEndpointConfig({ baseUrl: "http://127.0.0.1:8080/v1", model: "m" });
+  expect(authFailureActive("openai-compatible")).toBe(false);
+});
+
+test("an unchanged endpoint keeps its failure mark", () => {
+  setCustomEndpointConfig({ baseUrl: "http://127.0.0.1:1337/v1", model: "m" });
+  noteAuthFailure("openai-compatible");
+  expect(authFailureActive("openai-compatible")).toBe(true);
+  expect(authFailureActive("openai-compatible")).toBe(true);
+});

--- a/packages/runtime/src/auth/credential-health.test.ts
+++ b/packages/runtime/src/auth/credential-health.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, expect, test } from "vitest";
+import {
+  authFailureActive,
+  clearAuthFailure,
+  noteAuthFailure,
+  resetAuthFailures,
+} from "./credential-health";
+
+// Fingerprints are injected everywhere, so these tests never touch auth.json
+// or the Claude credential file — the module's IO is exercised implicitly by
+// the fact that production callers omit the parameter.
+
+afterEach(() => resetAuthFailures());
+
+test("nothing marked → no failure, no IO needed", () => {
+  expect(authFailureActive("anthropic", "fp-a")).toBe(false);
+});
+
+test("a marked credential reads as failed while it is still in place", () => {
+  noteAuthFailure("anthropic", "fp-a");
+  expect(authFailureActive("anthropic", "fp-a")).toBe(true);
+  // Still the same credential on a later poll — still failed.
+  expect(authFailureActive("anthropic", "fp-a")).toBe(true);
+});
+
+test("a credential change auto-heals the mark (re-login, fresh served token, pasted key)", () => {
+  noteAuthFailure("anthropic", "fp-dead");
+  expect(authFailureActive("anthropic", "fp-fresh")).toBe(false);
+  // The heal is permanent: even the old fingerprint no longer reads failed
+  // (the mark was deleted, not merely bypassed).
+  expect(authFailureActive("anthropic", "fp-dead")).toBe(false);
+});
+
+test("a serve loop re-applying the SAME dead token does not heal the mark", () => {
+  // applyServedCredential rewrites auth.json with identical bytes → identical
+  // fingerprint → the provider must stay disconnected (no status flapping).
+  noteAuthFailure("openai-codex", "fp-dead");
+  expect(authFailureActive("openai-codex", "fp-dead")).toBe(true);
+});
+
+test("a clean turn clears the mark explicitly (the Keychain re-login no fingerprint can see)", () => {
+  noteAuthFailure("anthropic", "fp-a");
+  clearAuthFailure("anthropic");
+  expect(authFailureActive("anthropic", "fp-a")).toBe(false);
+});
+
+test("marks are per provider", () => {
+  noteAuthFailure("anthropic", "fp-a");
+  expect(authFailureActive("openai-codex", "fp-a")).toBe(false);
+});

--- a/packages/runtime/src/auth/credential-health.ts
+++ b/packages/runtime/src/auth/credential-health.ts
@@ -1,0 +1,106 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { endpointFileIn, OPENAI_COMPATIBLE } from "../ai/openai-compatible";
+import { claudeCredentialsFile } from "../backends/claude/paths";
+import { config } from "../config";
+import { readAuthFile } from "./auth-file";
+
+/**
+ * Turn-time truth fed back into provider status.
+ *
+ * Presence/expiry checks (storage.ts, credentials-file.ts) catch a credential
+ * that is VISIBLY dead, but some deaths are invisible on disk: a refresh token
+ * rotated away by another login (Anthropic invalidates the previous holder on
+ * refresh), a centrally-served token revoked upstream, a Keychain credential
+ * `claude auth status` still calls logged-in. The one place those surface is a
+ * turn failing with the `unauthenticated` provider error — so when that
+ * happens, remember WHICH credential failed and report the provider
+ * disconnected (`providerUsable` in ai/providers.ts) while that same
+ * credential is still in place.
+ *
+ * The mark is keyed by a fingerprint of the credential at failure time and
+ * AUTO-HEALS the moment the credential changes — a re-login, a pasted key, a
+ * fresh centrally-served token, or a credential push all rewrite auth.json or
+ * the materialized file, so the connect paths need no explicit clear-wiring
+ * (and a serve loop re-applying the SAME dead token cannot flap the status
+ * back to connected). A clean turn also clears it, which covers the one
+ * change no fingerprint can see: a macOS Keychain re-login.
+ *
+ * Reads the persisted credential material directly (auth-file.ts + the
+ * materialized Claude file) rather than going through auth/storage.ts — that
+ * module reaches the Claude backend, which this module's callers (the
+ * backends' error classifiers) sit underneath, and the import cycle is not
+ * worth a cached view of the same bytes. In-memory only, deliberately: a
+ * restart re-learns the truth from the next turn, and persisting "broken"
+ * state could wedge a provider off after an out-of-band fix.
+ */
+
+/** provider id → fingerprint of the credential that failed authentication. */
+const failed = new Map<string, string>();
+
+function digest(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+/** A file's content hash, or "absent" when it can't be read. */
+function fileFingerprint(path: string): string {
+  try {
+    return digest(readFileSync(path));
+  } catch {
+    return "absent";
+  }
+}
+
+/**
+ * A stable fingerprint of a provider's CURRENT persisted credential material.
+ * Two providers span more than their auth.json entry: anthropic also carries
+ * the shared-dir credentials file (the Keychain is not observable from here —
+ * its rotations heal via the clean-turn clear instead), and the local
+ * OpenAI-compatible provider carries its endpoint config (same placeholder
+ * key, different server = a different "credential": reconfiguring the
+ * endpoint must heal a failure mark).
+ */
+function credentialFingerprint(id: string): string {
+  const cred = readAuthFile(join(config.dataDir, "auth.json"))[id];
+  const stored = cred ? digest(JSON.stringify(cred)) : "absent";
+  if (id === "anthropic")
+    return `${stored}|${fileFingerprint(claudeCredentialsFile())}`;
+  if (id === OPENAI_COMPATIBLE)
+    return `${stored}|${fileFingerprint(endpointFileIn(config.dataDir))}`;
+  return stored;
+}
+
+/** Record that a turn failed authentication on this provider's current
+ *  credential. `fingerprint` is injectable for tests. */
+export function noteAuthFailure(id: string, fingerprint?: string): void {
+  failed.set(id, fingerprint ?? credentialFingerprint(id));
+}
+
+/** Heal the mark without a credential change — a turn that COMPLETED on this
+ *  provider proved the credential works (exec-turn / turn-session call this on
+ *  every clean turn; cheap no-op when nothing is marked). */
+export function clearAuthFailure(id: string): void {
+  failed.delete(id);
+}
+
+/**
+ * Whether this provider's CURRENT credential is the one that failed a turn's
+ * authentication. A changed credential deletes the mark (auto-heal), so the
+ * check stays true only while retrying would fail the same way. The common
+ * path (nothing marked) does no IO. `fingerprint` is injectable for tests.
+ */
+export function authFailureActive(id: string, fingerprint?: string): boolean {
+  const marked = failed.get(id);
+  if (marked === undefined) return false;
+  if (marked !== (fingerprint ?? credentialFingerprint(id))) {
+    failed.delete(id);
+    return false;
+  }
+  return true;
+}
+
+/** Tests only: forget every mark. */
+export function resetAuthFailures(): void {
+  failed.clear();
+}

--- a/packages/runtime/src/auth/storage.test.ts
+++ b/packages/runtime/src/auth/storage.test.ts
@@ -4,7 +4,7 @@ import {
   refreshAnthropicCredential,
   resetAnthropicCredentialCache,
 } from "../backends/claude/credential-status";
-import { providerConnected } from "./storage";
+import { credentialUsable, providerConnected } from "./storage";
 
 test("providerConnected: only a STORED credential counts; connect then logout flips it", () => {
   const store = AuthStorage.inMemory({});
@@ -59,4 +59,63 @@ test("providerConnected(anthropic): a pasted setup token also counts (degraded f
   expect(providerConnected(store, "anthropic")).toBe(false);
   store.set("anthropic", { type: "api_key", key: "sk-ant-oat01-x" });
   expect(providerConnected(store, "anthropic")).toBe(true);
+});
+
+test("credentialUsable: presence is not connection — a dead serve-written entry reads unusable", () => {
+  const now = 1_784_000_000_000;
+  // An API key never expires (it was live-verified at connect).
+  expect(credentialUsable({ type: "api_key" }, now)).toBe(true);
+  // OAuth with a refresh token: pi auto-refreshes → usable even past expiry.
+  expect(
+    credentialUsable({ type: "oauth", refresh: "rt", expires: now - 1 }, now),
+  ).toBe(true);
+  // The Gate #2 serve shape (refresh="") is usable only until it expires…
+  expect(
+    credentialUsable(
+      { type: "oauth", refresh: "", expires: now + 60_000 },
+      now,
+    ),
+  ).toBe(true);
+  // …and DEAD after: this is the stale entry that showed "Connected" while
+  // every turn failed with the reconnect card.
+  expect(
+    credentialUsable({ type: "oauth", refresh: "", expires: now - 1 }, now),
+  ).toBe(false);
+  // expires 0/absent = no expiry recorded (a pasted token stored as oauth).
+  expect(
+    credentialUsable({ type: "oauth", refresh: "", expires: 0 }, now),
+  ).toBe(true);
+  expect(credentialUsable(undefined, now)).toBe(false);
+  // An unrecognized variant is not something we can vouch for.
+  expect(credentialUsable({ type: "mystery" }, now)).toBe(false);
+});
+
+test("providerConnected: an EXPIRED access-only oauth entry no longer counts as connected", async () => {
+  const store = AuthStorage.inMemory({});
+  store.set("openai-codex", {
+    type: "oauth",
+    access: "at",
+    refresh: "",
+    expires: Date.now() - 60_000,
+  });
+  expect(providerConnected(store, "openai-codex")).toBe(false);
+  // The same shape while still fresh IS connected.
+  store.set("openai-codex", {
+    type: "oauth",
+    access: "at",
+    refresh: "",
+    expires: Date.now() + 60_000,
+  });
+  expect(providerConnected(store, "openai-codex")).toBe(true);
+
+  // Anthropic's auth.json entry follows the same rule (the probe stays off).
+  await refreshAnthropicCredential(async () => false);
+  resetAnthropicCredentialCache(false);
+  store.set("anthropic", {
+    type: "oauth",
+    access: "at",
+    refresh: "",
+    expires: Date.now() - 60_000,
+  });
+  expect(providerConnected(store, "anthropic")).toBe(false);
 });

--- a/packages/runtime/src/auth/storage.ts
+++ b/packages/runtime/src/auth/storage.ts
@@ -16,11 +16,49 @@ export const authStorage = AuthStorage.create(
 );
 
 /**
- * Whether the user has CONNECTED this provider here — i.e. a credential is
- * STORED in auth.json (a UI paste-a-key, an OAuth sign-in, or a cloud-served
+ * The stored-credential shapes `credentialUsable` can judge — pi's
+ * `AuthCredential` union, structurally (an OAuth token or a plain API key).
+ * Widened with a catch-all `type` so an unrecognized future variant reads as
+ * NOT usable instead of failing to compile here.
+ */
+export type StoredCredential =
+  | { type: "oauth"; refresh?: string; expires?: number }
+  | { type: "api_key" }
+  | { type: string };
+
+/**
+ * Whether a STORED credential can still produce a working request — presence
+ * alone is not connection. The managed-cloud serve path writes OAuth entries
+ * with refresh="" (Gate #2, access-only); when the control plane then stops
+ * serving (an outage, a central disconnect the provenance gate couldn't
+ * remove), the dead entry lingers in auth.json and `has()` kept reporting the
+ * provider connected while every turn failed with the reconnect card. The rule:
+ * - an API key never expires (it was live-verified at connect);
+ * - an OAuth entry with a refresh token is usable (pi auto-refreshes it);
+ * - an OAuth entry with NO refresh token is usable only until `expires`
+ *   (`expires` 0/absent = no expiry recorded, e.g. a pasted token — usable).
+ * Mirrors backends/claude/read-token.ts, which already refuses to hand the SDK
+ * an expired served token.
+ */
+export function credentialUsable(
+  cred: StoredCredential | undefined,
+  now: number = Date.now(),
+): boolean {
+  if (!cred) return false;
+  if (cred.type === "api_key") return true;
+  if (cred.type !== "oauth") return false;
+  const c = cred as { refresh?: string; expires?: number };
+  if (c.refresh) return true;
+  const expires = c.expires ?? 0;
+  return expires <= 0 || expires > now;
+}
+
+/**
+ * Whether the user has CONNECTED this provider here — i.e. a USABLE credential
+ * is STORED in auth.json (a UI paste-a-key, an OAuth sign-in, or a cloud-served
  * central credential the host wrote in).
  *
- * Deliberately `has()` (stored only), NOT `hasAuth()`. `hasAuth()` ALSO returns
+ * Deliberately the stored entry only, NOT `hasAuth()`. `hasAuth()` ALSO returns
  * true for an ambient env var (`OPENROUTER_API_KEY`, `GEMINI_API_KEY`, …), a CLI
  * `--api-key` override, or a models.json fallback. Those can make a model
  * callable, but none is a connection the user made through Houston, and none is
@@ -29,21 +67,29 @@ export const authStorage = AuthStorage.create(
  * `AuthStorage.getAuthStatus()` draws the exact same line: a stored credential
  * is `configured`, env / override / fallback are not.
  *
+ * The stored entry must also be USABLE (`credentialUsable`): a serve-written
+ * access-only token that expired with no refresh token is a dead credential,
+ * and reporting it connected showed a "Connected" provider whose every turn
+ * failed with the reconnect card.
+ *
  * ANTHROPIC is the exception: its primary desktop credential is NOT in auth.json
  * at all — the browser login (`claude auth login`) caches it in the shared login
  * dir (Keychain / `.credentials.json`), read only by the `claude` binary. So it
- * counts as connected when EITHER a setup-token was pasted into auth.json (the
- * degraded fallback, `has`) OR the shared-dir credential probe reads logged-in
+ * counts as connected when EITHER a usable setup-token/served entry is in
+ * auth.json OR the shared-dir credential signal reads logged-in
  * (`anthropicCredentialCached`, warmed by `getAuthStatus`).
  *
  * Pure over its inputs (store + the cached probe) so the rule stays testable.
  */
 export function providerConnected(
-  store: Pick<AuthStorage, "has">,
+  store: Pick<AuthStorage, "get">,
   id: string,
 ): boolean {
-  if (id === "anthropic") return store.has(id) || anthropicCredentialCached();
-  return store.has(id);
+  const usable = credentialUsable(
+    store.get(id) as StoredCredential | undefined,
+  );
+  if (id === "anthropic") return usable || anthropicCredentialCached();
+  return usable;
 }
 
 export const modelRegistry = ModelRegistry.create(

--- a/packages/runtime/src/backends/claude/credential-status.test.ts
+++ b/packages/runtime/src/backends/claude/credential-status.test.ts
@@ -126,6 +126,43 @@ test("the materialized credentials file short-circuits the sync signal (pod path
   });
 });
 
+test("a STALE materialized file (expired, no refresh token) no longer reads connected", () => {
+  withHoustonHome((credFile) => {
+    // The screenshot bug: the file survives the credential it carried, and its
+    // mere EXISTENCE shadowed a probe that correctly said logged-out — so the
+    // AI Models page showed Connected while every turn hit the reconnect card.
+    mkdirSync(dirname(credFile), { recursive: true });
+    writeFileSync(
+      credFile,
+      JSON.stringify({
+        claudeAiOauth: { accessToken: "sk-ant-oat01-x", expiresAt: 1 },
+      }),
+    );
+    resetAnthropicCredentialCache(false);
+    expect(anthropicCredentialCached()).toBe(false); // dead file → probe cache
+    resetAnthropicCredentialCache(true);
+    expect(anthropicCredentialCached()).toBe(true); // probe still decides
+  });
+});
+
+test("a refresh-bearing file stays connected past its access-token expiry (SDK self-refreshes)", () => {
+  withHoustonHome((credFile) => {
+    mkdirSync(dirname(credFile), { recursive: true });
+    writeFileSync(
+      credFile,
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "sk-ant-oat01-x",
+          refreshToken: "rt",
+          expiresAt: 1,
+        },
+      }),
+    );
+    resetAnthropicCredentialCache(false);
+    expect(anthropicCredentialCached()).toBe(true);
+  });
+});
+
 test("logout removes the materialized file so the signal flips off", async () => {
   await withHoustonHomeAsync(async (credFile) => {
     writeCredFile(credFile);

--- a/packages/runtime/src/backends/claude/credential-status.ts
+++ b/packages/runtime/src/backends/claude/credential-status.ts
@@ -1,7 +1,8 @@
 import { execFile } from "node:child_process";
-import { existsSync, rmSync } from "node:fs";
+import { rmSync } from "node:fs";
 import { buildClaudeEnv } from "./backend";
 import { resolveClaudeExecutable } from "./binary-path";
+import { claudeCredentialFileUsable } from "./credentials-file";
 import { claudeCredentialsFile, claudeLoginConfigDir } from "./paths";
 
 /**
@@ -133,18 +134,19 @@ export async function refreshAnthropicCredential(
  * The sync "is anthropic connected?" signal, hit at turn time by
  * `activeProvider`/`providerConnected`.
  *
- * On the POD (Linux) the credential is materialized as a file — a sync stat is
+ * On the POD (Linux) the credential is materialized as a file — a sync read is
  * instant, needs no subprocess, and is correct the moment the file is written,
- * so there is no cold-start race and no probe spam on the turn path. macOS-local
- * caches in the Keychain (no file to stat), so there we fall back to the last
- * `claude auth status` probe result (warmed by `getAuthStatus`).
+ * so there is no cold-start race and no probe spam on the turn path. The file
+ * must actually be USABLE (`claudeCredentialFileUsable`), not merely present: a
+ * stale materialized file whose token expired with no refresh token used to
+ * short-circuit this to "connected" — even shadowing a probe that correctly
+ * said logged-out — so the AI Models page showed Connected while every turn
+ * failed with the reconnect card. macOS-local caches in the Keychain (no file
+ * to read), so a missing/dead file falls back to the last `claude auth status`
+ * probe result (warmed by `getAuthStatus`).
  */
 export function anthropicCredentialCached(): boolean {
-  try {
-    if (existsSync(claudeCredentialsFile())) return true;
-  } catch {
-    // A stat failure just defers to the probe cache below.
-  }
+  if (claudeCredentialFileUsable(claudeCredentialsFile())) return true;
   return cache ?? false;
 }
 

--- a/packages/runtime/src/backends/claude/credentials-file.test.ts
+++ b/packages/runtime/src/backends/claude/credentials-file.test.ts
@@ -1,8 +1,18 @@
-import { mkdtempSync, readFileSync, statSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { expect, test } from "vitest";
-import { writeClaudeOAuthCredentialFile } from "./credentials-file";
+import {
+  claudeCredentialFileUsable,
+  claudeOAuthCredentialUsable,
+  writeClaudeOAuthCredentialFile,
+} from "./credentials-file";
 import { claudeCredentialsFile } from "./paths";
 
 const cred = {
@@ -41,4 +51,72 @@ test("overwrites in place (a re-push replaces the credential)", () => {
   expect(
     JSON.parse(readFileSync(claudeCredentialsFile(configDir), "utf8")),
   ).toEqual({ claudeAiOauth: next });
+});
+
+const NOW = 1_784_000_000_000;
+
+test("claudeOAuthCredentialUsable: a refresh token makes the credential self-healing", () => {
+  expect(
+    claudeOAuthCredentialUsable(
+      { accessToken: "at", refreshToken: "rt", expiresAt: NOW - 1 },
+      NOW,
+    ),
+  ).toBe(true);
+});
+
+test("claudeOAuthCredentialUsable: without a refresh token, expiry decides", () => {
+  expect(
+    claudeOAuthCredentialUsable(
+      { accessToken: "at", expiresAt: NOW + 60_000 },
+      NOW,
+    ),
+  ).toBe(true);
+  // The stale materialized file that showed "Connected" while the SDK said
+  // "Not logged in": expired access token, nothing to refresh with.
+  expect(
+    claudeOAuthCredentialUsable({ accessToken: "at", expiresAt: NOW - 1 }, NOW),
+  ).toBe(false);
+  // No expiry recorded → usable (mirrors read-token.ts's expires=0 rule).
+  expect(claudeOAuthCredentialUsable({ accessToken: "at" }, NOW)).toBe(true);
+});
+
+function fileWith(contents: string): string {
+  const path = join(
+    mkdtempSync(join(tmpdir(), "claude-credfile-")),
+    "claude-login",
+    ".credentials.json",
+  );
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+  return path;
+}
+
+test("claudeCredentialFileUsable: absent file → false (defer to the probe)", () => {
+  expect(claudeCredentialFileUsable("/nonexistent/.credentials.json")).toBe(
+    false,
+  );
+});
+
+test("claudeCredentialFileUsable: corrupt / non-envelope contents → false", () => {
+  expect(claudeCredentialFileUsable(fileWith("not json"), NOW)).toBe(false);
+  expect(claudeCredentialFileUsable(fileWith("{}"), NOW)).toBe(false);
+});
+
+test("claudeCredentialFileUsable: judges the envelope, not the file's existence", () => {
+  const dead = fileWith(
+    JSON.stringify({
+      claudeAiOauth: { accessToken: "at", expiresAt: NOW - 1 },
+    }),
+  );
+  expect(claudeCredentialFileUsable(dead, NOW)).toBe(false);
+  const alive = fileWith(
+    JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "at",
+        refreshToken: "rt",
+        expiresAt: NOW - 1,
+      },
+    }),
+  );
+  expect(claudeCredentialFileUsable(alive, NOW)).toBe(true);
 });

--- a/packages/runtime/src/backends/claude/credentials-file.ts
+++ b/packages/runtime/src/backends/claude/credentials-file.ts
@@ -1,5 +1,8 @@
-import { mkdirSync, renameSync, writeFileSync } from "node:fs";
-import type { ClaudeOAuthCredential } from "@houston/runtime-client";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+  type ClaudeOAuthCredential,
+  parseClaudeOAuthEnvelope,
+} from "@houston/runtime-client";
 import { claudeCredentialsFile } from "./paths";
 
 /**
@@ -34,4 +37,52 @@ export function writeClaudeOAuthCredentialFile(
   const tmp = `${path}.tmp`;
   writeFileSync(tmp, JSON.stringify({ claudeAiOauth: cred }), { mode: 0o600 });
   renameSync(tmp, path);
+}
+
+/**
+ * Whether a materialized credential can still authenticate a turn. The file's
+ * EXISTENCE used to be the pod's "connected" signal, but a stale file survives
+ * the credential it carried: an access token that expired with no refresh token
+ * (or after the refresh token was rotated away by another login — Anthropic
+ * rotates on refresh, so a second holder invalidates the first) leaves a file
+ * that reads "Connected" while the SDK answers "Not logged in".
+ * - a refresh token present → usable (the SDK self-refreshes in place);
+ * - no refresh token → usable only until `expiresAt` (absent/0 = no expiry
+ *   recorded, treated as usable — mirrors read-token.ts's `expires=0` rule).
+ * A revoked-but-unexpired credential is indistinguishable on disk; the
+ * turn-failure feedback in auth/credential-health.ts covers that residue.
+ */
+export function claudeOAuthCredentialUsable(
+  cred: ClaudeOAuthCredential,
+  now: number = Date.now(),
+): boolean {
+  if (cred.refreshToken) return true;
+  const expires = cred.expiresAt ?? 0;
+  return expires <= 0 || expires > now;
+}
+
+/**
+ * Read `<configDir>/.credentials.json` and judge it: true only when the file
+ * exists, parses as the CLI envelope, AND carries a usable credential. An
+ * absent, corrupt, or dead file reads false — the caller falls back to the
+ * `claude auth status` probe, which owns the Keychain (macOS) answer.
+ */
+export function claudeCredentialFileUsable(
+  path: string,
+  now: number = Date.now(),
+): boolean {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return false; // absent (the common case) or unreadable — defer to the probe
+  }
+  let body: unknown;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return false;
+  }
+  const parsed = parseClaudeOAuthEnvelope(body);
+  return parsed.ok && claudeOAuthCredentialUsable(parsed.value, now);
 }

--- a/packages/runtime/src/backends/claude/errors.ts
+++ b/packages/runtime/src/backends/claude/errors.ts
@@ -5,6 +5,7 @@ import {
   extractRetryAfterSeconds,
 } from "../../ai/provider-error";
 import { logProviderError } from "../../ai/provider-error-log";
+import { noteAuthFailure } from "../../auth/credential-health";
 
 /** The pi provider id this backend runs as — every error is attributed to it. */
 const PROVIDER = "anthropic";
@@ -45,7 +46,13 @@ export function mapSdkError(
   const status = ctx.status ?? null;
   const mapped = mapSdkEnum(error, message, model, status, ctx);
   // Fall-through cases delegate to classifyText, which logs for itself.
-  if (mapped) logProviderError(mapped, { model, status, sdkError: error });
+  if (mapped) {
+    logProviderError(mapped, { model, status, sdkError: error });
+    // Feed the failure into the status surface: the credential the turn just
+    // ran on cannot authenticate, so "Connected" would be a lie until it
+    // changes (auth/credential-health.ts).
+    if (mapped.kind === "unauthenticated") noteAuthFailure(mapped.provider);
+  }
   return mapped ?? classifyText(message, model, status);
 }
 
@@ -123,6 +130,8 @@ export function classifyText(
     status,
   });
   logProviderError(classified, { model, status });
+  if (classified.kind === "unauthenticated")
+    noteAuthFailure(classified.provider);
   return classified;
 }
 

--- a/packages/runtime/src/backends/pi/wire.ts
+++ b/packages/runtime/src/backends/pi/wire.ts
@@ -7,6 +7,7 @@ import {
 } from "@houston/runtime-client";
 import { classifyProviderError } from "../../ai/provider-error";
 import { logProviderError } from "../../ai/provider-error-log";
+import { noteAuthFailure } from "../../auth/credential-health";
 
 /**
  * Normalize pi's per-message `Usage` into our provider-agnostic `TokenUsage`.
@@ -134,6 +135,11 @@ export function toWire(e: AgentSessionEvent): WireEvent | null {
           status,
         });
         logProviderError(classified, { model: msg.model ?? null, status });
+        // Feed an auth failure into the status surface: the credential the
+        // turn just ran on cannot authenticate, so "Connected" would be a lie
+        // until it changes (auth/credential-health.ts).
+        if (classified.kind === "unauthenticated")
+          noteAuthFailure(classified.provider);
         return { type: "provider_error", data: classified };
       }
       // Otherwise its usage carries the latest request's context size = the

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -15,6 +15,7 @@ import {
 import { classifyProviderError } from "../ai/provider-error";
 import { activeEffort, resolveModel } from "../ai/providers";
 import { recordTokenSpend } from "../ai/usage/ledger";
+import { clearAuthFailure, noteAuthFailure } from "../auth/credential-health";
 import { config } from "../config";
 import {
   appendAssistantMessage,
@@ -478,7 +479,12 @@ export async function execTurn(
     // clean-done path, carry whatever the model is now waiting on the user for so
     // the board card settles to `needs_you` (absent → `done`). Only the clean
     // done ever carries it.
-    if (!providerError && !stopped)
+    if (!providerError && !stopped) {
+      // A completed turn proves this provider's credential works — heal any
+      // stale turn-failure mark so status reads connected again
+      // (auth/credential-health.ts; covers the macOS Keychain re-login no
+      // fingerprint can observe).
+      clearAuthFailure(model.provider);
       publish(id, {
         type: "done",
         data: null,
@@ -487,6 +493,7 @@ export async function execTurn(
           ? { pendingInteraction: interaction.pending }
           : {}),
       });
+    }
   } catch (err) {
     // Persist the failure even when nothing streamed: a thrown turn (bad pin,
     // missing credential, stale model id) must leave the same durable trace a
@@ -520,6 +527,12 @@ export async function execTurn(
       tools.length === 0
     )
       thrown.undelivered_prompt = text;
+    // A thrown auth failure never crossed the backends' streamed-error seams,
+    // so feed it into the status surface here — e.g. a refresh-bearing entry
+    // whose refresh token was rejected raises at prompt time, before any
+    // stream exists (auth/credential-health.ts).
+    if (thrown.kind === "unauthenticated" && !providerError)
+      noteAuthFailure(thrown.provider);
     const typed = thrown.kind !== "unknown" ? thrown : undefined;
     appendAssistantMessage(id, assistantText, {
       tools,

--- a/packages/runtime/src/transport/provider-routes.test.ts
+++ b/packages/runtime/src/transport/provider-routes.test.ts
@@ -136,6 +136,9 @@ test("GET /providers hydrates served credentials before listing providers", asyn
   process.env.HOUSTON_DATA_DIR = dataDir;
   process.env.HOUSTON_CONTROL_PLANE_URL = "http://control-plane.test";
   process.env.HOUSTON_SANDBOX_TOKEN = "sbx-token";
+  // A served access token is short-TTL but FRESH — `configured` only counts a
+  // usable credential, so the fixture's expiry must sit in the future.
+  const servedExpires = Date.now() + 3_600_000;
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input);
     if (url.includes("provider=openai-codex")) {
@@ -144,7 +147,7 @@ test("GET /providers hydrates served credentials before listing providers", asyn
           provider: "openai-codex",
           kind: "oauth",
           access: "AT-served",
-          expires: 1_730_000_000_000,
+          expires: servedExpires,
           accountId: null,
           enterpriseUrl: null,
         }),
@@ -178,7 +181,7 @@ test("GET /providers hydrates served credentials before listing providers", asyn
       type: "oauth",
       access: "AT-served",
       refresh: "",
-      expires: 1_730_000_000_000,
+      expires: servedExpires,
     });
     expect(
       (

--- a/packages/runtime/src/transport/provider-routes.ts
+++ b/packages/runtime/src/transport/provider-routes.ts
@@ -1,4 +1,5 @@
 import { parseClaudeOAuthEnvelope } from "@houston/runtime-client";
+import { refreshEndpointReachability } from "../ai/endpoint-reachability";
 import { customEndpointStatus } from "../ai/openai-compatible";
 import {
   claimActiveProvider,
@@ -29,10 +30,15 @@ export async function handleProviderRoute(ctx: RouteContext): Promise<boolean> {
 
   if (method === "GET" && path === "/providers") {
     await syncServedCredentialSafe("providers");
-    // Warm the anthropic shared-dir credential probe so a just-completed browser
-    // login flips `configured` on this poll (the card-status path goes through
-    // /providers, not /auth/status). listProviders() then reads the fresh cache.
-    await refreshAnthropicCredential();
+    // Warm the cached health signals listProviders() reads synchronously: the
+    // anthropic shared-dir credential probe (so a just-completed browser login
+    // flips `configured` on this poll — the card-status path goes through
+    // /providers, not /auth/status) and the local endpoint's reachability
+    // probe (so a stopped Ollama/LM Studio server stops offering its model).
+    await Promise.all([
+      refreshAnthropicCredential(),
+      refreshEndpointReachability(),
+    ]);
     json(res, 200, listProviders());
     return true;
   }

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -11,6 +11,7 @@ import type {
 } from "@houston/runtime-client";
 import { DEFAULT_REASONING_EFFORT, toThinkingLevel } from "../ai/effort";
 import { classifyProviderError } from "../ai/provider-error";
+import { clearAuthFailure, noteAuthFailure } from "../auth/credential-health";
 import { createPiBackend } from "../backends/pi/backend";
 import { config } from "../config";
 import {
@@ -283,6 +284,9 @@ export async function runPiTurn(
       turnId,
     });
     if (fileChanges) emit({ type: "file_changes", data: fileChanges });
+    // A completed turn proves this provider's credential works — heal any
+    // stale turn-failure mark (auth/credential-health.ts; mirrors exec-turn).
+    if (!providerError) clearAuthFailure(provider);
     // Carry the pending question only on a clean turn — never alongside a
     // provider error (mirrors exec-turn: only the clean `done` carries it).
     return providerError ? {} : { pendingInteraction: interaction.pending };
@@ -311,6 +315,10 @@ export async function runPiTurn(
         tools.length === 0
       )
         thrown.undelivered_prompt = text;
+      // A thrown auth failure never crossed the backends' streamed-error
+      // seams — feed it into the status surface (auth/credential-health.ts;
+      // mirrors exec-turn).
+      if (thrown.kind === "unauthenticated") noteAuthFailure(thrown.provider);
       if (thrown.kind !== "unknown") {
         appendAssistantMessageAt(
           conversationsDir,


### PR DESCRIPTION
## Problem

The AI Models page showed **Anthropic** and **Local model** as Connected while neither could serve a turn — sending a message to the Claude model returned the "Sign in to Anthropic again" reconnect card, and the local Jan server wasn't even running. The chat model picker kept offering both providers' models.

Root cause (confirmed against the dev environment's `runtime.log` at the moment of the repro): the `/providers` rows' `configured` flag — which the frontend maps directly to authenticated/unauthenticated for both the AI Models page and the picker — was **pure presence**:

- an `anthropic` OAuth entry in `auth.json` counted even when it was a serve-written access-only token (`refresh: ""`) whose `expires` had passed (a control-plane serve outage leaves exactly this behind — the log showed `applied central credentials: (none)` at the failing turn);
- a materialized `claude-login/.credentials.json` counted by **existence** (`existsSync`), even shadowing a `claude auth status` probe that correctly said logged-out (the repro machine's probe says `loggedIn: false` while the stale file sat there);
- the local OpenAI-compatible provider counted whenever `custom-endpoint.json` had a base URL + model — no reachability check at all (`curl http://127.0.0.1:1337/v1/models` → connection refused, still "Connected").

## Fix — status means *usable*, in the runtime

1. **`auth/storage.ts` `credentialUsable`** — a stored OAuth entry with `refresh: ""` is dead once `expires` passes; refresh-bearing entries (pi auto-refreshes) and API keys (live-verified at connect) are unchanged. Mirrors `read-token.ts`, which already refuses to hand the SDK an expired served token.
2. **`backends/claude/credentials-file.ts` `claudeCredentialFileUsable`** — the materialized file is judged by content (refresh token present, or unexpired access token), never by existence. A dead/corrupt/absent file defers to the `claude auth status` probe.
3. **`ai/endpoint-reachability.ts`** — the local provider's status row additionally requires a cached `GET <baseUrl>/models` probe to succeed (2s timeout, 10s TTL, coalesced, keyed by base URL so a reconfigure invalidates and a mid-probe reconfigure can't adopt the old server's answer). Warmed by `GET /providers` alongside the existing anthropic probe.
4. **`auth/credential-health.ts`** — turn-time truth feedback: a turn failing `unauthenticated` (streamed via the pi/claude backends, or thrown at prompt time in `exec-turn`/`turn-session`) marks the provider's **fingerprinted** credential broken, catching deaths invisible on disk (refresh token rotated away by another login, upstream revocation). The mark auto-heals the moment the credential material changes (re-login, fresh served token, pasted key, endpoint reconfigure) and on the next clean turn — so a serve loop re-applying the *same* dead token can't flap the status back to connected.

`providerRow.configured` now reports `providerUsable` (configured ∧ no active auth-failure mark ∧ local endpoint reachable). The frontend needs no mapping changes — the picker already hides disconnected providers and the AI Models page already groups by this flag.

**The turn path deliberately keeps presence-based gating**: a turn on a suspect provider runs and surfaces its real typed card (network / reconnect), and a clean turn heals a stale mark. A dead credential drops out of `activeProvider()` exactly like a logged-out one, which the existing `NO_CREDENTIALS_PATTERNS` classification (HOU-718) already renders as the reconnect card — never a silent provider switch.

## Frontend

One addition: a mounting `unauthenticated` / `network_unreachable` card invalidates `queryKeys.providerStatuses()`, so the picker reflects the disconnect immediately instead of after its 30s `staleTime` (the AI Models page already re-probes on mount).

## Tests

- `credentialUsable` matrix (api_key / refresh-bearing / dead serve shape / no-expiry) + `providerConnected` with expired vs fresh access-only entries
- `claudeOAuthCredentialUsable` + `claudeCredentialFileUsable` (absent / corrupt / dead / refresh-bearing) + credential-status: a stale file no longer shadows the probe; a refresh-bearing file survives access expiry
- endpoint reachability: TTL coalescing, concurrent sharing, base-URL keying, optimistic-before-first-probe, and the mid-probe reconfigure race
- credential-health: mark/heal semantics with injected fingerprints, plus the real-fingerprint path proving an endpoint reconfigure heals a local-model mark
- updated the served-credential route fixture to a future expiry (a served token is short-TTL but fresh)

`pnpm check` clean, `check:boundaries` clean, runtime 762/762, host 1055 passed (one pre-existing flake observed once, passed on 3 consecutive re-runs), domain 147/147, `tsgo` clean across app / web / runtime / host.