### PR TITLE
feat: mission-card face stacks show every human, with the landing anatomy

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -77,7 +77,8 @@ Status (each has a `-text`): `danger` `#e02e2a`→`#ef4444` · `success` `#00a24
 Reserved families — do not reach for outside their home:
 - `sidebar*` (`-text`/`-line`/`-hover`/`-active`): sidebar is transparent; `sidebar-active` is the selected-row fill, a clear step above hover.
 - `space-*`: theme-invariant **dark**, ONLY for the workspace-loading splash / `OrbitLoader` / storage-unavailable gate (`app/src/components/space/`). Any themed control placed on it must pin `data-theme="dark"`.
-- `agent.{charcoal,forest,navy,purple,crimson,orange,golden}`: avatar palette — resolve stored ids via `resolveAgentColor` from `@houston-ai/core`, never app-local helpers. Use `HoustonAvatar`.
+- `agent.{charcoal,forest,navy,purple,crimson,orange,golden}`: AGENT avatar palette — resolve stored ids via `resolveAgentColor` from `@houston-ai/core`, never app-local helpers. Use `HoustonAvatar`.
+- `person-{slate,sage,mauve,taupe,indigo}` + `person-initials` + `person-overflow`/`person-overflow-text`: HUMAN avatar palette (mission face stacks). Deliberately desaturated so teammates never compete with agent helmets. Pick a tone with `personToneClass(id)` from `@houston-ai/board` — never by list index, or a person's colour changes when the roster does.
 
 ## 5. Motion rules
 Merge the tokenized scale (§4) with these craft rules:

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,28 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v36 - 2026-07-27
+
+Refine `mission-card` (no new component, no `since` change): its anatomy gains
+`people-face-stack` + `people-overflow-chip` and an `attributed` state -- the
+multi-contributor signal on the shared board (HOU-947). Every human on a mission
+renders as an overlapping ringed avatar over the card body's bottom-right
+corner: a photo when the profile has one, otherwise initials on an OPAQUE
+desaturated person tone (`person.*` design tokens: slate / sage / mauve / taupe
+/ indigo, plus an initials colour and a solid overflow-chip fill/text pair, both
+themes) chosen deterministically from the person's stable id, so one person
+keeps one tone on every card and in the expansion popover. Past five faces the
+rest collapse into a solid, high-contrast "+N" chip that opens the full roster,
+and the card body reserves a right gutter sized to the stack so no text runs
+underneath it. Three rendering defects went with it: the initials fill was
+`chip-subtle` (~96% transparent, so overlapped faces and card text showed
+through the letters), the "+N" chip wore the same translucent fill (it read as a
+hole in the stack), and `TooltipTrigger asChild` was overwriting the avatar's
+`data-slot`, which silently disabled `AvatarGroup`'s 2px ring contract so the
+faces collided edge to edge with no cutout. The stack also takes the surface it
+sits on, so the mission detail panel rings its faces in the panel colour instead
+of the card colour.
+
 ## v35 - 2026-07-26
 
 Refine the shared `CatalogRow` (no new component, no `since` change): its

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 35
+version: 36
 
 components:
   - id: agent-avatar
@@ -452,13 +452,45 @@ components:
   - id: mission-card
     title: Mission card
     purpose: A board card representing one mission/conversation.
-    anatomy: [avatar, title, status-chip, actions, drag-handle, select-checkbox]
-    states: [resting, running, needs-you, error, selected, focused, dragging]
+    anatomy:
+      [
+        avatar,
+        title,
+        status-chip,
+        actions,
+        drag-handle,
+        select-checkbox,
+        people-face-stack,
+        people-overflow-chip,
+      ]
+    states:
+      [
+        resting,
+        running,
+        needs-you,
+        error,
+        selected,
+        focused,
+        dragging,
+        attributed,
+      ]
     variants: [board-card, archived-list-row]
     behavior: >-
       Running state shows the comet glow; approve moves to done. Drag/multi-select
-      are surface-capability gated (pointer drag on desktop).
-    a11y: article/button role; title as label; checkbox labeled; status not color-only.
+      are surface-capability gated (pointer drag on desktop). The people face stack
+      is the multi-contributor signal: every human on the mission, creator first,
+      as overlapping ringed avatars over the card body's bottom-right corner
+      (photo when known, otherwise initials on an opaque desaturated person tone
+      picked deterministically from the person's id, so one person keeps one tone
+      everywhere). Past five faces the rest collapse into a solid "+N" chip that
+      expands to the full roster, and the card body reserves a right gutter sized
+      to the stack so no text ever runs underneath it. Server-stamped attribution
+      only (multiplayer); an unattributed card renders exactly as before.
+    a11y: >-
+      article/button role; title as label; checkbox labeled; status not
+      color-only; the face stack is a labeled group, each face names its person
+      (tooltip + title) and the "+N" chip is a labeled control, so no contributor
+      is reachable by hover alone.
     since: 1
 
   - id: mission-board

--- a/knowledge-base/design-system.md
+++ b/knowledge-base/design-system.md
@@ -93,7 +93,15 @@ The owner vocabulary (say these words to direct changes):
 - **Lines & focus**: `line` (hairlines), `line-input` (field borders), `focus`.
 - **Status**: `danger`, `success`, `warning`, `highlight` (each with `-text`).
 - Untouched families: `space-*` (the workspace-loading splash + OrbitLoader),
-  `agent.*` (avatar palette),
+  `agent.*` (agent avatar palette),
+  `person-*` (HUMAN avatar palette — `slate` / `sage` / `mauve` / `taupe` /
+  `indigo` fills, `person-initials`, and the `person-overflow` /
+  `person-overflow-text` pair for the "+N" chip. Deliberately DESATURATED so a
+  teammate's face never competes with a vivid agent helmet; unlike `agent.*`
+  these ARE bridged to Tailwind utilities (`bg-person-slate`,
+  `text-person-initials`, …) because the mission face stack picks a tone by
+  className, hashed from the person's stable id — see
+  `ui/board/src/kanban-people-tone.ts`),
   `sidebar*` (with `-text`/`-hover`/`-line`/`-active` suffixes; `sidebar-active`
   is the selected-row fill, a clear step above hover in both themes).
 

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -738,10 +738,20 @@ unit-tested: creator first, deduped; label falls back **profile name > stored
 `name` > 8-char id slice**; avatar is the profile image when known).
 
 **Board surface (`@houston-ai/board`).** Generic `KanbanPerson`
-(`{id, label, imageUrl?}`) + a `KanbanPeople` overlapping face stack (max 3 faces
-+ a "+N" chip, initials fallback when no/broken image) render on cards
-(`kanban-card.tsx`) and the detail panel (`kanban-detail-panel.tsx`). Props-only,
-i18n-agnostic (label passed in). Alongside the agent filter, the app adds
+(`{id, label, imageUrl?}`) + a `KanbanPeople` overlapping face stack render on
+cards (`kanban-card.tsx`, up to `CARD_PEOPLE_MAX = 5` faces at `sm`) and the
+detail panel (`kanban-detail-panel.tsx`, 3 at `md`). Anatomy: circles overlapped
+`6px`, each carrying a `2px` ring painted in the SURFACE colour it sits on
+(`input` on cards, `background` on the panel) so an overlap reads as a cutout,
+not a halo; the initials fallback is OPAQUE, a desaturated tone hashed from the
+person's stable id (`personToneClass` — the same teammate wears the same colour
+everywhere, see `DESIGN.md` person palette); the "+N" chip is a solid
+`bg-person-overflow` fill and, when `expandable`, a button whose popover lists
+EVERY contributor. The card body reserves a right gutter sized to the painted
+stack and rounded up to the sanctioned spacing scale (`peopleGutterClass`) so
+the description never runs under the faces — `""` for an unattributed card, which
+keeps a single-player board byte-identical. Props-only, i18n-agnostic (labels
+passed in). Alongside the agent filter, the app adds
 `mission-person-filter.tsx` — a dropdown of **Everyone / My missions / each person
 on the board** (roster from `distinctBoardPeople`), itself gated on
 `isMultiplayer` and a signed-in user.

--- a/knowledge-base/ui-testing.md
+++ b/knowledge-base/ui-testing.md
@@ -68,7 +68,12 @@ cache was warm).
 - **Board = files-first.** Reads/writes `.houston/activity/activity.json` via
   `/agents/:id/agentfile/*` (NOT just `/activities`). Fake host backs it with a
   real store, unified with `/activities` (same data, as in the real host),
-  so a turn's status flip shows on the board.
+  so a turn's status flip shows on the board. Both seeded missions also carry
+  Teams attribution (`created_by` + `contributors`; 2 people and 7 people), so
+  the card face stacks + "+N" chip are testable — but only in multiplayer, on
+  **Mission Control**: the per-agent board opens on the `me` person scope and
+  identity is off in this project, so an attributed mission is filtered out
+  there. Single-player runs (and every visual baseline) see the board unchanged.
 - **Teams mode is armable.** Single-player alone can't reach the Teams-shaped
   state (multiplayer + an integration allowlist ceiling) that the agent
   Integrations tab's locked browse rows need. Two fake-host controls arm it:

--- a/packages/design-tokens/test/legacy-resolved.json
+++ b/packages/design-tokens/test/legacy-resolved.json
@@ -55,7 +55,15 @@
     "ht-agent-purple": "#5b21b6",
     "ht-agent-crimson": "#a3261a",
     "ht-agent-orange": "#b45309",
-    "ht-agent-golden": "#a16207"
+    "ht-agent-golden": "#a16207",
+    "ht-person-slate": "#5b6b7a",
+    "ht-person-sage": "#5e7266",
+    "ht-person-mauve": "#84616b",
+    "ht-person-taupe": "#736550",
+    "ht-person-indigo": "#5b6488",
+    "ht-person-initials": "#ffffff",
+    "ht-person-overflow": "#e6e8ec",
+    "ht-person-overflow-text": "#555b66"
   },
   "dark": {
     "ht-hover": "rgba(255, 255, 255, 0.08)",
@@ -113,6 +121,14 @@
     "ht-agent-purple": "#a78bfa",
     "ht-agent-crimson": "#f87171",
     "ht-agent-orange": "#fb923c",
-    "ht-agent-golden": "#fbbf24"
+    "ht-agent-golden": "#fbbf24",
+    "ht-person-slate": "#647585",
+    "ht-person-sage": "#647a6d",
+    "ht-person-mauve": "#8e6b76",
+    "ht-person-taupe": "#7d6f59",
+    "ht-person-indigo": "#656e93",
+    "ht-person-initials": "#ffffff",
+    "ht-person-overflow": "#4c4c52",
+    "ht-person-overflow-text": "#d4d4d4"
   }
 }

--- a/packages/design-tokens/tokens/primitive/color.json
+++ b/packages/design-tokens/tokens/primitive/color.json
@@ -167,6 +167,48 @@
       "golden-bright": {
         "$value": "#fbbf24"
       }
+    },
+    "person": {
+      "$type": "color",
+      "slate": {
+        "$value": "#5b6b7a"
+      },
+      "slate-bright": {
+        "$value": "#647585"
+      },
+      "sage": {
+        "$value": "#5e7266"
+      },
+      "sage-bright": {
+        "$value": "#647a6d"
+      },
+      "mauve": {
+        "$value": "#84616b"
+      },
+      "mauve-bright": {
+        "$value": "#8e6b76"
+      },
+      "taupe": {
+        "$value": "#736550"
+      },
+      "taupe-bright": {
+        "$value": "#7d6f59"
+      },
+      "indigo": {
+        "$value": "#5b6488"
+      },
+      "indigo-bright": {
+        "$value": "#656e93"
+      },
+      "overflow": {
+        "$value": "#e6e8ec"
+      },
+      "overflow-dark": {
+        "$value": "#4c4c52"
+      },
+      "overflow-text": {
+        "$value": "#555b66"
+      }
     }
   }
 }

--- a/packages/design-tokens/tokens/semantic/color.dark.json
+++ b/packages/design-tokens/tokens/semantic/color.dark.json
@@ -58,6 +58,16 @@
       "crimson": { "$value": "{color.agent.crimson-bright}" },
       "orange": { "$value": "{color.agent.orange-bright}" },
       "golden": { "$value": "{color.agent.golden-bright}" }
+    },
+    "person": {
+      "slate": { "$value": "{color.person.slate-bright}" },
+      "sage": { "$value": "{color.person.sage-bright}" },
+      "mauve": { "$value": "{color.person.mauve-bright}" },
+      "taupe": { "$value": "{color.person.taupe-bright}" },
+      "indigo": { "$value": "{color.person.indigo-bright}" },
+      "initials": { "$value": "{color.base.white}" },
+      "overflow": { "$value": "{color.person.overflow-dark}" },
+      "overflow-text": { "$value": "{color.neutral.250}" }
     }
   }
 }

--- a/packages/design-tokens/tokens/semantic/color.light.json
+++ b/packages/design-tokens/tokens/semantic/color.light.json
@@ -58,6 +58,16 @@
       "crimson": { "$value": "{color.agent.crimson}" },
       "orange": { "$value": "{color.agent.orange}" },
       "golden": { "$value": "{color.agent.golden}" }
+    },
+    "person": {
+      "slate": { "$value": "{color.person.slate}" },
+      "sage": { "$value": "{color.person.sage}" },
+      "mauve": { "$value": "{color.person.mauve}" },
+      "taupe": { "$value": "{color.person.taupe}" },
+      "indigo": { "$value": "{color.person.indigo}" },
+      "initials": { "$value": "{color.base.white}" },
+      "overflow": { "$value": "{color.person.overflow}" },
+      "overflow-text": { "$value": "{color.person.overflow-text}" }
     }
   }
 }

--- a/packages/fake-host/README.md
+++ b/packages/fake-host/README.md
@@ -42,6 +42,15 @@ pnpm --filter @houston/fake-host start   # tsx src/main.ts, listens on :4399
 
 Set `FAKE_HOST_LOG=1` to log every request it serves.
 
+Both seeded missions carry Teams attribution (`created_by` + `contributors`,
+`state-store.ts`): "Plan a trip to Tokyo" has 2 people, "Draft the launch email"
+has 7 — enough to overflow the mission card's five-face cap and render its "+N"
+chip. The app only paints face stacks in multiplayer, so a default single-player
+run (and every visual baseline) is unaffected; arm
+`/__test__/capabilities` `{ multiplayer: true }` to make them appear, and read
+them on Mission Control (the per-agent board's default `me` person scope hides
+missions the signed-in user is not on, and identity is off in the e2e project).
+
 ## `POST /__test__/*` control endpoints
 
 Server-to-server test controls (no CORS gate; the harness calls them directly).

--- a/packages/fake-host/src/state-store.ts
+++ b/packages/fake-host/src/state-store.ts
@@ -205,6 +205,36 @@ export const SEED_USAGE: TokenUsage = {
 export const EPOCH = Date.UTC(2024, 0, 1);
 export const ISO = new Date(EPOCH).toISOString();
 
+/**
+ * Teams attribution on the seeded missions — the humans on each one, exactly as
+ * the gateway stamps them (`created_by` + `contributors`). Two shapes on
+ * purpose: a SMALL stack (creator + one collaborator, both photo-less so the
+ * initials faces render) and a stack that OVERFLOWS the card's five-face cap,
+ * so the "+N" chip has coverage.
+ *
+ * Seeding it on the existing missions (rather than adding cards) is deliberate:
+ * face stacks are multiplayer-gated in the app, so a default single-player run —
+ * including the visual-regression baselines — sees exactly the board it saw
+ * before. A spec arms `/__test__/capabilities` `{ multiplayer: true }` to make
+ * them appear. Names ride on the contributor entries, so a stack renders with
+ * readable labels without a `/v1/org/profiles` round trip (identity is off in
+ * the default e2e project).
+ */
+const SEED_TRIP_CONTRIBUTORS = [
+  { user_id: "u-self", name: "Ada Lovelace" },
+  { user_id: "u-bob", name: "Bob Stone" },
+];
+
+const SEED_LAUNCH_CONTRIBUTORS = [
+  { user_id: "u-self", name: "Ada Lovelace" },
+  { user_id: "u-bob", name: "Bob Stone" },
+  { user_id: "u-cleo", name: "Cleo Nakamura" },
+  { user_id: "u-dmitri", name: "Dmitri Volkov" },
+  { user_id: "u-elena", name: "Elena Ruiz" },
+  { user_id: "u-farid", name: "Farid Haddad" },
+  { user_id: "u-gita", name: "Gita Raman" },
+];
+
 const SEED_ACTIVITIES: Activity[] = [
   {
     id: "act-1",
@@ -212,6 +242,8 @@ const SEED_ACTIVITIES: Activity[] = [
     description: "Research flights and hotels for the spring",
     status: "needs_you",
     updated_at: ISO,
+    created_by: "u-self",
+    contributors: SEED_TRIP_CONTRIBUTORS,
   },
   {
     id: "act-2",
@@ -219,6 +251,8 @@ const SEED_ACTIVITIES: Activity[] = [
     description: "Write the beta announcement to the waitlist",
     status: "done",
     updated_at: ISO,
+    created_by: "u-self",
+    contributors: SEED_LAUNCH_CONTRIBUTORS,
   },
 ];
 

--- a/packages/web/e2e/board-people.spec.ts
+++ b/packages/web/e2e/board-people.spec.ts
@@ -1,0 +1,186 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * Mission cards carry the HUMANS on the mission as an overlapping face stack
+ * (bottom-right of the card body). The attribution is server-stamped — the fake
+ * host seeds `created_by` + `contributors` on both missions (state-store.ts) —
+ * and the app renders it ONLY in multiplayer, so every assertion here first
+ * arms `/__test__/capabilities`.
+ *
+ * What these guard (HOU-947): the stack renders at all (it never did in e2e
+ * before, because nothing seeded attribution), the five-face cap collapses the
+ * rest into a "+N" chip that reaches every contributor, and the faces are
+ * OPAQUE — the bug was a translucent initials fill that let the face behind and
+ * the card's own text show through the letters.
+ */
+
+/** Teams owner: multiplayer + Teams, top role. Face stacks are multiplayer-gated. */
+const TEAMS_CAPS = { multiplayer: true, teams: true, role: "owner" };
+
+/** Accessible group label of a card's face stack (app/src/locales/en/board.json). */
+const PEOPLE_LABEL = "People on this mission";
+
+async function armTeams(request: APIRequestContext): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/capabilities`, {
+    data: TEAMS_CAPS,
+  });
+}
+
+/**
+ * Open Mission Control — the CROSS-AGENT board, the "shared board" the face
+ * stacks were built for. The per-agent board opens on the `me` person scope,
+ * which hides missions the signed-in user is not stamped on; identity is off in
+ * this project (no session uid), so every attributed mission would be filtered
+ * out there. Mission Control has no default person filter.
+ */
+async function openMissionControl(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.locator("[data-tour-target='nav-dashboard']").click();
+}
+
+/** The mission card carrying `title` (the board's `role="option"` cards). */
+function card(page: Page, title: string) {
+  return page.getByRole("option").filter({ hasText: title });
+}
+
+/**
+ * The face stack on that card. Addressed by attribute, not `getByRole`: the
+ * card is an ARIA `option`, whose children are PRESENTATIONAL — the stack's
+ * `role="group"` (and the chip's `button`) never reach the accessibility tree,
+ * so a role query inside a card matches nothing.
+ */
+function stack(page: Page, title: string) {
+  return card(page, title).locator(
+    `[role="group"][aria-label="${PEOPLE_LABEL}"]`,
+  );
+}
+
+/** The expandable "+N" overflow chip on that card's stack. */
+function overflowChip(page: Page, title: string) {
+  return stack(page, title).locator('button[aria-label="All people"]');
+}
+
+test("a two-person mission shows both faces, no overflow chip", async ({
+  page,
+  request,
+}) => {
+  await armTeams(request);
+  await openMissionControl(page);
+  await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible();
+
+  const faces = stack(page, "Plan a trip to Tokyo").locator(
+    '[data-slot="avatar"]',
+  );
+  await expect(faces).toHaveCount(2);
+  // Each face carries the 2px surface-colored ring that makes the overlap read
+  // as a cutout. `AvatarGroup` paints it through `*:data-[slot=avatar]`, so this
+  // also guards the slot marker the tooltip trigger used to clobber.
+  for (const i of [0, 1]) {
+    const ring = await faces
+      .nth(i)
+      .evaluate((el) => getComputedStyle(el).boxShadow);
+    expect(ring).not.toBe("none");
+  }
+  // Photo-less people fall back to initials, derived from the stored
+  // contributor names ("Ada Lovelace" -> AL, "Bob Stone" -> BS).
+  await expect(faces.nth(0)).toHaveText("AL");
+  await expect(faces.nth(1)).toHaveText("BS");
+  await expect(overflowChip(page, "Plan a trip to Tokyo")).toHaveCount(0);
+});
+
+test("a seven-person mission caps at five faces and shows a +2 chip", async ({
+  page,
+  request,
+}) => {
+  await armTeams(request);
+  await openMissionControl(page);
+  await expect(page.getByText("Draft the launch email")).toBeVisible();
+
+  const launch = stack(page, "Draft the launch email");
+  await expect(launch.locator('[data-slot="avatar"]')).toHaveCount(5);
+
+  const chip = overflowChip(page, "Draft the launch email");
+  await expect(chip).toBeVisible();
+  await expect(chip).toHaveText("+2");
+});
+
+test("the +N chip expands to every contributor, none unreachable", async ({
+  page,
+  request,
+}) => {
+  await armTeams(request);
+  await openMissionControl(page);
+  await expect(page.getByText("Draft the launch email")).toBeVisible();
+
+  await overflowChip(page, "Draft the launch email").click();
+
+  // All seven, including the two hidden behind the chip.
+  for (const name of [
+    "Ada Lovelace",
+    "Bob Stone",
+    "Cleo Nakamura",
+    "Dmitri Volkov",
+    "Elena Ruiz",
+    "Farid Haddad",
+    "Gita Raman",
+  ]) {
+    await expect(page.getByRole("dialog").getByText(name)).toBeVisible();
+  }
+});
+
+test("initials faces are opaque, so an overlapped face never bleeds through", async ({
+  page,
+  request,
+}) => {
+  await armTeams(request);
+  await openMissionControl(page);
+  await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible();
+
+  const fallbacks = stack(page, "Plan a trip to Tokyo").locator(
+    '[data-slot="avatar-fallback"]',
+  );
+  await expect(fallbacks).toHaveCount(2);
+
+  // The regression: `bg-chip-subtle` resolves to ~3.5% alpha ink. Every face
+  // must now paint a fully opaque person tone instead.
+  const count = await fallbacks.count();
+  for (let i = 0; i < count; i++) {
+    const alpha = await fallbacks.nth(i).evaluate((el) => {
+      const match = /^rgba?\(([^)]+)\)$/.exec(
+        getComputedStyle(el).backgroundColor,
+      );
+      if (!match) return Number.NaN;
+      const parts = match[1].split(",").map((p) => p.trim());
+      return parts.length === 4 ? Number(parts[3]) : 1;
+    });
+    expect(alpha).toBe(1);
+  }
+});
+
+test("the card body reserves a gutter so text never runs under the stack", async ({
+  page,
+  request,
+}) => {
+  await armTeams(request);
+  await openMissionControl(page);
+  await expect(page.getByText("Draft the launch email")).toBeVisible();
+
+  const description = card(page, "Draft the launch email").getByText(
+    "Write the beta announcement to the waitlist",
+  );
+  // The CONTENT edge, not the border box: the reserve is the paragraph's own
+  // padding-right, so its border box still spans the full card body.
+  const textRight = await description.evaluate(
+    (el) =>
+      el.getBoundingClientRect().right -
+      Number.parseFloat(getComputedStyle(el).paddingRight),
+  );
+  const stackBox = await stack(page, "Draft the launch email").boundingBox();
+  if (!stackBox) throw new Error("face stack did not lay out");
+
+  // Text must stop before the stack begins — no horizontal overlap. The ring
+  // bleeds 2px left of the first face, so compare against that painted edge.
+  expect(textRight).toBeLessThanOrEqual(stackBox.x - 2);
+});

--- a/ui/board/src/index.ts
+++ b/ui/board/src/index.ts
@@ -25,7 +25,10 @@ export { KanbanListItem } from "./kanban-list-item";
 export { KANBAN_LIST_RAIL_CLASS_NAME } from "./kanban-list-layout";
 export type { KanbanListRailProps } from "./kanban-list-rail";
 export { KanbanListRail } from "./kanban-list-rail";
-export type { KanbanPeopleProps } from "./kanban-people";
+export type {
+  KanbanPeopleProps,
+  KanbanPeopleSurface,
+} from "./kanban-people";
 export {
   CARD_PEOPLE_MAX,
   initialsFor,
@@ -33,6 +36,8 @@ export {
   overflowCount,
   visiblePeople,
 } from "./kanban-people";
+export type { PersonToneClass } from "./kanban-people-tone";
+export { personToneClass } from "./kanban-people-tone";
 export type {
   BoardSearchSnippet,
   ConversationEntry,

--- a/ui/board/src/kanban-card.tsx
+++ b/ui/board/src/kanban-card.tsx
@@ -8,7 +8,11 @@ import {
 import { Check, Pencil, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { KanbanPeople } from "./kanban-people";
-import { CARD_PEOPLE_MAX } from "./kanban-people-logic";
+import {
+  CARD_PEOPLE_MAX,
+  peopleGutterClass,
+  stackSlots,
+} from "./kanban-people-logic";
 import type { KanbanItem } from "./types";
 
 export interface KanbanCardLabels {
@@ -106,6 +110,13 @@ export function KanbanCard({
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(item.title);
   const inputRef = useRef<HTMLInputElement>(null);
+  // The face stack floats over the body's bottom-right corner, so the body has
+  // to give it a gutter or the last line of text runs underneath the faces
+  // (the artifact the landing mock avoids with `.tc-desc { padding-right }`).
+  // Empty for an unattributed card, so a single-player board is byte-identical.
+  const peopleGutter = peopleGutterClass(
+    stackSlots(item.people ?? [], CARD_PEOPLE_MAX),
+  );
   // Don't let a drag start while renaming (the title input owns the gesture)
   // or while a multi-select is active (the bulk action bar owns moves then).
   const canDrag = enableDrag && !editing && !anySelected;
@@ -348,14 +359,26 @@ export function KanbanCard({
               className="text-[13px] font-medium text-ink bg-transparent border-b border-ink/20 outline-none w-full"
             />
           ) : (
-            <p className="text-[13px] font-medium text-ink line-clamp-2 cursor-pointer">
+            <p
+              className={cn(
+                "text-[13px] font-medium text-ink line-clamp-2 cursor-pointer",
+                // The stack sits at the BOTTOM of the body, so it only needs to
+                // clear the title when there is no description under it.
+                !item.description && peopleGutter,
+              )}
+            >
               {item.title}
             </p>
           )}
 
           {/* Description */}
           {item.description && (
-            <p className="text-xs text-ink-muted line-clamp-2 mt-1">
+            <p
+              className={cn(
+                "text-xs text-ink-muted line-clamp-2 mt-1",
+                peopleGutter,
+              )}
+            >
               {item.description}
             </p>
           )}
@@ -368,7 +391,14 @@ export function KanbanCard({
              only separation from the text underneath — no border/divider. The
              expandable "+N" popover is portalled, so nothing clips it. Renders
              nothing when the mission has no people, leaving the card
-             untouched. */}
+             untouched.
+
+             `right-0 bottom-0` is NOT flush with the card: this wrapper lives
+             inside the card's own `p-3`, so the stack rests 12px from the card
+             edge and its 2px ring bleeds 2px into that padding — the landing
+             mock's `.faces { right: 10px; bottom: 10px }` optical inset. The
+             text it floats over gets its clearance from `peopleGutter` above,
+             mirroring the mock's `.tc-desc { padding-right }`. */}
           <KanbanPeople
             people={item.people}
             max={CARD_PEOPLE_MAX}

--- a/ui/board/src/kanban-detail-panel.tsx
+++ b/ui/board/src/kanban-detail-panel.tsx
@@ -108,9 +108,13 @@ export const KanbanDetailPanel = forwardRef<
             <Loader2 className="size-4 animate-spin text-blue-500 shrink-0" />
           )}
           {people && people.length > 0 && (
+            /* `surface="background"` because this header wears `bg-background`,
+               not the card tier: the default `ring-input` ring would paint a
+               white halo band around each face instead of a cutout. */
             <KanbanPeople
               people={people}
               size="md"
+              surface="background"
               label={peopleLabel}
               expandable
               expandLabel={peopleExpandLabel}

--- a/ui/board/src/kanban-people-face.tsx
+++ b/ui/board/src/kanban-people-face.tsx
@@ -1,0 +1,113 @@
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+  cn,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@houston-ai/core";
+import { initialsFor } from "./kanban-people-logic";
+import { personToneClass } from "./kanban-people-tone";
+import type { KanbanPerson } from "./types";
+
+/** The surface a face stack sits on. The 2px ring around every face is painted
+ *  in that surface's colour, so an overlapped face reads as a CUTOUT rather
+ *  than a halo band. `input` (the default) is the card tier; `background` is
+ *  the floating screen the mission detail panel wears. */
+export type KanbanPeopleSurface = "input" | "background";
+
+/** Face diameters. `sm` (18px) matches dense card rows; `md` (24px) the panel. */
+export const FACE_SIZE = {
+  sm: "size-[18px]",
+  md: "size-6",
+} as const;
+
+export const TEXT_SIZE = {
+  sm: "text-[9px]",
+  md: "text-[10px]",
+} as const;
+
+export type FaceSize = keyof typeof FACE_SIZE;
+
+// Ring overrides, spelled out per surface as whole literal class strings so
+// Tailwind's source scanner sees them (a template-built class would never be
+// generated). The FACE ring has to be set at the GROUP level: AvatarGroup
+// styles its children through `*:data-[slot=avatar]:ring-*`, which outranks any
+// class on the avatar itself. `background` is glass in dark mode — a
+// translucent ring would let the neighbouring face bleed through, the very
+// artifact the ring exists to prevent — so dark falls back to the solid tone
+// that glass composites to over the canvas.
+export const RING_GROUP: Record<KanbanPeopleSurface, string> = {
+  input: "*:data-[slot=avatar]:ring-input",
+  background:
+    "*:data-[slot=avatar]:ring-background dark:*:data-[slot=avatar]:ring-input",
+};
+
+export const RING_CHIP: Record<KanbanPeopleSurface, string> = {
+  input: "ring-input",
+  background: "ring-background dark:ring-input",
+};
+
+/** A single avatar face: image when known, initials fallback otherwise. Shared
+ *  by the overlapping stack and the expansion popover so both read identically.
+ *  With `tooltip`, hovering the face shows the person's display name via the
+ *  app's Tooltip primitive (the stack has no visible label of its own); the
+ *  popover passes it off since it already lists the name in text beside each
+ *  face. Off `tooltip`, the native `title` still carries the name.
+ *
+ *  The initials fallback is OPAQUE — a desaturated person tone picked from the
+ *  person's stable id — because the inherited `bg-chip-subtle` is ~96%
+ *  transparent: the face underneath and the card's own text used to show
+ *  straight through the letters. */
+export function Face({
+  person,
+  faceSize,
+  textSize,
+  tooltip = false,
+}: {
+  person: KanbanPerson;
+  faceSize: string;
+  textSize: string;
+  tooltip?: boolean;
+}) {
+  const avatar = (
+    <Avatar
+      // Re-assert the slot marker EXPLICITLY. `TooltipTrigger asChild` renders
+      // a Radix Slot that injects `data-slot="tooltip-trigger"` into this
+      // element's props, and `Avatar` spreads incoming props AFTER its own
+      // `data-slot`, so the marker was being overwritten — which silently
+      // killed the whole `AvatarGroup` ring contract
+      // (`*:data-[slot=avatar]:ring-2`): the faces in the stack rendered with
+      // NO ring and simply collided edge to edge. Passing it here makes it a
+      // CHILD prop, which wins the Slot merge.
+      data-slot="avatar"
+      title={tooltip ? undefined : person.label}
+      className={faceSize}
+    >
+      {person.imageUrl && (
+        <AvatarImage
+          src={person.imageUrl}
+          alt={person.label}
+          referrerPolicy="no-referrer"
+        />
+      )}
+      <AvatarFallback
+        className={cn(
+          textSize,
+          "font-medium text-person-initials",
+          personToneClass(person.id),
+        )}
+      >
+        {initialsFor(person.label)}
+      </AvatarFallback>
+    </Avatar>
+  );
+  if (!tooltip) return avatar;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{avatar}</TooltipTrigger>
+      <TooltipContent side="top">{person.label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/ui/board/src/kanban-people-logic.ts
+++ b/ui/board/src/kanban-people-logic.ts
@@ -8,14 +8,21 @@ export const CARD_PEOPLE_MAX = 5;
 /** Up-to-two-initials derived from a display label. Splits on whitespace and
  *  takes the first letter of the first and last word (single word → first two
  *  letters); empty/letterless input falls back to "?". Pure, JSX-free so it can
- *  be unit-tested under `node --experimental-strip-types`. */
+ *  be unit-tested under `node --experimental-strip-types`.
+ *
+ *  Slices by CODE POINT (`[...word]`), not by UTF-16 code unit: this is the one
+ *  initials helper behind board faces, chat sender faces and learning
+ *  provenance faces, and a label starting with an astral character (an emoji, a
+ *  rare CJK ideograph) would otherwise be cut mid-surrogate-pair and render as
+ *  "�". */
 export function initialsFor(label: string): string {
   const words = label.trim().split(/\s+/).filter(Boolean);
   if (words.length === 0) return "?";
+  const first = [...words[0]];
   const letters =
     words.length === 1
-      ? words[0].slice(0, 2)
-      : `${words[0][0]}${words[words.length - 1][0]}`;
+      ? first.slice(0, 2).join("")
+      : `${first[0]}${[...words[words.length - 1]][0]}`;
   return letters.toUpperCase() || "?";
 }
 
@@ -30,4 +37,46 @@ export function visiblePeople(
 /** How many people are hidden behind the "+N" overflow chip. */
 export function overflowCount(people: KanbanPerson[], max: number): number {
   return Math.max(0, people.length - Math.max(0, max));
+}
+
+/** Circles the card's stack actually paints: the visible faces plus the "+N"
+ *  chip, which occupies one more slot. */
+export function stackSlots(people: KanbanPerson[], max: number): number {
+  return (
+    visiblePeople(people, max).length + (overflowCount(people, max) > 0 ? 1 : 0)
+  );
+}
+
+/**
+ * Right gutter the card body reserves for the bottom-right face stack, as a
+ * Tailwind padding utility (never a raw px literal). Mirrors the landing mock's
+ * `.tc-desc { padding-right: 44px }`: without it the last line of the
+ * description runs underneath the faces.
+ *
+ * Sized to the stack it has to clear, rounded UP to the sanctioned spacing
+ * scale (DESIGN.md §4), rather than capped: an opaque face hides the text under
+ * it just as thoroughly as a translucent one garbled it, so "the tail of the
+ * sentence is gone" is not an acceptable trade for a wider description. The
+ * stack is `18px` circles overlapped by `6px`, each carrying a `2px` ring that
+ * bleeds outward, so N circles paint `N * 12 + 10` px; each tier is the first
+ * scale step at or above that (22->24, 34->40, 46->48, 58->64, 70->80,
+ * 82->96) — rounding up only ever adds clearance. N never exceeds
+ * {@link CARD_PEOPLE_MAX} + 1 (the faces plus the "+N" chip).
+ *
+ * Returns `""` for an unattributed card so its body class list — and therefore
+ * a single-player board — stays byte-identical.
+ */
+const PEOPLE_GUTTER = [
+  "",
+  "pr-6",
+  "pr-10",
+  "pr-12",
+  "pr-16",
+  "pr-20",
+  "pr-24",
+] as const;
+
+export function peopleGutterClass(slots: number): string {
+  if (slots <= 0) return "";
+  return PEOPLE_GUTTER[Math.min(slots, PEOPLE_GUTTER.length - 1)];
 }

--- a/ui/board/src/kanban-people-tone.ts
+++ b/ui/board/src/kanban-people-tone.ts
@@ -1,0 +1,47 @@
+/**
+ * Deterministic tone assignment for HUMAN avatar faces (the mission face
+ * stack). Pure and JSX-free so it runs under `node --experimental-strip-types`
+ * in `../tests/kanban-people-tone.test.ts`.
+ *
+ * Why a hash and not a rotating index: the same teammate must wear the same
+ * colour on EVERY card, in every column, on both boards, and in the expansion
+ * popover. An index into the render order would recolour a person the moment a
+ * mission gains or loses another contributor. Hashing the person's stable id
+ * makes the tone a property of the person, not of the list they appear in.
+ *
+ * The five tones are deliberately DESATURATED (slate / sage / mauve / taupe /
+ * indigo) so a human face never competes with the vivid `agent.*` helmet
+ * palette — teammates are context, the agent is the subject.
+ */
+
+/** The person-tone background utilities, in palette order. */
+export const PERSON_TONE_CLASSES = [
+  "bg-person-slate",
+  "bg-person-sage",
+  "bg-person-mauve",
+  "bg-person-taupe",
+  "bg-person-indigo",
+] as const;
+
+export type PersonToneClass = (typeof PERSON_TONE_CLASSES)[number];
+
+/**
+ * FNV-1a over the id's UTF-16 code units, folded to a palette index. Chosen
+ * over `sum(charCodes)` because contributor ids are long, near-identical
+ * strings (`u-alice`, `u-alexis`) whose character sums collide constantly —
+ * FNV-1a's multiply-and-mix spreads those onto different tones. `Math.imul`
+ * keeps the 32-bit multiply exact in JS.
+ */
+export function personToneIndex(id: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < id.length; i++) {
+    hash ^= id.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash % PERSON_TONE_CLASSES.length;
+}
+
+/** The background utility this person's initials avatar wears, everywhere. */
+export function personToneClass(id: string): PersonToneClass {
+  return PERSON_TONE_CLASSES[personToneIndex(id)];
+}

--- a/ui/board/src/kanban-people.tsx
+++ b/ui/board/src/kanban-people.tsx
@@ -1,17 +1,20 @@
 import {
-  Avatar,
-  AvatarFallback,
   AvatarGroup,
   AvatarGroupCount,
-  AvatarImage,
   cn,
   Popover,
   PopoverContent,
   PopoverTrigger,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
 } from "@houston-ai/core";
+import {
+  FACE_SIZE,
+  Face,
+  type FaceSize,
+  type KanbanPeopleSurface,
+  RING_CHIP,
+  RING_GROUP,
+  TEXT_SIZE,
+} from "./kanban-people-face";
 import {
   CARD_PEOPLE_MAX,
   initialsFor,
@@ -20,6 +23,7 @@ import {
 } from "./kanban-people-logic";
 import type { KanbanPerson } from "./types";
 
+export type { KanbanPeopleSurface };
 // Re-export the pure, JSX-free helpers so consumers can import them from the
 // component module too; they live in `kanban-people-logic.ts` so tests can run
 // them under `node --experimental-strip-types` (which can't transform JSX).
@@ -30,7 +34,9 @@ export interface KanbanPeopleProps {
   /** Max faces before collapsing into a "+N" chip. */
   max?: number;
   /** `sm` (~18px) matches dense card rows; `md` (~24px) suits the detail panel. */
-  size?: "sm" | "md";
+  size?: FaceSize;
+  /** Surface the stack is drawn on — decides the ring colour. Default `input`. */
+  surface?: KanbanPeopleSurface;
   /** Accessible group label (English default "People"). */
   label?: string;
   /** When set, the "+N" overflow chip becomes a button that opens a popover
@@ -43,56 +49,6 @@ export interface KanbanPeopleProps {
   className?: string;
 }
 
-const FACE_SIZE: Record<NonNullable<KanbanPeopleProps["size"]>, string> = {
-  sm: "size-[18px]",
-  md: "size-6",
-};
-
-const TEXT_SIZE: Record<NonNullable<KanbanPeopleProps["size"]>, string> = {
-  sm: "text-[9px]",
-  md: "text-[10px]",
-};
-
-/** A single avatar face: image when known, initials fallback otherwise. Shared
- *  by the overlapping stack and the expansion popover so both read identically.
- *  With `tooltip`, hovering the face shows the person's display name via the
- *  app's Tooltip primitive (the stack has no visible label of its own); the
- *  popover passes it off since it already lists the name in text beside each
- *  face. Off `tooltip`, the native `title` still carries the name. */
-function Face({
-  person,
-  faceSize,
-  textSize,
-  tooltip = false,
-}: {
-  person: KanbanPerson;
-  faceSize: string;
-  textSize: string;
-  tooltip?: boolean;
-}) {
-  const avatar = (
-    <Avatar title={tooltip ? undefined : person.label} className={faceSize}>
-      {person.imageUrl && (
-        <AvatarImage
-          src={person.imageUrl}
-          alt={person.label}
-          referrerPolicy="no-referrer"
-        />
-      )}
-      <AvatarFallback className={cn(textSize, "font-medium")}>
-        {initialsFor(person.label)}
-      </AvatarFallback>
-    </Avatar>
-  );
-  if (!tooltip) return avatar;
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>{avatar}</TooltipTrigger>
-      <TooltipContent side="top">{person.label}</TooltipContent>
-    </Tooltip>
-  );
-}
-
 /** An overlapping face stack: up to `max` avatars + a "+N" overflow chip.
  *  Props-only, i18n-agnostic (labels passed in). Renders nothing when empty.
  *  With `expandable`, the "+N" chip opens a popover of every person. */
@@ -100,6 +56,7 @@ export function KanbanPeople({
   people,
   max = 3,
   size = "sm",
+  surface = "input",
   label = "People",
   expandable = false,
   expandLabel,
@@ -111,13 +68,21 @@ export function KanbanPeople({
   const extra = overflowCount(people, max);
   const faceSize = FACE_SIZE[size];
   const textSize = TEXT_SIZE[size];
-  const chipClass = cn(faceSize, textSize, "font-medium");
+  // The overflow chip is a SOLID fill with high-contrast text (semibold), not
+  // the translucent `bg-chip-subtle` it used to wear — that read as an empty
+  // hole in the stack over a busy card.
+  const chipClass = cn(
+    faceSize,
+    textSize,
+    "font-semibold bg-person-overflow text-person-overflow-text",
+    RING_CHIP[surface],
+  );
 
   return (
     <AvatarGroup
       role="group"
       aria-label={label}
-      className={cn("-space-x-1.5", className)}
+      className={cn("-space-x-1.5", RING_GROUP[surface], className)}
     >
       {faces.map((person) => (
         <Face
@@ -141,7 +106,10 @@ export function KanbanPeople({
                 title={`+${extra}`}
                 className={cn(
                   chipClass,
-                  "relative flex shrink-0 items-center justify-center rounded-full bg-chip-subtle text-ink-muted ring-2 ring-input transition-colors hover:bg-ink-muted/20 cursor-pointer",
+                  // Hover dims rather than re-tinting: the fill is a solid
+                  // token whose "one step darker" differs per theme, and
+                  // opacity reads identically in both.
+                  "relative flex shrink-0 items-center justify-center rounded-full ring-2 transition-opacity hover:opacity-80 cursor-pointer",
                 )}
               >
                 +{extra}
@@ -160,8 +128,8 @@ export function KanbanPeople({
                   >
                     <Face
                       person={person}
-                      faceSize="size-6"
-                      textSize="text-[10px]"
+                      faceSize={FACE_SIZE.md}
+                      textSize={TEXT_SIZE.md}
                     />
                     <span className="min-w-0 flex-1 truncate text-sm text-ink">
                       {person.label}

--- a/ui/board/tests/kanban-people-tone.test.ts
+++ b/ui/board/tests/kanban-people-tone.test.ts
@@ -1,0 +1,64 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  PERSON_TONE_CLASSES,
+  personToneClass,
+  personToneIndex,
+} from "../src/kanban-people-tone.ts";
+
+/**
+ * The face-stack tone rule. The product promise these guard: the SAME teammate
+ * wears the SAME colour on every card, in every column, on both boards and in
+ * the expansion popover — so a face stack is scannable rather than a lottery.
+ */
+
+describe("personToneIndex", () => {
+  it("stays inside the palette", () => {
+    for (const id of ["", "a", "u-alice", "u-bob", "🙂", "x".repeat(500)]) {
+      const i = personToneIndex(id);
+      assert.ok(Number.isInteger(i), `${id} -> ${i} is not an integer`);
+      assert.ok(i >= 0 && i < PERSON_TONE_CLASSES.length, `${id} -> ${i}`);
+    }
+  });
+
+  it("is deterministic — the same id always hashes the same", () => {
+    const id = "u-7f3a91c2";
+    assert.equal(personToneIndex(id), personToneIndex(id));
+    assert.equal(personToneIndex(id), personToneIndex(`${id}`.slice(0)));
+  });
+
+  it("is case- and character-sensitive (distinct ids may differ)", () => {
+    // Not a guarantee of inequality for any given pair, but the hash must not
+    // collapse near-identical ids by construction (a char-sum hash would).
+    const ids = ["u-alice", "u-alexis", "u-alicia", "u-alison"];
+    const tones = new Set(ids.map(personToneIndex));
+    assert.ok(tones.size > 1, "near-identical ids all landed on one tone");
+  });
+
+  it("spreads a realistic roster across the whole palette", () => {
+    const ids = Array.from({ length: 200 }, (_, i) => `u-${i.toString(16)}`);
+    const used = new Set(ids.map(personToneIndex));
+    assert.equal(used.size, PERSON_TONE_CLASSES.length);
+  });
+});
+
+describe("personToneClass", () => {
+  it("returns a palette class, never an ad-hoc string", () => {
+    const cls = personToneClass("u-alice");
+    assert.ok(
+      (PERSON_TONE_CLASSES as readonly string[]).includes(cls),
+      `${cls} is not in the palette`,
+    );
+  });
+
+  it("gives one person one tone across every render site", () => {
+    const id = "u-bob";
+    assert.equal(personToneClass(id), personToneClass(id));
+  });
+
+  it("uses only tokenized person utilities (no raw colour)", () => {
+    for (const cls of PERSON_TONE_CLASSES) {
+      assert.match(cls, /^bg-person-[a-z]+$/);
+    }
+  });
+});

--- a/ui/board/tests/kanban-people.test.ts
+++ b/ui/board/tests/kanban-people.test.ts
@@ -4,6 +4,8 @@ import {
   CARD_PEOPLE_MAX,
   initialsFor,
   overflowCount,
+  peopleGutterClass,
+  stackSlots,
   visiblePeople,
 } from "../src/kanban-people-logic.ts";
 import type { KanbanPerson } from "../src/types.ts";
@@ -35,6 +37,21 @@ describe("initialsFor", () => {
   it("falls back to '?' for empty/whitespace input", () => {
     assert.equal(initialsFor(""), "?");
     assert.equal(initialsFor("   "), "?");
+  });
+
+  // The helper slices by code point, not by UTF-16 code unit: a label starting
+  // with an astral character (emoji, rare CJK) would otherwise be cut
+  // mid-surrogate-pair and render as "�".
+  it("never splits an astral character", () => {
+    // Single word: the first TWO code points, both intact.
+    assert.equal(initialsFor("🚀🛰️mission"), "🚀🛰");
+    // Multi-word: first code point of the first and last word.
+    assert.equal(initialsFor("🚀 Lovelace"), "🚀L");
+    assert.equal(initialsFor("Ada 🛰️"), "A🛰");
+    assert.equal(initialsFor("𝒜lan 𝒯uring"), "𝒜𝒯");
+    for (const label of ["🚀🛰️mission", "🚀 Lovelace", "Ada 🛰️"]) {
+      assert.ok(!initialsFor(label).includes("�"), label);
+    }
   });
 });
 
@@ -105,6 +122,73 @@ describe("card people overlay partition (CARD_PEOPLE_MAX)", () => {
         visiblePeople(list, CARD_PEOPLE_MAX).length +
           overflowCount(list, CARD_PEOPLE_MAX),
         n,
+      );
+    }
+  });
+});
+
+// The stack floats over the card body's bottom-right corner, so the body has to
+// reserve room for it or the description's last line runs under the faces.
+describe("stackSlots", () => {
+  it("counts the visible faces when nothing overflows", () => {
+    assert.equal(stackSlots(people(0), CARD_PEOPLE_MAX), 0);
+    assert.equal(stackSlots(people(1), CARD_PEOPLE_MAX), 1);
+    assert.equal(stackSlots(people(5), CARD_PEOPLE_MAX), 5);
+  });
+
+  it("counts the '+N' chip as one more circle", () => {
+    assert.equal(stackSlots(people(6), CARD_PEOPLE_MAX), CARD_PEOPLE_MAX + 1);
+    assert.equal(stackSlots(people(40), CARD_PEOPLE_MAX), CARD_PEOPLE_MAX + 1);
+  });
+});
+
+describe("peopleGutterClass", () => {
+  it("reserves nothing for an unattributed card", () => {
+    assert.equal(peopleGutterClass(0), "");
+    assert.equal(peopleGutterClass(-1), "");
+  });
+
+  it("grows one spacing-scale step per circle", () => {
+    assert.equal(peopleGutterClass(1), "pr-6");
+    assert.equal(peopleGutterClass(2), "pr-10");
+    assert.equal(peopleGutterClass(3), "pr-12");
+    assert.equal(peopleGutterClass(4), "pr-16");
+    assert.equal(peopleGutterClass(5), "pr-20");
+    assert.equal(peopleGutterClass(6), "pr-24");
+  });
+
+  // DESIGN.md §4 sanctions one spacing scale; a gutter is spacing like any
+  // other, so the ladder may only step through it (rounding up, never down —
+  // extra clearance is free, a short gutter puts text under a face).
+  it("only uses steps on the sanctioned spacing scale", () => {
+    const SPACING_SCALE = [2, 4, 6, 8, 10, 12, 16, 20, 24, 32, 40, 48, 64];
+    for (let n = 1; n <= CARD_PEOPLE_MAX + 1; n++) {
+      const step = Number(peopleGutterClass(n).slice("pr-".length));
+      assert.ok(SPACING_SCALE.includes(step), `pr-${step} is off the scale`);
+    }
+  });
+
+  it("saturates past the widest stack the card can paint", () => {
+    // CARD_PEOPLE_MAX faces + the "+N" chip is the most circles that exist.
+    assert.equal(peopleGutterClass(CARD_PEOPLE_MAX + 1), peopleGutterClass(99));
+  });
+
+  it("only ever emits padding utilities, never a raw length", () => {
+    for (let n = 0; n <= 8; n++) {
+      const cls = peopleGutterClass(n);
+      if (cls === "") continue;
+      assert.match(cls, /^pr-\d+$/);
+    }
+  });
+
+  it("clears the stack it is sized against (18px circle, -6px overlap, 2px ring)", () => {
+    // Painted width of N ringed, overlapping circles.
+    const painted = (slots: number) => slots * 12 + 10;
+    const px = (cls: string) => Number(cls.slice("pr-".length)) * 4;
+    for (let slots = 1; slots <= CARD_PEOPLE_MAX + 1; slots++) {
+      assert.ok(
+        px(peopleGutterClass(slots)) >= painted(slots),
+        `gutter for ${slots} circles is narrower than the stack`,
       );
     }
   });

--- a/ui/core/src/globals.css
+++ b/ui/core/src/globals.css
@@ -93,6 +93,20 @@
   --color-warning-text: var(--ht-warning-text);
   --color-highlight: var(--ht-highlight);
   --color-highlight-text: var(--ht-highlight-text);
+  /* Human (not agent) avatar palette: five deliberately DESATURATED tones so a
+     teammate's face never competes with the vivid agent helmets, plus the
+     initials colour they carry and the solid fill/text pair the "+N" overflow
+     chip wears. Bridged as utilities (unlike --ht-agent-*, which is resolved to
+     an inline var() by resolveAgentColor) because the face stack picks a tone
+     by className, deterministically from the person's id. */
+  --color-person-slate: var(--ht-person-slate);
+  --color-person-sage: var(--ht-person-sage);
+  --color-person-mauve: var(--ht-person-mauve);
+  --color-person-taupe: var(--ht-person-taupe);
+  --color-person-indigo: var(--ht-person-indigo);
+  --color-person-initials: var(--ht-person-initials);
+  --color-person-overflow: var(--ht-person-overflow);
+  --color-person-overflow-text: var(--ht-person-overflow-text);
   --animate-caret-blink: caret-blink 1.2s ease-out infinite;
 }
 


### PR DESCRIPTION
Fixes HOU-947

**Stack 1/3** (merge first; HOU-943 and HOU-946 PRs are stacked on this branch).

## What

Cards on the shared board show ALL humans on a mission as an overlapping face stack matching the landing anatomy (18px faces, -6px overlap, 2px surface-colour ring, +N chip), and the bad-overlap rendering bug is fixed. Multi-contributor stamping was confirmed already working end to end host-side; this is the rendering fix + coverage.

## Root causes found

1. `TooltipTrigger asChild` clobbered `data-slot="avatar"`, silently disabling `AvatarGroup`'s 2px ring contract — faces collided edge to edge (the primary defect; now locked by an e2e computed-style assertion).
2. Initials sat on `bg-chip-subtle` (~96% transparent) so faces and card text bled through each other. New `person.*` design tokens: 5 opaque desaturated tones (landing values in light, tuned dark counterparts, contrast-verified), hashed deterministically from the person's stable id — one person, one tone, everywhere.
3. The +N chip wore the same translucent fill; now a solid overflow chip.
4. The stack floated over the description; the card body now reserves an on-scale right gutter sized to the stack (empty for unattributed cards — single-player boards stay byte-identical, visual baselines unchanged).
5. The detail panel's ring now matches its own surface via a typed `surface` prop.

## Verification

Full workspace green: biome, boundaries, parity (inventory v36), root+app+web typecheck, ui/board 50 tests, design-tokens 140, app 2100, new `board-people.spec.ts` e2e (5), visual regression 6/6 with **unchanged baselines**. Adversarially reviewed by three independent finder agents; all confirmed findings fixed (opaque tones extended to every human-face surface, on-scale gutter ladder with a drift-guard test, code-point-safe initials).

Notes for review: fake host now seeds contributors on both missions (multiplayer-gated, so specs that open the per-agent board under the default "me" scope won't see them — documented in the fake-host README and ui-testing.md). WebKit e2e project not run locally (needs `playwright install webkit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)