### PR TITLE
fix(credentials): fill-only desktop reconcile so a stale snapshot cannot revoke the Anthropic token family (HOU-855)

### DIFF
--- a/app/src/lib/claude-login-remote.ts
+++ b/app/src/lib/claude-login-remote.ts
@@ -58,6 +58,7 @@ type ClaudeCredentialPusher = {
   pushClaudeOAuthCredential?: (
     agentId: string | null,
     credentialJson: string,
+    opts?: { ifAbsent?: boolean },
   ) => Promise<void>;
 };
 
@@ -73,8 +74,18 @@ export type ClaudeHandoffResult =
  * workspace-central, any real pod stores and serves them), else the agentless
  * setup runtime (true first-run). Retries transient failures with backoff.
  * Never throws; the caller decides how loud the outcome is.
+ *
+ * `ifAbsent` (the background RECONCILE): the cached credential may be an OLD
+ * snapshot whose refresh token the gateway has since rotated — overwriting the
+ * live central credential with it makes the gateway's next refresh trip
+ * Anthropic's refresh-token-reuse detection and revoke the whole token family
+ * (HOU-855). Fill-only: the push is a no-op when a central credential already
+ * exists. The fresh-login path omits it (a just-minted credential SHOULD
+ * replace whatever is stored).
  */
-export async function pushCachedClaudeCredential(): Promise<ClaudeHandoffResult> {
+export async function pushCachedClaudeCredential(opts?: {
+  ifAbsent?: boolean;
+}): Promise<ClaudeHandoffResult> {
   let credentialJson: string;
   try {
     credentialJson = await osReadClaudeCredential();
@@ -92,7 +103,7 @@ export async function pushCachedClaudeCredential(): Promise<ClaudeHandoffResult>
     }
     for (let attempt = 0; ; attempt++) {
       try {
-        await engine.pushClaudeOAuthCredential(agentId, credentialJson);
+        await engine.pushClaudeOAuthCredential(agentId, credentialJson, opts);
         return { ok: true };
       } catch (err) {
         const delay = PUSH_RETRY_DELAYS_MS[attempt];

--- a/app/src/lib/claude-login.ts
+++ b/app/src/lib/claude-login.ts
@@ -134,7 +134,11 @@ export async function reconcileClaudeCredentialHandoff(): Promise<void> {
   } catch {
     return; // engine unreachable — nothing to reconcile against
   }
-  const result = await pushCachedClaudeCredential();
+  // Fill-only: this cached snapshot may predate gateway refresh-token
+  // rotations, and clobbering the live central credential with it would
+  // revoke the whole token family (HOU-855). When a central credential
+  // already exists the push no-ops and the confirm below decides the outcome.
+  const result = await pushCachedClaudeCredential({ ifAbsent: true });
   if (!result.ok) {
     if (result.reason === "push-failed") {
       logger.warn(

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -436,19 +436,41 @@ export class ProxyChannel implements RuntimeChannel {
   async saveClaudeOAuthCredential(
     ctx: ChannelCtx,
     cred: ClaudeOAuthCredential,
+    opts?: { ifAbsent?: boolean },
   ): Promise<void> {
-    await this.opts.credentials.put({
-      workspaceId: ctx.agent.workspaceId,
-      // pi's provider id for Houston's native Anthropic provider.
-      provider: "anthropic",
-      kind: "oauth",
-      accessToken: cred.accessToken,
-      // Central-store durability marker only — the pod authenticates from the
-      // materialized file, not this. A credential without a refresh token /
-      // expiry (both optional in the CLI shape) still stores cleanly.
-      refreshToken: cred.refreshToken ?? "",
-      expiresAt: cred.expiresAt ?? 0,
-    });
+    if (opts?.ifAbsent) {
+      // Fill-only push (the desktop reconcile of a CACHED snapshot, HOU-855):
+      // when the workspace already holds a central anthropic credential —
+      // whose refresh token the gateway may have rotated since this snapshot
+      // was cached — storing OR materializing the snapshot would poison the
+      // family (the gateway's next refresh with the superseded token trips
+      // Anthropic's reuse detection and revokes every access token). Present
+      // means done: the pod serves the live credential. A probe failure
+      // throws — the reconcile logs it and retries next session; guessing
+      // "absent" here and materializing a stale file is never worth it.
+      const existing = await this.opts.credentials.get(
+        ctx.agent.workspaceId,
+        "anthropic",
+      );
+      if (existing) return;
+    }
+    await this.opts.credentials.put(
+      {
+        workspaceId: ctx.agent.workspaceId,
+        // pi's provider id for Houston's native Anthropic provider.
+        provider: "anthropic",
+        kind: "oauth",
+        accessToken: cred.accessToken,
+        // Central-store durability marker only — the pod authenticates from the
+        // materialized file, not this. A credential without a refresh token /
+        // expiry (both optional in the CLI shape) still stores cleanly.
+        refreshToken: cred.refreshToken ?? "",
+        expiresAt: cred.expiresAt ?? 0,
+      },
+      // Belt-and-braces under the gateway's atomic row lock: a concurrent
+      // write between the probe above and this put still cannot be clobbered.
+      { ifAbsent: opts?.ifAbsent },
+    );
     const endpoint = await this.opts.launcher.ensureAwake(ctx.agent);
     const res = await fetch(
       `${endpoint.baseUrl}/auth/anthropic/oauth-credential`,

--- a/packages/host/src/credentials/file-store.ts
+++ b/packages/host/src/credentials/file-store.ts
@@ -57,8 +57,13 @@ export class FileCredentialStore implements CredentialStore {
     return this.creds.get(this.key(workspaceId, provider)) ?? null;
   }
 
-  async put(cred: WorkspaceCredential): Promise<void> {
-    this.creds.set(this.key(cred.workspaceId, cred.provider), { ...cred });
+  async put(
+    cred: WorkspaceCredential,
+    opts?: { ifAbsent?: boolean },
+  ): Promise<void> {
+    const key = this.key(cred.workspaceId, cred.provider);
+    if (opts?.ifAbsent && this.creds.has(key)) return;
+    this.creds.set(key, { ...cred });
     this.flush();
   }
 

--- a/packages/host/src/credentials/remote-store.test.ts
+++ b/packages/host/src/credentials/remote-store.test.ts
@@ -168,6 +168,30 @@ test("positive cache absorbs repeated gets within the TTL", async () => {
   expect(calls).toHaveLength(1);
 });
 
+test("put with ifAbsent sends the gateway's fill-only header (HOU-855)", async () => {
+  const { calls, fetchImpl } = fakeFetch((call) => {
+    if (call.init?.method === "PUT") {
+      expect(headers(call)["x-houston-if-absent"]).toBe("1");
+      return json({ ok: true });
+    }
+    return json(gatewayCredential({ access: "AT" }));
+  });
+  const s = store(fetchImpl);
+
+  await s.put(
+    {
+      workspaceId: "ws_1",
+      provider: "openai-codex",
+      kind: "oauth",
+      accessToken: "AT-local",
+      refreshToken: "RT-local",
+      expiresAt: 456,
+    },
+    { ifAbsent: true },
+  );
+  expect(calls.some((c) => c.init?.method === "PUT")).toBe(true);
+});
+
 test("put writes the gateway row and invalidates the provider cache", async () => {
   let getCount = 0;
   const { calls, fetchImpl } = fakeFetch((call) => {

--- a/packages/host/src/credentials/remote-store.ts
+++ b/packages/host/src/credentials/remote-store.ts
@@ -71,8 +71,14 @@ export class RemoteCredentialStore implements CredentialStore {
     return this.withWorkspace(workspaceId, adopted);
   }
 
-  async put(cred: WorkspaceCredential): Promise<void> {
-    await this.putRemote(cred.provider, cred);
+  async put(
+    cred: WorkspaceCredential,
+    opts?: { ifAbsent?: boolean },
+  ): Promise<void> {
+    // ifAbsent rides to the gateway as `x-houston-if-absent`, whose PUT is
+    // atomic under the per-(org, provider) row lock — the authoritative guard
+    // against clobbering a live rotated refresh token with a cached snapshot.
+    await this.putRemote(cred.provider, cred, { ifAbsent: opts?.ifAbsent });
     this.cache.delete(cred.provider);
   }
 

--- a/packages/host/src/credentials/store.test.ts
+++ b/packages/host/src/credentials/store.test.ts
@@ -31,6 +31,22 @@ test("MemoryCredentialStore: get is null, then put → get → overwrite → rem
   expect(await s.get("ws_1", "openai-codex")).toBeNull();
 });
 
+test("MemoryCredentialStore: ifAbsent put fills a hole but never clobbers (HOU-855)", async () => {
+  const s = new MemoryCredentialStore();
+
+  // Absent → fills.
+  await s.put(cred({ accessToken: "at-fill" }), { ifAbsent: true });
+  expect((await s.get("ws_1", "openai-codex"))?.accessToken).toBe("at-fill");
+
+  // Present → the stale snapshot is dropped, the live row survives.
+  await s.put(cred({ accessToken: "at-stale", refreshToken: "rt-stale" }), {
+    ifAbsent: true,
+  });
+  const kept = await s.get("ws_1", "openai-codex");
+  expect(kept?.accessToken).toBe("at-fill");
+  expect(kept?.refreshToken).toBe("rt");
+});
+
 test("MemoryCredentialStore: workspaces + providers are isolated keys", async () => {
   const s = new MemoryCredentialStore();
   await s.put(cred({ workspaceId: "ws_a" }));

--- a/packages/host/src/credentials/store.ts
+++ b/packages/host/src/credentials/store.ts
@@ -24,8 +24,13 @@ export class MemoryCredentialStore implements CredentialStore {
   ): Promise<WorkspaceCredential | null> {
     return this.creds.get(this.key(workspaceId, provider)) ?? null;
   }
-  async put(cred: WorkspaceCredential): Promise<void> {
-    this.creds.set(this.key(cred.workspaceId, cred.provider), { ...cred });
+  async put(
+    cred: WorkspaceCredential,
+    opts?: { ifAbsent?: boolean },
+  ): Promise<void> {
+    const key = this.key(cred.workspaceId, cred.provider);
+    if (opts?.ifAbsent && this.creds.has(key)) return;
+    this.creds.set(key, { ...cred });
   }
   async remove(workspaceId: WorkspaceId, provider: string): Promise<void> {
     this.creds.delete(this.key(workspaceId, provider));

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -276,6 +276,16 @@ export interface RuntimeChannel {
   saveClaudeOAuthCredential(
     ctx: ChannelCtx,
     cred: ClaudeOAuthCredential,
+    opts?: {
+      /**
+       * Fill-only push (the desktop RECONCILE of a cached snapshot): when the
+       * workspace already holds a live central credential — whose refresh
+       * token the gateway may have rotated since this snapshot was cached —
+       * the push is a no-op instead of a clobber (HOU-855). A fresh browser
+       * login omits it and overwrites.
+       */
+      ifAbsent?: boolean;
+    },
   ): Promise<void>;
   /**
    * Connect an OpenAI-compatible server: a base URL + model id. Desktop/self-host
@@ -340,8 +350,15 @@ export interface CredentialStore {
     workspaceId: WorkspaceId,
     provider: string,
   ): Promise<WorkspaceCredential | null>;
-  /** Upsert (overwrite in place on refresh). */
-  put(cred: WorkspaceCredential): Promise<void>;
+  /**
+   * Upsert (overwrite in place on refresh). `ifAbsent` makes it a FILL, not a
+   * clobber: an existing entry is left untouched. Required for any push of a
+   * CACHED credential snapshot (the desktop reconcile) — the central copy may
+   * hold a rotated refresh token, and overwriting it with a stale snapshot
+   * makes the next central refresh trip the provider's refresh-token-reuse
+   * detection, revoking the whole family (HOU-855).
+   */
+  put(cred: WorkspaceCredential, opts?: { ifAbsent?: boolean }): Promise<void>;
   remove(workspaceId: WorkspaceId, provider: string): Promise<void>;
 }
 

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -524,6 +524,10 @@ export async function handleAgents(
       await channel.saveClaudeOAuthCredential(
         { workspace: authz.workspace, agent: authz.agent },
         parsed.value,
+        // `?if_absent=1` marks a fill-only push of a CACHED snapshot (the
+        // desktop reconcile) — never allowed to clobber a live central
+        // credential whose refresh token may have rotated since (HOU-855).
+        { ifAbsent: url.searchParams.get("if_absent") === "1" },
       );
       json(res, 200, { ok: true });
     } catch (err) {

--- a/packages/host/src/routes/claude-oauth.test.ts
+++ b/packages/host/src/routes/claude-oauth.test.ts
@@ -126,9 +126,15 @@ async function boot(owner = "alice"): Promise<Fixture> {
   };
 }
 
-function push(base: string, agentId: string, body: unknown, user = "alice") {
+function push(
+  base: string,
+  agentId: string,
+  body: unknown,
+  user = "alice",
+  query = "",
+) {
   return fetch(
-    `${base}/agents/${encodeURIComponent(agentId)}/credential/claude-oauth`,
+    `${base}/agents/${encodeURIComponent(agentId)}/credential/claude-oauth${query}`,
     {
       method: "POST",
       headers: {
@@ -244,5 +250,76 @@ describe("POST /agents/:id/credential/claude-oauth", () => {
       for (const restore of spies) restore();
       fx.close();
     }
+  });
+
+  // The desktop RECONCILE re-pushes a CACHED snapshot whose refresh token the
+  // gateway may have rotated since; clobbering the live central credential
+  // with it revokes the whole token family (HOU-855). `?if_absent=1` makes the
+  // push fill-only.
+  describe("?if_absent=1 (cached-snapshot reconcile)", () => {
+    const STALE = {
+      claudeAiOauth: {
+        accessToken: "sk-ant-oat-STALE-ACCESS",
+        refreshToken: "sk-ant-ort-STALE-REFRESH",
+        expiresAt: 1_700_000_000_000,
+      },
+    };
+
+    test("central credential present → 200 no-op: store untouched, runtime NOT materialized", async () => {
+      const fx = await boot();
+      try {
+        // The live (rotated) central credential a fresh login stored earlier.
+        await push(fx.base, fx.agent.id, VALID);
+        lastPush = null;
+
+        const res = await push(
+          fx.base,
+          fx.agent.id,
+          STALE,
+          "alice",
+          "?if_absent=1",
+        );
+        expect(res.status).toBe(200);
+
+        const cred = await fx.credentials.get(fx.workspace.id, "anthropic");
+        expect(cred?.refreshToken).toBe("sk-ant-ort-REFRESH-SECRET");
+        expect(lastPush).toBeNull();
+      } finally {
+        fx.close();
+      }
+    });
+
+    test("no central credential → fills: store + runtime dual write as usual", async () => {
+      const fx = await boot();
+      try {
+        const res = await push(
+          fx.base,
+          fx.agent.id,
+          STALE,
+          "alice",
+          "?if_absent=1",
+        );
+        expect(res.status).toBe(200);
+
+        const cred = await fx.credentials.get(fx.workspace.id, "anthropic");
+        expect(cred?.refreshToken).toBe("sk-ant-ort-STALE-REFRESH");
+        expect(lastPush).toEqual(STALE);
+      } finally {
+        fx.close();
+      }
+    });
+
+    test("without the flag a push still overwrites (fresh login)", async () => {
+      const fx = await boot();
+      try {
+        await push(fx.base, fx.agent.id, STALE);
+        const res = await push(fx.base, fx.agent.id, VALID);
+        expect(res.status).toBe(200);
+        const cred = await fx.credentials.get(fx.workspace.id, "anthropic");
+        expect(cred?.refreshToken).toBe("sk-ant-ort-REFRESH-SECRET");
+      } finally {
+        fx.close();
+      }
+    });
   });
 });

--- a/packages/host/src/routes/setup-runtime.ts
+++ b/packages/host/src/routes/setup-runtime.ts
@@ -146,7 +146,11 @@ export async function handleSetupRuntime(
       return true;
     }
     try {
-      await channel.saveClaudeOAuthCredential(ctx, parsed.value);
+      await channel.saveClaudeOAuthCredential(ctx, parsed.value, {
+        // Fill-only for a cached-snapshot reconcile (HOU-855) — mirrors the
+        // per-agent claude-oauth route.
+        ifAbsent: url.searchParams.get("if_absent") === "1",
+      });
       json(res, 200, { ok: true });
     } catch (err) {
       json(res, 502, {

--- a/packages/web/src/engine-adapter/client/provider-credentials-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-credentials-mixin.ts
@@ -50,6 +50,7 @@ export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
     async pushClaudeOAuthCredential(
       agentId: string | null,
       credentialJson: string,
+      opts?: { ifAbsent?: boolean },
     ): Promise<void> {
       if (!this.ctx.cp) {
         throw new Error("Pushing a Claude credential needs a cloud engine.");
@@ -59,12 +60,14 @@ export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
           this.ctx.cp,
           agentId,
           credentialJson,
+          opts,
         );
         return;
       }
       await controlPlane.pushSetupClaudeOAuthCredential(
         this.ctx.cp,
         credentialJson,
+        opts,
       );
     }
 

--- a/packages/web/src/engine-adapter/cp/credentials.ts
+++ b/packages/web/src/engine-adapter/cp/credentials.ts
@@ -37,12 +37,24 @@ export async function pushClaudeOAuthCredential(
   cfg: ControlPlaneConfig,
   agentId: string,
   credentialJson: string,
+  opts?: { ifAbsent?: boolean },
 ): Promise<void> {
   await cpFetch(
     cfg,
-    `/agents/${encodeURIComponent(agentId)}/credential/claude-oauth`,
+    `/agents/${encodeURIComponent(agentId)}/credential/claude-oauth${ifAbsentQuery(opts)}`,
     { method: "POST", body: credentialJson },
   );
+}
+
+/**
+ * `?if_absent=1` marks a fill-only push of a CACHED credential snapshot (the
+ * reconcile): the host must never overwrite a live central credential whose
+ * refresh token the gateway may have rotated since the snapshot was cached
+ * (HOU-855). A fresh browser login omits it and overwrites. Rides the query
+ * string so the CLI's credential JSON is forwarded byte-verbatim as the body.
+ */
+function ifAbsentQuery(opts?: { ifAbsent?: boolean }): string {
+  return opts?.ifAbsent ? "?if_absent=1" : "";
 }
 
 /**
@@ -133,11 +145,16 @@ export async function getTunnelCredentials(
 export async function pushSetupClaudeOAuthCredential(
   cfg: ControlPlaneConfig,
   credentialJson: string,
+  opts?: { ifAbsent?: boolean },
 ): Promise<void> {
-  await cpFetch(cfg, `/setup-runtime/credential/claude-oauth`, {
-    method: "POST",
-    body: credentialJson,
-  });
+  await cpFetch(
+    cfg,
+    `/setup-runtime/credential/claude-oauth${ifAbsentQuery(opts)}`,
+    {
+      method: "POST",
+      body: credentialJson,
+    },
+  );
 }
 
 /** Connect-once capture on the setup runtime — `captureCredential`, agentless. */


### PR DESCRIPTION
Fixes HOU-855. Sentry: HOUSTON-APP-4YA (943 events / 36 users, managed-cloud pods failing every turn with `401 OAuth access token has been revoked`).

## Root cause

Since the gateway's central Anthropic refresh reached prod (~Jul 19-20 — the older "credential expired" 502s stopped exactly then and the "revoked" wave started), the gateway rotates the refresh token on every refresh. The desktop keeps the original credential snapshot in its Keychain, and the background reconcile (`reconcileClaudeCredentialHandoff`, runs on app-session mount whenever the pod reads anthropic disconnected) re-pushed that stale snapshot through a blind clobber PUT. The gateway's next refresh then used the superseded refresh token, tripping Anthropic's refresh-token-reuse detection, which revokes the entire token family — every already-served access token dies mid-validity, pods 401 on every turn, the pod reads disconnected, and the next desktop session re-pushes the stale snapshot again. Self-sustaining churn.

The gateway already had the guard for exactly this (`x-houston-if-absent`, honored atomically under its per-(org, provider) row lock); nothing on the push path used it.

## The fix

The reconcile now declares itself **fill-only** (`?if_absent=1` on both claude-oauth push routes: per-agent and setup-runtime), enforced at three layers:

1. **ProxyChannel** probes the central store first: if a credential exists, the push is a successful no-op — the stale snapshot is neither stored nor materialized on the pod. A probe failure throws (logged by the reconcile, retried next session) instead of guessing "absent" and materializing a stale file.
2. **RemoteCredentialStore.put** forwards `x-houston-if-absent`, so even a write racing between the probe and the put cannot clobber (the gateway PUT is atomic).
3. **File/Memory stores** honor `ifAbsent` for desktop/self-host parity.

A fresh browser login still omits the flag and overwrites — a just-minted credential should replace whatever is stored. Old hosts ignore the query param gracefully (current clobber behavior, no wire break).

## Tests

- Route-level (real HTTP through the real ProxyChannel): `?if_absent=1` with an existing central credential → 200 no-op, store untouched, runtime not materialized; with no credential → normal dual write; without the flag → still overwrites.
- `RemoteCredentialStore.put({ifAbsent})` sends the gateway header; MemoryCredentialStore fill-vs-clobber unit test.
- Full `@houston/host` suite passes (130 files / 1064 tests), workspace typecheck + Biome green.

## Verify

Before: on a cloud-connected account, let the gateway rotate the credential (any refresh), then open the desktop app while the pod momentarily reads anthropic disconnected — the gateway's stored refresh token is replaced by the stale snapshot, and the next central refresh kills the family (watch HOUSTON-APP-4YA).

After: the same reconcile no-ops when a central credential exists (`if_absent=1` visible in the gateway request log); HOUSTON-APP-4YA event rate should decay to zero as desktops update. A genuinely lost central credential (the reconcile's real purpose: a failed original handoff) still gets filled and confirmed.