### PR TITLE
feat(migration): emoji space-invaders + progress screen polish

### DIFF
--- a/app/src/components/onboarding/cloud-migration/progress-agent-row.tsx
+++ b/app/src/components/onboarding/cloud-migration/progress-agent-row.tsx
@@ -1,0 +1,92 @@
+import { AsyncButton, cn } from "@houston-ai/core";
+import type { TFunction } from "i18next";
+import { Check, CircleAlert, Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { MigrationTask } from "../../../lib/cloud-migration";
+import type { AgentMigrationProgress } from "../../../lib/cloud-migration-progress";
+
+/**
+ * One agent's row in the migration attention panel (HOU-719) — shown only when
+ * a run needs the user (a failed agent): status icon, live step label, and the
+ * per-row Retry. The happy path renders the aggregate wait screen instead
+ * (see `progress-screen.tsx`).
+ */
+
+function stepLabel(
+  t: TFunction<"migration">,
+  p: AgentMigrationProgress,
+): string {
+  switch (p.step) {
+    case "pending":
+      return t("progress.step.pending");
+    case "creating":
+      return t("progress.step.creating");
+    case "warming":
+      return t("progress.step.warming");
+    case "uploading":
+      return t("progress.step.uploading", {
+        current: Math.max(p.chunkIndex, 1),
+        total: Math.max(p.chunkCount, 1),
+      });
+    case "finalizing":
+      return t("progress.step.finalizing");
+    case "done":
+      return t("progress.step.done");
+    case "error":
+      return t("progress.step.error");
+  }
+}
+
+/** The steps that mean "work is actively happening on this agent". */
+export const RUNNING: ReadonlySet<AgentMigrationProgress["step"]> = new Set([
+  "creating",
+  "warming",
+  "uploading",
+  "finalizing",
+]);
+
+export function AgentRow({
+  task,
+  progress,
+  onRetry,
+}: {
+  task: MigrationTask;
+  progress: AgentMigrationProgress;
+  onRetry: () => Promise<void>;
+}) {
+  const { t } = useTranslation("migration");
+  const running = RUNNING.has(progress.step);
+  return (
+    <div className="flex items-center gap-3 rounded-xl bg-chip px-4 py-3">
+      <span className="shrink-0">
+        {progress.step === "done" ? (
+          <Check className="size-4 text-ink" />
+        ) : progress.step === "error" ? (
+          <CircleAlert className="size-4 text-danger" />
+        ) : (
+          <Loader2
+            className={cn("size-4 text-ink-muted", running && "animate-spin")}
+          />
+        )}
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{task.targetName}</p>
+        <p className="truncate text-xs text-ink-muted">
+          {progress.step === "error" && progress.errorMessage
+            ? progress.errorMessage
+            : stepLabel(t, progress)}
+        </p>
+      </div>
+      {progress.step === "error" && (
+        <AsyncButton
+          variant="outline"
+          size="sm"
+          className="shrink-0 rounded-full"
+          onClick={() => onRetry()}
+        >
+          {t("progress.retry")}
+        </AsyncButton>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/onboarding/cloud-migration/progress-screen.tsx
+++ b/app/src/components/onboarding/cloud-migration/progress-screen.tsx
@@ -184,6 +184,9 @@ export function ProgressScreen({ onDefer }: { onDefer?: () => void }) {
                   {t("progress.playCaption")}
                 </p>
                 <SpaceInvaders />
+                <p className="text-center text-[11px] text-ink-muted">
+                  {t("progress.playHint")}
+                </p>
               </div>
             )}
           </div>

--- a/app/src/components/onboarding/cloud-migration/progress-screen.tsx
+++ b/app/src/components/onboarding/cloud-migration/progress-screen.tsx
@@ -1,52 +1,15 @@
-import { AsyncButton, Button, cn } from "@houston-ai/core";
+import { AsyncButton, Button } from "@houston-ai/core";
 import { useReducedMotion } from "framer-motion";
-import type { TFunction } from "i18next";
-import { Check, CircleAlert, Loader2 } from "lucide-react";
 import type { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
-import type { MigrationTask } from "../../../lib/cloud-migration";
-import {
-  type AgentMigrationProgress,
-  computeOverallProgress,
-} from "../../../lib/cloud-migration-progress";
+import { computeOverallProgress } from "../../../lib/cloud-migration-progress";
 import { useCloudMigrationStore } from "../../../stores/cloud-migration";
 import { OrbitLoader } from "../../space/orbit-loader";
 import { MigrationProgressBar } from "./migration-progress-bar";
+import { AgentRow, RUNNING } from "./progress-agent-row";
 import { SpaceInvaders } from "./space-invaders";
 import { MigrationStatusCycle } from "./status-cycle";
 import { WizardFrame } from "./wizard-frame";
-
-function stepLabel(
-  t: TFunction<"migration">,
-  p: AgentMigrationProgress,
-): string {
-  switch (p.step) {
-    case "pending":
-      return t("progress.step.pending");
-    case "creating":
-      return t("progress.step.creating");
-    case "warming":
-      return t("progress.step.warming");
-    case "uploading":
-      return t("progress.step.uploading", {
-        current: Math.max(p.chunkIndex, 1),
-        total: Math.max(p.chunkCount, 1),
-      });
-    case "finalizing":
-      return t("progress.step.finalizing");
-    case "done":
-      return t("progress.step.done");
-    case "error":
-      return t("progress.step.error");
-  }
-}
-
-const RUNNING: ReadonlySet<AgentMigrationProgress["step"]> = new Set([
-  "creating",
-  "warming",
-  "uploading",
-  "finalizing",
-]);
 
 // The OrbitLoader draws entirely from --ht-space-foreground/-star (white tones
 // tuned for the space photo). On the light wizard those would vanish, so for
@@ -56,52 +19,6 @@ const ORBIT_INK_VARS: CSSProperties = {
   "--ht-space-foreground": "var(--ht-ink)",
   "--ht-space-star": "var(--ht-ink-muted)",
 } as CSSProperties;
-
-function AgentRow({
-  task,
-  progress,
-  onRetry,
-}: {
-  task: MigrationTask;
-  progress: AgentMigrationProgress;
-  onRetry: () => Promise<void>;
-}) {
-  const { t } = useTranslation("migration");
-  const running = RUNNING.has(progress.step);
-  return (
-    <div className="flex items-center gap-3 rounded-xl bg-chip px-4 py-3">
-      <span className="shrink-0">
-        {progress.step === "done" ? (
-          <Check className="size-4 text-ink" />
-        ) : progress.step === "error" ? (
-          <CircleAlert className="size-4 text-danger" />
-        ) : (
-          <Loader2
-            className={cn("size-4 text-ink-muted", running && "animate-spin")}
-          />
-        )}
-      </span>
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium">{task.targetName}</p>
-        <p className="truncate text-xs text-ink-muted">
-          {progress.step === "error" && progress.errorMessage
-            ? progress.errorMessage
-            : stepLabel(t, progress)}
-        </p>
-      </div>
-      {progress.step === "error" && (
-        <AsyncButton
-          variant="outline"
-          size="sm"
-          className="shrink-0 rounded-full"
-          onClick={() => onRetry()}
-        >
-          {t("progress.retry")}
-        </AsyncButton>
-      )}
-    </div>
-  );
-}
 
 /** The quiet "Migrate later" escape hatch — the same `onDefer` everywhere:
  *  while the run is still going AND on every error state, so a user stuck on
@@ -243,16 +160,26 @@ export function ProgressScreen({ onDefer }: { onDefer?: () => void }) {
                 }
               />
               {!indeterminate && (
-                <p className="text-xs text-ink-muted">
-                  {t("progress.keepOpen")}
-                </p>
+                <div className="flex flex-col gap-1">
+                  {tasks.length > 1 && (
+                    <p className="text-xs text-ink-muted">
+                      {t("progress.overall", {
+                        done: done.length,
+                        total: tasks.length,
+                      })}
+                    </p>
+                  )}
+                  <p className="text-xs text-ink-muted">
+                    {t("progress.keepOpen")}
+                  </p>
+                </div>
               )}
             </div>
             {/* The roomy wait is a chance to play: a tiny Space Invaders under
                 the bar (subtle, card-width). It self-nulls under reduced motion,
                 so the invitation is gated on the same signal to never orphan. */}
             {!indeterminate && !reduce && (
-              <div className="mt-2 flex w-full max-w-xs flex-col items-center gap-2">
+              <div className="mt-2 flex w-full max-w-xs flex-col items-center gap-2 rounded-2xl border border-line bg-card/60 p-4">
                 <p className="text-xs text-ink-muted">
                   {t("progress.playCaption")}
                 </p>

--- a/app/src/components/onboarding/cloud-migration/space-invaders-defs.ts
+++ b/app/src/components/onboarding/cloud-migration/space-invaders-defs.ts
@@ -1,0 +1,62 @@
+/**
+ * Geometry constants and state shapes for the {@link SpaceInvaders} easter egg
+ * — the data half of the game. The rules (`spawnInvaders`, `step`, …) live in
+ * `space-invaders-model.ts`; frame rendering in `space-invaders-draw.ts`.
+ */
+
+// Fixed internal resolution; the canvas is scaled to its container via CSS and
+// devicePixelRatio, so play reads crisp at any width without re-laying-out.
+export const W = 320;
+export const H = 240;
+export const ROWS = 4;
+export const COLS = 8;
+export const INV_W = 16;
+export const INV_H = 14;
+export const GAP_X = 14;
+export const GAP_Y = 8;
+export const SHIP_W = 22;
+export const SHIP_Y = H - 16;
+export const SHIP_SPEED = 150; // px/s from held keys
+export const BULLET_SPEED = 260;
+export const BOMB_SPEED = 90;
+/** Seconds a kill's 💥 stays on screen (fading) before it is pruned. */
+export const EXPLOSION_TTL = 0.35;
+/** Most player bullets allowed in flight at once. */
+export const MAX_BULLETS = 3;
+
+export interface Invader {
+  x: number;
+  y: number;
+  /** 0-based spawn row — picks the invader's sprite. */
+  row: number;
+  alive: boolean;
+}
+export interface Shot {
+  x: number;
+  y: number;
+}
+export interface Explosion {
+  x: number;
+  y: number;
+  /** Seconds since the kill; render alpha fades toward EXPLOSION_TTL. */
+  age: number;
+}
+export interface GameState {
+  invaders: Invader[];
+  /** Swarm horizontal direction, +1 / -1. */
+  dir: number;
+  shipX: number;
+  bullets: Shot[];
+  bombs: Shot[];
+  explosions: Explosion[];
+  score: number;
+  over: boolean;
+  /** Seconds until the next enemy bomb may drop. */
+  bombTimer: number;
+}
+/** Per-frame input: held movement keys + the elapsed seconds. */
+export interface StepInput {
+  left: boolean;
+  right: boolean;
+  dt: number;
+}

--- a/app/src/components/onboarding/cloud-migration/space-invaders-draw.ts
+++ b/app/src/components/onboarding/cloud-migration/space-invaders-draw.ts
@@ -1,0 +1,92 @@
+/**
+ * Canvas renderer for the {@link SpaceInvaders} shell — every fillText/fillRect
+ * of one frame, split out so the component keeps to input wiring and the rAF
+ * loop. Pure with respect to the model: it reads {@link GameState}, never
+ * mutates it (the swarm's bob is applied at render only — collision stays
+ * authoritative on model coords).
+ */
+
+import {
+  COLS,
+  EXPLOSION_TTL,
+  type GameState,
+  H,
+  INV_H,
+  INV_W,
+  SHIP_W,
+  SHIP_Y,
+  W,
+} from "./space-invaders-defs.ts";
+
+/** Per-spawn-row invader sprites, top to bottom. */
+const INVADER_SPRITES = ["👾", "🛸", "👽", "🤖"];
+
+export interface DrawOptions {
+  /** Resolved ink color (the canvas's CSS `color`) for HUD text and shots. */
+  color: string;
+  /** All-time best score, shown top-right. */
+  best: number;
+  /** Elapsed play seconds — drives the swarm's render-only bob. */
+  elapsed: number;
+  /** Localized game-over copy: headline (with score) + play-again hint. */
+  overLine: string;
+  playAgainLine: string;
+}
+
+/** Render one frame of `state` onto `canvas` (already sized to DPR). */
+export function drawGame(
+  ctx: CanvasRenderingContext2D,
+  canvas: HTMLCanvasElement,
+  state: GameState,
+  opts: DrawOptions,
+): void {
+  ctx.setTransform(canvas.width / W, 0, 0, canvas.height / H, 0, 0);
+  ctx.clearRect(0, 0, W, H);
+  ctx.fillStyle = opts.color;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.font = `${INV_W}px system-ui, sans-serif`;
+  state.invaders.forEach((inv, index) => {
+    if (!inv.alive) return;
+    const bob = Math.sin(opts.elapsed * 3 + (index % COLS) * 0.7) * 1.5;
+    ctx.fillText(
+      INVADER_SPRITES[inv.row % INVADER_SPRITES.length],
+      inv.x + INV_W / 2,
+      inv.y + INV_H / 2 + bob,
+    );
+  });
+  for (const explosion of state.explosions) {
+    ctx.globalAlpha = 1 - explosion.age / EXPLOSION_TTL;
+    ctx.font = `${14 + (explosion.age / EXPLOSION_TTL) * 6}px system-ui, sans-serif`;
+    ctx.fillText("💥", explosion.x, explosion.y);
+  }
+  ctx.globalAlpha = 1;
+  for (const bullet of state.bullets) {
+    ctx.beginPath();
+    ctx.roundRect(bullet.x - 1, bullet.y - 6, 2, 6, 1);
+    ctx.fill();
+  }
+  ctx.font = "10px system-ui, sans-serif";
+  for (const bomb of state.bombs) ctx.fillText("⚡", bomb.x, bomb.y + 5);
+  // The rocket glyph natively points up-right 45°; rotate it to point up.
+  ctx.save();
+  ctx.translate(state.shipX, SHIP_Y);
+  ctx.rotate(-Math.PI / 4);
+  ctx.font = `${SHIP_W}px system-ui, sans-serif`;
+  ctx.fillText("🚀", 0, 0);
+  ctx.restore();
+  ctx.globalAlpha = 0.7;
+  ctx.font = "11px system-ui, sans-serif";
+  ctx.textAlign = "left";
+  ctx.fillText(`⭐ ${state.score}`, 8, 10);
+  ctx.textAlign = "right";
+  ctx.fillText(`🏆 ${opts.best}`, W - 8, 10);
+  ctx.globalAlpha = 1;
+  if (state.over) {
+    ctx.textAlign = "center";
+    ctx.font = "10px system-ui, sans-serif";
+    ctx.fillText(opts.overLine, W / 2, H / 2 - 6);
+    ctx.font = "8px system-ui, sans-serif";
+    ctx.fillText(opts.playAgainLine, W / 2, H / 2 + 8);
+  }
+}

--- a/app/src/components/onboarding/cloud-migration/space-invaders-model.ts
+++ b/app/src/components/onboarding/cloud-migration/space-invaders-model.ts
@@ -1,57 +1,32 @@
 /**
- * Pure model for the {@link SpaceInvaders} canvas easter egg — every rule of
- * the game that can be reasoned about without a canvas: the fixed-resolution
- * geometry, the state shape, and a deterministic `step`. The React/canvas shell
+ * Pure rules for the {@link SpaceInvaders} canvas easter egg — everything about
+ * the game that can be reasoned about without a canvas: spawning, movement,
+ * collisions, and a deterministic `step`. Geometry constants and state shapes
+ * live in `space-invaders-defs.ts`; the React/canvas shell
  * (`space-invaders.tsx`) owns only rendering and input wiring, so this file is
  * unit-testable under `node --test` (see `app/tests/space-invaders-model.ts`).
  */
 
-// Fixed internal resolution; the canvas is scaled to its container via CSS and
-// devicePixelRatio, so play reads crisp at any width without re-laying-out.
-export const W = 320;
-export const H = 240;
-export const ROWS = 4;
-export const COLS = 8;
-export const INV_W = 16;
-export const INV_H = 10;
-const GAP_X = 14;
-const GAP_Y = 12;
-export const SHIP_W = 22;
-export const SHIP_H = 8;
-export const SHIP_Y = H - 16;
-const SHIP_SPEED = 150; // px/s from held keys
-const BULLET_SPEED = 260;
-const BOMB_SPEED = 90;
-/** Most player bullets allowed in flight at once. */
-const MAX_BULLETS = 3;
-
-export interface Invader {
-  x: number;
-  y: number;
-  alive: boolean;
-}
-export interface Shot {
-  x: number;
-  y: number;
-}
-export interface GameState {
-  invaders: Invader[];
-  /** Swarm horizontal direction, +1 / -1. */
-  dir: number;
-  shipX: number;
-  bullets: Shot[];
-  bombs: Shot[];
-  score: number;
-  over: boolean;
-  /** Seconds until the next enemy bomb may drop. */
-  bombTimer: number;
-}
-/** Per-frame input: held movement keys + the elapsed seconds. */
-export interface StepInput {
-  left: boolean;
-  right: boolean;
-  dt: number;
-}
+import {
+  BOMB_SPEED,
+  BULLET_SPEED,
+  COLS,
+  EXPLOSION_TTL,
+  GAP_X,
+  GAP_Y,
+  type GameState,
+  H,
+  INV_H,
+  INV_W,
+  type Invader,
+  MAX_BULLETS,
+  ROWS,
+  SHIP_SPEED,
+  SHIP_W,
+  SHIP_Y,
+  type StepInput,
+  W,
+} from "./space-invaders-defs.ts";
 
 const clamp = (n: number, min: number, max: number) =>
   Math.min(max, Math.max(min, n));
@@ -65,6 +40,7 @@ export function spawnInvaders(): Invader[] {
       list.push({
         x: left + c * (INV_W + GAP_X),
         y: 24 + r * (INV_H + GAP_Y),
+        row: r,
         alive: true,
       });
   return list;
@@ -77,6 +53,7 @@ export function createState(): GameState {
     shipX: W / 2,
     bullets: [],
     bombs: [],
+    explosions: [],
     score: 0,
     over: false,
     bombTimer: 0,
@@ -111,6 +88,10 @@ export function step(
 ): void {
   if (s.over) return;
   const { dt } = input;
+  for (const explosion of s.explosions) explosion.age += dt;
+  s.explosions = s.explosions.filter(
+    (explosion) => explosion.age <= EXPLOSION_TTL,
+  );
   if (input.left) s.shipX -= SHIP_SPEED * dt;
   if (input.right) s.shipX += SHIP_SPEED * dt;
   s.shipX = clamp(s.shipX, SHIP_W / 2, W - SHIP_W / 2);
@@ -133,7 +114,7 @@ export function step(
     s.dir *= -1;
     for (const inv of live) inv.y += INV_H;
   }
-  for (const inv of live) if (inv.y + INV_H >= SHIP_Y) s.over = true;
+  for (const inv of live) if (inv.y + INV_H >= SHIP_Y) endGame(s);
 
   // Enemy bombs, dropped occasionally from a random front-line invader.
   s.bombTimer -= dt;
@@ -151,7 +132,7 @@ export function step(
       b.x < s.shipX + SHIP_W / 2 &&
       b.y > SHIP_Y
     )
-      s.over = true;
+      endGame(s);
   }
 
   for (const sh of s.bullets) sh.y -= BULLET_SPEED * dt;
@@ -172,7 +153,18 @@ export function step(
         inv.alive = false;
         s.bullets.splice(i, 1);
         s.score++;
+        s.explosions.push({
+          x: inv.x + INV_W / 2,
+          y: inv.y + INV_H / 2,
+          age: 0,
+        });
         break;
       }
   }
+}
+
+function endGame(s: GameState): void {
+  if (s.over) return;
+  s.over = true;
+  s.explosions.push({ x: s.shipX, y: SHIP_Y, age: 0 });
 }

--- a/app/src/components/onboarding/cloud-migration/space-invaders.tsx
+++ b/app/src/components/onboarding/cloud-migration/space-invaders.tsx
@@ -1,31 +1,27 @@
 import { useReducedMotion } from "framer-motion";
 import { useEffect, useRef } from "react";
-import {
-  createState,
-  H,
-  INV_H,
-  INV_W,
-  reset,
-  SHIP_H,
-  SHIP_W,
-  SHIP_Y,
-  shoot,
-  steer,
-  step,
-  W,
-} from "./space-invaders-model";
+import { useTranslation } from "react-i18next";
+import { H, W } from "./space-invaders-defs";
+import { drawGame } from "./space-invaders-draw";
+import { createState, reset, shoot, steer, step } from "./space-invaders-model";
+
+const BEST_KEY = "houston.migration.invaders.best";
 
 /**
- * A tiny, tasteful Space Invaders on a <canvas> — a quiet easter egg to pass
- * the time during a long cloud migration. Monochrome (it inherits the
- * surrounding text colour), one life, no audio, no levels: the swarm just
- * speeds up as it thins. All game rules live in `space-invaders-model.ts`; this
- * shell only renders state and wires input. Keyboard input is window-scoped but
- * yields to any focused field, so it never steals typing. Reduced motion → null.
+ * A tiny Space Invaders on a <canvas> — a quiet easter egg to pass the time
+ * during a long cloud migration. Emoji sprites (👾🛸👽🤖 vs 🚀, 💥 on kills)
+ * over ink-colored HUD/shots that inherit the surrounding text colour; one
+ * life, no audio, no levels: the swarm just speeds up as it thins. Game rules
+ * live in `space-invaders-model.ts`, frame rendering in `space-invaders-draw.ts`;
+ * this shell wires input, the rAF loop, and the persisted best score. Keyboard
+ * input is window-scoped but yields to any focused field, so it never steals
+ * typing. Reduced motion → null.
  */
 export function SpaceInvaders({ className }: { className?: string }) {
   const reduce = useReducedMotion() ?? false;
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const bestRef = useRef<number | null>(null);
+  const { t } = useTranslation("migration");
 
   useEffect(() => {
     if (reduce) return;
@@ -39,9 +35,20 @@ export function SpaceInvaders({ className }: { className?: string }) {
 
     const state = createState();
     const held = { left: false, right: false };
+    let best = bestRef.current ?? 0;
+    let recordedOver = false;
+    let elapsed = 0;
     // Filled from the canvas's resolved `color` (text-ink) on resize, before the
     // first draw; the literal is only a pre-resize fallback (dark ink on light).
     let color = "#0d0d0d";
+    if (bestRef.current === null) {
+      try {
+        best = Number(localStorage.getItem(BEST_KEY)) || 0;
+      } catch {
+        /* storage disabled — best just starts at 0 */
+      }
+      bestRef.current = best;
+    }
 
     // Backing store follows the CSS size and devicePixelRatio.
     function resize() {
@@ -55,31 +62,11 @@ export function SpaceInvaders({ className }: { className?: string }) {
     const ro = new ResizeObserver(resize);
     ro.observe(canvas);
 
-    function draw() {
-      ctx.setTransform(canvas.width / W, 0, 0, canvas.height / H, 0, 0);
-      ctx.clearRect(0, 0, W, H);
-      ctx.fillStyle = color;
-      for (const inv of state.invaders)
-        if (inv.alive) ctx.fillRect(inv.x, inv.y, INV_W, INV_H);
-      for (const b of state.bullets) ctx.fillRect(b.x - 1, b.y - 5, 2, 5);
-      for (const b of state.bombs) ctx.fillRect(b.x - 1, b.y, 2, 5);
-      // Player ship: a small triangle atop a base.
-      ctx.beginPath();
-      ctx.moveTo(state.shipX, SHIP_Y);
-      ctx.lineTo(state.shipX - SHIP_W / 2, SHIP_Y + SHIP_H);
-      ctx.lineTo(state.shipX + SHIP_W / 2, SHIP_Y + SHIP_H);
-      ctx.closePath();
-      ctx.fill();
-      if (state.over) {
-        ctx.textAlign = "center";
-        ctx.font = "10px system-ui, sans-serif";
-        ctx.fillText(`score ${state.score} · press space`, W / 2, H / 2);
-      }
-    }
-
     function fire() {
-      if (state.over) reset(state);
-      else shoot(state);
+      if (state.over) {
+        reset(state);
+        recordedOver = false;
+      } else shoot(state);
     }
 
     // ── Input: window-scoped, but never steals typing from a focused field ──
@@ -125,8 +112,27 @@ export function SpaceInvaders({ className }: { className?: string }) {
     function frame(now: number) {
       const dt = Math.min((now - last) / 1000, 0.05);
       last = now;
+      elapsed += dt;
       step(state, { left: held.left, right: held.right, dt });
-      draw();
+      if (state.over && !recordedOver) {
+        recordedOver = true;
+        if (state.score > best) {
+          best = state.score;
+          bestRef.current = best;
+          try {
+            localStorage.setItem(BEST_KEY, String(best));
+          } catch {
+            /* storage disabled — the run's best just isn't remembered */
+          }
+        }
+      }
+      drawGame(ctx, canvas, state, {
+        color,
+        best,
+        elapsed,
+        overLine: t("game.over", { score: state.score }),
+        playAgainLine: t("game.playAgain"),
+      });
       raf = requestAnimationFrame(frame);
     }
     raf = requestAnimationFrame(frame);
@@ -139,7 +145,7 @@ export function SpaceInvaders({ className }: { className?: string }) {
       canvas.removeEventListener("pointermove", onSteer);
       canvas.removeEventListener("pointerdown", onPointerDown);
     };
-  }, [reduce]);
+  }, [reduce, t]);
 
   if (reduce) return null;
   return (

--- a/app/src/lib/cloud-migration-demo.ts
+++ b/app/src/lib/cloud-migration-demo.ts
@@ -9,6 +9,9 @@
  *
  * Toggle it from the running app's devtools console:
  *   localStorage.setItem("houston.cloudMigration.demo", "1"); location.reload();
+ *   // "hold" instead of "1" parks the run mid-upload FOREVER — the progress
+ *   // screen (and its wait game) stays up for design iteration:
+ *   localStorage.setItem("houston.cloudMigration.demo", "hold"); location.reload();
  *   // turn off: localStorage.removeItem("houston.cloudMigration.demo")
  *
  * Guarded by `import.meta.env.DEV`, so the whole path is dead-code-eliminated
@@ -21,19 +24,23 @@ import {
   initialProgress,
 } from "./cloud-migration-progress";
 
-export function isMigrationDemo(): boolean {
+function demoFlag(): string | null {
   try {
-    if (!import.meta.env.DEV) return false;
+    if (!import.meta.env.DEV) return null;
     // `VITE_MIGRATION_DEMO=1 pnpm tauri dev` forces it on for the whole launch
     // (no console step needed); otherwise the per-tab localStorage flag.
-    if (import.meta.env.VITE_MIGRATION_DEMO === "1") return true;
-    return (
-      typeof localStorage !== "undefined" &&
-      localStorage.getItem("houston.cloudMigration.demo") === "1"
-    );
+    if (import.meta.env.VITE_MIGRATION_DEMO === "1") return "1";
+    return typeof localStorage !== "undefined"
+      ? localStorage.getItem("houston.cloudMigration.demo")
+      : null;
   } catch {
-    return false;
+    return null;
   }
+}
+
+export function isMigrationDemo(): boolean {
+  const flag = demoFlag();
+  return flag === "1" || flag === "hold";
 }
 
 export const DEMO_DETECTION: LegacyDetection = {
@@ -109,13 +116,17 @@ export async function runDemoMigration(
   await sleep(750);
   set(() => ({ preparing: false }));
 
-  for (const t of DEMO_TASKS) {
+  for (const [i, t] of DEMO_TASKS.entries()) {
     patch(t.sourceId, { step: "creating" });
     await sleep(500);
     patch(t.sourceId, { step: "warming" });
     await sleep(650);
     patch(t.sourceId, { step: "uploading", chunkIndex: 1, chunkCount: 3 });
     await sleep(500);
+    // "hold": park the SECOND agent mid-upload forever (one done, one active,
+    // one pending — a representative frame) so the progress screen + game can
+    // be designed against without racing the timers.
+    if (i === 1 && demoFlag() === "hold") return;
     patch(t.sourceId, { chunkIndex: 2 });
     await sleep(500);
     patch(t.sourceId, { chunkIndex: 3 });

--- a/app/src/lib/cloud-migration-demo.ts
+++ b/app/src/lib/cloud-migration-demo.ts
@@ -27,9 +27,10 @@ import {
 function demoFlag(): string | null {
   try {
     if (!import.meta.env.DEV) return null;
-    // `VITE_MIGRATION_DEMO=1 pnpm tauri dev` forces it on for the whole launch
-    // (no console step needed); otherwise the per-tab localStorage flag.
-    if (import.meta.env.VITE_MIGRATION_DEMO === "1") return "1";
+    // `VITE_MIGRATION_DEMO=1|hold pnpm tauri dev` forces it on for the whole
+    // launch (no console step needed); otherwise the per-tab localStorage flag.
+    const env = import.meta.env.VITE_MIGRATION_DEMO;
+    if (env === "1" || env === "hold") return env;
     return typeof localStorage !== "undefined"
       ? localStorage.getItem("houston.cloudMigration.demo")
       : null;

--- a/app/src/locales/en/migration.json
+++ b/app/src/locales/en/migration.json
@@ -41,6 +41,10 @@
     },
     "migrateLater": "Migrate later"
   },
+  "game": {
+    "over": "Game over. You scored {{score}}.",
+    "playAgain": "Tap or press space to play again"
+  },
   "done": {
     "stepAi": "Step 1 of 2",
     "stepApps": "Step 2 of 2",

--- a/app/src/locales/en/migration.json
+++ b/app/src/locales/en/migration.json
@@ -24,6 +24,7 @@
     "phaseCloud": "Setting up your cloud",
     "keepOpen": "Keep Houston open until it finishes.",
     "playCaption": "While you wait, defend the galaxy.",
+    "playHint": "Move with the arrow keys and shoot with the space bar, or drag and tap.",
     "backingUp": "Backing up your data on this computer.",
     "preparing": "Getting your data ready. This can take a few minutes.",
     "startFailed": "We couldn't start the move, so nothing was changed. You can try again.",

--- a/app/src/locales/es/migration.json
+++ b/app/src/locales/es/migration.json
@@ -24,6 +24,7 @@
     "phaseCloud": "Preparando tu nube",
     "keepOpen": "Mantén Houston abierto hasta que termine.",
     "playCaption": "Mientras esperas, defiende la galaxia.",
+    "playHint": "Muévete con las flechas y dispara con la barra espaciadora, o arrastra y toca.",
     "backingUp": "Haciendo una copia de seguridad de tus datos en este computador.",
     "preparing": "Preparando tus datos. Esto puede tomar unos minutos.",
     "startFailed": "No pudimos iniciar la mudanza, así que no se cambió nada. Puedes intentar de nuevo.",

--- a/app/src/locales/es/migration.json
+++ b/app/src/locales/es/migration.json
@@ -41,6 +41,10 @@
     },
     "migrateLater": "Migrar después"
   },
+  "game": {
+    "over": "Fin del juego. Hiciste {{score}} puntos.",
+    "playAgain": "Toca o presiona espacio para jugar de nuevo"
+  },
   "done": {
     "stepAi": "Paso 1 de 2",
     "stepApps": "Paso 2 de 2",

--- a/app/src/locales/pt/migration.json
+++ b/app/src/locales/pt/migration.json
@@ -24,6 +24,7 @@
     "phaseCloud": "Preparando sua nuvem",
     "keepOpen": "Mantenha o Houston aberto até terminar.",
     "playCaption": "Enquanto espera, defenda a galáxia.",
+    "playHint": "Mova com as setas e atire com a barra de espaço, ou arraste e toque.",
     "backingUp": "Fazendo um backup dos seus dados neste computador.",
     "preparing": "Preparando seus dados. Isso pode demorar alguns minutos.",
     "startFailed": "Não conseguimos iniciar a mudança, então nada foi alterado. Você pode tentar de novo.",

--- a/app/src/locales/pt/migration.json
+++ b/app/src/locales/pt/migration.json
@@ -41,6 +41,10 @@
     },
     "migrateLater": "Migrar depois"
   },
+  "game": {
+    "over": "Fim de jogo. Você fez {{score}} pontos.",
+    "playAgain": "Toque ou pressione espaço para jogar de novo"
+  },
   "done": {
     "stepAi": "Etapa 1 de 2",
     "stepApps": "Etapa 2 de 2",

--- a/app/tests/space-invaders-model.test.ts
+++ b/app/tests/space-invaders-model.test.ts
@@ -2,17 +2,20 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   COLS,
-  createState,
+  EXPLOSION_TTL,
   INV_H,
   INV_W,
   ROWS,
-  reset,
   SHIP_W,
   SHIP_Y,
+  W,
+} from "../src/components/onboarding/cloud-migration/space-invaders-defs.ts";
+import {
+  createState,
+  reset,
   shoot,
   steer,
   step,
-  W,
 } from "../src/components/onboarding/cloud-migration/space-invaders-model.ts";
 
 const IDLE = { left: false, right: false, dt: 1 / 60 };
@@ -47,6 +50,26 @@ test("a bullet overlapping an invader kills it and scores", () => {
   assert.equal(target.alive, false);
   assert.equal(s.score, 1);
   assert.equal(s.bullets.length, 0);
+  assert.deepEqual(s.explosions, [
+    { x: target.x + INV_W / 2, y: target.y + INV_H / 2, age: 0 },
+  ]);
+});
+
+test("explosions age with each frame and expire after their lifetime", () => {
+  const s = createState();
+  s.explosions.push({ x: 10, y: 20, age: 0 });
+  step(s, { ...IDLE, dt: EXPLOSION_TTL / 2 });
+  assert.equal(s.explosions[0]?.age, EXPLOSION_TTL / 2);
+  step(s, { ...IDLE, dt: EXPLOSION_TTL / 2 + 0.001 });
+  assert.equal(s.explosions.length, 0);
+});
+
+test("invaders preserve their zero-based spawn row", () => {
+  const s = createState();
+  assert.deepEqual(
+    s.invaders.map((invader) => invader.row),
+    Array.from({ length: ROWS }, (_, row) => Array(COLS).fill(row)).flat(),
+  );
 });
 
 test("clearing the swarm respawns it and keeps the score", () => {
@@ -66,6 +89,7 @@ test("an invader reaching the ship row ends the game", () => {
   s.invaders[0].y = SHIP_Y - INV_H + 1; // its bottom crosses the ship row
   step(s, IDLE);
   assert.equal(s.over, true);
+  assert.deepEqual(s.explosions, [{ x: s.shipX, y: SHIP_Y, age: 0 }]);
 });
 
 test("an enemy bomb striking the ship ends the game", () => {
@@ -73,6 +97,7 @@ test("an enemy bomb striking the ship ends the game", () => {
   s.bombs.push({ x: s.shipX, y: SHIP_Y }); // right on the ship
   step(s, IDLE);
   assert.equal(s.over, true);
+  assert.deepEqual(s.explosions, [{ x: s.shipX, y: SHIP_Y, age: 0 }]);
 });
 
 test("step is a no-op once the game is over", () => {


### PR DESCRIPTION
## What

The migration wait game gets real sprites and the progress screen gets a small UX polish (requested by Julian on HOU-737: "use icons/emojis so it looks better, improve the overall UX of that screen").

**Game (`space-invaders-*`)**
- Per-row emoji invaders 👾🛸👽🤖 with a subtle render-only bob (collision stays on model coords)
- 🚀 ship (rotated to point up), ⚡ enemy bombs, fading/growing 💥 explosions on kills and on the ship's demise
- In-canvas HUD: ⭐ score / 🏆 best, best persisted in localStorage
- Game-over copy localized (en/es/pt) — the old hardcoded `score N · press space` violated the i18n rule

**Progress screen**
- "x of y assistants moved" now shows on the happy path (was error-state only)
- The game sits in a soft glass card matching the wizard's light-glass language

**File-size rule cleanup** (200-line limit, while touching these files)
- Geometry/state shapes → `space-invaders-defs.ts`, frame rendering → `space-invaders-draw.ts`, agent attention row → `progress-agent-row.tsx`; dead `SHIP_H` removed

## Verification

- `node --test app/tests/space-invaders-model.test.ts` — 12/12 (4 new: explosions spawn/age/prune, spawn rows, ship-death explosion)
- `pnpm check` (Biome), `app pnpm tsgo --noEmit`, `pnpm check-locales`, `houston-web typecheck` — all clean
- Visual check: drove the wizard demo mode headless (Playwright, chromium) and reviewed screenshots of the progress screen + game mid-play

Fixes HOU-737

🤖 Generated with [Claude Code](https://claude.com/claude-code)