### PR TITLE
feat(teams): teammate names and avatars from the gateway profile source

### DIFF
--- a/app/src/components/organization/people-roster.tsx
+++ b/app/src/components/organization/people-roster.tsx
@@ -14,8 +14,6 @@ import type { OrgMember, OrgRole } from "@houston-ai/engine-client";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useRemoveMember, useSetMemberRole } from "../../hooks/queries";
-import { useUserProfiles } from "../../hooks/queries/use-user-profiles";
-import { avatarUrlFromProfiles } from "../../hooks/queries/user-profiles-map";
 import { GRANTABLE_ROLES } from "../../lib/org-roles";
 import { canEditMember, initialsFor, memberLabel } from "./people-tab-model";
 
@@ -40,7 +38,6 @@ export function PeopleRoster({
   const { t } = useTranslation("teams");
   const setRole = useSetMemberRole();
   const removeMember = useRemoveMember();
-  const { profiles } = useUserProfiles(members.map((m) => m.userId));
   const [pendingRemove, setPendingRemove] = useState<OrgMember | null>(null);
 
   const roleLabel = (role: OrgRole) => t(`people.roles.${role}`);
@@ -58,7 +55,12 @@ export function PeopleRoster({
             isSelf,
             role: member.role,
           });
-          const avatarUrl = avatarUrlFromProfiles(profiles, member.userId);
+          // Display name is primary when the gateway resolved one; the email
+          // then drops to a muted secondary line. Falls back to email/id.
+          const name = member.displayName ?? memberLabel(member);
+          const secondaryEmail =
+            member.displayName && member.email ? member.email : null;
+          const avatarUrl = member.photoUrl ?? null;
           return (
             <li
               key={member.userId}
@@ -74,18 +76,23 @@ export function PeopleRoster({
                     />
                   )}
                   <AvatarFallback className="text-xs">
-                    {initialsFor(memberLabel(member))}
+                    {initialsFor(name)}
                   </AvatarFallback>
                 </Avatar>
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-sm font-medium text-ink">
-                    {memberLabel(member)}
+                    {name}
                     {isSelf && (
                       <span className="ml-2 text-xs text-ink-muted">
                         {t("people.roster.you")}
                       </span>
                     )}
                   </div>
+                  {secondaryEmail && (
+                    <div className="truncate text-xs text-ink-muted">
+                      {secondaryEmail}
+                    </div>
+                  )}
                 </div>
               </div>
               {editable ? (

--- a/app/src/hooks/queries/use-user-profiles.ts
+++ b/app/src/hooks/queries/use-user-profiles.ts
@@ -1,38 +1,74 @@
-import type { UserProfile } from "./user-profiles-map";
+import { useQuery } from "@tanstack/react-query";
+import { isIdentityConfigured } from "../../lib/identity";
+import { isMultiplayer } from "../../lib/org-roles";
+import { tauriOrg } from "../../lib/tauri";
+import { useCapabilities } from "../use-capabilities";
+import {
+  mapProfilesResult,
+  normalizeUserIds,
+  profilesQueryEnabled,
+  type UserProfile,
+} from "./user-profiles-map";
 
 export type { UserProfile } from "./user-profiles-map";
 
 /**
- * Shared query-key prefix for the per-contributor `user-profiles` cache entries.
- * The Supabase `profiles` read died with Supabase auth (its RLS matched
- * `auth.uid()`, which cannot match a Firebase uid), so this hook is a stub today
- * and nothing populates the cache — but the key stays exported for the gateway
- * profile store that will repopulate it (follow-up tracked in
- * knowledge-base/auth-migration.md).
+ * Shared query-key prefix for every per-contributor `user-profiles` cache entry
+ * (each is `[USER_PROFILES_KEY, ...ids]`). Exported so a profile change can
+ * invalidate ALL of them with one prefix match, repainting face stacks.
  */
 export const USER_PROFILES_KEY = "user-profiles";
 
-// Stable empty-map identity so consumers don't get a fresh Map every render
-// (which would defeat memoized face-stack children).
+// Stable empty-map identity so a disabled/loading hook doesn't hand consumers a
+// fresh Map every render (which would defeat memoized face-stack children).
 const EMPTY_PROFILES: ReadonlyMap<string, UserProfile> = new Map();
 
 /**
- * Resolve display profiles for a set of contributor user ids.
+ * Resolve display profiles (name + photo) for a set of contributor user ids via
+ * the gateway's `GET /v1/org/profiles` (its stored GCIP name/picture). Teammate
+ * face stacks / the person filter are multiplayer-gated (hosted Teams) —
+ * single-player has no roster to resolve. Pass `alwaysEnabled` for the caller's
+ * OWN-profile lookup ({@link useMyProfile}): it fires regardless of multiplayer
+ * so a signed-in user resolves their own face; off-gateway the read degrades to
+ * an empty map and the self-face falls back to the session's displayName/
+ * photoUrl. Either way, at least one id and a configured identity backend are
+ * required — see {@link profilesQueryEnabled}.
  *
- * DEGRADED (Wave 2a): the Supabase `profiles` table + avatar storage retired
- * with Supabase auth, so there is no roster source to read yet. This keeps its
- * signature and always resolves the stable empty map; teammate face stacks fall
- * back to initials and the self-face falls back to the identity session's
- * displayName/photoUrl (see {@link useMyProfile}). When the gateway profile
- * store lands it repopulates this hook without touching any consumer.
+ * The ids are deduped + sorted into a stable query key so the same contributor
+ * set (in any order, with repeats) hits one cache entry. Cached generously
+ * (profiles change rarely); the query key is NOT org-scoped because a space
+ * switch drops the whole query cache (see knowledge-base/teams.md §Spaces).
  */
 export function useUserProfiles(
-  _userIds: string[],
-  _opts?: { alwaysEnabled?: boolean },
+  userIds: string[],
+  opts?: { alwaysEnabled?: boolean },
 ): {
   profiles: ReadonlyMap<string, UserProfile>;
   isLoading: boolean;
   isError: boolean;
 } {
-  return { profiles: EMPTY_PROFILES, isLoading: false, isError: false };
+  const { capabilities } = useCapabilities();
+  const ids = normalizeUserIds(userIds);
+  const enabled = profilesQueryEnabled({
+    idCount: ids.length,
+    authConfigured: isIdentityConfigured(),
+    multiplayer: isMultiplayer(capabilities),
+    alwaysEnabled: opts?.alwaysEnabled === true,
+  });
+
+  const query = useQuery({
+    queryKey: [USER_PROFILES_KEY, ...ids],
+    queryFn: () =>
+      tauriOrg
+        .profiles(ids)
+        .then((result) => mapProfilesResult(result.profiles)),
+    enabled,
+    staleTime: 5 * 60_000,
+  });
+
+  return {
+    profiles: query.data ?? EMPTY_PROFILES,
+    isLoading: enabled && query.isLoading,
+    isError: query.isError,
+  };
 }

--- a/app/src/hooks/queries/user-profiles-map.ts
+++ b/app/src/hooks/queries/user-profiles-map.ts
@@ -1,15 +1,15 @@
 /**
  * Pure, import-free wire-shape helpers for the per-mission attribution face
  * stacks and the filter-by-person control (hosted Teams). Kept dependency-free
- * so the row->Map translation and id normalization are unit-tested under
- * `node --test` without pulling a live Supabase client.
+ * so the result->Map translation and id normalization are unit-tested under
+ * `node --test` without pulling a live client.
  */
 
 /**
- * Public-facing profile of a human org member. The `profiles` table grants anon
- * a COLUMN-SCOPED select on exactly these fields (see
- * `supabase/migrations/20260628000000_profiles_anon_column_scope.sql`), so this
- * is a designed public surface, not a leak.
+ * A human org member's resolved display face, as the app's face-stack / roster
+ * consumers read it. Sourced from the gateway's `GET /v1/org/profiles` (its
+ * stored GCIP name + photo); a member who never set a name/photo maps to
+ * explicit `null` so a consumer falls back to initials or a short id.
  */
 export interface UserProfile {
   userId: string;
@@ -17,15 +17,8 @@ export interface UserProfile {
   avatarUrl: string | null;
 }
 
-/** The column-scoped row shape returned by the anon `profiles` select. */
-export interface ProfileRow {
-  user_id: string;
-  name: string | null;
-  avatar_url: string | null;
-}
-
 /**
- * Sorted, de-duplicated ids. Both the query key and the `.in()` argument use
+ * Sorted, de-duplicated ids. Both the query key and the request argument use
  * this so the same set of contributors — in any order, with any repeats — hits
  * one stable cache entry instead of thrashing a new fetch per card render.
  */
@@ -45,7 +38,7 @@ export function normalizeUserIds(ids: string[]): string[] {
  * - Otherwise (teammate face stacks / person filter) it stays multiplayer-gated:
  *   single-player has no roster to resolve.
  *
- * Both paths still require at least one id and a configured Supabase client.
+ * Both paths still require at least one id and a configured identity backend.
  */
 export function profilesQueryEnabled(input: {
   idCount: number;
@@ -58,18 +51,20 @@ export function profilesQueryEnabled(input: {
 }
 
 /**
- * Pure rows -> Map mapping, keyed by `user_id`. A row whose `name`/`avatar_url`
- * is absent (never signed up under a display name, no uploaded avatar) maps to
- * explicit `null`, so a consumer can fall back to initials or a short id rather
- * than render an empty face.
+ * Pure `GET /v1/org/profiles` result -> Map mapping, keyed by user id. Renames
+ * the wire `displayName`/`photoUrl` to the app's `name`/`avatarUrl`, mapping an
+ * absent field to explicit `null` (the member set no name/photo) so a consumer
+ * falls back to initials or a short id rather than render an empty face.
  */
-export function mapProfileRows(rows: ProfileRow[]): Map<string, UserProfile> {
+export function mapProfilesResult(
+  profiles: Record<string, { displayName?: string; photoUrl?: string }>,
+): Map<string, UserProfile> {
   const map = new Map<string, UserProfile>();
-  for (const row of rows) {
-    map.set(row.user_id, {
-      userId: row.user_id,
-      name: row.name ?? null,
-      avatarUrl: row.avatar_url ?? null,
+  for (const [userId, p] of Object.entries(profiles)) {
+    map.set(userId, {
+      userId,
+      name: p.displayName ?? null,
+      avatarUrl: p.photoUrl ?? null,
     });
   }
   return map;

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1657,6 +1657,15 @@ export const tauriIntegrations = {
  */
 export const tauriOrg = {
   get: () => call("get_org", () => getEngine().getOrg()),
+  /** Teammate display profiles (name + photo) for member ids. A cosmetic,
+   *  non-user-initiated read: it degrades to an empty map off-gateway/on hosts
+   *  without the route, so a rare hard failure stays silent (no toast, no
+   *  Sentry) and consumers fall back to initials via React Query's `isError`. */
+  profiles: (ids: string[]) =>
+    call("get_org_profiles", () => getEngine().getOrgProfiles(ids), undefined, {
+      toast: false,
+      capture: false,
+    }),
   addMember: (
     email: string,
     role: import("@houston-ai/engine-client").OrgRole,

--- a/app/tests/user-profiles.test.ts
+++ b/app/tests/user-profiles.test.ts
@@ -1,16 +1,16 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
-  mapProfileRows,
+  mapProfilesResult,
   normalizeUserIds,
   profilesQueryEnabled,
 } from "../src/hooks/queries/user-profiles-map.ts";
 
-describe("mapProfileRows", () => {
-  it("keys the map by user_id and renames to camelCase", () => {
-    const map = mapProfileRows([
-      { user_id: "u1", name: "Maria", avatar_url: "https://cdn/x.png" },
-    ]);
+describe("mapProfilesResult", () => {
+  it("keys the map by user id and renames the wire fields", () => {
+    const map = mapProfilesResult({
+      u1: { displayName: "Maria", photoUrl: "https://cdn/x.png" },
+    });
     deepStrictEqual(map.get("u1"), {
       userId: "u1",
       name: "Maria",
@@ -18,10 +18,8 @@ describe("mapProfileRows", () => {
     });
   });
 
-  it("preserves explicit null name/avatar for a bare profile", () => {
-    const map = mapProfileRows([
-      { user_id: "u2", name: null, avatar_url: null },
-    ]);
+  it("maps an absent displayName/photoUrl to explicit null", () => {
+    const map = mapProfilesResult({ u2: {} });
     deepStrictEqual(map.get("u2"), {
       userId: "u2",
       name: null,
@@ -29,17 +27,17 @@ describe("mapProfileRows", () => {
     });
   });
 
-  it("last row wins on a duplicate user_id", () => {
-    const map = mapProfileRows([
-      { user_id: "u1", name: "Old", avatar_url: null },
-      { user_id: "u1", name: "New", avatar_url: null },
-    ]);
-    deepStrictEqual(map.get("u1")?.name, "New");
-    deepStrictEqual(map.size, 1);
+  it("maps just a name, avatar staying null", () => {
+    const map = mapProfilesResult({ u3: { displayName: "Ana" } });
+    deepStrictEqual(map.get("u3"), {
+      userId: "u3",
+      name: "Ana",
+      avatarUrl: null,
+    });
   });
 
-  it("returns an empty map for no rows", () => {
-    deepStrictEqual(mapProfileRows([]).size, 0);
+  it("returns an empty map for no profiles", () => {
+    deepStrictEqual(mapProfilesResult({}).size, 0);
   });
 });
 

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -719,25 +719,50 @@ i18n-agnostic (label passed in). Alongside the agent filter, the app adds
 on the board** (roster from `distinctBoardPeople`), itself gated on
 `isMultiplayer` and a signed-in user.
 
-**Teammate names + photos.** The Supabase `public.profiles` table + avatar storage
-that used to back these were **retired with Supabase auth** — RLS `auth.uid()` can't
-match Firebase (GCIP) uids, so the profiles source no longer resolves (see
-`knowledge-base/auth-migration.md`). `useUserProfiles`
-(`app/src/hooks/queries/use-user-profiles.ts`) is therefore **stubbed**: teammate
-names fall back to **initials** (from the stored `name` or the id slice) until a
-gateway-backed profile source lands, and avatars are absent. i18n:
+**Teammate names + photos — gateway-backed (HOU-876).** The Supabase `public.profiles`
+table + avatar storage were retired with Supabase auth (RLS `auth.uid()` can't match a
+GCIP uid; see `knowledge-base/auth-migration.md`). The source is now the **gateway**,
+which stores each user's GCIP `name`/`picture` and serves them two ways:
+
+- **Inline on the roster.** `GET /v1/org` members each carry optional
+  `displayName?`/`photoUrl?` (`OrgMember`). The **People roster**
+  (`people-roster.tsx`) reads these directly — display name is the primary label,
+  the email drops to a muted secondary line, and `photoUrl` is the avatar (initials
+  fallback via the design system's `Avatar`/`AvatarFallback`). No profiles fetch there.
+- **By id for face stacks.** `GET /v1/org/profiles?ids=<csv>` (`getOrgProfiles`,
+  `cp/orgs.ts` + `orgs-mixin.ts`, `tauriOrg.profiles`) resolves display profiles for any
+  contributor id, `200 {"profiles":{"<id>":{displayName?,photoUrl?}}}`. `useUserProfiles`
+  (`app/src/hooks/queries/use-user-profiles.ts`) is a real TanStack Query over it —
+  multiplayer-gated (`alwaysEnabled` for the caller's own id in `useMyProfile`), ids
+  deduped+sorted into a stable key `[USER_PROFILES_KEY, ...ids]`, `staleTime` 5 min. It
+  backs the mission face stacks (`mission-people.ts`, `KanbanPeople`), the person filter,
+  the Share dialogs, and the agent People tab (avatars). Wire→app mapping
+  (`displayName`/`photoUrl` → `name`/`avatarUrl`, absent → `null`) is the pure
+  `mapProfilesResult` (`user-profiles-map.ts`).
+
+**Privacy boundary.** The gateway is the sole enforcer: `/v1/org/profiles` returns a
+profile ONLY for a **co-member of the caller's active space** (≤100 ids/request);
+non-co-members are omitted, and a **personal space resolves only the caller**. Off-gateway
+(desktop/self-host) and on a pre-feature gateway (404) both reads degrade to an empty map —
+faces fall back to initials, `useMyProfile` collapses to the session's displayName/photoUrl
+— so a single-player `activity.json`/roster stays byte-identical. It is a cosmetic,
+non-user-initiated read: `tauriOrg.profiles` runs with `{toast:false,capture:false}`, so a
+rare hard failure stays silent and consumers fall back via React Query's `isError`. i18n:
 `dashboard:peopleFilter.*`, `board:people.label` (en/es/pt).
 
 ## engine-client types + methods
 
-Wire types in `ui/engine-client/src/types.ts`: `OrgRole`, `OrgMember`,
-`OrgInfo`, `OrgInvite`, `AddOrgMemberResult`, `AgentAccess`, `AgentAssignment`,
+Wire types in `ui/engine-client/src/types.ts`: `OrgRole`, `OrgMember`
+(+ optional `displayName`/`photoUrl`), `UserProfile`/`UserProfilesResult` (the
+`GET /v1/org/profiles` shape), `OrgInfo`, `OrgInvite`, `AddOrgMemberResult`,
+`AgentAccess`, `AgentAssignment`,
 `AgentSettings` (`allowedToolkits` + `allowedModels` — the agent's whole ceilings;
 policy is per agent only, there is no `OrgSettings` type), `AuditEntry`, `UsageRow`,
 `AgentModelChoice` / `AgentModelChoiceInfo`. `Agent` gains multiplayer-only
 `assigned` / `assignedUserIds` / `access` / `assignments`. All hand-maintained
 against the gateway (the server is source of truth). Methods in `client.ts`:
-`getOrg`, `addOrgMember`, `deleteOrgInvite`, `removeOrgMember`, `setOrgMemberRole`,
+`getOrg`, `getOrgProfiles` (404-degrades to `{}`), `addOrgMember`, `deleteOrgInvite`,
+`removeOrgMember`, `setOrgMemberRole`,
 `setAgentAssignments` (v2 `{assignments}` or legacy `{userIds}`), `getAgentSettings`
 / `setAgentSettings`, `getAgentModelChoice` /
 `setAgentModelChoice`, `orgAudit`, `orgUsage`, and

--- a/packages/fake-host/src/router.ts
+++ b/packages/fake-host/src/router.ts
@@ -260,7 +260,7 @@ export async function handle(req: Request): Promise<Response> {
   if (userRoute) return userRoute;
 
   // --- Teams v2 gateway routes (agent + org settings / allowlist ceilings) ---
-  const teamsRoute = handleTeamsRoutes(method, segs, body);
+  const teamsRoute = handleTeamsRoutes(method, segs, body, url);
   if (teamsRoute) return teamsRoute;
 
   // --- everything under /agents/* ---

--- a/packages/fake-host/src/routes-teams.ts
+++ b/packages/fake-host/src/routes-teams.ts
@@ -54,6 +54,7 @@ export function handleTeamsRoutes(
   method: string,
   segs: string[],
   body: Record<string, unknown> | undefined,
+  url: URL,
 ): Response | undefined {
   // /v1/org — the caller's org identity + role (+ a minimal roster). The
   // Organization ("Admin") view loads this on mount; `role` drives owner-edit
@@ -84,6 +85,36 @@ export function handleTeamsRoutes(
       members,
       invites: state.getOrgInvites(),
     });
+  }
+
+  // GET /v1/org/profiles?ids=<csv> — display profiles (name + photo) for any
+  // co-member of the active space, keyed by user id. Served from the armed org
+  // roster (each `FakeMember` may carry `displayName`/`photoUrl`); ids that are
+  // NOT in the roster are omitted, and a member with neither field is skipped,
+  // mirroring the gateway (non-co-members omitted, bare profiles absent).
+  if (
+    segs[0] === "v1" &&
+    segs[1] === "org" &&
+    segs[2] === "profiles" &&
+    segs.length === 3
+  ) {
+    if (method !== "GET") return json({ error: "not found" }, 404);
+    const raw = url.searchParams.get("ids") ?? "";
+    const wanted = new Set(raw.split(",").filter(Boolean));
+    const members = state.getOrgMembers() ?? [];
+    const profiles: Record<
+      string,
+      { displayName?: string; photoUrl?: string }
+    > = {};
+    for (const m of members) {
+      if (!wanted.has(m.userId)) continue;
+      if (m.displayName === undefined && m.photoUrl === undefined) continue;
+      profiles[m.userId] = {
+        ...(m.displayName !== undefined ? { displayName: m.displayName } : {}),
+        ...(m.photoUrl !== undefined ? { photoUrl: m.photoUrl } : {}),
+      };
+    }
+    return json({ profiles });
   }
 
   // POST /v1/org/members — add a member by email (Teams v2). The fake host

--- a/packages/fake-host/src/state-store.ts
+++ b/packages/fake-host/src/state-store.ts
@@ -116,6 +116,10 @@ export interface FakeMember {
   userId: string;
   email?: string;
   role: OrgRole;
+  /** GCIP display name, when the gateway has one stored (Teams profiles). */
+  displayName?: string;
+  /** GCIP profile photo URL, when the gateway has one stored. */
+  photoUrl?: string;
 }
 
 /** A pending org invite (the `OrgInvite` wire shape) `GET /v1/org` surfaces to

--- a/packages/web/e2e/permissions.spec.ts
+++ b/packages/web/e2e/permissions.spec.ts
@@ -250,3 +250,36 @@ test("agent Permissions tab: a plain member sees it read-only (states visible, n
   ).toBeVisible();
   await expect(page.getByRole("radio", { name: "Any app" })).toBeDisabled();
 });
+
+test("Admin People roster shows a member's gateway display name, email as a secondary line", async ({
+  page,
+  request,
+}) => {
+  await armCapabilities(request, OWNER_CAPS);
+  // Arm a roster where Bob carries the gateway-stored GCIP display name; the
+  // owner keeps only an email (never set a name), proving the fallback too.
+  await request.post(`${FAKE_HOST_URL}/__test__/org`, {
+    data: {
+      members: [
+        { userId: "u-self", email: "you@acme.test", role: "owner" },
+        {
+          userId: "u-bob",
+          email: "bob@acme.test",
+          role: "user",
+          displayName: "Bob Q. Public",
+        },
+      ],
+    },
+  });
+
+  await page.goto("/");
+  await page.locator('[data-tour-target="nav-organization"]').click();
+  await page.getByRole("button", { name: /People/ }).click();
+
+  // Bob's display name is the primary label; his email drops to a muted
+  // secondary line — the gateway-backed profile lit up the roster row.
+  await expect(page.getByText("Bob Q. Public")).toBeVisible();
+  await expect(page.getByText("bob@acme.test")).toBeVisible();
+  // The owner has no display name, so the row still shows the email as primary.
+  await expect(page.getByText("you@acme.test")).toBeVisible();
+});

--- a/packages/web/src/engine-adapter/client/orgs-mixin.ts
+++ b/packages/web/src/engine-adapter/client/orgs-mixin.ts
@@ -9,6 +9,16 @@ export function OrgsMixin<TBase extends BaseCtor>(Base: TBase) {
         throw new Error("multiplayer requires the hosted gateway");
       return controlPlane.getOrg(this.ctx.cp);
     }
+    // Teammate display profiles (name + photo) for a set of member ids. Off-cloud
+    // (`this.cp === null`) there is no roster to resolve, so this degrades to an
+    // empty map (faces fall back to initials) rather than throwing — a cosmetic
+    // read, unlike the org mutators above. Mirrors `getBilling`/`listOrgs`.
+    async getOrgProfiles(
+      ids: string[],
+    ): Promise<controlPlane.UserProfilesResult> {
+      if (!this.ctx.cp) return { profiles: {} };
+      return controlPlane.getOrgProfiles(this.ctx.cp, ids);
+    }
     async addOrgMember(
       email: string,
       role: controlPlane.OrgRole,

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -45,6 +45,8 @@ export type {
   TriggerStatusItem,
   TriggerType,
   UsageRow,
+  UserProfile,
+  UserProfilesResult,
   WebhookKeyReveal,
 } from "../../../../ui/engine-client/src/types";
 

--- a/packages/web/src/engine-adapter/cp/orgs.ts
+++ b/packages/web/src/engine-adapter/cp/orgs.ts
@@ -5,12 +5,39 @@ import type {
   OrgInfo,
   OrgRole,
   UsageRow,
+  UserProfilesResult,
 } from "../../../../../ui/engine-client/src/types";
+import { HoustonEngineError } from "../client/errors";
 import { type ControlPlaneConfig, cpFetch } from "./fetch";
 
 export async function getOrg(cfg: ControlPlaneConfig): Promise<OrgInfo> {
   const res = await cpFetch(cfg, "/v1/org");
   return (await res.json()) as OrgInfo;
+}
+
+/**
+ * Display profiles (name + photo) for the given member ids — any co-member of
+ * the active space (the personal space resolves only the caller). Non-co-member
+ * ids are omitted server-side. Degrades to an empty map on a gateway that
+ * predates the route (404) — teammate faces then fall back to initials — so a
+ * pre-feature host stays byte-identical. Mirrors `getAgentModelChoice`'s 404
+ * swallow; every other error throws.
+ */
+export async function getOrgProfiles(
+  cfg: ControlPlaneConfig,
+  ids: string[],
+): Promise<UserProfilesResult> {
+  if (ids.length === 0) return { profiles: {} };
+  const query = new URLSearchParams({ ids: ids.join(",") }).toString();
+  try {
+    const res = await cpFetch(cfg, `/v1/org/profiles?${query}`);
+    return (await res.json()) as UserProfilesResult;
+  } catch (err) {
+    if (err instanceof HoustonEngineError && err.status === 404) {
+      return { profiles: {} };
+    }
+    throw err;
+  }
 }
 
 export async function addOrgMember(

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -119,6 +119,7 @@ import type {
   UpdateAgent,
   UpdateProvider,
   UsageRow,
+  UserProfilesResult,
   VersionResponse,
   WebhookKeyReveal,
   Workspace,
@@ -1378,6 +1379,27 @@ export class HoustonClient {
   /** The current user's org + role (and, for owner/admin, the member roster). */
   getOrg(): Promise<OrgInfo> {
     return this.request("GET", "/org");
+  }
+  /**
+   * Display profiles (name + photo) for the given member ids (any co-member of
+   * the active space; the personal space resolves only the caller). Non-co-member
+   * ids are omitted. Degrades to an empty map on a host without the route (404),
+   * mirroring `getAgentModelChoice`'s swallow; every other error throws.
+   */
+  async getOrgProfiles(ids: string[]): Promise<UserProfilesResult> {
+    if (ids.length === 0) return { profiles: {} };
+    const query = new URLSearchParams({ ids: ids.join(",") }).toString();
+    try {
+      return await this.request<UserProfilesResult>(
+        "GET",
+        `/org/profiles?${query}`,
+      );
+    } catch (err) {
+      if (isHoustonEngineError(err) && err.status === 404) {
+        return { profiles: {} };
+      }
+      throw err;
+    }
   }
   /**
    * Add a member by email at a role (owner only; enforced by the host). A known

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -153,6 +153,33 @@ export interface OrgMember {
   /** The member's email, when the host exposes it to the caller. */
   email?: string;
   role: OrgRole;
+  /** The member's GCIP display name, when the gateway has one stored. */
+  displayName?: string;
+  /** The member's GCIP profile photo URL, when the gateway has one stored. */
+  photoUrl?: string;
+}
+
+/**
+ * The public display fields of one human user (Teams), from
+ * `GET /v1/org/profiles`. Both are optional — a user who never set a name or
+ * photo resolves to a bare `{}`, so a consumer falls back to initials / a short
+ * id rather than render an empty face. Sourced from the gateway's stored GCIP
+ * `name`/`picture`; kept in sync by hand with the gateway (server is the source
+ * of truth).
+ */
+export interface UserProfile {
+  displayName?: string;
+  photoUrl?: string;
+}
+
+/**
+ * Response of `GET /v1/org/profiles?ids=<csv>` (Teams): display profiles for the
+ * requested member ids, keyed by user id. Ids that are NOT co-members of the
+ * caller's active space are omitted (the personal space resolves only the
+ * caller). Degrades to `{ profiles: {} }` on a host without the route.
+ */
+export interface UserProfilesResult {
+  profiles: Record<string, UserProfile>;
 }
 
 /**


### PR DESCRIPTION
## What

Client half of **HOU-876** — teammate names + avatars, dead since the Supabase-auth retirement (`useUserProfiles` was a stub; rosters showed raw emails, face stacks always initials).

- `OrgMember` gains `displayName`/`photoUrl`; new `UserProfile`/`UserProfilesResult` wire types + `getOrgProfiles(ids)` (engine-adapter + legacy client), 404-degrading to empty so pre-feature/off-gateway hosts stay byte-identical (initials fallback).
- `useUserProfiles` is real again: multiplayer-gated TanStack Query over `GET /v1/org/profiles`, deduped+sorted stable key, 5-min staleTime; consumer shape unchanged so mission face stacks, the person filter, and the Share/People surfaces light up with no changes.
- Org People roster renders the display name primary + email as a muted secondary line + photo avatar (existing `Avatar` component, initials fallback).
- Fake host serves armed profiles; new e2e case: roster shows an armed display name (7/7 on `permissions.spec.ts`).

Gateway half: gethouston/cloud#178 (lands first; this PR degrades cleanly if it hasn't).

## Verification

Biome, app tsgo, check-locales, 1991 app unit tests (incl. new `mapProfilesResult` cases), fake-host typecheck + tests, web typecheck + shim parity, Playwright `permissions.spec.ts` 7/7 on task-private ports — all green.

Fixes HOU-876

🤖 Generated with [Claude Code](https://claude.com/claude-code)