### PR TITLE
fix(app): mint each cloud space its own Claude token family, exclusive handoff (HOU-954)

### DIFF
--- a/app/src-tauri/src/claude_login/credential.rs
+++ b/app/src-tauri/src/claude_login/credential.rs
@@ -31,7 +31,7 @@ use std::process::Command;
 
 use sha2::{Digest, Sha256};
 
-use super::claude_login_config_dir;
+use super::config_dir_for;
 
 /// Base Keychain service name the `claude` CLI stores credentials under
 /// (macOS). The default `~/.claude` install uses it bare; any other
@@ -44,7 +44,7 @@ const KEYCHAIN_SERVICE_BASE: &str = "Claude Code-credentials";
 /// Houston's login dir. The hash input is the path string EXACTLY as the CLI
 /// received it in `CLAUDE_CONFIG_DIR` (no normalization), which is the same
 /// `claude_login_config_dir()` string the login spawn passed.
-fn keychain_service_for(config_dir: &Path) -> String {
+pub(super) fn keychain_service_for(config_dir: &Path) -> String {
     let digest = Sha256::digest(config_dir.to_string_lossy().as_bytes());
     let prefix: String = digest
         .iter()
@@ -54,13 +54,16 @@ fn keychain_service_for(config_dir: &Path) -> String {
     format!("{KEYCHAIN_SERVICE_BASE}-{prefix}")
 }
 
-/// Read the cached Anthropic credential JSON for Houston's shared login dir and
-/// return it verbatim (the CLI's `.credentials.json` shape). `Err` on
-/// not-found, an unreadable file/Keychain, or malformed JSON — the caller
-/// degrades to the paste flow instead of leaving a dead spinner.
-#[tauri::command]
-pub async fn read_claude_credential() -> Result<String, String> {
-    let dir = claude_login_config_dir();
+/// Read the cached Anthropic credential JSON the login wrote and return it
+/// verbatim (the CLI's `.credentials.json` shape). `handoff` selects the same
+/// dir the matching `start_claude_login` minted into — for a remote engine
+/// that is the throwaway handoff dir, whose contents are destroyed after the
+/// push (`discard`). `Err` on not-found, an unreadable file/Keychain, or
+/// malformed JSON — the caller degrades to the paste flow instead of leaving a
+/// dead spinner.
+#[tauri::command(rename_all = "snake_case")]
+pub async fn read_claude_credential(handoff: bool) -> Result<String, String> {
+    let dir = config_dir_for(handoff);
     read_credential(&dir, |service| keychain_credential(service))
 }
 

--- a/app/src-tauri/src/claude_login/discard.rs
+++ b/app/src-tauri/src/claude_login/discard.rs
@@ -1,0 +1,177 @@
+//! Destroy the HANDOFF-scoped Claude credential after its push to the gateway.
+//!
+//! A remote-engine login mints its refresh-token family into the throwaway
+//! handoff dir ([`super::claude_handoff_config_dir`]); once the credential is
+//! pushed, the gateway is that family's sole rotator, and every local copy is
+//! a liability — anything that ever refreshed it would trip Anthropic's
+//! refresh-token-reuse detection and revoke the family for both sides
+//! (HOU-950). The frontend calls this right after the push settles (success or
+//! terminal failure) to delete both places the CLI caches to:
+//!   1. `<handoffDir>/.credentials.json` — Linux/Windows/some macOS setups.
+//!   2. The macOS Keychain item(s) under the dir-scoped service
+//!      `Claude Code-credentials-<sha256(dir)[..8]>` (every account: an
+//!      env-scrubbed SDK subprocess may have written a second item under
+//!      another account name).
+//!
+//! Idempotent: nothing cached is success. A genuine deletion failure is `Err`
+//! (the caller logs it — the leftover is inert, nothing ever reads or rotates
+//! the handoff dir outside the login flow, and the next login overwrites it).
+
+use std::path::Path;
+use std::process::Command;
+
+use super::{claude_handoff_config_dir, credential::keychain_service_for};
+
+/// `security` exits 44 (`errSecItemNotFound`) when no item matches — the
+/// idempotent "already gone" outcome.
+const SECURITY_NOT_FOUND: i32 = 44;
+
+/// Cap the delete loop: the CLI writes one item per account and there are at
+/// most a handful of accounts; anything past this is `security` misbehaving.
+const MAX_KEYCHAIN_DELETES: usize = 8;
+
+/// Delete the handoff dir's cached credential (file + Keychain). Idempotent.
+#[tauri::command(rename_all = "snake_case")]
+pub async fn discard_claude_handoff_credential() -> Result<(), String> {
+    let dir = claude_handoff_config_dir();
+    discard(&dir, delete_keychain_items)
+}
+
+/// Core, split from the command so it is unit-testable with an injected
+/// Keychain deleter (no real `security`, no `AppHandle`).
+fn discard<F>(config_dir: &Path, delete_keychain: F) -> Result<(), String>
+where
+    F: FnOnce(&str) -> Result<(), String>,
+{
+    let file = config_dir.join(".credentials.json");
+    match std::fs::remove_file(&file) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(format!(
+                "Could not delete the handed-off Claude credential ({}): {e}",
+                file.display()
+            ));
+        }
+    }
+    delete_keychain(&keychain_service_for(config_dir))
+}
+
+/// Build one `security delete-generic-password` invocation. No `-a`: each call
+/// deletes the FIRST item under the service regardless of account, and the
+/// caller loops until none remain. Split out so the argv is unit-testable.
+fn build_delete_command(service: &str) -> Command {
+    let mut cmd = Command::new("security");
+    cmd.args(["delete-generic-password", "-s", service]);
+    cmd
+}
+
+/// Delete every Keychain item under the dir-scoped service (macOS). Exit 44 on
+/// the first call means nothing was cached — success.
+#[cfg(target_os = "macos")]
+fn delete_keychain_items(service: &str) -> Result<(), String> {
+    for _ in 0..MAX_KEYCHAIN_DELETES {
+        let output = build_delete_command(service)
+            .output()
+            .map_err(|e| format!("Could not access the macOS Keychain: {e}"))?;
+        if output.status.success() {
+            continue; // deleted one item — check for more under another account
+        }
+        return match output.status.code() {
+            Some(SECURITY_NOT_FOUND) => Ok(()),
+            code => Err(format!(
+                "Could not delete the handed-off Claude Keychain item (security exited {code:?})"
+            )),
+        };
+    }
+    Err(format!(
+        "Keychain still holds items under {service} after {MAX_KEYCHAIN_DELETES} deletes"
+    ))
+}
+
+/// Off macOS there is no Keychain — the file delete is the whole job.
+#[cfg(not(target_os = "macos"))]
+fn delete_keychain_items(_service: &str) -> Result<(), String> {
+    let _ = (SECURITY_NOT_FOUND, MAX_KEYCHAIN_DELETES, build_delete_command);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn unique_tmp_dir(tag: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "houston-claude-discard-{tag}-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir temp");
+        dir
+    }
+
+    #[test]
+    fn deletes_the_credentials_file() {
+        let dir = unique_tmp_dir("file");
+        let file = dir.join(".credentials.json");
+        std::fs::write(&file, r#"{"claudeAiOauth":{"accessToken":"tok"}}"#).expect("write");
+        discard(&dir, |_| Ok(())).expect("discard");
+        assert!(!file.exists(), "credential file must be gone");
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn absent_file_is_success_and_keychain_still_runs() {
+        let dir = unique_tmp_dir("absent");
+        let mut keychain_ran = false;
+        discard(&dir, |_| {
+            keychain_ran = true;
+            Ok(())
+        })
+        .expect("idempotent");
+        assert!(keychain_ran, "the Keychain delete must run even with no file");
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn keychain_delete_targets_the_dir_scoped_service() {
+        let dir = unique_tmp_dir("svc");
+        let expected = keychain_service_for(&dir);
+        discard(&dir, |service| {
+            assert_eq!(service, expected);
+            Ok(())
+        })
+        .expect("discard");
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn keychain_failure_propagates() {
+        let dir = unique_tmp_dir("kcerr");
+        let got = discard(&dir, |_| Err("security blew up".to_string()));
+        assert_eq!(got, Err("security blew up".to_string()));
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn delete_command_argv_is_scoped_to_the_service() {
+        let cmd = build_delete_command("Claude Code-credentials-3d1329c5");
+        assert_eq!(cmd.get_program(), "security");
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            args,
+            vec![
+                "delete-generic-password".to_string(),
+                "-s".to_string(),
+                "Claude Code-credentials-3d1329c5".to_string(),
+            ]
+        );
+    }
+}

--- a/app/src-tauri/src/claude_login/mod.rs
+++ b/app/src-tauri/src/claude_login/mod.rs
@@ -42,6 +42,7 @@
 // a re-export of just the fn would not carry them.
 pub(crate) mod code_input;
 pub(crate) mod credential;
+pub(crate) mod discard;
 mod resolve;
 mod runner;
 
@@ -62,12 +63,34 @@ const EVENT_URL: &str = "claude-login://url";
 /// Payload: `{ success: bool, error: string | null }`.
 const EVENT_DONE: &str = "claude-login://done";
 
-/// Houston's shared Claude login dir, used as `CLAUDE_CONFIG_DIR` for both this
-/// login AND the engine so the cached credential is visible to the engine. The
-/// `credential` submodule reads back from the same dir to push the cred to a
-/// remote pod.
+/// Houston's shared Claude login dir, used as `CLAUDE_CONFIG_DIR` for both a
+/// CO-LOCATED login AND the engine so the cached credential is visible to the
+/// engine. The engine reads ONLY this dir — never the handoff dir below.
 pub(super) fn claude_login_config_dir() -> PathBuf {
     crate::houston_dir().join("claude-login")
+}
+
+/// Config dir for a REMOTE-engine login (`handoff: true`): the minted
+/// credential's refresh-token family will be owned and rotated by the gateway
+/// alone, so it must never land in the engine-shared dir — a co-located engine
+/// reading it later would put a second rotator on the family, and Anthropic's
+/// refresh-token-reuse detection then revokes the whole family (HOU-950). The
+/// credential lives here only between `Login successful` and the push; the
+/// frontend destroys it afterwards (`discard`). Fixed (not per-login random)
+/// so the macOS Keychain item it maps to is stable: each login overwrites it,
+/// and a failed discard leaves at most one inert, never-rotated credential
+/// behind for the next login to overwrite.
+pub(super) fn claude_handoff_config_dir() -> PathBuf {
+    crate::houston_dir().join("claude-login-handoff")
+}
+
+/// The login's `CLAUDE_CONFIG_DIR` for the given topology.
+pub(super) fn config_dir_for(handoff: bool) -> PathBuf {
+    if handoff {
+        claude_handoff_config_dir()
+    } else {
+        claude_login_config_dir()
+    }
 }
 
 /// Managed state so `cancel_claude_login` can tear down an in-flight login.
@@ -87,7 +110,9 @@ pub struct ClaudeLoginHandle {
     stdin: code_input::StdinSlot,
 }
 
-/// Start the native Claude sign-in. Returns `Err` (→ frontend toast) only for
+/// Start the native Claude sign-in. `handoff: true` (remote engine) mints into
+/// the throwaway handoff dir instead of the engine-shared one — see
+/// [`claude_handoff_config_dir`]. Returns `Err` (→ frontend toast) only for
 /// the up-front, user-visible failures: the config dir can't be created, or the
 /// helper can't be spawned. Once the child is up, the flow reports its result
 /// through the `claude-login://done` event instead.
@@ -95,8 +120,9 @@ pub struct ClaudeLoginHandle {
 pub async fn start_claude_login(
     app: AppHandle,
     state: State<'_, ClaudeLoginState>,
+    handoff: bool,
 ) -> Result<(), String> {
-    let config_dir = claude_login_config_dir();
+    let config_dir = config_dir_for(handoff);
     // The CLI writes the cached credential here; it must exist first.
     std::fs::create_dir_all(&config_dir).map_err(|e| {
         format!(
@@ -184,5 +210,15 @@ mod tests {
     fn config_dir_lives_under_houston_home() {
         // The shared login dir hangs off the Houston data root.
         assert!(claude_login_config_dir().ends_with("claude-login"));
+    }
+
+    #[test]
+    fn handoff_dir_is_distinct_from_the_engine_shared_dir() {
+        // The whole point: a remote-engine mint must never be visible to a
+        // co-located engine, or two rotators share one refresh-token family.
+        assert!(claude_handoff_config_dir().ends_with("claude-login-handoff"));
+        assert_ne!(claude_handoff_config_dir(), claude_login_config_dir());
+        assert_eq!(config_dir_for(true), claude_handoff_config_dir());
+        assert_eq!(config_dir_for(false), claude_login_config_dir());
     }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -493,6 +493,9 @@ pub fn run() {
             // Extract the cached credential to push to a REMOTE engine pod
             // (a hosted pod can't read this machine's Keychain).
             claude_login::credential::read_claude_credential,
+            // Destroy the handoff-dir copy after the push: the gateway is the
+            // family's only rotator from then on (HOU-950).
+            claude_login::discard::discard_claude_handoff_credential,
             // Pull the app to the foreground when a flow finishes in the
             // browser (e.g. a Composio integration connection landing).
             window_focus::focus_main_window,

--- a/app/src/components/shell/claude-browser-login.tsx
+++ b/app/src/components/shell/claude-browser-login.tsx
@@ -1,12 +1,8 @@
 import { useEffect, useState } from "react";
-import {
-  cancelClaudeBrowserLogin,
-  reconcileClaudeCredentialHandoff,
-} from "../../lib/claude-login";
+import { cancelClaudeBrowserLogin } from "../../lib/claude-login";
 import { listenOsEvent } from "../../lib/events";
 import {
   osCompleteClaudeLoginFromClipboard,
-  osIsTauri,
   osSubmitClaudeLoginCode,
 } from "../../lib/os-bridge";
 import { PROVIDERS } from "../../lib/providers";
@@ -45,13 +41,11 @@ export function ClaudeBrowserLogin() {
     };
   }, []);
 
-  // Finish any EARLIER browser login whose cloud handoff failed: the minted
-  // credential is still cached on this machine, so the connect completes
-  // silently, with no browser round-trip and no token paste (one-shot per
-  // session; a quiet no-op when there's nothing to finish).
-  useEffect(() => {
-    if (osIsTauri()) void reconcileClaudeCredentialHandoff();
-  }, []);
+  // There is deliberately NO background reconcile of an earlier login's cached
+  // credential here: pushing a cached snapshot is how one refresh-token family
+  // ended up behind several independent rotators, tripping Anthropic's
+  // reuse-detection and revoking the family (HOU-950). A failed handoff is
+  // finished by the user reconnecting from the card — a fresh mint.
 
   if (!url || !ANTHROPIC) return null;
   return (

--- a/app/src/lib/claude-login-remote.ts
+++ b/app/src/lib/claude-login-remote.ts
@@ -3,10 +3,20 @@
  *
  * On a CO-LOCATED engine the credential `claude auth login` just cached IS the
  * dir the local runtime reads, so nothing is pushed. On a REMOTE/HOSTED engine
- * the pod can't read this machine's Keychain, so after a successful browser
- * login the desktop EXTRACTS the cached credential (`read_claude_credential`)
- * and PUSHES it to the pod over the control plane, then polls until the pod's
- * runtime reads anthropic as connected.
+ * the pod can't read this machine's Keychain, so the login mints into a
+ * throwaway HANDOFF dir; after `Login successful` the desktop EXTRACTS that
+ * credential (`read_claude_credential`), PUSHES it to the pod over the control
+ * plane, DESTROYS the local copy, then polls until the pod's runtime reads
+ * anthropic as connected.
+ *
+ * OWNERSHIP: Anthropic refresh tokens rotate — one family tolerates exactly
+ * one rotator, and a second one trips reuse-detection and revokes the family
+ * everywhere (HOU-950). So the freshly minted family is handed off
+ * EXCLUSIVELY: once pushed, the gateway is its only holder, which is why the
+ * handoff-dir copy is discarded the moment the push settles (success or
+ * terminal failure). There is deliberately no path that re-pushes a cached
+ * snapshot later — a failed handoff means the user reconnects from the card,
+ * minting a new family.
  *
  * With NO agent selected (first-run onboarding, the cloud-migration wizard)
  * the push goes to the gateway's agentless SETUP runtime instead — same
@@ -17,9 +27,7 @@
  *
  * The push RETRIES transient failures (engine 5xx, network) with backoff
  * before ever degrading — a waking pod or a momentary gateway blip must not
- * cost the user a manual token paste. And because the minted credential stays
- * cached on this machine, {@link pushCachedClaudeCredential} lets a later
- * session finish a failed handoff silently (see claude-login.ts's reconcile).
+ * cost the user a manual token paste.
  *
  * SAFETY: this ships unsupervised, so EVERY user-initiated failure here
  * (extraction not-found, malformed cred, push non-200 after retries, network)
@@ -36,7 +44,10 @@ import {
 import { getEngine } from "./engine";
 import i18n from "./i18n";
 import { logger } from "./logger";
-import { osReadClaudeCredential } from "./os-bridge";
+import {
+  osDiscardClaudeHandoffCredential,
+  osReadClaudeCredential,
+} from "./os-bridge";
 import { providerLoginFailureText } from "./provider-login-error";
 
 /** Announce the outcome on the client bus (same shape as claude-login's own). */
@@ -58,7 +69,6 @@ type ClaudeCredentialPusher = {
   pushClaudeOAuthCredential?: (
     agentId: string | null,
     credentialJson: string,
-    opts?: { ifAbsent?: boolean },
   ) => Promise<void>;
 };
 
@@ -69,26 +79,21 @@ export type ClaudeHandoffResult =
   | { ok: false; reason: "no-credential" | "push-failed"; error: unknown };
 
 /**
- * Read this machine's cached Claude credential and push it to the cloud —
- * the selected agent's pod, else the first loaded agent's (credentials are
- * workspace-central, any real pod stores and serves them), else the agentless
- * setup runtime (true first-run). Retries transient failures with backoff.
- * Never throws; the caller decides how loud the outcome is.
+ * Read the handoff dir's freshly minted Claude credential and push it to the
+ * cloud — the selected agent's pod, else the first loaded agent's (credentials
+ * are workspace-central, any real pod stores and serves them), else the
+ * agentless setup runtime (true first-run). Retries transient failures with
+ * backoff. Never throws; the caller decides how loud the outcome is.
  *
- * `ifAbsent` (the background RECONCILE): the cached credential may be an OLD
- * snapshot whose refresh token the gateway has since rotated — overwriting the
- * live central credential with it makes the gateway's next refresh trip
- * Anthropic's refresh-token-reuse detection and revoke the whole token family
- * (HOU-855). Fill-only: the push is a no-op when a central credential already
- * exists. The fresh-login path omits it (a just-minted credential SHOULD
- * replace whatever is stored).
+ * A fresh mint always REPLACES whatever the central store holds — the user
+ * just authorized this space, and the old row's family (if any) simply stops
+ * being rotated once overwritten, which Anthropic treats as abandonment, not
+ * reuse.
  */
-export async function pushCachedClaudeCredential(opts?: {
-  ifAbsent?: boolean;
-}): Promise<ClaudeHandoffResult> {
+async function pushMintedClaudeCredential(): Promise<ClaudeHandoffResult> {
   let credentialJson: string;
   try {
-    credentialJson = await osReadClaudeCredential();
+    credentialJson = await osReadClaudeCredential(true);
   } catch (err) {
     return { ok: false, reason: "no-credential", error: err };
   }
@@ -103,7 +108,7 @@ export async function pushCachedClaudeCredential(opts?: {
     }
     for (let attempt = 0; ; attempt++) {
       try {
-        await engine.pushClaudeOAuthCredential(agentId, credentialJson, opts);
+        await engine.pushClaudeOAuthCredential(agentId, credentialJson);
         return { ok: true };
       } catch (err) {
         const delay = PUSH_RETRY_DELAYS_MS[attempt];
@@ -120,16 +125,35 @@ export async function pushCachedClaudeCredential(opts?: {
 }
 
 /**
- * Extract this machine's freshly-cached Anthropic credential and push it to
- * the cloud, then confirm the connection. Any failure falls back to the paste
- * flow. Never rejects.
+ * Destroy the handoff dir's local copy once the push has settled. On success
+ * the gateway is the family's sole rotator and the copy is a revocation
+ * hazard; on failure the mint is abandoned (never re-pushed), so the copy is
+ * dead weight either way. A deletion failure is only logged: the leftover is
+ * inert (nothing reads or rotates the handoff dir outside a login) and the
+ * next login overwrites it — not worth interrupting a flow that succeeded.
+ */
+async function discardHandoffCopy(): Promise<void> {
+  try {
+    await osDiscardClaudeHandoffCredential();
+  } catch (err) {
+    logger.warn(
+      `[claude-login] could not discard the handed-off credential copy: ${String(err)}`,
+    );
+  }
+}
+
+/**
+ * Extract the freshly minted Anthropic credential from the handoff dir, push
+ * it to the cloud, and destroy the local copy, then confirm the connection.
+ * Any failure falls back to the paste flow. Never rejects.
  */
 export async function finishRemoteClaudeLogin(
   frontendProviderId: string,
   confirmConnected: Confirm,
   announce: Announce,
 ): Promise<void> {
-  const result = await pushCachedClaudeCredential();
+  const result = await pushMintedClaudeCredential();
+  await discardHandoffCopy();
   if (!result.ok) {
     fallbackToPaste(frontendProviderId, result.error, announce);
     return;

--- a/app/src/lib/claude-login.ts
+++ b/app/src/lib/claude-login.ts
@@ -16,23 +16,30 @@
  *
  * TOPOLOGY: the SAME browser login runs on this machine for both a co-located
  * and a remote engine (`shouldUseClaudeDesktopLogin` is now any Tauri desktop).
- * What differs is what happens AFTER `claude-login://done` with success:
- *   * CO-LOCATED — the credential the desktop just cached is the very dir the
- *     local runtime reads, so we only poll until the runtime reads it connected.
- *   * REMOTE (hosted pod) — the pod can't read this machine's Keychain, so we
- *     EXTRACT the cached credential and PUSH it to the pod (see
- *     `claude-login-remote.ts`), then poll. Any failure there degrades to the
- *     setup-token paste flow, never a dead spinner.
+ * What differs is WHERE the credential is minted and what happens AFTER
+ * `claude-login://done` with success:
+ *   * CO-LOCATED — the login caches into the shared dir the local runtime
+ *     reads, so we only poll until the runtime reads it connected. That
+ *     credential's refresh-token family stays local: the CLI is its only
+ *     rotator, and it is NEVER pushed anywhere.
+ *   * REMOTE (hosted pod) — the pod can't read this machine's Keychain, so the
+ *     login mints into a throwaway HANDOFF dir, we EXTRACT the credential and
+ *     PUSH it to the pod (see `claude-login-remote.ts`), destroy the local
+ *     copy, then poll. From the push on, the gateway is that family's ONLY
+ *     rotator (HOU-950 — a second rotator trips Anthropic's refresh-token-reuse
+ *     detection and revokes the family, signing the user out everywhere). Any
+ *     failure degrades to the setup-token paste flow, never a dead spinner.
+ *
+ * Each space the user connects therefore gets its OWN freshly minted token
+ * family. There is deliberately NO path that seeds a space from a cached
+ * credential snapshot: the old background reconcile did exactly that and was
+ * how one family ended up behind several rotating stores (HOU-950 root cause).
  */
 
-import {
-  finishRemoteClaudeLogin,
-  pushCachedClaudeCredential,
-} from "./claude-login-remote";
+import { finishRemoteClaudeLogin } from "./claude-login-remote";
 import { isRemoteEngine } from "./engine";
 import { publishLocalHoustonEvent } from "./events";
 import i18n from "./i18n";
-import { logger } from "./logger";
 import {
   legacyListen,
   osCancelClaudeLogin,
@@ -108,54 +115,6 @@ async function confirmConnected(provider: string): Promise<boolean> {
   return false;
 }
 
-// One reconcile attempt per app session — it runs on the login surface's
-// mount, and a failed background push must not turn into a retry loop.
-let reconcileRan = false;
-
-/**
- * Silently finish an EARLIER browser login whose cloud handoff failed. The
- * `claude` CLI cached the minted credential on this machine, so when the
- * hosted engine still reads anthropic as disconnected (the push failed — e.g.
- * the gateway was unavailable at the time), the user's intent can be
- * completed WITHOUT re-running the browser flow or asking for a token paste:
- * re-push the cached credential and, on success, announce the normal
- * completion so the provider card flips.
- *
- * Background reconciliation, not a user action: failures are logged, never
- * toasted (the user retries from the connect card whenever they choose).
- * One-shot per session; no-op off-desktop-hosted or when nothing is cached.
- */
-export async function reconcileClaudeCredentialHandoff(): Promise<void> {
-  if (reconcileRan || !isRemoteEngine()) return;
-  reconcileRan = true;
-  try {
-    const status = await tauriProvider.checkStatus("anthropic");
-    if (status.authenticated) return; // nothing to finish
-  } catch {
-    return; // engine unreachable — nothing to reconcile against
-  }
-  // Fill-only: this cached snapshot may predate gateway refresh-token
-  // rotations, and clobbering the live central credential with it would
-  // revoke the whole token family (HOU-855). When a central credential
-  // already exists the push no-ops and the confirm below decides the outcome.
-  const result = await pushCachedClaudeCredential({ ifAbsent: true });
-  if (!result.ok) {
-    if (result.reason === "push-failed") {
-      logger.warn(
-        `[claude-login] background credential reconcile failed: ${String(result.error)}`,
-      );
-    }
-    return;
-  }
-  const ok = await confirmConnected("anthropic");
-  if (ok) {
-    logger.info(
-      "[claude-login] finished an earlier Claude sign-in from the cached credential",
-    );
-    announce("anthropic", true, null);
-  }
-}
-
 /**
  * Drive the desktop Claude browser sign-in end to end. Resolves once the flow
  * has STARTED (the native helper spawned); the outcome arrives asynchronously as
@@ -167,6 +126,10 @@ export async function reconcileClaudeCredentialHandoff(): Promise<void> {
 export async function beginClaudeBrowserLogin(
   frontendProviderId: string,
 ): Promise<void> {
+  // Pinned for the whole attempt: it decides the mint dir (handoff vs the
+  // engine-shared one) AND the completion branch, and those must agree even if
+  // the engine target were to change mid-login.
+  const handoff = isRemoteEngine();
   let unlisten: (() => void) | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let settled = false;
@@ -210,9 +173,10 @@ export async function beginClaudeBrowserLogin(
           announce(frontendProviderId, false, error);
           return;
         }
-        if (isRemoteEngine()) {
-          // Remote pod: extract this machine's cred + push it, then confirm.
-          // Guarantees fallback-to-paste on any failure inside.
+        if (handoff) {
+          // Remote pod: extract the handoff-dir cred + push it (the local copy
+          // is destroyed after the push settles), then confirm. Guarantees
+          // fallback-to-paste on any failure inside.
           void finishRemoteClaudeLogin(
             frontendProviderId,
             confirmConnected,
@@ -251,7 +215,7 @@ export async function beginClaudeBrowserLogin(
   }, LOGIN_TIMEOUT_MS);
 
   try {
-    await osStartClaudeLogin();
+    await osStartClaudeLogin(handoff);
   } catch (err) {
     if (settled) return;
     cleanup();

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -133,24 +133,38 @@ export function osStartCodexOauthLoopback(): Promise<void> {
 
 /** Run `claude auth login --claudeai` FOR the user on the desktop (zero
  * terminal): the native side spawns the bundled `claude`, which opens the
- * browser and catches its own callback, caching the credential in Houston's
- * shared login dir (the same `CLAUDE_CONFIG_DIR` the engine reads). Emits
- * `claude-login://url` (the authorize URL, as a fallback for the "didn't open"
- * link) and `claude-login://done` (`{ success, error }`). Rejects only on an
- * up-front spawn failure. Desktop + co-located engine only. */
-export function osStartClaudeLogin(): Promise<void> {
-  return invoke<void>("start_claude_login");
+ * browser and catches its own callback. `handoff: false` (co-located engine)
+ * caches into Houston's shared login dir — the same `CLAUDE_CONFIG_DIR` the
+ * engine reads. `handoff: true` (remote engine) mints into a separate
+ * throwaway handoff dir instead: the credential's refresh-token family will be
+ * owned by the gateway alone, so it must never be visible to a co-located
+ * engine (HOU-950). Emits `claude-login://url` (the authorize URL, as a
+ * fallback for the "didn't open" link) and `claude-login://done`
+ * (`{ success, error }`). Rejects only on an up-front spawn failure. */
+export function osStartClaudeLogin(handoff: boolean): Promise<void> {
+  return invoke<void>("start_claude_login", { handoff });
 }
 
-/** Extract the Anthropic OAuth credential the `claude` CLI just cached for
- * Houston's shared login dir, as the CLI's `.credentials.json` JSON string
- * (`{claudeAiOauth:{...}}`). Used ONLY for a REMOTE engine: the desktop pushes
- * the extracted cred to the pod (which can't read this machine's Keychain). The
- * native side reads `<claudeLoginConfigDir>/.credentials.json` or, on macOS, the
- * `"Claude Code-credentials"` Keychain item; rejects (never a silent empty) on
- * not-found / parse failure so the caller can fall back to the paste flow. */
-export function osReadClaudeCredential(): Promise<string> {
-  return invoke<string>("read_claude_credential");
+/** Extract the Anthropic OAuth credential the `claude` CLI just cached, as the
+ * CLI's `.credentials.json` JSON string (`{claudeAiOauth:{...}}`). Used ONLY
+ * for a REMOTE engine (`handoff: true`, the same dir the matching login minted
+ * into): the desktop pushes the extracted cred to the pod (which can't read
+ * this machine's Keychain). The native side reads the dir's
+ * `.credentials.json` or, on macOS, its dir-scoped Keychain item; rejects
+ * (never a silent empty) on not-found / parse failure so the caller can fall
+ * back to the paste flow. */
+export function osReadClaudeCredential(handoff: boolean): Promise<string> {
+  return invoke<string>("read_claude_credential", { handoff });
+}
+
+/** Destroy the handoff dir's cached Claude credential (file + Keychain item)
+ * once the push to the gateway has settled: from then on the gateway is the
+ * refresh-token family's ONLY rotator, and any surviving local copy is a
+ * revocation hazard (HOU-950). Idempotent; rejects with the real reason on a
+ * genuine deletion failure (the leftover is inert — nothing reads the handoff
+ * dir outside the login flow — so callers log rather than toast). */
+export function osDiscardClaudeHandoffCredential(): Promise<void> {
+  return invoke<void>("discard_claude_handoff_credential");
 }
 
 /** Relay a pasted authorization code to the in-flight desktop Claude sign-in.

--- a/knowledge-base/anthropic-credentials.md
+++ b/knowledge-base/anthropic-credentials.md
@@ -35,14 +35,23 @@ the traps at the bottom — read them before touching any of this.
   link back to the app — the app watches the CLI's stdout/exit. The `visit:`
   URL line is OSC-8 hyperlink-wrapped by current CLIs; `resolve.rs` strips that
   before parsing.
-- **Remote/cloud handoff** (`app/src/lib/claude-login-remote.ts`): after the
-  local login, `read_claude_credential` (Rust) extracts the cached credential —
-  file first, then the Keychain item `Claude Code-credentials-<sha256(dir)[:8]>`
-  (the CLI scopes the service name by config dir; account = username) — and
-  pushes it: host route `POST /agents/:id/credential/claude-oauth` → central
-  store put (access + refresh) + materialize on the pod. Any failure degrades
-  to the setup-token paste dialog (deliberate last resort; also the only path
-  for a pure-web client, which has no local CLI).
+- **Remote/cloud handoff** (`app/src/lib/claude-login-remote.ts`): a
+  remote-engine login mints into a THROWAWAY handoff dir
+  (`<HOUSTON_HOME>/claude-login-handoff`, `start_claude_login` with
+  `handoff: true`) — never the engine-shared dir. `read_claude_credential`
+  (Rust) extracts it — file first, then the Keychain item
+  `Claude Code-credentials-<sha256(dir)[:8]>` (the CLI scopes the service name
+  by config dir; account = username) — and pushes it: host route
+  `POST /agents/:id/credential/claude-oauth` → central store put (access +
+  refresh) + materialize on the pod. Once the push settles the local copy is
+  DESTROYED (`discard_claude_handoff_credential`): the gateway is that
+  family's only rotator from then on. Every space the user connects mints its
+  own family this way; there is deliberately NO path that seeds a space from a
+  cached snapshot (the old `?if_absent=1` background reconcile did exactly
+  that and was the HOU-950 root cause — the host still honors the flag for
+  older clients, but nothing current sends it). Any failure degrades to the
+  setup-token paste dialog (deliberate last resort; also the only path for a
+  pure-web client, which has no local CLI).
 - **Per-turn serve (managed cloud)**: the pod's serve sync
   (`packages/runtime/src/auth/serve.ts`) probes anthropic like every provider;
   the pod host serves a gateway-refreshed ACCESS-ONLY token
@@ -68,11 +77,17 @@ the traps at the bottom — read them before touching any of this.
    `packages/host/src/routes/credential.ts`) — a desktop host serving its
    stale durability-marker entry would shadow the working Keychain login.
 4. **One refresh-token family = one rotator.** Anthropic rotates the refresh
-   token on every use and invalidates the old one. The gateway is the single
-   rotator for pods; the desktop CLI is the single rotator locally; the
+   token on every use and invalidates the old one; REUSING a stale one revokes
+   the whole family, signing the user out everywhere. The gateway is the
+   single rotator for pods; the desktop CLI is the single rotator locally; the
    central-store copy on a desktop host is an inert marker (never served,
    never refreshed — TS `credentials/refresh.ts` deliberately has no anthropic
-   entry).
+   entry). HOU-950 corollary: a family must never be COPIED between rotating
+   stores — a remote login mints in the handoff dir and the local copy dies
+   after the push (exclusive handoff), and cached snapshots are never pushed.
+   No locking or freshness check makes a shared family safe; the invalidation
+   happens at Anthropic. Separate spaces get separate families (Anthropic
+   allows many concurrent families per account).
 5. **Windows: the CLI needs a shell BEFORE it does anything — even
    `auth login`.** At startup on Windows the CLI exits 1 unless it finds Git
    Bash or PowerShell (`pwsh` on PATH → three pwsh install dirs → plain

--- a/packages/web/src/engine-adapter/client/provider-credentials-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-credentials-mixin.ts
@@ -50,7 +50,6 @@ export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
     async pushClaudeOAuthCredential(
       agentId: string | null,
       credentialJson: string,
-      opts?: { ifAbsent?: boolean },
     ): Promise<void> {
       if (!this.ctx.cp) {
         throw new Error("Pushing a Claude credential needs a cloud engine.");
@@ -60,14 +59,12 @@ export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
           this.ctx.cp,
           agentId,
           credentialJson,
-          opts,
         );
         return;
       }
       await controlPlane.pushSetupClaudeOAuthCredential(
         this.ctx.cp,
         credentialJson,
-        opts,
       );
     }
 

--- a/packages/web/src/engine-adapter/cp/credentials.ts
+++ b/packages/web/src/engine-adapter/cp/credentials.ts
@@ -25,36 +25,28 @@ export async function captureCredential(
 }
 
 /**
- * Push a desktop-extracted Anthropic OAuth credential to the agent's pod. The
- * body is the `claude` CLI's `.credentials.json` shape (`{claudeAiOauth:{...}}`),
- * already a JSON string; the host stores it centrally and materializes it on the
- * pod PVC. Used ONLY for a REMOTE engine — a hosted pod can't read this machine's
- * Keychain, so the co-located desktop (which shares the credential dir with its
- * local runtime) never calls this. Resolves on 200; throws the host's reason
- * otherwise so the caller can degrade to the paste flow.
+ * Push the desktop's freshly minted Anthropic OAuth credential to the agent's
+ * pod. The body is the `claude` CLI's `.credentials.json` shape
+ * (`{claudeAiOauth:{...}}`), already a JSON string; the host stores it
+ * centrally and materializes it on the pod PVC. Used ONLY for a REMOTE engine
+ * — a hosted pod can't read this machine's Keychain, so the co-located desktop
+ * (which shares the credential dir with its local runtime) never calls this.
+ * Always a fresh mint whose family the gateway will own exclusively — the old
+ * `?if_absent=1` fill-only push of a CACHED snapshot is gone with the
+ * background reconcile (HOU-950; the host still honors the flag for older
+ * clients). Resolves on 200; throws the host's reason otherwise so the caller
+ * can degrade to the paste flow.
  */
 export async function pushClaudeOAuthCredential(
   cfg: ControlPlaneConfig,
   agentId: string,
   credentialJson: string,
-  opts?: { ifAbsent?: boolean },
 ): Promise<void> {
   await cpFetch(
     cfg,
-    `/agents/${encodeURIComponent(agentId)}/credential/claude-oauth${ifAbsentQuery(opts)}`,
+    `/agents/${encodeURIComponent(agentId)}/credential/claude-oauth`,
     { method: "POST", body: credentialJson },
   );
-}
-
-/**
- * `?if_absent=1` marks a fill-only push of a CACHED credential snapshot (the
- * reconcile): the host must never overwrite a live central credential whose
- * refresh token the gateway may have rotated since the snapshot was cached
- * (HOU-855). A fresh browser login omits it and overwrites. Rides the query
- * string so the CLI's credential JSON is forwarded byte-verbatim as the body.
- */
-function ifAbsentQuery(opts?: { ifAbsent?: boolean }): string {
-  return opts?.ifAbsent ? "?if_absent=1" : "";
 }
 
 /**
@@ -145,16 +137,11 @@ export async function getTunnelCredentials(
 export async function pushSetupClaudeOAuthCredential(
   cfg: ControlPlaneConfig,
   credentialJson: string,
-  opts?: { ifAbsent?: boolean },
 ): Promise<void> {
-  await cpFetch(
-    cfg,
-    `/setup-runtime/credential/claude-oauth${ifAbsentQuery(opts)}`,
-    {
-      method: "POST",
-      body: credentialJson,
-    },
-  );
+  await cpFetch(cfg, `/setup-runtime/credential/claude-oauth`, {
+    method: "POST",
+    body: credentialJson,
+  });
 }
 
 /** Connect-once capture on the setup runtime — `captureCredential`, agentless. */

--- a/packages/web/src/shims/tauri-core.ts
+++ b/packages/web/src/shims/tauri-core.ts
@@ -235,6 +235,7 @@ export async function invoke<T = unknown>(
     case "submit_claude_login_code": // relays a pasted code to the desktop `claude` child's stdin
     case "complete_claude_login_from_clipboard": // desktop clipboard probe for the sign-in auto-finish
     case "read_claude_credential": // reads this machine's Keychain/cred file; web has neither
+    case "discard_claude_handoff_credential": // destroys the desktop's handed-off credential copy; web never minted one
 
     case "get_engine_handshake": // web injects window.__HOUSTON_ENGINE__ directly
     // The guided "connect a local model" bridge scans localhost and runs an


### PR DESCRIPTION
Fixes the root cause of HOU-954 / HOU-950 item A: users signed out of their Claude subscription mid-session (Sentry HOUSTON-APP-4YA, ~4k events / 58 users, all managed-cloud).

## Root cause

Anthropic OAuth refresh tokens are single-use and rotating; reusing a stale one revokes the **entire token family** — every copy, everywhere. The only safe shape is one rotator per family, and two client paths broke it for individual users:

1. **Shared mint dir.** A remote-engine browser login minted the credential into the same `claude-login` config dir a co-located engine reads, then pushed it to the gateway. Both the gateway and the local CLI could rotate that one family.
2. **Cached-snapshot seeding.** `reconcileClaudeCredentialHandoff` silently pushed the desktop's cached credential to any cloud space that read disconnected. The confirmed staging incident (HOU-950) shows such a snapshot arriving dead: `PUT` accepted at 14:26:15.523, row deleted at 14:26:15.957 on `invalid_grant`, zero real OAuth handshakes in 90 minutes.

No locking or freshness check can make a shared family safe — the invalidation happens at Anthropic. Separate families need zero coordination, and Anthropic allows many per account.

## The fix: one fresh family per space, handed off exclusively

- **Rust** (`app/src-tauri/src/claude_login/`): `start_claude_login` / `read_claude_credential` gain a `handoff` mode that mints into a throwaway `claude-login-handoff` config dir — never the engine-shared one. New `discard_claude_handoff_credential` command destroys the local copy (file + dir-scoped Keychain items) once the push settles, making the gateway the family's **only** rotator.
- **TS** (`app/src/lib/claude-login*.ts`): the remote flow reads the handoff mint, pushes it, and always discards the local copy (success or terminal failure). The background reconcile and its `?if_absent=1` client plumbing are **deleted** — no cloud space is ever seeded from a cached snapshot again. The host still honors `if_absent` for older clients.
- Co-located logins are unchanged: the shared dir stays the local engine's credential, rotated only by the CLI, never pushed.
- `knowledge-base/anthropic-credentials.md` updated (flows + trap #4).

Existing users are never force-disconnected: a legacy shared family that eventually revokes lands on the honest reconnect prompt (cloud#188 / cloud#190 / #1106), and reconnecting mints a clean single-rotator family — each incident permanently heals that user.

## Before the fix (repro)

1. On a desktop app pointed at a hosted engine, connect Claude via the browser login; the minted family is now held by both the gateway (rotating per serve) and this machine's `claude-login` dir.
2. Use a co-located engine on the same machine (or let anything refresh the local copy): the next refresh on either side gets `invalid_grant`, Anthropic revokes the family, and every space using it flips to signed-out — the HOUSTON-APP-4YA event.
3. Variant: with a disconnected cloud space, relaunching the app fired the one-shot reconcile and pushed the stale local snapshot; the gateway accepted then deleted it on first refresh (the HOU-950 staging timeline).

## After the fix (verify)

1. Same setup: connect Claude in a cloud space. Observe the login spawn logs `CLAUDE_CONFIG_DIR=…/claude-login-handoff`, the push lands, and afterwards the handoff dir has no `.credentials.json` and no `Claude Code-credentials-<hash>` Keychain item (`security find-generic-password -s <service>` → not found).
2. The shared `claude-login` dir is untouched by the remote flow; a co-located engine keeps its own working login independently.
3. Relaunching the app with a disconnected cloud space no longer pushes anything — the space honestly shows the connect card until the user connects it (each connect = a fresh browser approval, one click when already signed into claude.ai).
4. Metric: HOUSTON-APP-4YA event rate trends to zero for non-team users as legacy families cycle out (each revocation now heals permanently instead of recurring).

Gates: Biome clean, `pnpm typecheck` (all projects, shim parity 45/45), `cargo test` 185 passed (9 new claude_login assertions), app node:test 2087 passed, host/runtime/domain vitest green, `pnpm check:boundaries` OK.

Out of scope (tracked in HOU-950): the teams/multi-space credential-ownership product decision, and gateway-side alerting on `credential_revoked*`.
