### PR TITLE
feat(skills): build and edit custom skills in a persistent agent chat (HOU-791)

### DIFF
--- a/app/src-tauri/src/houston_prompt/skills_memory.rs
+++ b/app/src-tauri/src/houston_prompt/skills_memory.rs
@@ -41,6 +41,7 @@ Skill rules:
 - `description` is shown to the user and drives tool matching. Lead with the outcome in plain language.
 - `image` should be a Fluent emoji slug or a full https URL.
 - `featured: yes` makes the Skill visible in the chat empty state.
+- If the frontmatter has a `setup_activity_id` field, keep it unchanged when editing — it links the Skill to the conversation it was built in.
 - `integrations` lists Composio toolkit slugs when the Skill needs connected apps.
 - If a Skill needs missing details, the procedure should ask for them together through the `ask_user` tool, up to 3 questions in one call, and continue when the answers arrive.
 - The desktop adds an explicit `Use the <skill> skill.` prefix so invocation stays deterministic.

--- a/app/src/components/board/use-agent-board-send.ts
+++ b/app/src/components/board/use-agent-board-send.ts
@@ -32,12 +32,20 @@ export function useAgentBoardSend({
   rawItems,
   pendingAgentMode,
   setPendingAgentMode,
+  promptContext,
 }: {
   agent: Agent;
   agentDef: AgentDefinition;
   rawItems: Activity[] | undefined;
   pendingAgentMode: string | null;
   setPendingAgentMode: (mode: string | null) => void;
+  /**
+   * Model-facing context prepended to EVERY outgoing prompt, hidden from the
+   * chat (the bubble keeps the user's words via `displayText` / the
+   * attachment marker). The skill setup chat pins its bound skill with this
+   * so the model never has to remember it from the kickoff alone.
+   */
+  promptContext?: string;
 }) {
   const { t } = useTranslation(["board", "chat", "common"]);
   const path = agent.folderPath;
@@ -180,11 +188,22 @@ export function useAgentBoardSend({
           agentPath: path,
           sessionKey,
           text,
+          // A builder also runs for a bare context send: the flush then
+          // persists the clean `text` as the bubble (displayText), exactly
+          // like the attachment case.
           buildPrompt:
-            files.length > 0
+            files.length > 0 || promptContext
               ? async () => {
-                  const saved = await tauriAttachments.save(scopeId, files);
-                  return buildAttachmentPrompt(text, files, saved);
+                  const saved =
+                    files.length > 0
+                      ? await tauriAttachments.save(scopeId, files)
+                      : [];
+                  return buildAttachmentPrompt(
+                    text,
+                    files,
+                    saved,
+                    promptContext,
+                  );
                 }
               : undefined,
           promptFile: warmingMode?.promptFile,
@@ -214,7 +233,7 @@ export function useAgentBoardSend({
       }
       try {
         const paths = await tauriAttachments.save(scopeId, files);
-        const prompt = buildAttachmentPrompt(text, files, paths);
+        const prompt = buildAttachmentPrompt(text, files, paths, promptContext);
         const mode = agentModes?.find((m) => m.id === activity?.agent);
         await tauriChat.send(path, prompt, sessionKey, {
           mode: mode?.promptFile,
@@ -222,6 +241,10 @@ export function useAgentBoardSend({
           modelOverride: overrides.modelOverride,
           modeOverride: overrides.modeOverride,
           mentions: overrides.mentions,
+          // A context-prefixed prompt with no attachment marker would render
+          // raw — persist the user's words as the bubble instead. (With
+          // attachments the marker already carries them.)
+          displayText: promptContext && files.length === 0 ? text : undefined,
           // If the conversation is mid-turn the adapter holds this send; the
           // queued bubble shows the user's words, not the built prompt.
           queuedPreview: {
@@ -247,7 +270,7 @@ export function useAgentBoardSend({
         throw err;
       }
     },
-    [path, agent.id, addToast, rawItems, agentModes, t],
+    [path, agent.id, addToast, rawItems, agentModes, t, promptContext],
   );
 
   const stopSession = useCallback(

--- a/app/src/components/tabs/agent-admin/agent-admin-skills.tsx
+++ b/app/src/components/tabs/agent-admin/agent-admin-skills.tsx
@@ -6,8 +6,9 @@ import type { AgentAdminScreenProps } from "./agent-admin-nav.ts";
 /**
  * Skills section: the catalog-grammar Skills surface (installed-tile strip +
  * Store / Custom skills tabs), reusing {@link useSkillSurface} for
- * install/search and edit/delete. Editing opens a modal from a tile; there is
- * no separate detail screen. Always editable.
+ * install/search and edit/delete. A skill row opens its persistent setup chat
+ * (HOU-791); the raw-markdown modal stays reachable from the chat header.
+ * Always editable.
  */
 export function AgentAdminSkills({ agent }: AgentAdminScreenProps) {
   const surface = useSkillSurface(agent.folderPath);
@@ -16,6 +17,7 @@ export function AgentAdminSkills({ agent }: AgentAdminScreenProps) {
   return (
     <div className="max-w-3xl mx-auto w-full px-6 pb-12 pt-6 flex-1 flex flex-col">
       <SkillsContent
+        agent={agent}
         skills={surface.skills}
         loading={surface.skillsLoading}
         editingSkillName={surface.editingSkillName}

--- a/app/src/components/tabs/houston-skill-preview.tsx
+++ b/app/src/components/tabs/houston-skill-preview.tsx
@@ -1,0 +1,100 @@
+import type { CommunitySkill, SkillPreviewState } from "@houston-ai/skills";
+import { SkillPreviewModal } from "@houston-ai/skills";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import type { HoustonLibrarySkill } from "../../lib/houston-skill-library";
+import { skillIntegrationSlugs } from "../../lib/skill-integrations";
+import { IntegrationBadges } from "../integrations";
+import { useSkillMarketplaceSectionLabels } from "./use-skill-surface-labels";
+
+/** What the shelves put under preview: the skill + its shipping agent's name. */
+export interface HoustonSkillPreviewTarget {
+  skill: HoustonLibrarySkill;
+  agentName: string;
+}
+
+interface Props {
+  target: HoustonSkillPreviewTarget | null;
+  onClose: () => void;
+  install: (skill: HoustonLibrarySkill) => void;
+  installing: string | null;
+  installedSkillNames?: Set<string>;
+}
+
+/**
+ * The Houston-library skill preview (HOU-791 follow-up): reuses the
+ * marketplace's {@link SkillPreviewModal} — title, description, the apps it
+ * works with, category, and the full step-by-step body behind the expander —
+ * so a library row NEVER installs on click; the modal's Install button is the
+ * one commit point. The bundle ships the whole SKILL.md, so the preview is
+ * always instantly "loaded", and the by-line reads "From the {agent} agent"
+ * instead of the marketplace's owner/repo source.
+ */
+export function HoustonSkillPreview({
+  target,
+  onClose,
+  install,
+  installing,
+  installedSkillNames,
+}: Props) {
+  const { t } = useTranslation("skills");
+  const marketplaceLabels = useSkillMarketplaceSectionLabels();
+
+  const skill = target?.skill ?? null;
+  const modalSkill: CommunitySkill | null = useMemo(
+    () =>
+      skill
+        ? {
+            id: skill.slug,
+            skillId: skill.slug,
+            name: skill.slug,
+            installs: 0,
+            source: `houston/${skill.agentId}`,
+          }
+        : null,
+    [skill],
+  );
+  const preview: SkillPreviewState = useMemo(
+    () =>
+      skill
+        ? {
+            status: "loaded",
+            preview: {
+              title: skill.title,
+              description: skill.description,
+              image: skill.image,
+              category: skill.category,
+              tags: [],
+              integrations: skill.integrations,
+              content: skill.body || null,
+            },
+          }
+        : { status: "loading" },
+    [skill],
+  );
+
+  return (
+    <SkillPreviewModal
+      open={target !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      skill={modalSkill}
+      preview={preview}
+      installing={installing !== null && installing === skill?.slug}
+      installed={!!skill && !!installedSkillNames?.has(skill.slug)}
+      onInstall={() => skill && install(skill)}
+      renderIntegrations={(slugs) => (
+        <IntegrationBadges
+          toolkits={skillIntegrationSlugs(slugs)}
+          label={t("detail.integrations")}
+        />
+      )}
+      labels={{
+        ...marketplaceLabels.preview,
+        bySource: () =>
+          t("library.fromAgent", { agent: target?.agentName ?? "" }),
+      }}
+    />
+  );
+}

--- a/app/src/components/tabs/houston-skill-shelves.tsx
+++ b/app/src/components/tabs/houston-skill-shelves.tsx
@@ -1,0 +1,149 @@
+import {
+  Button,
+  CatalogAddButton,
+  CatalogGrid,
+  CatalogRow,
+  CatalogSectionHeader,
+  CatalogShowMore,
+  Skeleton,
+} from "@houston-ai/core";
+import { Check } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { HoustonLibrarySkill } from "../../lib/houston-skill-library";
+import { skillDisplayTitle } from "../../lib/humanize-skill-name";
+import { SkillIcon } from "../skill-icon";
+import type { HoustonLibraryGroup } from "./use-houston-skill-library";
+
+/** Rows shown per agent shelf at rest; "Show all" reveals the rest. */
+const SHELF_CAP = 4;
+
+interface Props {
+  groups: HoustonLibraryGroup[];
+  loading: boolean;
+  failed: boolean;
+  retry: () => void;
+  install: (skill: HoustonLibrarySkill) => void;
+  /** Slug currently installing (drives that row's spinner), or null. */
+  installing: string | null;
+  /** Already-installed slugs — their rows show a quiet check, not an add. */
+  installedSkillNames?: Set<string>;
+}
+
+/**
+ * The Houston skill library shelves (Custom tab): one shelf per pre-set
+ * agent, each a capped grid of installable skill rows in the shared catalog
+ * grammar — the skill's own icon, title, one-line description, and the round
+ * add button that becomes a quiet check once the skill is in "Your skills".
+ */
+export function HoustonSkillShelves({
+  groups,
+  loading,
+  failed,
+  retry,
+  install,
+  installing,
+  installedSkillNames,
+}: Props) {
+  const { t } = useTranslation("skills");
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
+
+  if (loading) {
+    return (
+      <div
+        role="status"
+        className="flex flex-col gap-2"
+        aria-label={t("library.loading")}
+      >
+        {[0, 1, 2].map((i) => (
+          <Skeleton key={i} className="h-12 w-full rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+
+  if (failed) {
+    return (
+      <div className="flex items-center gap-3">
+        <p className="text-sm text-ink-muted">{t("library.loadFailed")}</p>
+        <Button type="button" variant="outline" size="sm" onClick={retry}>
+          {t("library.retry")}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {groups.map((group) => {
+        const open = expanded.has(group.agentId);
+        const visible = open ? group.skills : group.skills.slice(0, SHELF_CAP);
+        return (
+          <section key={group.agentId} className="flex flex-col gap-2">
+            <CatalogSectionHeader
+              title={group.agentName}
+              count={group.skills.length}
+            />
+            <CatalogGrid>
+              {visible.map((skill) => {
+                const name = skillDisplayTitle({
+                  name: skill.slug,
+                  title: skill.title,
+                });
+                const installed = installedSkillNames?.has(skill.slug);
+                return (
+                  <CatalogRow
+                    key={skill.slug}
+                    // The row body is the same install target as the + —
+                    // one row, one action; an installed row is inert.
+                    onClick={
+                      installed || installing !== null
+                        ? undefined
+                        : () => install(skill)
+                    }
+                    icon={
+                      <SkillIcon
+                        image={skill.image}
+                        bubbleClassName="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-line-input"
+                      />
+                    }
+                    title={name}
+                    description={skill.description || undefined}
+                    action={
+                      installed ? (
+                        <span
+                          role="img"
+                          className="flex size-7 shrink-0 items-center justify-center text-ink-muted"
+                          aria-label={t("library.installedLabel")}
+                          title={t("library.installedLabel")}
+                        >
+                          <Check className="size-4" />
+                        </span>
+                      ) : (
+                        <CatalogAddButton
+                          label={t("library.installLabel", { name })}
+                          busy={installing === skill.slug}
+                          disabled={installing !== null}
+                          onClick={() => install(skill)}
+                        />
+                      )
+                    }
+                  />
+                );
+              })}
+            </CatalogGrid>
+            {!open && group.skills.length > SHELF_CAP && (
+              <CatalogShowMore
+                onClick={() =>
+                  setExpanded((prev) => new Set(prev).add(group.agentId))
+                }
+              >
+                {t("grid.showAllSkills", { count: group.skills.length })}
+              </CatalogShowMore>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/src/components/tabs/houston-skill-shelves.tsx
+++ b/app/src/components/tabs/houston-skill-shelves.tsx
@@ -13,6 +13,10 @@ import { useTranslation } from "react-i18next";
 import type { HoustonLibrarySkill } from "../../lib/houston-skill-library";
 import { skillDisplayTitle } from "../../lib/humanize-skill-name";
 import { SkillIcon } from "../skill-icon";
+import {
+  HoustonSkillPreview,
+  type HoustonSkillPreviewTarget,
+} from "./houston-skill-preview";
 import type { HoustonLibraryGroup } from "./use-houston-skill-library";
 
 /** Rows shown per agent shelf at rest; "Show all" reveals the rest. */
@@ -32,9 +36,11 @@ interface Props {
 
 /**
  * The Houston skill library shelves (Custom tab): one shelf per pre-set
- * agent, each a capped grid of installable skill rows in the shared catalog
- * grammar — the skill's own icon, title, one-line description, and the round
- * add button that becomes a quiet check once the skill is in "Your skills".
+ * agent, each a capped grid of skill rows in the shared catalog grammar —
+ * the skill's own icon, title, one-line description, and the round add
+ * button that becomes a quiet check once the skill is in "Your skills".
+ * A row (and its +) opens the PREVIEW modal, never installs directly —
+ * installing is the modal's one commit point ({@link HoustonSkillPreview}).
  */
 export function HoustonSkillShelves({
   groups,
@@ -47,6 +53,9 @@ export function HoustonSkillShelves({
 }: Props) {
   const { t } = useTranslation("skills");
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
+  const [preview, setPreview] = useState<HoustonSkillPreviewTarget | null>(
+    null,
+  );
 
   if (loading) {
     return (
@@ -91,16 +100,14 @@ export function HoustonSkillShelves({
                   title: skill.title,
                 });
                 const installed = installedSkillNames?.has(skill.slug);
+                const openPreview = () =>
+                  setPreview({ skill, agentName: group.agentName });
                 return (
                   <CatalogRow
                     key={skill.slug}
-                    // The row body is the same install target as the + —
-                    // one row, one action; an installed row is inert.
-                    onClick={
-                      installed || installing !== null
-                        ? undefined
-                        : () => install(skill)
-                    }
+                    // Row AND + both open the preview — nothing installs on
+                    // a bare click; the modal's Install button commits.
+                    onClick={openPreview}
                     icon={
                       <SkillIcon
                         image={skill.image}
@@ -121,10 +128,9 @@ export function HoustonSkillShelves({
                         </span>
                       ) : (
                         <CatalogAddButton
-                          label={t("library.installLabel", { name })}
+                          label={t("library.previewLabel", { name })}
                           busy={installing === skill.slug}
-                          disabled={installing !== null}
-                          onClick={() => install(skill)}
+                          onClick={openPreview}
                         />
                       )
                     }
@@ -144,6 +150,13 @@ export function HoustonSkillShelves({
           </section>
         );
       })}
+      <HoustonSkillPreview
+        target={preview}
+        onClose={() => setPreview(null)}
+        install={install}
+        installing={installing}
+        installedSkillNames={installedSkillNames}
+      />
     </div>
   );
 }

--- a/app/src/components/tabs/routine-setup-chat-board.tsx
+++ b/app/src/components/tabs/routine-setup-chat-board.tsx
@@ -48,6 +48,9 @@ interface Props extends TabProps {
   /** Header actions on the panel's right side (the integration setup chat
    *  puts its "Done" button here). Omit for none (routines). */
   panelActions?: ReactNode;
+  /** Model-facing context prepended to every outgoing prompt, hidden from
+   *  the transcript (the skill chat pins its bound skill). Omit for none. */
+  promptContext?: string;
 }
 
 export function RoutineSetupChatBoard({
@@ -60,6 +63,7 @@ export function RoutineSetupChatBoard({
   missionLabel,
   panelActions,
   onPanelClose,
+  promptContext,
 }: Props) {
   const path = agent.folderPath;
   const openHref = useOpenAgentHref(path);
@@ -99,6 +103,7 @@ export function RoutineSetupChatBoard({
     rawItems,
     pendingAgentMode: null,
     setPendingAgentMode: noop,
+    promptContext,
   });
   const sendQueue = useBoardSendQueue({
     selectedSessionKey: sessionKey,

--- a/app/src/components/tabs/skill-custom-tab.tsx
+++ b/app/src/components/tabs/skill-custom-tab.tsx
@@ -1,0 +1,103 @@
+import {
+  Button,
+  CatalogGrid,
+  CatalogRow,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@houston-ai/core";
+import type { Activity } from "@houston-ai/engine-client";
+import { Plus, Sparkles, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  /** Unclaimed create-chats — each resumes right where the interview left off. */
+  drafts: Activity[];
+  onResumeDraft: (activityId: string) => void;
+  onDiscardDraft: (activityId: string) => void;
+  /** Start a new agent-guided create chat (HOU-791, the primary path). */
+  onCreateWithAi: () => void;
+  /** Open the manual GitHub / from-scratch dialog (the secondary path). */
+  onAddClick: () => void;
+}
+
+/**
+ * The Custom skills tab: build-with-the-agent first (HOU-791). Unfinished
+ * create-chats show as resumable rows (with an always-visible discard, no
+ * hover-gating); under them — or as the empty state's own actions — the
+ * primary "Create with AI" CTA and the manual add dialog as the quiet
+ * secondary path.
+ */
+export function SkillCustomTab({
+  drafts,
+  onResumeDraft,
+  onDiscardDraft,
+  onCreateWithAi,
+  onAddClick,
+}: Props) {
+  const { t } = useTranslation("skills");
+
+  const actions = (
+    <div className="flex items-center gap-2">
+      <Button type="button" onClick={onCreateWithAi}>
+        <Sparkles className="size-4" />
+        {t("tabs.createWithAi")}
+      </Button>
+      <Button type="button" variant="outline" onClick={onAddClick}>
+        <Plus className="size-4" />
+        {t("grid.addSkill")}
+      </Button>
+    </div>
+  );
+
+  if (drafts.length === 0) {
+    return (
+      <Empty className="py-16">
+        <EmptyHeader>
+          <EmptyTitle className="text-lg">
+            {t("tabs.customEmptyTitle")}
+          </EmptyTitle>
+          <EmptyDescription>
+            {t("tabs.customEmptyDescription")}
+          </EmptyDescription>
+        </EmptyHeader>
+        {actions}
+      </Empty>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <CatalogGrid>
+        {drafts.map((draft) => (
+          <CatalogRow
+            key={draft.id}
+            icon={
+              <span className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-line-input">
+                <Sparkles aria-hidden className="size-5 text-ink-muted" />
+              </span>
+            }
+            title={draft.title}
+            description={t("setupChat.draftInProgress")}
+            trailing={
+              <button
+                type="button"
+                aria-label={t("setupChat.discardDraft")}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDiscardDraft(draft.id);
+                }}
+                className="flex size-7 shrink-0 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-hover/50 hover:text-ink"
+              >
+                <X className="size-4" />
+              </button>
+            }
+            onClick={() => onResumeDraft(draft.id)}
+          />
+        ))}
+      </CatalogGrid>
+      <div>{actions}</div>
+    </div>
+  );
+}

--- a/app/src/components/tabs/skill-custom-tab.tsx
+++ b/app/src/components/tabs/skill-custom-tab.tsx
@@ -41,8 +41,7 @@ export function SkillCustomTab({
   const actions = (
     <div className="flex items-center gap-2">
       <Button type="button" onClick={onCreateWithAi}>
-        <Sparkles className="size-4" />
-        {t("tabs.createWithAi")}
+        {t("tabs.createSkill")}
       </Button>
       <Button type="button" variant="outline" onClick={onAddClick}>
         <Plus className="size-4" />

--- a/app/src/components/tabs/skill-custom-tab.tsx
+++ b/app/src/components/tabs/skill-custom-tab.tsx
@@ -2,16 +2,17 @@ import {
   Button,
   CatalogGrid,
   CatalogRow,
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyTitle,
+  CatalogSectionHeader,
 } from "@houston-ai/core";
 import type { Activity } from "@houston-ai/engine-client";
 import { Plus, Sparkles, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { HoustonSkillShelves } from "./houston-skill-shelves";
+import { useHoustonSkillLibrary } from "./use-houston-skill-library";
 
 interface Props {
+  /** The agent the library installs into (and whose drafts these are). */
+  agentPath: string;
   /** Unclaimed create-chats — each resumes right where the interview left off. */
   drafts: Activity[];
   onResumeDraft: (activityId: string) => void;
@@ -20,83 +21,89 @@ interface Props {
   onCreateWithAi: () => void;
   /** Open the manual GitHub / from-scratch dialog (the secondary path). */
   onAddClick: () => void;
+  /** Installed slugs — library rows show a quiet check instead of an add. */
+  installedSkillNames?: Set<string>;
 }
 
 /**
- * The Custom skills tab: build-with-the-agent first (HOU-791). Unfinished
- * create-chats show as resumable rows (with an always-visible discard, no
- * hover-gating); under them — or as the empty state's own actions — the
- * primary "Create with AI" CTA and the manual add dialog as the quiet
- * secondary path.
+ * The Custom skills tab — the user's SOURCES of skills: build one with the
+ * agent (primary), add one manually (GitHub / from scratch), resume an
+ * unfinished create-chat, or pull a curated skill from the Houston library —
+ * every skill our pre-set store agents ship, installable one by one
+ * ({@link HoustonSkillShelves}).
  */
 export function SkillCustomTab({
+  agentPath,
   drafts,
   onResumeDraft,
   onDiscardDraft,
   onCreateWithAi,
   onAddClick,
+  installedSkillNames,
 }: Props) {
   const { t } = useTranslation("skills");
-
-  const actions = (
-    <div className="flex items-center gap-2">
-      <Button type="button" onClick={onCreateWithAi}>
-        {t("tabs.createSkill")}
-      </Button>
-      <Button type="button" variant="outline" onClick={onAddClick}>
-        <Plus className="size-4" />
-        {t("grid.addSkill")}
-      </Button>
-    </div>
-  );
-
-  if (drafts.length === 0) {
-    return (
-      <Empty className="py-16">
-        <EmptyHeader>
-          <EmptyTitle className="text-lg">
-            {t("tabs.customEmptyTitle")}
-          </EmptyTitle>
-          <EmptyDescription>
-            {t("tabs.customEmptyDescription")}
-          </EmptyDescription>
-        </EmptyHeader>
-        {actions}
-      </Empty>
-    );
-  }
+  const library = useHoustonSkillLibrary(agentPath);
 
   return (
-    <div className="flex flex-col gap-4">
-      <CatalogGrid>
-        {drafts.map((draft) => (
-          <CatalogRow
-            key={draft.id}
-            icon={
-              <span className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-line-input">
-                <Sparkles aria-hidden className="size-5 text-ink-muted" />
-              </span>
-            }
-            title={draft.title}
-            description={t("setupChat.draftInProgress")}
-            trailing={
-              <button
-                type="button"
-                aria-label={t("setupChat.discardDraft")}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDiscardDraft(draft.id);
-                }}
-                className="flex size-7 shrink-0 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-hover/50 hover:text-ink"
-              >
-                <X className="size-4" />
-              </button>
-            }
-            onClick={() => onResumeDraft(draft.id)}
-          />
-        ))}
-      </CatalogGrid>
-      <div>{actions}</div>
+    <div className="flex flex-col gap-6">
+      {drafts.length > 0 && (
+        <CatalogGrid>
+          {drafts.map((draft) => (
+            <CatalogRow
+              key={draft.id}
+              icon={
+                <span className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-line-input">
+                  <Sparkles aria-hidden className="size-5 text-ink-muted" />
+                </span>
+              }
+              title={draft.title}
+              description={t("setupChat.draftInProgress")}
+              trailing={
+                <button
+                  type="button"
+                  aria-label={t("setupChat.discardDraft")}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDiscardDraft(draft.id);
+                  }}
+                  className="flex size-7 shrink-0 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-hover/50 hover:text-ink"
+                >
+                  <X className="size-4" />
+                </button>
+              }
+              onClick={() => onResumeDraft(draft.id)}
+            />
+          ))}
+        </CatalogGrid>
+      )}
+
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-ink-muted">
+          {t("tabs.customEmptyDescription")}
+        </p>
+        <div className="flex items-center gap-2">
+          <Button type="button" onClick={onCreateWithAi}>
+            {t("tabs.createSkill")}
+          </Button>
+          <Button type="button" variant="outline" onClick={onAddClick}>
+            <Plus className="size-4" />
+            {t("grid.addSkill")}
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <CatalogSectionHeader title={t("library.heading")} size="lg" />
+        <HoustonSkillShelves
+          groups={library.groups}
+          loading={library.loading}
+          failed={library.failed}
+          retry={library.retry}
+          install={library.install}
+          installing={library.installing}
+          installedSkillNames={installedSkillNames}
+        />
+      </div>
     </div>
   );
 }

--- a/app/src/components/tabs/skill-discovery-tabs.tsx
+++ b/app/src/components/tabs/skill-discovery-tabs.tsx
@@ -1,31 +1,32 @@
-import {
-  Button,
-  type CatalogShellTab,
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyTitle,
-} from "@houston-ai/core";
+import type { CatalogShellTab } from "@houston-ai/core";
+import type { Activity } from "@houston-ai/engine-client";
 import type { CommunitySkill, CommunitySkillPreview } from "@houston-ai/skills";
 import { SkillMarketplaceSection } from "@houston-ai/skills";
-import { Plus } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { skillIntegrationSlugs } from "../../lib/skill-integrations";
 import { IntegrationBadges } from "../integrations";
+import { SkillCustomTab } from "./skill-custom-tab";
 import { useSkillMarketplaceSectionLabels } from "./use-skill-surface-labels";
 
 /**
  * The Skills surface's two discovery tabs for {@link CatalogShell}: **Store**
  * (the skills.sh marketplace section, with its own search + category controls)
- * and **Custom skills** (an empty state for now — the explanation + the Add CTA
- * opening the GitHub / From-scratch dialog). Each tab is present only when its
- * capability is: the Store needs the community search/install callbacks, the
- * Custom tab needs `showCustom` (an add flow available in a writable surface).
- * Read-only mode passes neither, so the shell drops the tab chrome entirely.
+ * and **Custom skills** ({@link SkillCustomTab}: agent-guided create chats
+ * first — HOU-791 — with the GitHub / From-scratch dialog as the secondary
+ * path). Each tab is present only when its capability is: the Store needs the
+ * community search/install callbacks, the Custom tab needs `showCustom` (an
+ * add flow available in a writable surface). Read-only mode passes neither,
+ * so the shell drops the tab chrome entirely.
  */
 export function useSkillDiscoveryTabs(opts: {
   showCustom: boolean;
   onAddClick: () => void;
+  /** Custom tab (HOU-791): start a new agent-guided create chat. */
+  onCreateWithAi: () => void;
+  /** Custom tab: unclaimed create-chats, shown as resumable rows. */
+  drafts: Activity[];
+  onResumeDraft: (activityId: string) => void;
+  onDiscardDraft: (activityId: string) => void;
   /** The page's ONE search query, driving the Store marketplace's results. */
   query: string;
   onQueryChange: (q: string) => void;
@@ -81,20 +82,13 @@ export function useSkillDiscoveryTabs(opts: {
             value: "custom",
             label: t("tabs.custom"),
             content: (
-              <Empty className="py-16">
-                <EmptyHeader>
-                  <EmptyTitle className="text-lg">
-                    {t("tabs.customEmptyTitle")}
-                  </EmptyTitle>
-                  <EmptyDescription>
-                    {t("tabs.customEmptyDescription")}
-                  </EmptyDescription>
-                </EmptyHeader>
-                <Button type="button" onClick={opts.onAddClick}>
-                  <Plus className="size-4" />
-                  {t("grid.addSkill")}
-                </Button>
-              </Empty>
+              <SkillCustomTab
+                drafts={opts.drafts}
+                onResumeDraft={opts.onResumeDraft}
+                onDiscardDraft={opts.onDiscardDraft}
+                onCreateWithAi={opts.onCreateWithAi}
+                onAddClick={opts.onAddClick}
+              />
             ),
           },
         ]

--- a/app/src/components/tabs/skill-discovery-tabs.tsx
+++ b/app/src/components/tabs/skill-discovery-tabs.tsx
@@ -20,6 +20,9 @@ import { useSkillMarketplaceSectionLabels } from "./use-skill-surface-labels";
  */
 export function useSkillDiscoveryTabs(opts: {
   showCustom: boolean;
+  /** The agent whose Skills surface this is — the Custom tab's Houston
+   *  library installs into it. */
+  agentPath: string;
   onAddClick: () => void;
   /** Custom tab (HOU-791): start a new agent-guided create chat. */
   onCreateWithAi: () => void;
@@ -83,11 +86,13 @@ export function useSkillDiscoveryTabs(opts: {
             label: t("tabs.custom"),
             content: (
               <SkillCustomTab
+                agentPath={opts.agentPath}
                 drafts={opts.drafts}
                 onResumeDraft={opts.onResumeDraft}
                 onDiscardDraft={opts.onDiscardDraft}
                 onCreateWithAi={opts.onCreateWithAi}
                 onAddClick={opts.onAddClick}
+                installedSkillNames={opts.installedSkillNames}
               />
             ),
           },

--- a/app/src/components/tabs/skill-setup-chat.tsx
+++ b/app/src/components/tabs/skill-setup-chat.tsx
@@ -1,0 +1,115 @@
+import { Button } from "@houston-ai/core";
+import type { Activity } from "@houston-ai/engine-client";
+import { Loader2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { Agent, AgentDefinition } from "../../lib/types";
+import { RoutineSetupChatBoard } from "./routine-setup-chat-board";
+
+interface Props {
+  /** The agent that owns this setup chat. */
+  agent: Agent;
+  /**
+   * The chat's activity — a skill's persistent chat or an unclaimed draft —
+   * or null while it is still being created / loading (renders a calm
+   * loading state, never a dead screen).
+   */
+  activity: Activity | null;
+  /** Which chat this is: an installed skill's own chat, or a create draft.
+   *  Drives the header label and the Edit-manually affordance. */
+  kind: "skill" | "draft";
+  /** The skill's display name, for the "Skill: {name}" header. Unused for
+   *  drafts (the header shows the create title). */
+  skillName?: string;
+  /** Close the pane and clear the selection (the catalog stays put). Wired
+   *  to the panel chrome's close X. */
+  onClose: () => void;
+  /** The manual escape hatch (HOU-791 keeps it): opens the raw markdown edit
+   *  modal for THIS skill. Only offered on an installed skill's chat. */
+  onEditManually?: () => void;
+}
+
+/**
+ * A custom skill's setup chat, rendered INLINE inside the Skills section
+ * (HOU-791 — mirrors the custom-integration setup chat). The guided chat is a
+ * real mission under the hood, but every board filters it out via the
+ * skill-setup sentinel — so this owns its OWN local container div and portals
+ * the chat's detail panel into it, keeping the chat embedded on the Skills
+ * page.
+ *
+ * The shared {@link RoutineSetupChatBoard} does the AIBoard mount + full
+ * `useAgentChatPanel` wiring — crucially `composerOverride`, which renders the
+ * ask_user question cards the create interview depends on. The auto
+ * "Mission: {title}" header line is overridden to read "Skill: {name}" (or
+ * the create title for a draft).
+ */
+export function SkillSetupChat({
+  agent,
+  activity,
+  kind,
+  skillName,
+  onClose,
+  onEditManually,
+}: Props) {
+  const { t } = useTranslation("skills");
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+
+  // The Skills section has no ambient AgentDefinition. RoutineSetupChatBoard
+  // needs one only for its agent-modes list, which a setup chat never uses —
+  // synthesize a minimal def so the send path still compiles and runs (the
+  // same shim the custom-integration setup chat uses).
+  const agentDef = useMemo<AgentDefinition>(
+    () => ({
+      config: { id: agent.configId, name: agent.name, description: "" },
+      source: "builtin",
+    }),
+    [agent.configId, agent.name],
+  );
+
+  const missionLabel =
+    kind === "draft"
+      ? t("setupChat.missionTitle")
+      : t("setupChat.skillLabel", { name: skillName ?? "" });
+
+  // Draft still being created, or a skill chat still loading: keep the pane
+  // shape stable over a calm loading state rather than flashing an empty box.
+  if (!activity) {
+    return (
+      <div className="flex h-[36rem] min-h-0 flex-col overflow-hidden rounded-2xl border border-line">
+        <div className="flex min-h-0 flex-1 items-center justify-center gap-2 text-ink-muted">
+          <Loader2 className="size-4 animate-spin" />
+          <span className="text-sm">{t("setupChat.opening")}</span>
+        </div>
+      </div>
+    );
+  }
+
+  const sessionKey = activity.session_key ?? `activity-${activity.id}`;
+
+  // The manual editor stays one click away — always visible in the header,
+  // never behind a menu (no hover-only affordances).
+  const editManuallyButton =
+    kind === "skill" && onEditManually ? (
+      <Button variant="outline" size="sm" onClick={onEditManually}>
+        {t("setupChat.editManually")}
+      </Button>
+    ) : undefined;
+
+  return (
+    <div className="flex h-[36rem] min-h-0 flex-col overflow-hidden rounded-2xl border border-line">
+      <div ref={setContainer} className="min-h-0 flex-1" />
+      <div className="hidden">
+        <RoutineSetupChatBoard
+          agent={agent}
+          agentDef={agentDef}
+          activity={activity}
+          sessionKey={sessionKey}
+          panelContainer={container}
+          missionLabel={missionLabel}
+          panelActions={editManuallyButton}
+          onPanelClose={onClose}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/tabs/skill-setup-chat.tsx
+++ b/app/src/components/tabs/skill-setup-chat.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@houston-ai/core";
 import type { Activity } from "@houston-ai/engine-client";
-import { Loader2 } from "lucide-react";
+import { ArrowLeft, Loader2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { Agent, AgentDefinition } from "../../lib/types";
@@ -71,11 +71,26 @@ export function SkillSetupChat({
       ? t("setupChat.missionTitle")
       : t("setupChat.skillLabel", { name: skillName ?? "" });
 
+  // The way back to the Skills section, always visible at the pane's left —
+  // the same affordance the custom-integration setup chat leads with.
+  const backButton = (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      onClick={onClose}
+      aria-label={t("setupChat.back")}
+    >
+      <ArrowLeft className="size-4" />
+    </Button>
+  );
+
   // Draft still being created, or a skill chat still loading: keep the pane
-  // shape stable over a calm loading state rather than flashing an empty box.
+  // shape stable over a calm loading state rather than flashing an empty box,
+  // with the way back reachable the whole time.
   if (!activity) {
     return (
       <div className="flex h-[36rem] min-h-0 flex-col overflow-hidden rounded-2xl border border-line">
+        <div className="border-line border-b px-4 py-3">{backButton}</div>
         <div className="flex min-h-0 flex-1 items-center justify-center gap-2 text-ink-muted">
           <Loader2 className="size-4 animate-spin" />
           <span className="text-sm">{t("setupChat.opening")}</span>
@@ -105,6 +120,7 @@ export function SkillSetupChat({
           activity={activity}
           sessionKey={sessionKey}
           panelContainer={container}
+          panelLeading={backButton}
           missionLabel={missionLabel}
           panelActions={editManuallyButton}
           onPanelClose={onClose}

--- a/app/src/components/tabs/skill-setup-chat.tsx
+++ b/app/src/components/tabs/skill-setup-chat.tsx
@@ -3,6 +3,7 @@ import type { Activity } from "@houston-ai/engine-client";
 import { ArrowLeft, Loader2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { skillChatTurnContext } from "../../lib/skill-chat-prompts";
 import type { Agent, AgentDefinition } from "../../lib/types";
 import { RoutineSetupChatBoard } from "./routine-setup-chat-board";
 
@@ -21,6 +22,9 @@ interface Props {
   /** The skill's display name, for the "Skill: {name}" header. Unused for
    *  drafts (the header shows the create title). */
   skillName?: string;
+  /** The skill's directory slug — pins the per-turn model context to the
+   *  bound skill. Unused for drafts (nothing exists to pin yet). */
+  skillSlug?: string;
   /** Close the pane and clear the selection (the catalog stays put). Wired
    *  to the panel chrome's close X. */
   onClose: () => void;
@@ -48,6 +52,7 @@ export function SkillSetupChat({
   activity,
   kind,
   skillName,
+  skillSlug,
   onClose,
   onEditManually,
 }: Props) {
@@ -124,6 +129,17 @@ export function SkillSetupChat({
           missionLabel={missionLabel}
           panelActions={editManuallyButton}
           onPanelClose={onClose}
+          // Every send re-asserts which skill this chat manages — the model
+          // must never have to remember it from the kickoff alone (it was
+          // observed asking "which skill?" inside a skill's own chat).
+          promptContext={
+            kind === "skill" && skillSlug
+              ? skillChatTurnContext({
+                  slug: skillSlug,
+                  displayName: skillName ?? "",
+                })
+              : undefined
+          }
         />
       </div>
     </div>

--- a/app/src/components/tabs/skill-setup-chat.tsx
+++ b/app/src/components/tabs/skill-setup-chat.tsx
@@ -94,7 +94,7 @@ export function SkillSetupChat({
   // with the way back reachable the whole time.
   if (!activity) {
     return (
-      <div className="flex h-[36rem] min-h-0 flex-col overflow-hidden rounded-2xl border border-line">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-line">
         <div className="border-line border-b px-4 py-3">{backButton}</div>
         <div className="flex min-h-0 flex-1 items-center justify-center gap-2 text-ink-muted">
           <Loader2 className="size-4 animate-spin" />
@@ -116,7 +116,9 @@ export function SkillSetupChat({
     ) : undefined;
 
   return (
-    <div className="flex h-[36rem] min-h-0 flex-col overflow-hidden rounded-2xl border border-line">
+    // Fills the section's whole height (the Automations chat look) — the
+    // pane is flex-1 against the settings column, never a fixed box.
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-line">
       <div ref={setContainer} className="min-h-0 flex-1" />
       <div className="hidden">
         <RoutineSetupChatBoard

--- a/app/src/components/tabs/skills-content-props.ts
+++ b/app/src/components/tabs/skills-content-props.ts
@@ -1,0 +1,52 @@
+import type {
+  CommunitySkill,
+  CommunitySkillPreview,
+  InstalledSkillEditorState,
+  RepoSkill,
+  SkillEditModalLabels,
+} from "@houston-ai/skills";
+import type { Agent, SkillSummary } from "../../lib/types";
+import type { DeleteConfirmLabels } from "./skill-editor-dialogs";
+
+/** Props contract for {@link SkillsContent}, split out to hold the file law. */
+export interface SkillsContentProps {
+  /** The agent whose skills these are — the setup chats run against it. */
+  agent: Agent;
+  skills: SkillSummary[];
+  loading: boolean;
+  /**
+   * Managed-agent read-only mode (matrix v2): a non-manager may view skills but
+   * not add/create/install any. Hides the discovery tabs and the add CTA.
+   * The gateway 403s writes regardless.
+   */
+  readOnly?: boolean;
+  /** Name of the installed skill whose edit modal is open, if any. */
+  editingSkillName: string | null;
+  editorState: InstalledSkillEditorState;
+  onEditSkill: (name: string) => void;
+  onCloseEdit: () => void;
+  onSaveEditing: (content: string) => Promise<void>;
+  onDeleteSkill: (name: string) => Promise<void>;
+  editModalLabels: SkillEditModalLabels;
+  deleteConfirm: DeleteConfirmLabels;
+  onSearch?: (query: string, signal?: AbortSignal) => Promise<CommunitySkill[]>;
+  onInstallCommunity?: (
+    skill: CommunitySkill,
+    signal?: AbortSignal,
+  ) => Promise<string>;
+  onPreviewCommunity?: (
+    skill: CommunitySkill,
+    signal?: AbortSignal,
+  ) => Promise<CommunitySkillPreview>;
+  onListFromRepo?: (source: string) => Promise<RepoSkill[]>;
+  onInstallFromRepo?: (
+    source: string,
+    skills: RepoSkill[],
+  ) => Promise<string[]>;
+  onCreateFromScratch?: (input: {
+    name: string;
+    description: string;
+    content: string;
+  }) => Promise<string>;
+  installedSkillNames?: Set<string>;
+}

--- a/app/src/components/tabs/skills-content.tsx
+++ b/app/src/components/tabs/skills-content.tsx
@@ -61,7 +61,13 @@ export function SkillsContent({
   const [query, setQuery] = useState("");
   // The chat layer (HOU-791): a row click opens the skill's setup chat; the
   // modal stays the read-only fallback + the chat's Edit-manually target.
-  const chat = useSkillsChatSurface({ agent, skills, readOnly, onEditSkill });
+  const chat = useSkillsChatSurface({
+    agent,
+    skills,
+    loading,
+    readOnly,
+    onEditSkill,
+  });
   const { sorted, installedCount, installed } = useInstalledSkillsStrip(
     skills,
     chat.openRow,

--- a/app/src/components/tabs/skills-content.tsx
+++ b/app/src/components/tabs/skills-content.tsx
@@ -1,22 +1,13 @@
 import { CatalogSearchField, CatalogShell, Spinner } from "@houston-ai/core";
-import type {
-  CommunitySkill,
-  CommunitySkillPreview,
-  InstalledSkillEditorState,
-  RepoSkill,
-  SkillEditModalLabels,
-} from "@houston-ai/skills";
 import { AddSkillDialog } from "@houston-ai/skills";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { SkillSummary } from "../../lib/types";
 import { useInstalledSkillsStrip } from "./installed-skills-strip";
 import { useSkillDiscoveryTabs } from "./skill-discovery-tabs";
-import {
-  type DeleteConfirmLabels,
-  SkillEditorDialogs,
-} from "./skill-editor-dialogs";
+import { SkillEditorDialogs } from "./skill-editor-dialogs";
+import type { SkillsContentProps } from "./skills-content-props";
 import { useSkillDialogLabels } from "./use-skill-surface-labels";
+import { useSkillsChatSurface } from "./use-skills-chat-surface";
 
 /** Approximate size of the skills.sh store, shown verbatim on the Available chip
  * (the store is async with no cheap total, so we label the ballpark). */
@@ -34,8 +25,15 @@ const SKILL_STORE_SIZE_LABEL = "9000+";
  * query filters the strip AND the store; a strip with no matches is dropped.
  * Read-only mode (managed agent, non-manager) drops the tabs entirely and keeps
  * just the strip.
+ *
+ * HOU-791: a skill's primary surface is its persistent setup CHAT (the
+ * Automations-tab experience) — a row click opens it inline in place of the
+ * catalog, `useSkillsChatSurface` owns the lifecycle, and the raw-markdown
+ * modal stays reachable via the chat header's "Edit manually" (and stays the
+ * row behavior in read-only mode).
  */
 export function SkillsContent({
+  agent,
   skills,
   loading,
   readOnly = false,
@@ -54,54 +52,19 @@ export function SkillsContent({
   onInstallFromRepo,
   onCreateFromScratch,
   installedSkillNames,
-}: {
-  skills: SkillSummary[];
-  loading: boolean;
-  /**
-   * Managed-agent read-only mode (matrix v2): a non-manager may view skills but
-   * not add/create/install any. Hides the discovery tabs and the add CTA.
-   * The gateway 403s writes regardless.
-   */
-  readOnly?: boolean;
-  /** Name of the installed skill whose edit modal is open, if any. */
-  editingSkillName: string | null;
-  editorState: InstalledSkillEditorState;
-  onEditSkill: (name: string) => void;
-  onCloseEdit: () => void;
-  onSaveEditing: (content: string) => Promise<void>;
-  onDeleteSkill: (name: string) => Promise<void>;
-  editModalLabels: SkillEditModalLabels;
-  deleteConfirm: DeleteConfirmLabels;
-  onSearch?: (query: string, signal?: AbortSignal) => Promise<CommunitySkill[]>;
-  onInstallCommunity?: (
-    skill: CommunitySkill,
-    signal?: AbortSignal,
-  ) => Promise<string>;
-  onPreviewCommunity?: (
-    skill: CommunitySkill,
-    signal?: AbortSignal,
-  ) => Promise<CommunitySkillPreview>;
-  onListFromRepo?: (source: string) => Promise<RepoSkill[]>;
-  onInstallFromRepo?: (
-    source: string,
-    skills: RepoSkill[],
-  ) => Promise<string[]>;
-  onCreateFromScratch?: (input: {
-    name: string;
-    description: string;
-    content: string;
-  }) => Promise<string>;
-  installedSkillNames?: Set<string>;
-}) {
+}: SkillsContentProps) {
   const { t } = useTranslation("skills");
   const dialogLabels = useSkillDialogLabels();
   const [tab, setTab] = useState("store");
   const [dialogOpen, setDialogOpen] = useState(false);
   // The ONE page search: it filters the installed strip AND drives the Store.
   const [query, setQuery] = useState("");
+  // The chat layer (HOU-791): a row click opens the skill's setup chat; the
+  // modal stays the read-only fallback + the chat's Edit-manually target.
+  const chat = useSkillsChatSurface({ agent, skills, readOnly, onEditSkill });
   const { sorted, installedCount, installed } = useInstalledSkillsStrip(
     skills,
-    onEditSkill,
+    chat.openRow,
     query,
   );
   const editingSkill = sorted.find((s) => s.name === editingSkillName) ?? null;
@@ -117,6 +80,10 @@ export function SkillsContent({
   const tabs = useSkillDiscoveryTabs({
     showCustom: addDialogProps !== null,
     onAddClick: () => setDialogOpen(true),
+    onCreateWithAi: chat.startCreate,
+    drafts: chat.drafts,
+    onResumeDraft: chat.resumeDraft,
+    onDiscardDraft: chat.discardDraft,
     query,
     onQueryChange: setQuery,
     // Read-only mode never offers the Store either: no community callbacks.
@@ -143,33 +110,42 @@ export function SkillsContent({
 
   return (
     <>
-      {/* Read-only mode yields zero tabs: the shell then renders only the
-          installed strip (or nothing at all when there are no skills). */}
-      <CatalogShell
-        controls={
-          (tabs.length > 0 || sorted.length > 0) && (
-            <CatalogSearchField
-              value={query}
-              onChange={setQuery}
-              label={t("grid.searchSkills")}
-            />
-          )
-        }
-        installedTitle={t("grid.yourSkillsHeading")}
-        installedCount={installedCount}
-        installed={installed}
-        availableTitle={t("grid.availableHeading")}
-        // The store-size label belongs to the Store tab only; on Custom the
-        // chip would contradict the visible content.
-        availableCount={tab === "store" ? SKILL_STORE_SIZE_LABEL : undefined}
-        tabs={tabs}
-        value={tab}
-        onValueChange={setTab}
-      />
-      {noInstalledMatches && (
-        <p className="text-[13px] text-ink-muted">
-          {t("grid.noMatchingSkills")}
-        </p>
+      {/* An open setup chat owns the section (HOU-791): the catalog steps
+          aside so the conversation gets the room, and closing the chat
+          returns it. The dialogs below stay mounted — the chat header's
+          Edit-manually opens the modal over the chat. */}
+      {chat.chatNode}
+      {!chat.chatNode && (
+        <>
+          <CatalogShell
+            controls={
+              (tabs.length > 0 || sorted.length > 0) && (
+                <CatalogSearchField
+                  value={query}
+                  onChange={setQuery}
+                  label={t("grid.searchSkills")}
+                />
+              )
+            }
+            installedTitle={t("grid.yourSkillsHeading")}
+            installedCount={installedCount}
+            installed={installed}
+            availableTitle={t("grid.availableHeading")}
+            // The store-size label belongs to the Store tab only; on Custom
+            // the chip would contradict the visible content.
+            availableCount={
+              tab === "store" ? SKILL_STORE_SIZE_LABEL : undefined
+            }
+            tabs={tabs}
+            value={tab}
+            onValueChange={setTab}
+          />
+          {noInstalledMatches && (
+            <p className="text-[13px] text-ink-muted">
+              {t("grid.noMatchingSkills")}
+            </p>
+          )}
+        </>
       )}
       {addDialogProps && (
         <AddSkillDialog

--- a/app/src/components/tabs/skills-content.tsx
+++ b/app/src/components/tabs/skills-content.tsx
@@ -85,6 +85,7 @@ export function SkillsContent({
       : null;
   const tabs = useSkillDiscoveryTabs({
     showCustom: addDialogProps !== null,
+    agentPath: agent.folderPath,
     onAddClick: () => setDialogOpen(true),
     onCreateWithAi: chat.startCreate,
     drafts: chat.drafts,

--- a/app/src/components/tabs/use-houston-skill-library.ts
+++ b/app/src/components/tabs/use-houston-skill-library.ts
@@ -1,0 +1,89 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { storeCatalogConfigs } from "../../agents/builtin/store-catalog";
+import { loadStoreTemplate } from "../../agents/builtin/store-template-loader";
+import { analytics } from "../../lib/analytics";
+import {
+  extractTemplateSkills,
+  type HoustonLibrarySkill,
+  withFeaturedFrontmatter,
+} from "../../lib/houston-skill-library";
+import { logger } from "../../lib/logger";
+import { queryKeys } from "../../lib/query-keys";
+import { tauriAgent } from "../../lib/tauri";
+
+/** The library grouped the way it reads: by the pre-set agent that ships it. */
+export interface HoustonLibraryGroup {
+  agentId: string;
+  agentName: string;
+  skills: HoustonLibrarySkill[];
+}
+
+/**
+ * The Custom tab's Houston skill library: every skill the release-bundled
+ * pre-set agents ship (translated variant when the app runs es/pt), plus the
+ * one-click install that writes the SKILL.md into THIS agent. The bundle is
+ * static per release, so the parse runs once per locale and never refetches.
+ */
+export function useHoustonSkillLibrary(agentPath: string) {
+  const { i18n } = useTranslation();
+  const locale = i18n.language;
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: ["houston-skill-library", locale.toLowerCase().split("-")[0]],
+    staleTime: Number.POSITIVE_INFINITY,
+    queryFn: async (): Promise<HoustonLibraryGroup[]> => {
+      const groups = await Promise.all(
+        storeCatalogConfigs.map(async (config) => {
+          const template = await loadStoreTemplate(config.id, locale);
+          return {
+            agentId: config.id,
+            agentName: config.name,
+            skills: extractTemplateSkills(config.id, template.seeds),
+          };
+        }),
+      );
+      return groups.filter((g) => g.skills.length > 0);
+    },
+  });
+
+  // One install at a time; the slug in flight drives that row's spinner.
+  const [installing, setInstalling] = useState<string | null>(null);
+  const install = useCallback(
+    async (skill: HoustonLibrarySkill) => {
+      if (installing) return;
+      setInstalling(skill.slug);
+      try {
+        await tauriAgent.writeFile(
+          agentPath,
+          `.agents/skills/${skill.slug}/SKILL.md`,
+          withFeaturedFrontmatter(skill.content),
+        );
+        analytics.track("skill_installed", {
+          skill_slug: skill.slug,
+          source: "houston",
+        });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.skills(agentPath),
+        });
+      } catch (err) {
+        // call() already toasted the write failure; log so it isn't silent.
+        logger.error(`[skill-library] install ${skill.slug} failed: ${err}`);
+      } finally {
+        setInstalling(null);
+      }
+    },
+    [agentPath, installing, queryClient],
+  );
+
+  return {
+    groups: query.data ?? [],
+    loading: query.isLoading,
+    failed: query.isError,
+    retry: () => void query.refetch(),
+    install: (skill: HoustonLibrarySkill) => void install(skill),
+    installing,
+  };
+}

--- a/app/src/components/tabs/use-skill-chat-setup.ts
+++ b/app/src/components/tabs/use-skill-chat-setup.ts
@@ -1,0 +1,167 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useActivity } from "../../hooks/queries";
+import { analytics } from "../../lib/analytics";
+import { createMission } from "../../lib/create-mission";
+import { skillDisplayTitle } from "../../lib/humanize-skill-name";
+import { logger } from "../../lib/logger";
+import { queryKeys } from "../../lib/query-keys";
+import {
+  encodeSkillModifyMessage,
+  encodeSkillSetupMessage,
+} from "../../lib/skill-chat-prompts";
+import {
+  findDraftSkillChatActivities,
+  findSkillChatActivity,
+  findSkillChatHeal,
+  SKILL_SETUP_AGENT_MODE,
+} from "../../lib/skill-chat-setup";
+import { tauriActivity } from "../../lib/tauri";
+import type { Agent, SkillSummary } from "../../lib/types";
+import { readAgentRunOverrides } from "./routine-run-overrides";
+
+/**
+ * Owns a custom skill's setup chat (HOU-791 — the Automations-tab experience
+ * on the Skills surface), tagged with the skill-setup sentinel so it never
+ * shows as a board card. A chat starts as a "draft" (no skill yet); once the
+ * agent creates the skill with the chat's `setup_activity_id` in its
+ * frontmatter, the chat is the skill's for good and reopening the skill
+ * resumes it. Skills without a chat (store installs, GitHub imports, manual
+ * creates, pre-HOU-791 skills) get one on first open via `startForSkill`.
+ */
+export function useSkillChatSetup(
+  agent: Agent,
+  skills: SkillSummary[] | undefined,
+) {
+  const { t } = useTranslation("skills");
+  const path = agent.folderPath;
+  const queryClient = useQueryClient();
+  const { data: rawItems } = useActivity(path);
+  const [pending, setPending] = useState(false);
+
+  const mode = SKILL_SETUP_AGENT_MODE;
+  const missionTitle = t("setupChat.missionTitle");
+
+  // Every unlinked, live create-chat for this agent — a person can be
+  // building several skills at once.
+  const draftActivities = findDraftSkillChatActivities(rawItems, skills);
+
+  // The persisted chat attached to a skill, or null if it has none yet.
+  const activityFor = useCallback(
+    (skill: SkillSummary) => findSkillChatActivity(rawItems, skill),
+    [rawItems],
+  );
+
+  // Background link reconciliation: an agent-created skill carries the
+  // forward `setup_activity_id` but its chat has no durable `skill_slug`
+  // stamp until the client writes one. One repair per pass; the invalidation
+  // refetch re-runs the effect until consistent. Failures only log: there is
+  // no user action to toast on, and the next refetch retries anyway.
+  const healingRef = useRef(false);
+  useEffect(() => {
+    if (healingRef.current) return;
+    const heal = findSkillChatHeal(rawItems, skills);
+    if (!heal) return;
+    healingRef.current = true;
+    tauriActivity
+      .update(path, heal.activityId, { skill_slug: heal.slug })
+      .then(() =>
+        queryClient.invalidateQueries({ queryKey: queryKeys.activity(path) }),
+      )
+      .catch((err) => logger.error(`[skill-chat] link heal failed: ${err}`))
+      .finally(() => {
+        healingRef.current = false;
+      });
+  }, [rawItems, skills, path, queryClient]);
+
+  /**
+   * Start a brand-new create-chat. Always creates a fresh one — "Create with
+   * AI" means new, even while other drafts are still unfinished; those stay
+   * put as their own resumable items. Returns the new activity id (or null on
+   * failure) so the caller can open it right away.
+   */
+  const startDraft = useCallback(async () => {
+    if (pending) return null; // a start is already in flight — never double-create
+    setPending(true);
+    try {
+      // The kickoff needs the activity's own id (the agent writes it into the
+      // skill's `setup_activity_id`), so the prompt is built after create.
+      const { conversationId } = await createMission(agent, "", {
+        title: missionTitle,
+        agentMode: mode,
+        // Pin the agent's configured brain onto the kickoff turn (see helper).
+        ...(await readAgentRunOverrides(path)),
+        // Setup chats always run as Ask first: the interview needs ask_user
+        // (auto strips it) and must never open read-only in Planner.
+        modeOverride: "execute",
+        buildPrompt: (activityId) => encodeSkillSetupMessage(activityId),
+      });
+      // createMission bypasses useCreateActivity — refetch so the chat
+      // view's backing activity exists before it tries to render.
+      queryClient.invalidateQueries({ queryKey: queryKeys.activity(path) });
+      analytics.track("skill_chat_setup_started");
+      return conversationId;
+    } catch {
+      // Every failure path here surfaces via call() (activity create's
+      // read/write, the session send) — a toast here would double up.
+      return null;
+    } finally {
+      setPending(false);
+    }
+  }, [agent, path, pending, queryClient, missionTitle]);
+
+  /**
+   * Start the persistent chat for a skill that doesn't have one yet, and
+   * stamp the durable reverse link so every future open resumes it. (The
+   * forward frontmatter link stays agent-owned; the client never rewrites
+   * SKILL.md, so a concurrent agent edit can't be clobbered.)
+   */
+  const startForSkill = useCallback(
+    async (skill: SkillSummary) => {
+      if (pending) return false; // a start is already in flight — never double-create
+      setPending(true);
+      try {
+        const { conversationId } = await createMission(
+          agent,
+          encodeSkillModifyMessage({
+            slug: skill.name,
+            displayName: skillDisplayTitle(skill),
+          }),
+          {
+            title: skillDisplayTitle(skill),
+            agentMode: mode,
+            // Same brain pin as startDraft, and the same Ask first pin —
+            // setup chats are interactive by design.
+            ...(await readAgentRunOverrides(path)),
+            modeOverride: "execute",
+          },
+        );
+        // The durable direction: agents never rewrite activity.json.
+        await tauriActivity.update(path, conversationId, {
+          skill_slug: skill.name,
+        });
+        queryClient.invalidateQueries({ queryKey: queryKeys.activity(path) });
+        return true;
+      } catch {
+        // Every failure path here surfaces via call() (createMission's
+        // read/write/send, the link write) — a toast here would double up.
+        return false;
+      } finally {
+        setPending(false);
+      }
+    },
+    [agent, path, pending, queryClient],
+  );
+
+  return {
+    draftActivities,
+    activityFor,
+    /** Whether the activity query has resolved (vs. still loading) — lets the
+     *  surface distinguish "no match yet" from "loaded, genuinely no match". */
+    activitiesLoaded: rawItems !== undefined,
+    startDraft,
+    startForSkill,
+    pending,
+  };
+}

--- a/app/src/components/tabs/use-skill-chat-setup.ts
+++ b/app/src/components/tabs/use-skill-chat-setup.ts
@@ -15,6 +15,7 @@ import {
   findDraftSkillChatActivities,
   findSkillChatActivity,
   findSkillChatHeal,
+  isSkillSetupMode,
   SKILL_SETUP_AGENT_MODE,
 } from "../../lib/skill-chat-setup";
 import { tauriActivity } from "../../lib/tauri";
@@ -50,6 +51,16 @@ export function useSkillChatSetup(
   // The persisted chat attached to a skill, or null if it has none yet.
   const activityFor = useCallback(
     (skill: SkillSummary) => findSkillChatActivity(rawItems, skill),
+    [rawItems],
+  );
+
+  // A skill-setup chat by its activity id (notification nav): the activity's
+  // own `skill_slug` stamp resolves its skill without waiting on the skills
+  // list, so the deep link works even mid-load.
+  const activityById = useCallback(
+    (id: string) =>
+      (rawItems ?? []).find((a) => a.id === id && isSkillSetupMode(a.agent)) ??
+      null,
     [rawItems],
   );
 
@@ -157,6 +168,7 @@ export function useSkillChatSetup(
   return {
     draftActivities,
     activityFor,
+    activityById,
     /** Whether the activity query has resolved (vs. still loading) — lets the
      *  surface distinguish "no match yet" from "loaded, genuinely no match". */
     activitiesLoaded: rawItems !== undefined,

--- a/app/src/components/tabs/use-skill-chat-setup.ts
+++ b/app/src/components/tabs/use-skill-chat-setup.ts
@@ -66,13 +66,15 @@ export function useSkillChatSetup(
 
   // Background link reconciliation: an agent-created skill carries the
   // forward `setup_activity_id` but its chat has no durable `skill_slug`
-  // stamp until the client writes one. One repair per pass; the invalidation
-  // refetch re-runs the effect until consistent. Failures only log: there is
-  // no user action to toast on, and the next refetch retries anyway.
+  // stamp until the client writes one; a title-matched orphan chat (a stamp
+  // write that failed mid-flight) is adopted back too. One repair per pass;
+  // the invalidation refetch re-runs the effect until consistent. Failures
+  // only log: there is no user action to toast on, and the next refetch
+  // retries anyway.
   const healingRef = useRef(false);
   useEffect(() => {
     if (healingRef.current) return;
-    const heal = findSkillChatHeal(rawItems, skills);
+    const heal = findSkillChatHeal(rawItems, skills, skillDisplayTitle);
     if (!heal) return;
     healingRef.current = true;
     tauriActivity
@@ -148,10 +150,23 @@ export function useSkillChatSetup(
             modeOverride: "execute",
           },
         );
-        // The durable direction: agents never rewrite activity.json.
-        await tauriActivity.update(path, conversationId, {
-          skill_slug: skill.name,
-        });
+        try {
+          // The durable direction: agents never rewrite activity.json.
+          await tauriActivity.update(path, conversationId, {
+            skill_slug: skill.name,
+          });
+        } catch (err) {
+          // The chat exists but the link write failed: archive it so it can
+          // never linger as a bogus "draft" row on the Custom tab (the heal's
+          // title-match adoption is a repair, not a license to leak).
+          logger.error(`[skill-chat] link stamp failed, retiring chat: ${err}`);
+          await tauriActivity
+            .update(path, conversationId, { status: "archived" })
+            .catch((cleanupErr) =>
+              logger.error(`[skill-chat] orphan cleanup failed: ${cleanupErr}`),
+            );
+          throw err;
+        }
         queryClient.invalidateQueries({ queryKey: queryKeys.activity(path) });
         return true;
       } catch {
@@ -169,6 +184,8 @@ export function useSkillChatSetup(
     draftActivities,
     activityFor,
     activityById,
+    /** The raw activity list (claim heuristics need the full picture). */
+    activities: rawItems,
     /** Whether the activity query has resolved (vs. still loading) — lets the
      *  surface distinguish "no match yet" from "loaded, genuinely no match". */
     activitiesLoaded: rawItems !== undefined,

--- a/app/src/components/tabs/use-skill-chat-setup.ts
+++ b/app/src/components/tabs/use-skill-chat-setup.ts
@@ -15,6 +15,7 @@ import {
   findDraftSkillChatActivities,
   findSkillChatActivity,
   findSkillChatHeal,
+  findSkillChatTitleHeal,
   isSkillSetupMode,
   SKILL_SETUP_AGENT_MODE,
 } from "../../lib/skill-chat-setup";
@@ -64,25 +65,35 @@ export function useSkillChatSetup(
     [rawItems],
   );
 
-  // Background link reconciliation: an agent-created skill carries the
-  // forward `setup_activity_id` but its chat has no durable `skill_slug`
-  // stamp until the client writes one; a title-matched orphan chat (a stamp
-  // write that failed mid-flight) is adopted back too. One repair per pass;
-  // the invalidation refetch re-runs the effect until consistent. Failures
-  // only log: there is no user action to toast on, and the next refetch
-  // retries anyway.
+  // Background reconciliation, one repair per pass (the invalidation refetch
+  // re-runs the effect until consistent). Links first: an agent-created
+  // skill carries the forward `setup_activity_id` but its chat has no
+  // durable `skill_slug` stamp until the client writes one, and a
+  // title-matched orphan chat (a stamp write that failed mid-flight) is
+  // adopted back. Then titles: a skill's chat keeps the skill's display
+  // title, so a rename in the conversation renames the conversation too.
+  // Failures only log: there is no user action to toast on, and the next
+  // refetch retries anyway.
   const healingRef = useRef(false);
   useEffect(() => {
     if (healingRef.current) return;
     const heal = findSkillChatHeal(rawItems, skills, skillDisplayTitle);
-    if (!heal) return;
+    const titleHeal = heal
+      ? null
+      : findSkillChatTitleHeal(rawItems, skills, skillDisplayTitle);
+    const patch = heal
+      ? { id: heal.activityId, update: { skill_slug: heal.slug } }
+      : titleHeal
+        ? { id: titleHeal.activityId, update: { title: titleHeal.title } }
+        : null;
+    if (!patch) return;
     healingRef.current = true;
     tauriActivity
-      .update(path, heal.activityId, { skill_slug: heal.slug })
+      .update(path, patch.id, patch.update)
       .then(() =>
         queryClient.invalidateQueries({ queryKey: queryKeys.activity(path) }),
       )
-      .catch((err) => logger.error(`[skill-chat] link heal failed: ${err}`))
+      .catch((err) => logger.error(`[skill-chat] heal failed: ${err}`))
       .finally(() => {
         healingRef.current = false;
       });

--- a/app/src/components/tabs/use-skill-setup-view.ts
+++ b/app/src/components/tabs/use-skill-setup-view.ts
@@ -43,17 +43,16 @@ export function useSkillSetupView(
     (s) => s.setPendingSkillChatActivityId,
   );
   useEffect(() => {
-    if (!pendingActivityId) return;
-    if (!chatSetup.activitiesLoaded || skills === undefined) return;
-    const draft = chatSetup.draftActivities.find(
-      (a) => a.id === pendingActivityId,
-    );
-    const owner = skills.find(
-      (s) => chatSetup.activityFor(s)?.id === pendingActivityId,
-    );
+    if (!pendingActivityId || !chatSetup.activitiesLoaded) return;
+    const activity = chatSetup.activityById(pendingActivityId);
     setPendingSkillChatActivityId(null);
-    if (owner) setSelected({ kind: "skill", slug: owner.name });
-    else if (draft) setSelected({ kind: "draft", activityId: draft.id });
+    if (!activity || activity.status === "archived") return;
+    // The durable reverse stamp names the skill without waiting on the skills
+    // list; an unstamped chat opens as its claiming skill (forward link) or as
+    // a resumable draft — the claim effect below swaps it once skills load.
+    const slug = activity.skill_slug ?? claimedSkillSlug(activity.id, skills);
+    if (slug) setSelected({ kind: "skill", slug });
+    else setSelected({ kind: "draft", activityId: activity.id });
   }, [pendingActivityId, skills, chatSetup, setPendingSkillChatActivityId]);
 
   // Draft → claimed: when the agent creates the skill (its frontmatter

--- a/app/src/components/tabs/use-skill-setup-view.ts
+++ b/app/src/components/tabs/use-skill-setup-view.ts
@@ -1,0 +1,142 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useState } from "react";
+import { analytics } from "../../lib/analytics";
+import { logger } from "../../lib/logger";
+import { queryKeys } from "../../lib/query-keys";
+import { claimedSkillSlug } from "../../lib/skill-chat-setup";
+import { tauriActivity } from "../../lib/tauri";
+import type { Agent, SkillSummary } from "../../lib/types";
+import { useUIStore } from "../../stores/ui";
+import type { useSkillChatSetup } from "./use-skill-chat-setup";
+
+/** Which chat — if any — owns the Skills surface's inline chat pane. */
+export type SkillChatSelection =
+  | { kind: "draft"; activityId: string | null }
+  | { kind: "skill"; slug: string };
+
+/**
+ * The Skills surface's chat selection state machine (HOU-791, mirrors the
+ * Automations tab's `useRoutinesTabView`): which skill's setup chat — or
+ * which unclaimed draft — is open, and the effects that move the cursor.
+ */
+export function useSkillSetupView(
+  agent: Agent,
+  skills: SkillSummary[] | undefined,
+  chatSetup: ReturnType<typeof useSkillChatSetup>,
+) {
+  const [selected, setSelected] = useState<SkillChatSelection | null>(null);
+  const queryClient = useQueryClient();
+
+  // The surface is reused across agents; clear the selection on agent switch
+  // so a chat never bleeds between agents' Skills sections.
+  const [trackedAgentId, setTrackedAgentId] = useState(agent.id);
+  if (trackedAgentId !== agent.id) {
+    setTrackedAgentId(agent.id);
+    setSelected(null);
+  }
+
+  // A session-finished notification lands as a one-shot activity id; select
+  // its skill/draft chat, or clear a stale/foreign id once both data sources
+  // have loaded.
+  const pendingActivityId = useUIStore((s) => s.pendingSkillChatActivityId);
+  const setPendingSkillChatActivityId = useUIStore(
+    (s) => s.setPendingSkillChatActivityId,
+  );
+  useEffect(() => {
+    if (!pendingActivityId) return;
+    if (!chatSetup.activitiesLoaded || skills === undefined) return;
+    const draft = chatSetup.draftActivities.find(
+      (a) => a.id === pendingActivityId,
+    );
+    const owner = skills.find(
+      (s) => chatSetup.activityFor(s)?.id === pendingActivityId,
+    );
+    setPendingSkillChatActivityId(null);
+    if (owner) setSelected({ kind: "skill", slug: owner.name });
+    else if (draft) setSelected({ kind: "draft", activityId: draft.id });
+  }, [pendingActivityId, skills, chatSetup, setPendingSkillChatActivityId]);
+
+  // Draft → claimed: when the agent creates the skill (its frontmatter
+  // pointing back at the draft chat), swap the selection to the skill's chat
+  // so the SAME conversation continues seamlessly in the same pane.
+  useEffect(() => {
+    if (selected?.kind !== "draft" || !selected.activityId) return;
+    const slug = claimedSkillSlug(selected.activityId, skills);
+    if (slug) setSelected({ kind: "skill", slug });
+  }, [selected, skills]);
+
+  // "Create with AI": open the calm creating surface instantly, then swap in
+  // the draft's id (or clear the selection on failure) once the start lands —
+  // but only if the user is still waiting on this create.
+  const startCreate = useCallback(async () => {
+    setSelected({ kind: "draft", activityId: null });
+    analytics.track("skill_chat_create_clicked");
+    const activityId = await chatSetup.startDraft();
+    setSelected((s) =>
+      s?.kind === "draft" && s.activityId === null
+        ? activityId
+          ? { kind: "draft", activityId }
+          : null
+        : s,
+    );
+  }, [chatSetup]);
+
+  // Skill row click: open the skill's chat (starting one first if it lacks
+  // one), or close it when it is already the open one (re-click). A failed
+  // start clears the selection so it never strands the user.
+  const openSkillChat = useCallback(
+    (slug: string) => {
+      if (selected?.kind === "skill" && selected.slug === slug) {
+        setSelected(null);
+        return;
+      }
+      setSelected({ kind: "skill", slug });
+      const skill = skills?.find((s) => s.name === slug);
+      if (skill && !chatSetup.activityFor(skill)) {
+        void chatSetup.startForSkill(skill).then((ok) => {
+          if (!ok)
+            setSelected((s) =>
+              s?.kind === "skill" && s.slug === slug ? null : s,
+            );
+        });
+      }
+    },
+    [selected, skills, chatSetup],
+  );
+
+  const resumeDraft = useCallback(
+    (activityId: string) => setSelected({ kind: "draft", activityId }),
+    [],
+  );
+
+  // Abandon a draft: archive its chat so it stops showing as a resumable
+  // item. Failures surface via call()'s own toast path.
+  const discardDraft = useCallback(
+    (activityId: string) => {
+      setSelected((s) =>
+        s?.kind === "draft" && s.activityId === activityId ? null : s,
+      );
+      tauriActivity
+        .update(agent.folderPath, activityId, { status: "archived" })
+        .then(() =>
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.activity(agent.folderPath),
+          }),
+        )
+        // call() already toasted the failure; log so the rejection isn't silent.
+        .catch((err) => logger.error(`[skill-chat] discard failed: ${err}`));
+    },
+    [agent.folderPath, queryClient],
+  );
+
+  const deselect = useCallback(() => setSelected(null), []);
+
+  return {
+    selected,
+    startCreate,
+    openSkillChat,
+    resumeDraft,
+    discardDraft,
+    deselect,
+  };
+}

--- a/app/src/components/tabs/use-skill-setup-view.ts
+++ b/app/src/components/tabs/use-skill-setup-view.ts
@@ -1,9 +1,12 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { analytics } from "../../lib/analytics";
 import { logger } from "../../lib/logger";
 import { queryKeys } from "../../lib/query-keys";
-import { claimedSkillSlug } from "../../lib/skill-chat-setup";
+import {
+  claimedSkillSlug,
+  claimNewlyCreatedSkill,
+} from "../../lib/skill-chat-setup";
 import { tauriActivity } from "../../lib/tauri";
 import type { Agent, SkillSummary } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
@@ -63,6 +66,33 @@ export function useSkillSetupView(
     const slug = claimedSkillSlug(selected.activityId, skills);
     if (slug) setSelected({ kind: "skill", slug });
   }, [selected, skills]);
+
+  // Claim FALLBACK: an agent that forgot the frontmatter link would strand
+  // the draft forever ("Meeting prep" showing both installed AND in
+  // progress). While the user sits in a draft chat, the one skill that newly
+  // appears with no link and no chat of its own is this conversation's
+  // creation — stamp the durable link ourselves and swap.
+  const prevSlugsRef = useRef<ReadonlySet<string> | null>(null);
+  useEffect(() => {
+    const prev = prevSlugsRef.current;
+    if (skills !== undefined)
+      prevSlugsRef.current = new Set(skills.map((s) => s.name));
+    if (!prev || selected?.kind !== "draft" || !selected.activityId) return;
+    const activityId = selected.activityId;
+    const slug = claimNewlyCreatedSkill(prev, skills, chatSetup.activities);
+    if (!slug) return;
+    setSelected({ kind: "skill", slug });
+    tauriActivity
+      .update(agent.folderPath, activityId, { skill_slug: slug })
+      .then(() =>
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.activity(agent.folderPath),
+        }),
+      )
+      .catch((err) =>
+        logger.error(`[skill-chat] fallback claim stamp failed: ${err}`),
+      );
+  }, [selected, skills, chatSetup.activities, agent.folderPath, queryClient]);
 
   // "Create with AI": open the calm creating surface instantly, then swap in
   // the draft's id (or clear the selection on failure) once the start lands —

--- a/app/src/components/tabs/use-skills-chat-surface.tsx
+++ b/app/src/components/tabs/use-skills-chat-surface.tsx
@@ -1,0 +1,96 @@
+import type { Activity } from "@houston-ai/engine-client";
+import { type ReactNode, useEffect } from "react";
+import { skillDisplayTitle } from "../../lib/humanize-skill-name";
+import type { Agent, SkillSummary } from "../../lib/types";
+import { SkillSetupChat } from "./skill-setup-chat";
+import { useSkillChatSetup } from "./use-skill-chat-setup";
+import { useSkillSetupView } from "./use-skill-setup-view";
+
+/**
+ * The Skills surface's chat layer (HOU-791): glues the setup-chat lifecycle
+ * (`useSkillChatSetup`) and the selection machine (`useSkillSetupView`) into
+ * what {@link SkillsContent} renders — the inline chat pane for the open
+ * selection, the row-click handler that opens a skill's chat, and the Custom
+ * tab's create/draft affordances. Disabled (null chat, rows fall back to the
+ * manual edit modal) in read-only mode.
+ */
+export function useSkillsChatSurface(opts: {
+  agent: Agent;
+  skills: SkillSummary[];
+  readOnly: boolean;
+  /** Opens the manual markdown edit modal (the read-only fallback, and the
+   *  chat header's "Edit manually" escape hatch). */
+  onEditSkill: (name: string) => void;
+}): {
+  /** The open chat pane, or null when nothing is selected. */
+  chatNode: ReactNode | null;
+  /** Row click: the skill's chat (writable) or the manual modal (read-only). */
+  openRow: (name: string) => void;
+  /** Unclaimed create-chats, shown as resumable rows on the Custom tab. */
+  drafts: Activity[];
+  resumeDraft: (activityId: string) => void;
+  discardDraft: (activityId: string) => void;
+  startCreate: () => void;
+} {
+  const { agent, skills, readOnly, onEditSkill } = opts;
+  const chatSetup = useSkillChatSetup(agent, skills);
+  const view = useSkillSetupView(agent, skills, chatSetup);
+  const { selected, deselect } = view;
+
+  // A skill deleted while its chat is open (edit modal's delete, an agent
+  // cleanup): close the pane instead of stranding a chat for a ghost skill.
+  const selectedSkill =
+    selected?.kind === "skill"
+      ? (skills.find((s) => s.name === selected.slug) ?? null)
+      : null;
+  useEffect(() => {
+    if (selected?.kind === "skill" && !selectedSkill) deselect();
+  }, [selected, selectedSkill, deselect]);
+
+  if (readOnly) {
+    return {
+      chatNode: null,
+      openRow: onEditSkill,
+      drafts: [],
+      resumeDraft: () => {},
+      discardDraft: () => {},
+      startCreate: () => {},
+    };
+  }
+
+  let chatNode: ReactNode | null = null;
+  if (selected?.kind === "skill" && selectedSkill) {
+    chatNode = (
+      <SkillSetupChat
+        agent={agent}
+        activity={chatSetup.activityFor(selectedSkill)}
+        kind="skill"
+        skillName={skillDisplayTitle(selectedSkill)}
+        onClose={deselect}
+        onEditManually={() => onEditSkill(selectedSkill.name)}
+      />
+    );
+  } else if (selected?.kind === "draft") {
+    const activity = selected.activityId
+      ? (chatSetup.draftActivities.find((a) => a.id === selected.activityId) ??
+        null)
+      : null;
+    chatNode = (
+      <SkillSetupChat
+        agent={agent}
+        activity={activity}
+        kind="draft"
+        onClose={deselect}
+      />
+    );
+  }
+
+  return {
+    chatNode,
+    openRow: view.openSkillChat,
+    drafts: chatSetup.draftActivities,
+    resumeDraft: view.resumeDraft,
+    discardDraft: view.discardDraft,
+    startCreate: () => void view.startCreate(),
+  };
+}

--- a/app/src/components/tabs/use-skills-chat-surface.tsx
+++ b/app/src/components/tabs/use-skills-chat-surface.tsx
@@ -17,6 +17,9 @@ import { useSkillSetupView } from "./use-skill-setup-view";
 export function useSkillsChatSurface(opts: {
   agent: Agent;
   skills: SkillSummary[];
+  /** Whether the skills list is still loading — gates the ghost-skill
+   *  deselect so an in-flight (empty) list never closes an open chat. */
+  loading: boolean;
   readOnly: boolean;
   /** Opens the manual markdown edit modal (the read-only fallback, and the
    *  chat header's "Edit manually" escape hatch). */
@@ -32,20 +35,22 @@ export function useSkillsChatSurface(opts: {
   discardDraft: (activityId: string) => void;
   startCreate: () => void;
 } {
-  const { agent, skills, readOnly, onEditSkill } = opts;
+  const { agent, skills, loading, readOnly, onEditSkill } = opts;
   const chatSetup = useSkillChatSetup(agent, skills);
   const view = useSkillSetupView(agent, skills, chatSetup);
   const { selected, deselect } = view;
 
   // A skill deleted while its chat is open (edit modal's delete, an agent
   // cleanup): close the pane instead of stranding a chat for a ghost skill.
+  // Gated on a loaded list — an in-flight fetch reads as [] and must not
+  // close the chat it is about to re-confirm.
   const selectedSkill =
     selected?.kind === "skill"
       ? (skills.find((s) => s.name === selected.slug) ?? null)
       : null;
   useEffect(() => {
-    if (selected?.kind === "skill" && !selectedSkill) deselect();
-  }, [selected, selectedSkill, deselect]);
+    if (!loading && selected?.kind === "skill" && !selectedSkill) deselect();
+  }, [loading, selected, selectedSkill, deselect]);
 
   if (readOnly) {
     return {

--- a/app/src/components/tabs/use-skills-chat-surface.tsx
+++ b/app/src/components/tabs/use-skills-chat-surface.tsx
@@ -71,6 +71,7 @@ export function useSkillsChatSurface(opts: {
         activity={chatSetup.activityFor(selectedSkill)}
         kind="skill"
         skillName={skillDisplayTitle(selectedSkill)}
+        skillSlug={selectedSkill.name}
         onClose={deselect}
         onEditManually={() => onEditSkill(selectedSkill.name)}
       />

--- a/app/src/data/activity.ts
+++ b/app/src/data/activity.ts
@@ -31,6 +31,9 @@ export interface Activity {
   agent?: string;
   routine_id?: string;
   routine_run_id?: string;
+  /** The installed skill (directory slug) this setup chat belongs to — the
+   *  durable reverse direction of the skill <-> chat link (HOU-791). */
+  skill_slug?: string;
   updated_at?: string;
   provider?: string;
   model?: string;
@@ -46,6 +49,7 @@ export interface ActivityUpdate {
   agent?: string;
   routine_id?: string;
   routine_run_id?: string;
+  skill_slug?: string;
   provider?: string;
   model?: string;
   /** Clear the persisted pending interaction (the board card leaves "Needs

--- a/app/src/hooks/session-notifications.ts
+++ b/app/src/hooks/session-notifications.ts
@@ -18,6 +18,7 @@ import { isMac } from "../lib/platform";
 import { queryClient } from "../lib/query-client";
 import { queryKeys } from "../lib/query-keys";
 import { isRoutineSetupMode } from "../lib/routine-chat-setup";
+import { isSkillSetupMode } from "../lib/skill-chat-setup";
 import { tauriActivity } from "../lib/tauri";
 import { useAgentStore } from "../stores/agents";
 import { useUIStore } from "../stores/ui";
@@ -41,7 +42,7 @@ async function resolveActivityTarget(
   sessionKey: string,
 ): Promise<{
   activityId: string;
-  setupKind: "routine" | "integration" | null;
+  setupKind: "routine" | "integration" | "skill" | null;
 } | null> {
   try {
     const activities = await queryClient.fetchQuery({
@@ -55,7 +56,9 @@ async function resolveActivityTarget(
       ? "routine"
       : isIntegrationSetupMode(activity?.agent)
         ? "integration"
-        : null;
+        : isSkillSetupMode(activity?.agent)
+          ? "skill"
+          : null;
     return { activityId, setupKind };
   } catch (e) {
     // Log-only (no toast): nav is best-effort and this same path fires on a
@@ -112,6 +115,14 @@ export async function consumePendingNav() {
     // the global Integrations page, where the panel reopens for this agent.
     useUIStore.getState().setViewMode(INTEGRATIONS_VIEW_ID);
     useUIStore.getState().setIntegrationSetupChatAgentId(agent.id);
+    return;
+  }
+  if (target.setupKind === "skill") {
+    // A skill-setup chat has no board card either: its home is the agent's
+    // Skills section (Agent Settings), where the chat reopens on the spot.
+    useUIStore.getState().setViewMode("job-description");
+    useUIStore.getState().setJobDescriptionTarget("skills");
+    useUIStore.getState().setPendingSkillChatActivityId(target.activityId);
     return;
   }
   useUIStore.getState().setViewMode("activity");

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -111,6 +111,11 @@ export type AnalyticsEventName =
   | "routine_scheduled"
   | "routine_executed"
   | "routine_chat_setup_started"
+  // HOU-791: the guided skill-build chat — "Create with AI" was clicked
+  // (`skill_chat_create_clicked`) and the draft chat actually started
+  // (`skill_chat_setup_started`).
+  | "skill_chat_create_clicked"
+  | "skill_chat_setup_started"
   // Create-intake funnel: the locally-driven question cards (before any model
   // call) either resolved into a draft (`source`: custom flow / template pick /
   // composer escape hatch; `template_id` when a template) or were dismissed.

--- a/app/src/lib/attachment-message.ts
+++ b/app/src/lib/attachment-message.ts
@@ -50,8 +50,16 @@ export function buildAttachmentPrompt(
   text: string,
   files: readonly File[],
   paths: readonly string[],
+  /**
+   * Model-facing context prepended to the prompt but NEVER shown to the user
+   * (the skill setup chat pins its bound skill this way). The bubble stays
+   * the plain `text`: the attachment marker's `message` carries it here, and
+   * a context-only send (no files) pairs with `displayText` at the call site.
+   */
+  modelContext?: string,
 ): string {
-  const prompt = withAttachmentPaths(text, [...paths]);
+  const base = modelContext ? `${modelContext}\n\n${text}` : text;
+  const prompt = withAttachmentPaths(base, [...paths]);
   const attachments = attachmentReferences(files, paths);
   if (attachments.length === 0) return prompt;
   return encodeAttachmentMessage(text, attachments, prompt);

--- a/app/src/lib/houston-skill-library.ts
+++ b/app/src/lib/houston-skill-library.ts
@@ -1,0 +1,80 @@
+/**
+ * The Houston skill library (HOU-791 follow-up): the curated skills our
+ * pre-set store agents ship, offered one-by-one on the Custom skills tab so
+ * a user can pull "Research an account" into THEIR agent without installing
+ * the whole Sales agent. Source = the release-bundled store templates
+ * (`app/src/agents/builtin/store-templates/<id>.json`, locale variants
+ * included) — the live Agent Store catalog has no published first-party
+ * listings yet, and the bundle works offline and ships translated.
+ *
+ * This module is pure + node-test-safe (no vite globs, no React): the
+ * template loading lives in `components/tabs/use-houston-skill-library.ts`.
+ */
+
+// The subpath export keeps this module node-test-safe: the contract's root
+// index pulls extensionless vite-style imports node ESM can't resolve.
+import { parseSkillFrontmatter } from "@houston/agentstore-contract/skill-frontmatter";
+
+/** One installable library skill, display fields pre-parsed from its SKILL.md. */
+export interface HoustonLibrarySkill {
+  /** The skill's directory slug — its install identity. */
+  slug: string;
+  /** The pre-set agent this skill ships with (store template id). */
+  agentId: string;
+  title: string | null;
+  description: string;
+  image: string | null;
+  integrations: string[];
+  /** The full SKILL.md text, installed verbatim (minus the featured upgrade). */
+  content: string;
+}
+
+const SKILL_SEED = /^\.agents\/skills\/([^/]+)\/SKILL\.md$/;
+
+/**
+ * The library entries inside one store template's seed map, sorted by slug.
+ * Display fields come from the seed's own frontmatter (the same parser the
+ * store contract uses — the caller's slug is the identity, never `name:`).
+ */
+export function extractTemplateSkills(
+  agentId: string,
+  seeds: Record<string, string>,
+): HoustonLibrarySkill[] {
+  const out: HoustonLibrarySkill[] = [];
+  for (const [key, content] of Object.entries(seeds)) {
+    const slug = key.match(SKILL_SEED)?.[1];
+    if (!slug) continue;
+    const fm = parseSkillFrontmatter(content);
+    out.push({
+      slug,
+      agentId,
+      title: fm.title,
+      description: fm.description,
+      image: fm.image,
+      integrations: fm.integrations,
+      content,
+    });
+  }
+  return out.sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+/**
+ * The install-time frontmatter upgrade: an explicitly installed skill must be
+ * findable, and the chat empty state shows only featured skills when any
+ * exist (the same invariant `composeInstalledSkillMd` enforces for store /
+ * repo installs). Rewrites an existing `featured:` line in the frontmatter
+ * block, or inserts one before its closing `---`; content without a
+ * frontmatter block is returned unchanged (nothing safe to edit).
+ */
+export function withFeaturedFrontmatter(content: string): string {
+  const m = content.match(/^(---\r?\n)([\s\S]*?)(\r?\n---(?:\r?\n|$))/);
+  if (!m) return content;
+  const [, open, fm, close] = m;
+  const body = content.slice(m[0].length);
+  const rewritten = /^featured:.*$/m.test(fm ?? "")
+    ? (fm ?? "").replace(/^featured:.*$/m, "featured: yes")
+    : fm
+      ? `${fm}\nfeatured: yes`
+      : "featured: yes";
+  return `${open}${rewritten}${close}${body}`;
+}

--- a/app/src/lib/houston-skill-library.ts
+++ b/app/src/lib/houston-skill-library.ts
@@ -24,12 +24,22 @@ export interface HoustonLibrarySkill {
   title: string | null;
   description: string;
   image: string | null;
+  category: string | null;
   integrations: string[];
   /** The full SKILL.md text, installed verbatim (minus the featured upgrade). */
   content: string;
+  /** The markdown body with the frontmatter stripped — what the preview
+   *  modal shows as the step-by-step instructions. */
+  body: string;
 }
 
 const SKILL_SEED = /^\.agents\/skills\/([^/]+)\/SKILL\.md$/;
+const FM_BLOCK = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/;
+
+/** The SKILL.md markdown body with the frontmatter block stripped. */
+export function skillBodyOf(content: string): string {
+  return content.replace(FM_BLOCK, "").trim();
+}
 
 /**
  * The library entries inside one store template's seed map, sorted by slug.
@@ -51,8 +61,10 @@ export function extractTemplateSkills(
       title: fm.title,
       description: fm.description,
       image: fm.image,
+      category: fm.category,
       integrations: fm.integrations,
       content,
+      body: skillBodyOf(content),
     });
   }
   return out.sort((a, b) => a.slug.localeCompare(b.slug));

--- a/app/src/lib/integration-chat-setup.ts
+++ b/app/src/lib/integration-chat-setup.ts
@@ -15,6 +15,7 @@
 
 import { encodeAutoContinueMessage } from "./auto-continue-message.ts";
 import { isRoutineSetupMode } from "./routine-chat-setup.ts";
+import { isSkillSetupMode } from "./skill-chat-setup.ts";
 
 /**
  * Sentinel stored in the activity's `agent` (mode) field so every mission
@@ -32,12 +33,16 @@ export function isIntegrationSetupMode(
 }
 
 /**
- * True for EITHER guided-setup sentinel (routine or integration). This is the
- * one predicate every board / badge / notification filter uses so the two
+ * True for ANY guided-setup sentinel (routine, integration, or skill). This
+ * is the one predicate every board / badge / notification filter uses so the
  * hidden-chat kinds are handled by the same mechanism, never forked.
  */
 export function isSetupChatMode(agent: string | null | undefined): boolean {
-  return isRoutineSetupMode(agent) || isIntegrationSetupMode(agent);
+  return (
+    isRoutineSetupMode(agent) ||
+    isIntegrationSetupMode(agent) ||
+    isSkillSetupMode(agent)
+  );
 }
 
 interface IntegrationSetupActivityLike {

--- a/app/src/lib/skill-chat-prompts.ts
+++ b/app/src/lib/skill-chat-prompts.ts
@@ -1,0 +1,72 @@
+/**
+ * The Claude-facing kickoffs for a custom skill's setup chat (HOU-791 — the
+ * Skills surface gets the Automations-tab experience: build and change a
+ * skill by talking to the agent, never by hand-editing markdown). English on
+ * purpose (all prompts are); the agent mirrors the user's language when it
+ * answers. They ride the auto-continue marker (`lib/auto-continue-message.ts`):
+ * the user never typed anything, so the transcript hides the bubble and the
+ * conversation opens with the agent's greeting.
+ *
+ * The product prompt's "Skills" how-to section (the SKILL.md shape, naming
+ * rules, user-voice rules) does the heavy lifting; these kickoffs run the
+ * interview and pin the chat <-> skill link (`skill-chat-setup.ts`).
+ */
+
+import { encodeAutoContinueMessage } from "./auto-continue-message.ts";
+
+/**
+ * The create kickoff. Takes the setup chat's own activity id so the agent can
+ * link the new skill back to it via the frontmatter `setup_activity_id`.
+ */
+export function skillSetupPrompt(activityId: string): string {
+  return `Houston sent this message automatically: the user clicked "Create with AI" on the Skills page. This chat is where you build their new skill, and it stays attached to the skill forever — the user can come back to it any time to change how the skill works. The user has not said anything yet and is waiting for you to start.
+
+Your job in this conversation: guide the user through creating ONE new skill, then create it. A skill is a reusable step-by-step procedure you follow whenever the user asks for that kind of work — writing their weekly update in their voice, researching a company the way they like, preparing an invoice their way.
+
+Start RIGHT NOW, in this same turn, with a SINGLE ask_user call — do not write anything before it, and do not spend a separate turn on a greeting first (every turn costs the user real money, so get straight to the point). Fold a brief, friendly framing INTO the question itself (match the user's language): mention you'll help them build this and they can always come back to this same chat to change it later, then ask what the skill should help them with. Offer 3 or 4 concrete example options based on what you help this user with (for example "Write my weekly investor update", "Research a company before a call", "Turn meeting notes into action items"), and they can always describe their own idea instead. A turn that ends without an ask_user call is a mistake, until the skill is created.
+
+Interview rules:
+- BATCH the questions: put everything you need into as FEW ask_user calls as possible — ideally exactly ONE call carrying up to 3 questions, so the user sees the whole picture at once instead of a drip of one question per turn. Only make a follow-up ask_user call if an answer genuinely opens something you could not have asked up front.
+- Offer answer options for every question that allows it.
+- Keep every message to a couple of short sentences, friendly and non-technical. Never mention files, markdown, JSON, schemas, tools, or field names.
+- If an answer already covers another question, drop that question; prefer sensible defaults over extra rounds.
+
+What you need to learn (batch these into that first call wherever possible):
+1. What the skill should do, step by step at whatever level of detail the user can give — plus anything that makes the result THEIRS (tone, format, examples, rules).
+2. When they'd reach for it, in their own words (this becomes how you recognize they want it later).
+3. Which of their connected apps it should use, if the work touches email, calendar, documents, or other apps.
+
+When you have everything, summarize the skill in a few plain lines (what it does, and when you'll use it) and ask for approval with ask_user (Yes / No). Only create it after a Yes. Create it following your Skills guidance — propose a short plain name yourself — and include a frontmatter field "setup_activity_id" set to exactly "${activityId}"; that keeps this chat attached to the skill. Never mention this field or any other technical detail to the user. Then confirm it is ready, mention they can run it any time just by asking, and remind them they can change it right here, in this same chat, any time.`;
+}
+
+/**
+ * The kickoff for an existing skill's first-ever chat (installed from the
+ * store or GitHub, created from scratch, or from before setup chats existed).
+ * One calm greeting, no interview — it already exists.
+ */
+export function skillModifyPrompt(skill: {
+  slug: string;
+  displayName: string;
+}): string {
+  return `Houston sent this message automatically: the user opened their existing skill "${skill.displayName}" on the Skills page. This chat stays attached to this skill from now on. The user has not said anything yet.
+
+Right now, write exactly one short, friendly line (match the user's language) saying you can change this skill for them any time — what it does, the steps it follows, its tone, anything — they just have to tell you. Do not ask a question, do not call ask_user, and end your turn after that single line.
+
+Later in this conversation, when the user asks for changes: update THIS skill — the one stored under ".agents/skills/${skill.slug}/" — in place. Never create a second skill for a change request, and never rename its folder unless the user explicitly asks for a new name. Change only what the user asked about and keep everything else exactly as it already is, including the frontmatter "setup_activity_id" field if present (it keeps this chat attached to the skill). Ask for approval with ask_user (Yes / No) before saving a change, keep every message short and non-technical, and never mention files, markdown, schemas, ids, or field names to the user.`;
+}
+
+/**
+ * The full first-message body for a new-skill chat: marker (hides the bubble)
+ * + create kickoff (what the model acts on).
+ */
+export function encodeSkillSetupMessage(activityId: string): string {
+  return encodeAutoContinueMessage(skillSetupPrompt(activityId));
+}
+
+/** The full first-message body for an existing skill's first-ever chat. */
+export function encodeSkillModifyMessage(skill: {
+  slug: string;
+  displayName: string;
+}): string {
+  return encodeAutoContinueMessage(skillModifyPrompt(skill));
+}

--- a/app/src/lib/skill-chat-prompts.ts
+++ b/app/src/lib/skill-chat-prompts.ts
@@ -50,9 +50,19 @@ export function skillModifyPrompt(skill: {
 }): string {
   return `Houston sent this message automatically: the user opened their existing skill "${skill.displayName}" on the Skills page. This chat stays attached to this skill from now on. The user has not said anything yet.
 
-Right now, write exactly one short, friendly line (match the user's language) saying you can change this skill for them any time — what it does, the steps it follows, its tone, anything — they just have to tell you. Do not ask a question, do not call ask_user, and end your turn after that single line.
+Right now, write exactly one short, friendly line (match the user's language) saying you can change this skill for them any time — what it does, the steps it follows, its name, anything — they just have to tell you. Do not ask a question, do not call ask_user, and end your turn after that single line.
 
-Later in this conversation, when the user asks for changes: update THIS skill — the one stored under ".agents/skills/${skill.slug}/" — in place. Never create a second skill for a change request, and never rename its folder unless the user explicitly asks for a new name. Change only what the user asked about and keep everything else exactly as it already is, including the frontmatter "setup_activity_id" field if present (it keeps this chat attached to the skill). Ask for approval with ask_user (Yes / No) before saving a change, keep every message short and non-technical, and never mention files, markdown, schemas, ids, or field names to the user.`;
+Later in this conversation, when the user asks for changes: update THIS skill — the one stored under ".agents/skills/${skill.slug}/" — in place. Never create a second skill for a change request.
+
+Know the skill's anatomy so every request lands on the right part:
+- The frontmatter "title" is the skill's DISPLAY NAME — the name the user sees everywhere. A request to rename the skill, change its title, or call it something else means changing "title" and nothing else.
+- The folder name ".agents/skills/${skill.slug}/" and the frontmatter "name" are the skill's permanent identity. NEVER rename or move the folder and never change "name", even for a rename request — identity changes break how Houston finds the skill. The user never sees these, so there is nothing to fix there.
+- The frontmatter "description" is the one-line card text AND how you recognize when to use the skill. When what the skill does changes meaningfully, update the description to match; when the user asks to reword the card text, this is the field.
+- "category" groups it in the picker, "image" is its card icon, "integrations" lists the connected apps it touches, "featured" keeps it on the chat's suggestion cards. Update these when a change touches them (e.g. the skill starts using a new app).
+- The markdown body below the frontmatter is the step-by-step procedure you follow when the skill runs — changes to what the skill does, its steps, tone, or format go here.
+- Keep the frontmatter "setup_activity_id" field exactly as it is if present (it keeps this chat attached to the skill).
+
+Change only what the user asked about and keep everything else exactly as it already is. Ask for approval with ask_user (Yes / No) before saving a change, keep every message short and non-technical, and never mention files, markdown, schemas, ids, or field names to the user — talk about "the name", "the description", "the steps" in plain words.`;
 }
 
 /**

--- a/app/src/lib/skill-chat-prompts.ts
+++ b/app/src/lib/skill-chat-prompts.ts
@@ -66,6 +66,21 @@ Change only what the user asked about and keep everything else exactly as it alr
 }
 
 /**
+ * The per-TURN context prefix for an existing skill's chat. The kickoff names
+ * the bound skill once, but a model can lose first-message context (long
+ * histories, compaction, or plain inattention — observed: "which skill should
+ * I rename?" asked INSIDE a skill's own chat). Every send re-asserts the
+ * binding on the model-facing prompt; the user's bubble stays their own words
+ * (`displayText`).
+ */
+export function skillChatTurnContext(skill: {
+  slug: string;
+  displayName: string;
+}): string {
+  return `[Houston context — not written by the user: this conversation manages ONE skill, the one stored under ".agents/skills/${skill.slug}/" (the user knows it as "${skill.displayName}"). Any request about "this skill" or "the skill" — renaming it, changing its description, steps, tone, anything — refers to exactly that skill. Never ask which skill is meant, and never touch a different skill unless the user explicitly names another one. A rename means the frontmatter "title" field; never rename the folder or the "name" field. Reply to the message below.]`;
+}
+
+/**
  * The full first-message body for a new-skill chat: marker (hides the bubble)
  * + create kickoff (what the model acts on).
  */

--- a/app/src/lib/skill-chat-setup.ts
+++ b/app/src/lib/skill-chat-setup.ts
@@ -1,0 +1,133 @@
+/**
+ * The setup chat behind a custom skill — its persistent conversation
+ * (HOU-791, the Automations-tab experience applied to Skills). Each custom
+ * skill gets exactly one: building it with the agent starts the chat, and
+ * reopening the skill resumes the very same conversation instead of a manual
+ * editor.
+ *
+ * New chats carry `SKILL_SETUP_AGENT_MODE`; board surfaces hide it via
+ * `isSetupChatMode` (`integration-chat-setup.ts`), the shared predicate for
+ * every guided-setup sentinel. The kickoff prompts live in
+ * `skill-chat-prompts.ts`. This module owns the sentinel and the chat <->
+ * skill link resolution.
+ *
+ * The chat <-> skill link is stored in both directions, the same shape as
+ * routines: the skill's frontmatter `setup_activity_id` (written by the agent
+ * when it creates the skill) and the activity's `skill_slug` (client-stamped,
+ * durable because agents never rewrite activity.json). The frontmatter side
+ * is fragile — the agent rewrites SKILL.md whenever it edits the skill — so
+ * resolution trusts the reverse link first and a heal restores the missing
+ * activity stamp.
+ */
+
+/**
+ * Sentinel stored in the activity's `agent` (mode) field so every mission
+ * surface can recognize a skill-setup chat. Namespaced with `houston:` so it
+ * can never collide with a user-defined agent-mode id — the routine and
+ * integration sentinels use the same convention.
+ */
+export const SKILL_SETUP_AGENT_MODE = "houston:skill-setup";
+
+/** True when an activity's `agent` (mode) marks it as a skill-setup chat. */
+export function isSkillSetupMode(agent: string | null | undefined): boolean {
+  return agent === SKILL_SETUP_AGENT_MODE;
+}
+
+// ── Chat ↔ skill link resolution (pure, unit-tested) ──────────────────────
+
+interface SkillSetupActivityLike {
+  id: string;
+  agent?: string | null;
+  status?: string;
+  skill_slug?: string;
+}
+interface SkillLinkLike {
+  /** The installed skill's directory slug — its one canonical identity. */
+  name: string;
+  setup_activity_id?: string | null;
+}
+
+/** The chat attached to a skill: reverse link first (durable), then forward. */
+export function findSkillChatActivity<A extends SkillSetupActivityLike>(
+  activities: A[] | undefined,
+  skill: SkillLinkLike,
+): A | null {
+  const items = activities ?? [];
+  return (
+    items.find(
+      (a) => isSkillSetupMode(a.agent) && a.skill_slug === skill.name,
+    ) ??
+    (skill.setup_activity_id
+      ? (items.find((a) => a.id === skill.setup_activity_id) ?? null)
+      : null)
+  );
+}
+
+/**
+ * Every live "skill in construction" chat: a skill-setup chat that no
+ * installed skill has claimed yet, neither by forward link nor by its own
+ * `skill_slug` stamp. A person can have several going at once — each shows as
+ * its own resumable item, so this returns ALL of them.
+ */
+export function findDraftSkillChatActivities<A extends SkillSetupActivityLike>(
+  activities: A[] | undefined,
+  skills: SkillLinkLike[] | undefined,
+): A[] {
+  const claimed = new Set<string>();
+  for (const s of skills ?? []) {
+    if (s.setup_activity_id) claimed.add(s.setup_activity_id);
+  }
+  return (activities ?? []).filter(
+    (a) =>
+      isSkillSetupMode(a.agent) &&
+      a.status !== "archived" &&
+      !a.skill_slug &&
+      !claimed.has(a.id),
+  );
+}
+
+/**
+ * The slug of the skill that claimed a draft chat (the agent created it with
+ * `setup_activity_id` pointing back at the chat), or null while unclaimed.
+ * The view swaps its draft selection to the skill's chat on this signal so
+ * the SAME conversation continues seamlessly.
+ */
+export function claimedSkillSlug(
+  activityId: string,
+  skills: SkillLinkLike[] | undefined,
+): string | null {
+  return (
+    (skills ?? []).find((s) => s.setup_activity_id === activityId)?.name ?? null
+  );
+}
+
+export type SkillChatHeal = {
+  kind: "stamp_activity";
+  activityId: string;
+  slug: string;
+};
+
+/**
+ * The next link repair to apply, or null when everything is consistent: a
+ * skill whose forward link points at an unstamped setup chat gets the durable
+ * reverse stamp written. One fix at a time — the caller applies it, queries
+ * refetch, and this runs again until it returns null. (There is no reverse
+ * repair rule: the forward link lives in agent-owned frontmatter, and a
+ * client rewrite of SKILL.md could clobber a concurrent agent edit — the
+ * reverse stamp alone keeps the chat resolvable.)
+ */
+export function findSkillChatHeal(
+  activities: SkillSetupActivityLike[] | undefined,
+  skills: SkillLinkLike[] | undefined,
+): SkillChatHeal | null {
+  const acts = activities ?? [];
+  for (const s of skills ?? []) {
+    if (!s.setup_activity_id) continue;
+    const a = acts.find((x) => x.id === s.setup_activity_id);
+    // Only stamp an unstamped activity — never reassign one.
+    if (a && isSkillSetupMode(a.agent) && !a.skill_slug) {
+      return { kind: "stamp_activity", activityId: a.id, slug: s.name };
+    }
+  }
+  return null;
+}

--- a/app/src/lib/skill-chat-setup.ts
+++ b/app/src/lib/skill-chat-setup.ts
@@ -178,6 +178,39 @@ export function findSkillChatHeal(
   return null;
 }
 
+export type SkillChatTitleHeal = { activityId: string; title: string };
+
+/**
+ * The next chat-title repair, or null when titles are consistent: a skill's
+ * chat keeps the skill's display title (the pane header is live, but the
+ * PERSISTED activity title also surfaces — notifications, deep links — and
+ * would otherwise read the old name forever after a rename; a claimed create
+ * draft would stay "New skill"). One fix at a time, and a chat that two
+ * skills resolve to is left alone — never flip-flop between two titles.
+ */
+export function findSkillChatTitleHeal(
+  activities: SkillSetupActivityLike[] | undefined,
+  skills: SkillLinkLike[] | undefined,
+  displayTitle: (skill: SkillLinkLike) => string,
+): SkillChatTitleHeal | null {
+  const acts = activities ?? [];
+  const owners = new Map<string, SkillLinkLike[]>();
+  for (const s of skills ?? []) {
+    const chat = findSkillChatActivity(acts, s);
+    if (chat) owners.set(chat.id, [...(owners.get(chat.id) ?? []), s]);
+  }
+  for (const [chatId, list] of owners) {
+    const skill = list.length === 1 ? list[0] : undefined;
+    if (!skill) continue;
+    const chat = acts.find((a) => a.id === chatId);
+    const want = displayTitle(skill);
+    if (chat && want && chat.title !== want) {
+      return { activityId: chatId, title: want };
+    }
+  }
+  return null;
+}
+
 /**
  * The create-flow claim FALLBACK: the kickoff tells the agent to write the
  * chat's id into the new skill's frontmatter, but an agent that forgets it

--- a/app/src/lib/skill-chat-setup.ts
+++ b/app/src/lib/skill-chat-setup.ts
@@ -40,11 +40,29 @@ interface SkillSetupActivityLike {
   agent?: string | null;
   status?: string;
   skill_slug?: string;
+  title?: string;
 }
 interface SkillLinkLike {
   /** The installed skill's directory slug — its one canonical identity. */
   name: string;
+  title?: string | null;
   setup_activity_id?: string | null;
+}
+
+/** True when NO chat resolves to this skill — neither a stamped activity nor
+ *  a live forward link. Used by the adoption heuristics below so a skill can
+ *  never end up claimed by two chats. */
+function skillHasNoChat(
+  skill: SkillLinkLike,
+  activities: SkillSetupActivityLike[],
+): boolean {
+  return (
+    !activities.some(
+      (a) => isSkillSetupMode(a.agent) && a.skill_slug === skill.name,
+    ) &&
+    (!skill.setup_activity_id ||
+      !activities.some((a) => a.id === skill.setup_activity_id))
+  );
 }
 
 /** The chat attached to a skill: reverse link first (durable), then forward. */
@@ -108,20 +126,32 @@ export type SkillChatHeal = {
 };
 
 /**
- * The next link repair to apply, or null when everything is consistent: a
- * skill whose forward link points at an unstamped setup chat gets the durable
- * reverse stamp written. One fix at a time — the caller applies it, queries
- * refetch, and this runs again until it returns null. (There is no reverse
- * repair rule: the forward link lives in agent-owned frontmatter, and a
- * client rewrite of SKILL.md could clobber a concurrent agent edit — the
- * reverse stamp alone keeps the chat resolvable.)
+ * The next link repair to apply, or null when everything is consistent. One
+ * fix at a time — the caller applies it, queries refetch, and this runs again
+ * until it returns null. Two rules:
+ *
+ * 1. A skill whose forward link points at an unstamped setup chat gets the
+ *    durable reverse stamp written (the normal agent-created claim).
+ * 2. Orphan adoption: an unclaimed live setup chat whose TITLE matches
+ *    exactly one chatless skill's display title is stamped as that skill's
+ *    chat. This repairs a modify-chat whose link write failed mid-flight
+ *    (the chat is titled with the skill's display name) — without it the
+ *    skill's own chat shows forever as a bogus "draft" on the Custom tab.
+ *
+ * (There is no reverse repair rule: the forward link lives in agent-owned
+ * frontmatter, and a client rewrite of SKILL.md could clobber a concurrent
+ * agent edit — the reverse stamp alone keeps the chat resolvable.)
  */
 export function findSkillChatHeal(
   activities: SkillSetupActivityLike[] | undefined,
   skills: SkillLinkLike[] | undefined,
+  /** Display-title resolver (the app passes `skillDisplayTitle`); rule 2 is
+   *  skipped when omitted. */
+  displayTitle?: (skill: SkillLinkLike) => string,
 ): SkillChatHeal | null {
   const acts = activities ?? [];
-  for (const s of skills ?? []) {
+  const all = skills ?? [];
+  for (const s of all) {
     if (!s.setup_activity_id) continue;
     const a = acts.find((x) => x.id === s.setup_activity_id);
     // Only stamp an unstamped activity — never reassign one.
@@ -129,5 +159,44 @@ export function findSkillChatHeal(
       return { kind: "stamp_activity", activityId: a.id, slug: s.name };
     }
   }
+  if (displayTitle) {
+    for (const orphan of findDraftSkillChatActivities(acts, all)) {
+      if (!orphan.title) continue;
+      const matches = all.filter(
+        (s) => displayTitle(s) === orphan.title && skillHasNoChat(s, acts),
+      );
+      const match = matches.length === 1 ? matches[0] : undefined;
+      if (match) {
+        return {
+          kind: "stamp_activity",
+          activityId: orphan.id,
+          slug: match.name,
+        };
+      }
+    }
+  }
   return null;
+}
+
+/**
+ * The create-flow claim FALLBACK: the kickoff tells the agent to write the
+ * chat's id into the new skill's frontmatter, but an agent that forgets it
+ * would strand the draft forever. While the user sits in a draft chat, a
+ * skill that newly APPEARED in the list (vs. the previous fetch), has no
+ * forward link, and no chat of its own is — if it is the only such arrival —
+ * unambiguously the skill this conversation just created.
+ */
+export function claimNewlyCreatedSkill(
+  previousSlugs: ReadonlySet<string>,
+  skills: SkillLinkLike[] | undefined,
+  activities: SkillSetupActivityLike[] | undefined,
+): string | null {
+  const acts = activities ?? [];
+  const arrivals = (skills ?? []).filter(
+    (s) =>
+      !previousSlugs.has(s.name) &&
+      !s.setup_activity_id &&
+      skillHasNoChat(s, acts),
+  );
+  return arrivals.length === 1 ? (arrivals[0]?.name ?? null) : null;
 }

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -557,6 +557,7 @@ export const tauriSkills = {
             featured: s.featured ?? false,
             integrations: s.integrations ?? [],
             image: s.image ?? null,
+            setup_activity_id: s.setupActivityId ?? null,
             inputs: (s.inputs ?? []).map((i) => ({
               name: i.name,
               label: i.label,

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -124,6 +124,10 @@ export interface SkillSummary {
   integrations: string[];
   /** Image URL or Microsoft Fluent Emoji slug (e.g. "rocket"). */
   image: string | null;
+  /** The setup chat this skill was built in (HOU-791). Forward link from the
+   *  frontmatter `setup_activity_id:`; the durable reverse link is the
+   *  activity's `skill_slug`. */
+  setup_activity_id?: string | null;
   /** Legacy structured inputs. Parsed for compatibility, ignored by composer UX. */
   inputs: SkillInputDef[];
   /** Legacy prompt template. Parsed for compatibility, ignored by sends. */

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -139,6 +139,15 @@
     "store": "Store",
     "custom": "Custom skills",
     "customEmptyTitle": "No custom skills yet",
-    "customEmptyDescription": "Create your own skill from scratch or import one from GitHub."
+    "customEmptyDescription": "Describe what you need and build it together with your agent, or add one yourself from GitHub or from scratch.",
+    "createWithAi": "Create with AI"
+  },
+  "setupChat": {
+    "missionTitle": "New skill",
+    "skillLabel": "Skill: {{name}}",
+    "opening": "Opening chat...",
+    "editManually": "Edit manually",
+    "draftInProgress": "Skill in progress. Pick up where you left off.",
+    "discardDraft": "Discard draft"
   }
 }

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -152,7 +152,8 @@
   },
   "library": {
     "heading": "From Houston's agents",
-    "installLabel": "Install {{name}}",
+    "previewLabel": "Preview {{name}}",
+    "fromAgent": "From the {{agent}} agent",
     "installedLabel": "Installed",
     "loading": "Loading skills...",
     "loadFailed": "Couldn't load the skill library.",

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -138,8 +138,7 @@
   "tabs": {
     "store": "Store",
     "custom": "Custom skills",
-    "customEmptyTitle": "No custom skills yet",
-    "customEmptyDescription": "Describe what you need and build it together with your agent, or add one yourself from GitHub or from scratch.",
+    "customEmptyDescription": "Describe what you need and build it together with your agent, add one yourself, or pick a ready-made skill from the library below.",
     "createSkill": "Create skill"
   },
   "setupChat": {
@@ -150,5 +149,13 @@
     "editManually": "Edit manually",
     "draftInProgress": "Skill in progress. Pick up where you left off.",
     "discardDraft": "Discard draft"
+  },
+  "library": {
+    "heading": "From Houston's agents",
+    "installLabel": "Install {{name}}",
+    "installedLabel": "Installed",
+    "loading": "Loading skills...",
+    "loadFailed": "Couldn't load the skill library.",
+    "retry": "Retry"
   }
 }

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -146,6 +146,7 @@
     "missionTitle": "New skill",
     "skillLabel": "Skill: {{name}}",
     "opening": "Opening chat...",
+    "back": "Back to skills",
     "editManually": "Edit manually",
     "draftInProgress": "Skill in progress. Pick up where you left off.",
     "discardDraft": "Discard draft"

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -140,7 +140,7 @@
     "custom": "Custom skills",
     "customEmptyTitle": "No custom skills yet",
     "customEmptyDescription": "Describe what you need and build it together with your agent, or add one yourself from GitHub or from scratch.",
-    "createWithAi": "Create with AI"
+    "createSkill": "Create skill"
   },
   "setupChat": {
     "missionTitle": "New skill",

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -140,7 +140,7 @@
     "custom": "Habilidades personalizadas",
     "customEmptyTitle": "Aún no tienes habilidades personalizadas",
     "customEmptyDescription": "Describe lo que necesitas y constrúyela junto a tu agente, o agrégala tú mismo desde GitHub o desde cero.",
-    "createWithAi": "Crear con IA"
+    "createSkill": "Crear habilidad"
   },
   "setupChat": {
     "missionTitle": "Nueva habilidad",

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -146,6 +146,7 @@
     "missionTitle": "Nueva habilidad",
     "skillLabel": "Habilidad: {{name}}",
     "opening": "Abriendo el chat...",
+    "back": "Volver a habilidades",
     "editManually": "Editar manualmente",
     "draftInProgress": "Habilidad en construcción. Retoma donde quedaste.",
     "discardDraft": "Descartar borrador"

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -152,7 +152,8 @@
   },
   "library": {
     "heading": "De los agentes de Houston",
-    "installLabel": "Instalar {{name}}",
+    "previewLabel": "Ver {{name}}",
+    "fromAgent": "Del agente {{agent}}",
     "installedLabel": "Instalada",
     "loading": "Cargando habilidades...",
     "loadFailed": "No se pudo cargar la biblioteca de habilidades.",

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -138,8 +138,7 @@
   "tabs": {
     "store": "Tienda",
     "custom": "Habilidades personalizadas",
-    "customEmptyTitle": "Aún no tienes habilidades personalizadas",
-    "customEmptyDescription": "Describe lo que necesitas y constrúyela junto a tu agente, o agrégala tú mismo desde GitHub o desde cero.",
+    "customEmptyDescription": "Describe lo que necesitas y constrúyela junto a tu agente, agrégala tú mismo, o elige una habilidad lista de la biblioteca de abajo.",
     "createSkill": "Crear habilidad"
   },
   "setupChat": {
@@ -150,5 +149,13 @@
     "editManually": "Editar manualmente",
     "draftInProgress": "Habilidad en construcción. Retoma donde quedaste.",
     "discardDraft": "Descartar borrador"
+  },
+  "library": {
+    "heading": "De los agentes de Houston",
+    "installLabel": "Instalar {{name}}",
+    "installedLabel": "Instalada",
+    "loading": "Cargando habilidades...",
+    "loadFailed": "No se pudo cargar la biblioteca de habilidades.",
+    "retry": "Reintentar"
   }
 }

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -139,6 +139,15 @@
     "store": "Tienda",
     "custom": "Habilidades personalizadas",
     "customEmptyTitle": "Aún no tienes habilidades personalizadas",
-    "customEmptyDescription": "Crea tu propia habilidad desde cero o impórtala desde GitHub."
+    "customEmptyDescription": "Describe lo que necesitas y constrúyela junto a tu agente, o agrégala tú mismo desde GitHub o desde cero.",
+    "createWithAi": "Crear con IA"
+  },
+  "setupChat": {
+    "missionTitle": "Nueva habilidad",
+    "skillLabel": "Habilidad: {{name}}",
+    "opening": "Abriendo el chat...",
+    "editManually": "Editar manualmente",
+    "draftInProgress": "Habilidad en construcción. Retoma donde quedaste.",
+    "discardDraft": "Descartar borrador"
   }
 }

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -138,8 +138,7 @@
   "tabs": {
     "store": "Loja",
     "custom": "Habilidades personalizadas",
-    "customEmptyTitle": "Você ainda não tem habilidades personalizadas",
-    "customEmptyDescription": "Descreva o que você precisa e construa junto com seu agente, ou adicione você mesmo do GitHub ou do zero.",
+    "customEmptyDescription": "Descreva o que você precisa e construa junto com seu agente, adicione você mesmo, ou escolha uma habilidade pronta da biblioteca abaixo.",
     "createSkill": "Criar habilidade"
   },
   "setupChat": {
@@ -150,5 +149,13 @@
     "editManually": "Editar manualmente",
     "draftInProgress": "Habilidade em construção. Continue de onde parou.",
     "discardDraft": "Descartar rascunho"
+  },
+  "library": {
+    "heading": "Dos agentes da Houston",
+    "installLabel": "Instalar {{name}}",
+    "installedLabel": "Instalada",
+    "loading": "Carregando habilidades...",
+    "loadFailed": "Não foi possível carregar a biblioteca de habilidades.",
+    "retry": "Tentar novamente"
   }
 }

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -139,6 +139,15 @@
     "store": "Loja",
     "custom": "Habilidades personalizadas",
     "customEmptyTitle": "Você ainda não tem habilidades personalizadas",
-    "customEmptyDescription": "Crie sua própria habilidade do zero ou importe uma do GitHub."
+    "customEmptyDescription": "Descreva o que você precisa e construa junto com seu agente, ou adicione você mesmo do GitHub ou do zero.",
+    "createWithAi": "Criar com IA"
+  },
+  "setupChat": {
+    "missionTitle": "Nova habilidade",
+    "skillLabel": "Habilidade: {{name}}",
+    "opening": "Abrindo o chat...",
+    "editManually": "Editar manualmente",
+    "draftInProgress": "Habilidade em construção. Continue de onde parou.",
+    "discardDraft": "Descartar rascunho"
   }
 }

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -140,7 +140,7 @@
     "custom": "Habilidades personalizadas",
     "customEmptyTitle": "Você ainda não tem habilidades personalizadas",
     "customEmptyDescription": "Descreva o que você precisa e construa junto com seu agente, ou adicione você mesmo do GitHub ou do zero.",
-    "createWithAi": "Criar com IA"
+    "createSkill": "Criar habilidade"
   },
   "setupChat": {
     "missionTitle": "Nova habilidade",

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -152,7 +152,8 @@
   },
   "library": {
     "heading": "Dos agentes da Houston",
-    "installLabel": "Instalar {{name}}",
+    "previewLabel": "Ver {{name}}",
+    "fromAgent": "Do agente {{agent}}",
     "installedLabel": "Instalada",
     "loading": "Carregando habilidades...",
     "loadFailed": "Não foi possível carregar a biblioteca de habilidades.",

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -146,6 +146,7 @@
     "missionTitle": "Nova habilidade",
     "skillLabel": "Habilidade: {{name}}",
     "opening": "Abrindo o chat...",
+    "back": "Voltar para habilidades",
     "editManually": "Editar manualmente",
     "draftInProgress": "Habilidade em construção. Continue de onde parou.",
     "discardDraft": "Descartar rascunho"

--- a/app/src/stores/ui.ts
+++ b/app/src/stores/ui.ts
@@ -62,6 +62,13 @@ interface UIState {
    * navigates, clears it) the moment it sees a match.
    */
   pendingRoutineActivityId: string | null;
+  /**
+   * One-shot nav target for a skill-setup chat with no board card (session-
+   * finished notification click, HOU-791): the activity id to open in the
+   * Skills section. The surface consumes it (resolves which skill or draft it
+   * belongs to, opens the chat, clears it) the moment it sees a match.
+   */
+  pendingSkillChatActivityId: string | null;
   /** Agent id whose custom-integration setup chat (Integrations page) is
    *  open, or null. The draft itself is derived from that agent's activities;
    *  the page has no per-chat route, so an explicit flag marks the open one. */
@@ -148,6 +155,7 @@ interface UIState {
   setAgentArchivedSearchLoading: (agentPath: string, loading: boolean) => void;
   setMissionPanelOpen: (open: boolean) => void;
   setPendingRoutineActivityId: (activityId: string | null) => void;
+  setPendingSkillChatActivityId: (activityId: string | null) => void;
   setIntegrationSetupChatAgentId: (agentId: string | null) => void;
   setPaletteOpen: (open: boolean) => void;
   setCheatsheetOpen: (open: boolean) => void;
@@ -202,6 +210,7 @@ const initialUIState = {
   agentArchivedSearchLoading: {},
   missionPanelOpen: false,
   pendingRoutineActivityId: null,
+  pendingSkillChatActivityId: null,
   integrationSetupChatAgentId: null,
   paletteOpen: false,
   cheatsheetOpen: false,
@@ -338,6 +347,8 @@ export const useUIStore = create<UIState>()(
       setMissionPanelOpen: (missionPanelOpen) => set({ missionPanelOpen }),
       setPendingRoutineActivityId: (pendingRoutineActivityId) =>
         set({ pendingRoutineActivityId }),
+      setPendingSkillChatActivityId: (pendingSkillChatActivityId) =>
+        set({ pendingSkillChatActivityId }),
       setIntegrationSetupChatAgentId: (integrationSetupChatAgentId) =>
         set({ integrationSetupChatAgentId }),
       setPaletteOpen: (paletteOpen) => set({ paletteOpen }),

--- a/app/tests/houston-skill-library.test.ts
+++ b/app/tests/houston-skill-library.test.ts
@@ -46,8 +46,11 @@ describe("houston skill library", () => {
       "Everything on a company before the call",
     );
     strictEqual(research.image, "handshake");
+    strictEqual(research.category, "Sales");
     deepStrictEqual(research.integrations, ["hubspot"]);
     strictEqual(research.content, SKILL);
+    // The preview body is the markdown with the frontmatter stripped.
+    strictEqual(research.body, "# Research an account\nSteps.");
     strictEqual(skills[1]?.title, "Write a proposal");
   });
 

--- a/app/tests/houston-skill-library.test.ts
+++ b/app/tests/houston-skill-library.test.ts
@@ -1,0 +1,78 @@
+import { deepStrictEqual, ok, strictEqual } from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  extractTemplateSkills,
+  withFeaturedFrontmatter,
+} from "../src/lib/houston-skill-library.ts";
+
+// The Custom tab's Houston library: the pre-set store agents' packaged
+// skills, parsed straight out of a template's seed map and installed by
+// writing the SKILL.md verbatim (plus the featured upgrade every explicit
+// install gets, so the skill actually shows on the chat empty-state cards).
+
+const SKILL = `---
+name: research-an-account
+description: "Everything on a company before the call"
+category: Sales
+featured: no
+image: handshake
+integrations: [hubspot]
+---
+
+# Research an account
+Steps.
+`;
+
+describe("houston skill library", () => {
+  it("extracts skills from a template's seed map, slug-sorted, display fields parsed", () => {
+    const seeds = {
+      "CLAUDE.md": "instructions",
+      ".houston/manifest.json": "{}",
+      ".agents/skills/write-a-proposal/SKILL.md": `---\ntitle: "Write a proposal"\ndescription: Draft it\n---\nBody`,
+      ".agents/skills/research-an-account/SKILL.md": SKILL,
+      // A nested non-top-level file never reads as a skill.
+      ".agents/skills/research-an-account/notes/extra.md": "x",
+    };
+    const skills = extractTemplateSkills("sales", seeds);
+    deepStrictEqual(
+      skills.map((s) => s.slug),
+      ["research-an-account", "write-a-proposal"],
+    );
+    const research = skills[0];
+    ok(research);
+    strictEqual(research.agentId, "sales");
+    strictEqual(
+      research.description,
+      "Everything on a company before the call",
+    );
+    strictEqual(research.image, "handshake");
+    deepStrictEqual(research.integrations, ["hubspot"]);
+    strictEqual(research.content, SKILL);
+    strictEqual(skills[1]?.title, "Write a proposal");
+  });
+
+  it("upgrades featured: no to yes, keeping everything else byte-identical", () => {
+    const installed = withFeaturedFrontmatter(SKILL);
+    ok(installed.includes("featured: yes"));
+    ok(!installed.includes("featured: no"));
+    strictEqual(installed.replace("featured: yes", "featured: no"), SKILL);
+  });
+
+  it("inserts featured when the frontmatter lacks it, body untouched", () => {
+    const bare = `---\nname: x\ndescription: d\n---\n\n# Body\nfeatured: no way this line changes\n`;
+    const installed = withFeaturedFrontmatter(bare);
+    ok(
+      installed.startsWith(
+        "---\nname: x\ndescription: d\nfeatured: yes\n---\n",
+      ),
+    );
+    ok(installed.endsWith("# Body\nfeatured: no way this line changes\n"));
+  });
+
+  it("leaves content without a frontmatter block unchanged", () => {
+    strictEqual(
+      withFeaturedFrontmatter("# Just markdown\n"),
+      "# Just markdown\n",
+    );
+  });
+});

--- a/app/tests/skill-chat-setup.test.ts
+++ b/app/tests/skill-chat-setup.test.ts
@@ -1,0 +1,264 @@
+import { deepStrictEqual, ok } from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildAgentActivitySummaries } from "../src/components/shell/agent-activity-summary-model.ts";
+import {
+  filterAutoContinueFeedItems,
+  isAutoContinueMessage,
+} from "../src/lib/auto-continue-message.ts";
+import { isSetupChatMode } from "../src/lib/integration-chat-setup.ts";
+import { selectActive, selectArchived } from "../src/lib/mission-selection.ts";
+import {
+  encodeSkillModifyMessage,
+  encodeSkillSetupMessage,
+  skillModifyPrompt,
+  skillSetupPrompt,
+} from "../src/lib/skill-chat-prompts.ts";
+import {
+  claimedSkillSlug,
+  findDraftSkillChatActivities,
+  findSkillChatActivity,
+  findSkillChatHeal,
+  isSkillSetupMode,
+  SKILL_SETUP_AGENT_MODE,
+} from "../src/lib/skill-chat-setup.ts";
+
+// HOU-791: a custom skill is built and changed in a persistent agent chat
+// (the Automations-tab experience), never a raw markdown editor. The kickoff
+// is Houston-sent, not user-typed: it must ride the auto-continue marker so
+// the transcript hides the bubble and the chat opens with the AGENT's
+// greeting.
+
+describe("skill chat setup message", () => {
+  it("is tagged as an auto-continue message and filtered from the feed", () => {
+    for (const body of [
+      encodeSkillSetupMessage("act-1"),
+      encodeSkillModifyMessage({
+        slug: "weekly-update",
+        displayName: "Weekly update",
+      }),
+    ]) {
+      ok(isAutoContinueMessage(body));
+      const filtered = filterAutoContinueFeedItems([
+        { feed_type: "user_message", data: body },
+      ]);
+      ok(filtered.length === 0, "kickoff bubble must not render");
+    }
+  });
+
+  it("carries the kickoff prompt as the model-facing body", () => {
+    ok(encodeSkillSetupMessage("act-1").endsWith(skillSetupPrompt("act-1")));
+    const skill = { slug: "weekly-update", displayName: "Weekly update" };
+    ok(encodeSkillModifyMessage(skill).endsWith(skillModifyPrompt(skill)));
+  });
+
+  it("setup chats never surface as missions", () => {
+    const setup = {
+      id: "s1",
+      status: "needs_you",
+      agent: SKILL_SETUP_AGENT_MODE,
+    };
+    const archivedSetup = {
+      id: "s2",
+      status: "archived",
+      agent: SKILL_SETUP_AGENT_MODE,
+    };
+    const normal = { id: "n1", status: "needs_you", agent: "researcher" };
+    const archivedNormal = { id: "n2", status: "archived" };
+    ok(isSkillSetupMode(SKILL_SETUP_AGENT_MODE));
+    ok(!isSkillSetupMode("researcher"));
+    ok(!isSkillSetupMode(null));
+    // The ONE shared predicate every board filter uses covers the new kind.
+    ok(isSetupChatMode(SKILL_SETUP_AGENT_MODE));
+    // Active board: only the normal mission survives.
+    deepStrictEqual(
+      selectActive([setup, archivedSetup, normal, archivedNormal]).map(
+        (i) => i.id,
+      ),
+      ["n1"],
+    );
+    // Archived tab: closed setup chats stay invisible too.
+    deepStrictEqual(
+      selectArchived([setup, archivedSetup, normal, archivedNormal]).map(
+        (i) => i.id,
+      ),
+      ["n2"],
+    );
+  });
+
+  it("setup chats never count toward the needs-you badge", () => {
+    const agents = [{ id: "a", folderPath: "/w/a" }];
+    const summaries = buildAgentActivitySummaries(agents, [
+      {
+        agent_path: "/w/a",
+        type: "activity",
+        status: "needs_you",
+        agent: SKILL_SETUP_AGENT_MODE,
+      },
+      { agent_path: "/w/a", type: "activity", status: "needs_you" },
+    ]);
+    deepStrictEqual(summaries.a, { needsYouCount: 1, runningCount: 0 });
+  });
+
+  it("create kickoff covers the guided interview HOU-791 asks for", () => {
+    // Load-bearing beats: the agent opens in a single ask_user call (no
+    // wasted greeting turn), batches questions, gates creation on approval,
+    // stays non-technical, and links the skill back to this chat via the
+    // frontmatter setup_activity_id.
+    const prompt = skillSetupPrompt("act-42");
+    for (const needle of [
+      "The user has not said anything yet",
+      "Start RIGHT NOW, in this same turn",
+      "SINGLE ask_user call",
+      "friendly framing INTO the question",
+      "come back to this same chat",
+      "A turn that ends without an ask_user call is a mistake",
+      "BATCH the questions",
+      "as FEW ask_user calls as possible",
+      "approval",
+      "Never mention files, markdown, JSON, schemas, tools, or field names",
+      '"setup_activity_id" set to exactly "act-42"',
+    ]) {
+      ok(prompt.includes(needle), `prompt must mention: ${needle}`);
+    }
+  });
+
+  it("modify kickoff greets once, pins the skill, and never duplicates it", () => {
+    const prompt = skillModifyPrompt({
+      slug: "weekly-update",
+      displayName: "Weekly update",
+    });
+    for (const needle of [
+      'skill "Weekly update"',
+      "exactly one short, friendly line",
+      "do not call ask_user",
+      "end your turn after that single line",
+      '".agents/skills/weekly-update/"',
+      "Never create a second skill",
+      "never rename its folder",
+      '"setup_activity_id" field if present',
+      "approval",
+    ]) {
+      ok(prompt.includes(needle), `prompt must mention: ${needle}`);
+    }
+  });
+
+  it("resolves a skill's chat by the durable reverse link first", () => {
+    // The forward link (frontmatter setup_activity_id) lives in SKILL.md,
+    // which the agent rewrites on every edit — a rewrite that drops it must
+    // NOT lose the chat, because the activity's skill_slug stamp survives.
+    const chat = {
+      id: "a1",
+      agent: SKILL_SETUP_AGENT_MODE,
+      skill_slug: "weekly-update",
+    };
+    const other = { id: "a2", agent: "researcher" };
+    deepStrictEqual(
+      findSkillChatActivity([other, chat], { name: "weekly-update" }),
+      chat,
+    );
+    // Forward link only (agent-created skill, before the heal stamps back).
+    const unstamped = { id: "a3", agent: SKILL_SETUP_AGENT_MODE };
+    deepStrictEqual(
+      findSkillChatActivity([unstamped], {
+        name: "research-company",
+        setup_activity_id: "a3",
+      }),
+      unstamped,
+    );
+    // No link at all → null (a modify chat gets started on open).
+    deepStrictEqual(findSkillChatActivity([other], { name: "sin-chat" }), null);
+  });
+
+  it("returns ALL live setup chats no skill claims, in input order", () => {
+    const draftA = {
+      id: "d1",
+      agent: SKILL_SETUP_AGENT_MODE,
+      status: "running",
+    };
+    const draftB = {
+      id: "d5",
+      agent: SKILL_SETUP_AGENT_MODE,
+      status: "needs_you",
+    };
+    // Claimed by a skill's forward link (setup_activity_id).
+    const claimedForward = {
+      id: "d2",
+      agent: SKILL_SETUP_AGENT_MODE,
+      status: "done",
+    };
+    // Claimed by its own skill_slug stamp (the durable reverse link).
+    const claimedReverse = {
+      id: "d3",
+      agent: SKILL_SETUP_AGENT_MODE,
+      status: "done",
+      skill_slug: "weekly-update",
+    };
+    const archived = {
+      id: "d4",
+      agent: SKILL_SETUP_AGENT_MODE,
+      status: "archived",
+    };
+    const normal = { id: "n1", agent: "researcher", status: "running" };
+    const skills = [{ name: "s1", setup_activity_id: "d2" }];
+    deepStrictEqual(
+      findDraftSkillChatActivities(
+        [draftA, claimedForward, claimedReverse, archived, normal, draftB],
+        skills,
+      ),
+      [draftA, draftB],
+    );
+    deepStrictEqual(findDraftSkillChatActivities(undefined, undefined), []);
+  });
+
+  it("claim detection: the skill whose forward link names the draft", () => {
+    const skills = [
+      { name: "s1", setup_activity_id: "other" },
+      { name: "s2", setup_activity_id: "d1" },
+    ];
+    deepStrictEqual(claimedSkillSlug("d1", skills), "s2");
+    deepStrictEqual(claimedSkillSlug("dX", skills), null);
+    deepStrictEqual(claimedSkillSlug("d1", undefined), null);
+  });
+
+  it("link heal: stamps the activity once, then stays quiet", () => {
+    // Fresh claim: forward link exists, reverse stamp missing → stamp it.
+    deepStrictEqual(
+      findSkillChatHeal(
+        [{ id: "a1", agent: SKILL_SETUP_AGENT_MODE }],
+        [{ name: "weekly-update", setup_activity_id: "a1" }],
+      ),
+      { kind: "stamp_activity", activityId: "a1", slug: "weekly-update" },
+    );
+    // Already stamped → nothing to do (the effect loop terminates).
+    deepStrictEqual(
+      findSkillChatHeal(
+        [
+          {
+            id: "a1",
+            agent: SKILL_SETUP_AGENT_MODE,
+            skill_slug: "weekly-update",
+          },
+        ],
+        [{ name: "weekly-update", setup_activity_id: "a1" }],
+      ),
+      null,
+    );
+    // A stamped activity is never reassigned, even if another skill's
+    // forward link points at it.
+    deepStrictEqual(
+      findSkillChatHeal(
+        [{ id: "a1", agent: SKILL_SETUP_AGENT_MODE, skill_slug: "s-old" }],
+        [{ name: "s-new", setup_activity_id: "a1" }],
+      ),
+      null,
+    );
+    // A forward link to a non-setup activity is ignored.
+    deepStrictEqual(
+      findSkillChatHeal(
+        [{ id: "a1", agent: "researcher" }],
+        [{ name: "s1", setup_activity_id: "a1" }],
+      ),
+      null,
+    );
+  });
+});

--- a/app/tests/skill-chat-setup.test.ts
+++ b/app/tests/skill-chat-setup.test.ts
@@ -5,6 +5,7 @@ import {
   filterAutoContinueFeedItems,
   isAutoContinueMessage,
 } from "../src/lib/auto-continue-message.ts";
+import { skillDisplayTitle } from "../src/lib/humanize-skill-name.ts";
 import { isSetupChatMode } from "../src/lib/integration-chat-setup.ts";
 import { selectActive, selectArchived } from "../src/lib/mission-selection.ts";
 import {
@@ -15,6 +16,7 @@ import {
 } from "../src/lib/skill-chat-prompts.ts";
 import {
   claimedSkillSlug,
+  claimNewlyCreatedSkill,
   findDraftSkillChatActivities,
   findSkillChatActivity,
   findSkillChatHeal,
@@ -258,6 +260,133 @@ describe("skill chat setup message", () => {
         [{ id: "a1", agent: "researcher" }],
         [{ name: "s1", setup_activity_id: "a1" }],
       ),
+      null,
+    );
+  });
+
+  it("heal adopts a title-matched orphan chat back onto its chatless skill", () => {
+    // The reported bug: "Meeting prep" installed AND showing as a draft —
+    // the modify chat was created (titled with the skill's display name) but
+    // the link stamp never landed. The heal stamps it back.
+    const orphan = {
+      id: "a1",
+      agent: SKILL_SETUP_AGENT_MODE,
+      status: "done",
+      title: "Meeting prep",
+    };
+    deepStrictEqual(
+      findSkillChatHeal(
+        [orphan],
+        [{ name: "meeting-prep" }],
+        skillDisplayTitle,
+      ),
+      { kind: "stamp_activity", activityId: "a1", slug: "meeting-prep" },
+    );
+    // Frontmatter title wins over the humanized slug, same as everywhere.
+    deepStrictEqual(
+      findSkillChatHeal(
+        [{ ...orphan, title: "Preparar reunión" }],
+        [{ name: "preparar-reunion", title: "Preparar reunión" }],
+        skillDisplayTitle,
+      ),
+      {
+        kind: "stamp_activity",
+        activityId: "a1",
+        slug: "preparar-reunion",
+      },
+    );
+    // Ambiguous (two skills share the display title) → never guess.
+    deepStrictEqual(
+      findSkillChatHeal(
+        [orphan],
+        [
+          { name: "meeting-prep" },
+          { name: "meeting-prep-2", title: "Meeting prep" },
+        ],
+        skillDisplayTitle,
+      ),
+      null,
+    );
+    // The skill already has its own chat → the orphan stays a draft.
+    deepStrictEqual(
+      findSkillChatHeal(
+        [
+          orphan,
+          {
+            id: "a2",
+            agent: SKILL_SETUP_AGENT_MODE,
+            skill_slug: "meeting-prep",
+          },
+        ],
+        [{ name: "meeting-prep" }],
+        skillDisplayTitle,
+      ),
+      null,
+    );
+    // A create-flow draft ("New skill") matches no skill → untouched, and
+    // without the resolver rule 2 never runs.
+    deepStrictEqual(
+      findSkillChatHeal(
+        [{ ...orphan, title: "New skill" }],
+        [{ name: "meeting-prep" }],
+        skillDisplayTitle,
+      ),
+      null,
+    );
+    deepStrictEqual(
+      findSkillChatHeal([orphan], [{ name: "meeting-prep" }]),
+      null,
+    );
+  });
+
+  it("fallback claim: the one new, linkless, chatless skill wins the draft", () => {
+    const prev = new Set(["existing"]);
+    const acts = [{ id: "d1", agent: SKILL_SETUP_AGENT_MODE }];
+    // One arrival, no forward link, no chat → claimed.
+    deepStrictEqual(
+      claimNewlyCreatedSkill(
+        prev,
+        [{ name: "existing" }, { name: "meeting-prep" }],
+        acts,
+      ),
+      "meeting-prep",
+    );
+    // An arrival that DID link itself is the normal claim path, not this one.
+    deepStrictEqual(
+      claimNewlyCreatedSkill(
+        prev,
+        [{ name: "meeting-prep", setup_activity_id: "d1" }],
+        acts,
+      ),
+      null,
+    );
+    // Two ambiguous arrivals → never guess.
+    deepStrictEqual(
+      claimNewlyCreatedSkill(
+        prev,
+        [{ name: "a-skill" }, { name: "b-skill" }],
+        acts,
+      ),
+      null,
+    );
+    // An arrival whose chat already exists (stamped elsewhere) is not free.
+    deepStrictEqual(
+      claimNewlyCreatedSkill(
+        prev,
+        [{ name: "meeting-prep" }],
+        [
+          {
+            id: "a9",
+            agent: SKILL_SETUP_AGENT_MODE,
+            skill_slug: "meeting-prep",
+          },
+        ],
+      ),
+      null,
+    );
+    // Nothing new → nothing claimed.
+    deepStrictEqual(
+      claimNewlyCreatedSkill(new Set(["existing"]), [{ name: "existing" }], []),
       null,
     );
   });

--- a/app/tests/skill-chat-setup.test.ts
+++ b/app/tests/skill-chat-setup.test.ts
@@ -1,6 +1,7 @@
 import { deepStrictEqual, ok } from "node:assert/strict";
 import { describe, it } from "node:test";
 import { buildAgentActivitySummaries } from "../src/components/shell/agent-activity-summary-model.ts";
+import { buildAttachmentPrompt } from "../src/lib/attachment-message.ts";
 import {
   filterAutoContinueFeedItems,
   isAutoContinueMessage,
@@ -11,6 +12,7 @@ import { selectActive, selectArchived } from "../src/lib/mission-selection.ts";
 import {
   encodeSkillModifyMessage,
   encodeSkillSetupMessage,
+  skillChatTurnContext,
   skillModifyPrompt,
   skillSetupPrompt,
 } from "../src/lib/skill-chat-prompts.ts";
@@ -397,6 +399,43 @@ describe("skill chat setup message", () => {
       claimNewlyCreatedSkill(new Set(["existing"]), [{ name: "existing" }], []),
       null,
     );
+  });
+
+  it("per-turn context pins the bound skill on every send, hidden from the bubble", () => {
+    // The reported bug: inside "Audit my books"'s own chat, the model asked
+    // "which skill should I rename?" — first-message context alone is not
+    // reliable, so every outgoing prompt re-asserts the binding.
+    const ctx = skillChatTurnContext({
+      slug: "audit-my-books",
+      displayName: "Audit my books",
+    });
+    for (const needle of [
+      "not written by the user",
+      '".agents/skills/audit-my-books/"',
+      '"Audit my books"',
+      "Never ask which skill is meant",
+      'frontmatter "title" field',
+      'never rename the folder or the "name" field',
+    ]) {
+      ok(ctx.includes(needle), `context must mention: ${needle}`);
+    }
+    // No files: the model prompt is context + the user's words (the bubble is
+    // the caller's displayText, not this).
+    const prompt = buildAttachmentPrompt("rename it", [], [], ctx);
+    ok(prompt.startsWith(ctx));
+    ok(prompt.endsWith("rename it"));
+    // With files: the attachment marker's `message` keeps ONLY the user's
+    // words — the context never leaks into the rendered bubble.
+    const withFile = buildAttachmentPrompt(
+      "rename it",
+      [{ name: "notes.txt" } as File],
+      ["/tmp/notes.txt"],
+      ctx,
+    );
+    const marker = withFile.split("\n")[0] ?? "";
+    ok(marker.startsWith("<!--houston:attachments"));
+    ok(!marker.includes("Houston context"));
+    ok(withFile.includes(ctx));
   });
 
   it("title heal keeps a skill's chat named after the skill", () => {

--- a/app/tests/skill-chat-setup.test.ts
+++ b/app/tests/skill-chat-setup.test.ts
@@ -20,6 +20,7 @@ import {
   findDraftSkillChatActivities,
   findSkillChatActivity,
   findSkillChatHeal,
+  findSkillChatTitleHeal,
   isSkillSetupMode,
   SKILL_SETUP_AGENT_MODE,
 } from "../src/lib/skill-chat-setup.ts";
@@ -136,8 +137,15 @@ describe("skill chat setup message", () => {
       "end your turn after that single line",
       '".agents/skills/weekly-update/"',
       "Never create a second skill",
-      "never rename its folder",
-      '"setup_activity_id" field if present',
+      // Structure awareness: a rename means the display title, never the
+      // folder/name identity (renaming those breaks how Houston finds it).
+      "DISPLAY NAME",
+      'means changing "title"',
+      "NEVER rename or move the folder",
+      'never change "name"',
+      '"description" is the one-line card text',
+      "step-by-step procedure",
+      '"setup_activity_id" field exactly as it is',
       "approval",
     ]) {
       ok(prompt.includes(needle), `prompt must mention: ${needle}`);
@@ -387,6 +395,56 @@ describe("skill chat setup message", () => {
     // Nothing new → nothing claimed.
     deepStrictEqual(
       claimNewlyCreatedSkill(new Set(["existing"]), [{ name: "existing" }], []),
+      null,
+    );
+  });
+
+  it("title heal keeps a skill's chat named after the skill", () => {
+    // The reported gap: renaming the skill in its chat left the persisted
+    // conversation title on the old name (and a claimed create draft stayed
+    // "New skill") — the chat follows the skill's display title.
+    const chat = {
+      id: "a1",
+      agent: SKILL_SETUP_AGENT_MODE,
+      skill_slug: "meeting-prep",
+      title: "Meeting prep",
+    };
+    deepStrictEqual(
+      findSkillChatTitleHeal(
+        [chat],
+        [{ name: "meeting-prep", title: "meeting skill" }],
+        skillDisplayTitle,
+      ),
+      { activityId: "a1", title: "meeting skill" },
+    );
+    // Already consistent → nothing to do (the effect loop terminates).
+    deepStrictEqual(
+      findSkillChatTitleHeal(
+        [{ ...chat, title: "meeting skill" }],
+        [{ name: "meeting-prep", title: "meeting skill" }],
+        skillDisplayTitle,
+      ),
+      null,
+    );
+    // No frontmatter title → the humanized slug is the display title.
+    deepStrictEqual(
+      findSkillChatTitleHeal(
+        [{ ...chat, title: "New skill" }],
+        [{ name: "meeting-prep" }],
+        skillDisplayTitle,
+      ),
+      { activityId: "a1", title: "Meeting prep" },
+    );
+    // A chat two skills resolve to is never retitled (no flip-flopping).
+    deepStrictEqual(
+      findSkillChatTitleHeal(
+        [{ id: "a2", agent: SKILL_SETUP_AGENT_MODE, title: "X" }],
+        [
+          { name: "s1", setup_activity_id: "a2" },
+          { name: "s2", setup_activity_id: "a2" },
+        ],
+        skillDisplayTitle,
+      ),
       null,
     );
   });

--- a/app/tests/skill-chat-setup.test.ts
+++ b/app/tests/skill-chat-setup.test.ts
@@ -101,7 +101,11 @@ describe("skill chat setup message", () => {
       },
       { agent_path: "/w/a", type: "activity", status: "needs_you" },
     ]);
-    deepStrictEqual(summaries.a, { needsYouCount: 1, runningCount: 0 });
+    deepStrictEqual(summaries.a, {
+      needsYouCount: 1,
+      runningCount: 0,
+      unreadCount: 0,
+    });
   });
 
   it("create kickoff covers the guided interview HOU-791 asks for", () => {

--- a/packages/agentstore-contract/package.json
+++ b/packages/agentstore-contract/package.json
@@ -18,6 +18,10 @@
     "./handle": {
       "types": "./src/handle.ts",
       "import": "./src/handle.ts"
+    },
+    "./skill-frontmatter": {
+      "types": "./src/skill-frontmatter.ts",
+      "import": "./src/skill-frontmatter.ts"
     }
   },
   "files": [

--- a/packages/domain/src/skills.test.ts
+++ b/packages/domain/src/skills.test.ts
@@ -50,7 +50,23 @@ test("parses Houston's existing frontmatter, including YAML-1.1 'featured: yes' 
   expect(parsed.summary.created).toContain("2026-04-25"); // YAML date scalar → string
   expect(parsed.summary.integrations).toEqual(["tavily", "gmail"]);
   expect(parsed.summary.category).toBe("research");
+  expect(parsed.summary.setupActivityId).toBeNull(); // no setup chat link
   expect(parsed.body).toContain("## Procedure");
+});
+
+test("frontmatter setup_activity_id: surfaces as the setup-chat link (HOU-791)", () => {
+  const built = `---
+name: weekly-update
+description: Draft my weekly investor update
+setup_activity_id: act-42
+---
+
+## Procedure
+Step one.
+`;
+  const parsed = parseSkillMd("weekly-update", built);
+  if ("error" in parsed) throw new Error(parsed.error);
+  expect(parsed.summary.setupActivityId).toBe("act-42");
 });
 
 test("frontmatter title: surfaces as the display title while name stays the directory slug", async () => {

--- a/packages/domain/src/skills.ts
+++ b/packages/domain/src/skills.ts
@@ -72,6 +72,9 @@ export function parseSkillMd(
       ? fm.integrations.map(String)
       : [],
     image: str(fm.image),
+    // The setup chat this skill was built in (HOU-791). Forward link only —
+    // the durable reverse link is the activity's `skill_slug`.
+    setupActivityId: str(fm.setup_activity_id),
   };
   return { summary, body: m[2] ?? "" };
 }

--- a/packages/host/src/houston-prompt.ts
+++ b/packages/host/src/houston-prompt.ts
@@ -137,6 +137,7 @@ Skill rules:
 - \`description\` is shown to the user and drives tool matching. Lead with the outcome in plain language.
 - \`image\` should be a Fluent emoji slug or a full https URL.
 - \`featured: yes\` makes the Skill visible in the chat empty state.
+- If the frontmatter has a \`setup_activity_id\` field, keep it unchanged when editing — it links the Skill to the conversation it was built in.
 - If a Skill needs missing details, the procedure should ask for them together through the \`ask_user\` tool, up to 3 questions in one call, and continue when the answers arrive.
 
 The Skill body is allowed to contain technical procedure details. But any text it tells the AI to say to the user must follow the user-voice rules above.

--- a/packages/protocol/src/domain/activity.ts
+++ b/packages/protocol/src/domain/activity.ts
@@ -40,6 +40,12 @@ export interface Activity {
   worktree_path?: string | null;
   routine_id?: string;
   routine_run_id?: string;
+  /** The installed skill (directory slug) this setup chat belongs to. The
+   *  durable direction of the skill <-> chat link: agents rewrite SKILL.md
+   *  (which carries the forward `setup_activity_id`) but never activity.json,
+   *  so this client-stamped reverse link survives (HOU-791, mirrors
+   *  `routine_id`). */
+  skill_slug?: string;
   updated_at?: string;
   provider?: string;
   model?: string;
@@ -70,6 +76,7 @@ export interface ActivityUpdate {
   worktree_path?: string | null;
   routine_id?: string;
   routine_run_id?: string;
+  skill_slug?: string;
   provider?: string;
   model?: string;
   /** Set to record a new pending interaction; `null` clears it explicitly. */

--- a/packages/protocol/src/domain/skill.ts
+++ b/packages/protocol/src/domain/skill.ts
@@ -25,6 +25,11 @@ export interface SkillSummary {
   integrations: string[];
   /** Image URL or Microsoft Fluent Emoji slug (e.g. "rocket"). */
   image: string | null;
+  /** Frontmatter `setup_activity_id:` — the setup chat this skill was built
+   *  in (HOU-791). Forward direction of the skill <-> chat link, written by
+   *  the agent at create time; the durable reverse link is the activity's
+   *  `skill_slug` (mirrors the routine `setup_activity_id` pattern). */
+  setupActivityId?: string | null;
 }
 
 export interface SkillDetail {

--- a/ui/agent-schemas/src/activity.schema.json
+++ b/ui/agent-schemas/src/activity.schema.json
@@ -20,6 +20,10 @@
       "worktree_path": { "type": ["string", "null"] },
       "routine_id": { "type": "string" },
       "routine_run_id": { "type": "string" },
+      "skill_slug": {
+        "type": "string",
+        "description": "The installed skill (directory slug) this setup chat belongs to. Set by Houston, not by the agent."
+      },
       "updated_at": { "type": "string", "format": "date-time" },
       "provider": { "type": "string" },
       "model": { "type": "string" },

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -742,6 +742,9 @@ export interface Activity {
   agent?: string;
   routine_id?: string;
   routine_run_id?: string;
+  /** The installed skill (directory slug) this setup chat belongs to. The
+   *  durable reverse direction of the skill <-> chat link (HOU-791). */
+  skill_slug?: string;
   updated_at?: string;
   provider?: string;
   model?: string;
@@ -766,6 +769,7 @@ export interface ActivityUpdate {
   agent?: string;
   routine_id?: string;
   routine_run_id?: string;
+  skill_slug?: string;
   provider?: string;
   model?: string;
   /** Set to record a new pending interaction; `null` clears it explicitly. */
@@ -1031,6 +1035,10 @@ export interface SkillSummary {
   integrations: string[];
   /** Image URL or Microsoft Fluent Emoji slug (e.g. "rocket"). */
   image: string | null;
+  /** Frontmatter `setup_activity_id:` — the setup chat this skill was built
+   *  in (HOU-791). Forward link; the durable reverse link is the activity's
+   *  `skill_slug`. */
+  setupActivityId?: string | null;
   /** Legacy structured inputs. Parsed for compatibility, ignored by composer UX. */
   inputs: SkillInputDef[];
   /** Legacy prompt template. Parsed for compatibility, ignored by sends. */


### PR DESCRIPTION
## Summary

HOU-791: custom skills get the same experience as the Automations tab — each skill has a linked conversation where the agent builds and changes it. People don't want to edit markdown by hand; they want to build the skill with the agent.

**Before:** the Custom skills tab was a pure empty state whose only CTA opened the manual GitHub / from-scratch dialog, and clicking an installed skill opened a raw-markdown edit modal.

**After:**
- Clicking an installed skill opens its **persistent setup chat** inline in the Skills section (Agent Settings → Skills). Reopening the skill resumes the exact same conversation. "Edit manually" in the chat header keeps the raw editor one click away; read-only (managed agent, non-manager) keeps the modal-only path.
- The Custom tab leads with **Create with AI**: a hidden auto-continue kickoff starts a batched `ask_user` interview; on approval the agent writes `.agents/skills/<slug>/SKILL.md` itself (per the product prompt's Skills guidance). Unfinished create-chats show as resumable/discardable draft rows. The manual add dialog stays as the secondary path.

## How it works (mirrors the routines pattern)

- **Bidirectional link:** the agent stamps the chat's id into the skill frontmatter (`setup_activity_id`, forward link, parsed into `SkillSummary.setupActivityId`); the client stamps the durable reverse link `activity.skill_slug` (agents never rewrite activity.json). A one-rule heal loop (`findSkillChatHeal`) restores the reverse stamp for agent-created skills, so an agent rewrite of SKILL.md that drops the frontmatter field never loses the chat. Both product-prompt copies (host TS + desktop Rust) now tell agents to preserve `setup_activity_id` when editing a skill.
- **Sentinel:** setup chats run under `houston:skill-setup`, folded into the shared `isSetupChatMode` predicate — boards, Mission Control, archived tab, command palette, and the needs-you badge all hide them through the one existing mechanism.
- **Chat mount:** reuses `RoutineSetupChatBoard` (the same shared mount the custom-integration setup chat uses), portaled into a local inline container. Draft→claimed selection swap keeps the same conversation on screen the moment the agent creates the skill.
- **Reactivity:** the agent's direct SKILL.md writes already classify as `SkillsChanged` in the host FS watcher, so the strip repaints without any new plumbing.
- **Notifications:** a finished skill-setup session routes to Agent Settings → Skills and reopens the chat (`pendingSkillChatActivityId`), resolved from the activity's own stamp so it works mid-load.
- **Wire contract:** additive only — `Activity.skill_slug` (+ `ActivityUpdate`, activity.schema.json, engine-client, app data layer) and `SkillSummary.setupActivityId`.

## Tests

- `app/tests/skill-chat-setup.test.ts` (node:test): kickoff encoding/hiding, board/badge invisibility via the shared predicate, reverse-first link resolution, draft claiming, heal termination + never-reassign, prompt content beats.
- `packages/domain/src/skills.test.ts`: `setup_activity_id` frontmatter parse (+ null when absent).
- Gates: domain + host vitest (1025 passed), app node:test (1994 passed), `pnpm typecheck`, `houston-web` typecheck + e2e-harness typecheck, `pnpm check-locales` (en/es/pt in sync), `pnpm check` (Biome clean), `pnpm check:boundaries`, `cargo check` + prompt-module `cargo test`.

## Repro / verify

**Before the fix (repro):** Agent Settings → Skills → Custom skills tab shows only an empty state with an "Add skill" dialog CTA; clicking an installed skill opens the raw markdown modal — there is no way to build or edit a skill by talking to the agent, and no conversation is attached to any skill.

**After (verify):**
1. `pnpm dev`, open an agent → Settings → Skills → Custom skills → **Create with AI**. An inline chat opens; the agent greets you with one batched question card (no visible kickoff bubble).
2. Answer the interview, approve — the agent creates the skill; the row appears in *Your skills* and the pane header flips from "New skill" to "Skill: {name}" (same conversation, no reload).
3. Close the chat, click the skill row — the SAME conversation resumes (check the transcript history).
4. Ask for a change ("make the tone more formal") — the agent edits the skill in place; no duplicate skill appears.
5. "Edit manually" in the chat header opens the raw markdown modal; the frontmatter carries `setup_activity_id`.
6. Install a store skill and click its row — a fresh chat opens with a one-line greeting and edits that skill in place.
7. Boards stay clean: no setup chat appears on the Activity board, Mission Control, archived tab, or the command palette, and none counts toward the needs-you badge.

HOU-791

## Follow-up in this PR: the Custom tab as a skill source

- **Houston skill library**: the Custom tab now offers every skill our eight pre-set store agents ship (Bookkeeper, General Counsel, Marketing, Operations, Outbound, People, Sales, Support) — one shelf per agent, installable one by one into the current agent. Source is the release-bundled store templates (translated es/pt variants included; the live Agent Store catalog has no first-party listings yet, and the bundle works offline). Install writes the SKILL.md verbatim through the agent-file route (already emits `SkillsChanged`) with the same `featured` upgrade every explicit install gets; installed rows show a quiet check.
- **Back arrow** on the setup-chat pane (both live and loading states) so the way back to the Skills section is always visible.
- **"Create skill"** plain-text button (sparkle icon removed) as the primary create action.
- New `@houston/agentstore-contract` subpath export `./skill-frontmatter` (node-ESM-safe parser import, mirrors `./ir`).
