### PR TITLE
fix(web): webhook-key mint routed to the gateway + dev GW_PUBLIC_BASE_URL (HOU-807)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -40,6 +40,10 @@ FIREBASE_AUTH_DOMAIN=gethouston.firebaseapp.com
 GW_PORT=9080
 GW_DB_URL=postgres://postgres:houston@127.0.0.1:5433/postgres
 GW_AUTH_GCIP_PROJECT=gethouston
+# The gateway's own public origin, as a CALLER reaches it. It is the base for
+# minted incoming-webhook addresses (Routines tab → "Create webhook address")
+# and the A2A card URL — without it the webhook mint route answers 503 in dev.
+GW_PUBLIC_BASE_URL=http://localhost:9080
 # Browser-origin allowlist (exact match): the web pane, the desktop app's dev
 # webview (:1420, for DEV_DESKTOP_PROFILE=cloud), and the packaged-webview
 # origins. The Tauri webview IS a browser client to the gateway.

--- a/packages/web/src/engine-adapter/cp/board.ts
+++ b/packages/web/src/engine-adapter/cp/board.ts
@@ -130,9 +130,13 @@ export async function mintRoutineWebhookKey(
   routineId: string,
 ): Promise<WebhookKeyReveal | null> {
   try {
+    // The mint is a GATEWAY control route (`/v1/agents/…`, like trigger-status)
+    // — NOT an agent-proxy path: `agentPath()` would forward it to the engine
+    // pod, which never serves webhook keys, and its 404 would read as "this
+    // host can't mint" on a gateway that can (HOU-807).
     const res = await cpFetch(
       cfg,
-      `${agentPath(agentId)}/routines/${encodeURIComponent(routineId)}/webhook-key`,
+      `/v1/agents/${encodeURIComponent(agentId)}/routines/${encodeURIComponent(routineId)}/webhook-key`,
       { method: "POST" },
     );
     return (await res.json()) as WebhookKeyReveal;


### PR DESCRIPTION
Two fixes for the Routines-tab webhook flow (companion: gethouston/cloud#191).

## 1. The real bug — every "Create webhook address" click failed with "Update needed" (dev AND hosted cloud)

The cloud adapter built the mint URL with `agentPath()` — the agent-proxy shape (`/agents/:slug/…`) the gateway forwards to the engine pod. The pod never serves webhook keys, so its 404 came back through the client's degrade path as "this host predates minting", and the chip toasted **"Update needed — Creating a webhook address needs the latest version of Houston"** on every click. Caught live in the dev gateway's request log:

```
POST /agents/3c8b…/routines/378c…/webhook-key          ← app request (no /v1)
  → engine proxy → upstream /agents/Personal%2FPersonal%20Assistant/… → 404
```

The mint is a gateway control route, exactly like `agentTriggerStatus` one file over: `/v1/agents/:slug/routines/:id/webhook-key`. Every other `agentPath()` call in `cp/board.ts` is a genuine pod route (activities, routines CRUD, runs) and stays.

## 2. Dev loop: `GW_PUBLIC_BASE_URL=http://localhost:9080` in `.env.development`

The mint route builds the returned address from `GW_HOOKS_PUBLIC_URL → GW_WEBHOOK_PUBLIC_URL → GW_PUBLIC_BASE_URL`; the dev loop set none, so even a correctly-routed mint would 503 locally. Committed per the features-default-on rule — the dev gateway's public origin IS localhost:9080.

## Verify

Dev loop with cloud#191: create a webhook routine → chip shows "Create webhook address" within a few seconds → click → the reveal dialog shows `http://localhost:9080/v1/hooks/…` + secret → status flips Active → `curl -X POST <url>` fires the routine.