### PR TITLE
fix(board): never paint the previous agent's missions on switch (HOU-858)

### DIFF
--- a/app/src/hooks/queries/use-activity.ts
+++ b/app/src/hooks/queries/use-activity.ts
@@ -33,11 +33,17 @@ export function useActivity(agentPath: string | undefined) {
     // Placeholder semantics keep the contract above: never persisted,
     // replaced by the held read when the pod answers, and `undefined`
     // (still loading) when nothing is cached — never a fabricated `[]`.
-    placeholderData: (previousData) =>
-      previousData ??
-      (agentPath
+    //
+    // The placeholder must ignore `placeholderData`'s previous-data argument
+    // (HOU-858): that argument carries the PREVIOUS query key's data, and the
+    // only way this key changes is an agent switch — so "previous data" is
+    // always the previous AGENT's board, and serving it painted the old
+    // agent's mission cards under the new agent until the fetch landed. Only
+    // the agent-scoped cache lookup may seed the placeholder.
+    placeholderData: () =>
+      agentPath
         ? latestCachedAgentActivities(queryClient, agentPath)
-        : undefined),
+        : undefined,
   });
 }
 

--- a/packages/web/e2e/agents.spec.ts
+++ b/packages/web/e2e/agents.spec.ts
@@ -1,3 +1,4 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
 import { createAgent } from "./support/create-agent";
 import { expect, test } from "./support/fixtures";
 
@@ -41,6 +42,59 @@ test("switches between two agents", async ({ page }) => {
     .last()
     .click();
   await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible();
+});
+
+/**
+ * HOU-858: switching agents must NEVER paint the previous agent's mission
+ * cards while the next agent's board read is still in flight. The switch test
+ * above can't catch a transient leak — its assertions auto-retry until the
+ * (instant) live read lands — so this one makes the in-flight window
+ * effectively permanent: the target agent's reads are held for 8s, and the
+ * old agent's card must be gone (and the new agent's cached setup mission
+ * painted from the sidebar aggregate) well inside that hold. Stale cards
+ * previously leaked through `useActivity`'s `placeholderData(previousData)`.
+ */
+test("never shows the previous agent's missions while the next board read is in flight", async ({
+  page,
+  request,
+}) => {
+  await page.goto("/");
+  await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible();
+
+  // A second agent whose board must be COLD when we later switch to it:
+  // create it (which selects it and warms its board query), switch back to
+  // the seeded agent, then reload. The default e2e token keeps query
+  // persistence off, so the fresh page only loads the seeded agent's board
+  // plus the all-conversations aggregate — "Research Bot"'s per-agent
+  // activity key has no cache entry, exactly like an agent first visited
+  // mid-session in production.
+  await createAgent(page, "Research Bot");
+  await page
+    .getByRole("button", { name: "Houston", exact: true })
+    .last()
+    .click();
+  await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible();
+  await page.reload();
+  await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible();
+
+  // Stall every per-agent read the way an asleep cloud pod does, then switch.
+  await request.post(`${FAKE_HOST_URL}/__test__/hold-agent-reads`, {
+    data: { ms: 8_000 },
+  });
+  await page
+    .getByRole("button", { name: "Research Bot", exact: true })
+    .last()
+    .click();
+
+  // Research Bot's setup mission paints immediately from the cached sidebar
+  // aggregate — and the seeded agent's card is gone — while the live read is
+  // still held (3s of grace, far under the 8s hold).
+  await expect(page.getByText("Getting set up")).toBeVisible({
+    timeout: 3_000,
+  });
+  await expect(page.getByText("Plan a trip to Tokyo")).toHaveCount(0, {
+    timeout: 3_000,
+  });
 });
 
 /**

--- a/ui/board/src/kanban-column.tsx
+++ b/ui/board/src/kanban-column.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@houston-ai/core";
-import { AnimatePresence, motion } from "framer-motion";
+import { motion } from "framer-motion";
 import { Plus } from "lucide-react";
 import { KanbanCard, type KanbanCardLabels } from "./kanban-card";
 import type { KanbanItem } from "./types";
@@ -110,48 +110,47 @@ export function KanbanColumn({
       {/* Cards. `pt-1` so the selected ring on the first card isn't
           clipped by the scroll container's top edge. */}
       <div className="flex-1 px-1.5 pt-1 pb-1.5 space-y-1.5 overflow-y-auto">
-        <AnimatePresence mode="popLayout">
-          {items.map((item) => (
-            <motion.div
-              key={item.id}
-              layout
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -8 }}
-              transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
-            >
-              {renderCard ? (
-                renderCard(item)
-              ) : (
-                <KanbanCard
-                  item={item}
-                  selected={selectedId === item.id}
-                  highlighted={highlightedId === item.id}
-                  onSelect={() => onSelect(item)}
-                  onDelete={onDelete ? () => onDelete(item) : undefined}
-                  onApprove={onApprove ? () => onApprove(item) : undefined}
-                  onRename={
-                    onRename ? (title) => onRename(item, title) : undefined
-                  }
-                  runningStatuses={runningStatuses}
-                  approveStatuses={approveStatuses}
-                  errorStatuses={errorStatuses}
-                  actions={actions?.(item)}
-                  avatar={avatar}
-                  labels={cardLabels}
-                  selectable={selectable}
-                  selectedForBulk={selectedIds?.has(item.id) ?? false}
-                  anySelected={anySelected}
-                  onToggleSelect={
-                    onToggleSelect ? () => onToggleSelect(item) : undefined
-                  }
-                  enableDrag={dndEnabled}
-                  dragging={draggingId === item.id}
-                />
-              )}
-            </motion.div>
-          ))}
-        </AnimatePresence>
+        {/* Cards mount/unmount with NO enter/exit animation: switching agents
+            swaps the whole item set, and any fade would cross-blend the
+            previous agent's cards with the next one's (HOU-858). `layout`
+            stays so a card gliding between columns still animates. */}
+        {items.map((item) => (
+          <motion.div
+            key={item.id}
+            layout
+            transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
+          >
+            {renderCard ? (
+              renderCard(item)
+            ) : (
+              <KanbanCard
+                item={item}
+                selected={selectedId === item.id}
+                highlighted={highlightedId === item.id}
+                onSelect={() => onSelect(item)}
+                onDelete={onDelete ? () => onDelete(item) : undefined}
+                onApprove={onApprove ? () => onApprove(item) : undefined}
+                onRename={
+                  onRename ? (title) => onRename(item, title) : undefined
+                }
+                runningStatuses={runningStatuses}
+                approveStatuses={approveStatuses}
+                errorStatuses={errorStatuses}
+                actions={actions?.(item)}
+                avatar={avatar}
+                labels={cardLabels}
+                selectable={selectable}
+                selectedForBulk={selectedIds?.has(item.id) ?? false}
+                anySelected={anySelected}
+                onToggleSelect={
+                  onToggleSelect ? () => onToggleSelect(item) : undefined
+                }
+                enableDrag={dndEnabled}
+                dragging={draggingId === item.id}
+              />
+            )}
+          </motion.div>
+        ))}
         {onAdd && (
           <button
             type="button"

--- a/ui/board/src/kanban-list.tsx
+++ b/ui/board/src/kanban-list.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@houston-ai/core";
-import { AnimatePresence, motion } from "framer-motion";
+import { motion } from "framer-motion";
 import type { KanbanCardLabels } from "./kanban-card";
 import { KanbanListItem } from "./kanban-list-item";
 import { KanbanListRail } from "./kanban-list-rail";
@@ -59,28 +59,25 @@ export function KanbanList({
       )}
     >
       <KanbanListRail align={align} className="space-y-1.5">
-        <AnimatePresence mode="popLayout">
-          {sorted.map((item) => (
-            <motion.div
-              key={item.id}
-              layout
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -8 }}
-              transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
-            >
-              <KanbanListItem
-                item={item}
-                avatar={avatar}
-                selected={selectedId === item.id}
-                onSelect={() => onSelect(item)}
-                onDelete={onDelete ? () => onDelete(item) : undefined}
-                labels={cardLabels}
-                snippet={searchSnippets?.[item.id]}
-              />
-            </motion.div>
-          ))}
-        </AnimatePresence>
+        {/* No enter/exit animation — an agent switch swaps the whole list and
+            must repaint instantly (HOU-858); `layout` keeps reorder glides. */}
+        {sorted.map((item) => (
+          <motion.div
+            key={item.id}
+            layout
+            transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
+          >
+            <KanbanListItem
+              item={item}
+              avatar={avatar}
+              selected={selectedId === item.id}
+              onSelect={() => onSelect(item)}
+              onDelete={onDelete ? () => onDelete(item) : undefined}
+              labels={cardLabels}
+              snippet={searchSnippets?.[item.id]}
+            />
+          </motion.div>
+        ))}
       </KanbanListRail>
     </div>
   );


### PR DESCRIPTION
Fixes HOU-858.

## Root cause

`useActivity`'s `placeholderData` fell back to the callback's previous-data argument. That argument carries the **previous query key's** data, and the only way this query's key changes is an agent switch — so "previous data" was always the previous **agent's** board. On a switch, the old agent's mission cards painted under the new agent until its activities read landed (seconds during a cloud pod wake), and the stale rows could briefly resolve an old session key against the new agent's path, mixing conversations. The 200ms framer-motion enter/exit fades on the kanban cards then cross-blended both boards, making the swap feel slow.

## Fix

- `app/src/hooks/queries/use-activity.ts` — the placeholder now ignores the previous-key data and seeds **only** from the agent-scoped cache (`latestCachedAgentActivities`: the per-agent list or the always-swept all-conversations aggregate). Cold-open seeding (PR #950 behavior) is unchanged; the `undefined` = "still loading" contract is unchanged.
- `ui/board/src/kanban-column.tsx`, `ui/board/src/kanban-list.tsx` — removed `AnimatePresence` and the per-card enter/exit fade/slide so an agent switch repaints instantly. `layout` animations stay, so a card gliding between columns (drag / status move) still animates.
- `packages/web/e2e/agents.spec.ts` — new regression test (see verification below).

`useAllConversations` keeps its previous-data fallback on purpose: its key embeds the whole agent roster, and blanking the sidebar badges on roster drift is the documented reason that fallback exists.

## Reproduction (before the fix)

1. Open the app with two agents, each with distinct missions; only agent A's board visited this session.
2. Switch to agent B (worst case: its cloud pod is asleep, so the activities read takes seconds).
3. Agent A's mission cards stay on agent B's board until B's read lands, cross-fading with B's cards when they arrive.

Deterministic repro via the e2e harness: `packages/web/e2e/agents.spec.ts` › *"never shows the previous agent's missions while the next board read is in flight"* — it holds the target agent's per-agent reads for 8s (the asleep-pod shape) and asserts the old agent's card is gone and the new agent's cached mission painted within 3s. **Verified failing against the un-fixed hook and passing with the fix.**

## Verification (after the fix)

- `pnpm --filter houston-web test:e2e` — 134 passed (includes the new regression test)
- `pnpm --filter houston-web test:visual` — 6 passed, no baseline changes (settled screens are identical; only mount/unmount animation removed)
- `cd app && pnpm test` — 1984 passed
- `pnpm typecheck` (all 25 packages) + `pnpm check` — clean

Manual check: switch between agents in the sidebar — the board must swap instantly with no old cards, no cross-fade, and no flash of the previous conversation in the panel.