### PR TITLE
feat: render skill icons with the flat 2D Fluent emoji variant

### DIFF
--- a/app/src/components/skill-card.tsx
+++ b/app/src/components/skill-card.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { SkillIcon } from "./skill-icon";
 
 interface Props {
-  /** Image URL or Microsoft Fluent 3D Emoji slug. */
+  /** Image URL or Microsoft Fluent Emoji slug. */
   image?: string | null;
   /** Card heading. */
   title: string;

--- a/app/src/components/skill-icon.tsx
+++ b/app/src/components/skill-icon.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { fluentEmojiUrl, resolveSkillImageUrl } from "../lib/skill-image";
 
 interface Props {
-  /** Image URL or Microsoft Fluent 3D Emoji slug. Bare slugs auto-resolve to the jsDelivr CDN. */
+  /** Image URL or Microsoft Fluent Emoji slug. Bare slugs auto-resolve to the jsDelivr CDN. */
   image?: string | null;
   /** Outer bubble class. Default: 48px round, muted-gray background. */
   bubbleClassName?: string;
@@ -14,7 +14,7 @@ const FALLBACK_SLUG = "sparkles";
  * Circular avatar bubble for skill cards. Renders the image desaturated
  * (grayscale) so cards stay sober against the secondary background.
  *
- * Accepts either a full URL or a Microsoft Fluent 3D Emoji slug
+ * Accepts either a full URL or a Microsoft Fluent Emoji slug
  * (e.g. `rocket`, `magnifying-glass-tilted-left`). Falls back to the
  * `sparkles` slug if the value is missing or fails to load.
  *

--- a/app/src/lib/skill-image.ts
+++ b/app/src/lib/skill-image.ts
@@ -1,9 +1,10 @@
 /**
  * Resolve a skill's `image` frontmatter value to a renderable URL.
  *
- * A skill image is either a full `https://` URL or a Microsoft Fluent 3D Emoji
+ * A skill image is either a full `https://` URL or a Microsoft Fluent Emoji
  * slug (e.g. `rocket`, `magnifying-glass-tilted-left`, folder name lowercased
- * with spaces turned to dashes). Bare slugs resolve to the jsDelivr CDN.
+ * with spaces turned to dashes). Bare slugs resolve to the flat 2D variant on
+ * the jsDelivr CDN.
  *
  * Returns `null` when there is no usable image, so callers can decide their own
  * fallback (a monogram box for the installed-skill rows, the `sparkles` emoji
@@ -18,7 +19,7 @@ export function resolveSkillImageUrl(
   return fluentEmojiUrl(trimmed);
 }
 
-/** Build the jsDelivr CDN URL for a Fluent 3D Emoji slug. */
+/** Build the jsDelivr CDN URL for a Fluent Emoji slug (flat 2D variant). */
 export function fluentEmojiUrl(slug: string): string {
   const parts = slug
     .split(/[-_\s]+/)
@@ -28,6 +29,6 @@ export function fluentEmojiUrl(slug: string): string {
     parts[0].charAt(0).toUpperCase() +
     parts[0].slice(1) +
     (parts.length > 1 ? ` ${parts.slice(1).join(" ")}` : "");
-  const file = `${parts.join("_")}_3d.png`;
-  return `https://cdn.jsdelivr.net/gh/microsoft/fluentui-emoji@main/assets/${encodeURIComponent(folder)}/3D/${file}`;
+  const file = `${parts.join("_")}_flat.svg`;
+  return `https://cdn.jsdelivr.net/gh/microsoft/fluentui-emoji@main/assets/${encodeURIComponent(folder)}/Flat/${file}`;
 }

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -122,7 +122,7 @@ export interface SkillSummary {
   featured: boolean;
   /** Legacy toolkit slugs declared in skill frontmatter (display-only metadata). */
   integrations: string[];
-  /** Image URL or Microsoft Fluent 3D Emoji slug (e.g. "rocket"). */
+  /** Image URL or Microsoft Fluent Emoji slug (e.g. "rocket"). */
   image: string | null;
   /** Legacy structured inputs. Parsed for compatibility, ignored by composer UX. */
   inputs: SkillInputDef[];

--- a/app/tests/skill-image.test.ts
+++ b/app/tests/skill-image.test.ts
@@ -1,0 +1,51 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  fluentEmojiUrl,
+  resolveSkillImageUrl,
+} from "../src/lib/skill-image.ts";
+
+describe("fluentEmojiUrl (HOU-793: flat 2D variant)", () => {
+  it("builds the Flat SVG URL for a single-word slug", () => {
+    strictEqual(
+      fluentEmojiUrl("rocket"),
+      "https://cdn.jsdelivr.net/gh/microsoft/fluentui-emoji@main/assets/Rocket/Flat/rocket_flat.svg",
+    );
+  });
+
+  it("capitalizes only the first word of multi-word folders and encodes spaces", () => {
+    strictEqual(
+      fluentEmojiUrl("chart-increasing"),
+      "https://cdn.jsdelivr.net/gh/microsoft/fluentui-emoji@main/assets/Chart%20increasing/Flat/chart_increasing_flat.svg",
+    );
+  });
+
+  it("normalizes underscores and whitespace separators alike", () => {
+    strictEqual(
+      fluentEmojiUrl("magnifying_glass tilted-left"),
+      "https://cdn.jsdelivr.net/gh/microsoft/fluentui-emoji@main/assets/Magnifying%20glass%20tilted%20left/Flat/magnifying_glass_tilted_left_flat.svg",
+    );
+  });
+});
+
+describe("resolveSkillImageUrl", () => {
+  it("passes full URLs through untouched", () => {
+    strictEqual(
+      resolveSkillImageUrl("https://example.com/icon.png"),
+      "https://example.com/icon.png",
+    );
+  });
+
+  it("resolves bare slugs to the flat Fluent Emoji CDN URL", () => {
+    strictEqual(
+      resolveSkillImageUrl("sparkles"),
+      "https://cdn.jsdelivr.net/gh/microsoft/fluentui-emoji@main/assets/Sparkles/Flat/sparkles_flat.svg",
+    );
+  });
+
+  it("returns null for missing or blank values", () => {
+    strictEqual(resolveSkillImageUrl(null), null);
+    strictEqual(resolveSkillImageUrl(undefined), null);
+    strictEqual(resolveSkillImageUrl("   "), null);
+  });
+});

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -55,7 +55,7 @@ last_used: 2026-04-25
 category: research                 # tab in picker; missing = "Other"
 featured: yes                      # showcase on chat empty-state cards
 image: magnifying-glass-tilted-left
-                                   # Fluent 3D emoji slug OR full https URL
+                                   # Fluent emoji slug (flat 2D) OR full https URL
 integrations: [tavily, gmail]      # Composio toolkit slugs (lowercase)
 ---
 
@@ -74,7 +74,7 @@ Step-by-step instructions Claude follows when the Skill runs.
 | `created` / `last_used` | string | unset | YYYY-MM-DD. Engine maintains. |
 | `category` | string | unset | Picker tab grouping. Missing → falls under "Other". |
 | `featured` | bool | `false` | Accepts `yes` / `true` / `1` / `on`. Surfaces on the empty-chat showcase. |
-| `image` | string | unset | Either an `https://...` URL OR a Fluent 3D Emoji slug (lowercased folder name from [microsoft/fluentui-emoji/assets](https://github.com/microsoft/fluentui-emoji/tree/main/assets), spaces → dashes). Resolved frontend-side via `resolveSkillImage`. |
+| `image` | string | unset | Either an `https://...` URL OR a Fluent Emoji slug (rendered as the flat 2D variant) (lowercased folder name from [microsoft/fluentui-emoji/assets](https://github.com/microsoft/fluentui-emoji/tree/main/assets), spaces → dashes). Resolved frontend-side via `resolveSkillImage`. |
 | `integrations` | string[] | `[]` | Composio toolkit slugs. Drives the small logo row on the card. |
 
 ## Render pipeline
@@ -353,7 +353,7 @@ When the user asks "create a skill that does X", Claude should:
 2. Write `~/.houston/workspaces/<Workspace>/<Agent>/.agents/skills/<slug>/SKILL.md` with the full frontmatter schema above.
 3. Set `description` carefully — it's the trigger phrase Claude itself will use for tool matching later.
 4. Default to `featured: yes` for new Skills until proven otherwise (so the user actually finds them).
-5. Include an `image` slug — pick a relevant Fluent 3D emoji (browse the assets folder).
+5. Include an `image` slug — pick a relevant Fluent emoji (browse the assets folder).
 6. Body: at least an `## Instructions` or `## Procedure` section.
 
 ### Naming rules — non-technical users only

--- a/packages/protocol/src/domain/skill.ts
+++ b/packages/protocol/src/domain/skill.ts
@@ -23,7 +23,7 @@ export interface SkillSummary {
   featured: boolean;
   /** Integration slugs this skill touches. */
   integrations: string[];
-  /** Image URL or Microsoft Fluent 3D Emoji slug (e.g. "rocket"). */
+  /** Image URL or Microsoft Fluent Emoji slug (e.g. "rocket"). */
   image: string | null;
 }
 

--- a/ui/chat/src/skill-message.ts
+++ b/ui/chat/src/skill-message.ts
@@ -40,7 +40,7 @@ export interface SkillInvocation {
   /** Title-cased display name shown on the card. */
   displayName: string;
   /**
-   * Either a full image URL or a Microsoft Fluent 3D Emoji slug. The
+   * Either a full image URL or a Microsoft Fluent Emoji slug. The
    * renderer is responsible for resolving slugs to URLs.
    */
   image: string | null;
@@ -105,8 +105,8 @@ export function resolveSkillImage(
     parts[0].charAt(0).toUpperCase() +
     parts[0].slice(1) +
     (parts.length > 1 ? ` ${parts.slice(1).join(" ")}` : "");
-  const file = `${parts.join("_")}_3d.png`;
-  return `https://cdn.jsdelivr.net/gh/microsoft/fluentui-emoji@main/assets/${encodeURIComponent(folder)}/3D/${file}`;
+  const file = `${parts.join("_")}_flat.svg`;
+  return `https://cdn.jsdelivr.net/gh/microsoft/fluentui-emoji@main/assets/${encodeURIComponent(folder)}/Flat/${file}`;
 }
 
 function humanize(slug: string): string {

--- a/ui/chat/tests/resolve-skill-image.test.ts
+++ b/ui/chat/tests/resolve-skill-image.test.ts
@@ -1,0 +1,32 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { resolveSkillImage } from "../src/skill-message.ts";
+
+describe("resolveSkillImage (HOU-793: flat 2D variant)", () => {
+  it("resolves bare slugs to the flat Fluent Emoji CDN URL", () => {
+    strictEqual(
+      resolveSkillImage("rocket"),
+      "https://cdn.jsdelivr.net/gh/microsoft/fluentui-emoji@main/assets/Rocket/Flat/rocket_flat.svg",
+    );
+  });
+
+  it("handles multi-word slugs with encoded folder names", () => {
+    strictEqual(
+      resolveSkillImage("chart-increasing"),
+      "https://cdn.jsdelivr.net/gh/microsoft/fluentui-emoji@main/assets/Chart%20increasing/Flat/chart_increasing_flat.svg",
+    );
+  });
+
+  it("passes full URLs through untouched", () => {
+    strictEqual(
+      resolveSkillImage("https://example.com/icon.png"),
+      "https://example.com/icon.png",
+    );
+  });
+
+  it("returns null for missing or blank values", () => {
+    strictEqual(resolveSkillImage(null), null);
+    strictEqual(resolveSkillImage(undefined), null);
+    strictEqual(resolveSkillImage("  "), null);
+  });
+});

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -961,7 +961,7 @@ export interface SkillSummary {
   featured: boolean;
   /** Composio toolkit slugs this skill touches (e.g. ["gmail", "slack"]). */
   integrations: string[];
-  /** Image URL or Microsoft Fluent 3D Emoji slug (e.g. "rocket"). */
+  /** Image URL or Microsoft Fluent Emoji slug (e.g. "rocket"). */
   image: string | null;
   /** Legacy structured inputs. Parsed for compatibility, ignored by composer UX. */
   inputs: SkillInputDef[];


### PR DESCRIPTION
Skill icon slugs now resolve to Microsoft Fluent emoji **Flat SVG** assets instead of the 3D PNGs, in both resolvers (`app/src/lib/skill-image.ts` and `ui/chat/src/skill-message.ts`). The muted grayscale bubble treatment is unchanged. Doc comments and the skills KB updated; unit tests added for both URL builders.

Verified: `pnpm check`, full `pnpm typecheck`, app unit tests (1990 pass), ui/chat tests (181 pass), visual regression suite (6/6, no baseline impact).

Fixes HOU-793

🤖 Generated with [Claude Code](https://claude.com/claude-code)