### PR TITLE
fix: restore Windows download path for non-Windows visitors

### DIFF
--- a/website/src/_includes/landing/footer.njk
+++ b/website/src/_includes/landing/footer.njk
@@ -5,6 +5,10 @@
         <a class="lnav-brand" href="/">Houston</a>
         <p>AI agents that do the work for you. One free desktop app that runs on the ChatGPT or Claude plan you already pay for.</p>
         <button class="btn btn-ghost btn-sm" data-dl-trigger data-dl-source="footer">Download</button>
+        <p class="dl-os-links">
+          <button class="dl-os-link" data-dl-trigger data-dl-source="footer-os" data-dl-os="mac">macOS</button> ·
+          <button class="dl-os-link" data-dl-trigger data-dl-source="footer-os" data-dl-os="windows">Windows</button>
+        </p>
       </div>
       <div class="lfoot-col">
         <h4>Product</h4>

--- a/website/src/_includes/landing/pricing.njk
+++ b/website/src/_includes/landing/pricing.njk
@@ -11,6 +11,10 @@
       <div class="price-note"></div>
       <p class="price-desc">Runs on your computer. Bring your own GPT subscription.</p>
       <div class="price-cta"><button class="btn btn-outline" data-dl-trigger data-dl-source="pricing">Download App</button></div>
+      <p class="dl-os-links">Available for
+        <button class="dl-os-link" data-dl-trigger data-dl-source="pricing-os" data-dl-os="mac">macOS</button> and
+        <button class="dl-os-link" data-dl-trigger data-dl-source="pricing-os" data-dl-os="windows">Windows</button>.
+      </p>
       <div class="price-list-intro">Everything you need:</div>
       <ul class="price-feats">
         <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>Unlimited agents, every feature included</li>

--- a/website/src/assets/css/landing.css
+++ b/website/src/assets/css/landing.css
@@ -387,3 +387,35 @@ img {
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Explicit per-OS download triggers (HOU-919) ──────────────────────────
+   The gate script routes [data-dl-trigger] by data-dl-os (else detectOs),
+   but v3 dropped every pinned trigger — non-Windows visitors had no path to
+   the Windows installer. These quiet text links restore both directions. */
+.dl-os-links {
+  margin-top: 10px;
+  font-size: 12.5px;
+  color: var(--ink-subtle);
+}
+.dl-os-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--ink-muted);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+.dl-os-link:hover {
+  color: var(--ink-strong);
+}
+.lfoot .dl-os-links {
+  color: var(--on-ink-faint);
+}
+.lfoot .dl-os-link {
+  color: var(--on-ink-muted);
+}
+.lfoot .dl-os-link:hover {
+  color: var(--on-ink);
+}


### PR DESCRIPTION
## Bug (HOU-919, urgent)
Julian: "the download button is not working for windows." Live diagnosis: the Windows flow works under a Windows UA (modal → code unlock → real `Houston_0.5.28_x64_en-US.msi` download, arm64 asset present) — but landing v3 (#1088) deleted `cta.njk` and with it every pinned `data-dl-os` trigger, so **non-Windows visitors have no path to the Windows installer at all**. The gate script's pinned-trigger support survived; no markup used it.

## Fix (markup + a few CSS lines)
Quiet "Available for **macOS** and **Windows**" text triggers under the pricing Download App button and the footer Download button, each pinning its modal via `data-dl-trigger data-dl-os`. New analytics sources `pricing-os` / `footer-os` flow through the existing `track()` payloads unchanged.

## Verification (local build, Mac UA)
Both Windows links open the Windows modal; invite code enables the x64 button with the real MSI href; macOS link opens the Mac modal; Escape/overlay close intact; zero console errors; build clean, subpages unchanged.

Fixes HOU-919

🤖 Generated with [Claude Code](https://claude.com/claude-code)