### PR TITLE
feat: project turn_id onto folded chat-history entries

### DIFF
--- a/packages/sdk/src/modules/turns/history.test.ts
+++ b/packages/sdk/src/modules/turns/history.test.ts
@@ -29,6 +29,35 @@ describe("historyToFeed", () => {
     ]);
   });
 
+  it("projects the source ChatMessage.turnId onto every folded frame of the turn", () => {
+    const messages: ChatMessage[] = [
+      { role: "user", content: "hi", ts: 1, turnId: "turn-abc" },
+      {
+        role: "assistant",
+        content: "hello",
+        ts: 2,
+        turnId: "turn-abc",
+        thinking: "hmm",
+        usage: { context_tokens: 10, output_tokens: 2, cached_tokens: 0 },
+      },
+    ];
+    const feed = historyToFeed(messages);
+    // The user bubble and every assistant frame (thinking, assistant_text,
+    // final_result) fold under the SAME turn_id — the alignment key a resyncing
+    // client uses to match backfilled entries to the live turn.
+    expect(feed.map((f) => f.turn_id)).toEqual([
+      "turn-abc",
+      "turn-abc",
+      "turn-abc",
+      "turn-abc",
+    ]);
+  });
+
+  it("folds turn_id as undefined for a pre-turn-id transcript (additive back-compat)", () => {
+    const feed = historyToFeed([{ role: "user", content: "hi", ts: 1 }]);
+    expect(feed[0].turn_id).toBeUndefined();
+  });
+
   it("renders displayText as the user bubble when the stored prompt carried hidden text", () => {
     const feed = historyToFeed([
       {

--- a/packages/sdk/src/modules/turns/history.ts
+++ b/packages/sdk/src/modules/turns/history.ts
@@ -34,6 +34,17 @@ export interface FeedFrame {
    * crosses the SDK/bridge boundary unchanged.
    */
   ts?: number;
+  /**
+   * The turn this frame belongs to — the source `ChatMessage.turnId`, the SAME
+   * id the live stream stamps on the turn's wire frames (`WireFrame.turnId`).
+   * Persisted on both the user and assistant messages of a turn, so a client
+   * resyncing across a turn boundary can match a backfilled history frame to a
+   * live turn (`convergence/README.md`: the `sync{resync:true}` → refetch-history
+   * recovery path). Optional/additive: absent for pre-turn-id transcripts and
+   * for frames not tied to a message. Plain JSON — it crosses the SDK/bridge
+   * boundary unchanged.
+   */
+  turn_id?: string;
 }
 
 /** Identity provider map — the SDK default (carry the pi id through). */
@@ -55,6 +66,10 @@ export function historyToFeed(
     // Every frame folded from a message carries that message's epoch-ms `ts`
     // (additive; a pre-`ts` transcript simply folds frames with `ts: undefined`).
     const ts = m.ts;
+    // …and that message's `turnId`, so a backfilled frame can be matched to the
+    // turn a resyncing client watched live (additive; a pre-turn-id transcript
+    // folds frames with `turn_id: undefined`). Threaded exactly like `ts`.
+    const turn_id = m.turnId;
     if (m.role === "user") {
       out.push({
         feed_type: "user_message",
@@ -64,6 +79,7 @@ export function historyToFeed(
         data: m.displayText ?? m.content,
         author: m.author,
         ts,
+        turn_id,
       });
       continue;
     }
@@ -78,6 +94,7 @@ export function historyToFeed(
           pre_tokens: m.providerSwitch.pre_tokens,
         },
         ts,
+        turn_id,
       });
     }
     // A persisted proactive compaction: replay the boundary divider so it
@@ -90,6 +107,7 @@ export function historyToFeed(
           pre_tokens: m.compaction.pre_tokens,
         },
         ts,
+        turn_id,
       });
     }
     // A persisted provider failure: replay the typed card so the inline
@@ -102,6 +120,7 @@ export function historyToFeed(
           provider: mapProvider(m.providerError.provider),
         },
         ts,
+        turn_id,
       });
     }
     // Replay the turn's reasoning BEFORE its tool calls — the live VM keeps a
@@ -109,26 +128,28 @@ export function historyToFeed(
     // (ahead of the tools), so a reload renders the mission log in the same
     // order a live watcher saw (HOU-717).
     if (m.thinking) {
-      out.push({ feed_type: "thinking", data: m.thinking, ts });
+      out.push({ feed_type: "thinking", data: m.thinking, ts, turn_id });
     }
     for (const t of m.tools ?? []) {
       out.push({
         feed_type: "tool_call",
         data: { name: t.name, input: t.input ?? {} },
         ts,
+        turn_id,
       });
       out.push({
         feed_type: "tool_result",
         data: { content: t.result ?? "", is_error: !!t.isError },
         ts,
+        turn_id,
       });
     }
     if (m.content)
-      out.push({ feed_type: "assistant_text", data: m.content, ts });
+      out.push({ feed_type: "assistant_text", data: m.content, ts, turn_id });
     // A persisted file-change summary: replay it AFTER the assistant text so
     // the chat attaches it to this turn's assistant message on reload.
     if (m.fileChanges) {
-      out.push({ feed_type: "file_changes", data: m.fileChanges, ts });
+      out.push({ feed_type: "file_changes", data: m.fileChanges, ts, turn_id });
     }
     // A turn the user interrupted persisted `stopped`: replay the standard
     // "Stopped by user" system line so the transcript reads identically after a
@@ -136,7 +157,12 @@ export function historyToFeed(
     // (`finishErr`'s system_message, after the turn's text/tools). A stopped
     // turn never carries a `pendingInteraction`, so no card competes with it.
     if (m.stopped) {
-      out.push({ feed_type: "system_message", data: STOPPED_BY_USER, ts });
+      out.push({
+        feed_type: "system_message",
+        data: STOPPED_BY_USER,
+        ts,
+        turn_id,
+      });
     }
     if (m.usage) {
       out.push({
@@ -148,6 +174,7 @@ export function historyToFeed(
           usage: m.usage,
         },
         ts,
+        turn_id,
       });
     }
   }

--- a/packages/sdk/tests/turns-history.contract.test.ts
+++ b/packages/sdk/tests/turns-history.contract.test.ts
@@ -64,11 +64,13 @@ describe("turns/history — fold persisted transcript", () => {
         data: "Ping",
         author: undefined,
         ts: expect.any(Number),
+        turn_id: expect.any(String),
       },
       {
         feed_type: "assistant_text",
         data: cannedReply("Ping"),
         ts: expect.any(Number),
+        turn_id: expect.any(String),
       },
       {
         feed_type: "final_result",
@@ -79,10 +81,18 @@ describe("turns/history — fold persisted transcript", () => {
           usage: seedUsage,
         },
         ts: expect.any(Number),
+        turn_id: expect.any(String),
       },
     ]);
     // Each folded frame carries its source ChatMessage.ts (epoch ms).
     for (const f of feed) expect(f.ts).toBeGreaterThan(0);
+    // …and its source ChatMessage.turnId: the whole settled turn — the user
+    // bubble and the assistant's frames — folds under ONE turn_id, so a client
+    // refetching history on a resync can align every backfilled entry to the
+    // live turn it belongs to (the point of W2).
+    const turnIds = new Set(feed.map((f) => f.turn_id));
+    expect(turnIds.size).toBe(1);
+    expect([...turnIds][0]).toEqual(expect.any(String));
   });
 });
 

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -1343,6 +1343,14 @@ export interface ChatHistoryEntry {
    * Absent on every other feed type and in single-player mode.
    */
   author?: { userId: string; name?: string };
+  /**
+   * The turn this entry belongs to — the source `ChatMessage.turnId`, the SAME
+   * id the live stream stamps on the turn's wire frames (`WireFrame.turnId`).
+   * Lets a client that ingests live frames and refetches history on a resync
+   * (`sync{resync:true}`) match a backfilled entry to the turn it belongs to.
+   * Optional/additive: absent on pre-turn-id transcripts and pre-field servers.
+   */
+  turn_id?: string;
 }
 
 export interface SummarizeResult {


### PR DESCRIPTION
## What

Project each folded history frame's source `ChatMessage.turnId` onto the feed entry as `turn_id`. The fold `historyToFeed` currently drops it.

## Why — completing an existing design

`convergence/README.md` (the resumable-stream design) states the intent already: `turnId` is *"persisted on the turn's user+assistant `ChatMessage`s … so a client resyncing across a turn boundary can match history to a live turn,"* with `sync{resync:true}` telling the client to *"refetch history."*

The data is already there — `ChatMessage.turnId` is persisted on both messages of a turn (`packages/protocol/src/conversation.ts`), and it's the same id the live stream stamps on wire frames (`WireFrame.turnId`). `settleFromHistory` already aligns a resync against history by `turnId`. The only gap is that the history fold never projected `turnId` onto the `FeedFrame` / `ChatHistoryEntry` it emits, so backfilled entries carried no per-turn identity. This PR closes that gap.

## Consumer motivation (secondary)

For a client that ingests the live SSE stream and uses REST history as its recovery path: when a sleeping pod makes the resume cursor unserviceable, the server sends `sync{resync:true}` and the client refetches history. `turn_id` on the folded entries is what lets that refetched history be aligned to the turns already received live, instead of guessing.

## Scope

- **Strictly additive, client-SDK only** — no server, wire, or protocol change. The server already returns `turnId` on every `ChatMessage`.
- Optional field — **absent for pre-turn-id transcripts** (covered by a test).
- `FeedFrame` (`packages/sdk/src/modules/turns/history.ts`) and its twin `ChatHistoryEntry` (`ui/engine-client/src/types.ts`) each gain `turn_id?: string`; `historyToFeed` threads it through every folded frame, mirroring how `ts` is already carried.

## Tests

- `@houston/sdk`: 371/371 — unit tests assert `turn_id` is projected onto every frame of a turn (user bubble + assistant frames share one id) and is `undefined` for a pre-turn-id transcript.
- A contract test proves the **server → REST → fold** round-trip preserves `turn_id`, and that a whole settled turn folds under a single `turn_id`.
- `houston-web`: 218/218 (translate + history-cache unaffected). Full `pnpm -r typecheck` clean; Biome clean.

## Naming

`turn_id` (snake) to match `feed_type` on the same object — consistency within the entry. Trivial to flip to `turnId` (matching the source field) if maintainers prefer.
