### PR TITLE
fix(website): mobile excellence pass

### DIFF
--- a/website/src/assets/css/landing-splits.css
+++ b/website/src/assets/css/landing-splits.css
@@ -35,11 +35,22 @@
     grid-template-columns: 1fr;
     gap: 32px;
   }
-  .split-rev .split-copy {
+  /* Every stacked split leads with its copy: the headline frames the visual
+     that follows. Consistent with #multiplayer and #compound, and stops
+     #parallel (a plain .split, visual-first in the DOM for its desktop left
+     placement) from opening with a context-less board on a phone. */
+  .split-copy {
+    order: -1;
+  }
+  .split-visual {
     order: 0;
   }
-  .split-rev .split-visual {
-    order: 1;
+  /* Let the single-column grid tracks shrink below their content's intrinsic
+     width so no child forces the section past the viewport (body clips
+     overflow-x, so any excess would silently crop copy). */
+  .split-copy,
+  .split-visual {
+    min-width: 0;
   }
 }
 
@@ -80,6 +91,11 @@
 }
 
 /* ── Full-screen section rhythm — each story owns a viewport ─────────────── */
+/* Desktop-only (>=881px) on purpose: on a phone these sections stack to their
+   natural (tall) content height, so one-story-per-viewport and scroll-snap
+   don't apply. Snapping stacked, variable-height mobile sections fights native
+   momentum scrolling and can trap the reader mid-section, so mobile scrolls
+   free — the sections just flow. */
 @media (min-width: 881px) {
   #multiplayer,
   #parallel,
@@ -212,6 +228,16 @@
   padding: 6px 12px;
   font-size: 12.5px;
   white-space: nowrap;
+}
+/* On phones the tabs get the full page width but there are 4–5 of them; let the
+   row wrap (like the multiplayer .chat-tabs) instead of a nowrap row whose last
+   tab ("Support Rep" / "Permissions") clips off-screen. Placed AFTER the base
+   nowrap rule so it wins the cascade at equal specificity. */
+@media (max-width: 880px) {
+  .acol-tabs,
+  .feat-tabs {
+    flex-wrap: wrap;
+  }
 }
 
 /* ── One agent's kanban column (#parallel) — every card is a chat ────────── */

--- a/website/src/assets/css/landing.css
+++ b/website/src/assets/css/landing.css
@@ -391,77 +391,7 @@ img {
   .lnav-links {
     display: none;
   }
-  .lnav-cta-glyph {
-  width: 15px;
-  height: 15px;
-  display: inline-block;
-  background: currentColor;
-  -webkit-mask: var(--helmet-mask) center / contain no-repeat;
-  mask: var(--helmet-mask) center / contain no-repeat;
-}
-/* Resources dropdown — quiet menu for everything that leaves the page. */
-.lnav-res {
-  position: relative;
-}
-.lnav-res-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-family: var(--sans);
-  color: var(--ink-muted);
-  font-size: 14.5px;
-  font-weight: 500;
-  transition: color var(--dur-fast) var(--ease-standard);
-}
-.lnav-res-btn:hover,
-.lnav-res.open .lnav-res-btn {
-  color: var(--ink-strong);
-}
-.lnav-res-btn svg {
-  transition: transform var(--dur-fast) var(--ease-standard);
-}
-.lnav-res.open .lnav-res-btn svg {
-  transform: rotate(180deg);
-}
-.lnav-res-menu {
-  position: absolute;
-  top: calc(100% + 12px);
-  left: 50%;
-  transform: translateX(-50%) translateY(-4px);
-  min-width: 168px;
-  background: var(--card);
-  border: 1px solid var(--line);
-  border-radius: 14px;
-  padding: 8px;
-  box-shadow: 0 20px 48px -24px rgba(40, 36, 28, 0.25);
-  opacity: 0;
-  visibility: hidden;
-  transition: opacity var(--dur-fast) var(--ease-standard),
-    transform var(--dur-fast) var(--ease-entrance),
-    visibility var(--dur-fast) var(--ease-standard);
-}
-.lnav-res.open .lnav-res-menu {
-  opacity: 1;
-  visibility: visible;
-  transform: translateX(-50%) translateY(0);
-}
-.lnav-res-menu a {
-  display: block;
-  padding: 9px 12px;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--ink);
-}
-.lnav-res-menu a:hover {
-  background: var(--panel);
-  color: var(--ink-strong);
-}
-
-.lnav-burger {
+  .lnav-burger {
     display: inline-flex;
   }
 }
@@ -542,6 +472,14 @@ img {
   .lfoot-top {
     grid-template-columns: 1fr 1fr;
     gap: 28px;
+  }
+  /* Give the bottom-row legal/credit links a comfortable tap height on phones
+     (they are single-line text links, ~19px tall otherwise). */
+  .lfoot-bottom {
+    row-gap: 6px;
+  }
+  .lfoot-bottom a {
+    padding: 6px 0;
   }
 }
 @media (max-width: 460px) {


### PR DESCRIPTION
Final leg of tonight's batch (after #1103). Two full audit-fix loops at 360/390/430/768 across the landing + all migrated subpages.

- **Real bug fixed**: swap-pill rows were `flex-nowrap`, inflating the mobile grid past the viewport and silently cropping the last pill and section titles at 360/390 (masked by `overflow-x:hidden`). Now wrapped + `min-width:0` tracks; **zero horizontal overflow across all 36 page×width combos**.
- Stacked splits unified copy-first on mobile; desktop zig-zag untouched (1440 fold confirmed pixel-identical).
- Footer legal links to 31px tap height; 63 lines of duplicated dead CSS removed.
- Interactions verified at 390: burger, download gate (16px input, no iOS zoom), chat tabs + fixed thread (~46svh), both switchers, FAQ, footer. Landing transfer 382KB excl. GitHub API; hero serves the 900w cut.
- Deliberately left, with reasons in the commit: text-only dl-os links under 24px, 13.5–14.5px secondary text mirroring real app chrome, landing.css at 521 lines (pre-existing debt, reduced not grown; clean fix is a shared-footer extraction).

Fixes HOU-935

🤖 Generated with [Claude Code](https://claude.com/claude-code)