### PR TITLE
chore(ci): announce merged PRs in Slack #get-shit-done

### DIFF
--- a/.github/workflows/slack-shipped.yml
+++ b/.github/workflows/slack-shipped.yml
@@ -1,0 +1,39 @@
+name: Ship announcement
+
+# Posts every merged PR to Slack #get-shit-done so the team sees what ships.
+# Requires the SLACK_SHIPPED_WEBHOOK_URL repo secret (a Slack incoming webhook
+# pointed at #get-shit-done). Skips silently until the secret is configured.
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  announce:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to get-shit-done
+        env:
+          WEBHOOK: ${{ secrets.SLACK_SHIPPED_WEBHOOK_URL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_ADDITIONS: ${{ github.event.pull_request.additions }}
+          PR_DELETIONS: ${{ github.event.pull_request.deletions }}
+        run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "SLACK_SHIPPED_WEBHOOK_URL not set; skipping announcement."
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg title "$PR_TITLE" \
+            --arg url "$PR_URL" \
+            --arg num "$PR_NUMBER" \
+            --arg author "$PR_AUTHOR" \
+            --arg adds "$PR_ADDITIONS" \
+            --arg dels "$PR_DELETIONS" \
+            '{text: (":ship: <" + $url + "|#" + $num + " " + $title + "> shipped by " + $author + "  (+" + $adds + " / -" + $dels + ")")}')
+          curl -sf -X POST -H 'Content-Type: application/json' -d "$payload" "$WEBHOOK"


### PR DESCRIPTION
Posts every merged PR to the new #get-shit-done channel: `🚢 #1104 fix(website): mobile excellence pass shipped by X (+241 / -84)`.

- Fires on `pull_request: closed` with `merged == true` only.
- Payload built with `jq` from env vars (PR titles can't inject), `permissions: {}`.
- Inert until the `SLACK_SHIPPED_WEBHOOK_URL` repo secret is set (skips with a log line), so merging this is safe immediately; the secret lands separately.

No Linear issue: team-visibility plumbing requested by Julian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)