### PR TITLE
fix: how-it-works heading joins the left column (full two-side split)

### DIFF
--- a/website/src/_includes/landing/how.njk
+++ b/website/src/_includes/landing/how.njk
@@ -1,12 +1,12 @@
 {% from "houston-logo.njk" import houstonLogo %}
 <section id="features" class="section is-panel">
-  <div class="hiw-head reveal">
-    <div class="eyebrow-mono" style="justify-content:center">How it works</div>
-    <h2 class="sec-title">You ask. Your agent does it.</h2>
-  </div>
-
-  <div class="feature-row reveal reveal-d1">
+  <div class="feature-row reveal">
     <div class="hiw-left">
+      <div class="hiw-head">
+        <div class="eyebrow-mono">How it works</div>
+        <h2 class="sec-title">You ask. Your agent does it.</h2>
+      </div>
+
       <div class="hiw-tabs">
         <button class="hiw-tab active" data-agent="0">Personal Assistant</button>
         <button class="hiw-tab" data-agent="1">Bookkeeper</button>

--- a/website/src/assets/css/landing-body.css
+++ b/website/src/assets/css/landing-body.css
@@ -138,16 +138,18 @@
 #features.section {
   padding-block: clamp(44px, 5vw, 64px);
 }
+/* Heading lives inside the left column: full two-side split. */
 .hiw-head {
-  text-align: center;
-  margin-bottom: 8px;
+  text-align: left;
+  margin-bottom: 4px;
 }
 .hiw-head .eyebrow-mono {
   margin-bottom: 14px;
+  justify-content: flex-start;
 }
 .hiw-head .sec-title {
   max-width: none;
-  margin: 0 auto;
+  margin: 0;
 }
 .hiw-tabs {
   display: flex;
@@ -191,7 +193,6 @@
   grid-template-columns: 1.05fr 0.95fr;
   gap: clamp(32px, 5vw, 60px);
   align-items: center;
-  margin-top: 24px;
 }
 .hiw-left {
   display: flex;


### PR DESCRIPTION
Follow-up layout tweak to the #features section per Julian: the section heading ("How it works" + "You ask. Your agent does it.") moves inside the left column above the tabs and steps, making the section a clean two-side split with the phone on the right. Verified at 1440 and 390 (stacks correctly).

No new Linear issue — small follow-up to the HOU-913 layout change shipped in #1093.

🤖 Generated with [Claude Code](https://claude.com/claude-code)