### PR TITLE
feat: make display name optional in the creator profile forms

### DIFF
--- a/agentstore/src/app/me/profile/profile-form.tsx
+++ b/agentstore/src/app/me/profile/profile-form.tsx
@@ -66,7 +66,7 @@ export function ProfileForm({
         </h1>
         <p className="mt-2 text-muted-foreground">
           {claiming
-            ? "Pick a handle and a display name to create your public creator page."
+            ? "Pick a handle to create your public creator page."
             : "Update how you appear across the store."}
         </p>
       </header>
@@ -95,7 +95,7 @@ export function ProfileForm({
 
       <div className="flex flex-col gap-1.5">
         <label htmlFor="profile-name" className="text-sm font-medium">
-          Display name
+          Display name <span className="text-muted-foreground">(optional)</span>
         </label>
         <Input
           id="profile-name"
@@ -104,6 +104,9 @@ export function ProfileForm({
           maxLength={80}
           placeholder="Your name or brand"
         />
+        <p className="text-sm text-muted-foreground">
+          Leave it empty to use your @handle.
+        </p>
       </div>
 
       <div className="flex flex-col gap-1.5">

--- a/app/src/components/store-view/profile/creator-profile-editor.tsx
+++ b/app/src/components/store-view/profile/creator-profile-editor.tsx
@@ -84,7 +84,6 @@ export function CreatorProfileEditorDialog({
     claiming,
     handleChanged,
     handleValid,
-    displayName,
     links,
     saving,
   });
@@ -146,7 +145,8 @@ export function CreatorProfileEditorDialog({
               htmlFor={displayNameId}
               className="text-sm font-medium text-ink"
             >
-              {t("profile.displayNameLabel")}
+              {t("profile.displayNameLabel")}{" "}
+              <span className="text-ink-muted">{t("profile.optional")}</span>
             </label>
             <Input
               id={displayNameId}
@@ -155,10 +155,13 @@ export function CreatorProfileEditorDialog({
               onChange={(e) => setDisplayName(e.target.value)}
               disabled={saving}
             />
+            <p className="text-xs text-ink-muted">
+              {t("profile.displayNameHint")}
+            </p>
           </div>
           <AvatarUploadField
             avatarUrl={profile?.avatarUrl ?? null}
-            displayName={displayName}
+            displayName={displayName.trim() || normalized}
             onChanged={() => void invalidate()}
             disabled={saving}
             claiming={claiming}

--- a/app/src/components/store-view/profile/profile-form.ts
+++ b/app/src/components/store-view/profile/profile-form.ts
@@ -71,9 +71,10 @@ export function linksEqual(a: CreatorLinks, b: CreatorLinks): boolean {
  * The minimal `PATCH /me/profile` body: only fields that actually differ from
  * the current profile. Crucially the `handle` is omitted when unchanged, so
  * merely saving a bio edit can never trip the gateway's `handle_change_too_soon`
- * rate limit. `displayName` is trimmed. An unclaimed profile (`current` null or
- * its `handle` null) makes the first materializing patch carry `handle` +
- * `displayName` automatically, because both differ from the empty baseline.
+ * rate limit. `displayName` is trimmed and sent only when it differs from the
+ * baseline: a blank display name on claim sends NO `displayName` (so the gateway
+ * defaults it to the handle), while clearing a previously set name sends `""`
+ * (which the gateway likewise resets to the handle).
  */
 export function buildProfilePatch(
   form: ProfileFormValues,
@@ -99,8 +100,6 @@ export interface SaveGateInputs {
   handleChanged: boolean;
   /** Whether the normalized handle passes grammar and is not reserved. */
   handleValid: boolean;
-  /** The raw display-name field value (trimmed here). */
-  displayName: string;
   /** The current social links, for the invalid-URL guard. */
   links: CreatorLinks;
   /** Whether a save is already in flight. */
@@ -113,16 +112,12 @@ export interface SaveGateInputs {
  * gating on "changed" alone would enable Save and round-trip a handle-less patch
  * that the gateway bounces with `invalid_handle` against a blank field. When
  * editing an existing profile an unchanged handle is fine; a changed one must be
- * valid. A non-empty display name and only valid links are always required.
+ * valid. Only valid links are additionally required — the display name is
+ * optional, since the gateway defaults a blank one to the `@handle`.
  */
 export function canSaveProfile(inputs: SaveGateInputs): boolean {
   const handleOk = inputs.claiming
     ? inputs.handleValid
     : !inputs.handleChanged || inputs.handleValid;
-  return (
-    handleOk &&
-    inputs.displayName.trim().length > 0 &&
-    !hasInvalidLink(inputs.links) &&
-    !inputs.saving
-  );
+  return handleOk && !hasInvalidLink(inputs.links) && !inputs.saving;
 }

--- a/app/src/locales/en/store.json
+++ b/app/src/locales/en/store.json
@@ -95,6 +95,8 @@
     "handleChecking": "Checking...",
     "handleChangeTooSoon": "You changed your handle recently. Try again later.",
     "displayNameLabel": "Display name",
+    "optional": "(optional)",
+    "displayNameHint": "Leave it empty to use your @handle.",
     "bioLabel": "Bio",
     "bioPlaceholder": "Tell people what you build.",
     "avatarLabel": "Profile photo",

--- a/app/src/locales/es/store.json
+++ b/app/src/locales/es/store.json
@@ -95,6 +95,8 @@
     "handleChecking": "Comprobando...",
     "handleChangeTooSoon": "Cambiaste tu handle hace poco. Inténtalo más tarde.",
     "displayNameLabel": "Nombre visible",
+    "optional": "(opcional)",
+    "displayNameHint": "Déjalo vacío para usar tu @handle.",
     "bioLabel": "Biografía",
     "bioPlaceholder": "Cuéntale a la gente lo que creas.",
     "avatarLabel": "Foto de perfil",

--- a/app/src/locales/pt/store.json
+++ b/app/src/locales/pt/store.json
@@ -95,6 +95,8 @@
     "handleChecking": "Verificando...",
     "handleChangeTooSoon": "Você mudou seu handle há pouco. Tente mais tarde.",
     "displayNameLabel": "Nome de exibição",
+    "optional": "(opcional)",
+    "displayNameHint": "Deixe em branco para usar seu @handle.",
     "bioLabel": "Biografia",
     "bioPlaceholder": "Conte para as pessoas o que você cria.",
     "avatarLabel": "Foto de perfil",

--- a/app/tests/profile-form.test.ts
+++ b/app/tests/profile-form.test.ts
@@ -107,6 +107,32 @@ describe("buildProfilePatch", () => {
     deepStrictEqual(patch, { handle: "newbie", displayName: "New Bee" });
   });
 
+  it("omits displayName on a first claim with a blank name (gateway defaults to the handle)", () => {
+    const patch = buildProfilePatch(
+      {
+        handle: "newbie",
+        displayName: "   ",
+        bio: "",
+        links: {},
+      },
+      profile({ handle: null, displayName: "", bio: null, links: {} }),
+    );
+    deepStrictEqual(patch, { handle: "newbie" });
+  });
+
+  it("sends an empty displayName to clear a previously set one (gateway resets it to the handle)", () => {
+    const patch = buildProfilePatch(
+      {
+        handle: "ana",
+        displayName: "",
+        bio: "builds things",
+        links: { github: "https://github.com/ana" },
+      },
+      profile(),
+    );
+    deepStrictEqual(patch, { displayName: "" });
+  });
+
   it("sends an empty bio to clear a previously set one", () => {
     const patch = buildProfilePatch(
       {
@@ -154,7 +180,6 @@ describe("canSaveProfile", () => {
     claiming: true,
     handleChanged: false,
     handleValid: false,
-    displayName: "New Bee",
     links: {},
     saving: false,
   };
@@ -180,15 +205,10 @@ describe("canSaveProfile", () => {
     );
   });
 
-  it("still requires a non-empty display name on claim", () => {
+  it("allows Save on claim with an empty display name (gateway defaults it to the handle)", () => {
     strictEqual(
-      canSaveProfile({
-        ...base,
-        handleChanged: true,
-        handleValid: true,
-        displayName: "   ",
-      }),
-      false,
+      canSaveProfile({ ...base, handleChanged: true, handleValid: true }),
+      true,
     );
   });
 
@@ -199,7 +219,6 @@ describe("canSaveProfile", () => {
         claiming: false,
         handleChanged: false,
         handleValid: false,
-        displayName: "Ana",
       }),
       true,
     );
@@ -212,7 +231,6 @@ describe("canSaveProfile", () => {
         claiming: false,
         handleChanged: true,
         handleValid: false,
-        displayName: "Ana",
       }),
       false,
     );


### PR DESCRIPTION
## What

Frontend half of HOU-868: claiming a creator profile requires only a handle; everything else can be completed later.

- **In-app editor**: `canSaveProfile` no longer requires a non-empty display name (the now-unused `displayName` input was removed from `SaveGateInputs`). The field is labeled "(optional)" with a hint "Leave it empty to use your @handle." (en/es/pt, no em dashes). Avatar alt text falls back to the handle while the name field is blank.
- **Website** (`agentstore/`): claim subtitle drops the display-name mention; the field gets the same "(optional)" label + hint. No gating change needed (Save never gated on it).
- Both surfaces keep the `display_name_required` error mapping for rollout skew against an older gateway.
- `buildProfilePatch` pins added: a blank name on first claim sends no `displayName` (gateway defaults it to the handle); clearing an existing name sends `""` (gateway resets it to the handle).

Gateway sibling (merged first): gethouston/cloud#174.

## Verification

`pnpm check` exit 0 · app `tsgo --noEmit` · `check-locales` all in sync · `profile-form.test.ts` 21/21 · `houston-agentstore` typecheck clean.

Fixes HOU-868

🤖 Generated with [Claude Code](https://claude.com/claude-code)