### PR TITLE
fix(runtime): report a provider-revoked served token to the control plane (HOU-952)

### DIFF
--- a/packages/host/src/credentials/file-store.ts
+++ b/packages/host/src/credentials/file-store.ts
@@ -7,6 +7,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname } from "node:path";
+import { accessDigestMatches } from "@houston/protocol/access-digest";
 import type { WorkspaceId } from "../domain/types";
 import type { CredentialStore, WorkspaceCredential } from "../ports";
 
@@ -70,5 +71,21 @@ export class FileCredentialStore implements CredentialStore {
   async remove(workspaceId: WorkspaceId, provider: string): Promise<void> {
     this.creds.delete(this.key(workspaceId, provider));
     this.flush();
+  }
+
+  /** Compare-and-delete under this process's single-threaded map access — the
+   *  local equivalent of the gateway's row lock (HOU-952). */
+  async removeIfAccess(
+    workspaceId: WorkspaceId,
+    provider: string,
+    accessSha256: string,
+  ): Promise<boolean> {
+    const key = this.key(workspaceId, provider);
+    const current = this.creds.get(key);
+    if (!current || !accessDigestMatches(current.accessToken, accessSha256))
+      return false;
+    this.creds.delete(key);
+    this.flush();
+    return true;
   }
 }

--- a/packages/host/src/credentials/remote-store.test.ts
+++ b/packages/host/src/credentials/remote-store.test.ts
@@ -110,6 +110,7 @@ test("404 adopts a legacy fallback credential with insert-only PUT, then re-gets
     get: async () => legacy,
     put: async () => {},
     remove: async () => {},
+    removeIfAccess: async () => false,
   };
   const { calls, fetchImpl } = fakeFetch((call, index) => {
     if (index === 0) return json({ error: "org not connected" }, 404);
@@ -266,6 +267,7 @@ test("remove treats the gateway's not-connected 404 as already signed out and cl
     remove: async () => {
       fallbackCred = null;
     },
+    removeIfAccess: async () => false,
   };
   const { calls, fetchImpl } = fakeFetch(() =>
     json({ error: "org not connected" }, 404),
@@ -295,6 +297,7 @@ test("logout cannot resurrect through the legacy fallback after remove", async (
     remove: async () => {
       fallbackCred = null;
     },
+    removeIfAccess: async () => false,
   };
   const { calls, fetchImpl } = fakeFetch((call) => {
     if (call.init?.method === "DELETE") return json({ ok: true });

--- a/packages/host/src/credentials/remote-store.ts
+++ b/packages/host/src/credentials/remote-store.ts
@@ -100,6 +100,46 @@ export class RemoteCredentialStore implements CredentialStore {
     this.cache.delete(provider);
   }
 
+  /**
+   * Report a token the PROVIDER revoked: the gateway drops its row only while
+   * that token is still the stored one (HOU-952). Rides the same DELETE with
+   * `x-houston-if-access-sha256`, so the comparison happens under the gateway's
+   * per-(org, provider) row lock rather than as a read-then-delete here — a
+   * reconnect racing the report waits behind it instead of being deleted by it.
+   *
+   * Returns whether the gateway actually removed anything. A `removed:false`
+   * is the ordinary superseded case (the org reconnected, or a sibling pod
+   * reported the same dead token first), not a failure.
+   */
+  async removeIfAccess(
+    workspaceId: WorkspaceId,
+    provider: string,
+    accessSha256: string,
+  ): Promise<boolean> {
+    const res = await this.fetchImpl(this.url(provider), {
+      method: "DELETE",
+      headers: {
+        ...this.authHeaders(),
+        "x-houston-if-access-sha256": accessSha256,
+      },
+    });
+    // Idempotent like remove(): an already-gone row is the outcome we wanted.
+    if (res.status !== 200 && !(await isNotConnected404(res)))
+      throw await this.errorFromResponse(res, "DELETE", provider);
+    const removed =
+      res.status === 200 &&
+      ((await res.json().catch(() => null)) as { removed?: boolean } | null)
+        ?.removed === true;
+    // Only a real removal invalidates local state. Leaving the cache and the
+    // legacy fallback entry alone on a superseded report is deliberate: they
+    // may describe the credential that SUPERSEDED the revoked one.
+    if (removed) {
+      this.cache.delete(provider);
+      await this.fallback?.remove(workspaceId, provider);
+    }
+    return removed;
+  }
+
   private async adoptFallback(
     workspaceId: WorkspaceId,
     provider: string,

--- a/packages/host/src/credentials/store.ts
+++ b/packages/host/src/credentials/store.ts
@@ -1,3 +1,4 @@
+import { accessDigestMatches } from "@houston/protocol/access-digest";
 import type { WorkspaceId } from "../domain/types";
 import type { CredentialStore, WorkspaceCredential } from "../ports";
 
@@ -34,5 +35,19 @@ export class MemoryCredentialStore implements CredentialStore {
   }
   async remove(workspaceId: WorkspaceId, provider: string): Promise<void> {
     this.creds.delete(this.key(workspaceId, provider));
+  }
+  /** Compare-and-delete: only the reported token goes, never whatever
+   *  replaced it (HOU-952). */
+  async removeIfAccess(
+    workspaceId: WorkspaceId,
+    provider: string,
+    accessSha256: string,
+  ): Promise<boolean> {
+    const key = this.key(workspaceId, provider);
+    const current = this.creds.get(key);
+    if (!current || !accessDigestMatches(current.accessToken, accessSha256))
+      return false;
+    this.creds.delete(key);
+    return true;
   }
 }

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -360,6 +360,22 @@ export interface CredentialStore {
    */
   put(cred: WorkspaceCredential, opts?: { ifAbsent?: boolean }): Promise<void>;
   remove(workspaceId: WorkspaceId, provider: string): Promise<void>;
+  /**
+   * Compare-and-delete: drop the credential only while its access token still
+   * hashes to `accessSha256`. Resolves to whether anything was removed.
+   *
+   * This is the ONLY safe way to act on a runtime's report that a provider
+   * REVOKED a served token (HOU-952). A revoked token is not an expired one —
+   * no refresh ever fails, so the store would keep serving it — but the report
+   * arrives from a turn that may have started before the user reconnected, and
+   * an unconditional remove would then delete the credential they just
+   * created. A digest mismatch means the report is stale: no-op, not an error.
+   */
+  removeIfAccess(
+    workspaceId: WorkspaceId,
+    provider: string,
+    accessSha256: string,
+  ): Promise<boolean>;
 }
 
 /** Mints/validates the non-secret per-sandbox identity tokens (HMAC). */

--- a/packages/host/src/routes/agent-configs.test.ts
+++ b/packages/host/src/routes/agent-configs.test.ts
@@ -52,6 +52,9 @@ const deps: ControlPlaneDeps = {
     },
     async put() {},
     async remove() {},
+    async removeIfAccess() {
+      return false;
+    },
   },
   vault: { sandboxToken: () => "x", validateSandboxToken: () => null },
   channels: {},

--- a/packages/host/src/routes/agents-rename.test.ts
+++ b/packages/host/src/routes/agents-rename.test.ts
@@ -256,6 +256,7 @@ test("ProxyChannel.quiesce sleeps the agent's runtime without destroying it", as
       put: async () => {},
       get: async () => null,
       remove: async () => {},
+      removeIfAccess: async () => false,
     },
     forwardActingHeader: false,
   });

--- a/packages/host/src/routes/credential-revoked.ts
+++ b/packages/host/src/routes/credential-revoked.ts
@@ -1,0 +1,72 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { CredentialStore, CredentialVault } from "../ports";
+import { bearer, json, readJson } from "./http";
+
+/**
+ * Sandbox-facing: the runtime reporting that a PROVIDER revoked the token this
+ * host served it.
+ *
+ * A revoked token is not an expired one. Nothing on the serve path can see the
+ * difference — the credential is present, unexpired, and refreshing it would
+ * succeed or fail for unrelated reasons — so the store keeps handing the dead
+ * token to every runtime in the workspace and every turn 401s until the clock
+ * runs out. Sentry HOUSTON-APP-4YA: 3,935 failed turns across 58 users, all on
+ * managed-cloud pods. The runtime's turn is the only witness, and this route is
+ * how its testimony reaches the store (HOU-952).
+ *
+ * The report names the token by digest, never by value, and the store's
+ * compare-and-delete drops it only while it is still the stored one — a report
+ * from a turn that began before the user reconnected must not delete the
+ * credential they just created.
+ *
+ * Returns true when the request was handled.
+ */
+export async function handleSandboxCredentialRevoked(
+  deps: { vault: CredentialVault; credentials: CredentialStore },
+  method: string,
+  path: string,
+  url: URL,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  if (method !== "POST" || path !== "/sandbox/credential/revoked") return false;
+
+  const sbToken = bearer(req, url);
+  const claim = sbToken ? deps.vault.validateSandboxToken(sbToken) : null;
+  if (!claim) {
+    json(res, 401, { error: "unauthorized" });
+    return true;
+  }
+
+  const body = (await readJson(req).catch(() => null)) as {
+    provider?: unknown;
+    accessSha256?: unknown;
+  } | null;
+  const provider = typeof body?.provider === "string" ? body.provider : "";
+  const accessSha256 =
+    typeof body?.accessSha256 === "string" ? body.accessSha256.trim() : "";
+  if (!provider || !accessSha256) {
+    // Refuse rather than guess: a report without a token identity could only
+    // be actioned as an unconditional delete, which is the one thing this
+    // route must never do.
+    json(res, 400, { error: "provider and accessSha256 are required" });
+    return true;
+  }
+
+  const removed = await deps.credentials.removeIfAccess(
+    claim.workspaceId,
+    provider,
+    accessSha256,
+  );
+  // Both outcomes are success. `removed:false` means the report was superseded
+  // — the workspace reconnected, or a sibling runtime reported the same dead
+  // token first — and the reporter's own retry/backoff must not treat that as
+  // an error to escalate.
+  console[removed ? "error" : "info"](
+    `[sandbox/credential] revoked-token report for ${provider}: ${
+      removed ? "credential disconnected" : "superseded, left in place"
+    }`,
+  );
+  json(res, 200, { ok: true, removed });
+  return true;
+}

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -38,6 +38,7 @@ import {
 import { handleAgents, podActivityStatus } from "./routes/agents";
 import { handleCatalog } from "./routes/catalog";
 import { handleSandboxCredential } from "./routes/credential";
+import { handleSandboxCredentialRevoked } from "./routes/credential-revoked";
 import {
   type CustomIntegrationDeps,
   handleSandboxCustomIntegrations,
@@ -264,6 +265,11 @@ async function handle(
 
   // Sandbox-facing credential serve (HMAC sandbox token, not a user JWT).
   if (await handleSandboxCredential(deps, method, path, url, req, res)) return;
+  // Sandbox-facing revoked-token report (HOU-952): the runtime's turn is the
+  // only witness to a provider revoking a served token, since a revoked token
+  // is not an expired one and the serve path cannot tell them apart.
+  if (await handleSandboxCredentialRevoked(deps, method, path, url, req, res))
+    return;
   // Sandbox-facing central usage probe (Copilot quota needs the host-held token).
   if (await handleSandboxProviderUsage(deps, method, path, url, req, res))
     return;

--- a/packages/host/src/testing/credential-contract.ts
+++ b/packages/host/src/testing/credential-contract.ts
@@ -1,3 +1,4 @@
+import { accessDigest } from "@houston/protocol/access-digest";
 import { describe, expect, test } from "vitest";
 import {
   type CredentialStore,
@@ -135,6 +136,52 @@ export function runCredentialStoreContract(
       await s.remove("ws_a", "openai-codex");
       expect(await s.get("ws_a", "openai-codex")).toBeNull();
       expect((await s.get("ws_b", "openai-codex"))?.accessToken).toBe("bb");
+    });
+
+    // HOU-952: a runtime reporting a provider-REVOKED token. Every adapter has
+    // to compare before deleting, or the report becomes a new way to sign a
+    // workspace out.
+    test("removeIfAccess drops the reported token", async () => {
+      const s = make();
+      await s.put(cred({ accessToken: "revoked-tok" }));
+      expect(
+        await s.removeIfAccess(
+          "ws_1",
+          "openai-codex",
+          accessDigest("revoked-tok"),
+        ),
+      ).toBe(true);
+      expect(await s.get("ws_1", "openai-codex")).toBeNull();
+    });
+
+    test("removeIfAccess spares a credential that moved on", async () => {
+      // The reporting turn began BEFORE the user reconnected. Deleting here
+      // would destroy the credential they just created.
+      const s = make();
+      await s.put(cred({ accessToken: "freshly-reconnected" }));
+      expect(
+        await s.removeIfAccess("ws_1", "openai-codex", accessDigest("old-tok")),
+      ).toBe(false);
+      expect((await s.get("ws_1", "openai-codex"))?.accessToken).toBe(
+        "freshly-reconnected",
+      );
+    });
+
+    test("removeIfAccess on an absent credential is false, not an error", async () => {
+      const s = make();
+      expect(
+        await s.removeIfAccess("ws_1", "openai-codex", accessDigest("any")),
+      ).toBe(false);
+    });
+
+    test("removeIfAccess is scoped to one (workspace, provider)", async () => {
+      const s = make();
+      await s.put(cred({ workspaceId: "ws_a", accessToken: "same" }));
+      await s.put(cred({ workspaceId: "ws_b", accessToken: "same" }));
+      await s.removeIfAccess("ws_a", "openai-codex", accessDigest("same"));
+      expect(await s.get("ws_a", "openai-codex")).toBeNull();
+      // An identical token in ANOTHER workspace is a different credential.
+      expect((await s.get("ws_b", "openai-codex"))?.accessToken).toBe("same");
     });
   });
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -11,6 +11,10 @@
       "types": "./src/index.ts",
       "import": "./src/index.ts"
     },
+    "./access-digest": {
+      "types": "./src/access-digest.ts",
+      "import": "./src/access-digest.ts"
+    },
     "./model-windows": {
       "types": "./src/model-windows.ts",
       "import": "./src/model-windows.ts"

--- a/packages/protocol/src/access-digest.ts
+++ b/packages/protocol/src/access-digest.ts
@@ -1,0 +1,41 @@
+import { createHash } from "node:crypto";
+
+/**
+ * SUBPATH EXPORT ONLY — deliberately absent from this package's barrel
+ * (`@houston/protocol`). The barrel is browser-facing: `app` and `packages/web`
+ * typecheck and bundle it, and `node:crypto` is not resolvable there. Only
+ * Node/Bun consumers (the runtime and the host) import
+ * `@houston/protocol/access-digest`.
+ *
+ * The wire identity of an access token: lowercase hex sha256.
+ *
+ * A runtime that hits `401 token revoked` needs to tell the credential store
+ * WHICH token the provider rejected, so the store can drop that one and only
+ * that one (HOU-952). Naming it by digest keeps the token itself out of a
+ * report that crosses a process — and out of logs, which is where reports of
+ * this kind end up.
+ *
+ * Must stay byte-compatible with the gateway's `store.AccessDigest`
+ * (cloud/internal/store/store.go): the pod computes the digest and the gateway
+ * compares it against what IT holds, so both sides must agree on the hash and
+ * the casing.
+ */
+export function accessDigest(accessToken: string): string {
+  return createHash("sha256").update(accessToken).digest("hex");
+}
+
+/**
+ * Whether a stored access token is the one a digest names. Case-insensitive on
+ * the hex so an upper-cased digest is not silently read as "some other token"
+ * — that would turn a real revocation report into a no-op.
+ */
+export function accessDigestMatches(
+  accessToken: string,
+  digest: string,
+): boolean {
+  const want = accessDigest(accessToken);
+  const got = digest.trim().toLowerCase();
+  // Lengths are fixed and equal here, so a plain compare leaks nothing useful;
+  // the digest is not a secret in the first place (the token it names is).
+  return want === got;
+}

--- a/packages/runtime/src/auth/report-revoked.test.ts
+++ b/packages/runtime/src/auth/report-revoked.test.ts
@@ -1,0 +1,177 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ProviderError } from "@houston/protocol";
+import { accessDigest } from "@houston/protocol/access-digest";
+import { expect, test } from "vitest";
+import { config } from "../config";
+import { reportRevokedServedToken } from "./report-revoked";
+
+/**
+ * The reporter is a DELETE trigger for a workspace-wide credential, so the
+ * gating is the safety-critical part: every test here is about what must NOT
+ * produce a report (HOU-952).
+ */
+
+type Captured = { url: string; body: Record<string, unknown> } | null;
+
+/** Serve mode + a data dir, with fetch captured. Returns what was reported. */
+async function withServeMode(
+  setup: (dataDir: string) => void,
+  body: () => void,
+  opts?: { serveMode?: boolean },
+): Promise<Captured> {
+  const prevUrl = config.controlPlaneUrl;
+  const prevTok = config.sandboxToken;
+  const prevDataDir = config.dataDir;
+  const prevFetch = globalThis.fetch;
+  let captured: Captured = null;
+
+  config.controlPlaneUrl =
+    opts?.serveMode === false ? "" : "http://control-plane.test";
+  config.sandboxToken = opts?.serveMode === false ? "" : "sbx-token";
+  config.dataDir = mkdtempSync(join(tmpdir(), "houston-revoked-"));
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    captured = {
+      url: String(url),
+      body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>,
+    };
+    return new Response(JSON.stringify({ ok: true, removed: true }), {
+      status: 200,
+    });
+  }) as unknown as typeof globalThis.fetch;
+
+  try {
+    setup(config.dataDir);
+    body();
+    // The reporter is fire-and-forget; let its microtasks drain.
+    await new Promise((r) => setTimeout(r, 10));
+    return captured;
+  } finally {
+    globalThis.fetch = prevFetch;
+    config.controlPlaneUrl = prevUrl;
+    config.sandboxToken = prevTok;
+    config.dataDir = prevDataDir;
+  }
+}
+
+/** A served anthropic oauth credential on disk, as a serve sync would leave it. */
+function servedAnthropic(dataDir: string, access = "served-access"): void {
+  writeFileSync(
+    join(dataDir, "auth.json"),
+    JSON.stringify({
+      anthropic: { type: "oauth", access, refresh: "", expires: 0 },
+    }),
+  );
+  writeFileSync(
+    join(dataDir, "served-providers.json"),
+    JSON.stringify(["anthropic"]),
+  );
+}
+
+const revoked: ProviderError = {
+  kind: "unauthenticated",
+  provider: "anthropic",
+  cause: "token_revoked",
+  message: "401 OAuth access token has been revoked",
+};
+
+test("reports a revoked served token, naming it by digest only", async () => {
+  const captured = await withServeMode(
+    (dir) => servedAnthropic(dir, "the-revoked-token"),
+    () => reportRevokedServedToken(revoked),
+  );
+
+  expect(captured?.url).toBe(
+    "http://control-plane.test/sandbox/credential/revoked",
+  );
+  expect(captured?.body.provider).toBe("anthropic");
+  expect(captured?.body.accessSha256).toBe(accessDigest("the-revoked-token"));
+  // The token itself must never leave the runtime.
+  expect(JSON.stringify(captured?.body)).not.toContain("the-revoked-token");
+});
+
+test("does NOT report a non-terminal auth failure", async () => {
+  // `unauthenticated` at large covers transient provider blips and bad keys.
+  // Reporting those would delete a credential that is fine.
+  const captured = await withServeMode(
+    (dir) => servedAnthropic(dir),
+    () =>
+      reportRevokedServedToken({
+        ...revoked,
+        cause: "invalid_api_key",
+      } as ProviderError),
+  );
+  expect(captured).toBeNull();
+});
+
+test("does NOT report a credential this runtime owns locally", async () => {
+  // No served-providers entry = a desktop keychain login. It never backed this
+  // turn and is none of the control plane's business.
+  const captured = await withServeMode(
+    (dir) => {
+      writeFileSync(
+        join(dir, "auth.json"),
+        JSON.stringify({
+          anthropic: { type: "oauth", access: "local-tok", refresh: "r" },
+        }),
+      );
+      writeFileSync(join(dir, "served-providers.json"), JSON.stringify([]));
+    },
+    () => reportRevokedServedToken(revoked),
+  );
+  expect(captured).toBeNull();
+});
+
+test("does NOT report when serve mode is off", async () => {
+  const captured = await withServeMode(
+    (dir) => servedAnthropic(dir),
+    () => reportRevokedServedToken(revoked),
+    { serveMode: false },
+  );
+  expect(captured).toBeNull();
+});
+
+test("does NOT report an api_key credential", async () => {
+  // An api_key has no revocation semantics worth acting on here; treating one
+  // as revoked would delete a key the user still wants.
+  const captured = await withServeMode(
+    (dir) => {
+      writeFileSync(
+        join(dir, "auth.json"),
+        JSON.stringify({ anthropic: { type: "api_key", key: "sk-1" } }),
+      );
+      writeFileSync(
+        join(dir, "served-providers.json"),
+        JSON.stringify(["anthropic"]),
+      );
+    },
+    () => reportRevokedServedToken(revoked),
+  );
+  expect(captured).toBeNull();
+});
+
+test("a failing control plane never throws into the caller", async () => {
+  // This runs inside error handling for a turn that already failed; a
+  // reporting hiccup must not replace the real provider error.
+  const prevFetch = globalThis.fetch;
+  const prevUrl = config.controlPlaneUrl;
+  const prevTok = config.sandboxToken;
+  const prevDataDir = config.dataDir;
+  config.controlPlaneUrl = "http://control-plane.test";
+  config.sandboxToken = "sbx-token";
+  config.dataDir = mkdtempSync(join(tmpdir(), "houston-revoked-boom-"));
+  globalThis.fetch = (async () => {
+    throw new Error("gateway unreachable");
+  }) as unknown as typeof globalThis.fetch;
+  try {
+    servedAnthropic(config.dataDir);
+    expect(() => reportRevokedServedToken(revoked)).not.toThrow();
+    await new Promise((r) => setTimeout(r, 10));
+  } finally {
+    globalThis.fetch = prevFetch;
+    config.controlPlaneUrl = prevUrl;
+    config.sandboxToken = prevTok;
+    config.dataDir = prevDataDir;
+  }
+});

--- a/packages/runtime/src/auth/report-revoked.ts
+++ b/packages/runtime/src/auth/report-revoked.ts
@@ -1,0 +1,100 @@
+import { join } from "node:path";
+import type { ProviderError } from "@houston/protocol";
+import { accessDigest } from "@houston/protocol/access-digest";
+import { config } from "../config";
+import { readAuthFile, readServedProvidersAt } from "./auth-file";
+import { serveModeOn } from "./serve";
+
+/**
+ * Tell the control plane when a provider REVOKES a token it served us.
+ *
+ * A revoked token is not an expired one, and nothing upstream can tell them
+ * apart: the credential is present and unexpired, so the control plane keeps
+ * serving it to every runtime in the workspace and every turn 401s until the
+ * clock runs out. Sentry HOUSTON-APP-4YA — 3,935 failed turns across 58 users.
+ * The turn that just failed is the ONLY witness, so it has to speak up
+ * (HOU-952).
+ *
+ * The pod-local mark in credential-health.ts stays: it makes THIS runtime stop
+ * claiming "Connected". This is the other half — the workspace's other runtimes
+ * cannot learn it from our memory.
+ *
+ * Deliberately narrow. Three gates, each of which would otherwise let a report
+ * sign a workspace out of a credential that is fine:
+ *
+ *  1. `token_revoked` ONLY, never `unauthenticated` at large. The broad kind
+ *     covers transient provider auth blips and misconfigured keys; the terminal
+ *     cause is the one that means "this token is dead forever" (see
+ *     protocol/provider-error.ts).
+ *  2. Serve mode, and the provider must be in the SERVED manifest. A credential
+ *     this runtime owns locally (a desktop keychain login) is none of the
+ *     control plane's business, and reporting it would ask the store to delete
+ *     a row that never backed this turn.
+ *  3. OAuth only. An api_key has no revocation semantics worth acting on here,
+ *     and treating one as revoked would delete a key the user still wants.
+ *
+ * Fire-and-forget and never throws: this runs inside error handling for a turn
+ * that has already failed, and a reporting hiccup must not replace the real
+ * provider error the user needs to see.
+ */
+export function reportRevokedServedToken(err: ProviderError): void {
+  void reportRevoked(err).catch(() => {});
+}
+
+async function reportRevoked(err: ProviderError): Promise<void> {
+  if (err.kind !== "unauthenticated" || err.cause !== "token_revoked") return;
+  if (!serveModeOn()) return;
+
+  const provider = err.provider;
+  const served = readServedProvidersAt(
+    join(config.dataDir, "served-providers.json"),
+  );
+  if (!served.includes(provider)) return;
+
+  const cred = readAuthFile(join(config.dataDir, "auth.json"))[provider];
+  if (cred?.type !== "oauth" || !cred.access) return;
+
+  try {
+    const res = await fetch(
+      `${config.controlPlaneUrl}/sandbox/credential/revoked`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.sandboxToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          provider,
+          // The token is named, never shipped: the control plane holds its own
+          // copy and compares digests.
+          accessSha256: accessDigest(cred.access),
+        }),
+        signal: AbortSignal.timeout(REPORT_TIMEOUT_MS),
+      },
+    );
+    if (!res.ok) {
+      console.warn(
+        `[serve] revoked-token report for ${provider} failed: ${res.status}`,
+      );
+      return;
+    }
+    const body = (await res.json().catch(() => null)) as {
+      removed?: boolean;
+    } | null;
+    console.log(
+      `[serve] reported revoked ${provider} token: ${
+        body?.removed
+          ? "central credential disconnected"
+          : "superseded, left in place"
+      }`,
+    );
+  } catch (reportErr) {
+    console.warn(
+      `[serve] revoked-token report for ${provider} failed:`,
+      reportErr instanceof Error ? reportErr.message : reportErr,
+    );
+  }
+}
+
+/** One stalled control-plane socket must not outlive the failed turn. */
+const REPORT_TIMEOUT_MS = 10_000;

--- a/packages/runtime/src/backends/claude/errors.ts
+++ b/packages/runtime/src/backends/claude/errors.ts
@@ -6,6 +6,7 @@ import {
 } from "../../ai/provider-error";
 import { logProviderError } from "../../ai/provider-error-log";
 import { noteAuthFailure } from "../../auth/credential-health";
+import { reportRevokedServedToken } from "../../auth/report-revoked";
 
 /** The pi provider id this backend runs as — every error is attributed to it. */
 const PROVIDER = "anthropic";
@@ -51,7 +52,11 @@ export function mapSdkError(
     // Feed the failure into the status surface: the credential the turn just
     // ran on cannot authenticate, so "Connected" would be a lie until it
     // changes (auth/credential-health.ts).
-    if (mapped.kind === "unauthenticated") noteAuthFailure(mapped.provider);
+    if (mapped.kind === "unauthenticated") {
+      noteAuthFailure(mapped.provider);
+      // A REVOKED served token is invisible to the control plane (HOU-952).
+      reportRevokedServedToken(mapped);
+    }
   }
   return mapped ?? classifyText(message, model, status);
 }

--- a/packages/runtime/src/backends/pi/wire.ts
+++ b/packages/runtime/src/backends/pi/wire.ts
@@ -8,6 +8,7 @@ import {
 import { classifyProviderError } from "../../ai/provider-error";
 import { logProviderError } from "../../ai/provider-error-log";
 import { noteAuthFailure } from "../../auth/credential-health";
+import { reportRevokedServedToken } from "../../auth/report-revoked";
 
 /**
  * Normalize pi's per-message `Usage` into our provider-agnostic `TokenUsage`.
@@ -186,8 +187,11 @@ export function toWire(e: AgentSessionEvent): WireEvent | null {
         // Feed an auth failure into the status surface: the credential the
         // turn just ran on cannot authenticate, so "Connected" would be a lie
         // until it changes (auth/credential-health.ts).
-        if (classified.kind === "unauthenticated")
+        if (classified.kind === "unauthenticated") {
           noteAuthFailure(classified.provider);
+          // A REVOKED served token is invisible to the control plane (HOU-952).
+          reportRevokedServedToken(classified);
+        }
         return { type: "provider_error", data: classified };
       }
       // Otherwise its usage carries the latest request's context size = the

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -16,6 +16,7 @@ import { classifyProviderError } from "../ai/provider-error";
 import { activeEffort, resolveModel } from "../ai/providers";
 import { recordTokenSpend } from "../ai/usage/ledger";
 import { clearAuthFailure, noteAuthFailure } from "../auth/credential-health";
+import { reportRevokedServedToken } from "../auth/report-revoked";
 import { config } from "../config";
 import {
   appendAssistantMessage,
@@ -531,8 +532,11 @@ export async function execTurn(
     // so feed it into the status surface here — e.g. a refresh-bearing entry
     // whose refresh token was rejected raises at prompt time, before any
     // stream exists (auth/credential-health.ts).
-    if (thrown.kind === "unauthenticated" && !providerError)
+    if (thrown.kind === "unauthenticated" && !providerError) {
       noteAuthFailure(thrown.provider);
+      // A REVOKED served token is invisible to the control plane (HOU-952).
+      reportRevokedServedToken(thrown);
+    }
     const typed = thrown.kind !== "unknown" ? thrown : undefined;
     appendAssistantMessage(id, assistantText, {
       tools,

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -13,6 +13,7 @@ import { DEFAULT_REASONING_EFFORT, toThinkingLevel } from "../ai/effort";
 import { registerCustomProviderIfConfigured } from "../ai/openai-compatible";
 import { classifyProviderError } from "../ai/provider-error";
 import { clearAuthFailure, noteAuthFailure } from "../auth/credential-health";
+import { reportRevokedServedToken } from "../auth/report-revoked";
 import { createPiBackend } from "../backends/pi/backend";
 import { config } from "../config";
 import {
@@ -323,7 +324,11 @@ export async function runPiTurn(
       // A thrown auth failure never crossed the backends' streamed-error
       // seams — feed it into the status surface (auth/credential-health.ts;
       // mirrors exec-turn).
-      if (thrown.kind === "unauthenticated") noteAuthFailure(thrown.provider);
+      if (thrown.kind === "unauthenticated") {
+        noteAuthFailure(thrown.provider);
+        // A REVOKED served token is invisible to the control plane (HOU-952).
+        reportRevokedServedToken(thrown);
+      }
       if (thrown.kind !== "unknown") {
         appendAssistantMessageAt(
           conversationsDir,


### PR DESCRIPTION
Part 2 of 2 for HOU-952 / Sentry [HOUSTON-APP-4YA](https://houston-cd.sentry.io/issues/7622113876/). The gateway primitive this calls is cloud#190 — **merge that first**.

## The problem

**3,935 failed turns across 58 users**, still firing. Every sampled event is `deployment=managed-cloud`, `server_name=agent-…-<pod>` — production engine pods, all `401 OAuth access token has been revoked`.

A revoked token is **not an expired one**. Nothing on the serve path can tell them apart — the credential is present and unexpired — so the control plane keeps handing the dead token to every runtime in the workspace and every turn 401s until the clock runs out. That is the ~68 failed turns per affected user.

The turn that just failed is the only witness, and until now it only whispered: `auth/credential-health.ts` marks the provider unusable in **this process's memory**, which the workspace's other runtimes cannot read. Its own docblock names the case — *"a centrally-served token revoked upstream"* — but the signal never left the pod.

## The change

The runtime reports the revocation. The token is named by **sha256 digest**, never by value, so it never leaves the process or lands in a log. The store does a compare-and-delete: the row goes only while that token is still the stored one.

Path: runtime → `POST /sandbox/credential/revoked` (existing sandbox-token channel) → `CredentialStore.removeIfAccess` → for a pod, `DELETE` with `x-houston-if-access-sha256` → gateway compares under its per-`(org, provider)` row lock.

### Every gate is load-bearing

This is a DELETE trigger for a workspace-wide credential, so the gating *is* the feature:

- **`token_revoked` only** — never `unauthenticated` at large. The broad kind covers transient provider blips and bad keys; reporting those would delete a credential that is fine. `token_revoked` is the terminal cause per `packages/protocol/src/provider-error.ts:15`.
- **Serve mode + the SERVED manifest.** A credential this runtime owns locally (a desktop keychain login) never backed the turn and is none of the control plane's business.
- **OAuth only.** An api_key has no revocation semantics worth acting on, and treating one as revoked would delete a key the user still wants.

I verified the first two gates are real by removing them: the corresponding tests fail. They are not decorative.

**Fire-and-forget, never throws.** It runs inside error handling for a turn that already failed; a reporting hiccup must not replace the real provider error the user needs to see. A superseded report (`removed:false`) is an ordinary outcome — the workspace reconnected, or a sibling pod reported first — not an error to escalate.

**The pod-local mark stays.** It is what stops *this* runtime claiming "Connected". This is the other half.

## Notable

`accessDigest` lives in `@houston/protocol` because three processes must agree on it byte-for-byte: the runtime computes it, the host forwards it, the Go gateway compares against `store.AccessDigest`. It is a **subpath export**, not part of the barrel — the barrel is browser-facing and `node:crypto` does not resolve in `app`/`packages/web`. (The pre-commit hook caught exactly that; hence the subpath.)

`CredentialStore` grows `removeIfAccess`, implemented by every adapter and added to the **shared contract** (`testing/credential-contract.ts`), so Memory and File are both held to compare-before-delete.

## Test plan

`packages/runtime/src/auth/report-revoked.test.ts` — 6 tests, five of which assert what must **not** produce a report:
- reports a revoked served token, naming it by digest only (and asserts the raw token is absent from the body)
- does NOT report a non-terminal auth failure
- does NOT report a credential this runtime owns locally
- does NOT report when serve mode is off
- does NOT report an api_key credential
- a failing control plane never throws into the caller

Contract additions (run against **both** Memory and File adapters): drops the reported token; **spares a credential that moved on**; absent credential is `false` not an error; scoped to one `(workspace, provider)` even when two workspaces hold an identical token.

`pnpm typecheck` (all 25 projects incl. app + web), `pnpm check`, `pnpm check:boundaries`, and the host/runtime/domain suites all green — 1,984 tests.

## Scope

Fixes the *aftermath* of a revocation: one honest reconnect prompt instead of dozens of failing turns. Does **not** stop the revocation — that is HOU-950 item A (one refresh-token family per rotator), which needs a product decision on how a team space acquires its subscription.