### PR TITLE
chore(ci): move the daily cut to 07:30 Bogotá

### DIFF
--- a/.github/workflows/daily-cloud-cut.yml
+++ b/.github/workflows/daily-cloud-cut.yml
@@ -33,10 +33,10 @@
 #   the write we need is the PAT's, not the job token's. (Read-only check-run
 #   queries still use GITHUB_TOKEN; those don't need to trigger anything.)
 #
-# WHY WEEKDAYS-ONLY AT 12:45 UTC:
+# WHY WEEKDAYS-ONLY AT 12:30 UTC:
 #   The team QAs in the 08:30 America/Bogota daily, which runs Mon–Fri. Bogotá is
-#   UTC-5 all year (Colombia observes no DST), so 12:45 UTC == 07:45 Bogotá. The
-#   release build takes ~30 min, so cutting at 07:45 leaves the draft ready
+#   UTC-5 all year (Colombia observes no DST), so 12:30 UTC == 07:30 Bogotá. The
+#   release build takes ~30 min, so cutting at 07:30 leaves the draft ready
 #   before 08:30. `cron: '1-5'` skips weekends — no daily, no cut.
 #
 # WHY TAG-ONLY PUSH:
@@ -54,9 +54,9 @@ name: Daily cloud cut
 
 on:
   schedule:
-    # 12:45 UTC, Mon–Fri == 07:45 America/Bogota (UTC-5, no DST). ~30-min build
+    # 12:30 UTC, Mon–Fri == 07:30 America/Bogota (UTC-5, no DST). ~30-min build
     # finishes before the 08:30 daily. See the header for the full rationale.
-    - cron: "45 12 * * 1-5"
+    - cron: "30 12 * * 1-5"
   workflow_dispatch:
     inputs:
       version:

--- a/knowledge-base/production-infra.md
+++ b/knowledge-base/production-infra.md
@@ -236,7 +236,7 @@ Every `cloud-v*` release builds a SECOND macOS DMG, `Houston_staging_<version>_u
 
 ### Daily cloud cut (`daily-cloud-cut.yml`)
 
-Cuts the `cloud-v*` release automatically at 12:45 UTC Mon–Fri (07:45 America/Bogota, no DST) so the draft is built before the 08:30 daily. Replicates the manual cut: branch from main tip → `scripts/version.sh` → `release: v<version>` commit (lives only under the tag, never pushed to protected main) → annotated `cloud-v<version>` tag pushed with the `RELEASE_CUT_TOKEN` fine-grained PAT (a default-GITHUB_TOKEN tag push would not trigger `release.yml` — recursive-workflow guard). Guards: skips quietly when main has no new commits since the last cut; refuses to cut a red main (failed completed check-runs) and pings the release Slack webhook. Manual/off-schedule cuts: `workflow_dispatch`, optional `version` override.
+Cuts the `cloud-v*` release automatically at 12:30 UTC Mon–Fri (07:30 America/Bogota, no DST) so the draft is built before the 08:30 daily. Replicates the manual cut: branch from main tip → `scripts/version.sh` → `release: v<version>` commit (lives only under the tag, never pushed to protected main) → annotated `cloud-v<version>` tag pushed with the `RELEASE_CUT_TOKEN` fine-grained PAT (a default-GITHUB_TOKEN tag push would not trigger `release.yml` — recursive-workflow guard). Guards: skips quietly when main has no new commits since the last cut; refuses to cut a red main (failed completed check-runs) and pings the release Slack webhook. Manual/off-schedule cuts: `workflow_dispatch`, optional `version` override.
 
 ### Ship train (`ship-train.yml`) — publish is the ship button
 


### PR DESCRIPTION
Cron 12:45 → 12:30 UTC (07:30 Bogotá, no DST) + comment/KB updates. Draft now ready ~08:00, more slack before the 08:30 daily. Nothing downstream keys on the time.

No Linear issue — schedule preference change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)