### PR TITLE
feat: agent design process — DESIGN.md + frontend-design/design-review skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Bug? Don't guess → `/debug`
 
 Need specific knowledge? Load on demand:
 - **Host architecture (host + pi runtime + adapter profiles, protocol v3, Composio-as-REST) → `knowledge-base/architecture.md`.** `convergence/` is the record of how we got here (the Rust→host cutover) — historical, not the day-to-day map.
-- Colors, typography, components, animation → `knowledge-base/design-system.md`
+- Design — the rules before ANY UI work → **`/DESIGN.md`** (repo-root compact agent spec: identity, hard rules, tokens, motion, banned defaults, polish checklist; **MANDATORY, hold it in context**). The deep narrative (rationale, component/animation detail, futuristic-theme internals) → `knowledge-base/design-system.md`
 - Client architecture — SDK / tokens / inventory / parity procedures → `knowledge-base/client-architecture.md`
 - `.houston/` layout, schemas, reactivity → `knowledge-base/files-first.md`
 - Skills on disk + UI, picker, invocation marker → `knowledge-base/skills.md`
@@ -59,7 +59,7 @@ Need specific knowledge? Load on demand:
 - Translating UI strings, namespaces, ui/ labels prop pattern, `t()` rules → `knowledge-base/i18n.md`
 - Automated UI / end-to-end tests (Playwright, web build, fake host, new TS engine) → `knowledge-base/ui-testing.md` + `packages/web/e2e/README.md`
 
-Design work? Skills: `/critique` before, `/polish` after. Else `/clarify` (copy), `/distill` (overloaded screen), `/animate` (micro-interactions), `/audit` (a11y).
+UI / design work? Two skills: **`/frontend-design`** when creating a new surface (3–5 genuinely distinct variants, two-pass discipline) and **`/design-review`** (the screenshot self-critique loop — MANDATORY before calling any UI done).
 
 ---
 
@@ -71,7 +71,7 @@ The phases themselves are in the workspace CLAUDE.md. In this repo they mean:
 - Phase 3 (challenge): library or app? Generic → ui/engine. App-specific → app/. Props generic, no store imports, no app types?
 - Phase 4 (plan): tag each step `[ui/board]`, `[host]`, `[app]`. Library before app.
 - Phase 6 (test): host/runtime/domain → vitest; the Tauri shell (`app/src-tauri`) → `cargo test`, not just check.
-- Phase 7 (verify): UI touched → visual fidelity check. Issue? Add logging first (`/debug`), never blind fix.
+- Phase 7 (verify): UI touched → run the `/design-review` loop + `pnpm --filter houston-web test:visual`. Issue? Add logging first (`/debug`), never blind fix.
 - Phase 9 (cleanup): ui/ → no `@/`, no Zustand, no Tauri. app/ → no duplicated logic.
 - Phase 10 (document): `knowledge-base/*.md`, skills, showcase.
 
@@ -89,6 +89,7 @@ The phases themselves are in the workspace CLAUDE.md. In this repo they mean:
 | app/ i18n | `cd app && pnpm check-locales` | — | — |
 | packages/web | `pnpm --filter houston-web typecheck` (runs Tauri shim-parity guard + tsgo) | — | `pnpm --filter houston-web build` |
 | packages/web UI tests | `pnpm --filter houston-web test:e2e` (Playwright; `typecheck:e2e` for the harness) — see `knowledge-base/ui-testing.md` | — | — |
+| packages/web visual regression | `pnpm --filter houston-web test:visual` (screenshot baselines for key screens; re-record intentionally via `test:visual:update`) — see `knowledge-base/ui-testing.md` → Visual regression | — | — |
 
 ### Host sidecar staleness
 
@@ -124,6 +125,7 @@ Three surfaces (web/desktop today; iOS/Android next), one model of the world. Th
 - **Behavior** (turn lifecycle, state, reconnection, VM fields) → change `@houston/sdk` FIRST, then surfaces bind. NEVER re-implement behavior in surface code. VM-snapshot changes are contract changes — additive only.
 - **Visual values** → a design-token edit (`packages/design-tokens`), never a hardcoded hex/spacing literal in app or `ui/`.
 - **Cross-surface structure** (a component added/changed) → bump `design/inventory/inventory.yaml` + CHANGELOG + enforced manifests in the SAME PR (`pnpm check:parity`).
+- **Visual baselines** → a visual-value change that alters a key screen (mission board, chat, first-run) requires re-recording the Playwright visual baselines intentionally (`pnpm --filter houston-web test:visual:update`, both `darwin` + `linux` sets) in the SAME PR (`knowledge-base/ui-testing.md` → Visual regression).
 
 Full procedures + decision table + verification matrix: `knowledge-base/client-architecture.md`.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,123 @@
+# DESIGN.md — Houston UI spec (load before ANY UI work)
+
+## 1. What this file is
+Mandatory context for every coding agent (Claude Code / Codex) before touching UI. Distills the canonical sources into rules you can hold in context.
+Canonical sources, in precedence order: `packages/design-tokens/tokens/*.json` (source of truth — **tokens win on any conflict**) › `knowledge-base/design-system.md` (current-state doctrine) › this file (summary). If this file disagrees with the token JSON, the JSON is right — fix this file.
+
+## 2. Product design identity
+Houston is a calm, futuristic desktop AI product — "quiet expert," not flashy, not corporate. Current look = the **futuristic theme** (`app/src/styles/futuristic.css`, imported last so its overrides win).
+- **Arc / Zen "canvas" layout.** Main content floats as a rounded "screen" card (`bg-background`, `.canvas-screen`) on a recessed window **gutter** (`bg-gutter`); the sidebar is transparent and melts into the gutter.
+- **Dark mode is the loved baseline** — a slow-drifting multi-radial **aurora glow** (blue/indigo/orange, 32s) on `body::before` + translucent **glass** surfaces with `backdrop-filter` blur.
+- **Light mode** — cool solid **"Aurora" palette** (gutter `#eef1f7`, screen `#fcfcfc`, cards over it), no glow mesh (read as glitter over solids). Clean by restraint.
+- **Near-monochrome content, brand-coloured chrome.** Text/controls stay grayscale; colour lives in chrome (aurora, glass sheen, running-card glow) + semantic status + agent avatars + links. Never decorative colour on content surfaces.
+- Both themes ship on every screen via `[data-theme]`. Floating surfaces (modals, popovers) are **solid** in both themes — never glass, never bleed content.
+
+## 3. Hard rules (non-negotiable)
+1. **Semantic tokens only. Never a raw hex/rgba/px literal** in `app/` or `ui/`. A visual change is a token edit (`packages/design-tokens/tokens/*.json`), never a hardcoded value. Sanctioned raw-hex exceptions (the ONLY ones):
+   - `app/src/components/shell/provider-brand-colors.ts` — brand-mark hex map (AI Hub candy store)
+   - `app/src/components/provider-browser/brand-mark.tsx`, `app/src/components/auth/provider-brand-icons.tsx` — full-colour brand marks
+   - `app/src/main.tsx` — pre-boot fallback colour before tokens load
+   - `futuristic.css` effects layer — aurora / `.ht-live-glow` / glass-sheen rgba (sanctioned effect values, not tokenized)
+2. **Use `@houston-ai/core` primitives** (§ inventory). Never invent a parallel component; never import another component library. Search core + the shadcn registry before building.
+3. **Lucide icons only**, `currentColor`, 20px standard (`h-5 w-5`), 16px small, 24px large, stroke 2px. **No emoji as icons, ever.**
+4. **Every screen ships light AND dark** via `[data-theme]`. Pin a subtree with `data-theme="light|dark"` on a wrapper when it must defy the app theme (e.g. controls on the dark space backdrop). Keep the `:not(:where([data-theme="light"], …))` guard on any new dark-scoped descendant rule.
+5. **`ui/` (`@houston-ai/*`) stays generic**: props only — no Zustand/store/Tauri imports, no `app/` types, no `@/` aliases. **i18n-agnostic**: take `labels?` props with English defaults; the `app/` consumer passes `t()` results in. No `react-i18next` in `ui/`.
+6. **New/changed shared component → bump `design/inventory/inventory.yaml`** + `CHANGELOG.md` + every enforced surface manifest in the SAME PR; run `pnpm check:parity`. Desktop-only chrome is excluded — build in `app/`, don't inventory.
+7. No hover-only affordances. Pill buttons (`rounded-full`). No em dashes in user copy. Files ≤200 lines (CSS ≤500).
+
+## 4. Tokens quick reference
+Every value below is a `--ht-*` token, re-exported to Tailwind `--color-*` (use the utility, e.g. `bg-card`, `text-ink`). Never the raw value.
+
+**Type scale** (`scale/typography.json`) — system font stack `ui-sans-serif, -apple-system, system-ui, 'Segoe UI', Helvetica, Arial, sans-serif`; **no webfonts**. Weights 400 / 500 / 600.
+
+| role | size | weight | Tailwind |
+|---|---|---|---|
+| h1 / page title | 28px | 400 | `text-[28px] font-normal` |
+| model selector | 18px | 400 | `text-lg` |
+| body / input | 16px | 400 | `text-base` |
+| buttons | 14px | 500 | `text-sm font-medium` |
+| sidebar / small labels | 14 / 12px | 400 | `text-sm` / `text-xs` |
+
+Section headers: sentence case, `text-sm font-medium`. Never uppercase / `tracking-wider`.
+
+**Spacing** (`scale/spacing.json`, px): 2 · 4 · 6 · 8 · 10 · 12 · 16 · 20 · 24 · 32 · 40 · 48 · 64.
+
+**Radius** (`scale/radius.json`): `sm 4` (chips) · `md 6` (inputs) · `lg 8` (sidebar items, icon btns) · `xl 12` (cards) · `xxl 16` (large cards / dialogs) · `composer 28` · `full 9999` (pills, avatars).
+
+**Motion** (`scale/motion.json`): durations `fast 200ms` · `elegant 582ms` · `common 667ms` · `bounce 833ms` · `ambient 32000ms`. Easings `standard [0.25,0.1,0.25,1]` · `entrance [0.16,1,0.3,1]`.
+
+**Elevation** (`scale/elevation.json`): `edge` = `0 1px 0 rgba(0,0,0,0.05)` (default flat depth) · `composer` = the signature multi-shadow. In **dark mode use NO drop shadows** — depth comes from the surface ladder + `.ht-hairline` inset ring + glass sheen.
+
+**Semantic colour roles** (token | light → dark | use for):
+
+Surface ladder (bottom → top):
+| token / utility | light → dark | use for |
+|---|---|---|
+| `bg-gutter` (`--ht-base`) | `#eef1f7` → `#141416` | window frame / gutter the sidebar melts into |
+| `bg-background` (`--ht-background`) | `#fcfcfc` → glass `rgba(38,38,40,.55)` | the floating "screen" — **standard main pane** (via `.canvas-screen`) |
+| `bg-input` (`--ht-input`) | `#ffffff` → `#1e1e1e` | floating white inputs, composer, pills |
+| `bg-card` (`--ht-card`) | glass `white-68` → glass `neutral-50` | cards/panels that **float above** the canvas |
+| `bg-popover` / `bg-dialog` | white → `#1e1e1e` | menus / modals — **SOLID both themes, never blur, never alpha** |
+| `bg-chip` / `bg-chip-subtle` | `ink-a035` → `white-a05` | recessed panels below the card tier (board columns, rows) |
+
+Text · interactive · lines:
+| token | light → dark | use for |
+|---|---|---|
+| `text-ink` | `#14161d` → `#e5e5e5` | primary text |
+| `text-ink-muted` | `#8e8e8e` → neutral-450 | secondary text |
+| `bg-action` / `text-action-text` | `#0d0d0d`/white → `#e5e5e5`/`#171717` | filled CTA fill/label (also progress, tab underline, switches, status dots) |
+| `bg-hover` / `text-hover-text` | `#fcfcfc`→ / white-a08 | row + menu hover fill |
+| `bg-chip` / `text-chip-text` | soft fill | soft chips / badges |
+| `border-line` (`--ht-line`) | `rgba(60,70,120,.1)` → white-a10 | hairlines (prefer `.ht-hairline` outline on cards) |
+| `border-line-input` | `#e3e3e3` → neutral-700 | field borders |
+| `ring-focus` (`--ht-focus`) | `#0d0d0d` → `#e5e5e5` | focus ring — **near-ink, NOT blue** |
+
+Status (each has a `-text`): `danger` `#e02e2a`→`#ef4444` · `success` `#00a240`→`#22c55e` · `warning` `#e0ac00`→`#eab308` · `highlight` (brand wash + ink `-text`).
+
+Reserved families — do not reach for outside their home:
+- `sidebar*` (`-text`/`-line`/`-hover`/`-active`): sidebar is transparent; `sidebar-active` is the selected-row fill, a clear step above hover.
+- `space-*`: theme-invariant **dark**, ONLY for the workspace-loading splash / `OrbitLoader` / storage-unavailable gate (`app/src/components/space/`). Any themed control placed on it must pin `data-theme="dark"`.
+- `agent.{charcoal,forest,navy,purple,crimson,orange,golden}`: avatar palette — resolve stored ids via `resolveAgentColor` from `@houston-ai/core`, never app-local helpers. Use `HoustonAvatar`.
+
+## 5. Motion rules
+Merge the tokenized scale (§4) with these craft rules:
+- UI motion **<300ms** (`fast 200ms`) — reserve `elegant 582ms`+ for designated "elegant" moments only.
+- **Exits faster than entrances.** Ease-**out** for entrances (`entrance [0.16,1,0.3,1]`); **never ease-in** for UI reveals.
+- Animate **only `transform` + `opacity`.** Never layout/color/box-shadow per frame.
+- Never from `scale(0)` — start ≥ `scale(0.95)` (see AI-Hub modal: `0.98→1`).
+- **NO animation on high-frequency interactions** — menus, dropdowns, keyboard-driven actions open instantly.
+- Respect `prefers-reduced-motion`: collapse to opacity-only or static (the aurora + OrbitLoader already branch on it).
+- Gestures / drags → springs, interruptible (Framer `{type:"spring", stiffness:300, damping:30}`); reordering lists use the `layout` prop + `AnimatePresence mode="popLayout"`.
+
+## 6. Banned generic-AI defaults (never produce)
+- Indigo/purple gradient on a white page. Houston's colour is chrome-scoped brand aurora, not a hero gradient.
+- Centered-hero + three icon feature-cards as a reflex layout.
+- Reaching for **Inter / Space Grotesk** as a "safe" font. Houston uses the **system font stack** — adding a webfont to the app is a deliberate design decision, not a default.
+- Emoji as section markers or icons (Lucide only).
+- Reflexive `01 / 02 / 03` step numbering as decoration.
+- `rounded-lg` + 1px gray border card grid as filler chrome (use the flat "plane" row language: transparent rows, `hover:bg-hover`).
+- `transition: all`.
+- **Drop shadows in dark mode** — use the surface ladder + `.ht-hairline` + glass sheen.
+- Decorative colour on content. Colour must be semantic (status/link) or a sanctioned brand mark.
+
+## 7. Polish checklist (pro-tells — apply before "done")
+- **Concentric radii**: outer radius = inner radius + padding. Nested corners must be visually parallel.
+- `tabular-nums` on any updating or column-aligned numbers.
+- `text-wrap: balance` on headings.
+- Press feedback ~`scale(0.96)` on primary tap targets.
+- **Design every state**: empty / sparse / error / loading for every view. Skeletons mirror the final layout (no CLS). Use `Empty` + `Skeleton` from core.
+- Inputs ≥ **16px** font (prevents mobile zoom, reads as intentional).
+- **Visible focus**: ≥2px, ≥3:1 contrast, box-shadow style that respects the element radius (`ring-focus`).
+- **WCAG**: 4.5:1 body text, 3:1 large text + UI boundaries; hit targets ≥24px (prefer ≥44px for primary).
+- Virtualize lists > 50 items.
+- **Never block paste.**
+
+## 8. Process (mandatory for UI tasks)
+1. Load THIS file first, plus `knowledge-base/design-system.md` for the surface it touches.
+2. **New surface/screen** → generate **3–5 genuinely distinct** design directions, judge them, pin the winner before building → `skills/frontend-design/SKILL.md`.
+3. Before declaring done → run the screenshot self-critique loop → `skills/design-review/SKILL.md`.
+4. Scoped checks only (biome + your vitest); run **`pnpm check:parity`** whenever a shared/`ui/` component changed.
+
+## Component inventory (`@houston-ai/core` — the primitive lock)
+accordion · agent-avatar · alert · alert-dialog · async-button · avatar · badge · button · button-group · card · carousel · catalog · catalog-detail-dialog · catalog-row · catalog-shell · collapsible · command · confirm-dialog · context-menu · dialog · dropdown-menu · empty · error-boundary · highlighted-text · houston-avatar · hover-card · input · input-group · input-otp · kbd · model-picker · popover · progress · resizable · scroll-area · select · separator · sheet · sidebar · skeleton · sonner · spinner · status-badge · stepper · switch · tabs · textarea · toast-container · tooltip · verified-badge.
+Cross-surface product components (chat cards, board, files, etc.) live in `design/inventory/inventory.yaml` (the versioned contract) + `@houston-ai/{chat,board,agent,…}`.

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -8,7 +8,8 @@ Load on demand.
 |------|-------|
 | [architecture.md](architecture.md) | Repo shape — products + the single TS engine (host + pi runtime), the app/Tauri shell, current gaps |
 | [dev-loop.md](dev-loop.md) | `pnpm dev` — THE dev entry point: doctor, six panes, two-file env model, engines-as-processes (full multiplayer locally, no Kubernetes) |
-| [design-system.md](design-system.md) | Colors, typography, spacing, components, animation |
+| [design-system.md](design-system.md) | Current futuristic theme — tokens, typography, components, animation (deep narrative; `/DESIGN.md` is the compact spec) |
+| [design-system-history.md](design-system-history.md) | _HISTORICAL_ — superseded pre-futuristic monochrome ("ChatGPT-like") doctrine, kept for archaeology |
 | [client-architecture.md](client-architecture.md) | Three-surface client contract — SDK / tokens / inventory / parity, change-flow procedures |
 | [files-first.md](files-first.md) | `.houston/` layout, atomic writes, schemas, AI-native reactivity |
 | [skills.md](skills.md) | Skills on disk + UI — frontmatter schema, picker rendering, invocation marker |

--- a/knowledge-base/design-system-history.md
+++ b/knowledge-base/design-system-history.md
@@ -1,0 +1,119 @@
+# Design System — History (superseded)
+
+**What this is:** the pre-futuristic **monochrome "ChatGPT-like" doctrine** that
+governed Houston's look before the futuristic-theme brand refactor. It is kept
+for archaeology only — **none of it is current**. The current design system is
+`knowledge-base/design-system.md` (deep narrative) and `/DESIGN.md` (compact
+agent spec); the design tokens in `packages/design-tokens/tokens/*.json` are the
+source of truth. Superseded on an unknown date (the futuristic theme landed as
+`app/src/styles/futuristic.css`, imported last so its token overrides win).
+
+Read this ONLY to understand where a value came from or why an old commit looks
+the way it does. Do NOT copy anything here into new code — the hex literals,
+`gray-*` class names, and `rgba(13,13,13,X)` borders below are all replaced by
+semantic `--ht-*` tokens (Tailwind `--color-*` utilities). Several values here
+are also just **wrong** relative to today's tokens (noted inline).
+
+---
+
+## The transition banner (the bridge artifact)
+
+For a while `design-system.md` opened with this warning, layering the futuristic
+theme on top of the monochrome doctrine while both coexisted in one doc:
+
+> **⚠️ Updated — the desktop app now ships the "futuristic" theme**, a deliberate
+> brand-direction refactor layered into `app/src/styles/futuristic.css` (imported
+> last so its token overrides win). It intentionally overrides much of the
+> monochrome guidance below: an aurora glow + glass surfaces in **dark**, a cool
+> solid "Aurora" palette in **light**, an Arc/Zen "canvas" layout, and a seamless
+> macOS overlay title bar. The grayscale / "never decorative colour" / "light
+> mode only" notes below are kept for history, but the futuristic layer is the
+> current source of truth.
+
+That two-era split is what this history file resolves: the current doc is now
+futuristic-only, and the superseded monochrome content lives here.
+
+---
+
+## Original visual language
+
+> Visual language: ChatGPT-like. Near-black primary, monochrome, clean
+> typography, minimal chrome.
+
+**Light mode only.** The monochrome era shipped a single light palette; dark
+mode did not exist. (Both themes ship now via `[data-theme]`.)
+
+**"Never decorative colour"** was absolute — colour was banned everywhere, on
+chrome as well as content. (The futuristic theme rescoped this to *content*
+surfaces only; chrome now carries deliberate brand colour — aurora, glass sheen,
+running-card glow.)
+
+## Grays (the old neutral ladder)
+
+The monochrome palette was a hand-authored gray ramp, referenced as `gray-*`
+Tailwind utilities:
+
+`gray-50 #f9f9f9` (sidebar bg) · `100 #ececec` (hover, user bubble) ·
+`200 #e3e3e3` (pressed, dividers) · `300 #cdcdcd` (borders) · `400 #b4b4b4`
+(disabled) · `500 #9b9b9b` (placeholder) · `600 #676767` (secondary text) ·
+`700 #424242` (body) · `950 #0d0d0d` (primary text + buttons).
+
+**These no longer match the shipped neutral primitives.** Today's neutrals are
+e.g. `neutral.50 #fcfcfc`, `neutral.150 #e5e5e5`, `neutral.500 #8e8e8e` (see
+`packages/design-tokens/tokens/primitive/color.json`) — different hexes, and
+reached through semantic `--ht-*` tokens, never a `gray-*` literal.
+
+## Borders (old opacity ladder)
+
+> 5%/15%/15%/25% = light/medium/heavy/xheavy. Use `rgba(13,13,13,X)`.
+
+Hardcoded near-ink alpha for every hairline. **Replaced** by the `--ht-line` /
+`--ht-line-input` tokens and the `.ht-hairline` inset-ring utility. The
+"invisible borders" *principle* (very low opacity, 5–15%) survives in the
+current doc; the raw `rgba(13,13,13,X)` recipe does not.
+
+## Buttons (old monochrome class recipes)
+
+Pill shape everywhere (`rounded-full`) — that part survives. The colour recipes
+were raw `gray-*` / hex utilities:
+
+- **Primary:** `bg-gray-950 text-white rounded-full h-9 px-3 text-sm font-medium hover:bg-gray-800`
+- **Secondary:** `bg-white text-gray-950 rounded-full h-9 px-3 border border-black/15 hover:bg-gray-50`
+- **Ghost:** `bg-transparent rounded-lg w-9 h-9 hover:bg-[#f3f3f3]`
+- **Soft chip:** `bg-gray-100 rounded-full h-9 px-3 hover:bg-gray-200`
+- **Large:** `h-11 px-4`
+
+**Replaced** by token-driven variants on the `Button` primitive
+(`bg-action`/`text-action-text`, `bg-input`+`border-line`, `bg-chip`,
+`bg-hover`). Never hardcode a `gray-*` or `bg-[#…]` button fill.
+
+## Messages (old user bubble)
+
+- **User:** `ml-auto max-w-[70%] rounded-3xl bg-[#f4f4f4] px-5 py-2.5`
+- **Assistant:** no bubble. Plain markdown, left-aligned, transparent.
+
+The assistant-has-no-bubble rule survives. The user bubble's hardcoded
+`bg-[#f4f4f4]` was **replaced** by a soft `bg-chip` token fill.
+
+## Composer / cards (old literal phrasings)
+
+The signature composer (`max-w-3xl rounded-[28px] … p-2.5` + the multi-shadow)
+and card grammar survive, but the old prose described surfaces as literal
+`bg-white` / `border-black/5` / `bg-[#f4f4f4]`. Current guidance routes every one
+of those through a token (`bg-input`, `bg-card`, `border-line`).
+
+## Layout chrome (old fixed tones)
+
+- **Sidebar** was `#f5f5f5`, a solid light-gray panel. It is now **transparent**
+  and melts into the window gutter (`bg-gutter`, `--ht-base`) — the Arc/Zen
+  canvas layout.
+- The **main pane** was variously described as `#fbfbfb` / `#f5f5f5`. The shipped
+  standard pane is `bg-background` (`--ht-background` = `neutral.50` = `#fcfcfc`
+  in light) rendered via the `.canvas-screen` class.
+
+## Status colours (unchanged carry-over)
+
+The monochrome era already allowed semantic status colour, and the values
+carried forward: `success #00a240` · `warning #e0ac00` · `danger #e02e2a` (plus
+`info #0169cc`, since folded into links/highlight). These remain live tokens —
+listed here only because they predate the futuristic refactor.

--- a/knowledge-base/design-system.md
+++ b/knowledge-base/design-system.md
@@ -1,15 +1,19 @@
 # Design System
 
-Visual language: ChatGPT-like. Near-black primary, monochrome, clean typography, minimal chrome.
+**Read `/DESIGN.md` first.** That repo-root file is the compact, agent-facing
+spec — the rules you hold in context before touching any UI (hard rules, token
+quick-reference, motion, banned defaults, polish checklist, component
+inventory). This doc is the **deeper narrative layer**: the rationale, the
+detailed component and animation guidance, and the futuristic-theme internals
+that `/DESIGN.md`'s telegraphic tables can't hold. Precedence on any conflict:
+`packages/design-tokens/tokens/*.json` (tokens win) › this doc › `/DESIGN.md`.
 
-> **⚠️ Updated — the desktop app now ships the "futuristic" theme**, a deliberate
-> brand-direction refactor layered into `app/src/styles/futuristic.css` (imported
-> last so its token overrides win). It intentionally overrides much of the
-> monochrome guidance below: an aurora glow + glass surfaces in **dark**, a cool
-> solid "Aurora" palette in **light**, an Arc/Zen "canvas" layout, and a seamless
-> macOS overlay title bar. See **Futuristic theme** at the bottom of this doc. The
-> grayscale / "never decorative colour" / "light mode only" notes below are kept
-> for history, but the futuristic layer is the current source of truth.
+The current look is the **futuristic theme** — a calm, futuristic desktop AI
+product ("quiet expert"). Dark mode is the loved baseline (aurora glow + glass);
+light mode is the cool solid "Aurora" palette. Content stays near-monochrome;
+colour lives in the chrome. Everything below describes the current system.
+(Pre-futuristic monochrome doctrine is archived in
+`knowledge-base/design-system-history.md` — history only, don't copy from it.)
 
 ## Design tokens are the source of truth
 
@@ -38,7 +42,6 @@ the guard on any new dark-scoped descendant rule. Outputs:
 the client-architecture contract — see `knowledge-base/client-architecture.md`
 for how visual, behavior, and structural changes flow across all three surfaces):
 
-
 1. Edit `packages/design-tokens/tokens/*.json` (a primitive value or a semantic
    reference). NEVER edit `dist/` and NEVER add a new hardcoded colour/spacing
    literal to app or `ui/` CSS — reference a `--ht-*` var (or a Tailwind
@@ -63,25 +66,25 @@ Capable, calm, invisible. Quiet expert. Not flashy, not corporate, not techy. Li
 2. **Always feel alive.** AI working → user sees movement every second. Silence = broken.
 3. **Chat is interface.** Primary interaction. Everything else supports.
 4. **Non-technical labels.** "Prompt" not "Description". "Needs You" not "In Review". Mom-test every word.
-5. **Invisible borders, visible actions.** Borders 5-15% opacity. Action buttons (Start/Approve/Delete) always visible — never hover-only.
+5. **Invisible borders, visible actions.** Borders 5–15% opacity (via `--ht-line` / `.ht-hairline`, never a raw rgba). Action buttons (Start/Approve/Delete) always visible — never hover-only.
 
 ## Color
-Near-black `#0d0d0d`, NEVER pure black. **Both light and dark ship** now (the
-"light mode only" era is over — see Futuristic theme).
 
-### Grays
-`gray-50 #f9f9f9` (sidebar bg) · `100 #ececec` (hover, user bubble) · `200 #e3e3e3` (pressed, dividers) · `300 #cdcdcd` (borders) · `400 #b4b4b4` (disabled) · `500 #9b9b9b` (placeholder) · `600 #676767` (secondary text) · `700 #424242` (body) · `950 #0d0d0d` (primary text + buttons)
+Both light and dark ship on every screen. Primary ink is near-black `#0d0d0d`,
+NEVER pure black. Content stays near-monochrome; the **chrome** (window
+background, glass, aurora glow) carries deliberate brand colour.
 
 ### Tokens
+
 The semantic `--ht-*` set (re-exported to Tailwind `--color-*`) is generated from
 `@houston/design-tokens` — see `tokens/semantic/color.{light,dark}.json` for the
 live values (each token carries its own light AND dark value; dark glass keeps
 its transparency inside the value).
 
 The owner vocabulary (say these words to direct changes):
-- **Grounds**: `base` (the app frame the sidebar sits on) → `background` (the
-  main pane, light `#fcfcfc`) → `input` (the white `#fff` surface — fields,
-  composer, floating cards).
+- **Grounds**: `gutter` (`--ht-base`, the window frame the sidebar melts into) →
+  `background` (the main pane / floating "screen", light `#fcfcfc`) → `input`
+  (the white `#fff` surface — fields, composer, floating cards).
 - **Elevated**: `card` / `card-hover` (glass) / `card-solid` (solid board card)
   / `popover` / `dialog` (both SOLID — floating surfaces never bleed).
 - **Text**: `ink`, `ink-muted` (+ per-surface `card-text`, `popover-text`).
@@ -93,6 +96,45 @@ The owner vocabulary (say these words to direct changes):
   `agent.*` (avatar palette),
   `sidebar*` (with `-text`/`-hover`/`-line`/`-active` suffixes; `sidebar-active`
   is the selected-row fill, a clear step above hover in both themes).
+
+The Tailwind utility for the gutter token is **`bg-gutter`** (`--color-gutter →
+--ht-base`), deliberately NOT `bg-base` — see the "`base` colour naming gotcha"
+under Animation → First-run flow for why the alias was renamed.
+
+### The surface ladder (real tokens)
+
+There is **no `layer-*` token** — the surface stack is expressed through the
+grounds/elevated tokens above. Bottom → top (with the Tailwind utility, and
+light → dark value):
+
+- **`bg-gutter`** (`--ht-base`, `#eef1f7` → `#141416`) — the recessed window
+  frame the sidebar melts into. Sits one step BELOW `background` so the screen
+  reads as raised (in `futuristic.css` this is `body`'s `background-color`).
+- **`bg-background`** (`--ht-background`, `#fcfcfc` → glass `rgba(38,38,40,.55)`)
+  — the floating "screen" and the **standard main pane** every content surface
+  sits on (board, chat, routines, integrations, files, settings, AI hub…).
+  Applied via the `.canvas-screen` class (which also carries the dark
+  frosted-glass blur); `bg-background` stays on the element as the theme-off
+  opaque fallback. In light it is a calm light-gray, NOT white, so white cards,
+  the composer, inputs and popovers **float** on it rather than vanishing
+  white-on-white.
+- **`bg-input`** (`--ht-input`, `#ffffff` → `#1e1e1e`) — floating white inputs,
+  the composer, white pills. NOT a pane background (a pane painted `bg-input`
+  becomes a white slab on the gray canvas).
+- **`bg-card` / `bg-card-hover`** (glass `white-68`/`white-76` → glass
+  `neutral-50`/`neutral-58`) — cards/panels that should **float above** the
+  canvas (mission cards, settings group cards, AI-hub material). White + border +
+  sheen is what makes them lift off the gray.
+- **`bg-popover` / `bg-dialog`** (white → `#1e1e1e`) — menus / modals; **SOLID in
+  both themes** (see Modals below).
+- **`bg-chip` / `bg-chip-subtle`** (`ink-a035` = `rgba(13,13,13,.035)` →
+  `white-a05`) — recessed panels that sit BELOW the card tier (board columns,
+  provider rows, soft chips).
+
+The `futuristic.css` AI-Hub material comment states the same ladder as its depth
+vocabulary: `bg-background → bg-card → bg-card-hover → bg-popover`, with depth
+from HAIRLINE INSET RINGS (`.ht-hairline`), not opaque borders or drop shadows —
+real shadow is reserved for floating chrome (modals/popovers).
 
 ### `--ht-space-*` (workspace-loading splash)
 A deliberately **theme-invariant** group — both `color.light.json` and
@@ -121,21 +163,27 @@ white-glass card material for cards floating on the photo). The first-run
 flow is flat light with plain white cards now, so nothing floats on the photo
 — the `glass.space-75` + `glass.white-92` primitives went with them.
 
-### Borders (opacity)
-5%/15%/15%/25% = light/medium/heavy/xheavy. Use `rgba(13,13,13,X)`.
+### Borders & lines
+The "invisible borders" principle holds: hairlines are very low opacity (5–15%).
+Reach for the **`border-line`** token (`--ht-line`) or the **`.ht-hairline`**
+inset-ring utility (a 1px `outline` in the `--ht-line` colour, so it composes
+with glass sheen and Tailwind ring/shadow utilities) — never a raw `rgba`.
+Field borders use **`border-line-input`** (`--ht-line-input`, `#e3e3e3` light).
 
 ### Status
-success `#00a240` · info `#0169cc` · warning `#e0ac00` · danger `#e02e2a`
+`success #00a240` → bright `#22c55e` · `warning #e0ac00` → `#eab308` ·
+`danger #e02e2a` → `#ef4444` (each with a `-text`), plus `highlight` (brand
+wash + ink). Links use the same semantic status/highlight family.
 
 ### Color restraint
-The monochrome discipline still holds for *content* (text, controls), but the
-futuristic theme adds intentional **ambient brand colour** as chrome:
+The monochrome discipline holds for *content* (text, controls); the futuristic
+theme adds intentional **ambient brand colour** as chrome:
 1. card-running-glow gradient (blue→indigo→orange→yellow) — the brand palette
 2. the **aurora glow** behind dark mode (same blue/indigo/orange family)
 3. the cool **Aurora** light palette (blue/indigo-tinted gutter + cards)
 4. status indicators, agent/channel avatars, links
 
-"Never decorative colour" is now scoped to *content surfaces*; the **chrome**
+"Never decorative colour" is scoped to *content surfaces*; the **chrome**
 (window background, glass, glow) carries brand colour deliberately.
 
 ### Agent avatars
@@ -153,7 +201,7 @@ System font stack. No webfonts.
 
 | Element | Size | Weight | Tailwind |
 |---------|------|--------|----------|
-| h1 | 28px | 400 | `text-[28px]` |
+| h1 / page title | 28px | 400 | `text-[28px] font-normal` |
 | model selector | 18px | 400 | `text-lg` |
 | body/input | 16px | 400 | `text-base` |
 | buttons | 14px | 500 | `text-sm font-medium` |
@@ -163,16 +211,19 @@ System font stack. No webfonts.
 Section headers: sentence case, never uppercase/tracking-wider. `text-sm font-medium`.
 
 ## Buttons
-Pill shape (`rounded-full`) everywhere.
+Pill shape (`rounded-full`) everywhere. Use the `Button` primitive from
+`@houston-ai/core` and its variants — never hardcode a fill. Variants map to
+tokens:
 
-- **Primary:** `bg-gray-950 text-white rounded-full h-9 px-3 text-sm font-medium hover:bg-gray-800`
-- **Secondary:** `bg-white text-gray-950 rounded-full h-9 px-3 border border-black/15 hover:bg-gray-50`
-- **Ghost:** `bg-transparent rounded-lg w-9 h-9 hover:bg-[#f3f3f3]`
-- **Soft chip:** `bg-gray-100 rounded-full h-9 px-3 hover:bg-gray-200`
-- **Large:** `h-11 px-4`
+- **Primary:** filled `bg-action` / `text-action-text`, `h-9 px-3 text-sm font-medium` (flat and sober — not a glossy slab).
+- **Secondary:** `bg-input` + `border-line`, `text-ink`, hover `bg-hover`.
+- **Ghost:** transparent, `rounded-lg w-9 h-9`, hover `bg-hover`.
+- **Soft chip:** `bg-chip`, `rounded-full h-9 px-3`, hover `bg-chip-solid-hover`.
+- **Large:** `h-11 px-4`.
 
 ## Composer (signature)
-`max-w-3xl rounded-[28px] bg-white p-2.5` + multi-shadow:
+`max-w-3xl rounded-[28px] bg-input p-2.5` + the signature multi-shadow (the
+tokenized `composer` elevation):
 ```
 0 4px 4px rgba(0,0,0,0.04),
 0 4px 80px 8px rgba(0,0,0,0.04),
@@ -181,11 +232,14 @@ Pill shape (`rounded-full`) everywhere.
 Grid: leading (attach) | primary (text) | trailing (send).
 
 ## Messages
-- **User:** `ml-auto max-w-[70%] rounded-3xl bg-[#f4f4f4] px-5 py-2.5`
+- **User:** `ml-auto max-w-[70%] rounded-3xl bg-chip px-5 py-2.5`
 - **Assistant:** no bubble. Plain markdown, left-aligned, transparent.
 
 ## Cards
-White bg, `border-black/5`, `rounded-xl`, hover shadow. Running state = `card-running-glow` animation border.
+`bg-card` (or `bg-input` for a floating white card), `border-line` /
+`.ht-hairline`, `rounded-xl`, hover lift. Running state = `card-running-glow`
+animation border. Kanban resting cards use one token, `--ht-card-solid`
+(`#2c2c2b` dark / white light), unified across resting + running + needs-you.
 
 ### RowCard (inline notice + integration cards)
 One shared component (`app/src/components/cards/row-card.tsx`) for the compact horizontal cards in chat and integration surfaces: monochrome logo/icon left (`size-8 rounded-lg` media box), `text-[13px]` title + `text-[11px]` muted description, single right-side action slot. Always grey `bg-chip`, `rounded-xl`, `px-3 py-2.5`. The `inline` prop renders a `<span>` row so it can sit inside assistant markdown prose; `size="md"` gives a roomier modal-heading variant. Pair with `RowCardButton` (`h-7 rounded-full` pill) — its `icon` is **optional**, so action buttons are text-only by default (only the Composio cards pass a trailing link icon), and it is built on `AsyncButton` (HOU-465 rage-click guard). The media slot takes either a `ProviderGlyph` (`shell/provider-logos.tsx`) — monochrome, never full-color brand marks, keyed by provider id with an initial fallback — or a lucide icon. Used by: reconnect / sign-in (`UnauthenticatedCard`, `ProviderReconnectCard`), rate-limit (`RateLimitedCard`, clock icon), the provider-switch dialog, and the inline Composio `#houston_toolkit` link card. **Not** the interaction-card stepper's connect/signin STEPS — those compose the shared `InteractionModal` shell (`ui/chat`, reference "Coworker card" look, inventory v19): the `(icon) name` identity lockup (brand logo `sm` beside the integration NAME at REGULAR weight, via `InteractionModalTitle`) is the modal HEADER title, on the same row as the pager + dismiss X; the body is TWO fields (the agent's reason in foreground tone, then the app description / sign-in explainer muted); the FOOTER is the unified "Not now" + Esc hint beside a filled CTA with a return-key glyph. Weight is restrained: color tone carries the hierarchy, so the title and labels are regular — `font-medium` survives only on the Recommended chip, the number badge, and the CTA label; no competing bolds. "Not now" travels WITH the CTA (present wherever the CTA is, including a reconsidered skip). The signin/connect body renders its OWN `InteractionModal` wired with the stepper's `StepChrome` (pager + dismiss), so ui/chat stays auth/Composio-unaware. See `chat-connect-interaction-card.tsx` / `chat-signin-interaction-card.tsx`.
@@ -208,7 +262,10 @@ One shared component (`app/src/components/cards/row-card.tsx`) for the compact h
 +----------+---------------+-------------+
 ```
 
-Sidebar 200px `#f5f5f5`. Right panel 45% width, 380px min. Split view resizable, default 55/45. Chat max-width 768px (`max-w-3xl`). Header 52px.
+Sidebar 200px, **transparent** — its token is transparent, so it melts into the
+window gutter (`bg-gutter`, the Arc/Zen canvas layout). Right panel 45% width,
+380px min. Split view resizable, default 55/45. Chat max-width 768px
+(`max-w-3xl`). Header 52px.
 
 ### Radii
 `rounded` (0.25rem chips) · `rounded-md` (inputs) · `rounded-lg` (sidebar items, icon btns) · `rounded-xl` (cards) · `rounded-2xl` (large cards, dialogs) · `rounded-[28px]` (composer) · `rounded-full` (pills, avatars)
@@ -217,7 +274,9 @@ Sidebar 200px `#f5f5f5`. Right panel 45% width, 380px min. Split view resizable,
 `h-9` standard · `h-11` large · `w-9 h-9` icon
 
 ## Shadows
-Composer shadow = main depth cue. Else flat or 1px edge: `0 1px 0 rgba(0,0,0,0.05)`.
+The composer shadow is the signature depth cue. Otherwise flat or a 1px edge
+(`edge` = `0 1px 0 rgba(0,0,0,0.05)`). **In dark mode use NO drop shadows** —
+depth comes from the surface ladder + `.ht-hairline` inset ring + glass sheen.
 
 ## Animation
 - **card-running-glow** — rotating conic-gradient border. blue→indigo→orange→yellow. 2.5s infinite. Comet tail.
@@ -228,7 +287,7 @@ Composer shadow = main depth cue. Else flat or 1px edge: `0 1px 0 rgba(0,0,0,0.0
 
 Duration: fast 0.2s / common 0.667s / bounce 0.833s / elegant 0.582s. Under 0.3s for interactions.
 
-Rules: `layout` prop on reordering items. `AnimatePresence mode="popLayout"` for lists. Spring > CSS easing.
+Rules: `layout` prop on reordering items. `AnimatePresence mode="popLayout"` for lists. Spring > CSS easing. (Full craft rules — exits faster than entrances, animate only transform+opacity, never `scale(0)`, no animation on high-frequency menus — in `/DESIGN.md` §5.)
 
 ### First-run flow (flat light, `FirstRunScreen`)
 The language + disclaimer gates, **sign-in**, **onboarding**, and the
@@ -262,14 +321,14 @@ the space/galaxy look is OUT for first-run.
   light tokens. The progress `OrbitLoader` is remapped to ink (`ORBIT_INK_VARS`,
   see `--ht-space-*` above). The done congrats keeps the one colour accent, the
   `SuccessCheck`.
-- **Gotcha RESOLVED (2026-07): `text-base` is a plain font-size utility
-  again.** The gutter token's Tailwind alias was renamed `--color-base` →
-  `--color-gutter` (`ui/core/src/globals.css`) precisely because a colour
-  named `base` made Tailwind also emit `text-base` as a COLOUR utility —
+- **`base` colour naming gotcha (RESOLVED, 2026-07): `text-base` is a plain
+  font-size utility again.** The gutter token's Tailwind alias was renamed
+  `--color-base` → `--color-gutter` (`ui/core/src/globals.css`) precisely because
+  a colour named `base` made Tailwind also emit `text-base` as a COLOUR utility —
   any `text-base` heading without its own colour class rendered
   background-coloured (invisible on a matching surface, both themes; the
   forced-update dialog title was the casualty that exposed it). Never
-  reintroduce a colour token named `base`.
+  reintroduce a colour token named `base` — the gutter utility is `bg-gutter`.
 
 ### Space screen backdrop (boot gate states)
 `SpaceScreen` (`app/src/components/space/space-screen.tsx`) is the **shared
@@ -345,9 +404,8 @@ Lucide React only. 20px standard (`h-5 w-5`), 16px small, 24px large. Stroke 2px
 7. Brand via tokens only — never hardcode hex
 
 ## Design skill workflow
-1. `/critique` — before building
-2. `/polish` — final alignment/spacing/consistency pass
-Use when relevant: `/clarify` (UX copy), `/distill` (overloaded screen), `/animate` (micro-interactions), `/audit` (a11y, perf).
+1. `/frontend-design` — before building a new surface (3–5 genuinely distinct variants, two-pass discipline)
+2. `/design-review` — the screenshot self-critique loop, mandatory before calling any UI done
 
 ## Futuristic theme
 
@@ -358,41 +416,26 @@ tokens, re-exported to Tailwind as `--color-*`, so the theme is mostly token
 overrides — not a 20-component rewrite.
 
 **Arc / Zen "canvas" layout.** The main content floats as a rounded "screen"
-card (the `background` token; the `.canvas-screen` CSS class) on a recessed **window gutter** (`base`); the sidebar is
-transparent and melts into the gutter. Tokens: `--ht-layer-0` (window bg)
-and `--ht-layer-1` (the floating screen). The mission panel opens as a
-second rounded card with a gutter gap.
+card (`bg-background`; the `.canvas-screen` CSS class) on a recessed **window
+gutter** (`bg-gutter`, `--ht-base`); the sidebar is transparent and melts into
+the gutter. The mission panel opens as a second rounded card with a gutter gap.
+There is **no `--ht-layer-*` token** — the window bg is `--ht-base` (`bg-gutter`)
+and the floating screen is `--ht-background` (`bg-background`).
 
 **The canvas is the standard main surface — a light gray, not white (light
-mode).** `--ht-layer-1` is the tone every content pane (board, chat,
-routines, integrations, files, settings, AI hub, agent settings…) sits on. In
-**light** it is `#fbfbfb` — the flattened equivalent of the chat panel's former
-`bg-chip-subtle/50` over white, promoted to the ONE standard so white cards, the
-composer, inputs, and popovers **float** on a calm gray rather than vanishing
-into white-on-white. In **dark** it is unchanged (`{color.glass.screen-55}`
-frosted glass); the light change never moves dark. It is exposed to Tailwind as
-**`bg-layer-1`** (`--color-layer-1 → --ht-layer-1`, `ui/core/src/globals.css`
-`@theme`) so any surface that lives ON the canvas can reference the SAME tone as
-one source of truth — e.g. the chat panel (`ui/chat/chat-panel.tsx`) is
-`bg-layer-1 dark:bg-transparent` (transparent in dark to let the pane's glass
-through). The two shell panes (`shell/workspace-shell.tsx`) get it via the
-`.canvas-screen` class, which ALSO carries the dark frosted-glass blur — so they
-keep the class (never swap it for a bare `bg-layer-1`, which would drop the dark
-glass); the light-gray flip is purely the token value change.
-
-**the surface ladder (light mode):**
-- **`bg-layer-1`** (`#fbfbfb`) — the main pane / standard surface things float
-  ON. Use for a content-area background that should read as the calm base.
-- **`bg-card`** (`white-68` glass ≈ near-white over canvas) — a card/panel that
-  should **float above** the canvas (mission cards, settings group cards). White
-  + border + sheen is what makes it lift off the gray.
-- **`bg-layer-2`** (`#fff`) — the opaque-white fallback / floating inputs &
-  the composer (white pills that float on the canvas). NOT for pane backgrounds
-  in the futuristic layout (a pane painted `bg-layer-2` becomes a white slab
-  on the gray canvas — the `.canvas-screen` panes keep `bg-background` only as
-  the theme-off fallback, overridden by the class).
-- **`bg-chip` / `bg-chip-subtle`** (`ink-a035`, subtle darker-than-canvas) —
-  recessed panels that sit BELOW the card tier (board columns, provider rows).
+mode).** `bg-background` (`--ht-background`) is the tone every content pane
+(board, chat, routines, integrations, files, settings, AI hub, agent settings…)
+sits on. In **light** it is `#fcfcfc` (`neutral.50`) — a calm gray promoted to
+the ONE standard so white cards, the composer, inputs, and popovers **float** on
+it rather than vanishing white-on-white. In **dark** it is frosted glass
+(`glass.screen-55` = `rgba(38,38,40,.55)`); the light change never moves dark.
+Consumers reference the SAME tone as one source of truth: the chat panel
+(`ui/chat/chat-panel.tsx`) is `bg-background dark:bg-transparent` (transparent in
+dark to let the pane's glass through). The two shell panes
+(`shell/workspace-shell.tsx`) get it via `rounded-2xl bg-background
+canvas-screen` — the `.canvas-screen` class carries the dark frosted-glass blur,
+so keep the class (never drop it for a bare `bg-background`, which would lose the
+dark glass); the light-gray value is purely the token.
 
 **Dark mode** — the signature look: a multi-radial **aurora glow** on
 `body::before` (blue/indigo/orange, slow 32s drift, disabled under
@@ -401,10 +444,10 @@ sidebar) with `backdrop-filter` blur. FLOATING surfaces (`popover`, `dialog`)
 are NOT glass — they are solid in both themes (see "Modals" below).
 
 **Light mode** — the cool, solid **"Aurora" palette** (no glow mesh — it read as
-"glitter" over solid surfaces): gutter `#eef1f7`, screen `#fbfbfb` (the standard
-light-gray canvas — see "The canvas is the standard main surface" above), cards
-`#f4f6fc`, cool blue/indigo border. Clean and futuristic by restraint, not
-decoration.
+"glitter" over solid surfaces): gutter `#eef1f7` (`cool.gutter`), screen
+`#fcfcfc` (the standard light-gray canvas — see above), near-white glass cards
+(`bg-card` = `glass.white-68`), cool blue/indigo border. Clean and futuristic by
+restraint, not decoration.
 
 **Modals and popovers: SOLID in both themes.** All modal primitives —
 `DialogContent` (`ui/core/components/dialog.tsx`), `AlertDialogContent`,
@@ -523,3 +566,11 @@ editors render full-width, the rest in a centered `max-w-xl` column, all under a
 appear only when `accountAvailable` / `showMembers`. Version string = overview
 footer. Nav-row copy + group titles + `Set`/count values live under
 `settings.index.*` / `settings.nav.*` in the three locale files.
+
+---
+
+**History:** the pre-futuristic monochrome ("ChatGPT-like") doctrine — the old
+gray ladder, `light mode only`, hardcoded `gray-*` / `rgba(13,13,13,X)` recipes,
+and the transition banner that once topped this doc — is archived in
+[`design-system-history.md`](design-system-history.md). It is superseded; read
+it only for archaeology, never copy from it.

--- a/skills/design-review/SKILL.md
+++ b/skills/design-review/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: design-review
+description: The screenshot self-critique loop. Run BEFORE declaring ANY Houston UI work done. Screenshot the touched screens in both themes at desktop + narrow widths, critique against a scored rubric with vision, fix the top 3 issues, repeat. Gate: loop passes + scoped checks + parity. Tool-agnostic, Playwright is the default path.
+---
+
+# /design-review
+
+You cannot judge UI from code. Look at it. A picture is worth 1000 tokens.
+
+**Never report UI work complete without running this loop.** Minimum 2 passes; plan on 3–5. Stop when a pass finds nothing above severity-minor.
+
+## Precondition
+
+Read **`/DESIGN.md`** (repo root) FIRST — the compact spec that defines the rules this loop scores against (hard rules, token quick-reference, motion, banned defaults). Then **`knowledge-base/design-system.md`** for the deeper narrative on the surface you touched. The `--ht-*` token values live in `packages/design-tokens/tokens/*.json`. This is what "token compliance" and "motion rules" below are measured against.
+
+## The loop
+
+### 1. Bring the surface up
+
+**App screens** (`app/src` / `packages/web`) run against an in-memory **fake host** — no real backend, no AI, no credentials. Two paths:
+
+- **Playwright harness (default, hermetic).** `pnpm --filter houston-web test:e2e` boots both servers itself (vite `:1430` + fake host `:4399`) — write a throwaway spec (or extend one) that navigates the touched screen and calls `page.screenshot(...)`. Fixtures seed a booted shell with one agent selected (`packages/web/e2e/README.md`, `knowledge-base/ui-testing.md`). Arm Teams / integration / board states via the `/__test__/*` controls documented there. There is also a scoped **`/verify`** skill (`houston/packages/web:verify`) that drives host + Playwright flows.
+- **Manual, two panes.** Terminal 1: `pnpm --filter houston-web fake-host` (`:4399`). Terminal 2: `pnpm --filter houston-web dev` (vite `:1430`). Then drive a browser — Playwright script, or the Chrome/browser MCP if available — to the touched screen.
+
+**Website** (`website/`, Eleventy — no fake host): `cd website && npm run dev` serves the built site (`--serve`), or `npm run build` then serve `_site/`. Same rubric applies.
+
+### 2. Screenshot — both themes, two widths
+
+For **every** touched screen, capture the matrix:
+
+|            | Desktop (~1280px) | Narrow (~380px) |
+|------------|-------------------|-----------------|
+| **Light**  | ✓                 | ✓               |
+| **Dark**   | ✓                 | ✓               |
+
+Toggle theme by setting `data-theme` on the root element (`app/src/lib/theme.ts` applies it): dark = `document.documentElement.setAttribute("data-theme","dark")`; light = remove the attribute (or set `"light"`). In Playwright: `page.evaluate(...)` then screenshot. Capture any designed **states** (empty / loading / error) too — the fake host `/__test__/*` controls or seed data drive them.
+
+### 3. Critique with vision — score each 1–5
+
+Look at every screenshot and score against this rubric. Any score ≤3 is an issue.
+
+- **Visual hierarchy** — one clear focal point? One obvious action?
+- **Spacing rhythm** — token grid respected, no ad-hoc gaps or one-off margins?
+- **Token compliance** — any colour/spacing that isn't a `--ht-*` token / Tailwind utility? (No raw hex outside the two sanctioned brand-hex files.)
+- **Both-themes parity** — dark isn't a naive inversion; contrast holds; glass/aurora chrome reads right; no dark chrome leaking into a light-pinned subtree.
+- **Typography** — type scale respected (design-system.md → Typography), no orphan font sizes, sentence-case section headers.
+- **States** — empty / loading / error present AND designed, not afterthoughts.
+- **Motion** — obeys design-system.md → Animation (durations, springs, `card-running-glow`); `prefers-reduced-motion` honoured; no gratuitous animation.
+- **Accessibility spot-checks** — contrast ≥4.5:1 body / ≥3:1 large + UI; focus visible; hit targets ≥24px; no hover-only affordances.
+- **Generic-AI tells** — none of the banned defaults (`/DESIGN.md` → Banned generic-AI defaults + the three AI-cluster looks: cream/serif/terracotta, near-black + acid accent, broadsheet hairlines).
+- **The overall question** — *"Does this look like it was designed on purpose?"*
+
+Write the findings down (a scratch note), ranked by severity.
+
+### 4. Fix the TOP 3 issues
+
+Only the worst three this pass. A visual fix is a token/component edit, not a hardcoded literal. Keep changes on the surface ladder and inside the type/spacing scale.
+
+### 5. Repeat
+
+Re-screenshot the full matrix, re-critique. **Minimum 2 passes; stop only when a pass surfaces nothing above severity-minor.**
+
+## Gate — all must hold before "done"
+
+- The loop passes (a clean pass, nothing above minor).
+- Scoped checks pass: **`pnpm check`** (biome, on touched paths — `pnpm check:fix` first) + the relevant **vitest / e2e** (`pnpm --filter houston-web test:e2e`, or the touched package's tests).
+- **Visual regression** — after UI changes to a key screen (mission board, chat, first-run), run **`pnpm --filter houston-web test:visual`**. When the visual change is intentional, re-record with **`pnpm --filter houston-web test:visual:update`**, eyeball the new PNGs, and commit them in the same PR — never blindly re-record to turn a red run green (`packages/web/e2e/README.md` → Visual regression).
+- **`pnpm check:parity`** if a shared cross-surface component changed (with `design/inventory/inventory.yaml` + CHANGELOG bumped in the same change).
+
+Only then report the UI work complete.
+
+## Anti-patterns
+
+- ❌ "The code looks right, shipping it." → You didn't look at it.
+- ❌ One theme, one width. → Dark and narrow are where it breaks.
+- ❌ One pass. → The second pass always finds something.
+- ❌ Fixing a colour with a raw hex. → Token edit, or it fails token compliance.

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: frontend-design
+description: Design new Houston UI (app screens, components, website sections) with intent, not templated defaults. Two-pass discipline inside Houston's token system, multi-variant exploration for new surfaces, restraint rules. Supplements the design system with process; the design system wins on conflict. Run /design-review before calling any UI done.
+---
+
+# /frontend-design
+
+Design like the lead at a studio that gives every product an identity no one else could mistake. Deliberate, opinionated choices — but always **inside Houston's system**. Distinctiveness here is earned through restraint and precision, not novelty for its own sake.
+
+## Precondition — load the system FIRST
+
+Before any pixel:
+
+1. Read **`/DESIGN.md`** (repo root) FIRST — the compact, agent-facing spec you hold in context (identity, hard rules, token quick-reference, motion, banned defaults, polish checklist, component inventory). Then **`knowledge-base/design-system.md`** for the surface you touch — the deeper narrative layer (rationale, detailed component/animation guidance, futuristic-theme internals).
+2. Token VALUES are authoritative in **`packages/design-tokens/tokens/*.json`** (semantic `--ht-*` alias layer, light + dark). Never a hardcoded hex/spacing literal — a visual change is a token edit (design-system.md → Change procedure).
+3. Search before building: `@houston-ai/*` showcase, existing `app/src` components, shadcn/ui registry. Reuse beats invention (`houston/CLAUDE.md` → Search before building).
+
+**The design system wins on any conflict.** This skill adds *process*; it never overrides a documented token, rule, or pattern.
+
+## Two-pass discipline
+
+### Pass 1 — commit direction BEFORE code
+
+Write a compact plan, entirely within Houston's tokens. Keep it in your thinking / a scratch note; show the user only once you're confident:
+
+- **Layout concept** — one-sentence prose + an **ASCII wireframe**. Place it on the real surface ladder (`bg-background` canvas, `bg-card` floats, `bg-input` fields — design-system.md → The surface ladder; there is no `layer-*` token).
+- **Hierarchy** — name the ONE focal point. One obvious action per screen (Show, don't configure).
+- **The signature element** — the single thing this surface is remembered by, drawn from Houston's world (the composer's multi-shadow lift, the card-running-glow, the aurora chrome). Spend boldness here.
+- **Motion moments** — where (if anywhere) animation serves: a load sequence, a reveal, a hover micro-interaction. Use only the vocabulary in design-system.md → Animation (durations, springs, `card-running-glow`, framer springs). Less is usually more.
+- **Copy** — the real strings, in Houston's voice (see Copy rules below).
+
+### Pass 2 — self-critique the plan, then revise
+
+Interrogate the plan before writing code:
+
+> "Does any part read like the generic default I'd produce for *any* surface of this kind?"
+
+Work the prompt as if from scratch — if you'd land in the same place, that part is a default, not a choice. **Banned defaults** (don't duplicate the list): `/DESIGN.md` → Banned generic-AI defaults, plus the three AI-cluster looks (cream + high-contrast serif + terracotta; near-black + one acid accent; broadsheet hairlines + zero radius). Revise the part, say what changed and why. Only then write code, deriving every value from the revised plan.
+
+## Multi-variant rule (NEW surfaces only)
+
+A **new screen, new website section, or new major component** gets 3–5 genuinely distinct directions explored as *cheap* artifacts first — never in `src/`:
+
+1. Produce each as an **ASCII wireframe + a short written treatment** (hierarchy, signature, motion, copy), or as throwaway HTML mockups in a **scratch dir outside the repo** (your scratchpad, never `app/src`, `packages/web/src`, `ui/`, or `website/src`).
+2. Judge them **pairwise** against the brief + the design system. Kill the defaults.
+3. Pin the winner in a **short written spec** (the Pass-1 plan, hardened).
+4. THEN build the winner in `src/`, following the spec exactly.
+
+**Small edits to an existing surface skip variants** — match the surrounding design exactly (same tokens, same spacing rhythm, same component grammar). Don't redesign a neighbourhood to change one house.
+
+## Restraint rules
+
+- **Spend boldness in one place.** The signature is the one memorable thing; keep everything around it quiet and disciplined.
+- **The product/content is the hero**, not the chrome. Monochrome content; brand colour lives only in chrome (design-system.md → Color restraint).
+- **When in doubt, remove one decoration.** Before declaring a surface done, take one accessory off.
+- **Match complexity to the vision.** Minimal directions demand precision in spacing, type, and detail — elegance is executing the chosen vision well, not adding to it.
+- Quality floor, unannounced: responsive to narrow widths, visible keyboard focus, `prefers-reduced-motion` respected, no hover-only affordances.
+
+## Copy rules
+
+Words are design material (design-system.md → Non-technical labels; `houston/CLAUDE.md` → Internationalization). Every user-facing string:
+
+- **Sentence case.** Never uppercase / `tracking-wider` headers.
+- **Verbs that name the action** — "Save changes", not "Submit". "Start", "Approve", "Delete".
+- **Consistent naming across a flow** — the button that says "Publish" produces a toast that says "Published".
+- **Active voice, plain words**, non-technical (the target user never sees files/JSON/config/CLI). Errors explain what happened and how to fix it; empty states invite an action.
+- **No em dashes** in user-facing copy — commas or sentence breaks (validator enforces).
+- **Everything user-facing flows through i18n** — `t()` in `app/` (en source, es + pt mirror the shape; namespaces under `app/src/locales/<lang>/`). `ui/@houston-ai/*` stays i18n-agnostic: expose optional `labels?` props with English defaults; the `app/` consumer passes `t()` results in. Never import `react-i18next` in `ui/`.
+
+## When you touch shared surface
+
+- New/changed cross-surface component → bump `design/inventory/inventory.yaml` + CHANGELOG in the SAME change and run `pnpm check:parity` (`houston/CLAUDE.md` → Client-surface changes).
+- Generic reusable → `ui/`. App-specific → `app/`. Props over stores; no `@/` aliases and no app types in `ui/`.
+
+## Gate
+
+**Design is not done until `/design-review` passes.** Never declare UI work complete on the strength of the code alone — run the screenshot self-critique loop first.


### PR DESCRIPTION
## What

**Design process infrastructure — part 1 of the design-quality program** (part 2, the QA gates, merged in #1068 from this same branch).

Encodes the AI design workflow as repo infrastructure so every agent session (Claude Code and Codex via the AGENTS.md symlink) produces on-system UI by default:

- **`DESIGN.md`** (repo root, 123 lines): compact agent-facing design spec — identity (futuristic theme), hard rules (semantic tokens only + sanctioned exceptions, core-primitives lock, Lucide-only, both themes), real token scales (type/spacing/radius/motion/elevation), the semantic color ladder with actual light/dark values, motion craft rules (<300ms, ease-out, exits faster, transform/opacity only, no animation on high-frequency interactions), banned generic-AI defaults, polish checklist, process pointers. Token JSON stays authoritative on conflict.
- **`skills/frontend-design`**: two-pass discipline (commit direction before code, self-critique the plan against the brief), 3–5 genuinely distinct variants for new surfaces judged before building, restraint + copy rules.
- **`skills/design-review`**: mandatory screenshot self-critique loop — both themes × desktop/narrow, 10-point rubric scored with vision, fix top 3, repeat (min 2 passes), completion gate including `test:visual`.
- **CLAUDE.md**: DESIGN.md + both skills wired into the dispatch table, phase-7 verify, test-commands table, client-surface iron rules. Replaces the stale `/critique`/`/polish`/… skill references (not in this repo).
- **`knowledge-base/design-system.md`** rewritten current-state-only with verified token truth: real surface ladder (`bg-gutter`/`bg-background`/`bg-input`/`bg-card`/`bg-chip` — the documented `--ht-layer-*` tokens never existed), `#fcfcfc` not `#fbfbfb`, near-ink focus ring, `card` = `glass.white-68`. Superseded monochrome doctrine moved to `design-system-history.md`; KB index updated.

## Verification
Docs/skills only (no runtime code). `pnpm check`, `check:boundaries`, `check:parity`, `houston-web typecheck` + `typecheck:e2e` all pass; pre-commit ran repo-wide typecheck green. All section anchors and command/port references in the skills verified against the actual repo (dev :1430, fake-host :4399, test:visual).

Fixes HOU-882

🤖 Generated with [Claude Code](https://claude.com/claude-code)