### PR TITLE
fix(runtime): paragraph break between a turn's streamed text blocks (HOU-857)

### DIFF
--- a/packages/runtime/src/backends/claude/translate.test.ts
+++ b/packages/runtime/src/backends/claude/translate.test.ts
@@ -128,6 +128,59 @@ test("text_delta / thinking_delta map to text / thinking frames", () => {
   ]);
 });
 
+test("a follow-up text block gets a paragraph-break prefix on its first delta (HOU-857)", () => {
+  // The screenshot bug: text → tool call → text streams as distinct content
+  // blocks, but the bare deltas concatenate downstream into "…for you now.Go
+  // ahead…". The new block's first delta must carry the separator.
+  const blockStart = (index: number, type: string) =>
+    streamEvent({
+      type: "content_block_start",
+      index,
+      content_block: { type },
+    });
+  const { events } = collect([
+    blockStart(0, "text"),
+    textDelta("I'll get that set up for you now."),
+    toolStart(1, "t1", "connect"),
+    blockStop(1),
+    toolResult("t1", false),
+    blockStart(0, "text"),
+    textDelta("Go ahead and sign in."),
+    textDelta(" Once connected, I'll confirm."),
+  ]);
+  expect(events).toEqual([
+    { type: "text", data: "I'll get that set up for you now." },
+    { type: "tool_start", data: { name: "connect", args: {} } },
+    { type: "tool_end", data: { name: "connect", isError: false } },
+    // Separator rides the follow-up block's FIRST delta only.
+    { type: "text", data: "\n\nGo ahead and sign in." },
+    { type: "text", data: " Once connected, I'll confirm." },
+  ]);
+});
+
+test("thinking blocks separate independently; the first of each kind is never prefixed", () => {
+  const blockStart = (index: number, type: string) =>
+    streamEvent({
+      type: "content_block_start",
+      index,
+      content_block: { type },
+    });
+  const { events } = collect([
+    blockStart(0, "thinking"),
+    thinkingDelta("first thoughts"),
+    blockStart(1, "thinking"),
+    thinkingDelta("second thoughts"),
+    // First TEXT block after thinking-only content: text starts fresh.
+    blockStart(2, "text"),
+    textDelta("Hello"),
+  ]);
+  expect(events).toEqual([
+    { type: "thinking", data: "first thoughts" },
+    { type: "thinking", data: "\n\nsecond thoughts" },
+    { type: "text", data: "Hello" },
+  ]);
+});
+
 test("tool_use: accumulated input_json_delta parses into tool_start args at stop", () => {
   const { events } = collect([
     toolStart(1, "t1", "Read"),

--- a/packages/runtime/src/backends/claude/translate.ts
+++ b/packages/runtime/src/backends/claude/translate.ts
@@ -38,6 +38,17 @@ export function createStreamTranslator(cb: TranslatorCallbacks) {
   const toolBlocks = new Map<number, ToolBlock>();
   const toolNameById = new Map<string, string>();
   let lastRateLimitRetry: number | null = null;
+  // Block-boundary tracking (HOU-857): a turn's text arrives as flat deltas,
+  // but the model emits DISTINCT content blocks (text → tool_use → text on the
+  // next request). Downstream every consumer concatenates the deltas verbatim
+  // — the live feed, the persisted transcript — so without a separator the
+  // second block glues onto the first mid-sentence ("…for you now.Go ahead…").
+  // When a NEW text block starts after this turn already streamed text, prefix
+  // its first delta with a paragraph break. Same for thinking blocks.
+  let sawText = false;
+  let sawThinking = false;
+  let sepText = false;
+  let sepThinking = false;
   // At most one provider_error per turn: an errored assistant message and an
   // error result can both describe the same failure — never double-terminal.
   let emittedError = false;
@@ -97,14 +108,27 @@ export function createStreamTranslator(cb: TranslatorCallbacks) {
         });
         toolNameById.set(block.id, block.name);
       }
+      // A FOLLOW-UP text/thinking block: arm the separator; the block's first
+      // delta carries it (never emitted standalone, so an empty block can't
+      // leave a dangling break).
+      if (block?.type === "text" && sawText) sepText = true;
+      if (block?.type === "thinking" && sawThinking) sepThinking = true;
       return [];
     }
     if (event?.type === "content_block_delta") {
       const d = event.delta;
-      if (d?.type === "text_delta" && d.text !== undefined)
-        return [{ type: "text", data: d.text }];
-      if (d?.type === "thinking_delta" && d.thinking !== undefined)
-        return [{ type: "thinking", data: d.thinking }];
+      if (d?.type === "text_delta" && d.text !== undefined) {
+        sawText = true;
+        const data = sepText ? `\n\n${d.text}` : d.text;
+        sepText = false;
+        return [{ type: "text", data }];
+      }
+      if (d?.type === "thinking_delta" && d.thinking !== undefined) {
+        sawThinking = true;
+        const data = sepThinking ? `\n\n${d.thinking}` : d.thinking;
+        sepThinking = false;
+        return [{ type: "thinking", data }];
+      }
       if (d?.type === "input_json_delta" && event.index !== undefined) {
         const tb = toolBlocks.get(event.index);
         if (tb) tb.json += d.partial_json ?? "";

--- a/packages/runtime/src/backends/pi/session.ts
+++ b/packages/runtime/src/backends/pi/session.ts
@@ -2,14 +2,16 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import type { WireEvent } from "@houston/runtime-client";
 import type { HarnessSession, ResolvedModel, ThinkingLevel } from "../types";
-import { toWire } from "./wire";
+import { createWireTranslator } from "./wire";
 
 /**
  * The pi implementation of HarnessSession: a thin wrapper over a pi
- * `AgentSession`. It runs pi's event stream through `toWire` and forwards only
- * the non-null WireEvents; every other method forwards to the underlying session.
- * The single `Model<Api>` cast lives here — the seam speaks `ResolvedModel`, and
- * the concrete objects flowing through are real pi models.
+ * `AgentSession`. It runs pi's event stream through a per-subscription wire
+ * translator (`createWireTranslator` — the `toWire` mapping plus block-boundary
+ * separators, HOU-857) and forwards only the non-null WireEvents; every other
+ * method forwards to the underlying session. The single `Model<Api>` cast lives
+ * here — the seam speaks `ResolvedModel`, and the concrete objects flowing
+ * through are real pi models.
  */
 export class PiSession implements HarnessSession {
   private disposed = false;
@@ -17,8 +19,9 @@ export class PiSession implements HarnessSession {
   constructor(private readonly session: AgentSession) {}
 
   subscribe(listener: (e: WireEvent) => void): () => void {
+    const translate = createWireTranslator();
     return this.session.subscribe((e) => {
-      const wire = toWire(e);
+      const wire = translate(e);
       if (wire) listener(wire);
     });
   }

--- a/packages/runtime/src/backends/pi/wire.test.ts
+++ b/packages/runtime/src/backends/pi/wire.test.ts
@@ -5,7 +5,7 @@ import type {
 } from "@earendil-works/pi-ai";
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import { expect, test } from "vitest";
-import { normalizeUsage, toWire } from "./wire";
+import { createWireTranslator, normalizeUsage, toWire } from "./wire";
 
 /** A valid pi `Usage` for fixtures; `cost` is required by the type. */
 function usage(partial: Partial<Usage>): Usage {
@@ -265,6 +265,96 @@ test("toWire omits tool_end content for a text-less or malformed result", () => 
   expect(toWire(bare)).toEqual({
     type: "tool_end",
     data: { name: "bash", isError: true },
+  });
+});
+
+// --- createWireTranslator: block-boundary separators (HOU-857) ---------------
+
+/** A `message_update` session event carrying the given assistant-message event. */
+function msgUpdate(assistantMessageEvent: unknown): AgentSessionEvent {
+  return {
+    type: "message_update",
+    message: assistantMessage(usage({})),
+    assistantMessageEvent,
+  } as unknown as AgentSessionEvent;
+}
+const textStart = () => msgUpdate({ type: "text_start", contentIndex: 0 });
+const textDelta = (delta: string) =>
+  msgUpdate({ type: "text_delta", contentIndex: 0, delta });
+const thinkingStart = () =>
+  msgUpdate({ type: "thinking_start", contentIndex: 0 });
+const thinkingDelta = (delta: string) =>
+  msgUpdate({ type: "thinking_delta", contentIndex: 0, delta });
+const agentStart = () =>
+  ({ type: "agent_start" }) as unknown as AgentSessionEvent;
+
+test("translator inserts a paragraph break between a turn's text blocks (HOU-857)", () => {
+  // The screenshot bug: text → tool call → text streamed as two blocks, but the
+  // bare deltas concatenate downstream into "…for you now.Go ahead…". The
+  // second block's FIRST delta must carry the separator.
+  const translate = createWireTranslator();
+  expect(translate(textStart())).toBeNull();
+  expect(translate(textDelta("I'll get that set up for you now."))).toEqual({
+    type: "text",
+    data: "I'll get that set up for you now.",
+  });
+  translate({
+    type: "tool_execution_start",
+    toolCallId: "t1",
+    toolName: "connect",
+    args: {},
+  } as unknown as AgentSessionEvent);
+  expect(translate(textStart())).toBeNull();
+  expect(translate(textDelta("Go ahead and sign in."))).toEqual({
+    type: "text",
+    data: "\n\nGo ahead and sign in.",
+  });
+  // Later deltas of the SAME block stream unprefixed.
+  expect(translate(textDelta(" Once connected, I'll confirm."))).toEqual({
+    type: "text",
+    data: " Once connected, I'll confirm.",
+  });
+});
+
+test("translator never prefixes the turn's first text block — even after thinking", () => {
+  const translate = createWireTranslator();
+  expect(translate(thinkingStart())).toBeNull();
+  expect(translate(thinkingDelta("hmm"))).toEqual({
+    type: "thinking",
+    data: "hmm",
+  });
+  // First TEXT block: thinking streamed already, but text starts fresh.
+  expect(translate(textStart())).toBeNull();
+  expect(translate(textDelta("Hello"))).toEqual({
+    type: "text",
+    data: "Hello",
+  });
+});
+
+test("translator separates thinking blocks independently of text blocks", () => {
+  const translate = createWireTranslator();
+  translate(thinkingStart());
+  expect(translate(thinkingDelta("first block"))).toEqual({
+    type: "thinking",
+    data: "first block",
+  });
+  translate(thinkingStart());
+  expect(translate(thinkingDelta("second block"))).toEqual({
+    type: "thinking",
+    data: "\n\nsecond block",
+  });
+});
+
+test("translator resets its block state on agent_start (a new turn starts fresh)", () => {
+  const translate = createWireTranslator();
+  translate(textStart());
+  translate(textDelta("turn one"));
+  translate(agentStart());
+  translate(textStart());
+  // A long-lived subscriber crossing into the next turn: no leaked separator.
+  expect(translate(textDelta("turn two"))).toEqual({
+    type: "text",
+    data: "turn two",
   });
 });
 

--- a/packages/runtime/src/backends/pi/wire.ts
+++ b/packages/runtime/src/backends/pi/wire.ts
@@ -68,11 +68,59 @@ export function normalizeUsage(u: unknown): TokenUsage | null {
 }
 
 /**
+ * A stateful per-subscription translator over {@link toWire}: injects the
+ * paragraph break between CONTENT BLOCKS that the flat delta stream otherwise
+ * loses (HOU-857). A turn shaped text → tool call → text streams as two
+ * distinct blocks (pi emits `text_start` for each), but every downstream
+ * consumer — the live feed, the persisted transcript — concatenates the bare
+ * deltas, gluing the second block onto the first mid-sentence ("…for you
+ * now.Go ahead…"). When a new text block starts after this turn already
+ * streamed text, the block's FIRST delta is prefixed with "\n\n"; same for
+ * thinking blocks. The separator rides a delta (never emitted standalone), so
+ * an empty block can't leave a dangling break. State resets on `agent_start`
+ * so a long-lived subscriber never bleeds one turn's blocks into the next.
+ */
+export function createWireTranslator(): (
+  e: AgentSessionEvent,
+) => WireEvent | null {
+  let sawText = false;
+  let sawThinking = false;
+  let sepText = false;
+  let sepThinking = false;
+  return (e) => {
+    if (e.type === "agent_start") {
+      sawText = sawThinking = sepText = sepThinking = false;
+    } else if (e.type === "message_update") {
+      const t = e.assistantMessageEvent.type;
+      if (t === "text_start" && sawText) sepText = true;
+      if (t === "thinking_start" && sawThinking) sepThinking = true;
+    }
+    const wire = toWire(e);
+    if (wire?.type === "text") {
+      sawText = true;
+      if (sepText) {
+        sepText = false;
+        return { ...wire, data: `\n\n${wire.data}` };
+      }
+    } else if (wire?.type === "thinking") {
+      sawThinking = true;
+      if (sepThinking) {
+        sepThinking = false;
+        return { ...wire, data: `\n\n${wire.data}` };
+      }
+    }
+    return wire;
+  };
+}
+
+/**
  * Map a pi AgentSession event to our wire event (or null to drop it). Shared
  * by the long-lived server (chat.ts) and the per-turn cloud runtime — the two
  * MUST emit identical frames, since the web client and the control-plane relay
  * speak this one dialect. Typed against pi's own `AgentSessionEvent` union so
- * the `switch` narrows each arm to the exact event shape.
+ * the `switch` narrows each arm to the exact event shape. Subscriptions go
+ * through {@link createWireTranslator}, which wraps this pure mapping with the
+ * per-turn block-boundary state.
  */
 export function toWire(e: AgentSessionEvent): WireEvent | null {
   switch (e.type) {


### PR DESCRIPTION
## Summary

HOU-857: sometimes the agent's reply renders with two sentences glued together mid-word ("…I'll get that set up for you now.**Go** ahead and sign in…"), with no spacing or line break.

### Root cause

A turn shaped **text → tool call → text** (e.g. the connect-your-calendar flow: the model explains, renders the connect card via a tool, then continues) streams as *distinct content blocks*. But the wire dialect flattens them into bare `text` delta frames with no block boundary, and every consumer concatenates the deltas verbatim:

- live feed: `packages/sdk/src/modules/turns/turn-frames.ts` (`s.text += ev.data`)
- persisted transcript: `packages/runtime/src/session/exec-turn.ts` (`assistantText += wire.data`)

So the second block's first word lands directly against the first block's last character — both live *and* in reloaded history. It only reproduces when the model emits more than one text block per turn (usually around tool use), which matches the "only sometimes, when it's doing background work" symptom.

### Fix

Emit the boundary at the source, in both backends, so every consumer (live feed, persisted history, web/desktop/iOS) inherits correct text with zero changes:

- **pi backend**: new stateful `createWireTranslator()` wrapping the pure `toWire` — pi's `text_start`/`thinking_start` block events arm a separator, and the follow-up block's first delta is prefixed with `\n\n`. State resets on `agent_start`. `PiSession.subscribe` now builds one translator per subscription.
- **Claude SDK backend**: `createStreamTranslator` (already per-turn) arms the separator on `content_block_start` of a text/thinking block after that kind already streamed.

The separator always rides a real delta (never emitted standalone), so an empty block can't leave a dangling break. First block of each kind is never prefixed. Thinking blocks separate independently of text blocks.

### Tests

- `wire.test.ts`: separator between tool-split text blocks; first block (even after thinking) unprefixed; thinking-block separation; `agent_start` reset.
- `translate.test.ts`: same scenarios through the Claude SDK stream shape.

All gates pass: runtime 777 ✓, host 1025 ✓, domain ✓, `pnpm typecheck` ✓, `pnpm check` ✓, `pnpm check:boundaries` ✓.

### Repro (before the fix)

1. Chat with an agent whose turn interleaves prose and a tool call — e.g. ask "please help me connect my calendar" so the model explains, invokes the integration connect card, then continues with instructions.
2. Observe the reply: the post-tool sentence is glued to the pre-tool sentence with no space or paragraph break ("…for you now.Go ahead…"), both while streaming and after reload.

### Verify (after the fix)

1. Repeat the same flow (`pnpm dev`, any provider — both the pi and Claude-SDK backends are covered).
2. The pre-tool and post-tool sentences render as separate paragraphs, live and after reopening the chat (the separator is persisted in the transcript).