### PR TITLE
fix(host): tolerate a BOM in .houston docs and fail-isolate the scheduler sweep (HOU-953)

### DIFF
--- a/packages/domain/src/domain.test.ts
+++ b/packages/domain/src/domain.test.ts
@@ -810,6 +810,27 @@ test("config: object round-trip; junk reported as empty + diagnostic", async () 
   expect(bad.diagnostics).toHaveLength(1);
 });
 
+test("a UTF-8 BOM is decoded away, not read as corruption", async () => {
+  // Files-first docs are written by agents, users and editors, and plenty emit
+  // a BOM. `JSON.parse` rejects one, so the read used to throw and declare the
+  // user's intact data unreadable — which stopped every routine on a pod for
+  // six days (HOU-953). Every TextStore impl must tolerate it, not just the
+  // host's Vfs.
+  const store = memStore();
+  const routines = [
+    createRoutine({ name: "R", prompt: "p", schedule: "0 9 * * *" }, "r1", NOW),
+  ];
+  await store.writeText(
+    docKey(ROOT, "routines"),
+    `﻿${JSON.stringify(routines)}`,
+  );
+
+  const loaded = await loadRoutines(store, ROOT);
+  expect(loaded.items).toHaveLength(1);
+  expect(loaded.items[0]?.id).toBe("r1");
+  expect(loaded.diagnostics).toEqual([]);
+});
+
 test("missing files load as empty, never throw", async () => {
   const store = memStore();
   expect((await loadActivities(store, ROOT)).items).toEqual([]);

--- a/packages/domain/src/store.ts
+++ b/packages/domain/src/store.ts
@@ -35,8 +35,14 @@ export async function loadJson<T>(
 ): Promise<T> {
   const raw = await store.readText(key);
   if (raw === null) return fallback;
+  // A leading byte-order mark is an encoding artifact, not content: files-first
+  // docs get hand-written by agents, users and editors, and `JSON.parse` rejects
+  // a BOM outright (HOU-953). The host's Vfs already drops it on decode; strip
+  // here too so EVERY TextStore impl reads a BOM'd doc rather than declaring the
+  // user's data corrupt over one invisible byte.
+  const text = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
   try {
-    return JSON.parse(raw) as T;
+    return JSON.parse(text) as T;
   } catch (err) {
     throw new Error(
       `${key} is not valid JSON (${err instanceof Error ? err.message : String(err)})`,

--- a/packages/host/src/schedule/agent-scan.ts
+++ b/packages/host/src/schedule/agent-scan.ts
@@ -1,0 +1,157 @@
+import { dueAt, loadRoutines } from "@houston/domain";
+import type { Routine } from "@houston/protocol";
+import { TurnFireError } from "../channel/fire-error";
+import type { Agent, Workspace } from "../domain/types";
+import type { EventHub } from "../events/hub";
+import type { WorkspacePaths } from "../paths";
+import type { Vfs } from "../vfs";
+import { reconcileAgentRuns } from "./reconcile";
+import { fireRoutineRun, RoutineBusyError } from "./run";
+
+/** A due routine to run, with its resolved conversation + run id. */
+export interface FiringJob {
+  workspace: Workspace;
+  agent: Agent;
+  routine: Routine;
+  conversationId: string;
+  runId: string;
+}
+
+/**
+ * Runs a due routine's prompt as a turn. Deployment-specific (the firing path
+ * differs cloud vs local), injected into the driver. `fire` resolves once the
+ * turn is ACCEPTED, not when it completes — the run's running→surfaced/silent
+ * transition is driven by turn completion.
+ */
+export interface RoutineFirer {
+  fire(job: FiringJob): Promise<void>;
+}
+
+/** The dedup primitive the scheduler needs from the bus (atomic set-if-absent). */
+export interface FireLock {
+  setNx(key: string, value: string, ttlSec: number): Promise<boolean>;
+}
+
+/** What one agent's scan needs — SchedulerDeps minus the workspace listing. */
+export interface AgentScanDeps {
+  vfs: Vfs;
+  paths: WorkspacePaths;
+  lock: FireLock;
+  firer: RoutineFirer;
+  events?: EventHub;
+  now: () => Date;
+  newId: () => string;
+  /** Dedup-lock TTL (s); must exceed the scan interval. */
+  dedupTtlSec: number;
+}
+
+const reason = (err: unknown) =>
+  err instanceof Error ? err.message : String(err);
+
+/**
+ * One agent's slice of a tick: fire the routines that came due in
+ * (`since`, `now`], then settle the runs whose turn has finished.
+ *
+ * The two halves are isolated from each other, and from the sweep that calls
+ * this. Houston is files-first — agents write their own `.houston` docs — so ANY
+ * of them can be unreadable at any moment, and an unreadable document must cost
+ * exactly the reader that needs it. A single BOM-prefixed routines.json threw
+ * out of the whole scan loop and stopped every routine on a pod for six days
+ * (HOU-953); now a broken routines.json still lets that agent's runs settle, and
+ * a broken agent still lets every other agent fire.
+ *
+ * This is the background scan with no UI thread to toast on, so a failure logs
+ * (the sanctioned `console.error` boundary) and the sweep continues.
+ */
+export async function scanAgent(
+  deps: AgentScanDeps,
+  ws: Workspace,
+  agent: Agent,
+  timezone: string | null,
+  since: Date,
+  now: Date,
+): Promise<void> {
+  const where = `${ws.id}/${agent.id}`;
+  try {
+    const root = deps.paths.agentRoot(ws, agent);
+    const { items: routines } = await loadRoutines(deps.vfs, root);
+    for (const routine of routines) {
+      const at = dueAt(routine, since, now, timezone);
+      if (!at) continue;
+      // The instant is replica-independent → all replicas race for one key.
+      const won = await deps.lock.setNx(
+        `routine:fired:${routine.id}:${at.toISOString()}`,
+        "1",
+        deps.dedupTtlSec,
+      );
+      if (won) await fireRoutine(deps, ws, agent, routine);
+    }
+  } catch (err) {
+    console.error(`[scheduler] ${where} routine scan failed:`, reason(err));
+  }
+
+  // Complete runs whose turn has finished (silent/surfaced/timeout). Runs live
+  // in their own document, so they settle even when routines.json is unreadable.
+  try {
+    await reconcileAgentRuns(
+      {
+        vfs: deps.vfs,
+        paths: deps.paths,
+        lock: deps.lock,
+        events: deps.events,
+        now: deps.now,
+        newId: deps.newId,
+      },
+      ws,
+      agent,
+    );
+  } catch (err) {
+    console.error(`[scheduler] ${where} run reconcile failed:`, reason(err));
+  }
+}
+
+/**
+ * Record + fire one due routine. Shares `fireRoutineRun` with the on-demand
+ * "run now" route, so a scheduled run and a hand-pressed one are identical
+ * (same record, same firer, same errored-on-fail bookkeeping). The helper
+ * rethrows a fire failure; here we log it and let the scan continue to the
+ * next routine.
+ */
+async function fireRoutine(
+  deps: AgentScanDeps,
+  ws: Workspace,
+  agent: Agent,
+  routine: Routine,
+): Promise<void> {
+  try {
+    await fireRoutineRun(
+      {
+        vfs: deps.vfs,
+        paths: deps.paths,
+        firer: deps.firer,
+        events: deps.events,
+        now: deps.now,
+        newId: deps.newId,
+      },
+      ws,
+      agent,
+      routine,
+    );
+  } catch (err) {
+    // Expected when the previous run is still in flight — the instant is
+    // skipped (its dedup lock is already burned), not an error.
+    if (err instanceof RoutineBusyError) return;
+    // A routine firing while the workspace has no provider connected is an
+    // expected user state, not an engine fault (HOUSTON-APP-4XM): the run is
+    // already recorded errored with the real reason (user-visible in the
+    // routine's history), so a warning breadcrumb suffices here.
+    if (err instanceof TurnFireError && err.code === "no_provider") {
+      console.warn(`[scheduler] routine ${routine.id} skipped: ${err.message}`);
+      return;
+    }
+    console.error(
+      `[scheduler] routine ${routine.id} fire failed:`,
+      reason(err),
+    );
+  }
+}

--- a/packages/host/src/schedule/scheduler.test.ts
+++ b/packages/host/src/schedule/scheduler.test.ts
@@ -206,3 +206,82 @@ test("the workspace timezone preference re-times routines (account-wide zone)", 
   expect(firer.jobs).toHaveLength(1);
   expect(firer.jobs[0]?.routine.schedule).toBe("0 9 * * *");
 });
+
+/**
+ * Fail-isolation (HOU-953). A files-first agent writes its own `.houston` docs,
+ * so any of them can be unreadable at any moment. `tick` advances `lastTick`
+ * before it scans, so a throw that escapes the sweep doesn't just skip a
+ * workspace — it drops that window's instants for every agent behind it,
+ * permanently and silently. The sweep must survive one bad document.
+ */
+
+/** Silence the sanctioned scan-failure logs while asserting the sweep goes on. */
+function muteConsole() {
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  return { error, restore: () => error.mockRestore() };
+}
+
+test("a BOM'd routines.json still fires — the byte is decoded, not fatal", async () => {
+  const env = await setup([routine({ schedule: ENABLED })]);
+  const key = `${workspaceRoot(env.ws, env.agent)}/.houston/routines/routines.json`;
+  const raw = await env.vfs.readText(key);
+  await env.vfs.writeBytes(key, Buffer.from(`﻿${raw}`, "utf8"));
+
+  const firer = new CaptureFirer();
+  const s = makeScheduler(env, firer);
+  s.start();
+  await s.tick(DUE);
+
+  expect(firer.jobs).toHaveLength(1);
+});
+
+test("an unreadable routines.json costs that agent only — every other agent still fires", async () => {
+  const env = await setup([routine({ schedule: ENABLED })]);
+  // A second agent whose routines.json is mangled beyond decoding.
+  const broken = await env.store.createAgent({
+    workspaceId: env.ws.id,
+    name: "Broken",
+  });
+  await env.vfs.writeText(
+    `${workspaceRoot(env.ws, broken)}/.houston/routines/routines.json`,
+    "{not json",
+  );
+
+  const firer = new CaptureFirer();
+  const s = makeScheduler(env, firer);
+  const log = muteConsole();
+  try {
+    s.start();
+    await s.tick(DUE);
+    // Named, never swallowed: the broken agent surfaces in the logs...
+    expect(log.error).toHaveBeenCalled();
+  } finally {
+    log.restore();
+  }
+  // ...and the healthy agent's routine still fired.
+  expect(firer.jobs).toHaveLength(1);
+  expect(firer.jobs[0]?.agent.id).toBe(env.agent.id);
+});
+
+test("an unreadable routines.json still lets that agent's runs settle", async () => {
+  // Runs live in their own document; a broken routines.json must not strand
+  // in-flight runs as permanently "running".
+  const env = await setup([routine({ schedule: ENABLED })]);
+  const firer = new CaptureFirer();
+  const s = makeScheduler(env, firer);
+  s.start();
+  await s.tick(DUE); // records a running run
+
+  const root = workspaceRoot(env.ws, env.agent);
+  await env.vfs.writeText(`${root}/.houston/routines/routines.json`, "{ bad");
+  const log = muteConsole();
+  try {
+    // The reconcile half runs even though the routine half threw.
+    await expect(
+      s.tick(new Date(DUE.getTime() + 60_000)),
+    ).resolves.toBeUndefined();
+    expect(log.error).toHaveBeenCalled();
+  } finally {
+    log.restore();
+  }
+});

--- a/packages/host/src/schedule/scheduler.ts
+++ b/packages/host/src/schedule/scheduler.ts
@@ -1,37 +1,12 @@
-import { dueAt, getPreference, loadRoutines } from "@houston/domain";
-import type { Routine } from "@houston/protocol";
-import { TurnFireError } from "../channel/fire-error";
-import type { Agent, Workspace } from "../domain/types";
+import { getPreference } from "@houston/domain";
+import type { Workspace } from "../domain/types";
 import type { EventHub } from "../events/hub";
 import type { WorkspacePaths } from "../paths";
 import type { WorkspaceStore } from "../ports";
 import type { Vfs } from "../vfs";
-import { reconcileAgentRuns } from "./reconcile";
-import { fireRoutineRun, RoutineBusyError } from "./run";
+import { type FireLock, type RoutineFirer, scanAgent } from "./agent-scan";
 
-/** A due routine to run, with its resolved conversation + run id. */
-export interface FiringJob {
-  workspace: Workspace;
-  agent: Agent;
-  routine: Routine;
-  conversationId: string;
-  runId: string;
-}
-
-/**
- * Runs a due routine's prompt as a turn. Deployment-specific (the firing path
- * differs cloud vs local), injected into the driver. `fire` resolves once the
- * turn is ACCEPTED, not when it completes — the run's running→surfaced/silent
- * transition is driven by turn completion (wired with the firer in 3.4b).
- */
-export interface RoutineFirer {
-  fire(job: FiringJob): Promise<void>;
-}
-
-/** The dedup primitive the scheduler needs from the bus (atomic set-if-absent). */
-export interface FireLock {
-  setNx(key: string, value: string, ttlSec: number): Promise<boolean>;
-}
+export type { FireLock, FiringJob, RoutineFirer } from "./agent-scan";
 
 export interface SchedulerDeps {
   store: WorkspaceStore;
@@ -59,6 +34,11 @@ export interface SchedulerDeps {
  * Deployment-agnostic: cloud and local inject their own RoutineFirer + lock
  * (Redis vs in-process). lastTick resets to `now` on start, so a freshly
  * started replica never replays history.
+ *
+ * The sweep is fail-isolated at every level (HOU-953): a workspace or agent
+ * that throws is logged and skipped, never allowed to abort the tick. `lastTick`
+ * has already advanced by then, so an escaping throw would drop that window's
+ * instants for every agent behind it — permanently, and silently.
  */
 export class Scheduler {
   private timer: ReturnType<typeof setInterval> | undefined;
@@ -103,87 +83,54 @@ export class Scheduler {
     const since = this.lastTick;
     this.lastTick = now;
 
-    for (const ws of await this.deps.store.listWorkspaces()) {
-      // One account-wide zone governs every routine in the workspace (HOU-470:
-      // no per-routine override). Re-read it each tick, so when the preference
-      // changes the next scan re-times every routine — the cloud analog of the
-      // Rust scheduler's respawn-on-tz-change.
-      const timezone = await getPreference(this.deps.vfs, ws.id, "timezone");
-      for (const agent of await this.deps.store.listAgents(ws.id)) {
-        const root = this.deps.paths.agentRoot(ws, agent);
-        const { items: routines } = await loadRoutines(this.deps.vfs, root);
-        for (const routine of routines) {
-          const at = dueAt(routine, since, now, timezone);
-          if (!at) continue;
-          // The instant is replica-independent → all replicas race for one key.
-          const won = await this.deps.lock.setNx(
-            `routine:fired:${routine.id}:${at.toISOString()}`,
-            "1",
-            this.dedupTtlSec,
-          );
-          if (won) await this.fireRoutine(ws, agent, routine);
-        }
-        // Complete runs whose turn has finished (silent/surfaced/timeout).
-        await reconcileAgentRuns(
-          {
-            vfs: this.deps.vfs,
-            paths: this.deps.paths,
-            lock: this.deps.lock,
-            events: this.deps.events,
-            now: this.now,
-            newId: this.newId,
-          },
-          ws,
-          agent,
-        );
-      }
+    let workspaces: Workspace[];
+    try {
+      workspaces = await this.deps.store.listWorkspaces();
+    } catch (err) {
+      console.error("[scheduler] workspace listing failed:", reason(err));
+      return;
+    }
+    for (const ws of workspaces) {
+      await this.scanWorkspace(ws, since, now);
     }
   }
 
   /**
-   * Record + fire one due routine. Shares `fireRoutineRun` with the on-demand
-   * "run now" route, so a scheduled run and a hand-pressed one are identical
-   * (same record, same firer, same errored-on-fail bookkeeping). The helper
-   * rethrows a fire failure; here — the background scan, with no UI thread to
-   * toast on — we log it (the one sanctioned `console.error` boundary).
+   * One workspace's scan. Its timezone read and agent listing are shared by
+   * every agent below it, so a failure here skips this workspace only — the
+   * others still fire.
    */
-  private async fireRoutine(
+  private async scanWorkspace(
     ws: Workspace,
-    agent: Agent,
-    routine: Routine,
+    since: Date,
+    now: Date,
   ): Promise<void> {
     try {
-      await fireRoutineRun(
-        {
-          vfs: this.deps.vfs,
-          paths: this.deps.paths,
-          firer: this.deps.firer,
-          events: this.deps.events,
-          now: this.now,
-          newId: this.newId,
-        },
-        ws,
-        agent,
-        routine,
-      );
-    } catch (err) {
-      // Expected when the previous run is still in flight — the instant is
-      // skipped (its dedup lock is already burned), not an error.
-      if (err instanceof RoutineBusyError) return;
-      // A routine firing while the workspace has no provider connected is an
-      // expected user state, not an engine fault (HOUSTON-APP-4XM): the run is
-      // already recorded errored with the real reason (user-visible in the
-      // routine's history), so a warning breadcrumb suffices here.
-      if (err instanceof TurnFireError && err.code === "no_provider") {
-        console.warn(
-          `[scheduler] routine ${routine.id} skipped: ${err.message}`,
+      // One account-wide zone governs every routine in the workspace (HOU-470:
+      // no per-routine override). Re-read it each tick, so when the preference
+      // changes the next scan re-times every routine.
+      const timezone = await getPreference(this.deps.vfs, ws.id, "timezone");
+      const agents = await this.deps.store.listAgents(ws.id);
+      for (const agent of agents) {
+        await scanAgent(
+          {
+            ...this.deps,
+            now: this.now,
+            newId: this.newId,
+            dedupTtlSec: this.dedupTtlSec,
+          },
+          ws,
+          agent,
+          timezone,
+          since,
+          now,
         );
-        return;
       }
-      console.error(
-        `[scheduler] routine ${routine.id} fire failed:`,
-        err instanceof Error ? err.message : err,
-      );
+    } catch (err) {
+      console.error(`[scheduler] workspace ${ws.id} scan failed:`, reason(err));
     }
   }
 }
+
+const reason = (err: unknown) =>
+  err instanceof Error ? err.message : String(err);

--- a/packages/host/src/testing/vfs-contract.ts
+++ b/packages/host/src/testing/vfs-contract.ts
@@ -30,6 +30,26 @@ export function runVfsContract(name: string, make: () => Vfs): void {
       expect(await vfs.readBytes(`${P}/nope.bin`)).toBeNull();
     });
 
+    test("readText drops a leading BOM; readBytes keeps the file verbatim", async () => {
+      // A files-first doc can be written by any editor or agent, and plenty
+      // emit a UTF-8 BOM. `JSON.parse` rejects one outright, so a BOM'd
+      // routines.json bricked every routine on a pod (HOU-953). Text reads
+      // decode it away; byte reads stay lossless (downloads, binary seeds).
+      const vfs = make();
+      const bommed = `﻿[{"id":"a"}]`;
+      await vfs.writeBytes(
+        `${P}/data/routines.json`,
+        Buffer.from(bommed, "utf8"),
+      );
+
+      const text = await vfs.readText(`${P}/data/routines.json`);
+      expect(text).toBe(`[{"id":"a"}]`);
+      expect(JSON.parse(text as string)).toEqual([{ id: "a" }]);
+      expect((await vfs.readBytes(`${P}/data/routines.json`))?.length).toBe(
+        Buffer.byteLength(bommed, "utf8"),
+      );
+    });
+
     test("list/listDetailed are prefix-scoped and sorted; no cross-prefix leak", async () => {
       const vfs = make();
       await vfs.writeText(`${P}/workspace/b.txt`, "b");

--- a/packages/host/src/vfs/fs.ts
+++ b/packages/host/src/vfs/fs.ts
@@ -9,7 +9,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { dirname, join, sep } from "node:path";
-import { assertSafeKey, type ObjectStat, type Vfs } from "./vfs";
+import { assertSafeKey, decodeText, type ObjectStat, type Vfs } from "./vfs";
 
 /**
  * Real-filesystem Vfs — the local profile's adapter. Keys map 1:1 to paths
@@ -83,7 +83,7 @@ export class FsVfs implements Vfs {
 
   async readText(key: string): Promise<string | null> {
     const buf = await this.readBytes(key);
-    return buf ? buf.toString("utf8") : null;
+    return buf ? decodeText(buf) : null;
   }
 
   async readBytes(key: string): Promise<Buffer | null> {

--- a/packages/host/src/vfs/index.ts
+++ b/packages/host/src/vfs/index.ts
@@ -1,6 +1,6 @@
 export { FsVfs } from "./fs";
 export { MemoryVfs } from "./memory";
-export { assertSafeKey, type ObjectStat, type Vfs } from "./vfs";
+export { assertSafeKey, decodeText, type ObjectStat, type Vfs } from "./vfs";
 // The closed GcsVfs adapter was retired with `@houston/host-cloud` (git
 // history); any out-of-repo Vfs adapter binds behind the port, never through
 // this open barrel.

--- a/packages/host/src/vfs/memory.ts
+++ b/packages/host/src/vfs/memory.ts
@@ -1,4 +1,4 @@
-import { assertSafeKey, type ObjectStat, type Vfs } from "./vfs";
+import { assertSafeKey, decodeText, type ObjectStat, type Vfs } from "./vfs";
 
 /** In-memory Vfs for tests and CP_DEV=1. */
 export class MemoryVfs implements Vfs {
@@ -27,7 +27,8 @@ export class MemoryVfs implements Vfs {
   }
 
   async readText(key: string): Promise<string | null> {
-    return this.files.get(key)?.content.toString("utf8") ?? null;
+    const buf = this.files.get(key)?.content;
+    return buf ? decodeText(buf) : null;
   }
 
   async readBytes(key: string): Promise<Buffer | null> {

--- a/packages/host/src/vfs/vfs.ts
+++ b/packages/host/src/vfs/vfs.ts
@@ -38,6 +38,22 @@ export interface Vfs {
   deletePrefix(prefix: string): Promise<void>;
 }
 
+/**
+ * Decode UTF-8 file bytes, dropping a leading byte-order mark.
+ *
+ * A BOM is an encoding artifact, not content — but Node's decoder keeps it and
+ * `JSON.parse` rejects it, so one invisible byte permanently bricks a document.
+ * Houston is files-first: agents and users write `.houston` docs directly, and
+ * plenty of editors and tools emit a BOM (the Windows default). A BOM-prefixed
+ * routines.json stopped every routine on a pod for six days (HOU-953). Stripping
+ * it at the single decode door fixes every reader at once — JSON docs, CLAUDE.md,
+ * skills — and the next save rewrites the file clean, so it self-heals.
+ */
+export function decodeText(bytes: Buffer): string {
+  const text = bytes.toString("utf8");
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
 /** Reject traversal/absolute keys before any impl maps them anywhere. */
 export function assertSafeKey(key: string): void {
   if (


### PR DESCRIPTION
Fixes HOU-953. Sentry: HOUSTON-APP-4Z2 — 5,935 events, 3 users, one every 30s since 2026-07-21, still firing.

```text
[scheduler] tick failed: Personal/Ingeniero automatizacion/.houston/routines/routines.json is not valid JSON (Unexpected token '﻿', "﻿[{"id":"a"... is not valid JSON)
```

## Root cause

Two defects, one symptom: the affected pod's routines silently stopped running.

**1. A UTF-8 BOM makes a good document unreadable.** The file's JSON was intact — it just carried a leading byte-order mark. Node's decoder keeps a BOM and `JSON.parse` rejects it outright, so `loadJson` threw and declared the user's data corrupt over one invisible byte. Houston is files-first: agents, users and editors write `.houston` docs directly, and plenty of tools emit a BOM (the Windows default). This was never routines-specific — it applies to every JSON doc read through the Vfs.

**2. One unreadable file wedged the entire sweep.** This is the severe one; the BOM is just what found it. `Scheduler.tick` looped workspaces then agents with no isolation, so the throw escaped everything:

- no agent behind the failing one was ever scanned
- `reconcileAgentRuns` never ran, so in-flight runs never settled
- `lastTick` had already advanced, so the missed instants were dropped, not replayed

Any malformed agent-written file reproduces it, indefinitely, once every 30s.

## Fix

- **Strip the BOM at the decode door.** `Vfs.readText` (`decodeText` in `vfs/vfs.ts`, used by both Fs and Memory adapters) drops a leading U+FEFF, so every reader benefits at once — JSON docs, `CLAUDE.md`, skills. `readBytes` stays lossless for downloads and binary seeds. `loadJson` strips it too, so any `TextStore` impl is covered, not just the host's Vfs. The next save rewrites the file clean, so an affected agent self-heals.
- **Fail-isolate the sweep.** The per-agent scan moves to `schedule/agent-scan.ts` and is isolated per workspace, per agent, and between its fire and reconcile halves. A failure is logged with the agent named (the sanctioned background-scan `console.error` boundary — no UI thread to toast on) and the sweep continues. A broken routines.json now costs exactly the reader that needs it: that agent's runs still settle, and every other agent still fires.

Tolerating a BOM is a decode fix, not a license to reset mangled data: a genuinely unparseable document still throws with the key named, as before.

`scheduler.ts` 189 → 136 lines; new `agent-scan.ts` 157.

## Verification

Each new test was confirmed to fail against the pre-fix source, not just pass after it.

**Before** (revert `vfs/` + `domain/src/store.ts`, run `vitest src/vfs/contract.test.ts src/schedule/scheduler.test.ts`):
```
× Vfs contract: MemoryVfs > readText drops a leading BOM...
× Vfs contract: FsVfs > readText drops a leading BOM...
× a BOM'd routines.json still fires — the byte is decoded, not fatal
```
**Before** (revert `schedule/`):
```
× an unreadable routines.json costs that agent only — every other agent still fires
× an unreadable routines.json still lets that agent's runs settle
  → Error: .../routines.json is not valid JSON   ← the Sentry error, escaping the tick
```

**After:** `pnpm --filter @houston/host --filter @houston/domain test` → 1041 host + 148 domain passing. Plus `pnpm check` (Biome), `pnpm typecheck` (all 25 projects, via pre-commit), `pnpm check:boundaries`.

New coverage: BOM tolerance pinned in the shared Vfs contract (so both adapters are held to it) and in the domain doc reader; scheduler regression tests for a BOM'd routines.json firing normally, an unreadable agent not costing its neighbours, and runs settling when routines.json is unreadable.

Manual repro on a live pod: prepend `\xEF\xBB\xBF` to any agent's `.houston/routines/routines.json` and watch `[scheduler] tick failed` every 30s with zero routines firing; after this change the routine fires and the byte is gone on next write.