### PR TITLE
fix(i18n): translate the pre-auth sign-in screen (es/pt)

### DIFF
--- a/app/src/components/auth/email-code-footer.tsx
+++ b/app/src/components/auth/email-code-footer.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next";
+
 /**
  * Helper copy + secondary actions under the 6-digit code entry: where the code
  * went, resend, and switch-address. `pr-12` mirrors the send button + gap on
@@ -17,10 +19,11 @@ export function EmailCodeFooter({
   onResend: () => void;
   onChangeEmail: () => void;
 }) {
+  const { t } = useTranslation("auth");
   return (
     <>
       <p className="pr-12 text-center text-xs text-ink-muted">
-        We sent a 6-digit code to {email}.
+        {t("email.codeSentTo", { email })}
       </p>
       <div className="flex items-center justify-center gap-4 pr-12">
         <button
@@ -29,14 +32,14 @@ export function EmailCodeFooter({
           onClick={onResend}
           className="text-xs text-ink-muted underline-offset-2 hover:text-ink hover:underline disabled:opacity-50"
         >
-          Resend code
+          {t("email.resendCode")}
         </button>
         <button
           type="button"
           onClick={onChangeEmail}
           className="text-xs text-ink-muted underline-offset-2 hover:text-ink hover:underline"
         >
-          Use a different email
+          {t("email.useDifferentEmail")}
         </button>
       </div>
       {error && (

--- a/app/src/components/auth/email-sign-in.tsx
+++ b/app/src/components/auth/email-sign-in.tsx
@@ -43,6 +43,7 @@ export function EmailSignIn({
   autoSubmit?: { email: string; token: number };
 }) {
   const { t } = useTranslation("errors");
+  const { t: tAuth } = useTranslation("auth");
   const [step, setStep] = useState<Step>("email");
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
@@ -113,7 +114,9 @@ export function EmailSignIn({
       size="icon"
       variant={submitFilled ? "default" : "secondary"}
       disabled={disabled}
-      aria-label={step === "code" ? "Verify code" : "Send code"}
+      aria-label={
+        step === "code" ? tAuth("email.verifyCode") : tAuth("email.sendCode")
+      }
       className="size-10 shrink-0 rounded-full border-none!"
     >
       {pending ? (

--- a/app/src/components/auth/provider-button-row.tsx
+++ b/app/src/components/auth/provider-button-row.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@houston-ai/core";
 import { Loader2 } from "lucide-react";
 import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import { AppleIcon, GoogleIcon, MicrosoftIcon } from "./provider-brand-icons";
 
 export type Provider = "google" | "apple" | "azure";
@@ -22,10 +23,11 @@ export function ProviderButtonRow({
   pending: Provider | null;
   onSignIn: (provider: Provider) => () => void;
 }) {
+  const { t } = useTranslation("auth");
   return (
     <div className="flex items-center gap-2.5">
       <ProviderIconButton
-        label="Continue with Google"
+        label={t("continueWith", { provider: "Google" })}
         pending={pending === "google"}
         disabled={pending !== null}
         onClick={onSignIn("google")}
@@ -33,7 +35,7 @@ export function ProviderButtonRow({
         <GoogleIcon />
       </ProviderIconButton>
       <ProviderIconButton
-        label="Continue with Apple"
+        label={t("continueWith", { provider: "Apple" })}
         pending={pending === "apple"}
         disabled={pending !== null}
         onClick={onSignIn("apple")}
@@ -41,7 +43,7 @@ export function ProviderButtonRow({
         <AppleIcon />
       </ProviderIconButton>
       <ProviderIconButton
-        label="Continue with Microsoft"
+        label={t("continueWith", { provider: "Microsoft" })}
         pending={pending === "azure"}
         disabled={pending !== null}
         onClick={onSignIn("azure")}

--- a/app/src/components/auth/sign-in-screen.tsx
+++ b/app/src/components/auth/sign-in-screen.tsx
@@ -146,7 +146,7 @@ export function SignInScreen() {
             login reads the same bright way in both app themes. */}
         <div className="grid w-full max-w-3xl grid-cols-1 overflow-hidden rounded-2xl border border-line bg-card text-ink shadow-[0_4px_24px_rgba(0,0,0,0.06)] sm:grid-cols-3">
           <div className="flex flex-col gap-5 bg-card p-8 sm:col-span-2">
-            <h1 className="text-lg font-medium">Log in</h1>
+            <h1 className="text-lg font-medium">{tAuth("title")}</h1>
 
             {showContinue && lastSignIn && continueTitle && (
               <>

--- a/app/src/locales/en/auth.json
+++ b/app/src/locales/en/auth.json
@@ -1,4 +1,6 @@
 {
+  "title": "Log in",
+  "continueWith": "Continue with {{provider}}",
   "lastSignIn": {
     "continueWithProvider": "Continue with {{provider}}",
     "continueWithEmail": "Continue with your email"
@@ -6,6 +8,13 @@
   "divider": {
     "or": "or",
     "orAnotherWay": "or use another way"
+  },
+  "email": {
+    "sendCode": "Send code",
+    "verifyCode": "Verify code",
+    "codeSentTo": "We sent a 6-digit code to {{email}}.",
+    "resendCode": "Resend code",
+    "useDifferentEmail": "Use a different email"
   },
   "referral": {
     "title": "Share the love",

--- a/app/src/locales/es/auth.json
+++ b/app/src/locales/es/auth.json
@@ -1,4 +1,6 @@
 {
+  "title": "Inicia sesión",
+  "continueWith": "Continuar con {{provider}}",
   "lastSignIn": {
     "continueWithProvider": "Continuar con {{provider}}",
     "continueWithEmail": "Continuar con tu correo"
@@ -6,6 +8,13 @@
   "divider": {
     "or": "o",
     "orAnotherWay": "o usa otra forma"
+  },
+  "email": {
+    "sendCode": "Enviar código",
+    "verifyCode": "Verificar código",
+    "codeSentTo": "Te enviamos un código de 6 dígitos a {{email}}.",
+    "resendCode": "Reenviar código",
+    "useDifferentEmail": "Usa otro correo"
   },
   "referral": {
     "title": "Comparte lo bueno",

--- a/app/src/locales/pt/auth.json
+++ b/app/src/locales/pt/auth.json
@@ -1,4 +1,6 @@
 {
+  "title": "Entrar",
+  "continueWith": "Continuar com {{provider}}",
   "lastSignIn": {
     "continueWithProvider": "Continuar com {{provider}}",
     "continueWithEmail": "Continuar com seu e-mail"
@@ -6,6 +8,13 @@
   "divider": {
     "or": "ou",
     "orAnotherWay": "ou use outra forma"
+  },
+  "email": {
+    "sendCode": "Enviar código",
+    "verifyCode": "Verificar código",
+    "codeSentTo": "Enviamos um código de 6 dígitos para {{email}}.",
+    "resendCode": "Reenviar código",
+    "useDifferentEmail": "Usar outro e-mail"
   },
   "referral": {
     "title": "Compartilhe o que é bom",


### PR DESCRIPTION
## What

The first-run flow (language gate, disclaimer, onboarding) was fully localized except the pre-auth sign-in screen: a Spanish or Portuguese user picked their language and then hit "Log in / Continue with Google / We sent a 6-digit code..." in English. This was reported as "onboarding is only in English".

## How

- Extends the existing `auth` namespace (en/es/pt) with `title`, `continueWith` ({{provider}} interpolation, brand names untranslated), and the `email.*` code-entry strings.
- Wires `sign-in-screen.tsx`, `provider-button-row.tsx`, `email-sign-in.tsx` (aria-labels), and `email-code-footer.tsx` through `t()`.
- es = Latin-American neutral (tú), pt = Brazilian (você), no em dashes.

## Verification

- `cd app && pnpm tsgo --noEmit` — pass
- `cd app && pnpm check-locales` — pass (all namespaces in sync)
- Biome clean; English output is byte-identical to the old hardcoded strings, so the sign-in e2e specs are unaffected.

Fixes HOU-756

🤖 Generated with [Claude Code](https://claude.com/claude-code)