### PR TITLE
fix(analytics): let session replay start by not disabling flags

### DIFF
--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -297,9 +297,17 @@ function bootstrap() {
     // selectors/positions — so user content still never leaves the app.
     // The PostHog project toggles (session_recording_opt_in /
     // heatmaps_opt_in) must be ON too; either side alone captures nothing.
+    //
+    // Do NOT set `advanced_disable_flags` here. The web recorder does not
+    // start from local config alone: it waits for the remote `/flags`
+    // response, which carries the `sessionRecording` block (endpoint, sample
+    // rate, masking). Suppressing that request means the recorder never
+    // initializes, `recorder.js` is never fetched, and not a single
+    // `$snapshot` is emitted — replay looks enabled on both sides yet
+    // captures nothing, silently. That flag shipped alongside replay in
+    // 0.5.18+ and is why this project has zero recordings.
     disable_session_recording: false,
     enable_heatmaps: true,
-    advanced_disable_flags: true,
     loaded: (ph) => {
       ph.register({
         ...baseSuperProps(),


### PR DESCRIPTION
## Problem

Session replay has **never produced a single recording** in this project. Not "it broke recently" — zero rows in `raw_session_replay_events` for all time, and `$snapshot` is absent from the project taxonomy entirely. The events were never generated client-side, rather than being generated and rejected on ingest.

## Root cause

`advanced_disable_flags: true`, which shipped alongside replay itself in 0.5.18+.

The posthog-js web recorder does not start from local config alone. It waits for the remote `/flags` response, which carries the `sessionRecording` block (endpoint, sample rate, masking). `advanced_disable_flags` suppresses that request, so the recorder never initializes and `recorder.js` is never fetched. Replay reads as *enabled* on both the client and the project while silently capturing nothing.

The project-side toggles were never the problem, contrary to what the old comment claimed:

| Setting | Value |
|---|---|
| `session_recording_opt_in` | ✅ `true` |
| `heatmaps_opt_in` | ✅ `true` |
| `recording_domains` | empty (unrestricted) |

## Fix

Drop `advanced_disable_flags: true` from the desktop/web app init, and correct the misleading comment so the flag does not get reintroduced.

## Why this is safe

Nothing in the codebase reads feature flags — no `isFeatureEnabled`, `getFeatureFlag`, `useFeatureFlag`, or `onFeatureFlags` call sites anywhere. Re-enabling the `/flags` request has no behavioural side effect beyond unblocking replay.

Privacy posture is unchanged: recordings ride the same masking already applied to autocapture (`mask_all_text`, `mask_all_element_attributes`), so the captured DOM is all asterisks.

The marketing site (`website/src/_includes/base.njk`) keeps `advanced_disable_flags: true` deliberately — it opts out of replay and heatmaps — and is untouched.

## Verification

- `pnpm tsgo --noEmit` — clean
- `pnpm check:fix` — clean, no fixes applied

Post-merge, confirm recordings actually arrive rather than assuming: `$snapshot` should appear in the taxonomy and `raw_session_replay_events` should start filling.

## Known follow-up (not in this PR)

This fix only reaches users on the **cloud `0.5.x` line**. The commit that enabled replay (`e4826bf`, 16 Jul) is contained only in `cloud-*` tags — **no `v0.4.x` release contains it**. Over the last 7 days that is ~618 users on `0.4.x` who will still record nothing until the change reaches that line. Worth deciding separately whether the desktop `0.4.x` line is still maintained.

Two adjacent risks also worth tracking separately:

- Clients report `$current_url` as `tauri://localhost` / `http://tauri.localhost/`. `recording_domains` is empty today so nothing is blocked, but adding authorized domains without those origins would silently break replay again.
- 12 of 24 dashboards are pinned to `app_version semver_eq 0.5.20`, which now excludes ~83% of events. Unrelated to this fix, but it distorts the dashboards used to validate it.
