### PR TITLE
fix(runtime): bound integration tool results — a 1 MB Gmail fetch killed every trigger run (HOU-893)

### DIFF
--- a/packages/runtime/src/session/tools/integrations.test.ts
+++ b/packages/runtime/src/session/tools/integrations.test.ts
@@ -209,6 +209,31 @@ test("execute runs an action and returns its data; a failed action surfaces", as
   ).rejects.toThrow(/did not succeed: missing recipient/);
 });
 
+test("a giant execute result is truncated with recovery guidance, never fed whole", async () => {
+  // A single Gmail fetch with full payloads exceeds 1 MB of JSON — enough to
+  // overflow a model context window on its own (HOU-893: every event-trigger
+  // run on a newsletter inbox died with a terminal context-window error).
+  mockFetch(() => ({
+    body: { successful: true, data: { html: "x".repeat(1_200_000) } },
+  }));
+  const out = await run(execute, {
+    action: "GMAIL_FETCH_EMAILS",
+    params: { include_payload: true },
+  });
+  const text = (out.content[0] as { text: string }).text;
+  expect(text.length).toBeLessThan(300 * 1024);
+  expect(text).toContain("[result truncated");
+  expect(text).toContain("Re-run the action with tighter parameters");
+});
+
+test("a small execute result passes through untouched", async () => {
+  mockFetch(() => ({ body: { successful: true, data: { ok: 1 } } }));
+  const out = await run(execute, { action: "X", params: {} });
+  expect((out.content[0] as { text: string }).text).not.toContain(
+    "[result truncated",
+  );
+});
+
 test("a no-connected-account failure hands off to request_connection", async () => {
   mockFetch(() => ({
     body: { successful: false, error: "no connected account found for user" },

--- a/packages/runtime/src/session/tools/integrations.ts
+++ b/packages/runtime/src/session/tools/integrations.ts
@@ -161,6 +161,23 @@ function renderMatch(m: ToolMatch, status: AppStatus): string {
  */
 const REQUEST_CONNECTION_GUIDANCE =
   "To let the user connect an app, call the request_connection tool with that app's toolkit (the slug shown in the results). Houston shows the user a one-click connect card in place of the chat input, then automatically sends you a message once the connection is live so you can continue - do not ask the user to confirm.";
+
+/**
+ * Ceiling for one integration tool result, aligned with the code sandbox's
+ * output limit (code-sandbox DEFAULT_LIMITS.maxOutputBytes). App APIs return
+ * unbounded documents — a single GMAIL_FETCH_EMAILS with include_payload can
+ * exceed 1 MB of JSON, which alone overflows a model's context window and
+ * terminally errors the turn (every event-trigger run on a newsletter inbox
+ * died this way, HOU-893). Truncate with an instructive marker instead: the
+ * model re-runs the action with tighter parameters rather than the turn dying.
+ */
+const MAX_RESULT_CHARS = 256 * 1024;
+
+/** Bound a tool-result text; the marker tells the model how to recover. */
+function boundResultText(text: string, guidance: string): string {
+  if (text.length <= MAX_RESULT_CHARS) return text;
+  return `${text.slice(0, MAX_RESULT_CHARS)}\n[result truncated: it exceeded the ${Math.floor(MAX_RESULT_CHARS / 1024)} KB tool-result limit and is cut off mid-document. ${guidance}]`;
+}
 interface ActionResult {
   successful: boolean;
   data?: unknown;
@@ -293,7 +310,15 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
         );
       }
       return {
-        content: [{ type: "text" as const, text: parts.join("\n\n") }],
+        content: [
+          {
+            type: "text" as const,
+            text: boundResultText(
+              parts.join("\n\n"),
+              "Search again with a more specific query to see the actions that were cut off.",
+            ),
+          },
+        ],
         details: {
           matches: items.length,
           actions: items.filter((m) => m.action).map((m) => m.action),
@@ -360,7 +385,10 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
           : "";
         throw new Error(`"${params.action}" did not succeed: ${reason}${hint}`);
       }
-      const text = result.data ? JSON.stringify(result.data, null, 2) : "Done.";
+      const text = boundResultText(
+        result.data ? JSON.stringify(result.data, null, 2) : "Done.",
+        "Do not rely on the cut-off tail. Re-run the action with tighter parameters — fewer results, specific ids or fields, and without full payloads/bodies — to get what you need within the limit.",
+      );
       return {
         content: [{ type: "text" as const, text }],
         details: { action: params.action },


### PR DESCRIPTION
## Root cause

`integration_execute` fed the app API's response to the model verbatim — `JSON.stringify(result.data)` with no size bound. `GMAIL_FETCH_EMAILS` with `include_payload: true` returns **0.4–1 MB+** for a real inbox (newsletter HTML, inline content). One such tool result overflows the model's context window on its own: the turn dies with a terminal *"input exceeds the context window"* provider error, the runtime's compaction discards the pending task (the next reply is "I'm ready. What would you like me to help with?"), and the routine run is marked `error`.

Diagnosed on a live production repro (HOU-893, "set up a Gmail trigger, it never fired"): the C9 trigger pipeline delivered **every** event correctly — three runs fired within minutes — but each turn died mid-flight on the giant tool result, so the automation read as broken. Pod session jsonl showed the sequence per run: `integration_search` (110 KB) → `integration_execute` GMAIL_FETCH_EMAILS (≈1 MB) → `compaction` → terminal context-window error.

This affects any turn that touches a large app-API response; event triggers just make it near-certain (every newsletter email trips it).

## Fix

Truncate `integration_search` / `integration_execute` result text at **256 KB** — the same ceiling the code sandbox applies to program output (`DEFAULT_LIMITS.maxOutputBytes`) — with a marker that tells the model the result is cut off mid-document and to re-run the action with tighter parameters (fewer results, specific ids/fields, no full payloads) instead of relying on the tail.

## Verification

- New tests: a 1.2 MB execute result is truncated with the recovery guidance; a small result passes through untouched.
- `pnpm --filter @houston/runtime test` — 816 passed.
- Before the fix (prod): every `GMAIL_NEW_GMAIL_MESSAGE` trigger run on a real inbox errored with the context-window message. After: the fetch result is bounded, the turn completes.

HOU-893