### PR TITLE
fix(runtime): unbreak the engine bundle — drop the serve.ts import cycle (HOU-952)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,20 @@ jobs:
       - name: Typecheck (pnpm workspace)
         run: pnpm -r typecheck
 
+      # The engine pods run the BUNDLED host/runtime, and bundling can fail in
+      # ways nothing above can see: an import that pulls a module into esbuild's
+      # async-init subgraph makes it emit `await init_x()` inside a non-async
+      # wrapper, and the bundle dies at startup with `SyntaxError: Unexpected
+      # reserved word`. That shipped once (HOU-952) — typecheck and 1,984 tests
+      # were green, and the only build that would have caught it runs AFTER
+      # merge. Bundling takes ~50ms; parse the output here instead.
+      - name: Engine bundle parses (host + runtime)
+        run: |
+          set -euo pipefail
+          node selfhost/bundle.mjs
+          node --check dist/runtime/main.mjs
+          node --check dist/host/main.mjs
+
       - name: Unit + contract tests (Vitest)
         run: |
           set -euo pipefail

--- a/packages/runtime/src/auth/report-revoked.ts
+++ b/packages/runtime/src/auth/report-revoked.ts
@@ -3,7 +3,6 @@ import type { ProviderError } from "@houston/protocol";
 import { accessDigest } from "@houston/protocol/access-digest";
 import { config } from "../config";
 import { readAuthFile, readServedProvidersAt } from "./auth-file";
-import { serveModeOn } from "./serve";
 
 /**
  * Tell the control plane when a provider REVOKES a token it served us.
@@ -43,7 +42,14 @@ export function reportRevokedServedToken(err: ProviderError): void {
 
 async function reportRevoked(err: ProviderError): Promise<void> {
   if (err.kind !== "unauthenticated" || err.cause !== "token_revoked") return;
-  if (!serveModeOn()) return;
+  // Serve mode, read straight off config rather than through serve.ts's
+  // serveModeOn(). That import is what broke the engine bundle: serve.ts sits
+  // in an async-initialized cycle (storage -> providers -> serve), so pulling
+  // it in here made THIS module async too, and esbuild then emitted
+  // `await init_report_revoked()` inside backends/claude/errors.ts's
+  // non-async init wrapper -> `SyntaxError: Unexpected reserved word` at
+  // runtime start. Same two reads, no cycle.
+  if (!config.controlPlaneUrl || !config.sandboxToken) return;
 
   const provider = err.provider;
   const served = readServedProvidersAt(


### PR DESCRIPTION
**#1106 broke every engine pod. This is the fix.** I introduced it; found it minutes ago while benchmarking staging.

## The breakage

The bundled runtime fails to **parse** at startup:

```
file:///app/dist/runtime/main.mjs:3340
    await init_report_revoked();
    ^^^^^
SyntaxError: Unexpected reserved word
```

The runtime child process crash-loops, so every turn dies with `runtime exited before becoming healthy`. The pod container stays `Running` — it's the host — which is why nothing looked obviously down.

- **Staging: 219 of 220** agent deployments were on the bad image. Rolled back to `e5b5d908` as mitigation while this lands.
- **Prod: unaffected.** It's on `e448c3b5` (= `004541cc`), pre-#1106. Prod only rolls on a release publish — so **do not publish a train until this merges**, or `ship-train` will resolve the newest engine image and take prod down.

## Cause

`report-revoked.ts` imported `serveModeOn` from `./serve`. `serve.ts` sits in an already-async-initialized cycle (`auth/storage` → `ai/providers` → `auth/serve`), which is harmless while every consumer is itself async. Importing it made `report-revoked` async too, and esbuild then emitted `await init_report_revoked()` inside `backends/claude/errors.ts`'s **non-async** init wrapper.

Confirmed in the generated bundle:

```js
var init_report_revoked = __esm({
  async "packages/runtime/src/auth/report-revoked.ts"() {   // async…
    …
    await init_serve();
});
var init_errors = __esm({
  "packages/runtime/src/backends/claude/errors.ts"() {      // …not async
    await init_report_revoked();                            // SyntaxError
```

`target: node22` supports top-level await, so this isn't a target problem — it's esbuild's async-module codegen meeting a wrapper that can't host an `await`.

## The fix

`serveModeOn()` is exactly `!!config.controlPlaneUrl && !!config.sandboxToken`, and `config` is already imported here as a leaf. Read the two fields directly: identical behavior, no edge into the async subgraph.

Verified: `await init_report_revoked` no longer appears, `node --check` passes on **both** bundles, and the 6 reporter tests still pass unchanged.

## Closing the hole that let it merge green

Nothing in CI bundles the engine. #1106 passed `pnpm check`, `pnpm -r typecheck` across 25 projects, `check:boundaries`, and 1,984 tests — and still shipped a bundle that cannot parse. The only build that would have caught it (`engine-pod-image.yml`) runs **after** merge, on `main`.

The TS-checks job now bundles and parses both outputs. Bundling takes ~50ms. **I verified the guard fails when the cycle is reintroduced** — it is not decorative.

This is the more valuable half of the PR: the class of bug (an import that quietly pulls a module into the async-init subgraph) is invisible to every other check we run.