### PR TITLE
feat(settings): hide the API keys row — Agents API via Routines tab for now (HOU-806)

### DIFF
--- a/app/src/components/settings/settings-index.tsx
+++ b/app/src/components/settings/settings-index.tsx
@@ -4,7 +4,6 @@ import {
   CloudUpload,
   FileText,
   Keyboard,
-  KeyRound,
   User,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -23,7 +22,6 @@ import { SettingsCard, SettingsRow } from "./settings-row";
 
 interface SettingsIndexProps {
   accountAvailable: boolean;
-  apiKeysAvailable: boolean;
   migrationAvailable: boolean;
   profileAvailable: boolean;
   onSelect: (id: SettingsSectionId) => void;
@@ -37,7 +35,6 @@ interface SettingsIndexProps {
  */
 export function SettingsIndex({
   accountAvailable,
-  apiKeysAvailable,
   migrationAvailable,
   profileAvailable,
   onSelect,
@@ -87,14 +84,10 @@ export function SettingsIndex({
           <LanguageSection />
           <NotificationsSection />
           {accountAvailable && <AccountSection />}
-          {apiKeysAvailable && (
-            <SettingsRow
-              icon={KeyRound}
-              title={t("settings:nav.apiKeys")}
-              description={t("settings:index.rows.apiKeys")}
-              onClick={() => onSelect("apiKeys")}
-            />
-          )}
+          {/* The API-keys row is HIDDEN for now (HOU-806): the Agents API
+              surface lives in the Routines tab. The section, its strings, and
+              all plumbing remain — restore by re-adding this row (and the
+              apiKeysAvailable gate from apiKeysSupported) when it returns. */}
         </SettingsCard>
 
         <SettingsCard title={t("settings:index.groups.context")}>

--- a/app/src/components/settings/settings-view.tsx
+++ b/app/src/components/settings/settings-view.tsx
@@ -9,8 +9,6 @@ import {
 import { ChevronLeft } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useCapabilities } from "../../hooks/use-capabilities";
-import { apiKeysSupported } from "../../lib/api-keys-model";
 import {
   parseSettingsSection,
   type SettingsSectionId,
@@ -39,8 +37,6 @@ export function SettingsView() {
   const accountAvailable = useAccountAvailable();
   const profileAvailable = useProfileAvailable();
   const migrationAvailable = useMigrationAvailable();
-  const { capabilities } = useCapabilities();
-  const apiKeysAvailable = apiKeysSupported(capabilities);
   const setSettingsSection = useUIStore((s) => s.setSettingsSection);
   // Consume the one-shot deep-link the moment this view mounts: another surface
   // may have pinned a section (e.g. "apiKeys") right before switching to
@@ -109,7 +105,6 @@ export function SettingsView() {
       <div className="flex-1 overflow-y-auto">
         <SettingsIndex
           accountAvailable={accountAvailable}
-          apiKeysAvailable={apiKeysAvailable}
           migrationAvailable={migrationAvailable}
           profileAvailable={profileAvailable}
           onSelect={setActive}
@@ -138,6 +133,10 @@ export function SettingsView() {
         ) : (
           <div className="mx-auto max-w-xl px-8 pb-10">
             {active === "profile" && <ProfileSection />}
+            {/* The API-keys screen is HIDDEN from the index for now (HOU-806:
+                the Agents API surface lives in the Routines tab) — its nav row
+                is gone, so only a programmatic deep-link pin reaches it. The
+                section and its plumbing stay intact for when it returns. */}
             {active === "apiKeys" && <ApiKeysSection />}
             {active === "shortcuts" && <ShortcutsSection />}
             {active === "reportBug" && <ReportBugSection />}


### PR DESCRIPTION
Follow-up to HOU-806 ("it should be only in Routines for now"): the Settings → API keys **nav row is hidden**, making the Routines tab's webhook flow the only user-visible door to the agent's API.

**Hide, not delete** — 2 files, 8 insertions, 16 deletions:
- `settings-index.tsx`: the API-keys row no longer renders (comment marks the spot and how to restore).
- `settings-view.tsx`: stops computing/passing the row's gate; the `apiKeys` screen render stays (deep-link-only now).

Everything else is untouched and alive: the section components, `useApiKeys`, `tauriApiKeys`, `api-keys-model`, the `apiKeys` section id, en/es/pt strings, and all tests. Restoring the surface = re-adding one row. The gateway keeps serving `/v1/keys`; **existing `hst_` keys keep working**.

Known consequence (deliberate, per "only in Routines for now"): no in-app mint/revoke of `hst_` keys, so the missions/MCP/A2A faces have no user-reachable credential and the developer docs' "Settings → API Keys" reference goes stale — docs follow-up when this merges.

Gates: typecheck, biome, check-locales, app unit tests (2242) all green.