### PR TITLE
feat: @mentions in shared chats + relevance-scoped notifications

### DIFF
--- a/app/src-tauri/src/houston_prompt/base.rs
+++ b/app/src-tauri/src/houston_prompt/base.rs
@@ -29,6 +29,7 @@ Assume the user is smart and busy, but not technical.
 - Briefly explain why you need missing information or an integration.
 - Report outcomes, choices, blockers, and approval requests. Do not narrate implementation steps.
 - For long-running or risky work, give short status updates in user language.
+- In a chat shared with several people, when what you say next needs one particular person to confirm or decide, address that person by writing "@" and their name, for example "@Dana please confirm and I'll send it".
 
 # Interaction Procedure
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -21,6 +21,7 @@ import { useCanCreateAgents } from "./hooks/use-can-create-agents";
 import { useHoustonInit } from "./hooks/use-houston-init";
 import { useIntegrationSessionSync } from "./hooks/use-integration-session-sync";
 import { useLocalBridgeAutoReconnect } from "./hooks/use-local-bridge-autoreconnect";
+import { useMentionNotifications } from "./hooks/use-mention-notifications";
 import { useMigrationReconnect } from "./hooks/use-migration-reconnect";
 import { useMoveResume } from "./hooks/use-move-resume";
 import { useNotificationNudges } from "./hooks/use-notification-nudges";
@@ -28,6 +29,7 @@ import { useOnboardingCompleted } from "./hooks/use-onboarding-completed";
 import { useOnboardingPending } from "./hooks/use-onboarding-pending";
 import { useOnboardingSegment } from "./hooks/use-onboarding-segment";
 import { useProviderCatalog } from "./hooks/use-provider-catalog";
+import { useReadCursorTracker } from "./hooks/use-read-cursors";
 import { SessionUnavailableError, useSession } from "./hooks/use-session";
 import { useSessionEvents } from "./hooks/use-session-events";
 import { analytics } from "./lib/analytics";
@@ -59,6 +61,11 @@ export default function App() {
   const authConfigured = isIdentityConfigured();
   useHoustonInit();
   useSessionEvents();
+  // HOU-945: ping on @mentions, and remember which missions have been read so
+  // the sidebar can show what is new for THIS person. Both ride the query cache
+  // passively (no observers, no fetches) — see their module docs.
+  useMentionNotifications();
+  useReadCursorTracker();
   useNotificationNudges();
   useAgentInvalidation();
   useAnalyticsSubscriber();

--- a/app/src/components/board/board-source.ts
+++ b/app/src/components/board/board-source.ts
@@ -1,5 +1,5 @@
 import type { KanbanItem, NewPanelOpener } from "@houston-ai/board";
-import type { FeedItem } from "@houston-ai/chat";
+import type { FeedItem, MessageMention } from "@houston-ai/chat";
 import type { ReactNode } from "react";
 import type { HistoryLoadOptions } from "../../lib/tauri";
 import type { TurnMode } from "../../lib/turn-mode";
@@ -22,14 +22,19 @@ import type { Agent, AgentDefinition } from "../../lib/types";
  * one presentational/wiring component, two injected data backends.
  */
 
-/** Provider/model override pair, forwarded to a send/create so the wire
- *  mirrors the model the composer dropdown is showing (never silently
- *  re-resolved by the engine). */
+/** Everything a user-typed send carries beside its text and files: the
+ *  provider/model pair (so the wire mirrors the model the composer dropdown is
+ *  showing, never silently re-resolved by the engine), the turn-mode pin, and
+ *  the teammates the message named. */
 export interface SendOverrides {
   providerOverride: string;
   modelOverride: string;
   /** Turn mode pin for user-typed sends; absent = execute. */
   modeOverride?: TurnMode;
+  /** Teammates this message @mentions (HOU-944). Per-send, not a composer
+   *  setting: it comes from the submit, not the toolbar. Absent on an
+   *  agent-initiated send (retry, auto-resume, routine). */
+  mentions?: MessageMention[];
 }
 
 /**

--- a/app/src/components/board/mentions-inbox-model.ts
+++ b/app/src/components/board/mentions-inbox-model.ts
@@ -1,0 +1,113 @@
+import { isSetupChatMode } from "../../lib/integration-chat-setup.ts";
+import { latestMentionFor } from "../../lib/mission-relevance.ts";
+import {
+  cursorKey,
+  mentionReadFloorFor,
+  type ReadCursorStore,
+} from "../../lib/read-cursors.ts";
+import {
+  isUnreadForMe,
+  type UnreadConversationInput,
+} from "../../lib/unread-model.ts";
+
+/**
+ * Pure, DOM-free model for the Mentions inbox (HOU-945): every mission where a
+ * teammate typed my name, newest first.
+ *
+ * It is the one surface in the feature that is a LIST rather than a badge, so
+ * its ordering is part of the contract: a row that reshuffles between renders
+ * is a row the user misclicks. Hence the deterministic tiebreak on conversation
+ * id, and hence the whole model living outside the component where it can be
+ * asserted on directly.
+ *
+ * Display names are NOT resolved here. Mentions carry user ids; turning an id
+ * into a name and an avatar is a React Query lookup, and dragging it in would
+ * cost this module its node-testability for no gain — the renderer already has
+ * the profile map.
+ *
+ * Every row carries TWO unread claims, because the two surfaces reading them ask
+ * different questions and one answer cannot serve both:
+ *
+ * - `unread` — "there is something new for me in this mission": an outstanding
+ *   @mention OR ambient movement past my read cursor ({@link isUnreadForMe}, the
+ *   same verdict the board card and the sidebar paint). The ROW's dot reads it,
+ *   and reading it broadly is right there: the dot promises news, not a name.
+ * - `mentionOutstanding` — "somebody typed my name and I have not been back
+ *   since". The toolbar PILL reads this one, and only this one.
+ *
+ * Collapsing them would make the pill lie. Its accessible name is literally "N
+ * unread mentions", so a mission that merely MOVED would inflate a number the
+ * user reads as "N people typed my name" — the one count in the product that has
+ * to mean exactly that, or the whole mention signal becomes noise.
+ */
+
+export interface MentionInboxConversation extends UnreadConversationInput {
+  title: string;
+  agent_name: string;
+  session_key: string;
+}
+
+/** One row of the Mentions inbox. */
+export interface MentionInboxRow {
+  conversationId: string;
+  agentPath: string;
+  agentName: string;
+  sessionKey: string;
+  title: string;
+  /** Epoch ms of the mention. */
+  at: number;
+  /** Who mentioned me (user id); resolve the display name at render time. */
+  byUserId?: string;
+  /** Something new here for me, mention or ambient movement. The row's dot. */
+  unread: boolean;
+  /** A mention of me newer than my read cursor for this conversation — strictly
+   *  narrower than {@link MentionInboxRow.unread}. The toolbar pill's count. */
+  mentionOutstanding: boolean;
+}
+
+/**
+ * Every mission that @mentions me, newest mention first. Deterministic tiebreak
+ * on conversation id so the list never reshuffles between renders.
+ *
+ * `selfId === null` yields `[]`: with nobody signed in there is no "me" to be
+ * mentioned, and the inbox itself is a multiplayer surface that never renders
+ * on desktop. Guided setup chats are excluded like everywhere else — they have
+ * no board card to open, so a row for one would navigate nowhere.
+ */
+export function buildMentionInbox(
+  convs: readonly MentionInboxConversation[],
+  store: ReadCursorStore,
+  selfId: string | null,
+): MentionInboxRow[] {
+  if (selfId === null) return [];
+
+  const rows: MentionInboxRow[] = [];
+  for (const conv of convs) {
+    if (isSetupChatMode(conv.agent)) continue;
+    const latest = latestMentionFor(conv, selfId);
+    if (!latest) continue;
+    rows.push({
+      conversationId: conv.id,
+      agentPath: conv.agent_path,
+      agentName: conv.agent_name,
+      sessionKey: conv.session_key,
+      title: conv.title,
+      at: latest.at,
+      byUserId: latest.mention.by,
+      unread: isUnreadForMe(conv, store, selfId),
+      // The mention clause of `isUnreadForMe`, re-asked on its own: the same
+      // helpers, the same floor (no `since` fallback — a mention names me
+      // however old it is), the same strictly-after comparison. Sharing the
+      // helpers rather than a copied rule is what keeps the pill and the dot
+      // from drifting the next time either floor changes.
+      mentionOutstanding:
+        latest.at >
+        mentionReadFloorFor(store, cursorKey(conv.agent_path, conv.id)),
+    });
+  }
+
+  rows.sort(
+    (a, b) => b.at - a.at || a.conversationId.localeCompare(b.conversationId),
+  );
+  return rows;
+}

--- a/app/src/components/board/mentions-inbox-row.tsx
+++ b/app/src/components/board/mentions-inbox-row.tsx
@@ -1,0 +1,100 @@
+import { cn, Skeleton } from "@houston-ai/core";
+import { AtSign } from "lucide-react";
+import { PersonFace } from "../mission-person-face";
+import { formatRelativeTime } from "../organization/org-time";
+import type { MentionInboxRow } from "./mentions-inbox-model";
+
+/**
+ * One row of the Mentions inbox, in Mission Control's flat "plane" language:
+ * a transparent full-width button that fills on hover, never a bordered card.
+ *
+ * Layout is a fixed four-track line so read and unread rows stay optically
+ * aligned: a 8px unread rail, the mentioner's face, the mission title over the
+ * "who + where" line, and the relative time flushed right. The rail is always
+ * reserved (not conditionally rendered) because a dot that inserts itself would
+ * shift every unread title 20px to the right of its read neighbours.
+ *
+ * Unread is carried by the same quiet pair the sidebar uses, a filled
+ * `bg-action` dot plus a medium title. No colour beyond that: a mention is a
+ * claim on attention, not a status.
+ */
+export interface MentionRowLabels {
+  /** "Ana mentioned you", already resolved to a display name. */
+  by: string;
+  /** "in Finance". */
+  agent: string;
+}
+
+export function MentionsInboxRow({
+  row,
+  labels,
+  avatarLabel,
+  avatarUrl,
+  locale,
+  onOpen,
+}: {
+  row: MentionInboxRow;
+  labels: MentionRowLabels;
+  /** Display name behind the face. Never a raw user id. */
+  avatarLabel: string;
+  avatarUrl?: string;
+  locale: string;
+  onOpen: (row: MentionInboxRow) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(row)}
+      className="flex min-h-11 w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+    >
+      <span aria-hidden className="flex w-2 shrink-0 justify-center">
+        {row.unread && <span className="size-2 rounded-full bg-action" />}
+      </span>
+      {row.byUserId ? (
+        <PersonFace
+          person={{
+            id: row.byUserId,
+            label: avatarLabel,
+            ...(avatarUrl ? { imageUrl: avatarUrl } : {}),
+          }}
+        />
+      ) : (
+        <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-chip text-chip-text">
+          <AtSign className="size-3" />
+        </span>
+      )}
+      <span className="min-w-0 flex-1">
+        <span
+          className={cn(
+            "block truncate text-sm text-ink",
+            row.unread && "font-medium",
+          )}
+        >
+          {row.title}
+        </span>
+        <span className="block truncate text-xs text-ink-muted">
+          {`${labels.by} ${labels.agent}`}
+        </span>
+      </span>
+      <span className="shrink-0 text-xs text-ink-muted tabular-nums">
+        {formatRelativeTime(row.at, locale)}
+      </span>
+    </button>
+  );
+}
+
+/** Placeholder row mirroring {@link MentionsInboxRow}'s tracks, so the list
+ *  does not shift when the real rows land. */
+export function MentionsInboxRowSkeleton() {
+  return (
+    <div className="flex min-h-11 w-full items-center gap-3 px-3 py-2">
+      <span className="w-2 shrink-0" />
+      <Skeleton className="size-5 shrink-0 rounded-full" />
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <Skeleton className="h-3.5 w-1/2" />
+        <Skeleton className="h-3 w-1/3" />
+      </div>
+      <Skeleton className="h-3 w-10 shrink-0" />
+    </div>
+  );
+}

--- a/app/src/components/board/mentions-inbox-view-model.ts
+++ b/app/src/components/board/mentions-inbox-view-model.ts
@@ -1,0 +1,77 @@
+import type { UserProfile } from "../../hooks/queries/use-user-profiles.ts";
+import { shortUserLabel } from "../../lib/mission-people.ts";
+import type {
+  MentionInboxConversation,
+  MentionInboxRow,
+} from "./mentions-inbox-model.ts";
+
+/**
+ * The render-side rules of the Mentions inbox, kept pure and DOM-free beside
+ * the ordering model ({@link import("./mentions-inbox-model.ts")}) so each is
+ * asserted directly under plain node instead of through a rendered tree.
+ *
+ * All four answer questions the component must never improvise: how big a
+ * number may get before it breaks the toolbar line, which profiles to fetch,
+ * and — the load-bearing one — what to show for a person we only know by id.
+ */
+
+/**
+ * The unread count as it appears on the Mentions pill. Clamped because the
+ * control shares one line with the Mission Control title and the search field:
+ * a four-digit backlog would push the title off-screen, and past "lots" the
+ * exact number tells the user nothing they act on differently.
+ */
+export function mentionCountLabel(count: number): string {
+  return count > 99 ? "99+" : String(count);
+}
+
+/**
+ * The distinct mentioners across the inbox — the argument for the batched
+ * `useUserProfiles` lookup. Deduped so one teammate who pinged five times costs
+ * one profile, and stable in row order so the query key does not churn.
+ */
+export function mentionerIds(rows: readonly MentionInboxRow[]): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    if (!row.byUserId || seen.has(row.byUserId)) continue;
+    seen.add(row.byUserId);
+    ids.push(row.byUserId);
+  }
+  return ids;
+}
+
+/**
+ * Names the gateway already stamped onto missions, the fallback for a person
+ * whose profile has not resolved yet. First stored entry for an id wins, the
+ * same rule `buildMissionPeople` applies to face stacks, so a teammate cannot
+ * be called one thing on a board card and another in this list.
+ */
+export function storedContributorNames(
+  convs: readonly MentionInboxConversation[],
+): Map<string, string> {
+  const names = new Map<string, string>();
+  for (const conv of convs) {
+    for (const contributor of conv.contributors ?? []) {
+      if (contributor.name && !names.has(contributor.user_id)) {
+        names.set(contributor.user_id, contributor.name);
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * The display name for a mentioner: live profile, else the stored contributor
+ * name, else a short id slice. NEVER the raw id — our users are non-technical
+ * and a 36-character UUID in "…mentioned you" reads as a bug.
+ */
+export function resolveMentionerName(
+  userId: string,
+  profiles: ReadonlyMap<string, UserProfile>,
+  stored: ReadonlyMap<string, string>,
+): string {
+  return (
+    profiles.get(userId)?.name ?? stored.get(userId) ?? shortUserLabel(userId)
+  );
+}

--- a/app/src/components/board/mentions-inbox.tsx
+++ b/app/src/components/board/mentions-inbox.tsx
@@ -1,0 +1,172 @@
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@houston-ai/core";
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useAllConversations } from "../../hooks/queries";
+import { useUserProfiles } from "../../hooks/queries/use-user-profiles";
+import { useReadCursorStore } from "../../hooks/use-read-cursors";
+import { useSession } from "../../hooks/use-session";
+import { activityIdForSessionKey } from "../../lib/notification-nav";
+import type { Agent } from "../../lib/types";
+import { useAgentStore } from "../../stores/agents";
+import { useUIStore } from "../../stores/ui";
+import { MissionControlToolbar } from "../mission-control-toolbar";
+import {
+  buildMentionInbox,
+  type MentionInboxConversation,
+  type MentionInboxRow,
+} from "./mentions-inbox-model";
+import {
+  MentionsInboxRow,
+  MentionsInboxRowSkeleton,
+} from "./mentions-inbox-row";
+import {
+  mentionerIds,
+  resolveMentionerName,
+  storedContributorNames,
+} from "./mentions-inbox-view-model";
+
+/**
+ * Everything the inbox rows AND the toolbar's Mentions pill read, in one hook,
+ * so the number on the pill and the rows behind it are derived from one list.
+ * Both consumers share the one `useAllConversations` query, so mounting this
+ * twice costs no extra fetch.
+ *
+ * The pill counts `mentionOutstanding`, NOT the broader row `unread` flag: the
+ * pill says "N unread mentions" out loud, so counting a mission that merely
+ * moved would announce teammates typing my name when nobody did. The rows keep
+ * their broader dot, which claims only "something new here" (see
+ * `mentions-inbox-model.ts` for the two claims). Nothing renders the row-level
+ * unread total today, so the hook does not compute one.
+ */
+export function useMentionInbox(agents: Agent[]) {
+  const { data: session } = useSession();
+  const selfId = session?.uid ?? null;
+  const cursors = useReadCursorStore();
+  const paths = useMemo(() => agents.map((a) => a.folderPath), [agents]);
+  const { data, isPending } = useAllConversations(paths);
+  const conversations: MentionInboxConversation[] = useMemo(
+    () => data ?? [],
+    [data],
+  );
+  const rows = useMemo(
+    () => buildMentionInbox(conversations, cursors, selfId),
+    [conversations, cursors, selfId],
+  );
+  const mentionCount = useMemo(
+    () => rows.reduce((n, row) => n + (row.mentionOutstanding ? 1 : 0), 0),
+    [rows],
+  );
+  return { rows, conversations, mentionCount, isPending };
+}
+
+/**
+ * Mission Control's Mentions inbox: every mission where a teammate typed my
+ * name, newest first. A multiplayer-only surface — `Dashboard` never routes
+ * here without the capability, so single player gains no chrome at all.
+ *
+ * Deliberately NOT a board: there are no columns to move a mention between and
+ * no status to read off it, only "who pinged me, where, and how long ago". So
+ * it is a plain scrollable list of plane rows, each of which navigates to the
+ * mission's chat the same way a completion notification does.
+ */
+export function MentionsInbox({
+  agents,
+  onShowActive,
+}: {
+  agents: Agent[];
+  onShowActive: () => void;
+}) {
+  const { t, i18n } = useTranslation("dashboard");
+  const { rows, conversations, mentionCount, isPending } =
+    useMentionInbox(agents);
+
+  const senderIds = useMemo(() => mentionerIds(rows), [rows]);
+  const { profiles } = useUserProfiles(senderIds);
+  const fallbackNames = useMemo(
+    () => storedContributorNames(conversations),
+    [conversations],
+  );
+  const nameFor = useCallback(
+    (userId: string) => resolveMentionerName(userId, profiles, fallbackNames),
+    [profiles, fallbackNames],
+  );
+
+  const openRow = useCallback(
+    (row: MentionInboxRow) => {
+      // Rows are built from these very agents' conversations, so the lookup
+      // always hits; the guard only keeps a roster reload mid-click harmless.
+      const agent = agents.find((a) => a.folderPath === row.agentPath);
+      if (!agent) return;
+      const activityId =
+        activityIdForSessionKey(
+          conversations.filter((c) => c.agent_path === row.agentPath),
+          row.sessionKey,
+        ) ?? row.conversationId;
+      // The same three-step nav a completion notification performs.
+      useAgentStore.getState().setCurrent(agent);
+      useUIStore.getState().setViewMode("activity");
+      useUIStore.getState().setActivityPanelId(activityId, { forceOpen: true });
+    },
+    [agents, conversations],
+  );
+
+  return (
+    <>
+      <MissionControlToolbar
+        agents={agents}
+        collapsed={false}
+        mentionsActive
+        onToggleMentions={onShowActive}
+        mentionCount={mentionCount}
+        onBack={onShowActive}
+      />
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-4">
+        {isPending ? (
+          <div aria-hidden>
+            {[0, 1, 2, 3, 4].map((i) => (
+              <MentionsInboxRowSkeleton key={i} />
+            ))}
+          </div>
+        ) : rows.length === 0 ? (
+          <Empty className="border-0">
+            <EmptyHeader>
+              <EmptyTitle>{t("mentions.empty.title")}</EmptyTitle>
+              <EmptyDescription>
+                {t("mentions.empty.description")}
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <ul>
+            {rows.map((row) => (
+              <li key={`${row.agentPath}:${row.conversationId}`}>
+                <MentionsInboxRow
+                  row={row}
+                  labels={{
+                    by: row.byUserId
+                      ? t("mentions.row.by", { name: nameFor(row.byUserId) })
+                      : t("mentions.row.byUnknown"),
+                    agent: t("mentions.row.agent", { agent: row.agentName }),
+                  }}
+                  avatarLabel={row.byUserId ? nameFor(row.byUserId) : ""}
+                  avatarUrl={
+                    (row.byUserId
+                      ? profiles.get(row.byUserId)?.avatarUrl
+                      : null) ?? undefined
+                  }
+                  locale={i18n.language}
+                  onOpen={openRow}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -1,4 +1,4 @@
-import { AIBoard } from "@houston-ai/board";
+import { AIBoard, type MessageMention } from "@houston-ai/board";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useOpenAgentHref } from "../../hooks/use-open-agent-file";
@@ -105,8 +105,8 @@ export function MissionBoard({ source }: { source: BoardSource }) {
   });
 
   const handleCreateConversation = useCallback(
-    (text: string, files: File[]) =>
-      source.createConversation({ text, files, ...overrides }),
+    (text: string, files: File[], mentions?: MessageMention[]) =>
+      source.createConversation({ text, files, ...overrides, mentions }),
     [source.createConversation, overrides],
   );
   const handleNotice = useCallback(
@@ -163,6 +163,7 @@ export function MissionBoard({ source }: { source: BoardSource }) {
           showSenders={panel.showSenders}
           agentLabel={panel.agentLabel}
           renderSenderAvatar={panel.renderSenderAvatar}
+          {...panel.mentionProps}
           dictation={panel.dictation}
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}

--- a/app/src/components/board/mission-control-active.tsx
+++ b/app/src/components/board/mission-control-active.tsx
@@ -1,4 +1,5 @@
 import type { Agent } from "../../lib/types";
+import type { MissionsToolbarMentions } from "../mission-toolbar-actions";
 import { MissionBoard } from "./mission-board";
 import { useMissionControlSource } from "./use-mission-control-source";
 
@@ -11,10 +12,14 @@ import { useMissionControlSource } from "./use-mission-control-source";
 export function MissionControlActive({
   agents,
   onShowArchived,
+  mentions,
 }: {
   agents: Agent[];
   onShowArchived: () => void;
+  /** Mentions-inbox entry point for the toolbar. Multiplayer only: undefined
+   *  on single player, where no Mentions control renders at all. */
+  mentions?: MissionsToolbarMentions;
 }) {
-  const source = useMissionControlSource(agents, onShowArchived);
+  const source = useMissionControlSource(agents, onShowArchived, mentions);
   return <MissionBoard source={source} />;
 }

--- a/app/src/components/board/mission-control-archived.tsx
+++ b/app/src/components/board/mission-control-archived.tsx
@@ -170,6 +170,7 @@ export function MissionControlArchived({
           showSenders={panel.showSenders}
           agentLabel={panel.agentLabel}
           renderSenderAvatar={panel.renderSenderAvatar}
+          {...panel.mentionProps}
           renderSystemMessage={panel.renderSystemMessage}
           conversationMap={panel.conversationMap}
           mapFeedItems={panel.mapFeedItems}

--- a/app/src/components/board/use-agent-board-scope.tsx
+++ b/app/src/components/board/use-agent-board-scope.tsx
@@ -3,11 +3,14 @@ import { useMemo } from "react";
 import { useSession } from "../../hooks/use-session";
 import { missionMatchesScope } from "../../lib/agent-person-scope";
 import { attachBoardPeople } from "../../lib/mission-people";
+import { attachMissionUnread } from "../../lib/unread-model";
 import { useAgentPersonScope } from "../agent-person-scope-context";
 import { useAgentBoardPeople } from "./use-agent-board-people";
+import { useAgentBoardUnread } from "./use-board-unread";
 
 /**
- * Narrow a single agent's board to the active PERSON SCOPE, split out of
+ * Join the per-mission truth the activity list does not carry onto a single
+ * agent's cards, then narrow them to the active PERSON SCOPE. Split out of
  * {@link useAgentBoardSource} so the source stays a thin composition. The scope
  * itself is chosen in the agent header ({@link AgentPersonScopeMenu}) and shared
  * via {@link useAgentPersonScope}; this only applies it to the cards:
@@ -18,7 +21,9 @@ import { useAgentBoardPeople } from "./use-agent-board-people";
  *   is an identity pass-through off multiplayer);
  * - filters BEFORE text search, exactly as the cross-agent board;
  * - defaults to "me", which keeps unattributed / legacy missions visible (see
- *   {@link missionMatchesScope}).
+ *   {@link missionMatchesScope});
+ * - joins the unread mark (HOU-945) on AFTER the filter, so a cursor moving
+ *   re-maps only the cards that survived it, and never the whole activity list.
  */
 export function useAgentBoardScope({
   path,
@@ -41,9 +46,15 @@ export function useAgentBoardScope({
     () => attachBoardPeople(items, peopleById),
     [items, peopleById],
   );
-  return useMemo(
+  const scopedItems = useMemo(
     () =>
       peopledItems.filter((i) => missionMatchesScope(i.people, scope, selfId)),
     [peopledItems, scope, selfId],
+  );
+
+  const unreadIds = useAgentBoardUnread(path);
+  return useMemo(
+    () => attachMissionUnread(scopedItems, unreadIds),
+    [scopedItems, unreadIds],
   );
 }

--- a/app/src/components/board/use-agent-board-send.ts
+++ b/app/src/components/board/use-agent-board-send.ts
@@ -86,6 +86,7 @@ export function useAgentBoardSend({
       providerOverride,
       modelOverride,
       modeOverride,
+      mentions,
     }: { text: string; files: File[] } & SendOverrides) => {
       const agentMode = pendingAgentMode ?? agentModes?.[0]?.id;
       const mode = agentModes?.find((m) => m.id === agentMode);
@@ -106,6 +107,7 @@ export function useAgentBoardSend({
           providerOverride,
           modelOverride,
           modeOverride,
+          mentions,
           titleText: visible,
           buildPrompt: async (activityId) => {
             const saved = await tauriAttachments.save(
@@ -189,6 +191,7 @@ export function useAgentBoardSend({
           provider: overrides.providerOverride,
           model: overrides.modelOverride,
           mode: overrides.modeOverride,
+          mentions: overrides.mentions,
         });
       if (queuedWarm) {
         // The parked message narrates itself: the trailing user bubble keeps
@@ -218,6 +221,7 @@ export function useAgentBoardSend({
           providerOverride: overrides.providerOverride,
           modelOverride: overrides.modelOverride,
           modeOverride: overrides.modeOverride,
+          mentions: overrides.mentions,
           // If the conversation is mid-turn the adapter holds this send; the
           // queued bubble shows the user's words, not the built prompt.
           queuedPreview: {

--- a/app/src/components/board/use-board-labels.ts
+++ b/app/src/components/board/use-board-labels.ts
@@ -25,6 +25,7 @@ export function useBoardLabels(): {
       selectTooltip: t("board:cardActions.select"),
       people: t("board:people.label"),
       peopleExpand: t("board:people.expand"),
+      unread: t("board:unread.label"),
     },
     composerLabels: {
       fileAlreadyInChat: t("chat:composer.fileAlreadyInChat"),

--- a/app/src/components/board/use-board-send-queue.ts
+++ b/app/src/components/board/use-board-send-queue.ts
@@ -1,4 +1,5 @@
 import type { AIBoardProps } from "@houston-ai/board";
+import type { MessageMention } from "@houston-ai/chat";
 import { useCallback, useMemo } from "react";
 import { useSessionMessageQueue } from "../../hooks/use-session-message-queue";
 import type { SendOverrides } from "./board-source";
@@ -45,9 +46,18 @@ export function useBoardSendQueue({
     sendNow: sendSelectedNow,
   });
 
+  // The composer's per-send @mentions (HOU-944) merge into the same overrides
+  // bag as the provider/model pick, so every `sendMessageNow` gets them from
+  // one argument. `undefined` (the message named nobody) is dropped rather than
+  // sent as an empty list.
   const handleSendMessage = useCallback(
-    async (sessionKey: string, text: string, files: File[]) => {
-      await sendMessageNow(sessionKey, text, files, overrides);
+    async (
+      sessionKey: string,
+      text: string,
+      files: File[],
+      mentions?: MessageMention[],
+    ) => {
+      await sendMessageNow(sessionKey, text, files, { ...overrides, mentions });
     },
     [sendMessageNow, overrides],
   );

--- a/app/src/components/board/use-board-unread.ts
+++ b/app/src/components/board/use-board-unread.ts
@@ -1,0 +1,60 @@
+import { useMemo } from "react";
+import { useConversations } from "../../hooks/queries";
+import { useCapabilities } from "../../hooks/use-capabilities";
+import { useReadCursorStore } from "../../hooks/use-read-cursors";
+import { useSession } from "../../hooks/use-session";
+import { isMultiplayer } from "../../lib/org-roles";
+import {
+  type UnreadConversationInput,
+  unreadMissionIds,
+} from "../../lib/unread-model";
+
+const EMPTY: ReadonlySet<string> = new Set();
+
+/**
+ * Which of these missions have something new FOR ME (HOU-945) — the per-card
+ * half of the sidebar's unread badge, reusing the SAME pure model
+ * ({@link unreadMissionIds}) and the SAME live cursor store, so a lit card and a
+ * lit agent row can never tell the user different things.
+ *
+ * Multiplayer-gated twice over, on purpose. The capability gate keeps
+ * single player / desktop on the empty set (no cursor read reaches the cards at
+ * all), and the model itself returns nothing without a `selfId` — an unread
+ * badge is per-person reading state, and with nobody signed in it would be a
+ * mark no one could ever clear.
+ *
+ * The cursor store is an EXTERNAL store, not a query, so reading it here adds
+ * no query observer and can never trigger a fetch (in hosted mode a stray fetch
+ * is the thing that WAKES a sleeping pod).
+ */
+export function useBoardUnread(
+  convos: readonly UnreadConversationInput[] | undefined,
+): ReadonlySet<string> {
+  const { capabilities } = useCapabilities();
+  const multiplayer = isMultiplayer(capabilities);
+  const cursors = useReadCursorStore();
+  const { data: session } = useSession();
+  const selfId = session?.uid ?? null;
+
+  return useMemo(
+    () =>
+      multiplayer && convos ? unreadMissionIds(convos, cursors, selfId) : EMPTY,
+    [multiplayer, convos, cursors, selfId],
+  );
+}
+
+/**
+ * The same verdict for ONE agent's board. Mirrors {@link useAgentBoardPeople}:
+ * the board's own rows come from the activity list, which carries no
+ * attribution and no mention aggregate, so the conversations query is what can
+ * answer "is this mine, and has anyone typed my name here". React Query dedupes
+ * it with the attribution hook's identical read, so this costs no extra request
+ * — and off multiplayer it is never enabled at all.
+ */
+export function useAgentBoardUnread(agentPath: string): ReadonlySet<string> {
+  const { capabilities } = useCapabilities();
+  const { data: convos } = useConversations(
+    isMultiplayer(capabilities) ? agentPath : undefined,
+  );
+  return useBoardUnread(convos);
+}

--- a/app/src/components/board/use-mc-actions.ts
+++ b/app/src/components/board/use-mc-actions.ts
@@ -45,6 +45,7 @@ export function useMcActions({
       files,
       providerOverride,
       modelOverride,
+      mentions,
     }: { text: string; files: File[] } & SendOverrides) => {
       const plan = planNewMission({
         activeAgent,
@@ -64,20 +65,23 @@ export function useMcActions({
         promptFile: plan.promptFile,
         providerOverride: plan.providerOverride,
         modelOverride: plan.modelOverride,
+        mentions,
       });
     },
     [activeAgent, activeAgentDef, mc.handleCreateConversation, addToast, t],
   );
 
-  // Cross-agent: ignore composer overrides, re-resolve from the activity (see
-  // useMissionControl). 4th param keeps the BoardSource signature aligned.
+  // Cross-agent: ignore the composer's provider/model overrides, re-resolve
+  // them from the activity (see useMissionControl). `mentions` are NOT an
+  // override in that sense — they are what this very message said — so they
+  // ride through.
   const sendMessageNow = useCallback(
     (
       sessionKey: string,
       text: string,
       files: File[],
-      _overrides: SendOverrides,
-    ) => mc.handleSendMessage(sessionKey, text, files),
+      overrides: SendOverrides,
+    ) => mc.handleSendMessage(sessionKey, text, files, overrides.mentions),
     [mc.handleSendMessage],
   );
 

--- a/app/src/components/board/use-mission-control-archived-send.ts
+++ b/app/src/components/board/use-mission-control-archived-send.ts
@@ -1,4 +1,5 @@
 import type { KanbanItem } from "@houston-ai/board";
+import type { MessageMention } from "@houston-ai/chat";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { analytics } from "../../lib/analytics";
@@ -38,7 +39,12 @@ export function useMissionControlArchivedSend({
   const setActivityPanelId = useUIStore((s) => s.setActivityPanelId);
 
   return useCallback(
-    async (sessionKey: string, text: string, files: File[]) => {
+    async (
+      sessionKey: string,
+      text: string,
+      files: File[],
+      mentions?: MessageMention[],
+    ) => {
       if (!activeAgent || !selectedItem) return;
       const agentPath = activeAgent.folderPath;
       const missionId = selectedItem.id;
@@ -58,6 +64,7 @@ export function useMissionControlArchivedSend({
           providerOverride,
           modelOverride,
           modeOverride: await readAgentTurnMode(agentPath, tauriConfig.read),
+          mentions,
         });
         analytics.track("chat_message_sent", {
           provider: providerOverride,

--- a/app/src/components/board/use-mission-control-source.tsx
+++ b/app/src/components/board/use-mission-control-source.tsx
@@ -6,6 +6,7 @@ import { useAgentCatalogStore } from "../../stores/agent-catalog";
 import { useUIStore } from "../../stores/ui";
 import { MissionBoardEmptyState } from "../mission-board-empty-state";
 import { MissionControlToolbar } from "../mission-control-toolbar";
+import type { MissionsToolbarMentions } from "../mission-toolbar-actions";
 import { useMissionControl } from "../use-mission-control";
 import { useMissionSearch } from "../use-mission-search";
 import type { BoardSource } from "./board-source";
@@ -23,6 +24,7 @@ import { useMcNewMission } from "./use-mc-new-mission";
 export function useMissionControlSource(
   agents: Agent[],
   onShowArchived: () => void,
+  mentions?: MissionsToolbarMentions,
 ): BoardSource {
   const { t } = useTranslation(["dashboard", "board"]);
   const getAgentDef = useAgentCatalogStore((s) => s.getById);
@@ -153,6 +155,8 @@ export function useMissionControlSource(
       onSearchChange={setMissionSearchQuery}
       archivedActive={false}
       onToggleArchived={onShowArchived}
+      onToggleMentions={mentions?.onShow}
+      mentionCount={mentions?.count}
       onNewMission={newMission.openNewMission}
       collapsed={missionPanelOpen}
     />

--- a/app/src/components/dashboard.tsx
+++ b/app/src/components/dashboard.tsx
@@ -9,23 +9,39 @@ import { Plus } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCanCreateAgents } from "../hooks/use-can-create-agents";
+import { useCapabilities } from "../hooks/use-capabilities";
+import { isMultiplayer } from "../lib/org-roles";
 import { useAgentStore } from "../stores/agents";
 import { useUIStore } from "../stores/ui";
+import { MentionsInbox, useMentionInbox } from "./board/mentions-inbox";
 import { MissionControlActive } from "./board/mission-control-active";
 import { MissionControlArchived } from "./board/mission-control-archived";
 
 /**
- * Mission Control: every agent's missions on one board. The active board and
- * the cross-agent Archived view are separate components that swap (not hide)
- * so only the mounted one's hooks run. This view owns the toggle + the
- * no-agents empty state; all board wiring lives in the shared `<MissionBoard>`.
+ * Which Mission Control surface is showing. A union rather than a pile of
+ * booleans: the three are mutually exclusive by construction, and "archived AND
+ * mentions" must never be representable.
+ */
+type MissionControlMode = "active" | "archived" | "mentions";
+
+/**
+ * Mission Control: every agent's missions on one board. The active board, the
+ * cross-agent Archived view and the Mentions inbox are separate components that
+ * swap (not hide) so only the mounted one's hooks run. This view owns the mode
+ * + the no-agents empty state; all board wiring lives in `<MissionBoard>`.
  */
 export function Dashboard() {
   const { t } = useTranslation("dashboard");
   const agents = useAgentStore((s) => s.agents);
   const setDialogOpen = useUIStore((s) => s.setCreateAgentDialogOpen);
   const { canCreate: canCreateAgents } = useCanCreateAgents();
-  const [showArchived, setShowArchived] = useState(false);
+  const { capabilities } = useCapabilities();
+  const [mode, setMode] = useState<MissionControlMode>("active");
+  // Mentions are a team surface: with nobody to mention you, the inbox is dead
+  // chrome. Single player never sees the control and can never land in the mode.
+  const mentionsEnabled = isMultiplayer(capabilities);
+  const { mentionCount } = useMentionInbox(agents);
+  const activeMode = mode === "mentions" && !mentionsEnabled ? "active" : mode;
 
   if (agents.length === 0) {
     return (
@@ -51,15 +67,22 @@ export function Dashboard() {
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
-      {showArchived ? (
+      {activeMode === "archived" ? (
         <MissionControlArchived
           agents={agents}
-          onShowActive={() => setShowArchived(false)}
+          onShowActive={() => setMode("active")}
         />
+      ) : activeMode === "mentions" ? (
+        <MentionsInbox agents={agents} onShowActive={() => setMode("active")} />
       ) : (
         <MissionControlActive
           agents={agents}
-          onShowArchived={() => setShowArchived(true)}
+          onShowArchived={() => setMode("archived")}
+          mentions={
+            mentionsEnabled
+              ? { onShow: () => setMode("mentions"), count: mentionCount }
+              : undefined
+          }
         />
       )}
     </div>

--- a/app/src/components/mission-agent-filter.tsx
+++ b/app/src/components/mission-agent-filter.tsx
@@ -1,0 +1,73 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@houston-ai/core";
+import { ChevronDown, ListFilter } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { Agent } from "../lib/types";
+import { AgentCardAvatar } from "./shell/agent-card-avatar";
+
+/**
+ * Mission Control's filter-by-agent menu, sibling of {@link MissionPersonFilter}
+ * and shaped the same way: an "everything" default plus one row per agent,
+ * collapsing to the selected agent's avatar when a chat panel narrows the bar.
+ */
+export function MissionAgentFilter({
+  agents,
+  filterPath,
+  onFilterPathChange,
+  collapsed,
+}: {
+  agents: Agent[];
+  /** Selected agent's folder path, or `""` for all agents. */
+  filterPath: string;
+  onFilterPathChange: (path: string) => void;
+  collapsed: boolean;
+}) {
+  const { t } = useTranslation("dashboard");
+  const selectedAgent = agents.find((agent) => agent.folderPath === filterPath);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        {collapsed ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="rounded-full"
+            aria-label={selectedAgent?.name ?? t("filter.allAgents")}
+          >
+            {selectedAgent ? (
+              <AgentCardAvatar color={selectedAgent.color} />
+            ) : (
+              <ListFilter className="size-4" />
+            )}
+          </Button>
+        ) : (
+          <Button variant="ghost" className="rounded-full gap-1.5">
+            {selectedAgent?.name ?? t("filter.allAgents")}
+            <ChevronDown className="size-3.5 text-ink-muted" />
+          </Button>
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => onFilterPathChange("")}>
+          {t("filter.allAgents")}
+        </DropdownMenuItem>
+        {agents.map((agent) => (
+          <DropdownMenuItem
+            key={agent.id}
+            onClick={() => onFilterPathChange(agent.folderPath)}
+            className="gap-2"
+          >
+            <AgentCardAvatar color={agent.color} />
+            {agent.name}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/app/src/components/mission-control-toolbar.tsx
+++ b/app/src/components/mission-control-toolbar.tsx
@@ -1,71 +1,44 @@
-import type { KanbanItem } from "@houston-ai/board";
 import {
   Button,
-  cn,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@houston-ai/core";
-import { Archive, ArrowLeft, ChevronDown, ListFilter } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { shortcutLabel } from "../lib/shortcuts";
-import type { Agent } from "../lib/types";
-import { MissionPersonFilter } from "./mission-person-filter";
 import { MissionSearchInput } from "./mission-search-input";
-import { AgentCardAvatar } from "./shell/agent-card-avatar";
-import { HoustonLogo } from "./shell/experience-card";
+import {
+  MissionToolbarActions,
+  type MissionToolbarActionsProps,
+} from "./mission-toolbar-actions";
 
-interface MissionControlToolbarProps {
-  agents: Agent[];
-  /** Visible board items (post agent-filter) — feeds the person-filter roster.
-   *  Omitted by the Archived toolbar, which has no attribution filter. */
-  items?: KanbanItem[];
-  filterPath: string;
-  /** Selected person for the attribution filter, or `null` for Everyone. */
-  filterUserId?: string | null;
-  search: string;
-  isSearchingText: boolean;
-  onFilterPathChange: (path: string) => void;
-  /** When set, renders the filter-by-person control (active board only). */
-  onFilterUserIdChange?: (userId: string | null) => void;
-  onSearchChange: (value: string) => void;
-  /** Whether the Archived view is currently showing (highlights the toggle). */
-  archivedActive: boolean;
-  /** Toggle between the active board and the cross-agent Archived view. */
-  onToggleArchived: () => void;
-  /** "New mission" trigger. Present in both the active and archived toolbars. */
-  onNewMission?: () => void;
-  /** When set, renders a back button on the left (used by the Archived view to
-   *  return to the active board). */
+/**
+ * The Mission Control bar: an optional back arrow, the mode's title, an
+ * optional search field, and the {@link MissionToolbarActions} cluster. Every
+ * Mission Control mode (active board, Archived, Mentions) renders this same
+ * bar and simply omits the callbacks it has nothing to do with.
+ */
+interface MissionControlToolbarProps extends MissionToolbarActionsProps {
+  search?: string;
+  isSearchingText?: boolean;
+  /** When set, renders the text-search field. Omitted by the Mentions inbox,
+   *  which is a short chronological list with nothing to search. */
+  onSearchChange?: (value: string) => void;
+  /** When set, renders a back button on the left (used by the Archived and
+   *  Mentions views to return to the active board). */
   onBack?: () => void;
-  /** Compact layout: a chat panel is open, so the board is narrow. Shrinks the
-   *  search placeholder and collapses the buttons to icons so the title stays
-   *  on one line. The search itself flexes to fill whatever space is left. */
-  collapsed: boolean;
 }
 
-export function MissionControlToolbar({
-  agents,
-  items,
-  filterPath,
-  filterUserId,
-  search,
-  isSearchingText,
-  onFilterPathChange,
-  onFilterUserIdChange,
-  onSearchChange,
-  archivedActive,
-  onToggleArchived,
-  onNewMission,
-  onBack,
-  collapsed,
-}: MissionControlToolbarProps) {
+export function MissionControlToolbar(props: MissionControlToolbarProps) {
   const { t } = useTranslation("dashboard");
-  const selectedAgent = agents.find((agent) => agent.folderPath === filterPath);
+  const {
+    search = "",
+    isSearchingText = false,
+    onSearchChange,
+    onBack,
+    archivedActive = false,
+    mentionsActive = false,
+  } = props;
 
   return (
     <div className="shrink-0 px-5 pt-4">
@@ -87,108 +60,28 @@ export function MissionControlToolbar({
           </Tooltip>
         )}
         <h1 className="shrink-0 text-xl font-semibold text-ink">
-          {archivedActive ? t("archived.title") : t("title")}
+          {mentionsActive
+            ? t("mentions.title")
+            : archivedActive
+              ? t("archived.title")
+              : t("title")}
         </h1>
         <div className="flex min-w-0 flex-1 items-center justify-end gap-2">
-          <MissionSearchInput
-            value={search}
-            isSearchingText={isSearchingText}
-            labels={{
-              placeholder: t("search.placeholder"),
-              placeholderShort: t("search.placeholderShort"),
-              clear: t("search.clear"),
-              searchingText: t("search.searchingText"),
-            }}
-            className="relative min-w-0 flex-1 max-w-[320px]"
-            onChange={onSearchChange}
-          />
-          <div className="flex shrink-0 items-center gap-2">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                {collapsed ? (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="rounded-full"
-                    aria-label={selectedAgent?.name ?? t("filter.allAgents")}
-                  >
-                    {selectedAgent ? (
-                      <AgentCardAvatar color={selectedAgent.color} />
-                    ) : (
-                      <ListFilter className="size-4" />
-                    )}
-                  </Button>
-                ) : (
-                  <Button variant="ghost" className="rounded-full gap-1.5">
-                    {selectedAgent?.name ?? t("filter.allAgents")}
-                    <ChevronDown className="size-3.5 text-ink-muted" />
-                  </Button>
-                )}
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => onFilterPathChange("")}>
-                  {t("filter.allAgents")}
-                </DropdownMenuItem>
-                {agents.map((agent) => (
-                  <DropdownMenuItem
-                    key={agent.id}
-                    onClick={() => onFilterPathChange(agent.folderPath)}
-                    className="gap-2"
-                  >
-                    <AgentCardAvatar color={agent.color} />
-                    {agent.name}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-            {onFilterUserIdChange && (
-              <MissionPersonFilter
-                items={items ?? []}
-                filterUserId={filterUserId ?? null}
-                onFilterUserIdChange={onFilterUserIdChange}
-                collapsed={collapsed}
-              />
-            )}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant={archivedActive ? "secondary" : "ghost"}
-                  size={collapsed ? "icon" : "default"}
-                  className={cn("rounded-full", !collapsed && "gap-1.5")}
-                  onClick={onToggleArchived}
-                  aria-label={t("archived.button")}
-                >
-                  <Archive className="size-4" />
-                  {!collapsed && t("archived.button")}
-                </Button>
-              </TooltipTrigger>
-              {collapsed && (
-                <TooltipContent side="bottom">
-                  {t("archived.button")}
-                </TooltipContent>
-              )}
-            </Tooltip>
-            {onNewMission && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    size={collapsed ? "icon" : "default"}
-                    className={cn(collapsed && "rounded-full")}
-                    onClick={onNewMission}
-                    aria-label={t("empty.newMission")}
-                  >
-                    <HoustonLogo size={16} />
-                    {!collapsed && t("empty.newMission")}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {collapsed
-                    ? t("empty.newMission")
-                    : shortcutLabel("newMission")}
-                </TooltipContent>
-              </Tooltip>
-            )}
-          </div>
+          {onSearchChange && (
+            <MissionSearchInput
+              value={search}
+              isSearchingText={isSearchingText}
+              labels={{
+                placeholder: t("search.placeholder"),
+                placeholderShort: t("search.placeholderShort"),
+                clear: t("search.clear"),
+                searchingText: t("search.searchingText"),
+              }}
+              className="relative min-w-0 flex-1 max-w-[320px]"
+              onChange={onSearchChange}
+            />
+          )}
+          <MissionToolbarActions {...props} />
         </div>
       </div>
     </div>

--- a/app/src/components/mission-toolbar-actions.tsx
+++ b/app/src/components/mission-toolbar-actions.tsx
@@ -1,0 +1,175 @@
+import type { KanbanItem } from "@houston-ai/board";
+import {
+  Button,
+  cn,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@houston-ai/core";
+import { Archive, AtSign } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { shortcutLabel } from "../lib/shortcuts";
+import type { Agent } from "../lib/types";
+import { mentionCountLabel } from "./board/mentions-inbox-view-model";
+import { MissionAgentFilter } from "./mission-agent-filter";
+import { MissionPersonFilter } from "./mission-person-filter";
+import { HoustonLogo } from "./shell/experience-card";
+
+/**
+ * The right-hand control cluster of the Mission Control bar: filter by agent,
+ * filter by person, the Mentions and Archived mode pills, and "New mission".
+ *
+ * Every control is opt-in by callback presence, so each Mission Control mode
+ * shows exactly the chrome it can act on: the active board takes all of them,
+ * the Archived view drops the person filter, and the Mentions inbox drops
+ * everything but its own pill. That also keeps the single-player desktop
+ * byte-identical to before — no `onToggleMentions`, no Mentions chrome.
+ */
+/** The Mentions-inbox entry point the toolbar renders (multiplayer only). */
+export interface MissionsToolbarMentions {
+  onShow: () => void;
+  /** Unread mention count shown on the control. */
+  count: number;
+}
+
+export interface MissionToolbarActionsProps {
+  agents: Agent[];
+  /** Visible board items (post agent-filter) — feeds the person-filter roster.
+   *  Omitted by the Archived toolbar, which has no attribution filter. */
+  items?: KanbanItem[];
+  filterPath?: string;
+  /** Selected person for the attribution filter, or `null` for Everyone. */
+  filterUserId?: string | null;
+  /** When set, renders the filter-by-agent menu. Omitted by the Mentions
+   *  inbox, whose rows already name their agent. */
+  onFilterPathChange?: (path: string) => void;
+  /** When set, renders the filter-by-person control (active board only). */
+  onFilterUserIdChange?: (userId: string | null) => void;
+  /** Whether the Archived view is currently showing (highlights the toggle). */
+  archivedActive?: boolean;
+  /** Toggle between the active board and the cross-agent Archived view. When
+   *  omitted, no Archived control renders. */
+  onToggleArchived?: () => void;
+  /** Whether the Mentions inbox is currently showing (highlights the control
+   *  and switches the title line). */
+  mentionsActive?: boolean;
+  /** Toggle between the active board and the Mentions inbox. Multiplayer only:
+   *  omit it and single player gains no Mentions chrome at all. */
+  onToggleMentions?: () => void;
+  /** Unread mention count shown on the Mentions control. 0 renders no number. */
+  mentionCount?: number;
+  /** "New mission" trigger. Present in both the active and archived toolbars. */
+  onNewMission?: () => void;
+  /** Compact layout: a chat panel is open, so the board is narrow. Collapses
+   *  the buttons to icons so the title stays on one line. */
+  collapsed: boolean;
+}
+
+export function MissionToolbarActions({
+  agents,
+  items,
+  filterPath = "",
+  filterUserId,
+  onFilterPathChange,
+  onFilterUserIdChange,
+  archivedActive = false,
+  onToggleArchived,
+  mentionsActive = false,
+  onToggleMentions,
+  mentionCount = 0,
+  onNewMission,
+  collapsed,
+}: MissionToolbarActionsProps) {
+  const { t } = useTranslation("dashboard");
+  const hasMentionCount = mentionCount > 0;
+  const mentionsLabel = hasMentionCount
+    ? t("mentions.ariaCount", { count: mentionCount })
+    : t("mentions.button");
+
+  return (
+    <div className="flex shrink-0 items-center gap-2">
+      {onFilterPathChange && (
+        <MissionAgentFilter
+          agents={agents}
+          filterPath={filterPath}
+          onFilterPathChange={onFilterPathChange}
+          collapsed={collapsed}
+        />
+      )}
+      {onFilterUserIdChange && (
+        <MissionPersonFilter
+          items={items ?? []}
+          filterUserId={filterUserId ?? null}
+          onFilterUserIdChange={onFilterUserIdChange}
+          collapsed={collapsed}
+        />
+      )}
+      {onToggleMentions && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant={mentionsActive ? "secondary" : "ghost"}
+              size={collapsed && !hasMentionCount ? "icon" : "default"}
+              className={cn(
+                "rounded-full",
+                (!collapsed || hasMentionCount) && "gap-1.5",
+              )}
+              onClick={onToggleMentions}
+              aria-label={mentionsLabel}
+            >
+              <AtSign className="size-4" />
+              {!collapsed && t("mentions.button")}
+              {hasMentionCount && (
+                <span className="text-sm font-medium tabular-nums">
+                  {mentionCountLabel(mentionCount)}
+                </span>
+              )}
+            </Button>
+          </TooltipTrigger>
+          {collapsed && (
+            <TooltipContent side="bottom">{mentionsLabel}</TooltipContent>
+          )}
+        </Tooltip>
+      )}
+      {onToggleArchived && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant={archivedActive ? "secondary" : "ghost"}
+              size={collapsed ? "icon" : "default"}
+              className={cn("rounded-full", !collapsed && "gap-1.5")}
+              onClick={onToggleArchived}
+              aria-label={t("archived.button")}
+            >
+              <Archive className="size-4" />
+              {!collapsed && t("archived.button")}
+            </Button>
+          </TooltipTrigger>
+          {collapsed && (
+            <TooltipContent side="bottom">
+              {t("archived.button")}
+            </TooltipContent>
+          )}
+        </Tooltip>
+      )}
+      {onNewMission && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size={collapsed ? "icon" : "default"}
+              className={cn(collapsed && "rounded-full")}
+              onClick={onNewMission}
+              aria-label={t("empty.newMission")}
+            >
+              <HoustonLogo size={16} />
+              {!collapsed && t("empty.newMission")}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {collapsed ? t("empty.newMission") : shortcutLabel("newMission")}
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/shell/agent-activity-summary-model.ts
+++ b/app/src/components/shell/agent-activity-summary-model.ts
@@ -1,21 +1,39 @@
 import { isSetupChatMode } from "../../lib/integration-chat-setup.ts";
+import type { ReadCursorStore } from "../../lib/read-cursors.ts";
+import {
+  countUnreadByAgentPath,
+  type UnreadConversationInput,
+} from "../../lib/unread-model.ts";
 
 export interface AgentActivitySummaryInput {
   id: string;
   folderPath: string;
 }
 
-export interface ActivityConversationSummaryInput {
-  agent_path: string;
-  type: "primary" | "activity";
+/**
+ * A conversation row as the sidebar summarizes it. It EXTENDS the unread
+ * model's input rather than restating the fields (id, `updated_at`, and the
+ * `created_by`/`contributors`/`mentioned` attribution) so the two can never
+ * drift into disagreeing about what a mission is.
+ */
+export interface ActivityConversationSummaryInput
+  extends UnreadConversationInput {
   status?: string | null;
-  /** Agent-mode id; routine-setup chats never count toward badges. */
-  agent?: string | null;
 }
 
 export interface AgentActivitySummary {
   needsYouCount: number;
   runningCount: number;
+  /** Missions that moved since I last read them (HOU-945). Always 0 off
+   *  multiplayer or without a signed-in user, so single-player / desktop
+   *  renders no new chrome. */
+  unreadCount: number;
+}
+
+/** Everything the unread count needs: the reader's cursors and who they are. */
+export interface UnreadSummaryOptions {
+  store: ReadCursorStore;
+  selfId: string | null;
 }
 
 /** One agent's board rows (`.houston/activity`), the summary-relevant bits. */
@@ -30,11 +48,20 @@ export interface ActivitySummaryInput {
  * counting rule) as the "Activity N" tab badge in workspace-shell.tsx, used
  * as the sidebar fallback while the all-conversations aggregate has not
  * fetched for the current roster key (cold boot, pods still waking).
+ *
+ * `unreadCount` is always 0 here, and cannot be anything else: a board row
+ * carries no attribution (no `created_by`, no `mentioned`), so there is nothing
+ * to decide relevance against. The aggregate path below owns the unread number,
+ * and this fallback simply reports none rather than guessing one.
  */
 export function summarizeActivities(
   activities: ActivitySummaryInput[],
 ): AgentActivitySummary {
-  const summary: AgentActivitySummary = { needsYouCount: 0, runningCount: 0 };
+  const summary: AgentActivitySummary = {
+    needsYouCount: 0,
+    runningCount: 0,
+    unreadCount: 0,
+  };
   for (const activity of activities) {
     if (isSetupChatMode(activity.agent)) continue;
     if (activity.status === "needs_you") {
@@ -46,15 +73,32 @@ export function summarizeActivities(
   return summary;
 }
 
+/**
+ * The sidebar's per-agent badge numbers.
+ *
+ * `unread` is OPTIONAL, and its absence (or a null `selfId`) leaves every
+ * `unreadCount` at 0 — so single-player and desktop render exactly the chrome
+ * they render today, with no new dot to explain. That absence is how the gate
+ * is expressed: the sidebar hook omits the option entirely unless the
+ * deployment advertises `capabilities.multiplayer`. The counting itself is
+ * delegated to {@link countUnreadByAgentPath} rather than re-derived here: the
+ * badge, the Mentions inbox and the notifier must agree on what "unread" means,
+ * and they only can if there is one implementation of it.
+ */
 export function buildAgentActivitySummaries(
   agents: AgentActivitySummaryInput[],
   conversations: ActivityConversationSummaryInput[],
+  unread?: UnreadSummaryOptions,
 ): Record<string, AgentActivitySummary> {
   const summaries: Record<string, AgentActivitySummary> = {};
   const agentIdByPath = new Map<string, string>();
 
   for (const agent of agents) {
-    summaries[agent.id] = { needsYouCount: 0, runningCount: 0 };
+    summaries[agent.id] = {
+      needsYouCount: 0,
+      runningCount: 0,
+      unreadCount: 0,
+    };
     agentIdByPath.set(agent.folderPath, agent.id);
   }
 
@@ -72,6 +116,19 @@ export function buildAgentActivitySummaries(
       summary.needsYouCount += 1;
     } else if (conversation.status === "running") {
       summary.runningCount += 1;
+    }
+  }
+
+  if (unread) {
+    const byPath = countUnreadByAgentPath(
+      conversations,
+      unread.store,
+      unread.selfId,
+    );
+    for (const [agentPath, count] of Object.entries(byPath)) {
+      const agentId = agentIdByPath.get(agentPath);
+      const summary = agentId ? summaries[agentId] : undefined;
+      if (summary) summary.unreadCount = count;
     }
   }
 

--- a/app/src/components/shell/agent-sidebar-items.tsx
+++ b/app/src/components/shell/agent-sidebar-items.tsx
@@ -8,13 +8,18 @@ import {
 import type { Agent } from "../../lib/types";
 import type { AgentActivitySummary } from "./agent-activity-summary-model";
 import { AgentSidebarColorMenu } from "./agent-sidebar-color-menu";
-import { AgentSidebarIcon, NeedsYouChip } from "./agent-sidebar-status";
+import {
+  AgentSidebarIcon,
+  NeedsYouChip,
+  UnreadDot,
+} from "./agent-sidebar-status";
 
 interface BuildAgentSidebarItemsArgs {
   agents: Agent[];
   summaries: Record<string, AgentActivitySummary>;
   runningLabel: (count: number) => string;
   needsYouLabel: (count: number) => string;
+  unreadLabel: (count: number) => string;
   onChangeColor: (agentId: string, color: string) => void;
   onShareAgent: (agentId: string) => void;
   shareLabel: string;
@@ -25,6 +30,7 @@ export function buildAgentSidebarItems({
   summaries,
   runningLabel,
   needsYouLabel,
+  unreadLabel,
   onChangeColor,
   onShareAgent,
   shareLabel,
@@ -33,8 +39,11 @@ export function buildAgentSidebarItems({
     const summary = summaries[agent.id] ?? {
       needsYouCount: 0,
       runningCount: 0,
+      unreadCount: 0,
     };
     const hasRunning = summary.runningCount > 0;
+    const hasUnread = summary.unreadCount > 0;
+    const needsYou = summary.needsYouCount > 0;
 
     return {
       id: agent.id,
@@ -46,12 +55,23 @@ export function buildAgentSidebarItems({
           runningLabel={runningLabel(summary.runningCount)}
         />
       ),
+      // Both signals can show at once, dot first: an agent with something
+      // urgent may ALSO have unread news, and hiding one behind the other
+      // would make the rail lie about what is waiting. Nothing to say leaves
+      // `trailing` undefined, exactly as before.
       trailing:
-        summary.needsYouCount > 0 ? (
-          <NeedsYouChip
-            count={summary.needsYouCount}
-            label={needsYouLabel(summary.needsYouCount)}
-          />
+        hasUnread || needsYou ? (
+          <span className="flex items-center gap-1.5">
+            {hasUnread ? (
+              <UnreadDot label={unreadLabel(summary.unreadCount)} />
+            ) : null}
+            {needsYou ? (
+              <NeedsYouChip
+                count={summary.needsYouCount}
+                label={needsYouLabel(summary.needsYouCount)}
+              />
+            ) : null}
+          </span>
         ) : undefined,
       menuContent: (
         <>

--- a/app/src/components/shell/agent-sidebar-status.tsx
+++ b/app/src/components/shell/agent-sidebar-status.tsx
@@ -49,3 +49,21 @@ export function NeedsYouChip({ count, label }: NeedsYouChipProps) {
     </Badge>
   );
 }
+
+/** The quiet unread signal: a small filled dot, deliberately NOT a count chip.
+ *  `NeedsYouChip` means "act now"; this only means "there is something new here
+ *  for you". Different weight, different shape, so the two never read alike.
+ *  The count lives in the accessible label, where a screen reader and a hover
+ *  can reach it without the rail turning into a wall of numbers. */
+export function UnreadDot({ label }: { label: string }) {
+  return (
+    <span
+      role="img"
+      aria-label={label}
+      title={label}
+      className="flex size-3 shrink-0 items-center justify-center"
+    >
+      <span className="size-1.5 rounded-full bg-action" />
+    </span>
+  );
+}

--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -100,6 +100,7 @@ export function Sidebar({ children }: { children: ReactNode }) {
     summaries: activitySummaries,
     runningLabel: (count) => t("shell:sidebar.runningCount", { count }),
     needsYouLabel: (count) => t("shell:sidebar.needsYouCount", { count }),
+    unreadLabel: (count) => t("shell:sidebar.unreadCount", { count }),
     onChangeColor: (agentId, color) => void handleChangeColor(agentId, color),
     onShareAgent: (agentId) => useUIStore.getState().setShareAgentId(agentId),
     shareLabel: t("portable:exportMenu"),

--- a/app/src/components/shell/use-agent-activity-summaries.ts
+++ b/app/src/components/shell/use-agent-activity-summaries.ts
@@ -2,6 +2,10 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
 import type { Activity } from "../../data/activity";
 import { useAllConversations } from "../../hooks/queries";
+import { useCapabilities } from "../../hooks/use-capabilities";
+import { useReadCursorStore } from "../../hooks/use-read-cursors";
+import { useSession } from "../../hooks/use-session";
+import { isMultiplayer } from "../../lib/org-roles";
 import { queryKeys } from "../../lib/query-keys";
 import type { Agent } from "../../lib/types";
 import {
@@ -46,11 +50,28 @@ export function useAgentActivitySummaries(
     return activityCacheVersion.current;
   });
 
+  // Unread badges (HOU-945). Multiplayer-gated twice over, exactly like
+  // `useBoardUnread`: off multiplayer the `unread` option is never passed, so
+  // every count stays 0 and single-player / desktop renders today's chrome with
+  // no dot to explain; and the model itself counts nothing without a `selfId` —
+  // an unread mark nobody is signed in to clear is a mark that never clears.
+  // The cursor store is an EXTERNAL store, not a query, so reading it here adds
+  // no observer and keeps the perf discipline above intact.
+  const { capabilities } = useCapabilities();
+  const multiplayer = isMultiplayer(capabilities);
+  const cursors = useReadCursorStore();
+  const { data: session } = useSession();
+  const selfId = session?.uid ?? null;
+
   return useMemo(() => {
     // The version stamp is not read below — it is a dependency so the memo
     // recomputes when a board query lands/updates in the cache.
     void cacheVersion;
-    const summaries = buildAgentActivitySummaries(agents, conversations ?? []);
+    const summaries = buildAgentActivitySummaries(
+      agents,
+      conversations ?? [],
+      multiplayer ? { store: cursors, selfId } : undefined,
+    );
     if (!aggregateIsAuthoritative) {
       // While the aggregate has not fetched for the current roster key (cold
       // boot, pods still waking), an agent with restored/live board data gets
@@ -60,7 +81,14 @@ export function useAgentActivitySummaries(
         const activities = queryClient.getQueryData<Activity[]>(
           queryKeys.activity(agent.folderPath),
         );
-        if (activities) summaries[agent.id] = summarizeActivities(activities);
+        if (!activities) continue;
+        // Board rows carry no attribution, so they can only answer needs-you /
+        // running. Keep the unread number the aggregate already computed rather
+        // than zeroing a badge the user can see.
+        summaries[agent.id] = {
+          ...summarizeActivities(activities),
+          unreadCount: summaries[agent.id]?.unreadCount ?? 0,
+        };
       }
     }
     return summaries;
@@ -70,5 +98,8 @@ export function useAgentActivitySummaries(
     aggregateIsAuthoritative,
     queryClient,
     cacheVersion,
+    multiplayer,
+    cursors,
+    selfId,
   ]);
 }

--- a/app/src/components/tabs/archived-tab.tsx
+++ b/app/src/components/tabs/archived-tab.tsx
@@ -1,7 +1,5 @@
-import type { KanbanItem } from "@houston-ai/board";
-import { AIBoard } from "@houston-ai/board";
-import type { FeedItem } from "@houston-ai/chat";
-import { messagePreviewText } from "@houston-ai/chat";
+import { AIBoard, type KanbanItem } from "@houston-ai/board";
+import { type FeedItem, messagePreviewText } from "@houston-ai/chat";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useActivity, useDeleteActivity } from "../../hooks/queries";
@@ -182,6 +180,7 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
           showSenders={panel.showSenders}
           agentLabel={panel.agentLabel}
           renderSenderAvatar={panel.renderSenderAvatar}
+          {...panel.mentionProps}
           renderSystemMessage={panel.renderSystemMessage}
           conversationMap={panel.conversationMap}
           mapFeedItems={panel.mapFeedItems}

--- a/app/src/components/tabs/routine-setup-chat-board.tsx
+++ b/app/src/components/tabs/routine-setup-chat-board.tsx
@@ -189,6 +189,7 @@ export function RoutineSetupChatBoard({
         showSenders={panel.showSenders}
         agentLabel={panel.agentLabel}
         renderSenderAvatar={panel.renderSenderAvatar}
+        {...panel.mentionProps}
         renderSystemMessage={panel.renderSystemMessage}
         conversationMap={panel.conversationMap}
         mapFeedItems={panel.mapFeedItems}

--- a/app/src/components/tabs/use-archived-send-message.ts
+++ b/app/src/components/tabs/use-archived-send-message.ts
@@ -1,3 +1,4 @@
+import type { MessageMention } from "@houston-ai/chat";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -35,7 +36,12 @@ export function useArchivedSendMessage({
   const setActivityPanelId = useUIStore((s) => s.setActivityPanelId);
 
   return useCallback(
-    async (sessionKey: string, text: string, files: File[]) => {
+    async (
+      sessionKey: string,
+      text: string,
+      files: File[],
+      mentions?: MessageMention[],
+    ) => {
       const missionId = selectedId ?? sessionKey.replace(/^activity-/, "");
       const activity = archived.find((a) => a.id === missionId);
       const mode = agentDef.config.agents?.find(
@@ -55,6 +61,7 @@ export function useArchivedSendMessage({
           providerOverride: effectiveProvider,
           modelOverride: effectiveModel,
           modeOverride: await readAgentTurnMode(agentPath, tauriConfig.read),
+          mentions,
         });
         analytics.track("chat_message_sent", {
           provider: effectiveProvider,

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -173,6 +173,7 @@ import {
 } from "./tabs/provider-auth-feed";
 import { isToolRuntimeErrorMessage } from "./tool-runtime-feed";
 import { useChatDisplayLabels } from "./use-chat-display-labels";
+import { type ChatMentionProps, useChatMentions } from "./use-chat-mentions";
 import { useChatSenderAvatars } from "./use-chat-sender-avatars";
 import { useToolkitBrandResolver } from "./use-toolkit-brand-resolver";
 import { UserSkillMessage } from "./user-skill-message";
@@ -258,6 +259,10 @@ interface AgentChatPanelProps {
   agentLabel: ChatPanelProps["agentLabel"];
   /** Face for a message's sender: teammate photo/initials, or the agent mark. */
   renderSenderAvatar: ChatPanelProps["renderSenderAvatar"];
+  /** The @mention props (HOU-944), spread as ONE group at every AIBoard mount:
+   *  the composer's roster, the render roster, the row face and the labels.
+   *  Every list is empty off multiplayer, so "@" just types plainly. */
+  mentionProps: ChatMentionProps;
   /** Prop-driven dictation control for the composer mic. Undefined on web
    *  (no native mic capture) — ChatPanel hides the mic entirely. */
   dictation: ChatPanelProps["dictation"];
@@ -521,6 +526,10 @@ export function useAgentChatPanel({
     agent,
     sessionFeedItems,
   );
+
+  // @mentions of teammates (HOU-944): the space roster the composer offers and
+  // the renderer chips against. Empty off multiplayer — "@" then types plainly.
+  const mentionProps = useChatMentions();
 
   // The live turn state for this conversation, for the pending-interaction
   // override: `running` gates the card (a running turn shows the composer, not
@@ -905,7 +914,7 @@ export function useAgentChatPanel({
   const handleSkillComposerSubmit = useCallback<
     NonNullable<AIBoardProps["onComposerSubmit"]>
   >(
-    async ({ sessionKey, text, files }) => {
+    async ({ sessionKey, text, files, mentions }) => {
       const skill = activeSkill;
       if (!skill || !agent || !path) return false;
 
@@ -940,6 +949,9 @@ export function useAgentChatPanel({
           modelOverride: effectiveModel,
           effortOverride: effectiveEffort,
           modeOverride: turnMode,
+          // A Skill send still carries whatever the user typed alongside it, so
+          // the teammates they named there must ride too (HOU-944).
+          mentions,
         });
       } else {
         // New conversation: createMission with `title` override so the
@@ -963,6 +975,7 @@ export function useAgentChatPanel({
             modelOverride: effectiveModel,
             effortOverride: effectiveEffort,
             modeOverride: turnMode,
+            mentions,
             buildPrompt: async (activityId) => {
               const paths = await tauriAttachments.save(
                 `activity-${activityId}`,
@@ -2110,6 +2123,7 @@ export function useAgentChatPanel({
     showSenders,
     agentLabel,
     renderSenderAvatar,
+    mentionProps,
     dictation,
   };
 }

--- a/app/src/components/use-chat-mentions.tsx
+++ b/app/src/components/use-chat-mentions.tsx
@@ -1,0 +1,58 @@
+/**
+ * @mentions of teammates in a chat (HOU-944) — the app half.
+ *
+ * `ui/chat` never fetches: it takes the roster, the row avatar and the labels
+ * as props. This hook resolves all four from the active space's co-member
+ * directory and hands them to `ChatPanel` (via `AIBoard`). Off multiplayer the
+ * rosters are empty, so `@` just types plainly and no popover ever opens.
+ */
+
+import type { ChatPanelProps, MentionPerson } from "@houston-ai/chat";
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useOrgPeople } from "../hooks/queries/use-org-people";
+import { PersonFace } from "./mission-person-face";
+
+/** The four @mention props an `AIBoard` mount forwards to its `ChatPanel`. */
+export interface ChatMentionProps {
+  /** Teammates the composer can @mention (the viewer excluded). */
+  mentionPeople: ChatPanelProps["mentionPeople"];
+  /** Roster an agent reply's "@Name" runs are chipped against (viewer included). */
+  messageMentionPeople: ChatPanelProps["messageMentionPeople"];
+  /** Face for a row in the @mention popover. */
+  renderMentionAvatar: ChatPanelProps["renderMentionAvatar"];
+  /** Localized labels for the @mention popover. */
+  mentionLabels: ChatPanelProps["mentionLabels"];
+}
+
+export function useChatMentions(): ChatMentionProps {
+  const { t } = useTranslation("chat");
+  const { people, mentionable } = useOrgPeople();
+
+  // Same face the sender line and the board stacks render, so one person wears
+  // one opaque `person.*` tone everywhere — the `id` is what supplies it.
+  const renderMentionAvatar = useCallback(
+    (person: MentionPerson) => (
+      <PersonFace
+        person={{
+          id: person.userId,
+          label: person.name,
+          imageUrl: person.imageUrl,
+        }}
+      />
+    ),
+    [],
+  );
+
+  const mentionLabels = useMemo(
+    () => ({ listAriaLabel: t("mentions.listAriaLabel") }),
+    [t],
+  );
+
+  return {
+    mentionPeople: mentionable,
+    messageMentionPeople: people,
+    renderMentionAvatar,
+    mentionLabels,
+  };
+}

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -1,5 +1,5 @@
 import type { KanbanItem } from "@houston-ai/board";
-import type { FeedItem } from "@houston-ai/chat";
+import type { FeedItem, MessageMention } from "@houston-ai/chat";
 import { messagePreviewText } from "@houston-ai/chat";
 import { useQueryClient } from "@tanstack/react-query";
 import { createElement, useCallback, useMemo, useRef, useState } from "react";
@@ -31,8 +31,10 @@ import {
 } from "../lib/tauri";
 import { readAgentTurnMode } from "../lib/turn-mode";
 import type { Agent } from "../lib/types";
+import { attachMissionUnread } from "../lib/unread-model";
 import { useAgentCatalogStore } from "../stores/agent-catalog";
 import { useUIStore } from "../stores/ui";
+import { useBoardUnread } from "./board/use-board-unread";
 import { resolveActivityOverride } from "./mission-control-send";
 import { AgentCardAvatar } from "./shell/agent-card-avatar";
 
@@ -82,7 +84,7 @@ export function useMissionControl(agents: Agent[]) {
     return m;
   }, [agents]);
 
-  const items: KanbanItem[] = useMemo(() => {
+  const builtItems: KanbanItem[] = useMemo(() => {
     if (!convos) return [];
     const map: Record<string, string> = {};
     const sessionMap: Record<
@@ -142,6 +144,17 @@ export function useMissionControl(agents: Agent[]) {
     sessionMapRef.current = sessionMap;
     return result;
   }, [convos, agentColorMap, agentMap, getAgentDef, multiplayer, profiles, t]);
+
+  // Per-mission unread marks (HOU-945), joined on as a LAST pass rather than
+  // computed inside the card build: a read cursor moves on every mission open,
+  // and folding it into the build above would rebuild every card (and the
+  // path/session maps) each time. Identity pass-through when nothing is unread,
+  // so single player keeps the exact same array reference.
+  const unreadIds = useBoardUnread(convos);
+  const items = useMemo(
+    () => attachMissionUnread(builtItems, unreadIds),
+    [builtItems, unreadIds],
+  );
 
   // The open conversation's reactive feed, straight from the SDK conversation
   // VM. AIBoard only ever reads `feedItems[activeSessionKey]`, so a
@@ -211,7 +224,12 @@ export function useMissionControl(agents: Agent[]) {
   );
 
   const handleSendMessage = useCallback(
-    async (sessionKey: string, text: string, files: File[]) => {
+    async (
+      sessionKey: string,
+      text: string,
+      files: File[],
+      mentions?: MessageMention[],
+    ) => {
       const entry = sessionMapRef.current[sessionKey];
       if (!entry) return;
       const { agentPath, activityId } = entry;
@@ -243,6 +261,7 @@ export function useMissionControl(agents: Agent[]) {
         // user's words, not the built prompt.
         await tauriChat.send(agentPath, prompt, sessionKey, {
           ...overrides,
+          mentions,
           queuedPreview: {
             text,
             attachmentNames: files.map((f) => f.name),
@@ -281,6 +300,8 @@ export function useMissionControl(agents: Agent[]) {
         promptFile?: string;
         providerOverride?: string;
         modelOverride?: string;
+        /** Teammates the first message @mentions (HOU-944). */
+        mentions?: MessageMention[];
       },
     ): Promise<string> => {
       const agentPath = agent.folderPath;
@@ -302,6 +323,7 @@ export function useMissionControl(agents: Agent[]) {
             promptFile: opts?.promptFile,
             providerOverride: opts?.providerOverride,
             modelOverride: opts?.modelOverride,
+            mentions: opts?.mentions,
             // Per-agent composer memory; Mission Control has no pill state.
             modeOverride: await readAgentTurnMode(agentPath, tauriConfig.read),
             titleText: visible,

--- a/app/src/hooks/completion-notification.ts
+++ b/app/src/hooks/completion-notification.ts
@@ -1,0 +1,152 @@
+import type { TFunction } from "i18next";
+import { actingUser } from "../lib/acting-user";
+import {
+  completionInteractionReady,
+  interactionNotificationBodyKey,
+  interactionQuestionCount,
+} from "../lib/active-interaction";
+import { latestCachedAllConversations } from "../lib/all-conversations-cache";
+import { logger } from "../lib/logger";
+import {
+  type NotificationNav,
+  resolveNotificationTarget,
+} from "../lib/notification-nav";
+import {
+  type SessionConversationRow,
+  shouldNotifyCompletion,
+} from "../lib/notification-relevance";
+import { queryClient } from "../lib/query-client";
+import type { Agent } from "../lib/types";
+import type { CompletionLatches } from "./completion-latches";
+import { sendSessionNotification } from "./session-notifications";
+import {
+  getConversationBoardStatus,
+  getConversationInteraction,
+} from "./use-conversation-vm";
+
+/**
+ * Everything the completion notification needs from the shell, passed in rather
+ * than read from stores here, so this module stays a plain function over data.
+ */
+export interface CompletionNotificationContext {
+  agents: Agent[];
+  workspaceName: string;
+  /** Name to fall back to when the finished agent is not in the loaded list. */
+  fallbackAgentName: string;
+  /** Read at FIRE time, so the copy follows a language change mid-turn. */
+  t: () => TFunction<["common"]>;
+}
+
+/** The translated body for the interaction the turn settled on. */
+function completionBody(
+  t: TFunction<["common"]>,
+  agentPath: string,
+  sessionKey: string,
+): string {
+  const interaction = getConversationInteraction(agentPath, sessionKey) ?? null;
+  switch (interactionNotificationBodyKey(interaction)) {
+    case "sessionComplete.question":
+      return t("common:notifications.sessionComplete.question", {
+        count: interactionQuestionCount(interaction),
+      });
+    case "sessionComplete.signin":
+      return t("common:notifications.sessionComplete.signin");
+    case "sessionComplete.connect":
+      return t("common:notifications.sessionComplete.connect");
+    case "sessionComplete.credential":
+      return t("common:notifications.sessionComplete.credential");
+    default:
+      return t("common:notifications.sessionComplete.body");
+  }
+}
+
+/**
+ * Should this completed session interrupt the signed-in user? (HOU-945)
+ *
+ * In a team many agents run in parallel, so "a mission finished" is only news
+ * when the mission is MINE or @mentions me; otherwise the ping trains the user
+ * to dismiss every ping, including the ones that matter. The rule itself lives
+ * in `lib/notification-relevance.ts` (pure, unit-tested) and fails OPEN: an
+ * unattributed mission, a mission the roster cache has not described yet, and a
+ * signed-out user all notify, so desktop and single-player behaviour stay
+ * byte-identical to before this gate existed.
+ *
+ * `selfId` is read HERE rather than when the latch was armed: a latch can
+ * outlive a sign-in or sign-out by its grace window, and the person worth
+ * interrupting is whoever is signed in when the notification actually fires.
+ */
+function isRelevantCompletion(agentPath: string, sessionKey: string): boolean {
+  return shouldNotifyCompletion({
+    rows: latestCachedAllConversations<SessionConversationRow[]>(queryClient),
+    agentPath,
+    sessionKey,
+    selfId: actingUser()?.userId ?? null,
+  });
+}
+
+/**
+ * Arm the OS notification for a session that just completed.
+ *
+ * The body depends on the interaction the turn settled on, which
+ * `persistBoardStatus` folds into the conversation VM AFTER the `SessionStatus`
+ * event but BEFORE the settle's `ActivityChanged` echo. So the notification is
+ * LATCHED here and sent on that echo: `ready` gates the fire on the fold having
+ * landed, and the send reads the settled body (see `completion-latches.ts`).
+ *
+ * The nav target is resolved now, against the agent that FINISHED (matched by
+ * folder path) rather than the one currently open, so clicking the notification
+ * jumps to it even after the user switched agents or closed the chat.
+ */
+export function latchCompletionNotification(
+  latches: CompletionLatches,
+  agentPath: string,
+  sessionKey: string,
+  ctx: CompletionNotificationContext,
+): void {
+  const { agentName, nav } = resolveNotificationTarget(
+    ctx.agents,
+    agentPath,
+    sessionKey,
+    ctx.fallbackAgentName,
+  );
+  warnIfUnnavigable(nav, agentPath, sessionKey);
+
+  const title = ctx.t()("common:notifications.sessionComplete.title", {
+    workspace: ctx.workspaceName,
+    agent: agentName,
+  });
+
+  latches.latch(
+    agentPath,
+    sessionKey,
+    () =>
+      completionInteractionReady(
+        getConversationBoardStatus(agentPath, sessionKey),
+      ),
+    () => {
+      const body = completionBody(ctx.t(), agentPath, sessionKey);
+      if (!isRelevantCompletion(agentPath, sessionKey)) {
+        logger.debug(
+          `[notification] completion suppressed, mission not relevant to the signed-in user: agent_path=${agentPath} session_key=${sessionKey}`,
+        );
+        return;
+      }
+      sendSessionNotification(title, body, nav);
+    },
+  );
+}
+
+/** A chat that should have been navigable but isn't is a real (silent) defect,
+ *  so it leaves a breadcrumb instead of failing quietly. */
+function warnIfUnnavigable(
+  nav: NotificationNav | undefined,
+  agentPath: string,
+  sessionKey: string,
+): void {
+  if (nav) return;
+  if (!sessionKey.startsWith("activity-") && !sessionKey.startsWith("routine-"))
+    return;
+  logger.debug(
+    `[notification] completed chat not navigable (agent not in loaded list?): agent_path=${agentPath} session_key=${sessionKey}`,
+  );
+}

--- a/app/src/hooks/notification-click-listeners.ts
+++ b/app/src/hooks/notification-click-listeners.ts
@@ -1,0 +1,88 @@
+import { listenOsEvent } from "../lib/events";
+import { logger } from "../lib/logger";
+import { shouldNavigateOnAppActivation } from "../lib/notification-nav";
+import { isMac } from "../lib/platform";
+import { useAgentStore } from "../stores/agents";
+import { useWorkspaceStore } from "../stores/workspaces";
+import {
+  consumePendingNav,
+  describePendingNotificationNav,
+  listenForNotificationFocus,
+} from "./session-notifications";
+
+/**
+ * Every path by which a notification CLICK reaches the app, wired in one place.
+ *
+ * There is no single cross-platform click event, which is the whole reason this
+ * is fiddly enough to deserve its own module:
+ *  - **mobile only** — the plugin's Actions API (`onAction`). A no-op on every
+ *    desktop OS; kept for when Houston ships a mobile shell.
+ *  - **macOS** — no desktop click event exists, so app ACTIVATION is the click
+ *    proxy (`app-activated`, plus a Tauri window-focus fallback).
+ *  - **Linux/Windows** — a genuine, distinct `notification-clicked` event from
+ *    `notification.rs`. On those platforms activation must NOT navigate, or
+ *    refocusing Houston for any reason would yank the user back to a finished
+ *    mission.
+ * `shouldNavigateOnAppActivation` is the pure rule that keeps those apart.
+ *
+ * `app-activated` additionally drives an unconditional silent agent-list
+ * refresh, so external changes (a Finder delete) are picked up when the window
+ * comes forward. Silent on purpose: flipping `loading:true` would unmount the
+ * whole tree and wipe open modals, sub-tabs and panels.
+ *
+ * Returns a disposer that detaches everything.
+ */
+export function listenForNotificationClicks(): () => void {
+  const navigate = (source: string) => {
+    logger.debug(
+      `[notification] ${source} fired: pendingNav=${describePendingNotificationNav()}`,
+    );
+    consumePendingNav().catch((e) => {
+      logger.error(`[notification] consumePendingNav (${source}) failed: ${e}`);
+    });
+  };
+
+  let unlistenAction: (() => void) | undefined;
+  import("@tauri-apps/plugin-notification").then(({ onAction }) => {
+    onAction((action) => {
+      logger.debug(
+        `[notification] onAction payload: ${JSON.stringify(action)}`,
+      );
+      navigate("onAction");
+    })
+      .then((unlisten) => {
+        unlistenAction = () => {
+          unlisten.unregister();
+        };
+      })
+      .catch((e) => {
+        logger.debug(`[notification] onAction registration failed: ${e}`);
+      });
+  });
+
+  const unlistenActivated = listenOsEvent<unknown>("app-activated", () => {
+    if (shouldNavigateOnAppActivation(isMac)) navigate("app-activated");
+    const ws = useWorkspaceStore.getState().current;
+    if (ws) useAgentStore.getState().loadAgents(ws.id, { silent: true });
+  });
+
+  const unlistenClick = listenOsEvent<unknown>("notification-clicked", () => {
+    navigate("notification-clicked");
+  });
+
+  // macOS-only window-focus fallback (see listenForNotificationFocus).
+  const unlistenFocus = listenForNotificationFocus();
+
+  return () => {
+    unlistenActivated();
+    unlistenClick();
+    unlistenAction?.();
+    unlistenFocus
+      ?.then((fn) => fn())
+      .catch((e) => {
+        logger.debug(
+          `[notification] Tauri focus listener cleanup failed: ${e}`,
+        );
+      });
+  };
+}

--- a/app/src/hooks/queries/org-people-map.ts
+++ b/app/src/hooks/queries/org-people-map.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure wire-shape helpers for the space roster behind @mentions (HOU-944).
+ *
+ * Kept dependency-free (the one import is a type, erased at runtime) so the
+ * `GET /v1/org/people` -> `MentionPerson[]` projection, the named-only filter
+ * and the self exclusion are unit-tested under `node --test` without a live
+ * client. Same precedent as `user-profiles-map.ts`.
+ */
+
+import type { MentionPerson } from "@houston-ai/chat";
+
+/**
+ * One row of the gateway's sanitized co-member directory (`OrgPerson` on the
+ * wire): no email, no role, and BOTH display fields optional. Restated here as
+ * a bare shape so this module imports no client; a live `OrgPerson` from
+ * `@houston-ai/engine-client` structurally satisfies it.
+ */
+export interface OrgPersonRow {
+  userId: string;
+  displayName?: string;
+  photoUrl?: string;
+}
+
+/**
+ * The roster rows the composer and the renderer can actually use.
+ *
+ * A member with no `displayName` is DROPPED, not rendered under their id: the
+ * `@` autocomplete inserts plain text, and "@a1b2c3d4" is nonsense to a
+ * non-technical reader (see the `MentionPerson.name` contract). A blank or
+ * whitespace-only name counts as no name for the same reason. Order is
+ * preserved — the gateway already sorts named-first.
+ *
+ * Names are normalized to NFC here, at the boundary. "José" can arrive from
+ * GCIP as one precomposed character or as "e" plus a combining accent; the
+ * renderer measures a name's length to find its run in the message text, so
+ * the two forms have to agree before either is written into a composer or
+ * matched against a transcript.
+ */
+export function toMentionPeople(
+  people: readonly OrgPersonRow[],
+): MentionPerson[] {
+  const out: MentionPerson[] = [];
+  for (const person of people) {
+    const name = person.displayName?.normalize("NFC").trim();
+    if (!name) continue;
+    out.push({
+      userId: person.userId,
+      name,
+      // A member who never set a photo renders initials in their own tone.
+      ...(person.photoUrl ? { imageUrl: person.photoUrl } : {}),
+    });
+  }
+  return out;
+}
+
+/**
+ * The COMPOSER's list: the roster minus the caller. You do not @mention
+ * yourself, so the viewer never appears in the autocomplete — but they DO stay
+ * in the render roster, so an agent reply saying "@Julian" still chips for
+ * Julian. Signed out (`selfUserId` absent) nothing is excluded.
+ *
+ * Returns the input array itself when the caller isn't in it, so a roster that
+ * needs no filtering keeps its identity and memoized consumers don't repaint.
+ */
+export function excludeSelf(
+  people: readonly MentionPerson[],
+  selfUserId: string | null | undefined,
+): readonly MentionPerson[] {
+  if (!selfUserId) return people;
+  if (!people.some((p) => p.userId === selfUserId)) return people;
+  return people.filter((p) => p.userId !== selfUserId);
+}

--- a/app/src/hooks/queries/use-org-people.ts
+++ b/app/src/hooks/queries/use-org-people.ts
@@ -1,0 +1,70 @@
+import type { MentionPerson } from "@houston-ai/chat";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { isIdentityConfigured } from "../../lib/identity";
+import { isMultiplayer } from "../../lib/org-roles";
+import { tauriOrg } from "../../lib/tauri";
+import { useCapabilities } from "../use-capabilities";
+import { useSession } from "../use-session";
+import { excludeSelf, toMentionPeople } from "./org-people-map";
+
+/** Query key for the active space's co-member directory. */
+export const ORG_PEOPLE_KEY = "org-people";
+
+// Stable empty identity so a disabled hook (single-player, signed out, an
+// older gateway) hands every consumer the SAME array each render — a fresh
+// `[]` would repaint the memoized composer popover and message renderer.
+const EMPTY_PEOPLE: readonly MentionPerson[] = [];
+
+/** The two rosters @mentions need. See {@link useOrgPeople}. */
+export interface OrgPeopleRoster {
+  /**
+   * Everyone in the active space who has a display name, the VIEWER INCLUDED.
+   * This is the RENDER roster: an agent reply that writes "@Julian" must chip
+   * for Julian while Julian is the one reading it.
+   */
+  people: readonly MentionPerson[];
+  /**
+   * {@link people} minus the caller. This is the COMPOSER list: you do not
+   * @mention yourself.
+   */
+  mentionable: readonly MentionPerson[];
+}
+
+/**
+ * The active space's co-member directory for @mentions (HOU-944), from the
+ * gateway's `GET /v1/org/people`.
+ *
+ * Multiplayer-gated exactly like {@link useUserProfiles}: single-player and
+ * self-host have no roster to mention, and the route only exists on the hosted
+ * gateway. Off-gateway (or on a gateway predating the route, which 404s) the
+ * read degrades to an EMPTY list — `@` then just types plainly and no popover
+ * ever opens. This is a cosmetic, non-user-initiated read, so it never toasts
+ * and is never captured (see `tauriOrg.people`); a failure is indistinguishable
+ * from an empty space by design.
+ *
+ * Cached generously (a roster changes when someone joins or leaves). The query
+ * key is not space-scoped because switching spaces drops the whole query cache
+ * (knowledge-base/teams.md, Spaces).
+ */
+export function useOrgPeople(): OrgPeopleRoster {
+  const { capabilities } = useCapabilities();
+  const { data: session } = useSession();
+  const enabled = isIdentityConfigured() && isMultiplayer(capabilities);
+
+  const query = useQuery({
+    queryKey: [ORG_PEOPLE_KEY],
+    queryFn: () => tauriOrg.people().then(toMentionPeople),
+    enabled,
+    staleTime: 5 * 60_000,
+  });
+
+  const people = query.data ?? EMPTY_PEOPLE;
+  const selfUserId = session?.uid;
+  const mentionable = useMemo(
+    () => excludeSelf(people, selfUserId),
+    [people, selfUserId],
+  );
+
+  return { people, mentionable };
+}

--- a/app/src/hooks/use-mention-notifications.ts
+++ b/app/src/hooks/use-mention-notifications.ts
@@ -1,0 +1,150 @@
+import type { Capabilities } from "@houston-ai/engine-client";
+import type { TFunction } from "i18next";
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { actingUser } from "../lib/acting-user";
+import { latestCachedAllConversations } from "../lib/all-conversations-cache";
+import { isSetupChatMode } from "../lib/integration-chat-setup";
+import { logger } from "../lib/logger";
+import {
+  latestMentionFor,
+  type RelevanceConversation,
+} from "../lib/mission-relevance";
+import { resolveNotificationTarget } from "../lib/notification-nav";
+import { isMultiplayer } from "../lib/org-roles";
+import { queryClient } from "../lib/query-client";
+import { queryKeys } from "../lib/query-keys";
+import {
+  getReadCursorStore,
+  markConversationMentionNotified,
+} from "../lib/read-cursor-live-store";
+import { cursorKey, notifiedFloorFor } from "../lib/read-cursors";
+import { useAgentStore } from "../stores/agents";
+import type { UserProfile } from "./queries/use-user-profiles";
+import { USER_PROFILES_KEY } from "./queries/use-user-profiles";
+import { sendSessionNotification } from "./session-notifications";
+
+/**
+ * OS notifications for @mentions (HOU-945): when a teammate types your name in
+ * a mission, you hear about it even if Houston is in the background and the
+ * mission is not yours.
+ *
+ * There is no push channel for mentions, and adding one would mean a new
+ * subscription per user. Instead this rides the conversation lists the shell
+ * ALREADY sweeps: a raw `QueryCache.subscribe` (no query observer, so it can
+ * never trigger a fetch or wake a pod) watches the `all-conversations`
+ * aggregate and the per-agent `activity` lists, and re-scans the cached rows for
+ * a mention newer than the watermark this user has already been pinged about.
+ *
+ * The watermark ({@link markConversationMentionNotified}) is bumped BEFORE the
+ * notification is sent and persists to disk, so one mention aggregate pings
+ * exactly once — across re-renders, across a re-scan triggered a millisecond
+ * later by a sibling list, and across app restarts.
+ */
+
+/** The cached conversation row this hook reads. */
+interface MentionRow extends RelevanceConversation {
+  id: string;
+  title: string;
+  agent_path: string;
+  agent_name: string;
+  session_key: string;
+  /** Agent-mode id; guided setup chats are never a mention surface. */
+  agent?: string;
+  contributors?: { user_id: string; name?: string }[];
+}
+
+/**
+ * The mentioner's display name from state we ALREADY have: any cached
+ * `user-profiles` entry, else the name the row's own contributor stamp carries.
+ * A notification path must never fire a fetch, so an unresolved id simply falls
+ * back to the generic title.
+ */
+function mentionerName(row: MentionRow, userId: string): string | undefined {
+  for (const query of queryClient
+    .getQueryCache()
+    .findAll({ queryKey: [USER_PROFILES_KEY] })) {
+    const profiles = query.state.data;
+    if (!(profiles instanceof Map)) continue;
+    const name = (profiles as ReadonlyMap<string, UserProfile>).get(
+      userId,
+    )?.name;
+    if (name) return name;
+  }
+  return row.contributors?.find((c) => c.user_id === userId)?.name;
+}
+
+/**
+ * Notify for every mention of me that is newer than my watermark. Multiplayer
+ * and signed-in only: single-player has no teammates to be mentioned by, so on
+ * desktop this whole path is inert.
+ */
+function scanForMentions(t: TFunction<readonly ["common"]>): void {
+  const capabilities = queryClient.getQueryData<Capabilities>(
+    queryKeys.capabilities(),
+  );
+  if (!isMultiplayer(capabilities)) return;
+  const selfId = actingUser()?.userId ?? null;
+  if (!selfId) return;
+
+  const rows = latestCachedAllConversations<MentionRow[]>(queryClient) ?? [];
+  for (const row of rows) {
+    // Guided setup chats are excluded everywhere else in this feature (they
+    // have no board card, so a ping would open nothing); keep them out here.
+    if (isSetupChatMode(row.agent)) continue;
+    const latest = latestMentionFor(row, selfId);
+    if (!latest) continue;
+    const key = cursorKey(row.agent_path, row.id);
+    if (latest.at <= notifiedFloorFor(getReadCursorStore(), key)) continue;
+
+    // Bump first: a sibling list landing in the cache re-enters this scan
+    // synchronously, and the watermark is what makes that a no-op.
+    markConversationMentionNotified(row.agent_path, row.id, latest.at);
+    // Mentioning yourself is not news, and this path never sees one:
+    // `latestMentionFor` drops self-authored entries at the source, so the
+    // ping, the inbox row and the unread badge all agree about it.
+    const name = latest.mention.by
+      ? mentionerName(row, latest.mention.by)
+      : undefined;
+    const title = name
+      ? t("common:notifications.mentioned.title", { name })
+      : t("common:notifications.mentioned.titleUnknown");
+    const body = t("common:notifications.mentioned.body", {
+      mission: row.title,
+    });
+    const { nav } = resolveNotificationTarget(
+      useAgentStore.getState().agents,
+      row.agent_path,
+      row.session_key,
+      row.agent_name,
+    );
+    sendSessionNotification(title, body, nav).catch((e) => {
+      logger.error(`[notification] mention notification failed: ${e}`);
+    });
+  }
+}
+
+/**
+ * Mount once, at the top of the app, beside `useSessionEvents()`. Watches the
+ * conversation caches and pings on every new @mention of the signed-in user.
+ */
+export function useMentionNotifications(): void {
+  const { t } = useTranslation(["common"]);
+  const tRef = useRef(t);
+  tRef.current = t;
+
+  useEffect(() => {
+    return queryClient.getQueryCache().subscribe((event) => {
+      const head = event.query.queryKey[0];
+      if (head !== "all-conversations" && head !== "activity") return;
+      try {
+        scanForMentions(tRef.current);
+      } catch (e) {
+        // Log-only, the documented exception: a passive cache observer has no
+        // UI thread to toast on, and throwing here would break the cache's
+        // notification loop for every other subscriber in the app.
+        logger.error(`[notification] mention scan failed: ${e}`);
+      }
+    });
+  }, []);
+}

--- a/app/src/hooks/use-read-cursors.ts
+++ b/app/src/hooks/use-read-cursors.ts
@@ -1,0 +1,87 @@
+import { useEffect, useSyncExternalStore } from "react";
+import { conversationIdForChat } from "../lib/chat-conversation-id";
+import { logger } from "../lib/logger";
+import { queryClient } from "../lib/query-client";
+import {
+  getReadCursorStore,
+  markConversationRead,
+  subscribeToReadCursors,
+} from "../lib/read-cursor-live-store";
+import type { ReadCursorStore } from "../lib/read-cursors";
+
+/**
+ * The React bindings for the app's live read-cursor store (HOU-945): one hook
+ * to READ it and one to FEED it.
+ *
+ * Everything stateful lives in `lib/read-cursor-live-store.ts`, which is
+ * React-free so a notification callback running with no component mounted reads
+ * the very same store the shell paints. This module adds only the two things
+ * that genuinely need React: the external-store subscription, and the effect
+ * that mounts the "conversation viewed" observer.
+ */
+
+/** The live cursor store for the signed-in user (a fresh empty store when
+ *  signed out). Re-renders the caller whenever a cursor moves. */
+export function useReadCursorStore(): ReadCursorStore {
+  return useSyncExternalStore(
+    subscribeToReadCursors,
+    getReadCursorStore,
+    getReadCursorStore,
+  );
+}
+
+/**
+ * Cache events that mean "this conversation is being read RIGHT NOW": it was
+ * just put on screen (`observerAdded`), or fresh content landed in it
+ * (`updated` — a refetch after the `ConversationsChanged` invalidation, i.e. a
+ * teammate's turn repainting the open chat).
+ *
+ * Everything else is deliberately ignored, and the exclusion is load-bearing
+ * rather than an optimization: `observerOptionsUpdated` fires on EVERY RENDER of
+ * every component holding the query (React Query hands the observer a fresh
+ * options object each time). Marking on those made the tracker a render-driven
+ * write — each one stamps a NEW `Date.now()`, so the cursor store changed on
+ * every render and notified its subscribers. That was invisible while only the
+ * sidebar read the store (it observes no chat history, so the cascade stopped),
+ * and became an infinite update loop the moment a SECOND surface subscribed:
+ * store change → board re-render → options updated → new cursor → store change.
+ */
+const VIEWED_EVENTS = new Set(["observerAdded", "updated"]);
+
+/**
+ * Mounts the "conversation viewed" tracker. Call once, at the top of the app.
+ *
+ * The seam is the `["chat-history", agentPath, sessionKey]` query that EVERY
+ * surface opening a chat mounts, observed raw so no surface has to remember to
+ * report anything. `getObserversCount() > 0` is what makes it mean "open on
+ * screen" rather than "still in cache". It re-marks on every VIEWED event (see
+ * {@link VIEWED_EVENTS}), not just the first, so a conversation the user is
+ * watching while it streams cannot go stale-unread under them.
+ */
+export function useReadCursorTracker(): void {
+  useEffect(() => {
+    return queryClient.getQueryCache().subscribe((event) => {
+      if (!VIEWED_EVENTS.has(event.type)) return;
+      const [head, agentPath, sessionKey] = event.query.queryKey;
+      if (head !== "chat-history") return;
+      if (typeof agentPath !== "string" || agentPath === "") return;
+      if (typeof sessionKey !== "string" || sessionKey === "") return;
+      if (event.query.getObserversCount() <= 0) return;
+      try {
+        // Null means the caches cannot yet name this chat's mission. Writing a
+        // cursor anyway would key it by something no reader ever looks up (see
+        // `chat-conversation-id.ts`); the events above re-fire once the lists
+        // land, and THAT pass marks the real key.
+        const conversationId = conversationIdForChat(agentPath, sessionKey);
+        if (conversationId === null) return;
+        markConversationRead(agentPath, conversationId);
+      } catch (e) {
+        // Log-only, the documented exception: this is a passive cache observer
+        // with no UI thread to toast on, and the worst outcome is a badge that
+        // stays lit until the next open. Never let it break the query cache's
+        // notification loop for every other subscriber.
+        logger.error(`[read-cursors] failed to mark conversation read: ${e}`);
+      }
+    });
+  }, []);
+}

--- a/app/src/hooks/use-session-events.ts
+++ b/app/src/hooks/use-session-events.ts
@@ -1,32 +1,14 @@
 import type { HoustonEvent } from "@houston-ai/core";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  completionInteractionReady,
-  interactionNotificationBodyKey,
-  interactionQuestionCount,
-} from "../lib/active-interaction";
-import { listenOsEvent, subscribeHoustonEvents } from "../lib/events";
+import { subscribeHoustonEvents } from "../lib/events";
 import { logger } from "../lib/logger";
-import {
-  resolveNotificationTarget,
-  shouldNavigateOnAppActivation,
-} from "../lib/notification-nav";
-import { isMac } from "../lib/platform";
 import { useAgentStore } from "../stores/agents";
 import { useUIStore } from "../stores/ui";
 import { useWorkspaceStore } from "../stores/workspaces";
 import { CompletionLatches } from "./completion-latches";
-import {
-  consumePendingNav,
-  describePendingNotificationNav,
-  listenForNotificationFocus,
-  sendSessionNotification,
-} from "./session-notifications";
-import {
-  getConversationBoardStatus,
-  getConversationInteraction,
-} from "./use-conversation-vm";
+import { latchCompletionNotification } from "./completion-notification";
+import { listenForNotificationClicks } from "./notification-click-listeners";
 
 /**
  * How long a completed session waits for its settle `ActivityChanged` echo
@@ -91,78 +73,22 @@ export function useSessionEvents() {
           // is the turn sink's job (it pushes the failure into the VM feed).
           // This listener owns only the OS notification on completion.
           if (status === "completed") {
-            const workspace = h.getWorkspace();
-            const workspaceName = workspace?.name ?? "Personal";
-
-            // Activity status flip (→ "needs_you") is owned by the
-            // engine now — `sessions::start` spawns a task that writes
-            // the terminal status after the runner finishes and emits
-            // `ActivityChanged`. That way anything that skips this webview
-            // (the web app, a scheduled run) sees the same transition. Here
-            // we only need the notification title + the click-to-navigate
-            // target.
-            //
-            // Target the agent that *finished* (matched by folder path),
-            // not the currently-open one, so clicking the notification
-            // jumps to it even after the user switched agents or closed
-            // the chat. consumePendingNav() switches the active agent.
-            const { agentName, nav } = resolveNotificationTarget(
-              useAgentStore.getState().agents,
+            // Activity status flip (→ "needs_you") is owned by the engine now
+            // — `sessions::start` writes the terminal status after the runner
+            // finishes and emits `ActivityChanged`, so anything that skips this
+            // webview (the web app, a scheduled run) sees the same transition.
+            // All this listener owns is the OS notification: title, body, nav
+            // target and the relevance gate all live in
+            // `completion-notification.ts`.
+            latchCompletionNotification(
+              latchesRef.current,
               agent_path,
               session_key,
-              h.getAgent()?.name ?? "Agent",
-            );
-            if (
-              !nav &&
-              (session_key.startsWith("activity-") ||
-                session_key.startsWith("routine-"))
-            ) {
-              logger.debug(
-                `[notification] completed chat not navigable (agent not in loaded list?): agent_path=${agent_path} session_key=${session_key}`,
-              );
-            }
-
-            const title = h.t("common:notifications.sessionComplete.title", {
-              workspace: workspaceName,
-              agent: agentName,
-            });
-            // Latch: the body depends on the interaction the turn settled on,
-            // which `persistBoardStatus` folds into the VM AFTER this event but
-            // BEFORE the settle's `ActivityChanged` echo. `ready` gates the echo
-            // fire on that fold having landed; the send reads the settled body.
-            latchesRef.current.latch(
-              agent_path,
-              session_key,
-              () =>
-                completionInteractionReady(
-                  getConversationBoardStatus(agent_path, session_key),
-                ),
-              () => {
-                const interaction =
-                  getConversationInteraction(agent_path, session_key) ?? null;
-                const bodyKey = interactionNotificationBodyKey(interaction);
-                const body =
-                  bodyKey === "sessionComplete.question"
-                    ? handlersRef.current.t(
-                        "common:notifications.sessionComplete.question",
-                        { count: interactionQuestionCount(interaction) },
-                      )
-                    : bodyKey === "sessionComplete.signin"
-                      ? handlersRef.current.t(
-                          "common:notifications.sessionComplete.signin",
-                        )
-                      : bodyKey === "sessionComplete.connect"
-                        ? handlersRef.current.t(
-                            "common:notifications.sessionComplete.connect",
-                          )
-                        : bodyKey === "sessionComplete.credential"
-                          ? handlersRef.current.t(
-                              "common:notifications.sessionComplete.credential",
-                            )
-                          : handlersRef.current.t(
-                              "common:notifications.sessionComplete.body",
-                            );
-                sendSessionNotification(title, body, nav);
+              {
+                agents: useAgentStore.getState().agents,
+                workspaceName: h.getWorkspace()?.name ?? "Personal",
+                fallbackAgentName: h.getAgent()?.name ?? "Agent",
+                t: () => handlersRef.current.t,
               },
             );
           }
@@ -189,99 +115,14 @@ export function useSessionEvents() {
       }
     });
 
-    // Notification "action performed" listener. NOTE: the plugin's Actions API
-    // only fires on mobile — on every desktop OS this is a no-op. Desktop
-    // notification clicks navigate via the `app-activated` / focus path below
-    // (macOS: OS app-activation on click; Linux/Windows: the Rust command in
-    // notification.rs raises the window and emits `app-activated`). Kept for
-    // when Houston ships a mobile shell.
-    let unlistenNotificationAction: (() => void) | undefined;
-    import("@tauri-apps/plugin-notification").then(({ onAction }) => {
-      onAction((action) => {
-        logger.debug(
-          `[notification] onAction fired: ${JSON.stringify(action)} pendingNav=${describePendingNotificationNav()}`,
-        );
-        consumePendingNav().catch((e) => {
-          logger.error(
-            `[notification] consumePendingNav (onAction) failed: ${e}`,
-          );
-        });
-      })
-        .then((unlisten) => {
-          unlistenNotificationAction = () => {
-            unlisten.unregister();
-          };
-        })
-        .catch((e) => {
-          logger.debug(`[notification] onAction registration failed: ${e}`);
-        });
-    });
-
-    // `app-activated` fires on ANY foregrounding (window focus, dock click,
-    // RunEvent::Resumed) — not just a notification click. So it drives two
-    // different things:
-    //
-    //  - Navigation: only on macOS, where the JS notification plugin has no
-    //    desktop click event and a click is indistinguishable from activation.
-    //    On Linux/Windows a real click arrives as the distinct
-    //    `notification-clicked` event below, so navigating here would yank the
-    //    user back to a finished mission whenever they refocus Houston for any
-    //    reason — the bug we're fixing.
-    //  - Agent-list refresh: always, so external changes (e.g. Finder delete)
-    //    are picked up when the window comes forward.
-    const unlistenActivated = listenOsEvent<unknown>("app-activated", () => {
-      logger.debug(
-        `[notification] app-activated event fired: pendingNav=${describePendingNotificationNav()}`,
-      );
-      if (shouldNavigateOnAppActivation(isMac)) {
-        consumePendingNav().catch((e) => {
-          logger.error(
-            `[notification] consumePendingNav (app-activated) failed: ${e}`,
-          );
-        });
-      }
-      const ws = useWorkspaceStore.getState().current;
-      if (ws) {
-        // Silent refresh — don't flip loading:true, which would unmount the
-        // entire UI tree and wipe local state (open modals, sub-tabs, panels).
-        useAgentStore.getState().loadAgents(ws.id, { silent: true });
-      }
-    });
-
-    // Linux/Windows: a genuine notification click (emitted by notification.rs).
-    // This is the ONLY foregrounding that should navigate to the finished
-    // mission on those platforms. macOS never emits it (uses the focus path).
-    const unlistenNotifClick = listenOsEvent<unknown>(
-      "notification-clicked",
-      () => {
-        logger.debug(
-          `[notification] notification-clicked event fired: pendingNav=${describePendingNotificationNav()}`,
-        );
-        consumePendingNav().catch((e) => {
-          logger.error(
-            `[notification] consumePendingNav (notification-clicked) failed: ${e}`,
-          );
-        });
-      },
-    );
-
-    // Fallback: Tauri window focus event (macOS only — see listenForNotificationFocus).
-    const unlistenTauriFocus = listenForNotificationFocus();
+    // Every way a notification click can reach us (per-OS; see the module).
+    const unlistenClicks = listenForNotificationClicks();
 
     const latches = latchesRef.current;
     return () => {
       latches.dispose();
       unlisten();
-      unlistenActivated();
-      unlistenNotifClick();
-      unlistenNotificationAction?.();
-      unlistenTauriFocus
-        ?.then((fn) => fn())
-        .catch((e) => {
-          logger.debug(
-            `[notification] Tauri focus listener cleanup failed: ${e}`,
-          );
-        });
+      unlistenClicks();
     };
   }, []);
 }

--- a/app/src/lib/agent-provisioning.ts
+++ b/app/src/lib/agent-provisioning.ts
@@ -10,8 +10,11 @@
  * shape; the Zustand store (`stores/agent-provisioning.ts`) wires it to the
  * real engine client, toast, and localStorage.
  *
- * Kept dependency-free so `node --test` can exercise it directly.
+ * Kept dependency-free so `node --test` can exercise it directly (the one
+ * import below is a type, erased at runtime).
  */
+
+import type { MessageMention } from "@houston-ai/engine-client";
 
 /**
  * Small, always-present, side-effect-free per-agent read. This is the typed
@@ -115,6 +118,9 @@ export interface PendingWarmingSend {
   effort?: string;
   /** Per-turn mode pin (composer "Mode" selector), forwarded at flush time. */
   mode?: "execute" | "plan" | "auto";
+  /** Teammates this message @mentions (HOU-944). Plain JSON, so it survives
+   *  the localStorage mirror and a relaunch mid-warm-up alongside the text. */
+  mentions?: MessageMention[];
   /** Epoch ms the message was queued — orders the optimistic board rows. */
   queuedAt?: number;
   /**

--- a/app/src/lib/chat-conversation-id.ts
+++ b/app/src/lib/chat-conversation-id.ts
@@ -1,0 +1,53 @@
+// Extension-qualified so the module resolves under plain `node --test` as well
+// as Vite: its null-vs-id contract is what the read-cursor tracker branches on,
+// and that has to be assertable against a real query cache.
+import { latestCachedAllConversations } from "./all-conversations-cache.ts";
+import { activityIdForSessionKey } from "./notification-nav.ts";
+import { queryClient } from "./query-client.ts";
+import { queryKeys } from "./query-keys.ts";
+
+/** A cached row that can answer "which conversation is this chat?". */
+interface ChatKeyRow {
+  id: string;
+  session_key?: string;
+  agent_path?: string;
+}
+
+/**
+ * The conversation id behind an OPEN chat, resolved from cache alone — or
+ * `null` when the caches cannot yet name it.
+ *
+ * The `["chat-history", agentPath, sessionKey]` query key's third segment is a
+ * SESSION key (`activity-<id>`, or a routine's own `routine-<id>`), not a
+ * conversation id, so it goes through the board's own derivation
+ * ({@link activityIdForSessionKey}) against whatever the cache already holds:
+ * the agent's board rows first, else the all-conversations aggregate.
+ *
+ * Cache reads ONLY, never a fetch. The one caller is a passive query-cache
+ * observer (the read-cursor tracker), and in hosted mode a read here would be
+ * the thing that wakes a sleeping pod.
+ *
+ * **Null rather than the raw session key.** Falling back to the session key
+ * looked like it kept the mapping stable, but it produced a cursor under a key
+ * NOTHING reads: every unread surface looks the cursor up by the conversation's
+ * own id (`cursorKey(agent_path, conv.id)`), which for a routine chat has no
+ * relation to `routine-<id>` at all. So a cold cache wrote a cursor that could
+ * never clear the badge it was meant to clear, and left an orphan behind in a
+ * capped store. Skipping the write instead costs nothing: the tracker re-fires
+ * on the very cache events that make the lists resolvable, and that pass marks
+ * the real key.
+ */
+export function conversationIdForChat(
+  agentPath: string,
+  sessionKey: string,
+): string | null {
+  const board = queryClient.getQueryData<ChatKeyRow[]>(
+    queryKeys.activity(agentPath),
+  );
+  const rows =
+    board ??
+    (latestCachedAllConversations<ChatKeyRow[]>(queryClient) ?? []).filter(
+      (row) => row.agent_path === agentPath,
+    );
+  return activityIdForSessionKey(rows, sessionKey);
+}

--- a/app/src/lib/create-mission-warming.ts
+++ b/app/src/lib/create-mission-warming.ts
@@ -72,6 +72,7 @@ export function createMissionWhileWarming(
       model: opts.modelOverride,
       effort: opts.effortOverride,
       mode: opts.modeOverride,
+      mentions: opts.mentions,
       titleText: opts.title ? undefined : titleText,
     });
   if (!queued) {
@@ -111,6 +112,7 @@ export function createMissionWhileWarming(
         modelOverride: opts.modelOverride,
         effortOverride: opts.effortOverride,
         modeOverride: opts.modeOverride,
+        mentions: opts.mentions,
       });
       // The engine answers now, so the AI title pass runs like the normal
       // path's (createMission fires it right after the first send).

--- a/app/src/lib/create-mission.ts
+++ b/app/src/lib/create-mission.ts
@@ -4,6 +4,7 @@
  * and the mobile sync responder so the flow stays identical.
  */
 
+import type { MessageMention } from "@houston-ai/engine-client";
 import { isAgentProvisioning } from "../stores/agent-provisioning";
 import { analytics } from "./analytics";
 import { createMissionWhileWarming } from "./create-mission-warming";
@@ -73,6 +74,9 @@ export interface CreateMissionOptions {
   effortOverride?: string;
   /** Per-turn mode pin (composer "Mode" selector) forwarded to tauriChat.send. */
   modeOverride?: "execute" | "plan" | "auto";
+  /** Teammates the first message @mentions (HOU-944), forwarded to
+   *  tauriChat.send as a sidecar beside the prompt. */
+  mentions?: MessageMention[];
   /**
    * Explicit activity title. Overrides the default `autoTitleFromText(text)`.
    * Used by action invocations where `text` is a structured marker that
@@ -134,6 +138,7 @@ export async function createMission(
       modelOverride: opts.modelOverride,
       effortOverride: opts.effortOverride,
       modeOverride: opts.modeOverride,
+      mentions: opts.mentions,
       // `buildPrompt` swaps in a prompt the user should not see (a hidden setup
       // directive, or attachment paths appended to their words) — so the bubble
       // renders the clean `text` instead, live and on every history reload.

--- a/app/src/lib/mission-relevance.ts
+++ b/app/src/lib/mission-relevance.ts
@@ -1,0 +1,149 @@
+import type { UserProfile } from "../hooks/queries/use-user-profiles.ts";
+import { missionMatchesScope } from "./agent-person-scope.ts";
+import {
+  buildMissionPeople,
+  type MissionAttribution,
+} from "./mission-people.ts";
+
+/**
+ * Pure, DOM-free model of the ONE question every relevance-scoped surface asks:
+ * does this mission concern ME? (HOU-945.) No React, no store, no Supabase — so
+ * the rule is unit-tested once and shared verbatim by the completion
+ * notification, the unread badges, and the Mentions inbox, which must never
+ * drift apart.
+ *
+ * Two load-bearing fail-OPEN clauses. Neither may be dropped:
+ *
+ * 1. **No signed-in user (`selfId === null`) means everything is relevant.**
+ *    Desktop and single player have no attribution at all; the whole feature has
+ *    to be a no-op there, so behaviour stays byte-identical to today.
+ * 2. **An unknown mission (`undefined`) is relevant.** Callers resolve a mission
+ *    from a cache that can legitimately be a beat behind the event that woke
+ *    them. Guessing "not mine" on a cache miss would swallow a real ping — the
+ *    one failure mode a notification can never have — so a miss notifies.
+ *
+ * The "is it mine" half deliberately delegates to {@link missionMatchesScope}
+ * with the `me` scope rather than re-deriving the rule, which is what carries
+ * its own third fail-open clause into this module: a mission with NO attribution
+ * whatsoever counts as mine. Legacy and pre-Teams missions carry no
+ * `created_by`/`contributors`, and treating them as somebody else's would go
+ * silent on a long-tenured user's entire history on day one of this change.
+ */
+
+/** One entry of a mission's @mention aggregate (HOU-945). */
+export interface MissionMention {
+  user_id: string;
+  /** ISO 8601 instant of the newest mention of this person on this mission. */
+  at: string;
+  /** Who wrote the mention (user id), when the gateway stamped it. */
+  by?: string;
+}
+
+/** The subset of a conversation row every relevance decision reads. */
+export interface RelevanceConversation extends MissionAttribution {
+  mentioned?: MissionMention[];
+}
+
+/**
+ * Membership is decided on ids alone, so the face-stack builder is fed an empty
+ * profile map: resolving display names would drag a React Query hook into a
+ * module that must stay importable under plain node.
+ */
+const NO_PROFILES: ReadonlyMap<string, UserProfile> = new Map();
+
+/**
+ * Is this mission MINE? Delegates to the `me` person scope over the mission's
+ * face stack, so the "created by me OR I contributed OR nobody is stamped at
+ * all" rule lives in exactly one place ({@link missionMatchesScope}).
+ */
+export function missionIsMine(
+  conv: RelevanceConversation,
+  selfId: string,
+): boolean {
+  return missionMatchesScope(
+    buildMissionPeople(conv, NO_PROFILES),
+    { kind: "me" },
+    selfId,
+  );
+}
+
+/**
+ * Does ONE aggregate entry count as a ping for `selfId`? It has to name me AND
+ * have been written by somebody else. Typing your own name in a mission is not
+ * news: it would otherwise earn a permanent Mentions-inbox row and a
+ * mention-unread badge that no amount of reading can clear, because the mention
+ * clause of {@link isUnreadForMe} deliberately has no `since` floor. The OS ping
+ * already refuses to fire on a self-authored mention
+ * (`hooks/use-mention-notifications.ts`), so applying the same rule at the
+ * source is what keeps the three surfaces telling one story instead of leaving a
+ * badge behind for a notification that was never sent.
+ *
+ * `by` is OPTIONAL, and an entry that carries none STILL COUNTS. The gateway
+ * only began stamping mention authors with this feature, so an unstamped entry
+ * is a real mention from before the stamp; reading "no author" as "me" would
+ * silently swallow a whole generation of them. `mention.by !== selfId` — rather
+ * than a `by` presence check — is therefore the load-bearing shape here, not an
+ * accident of how the comparison happens to be written.
+ */
+function isPingForMe(mention: MissionMention, selfId: string): boolean {
+  return mention.user_id === selfId && mention.by !== selfId;
+}
+
+/** Does the mention aggregate name me, written by somebody else? See
+ *  {@link isPingForMe} for why a self-authored entry never counts and why an
+ *  entry with no stamped author still does. */
+export function missionMentionsMe(
+  conv: RelevanceConversation,
+  selfId: string,
+): boolean {
+  return (conv.mentioned ?? []).some((m) => isPingForMe(m, selfId));
+}
+
+/**
+ * The newest mention of `selfId` on this mission, with its epoch ms — the one
+ * derivation of "when was I last pinged here", so the inbox row and the
+ * notification watermark can never disagree about which entry is newest.
+ *
+ * Self-authored entries are skipped ({@link isPingForMe}), which is what stops
+ * my own typing from filling my own inbox.
+ *
+ * An entry whose `at` does not parse is IGNORED rather than treated as now or
+ * as epoch zero: a malformed timestamp from the wire must not fabricate a fresh
+ * ping, and must not hide a well-formed sibling entry either.
+ */
+export function latestMentionFor(
+  conv: RelevanceConversation,
+  selfId: string,
+): { mention: MissionMention; at: number } | null {
+  let best: { mention: MissionMention; at: number } | null = null;
+  for (const mention of conv.mentioned ?? []) {
+    if (!isPingForMe(mention, selfId)) continue;
+    const at = Date.parse(mention.at);
+    if (Number.isNaN(at)) continue;
+    if (!best || at > best.at) best = { mention, at };
+  }
+  return best;
+}
+
+/** Epoch ms of the newest mention of `selfId`, or null. */
+export function latestMentionAtFor(
+  conv: RelevanceConversation,
+  selfId: string,
+): number | null {
+  return latestMentionFor(conv, selfId)?.at ?? null;
+}
+
+/**
+ * The one relevance rule the whole feature reads: a mission signals ME when it
+ * is mine, or when it @mentions me. `selfId === null` (signed out / single
+ * player) always true, so desktop behaviour is byte-identical to today. An
+ * unknown mission (`undefined`) also true: we fail OPEN, never swallowing a
+ * real ping. See the module doc for why both clauses are load-bearing.
+ */
+export function isRelevantToMe(
+  conv: RelevanceConversation | undefined,
+  selfId: string | null,
+): boolean {
+  if (selfId === null || !conv) return true;
+  return missionIsMine(conv, selfId) || missionMentionsMe(conv, selfId);
+}

--- a/app/src/lib/notification-relevance.ts
+++ b/app/src/lib/notification-relevance.ts
@@ -1,0 +1,65 @@
+import {
+  isRelevantToMe,
+  type RelevanceConversation,
+} from "./mission-relevance.ts";
+
+/**
+ * Pure, DOM-free decision behind the completion OS notification (HOU-945): the
+ * session that just finished belongs to a mission, and only missions that
+ * concern me are worth interrupting me for.
+ *
+ * It lives outside `hooks/session-notifications.ts` on purpose. That module is
+ * all side effect — Tauri windows, the notification plugin, OS permission — and
+ * is therefore untestable; the RULE it applies is the part that must never
+ * regress, so the rule is here, pure, and the hook keeps only the plumbing.
+ *
+ * Everything about this module fails OPEN. In a team, a missed ping is a
+ * teammate waiting on a mission nobody knows finished; an extra ping is a
+ * moment of noise. So an unresolvable session, an unattributed mission, and a
+ * signed-out user all notify. See {@link isRelevantToMe}.
+ */
+
+/** The conversation-list row shape this module matches sessions against. */
+export interface SessionConversationRow extends RelevanceConversation {
+  agent_path: string;
+  session_key: string;
+}
+
+/**
+ * Find the mission a completed session belongs to. Session keys are unique
+ * within an agent but NOT across agents (`activity-<n>` restarts per agent), so
+ * the agent path is part of the match, never an optimization.
+ *
+ * `undefined` when the roster cache has no row for it — a real and expected
+ * state, since the completion event can land before the conversation list that
+ * would describe it. Callers must treat that as "unknown", not as "not mine".
+ */
+export function findSessionConversation(
+  rows: readonly SessionConversationRow[] | undefined,
+  agentPath: string,
+  sessionKey: string,
+): SessionConversationRow | undefined {
+  return rows?.find(
+    (row) => row.agent_path === agentPath && row.session_key === sessionKey,
+  );
+}
+
+/**
+ * Should a completed session's OS notification fire? Relevance-scoped
+ * (HOU-945): only my missions, missions I contributed to, missions that
+ * @mention me — and everything, byte-identically, when there is no signed-in
+ * user or the mission carries no attribution at all.
+ */
+export function shouldNotifyCompletion(args: {
+  rows: readonly SessionConversationRow[] | undefined;
+  agentPath: string;
+  sessionKey: string;
+  selfId: string | null;
+}): boolean {
+  const conv = findSessionConversation(
+    args.rows,
+    args.agentPath,
+    args.sessionKey,
+  );
+  return isRelevantToMe(conv, args.selfId);
+}

--- a/app/src/lib/read-cursor-live-store.ts
+++ b/app/src/lib/read-cursor-live-store.ts
@@ -1,0 +1,200 @@
+import { actingUser } from "./acting-user.ts";
+import { queryClient } from "./query-client.ts";
+import {
+  cursorKey,
+  markMentionNotified,
+  markRead,
+  type ReadCursorStore,
+} from "./read-cursors.ts";
+import { mergeReadCursorStores } from "./read-cursors-merge.ts";
+import {
+  type CursorStorage,
+  loadReadCursors,
+  pruneForeignCursorStores,
+  readCursorStorageKey,
+  saveReadCursors,
+} from "./read-cursors-storage.ts";
+
+/**
+ * The app's ONE live read-cursor store (HOU-945): the singleton the sidebar
+ * badge, the Mentions inbox and the mention notifier all read, so they can never
+ * disagree about what the user has already seen.
+ *
+ * React-free on purpose. The rules live in the pure `read-cursors*.ts` modules;
+ * this one owns the mutable instance, its persistence and its subscribers, and
+ * the React bindings are a thin `useSyncExternalStore` wrapper in
+ * `hooks/use-read-cursors.ts`. That split is what lets a notification callback —
+ * which runs with no component mounted — read the same store the shell paints.
+ *
+ * **The tradeoff, deliberately taken: cursors are per-device `localStorage`, NOT
+ * host preferences.** An unread badge is local reading state, and the user
+ * experiences clearing it as instant. Persisting it host-side would put a
+ * request on every mission open, and in hosted mode that request can be the
+ * thing that WAKES a sleeping pod, which is an absurd price for a dot. The cost
+ * we accept: a second device starts from its own `since` floor instead of
+ * inheriting what you already read there. Nothing is lost that the user cannot
+ * clear by opening the mission, which is the same gesture that cleared it on the
+ * first device.
+ *
+ * A second TAB, unlike a second device, is not a tradeoff — it is the normal way
+ * people use the web app, and both tabs write the same key. So every save merges
+ * against disk and adopts the result, and a `storage` event (which fires only in
+ * the OTHER tabs) folds their writes into this one live. See
+ * `read-cursors-storage.ts` for why last-writer-wins was never acceptable.
+ *
+ * Uid changes are picked up by subscribing to the `["session"]` query in the
+ * shared cache — the same raw `QueryCache.subscribe` pattern the sidebar
+ * summaries use (`use-agent-activity-summaries.ts`), which attaches no query
+ * observer and therefore can never trigger a fetch or wake a pod. Non-React
+ * callers additionally get a lazy re-check on every read, so a notification
+ * firing before any component subscribed still resolves the right user.
+ */
+
+/** `localStorage`, or null where there is none (Tauri splash window, SSR-style
+ *  builds, node tests). Resolved per call so the module never touches a DOM
+ *  global at import time. */
+function storage(): CursorStorage | null {
+  return typeof localStorage === "undefined" ? null : localStorage;
+}
+
+let currentUid: string | null = null;
+let currentStore: ReadCursorStore = { since: Date.now(), cursors: {} };
+let resolvedOnce = false;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+/**
+ * Re-point the singleton at the signed-in user, reloading from disk when the
+ * uid changed. Returns whether it changed, so callers only notify on a real
+ * swap. A signed-out user gets a fresh empty store rather than the previous
+ * user's, so one account can never paint another's badges.
+ *
+ * A real sign-in is also the moment to evict the accounts nobody is using: it
+ * is the only point where we know which uid is current, and it happens once per
+ * swap rather than on every write.
+ */
+function syncUid(): boolean {
+  const uid = actingUser()?.userId ?? null;
+  if (resolvedOnce && uid === currentUid) return false;
+  resolvedOnce = true;
+  currentUid = uid;
+  const store = storage();
+  if (uid && store) {
+    currentStore = loadReadCursors(store, uid);
+    pruneForeignCursorStores(store, uid);
+  } else {
+    currentStore = { since: Date.now(), cursors: {} };
+  }
+  return true;
+}
+
+/** Non-React read, for callbacks (notifications) and for React's snapshot. */
+export function getReadCursorStore(): ReadCursorStore {
+  syncUid();
+  return currentStore;
+}
+
+/**
+ * Adopt a new store and persist it. The pure mutators return the SAME reference
+ * when nothing changed, so the identity check here is what keeps a re-render
+ * (and a `localStorage` write) off the common no-op path.
+ *
+ * What lands in memory is what {@link saveReadCursors} actually WROTE, not what
+ * the caller passed: the write merges with whatever another tab has put on disk
+ * since our last load, and keeping the pre-merge value would let this tab
+ * overwrite that tab again on its next save.
+ */
+function setStore(next: ReadCursorStore): void {
+  if (next === currentStore) return;
+  const store = storage();
+  currentStore =
+    store && currentUid ? saveReadCursors(store, currentUid, next) : next;
+  emit();
+}
+
+/** Record that a conversation was just seen. No-op when signed out. */
+export function markConversationRead(
+  agentPath: string,
+  conversationId: string,
+  at: number = Date.now(),
+): void {
+  const store = getReadCursorStore();
+  if (!currentUid) return;
+  setStore(markRead(store, cursorKey(agentPath, conversationId), at));
+}
+
+/** Record that we have already OS-pinged the user about a mention here. */
+export function markConversationMentionNotified(
+  agentPath: string,
+  conversationId: string,
+  at: number,
+): void {
+  const store = getReadCursorStore();
+  if (!currentUid) return;
+  setStore(
+    markMentionNotified(store, cursorKey(agentPath, conversationId), at),
+  );
+}
+
+/**
+ * Fold another tab's write into this tab's live store.
+ *
+ * No write-back: every save merges before it writes, so disk is already a
+ * superset of what either tab knows, and re-saving here would bounce a write
+ * back at the tab we just heard from. The merge still runs (rather than a plain
+ * replace) for two reasons: it returns the same reference when nothing new
+ * arrived, which keeps a `storage` event from re-rendering the shell for
+ * nothing, and it means a tab that CLEARS the origin can never delete cursors
+ * out of this tab's memory — watermarks only move forward.
+ */
+function adoptStoredCursors(): void {
+  const store = storage();
+  if (!store || !currentUid) return;
+  const merged = mergeReadCursorStores(
+    currentStore,
+    loadReadCursors(store, currentUid),
+  );
+  if (merged === currentStore) return;
+  currentStore = merged;
+  emit();
+}
+
+/** Cross-tab handler. A null `key` is a whole-origin `clear()` (a sign-out
+ *  elsewhere), which goes through the same merge as any write to our key. */
+function onStorageEvent(event: StorageEvent): void {
+  if (
+    event.key !== null &&
+    (!currentUid || event.key !== readCursorStorageKey(currentUid))
+  )
+    return;
+  adoptStoredCursors();
+}
+
+let storageListenerAttached = false;
+
+/**
+ * Subscribe to cursor movement, in `useSyncExternalStore`'s shape.
+ *
+ * The cross-tab listener is attached ONCE for the lifetime of the process
+ * rather than per subscriber: it serves one global concern, and tying it to a
+ * subscription would let the first component to unmount tear it out from under
+ * every other reader.
+ */
+export function subscribeToReadCursors(onStoreChange: () => void): () => void {
+  if (!storageListenerAttached && typeof window !== "undefined") {
+    storageListenerAttached = true;
+    window.addEventListener("storage", onStorageEvent);
+  }
+  listeners.add(onStoreChange);
+  const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+    if (event.query.queryKey[0] !== "session") return;
+    if (syncUid()) emit();
+  });
+  return () => {
+    listeners.delete(onStoreChange);
+    unsubscribe();
+  };
+}

--- a/app/src/lib/read-cursors-merge.ts
+++ b/app/src/lib/read-cursors-merge.ts
@@ -1,0 +1,80 @@
+import {
+  capCursors,
+  type ReadCursor,
+  type ReadCursorStore,
+} from "./read-cursors.ts";
+
+/**
+ * Combining two views of the SAME user's read cursors (HOU-945).
+ *
+ * It exists because the store persists as ONE whole-blob value per user, and a
+ * browser lets the user open Houston in as many tabs as they like. A plain
+ * overwrite is therefore last-writer-wins: the tab that saves second silently
+ * erases every mission the other tab marked read while it was open, and the
+ * badges the user already cleared light up again on the next reload.
+ *
+ * The rule is per conversation, never per blob: take the LATER of each
+ * watermark. A cursor can then only be lost if both views are behind on it,
+ * which cannot happen. Read cursors only ever move forward in time, which is
+ * what makes this merge (rather than a lock, a lease, or a broadcast channel)
+ * the honest fix: the two tabs are not in conflict, they each know part of the
+ * truth.
+ *
+ * Split out of `read-cursors.ts` because that module answers "what does one
+ * view of the world say?" while this one answers "how do two of them combine?"
+ * — and because keeping the algebra readable matters more than keeping it in
+ * one file.
+ */
+
+/** The later of each watermark; returns `a` when it already leads on both, so
+ *  the merge above can detect "nothing changed" by identity. */
+function mergeCursor(a: ReadCursor, b: ReadCursor): ReadCursor {
+  const readAt = Math.max(a.readAt, b.readAt);
+  const notifiedAt =
+    a.notifiedAt === undefined
+      ? b.notifiedAt
+      : b.notifiedAt === undefined
+        ? a.notifiedAt
+        : Math.max(a.notifiedAt, b.notifiedAt);
+  if (readAt === a.readAt && notifiedAt === a.notifiedAt) return a;
+  return notifiedAt === undefined ? { readAt } : { readAt, notifiedAt };
+}
+
+/**
+ * Merge `incoming` into `base`, taking the later of every watermark.
+ *
+ * `since` takes the EARLIER of the two, because it records when this device
+ * first knew this user: adopting a later floor would silently mark somebody's
+ * backlog read, which is the one direction this feature must never move in
+ * without the user's own gesture.
+ *
+ * Returns `base` unchanged when `incoming` contributes nothing, so merging on
+ * every save costs no extra write and no re-render on the overwhelmingly common
+ * path where this tab is the only writer — the same skip-the-write contract the
+ * cursor mutators give.
+ */
+export function mergeReadCursorStores(
+  base: ReadCursorStore,
+  incoming: ReadCursorStore,
+): ReadCursorStore {
+  let changed = incoming.since < base.since;
+  const cursors: Record<string, ReadCursor> = { ...base.cursors };
+  for (const [key, other] of Object.entries(incoming.cursors)) {
+    const mine = cursors[key];
+    if (mine !== undefined) {
+      const merged = mergeCursor(mine, other);
+      if (merged === mine) continue;
+      cursors[key] = merged;
+    } else {
+      cursors[key] = other;
+    }
+    changed = true;
+  }
+  if (!changed) return base;
+  return {
+    since: Math.min(base.since, incoming.since),
+    // A union of two tabs' cursor sets is the other way the map can cross the
+    // growth cap, and it must land on the same survivors a single tab would.
+    cursors: capCursors(cursors),
+  };
+}

--- a/app/src/lib/read-cursors-parse.ts
+++ b/app/src/lib/read-cursors-parse.ts
@@ -1,0 +1,99 @@
+import type { ReadCursor, ReadCursorStore } from "./read-cursors.ts";
+
+/**
+ * Decoder for the persisted read-cursor blob (HOU-945).
+ *
+ * Split out of `read-cursors.ts` because it answers a different question: that
+ * module owns the cursor ALGEBRA (floors, watermarks, the growth cap) over a
+ * store it can trust, while this one is the boundary that decides what may be
+ * trusted at all. Everything crossing it is untyped text written by an older
+ * build, another tab, or a user with devtools open.
+ *
+ * It is total: it never throws, and it never returns a partially-typed store.
+ * A payload that is not an object, a `since` that is not a finite number, and a
+ * row that is not a cursor are each replaced or dropped INDIVIDUALLY, so one
+ * bad entry costs the user one conversation's read state rather than all of it.
+ */
+
+/**
+ * The schema version stamped on every blob this build writes.
+ *
+ * It is deliberately NOT a gate. This decoder validates field by field, so a
+ * blob from a build that predates the stamp (no `version` at all) and a blob
+ * from a FUTURE build both decode to exactly the fields they share with us —
+ * which is the whole point of the field-wise design, and the reason two Houston
+ * versions open in two tabs cannot corrupt each other. The number exists so a
+ * change that genuinely CANNOT be expressed field-wise has a marker to branch
+ * on; until such a change exists, nothing reads it.
+ */
+export const READ_CURSOR_SCHEMA_VERSION = 1;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+/** One stored entry, or null when it is not a cursor we can trust. */
+function parseCursor(value: unknown): ReadCursor | null {
+  if (!isRecord(value)) return null;
+  const readAt = finiteNumber(value.readAt);
+  if (readAt === undefined) return null;
+  const notifiedAt = finiteNumber(value.notifiedAt);
+  return notifiedAt === undefined ? { readAt } : { readAt, notifiedAt };
+}
+
+/** JSON.parse that answers `undefined` instead of throwing. */
+function decode(raw: string | null): Record<string, unknown> | undefined {
+  if (raw === null) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Decode a stored blob into a store, falling back to a fresh one floored at
+ * `now`.
+ *
+ * The empty-on-corruption fallback is a DELIBERATE silent recovery, the
+ * documented exception to the no-silent-failures rule: cursors are derived
+ * convenience state that the app rewrites within seconds of use, there is
+ * nothing here a user could act on, and letting a stray parse error escape
+ * would take down the shell over a badge.
+ */
+export function parseReadCursorStore(
+  raw: string | null,
+  now: number,
+): ReadCursorStore {
+  const parsed = decode(raw);
+  if (!parsed) return { since: now, cursors: {} };
+
+  const cursors: Record<string, ReadCursor> = {};
+  if (isRecord(parsed.cursors)) {
+    for (const [key, value] of Object.entries(parsed.cursors)) {
+      const cursor = parseCursor(value);
+      if (cursor) cursors[key] = cursor;
+    }
+  }
+  return { since: finiteNumber(parsed.since) ?? now, cursors };
+}
+
+/**
+ * When the blob was last written, epoch ms — 0 for anything that cannot say.
+ *
+ * Read WITHOUT decoding the cursors, because its one caller sweeps the blobs of
+ * OTHER accounts on this device to decide which to evict, and those are exactly
+ * the blobs whose contents are none of the current user's business. A blob with
+ * no stamp (written before this field existed) sorts oldest and is evicted
+ * first, which costs that account its read floor and nothing else.
+ */
+export function parseLastTouched(raw: string | null): number {
+  return finiteNumber(decode(raw)?.lastTouched) ?? 0;
+}

--- a/app/src/lib/read-cursors-storage.ts
+++ b/app/src/lib/read-cursors-storage.ts
@@ -1,0 +1,146 @@
+import type { ReadCursorStore } from "./read-cursors.ts";
+import { mergeReadCursorStores } from "./read-cursors-merge.ts";
+import {
+  parseLastTouched,
+  parseReadCursorStore,
+  READ_CURSOR_SCHEMA_VERSION,
+} from "./read-cursors-parse.ts";
+
+/**
+ * Where a user's read cursors live on this device, and the two rules that make
+ * ONE shared browser origin safe for them (HOU-945).
+ *
+ * Cursors live in ONE JSON blob per signed-in user ({@link
+ * readCursorStorageKey}) so two accounts on the same machine can never read
+ * each other's cursors, and so a sign-out cannot leave a half-migrated pile of
+ * per-conversation keys behind. That single-blob shape is what forces both
+ * rules here:
+ *
+ * 1. **Every write MERGES** ({@link saveReadCursors}) against whatever is on
+ *    disk at that instant. A second tab is not a rare case — it is the normal
+ *    way people use the web app — and a whole-blob overwrite would silently
+ *    erase the missions the other tab had already cleared.
+ * 2. **Foreign accounts are EVICTED** ({@link pruneForeignCursorStores}).
+ *    Nothing ever removed a signed-out account's blob, so a shared or
+ *    demo machine accreted one uncapped store per person who ever signed in,
+ *    against a ~5MB origin quota this app already shares with the query
+ *    persister.
+ *
+ * Storage is INJECTED ({@link CursorStorage}) rather than reached for as a
+ * global. That keeps the module importable under plain node with no DOM, so
+ * every rule here is unit-tested, and it means the module never touches
+ * `localStorage` at import time (which would throw in the Tauri splash window
+ * and in SSR-style builds).
+ */
+
+/**
+ * Minimal storage seam (`localStorage` in the app, a Map in tests). It is
+ * ENUMERABLE (`length` / `key`) because the foreign-account sweep has to
+ * discover blobs belonging to uids this session has never heard of.
+ */
+export interface CursorStorage {
+  getItem(k: string): string | null;
+  setItem(k: string, v: string): void;
+  removeItem(k: string): void;
+  readonly length: number;
+  key(index: number): string | null;
+}
+
+/** Shared by every account's blob, so the sweep can recognize its own family
+ *  of keys without touching anything else in the origin. */
+const KEY_PREFIX = "houston.read-cursors.";
+
+/**
+ * How many OTHER accounts' cursor blobs this device keeps.
+ *
+ * Small on purpose. The value of a signed-out account's cursors is "if you sign
+ * back in, your badges are where you left them", which is worth a few hundred
+ * bytes for the handful of accounts a person actually switches between and
+ * worth nothing for the long tail of one-off sign-ins on a shared machine.
+ * Losing an evicted account's blob costs it only its read floor: the store is
+ * recreated at the moment of the next sign-in, so nothing old appears unread.
+ */
+const MAX_FOREIGN_STORES = 4;
+
+/** localStorage key for one user. Per-uid so two accounts on one machine never
+ *  read each other's cursors. */
+export function readCursorStorageKey(uid: string): string {
+  return `${KEY_PREFIX}${uid}`;
+}
+
+/**
+ * Load (or create) a user's store. A corrupt or foreign payload is replaced
+ * with a fresh store rather than throwing — see `read-cursors-parse.ts` for why
+ * that silent recovery is the right call here.
+ */
+export function loadReadCursors(
+  storage: CursorStorage,
+  uid: string,
+  now: number = Date.now(),
+): ReadCursorStore {
+  return parseReadCursorStore(storage.getItem(readCursorStorageKey(uid)), now);
+}
+
+/**
+ * Persist a store, MERGED over whatever is on disk at this instant, and answer
+ * what was actually written.
+ *
+ * The read-modify-write is the point: between this tab's last load and this
+ * save, another tab may have cleared missions of its own. Callers must adopt
+ * the returned store rather than keeping the one they passed in, otherwise this
+ * tab's memory and the disk disagree until the next reload — and the badge the
+ * other tab cleared would come back on the next write from here.
+ */
+export function saveReadCursors(
+  storage: CursorStorage,
+  uid: string,
+  store: ReadCursorStore,
+  now: number = Date.now(),
+): ReadCursorStore {
+  const key = readCursorStorageKey(uid);
+  // Fall back to THIS store's own floor, so a first-ever write merges with an
+  // absent blob without inventing an earlier `since` out of the clock.
+  const stored = parseReadCursorStore(storage.getItem(key), store.since);
+  const merged = mergeReadCursorStores(store, stored);
+  storage.setItem(
+    key,
+    JSON.stringify({
+      version: READ_CURSOR_SCHEMA_VERSION,
+      since: merged.since,
+      // Stamped on every write and read only by the sweep below: it is how one
+      // account's blob answers "is anybody still using me?".
+      lastTouched: now,
+      cursors: merged.cursors,
+    }),
+  );
+  return merged;
+}
+
+/**
+ * Evict the read-cursor blobs of accounts other than `uid`, keeping the
+ * {@link MAX_FOREIGN_STORES} most recently written.
+ *
+ * The signed-in user's own blob is never a candidate, whatever its stamp says.
+ * Ties break on the key so the surviving set is deterministic, and every
+ * candidate is collected BEFORE anything is removed, because the seam's index
+ * shifts under a delete.
+ */
+export function pruneForeignCursorStores(
+  storage: CursorStorage,
+  uid: string,
+): void {
+  const mine = readCursorStorageKey(uid);
+  const foreign: { key: string; lastTouched: number }[] = [];
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i);
+    if (key === null || key === mine || !key.startsWith(KEY_PREFIX)) continue;
+    foreign.push({ key, lastTouched: parseLastTouched(storage.getItem(key)) });
+  }
+  if (foreign.length <= MAX_FOREIGN_STORES) return;
+  foreign.sort(
+    (a, b) => b.lastTouched - a.lastTouched || a.key.localeCompare(b.key),
+  );
+  for (const stale of foreign.slice(MAX_FOREIGN_STORES)) {
+    storage.removeItem(stale.key);
+  }
+}

--- a/app/src/lib/read-cursors.ts
+++ b/app/src/lib/read-cursors.ts
@@ -1,0 +1,173 @@
+/**
+ * Per-user last-read cursors and the mention-notification watermark (HOU-945)
+ * — the local memory behind "this mission has something new for me" and behind
+ * "I have already been pinged about this mention".
+ *
+ * Client-side on purpose: read state is a per-device convenience, not shared
+ * team truth, and routing it through the gateway would put a write on every
+ * mission open.
+ *
+ * This module is the cursor ALGEBRA alone: pure, DOM-free, importable under
+ * plain node, so every rule below is unit-tested without a browser. The two
+ * siblings own the edges — `read-cursors-storage.ts` decides where the blob
+ * lives, how concurrent tabs merge into it and when a signed-out account's
+ * cursors are evicted; `read-cursors-parse.ts` decides what an untrusted stored
+ * blob may be trusted to say.
+ *
+ * Three invariants the callers depend on:
+ * - **`since` is the floor.** A conversation with no cursor of its own is
+ *   treated as read up to the moment this store was created. Without it,
+ *   signing in on a second device would mark years of history unread on day
+ *   one, and re-notify every mention that ever happened.
+ * - **Reading a mission counts as having seen its mentions**
+ *   ({@link notifiedFloorFor}) — otherwise an @mention could OS-ping the user
+ *   about a conversation open on their screen.
+ * - **Every mutator returns the SAME reference when nothing changed**
+ *   ({@link markRead}, {@link markMentionNotified}, {@link
+ *   mergeReadCursorStores}), so callers skip the write (and the React state
+ *   update) without diffing.
+ */
+
+/** What we remember about one conversation, per signed-in user. */
+export interface ReadCursor {
+  /** Epoch ms the user last had this conversation open. */
+  readAt: number;
+  /** Epoch ms of the newest mention of this user we have already OS-notified. */
+  notifiedAt?: number;
+}
+
+export interface ReadCursorStore {
+  /** Epoch ms this store was first created for this user — the FLOOR for every
+   *  conversation with no cursor of its own. Without it, signing in on a second
+   *  device would mark years of history unread on day one. */
+  since: number;
+  cursors: Record<string, ReadCursor>;
+}
+
+/**
+ * How many conversations we remember per user. Cursors are unbounded by nature
+ * — every mission ever opened would earn one — and localStorage is a hard ~5MB
+ * per origin shared with the query persister, so an uncapped store would
+ * eventually make the whole shell fail to persist anything. 500 is far beyond
+ * any real backlog of missions a person revisits, and the entries we drop are
+ * the least recently touched, whose floor gracefully degrades to `since`.
+ */
+const MAX_CURSORS = 500;
+
+/** The stable per-conversation key. */
+export function cursorKey(agentPath: string, conversationId: string): string {
+  return `${agentPath}::${conversationId}`;
+}
+
+/** How recently this cursor was touched at all, by either watermark. */
+function touchedAt(cursor: ReadCursor): number {
+  return Math.max(cursor.readAt, cursor.notifiedAt ?? 0);
+}
+
+/**
+ * Keep the {@link MAX_CURSORS} most recently touched keys. Ties break on the
+ * key so the surviving set is deterministic across runs.
+ *
+ * Exported for `read-cursors-merge.ts` alone: a merge unions two tabs' cursor
+ * sets and so is the other way the map can cross the cap, and it must land on
+ * the SAME survivors this module would have kept.
+ */
+export function capCursors(
+  cursors: Record<string, ReadCursor>,
+): Record<string, ReadCursor> {
+  const entries = Object.entries(cursors);
+  if (entries.length <= MAX_CURSORS) return cursors;
+  entries.sort(
+    (a, b) => touchedAt(b[1]) - touchedAt(a[1]) || a[0].localeCompare(b[0]),
+  );
+  return Object.fromEntries(entries.slice(0, MAX_CURSORS));
+}
+
+function withCursor(
+  store: ReadCursorStore,
+  key: string,
+  cursor: ReadCursor,
+): ReadCursorStore {
+  return {
+    since: store.since,
+    cursors: capCursors({ ...store.cursors, [key]: cursor }),
+  };
+}
+
+/** Returns the SAME store reference when the cursor is already at/after `at`,
+ *  so callers skip the write. */
+export function markRead(
+  store: ReadCursorStore,
+  key: string,
+  at: number,
+): ReadCursorStore {
+  const current = store.cursors[key];
+  if (current && current.readAt >= at) return store;
+  return withCursor(store, key, { ...current, readAt: at });
+}
+
+/**
+ * Record that we have OS-notified the user about a mention at `at`. Same
+ * skip-the-write contract as {@link markRead}.
+ *
+ * Creating a cursor here seeds `readAt` with the store's `since`, NOT with
+ * `at`: being pinged about a mission is not the same as having read it, and
+ * seeding the read floor forward would silently clear the unread badge the ping
+ * was announcing. Seeding it with `since` leaves {@link readFloorFor}
+ * answering exactly what it answered before this call.
+ */
+export function markMentionNotified(
+  store: ReadCursorStore,
+  key: string,
+  at: number,
+): ReadCursorStore {
+  const current = store.cursors[key];
+  if (current?.notifiedAt !== undefined && current.notifiedAt >= at)
+    return store;
+  return withCursor(store, key, {
+    readAt: current?.readAt ?? store.since,
+    notifiedAt: at,
+  });
+}
+
+/** The read floor for one conversation: its own cursor, else the store's `since`. */
+export function readFloorFor(store: ReadCursorStore, key: string): number {
+  return store.cursors[key]?.readAt ?? store.since;
+}
+
+/**
+ * The floor an @mention must beat to earn an OS notification: the newest
+ * mention we have already pinged about, or the moment the user last OPENED the
+ * conversation, whichever is later (else the store's `since`).
+ *
+ * Folding `readAt` in is what stops the ping the user can already see.
+ * {@link markRead} deliberately never touches `notifiedAt` — the two
+ * watermarks answer different questions, and collapsing them at write time
+ * would let opening a mission claim we had pinged about a mention that is still
+ * outstanding in the badge. So they are combined HERE, at the one place that
+ * asks "do I still owe this user a ping?", where the answer is plainly no:
+ * a mention that landed in a conversation on my screen, or that predates the
+ * moment I opened it after a reload, has already been seen.
+ */
+export function notifiedFloorFor(store: ReadCursorStore, key: string): number {
+  const cursor = store.cursors[key];
+  if (!cursor) return store.since;
+  return Math.max(cursor.notifiedAt ?? store.since, cursor.readAt);
+}
+
+/**
+ * The read floor for a conversation that @MENTIONS me, which deliberately does
+ * NOT fall back to `since`: a mention names me personally, so "I have never
+ * opened this conversation" means the mention is still outstanding, however old
+ * it is. `since` exists to stop a fresh device flooding its badge with a
+ * backlog of ambient movement, and a mention is not ambient movement. Without
+ * this, signing in on a second device would silently mark every mention that
+ * predates the install as read, which is precisely the miss this feature was
+ * built to prevent.
+ */
+export function mentionReadFloorFor(
+  store: ReadCursorStore,
+  key: string,
+): number {
+  return store.cursors[key]?.readAt ?? 0;
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -19,6 +19,7 @@ import type {
   ComposioStatus as EngineComposioStatus,
   ProviderStatus as EngineProviderStatus,
   GenerateInstructionsResult,
+  MessageMention,
   ProviderAuthState,
   ProviderUsage,
 } from "@houston-ai/engine-client";
@@ -392,6 +393,13 @@ export const tauriChat = {
        * (see SessionStartRequest).
        */
       displayText?: string;
+      /**
+       * Teammates this message @mentions (HOU-944), a structured sidecar
+       * ALONGSIDE the prompt — the model only ever sees the plain "@Name" text.
+       * User-typed sends only; an agent/system-initiated send (retry prompt,
+       * auto-resume, routine) carries none (see SessionStartRequest).
+       */
+      mentions?: MessageMention[];
     },
   ) =>
     call<string>("send_message", async () => {
@@ -415,6 +423,9 @@ export const tauriChat = {
         // Who is sending: stamps the optimistic bubble so a shared conversation
         // attributes it immediately (HOU-943). Undefined signed out / local.
         author: actingUser(),
+        // Who this message names (HOU-944). An empty list means what absence
+        // means, so never put `[]` on the wire.
+        mentions: opts?.mentions?.length ? opts.mentions : undefined,
       });
       return res.sessionKey;
     }),
@@ -900,6 +911,9 @@ interface RawConversation {
   /** Humans who started or collaborated on this mission (Teams attribution).
    *  Server-stamped in multiplayer only; absent on desktop/single-player. */
   contributors?: { user_id: string; name?: string }[];
+  /** Teammates @mentioned in this mission's chat, latest per person.
+   *  Server-stamped in multiplayer only; absent on desktop/single-player. */
+  mentioned?: { user_id: string; at: string; by?: string }[];
 }
 
 export const tauriConversations = {
@@ -945,6 +959,7 @@ function conversationToRaw(
     routine_id: c.routine_id,
     created_by: c.created_by,
     contributors: c.contributors,
+    mentioned: c.mentioned,
   };
 }
 
@@ -1651,6 +1666,16 @@ export const tauriOrg = {
    *  Sentry) and consumers fall back to initials via React Query's `isError`. */
   profiles: (ids: string[]) =>
     call("get_org_profiles", () => getEngine().getOrgProfiles(ids), undefined, {
+      toast: false,
+      capture: false,
+    }),
+  /** The active space's sanitized co-member directory (HOU-944), the roster
+   *  the chat composer's @mention autocomplete offers. Same cosmetic,
+   *  non-user-initiated posture as `profiles`: it degrades to an empty list
+   *  off-gateway / on a gateway predating the route, so a rare hard failure
+   *  stays silent (no toast, no Sentry) and `@` simply types plainly. */
+  people: () =>
+    call("get_org_people", () => getEngine().getOrgPeople(), undefined, {
       toast: false,
       capture: false,
     }),

--- a/app/src/lib/unread-model.ts
+++ b/app/src/lib/unread-model.ts
@@ -1,0 +1,143 @@
+import type { KanbanItem } from "@houston-ai/board";
+import { isSetupChatMode } from "./integration-chat-setup.ts";
+import {
+  isRelevantToMe,
+  latestMentionAtFor,
+  type RelevanceConversation,
+} from "./mission-relevance.ts";
+import {
+  cursorKey,
+  mentionReadFloorFor,
+  type ReadCursorStore,
+  readFloorFor,
+} from "./read-cursors.ts";
+
+/**
+ * Pure, DOM-free unread model (HOU-945): which missions have moved since I last
+ * looked at them, and how many per agent — the numbers the sidebar paints.
+ *
+ * Unread is defined against MY read floor ({@link readFloorFor}), never against
+ * a server flag, so it stays correct with no write on every mission open and
+ * degrades to the store's `since` for anything I have never opened.
+ *
+ * Relevance comes first, deliberately: in a team, a teammate's mission moving
+ * is not news for me, and a sidebar that counts it teaches the user to ignore
+ * the badge. A mission that @mentions me counts even though I never touched it
+ * — the @mention IS the claim on my attention.
+ */
+
+export interface UnreadConversationInput extends RelevanceConversation {
+  id: string;
+  agent_path: string;
+  type: "primary" | "activity";
+  /** Agent-mode id; guided setup chats never count. */
+  agent?: string | null;
+  /** ISO 8601 instant of the mission's last movement. */
+  updated_at?: string;
+}
+
+/**
+ * Is this conversation unread FOR ME? Only relevant missions can be unread
+ * (relevance is the whole point). No `selfId` or a setup chat is never unread.
+ *
+ * "No `selfId` is never unread" is the mirror image of relevance failing open:
+ * with nobody signed in there is no per-person read state to compare against,
+ * so an unread badge would be a number nobody could ever clear. Notifications
+ * fail open because a missed ping is unrecoverable; a badge is not.
+ *
+ * TWO clocks, because the two signals are not the same claim:
+ *
+ * - An outstanding @MENTION of me wins outright, measured against my cursor for
+ *   this conversation ALONE ({@link mentionReadFloorFor} — no `since` fallback).
+ *   Someone typed my name; until I open the mission that is unread however old
+ *   it is and whether or not I have ever touched it. Judging a mention by
+ *   `updated_at` would also lose it the moment the mission moved on without me.
+ * - Otherwise ambient movement: `updated_at` strictly after my read floor, which
+ *   DOES fall back to `since` so a fresh device does not open on a backlog.
+ *
+ * Strictly-after (not at-or-after) so marking a mission read at the instant of
+ * its own `updated_at` clears it, instead of leaving it stuck unread.
+ */
+export function isUnreadForMe(
+  conv: UnreadConversationInput,
+  store: ReadCursorStore,
+  selfId: string | null,
+): boolean {
+  if (selfId === null) return false;
+  if (isSetupChatMode(conv.agent)) return false;
+  if (!isRelevantToMe(conv, selfId)) return false;
+
+  const key = cursorKey(conv.agent_path, conv.id);
+  const mentionedAt = latestMentionAtFor(conv, selfId);
+  if (mentionedAt !== null && mentionedAt > mentionReadFloorFor(store, key))
+    return true;
+
+  if (!conv.updated_at) return false;
+  const updatedAt = Date.parse(conv.updated_at);
+  if (Number.isNaN(updatedAt)) return false;
+  return updatedAt > readFloorFor(store, key);
+}
+
+/**
+ * Unread counts per `agent_path`. Setup chats and non-`activity` rows never
+ * count — the same exclusions the sidebar's needs-you badge already applies
+ * ({@link buildAgentActivitySummaries}), so the two badges can never disagree
+ * about what a mission is. Agents with nothing unread get no entry, so the
+ * caller reads a missing key as zero.
+ */
+export function countUnreadByAgentPath(
+  convs: readonly UnreadConversationInput[],
+  store: ReadCursorStore,
+  selfId: string | null,
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const conv of convs) {
+    if (conv.type !== "activity") continue;
+    if (!isUnreadForMe(conv, store, selfId)) continue;
+    counts[conv.agent_path] = (counts[conv.agent_path] ?? 0) + 1;
+  }
+  return counts;
+}
+
+/**
+ * The ids of the missions that are unread FOR ME — the per-card half of the
+ * same signal the sidebar counts, so a lit card and a lit agent row can never
+ * disagree. Same exclusions as {@link countUnreadByAgentPath} (only `activity`
+ * conversations become cards; the agent's primary chat is not a mission).
+ *
+ * A Set, not a flag on the row: the per-agent board builds its cards from the
+ * activity list, which carries no attribution at all, so the unread verdict has
+ * to be joined back on by mission id — exactly as the face stacks are.
+ */
+export function unreadMissionIds(
+  convs: readonly UnreadConversationInput[],
+  store: ReadCursorStore,
+  selfId: string | null,
+): ReadonlySet<string> {
+  const ids = new Set<string>();
+  for (const conv of convs) {
+    if (conv.type !== "activity") continue;
+    if (isUnreadForMe(conv, store, selfId)) ids.add(conv.id);
+  }
+  return ids;
+}
+
+/**
+ * Join the unread verdict onto board items by id. Identity pass-through when
+ * nothing is unread, so the items array KEEPS ITS REFERENCE and memoized cards
+ * never re-render — which is also what makes single player (where the set is
+ * always empty) byte-identical to before this feature.
+ *
+ * Only sets the key when true: an absent `unread` is what the card reads as
+ * "render nothing at all", and writing `unread: false` on every card would
+ * churn every item object on every cursor move for no visible difference.
+ */
+export function attachMissionUnread(
+  items: KanbanItem[],
+  unreadIds: ReadonlySet<string>,
+): KanbanItem[] {
+  if (unreadIds.size === 0) return items;
+  return items.map((item) =>
+    unreadIds.has(item.id) ? { ...item, unread: true } : item,
+  );
+}

--- a/app/src/lib/warming-sends.ts
+++ b/app/src/lib/warming-sends.ts
@@ -13,7 +13,10 @@
  * a relaunch the flush falls back to the message text alone.
  */
 
-import { pushPendingUserMessage } from "@houston-ai/engine-client";
+import {
+  type MessageMention,
+  pushPendingUserMessage,
+} from "@houston-ai/engine-client";
 import { getConversationFeed } from "../hooks/use-conversation-vm";
 import { actingUser } from "./acting-user";
 import type {
@@ -51,6 +54,9 @@ export interface QueueWarmingSendArgs {
   model?: string;
   effort?: string;
   mode?: "execute" | "plan" | "auto";
+  /** Teammates this message @mentions (HOU-944) — chipped on the local bubble
+   *  now, shipped with the deferred send at flush. */
+  mentions?: MessageMention[];
   /** Set = run the async AI title pass on this text once the flush lands. */
   titleText?: string;
   /** Row-only entry: no bubble now, no wire send at flush (HOU-713). */
@@ -70,11 +76,14 @@ export function buildWarmingSend(
     // Stamp the sender (HOU-943): the real send at flush suppresses its own
     // bubble, so this push is the row's ONLY chance to be attributed — without
     // it a warmed-up agent's first message stays nameless in a shared thread.
+    // `mentions` rides for the same reason (HOU-944): this push is the only
+    // chance the bubble ever gets to chip the teammates it named.
     pushPendingUserMessage(
       args.agentPath,
       args.sessionKey,
       args.text,
       actingUser(),
+      args.mentions,
     );
   }
   const send: PendingWarmingSend = {
@@ -87,6 +96,7 @@ export function buildWarmingSend(
     model: args.model,
     effort: args.effort,
     mode: args.mode,
+    mentions: args.mentions,
     queuedAt: Date.now(),
     titleText: args.titleText,
     rowOnly: args.rowOnly,
@@ -112,6 +122,7 @@ export function restoreWarmingBubbles(entry: ProvisioningEntry): void {
         send.sessionKey,
         send.text,
         author,
+        send.mentions,
       );
     }
   }
@@ -199,6 +210,7 @@ export async function flushWarmingSends(
         modelOverride: send.model,
         effortOverride: send.effort,
         modeOverride: send.mode,
+        mentions: send.mentions,
         suppressUserBubble: suppress,
         // A prompt builder rewrote the wire prompt (a hidden setup directive /
         // attachment paths) — persist the clean `send.text` as the bubble so a

--- a/app/src/locales/en/board.json
+++ b/app/src/locales/en/board.json
@@ -17,6 +17,9 @@
     "label": "People on this mission",
     "expand": "All people"
   },
+  "unread": {
+    "label": "Unread updates"
+  },
   "empty": {
     "title": "No conversations yet",
     "description": "Start a new conversation to delegate work to an agent.",

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -30,6 +30,9 @@
       "noMic": "No microphone was found."
     }
   },
+  "mentions": {
+    "listAriaLabel": "Mention a teammate"
+  },
   "attribution": {
     "you": "You"
   },

--- a/app/src/locales/en/common.json
+++ b/app/src/locales/en/common.json
@@ -49,6 +49,11 @@
       "connect": "Your agent needs you to connect an app.",
       "credential": "Your agent needs an API key to finish."
     },
+    "mentioned": {
+      "title": "{{name}} mentioned you",
+      "titleUnknown": "You were mentioned",
+      "body": "In {{mission}}"
+    },
     "preprompt": {
       "title": "Want a ping when your agent finishes?",
       "body": "Turn on notifications and Houston will let you know the moment a mission finishes or needs you.",

--- a/app/src/locales/en/dashboard.json
+++ b/app/src/locales/en/dashboard.json
@@ -5,6 +5,21 @@
     "button": "Archived",
     "title": "Archived"
   },
+  "mentions": {
+    "button": "Mentions",
+    "title": "Mentions",
+    "ariaCount_one": "{{count}} unread mention",
+    "ariaCount_other": "{{count}} unread mentions",
+    "row": {
+      "by": "{{name}} mentioned you",
+      "byUnknown": "You were mentioned",
+      "agent": "in {{agent}}"
+    },
+    "empty": {
+      "title": "No mentions yet",
+      "description": "When a teammate names you in a mission, it shows up here."
+    }
+  },
   "filter": {
     "allAgents": "All agents"
   },

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -25,6 +25,8 @@
     "needsYouCount_other": "{{count}} issues need you",
     "runningCount_one": "{{count}} issue running",
     "runningCount_other": "{{count}} issues running",
+    "unreadCount_one": "{{count}} unread update",
+    "unreadCount_other": "{{count}} unread updates",
     "collapse": "Collapse sidebar",
     "expand": "Expand sidebar",
     "createWorkspace": "Create workspace",

--- a/app/src/locales/es/board.json
+++ b/app/src/locales/es/board.json
@@ -17,6 +17,9 @@
     "label": "Personas en esta misión",
     "expand": "Todas las personas"
   },
+  "unread": {
+    "label": "Novedades sin leer"
+  },
   "empty": {
     "title": "Aún no hay conversaciones",
     "description": "Inicia una conversación nueva para delegarle trabajo a un agente.",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -30,6 +30,9 @@
       "noMic": "No se encontró ningún micrófono."
     }
   },
+  "mentions": {
+    "listAriaLabel": "Mencionar a un compañero"
+  },
   "attribution": {
     "you": "Tú"
   },

--- a/app/src/locales/es/common.json
+++ b/app/src/locales/es/common.json
@@ -49,6 +49,11 @@
       "connect": "Tu agente necesita que conectes una aplicación.",
       "credential": "Tu agente necesita una clave de API para terminar."
     },
+    "mentioned": {
+      "title": "{{name}} te mencionó",
+      "titleUnknown": "Te mencionaron",
+      "body": "En {{mission}}"
+    },
     "preprompt": {
       "title": "¿Quieres un aviso cuando tu agente termine?",
       "body": "Activa las notificaciones y Houston te avisará en cuanto una misión termine o te necesite.",

--- a/app/src/locales/es/dashboard.json
+++ b/app/src/locales/es/dashboard.json
@@ -5,6 +5,21 @@
     "button": "Archivadas",
     "title": "Archivadas"
   },
+  "mentions": {
+    "button": "Menciones",
+    "title": "Menciones",
+    "ariaCount_one": "{{count}} mención sin leer",
+    "ariaCount_other": "{{count}} menciones sin leer",
+    "row": {
+      "by": "{{name}} te mencionó",
+      "byUnknown": "Te mencionaron",
+      "agent": "en {{agent}}"
+    },
+    "empty": {
+      "title": "Aún no hay menciones",
+      "description": "Cuando alguien de tu equipo te nombre en una misión, aparece aquí."
+    }
+  },
   "filter": {
     "allAgents": "Todos los agentes"
   },

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -25,6 +25,8 @@
     "needsYouCount_other": "{{count}} asuntos necesitan tu atención",
     "runningCount_one": "{{count}} asunto en curso",
     "runningCount_other": "{{count}} asuntos en curso",
+    "unreadCount_one": "{{count}} novedad sin leer",
+    "unreadCount_other": "{{count}} novedades sin leer",
     "collapse": "Contraer barra lateral",
     "expand": "Expandir barra lateral",
     "createWorkspace": "Crear espacio de trabajo",

--- a/app/src/locales/pt/board.json
+++ b/app/src/locales/pt/board.json
@@ -17,6 +17,9 @@
     "label": "Pessoas nesta missão",
     "expand": "Todas as pessoas"
   },
+  "unread": {
+    "label": "Novidades não lidas"
+  },
   "empty": {
     "title": "Ainda sem conversas",
     "description": "Comece uma conversa nova para delegar trabalho a um agente.",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -30,6 +30,9 @@
       "noMic": "Nenhum microfone foi encontrado."
     }
   },
+  "mentions": {
+    "listAriaLabel": "Mencionar um colega"
+  },
   "attribution": {
     "you": "Você"
   },

--- a/app/src/locales/pt/common.json
+++ b/app/src/locales/pt/common.json
@@ -49,6 +49,11 @@
       "connect": "Seu agente precisa que você conecte um aplicativo.",
       "credential": "Seu agente precisa de uma chave de API para terminar."
     },
+    "mentioned": {
+      "title": "{{name}} mencionou você",
+      "titleUnknown": "Você foi mencionado",
+      "body": "Em {{mission}}"
+    },
     "preprompt": {
       "title": "Quer um aviso quando seu agente terminar?",
       "body": "Ative as notificações e o Houston avisa você assim que uma missão terminar ou precisar de você.",

--- a/app/src/locales/pt/dashboard.json
+++ b/app/src/locales/pt/dashboard.json
@@ -5,6 +5,21 @@
     "button": "Arquivadas",
     "title": "Arquivadas"
   },
+  "mentions": {
+    "button": "Menções",
+    "title": "Menções",
+    "ariaCount_one": "{{count}} menção não lida",
+    "ariaCount_other": "{{count}} menções não lidas",
+    "row": {
+      "by": "{{name}} mencionou você",
+      "byUnknown": "Você foi mencionado",
+      "agent": "em {{agent}}"
+    },
+    "empty": {
+      "title": "Ainda não há menções",
+      "description": "Quando alguém do time citar você em uma missão, aparece aqui."
+    }
+  },
   "filter": {
     "allAgents": "Todos os agentes"
   },

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -44,6 +44,8 @@
     "needsYouCount_other": "{{count}} assuntos precisam de você",
     "runningCount_one": "{{count}} assunto em execução",
     "runningCount_other": "{{count}} assuntos em execução",
+    "unreadCount_one": "{{count}} novidade não lida",
+    "unreadCount_other": "{{count}} novidades não lidas",
     "integrations": "Integrações",
     "agentStore": "Loja de agentes",
     "permissions": "Permissões"

--- a/app/tests/agent-activity-summary-model.test.ts
+++ b/app/tests/agent-activity-summary-model.test.ts
@@ -4,34 +4,72 @@ import {
   buildAgentActivitySummaries,
   summarizeActivities,
 } from "../src/components/shell/agent-activity-summary-model.ts";
+import type { ReadCursorStore } from "../src/lib/read-cursors.ts";
+
+const AGENTS = [
+  { id: "agent-a", folderPath: "/workspace/a" },
+  { id: "agent-b", folderPath: "/workspace/b" },
+  { id: "agent-c", folderPath: "/workspace/c" },
+];
+
+const ME = "user-me";
+const MATE = "user-mate";
+
+/** Everything happened after this floor, so unread is decided by relevance. */
+const STORE: ReadCursorStore = { since: 0, cursors: {} };
+const MOVED = "2026-07-01T10:00:00.000Z";
 
 describe("agent activity summary model", () => {
   it("counts needs-you and running activity rows by agent", () => {
-    const summaries = buildAgentActivitySummaries(
-      [
-        { id: "agent-a", folderPath: "/workspace/a" },
-        { id: "agent-b", folderPath: "/workspace/b" },
-        { id: "agent-c", folderPath: "/workspace/c" },
-      ],
-      [
-        { agent_path: "/workspace/a", type: "activity", status: "needs_you" },
-        { agent_path: "/workspace/a", type: "activity", status: "needs_you" },
-        { agent_path: "/workspace/a", type: "activity", status: "running" },
-        { agent_path: "/workspace/b", type: "activity", status: "running" },
-        { agent_path: "/workspace/b", type: "activity", status: "done" },
-        { agent_path: "/workspace/b", type: "primary", status: "needs_you" },
-        {
-          agent_path: "/workspace/missing",
-          type: "activity",
-          status: "needs_you",
-        },
-      ],
-    );
+    const summaries = buildAgentActivitySummaries(AGENTS, [
+      {
+        id: "m1",
+        agent_path: "/workspace/a",
+        type: "activity",
+        status: "needs_you",
+      },
+      {
+        id: "m2",
+        agent_path: "/workspace/a",
+        type: "activity",
+        status: "needs_you",
+      },
+      {
+        id: "m3",
+        agent_path: "/workspace/a",
+        type: "activity",
+        status: "running",
+      },
+      {
+        id: "m4",
+        agent_path: "/workspace/b",
+        type: "activity",
+        status: "running",
+      },
+      {
+        id: "m5",
+        agent_path: "/workspace/b",
+        type: "activity",
+        status: "done",
+      },
+      {
+        id: "m6",
+        agent_path: "/workspace/b",
+        type: "primary",
+        status: "needs_you",
+      },
+      {
+        id: "m7",
+        agent_path: "/workspace/missing",
+        type: "activity",
+        status: "needs_you",
+      },
+    ]);
 
     deepStrictEqual(summaries, {
-      "agent-a": { needsYouCount: 2, runningCount: 1 },
-      "agent-b": { needsYouCount: 0, runningCount: 1 },
-      "agent-c": { needsYouCount: 0, runningCount: 0 },
+      "agent-a": { needsYouCount: 2, runningCount: 1, unreadCount: 0 },
+      "agent-b": { needsYouCount: 0, runningCount: 1, unreadCount: 0 },
+      "agent-c": { needsYouCount: 0, runningCount: 0, unreadCount: 0 },
     });
   });
 
@@ -44,7 +82,7 @@ describe("agent activity summary model", () => {
         { status: "done" },
         { status: "archived" },
       ]),
-      { needsYouCount: 2, runningCount: 1 },
+      { needsYouCount: 2, runningCount: 1, unreadCount: 0 },
     );
   });
 
@@ -54,7 +92,148 @@ describe("agent activity summary model", () => {
         { status: "needs_you", agent: "houston:routine-setup" },
         { status: "needs_you" },
       ]),
-      { needsYouCount: 1, runningCount: 0 },
+      { needsYouCount: 1, runningCount: 0, unreadCount: 0 },
     );
+  });
+});
+
+describe("agent activity summary model — unread badge", () => {
+  const CONVERSATIONS = [
+    // Mine: created by me.
+    {
+      id: "mine",
+      agent_path: "/workspace/a",
+      type: "activity" as const,
+      status: "done",
+      updated_at: MOVED,
+      created_by: ME,
+    },
+    // Not mine and no mention of me: a teammate's mission is not my news.
+    {
+      id: "theirs",
+      agent_path: "/workspace/a",
+      type: "activity" as const,
+      status: "done",
+      updated_at: MOVED,
+      created_by: MATE,
+    },
+    // Not mine, but it @mentions me: the mention IS the claim on my attention.
+    {
+      id: "mentions-me",
+      agent_path: "/workspace/b",
+      type: "activity" as const,
+      status: "done",
+      updated_at: MOVED,
+      created_by: MATE,
+      mentioned: [{ user_id: ME, at: MOVED, by: MATE }],
+    },
+    // A guided setup chat never counts, even when it is mine.
+    {
+      id: "setup",
+      agent_path: "/workspace/b",
+      type: "activity" as const,
+      status: "done",
+      updated_at: MOVED,
+      created_by: ME,
+      agent: "houston:routine-setup",
+    },
+  ];
+
+  it("counts only my missions and missions that mention me", () => {
+    const summaries = buildAgentActivitySummaries(AGENTS, CONVERSATIONS, {
+      store: STORE,
+      selfId: ME,
+    });
+
+    deepStrictEqual(summaries, {
+      "agent-a": { needsYouCount: 0, runningCount: 0, unreadCount: 1 },
+      "agent-b": { needsYouCount: 0, runningCount: 0, unreadCount: 1 },
+      "agent-c": { needsYouCount: 0, runningCount: 0, unreadCount: 0 },
+    });
+  });
+
+  it("counts nothing when nobody is signed in", () => {
+    const summaries = buildAgentActivitySummaries(AGENTS, CONVERSATIONS, {
+      store: STORE,
+      selfId: null,
+    });
+
+    deepStrictEqual(summaries, {
+      "agent-a": { needsYouCount: 0, runningCount: 0, unreadCount: 0 },
+      "agent-b": { needsYouCount: 0, runningCount: 0, unreadCount: 0 },
+      "agent-c": { needsYouCount: 0, runningCount: 0, unreadCount: 0 },
+    });
+  });
+
+  it("stays silent on single-player / desktop, where the hook omits `unread`", () => {
+    // Same rows that DO count for this signed-in reader (see the first case),
+    // so the zeros below can only come from the omitted option — the exact
+    // contract the sidebar's `capabilities.multiplayer` gate relies on.
+    const signedIn = buildAgentActivitySummaries(AGENTS, CONVERSATIONS, {
+      store: STORE,
+      selfId: ME,
+    });
+    deepStrictEqual(
+      [signedIn["agent-a"]?.unreadCount, signedIn["agent-b"]?.unreadCount],
+      [1, 1],
+    );
+
+    const summaries = buildAgentActivitySummaries(AGENTS, CONVERSATIONS);
+
+    deepStrictEqual(summaries, {
+      "agent-a": { needsYouCount: 0, runningCount: 0, unreadCount: 0 },
+      "agent-b": { needsYouCount: 0, runningCount: 0, unreadCount: 0 },
+      "agent-c": { needsYouCount: 0, runningCount: 0, unreadCount: 0 },
+    });
+  });
+
+  it("a mission read after it moved is no longer unread", () => {
+    const store: ReadCursorStore = {
+      since: 0,
+      cursors: {
+        "/workspace/a::mine": { readAt: Date.parse(MOVED) + 1 },
+      },
+    };
+    const summaries = buildAgentActivitySummaries(AGENTS, CONVERSATIONS, {
+      store,
+      selfId: ME,
+    });
+
+    deepStrictEqual(summaries["agent-a"], {
+      needsYouCount: 0,
+      runningCount: 0,
+      unreadCount: 0,
+    });
+  });
+
+  it("counts unread alongside needs-you without disturbing it", () => {
+    const summaries = buildAgentActivitySummaries(
+      AGENTS,
+      [
+        {
+          id: "urgent",
+          agent_path: "/workspace/a",
+          type: "activity",
+          status: "needs_you",
+          updated_at: MOVED,
+          created_by: ME,
+        },
+        {
+          id: "busy",
+          agent_path: "/workspace/a",
+          type: "activity",
+          status: "running",
+          updated_at: MOVED,
+          created_by: ME,
+        },
+      ],
+      { store: STORE, selfId: ME },
+    );
+
+    deepStrictEqual(summaries["agent-a"], {
+      needsYouCount: 1,
+      runningCount: 1,
+      unreadCount: 2,
+    });
   });
 });

--- a/app/tests/chat-conversation-id.test.ts
+++ b/app/tests/chat-conversation-id.test.ts
@@ -1,0 +1,72 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { afterEach, describe, it } from "node:test";
+import { conversationIdForChat } from "../src/lib/chat-conversation-id.ts";
+import { queryClient } from "../src/lib/query-client.ts";
+import { queryKeys } from "../src/lib/query-keys.ts";
+
+/**
+ * HOU-945 review fix: the read-cursor tracker must not write a cursor it can
+ * never read back.
+ *
+ * A chat's query key carries a SESSION key, and only the board lists can say
+ * which mission that is. While they are cold the resolver used to hand back the
+ * raw session key, which for a routine chat (`routine-<id>`) is unrelated to
+ * the conversation id every unread surface looks up — so the cursor landed
+ * under a key nothing reads, and the badge it was meant to clear stayed lit.
+ *
+ * This drives the resolver against the app's real query cache, seeded directly,
+ * because the "which cache answers, and when is it cold" question IS the
+ * behaviour under test.
+ */
+
+const AGENT = "/w/alpha";
+
+afterEach(() => {
+  queryClient.clear();
+});
+
+describe("conversationIdForChat", () => {
+  it("resolves a routine chat from the agent's own board rows", () => {
+    queryClient.setQueryData(queryKeys.activity(AGENT), [
+      { id: "m-42", session_key: "routine-7" },
+    ]);
+    strictEqual(conversationIdForChat(AGENT, "routine-7"), "m-42");
+  });
+
+  it("falls back to the all-conversations aggregate, scoped to this agent", () => {
+    queryClient.setQueryData(queryKeys.allConversations([AGENT, "/w/beta"]), [
+      { id: "wrong", session_key: "routine-7", agent_path: "/w/beta" },
+      { id: "m-42", session_key: "routine-7", agent_path: AGENT },
+    ]);
+    strictEqual(conversationIdForChat(AGENT, "routine-7"), "m-42");
+  });
+
+  it("answers NULL for a routine chat no cached list can name", () => {
+    // The regression: this used to answer "routine-7", writing a cursor under a
+    // key no unread surface ever looks up.
+    strictEqual(conversationIdForChat(AGENT, "routine-7"), null);
+    queryClient.setQueryData(queryKeys.activity(AGENT), []);
+    strictEqual(conversationIdForChat(AGENT, "routine-7"), null);
+  });
+
+  it("answers NULL for a session that is not a chat at all", () => {
+    queryClient.setQueryData(queryKeys.activity(AGENT), []);
+    strictEqual(conversationIdForChat(AGENT, "main"), null);
+  });
+
+  it("still resolves a standard mission with no list cached", () => {
+    // `activity-<id>` carries the mission id in the key itself, so a cold cache
+    // costs nothing here — only the keys that need a lookup can go unresolved.
+    strictEqual(conversationIdForChat(AGENT, "activity-m-9"), "m-9");
+  });
+
+  it("prefers the agent's own board rows over the aggregate", () => {
+    queryClient.setQueryData(queryKeys.activity(AGENT), [
+      { id: "fresh", session_key: "routine-7" },
+    ]);
+    queryClient.setQueryData(queryKeys.allConversations([AGENT]), [
+      { id: "stale", session_key: "routine-7", agent_path: AGENT },
+    ]);
+    deepStrictEqual(conversationIdForChat(AGENT, "routine-7"), "fresh");
+  });
+});

--- a/app/tests/mentions-inbox-model.test.ts
+++ b/app/tests/mentions-inbox-model.test.ts
@@ -1,0 +1,223 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  buildMentionInbox,
+  type MentionInboxConversation,
+} from "../src/components/board/mentions-inbox-model.ts";
+import type { ReadCursorStore } from "../src/lib/read-cursors.ts";
+import { ROUTINE_SETUP_AGENT_MODE } from "../src/lib/routine-chat-setup.ts";
+
+const ME = "user-me";
+const MATE = "user-mate";
+const SINCE = Date.parse("2026-07-01T00:00:00.000Z");
+
+const store = (cursors: ReadCursorStore["cursors"] = {}): ReadCursorStore => ({
+  since: SINCE,
+  cursors,
+});
+
+const conv = (
+  over: Partial<MentionInboxConversation> & { id: string },
+): MentionInboxConversation => ({
+  agent_path: "/w/alpha",
+  agent_name: "Alpha",
+  session_key: `activity-${over.id}`,
+  title: `Mission ${over.id}`,
+  type: "activity",
+  created_by: MATE,
+  contributors: [{ user_id: MATE }],
+  updated_at: "2026-07-10T00:00:00.000Z",
+  ...over,
+});
+
+describe("buildMentionInbox", () => {
+  it("returns [] with nobody signed in", () => {
+    const c = conv({
+      id: "m1",
+      mentioned: [{ user_id: ME, at: "2026-07-05T00:00:00.000Z" }],
+    });
+    deepStrictEqual(buildMentionInbox([c], store(), null), []);
+  });
+
+  it("keeps only missions that @mention me", () => {
+    const rows = buildMentionInbox(
+      [
+        conv({ id: "mine", created_by: ME, contributors: [{ user_id: ME }] }),
+        conv({ id: "theirs" }),
+        conv({
+          id: "pinged",
+          mentioned: [{ user_id: ME, at: "2026-07-05T00:00:00.000Z" }],
+        }),
+        conv({
+          id: "other-pinged",
+          mentioned: [
+            { user_id: "user-third", at: "2026-07-05T00:00:00.000Z" },
+          ],
+        }),
+      ],
+      store(),
+      ME,
+    );
+    deepStrictEqual(
+      rows.map((r) => r.conversationId),
+      ["pinged"],
+    );
+  });
+
+  it("maps the full row, newest mention first, id as tiebreak", () => {
+    const rows = buildMentionInbox(
+      [
+        conv({
+          id: "b",
+          mentioned: [
+            { user_id: ME, at: "2026-07-05T00:00:00.000Z", by: MATE },
+          ],
+        }),
+        conv({
+          id: "newest",
+          agent_path: "/w/beta",
+          agent_name: "Beta",
+          mentioned: [
+            { user_id: ME, at: "2026-07-02T00:00:00.000Z", by: MATE },
+            { user_id: ME, at: "2026-07-09T00:00:00.000Z", by: "user-third" },
+          ],
+        }),
+        conv({
+          id: "a",
+          mentioned: [{ user_id: ME, at: "2026-07-05T00:00:00.000Z" }],
+        }),
+      ],
+      store(),
+      ME,
+    );
+
+    deepStrictEqual(
+      rows.map((r) => r.conversationId),
+      ["newest", "a", "b"],
+    );
+    deepStrictEqual(rows[0], {
+      conversationId: "newest",
+      agentPath: "/w/beta",
+      agentName: "Beta",
+      sessionKey: "activity-newest",
+      title: "Mission newest",
+      at: Date.parse("2026-07-09T00:00:00.000Z"),
+      byUserId: "user-third",
+      unread: true,
+      mentionOutstanding: true,
+    });
+    strictEqual(rows[1]?.byUserId, undefined);
+  });
+
+  it("flags unread per the read cursor", () => {
+    const convs = [
+      conv({
+        id: "read",
+        mentioned: [{ user_id: ME, at: "2026-07-05T00:00:00.000Z" }],
+      }),
+      conv({
+        id: "unread",
+        mentioned: [{ user_id: ME, at: "2026-07-05T00:00:00.000Z" }],
+      }),
+    ];
+    const cursors = {
+      "/w/alpha::read": { readAt: Date.parse("2026-07-11T00:00:00.000Z") },
+    };
+    const rows = buildMentionInbox(convs, store(cursors), ME);
+    deepStrictEqual(
+      rows.map((r) => [r.conversationId, r.unread]),
+      [
+        ["read", false],
+        ["unread", true],
+      ],
+    );
+  });
+
+  it("separates ambient movement from an outstanding mention", () => {
+    // The pill counts `mentionOutstanding` and the row dot reads `unread`, so
+    // this is the assertion that stops a mission which merely MOVED from being
+    // announced as "somebody typed your name".
+    const convs = [
+      conv({
+        id: "moved",
+        updated_at: "2026-07-10T00:00:00.000Z",
+        mentioned: [{ user_id: ME, at: "2026-07-05T00:00:00.000Z" }],
+      }),
+      conv({
+        id: "pinged",
+        updated_at: "2026-07-10T00:00:00.000Z",
+        mentioned: [{ user_id: ME, at: "2026-07-08T00:00:00.000Z" }],
+      }),
+      conv({
+        id: "settled",
+        updated_at: "2026-07-10T00:00:00.000Z",
+        mentioned: [{ user_id: ME, at: "2026-07-05T00:00:00.000Z" }],
+      }),
+    ];
+    const cursors = {
+      // Read AFTER the mention but BEFORE the mission's last movement.
+      "/w/alpha::moved": { readAt: Date.parse("2026-07-06T00:00:00.000Z") },
+      // Read BEFORE the mention landed.
+      "/w/alpha::pinged": { readAt: Date.parse("2026-07-06T00:00:00.000Z") },
+      // Read after everything.
+      "/w/alpha::settled": { readAt: Date.parse("2026-07-11T00:00:00.000Z") },
+    };
+    const rows = buildMentionInbox(convs, store(cursors), ME);
+    deepStrictEqual(
+      rows.map((r) => [r.conversationId, r.unread, r.mentionOutstanding]),
+      [
+        ["pinged", true, true],
+        ["moved", true, false],
+        ["settled", false, false],
+      ],
+    );
+  });
+
+  it("keeps a never-opened mention outstanding however old it is", () => {
+    // No cursor at all: `mentionReadFloorFor` deliberately has no `since`
+    // fallback, so a mention that predates this device still counts on the pill.
+    const rows = buildMentionInbox(
+      [
+        conv({
+          id: "ancient",
+          updated_at: "2026-06-01T00:00:00.000Z",
+          mentioned: [{ user_id: ME, at: "2026-06-01T00:00:00.000Z" }],
+        }),
+      ],
+      store(),
+      ME,
+    );
+    strictEqual(rows[0]?.mentionOutstanding, true);
+  });
+
+  it("never builds a row from a mention I wrote about myself", () => {
+    const rows = buildMentionInbox(
+      [
+        conv({
+          id: "self",
+          created_by: ME,
+          contributors: [{ user_id: ME }],
+          mentioned: [{ user_id: ME, at: "2026-07-05T00:00:00.000Z", by: ME }],
+        }),
+      ],
+      store(),
+      ME,
+    );
+    deepStrictEqual(rows, []);
+  });
+
+  it("excludes guided setup chats", () => {
+    const rows = buildMentionInbox(
+      [
+        conv({
+          id: "setup",
+          agent: ROUTINE_SETUP_AGENT_MODE,
+          mentioned: [{ user_id: ME, at: "2026-07-05T00:00:00.000Z" }],
+        }),
+      ],
+      store(),
+      ME,
+    );
+    deepStrictEqual(rows, []);
+  });
+});

--- a/app/tests/mentions-inbox-view-model.test.ts
+++ b/app/tests/mentions-inbox-view-model.test.ts
@@ -1,0 +1,144 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type {
+  MentionInboxConversation,
+  MentionInboxRow,
+} from "../src/components/board/mentions-inbox-model.ts";
+import {
+  mentionCountLabel,
+  mentionerIds,
+  resolveMentionerName,
+  storedContributorNames,
+} from "../src/components/board/mentions-inbox-view-model.ts";
+import type { UserProfile } from "../src/hooks/queries/use-user-profiles.ts";
+
+const row = (over: Partial<MentionInboxRow> = {}): MentionInboxRow => ({
+  conversationId: "m1",
+  agentPath: "/agents/finance",
+  agentName: "Finance",
+  sessionKey: "activity-m1",
+  title: "Close the books",
+  at: Date.parse("2026-07-10T00:00:00.000Z"),
+  unread: true,
+  mentionOutstanding: true,
+  ...over,
+});
+
+const conv = (
+  over: Partial<MentionInboxConversation> = {},
+): MentionInboxConversation => ({
+  id: "m1",
+  agent_path: "/agents/finance",
+  agent_name: "Finance",
+  session_key: "activity-m1",
+  title: "Close the books",
+  type: "activity",
+  ...over,
+});
+
+const profile = (name: string): UserProfile => ({ name, avatarUrl: null });
+
+describe("mentionCountLabel", () => {
+  it("renders small counts verbatim", () => {
+    strictEqual(mentionCountLabel(0), "0");
+    strictEqual(mentionCountLabel(1), "1");
+    strictEqual(mentionCountLabel(99), "99");
+  });
+
+  it("clamps at 99+ so the pill can never push the title off its line", () => {
+    strictEqual(mentionCountLabel(100), "99+");
+    strictEqual(mentionCountLabel(4321), "99+");
+  });
+});
+
+describe("mentionerIds", () => {
+  it("dedupes a repeat mentioner into one profile lookup", () => {
+    deepStrictEqual(
+      mentionerIds([
+        row({ conversationId: "a", byUserId: "u-ana" }),
+        row({ conversationId: "b", byUserId: "u-bob" }),
+        row({ conversationId: "c", byUserId: "u-ana" }),
+      ]),
+      ["u-ana", "u-bob"],
+    );
+  });
+
+  it("keeps row order so the query key does not churn between renders", () => {
+    deepStrictEqual(
+      mentionerIds([
+        row({ conversationId: "a", byUserId: "u-zoe" }),
+        row({ conversationId: "b", byUserId: "u-ana" }),
+      ]),
+      ["u-zoe", "u-ana"],
+    );
+  });
+
+  it("skips rows with no known mentioner", () => {
+    deepStrictEqual(mentionerIds([row(), row({ byUserId: "u-ana" })]), [
+      "u-ana",
+    ]);
+  });
+
+  it("is empty for an empty inbox", () => {
+    deepStrictEqual(mentionerIds([]), []);
+  });
+});
+
+describe("storedContributorNames", () => {
+  it("collects server-stamped names across missions", () => {
+    const names = storedContributorNames([
+      conv({ contributors: [{ user_id: "u-ana", name: "Ana" }] }),
+      conv({ id: "m2", contributors: [{ user_id: "u-bob", name: "Bob" }] }),
+    ]);
+    strictEqual(names.get("u-ana"), "Ana");
+    strictEqual(names.get("u-bob"), "Bob");
+  });
+
+  it("keeps the first stored name, matching the board face stacks", () => {
+    const names = storedContributorNames([
+      conv({ contributors: [{ user_id: "u-ana", name: "Ana" }] }),
+      conv({ id: "m2", contributors: [{ user_id: "u-ana", name: "Ana R." }] }),
+    ]);
+    strictEqual(names.get("u-ana"), "Ana");
+  });
+
+  it("ignores contributors with no stored name", () => {
+    const names = storedContributorNames([
+      conv({ contributors: [{ user_id: "u-ana" }] }),
+    ]);
+    strictEqual(names.has("u-ana"), false);
+  });
+
+  it("tolerates missions with no attribution at all", () => {
+    strictEqual(storedContributorNames([conv()]).size, 0);
+  });
+});
+
+describe("resolveMentionerName", () => {
+  const stored = new Map([["u-ana", "Ana (stored)"]]);
+
+  it("prefers the live profile name", () => {
+    strictEqual(
+      resolveMentionerName(
+        "u-ana",
+        new Map([["u-ana", profile("Ana Lopez")]]),
+        stored,
+      ),
+      "Ana Lopez",
+    );
+  });
+
+  it("falls back to the stored contributor name before the id", () => {
+    strictEqual(
+      resolveMentionerName("u-ana", new Map(), stored),
+      "Ana (stored)",
+    );
+  });
+
+  it("never renders a raw user id", () => {
+    const id = "0f2c9a1e-7d43-4c5b-9a10-6b8e2f4d1c33";
+    const label = resolveMentionerName(id, new Map(), new Map());
+    strictEqual(label, "0f2c9a1e");
+    strictEqual(label === id, false);
+  });
+});

--- a/app/tests/mission-relevance.test.ts
+++ b/app/tests/mission-relevance.test.ts
@@ -1,0 +1,241 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  isRelevantToMe,
+  latestMentionAtFor,
+  latestMentionFor,
+  missionIsMine,
+  missionMentionsMe,
+  type RelevanceConversation,
+} from "../src/lib/mission-relevance.ts";
+
+const ME = "user-me";
+const MATE = "user-mate";
+
+const conv = (
+  over: Partial<RelevanceConversation> = {},
+): RelevanceConversation => ({ ...over }) as RelevanceConversation;
+
+describe("missionIsMine", () => {
+  it("matches the creator", () => {
+    strictEqual(missionIsMine(conv({ created_by: ME }), ME), true);
+  });
+
+  it("matches a contributor", () => {
+    strictEqual(
+      missionIsMine(
+        conv({ created_by: MATE, contributors: [{ user_id: ME }] }),
+        ME,
+      ),
+      true,
+    );
+  });
+
+  it("does NOT match a teammate's own mission", () => {
+    strictEqual(
+      missionIsMine(
+        conv({ created_by: MATE, contributors: [{ user_id: MATE }] }),
+        ME,
+      ),
+      false,
+    );
+  });
+
+  it("treats a mission with NO attribution at all as mine", () => {
+    // The load-bearing desktop-parity clause: legacy / pre-Teams missions carry
+    // no created_by and no contributors and must never go silent.
+    strictEqual(missionIsMine(conv(), ME), true);
+    strictEqual(missionIsMine(conv({ contributors: [] }), ME), true);
+  });
+});
+
+describe("missionMentionsMe", () => {
+  it("is true when the aggregate names me", () => {
+    const c = conv({
+      created_by: MATE,
+      mentioned: [{ user_id: ME, at: "2026-07-01T10:00:00.000Z", by: MATE }],
+    });
+    strictEqual(missionMentionsMe(c, ME), true);
+  });
+
+  it("is false when it names only somebody else", () => {
+    const c = conv({
+      mentioned: [{ user_id: MATE, at: "2026-07-01T10:00:00.000Z" }],
+    });
+    strictEqual(missionMentionsMe(c, ME), false);
+  });
+
+  it("is false with no aggregate at all", () => {
+    strictEqual(missionMentionsMe(conv(), ME), false);
+  });
+
+  it("is false when I mentioned MYSELF", () => {
+    // Typing your own name is not news, and the OS ping already refuses to fire
+    // on it. Counting it here would earn a permanent inbox row and a
+    // mention-unread badge that no amount of reading can clear.
+    const c = conv({
+      created_by: ME,
+      mentioned: [{ user_id: ME, at: "2026-07-01T10:00:00.000Z", by: ME }],
+    });
+    strictEqual(missionMentionsMe(c, ME), false);
+  });
+
+  it("still counts a mention of me carrying NO author", () => {
+    // Pre-stamp entries have no `by`. Reading "no author" as "me" would go
+    // silent on every mention written before the gateway stamped authors.
+    const c = conv({
+      created_by: MATE,
+      mentioned: [{ user_id: ME, at: "2026-07-01T10:00:00.000Z" }],
+    });
+    strictEqual(missionMentionsMe(c, ME), true);
+  });
+
+  it("a self-mention never hides a real one on the same mission", () => {
+    const c = conv({
+      mentioned: [
+        { user_id: ME, at: "2026-07-01T10:00:00.000Z", by: ME },
+        { user_id: ME, at: "2026-07-02T10:00:00.000Z", by: MATE },
+      ],
+    });
+    strictEqual(missionMentionsMe(c, ME), true);
+  });
+});
+
+describe("latestMentionFor", () => {
+  it("returns the newest entry for me, with its author", () => {
+    const c = conv({
+      mentioned: [
+        { user_id: ME, at: "2026-07-01T10:00:00.000Z", by: MATE },
+        { user_id: MATE, at: "2026-07-09T10:00:00.000Z" },
+        { user_id: ME, at: "2026-07-05T10:00:00.000Z", by: "user-third" },
+      ],
+    });
+    const latest = latestMentionFor(c, ME);
+    strictEqual(latest?.at, Date.parse("2026-07-05T10:00:00.000Z"));
+    strictEqual(latest?.mention.by, "user-third");
+  });
+
+  it("returns null when nobody mentioned me", () => {
+    strictEqual(latestMentionFor(conv(), ME), null);
+  });
+
+  it("ignores a mention I wrote about myself", () => {
+    const c = conv({
+      mentioned: [{ user_id: ME, at: "2026-07-01T10:00:00.000Z", by: ME }],
+    });
+    strictEqual(latestMentionFor(c, ME), null);
+  });
+
+  it("returns an authorless mention of me, so pre-stamp pings survive", () => {
+    const c = conv({
+      mentioned: [{ user_id: ME, at: "2026-07-01T10:00:00.000Z" }],
+    });
+    strictEqual(
+      latestMentionFor(c, ME)?.at,
+      Date.parse("2026-07-01T10:00:00.000Z"),
+    );
+  });
+
+  it("skips a NEWER self-mention in favour of a real one", () => {
+    // The newest entry is mine; the inbox must still show me the teammate's.
+    const c = conv({
+      mentioned: [
+        { user_id: ME, at: "2026-07-05T10:00:00.000Z", by: MATE },
+        { user_id: ME, at: "2026-07-09T10:00:00.000Z", by: ME },
+      ],
+    });
+    const latest = latestMentionFor(c, ME);
+    strictEqual(latest?.at, Date.parse("2026-07-05T10:00:00.000Z"));
+    strictEqual(latest?.mention.by, MATE);
+  });
+});
+
+describe("latestMentionAtFor", () => {
+  it("gives epoch ms of the newest mention", () => {
+    const c = conv({
+      mentioned: [{ user_id: ME, at: "2026-07-01T10:00:00.000Z" }],
+    });
+    strictEqual(
+      latestMentionAtFor(c, ME),
+      Date.parse("2026-07-01T10:00:00.000Z"),
+    );
+  });
+
+  it("ignores an unparseable timestamp instead of inventing a ping", () => {
+    const c = conv({ mentioned: [{ user_id: ME, at: "not-a-date" }] });
+    strictEqual(latestMentionAtFor(c, ME), null);
+  });
+
+  it("an unparseable entry never hides a well-formed sibling", () => {
+    const c = conv({
+      mentioned: [
+        { user_id: ME, at: "not-a-date" },
+        { user_id: ME, at: "2026-07-02T00:00:00.000Z" },
+      ],
+    });
+    strictEqual(
+      latestMentionAtFor(c, ME),
+      Date.parse("2026-07-02T00:00:00.000Z"),
+    );
+  });
+
+  it("returns null with no mentions", () => {
+    strictEqual(latestMentionAtFor(conv(), ME), null);
+  });
+});
+
+describe("isRelevantToMe", () => {
+  const mates = conv({ created_by: MATE, contributors: [{ user_id: MATE }] });
+
+  it("everything is relevant when signed out / single player", () => {
+    strictEqual(isRelevantToMe(mates, null), true);
+    strictEqual(isRelevantToMe(undefined, null), true);
+  });
+
+  it("fails OPEN on an unknown mission", () => {
+    strictEqual(isRelevantToMe(undefined, ME), true);
+  });
+
+  it("keeps an unattributed mission relevant for a signed-in user", () => {
+    strictEqual(isRelevantToMe(conv(), ME), true);
+  });
+
+  it("is relevant when the mission is mine", () => {
+    strictEqual(isRelevantToMe(conv({ created_by: ME }), ME), true);
+  });
+
+  it("is relevant when it only @mentions me", () => {
+    const c = conv({
+      created_by: MATE,
+      contributors: [{ user_id: MATE }],
+      mentioned: [{ user_id: ME, at: "2026-07-01T10:00:00.000Z", by: MATE }],
+    });
+    strictEqual(isRelevantToMe(c, ME), true);
+  });
+
+  it("is NOT made relevant by a mention I wrote about myself", () => {
+    const c = conv({
+      created_by: MATE,
+      contributors: [{ user_id: MATE }],
+      mentioned: [{ user_id: ME, at: "2026-07-01T10:00:00.000Z", by: ME }],
+    });
+    strictEqual(isRelevantToMe(c, ME), false);
+  });
+
+  it("is NOT relevant for a teammate's mission that never names me", () => {
+    strictEqual(isRelevantToMe(mates, ME), false);
+    strictEqual(
+      isRelevantToMe(
+        conv({
+          created_by: MATE,
+          contributors: [{ user_id: MATE }],
+          mentioned: [
+            { user_id: "user-third", at: "2026-07-01T10:00:00.000Z" },
+          ],
+        }),
+        ME,
+      ),
+      false,
+    );
+  });
+});

--- a/app/tests/notification-relevance.test.ts
+++ b/app/tests/notification-relevance.test.ts
@@ -1,0 +1,114 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  findSessionConversation,
+  type SessionConversationRow,
+  shouldNotifyCompletion,
+} from "../src/lib/notification-relevance.ts";
+
+const ME = "user-me";
+const MATE = "user-mate";
+
+const row = (
+  over: Partial<SessionConversationRow> & { session_key: string },
+): SessionConversationRow => ({
+  agent_path: "/w/alpha",
+  ...over,
+});
+
+describe("findSessionConversation", () => {
+  const rows = [
+    row({ session_key: "activity-1", created_by: ME }),
+    row({ session_key: "activity-2", created_by: MATE }),
+    row({ session_key: "activity-1", agent_path: "/w/beta", created_by: MATE }),
+  ];
+
+  it("matches the session key within the agent", () => {
+    strictEqual(
+      findSessionConversation(rows, "/w/alpha", "activity-2")?.created_by,
+      MATE,
+    );
+  });
+
+  it("never crosses agents on a shared session key", () => {
+    strictEqual(
+      findSessionConversation(rows, "/w/beta", "activity-1")?.created_by,
+      MATE,
+    );
+    strictEqual(
+      findSessionConversation(rows, "/w/alpha", "activity-1")?.created_by,
+      ME,
+    );
+  });
+
+  it("is undefined when the roster cache has no such row", () => {
+    strictEqual(
+      findSessionConversation(rows, "/w/alpha", "activity-9"),
+      undefined,
+    );
+    strictEqual(
+      findSessionConversation(undefined, "/w/alpha", "activity-1"),
+      undefined,
+    );
+  });
+});
+
+describe("shouldNotifyCompletion", () => {
+  const mine = row({ session_key: "activity-1", created_by: ME });
+  const theirs = row({
+    session_key: "activity-2",
+    created_by: MATE,
+    contributors: [{ user_id: MATE }],
+  });
+  const unattributed = row({ session_key: "activity-3" });
+  const mentionsMe = row({
+    session_key: "activity-4",
+    created_by: MATE,
+    contributors: [{ user_id: MATE }],
+    mentioned: [{ user_id: ME, at: "2026-07-01T10:00:00.000Z", by: MATE }],
+  });
+  const rows = [mine, theirs, unattributed, mentionsMe];
+
+  const notify = (sessionKey: string, selfId: string | null) =>
+    shouldNotifyCompletion({
+      rows,
+      agentPath: "/w/alpha",
+      sessionKey,
+      selfId,
+    });
+
+  it("notifies for everything when there is no signed-in user", () => {
+    strictEqual(notify("activity-1", null), true);
+    strictEqual(notify("activity-2", null), true);
+    strictEqual(notify("activity-9", null), true);
+  });
+
+  it("notifies for my own mission", () => {
+    strictEqual(notify("activity-1", ME), true);
+  });
+
+  it("notifies for an unattributed mission (desktop parity, signed in)", () => {
+    strictEqual(notify("activity-3", ME), true);
+  });
+
+  it("notifies for a teammate's mission that @mentions me", () => {
+    strictEqual(notify("activity-4", ME), true);
+  });
+
+  it("stays silent on a teammate's mission that never names me", () => {
+    strictEqual(notify("activity-2", ME), false);
+  });
+
+  it("fails OPEN on an unknown session", () => {
+    strictEqual(notify("activity-9", ME), true);
+    strictEqual(
+      shouldNotifyCompletion({
+        rows: undefined,
+        agentPath: "/w/alpha",
+        sessionKey: "activity-2",
+        selfId: ME,
+      }),
+      true,
+    );
+  });
+});

--- a/app/tests/org-people-map.test.ts
+++ b/app/tests/org-people-map.test.ts
@@ -1,0 +1,97 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { MentionPerson } from "@houston-ai/chat";
+import {
+  excludeSelf,
+  type OrgPersonRow,
+  toMentionPeople,
+} from "../src/hooks/queries/org-people-map.ts";
+
+// The app half of @mentions (HOU-944): `GET /v1/org/people` gives a sanitized
+// co-member directory whose display fields are BOTH optional. These cover the
+// projection into `ui/chat`'s MentionPerson, the named-only rule, and the
+// composer's self exclusion.
+
+describe("toMentionPeople", () => {
+  it("maps displayName -> name and photoUrl -> imageUrl", () => {
+    const rows: OrgPersonRow[] = [
+      { userId: "u-1", displayName: "Ada Lovelace", photoUrl: "https://a/1" },
+    ];
+    deepStrictEqual(toMentionPeople(rows), [
+      { userId: "u-1", name: "Ada Lovelace", imageUrl: "https://a/1" },
+    ]);
+  });
+
+  it("omits imageUrl for a member with no photo (initials render instead)", () => {
+    const [person] = toMentionPeople([{ userId: "u-1", displayName: "Ada" }]);
+    deepStrictEqual(person, { userId: "u-1", name: "Ada" });
+    strictEqual("imageUrl" in person, false);
+  });
+
+  it("drops a member with no display name — never offers '@a1b2c3d4'", () => {
+    const rows: OrgPersonRow[] = [
+      { userId: "u-1", displayName: "Ada" },
+      { userId: "u-2", photoUrl: "https://a/2" },
+      { userId: "u-3", displayName: "Grace" },
+    ];
+    deepStrictEqual(
+      toMentionPeople(rows).map((p) => p.userId),
+      ["u-1", "u-3"],
+    );
+  });
+
+  it("treats a blank / whitespace-only name as no name, and trims the rest", () => {
+    const rows: OrgPersonRow[] = [
+      { userId: "u-1", displayName: "   " },
+      { userId: "u-2", displayName: "" },
+      { userId: "u-3", displayName: "  Grace Hopper  " },
+    ];
+    deepStrictEqual(toMentionPeople(rows), [
+      { userId: "u-3", name: "Grace Hopper" },
+    ]);
+  });
+
+  it("preserves roster order (the gateway already sorts named-first)", () => {
+    const rows: OrgPersonRow[] = [
+      { userId: "u-z", displayName: "Zoe" },
+      { userId: "u-a", displayName: "Ada" },
+    ];
+    deepStrictEqual(
+      toMentionPeople(rows).map((p) => p.name),
+      ["Zoe", "Ada"],
+    );
+  });
+
+  it("degrades to an empty list — the 404 / single-player shape", () => {
+    deepStrictEqual(toMentionPeople([]), []);
+  });
+});
+
+describe("excludeSelf", () => {
+  const people: MentionPerson[] = [
+    { userId: "u-1", name: "Ada" },
+    { userId: "u-2", name: "Grace" },
+    { userId: "u-3", name: "Alan" },
+  ];
+
+  it("removes the caller — you do not @mention yourself", () => {
+    deepStrictEqual(
+      excludeSelf(people, "u-2").map((p) => p.userId),
+      ["u-1", "u-3"],
+    );
+  });
+
+  it("keeps the roster identity when the caller is not in it", () => {
+    strictEqual(excludeSelf(people, "u-9"), people);
+  });
+
+  it("keeps the roster identity when signed out", () => {
+    strictEqual(excludeSelf(people, undefined), people);
+    strictEqual(excludeSelf(people, null), people);
+  });
+
+  it("stays empty for an empty roster", () => {
+    const empty: MentionPerson[] = [];
+    strictEqual(excludeSelf(empty, "u-1"), empty);
+  });
+});

--- a/app/tests/read-cursors.test.ts
+++ b/app/tests/read-cursors.test.ts
@@ -1,0 +1,492 @@
+import { deepStrictEqual, ok, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  cursorKey,
+  markMentionNotified,
+  markRead,
+  mentionReadFloorFor,
+  notifiedFloorFor,
+  type ReadCursorStore,
+  readFloorFor,
+} from "../src/lib/read-cursors.ts";
+import { mergeReadCursorStores } from "../src/lib/read-cursors-merge.ts";
+import {
+  type CursorStorage,
+  loadReadCursors,
+  pruneForeignCursorStores,
+  readCursorStorageKey,
+  saveReadCursors,
+} from "../src/lib/read-cursors-storage.ts";
+
+const UID = "user-me";
+const NOW = Date.UTC(2026, 6, 27, 12, 0, 0);
+
+/** The injectable storage seam, backed by a Map instead of the DOM. Insertion
+ *  order is `Map`'s, which is what `localStorage`'s index order is too. */
+function memoryStorage(seed?: Record<string, string>): CursorStorage & {
+  map: Map<string, string>;
+} {
+  const map = new Map<string, string>(Object.entries(seed ?? {}));
+  return {
+    map,
+    get length() {
+      return map.size;
+    },
+    key: (i) => [...map.keys()][i] ?? null,
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => {
+      map.set(k, v);
+    },
+    removeItem: (k) => {
+      map.delete(k);
+    },
+  };
+}
+
+/** The persisted envelope, as it actually sits in storage. */
+function storedBlob(
+  storage: CursorStorage,
+  uid: string,
+): Record<string, unknown> {
+  return JSON.parse(storage.getItem(readCursorStorageKey(uid)) ?? "null");
+}
+
+describe("cursorKey / readCursorStorageKey", () => {
+  it("keys a conversation by agent and id", () => {
+    strictEqual(cursorKey("/w/alpha", "m1"), "/w/alpha::m1");
+  });
+
+  it("scopes storage per signed-in user", () => {
+    strictEqual(readCursorStorageKey(UID), "houston.read-cursors.user-me");
+    ok(readCursorStorageKey("other") !== readCursorStorageKey(UID));
+  });
+});
+
+describe("loadReadCursors", () => {
+  it("creates a store floored at now when nothing is stored", () => {
+    const store = loadReadCursors(memoryStorage(), UID, NOW);
+    deepStrictEqual(store, { since: NOW, cursors: {} });
+  });
+
+  it("round-trips through saveReadCursors", () => {
+    const storage = memoryStorage();
+    const store: ReadCursorStore = {
+      since: 1_000,
+      cursors: { "/w/alpha::m1": { readAt: 2_000, notifiedAt: 3_000 } },
+    };
+    saveReadCursors(storage, UID, store);
+    deepStrictEqual(loadReadCursors(storage, UID, NOW), store);
+  });
+
+  it("recovers from a corrupt payload with a fresh store", () => {
+    const storage = memoryStorage({
+      [readCursorStorageKey(UID)]: "{not json at all",
+    });
+    deepStrictEqual(loadReadCursors(storage, UID, NOW), {
+      since: NOW,
+      cursors: {},
+    });
+  });
+
+  it("recovers from a foreign (non-object) payload", () => {
+    const storage = memoryStorage({ [readCursorStorageKey(UID)]: "[1,2,3]" });
+    deepStrictEqual(loadReadCursors(storage, UID, NOW), {
+      since: NOW,
+      cursors: {},
+    });
+  });
+
+  it("drops individual bad rows without losing the good ones", () => {
+    const storage = memoryStorage({
+      [readCursorStorageKey(UID)]: JSON.stringify({
+        since: "yesterday",
+        cursors: {
+          good: { readAt: 5_000 },
+          noReadAt: { notifiedAt: 9_000 },
+          notAnObject: 7,
+          nanReadAt: { readAt: "soon" },
+        },
+      }),
+    });
+    deepStrictEqual(loadReadCursors(storage, UID, NOW), {
+      since: NOW,
+      cursors: { good: { readAt: 5_000 } },
+    });
+  });
+
+  it("never reads another account's cursors", () => {
+    const storage = memoryStorage();
+    saveReadCursors(storage, "other", {
+      since: 1,
+      cursors: { "/w/alpha::m1": { readAt: 99 } },
+    });
+    deepStrictEqual(loadReadCursors(storage, UID, NOW).cursors, {});
+  });
+});
+
+describe("read floors", () => {
+  it("falls back to `since` so a fresh device does not flood", () => {
+    const store = loadReadCursors(memoryStorage(), UID, NOW);
+    strictEqual(readFloorFor(store, "/w/alpha::m1"), NOW);
+    strictEqual(notifiedFloorFor(store, "/w/alpha::m1"), NOW);
+  });
+
+  it("prefers the conversation's own cursor", () => {
+    const store: ReadCursorStore = {
+      since: NOW,
+      cursors: { k: { readAt: 10, notifiedAt: 20 } },
+    };
+    strictEqual(readFloorFor(store, "k"), 10);
+    strictEqual(notifiedFloorFor(store, "k"), 20);
+  });
+});
+
+describe("markRead", () => {
+  it("advances the read cursor", () => {
+    const store: ReadCursorStore = { since: 100, cursors: {} };
+    const next = markRead(store, "k", 500);
+    strictEqual(readFloorFor(next, "k"), 500);
+    strictEqual(readFloorFor(store, "k"), 100);
+  });
+
+  it("returns the SAME reference when already at/after `at`", () => {
+    const store: ReadCursorStore = {
+      since: 100,
+      cursors: { k: { readAt: 500 } },
+    };
+    strictEqual(markRead(store, "k", 500), store);
+    strictEqual(markRead(store, "k", 400), store);
+  });
+
+  it("keeps the mention watermark while advancing the read cursor", () => {
+    const store: ReadCursorStore = {
+      since: 100,
+      cursors: { k: { readAt: 200, notifiedAt: 300 } },
+    };
+    deepStrictEqual(markRead(store, "k", 900).cursors.k, {
+      readAt: 900,
+      notifiedAt: 300,
+    });
+  });
+});
+
+describe("markMentionNotified", () => {
+  it("records the watermark without marking the mission read", () => {
+    const store: ReadCursorStore = { since: 100, cursors: {} };
+    const next = markMentionNotified(store, "k", 900);
+    strictEqual(notifiedFloorFor(next, "k"), 900);
+    // Seeded from `since`, so the unread badge the ping announced survives.
+    strictEqual(readFloorFor(next, "k"), 100);
+  });
+
+  it("returns the SAME reference when already at/after `at`", () => {
+    const store: ReadCursorStore = {
+      since: 100,
+      cursors: { k: { readAt: 200, notifiedAt: 900 } },
+    };
+    strictEqual(markMentionNotified(store, "k", 900), store);
+    strictEqual(markMentionNotified(store, "k", 800), store);
+  });
+
+  it("advances an existing watermark and keeps readAt", () => {
+    const store: ReadCursorStore = {
+      since: 100,
+      cursors: { k: { readAt: 200, notifiedAt: 300 } },
+    };
+    deepStrictEqual(markMentionNotified(store, "k", 1_000).cursors.k, {
+      readAt: 200,
+      notifiedAt: 1_000,
+    });
+  });
+});
+
+describe("growth cap", () => {
+  it("prunes to the 500 most recently touched keys", () => {
+    let store: ReadCursorStore = { since: 0, cursors: {} };
+    for (let i = 0; i < 520; i++) store = markRead(store, `k${i}`, i + 1);
+
+    const keys = Object.keys(store.cursors);
+    strictEqual(keys.length, 500);
+    // The 20 oldest were dropped; the newest 500 survive.
+    strictEqual(store.cursors.k0, undefined);
+    strictEqual(store.cursors.k19, undefined);
+    strictEqual(store.cursors.k20?.readAt, 21);
+    strictEqual(store.cursors.k519?.readAt, 520);
+  });
+
+  it("ranks by either watermark, so a notify-only cursor survives", () => {
+    let store: ReadCursorStore = { since: 0, cursors: {} };
+    store = markMentionNotified(store, "pinged", 10_000);
+    for (let i = 0; i < 520; i++) store = markRead(store, `k${i}`, i + 1);
+    strictEqual(store.cursors.pinged?.notifiedAt, 10_000);
+    strictEqual(Object.keys(store.cursors).length, 500);
+  });
+
+  it("leaves the cursors object untouched below the cap", () => {
+    const store: ReadCursorStore = { since: 0, cursors: {} };
+    const next = markRead(store, "k", 1);
+    strictEqual(Object.keys(next.cursors).length, 1);
+  });
+});
+
+/**
+ * HOU-945 review fix: opening a mission must silence its pending mention ping.
+ * Both repro paths are asserted, because they fail for different reasons —
+ * one is "the mention landed while I was looking", the other is "I opened the
+ * mission after a reload and the mention predates that".
+ */
+describe("notifiedFloorFor folds in the read cursor", () => {
+  it("silences a mention that lands in a conversation I have open", () => {
+    // I am reading the mission: the tracker stamped `readAt` on the last
+    // repaint. A mention written a moment later must not reach the OS.
+    const store = markRead({ since: 100, cursors: {} }, "k", 5_000);
+    strictEqual(notifiedFloorFor(store, "k"), 5_000);
+    ok(4_900 <= notifiedFloorFor(store, "k"));
+  });
+
+  it("silences a mention that predates the mission I just opened", () => {
+    // Fresh boot, never notified about anything here; the mention is older
+    // than the moment I opened the mission, so I have already seen it.
+    const store: ReadCursorStore = {
+      since: 100,
+      cursors: { k: { readAt: 9_000 } },
+    };
+    strictEqual(notifiedFloorFor(store, "k"), 9_000);
+  });
+
+  it("still pings for a mention newer than both watermarks", () => {
+    const store: ReadCursorStore = {
+      since: 100,
+      cursors: { k: { readAt: 9_000, notifiedAt: 8_000 } },
+    };
+    ok(9_500 > notifiedFloorFor(store, "k"));
+  });
+
+  it("keeps the notified watermark when it leads the read cursor", () => {
+    // Pinged about a mention I have not opened yet: the ping must not repeat.
+    const store: ReadCursorStore = {
+      since: 100,
+      cursors: { k: { readAt: 200, notifiedAt: 9_000 } },
+    };
+    strictEqual(notifiedFloorFor(store, "k"), 9_000);
+  });
+
+  it("leaves the UNREAD badge lit for a mention I was only pinged about", () => {
+    // The whole point of keeping the two watermarks separate: folding them at
+    // write time would clear the badge the notification was announcing.
+    const store = markMentionNotified({ since: 100, cursors: {} }, "k", 9_000);
+    strictEqual(notifiedFloorFor(store, "k"), 9_000);
+    ok(9_000 > mentionReadFloorFor(store, "k"));
+  });
+});
+
+describe("mergeReadCursorStores", () => {
+  it("takes the later of every watermark, per conversation", () => {
+    const mine: ReadCursorStore = {
+      since: 100,
+      cursors: { a: { readAt: 500, notifiedAt: 700 }, mineOnly: { readAt: 1 } },
+    };
+    const theirs: ReadCursorStore = {
+      since: 100,
+      cursors: {
+        a: { readAt: 400, notifiedAt: 900 },
+        theirsOnly: { readAt: 2 },
+      },
+    };
+    deepStrictEqual(mergeReadCursorStores(mine, theirs).cursors, {
+      a: { readAt: 500, notifiedAt: 900 },
+      mineOnly: { readAt: 1 },
+      theirsOnly: { readAt: 2 },
+    });
+  });
+
+  it("adopts a watermark the other side has and this one does not", () => {
+    const merged = mergeReadCursorStores(
+      { since: 100, cursors: { a: { readAt: 500 } } },
+      { since: 100, cursors: { a: { readAt: 400, notifiedAt: 900 } } },
+    );
+    deepStrictEqual(merged.cursors.a, { readAt: 500, notifiedAt: 900 });
+  });
+
+  it("keeps the EARLIER `since`, never marking a backlog read", () => {
+    const merged = mergeReadCursorStores(
+      { since: 900, cursors: {} },
+      { since: 100, cursors: {} },
+    );
+    strictEqual(merged.since, 100);
+  });
+
+  it("returns the SAME reference when the other side adds nothing", () => {
+    const mine: ReadCursorStore = {
+      since: 100,
+      cursors: { a: { readAt: 500, notifiedAt: 700 } },
+    };
+    strictEqual(
+      mergeReadCursorStores(mine, {
+        since: 200,
+        cursors: { a: { readAt: 400, notifiedAt: 600 } },
+      }),
+      mine,
+    );
+    strictEqual(mergeReadCursorStores(mine, { since: 100, cursors: {} }), mine);
+  });
+
+  it("caps a union that crosses the growth limit", () => {
+    const rows = (from: number): Record<string, { readAt: number }> =>
+      Object.fromEntries(
+        Array.from({ length: 300 }, (_, i) => [`k${from + i}`, { readAt: 1 }]),
+      );
+    const merged = mergeReadCursorStores(
+      { since: 0, cursors: rows(0) },
+      { since: 0, cursors: rows(300) },
+    );
+    strictEqual(Object.keys(merged.cursors).length, 500);
+  });
+});
+
+/**
+ * Two tabs, one blob. Every one of these fails with a plain `setItem`, which is
+ * what the app did before this fix.
+ */
+describe("saveReadCursors merges instead of clobbering", () => {
+  it("keeps what another tab wrote while this one was open", () => {
+    const storage = memoryStorage();
+    // The other tab read mission B and saved.
+    saveReadCursors(storage, UID, {
+      since: 100,
+      cursors: { b: { readAt: 900 } },
+    });
+    // This tab still holds a view from before that, and now reads mission A.
+    const merged = saveReadCursors(storage, UID, {
+      since: 100,
+      cursors: { a: { readAt: 800 } },
+    });
+    deepStrictEqual(merged.cursors, {
+      a: { readAt: 800 },
+      b: { readAt: 900 },
+    });
+    deepStrictEqual(loadReadCursors(storage, UID, NOW).cursors, merged.cursors);
+  });
+
+  it("answers the store the caller must adopt, not the one it passed", () => {
+    const storage = memoryStorage();
+    saveReadCursors(storage, UID, {
+      since: 100,
+      cursors: { b: { readAt: 9 } },
+    });
+    const passed: ReadCursorStore = { since: 100, cursors: {} };
+    const written = saveReadCursors(storage, UID, passed);
+    ok(written !== passed);
+    strictEqual(written.cursors.b?.readAt, 9);
+  });
+
+  it("stamps the schema version and a lastTouched", () => {
+    const storage = memoryStorage();
+    saveReadCursors(
+      storage,
+      UID,
+      { since: 100, cursors: { a: { readAt: 1 } } },
+      NOW,
+    );
+    const blob = storedBlob(storage, UID);
+    strictEqual(blob.version, 1);
+    strictEqual(blob.lastTouched, NOW);
+    strictEqual(blob.since, 100);
+  });
+
+  it("reads a blob that predates the version stamp", () => {
+    const storage = memoryStorage({
+      [readCursorStorageKey(UID)]: JSON.stringify({
+        since: 100,
+        cursors: { a: { readAt: 7 } },
+      }),
+    });
+    deepStrictEqual(loadReadCursors(storage, UID, NOW), {
+      since: 100,
+      cursors: { a: { readAt: 7 } },
+    });
+  });
+
+  it("reads a blob from a FUTURE build, field by field", () => {
+    const storage = memoryStorage({
+      [readCursorStorageKey(UID)]: JSON.stringify({
+        version: 99,
+        since: 100,
+        cursors: { a: { readAt: 7 } },
+        somethingWeHaveNeverHeardOf: { nested: true },
+      }),
+    });
+    deepStrictEqual(loadReadCursors(storage, UID, NOW), {
+      since: 100,
+      cursors: { a: { readAt: 7 } },
+    });
+  });
+});
+
+describe("pruneForeignCursorStores", () => {
+  /** Seed `count` other accounts, oldest first, plus unrelated origin keys. */
+  function withAccounts(count: number) {
+    const storage = memoryStorage({
+      "houston.theme": "dark",
+      "houston.query-cache": "{}",
+    });
+    for (let i = 0; i < count; i++) {
+      saveReadCursors(
+        storage,
+        `other-${i}`,
+        { since: 0, cursors: { a: { readAt: 1 } } },
+        1_000 + i,
+      );
+    }
+    saveReadCursors(storage, UID, { since: 0, cursors: {} }, 5);
+    return storage;
+  }
+
+  it("keeps the four most recently written foreign accounts", () => {
+    const storage = withAccounts(7);
+    pruneForeignCursorStores(storage, UID);
+    const kept = [...storage.map.keys()].filter((k) =>
+      k.startsWith("houston.read-cursors."),
+    );
+    deepStrictEqual(
+      kept.sort(),
+      [
+        readCursorStorageKey("other-3"),
+        readCursorStorageKey("other-4"),
+        readCursorStorageKey("other-5"),
+        readCursorStorageKey("other-6"),
+        readCursorStorageKey(UID),
+      ].sort(),
+    );
+  });
+
+  it("never evicts the signed-in user, however stale their stamp", () => {
+    const storage = withAccounts(9);
+    pruneForeignCursorStores(storage, UID);
+    ok(storage.getItem(readCursorStorageKey(UID)) !== null);
+  });
+
+  it("touches nothing else in the origin", () => {
+    const storage = withAccounts(9);
+    pruneForeignCursorStores(storage, UID);
+    strictEqual(storage.getItem("houston.theme"), "dark");
+    strictEqual(storage.getItem("houston.query-cache"), "{}");
+  });
+
+  it("does nothing while the device is under the cap", () => {
+    const storage = withAccounts(4);
+    const before = storage.map.size;
+    pruneForeignCursorStores(storage, UID);
+    strictEqual(storage.map.size, before);
+  });
+
+  it("evicts an unstamped blob first, and does not throw on a corrupt one", () => {
+    const storage = withAccounts(4);
+    storage.setItem(readCursorStorageKey("legacy"), '{"since":1,"cursors":{}}');
+    storage.setItem(readCursorStorageKey("broken"), "{not json");
+    pruneForeignCursorStores(storage, UID);
+    strictEqual(storage.getItem(readCursorStorageKey("legacy")), null);
+    strictEqual(storage.getItem(readCursorStorageKey("broken")), null);
+    ok(storage.getItem(readCursorStorageKey("other-3")) !== null);
+  });
+});

--- a/app/tests/routine-chat-setup.test.ts
+++ b/app/tests/routine-chat-setup.test.ts
@@ -95,14 +95,24 @@ describe("automation chat setup message", () => {
     const agents = [{ id: "a", folderPath: "/w/a" }];
     const summaries = buildAgentActivitySummaries(agents, [
       {
+        id: "setup",
         agent_path: "/w/a",
         type: "activity",
         status: "needs_you",
         agent: ROUTINE_SETUP_AGENT_MODE,
       },
-      { agent_path: "/w/a", type: "activity", status: "needs_you" },
+      {
+        id: "real",
+        agent_path: "/w/a",
+        type: "activity",
+        status: "needs_you",
+      },
     ]);
-    deepStrictEqual(summaries.a, { needsYouCount: 1, runningCount: 0 });
+    deepStrictEqual(summaries.a, {
+      needsYouCount: 1,
+      runningCount: 0,
+      unreadCount: 0,
+    });
   });
 
   it("kickoff prompt covers the guided interview the issue asks for", () => {

--- a/app/tests/unread-model.test.ts
+++ b/app/tests/unread-model.test.ts
@@ -1,0 +1,298 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { KanbanItem } from "@houston-ai/board";
+import type { ReadCursorStore } from "../src/lib/read-cursors.ts";
+import { ROUTINE_SETUP_AGENT_MODE } from "../src/lib/routine-chat-setup.ts";
+import {
+  attachMissionUnread,
+  countUnreadByAgentPath,
+  isUnreadForMe,
+  type UnreadConversationInput,
+  unreadMissionIds,
+} from "../src/lib/unread-model.ts";
+
+const ME = "user-me";
+const MATE = "user-mate";
+const SINCE = Date.parse("2026-07-01T00:00:00.000Z");
+const NEWER = "2026-07-10T00:00:00.000Z";
+const OLDER = "2026-06-01T00:00:00.000Z";
+
+const store = (cursors: ReadCursorStore["cursors"] = {}): ReadCursorStore => ({
+  since: SINCE,
+  cursors,
+});
+
+const conv = (
+  over: Partial<UnreadConversationInput> = {},
+): UnreadConversationInput => ({
+  id: "m1",
+  agent_path: "/w/alpha",
+  type: "activity",
+  updated_at: NEWER,
+  ...over,
+});
+
+describe("isUnreadForMe", () => {
+  it("is unread when my own mission moved after my floor", () => {
+    strictEqual(isUnreadForMe(conv({ created_by: ME }), store(), ME), true);
+  });
+
+  it("is read once the cursor is past the update", () => {
+    const cursors = { "/w/alpha::m1": { readAt: Date.parse(NEWER) } };
+    strictEqual(
+      isUnreadForMe(conv({ created_by: ME }), store(cursors), ME),
+      false,
+    );
+  });
+
+  it("keeps an outstanding mention unread even when it predates `since`", () => {
+    // The second-device case: I install Houston today, and a mention from last
+    // month is still addressed to me. `since` exists to suppress ambient
+    // backlog, never a message that names me.
+    strictEqual(
+      isUnreadForMe(
+        conv({ updated_at: OLDER, mentioned: [{ user_id: ME, at: OLDER }] }),
+        store(),
+        ME,
+      ),
+      true,
+    );
+  });
+
+  it("clears a mention once I have opened that conversation", () => {
+    const cursors = { "/w/alpha::m1": { readAt: Date.parse(NEWER) } };
+    strictEqual(
+      isUnreadForMe(
+        conv({ updated_at: OLDER, mentioned: [{ user_id: ME, at: OLDER }] }),
+        store(cursors),
+        ME,
+      ),
+      false,
+    );
+  });
+
+  it("keeps a mention unread when the mission moved on without me", () => {
+    // Read at NEWER, but the mention landed after that: still my problem.
+    const cursors = { "/w/alpha::m1": { readAt: Date.parse(NEWER) } };
+    strictEqual(
+      isUnreadForMe(
+        conv({
+          updated_at: NEWER,
+          mentioned: [{ user_id: ME, at: "2026-07-11T00:00:00.000Z" }],
+        }),
+        store(cursors),
+        ME,
+      ),
+      true,
+    );
+  });
+
+  it("does not treat a mention I wrote about MYSELF as a claim on me", () => {
+    // Otherwise the badge outlives every read: the mention clause has no
+    // `since` floor, so a self-mention on a mission I never reopen would stay
+    // lit forever. The OS ping already ignores self-authored mentions.
+    strictEqual(
+      isUnreadForMe(
+        conv({
+          updated_at: OLDER,
+          created_by: MATE,
+          contributors: [{ user_id: MATE }],
+          mentioned: [{ user_id: ME, at: NEWER, by: ME }],
+        }),
+        store(),
+        ME,
+      ),
+      false,
+    );
+  });
+
+  it("keeps an authorless mention of me unread (pre-stamp entries)", () => {
+    strictEqual(
+      isUnreadForMe(
+        conv({
+          updated_at: OLDER,
+          created_by: MATE,
+          contributors: [{ user_id: MATE }],
+          mentioned: [{ user_id: ME, at: OLDER }],
+        }),
+        store(),
+        ME,
+      ),
+      true,
+    );
+  });
+
+  it("does not treat a mention of someone else as my mention", () => {
+    strictEqual(
+      isUnreadForMe(
+        conv({
+          updated_at: OLDER,
+          created_by: MATE,
+          contributors: [{ user_id: MATE }],
+          mentioned: [{ user_id: MATE, at: OLDER }],
+        }),
+        store(),
+        ME,
+      ),
+      false,
+    );
+  });
+
+  it("uses `since` as the floor, so history is not unread on a fresh device", () => {
+    strictEqual(
+      isUnreadForMe(conv({ created_by: ME, updated_at: OLDER }), store(), ME),
+      false,
+    );
+  });
+
+  it("counts a mission that only @mentions me, untouched by me", () => {
+    const c = conv({
+      created_by: MATE,
+      contributors: [{ user_id: MATE }],
+      mentioned: [{ user_id: ME, at: NEWER, by: MATE }],
+    });
+    strictEqual(isUnreadForMe(c, store(), ME), true);
+  });
+
+  it("ignores a teammate's mission that never names me", () => {
+    const c = conv({ created_by: MATE, contributors: [{ user_id: MATE }] });
+    strictEqual(isUnreadForMe(c, store(), ME), false);
+  });
+
+  it("keeps an unattributed mission unread-able (desktop parity)", () => {
+    strictEqual(isUnreadForMe(conv(), store(), ME), true);
+  });
+
+  it("is never unread with nobody signed in", () => {
+    strictEqual(isUnreadForMe(conv({ created_by: ME }), store(), null), false);
+  });
+
+  it("is never unread for a guided setup chat", () => {
+    strictEqual(
+      isUnreadForMe(
+        conv({ created_by: ME, agent: ROUTINE_SETUP_AGENT_MODE }),
+        store(),
+        ME,
+      ),
+      false,
+    );
+  });
+
+  it("is never unread without a usable updated_at", () => {
+    strictEqual(
+      isUnreadForMe(
+        conv({ created_by: ME, updated_at: undefined }),
+        store(),
+        ME,
+      ),
+      false,
+    );
+    strictEqual(
+      isUnreadForMe(
+        conv({ created_by: ME, updated_at: "whenever" }),
+        store(),
+        ME,
+      ),
+      false,
+    );
+  });
+});
+
+describe("countUnreadByAgentPath", () => {
+  it("counts only relevant, unread activity rows per agent", () => {
+    const convs: UnreadConversationInput[] = [
+      conv({ id: "a1", created_by: ME }),
+      conv({
+        id: "a2",
+        created_by: MATE,
+        contributors: [{ user_id: MATE }],
+        mentioned: [{ user_id: ME, at: NEWER }],
+      }),
+      // A teammate's own mission: relevant to them, not to me.
+      conv({ id: "a3", created_by: MATE, contributors: [{ user_id: MATE }] }),
+      // Already read.
+      conv({ id: "a4", created_by: ME }),
+      conv({ id: "b1", agent_path: "/w/beta", created_by: ME }),
+    ];
+    const cursors = { "/w/alpha::a4": { readAt: Date.parse(NEWER) } };
+    deepStrictEqual(countUnreadByAgentPath(convs, store(cursors), ME), {
+      "/w/alpha": 2,
+      "/w/beta": 1,
+    });
+  });
+
+  it("excludes setup chats and non-activity rows", () => {
+    const convs: UnreadConversationInput[] = [
+      conv({ id: "p1", type: "primary", created_by: ME }),
+      conv({ id: "s1", agent: ROUTINE_SETUP_AGENT_MODE, created_by: ME }),
+    ];
+    deepStrictEqual(countUnreadByAgentPath(convs, store(), ME), {});
+  });
+
+  it("counts nothing with nobody signed in", () => {
+    deepStrictEqual(
+      countUnreadByAgentPath([conv({ created_by: ME })], store(), null),
+      {},
+    );
+  });
+});
+
+describe("unreadMissionIds", () => {
+  it("returns the ids of the missions that are unread for me", () => {
+    const convs: UnreadConversationInput[] = [
+      conv({ id: "a1", created_by: ME }),
+      // A teammate's own mission: relevant to them, not to me.
+      conv({ id: "a2", created_by: MATE, contributors: [{ user_id: MATE }] }),
+      // Not mine, but it names me.
+      conv({
+        id: "a3",
+        created_by: MATE,
+        contributors: [{ user_id: MATE }],
+        mentioned: [{ user_id: ME, at: NEWER }],
+      }),
+    ];
+    deepStrictEqual([...unreadMissionIds(convs, store(), ME)].sort(), [
+      "a1",
+      "a3",
+    ]);
+  });
+
+  it("excludes setup chats and non-activity rows, like the sidebar count", () => {
+    const convs: UnreadConversationInput[] = [
+      conv({ id: "p1", type: "primary", created_by: ME }),
+      conv({ id: "s1", agent: ROUTINE_SETUP_AGENT_MODE, created_by: ME }),
+    ];
+    strictEqual(unreadMissionIds(convs, store(), ME).size, 0);
+  });
+
+  it("marks nothing with nobody signed in", () => {
+    strictEqual(
+      unreadMissionIds([conv({ created_by: ME })], store(), null).size,
+      0,
+    );
+  });
+});
+
+describe("attachMissionUnread", () => {
+  const items: KanbanItem[] = [
+    { id: "a1", title: "One", status: "running", updatedAt: NEWER },
+    { id: "a2", title: "Two", status: "done", updatedAt: NEWER },
+  ];
+
+  it("sets `unread` only on the missions in the set", () => {
+    const out = attachMissionUnread(items, new Set(["a2"]));
+    strictEqual(out[0]?.unread, undefined);
+    strictEqual(out[1]?.unread, true);
+  });
+
+  it("keeps the SAME array reference when nothing is unread", () => {
+    // The single-player / desktop path: no re-render, no new card objects.
+    strictEqual(attachMissionUnread(items, new Set()), items);
+  });
+
+  it("leaves the read items themselves untouched by reference", () => {
+    const out = attachMissionUnread(items, new Set(["a2"]));
+    strictEqual(out[0], items[0]);
+    strictEqual(out[1] === items[1], false);
+  });
+});

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,83 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v39 - 2026-07-27
+
+HOU-945, relevance-scoped notifications: a shared workspace only works if you can
+tell, at a glance, which of it moved while you were away. Four surfaces land
+together — a mark on the mission, a mark on the agent, an inbox of the missions
+where somebody typed your name, and the pill that opens it. All four are
+multiplayer-only: read state is per person and per device (local, never a write
+to the server on every mission open), so without a signed-in identity there is no
+"you" for anything to be unread FOR. Single player and the desktop app gain no
+new chrome at all, and reserve no space for any of it.
+
+`mission-card` gains an `unread-dot` (and the matching `unread` state) — the
+per-mission half. A mission card now carries a quiet mark when that mission has
+moved, or somebody typed your name in it, since you last opened it. The mark is
+a small filled dot in the semantic action tone, trailing the card's agent name:
+"there is something new here for you", never "act now" (which stays the needs-you
+status and its count chip). It is a mark, never a number, and it disappears the
+moment you open the mission.
+
+It sits in the card's identity line rather than among the approve / rename /
+delete icons (where a filled dot would read as a fourth button) and well clear of
+the contributors' faces in the body's bottom-right corner. A card with nothing
+new renders no dot AND reserves no space for one, so single player, a
+signed-out surface, and every legacy mission look exactly as they did.
+
+`agent-list-item` gains the matching `unread` state — the same dot, rolled up to
+the agent. A sidebar row now marks the agent when ANY of its missions has moved,
+or named you, since you last looked. It appears next to the needs-you chip, dot
+first, never in place of it: an agent can perfectly well have something urgent
+AND something new, and hiding one behind the other would make the rail lie about
+what is waiting. The dot never shows a number, but its label does ("3 unread
+updates"), so a screen reader and a hover both get the count without turning the
+rail into a wall of digits.
+
+Add `mentions-inbox`: a new Mission Control mode holding every mission where a
+teammate typed your name, newest first. Deliberately not a board — there is no
+column to move a mention between and no status to read off one, only who pinged
+you, where, and how long ago. So each row is a flat line: their face, "Ana
+mentioned you in Finance", the mission title, and how long ago, and clicking it
+lands you in that mission's chat exactly the way a completion notification does.
+A row that still has something new keeps the same quiet dot, on a rail that is
+always reserved so read and unread rows stay optically aligned. A mention we
+cannot attribute drops the face for an at-sign and says only that you were
+mentioned. Nobody has mentioned you yet: "No mentions yet".
+
+The way in is a Mentions pill in the Mission Control toolbar, beside Archived
+(`mission-board` gains it as an anatomy part). It highlights while the inbox is
+showing, collapses to its at-sign when a chat panel squeezes the board, and
+carries the number of mentions still outstanding — a mention of you newer than
+where you last read, NOT ambient mission movement, because a number the size of
+your whole workspace's activity is a number nobody clicks. Past ninety-nine it
+reads "99+"; the exact figure past that changes nothing you would do. The count
+is in the control's accessible name too, not just next to the glyph.
+
+## v38 - 2026-07-27
+
+Add `mention-autocomplete` + `mention-chip` (HOU-944): in a shared chat you can
+now tag a teammate. Typing "@" in the composer raises a picker over the space's
+co-members, filtered as you type (accent- and case-insensitive, yourself
+excluded); Arrow keys move, Enter or Tab accepts, Escape closes. Accepting types
+the plain text "@Name" into the message and remembers who that is, so the model
+reads ordinary prose while the message carries the identities alongside it. With
+no roster (single player, a personal space, or a host that predates the
+directory) the picker never opens and "@" is just a character.
+
+Both sides of the conversation render those names as chips: a human message
+chips the mentions stored on the message itself, and the agent's prose is matched
+against the known people of the space, since an agent writes a name as plain text
+when it needs someone specific to confirm something. A mention of the reader is
+emphasized, so an ask aimed at you stands out in a busy thread.
+
+Behind it the conversation view-model carries `mentions` end to end beside
+`author` (protocol `ChatMessage.mentions` + the `user` wire frame, runtime
+persistence, `packages/sdk`: `TurnSendInput` / `StreamTurnOptions` /
+`FeedFrame` / `FeedItemVM`), which is what a notification and inbox layer will
+read to tell someone they were tagged.
+
 ## v37 - 2026-07-27
 
 Refine `user-message` + `assistant-message` (no new component, no `since`

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 37
+version: 39
 
 components:
   - id: agent-avatar
@@ -56,12 +56,25 @@ components:
     title: Agent list item
     purpose: A single agent row/card in the agent list or sidebar.
     anatomy: [avatar, name, status-chip, unread-or-count-slot, trailing-actions]
-    states: [idle, running, needs-you, selected, focused]
+    states: [idle, running, needs-you, unread, selected, focused]
     variants: [sidebar-rail-collapsed, list-row, grid-card]
     behavior: >-
       Selection and run status come from the view-model; the row reflects the
-      agent's aggregate mission state, not a single conversation.
-    a11y: button/listitem role, name as accessible label, aria-current when selected.
+      agent's aggregate mission state, not a single conversation. The unread
+      state fills the unread-or-count-slot with a small filled action-token dot
+      whenever any of that agent's missions has moved, or somebody typed the
+      reader's name in one, since the reader last opened it. It renders
+      ALONGSIDE the needs-you chip and before it, never instead of it: "there is
+      something new here" and "act now" are different claims and must not
+      collapse into one mark. It is a dot, never a number -- the count lives in
+      the label. Read state is per person and per device, and the signal is
+      multiplayer-only, so single player, the desktop app and any signed-out
+      surface never paint it and reserve no space for it.
+    a11y: >-
+      button/listitem role, name as accessible label, aria-current when
+      selected; the unread dot is an image-role element carrying a text label
+      that states the count ("3 unread updates"), so the signal is never
+      colour/shape alone.
     since: 1
 
   - id: conversation-feed
@@ -205,6 +218,38 @@ components:
       card is the only intended action, e.g. onboarding's one-button offer.
     a11y: labeled textarea; send/stop button state-labeled; drop zone announced.
     since: 1
+
+  - id: mention-autocomplete
+    title: Mention autocomplete
+    purpose: The teammate picker the composer raises when the writer types "@" in a shared chat.
+    anatomy: [popover-surface, person-row, person-face, person-name]
+    states: [closed, open-filtering, open-empty-closes, keyboard-highlighted]
+    variants: [pointer-select, keyboard-select]
+    behavior: >-
+      Opens on an "@" that starts a word and filters the space's co-member
+      directory as the writer types (case- and accent-insensitive, self
+      excluded). Accepting inserts the plain text "@Name" and records the
+      person on the send's structured mention list, so the model reads prose
+      while the wire carries identities. Arrow keys move the highlight, Enter
+      or Tab accepts, Escape closes. With no roster (single player, personal
+      space, or a host without the directory) it never opens and "@" is just
+      a character.
+    a11y: listbox/option roles; the highlighted option is announced; the textarea keeps focus throughout.
+    since: 38
+
+  - id: mention-chip
+    title: Mention chip
+    purpose: An "@Name" inside a message, rendered as a person pill instead of raw text.
+    anatomy: [pill, at-sign, person-name]
+    states: [default, self-mention]
+    variants: [in-user-bubble, in-agent-prose]
+    behavior: >-
+      A human message chips the mentions stored on the message itself; agent
+      prose is matched against the known people of the space, since an agent
+      writes names as plain text. A mention of the reader is emphasized so
+      being asked for something stands out. Chips never render inside code.
+    a11y: Decorative styling only -- the chip keeps the literal "@Name" text in the reading order.
+    since: 38
 
   - id: turn-status
     title: Turn status line
@@ -469,6 +514,7 @@ components:
         select-checkbox,
         people-face-stack,
         people-overflow-chip,
+        unread-dot,
       ]
     states:
       [
@@ -480,6 +526,7 @@ components:
         focused,
         dragging,
         attributed,
+        unread,
       ]
     variants: [board-card, archived-list-row]
     behavior: >-
@@ -493,24 +540,92 @@ components:
       expands to the full roster, and the card body reserves a right gutter sized
       to the stack so no text ever runs underneath it. Server-stamped attribution
       only (multiplayer); an unattributed card renders exactly as before.
+      The unread dot is the per-mission half of the shell's unread signal: a
+      small filled action-token circle trailing the card's agent name, shown only
+      when this mission has moved (or someone typed the reader's name) since the
+      reader last opened it, and never on the card currently open in the detail
+      panel. It is a mark, never a count, so it can never be confused with the
+      needs-you status. Read state is per person, so single player and any
+      signed-out surface never paint it and reserve no space for it.
     a11y: >-
       article/button role; title as label; checkbox labeled; status not
       color-only; the face stack is a labeled group, each face names its person
       (tooltip + title) and the "+N" chip is a labeled control, so no contributor
-      is reachable by hover alone.
+      is reachable by hover alone; the unread dot is an image-role element with a
+      text label (tooltip + title), so the signal is never colour/shape alone.
     since: 1
 
   - id: mission-board
     title: Mission board
     purpose: The columned board that groups mission cards by status.
-    anatomy: [column, column-header, card-list, empty-column-state, bulk-action-bar]
+    anatomy:
+      [
+        column,
+        column-header,
+        card-list,
+        empty-column-state,
+        bulk-action-bar,
+        mentions-pill,
+      ]
     states: [populated, empty, loading, dragging]
     variants: [multi-column-board, single-column-list]
     behavior: >-
       Columns map to mission statuses; cards move between columns on approve/drag.
       Bulk-action bar appears when cards are multi-selected.
-    a11y: list/grid semantics per column; column headers labeled; DnD has non-pointer fallback.
+      The mentions pill is the toolbar control that swaps the board for the
+      mentions-inbox mode: an at-sign pill sitting beside the archived pill,
+      highlighted while that mode is showing, collapsing to its icon alone when
+      a chat panel narrows the board, and carrying the number of outstanding
+      mentions -- a mention of the reader newer than their read cursor, not
+      ambient mission movement -- clamped to "99+". Multiplayer only: single
+      player gets no mentions chrome at all.
+    a11y: >-
+      list/grid semantics per column; column headers labeled; DnD has
+      non-pointer fallback; the mentions pill names its mode and repeats its
+      outstanding count in its accessible name, so the number is never
+      visual-only.
     since: 1
+
+  - id: mentions-inbox
+    title: Mentions inbox
+    purpose: >-
+      Mission Control's multiplayer-only mode listing every mission where a
+      teammate typed the reader's name.
+    anatomy:
+      [
+        row-list,
+        mention-row,
+        unread-dot,
+        mentioner-face,
+        mission-title,
+        mentioner-line,
+        relative-time,
+        empty-state,
+      ]
+    states: [loading, populated, empty, unread-row]
+    variants: [with-mentioner-face, unattributed-mention]
+    behavior: >-
+      A plain scrollable list, deliberately NOT a board: there are no columns to
+      move a mention between and no status to read off one, only who pinged the
+      reader, where, and how long ago. One row per mission that mentions the
+      reader, newest mention first, with a deterministic tiebreak so the list
+      never reshuffles under a click. A row carries the mentioner's face, the
+      line "<Name> mentioned you in <Agent>", the mission title and the age of
+      the mention; opening it navigates to that mission's chat exactly as a
+      completion notification does. A mention whose author is unknown drops the
+      face for an at-sign glyph and says only that the reader was mentioned. A
+      row with something new since the reader last opened that mission carries
+      the same quiet action-token dot the sidebar and the mission card use, on a
+      rail that is always reserved so read and unread rows stay aligned. With
+      nobody mentioning the reader the list shows its empty state; with nobody
+      signed in there is no "me" to mention, and the mode is never routed to.
+    a11y: >-
+      list/listitem semantics; each row is a button whose accessible name is its
+      visible text (mission title, the "mentioned you in" line, the relative
+      time); the mentioner's name is that text, never the face alone, which is
+      decorative; the unread dot is presentational, since a row's presence in
+      the inbox is already the claim on attention.
+    since: 39
 
   - id: mission-status-chip
     title: Mission status chip

--- a/design/inventory/manifests/android.yaml
+++ b/design/inventory/manifests/android.yaml
@@ -33,6 +33,10 @@ components:
     status: not-started
   composer:
     status: not-started
+  mention-autocomplete:
+    status: not-started
+  mention-chip:
+    status: not-started
   turn-status:
     status: not-started
   progress-panel:
@@ -44,6 +48,8 @@ components:
   mission-card:
     status: not-started
   mission-board:
+    status: not-started
+  mentions-inbox:
     status: not-started
   mission-status-chip:
     status: not-started

--- a/design/inventory/manifests/ios.yaml
+++ b/design/inventory/manifests/ios.yaml
@@ -137,6 +137,10 @@ components:
       On send, staged files upload via turns/attachments/save then their saved
       paths are woven into the message by AttachmentMessage.encode (has-attachments
       state; AttachmentSend.swift). Drag-over is desktop-only.
+  mention-autocomplete:
+    status: not-started
+  mention-chip:
+    status: not-started
   turn-status:
     status: implemented
     ref: mobile/ios/Houston/Features/Chat/ChatTitleView.swift
@@ -178,11 +182,22 @@ components:
       separators, line 1 = title + relative time, line 2 = accent "Working…" /
       destructive snag / muted description, collapsing away when empty. That row
       is native-only styling of the same MissionCardData, not a separate inventory
-      component (the archived list reuses it).
+      component (the archived list reuses it). The v39 unread-dot is NOT rendered
+      yet: read cursors are per-device local state that iOS does not keep, so no
+      mission can be unread there.
   mission-board:
     status: implemented
     ref: mobile/ios/Houston/Features/MissionControl/MissionControlPager.swift
-    notes: Three-column pager (Running / Needs you / Done) with headers, card lists, empty-column states; no bulk-action bar on mobile.
+    notes: >-
+      Three-column pager (Running / Needs you / Done) with headers, card lists,
+      empty-column states; no bulk-action bar on mobile. The v39 mentions pill
+      is NOT there: it is the entry point of a mode iOS does not have yet, and
+      its count is read off per-device read cursors iOS does not keep.
+  mentions-inbox:
+    status: not-started
+    notes: >-
+      Blocked on the same per-device read cursors the v39 unread dot needs; iOS
+      keeps none, so no mention can be outstanding there.
   mission-status-chip:
     status: implemented
     ref: mobile/ios/Houston/DesignSystem/StatusChip.swift

--- a/design/inventory/manifests/web.yaml
+++ b/design/inventory/manifests/web.yaml
@@ -75,6 +75,14 @@ components:
     status: implemented
     ref: "@houston-ai/chat ChatInput / ai-elements/prompt-input"
 
+  mention-autocomplete:
+    status: implemented
+    ref: "@houston-ai/chat ChatInputMentions / useMentionAutocomplete (mention-query)"
+
+  mention-chip:
+    status: implemented
+    ref: "@houston-ai/chat MentionChip + mention-spans (rendered through MessageResponse)"
+
   turn-status:
     status: implemented
     ref: "@houston-ai/chat ChatStatusLine + chat-status"
@@ -126,6 +134,15 @@ components:
   mission-board:
     status: implemented
     ref: "@houston-ai/board KanbanBoard / AIBoard / KanbanColumn"
+
+  mentions-inbox:
+    status: partial
+    ref: "app/src/components/board/mentions-inbox.tsx (+ mentions-inbox-row.tsx, mentions-inbox-model.ts)"
+    notes: >-
+      Ships and works, but app/-locked: the row and the list live in app/src
+      rather than a shared @houston-ai/ package, so a native surface cannot yet
+      reuse their structure. The ordering + naming rules ARE already extracted
+      into DOM-free models (mentions-inbox-model / mentions-inbox-view-model).
 
   mission-status-chip:
     status: partial

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -826,18 +826,311 @@ authors, own rows via `useMyProfile`, `PersonFace` initials fallback).
 
 ---
 
+## Chat @mentions (HOU-944)
+
+Tag a teammate in a shared chat. Typing `@` in the composer raises a picker over
+the space's co-members; accepting inserts the PLAIN TEXT `@Name ` (the composer
+stays a plain textarea, no contenteditable) and remembers `{userId, name}` on the
+side. On send, the pending mentions whose `@Name` still appears in the message
+ship as a structured `mentions[]` sidecar next to the prompt: **the model reads
+prose, the wire carries identities.** Agents mention humans back in plain text
+(the product prompt tells them to address a person as `@Name` when a reply needs
+that person's confirmation), so ASSISTANT mentions are never structured.
+
+**The roster.** `GET /v1/org/people` → `{people:[{userId, displayName?,
+photoUrl?}]}` — the sanitized co-member directory of the ACTIVE space, served to
+EVERY member (a personal space resolves only the caller), named-first, no emails
+and no roles. Unlike `GET /v1/org` it is NOT owner/admin-only: every teammate
+must be able to mention their co-members. `getOrgPeople` 404-degrades to `[]`
+(an older gateway simply has no autocomplete), and the app hook
+`use-org-people.ts` is multiplayer-gated exactly like `useUserProfiles`
+(`staleTime` 5 min, no toast, no Sentry). It returns TWO lists: `people` (named
+co-members, viewer INCLUDED — the render roster, so an agent writing your name
+chips it) and `mentionable` (`people` minus the caller — the composer list). A
+co-member with no display name is never offered: `@a1b2c3d4` means nothing to a
+non-technical reader.
+
+**The wire.** `mentions?: {userId, name?}[]` rides beside `author` the whole way:
+protocol `ChatMessage.mentions` + the `user` frame's `data.mentions`, runtime
+`UserMessageMeta` (persisted) and the send-route body, `SessionStartRequest`
+/ `ChatHistoryEntry`, and the SDK's `TurnSendInput` / `StreamTurnOptions` /
+`FeedFrame` / `FeedItemVM` (so a live send, a reload and the offline cache all
+chip identically). Every untrusted reader runs the ONE shared guard
+`parseMentions` (`packages/protocol/src/conversation.ts`, hand-rolled, no zod).
+It caps the result at `MENTIONS_MAX` 32, clips `userId`/`name` to
+`MENTION_USER_ID_MAX` 128 / `MENTION_NAME_MAX` 256, keeps the FIRST entry per
+userId (a repeat can't spend the budget), stops scanning after
+`MENTIONS_SCAN_MAX` 1000 raw entries (a junk array is never walked in full),
+drops junk entries and omits the field when nothing survives. This is the
+persistence a notification/inbox feature consumes: scan a conversation for
+`mentions[].userId === me`.
+
+**Rendering (`@houston-ai/chat`).** `MentionChip` + the pure span finder
+(`mention-spans.ts`) + a hand-rolled rehype pass (`mention-rehype.ts`) appended
+AFTER Streamdown's own `raw → sanitize → harden` chain (Streamdown REPLACES its
+plugin list when you pass `rehypePlugins`, so the defaults are spread back in;
+the plugin is passed in tuple form because Streamdown caches processors by plugin
+name + `JSON.stringify(options)`). A user bubble chips off the message's own
+`mentions[]`; assistant prose is matched against the `mentionPeople` prop. A
+mention of the viewer wears the highlight wash.
+
+Matching rules that are easy to get wrong, all in `mention-text.ts`: BOTH the
+roster names and the message text are normalized to **NFC** before anything is
+compared, because the span finder slices the text by the name's UTF-16 length
+and "é" has two spellings — so the two must agree or a chip truncates
+mid-grapheme. Span matching is therefore case-folding ONLY; the accent-folding
+key (`mentionKey`) is used exclusively by the autocomplete FILTER, where a
+length change is harmless. Two co-members with the same display name collapse
+to ONE render target ("@Ana" cannot say which Ana), carrying the OR of their
+`isSelf` flags so the viewer's emphasis is never lost to sort order; which
+userId each occurrence ATTRIBUTES to is decided at send time instead, by handing
+occurrences to the pending picks in order (`mention-send.ts`).
+
+The composer half is `use-mention-autocomplete.ts` (+ `use-mention-combobox.ts`
+for the ids, `chat-input-mentions.tsx` for the surface), intercepting
+Enter/Tab/arrows/Escape through `PromptInputTextarea`'s external-handler-first
+`defaultPrevented` seam. Four rules live there: the list takes NO key while an
+IME composition is in flight (`mention-keys.ts` — Arrow/Escape/Enter/Tab all
+belong to the candidate window); a dismissal sticks for the LIFETIME of its
+token (same `@` index) and lifts only when the token stops existing, and a
+pointer-down on the anchor textarea is not a dismissal at all; the textarea
+itself carries the combobox ARIA (`role`, `aria-expanded`, `aria-controls`,
+`aria-activedescendant`) since focus never leaves it — which is why the list is
+plain markup, not cmdk, whose own element ids overwrite the caller's; and
+pending picks are parked per `draftKey` (the ChatPanel's `sessionKey`) in a
+bounded map, so switching conversations neither loses them nor cross-attaches
+them, with the send snapshotting rather than consuming them (a rejected send
+keeps its text, so it keeps its mentions).
+
+At SEND time the text is run through `mention-mask.ts` first — fenced code,
+inline code spans and inline links are blanked one character for one — because
+the renderer never chips inside `code`/`pre`/`a` and a mention recorded there
+would notify someone about a message that addresses them nowhere. It is a
+lexical pass, not a parser; the residual gaps (indented code blocks, reference
+links, autolinks, raw HTML) are listed in that module's header.
+
+**App wiring.** `use-chat-mentions.tsx` resolves the four props
+(`mentionPeople`, `messageMentionPeople`, `renderMentionAvatar` = `PersonFace`,
+`mentionLabels`); `use-agent-chat-panel` returns them as `mentionProps` and
+every AIBoard mount spreads them. Display names are normalized to NFC at that
+boundary (`org-people-map.ts`). The mentions themselves travel as an argument, not state:
+`ChatInput.onSend(text, files, mentions)` → `AIBoard.handleSend` →
+`onSendMessage`/`onCreateConversation`/`onComposerSubmit` → the board sources'
+`SendOverrides` bag → `tauriChat.send({mentions})`, including the warming-send
+queue (a parked message keeps its chips across a relaunch). E2E:
+`packages/web/e2e/chat-mentions.spec.ts`.
+
+---
+
+## Relevance-scoped notifications (HOU-945)
+
+With many agents running in parallel, a user must only be signalled when it
+matters to THEM. There is **no settings toggle** (features-default-ON): relevance
+IS the behaviour, and the existing global notifications on/off switch is
+untouched.
+
+**The relevance rule is not re-derived.** It is `missionMatchesScope(people,
+{kind:"me"}, selfId)` from `app/src/lib/agent-person-scope.ts`, reached through
+`app/src/lib/mission-relevance.ts`: a mission is mine if my face is on it
+(`created_by`/`contributors`) OR it carries no attribution at all. That second
+clause is load-bearing and keeps desktop/single-player byte-identical. A mission
+that @mentions me is relevant too, whether or not I ever touched it.
+
+### The mention aggregate lives on the ACTIVITY, not on `ConversationSummary`
+
+The client's mission list is derived from activities
+(`engine-adapter/client/activities-mixin.ts` → `activityToConversation`), NOT
+from the runtime's `ConversationSummary`. So the per-mission aggregate rides the
+activity record, which the board already fetches:
+
+```ts
+// packages/protocol/src/domain/activity.ts
+interface ActivityMention { user_id: string; at: string; by?: string }
+const ACTIVITY_MENTIONS_MAX = 32;
+interface Activity { …; mentioned?: ActivityMention[] }
+```
+
+Latest-per-person (an array of "who has been pinged here, and when", not a log),
+capped by dropping the oldest `at`. Declared in `ui/agent-schemas/src/activity.schema.json`
+(the doc is `additionalProperties: false`) and sanitized on read by
+`sanitizeMentions` inside `normalizeActivities`.
+
+**Server-stamped, one write.** `stampTurnAttribution`
+(`packages/host/src/routes/activity-attribution.ts`, formerly
+`stampTurnContributor`) now upserts the contributor AND the mentions in a single
+load→save→emit pass. It runs only when a gateway vouched for the actor
+(`actingAuthor` non-null), so off the gateway nothing runs, not even the body
+read, and `activity.json` stays byte-identical.
+
+Getting the mentions there needed one structural change: the turn body is
+normally first read inside the channel, so `ChannelCtx` gained an optional
+`body?: Buffer`. `routes/agents.ts` drains the turn POST once, derives the ids
+with the shared `parseMentions` guard, stamps, and hands the buffer down; both
+`ProxyChannel` and `TurnChannel`/`dispatchCloudrun` prefer it over the
+(now-exhausted) stream. Threaded on to `ConversationEntry` → `RawConversation`.
+
+A malformed turn body is not that seam's business — it stamps no mentions and
+passes the body on. `dispatchCloudrun` now GUARDS its parse and answers
+`400 {"error":"invalid JSON body"}` (re-throwing `BodyTooLargeError` so an
+over-cap body still maps to a clean 413). The proxy path is unchanged and still
+relays the pi runtime's `500 {"error":"internal error"}`, because
+`runtime/src/transport/http-helpers.ts` `readJson` is unguarded — a live
+follow-up, not something the host can fix from its side.
+
+`sanitizeMentions` keeps the NEWEST `ACTIVITY_MENTIONS_MAX` entries by `at`
+(returned in file order, ties stable), matching `upsertMentions`'s
+evict-the-oldest rule. It used to truncate to the first 32 in file order, so a
+read could drop exactly the mentions a write had just decided to keep.
+
+### Read cursors are per-device localStorage, on purpose
+
+Five modules, one concern each:
+
+| Module | Owns |
+| --- | --- |
+| `app/src/lib/read-cursors.ts` | the pure cursor ALGEBRA (keys, floors, watermarks, the 500-entry cap) |
+| `app/src/lib/read-cursors-merge.ts` | how two views of one user's store combine (the cross-tab rule) |
+| `app/src/lib/read-cursors-parse.ts` | decoding an untrusted stored blob; the `version` stamp |
+| `app/src/lib/read-cursors-storage.ts` | the `localStorage` seam: key, merge-on-write, foreign-account eviction |
+| `app/src/lib/read-cursor-live-store.ts` | the singleton instance + subscribers (React-free, so a notification callback reads it) |
+
+`app/src/hooks/use-read-cursors.ts` is now only the React bindings
+(`useReadCursorStore` = `useSyncExternalStore` over the live store,
+`useReadCursorTracker` = the "viewed" observer).
+
+Key `houston.read-cursors.<uid>`, per-uid so two accounts on one machine never
+read each other's state. Each entry holds `readAt` and the mention `notifiedAt`
+watermark; the store's `since` is the floor for anything with no cursor of its
+own, so a fresh device does not open on a backlog. The persisted envelope also
+carries `version: 1` and a `lastTouched` stamp.
+
+The tradeoff, taken deliberately: an unread badge is local reading state and the
+user experiences clearing it as instant. Host preferences would put a request on
+every mission open, and in hosted mode that request can be the thing that WAKES a
+sleeping pod. Cost: a second device starts from its own `since`.
+
+**A second TAB is not a tradeoff, it is the normal case.** One whole-blob value
+per user means a plain `setItem` is last-writer-wins: the tab that saves second
+erases every mission the other one cleared. So every save is a read-modify-write
+(`saveReadCursors` merges against disk and RETURNS what it wrote — callers must
+adopt that, not the value they passed), a `window` `storage` listener folds the
+other tabs' writes in live, and the merge rule is per conversation: the LATER of
+each watermark, the EARLIER `since`. Watermarks only move forward, so the two
+tabs are never in conflict — they each know part of the truth.
+
+**Foreign accounts are evicted** (`pruneForeignCursorStores`, on every uid
+change): the 4 most recently `lastTouched` blobs of OTHER uids survive, the rest
+are removed. Nothing used to clean them up, so a shared machine accreted one
+uncapped blob per person who ever signed in, against a ~5MB origin quota shared
+with the query persister.
+
+**Two clocks in `isUnreadForMe`.** An outstanding @mention is measured against my
+cursor for that conversation ALONE (`mentionReadFloorFor`, no `since` fallback):
+someone typed my name, so it stays unread however old it is, and it survives the
+mission moving on without me. Ambient movement uses `updated_at` vs the normal
+floor. Without the split, signing in on a second device silently marked every
+pre-install mention as read, which is exactly the miss this feature exists to
+prevent.
+
+**`notifiedFloorFor` folds `readAt` in.** `markRead` deliberately never touches
+`notifiedAt` (the two watermarks answer different questions, and collapsing them
+at write time would clear the badge a ping had just announced), so the OS-ping
+floor is `max(notifiedAt ?? since, readAt)` instead. Without it, a mention landing
+in a conversation ON SCREEN — or one predating the mission you just reopened
+after a reload — still fired a desktop notification.
+
+**Self-authored mentions never count.** `missionMentionsMe` / `latestMentionFor`
+(`lib/mission-relevance.ts`) require `by !== selfId`, so typing your own name
+cannot earn a permanent inbox row plus a mention-unread badge nothing can clear
+(the mention clause has no `since` floor). An entry with NO `by` still counts —
+the gateway only began stamping authors with this feature, and reading "no
+author" as "me" would swallow a whole generation of real mentions.
+
+The "viewed" seam is the `["chat-history", agentPath, sessionKey]` query, observed
+raw (`getObserversCount() > 0`) so no surface has to remember to report anything;
+session keys are resolved to conversation ids by
+`app/src/lib/chat-conversation-id.ts`, cache reads only. It answers **null** when
+no cached list can name the mission (a cold `routine-<id>`), and the tracker then
+writes NOTHING: the old fallback to the raw session key produced a cursor under a
+key no unread surface ever looks up, and the same cache events re-fire once the
+lists land.
+
+**Only `observerAdded` + `updated` count as "viewed"** (`VIEWED_EVENTS`), and the
+exclusion is load-bearing, not tidiness: React Query emits
+`observerOptionsUpdated` on EVERY RENDER of a component holding the query, and
+each mark stamps a fresh `Date.now()`, so marking on those turned the tracker
+into a render-driven write. Harmless while only the sidebar subscribed to the
+cursor store (it observes no chat history, so the cascade died), it became an
+infinite update loop the moment a second surface subscribed — store change →
+board re-render → options updated → new cursor → store change. Any new
+subscriber to `useReadCursorStore` depends on this filter.
+
+### Surfaces
+
+- **Completion notifications** — `app/src/hooks/completion-notification.ts` gates
+  the send on `shouldNotifyCompletion`. Fails OPEN (unknown mission, unattributed
+  mission, signed-out user all notify) and reads `selfId` at FIRE time, since a
+  latch can outlive a sign-in by its grace window.
+- **@mention pings** — `app/src/hooks/use-mention-notifications.ts`, once per
+  aggregate entry via the `notifiedAt` watermark.
+- **Sidebar** — `AgentActivitySummary.unreadCount` beside `needsYouCount`,
+  rendered as a quiet `UnreadDot` (a filled `bg-action` dot), deliberately a
+  different shape and weight from `NeedsYouChip`: "something new here" vs "act
+  now". Zero when signed out or single-player: `use-agent-activity-summaries.ts`
+  omits the `unread` option entirely unless `isMultiplayer(capabilities)`, and
+  `buildAgentActivitySummaries` leaves every count at 0 without it — the same
+  capability gate `use-board-unread.ts` applies to the cards.
+- **Mentions inbox** — Mission Control's third mode
+  (`app/src/components/board/mentions-inbox.tsx`), hidden entirely when
+  `!isMultiplayer(capabilities)`. `MissionControlToolbar` split into
+  `mission-toolbar-actions.tsx` + `mission-agent-filter.tsx`; the mode controls
+  are presence-gated (`onToggleMentions` absent = no chrome).
+
+  **The pill counts a narrower thing than the rows show.** A row's dot is
+  `isUnreadForMe` (mention OR ambient movement); the pill's number is
+  `mentionOutstanding` (a mention strictly newer than my cursor for that
+  conversation) — because the control says "N unread mentions", and a mission
+  that merely moved is not somebody typing your name. `MentionInboxRow` carries
+  both booleans so neither surface has to re-derive the other's rule.
+
+- **Mission cards** — the same quiet dot, per MISSION, trailing the card's agent
+  name in the header's identity cluster (never among the approve/rename/delete
+  icons, never near the bottom-right face stack). `KanbanItem.unread?: boolean`
+  is additive and props-only; the gate + tokens are the pure
+  `ui/board/src/kanban-card-unread.ts` (`showsUnreadDot`), which also hides the
+  mark on the card currently OPEN in the panel — the reader is looking at it, and
+  it swallows the flicker between the click and the cursor moving. Absent =
+  nothing rendered and no reserved rail, so single player is byte-identical.
+  Inventory `mission-card` v39 (`unread-dot` + `unread` state).
+
+  App fill: `unreadMissionIds` + `attachMissionUnread` (`lib/unread-model.ts`,
+  the SAME `isUnreadForMe` the sidebar counts) behind
+  `components/board/use-board-unread.ts`. Mission Control joins it onto the
+  cards as a last pass (a cursor move must not rebuild the card list and its
+  path/session maps); the per-agent board joins it in `use-agent-board-scope`
+  after the person filter, since its activity rows carry no attribution and no
+  mention aggregate — the conversations query answers both, deduped with the
+  face-stack read.
+
+E2E: `packages/web/e2e/mentions-inbox.spec.ts` (inbox + the card dot clearing on
+open).
+
+---
+
 ## engine-client types + methods
 
 Wire types in `ui/engine-client/src/types.ts`: `OrgRole`, `OrgMember`
 (+ optional `displayName`/`photoUrl`), `UserProfile`/`UserProfilesResult` (the
-`GET /v1/org/profiles` shape), `OrgInfo`, `OrgInvite`, `AddOrgMemberResult`,
+`GET /v1/org/profiles` shape), `OrgPerson` (the `GET /v1/org/people` directory
+row) + `MessageMention` (HOU-944), `OrgInfo`, `OrgInvite`, `AddOrgMemberResult`,
 `AgentAccess`, `AgentAssignment`,
 `AgentSettings` (`allowedToolkits` + `allowedModels` — the agent's whole ceilings;
 policy is per agent only, there is no `OrgSettings` type), `AuditEntry`, `UsageRow`,
 `AgentModelChoice` / `AgentModelChoiceInfo`. `Agent` gains multiplayer-only
 `assigned` / `assignedUserIds` / `access` / `assignments`. All hand-maintained
 against the gateway (the server is source of truth). Methods in `client.ts`:
-`getOrg`, `getOrgProfiles` (404-degrades to `{}`), `addOrgMember`, `deleteOrgInvite`,
+`getOrg`, `getOrgProfiles` (404-degrades to `{}`), `getOrgPeople` (the mention
+directory; 404-degrades to `[]`), `addOrgMember`, `deleteOrgInvite`,
 `removeOrgMember`, `setOrgMemberRole`,
 `setAgentAssignments` (v2 `{assignments}` or legacy `{userIds}`), `getAgentSettings`
 / `setAgentSettings`, `getAgentModelChoice` /

--- a/knowledge-base/ui-testing.md
+++ b/knowledge-base/ui-testing.md
@@ -68,7 +68,10 @@ cache was warm).
   `POST /__test__/chat-history` (`{ conversationId, messages, agentId? }`;
   replace a transcript verbatim — the only way to reach a SHARED conversation
   whose user messages carry the `author` the gateway stamps, for the sender
-  attribution spec `chat-senders.spec.ts`).
+  attribution spec `chat-senders.spec.ts`; the same control seeds a message's
+  `mentions[]` and an agent reply naming a person for the @mention spec
+  `chat-mentions.spec.ts`, whose roster comes from `POST /__test__/org`
+  → `GET /v1/org/people`).
 - **Board = files-first.** Reads/writes `.houston/activity/activity.json` via
   `/agents/:id/agentfile/*` (NOT just `/activities`). Fake host backs it with a
   real store, unified with `/activities` (same data, as in the real host),

--- a/packages/domain/src/activities.ts
+++ b/packages/domain/src/activities.ts
@@ -11,6 +11,7 @@ import {
   upsertContributor,
 } from "./contributors";
 import { docKey } from "./layout";
+import { sanitizeMentions } from "./mentions";
 import {
   type DocDiagnostic,
   loadJson,
@@ -72,6 +73,11 @@ export function normalizeActivities(
         } else {
           delete activity.contributors;
         }
+      }
+      if (entry.mentioned !== undefined) {
+        const mentioned = sanitizeMentions(entry.mentioned);
+        if (mentioned) activity.mentioned = mentioned;
+        else delete activity.mentioned;
       }
       if (
         entry.pending_interaction !== undefined &&

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -4,6 +4,7 @@ export * from "./anonymize-ai";
 export * from "./config";
 export * from "./contributors";
 export * from "./layout";
+export * from "./mentions";
 export * from "./portable";
 export * from "./portable-edit";
 export * from "./preferences";

--- a/packages/domain/src/mentions.test.ts
+++ b/packages/domain/src/mentions.test.ts
@@ -1,0 +1,209 @@
+import { ACTIVITY_MENTIONS_MAX, type Activity } from "@houston/protocol";
+import { expect, test } from "vitest";
+import { normalizeActivities } from "./activities";
+import { sanitizeMentions, upsertMentions } from "./mentions";
+
+/**
+ * The per-mission @mention aggregate (HOU-945): latest-per-person, capped,
+ * never a log. Stamped host-side under a gateway-verified acting identity, so
+ * these helpers stay pure — caller supplies the clock and the author.
+ */
+
+const NOW = "2026-07-27T10:00:00.000Z";
+const LATER = "2026-07-27T11:00:00.000Z";
+
+const mission = (mentioned?: Activity["mentioned"]): Activity => ({
+  id: "m1",
+  title: "Ship it",
+  description: "",
+  status: "running",
+  ...(mentioned !== undefined ? { mentioned } : {}),
+});
+
+test("upsertMentions records new people with the instant and the author", () => {
+  const next = upsertMentions(mission(), ["u-ada", "u-grace"], NOW, "u-alan");
+  expect(next.mentioned).toEqual([
+    { user_id: "u-ada", at: NOW, by: "u-alan" },
+    { user_id: "u-grace", at: NOW, by: "u-alan" },
+  ]);
+});
+
+test("upsertMentions omits `by` when the author is unknown", () => {
+  const next = upsertMentions(mission(), ["u-ada"], NOW);
+  expect(next.mentioned).toEqual([{ user_id: "u-ada", at: NOW }]);
+  expect("by" in (next.mentioned?.[0] ?? {})).toBe(false);
+});
+
+test("upsertMentions dedupes ids within one call", () => {
+  const next = upsertMentions(mission(), ["u-ada", "u-ada", "u-ada"], NOW);
+  expect(next.mentioned).toEqual([{ user_id: "u-ada", at: NOW }]);
+});
+
+test("upsertMentions drops non-string and empty ids", () => {
+  const next = upsertMentions(
+    mission(),
+    ["u-ada", "", null as unknown as string, 7 as unknown as string],
+    NOW,
+  );
+  expect(next.mentioned).toEqual([{ user_id: "u-ada", at: NOW }]);
+});
+
+test("a later mention overwrites the earlier one in place (latest wins)", () => {
+  const first = upsertMentions(mission(), ["u-ada", "u-grace"], NOW, "u-alan");
+  const second = upsertMentions(first, ["u-ada"], LATER, "u-edsger");
+  // One entry per person, same position — the aggregate is not a log.
+  expect(second.mentioned).toEqual([
+    { user_id: "u-ada", at: LATER, by: "u-edsger" },
+    { user_id: "u-grace", at: NOW, by: "u-alan" },
+  ]);
+});
+
+test("upsertMentions returns the SAME reference when nothing changed", () => {
+  const empty = mission();
+  expect(upsertMentions(empty, [], NOW)).toBe(empty);
+  expect(upsertMentions(empty, ["", ""], NOW)).toBe(empty);
+  const one = upsertMentions(empty, ["u-ada"], NOW, "u-alan");
+  // Re-stamping the same person at the same instant by the same author is a
+  // no-op, so the caller skips the disk write.
+  expect(upsertMentions(one, ["u-ada"], NOW, "u-alan")).toBe(one);
+});
+
+test("upsertMentions never touches updated_at", () => {
+  const before: Activity = { ...mission(), updated_at: NOW };
+  const next = upsertMentions(before, ["u-ada"], LATER);
+  expect(next.updated_at).toBe(NOW);
+});
+
+test("the aggregate is capped, dropping the OLDEST `at` first", () => {
+  let a = mission();
+  // ACTIVITY_MENTIONS_MAX people, each at a distinct (increasing) instant.
+  for (let i = 0; i < ACTIVITY_MENTIONS_MAX; i++) {
+    a = upsertMentions(
+      a,
+      [`u-${i}`],
+      `2026-07-27T00:${String(i).padStart(2, "0")}:00.000Z`,
+    );
+  }
+  expect(a.mentioned).toHaveLength(ACTIVITY_MENTIONS_MAX);
+  const capped = upsertMentions(a, ["u-new"], LATER);
+  expect(capped.mentioned).toHaveLength(ACTIVITY_MENTIONS_MAX);
+  // `u-0` was the oldest instant, so it is the one that fell off.
+  expect(capped.mentioned?.some((m) => m.user_id === "u-0")).toBe(false);
+  expect(capped.mentioned?.some((m) => m.user_id === "u-1")).toBe(true);
+  expect(capped.mentioned?.at(-1)).toEqual({ user_id: "u-new", at: LATER });
+});
+
+test("sanitizeMentions keeps only well-formed entries", () => {
+  expect(
+    sanitizeMentions([
+      { user_id: "u-ada", at: NOW, by: "u-alan" },
+      { user_id: "u-grace", at: NOW },
+      { user_id: "u-bad", at: 7 },
+      { user_id: "", at: NOW },
+      { at: NOW },
+      { user_id: "u-name", at: NOW, by: 42 },
+      null,
+      "nope",
+      [],
+    ]),
+  ).toEqual([
+    { user_id: "u-ada", at: NOW, by: "u-alan" },
+    { user_id: "u-grace", at: NOW },
+    { user_id: "u-name", at: NOW },
+  ]);
+});
+
+test("sanitizeMentions dedupes by user_id and returns undefined for nothing", () => {
+  expect(
+    sanitizeMentions([
+      { user_id: "u-ada", at: NOW },
+      { user_id: "u-ada", at: LATER },
+    ]),
+  ).toEqual([{ user_id: "u-ada", at: NOW }]);
+  expect(sanitizeMentions(undefined)).toBeUndefined();
+  expect(sanitizeMentions("garbage")).toBeUndefined();
+  expect(sanitizeMentions([])).toBeUndefined();
+  expect(sanitizeMentions([{ nope: true }])).toBeUndefined();
+});
+
+test("sanitizeMentions caps a hostile on-disk list", () => {
+  const many = Array.from({ length: ACTIVITY_MENTIONS_MAX + 10 }, (_, i) => ({
+    user_id: `u-${i}`,
+    at: NOW,
+  }));
+  expect(sanitizeMentions(many)).toHaveLength(ACTIVITY_MENTIONS_MAX);
+});
+
+/** An entry at minute `i` of the same hour — distinct, increasing instants. */
+const atMinute = (i: number) =>
+  `2026-07-27T00:${String(i).padStart(2, "0")}:00.000Z`;
+
+test("sanitizeMentions keeps the NEWEST entries over the cap, not the first ones in the file", () => {
+  // Oldest first in file order, so "keep the first MAX" and "keep the newest
+  // MAX" disagree: the read must drop the leading (oldest) 10, matching what a
+  // write would have dropped.
+  const oldestFirst = Array.from(
+    { length: ACTIVITY_MENTIONS_MAX + 10 },
+    (_, i) => ({ user_id: `u-${i}`, at: atMinute(i) }),
+  );
+  expect(sanitizeMentions(oldestFirst)).toEqual(oldestFirst.slice(10));
+
+  // Recency scattered through the file: the survivor set is chosen by `at`
+  // alone, and the survivors come back in FILE order (never reshuffled).
+  const scattered = Array.from(
+    { length: ACTIVITY_MENTIONS_MAX + 10 },
+    (_, i) => ({ user_id: `u-${i}`, at: atMinute((i * 17) % 42) }),
+  );
+  expect(sanitizeMentions(scattered)).toEqual(
+    scattered.filter((m) => m.at >= atMinute(10)),
+  );
+});
+
+test("sanitizeMentions breaks `at` ties by file order, deterministically", () => {
+  // Every entry at the SAME instant: nothing is newer, so the cap has to fall
+  // back on file order — and must land on the same survivors every run.
+  const tied = Array.from({ length: ACTIVITY_MENTIONS_MAX + 2 }, (_, i) => ({
+    user_id: `u-${i}`,
+    at: NOW,
+  }));
+  expect(sanitizeMentions(tied)).toEqual(tied.slice(0, ACTIVITY_MENTIONS_MAX));
+
+  // A tie at the cap boundary: 2 newest, then MAX tied older entries. The two
+  // newest survive outright; the tie fills the remaining slots from the top of
+  // the file, and every survivor keeps its file position.
+  const boundary = [
+    { user_id: "u-new-a", at: LATER },
+    ...Array.from({ length: ACTIVITY_MENTIONS_MAX }, (_, i) => ({
+      user_id: `u-tied-${i}`,
+      at: NOW,
+    })),
+    { user_id: "u-new-b", at: LATER },
+  ];
+  expect(sanitizeMentions(boundary)?.map((m) => m.user_id)).toEqual([
+    "u-new-a",
+    ...Array.from(
+      { length: ACTIVITY_MENTIONS_MAX - 2 },
+      (_, i) => `u-tied-${i}`,
+    ),
+    "u-new-b",
+  ]);
+});
+
+test("normalizeActivities sanitizes `mentioned` and deletes it when empty", () => {
+  const { items } = normalizeActivities(
+    [
+      {
+        id: "m1",
+        title: "Kept",
+        status: "running",
+        mentioned: [{ user_id: "u-ada", at: NOW }, { at: NOW }],
+      },
+      { id: "m2", title: "Garbage", status: "running", mentioned: "nope" },
+      { id: "m3", title: "Empty", status: "running", mentioned: [] },
+    ],
+    "k",
+  );
+  expect(items[0]?.mentioned).toEqual([{ user_id: "u-ada", at: NOW }]);
+  expect("mentioned" in (items[1] ?? {})).toBe(false);
+  expect("mentioned" in (items[2] ?? {})).toBe(false);
+});

--- a/packages/domain/src/mentions.ts
+++ b/packages/domain/src/mentions.ts
@@ -1,0 +1,127 @@
+import {
+  ACTIVITY_MENTIONS_MAX,
+  type Activity,
+  type ActivityMention,
+} from "@houston/protocol";
+
+/** Copy a mention, keeping `by` only when it is defined. */
+const cloneMention = (m: ActivityMention): ActivityMention =>
+  m.by !== undefined
+    ? { user_id: m.user_id, at: m.at, by: m.by }
+    : { user_id: m.user_id, at: m.at };
+
+/**
+ * Sanitize an untrusted `mentioned` array read off disk (agents write
+ * activity.json with file tools, so junk happens). Keep only objects with a
+ * non-empty string `user_id` and a string `at`; `by` rides along only when it
+ * is a string. The FIRST entry per `user_id` wins — a file that repeats a
+ * person is already corrupt, and taking the first keeps the survivor a
+ * function of the file, not of how far the scan ran.
+ *
+ * An over-cap file is trimmed the SAME way upsertMentions trims: keep the
+ * newest ACTIVITY_MENTIONS_MAX by `at`, drop the oldest. Truncating in file
+ * order instead would let a read silently discard the mentions a write just
+ * decided were the ones worth keeping — the two sides must agree on which
+ * mentions matter, or a hand-edited file quietly loses today's @mentions and
+ * keeps last month's. Ties on `at` fall back to file order (the sort is
+ * stable), so the survivor set is deterministic for a given file rather than
+ * engine-dependent. Survivors come back in FILE order, not recency order: an
+ * entry must never move just because the list was trimmed, exactly as
+ * upsertMentions restores the original ordering after capping.
+ *
+ * `undefined` when nothing survives, so the caller can delete the key rather
+ * than persist an empty array.
+ */
+export function sanitizeMentions(
+  value: unknown,
+): ActivityMention[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: ActivityMention[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry))
+      continue;
+    const e = entry as { user_id?: unknown; at?: unknown; by?: unknown };
+    if (typeof e.user_id !== "string" || !e.user_id) continue;
+    if (typeof e.at !== "string" || !e.at) continue;
+    if (seen.has(e.user_id)) continue;
+    seen.add(e.user_id);
+    out.push(
+      typeof e.by === "string"
+        ? { user_id: e.user_id, at: e.at, by: e.by }
+        : { user_id: e.user_id, at: e.at },
+    );
+  }
+  if (out.length === 0) return undefined;
+  if (out.length <= ACTIVITY_MENTIONS_MAX) return out;
+  // `at` is ISO 8601, so lexicographic ordering IS chronological ordering —
+  // the same comparison upsertMentions caps with, kept identical on purpose.
+  const keep = new Set(
+    out
+      .slice()
+      .sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0))
+      .slice(0, ACTIVITY_MENTIONS_MAX)
+      .map((m) => m.user_id),
+  );
+  return out.filter((m) => keep.has(m.user_id));
+}
+
+/**
+ * Record that `mentionedIds` were named in this mission at `atIso` by `by`.
+ * Latest-per-person wins (an existing entry's `at`/`by` are overwritten);
+ * new people are appended; the list is capped at ACTIVITY_MENTIONS_MAX by
+ * dropping the OLDEST `at` first. Returns the SAME object reference when
+ * nothing changed, so callers skip the disk write. Never touches `updated_at`
+ * (board sort order must not churn from stamping).
+ */
+export function upsertMentions(
+  activity: Activity,
+  mentionedIds: string[],
+  atIso: string,
+  by?: string,
+): Activity {
+  const ids: string[] = [];
+  for (const id of mentionedIds) {
+    if (typeof id !== "string" || !id) continue;
+    if (!ids.includes(id)) ids.push(id);
+  }
+  if (ids.length === 0) return activity;
+
+  const next = (activity.mentioned ?? []).map(cloneMention);
+  let changed = false;
+  for (const id of ids) {
+    const entry: ActivityMention =
+      by !== undefined
+        ? { user_id: id, at: atIso, by }
+        : { user_id: id, at: atIso };
+    const i = next.findIndex((m) => m.user_id === id);
+    if (i === -1) {
+      next.push(entry);
+      changed = true;
+      continue;
+    }
+    const current = next[i];
+    // Re-stamping the same person with the same instant + author changes
+    // nothing; leave the reference alone so the caller skips the disk write.
+    if (current !== undefined && current.at === entry.at && current.by === by)
+      continue;
+    next[i] = entry;
+    changed = true;
+  }
+  if (!changed) return activity;
+  // Cap by dropping the OLDEST `at` first: sort a copy by recency, keep the
+  // newest ACTIVITY_MENTIONS_MAX, then restore the original ordering so a
+  // surviving entry never moves just because the list was trimmed.
+  let capped = next;
+  if (next.length > ACTIVITY_MENTIONS_MAX) {
+    const keep = new Set(
+      next
+        .slice()
+        .sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0))
+        .slice(0, ACTIVITY_MENTIONS_MAX)
+        .map((m) => m.user_id),
+    );
+    capped = next.filter((m) => keep.has(m.user_id));
+  }
+  return { ...activity, mentioned: capped };
+}

--- a/packages/fake-host/README.md
+++ b/packages/fake-host/README.md
@@ -71,6 +71,7 @@ They drive the failure/reactivity scenarios the specs assert against:
 | `/__test__/integrations-connection` | `{ toolkit, status }` | Seed a connection at rest in a status clicking can't reach: `pending` (abandoned sign-in) or `error` (the provider refused); re-statuses the toolkit's existing connection when it has one. Those apps stay in the browse catalog wearing that status. Returns `{ connection }`. |
 | `/__test__/capabilities` | `Partial<Capabilities>` | Merge a partial into the advertised `/v1/capabilities`. Arm the Teams-shaped state single-player can't reach — e.g. `{ integrations:["composio"], multiplayer:true, teams:true, role:"owner" }` to light up the agent Integrations tab's locked browse rows, or just `{ integrations:["composio"] }` for a single-player-with-apps run. Returns the merged capabilities. |
 | `/__test__/agent-settings` | `{ allowedToolkits?, orgAllowedToolkits?, allowedModels?, access? }` | Set the Teams v2 ceilings served at `/v1/agents/:slug/settings` + `/v1/org/settings` (`allowedToolkits`/`orgAllowedToolkits`: `null` = unrestricted, `[]` = none). The `effectiveAllowlist` = agent ∩ org drives the tab's connectable-vs-locked partition. Returns the merged settings. |
+| `/__test__/org` | `{ members?: [{ userId, email?, role, displayName?, photoUrl? }], agents?: [...] }` | Arm the org roster `GET /v1/org` serves (owner/admin only) and the co-member directory `GET /v1/org/people` serves to EVERY member. `displayName`/`photoUrl` are the stored GCIP profile: a member without a `displayName` is still served, and the client decides who is @mentionable. Pair with `/__test__/capabilities` `{ multiplayer:true, teams:true, role:"owner" }`. Returns `{ members, agents }`. |
 | `/__test__/workspaces` | `{ teams: [{ slug, name }] }` | Arm the team-space rows the C8 Spaces workspaces bridge serves at `GET /v1/workspaces` (alongside the always-present personal seed row). Each `slug` (exactly `[a-f0-9]{16}`) becomes an `{ id:"org:<slug>", kind:"org" }` switcher row. Pair with `/__test__/capabilities` `{ spaces:true }`. `{ teams: [] }` (and reset) restores personal-only. Returns the armed `{ teams }`. |
 
 ## Modeled surface
@@ -86,6 +87,10 @@ They drive the failure/reactivity scenarios the specs assert against:
   Teams-shaped set), `/v1/workspaces` (the personal seed row plus any team-space
   rows armed by `/__test__/workspaces` — the C8 Spaces bridge), `/v1/integrations`,
   `/v1/preferences`, `/v1/events` (reactivity feed).
+- `/v1/org/people` — the sanitized co-member directory of the active space
+  (`{people:[{userId,displayName?,photoUrl?}]}`, named first, no emails or
+  roles) that the @mention autocomplete reads. Served to every member, unlike
+  `GET /v1/org`'s roster; empty until a spec arms `/__test__/org`.
 - `/v1/org` (Teams v2 identity + roster + pending `invites`) and
   `POST /v1/org/members` (invite path: an unknown email mints a pending invite,
   `202 { invited:true }`, then surfaced in `/v1/org`'s `invites`;
@@ -97,7 +102,10 @@ They drive the failure/reactivity scenarios the specs assert against:
   activities (backed by the SAME `.houston/activity/activity.json` the board
   reads via `/agents/:id/agentfile/*`), routines/skills (empty), providers/auth/
   settings/title, and the conversation stream
-  (`/agents/:id/conversations/:cid/{events,messages,cancel}`).
+  (`/agents/:id/conversations/:cid/{events,messages,cancel}`). The message POST
+  carries the same sidecars the real send route takes: `displayText`, and the
+  `mentions` @mention list (guarded by the protocol's own `parseMentions`),
+  which persists on the stored user message and rides the live `user` frame.
 
 Need more host behavior for a spec? Extend `src/state.ts` + `src/routes.ts`.
 

--- a/packages/fake-host/src/chat-stream.ts
+++ b/packages/fake-host/src/chat-stream.ts
@@ -10,6 +10,7 @@
  *   just like the real runtime; the nonce is echoed on the `user` frame.
  */
 
+import type { ChatMessage } from "@houston/protocol";
 import {
   parseResumeCursor,
   type ResumableStreamSource,
@@ -58,7 +59,8 @@ export function openChatStream(
 /**
  * `POST /agents/:id/conversations/:cid/messages` — fire the turn (202). The
  * turn produces into the replay log whether or not a stream is attached, just
- * like the real runtime. The nonce is echoed on the `user` frame.
+ * like the real runtime. The nonce is echoed on the `user` frame, and so are
+ * the send's `mentions` (already guarded by the route).
  */
 export function sendMessage(
   agentId: string,
@@ -66,7 +68,8 @@ export function sendMessage(
   text: string,
   nonce: string | undefined,
   displayText?: string,
+  mentions?: ChatMessage["mentions"],
 ): Response {
-  streamReplySafe(agentId, cid, text, nonce, displayText);
+  streamReplySafe(agentId, cid, text, nonce, displayText, mentions);
   return noContent(202);
 }

--- a/packages/fake-host/src/chat-turn.ts
+++ b/packages/fake-host/src/chat-turn.ts
@@ -15,7 +15,7 @@
  * mid-turn. Test controls that drive these primitives live in chat-controls.ts.
  */
 
-import type { PendingInteraction } from "@houston/protocol";
+import type { ChatMessage, PendingInteraction } from "@houston/protocol";
 import { type ChatChannel, channel, chatKey, publish } from "./chat-channel";
 import * as state from "./state";
 
@@ -69,6 +69,7 @@ async function streamReply(
   userText: string,
   nonce: string | undefined,
   displayText: string | undefined,
+  mentions: ChatMessage["mentions"],
 ): Promise<void> {
   const ch = channel(chatKey(agentId, cid));
   const epoch = ch.epoch;
@@ -76,10 +77,24 @@ async function streamReply(
   const reply = cannedReply(userText);
   ch.pending = { turnId, remaining: replyDeltas(reply) };
   // The user message persists at turn START (the dead-turn history shape).
-  state.appendUserMessage(agentId, cid, userText, turnId, displayText);
+  state.appendUserMessage(
+    agentId,
+    cid,
+    userText,
+    turnId,
+    displayText,
+    mentions,
+  );
+  // The send's @mentions ride the live frame the way `author` does, so a client
+  // watching the turn chips them without waiting for a history refetch.
   publish(ch, {
     type: "user",
-    data: { content: userText, ts: Date.now(), nonce },
+    data: {
+      content: userText,
+      ts: Date.now(),
+      nonce,
+      ...(mentions ? { mentions } : {}),
+    },
     turnId,
   });
   for (;;) {
@@ -127,13 +142,16 @@ export function streamReplySafe(
   text: string,
   nonce: string | undefined,
   displayText?: string,
+  mentions?: ChatMessage["mentions"],
 ): void {
-  streamReply(agentId, cid, text, nonce, displayText).catch((err: unknown) => {
-    console.error("[fake-host] streamReply failed:", err);
-    queueMicrotask(() => {
-      throw err;
-    });
-  });
+  streamReply(agentId, cid, text, nonce, displayText, mentions).catch(
+    (err: unknown) => {
+      console.error("[fake-host] streamReply failed:", err);
+      queueMicrotask(() => {
+        throw err;
+      });
+    },
+  );
 }
 
 /** Terminate a channel's running turn with a terminal `error` frame. */

--- a/packages/fake-host/src/routes-teams.ts
+++ b/packages/fake-host/src/routes-teams.ts
@@ -12,7 +12,7 @@
 
 import { json } from "./http";
 import * as state from "./state";
-import type { FakeAssignment } from "./state-store";
+import type { FakeAssignment, FakeMember } from "./state-store";
 
 /** Read a `string[] | null` field from a JSON body, preserving an explicit null. */
 function toolkitList(value: unknown): string[] | null {
@@ -115,6 +115,44 @@ export function handleTeamsRoutes(
       };
     }
     return json({ profiles });
+  }
+
+  // GET /v1/org/people — the sanitized co-member directory of the ACTIVE space
+  // (HOU-944 @mentions): `{people:[{userId,displayName?,photoUrl?}]}`, ordered
+  // exactly as the gateway orders it (named first, then case-folded
+  // alphabetical, `userId` breaking a tie), no emails and no roles. The client
+  // preserves that order, so the popover here lists people in the same order
+  // it does in production. Unlike `GET /v1/org` — whose roster the
+  // gateway hides from a plain `user` — this is served to EVERY member: the
+  // whole point is that any teammate can @mention their co-members. A member
+  // with no `displayName` is still served; the CLIENT decides who is
+  // mentionable (an "@a1b2c3d4" chip is nonsense to a non-technical reader).
+  if (
+    segs[0] === "v1" &&
+    segs[1] === "org" &&
+    segs[2] === "people" &&
+    segs.length === 3
+  ) {
+    if (method !== "GET") return json({ error: "not found" }, 404);
+    const members = state.getOrgMembers() ?? [];
+    const byName = (a: FakeMember, b: FakeMember) =>
+      (a.displayName ?? "")
+        .toLowerCase()
+        .localeCompare((b.displayName ?? "").toLowerCase()) ||
+      a.userId.localeCompare(b.userId);
+    const named = members
+      .filter((m) => m.displayName !== undefined)
+      .sort(byName);
+    const unnamed = members
+      .filter((m) => m.displayName === undefined)
+      .sort((a, b) => a.userId.localeCompare(b.userId));
+    return json({
+      people: [...named, ...unnamed].map((m) => ({
+        userId: m.userId,
+        ...(m.displayName !== undefined ? { displayName: m.displayName } : {}),
+        ...(m.photoUrl !== undefined ? { photoUrl: m.photoUrl } : {}),
+      })),
+    });
   }
 
   // POST /v1/org/members — add a member by email (Teams v2). The fake host

--- a/packages/fake-host/src/routes.ts
+++ b/packages/fake-host/src/routes.ts
@@ -14,6 +14,7 @@
  * → `done`) when the message lands. See translate.ts `streamTurn`.
  */
 
+import { parseMentions } from "@houston/protocol";
 import type { ProviderId } from "@houston/runtime-client";
 import { cancelChat, openChatStream, sendMessage } from "./chat";
 import { json, noContent } from "./http";
@@ -223,6 +224,9 @@ export function handleAgents(
             typeof body?.displayText === "string"
               ? body.displayText
               : undefined,
+            // The @mention sidecar, through the SAME wire guard the real send
+            // routes use — the mock can't drift on what a mention is.
+            parseMentions(body?.mentions),
           );
       }
       if (action === "cancel") {

--- a/packages/fake-host/src/server.test.ts
+++ b/packages/fake-host/src/server.test.ts
@@ -2,6 +2,52 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SEED_AGENT_ID, SEED_WORKSPACE_ID } from "./config";
 import { type FakeHost, startFakeHost } from "./server";
 
+const JSON_HEADERS = { "content-type": "application/json" };
+
+/** One `user` wire frame's payload, as the conversation stream serves it. */
+interface UserFrameData {
+  content: string;
+  ts: number;
+  nonce?: string;
+  mentions?: Array<{ userId: string; name?: string }>;
+}
+
+/**
+ * The payload of the first `user` frame on a conversation stream. Reads the SSE
+ * body the way the real client does — split on `\n\n`, keep `data:` lines — and
+ * aborts the connection once the frame is in hand.
+ */
+async function readUserFrame(eventsUrl: string): Promise<UserFrameData> {
+  const abort = new AbortController();
+  try {
+    const res = await fetch(eventsUrl, { signal: abort.signal });
+    const reader = (res.body as ReadableStream<Uint8Array>).getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error("stream ended before a user frame arrived");
+      buffer += decoder.decode(value, { stream: true });
+      let split = buffer.indexOf("\n\n");
+      while (split >= 0) {
+        const chunk = buffer.slice(0, split);
+        buffer = buffer.slice(split + 2);
+        const data = chunk.split("\n").find((l) => l.startsWith("data: "));
+        if (data) {
+          const frame = JSON.parse(data.slice(6)) as {
+            type: string;
+            data: unknown;
+          };
+          if (frame.type === "user") return frame.data as UserFrameData;
+        }
+        split = buffer.indexOf("\n\n");
+      }
+    }
+  } finally {
+    abort.abort();
+  }
+}
+
 /**
  * Covers the package's new lifecycle surface — `startFakeHost` / `FakeHost.stop`
  * — and a few representative routes, so the exported API is exercised outside
@@ -187,7 +233,6 @@ describe("startFakeHost", () => {
   it("dismiss-interaction stops the transcript and clears the activity", async () => {
     await fetch(`${host.url}/__test__/reset`, { method: "POST" });
     const agentBase = `${host.url}/agents/${SEED_AGENT_ID}`;
-    const jsonHeaders = { "content-type": "application/json" };
     const interaction = {
       steps: [
         {
@@ -207,7 +252,7 @@ describe("startFakeHost", () => {
     // interaction VERBATIM (covers the kind-agnostic PATCH set path).
     const patched = await fetch(`${agentBase}/activities/act-1`, {
       method: "PATCH",
-      headers: jsonHeaders,
+      headers: JSON_HEADERS,
       body: JSON.stringify({
         session_key: "conv-1",
         pending_interaction: interaction,
@@ -247,24 +292,198 @@ describe("startFakeHost", () => {
   it("deletes pending_interaction when an activity PATCH sends null", async () => {
     await fetch(`${host.url}/__test__/reset`, { method: "POST" });
     const url = `${host.url}/agents/${SEED_AGENT_ID}/activities/act-1`;
-    const jsonHeaders = { "content-type": "application/json" };
     const interaction = {
       steps: [{ kind: "question", id: "q1", question: "X?", toolkit: "gmail" }],
     };
 
     await fetch(url, {
       method: "PATCH",
-      headers: jsonHeaders,
+      headers: JSON_HEADERS,
       body: JSON.stringify({ pending_interaction: interaction }),
     });
     // Explicit null clears it — the key is DELETED, not stored as null.
     const cleared = await fetch(url, {
       method: "PATCH",
-      headers: jsonHeaders,
+      headers: JSON_HEADERS,
       body: JSON.stringify({ pending_interaction: null }),
     });
     const activity = (await cleared.json()) as Record<string, unknown>;
     expect("pending_interaction" in activity).toBe(false);
+  });
+
+  it("serves the space directory at /v1/org/people in the gateway's order", async () => {
+    await fetch(`${host.url}/__test__/reset`, { method: "POST" });
+
+    // No armed roster (personal space / single-player): an empty directory —
+    // the route EXISTS, so the client gets no autocomplete without taking the
+    // 404 degrade path.
+    const empty = await fetch(`${host.url}/v1/org/people`);
+    expect(empty.status).toBe(200);
+    expect(await empty.json()).toEqual({ people: [] });
+
+    await fetch(`${host.url}/__test__/org`, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({
+        // Deliberately shuffled, and none of it in the answer's order: the
+        // route must sort, not echo. A member the gateway has no GCIP profile
+        // for still appears, but AFTER everyone who has a name.
+        members: [
+          { userId: "u-ghost", email: "ghost@acme.test", role: "user" },
+          {
+            userId: "u-bob",
+            email: "bob@acme.test",
+            role: "user",
+            displayName: "Bob Stone",
+          },
+          {
+            userId: "u-self",
+            email: "you@acme.test",
+            role: "owner",
+            displayName: "Ada Lovelace",
+            photoUrl: "https://img.test/ada.png",
+          },
+          // Lower-cased on purpose: the sort folds case, so she lands between
+          // the two Adas and Bob, not ahead of every capital letter.
+          {
+            userId: "u-carol",
+            email: "carol@acme.test",
+            role: "user",
+            displayName: "ada mendez",
+          },
+          // Same display name as u-self: the userId breaks the tie.
+          {
+            userId: "u-aaa",
+            email: "other.ada@acme.test",
+            role: "user",
+            displayName: "Ada Lovelace",
+          },
+          { userId: "u-anon", email: "anon@acme.test", role: "user" },
+        ],
+      }),
+    });
+
+    const res = await fetch(`${host.url}/v1/org/people`);
+    expect(res.status).toBe(200);
+    // Exactly the gateway's order: named first, case-folded alphabetical,
+    // userId breaking a tie; then the unnamed, by userId. Sanitized too — the
+    // directory carries no email and no role.
+    expect(await res.json()).toEqual({
+      people: [
+        { userId: "u-aaa", displayName: "Ada Lovelace" },
+        {
+          userId: "u-self",
+          displayName: "Ada Lovelace",
+          photoUrl: "https://img.test/ada.png",
+        },
+        { userId: "u-carol", displayName: "ada mendez" },
+        { userId: "u-bob", displayName: "Bob Stone" },
+        { userId: "u-anon" },
+        { userId: "u-ghost" },
+      ],
+    });
+
+    // A plain member sees the whole directory — unlike `GET /v1/org`, whose
+    // roster the gateway hides from a `user`. Every teammate must be able to
+    // @mention their co-members.
+    await fetch(`${host.url}/__test__/capabilities`, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ multiplayer: true, teams: true, role: "user" }),
+    });
+    const asMember = (await (
+      await fetch(`${host.url}/v1/org/people`)
+    ).json()) as { people: unknown[] };
+    expect(asMember.people).toHaveLength(6);
+    const orgAsMember = (await (await fetch(`${host.url}/v1/org`)).json()) as {
+      members?: unknown[];
+    };
+    expect(orgAsMember.members).toBeUndefined();
+
+    // Non-GET 404s, exactly like its neighbours.
+    const post = await fetch(`${host.url}/v1/org/people`, { method: "POST" });
+    expect(post.status).toBe(404);
+  });
+
+  it("a send's mentions persist on history and ride the live user frame", async () => {
+    await fetch(`${host.url}/__test__/reset`, { method: "POST" });
+    const convo = `${host.url}/agents/${SEED_AGENT_ID}/conversations/conv-mentions`;
+    // Slow the canned reply so the turn is still in flight — its replay buffer
+    // intact — when the stream attaches with `?after=0` below.
+    await fetch(`${host.url}/__test__/chat-config`, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ replyDelayMs: 500 }),
+    });
+
+    const mentions = [
+      { userId: "u-bob", name: "Bob Stone" },
+      { userId: "u-x" },
+    ];
+    const sent = await fetch(`${convo}/messages`, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({
+        text: "@Bob Stone please confirm",
+        mentions,
+      }),
+    });
+    expect(sent.status).toBe(202);
+
+    // Persisted on the stored user message (a reloaded transcript chips the
+    // same teammates the live bubble did).
+    const history = (await (await fetch(`${convo}/messages`)).json()) as {
+      messages: Array<{ role: string; mentions?: unknown }>;
+    };
+    const userMessage = history.messages.find((m) => m.role === "user");
+    expect(userMessage?.mentions).toEqual(mentions);
+
+    // …and published on the live `user` frame, replayed from seq 0.
+    const frame = await readUserFrame(`${convo}/events?after=0`);
+    expect(frame.content).toBe("@Bob Stone please confirm");
+    expect(frame.mentions).toEqual(mentions);
+  });
+
+  it("drops junk mentions and omits the field when a send carries none", async () => {
+    await fetch(`${host.url}/__test__/reset`, { method: "POST" });
+    const convo = `${host.url}/agents/${SEED_AGENT_ID}/conversations/conv-junk`;
+
+    await fetch(`${convo}/messages`, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({
+        text: "hello",
+        mentions: [
+          { name: "No id at all" },
+          { userId: "" },
+          { userId: 7 },
+          "u-string",
+          null,
+          { userId: "u-ok", name: 42 },
+        ],
+      }),
+    });
+    await fetch(`${convo}/messages`, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ text: "plain", mentions: "not an array" }),
+    });
+    await fetch(`${convo}/messages`, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ text: "no sidecar" }),
+    });
+
+    const history = (await (await fetch(`${convo}/messages`)).json()) as {
+      messages: Array<Record<string, unknown>>;
+    };
+    const users = history.messages.filter((m) => m.role === "user");
+    // Only the one well-formed entry survives, and a non-string `name` is dropped.
+    expect(users[0]?.mentions).toEqual([{ userId: "u-ok" }]);
+    // A send with junk or no mentions stores the pre-feature message verbatim:
+    // the key is absent, never an empty array.
+    expect("mentions" in (users[1] ?? {})).toBe(false);
+    expect("mentions" in (users[2] ?? {})).toBe(false);
   });
 
   it("stops cleanly so the port stops accepting connections", async () => {

--- a/packages/fake-host/src/state-activities.ts
+++ b/packages/fake-host/src/state-activities.ts
@@ -32,6 +32,15 @@ export function createActivity(
     status: input.status ?? "running",
     session_key: input.session_key,
     updated_at: ISO,
+    // Teams attribution (created_by / contributors) and the @mention aggregate
+    // are server-stamped in the real host; accept them off the POST body so an
+    // e2e spec can seed an attributed or mentioned mission. Explicit keys only
+    // — an unknown field is still dropped.
+    ...(input.created_by !== undefined && { created_by: input.created_by }),
+    ...(input.contributors !== undefined && {
+      contributors: input.contributors,
+    }),
+    ...(input.mentioned !== undefined && { mentioned: input.mentioned }),
   };
   setActivities(agentId, [...listActivities(agentId), activity]);
   return activity;

--- a/packages/fake-host/src/state-history.ts
+++ b/packages/fake-host/src/state-history.ts
@@ -41,6 +41,7 @@ export function appendUserMessage(
   userText: string,
   turnId: string,
   displayText?: string,
+  mentions?: ChatMessage["mentions"],
 ): void {
   const key = `${agentId}:${conversationId}`;
   const list = state.histories.get(key) ?? [];
@@ -49,12 +50,15 @@ export function appendUserMessage(
   // a history reload renders `displayText ?? content`. Dropping it here made
   // the served fold DIFFER from the live bubble — a windowed reseed
   // (HOU-819) then replaced the pretty bubble with the raw directive.
+  // `mentions` persists beside it the way the real runtime persists `author`:
+  // a reloaded transcript must chip the same teammates the live bubble did.
   list.push({
     role: "user",
     content: userText,
     ts: EPOCH,
     turnId,
     ...(displayText !== undefined ? { displayText } : {}),
+    ...(mentions ? { mentions } : {}),
   });
   state.histories.set(key, list);
   emitDomain("ConversationsChanged", agentId);

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -80,8 +80,12 @@ export class ProxyChannel implements RuntimeChannel {
     // only bodies that reach a standing pod are control-plane JSON (messages,
     // settings, provider login) — a few MB is generous, and the cap stops an
     // oversized body from OOM-ing the (memory-capped) engine pod.
-    let body: Buffer | undefined;
-    if (method !== "GET" && method !== "HEAD") {
+    //
+    // A route that already drained the body hands it over on the ctx (the turn
+    // path peeks it to stamp mission attribution) — the stream is exhausted by
+    // then, so re-reading it here would forward an EMPTY body.
+    let body = ctx.body;
+    if (!body && method !== "GET" && method !== "HEAD") {
       body = await readBody(req, MAX_JSON_BYTES);
     }
     const params = new URLSearchParams(url.search);

--- a/packages/host/src/channel/turn.ts
+++ b/packages/host/src/channel/turn.ts
@@ -51,6 +51,10 @@ export class TurnChannel implements RuntimeChannel {
       url,
       req,
       res,
+      // The route may have already drained the body (the turn path peeks it to
+      // stamp mission attribution); the stream is exhausted by then, so the
+      // dispatch parses this buffer instead of re-reading nothing.
+      ctx.body,
     );
   }
 

--- a/packages/host/src/houston-prompt.ts
+++ b/packages/host/src/houston-prompt.ts
@@ -44,6 +44,7 @@ Assume the user is smart and busy, but not technical.
 - Briefly explain why you need missing information or an integration.
 - Report outcomes, choices, blockers, and approval requests. Do not narrate implementation steps.
 - For long-running or risky work, give short status updates in user language.
+- In a chat shared with several people, when what you say next needs one particular person to confirm or decide, address that person by writing "@" and their name, for example "@Dana please confirm and I'll send it".
 
 # Interaction Procedure
 

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -145,6 +145,13 @@ export interface RuntimeLauncher {
 export interface ChannelCtx {
   workspace: Workspace;
   agent: Agent;
+  /**
+   * The request body, already drained by the route. The turn path reads it
+   * before dispatch to stamp mission attribution (activity-attribution.ts);
+   * a channel MUST prefer this over reading the (now-exhausted) stream.
+   * Absent on every request the route did not peek.
+   */
+  body?: Buffer;
 }
 
 /**

--- a/packages/host/src/routes/activity-attribution.test.ts
+++ b/packages/host/src/routes/activity-attribution.test.ts
@@ -8,7 +8,7 @@ import type { RuntimeEndpoint, RuntimeLauncher, TokenVerifier } from "../ports";
 import { type ControlPlaneDeps, createControlPlaneServer } from "../server";
 import { MemoryWorkspaceStore } from "../store/memory";
 import { MemoryVfs } from "../vfs";
-import { stampTurnContributor } from "./activity-attribution";
+import { stampTurnAttribution } from "./activity-attribution";
 import { workspaceRoot } from "./agent-data";
 
 /**
@@ -50,6 +50,11 @@ const CAPS: Capabilities = {
 // A turn POST (…/conversations/:cid/messages) reaches the channel; answer 202
 // so the client's fetch resolves — the route already stamped attribution before
 // dispatch, which is what these tests assert.
+/** The body the channel actually received — the stream-exhaustion guard: the
+ *  route drains the turn body to read its mentions, so it MUST hand the buffer
+ *  down or the runtime would receive an empty message. */
+let forwardedBody: string | undefined;
+
 const deps = (): ControlPlaneDeps => ({
   verifier,
   store,
@@ -60,6 +65,7 @@ const deps = (): ControlPlaneDeps => ({
       launcher,
       proxy: {
         async forward(_e, _r, res: ServerResponse) {
+          forwardedBody = _r.body?.toString("utf8");
           res.writeHead(202, { "content-type": "application/json" });
           res.end(JSON.stringify({ ok: true }));
         },
@@ -206,6 +212,179 @@ test("a user turn falls back to the activity-<id> key when there is no session_k
   expect(m2?.contributors).toEqual([{ user_id: "supa-4" }]);
 });
 
+/**
+ * The per-mission @mention aggregate (HOU-945): the mentions ride the turn
+ * body, so the route drains it once, stamps, and hands the buffer to the
+ * channel. Latest-per-person — a second mention overwrites the first entry
+ * rather than appending a log line.
+ */
+test("a turn whose body carries mentions stamps `mentioned` on the mission", async () => {
+  await vfs.writeText(
+    docKey(root, "activity"),
+    JSON.stringify([
+      {
+        id: "m4",
+        title: "Mentions",
+        description: "",
+        status: "running",
+        session_key: "conv-mentions",
+      },
+    ]),
+  );
+  const turn = await fetch(
+    `${frontedBase}/agents/${agentId}/conversations/conv-mentions/messages`,
+    {
+      method: "POST",
+      headers: {
+        ...auth("alice"),
+        "x-houston-acting-as": actingToken("supa-6", "Ada"),
+      },
+      body: JSON.stringify({
+        text: "hey @Grace @Alan",
+        mentions: [{ userId: "supa-grace" }, { userId: "supa-alan" }],
+      }),
+    },
+  );
+  expect(turn.status).toBe(202);
+  const m4 = (await rows()).find((a) => a.id === "m4");
+  expect(m4?.mentioned?.map((m) => m.user_id)).toEqual([
+    "supa-grace",
+    "supa-alan",
+  ]);
+  // Every entry carries the instant and the acting author who wrote it.
+  for (const m of m4?.mentioned ?? []) {
+    expect(m.by).toBe("supa-6");
+    expect(Number.isNaN(Date.parse(m.at))).toBe(false);
+  }
+  // The contributor stamp rides the SAME single pass.
+  expect(m4?.contributors).toEqual([{ user_id: "supa-6", name: "Ada" }]);
+  // …and the drained body still reached the channel intact.
+  expect(forwardedBody && JSON.parse(forwardedBody)).toMatchObject({
+    text: "hey @Grace @Alan",
+    mentions: [{ userId: "supa-grace" }, { userId: "supa-alan" }],
+  });
+});
+
+test("mentioning the same person again overwrites the entry (latest wins)", async () => {
+  const before = (await rows()).find((a) => a.id === "m4");
+  const first = before?.mentioned?.find((m) => m.user_id === "supa-grace");
+  expect(first).toBeDefined();
+  const turn = await fetch(
+    `${frontedBase}/agents/${agentId}/conversations/conv-mentions/messages`,
+    {
+      method: "POST",
+      headers: {
+        ...auth("alice"),
+        "x-houston-acting-as": actingToken("supa-7", "Alan"),
+      },
+      body: JSON.stringify({
+        text: "@Grace again",
+        mentions: [{ userId: "supa-grace" }],
+      }),
+    },
+  );
+  expect(turn.status).toBe(202);
+  const m4 = (await rows()).find((a) => a.id === "m4");
+  // Still ONE entry for Grace, now attributed to the second author.
+  expect(m4?.mentioned).toHaveLength(2);
+  const grace = m4?.mentioned?.find((m) => m.user_id === "supa-grace");
+  expect(grace?.by).toBe("supa-7");
+  expect(Date.parse(grace?.at ?? "")).toBeGreaterThanOrEqual(
+    Date.parse(first?.at ?? ""),
+  );
+});
+
+test("a turn body with no mentions leaves the `mentioned` key absent", async () => {
+  await vfs.writeText(
+    docKey(root, "activity"),
+    JSON.stringify([
+      {
+        id: "m5",
+        title: "No mentions",
+        description: "",
+        status: "running",
+        session_key: "conv-plain",
+      },
+    ]),
+  );
+  const turn = await fetch(
+    `${frontedBase}/agents/${agentId}/conversations/conv-plain/messages`,
+    {
+      method: "POST",
+      headers: {
+        ...auth("alice"),
+        "x-houston-acting-as": actingToken("supa-8", "Ada"),
+      },
+      body: JSON.stringify({ text: "no one named here" }),
+    },
+  );
+  expect(turn.status).toBe(202);
+  const m5 = (await rows()).find((a) => a.id === "m5");
+  expect(m5?.contributors).toEqual([{ user_id: "supa-8", name: "Ada" }]);
+  expect("mentioned" in (m5 ?? {})).toBe(false);
+});
+
+test("a garbage `mentions` value stamps nothing and never errors the turn", async () => {
+  await vfs.writeText(
+    docKey(root, "activity"),
+    JSON.stringify([
+      {
+        id: "m6",
+        title: "Garbage mentions",
+        description: "",
+        status: "running",
+        session_key: "conv-garbage",
+      },
+    ]),
+  );
+  const turn = await fetch(
+    `${frontedBase}/agents/${agentId}/conversations/conv-garbage/messages`,
+    {
+      method: "POST",
+      headers: {
+        ...auth("alice"),
+        "x-houston-acting-as": actingToken("supa-9"),
+      },
+      body: JSON.stringify({ text: "hi", mentions: "@everyone" }),
+    },
+  );
+  expect(turn.status).toBe(202);
+  const m6 = (await rows()).find((a) => a.id === "m6");
+  expect("mentioned" in (m6 ?? {})).toBe(false);
+  expect(m6?.contributors).toEqual([{ user_id: "supa-9" }]);
+});
+
+test("an unparseable turn body never breaks the turn and stamps no mentions", async () => {
+  await vfs.writeText(
+    docKey(root, "activity"),
+    JSON.stringify([
+      {
+        id: "m7",
+        title: "Broken body",
+        description: "",
+        status: "running",
+        session_key: "conv-broken",
+      },
+    ]),
+  );
+  const turn = await fetch(
+    `${frontedBase}/agents/${agentId}/conversations/conv-broken/messages`,
+    {
+      method: "POST",
+      headers: {
+        ...auth("alice"),
+        "x-houston-acting-as": actingToken("supa-10"),
+      },
+      body: "{not json",
+    },
+  );
+  // The channel still gets the body and owns the client-facing outcome; the
+  // attribution seam just records no mentions.
+  expect(turn.status).toBe(202);
+  const m7 = (await rows()).find((a) => a.id === "m7");
+  expect("mentioned" in (m7 ?? {})).toBe(false);
+});
+
 test("a malformed acting header stamps nothing and never errors the turn", async () => {
   await vfs.writeText(
     docKey(root, "activity"),
@@ -256,7 +435,7 @@ test("off the gateway, an inbound acting header stamps NOTHING (byte-identical)"
   }
 });
 
-test("stampTurnContributor swallows a store failure — the turn is never broken", async () => {
+test("stampTurnAttribution swallows a store failure — the turn is never broken", async () => {
   const spy = vi.spyOn(console, "error").mockImplementation(() => {});
   const throwing = {
     async readText(): Promise<string | null> {
@@ -265,9 +444,14 @@ test("stampTurnContributor swallows a store failure — the turn is never broken
     async writeText(): Promise<void> {},
   };
   await expect(
-    stampTurnContributor(throwing, "root", "agent-x", "cid", {
-      user_id: "supa-5",
-    }),
+    stampTurnAttribution(
+      throwing,
+      "root",
+      "agent-x",
+      "cid",
+      { user_id: "supa-5" },
+      ["supa-9"],
+    ),
   ).resolves.toBeUndefined();
   expect(spy).toHaveBeenCalledOnce();
   spy.mockRestore();

--- a/packages/host/src/routes/activity-attribution.ts
+++ b/packages/host/src/routes/activity-attribution.ts
@@ -4,31 +4,35 @@ import {
   type TextStore,
   upsertById,
   upsertContributor,
+  upsertMentions,
 } from "@houston/domain";
 import type { ActivityContributor, HoustonEvent } from "@houston/protocol";
 
 /**
  * Teams attribution: stamp the acting human as a contributor on the mission a
- * turn is driving. Called only when a gateway-injected acting-as identity is
- * present (hosted Teams) — off the gateway `author` is null and nothing runs,
- * so single-player activity.json stays byte-identical.
+ * turn is driving, AND record the teammates that turn @mentioned (HOU-945).
+ * Called only when a gateway-injected acting-as identity is present (hosted
+ * Teams) — off the gateway `author` is null and nothing runs, so single-player
+ * activity.json stays byte-identical.
  *
  * The mission is matched by the conversation id: a mission's `session_key` (the
  * turn's conversation), with `activity-<id>` as the fallback for missions whose
- * key was never persisted separately. `upsertContributor` returns the SAME
- * reference when the actor is already recorded, so an unchanged mission skips
- * the disk write.
+ * key was never persisted separately. Both upserts return the SAME reference
+ * when they change nothing, so an unchanged mission skips the disk write — and
+ * both run over ONE load→save→emit pass, never two writes and never two events.
  *
  * INVARIANT: attribution is metadata — a stamping failure must NEVER block or
  * fail the turn. Everything here is best-effort and swallowed with a log; the
  * turn's own dispatch owns the user-visible outcome.
  */
-export async function stampTurnContributor(
+export async function stampTurnAttribution(
   store: TextStore,
   root: string,
   agentId: string,
   cid: string,
   author: ActivityContributor,
+  /** Teammates named in this turn's body; `[]` when the message named nobody. */
+  mentionedIds: string[],
   emit?: (event: HoustonEvent) => void,
 ): Promise<void> {
   try {
@@ -37,8 +41,13 @@ export async function stampTurnContributor(
       (a) => a.session_key === cid || `activity-${a.id}` === cid,
     );
     if (!activity) return;
-    const next = upsertContributor(activity, author);
-    if (next === activity) return; // already recorded — no write, no event.
+    const next = upsertMentions(
+      upsertContributor(activity, author),
+      mentionedIds,
+      new Date().toISOString(),
+      author.user_id,
+    );
+    if (next === activity) return; // nothing changed — no write, no event.
     await saveActivities(store, root, upsertById(items, next));
     emit?.({ type: "ActivityChanged", agentPath: agentId });
   } catch (err) {

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -4,6 +4,7 @@ import {
   type CustomEndpoint,
   type HoustonEvent,
   parseClaudeOAuthEnvelope,
+  parseMentions,
 } from "@houston/protocol";
 import {
   ACTING_AS_HEADER,
@@ -21,7 +22,7 @@ import { isApiKeyProvider } from "../providers";
 import { handleAttachments } from "../turn/attachments";
 import { handleFiles } from "../turn/files";
 import type { Vfs } from "../vfs";
-import { stampTurnContributor } from "./activity-attribution";
+import { stampTurnAttribution } from "./activity-attribution";
 import {
   type AgentRouteDeps,
   authorizeAgent,
@@ -40,6 +41,7 @@ import { handlePortableExport } from "./portable";
 import { handlePortableAnonymize } from "./portable-anonymize";
 import { handlePortablePreview } from "./portable-preview";
 import { handlePortableStore } from "./portable-store";
+import { MAX_JSON_BYTES, readBody } from "./read-body";
 import { handleRoutineRuns } from "./routine-runs";
 import { handleSkills } from "./skills";
 import { handleSkillsRemote } from "./skills-remote";
@@ -915,26 +917,63 @@ export async function handleAgents(
       return true;
     }
     // Teams attribution: a user turn (POST …/conversations/:cid/messages) marks
-    // the acting human as a contributor on the mission it drives. Best-effort
-    // metadata that never blocks the turn (see activity-attribution.ts); runs
-    // only when a gateway vouched for the actor (actingAuthor non-null).
+    // the acting human as a contributor on the mission it drives, and records
+    // the teammates that message @mentioned (HOU-945). Best-effort metadata
+    // that never blocks the turn (see activity-attribution.ts); runs only when
+    // a gateway vouched for the actor (actingAuthor non-null) — off the gateway
+    // nothing here runs, not even the body read, so desktop/self-host behavior
+    // and activity.json are byte-identical.
+    let turnBody: Buffer | undefined;
     if (actingAuthor && deps.vfs) {
       const turnMatch =
         method === "POST"
           ? rest.match(/^conversations\/([^/]+)\/messages$/)
           : null;
       if (turnMatch?.[1]) {
-        await stampTurnContributor(
+        // The mentions ride the turn body, which the channel reads next — drain
+        // it ONCE here and hand the buffer down on the ctx (the stream is
+        // exhausted afterwards, so the channel must not re-read it).
+        turnBody = await readBody(req, MAX_JSON_BYTES);
+        let mentionedIds: string[] = [];
+        try {
+          const parsed = JSON.parse(turnBody.toString("utf8") || "{}") as {
+            mentions?: unknown;
+          };
+          // The same shared guard the runtime and the cloud turn parser apply.
+          mentionedIds = (parseMentions(parsed.mentions) ?? []).map(
+            (m) => m.userId,
+          );
+        } catch {
+          // An unparseable body carries no mentions to stamp, and deciding what
+          // to tell the client is not this seam's business — the channel this
+          // request is headed for answers it, and the two channels answer
+          // differently: TurnChannel (cloudrun) parses the buffer below and
+          // returns a clean 400 {error:"invalid JSON body"} (turn/dispatch.ts),
+          // while ProxyChannel forwards the raw bytes to the agent's pi
+          // runtime, whose own body parse is unguarded — that path answers the
+          // runtime's 500 {error:"internal error"}, relayed verbatim. Swallow
+          // here only because the request keeps travelling; it never ends on a
+          // silent success.
+        }
+        await stampTurnAttribution(
           deps.vfs,
           paths.agentRoot(ctx.workspace, ctx.agent),
           ctx.agent.id,
           decodeURIComponent(turnMatch[1]),
           actingAuthor,
+          mentionedIds,
           emit,
         );
       }
     }
-    await channel.dispatch(ctx, method, rest, url, req, res);
+    await channel.dispatch(
+      turnBody ? { ...ctx, body: turnBody } : ctx,
+      method,
+      rest,
+      url,
+      req,
+      res,
+    );
     return true;
   }
 

--- a/packages/host/src/turn/dispatch.test.ts
+++ b/packages/host/src/turn/dispatch.test.ts
@@ -1,11 +1,12 @@
 import type { Server } from "node:http";
-import { createServer } from "node:http";
+import { createServer, request as httpRequest } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { WireFrame } from "@houston/runtime-client";
 import { afterAll, beforeAll, expect, test } from "vitest";
 import { MemoryCredentialStore } from "../credentials/store";
 import type { Agent, Workspace } from "../domain/types";
 import type { WorkspaceCredential } from "../ports";
+import { BodyTooLargeError, MAX_JSON_BYTES } from "../routes/read-body";
 import { MemoryVfs } from "../vfs";
 import { ConnectManager } from "./connect";
 import type { TurnDeps } from "./deps";
@@ -92,8 +93,15 @@ function makeDeps(): {
   return { deps, objects, credentials };
 }
 
-/** Drive dispatchCloudrun through a real HTTP server (it needs req/res). */
-function serve(deps: TurnDeps): Promise<{ base: string; close: () => void }> {
+/**
+ * Drive dispatchCloudrun through a real HTTP server (it needs req/res).
+ * `preReadBody` stands in for the route that already drained the body to stamp
+ * @mention attribution (routes/agents.ts) and hands the buffer down.
+ */
+function serve(
+  deps: TurnDeps,
+  preReadBody?: Buffer,
+): Promise<{ base: string; close: () => void }> {
   const s = createServer((req, res) => {
     const url = new URL(req.url || "/", "http://x");
     const rest = url.pathname.replace(/^\//, "");
@@ -106,8 +114,13 @@ function serve(deps: TurnDeps): Promise<{ base: string; close: () => void }> {
       url,
       req,
       res,
+      preReadBody,
     ).catch((err) => {
-      res.writeHead(500);
+      // Mirrors the real host's top-level mapping (server.ts): an over-cap body
+      // is a 413, everything else a 500. Without it a BodyTooLargeError that
+      // correctly escaped the route would be indistinguishable here from the
+      // 500 this change exists to stop returning.
+      res.writeHead(err instanceof BodyTooLargeError ? 413 : 500);
       res.end(String(err));
     });
   });
@@ -194,6 +207,77 @@ test("a pinned routine turn sends autopilot mode to the runtime", async () => {
   await done;
 
   expect(turnBodies[0]?.mode).toBe("auto");
+});
+
+test("a malformed turn body answers a clean 400 — both the streamed and the pre-read parse", async () => {
+  const { deps } = makeDeps();
+  const bad = "{not json";
+
+  // The plain path: the dispatch reads and parses the request stream itself.
+  const streamed = await serve(deps);
+  try {
+    const res = await fetch(`${streamed.base}/conversations/c-bad/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: bad,
+    });
+    // Not a 500: the client sent junk, and it must be told so — an unguarded
+    // parse used to escape into the host's top-level catch as an opaque 500.
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "invalid JSON body" });
+  } finally {
+    streamed.close();
+  }
+
+  // The attribution path: the route already drained the body, so the buffer is
+  // parsed in place of the (now exhausted) stream — same guard required.
+  const preread = await serve(deps, Buffer.from(bad));
+  try {
+    const res = await fetch(`${preread.base}/conversations/c-bad/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: bad,
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "invalid JSON body" });
+  } finally {
+    preread.close();
+  }
+});
+
+test("an over-cap turn body still propagates as a 413, not mislabelled a 400", async () => {
+  const { deps } = makeDeps();
+  const { base, close } = await serve(deps);
+  try {
+    // node:http rather than fetch: the host answers before the oversized body
+    // finishes uploading, so the write side may error after the response has
+    // already arrived — that is the intended behavior, not a test failure.
+    const { port } = new URL(base);
+    const status = await new Promise<number>((resolve, reject) => {
+      let responded = false;
+      const req = httpRequest(
+        {
+          host: "127.0.0.1",
+          port,
+          method: "POST",
+          path: "/conversations/c-huge/messages",
+          headers: { "content-type": "application/json" },
+        },
+        (res) => {
+          responded = true;
+          res.resume();
+          resolve(res.statusCode ?? 0);
+        },
+      );
+      req.on("error", (err) => {
+        if (!responded) reject(err);
+      });
+      req.end(Buffer.alloc(MAX_JSON_BYTES + 1, "a"));
+    });
+    expect(status).toBe(413);
+  } finally {
+    close();
+  }
 });
 
 test("conversation list + history read straight from object storage", async () => {

--- a/packages/host/src/turn/dispatch.ts
+++ b/packages/host/src/turn/dispatch.ts
@@ -1,6 +1,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { parseMentions } from "@houston/protocol";
 import type { ConversationSummary } from "@houston/runtime-client";
 import type { Agent, Workspace } from "../domain/types";
+import { BodyTooLargeError } from "../routes/read-body";
 import {
   conversationKey,
   json,
@@ -28,6 +30,12 @@ export async function dispatchCloudrun(
   url: URL,
   req: IncomingMessage,
   res: ServerResponse,
+  /**
+   * The request body when the route already drained it (the turn path peeks it
+   * to stamp mission attribution). The stream is exhausted by then, so this is
+   * parsed in place of re-reading the request.
+   */
+  preReadBody?: Buffer,
 ): Promise<void> {
   const prefix = prefixFor(ws, agent);
 
@@ -101,7 +109,26 @@ export async function dispatchCloudrun(
     }
 
     if (method === "POST" && action === "messages") {
-      const body = await readJson(req);
+      // A body that isn't JSON is a malformed REQUEST, so it gets the same 400
+      // shape as the missing-`text` check below. Unguarded, the parse threw all
+      // the way out to the server's top-level catch, which turned a client
+      // mistake into a 500 "Houston broke" — the exact silent-mislabel the beta
+      // policy forbids. An over-cap body is a different failure: readJson's
+      // BodyTooLargeError already carries the 413 that handler maps (and closes
+      // the socket for), so it must keep propagating, not be dressed as a 400.
+      // Same distinction the /feedback route draws (server.ts).
+      let body: Record<string, unknown>;
+      try {
+        body = preReadBody
+          ? (JSON.parse(preReadBody.toString("utf8") || "{}") as Record<
+              string,
+              unknown
+            >)
+          : await readJson(req);
+      } catch (err) {
+        if (err instanceof BodyTooLargeError) throw err;
+        return json(res, 400, { error: "invalid JSON body" });
+      }
       if (!body.text || typeof body.text !== "string") {
         return json(res, 400, { error: "missing 'text'" });
       }
@@ -116,6 +143,10 @@ export async function dispatchCloudrun(
         // Presentation-only bubble text; forwarded to the runtime, which
         // persists it beside the user message. The model still runs on `text`.
         typeof body.displayText === "string" ? body.displayText : undefined,
+        // The @mention sidecar (HOU-944): structure only, the names are already
+        // plain text in `text`. Sanitized here with the same shared guard the
+        // runtime re-applies on receipt.
+        parseMentions(body.mentions),
       );
     }
   }

--- a/packages/host/src/turn/start-turn.ts
+++ b/packages/host/src/turn/start-turn.ts
@@ -1,4 +1,5 @@
 import type { ServerResponse } from "node:http";
+import type { ChatMessage } from "@houston/protocol";
 import { readEventStream } from "@houston/runtime-client";
 import { isExpiring } from "../credentials/refresh";
 import type { Agent, Workspace } from "../domain/types";
@@ -59,6 +60,7 @@ export async function dispatchTurn(
   nonce: string | undefined,
   pin?: TurnPin,
   displayText?: string,
+  mentions?: ChatMessage["mentions"],
 ): Promise<TurnStart> {
   const prefix = prefixFor(ws, agent);
   // Resolve the provider (+ effort) for this turn BEFORE claiming the quota/relay
@@ -106,6 +108,9 @@ export async function dispatchTurn(
               // Presentation-only bubble text — the runtime persists it beside
               // the user message; the model still runs on `text`.
               ...(displayText ? { displayText } : {}),
+              // The @mention sidecar — omitted when the message named nobody,
+              // so a single-player turn's body is byte-identical to today.
+              ...(mentions?.length ? { mentions } : {}),
               gcsPrefix: prefix,
               credential: cred
                 ? {
@@ -159,6 +164,7 @@ export async function startTurn(
   nonce: string | undefined,
   res: ServerResponse,
   displayText?: string,
+  mentions?: ChatMessage["mentions"],
 ): Promise<void> {
   const outcome = await dispatchTurn(
     deps,
@@ -169,6 +175,7 @@ export async function startTurn(
     nonce,
     undefined,
     displayText,
+    mentions,
   );
   if (outcome.status === "quota")
     return json(res, 429, { error: outcome.message });

--- a/packages/protocol/src/conversation.ts
+++ b/packages/protocol/src/conversation.ts
@@ -296,6 +296,16 @@ export interface ChatMessage {
    * in single-player mode and on assistant turns.
    */
   author?: { userId: string; name?: string };
+  /**
+   * The teammates this message @mentions (HOU-944). Set on `role: "user"` turns
+   * whose text names people from the space roster: the model only ever sees the
+   * plain "@Name" text, and this structured sidecar is what lets a reader match
+   * a mention to a person — it is the scan key a notifications/inbox feature
+   * reads (`mentions[].userId === me`). Purely additive: absent on every message
+   * that mentions nobody, on single-player turns, and on assistant turns, whose
+   * "@Name" is plain text with no structure behind it.
+   */
+  mentions?: { userId: string; name?: string }[];
   tools?: ToolCallRecord[];
   /**
    * The turn's full reasoning text (the model's thinking blocks, concatenated
@@ -361,6 +371,65 @@ export interface ChatMessage {
    * a false `done`. Absent on turns that ran to completion.
    */
   stopped?: true;
+}
+
+/** The most @mentions one message may carry; the rest are dropped. */
+export const MENTIONS_MAX = 32;
+
+/** Longest `userId` a mention may carry. Comfortably past every id we mint
+ *  (a Firebase uid is 28 characters), short of letting one entry carry a
+ *  payload. Longer ones are truncated, not dropped: the id still has to match
+ *  a real member downstream to mean anything. */
+export const MENTION_USER_ID_MAX = 128;
+
+/** Longest display `name` a mention may carry — a generous full name, not a
+ *  document. Truncated rather than dropped, because the userId is the
+ *  load-bearing half and a garbled name must never cost the user the mention. */
+export const MENTION_NAME_MAX = 256;
+
+/** How many raw entries are inspected before the scan gives up. A junk array
+ *  is not worth walking in full: {@link MENTIONS_MAX} valid mentions can never
+ *  be more than this many entries in, and anything longer is not a send this
+ *  system produced. */
+export const MENTIONS_SCAN_MAX = 1000;
+
+/**
+ * Normalize an untrusted wire value into {@link ChatMessage.mentions}. Sibling
+ * of {@link normalizeTurnMode}: the single place every reader of a send body
+ * trusts the wire, so the send route, the cloud turn parser and the host's
+ * forwarding hop all agree on what a mention is.
+ *
+ * Anything but an array is nothing. An entry survives only as a plain object
+ * with a non-empty string `userId`; `name` rides along only when it is a
+ * string. Both are clipped to their length caps. The FIRST entry for a userId
+ * wins, so a repeated id cannot spend the budget. Invalid entries are dropped
+ * rather than failing the turn — a bad sidecar must never cost the user their
+ * message — the result is capped at {@link MENTIONS_MAX}, the scan itself
+ * stops after {@link MENTIONS_SCAN_MAX} entries, and an empty result is
+ * `undefined`, never `[]`.
+ */
+export function parseMentions(value: unknown): ChatMessage["mentions"] {
+  if (!Array.isArray(value)) return undefined;
+  const out: NonNullable<ChatMessage["mentions"]> = [];
+  const seen = new Set<string>();
+  const scanned = Math.min(value.length, MENTIONS_SCAN_MAX);
+  for (let i = 0; i < scanned; i += 1) {
+    if (out.length >= MENTIONS_MAX) break;
+    const entry = value[i];
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry))
+      continue;
+    const { userId, name } = entry as { userId?: unknown; name?: unknown };
+    if (typeof userId !== "string" || !userId) continue;
+    const id = userId.slice(0, MENTION_USER_ID_MAX);
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(
+      typeof name === "string"
+        ? { userId: id, name: name.slice(0, MENTION_NAME_MAX) }
+        : { userId: id },
+    );
+  }
+  return out.length ? out : undefined;
 }
 
 export interface ConversationSummary {

--- a/packages/protocol/src/domain/activity.ts
+++ b/packages/protocol/src/domain/activity.ts
@@ -11,6 +11,24 @@ export interface ActivityContributor {
   name?: string;
 }
 
+/**
+ * One @mention recorded on a mission (HOU-945): the LATEST time this teammate
+ * was named in the mission's chat. One entry per person — a later mention
+ * overwrites the earlier one's timestamp, so the array is a compact
+ * "who has been pinged here, and when", not a log.
+ */
+export interface ActivityMention {
+  /** The mentioned teammate's user id. */
+  user_id: string;
+  /** ISO 8601 instant of that most recent mention. */
+  at: string;
+  /** Who wrote the message (server-stamped acting identity), when known. */
+  by?: string;
+}
+
+/** The most people one mission's aggregate tracks; older entries drop first. */
+export const ACTIVITY_MENTIONS_MAX = 32;
+
 export interface Activity {
   id: string;
   title: string;
@@ -33,6 +51,13 @@ export interface Activity {
   /** Humans who started or collaborated on this mission (Teams attribution).
    *  Server-stamped from acting-as identity; absent on desktop/single-player. */
   contributors?: ActivityContributor[];
+  /**
+   * Teammates @mentioned in this mission's chat, latest-per-person (HOU-945).
+   * Server-stamped from the turn body under a gateway-verified acting identity;
+   * absent on desktop/single-player, so those activity.json files stay
+   * byte-identical.
+   */
+  mentioned?: ActivityMention[];
 }
 
 export interface ActivityUpdate {

--- a/packages/protocol/src/wire.ts
+++ b/packages/protocol/src/wire.ts
@@ -84,6 +84,20 @@ export type WireEvent =
          * `ChatMessage.author`. Absent in single-player mode.
          */
         author?: { userId: string; name?: string };
+        /**
+         * The teammates this message @mentions (HOU-944), matching the
+         * persisted `ChatMessage.mentions`.
+         *
+         * NOTHING READS THIS FIELD TODAY. The turn sink drops it, and a live
+         * client learns about a teammate's message from the history re-seed
+         * that follows, chipping it from the persisted `ChatMessage.mentions`
+         * instead. It rides the frame so the wire stays a faithful mirror of
+         * what was stored — an observer that wanted to chip without a refetch
+         * would have everything it needs — not because such an observer
+         * exists. Absent when the message mentions nobody; an assistant's
+         * "@Name" is plain text and never carries it.
+         */
+        mentions?: { userId: string; name?: string }[];
       };
     }
   | { type: "text"; data: string }

--- a/packages/runtime-client/src/client.ts
+++ b/packages/runtime-client/src/client.ts
@@ -71,6 +71,15 @@ export interface SendOptions {
    * the model always received `text`. Omitted when the bubble and prompt match.
    */
   displayText?: string;
+  /**
+   * The teammates this message @mentions (HOU-944): structure only — the model
+   * runs on the plain "@Name" text inside `text` either way. Persisted on the
+   * user message and echoed on the `user` frame, so a reloaded transcript chips
+   * the same names the sent bubble did. Omitted when the message mentions
+   * nobody; never an empty list. (Kept inline — this package stays zero-dep,
+   * like `mode` and `effort`.)
+   */
+  mentions?: { userId: string; name?: string }[];
   signal?: AbortSignal;
 }
 
@@ -368,6 +377,7 @@ export class HoustonEngineClient {
         effort: opts.effort,
         mode: opts.mode,
         displayText: opts.displayText,
+        mentions: opts.mentions,
       }),
       signal: opts.signal,
     });

--- a/packages/runtime/src/session/chat.ts
+++ b/packages/runtime/src/session/chat.ts
@@ -1,6 +1,7 @@
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import type { TurnMode } from "@houston/protocol";
+import type { ChatMessage } from "@houston/runtime-client";
 import { activeProvider, resolveModel } from "../ai/providers";
 import { syncServedCredentialSafe } from "../auth/serve";
 import { cleanupClaudeConversation } from "../backends/claude/cleanup";
@@ -76,6 +77,7 @@ export async function runTurn(
   acting?: ActingContext,
   context?: ProvidedContext,
   displayText?: string,
+  mentions?: ChatMessage["mentions"],
 ): Promise<void> {
   // Mint the turn's wire identity up front so even a turn that fails before
   // executing (the guards below) terminates under one id.
@@ -105,7 +107,7 @@ export async function runTurn(
     // an empty assistant message carrying the typed reason), so an unattended
     // reader (a routine's reconcile) errors its run with the real message
     // instead of finding no reply and timing out vague.
-    appendUserMessage(id, text, { turnId, displayText });
+    appendUserMessage(id, text, { turnId, displayText, mentions });
     // Publish the nonce-stamped `user` echo BEFORE the error, exactly like a
     // normal turn (recordUserTurn): the client sink adopts its turnId from
     // this echo, and a stamped `error` frame arriving with no adopted id
@@ -113,7 +115,7 @@ export async function runTurn(
     // no error and no reconnect card (the disconnected-local-model repro).
     publish(id, {
       type: "user",
-      data: { content: text, ts: Date.now(), nonce },
+      data: { content: text, ts: Date.now(), nonce, mentions },
       turnId,
     });
     // A NOT-CONNECTED failure is typed `unauthenticated`, not `unknown`: the
@@ -173,6 +175,7 @@ export async function runTurn(
       nonce,
       acting,
       displayText,
+      mentions,
     );
     return withWorkdirLock(config.workspaceDir, () =>
       execTurn(conv, id, turnId, text, recorded, pin, acting),

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -54,10 +54,12 @@ vi.mock("../store/conversations", () => ({
   getHistory: vi.fn(() => ({ messages: [] })),
 }));
 
-const { execTurn } = await import("./exec-turn");
+const { execTurn, recordUserTurn } = await import("./exec-turn");
 const { subscribe } = await import("./bus");
 const { recordQuestions, recordConnection } = await import("./interaction");
-const { appendAssistantMessage } = await import("../store/conversations");
+const { appendAssistantMessage, appendUserMessage } = await import(
+  "../store/conversations"
+);
 const { switchModeIfNeeded } = await import("./conversation-cache");
 
 afterAll(() => vi.restoreAllMocks());
@@ -395,4 +397,52 @@ test("a thrown turn emits an error frame and no done", async () => {
   expect(err?.data.message).toContain("kaboom");
   // A thrown turn settles via the catch path, which never carries the interaction.
   expect(persistedInteraction(id)).toBeUndefined();
+});
+
+/** The meta persisted on `id`'s USER message, or undefined. */
+function persistedUserMeta(id: string) {
+  const call = vi.mocked(appendUserMessage).mock.calls.find((c) => c[0] === id);
+  return call?.[2] as { mentions?: unknown } | undefined;
+}
+
+test("recordUserTurn persists the @mentions sidecar AND publishes it on the user frame (HOU-944)", () => {
+  const id = "record-mentions";
+  const { events, unsub } = collect(id);
+  const mentions = [{ userId: "user_a", name: "Ada" }, { userId: "user_g" }];
+
+  recordUserTurn(
+    {} as Conv,
+    id,
+    "turn-1",
+    "@Ada can you confirm?",
+    "nonce-1",
+    undefined,
+    undefined,
+    mentions,
+  );
+  unsub();
+
+  // Durable: a reader that refetches history maps "@Ada" back to a person.
+  expect(persistedUserMeta(id)?.mentions).toEqual(mentions);
+  // Live: a client watching the stream chips them without refetching.
+  const frame = events.find(
+    (e): e is Extract<WireEvent, { type: "user" }> => e.type === "user",
+  );
+  expect(frame?.data.mentions).toEqual(mentions);
+  // The model input is untouched — the names were always plain text.
+  expect(frame?.data.content).toBe("@Ada can you confirm?");
+});
+
+test("recordUserTurn leaves mentions absent on a turn that named nobody", () => {
+  const id = "record-no-mentions";
+  const { events, unsub } = collect(id);
+
+  recordUserTurn({} as Conv, id, "turn-1", "ship the report");
+  unsub();
+
+  expect(persistedUserMeta(id)?.mentions).toBeUndefined();
+  const frame = events.find(
+    (e): e is Extract<WireEvent, { type: "user" }> => e.type === "user",
+  );
+  expect(frame?.data.mentions).toBeUndefined();
 });

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -93,6 +93,7 @@ export function recordUserTurn(
   nonce?: string,
   acting?: ActingContext,
   displayText?: string,
+  mentions?: ChatMessage["mentions"],
 ): RecordedUserTurn {
   // Stamp the executing turn's id up front so a cancel/stop settles this turn.
   conv.turnId = turnId;
@@ -113,10 +114,13 @@ export function recordUserTurn(
 
   // `text` is what the model receives; `displayText` (when given) is only what
   // the bubble renders on a history reload — the two are stored side by side.
-  appendUserMessage(id, text, { author, turnId, displayText });
+  // `mentions` is the @mention sidecar (HOU-944): the model already sees the
+  // names as plain text inside `text`, so this only travels so a reader can map
+  // "@Name" back to a person. Persisted AND published, exactly like `author`.
+  appendUserMessage(id, text, { author, turnId, displayText, mentions });
   publish(id, {
     type: "user",
-    data: { content: text, ts: Date.now(), nonce, author },
+    data: { content: text, ts: Date.now(), nonce, author, mentions },
     turnId,
   });
   return { author, priorAuthors };

--- a/packages/runtime/src/store/conversation-file.test.ts
+++ b/packages/runtime/src/store/conversation-file.test.ts
@@ -225,6 +225,38 @@ test("a user message with no displayText stays displayText-free in the JSON (unc
   expect(raw).not.toContain("displayText");
 });
 
+test("a user message persists the @mentions sidecar beside content (HOU-944)", () => {
+  const dir = freshDir();
+  // The model already saw the names as plain text inside `content`; the sidecar
+  // is what lets a reader map "@Ada" back to a person.
+  appendUserMessageAt(dir, "c1", "@Ada can you confirm? @Grace fyi", {
+    mentions: [
+      { userId: "user_a", name: "Ada" },
+      { userId: "user_g", name: "Grace" },
+    ],
+  });
+
+  const msg = getHistoryAt(dir, "c1")?.messages.find((m) => m.role === "user");
+  expect(msg?.content).toBe("@Ada can you confirm? @Grace fyi");
+  expect(msg?.mentions).toEqual([
+    { userId: "user_a", name: "Ada" },
+    { userId: "user_g", name: "Grace" },
+  ]);
+});
+
+test("a user message with no mentions stays mentions-free in the JSON (unchanged records)", () => {
+  const dir = freshDir();
+  appendUserMessageAt(dir, "c1", "just a normal message");
+  // An empty list is treated exactly like an absent one — never `[]` on disk.
+  appendUserMessageAt(dir, "c1", "another normal message", { mentions: [] });
+
+  const msgs = getHistoryAt(dir, "c1")?.messages ?? [];
+  expect(msgs.every((m) => m.mentions === undefined)).toBe(true);
+  // Absent, not present-and-undefined — a single-player record is byte-identical.
+  const raw = readFileSync(join(dir, "c1.json"), "utf8");
+  expect(raw).not.toContain("mentions");
+});
+
 test("a user message with no acting-as token stays author-free (byte-identical to today)", () => {
   const dir = freshDir();
   // No token → decode yields undefined → no author stamped.

--- a/packages/runtime/src/store/conversation-file.ts
+++ b/packages/runtime/src/store/conversation-file.ts
@@ -65,6 +65,12 @@ function save(dir: string, conv: StoredConversation) {
 /** Optional fields of a persisted user message. */
 export interface UserMessageMeta {
   author?: ChatMessage["author"];
+  /**
+   * The teammates the message @mentions (HOU-944). Structure only: the model
+   * ran on the plain "@Name" text either way. Omitted when the message mentions
+   * nobody, so a single-player record stays byte-identical to today.
+   */
+  mentions?: ChatMessage["mentions"];
   /** The turn's wire id (`WireFrame.turnId`) — same on the assistant reply. */
   turnId?: string;
   /**
@@ -129,6 +135,9 @@ export function appendUserMessageAt(
     turnId: meta.turnId,
     // Presentation-only: kept out of `content` so the model input is unchanged.
     displayText: meta.displayText,
+    // Same posture as `author`: an empty list is omitted entirely (never `[]`),
+    // so a message that mentions nobody keeps the record byte-identical.
+    mentions: meta.mentions?.length ? meta.mentions : undefined,
   });
   conv.updatedAt = now;
   save(dir, conv);

--- a/packages/runtime/src/transport/conversation-routes.ts
+++ b/packages/runtime/src/transport/conversation-routes.ts
@@ -1,4 +1,4 @@
-import { normalizeTurnMode } from "@houston/protocol";
+import { normalizeTurnMode, parseMentions } from "@houston/protocol";
 import type { ActingContext } from "../session/acting-context";
 import { evict, isTurnRunning } from "../session/bus";
 import {
@@ -168,6 +168,7 @@ async function handleStartTurn(ctx: RouteContext, id: string) {
     workspaceContext,
     userContext,
     displayText,
+    mentions,
   } = await readJson(ctx.req);
   if (!text || typeof text !== "string") {
     json(ctx.res, 400, { error: "missing 'text'" });
@@ -223,6 +224,9 @@ async function handleStartTurn(ctx: RouteContext, id: string) {
     // Presentation-only bubble text (never trusted into the model input): the
     // model runs on `text`; this only changes what a history reload renders.
     typeof displayText === "string" ? displayText : undefined,
+    // The @mention sidecar (HOU-944), sanitized before it is persisted or
+    // published: junk entries are dropped and an empty list becomes nothing.
+    parseMentions(mentions),
   );
   json(ctx.res, 202, { ok: true, id });
 }

--- a/packages/runtime/src/transport/mentions.test.ts
+++ b/packages/runtime/src/transport/mentions.test.ts
@@ -1,0 +1,127 @@
+import {
+  MENTION_NAME_MAX,
+  MENTION_USER_ID_MAX,
+  MENTIONS_MAX,
+  MENTIONS_SCAN_MAX,
+  parseMentions,
+} from "@houston/protocol";
+import { expect, test } from "vitest";
+import { parseTurnRequest } from "../turn/types";
+
+/**
+ * The @mention send-body guard (HOU-944). `parseMentions` is the ONE place a
+ * mention sidecar is trusted — the long-lived send route
+ * (`conversation-routes.ts` → `handleStartTurn`), the cloud turn parser
+ * (`turn/types.ts` → `parseTurnRequest`) and the host's forwarding hop all call
+ * it — so a junk shape can never reach the transcript or the wire. It lives in
+ * `@houston/protocol` beside `normalizeTurnMode` and is exercised here, where
+ * both runtime readers live.
+ */
+
+test("a non-array is nothing at all", () => {
+  expect(parseMentions(undefined)).toBeUndefined();
+  expect(parseMentions(null)).toBeUndefined();
+  expect(parseMentions("@ada")).toBeUndefined();
+  expect(parseMentions(7)).toBeUndefined();
+  expect(parseMentions({ userId: "u1" })).toBeUndefined();
+});
+
+test("well-formed entries survive with their order and names intact", () => {
+  expect(
+    parseMentions([{ userId: "u1", name: "Ada Lovelace" }, { userId: "u2" }]),
+  ).toEqual([{ userId: "u1", name: "Ada Lovelace" }, { userId: "u2" }]);
+});
+
+test("an entry without a usable userId is dropped, the rest survive", () => {
+  expect(
+    parseMentions([
+      { name: "Ada" }, // no userId
+      { userId: "" }, // empty userId
+      { userId: 42 }, // non-string userId
+      null,
+      "u3",
+      ["u4"],
+      { userId: "u5", name: "Grace" },
+    ]),
+  ).toEqual([{ userId: "u5", name: "Grace" }]);
+});
+
+test("a non-string name is dropped but the mention itself is kept", () => {
+  // The userId is the load-bearing half (it is what a notification scans for);
+  // a garbled name must never cost the user the mention.
+  expect(parseMentions([{ userId: "u1", name: 42 }])).toEqual([
+    { userId: "u1" },
+  ]);
+  expect(parseMentions([{ userId: "u1", name: null }])).toEqual([
+    { userId: "u1" },
+  ]);
+});
+
+test("the list is capped at MENTIONS_MAX", () => {
+  const many = Array.from({ length: MENTIONS_MAX + 8 }, (_, i) => ({
+    userId: `u${i}`,
+  }));
+  const parsed = parseMentions(many);
+  expect(parsed).toHaveLength(MENTIONS_MAX);
+  expect(parsed?.[MENTIONS_MAX - 1]).toEqual({
+    userId: `u${MENTIONS_MAX - 1}`,
+  });
+});
+
+test("a userId repeated across entries is kept once, first one wins", () => {
+  // Otherwise one id could spend the whole MENTIONS_MAX budget and crowd the
+  // real mentions out of the message.
+  expect(
+    parseMentions([
+      { userId: "u1", name: "Ada" },
+      { userId: "u1", name: "Impostor" },
+      { userId: "u2" },
+    ]),
+  ).toEqual([{ userId: "u1", name: "Ada" }, { userId: "u2" }]);
+});
+
+test("an over-long userId or name is clipped, never dropped", () => {
+  // The userId is what a notification scans for: an oversized one is a bad
+  // client, not a reason to lose the mention.
+  const parsed = parseMentions([
+    { userId: "u".repeat(MENTION_USER_ID_MAX + 50), name: "x".repeat(9999) },
+  ]);
+  expect(parsed?.[0]?.userId).toHaveLength(MENTION_USER_ID_MAX);
+  expect(parsed?.[0]?.name).toHaveLength(MENTION_NAME_MAX);
+});
+
+test("the scan stops after MENTIONS_SCAN_MAX entries", () => {
+  // A junk array is not walked in full. A valid mention hiding past the scan
+  // window is simply never seen.
+  const junk = Array.from({ length: MENTIONS_SCAN_MAX + 500 }, () => null);
+  expect(parseMentions(junk)).toBeUndefined();
+  expect(parseMentions([...junk, { userId: "u_late" }])).toBeUndefined();
+  const inWindow = [...junk.slice(0, MENTIONS_SCAN_MAX - 1), { userId: "u1" }];
+  expect(parseMentions(inWindow)).toEqual([{ userId: "u1" }]);
+});
+
+test("an empty result is undefined, never [] — nothing empty rides the wire", () => {
+  expect(parseMentions([])).toBeUndefined();
+  expect(parseMentions([{ name: "Ada" }, null, 3])).toBeUndefined();
+});
+
+const TURN_BASE = {
+  workspaceId: "w1",
+  agentId: "a1",
+  conversationId: "c1",
+  text: "hey @Ada",
+  gcsPrefix: "ws/w1/a1",
+};
+
+test("parseTurnRequest runs the body's mentions through the same guard", () => {
+  expect(
+    parseTurnRequest({
+      ...TURN_BASE,
+      mentions: [{ userId: "u1", name: "Ada" }, { userId: "" }],
+    }).mentions,
+  ).toEqual([{ userId: "u1", name: "Ada" }]);
+  expect(parseTurnRequest(TURN_BASE).mentions).toBeUndefined();
+  expect(parseTurnRequest({ ...TURN_BASE, mentions: "u1" }).mentions).toBe(
+    undefined,
+  );
+});

--- a/packages/runtime/src/turn/server.ts
+++ b/packages/runtime/src/turn/server.ts
@@ -98,7 +98,12 @@ async function executeTurn(
     if (!turn.credential) {
       emit({
         type: "user",
-        data: { content: turn.text, ts: Date.now(), nonce: turn.nonce },
+        data: {
+          content: turn.text,
+          ts: Date.now(),
+          nonce: turn.nonce,
+          mentions: turn.mentions,
+        },
         turnId,
       });
       outcome = {
@@ -117,6 +122,7 @@ async function executeTurn(
         mode: turn.mode,
         turnId,
         displayText: turn.displayText,
+        mentions: turn.mentions,
       });
     }
 

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import type { TurnMode } from "@houston/protocol";
 import type {
+  ChatMessage,
   PendingInteraction,
   ProviderError,
   TokenUsage,
@@ -92,6 +93,12 @@ export interface PiTurnRequest {
    * history reload renders `displayText ?? content`. Absent when they match.
    */
   displayText?: string;
+  /**
+   * The teammates the message @mentions (HOU-944). Structure only — the names
+   * are already plain text inside `text`. Persisted beside the user message and
+   * echoed on the `user` frame. Absent when the message mentions nobody.
+   */
+  mentions?: ChatMessage["mentions"];
 }
 
 export async function runPiTurn(
@@ -108,6 +115,7 @@ export async function runPiTurn(
     mode,
     turnId,
     displayText,
+    mentions,
   } = turn;
   const emit = (e: WireFrame) => turn.emit({ ...e, turnId });
   const workspaceDir = join(root, "workspace");
@@ -117,8 +125,12 @@ export async function runPiTurn(
   appendUserMessageAt(conversationsDir, conversationId, text, {
     turnId,
     displayText,
+    mentions,
   });
-  emit({ type: "user", data: { content: text, ts: Date.now(), nonce } });
+  emit({
+    type: "user",
+    data: { content: text, ts: Date.now(), nonce, mentions },
+  });
 
   let assistantText = "";
   let usage: TokenUsage | null = null;

--- a/packages/runtime/src/turn/types.ts
+++ b/packages/runtime/src/turn/types.ts
@@ -1,4 +1,9 @@
-import { normalizeTurnMode, type TurnMode } from "@houston/protocol";
+import {
+  type ChatMessage,
+  normalizeTurnMode,
+  parseMentions,
+  type TurnMode,
+} from "@houston/protocol";
 import type { ServedCredential } from "../auth/auth-file";
 
 /**
@@ -34,6 +39,13 @@ export interface TurnRequest {
    * history reload renders `displayText ?? content`. Absent when they match.
    */
   displayText?: string;
+  /**
+   * The teammates the message @mentions (HOU-944). Structure only: the model
+   * runs on `text`, where the names already appear as plain "@Name". Persisted
+   * beside the user message and echoed on the `user` frame. Absent when the
+   * message mentions nobody.
+   */
+  mentions?: ChatMessage["mentions"];
 }
 
 const ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
@@ -91,5 +103,8 @@ export function parseTurnRequest(body: unknown): TurnRequest {
     // anything else normalizes to "execute".
     mode: normalizeTurnMode(b.mode),
     displayText: typeof b.displayText === "string" ? b.displayText : undefined,
+    // Same "never trust the wire" posture: junk entries are dropped and an
+    // empty list becomes nothing, so a bad sidecar never costs the user a turn.
+    mentions: parseMentions(b.mentions),
   };
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -154,6 +154,7 @@ export {
   type FeedAuthor,
   type FeedFrame,
   type FeedItemVM,
+  type FeedMention,
   type FeedOutput,
   type HistoryWindowVM,
   historyToFeed,

--- a/packages/sdk/src/modules/turns/history.test.ts
+++ b/packages/sdk/src/modules/turns/history.test.ts
@@ -133,6 +133,33 @@ describe("historyToFeed", () => {
     });
   });
 
+  it("folds a user message's @mentions onto its user_message frame", () => {
+    const feed = historyToFeed([
+      {
+        role: "user",
+        content: "@Ada Lovelace please confirm the renewals",
+        ts: 1,
+        author: { userId: "u1", name: "Bo" },
+        mentions: [{ userId: "u2", name: "Ada Lovelace" }],
+      },
+      { role: "assistant", content: "on it", ts: 2 },
+    ]);
+    expect(feed[0]).toEqual({
+      feed_type: "user_message",
+      data: "@Ada Lovelace please confirm the renewals",
+      author: { userId: "u1", name: "Bo" },
+      mentions: [{ userId: "u2", name: "Ada Lovelace" }],
+      ts: 1,
+    });
+    // Assistant prose is never structured: its @Names stay plain text.
+    expect(feed[1]).not.toHaveProperty("mentions");
+  });
+
+  it("leaves a user message that mentions nobody without mentions", () => {
+    const [frame] = historyToFeed([{ role: "user", content: "hi", ts: 1 }]);
+    expect(frame?.mentions).toBeUndefined();
+  });
+
   it("replays persisted reasoning before the tool calls, with their inputs (HOU-717)", () => {
     const feed = historyToFeed([
       { role: "user", content: "run it", ts: 1 },

--- a/packages/sdk/src/modules/turns/history.ts
+++ b/packages/sdk/src/modules/turns/history.ts
@@ -14,7 +14,7 @@
 
 import type { ChatMessage } from "@houston/runtime-client";
 import { STOPPED_BY_USER } from "./turn-errors";
-import type { FeedAuthor } from "./vm-output";
+import type { FeedAuthor, FeedMention } from "./vm-output";
 
 /**
  * One replayed feed frame: the SAME `{ feed_type, data }` push the turn
@@ -29,6 +29,11 @@ export interface FeedFrame {
    *  seed/prepend folds carry it onto the feed entry (`FeedItemVM.author`), so
    *  a reloaded shared conversation attributes every teammate's bubble. */
   author?: FeedAuthor;
+  /** The teammates a `user_message` @mentions (HOU-944). The seed/prepend folds
+   *  carry it onto the feed entry (`FeedItemVM.mentions`), so a reloaded shared
+   *  conversation chips the same names the sent bubble did. Absent when the
+   *  message mentioned nobody. */
+  mentions?: FeedMention[];
   /**
    * Epoch-ms timestamp of the source `ChatMessage` this frame was folded from
    * (`ChatMessage.ts`). Carried on every frame attributable to a message so a
@@ -66,6 +71,7 @@ export function historyToFeed(
         // ran on `content`, but the bubble shows what the user actually meant.
         data: m.displayText ?? m.content,
         author: m.author,
+        mentions: m.mentions,
         ts,
       });
       continue;

--- a/packages/sdk/src/modules/turns/index.ts
+++ b/packages/sdk/src/modules/turns/index.ts
@@ -192,6 +192,7 @@ export {
   DEFAULT_CONVERSATION_CACHE_MAX,
   type FeedAuthor,
   type FeedItemVM,
+  type FeedMention,
   type HistoryWindowVM,
   type QueuedMessageVM,
 } from "./vm-output";

--- a/packages/sdk/src/modules/turns/operations.ts
+++ b/packages/sdk/src/modules/turns/operations.ts
@@ -93,6 +93,8 @@ export function createTurnOperations(
         pin,
         // Multiplayer: the caller's identity stamps the optimistic bubble.
         author: input.author,
+        // Multiplayer: the teammates the message @mentions chip that bubble.
+        mentions: input.mentions,
       },
     );
   };

--- a/packages/sdk/src/modules/turns/turn-inputs.test.ts
+++ b/packages/sdk/src/modules/turns/turn-inputs.test.ts
@@ -21,3 +21,59 @@ test("asSendInput drops an unknown mode to undefined", () => {
   expect(asSendInput({ ...BASE, mode: 1 }).mode).toBeUndefined();
   expect(asSendInput({ ...BASE }).mode).toBeUndefined();
 });
+
+/**
+ * The @mention sidecar (HOU-944): a decoration on the send, never a reason to
+ * lose the message — junk entries are dropped, the good ones survive, and a
+ * send that mentions nobody carries no `mentions` key at all.
+ */
+
+test("asSendInput keeps well-formed mentions", () => {
+  expect(
+    asSendInput({
+      ...BASE,
+      mentions: [{ userId: "u1", name: "Ada Lovelace" }, { userId: "u2" }],
+    }).mentions,
+  ).toEqual([{ userId: "u1", name: "Ada Lovelace" }, { userId: "u2" }]);
+});
+
+test("asSendInput drops junk mention entries but keeps the good ones", () => {
+  expect(
+    asSendInput({
+      ...BASE,
+      mentions: [
+        null,
+        "u9",
+        42,
+        {},
+        { userId: "" },
+        { userId: 7 },
+        { userId: "u1", name: 3 },
+        { userId: "u2", name: "Bo" },
+      ],
+    }).mentions,
+    // A numeric `name` is not a name: the entry survives, the field does not.
+  ).toEqual([{ userId: "u1" }, { userId: "u2", name: "Bo" }]);
+});
+
+test("asSendInput rejects a non-array mentions value outright", () => {
+  expect(asSendInput({ ...BASE, mentions: "u1" }).mentions).toBeUndefined();
+  expect(
+    asSendInput({ ...BASE, mentions: { userId: "u1" } }).mentions,
+  ).toBeUndefined();
+  expect(asSendInput({ ...BASE, mentions: null }).mentions).toBeUndefined();
+});
+
+test("asSendInput caps a mention list at 32 entries", () => {
+  const many = Array.from({ length: 40 }, (_, i) => ({ userId: `u${i}` }));
+  expect(asSendInput({ ...BASE, mentions: many }).mentions).toHaveLength(32);
+});
+
+test("a send that mentions nobody carries no mentions at all", () => {
+  expect(asSendInput({ ...BASE }).mentions).toBeUndefined();
+  // An empty list means exactly what absence means — never `[]`.
+  expect(asSendInput({ ...BASE, mentions: [] }).mentions).toBeUndefined();
+  expect(
+    asSendInput({ ...BASE, mentions: [{ userId: "" }] }).mentions,
+  ).toBeUndefined();
+});

--- a/packages/sdk/src/modules/turns/turn-inputs.ts
+++ b/packages/sdk/src/modules/turns/turn-inputs.ts
@@ -4,7 +4,8 @@
  * a bad shape (CommandRegistry.dispatch turns the throw into `ok: false`).
  */
 
-import type { FeedAuthor } from "./vm-output";
+import { parseMentions } from "@houston/protocol";
+import type { FeedAuthor, FeedMention } from "./vm-output";
 
 /** Arguments for starting a turn — the `turns/send` command payload. */
 export interface TurnSendInput {
@@ -37,6 +38,13 @@ export interface TurnSendInput {
    * `StreamTurnOptions.author`). Omitted single-player / signed out.
    */
   author?: FeedAuthor;
+  /**
+   * The teammates this message @mentions, in a multiplayer deployment: chips
+   * the optimistic bubble so a shared conversation names them immediately (see
+   * `StreamTurnOptions.mentions`). The model only ever sees the plain `@Name`
+   * text inside `text`. Omitted when the message mentions nobody.
+   */
+  mentions?: FeedMention[];
 }
 
 /** The `turns/cancel` command payload. */
@@ -84,6 +92,14 @@ const author = (v: unknown): FeedAuthor | undefined => {
   };
 };
 
+/** Untrusted-envelope guard for the @mention sidecar. The protocol owns the ONE
+ *  definition of what a mention is (`parseMentions`: array only, entries need a
+ *  non-empty string `userId`, `name` kept only when a string, junk entries
+ *  dropped rather than failing the send, capped, empty -> undefined) — the send
+ *  route and the runtime read the wire through the same function, so a mention
+ *  that survives here survives there. */
+const mentions = (v: unknown): FeedMention[] | undefined => parseMentions(v);
+
 export function asSendInput(payload: unknown): TurnSendInput {
   const p = (payload ?? {}) as Record<string, unknown>;
   if (typeof p.conversationId !== "string" || typeof p.text !== "string")
@@ -97,6 +113,7 @@ export function asSendInput(payload: unknown): TurnSendInput {
     effort: str(p.effort),
     mode: mode(p.mode),
     author: author(p.author),
+    mentions: mentions(p.mentions),
   };
 }
 

--- a/packages/sdk/src/modules/turns/turn-stream.test.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "@houston/runtime-client";
 import { EngineError } from "@houston/runtime-client";
 import { afterEach, expect, test } from "vitest";
+import { ScopeStore } from "../../store";
 import type { FeedOutput } from "./feed-output";
 import { TURN_DIED_MESSAGE } from "./settle-from-history";
 import {
@@ -21,6 +22,11 @@ import {
   type StreamTuning,
   streamTurn,
 } from "./turn-stream";
+import {
+  type ConversationVM,
+  ConversationVmOutput,
+  conversationScope,
+} from "./vm-output";
 
 /**
  * The resumable turn/observer runners against a scripted fake engine: one
@@ -87,6 +93,7 @@ type Item = {
   pending?: boolean;
   fails_pending?: boolean;
   author?: { userId: string; name?: string };
+  mentions?: { userId: string; name?: string }[];
 };
 
 /** A recording FeedOutput: the sink's FeedItems, session statuses, board persists. */
@@ -484,6 +491,92 @@ test("the optimistic bubble stays authorless when no sender is supplied (single-
 
   const bubble = items.find((i) => i.feed_type === "user_message");
   expect(bubble?.author).toBeUndefined();
+});
+
+/**
+ * The @mention sidecar (HOU-944) rides the optimistic bubble the same way
+ * `author` does: the model receives only the plain `@Name` text in the prompt,
+ * while the VM entry carries the structure a surface chips from — and it must
+ * land on the real `FeedItemVM`, not just the raw push, or the sent bubble
+ * renders unchipped until history reloads.
+ */
+
+test("StreamTurnOptions.mentions reaches the optimistic FeedItemVM.mentions", async () => {
+  const { engine } = fakeEngine([
+    (o) => {
+      o.onEvent(sync(false, "", 0));
+      o.onEvent({ type: "done", data: null, seq: 1 });
+    },
+  ]);
+  const store = new ScopeStore();
+  const vm = new ConversationVmOutput(store);
+
+  await streamTurn(
+    engine,
+    "Houston/Bo",
+    "activity-mentions",
+    "@Ada please confirm and I'll send it",
+    vm,
+    registry,
+    { tuning: fast, mentions: [{ userId: "user_a", name: "Ada" }] },
+  );
+
+  const snap = store.getSnapshot(
+    conversationScope("Houston/Bo", "activity-mentions"),
+  ) as ConversationVM;
+  const bubble = snap.feed.find((f) => f.feed_type === "user_message");
+  expect(bubble?.data).toBe("@Ada please confirm and I'll send it");
+  expect(bubble?.mentions).toEqual([{ userId: "user_a", name: "Ada" }]);
+});
+
+test("mentions ride the send body so the runtime can persist them", async () => {
+  const { engine, sendOpts, texts } = fakeEngine([
+    (o) => {
+      o.onEvent(sync(false, "", 0));
+      o.onEvent({ type: "done", data: null, seq: 1 });
+    },
+  ]);
+  const { output } = makeOutput();
+
+  await streamTurn(
+    engine,
+    "Houston/Bo",
+    "activity-wire",
+    "@Ada please confirm",
+    output,
+    registry,
+    { tuning: fast, mentions: [{ userId: "user_a", name: "Ada" }] },
+  );
+
+  // The model still receives the plain text and nothing but it.
+  expect(texts[0]).toBe("@Ada please confirm");
+  expect(sendOpts[0]?.mentions).toEqual([{ userId: "user_a", name: "Ada" }]);
+});
+
+test("a send that mentions nobody carries NO mentions key, on the bubble or the wire", async () => {
+  const { engine, sendOpts } = fakeEngine([
+    (o) => {
+      o.onEvent(sync(false, "", 0));
+      o.onEvent({ type: "done", data: null, seq: 1 });
+    },
+  ]);
+  const { items, output } = makeOutput();
+
+  await streamTurn(
+    engine,
+    "Houston/Bo",
+    "activity-unmentioned",
+    "hi",
+    output,
+    registry,
+    // An EMPTY list means what absence means, and must normalize the same way:
+    // neither the bubble nor the wire ever carries `mentions: []`.
+    { tuning: fast, mentions: [] },
+  );
+
+  const bubble = items.find((i) => i.feed_type === "user_message");
+  expect(bubble?.mentions).toBeUndefined();
+  expect(sendOpts[0]?.mentions).toBeUndefined();
 });
 
 test("displayText renders as the bubble while the engine still receives the real prompt", async () => {

--- a/packages/sdk/src/modules/turns/turn-stream.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.ts
@@ -20,7 +20,7 @@ import {
   turnErrorMessage,
 } from "./turn-errors";
 import { TurnSink } from "./turn-sink";
-import type { FeedAuthor } from "./vm-output";
+import type { FeedAuthor, FeedMention } from "./vm-output";
 
 export { observeConversation } from "./observe-stream";
 export type { StreamRegistry, StreamTuning } from "./stream-registry";
@@ -80,6 +80,16 @@ export interface StreamTurnOptions {
    * bubble stays authorless, exactly as single-player renders today.
    */
   author?: FeedAuthor;
+  /**
+   * The teammates this turn @mentions (HOU-944): the structured sidecar the
+   * composer resolved for the `@Name` text inside `prompt`, stamped onto the
+   * optimistic bubble so a shared conversation chips those names from the
+   * instant it appears — matching the `mentions` the runtime persists and
+   * history replays. The model only ever sees the plain text. The SDK never
+   * infers it; omitted (or empty) leaves the bubble unchipped, exactly as
+   * single-player renders today.
+   */
+  mentions?: FeedMention[];
 }
 
 /**
@@ -131,6 +141,10 @@ export async function streamTurn(
   // Status BEFORE the bubble: `running: false` must mean settled-or-idle, so a
   // watcher can't mistake the optimistic-push snapshot for a settled turn.
   output.sessionStatus(agentPath, sessionKey, "running");
+  // An EMPTY @mention list means exactly what absence means (nobody was
+  // mentioned), so it is normalized away ONCE, here: neither the optimistic
+  // bubble nor the wire body ever carries `mentions: []`.
+  const mentions = opts.mentions?.length ? opts.mentions : undefined;
   // The optimistic user bubble: the surface never renders it itself, and the
   // sink never renders the server's echo of it (nonce-matched) — this push is
   // the ONE place a sent prompt enters the feed. Marker-tagged prompts
@@ -149,6 +163,9 @@ export async function streamTurn(
       pending: true,
       // Multiplayer: who is sending. Absent single-player (no identity).
       author: opts.author,
+      // Multiplayer: the teammates this message @mentions, chipping the bubble
+      // from the instant it appears — the same list the send carries below.
+      mentions,
     });
   }
   // Flip the card to "running" for this turn (re-running a needs_you/done
@@ -194,6 +211,7 @@ export async function streamTurn(
         nonce,
         ...opts.pin,
         displayText: opts.displayText,
+        mentions,
       });
     } catch (e) {
       registry.endSend(key);
@@ -269,6 +287,7 @@ export async function streamTurn(
           nonce,
           ...opts.pin,
           displayText: opts.displayText,
+          mentions,
         });
         sink.sendAccepted();
       } catch (e) {

--- a/packages/sdk/src/modules/turns/vm-output.test.ts
+++ b/packages/sdk/src/modules/turns/vm-output.test.ts
@@ -575,3 +575,56 @@ test("a pushed item carries its author; an authorless push stays authorless", ()
   expect(snap().feed[0]?.author).toEqual({ userId: "user_a", name: "Ada" });
   expect(snap().feed[1]).not.toHaveProperty("author");
 });
+
+test("seedHistory and prependHistory carry a frame's @mentions onto its entry", () => {
+  const { vm, snap } = harness();
+  vm.seedHistory(
+    "a",
+    "c1",
+    [
+      {
+        feed_type: "user_message",
+        data: "@Ada can you confirm?",
+        ts: 100,
+        mentions: [{ userId: "user_a", name: "Ada" }],
+      },
+      { feed_type: "assistant_text", data: "asking @Ada now", ts: 110 },
+    ],
+    { earliestLoaded: 5, total: 6 },
+  );
+  vm.prependHistory(
+    "a",
+    "c1",
+    [
+      {
+        feed_type: "user_message",
+        data: "@Bo and @Ada, standup?",
+        ts: 10,
+        mentions: [{ userId: "user_b", name: "Bo" }, { userId: "user_a" }],
+      },
+    ],
+    { earliestLoaded: 0, total: 6 },
+  );
+
+  expect(snap().feed.map((f) => f.mentions)).toEqual([
+    [{ userId: "user_b", name: "Bo" }, { userId: "user_a" }],
+    [{ userId: "user_a", name: "Ada" }],
+    undefined,
+  ]);
+  // Assistant prose is unstructured: no key at all, not an empty list.
+  expect(snap().feed[2]).not.toHaveProperty("mentions");
+});
+
+test("a pushed item carries its mentions; an unmentioning push carries no key", () => {
+  const { vm, snap } = harness();
+  vm.pushFeedItem("a", "c1", {
+    feed_type: "user_message",
+    data: "@Ada please review",
+    pending: true,
+    mentions: [{ userId: "user_a", name: "Ada" }],
+  });
+  vm.pushFeedItem("a", "c1", { feed_type: "user_message", data: "thanks" });
+
+  expect(snap().feed[0]?.mentions).toEqual([{ userId: "user_a", name: "Ada" }]);
+  expect(snap().feed[1]).not.toHaveProperty("mentions");
+});

--- a/packages/sdk/src/modules/turns/vm-output.ts
+++ b/packages/sdk/src/modules/turns/vm-output.ts
@@ -38,6 +38,18 @@ export interface FeedAuthor {
 }
 
 /**
+ * One @mention of a human inside a chat message: the protocol's
+ * `ChatMessage.mentions[]` entry. The model only ever saw the plain `@Name`
+ * text the user typed — this is the structure the composer resolved alongside
+ * it, so a surface can chip the name and a later notifications feature can scan
+ * a transcript for its own user id. User turns only.
+ */
+export interface FeedMention {
+  userId: string;
+  name?: string;
+}
+
+/**
  * What the seed/prepend folds consume: one folded history frame. Structurally
  * the `FeedFrame` `historyToFeed` produces — declared here (rather than
  * imported) so the fold and its consumer stay import-acyclic.
@@ -47,6 +59,7 @@ interface HistoryFrame {
   data: unknown;
   ts?: number;
   author?: FeedAuthor;
+  mentions?: FeedMention[];
 }
 
 /** A single reactive feed entry: a stable id plus the machinery's push payload. */
@@ -63,6 +76,15 @@ export interface FeedItemVM {
    * surface that does not render it simply ignores it.
    */
   author?: FeedAuthor;
+  /**
+   * The teammates this `user_message` @mentions (HOU-944). Carried verbatim
+   * from the history fold (`FeedFrame.mentions`) when a transcript is
+   * seeded/prepended, and from `StreamTurnOptions.mentions` on the optimistic
+   * send — so a shared conversation chips the same names live and on reload.
+   * Optional/additive: absent when the message mentioned nobody and on every
+   * non-user entry; a surface that does not render it simply ignores it.
+   */
+  mentions?: FeedMention[];
   /**
    * Epoch-ms timestamp of this entry. A seeded history frame carries its source
    * `ChatMessage.ts`; a LIVE push that lacks one is stamped `Date.now()` at push
@@ -270,15 +292,17 @@ export class ConversationVmOutput implements FeedOutput {
   ): void {
     const s = this.state(agentPath, sessionKey);
     // History frames carry their source `ChatMessage.ts` (absent for a pre-`ts`
-    // transcript) and, in multiplayer, its `author`; pass both through verbatim
-    // — a seeded frame is historical, so it is never stamped with the wall clock
-    // the way a live push is, and its author is the persisted one.
+    // transcript) and, in multiplayer, its `author` + `mentions`; pass all three
+    // through verbatim — a seeded frame is historical, so it is never stamped
+    // with the wall clock the way a live push is, and its author and mentions
+    // are the persisted ones.
     s.feed = frames.map((f) => ({
       id: `f${s.seq++}`,
       feed_type: f.feed_type,
       data: f.data,
       ...(f.ts !== undefined ? { ts: f.ts } : {}),
       ...(f.author !== undefined ? { author: f.author } : {}),
+      ...(f.mentions !== undefined ? { mentions: f.mentions } : {}),
     }));
     s.streaming.clear();
     // A windowed server read stamps its window; a cache paint / full-history
@@ -309,6 +333,7 @@ export class ConversationVmOutput implements FeedOutput {
         data: f.data,
         ...(f.ts !== undefined ? { ts: f.ts } : {}),
         ...(f.author !== undefined ? { author: f.author } : {}),
+        ...(f.mentions !== undefined ? { mentions: f.mentions } : {}),
       })),
       ...s.feed,
     ];
@@ -318,14 +343,16 @@ export class ConversationVmOutput implements FeedOutput {
 
   pushFeedItem(agentPath: string, sessionKey: string, item: unknown): void {
     const s = this.state(agentPath, sessionKey);
-    const { feed_type, data, ts, pending, fails_pending, author } = item as {
-      feed_type: string;
-      data: unknown;
-      ts?: number;
-      pending?: boolean;
-      fails_pending?: boolean;
-      author?: FeedAuthor;
-    };
+    const { feed_type, data, ts, pending, fails_pending, author, mentions } =
+      item as {
+        feed_type: string;
+        data: unknown;
+        ts?: number;
+        pending?: boolean;
+        fails_pending?: boolean;
+        author?: FeedAuthor;
+        mentions?: FeedMention[];
+      };
     // An optimistic (pending) push is NOT server evidence, so it never confirms a
     // sibling optimistic bubble — two queued prompts both keep their clock. ANY
     // other push resolves EVERY currently pending entry at once: a
@@ -351,8 +378,9 @@ export class ConversationVmOutput implements FeedOutput {
     } else {
       // A fresh entry: carry a supplied `ts`, else stamp the wall clock now; an
       // optimistic push carries `pending: true` until server evidence clears it,
-      // and (multiplayer) the sender's `author` so the bubble is attributed from
-      // the instant it appears — exactly as the reseeded history frame will be.
+      // and (multiplayer) the sender's `author` plus the teammates the message
+      // `mentions`, so the bubble is attributed and chipped from the instant it
+      // appears — exactly as the reseeded history frame will be.
       s.feed.push({
         id: `f${s.seq++}`,
         feed_type,
@@ -360,6 +388,7 @@ export class ConversationVmOutput implements FeedOutput {
         ts: ts ?? Date.now(),
         ...(pending === true ? { pending: true } : {}),
         ...(author !== undefined ? { author } : {}),
+        ...(mentions !== undefined ? { mentions } : {}),
       });
     }
     this.publish(agentPath, sessionKey, s);

--- a/packages/web/e2e/README.md
+++ b/packages/web/e2e/README.md
@@ -44,6 +44,7 @@ e2e/
   support/
     seed.ts         # localStorage + window.__HOUSTON_CP__ primed before any app script
     fixtures.ts     # the `test`/`expect` used by specs (resets the host per test)
+    identity.ts     # sign the harness in as a known user (see Signed-in specs below)
     global-setup.ts # warms the vite dev server once before the suite (see CI below)
   *.spec.ts         # the tests
 ```
@@ -86,6 +87,21 @@ assistant reply at turn END (both turn-stamped) — the identity contract
   nobody watches and start the next one, so the reconnect resyncs onto a
   DIFFERENT turnId and the client must settle its turn from history by turnId
   (the turn-boundary spec).
+
+**Signed-in specs.** The default server bakes no Firebase key, so
+`isIdentityConfigured()` is false and the session is always `null`. That is fine
+for almost everything, but a surface gated on a signed-in identity is then
+UNREACHABLE — `useOrgPeople` / `useUserProfiles` never even fetch — and anything
+that must know WHO is looking (`currentUserId`, e.g. the @mention self-chip) has
+no answer. `support/identity.ts` closes that gap: pair `test.use({ baseURL:
+AUTH_WEB_URL })` with `signInAsViewer(page)` and the spec runs on the identity-ON
+server (`:1435`, the one the sign-in spec uses), signed in as `E2E_VIEWER`
+(`uid: "u-self"`) through the app's REAL passwordless email screen. Only the
+NETWORK is mocked — the gateway's OTP contract plus GCIP's public REST wire
+(`identitytoolkit` / `securetoken`) — so nothing reaches into firebase-js-sdk's
+storage internals and an unmocked identity call fails loudly instead of escaping
+to Google. Arm the fake host's org roster with the same `u-self` id and "me" is
+assertable (`chat-mentions.spec.ts`).
 
 **Teams / integrations arming.** Single-player alone can't reach the Teams-shaped
 state the locked browse rows (and, later, the admin policy pages) need. Two

--- a/packages/web/e2e/chat-mentions.spec.ts
+++ b/packages/web/e2e/chat-mentions.spec.ts
@@ -1,0 +1,255 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "./support/fixtures";
+import { AUTH_WEB_URL, E2E_VIEWER, signInAsViewer } from "./support/identity";
+
+/**
+ * HOU-944 — @mentions of teammates in a chat, end to end.
+ *
+ * Three things have to be true for the feature to exist for a user:
+ *   1. the composer offers the space's teammates behind "@" — by keyboard AND
+ *      by click — and the sent message renders the pick as a chip;
+ *   2. a RELOADED transcript chips the same people: a user turn from its own
+ *      recorded `mentions[]`, an assistant turn from plain "@Name" prose matched
+ *      against the space roster (a hand-rolled rehype pass inside Streamdown's
+ *      plugin chain — the riskiest path in the feature), with a mention of the
+ *      VIEWER emphasized;
+ *   3. single player never fetches a roster, so "@" is just a character.
+ *
+ * The roster is armed on the fake host (`/__test__/org` → `GET /v1/org/people`)
+ * next to multiplayer capabilities — the same wire shape the cloud gateway
+ * serves. The seeded transcript (`/__test__/chat-history`) is the only way to
+ * reach a reloaded shared conversation locally.
+ *
+ * WHY THIS SPEC SIGNS IN. The roster read is gated on
+ * `isIdentityConfigured() && isMultiplayer(capabilities)`, and "is this mention
+ * ME?" keys off `useSession().uid`. The default e2e server bakes no Firebase key,
+ * so there the feature can't exist at all: no roster fetch, no popover, no
+ * self-chip. This spec therefore runs on the identity-ON server and signs in as
+ * {@link E2E_VIEWER} (see support/identity.ts), which makes the viewer's
+ * identity — the thing half of this feature is about — controllable.
+ */
+
+test.use({ baseURL: AUTH_WEB_URL });
+
+/** The spec's OWN mission + its conversation. Created here rather than reusing a
+ *  seeded card (see chat-senders.spec.ts): a fresh activity carries no
+ *  server-stamped contributors, so it stays visible under the board's default
+ *  person scope in multiplayer. */
+const MISSION_ID = "act-mentions";
+const MISSION_TITLE = "Quarterly close checklist";
+const CONVERSATION_ID = `activity-${MISSION_ID}`;
+
+/** The armed space: the signed-in viewer, one teammate, and a member with NO
+ *  display name — the client must never offer an id as a mentionable person. */
+const SELF = {
+  userId: E2E_VIEWER.uid,
+  email: E2E_VIEWER.email,
+  role: "owner",
+  displayName: E2E_VIEWER.displayName,
+  photoUrl: E2E_VIEWER.photoUrl,
+};
+const BOB = {
+  userId: "u-bob",
+  email: "bob@acme.test",
+  role: "user",
+  displayName: "Bob Stone",
+};
+const GHOST = { userId: "u-ghost", email: "ghost@acme.test", role: "user" };
+
+/** Put the deployment into multiplayer (what the real gateway advertises). */
+async function armMultiplayer(request: APIRequestContext): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/capabilities`, {
+    data: { multiplayer: true, teams: true, role: "owner" },
+  });
+}
+
+/** Arm the co-member directory `GET /v1/org/people` is built from. */
+async function armRoster(request: APIRequestContext): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/org`, {
+    data: { members: [GHOST, SELF, BOB] },
+  });
+}
+
+/** Create the mission whose card opens this conversation. */
+async function seedMission(request: APIRequestContext): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/agents/houston-assistant/activities`, {
+    data: { id: MISSION_ID, title: MISSION_TITLE, status: "needs_you" },
+  });
+}
+
+/** The rendered message rows the USER wrote — each carries its stable
+ *  conversation key, and `is-user` is the bubble's own marker, so an assertion
+ *  can never be satisfied by the agent echoing the same words back. */
+const userRows = (page: Page) =>
+  page.locator("[data-conversation-message-key].is-user");
+/** …and only the rows the agent wrote. */
+const agentRows = (page: Page) =>
+  page.locator("[data-conversation-message-key]:not(.is-user)");
+/** The composer of an already-open conversation. */
+const composerOf = (page: Page) => page.getByPlaceholder("Send a follow-up...");
+const popover = (page: Page) => page.locator("[data-mention-popover]");
+const option = (page: Page, userId: string) =>
+  page.locator(`[data-mention-option="${userId}"]`);
+
+/** Open the spec's mission on the signed-in shell. */
+async function openMission(page: Page): Promise<void> {
+  await page.getByText(MISSION_TITLE).click();
+  await expect(composerOf(page)).toBeVisible();
+}
+
+test("the composer offers teammates behind @ and the sent message chips the pick", async ({
+  page,
+  request,
+}) => {
+  await armMultiplayer(request);
+  await armRoster(request);
+  await seedMission(request);
+  await signInAsViewer(page);
+  await openMission(page);
+
+  const composer = composerOf(page);
+  await composer.click();
+
+  // --- input path 1: pick with the mouse -----------------------------------
+  await composer.pressSequentially("Ping @Bo");
+  await expect(popover(page)).toBeVisible();
+  // The list keeps the semantics a keyboard/AT user needs.
+  const listbox = popover(page).locator('[role="listbox"]');
+  await expect(listbox).toBeVisible();
+  const bob = option(page, "u-bob");
+  await expect(bob).toHaveAttribute("role", "option");
+
+  // Focus never leaves the textarea, so the TEXTAREA is the combobox: without
+  // this wiring a screen-reader user is never told the list opened, nor which
+  // teammate they are on.
+  await expect(composer).toHaveAttribute("role", "combobox");
+  await expect(composer).toHaveAttribute("aria-expanded", "true");
+  const listboxId = await listbox.getAttribute("id");
+  expect(listboxId).toBeTruthy();
+  await expect(composer).toHaveAttribute("aria-controls", String(listboxId));
+  const activeId = await composer.getAttribute("aria-activedescendant");
+  await expect(bob).toHaveAttribute("id", String(activeId));
+  // The row reads as a person: their face (initials here) beside their name.
+  await expect(bob).toContainText("Bob Stone");
+  await expect(bob.locator('[data-slot="avatar"]')).toBeVisible();
+  await expect(bob).toContainText("BS");
+
+  await bob.click();
+  // Accepting writes PLAIN TEXT: the composer stays a <textarea>.
+  await expect(composer).toHaveValue("Ping @Bob Stone ");
+  await expect(popover(page)).toHaveCount(0);
+  // …and the combobox wiring reverts cleanly: a plain textarea again.
+  await expect(composer).not.toHaveAttribute("role", "combobox");
+  await expect(composer).not.toHaveAttribute("aria-expanded", "true");
+  await expect(composer).not.toHaveAttribute("aria-activedescendant", /.*/);
+
+  // --- input path 2: pick with the keyboard --------------------------------
+  await composer.fill("");
+  await composer.pressSequentially("Please loop in @");
+  await expect(popover(page)).toBeVisible();
+  // You never @mention yourself, and a member with no display name is never
+  // offered ("@u-ghost" is nonsense to a non-technical reader) — so the bare
+  // "@" query offers exactly one person out of the three-member space.
+  await expect(option(page, E2E_VIEWER.uid)).toHaveCount(0);
+  await expect(option(page, "u-ghost")).toHaveCount(0);
+  await expect(popover(page).locator('[role="option"]')).toHaveCount(1);
+
+  await page.keyboard.press("ArrowDown");
+  await expect(bob).toHaveAttribute("data-selected", "true");
+  await page.keyboard.press("Enter");
+  await expect(composer).toHaveValue("Please loop in @Bob Stone ");
+  await expect(popover(page)).toHaveCount(0);
+
+  // --- the sent bubble chips the mention -----------------------------------
+  await composer.press("Enter");
+  const SENT = "Please loop in @Bob Stone";
+  const sent = userRows(page).filter({ hasText: SENT });
+  await expect(sent).toBeVisible();
+  const chip = sent.locator("[data-mention-chip]");
+  await expect(chip).toHaveText("@Bob Stone");
+  // Bob is not the viewer, so no emphasis.
+  await expect(chip).not.toHaveAttribute("data-mention-self", "");
+
+  // The mention travelled over the WIRE, not just into the optimistic bubble:
+  // after a reload the bubble is rebuilt from the host's persisted history, so
+  // the chip only survives if the send carried its `mentions[]` sidecar.
+  await page.reload();
+  await openMission(page);
+  await expect(
+    userRows(page).filter({ hasText: SENT }).locator("[data-mention-chip]"),
+  ).toHaveText("@Bob Stone");
+});
+
+test("a reloaded transcript chips mentions in a user turn and in assistant prose", async ({
+  page,
+  request,
+}) => {
+  await armMultiplayer(request);
+  await armRoster(request);
+  await seedMission(request);
+  // The user turn NAMES two people but RECORDED only Bob: a user bubble chips
+  // its own `mentions[]`, never the roster, so "@Ada Lovelace" stays prose.
+  const ASKED = "Can @Bob Stone close it with @Ada Lovelace?";
+  // The assistant turn records nothing — its "@Name" runs are matched against
+  // the space roster by the rehype pass, and the viewer's own is emphasized.
+  const REPLIED =
+    "On it. @Ada Lovelace signed off and @Bob Stone has the file.";
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-history`, {
+    data: {
+      conversationId: CONVERSATION_ID,
+      messages: [
+        {
+          role: "user",
+          content: ASKED,
+          ts: 1,
+          mentions: [{ userId: BOB.userId, name: BOB.displayName }],
+        },
+        { role: "assistant", content: REPLIED, ts: 2 },
+      ],
+    },
+  });
+  await signInAsViewer(page);
+  await openMission(page);
+
+  const asked = userRows(page).filter({ hasText: "Can @Bob Stone close it" });
+  await expect(asked).toBeVisible();
+  // Exactly one chip: the recorded mention. The unrecorded name stays prose.
+  await expect(asked.locator("[data-mention-chip]")).toHaveText(["@Bob Stone"]);
+
+  // The riskiest path: assistant PROSE, chipped from the roster alone.
+  const replied = agentRows(page).filter({ hasText: "signed off" });
+  await expect(replied).toBeVisible();
+  const chips = replied.locator("[data-mention-chip]");
+  await expect(chips).toHaveText(["@Ada Lovelace", "@Bob Stone"]);
+  // "The agent is asking ME": the viewer's own mention carries the emphasis.
+  await expect(chips.first()).toHaveAttribute("data-mention-self", "");
+  await expect(chips.last()).not.toHaveAttribute("data-mention-self", "");
+  await expect(replied.locator("[data-mention-self]")).toHaveCount(1);
+});
+
+test("single player never offers a mention list — @ is just a character", async ({
+  page,
+  request,
+}) => {
+  // No capabilities arming: the roster read is multiplayer-gated, so the
+  // directory is never fetched and no popover can exist. The roster IS armed on
+  // the host, so a fetch would succeed — proving the gate, not an empty space.
+  await armRoster(request);
+  await seedMission(request);
+  const rosterReads: string[] = [];
+  page.on("request", (req) => {
+    if (req.url().includes("/v1/org/people")) rosterReads.push(req.url());
+  });
+  await signInAsViewer(page);
+  await openMission(page);
+
+  const composer = composerOf(page);
+  await composer.click();
+  await composer.pressSequentially("Ping @Bo");
+
+  await expect(composer).toHaveValue("Ping @Bo");
+  await expect(popover(page)).toHaveCount(0);
+  await expect(option(page, "u-bob")).toHaveCount(0);
+  expect(rosterReads).toEqual([]);
+});

--- a/packages/web/e2e/mentions-inbox.spec.ts
+++ b/packages/web/e2e/mentions-inbox.spec.ts
@@ -1,0 +1,307 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "./support/fixtures";
+import { AUTH_WEB_URL, E2E_VIEWER, signInAsViewer } from "./support/identity";
+
+/**
+ * HOU-945 — relevance-scoped notifications, the surface half: Mission Control's
+ * Mentions inbox.
+ *
+ * With many agents running in parallel a user must only be signalled about work
+ * that is theirs, and an @mention is the strongest such claim. The inbox is the
+ * place those claims collect: one row per mission where a teammate typed your
+ * name, newest first, each row navigating to that mission's chat.
+ *
+ * Everything here is multiplayer-gated AND identity-gated: "is this mention ME?"
+ * keys off `useSession().uid`, so the default (identity-OFF) e2e server can't
+ * express the feature at all. This spec therefore runs on the identity-ON server
+ * and signs in as {@link E2E_VIEWER} (`u-self`), exactly like chat-mentions.spec.
+ *
+ * The mention AGGREGATE (`Activity.mentioned`) is server-stamped by the host from
+ * a gateway-verified acting identity, so it cannot be produced by a local turn.
+ * It is seeded straight onto the activity here, which is the same wire shape the
+ * real host serves from `.houston/activity`.
+ */
+
+test.use({ baseURL: AUTH_WEB_URL });
+
+/** The spec's OWN mission. A fresh activity carries no server-stamped
+ *  contributors, so nothing but what this spec seeds decides its relevance. */
+const MISSION_ID = "act-mention-inbox";
+const MISSION_TITLE = "Renew the vendor contracts";
+/** A second mission that mentions somebody ELSE: it must never reach my inbox. */
+const OTHER_ID = "act-not-mine";
+const OTHER_TITLE = "Rewrite the pricing page";
+/** A third mission: MINE, moved since I last looked, naming nobody at all. It
+ *  is the ambient-movement half of the "unread" signal, which the Mentions pill
+ *  must never fold into its count. */
+const MOVED_ID = "act-moved-no-mention";
+const MOVED_TITLE = "Reconcile the March invoices";
+
+const SELF = {
+  userId: E2E_VIEWER.uid,
+  email: E2E_VIEWER.email,
+  role: "owner",
+  displayName: E2E_VIEWER.displayName,
+  photoUrl: E2E_VIEWER.photoUrl,
+};
+const BOB = {
+  userId: "u-bob",
+  email: "bob@acme.test",
+  role: "user",
+  displayName: "Bob Stone",
+};
+
+/** Put the deployment into multiplayer (what the real gateway advertises). */
+async function armMultiplayer(request: APIRequestContext): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/capabilities`, {
+    data: { multiplayer: true, teams: true, role: "owner" },
+  });
+}
+
+/** Arm the roster the inbox resolves mentioner faces + names from. */
+async function armRoster(request: APIRequestContext): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/org`, {
+    data: { members: [SELF, BOB] },
+  });
+}
+
+/**
+ * Seed the two missions. The first carries a `mentioned` entry naming the
+ * viewer (stamped `by` Bob); the second names Bob instead, so the inbox has a
+ * genuine chance to get it wrong.
+ */
+async function seedMissions(request: APIRequestContext): Promise<void> {
+  const at = new Date(Date.now() - 5 * 60_000).toISOString();
+  await request.post(`${FAKE_HOST_URL}/agents/houston-assistant/activities`, {
+    data: {
+      id: MISSION_ID,
+      title: MISSION_TITLE,
+      status: "needs_you",
+      contributors: [{ user_id: BOB.userId, name: BOB.displayName }],
+      mentioned: [{ user_id: E2E_VIEWER.uid, at, by: BOB.userId }],
+    },
+  });
+  await request.post(`${FAKE_HOST_URL}/agents/houston-assistant/activities`, {
+    data: {
+      id: OTHER_ID,
+      title: OTHER_TITLE,
+      status: "running",
+      mentioned: [{ user_id: BOB.userId, at, by: E2E_VIEWER.uid }],
+    },
+  });
+}
+
+/**
+ * Seed a mission of MY OWN that carries no mention aggregate whatsoever. Paired
+ * with {@link armAncientReadFloor} it is unread for me the AMBIENT way, which is
+ * exactly the signal the Mentions pill must refuse to count.
+ */
+async function seedMovedMission(request: APIRequestContext): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/agents/houston-assistant/activities`, {
+    data: {
+      id: MOVED_ID,
+      title: MOVED_TITLE,
+      status: "running",
+      created_by: E2E_VIEWER.uid,
+      contributors: [{ user_id: E2E_VIEWER.uid, name: E2E_VIEWER.displayName }],
+    },
+  });
+}
+
+/**
+ * Plant a read-cursor store floored at the epoch BEFORE the app boots.
+ *
+ * A store the app creates for itself is floored at "now" (so a fresh device does
+ * not open on a backlog), while every fake-host activity is stamped at a fixed
+ * 2024 instant. Out of the box nothing can therefore be ambient-unread, and the
+ * distinction this spec turns on would be unobservable. An ancient floor is the
+ * local equivalent of "these missions moved while I was away", and it is the
+ * app's own persisted shape: `app/src/lib/read-cursors.ts` owns the key and the
+ * blob, `read-cursors-parse.ts` the decoding.
+ */
+async function armAncientReadFloor(page: Page): Promise<void> {
+  await page.addInitScript(
+    ([key, blob]) => window.localStorage.setItem(key, blob),
+    [
+      `houston.read-cursors.${E2E_VIEWER.uid}`,
+      JSON.stringify({ since: 0, cursors: {} }),
+    ] as const,
+  );
+}
+
+/** Mission Control, the top-level cross-agent view that owns the inbox. */
+async function openMissionControl(page: Page): Promise<void> {
+  await page.locator("[data-tour-target='nav-dashboard']").click();
+}
+
+/** The Mentions mode control. Its accessible name carries the unread count
+ *  once there is one, which is exactly what makes the badge assertable. */
+const mentionsControl = (page: Page) =>
+  page.getByRole("button", { name: /mention/i });
+
+/** The inbox rows (each row is a real button, so keyboard users reach them). */
+const inboxRows = (page: Page) =>
+  page.getByRole("button").filter({ hasText: "mentioned you" });
+
+/** A board card, addressed by the marker the board's own drag layer reads. */
+const missionCard = (page: Page, id: string) =>
+  page.locator(`[data-kanban-card='${id}']`);
+
+/**
+ * The card's unread mark. Addressed by attribute, not `getByRole`, for the same
+ * reason as the face stack in board-people.spec: the card is an ARIA `option`,
+ * whose children are presentational and never reach the accessibility tree.
+ * `app/src/locales/en/board.json` owns the label.
+ */
+const cardUnreadDot = (page: Page, id: string) =>
+  missionCard(page, id).locator('[role="img"][aria-label="Unread updates"]');
+
+test("the inbox lists a mission that mentions me, and only that one", async ({
+  page,
+  request,
+}) => {
+  await armMultiplayer(request);
+  await armRoster(request);
+  await seedMissions(request);
+  await signInAsViewer(page);
+  await openMissionControl(page);
+
+  // The control advertises the unread count in its accessible name, so the
+  // quiet visual badge has a non-visual equivalent (and one assertion covers
+  // both). One unread mention, not two: the Bob-only mission is not mine.
+  const control = mentionsControl(page);
+  await expect(control).toBeVisible();
+  await expect(control).toHaveAccessibleName(/1 unread mention/);
+
+  await control.click();
+
+  const rows = inboxRows(page);
+  await expect(rows).toHaveCount(1);
+  const row = rows.first();
+  await expect(row).toContainText(MISSION_TITLE);
+  // Who pinged me, and where. Never a raw user id.
+  await expect(row).toContainText("Bob Stone mentioned you");
+  await expect(row).toContainText("Houston");
+  await expect(row).not.toContainText(BOB.userId);
+  // The mission that mentions somebody else never reaches my inbox.
+  await expect(page.getByText(OTHER_TITLE)).toHaveCount(0);
+});
+
+test("the pill counts mentions only, never a mission that merely moved", async ({
+  page,
+  request,
+}) => {
+  await armMultiplayer(request);
+  await armRoster(request);
+  await seedMissions(request);
+  await seedMovedMission(request);
+  await armAncientReadFloor(page);
+  await signInAsViewer(page);
+  await openMissionControl(page);
+
+  // My own mission moved while I was away, so it IS unread: the board says so
+  // with the same dot the mentioning mission gets. Two unread missions.
+  await expect(missionCard(page, MOVED_ID)).toBeVisible();
+  await expect(cardUnreadDot(page, MOVED_ID)).toHaveCount(1);
+  await expect(cardUnreadDot(page, MISSION_ID)).toHaveCount(1);
+
+  // The pill makes a NARROWER claim than the dot: it says out loud that someone
+  // typed my name, so it counts the one mission where somebody did. Anchored,
+  // because the whole point of this test is the number itself.
+  await expect(mentionsControl(page)).toHaveAccessibleName(
+    /^1 unread mention$/,
+  );
+
+  // And the inbox never invents a row for a mission that only moved.
+  await mentionsControl(page).click();
+  await expect(inboxRows(page)).toHaveCount(1);
+  await expect(page.getByText(MOVED_TITLE)).toHaveCount(0);
+});
+
+test("an unread mention row carries the quiet unread dot until it is opened", async ({
+  page,
+  request,
+}) => {
+  await armMultiplayer(request);
+  await armRoster(request);
+  await seedMissions(request);
+  await signInAsViewer(page);
+  await openMissionControl(page);
+  await mentionsControl(page).click();
+
+  const row = inboxRows(page).first();
+  await expect(row).toBeVisible();
+  // The unread signal is a filled dot painted with the semantic action token,
+  // deliberately NOT a count chip: "there is something new here", not "act now".
+  const dot = row.locator("span.bg-action");
+  await expect(dot).toHaveCount(1);
+  const fill = await dot.evaluate((el) => getComputedStyle(el).backgroundColor);
+  expect(fill).not.toBe("rgba(0, 0, 0, 0)");
+});
+
+test("the mission's own card carries the unread dot until the mission is opened", async ({
+  page,
+  request,
+}) => {
+  await armMultiplayer(request);
+  await armRoster(request);
+  await seedMissions(request);
+  await signInAsViewer(page);
+  await openMissionControl(page);
+
+  // The board itself says which mission wants me, so the signal is not locked
+  // inside the inbox. Only the one that names me: the other mission is not
+  // unread for me, and a board where every card is lit says nothing.
+  await expect(missionCard(page, MISSION_ID)).toBeVisible();
+  await expect(cardUnreadDot(page, MISSION_ID)).toHaveCount(1);
+  await expect(cardUnreadDot(page, OTHER_ID)).toHaveCount(0);
+
+  await missionCard(page, MISSION_ID).click();
+  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
+
+  // Reload rather than just closing the panel: it proves the READ CURSOR was
+  // written and persisted, not merely that an open card suppresses its own mark.
+  // Nothing is selected after a reload, so a still-unread mission would light up
+  // again — which is exactly what a per-device cursor must not do once read.
+  await page.reload();
+  await openMissionControl(page);
+  await expect(missionCard(page, MISSION_ID)).toBeVisible();
+  await expect(cardUnreadDot(page, MISSION_ID)).toHaveCount(0);
+});
+
+test("opening a mention row navigates to that mission's chat", async ({
+  page,
+  request,
+}) => {
+  await armMultiplayer(request);
+  await armRoster(request);
+  await seedMissions(request);
+  await signInAsViewer(page);
+  await openMissionControl(page);
+  await mentionsControl(page).click();
+
+  await inboxRows(page).first().click();
+
+  // The same handoff a completion notification performs: the mission's agent
+  // becomes current, its board is showing, and the mission's chat is open. The
+  // composer of an already-open conversation is the proof (the inbox itself has
+  // none), and Mission Control is gone from under us.
+  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
+  await expect(mentionsControl(page)).toHaveCount(0);
+});
+
+test("single player never sees the Mentions mode", async ({
+  page,
+  request,
+}) => {
+  // No capabilities armed: the fake host advertises a single-player deployment,
+  // exactly like the desktop. Even with a mention aggregate on disk the mode is
+  // unreachable, so desktop gains no new chrome whatsoever.
+  await seedMissions(request);
+  await signInAsViewer(page);
+  await openMissionControl(page);
+
+  await expect(page.getByText(MISSION_TITLE)).toBeVisible();
+  await expect(mentionsControl(page)).toHaveCount(0);
+});

--- a/packages/web/e2e/support/identity.ts
+++ b/packages/web/e2e/support/identity.ts
@@ -1,0 +1,178 @@
+/**
+ * Sign the harness in as a known user.
+ *
+ * Most specs run on the identity-OFF vite server (no baked Firebase key), where
+ * `isIdentityConfigured()` is false and the app boots straight to the shell with
+ * a null session. That is enough for almost everything — but NOT for the
+ * surfaces gated on a signed-in identity (`useOrgPeople`, `useUserProfiles`),
+ * which never even fetch when identity is unconfigured, and not for anything
+ * that must know WHO is looking (`currentUserId` → the @mention self-chip).
+ *
+ * So this drives the identity-ON server (`AUTH_WEB_URL`, the same one the
+ * sign-in spec uses) through its REAL passwordless email flow, with only the
+ * NETWORK mocked:
+ *   - the gateway's OTP contract (`/v1/auth/email-otp/{start,verify}`), exactly
+ *     as `sign-in.spec.ts` mocks it, ending in a custom token;
+ *   - GCIP's public REST wire (`identitytoolkit` / `securetoken`), so
+ *     firebase-js-sdk completes `signInWithCustomToken` + `accounts:lookup`
+ *     offline and emits a real SDK session.
+ *
+ * Nothing here reaches into the SDK's storage internals: the app signs in
+ * through its own UI, and the browser ends up holding a genuine Firebase user
+ * whose uid is {@link E2E_VIEWER}`.uid`.
+ */
+
+import { expect, type Page } from "@playwright/test";
+import { AUTH_WEB_URL } from "../config";
+
+/** The signed-in viewer. Its `uid` is what `useSession().uid` resolves to, so a
+ *  spec can arm the same id on the fake host's org roster and assert "me". */
+export const E2E_VIEWER = {
+  uid: "u-self",
+  email: "you@acme.test",
+  displayName: "Ada Lovelace",
+  photoUrl: "https://img.test/ada.png",
+} as const;
+
+/** Any 6 digits: the OTP verify call is mocked, never checked. */
+const OTP_CODE = "424242";
+const REFRESH_TOKEN = "e2e-refresh-token";
+/** GCIP's own TTL for a minted ID token; the JWT below carries the same one. */
+const TOKEN_TTL_S = 3600;
+
+const b64url = (value: unknown): string =>
+  Buffer.from(JSON.stringify(value)).toString("base64url");
+
+/**
+ * An unsigned but structurally real Firebase ID token. The client never
+ * verifies a signature (the gateway does, against Google's JWKS) — it only
+ * DECODES the payload for `sub` / `email` / `exp` (`lib/identity/id-token.ts`),
+ * so a decodable payload is exactly what the app needs.
+ */
+function fakeIdToken(): string {
+  const now = Math.floor(Date.now() / 1000);
+  return [
+    b64url({ alg: "RS256", typ: "JWT", kid: "e2e" }),
+    b64url({
+      sub: E2E_VIEWER.uid,
+      user_id: E2E_VIEWER.uid,
+      email: E2E_VIEWER.email,
+      email_verified: true,
+      name: E2E_VIEWER.displayName,
+      picture: E2E_VIEWER.photoUrl,
+      aud: "gethouston",
+      iss: "https://securetoken.google.com/gethouston",
+      auth_time: now,
+      iat: now,
+      exp: now + TOKEN_TTL_S,
+      firebase: { sign_in_provider: "custom", identities: {} },
+    }),
+    "e2e-signature",
+  ].join(".");
+}
+
+/** Mock every identity network call the sign-in makes. */
+async function mockIdentityBackend(page: Page): Promise<void> {
+  const idToken = fakeIdToken();
+
+  // The gateway's OTP contract (identity/otp.ts): start always succeeds, verify
+  // hands back the custom token firebase then exchanges.
+  await page.route("**/v1/auth/email-otp/start", (route) =>
+    route.fulfill({ status: 204 }),
+  );
+  await page.route("**/v1/auth/email-otp/verify", (route) =>
+    route.fulfill({ status: 200, json: { customToken: "e2e-custom-token" } }),
+  );
+
+  // GCIP REST. An unmocked call is a harness gap, so it fails loudly instead of
+  // escaping to the real Google endpoint.
+  await page.route("**identitytoolkit.googleapis.com/**", (route) => {
+    const url = route.request().url();
+    if (url.includes("accounts:signInWithCustomToken")) {
+      return route.fulfill({
+        json: {
+          idToken,
+          refreshToken: REFRESH_TOKEN,
+          expiresIn: String(TOKEN_TTL_S),
+          localId: E2E_VIEWER.uid,
+          isNewUser: false,
+        },
+      });
+    }
+    if (url.includes("accounts:lookup")) {
+      return route.fulfill({
+        json: {
+          kind: "identitytoolkit#GetAccountInfoResponse",
+          users: [
+            {
+              localId: E2E_VIEWER.uid,
+              email: E2E_VIEWER.email,
+              emailVerified: true,
+              displayName: E2E_VIEWER.displayName,
+              photoUrl: E2E_VIEWER.photoUrl,
+              providerUserInfo: [
+                {
+                  providerId: "password",
+                  federatedId: E2E_VIEWER.email,
+                  email: E2E_VIEWER.email,
+                  displayName: E2E_VIEWER.displayName,
+                  photoUrl: E2E_VIEWER.photoUrl,
+                },
+              ],
+              validSince: "0",
+              createdAt: "0",
+              lastLoginAt: "0",
+            },
+          ],
+        },
+      });
+    }
+    return route.fulfill({
+      status: 500,
+      json: { error: { message: `UNMOCKED_IDENTITY_CALL ${url}` } },
+    });
+  });
+
+  // Proactive token refresh. The minted token lives an hour, so this should
+  // never fire inside a test — it answers correctly if it ever does.
+  await page.route("**securetoken.googleapis.com/**", (route) =>
+    route.fulfill({
+      json: {
+        access_token: idToken,
+        id_token: idToken,
+        refresh_token: REFRESH_TOKEN,
+        expires_in: String(TOKEN_TTL_S),
+        token_type: "Bearer",
+        user_id: E2E_VIEWER.uid,
+        project_id: "gethouston",
+      },
+    }),
+  );
+}
+
+/**
+ * Boot the identity-ON server and sign {@link E2E_VIEWER} in through the app's
+ * own passwordless email screen. Resolves once the shell is on screen.
+ *
+ * Pair it with `test.use({ baseURL: AUTH_WEB_URL })` so every later `goto`,
+ * and the app's own gateway calls, stay on that server.
+ */
+export async function signInAsViewer(page: Page): Promise<void> {
+  await mockIdentityBackend(page);
+  await page.goto(`${AUTH_WEB_URL}/`);
+
+  await page.getByPlaceholder("you@example.com").fill(E2E_VIEWER.email);
+  await page.getByRole("button", { name: "Send code" }).click();
+  // The sixth digit auto-submits (input-otp `onComplete`).
+  await page.locator('input[data-slot="input-otp"]').fill(OTP_CODE);
+
+  // The shell is up once its header actions are (the same anchor chat.spec.ts
+  // uses to open a mission).
+  await expect(page.locator('[data-tour-target="newMission"]')).toBeVisible({
+    timeout: 20_000,
+  });
+}
+
+/** The identity-ON server this helper drives. Re-exported so a spec's
+ *  `test.use({ baseURL })` and this module can never disagree. */
+export { AUTH_WEB_URL };

--- a/packages/web/src/engine-adapter/activities.ts
+++ b/packages/web/src/engine-adapter/activities.ts
@@ -62,6 +62,7 @@ export function activityToConversation(
     // conditionally so single-player entries don't carry undefined keys.
     ...(a.created_by !== undefined && { created_by: a.created_by }),
     ...(a.contributors !== undefined && { contributors: a.contributors }),
+    ...(a.mentioned !== undefined && { mentioned: a.mentioned }),
   };
 }
 

--- a/packages/web/src/engine-adapter/cache-persist.ts
+++ b/packages/web/src/engine-adapter/cache-persist.ts
@@ -32,8 +32,10 @@ export function cachePersistOutput(): FeedOutput {
           feed_type: f.feed_type,
           data: f.data,
           ...(f.ts !== undefined ? { ts: f.ts } : {}),
-          // Multiplayer attribution survives a cold reopen (HOU-943).
+          // Multiplayer attribution survives a cold reopen (HOU-943), and so do
+          // the message's @mention chips (HOU-944).
           ...(f.author !== undefined ? { author: f.author } : {}),
+          ...(f.mentions !== undefined ? { mentions: f.mentions } : {}),
         })),
       );
     },

--- a/packages/web/src/engine-adapter/client/chat-send-mixin.ts
+++ b/packages/web/src/engine-adapter/client/chat-send-mixin.ts
@@ -93,6 +93,7 @@ export function ChatSendMixin<TBase extends BaseCtor>(Base: TBase) {
         wireTurnPin(req),
         req.displayText,
         req.author,
+        req.mentions,
       ).finally(() => {
         // The turn settled (or failed): release anything queued behind it.
         if (req.autoResume) noteAutoResumeEnded(path, req.sessionKey);

--- a/packages/web/src/engine-adapter/client/orgs-mixin.ts
+++ b/packages/web/src/engine-adapter/client/orgs-mixin.ts
@@ -19,6 +19,14 @@ export function OrgsMixin<TBase extends BaseCtor>(Base: TBase) {
       if (!this.ctx.cp) return { profiles: {} };
       return controlPlane.getOrgProfiles(this.ctx.cp, ids);
     }
+    // The active space's co-member directory, backing the composer's @mention
+    // autocomplete (HOU-944). Off-cloud (`this.cp === null`) there is nobody to
+    // mention, so this degrades to an empty list — `@` types plainly and no
+    // popover ever opens — rather than throwing, exactly like `getOrgProfiles`.
+    async getOrgPeople(): Promise<controlPlane.OrgPerson[]> {
+      if (!this.ctx.cp) return [];
+      return controlPlane.getOrgPeople(this.ctx.cp);
+    }
     async addOrgMember(
       email: string,
       role: controlPlane.OrgRole,

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -39,6 +39,7 @@ export type {
   OrgInvite,
   OrgInviteSummary,
   OrgMember,
+  OrgPerson,
   OrgRole,
   OrgSummary,
   OrgsList,

--- a/packages/web/src/engine-adapter/conversation-cache-types.ts
+++ b/packages/web/src/engine-adapter/conversation-cache-types.ts
@@ -27,6 +27,13 @@ export interface CachedFrame {
    * records written before this field existed.
    */
   author?: { userId: string; name?: string };
+  /**
+   * The teammates this `user_message` @mentions (HOU-944), carried so a
+   * cache-painted transcript chips the same names immediately instead of
+   * rendering plain text until the server read lands. Absent when the message
+   * mentioned nobody and on records written before this field existed.
+   */
+  mentions?: { userId: string; name?: string }[];
 }
 
 /** A stored transcript: its frames plus a write stamp (prune order). */

--- a/packages/web/src/engine-adapter/conversation-cache.ts
+++ b/packages/web/src/engine-adapter/conversation-cache.ts
@@ -136,6 +136,7 @@ export async function writeCachedConversation(
         data: f.data,
         ...(f.ts !== undefined ? { ts: f.ts } : {}),
         ...(f.author !== undefined ? { author: f.author } : {}),
+        ...(f.mentions !== undefined ? { mentions: f.mentions } : {}),
       })),
       updatedAt: Date.now(),
     });

--- a/packages/web/src/engine-adapter/cp/orgs.ts
+++ b/packages/web/src/engine-adapter/cp/orgs.ts
@@ -3,6 +3,7 @@ import type {
   AuditEntry,
   ComputeUsage,
   OrgInfo,
+  OrgPerson,
   OrgRole,
   UsageRow,
   UserProfilesResult,
@@ -36,6 +37,27 @@ export async function getOrgProfiles(
     if (err instanceof HoustonEngineError && err.status === 404) {
       return { profiles: {} };
     }
+    throw err;
+  }
+}
+
+/**
+ * The sanitized co-member directory of the active space (the personal space
+ * resolves only the caller), named-first: no emails, no roles. It backs the
+ * composer's @mention autocomplete and the renderer's chips. Degrades to an
+ * empty list on a gateway that predates the route (404) — `@` then just types
+ * plainly and no popover ever opens — so a pre-feature host stays
+ * byte-identical. Mirrors `getOrgProfiles`'s 404 swallow; every other error
+ * throws.
+ */
+export async function getOrgPeople(
+  cfg: ControlPlaneConfig,
+): Promise<OrgPerson[]> {
+  try {
+    const res = await cpFetch(cfg, "/v1/org/people");
+    return ((await res.json()) as { people?: OrgPerson[] }).people ?? [];
+  } catch (err) {
+    if (err instanceof HoustonEngineError && err.status === 404) return [];
     throw err;
   }
 }

--- a/packages/web/src/engine-adapter/send-queue-merge.ts
+++ b/packages/web/src/engine-adapter/send-queue-merge.ts
@@ -1,0 +1,66 @@
+import type {
+  MessageMention,
+  SessionStartRequest,
+} from "../../../../ui/engine-client/src/types";
+
+/**
+ * How N held sends become ONE (see send-queue.ts): the per-field merge rules for
+ * a flush. Every field of the combined request comes from the LAST entry (the
+ * most recent picker state) EXCEPT the three derived here, which must reflect
+ * ALL the merged entries — the combined send says everything the user typed, so
+ * it must also carry everything that text implied.
+ */
+
+/** The fields a flush derives from the whole queue rather than its last entry. */
+export type MergedSendFields = Pick<
+  SessionStartRequest,
+  "prompt" | "displayText" | "mentions"
+>;
+
+/** Trim, drop the empties, and join blank-line-separated — the shape the old
+ *  app-side queue produced. */
+const joinLines = (parts: readonly string[]): string =>
+  parts
+    .map((p) => p.trim())
+    .filter(Boolean)
+    .join("\n\n");
+
+/**
+ * The @mention sidecars of every merged entry, deduped by `userId` and in
+ * first-seen order (HOU-944). The combined prompt contains every entry's text,
+ * so it must carry every entry's mentions: taking only the last entry's (the
+ * rule for the picker overrides) would silently drop a teammate the user named
+ * in an earlier queued line — the one thing a merge must never lose.
+ * `undefined` when no entry mentioned anyone, so an unmentioning flush stays
+ * byte-identical to what it sent before mentions existed.
+ */
+function unionMentions(
+  reqs: readonly SessionStartRequest[],
+): MessageMention[] | undefined {
+  const seen = new Map<string, MessageMention>();
+  for (const r of reqs)
+    for (const m of r.mentions ?? [])
+      if (!seen.has(m.userId)) seen.set(m.userId, m);
+  return seen.size > 0 ? [...seen.values()] : undefined;
+}
+
+/**
+ * Combine the held requests' prompt, bubble text and @mentions.
+ *
+ * The BUBBLE is reconstructed exactly like the prompt so a history reload
+ * matches what the send showed: each entry contributes what its own bubble
+ * showed (`displayText ?? prompt`). It is only carried when at least one entry
+ * hid its prompt behind a `displayText`; otherwise the bubble equals the prompt
+ * and the field stays absent.
+ */
+export function mergeSendFields(
+  reqs: readonly SessionStartRequest[],
+): MergedSendFields {
+  return {
+    prompt: joinLines(reqs.map((r) => r.prompt)),
+    displayText: reqs.some((r) => r.displayText !== undefined)
+      ? joinLines(reqs.map((r) => r.displayText ?? r.prompt))
+      : undefined,
+    mentions: unionMentions(reqs),
+  };
+}

--- a/packages/web/src/engine-adapter/send-queue.ts
+++ b/packages/web/src/engine-adapter/send-queue.ts
@@ -6,6 +6,7 @@ import {
 } from "@houston/sdk";
 import type { SessionStartRequest } from "../../../../ui/engine-client/src/types";
 import { armQueueWatchdog, disarmQueueWatchdog } from "./queue-watchdog";
+import { mergeSendFields } from "./send-queue-merge";
 import { armSettleWatcher, disarmSettleWatcher } from "./settle-watcher";
 import { conversationStore, conversationVm } from "./vm";
 
@@ -171,7 +172,8 @@ export function removeQueuedSend(
  * watcher; a no-op when nothing is queued or another turn already took the
  * conversation over. Prompts are trimmed and joined blank-line-separated (the
  * shape the old app-side queue produced); the LAST entry's overrides win (the
- * most recent picker state).
+ * most recent picker state), except the fields `mergeSendFields` derives from
+ * the whole queue — see send-queue-merge.ts.
  *
  * A held `autoResume` entry is dropped (not sent) when user-typed entries are
  * queued alongside it: their message resumes the conversation by itself, and
@@ -193,19 +195,9 @@ export function flushQueuedSends(
   disarmQueueWatchdog(k);
   publishQueued(agentPath, sessionKey);
   const last = entries[entries.length - 1];
-  const prompt = entries
-    .map((e) => e.req.prompt.trim())
-    .filter(Boolean)
-    .join("\n\n");
-  // Reconstruct the combined BUBBLE the same way as the combined prompt so the
-  // history reload matches: each entry contributes what its own bubble showed
-  // (`displayText ?? prompt`). Only carried when at least one entry hid its
-  // prompt behind a displayText; otherwise the bubble equals the prompt.
-  const displayText = entries.some((e) => e.req.displayText !== undefined)
-    ? entries
-        .map((e) => (e.req.displayText ?? e.req.prompt).trim())
-        .filter(Boolean)
-        .join("\n\n")
-    : undefined;
-  dispatch({ ...last.req, prompt, displayText, queuedPreview: undefined });
+  dispatch({
+    ...last.req,
+    ...mergeSendFields(entries.map((e) => e.req)),
+    queuedPreview: undefined,
+  });
 }

--- a/packages/web/src/engine-adapter/turn-stream.ts
+++ b/packages/web/src/engine-adapter/turn-stream.ts
@@ -4,6 +4,7 @@ import {
   conversationScope,
   type FeedAuthor,
   type FeedFrame,
+  type FeedMention,
   type HistoryWindowVM,
   MultiplexFeedOutput,
   type PendingInteraction,
@@ -115,17 +116,22 @@ export function seedConversationVm(
  * (HOU-943): because the real send SUPPRESSES its own bubble, this push is the
  * only chance this row ever gets to name its sender — without it a warmed-up
  * agent's first message would sit permanently unattributed in a shared thread.
+ * `mentions` rides along for the same reason (HOU-944): this is the only push
+ * that can chip the teammates the message named.
  */
 export function pushPendingUserMessage(
   agentPath: string,
   sessionKey: string,
   text: string,
   author?: FeedAuthor,
+  mentions?: FeedMention[],
 ): void {
   conversationVm.pushFeedItem(agentPath, sessionKey, {
     feed_type: "user_message",
     data: text,
     author,
+    // An empty list means what absence means: nobody was mentioned.
+    mentions: mentions?.length ? mentions : undefined,
   });
 }
 
@@ -142,7 +148,9 @@ export function pushPendingUserMessage(
  * instead of the agent-wide settings (HOU-695) — see `wireTurnPin`. `author` is
  * the acting user in a multiplayer deployment: it stamps the optimistic bubble
  * so a shared conversation names its sender before any server frame lands
- * (HOU-943), and is absent single-player.
+ * (HOU-943), and is absent single-player. `mentions` is that message's @mention
+ * sidecar (HOU-944), which chips the same bubble; the engine still receives
+ * only the plain `@Name` text inside `prompt`.
  */
 export function streamTurn(
   engine: HoustonEngineClient,
@@ -159,6 +167,7 @@ export function streamTurn(
   pin?: TurnWirePin,
   displayText?: string,
   author?: FeedAuthor,
+  mentions?: FeedMention[],
 ): Promise<void> {
   return sdkStreamTurn(
     engine,
@@ -174,6 +183,7 @@ export function streamTurn(
       pin,
       displayText,
       author,
+      mentions,
     },
   );
 }

--- a/packages/web/tests/gateway-404-fallbacks.test.ts
+++ b/packages/web/tests/gateway-404-fallbacks.test.ts
@@ -81,3 +81,48 @@ test("every other agent-configs failure still propagates — never swallowed", a
     "library exploded (engine error 500)",
   );
 });
+
+/**
+ * HOU-944: the @mention roster read has the same degrade posture as
+ * `getOrgProfiles` — a gateway that predates `/v1/org/people` (and a
+ * single-player deployment, which has no control plane at all) simply has
+ * nobody to mention, so `@` types plainly and no popover ever opens. A real
+ * failure still propagates; the roster is not important enough to lie about.
+ */
+
+test("getOrgPeople reads the space roster from /v1/org/people", async () => {
+  const calls = stubFetch(
+    json(200, {
+      people: [
+        { userId: "u1", displayName: "Ada Lovelace", photoUrl: "https://p/1" },
+        { userId: "u2" },
+      ],
+    }),
+  );
+  const client = new HoustonClient({ ...CFG, controlPlane: true });
+
+  await expect(client.getOrgPeople()).resolves.toEqual([
+    { userId: "u1", displayName: "Ada Lovelace", photoUrl: "https://p/1" },
+    { userId: "u2" },
+  ]);
+  expect(calls).toEqual(["https://gateway.example/v1/org/people"]);
+});
+
+test("a 404 on /v1/org/people reads as an empty roster — no toast", async () => {
+  stubFetch(json(404, { error: "not found" }));
+  const client = new HoustonClient({ ...CFG, controlPlane: true });
+
+  await expect(client.getOrgPeople()).resolves.toEqual([]);
+});
+
+test("getOrgPeople is empty off-cloud, and propagates every other failure", async () => {
+  // No control plane: single-player, nobody to mention.
+  const solo = new HoustonClient({ ...CFG });
+  await expect(solo.getOrgPeople()).resolves.toEqual([]);
+
+  stubFetch(json(500, { error: "roster exploded" }));
+  const client = new HoustonClient({ ...CFG, controlPlane: true });
+  await expect(client.getOrgPeople()).rejects.toThrow(
+    "roster exploded (engine error 500)",
+  );
+});

--- a/packages/web/tests/send-queue.test.ts
+++ b/packages/web/tests/send-queue.test.ts
@@ -191,6 +191,52 @@ describe("flushQueuedSends", () => {
   });
 });
 
+describe("merged @mentions (HOU-944)", () => {
+  it("unions every merged entry's mentions, deduped by userId", () => {
+    // The combined prompt contains BOTH lines, so it must carry both lines'
+    // mentions: taking only the last entry's (the rule for picker overrides)
+    // would silently drop the teammate named in the first one.
+    setRunning(true);
+    maybeQueueSend(
+      AGENT,
+      req(key, "@Ada can you confirm?", {
+        mentions: [{ userId: "u_ada", name: "Ada" }],
+      }),
+      dispatch,
+    );
+    maybeQueueSend(
+      AGENT,
+      req(key, "@Bo too, and @Ada again", {
+        mentions: [
+          { userId: "u_bo", name: "Bo" },
+          { userId: "u_ada", name: "Ada" },
+        ],
+      }),
+      dispatch,
+    );
+    setRunning(false);
+
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0]?.prompt).toBe(
+      "@Ada can you confirm?\n\n@Bo too, and @Ada again",
+    );
+    expect(dispatched[0]?.mentions).toEqual([
+      { userId: "u_ada", name: "Ada" },
+      { userId: "u_bo", name: "Bo" },
+    ]);
+  });
+
+  it("leaves a merge of unmentioning sends without mentions", () => {
+    setRunning(true);
+    maybeQueueSend(AGENT, req(key, "Wait"), dispatch);
+    maybeQueueSend(AGENT, req(key, "about cars"), dispatch);
+    setRunning(false);
+
+    // Never `[]`: an unmentioning send stays byte-identical to today's.
+    expect(dispatched[0]?.mentions).toBeUndefined();
+  });
+});
+
 describe("removeQueuedSend", () => {
   it("drops one held send by id and updates the VM", () => {
     setRunning(true);

--- a/ui/agent-schemas/src/activity.schema.json
+++ b/ui/agent-schemas/src/activity.schema.json
@@ -40,6 +40,20 @@
           }
         }
       },
+      "mentioned": {
+        "type": "array",
+        "description": "Teammates @mentioned in this mission's chat, latest per person. Set by Houston, not by the agent.",
+        "items": {
+          "type": "object",
+          "required": ["user_id", "at"],
+          "additionalProperties": false,
+          "properties": {
+            "user_id": { "type": "string" },
+            "at": { "type": "string" },
+            "by": { "type": "string" }
+          }
+        }
+      },
       "pending_interaction": {
         "type": "object",
         "description": "The ordered steps this mission is waiting on the user for, walked one at a time: question steps first (at most 3), then at most one signin step, then connect steps, then approval steps (last, since approving happens after connecting).",

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -1,6 +1,7 @@
 import type {
   ChatPanelProps,
   FeedItem,
+  MessageMention,
   ToolsAndCardsProps,
 } from "@houston-ai/chat";
 import { ChatPanel } from "@houston-ai/chat";
@@ -34,13 +35,21 @@ export interface AIBoardProps {
   onSelect?: (id: string | null) => void;
   onDelete?: (item: KanbanItem) => void;
   onApprove?: (item: KanbanItem) => void;
-  /** Called when user sends the first message in a new conversation. Should return the created activity ID. */
-  onCreateConversation?: (text: string, files: File[]) => Promise<string>;
-  /** Called when user sends a follow-up message in an existing conversation. */
+  /** Called when user sends the first message in a new conversation. Should
+   *  return the created activity ID. `mentions` (HOU-944) are the teammates the
+   *  composer named and whose "@Name" text survived into the sent message. */
+  onCreateConversation?: (
+    text: string,
+    files: File[],
+    mentions?: MessageMention[],
+  ) => Promise<string>;
+  /** Called when user sends a follow-up message in an existing conversation.
+   *  `mentions` as on {@link onCreateConversation}. */
   onSendMessage?: (
     sessionKey: string,
     text: string,
     files: File[],
+    mentions?: MessageMention[],
   ) => Promise<void>;
   /** Feed items keyed by session key (e.g. "activity-{id}"). */
   feedItems?: Record<string, FeedItem[]>;
@@ -167,6 +176,9 @@ export interface AIBoardProps {
     text: string;
     files: File[];
     hasMessages: boolean;
+    /** Teammates the composer named (HOU-944); `[]` when there are none. An
+     *  interceptor that builds its own send must carry these through. */
+    mentions: MessageMention[];
   }) => boolean | Promise<boolean>;
   /** Called when the user renames a card. */
   onRename?: (item: KanbanItem, newTitle: string) => void;
@@ -230,6 +242,16 @@ export interface AIBoardProps {
   /** Sender avatar (teammate face / agent mark) for the sender line. Forwarded
    *  to ChatPanel. */
   renderSenderAvatar?: ChatPanelProps["renderSenderAvatar"];
+  /** Teammates the composer can @mention (HOU-944, the viewer excluded).
+   *  Forwarded to ChatPanel; empty/absent means "@" just types plainly. */
+  mentionPeople?: ChatPanelProps["mentionPeople"];
+  /** The roster an agent reply's "@Name" runs are chipped against (the same
+   *  people INCLUDING the viewer). Forwarded to ChatPanel. */
+  messageMentionPeople?: ChatPanelProps["messageMentionPeople"];
+  /** Avatar for a row in the @mention list. Forwarded to ChatPanel. */
+  renderMentionAvatar?: ChatPanelProps["renderMentionAvatar"];
+  /** Localized labels for the @mention list. Forwarded to ChatPanel. */
+  mentionLabels?: ChatPanelProps["mentionLabels"];
   /** Prop-driven dictation control for the composer mic. Forwarded to
    *  ChatPanel; omit (or ChatPanel's own default) hides the mic entirely. */
   dictation?: ChatPanelProps["dictation"];
@@ -350,6 +372,10 @@ export function AIBoard({
   composerOverrideMode,
   composerLabels,
   currentUserId,
+  mentionPeople,
+  messageMentionPeople,
+  renderMentionAvatar,
+  mentionLabels,
   authorLabels,
   showSenders,
   agentLabel,
@@ -510,7 +536,7 @@ export function AIBoard({
   // Unified send handler: creates conversation on first message, sends follow-ups after
   const sendInFlightRef = useRef(false);
   const handleSend = useCallback(
-    async (text: string, files: File[]) => {
+    async (text: string, files: File[], mentions: MessageMention[]) => {
       // A repeated submit (Enter auto-repeat, double click) that lands while
       // the first send is still creating its conversation has no session key
       // to route to — letting it through would mint a duplicate mission and
@@ -530,6 +556,7 @@ export function AIBoard({
           text,
           files,
           hasMessages: activeFeed.length > 0,
+          mentions,
         });
         if (handled) {
           onDraftChange?.(activeDraftKey, "");
@@ -540,10 +567,10 @@ export function AIBoard({
           // `selectedItem`: a send fired while the created activity is
           // still absent from `items` must go to the existing session,
           // never fall through and create a duplicate conversation.
-          await onSendMessage(activeSessionKey, text, files);
+          await onSendMessage(activeSessionKey, text, files, mentions);
           onDraftChange?.(activeDraftKey, "");
         } else if (newPanelOpen && onCreateConversation) {
-          const activityId = await onCreateConversation(text, files);
+          const activityId = await onCreateConversation(text, files, mentions);
           onDraftChange?.(activeDraftKey, "");
           // Select the new activity so the feed renders. The freshly-created
           // activity may take a while to appear in `items` (the parent
@@ -737,6 +764,10 @@ export function AIBoard({
           showSenders={showSenders}
           agentLabel={agentLabel}
           renderSenderAvatar={renderSenderAvatar}
+          mentionPeople={mentionPeople}
+          messageMentionPeople={messageMentionPeople}
+          renderMentionAvatar={renderMentionAvatar}
+          mentionLabels={mentionLabels}
           conversationMap={conversationMap}
           dictation={dictation}
           afterMessages={renderedAfterMessages}

--- a/ui/board/src/index.ts
+++ b/ui/board/src/index.ts
@@ -1,3 +1,8 @@
+// `MessageMention` rides along because AIBoard's own send/create signatures
+// take it: a consumer typing `onCreateConversation` has to name the type, and
+// reaching past the board into `@houston-ai/chat` for it would be the board
+// leaking its dependency.
+export type { MessageMention } from "@houston-ai/chat";
 export type { AIBoardProps, NewPanelOpener, NewPanelOptions } from "./ai-board";
 export { AIBoard } from "./ai-board";
 export type {

--- a/ui/board/src/kanban-card-unread.ts
+++ b/ui/board/src/kanban-card-unread.ts
@@ -1,0 +1,45 @@
+import type { KanbanItem } from "./types";
+
+/**
+ * The mission card's quiet unread mark: the presentation rule + its tokens,
+ * kept pure so the gate is unit-tested without a DOM (the same split as
+ * `kanban-people-logic.ts`).
+ *
+ * Deliberately the SAME language as the app shell's sidebar unread dot — a
+ * small filled `bg-action` circle, never a count chip — so "there is something
+ * new here for you" reads identically wherever it appears, and never like the
+ * "act now" signal (a card's needs-you status, the sidebar's count badge).
+ */
+
+/** The dot's box. A fixed 12px square keeps the 6px dot optically centred on
+ *  the card's 11px header line; `shrink-0` protects it from the truncating
+ *  agent name beside it. Rendered ONLY when the mark shows, so a card with
+ *  nothing new reserves no rail and its layout is untouched. */
+export const UNREAD_DOT_BOX_CLASS =
+  "ml-1.5 flex size-3 shrink-0 items-center justify-center";
+
+/** The mark itself: a 6px filled circle on the semantic action token, which is
+ *  near-ink in BOTH themes (light `#0d0d0d`, dark `#e5e5e5`) — the quietest
+ *  possible way to be unmissable, and never a decorative colour. */
+export const UNREAD_DOT_CLASS = "size-1.5 rounded-full bg-action";
+
+/**
+ * Does this card paint the unread mark?
+ *
+ * Two gates, both load-bearing:
+ *
+ * - Only an explicit `unread === true`. The prop is optional and a board that
+ *   never computes it (single player, any surface with no per-person read
+ *   state) must render exactly what it rendered before — nothing, not an empty
+ *   rail.
+ * - Never on the card that is currently OPEN in the detail panel. The reader is
+ *   looking at the mission right now, so the mark would be telling them about
+ *   the thing on their screen; it also swallows the flicker between the click
+ *   and the read cursor moving.
+ */
+export function showsUnreadDot(
+  item: Pick<KanbanItem, "unread">,
+  selected: boolean,
+): boolean {
+  return item.unread === true && !selected;
+}

--- a/ui/board/src/kanban-card.tsx
+++ b/ui/board/src/kanban-card.tsx
@@ -7,6 +7,11 @@ import {
 } from "@houston-ai/core";
 import { Check, Pencil, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import {
+  showsUnreadDot,
+  UNREAD_DOT_BOX_CLASS,
+  UNREAD_DOT_CLASS,
+} from "./kanban-card-unread";
 import { KanbanPeople } from "./kanban-people";
 import {
   CARD_PEOPLE_MAX,
@@ -31,6 +36,9 @@ export interface KanbanCardLabels {
   people?: string;
   /** Accessible label for the people overlay's expandable "+N" chip. */
   peopleExpand?: string;
+  /** Accessible label for the quiet unread mark ({@link KanbanItem.unread}).
+   *  The mark is a dot with no text, so this is its only non-visual form. */
+  unread?: string;
 }
 
 const DEFAULT_LABELS: Required<KanbanCardLabels> = {
@@ -43,6 +51,7 @@ const DEFAULT_LABELS: Required<KanbanCardLabels> = {
   selectTooltip: "Select",
   people: "People",
   peopleExpand: "All people",
+  unread: "Unread",
 };
 
 export interface KanbanCardProps {
@@ -284,6 +293,23 @@ export function KanbanCard({
             {item.group && (
               <span className="ml-1.5 text-[11px] text-ink-muted truncate">
                 {item.group}
+              </span>
+            )}
+            {/* Unread mark. Anchored at the END of the header's identity
+                cluster — after the agent name, mirroring the sidebar row where
+                the same dot trails the agent it belongs to. Deliberately NOT in
+                the right-hand cluster (a filled dot among the approve / rename /
+                delete icons would read as a fourth button), and nowhere near the
+                body's bottom-right people stack. Absent = nothing rendered, so
+                a card with nothing new is byte-identical to before. */}
+            {showsUnreadDot(item, selected) && (
+              <span
+                role="img"
+                aria-label={l.unread}
+                title={l.unread}
+                className={UNREAD_DOT_BOX_CLASS}
+              >
+                <span className={UNREAD_DOT_CLASS} />
               </span>
             )}
           </div>

--- a/ui/board/src/types.ts
+++ b/ui/board/src/types.ts
@@ -26,6 +26,11 @@ export interface KanbanItem {
   metadata?: Record<string, unknown>;
   /** Human contributors shown as an avatar face stack on the card. */
   people?: KanbanPerson[];
+  /** Something on this item has moved since the reader last looked at it, so
+   *  the card paints a quiet unread mark. Optional and additive: a consumer
+   *  with no per-person read state (single player) simply never sets it and the
+   *  card renders exactly as before. */
+  unread?: boolean;
 }
 
 /** A matched body fragment shown below a board item during search. `text` is

--- a/ui/board/tests/kanban-card-unread.test.ts
+++ b/ui/board/tests/kanban-card-unread.test.ts
@@ -1,0 +1,46 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  showsUnreadDot,
+  UNREAD_DOT_BOX_CLASS,
+  UNREAD_DOT_CLASS,
+} from "../src/kanban-card-unread.ts";
+
+describe("showsUnreadDot", () => {
+  it("paints the mark for an unread card that is not open", () => {
+    assert.equal(showsUnreadDot({ unread: true }, false), true);
+  });
+
+  it("stays silent while the card is the one open in the panel", () => {
+    // The reader is looking at the mission right now; the mark would be
+    // announcing what is already on screen (and would flicker between the
+    // click and the read cursor moving).
+    assert.equal(showsUnreadDot({ unread: true }, true), false);
+  });
+
+  it("stays silent for a read card", () => {
+    assert.equal(showsUnreadDot({ unread: false }, false), false);
+  });
+
+  it("stays silent when the prop is absent", () => {
+    // The single-player gate: a board that never computes unread renders
+    // exactly what it rendered before this prop existed.
+    assert.equal(showsUnreadDot({}, false), false);
+    assert.equal(showsUnreadDot({ unread: undefined }, false), false);
+  });
+});
+
+describe("unread mark tokens", () => {
+  it("is the semantic action fill, never a raw colour", () => {
+    // Same quiet language as the shell sidebar's UnreadDot: a small filled
+    // `bg-action` circle. `bg-action` is near-ink in BOTH themes, so the mark
+    // needs no theme branch of its own.
+    assert.match(UNREAD_DOT_CLASS, /\bbg-action\b/);
+    assert.match(UNREAD_DOT_CLASS, /\brounded-full\b/);
+    assert.doesNotMatch(UNREAD_DOT_CLASS, /#|rgb|\[/);
+  });
+
+  it("cannot be squeezed by the truncating agent name beside it", () => {
+    assert.match(UNREAD_DOT_BOX_CLASS, /\bshrink-0\b/);
+  });
+});

--- a/ui/chat/src/ai-elements/message.tsx
+++ b/ui/chat/src/ai-elements/message.tsx
@@ -37,9 +37,14 @@ import {
   useMemo,
   useState,
 } from "react";
-import { Streamdown } from "streamdown";
+import { defaultRehypePlugins, Streamdown } from "streamdown";
 import { MarkdownCodeBlock } from "../markdown-code-block";
 import { classifyMarkdownLink } from "../markdown-link";
+import { MentionMarkdownSpan } from "../mention-chip.tsx";
+import type { MentionRehypeOptions } from "../mention-rehype.ts";
+import { mentionRehypePlugin } from "../mention-rehype.ts";
+import type { MentionTarget } from "../mention-spans.ts";
+import { sameMentionTargets } from "../mention-spans.ts";
 
 const MessageAvatarContext = createContext<React.ReactNode | undefined>(
   undefined,
@@ -385,15 +390,42 @@ export type MessageResponseProps = ComponentProps<typeof Streamdown> & {
    * special URL patterns.
    */
   renderLink?: RenderLinkFn;
+  /**
+   * People whose "@Name" occurrences in this message should render as chips
+   * (HOU-944). Empty/absent leaves the markdown pipeline exactly as it was.
+   */
+  mentions?: readonly MentionTarget[];
 };
 
 const streamdownPlugins = { cjk, code, math, mermaid };
 
 export const MessageResponse = memo(
-  ({ className, onOpenLink, renderLink, ...props }: MessageResponseProps) => {
+  ({
+    className,
+    onOpenLink,
+    renderLink,
+    mentions,
+    ...props
+  }: MessageResponseProps) => {
+    // Streamdown REPLACES its own plugin chain when `rehypePlugins` is set, so
+    // the mention pass is appended to the defaults — `raw` → `sanitize` →
+    // `harden` still run, and our spans are minted after them (nothing strips
+    // them). Tuple form: Streamdown keys its compiled-processor cache on the
+    // plugin name plus JSON-stringified options, so the targets must ride in
+    // the options or two messages would share one processor.
+    const rehypePlugins = useMemo(() => {
+      if (!mentions || mentions.length === 0) return undefined;
+      const mentionPass: [typeof mentionRehypePlugin, MentionRehypeOptions] = [
+        mentionRehypePlugin,
+        { targets: mentions },
+      ];
+      return [...Object.values(defaultRehypePlugins), mentionPass];
+    }, [mentions]);
+
     const components = useMemo(() => {
       const sharedComponents = {
         code: MarkdownCodeBlock,
+        span: MentionMarkdownSpan,
       };
       if (!onOpenLink && !renderLink) return sharedComponents;
       const fn = onOpenLink;
@@ -478,6 +510,7 @@ export const MessageResponse = memo(
           )}
           plugins={streamdownPlugins}
           components={components}
+          rehypePlugins={rehypePlugins}
           {...props}
         />
       </ErrorBoundary>
@@ -487,7 +520,11 @@ export const MessageResponse = memo(
     prevProps.children === nextProps.children &&
     nextProps.isAnimating === prevProps.isAnimating &&
     prevProps.onOpenLink === nextProps.onOpenLink &&
-    prevProps.renderLink === nextProps.renderLink,
+    prevProps.renderLink === nextProps.renderLink &&
+    // By VALUE: the row above rebuilds the target list every render, and
+    // comparing by identity here would re-parse every message on every
+    // keystroke.
+    sameMentionTargets(prevProps.mentions, nextProps.mentions),
 );
 
 MessageResponse.displayName = "MessageResponse";

--- a/ui/chat/src/chat-input-form.tsx
+++ b/ui/chat/src/chat-input-form.tsx
@@ -1,0 +1,122 @@
+/**
+ * The composer box itself: header slot, attach button, textarea (or the
+ * dictation waveform that replaces it), and the trailing send/stop controls.
+ *
+ * Split out of `chat-input.tsx` so that file stays the composer's STATE — text,
+ * attachments, mentions, dictation — and this one stays its layout.
+ */
+
+import type {
+  ChangeEventHandler,
+  ClipboardEventHandler,
+  KeyboardEventHandler,
+  ReactEventHandler,
+  ReactNode,
+} from "react";
+import type { PromptInputMessage } from "./ai-elements/prompt-input";
+import {
+  PromptInput,
+  PromptInputBody,
+  PromptInputHeader,
+  PromptInputTextarea,
+} from "./ai-elements/prompt-input";
+import { ComposerTrailing } from "./attachment-chip";
+import { ChatInputAttachButton } from "./chat-input-attachments";
+import type { ChatInputProps, InputStatus } from "./chat-input-types";
+import type { DictationControl } from "./dictation-types";
+import { DictationWaveform } from "./dictation-waveform";
+
+export interface ChatInputFormProps {
+  text: string;
+  placeholder: string;
+  status: InputStatus;
+  hasContent: boolean;
+  disabled: boolean;
+  header?: ReactNode;
+  attachMenu?: ChatInputProps["attachMenu"];
+  dictation?: DictationControl;
+  /** The waveform replaces the textarea while dictation is live. */
+  dictating: boolean;
+  onSubmit: (message: PromptInputMessage) => void | Promise<void>;
+  onOpenFilePicker: () => void;
+  onOpenFolderPicker: () => void;
+  onTextChange: ChangeEventHandler<HTMLTextAreaElement>;
+  onKeyDown: KeyboardEventHandler<HTMLTextAreaElement>;
+  onPaste: ClipboardEventHandler<HTMLTextAreaElement>;
+  /** Caret moved (arrow keys, click): re-reads the active "@query". */
+  onSelect: ReactEventHandler<HTMLTextAreaElement>;
+  onStop?: () => void;
+  /** Combobox wiring for the @mention list (HOU-944). Focus never leaves the
+   *  textarea, so IT is the combobox and the list is what it controls; absent
+   *  while no list is open, which reverts the textarea to a plain one. */
+  mentionCombobox?: MentionComboboxAria;
+}
+
+/** The ARIA a focused textarea needs to announce an open, navigable list. */
+export interface MentionComboboxAria {
+  "aria-controls": string;
+  "aria-activedescendant"?: string;
+}
+
+export function ChatInputForm({
+  text,
+  placeholder,
+  status,
+  hasContent,
+  disabled,
+  header,
+  attachMenu,
+  dictation,
+  dictating,
+  onSubmit,
+  onOpenFilePicker,
+  onOpenFolderPicker,
+  onTextChange,
+  onKeyDown,
+  onPaste,
+  onSelect,
+  onStop,
+  mentionCombobox,
+}: ChatInputFormProps) {
+  return (
+    <PromptInput onSubmit={onSubmit}>
+      {header && (
+        <PromptInputHeader className="pb-1">{header}</PromptInputHeader>
+      )}
+
+      <ChatInputAttachButton
+        attachMenu={attachMenu}
+        disabled={disabled}
+        onOpenFilePicker={onOpenFilePicker}
+        onOpenFolderPicker={onOpenFolderPicker}
+      />
+
+      <PromptInputBody>
+        {dictating && dictation ? (
+          <DictationWaveform control={dictation} />
+        ) : (
+          <PromptInputTextarea
+            {...mentionCombobox}
+            aria-expanded={mentionCombobox ? true : undefined}
+            disabled={disabled}
+            onChange={onTextChange}
+            onKeyDown={onKeyDown}
+            onPaste={onPaste}
+            onSelect={onSelect}
+            placeholder={placeholder}
+            role={mentionCombobox ? "combobox" : undefined}
+            value={text}
+          />
+        )}
+      </PromptInputBody>
+
+      <ComposerTrailing
+        dictation={dictation}
+        disabled={disabled}
+        hasContent={hasContent}
+        onStop={onStop}
+        status={status}
+      />
+    </PromptInput>
+  );
+}

--- a/ui/chat/src/chat-input-mentions.tsx
+++ b/ui/chat/src/chat-input-mentions.tsx
@@ -1,0 +1,121 @@
+/**
+ * The @mention autocomplete surface (HOU-944): a solid, unanimated list of
+ * teammates anchored above the composer while the caret sits in an "@query".
+ *
+ * Focus never leaves the textarea — the user keeps typing while the list
+ * filters — so the popover suppresses Radix's open/close autofocus, and the
+ * TEXTAREA carries the combobox semantics (`role`, `aria-expanded`,
+ * `aria-controls`, `aria-activedescendant`) that point a screen reader at the
+ * rows here. That is why the list is plain markup rather than cmdk: cmdk mints
+ * its own element ids and writes them AFTER the caller's, so the textarea
+ * could never name the option a reader is on. Rows carry `data-mention-option`
+ * and the container `data-mention-popover` as stable test hooks.
+ */
+
+import { Popover, PopoverAnchor, PopoverContent } from "@houston-ai/core";
+import type { ReactNode } from "react";
+import { useRef } from "react";
+import type { MentionPerson } from "./types";
+
+export interface ChatInputMentionsProps {
+  open: boolean;
+  people: readonly MentionPerson[];
+  /** Index into `people` of the highlighted row. */
+  highlighted: number;
+  onHighlight: (index: number) => void;
+  onSelect: (person: MentionPerson) => void;
+  /** Called when the surface asks to close (Escape, outside click). */
+  onDismiss: () => void;
+  renderAvatar?: (person: MentionPerson) => ReactNode;
+  listAriaLabel?: string;
+  /** DOM id of the listbox, so the textarea can `aria-controls` it. */
+  listId: string;
+  /** DOM id for the row at `index`; the textarea points `aria-activedescendant`
+   *  at the highlighted one. */
+  optionId: (index: number) => string;
+  /** The composer the list anchors to. */
+  children: ReactNode;
+}
+
+/** Same surface as a shadcn `CommandItem`, minus cmdk's id ownership. */
+const ROW_CLASS =
+  "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden data-[selected=true]:bg-hover data-[selected=true]:text-hover-text [&_svg]:pointer-events-none [&_svg]:shrink-0";
+
+export function ChatInputMentions({
+  open,
+  people,
+  highlighted,
+  onHighlight,
+  onSelect,
+  onDismiss,
+  renderAvatar,
+  listAriaLabel = "Mention a teammate",
+  listId,
+  optionId,
+  children,
+}: ChatInputMentionsProps) {
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+
+  return (
+    <Popover
+      onOpenChange={(next) => {
+        if (!next) onDismiss();
+      }}
+      open={open}
+    >
+      <PopoverAnchor asChild>
+        <div ref={anchorRef}>{children}</div>
+      </PopoverAnchor>
+      <PopoverContent
+        align="start"
+        // A keyboard-driven list opens instantly (DESIGN.md), and focus must
+        // stay in the textarea so typing keeps filtering it.
+        className="w-72 max-w-[min(20rem,90vw)] p-1 data-[state=closed]:animate-none data-[state=open]:animate-none"
+        data-mention-popover=""
+        onCloseAutoFocus={(event) => event.preventDefault()}
+        // Focus legitimately lives OUTSIDE this layer (in the textarea the
+        // user keeps typing into), so a focus-outside must never dismiss it.
+        onFocusOutside={(event) => event.preventDefault()}
+        // Neither may a pointer-down on the ANCHOR: clicking into the very
+        // "@query" the list is offering for is not "the user went elsewhere",
+        // and treating it as a dismissal killed the list for the rest of the
+        // token. Everywhere else outside still closes it.
+        onInteractOutside={(event) => {
+          const target = event.detail.originalEvent.target;
+          if (target instanceof Node && anchorRef.current?.contains(target)) {
+            event.preventDefault();
+          }
+        }}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        side="top"
+        sideOffset={8}
+      >
+        <div
+          aria-label={listAriaLabel}
+          className="max-h-64 scroll-py-1 overflow-x-hidden overflow-y-auto"
+          id={listId}
+          role="listbox"
+        >
+          {people.map((person, index) => (
+            // biome-ignore lint/a11y/useKeyWithClickEvents: the keyboard path is the combobox's, not the row's — Arrow/Enter/Tab/Escape are handled on the textarea that owns focus (`mention-keys.ts`), which is exactly what the pattern prescribes.
+            // biome-ignore lint/a11y/useFocusableInteractive: same reason — under aria-activedescendant the option is referenced by id from the focused textarea and must never take focus itself.
+            <div
+              aria-selected={index === highlighted}
+              className={ROW_CLASS}
+              data-mention-option={person.userId}
+              data-selected={index === highlighted ? "true" : undefined}
+              id={optionId(index)}
+              key={person.userId}
+              onClick={() => onSelect(person)}
+              onPointerMove={() => onHighlight(index)}
+              role="option"
+            >
+              {renderAvatar?.(person)}
+              <span className="min-w-0 truncate">{person.name}</span>
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/ui/chat/src/chat-input-types.ts
+++ b/ui/chat/src/chat-input-types.ts
@@ -9,6 +9,7 @@ import type {
   QueuedChatMessage,
   QueuedMessageLabels,
 } from "./queued-message-list";
+import type { MentionPerson, MessageMention } from "./types";
 
 export type InputStatus = "ready" | "streaming" | "submitted";
 
@@ -21,8 +22,14 @@ export interface ChatInputProps {
   attachments?: File[];
   /** Required if `attachments` is provided. */
   onAttachmentsChange?: (files: File[]) => void;
-  /** Called on submit. The current text + files are always passed for convenience. */
-  onSend: (text: string, files: File[]) => void | Promise<void>;
+  /** Called on submit. The current text + files are always passed for
+   *  convenience; `mentions` (HOU-944) are the pending @mentions whose "@Name"
+   *  text survived into the sent message, `[]` when there are none. */
+  onSend: (
+    text: string,
+    files: File[],
+    mentions: MessageMention[],
+  ) => void | Promise<void>;
   onStop?: () => void;
   status?: InputStatus;
   placeholder?: string;
@@ -59,4 +66,21 @@ export interface ChatInputProps {
   labels?: ChatComposerLabels;
   /** Prop-driven dictation affordance. Omit to hide the mic (web build). */
   dictation?: DictationControl;
+  /** Teammates the user can @mention (HOU-944), in the order they should be
+   *  offered. Empty or absent means the popover NEVER opens and "@" types
+   *  plainly, which is what single-player, a personal space, and a gateway
+   *  too old to serve the roster all look like. */
+  mentionPeople?: readonly MentionPerson[];
+  /** Avatar for a row in the mention list, so a teammate keeps their own
+   *  face/tone. Omit to show the name alone. */
+  renderMentionAvatar?: (person: MentionPerson) => ReactNode;
+  /** Localized labels for the mention list. English defaults live here; the
+   *  app passes `t()` results in (the library stays i18n-agnostic). */
+  mentionLabels?: { listAriaLabel?: string };
+  /** Opaque identity of the draft this composer is writing — the consumer's
+   *  session/conversation key. Composer TEXT is already parked per draft by
+   *  the app; the @mention picks recorded beside it are parked under the same
+   *  key, so switching conversations never sends one chat's picks with
+   *  another's words. Omit on a composer that never switches. */
+  draftKey?: string;
 }

--- a/ui/chat/src/chat-input.tsx
+++ b/ui/chat/src/chat-input.tsx
@@ -1,23 +1,16 @@
 import { cn } from "@houston-ai/core";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import type { PromptInputMessage } from "./ai-elements/prompt-input";
-import {
-  PromptInput,
-  PromptInputBody,
-  PromptInputHeader,
-  PromptInputTextarea,
-} from "./ai-elements/prompt-input";
-import { ComposerTrailing } from "./attachment-chip";
-import {
-  ChatInputAttachButton,
-  ChatInputAttachments,
-} from "./chat-input-attachments";
+import { ChatInputAttachments } from "./chat-input-attachments";
+import { ChatInputForm } from "./chat-input-form.tsx";
+import { ChatInputMentions } from "./chat-input-mentions.tsx";
 import type { ChatInputProps } from "./chat-input-types";
 import { isDictationActive, isDictationCapturing } from "./dictation-types";
-import { DictationWaveform } from "./dictation-waveform";
 import { QueuedMessageList } from "./queued-message-list";
 import { useComposerAttachments } from "./use-composer-attachments";
+import { useDictationHotkeys } from "./use-dictation-hotkeys.ts";
 import { useControllable } from "./use-file-drop-zone";
+import { useMentionCombobox } from "./use-mention-combobox.ts";
 
 export type { ChatInputProps } from "./chat-input-types";
 export type { ChatComposerLabels } from "./chat-panel-types";
@@ -44,6 +37,10 @@ export function ChatInput({
   disabled = false,
   labels,
   dictation,
+  mentionPeople,
+  renderMentionAvatar,
+  mentionLabels,
+  draftKey,
 }: ChatInputProps) {
   const [text, setText] = useControllable(value, onValueChange, "");
   const isTextControlled = value !== undefined;
@@ -66,14 +63,34 @@ export function ChatInput({
     onNotice,
     labels,
   });
+  const mentions = useMentionCombobox({
+    people: mentionPeople,
+    enabled: !disabled && !isDictationCapturing(dictation),
+    draftKey,
+    onTextChange: setText,
+  });
 
   const handleTextChange = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>) => setText(e.target.value),
-    [setText],
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setText(e.target.value);
+      mentions.refresh(e.target);
+    },
+    [setText, mentions.refresh],
+  );
+
+  const handleCaretMove = useCallback(
+    (e: React.SyntheticEvent<HTMLTextAreaElement>) =>
+      mentions.refresh(e.currentTarget),
+    [mentions.refresh],
   );
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // The mention list gets first say: every key it consumes is
+      // `preventDefault()`ed, which is what makes PromptInputTextarea bail
+      // before its own Enter handling and keeps Escape off the stop handler.
+      mentions.onKeyDown(e);
+      if (e.defaultPrevented) return;
       // Escape discards an in-flight capture first, before any streaming stop.
       if (e.key === "Escape" && isDictationCapturing(dictation)) {
         e.preventDefault();
@@ -85,7 +102,7 @@ export function ChatInput({
         onStop();
       }
     },
-    [status, onStop, dictation],
+    [status, onStop, dictation, mentions.onKeyDown],
   );
 
   const handleSubmit = useCallback(
@@ -93,7 +110,12 @@ export function ChatInput({
       if (disabled) return;
       const trimmed = message.text?.trim();
       if (!trimmed && files.length === 0 && !canSendEmpty) return;
-      await onSend(trimmed ?? "", files);
+      const sent = trimmed ?? "";
+      // Snapshot, never consume: a rejected `onSend` keeps the text in the
+      // composer, so it has to keep the mentions that text refers to. Text and
+      // mentions clear together, once the send actually landed.
+      await onSend(sent, files, mentions.mentionsFor(sent));
+      mentions.commitSent();
       // In uncontrolled mode, clear our own state. In controlled mode the
       // parent is responsible for clearing.
       if (!isTextControlled) setText("");
@@ -108,34 +130,14 @@ export function ChatInput({
       isFilesControlled,
       setText,
       setFiles,
+      mentions.mentionsFor,
+      mentions.commitSent,
     ],
   );
 
   const hasContent = canSendEmpty || text.trim().length > 0 || files.length > 0;
   const dictating = isDictationActive(dictation);
-
-  // While capturing, the textarea (which owns the keydown handler) is replaced
-  // by the waveform, so Escape/Enter have no focus target. Listen globally for
-  // the duration of the capture instead: Escape discards, Enter (no shift)
-  // accepts — the same as clicking ✓ (stop + transcribe). During transcribing
-  // this effect is inactive (not a capturing state), so Enter does nothing.
-  const capturing = isDictationCapturing(dictation);
-  useEffect(() => {
-    if (!capturing) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        dictation?.onCancel();
-        return;
-      }
-      if (e.key === "Enter" && !e.shiftKey) {
-        e.preventDefault();
-        dictation?.onStop();
-      }
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [capturing, dictation]);
+  useDictationHotkeys(dictation);
 
   return (
     <div className="shrink-0 px-4 pb-6 pt-2">
@@ -161,41 +163,32 @@ export function ChatInput({
           labels={queuedLabels}
         />
 
-        <PromptInput onSubmit={handleSubmit}>
-          {header && (
-            <PromptInputHeader className="pb-1">{header}</PromptInputHeader>
-          )}
-
-          <ChatInputAttachButton
-            onOpenFilePicker={openFilePicker}
-            onOpenFolderPicker={openFolderPicker}
+        <ChatInputMentions
+          {...mentions.list}
+          listAriaLabel={mentionLabels?.listAriaLabel}
+          renderAvatar={renderMentionAvatar}
+        >
+          <ChatInputForm
             attachMenu={attachMenu}
-            disabled={disabled}
-          />
-
-          <PromptInputBody>
-            {dictating && dictation ? (
-              <DictationWaveform control={dictation} />
-            ) : (
-              <PromptInputTextarea
-                onChange={handleTextChange}
-                onKeyDown={handleKeyDown}
-                onPaste={handlePaste}
-                value={text}
-                placeholder={placeholder}
-                disabled={disabled}
-              />
-            )}
-          </PromptInputBody>
-
-          <ComposerTrailing
-            status={status}
-            hasContent={hasContent}
-            onStop={onStop}
+            dictating={dictating}
             dictation={dictation}
             disabled={disabled}
+            hasContent={hasContent}
+            header={header}
+            mentionCombobox={mentions.combobox}
+            onKeyDown={handleKeyDown}
+            onOpenFilePicker={openFilePicker}
+            onOpenFolderPicker={openFolderPicker}
+            onPaste={handlePaste}
+            onSelect={handleCaretMove}
+            onStop={onStop}
+            onSubmit={handleSubmit}
+            onTextChange={handleTextChange}
+            placeholder={placeholder}
+            status={status}
+            text={text}
           />
-        </PromptInput>
+        </ChatInputMentions>
 
         {footer && (
           <div className="flex items-center px-2.5 pt-1">{footer}</div>

--- a/ui/chat/src/chat-message-body.tsx
+++ b/ui/chat/src/chat-message-body.tsx
@@ -8,6 +8,8 @@ import type { ReactNode } from "react";
 import type { RenderLinkProps } from "./ai-elements/message";
 import { MessageContent, MessageResponse } from "./ai-elements/message";
 import type { ChatMessage } from "./feed-to-messages";
+import type { MentionTarget } from "./mention-spans.ts";
+import type { MentionPerson } from "./types";
 
 interface ChatMessageBodyProps {
   message: ChatMessage;
@@ -19,6 +21,43 @@ interface ChatMessageBodyProps {
   renderUserMessage?: (msg: ChatMessage) => ReactNode | undefined;
   onOpenLink?: (url: string) => void;
   renderLink?: (props: RenderLinkProps) => ReactNode;
+  /** The space roster an ASSISTANT message's "@Name" runs are matched against
+   *  (HOU-944). A user message uses its own recorded mentions instead. */
+  mentionPeople?: readonly MentionPerson[];
+  /** The signed-in viewer, so a mention of them renders emphasized. */
+  currentUserId?: string;
+}
+
+/**
+ * Who this message may chip. A USER turn carries its own structured mentions
+ * (recorded at send time, so a later rename still chips the original text); an
+ * ASSISTANT turn mentions people in plain prose, so it matches against the
+ * roster the consumer supplied.
+ */
+function mentionTargets({
+  message,
+  mentionPeople,
+  currentUserId,
+}: Pick<ChatMessageBodyProps, "message" | "mentionPeople" | "currentUserId">):
+  | MentionTarget[]
+  | undefined {
+  if (message.from === "user") {
+    const named = (message.mentions ?? []).filter(
+      (mention) => typeof mention.name === "string" && mention.name.length > 0,
+    );
+    if (named.length === 0) return undefined;
+    return named.map((mention) => ({
+      name: mention.name as string,
+      userId: mention.userId,
+      isSelf: mention.userId === currentUserId,
+    }));
+  }
+  if (message.from !== "assistant" || !mentionPeople?.length) return undefined;
+  return mentionPeople.map((person) => ({
+    name: person.name,
+    userId: person.userId,
+    isSelf: person.userId === currentUserId,
+  }));
 }
 
 export function ChatMessageBody({
@@ -28,6 +67,8 @@ export function ChatMessageBody({
   renderUserMessage,
   onOpenLink,
   renderLink,
+  mentionPeople,
+  currentUserId,
 }: ChatMessageBodyProps) {
   if (!message.content) return null;
   if (message.from === "user" && renderUserMessage) {
@@ -43,6 +84,7 @@ export function ChatMessageBody({
     <MessageContent>
       <MessageResponse
         isAnimating={streaming}
+        mentions={mentionTargets({ message, mentionPeople, currentUserId })}
         onOpenLink={onOpenLink}
         renderLink={renderLink}
       >

--- a/ui/chat/src/chat-message-item.tsx
+++ b/ui/chat/src/chat-message-item.tsx
@@ -7,6 +7,7 @@ import type { ChatAuthorLabels } from "./author-label";
 import { authorLabelFor, senderNameFor } from "./author-label";
 import type { ToolsAndCardsProps } from "./chat-helpers";
 import { ChatMessageBody } from "./chat-message-body";
+import type { ChatMessagesProps } from "./chat-messages-types";
 import type { ChatProcessLabels } from "./chat-process-block";
 import type { ChatDisplayItem } from "./chat-process-groups";
 import { ChatProcessMessage } from "./chat-process-message";
@@ -50,6 +51,8 @@ interface ChatMessageItemProps {
   renderLink?: (props: RenderLinkProps) => ReactNode;
   currentUserId?: string;
   authorLabels?: ChatAuthorLabels;
+  /** Roster an assistant reply's "@Name" runs are chipped against (HOU-944). */
+  mentionPeople?: ChatMessagesProps["mentionPeople"];
 }
 
 export function ChatMessageItem({
@@ -77,6 +80,7 @@ export function ChatMessageItem({
   renderLink,
   currentUserId,
   authorLabels,
+  mentionPeople,
 }: ChatMessageItemProps) {
   if (item.kind === "process") {
     return (
@@ -157,6 +161,8 @@ export function ChatMessageItem({
           />
         ) : null}
         <ChatMessageBody
+          currentUserId={currentUserId}
+          mentionPeople={mentionPeople}
           message={message}
           onOpenLink={onOpenLink}
           renderLink={renderLink}

--- a/ui/chat/src/chat-messages-types.ts
+++ b/ui/chat/src/chat-messages-types.ts
@@ -8,6 +8,7 @@ import type { ConversationMapLabels } from "./conversation-map";
 import type { ConversationMoment } from "./conversation-map-model";
 import type { ChatMessage } from "./feed-to-messages";
 import type { TurnEndSummary } from "./turn-tools";
+import type { MentionPerson } from "./types";
 
 export interface ChatMessagesProps {
   messages: ChatMessage[];
@@ -79,6 +80,13 @@ export interface ChatMessagesProps {
    *  sender line. Return `undefined` to render the name alone. Distinct from
    *  `renderMessageAvatar`, which badges the bubble itself (channel logos). */
   renderSenderAvatar?: (msg: ChatMessage) => ReactNode | undefined;
+  /**
+   * Multiplayer only (HOU-944): the space roster an ASSISTANT reply's "@Name"
+   * runs are chipped against. A user message chips off its OWN recorded
+   * mentions, so it needs no roster. Include the viewer, so "@Julian" in an
+   * agent reply still chips for Julian. Empty/absent renders no chips.
+   */
+  mentionPeople?: readonly MentionPerson[];
   /** Props-only configuration for the optional Conversation Map. */
   conversationMap?: {
     labels?: ConversationMapLabels;

--- a/ui/chat/src/chat-messages.tsx
+++ b/ui/chat/src/chat-messages.tsx
@@ -50,6 +50,7 @@ export function ChatMessages({
   showSenders,
   agentLabel,
   renderSenderAvatar,
+  mentionPeople,
   conversationMap,
 }: ChatMessagesProps) {
   const [highlightedMessageKey, setHighlightedMessageKey] = useState<
@@ -117,6 +118,7 @@ export function ChatMessages({
             isSpecialTool={isSpecialTool}
             item={item}
             key={item.kind === "process" ? item.key : item.message.key}
+            mentionPeople={mentionPeople}
             messageCount={messages.length}
             onOpenLink={onOpenLink}
             processLabels={processLabels}

--- a/ui/chat/src/chat-panel-types.ts
+++ b/ui/chat/src/chat-panel-types.ts
@@ -7,7 +7,7 @@ import type {
   QueuedChatMessage,
   QueuedMessageLabels,
 } from "./queued-message-list";
-import type { FeedItem } from "./types";
+import type { FeedItem, MentionPerson, MessageMention } from "./types";
 
 export type ChatStatus = "ready" | "streaming" | "submitted";
 
@@ -46,7 +46,13 @@ export interface ChatComposerLabels {
 export interface ChatPanelProps {
   sessionKey: string;
   feedItems: FeedItem[];
-  onSend: (text: string, files: File[]) => void | Promise<void>;
+  /** Submit. `mentions` (HOU-944) are the composer's pending @mentions whose
+   *  "@Name" text survived into the sent message; `[]` when there are none. */
+  onSend: (
+    text: string,
+    files: File[],
+    mentions: MessageMention[],
+  ) => void | Promise<void>;
   onStop?: () => void;
   onBack?: () => void;
   isLoading: boolean;
@@ -132,6 +138,18 @@ export interface ChatPanelProps {
   agentLabel?: ChatMessagesProps["agentLabel"];
   /** Sender avatar (teammate face / agent mark) for the sender line. */
   renderSenderAvatar?: ChatMessagesProps["renderSenderAvatar"];
+  /** Teammates the COMPOSER can @mention (the viewer excluded — you do not
+   *  @mention yourself). Empty/absent (single-player, a personal space, an
+   *  older gateway) means "@" just types plainly and no popover ever opens. */
+  mentionPeople?: readonly MentionPerson[];
+  /** Roster an ASSISTANT reply's "@Name" runs are chipped against — the same
+   *  people INCLUDING the viewer, so "@Julian" in an agent reply chips for
+   *  Julian. Defaults to `mentionPeople` when omitted. */
+  messageMentionPeople?: ChatMessagesProps["mentionPeople"];
+  /** Avatar for a row in the @mention popover. See `ChatInputProps`. */
+  renderMentionAvatar?: (person: MentionPerson) => ReactNode;
+  /** Localized labels for the @mention popover. English defaults. */
+  mentionLabels?: { listAriaLabel?: string };
   /** Props-only configuration for the optional Conversation Map. */
   conversationMap?: ChatMessagesProps["conversationMap"];
 }

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -13,6 +13,7 @@ import { ChatMessages } from "./chat-messages";
 import type { ChatPanelProps } from "./chat-panel-types";
 import { deriveStatus } from "./chat-status";
 import { ChatThinkingIndicator } from "./chat-thinking-indicator";
+import type { MessageMention } from "./types";
 import {
   DEFAULT_TOO_MANY_FILES_NOTICE,
   useAttachmentIntake,
@@ -75,6 +76,10 @@ export function ChatPanel({
   showSenders,
   agentLabel,
   renderSenderAvatar,
+  mentionPeople,
+  messageMentionPeople,
+  renderMentionAvatar,
+  mentionLabels,
   conversationMap,
 }: ChatPanelProps) {
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -131,8 +136,8 @@ export function ChatPanel({
   // Wrap onSend so we clear internally-managed attachments after a send;
   // in controlled mode the parent is responsible for clearing.
   const handleSend = useCallback(
-    async (text: string, sent: File[]) => {
-      await onSend(text, sent);
+    async (text: string, sent: File[], mentions: MessageMention[]) => {
+      await onSend(text, sent, mentions);
       if (!isFilesControlled) setFiles([]);
     },
     [onSend, isFilesControlled, setFiles],
@@ -198,6 +203,7 @@ export function ChatPanel({
           showSenders={showSenders}
           agentLabel={agentLabel}
           renderSenderAvatar={renderSenderAvatar}
+          mentionPeople={messageMentionPeople ?? mentionPeople}
           conversationMap={conversationMap}
         />
       ) : (
@@ -242,6 +248,14 @@ export function ChatPanel({
           disabled={composerDisabled}
           labels={composerLabels}
           dictation={dictation}
+          mentionPeople={mentionPeople}
+          renderMentionAvatar={renderMentionAvatar}
+          mentionLabels={mentionLabels}
+          // The conversation on screen IS the draft: its @mention picks are
+          // parked under this key, exactly like its text is in the app's
+          // draft store, so a switch never crosses one chat's picks with
+          // another's words.
+          draftKey={sessionKey}
         />
       )}
     </div>

--- a/ui/chat/src/feed-to-messages.ts
+++ b/ui/chat/src/feed-to-messages.ts
@@ -9,6 +9,7 @@
 import type {
   FeedItem,
   MessageAuthor,
+  MessageMention,
   ProviderError,
   ToolRuntimeErrorEntry,
 } from "./types";
@@ -63,6 +64,12 @@ export interface ChatMessage {
    * authors — see `distinctAuthorCount`.
    */
   author?: MessageAuthor;
+  /**
+   * Multiplayer only (HOU-944): the teammates this USER message @mentioned.
+   * The renderer chips each "@Name" run it still finds in `content`; absent
+   * when the message mentioned nobody.
+   */
+  mentions?: MessageMention[];
   /**
    * Set on `from: "system"` messages that mark a context-compaction boundary.
    * The renderer shows a subtle divider instead of plain system text.
@@ -157,6 +164,7 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
           fileChanges: [],
           source,
           author: item.author,
+          mentions: item.mentions,
         });
         break;
       }

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -306,6 +306,17 @@ export {
   type InteractionModalProps,
   InteractionModalTitle,
 } from "./interaction-modal";
+// === @mentions (HOU-944) ===
+// A teammate named in a chat message. The composer offers `mentionPeople` and
+// ships the structured `mentions[]` sidecar; the renderer turns each surviving
+// "@Name" run into a chip. All props-only and i18n-agnostic.
+//
+// The only surface a consumer needs is the two data shapes, `MentionPerson`
+// and `MessageMention` (exported with the rest of the types below) plus the
+// `ChatPanel` props that take them. The matcher, the composer state, the mask
+// and the chip are INTERNAL: they are one feature's moving parts, and the
+// tests reach them by module path rather than through the package door.
+//
 // Clean, human-readable preview of a persisted user-message body: decodes the
 // Skill / attachment markers so cards and lists never show the raw marker.
 export { messagePreviewText } from "./message-preview";
@@ -328,7 +339,9 @@ export type { TurnEndSummary } from "./turn-tools";
 export type {
   AuthFailureCause,
   FeedItem,
+  MentionPerson,
   MessageAuthor,
+  MessageMention,
   ModelUnavailableReason,
   ProviderError,
   QuotaScope,

--- a/ui/chat/src/mention-chip.tsx
+++ b/ui/chat/src/mention-chip.tsx
@@ -1,0 +1,85 @@
+/**
+ * The rendered form of an "@Name" run in a chat message (HOU-944): a soft,
+ * non-interactive chip. A mention of the CURRENT viewer is emphasized with the
+ * highlight wash so "the agent is asking ME" reads at a glance.
+ *
+ * Two surfaces to satisfy: assistant prose (on the chat canvas) and the user
+ * bubble, whose fill is near-ink in light mode and a light wash in dark. The
+ * `group-[.is-user]:` scoping mirrors what the autolink `<a>` in
+ * `ai-elements/message.tsx` already does.
+ */
+
+import { cn } from "@houston-ai/core";
+import type { ComponentProps, ReactNode } from "react";
+import { MENTION_NAME_ATTR, MENTION_SELF_ATTR } from "./mention-rehype.ts";
+
+export interface MentionChipProps {
+  /** The name as it should read, WITHOUT the leading "@". */
+  name: string;
+  /** The mention points at the signed-in viewer. */
+  isSelf?: boolean;
+  className?: string;
+  children?: ReactNode;
+}
+
+/** Shared shape: a chip radius from the scale, tight spacing-scale padding, and
+ *  the semibold weight that lifts a name out of running prose. */
+const BASE =
+  "rounded-sm px-1 py-0.5 font-semibold [overflow-wrap:anywhere] whitespace-normal";
+
+/** Someone else. Soft chip fill on the canvas; inside the user bubble a light
+ *  wash over the near-ink fill (light) / an ink wash over the light fill
+ *  (dark), so it reads in both. */
+const OTHER =
+  "bg-chip text-chip-text group-[.is-user]:bg-input/20 group-[.is-user]:text-input dark:group-[.is-user]:bg-ink/10 dark:group-[.is-user]:text-ink";
+
+/** The viewer. The highlight wash carries in both themes; inside the light
+ *  user bubble the wash sits over near-ink, so the label flips to the bubble's
+ *  own foreground rather than the highlight ink. */
+const SELF =
+  "bg-highlight text-highlight-text group-[.is-user]:text-input dark:group-[.is-user]:text-highlight-text";
+
+export function MentionChip({
+  name,
+  isSelf = false,
+  className,
+  children,
+}: MentionChipProps) {
+  return (
+    <span
+      data-mention-chip=""
+      data-mention-self={isSelf ? "" : undefined}
+      className={cn(BASE, isSelf ? SELF : OTHER, className)}
+    >
+      {children ?? `@${name}`}
+    </span>
+  );
+}
+
+/** What react-markdown hands a component override alongside the DOM props. */
+type MarkdownNode = { properties?: Record<string, unknown> };
+
+/**
+ * The `components.span` override Streamdown renders every `<span>` through.
+ * Spans minted by `mentionRehypePlugin` become chips; every other span (KaTeX
+ * output, raw HTML the sanitizer kept) passes through untouched.
+ */
+export function MentionMarkdownSpan({
+  node,
+  children,
+  ...rest
+}: ComponentProps<"span"> & { node?: unknown }) {
+  const properties = (node as MarkdownNode | undefined)?.properties;
+  const name = properties?.[MENTION_NAME_ATTR];
+  if (typeof name !== "string") {
+    return <span {...rest}>{children}</span>;
+  }
+  return (
+    <MentionChip
+      isSelf={properties?.[MENTION_SELF_ATTR] !== undefined}
+      name={name}
+    >
+      {children}
+    </MentionChip>
+  );
+}

--- a/ui/chat/src/mention-keys.ts
+++ b/ui/chat/src/mention-keys.ts
@@ -1,0 +1,44 @@
+/**
+ * Which key an OPEN @mention list consumes, and what it means (HOU-944).
+ * Pure, no React — so the rules (above all the IME one) are testable without
+ * a browser.
+ */
+
+export type MentionKeyAction =
+  | { kind: "move"; step: number }
+  | { kind: "dismiss" }
+  | { kind: "accept" };
+
+/** The slice of a keydown the list cares about. */
+export interface MentionKeyEvent {
+  key: string;
+  shiftKey: boolean;
+  /** True while an IME composition is in flight. */
+  isComposing: boolean;
+}
+
+/**
+ * The action `event` triggers on a list of `count` rows, or null to let the
+ * key through untouched.
+ *
+ * MID-COMPOSITION THE LIST TAKES NOTHING. Every key it wants belongs to the
+ * IME candidate window first: Arrow moves through THAT list, Escape cancels
+ * the composition, Enter and Tab commit the reading. Intercepting any of them
+ * makes the composer unusable in Japanese, Chinese or Korean — the user's
+ * candidate selection silently becomes a teammate's name.
+ */
+export function mentionKeyAction(
+  event: MentionKeyEvent,
+  count: number,
+): MentionKeyAction | null {
+  if (count <= 0 || event.isComposing) return null;
+  if (event.key === "ArrowDown") return { kind: "move", step: 1 };
+  // Wrapping backwards, expressed as a forward step, so the caller can stay a
+  // single modulo.
+  if (event.key === "ArrowUp") return { kind: "move", step: count - 1 };
+  if (event.key === "Escape") return { kind: "dismiss" };
+  if (event.key === "Tab") return { kind: "accept" };
+  // Shift+Enter is a newline in the composer, never a pick.
+  if (event.key === "Enter" && !event.shiftKey) return { kind: "accept" };
+  return null;
+}

--- a/ui/chat/src/mention-mask.ts
+++ b/ui/chat/src/mention-mask.ts
@@ -1,0 +1,74 @@
+/**
+ * Blanking the markdown constructs a mention can hide inside (HOU-944).
+ *
+ * The renderer walks the PARSED tree and refuses to chip inside `code`, `pre`
+ * or `a`. The send path only ever sees the raw text, so without this pass an
+ * "@Name" written inside a code span, a fenced block or a link would record a
+ * mention the reader never sees — someone gets notified about a message that
+ * addresses nobody.
+ *
+ * Every masked character is replaced ONE FOR ONE (newlines survive as
+ * themselves), so offsets into the masked string still index the original.
+ * Pure, no React.
+ *
+ * WHAT STILL DIVERGES, honestly. This is a lexical pass, not a markdown
+ * parser, so a few constructs the real renderer treats as verbatim are not
+ * caught: indented (four-space) code blocks, reference-style links
+ * (`[label][ref]`), bare autolinks (`<https://…/@name>`), raw HTML `<code>`
+ * elements, and mentions inside a block quote of a code fence. In each of
+ * those a send may still record a mention the transcript shows as plain text.
+ * The failure is a notification with no chip, never a lost message; widening
+ * the net further means parsing markdown twice, which is the renderer's job.
+ */
+
+/** The stand-in for a masked character. A SPACE, deliberately: the renderer
+ *  parses a code span or a link into a node of its own, so the text right
+ *  after one begins a FRESH text node, where an "@" sits at index 0 and does
+ *  start a mention. Blanking to whitespace reproduces exactly that. */
+const MASK = " ";
+
+/** Fenced code, inline code and inline links, blanked out. */
+export function maskMarkdown(text: string): string {
+  const chars = text.split("");
+  maskFences(text, chars);
+  // Inline constructs are matched against the FENCE-MASKED text so a stray
+  // backtick or bracket inside a code block can never pair with a real one
+  // outside it.
+  maskPattern(chars.join(""), chars, /(`+)[\s\S]*?\1/g);
+  maskPattern(chars.join(""), chars, /!?\[[^\]\n]*\]\([^)\n]*\)/g);
+  return chars.join("");
+}
+
+/** ```/~~~ blocks, opening fence through closing fence. An unterminated fence
+ *  masks to the end of the text, which is how a renderer treats it too. */
+function maskFences(text: string, chars: string[]): void {
+  let offset = 0;
+  let fence: string | null = null;
+  let blockStart = 0;
+  for (const line of text.split("\n")) {
+    const marker = /^(`{3,}|~{3,})/.exec(line.trimStart())?.[1]?.[0];
+    if (fence === null) {
+      if (marker) {
+        fence = marker;
+        blockStart = offset;
+      }
+    } else if (marker === fence) {
+      maskRange(chars, blockStart, offset + line.length);
+      fence = null;
+    }
+    offset += line.length + 1;
+  }
+  if (fence !== null) maskRange(chars, blockStart, text.length);
+}
+
+function maskPattern(source: string, chars: string[], pattern: RegExp): void {
+  for (const match of source.matchAll(pattern)) {
+    maskRange(chars, match.index, match.index + match[0].length);
+  }
+}
+
+function maskRange(chars: string[], start: number, end: number): void {
+  for (let i = start; i < end; i += 1) {
+    if (chars[i] !== "\n") chars[i] = MASK;
+  }
+}

--- a/ui/chat/src/mention-pending.ts
+++ b/ui/chat/src/mention-pending.ts
@@ -1,0 +1,56 @@
+/**
+ * The composer's pending @mention picks, scoped per draft (HOU-944).
+ *
+ * Accepting a person writes PLAIN TEXT into the textarea and records
+ * `{userId, name}` here on the side. Draft text is already kept per
+ * conversation by the app, so the sidecar has to be too: a panel-global list
+ * would send one conversation's picks with another's text after a switch, or
+ * lose them entirely when the user comes back to finish a parked message.
+ *
+ * Pure map operations, no React, so the eviction and the per-draft isolation
+ * are unit-testable.
+ */
+
+import type { MessageMention } from "./types";
+
+/** Drafts kept at once. Past this the least recently touched is dropped: a
+ *  user who parked a mention in a conversation they have not opened in a dozen
+ *  switches will have to re-pick, which beats an unbounded map. */
+export const MENTION_DRAFT_LIMIT = 12;
+
+/** Picks by draft key, least recently touched first. */
+export type PendingMentions = Map<string, MessageMention[]>;
+
+/** The picks parked under `key`, oldest first. Never undefined. */
+export function readPending(
+  drafts: PendingMentions,
+  key: string,
+): readonly MessageMention[] {
+  return drafts.get(key) ?? EMPTY;
+}
+
+const EMPTY: readonly MessageMention[] = [];
+
+/** Record a pick under `key`, ignoring a person already parked there. */
+export function recordPending(
+  drafts: PendingMentions,
+  key: string,
+  mention: MessageMention,
+): void {
+  const current = drafts.get(key) ?? [];
+  const known = current.some((m) => m.userId === mention.userId);
+  // Re-insert either way: a Map keeps insertion order, which is what makes the
+  // first key the least recently touched one.
+  drafts.delete(key);
+  drafts.set(key, known ? current : [...current, mention]);
+  while (drafts.size > MENTION_DRAFT_LIMIT) {
+    const oldest = drafts.keys().next().value;
+    if (oldest === undefined) return;
+    drafts.delete(oldest);
+  }
+}
+
+/** Forget `key`'s picks — the draft was sent. */
+export function dropPending(drafts: PendingMentions, key: string): void {
+  drafts.delete(key);
+}

--- a/ui/chat/src/mention-query.ts
+++ b/ui/chat/src/mention-query.ts
@@ -1,0 +1,171 @@
+/**
+ * Composer-side mention logic (HOU-944): what the caret is currently
+ * "@querying", which people match it, what accepting one does to the text, and
+ * when the suggestion list is open. Pure, no React, no i18n. What a SEND ends
+ * up carrying is `mention-send.ts`.
+ */
+
+import { isMentionStart, mentionKey } from "./mention-text.ts";
+import type { MentionPerson } from "./types";
+
+/** Past this many characters after the "@" the user is writing prose, not
+ *  picking a person, and the popover closes. */
+export const MENTION_QUERY_MAX_LEN = 32;
+
+/** How many people the popover offers at once. */
+export const MENTION_SUGGESTION_LIMIT = 6;
+
+export { mentionKey } from "./mention-text.ts";
+
+/** The active "@query" at the caret: `start` is the index of the `@`. */
+export interface MentionQuery {
+  start: number;
+  query: string;
+}
+
+/**
+ * The active "@query" at the caret, or null. An `@` counts only at the start of
+ * the text or after whitespace/an opening bracket; the query runs from after
+ * the `@` to the caret and may contain single interior spaces (so "@Ada Lo"
+ * still matches "Ada Lovelace"), never a newline, and is capped at
+ * MENTION_QUERY_MAX_LEN — past that the popover closes.
+ */
+export function findMentionQuery(
+  text: string,
+  caret: number,
+): MentionQuery | null {
+  const end = Math.max(0, Math.min(caret, text.length));
+  for (let i = end - 1; i >= 0; i -= 1) {
+    const char = text[i] as string;
+    if (char === "\n") return null;
+    if (char !== "@") continue;
+    if (!isMentionStart(text, i)) return null;
+    const query = text.slice(i + 1, end);
+    return isTypeableQuery(query) ? { start: i, query } : null;
+  }
+  return null;
+}
+
+/** How many single spaces a query may hold — enough for a three-part name,
+ *  short of letting a whole sentence read as one mention query. */
+const MENTION_QUERY_MAX_SPACES = 2;
+
+/**
+ * A query is still "someone's name being typed" while it holds no second `@`,
+ * no run of spaces, few enough single spaces to still be a name, and stays
+ * under the length cap. Its spaces must be INTERIOR: a leading space means the
+ * user abandoned the mention ("@ "), and a trailing one means they finished a
+ * word and moved on — which is also what closes the list the instant a pick is
+ * accepted, since accepting writes "@Name " with the caret past the space.
+ * Whether it matches anyone is the roster filter's call, not this one's.
+ */
+function isTypeableQuery(query: string): boolean {
+  if (query.length > MENTION_QUERY_MAX_LEN) return false;
+  if (query.includes("@")) return false;
+  if (query.startsWith(" ") || query.endsWith(" ")) return false;
+  if (query.includes("  ")) return false;
+  return (query.match(/ /g)?.length ?? 0) <= MENTION_QUERY_MAX_SPACES;
+}
+
+/**
+ * People whose name matches `query` (a prefix of the full name OR of any word
+ * in it), in roster order, capped at MENTION_SUGGESTION_LIMIT. An empty query
+ * returns the first N people. Diacritic-insensitive: typing "jose" offers
+ * "José". (Placing a SPAN is not — see `mentionSpanKey`.)
+ */
+export function filterMentionPeople(
+  people: readonly MentionPerson[],
+  query: string,
+): MentionPerson[] {
+  const key = mentionKey(query.trim());
+  const matches = key
+    ? people.filter((person) => matchesPrefix(person.name, key))
+    : [...people];
+  return matches.slice(0, MENTION_SUGGESTION_LIMIT);
+}
+
+function matchesPrefix(name: string, key: string): boolean {
+  const normalized = mentionKey(name);
+  if (normalized.startsWith(key)) return true;
+  return normalized.split(/\s+/).some((word) => word.startsWith(key));
+}
+
+/** Characters that END a phrase, before which a space would be an orphan:
+ *  "@Ada , thanks" is not how anyone writes. Opening brackets and quotes are
+ *  deliberately absent — a name butted against "(" needs its space. */
+const TRAILING_PUNCTUATION = new Set([
+  ",",
+  ".",
+  ";",
+  ":",
+  "!",
+  "?",
+  ")",
+  "]",
+  "}",
+  '"',
+  "'",
+  "”",
+  "’",
+  "…",
+]);
+
+/**
+ * Replace the active query span with "@Name" and report the new caret.
+ *
+ * A trailing space follows the name when the text needs one: at the end of the
+ * message, or before another word. Whitespace already there is reused rather
+ * than doubled, and closing punctuation gets none at all.
+ */
+export function insertMention(
+  text: string,
+  start: number,
+  caret: number,
+  person: MentionPerson,
+): { text: string; caret: number } {
+  const before = text.slice(0, start);
+  const after = text.slice(Math.max(start, caret));
+  const following = after.charAt(0);
+  const spaced = following === " ";
+  const tight =
+    following !== "" &&
+    (spaced || /\s/.test(following) || TRAILING_PUNCTUATION.has(following));
+  const inserted = tight ? `@${person.name}` : `@${person.name} `;
+  return {
+    text: `${before}${inserted}${after}`,
+    caret: before.length + inserted.length + (spaced ? 1 : 0),
+  };
+}
+
+/**
+ * Whether the suggestion list shows.
+ *
+ * A dismissal (Escape, and accepting a pick) sticks for the LIFETIME OF THE
+ * TOKEN it was made in: typing one more character after Escape must not bring
+ * the list back, and the just-accepted "@Name" must not re-offer itself the
+ * moment the caret lands after it. `dismissedStart` is the `@` index it was
+ * made at — see {@link carryDismissal} for when it lifts.
+ */
+export function isMentionListOpen(state: {
+  enabled: boolean;
+  suggestionCount: number;
+  active: MentionQuery | null;
+  dismissedStart: number | null;
+}): boolean {
+  if (!state.enabled || state.suggestionCount === 0) return false;
+  if (!state.active) return false;
+  return state.dismissedStart !== state.active.start;
+}
+
+/**
+ * The dismissal to keep as the active query moves to `next`. It survives every
+ * edit INSIDE its token and lifts the moment the token stops existing (the
+ * "@" was deleted, the caret left it, the query stopped being a name) — after
+ * which a brand new "@" opens the list again.
+ */
+export function carryDismissal(
+  dismissedStart: number | null,
+  next: MentionQuery | null,
+): number | null {
+  return next ? dismissedStart : null;
+}

--- a/ui/chat/src/mention-rehype.ts
+++ b/ui/chat/src/mention-rehype.ts
@@ -1,0 +1,127 @@
+/**
+ * Markdown-safe @mention injection (HOU-944).
+ *
+ * A hand-rolled rehype transform (no new dependency) that runs AFTER
+ * Streamdown's own `raw` → `sanitize` → `harden` chain, so the spans it mints
+ * are never stripped and the sanitizer stays fully in force. It splits text
+ * nodes on their "@Name" runs and marks each with `data-mention-name`, which
+ * the `span` component override in `ai-elements/message.tsx` turns into a
+ * `MentionChip`.
+ *
+ * Nodes under `code`, `pre` or `a` are skipped: a mention must never appear
+ * inside a code span, a code block, or a link's text.
+ */
+
+import type { MentionTarget } from "./mention-spans.ts";
+import { findMentionSpans } from "./mention-spans.ts";
+import { normalizeMentionText } from "./mention-text.ts";
+
+/** Attribute the chip renderer keys off. */
+export const MENTION_NAME_ATTR = "data-mention-name";
+/** Present (empty string) when the mention points at the signed-in viewer. */
+export const MENTION_SELF_ATTR = "data-mention-self";
+
+/** Tags whose subtree is verbatim content, never prose. */
+const SKIP_TAGS = new Set(["code", "pre", "a"]);
+
+/** The slice of hast this transform needs. Declared structurally so `ui/chat`
+ *  takes no `@types/hast` dependency. */
+interface HastNode {
+  type: string;
+  tagName?: string;
+  value?: string;
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+}
+
+export interface MentionRehypeOptions {
+  targets: readonly MentionTarget[];
+}
+
+/**
+ * The rehype plugin. Always pass it in TUPLE form —
+ * `[mentionRehypePlugin, { targets }]` — because Streamdown keys its compiled
+ * processor cache on the plugin's name plus `JSON.stringify(options)`; a bare
+ * closure would make two messages with different rosters share one processor.
+ */
+export function mentionRehypePlugin(options: MentionRehypeOptions) {
+  const targets = options.targets;
+  return (tree: unknown) => {
+    if (targets.length === 0) return;
+    walk(tree as HastNode, targets, false);
+  };
+}
+
+function walk(
+  node: HastNode,
+  targets: readonly MentionTarget[],
+  skip: boolean,
+): void {
+  const children = node.children;
+  if (!children || children.length === 0) return;
+
+  const next: HastNode[] = [];
+  let changed = false;
+  for (const child of children) {
+    if (child.type === "element") {
+      walk(child, targets, skip || SKIP_TAGS.has(child.tagName ?? ""));
+      next.push(child);
+      continue;
+    }
+    if (skip || child.type !== "text" || typeof child.value !== "string") {
+      next.push(child);
+      continue;
+    }
+    const split = splitText(child.value, targets);
+    if (!split) {
+      next.push(child);
+      continue;
+    }
+    changed = true;
+    next.push(...split);
+  }
+  if (changed) node.children = next;
+}
+
+/**
+ * The text node's replacement nodes, or null when it holds no mention.
+ *
+ * Slices the NFC form, because that is what `findMentionSpans` returns offsets
+ * into. The two forms render identically, so re-emitting the normalized text is
+ * invisible to the reader and keeps every offset honest.
+ */
+function splitText(
+  raw: string,
+  targets: readonly MentionTarget[],
+): HastNode[] | null {
+  const spans = findMentionSpans(raw, targets);
+  if (spans.length === 0) return null;
+  const value = normalizeMentionText(raw);
+
+  const out: HastNode[] = [];
+  let cursor = 0;
+  for (const span of spans) {
+    if (span.start > cursor) {
+      out.push({ type: "text", value: value.slice(cursor, span.start) });
+    }
+    out.push(mentionElement(value.slice(span.start, span.end), span.target));
+    cursor = span.end;
+  }
+  if (cursor < value.length) {
+    out.push({ type: "text", value: value.slice(cursor) });
+  }
+  return out;
+}
+
+function mentionElement(text: string, target: MentionTarget): HastNode {
+  const properties: Record<string, unknown> = {
+    [MENTION_NAME_ATTR]: target.name,
+  };
+  if (target.isSelf) properties[MENTION_SELF_ATTR] = "";
+  return {
+    type: "element",
+    tagName: "span",
+    properties,
+    children: [{ type: "text", value: text }],
+  };
+}

--- a/ui/chat/src/mention-send.ts
+++ b/ui/chat/src/mention-send.ts
@@ -1,0 +1,84 @@
+/**
+ * Which pending @mentions a SEND actually carries (HOU-944).
+ *
+ * The composer records `{userId, name}` on the side when a person is accepted;
+ * the text stays plain. At send time only the picks whose "@Name" run still
+ * survives in the message ship, so deleting the words deletes the mention —
+ * and only where the RENDERER would chip them, so nobody is notified about a
+ * message that addresses them nowhere (see `mention-mask.ts`). Pure, no React.
+ */
+
+import { maskMarkdown } from "./mention-mask.ts";
+import { findMentionSpans } from "./mention-spans.ts";
+import { mentionSpanKey, normalizeMentionText } from "./mention-text.ts";
+import type { MessageMention } from "./types";
+
+/** A pending pick that can actually be matched: it knows the name it wrote. */
+type NamedMention = MessageMention & { name: string };
+
+/**
+ * The mentions `text` still contains, in pick order, deduped by userId.
+ *
+ * Two co-members can share a display name, and "@Ana" cannot say which Ana it
+ * means. Occurrences are therefore handed out IN ORDER to the picks made under
+ * that name: the first "@Ana" is the first Ana the user chose, the second is
+ * the second. Every occurrence past the number of people picked repeats the
+ * first — one Ana picked and written twice is still one mention of her.
+ */
+export function resolveMentions(
+  text: string,
+  pending: readonly MessageMention[],
+): MessageMention[] {
+  const named = pending.filter(
+    (mention): mention is NamedMention =>
+      typeof mention.name === "string" && mention.name.length > 0,
+  );
+  if (named.length === 0) return [];
+
+  const spans = findMentionSpans(
+    maskMarkdown(normalizeMentionText(text)),
+    named.map((mention) => ({ name: mention.name })),
+  );
+  if (spans.length === 0) return [];
+
+  const claimed = claimOccurrences(
+    spans.map((span) => span.target.name),
+    named,
+  );
+  const seen = new Set<string>();
+  const resolved: MessageMention[] = [];
+  for (const mention of named) {
+    if (!claimed.has(mention.userId) || seen.has(mention.userId)) continue;
+    seen.add(mention.userId);
+    resolved.push(mention);
+  }
+  return resolved;
+}
+
+/** The userIds the occurrences of each name resolve to. */
+function claimOccurrences(
+  occurrences: readonly string[],
+  named: readonly NamedMention[],
+): Set<string> {
+  const queues = new Map<string, NamedMention[]>();
+  for (const mention of named) {
+    const key = mentionSpanKey(mention.name);
+    const queue = queues.get(key);
+    if (queue) queue.push(mention);
+    else queues.set(key, [mention]);
+  }
+
+  const used = new Map<string, number>();
+  const claimed = new Set<string>();
+  for (const name of occurrences) {
+    const key = mentionSpanKey(name);
+    const queue = queues.get(key);
+    if (!queue) continue;
+    const index = used.get(key) ?? 0;
+    used.set(key, index + 1);
+    claimed.add(
+      (queue[Math.min(index, queue.length - 1)] as NamedMention).userId,
+    );
+  }
+  return claimed;
+}

--- a/ui/chat/src/mention-spans.ts
+++ b/ui/chat/src/mention-spans.ts
@@ -1,0 +1,131 @@
+/**
+ * Render-side mention matching (HOU-944): where in a message's text an
+ * "@Name" occurrence sits, so the markdown renderer can swap those runs for
+ * chips. Pure, no React, no i18n — the library boundary keeps it props-only.
+ */
+
+import {
+  extendsName,
+  isMentionStart,
+  mentionSpanKey,
+  normalizeMentionText,
+} from "./mention-text.ts";
+
+/** A person the renderer knows how to chip. `userId` is present for a user
+ *  message's own recorded mentions and absent when the match came from a
+ *  props-supplied roster; `isSelf` emphasizes a mention of the viewer. */
+export interface MentionTarget {
+  name: string;
+  userId?: string;
+  isSelf?: boolean;
+}
+
+/** A matched "@Name" run: `[start, end)` offsets into the source text, `start`
+ *  pointing at the `@`. */
+export interface MentionSpan {
+  start: number;
+  end: number;
+  target: MentionTarget;
+}
+
+/**
+ * Ordered, non-overlapping "@Name" spans in `text`. Longest name first (so
+ * "@Ada Lovelace" wins over "@Ada"), case-insensitive, the `@` must start the
+ * string or follow whitespace/an opening bracket, and the match may not run
+ * into a longer word ("@Adam" is not a mention of Ada). Pure.
+ *
+ * OFFSETS INDEX INTO `normalizeMentionText(text)`, not into `text`. Both the
+ * text and the target names are normalized to NFC here so a name's UTF-16
+ * length measures the same run on both sides; a caller that SLICES the result
+ * must normalize its own copy first (it is idempotent, so doing so costs
+ * nothing when the string is already NFC).
+ */
+export function findMentionSpans(
+  text: string,
+  targets: readonly MentionTarget[],
+): MentionSpan[] {
+  const ranked = rankTargets(targets);
+  if (ranked.length === 0) return [];
+  const source = normalizeMentionText(text);
+
+  const spans: MentionSpan[] = [];
+  for (let i = 0; i < source.length; i += 1) {
+    if (!isMentionStart(source, i)) continue;
+    const match = matchAt(source, i, ranked);
+    if (!match) continue;
+    spans.push(match);
+    // Resume after the match so spans never overlap (the loop's own `i += 1`
+    // lands on the first character past it).
+    i = match.end - 1;
+  }
+  return spans;
+}
+
+/**
+ * The targets the matcher runs on: NFC names, longest first (ties keep roster
+ * order — a stable sort), and ONE target per name.
+ *
+ * Two co-members can share a display name. The text "@Ana" cannot say which
+ * Ana it means, so they collapse into a single target that carries the first
+ * one's identity and the OR of their `isSelf` flags: "one of the people this
+ * names is me" is exactly what the viewer emphasis is for, and dropping it
+ * because the OTHER Ana sorted first would silently un-address the reader.
+ * Which userId a SEND attributes to each occurrence is decided separately,
+ * from the pending picks (`mention-send.ts`).
+ */
+function rankTargets(targets: readonly MentionTarget[]): MentionTarget[] {
+  const byName = new Map<string, MentionTarget>();
+  for (const target of targets) {
+    const name = normalizeMentionText(target.name);
+    if (name.length === 0) continue;
+    const key = mentionSpanKey(name);
+    const existing = byName.get(key);
+    if (existing) {
+      if (target.isSelf) existing.isSelf = true;
+      continue;
+    }
+    byName.set(key, { ...target, name });
+  }
+  return [...byName.values()].sort((a, b) => b.name.length - a.name.length);
+}
+
+/**
+ * Value equality for two target lists. `MessageResponse` is memoized with a
+ * hand-written comparator, and the target list is rebuilt on every render of
+ * the row above it, so comparing by identity there would re-render (and
+ * re-parse) every message on every keystroke.
+ */
+export function sameMentionTargets(
+  a: readonly MentionTarget[] | undefined,
+  b: readonly MentionTarget[] | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b || a.length !== b.length) return false;
+  return a.every((target, index) => {
+    const other = b[index] as MentionTarget;
+    return (
+      target.name === other.name &&
+      target.userId === other.userId &&
+      target.isSelf === other.isSelf
+    );
+  });
+}
+
+function matchAt(
+  text: string,
+  at: number,
+  ranked: readonly MentionTarget[],
+): MentionSpan | null {
+  for (const target of ranked) {
+    const end = at + 1 + target.name.length;
+    if (end > text.length) continue;
+    if (
+      mentionSpanKey(text.slice(at + 1, end)) !== mentionSpanKey(target.name)
+    ) {
+      continue;
+    }
+    if (extendsName(text[end])) continue;
+    return { start: at, end, target };
+  }
+  return null;
+}

--- a/ui/chat/src/mention-text.ts
+++ b/ui/chat/src/mention-text.ts
@@ -1,0 +1,71 @@
+/**
+ * The primitives every mention module shares (HOU-944): Unicode normalization,
+ * the two matching keys, and the "is this `@` a real mention start" boundary
+ * rule. They live in their own module so `mention-query.ts` (composer),
+ * `mention-send.ts` (send) and `mention-spans.ts` (renderer) can each depend on
+ * them without depending on each other. Pure, no React.
+ */
+
+/** Characters an `@` may legally follow and still start a mention: an opening
+ *  bracket or quote. Anything else (a letter, a digit, `.`) means the `@` is
+ *  mid-word — "ada@example.com" is an address, not a mention. */
+const OPENING_CHARS = new Set(["(", "[", "{", "<", '"', "'", "“", "‘"]);
+
+/** A character that would EXTEND a name, so a match must not be followed by
+ *  one: "@Ada" inside "@Adam" is not a mention of Ada. Combining marks count —
+ *  a leftover mark after a matched run belongs to that run's last letter. */
+const WORD_CHAR = /[\p{L}\p{N}\p{M}_]/u;
+
+/**
+ * THE normalization every mention comparison happens in. Two strings that a
+ * reader sees as identical can carry different code points ("é" as one
+ * precomposed character, or as "e" plus a combining accent); NFC picks the
+ * composed form for both, so a name's `.length` measures the same number of
+ * UTF-16 units in the roster and in the message text.
+ *
+ * This is what makes {@link matchAt}'s slice-by-name-length safe. Apply it to
+ * roster names once where the target list is built, and to message text at the
+ * entry of span finding — both are idempotent, so applying it twice is free.
+ */
+export function normalizeMentionText(s: string): string {
+  return s.normalize("NFC");
+}
+
+/**
+ * The SPAN key: NFC plus case folding, nothing else. Deliberately NOT
+ * diacritic-insensitive — the span finder slices the text by the target name's
+ * length, and folding accents away would let a 4-unit name match a 5-unit run
+ * (or the reverse), truncating the chip mid-grapheme and leaking a combining
+ * accent into the next text node. "@ada" still chips Ada; "@Jose" does not chip
+ * "José", because it is not that person's name.
+ */
+export function mentionSpanKey(s: string): string {
+  return normalizeMentionText(s).toLowerCase();
+}
+
+/**
+ * The FILTER key: case- AND diacritic-insensitive, so typing "jose" offers
+ * "José" in the autocomplete. Only ever used to decide which people the
+ * popover shows — never to place a span, where the length change it causes
+ * would be a correctness bug (see {@link mentionSpanKey}).
+ */
+export function mentionKey(s: string): string {
+  return s
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase();
+}
+
+/** True when the `@` at `index` may start a mention: it is at the start of the
+ *  text, or follows whitespace or an opening bracket/quote. */
+export function isMentionStart(text: string, index: number): boolean {
+  if (text[index] !== "@") return false;
+  if (index === 0) return true;
+  const prev = text[index - 1] as string;
+  return /\s/.test(prev) || OPENING_CHARS.has(prev);
+}
+
+/** True when `char` would run on from a matched name (so the match is bogus). */
+export function extendsName(char: string | undefined): boolean {
+  return char !== undefined && WORD_CHAR.test(char);
+}

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -13,6 +13,33 @@ export interface MessageAuthor {
 }
 
 /**
+ * One @mention of a human inside a chat message (HOU-944). Mirrors the
+ * protocol `ChatMessage.mentions[]` entry. Recorded on USER turns only — an
+ * agent addresses someone in plain prose, never as structured data. `name` is
+ * the display name as it appeared after the "@" when the message was sent, so
+ * the renderer can still find the run after the person was renamed.
+ */
+export interface MessageMention {
+  userId: string;
+  name?: string;
+}
+
+/**
+ * A person the composer can @mention and the renderer can chip. Supplied by
+ * the consumer (the app resolves the space roster); `ui/` never fetches.
+ */
+export interface MentionPerson {
+  userId: string;
+  /**
+   * Display name, as it appears after the "@". Required: a person with no
+   * known name is never offered, because an "@a1b2c3d4" chip is nonsense to a
+   * non-technical reader.
+   */
+  name: string;
+  imageUrl?: string;
+}
+
+/**
  * Optional stable identity for a feed item, carried from the conversation
  * view-model's feed entries. When present it keys the rendered message, so
  * PREPENDING older items (scroll-up lazy-load, HOU-819) never re-keys the
@@ -39,6 +66,11 @@ type FeedItemVariant =
        * single-player mode — the bubble renders exactly as before.
        */
       author?: MessageAuthor;
+      /**
+       * The teammates this message @mentioned (HOU-944). Drives the chips in
+       * the sent bubble; absent when the message mentioned nobody.
+       */
+      mentions?: MessageMention[];
     }
   | { feed_type: "tool_runtime_error"; data: ToolRuntimeErrorEntry }
   | { feed_type: "provider_error"; data: ProviderError }

--- a/ui/chat/src/use-dictation-hotkeys.ts
+++ b/ui/chat/src/use-dictation-hotkeys.ts
@@ -1,0 +1,34 @@
+/**
+ * While dictation is CAPTURING, the textarea that owns the composer's keydown
+ * handler is replaced by the waveform, so Escape/Enter have no focus target.
+ * This listens on the document for the duration of the capture instead:
+ * Escape discards, Enter (no shift) accepts — the same as clicking the check
+ * (stop + transcribe). While TRANSCRIBING the hook is inactive (not a
+ * capturing state), so Enter does nothing.
+ *
+ * Extracted from `chat-input.tsx` so that file stays a composer layout.
+ */
+
+import { useEffect } from "react";
+import type { DictationControl } from "./dictation-types.ts";
+import { isDictationCapturing } from "./dictation-types.ts";
+
+export function useDictationHotkeys(dictation: DictationControl | undefined) {
+  const capturing = isDictationCapturing(dictation);
+  useEffect(() => {
+    if (!capturing) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        dictation?.onCancel();
+        return;
+      }
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        dictation?.onStop();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [capturing, dictation]);
+}

--- a/ui/chat/src/use-mention-autocomplete.ts
+++ b/ui/chat/src/use-mention-autocomplete.ts
@@ -1,0 +1,199 @@
+/**
+ * Composer state for @mentions (HOU-944): the active "@query" at the caret, the
+ * highlighted row, the caret restoration after an accept, and the pending picks
+ * a send will carry.
+ *
+ * The composer stays a plain `<textarea>`: accepting a person inserts PLAIN
+ * TEXT "@Name " and records `{userId, name}` on the side, under the draft being
+ * written. What ships is whatever `resolveMentions` still finds in the sent
+ * text, so deleting the words also deletes the mention.
+ */
+
+import type { KeyboardEvent } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { mentionKeyAction } from "./mention-keys.ts";
+import type { MentionQuery } from "./mention-query.ts";
+import {
+  carryDismissal,
+  filterMentionPeople,
+  findMentionQuery,
+  insertMention,
+  isMentionListOpen,
+} from "./mention-query.ts";
+import type { MentionPerson, MessageMention } from "./types";
+import { usePendingMentions } from "./use-pending-mentions.ts";
+
+const NO_PEOPLE: readonly MentionPerson[] = [];
+
+/** The bucket picks land in when the consumer names no draft (a standalone
+ *  composer that never switches conversations). */
+const DEFAULT_DRAFT_KEY = "";
+
+export interface UseMentionAutocompleteOptions {
+  /** Teammates that may be offered. Empty/absent disables the whole feature. */
+  people?: readonly MentionPerson[];
+  /** False while something else owns the keyboard (dictation capture). */
+  enabled: boolean;
+  /** Opaque identity of the draft being written (the app's session key). Picks
+   *  are parked under it, so switching conversations neither loses them nor
+   *  attaches them to the next conversation's send. */
+  draftKey?: string;
+  /** Writes the composer text after an accept. */
+  onTextChange: (text: string) => void;
+}
+
+export interface MentionAutocomplete {
+  open: boolean;
+  suggestions: MentionPerson[];
+  highlighted: number;
+  setHighlighted: (index: number) => void;
+  /** Recompute the active query from the textarea's live value + caret. */
+  refresh: (textarea: HTMLTextAreaElement) => void;
+  /** Interception for the composer's `onKeyDown`; calls `preventDefault()`
+   *  on every key it consumes, which is what makes `PromptInputTextarea` bail
+   *  before its own Enter/Escape handling. */
+  onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+  accept: (person: MentionPerson) => void;
+  dismiss: () => void;
+  mentionsFor: (sent: string) => MessageMention[];
+  commitSent: () => void;
+}
+
+export function useMentionAutocomplete({
+  people,
+  enabled,
+  draftKey = DEFAULT_DRAFT_KEY,
+  onTextChange,
+}: UseMentionAutocompleteOptions): MentionAutocomplete {
+  const roster = people ?? NO_PEOPLE;
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const activeRef = useRef<MentionQuery | null>(null);
+  const caretRef = useRef<number | null>(null);
+  const pending = usePendingMentions(draftKey);
+  const [active, setActive] = useState<MentionQuery | null>(null);
+  const [dismissedStart, setDismissedStart] = useState<number | null>(null);
+  const [highlighted, setHighlighted] = useState(0);
+
+  // An empty roster (single-player, a personal space, an older gateway) filters
+  // to nobody, and no candidates means "@" is just a character. Dictation owns
+  // the keyboard while capturing, so the list stays shut then too.
+  const suggestions = active ? filterMentionPeople(roster, active.query) : [];
+  const open = isMentionListOpen({
+    enabled,
+    suggestionCount: suggestions.length,
+    active,
+    dismissedStart,
+  });
+
+  const setActiveQuery = useCallback((next: MentionQuery | null) => {
+    const prev = activeRef.current;
+    if (
+      prev &&
+      next &&
+      prev.start === next.start &&
+      prev.query === next.query
+    ) {
+      return;
+    }
+    activeRef.current = next;
+    setActive(next);
+    setDismissedStart((current) => carryDismissal(current, next));
+    setHighlighted(0);
+  }, []);
+
+  const refresh = useCallback(
+    (textarea: HTMLTextAreaElement) => {
+      textareaRef.current = textarea;
+      if (roster.length === 0) {
+        setActiveQuery(null);
+        return;
+      }
+      setActiveQuery(
+        findMentionQuery(textarea.value, textarea.selectionStart ?? 0),
+      );
+    },
+    [roster.length, setActiveQuery],
+  );
+
+  const dismiss = useCallback(() => {
+    const query = activeRef.current;
+    if (query) setDismissedStart(query.start);
+  }, []);
+
+  const accept = useCallback(
+    (person: MentionPerson) => {
+      const textarea = textareaRef.current;
+      const query = activeRef.current;
+      if (!textarea || !query) return;
+      const next = insertMention(
+        textarea.value,
+        query.start,
+        textarea.selectionStart ?? textarea.value.length,
+        person,
+      );
+      pending.record({ userId: person.userId, name: person.name });
+      caretRef.current = next.caret;
+      setActiveQuery(null);
+      // This token is settled. Otherwise a name accepted before a comma (which
+      // takes no trailing space) re-offers itself as soon as the caret lands
+      // after it, and the next Enter re-accepts instead of sending.
+      setDismissedStart(query.start);
+      onTextChange(next.text);
+    },
+    [onTextChange, pending.record, setActiveQuery],
+  );
+
+  // Put the caret back after the accepted name once React has committed the new
+  // value, so typing continues where the user expects. Deliberately runs after
+  // EVERY commit (no dependency list): the trigger is a ref an event handler
+  // set, which no dependency can express, and the guard no-ops every other pass.
+  useEffect(() => {
+    const caret = caretRef.current;
+    const textarea = textareaRef.current;
+    if (caret === null || !textarea) return;
+    caretRef.current = null;
+    textarea.focus();
+    textarea.setSelectionRange(caret, caret);
+  });
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (!open) return;
+      const count = suggestions.length;
+      const action = mentionKeyAction(
+        {
+          key: event.key,
+          shiftKey: event.shiftKey,
+          isComposing: event.nativeEvent.isComposing,
+        },
+        count,
+      );
+      if (!action) return;
+      event.preventDefault();
+      if (action.kind === "move") {
+        setHighlighted((index) => (index + action.step) % count);
+        return;
+      }
+      if (action.kind === "dismiss") {
+        dismiss();
+        return;
+      }
+      const person = suggestions[Math.min(highlighted, count - 1)];
+      if (person) accept(person);
+    },
+    [open, suggestions, highlighted, accept, dismiss],
+  );
+
+  return {
+    open,
+    suggestions,
+    highlighted,
+    setHighlighted,
+    refresh,
+    onKeyDown,
+    accept,
+    dismiss,
+    mentionsFor: pending.mentionsFor,
+    commitSent: pending.commitSent,
+  };
+}

--- a/ui/chat/src/use-mention-combobox.ts
+++ b/ui/chat/src/use-mention-combobox.ts
@@ -1,0 +1,77 @@
+/**
+ * The composer's @mention SURFACE wiring (HOU-944): `useMentionAutocomplete`
+ * plus the ids that tie the two halves together.
+ *
+ * Focus never leaves the textarea, so the accessibility relationship is a
+ * combobox: the textarea is the input, the popover's list is the listbox it
+ * `aria-controls`, and the highlighted row is what it names as its
+ * `aria-activedescendant`. Both ends need the SAME ids, and both render from
+ * `chat-input.tsx` — so the ids are minted once, here, instead of being
+ * threaded through it.
+ */
+
+import { useCallback, useId } from "react";
+import type { MentionComboboxAria } from "./chat-input-form.tsx";
+import type { ChatInputMentionsProps } from "./chat-input-mentions.tsx";
+import type {
+  MentionAutocomplete,
+  UseMentionAutocompleteOptions,
+} from "./use-mention-autocomplete.ts";
+import { useMentionAutocomplete } from "./use-mention-autocomplete.ts";
+
+/** What `<ChatInputMentions>` needs that is not the consumer's own labels or
+ *  avatar render prop. */
+type MentionListProps = Omit<
+  ChatInputMentionsProps,
+  "children" | "listAriaLabel" | "renderAvatar"
+>;
+
+export interface MentionComposer {
+  refresh: MentionAutocomplete["refresh"];
+  onKeyDown: MentionAutocomplete["onKeyDown"];
+  mentionsFor: MentionAutocomplete["mentionsFor"];
+  commitSent: MentionAutocomplete["commitSent"];
+  list: MentionListProps;
+  /** Absent while the list is shut, which reverts the textarea to a plain one. */
+  combobox?: MentionComboboxAria;
+}
+
+export function useMentionCombobox(
+  options: UseMentionAutocompleteOptions,
+): MentionComposer {
+  const mentions = useMentionAutocomplete(options);
+  const listId = `${useId()}mentions`;
+  const optionId = useCallback(
+    (index: number) => `${listId}-${index}`,
+    [listId],
+  );
+  // The filter can narrow between two renders, leaving the highlight past the
+  // end; `aria-activedescendant` must never name a row that is not there.
+  const highlighted = Math.min(
+    mentions.highlighted,
+    Math.max(0, mentions.suggestions.length - 1),
+  );
+
+  return {
+    refresh: mentions.refresh,
+    onKeyDown: mentions.onKeyDown,
+    mentionsFor: mentions.mentionsFor,
+    commitSent: mentions.commitSent,
+    list: {
+      highlighted,
+      listId,
+      onDismiss: mentions.dismiss,
+      onHighlight: mentions.setHighlighted,
+      onSelect: mentions.accept,
+      open: mentions.open,
+      optionId,
+      people: mentions.suggestions,
+    },
+    combobox: mentions.open
+      ? {
+          "aria-controls": listId,
+          "aria-activedescendant": optionId(highlighted),
+        }
+      : undefined,
+  };
+}

--- a/ui/chat/src/use-pending-mentions.ts
+++ b/ui/chat/src/use-pending-mentions.ts
@@ -1,0 +1,46 @@
+/**
+ * The composer's pending @mention picks as React state (HOU-944) — a thin
+ * wrapper over the pure per-draft map in `mention-pending.ts`.
+ *
+ * The map lives in a ref, not in state: nothing renders from it, and a pick
+ * must not repaint the message list. It is keyed by draft, so a conversation
+ * switch neither loses the picks parked in the one you left nor attaches them
+ * to the one you arrived at.
+ */
+
+import { useCallback, useRef } from "react";
+import type { PendingMentions } from "./mention-pending.ts";
+import { dropPending, readPending, recordPending } from "./mention-pending.ts";
+import { resolveMentions } from "./mention-send.ts";
+import type { MessageMention } from "./types";
+
+export interface PendingMentionsApi {
+  /** Park a pick under the active draft. */
+  record: (mention: MessageMention) => void;
+  /** The picks `sent` still contains. Does NOT clear: a send that fails keeps
+   *  its text, so it must keep the mentions that text refers to. */
+  mentionsFor: (sent: string) => MessageMention[];
+  /** Drop the active draft's picks. Call ONLY once the send resolved. */
+  commitSent: () => void;
+}
+
+export function usePendingMentions(draftKey: string): PendingMentionsApi {
+  const drafts = useRef<PendingMentions>(new Map());
+
+  const record = useCallback(
+    (mention: MessageMention) =>
+      recordPending(drafts.current, draftKey, mention),
+    [draftKey],
+  );
+  const mentionsFor = useCallback(
+    (sent: string) =>
+      resolveMentions(sent, readPending(drafts.current, draftKey)),
+    [draftKey],
+  );
+  const commitSent = useCallback(
+    () => dropPending(drafts.current, draftKey),
+    [draftKey],
+  );
+
+  return { record, mentionsFor, commitSent };
+}

--- a/ui/chat/tests/mentions.test.ts
+++ b/ui/chat/tests/mentions.test.ts
@@ -1,0 +1,686 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { feedItemsToMessages } from "../src/feed-to-messages.ts";
+import { mentionKeyAction } from "../src/mention-keys.ts";
+import { maskMarkdown } from "../src/mention-mask.ts";
+import type { PendingMentions } from "../src/mention-pending.ts";
+import {
+  dropPending,
+  MENTION_DRAFT_LIMIT,
+  readPending,
+  recordPending,
+} from "../src/mention-pending.ts";
+import {
+  carryDismissal,
+  filterMentionPeople,
+  findMentionQuery,
+  insertMention,
+  isMentionListOpen,
+  mentionKey,
+} from "../src/mention-query.ts";
+import { mentionRehypePlugin } from "../src/mention-rehype.ts";
+import { resolveMentions } from "../src/mention-send.ts";
+import { findMentionSpans } from "../src/mention-spans.ts";
+import { mentionSpanKey } from "../src/mention-text.ts";
+import type { FeedItem, MentionPerson } from "../src/types.ts";
+
+const ADA: MentionPerson = { userId: "u_ada", name: "Ada Lovelace" };
+const ADA_SHORT: MentionPerson = { userId: "u_short", name: "Ada" };
+const JOSE: MentionPerson = { userId: "u_jose", name: "José" };
+const BOB: MentionPerson = { userId: "u_bob", name: "Bob Ross" };
+const ROSTER = [ADA, ADA_SHORT, JOSE, BOB];
+
+/** "José" the two ways Unicode spells it: one precomposed character, or
+ *  "e" plus a combining acute. A reader sees no difference; `.length` does. */
+const JOSE_NFC = "Jos\u00e9";
+const JOSE_NFD = "Jose\u0301";
+
+describe("mentionKey", () => {
+  it("folds case and diacritics — it is the FILTER key", () => {
+    assert.equal(mentionKey("José"), "jose");
+    assert.equal(mentionKey("ÅNGSTRÖM"), "angstrom");
+  });
+});
+
+describe("mentionSpanKey", () => {
+  it("folds case but NOT diacritics, and normalizes to NFC", () => {
+    assert.equal(mentionSpanKey(JOSE_NFD), "jos\u00e9");
+    assert.notEqual(mentionSpanKey(JOSE_NFC), mentionSpanKey("Jose"));
+    assert.equal(mentionSpanKey(JOSE_NFD), mentionSpanKey(JOSE_NFC));
+    assert.equal(mentionSpanKey(JOSE_NFD).length, JOSE_NFC.length);
+  });
+});
+
+describe("findMentionQuery", () => {
+  it("detects an @ at the start of the text", () => {
+    assert.deepEqual(findMentionQuery("@Ad", 3), { start: 0, query: "Ad" });
+  });
+
+  it("detects an @ after whitespace and after an opening bracket", () => {
+    assert.deepEqual(findMentionQuery("hey @Ad", 7), { start: 4, query: "Ad" });
+    assert.deepEqual(findMentionQuery("(@Ad", 4), { start: 1, query: "Ad" });
+  });
+
+  it("opens on a bare @ so the whole roster is offered", () => {
+    assert.deepEqual(findMentionQuery("hey @", 5), { start: 4, query: "" });
+  });
+
+  it("does NOT trigger on an @ mid-word", () => {
+    assert.equal(findMentionQuery("she said hi@Ad", 14), null);
+  });
+
+  it("does NOT trigger inside an email address", () => {
+    assert.equal(findMentionQuery("write ada@example.com", 21), null);
+  });
+
+  it("keeps matching across ONE interior space", () => {
+    assert.deepEqual(findMentionQuery("hi @Ada Lo", 10), {
+      start: 3,
+      query: "Ada Lo",
+    });
+  });
+
+  it("stops on a double space, a leading space, or a newline", () => {
+    assert.equal(findMentionQuery("hi @Ada  Lo", 11), null);
+    assert.equal(findMentionQuery("hi @ Ada", 8), null);
+    assert.equal(findMentionQuery("hi @\nAda", 8), null);
+  });
+
+  it("closes on the trailing space an accepted pick leaves behind", () => {
+    const { text, caret } = insertMention("hi @Ad", 3, 6, ADA);
+    assert.equal(text, "hi @Ada Lovelace ");
+    assert.equal(findMentionQuery(text, caret), null);
+  });
+
+  it("closes past the length cap", () => {
+    assert.equal(findMentionQuery(`@${"a".repeat(33)}`, 34), null);
+  });
+
+  it("reads the query at the CARET, not at the end of the text", () => {
+    assert.deepEqual(findMentionQuery("@Ad and more", 3), {
+      start: 0,
+      query: "Ad",
+    });
+  });
+});
+
+describe("filterMentionPeople", () => {
+  it("returns everyone, in roster order, for an empty query", () => {
+    assert.deepEqual(
+      filterMentionPeople(ROSTER, "").map((p) => p.userId),
+      ["u_ada", "u_short", "u_jose", "u_bob"],
+    );
+  });
+
+  it("matches a prefix of the full name, ignoring case", () => {
+    assert.deepEqual(
+      filterMentionPeople(ROSTER, "ada l").map((p) => p.userId),
+      ["u_ada"],
+    );
+  });
+
+  it("matches a prefix of ANY word in the name", () => {
+    assert.deepEqual(
+      filterMentionPeople(ROSTER, "ross").map((p) => p.userId),
+      ["u_bob"],
+    );
+  });
+
+  it("matches across diacritics in both directions", () => {
+    assert.deepEqual(
+      filterMentionPeople(ROSTER, "jos").map((p) => p.userId),
+      ["u_jose"],
+    );
+    assert.deepEqual(
+      filterMentionPeople([{ userId: "u", name: "Jose" }], "José").map(
+        (p) => p.userId,
+      ),
+      ["u"],
+    );
+  });
+
+  it("caps the list at the suggestion limit", () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({
+      userId: `u${i}`,
+      name: `Person ${i}`,
+    }));
+    assert.equal(filterMentionPeople(many, "").length, 6);
+  });
+
+  it("returns nothing when no one matches", () => {
+    assert.deepEqual(filterMentionPeople(ROSTER, "zzz"), []);
+  });
+});
+
+describe("insertMention", () => {
+  it("replaces the query span with '@Name ' and puts the caret after it", () => {
+    const result = insertMention("hey @Ad", 4, 7, ADA);
+    assert.equal(result.text, "hey @Ada Lovelace ");
+    assert.equal(result.caret, result.text.length);
+  });
+
+  it("keeps the text that follows the caret", () => {
+    const result = insertMention("hey @Ad and Bob", 4, 7, ADA);
+    assert.equal(result.text, "hey @Ada Lovelace and Bob");
+    assert.equal(result.caret, "hey @Ada Lovelace ".length);
+  });
+
+  it("adds NO trailing space before punctuation", () => {
+    const result = insertMention("hey @Ad, thanks", 4, 7, ADA);
+    assert.equal(result.text, "hey @Ada Lovelace, thanks");
+    assert.equal(result.caret, "hey @Ada Lovelace".length);
+    for (const punctuation of [".", "!", "?", ")", ":", "…"]) {
+      const { text } = insertMention(`@Ad${punctuation}`, 0, 3, ADA_SHORT);
+      assert.equal(text, `@Ada${punctuation}`);
+    }
+  });
+
+  it("adds NO trailing space before a newline either", () => {
+    const result = insertMention("@Ad\nnext line", 0, 3, ADA_SHORT);
+    assert.equal(result.text, "@Ada\nnext line");
+    assert.equal(result.caret, "@Ada".length);
+  });
+
+  it("reuses an existing trailing space instead of stacking a second", () => {
+    const result = insertMention("hey @Ad ok", 4, 7, ADA);
+    assert.equal(result.text, "hey @Ada Lovelace ok");
+    assert.equal(result.caret, "hey @Ada Lovelace ".length);
+  });
+
+  it("round-trips: what it inserts, findMentionSpans finds back", () => {
+    const { text } = insertMention("hey @Ad", 4, 7, ADA);
+    const spans = findMentionSpans(text, [
+      { name: ADA.name, userId: ADA.userId },
+    ]);
+    assert.equal(spans.length, 1);
+    assert.equal(spans[0]?.start, 4);
+    assert.equal(spans[0]?.end, 4 + 1 + ADA.name.length);
+    assert.equal(text.slice(spans[0]?.start, spans[0]?.end), "@Ada Lovelace");
+    assert.equal(spans[0]?.target.userId, "u_ada");
+  });
+});
+
+describe("findMentionSpans", () => {
+  const targets = [
+    { name: "Ada", userId: "u_short" },
+    { name: "Ada Lovelace", userId: "u_ada" },
+  ];
+
+  it("prefers the LONGEST matching name", () => {
+    const spans = findMentionSpans("ping @Ada Lovelace please", targets);
+    assert.equal(spans.length, 1);
+    assert.equal(spans[0]?.target.userId, "u_ada");
+    assert.equal(spans[0]?.end, "ping @Ada Lovelace".length);
+  });
+
+  it("still matches the short name on its own", () => {
+    const spans = findMentionSpans("ping @Ada please", targets);
+    assert.equal(spans.length, 1);
+    assert.equal(spans[0]?.target.userId, "u_short");
+  });
+
+  it("does not match a name that runs into a longer word", () => {
+    assert.deepEqual(findMentionSpans("ping @Adam please", targets), []);
+  });
+
+  it("does not match an @ mid-word or inside an email address", () => {
+    assert.deepEqual(findMentionSpans("mail ada@Ada.com", targets), []);
+    assert.deepEqual(findMentionSpans("x@Ada", targets), []);
+  });
+
+  it("finds several non-overlapping spans in order", () => {
+    const spans = findMentionSpans("@Ada and @Bob Ross", [
+      ...targets,
+      { name: "Bob Ross", userId: "u_bob" },
+    ]);
+    assert.deepEqual(
+      spans.map((s) => s.target.userId),
+      ["u_short", "u_bob"],
+    );
+    assert.ok((spans[0]?.end ?? 0) <= (spans[1]?.start ?? 0));
+  });
+
+  it("ignores case", () => {
+    const spans = findMentionSpans("hola @JOS\u00c9", [
+      { name: JOSE_NFC, userId: "u_jose" },
+    ]);
+    assert.equal(spans.length, 1);
+    assert.equal(spans[0]?.target.userId, "u_jose");
+  });
+
+  it("does NOT chip a differently accented spelling — that is a different name", () => {
+    assert.deepEqual(
+      findMentionSpans("hola @jose", [{ name: JOSE_NFC, userId: "u_jose" }]),
+      [],
+    );
+  });
+});
+
+describe("findMentionSpans — Unicode normalization", () => {
+  const at = (text: string, span: { start: number; end: number }) =>
+    text.normalize("NFC").slice(span.start, span.end);
+
+  it("chips when the ROSTER name is NFD and the text is NFC", () => {
+    const text = `hola @${JOSE_NFC}, ¿todo bien?`;
+    const spans = findMentionSpans(text, [
+      { name: JOSE_NFD, userId: "u_jose" },
+    ]);
+    assert.equal(spans.length, 1);
+    assert.equal(at(text, spans[0] as { start: number; end: number }), "@José");
+    assert.equal(spans[0]?.target.userId, "u_jose");
+  });
+
+  it("chips when the ROSTER name is NFC and the text is NFD", () => {
+    const text = `hola @${JOSE_NFD}, ¿todo bien?`;
+    const spans = findMentionSpans(text, [
+      { name: JOSE_NFC, userId: "u_jose" },
+    ]);
+    assert.equal(spans.length, 1);
+    // The offsets index the NFC form, where the accent is part of the name —
+    // the bug this guards is a span that ended one unit short and leaked the
+    // combining accent into the text node after the chip.
+    assert.equal(at(text, spans[0] as { start: number; end: number }), "@José");
+  });
+
+  it("never truncates mid-grapheme: a floating accent is not a match at all", () => {
+    // "@Ana" + a combining acute composes to "@Aná", which is somebody else.
+    const spans = findMentionSpans("hi @Ana\u0301 there", [
+      { name: "Ana", userId: "u_ana" },
+    ]);
+    assert.deepEqual(spans, []);
+  });
+
+  it("reports the name in NFC, whichever form the roster used", () => {
+    const spans = findMentionSpans(`@${JOSE_NFC}`, [{ name: JOSE_NFD }]);
+    assert.equal(spans[0]?.target.name, JOSE_NFC);
+  });
+});
+
+describe("findMentionSpans — two people, one name", () => {
+  const anas = [
+    { name: "Ana", userId: "u_a1" },
+    { name: "Ana", userId: "u_a2", isSelf: true },
+  ];
+
+  it("collapses them into ONE target: the text cannot say which Ana", () => {
+    const spans = findMentionSpans("@Ana and @Ana", anas);
+    assert.equal(spans.length, 2);
+    assert.deepEqual(
+      spans.map((s) => s.target.userId),
+      ["u_a1", "u_a1"],
+    );
+  });
+
+  it("emphasizes the mention when ANY same-name entry is the viewer", () => {
+    // The viewer sorted second; dropping their flag would silently
+    // un-address the person reading the message.
+    const spans = findMentionSpans("@Ana", anas);
+    assert.equal(spans[0]?.target.isSelf, true);
+  });
+});
+
+describe("maskMarkdown", () => {
+  const masked = (text: string) => maskMarkdown(text);
+
+  it("blanks a fenced code block, preserving length and newlines", () => {
+    const text = "before\n```js\n@Ada Lovelace\n```\nafter";
+    const out = masked(text);
+    assert.equal(out.length, text.length);
+    assert.equal(out.split("\n").length, text.split("\n").length);
+    assert.ok(out.startsWith("before\n"));
+    assert.ok(out.endsWith("\nafter"));
+    assert.ok(!out.includes("@Ada"));
+  });
+
+  it("blanks an unterminated fence to the end of the text", () => {
+    const out = masked("hi\n```\n@Ada Lovelace");
+    assert.ok(!out.includes("@Ada"));
+    assert.ok(out.startsWith("hi\n"));
+  });
+
+  it("blanks an inline code span", () => {
+    const text = "run `ping @Ada Lovelace` first";
+    const out = masked(text);
+    assert.equal(out.length, text.length);
+    assert.ok(!out.includes("@Ada"));
+    assert.ok(out.startsWith("run "));
+    assert.ok(out.endsWith(" first"));
+  });
+
+  it("blanks a markdown link, label and destination alike", () => {
+    const text = "see [@Ada Lovelace](https://x/@Bob Ross) ok";
+    const out = masked(text);
+    assert.equal(out.length, text.length);
+    assert.ok(!out.includes("@Ada"));
+    assert.ok(!out.includes("@Bob"));
+    assert.ok(out.endsWith(" ok"));
+  });
+
+  it("leaves ordinary prose exactly as it is", () => {
+    const text = "thanks @Ada Lovelace, that helped";
+    assert.equal(masked(text), text);
+  });
+});
+
+describe("resolveMentions", () => {
+  const pending = [
+    { userId: "u_ada", name: "Ada Lovelace" },
+    { userId: "u_bob", name: "Bob Ross" },
+  ];
+
+  it("keeps only the mentions whose text survived", () => {
+    assert.deepEqual(resolveMentions("thanks @Ada Lovelace!", pending), [
+      { userId: "u_ada", name: "Ada Lovelace" },
+    ]);
+  });
+
+  it("drops everything when the text was deleted", () => {
+    assert.deepEqual(resolveMentions("thanks!", pending), []);
+  });
+
+  it("dedupes by userId even when the name appears twice", () => {
+    assert.deepEqual(
+      resolveMentions("@Ada Lovelace and @Ada Lovelace", [
+        ...pending,
+        { userId: "u_ada", name: "Ada Lovelace" },
+      ]),
+      [{ userId: "u_ada", name: "Ada Lovelace" }],
+    );
+  });
+
+  it("drops a pending entry with no name (it can never be matched)", () => {
+    assert.deepEqual(resolveMentions("@Ada Lovelace", [{ userId: "u_x" }]), []);
+  });
+
+  it("does not resolve a mention that only appears inside a longer word", () => {
+    assert.deepEqual(resolveMentions("mail ada@Ada Lovelace", pending), []);
+  });
+
+  it("records nothing for a name the RENDERER would never chip", () => {
+    // Each of these renders as verbatim content, so a chip never appears —
+    // recording the mention would notify someone about a message that
+    // addresses them nowhere.
+    assert.deepEqual(resolveMentions("run `@Ada Lovelace`", pending), []);
+    assert.deepEqual(resolveMentions("```\n@Ada Lovelace\n```", pending), []);
+    assert.deepEqual(
+      resolveMentions("see [@Ada Lovelace](https://x)", pending),
+      [],
+    );
+    // …and the same name OUTSIDE the code span still ships.
+    assert.deepEqual(resolveMentions("run `x` @Ada Lovelace", pending), [
+      { userId: "u_ada", name: "Ada Lovelace" },
+    ]);
+  });
+});
+
+describe("resolveMentions — two teammates called Ana", () => {
+  const ANA1 = { userId: "u_a1", name: "Ana" };
+  const ANA2 = { userId: "u_a2", name: "Ana" };
+
+  it("ships the Ana the user actually picked, not the first in the roster", () => {
+    assert.deepEqual(resolveMentions("hi @Ana", [ANA2]), [ANA2]);
+  });
+
+  it("hands occurrences to picks in order: first @Ana, second @Ana", () => {
+    assert.deepEqual(resolveMentions("@Ana and @Ana", [ANA1, ANA2]), [
+      ANA1,
+      ANA2,
+    ]);
+  });
+
+  it("attributes a single occurrence to the first pick made under the name", () => {
+    assert.deepEqual(resolveMentions("just @Ana", [ANA1, ANA2]), [ANA1]);
+  });
+
+  it("repeats the first pick past the number of people picked", () => {
+    assert.deepEqual(resolveMentions("@Ana @Ana @Ana", [ANA2]), [ANA2]);
+  });
+});
+
+describe("mentionKeyAction", () => {
+  const press = (name: string, over: Partial<{ shiftKey: boolean }> = {}) => ({
+    key: name,
+    shiftKey: false,
+    isComposing: false,
+    ...over,
+  });
+
+  it("navigates, dismisses and accepts", () => {
+    assert.deepEqual(mentionKeyAction(press("ArrowDown"), 3), {
+      kind: "move",
+      step: 1,
+    });
+    assert.deepEqual(mentionKeyAction(press("ArrowUp"), 3), {
+      kind: "move",
+      step: 2,
+    });
+    assert.deepEqual(mentionKeyAction(press("Escape"), 3), { kind: "dismiss" });
+    assert.deepEqual(mentionKeyAction(press("Enter"), 3), { kind: "accept" });
+    assert.deepEqual(mentionKeyAction(press("Tab"), 3), { kind: "accept" });
+  });
+
+  it("takes NOTHING while an IME composition is in flight", () => {
+    for (const name of ["ArrowDown", "ArrowUp", "Escape", "Enter", "Tab"]) {
+      assert.equal(
+        mentionKeyAction({ key: name, shiftKey: false, isComposing: true }, 3),
+        null,
+        `${name} must belong to the IME candidate window`,
+      );
+    }
+  });
+
+  it("leaves Shift+Enter, plain keys and an empty list alone", () => {
+    assert.equal(mentionKeyAction(press("Enter", { shiftKey: true }), 3), null);
+    assert.equal(mentionKeyAction(press("a"), 3), null);
+    assert.equal(mentionKeyAction(press("Enter"), 0), null);
+  });
+});
+
+describe("the dismissal state machine", () => {
+  const open = (over: Partial<Parameters<typeof isMentionListOpen>[0]>) =>
+    isMentionListOpen({
+      enabled: true,
+      suggestionCount: 2,
+      active: { start: 4, query: "Ad" },
+      dismissedStart: null,
+      ...over,
+    });
+
+  it("is open on an active query with candidates", () => {
+    assert.equal(open({}), true);
+  });
+
+  it("is shut with no query, no candidates, or while disabled", () => {
+    assert.equal(open({ active: null }), false);
+    assert.equal(open({ suggestionCount: 0 }), false);
+    assert.equal(open({ enabled: false }), false);
+  });
+
+  it("STAYS shut for the rest of the token after a dismissal", () => {
+    // Escape at "@Ad", then one more character typed: same token, same start.
+    assert.equal(open({ dismissedStart: 4 }), false);
+    assert.equal(
+      open({ dismissedStart: 4, active: { start: 4, query: "Ada" } }),
+      false,
+    );
+  });
+
+  it("opens again for a NEW token", () => {
+    assert.equal(
+      open({ dismissedStart: 4, active: { start: 12, query: "Bo" } }),
+      true,
+    );
+  });
+
+  it("lifts the dismissal only when the token itself is gone", () => {
+    // Still inside the token: kept.
+    assert.equal(carryDismissal(4, { start: 4, query: "Ada" }), 4);
+    // The "@" was deleted / the caret left / it stopped being a name.
+    assert.equal(carryDismissal(4, null), null);
+  });
+});
+
+describe("pending mentions are scoped per draft", () => {
+  const A = "activity-a";
+  const B = "activity-b";
+  const ADA_PICK = { userId: "u_ada", name: "Ada Lovelace" };
+  const BOB_PICK = { userId: "u_bob", name: "Bob Ross" };
+
+  it("keeps one conversation's picks out of another's send", () => {
+    const drafts: PendingMentions = new Map();
+    recordPending(drafts, A, ADA_PICK);
+    assert.deepEqual(readPending(drafts, B), []);
+    assert.deepEqual(
+      resolveMentions("hi @Ada Lovelace", readPending(drafts, B)),
+      [],
+    );
+  });
+
+  it("survives switching away and back", () => {
+    const drafts: PendingMentions = new Map();
+    recordPending(drafts, A, ADA_PICK);
+    recordPending(drafts, B, BOB_PICK);
+    assert.deepEqual(readPending(drafts, A), [ADA_PICK]);
+    assert.deepEqual(
+      resolveMentions("hi @Ada Lovelace", readPending(drafts, A)),
+      [ADA_PICK],
+    );
+  });
+
+  it("ignores a person already parked in the same draft", () => {
+    const drafts: PendingMentions = new Map();
+    recordPending(drafts, A, ADA_PICK);
+    recordPending(drafts, A, ADA_PICK);
+    assert.deepEqual(readPending(drafts, A), [ADA_PICK]);
+  });
+
+  it("drops only the draft that was sent", () => {
+    const drafts: PendingMentions = new Map();
+    recordPending(drafts, A, ADA_PICK);
+    recordPending(drafts, B, BOB_PICK);
+    dropPending(drafts, A);
+    assert.deepEqual(readPending(drafts, A), []);
+    assert.deepEqual(readPending(drafts, B), [BOB_PICK]);
+  });
+
+  it("evicts the least recently touched draft past the cap", () => {
+    const drafts: PendingMentions = new Map();
+    recordPending(drafts, "oldest", ADA_PICK);
+    for (let i = 0; i < MENTION_DRAFT_LIMIT; i += 1) {
+      recordPending(drafts, `draft-${i}`, BOB_PICK);
+    }
+    assert.equal(drafts.size, MENTION_DRAFT_LIMIT);
+    assert.deepEqual(readPending(drafts, "oldest"), []);
+  });
+
+  it("a FAILED send keeps the picks; only a landed one drops them", async () => {
+    // Mirrors `chat-input.tsx`'s ordering: resolve, await onSend, then commit.
+    const drafts: PendingMentions = new Map();
+    recordPending(drafts, A, ADA_PICK);
+    const send = async (accepted: boolean) => {
+      const mentions = resolveMentions(
+        "hi @Ada Lovelace",
+        readPending(drafts, A),
+      );
+      if (!accepted) throw new Error("network down");
+      dropPending(drafts, A);
+      return mentions;
+    };
+
+    await assert.rejects(() => send(false));
+    // The text is still in the composer, so the retry must still carry Ada.
+    assert.deepEqual(readPending(drafts, A), [ADA_PICK]);
+    assert.deepEqual(await send(true), [ADA_PICK]);
+    assert.deepEqual(readPending(drafts, A), []);
+  });
+});
+
+describe("mentionRehypePlugin", () => {
+  const targets = [{ name: "Ada", userId: "u_short", isSelf: true }];
+  const run = (tree: unknown, list = targets) => {
+    mentionRehypePlugin({ targets: list })(tree);
+    return tree;
+  };
+  const paragraph = (...children: unknown[]) => ({
+    type: "root",
+    children: [{ type: "element", tagName: "p", children }],
+  });
+  type Node = { type: string; tagName?: string; value?: string };
+  const kids = (tree: unknown): Node[] =>
+    (tree as { children: { children: Node[] }[] }).children[0]
+      ?.children as Node[];
+
+  it("splits a text node around the mention", () => {
+    const tree = run(paragraph({ type: "text", value: "hi @Ada ok" }));
+    assert.deepEqual(
+      kids(tree).map((n) => n.value ?? n.tagName),
+      ["hi ", "span", " ok"],
+    );
+  });
+
+  it("marks the span with the name and the self flag", () => {
+    const tree = run(paragraph({ type: "text", value: "@Ada" }));
+    const span = kids(tree)[0] as { properties: Record<string, unknown> };
+    assert.equal(span.properties["data-mention-name"], "Ada");
+    assert.equal(span.properties["data-mention-self"], "");
+  });
+
+  it("never chips inside code, pre or link text", () => {
+    for (const tagName of ["code", "pre", "a"]) {
+      const tree = run(
+        paragraph({
+          type: "element",
+          tagName,
+          children: [{ type: "text", value: "@Ada" }],
+        }),
+      );
+      const inner = (kids(tree)[0] as { children: Node[] }).children;
+      assert.equal(inner.length, 1);
+      assert.equal(inner[0]?.type, "text");
+    }
+  });
+
+  it("chips an NFD name written in NFC prose, whole grapheme and all", () => {
+    const tree = run(paragraph({ type: "text", value: `hola @${JOSE_NFC}!` }), [
+      { name: JOSE_NFD, userId: "u_jose" },
+    ]);
+    const nodes = kids(tree);
+    assert.deepEqual(
+      nodes.map((n) => n.value ?? n.tagName),
+      ["hola ", "span", "!"],
+    );
+    const chip = nodes[1] as unknown as { children: Node[] };
+    assert.equal(chip.children[0]?.value, `@${JOSE_NFC}`);
+  });
+
+  it("leaves a mention-free tree untouched", () => {
+    const tree = run(paragraph({ type: "text", value: "nothing here" }));
+    assert.deepEqual(
+      kids(tree).map((n) => n.value),
+      ["nothing here"],
+    );
+  });
+});
+
+describe("feedItemsToMessages", () => {
+  it("carries a user message's mentions through to the ChatMessage", () => {
+    const items: FeedItem[] = [
+      {
+        feed_type: "user_message",
+        data: "ping @Ada Lovelace",
+        mentions: [{ userId: "u_ada", name: "Ada Lovelace" }],
+      },
+    ];
+    const [message] = feedItemsToMessages(items);
+    assert.deepEqual(message?.mentions, [
+      { userId: "u_ada", name: "Ada Lovelace" },
+    ]);
+  });
+
+  it("leaves mentions absent when the feed item carries none", () => {
+    const [message] = feedItemsToMessages([
+      { feed_type: "user_message", data: "hello" },
+    ]);
+    assert.equal(message?.mentions, undefined);
+  });
+});

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -71,6 +71,7 @@ import type {
   NewActivity,
   NewRoutine,
   OrgInfo,
+  OrgPerson,
   OrgRole,
   OrgSummary,
   OrgsList,
@@ -1399,6 +1400,26 @@ export class HoustonClient {
       if (isHoustonEngineError(err) && err.status === 404) {
         return { profiles: {} };
       }
+      throw err;
+    }
+  }
+  /**
+   * The sanitized co-member directory of the active space: every member the
+   * caller shares the space with (the personal space resolves only the caller),
+   * named-first. No emails, no roles — it exists so the composer can offer
+   * @mentions and the renderer can chip them. Degrades to an empty list on a
+   * host without the route (404), mirroring `getOrgProfiles`'s swallow, so a
+   * pre-feature gateway simply offers no autocomplete; every other error throws.
+   */
+  async getOrgPeople(): Promise<OrgPerson[]> {
+    try {
+      const body = await this.request<{ people?: OrgPerson[] }>(
+        "GET",
+        "/org/people",
+      );
+      return body.people ?? [];
+    } catch (err) {
+      if (isHoustonEngineError(err) && err.status === 404) return [];
       throw err;
     }
   }

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -183,6 +183,26 @@ export interface UserProfilesResult {
 }
 
 /**
+ * One co-member of the active space, from `GET /v1/org/people` (Teams). The
+ * sanitized directory: no email, no role. `displayName`/`photoUrl` come from
+ * the gateway's stored GCIP profile and are both optional.
+ */
+export interface OrgPerson {
+  userId: string;
+  displayName?: string;
+  photoUrl?: string;
+}
+
+/**
+ * One @mention of a human in a chat message. Mirrors the protocol
+ * `ChatMessage.mentions[]` entry.
+ */
+export interface MessageMention {
+  userId: string;
+  name?: string;
+}
+
+/**
  * A per-agent access level (Teams v2). `manager` may reconfigure the agent
  * (instructions, skills, model, allowed toolkits, assignments); `user` may only
  * use it. Kept in sync (by hand) with the gateway — the server is the source of
@@ -690,6 +710,9 @@ export interface Activity {
   /** Humans who started or collaborated on this mission (Teams attribution).
    *  Server-stamped in multiplayer only; absent on desktop/single-player. */
   contributors?: { user_id: string; name?: string }[];
+  /** Teammates @mentioned in this mission's chat, latest per person.
+   *  Server-stamped in multiplayer only; absent on desktop/single-player. */
+  mentioned?: { user_id: string; at: string; by?: string }[];
 }
 
 export interface ActivityUpdate {
@@ -939,6 +962,9 @@ export interface ConversationEntry {
   /** Humans who started or collaborated on this mission (Teams attribution).
    *  Server-stamped in multiplayer only; absent on desktop/single-player. */
   contributors?: { user_id: string; name?: string }[];
+  /** Teammates @mentioned in this mission's chat, latest per person.
+   *  Server-stamped in multiplayer only; absent on desktop/single-player. */
+  mentioned?: { user_id: string; at: string; by?: string }[];
 }
 
 // ---------- Skills ----------
@@ -1346,6 +1372,15 @@ export interface SessionStartRequest {
    * single-player / signed out, leaving the bubble authorless.
    */
   author?: { userId: string; name?: string };
+  /**
+   * The teammates this message @mentions, as a structured sidecar ALONGSIDE the
+   * prompt (HOU-944). The model only ever sees the plain `@Name` text the user
+   * typed; this list carries the identities the composer resolved, so the sent
+   * bubble can chip them and a later notifications feature can scan a
+   * conversation for `mentions[].userId === me`. Omitted when the message
+   * mentions nobody, and in single-player deployments (no roster to mention).
+   */
+  mentions?: MessageMention[];
 }
 
 export interface SessionStartResponse {
@@ -1365,6 +1400,13 @@ export interface ChatHistoryEntry {
    * Absent on every other feed type and in single-player mode.
    */
   author?: { userId: string; name?: string };
+  /**
+   * The teammates a `user_message` entry @mentions (HOU-944), carried through
+   * to the ui/chat feed so a reloaded transcript chips the same names the sent
+   * bubble did. Absent on every other feed type and whenever the message
+   * mentioned nobody.
+   */
+  mentions?: MessageMention[];
 }
 
 export interface SummarizeResult {

--- a/ui/engine-client/src/vm.ts
+++ b/ui/engine-client/src/vm.ts
@@ -11,6 +11,9 @@
  * Shape-compatible with `@houston/sdk`'s `SnapshotSource` — kept dependency-free
  * on purpose (this package has no deps).
  */
+
+import type { MessageMention } from "./types";
+
 export interface ConversationSnapshotSource {
   subscribe(scope: string, cb: (snapshot: unknown) => void): () => void;
   getSnapshot(scope: string): unknown | undefined;
@@ -31,6 +34,7 @@ export function pushPendingUserMessage(
   _sessionKey: string,
   _text: string,
   _author?: { userId: string; name?: string },
+  _mentions?: MessageMention[],
 ): void {}
 
 /**


### PR DESCRIPTION
Fixes HOU-944
Fixes HOU-945

**Stack 4/4** — based on #1111; merge last. One PR for both issues because they are one system: mentions feed the notifications by design (HOU-944's issue text), and the implementations interleave across ~188 files.

Requires [gethouston/cloud#189](https://github.com/gethouston/cloud/pull/189) (the `GET /v1/org/people` directory) for autocomplete on a live gateway; an older gateway 404s and the app degrades to no autocomplete.

## @mentions (HOU-944)

- Composer `@` autocomplete over the space's sanitized people directory: keyboard-first (arrows/Enter/Tab/Escape), full combobox ARIA (`aria-activedescendant`), IME-safe (all keys yield to the candidate window), dismissal lasts the token's lifetime, clicking into your own `@query` doesn't dismiss.
- Mentions are a structured sidecar (`ChatMessage.mentions`), not markup: plain `@Name` text for the model, `{userId, name}` on the wire, guarded at every untrusted ingress by `parseMentions` (count/length caps, dedupe, bounded scan). Draft-scoped per conversation; survive failed sends, relaunch, and the IndexedDB cold-reopen path.
- Chips render in human bubbles (driven off stored mentions) and agent prose (rehype pass appended after Streamdown's raw→sanitize→harden chain — verified against the bundle; names are XSS-inert). Self-mentions get highlight emphasis. NFC normalization keeps accented names whole; two teammates sharing a display name each keep their identity. Send-time resolution masks code blocks/spans/links so nobody is notified from inside a code fence.
- Agents are prompted to `@Name` a person when asking for confirmation.

## Relevance-scoped notifications (HOU-945)

- Completion pings fire only for missions relevant to the viewer (the existing mission `me` scope: my face on it, or unattributed). **Fail-open** — desktop/single-player behavior is byte-identical.
- Missions carry a server-stamped mention aggregate (`Activity.mentioned`, stamped with contributors in one load→save→emit pass, gateway-only, best-effort-never-blocks preserved).
- Per-uid read cursors (localStorage, versioned, cross-tab `storage`-event merge, orphan pruning) drive: quiet unread dots on sidebar agents and mission cards, one OS ping per new mention (exactly-once watermark; cleared by reading the mission), and a **Mentions inbox** as Mission Control's third mode (hidden off-multiplayer). The toolbar pill counts only outstanding mentions, not ambient movement.

## Verification

Full workspace green at the head: all package suites (sdk 392, ui/chat 287, ui/board 56, runtime 809+, host 1061, domain 163, app 2240), repo-wide biome/typecheck/parity (inventory v38+v39)/boundaries/locales, e2e chat-mentions 3/3 + mentions-inbox 6/6 + all wave-1 specs, visual baselines unchanged, full chromium e2e suite passed during development (154). Both features were adversarially reviewed by independent finder agents; every confirmed finding was fixed (NFC matching, duplicate names, trust-boundary caps, a per-render cursor write storm, mention-ping-clears-on-open, multi-tab merge, and more — see commit body).

Known follow-ups (not in scope, happy to file): the runtime's own malformed-turn-body parse still 500s on the desktop/proxy path (the host's cloudrun path now 400s); `ui/core` primitives spread `{...props}` after `data-slot`, which is what let Radix `asChild` clobber the avatar ring pre-#1109; `KanbanDetailPanel`'s close button lacks an aria-label (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)