### PR TITLE
fix(runtime): resume a renamed agent's conversations — relocate the transcript, retry fresh as last resort (HOU-892)

### DIFF
--- a/packages/runtime/src/backends/claude/backend.ts
+++ b/packages/runtime/src/backends/claude/backend.ts
@@ -129,7 +129,7 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
         query,
         conversationId: opts.conversationId,
         baseOptions,
-        sessionsStore: createSessionsStore(deps.dataDir),
+        sessionsStore: createSessionsStore(deps.dataDir, deps.workspaceDir),
         model: toSdkModel(opts.model.id),
         thinkingLevel: opts.thinkingLevel,
       });

--- a/packages/runtime/src/backends/claude/session.test.ts
+++ b/packages/runtime/src/backends/claude/session.test.ts
@@ -274,6 +274,55 @@ test("no resume id → the option is omitted (fresh session)", async () => {
   expect(captured && "resume" in captured).toBe(false);
 });
 
+test("a resume the SDK rejects as unknown retries fresh: mapping dropped, no phantom error (HOU-892)", async () => {
+  // After an agent rename the transcript survives under the OLD cwd slug, so
+  // resolveResume still hands out the id but the SDK's cwd-scoped lookup
+  // rejects it — without the retry, every future turn of the conversation
+  // errors permanently (observed live: a weekly routine failing on every fire).
+  const store = fakeStore("sess-gone");
+  const removed: string[] = [];
+  store.remove = (c) => {
+    removed.push(c);
+  };
+  const optionsSeen: Options[] = [];
+  let call = 0;
+  const query: ClaudeQuery = (params) => {
+    optionsSeen.push(params.options);
+    call++;
+    if (call === 1)
+      return throwingQuery(
+        new Error("No conversation found with session ID: sess-gone"),
+      )(params);
+    return arrayQuery([textMsg("recovered", "sess-new"), usageMsg("sess-new")])(
+      params,
+    );
+  };
+  const session = make({ query, store });
+  const events: WireEvent[] = [];
+  session.subscribe((e) => events.push(e));
+  await session.prompt("go");
+
+  expect(removed).toEqual(["c1"]); // stale mapping dropped
+  expect(optionsSeen[0]?.resume).toBe("sess-gone");
+  expect(optionsSeen[1] && "resume" in optionsSeen[1]).toBe(false); // fresh retry
+  expect(events.some((e) => e.type === "provider_error")).toBe(false);
+  expect(events.some((e) => e.type === "text")).toBe(true);
+  expect(store.setCalls).toContainEqual(["c1", "sess-new"]);
+});
+
+test("the same SDK error WITHOUT a resume surfaces normally (no retry loop)", async () => {
+  const session = make({
+    query: throwingQuery(
+      new Error("No conversation found with session ID: whatever"),
+    ),
+    store: fakeStore(undefined),
+  });
+  const events: WireEvent[] = [];
+  session.subscribe((e) => events.push(e));
+  await session.prompt("go");
+  expect(events.some((e) => e.type === "provider_error")).toBe(true);
+});
+
 test("the captured session_id is persisted after the turn", async () => {
   const store = fakeStore();
   const session = make({

--- a/packages/runtime/src/backends/claude/session.ts
+++ b/packages/runtime/src/backends/claude/session.ts
@@ -33,6 +33,18 @@ const errMessage = (err: unknown): string =>
   err instanceof Error ? err.message : String(err);
 
 /**
+ * The SDK's rejection of a `resume` id it cannot find. `resolveResume` already
+ * drops mappings whose transcript file is gone, but the SDK scopes its lookup
+ * to the CURRENT cwd's project slug — after an agent rename moves the
+ * workspace directory, the transcript still exists (old slug) yet every resume
+ * fails with this error, permanently wedging the conversation (HOU-892 side
+ * finding: a weekly routine erroring on every fire after its agent was
+ * renamed). Matched on the message because the SDK surfaces it both as a
+ * thrown error and as an error result.
+ */
+const DANGLING_RESUME_RE = /No conversation found with session ID/i;
+
+/**
  * The Claude Agent SDK implementation of `HarnessSession`. `prompt` runs one
  * `query()` to completion, translating SDK messages into the pi wire dialect
  * (text/thinking/tool_start/tool_end/usage/provider_error) — never `done`, which
@@ -68,13 +80,36 @@ export class ClaudeSession implements HarnessSession {
 
   async prompt(text: string): Promise<void> {
     if (this.disposed) return;
+    const resume = this.deps.sessionsStore.resolveResume(
+      this.deps.conversationId,
+    );
+    const outcome = await this.runAttempt(text, resume);
+    if (outcome !== "retry-fresh") return;
+    // The SDK refused the resume id (its cwd-scoped lookup missed the
+    // transcript — e.g. the workspace was renamed). The stale mapping is
+    // already dropped; run the turn once more as a fresh session instead of
+    // erroring a conversation that can never resume again.
+    console.warn(
+      `[claude] resume for conversation ${this.deps.conversationId} was rejected by the SDK; starting a fresh session`,
+    );
+    await this.runAttempt(text, undefined);
+  }
+
+  /**
+   * One `query()` to completion. Returns "retry-fresh" ONLY when a resume was
+   * attempted and the SDK rejected the session id as unknown — the caller then
+   * reruns without resume; every wire event of the failed attempt is
+   * suppressed, so the user sees one clean turn, not an error + a retry. Any
+   * other outcome (success, abort, real provider failure) returns "done".
+   */
+  private async runAttempt(
+    text: string,
+    resume: string | undefined,
+  ): Promise<"done" | "retry-fresh"> {
     this.aborting = false;
     const abortController = new AbortController();
     this.abortController = abortController;
 
-    const resume = this.deps.sessionsStore.resolveResume(
-      this.deps.conversationId,
-    );
     const effort = this.thinkingLevel
       ? toSdkEffort(this.thinkingLevel)
       : undefined;
@@ -96,12 +131,24 @@ export class ClaudeSession implements HarnessSession {
     // throw-AFTER-error-result — the SDK routinely rejects the iterator right
     // after yielding an error `result` — is not reported a SECOND time.
     let providerErrored = false;
+    const danglingResume = (message: string): boolean =>
+      resume !== undefined && DANGLING_RESUME_RE.test(message);
     try {
       for await (const msg of this.deps.query({ prompt: text, options })) {
         if (this.aborting) break;
         if (hasSessionId(msg)) capturedSessionId = msg.session_id;
         for (const wire of translator.translate(msg)) {
-          if (wire.type === "provider_error") providerErrored = true;
+          if (wire.type === "provider_error") {
+            const errText =
+              wire.data.kind === "unknown"
+                ? wire.data.raw_excerpt
+                : wire.data.message;
+            if (danglingResume(errText)) {
+              this.deps.sessionsStore.remove(this.deps.conversationId);
+              return "retry-fresh";
+            }
+            providerErrored = true;
+          }
           this.emit(wire);
         }
       }
@@ -112,10 +159,14 @@ export class ClaudeSession implements HarnessSession {
       // state (not `instanceof AbortError`) deliberately: importing the SDK's
       // error class at module load would eager-load the 250 MB optional binary
       // into every non-Anthropic process.
-      if (this.aborting) return;
+      if (this.aborting) return "done";
       // The typed failure already rode the stream as a provider_error; the trailing
       // throw is just the SDK closing the iterator — don't re-report it.
-      if (providerErrored) return;
+      if (providerErrored) return "done";
+      if (danglingResume(errMessage(err))) {
+        this.deps.sessionsStore.remove(this.deps.conversationId);
+        return "retry-fresh";
+      }
       // Any other throw is an unexpected transport failure: surface it as a
       // typed provider_error rather than rethrow, so the turn never dies silently.
       this.emit({
@@ -129,6 +180,7 @@ export class ClaudeSession implements HarnessSession {
           capturedSessionId,
         );
     }
+    return "done";
   }
 
   async abort(): Promise<void> {

--- a/packages/runtime/src/backends/claude/sessions-store.test.ts
+++ b/packages/runtime/src/backends/claude/sessions-store.test.ts
@@ -109,6 +109,51 @@ test("a corrupt sessions.json degrades to empty rather than throwing", () => {
   expect(createSessionsStore(dir).getSessionId("c1")).toBeUndefined();
 });
 
+test("a transcript stranded under a stale cwd slug is relocated so the SDK can resume it (HOU-892)", () => {
+  // The agent was renamed: the workspace cwd changed, so the SDK's cwd-scoped
+  // resume lookup misses the transcript written under the OLD slug. resolveResume
+  // must move it into the CURRENT cwd's slug dir — preserving the conversation —
+  // rather than declaring it resumable and letting the SDK reject the id.
+  const cwd = "/ws/Personal/new name";
+  const store = createSessionsStore(dataDir(), cwd);
+  store.setSessionId("c1", "sess-1");
+  writeTranscript("sess-1"); // lands under the unrelated "proj" slug dir
+
+  expect(store.resolveResume("c1")).toBe("sess-1");
+
+  const slugDir = join(claudeProjectsDir(), "-ws-Personal-new-name");
+  expect(existsSync(join(slugDir, "sess-1.jsonl"))).toBe(true);
+  expect(existsSync(join(claudeProjectsDir(), "proj", "sess-1.jsonl"))).toBe(
+    false,
+  );
+  // Mapping survives — the next turn resumes normally with zero moves.
+  expect(store.getSessionId("c1")).toBe("sess-1");
+  expect(store.resolveResume("c1")).toBe("sess-1");
+});
+
+test("a transcript already under the current cwd slug is returned without moving", () => {
+  const cwd = "/ws/Personal/agent";
+  const store = createSessionsStore(dataDir(), cwd);
+  store.setSessionId("c1", "sess-1");
+  const slugDir = join(claudeProjectsDir(), "-ws-Personal-agent");
+  mkdirSync(slugDir, { recursive: true });
+  writeFileSync(join(slugDir, "sess-1.jsonl"), "{}");
+
+  expect(store.resolveResume("c1")).toBe("sess-1");
+  expect(existsSync(join(slugDir, "sess-1.jsonl"))).toBe(true);
+});
+
+test("without a cwd (purge-only store) resolveResume never relocates", () => {
+  const store = createSessionsStore(dataDir());
+  store.setSessionId("c1", "sess-1");
+  writeTranscript("sess-1");
+  expect(store.resolveResume("c1")).toBe("sess-1");
+  // Untouched in place.
+  expect(existsSync(join(claudeProjectsDir(), "proj", "sess-1.jsonl"))).toBe(
+    true,
+  );
+});
+
 test("two agents' transcripts under the shared projects dir don't collide", () => {
   // Different per-agent data dirs, DIFFERENT session ids → each resolves only
   // its own transcript even though the projects tree is shared.

--- a/packages/runtime/src/backends/claude/sessions-store.ts
+++ b/packages/runtime/src/backends/claude/sessions-store.ts
@@ -7,7 +7,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { claudeBaseDir, claudeProjectsDir, claudeSessionsFile } from "./paths";
 
 // NOTE on isolation: `sessions.json` (the conversationId → session_id map) lives
@@ -25,11 +25,15 @@ import { claudeBaseDir, claudeProjectsDir, claudeSessionsFile } from "./paths";
  * (same discipline as `auth/auth-file.ts`) since it sits beside credential data.
  *
  * The SDK writes each session's transcript JSONL under the SHARED config dir
- * (`<claudeLoginConfigDir>/projects/<cwd-slug>/<session_id>.jsonl`). If
- * that transcript is gone (config dir wiped) a resume would fail, so
- * `resolveResume` verifies the transcript exists by its known filename — no
- * fragile reconstruction of the SDK's project-slug scheme — and drops the dangling
- * mapping so we neither resume into nothing nor warn on every subsequent turn.
+ * (`<claudeLoginConfigDir>/projects/<cwd-slug>/<session_id>.jsonl`), and its
+ * `resume` looks the id up ONLY under the CURRENT cwd's slug. So
+ * `resolveResume` locates the transcript by its known filename and, when it
+ * sits under another slug dir (the agent was renamed, which moved the
+ * workspace cwd — HOU-892), RELOCATES it into the current cwd's slug dir so
+ * the SDK resumes the conversation with its context intact. A transcript
+ * that is gone entirely (config dir wiped), or that cannot be relocated,
+ * drops the dangling mapping so we neither resume into nothing nor warn on
+ * every subsequent turn — the session then starts fresh.
  */
 export interface SessionsStore {
   /** The stored SDK session id for a conversation, if any. */
@@ -49,10 +53,21 @@ export interface SessionsStore {
   resolveResume(conversationId: string): string | undefined;
 }
 
-export function createSessionsStore(dataDir: string): SessionsStore {
+/**
+ * @param cwd The agent's working directory (the SDK session cwd). When given,
+ * `resolveResume` can relocate a transcript stranded under a stale cwd slug;
+ * without it (e.g. the purge-only cleanup path) relocation is skipped.
+ */
+export function createSessionsStore(
+  dataDir: string,
+  cwd?: string,
+): SessionsStore {
   const baseDir = claudeBaseDir(dataDir);
   const filePath = claudeSessionsFile(dataDir);
   const projectsDir = claudeProjectsDir();
+  const currentSlugDir = cwd
+    ? join(projectsDir, sdkProjectSlug(cwd))
+    : undefined;
 
   function read(): Record<string, string> {
     if (!existsSync(filePath)) return {};
@@ -99,25 +114,65 @@ export function createSessionsStore(dataDir: string): SessionsStore {
     resolveResume(conversationId) {
       const sessionId = read()[conversationId];
       if (!sessionId) return undefined;
-      if (transcriptExists(projectsDir, sessionId)) return sessionId;
-      console.warn(
-        `[claude] transcript for conversation ${conversationId} (session ${sessionId}) is missing; starting a fresh session`,
-      );
-      remove(conversationId);
-      return undefined;
+      const located = locateTranscript(projectsDir, sessionId);
+      if (!located) {
+        console.warn(
+          `[claude] transcript for conversation ${conversationId} (session ${sessionId}) is missing; starting a fresh session`,
+        );
+        remove(conversationId);
+        return undefined;
+      }
+      // The SDK resolves `resume` only under the CURRENT cwd's slug dir. A
+      // transcript that sits anywhere else (the agent was renamed → new cwd →
+      // new slug) is moved home so the conversation continues with its
+      // context, instead of the SDK rejecting the id.
+      if (currentSlugDir && dirname(located) !== currentSlugDir) {
+        try {
+          mkdirSync(currentSlugDir, { recursive: true });
+          renameSync(located, join(currentSlugDir, `${sessionId}.jsonl`));
+          console.warn(
+            `[claude] relocated transcript for conversation ${conversationId} (session ${sessionId}) to the current workspace slug`,
+          );
+        } catch (err) {
+          console.warn(
+            `[claude] could not relocate transcript for conversation ${conversationId} (session ${sessionId}); starting a fresh session`,
+            err,
+          );
+          remove(conversationId);
+          return undefined;
+        }
+      }
+      return sessionId;
     },
   };
 }
 
-/** Whether a `<sessionId>.jsonl` transcript exists anywhere under `projectsDir`. */
-function transcriptExists(projectsDir: string, sessionId: string): boolean {
-  if (!existsSync(projectsDir)) return false;
+/**
+ * The SDK's project-slug scheme: the session cwd with every non-alphanumeric
+ * character replaced by `-` (verified against the dirs the SDK writes, e.g.
+ * `/Users/x/.h/ws/Agent 3` → `-Users-x--h-ws-Agent-3`). If the SDK ever
+ * changes the scheme, relocation targets a dir it ignores and resume fails —
+ * which the session-level fresh-retry (session.ts) then absorbs, so drift
+ * degrades to today's start-fresh behavior, never a wedge.
+ */
+function sdkProjectSlug(cwd: string): string {
+  return cwd.replace(/[^A-Za-z0-9]/g, "-");
+}
+
+/** The full path of a `<sessionId>.jsonl` transcript under `projectsDir`, if any. */
+function locateTranscript(
+  projectsDir: string,
+  sessionId: string,
+): string | undefined {
+  if (!existsSync(projectsDir)) return undefined;
   const file = `${sessionId}.jsonl`;
-  if (existsSync(join(projectsDir, file))) return true;
+  const top = join(projectsDir, file);
+  if (existsSync(top)) return top;
   for (const entry of readdirSync(projectsDir)) {
-    if (existsSync(join(projectsDir, entry, file))) return true;
+    const nested = join(projectsDir, entry, file);
+    if (existsSync(nested)) return nested;
   }
-  return false;
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #1079, from the HOU-892 verification sweep: renaming an agent permanently broke every Claude conversation resume on that agent.

**Root cause.** The Claude Agent SDK stores each session's transcript under `<CLAUDE_CONFIG_DIR>/projects/<cwd-slug>/<session_id>.jsonl` and resolves `resume` ONLY under the CURRENT cwd's slug. Renaming an agent moves the workspace directory (new cwd → new slug): the transcript survives under the old slug, `resolveResume`'s slug-agnostic existence check passes, and every resume fails with `No conversation found with session ID: <id>` — forever, because nothing drops or heals the stale mapping.

**Observed live (prod):** agent "Book2" renamed to "this is new book"; its `weekly-runway-refresh` routine surfaced fine Jul 17/20, then errored Jul 24 with exactly that message, and would fail every weekly fire from then on.

## Fix (two layers)

1. **Relocate, preserving the conversation** (`sessions-store.ts`): `resolveResume` now locates the transcript by filename and, when it sits under another slug dir, MOVES it into the current cwd's slug dir before handing out the resume id — the SDK continues the conversation with its history intact. The slug scheme (every non-alphanumeric char → `-`) is verified against the dirs the SDK actually writes.
2. **Fresh-session retry as last resort** (`session.ts`): when a resume is still rejected by the SDK (transcript truly gone, relocation failed, or slug-scheme drift), drop the stale mapping and rerun the turn once as a fresh session, suppressing the failed attempt's error frame. The same error without a resume surfaces normally — no retry loop by construction.

Layer 2 guarantees drift in the SDK's slug scheme degrades to start-fresh, never a permanent wedge; layer 1 makes the common rename case lossless.

## Verification

**Repro (before):** chat with a Claude-provider agent (or let a routine run) → rename the agent → next turn/fire errors with `No conversation found with session ID` and keeps erroring forever.

**After:** the next turn logs `[claude] relocated transcript … to the current workspace slug`, resumes with full context, and subsequent turns resume with zero moves. If the transcript is gone entirely, the turn completes as a clean fresh session instead of erroring.

Tests: relocation (stranded → moved home → resumes; already-home → untouched; no-cwd store → never relocates) + retry-fresh cases; `pnpm --filter @houston/runtime test` 785 passed; Biome + workspace typecheck clean.