### PR TITLE
fix(teams): first prod test round — identity reset, in-place switch, per-space provider state

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -185,6 +185,18 @@ export default function App() {
   const agentLoading = useAgentStore((s) => s.loading);
   const agents = useAgentStore((s) => s.agents);
   const agentsLoaded = useAgentStore((s) => s.loaded);
+  // First-boot latch (HOU-907). The workspace-boot splash below is a FIRST-BOOT
+  // affordance only: once the full gate has cleared once for this App mount, a
+  // space switch must never re-blank the shell. A switch flips capabilities +
+  // both onboarding flags to loading (the space-cache reset) and re-runs
+  // loadAgents — but the chrome is zustand-backed and every pane is
+  // skeleton-capable + capabilities-undefined-safe, so it tolerates the
+  // transition in place. Reset is natural, not manual: on sign-out / account
+  // change the HOU-903 identity reset drops the session, so <HostedEngineGate>
+  // (which wraps <App/> in main.tsx) swaps to the sign-in screen and UNMOUNTS
+  // this subtree — the next identity remounts App with the latch back at false,
+  // so a genuinely fresh identity still gets its first-boot splash.
+  const bootedRef = useRef(false);
   const toasts = useUIStore((s) => s.toasts);
   const dismissToast = useUIStore((s) => s.dismissToast);
   const tutorialActive = useUIStore((s) => s.tutorialActive);
@@ -325,16 +337,20 @@ export default function App() {
   // guaranteed to run and settle `loaded`. The legacy Rust wire gates on
   // workspaces alone and skips this wait (zero-workspace first runs never load
   // agents, so `loaded` would hang false there).
-  if (
+  const bootGateActive =
     agentLoading ||
     wsLoading ||
     capabilitiesLoading ||
     onboardingPendingLoading ||
     onboardingCompletedLoading ||
-    (newEngineActive() && !agentsLoaded)
-  ) {
+    (newEngineActive() && !agentsLoaded);
+  // First boot only: block on the splash until every gate input has settled
+  // once. After that, a space switch re-flips these (see `bootedRef`) but the
+  // shell stays mounted and its panes skeleton in place instead of unmounting.
+  if (!bootedRef.current && bootGateActive) {
     return <WorkspaceLoading />;
   }
+  bootedRef.current = true;
 
   // First-run signal differs by wire (HOU-653): the legacy Rust engine uses
   // zero WORKSPACES, but the v3 control plane has no workspace CRUD — the

--- a/app/src/components/shell/create-team-dialog.tsx
+++ b/app/src/components/shell/create-team-dialog.tsx
@@ -76,6 +76,14 @@ export function CreateTeamDialog({ open, onOpenChange }: Props) {
         if (ws) {
           setCurrentWorkspace(ws);
           await loadAgents(ws.id);
+          // The active space just switched under the user. If they opened this
+          // from Settings (or any non-home view, or an agent that belonged to
+          // the old space and the reload above just dropped), the view would
+          // stay put and the whole create reads as a silent failure. Land them
+          // in the new team's home — the same "dashboard" the shell resets a
+          // blocked view to — so the switch is visible. The toast's Invite
+          // action then takes them on to Admin from home.
+          setViewMode("dashboard");
         }
         // Point the user at the next step: the Admin dashboard's People card,
         // now guaranteed visible because the active space is the fresh team.

--- a/app/src/components/tabs/share-via-team-flow.tsx
+++ b/app/src/components/tabs/share-via-team-flow.tsx
@@ -49,6 +49,7 @@ import {
 } from "../../lib/share-via-team";
 import { orgSlugFromWorkspaceId } from "../../lib/space-id";
 import type { Agent } from "../../lib/types";
+import { useAgentStore } from "../../stores/agents";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { InviteStep } from "./share-via-team-invite";
 import {
@@ -91,6 +92,7 @@ export function ShareViaTeamFlow({
   const addMember = useAddMember();
   const loadWorkspaces = useWorkspaceStore((s) => s.loadWorkspaces);
   const setCurrentWorkspace = useWorkspaceStore((s) => s.setCurrent);
+  const loadAgents = useAgentStore((s) => s.loadAgents);
 
   const moveId = state.step === "moving" ? state.moveId : null;
   const moveStatus = useAgentMoveStatus(
@@ -157,6 +159,12 @@ export function ShareViaTeamFlow({
           return;
         }
         setCurrentWorkspace(ws);
+        // Load the new space's agents before declaring the switch done — every
+        // switch path must settle the agent store, or consumers gated on it
+        // (the provider-status re-probe) fire against the OLD space's agent
+        // under the new x-houston-org header.
+        await loadAgents(ws.id);
+        if (cancelled) return;
         setState((s) => switchDone(s));
       } catch {
         if (!cancelled) setState((s) => switchFailed(s));
@@ -165,7 +173,7 @@ export function ShareViaTeamFlow({
     return () => {
       cancelled = true;
     };
-  }, [state, loadWorkspaces, setCurrentWorkspace]);
+  }, [state, loadWorkspaces, setCurrentWorkspace, loadAgents]);
 
   const handleCreate = async (name: string) => {
     try {

--- a/app/src/hooks/provider-connections/use-provider-statuses.ts
+++ b/app/src/hooks/provider-connections/use-provider-statuses.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { providerAppearsConnected } from "../../components/shell/provider-reconnect-state";
 import { analytics } from "../../lib/analytics";
 import {
@@ -11,6 +11,8 @@ import {
   type ProviderStatus,
   tauriProvider,
 } from "../../lib/tauri";
+import { useAgentStore } from "../../stores/agents";
+import { useWorkspaceStore } from "../../stores/workspaces";
 import { scanIsUnreachable } from "./unreachable-scan";
 
 export interface ProviderStatusState {
@@ -68,6 +70,19 @@ export function useProviderStatuses(
   const hasBaseline = useRef(false);
   const prevStatuses = useRef<Record<string, ProviderStatus>>({});
 
+  // The active-space signals (C8). Provider connections are tenant data, so a
+  // space switch must re-seed from the NEW space's snapshot and re-probe live.
+  // The shell stays mounted across a switch (HOU-907), so this hook is NOT
+  // remounted — the mount-time seed (the `useState` initializer above, which
+  // reads the per-scope cache) and the mount probe (in `use-provider-connections`)
+  // won't re-run. These refs drive both off the active workspace id instead;
+  // they start AT the current id so a fresh mount doesn't double-seed/probe.
+  const currentWorkspaceId = useWorkspaceStore((s) => s.current?.id ?? null);
+  const agentsLoading = useAgentStore((s) => s.loading);
+  const agentsLoaded = useAgentStore((s) => s.loaded);
+  const seededWorkspaceIdRef = useRef(currentWorkspaceId);
+  const probedWorkspaceIdRef = useRef(currentWorkspaceId);
+
   const loadStatuses = useCallback(async () => {
     const gatewayIds = [
       ...new Set(visibleProviders.flatMap((p) => providerGatewayIds(p))),
@@ -106,6 +121,36 @@ export function useProviderStatuses(
     // Persist the confirmed scan so the NEXT visit paints instantly.
     saveCachedProviderStatuses(next);
   }, [visibleProviders]);
+
+  // On a real active-space change, immediately swap to the new scope's cached
+  // snapshot (keyed by active org — provider-status-cache.ts). This must NOT
+  // keep painting the previous space's connected cards: an empty new-scope cache
+  // flips back to the loading state until the live probe below reconciles. A new
+  // space is also a fresh analytics baseline, so its first probe emits no
+  // provider_configured transition against the prior space's snapshot.
+  useEffect(() => {
+    if (seededWorkspaceIdRef.current === currentWorkspaceId) return;
+    seededWorkspaceIdRef.current = currentWorkspaceId;
+    const seed = loadCachedProviderStatuses();
+    setStatuses(seed);
+    setLoading(Object.keys(seed).length === 0);
+    setProbed(false);
+    prevStatuses.current = {};
+    hasBaseline.current = false;
+  }, [currentWorkspaceId]);
+
+  // Re-probe LIVE after a switch, but ONLY once the new space's agents have
+  // loaded. The probe routes per-agent (last_agent_id + knownAgentIds in the
+  // engine adapter), so firing it before `loadAgents` settles would hit the OLD
+  // space's agent under the new org header — the sidebar switch handler awaits
+  // loadAgents, which repopulates knownAgentIds for the new org. Gating on the
+  // agent store's settled state closes that window.
+  useEffect(() => {
+    if (probedWorkspaceIdRef.current === currentWorkspaceId) return;
+    if (!agentsLoaded || agentsLoading) return;
+    probedWorkspaceIdRef.current = currentWorkspaceId;
+    void loadStatuses();
+  }, [currentWorkspaceId, agentsLoaded, agentsLoading, loadStatuses]);
 
   const patchAuthState = useCallback(
     (providerId: string, authenticated: boolean) => {

--- a/app/src/hooks/queries/use-billing.ts
+++ b/app/src/hooks/queries/use-billing.ts
@@ -31,8 +31,8 @@ import { useCapabilities } from "../use-capabilities";
 
 /**
  * The active team's billing summary, or `null` when off-entitlement (the wire
- * swallows the not-entitled 404/403 → null). Enabled only for an owner/admin on
- * a team space of a Spaces-capable host.
+ * swallows the not-entitled 404/403 and the billing-off 503 → null). Enabled
+ * only for an owner/admin on a team space of a Spaces-capable host.
  */
 export function useBilling() {
   const { capabilities } = useCapabilities();

--- a/app/src/hooks/use-onboarding-completed.ts
+++ b/app/src/hooks/use-onboarding-completed.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import { queryKeys } from "../lib/query-keys";
 import { tauriPreferences } from "../lib/tauri";
 import { useSession } from "./use-session";
 
@@ -10,8 +11,6 @@ import { useSession } from "./use-session";
  * app restart.
  */
 export const ONBOARDING_COMPLETED_KEY = "onboarding_completed";
-
-const queryKey = ["onboarding-completed"] as const;
 
 /** Per-user localStorage key for the device-local mirror of the flag (mirrors
  *  `onboardingSegmentLocalKey`). */
@@ -80,7 +79,7 @@ export function useOnboardingCompleted(): OnboardingCompletedState {
   const uid = session?.uid ?? null;
 
   const query = useQuery({
-    queryKey: [...queryKey, uid],
+    queryKey: queryKeys.onboardingCompleted(uid),
     queryFn: async (): Promise<boolean> => {
       let fromEngine = false;
       try {
@@ -116,7 +115,7 @@ export function useOnboardingCompleted(): OnboardingCompletedState {
       }
     },
     onSuccess: () => {
-      qc.setQueryData<boolean>([...queryKey, uid], true);
+      qc.setQueryData<boolean>(queryKeys.onboardingCompleted(uid), true);
     },
   });
 
@@ -127,7 +126,7 @@ export function useOnboardingCompleted(): OnboardingCompletedState {
   // completed — the backfill effect never fires twice and no onboarding frame
   // slips through.
   const markCompleted = useCallback(async () => {
-    qc.setQueryData<boolean>([...queryKey, uid], true);
+    qc.setQueryData<boolean>(queryKeys.onboardingCompleted(uid), true);
     await mutateAsync();
   }, [mutateAsync, qc, uid]);
 

--- a/app/src/hooks/use-onboarding-pending.ts
+++ b/app/src/hooks/use-onboarding-pending.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import { queryKeys } from "../lib/query-keys";
 import { tauriPreferences } from "../lib/tauri";
 
 /**
@@ -9,7 +10,7 @@ import { tauriPreferences } from "../lib/tauri";
  */
 export const ONBOARDING_PENDING_KEY = "onboarding_pending";
 
-const queryKey = ["onboarding-pending"] as const;
+const queryKey = queryKeys.onboardingPending();
 
 export interface OnboardingPendingState {
   /** True while the flow is mid-flight (set on mount, cleared on any terminal

--- a/app/src/identity-keyed-app.tsx
+++ b/app/src/identity-keyed-app.tsx
@@ -1,0 +1,28 @@
+import App from "./App";
+import { WorkspaceLoading } from "./components/shell/workspace-loading";
+import { useSession } from "./hooks/use-session";
+
+/**
+ * Mounts <App/> keyed by the signed-in identity so ANY identity change
+ * (sign-out, sign-in, in-place account switch) unmounts and re-bootstraps the
+ * whole subtree — the boot-splash latch (App's bootedRef), useHoustonInit's
+ * run-once guard, and every store-backed screen start clean for the new user.
+ *
+ * This is the one identity boundary that holds across EVERY deployment mode.
+ * HostedEngineGate unmounts App on session loss only in hosted-oauth builds;
+ * static-host (pnpm dev, self-host with cloud identity) and sidecar builds
+ * keep App mounted through App's own internal sign-in guard, which left the
+ * HOU-903 in-place reset with emptied stores and spent init guards (blank
+ * shell / false first-run on re-sign-in). Keying by uid closes that in all
+ * modes, including a signed-in A->B switch that never passes through null.
+ *
+ * Held on the splash until the session query settles so the key is stable
+ * from App's very first mount (no spurious remount when the session resolves
+ * moments after page load). Identity-off hosts resolve null immediately, so
+ * they mount once with the constant key and never remount.
+ */
+export function IdentityKeyedApp() {
+  const session = useSession();
+  if (session.isPending) return <WorkspaceLoading />;
+  return <App key={session.data?.uid ?? "signed-out"} />;
+}

--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -32,6 +32,8 @@ import {
   googleDesktopSession,
   microsoftDesktopSession,
 } from "./identity/desktop-signin";
+import { identityChanged } from "./identity-change";
+import { resetForIdentityChange } from "./identity-reset";
 import { writeLastSignIn } from "./last-sign-in";
 import { logger } from "./logger";
 import { osIsTauri } from "./os-bridge";
@@ -40,7 +42,24 @@ import { clearPersistedLocalData } from "./query-persist";
 
 setSessionSink((session) => cacheSession(session)); // refresh.ts → app cache
 
+// The Firebase uid whose world the app's in-memory caches/stores currently hold.
+// Tracked HERE rather than read from the session query cache because the
+// session-store clear notifies `useSession` — nulling that cache — BEFORE
+// `signOut()`'s `cacheSession(null)` runs, so a cache read would miss the
+// outgoing uid. Seeded by `cacheSession` on sign-in/refresh; nulled by `signOut`.
+let activeIdentityUid: string | null = null;
+
 function cacheSession(session: Session | null): void {
+  const nextUid = session?.uid ?? null;
+  // A different account signing in (an account switch with no explicit
+  // sign-out) must drop the outgoing identity's world before the new one loads
+  // (HOU-903). Sign-out is handled directly in `signOut` (it nulls
+  // `activeIdentityUid` first, so this stays a no-op there — no double reset);
+  // a token refresh keeps the same uid, so this is a no-op then too.
+  if (identityChanged(activeIdentityUid, nextUid)) {
+    resetForIdentityChange();
+  }
+  activeIdentityUid = nextUid;
   queryClient.setQueryData<Session | null>(SESSION_QUERY_KEY, session);
 }
 
@@ -237,11 +256,19 @@ export async function signOut(): Promise<void> {
   } catch (e) {
     logger.warn(`[auth] sign-out clear failed; local cleanup continues: ${e}`);
   }
-  cacheSession(null);
   // Wipe locally persisted per-user data so nothing lingers after sign-out (HOU-712).
   await clearPersistedLocalData();
   analytics.track("user_signed_out");
   analytics.reset();
+  // Drop the outgoing identity's in-memory world — query cache, zustand stores,
+  // active-org pin — so the next account never inherits it (HOU-903). Done here
+  // rather than relying on cacheSession's guard because the session-store clear
+  // above already nulled the session query cache, so the guard would compare
+  // null → null and miss the sign-out. Nulling `activeIdentityUid` first keeps
+  // the `cacheSession(null)` below a no-op (no double reset).
+  resetForIdentityChange();
+  activeIdentityUid = null;
+  cacheSession(null);
 }
 
 function requireConfigured(): void {

--- a/app/src/lib/identity-change.ts
+++ b/app/src/lib/identity-change.ts
@@ -1,0 +1,15 @@
+/**
+ * Whether a session-identity transition must drop the outgoing identity's
+ * in-memory world (HOU-903). Compares Firebase UIDs, never tokens.
+ *
+ * True only when a real, non-null identity is being replaced — by another
+ * account, or by sign-out. False for:
+ *  - the first sign-in / boot restore (`null → user`): nothing is cached yet;
+ *  - a token refresh of the SAME user (`user → same user`): uid unchanged.
+ */
+export function identityChanged(
+  prevUserId: string | null,
+  nextUserId: string | null,
+): boolean {
+  return prevUserId !== null && prevUserId !== nextUserId;
+}

--- a/app/src/lib/identity-reset.ts
+++ b/app/src/lib/identity-reset.ts
@@ -1,0 +1,38 @@
+import { useAgentProvisioningStore } from "../stores/agent-provisioning";
+import { useAgentStore } from "../stores/agents";
+import { useDraftStore } from "../stores/drafts";
+import { useUIStore } from "../stores/ui";
+import { useWorkspaceStore } from "../stores/workspaces";
+import { setActiveOrg } from "./engine";
+import { queryClient } from "./query-client";
+
+/**
+ * Drop the whole client-side world when the signed-in identity changes — a
+ * different account signs in, or the current one signs out (HOU-903).
+ *
+ * The gateway is the sole tenancy enforcer and never serves cross-tenant data;
+ * this is pure client-side stale memory. Three things outlive an identity swap
+ * and must be wiped, or the incoming account inherits the outgoing one's world:
+ *
+ *  1. The in-memory query cache. `queryClient.clear()` (stronger than
+ *     `removeQueries`) is deliberate: query keys are NOT user-scoped — the
+ *     gateway resolves the caller from the bearer + `x-houston-org` header — so
+ *     EVERY cached read (agents, org, provider-connection states) belongs to the
+ *     outgoing identity and would otherwise be served to the next account via
+ *     stale-while-revalidate. Mirrors `resetCacheForSpaceChange`, but for the
+ *     whole identity rather than one space.
+ *  2. The zustand stores. They live outside React and survive the sign-out
+ *     unmount, so their agents / workspaces / view state would carry over.
+ *  3. The active-space pin (`x-houston-org`). A stale team slug from the
+ *     outgoing identity would ride the next account's very first requests and
+ *     the gateway would 403 them `not_member`.
+ */
+export function resetForIdentityChange(): void {
+  queryClient.clear();
+  useAgentStore.getState().reset();
+  useWorkspaceStore.getState().reset();
+  useUIStore.getState().reset();
+  useDraftStore.getState().reset();
+  useAgentProvisioningStore.getState().reset();
+  setActiveOrg(null);
+}

--- a/app/src/lib/identity/session-store.ts
+++ b/app/src/lib/identity/session-store.ts
@@ -17,6 +17,7 @@
 // into the TanStack cache, and (2) `SESSION_QUERY_KEY`, the shared `["session"]`
 // cache key those callers write.
 
+import { queryKeys } from "../query-keys.ts";
 import { identityLog } from "./log.ts";
 import { type Session, serializeSession } from "./session.ts";
 import { createSessionLoader, type SessionLoadState } from "./session-load.ts";
@@ -24,8 +25,10 @@ import { isKeychainMode, storage, storageKey } from "./session-storage-kv.ts";
 
 export type { SessionLoadState } from "./session-load.ts";
 
-/** The TanStack Query key holding `Session | null` on both surfaces. */
-export const SESSION_QUERY_KEY = ["session"] as const;
+/** The TanStack Query key holding `Session | null` on both surfaces. Defined
+ *  canonically in `lib/query-keys.ts` (the pure key module) so the space-cache
+ *  purge can reference it without importing this identity chain. */
+export const SESSION_QUERY_KEY = queryKeys.session();
 
 // Monotonic auth epoch, bumped every time the session is cleared (sign-out /
 // terminal refresh). An in-flight refresh captures it before its network call

--- a/app/src/lib/provider-status-cache.ts
+++ b/app/src/lib/provider-status-cache.ts
@@ -1,15 +1,64 @@
 import type { ProviderStatus } from "./tauri";
 
 /**
- * Boot-time cache of the last provider-status scan.
+ * Boot-time cache of the last provider-status scan, keyed PER ACTIVE SPACE.
  *
  * Provider probes shell out to CLIs and can take seconds each (up to a 5s
  * timeout per provider), so the settings screen seeds its cards from this
  * snapshot and paints instantly; the live probe still runs and reconciles.
  * Same philosophy as the i18n locale flash-cache: localStorage is never the
  * source of truth, only a first-paint hint.
+ *
+ * The snapshot is scoped by the active space (C8) because provider connections
+ * are tenant data — a team's connected providers differ from the personal
+ * space's. A single global key (the old `.v1`) leaked one space's connected
+ * cards into another on a switch (HOU-906), because the seed is a localStorage
+ * read that the query-cache reset can't reach. Scoping the key by the active
+ * org slug (personal ⇒ the fixed `"personal"` scope, resolved the same way the
+ * engine adapter pins `x-houston-org` — `window.__HOUSTON_ACTIVE_ORG__`) makes
+ * the seed self-scope: a switch reads the new space's own snapshot (or none).
  */
-const CACHE_KEY = "houston.providerStatusCache.v1";
+const CACHE_KEY_PREFIX = "houston.providerStatusCache.v2";
+
+/** The old un-scoped (cross-space-leaking) key. Orphaned by the `.v2` bump. */
+const LEGACY_CACHE_KEY = "houston.providerStatusCache.v1";
+
+/**
+ * The active-space scope for the cache key: the team org slug pinned on
+ * `window.__HOUSTON_ACTIVE_ORG__`, or the fixed `"personal"` scope when no
+ * team is active (null/absent global — the same signal the engine adapter uses
+ * to send no `x-houston-org` header).
+ */
+function activeScope(): string {
+  if (typeof window === "undefined") return "personal";
+  return window.__HOUSTON_ACTIVE_ORG__ ?? "personal";
+}
+
+function scopedCacheKey(scope: string): string {
+  return `${CACHE_KEY_PREFIX}.${scope}`;
+}
+
+/**
+ * One-time removal of the orphaned un-scoped `.v1` snapshot, so a stale global
+ * hint can never re-seed a card after the `.v2` scope bump. Runs once at module
+ * load (idempotent — removing an absent key is a no-op); guarded so a
+ * non-browser (test/SSR) import is a no-op.
+ */
+export function purgeLegacyProviderStatusCache(
+  storage: Pick<Storage, "removeItem"> | undefined = typeof localStorage !==
+  "undefined"
+    ? localStorage
+    : undefined,
+): void {
+  try {
+    storage?.removeItem(LEGACY_CACHE_KEY);
+  } catch {
+    // A blocked/absent store just means the orphan lingers harmlessly under its
+    // dead key — it is never read again.
+  }
+}
+
+purgeLegacyProviderStatusCache();
 
 function isProviderStatus(value: unknown): value is ProviderStatus {
   if (typeof value !== "object" || value === null) return false;
@@ -31,9 +80,10 @@ type StatusStore = Pick<Storage, "getItem" | "setItem">;
  */
 export function loadCachedProviderStatuses(
   storage: StatusStore = localStorage,
+  scope: string = activeScope(),
 ): Record<string, ProviderStatus> {
   try {
-    const raw = storage.getItem(CACHE_KEY);
+    const raw = storage.getItem(scopedCacheKey(scope));
     if (!raw) return {};
     const parsed: unknown = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null) return {};
@@ -52,9 +102,10 @@ export function loadCachedProviderStatuses(
 export function saveCachedProviderStatuses(
   statuses: Record<string, ProviderStatus>,
   storage: StatusStore = localStorage,
+  scope: string = activeScope(),
 ): void {
   try {
-    storage.setItem(CACHE_KEY, JSON.stringify(statuses));
+    storage.setItem(scopedCacheKey(scope), JSON.stringify(statuses));
   } catch {
     // Same rationale as the read path: losing the hint is harmless.
   }

--- a/app/src/lib/query-keys.ts
+++ b/app/src/lib/query-keys.ts
@@ -49,6 +49,26 @@ export const queryKeys = {
   capabilities: () => ["capabilities"] as const,
 
   /**
+   * Durable onboarding flags — USER-scoped and space-INVARIANT (engine prefs on
+   * the user's own store, mirrored per uid). Centralized here so the space-cache
+   * purge (`resetCacheForSpaceChange`) can preserve them by their root segment
+   * without importing the hooks. `onboarding-pending` is the interrupted-flow
+   * resume bit; `onboarding-completed` is the "already onboarded" bit, keyed by
+   * uid so a user switch can't inherit a stale value.
+   */
+  onboardingPending: () => ["onboarding-pending"] as const,
+  onboardingCompleted: (uid: string | null) =>
+    ["onboarding-completed", uid] as const,
+
+  /**
+   * The identity `Session | null` cache key, shared by `useSession` on both
+   * surfaces. Defined here (the pure key module) as the single source of truth
+   * and re-exported as `SESSION_QUERY_KEY` from `identity/session-store`, so the
+   * space-cache purge can preserve it without importing the identity chain.
+   */
+  session: () => ["session"] as const,
+
+  /**
    * Live per-account provider usage (the AI Hub's Usage tab): rate-limit
    * windows + prepaid balances from each provider's own usage API. App-scoped
    * (credentials are workspace-central); refreshed on an interval while the

--- a/app/src/lib/space-cache.ts
+++ b/app/src/lib/space-cache.ts
@@ -1,17 +1,44 @@
 import type { QueryClient } from "@tanstack/react-query";
+import { queryKeys } from "./query-keys.ts";
 
 /**
- * Drop the whole query cache on a real active-space change (C8 §Active space).
+ * Query-key roots that OUTLIVE a space switch: they hold USER-scoped,
+ * space-INVARIANT state, not tenant data, so they must NOT be purged on a
+ * switch.
  *
- * Query keys are NOT org-scoped: the active space is only an `x-houston-org`
- * request header, so team A and team B collide on the same key. `removeQueries`
- * (not `invalidateQueries`) is required — `invalidateQueries` only marks queries
- * stale and refetches ACTIVE observers, leaving every INACTIVE query's data in
- * cache for `gcTime`. A not-currently-mounted view (e.g. an agent board loaded
- * under the prior space) would then serve that prior space's data via
- * stale-while-revalidate on navigation before the refetch resolves — a
- * cross-tenant data flash. `removeQueries` discards inactive-query data too, so
- * everything refetches clean under the new space.
+ *  - `session` — the identity `Session`. Purging it re-triggers `useSession`'s
+ *    fetch, whose `isLoading` re-arms App.tsx's auth-gate splash (a full-screen
+ *    unmount), the very blank the in-place switch (HOU-907) exists to remove.
+ *  - `onboarding-pending` / `onboarding-completed` — the durable first-run
+ *    flags. They gate the onboarding-vs-shell route in App.tsx; flashing them to
+ *    loading on a switch flaps that gate (and, on a switch INTO an empty team
+ *    space, would momentarily route a completed user back toward onboarding
+ *    before the flag refetches). They are the same across every space, so there
+ *    is nothing tenant-specific to reset.
+ *
+ * Capabilities (role) is deliberately NOT here — it is PER-SPACE, so it must
+ * refetch under the new space.
+ */
+const SPACE_INVARIANT_KEY_ROOTS: ReadonlySet<string> = new Set([
+  String(queryKeys.session()[0]),
+  String(queryKeys.onboardingPending()[0]),
+  String(queryKeys.onboardingCompleted(null)[0]),
+]);
+
+/**
+ * Drop the query cache on a real active-space change (C8 §Active space), EXCEPT
+ * the user-scoped, space-invariant keys above.
+ *
+ * Tenant query keys are NOT org-scoped: the active space is only an
+ * `x-houston-org` request header, so team A and team B collide on the same key.
+ * `removeQueries` (not `invalidateQueries`) is required — `invalidateQueries`
+ * only marks queries stale and refetches ACTIVE observers, leaving every
+ * INACTIVE query's data in cache for `gcTime`. A not-currently-mounted view
+ * (e.g. an agent board loaded under the prior space) would then serve that prior
+ * space's data via stale-while-revalidate on navigation before the refetch
+ * resolves — a cross-tenant data flash. The predicate discards inactive-query
+ * data too, so every tenant query refetches clean under the new space while the
+ * space-invariant user keys are left intact (HOU-907).
  *
  * A no-op when the space did not change (same-space reselect, or every switch on
  * a personal-only host where every id maps to null).
@@ -20,5 +47,9 @@ export function resetCacheForSpaceChange(
   queryClient: QueryClient,
   orgChanged: boolean,
 ): void {
-  if (orgChanged) queryClient.removeQueries();
+  if (!orgChanged) return;
+  queryClient.removeQueries({
+    predicate: (query) =>
+      !SPACE_INVARIANT_KEY_ROOTS.has(String(query.queryKey[0])),
+  });
 }

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -3,7 +3,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { Component, type ReactNode, useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { I18nextProvider } from "react-i18next";
-import App from "./App";
+import { IdentityKeyedApp } from "./identity-keyed-app";
 import { queryClient } from "./lib/query-client";
 import "./styles/globals.css";
 import { AgentFilePreviewHost } from "./components/agent-file-preview-host";
@@ -156,7 +156,7 @@ createRoot(rootElement).render(
               <QueryPersistenceProvider>
                 <LanguageGate>
                   <DisclaimerGate>
-                    <App />
+                    <IdentityKeyedApp />
                     {/* Global workspace-file preview (chat file clicks) — a
                         sibling of App so it overlays every screen, onboarding
                         included. Mirrored in packages/web/src/app-tree.tsx. */}

--- a/app/src/stores/agent-provisioning.ts
+++ b/app/src/stores/agent-provisioning.ts
@@ -85,6 +85,13 @@ interface AgentProvisioningState {
    * current — a probe's own settle must not clear a newer re-mark of the id.
    */
   clearProvisioning: (agentId: string, onlyIf?: ProvisioningEntry) => void;
+  /**
+   * Drop every provisioning entry (and its localStorage mirror) on an identity
+   * change (HOU-903): the marks are keyed by the outgoing account's agent ids
+   * and probe its engine. Live probes self-retire (their exit switch is entry
+   * identity, now absent from the store).
+   */
+  reset: () => void;
 }
 
 /** localStorage access, surfaced to Sentry (no toast — nothing user-blocking
@@ -215,6 +222,12 @@ export const useAgentProvisioningStore = create<AgentProvisioningState>(
         storageWrite(rest);
         return { provisioning: rest };
       });
+    },
+
+    reset: () => {
+      asleepChecks.clear();
+      storageWrite({});
+      set({ provisioning: {}, sendsVersion: 0 });
     },
   }),
 );

--- a/app/src/stores/agents.ts
+++ b/app/src/stores/agents.ts
@@ -68,6 +68,9 @@ interface AgentState {
     id: string,
     color: string,
   ) => Promise<void>;
+  /** Drop the agent list back to its initial (unloaded) state on an identity
+   *  change (HOU-903); the incoming account re-loads its own agents on boot. */
+  reset: () => void;
 }
 
 export const useAgentStore = create<AgentState>((set, get) => ({
@@ -188,4 +191,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       current: s.current?.id === id ? updated : s.current,
     }));
   },
+
+  reset: () =>
+    set({ agents: [], current: null, loading: false, loaded: false }),
 }));

--- a/app/src/stores/drafts.ts
+++ b/app/src/stores/drafts.ts
@@ -13,6 +13,9 @@ interface DraftsState {
   clearDraft: (key: string) => void;
   /** Remove all drafts whose key starts with the given prefix (e.g. on agent delete). */
   clearByPrefix: (prefix: string) => void;
+  /** Drop every draft — the outgoing account's parked messages are private to it
+   *  (identity change, HOU-903). */
+  reset: () => void;
 }
 
 /**
@@ -83,6 +86,8 @@ export const useDraftStore = create<DraftsState>((set) => ({
       }
       return { drafts: next };
     }),
+
+  reset: () => set({ drafts: {} }),
 }));
 
 /** Read-only selector for a single draft's text. Returns "" if no draft exists. */

--- a/app/src/stores/ui.ts
+++ b/app/src/stores/ui.ts
@@ -171,7 +171,58 @@ interface UIState {
   toggleSidebarCollapsed: () => void;
   setFilesViewMode: (mode: "grid" | "list") => void;
   setFilePreview: (preview: FilePreviewTarget | null) => void;
+  /**
+   * Reset the ephemeral, identity-scoped view state to its initial values on an
+   * identity change (HOU-903) — the outgoing account's open view, panels,
+   * dialogs, and searches must not greet the next account. The two persisted
+   * device layout prefs (`sidebarCollapsed`, `filesViewMode`) are kept: they are
+   * per-machine, not per-account.
+   */
+  reset: () => void;
 }
+
+/** The initial data state, shared by the store's creator and `reset()` so the
+ *  two can never drift. Excludes the action functions. */
+const initialUIState = {
+  viewMode: "chat",
+  settingsSection: null,
+  assistantPanelOpen: false,
+  activityPanelId: null,
+  activityPanelForceOpen: false,
+  claudeAvailable: null,
+  authRequired: null,
+  toasts: [],
+  createAgentDialogOpen: false,
+  agentWarmingNoticeOpen: false,
+  onStartMission: null,
+  boardActions: [],
+  agentMissionSearchQueries: {},
+  agentMissionSearchLoading: {},
+  agentArchivedSearchQueries: {},
+  agentArchivedSearchLoading: {},
+  missionPanelOpen: false,
+  pendingRoutineActivityId: null,
+  integrationSetupChatAgentId: null,
+  paletteOpen: false,
+  cheatsheetOpen: false,
+  onBoardNavigate: null,
+  onBoardOpen: null,
+  onPanelClose: null,
+  jobDescriptionTarget: null,
+  tutorialActive: false,
+  uiTourActive: false,
+  shareAgentId: null,
+  importFromFriendOpen: false,
+  importSeedPreview: null,
+  storeFocusSlug: null,
+  storeOwnerTab: null,
+  pendingStoreInstallSlug: null,
+  storeCreatorHandle: null,
+  creatorEditorOpen: false,
+  sidebarCollapsed: false,
+  filesViewMode: "grid",
+  filePreview: null,
+} satisfies Partial<UIState>;
 
 let toastCounter = 0;
 // Live dismiss timers by toast id, so a coalesced repeat can RESTART its
@@ -181,44 +232,7 @@ const toastTimers = new Map<string, ReturnType<typeof setTimeout>>();
 export const useUIStore = create<UIState>()(
   persist(
     (set) => ({
-      viewMode: "chat",
-      settingsSection: null,
-      assistantPanelOpen: false,
-      activityPanelId: null,
-      activityPanelForceOpen: false,
-      claudeAvailable: null,
-      authRequired: null,
-      toasts: [],
-      createAgentDialogOpen: false,
-      agentWarmingNoticeOpen: false,
-      onStartMission: null,
-      boardActions: [],
-      agentMissionSearchQueries: {},
-      agentMissionSearchLoading: {},
-      agentArchivedSearchQueries: {},
-      agentArchivedSearchLoading: {},
-      missionPanelOpen: false,
-      pendingRoutineActivityId: null,
-      integrationSetupChatAgentId: null,
-      paletteOpen: false,
-      cheatsheetOpen: false,
-      onBoardNavigate: null,
-      onBoardOpen: null,
-      onPanelClose: null,
-      jobDescriptionTarget: null,
-      tutorialActive: false,
-      uiTourActive: false,
-      shareAgentId: null,
-      importFromFriendOpen: false,
-      importSeedPreview: null,
-      storeFocusSlug: null,
-      storeOwnerTab: null,
-      pendingStoreInstallSlug: null,
-      storeCreatorHandle: null,
-      creatorEditorOpen: false,
-      sidebarCollapsed: false,
-      filesViewMode: "grid",
-      filePreview: null,
+      ...initialUIState,
 
       setViewMode: (viewMode) => set({ viewMode }),
       setSettingsSection: (settingsSection) => set({ settingsSection }),
@@ -351,6 +365,19 @@ export const useUIStore = create<UIState>()(
         set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
       setFilesViewMode: (filesViewMode) => set({ filesViewMode }),
       setFilePreview: (filePreview) => set({ filePreview }),
+
+      reset: () => {
+        // Cancel any live dismiss timers before dropping their toasts, so a
+        // pending timeout can't fire against the next account's store.
+        for (const timer of toastTimers.values()) clearTimeout(timer);
+        toastTimers.clear();
+        set((s) => ({
+          ...initialUIState,
+          // Keep the per-machine layout prefs (not identity-scoped).
+          sidebarCollapsed: s.sidebarCollapsed,
+          filesViewMode: s.filesViewMode,
+        }));
+      },
     }),
     {
       name: "houston-ui",

--- a/app/src/stores/workspaces.ts
+++ b/app/src/stores/workspaces.ts
@@ -19,6 +19,9 @@ interface WorkspaceState {
   rename: (id: string, newName: string) => Promise<void>;
   /** Set (or clear, with null) the workspace's UI-locale override. */
   setLocale: (id: string, locale: string | null) => Promise<void>;
+  /** Drop the workspace list back to its initial (loading) state on an identity
+   *  change (HOU-903); the incoming account re-loads its own spaces on boot. */
+  reset: () => void;
 }
 
 export const useWorkspaceStore = create<WorkspaceState>((set) => ({
@@ -106,4 +109,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set) => ({
       current: s.current?.id === id ? updated : s.current,
     }));
   },
+
+  // Mirrors the initial state (loading: true) so the shell shows its splash, not
+  // a stale list, until the incoming account's loadWorkspaces() resolves.
+  reset: () => set({ workspaces: [], current: null, loading: true }),
 }));

--- a/app/tests/ai-hub-review-fixes.test.ts
+++ b/app/tests/ai-hub-review-fixes.test.ts
@@ -134,7 +134,7 @@ describe("provider status cache seeds instant paint", () => {
   it("drops malformed entries rather than trusting a bad paint hint", () => {
     const store = memStore();
     store.setItem(
-      "houston.providerStatusCache.v1",
+      "houston.providerStatusCache.v2.personal",
       JSON.stringify({ good: connectedStatus(), bad: { provider: 1 } }),
     );
     const seeded = loadCachedProviderStatuses(store);

--- a/app/tests/identity-change.test.ts
+++ b/app/tests/identity-change.test.ts
@@ -1,0 +1,30 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { identityChanged } from "../src/lib/identity-change.ts";
+
+// HOU-903: the pure decision behind the sign-out / account-switch cache wipe.
+// Signing in as account B in the same app session used to render account A's
+// cached world; the reset must run on a real identity replacement, never on a
+// same-user token refresh or the first sign-in (nothing is cached yet).
+
+describe("identityChanged", () => {
+  it("resets on an account switch (different uid)", () => {
+    strictEqual(identityChanged("user-a", "user-b"), true);
+  });
+
+  it("resets on sign-out (user → null)", () => {
+    strictEqual(identityChanged("user-a", null), true);
+  });
+
+  it("does NOT reset on a token refresh of the same user", () => {
+    strictEqual(identityChanged("user-a", "user-a"), false);
+  });
+
+  it("does NOT reset on the first sign-in / boot restore (null → user)", () => {
+    strictEqual(identityChanged(null, "user-b"), false);
+  });
+
+  it("does NOT reset when there was and is no identity (null → null)", () => {
+    strictEqual(identityChanged(null, null), false);
+  });
+});

--- a/app/tests/provider-status-cache.test.ts
+++ b/app/tests/provider-status-cache.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   loadCachedProviderStatuses,
+  purgeLegacyProviderStatusCache,
   saveCachedProviderStatuses,
 } from "../src/lib/provider-status-cache.ts";
 import type { ProviderStatus } from "../src/lib/tauri.ts";
@@ -13,9 +14,17 @@ function memoryStorage(initial: Record<string, string> = {}) {
     setItem: (key: string, value: string) => {
       store.set(key, value);
     },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
     dump: () => Object.fromEntries(store),
   };
 }
+
+// The scoped-key grammar the cache uses (`.v2.<scope>`); node has no `window`,
+// so the DEFAULT scope resolves to "personal".
+const key = (scope: string) => `houston.providerStatusCache.v2.${scope}`;
+const LEGACY_KEY = "houston.providerStatusCache.v1";
 
 const CONNECTED: ProviderStatus = {
   provider: "anthropic",
@@ -38,15 +47,13 @@ test("empty storage yields an empty snapshot", () => {
 });
 
 test("corrupt JSON yields an empty snapshot", () => {
-  const storage = memoryStorage({
-    "houston.providerStatusCache.v1": "{not json",
-  });
+  const storage = memoryStorage({ [key("personal")]: "{not json" });
   assert.deepEqual(loadCachedProviderStatuses(storage), {});
 });
 
 test("malformed entries are dropped, valid ones kept", () => {
   const storage = memoryStorage({
-    "houston.providerStatusCache.v1": JSON.stringify({
+    [key("personal")]: JSON.stringify({
       anthropic: CONNECTED,
       openai: { provider: "openai" }, // missing fields
       google: "authenticated", // not an object
@@ -65,9 +72,57 @@ test("a throwing storage backend is treated as no cache", () => {
     setItem: () => {
       throw new Error("denied");
     },
+    removeItem: () => {
+      throw new Error("denied");
+    },
   };
   assert.deepEqual(loadCachedProviderStatuses(throwing), {});
   assert.doesNotThrow(() =>
     saveCachedProviderStatuses({ anthropic: CONNECTED }, throwing),
   );
+});
+
+test("snapshots are isolated per space scope", () => {
+  const storage = memoryStorage();
+  const TEAM = "00000000000000ab";
+
+  // Personal-space snapshot: anthropic connected.
+  saveCachedProviderStatuses({ anthropic: CONNECTED }, storage, "personal");
+  // A team space records a DIFFERENT world: nothing connected yet.
+  saveCachedProviderStatuses({}, storage, TEAM);
+
+  // Each scope reads back ONLY its own snapshot — no cross-space leak (HOU-906).
+  assert.deepEqual(loadCachedProviderStatuses(storage, "personal"), {
+    anthropic: CONNECTED,
+  });
+  assert.deepEqual(loadCachedProviderStatuses(storage, TEAM), {});
+
+  // The keys are physically distinct.
+  const keys = Object.keys(storage.dump());
+  assert.ok(keys.includes(key("personal")));
+  assert.ok(keys.includes(key(TEAM)));
+});
+
+test("the orphaned un-scoped v1 snapshot is purged", () => {
+  const storage = memoryStorage({
+    [LEGACY_KEY]: JSON.stringify({ anthropic: CONNECTED }),
+    [key("personal")]: JSON.stringify({ anthropic: CONNECTED }),
+  });
+
+  purgeLegacyProviderStatusCache(storage);
+
+  // The dead v1 key is gone; the live scoped key is untouched.
+  assert.equal(storage.getItem(LEGACY_KEY), null);
+  assert.deepEqual(loadCachedProviderStatuses(storage, "personal"), {
+    anthropic: CONNECTED,
+  });
+});
+
+test("the scoped default resolves to the personal scope without a window", () => {
+  const storage = memoryStorage();
+  saveCachedProviderStatuses({ anthropic: CONNECTED }, storage);
+  // The default-scope write lands under the personal key.
+  assert.deepEqual(JSON.parse(storage.getItem(key("personal")) ?? "null"), {
+    anthropic: CONNECTED,
+  });
 });

--- a/app/tests/ui-store-reset.test.ts
+++ b/app/tests/ui-store-reset.test.ts
@@ -1,0 +1,40 @@
+import { strictEqual } from "node:assert";
+import { afterEach, describe, it } from "node:test";
+import { useUIStore } from "../src/stores/ui.ts";
+
+// HOU-903: on an identity change the UI store must drop the outgoing account's
+// ephemeral view state back to its initial values, while keeping the two
+// per-machine layout preferences (which are device-, not account-, scoped).
+
+afterEach(() => useUIStore.getState().reset());
+
+describe("useUIStore.reset", () => {
+  it("returns identity-scoped view state to its initial values", () => {
+    const s = useUIStore.getState();
+    s.setViewMode("settings");
+    s.setActivityPanelId("activity-42", { forceOpen: true });
+    s.setShareAgentId("agent-a");
+    s.setPaletteOpen(true);
+    s.setAgentMissionSearchQuery("agent-a", "invoices");
+
+    useUIStore.getState().reset();
+
+    const next = useUIStore.getState();
+    strictEqual(next.viewMode, "chat");
+    strictEqual(next.activityPanelId, null);
+    strictEqual(next.shareAgentId, null);
+    strictEqual(next.paletteOpen, false);
+    strictEqual(next.agentMissionSearchQueries["agent-a"], undefined);
+  });
+
+  it("keeps the per-machine layout preferences", () => {
+    useUIStore.getState().setSidebarCollapsed(true);
+    useUIStore.getState().setFilesViewMode("list");
+
+    useUIStore.getState().reset();
+
+    const next = useUIStore.getState();
+    strictEqual(next.sidebarCollapsed, true);
+    strictEqual(next.filesViewMode, "list");
+  });
+});

--- a/app/tests/workspace-cache-reset.test.ts
+++ b/app/tests/workspace-cache-reset.test.ts
@@ -39,4 +39,30 @@ describe("resetCacheForSpaceChange", () => {
       { id: "same-space-agent" },
     ]);
   });
+
+  it("preserves user-scoped, space-invariant keys on a real change (HOU-907)", () => {
+    // Tenant data (per-space) — must be dropped.
+    queryClient.setQueryData(["agents"], [{ id: "prior-space-agent" }]);
+    queryClient.setQueryData(["capabilities"], { role: "owner" });
+    // User-scoped, space-invariant — must SURVIVE (purging them flaps the
+    // auth/onboarding gates and re-blanks the shell mid-switch).
+    queryClient.setQueryData(["session"], { uid: "u1" });
+    queryClient.setQueryData(["onboarding-pending"], false);
+    queryClient.setQueryData(["onboarding-completed", "u1"], true);
+
+    resetCacheForSpaceChange(queryClient, true);
+
+    // Tenant keys gone.
+    assert.strictEqual(queryClient.getQueryData(["agents"]), undefined);
+    assert.strictEqual(queryClient.getQueryData(["capabilities"]), undefined);
+    // User-scoped keys intact.
+    assert.deepStrictEqual(queryClient.getQueryData(["session"]), {
+      uid: "u1",
+    });
+    assert.strictEqual(queryClient.getQueryData(["onboarding-pending"]), false);
+    assert.strictEqual(
+      queryClient.getQueryData(["onboarding-completed", "u1"]),
+      true,
+    );
+  });
 });

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -309,6 +309,25 @@ failed remote/Keychain clear is logged, never silent, and never blocks local
 cleanup. The desktop hosted-mode **engine bearer clears reactively**: `cacheSession(null)`
 → `["session"]` null → `HostedEngineGate` effect calls `setHostedEngineSessionToken(null)`.
 
+### Identity reset — in-place, no cross-account bleed (HOU-903)
+
+When the signed-in identity CHANGES — a different account signs in, or the current
+one signs out — `resetForIdentityChange()` (`app/src/lib/identity-reset.ts`, called
+from `cacheSession` on a uid change and from `signOut` in `app/src/lib/auth.ts`)
+wipes the whole client-side world so the incoming account never inherits the
+outgoing one's memory. Three things outlive an identity swap and are reset:
+(1) the in-memory query cache via `queryClient.clear()` (stronger than the
+space-switch's scoped `removeQueries` — query keys are resolved from the bearer +
+`x-houston-org`, so EVERY cached read belongs to the outgoing identity);
+(2) the zustand stores (`agents`, `workspaces`, `ui`, `drafts`, `agent-provisioning`
+— they live outside React and survive the sign-out unmount); and (3) the active-space
+pin via `setActiveOrg(null)` (a stale team slug would ride the next account's first
+requests and 403 `not_member`). This is a client-side stale-memory wipe only — the
+gateway is the sole tenancy enforcer and never serves cross-tenant data. On sign-out
+the `<HostedEngineGate>` also swaps `<App/>` for the sign-in screen, so App
+UNMOUNTS; the next identity remounts it fresh (this is also what naturally resets
+App's first-boot splash latch — see teams.md **Spaces > The switcher**).
+
 ## The `identity/` module map (`app/src/lib/identity/`)
 
 | Module | Role |

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -376,17 +376,44 @@ per team, each `{ id: "org:" + slug, kind: "org" }` where `slug` is `[a-f0-9]{16
   recorded on `window.__HOUSTON_ACTIVE_ORG__` and pushed into the live client in
   place (no rebuild); a fresh/repointed client re-applies it (`applyConfig`), and
   the local host's header-free `/v1/ws` transport ignores it.
-- **Switch = full cache drop** (`app/src/stores/workspaces.ts` `setCurrent` →
-  `resetCacheForSpaceChange`, `app/src/lib/space-cache.ts`): query keys are NOT
-  org-scoped (the active space is only a request header), so team A and team B
+- **Switch = scoped cache drop** (`app/src/stores/workspaces.ts` `setCurrent` →
+  `resetCacheForSpaceChange`, `app/src/lib/space-cache.ts`): tenant query keys are
+  NOT org-scoped (the active space is only a request header), so team A and team B
   collide on the same key. On a REAL space change `setActiveOrg` returns `true`
-  and the store calls `queryClient.removeQueries()` (not `invalidate`, which would
+  and the store `removeQueries` with a predicate that drops every key EXCEPT the
+  user-scoped, space-INVARIANT ones (`removeQueries` not `invalidate`, which would
   leave inactive-query data serving the prior space's rows on navigation, a
-  cross-tenant flash). Everything (including `capabilities`, whose `role` is
-  per-space) refetches clean under the new space, and the event stream is
-  re-established so the new `?org=` applies. A same-space reselect, and every
-  switch on a personal-only host (every id maps to `null`), is a no-op. First
-  load pins the active space before the first fetches fire (no reset needed then).
+  cross-tenant flash). Tenant reads (including `capabilities`, whose `role` is
+  per-space) refetch clean under the new space; the event stream re-establishes so
+  the new `?org=` applies. **Preserved (HOU-907):** `["session"]` and the durable
+  onboarding flags (`["onboarding-pending"]`, `["onboarding-completed", uid]`) —
+  purging them would flap the App.tsx auth/onboarding gates and re-blank the shell
+  mid-switch, and they're identical across spaces (not tenant data). Their roots
+  are centralized in `app/src/lib/query-keys.ts` (`session`/`onboardingPending`/
+  `onboardingCompleted`) so the predicate references them without importing the
+  hooks. A same-space reselect, and every switch on a personal-only host (every id
+  maps to `null`), is a no-op. First load pins the active space before the first
+  fetches fire (no reset needed then).
+- **The switch is IN-PLACE — no splash (HOU-907).** `App.tsx`'s
+  `WorkspaceLoading` splash is FIRST-BOOT only: a `bootedRef` latch flips once the
+  full boot gate (agents/workspaces/capabilities/onboarding flags loaded) clears,
+  and the gate is `!booted && <condition>` thereafter. A switch re-flips
+  capabilities + onboarding-flag loading and re-runs `loadAgents`, but the chrome
+  is zustand-backed and every pane is skeleton-capable + capabilities-undefined-
+  safe, so it transitions in place instead of unmounting the shell. The latch
+  resets naturally on an identity change: sign-out drops the session, so
+  `<HostedEngineGate>` (which wraps `<App/>`) swaps to the sign-in screen and
+  unmounts the subtree — the next identity remounts App with `booted` back at
+  false. E2E: `spaces-gating.spec.ts` switches spaces through the real UI.
+- **Provider-connection state is PER-SPACE** (`app/src/lib/provider-status-cache.ts`,
+  HOU-906). Provider "connected" cards seed from a localStorage snapshot the query
+  reset can't reach; that snapshot is now keyed by the active org slug
+  (`houston.providerStatusCache.v2.<scope>`, personal ⇒ `"personal"`, resolved
+  from `window.__HOUSTON_ACTIVE_ORG__`) so a switch reads the NEW space's own
+  snapshot (or none ⇒ loading skeleton). `use-provider-statuses.ts` re-seeds and
+  re-probes on a workspace-id change, gating the live probe on the new space's
+  agents having loaded (the probe routes per-agent, so it must not fire at the old
+  agent under the new org header). The old un-scoped `.v1` key is orphaned + purged.
 - **Restore last space**: `resolveActiveWorkspace` (`app/src/lib/workspace-switch.ts`)
   restores the persisted `last_workspace_id`, else default, else first.
 

--- a/packages/web/e2e/spaces-gating.spec.ts
+++ b/packages/web/e2e/spaces-gating.spec.ts
@@ -20,21 +20,9 @@ import { expect, test } from "./support/fixtures";
  * rows the C8 workspaces bridge serves at `GET /v1/workspaces`). See
  * `@houston/fake-host` README + `knowledge-base/ui-testing.md`.
  *
- * ── Why the team-space cases are `test.fixme` ─────────────────────────────────
- * The switcher lists whatever `getEngine().listWorkspaces()` returns. In the web
- * engine-adapter that BOTH desktop and web run on
- * (`packages/web/src/engine-adapter/client/workspaces-mixin.ts`), `listWorkspaces`
- * returns a SINGLE hard-coded synthetic personal workspace and never fetches
- * `GET /v1/workspaces` — so the armed team rows the fake host now serves cannot
- * bridge into the switcher, and there is no way (UI switch OR persisted-last +
- * reload via `resolveActiveWorkspace`) to make the active space a team. Both the
- * reload path and the UI path require the team row to be in that list.
- *
- * The fake-host arming (below) is complete and ready. Once the adapter's
- * `listWorkspaces` fetches the C8 workspaces bridge (personal + team rows) in
- * host/CP mode, drop `.fixme` from the three team-space cases — they should pass
- * against the arming as written. Empirically verified today: with the team armed,
- * the switcher dropdown shows only the personal workspace.
+ * The team-space cases drive the REAL switcher UI against the fake host's
+ * armed team rows — live since the adapter's `listWorkspaces` bridges the C8
+ * workspaces surface (HOU-881).
  */
 
 /** A Spaces owner: multiplayer + Teams + Spaces, top role. */
@@ -112,9 +100,6 @@ test("regression: a non-spaces Teams host still shows Admin on the personal work
   await expect(adminNav(page)).toBeVisible();
   await expect(permissionsNav(page)).toBeVisible();
 });
-
-// ── Team-space direction: blocked on the adapter's `listWorkspaces` (see the
-// file header). Remove `.fixme` once the C8 workspaces bridge is wired. ──
 
 test("spaces host: switching to a team space reveals Admin and Permissions", async ({
   page,

--- a/packages/web/src/app-tree.tsx
+++ b/packages/web/src/app-tree.tsx
@@ -13,12 +13,12 @@
  *   I18nextProvider > LanguageGate > DisclaimerGate > App
  */
 
-import App from "@houston/app/App";
 import { AgentFilePreviewHost } from "@houston/app/components/agent-file-preview-host";
 import { DisclaimerGate } from "@houston/app/components/shell/disclaimer-gate";
 import { LanguageGate } from "@houston/app/components/shell/language-gate";
 import { QueryPersistenceProvider } from "@houston/app/components/shell/query-persistence-provider";
 import { WorkspaceLoading } from "@houston/app/components/shell/workspace-loading";
+import { IdentityKeyedApp } from "@houston/app/identity-keyed-app";
 import { analytics, classifyAnalyticsError } from "@houston/app/lib/analytics";
 import { isEngineReady, whenEngineReady } from "@houston/app/lib/engine";
 import { showErrorToast } from "@houston/app/lib/error-toast";
@@ -146,7 +146,7 @@ export default function AppTree() {
                 <PreviewBadge />
                 <LanguageGate>
                   <DisclaimerGate>
-                    <App />
+                    <IdentityKeyedApp />
                     {/* Global workspace-file preview (chat file clicks) —
                         mirrors app/src/main.tsx. */}
                     <AgentFilePreviewHost />

--- a/packages/web/src/engine-adapter/cp/spaces-billing.ts
+++ b/packages/web/src/engine-adapter/cp/spaces-billing.ts
@@ -78,10 +78,13 @@ export async function getMoveStatus(
 
 /**
  * The active team's billing summary. Degrades to `null` for the NOT-ENTITLED
- * cases — a gateway that predates billing (404) and a caller it refuses billing
- * detail (403 `personal_space` or plain member) — so the billing UI renders
- * nothing and the degrade surfaces take over. Every other error throws (mirrors
- * `getAgentModelChoice`'s 404 swallow).
+ * cases — a gateway that predates billing (404), a caller it refuses billing
+ * detail (403 `personal_space` or plain member), and a billing-off deployment
+ * (503 `billing not configured`: no `GW_STRIPE_*` set — every prod gateway with
+ * no Stripe, and the kind loop, run this way) — so the billing UI renders
+ * nothing and the degrade surfaces take over. Every other error throws. Mirrors
+ * the engine-client shim's `getBilling` (same 404/403/503 status set), which is
+ * what keeps the 503 from surfacing the red bug toast on team entry (HOU-904).
  */
 export async function getBilling(
   cfg: ControlPlaneConfig,
@@ -92,7 +95,7 @@ export async function getBilling(
   } catch (err) {
     if (
       err instanceof HoustonEngineError &&
-      (err.status === 404 || err.status === 403)
+      (err.status === 404 || err.status === 403 || err.status === 503)
     ) {
       return null;
     }

--- a/packages/web/tests/billing-degrade.test.ts
+++ b/packages/web/tests/billing-degrade.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { HoustonEngineError } from "../src/engine-adapter/client";
+import { getBilling } from "../src/engine-adapter/control-plane";
+
+/**
+ * `getBilling` on the HOSTED path (C8 §Billing) is the client every cloud build
+ * actually runs — the engine-client shim's `getBilling` only matters to the
+ * legacy client. So the not-entitled degrade has to land HERE: a gateway that
+ * predates billing (404), a caller it refuses billing detail (403), and — the
+ * HOU-904 regression — a billing-OFF deployment (503 `billing not configured`,
+ * every prod gateway with no `GW_STRIPE_*`) all resolve to `null` so the billing
+ * UI renders nothing, instead of throwing and firing the red "Houston, we have a
+ * problem" bug toast on every team entry. Any other status is a real failure and
+ * must throw. Mirrors `catalog-404.test.ts`.
+ */
+
+const CFG = { baseUrl: "https://host.example", token: "t" };
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Stub fetch to answer every call at `status`/`body`, recording the urls hit. */
+function stubFetch(status: number, body: unknown): string[] {
+  const calls: string[] = [];
+  globalThis.fetch = vi.fn(async (input: unknown) => {
+    calls.push(String(input));
+    return json(status, body);
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+const BILLING = { plan: "team", status: "trialing", seats: 3 };
+
+test("getBilling() hits /v1/org/billing and returns the parsed summary on 200", async () => {
+  const calls = stubFetch(200, BILLING);
+  await expect(getBilling(CFG)).resolves.toEqual(BILLING);
+  expect(calls).toEqual(["https://host.example/v1/org/billing"]);
+});
+
+test("getBilling() degrades a 404 (host predates billing) to null", async () => {
+  stubFetch(404, { error: "no route" });
+  await expect(getBilling(CFG)).resolves.toBeNull();
+});
+
+test("getBilling() degrades a 403 (personal space / plain member) to null", async () => {
+  stubFetch(403, { error: "personal_space" });
+  await expect(getBilling(CFG)).resolves.toBeNull();
+});
+
+test("getBilling() degrades a 503 (billing not configured) to null — HOU-904", async () => {
+  // 503 is transient for reads, so cpFetch blind-retries twice before the error
+  // surfaces to the degrade; fake timers fast-forward those waits.
+  vi.useFakeTimers();
+  const calls = stubFetch(503, { error: "billing not configured" });
+  const p = getBilling(CFG);
+  await vi.runAllTimersAsync();
+  await expect(p).resolves.toBeNull();
+  expect(calls.length).toBe(3); // initial + two transient retries, then degrade
+});
+
+test("getBilling() does NOT degrade a non-404/403/503 error (throws)", async () => {
+  stubFetch(500, { error: "boom" });
+  await expect(getBilling(CFG)).rejects.toThrow(HoustonEngineError);
+});


### PR DESCRIPTION
## What

Five bugs from Felipe's first real multiplayer test in prod (all root-caused from prod gateway logs + code traces), one wave:

- **HOU-903 — identity leak on account switch.** `signOut()` never reset in-memory state, so the next account rendered the previous account's cached world (gateway verified safe — hard `403 not_member`; this was client memory). Now: `resetForIdentityChange()` on sign-out + any uid change (query cache clear, 5 store resets, active-org unpin), AND the App subtree is keyed by session uid (`IdentityKeyedApp`) so identity changes remount + re-bootstrap in **every** deployment mode — the adversarial review caught that the hosted-oauth gate's unmount didn't cover dev/self-host/sidecar builds, and the key closes the in-place A→B path too.
- **HOU-904 — red toast on team entry.** Adapter `getBilling` degrades `503 billing not configured` → null (parity with the legacy client). Kills the retry-storm + toast on every Stripe-less gateway (= prod today).
- **HOU-905 — stranded in Settings.** Create-team lands you on the new team's dashboard; the toast's "Invite your team" action still deep-links Admin.
- **HOU-906 — personal connections shown inside teams.** Provider-status localStorage cache is per-space now (legacy unscoped key purged), re-seeds + re-probes on every switch, gated on the new space's agents settling so the probe can't hit the old space's agent under the new org header. `share-via-team`'s switch step now settles agents like every other switch path (review finding).
- **HOU-907 — blank app on space switch.** Boot splash latched to first boot; user-scoped query roots (session, onboarding) survive the switch purge; the shell stays mounted and panes fill with their own loading states. Query keys centralized in `query-keys.ts`.

Adversarial review pass over the combined diff: 3 findings, all fixed in this PR (App keying, share-via-team agent settling); all other categories clean.

## Verification

Biome, app tsgo, check-locales, **1995 app unit tests** (new: identity-change decision, store resets, per-scope provider cache, space-cache preservation, billing degrade), web typecheck + shim parity, Playwright `spaces-gating` + `permissions` **12/12** (task-private ports). KB updated (`teams.md` switcher section, `auth.md` sign-out reset).

Fixes HOU-903
Fixes HOU-904
Fixes HOU-905
Fixes HOU-906
Fixes HOU-907

🤖 Generated with [Claude Code](https://claude.com/claude-code)