### PR TITLE
feat(files): upload complete folders from the Files tab (HOU-889)

### DIFF
--- a/app/src/components/tabs/files-tab-labels.ts
+++ b/app/src/components/tabs/files-tab-labels.ts
@@ -25,6 +25,8 @@ export function buildBrowserLabels(t: TFunction<"agents">): FilesBrowserLabels {
     menuButton: t("files.menuButton"),
     breadcrumbs: t("files.breadcrumbs"),
     uploadFiles: t("files.uploadFiles"),
+    upload: t("files.upload"),
+    uploadFolder: t("files.uploadFolder"),
     openInFileManager: t("files.openInFileManager"),
     downloadAll: t("files.downloadAll"),
   };

--- a/app/src/components/tabs/files-tab.tsx
+++ b/app/src/components/tabs/files-tab.tsx
@@ -1,5 +1,6 @@
 import { type FileEntry, FilesBrowser } from "@houston-ai/agent";
 import { isTauri } from "@tauri-apps/api/core";
+import type { InputHTMLAttributes } from "react";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -20,6 +21,14 @@ import { useUIStore } from "../../stores/ui";
 import { FilePreviewDialog } from "../file-preview-dialog";
 import { MoveConflictDialog } from "../move-conflict-dialog";
 import { buildBrowserLabels, buildMenuLabels } from "./files-tab-labels";
+import { buildUploadIntake } from "./files-upload-intake";
+
+// Non-standard attribute (WebKit lineage, supported by every engine we ship
+// on): turns the picker into a directory picker. Unknown to React's typings,
+// hence the cast; engines without it fall back to a plain file picker.
+const FOLDER_INPUT_PROPS = {
+  webkitdirectory: "",
+} as InputHTMLAttributes<HTMLInputElement>;
 
 export default function FilesTab({ agent }: TabProps) {
   const { t } = useTranslation("agents");
@@ -41,6 +50,7 @@ export default function FilesTab({ agent }: TabProps) {
     osDir !== undefined;
   const [preview, setPreview] = useState<FileEntry | null>(null);
   const fileInput = useRef<HTMLInputElement>(null);
+  const folderInput = useRef<HTMLInputElement>(null);
   const browserLabels = buildBrowserLabels(t);
   const menuLabels = buildMenuLabels(t, canUseLocalFiles);
   const path = agent.folderPath;
@@ -76,6 +86,10 @@ export default function FilesTab({ agent }: TabProps) {
       .catch(() => {});
   };
   const pickFiles = () => fileInput.current?.click();
+  const pickFolder = () => folderInput.current?.click();
+  const { ingest, onDropError } = buildUploadIntake(t, (picked, targetDir) =>
+    uploadFiles.mutate({ files: picked, targetDir }),
+  );
 
   return (
     <div className="flex h-full flex-col">
@@ -85,10 +99,20 @@ export default function FilesTab({ agent }: TabProps) {
         multiple
         className="hidden"
         onChange={(e) => {
-          const picked = Array.from(e.currentTarget.files ?? []);
-          if (picked.length > 0) uploadFiles.mutate({ files: picked });
+          ingest(Array.from(e.currentTarget.files ?? []));
           e.currentTarget.value = ""; // allow re-picking the same file
         }}
+      />
+      <input
+        ref={folderInput}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          ingest(Array.from(e.currentTarget.files ?? []));
+          e.currentTarget.value = ""; // allow re-picking the same folder
+        }}
+        {...FOLDER_INPUT_PROPS}
       />
       <FilesBrowser
         files={files ?? []}
@@ -115,11 +139,9 @@ export default function FilesTab({ agent }: TabProps) {
         }
         onCreateFolder={(name) => createFolder.mutate(name)}
         onFilesDropped={(dropped, targetFolder) =>
-          uploadFiles.mutate({
-            files: dropped,
-            targetDir: targetFolder ?? null,
-          })
+          ingest(dropped, targetFolder ?? null)
         }
+        onDropError={onDropError}
         onMove={
           // Drag-move needs the TS host's move route; the legacy engine has none.
           newEngineActive() ? move.requestMove : undefined
@@ -130,6 +152,11 @@ export default function FilesTab({ agent }: TabProps) {
         labels={browserLabels}
         menuLabels={menuLabels}
         onUpload={pickFiles}
+        onUploadFolder={
+          // Folder structure needs the TS host's relPath-aware import route;
+          // the legacy engine's import flattens everything to the root.
+          newEngineActive() ? pickFolder : undefined
+        }
         onRevealAgent={
           canUseLocalFiles && osDir
             ? () => tauriFiles.revealAgent(osDir)

--- a/app/src/components/tabs/files-upload-intake.ts
+++ b/app/src/components/tabs/files-upload-intake.ts
@@ -1,0 +1,47 @@
+/**
+ * Intake for Files-tab uploads (file picker, folder picker, drag-drop),
+ * mirroring the chat composer's folder intake (HOU-808) for the Files tab
+ * (HOU-889): hidden files a folder pick sweeps in (.DS_Store, .git/**) are
+ * dropped, oversized batches are refused loudly — uploading a silent subset
+ * would misrepresent what got uploaded — and dropped-folder expansion
+ * failures surface as toasts (the async walk has no caller to throw to).
+ */
+import {
+  MAX_ATTACHMENT_FILES,
+  TooManyAttachmentFilesError,
+  visibleAttachmentFiles,
+} from "@houston-ai/core";
+import type { TFunction } from "i18next";
+import { showErrorToast, showExpectedStateToast } from "../../lib/error-toast";
+
+export function buildUploadIntake(
+  t: TFunction<"agents">,
+  upload: (files: File[], targetDir?: string | null) => void,
+) {
+  const tooManyFiles = () =>
+    showExpectedStateToast(
+      t("files.uploadFiles"),
+      t("chat:composer.tooManyFiles", { max: MAX_ATTACHMENT_FILES }),
+    );
+  const ingest = (picked: File[], targetDir?: string | null) => {
+    const visible = visibleAttachmentFiles(picked);
+    if (visible.length > MAX_ATTACHMENT_FILES) {
+      tooManyFiles();
+      return;
+    }
+    if (visible.length > 0) upload(visible, targetDir);
+  };
+  const onDropError = (error: unknown) => {
+    if (error instanceof TooManyAttachmentFilesError) {
+      tooManyFiles();
+      return;
+    }
+    showErrorToast(
+      "files_drop",
+      error instanceof Error ? error.message : String(error),
+      error,
+      { userMessage: t("files.folderDropFailed") },
+    );
+  };
+  return { ingest, onDropError };
+}

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -156,6 +156,9 @@
       "cancel": "Cancel"
     },
     "uploadFiles": "Upload files",
+    "upload": "Upload",
+    "uploadFolder": "Upload folder",
+    "folderDropFailed": "We could not read that folder. Try the Upload button instead.",
     "downloadAll": "Download all",
     "columns": {
       "name": "Name",

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -156,6 +156,9 @@
       "cancel": "Cancelar"
     },
     "uploadFiles": "Subir archivos",
+    "upload": "Subir",
+    "uploadFolder": "Subir carpeta",
+    "folderDropFailed": "No pudimos leer esa carpeta. Intenta con el botón Subir.",
     "downloadAll": "Descargar todo",
     "columns": {
       "name": "Nombre",

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -156,6 +156,9 @@
       "cancel": "Cancelar"
     },
     "uploadFiles": "Enviar arquivos",
+    "upload": "Enviar",
+    "uploadFolder": "Enviar pasta",
+    "folderDropFailed": "Não conseguimos ler essa pasta. Tente o botão Enviar.",
     "downloadAll": "Baixar tudo",
     "columns": {
       "name": "Nome",

--- a/packages/fake-host/src/routes-files.ts
+++ b/packages/fake-host/src/routes-files.ts
@@ -62,6 +62,7 @@ export function handleWorkspaceFiles(
     const files = (Array.isArray(body?.files) ? body.files : []) as {
       name: string;
       contentBase64: string;
+      relPath?: string;
     }[];
     const dir = typeof body?.dir === "string" && body.dir ? body.dir : null;
     return json({ paths: state.importWorkspaceFiles(id, dir, files) });

--- a/packages/fake-host/src/state-workspace.ts
+++ b/packages/fake-host/src/state-workspace.ts
@@ -106,12 +106,15 @@ export function readWorkspaceFile(
 export function importWorkspaceFiles(
   agentId: string,
   dir: string | null,
-  files: { name: string; contentBase64: string }[],
+  files: { name: string; contentBase64: string; relPath?: string }[],
 ): string[] {
   const now = Date.now();
   const paths: string[] = [];
   for (const f of files) {
-    let rel = dir ? `${dir}/${f.name}` : f.name;
+    // Folder uploads (HOU-889) send the folder-relative path; nested keys
+    // synthesize their directory rows in listWorkspaceFiles, like the real host.
+    const name = f.relPath ?? f.name;
+    let rel = dir ? `${dir}/${name}` : name;
     const dot = rel.lastIndexOf(".");
     for (let n = 1; state.workspace.has(key(agentId, rel)); n++) {
       const stem = dot > 0 ? rel.slice(0, dot) : rel;

--- a/packages/host/src/turn/files-import.test.ts
+++ b/packages/host/src/turn/files-import.test.ts
@@ -3,9 +3,9 @@ import { MemoryVfs } from "../vfs";
 import {
   importWorkspaceFiles,
   MAX_UPLOAD_BYTES,
-  moveWorkspaceEntry,
   parseImportBody,
 } from "./files-import";
+import { moveWorkspaceEntry } from "./files-move";
 import { FileOpError, FilePathError, listWorkspace } from "./files-ops";
 
 /**
@@ -77,6 +77,71 @@ test("upload names are single segments: traversal, separators, dot-files refused
       { name: "ok.txt", contentBase64: b64("x") },
     ]),
   ).rejects.toThrow(FilePathError);
+});
+
+test("folder uploads (relPath) keep their structure, at the root and under a dir", async () => {
+  const vfs = new MemoryVfs();
+  const paths = await importWorkspaceFiles(vfs, ROOT, null, [
+    {
+      name: "intro.md",
+      contentBase64: b64("i"),
+      relPath: "docs/guide/intro.md",
+    },
+    { name: "logo.png", contentBase64: b64("p"), relPath: "docs/logo.png" },
+  ]);
+  expect(paths).toEqual(["docs/guide/intro.md", "docs/logo.png"]);
+  expect(await vfs.readText(`${ROOT}/docs/guide/intro.md`)).toBe("i");
+  const nested = await importWorkspaceFiles(vfs, ROOT, "Reports", [
+    { name: "a.txt", contentBase64: b64("a"), relPath: "docs/a.txt" },
+  ]);
+  expect(nested).toEqual(["Reports/docs/a.txt"]);
+  expect(await vfs.readText(`${ROOT}/Reports/docs/a.txt`)).toBe("a");
+});
+
+test("re-uploading a folder merges directories but never overwrites files", async () => {
+  const vfs = new MemoryVfs();
+  await vfs.writeText(`${ROOT}/docs/a.txt`, "original");
+  const paths = await importWorkspaceFiles(vfs, ROOT, null, [
+    { name: "a.txt", contentBase64: b64("second"), relPath: "docs/a.txt" },
+    { name: "b.txt", contentBase64: b64("new"), relPath: "docs/b.txt" },
+  ]);
+  expect(paths).toEqual(["docs/a (1).txt", "docs/b.txt"]);
+  expect(await vfs.readText(`${ROOT}/docs/a.txt`)).toBe("original");
+  expect(await vfs.readText(`${ROOT}/docs/a (1).txt`)).toBe("second");
+});
+
+test("relPaths are validated per segment; one bad path fails the whole batch unwritten", async () => {
+  const vfs = new MemoryVfs();
+  for (const relPath of [
+    "../evil.txt", // 2 segments but traversal
+    "docs/../evil.txt",
+    "docs/.env", // hidden segment
+    "docs//a.txt", // empty segment
+    "docs\\a.txt", // backslash (single segment → plain-name rules)
+    "plain.txt", // 1 segment must arrive as `name`
+    `${"d/".repeat(33)}a.txt`, // too deep
+  ]) {
+    await expect(
+      importWorkspaceFiles(vfs, ROOT, null, [
+        { name: "good.txt", contentBase64: b64("ok") },
+        { name: "a.txt", contentBase64: b64("x"), relPath },
+      ]),
+    ).rejects.toThrow(FilePathError);
+  }
+  // Batch-level atomicity: the valid sibling was never written.
+  expect(await vfs.readBytes(`${ROOT}/good.txt`)).toBeNull();
+});
+
+test("parseImportBody rejects a non-string relPath and passes a valid one through", () => {
+  expect(() =>
+    parseImportBody({
+      files: [{ name: "a.txt", contentBase64: b64("x"), relPath: 42 }],
+    }),
+  ).toThrow("'relPath' must be a string");
+  const ok = parseImportBody({
+    files: [{ name: "a.txt", contentBase64: b64("x"), relPath: "docs/a.txt" }],
+  });
+  expect(ok.files[0]?.relPath).toBe("docs/a.txt");
 });
 
 test("move takes a file into a folder and back to the root", async () => {

--- a/packages/host/src/turn/files-import.ts
+++ b/packages/host/src/turn/files-import.ts
@@ -2,10 +2,10 @@ import type { Vfs } from "../vfs";
 import { FileOpError, FilePathError, fileKey, safeRel } from "./files-ops";
 
 /**
- * Uploads into + moves within an agent's workspace — the write half of the
- * Files tab (drag-drop / Browse / drag-a-row-onto-a-folder). Same path-safety
- * wall as every other files op: nothing lands in (or moves into) the internal
- * top-level dot-dirs, and nothing escapes the workspace root.
+ * Uploads into an agent's workspace — the upload half of the Files tab
+ * (drag-drop / Browse / folder pick; drag-moves live in `files-move.ts`).
+ * Same path-safety wall as every other files op: nothing lands in the
+ * internal top-level dot-dirs, and nothing escapes the workspace root.
  */
 
 /**
@@ -28,10 +28,18 @@ export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
 export const MAX_UPLOAD_BODY_BYTES =
   Math.ceil((MAX_UPLOAD_BYTES * 4) / 3) + 1024 * 1024;
 
-/** One uploaded file: original name + its base64-encoded bytes. */
+/**
+ * One uploaded file: original name + its base64-encoded bytes. `relPath` is
+ * set for folder uploads (HOU-889): the file's slash-joined path INSIDE the
+ * picked/dropped folder, including the filename (mirrors
+ * `File.webkitRelativePath`, e.g. `docs/guide/intro.md`) — the file then lands
+ * at `<dir>/<relPath>` so the folder's structure survives. Hosts predating
+ * folder support ignore the field and store the flat `name`.
+ */
 export interface UploadFile {
   name: string;
   contentBase64: string;
+  relPath?: string;
 }
 
 /** Validate an uploaded filename: one path segment, no traversal, no hidden files. */
@@ -49,6 +57,31 @@ function safeUploadName(name: string): string {
   return name;
 }
 
+/** Folder uploads can nest, but not absurdly: a runaway path is a client bug. */
+const MAX_RELPATH_SEGMENTS = 32;
+const MAX_RELPATH_LENGTH = 1024;
+
+/**
+ * Validate a folder-upload relative path: 2+ segments (a 1-segment path is a
+ * plain filename and must arrive as `name`), every segment individually held
+ * to the same rules as `safeUploadName` — so `..`, `\`, empty segments
+ * (`a//b`) and hidden dot-segments are all rejected loudly, and the joined
+ * path can never escape the workspace (or the target dir). Mirrors the
+ * composer-attachment route's validation (`turn/attachments.ts`).
+ */
+function safeUploadRelPath(relPath: string): string {
+  const segments = relPath.split("/");
+  if (
+    segments.length < 2 ||
+    segments.length > MAX_RELPATH_SEGMENTS ||
+    relPath.length > MAX_RELPATH_LENGTH
+  ) {
+    throw new FilePathError(relPath);
+  }
+  for (const segment of segments) safeUploadName(segment);
+  return relPath;
+}
+
 /** Parse + validate the `files/import` body. Throws (→ 4xx) on malformed input. */
 export function parseImportBody(body: Record<string, unknown>): {
   dir: string | null;
@@ -60,19 +93,26 @@ export function parseImportBody(body: Record<string, unknown>): {
   }
   let total = 0;
   const files = body.files.map((raw, i) => {
-    const f = raw as { name?: unknown; contentBase64?: unknown };
+    const f = raw as {
+      name?: unknown;
+      contentBase64?: unknown;
+      relPath?: unknown;
+    };
     if (typeof f.name !== "string" || typeof f.contentBase64 !== "string") {
       throw new FileOpError(
         400,
         `file[${i}] needs string 'name' and 'contentBase64'`,
       );
     }
+    if (f.relPath !== undefined && typeof f.relPath !== "string") {
+      throw new FileOpError(400, `file[${i}] 'relPath' must be a string`);
+    }
     // base64 is ~4/3 the byte size; estimate to fail oversized uploads loudly.
     total += Math.floor((f.contentBase64.length * 3) / 4);
     if (total > MAX_UPLOAD_BYTES) {
       throw new FileOpError(413, "upload exceeds the size limit");
     }
-    return { name: f.name, contentBase64: f.contentBase64 };
+    return { name: f.name, contentBase64: f.contentBase64, relPath: f.relPath };
   });
   return { dir, files };
 }
@@ -94,8 +134,14 @@ function dedupeRel(rel: string, taken: (r: string) => boolean): string {
 
 /**
  * Write each uploaded file into the workspace (under `dir` when given) and
- * return the relative paths stored. Existing files are never silently
- * overwritten — colliding names get " (n)" suffixes, Finder-style.
+ * return the relative paths stored. Folder uploads (`relPath` set) keep their
+ * directory structure: `docs/a.md` lands at `<dir>/docs/a.md`. FILES are never
+ * silently overwritten — colliding names get " (n)" suffixes, Finder-style —
+ * while DIRECTORIES deliberately merge (`dedupeRel` only suffixes the
+ * filename): the client uploads a folder across several size-batched
+ * requests, so a per-request folder rename would scatter one folder over
+ * many. The WHOLE batch is validated before anything is written, so one bad
+ * path 400s the request without leaving earlier files half-persisted.
  */
 export async function importWorkspaceFiles(
   vfs: Vfs,
@@ -105,63 +151,21 @@ export async function importWorkspaceFiles(
 ): Promise<string[]> {
   const target = dir === null ? "" : safeRel(dir);
   const existing = new Set((await vfs.listDetailed(root)).map((s) => s.key));
-  const paths: string[] = [];
-  for (const f of files) {
-    const name = safeUploadName(f.name);
+  const planned = files.map((f) => {
+    const name = f.relPath
+      ? safeUploadRelPath(f.relPath)
+      : safeUploadName(f.name);
     const rel = dedupeRel(target ? `${target}/${name}` : name, (r) =>
       existing.has(fileKey(root, r)),
     );
+    existing.add(fileKey(root, rel));
+    return { file: f, rel };
+  });
+  for (const { file, rel } of planned) {
     await vfs.writeBytes(
       fileKey(root, rel),
-      Buffer.from(f.contentBase64, "base64"),
+      Buffer.from(file.contentBase64, "base64"),
     );
-    existing.add(fileKey(root, rel));
-    paths.push(rel);
   }
-  return paths;
-}
-
-/**
- * Move a file or folder into `toDir` (null = workspace root), keeping its name.
- * Refuses to clobber an existing target (409) and to move a folder into itself.
- * Returns the new relative path.
- */
-export async function moveWorkspaceEntry(
-  vfs: Vfs,
-  root: string,
-  rel: string,
-  toDir: string | null,
-): Promise<string> {
-  const from = safeRel(rel);
-  const target = toDir === null ? "" : safeRel(toDir);
-  if (target === from || target.startsWith(`${from}/`)) {
-    throw new FileOpError(400, "cannot move a folder into itself");
-  }
-  const name = from.split("/").pop() ?? "";
-  const to = target ? `${target}/${name}` : name;
-  if (to === from) return from;
-
-  const fromKey = fileKey(root, from);
-  const toKey = fileKey(root, to);
-  const children = await vfs.listDetailed(fromKey); // non-empty ⇒ a directory
-  const existing = new Set((await vfs.listDetailed(root)).map((s) => s.key));
-  const targetTaken =
-    existing.has(toKey) || [...existing].some((k) => k.startsWith(`${toKey}/`));
-  if (targetTaken) {
-    throw new FileOpError(409, `"${name}" already exists there`);
-  }
-
-  if (children.length > 0) {
-    for (const c of children) {
-      await vfs.move(c.key, `${toKey}${c.key.slice(fromKey.length)}`);
-    }
-    // Per-key moves leave the (now empty) source directory tree behind on a
-    // real filesystem; sweep it.
-    await vfs.deletePrefix(fromKey);
-    await vfs.deleteKey(fromKey);
-  } else {
-    if (!existing.has(fromKey)) throw new FileOpError(404, "file not found");
-    await vfs.move(fromKey, toKey);
-  }
-  return to;
+  return planned.map((p) => p.rel);
 }

--- a/packages/host/src/turn/files-move.ts
+++ b/packages/host/src/turn/files-move.ts
@@ -1,0 +1,53 @@
+import type { Vfs } from "../vfs";
+import { FileOpError, fileKey, safeRel } from "./files-ops";
+
+/**
+ * Drag-moves within an agent's workspace — the move half of the Files tab
+ * (drag-a-row-onto-a-folder). Same path-safety wall as every other files op
+ * (see `files-import.ts` for the upload half).
+ */
+
+/**
+ * Move a file or folder into `toDir` (null = workspace root), keeping its name.
+ * Refuses to clobber an existing target (409) and to move a folder into itself.
+ * Returns the new relative path.
+ */
+export async function moveWorkspaceEntry(
+  vfs: Vfs,
+  root: string,
+  rel: string,
+  toDir: string | null,
+): Promise<string> {
+  const from = safeRel(rel);
+  const target = toDir === null ? "" : safeRel(toDir);
+  if (target === from || target.startsWith(`${from}/`)) {
+    throw new FileOpError(400, "cannot move a folder into itself");
+  }
+  const name = from.split("/").pop() ?? "";
+  const to = target ? `${target}/${name}` : name;
+  if (to === from) return from;
+
+  const fromKey = fileKey(root, from);
+  const toKey = fileKey(root, to);
+  const children = await vfs.listDetailed(fromKey); // non-empty ⇒ a directory
+  const existing = new Set((await vfs.listDetailed(root)).map((s) => s.key));
+  const targetTaken =
+    existing.has(toKey) || [...existing].some((k) => k.startsWith(`${toKey}/`));
+  if (targetTaken) {
+    throw new FileOpError(409, `"${name}" already exists there`);
+  }
+
+  if (children.length > 0) {
+    for (const c of children) {
+      await vfs.move(c.key, `${toKey}${c.key.slice(fromKey.length)}`);
+    }
+    // Per-key moves leave the (now empty) source directory tree behind on a
+    // real filesystem; sweep it.
+    await vfs.deletePrefix(fromKey);
+    await vfs.deleteKey(fromKey);
+  } else {
+    if (!existing.has(fromKey)) throw new FileOpError(404, "file not found");
+    await vfs.move(fromKey, toKey);
+  }
+  return to;
+}

--- a/packages/host/src/turn/files.ts
+++ b/packages/host/src/turn/files.ts
@@ -8,9 +8,9 @@ import { archiveWorkspace } from "./files-archive";
 import {
   importWorkspaceFiles,
   MAX_UPLOAD_BODY_BYTES,
-  moveWorkspaceEntry,
   parseImportBody,
 } from "./files-import";
+import { moveWorkspaceEntry } from "./files-move";
 import {
   createWorkspaceFolder,
   deleteWorkspaceFile,

--- a/packages/web/e2e/files.spec.ts
+++ b/packages/web/e2e/files.spec.ts
@@ -3,10 +3,11 @@ import { expect, test } from "./support/fixtures";
 /**
  * The Files tab on the host adapter (HOU-677 follow-through): the default
  * Drive-style card grid with per-folder navigation, the Finder-style list
- * view behind the toggle, uploads through the header button, context-menu
- * rename + delete, and the browser-mode header action ("Download all" —
- * reveal-in-OS only exists on a co-located desktop). The fake host models
- * the real host's `files*` routes (see `@houston/fake-host` routes-files.ts).
+ * view behind the toggle, uploads through the header's Upload menu (files or
+ * a whole folder, HOU-889), context-menu rename + delete, and the
+ * browser-mode header action ("Download all" — reveal-in-OS only exists on a
+ * co-located desktop). The fake host models the real host's `files*` routes
+ * (see `@houston/fake-host` routes-files.ts).
  */
 
 async function openFilesTab(page: import("@playwright/test").Page) {
@@ -14,6 +15,21 @@ async function openFilesTab(page: import("@playwright/test").Page) {
   await page.getByRole("button", { name: "Files", exact: true }).click();
   // Seeded workspace: Q3 report.pdf + Docs/sales.csv.
   await expect(page.getByText("Q3 report.pdf")).toBeVisible();
+}
+
+/** Open the header's Upload menu and pick an item, resolving its filechooser. */
+async function openUploadChooser(
+  page: import("@playwright/test").Page,
+  item: "Upload files" | "Upload folder",
+) {
+  const [chooser] = await Promise.all([
+    page.waitForEvent("filechooser"),
+    (async () => {
+      await page.getByRole("button", { name: "Upload", exact: true }).click();
+      await page.getByRole("menuitem", { name: item }).click();
+    })(),
+  ]);
+  return chooser;
 }
 
 test("grid is the default: cards, folder navigation, breadcrumbs", async ({
@@ -55,9 +71,9 @@ test("list view keeps kind, size, and both date columns", async ({ page }) => {
   await expect(page.getByText("PDF Document")).toBeVisible();
 
   // Browser build: no OS file manager — the header offers Download all +
-  // Upload files, never "Open in File Manager".
+  // the Upload menu, never "Open in File Manager".
   await expect(
-    page.getByRole("button", { name: "Upload files" }),
+    page.getByRole("button", { name: "Upload", exact: true }),
   ).toBeVisible();
   await expect(
     page.getByRole("button", { name: "Download all" }),
@@ -65,13 +81,10 @@ test("list view keeps kind, size, and both date columns", async ({ page }) => {
   await expect(page.getByText("Open in File Manager")).toHaveCount(0);
 });
 
-test("uploads a file through the header button", async ({ page }) => {
+test("uploads a file through the header's Upload menu", async ({ page }) => {
   await openFilesTab(page);
 
-  const [chooser] = await Promise.all([
-    page.waitForEvent("filechooser"),
-    page.getByRole("button", { name: "Upload files" }).click(),
-  ]);
+  const chooser = await openUploadChooser(page, "Upload files");
   await chooser.setFiles({
     name: "notes.md",
     mimeType: "text/markdown",
@@ -83,6 +96,33 @@ test("uploads a file through the header button", async ({ page }) => {
   // The list view knows its Finder-style kind label.
   await page.getByRole("button", { name: "List view" }).click();
   await expect(page.getByText("Markdown", { exact: true })).toBeVisible();
+});
+
+test("uploads a whole folder with its structure intact, hidden files skipped", async ({
+  page,
+}, testInfo) => {
+  const { mkdirSync, writeFileSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  // A real on-disk folder: nested subfolder + a hidden file the intake drops.
+  const folder = join(testInfo.outputPath(), "Brand assets");
+  mkdirSync(join(folder, "docs"), { recursive: true });
+  writeFileSync(join(folder, "logo.svg"), "<svg/>");
+  writeFileSync(join(folder, "docs", "intro.md"), "# intro");
+  writeFileSync(join(folder, ".DS_Store"), "junk");
+
+  await openFilesTab(page);
+  const chooser = await openUploadChooser(page, "Upload folder");
+  await chooser.setFiles(folder);
+
+  // The folder lands as a navigable tree, structure preserved.
+  await page.getByText("Brand assets", { exact: true }).click();
+  await expect(page.getByText("logo.svg")).toBeVisible();
+  await expect(page.getByText(".DS_Store")).toHaveCount(0);
+  await page.getByText("docs", { exact: true }).click();
+  await expect(page.getByText("intro.md")).toBeVisible();
+  const crumbs = page.getByRole("navigation", { name: "Folder path" });
+  await expect(crumbs.getByText("Brand assets", { exact: true })).toBeVisible();
+  await expect(crumbs.getByText("docs", { exact: true })).toBeVisible();
 });
 
 test("renames and deletes a file from the context menu", async ({ page }) => {
@@ -163,10 +203,7 @@ test("a move that collides on a name offers Keep both instead of erroring", asyn
   await expect(page.getByText("Q3 report.pdf")).toHaveCount(0);
 
   // Re-create the same name at the root.
-  const [chooser] = await Promise.all([
-    page.waitForEvent("filechooser"),
-    page.getByRole("button", { name: "Upload files" }).click(),
-  ]);
+  const chooser = await openUploadChooser(page, "Upload files");
   await chooser.setFiles({
     name: "Q3 report.pdf",
     mimeType: "application/pdf",

--- a/packages/web/src/engine-adapter/client/project-files-mixin.ts
+++ b/packages/web/src/engine-adapter/client/project-files-mixin.ts
@@ -113,9 +113,14 @@ export function ProjectFilesMixin<TBase extends BaseCtor>(Base: TBase) {
         })
       ).json()) as { created: string };
     }
-    /** Upload browser Files into the workspace (Files tab drag-drop / Browse),
-     * optionally into a subfolder. One request per file, so each request stays
-     * within the host's upload cap regardless of how many files were dropped. */
+    /** Upload browser Files into the workspace (Files tab drag-drop / Browse /
+     * folder pick), optionally into a subfolder. Folder-derived files carry
+     * `webkitRelativePath`, forwarded as `relPath` so the host stores them
+     * nested and the folder structure survives (HOU-889); hosts predating it
+     * ignore the field and store the flat name. Small files batch together
+     * (the same size-budgeted plan attachments use) so a many-file folder
+     * doesn't turn into hundreds of round trips, while every request stays
+     * within the host's upload cap. */
     async uploadProjectFiles(
       agentPath: string,
       files: File[],
@@ -124,15 +129,20 @@ export function ProjectFilesMixin<TBase extends BaseCtor>(Base: TBase) {
       if (files.length === 0) return;
       if (!this.ctx.cp)
         throw new Error("Uploading files needs a connected host.");
-      for (const f of files) {
-        const contentBase64 = controlPlane.bytesToBase64(
-          new Uint8Array(await f.arrayBuffer()),
-        );
+      for (const batch of controlPlane.planAttachmentBatches(files)) {
         await this.cpFilesFetch(agentPath, "files/import", {
           method: "POST",
           body: JSON.stringify({
             dir: targetDir ?? null,
-            files: [{ name: f.name, contentBase64 }],
+            files: await Promise.all(
+              batch.map(async (f) => ({
+                name: f.name,
+                contentBase64: controlPlane.bytesToBase64(
+                  new Uint8Array(await f.arrayBuffer()),
+                ),
+                relPath: controlPlane.uploadRelPath(f),
+              })),
+            ),
           }),
         });
       }

--- a/packages/web/src/engine-adapter/cp/files-context.ts
+++ b/packages/web/src/engine-adapter/cp/files-context.ts
@@ -95,7 +95,7 @@ export async function saveAttachments(
         batch.map(async (f) => ({
           name: f.name,
           contentBase64: bytesToBase64(new Uint8Array(await f.arrayBuffer())),
-          relPath: attachmentRelPath(f),
+          relPath: uploadRelPath(f),
         })),
       ),
     };
@@ -140,9 +140,10 @@ export function planAttachmentBatches(files: readonly File[]): File[][] {
 /**
  * The upload-relative path for a folder-derived file, or undefined for a plain
  * file. Normalized to forward slashes with no leading slash; a value without a
- * `/` carries no structure and is treated as plain.
+ * `/` carries no structure and is treated as plain. Shared by composer
+ * attachments and the Files tab's folder upload (HOU-889).
  */
-function attachmentRelPath(f: File): string | undefined {
+export function uploadRelPath(f: File): string | undefined {
   const raw = f.webkitRelativePath;
   if (!raw) return undefined;
   const normalized = raw.replace(/\\/g, "/").replace(/^\/+/, "");

--- a/ui/agent/src/drop-zone.tsx
+++ b/ui/agent/src/drop-zone.tsx
@@ -2,6 +2,11 @@
  * Drop zone hooks for drag-and-drop.
  * Container handles ALL drops. Folders only provide visual highlight state.
  */
+import {
+  collectDroppedItems,
+  resolveDroppedFiles,
+  visibleAttachmentFiles,
+} from "@houston-ai/core";
 import { useCallback, useRef, useState } from "react";
 
 /** MIME type used for internal file moves. */
@@ -14,11 +19,28 @@ function hasDragData(e: React.DragEvent) {
   );
 }
 
-/** Container-level drop zone. Handles ALL drop events (both external and internal). */
-export function useDropZone(
-  onFilesDropped?: (files: File[], targetFolder?: string) => void,
-  onMove?: (sourcePath: string, targetFolder: string | null) => void,
-) {
+export interface DropZoneOptions {
+  onFilesDropped?: (files: File[], targetFolder?: string) => void;
+  onMove?: (sourcePath: string, targetFolder: string | null) => void;
+  /** Snapshot the hovered drop target SYNCHRONOUSLY at drop time — folder
+   *  expansion is async, so reading it later could see a newer drag. */
+  resolveTargetFolder?: () => string | undefined;
+  /** Folder expansion failures (unreadable entries, too many files). REQUIRED
+   *  for surfacing when onFilesDropped is set — the async walk has no caller
+   *  to throw to, and swallowing the error would drop the upload silently. */
+  onDropError?: (error: unknown) => void;
+}
+
+/** Container-level drop zone. Handles ALL drop events (both external and
+ *  internal). Dropped folders are walked recursively; each produced File
+ *  carries its folder-relative path (`webkitRelativePath`), hidden entries
+ *  skipped — same behavior as the chat composer (HOU-808). */
+export function useDropZone({
+  onFilesDropped,
+  onMove,
+  resolveTargetFolder,
+  onDropError,
+}: DropZoneOptions) {
   const [isDragging, setIsDragging] = useState(false);
   const counter = useRef(0);
 
@@ -49,10 +71,22 @@ export function useDropZone(
         return;
       }
       if (!onFilesDropped) return;
-      const files = Array.from(e.dataTransfer.files);
-      if (files.length > 0) onFilesDropped(files);
+      // Both the DataTransfer entries and the hovered folder must be captured
+      // before the first await: the DataTransfer is neutered when the handler
+      // returns, and the drop target belongs to THIS drag.
+      const items = collectDroppedItems(e.dataTransfer);
+      const targetFolder = resolveTargetFolder?.();
+      void resolveDroppedFiles(items)
+        .then((files) => {
+          const visible = visibleAttachmentFiles(files);
+          if (visible.length > 0) onFilesDropped(visible, targetFolder);
+        })
+        .catch((error: unknown) => {
+          if (!onDropError) throw error;
+          onDropError(error);
+        });
     },
-    [onFilesDropped, onMove],
+    [onFilesDropped, onMove, resolveTargetFolder, onDropError],
   );
 
   return {

--- a/ui/agent/src/files-browser-labels.ts
+++ b/ui/agent/src/files-browser-labels.ts
@@ -25,6 +25,10 @@ export interface FilesBrowserLabels {
   breadcrumbs?: string;
   /** Header action labels (promoted from the old status-bar footer). */
   uploadFiles?: string;
+  /** The Upload pill when it opens the files/folder menu (HOU-889). */
+  upload?: string;
+  /** Menu item / empty-state CTA for uploading a whole folder (HOU-889). */
+  uploadFolder?: string;
   openInFileManager?: string;
   downloadAll?: string;
 }
@@ -80,6 +84,8 @@ export const DEFAULT_FILES_BROWSER_LABELS: Required<FilesBrowserLabels> = {
   menuButton: "More actions",
   breadcrumbs: "Folder path",
   uploadFiles: "Upload files",
+  upload: "Upload",
+  uploadFolder: "Upload folder",
   openInFileManager: "Open in File Manager",
   downloadAll: "Download all",
 };

--- a/ui/agent/src/files-browser.tsx
+++ b/ui/agent/src/files-browser.tsx
@@ -39,6 +39,10 @@ export interface FilesBrowserProps {
   onDownloadFolder?: (folder: FileEntry) => void;
   onDelete?: (file: FileEntry) => void;
   onFilesDropped?: (files: File[], targetFolder?: string) => void;
+  /** Surfaces dropped-folder expansion failures (unreadable entries, too many
+   *  files). Pass whenever onFilesDropped is set — the async folder walk has
+   *  nowhere to throw to, and errors must never be swallowed. */
+  onDropError?: (error: unknown) => void;
   /** Move a file/folder to a new location (null = root) */
   onMove?: (sourcePath: string, targetFolder: string | null) => void;
   onRename?: (file: FileEntry, newName: string) => void;
@@ -49,6 +53,8 @@ export interface FilesBrowserProps {
   emptyDescription?: string;
   /** Pick files to upload (header's filled primary pill). */
   onUpload?: () => void;
+  /** Pick a whole folder to upload (turns the pill into a files/folder menu). */
+  onUploadFolder?: () => void;
   /** Reveal the agent's folder in the OS file manager (co-located desktop). */
   onRevealAgent?: () => void;
   /** Download the whole workspace as one zip (browser/remote builds). */
@@ -70,6 +76,7 @@ export function FilesBrowser(props: FilesBrowserProps) {
     onSelect: props.onSelect,
     onCreateFolder: props.onCreateFolder,
     onFilesDropped: props.onFilesDropped,
+    onDropError: props.onDropError,
     onMove: props.onMove,
   });
 
@@ -83,6 +90,8 @@ export function FilesBrowser(props: FilesBrowserProps) {
         }
         browseLabel={l.browseFiles}
         onBrowse={props.onBrowse}
+        folderLabel={l.uploadFolder}
+        onBrowseFolder={props.onUploadFolder}
       />
     );
   }
@@ -111,7 +120,10 @@ export function FilesBrowser(props: FilesBrowserProps) {
         }
         newFolderLabel={l.newFolder}
         onUpload={props.onUpload}
-        uploadLabel={l.uploadFiles}
+        uploadLabel={props.onUploadFolder ? l.upload : l.uploadFiles}
+        onUploadFolder={props.onUploadFolder}
+        uploadFilesLabel={l.uploadFiles}
+        uploadFolderLabel={l.uploadFolder}
         onRevealAgent={props.onRevealAgent}
         revealAgentLabel={l.openInFileManager}
         onDownloadAll={props.onDownloadAll}

--- a/ui/agent/src/files-empty-state.tsx
+++ b/ui/agent/src/files-empty-state.tsx
@@ -1,19 +1,24 @@
 /**
- * Zero-files state for the Files tab: headline, hint, optional Browse CTA.
+ * Zero-files state for the Files tab: headline, hint, optional Browse CTA,
+ * optional whole-folder upload CTA beside it (HOU-889).
  */
 import { Button } from "@houston-ai/core";
-import { Upload } from "lucide-react";
+import { FolderUp, Upload } from "lucide-react";
 
 export function FilesEmptyState({
   title,
   description,
   browseLabel,
   onBrowse,
+  folderLabel,
+  onBrowseFolder,
 }: {
   title: string;
   description: string;
   browseLabel: string;
   onBrowse?: () => void;
+  folderLabel?: string;
+  onBrowseFolder?: () => void;
 }) {
   return (
     <div className="flex flex-1 flex-col items-center gap-4 px-8 pt-[20vh]">
@@ -21,10 +26,19 @@ export function FilesEmptyState({
         <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
         <p className="text-sm text-ink-muted">{description}</p>
       </div>
-      {onBrowse && (
-        <Button variant="default" size="sm" onClick={onBrowse}>
-          <Upload className="mr-1.5 size-4" /> {browseLabel}
-        </Button>
+      {(onBrowse || onBrowseFolder) && (
+        <div className="flex items-center gap-2">
+          {onBrowse && (
+            <Button variant="default" size="sm" onClick={onBrowse}>
+              <Upload className="mr-1.5 size-4" /> {browseLabel}
+            </Button>
+          )}
+          {onBrowseFolder && (
+            <Button variant="outline" size="sm" onClick={onBrowseFolder}>
+              <FolderUp className="mr-1.5 size-4" /> {folderLabel}
+            </Button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/ui/agent/src/files-header-upload.tsx
+++ b/ui/agent/src/files-header-upload.tsx
@@ -1,0 +1,52 @@
+/**
+ * The header's promoted Upload action. Plain pill when only file picking is
+ * available; with a folder handler it becomes a two-item menu (files / whole
+ * folder, HOU-889) so folder upload is visible without hover or discovery.
+ */
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@houston-ai/core";
+import { File, FolderUp, Upload } from "lucide-react";
+
+export function FilesHeaderUpload({
+  onUpload,
+  uploadLabel,
+  onUploadFolder,
+  uploadFilesLabel,
+  uploadFolderLabel,
+}: {
+  onUpload: () => void;
+  uploadLabel: string;
+  onUploadFolder?: () => void;
+  uploadFilesLabel: string;
+  uploadFolderLabel: string;
+}) {
+  if (!onUploadFolder) {
+    return (
+      <Button size="sm" onClick={onUpload} className="shrink-0">
+        <Upload aria-hidden /> {uploadLabel}
+      </Button>
+    );
+  }
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button size="sm" className="shrink-0">
+          <Upload aria-hidden /> {uploadLabel}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={onUpload}>
+          <File aria-hidden /> {uploadFilesLabel}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onUploadFolder}>
+          <FolderUp aria-hidden /> {uploadFolderLabel}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/ui/agent/src/files-header.tsx
+++ b/ui/agent/src/files-header.tsx
@@ -13,9 +13,9 @@ import {
   FolderOpen,
   FolderPlus,
   House,
-  Upload,
 } from "lucide-react";
 import { CrumbButton } from "./crumb-button";
+import { FilesHeaderUpload } from "./files-header-upload";
 import { crumbsForPath } from "./grid-utils";
 import { SortMenu, type SortMenuLabels } from "./sort-menu";
 import type { FilesViewMode } from "./types";
@@ -43,6 +43,9 @@ export function FilesHeader({
   newFolderLabel,
   onUpload,
   uploadLabel,
+  onUploadFolder,
+  uploadFilesLabel,
+  uploadFolderLabel,
   onRevealAgent,
   revealAgentLabel,
   onDownloadAll,
@@ -67,6 +70,11 @@ export function FilesHeader({
   /** Pick files to upload (filled primary pill). */
   onUpload?: () => void;
   uploadLabel: string;
+  /** Pick a whole folder to upload. When set, the Upload pill opens a menu
+   *  offering files or a folder instead of jumping straight to the picker. */
+  onUploadFolder?: () => void;
+  uploadFilesLabel: string;
+  uploadFolderLabel: string;
   /** Reveal the agent's folder in the OS file manager (co-located desktop). */
   onRevealAgent?: () => void;
   revealAgentLabel: string;
@@ -154,9 +162,13 @@ export function FilesHeader({
         </button>
       )}
       {onUpload && (
-        <Button size="sm" onClick={onUpload} className="shrink-0">
-          <Upload aria-hidden /> {uploadLabel}
-        </Button>
+        <FilesHeaderUpload
+          onUpload={onUpload}
+          uploadLabel={uploadLabel}
+          onUploadFolder={onUploadFolder}
+          uploadFilesLabel={uploadFilesLabel}
+          uploadFolderLabel={uploadFolderLabel}
+        />
       )}
       {secondary && (
         <Button

--- a/ui/agent/src/use-files-browser.ts
+++ b/ui/agent/src/use-files-browser.ts
@@ -18,12 +18,20 @@ export function useFilesBrowser(opts: {
   onSelect?: (file: FileEntry) => void;
   onCreateFolder?: (name: string) => void;
   onFilesDropped?: (files: File[], targetFolder?: string) => void;
+  /** Surfaces dropped-folder expansion failures (see DropZoneOptions). */
+  onDropError?: (error: unknown) => void;
   onMove?: (sourcePath: string, targetFolder: string | null) => void;
 }) {
   const [internalView, setInternalView] = useState<FilesViewMode>("grid");
   const view = opts.controlledView ?? internalView;
-  const { onViewChange, onSelect, onCreateFolder, onFilesDropped, onMove } =
-    opts;
+  const {
+    onViewChange,
+    onSelect,
+    onCreateFolder,
+    onFilesDropped,
+    onDropError,
+    onMove,
+  } = opts;
   const changeView = useCallback(
     (v: FilesViewMode) => {
       setInternalView(v);
@@ -80,17 +88,16 @@ export function useFilesBrowser(opts: {
     if (hovered != null) return hovered;
     return view === "grid" && resolvedPath ? resolvedPath : null;
   }, [view, resolvedPath]);
-  const handleDrop = useCallback(
-    (dropped: File[]) => {
-      onFilesDropped?.(dropped, resolveDropTarget() ?? undefined);
-    },
-    [onFilesDropped, resolveDropTarget],
-  );
   const handleMove = useCallback(
     (src: string) => onMove?.(src, resolveDropTarget()),
     [onMove, resolveDropTarget],
   );
-  const { isDragging, dragHandlers } = useDropZone(handleDrop, handleMove);
+  const { isDragging, dragHandlers } = useDropZone({
+    onFilesDropped,
+    onDropError,
+    onMove: handleMove,
+    resolveTargetFolder: () => resolveDropTarget() ?? undefined,
+  });
   const isBgDropTarget = isDragging && folderTargetRef.current === null;
 
   const handleSort = useCallback((key: SortKey) => {

--- a/ui/chat/src/chat-input-attachments.tsx
+++ b/ui/chat/src/chat-input-attachments.tsx
@@ -1,4 +1,9 @@
-import { Popover, PopoverContent, PopoverTrigger } from "@houston-ai/core";
+import {
+  attachmentFolderRoot,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@houston-ai/core";
 import { Plus } from "lucide-react";
 import type {
   ChangeEvent,
@@ -8,7 +13,6 @@ import type {
 } from "react";
 import { useState } from "react";
 import { AttachmentChip, FolderAttachmentChip } from "./attachment-chip";
-import { attachmentFolderRoot } from "./attachment-folders";
 import { fileIdentityKey } from "./clipboard-files";
 
 // Non-standard attribute (WebKit lineage, supported by every engine we ship

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -3,9 +3,10 @@
  * Follows the Vercel AI Elements chatbot example exactly.
  * Generic version: accepts feedItems/status as props, no store dependencies.
  */
+
+import { TooManyAttachmentFilesError } from "@houston-ai/core";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Shimmer } from "./ai-elements/shimmer";
-import { TooManyAttachmentFilesError } from "./attachment-folders";
 import { ChatDropOverlay } from "./chat-drop-overlay";
 import { feedItemsToMessages } from "./chat-helpers";
 import { ChatInput } from "./chat-input";

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -1,5 +1,11 @@
 // === Types ===
 
+export {
+  attachmentFolderRoot,
+  attachmentRelativePath,
+  MAX_ATTACHMENT_FILES,
+  TooManyAttachmentFilesError,
+} from "@houston-ai/core";
 export type {
   ConversationContentProps,
   ConversationDownloadProps,
@@ -135,7 +141,6 @@ export type {
   ReasoningProps,
   ReasoningTriggerProps,
 } from "./ai-elements/reasoning";
-
 // === AI Elements: Reasoning ===
 export {
   Reasoning,
@@ -152,12 +157,6 @@ export type {
 } from "./ai-elements/suggestion";
 // === AI Elements: Suggestion ===
 export { Suggestion, Suggestions } from "./ai-elements/suggestion";
-export {
-  attachmentFolderRoot,
-  attachmentRelativePath,
-  MAX_ATTACHMENT_FILES,
-  TooManyAttachmentFilesError,
-} from "./attachment-folders";
 export type {
   AttachmentInvocation,
   AttachmentReference,

--- a/ui/chat/src/use-attachment-intake.ts
+++ b/ui/chat/src/use-attachment-intake.ts
@@ -1,5 +1,5 @@
+import { MAX_ATTACHMENT_FILES } from "@houston-ai/core";
 import { useCallback } from "react";
-import { MAX_ATTACHMENT_FILES } from "./attachment-folders";
 import type {
   AttachmentRejection,
   PrepareAttachments,

--- a/ui/chat/src/use-composer-attachments.ts
+++ b/ui/chat/src/use-composer-attachments.ts
@@ -1,6 +1,6 @@
+import { visibleAttachmentFiles } from "@houston-ai/core";
 import type { ChangeEvent, ClipboardEvent, RefObject } from "react";
 import { useCallback, useRef } from "react";
-import { visibleAttachmentFiles } from "./attachment-folders";
 import type {
   AttachmentRejection,
   ChatComposerLabels,

--- a/ui/chat/src/use-file-drop-zone.ts
+++ b/ui/chat/src/use-file-drop-zone.ts
@@ -6,9 +6,9 @@
  * - mergeUniqueFiles: append-and-dedupe helper for File[] state.
  */
 
+import { collectDroppedItems, resolveDroppedFiles } from "@houston-ai/core";
 import type { DragEvent, DragEventHandler } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { collectDroppedItems, resolveDroppedFiles } from "./attachment-folders";
 import { fileIdentityKey } from "./clipboard-files";
 
 /**

--- a/ui/core/src/folder-upload.ts
+++ b/ui/core/src/folder-upload.ts
@@ -1,7 +1,8 @@
 /**
- * Folder attachments (HOU-808).
+ * Folder uploads (HOU-808 composer attachments, HOU-889 Files tab) — shared
+ * by every surface that accepts a whole folder from the user.
  *
- * A folder can enter the composer two ways:
+ * A folder can enter a surface two ways:
  *  - the folder picker (`<input webkitdirectory>`): the browser sets each
  *    File's `webkitRelativePath` natively;
  *  - drag-and-drop: `DataTransfer.files` flattens a folder to nothing, so the

--- a/ui/core/src/index.ts
+++ b/ui/core/src/index.ts
@@ -48,6 +48,7 @@ export * from "./components/textarea";
 export * from "./components/toast-container";
 export * from "./components/tooltip";
 export * from "./components/verified-badge";
+export * from "./folder-upload";
 export * from "./hooks/use-houston-event";
 export * from "./hooks/use-mobile";
 export * from "./hooks/use-session-events";

--- a/ui/core/tests/folder-upload.test.ts
+++ b/ui/core/tests/folder-upload.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  attachmentFolderRoot,
+  attachmentRelativePath,
+  visibleAttachmentFiles,
+} from "../src/folder-upload.ts";
+
+/** A File the way a folder pick produces it: `webkitRelativePath` set. */
+function folderFile(name: string, relPath: string): File {
+  const file = new File(["x"], name);
+  Object.defineProperty(file, "webkitRelativePath", {
+    value: relPath,
+    configurable: true,
+  });
+  return file;
+}
+
+test("attachmentRelativePath normalizes separators and ignores plain files", () => {
+  assert.equal(
+    attachmentRelativePath(folderFile("a.md", "docs/guide/a.md")),
+    "docs/guide/a.md",
+  );
+  assert.equal(
+    attachmentRelativePath(folderFile("a.md", "docs\\guide\\a.md")),
+    "docs/guide/a.md",
+  );
+  assert.equal(
+    attachmentRelativePath(folderFile("a.md", "/docs/a.md")),
+    "docs/a.md",
+  );
+  // No separator ⇒ carries no structure ⇒ plain.
+  assert.equal(attachmentRelativePath(folderFile("a.md", "a.md")), null);
+  assert.equal(attachmentRelativePath(new File(["x"], "plain.md")), null);
+});
+
+test("attachmentFolderRoot is the first path segment", () => {
+  assert.equal(
+    attachmentFolderRoot(folderFile("a.md", "docs/sub/a.md")),
+    "docs",
+  );
+  assert.equal(attachmentFolderRoot(new File(["x"], "plain.md")), null);
+});
+
+test("visibleAttachmentFiles drops hidden folder entries, keeps plain dotfiles", () => {
+  const visible = folderFile("a.md", "docs/a.md");
+  const hiddenFile = folderFile(".DS_Store", "docs/.DS_Store");
+  const hiddenDir = folderFile("config", "docs/.git/config");
+  const plainDotfile = new File(["x"], ".env"); // explicit pick: host rejects loudly
+  assert.deepEqual(
+    visibleAttachmentFiles([visible, hiddenFile, hiddenDir, plainDotfile]),
+    [visible, plainDotfile],
+  );
+});

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -736,7 +736,8 @@ export class HoustonClient {
   }
   /** Upload browser Files into the agent's workspace (Files tab drag-drop /
    * Browse). This engine's import route takes one file per request and has no
-   * target-folder parameter, so uploads land at the workspace root. */
+   * target-folder or relPath parameter, so uploads land flat at the workspace
+   * root (the Files tab hides the folder-upload affordance on this engine). */
   async uploadProjectFiles(
     agentPath: string,
     files: File[],


### PR DESCRIPTION
Fixes HOU-889.

## Root cause

Folder upload existed only in the chat composer (HOU-808). The Files tab's two upload paths were flat-file only:

- the hidden picker was a plain `<input type="file">` (no `webkitdirectory`), and
- the drop zone read `DataTransfer.files`, which flattens a dropped folder to nothing, so dropping a folder did nothing at all.

Even if files with relative paths had reached the upload path, the host's `files/import` route had no `relPath` concept and rejected any name containing `/`.

## What changed

**Shared helpers (`@houston-ai/core`)** — `ui/chat/src/attachment-folders.ts` moved to `ui/core/src/folder-upload.ts` so the files browser can reuse the folder traversal without depending on the chat package. Chat re-exports the same names, so its public API is unchanged.

**`ui/agent` (files browser)**
- The drop zone now walks dropped directory entries recursively (`webkitGetAsEntry`), tagging each produced `File` with its folder-relative path, exactly like the chat composer. The `DataTransfer` entries and the hovered drop target are snapshotted synchronously before the async walk.
- New `onDropError` prop surfaces expansion failures (unreadable entries, >1000 files) instead of swallowing them.
- The header's Upload pill becomes a two-item menu (Upload files / Upload folder) when a folder handler is provided; the empty state gains an "Upload folder" CTA next to "Browse files".

**`app` (Files tab)** — hidden `webkitdirectory` input; shared intake filters hidden entries (`.DS_Store`, `.git/**`), enforces the shared 1000-file ceiling with an informational toast, and toasts drop errors. New en/es/pt strings. The folder affordance is offered on the TS host only; the legacy engine's import route flattens structure, so it keeps the plain pill.

**Adapter (`packages/web`)** — `uploadProjectFiles` forwards `webkitRelativePath` as `relPath` and batches small files per request (the same size-budgeted batching composer attachments use) instead of one request per file, so a many-file folder doesn't become hundreds of round trips. Hosts predating `relPath` ignore the field and store flat names.

**Host** — `files/import` accepts an optional per-file `relPath`, validated per segment like the attachments route (no traversal, no `\`, no empty or hidden segments, 32-segment/1024-char caps), stored at `<dir>/<relPath>`. The whole batch validates before anything is written. Directories merge on re-upload while colliding files keep Finder-style " (n)" dedupe. `moveWorkspaceEntry` extracted to `files-move.ts` (file-size limit).

## Tests

- `packages/host` files-import suite: nested storage under root and a target dir, directory-merge + file-dedupe semantics, per-segment rejection (traversal, hidden, empty, backslash, 1-segment, too deep), batch atomicity, `relPath` body parsing. All host/runtime/domain suites pass (147/771/1029).
- `ui/core` node tests for the moved helpers (path normalization, folder root, hidden-file filtering).
- Biome, `pnpm typecheck` (ui + host + app + packages/web incl. shim parity), `check-locales`, `check:boundaries`, `check:parity`, app node:test (1984) all green.

## Reproduce the bug (before)

1. `pnpm dev`, open an agent's **Files** tab.
2. Drag a folder from Finder onto the file list: nothing is uploaded, with no feedback.
3. The header's only affordance is "Upload files"; no way to pick a folder, and picking files never preserves any directory structure.

## Verify the fix (after)

1. `pnpm dev`, open an agent's **Files** tab.
2. Click **Upload → Upload folder**, pick a folder with nested subfolders: the tree appears in the Files tab with its structure intact (hidden files like `.DS_Store` skipped).
3. Drag the same folder from Finder onto the list (or onto a subfolder row): it lands nested under the drop target, structure preserved.
4. Upload the same folder again: directories merge; colliding files get " (n)" suffixes instead of overwriting.
5. Empty workspace: the empty state now offers both "Browse files" and "Upload folder".