### PR TITLE
feat: merge the connect flow into the row as one card (HOU-847 follow-up)

### DIFF
--- a/app/src/components/integrations-view/plane-app-row.tsx
+++ b/app/src/components/integrations-view/plane-app-row.tsx
@@ -5,6 +5,7 @@ import {
   AppLogo,
   type ConnectFlow,
   ConnectFlowInline,
+  hasConnectState,
 } from "../integrations";
 
 /**
@@ -14,16 +15,24 @@ import {
  * The row BODY opens the app's "more info" modal (`onOpen`); only the `+`
  * connects.
  *
- * The row OWNS its connect state. While THIS app connects the `+` spins and the
- * row expands underneath with the live phase ({@link ConnectFlowInline}: opening
- * the browser, then the waiting copy and its recovery actions, then the
- * outcome), so the feedback sits exactly where the user clicked. Every OTHER row
- * stays fully enabled at full strength: connects are per toolkit and concurrent,
- * so handing off Slack must never lock the user out of Notion.
+ * The row OWNS its connect state, and while it does it stops being a flat row:
+ * the header and the live flow ({@link ConnectFlowInline}) are enclosed by ONE
+ * card, so the hand-off reads as this app's own surface rather than a panel
+ * floating loose underneath it. The card carries exactly one spinner — the `+`
+ * slot's, where the user just clicked — so the flow copy below adds words, not
+ * a second thing turning. Every OTHER row stays fully enabled at full strength:
+ * connects are per toolkit and concurrent, so handing off Slack must never lock
+ * the user out of Notion.
  *
  * The catalog renders some apps twice (the "Most used" spotlight repeats
- * category rows), so only the copy that `owns` the flow expands; the duplicate
- * keeps the spinning `+` — one app, one panel, on the row that was pressed.
+ * category rows), so only the copy that `owns` the flow becomes a card; the
+ * duplicate stays a flat row with its compact spinning `+` — one app, one card,
+ * on the row that was pressed.
+ *
+ * At rest nothing about the row changes: the card's border and fill live on
+ * their own layer behind the row, transparent until the flow starts, so the
+ * catalog keeps its flat transparent-row language and the treatment can
+ * cross-fade on opacity alone.
  */
 export function PlaneAppRow({
   display,
@@ -41,29 +50,48 @@ export function PlaneAppRow({
 }) {
   const { t } = useTranslation("integrations");
   const connecting = display.toolkit in connectFlow.states;
+  const carded = owns && hasConnectState(connectFlow, display.toolkit);
   return (
-    <div>
-      <CatalogRow
-        icon={<AppLogo display={display} size="lg" className="rounded-lg" />}
-        title={display.name}
-        description={display.description}
-        onClick={onOpen}
-        action={
-          <CatalogAddButton
-            label={t("home.connectApp", { name: display.name })}
-            busy={connecting}
-            onClick={onConnect}
+    <div className="relative">
+      <span
+        aria-hidden
+        data-live={carded}
+        className="connect-card-frame pointer-events-none absolute inset-0 rounded-xl border border-line bg-input"
+      />
+      <div className="relative">
+        <CatalogRow
+          // Square bottom while carded: the hover fill then stops on a straight
+          // line that reads as the card's header divider, never as a stray
+          // rounded box floating mid-card.
+          className={carded ? "rounded-b-none" : undefined}
+          icon={<AppLogo display={display} size="lg" className="rounded-lg" />}
+          title={display.name}
+          description={display.description}
+          onClick={onOpen}
+          action={
+            <CatalogAddButton
+              // The button's default hover fill IS the card's own surface, so
+              // inside the card it would hover into nothing.
+              className={carded ? "hover:bg-chip focus-visible:bg-chip" : ""}
+              label={t("home.connectApp", { name: display.name })}
+              busy={connecting}
+              onClick={onConnect}
+            />
+          }
+        />
+        {carded && (
+          <ConnectFlowInline
+            appName={display.name}
+            // The row's own rhythm continued: 12px side gutters (its `px-3`)
+            // and the 10px it already leaves under itself, so the card's
+            // padding is even top to bottom.
+            className="connect-card-body px-3 pt-0.5 pb-2.5"
+            connectFlow={connectFlow}
+            toolkit={display.toolkit}
+            variant="bare"
           />
-        }
-      />
-      {/* Indented to the row's text column so the state reads as this row's. */}
-      <ConnectFlowInline
-        appName={display.name}
-        className="mt-1 mb-2 ml-16 mr-3"
-        connectFlow={connectFlow}
-        toolkit={display.toolkit}
-        owns={owns}
-      />
+        )}
+      </div>
     </div>
   );
 }

--- a/app/src/components/integrations/connect-flow-inline.tsx
+++ b/app/src/components/integrations/connect-flow-inline.tsx
@@ -4,8 +4,33 @@ import type { ConnectFlow } from "./connect-flow-registry";
 import { ConnectNoticeLine, NoticeLine } from "./connect-notice-line";
 
 /**
- * ONE app's connect state, rendered INLINE where the user started it — under
- * the catalog row whose `+` they pressed, under the recovery row's identity
+ * How the block dresses itself.
+ *  - `"panel"` — its own bordered `input`-surface box with a leading spinner.
+ *    For the surfaces that host the block ALONE (the recovery callout, the
+ *    routine intake), where nothing around it reports the hand-off.
+ *  - `"bare"` — no box and no spinner of its own. For the catalog row, whose
+ *    WHOLE row becomes the card and whose `+` slot carries the one spinner: a
+ *    second frame inside that card, and a second spinner under the first, are
+ *    the same news told twice.
+ */
+export type ConnectFlowVariant = "panel" | "bare";
+
+/**
+ * Does this toolkit have anything for {@link ConnectFlowInline} to show — a
+ * live phase, or an outcome still inside its expiry window? A surface that
+ * DRESSES the block (the catalog row becomes a card around it) asks first, so
+ * the chrome and the content appear and leave as one.
+ */
+export function hasConnectState(
+  connectFlow: ConnectFlow,
+  toolkit: string,
+): boolean {
+  return toolkit in connectFlow.states || toolkit in connectFlow.notices;
+}
+
+/**
+ * ONE app's connect state, rendered INLINE where the user started it — inside
+ * the catalog card the pressed row became, under the recovery row's identity
  * line, under the intake's connect prompt. It is the only "we are connecting"
  * surface: there is no page-level banner, so nothing the user is reading ever
  * jumps to make room for feedback about a row far above it.
@@ -25,13 +50,17 @@ import { ConnectNoticeLine, NoticeLine } from "./connect-notice-line";
  * The whole block is a polite live region, so the starting -> waiting ->
  * settled progression is announced without stealing focus. Renders nothing
  * when this toolkit has no live flow and no fresh outcome.
+ *
+ * WHICH copy of a repeated app shows it is the host surface's call, not this
+ * component's: the catalog decides by origin key and simply does not render the
+ * block on the copies that did not start the flow.
  */
 export function ConnectFlowInline({
   toolkit,
   appName,
   connectFlow,
   className,
-  owns = true,
+  variant = "panel",
 }: {
   /** The toolkit this block reports on; its actions address that flow only. */
   toolkit: string;
@@ -39,20 +68,13 @@ export function ConnectFlowInline({
   appName: string;
   connectFlow: ConnectFlow;
   className?: string;
-  /**
-   * Whether THIS row is the one that shows the state. A surface that renders
-   * the same app more than once (the catalog's "Most used" spotlight repeats
-   * category rows) passes `false` on every copy that did not start the flow, so
-   * the panel — and its live region — exists exactly once. Surfaces with a
-   * single row per app leave it at the default.
-   */
-  owns?: boolean;
+  variant?: ConnectFlowVariant;
 }) {
   const { t } = useTranslation("integrations");
   const step = connectFlow.states[toolkit];
   const notice = connectFlow.notices[toolkit];
 
-  if (!owns || (!step && !notice)) return null;
+  if (!step && !notice) return null;
 
   return (
     <div
@@ -61,13 +83,20 @@ export function ConnectFlowInline({
       className={cn("text-[13px]", className)}
     >
       {step === "waiting" ? (
-        <WaitingPanel
+        <WaitingBlock
           appName={appName}
           toolkit={toolkit}
           connectFlow={connectFlow}
+          variant={variant}
         />
       ) : step === "starting" ? (
-        <NoticeLine icon={<Spinner className="size-3.5" />} tone="muted">
+        <NoticeLine
+          // `bare` sits in a card whose `+` slot is already spinning.
+          icon={
+            variant === "panel" ? <Spinner className="size-3.5" /> : undefined
+          }
+          tone="muted"
+        >
           {t("waiting.opening", { app: appName })}
         </NoticeLine>
       ) : notice ? (
@@ -79,35 +108,52 @@ export function ConnectFlowInline({
 
 /**
  * The waiting step's compact expansion: the browser hand-off explained, plus
- * the three recovery actions. Same quiet input-surface panel language as the
- * pending-connection recovery callout, so an interrupted OAuth reads the same
- * whether the user is still in the flow or comes back to it later.
+ * the three recovery actions. As a `panel` it wears the same quiet
+ * input-surface box as the pending-connection recovery callout, so an
+ * interrupted OAuth reads the same whether the user is still in the flow or
+ * comes back to it later; as `bare` it is already inside the catalog row's own
+ * card and brings no frame and no spinner of its own.
  */
-function WaitingPanel({
+function WaitingBlock({
   appName,
   toolkit,
   connectFlow,
+  variant,
 }: {
   appName: string;
   toolkit: string;
   connectFlow: ConnectFlow;
+  variant: ConnectFlowVariant;
 }) {
   const { t } = useTranslation("integrations");
+  const copy = (
+    <>
+      <p className="font-medium text-ink">
+        {t("waiting.title", { app: appName })}
+      </p>
+      {/* The body names the app too: it was shipping the raw "{{app}}"
+          placeholder, because the old panel never passed the value in. */}
+      <p className="mt-0.5 text-ink-muted text-xs">
+        {t("waiting.body", { app: appName })}
+      </p>
+    </>
+  );
   return (
-    <div className="rounded-xl border border-line bg-input p-3">
-      <div className="flex items-start gap-2.5">
-        <Spinner className="mt-0.5 size-4 text-ink-muted" />
-        <div className="min-w-0 flex-1">
-          <p className="font-medium text-ink">
-            {t("waiting.title", { app: appName })}
-          </p>
-          {/* The body names the app too: it was shipping the raw "{{app}}"
-              placeholder, because the old panel never passed the value in. */}
-          <p className="mt-0.5 text-ink-muted text-xs">
-            {t("waiting.body", { app: appName })}
-          </p>
+    <div
+      className={
+        variant === "panel"
+          ? "rounded-xl border border-line bg-input p-3"
+          : undefined
+      }
+    >
+      {variant === "panel" ? (
+        <div className="flex items-start gap-2.5">
+          <Spinner className="mt-0.5 size-4 text-ink-muted" />
+          <div className="min-w-0 flex-1">{copy}</div>
         </div>
-      </div>
+      ) : (
+        copy
+      )}
       <div className="mt-3 flex flex-wrap gap-2">
         {/* Waking the poll is synchronous — nothing to await, so nothing for an
             AsyncButton's in-flight guard to hold. */}

--- a/app/src/components/integrations/index.ts
+++ b/app/src/components/integrations/index.ts
@@ -34,7 +34,7 @@ export {
 } from "./browse-sections";
 export { CatalogLockedSection } from "./catalog-locked-section";
 export { CATEGORY_PRIORITY } from "./category-priority";
-export { ConnectFlowInline } from "./connect-flow-inline";
+export { ConnectFlowInline, hasConnectState } from "./connect-flow-inline";
 export { ConnectNoticeLine } from "./connect-notice-line";
 export {
   connectOriginKey,

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -169,3 +169,42 @@ body {
     animation: none;
   }
 }
+
+/* A catalog row that OWNS a live connect hand-off becomes ONE card. The card's
+   border + fill live on their own layer BEHIND the row (always mounted,
+   transparent at rest), so the treatment cross-fades on opacity alone — the
+   flat transparent catalog row is untouched until the flow starts, and nothing
+   animates a colour or a shadow per frame. The exit is the faster one. */
+.connect-card-frame {
+  opacity: 0;
+  transition: opacity 0.15s ease-out;
+}
+
+.connect-card-frame[data-live="true"] {
+  opacity: 1;
+  transition: opacity 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* The flow content rises out of the row it belongs to. The card growing taller
+   is the accepted expansion (only what sits BELOW it moves); the content itself
+   animates on opacity + transform. */
+@keyframes connect-card-body-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.connect-card-body {
+  animation: connect-card-body-in 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .connect-card-body {
+    animation: none;
+  }
+}

--- a/knowledge-base/integrations.md
+++ b/knowledge-base/integrations.md
@@ -352,7 +352,8 @@ dialog: a brand-new user with zero connections immediately sees the full
 ~1000-app catalog (`AppCatalogPicker` was deleted long ago). BOTH the global page
 and the agent tab now render it through the shared `CatalogPane` +
 `CategoryCatalog` (see Personal mode below); an in-progress OAuth renders on ITS
-OWN row via `ConnectFlowInline` (never a page-level banner). The old `ConnectMoreAppsSection` / `CatalogBrowser`
+OWN row via `ConnectFlowInline` (never a page-level banner), which cards that row
+around it. The old `ConnectMoreAppsSection` / `CatalogBrowser`
 pair was DELETED with the agent-tab convergence — `AppCatalogGrid` (search +
 category + load-more grid) survives solely inside the allowlist editor.
 
@@ -492,8 +493,9 @@ integrations** tab (§2, `teams.md`).
   transparent at rest, hover fills the circle with the elevated `input` surface —
   white in light mode — against the row's `hover` wash; spins while THIS app
   connects and NEVER disables because another app is connecting) is
-  the ONLY row-level connect; the row expands beneath it with that app's live
-  connect state (`ConnectFlowInline`). Copy: `home.connect` /
+  the ONLY row-level connect; while the row owns that app's live connect state the
+  whole row becomes ONE card around it (`ConnectFlowInline variant="bare"` — see
+  "The owning catalog row IS the card" below). Copy: `home.connect` /
   `home.connectApp`. Disconnect is scope `everywhere` (a user-level connection
   disappears for ALL agents); the confirm names no agents (chip plumbing removed).
   This page is a PERSONAL-CONNECTIONS surface only: a connected app's
@@ -676,14 +678,46 @@ fully enabled at full strength. `busy`/`disabled` cross-row props were removed f
 
 **Feedback lands where the user clicked.** `ConnectFlowInline`
 (`integrations/connect-flow-inline.tsx`, replacing the deleted
-`ConnectWaitingPanel`) renders one app's state INLINE — under the catalog row whose
-`+` was pressed, under the recovery row, under the intake's connect prompt. It is a
+`ConnectWaitingPanel`) renders one app's state INLINE — inside the catalog card the
+pressed row became, under the recovery row, under the intake's connect prompt. It is a
 `role="status" aria-live="polite"` region announcing starting → waiting → settled:
 `waiting.opening` ("Opening {{app}} in your browser") while the link mints, the
 waiting copy + Reopen / I have finished / Cancel (core `Button`/`AsyncButton`, no
 hand-rolled utility buttons) once the browser is open, then the outcome line. The
 old top-of-catalog banner is gone: it shoved the sections ~90px down, far from the
 row that caused it.
+
+**The owning catalog row IS the card — one box, one spinner.** A bordered panel
+floating under a flat row read as a detached box about nothing in particular, and
+it put TWO spinners on one hand-off (the row's `+` and the panel's). So while a
+row owns a live or just-settled flow, `PlaneAppRow` turns the WHOLE row into one
+container: `rounded-xl border-line bg-input` (the recovery callout's surface
+language) enclosing the app header — logo, name, description, the `+` slot — and,
+directly below it, the flow copy and its pills. Nothing is nested inside it: the
+block renders `variant="bare"` (no frame of its own, and no spinner — the header's
+`CatalogAddButton busy` is the ONE spinner, sitting where the user just clicked).
+`variant="panel"` is the default and is what the standalone hosts still get
+(`PendingConnectionCallout`, the routine intake), where nothing around the block
+reports the hand-off; their rendering is unchanged. `hasConnectState(flow, slug)`
+is the shared predicate deciding whether there is anything to dress, so the chrome
+and the content appear and leave as one. Body padding continues the row's own
+rhythm (`px-3` gutters, the 10px the row already leaves under itself).
+
+**Rows at rest are untouched, and the treatment animates on opacity alone.** The
+card's border + fill live on their own always-mounted layer behind the row
+(`span.connect-card-frame[data-live]`, `absolute inset-0`), transparent at rest —
+so the catalog keeps its flat transparent-row language, and carding cross-fades
+without animating a colour or a shadow per frame (`app/src/styles/globals.css`:
+200ms `entrance` in, 150ms out, per DESIGN.md's motion budget). The flow content
+rises in with `connect-card-body` (opacity + `translateY`, 200ms, `animation:
+none` under `prefers-reduced-motion`); the card growing taller is the accepted
+expansion — only what sits BELOW moves, never the row beside it in the 2-col grid.
+While carded the header's hover fill squares its bottom (`rounded-b-none`) so it
+reads as the card's divider, and the `+` swaps to `hover:bg-chip` because its
+default hover fill IS the card's own surface. Covered by
+`integrations-browse.spec.ts` → "the owning row becomes ONE card carrying ONE
+spinner" (one container, one `role="status"` spinner in the `+` slot, zero
+bordered non-button elements inside the live region).
 
 **One panel per hand-off — the ORIGIN KEY** (`integrations/connect-origin.ts`,
 node-tested in `app/tests/connect-origin.test.ts`). The browse catalog renders some
@@ -695,15 +729,17 @@ Cancel buttons. Now every catalog row carries
 the store, and `inlineOwners()` hands the expansion to ONE row: the row the flow
 was started from, or — when that row is no longer rendered (the user searched
 mid-hand-off and the at-rest spotlight dropped out) — the first rendered copy, so a
-live OAuth and its Cancel can never vanish from the page. Duplicate rows keep their
-compact per-slug `+` spinner (`CatalogAddButton busy`), gated on `slug in states`
-and knowing nothing about origins. The settled line itself lives in
-`integrations/connect-notice-line.tsx` (`ConnectNoticeLine`), so the recovery
-callout can render an outcome without pulling in the live-phase block.
-`ConnectFlowInline` takes `owns` (default
-`true`): surfaces with a single row per app — the recovery callout, the intake —
-never pass it, so cross-surface visibility of a live or recovering connection is
-untouched (it gates on connection status, not origin). `surface` is threaded from
+live OAuth and its Cancel can never vanish from the page. Duplicate rows stay FLAT
+(never carded) and keep their compact per-slug `+` spinner (`CatalogAddButton
+busy`), gated on `slug in states` and knowing nothing about origins. The settled
+line itself lives in `integrations/connect-notice-line.tsx` (`ConnectNoticeLine`),
+so the recovery callout can render an outcome without pulling in the live-phase
+block. Ownership is the HOST surface's call, not the block's: `PlaneAppRow` gates
+on `owns && hasConnectState(...)` and simply does not render `ConnectFlowInline`
+on the copies that did not start the flow (the old `owns` prop is gone — only the
+catalog ever repeated a row, and the callout / intake never passed it, so
+cross-surface visibility of a live or recovering connection is untouched: it gates
+on connection status, not origin). `surface` is threaded from
 `IntegrationsReady` (`"integrations"`) and `AgentIntegrationsBody`
 (`` `agent:${id}` ``) through `CatalogPane` into `CategoryCatalog`.
 

--- a/packages/web/e2e/integrations-browse.spec.ts
+++ b/packages/web/e2e/integrations-browse.spec.ts
@@ -157,6 +157,59 @@ test("a row's + connects INLINE, exactly once, leaving every other row usable", 
   await expect(page.getByText("Finish connecting GitHub")).toHaveCount(1);
 });
 
+test("the owning row becomes ONE card carrying ONE spinner", async ({
+  page,
+  request,
+}) => {
+  await armCapabilities(request, { integrations: ["composio"] });
+  await openIntegrationsPage(page);
+
+  await page.getByRole("button", { name: "Connect Slack" }).first().click();
+  await expect(page.getByText("Finish connecting Slack")).toBeVisible();
+
+  // The card is ONE container: the app header (logo + name + description) and
+  // the flow copy share a single bordered box, so the state can never read as a
+  // detached panel floating under an unrelated row. `data-live` is the card
+  // treatment's own layer — present only while this row owns a flow.
+  const card = page
+    .locator('div:has(> span[data-live="true"])')
+    .filter({ hasText: "Finish connecting Slack" });
+  await expect(card).toHaveCount(1);
+  await expect(card.getByText("Slack", { exact: true })).toBeVisible();
+  await expect(card.getByText("Team messaging")).toBeVisible();
+
+  // ONE spinner in it, in the header's `+` slot where the user clicked. The
+  // flow copy below adds words, never a second thing turning.
+  await expect(card.getByRole("status", { name: "Loading" })).toHaveCount(1);
+  await expect(
+    card
+      .getByRole("button", { name: "Connect Slack" })
+      .getByRole("status", { name: "Loading" }),
+  ).toHaveCount(1);
+
+  // And NO box inside the box: nothing in the live region draws a border of its
+  // own (the outlined Reopen pill is a control, not a container).
+  const nested = await card
+    .getByRole("status")
+    .filter({ hasText: "Finish connecting Slack" })
+    .evaluate(
+      (el) =>
+        [el, ...el.querySelectorAll("*")].filter(
+          (n) =>
+            n.tagName !== "BUTTON" &&
+            getComputedStyle(n).borderTopWidth !== "0px",
+        ).length,
+    );
+  expect(nested).toBe(0);
+
+  // The duplicate copy of Slack is NOT carded — it stays a flat catalog row
+  // with the compact busy `+`, so one hand-off is one card.
+  await expect(page.locator('span[data-live="true"]')).toHaveCount(1);
+  await expect(
+    page.getByRole("button", { name: "Connect Slack" }).last(),
+  ).toBeDisabled();
+});
+
 test("the row the user pressed owns the panel, not the first copy of the app", async ({
   page,
   request,


### PR DESCRIPTION
Part of HOU-847 (follow-up polish on user feedback: "this could be way more integrated to the cards").

## What

The inline connect state shipped in #1097 rendered as a detached bordered panel floating under the catalog row, with its own spinner next to the row's spinner. Now the row that owns the flow becomes **one card**: header (logo / name / description / single spinner in the + slot) and flow content (phase copy + I have finished / Reopen / Cancel, or the settled line) inside a single rounded container. Entrance/exit is 200ms opacity+transform with `prefers-reduced-motion` honored. Rows at rest, duplicate spotlight rows, recovery callouts, and the routine intake are unchanged (the framed variant remains for the latter two).

## Verification

- Screenshot design-review loop across rest / starting / waiting / two-up / settled, light + dark, plus the agent tab
- New e2e guard: one container, exactly one spinner (in the + slot), duplicate row not carded
- Full web e2e suite: 137 passed; app: 2082 unit tests pass; biome/tsgo/locales clean
- No visual baselines affected (integrations screens are not in the baseline set); no `ui/` package changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)