### PR TITLE
fix(runtime): show the connect card in Autopilot mode (HOU-853)

### DIFF
--- a/app/src/components/onboarding/missions/use-email-mission-session.ts
+++ b/app/src/components/onboarding/missions/use-email-mission-session.ts
@@ -128,7 +128,8 @@ export function useEmailMissionSession({
           modelOverride: model,
           effortOverride: "medium",
           // Autopilot: the onboarding turn must SEND the email on the first
-          // message, not pause on ask_user/request_connection questions.
+          // message, not pause on ask_user questions (the email app was
+          // already connected earlier in the tutorial).
           modeOverride: "auto",
         },
       );

--- a/app/src/lib/turn-mode.ts
+++ b/app/src/lib/turn-mode.ts
@@ -4,9 +4,10 @@
  * `execute` is a normal turn (Houston can read, act, and change things).
  * `plan` pins a read-only planning turn: the runtime restricts the turn to
  * read-only tools and a planning overlay via the per-turn pin.
- * `auto` (Autopilot) is fire-and-forget: the runtime removes the blocking
- * tools (ask_user, request_connection) so the agent finishes the task with
- * what it has instead of pausing to ask, then reports back. An UNPINNED turn
+ * `auto` (Autopilot) is fire-and-forget: the runtime removes ask_user so the
+ * agent finishes the task with what it has instead of pausing to ask, then
+ * reports back (a missing app connection still queues a connect card, which
+ * ends the turn and auto-continues once connected — HOU-853). An UNPINNED turn
  * is always `execute`, so `plan`/`auto` only take effect on sends that forward
  * the pin as `modeOverride`. A pick while a turn is RUNNING additionally
  * applies to that turn live (`tauriChat.setLiveTurnMode` — Claude Code's

--- a/packages/host/src/schedule/firer.ts
+++ b/packages/host/src/schedule/firer.ts
@@ -27,7 +27,9 @@ export class ChannelRoutineFirer implements RoutineFirer {
     // inherit), with routinePin applying the read-time legacy id mapping —
     // the pin is what makes a routine's provider stick regardless of what
     // other chats or routines have picked since. Routine fires also pin
-    // Autopilot mode so they never block on ask_user/request_connection.
+    // Autopilot mode so they never block on an ask_user question (a missing
+    // app connection still queues a connect card the user finds in the chat —
+    // the turn ends rather than blocking).
     // The creator's sub (C2) is threaded as the turn's acting-user so integration
     // calls act as them; absent for legacy creator-less routines → acts as owner.
     const createdBy = job.routine.created_by;

--- a/packages/runtime/src/backends/claude/backend-mcp.test.ts
+++ b/packages/runtime/src/backends/claude/backend-mcp.test.ts
@@ -120,10 +120,10 @@ test("plan mode builds the MCP server WITHOUT integrations — ask_user + plan_r
 
 test("auto mode builds the MCP with integrations ON and ask_user OFF", async () => {
   // Autopilot is the inverse of plan: it KEEPS the acting integration tools
-  // (and the non-blocking suggest_reusable and save_routine, and
-  // request_credential — the one hand-off autonomy cannot avoid) but drops the
-  // blocking tools (ask_user, request_connection) so the agent never waits on
-  // the user.
+  // (and the non-blocking suggest_reusable and save_routine, and the
+  // request_connection / request_credential hand-offs autonomy cannot avoid —
+  // HOU-853) but drops ask_user so the agent never waits on the user's
+  // judgment.
   const options = await runTurn(
     { baseUrl: "http://host.local", sandboxToken: "tok" },
     "auto",
@@ -136,19 +136,20 @@ test("auto mode builds the MCP with integrations ON and ask_user OFF", async () 
       "save_routine",
       "integration_search",
       "integration_execute",
+      "request_connection",
       "custom_integration_detect",
       "custom_integration_add",
       "request_credential",
     ]),
   );
   expect(exposed).not.toContain("ask_user");
-  expect(exposed).not.toContain("request_connection");
   expect(new Set(options.allowedTools)).toEqual(
     new Set([
       "mcp__houston__suggest_reusable",
       "mcp__houston__save_routine",
       "mcp__houston__integration_search",
       "mcp__houston__integration_execute",
+      "mcp__houston__request_connection",
       "mcp__houston__custom_integration_detect",
       "mcp__houston__custom_integration_add",
       "mcp__houston__request_credential",

--- a/packages/runtime/src/backends/claude/custom-tools.test.ts
+++ b/packages/runtime/src/backends/claude/custom-tools.test.ts
@@ -180,19 +180,21 @@ test("save_routine is bridged for execute/auto but stripped from plan", () => {
   );
 });
 
-test("auto mode keeps the integration + suggest_reusable tools but drops the blocking tools", () => {
+test("auto mode keeps the integration + suggest_reusable tools but drops ask_user", () => {
   const { tools, mcp } = build(INTEGRATIONS, "auto");
-  // Autopilot never waits on the user: ask_user + request_connection are gone
-  // (and plan_ready is plan-only). The acting integration tools stay,
-  // suggest_reusable stays (it never blocks the turn), and request_credential
-  // stays — an API key is the one thing autonomy cannot produce, and its card
-  // auto-continues the run.
+  // Autopilot never waits on the user's judgment: ask_user is gone (and
+  // plan_ready is plan-only). The acting integration tools stay,
+  // suggest_reusable stays (it never blocks the turn), and request_connection
+  // + request_credential stay (HOU-853) — a missing connection or API key is
+  // the one thing autonomy cannot produce, and the queued card ends the turn
+  // and auto-continues the run.
   expect(new Set(tools.map((t) => t.name))).toEqual(
     new Set([
       "suggest_reusable",
       "save_routine",
       "integration_search",
       "integration_execute",
+      "request_connection",
       "custom_integration_detect",
       "custom_integration_add",
       "request_credential",
@@ -204,6 +206,7 @@ test("auto mode keeps the integration + suggest_reusable tools but drops the blo
       "mcp__houston__save_routine",
       "mcp__houston__integration_search",
       "mcp__houston__integration_execute",
+      "mcp__houston__request_connection",
       "mcp__houston__custom_integration_detect",
       "mcp__houston__custom_integration_add",
       "mcp__houston__request_credential",

--- a/packages/runtime/src/backends/claude/custom-tools.ts
+++ b/packages/runtime/src/backends/claude/custom-tools.ts
@@ -76,10 +76,12 @@ export interface HoustonMcpInput {
   /**
    * The turn's execution mode, applied as the SAME tool filter the pi path uses
    * (`toolNamesForMode`): "plan" keeps `ask_user` + `plan_ready` (the acting
-   * integration tools are withheld), "auto" drops the blocking tools (`ask_user`,
-   * `request_connection`) and `plan_ready` while KEEPING `integration_search` /
-   * `integration_execute`, and "execute" (or absent) exposes the full built set
-   * minus `plan_ready` (plan-only). `plan_ready` never survives outside plan.
+   * integration tools are withheld), "auto" drops `ask_user` (the one blocking
+   * tool) and `plan_ready` while KEEPING `integration_search` /
+   * `integration_execute` / `request_connection` (the queued connect card ends
+   * the turn instead of holding it open — HOU-853), and "execute" (or absent)
+   * exposes the full built set minus `plan_ready` (plan-only). `plan_ready`
+   * never survives outside plan.
    * `suggest_reusable` mirrors the acting tools' reach — it survives execute AND
    * auto (it never blocks the turn) but never plan (plan is not a finished task).
    */

--- a/packages/runtime/src/backends/claude/tool-policy.ts
+++ b/packages/runtime/src/backends/claude/tool-policy.ts
@@ -68,8 +68,8 @@ export interface ToolPolicyInput {
    * subset (Read/Glob/Grep) and denies Edit/Write/Bash. "auto" (Autopilot) keeps
    * the SAME built-in policy as execute (file tools + Bash per `localBash`) — the
    * Claude-native built-ins have no blocking `ask_user`, so auto's "never wait on
-   * the user" rule is enforced only on the MCP side (custom-tools drops ask_user
-   * and request_connection); nothing to clamp here. Absent or "execute" is the
+   * the user" rule is enforced only on the MCP side (custom-tools drops
+   * ask_user); nothing to clamp here. Absent or "execute" is the
    * full policy gated only by `localBash`.
    */
   mode?: TurnMode;

--- a/packages/runtime/src/backends/pi/backend.ts
+++ b/packages/runtime/src/backends/pi/backend.ts
@@ -48,7 +48,7 @@ export function createPiBackend(deps: PiBackendDeps): HarnessBackend {
     async createSession(opts: CreateSessionOptions): Promise<HarnessSession> {
       // The turn's mode overlays its prompt (via the loader) and clamps the
       // allowlist through `toolNamesForMode`: plan → the read-only subset, auto →
-      // everything minus the blocking tools (ask_user/request_connection),
+      // everything minus ask_user (the one blocking tool),
       // execute → unchanged. The customTools list is UNCHANGED — pi gates its
       // custom tools by the `tools` name allowlist, so filtering the names here
       // drops the excluded tools from the model's reach without rebuilding the

--- a/packages/runtime/src/session/mode-overlays.test.ts
+++ b/packages/runtime/src/session/mode-overlays.test.ts
@@ -59,3 +59,11 @@ test("the auto overlay establishes the never-wait, act-and-report contract", () 
   expect(lower).toContain("assum");
   expect(lower).toContain("report");
 });
+
+test("the auto overlay teaches the connect hand-off instead of writing apps off (HOU-853)", () => {
+  // request_connection survives Autopilot (tool-selection.ts): an unconnected
+  // app must produce a connect card, never a "go connect it yourself" reply.
+  const lower = AUTO_MODE_OVERLAY.toLowerCase();
+  expect(lower).toContain("request_connection");
+  expect(lower).toContain("not connected");
+});

--- a/packages/runtime/src/session/mode-overlays.ts
+++ b/packages/runtime/src/session/mode-overlays.ts
@@ -26,9 +26,12 @@ export const PLAN_MODE_OVERLAY = [
 /**
  * Autopilot mode's system-prompt overlay. Appended (LAST, after the agent's own
  * context) on an "auto" turn only. Auto is fire-and-forget: the model CANNOT
- * block on the user — the blocking tools (`ask_user`, `request_connection`) are
- * withheld from its toolset (session/tool-selection.ts) — so this overlay tells
- * it to act on its own judgment and report back.
+ * block on the user's judgment — `ask_user` is withheld from its toolset
+ * (session/tool-selection.ts) — so this overlay tells it to act on its own
+ * judgment and report back. `request_connection` DOES survive auto (HOU-853):
+ * a missing app connection is the one thing autonomy cannot produce, and the
+ * queued connect card ends the turn rather than holding it open, so the
+ * overlay teaches the hand-off instead of declaring the app out of reach.
  *
  * Voice: same non-technical rule as the plan overlay — no files, JSON, or CLIs.
  */
@@ -37,7 +40,8 @@ export const AUTO_MODE_OVERLAY = [
   "",
   "- Do not ask the user questions or wait for their input. Work with the information you have.",
   "- When something is ambiguous, make the most sensible choice and keep going. Remember the important assumptions you make.",
-  "- If something is truly out of reach (for example an app that is not connected), do the rest of the task and say clearly what you could not do and why.",
+  "- If the task needs an app that is not connected yet, call the request_connection tool for it. Houston shows the user a connect card and sends you a message automatically once the connection is live - so first finish everything that does not need that app, then end your turn.",
+  "- If something else is truly out of reach, do the rest of the task and say clearly what you could not do and why.",
   "- Finish with a short report: what you did, what you assumed, and anything that needs the user's attention.",
 ].join("\n");
 

--- a/packages/runtime/src/session/tool-selection.test.ts
+++ b/packages/runtime/src/session/tool-selection.test.ts
@@ -162,34 +162,35 @@ describe("planToolNames", () => {
 });
 
 describe("autoToolNames", () => {
-  test("drops exactly the blocking tools from the full local selection", () => {
+  test("drops exactly ask_user from the full local selection", () => {
     const local = buildToolSelection({
       codeExecution: "local",
       integrations: true,
     });
-    // Auto keeps every read/write/exec/integration tool; it only removes the
-    // blocking tools. request_credential survives: an API key is the one thing
-    // autonomy cannot produce, and the card auto-continues the run (an auto
-    // add of a keyed custom integration was a dead end without it). Order is
-    // preserved (filter, not reorder).
+    // Auto keeps every read/write/exec/integration tool; it only removes
+    // ask_user (the one tool that waits on the user's judgment).
+    // request_connection and request_credential survive (HOU-853): a missing
+    // connection — like an API key — is the one thing autonomy cannot produce,
+    // and the queued card ends the turn instead of holding it open, then
+    // auto-continues the run. Order is preserved (filter, not reorder).
     expect(autoToolNames(local.toolNames)).toEqual([
       ...CLAMPED_FILE_TOOL_NAMES,
       "suggest_reusable",
       "bash",
       "integration_search",
       "integration_execute",
+      "request_connection",
       "custom_integration_detect",
       "custom_integration_add",
       "request_credential",
     ]);
-    for (const dropped of ["ask_user", "request_connection"])
-      expect(autoToolNames(local.toolNames)).not.toContain(dropped);
+    expect(autoToolNames(local.toolNames)).not.toContain("ask_user");
     // …and it keeps the file WRITE tools + bash, unlike plan.
     for (const kept of ["edit", "write", "bash"])
       expect(autoToolNames(local.toolNames)).toContain(kept);
   });
 
-  test("keeps run_code from the remote selection, drops the blocking tools", () => {
+  test("keeps run_code from the remote selection, drops ask_user", () => {
     const remote = buildToolSelection({
       codeExecution: "remote",
       integrations: true,
@@ -197,8 +198,8 @@ describe("autoToolNames", () => {
     const names = autoToolNames(remote.toolNames);
     expect(names).toContain("run_code");
     expect(names).toContain("integration_search");
+    expect(names).toContain("request_connection");
     expect(names).not.toContain("ask_user");
-    expect(names).not.toContain("request_connection");
   });
 
   test("the disabled, integration-less selection just loses ask_user", () => {
@@ -212,11 +213,8 @@ describe("autoToolNames", () => {
     ]);
   });
 
-  test("the excluded set is exactly ask_user + request_connection", () => {
-    expect([...AUTO_MODE_EXCLUDED_TOOL_NAMES]).toEqual([
-      "ask_user",
-      "request_connection",
-    ]);
+  test("the excluded set is exactly ask_user", () => {
+    expect([...AUTO_MODE_EXCLUDED_TOOL_NAMES]).toEqual(["ask_user"]);
   });
 });
 

--- a/packages/runtime/src/session/tool-selection.ts
+++ b/packages/runtime/src/session/tool-selection.ts
@@ -2,10 +2,7 @@ import type { TurnMode } from "@houston/protocol";
 import { ASK_USER_TOOL_NAME } from "./tools/ask-user";
 import { CLAMPED_FILE_TOOL_NAMES } from "./tools/clamped-fs";
 import { CUSTOM_INTEGRATION_TOOL_NAMES } from "./tools/custom-integrations";
-import {
-  INTEGRATION_TOOL_NAMES,
-  REQUEST_CONNECTION_TOOL_NAME,
-} from "./tools/integrations";
+import { INTEGRATION_TOOL_NAMES } from "./tools/integrations";
 import { PLAN_READY_TOOL_NAME } from "./tools/plan-ready";
 import { SAVE_ROUTINE_TOOL_NAME } from "./tools/save-routine";
 import { SUGGEST_REUSABLE_TOOL_NAME } from "./tools/suggest-reusable";
@@ -65,23 +62,23 @@ export function planToolNames(all: readonly string[]): string[] {
 
 /**
  * The blocking/interactive tools Autopilot ("auto") mode drops: `ask_user`
- * (holds the turn open on a question) and `request_connection` (holds it open
- * on a connect card). Auto never waits on the user, so both are removed.
- * EVERYTHING else an execute turn had — the clamped-fs read AND write tools,
- * `bash` / `run_code`, and the acting integration tools (`integration_search`,
- * `integration_execute`) — stays: auto acts, it just never blocks.
+ * (holds the turn open on a question) — auto never waits on the user's
+ * judgment. EVERYTHING else an execute turn had — the clamped-fs read AND
+ * write tools, `bash` / `run_code`, and the acting integration tools
+ * (`integration_search`, `integration_execute`) — stays: auto acts, it just
+ * never blocks on a question only the user can answer.
  *
- * `request_credential` deliberately SURVIVES auto: a custom integration's API
- * key is the one thing autonomy cannot produce, and without the tool an auto
- * run that adds a keyed integration is a dead end by construction — the add
- * result says "call request_credential" while the mode has removed it, so the
- * agent can neither show the secure card nor (per the prompt) accept a key in
- * chat. Recording the step doesn't hold the turn open; it ends the turn with
- * the key-entry card, and the saved key AUTO-CONTINUES the autopilot run.
+ * `request_connection` and `request_credential` deliberately SURVIVE auto
+ * (HOU-853): a missing app connection — like an API key — is the one thing
+ * autonomy cannot produce. Without them an auto run that hits an unconnected
+ * app is a dead end by construction: the search results say "call
+ * request_connection" while the mode has removed it, so the agent can only
+ * tell the user to go connect the app by hand. Recording the step doesn't
+ * hold the turn open; it ends the turn with the connect/key-entry card, and
+ * the live connection (or saved key) AUTO-CONTINUES the autopilot run.
  */
 export const AUTO_MODE_EXCLUDED_TOOL_NAMES: readonly string[] = [
   ASK_USER_TOOL_NAME,
-  REQUEST_CONNECTION_TOOL_NAME,
 ];
 
 /**

--- a/packages/runtime/src/session/tools/integrations.test.ts
+++ b/packages/runtime/src/session/tools/integrations.test.ts
@@ -487,7 +487,7 @@ test("the turn-mode header is sent iff the turn is Autopilot", async () => {
   expect(bare[0]?.headers["x-houston-turn-mode"]).toBeUndefined();
 });
 
-test("live mode gates: a turn switched to Plan refuses execute; Autopilot refuses request_connection", async () => {
+test("live mode gates: a turn switched to Plan refuses execute and the connect hand-off", async () => {
   // The user flipped the Mode pill to Plan while the turn ran: acting on the
   // user's apps refuses BEFORE any network call, with the planning instruction.
   const calls = mockFetch(() => ({ body: { successful: true } }));
@@ -496,18 +496,30 @@ test("live mode gates: a turn switched to Plan refuses execute; Autopilot refuse
   ).rejects.toThrow(/Plan mode/);
   expect(calls).toHaveLength(0);
 
-  // A flip to Autopilot mid-turn: waiting on the user to connect an app refuses.
-  await expect(
-    runWithTurnMode({ current: "auto" }, () =>
-      run(requestConnection, { toolkit: "gmail" }),
-    ),
-  ).rejects.toThrow(/Autopilot mode/);
   // And Plan refuses the connect hand-off too (setup while planning).
   await expect(
     runWithTurnMode({ current: "plan" }, () =>
       run(requestConnection, { toolkit: "gmail" }),
     ),
   ).rejects.toThrow(/Plan mode/);
+});
+
+test("Autopilot does NOT gate request_connection: the connect step is recorded (HOU-853)", async () => {
+  // Auto never waits on the user's judgment, but a missing connection is the
+  // one thing autonomy cannot produce — the queued connect card ends the turn
+  // (it never holds it open) and the live connection auto-continues the run,
+  // so the hand-off works in Autopilot exactly as in Coworker.
+  const holder = newInteractionHolder();
+  await runWithTurnMode({ current: "auto" }, () =>
+    runWithInteractionCapture(holder, () =>
+      run(requestConnection, { toolkit: "gmail", reason: "to send email" }),
+    ),
+  );
+  expect(holder.pending).toEqual({
+    steps: [
+      { kind: "connect", id: "c1", toolkit: "gmail", reason: "to send email" },
+    ],
+  });
 });
 
 test("C2: attaches the turn's acting-as header inside a turn, and nothing outside one", async () => {

--- a/packages/runtime/src/session/tools/integrations.ts
+++ b/packages/runtime/src/session/tools/integrations.ts
@@ -2,7 +2,7 @@ import { defineTool } from "@earendil-works/pi-coding-agent";
 import { type Static, Type } from "typebox";
 import { currentActingContext } from "../acting-context";
 import { recordApproval, recordConnection, recordSignin } from "../interaction";
-import { assertNotAutoMode, assertNotPlanMode } from "../live-mode-gate";
+import { assertNotPlanMode } from "../live-mode-gate";
 import { currentTurnMode } from "../turn-mode-context";
 
 /**
@@ -495,10 +495,11 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
     parameters: ConnectParams,
     executionMode: "sequential",
     async execute(_id: string, params: ConnectParams) {
-      // Live gates for the mid-turn Mode-pill switch: connecting an app both
-      // waits on the user (never in Autopilot) and sets up a real-world
-      // capability (not while planning).
-      assertNotAutoMode("wait for the user to connect an app");
+      // Live gate for the mid-turn Mode-pill switch: connecting an app sets up
+      // a real-world capability, off-limits while planning. Autopilot is NOT
+      // gated (HOU-853): the recorded step doesn't hold the turn open — it ends
+      // the turn with the connect card, and the live connection auto-continues
+      // the run (same shape as request_credential).
       assertNotPlanMode("ask the user to connect an app");
       const toolkit = normalizeToolkitSlug(params.toolkit);
       if (!toolkit)
@@ -521,10 +522,13 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
 }
 
 /**
- * The in-chat connect hand-off tool. A blocking/interactive tool (it waits for
- * the user to connect an app), so — like `ask_user` — it is EXCLUDED from
- * Autopilot ("auto") mode, which never waits on the user. Named here so the
- * mode tool filter can reference it without a string literal.
+ * The in-chat connect hand-off tool. Available in EVERY acting mode, Autopilot
+ * included (HOU-853): a missing connection is the one thing autonomy cannot
+ * produce, and the recorded step doesn't hold the turn open — it ends the turn
+ * with the connect card, and the live connection auto-continues the run (the
+ * same rationale as `request_credential`). Only Plan mode withholds it (no
+ * real-world setup while planning). Named here so the mode tool filter can
+ * reference it without a string literal.
  */
 export const REQUEST_CONNECTION_TOOL_NAME = "request_connection";
 


### PR DESCRIPTION
## Summary

Fixes HOU-853: connection cards were never shown when the agent ran in Autopilot mode. The agent would instead reply with things like *"my connect-card tool is currently unavailable. Could you connect Google Sheets from the Integrations tab?"* — while the same request in Coworker mode produced the one-click connect card.

### Root cause

This was by construction, not a rendering bug: Autopilot's tool filter (`AUTO_MODE_EXCLUDED_TOOL_NAMES`) dropped `request_connection` alongside `ask_user`, and the tool itself carried an `assertNotAutoMode` live gate. Meanwhile `integration_search` results still told the model to *"call the request_connection tool"* — hence the confused "tool is currently unavailable" replies.

The premise ("auto never waits on the user") doesn't actually hold for connections: recording a connect step never holds the turn open — it ends the turn with the connect card, and the live connection auto-continues the run. That is exactly the rationale `request_credential` already ships with in auto mode.

### Fix

- `request_connection` now survives Autopilot on both backends (pi via `tool-selection.ts`, Claude via `custom-tools.ts` — both flow through the same `toolNamesForMode`); the auto-excluded set is now just `ask_user`.
- The `assertNotAutoMode` live gate is removed from the tool (the Plan-mode gate stays: no real-world setup while planning).
- The Autopilot system-prompt overlay now teaches the connect hand-off (finish everything that doesn't need the app, queue the card, end the turn) instead of declaring unconnected apps out of reach.
- Stale comments updated (Claude tool policy, pi backend, routine firer, app turn-mode docs); routine fires still pin auto and now queue a connect card instead of silently skipping the app.

### Tests

- `tool-selection.test.ts`: auto keeps `request_connection`; excluded set is exactly `ask_user`.
- `integrations.test.ts`: new test — an auto turn records the connect interaction step (Plan still refuses).
- `custom-tools.test.ts` / `backend-mcp.test.ts`: Claude auto toolset + allowedTools include `request_connection`.
- `mode-overlays.test.ts`: the auto overlay names `request_connection` and the not-connected case (and stays jargon-free).

`pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test` (1945 tests), `pnpm typecheck`, app `tsgo --noEmit`, and `pnpm check` all pass.

## Repro (before the fix)

1. Open a chat with an agent, set the composer Mode pill to **Autopilot**.
2. Ask for something needing an unconnected app, e.g. *"Save that metadata into a spreadsheet on my Google Drive"* with Google Sheets not connected.
3. The agent replies in text that it cannot show the connect card and asks you to use the Integrations tab. Switching the pill to **Coworker** and retrying shows the card.

## Verify (after the fix)

1. Same setup: **Autopilot** mode, ask for an action on an unconnected app.
2. The one-click connect card appears in place of the chat input at the end of the turn.
3. Click **Connect** and complete OAuth — Houston auto-sends the continue message and the autopilot run finishes the task.
4. In **Plan** mode the agent still refuses to set up connections (unchanged).