### PR TITLE
fix(HOU-892): routines incident — stale Claude-credential overwrite guard + idempotent Composio disconnect

### DIFF
--- a/packages/host/src/channel/contract.test.ts
+++ b/packages/host/src/channel/contract.test.ts
@@ -477,4 +477,42 @@ describe("saveClaudeOAuthCredential (single-tenant only, asymmetric)", () => {
       /cloud|per-turn|available/i,
     );
   });
+
+  test("an overwrite push with an already-expired access token is rejected, keeping the live credential (HOU-892)", async () => {
+    // A fresh browser login always mints a future-dated access token. An
+    // expired one on the overwrite path is a stale cached snapshot wearing the
+    // wrong hat — accepting it clobbers the live rotated credential and
+    // re-revokes the family (observed live: a 7-hours-expired snapshot
+    // overwrote a freshly reconnected credential).
+    const { channel, credentials } = makeProxyFixture();
+    await channel.saveClaudeOAuthCredential(ctx, cred); // live credential
+
+    const stale = { ...cred, accessToken: "sk-ant-oat-stale", expiresAt: 1 };
+    await expect(channel.saveClaudeOAuthCredential(ctx, stale)).rejects.toThrow(
+      /expired/i,
+    );
+    expect((await credentials.get(ws.id, "anthropic"))?.accessToken).toBe(
+      "sk-ant-oat-access",
+    );
+
+    // The same stale snapshot on the RECONCILE path (fill-only) stays a quiet
+    // no-op against a live credential — reconciles legitimately carry old
+    // snapshots and must neither clobber nor error.
+    await channel.saveClaudeOAuthCredential(ctx, stale, { ifAbsent: true });
+    expect((await credentials.get(ws.id, "anthropic"))?.accessToken).toBe(
+      "sk-ant-oat-access",
+    );
+  });
+
+  test("a credential without an expiry still overwrites (absent metadata proves nothing)", async () => {
+    const { channel, credentials } = makeProxyFixture();
+    const { expiresAt: _dropped, ...noExpiry } = {
+      ...cred,
+      accessToken: "sk-ant-oat-no-expiry",
+    };
+    await channel.saveClaudeOAuthCredential(ctx, noExpiry);
+    expect((await credentials.get(ws.id, "anthropic"))?.accessToken).toBe(
+      "sk-ant-oat-no-expiry",
+    );
+  });
 });

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -28,6 +28,13 @@ export interface RuntimeProxy {
 }
 
 /**
+ * Clock-skew grace for the fresh-push staleness gate in
+ * saveClaudeOAuthCredential: a credential minted seconds ago on a machine with
+ * a slightly-fast clock must not be rejected as expired.
+ */
+const STALE_SKEW_MS = 60_000;
+
+/**
  * The standing-runtime channel: wake the agent's runtime (GKE pod today, local
  * subprocess in P4) and relay the request 1:1 over the runtime's whole contract
  * (chat, SSE events, provider device-code login, settings).
@@ -453,6 +460,21 @@ export class ProxyChannel implements RuntimeChannel {
         "anthropic",
       );
       if (existing) return;
+    } else if (cred.expiresAt && cred.expiresAt < Date.now() - STALE_SKEW_MS) {
+      // Overwrite intent claims "just minted by a browser login" — but a
+      // genuine fresh mint always carries a future-dated access token. An
+      // already-expired one is a CACHED snapshot wearing the wrong hat (a
+      // login flow that failed to update the OS cache before extraction), and
+      // storing it would clobber the live central credential and poison the
+      // token family exactly like the HOU-855 clobber (observed in HOU-892: a
+      // 7-hours-expired snapshot overwrote a freshly reconnected credential,
+      // re-revoking it). Reject loudly — the desktop degrades to the paste
+      // flow with a visible toast. Credentials without an expiry pass: absent
+      // metadata proves nothing, and the reconcile's fill-only path (above)
+      // stays the home for possibly-stale snapshots.
+      throw new Error(
+        "This Claude credential's access token is already expired, so it can't be a fresh sign-in. Sign in to Claude again, or paste a setup token.",
+      );
     }
     await this.opts.credentials.put(
       {

--- a/packages/host/src/integrations/composio.test.ts
+++ b/packages/host/src/integrations/composio.test.ts
@@ -435,6 +435,32 @@ test("disconnect deletes every connected account for the toolkit", async () => {
   ]);
 });
 
+test("disconnect succeeds when an account is already gone upstream (DELETE → 404)", async () => {
+  // Composio can expire/remove a connected account on its own (HOU-892: a
+  // Gmail login vanished server-side overnight). The list can then still
+  // return the account, or a retry can race a prior disconnect — either way
+  // the DELETE 404s and the disconnect must land as success, not wedge the
+  // user's only cleanup path with an error.
+  const deleted: string[] = [];
+  const { provider } = harness((url, method) => {
+    if (url.pathname === "/api/v3/connected_accounts" && method === "GET") {
+      return { body: { items: [{ id: "ca_gone" }, { id: "ca_live" }] } };
+    }
+    if (method === "DELETE") {
+      deleted.push(url.pathname);
+      return url.pathname.endsWith("ca_gone")
+        ? { status: 404 }
+        : { status: 204 };
+    }
+    return { status: 404 };
+  });
+  await provider.disconnect(USER, "gmail");
+  expect(deleted).toEqual([
+    "/api/v3/connected_accounts/ca_gone",
+    "/api/v3/connected_accounts/ca_live",
+  ]);
+});
+
 test("search runs BOTH the scoped and global query, merges (scoped first, deduped), and stamps status", async () => {
   const { provider } = harness((url) => {
     if (url.pathname === "/api/v3/connected_accounts")

--- a/packages/host/src/integrations/composio.ts
+++ b/packages/host/src/integrations/composio.ts
@@ -193,7 +193,12 @@ export class ComposioProvider implements IntegrationProvider {
   async disconnect(userId: string, toolkit: string): Promise<void> {
     // Remove every connected account for the toolkit (a toolkit can have more
     // than one, e.g. two Gmail logins). List, then DELETE all in parallel —
-    // the deletes are independent; any failure still rejects (surfaces).
+    // the deletes are independent; any failure still rejects (surfaces). A 404
+    // on the DELETE is success, not failure: the account is already gone
+    // upstream (Composio expired/removed it, or a retry raced a prior
+    // disconnect), and the user's intent — "this account is disconnected" —
+    // holds. Erroring here wedges the one flow that would clear the stale
+    // entry (HOU-892).
     const accounts = await this.http.call<{ items?: RawConnection[] }>(
       "/api/v3/connected_accounts",
       { query: { user_ids: userId, toolkit_slugs: toolkit, limit: "100" } },
@@ -204,7 +209,7 @@ export class ComposioProvider implements IntegrationProvider {
         .map((id) =>
           this.http.call(
             `/api/v3/connected_accounts/${encodeURIComponent(id)}`,
-            { method: "DELETE" },
+            { method: "DELETE", nullStatuses: [404] },
           ),
         ),
     );


### PR DESCRIPTION
## Summary

Fixes the two Houston-side defects found investigating **HOU-892** (the every-5-minutes email routine that died at ~4 a.m. Bogota and could not be durably reconnected).

### What actually happened (confirmed from the live pod + gateway DB)

The routine machinery worked flawlessly the whole time: the scheduler fired exactly on the 5-minute cron all night and recorded every failure. What broke was the agent's **Claude subscription OAuth credential** (not Gmail/Composio):

- `01:10 UTC` — Claude connected via desktop browser login, credential pushed to the org's central store; routine created `01:17`, emails flowing.
- `09:10:10 UTC` — the access token's exact 8-hour expiry. The refresh attempt returned `401 OAuth access token has been revoked` — Anthropic's refresh-token-reuse detection killed the family (two holders of one grant: the gateway is the intended single rotator per HOU-680, but the claude-oauth push also materializes the refresh token onto the pod for SDK self-refresh). Every run after that failed with the same 401.
- `16:23 UTC` — user reconnected Claude; emails resumed.
- `17:10:10 UTC` — the central credential row was **overwritten with the original 01:10 snapshot** (the stored `expires_at` still read 09:10 — 7 hours in the past) by an overwrite-intent push, re-poisoning the family. Dead again from there on.

### Fix 1 — reject a stale snapshot pushed as a fresh sign-in (`packages/host/src/channel/proxy.ts`)

A genuine fresh browser login always carries a future-dated access token. The overwrite path of `saveClaudeOAuthCredential` now rejects an already-expired one (60s clock-skew grace) with an actionable error; the desktop degrades to the visible paste flow. The fill-only reconcile path (HOU-855) is untouched — cached snapshots may legitimately carry expired access tokens and still must never clobber.

### Fix 2 — idempotent toolkit-wide Composio disconnect (`packages/host/src/integrations/composio.ts`)

Found chasing the initial (wrong) Gmail hypothesis, still a real defect: `disconnect()` DELETEs every connected account for a toolkit, and a 404 (account already gone upstream, or a retry racing a prior disconnect) failed the whole disconnect with a 502 — wedging the user's cleanup path. 404 is now idempotent success, matching the per-id delete's existing contract. Companion fix for the production Go gateway path: gethouston/cloud#179.

### Left for a team decision (commented on the Linear issue)

The root double-rotator conflict: cloud gateway HOU-680 declares itself the single refresh-token rotator ("a pod-held copy would race the rotation and sign the org out mid-session"), while the TS host's claude-oauth push materializes the refresh token onto the pod for SDK self-refresh. One of them has to win; that's an ADR-level change not made here.

## Verification

**Repro (before):**
1. Connect Claude on a cloud agent; wait for or force the central credential to rotate.
2. Push the originally-cached (now stale) credential JSON via `POST /agents/:id/credential/claude-oauth` (no `if_absent`) → it overwrites the live credential; the next refresh revokes the whole family and every routine run fails with `401 … revoked`.
3. Composio: delete a connected account server-side, then hit Disconnect in Houston → 502.

**After:**
1. The same stale push is rejected with "already expired … Sign in to Claude again"; the live credential survives and routine runs keep working.
2. Disconnect completes even when Composio already dropped the account.
3. `pnpm --filter @houston/host test` — 1028 tests pass, including the new HOU-892 contract tests; Biome + workspace typecheck clean.