### PR TITLE
fix(teams): personal space never offers a broken invite flow

### DIFF
--- a/app/src/components/organization/org-view-model.ts
+++ b/app/src/components/organization/org-view-model.ts
@@ -1,5 +1,5 @@
 import type { AuditEntry, Capabilities } from "@houston-ai/engine-client";
-import { canSeeMembers } from "../../lib/org-roles.ts";
+import { canSeeMembers, hasSpaces } from "../../lib/org-roles.ts";
 
 /**
  * Pure, DOM-free logic for the Organization dashboard (Teams v2 + C8 billing).
@@ -38,16 +38,27 @@ export function orgTabIds(gates: { billing: boolean }): readonly OrgTabId[] {
 
 /**
  * Whether the Organization view — and its sidebar nav entry — should render at
- * all. True only for a multiplayer owner/admin; single-player and plain members
- * never see it. This is exactly the members-roster gate (`canSeeMembers` is
- * already "multiplayer AND owner|admin": `orgRole` returns null off-multiplayer
- * and the least-privileged `user` otherwise), so the dashboard and the roster
- * share one source of truth. The gateway is the real enforcer; this only hides
- * an affordance the user can't act on.
+ * all, plus the Permissions view, which shares this gate exactly.
+ *
+ * On a C8 Spaces host the personal space is single-player semantics
+ * (non-invitable, no roster, no policy — the gateway 403s a member-add with
+ * `personal_space`), so the org dashboard and Permissions are TEAM-space
+ * surfaces: they hide whenever the active space is personal, whatever the role.
+ * On a non-spaces multiplayer host (legacy Teams v2, exactly one org) there is
+ * no personal/team split, so `activeSpaceIsTeam` is irrelevant and behavior is
+ * unchanged — the gate falls through to the members-roster rule.
+ *
+ * That base rule is exactly the members-roster gate (`canSeeMembers` is already
+ * "multiplayer AND owner|admin": `orgRole` returns null off-multiplayer and the
+ * least-privileged `user` otherwise), so the dashboard and the roster share one
+ * source of truth. The gateway is the real enforcer; this only hides an
+ * affordance the user can't act on.
  */
 export function canSeeOrganization(
   caps: Capabilities | null | undefined,
+  activeSpaceIsTeam: boolean,
 ): boolean {
+  if (hasSpaces(caps) && !activeSpaceIsTeam) return false;
   return canSeeMembers(caps);
 }
 

--- a/app/src/components/organization/organization-view.tsx
+++ b/app/src/components/organization/organization-view.tsx
@@ -44,8 +44,9 @@ export interface OrgTabProps {
  *
  * Permission surfaces (who can use which agent, per-agent + org-wide ceilings)
  * moved OUT to the top-level Permissions view. Rendered ONLY when
- * `canSeeOrganization` (multiplayer owner/admin) — the sidebar hides the nav
- * entry and `workspace-shell` guards the render for everyone else.
+ * `canSeeOrganization` (multiplayer owner/admin, and on a Spaces host a TEAM
+ * active space — never the personal one) — the sidebar hides the nav entry and
+ * `workspace-shell` guards the render for everyone else.
  */
 export function OrganizationView() {
   const { t } = useTranslation("teams");

--- a/app/src/components/permissions/permissions-view.tsx
+++ b/app/src/components/permissions/permissions-view.tsx
@@ -21,9 +21,10 @@ import {
  * A shell only: it loads the org once (roster), owns the drill-in state, and
  * consumes a one-shot deep link from {@link usePermissionsNav} (the blocked-app
  * CTA in the agent workspace routes straight into that agent's detail). Rendered
- * ONLY when `canSeeOrganization` (multiplayer owner/admin) — the sidebar hides
- * the entry and `workspace-shell` guards the render for everyone else, so it
- * never mounts in single-player or for a plain member.
+ * ONLY when `canSeeOrganization` (multiplayer owner/admin, and on a Spaces host
+ * a TEAM active space, never the personal one) — the sidebar hides the entry and
+ * `workspace-shell` guards the render for everyone else, so it never mounts in
+ * single-player, for a plain member, or in a personal space.
  */
 export function PermissionsView() {
   const { t } = useTranslation("teams");

--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -14,6 +14,7 @@ import { useCapabilities } from "../../hooks/use-capabilities";
 import { useSidebarLayout } from "../../hooks/use-sidebar-layout";
 import { canSeeAiModelsPage } from "../../lib/org-roles";
 import { resolveAutoCollapse } from "../../lib/sidebar-auto-collapse";
+import { isTeamWorkspace } from "../../lib/space-id";
 import { isTopLevelView } from "../../lib/top-level-views";
 import { useAgentStore } from "../../stores/agents";
 import { useUIStore } from "../../stores/ui";
@@ -59,9 +60,13 @@ export function Sidebar({ children }: { children: ReactNode }) {
   const { canCreate: canCreateAgents } = useCanCreateAgents();
   const { capabilities } = useCapabilities();
   // Teams v2: the Organization dashboard is owner/admin-only and multiplayer-
-  // only. Hidden entirely for plain members and single-player (canSeeOrganization
-  // is the same gate as the members roster).
-  const showOrganization = canSeeOrganization(capabilities);
+  // only. Hidden entirely for plain members and single-player, and on a Spaces
+  // host also whenever the active space is personal (non-invitable, no roster) —
+  // Admin + Permissions are team-space surfaces there.
+  const isTeam = currentWorkspace
+    ? isTeamWorkspace(currentWorkspace.id)
+    : false;
+  const showOrganization = canSeeOrganization(capabilities, isTeam);
   // Teams v2: in a Teams workspace the AI Models hub is owner/admin territory
   // (org-level provider credentials + admin model policy), so plain members lose
   // its nav entry too — they pick their model per agent in the composer.

--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -32,10 +32,12 @@ import { canSeeAiModelsPage, hasSpaces } from "../../lib/org-roles";
 import { osIsTauri } from "../../lib/os-bridge";
 import { isMac } from "../../lib/platform";
 import { shortcutLabel } from "../../lib/shortcuts";
+import { isTeamWorkspace } from "../../lib/space-id";
 import { blockedTopLevelView, isTopLevelView } from "../../lib/top-level-views";
 import { useAgentCatalogStore } from "../../stores/agent-catalog";
 import { useAgentStore } from "../../stores/agents";
 import { useUIStore } from "../../stores/ui";
+import { useWorkspaceStore } from "../../stores/workspaces";
 import { AgentPersonScopeProvider } from "../agent-person-scope-context";
 import { AgentPersonScopeMenu } from "../agent-person-scope-menu";
 import { AiHubView } from "../ai-hub/ai-hub-view";
@@ -107,9 +109,15 @@ export function WorkspaceShell({
   );
   const { canCreate: canCreateAgents } = useCanCreateAgents();
   const { capabilities } = useCapabilities();
-  // Teams v2: guard the Organization render so a stale `viewMode` can never show
-  // it to a plain member / single-player (the sidebar already hides the entry).
-  const showOrganization = canSeeOrganization(capabilities);
+  const currentWorkspace = useWorkspaceStore((s) => s.current);
+  // Teams v2: guard the Organization + Permissions render so a stale `viewMode`
+  // can never show them to a plain member / single-player (the sidebar already
+  // hides the entry), and on a Spaces host also when the active space is personal
+  // (single-player semantics — Admin + Permissions are team-space surfaces).
+  const isTeam = currentWorkspace
+    ? isTeamWorkspace(currentWorkspace.id)
+    : false;
+  const showOrganization = canSeeOrganization(capabilities, isTeam);
   // Teams v2: same guard for the AI Models hub — owner/admin only in a Teams
   // workspace (org-level providers + admin model policy).
   const showAiModels = canSeeAiModelsPage(capabilities);

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -47,7 +47,7 @@ import { logger } from "./logger";
 import { isMissingSkillError } from "./missing-skill";
 import { osIsTauri, osPickDirectory } from "./os-bridge";
 import { normalizeLegacyModel } from "./providers";
-import { isNeedsUpgradeError } from "./team-status-model";
+import { isNeedsUpgradeError, isPersonalSpaceError } from "./team-status-model";
 import type {
   Agent,
   CommunitySkillResult,
@@ -142,6 +142,19 @@ async function surfaceError(
     showExpectedStateToast(
       i18n.t("teams:degrade.writeBlockedTitle"),
       i18n.t("teams:degrade.writeBlockedBody"),
+    );
+    return;
+  }
+
+  // Expected business state, not a bug: a member-add attempted on the caller's
+  // personal space (C8 `personal_space`), which is non-invitable by design —
+  // sharing goes through creating a team. Surface the real reason as a plain
+  // info toast, never the red bug pair, so the user learns to create a team.
+  if (isPersonalSpaceError(err)) {
+    const { showExpectedStateToast } = await import("./error-toast");
+    showExpectedStateToast(
+      i18n.t("teams:personalSpace.inviteBlockedTitle"),
+      i18n.t("teams:personalSpace.inviteBlockedBody"),
     );
     return;
   }

--- a/app/src/lib/team-status-model.ts
+++ b/app/src/lib/team-status-model.ts
@@ -108,3 +108,15 @@ export function teamStatusView(input: TeamStatusInput): TeamStatusView {
 export function isNeedsUpgradeError(err: unknown): boolean {
   return shareErrorCode(err) === "needs_upgrade";
 }
+
+/**
+ * True for a gateway `personal_space` rejection (403) — an EXPECTED business
+ * state, NOT a Houston bug: the caller tried to add a member to their personal
+ * space, which is non-invitable by design (sharing goes through creating a
+ * team). Routed to a plain informational toast, exactly like
+ * {@link isNeedsUpgradeError}, so the user learns to create a team instead of
+ * seeing a red "report a bug" toast. Reuses the same kind/code/body extractor.
+ */
+export function isPersonalSpaceError(err: unknown): boolean {
+  return shareErrorCode(err) === "personal_space";
+}

--- a/app/src/locales/en/teams.json
+++ b/app/src/locales/en/teams.json
@@ -373,5 +373,9 @@
     "upgrade": "Upgrade",
     "writeBlockedTitle": "Upgrade needed",
     "writeBlockedBody": "Your team's trial ended. Ask your team's owner to upgrade to make changes."
+  },
+  "personalSpace": {
+    "inviteBlockedTitle": "This is your personal space",
+    "inviteBlockedBody": "Your personal space is just for you. Create a team to invite people."
   }
 }

--- a/app/src/locales/es/teams.json
+++ b/app/src/locales/es/teams.json
@@ -373,5 +373,9 @@
     "upgrade": "Mejorar",
     "writeBlockedTitle": "Necesitas mejorar el plan",
     "writeBlockedBody": "La prueba de tu equipo terminó. Pídele al propietario que mejore el plan para hacer cambios."
+  },
+  "personalSpace": {
+    "inviteBlockedTitle": "Este es tu espacio personal",
+    "inviteBlockedBody": "Tu espacio personal es solo para ti. Crea un equipo para invitar a otras personas."
   }
 }

--- a/app/src/locales/pt/teams.json
+++ b/app/src/locales/pt/teams.json
@@ -373,5 +373,9 @@
     "upgrade": "Fazer upgrade",
     "writeBlockedTitle": "Upgrade necessário",
     "writeBlockedBody": "O teste da sua equipe terminou. Peça ao proprietário para fazer o upgrade para fazer alterações."
+  },
+  "personalSpace": {
+    "inviteBlockedTitle": "Este é o seu espaço pessoal",
+    "inviteBlockedBody": "Seu espaço pessoal é só para você. Crie uma equipe para convidar pessoas."
   }
 }

--- a/app/tests/org-view-model.test.ts
+++ b/app/tests/org-view-model.test.ts
@@ -16,23 +16,56 @@ const ADMIN: Capabilities = { multiplayer: true, role: "admin" };
 const MEMBER: Capabilities = { multiplayer: true, role: "user" };
 // A multiplayer host that (invalidly) omits the role → clamp to least-privileged.
 const NO_ROLE: Capabilities = { multiplayer: true };
+// C8 Spaces hosts: the personal/team split is live, so the gate keys on the
+// active-space boolean too.
+const SPACES_OWNER: Capabilities = {
+  multiplayer: true,
+  spaces: true,
+  role: "owner",
+};
+const SPACES_ADMIN: Capabilities = {
+  multiplayer: true,
+  spaces: true,
+  role: "admin",
+};
+const SPACES_MEMBER: Capabilities = {
+  multiplayer: true,
+  spaces: true,
+  role: "user",
+};
 
 describe("canSeeOrganization", () => {
   it("shows the Organization view to a multiplayer owner and admin", () => {
-    strictEqual(canSeeOrganization(OWNER), true);
-    strictEqual(canSeeOrganization(ADMIN), true);
+    // Non-spaces (legacy Teams v2): the active-space boolean is irrelevant.
+    strictEqual(canSeeOrganization(OWNER, false), true);
+    strictEqual(canSeeOrganization(OWNER, true), true);
+    strictEqual(canSeeOrganization(ADMIN, false), true);
   });
 
   it("hides it from plain members", () => {
-    strictEqual(canSeeOrganization(MEMBER), false);
-    strictEqual(canSeeOrganization(NO_ROLE), false);
+    strictEqual(canSeeOrganization(MEMBER, true), false);
+    strictEqual(canSeeOrganization(NO_ROLE, true), false);
   });
 
   it("hides it entirely in single-player (no org)", () => {
-    strictEqual(canSeeOrganization(SINGLE_PLAYER), false);
-    strictEqual(canSeeOrganization(SINGLE_PLAYER_EXPLICIT), false);
-    strictEqual(canSeeOrganization(null), false);
-    strictEqual(canSeeOrganization(undefined), false);
+    strictEqual(canSeeOrganization(SINGLE_PLAYER, true), false);
+    strictEqual(canSeeOrganization(SINGLE_PLAYER_EXPLICIT, true), false);
+    strictEqual(canSeeOrganization(null, true), false);
+    strictEqual(canSeeOrganization(undefined, true), false);
+  });
+
+  it("hides it in the personal space of a Spaces host, even for an owner", () => {
+    strictEqual(canSeeOrganization(SPACES_OWNER, false), false);
+    strictEqual(canSeeOrganization(SPACES_ADMIN, false), false);
+  });
+
+  it("shows it in a team space of a Spaces host for owner/admin", () => {
+    strictEqual(canSeeOrganization(SPACES_OWNER, true), true);
+    strictEqual(canSeeOrganization(SPACES_ADMIN, true), true);
+  });
+
+  it("hides it from a plain member even in a team space", () => {
+    strictEqual(canSeeOrganization(SPACES_MEMBER, true), false);
   });
 });
 

--- a/app/tests/team-status-model.test.ts
+++ b/app/tests/team-status-model.test.ts
@@ -4,6 +4,7 @@ import type { BillingSummary, OrgRole } from "@houston-ai/engine-client";
 import {
   daysLeftUntil,
   isNeedsUpgradeError,
+  isPersonalSpaceError,
   type TeamStatusView,
   teamStatusView,
 } from "../src/lib/team-status-model.ts";
@@ -142,5 +143,22 @@ describe("isNeedsUpgradeError", () => {
     strictEqual(isNeedsUpgradeError({ code: "not_owner" }), false);
     strictEqual(isNeedsUpgradeError(new Error("boom")), false);
     strictEqual(isNeedsUpgradeError(null), false);
+  });
+});
+
+describe("isPersonalSpaceError", () => {
+  it("matches a gateway personal_space rejection", () => {
+    strictEqual(isPersonalSpaceError({ code: "personal_space" }), true);
+    strictEqual(
+      isPersonalSpaceError({ body: { error: "personal_space" } }),
+      true,
+    );
+  });
+
+  it("ignores other errors", () => {
+    strictEqual(isPersonalSpaceError({ code: "needs_upgrade" }), false);
+    strictEqual(isPersonalSpaceError({ code: "not_owner" }), false);
+    strictEqual(isPersonalSpaceError(new Error("boom")), false);
+    strictEqual(isPersonalSpaceError(null), false);
   });
 });

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -121,9 +121,22 @@ Top-level view labelled **"Admin"** in the UI (`teams:org.nav`/`org.title`;
 "Admin" / "Administración" / "Administração"). The internal id, dir, and gate are
 UNCHANGED: `ORGANIZATION_VIEW_ID = "organization"`
 (`app/src/components/organization/`), rendered only when
-`canSeeOrganization(caps)` (multiplayer owner/admin). The sidebar nav entry and
-the `workspace-shell` render branch both guard on it, so it never mounts for a
-plain member or single-player.
+`canSeeOrganization(caps, activeSpaceIsTeam)` (multiplayer owner/admin, AND — on
+a Spaces host — a TEAM active space). The sidebar nav entry and the
+`workspace-shell` render branch both guard on it, so it never mounts for a plain
+member, single-player, or in the personal space of a Spaces host.
+
+**Personal space hides Admin + Permissions (HOU-824).** On a C8 Spaces host the
+personal space is single-player semantics: non-invitable (the gateway 403s a
+member-add with `personal_space`), no roster, no policy. So Admin and Permissions
+are TEAM-space surfaces there — `canSeeOrganization` returns false whenever the
+active space is personal (`!isTeamWorkspace(current.id)`), whatever the role. The
+two call sites (`workspace-shell.tsx`, `sidebar.tsx`) derive `activeSpaceIsTeam`
+from the active workspace id and thread the resulting `showOrganization` boolean
+everywhere it gates (the render branches, the `blockedTopLevelView` fallback that
+resets a stale personal-space `viewMode` to the dashboard, and the org/permissions
+UI tour steps). On a non-spaces multiplayer host (legacy Teams v2, exactly one
+org) `activeSpaceIsTeam` is irrelevant and behavior is unchanged.
 
 **Now membership + insights + billing ONLY.** All policy (per-agent access and
 per-agent ceilings) moved OUT to the new top-level **Permissions** view (next
@@ -194,8 +207,10 @@ pick an agent, then manage who can use it and what it can use.
 `PERMISSIONS_VIEW_ID = "permissions"`
 (`app/src/components/permissions/id.ts`), registered in
 `app/src/lib/top-level-views.ts` (`TOP_LEVEL_VIEWS` + `blockedTopLevelView`, which
-shares the Organization gate exactly). Gated by `canSeeOrganization(caps)`
-(multiplayer owner/admin) — the IDENTICAL gate to the Organization view. The sidebar
+shares the Organization gate exactly). Gated by `canSeeOrganization(caps,
+activeSpaceIsTeam)` (multiplayer owner/admin, and a TEAM active space on a Spaces
+host) — the IDENTICAL gate to the Organization view, threaded through the same
+`showOrganization` boolean. The sidebar
 nav item (`app/src/components/shell/sidebar-chrome.tsx`, `buildSidebarNavItems`) is a
 `ShieldCheck` lucide icon, label `shell:sidebar.permissions`, placed right BEFORE the
 Organization item (both inside the `showOrganization` block). Render branch + tour
@@ -433,6 +448,15 @@ team-space-only:
   into an expired team) is an EXPECTED business state, not a bug.
   `isNeedsUpgradeError` (`team-status-model.ts`) routes it to a plain
   informational toast instead of the red "report a bug" toast.
+- **`personal_space` invite failures**: a `403 personal_space` (a member-add on
+  the caller's personal space, which is non-invitable by design — share via
+  creating a team) is likewise EXPECTED, not a bug. `isPersonalSpaceError`
+  (`team-status-model.ts`) is routed in `tauri.ts` `surfaceError` exactly like
+  `needs_upgrade` to an informational toast (`teams:personalSpace.inviteBlocked*`:
+  "This is your personal space" / "Your personal space is just for you. Create a
+  team to invite people."). Defense in depth: the org-surface gate (HOU-824) now
+  hides the invite box in the personal space, so this toast is the fallback for
+  any invite that still reaches the gateway.
 
 **No push on expiry.** The effective status is a DERIVED gateway read, so the
 client re-reads on entering a team space (the switch cache-drop refetches
@@ -565,8 +589,10 @@ hides the "Add models" list, all copy passed in.
 
 ## Invites, members, audit, usage
 
-- **Invites**: `addOrgMember(email, role)` → `POST /org/members` (targets the
-  ACTIVE space; `403 personal_space` on a personal one). A known user is added
+- **Invites**: `addOrgMember(email, role)` → `POST /v1/org/members` (the shipped
+  adapter path, `packages/web/src/engine-adapter/cp/orgs.ts`; targets the ACTIVE
+  space; `403 personal_space` on a personal one — surfaced as the friendly
+  `personalSpace` toast, and the invite box is hidden there per HOU-824). A known user is added
   directly (`AddOrgMemberResult.userId`); an unknown email creates a pending
   invite and the host answers **202 `{invited:true}`**. `OrgInvite` rows surface
   on `GET /org` for owner/admin; `deleteOrgInvite` revokes (owner only).


### PR DESCRIPTION
## What

Production evidence (prod gateway logs, houston-prod): `POST /v1/org/members` has **never returned success** — every invite attempt 403s. Root cause: the gateway advertises `multiplayer:true, role:"owner"` even in the C8 **personal** space, so the Admin (Organization) and Permissions surfaces rendered there with an active invite box, and every invite hit the non-invitable personal space (`403 personal_space`), surfacing as the raw red bug toast.

- `canSeeOrganization(caps)` → `canSeeOrganization(caps, activeSpaceIsTeam)`: on a Spaces host, Admin + Permissions are team-space surfaces (hidden in the personal space, any role). Legacy Teams v2 hosts and single-player are byte-identical (unit-tested).
- Residual `personal_space` rejections route to a plain informational toast with create-a-team guidance (mirrors `needs_upgrade`), new i18n keys en/es/pt.
- KB: `teams.md` gate docs + fixed the stale invite path (`POST /v1/org/members`, not `/org/members`).

## Verification

- app unit tests 1991/1991; `tsgo --noEmit`; `check-locales`; Biome; web typecheck + shim parity — all green
- Playwright e2e (fake host): permissions/ai-models/integrations-locked specs 14/14
- Adversarial review pass: clean; one noted non-blocker — the blocked-app "Enable it in Permissions" CTA doesn't take the new team gate, but it is unreachable in a personal space (no per-agent policy there) and a stale deep-link safely bounces to dashboard via `blockedTopLevelView`.

HOU-825 (create-team failures) was a CORS regression already healed in prod; the prevention work lands in the sibling cloud PR (contract test + error-code access logs).

Fixes HOU-824
Fixes HOU-871

🤖 Generated with [Claude Code](https://claude.com/claude-code)