### PR TITLE
fix(host): nonce-idempotent turn re-send + provider_error terminality docs (HOU-807)

### DIFF
--- a/packages/host/src/turn/relay.test.ts
+++ b/packages/host/src/turn/relay.test.ts
@@ -480,3 +480,39 @@ test("cancel from replica B aborts a turn owned by replica A", async () => {
     { type: "error", data: { message: "Stopped by user" }, seq: 1 },
   ]);
 });
+
+test("a re-send of the running turn (same conversation + nonce) reads as a duplicate, not a foreign busy (HOU-807)", async () => {
+  const relay = new TurnRelay();
+  let finish!: () => void;
+  await relay.start(
+    "a1",
+    "a1/c1",
+    () => new Promise<void>((r) => (finish = r)),
+    "nonce-1",
+  );
+
+  // The caller's retry of the SAME send — the request whose response it lost.
+  expect(relay.duplicateSend("a1", "a1/c1", "nonce-1")).toBe(true);
+  // A genuinely different send is NOT a duplicate: another nonce, another
+  // conversation, or no nonce at all.
+  expect(relay.duplicateSend("a1", "a1/c1", "nonce-2")).toBe(false);
+  expect(relay.duplicateSend("a1", "a1/c2", "nonce-1")).toBe(false);
+  expect(relay.duplicateSend("a1", "a1/c1", "")).toBe(false);
+
+  finish();
+  await drainTick();
+  // Slot released → nothing is a duplicate anymore.
+  expect(relay.duplicateSend("a1", "a1/c1", "nonce-1")).toBe(false);
+});
+
+test("a nonce-less turn (routine fire) never matches a duplicate probe", async () => {
+  const relay = new TurnRelay();
+  let finish!: () => void;
+  await relay.start(
+    "a1",
+    "a1/c1",
+    () => new Promise<void>((r) => (finish = r)),
+  );
+  expect(relay.duplicateSend("a1", "a1/c1", "anything")).toBe(false);
+  finish();
+});

--- a/packages/host/src/turn/relay.ts
+++ b/packages/host/src/turn/relay.ts
@@ -32,8 +32,14 @@ const cancelChannel = (agentId: string) => `turn:cancel:${agentId}`;
 
 export class TurnRelay {
   private readonly channels: RelayChannels;
-  /** Agents whose turn THIS replica is pumping right now → the conversation key. */
-  private inflightLocal = new Map<string, string>();
+  /** Agents whose turn THIS replica is pumping right now → the conversation
+   *  key plus the send nonce that started it (nonce absent for routine fires).
+   *  The nonce makes a client's wake-retry re-send recognizable as the SAME
+   *  request (see duplicateSend) instead of a spurious busy-409. */
+  private inflightLocal = new Map<
+    string,
+    { key: string; nonce: string | undefined }
+  >();
   /** In-flight dead-turn heals, deduped per conversation (see reapIfDead). */
   private healing = new Map<string, Promise<boolean>>();
 
@@ -62,6 +68,7 @@ export class TurnRelay {
       publish: (e: WireFrame) => Promise<void>,
       signal: AbortSignal,
     ) => Promise<void>,
+    nonce?: string,
   ): Promise<boolean> {
     if (this.inflightLocal.has(agentId)) return false;
     // The lease VALUE is the conversation key, so a conversation-scoped cancel
@@ -70,7 +77,7 @@ export class TurnRelay {
       !(await this.bus.setNx(inflightKey(agentId), conversationKey, LEASE_SEC))
     )
       return false;
-    this.inflightLocal.set(agentId, conversationKey);
+    this.inflightLocal.set(agentId, { key: conversationKey, nonce });
 
     const ctrl = new AbortController();
     const unsubCancel = this.bus.subscribe(cancelChannel(agentId), () =>
@@ -169,12 +176,32 @@ export class TurnRelay {
    */
   async cancel(agentId: string, conversationKey?: string): Promise<boolean> {
     const inflight =
-      this.inflightLocal.get(agentId) ??
+      this.inflightLocal.get(agentId)?.key ??
       (await this.bus.get(inflightKey(agentId)));
     if (inflight === null || inflight === undefined) return false;
     if (conversationKey && inflight !== conversationKey) return false;
     await this.bus.publish(cancelChannel(agentId), "cancel");
     return true;
+  }
+
+  /**
+   * Whether a send is a REPLAY of the turn this replica is pumping right now:
+   * same conversation, same non-empty nonce. A caller that lost the response
+   * to its accepted send (a torn connection mid-pod-boot) retries the same
+   * request; answering that retry "busy" fails a turn that is actually running
+   * — the caller should hear "accepted" again instead (HOU-807).
+   */
+  duplicateSend(
+    agentId: string,
+    conversationKey: string,
+    nonce: string,
+  ): boolean {
+    const inflight = this.inflightLocal.get(agentId);
+    return (
+      nonce !== "" &&
+      inflight?.key === conversationKey &&
+      inflight?.nonce === nonce
+    );
   }
 
   /** Sequence + broadcast one frame (see RelayChannels.publish). */

--- a/packages/host/src/turn/start-turn.ts
+++ b/packages/host/src/turn/start-turn.ts
@@ -41,6 +41,7 @@ export async function freshCredential(
 export type TurnStart =
   | { status: "accepted" }
   | { status: "busy" }
+  | { status: "duplicate" }
   | { status: "quota"; message: string };
 
 /**
@@ -74,9 +75,10 @@ export async function dispatchTurn(
       return { status: "quota", message: err.message };
     throw err;
   }
+  const key = `${agent.id}/${cid}`;
   const started = await deps.relay.start(
     agent.id,
-    `${agent.id}/${cid}`,
+    key,
     async (publish, signal) => {
       try {
         const cred = await freshCredential(deps, ws.id, provider);
@@ -132,9 +134,16 @@ export async function dispatchTurn(
         await release();
       }
     },
+    nonce,
   );
   if (!started) {
     await release();
+    // A re-send of the turn we are ALREADY pumping (same conversation, same
+    // nonce) is a caller retrying a send whose response it lost — a torn
+    // connection during pod boot, a proxy blip. The turn is running; telling
+    // that caller "busy" fails work that actually succeeded (HOU-807).
+    if (nonce && deps.relay.duplicateSend(agent.id, key, nonce))
+      return { status: "duplicate" };
     return { status: "busy" };
   }
   return { status: "accepted" };
@@ -167,5 +176,7 @@ export async function startTurn(
     return json(res, 409, {
       error: "a turn is already running for this agent",
     });
+  // "duplicate" answers exactly like the accept it replays: the original send
+  // started this turn; the retry must not read as a failure.
   return json(res, 202, { ok: true });
 }

--- a/packages/protocol/src/wire.ts
+++ b/packages/protocol/src/wire.ts
@@ -31,8 +31,10 @@ import type { ProviderError } from "./provider-error";
  *   mid-session; renders a boundary divider and resets the context-usage window.
  * - `provider_error` — the turn's model request failed with a typed provider /
  *   auth / rate-limit / 5xx / network error; renders the matching inline card.
- *   The turn still ends with a normal terminal frame (pi resolves the turn — it
- *   does NOT throw on a provider error), so this never replaces `done`.
+ *   This IS the failed turn's terminal frame: the turn's server deliberately
+ *   skips the clean `done` after one (a `done` would settle the chat as a
+ *   clean success — see session/exec-turn.ts), so consumers must treat
+ *   `provider_error` as ending the turn.
  * - `file_changes` — user-visible workspace files this turn created/modified,
  *   emitted once before `done` (only when non-empty). Drives the "files this
  *   mission touched" summary.
@@ -142,8 +144,10 @@ export type WireEvent =
        * Published live so the chat renders the matching reconnect / rate-limit
        * card, and persisted on the turn's assistant message
        * (`ChatMessage.providerError`) so the card survives a reload. pi resolves
-       * the turn rather than throwing, so a normal terminal frame (`done`) still
-       * follows — this is NOT a substitute for it.
+       * the turn rather than throwing, but the turn's server then SKIPS the
+       * clean `done` (it would settle the chat as a clean success — see
+       * session/exec-turn.ts): this frame IS the failed turn's terminal
+       * surface, and stream consumers must treat it as ending the turn.
        */
       type: "provider_error";
       data: ProviderError;

--- a/website/src/developers/missions/index.html
+++ b/website/src/developers/missions/index.html
@@ -101,6 +101,12 @@ lang: en
   "status": "running",
   "createdAt": "2026-07-12T09:31:07.482Z"
 }{% endraw %}</code></pre></div>
+        <p>
+          An agent runs one turn at a time. If it is already working, for
+          example on another mission or a chat, you get
+          <code>409 Conflict</code>; retry once the current work finishes.
+        </p>
+        <div class="codeblock"><pre><code>{% raw %}{ "code": "agent_busy" }{% endraw %}</code></pre></div>
 
         <h2 id="list">List missions</h2>
         <div class="endpoint">


### PR DESCRIPTION
Part of HOU-807 (public Agents API: "test that it is working and debug"). Companion to the gateway fix gethouston/cloud#181 — the root wedge lives there; this PR is the pod-host half plus doc corrections.

## What was broken

Live-probing the hosted public API showed a mission create can fail `502 engine unavailable` while the agent's turn actually starts and runs (billed, no mission row). Cause: the gateway retries a message-send once through a pod wake when the first attempt's response is lost mid-pod-boot; the retry carries the same dedup `nonce`, but the pod's per-agent turn gate answered it `409 a turn is already running` — refusing its own request's replay.

## Fix

- `TurnRelay` records the nonce that started the in-flight turn; the message route answers a same-conversation, same-nonce re-send `202` — exactly like the accept it replays. Routine fires carry no nonce and never match. Tests in `relay.test.ts`.
- `packages/protocol/src/wire.ts`: the `provider_error` doc claimed a clean `done` still follows — the runtime deliberately skips it (`session/exec-turn.ts`: "the provider_error frame is the turn's terminal surface"). The comment now states the actual contract; the gateway consumed the wrong version of it and wedged failed missions.
- `website` missions reference: documents the new `409 {"code":"agent_busy"}` create refusal the gateway now returns instead of a 502.

## Verify

Before (against a gateway without the companion fix): `POST /v1/agents/:slug/missions` on a cold pod intermittently returns `502 {"detail":"mission: pod refused message-send (status 409)"}` while the agent's conversation shows the turn ran.

After: the same retry answers 202 and the mission proceeds. `pnpm --filter @houston/host test` (126 files green), `pnpm check`, `pnpm typecheck`, `pnpm check:boundaries` all pass.