### PR TITLE
test(runtime): pin the mid-turn Mode-pill hot-swap on the Claude SDK backend (HOU-776)

### DIFF
--- a/packages/runtime/src/backends/claude/live-mode.test.ts
+++ b/packages/runtime/src/backends/claude/live-mode.test.ts
@@ -1,0 +1,161 @@
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  CanUseTool,
+  createSdkMcpServer as CreateSdkMcpServer,
+  PermissionResult,
+  SdkMcpToolDefinition,
+} from "@anthropic-ai/claude-agent-sdk";
+import { expect, test } from "vitest";
+import {
+  runWithTurnMode,
+  type TurnModeRef,
+} from "../../session/turn-mode-context";
+import { buildHoustonMcpServer } from "./custom-tools";
+import { type ClaudeQuery, ClaudeSession } from "./session";
+import type { SessionsStore } from "./sessions-store";
+import { makeCanUseTool } from "./tool-policy";
+
+/**
+ * HOU-776: the mid-turn Mode-pill switch (Claude Code's shift+tab) on the
+ * Claude Agent SDK backend. `POST /conversations/:id/mode` mutates the running
+ * turn's `TurnModeRef`; on this backend the flip lands through TWO live gates:
+ * `makeCanUseTool`'s plan-deny for the mutating built-ins (Edit/Write/Bash),
+ * and the bridged pi tools' own gates (ask_user's auto refusal). Both read the
+ * ref via `currentTurnMode()`, so they depend on exec-turn's AsyncLocalStorage
+ * context reaching callbacks the SDK dispatches during `session.prompt()` —
+ * the exact chain these tests pin down.
+ */
+
+const CTX: Parameters<CanUseTool>[2] = {
+  signal: new AbortController().signal,
+  toolUseID: "t",
+  requestId: "r",
+};
+
+function workspace(): string {
+  return realpathSync(mkdtempSync(join(tmpdir(), "claude-live-")));
+}
+
+async function decide(
+  can: CanUseTool,
+  tool: string,
+  input: Record<string, unknown>,
+): Promise<PermissionResult> {
+  const r = await can(tool, input, CTX);
+  if (!r) throw new Error("expected a permission result");
+  return r;
+}
+
+test("a live flip to plan denies Edit/Write/Bash at permission time, and flipping back re-allows", async () => {
+  const ws = workspace();
+  const can = makeCanUseTool(ws);
+  const ref: TurnModeRef = { current: "execute" };
+  await runWithTurnMode(ref, async () => {
+    const target = { file_path: join(ws, "a.txt") };
+    expect((await decide(can, "Write", target)).behavior).toBe("allow");
+
+    // The user switches the Mode pill to Plan while the turn runs.
+    ref.current = "plan";
+    for (const tool of ["Edit", "Write"]) {
+      const r = await decide(can, tool, target);
+      expect(r.behavior).toBe("deny");
+      if (r.behavior === "deny") expect(r.message).toMatch(/Plan mode/);
+    }
+    expect((await decide(can, "Bash", { command: "ls" })).behavior).toBe(
+      "deny",
+    );
+    // Read-only built-ins keep working in plan.
+    expect((await decide(can, "Read", target)).behavior).toBe("allow");
+
+    // Flipping back to execute re-allows immediately — same turn.
+    ref.current = "execute";
+    expect((await decide(can, "Write", target)).behavior).toBe("allow");
+  });
+});
+
+test("outside a turn (no ambient mode) the plan gate never fires", async () => {
+  const ws = workspace();
+  const can = makeCanUseTool(ws);
+  const r = await decide(can, "Write", { file_path: join(ws, "a.txt") });
+  expect(r.behavior).toBe("allow");
+});
+
+function fakeStore(): SessionsStore {
+  return {
+    getSessionId: () => undefined,
+    setSessionId: () => {},
+    remove: () => {},
+    purge: () => {},
+    resolveResume: () => undefined,
+  };
+}
+
+test("a mid-turn flip reaches canUseTool dispatched off a Claude-session turn", async () => {
+  // Model the SDK's real dispatch (see custom-tools.test): `query()` spawns its
+  // subprocess-stream reader synchronously, and that reader later invokes
+  // `canUseTool` across an async boundary. The reader inherits the ALS context
+  // active when `query()` was called — the turn-mode ref exec-turn establishes
+  // around `session.prompt()`. Two Write decisions are requested; the ref flips
+  // to plan between them, exactly what `setLiveTurnMode` does mid-turn.
+  const ws = workspace();
+  const can = makeCanUseTool(ws);
+  const ref: TurnModeRef = { current: "execute" };
+  const decisions: PermissionResult[] = [];
+
+  const query: ClaudeQuery = () => {
+    const dispatched = (async () => {
+      await Promise.resolve();
+      decisions.push(await decide(can, "Write", { file_path: join(ws, "a") }));
+      ref.current = "plan"; // the Mode pill switched while the turn runs
+      decisions.push(await decide(can, "Write", { file_path: join(ws, "b") }));
+    })();
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: async () => {
+          await dispatched;
+          return { done: true, value: undefined };
+        },
+      }),
+    };
+  };
+
+  const session = new ClaudeSession({
+    query,
+    conversationId: "c1",
+    baseOptions: {},
+    sessionsStore: fakeStore(),
+    model: "claude-sonnet-4-6",
+  });
+  await runWithTurnMode(ref, () => session.prompt("hi"));
+
+  expect(decisions[0]?.behavior).toBe("allow");
+  expect(decisions[1]?.behavior).toBe("deny");
+});
+
+test("a mid-turn flip to auto makes the bridged ask_user refuse", async () => {
+  // The execute-built session exposes ask_user via the in-process MCP bridge;
+  // the flip must reach the pi tool's own live gate (assertNotAutoMode).
+  let tools: SdkMcpToolDefinition[] = [];
+  buildHoustonMcpServer({
+    createSdkMcpServer: ((opts: { tools: SdkMcpToolDefinition[] }) => {
+      tools = opts.tools;
+      return { type: "sdk", name: "houston", instance: {} };
+    }) as unknown as typeof CreateSdkMcpServer,
+    mode: "execute",
+  });
+  const askUser = tools.find((t) => t.name === "ask_user");
+  if (!askUser) throw new Error("no ask_user tool");
+  const handler = askUser.handler as unknown as (
+    args: unknown,
+    extra: unknown,
+  ) => Promise<unknown>;
+
+  const ref: TurnModeRef = { current: "auto" };
+  await runWithTurnMode(ref, async () => {
+    await expect(
+      handler({ questions: [{ question: "Which color?" }] }, {}),
+    ).rejects.toThrow(/Autopilot/);
+  });
+});


### PR DESCRIPTION
## Summary

HOU-776 reports that switching between Coworker / Planner / Autopilot **while the agent is responding** works on the pi-managed providers but not on Anthropic (the Claude Agent SDK backend).

I could **not reproduce the asymmetry on current `main`** — the mid-turn hot-swap works on the Claude path, verified end-to-end through the real runtime (`runTurn` + `setLiveTurnMode`, real `@anthropic-ai/claude-agent-sdk` subprocess, real API turns):

- **execute → plan mid-turn**: the very next `Write` was denied at permission time with the switch-to-planning message; no files were written after the flip.
- **execute → auto mid-turn**: the bridged `ask_user` refused with the keep-going message and the model continued autonomously (picked its own answer and finished the task).
- AsyncLocalStorage propagation of the turn-mode ref into the SDK's `canUseTool` and in-process MCP handlers was verified under **both Node and Bun** against the real SDK.
- The mode machinery is byte-identical to what was on `main` when the issue was filed (no fix landed in between), so the report most likely came from a build predating `c4b5e1e2` (the live mid-turn apply, 2026-07-17 — first shipped in `cloud-v0.5.19`; no packaged desktop release carries it yet).

What WAS missing is any regression coverage on the Claude path: the live plan-deny gate in `makeCanUseTool` (`tool-policy.ts`) and the ALS chain that carries the mode ref into callbacks dispatched off `session.prompt()` were completely untested — a regression would ship silently. This PR pins all of it.

## Changes

- `packages/runtime/src/backends/claude/live-mode.test.ts` (new): 
  - live flip to plan denies Edit/Write/Bash at permission time; flipping back re-allows within the same turn; Read stays allowed
  - no ambient turn mode → the gate never fires (unit-test safety)
  - a mid-turn flip reaches `canUseTool` dispatched off a `ClaudeSession` turn (the exec-turn → `prompt()` → `query()` ALS chain)
  - a mid-turn flip to auto makes the bridged `ask_user` refuse (`assertNotAutoMode`)

Note: the permissive direction (plan → execute/auto mid-turn) applies on the **next** message on BOTH backends by design — a running session cannot conjure tools it was built without (see `live-mode-gate.ts`); pi has the same trade-off.

## Verification

Before the fix landed (any build < `c4b5e1e2`, e.g. the current packaged desktop): flip the Mode pill to Planner while an Anthropic agent is writing files → it keeps writing until the turn ends.

To verify current behavior:
1. `pnpm dev`, connect Anthropic, ask an agent (Anthropic model) to create several files one at a time.
2. While it works, flip the Mode pill to **Planner** → the next file write is refused and the agent pivots to summarizing + planning.
3. Repeat with a task that asks you a question; flip to **Autopilot** mid-turn → the question tool is refused and the agent continues autonomously.
4. `pnpm --filter @houston/runtime test -- live-mode` runs the new regression suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)