### PR TITLE
feat: learnings carry provenance (person + mission)

### DIFF
--- a/app/src-tauri/src/houston_prompt/skills_memory.rs
+++ b/app/src-tauri/src/houston_prompt/skills_memory.rs
@@ -61,5 +61,7 @@ Save a learning only when:
 
 Do not save trivial observations, temporary task facts, private credentials, or anything derivable from the workspace.
 
-When saving, read `.houston/learnings/learnings.schema.json`, then update `.houston/learnings/learnings.json` to match it exactly.
+Save with the `save_learning` tool. Pass the learning's text and nothing else. It is the only safe way to save: it merges with the user's existing memory instead of overwriting it, and Houston records on its own who taught the learning and which mission it came from, so the user can always see where a memory came from. Save one learning per call, written in the user's own terms. Never write the person's name or the mission into the text yourself, Houston attaches those.
+
+Reading `.houston/learnings/learnings.json` to check what is already remembered is fine. Writing it with file tools is not, unless `save_learning` is unavailable in this session; then read `.houston/learnings/learnings.schema.json` first and match it exactly.
 "#;

--- a/app/src/components/tabs/agent-admin/agent-admin-knowledge.tsx
+++ b/app/src/components/tabs/agent-admin/agent-admin-knowledge.tsx
@@ -1,9 +1,16 @@
+import { useMemo } from "react";
 import {
+  useActivity,
   useAddLearning,
   useLearnings,
   useRemoveLearning,
   useUpdateLearning,
 } from "../../../hooks/queries";
+import { useUserProfiles } from "../../../hooks/queries/use-user-profiles";
+import {
+  collectTaughtByIds,
+  resolveLearningProvenance,
+} from "../../../lib/learning-provenance";
 import { LearningsContent } from "../learnings-content";
 import type { AgentAdminScreenProps } from "./agent-admin-nav.ts";
 
@@ -14,9 +21,35 @@ export function AgentAdminKnowledge({ agent }: AgentAdminScreenProps) {
   const addLearning = useAddLearning(path);
   const removeLearning = useRemoveLearning(path);
   const updateLearning = useUpdateLearning(path);
+
+  const entries = data?.entries ?? [];
+  // Faces for whoever taught these learnings. The hook is multiplayer-gated, so
+  // single player / desktop resolves nothing and the line falls back to the name
+  // stored on the learning itself.
+  const { profiles } = useUserProfiles(collectTaughtByIds(entries));
+  // Live mission titles, so a renamed mission reads correctly; the title stored
+  // at save time covers a mission that was since deleted.
+  const { data: activities } = useActivity(path);
+  const missionTitles = useMemo(
+    () => new Map((activities ?? []).map((a) => [a.id, a.title])),
+    [activities],
+  );
+
+  // The card takes the RESOLVED line only; the raw provenance fields stop here.
+  const rows = useMemo(
+    () =>
+      entries.map(({ index, text, id, ...source }) => ({
+        index,
+        text,
+        id,
+        provenance: resolveLearningProvenance(source, profiles, missionTitles),
+      })),
+    [entries, profiles, missionTitles],
+  );
+
   return (
     <LearningsContent
-      entries={data?.entries ?? []}
+      entries={rows}
       onAdd={(text) => addLearning.mutateAsync(text)}
       onRemove={(index) => removeLearning.mutateAsync(index)}
       onUpdate={(id, text) => updateLearning.mutateAsync({ id, text })}

--- a/app/src/components/tabs/learning-card-preview.tsx
+++ b/app/src/components/tabs/learning-card-preview.tsx
@@ -2,11 +2,14 @@ import { cn } from "@houston-ai/core";
 import { ChevronDown, Pencil, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { learningPreviewText } from "../../lib/learning-preview";
+import type { LearningProvenanceView } from "../../lib/learning-provenance";
+import { LearningProvenanceLine } from "./learning-provenance";
 
 export function LearningPreview({
   text,
   expanded,
   canExpand,
+  provenance,
   onToggle,
   onEdit,
   onDelete,
@@ -14,6 +17,8 @@ export function LearningPreview({
   text: string;
   expanded: boolean;
   canExpand: boolean;
+  /** Where this memory came from (person and/or mission). Absent = no line. */
+  provenance?: LearningProvenanceView | null;
   onToggle: () => void;
   /** Omitted in read-only mode: no edit affordance is rendered. */
   onEdit?: () => void;
@@ -48,16 +53,19 @@ export function LearningPreview({
       ) : (
         <div className="size-7 shrink-0" />
       )}
-      <p
-        className={cn(
-          "min-w-0 flex-1 text-sm leading-relaxed text-ink break-words",
-          expanded
-            ? "whitespace-pre-wrap"
-            : "overflow-hidden [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2]",
-        )}
-      >
-        {expanded || !canExpand ? text : learningPreviewText(text)}
-      </p>
+      <div className="min-w-0 flex-1">
+        <p
+          className={cn(
+            "text-sm leading-relaxed text-ink break-words",
+            expanded
+              ? "whitespace-pre-wrap"
+              : "overflow-hidden [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2]",
+          )}
+        >
+          {expanded || !canExpand ? text : learningPreviewText(text)}
+        </p>
+        {provenance && <LearningProvenanceLine provenance={provenance} />}
+      </div>
       {(onEdit || onDelete) && (
         <div className="flex shrink-0 items-center gap-1">
           {onEdit && (

--- a/app/src/components/tabs/learning-card.tsx
+++ b/app/src/components/tabs/learning-card.tsx
@@ -3,10 +3,12 @@ import { Check, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { learningNeedsExpansion } from "../../lib/learning-preview";
+import type { LearningProvenanceView } from "../../lib/learning-provenance";
 import { LearningPreview } from "./learning-card-preview";
 
 export function LearningCard({
   initialText,
+  provenance,
   onSave,
   onDelete,
   onCancel,
@@ -14,6 +16,12 @@ export function LearningCard({
   readOnly = false,
 }: {
   initialText: string;
+  /**
+   * Where this memory came from. Shown under the text in the preview state and
+   * hidden while editing (the editor is about the text, and the provenance is
+   * not the editor's to change).
+   */
+  provenance?: LearningProvenanceView | null;
   onSave: (text: string) => Promise<unknown> | unknown;
   onDelete?: () => void;
   onCancel?: () => void;
@@ -82,6 +90,7 @@ export function LearningCard({
           text={initialText}
           expanded={expanded}
           canExpand={canExpand}
+          provenance={provenance}
           onToggle={() => setExpanded((next) => !next)}
           onEdit={readOnly ? undefined : startEditing}
           onDelete={readOnly ? undefined : onDelete}

--- a/app/src/components/tabs/learning-provenance.tsx
+++ b/app/src/components/tabs/learning-provenance.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from "react-i18next";
+import type { LearningProvenanceView } from "../../lib/learning-provenance";
+import { PersonFace } from "../mission-person-face";
+
+/**
+ * The muted "where this memory came from" line under a learning: the person who
+ * taught it (face + name) and the mission it came from. Rendered only when at
+ * least one of the two is known — see `resolveLearningProvenance`, which returns
+ * null otherwise, so a learning with no provenance keeps today's exact row.
+ *
+ * The face is the SAME `PersonFace` the person filter and the chat sender line
+ * draw, so one human wears one avatar (and one tone) across every surface.
+ */
+export function LearningProvenanceLine({
+  provenance,
+}: {
+  provenance: LearningProvenanceView;
+}) {
+  const { t } = useTranslation("agents");
+  const { name, personId, photoUrl, mission } = provenance;
+  const label =
+    name && mission
+      ? t("learnings.provenanceFromMission", { name, mission })
+      : name
+        ? t("learnings.provenanceFrom", { name })
+        : t("learnings.provenanceMission", { mission });
+
+  return (
+    <p className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-ink-muted">
+      {name && (
+        <PersonFace
+          person={{
+            label: name,
+            ...(personId ? { id: personId } : {}),
+            ...(photoUrl ? { imageUrl: photoUrl } : {}),
+          }}
+        />
+      )}
+      <span className="truncate">{label}</span>
+    </p>
+  );
+}

--- a/app/src/components/tabs/learnings-content.tsx
+++ b/app/src/components/tabs/learnings-content.tsx
@@ -8,12 +8,19 @@ import {
 import { Plus } from "lucide-react";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import type { LearningProvenanceView } from "../../lib/learning-provenance";
 import { LearningCard } from "./learning-card";
 
 export interface LearningEntry {
   index: number;
   text: string;
   id: string;
+  /**
+   * Resolved provenance line, joined on by the screen (raw `taught_by` /
+   * mission fields stay in `LearningSourceRow` — this view never reads them).
+   * Absent or null = no line.
+   */
+  provenance?: LearningProvenanceView | null;
 }
 
 export function LearningsContent({
@@ -114,6 +121,7 @@ export function LearningsContent({
           <LearningCard
             key={entry.id}
             initialText={entry.text}
+            provenance={entry.provenance}
             readOnly={readOnly}
             onSave={(text) => onUpdate(entry.id, text)}
             onDelete={() => setPendingRemove(entry)}

--- a/app/src/data/learnings.ts
+++ b/app/src/data/learnings.ts
@@ -3,10 +3,27 @@
 import schema from "@houston-ai/agent-schemas/learnings.schema.json";
 import { newId, now, readAgentJson, writeAgentJson } from "./agent-file";
 
+/** WHO taught a learning. Mirrors the protocol's `ActivityContributor`. */
+export interface LearningAuthor {
+  user_id: string;
+  name?: string;
+}
+
 export interface Learning {
   id: string;
   text: string;
   created_at: string;
+  /**
+   * Provenance: the person this learning came from. Stamped by the host from
+   * the gateway's acting-as identity when an agent turn saved it, or here from
+   * the signed-in session when a person added it in Memory. Absent on
+   * desktop / single-player, which keeps those files identity-key free.
+   */
+  taught_by?: LearningAuthor;
+  /** Provenance: the mission whose conversation taught this learning. */
+  mission_id?: string;
+  /** The mission's title at save time, the fallback when the live one is gone. */
+  mission_title?: string;
 }
 
 const NAME = "learnings";
@@ -16,9 +33,27 @@ export async function list(agentPath: string): Promise<Learning[]> {
   return readAgentJson<Learning[]>(agentPath, NAME, s, []);
 }
 
-export async function add(agentPath: string, text: string): Promise<Learning> {
+/**
+ * Add a learning the USER typed in the Memory tab.
+ *
+ * `taughtBy` is provenance, passed in by the caller (see `useAddLearning`) and
+ * stamped ONLY in multiplayer — a single-player file has one author by
+ * definition, so it stays free of identity keys and byte-identical in shape to
+ * what earlier versions wrote. No mission is stamped here: a learning typed in
+ * settings did not come from one.
+ */
+export async function add(
+  agentPath: string,
+  text: string,
+  taughtBy?: LearningAuthor,
+): Promise<Learning> {
   const items = await list(agentPath);
-  const learning: Learning = { id: newId(), text, created_at: now() };
+  const learning: Learning = {
+    id: newId(),
+    text,
+    created_at: now(),
+    ...(taughtBy ? { taught_by: taughtBy } : {}),
+  };
   await writeAgentJson(agentPath, NAME, s, [...items, learning]);
   return learning;
 }

--- a/app/src/hooks/queries/use-learnings.ts
+++ b/app/src/hooks/queries/use-learnings.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as learnings from "../../data/learnings";
+import type { LearningSourceRow } from "../../lib/learning-provenance";
+import { isMultiplayer } from "../../lib/org-roles";
 import { queryKeys } from "../../lib/query-keys";
+import { useCapabilities } from "../use-capabilities";
+import { useSession } from "../use-session";
 
 export function useLearnings(agentPath: string | undefined) {
   const q = useQuery({
@@ -8,21 +12,39 @@ export function useLearnings(agentPath: string | undefined) {
     queryFn: () => learnings.list(agentPath ?? ""),
     enabled: !!agentPath,
   });
-  // Adapt to legacy `{ index, text }[]` shape so existing UIs keep working.
-  const entries = (q.data ?? []).map((l, index) => ({
+  // Adapt to the legacy `{ index, text }[]` shape so existing UIs keep working,
+  // carrying the provenance fields through: the Memory rows show who taught a
+  // learning and which mission it came from, and dropping them here (as this
+  // adapter used to) makes that invisible no matter what the file says.
+  const entries: LearningSourceRow[] = (q.data ?? []).map((l, index) => ({
     index,
     text: l.text,
     id: l.id,
+    ...(l.taught_by ? { taughtBy: l.taught_by } : {}),
+    ...(l.mission_id ? { missionId: l.mission_id } : {}),
+    ...(l.mission_title ? { missionTitle: l.mission_title } : {}),
   }));
   return { data: { entries }, isLoading: q.isLoading };
 }
 
 export function useAddLearning(agentPath: string | undefined) {
   const qc = useQueryClient();
+  const { data: session } = useSession();
+  const { capabilities } = useCapabilities();
+  // WHO is adding this learning by hand. Multiplayer only: in single player the
+  // answer is always "the one user", so stamping it would add an identity key
+  // to every desktop learnings.json for no reader.
+  const taughtBy =
+    isMultiplayer(capabilities) && session
+      ? {
+          user_id: session.uid,
+          ...(session.displayName ? { name: session.displayName } : {}),
+        }
+      : undefined;
   return useMutation({
     mutationFn: (text: string) => {
       if (!agentPath) throw new Error("agentPath required");
-      return learnings.add(agentPath, text);
+      return learnings.add(agentPath, text, taughtBy);
     },
     onSuccess: () => {
       if (agentPath)

--- a/app/src/lib/learning-provenance.ts
+++ b/app/src/lib/learning-provenance.ts
@@ -1,0 +1,85 @@
+import type { UserProfile } from "../hooks/queries/use-user-profiles";
+
+/**
+ * Pure, DOM-free resolution of a learning's PROVENANCE — the person who taught
+ * it and the mission it came from — into the two display values the Memory row
+ * renders. Kept out of the component so the fallback ladder (which title wins,
+ * what happens with no roster) is unit-tested in isolation.
+ *
+ * Two fallbacks carry the whole design:
+ *  - PERSON: the live profile name (multiplayer roster) wins, then the name
+ *    STORED on the learning. Single player / desktop resolves no profiles at
+ *    all, so a learning taught in the cloud still reads "From Felipe" there.
+ *  - MISSION: the live title looked up by `mission_id` wins, so a renamed
+ *    mission reads correctly; the title stored at save time is the fallback for
+ *    a mission that was since deleted.
+ *
+ * A learning with neither resolves to `null` — the row renders no provenance
+ * line at all rather than an empty or "Unknown" one.
+ */
+
+/** The provenance fields a Memory row carries (from `useLearnings`). */
+export interface LearningProvenanceSource {
+  taughtBy?: { user_id: string; name?: string };
+  missionId?: string;
+  missionTitle?: string;
+}
+
+/**
+ * A Memory row exactly as `useLearnings` yields it: the learning plus its RAW
+ * provenance. The screen resolves the raw half into a `LearningProvenanceView`
+ * and hands the card only that — the row component never reads these fields.
+ */
+export interface LearningSourceRow extends LearningProvenanceSource {
+  index: number;
+  text: string;
+  id: string;
+}
+
+/** What the provenance line renders. */
+export interface LearningProvenanceView {
+  /** The person's display name, when one is known. */
+  name?: string;
+  /** The person's stable id, so their face wears the one tone that person
+   *  wears everywhere else (board stacks, chat sender line). */
+  personId?: string;
+  /** The person's photo, when the roster resolved one. */
+  photoUrl?: string;
+  /** The mission's title, live one preferred. */
+  mission?: string;
+}
+
+export function resolveLearningProvenance(
+  learning: LearningProvenanceSource,
+  profiles: ReadonlyMap<string, UserProfile>,
+  missionTitles: ReadonlyMap<string, string>,
+): LearningProvenanceView | null {
+  const profile = learning.taughtBy
+    ? profiles.get(learning.taughtBy.user_id)
+    : undefined;
+  const name = profile?.name || learning.taughtBy?.name || undefined;
+  const photoUrl = profile?.avatarUrl || undefined;
+  const mission = learning.missionId
+    ? (missionTitles.get(learning.missionId) ?? learning.missionTitle)
+    : learning.missionTitle;
+
+  if (!name && !mission) return null;
+  // The id rides along only WITH a name: it is the face's tone key, and a face
+  // is drawn only for a person we can name (an id slice is not a person).
+  return {
+    ...(name ? { name } : {}),
+    ...(name && learning.taughtBy
+      ? { personId: learning.taughtBy.user_id }
+      : {}),
+    ...(photoUrl ? { photoUrl } : {}),
+    ...(mission ? { mission } : {}),
+  };
+}
+
+/** The distinct `taught_by` ids across a set of rows — the argument for the
+ *  batched `useUserProfiles` lookup. */
+export function collectTaughtByIds(rows: LearningProvenanceSource[]): string[] {
+  const ids = new Set<string>();
+  for (const row of rows) if (row.taughtBy) ids.add(row.taughtBy.user_id);
+  return Array.from(ids);
+}

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -72,7 +72,10 @@
     "removeAria": "Remove learning",
     "confirmRemoveTitle": "Remove this learning?",
     "confirmRemoveDescription": "The agent will lose this note. You can add it back later.",
-    "confirmRemoveLabel": "Remove"
+    "confirmRemoveLabel": "Remove",
+    "provenanceFromMission": "From {{name}} · {{mission}}",
+    "provenanceFrom": "From {{name}}",
+    "provenanceMission": "From {{mission}}"
   },
   "subTabs": {
     "instructions": "Instructions",

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -72,7 +72,10 @@
     "removeAria": "Quitar aprendizaje",
     "confirmRemoveTitle": "¿Quitar este aprendizaje?",
     "confirmRemoveDescription": "El agente perderá esta nota. Puedes añadirla de nuevo más tarde.",
-    "confirmRemoveLabel": "Quitar"
+    "confirmRemoveLabel": "Quitar",
+    "provenanceFromMission": "De {{name}} · {{mission}}",
+    "provenanceFrom": "De {{name}}",
+    "provenanceMission": "De {{mission}}"
   },
   "subTabs": {
     "instructions": "Instrucciones",

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -72,7 +72,10 @@
     "removeAria": "Remover aprendizado",
     "confirmRemoveTitle": "Remover este aprendizado?",
     "confirmRemoveDescription": "O agente vai perder esta nota. Você pode adicionar de novo depois.",
-    "confirmRemoveLabel": "Remover"
+    "confirmRemoveLabel": "Remover",
+    "provenanceFromMission": "De {{name}} · {{mission}}",
+    "provenanceFrom": "De {{name}}",
+    "provenanceMission": "De {{mission}}"
   },
   "subTabs": {
     "instructions": "Instruções",

--- a/app/tests/learning-provenance.test.ts
+++ b/app/tests/learning-provenance.test.ts
@@ -1,0 +1,125 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { UserProfile } from "../src/hooks/queries/use-user-profiles.ts";
+import {
+  collectTaughtByIds,
+  type LearningProvenanceSource,
+  resolveLearningProvenance,
+} from "../src/lib/learning-provenance.ts";
+
+/**
+ * Learning provenance (HOU-946): every learning links to the person who taught
+ * it and the mission it came from. These pin the two fallback ladders that make
+ * that readable on EVERY deployment — including desktop, where there is no
+ * roster to resolve names or photos from.
+ */
+
+const profiles = (rows: UserProfile[]): Map<string, UserProfile> =>
+  new Map(rows.map((r) => [r.userId, r]));
+
+const NO_PROFILES = profiles([]);
+const NO_MISSIONS = new Map<string, string>();
+
+describe("resolveLearningProvenance", () => {
+  it("returns null when a learning carries no provenance at all", () => {
+    strictEqual(resolveLearningProvenance({}, NO_PROFILES, NO_MISSIONS), null);
+  });
+
+  it("prefers the live profile name and photo over the stored name", () => {
+    const view = resolveLearningProvenance(
+      { taughtBy: { user_id: "u1", name: "Old Name" } },
+      profiles([
+        { userId: "u1", name: "Felipe Ruiz", avatarUrl: "https://x/f.png" },
+      ]),
+      NO_MISSIONS,
+    );
+    deepStrictEqual(view, {
+      name: "Felipe Ruiz",
+      personId: "u1",
+      photoUrl: "https://x/f.png",
+    });
+  });
+
+  it("falls back to the STORED name when no roster resolves (desktop)", () => {
+    const view = resolveLearningProvenance(
+      { taughtBy: { user_id: "u1", name: "Felipe" } },
+      NO_PROFILES,
+      NO_MISSIONS,
+    );
+    // The id rides along as the face's tone key even with no roster.
+    deepStrictEqual(view, { name: "Felipe", personId: "u1" });
+  });
+
+  it("prefers the LIVE mission title so a rename reads correctly", () => {
+    const view = resolveLearningProvenance(
+      { missionId: "act-1", missionTitle: "Q3 pipeline" },
+      NO_PROFILES,
+      new Map([["act-1", "Q3 pipeline review"]]),
+    );
+    deepStrictEqual(view, { mission: "Q3 pipeline review" });
+  });
+
+  it("falls back to the stored title when the mission is gone", () => {
+    const view = resolveLearningProvenance(
+      { missionId: "act-gone", missionTitle: "Q3 pipeline" },
+      NO_PROFILES,
+      new Map([["act-1", "Something else"]]),
+    );
+    deepStrictEqual(view, { mission: "Q3 pipeline" });
+  });
+
+  it("carries both halves when both are known", () => {
+    const view = resolveLearningProvenance(
+      { taughtBy: { user_id: "u1", name: "Felipe" }, missionId: "act-1" },
+      NO_PROFILES,
+      new Map([["act-1", "Q3 pipeline"]]),
+    );
+    deepStrictEqual(view, {
+      name: "Felipe",
+      personId: "u1",
+      mission: "Q3 pipeline",
+    });
+  });
+
+  it("an id with no resolvable name and no mission renders nothing", () => {
+    // A stamped id whose owner left the org and whose name was never stored:
+    // an id slice is not a person, so the line is omitted entirely.
+    strictEqual(
+      resolveLearningProvenance(
+        { taughtBy: { user_id: "u-ghost" } },
+        NO_PROFILES,
+        NO_MISSIONS,
+      ),
+      null,
+    );
+  });
+
+  it("an unnameable id carries NO personId onto a mission-only line", () => {
+    // Same rule one level down: the mission keeps the line alive, but there is
+    // no person to draw, so nothing hands the face a tone key.
+    deepStrictEqual(
+      resolveLearningProvenance(
+        { taughtBy: { user_id: "u-ghost" }, missionId: "act-1" },
+        NO_PROFILES,
+        new Map([["act-1", "Q3 pipeline"]]),
+      ),
+      { mission: "Q3 pipeline" },
+    );
+  });
+});
+
+describe("collectTaughtByIds", () => {
+  it("dedupes and skips rows with no person", () => {
+    const rows: LearningProvenanceSource[] = [
+      { taughtBy: { user_id: "u1" } },
+      { taughtBy: { user_id: "u1", name: "Dup" } },
+      { missionId: "act-1" },
+      { taughtBy: { user_id: "u2" } },
+    ];
+    deepStrictEqual(collectTaughtByIds(rows), ["u1", "u2"]);
+  });
+
+  it("is empty for a set with no provenance", () => {
+    deepStrictEqual(collectTaughtByIds([{}, {}]), []);
+  });
+});

--- a/knowledge-base/architecture.md
+++ b/knowledge-base/architecture.md
@@ -358,6 +358,62 @@ the interview needs blocking `ask_user` cards. A routine's FIRED run pins
 **Autopilot** (`auto`) so scheduled/triggered work never waits on the user — see
 "Turn modes" above (unchanged).
 
+## Learnings (memory) + their provenance
+
+A **Learning** is a stable fact the agent carries across sessions, stored one
+JSON array per agent at `.houston/learnings/learnings.json` (schema:
+`ui/agent-schemas/src/learnings.schema.json`; wire type: `Learning` in
+`packages/protocol/src/domain/activity.ts`).
+
+**`save_learning` is the agent's write path** (HOU-946), built on exactly the
+`save_routine` pattern above and for the same two reasons — merge safety and a
+fact the model must not author. The runtime tool
+(`packages/runtime/src/session/tools/save-learning.ts`,
+`SAVE_LEARNING_TOOL_NAME`) takes ONLY `text` and POSTs
+`/sandbox/learnings/save` under the per-sandbox HMAC token
+(`packages/host/src/routes/learnings-sandbox.ts`), which read-modify-writes
+(`loadLearnings → append → saveLearnings`) under the per-doc lock
+(`withDocLock(\`${root}#learnings\`)`, routes/doc-lock.ts — the SAME key the
+Memory tab's whole-file PUT in `agent-data.ts` takes, so concurrent saves and UI
+edits serialize instead of dropping each other) and stamps the learning's
+**provenance**:
+
+- `taught_by` (`{user_id, name?}`) — decoded from the gateway-minted
+  `x-houston-acting-as` header, and ONLY when `deps.gatewayFronted`; with no
+  acting-as token there (a FIRED ROUTINE has no driving human) the routine
+  creator's sub from `x-houston-acting-user` is the author, the same two-rung
+  ladder `routes/integrations-sandbox.ts` walks. NOT the workspace owner: on a
+  managed pod that is the placeholder `local-owner`. Off the gateway the headers
+  are untrusted client input and there is one human anyway, so NO identity key
+  is written and a desktop `learnings.json` keeps the shape it has always had.
+- `mission_id` + `mission_title` — resolved from the turn's conversation id,
+  forwarded by the tool on `x-houston-conversation-id` from a per-turn
+  `AsyncLocalStorage` (`packages/runtime/src/session/conversation-context.ts`,
+  established beside the acting context in `exec-turn.ts`). The match uses the
+  SAME convention as per-mission attribution — `session_key === cid`, with
+  `activity-<id>` as the fallback. Stamped on EVERY deployment: a mission is not
+  an identity, and "from the Q3 pipeline mission" is the useful half of
+  provenance for a solo user. `mission_title` is denormalized so a renamed or
+  deleted mission still reads; renderers prefer the live title by `mission_id`.
+
+Everything is best-effort metadata: a failed mission lookup logs and saves the
+learning without it. The app's own Memory-tab add path stamps `taught_by` from
+the signed-in session, multiplayer only (`use-learnings.ts`). Provenance is
+ORG-LOCAL and never travels: `packages/domain/src/portable.ts` strips it on both
+pack and unpack (one `stripLearningProvenance` helper, both legs), like a
+routine's `created_by`.
+
+The provenance keys only reach disk if the agent's **seeded schema knows them** —
+the prompt tells the model to match the schema, and every family schema is
+`additionalProperties: false`. Agents created before HOU-946 are brought forward
+by the boot re-seed (`packages/host/src/migrate/agent-schemas.ts`, wired in
+`local/host.ts` `start()` beside the other migrations; content-compared, so a
+steady-state boot writes nothing). The Memory row renders the pair as a muted
+"From {name} · {mission}" line with the shared `PersonFace`
+(`app/src/components/tabs/learning-provenance.tsx`; fallback ladders in
+`app/src/lib/learning-provenance.ts`), and nothing at all when a learning has no
+provenance.
+
 ## Current gap to vision
 
 | Goal | Status |

--- a/knowledge-base/files-first.md
+++ b/knowledge-base/files-first.md
@@ -53,7 +53,9 @@ If app-specific → `.houston/`.
     config/
       config.json + .schema.json
     learnings/
-      learnings.json + .schema.json   ({id, text, created_at})
+      learnings.json + .schema.json   ({id, text, created_at}
+                                       + optional provenance: taught_by
+                                       {user_id,name?}, mission_id, mission_title)
       # Legacy `.houston/memory/learnings.md` auto-migrated on startup
       # (bullet list → JSON). See `houston_agent_files::migrate_agent_data`.
     prompts/
@@ -134,6 +136,30 @@ vanish on the next read).
 
 ## Schemas
 Authoritative. Live in `ui/agent-schemas/src/*.schema.json`. `packages/domain` seeds them into each agent's `.houston/<type>/<type>.schema.json` on create. Prompts instruct the model to read the schema before writing a data file.
+
+Schemas are seeded on agent creation AND re-seeded on every host boot
+(`packages/host/src/migrate/agent-schemas.ts`, content-compared so a
+steady-state boot writes nothing) — an agent created before a schema gained a
+field would otherwise keep a stale `additionalProperties: false` copy and strip
+what the host stamps.
+
+## Learnings provenance (HOU-946) — on-disk shape
+
+A learning record in `.houston/learnings/learnings.json` may carry three
+optional, additive provenance keys (no migration; older entries read unchanged):
+
+```json
+{
+  "id": "…", "text": "…", "created_at": "…",
+  "taught_by": { "user_id": "…", "name": "Felipe" },
+  "mission_id": "act-1",
+  "mission_title": "Q3 pipeline"
+}
+```
+
+All three are **server-stamped, never agent-written**. The mechanism (write
+route, stamping rules, portability, UI) is documented once in
+`knowledge-base/architecture.md` → "Learnings (memory) + their provenance".
 
 ## Learnings prompt injection
 `engine/houston-engine-core/src/agents/prompt.rs::build_agent_context`

--- a/packages/domain/src/layout.ts
+++ b/packages/domain/src/layout.ts
@@ -3,7 +3,7 @@ import configSchema from "@houston-ai/agent-schemas/config.schema.json";
 import learningsSchema from "@houston-ai/agent-schemas/learnings.schema.json";
 import routineRunsSchema from "@houston-ai/agent-schemas/routine_runs.schema.json";
 import routinesSchema from "@houston-ai/agent-schemas/routines.schema.json";
-import { saveJson, type TextStore } from "./store";
+import { jsonDoc, type TextStore } from "./store";
 
 /**
  * The `.houston/` layout inside an agent's workspace — ONE convention for
@@ -56,15 +56,25 @@ const SCHEMAS: Record<HoustonFamily, unknown> = {
 };
 
 /**
+ * The EXACT document `seedSchemas` writes for a family. Exported so a re-seed
+ * (the host's boot migration for agents created before a schema changed) can
+ * compare byte-for-byte and skip the write when the file is already current.
+ */
+export function schemaDoc(family: HoustonFamily): string {
+  return jsonDoc(SCHEMAS[family]);
+}
+
+/**
  * Seed every family's `.schema.json` (idempotent overwrite — the schema ships
  * with the app and is not user data). Run on agent creation so agents and
- * external tools can validate what they write.
+ * external tools can validate what they write. Existing agents are brought
+ * forward on boot by the host's schema re-seed migration.
  */
 export async function seedSchemas(
   store: TextStore,
   root: string,
 ): Promise<void> {
   for (const family of FAMILIES) {
-    await saveJson(store, schemaKey(root, family), SCHEMAS[family]);
+    await store.writeText(schemaKey(root, family), schemaDoc(family));
   }
 }

--- a/packages/domain/src/portable.test.ts
+++ b/packages/domain/src/portable.test.ts
@@ -174,6 +174,62 @@ test("malformed routine/learning entries are dropped on unpack", () => {
   expect(pkg.learnings as Learning[]).toEqual([]);
 });
 
+test("a shared learning carries its text, never its provenance", () => {
+  const c = content();
+  const shared: PortableContent = {
+    ...c,
+    learnings: [
+      {
+        id: "l1",
+        text: "Exclude churned accounts from pipeline math.",
+        created_at: NOW,
+        taught_by: { user_id: "u-felipe", name: "Felipe" },
+        mission_id: "act-1",
+        mission_title: "Q3 pipeline",
+      },
+    ],
+  };
+  const pkg = unpackAgent(packAgent(shared, meta, NOW));
+  // The learning itself travels; the exporter's person + mission do not.
+  expect(pkg.learnings).toEqual([
+    {
+      id: "l1",
+      text: "Exclude churned accounts from pipeline math.",
+      created_at: NOW,
+    },
+  ]);
+});
+
+test("a pack that DOES carry provenance still imports, stripped", () => {
+  const { zipSync, strToU8 } = require("fflate");
+  const bytes = zipSync({
+    "manifest.json": strToU8(
+      JSON.stringify({
+        agentName: "X",
+        houstonVersion: "1",
+        createdAt: NOW,
+        formatVersion: 1,
+      }),
+    ),
+    "learnings.json": strToU8(
+      JSON.stringify([
+        {
+          id: "l1",
+          text: "keep me",
+          created_at: NOW,
+          taught_by: { user_id: "u-stranger", name: "Stranger" },
+          mission_id: "act-9",
+          mission_title: "Someone else's mission",
+        },
+      ]),
+    ),
+  });
+  const pkg = unpackAgent(bytes);
+  expect(pkg.learnings as Learning[]).toEqual([
+    { id: "l1", text: "keep me", created_at: NOW },
+  ]);
+});
+
 test("filterPackage keeps only the selected parts", () => {
   const pkg = unpackAgent(
     packAgent(content(), { agentName: "Sales", houstonVersion: "0.5.0" }, NOW),

--- a/packages/domain/src/portable.ts
+++ b/packages/domain/src/portable.ts
@@ -39,6 +39,22 @@ const ROUTINES = "routines.json";
 const LEARNINGS = "learnings.json";
 const skillPath = (slug: string) => `skills/${slug}/SKILL.md`;
 
+/**
+ * A learning without its provenance. Provenance is ORG-LOCAL: `taught_by` names
+ * a person in the exporter's workspace and the mission it came from is a
+ * conversation the importer never had — neither means anything, nor is ours to
+ * publish, on the other side. Same rule routines follow for `created_by` /
+ * `setup_activity_id`; the learning itself travels. Applied on BOTH legs, so a
+ * pack hand-built or produced by another build can never install a person from
+ * the exporter's org or a mission id that resolves to something unrelated here.
+ */
+const stripLearningProvenance = ({
+  taught_by: _person,
+  mission_id: _mission,
+  mission_title: _missionTitle,
+  ...learning
+}: Learning): Learning => learning;
+
 /** Build the `.houstonagent` bytes. Caller supplies content already filtered by selection. */
 export function packAgent(
   content: PortableContent,
@@ -76,8 +92,10 @@ export function packAgent(
     );
     files[ROUTINES] = strToU8(JSON.stringify(shareable, null, 2));
   }
-  if (content.learnings.length)
-    files[LEARNINGS] = strToU8(JSON.stringify(content.learnings, null, 2));
+  if (content.learnings.length) {
+    const shareable = content.learnings.map(stripLearningProvenance);
+    files[LEARNINGS] = strToU8(JSON.stringify(shareable, null, 2));
+  }
   return zipSync(files);
 }
 
@@ -135,9 +153,9 @@ export function unpackAgent(bytes: Uint8Array): PortablePackage {
       parseArray<Routine>(routinesRaw),
       ROUTINES,
     ).items.map(({ setup_activity_id: _local, created_by: _owner, ...r }) => r),
-    learnings: parseArray<Learning>(learningsRaw).filter(
-      (l) => isRecord(l) && typeof l.id === "string",
-    ),
+    learnings: parseArray<Learning>(learningsRaw)
+      .filter((l) => isRecord(l) && typeof l.id === "string")
+      .map(stripLearningProvenance),
   };
 }
 

--- a/packages/fake-host/src/state-store.ts
+++ b/packages/fake-host/src/state-store.ts
@@ -12,7 +12,12 @@
  * typecheck here instead of silently drifting the mock.
  */
 
-import type { Activity, Capabilities, SidebarLayout } from "@houston/protocol";
+import type {
+  Activity,
+  Capabilities,
+  Learning,
+  SidebarLayout,
+} from "@houston/protocol";
 import type {
   ChatMessage,
   IntegrationConnection,
@@ -197,6 +202,7 @@ export interface CpAgent {
 
 export const ACTIVITY_PATH = ".houston/activity/activity.json";
 export const ROUTINES_PATH = ".houston/routines/routines.json";
+export const LEARNINGS_PATH = ".houston/learnings/learnings.json";
 export const SEED_USAGE: TokenUsage = {
   context_tokens: 1200,
   output_tokens: 80,
@@ -253,6 +259,32 @@ const SEED_ACTIVITIES: Activity[] = [
     updated_at: ISO,
     created_by: "u-self",
     contributors: SEED_LAUNCH_CONTRIBUTORS,
+  },
+];
+
+/**
+ * Seeded memory for the Memory (learnings) tab. Two shapes on purpose:
+ *  - one WITH provenance (HOU-946) — the person who taught it plus the mission
+ *    it came from (`act-1`, so the live title lookup has something to resolve),
+ *  - one with none, proving the provenance line is omitted rather than faked.
+ *
+ * The person's name rides ON the learning, exactly as the host stamps it, so it
+ * reads without a `/v1/org/profiles` round trip — identity is off in the default
+ * e2e project, and desktop / single-player has no roster either.
+ */
+const SEED_LEARNINGS: Learning[] = [
+  {
+    id: "learn-1",
+    text: "Exclude churned accounts from pipeline math.",
+    created_at: ISO,
+    taught_by: { user_id: "u-self", name: "Ada Lovelace" },
+    mission_id: "act-1",
+    mission_title: "Plan a trip to Tokyo",
+  },
+  {
+    id: "learn-2",
+    text: "Prefers metric units in every report.",
+    created_at: ISO,
   },
 ];
 
@@ -339,6 +371,10 @@ function freshState(): HostState {
   files.set(
     fileKey(SEED_AGENT_ID, ACTIVITY_PATH),
     JSON.stringify(SEED_ACTIVITIES),
+  );
+  files.set(
+    fileKey(SEED_AGENT_ID, LEARNINGS_PATH),
+    JSON.stringify(SEED_LEARNINGS),
   );
   // Two seeded workspace files so the Files tab has rows on first paint.
   const workspace = new Map<

--- a/packages/host/src/houston-prompt.ts
+++ b/packages/host/src/houston-prompt.ts
@@ -154,7 +154,9 @@ Save a learning only when:
 
 Do not save trivial observations, temporary task facts, private credentials, or anything derivable from the workspace.
 
-When saving, read \`.houston/learnings/learnings.schema.json\`, then update \`.houston/learnings/learnings.json\` to match it exactly.`;
+Save with the \`save_learning\` tool. Pass the learning's text and nothing else. It is the only safe way to save: it merges with the user's existing memory instead of overwriting it, and Houston records on its own who taught the learning and which mission it came from, so the user can always see where a memory came from. Save one learning per call, written in the user's own terms. Never write the person's name or the mission into the text yourself, Houston attaches those.
+
+Reading \`.houston/learnings/learnings.json\` to check what is already remembered is fine. Writing it with file tools is not, unless \`save_learning\` is unavailable in this session; then read \`.houston/learnings/learnings.schema.json\` first and match it exactly.`;
 
 const INTEGRATIONS = `## How-To Guidance: Connected Apps (Integrations)
 

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -26,6 +26,7 @@ import { RemoteIntegrationProvider } from "../integrations/remote";
 import { ProcessLauncher, type RuntimeSpawner } from "../launcher/process";
 import { RuntimeProcessSpawner } from "../launcher/runtime-spawner";
 import { migrateAgentLayouts } from "../migrate/agent-layout";
+import { reseedAgentSchemas } from "../migrate/agent-schemas";
 import { migrateChatHistory } from "../migrate/chat-history";
 import { LocalPaths } from "../paths";
 import type { ChannelCtx } from "../ports";
@@ -575,6 +576,22 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
         // loudly so the failure shows in the app logs / bug report tail.
         console.error(
           "[local-host] agent-layout migration failed (continuing):",
+          err,
+        );
+      }
+      // Bring every EXISTING agent's seeded `.houston/**.schema.json` up to the
+      // schemas this build ships (they are seeded once, at agent creation, and
+      // are app data — a stale `additionalProperties: false` copy actively tells
+      // the model to strip fields the host stamps). Content-compared, so a
+      // steady-state boot writes nothing; runs BEFORE the watcher like the
+      // migrations above.
+      try {
+        reseedAgentSchemas({ workspacesRoot: opts.workspacesRoot });
+      } catch (err) {
+        // No UI thread to toast on at boot; the supervisor must stay up. Log
+        // loudly so the failure shows in the app logs / bug report tail.
+        console.error(
+          "[local-host] agent schema re-seed failed (continuing):",
           err,
         );
       }

--- a/packages/host/src/migrate/agent-schemas.test.ts
+++ b/packages/host/src/migrate/agent-schemas.test.ts
@@ -1,0 +1,106 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { FAMILIES, schemaDoc } from "@houston/domain";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { reseedAgentSchemas } from "./agent-schemas";
+
+/**
+ * The boot re-seed that brings EXISTING agents' schema files up to the build's
+ * schemas. What matters: a stale copy is replaced (an agent created before
+ * HOU-946 has a learnings schema with no provenance keys and
+ * `additionalProperties: false`, which tells the model to strip them), an
+ * already-current tree costs zero writes, and one bad agent never stops the rest.
+ */
+
+let root: string;
+let agent: string;
+
+const schemaPath = (agentRoot: string, family: string) =>
+  join(agentRoot, ".houston", family, `${family}.schema.json`);
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "agent-schemas-"));
+  agent = join(root, "Personal", "Alfred");
+  mkdirSync(join(agent, ".houston"), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("reseedAgentSchemas", () => {
+  it("replaces a stale schema with the one this build ships", () => {
+    const stale = JSON.stringify({ type: "array", items: {} });
+    mkdirSync(join(agent, ".houston", "learnings"), { recursive: true });
+    writeFileSync(schemaPath(agent, "learnings"), stale, "utf8");
+
+    const result = reseedAgentSchemas({ workspacesRoot: root, log: () => {} });
+
+    expect(result.updatedAgents).toBe(1);
+    // Every family is (re-)seeded, so an agent that never had one gets it too.
+    expect(result.updatedFiles).toBe(FAMILIES.length);
+    const written = readFileSync(schemaPath(agent, "learnings"), "utf8");
+    expect(written).toBe(schemaDoc("learnings"));
+    // The whole point: the provenance keys are now describable by the model.
+    expect(written).toContain("taught_by");
+    expect(written).toContain("mission_id");
+  });
+
+  it("is a no-op the second time (content-compared, zero writes)", () => {
+    reseedAgentSchemas({ workspacesRoot: root, log: () => {} });
+
+    const again = reseedAgentSchemas({ workspacesRoot: root, log: () => {} });
+
+    expect(again).toEqual({ updatedAgents: 0, updatedFiles: 0 });
+  });
+
+  it("skips directories that are not agents", () => {
+    // A workspace folder with no `.houston` is not an agent tree — never create
+    // one for it.
+    mkdirSync(join(root, "Personal", "not-an-agent"), { recursive: true });
+
+    reseedAgentSchemas({ workspacesRoot: root, log: () => {} });
+
+    expect(existsSync(join(root, "Personal", "not-an-agent", ".houston"))).toBe(
+      false,
+    );
+  });
+
+  it("logs and continues when one agent cannot be written", () => {
+    // A family path occupied by a FILE where the layout wants a directory: the
+    // mkdir throws, and boot must survive it.
+    const broken = join(root, "Personal", "Broken");
+    mkdirSync(join(broken, ".houston"), { recursive: true });
+    writeFileSync(join(broken, ".houston", FAMILIES[0] ?? ""), "junk", "utf8");
+    const lines: string[] = [];
+
+    const result = reseedAgentSchemas({
+      workspacesRoot: root,
+      log: (l) => lines.push(l),
+    });
+
+    // The healthy agent still got its schemas.
+    expect(result.updatedAgents).toBe(1);
+    expect(readFileSync(schemaPath(agent, "learnings"), "utf8")).toBe(
+      schemaDoc("learnings"),
+    );
+    expect(lines.some((l) => l.includes("re-seed failed"))).toBe(true);
+  });
+
+  it("returns an empty result for a workspaces root that does not exist", () => {
+    const result = reseedAgentSchemas({
+      workspacesRoot: join(root, "nope"),
+      log: () => {},
+    });
+
+    expect(result).toEqual({ updatedAgents: 0, updatedFiles: 0 });
+  });
+});

--- a/packages/host/src/migrate/agent-schemas.ts
+++ b/packages/host/src/migrate/agent-schemas.ts
@@ -1,0 +1,103 @@
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { FAMILIES, schemaDoc } from "@houston/domain";
+import { agentRoots } from "./chat-history";
+
+/**
+ * Re-seed every existing agent's `.houston/<family>/<family>.schema.json` with
+ * the schema THIS build ships.
+ *
+ * The schemas are seeded once, at agent creation (`seedSchemas`), and are app
+ * data — not user data. So an agent created before a schema gained a field kept
+ * a stale copy forever, and stale copies are not inert: the product prompt tells
+ * the model to read the schema and match it exactly, and every family schema is
+ * `additionalProperties: false`. An agent reading a pre-HOU-946 learnings schema
+ * (no `taught_by` / `mission_id` / `mission_title`) would conclude the
+ * host-stamped provenance is invalid and strip it back out.
+ *
+ * Idempotent and cheap: the file is written only when its content differs, so a
+ * steady-state boot is one small read per family per agent and zero writes (and
+ * zero watcher churn — this also runs before the watcher starts).
+ */
+
+export interface ReseedSchemasResult {
+  /** Agents where at least one schema file was rewritten this run. */
+  updatedAgents: number;
+  /** Individual schema files rewritten this run. */
+  updatedFiles: number;
+}
+
+/** Write via tmp + rename so a crash mid-write never leaves a torn schema. */
+function writeAtomic(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = join(dirname(path), `.${Date.now()}-${Math.random()}.tmp`);
+  writeFileSync(tmp, content, "utf8");
+  renameSync(tmp, path);
+}
+
+/** Re-seed one agent, returning how many schema files it rewrote. Exported for
+ *  tests; production goes through {@link reseedAgentSchemas}. */
+export function reseedAgentSchema(
+  agentRoot: string,
+  log: (line: string) => void,
+): number {
+  const rewritten: string[] = [];
+  for (const family of FAMILIES) {
+    const path = join(agentRoot, ".houston", family, `${family}.schema.json`);
+    const want = schemaDoc(family);
+    let current: string | null = null;
+    try {
+      current = readFileSync(path, "utf8");
+    } catch {
+      current = null; // never seeded (or unreadable) — write it
+    }
+    if (current === want) continue;
+    writeAtomic(path, want);
+    rewritten.push(family);
+  }
+  // One line per AGENT, not per file: a first boot after a schema change would
+  // otherwise print five lines per agent for a no-op-shaped event.
+  if (rewritten.length) {
+    log(`[agent-schemas] ${agentRoot}: re-seeded ${rewritten.join(", ")}`);
+  }
+  return rewritten.length;
+}
+
+/**
+ * Re-seed every agent under the workspaces tree. Per-agent failures are logged
+ * and skipped: a schema is a convenience for the model, and one unwritable agent
+ * directory must never stop the host from booting (same posture as the
+ * agent-layout migration this runs beside).
+ */
+export function reseedAgentSchemas(opts: {
+  workspacesRoot: string;
+  log?: (line: string) => void;
+}): ReseedSchemasResult {
+  const log = opts.log ?? ((l: string) => console.log(l));
+  const result: ReseedSchemasResult = { updatedAgents: 0, updatedFiles: 0 };
+  for (const agentRoot of agentRoots(opts.workspacesRoot)) {
+    // Only agents that already have a `.houston/` DIRECTORY — never eagerly
+    // create one for a random folder in the tree.
+    try {
+      if (!statSync(join(agentRoot, ".houston")).isDirectory()) continue;
+    } catch {
+      continue; // no .houston at all
+    }
+    try {
+      const updated = reseedAgentSchema(agentRoot, log);
+      if (updated > 0) {
+        result.updatedAgents++;
+        result.updatedFiles += updated;
+      }
+    } catch (err) {
+      log(`[agent-schemas] ${agentRoot}: re-seed failed (skipping): ${err}`);
+    }
+  }
+  return result;
+}

--- a/packages/host/src/routes/agent-data.ts
+++ b/packages/host/src/routes/agent-data.ts
@@ -12,6 +12,7 @@ import type { WorkspacePaths } from "../paths";
 import type { Vfs } from "../vfs";
 import { handleActivitiesData } from "./agent-data-activities";
 import { handleRoutinesData } from "./agent-data-routines";
+import { withDocLock } from "./doc-lock";
 import { json, readJson } from "./http";
 
 // The cloud-layout root, kept as a convenience for cloud tests + callers that
@@ -144,11 +145,18 @@ export async function handleAgentData(
     }
     if (method === "PUT") {
       const body = await readJson(req);
-      if (!Array.isArray(body.items)) {
+      const items = body.items;
+      if (!Array.isArray(items)) {
         json(res, 400, { error: "missing 'items' array" });
         return true;
       }
-      await saveLearnings(vfs, root, body.items);
+      // Whole-file replace, under the SAME per-doc lock the runtime's
+      // `save_learning` route takes (routes/learnings-sandbox.ts) — otherwise
+      // this write can land in the middle of that route's load→append→save and
+      // silently drop the learning the agent just recorded.
+      await withDocLock(`${root}#learnings`, () =>
+        saveLearnings(vfs, root, items),
+      );
       fireChange();
       json(res, 200, { ok: true });
       return true;

--- a/packages/host/src/routes/learnings-sandbox.test.ts
+++ b/packages/host/src/routes/learnings-sandbox.test.ts
@@ -1,0 +1,288 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { docKey, saveActivities, saveLearnings } from "@houston/domain";
+import type { Activity, HoustonEvent, Learning } from "@houston/protocol";
+import { beforeEach, expect, test } from "vitest";
+import type { Agent, Workspace } from "../domain/types";
+import { LocalPaths } from "../paths";
+import type { CredentialVault } from "../ports";
+import { MemoryWorkspaceStore } from "../store/memory";
+import { MemoryVfs } from "../vfs";
+import {
+  CONVERSATION_ID_HEADER,
+  handleSandboxLearnings,
+} from "./learnings-sandbox";
+
+/**
+ * The runtime-facing memory save route: merge-safe, and the ONLY writer that
+ * records a learning's provenance.
+ *
+ * The invariants under test:
+ *  - Gateway-fronted: the acting-as header names the person (`taught_by`), and
+ *    with no acting-as token (a fired routine) the creator's `acting-user` sub
+ *    does — the same ladder the integrations sandbox route walks.
+ *  - Off the gateway: NO identity key at all, even with a header present — an
+ *    inbound acting header is untrusted client input on the desktop, and a
+ *    single-player learnings.json must stay free of identity keys.
+ *  - The mission is matched by the SAME convention per-mission attribution
+ *    uses: `session_key === cid`, with `activity-<id>` as the fallback. It is
+ *    stamped on every deployment (a mission is not an identity).
+ *  - The write MERGES: existing learnings survive, even when two saves run
+ *    concurrently (the load→append→save runs under the per-doc lock).
+ */
+
+const paths = new LocalPaths();
+const OWNER = "alice";
+
+let store: MemoryWorkspaceStore;
+let vfs: MemoryVfs;
+let ws: Workspace;
+let agent: Agent;
+let root: string;
+let events: HoustonEvent[];
+
+const vault: CredentialVault = {
+  sandboxToken: () => "sb",
+  validateSandboxToken: (token) =>
+    token === "sb-good" ? { workspaceId: ws.id, agentId: agent.id } : null,
+};
+
+/** `acting-v1.<payloadB64Url>.<sig>` — what the gateway stamps on a proxied request. */
+function actingHeader(sub: string, name?: string): string {
+  const payload = Buffer.from(JSON.stringify({ sub, name })).toString(
+    "base64url",
+  );
+  return `acting-v1.${payload}.sig`;
+}
+
+/** A fake IncomingMessage: an async byte stream carrying the JSON body. */
+function fakeReq(
+  body: unknown,
+  headers: Record<string, string>,
+): IncomingMessage {
+  const buf = Buffer.from(JSON.stringify(body));
+  return {
+    headers,
+    async *[Symbol.asyncIterator]() {
+      if (buf.byteLength) yield buf;
+    },
+  } as unknown as IncomingMessage;
+}
+
+/** A fake ServerResponse capturing the status + JSON body `json()` writes. */
+function fakeRes() {
+  const captured: { status: number; body: unknown } = { status: 0, body: null };
+  const res = {
+    writeHead(status: number) {
+      captured.status = status;
+      return res;
+    },
+    end(chunk?: Buffer) {
+      captured.body = chunk ? JSON.parse(chunk.toString("utf8")) : null;
+    },
+  } as unknown as ServerResponse;
+  return { res, captured };
+}
+
+async function save(
+  text: string,
+  opts: {
+    gatewayFronted?: boolean;
+    acting?: string;
+    /** The routine creator's sub, as a fired routine's turn forwards it. */
+    actingUser?: string;
+    conversationId?: string;
+    token?: string;
+  } = {},
+) {
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${opts.token ?? "sb-good"}`,
+  };
+  if (opts.acting) headers["x-houston-acting-as"] = opts.acting;
+  if (opts.actingUser) headers["x-houston-acting-user"] = opts.actingUser;
+  if (opts.conversationId)
+    headers[CONVERSATION_ID_HEADER] = opts.conversationId;
+  const { res, captured } = fakeRes();
+  const handled = await handleSandboxLearnings(
+    {
+      vault,
+      store,
+      vfs,
+      paths,
+      events: {
+        emit: (_userId: string, event: HoustonEvent) => events.push(event),
+      } as never,
+      ...(opts.gatewayFronted ? { gatewayFronted: true } : {}),
+    },
+    "POST",
+    "/sandbox/learnings/save",
+    new URL("http://host/sandbox/learnings/save"),
+    fakeReq({ text }, headers),
+    res,
+  );
+  return { handled, ...captured };
+}
+
+/** The learnings file as it is on disk after a save. */
+async function onDisk(): Promise<Learning[]> {
+  return JSON.parse(
+    (await vfs.readText(docKey(root, "learnings"))) ?? "[]",
+  ) as Learning[];
+}
+
+const MISSION: Activity = {
+  id: "act-1",
+  title: "Q3 pipeline",
+  description: "",
+  status: "running",
+  session_key: "conv-42",
+};
+
+beforeEach(async () => {
+  store = new MemoryWorkspaceStore({ defaultRuntime: "local" });
+  vfs = new MemoryVfs();
+  events = [];
+  ws = await store.getOrCreatePersonalWorkspace(OWNER);
+  agent = await store.createAgent({ workspaceId: ws.id, name: "Helper" });
+  root = paths.agentRoot(ws, agent);
+  await saveActivities(vfs, root, [MISSION]);
+});
+
+test("a bad sandbox token is rejected before anything is written", async () => {
+  const r = await save("nope", { token: "sb-bad" });
+  expect(r.handled).toBe(true);
+  expect(r.status).toBe(401);
+  expect(await onDisk()).toEqual([]);
+});
+
+test("an empty text is rejected", async () => {
+  const r = await save("   ");
+  expect(r.status).toBe(400);
+  expect(await onDisk()).toEqual([]);
+});
+
+test("gateway-fronted: stamps the person AND the mission", async () => {
+  const r = await save("Exclude churned accounts from pipeline math", {
+    gatewayFronted: true,
+    acting: actingHeader("u-felipe", "Felipe"),
+    conversationId: "conv-42",
+  });
+  expect(r.status).toBe(201);
+
+  const [learning, ...rest] = await onDisk();
+  expect(rest).toEqual([]);
+  expect(learning?.text).toBe("Exclude churned accounts from pipeline math");
+  expect(learning?.taught_by).toEqual({ user_id: "u-felipe", name: "Felipe" });
+  expect(learning?.mission_id).toBe("act-1");
+  expect(learning?.mission_title).toBe("Q3 pipeline");
+  expect(events).toEqual([{ type: "LearningsChanged", agentPath: agent.id }]);
+});
+
+test("gateway-fronted fired routine: the creator's acting-user sub is the author", async () => {
+  // A FIRED ROUTINE has no driving human, so there is no acting-as token — the
+  // runtime forwards the routine creator's sub instead. Without this rung a
+  // routine-taught learning would be anonymous in hosted Teams.
+  const r = await save("Renewal emails go out on Mondays", {
+    gatewayFronted: true,
+    actingUser: "sub-alice",
+    conversationId: "conv-42",
+  });
+  expect(r.status).toBe(201);
+  expect((await onDisk())[0]?.taught_by).toEqual({ user_id: "sub-alice" });
+});
+
+test("gateway-fronted with NO identity at all stamps no person", async () => {
+  const r = await save("nobody taught this", { gatewayFronted: true });
+  expect(r.status).toBe(201);
+  expect((await onDisk())[0]).not.toHaveProperty("taught_by");
+});
+
+test("off the gateway: an acting-user header is ignored too", async () => {
+  await save("desktop", { actingUser: "sub-attacker" });
+  expect((await onDisk())[0]).not.toHaveProperty("taught_by");
+});
+
+test("off the gateway: no identity key even when the header is present", async () => {
+  const r = await save("Invoices go out on the 1st", {
+    acting: actingHeader("u-attacker", "Mallory"),
+    conversationId: "conv-42",
+  });
+  expect(r.status).toBe(201);
+
+  const [learning] = await onDisk();
+  expect(learning).not.toHaveProperty("taught_by");
+  // The mission IS stamped off the gateway: it is not an identity, and it is
+  // the useful half of provenance for a single-player user.
+  expect(learning?.mission_id).toBe("act-1");
+  expect(learning?.mission_title).toBe("Q3 pipeline");
+});
+
+test("the mission matches by session_key", async () => {
+  await save("a", { conversationId: "conv-42" });
+  expect((await onDisk())[0]?.mission_id).toBe("act-1");
+});
+
+test("the mission matches by the activity-<id> fallback", async () => {
+  await saveActivities(vfs, root, [
+    { ...MISSION, id: "act-9", title: "Renewals", session_key: undefined },
+  ]);
+  await save("a", { conversationId: "activity-act-9" });
+  const [learning] = await onDisk();
+  expect(learning?.mission_id).toBe("act-9");
+  expect(learning?.mission_title).toBe("Renewals");
+});
+
+test("no conversation id and no match stamp no mission keys", async () => {
+  await save("no cid");
+  await save("unknown cid", { conversationId: "conv-nope" });
+  for (const learning of await onDisk()) {
+    expect(learning).not.toHaveProperty("mission_id");
+    expect(learning).not.toHaveProperty("mission_title");
+  }
+});
+
+test("the save merges: existing learnings survive", async () => {
+  await saveLearnings(vfs, root, [
+    { id: "old-1", text: "first", created_at: "2020-01-01T00:00:00.000Z" },
+  ]);
+  await save("second");
+  await save("third");
+
+  const items = await onDisk();
+  expect(items.map((l) => l.text)).toEqual(["first", "second", "third"]);
+  // The pre-existing entry is untouched, keys and all.
+  expect(items[0]).toEqual({
+    id: "old-1",
+    text: "first",
+    created_at: "2020-01-01T00:00:00.000Z",
+  });
+});
+
+test("two CONCURRENT saves both survive (the per-doc lock)", async () => {
+  await saveLearnings(vfs, root, [
+    { id: "old-1", text: "first", created_at: "2020-01-01T00:00:00.000Z" },
+  ]);
+  // Two conversations on the same pod saving at once. Without the lock both
+  // load the same base list and the second write drops the first's entry.
+  const [a, b] = await Promise.all([save("from chat A"), save("from chat B")]);
+  expect([a.status, b.status]).toEqual([201, 201]);
+
+  const items = await onDisk();
+  expect(items.map((l) => l.text).sort()).toEqual([
+    "first",
+    "from chat A",
+    "from chat B",
+  ]);
+});
+
+test("a non-matching path or method is not handled", async () => {
+  const { res } = fakeRes();
+  const handled = await handleSandboxLearnings(
+    { vault, store, vfs, paths },
+    "GET",
+    "/sandbox/learnings/save",
+    new URL("http://host/sandbox/learnings/save"),
+    fakeReq({}, {}),
+    res,
+  );
+  expect(handled).toBe(false);
+});

--- a/packages/host/src/routes/learnings-sandbox.ts
+++ b/packages/host/src/routes/learnings-sandbox.ts
@@ -1,0 +1,199 @@
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  loadActivities,
+  loadLearnings,
+  saveLearnings,
+  type TextStore,
+} from "@houston/domain";
+import type { HoustonEvent, Learning } from "@houston/protocol";
+import { ACTING_AS_HEADER, actingAuthorFromHeader } from "../auth/acting";
+import type { EventHub } from "../events/hub";
+import type { WorkspacePaths } from "../paths";
+import type { CredentialVault, WorkspaceStore } from "../ports";
+import type { Vfs } from "../vfs";
+import { DEFAULT_PATHS } from "./agent-authz";
+import { withDocLock } from "./doc-lock";
+import { bearer, header, json, readJson } from "./http";
+
+/** The header the runtime's `save_learning` tool carries the turn's conversation
+ *  id on, so the mission a learning came from can be resolved. Provenance only —
+ *  never authorization (the sandbox token is what authenticates the call). */
+export const CONVERSATION_ID_HEADER = "x-houston-conversation-id";
+
+/** The routine creator's Supabase `sub`, forwarded by the runtime when the turn
+ *  is a FIRED ROUTINE (no live human, so no acting-as token). Same header the
+ *  integrations sandbox route reads for the routine auth mode. */
+const ACTING_USER_HEADER = "x-houston-acting-user";
+
+/**
+ * The RUNTIME-facing memory write route (`POST /sandbox/learnings/save`, authed
+ * by the per-sandbox HMAC token). The agent's `save_learning` tool calls THIS
+ * instead of editing `.houston/learnings/learnings.json` with file tools.
+ *
+ * WHY it exists (two reasons, mirroring routines-sandbox.ts):
+ *  1. MERGE SAFETY. A wholesale file write drops every entry the model did not
+ *     happen to read back. This route read-modify-writes (loadLearnings →
+ *     append → saveLearnings), so a save never clobbers existing memory.
+ *  2. PROVENANCE. Every learning should say who taught it and which mission it
+ *     came from — facts the agent cannot know and must not be trusted to write.
+ *     They are derived HERE: the person from the gateway-minted acting-as
+ *     header, the mission from the turn's conversation id.
+ *
+ * Stamping semantics:
+ *  - `taught_by` ONLY when `deps.gatewayFronted`. Off the gateway (desktop /
+ *    self-host) an inbound acting header is untrusted client input, and there is
+ *    only one human anyway — so no identity key is written at all and a
+ *    single-player learnings.json keeps exactly the shape it has today. ON the
+ *    gateway with no acting-as token (a FIRED ROUTINE has no driving human) the
+ *    routine creator's sub — forwarded as `x-houston-acting-user` — is the
+ *    author, so a routine-taught learning is never anonymous in Teams.
+ *  - `mission_id` + `mission_title` whenever the conversation matches a mission,
+ *    on EVERY deployment: a mission is not an identity, and "from the Q3
+ *    pipeline mission" is the more useful half of provenance for a solo user.
+ *    No conversation id, or no matching mission (a routine run, a chat with no
+ *    board row) → no mission keys.
+ *  - Everything is best-effort metadata: a failure to resolve the mission must
+ *    never cost the user their learning, so the mission lookup is swallowed and
+ *    the learning is saved without it.
+ */
+export async function handleSandboxLearnings(
+  deps: {
+    vault: CredentialVault;
+    store: WorkspaceStore;
+    vfs?: Vfs;
+    paths?: WorkspacePaths;
+    events?: EventHub;
+    /**
+     * True only when a trusted gateway fronts every request (the managed pod).
+     * Then the acting-as header names the human who taught the learning; on the
+     * desktop the header is untrusted client input and nothing is stamped.
+     * Mirrors routes/routines-sandbox.ts.
+     */
+    gatewayFronted?: boolean;
+  },
+  method: string,
+  path: string,
+  url: URL,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  if (path !== "/sandbox/learnings/save" || method !== "POST") return false;
+
+  // Authenticate the sandbox (NOT a user JWT) — same gate as /sandbox/credential.
+  const sbToken = bearer(req, url);
+  const claim = sbToken ? deps.vault.validateSandboxToken(sbToken) : null;
+  if (!claim) {
+    json(res, 401, { error: "unauthorized" });
+    return true;
+  }
+  const vfs = deps.vfs;
+  if (!vfs) {
+    // Same stable code the generic sandbox proxies use, so the runtime tool
+    // renders the honest "not available in this install" speech act.
+    json(res, 503, {
+      error: "agent data not configured",
+      code: "agent_data_not_configured",
+    });
+    return true;
+  }
+  const ws = await deps.store.getWorkspace(claim.workspaceId);
+  const agent = await deps.store.getAgent(claim.agentId);
+  if (!ws || !agent) {
+    json(res, 404, { error: "agent not found" });
+    return true;
+  }
+
+  const body = await readJson(req);
+  const text = typeof body.text === "string" ? body.text.trim() : "";
+  if (!text) {
+    json(res, 400, { error: "missing 'text'" });
+    return true;
+  }
+
+  const paths = deps.paths ?? DEFAULT_PATHS;
+  const root = paths.agentRoot(ws, agent);
+  // WHO taught this, same two-rung ladder the integrations sandbox route walks:
+  // the gateway-minted acting-as human, else the routine creator's sub (a FIRED
+  // ROUTINE has no live human, so the runtime forwards `x-houston-acting-user`
+  // instead). Off the gateway: nobody at all. NOT the workspace owner — on a
+  // managed pod that is the placeholder "local-owner", which resolves to no
+  // profile and would only put a junk id in the file.
+  const actingUser = header(req, ACTING_USER_HEADER);
+  const taughtBy = deps.gatewayFronted
+    ? (actingAuthorFromHeader(req.headers[ACTING_AS_HEADER]) ??
+      (actingUser ? { user_id: actingUser } : null))
+    : null;
+  const mission = await resolveMission(
+    vfs,
+    root,
+    header(req, CONVERSATION_ID_HEADER),
+  );
+
+  const learning: Learning = {
+    id: randomUUID(),
+    text,
+    created_at: new Date().toISOString(),
+    // Spread-when-present: absent provenance writes NO key, so a single-player
+    // learnings.json stays byte-identical in shape to today's.
+    ...(taughtBy ? { taught_by: taughtBy } : {}),
+    ...mission,
+  };
+
+  // Merge-save: read what is there, append, write the whole set back — so a
+  // second save never clobbers the first. Under the per-doc lock (see
+  // doc-lock.ts) because the read-modify-write is only merge-safe when it is
+  // ATOMIC: two saves from different conversations on the same pod, or a save
+  // racing the Memory tab's whole-file PUT (agent-data.ts, same key), would
+  // otherwise both load the same base list and the last write would win.
+  await withDocLock(`${root}#learnings`, async () => {
+    const { items } = await loadLearnings(vfs, root);
+    await saveLearnings(vfs, root, [...items, learning]);
+  });
+  // React on the SAME channel a UI or file-watcher write does; scope to the
+  // workspace owner, exactly as the agent-data learnings PUT does.
+  const event: HoustonEvent = { type: "LearningsChanged", agentPath: agent.id };
+  deps.events?.emit(ws.ownerUserId, event);
+
+  json(res, 201, learning);
+  return true;
+}
+
+/**
+ * The mission a conversation belongs to, as the learning's mission keys, or an
+ * empty object when there is no id / no match / the read failed.
+ *
+ * Matching uses the SAME convention as per-mission attribution
+ * (`activity-attribution.ts`): a mission's `session_key` IS the turn's
+ * conversation id, with `activity-<id>` as the fallback for missions whose key
+ * was never persisted separately.
+ *
+ * `mission_title` is denormalized on purpose: the mission may later be renamed
+ * or deleted, and a learning that reads "from a mission that no longer exists"
+ * is worse than one that keeps the title it was taught under. Renderers prefer
+ * the live title looked up by `mission_id` and fall back to this.
+ */
+async function resolveMission(
+  store: TextStore,
+  root: string,
+  conversationId: string | undefined,
+): Promise<{ mission_id?: string; mission_title?: string }> {
+  if (!conversationId) return {};
+  try {
+    const { items } = await loadActivities(store, root);
+    const activity = items.find(
+      (a) =>
+        a.session_key === conversationId ||
+        `activity-${a.id}` === conversationId,
+    );
+    if (!activity) return {};
+    return {
+      mission_id: activity.id,
+      ...(activity.title ? { mission_title: activity.title } : {}),
+    };
+  } catch (err) {
+    // Provenance is metadata: never cost the user their learning over it.
+    console.error(`[learnings] mission lookup failed for ${root}:`, err);
+    return {};
+  }
+}

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -50,6 +50,7 @@ import {
   type IntegrationDeps,
 } from "./routes/integrations";
 import { handleSandboxIntegrations } from "./routes/integrations-sandbox";
+import { handleSandboxLearnings } from "./routes/learnings-sandbox";
 import { handleMigrationSource } from "./routes/migration-source";
 import { handlePortableAccount } from "./routes/portable";
 import { handlePortableFromStore } from "./routes/portable-from-store";
@@ -276,6 +277,10 @@ async function handle(
   // Runtime-facing scheduled-task save (merge-safe; HMAC sandbox token). The
   // agent's save_routine tool calls this instead of writing routines.json.
   if (await handleSandboxRoutines(deps, method, path, url, req, res)) return;
+  // Runtime-facing memory save (merge-safe + provenance-stamping; HMAC sandbox
+  // token). The agent's save_learning tool calls this instead of editing
+  // learnings.json — it is the only path that records who taught a learning.
+  if (await handleSandboxLearnings(deps, method, path, url, req, res)) return;
 
   // Everything past here is authenticated.
   const userId = await principal(deps, req, url);

--- a/packages/protocol/src/domain/activity.ts
+++ b/packages/protocol/src/domain/activity.ts
@@ -71,4 +71,23 @@ export interface Learning {
   id: string;
   text: string;
   created_at: string;
+  /**
+   * WHO taught this learning (provenance). Stamped by the host from the
+   * gateway-injected acting-as identity when a turn saved it, or by the app
+   * from the signed-in session when a person added it in Memory. Absent on
+   * desktop / single-player, so those files stay free of identity keys.
+   */
+  taught_by?: ActivityContributor;
+  /**
+   * The mission (activity) whose conversation taught this learning, matched by
+   * the turn's conversation id. Absent when nothing matched (settings-added
+   * learnings, a routine run with no mission, a legacy entry).
+   */
+  mission_id?: string;
+  /**
+   * The mission's title AT SAVE TIME — a denormalized fallback so a renamed or
+   * deleted mission still reads. Renderers prefer the live title looked up by
+   * `mission_id` and fall back to this.
+   */
+  mission_title?: string;
 }

--- a/packages/runtime/src/backends/claude/backend-mcp.test.ts
+++ b/packages/runtime/src/backends/claude/backend-mcp.test.ts
@@ -120,7 +120,8 @@ test("plan mode builds the MCP server WITHOUT integrations — ask_user + plan_r
 
 test("auto mode builds the MCP with integrations ON and ask_user OFF", async () => {
   // Autopilot is the inverse of plan: it KEEPS the acting integration tools
-  // (and the non-blocking suggest_reusable and save_routine, and the
+  // (and the non-blocking suggest_reusable, save_routine and save_learning,
+  // and the
   // request_connection / request_credential hand-offs autonomy cannot avoid —
   // HOU-853) but drops ask_user so the agent never waits on the user's
   // judgment.
@@ -134,6 +135,7 @@ test("auto mode builds the MCP with integrations ON and ask_user OFF", async () 
     new Set([
       "suggest_reusable",
       "save_routine",
+      "save_learning",
       "integration_search",
       "integration_execute",
       "request_connection",
@@ -147,6 +149,7 @@ test("auto mode builds the MCP with integrations ON and ask_user OFF", async () 
     new Set([
       "mcp__houston__suggest_reusable",
       "mcp__houston__save_routine",
+      "mcp__houston__save_learning",
       "mcp__houston__integration_search",
       "mcp__houston__integration_execute",
       "mcp__houston__request_connection",

--- a/packages/runtime/src/backends/claude/custom-tools.test.ts
+++ b/packages/runtime/src/backends/claude/custom-tools.test.ts
@@ -89,6 +89,7 @@ test("exposes ask_user + suggest_reusable + integration tools when the integrati
       "ask_user",
       "suggest_reusable",
       "save_routine",
+      "save_learning",
       "integration_search",
       "integration_execute",
       "request_connection",
@@ -102,6 +103,7 @@ test("exposes ask_user + suggest_reusable + integration tools when the integrati
       "mcp__houston__ask_user",
       "mcp__houston__suggest_reusable",
       "mcp__houston__save_routine",
+      "mcp__houston__save_learning",
       "mcp__houston__integration_search",
       "mcp__houston__integration_execute",
       "mcp__houston__request_connection",
@@ -180,6 +182,27 @@ test("save_routine is bridged for execute/auto but stripped from plan", () => {
   );
 });
 
+test("save_learning is bridged for execute/auto but stripped from plan", () => {
+  // Same gate and same reach as save_routine: it proxies to the host under the
+  // sandbox token, so it exists only when the host is reachable, and saving a
+  // learning is a write — never in read-only plan mode.
+  expect(build(INTEGRATIONS).tools.map((t) => t.name)).toContain(
+    "save_learning",
+  );
+  expect(build(INTEGRATIONS, "execute").tools.map((t) => t.name)).toContain(
+    "save_learning",
+  );
+  expect(build(INTEGRATIONS, "auto").tools.map((t) => t.name)).toContain(
+    "save_learning",
+  );
+  expect(build(INTEGRATIONS, "plan").tools.map((t) => t.name)).not.toContain(
+    "save_learning",
+  );
+  expect(build(undefined).tools.map((t) => t.name)).not.toContain(
+    "save_learning",
+  );
+});
+
 test("auto mode keeps the integration + suggest_reusable tools but drops ask_user", () => {
   const { tools, mcp } = build(INTEGRATIONS, "auto");
   // Autopilot never waits on the user's judgment: ask_user is gone (and
@@ -192,6 +215,7 @@ test("auto mode keeps the integration + suggest_reusable tools but drops ask_use
     new Set([
       "suggest_reusable",
       "save_routine",
+      "save_learning",
       "integration_search",
       "integration_execute",
       "request_connection",
@@ -204,6 +228,7 @@ test("auto mode keeps the integration + suggest_reusable tools but drops ask_use
     new Set([
       "mcp__houston__suggest_reusable",
       "mcp__houston__save_routine",
+      "mcp__houston__save_learning",
       "mcp__houston__integration_search",
       "mcp__houston__integration_execute",
       "mcp__houston__request_connection",

--- a/packages/runtime/src/backends/claude/custom-tools.ts
+++ b/packages/runtime/src/backends/claude/custom-tools.ts
@@ -18,6 +18,7 @@ import {
   makeIntegrationTools,
 } from "../../session/tools/integrations";
 import { makePlanReadyTool } from "../../session/tools/plan-ready";
+import { makeSaveLearningTool } from "../../session/tools/save-learning";
 import { makeSaveRoutineTool } from "../../session/tools/save-routine";
 import { makeSuggestReusableTool } from "../../session/tools/suggest-reusable";
 
@@ -143,6 +144,9 @@ export function buildHoustonMcpServer(input: HoustonMcpInput): HoustonMcp {
     // tools use (present ⟺ host reachable). It reaches execute/auto but never
     // plan — the same reach as suggest_reusable, applied by `toolNamesForMode`.
     ...(input.integrations ? [makeSaveRoutineTool(input.integrations)] : []),
+    // save_learning reaches the host with the SAME sandbox token, and has the
+    // same reach as save_routine: execute/auto, never plan.
+    ...(input.integrations ? [makeSaveLearningTool(input.integrations)] : []),
     ...(input.integrations ? makeIntegrationTools(input.integrations) : []),
     ...(input.integrations
       ? makeCustomIntegrationTools(input.integrations)

--- a/packages/runtime/src/session/conversation-cache.ts
+++ b/packages/runtime/src/session/conversation-cache.ts
@@ -22,6 +22,7 @@ import { makeIdTokenProvider } from "./tools/gcp-id-token";
 import { makeIntegrationTools } from "./tools/integrations";
 import { makePlanReadyTool } from "./tools/plan-ready";
 import { makeRunCodeTool } from "./tools/run-code";
+import { makeSaveLearningTool } from "./tools/save-learning";
 import { makeSaveRoutineTool } from "./tools/save-routine";
 import { makeSuggestReusableTool } from "./tools/suggest-reusable";
 import type { TurnModeRef } from "./turn-mode-context";
@@ -97,10 +98,22 @@ const saveRoutineTool = hostReachable
     })
   : null;
 
+// The merge-safe memory write tool: proxies to /sandbox/learnings/save so the
+// agent never rewrites learnings.json wholesale AND the host can stamp the
+// learning's provenance (who taught it, which mission it came from) from the
+// turn's acting identity + conversation id. Same reachability gate as above.
+const saveLearningTool = hostReachable
+  ? makeSaveLearningTool({
+      baseUrl: config.controlPlaneUrl,
+      sandboxToken: config.sandboxToken,
+    })
+  : null;
+
 const toolSelection = buildToolSelection({
   codeExecution: config.codeExecution,
   integrations: integrationTools.length > 0,
   saveRoutine: hostReachable,
+  saveLearning: hostReachable,
 });
 const runCodeTool = toolSelection.includeRunCode
   ? makeRunCodeTool({
@@ -132,6 +145,7 @@ const piBackend = createPiBackend({
     suggestReusableTool,
     ...(runCodeTool ? [runCodeTool] : []),
     ...(saveRoutineTool ? [saveRoutineTool] : []),
+    ...(saveLearningTool ? [saveLearningTool] : []),
     ...integrationTools,
     ...customIntegrationTools,
   ],

--- a/packages/runtime/src/session/conversation-context.ts
+++ b/packages/runtime/src/session/conversation-context.ts
@@ -1,0 +1,37 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * WHICH conversation the current turn belongs to, made available to the tools
+ * while the turn runs.
+ *
+ * WHY it exists: a tool that wants to link what it saves back to the mission the
+ * user was in (learnings carry `mission_id` / `mission_title`) needs the turn's
+ * conversation id, and pi hands a tool only its own parameters. Asking the MODEL
+ * for the id would be unreliable (it can't see it) and forgeable; the runtime
+ * knows it for free.
+ *
+ * Turn-scoping mechanism + assumption: identical to `acting-context.ts` — an
+ * `AsyncLocalStorage` whose store is established for the DURATION of
+ * `session.prompt()` (see exec-turn.ts). Tool `execute` callbacks run inside
+ * that same async subtree, so two conversations running concurrently in one
+ * runtime never read each other's id (a module-level "current conversation"
+ * would leak across them). Outside a turn the store is undefined, so tools
+ * attach nothing and behavior is unchanged.
+ */
+
+const store = new AsyncLocalStorage<string>();
+
+/** Run `fn` with `id` as the ambient conversation id for its whole async subtree. */
+export function runWithConversationId<T>(
+  id: string | undefined,
+  fn: () => T,
+): T {
+  // No id to carry: run plainly so tools see `undefined` and attach nothing.
+  if (!id) return fn();
+  return store.run(id, fn);
+}
+
+/** The current turn's conversation id, or undefined outside a turn. */
+export function currentConversationId(): string | undefined {
+  return store.getStore();
+}

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -35,6 +35,7 @@ import {
   switchBackendIfNeeded,
   switchModeIfNeeded,
 } from "./conversation-cache";
+import { runWithConversationId } from "./conversation-context";
 import {
   diffSnapshots,
   type FileSnapshot,
@@ -370,9 +371,11 @@ export async function execTurn(
     watchdog.arm();
     try {
       await runWithActingContext(acting, () =>
-        runWithTurnMode(liveMode, () =>
-          runWithInteractionCapture(interaction, () =>
-            conv.session.prompt(promptText),
+        runWithConversationId(id, () =>
+          runWithTurnMode(liveMode, () =>
+            runWithInteractionCapture(interaction, () =>
+              conv.session.prompt(promptText),
+            ),
           ),
         ),
       );

--- a/packages/runtime/src/session/tool-selection.test.ts
+++ b/packages/runtime/src/session/tool-selection.test.ts
@@ -115,6 +115,42 @@ describe("buildToolSelection", () => {
       "save_routine",
     );
   });
+
+  test("save_learning is added when the host is reachable, off by default", () => {
+    const off = buildToolSelection({
+      codeExecution: "disabled",
+      integrations: false,
+    });
+    expect(off.toolNames).not.toContain("save_learning");
+
+    const on = buildToolSelection({
+      codeExecution: "disabled",
+      integrations: false,
+      saveLearning: true,
+    });
+    // Same reachability gate as save_routine, independent of Composio.
+    expect(on.toolNames).toEqual([
+      ...CLAMPED_FILE_TOOL_NAMES,
+      "ask_user",
+      "suggest_reusable",
+      "save_learning",
+    ]);
+  });
+
+  test("save_learning reaches execute and auto but never plan", () => {
+    const on = buildToolSelection({
+      codeExecution: "disabled",
+      integrations: false,
+      saveLearning: true,
+    });
+    expect(toolNamesForMode("execute", on.toolNames)).toContain(
+      "save_learning",
+    );
+    expect(toolNamesForMode("auto", on.toolNames)).toContain("save_learning");
+    expect(toolNamesForMode("plan", on.toolNames)).not.toContain(
+      "save_learning",
+    );
+  });
 });
 
 describe("planToolNames", () => {

--- a/packages/runtime/src/session/tool-selection.ts
+++ b/packages/runtime/src/session/tool-selection.ts
@@ -4,6 +4,7 @@ import { CLAMPED_FILE_TOOL_NAMES } from "./tools/clamped-fs";
 import { CUSTOM_INTEGRATION_TOOL_NAMES } from "./tools/custom-integrations";
 import { INTEGRATION_TOOL_NAMES } from "./tools/integrations";
 import { PLAN_READY_TOOL_NAME } from "./tools/plan-ready";
+import { SAVE_LEARNING_TOOL_NAME } from "./tools/save-learning";
 import { SAVE_ROUTINE_TOOL_NAME } from "./tools/save-routine";
 import { SUGGEST_REUSABLE_TOOL_NAME } from "./tools/suggest-reusable";
 
@@ -21,6 +22,14 @@ export interface ToolSelectionInput {
    * it must never write routines.json wholesale), on where the host is reachable.
    */
   saveRoutine?: boolean;
+  /**
+   * Whether this runtime can reach its host with a sandbox token — the SAME
+   * reachability `saveRoutine` needs. Adds `save_learning`, the merge-safe way
+   * to persist a learning (and the only path that records its provenance:
+   * who taught it, which mission it came from). Absent/false leaves the tool
+   * off and the agent falls back to the raw file, which records neither.
+   */
+  saveLearning?: boolean;
 }
 
 export interface ToolSelection {
@@ -144,6 +153,11 @@ export function buildToolSelection(input: ToolSelectionInput): ToolSelection {
       // filters it out, and it isn't in AUTO_MODE_EXCLUDED_TOOL_NAMES so auto
       // keeps it — the same reach as suggest_reusable.
       ...(input.saveRoutine ? [SAVE_ROUTINE_TOOL_NAME] : []),
+      // save_learning has the SAME reach as save_routine — execute and auto,
+      // never plan (plan is read-only and saving a learning is a real write).
+      // PLAN_MODE_TOOL_NAMES omits it so planToolNames filters it out, and it
+      // isn't in AUTO_MODE_EXCLUDED_TOOL_NAMES so auto keeps it.
+      ...(input.saveLearning ? [SAVE_LEARNING_TOOL_NAME] : []),
       ...executable,
       ...(input.integrations
         ? [...INTEGRATION_TOOL_NAMES, ...CUSTOM_INTEGRATION_TOOL_NAMES]

--- a/packages/runtime/src/session/tools/save-learning.test.ts
+++ b/packages/runtime/src/session/tools/save-learning.test.ts
@@ -1,0 +1,95 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { afterEach, expect, test } from "vitest";
+import { runWithActingContext } from "../acting-context";
+import { runWithConversationId } from "../conversation-context";
+import {
+  CONVERSATION_ID_HEADER,
+  makeSaveLearningTool,
+  SAVE_LEARNING_TOOL_NAME,
+} from "./save-learning";
+
+/**
+ * save_learning is a thin proxy to the host's merge-safe + provenance-stamping
+ * /sandbox/learnings/save route under the per-sandbox token. These pin: the URL
+ * + Authorization header, that ONLY the text crosses the wire (provenance is
+ * derived server-side, never claimed by the model), the acting-as + conversation
+ * forwarding that makes that derivation possible, and that a host rejection
+ * surfaces as a tool error the agent can relay.
+ */
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+interface Captured {
+  url: string;
+  auth?: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+function mockFetch(reply: () => { status?: number; body?: unknown }) {
+  const calls: Captured[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    calls.push({
+      url: String(input),
+      auth: headers.authorization,
+      headers,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    const r = reply();
+    return new Response(r.body === undefined ? null : JSON.stringify(r.body), {
+      status: r.status ?? 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  return calls;
+}
+
+const tool = makeSaveLearningTool({
+  baseUrl: "https://host.test/",
+  sandboxToken: "sb-tok",
+});
+const ctx = {} as unknown as ExtensionContext;
+const run = (params: unknown) =>
+  tool.execute("id", params as never, undefined, undefined, ctx);
+
+const OK = () => ({ status: 201, body: { id: "l1" } });
+
+test("is named save_learning", () => {
+  expect(tool.name).toBe(SAVE_LEARNING_TOOL_NAME);
+});
+
+test("POSTs only the text to the merge-safe route with the sandbox token", async () => {
+  const calls = mockFetch(OK);
+  const out = await run({ text: "Exclude churned accounts" });
+  expect(calls[0]?.url).toBe("https://host.test/sandbox/learnings/save");
+  expect(calls[0]?.auth).toBe("Bearer sb-tok");
+  // Provenance is NOT a parameter: the model cannot claim who taught it.
+  expect(calls[0]?.body).toEqual({ text: "Exclude churned accounts" });
+  expect((out.details as { id: string }).id).toBe("l1");
+});
+
+test("outside a turn it forwards no identity or conversation headers", async () => {
+  const calls = mockFetch(OK);
+  await run({ text: "solo" });
+  expect(calls[0]?.headers["x-houston-acting-as"]).toBeUndefined();
+  expect(calls[0]?.headers[CONVERSATION_ID_HEADER]).toBeUndefined();
+});
+
+test("forwards the acting identity and the turn's conversation id", async () => {
+  const calls = await runWithActingContext({ actingAs: "tok-abc" }, () =>
+    runWithConversationId("conv-42", () => {
+      const c = mockFetch(OK);
+      return run({ text: "Invoices go out on the 1st" }).then(() => c);
+    }),
+  );
+  expect(calls[0]?.headers["x-houston-acting-as"]).toBe("tok-abc");
+  expect(calls[0]?.headers[CONVERSATION_ID_HEADER]).toBe("conv-42");
+});
+
+test("surfaces a host rejection as a tool error (never a silent success)", async () => {
+  mockFetch(() => ({ status: 400, body: { error: "missing 'text'" } }));
+  await expect(run({ text: "" })).rejects.toThrow(/missing 'text'/);
+});

--- a/packages/runtime/src/session/tools/save-learning.ts
+++ b/packages/runtime/src/session/tools/save-learning.ts
@@ -1,0 +1,109 @@
+import { defineTool } from "@earendil-works/pi-coding-agent";
+import { type Static, Type } from "typebox";
+import { currentActingContext } from "../acting-context";
+import { currentConversationId } from "../conversation-context";
+
+/**
+ * The agent's structured tool to SAVE a learning (a stable fact or preference
+ * the agent should carry into future sessions).
+ *
+ * WHY it exists: the product prompt used to tell the agent to edit
+ * `.houston/learnings/learnings.json` with file tools. Two problems with that.
+ * (1) It is the same wholesale-write hazard `save_routine` was created for — a
+ * model that rewrites the array drops everything it did not happen to read.
+ * (2) A learning has PROVENANCE the agent cannot know or be trusted to write:
+ * WHO taught it and WHICH mission it came from. Both are derived server-side —
+ * the person from the gateway-minted acting-as header, the mission from the
+ * turn's conversation id — so the tool takes only the learning's text.
+ *
+ * Same trust posture as the other host-proxying tools: it holds no secret and
+ * carries only the per-sandbox HMAC token; the host resolves the sandbox to its
+ * workspace, stamps provenance, and owns the merge-safe write.
+ */
+export const SAVE_LEARNING_TOOL_NAME = "save_learning";
+
+/** The header carrying the turn's conversation id, so the host can resolve the
+ *  mission this learning came from. Read-only provenance, never authorization. */
+export const CONVERSATION_ID_HEADER = "x-houston-conversation-id";
+
+const SaveLearningParams = Type.Object({
+  text: Type.String({
+    description:
+      "The learning itself, in one or two plain sentences, written so it still makes sense months later without this conversation's context.",
+  }),
+});
+type SaveLearningParams = Static<typeof SaveLearningParams>;
+
+export interface SaveLearningToolOptions {
+  baseUrl: string;
+  /** The per-sandbox HMAC token (HOUSTON_SANDBOX_TOKEN). */
+  sandboxToken: string;
+}
+
+/** What the host echoes back on a successful save. */
+interface SavedLearning {
+  id: string;
+}
+
+export function makeSaveLearningTool(opts: SaveLearningToolOptions) {
+  const base = opts.baseUrl.replace(/\/$/, "");
+
+  return defineTool({
+    name: SAVE_LEARNING_TOOL_NAME,
+    label: "Remember this",
+    description:
+      "Save one learning to the user's memory so it survives into future sessions. NEVER write .houston/learnings/learnings.json with file tools — this tool is the ONLY safe way to save, because it merges with the user's existing memory instead of overwriting it, and it records who taught the learning and which mission it came from. Pass only the learning's text. On success, confirm in plain words - never mention files, JSON, or paths.",
+    promptSnippet: "Save a learning to memory",
+    parameters: SaveLearningParams,
+    executionMode: "sequential",
+    async execute(
+      _id: string,
+      params: SaveLearningParams,
+      signal: AbortSignal | undefined,
+    ) {
+      // WHO this turn acts as (C2) and WHICH conversation it belongs to: both
+      // are turn-scoped ambient context, forwarded so the host can stamp the
+      // learning's provenance. Absent outside a turn (or off the gateway), and
+      // the host then simply stamps nothing.
+      const acting = currentActingContext();
+      const conversationId = currentConversationId();
+      const res = await fetch(`${base}/sandbox/learnings/save`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${opts.sandboxToken}`,
+          ...(acting?.actingAs
+            ? { "x-houston-acting-as": acting.actingAs }
+            : {}),
+          ...(acting?.actingUser
+            ? { "x-houston-acting-user": acting.actingUser }
+            : {}),
+          ...(conversationId
+            ? { [CONVERSATION_ID_HEADER]: conversationId }
+            : {}),
+        },
+        body: JSON.stringify({ text: params.text }),
+        signal,
+      });
+      if (!res.ok) {
+        const detail = await res.text().catch(() => "");
+        // The host's error bodies are already agent-actionable (empty text,
+        // memory not available on this install) — relay them so the agent
+        // explains the reason to the user and can correct itself.
+        throw new Error(
+          `save_learning failed (${res.status}): ${detail.slice(0, 300)}`,
+        );
+      }
+      const saved = (await res.json()) as SavedLearning;
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: "Saved to memory. Tell the user you'll remember it, in plain words.",
+          },
+        ],
+        details: { id: saved.id },
+      };
+    },
+  });
+}

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -143,10 +143,12 @@ export async function runPiTurn(
     const toolSelection = buildToolSelection({
       codeExecution: config.codeExecution === "remote" ? "remote" : "disabled",
       integrations: false,
-      // The retired stateless per-turn cloud runtime has no sandbox routine
-      // route wired (it syncs the whole workspace prefix), so save_routine is
-      // off here — the standing per-agent pods run in server mode with it on.
+      // The retired stateless per-turn cloud runtime has no sandbox routine or
+      // learning route wired (it syncs the whole workspace prefix), so both
+      // host-proxying save tools are off here — the standing per-agent pods run
+      // in server mode with them on.
       saveRoutine: false,
+      saveLearning: false,
     });
     const sandbox = toolSelection.includeRunCode
       ? makeRunCodeTool({

--- a/packages/web/e2e/learnings-provenance.spec.ts
+++ b/packages/web/e2e/learnings-provenance.spec.ts
@@ -1,0 +1,85 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * Memory (learnings) provenance — HOU-946.
+ *
+ * Every learning links back to the person who taught it and the mission it came
+ * from, and that link has to be VISIBLE wherever learnings are shown. The fake
+ * host seeds two: one stamped with both halves, one with neither.
+ *
+ * The default e2e project is single-player with identity off, so no roster
+ * resolves — which is exactly the desktop case. The line must still read, from
+ * the name stored on the learning itself. And the learning WITHOUT provenance
+ * must render no line at all rather than a hollow "From unknown".
+ */
+
+/** Agent Settings (job-description) → the Memory section. */
+async function openMemory(page: Page) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Agent Settings" }).click();
+  await page.getByText("Memory", { exact: true }).click();
+}
+
+// NOTE: no test title here may END in the word "from" — `check:boundaries`
+// extracts imports with a regex that reads `from"` as a specifier and reports
+// the rest of the file as an undeclared dependency.
+test("a learning shows the person who taught it and its mission", async ({
+  page,
+}) => {
+  await openMemory(page);
+
+  const stamped = page
+    .locator("article")
+    .filter({ hasText: "Exclude churned accounts from pipeline math." });
+  await expect(stamped).toBeVisible();
+  // Person AND mission, in one muted line. The mission title is the LIVE one
+  // (looked up by mission_id against the seeded board), not a stale copy.
+  await expect(
+    stamped.getByText("From Ada Lovelace · Plan a trip to Tokyo"),
+  ).toBeVisible();
+  // The face renders from initials when no roster photo is available.
+  await expect(stamped.getByText("AL", { exact: true })).toBeVisible();
+});
+
+test("a learning with no provenance renders no provenance line", async ({
+  page,
+}) => {
+  await openMemory(page);
+
+  const plain = page
+    .locator("article")
+    .filter({ hasText: "Prefers metric units in every report." });
+  await expect(plain).toBeVisible();
+  await expect(plain.getByText(/^From /)).toHaveCount(0);
+});
+
+test("the provenance line survives an edit and stays out of the editor", async ({
+  page,
+}) => {
+  await openMemory(page);
+
+  // Pinned by position, not by text: the editor replaces the row's rendered
+  // text, so a text filter would stop matching the moment we type.
+  const stamped = page.locator("article").first();
+  await expect(stamped).toContainText(
+    "Exclude churned accounts from pipeline math.",
+  );
+  await stamped.getByRole("button", { name: "Edit learning" }).click();
+
+  // Editing is about the text; provenance is not the editor's to change.
+  const editor = stamped.getByRole("textbox");
+  await expect(editor).toBeVisible();
+  await expect(stamped.getByText(/^From /)).toHaveCount(0);
+
+  await editor.fill("Exclude churned accounts, and dormant ones too.");
+  await stamped.getByRole("button", { name: "Save" }).click();
+
+  // The rewritten learning keeps the provenance the update path preserved.
+  await expect(stamped).toContainText(
+    "Exclude churned accounts, and dormant ones too.",
+  );
+  await expect(
+    stamped.getByText("From Ada Lovelace · Plan a trip to Tokyo"),
+  ).toBeVisible();
+});

--- a/ui/agent-schemas/src/learnings.schema.json
+++ b/ui/agent-schemas/src/learnings.schema.json
@@ -9,7 +9,25 @@
     "properties": {
       "id": { "type": "string" },
       "text": { "type": "string" },
-      "created_at": { "type": "string", "format": "date-time" }
+      "created_at": { "type": "string", "format": "date-time" },
+      "taught_by": {
+        "description": "The human this learning came from. Server-stamped from the gateway-injected acting-as identity (hosted Teams) or the app's own signed-in session; absent on desktop/single-player.",
+        "type": "object",
+        "required": ["user_id"],
+        "properties": {
+          "user_id": { "type": "string" },
+          "name": { "type": "string" }
+        },
+        "additionalProperties": false
+      },
+      "mission_id": {
+        "description": "The id of the mission (activity) whose conversation taught this learning. Absent when the learning came from settings or no mission matched.",
+        "type": "string"
+      },
+      "mission_title": {
+        "description": "The mission's title at save time, denormalized so a renamed or deleted mission still reads. The live title (looked up by mission_id) wins when it resolves.",
+        "type": "string"
+      }
     },
     "additionalProperties": false
   }


### PR DESCRIPTION
Fixes HOU-946

**Stack 3/3** — based on #1110 (PersonFace tones); merge last.

## What

Every learning an agent carries can now link to the person who taught it and the mission it came from ('Exclude churned accounts from pipeline math, from Felipe, Q3 pipeline mission'), surfaced in the Memory tab with the teammate's face and the live mission title.

## How

- **Schema/types** (additive, optional): `taught_by {user_id, name?}`, `mission_id`, `mission_title` on the learning record.
- **New `save_learning` runtime tool** (registered beside `save_routine` in all three sites) posts the text to a new host route `/sandbox/learnings/save`; the **host** stamps provenance so the model can't forge it: `taught_by` from the gateway acting headers (acting-as author, then the acting-user sub so fired-routine runs still attribute; never off-gateway — desktop files keep their exact shape), mission from the conversation id via the session-key convention. One deliberate choice: mission provenance stamps on every deployment — a mission is not identity, and it's the useful half for a solo user.
- **Safety**: saves are `withDocLock` read-modify-writes (concurrent saves can't drop entries — the review caught this); a boot migration re-seeds stale per-agent schema files so the new optional keys validate (otherwise the prompt's fallback path could strip them); provenance is stripped from portable export **and** import (org-local identity never leaks); the Memory-tab add stamps `taught_by` client-side only in multiplayer.
- **Prompts** teach the tool on both the host and the desktop shell copy.

## Verification

domain 149, host 1057 (incl. concurrency + migration tests), runtime 795+, app 2100 tests; repo-wide biome/typecheck/parity/boundaries; locales in sync; learnings-provenance e2e 3/3. Adversarially reviewed; all confirmed findings fixed (doc-lock, schema re-seed migration, routine-run attribution, PersonFace reuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)