### PR TITLE
fix: surface the real cause when a creator profile save or photo upload fails

### DIFF
--- a/app/src/components/store-view/profile/avatar-upload-field.tsx
+++ b/app/src/components/store-view/profile/avatar-upload-field.tsx
@@ -6,6 +6,8 @@ import { getEngine } from "../../../lib/engine";
 import { reportError } from "../../../lib/error-toast";
 import { cropAvatarToBlob } from "../../../lib/image-crop";
 import { useUIStore } from "../../../stores/ui";
+import { gatewayErrorCode } from "./save-error";
+import { avatarErrorKey } from "./save-error-map";
 
 /** Image types the gateway accepts for an avatar (`POST /me/avatar`). */
 const ALLOWED_AVATAR_TYPES = ["image/png", "image/jpeg", "image/webp"];
@@ -48,8 +50,9 @@ export function AvatarUploadField({
   const locked = busy || disabled || claiming;
 
   const fail = (command: string, message: string, err: unknown) => {
-    reportError(command, message, err);
-    addToast({ title: t("profile.saveFailed"), variant: "error" });
+    const code = gatewayErrorCode(err);
+    reportError(command, `${message} (${code ?? "unknown"})`, err);
+    addToast({ title: t(avatarErrorKey(code)), variant: "error" });
   };
 
   const handlePick = async (file: File) => {

--- a/app/src/components/store-view/profile/creator-profile-editor.tsx
+++ b/app/src/components/store-view/profile/creator-profile-editor.tsx
@@ -25,7 +25,8 @@ import { AvatarUploadField } from "./avatar-upload-field";
 import { BioField } from "./bio-field";
 import { HandleField } from "./handle-field";
 import { buildProfilePatch, canSaveProfile } from "./profile-form";
-import { gatewayErrorCode, HANDLE_ERROR_KEYS } from "./save-error";
+import { gatewayErrorCode } from "./save-error";
+import { HANDLE_ERROR_KEYS, saveErrorKey } from "./save-error-map";
 import { SocialsEditor } from "./socials-editor";
 
 /**
@@ -113,7 +114,7 @@ export function CreatorProfileEditorDialog({
       );
       const handleKey = code ? HANDLE_ERROR_KEYS[code] : undefined;
       if (handleKey) setHandleServerError(t(handleKey));
-      else addToast({ title: t("profile.saveFailed"), variant: "error" });
+      else addToast({ title: t(saveErrorKey(code)), variant: "error" });
     } finally {
       setSaving(false);
     }

--- a/app/src/components/store-view/profile/save-error-map.ts
+++ b/app/src/components/store-view/profile/save-error-map.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure gateway-token → i18n-key maps for the creator-profile editor, split out
+ * from `save-error.ts` (which imports the engine-client value to read the token)
+ * so the node test runner loads these with zero resolution cost — the same split
+ * `profile-form.ts` keeps for the form logic. Every known token gets specific,
+ * friendly copy; only a genuinely unknown token falls back to a generic string,
+ * and even that generic is scoped (save vs. photo) so no failure lies about what
+ * broke.
+ */
+
+/** Handle-specific gateway tokens → the localized handle-field message key.
+ *  A token absent from this map is a non-handle failure (→ a generic toast). */
+export const HANDLE_ERROR_KEYS: Record<string, string> = {
+  handle_taken: "profile.handleTaken",
+  handle_reserved: "profile.handleReserved",
+  invalid_handle: "profile.handleInvalid",
+  handle_change_too_soon: "profile.handleChangeTooSoon",
+};
+
+/** Non-handle `PATCH /me/profile` tokens → their specific toast key. `bio_too_long`
+ *  and `invalid_link` are also guarded client-side, so they only reach here on a
+ *  contract skew; `user_not_found` covers the missing account row on first save. */
+const SAVE_ERROR_KEYS: Record<string, string> = {
+  bio_too_long: "profile.bioTooLong",
+  invalid_link: "profile.invalidLink",
+  display_name_required: "profile.displayNameRequired",
+  user_not_found: "profile.saveFailedAccount",
+};
+
+/** Avatar `POST/DELETE /me/avatar` tokens → their specific toast key. `no_profile`
+ *  reuses the claim hint (save the profile first); the three type/format tokens
+ *  share the "use a PNG, JPEG or WebP" copy. */
+const AVATAR_ERROR_KEYS: Record<string, string> = {
+  no_profile: "profile.avatarClaimHint",
+  image_too_large: "profile.avatarTooLarge",
+  unsupported_media_type: "profile.avatarBadType",
+  invalid_image: "profile.avatarBadType",
+  no_file: "profile.avatarBadType",
+};
+
+/**
+ * The toast key for a non-handle profile-save failure. Handle tokens are handled
+ * field-level by the caller (via {@link HANDLE_ERROR_KEYS}); every other known
+ * token gets specific copy, and an unknown/null token (network, session, a 500
+ * "gateway error") falls back to the generic save copy.
+ */
+export function saveErrorKey(code: string | null): string {
+  return (code && SAVE_ERROR_KEYS[code]) || "profile.saveFailed";
+}
+
+/**
+ * The toast key for an avatar upload/remove failure. An unknown/null token falls
+ * back to a photo-specific generic (`profile.avatarFailed`), never the
+ * profile-save copy, so a photo failure never claims the whole profile failed.
+ */
+export function avatarErrorKey(code: string | null): string {
+  return (code && AVATAR_ERROR_KEYS[code]) || "profile.avatarFailed";
+}

--- a/app/src/components/store-view/profile/save-error.ts
+++ b/app/src/components/store-view/profile/save-error.ts
@@ -1,20 +1,10 @@
 import { isHoustonEngineError } from "@houston-ai/engine-client";
 
 /**
- * Maps a failed profile-save to the editor's response. Kept out of
- * `profile-form.ts` (which stays runtime-dependency-free for the node test
- * runner) because reading the gateway token needs the engine-client value
- * import.
+ * Reads the machine token from a failed profile/avatar mutation. Kept out of the
+ * pure `save-error-map.ts` (which stays runtime-dependency-free for the node test
+ * runner) because reading the gateway token needs the engine-client value import.
  */
-
-/** Handle-specific gateway tokens → the localized handle-field message key.
- *  A token absent from this map is a non-handle failure (→ a generic toast). */
-export const HANDLE_ERROR_KEYS: Record<string, string> = {
-  handle_taken: "profile.handleTaken",
-  handle_reserved: "profile.handleReserved",
-  invalid_handle: "profile.handleInvalid",
-  handle_change_too_soon: "profile.handleChangeTooSoon",
-};
 
 /**
  * The machine token from an agentstore-gateway error. The gateway returns a

--- a/app/src/locales/en/store.json
+++ b/app/src/locales/en/store.json
@@ -104,6 +104,7 @@
     "avatarTooLarge": "That image is too large. Pick one under 2 MB.",
     "avatarBadType": "Use a PNG, JPEG or WebP image.",
     "avatarClaimHint": "Save your profile first to add a photo.",
+    "avatarFailed": "Your photo could not be uploaded. Please try again.",
     "socials": {
       "x": "X",
       "youtube": "YouTube",
@@ -118,6 +119,10 @@
     "saving": "Saving...",
     "saved": "Profile saved",
     "saveFailed": "Your profile could not be saved. Please try again.",
+    "saveFailedAccount": "We could not find your account. Sign out, sign back in, and try again.",
+    "bioTooLong": "Your bio is too long. Make it shorter and try again.",
+    "invalidLink": "One of your links is not a valid web address. Check them and try again.",
+    "displayNameRequired": "Add a display name to save your profile.",
     "cancel": "Cancel",
     "claimCta": "Claim your handle",
     "claimBody": "Pick a public @handle so people can find every agent you publish in one place."

--- a/app/src/locales/es/store.json
+++ b/app/src/locales/es/store.json
@@ -104,6 +104,7 @@
     "avatarTooLarge": "Esa imagen es muy grande. Elige una de menos de 2 MB.",
     "avatarBadType": "Usa una imagen PNG, JPEG o WebP.",
     "avatarClaimHint": "Guarda tu perfil primero para agregar una foto.",
+    "avatarFailed": "No se pudo subir tu foto. Inténtalo de nuevo.",
     "socials": {
       "x": "X",
       "youtube": "YouTube",
@@ -118,6 +119,10 @@
     "saving": "Guardando...",
     "saved": "Perfil guardado",
     "saveFailed": "No se pudo guardar tu perfil. Inténtalo de nuevo.",
+    "saveFailedAccount": "No encontramos tu cuenta. Cierra sesión, vuelve a entrar e inténtalo de nuevo.",
+    "bioTooLong": "Tu biografía es muy larga. Acórtala e inténtalo de nuevo.",
+    "invalidLink": "Uno de tus enlaces no es una dirección web válida. Revísalos e inténtalo de nuevo.",
+    "displayNameRequired": "Agrega un nombre visible para guardar tu perfil.",
     "cancel": "Cancelar",
     "claimCta": "Reclamar mi handle",
     "claimBody": "Elige un @handle público para que la gente encuentre en un solo lugar todos los agentes que publicas."

--- a/app/src/locales/pt/store.json
+++ b/app/src/locales/pt/store.json
@@ -104,6 +104,7 @@
     "avatarTooLarge": "Essa imagem é muito grande. Escolha uma com menos de 2 MB.",
     "avatarBadType": "Use uma imagem PNG, JPEG ou WebP.",
     "avatarClaimHint": "Salve seu perfil primeiro para adicionar uma foto.",
+    "avatarFailed": "Não foi possível enviar sua foto. Tente de novo.",
     "socials": {
       "x": "X",
       "youtube": "YouTube",
@@ -118,6 +119,10 @@
     "saving": "Salvando...",
     "saved": "Perfil salvo",
     "saveFailed": "Não foi possível salvar seu perfil. Tente de novo.",
+    "saveFailedAccount": "Não encontramos sua conta. Saia, entre de novo e tente outra vez.",
+    "bioTooLong": "Sua biografia é muito longa. Deixe mais curta e tente de novo.",
+    "invalidLink": "Um dos seus links não é um endereço web válido. Confira e tente de novo.",
+    "displayNameRequired": "Adicione um nome de exibição para salvar seu perfil.",
     "cancel": "Cancelar",
     "claimCta": "Reservar meu handle",
     "claimBody": "Escolha um @handle público para as pessoas encontrarem em um só lugar todos os agentes que você publica."

--- a/app/tests/save-error-map.test.ts
+++ b/app/tests/save-error-map.test.ts
@@ -1,0 +1,72 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  avatarErrorKey,
+  HANDLE_ERROR_KEYS,
+  saveErrorKey,
+} from "../src/components/store-view/profile/save-error-map.ts";
+
+describe("HANDLE_ERROR_KEYS", () => {
+  it("maps every handle token to its field message key", () => {
+    strictEqual(HANDLE_ERROR_KEYS.handle_taken, "profile.handleTaken");
+    strictEqual(HANDLE_ERROR_KEYS.handle_reserved, "profile.handleReserved");
+    strictEqual(HANDLE_ERROR_KEYS.invalid_handle, "profile.handleInvalid");
+    strictEqual(
+      HANDLE_ERROR_KEYS.handle_change_too_soon,
+      "profile.handleChangeTooSoon",
+    );
+  });
+
+  it("has no entry for a non-handle token", () => {
+    strictEqual(HANDLE_ERROR_KEYS.bio_too_long, undefined);
+  });
+});
+
+describe("saveErrorKey", () => {
+  it("maps every known non-handle save token to its specific key", () => {
+    strictEqual(saveErrorKey("bio_too_long"), "profile.bioTooLong");
+    strictEqual(saveErrorKey("invalid_link"), "profile.invalidLink");
+    strictEqual(
+      saveErrorKey("display_name_required"),
+      "profile.displayNameRequired",
+    );
+    strictEqual(saveErrorKey("user_not_found"), "profile.saveFailedAccount");
+  });
+
+  it("falls back to the generic save copy for null (network/session)", () => {
+    strictEqual(saveErrorKey(null), "profile.saveFailed");
+  });
+
+  it("falls back to the generic save copy for an unknown token (500)", () => {
+    strictEqual(saveErrorKey("gateway error"), "profile.saveFailed");
+    strictEqual(saveErrorKey("no_profile"), "profile.saveFailed");
+  });
+});
+
+describe("avatarErrorKey", () => {
+  it("reuses the claim hint for a not-yet-saved profile", () => {
+    strictEqual(avatarErrorKey("no_profile"), "profile.avatarClaimHint");
+  });
+
+  it("maps the size token to the too-large copy", () => {
+    strictEqual(avatarErrorKey("image_too_large"), "profile.avatarTooLarge");
+  });
+
+  it("maps every type/format token to the bad-type copy", () => {
+    strictEqual(
+      avatarErrorKey("unsupported_media_type"),
+      "profile.avatarBadType",
+    );
+    strictEqual(avatarErrorKey("invalid_image"), "profile.avatarBadType");
+    strictEqual(avatarErrorKey("no_file"), "profile.avatarBadType");
+  });
+
+  it("falls back to a photo-specific generic, never the save copy", () => {
+    strictEqual(avatarErrorKey(null), "profile.avatarFailed");
+    strictEqual(avatarErrorKey("gateway error"), "profile.avatarFailed");
+    strictEqual(
+      avatarErrorKey("some_rate_limit_token"),
+      "profile.avatarFailed",
+    );
+  });
+});

--- a/knowledge-base/agent-store.md
+++ b/knowledge-base/agent-store.md
@@ -276,7 +276,12 @@ Houston surfaces (SDK: profile/creator/analytics methods on
   app-wide from the user menu, opened via the `creatorEditorOpen` ui-store flag
   (user menu, My agents header, publish wizard). Handle picker with debounced
   availability, avatar pick → `app/src/lib/image-crop.ts` (pure canvas
-  center-crop to 512px, no deps) → upload, socials, bio.
+  center-crop to 512px, no deps) → upload, socials, bio. Failure surfacing
+  (HOU-864/865): every known gateway token maps to specific copy via the pure
+  maps in `store-view/profile/save-error-map.ts` (handle tokens → field-level
+  message; other save tokens + avatar tokens → specific toasts; unknowns fall
+  back to a save-scoped or photo-scoped generic — never cross-labeled).
+  `save-error.ts` holds only the engine-client token reader.
 - **In-app creator pane** `store-view/creator/` — full-pane profile (agents
   grid, socials, `VerifiedBadge` from `@houston-ai/core` — inventory-tracked)
   opened via the `storeCreatorHandle` one-shot: from creator chips on rows and


### PR DESCRIPTION
## What

The in-app Agent Store profile editor collapsed every non-handle save failure into one generic "Your profile could not be saved." toast, and avatar upload/remove failures reused that same wrong copy. This hid the real cause from users (and from bug reports: HOU-864/HOU-865 both arrived with no actionable detail) and violated the repo's no-silent-failures beta policy.

- New pure module `app/src/components/store-view/profile/save-error-map.ts` (node-tested, dependency-free, following the `profile-form.ts` split): handle tokens keep their field-level messages; `bio_too_long`, `invalid_link`, `display_name_required`, `user_not_found` get specific toasts; avatar tokens map to photo-scoped copy (`no_profile` reuses the save-first hint, size/type tokens reuse existing strings); unknown tokens fall back to a save-scoped or photo-scoped generic, never cross-labeled.
- `save-error.ts` now holds only the engine-client token reader; editor and avatar field wire through the maps. Sentry `reportError` calls keep the raw token.
- 5 new strings each in en/es/pt `store.json` (no em dashes, `check-locales` green).

`user_not_found` covers the gateway's new missing-account-row code from the sibling backend fix: gethouston/cloud#173 (HOU-865).

## Tests / verification

- `app/tests/save-error-map.test.ts`: 9 tests, every token → expected key + fallbacks.
- `pnpm check` (Biome) exit 0 · `cd app && pnpm tsgo --noEmit` · `pnpm check-locales` ("All locales in sync") · full `app` suite: 1982 pass, 0 fail.

## Docs

`knowledge-base/agent-store.md` in-app editor section updated with the error-surfacing map.

Fixes HOU-864

🤖 Generated with [Claude Code](https://claude.com/claude-code)