### PR TITLE
feat: every chat turn shows its sender in multiplayer

### DIFF
--- a/app/src/components/agent-person-scope-menu.tsx
+++ b/app/src/components/agent-person-scope-menu.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from "react-i18next";
 import { useCapabilities } from "../hooks/use-capabilities";
 import { useMyProfile } from "../hooks/use-my-profile";
 import { buildScopeOptions } from "../lib/agent-person-scope";
-import { distinctBoardPeople } from "../lib/mission-people";
+import { distinctBoardPeople, shortUserLabel } from "../lib/mission-people";
 import { isTeamWorkspace } from "../lib/space-id";
 import type { Agent } from "../lib/types";
 import { useWorkspaceStore } from "../stores/workspaces";
@@ -59,9 +59,12 @@ export function AgentPersonScopeMenu({
 
   if (mode === "hidden" || !user) return null;
 
-  const selfName = myProfile?.name ?? user.email ?? user.id.slice(0, 8);
+  const selfName = myProfile?.name ?? user.email ?? shortUserLabel(user.id);
   const selfShort = selfName.split(/\s+/)[0] || selfName;
+  // Carrying the `id` is what earns the initials fallback this person's opaque
+  // `person.*` tone — the same one their face wears on every board card.
   const selfFace: FilterFace = {
+    id: user.id,
     label: selfName,
     imageUrl: myProfile?.avatarUrl ?? undefined,
   };
@@ -79,7 +82,7 @@ export function AgentPersonScopeMenu({
   } else if (scope.kind === "person") {
     const person = roster.find((p) => p.id === scope.userId);
     activeFace = person ?? null;
-    activeText = person?.label ?? scope.userId.slice(0, 8);
+    activeText = person?.label ?? shortUserLabel(scope.userId);
   }
 
   const inPersonalSpace = !isTeamWorkspace(current?.id ?? "");

--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -160,6 +160,9 @@ export function MissionBoard({ source }: { source: BoardSource }) {
           composerLabels={composerLabels}
           currentUserId={panel.currentUserId}
           authorLabels={panel.authorLabels}
+          showSenders={panel.showSenders}
+          agentLabel={panel.agentLabel}
+          renderSenderAvatar={panel.renderSenderAvatar}
           dictation={panel.dictation}
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}

--- a/app/src/components/board/mission-control-archived.tsx
+++ b/app/src/components/board/mission-control-archived.tsx
@@ -167,6 +167,9 @@ export function MissionControlArchived({
           renderLink={panel.renderLink}
           currentUserId={panel.currentUserId}
           authorLabels={panel.authorLabels}
+          showSenders={panel.showSenders}
+          agentLabel={panel.agentLabel}
+          renderSenderAvatar={panel.renderSenderAvatar}
           renderSystemMessage={panel.renderSystemMessage}
           conversationMap={panel.conversationMap}
           mapFeedItems={panel.mapFeedItems}

--- a/app/src/components/mission-person-face.tsx
+++ b/app/src/components/mission-person-face.tsx
@@ -1,12 +1,29 @@
-import { initialsFor, type KanbanPerson } from "@houston-ai/board";
-import { Avatar, AvatarFallback, AvatarImage, Button } from "@houston-ai/core";
+import {
+  initialsFor,
+  type KanbanPerson,
+  personToneClass,
+} from "@houston-ai/board";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+  Button,
+  cn,
+} from "@houston-ai/core";
 import { ChevronDown, Users } from "lucide-react";
 import type * as React from "react";
 
 /** The minimal face shape both the trigger and the menu rows render. */
-export type FilterFace = Pick<KanbanPerson, "label" | "imageUrl">;
+export type FilterFace = Pick<KanbanPerson, "label" | "imageUrl"> &
+  Partial<Pick<KanbanPerson, "id">>;
 
-/** A compact avatar face used in the person-filter trigger and menu rows. */
+/**
+ * A compact avatar face for a human, used by the person filter, the chat
+ * sender line, and the learnings provenance line. When the person's stable
+ * `id` is known the initials fallback wears their opaque `person.*` tone
+ * (one person = one tone everywhere, same rule as the board face stacks);
+ * without an id it stays on the neutral fallback fill.
+ */
 export function PersonFace({ person }: { person: FilterFace }) {
   return (
     <Avatar className="size-5">
@@ -17,7 +34,12 @@ export function PersonFace({ person }: { person: FilterFace }) {
           referrerPolicy="no-referrer"
         />
       )}
-      <AvatarFallback className="text-[9px] font-medium">
+      <AvatarFallback
+        className={cn(
+          "text-[9px] font-medium",
+          person.id && cn(personToneClass(person.id), "text-person-initials"),
+        )}
+      >
         {initialsFor(person.label)}
       </AvatarFallback>
     </Avatar>

--- a/app/src/components/mission-person-filter.tsx
+++ b/app/src/components/mission-person-filter.tsx
@@ -7,7 +7,7 @@ import {
 } from "@houston-ai/core";
 import { useTranslation } from "react-i18next";
 import { useMyProfile } from "../hooks/use-my-profile";
-import { distinctBoardPeople } from "../lib/mission-people";
+import { distinctBoardPeople, shortUserLabel } from "../lib/mission-people";
 import {
   type FilterFace,
   FilterTrigger,
@@ -48,8 +48,11 @@ export function MissionPersonFilter({
   const myProfile = useMyProfile();
   if (mode === "hidden" || !user) return null;
 
-  const selfName = myProfile?.name ?? user.email ?? user.id.slice(0, 8);
+  const selfName = myProfile?.name ?? user.email ?? shortUserLabel(user.id);
+  // Carrying the `id` is what earns the initials fallback this person's opaque
+  // `person.*` tone — the same one their face wears on every board card.
   const selfFace: FilterFace = {
+    id: user.id,
     label: selfName,
     imageUrl: myProfile?.avatarUrl ?? undefined,
   };
@@ -73,7 +76,7 @@ export function MissionPersonFilter({
   } else if (filterUserId) {
     const person = roster.find((p) => p.id === filterUserId);
     activeFace = person ?? null;
-    activeText = person?.label ?? filterUserId.slice(0, 8);
+    activeText = person?.label ?? shortUserLabel(filterUserId);
   }
 
   return (

--- a/app/src/components/tabs/archived-tab.tsx
+++ b/app/src/components/tabs/archived-tab.tsx
@@ -179,6 +179,9 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
           renderLink={panel.renderLink}
           currentUserId={panel.currentUserId}
           authorLabels={panel.authorLabels}
+          showSenders={panel.showSenders}
+          agentLabel={panel.agentLabel}
+          renderSenderAvatar={panel.renderSenderAvatar}
           renderSystemMessage={panel.renderSystemMessage}
           conversationMap={panel.conversationMap}
           mapFeedItems={panel.mapFeedItems}

--- a/app/src/components/tabs/routine-setup-chat-board.tsx
+++ b/app/src/components/tabs/routine-setup-chat-board.tsx
@@ -186,6 +186,9 @@ export function RoutineSetupChatBoard({
         renderLink={panel.renderLink}
         currentUserId={panel.currentUserId}
         authorLabels={panel.authorLabels}
+        showSenders={panel.showSenders}
+        agentLabel={panel.agentLabel}
+        renderSenderAvatar={panel.renderSenderAvatar}
         renderSystemMessage={panel.renderSystemMessage}
         conversationMap={panel.conversationMap}
         mapFeedItems={panel.mapFeedItems}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -173,6 +173,7 @@ import {
 } from "./tabs/provider-auth-feed";
 import { isToolRuntimeErrorMessage } from "./tool-runtime-feed";
 import { useChatDisplayLabels } from "./use-chat-display-labels";
+import { useChatSenderAvatars } from "./use-chat-sender-avatars";
 import { useToolkitBrandResolver } from "./use-toolkit-brand-resolver";
 import { UserSkillMessage } from "./user-skill-message";
 
@@ -249,6 +250,14 @@ interface AgentChatPanelProps {
   currentUserId: ChatPanelProps["currentUserId"];
   /** Localized author-attribution labels forwarded to ChatPanel. */
   authorLabels: ChatPanelProps["authorLabels"];
+  /** Attribute EVERY turn (HOU-943): true whenever the deployment is
+   *  multiplayer, so a shared chat always says who sent each message.
+   *  Single-player stays false and the transcript is unchanged. */
+  showSenders: ChatPanelProps["showSenders"];
+  /** The agent's display name, shown on its own rows when senders show. */
+  agentLabel: ChatPanelProps["agentLabel"];
+  /** Face for a message's sender: teammate photo/initials, or the agent mark. */
+  renderSenderAvatar: ChatPanelProps["renderSenderAvatar"];
   /** Prop-driven dictation control for the composer mic. Undefined on web
    *  (no native mic capture) — ChatPanel hides the mic entirely. */
   dictation: ChatPanelProps["dictation"];
@@ -272,7 +281,7 @@ export function useAgentChatPanel({
   // the viewer's own bubbles from teammates'. Undefined signed out / local.
   const { data: session } = useSession();
   const currentUserId = session?.uid;
-  const authorLabels = undefined;
+  const authorLabels = useMemo(() => ({ you: t("chat:attribution.you") }), [t]);
 
   const conversationMap = useMemo<
     NonNullable<AIBoardProps["conversationMap"]>
@@ -504,6 +513,14 @@ export function useAgentChatPanel({
     selectedSessionKey ?? undefined,
   );
   const sessionFeedItems = useConversationFeed(path, selectedSessionKey);
+
+  // Sender identity (HOU-943): in a shared (multiplayer) deployment every turn
+  // shows who sent it — the teammate's face + name, the agent's mark + name.
+  // Resolved from the feed's authors, so it repaints as teammates' turns land.
+  const { showSenders, agentLabel, renderSenderAvatar } = useChatSenderAvatars(
+    agent,
+    sessionFeedItems,
+  );
 
   // The live turn state for this conversation, for the pending-interaction
   // override: `running` gates the card (a running turn shows the composer, not
@@ -2090,6 +2107,9 @@ export function useAgentChatPanel({
     turnMode,
     currentUserId,
     authorLabels,
+    showSenders,
+    agentLabel,
+    renderSenderAvatar,
     dictation,
   };
 }

--- a/app/src/components/use-chat-sender-avatars.tsx
+++ b/app/src/components/use-chat-sender-avatars.tsx
@@ -1,0 +1,107 @@
+/**
+ * Sender identity for the chat panel (HOU-943): in a SHARED (multiplayer)
+ * deployment every turn says who sent it — a teammate's face + name on human
+ * messages, the agent's mark + name on its own. Single-player is untouched: the
+ * transcript renders exactly as before.
+ *
+ * The faces resolve through the same batched `GET /v1/org/profiles` lookup the
+ * mission face stacks use (one cache entry per contributor set), with the
+ * caller's own resolved profile layered on for their rows. A profile that never
+ * landed (or a host with no roster) falls back to the author's stored name, then
+ * to initials — a row is never faceless.
+ */
+
+import type { ChatMessage, FeedItem } from "@houston-ai/chat";
+import { HoustonAvatar, resolveAgentColor } from "@houston-ai/core";
+import { type ReactNode, useCallback, useMemo } from "react";
+import { useUserProfiles } from "../hooks/queries/use-user-profiles";
+import { useCapabilities } from "../hooks/use-capabilities";
+import { useMyProfile } from "../hooks/use-my-profile";
+import { shortUserLabel } from "../lib/mission-people";
+import { isMultiplayer } from "../lib/org-roles";
+import type { Agent } from "../lib/types";
+import { PersonFace } from "./mission-person-face";
+
+/** The agent mark's diameter, matched to `PersonFace`'s 20px teammate face so
+ *  human and agent rows sit on the same optical line. */
+const AGENT_MARK_PX = 20;
+
+/** Every distinct author id in a conversation's feed (stable, sorted). */
+function authorIdsIn(feedItems: FeedItem[]): string[] {
+  const ids = new Set<string>();
+  for (const item of feedItems) {
+    if (item.feed_type === "user_message" && item.author)
+      ids.add(item.author.userId);
+  }
+  return Array.from(ids).sort();
+}
+
+export interface ChatSenderIdentity {
+  /**
+   * `true` = attribute EVERY turn (the deployment is multiplayer, so sender
+   * identity is a property of the deployment). NEVER `false`: `undefined` hands
+   * the decision to `ui/chat`'s ≥2-distinct-authors heuristic, which is the
+   * right answer everywhere else — including the capabilities-loading window
+   * (a shared transcript must not paint unattributed and then pop names in) and
+   * any host that serves an authored transcript without advertising
+   * multiplayer, where a hard `false` would actively SUPPRESS attribution.
+   */
+  showSenders: true | undefined;
+  /** The agent's display name, shown on its rows. */
+  agentLabel: string | undefined;
+  /** The face for a message's sender: teammate photo/initials, or agent mark. */
+  renderSenderAvatar: (msg: ChatMessage) => ReactNode | undefined;
+}
+
+export function useChatSenderAvatars(
+  agent: Agent | null,
+  feedItems: FeedItem[],
+): ChatSenderIdentity {
+  const { capabilities } = useCapabilities();
+  const showSenders = isMultiplayer(capabilities) || undefined;
+  const myProfile = useMyProfile();
+
+  // Every authored id in the transcript — empty in single-player, where no
+  // message carries an author, and the batched profiles query is multiplayer
+  // gated on top of that (see `profilesQueryEnabled`).
+  const authorIds = useMemo(() => authorIdsIn(feedItems), [feedItems]);
+  const { profiles } = useUserProfiles(authorIds);
+
+  const agentColor = agent?.color;
+  const renderSenderAvatar = useCallback(
+    (msg: ChatMessage): ReactNode | undefined => {
+      if (msg.from === "assistant")
+        return (
+          <HoustonAvatar
+            color={resolveAgentColor(agentColor)}
+            diameter={AGENT_MARK_PX}
+          />
+        );
+      const author = msg.author;
+      if (!author) return undefined;
+      const isSelf = myProfile?.userId === author.userId;
+      const profile = profiles.get(author.userId);
+      const name =
+        (isSelf ? myProfile?.name : null) ??
+        profile?.name ??
+        author.name ??
+        shortUserLabel(author.userId);
+      const imageUrl =
+        (isSelf ? myProfile?.avatarUrl : null) ?? profile?.avatarUrl ?? null;
+      // The `id` is what gives the initials fallback this person's opaque
+      // `person.*` tone — one person, one tone, on the board and here alike.
+      return (
+        <PersonFace
+          person={{
+            id: author.userId,
+            label: name,
+            imageUrl: imageUrl ?? undefined,
+          }}
+        />
+      );
+    },
+    [agentColor, profiles, myProfile],
+  );
+
+  return { showSenders, agentLabel: agent?.name, renderSenderAvatar };
+}

--- a/app/src/lib/acting-user.ts
+++ b/app/src/lib/acting-user.ts
@@ -1,0 +1,34 @@
+/**
+ * Who is sending a turn — the acting user's identity, as the send path stamps
+ * it onto the optimistic bubble (HOU-943).
+ *
+ * In a shared conversation the gateway stamps every persisted message with its
+ * author (from `x-houston-acting-as`), so a reload attributes each turn. The
+ * LIVE bubble is pushed client-side before any server frame exists, so it needs
+ * the same identity from here — otherwise the message the user just sent is the
+ * one row in a multiplayer thread with no name on it.
+ *
+ * Read from the shared query cache (`["session"]`, the one place the signed-in
+ * session lives) rather than a second copy: no new state to keep in sync, and a
+ * signed-out or single-player client simply resolves `undefined`, leaving the
+ * bubble authorless exactly as it is today.
+ */
+
+import type { Session } from "./identity";
+import { queryClient } from "./query-client";
+import { queryKeys } from "./query-keys";
+
+export interface ActingUser {
+  userId: string;
+  name?: string;
+}
+
+/** The signed-in caller, or `undefined` when signed out / identity-less. */
+export function actingUser(): ActingUser | undefined {
+  const session = queryClient.getQueryData<Session | null>(queryKeys.session());
+  if (!session) return undefined;
+  return {
+    userId: session.uid,
+    ...(session.displayName ? { name: session.displayName } : {}),
+  };
+}

--- a/app/src/lib/mission-people.ts
+++ b/app/src/lib/mission-people.ts
@@ -17,6 +17,17 @@ export interface MissionAttribution {
 }
 
 /**
+ * The last-resort display label for a person we know only by id: a short slice,
+ * never the raw id. Houston's user ids are opaque UUIDs and our users are
+ * non-technical — a 36-character id in a face stack or a chat sender line reads
+ * as a bug, and its "initials" would be two random hex characters. Mirrored in
+ * `ui/chat`'s `author-label.ts` (the library boundary forbids importing this).
+ */
+export function shortUserLabel(userId: string): string {
+  return userId.slice(0, 8);
+}
+
+/**
  * Build the ordered face stack for one mission: the creator first (deduped
  * against the contributor list), then the remaining contributors in stored
  * order. Label falls back profile name > stored contributor name > a short id
@@ -44,7 +55,8 @@ export function buildMissionPeople(
 
   return orderedIds.map((id) => {
     const profile = profiles.get(id);
-    const label = profile?.name ?? contributorName.get(id) ?? id.slice(0, 8);
+    const label =
+      profile?.name ?? contributorName.get(id) ?? shortUserLabel(id);
     const imageUrl = profile?.avatarUrl ?? undefined;
     return imageUrl ? { id, label, imageUrl } : { id, label };
   });

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -23,6 +23,7 @@ import type {
   ProviderUsage,
 } from "@houston-ai/engine-client";
 import { shouldUseClaudeDesktopLogin } from "../components/shell/provider-login-url";
+import { actingUser } from "./acting-user";
 import {
   blockWriteWhileWarming,
   blockWriteWhileWarmingById,
@@ -411,6 +412,9 @@ export const tauriChat = {
         queuedPreview: opts?.queuedPreview,
         displayText: opts?.displayText,
         autoResume: opts?.autoResume,
+        // Who is sending: stamps the optimistic bubble so a shared conversation
+        // attributes it immediately (HOU-943). Undefined signed out / local.
+        author: actingUser(),
       });
       return res.sessionKey;
     }),

--- a/app/src/lib/warming-sends.ts
+++ b/app/src/lib/warming-sends.ts
@@ -15,6 +15,7 @@
 
 import { pushPendingUserMessage } from "@houston-ai/engine-client";
 import { getConversationFeed } from "../hooks/use-conversation-vm";
+import { actingUser } from "./acting-user";
 import type {
   PendingWarmingSend,
   ProvisioningEntry,
@@ -66,7 +67,15 @@ export function buildWarmingSend(
 ): PendingWarmingSend {
   // A row-only entry carries no user message — nothing to render.
   if (!args.rowOnly) {
-    pushPendingUserMessage(args.agentPath, args.sessionKey, args.text);
+    // Stamp the sender (HOU-943): the real send at flush suppresses its own
+    // bubble, so this push is the row's ONLY chance to be attributed — without
+    // it a warmed-up agent's first message stays nameless in a shared thread.
+    pushPendingUserMessage(
+      args.agentPath,
+      args.sessionKey,
+      args.text,
+      actingUser(),
+    );
   }
   const send: PendingWarmingSend = {
     id: crypto.randomUUID(),
@@ -89,13 +98,21 @@ export function buildWarmingSend(
 /**
  * After a relaunch mid-warm-up: the VM is empty, so re-render the queued
  * bubbles. Only when the conversation truly has nothing — a live VM already
- * shows them.
+ * shows them. Re-stamped with the acting user for the same reason as the
+ * original push: the queue is this account's own, and the flush's send will
+ * suppress the bubble that would otherwise carry the name.
  */
 export function restoreWarmingBubbles(entry: ProvisioningEntry): void {
+  const author = actingUser();
   for (const send of entry.pendingSends ?? []) {
     if (send.rowOnly) continue;
     if (getConversationFeed(entry.agentPath, send.sessionKey).length === 0) {
-      pushPendingUserMessage(entry.agentPath, send.sessionKey, send.text);
+      pushPendingUserMessage(
+        entry.agentPath,
+        send.sessionKey,
+        send.text,
+        author,
+      );
     }
   }
 }

--- a/app/tests/chat-sender-identity.test.ts
+++ b/app/tests/chat-sender-identity.test.ts
@@ -1,0 +1,60 @@
+import { ok } from "node:assert";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+/**
+ * Chat sender identity (HOU-943). The node test runner has no DOM, so (per the
+ * repo's React-test idiom) these assert on the hook's source — they pin two
+ * decisions that are invisible in a screenshot and easy to regress:
+ *
+ *  1. `showSenders` is `true` or `undefined`, NEVER `false`. `true` forces
+ *     attribution on in a multiplayer deployment; `undefined` hands the call to
+ *     `ui/chat`'s ≥2-distinct-authors heuristic — which is what must govern
+ *     during the capabilities-loading window (else a shared transcript paints
+ *     unattributed and then pops names in) and on any host that serves an
+ *     authored transcript without advertising multiplayer. A hard `false` would
+ *     make that heuristic unreachable and SUPPRESS attribution.
+ *  2. The sender face carries the author's stable `id`, which is what gives the
+ *     initials fallback their opaque `person.*` tone — one person, one tone,
+ *     identical to their face on every board card.
+ */
+
+const src = readFileSync(
+  new URL("../src/components/use-chat-sender-avatars.tsx", import.meta.url),
+  "utf8",
+);
+
+describe("chat sender identity", () => {
+  it("never passes a hard `false` for showSenders", () => {
+    ok(
+      src.includes("isMultiplayer(capabilities) || undefined"),
+      "showSenders is true in multiplayer, undefined everywhere else",
+    );
+    ok(
+      !/showSenders\s*[:=]\s*false/.test(src),
+      "no code path pins showSenders to false",
+    );
+    ok(
+      src.includes("showSenders: true | undefined"),
+      "the exported type forbids `false` at compile time",
+    );
+  });
+
+  it("gives the sender face the author id, so the person tone applies", () => {
+    ok(
+      /<PersonFace[\s\S]*?id:\s*author\.userId/.test(src),
+      "PersonFace receives the author's userId as its stable id",
+    );
+  });
+
+  it("never labels a face with a raw user id", () => {
+    ok(
+      src.includes("shortUserLabel(author.userId)"),
+      "a nameless author falls back to the shared short-id label",
+    );
+    ok(
+      !/author\.name\s*\?\?\s*author\.userId/.test(src),
+      "no raw-userId fallback remains",
+    );
+  });
+});

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,27 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v37 - 2026-07-27
+
+Refine `user-message` + `assistant-message` (no new component, no `since`
+change): in a SHARED conversation every turn now carries a **sender line** --
+the writer's face + name above a human bubble, the agent's mark + name above its
+prose (HOU-943). Attribution follows the DEPLOYMENT: a multiplayer client
+attributes every turn from the first message (the old "label only once two
+people have written" heuristic left a shared chat looking single-player until a
+second person spoke, and never named the agent; it still governs outside
+multiplayer, so legacy attributed transcripts keep their labels). Single-player
+is untouched -- no line, no faces, byte-identical transcript.
+
+Behind it, the conversation view-model now carries a message's `author` end to
+end (`packages/sdk`: `FeedItemVM.author`, folded by `seedHistory` /
+`prependHistory` and stamped on the optimistic send via
+`StreamTurnOptions.author`), which is what makes a teammate's bubble keep its
+identity across reload, scroll-up paging, and the live send. Web ships it in
+`ui/chat` (`ChatSenderHeader`, threaded through `ChatPanel`/`ChatMessages` as
+`showSenders` + `agentLabel` + `renderSenderAvatar`); the app resolves faces
+through the batched org-profiles lookup the mission face stacks already use.
+
 ## v36 - 2026-07-27
 
 Refine `mission-card` (no new component, no `since` change): its anatomy gains

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 36
+version: 37
 
 components:
   - id: agent-avatar
@@ -84,24 +84,31 @@ components:
   - id: assistant-message
     title: Assistant message
     purpose: A model turn's prose -- markdown, no bubble, left aligned.
-    anatomy: [markdown-body, code-block, inline-links, copy-action]
+    anatomy: [sender-line, markdown-body, code-block, inline-links, copy-action]
     states: [streaming, complete]
-    variants: [with-code, plain-prose]
+    variants: [with-code, plain-prose, single-player, multiplayer-attributed]
     behavior: >-
       assistant_text vs assistant_text_streaming decide whether the body grows
-      token-by-token; copy acts on the resolved markdown source.
+      token-by-token; copy acts on the resolved markdown source. In a SHARED
+      conversation (v37) the turn carries a sender line above the prose -- the
+      agent's mark + its name -- so every turn in a multiplayer thread says who
+      spoke; single-player renders no sender line at all.
     a11y: article/group role; code blocks keyboard-selectable; copy button labeled.
     since: 1
 
   - id: user-message
     title: User message
     purpose: A message the user (or a teammate) sent, right-aligned bubble.
-    anatomy: [bubble, author-label, attachment-chips]
+    anatomy: [sender-line, sender-avatar, bubble, attachment-chips]
     states: [default, with-attachments]
     variants: [single-player, multiplayer-authored]
     behavior: >-
-      In multiplayer the author field labels a teammate's bubble; single-player
-      omits it. Attachment/skill markers are decoded to a clean preview.
+      The message's stored author drives attribution. In a SHARED conversation
+      (v37) EVERY turn carries a sender line -- the writer's face + name,
+      whoever they are and however many people have written -- so attribution
+      follows the deployment, not the thread's cast; the viewer's own rows use
+      the consumer's "you" label. Single-player omits the line entirely.
+      Attachment/skill markers are decoded to a clean preview.
     a11y: group role; author announced in multiplayer; attachments labeled.
     since: 1
 

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -787,6 +787,45 @@ non-user-initiated read: `tauriOrg.profiles` runs with `{toast:false,capture:fal
 rare hard failure stays silent and consumers fall back via React Query's `isError`. i18n:
 `dashboard:peopleFilter.*`, `board:people.label` (en/es/pt).
 
+## Chat sender attribution (HOU-943)
+
+In a shared chat EVERY turn says who sent it: the writer's face + name above a
+human bubble, the agent's mark + name above its prose. The trigger is the
+DEPLOYMENT, not the thread — `isMultiplayer(capabilities)` — so a shared chat
+attributes its first message, not only once a second person writes. Single-player
+renders no sender line at all (byte-identical transcript).
+
+**The identity travels on the view-model.** A message's author is already stored
+and on the wire (`ChatMessage.author`, stamped by the runtime from
+`x-houston-acting-as`, gateway-fronted only). `@houston/sdk` now carries it end to
+end: `FeedItemVM.author` (additive), folded by `seedHistory` / `prependHistory`
+from `historyToFeed`'s `FeedFrame.author`, and stamped on the OPTIMISTIC send via
+`StreamTurnOptions.author` — so a teammate's bubble keeps its identity across
+reload, scroll-up paging, and the live send alike. The optimistic identity is
+supplied by the surface (the SDK has none): `SessionStartRequest.author` →
+adapter `streamTurn` → SDK, filled once in `tauriChat.send` from
+`app/src/lib/acting-user.ts` (a read of the shared `["session"]` cache; signed
+out ⇒ absent ⇒ authorless, exactly as today).
+
+**Rendering (`@houston-ai/chat`).** `ChatPanel`/`ChatMessages` take
+`showSenders` (force attribution on every turn; omitted = the legacy
+"≥2 distinct authors" heuristic, user rows only), `agentLabel`, and
+`renderSenderAvatar`. `ChatSenderHeader` draws the line (avatar + name, mirrored
+on the right-aligned user bubble); the pure name rule is `senderNameFor`
+(`author-label.ts`) — the viewer gets `labels.you`, never nothing. Props-only and
+i18n-agnostic, as ever.
+
+**App wiring.** `use-chat-sender-avatars.tsx` resolves it: `showSenders` from
+capabilities, `agentLabel` from the agent, and faces from the SAME batched
+`useUserProfiles` lookup the board face stacks use (ids collected from the feed's
+authors, own rows via `useMyProfile`, `PersonFace` initials fallback).
+`use-agent-chat-panel` returns the three props, `authorLabels.you` =
+`chat:attribution.you`, and every AIBoard mount forwards them. E2E:
+`packages/web/e2e/chat-senders.spec.ts` against the fake host's
+`/__test__/chat-history` control.
+
+---
+
 ## engine-client types + methods
 
 Wire types in `ui/engine-client/src/types.ts`: `OrgRole`, `OrgMember`

--- a/knowledge-base/ui-testing.md
+++ b/knowledge-base/ui-testing.md
@@ -64,7 +64,11 @@ cache was warm).
   (`{ nextText }`; end the running turn unseen + start the next one — the
   settle-from-history-by-turnId spec), and `POST /__test__/chat-interaction`
   (`{ interaction }`; end the next turn's `done` frame on that
-  `pendingInteraction` — the composer question/connect card spec).
+  `pendingInteraction` — the composer question/connect card spec), plus
+  `POST /__test__/chat-history` (`{ conversationId, messages, agentId? }`;
+  replace a transcript verbatim — the only way to reach a SHARED conversation
+  whose user messages carry the `author` the gateway stamps, for the sender
+  attribution spec `chat-senders.spec.ts`).
 - **Board = files-first.** Reads/writes `.houston/activity/activity.json` via
   `/agents/:id/agentfile/*` (NOT just `/activities`). Fake host backs it with a
   real store, unified with `/activities` (same data, as in the real host),

--- a/packages/fake-host/README.md
+++ b/packages/fake-host/README.md
@@ -62,6 +62,7 @@ They drive the failure/reactivity scenarios the specs assert against:
 | `/__test__/emit` | `{ type, agentPath? }` | Push a domain event onto the `/v1/events` reactivity feed. |
 | `/__test__/chat-config` | `{ replyDelayMs }` | Slow the canned reply so a drop/kill lands mid-turn deterministically. |
 | `/__test__/chat-interaction` | `{ interaction }` | Arm the NEXT scripted turn to end on a `PendingInteraction` (its `done` frame carries it) so the settle lands the card on `needs_you` + composer card. `null` disarms. |
+| `/__test__/chat-history` | `{ conversationId, messages, agentId? }` | Replace a conversation's transcript verbatim with the given `ChatMessage[]` (defaults to the seeded agent). The only way to reach a SHARED conversation locally: user messages carrying the `author` the cloud gateway stamps in multiplayer, which the sender-attribution spec renders. Returns `{ messages }`. |
 | `/__test__/drop-chat-streams` | — | Sever every open chat stream WITHOUT ending the turns (network blip). Returns `{ dropped }`. |
 | `/__test__/kill-turn` | — | Synthesize the host reaper's terminal `error` frame on every running turn (dead-turn settle). Returns `{ killed }`. |
 | `/__test__/turn-boundary` | `{ nextText }` | End the running turn while nobody watches, then start the next one, so a reconnect resyncs onto a DIFFERENT turnId. Returns `{ advanced }`. |

--- a/packages/fake-host/src/router.ts
+++ b/packages/fake-host/src/router.ts
@@ -8,7 +8,7 @@
  */
 
 import { buildProviderCatalog } from "@houston/host/src/providers/pi-catalog";
-import type { PendingInteraction } from "@houston/protocol";
+import type { ChatMessage, PendingInteraction } from "@houston/protocol";
 import { setNextInteraction, setReplyDelay } from "./chat";
 import {
   clearChatStreams,
@@ -16,6 +16,7 @@ import {
   killRunningTurns,
   turnBoundary,
 } from "./chat-controls";
+import { SEED_AGENT_ID } from "./config";
 import { CORS, json } from "./http";
 import { handleAgents } from "./routes";
 import { handleUserRoutes } from "./routes-integrations";
@@ -92,6 +93,23 @@ export async function handle(req: Request): Promise<Response> {
       (body?.interaction as PendingInteraction | null) ?? null,
     );
     return json({ ok: true });
+  }
+  // Seed a conversation's transcript verbatim: `{ conversationId, messages }`
+  // (optionally `agentId`, default the seeded agent). The only way to reach a
+  // SHARED conversation locally — user messages carrying the `author` the
+  // gateway stamps in multiplayer — for the sender-attribution spec.
+  if (path === "/__test__/chat-history" && method === "POST") {
+    const body = await parseBody(req);
+    const messages = Array.isArray(body?.messages)
+      ? (body.messages as ChatMessage[])
+      : [];
+    return json({
+      messages: state.seedHistory(
+        typeof body?.agentId === "string" ? body.agentId : SEED_AGENT_ID,
+        String(body?.conversationId ?? ""),
+        messages,
+      ),
+    });
   }
   // Synthesize the dead-pump reaper's terminal error on every running turn.
   if (path === "/__test__/kill-turn" && method === "POST") {

--- a/packages/fake-host/src/state-history.ts
+++ b/packages/fake-host/src/state-history.ts
@@ -14,6 +14,23 @@ export function getHistory(
   return state.histories.get(`${agentId}:${conversationId}`) ?? [];
 }
 /**
+ * Replace a conversation's transcript wholesale — the `/__test__/chat-history`
+ * arming control. Specs use it to reach a shape no scripted turn can produce
+ * locally: a SHARED conversation whose user messages carry the `author` the
+ * gateway stamps in multiplayer (the sender-attribution spec). The messages are
+ * stored verbatim, so the history route serves exactly the wire shape given.
+ */
+export function seedHistory(
+  agentId: string,
+  conversationId: string,
+  messages: ChatMessage[],
+): ChatMessage[] {
+  state.histories.set(`${agentId}:${conversationId}`, [...messages]);
+  emitDomain("ConversationsChanged", agentId);
+  return messages;
+}
+
+/**
  * Persist the turn's user message at turn START, stamped with the turn's id —
  * matching the real runtime, so a turn that dies before replying leaves
  * exactly the user message behind (the dead-turn history shape).

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -151,6 +151,7 @@ export {
   conversationScope,
   type DecodedAttachmentText,
   decodeAttachmentText,
+  type FeedAuthor,
   type FeedFrame,
   type FeedItemVM,
   type FeedOutput,

--- a/packages/sdk/src/modules/turns/history.ts
+++ b/packages/sdk/src/modules/turns/history.ts
@@ -14,6 +14,7 @@
 
 import type { ChatMessage } from "@houston/runtime-client";
 import { STOPPED_BY_USER } from "./turn-errors";
+import type { FeedAuthor } from "./vm-output";
 
 /**
  * One replayed feed frame: the SAME `{ feed_type, data }` push the turn
@@ -24,8 +25,10 @@ import { STOPPED_BY_USER } from "./turn-errors";
 export interface FeedFrame {
   feed_type: string;
   data: unknown;
-  /** Multiplayer only: who wrote a `user_message`. Absent single-player. */
-  author?: { userId: string; name?: string };
+  /** Multiplayer only: who wrote a `user_message`. Absent single-player. The
+   *  seed/prepend folds carry it onto the feed entry (`FeedItemVM.author`), so
+   *  a reloaded shared conversation attributes every teammate's bubble. */
+  author?: FeedAuthor;
   /**
    * Epoch-ms timestamp of the source `ChatMessage` this frame was folded from
    * (`ChatMessage.ts`). Carried on every frame attributable to a message so a

--- a/packages/sdk/src/modules/turns/index.ts
+++ b/packages/sdk/src/modules/turns/index.ts
@@ -190,6 +190,7 @@ export {
   ConversationVmOutput,
   conversationScope,
   DEFAULT_CONVERSATION_CACHE_MAX,
+  type FeedAuthor,
   type FeedItemVM,
   type HistoryWindowVM,
   type QueuedMessageVM,

--- a/packages/sdk/src/modules/turns/operations.ts
+++ b/packages/sdk/src/modules/turns/operations.ts
@@ -87,7 +87,13 @@ export function createTurnOperations(
       input.text,
       output,
       registry,
-      { nonce: input.nonce, provider: pin?.provider, pin },
+      {
+        nonce: input.nonce,
+        provider: pin?.provider,
+        pin,
+        // Multiplayer: the caller's identity stamps the optimistic bubble.
+        author: input.author,
+      },
     );
   };
 

--- a/packages/sdk/src/modules/turns/turn-inputs.ts
+++ b/packages/sdk/src/modules/turns/turn-inputs.ts
@@ -4,6 +4,8 @@
  * a bad shape (CommandRegistry.dispatch turns the throw into `ok: false`).
  */
 
+import type { FeedAuthor } from "./vm-output";
+
 /** Arguments for starting a turn — the `turns/send` command payload. */
 export interface TurnSendInput {
   /** The agent whose sandbox runs the turn (informational for the single client). */
@@ -29,6 +31,12 @@ export interface TurnSendInput {
    * the turn as "execute".
    */
   mode?: "execute" | "plan" | "auto";
+  /**
+   * Who is sending, in a multiplayer deployment: stamps the optimistic bubble
+   * so a shared conversation attributes it immediately (see
+   * `StreamTurnOptions.author`). Omitted single-player / signed out.
+   */
+  author?: FeedAuthor;
 }
 
 /** The `turns/cancel` command payload. */
@@ -64,6 +72,18 @@ const str = (v: unknown): string | undefined =>
 const mode = (v: unknown): "execute" | "plan" | "auto" | undefined =>
   v === "execute" || v === "plan" || v === "auto" ? v : undefined;
 
+/** Untrusted-envelope guard for the sender identity: only an object carrying a
+ *  non-empty string `userId` passes (with an optional string `name`); anything
+ *  else drops to undefined and the bubble stays authorless. */
+const author = (v: unknown): FeedAuthor | undefined => {
+  const a = v as { userId?: unknown; name?: unknown } | null | undefined;
+  if (!a || typeof a.userId !== "string" || a.userId === "") return undefined;
+  return {
+    userId: a.userId,
+    ...(typeof a.name === "string" ? { name: a.name } : {}),
+  };
+};
+
 export function asSendInput(payload: unknown): TurnSendInput {
   const p = (payload ?? {}) as Record<string, unknown>;
   if (typeof p.conversationId !== "string" || typeof p.text !== "string")
@@ -76,6 +96,7 @@ export function asSendInput(payload: unknown): TurnSendInput {
     model: str(p.model),
     effort: str(p.effort),
     mode: mode(p.mode),
+    author: author(p.author),
   };
 }
 

--- a/packages/sdk/src/modules/turns/turn-stream.test.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.test.ts
@@ -86,6 +86,7 @@ type Item = {
   data?: unknown;
   pending?: boolean;
   fails_pending?: boolean;
+  author?: { userId: string; name?: string };
 };
 
 /** A recording FeedOutput: the sink's FeedItems, session statuses, board persists. */
@@ -437,6 +438,52 @@ test("suppressUserBubble pushes no optimistic bubble at all (a resend, no clock)
   );
 
   expect(items.some((i) => i.feed_type === "user_message")).toBe(false);
+});
+
+test("the optimistic bubble carries the sender's author (multiplayer attribution)", async () => {
+  const { engine } = fakeEngine([
+    (o) => {
+      o.onEvent(sync(false, "", 0));
+      o.onEvent({ type: "done", data: null, seq: 1 });
+    },
+  ]);
+  const { items, output } = makeOutput();
+
+  await streamTurn(
+    engine,
+    "Houston/Bo",
+    "activity-shared",
+    "hi team",
+    output,
+    registry,
+    { tuning: fast, author: { userId: "user_a", name: "Ada" } },
+  );
+
+  const bubble = items.find((i) => i.feed_type === "user_message");
+  expect(bubble?.author).toEqual({ userId: "user_a", name: "Ada" });
+});
+
+test("the optimistic bubble stays authorless when no sender is supplied (single-player)", async () => {
+  const { engine } = fakeEngine([
+    (o) => {
+      o.onEvent(sync(false, "", 0));
+      o.onEvent({ type: "done", data: null, seq: 1 });
+    },
+  ]);
+  const { items, output } = makeOutput();
+
+  await streamTurn(
+    engine,
+    "Houston/Bo",
+    "activity-solo",
+    "hi",
+    output,
+    registry,
+    { tuning: fast },
+  );
+
+  const bubble = items.find((i) => i.feed_type === "user_message");
+  expect(bubble?.author).toBeUndefined();
 });
 
 test("displayText renders as the bubble while the engine still receives the real prompt", async () => {

--- a/packages/sdk/src/modules/turns/turn-stream.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.ts
@@ -20,6 +20,7 @@ import {
   turnErrorMessage,
 } from "./turn-errors";
 import { TurnSink } from "./turn-sink";
+import type { FeedAuthor } from "./vm-output";
 
 export { observeConversation } from "./observe-stream";
 export type { StreamRegistry, StreamTuning } from "./stream-registry";
@@ -70,6 +71,15 @@ export interface StreamTurnOptions {
    * paths. Omitted when the bubble and the prompt are the same string.
    */
   displayText?: string;
+  /**
+   * Who is sending this turn, in a MULTIPLAYER deployment: the acting user's
+   * identity, stamped onto the optimistic bubble so a shared conversation
+   * attributes it from the instant it appears — matching the `author` the
+   * gateway persists and history replays. The SDK never infers it (it has no
+   * identity of its own); a caller with no signed-in user omits it and the
+   * bubble stays authorless, exactly as single-player renders today.
+   */
+  author?: FeedAuthor;
 }
 
 /**
@@ -137,6 +147,8 @@ export async function streamTurn(
       // the engine still receives `prompt` below.
       data: opts.displayText ?? prompt,
       pending: true,
+      // Multiplayer: who is sending. Absent single-player (no identity).
+      author: opts.author,
     });
   }
   // Flip the card to "running" for this turn (re-running a needs_you/done

--- a/packages/sdk/src/modules/turns/vm-output.test.ts
+++ b/packages/sdk/src/modules/turns/vm-output.test.ts
@@ -501,3 +501,77 @@ test("stampHistoryWindow with an unchanged window does not republish", () => {
 
   expect(listener).not.toHaveBeenCalled();
 });
+
+test("seedHistory carries each frame's multiplayer author onto its feed entry", () => {
+  const { vm, snap } = harness();
+  vm.seedHistory("a", "c1", [
+    {
+      feed_type: "user_message",
+      data: "rebuild the report",
+      ts: 10,
+      author: { userId: "user_a", name: "Ada" },
+    },
+    { feed_type: "assistant_text", data: "on it", ts: 20 },
+    {
+      feed_type: "user_message",
+      data: "add the renewals",
+      ts: 30,
+      author: { userId: "user_b", name: "Bo" },
+    },
+  ]);
+
+  expect(snap().feed.map((f) => f.author)).toEqual([
+    { userId: "user_a", name: "Ada" },
+    undefined,
+    { userId: "user_b", name: "Bo" },
+  ]);
+});
+
+test("prependHistory carries authors onto the older page too", () => {
+  const { vm, snap } = harness();
+  vm.seedHistory(
+    "a",
+    "c1",
+    [
+      {
+        feed_type: "user_message",
+        data: "newer",
+        ts: 100,
+        author: { userId: "user_a" },
+      },
+    ],
+    { earliestLoaded: 5, total: 6 },
+  );
+  vm.prependHistory(
+    "a",
+    "c1",
+    [
+      {
+        feed_type: "user_message",
+        data: "older",
+        ts: 10,
+        author: { userId: "user_b", name: "Bo" },
+      },
+    ],
+    { earliestLoaded: 0, total: 6 },
+  );
+
+  expect(snap().feed.map((f) => f.author)).toEqual([
+    { userId: "user_b", name: "Bo" },
+    { userId: "user_a" },
+  ]);
+});
+
+test("a pushed item carries its author; an authorless push stays authorless", () => {
+  const { vm, snap } = harness();
+  vm.pushFeedItem("a", "c1", {
+    feed_type: "user_message",
+    data: "hi team",
+    pending: true,
+    author: { userId: "user_a", name: "Ada" },
+  });
+  vm.pushFeedItem("a", "c1", { feed_type: "assistant_text", data: "hello" });
+
+  expect(snap().feed[0]?.author).toEqual({ userId: "user_a", name: "Ada" });
+  expect(snap().feed[1]).not.toHaveProperty("author");
+});

--- a/packages/sdk/src/modules/turns/vm-output.ts
+++ b/packages/sdk/src/modules/turns/vm-output.ts
@@ -27,11 +27,42 @@ import type {
  * a genuine failure. `sessionStatus` semantics are unchanged, for web parity.
  */
 
+/**
+ * Who wrote a feed entry, in a MULTIPLAYER deployment: the protocol's
+ * `ChatMessage.author`, stamped by the gateway from the acting user. Absent
+ * single-player (desktop / self-host never stamp one).
+ */
+export interface FeedAuthor {
+  userId: string;
+  name?: string;
+}
+
+/**
+ * What the seed/prepend folds consume: one folded history frame. Structurally
+ * the `FeedFrame` `historyToFeed` produces — declared here (rather than
+ * imported) so the fold and its consumer stay import-acyclic.
+ */
+interface HistoryFrame {
+  feed_type: string;
+  data: unknown;
+  ts?: number;
+  author?: FeedAuthor;
+}
+
 /** A single reactive feed entry: a stable id plus the machinery's push payload. */
 export interface FeedItemVM {
   id: string;
   feed_type: string;
   data: unknown;
+  /**
+   * Multiplayer only: who wrote this `user_message`. Carried verbatim from the
+   * history fold (`FeedFrame.author`) when a transcript is seeded/prepended,
+   * and from `StreamTurnOptions.author` on the optimistic send — so a shared
+   * conversation attributes EVERY turn identically on reload and live.
+   * Optional/additive: absent in single-player and on every non-user entry; a
+   * surface that does not render it simply ignores it.
+   */
+  author?: FeedAuthor;
   /**
    * Epoch-ms timestamp of this entry. A seeded history frame carries its source
    * `ChatMessage.ts`; a LIVE push that lacks one is stamped `Date.now()` at push
@@ -234,18 +265,20 @@ export class ConversationVmOutput implements FeedOutput {
   seedHistory(
     agentPath: string,
     sessionKey: string,
-    frames: readonly { feed_type: string; data: unknown; ts?: number }[],
+    frames: readonly HistoryFrame[],
     window?: HistoryWindowVM,
   ): void {
     const s = this.state(agentPath, sessionKey);
     // History frames carry their source `ChatMessage.ts` (absent for a pre-`ts`
-    // transcript); pass it through verbatim — a seeded frame is historical, so
-    // it is never stamped with the wall clock the way a live push is.
+    // transcript) and, in multiplayer, its `author`; pass both through verbatim
+    // — a seeded frame is historical, so it is never stamped with the wall clock
+    // the way a live push is, and its author is the persisted one.
     s.feed = frames.map((f) => ({
       id: `f${s.seq++}`,
       feed_type: f.feed_type,
       data: f.data,
       ...(f.ts !== undefined ? { ts: f.ts } : {}),
+      ...(f.author !== undefined ? { author: f.author } : {}),
     }));
     s.streaming.clear();
     // A windowed server read stamps its window; a cache paint / full-history
@@ -265,7 +298,7 @@ export class ConversationVmOutput implements FeedOutput {
   prependHistory(
     agentPath: string,
     sessionKey: string,
-    frames: readonly { feed_type: string; data: unknown; ts?: number }[],
+    frames: readonly HistoryFrame[],
     window: HistoryWindowVM,
   ): void {
     const s = this.state(agentPath, sessionKey);
@@ -275,6 +308,7 @@ export class ConversationVmOutput implements FeedOutput {
         feed_type: f.feed_type,
         data: f.data,
         ...(f.ts !== undefined ? { ts: f.ts } : {}),
+        ...(f.author !== undefined ? { author: f.author } : {}),
       })),
       ...s.feed,
     ];
@@ -284,12 +318,13 @@ export class ConversationVmOutput implements FeedOutput {
 
   pushFeedItem(agentPath: string, sessionKey: string, item: unknown): void {
     const s = this.state(agentPath, sessionKey);
-    const { feed_type, data, ts, pending, fails_pending } = item as {
+    const { feed_type, data, ts, pending, fails_pending, author } = item as {
       feed_type: string;
       data: unknown;
       ts?: number;
       pending?: boolean;
       fails_pending?: boolean;
+      author?: FeedAuthor;
     };
     // An optimistic (pending) push is NOT server evidence, so it never confirms a
     // sibling optimistic bubble — two queued prompts both keep their clock. ANY
@@ -315,13 +350,16 @@ export class ConversationVmOutput implements FeedOutput {
       s.streaming.delete(finalOf);
     } else {
       // A fresh entry: carry a supplied `ts`, else stamp the wall clock now; an
-      // optimistic push carries `pending: true` until server evidence clears it.
+      // optimistic push carries `pending: true` until server evidence clears it,
+      // and (multiplayer) the sender's `author` so the bubble is attributed from
+      // the instant it appears — exactly as the reseeded history frame will be.
       s.feed.push({
         id: `f${s.seq++}`,
         feed_type,
         data,
         ts: ts ?? Date.now(),
         ...(pending === true ? { pending: true } : {}),
+        ...(author !== undefined ? { author } : {}),
       });
     }
     this.publish(agentPath, sessionKey, s);

--- a/packages/web/e2e/chat-senders.spec.ts
+++ b/packages/web/e2e/chat-senders.spec.ts
@@ -1,0 +1,119 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * HOU-943 — in a SHARED chat every turn says who sent it: the teammate's face +
+ * name on human messages, the agent's mark + name on its own. Single-player is
+ * untouched (no names, no faces).
+ *
+ * The shared shape can't be produced by a local turn (only the cloud gateway
+ * stamps a message's `author`), so the transcript is armed on the fake host
+ * (`/__test__/chat-history`) alongside multiplayer capabilities — the same
+ * wire shape `GET /agents/:id/conversations/:id/history` serves in the cloud.
+ * That makes this a real regression test for the whole pipeline: history →
+ * `historyToFeed` → the SDK conversation VM → `ui/chat`'s sender line.
+ */
+
+/**
+ * The spec's OWN mission + its conversation. Created here rather than reusing a
+ * seeded card so the transcript is the only thing under test: a fresh activity
+ * carries no server-stamped contributors, so it stays visible under the board's
+ * default person scope in multiplayer (`missionMatchesScope`'s unattributed
+ * clause) whatever the fixtures stamp on the seeded missions.
+ */
+const MISSION_ID = "act-shared";
+const MISSION_TITLE = "Q3 pipeline handover";
+const CONVERSATION_ID = `activity-${MISSION_ID}`;
+
+const ADA = { userId: "user_a", name: "Ada Lovelace" };
+const BO = { userId: "user_b", name: "Bo Diaz" };
+
+const ASKED = "Rebuild the Q3 pipeline report";
+const REPLIED = "Sixty-three open deals, cross-checked.";
+const FOLLOWED_UP = "Exclude the churned accounts";
+
+/** Arm a two-author transcript. `authored: false` seeds the same words with no
+ *  author — a single-player conversation. */
+async function seedTranscript(
+  request: APIRequestContext,
+  authored: boolean,
+): Promise<void> {
+  const author = (who: typeof ADA) => (authored ? { author: who } : {});
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-history`, {
+    data: {
+      conversationId: CONVERSATION_ID,
+      messages: [
+        { role: "user", content: ASKED, ts: 1, ...author(ADA) },
+        { role: "assistant", content: REPLIED, ts: 2 },
+        { role: "user", content: FOLLOWED_UP, ts: 3, ...author(BO) },
+      ],
+    },
+  });
+}
+
+/** Create the mission whose card opens this conversation. */
+async function seedMission(request: APIRequestContext): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/agents/houston-assistant/activities`, {
+    data: { id: MISSION_ID, title: MISSION_TITLE, status: "needs_you" },
+  });
+}
+
+/** Put the deployment into multiplayer (what the real gateway advertises). */
+async function armMultiplayer(request: APIRequestContext): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/capabilities`, {
+    data: { multiplayer: true, teams: true, role: "owner" },
+  });
+}
+
+/** The rendered message rows (each carries its stable conversation key). */
+const rows = (page: import("@playwright/test").Page) =>
+  page.locator("[data-conversation-message-key]");
+
+test("a shared chat names and faces the sender of every turn", async ({
+  page,
+  request,
+}) => {
+  await armMultiplayer(request);
+  await seedMission(request);
+  await seedTranscript(request, true);
+  await page.goto("/");
+  await page.getByText(MISSION_TITLE).click();
+
+  const asked = rows(page).filter({ hasText: ASKED });
+  await expect(asked).toBeVisible();
+  // The teammate who wrote it: name + a face (their initials, no photo here).
+  await expect(asked).toContainText(ADA.name);
+  await expect(asked.locator('[data-slot="avatar"]')).toBeVisible();
+  await expect(asked).toContainText("AL");
+
+  // The agent's own turn: its name + the Houston mark (an inline glyph).
+  const replied = rows(page).filter({ hasText: REPLIED });
+  await expect(replied).toContainText("Houston");
+  await expect(replied.locator("svg")).toBeVisible();
+
+  // The SECOND human, so attribution is not a one-author illusion.
+  const followUp = rows(page).filter({ hasText: FOLLOWED_UP });
+  await expect(followUp).toContainText(BO.name);
+  await expect(followUp.locator('[data-slot="avatar"]')).toBeVisible();
+});
+
+test("a single-player chat shows no sender on any turn", async ({
+  page,
+  request,
+}) => {
+  await seedMission(request);
+  await seedTranscript(request, false);
+  await page.goto("/");
+  await page.getByText(MISSION_TITLE).click();
+
+  const asked = rows(page).filter({ hasText: ASKED });
+  await expect(asked).toBeVisible();
+  await expect(asked.locator('[data-slot="avatar"]')).toHaveCount(0);
+
+  // The agent's reply renders bare — no mark, no "Houston" line above it.
+  const replied = rows(page).filter({ hasText: REPLIED });
+  await expect(replied).toBeVisible();
+  await expect(replied).not.toContainText("Houston");
+  await expect(replied.locator("svg")).toHaveCount(0);
+});

--- a/packages/web/src/engine-adapter/cache-persist.ts
+++ b/packages/web/src/engine-adapter/cache-persist.ts
@@ -1,5 +1,8 @@
 import { conversationScope, type FeedOutput } from "@houston/sdk";
-import { writeCachedConversation } from "./conversation-cache";
+import {
+  type CachedFrame,
+  writeCachedConversation,
+} from "./conversation-cache";
 import { conversationStore } from "./vm";
 
 /**
@@ -19,9 +22,7 @@ export function cachePersistOutput(): FeedOutput {
       if (status === "running") return;
       const snapshot = conversationStore.getSnapshot(
         conversationScope(agentPath, sessionKey),
-      ) as
-        | { feed?: { feed_type: string; data: unknown; ts?: number }[] }
-        | undefined;
+      ) as { feed?: CachedFrame[] } | undefined;
       const frames = snapshot?.feed;
       if (!frames || frames.length === 0) return;
       void writeCachedConversation(
@@ -31,6 +32,8 @@ export function cachePersistOutput(): FeedOutput {
           feed_type: f.feed_type,
           data: f.data,
           ...(f.ts !== undefined ? { ts: f.ts } : {}),
+          // Multiplayer attribution survives a cold reopen (HOU-943).
+          ...(f.author !== undefined ? { author: f.author } : {}),
         })),
       );
     },

--- a/packages/web/src/engine-adapter/client/chat-send-mixin.ts
+++ b/packages/web/src/engine-adapter/client/chat-send-mixin.ts
@@ -92,6 +92,7 @@ export function ChatSendMixin<TBase extends BaseCtor>(Base: TBase) {
         req.suppressUserBubble,
         wireTurnPin(req),
         req.displayText,
+        req.author,
       ).finally(() => {
         // The turn settled (or failed): release anything queued behind it.
         if (req.autoResume) noteAutoResumeEnded(path, req.sessionKey);

--- a/packages/web/src/engine-adapter/conversation-cache-idb.ts
+++ b/packages/web/src/engine-adapter/conversation-cache-idb.ts
@@ -12,7 +12,7 @@
 import type {
   CacheRecord,
   ConversationCacheBackend,
-} from "./conversation-cache";
+} from "./conversation-cache-types";
 
 const DB_NAME = "houston-conversation-cache";
 const DB_VERSION = 1;

--- a/packages/web/src/engine-adapter/conversation-cache-types.ts
+++ b/packages/web/src/engine-adapter/conversation-cache-types.ts
@@ -1,0 +1,49 @@
+/**
+ * What the local conversation cache stores, and what it stores THROUGH
+ * (HOU-712) — the record shapes plus the storage port the operations in
+ * `conversation-cache.ts` run on (IndexedDB in the app, in-memory in tests).
+ *
+ * Declared apart from the operations so the IndexedDB backend can depend on the
+ * contract alone: it implements {@link ConversationCacheBackend} without
+ * importing the module that installs it.
+ */
+
+/** One cached feed frame — the folded `{feed_type, data}` the VM seeds from. */
+export interface CachedFrame {
+  feed_type: string;
+  data: unknown;
+  /**
+   * The frame's timestamp, when the source fold carried one — preserved so a
+   * cache-painted bubble keeps its real time instead of losing it (HOU-819).
+   * Display metadata only: seed/replace decisions never compare timestamps
+   * (live pushes and history folds are stamped by different clocks). Absent
+   * on records written before this field existed.
+   */
+  ts?: number;
+  /**
+   * Who wrote this `user_message` in a shared conversation (HOU-943), carried
+   * so a cache-painted transcript names its senders immediately instead of
+   * going anonymous until the server read lands. Absent single-player and on
+   * records written before this field existed.
+   */
+  author?: { userId: string; name?: string };
+}
+
+/** A stored transcript: its frames plus a write stamp (prune order). */
+export interface CacheRecord {
+  frames: CachedFrame[];
+  updatedAt: number;
+}
+
+/** The storage the cache runs on — IndexedDB in the app, in-memory in tests. */
+export interface ConversationCacheBackend {
+  get(key: string): Promise<CacheRecord | null>;
+  set(key: string, record: CacheRecord): Promise<void>;
+  delete(key: string): Promise<void>;
+  /**
+   * Every stored key, oldest write first — the prune sweep's input. Keys
+   * ONLY: the sweep runs on every write, so it must never load transcripts.
+   */
+  keysOldestFirst(): Promise<string[]>;
+  clear(): Promise<void>;
+}

--- a/packages/web/src/engine-adapter/conversation-cache.ts
+++ b/packages/web/src/engine-adapter/conversation-cache.ts
@@ -17,48 +17,30 @@
  * Entries are keyed per gateway + user (the Supabase JWT `sub`), so cached
  * transcripts never leak across accounts on a shared machine; sign-out clears
  * the whole store. Local/desktop engines never cache (reads are local disk).
+ *
+ * This module is the cache's OPERATIONS and its policy (scoping, validation,
+ * disk cap). The record shapes and the storage port live in
+ * `conversation-cache-types.ts`, the IndexedDB implementation of that port in
+ * `conversation-cache-idb.ts`, and the scope derivation in
+ * `conversation-cache-identity.ts` — all re-exported here as the front door.
  */
 
 import { createIdbBackend } from "./conversation-cache-idb";
+import type {
+  CachedFrame,
+  ConversationCacheBackend,
+} from "./conversation-cache-types";
 import { trimForCache } from "./history-window";
 
 export {
   conversationCacheScope,
   jwtSub,
 } from "./conversation-cache-identity";
-
-/** One cached feed frame — the folded `{feed_type, data}` the VM seeds from. */
-export interface CachedFrame {
-  feed_type: string;
-  data: unknown;
-  /**
-   * The frame's timestamp, when the source fold carried one — preserved so a
-   * cache-painted bubble keeps its real time instead of losing it (HOU-819).
-   * Display metadata only: seed/replace decisions never compare timestamps
-   * (live pushes and history folds are stamped by different clocks). Absent
-   * on records written before this field existed.
-   */
-  ts?: number;
-}
-
-/** A stored transcript: its frames plus a write stamp (prune order). */
-export interface CacheRecord {
-  frames: CachedFrame[];
-  updatedAt: number;
-}
-
-/** The storage the cache runs on — IndexedDB in the app, in-memory in tests. */
-export interface ConversationCacheBackend {
-  get(key: string): Promise<CacheRecord | null>;
-  set(key: string, record: CacheRecord): Promise<void>;
-  delete(key: string): Promise<void>;
-  /**
-   * Every stored key, oldest write first — the prune sweep's input. Keys
-   * ONLY: the sweep runs on every write, so it must never load transcripts.
-   */
-  keysOldestFirst(): Promise<string[]>;
-  clear(): Promise<void>;
-}
+export type {
+  CachedFrame,
+  CacheRecord,
+  ConversationCacheBackend,
+} from "./conversation-cache-types";
 
 /** Disk cap: keep the most recently written transcripts, evict the oldest. */
 export const MAX_CACHED_CONVERSATIONS = 256;
@@ -153,6 +135,7 @@ export async function writeCachedConversation(
         feed_type: f.feed_type,
         data: f.data,
         ...(f.ts !== undefined ? { ts: f.ts } : {}),
+        ...(f.author !== undefined ? { author: f.author } : {}),
       })),
       updatedAt: Date.now(),
     });

--- a/packages/web/src/engine-adapter/turn-stream.ts
+++ b/packages/web/src/engine-adapter/turn-stream.ts
@@ -2,6 +2,7 @@ import type { HoustonEngineClient } from "@houston/runtime-client";
 import {
   type BoardStatus,
   conversationScope,
+  type FeedAuthor,
   type FeedFrame,
   type HistoryWindowVM,
   MultiplexFeedOutput,
@@ -109,15 +110,22 @@ export function seedConversationVm(
  * the just-created agent's engine answers, but the user must see it as sent
  * immediately. The eventual real send goes out with `suppressUserBubble` so
  * the bubble is never doubled.
+ *
+ * `author` is the acting user, same shape and purpose as {@link streamTurn}'s
+ * (HOU-943): because the real send SUPPRESSES its own bubble, this push is the
+ * only chance this row ever gets to name its sender — without it a warmed-up
+ * agent's first message would sit permanently unattributed in a shared thread.
  */
 export function pushPendingUserMessage(
   agentPath: string,
   sessionKey: string,
   text: string,
+  author?: FeedAuthor,
 ): void {
   conversationVm.pushFeedItem(agentPath, sessionKey, {
     feed_type: "user_message",
     data: text,
+    author,
   });
 }
 
@@ -131,7 +139,10 @@ export function pushPendingUserMessage(
  * pick (frontend id) — it labels the typed reconnect card when the runtime
  * refuses the send as not-connected. `pin` is the same pick in ENGINE ids,
  * sent on the wire so the turn runs on the conversation's own provider/model
- * instead of the agent-wide settings (HOU-695) — see `wireTurnPin`.
+ * instead of the agent-wide settings (HOU-695) — see `wireTurnPin`. `author` is
+ * the acting user in a multiplayer deployment: it stamps the optimistic bubble
+ * so a shared conversation names its sender before any server frame lands
+ * (HOU-943), and is absent single-player.
  */
 export function streamTurn(
   engine: HoustonEngineClient,
@@ -147,6 +158,7 @@ export function streamTurn(
   suppressUserBubble?: boolean,
   pin?: TurnWirePin,
   displayText?: string,
+  author?: FeedAuthor,
 ): Promise<void> {
   return sdkStreamTurn(
     engine,
@@ -161,6 +173,7 @@ export function streamTurn(
       suppressUserBubble,
       pin,
       displayText,
+      author,
     },
   );
 }

--- a/packages/web/tests/pending-user-message.test.ts
+++ b/packages/web/tests/pending-user-message.test.ts
@@ -1,0 +1,44 @@
+import { conversationScope } from "@houston/sdk";
+import { expect, test } from "vitest";
+import { pushPendingUserMessage } from "../src/engine-adapter/turn-stream";
+import { conversationStore } from "../src/engine-adapter/vm";
+
+/**
+ * The warming-engine send queue's optimistic bubble (HOU-693). The REAL send at
+ * flush goes out with `suppressUserBubble`, so this push is the only chance the
+ * row ever gets to name its sender: without the author it would sit permanently
+ * unattributed in a shared conversation (HOU-943), while every other message in
+ * the thread carries a name.
+ */
+
+type FeedEntry = {
+  feed_type: string;
+  data: unknown;
+  author?: { userId: string; name?: string };
+};
+
+function feedOf(agentPath: string, sessionKey: string): FeedEntry[] {
+  const snapshot = conversationStore.getSnapshot(
+    conversationScope(agentPath, sessionKey),
+  ) as { feed?: FeedEntry[] } | undefined;
+  return snapshot?.feed ?? [];
+}
+
+test("a warming bubble carries the acting user, so it is attributed at once", () => {
+  pushPendingUserMessage("Houston/Bo", "warm-authored", "book the flight", {
+    userId: "user_a",
+    name: "Ada Lovelace",
+  });
+  const feed = feedOf("Houston/Bo", "warm-authored");
+  expect(feed).toHaveLength(1);
+  expect(feed[0]?.feed_type).toBe("user_message");
+  expect(feed[0]?.data).toBe("book the flight");
+  expect(feed[0]?.author).toEqual({ userId: "user_a", name: "Ada Lovelace" });
+});
+
+test("no acting user (single-player / signed out) leaves the bubble authorless", () => {
+  pushPendingUserMessage("Houston/Bo", "warm-anon", "book the flight");
+  const feed = feedOf("Houston/Bo", "warm-anon");
+  expect(feed).toHaveLength(1);
+  expect(feed[0]).not.toHaveProperty("author");
+});

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -222,6 +222,14 @@ export interface AIBoardProps {
   currentUserId?: ChatPanelProps["currentUserId"];
   /** Localized author-attribution labels. Forwarded to ChatPanel. */
   authorLabels?: ChatPanelProps["authorLabels"];
+  /** Force sender identity onto every turn (a shared conversation). Forwarded
+   *  to ChatPanel — see `ChatMessagesProps.showSenders`. */
+  showSenders?: ChatPanelProps["showSenders"];
+  /** The agent's display name for its sender line. Forwarded to ChatPanel. */
+  agentLabel?: ChatPanelProps["agentLabel"];
+  /** Sender avatar (teammate face / agent mark) for the sender line. Forwarded
+   *  to ChatPanel. */
+  renderSenderAvatar?: ChatPanelProps["renderSenderAvatar"];
   /** Prop-driven dictation control for the composer mic. Forwarded to
    *  ChatPanel; omit (or ChatPanel's own default) hides the mic entirely. */
   dictation?: ChatPanelProps["dictation"];
@@ -343,6 +351,9 @@ export function AIBoard({
   composerLabels,
   currentUserId,
   authorLabels,
+  showSenders,
+  agentLabel,
+  renderSenderAvatar,
   dictation,
   layout = "board",
   listAlign,
@@ -723,6 +734,9 @@ export function AIBoard({
           renderUserMessage={renderUserMessage}
           currentUserId={currentUserId}
           authorLabels={authorLabels}
+          showSenders={showSenders}
+          agentLabel={agentLabel}
+          renderSenderAvatar={renderSenderAvatar}
           conversationMap={conversationMap}
           dictation={dictation}
           afterMessages={renderedAfterMessages}

--- a/ui/chat/src/author-label.ts
+++ b/ui/chat/src/author-label.ts
@@ -19,11 +19,23 @@ export interface ChatAuthorLabels {
 }
 
 /**
+ * The last-resort name for an author we know only by id: a short slice, never
+ * the raw id. User ids are opaque UUIDs and the reader is non-technical — a
+ * 36-character id above a bubble reads as a bug, and the initials derived from
+ * it would be two random hex characters. Same rule as the board's face-stack
+ * label fallback (the app's `mission-people.ts`), duplicated rather than shared
+ * because `ui/` may not import app code.
+ */
+function shortIdName(userId: string): string {
+  return userId.slice(0, 8);
+}
+
+/**
  * The label text shown above a user bubble in a multiplayer thread, or `null`
  * to show none:
  *  - authorless message → no label (single-player / legacy turn).
  *  - the viewer's own message → `authorLabels.you` if provided, else no label.
- *  - a teammate's message → their display name, falling back to the userId.
+ *  - a teammate's message → their display name, falling back to a short id.
  */
 export function authorLabelFor(
   author: MessageAuthor | undefined,
@@ -32,5 +44,25 @@ export function authorLabelFor(
 ): string | null {
   if (!author) return null;
   if (author.userId === currentUserId) return authorLabels?.you ?? null;
-  return author.name ?? author.userId;
+  return author.name ?? shortIdName(author.userId);
+}
+
+/**
+ * The sender name for a user bubble when attribution is FORCED on (`showSenders`
+ * — a multiplayer deployment labels every turn, however many people have
+ * written). Same rule as {@link authorLabelFor} except the viewer is never
+ * anonymous: with no `you` label their own name (then a short id) stands in, so
+ * no row in a shared thread is left unattributed. An authorless message
+ * (single-player history, or a send by a client with no identity) still yields
+ * `null` — there is nobody to name.
+ */
+export function senderNameFor(
+  author: MessageAuthor | undefined,
+  currentUserId: string | undefined,
+  authorLabels: ChatAuthorLabels | undefined,
+): string | null {
+  if (!author) return null;
+  if (author.userId === currentUserId)
+    return authorLabels?.you ?? author.name ?? shortIdName(author.userId);
+  return author.name ?? shortIdName(author.userId);
 }

--- a/ui/chat/src/chat-message-body.tsx
+++ b/ui/chat/src/chat-message-body.tsx
@@ -1,0 +1,54 @@
+/**
+ * A message's rendered body: the markdown/user content inside its bubble. Split
+ * out of `chat-message-item.tsx` so that file stays a thin row composer (sender
+ * line + body + turn summary) and each piece keeps its own docs.
+ */
+
+import type { ReactNode } from "react";
+import type { RenderLinkProps } from "./ai-elements/message";
+import { MessageContent, MessageResponse } from "./ai-elements/message";
+import type { ChatMessage } from "./feed-to-messages";
+
+interface ChatMessageBodyProps {
+  message: ChatMessage;
+  streaming: boolean;
+  transformContent?: (content: string) => {
+    content: string;
+    extra?: ReactNode;
+  };
+  renderUserMessage?: (msg: ChatMessage) => ReactNode | undefined;
+  onOpenLink?: (url: string) => void;
+  renderLink?: (props: RenderLinkProps) => ReactNode;
+}
+
+export function ChatMessageBody({
+  message,
+  streaming,
+  transformContent,
+  renderUserMessage,
+  onOpenLink,
+  renderLink,
+}: ChatMessageBodyProps) {
+  if (!message.content) return null;
+  if (message.from === "user" && renderUserMessage) {
+    const custom = renderUserMessage(message);
+    if (custom !== undefined) return custom;
+  }
+  const transformed =
+    message.from === "assistant" && transformContent
+      ? transformContent(message.content)
+      : null;
+
+  return (
+    <MessageContent>
+      <MessageResponse
+        isAnimating={streaming}
+        onOpenLink={onOpenLink}
+        renderLink={renderLink}
+      >
+        {transformed?.content ?? message.content}
+      </MessageResponse>
+      {transformed?.extra}
+    </MessageContent>
+  );
+}

--- a/ui/chat/src/chat-message-item.tsx
+++ b/ui/chat/src/chat-message-item.tsx
@@ -1,18 +1,16 @@
 import { cn } from "@houston-ai/core";
 import type { ReactNode } from "react";
 import type { RenderLinkProps } from "./ai-elements/message";
-import {
-  Message,
-  MessageContent,
-  MessageResponse,
-} from "./ai-elements/message";
+import { Message } from "./ai-elements/message";
 import type { ReasoningTriggerProps } from "./ai-elements/reasoning";
 import type { ChatAuthorLabels } from "./author-label";
-import { authorLabelFor } from "./author-label";
+import { authorLabelFor, senderNameFor } from "./author-label";
 import type { ToolsAndCardsProps } from "./chat-helpers";
+import { ChatMessageBody } from "./chat-message-body";
 import type { ChatProcessLabels } from "./chat-process-block";
 import type { ChatDisplayItem } from "./chat-process-groups";
 import { ChatProcessMessage } from "./chat-process-message";
+import { ChatSenderHeader } from "./chat-sender-header";
 import { ChatSystemMessage } from "./chat-system-message";
 import type { ChatMessage } from "./feed-to-messages";
 import { OFFSCREEN_RENDER_SKIP } from "./offscreen-render";
@@ -24,7 +22,16 @@ interface ChatMessageItemProps {
   turnEndSummaries: Map<number, TurnEndSummary>;
   highlightedMessageKey: string | null;
   selectedLabel?: string;
+  /** User rows carry a sender line (forced by `showSenders`, else the ≥2-author
+   *  heuristic). */
   showAuthorLabels: boolean;
+  /** Attribution is FORCED on (a shared conversation): agent rows carry the
+   *  agent's sender line, and a user row never leaves the viewer anonymous.
+   *  False = the legacy ≥2-author heuristic, which labels user rows only. */
+  forcedSenders: boolean;
+  /** The agent's display name for its sender line. */
+  agentLabel?: string;
+  renderSenderAvatar?: (msg: ChatMessage) => ReactNode | undefined;
   transformContent?: (content: string) => {
     content: string;
     extra?: ReactNode;
@@ -52,6 +59,9 @@ export function ChatMessageItem({
   highlightedMessageKey,
   selectedLabel,
   showAuthorLabels,
+  forcedSenders,
+  agentLabel,
+  renderSenderAvatar,
   transformContent,
   toolLabels,
   isSpecialTool,
@@ -111,10 +121,22 @@ export function ChatMessageItem({
     );
   }
 
-  const authorLabel =
-    message.from === "user" && showAuthorLabels
-      ? authorLabelFor(message.author, currentUserId, authorLabels)
-      : null;
+  // Who said this turn. A user row names its author (forced attribution never
+  // leaves the viewer anonymous — `senderNameFor`; the legacy heuristic keeps
+  // `authorLabelFor`'s "own bubbles stay bare"); an agent row names the agent,
+  // and only when attribution is forced on.
+  const isUser = message.from === "user";
+  const attributed = isUser ? showAuthorLabels : forcedSenders;
+  const senderName = !attributed
+    ? null
+    : !isUser
+      ? (agentLabel ?? null)
+      : forcedSenders
+        ? senderNameFor(message.author, currentUserId, authorLabels)
+        : authorLabelFor(message.author, currentUserId, authorLabels);
+  const senderAvatar = attributed ? renderSenderAvatar?.(message) : undefined;
+  const showSenderLine =
+    attributed && (senderName !== null || senderAvatar !== undefined);
   const streaming = message.isStreaming && sourceIndex === messageCount - 1;
   const summary = renderTurnSummary
     ? turnEndSummaries.get(sourceIndex)
@@ -127,10 +149,12 @@ export function ChatMessageItem({
       from={message.from}
     >
       <div>
-        {authorLabel ? (
-          <div className="mb-1 px-1 text-xs text-ink-muted group-[.is-user]:text-right">
-            {authorLabel}
-          </div>
+        {showSenderLine ? (
+          <ChatSenderHeader
+            avatar={senderAvatar}
+            isUser={isUser}
+            name={senderName ?? undefined}
+          />
         ) : null}
         <ChatMessageBody
           message={message}
@@ -143,46 +167,5 @@ export function ChatMessageItem({
         {summary ? renderTurnSummary?.(summary) : null}
       </div>
     </Message>
-  );
-}
-
-interface ChatMessageBodyProps {
-  message: ChatMessage;
-  streaming: boolean;
-  transformContent?: ChatMessageItemProps["transformContent"];
-  renderUserMessage?: ChatMessageItemProps["renderUserMessage"];
-  onOpenLink?: (url: string) => void;
-  renderLink?: (props: RenderLinkProps) => ReactNode;
-}
-
-function ChatMessageBody({
-  message,
-  streaming,
-  transformContent,
-  renderUserMessage,
-  onOpenLink,
-  renderLink,
-}: ChatMessageBodyProps) {
-  if (!message.content) return null;
-  if (message.from === "user" && renderUserMessage) {
-    const custom = renderUserMessage(message);
-    if (custom !== undefined) return custom;
-  }
-  const transformed =
-    message.from === "assistant" && transformContent
-      ? transformContent(message.content)
-      : null;
-
-  return (
-    <MessageContent>
-      <MessageResponse
-        isAnimating={streaming}
-        onOpenLink={onOpenLink}
-        renderLink={renderLink}
-      >
-        {transformed?.content ?? message.content}
-      </MessageResponse>
-      {transformed?.extra}
-    </MessageContent>
   );
 }

--- a/ui/chat/src/chat-messages-types.ts
+++ b/ui/chat/src/chat-messages-types.ts
@@ -61,6 +61,24 @@ export interface ChatMessagesProps {
   currentUserId?: string;
   /** Localized labels for author attribution. See `ChatAuthorLabels`. */
   authorLabels?: ChatAuthorLabels;
+  /**
+   * Force sender identity onto EVERY turn: each user row shows its author's
+   * face + name, each assistant row the agent's mark + name. Set it when the
+   * conversation is shared (a multiplayer deployment) — attribution is a
+   * property of the deployment, not of how many people have written yet.
+   *
+   * Omitted (the default) keeps the historical heuristic: user rows carry a
+   * plain author label only once the thread holds ≥2 distinct authors, and
+   * assistant rows carry none.
+   */
+  showSenders?: boolean;
+  /** The agent's display name, shown on assistant rows when `showSenders`.
+   *  Without it an assistant row shows its mark only. */
+  agentLabel?: string;
+  /** The sender avatar for a row (teammate face / agent mark), shown in the
+   *  sender line. Return `undefined` to render the name alone. Distinct from
+   *  `renderMessageAvatar`, which badges the bubble itself (channel logos). */
+  renderSenderAvatar?: (msg: ChatMessage) => ReactNode | undefined;
   /** Props-only configuration for the optional Conversation Map. */
   conversationMap?: {
     labels?: ConversationMapLabels;

--- a/ui/chat/src/chat-messages.tsx
+++ b/ui/chat/src/chat-messages.tsx
@@ -22,7 +22,7 @@ import { distinctAuthorCount } from "./feed-to-messages";
 import { computeTurnEndSummary } from "./turn-tools";
 
 export type { ChatAuthorLabels } from "./author-label";
-export { authorLabelFor } from "./author-label";
+export { authorLabelFor, senderNameFor } from "./author-label";
 export type { ChatMessagesProps } from "./chat-messages-types";
 
 export function ChatMessages({
@@ -47,16 +47,22 @@ export function ChatMessages({
   renderLink,
   currentUserId,
   authorLabels,
+  showSenders,
+  agentLabel,
+  renderSenderAvatar,
   conversationMap,
 }: ChatMessagesProps) {
   const [highlightedMessageKey, setHighlightedMessageKey] = useState<
     string | null
   >(null);
-  // Show author labels only when the thread has ≥2 distinct authors (C5); a
-  // single-author (or single-player) conversation stays label-free.
+  // A shared conversation attributes EVERY turn (`showSenders`) — sender
+  // identity is a property of the deployment, not of how many people have
+  // written. Without that signal, fall back to the historical heuristic: label
+  // user bubbles only once the thread holds ≥2 distinct authors (C5), and never
+  // label the agent.
   const showAuthorLabels = useMemo(
-    () => distinctAuthorCount(messages) >= 2,
-    [messages],
+    () => showSenders ?? distinctAuthorCount(messages) >= 2,
+    [showSenders, messages],
   );
   const turnEndSummaries = useMemo(
     () => computeTurnEndSummary(messages, status),
@@ -101,9 +107,11 @@ export function ChatMessages({
         ) : null}
         {displayItems.map((item) => (
           <ChatMessageItem
+            agentLabel={agentLabel}
             authorLabels={authorLabels}
             contextCompactedLabel={contextCompactedLabel}
             currentUserId={currentUserId}
+            forcedSenders={showSenders === true}
             getThinkingMessage={getThinkingMessage}
             highlightedMessageKey={highlightedMessageKey}
             isSpecialTool={isSpecialTool}
@@ -114,6 +122,7 @@ export function ChatMessages({
             processLabels={processLabels}
             renderLink={renderLink}
             renderMessageAvatar={renderMessageAvatar}
+            renderSenderAvatar={renderSenderAvatar}
             renderSystemMessage={renderSystemMessage}
             renderToolResult={renderToolResult}
             renderTurnSummary={renderTurnSummary}

--- a/ui/chat/src/chat-panel-types.ts
+++ b/ui/chat/src/chat-panel-types.ts
@@ -125,6 +125,13 @@ export interface ChatPanelProps {
   currentUserId?: ChatMessagesProps["currentUserId"];
   /** Localized author-attribution labels. See `ChatAuthorLabels`. */
   authorLabels?: ChatMessagesProps["authorLabels"];
+  /** Force sender identity onto every turn (shared conversations). See
+   *  `ChatMessagesProps.showSenders`. */
+  showSenders?: ChatMessagesProps["showSenders"];
+  /** The agent's display name for assistant sender lines. */
+  agentLabel?: ChatMessagesProps["agentLabel"];
+  /** Sender avatar (teammate face / agent mark) for the sender line. */
+  renderSenderAvatar?: ChatMessagesProps["renderSenderAvatar"];
   /** Props-only configuration for the optional Conversation Map. */
   conversationMap?: ChatMessagesProps["conversationMap"];
 }

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -72,6 +72,9 @@ export function ChatPanel({
   dictation,
   currentUserId,
   authorLabels,
+  showSenders,
+  agentLabel,
+  renderSenderAvatar,
   conversationMap,
 }: ChatPanelProps) {
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -192,6 +195,9 @@ export function ChatPanel({
           renderLink={renderLink}
           currentUserId={currentUserId}
           authorLabels={authorLabels}
+          showSenders={showSenders}
+          agentLabel={agentLabel}
+          renderSenderAvatar={renderSenderAvatar}
           conversationMap={conversationMap}
         />
       ) : (

--- a/ui/chat/src/chat-sender-header.tsx
+++ b/ui/chat/src/chat-sender-header.tsx
@@ -1,0 +1,42 @@
+/**
+ * The sender line above a message: who said this turn — a face (teammate photo
+ * or initials) plus their name, or the agent's mark plus its name. Rendered
+ * once per attributed row, mirroring the shared-chat anatomy: avatar leading,
+ * name beside it, message body below.
+ *
+ * The avatar node itself is supplied by the consumer (`renderSenderAvatar`) so
+ * the library stays free of profile lookups and agent-color resolution; a row
+ * with no avatar shows the name alone.
+ */
+
+import { cn } from "@houston-ai/core";
+import type { ReactNode } from "react";
+
+interface ChatSenderHeaderProps {
+  /** The sender's display name. Absent renders the avatar alone. */
+  name?: string;
+  /** The sender's avatar (person face / agent mark). Optional. */
+  avatar?: ReactNode;
+  /** A user row: the bubble is right-aligned, so the line mirrors to match. */
+  isUser: boolean;
+}
+
+export function ChatSenderHeader({
+  name,
+  avatar,
+  isUser,
+}: ChatSenderHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "mb-1 flex items-center gap-1.5 px-1",
+        isUser && "flex-row-reverse",
+      )}
+    >
+      {avatar ? <span className="flex shrink-0">{avatar}</span> : null}
+      {name ? (
+        <span className="truncate text-xs font-semibold text-ink">{name}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -182,7 +182,7 @@ export type { ChatComposerLabels, ChatInputProps } from "./chat-input";
 export { ChatInput } from "./chat-input";
 export type { AttachMenuItem } from "./chat-input-parts";
 export type { ChatAuthorLabels } from "./chat-messages";
-export { authorLabelFor } from "./chat-messages";
+export { authorLabelFor, senderNameFor } from "./chat-messages";
 // === Chat Components ===
 export { ChatPanel } from "./chat-panel";
 export type {

--- a/ui/chat/tests/attribution.test.ts
+++ b/ui/chat/tests/attribution.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
-import { authorLabelFor } from "../src/author-label.ts";
+import { authorLabelFor, senderNameFor } from "../src/author-label.ts";
 import {
   type ChatMessage,
   distinctAuthorCount,
@@ -69,5 +69,44 @@ describe("authorLabelFor", () => {
   it("falls back to the userId when a teammate has no name", () => {
     const nameless = { userId: "user_b" };
     assert.equal(authorLabelFor(nameless, "user_z", { you: "You" }), "user_b");
+  });
+
+  it("never prints a raw UUID at a non-technical reader", () => {
+    const nameless = { userId: "8f14e45f-ceea-467a-9e8a-2f4d6b1c0a37" };
+    assert.equal(
+      authorLabelFor(nameless, "user_z", { you: "You" }),
+      "8f14e45f",
+    );
+  });
+});
+
+describe("senderNameFor (forced attribution)", () => {
+  const ada = { userId: "user_a", name: "Ada" };
+
+  it("returns null for an authorless message (nobody to name)", () => {
+    assert.equal(senderNameFor(undefined, "viewer", { you: "You" }), null);
+  });
+
+  it("shows the `you` override for the viewer's own message", () => {
+    assert.equal(senderNameFor(ada, "user_a", { you: "You" }), "You");
+  });
+
+  it("never leaves the viewer anonymous: falls back to their own name", () => {
+    assert.equal(senderNameFor(ada, "user_a", undefined), "Ada");
+  });
+
+  it("falls back to the viewer's userId when nothing else is known", () => {
+    assert.equal(senderNameFor({ userId: "user_b" }, "user_b", {}), "user_b");
+  });
+
+  it("shows a teammate's display name", () => {
+    assert.equal(senderNameFor(ada, "user_z", { you: "You" }), "Ada");
+  });
+
+  it("shortens a nameless author's id instead of printing a raw UUID", () => {
+    const nameless = { userId: "8f14e45f-ceea-467a-9e8a-2f4d6b1c0a37" };
+    assert.equal(senderNameFor(nameless, "user_z", { you: "You" }), "8f14e45f");
+    // Same for the viewer's own nameless row (no `you` label to fall back on).
+    assert.equal(senderNameFor(nameless, nameless.userId, {}), "8f14e45f");
   });
 });

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -1337,6 +1337,15 @@ export interface SessionStartRequest {
    * itself a resume.
    */
   autoResume?: boolean;
+  /**
+   * Who is sending, in a MULTIPLAYER deployment: stamps the optimistic user
+   * bubble so a shared conversation attributes the message from the instant it
+   * appears — matching the `author` the gateway persists and history replays
+   * (HOU-943). Presentation-only, like `displayText`: the wire send is
+   * unchanged, and the gateway remains the authority on who acted. Omitted
+   * single-player / signed out, leaving the bubble authorless.
+   */
+  author?: { userId: string; name?: string };
 }
 
 export interface SessionStartResponse {

--- a/ui/engine-client/src/vm.ts
+++ b/ui/engine-client/src/vm.ts
@@ -30,6 +30,7 @@ export function pushPendingUserMessage(
   _agentPath: string,
   _sessionKey: string,
   _text: string,
+  _author?: { userId: string; name?: string },
 ): void {}
 
 /**


### PR DESCRIPTION
Fixes HOU-943

**Stack 2/3** — based on #1109 (person tones); merge after it. HOU-946 stacks on this.

## What

In shared-agent chats every turn shows the sender: teammate avatar + name above human bubbles, the agent mark + name above agent prose — the landing's multiplayer chat anatomy, on web and desktop. Attribution follows the deployment: forced on whenever `capabilities.multiplayer`, from the very first message. Outside multiplayer (including the capabilities-loading window) the legacy two-author heuristic still governs, so legacy attributed transcripts keep their labels. Single-player transcripts are byte-identical.

## How

Sender identity was ~80% built and dormant: `ChatMessage.author` is already stamped by the runtime from the gateway's acting header and served on history + the wire — but the SDK view-model dropped it. Now:

- **`@houston/sdk`**: additive `FeedItemVM.author`, carried through `seedHistory`/`prependHistory`, the IndexedDB cache round-trip (cold reopen keeps names), and the optimistic send via `StreamTurnOptions.author` — including warming-engine sends, which previously produced a permanently anonymous bubble.
- **`ui/chat`**: `showSenders`/`agentLabel`/`renderSenderAvatar` props + `ChatSenderHeader` (30px avatar, always-visible name). Props-only, i18n-agnostic. Nameless authors render an 8-char id label, never a raw UUID.
- **App**: `use-chat-sender-avatars` resolves faces via the same batched org-profiles lookup the board stacks use; human initials wear the opaque person tones from #1109; agent rows use `HoustonAvatar`.
- **Fake host**: new `POST /__test__/chat-history` control — the only way to reach a shared conversation locally — plus a `chat-senders` e2e (multiplayer shows senders; single-player shows none).

## Verification

sdk 380, ui/chat 214, web adapter 258, app 2100 tests; all typechecks; locales in sync; chat-senders e2e 2/2; visual baselines unchanged (no re-record needed). Adversarially reviewed; all confirmed findings fixed. Inventory v37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)