### PR TITLE
fix(auth): register the houston:// scheme at runtime on Windows

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -293,17 +293,22 @@ pub fn run() {
             // Managed BEFORE `on_open_url` is wired so a launch-by-deep-link URL
             // that arrives immediately has somewhere to land.
             app.manage(store_deep_link::PendingStoreDeepLinkState::default());
-            // Linux: OS deep-link routing needs an installed .desktop handler
-            // declaring `x-scheme-handler/houston`. Package installs get one
-            // from the bundle, but an AppImage is never installed — without
-            // this runtime registration (which writes
-            // `~/.local/share/applications/houston-app-handler.desktop`
-            // pointing at the AppImage path) `houston://auth-callback` never
-            // reaches the app and Apple sign-in cannot complete. macOS
-            // (Info.plist) and Windows (MSI registry) register at install
-            // time. Failure is a warn, not a crash: Google/Microsoft/email
-            // sign-in don't depend on the scheme.
-            #[cfg(target_os = "linux")]
+            // Runtime `houston://` scheme registration. Only macOS registers
+            // the scheme at install time (the bundler bakes it into
+            // Info.plist). Neither of Windows' MSI/WiX installers register a
+            // custom URL scheme, and a Linux AppImage is never "installed" at
+            // all — so Windows AND Linux must register the handler at runtime,
+            // on every launch, or `houston://auth-callback` (Apple sign-in),
+            // the Agent Store "Open in Houston" links, and the loopback success
+            // page's "Open Houston" button never reach the app.
+            //   - Windows: `register_all()` writes HKCU\Software\Classes\houston
+            //     pointing at the current exe (per-user, no admin, idempotent).
+            //   - Linux: it writes
+            //     `~/.local/share/applications/houston-app-handler.desktop`
+            //     declaring `x-scheme-handler/houston` at the AppImage path.
+            // Must run in setup(), before any sign-in. Failure is a warn, not a
+            // crash: Google/Microsoft/email sign-in don't depend on the scheme.
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
             {
                 use tauri_plugin_deep_link::DeepLinkExt;
                 if let Err(e) = app.deep_link().register_all() {

--- a/knowledge-base/i18n.md
+++ b/knowledge-base/i18n.md
@@ -5,7 +5,7 @@ Houston ships in **en**, **es**, **pt**. Every user-facing string flows through 
 ## Stack
 - `react-i18next` + `i18next` + `i18next-browser-languagedetector`
 - Config: [app/src/lib/i18n.ts](../app/src/lib/i18n.ts) — singleton, initialized synchronously at module load
-- Resources: `app/src/locales/{en,es,pt}/<namespace>.json` (the count grows; `check-locales` is the authority). Newest: `auth` (sign-in screen strings, e.g. the last-sign-in hint) — note most of the sign-in screen's older copy is still hardcoded English, a known follow-up.
+- Resources: `app/src/locales/{en,es,pt}/<namespace>.json` (the count grows; `check-locales` is the authority). Newest: `auth` (the full sign-in screen: title, provider buttons via `continueWith` interpolation, email-code entry under `email.*`, last-sign-in hint).
 - Type augmentation: [app/src/types/react-i18next.d.ts](../app/src/types/react-i18next.d.ts) — `t()` keys are compile-time checked
 
 ## Namespaces


### PR DESCRIPTION
## What

The `houston://` URL scheme was never registered on Windows: the MSI/WiX installer does not register custom URL schemes (the Tauri v2 deep-link plugin only does that for NSIS), and the only runtime `register_all()` call was gated to Linux, behind a comment claiming MSI handles it at install time. Result: `houston://auth-callback` went nowhere on Windows — Apple sign-in hung until its 300s timeout, and Agent Store "Open in Houston" links were dead.

## How

- Widened the cfg gate in `app/src-tauri/src/lib.rs` to `any(target_os = "linux", target_os = "windows")` so `register_all()` runs on Windows at every launch (per-user HKCU write, no admin, idempotent; verified non-cfg-gated in the plugin source).
- Corrected the false comment; error handling unchanged (warn, non-fatal — Google/Microsoft/email sign-in don't use the scheme).
- Second commit removes the now-resolved sign-in-screen i18n follow-up note from the KB (docs only).

## Verification

- `cargo check` pass; `cargo test` full shell suite: 179 passed, 0 failed.
- Windows-target compile not run locally (toolchain not installed); the changed block is byte-identical to the previously-compiling Linux block and the plugin API is platform-unconditional.
- Real-device verification: after install, `reg query HKCU\Software\Classes\houston` should exist post-launch; Apple sign-in returns to the app (needs the UTM Windows VM loop).

## Deferred decision

Optionally also ship an NSIS installer target (registers the scheme at install time, covers deep links clicked before first launch). Left out deliberately — that changes release artifacts/updater config.

Fixes HOU-757

🤖 Generated with [Claude Code](https://claude.com/claude-code)