### PR TITLE
fix: boundary scanner no longer reads string contents as imports

### DIFF
--- a/scripts/check-boundaries.mjs
+++ b/scripts/check-boundaries.mjs
@@ -207,6 +207,12 @@ function stripComments(src) {
   let i = 0;
   const n = src.length;
   let quote = null;
+  let quoteStart = -1;
+  /** [start, end) spans of string-literal CONTENTS in `out` (quotes excluded),
+   *  so the matcher can reject a keyword that sits INSIDE a string — e.g. a
+   *  test title ending in the word `from",` reads as `from "<code...>"` to a
+   *  span-blind regex and false-FAILs the gate. */
+  const stringSpans = [];
   while (i < n) {
     const c = src[i];
     const d = src[i + 1];
@@ -217,13 +223,17 @@ function stripComments(src) {
         i += 2;
         continue;
       }
-      if (c === quote) quote = null;
+      if (c === quote) {
+        stringSpans.push([quoteStart, out.length - 1]);
+        quote = null;
+      }
       i++;
       continue;
     }
     if (c === '"' || c === "'" || c === "`") {
       quote = c;
       out += c;
+      quoteStart = out.length;
       i++;
       continue;
     }
@@ -240,7 +250,8 @@ function stripComments(src) {
     out += c;
     i++;
   }
-  return out;
+  if (quote) stringSpans.push([quoteStart, out.length]);
+  return { out, stringSpans };
 }
 
 /**
@@ -252,8 +263,16 @@ const SPEC_RE =
   /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s+|\brequire\s*\(\s*)["']([^"']+)["']/g;
 
 function importsOf(src) {
+  const { out, stringSpans } = stripComments(src);
+  const insideString = (idx) =>
+    stringSpans.some(([start, end]) => idx >= start && idx < end);
   const specs = [];
-  for (const m of stripComments(src).matchAll(SPEC_RE)) specs.push(m[1]);
+  for (const m of out.matchAll(SPEC_RE)) {
+    // A keyword inside a string literal is prose, not an import — the string
+    // AFTER a real keyword is the specifier and is rightly its own span.
+    if (insideString(m.index)) continue;
+    specs.push(m[1]);
+  }
   return specs;
 }
 

--- a/scripts/test/check-boundaries.test.sh
+++ b/scripts/test/check-boundaries.test.sh
@@ -167,6 +167,20 @@ export const v = x;
 EOF
 assert_pass "commented-out cloud import does not false-fail"
 
+# String contents — a string ENDING in the word `from` reads as `from "<code>"`
+# to a span-blind regex (e.g. a test title: `test("who it came from", async`),
+# and prose after it became the phantom specifier. Neither may false-fail; a
+# REAL import in the same file must still be seen.
+reset_fixture
+cat > "$TMP/packages/host/src/string-froms.ts" <<'EOF'
+import { x } from "@houston/domain";
+export const title = "who it came from";
+export const also = `derived from`;
+export const union = title ? "own" : "peer";
+export const v = x;
+EOF
+assert_pass "a string ending in the word from does not false-fail"
+
 # ---------------------------------------------------------------------------
 echo
 printf 'PASS %d  FAIL %d\n' "$pass" "$fail"


### PR DESCRIPTION
Unblocks the daily cloud cut: main's TS-checks job is red on two FALSE positives from `check-boundaries.mjs` — a test title ending in the word "from" (`chat-senders.spec.ts`) and a doc string in `author-label.ts` read as `from "<code>"` to the span-blind regex. No real leak exists.

The comment stripper (already string-aware) now records string-literal spans; the specifier matcher rejects any keyword inside one. Real imports still match (the specifier is the string AFTER the keyword). Regression test added — 14/14, and `pnpm check:boundaries` is green on the real tree (980 files).

No Linear issue — CI-infra hotfix unblocking the cloud-v0.5.30 cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)