### PR TITLE
fix: honest guidance when a user lacks access to an agent's integrations

### DIFF
--- a/knowledge-base/integrations.md
+++ b/knowledge-base/integrations.md
@@ -131,6 +131,18 @@ guidance (the app is turned off for this agent; tell the user to enable it in th
 Permissions tab; do not retry until they confirm), never a thrown/raw error.
 Marked `details.appTurnedOff`.
 
+**No access to the agent (HOU-967).** The gateway 403s with `{code:"not_assigned"}`
+when the acting user is not one of the people with access to the agent. BOTH
+`integration_search` and `integration_execute` classify that code and RETURN
+guidance (the user has no access; someone who manages the agent gives it to them in
+Permissions > this agent > People; do not retry, do not `request_connection`),
+marked `details.noAgentAccess`. The gateway's own phrasing ("isn't assigned to you")
+and its JSON body never reach the model — it paraphrases whatever we hand it.
+Same rule for any OTHER unrecognized 4xx: the body is REDACTED from the thrown
+message, leaving `integrations <path> failed (<status>[, code <code>])` plus a plain
+instruction not to quote technical detail. Uncoded 5xx keeps its body (transient,
+diagnostic).
+
 **Prompt contract — the four speech acts.** `packages/host/src/houston-prompt.ts`
 INTEGRATIONS section and its verbatim Rust mirror
 `app/src-tauri/src/houston_prompt/integrations.rs` (`PI_INTEGRATIONS_GUIDANCE`,

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -657,9 +657,9 @@ hides the "Add models" list, all copy passed in.
 Members can only connect apps the agent allows. See `integrations.md` §2
 for the full model. In short: `effective = agentCeiling` (`null` = all, `[]` =
 none — the org-wide ceiling was removed 2026-07-16 as overengineering; policy is
-per agent only), grants are pruned when the ceiling shrinks, and a per-agent
-connect carries the agent slug so the gateway checks the allowlist and auto-grants
-on success.
+per agent only), now-disallowed toolkits are pruned from live connections when the
+ceiling shrinks, and a per-agent connect carries the agent slug so the gateway
+checks the toolkit against the allowlist on a successful OAuth.
 
 **The per-agent ceiling has one frontend home** — the shared presentational
 `AllowlistEditor` (`app/src/components/integrations/allowlist-editor.tsx`):
@@ -672,10 +672,12 @@ on success.
   Integrations tab (`permissions/agent-detail.tsx`), same editor, same wire.
 
 The global Integrations page has no ceiling to apply (policy is per agent), so it
-never locks a row — it's the personal catalog for every member. Per-agent GRANT
-toggles are a separate concept and live only on the global Integrations page's app
-detail modal (the ONE by-app grants lens; the Settings row deep-links there), never
-in the ceiling editor.
+never locks a row — it's the personal catalog for every member. Connections are
+per USER and global: one connection serves every agent that person may use.
+**Usable = connected AND the person may use the agent AND the toolkit is inside
+that agent's app ceiling.** There are no grants anywhere — the per-`(user, agent)`
+grants layer was DELETED (client, host and UI; `integrations.md` §2), so no
+surface carries a grant toggle, the app detail modal included.
 
 **Design principle: blocked is visible, never silently hidden.** Applied wherever the
 agent ceiling narrows a member's world: the per-agent Integrations tab ITEMIZES the

--- a/packages/runtime/src/session/tools/integrations.test.ts
+++ b/packages/runtime/src/session/tools/integrations.test.ts
@@ -399,7 +399,11 @@ test("a 409 (approval_required) is no longer special: it surfaces as a generic e
   const failure = runWithInteractionCapture(holder, () =>
     run(execute, { action: "GMAIL_SEND_EMAIL", params: { to: "a@b.com" } }),
   );
-  await expect(failure).rejects.toThrow(/integrations execute failed \(409\)/);
+  await expect(failure).rejects.toThrow(
+    /integrations execute failed \(409, code approval_required\)/,
+  );
+  // Unrecognized 4xx → the body (toolkit, action, params hash) is redacted.
+  await expect(failure).rejects.not.toThrow(/paramsHash|h7f3a1/);
   expect(holder.pending).toBeUndefined();
 });
 
@@ -435,6 +439,81 @@ test("a 403 (toolkit_not_allowed) returns Permissions-tab guidance, not a raw er
   });
   // No interaction card is queued — the fix lives in the Permissions tab.
   expect(holder.pending).toBeUndefined();
+});
+
+test("a 403 (not_assigned) returns access guidance on BOTH search and execute, never the gateway's words", async () => {
+  // HOU-967: the gateway refuses when the acting user isn't one of the people
+  // with access to this agent. Its body ("this agent isn't assigned to you")
+  // is internal jargon the model used to paraphrase at a non-technical user —
+  // so both tools classify the stable code and RETURN the human remedy.
+  const notAssigned = () => ({
+    status: 403,
+    body: { error: "this agent isn't assigned to you", code: "not_assigned" },
+  });
+  const holder = newInteractionHolder();
+
+  mockFetch(notAssigned);
+  const found = await runWithInteractionCapture(holder, () =>
+    run(search, { query: "send an email" }),
+  );
+  mockFetch(notAssigned);
+  const ran = await runWithInteractionCapture(holder, () =>
+    run(execute, { action: "GMAIL_SEND_EMAIL", params: { to: "a@b.com" } }),
+  );
+
+  for (const out of [found, ran]) {
+    const text = (out.content[0] as { text: string }).text;
+    expect(text).toContain("does not have access to this agent");
+    // The remedy names the exact place a manager fixes it.
+    expect(text).toContain("Permissions");
+    expect(text).toContain("People");
+    expect(text).toContain("Do not retry");
+    // Never the raw body, the gateway's jargon, or a connect offer.
+    expect(text).not.toContain("not_assigned");
+    expect(text).not.toContain("assigned");
+    expect(text).not.toContain("{");
+    expect(text).not.toContain("403");
+  }
+  expect(found.details).toEqual({
+    matches: 0,
+    actions: [],
+    noAgentAccess: true,
+  });
+  expect(ran.details).toEqual({
+    action: "GMAIL_SEND_EMAIL",
+    noAgentAccess: true,
+  });
+  // A permission state, not an interaction: nothing is queued for the user.
+  expect(holder.pending).toBeUndefined();
+});
+
+test("an unrecognized 4xx redacts the response body, keeping only status + code", async () => {
+  // The model reads whatever we throw, so an unclassified refusal must not hand
+  // it gateway JSON to paraphrase — status + code survive for the logs.
+  mockFetch(() => ({
+    status: 422,
+    body: {
+      error: "tenant xyz-9 exceeded seat_policy for org 41f",
+      code: "seat_policy_violation",
+    },
+  }));
+  const failure = run(execute, { action: "GMAIL_SEND_EMAIL" });
+  await expect(failure).rejects.toThrow(
+    /integrations execute failed \(422, code seat_policy_violation\)/,
+  );
+  await expect(failure).rejects.toThrow(/never quote this message/);
+  // No trace of the body: no JSON, no upstream prose.
+  await expect(failure).rejects.not.toThrow(/tenant xyz-9/);
+  await expect(failure).rejects.not.toThrow(/seat_policy for org/);
+  await expect(failure).rejects.not.toThrow(/[{}]/);
+
+  // Search redacts identically.
+  mockFetch(() => ({ status: 400, body: { error: "bad query for org 41f" } }));
+  const searchFailure = run(search, { query: "x" });
+  await expect(searchFailure).rejects.toThrow(
+    /integrations search failed \(400\)\./,
+  );
+  await expect(searchFailure).rejects.not.toThrow(/bad query/);
 });
 
 test("a RELAYED upstream 403 (no code) stays a generic error, not the turned-off guidance", async () => {

--- a/packages/runtime/src/session/tools/integrations.ts
+++ b/packages/runtime/src/session/tools/integrations.ts
@@ -98,6 +98,31 @@ class ToolkitNotAllowedError extends Error {
   }
 }
 
+/**
+ * Thrown by `post()` when the gateway REFUSED because the acting USER may not
+ * use this agent at all (403 "not_assigned" — they are not among the people
+ * with access to it). Module-private and handled by BOTH tools: like the
+ * allowlist refusal, it is an expected, user-fixable permission state, so each
+ * tool RETURNS guidance rather than failing. Classified on the stable `code`,
+ * never the bare 403 (a relayed upstream 403 carries no such code).
+ */
+class NoAgentAccessError extends Error {
+  constructor() {
+    super("no agent access");
+    this.name = "NoAgentAccessError";
+  }
+}
+
+/**
+ * What the model must say when the user may not use this agent. The gateway's
+ * own wording is internal jargon ("this agent isn't assigned to you") and its
+ * body is JSON — both would be paraphrased straight at a non-technical user, so
+ * neither ever reaches the model. This does: the state, the human remedy, and
+ * the exact place someone who manages the agent fixes it.
+ */
+const NO_AGENT_ACCESS_GUIDANCE =
+  "The user does not have access to this agent, so its connected apps cannot be used for them. Tell the user plainly that someone who manages this agent needs to give them access to it, in Permissions: open this agent and add them under People. Do not retry until they confirm they have access, do not call request_connection, and never imply Houston lacks the app or that something is broken.";
+
 export interface IntegrationToolOptions {
   /** The host control-plane base URL (HOUSTON_CONTROL_PLANE_URL). */
   baseUrl: string;
@@ -210,6 +235,13 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
       if (code === "toolkit_not_allowed") {
         throw new ToolkitNotAllowedError();
       }
+      // not_assigned (403): the gateway refused because the acting user is not
+      // one of the people with access to this agent — a permission state a
+      // manager fixes in Permissions > this agent > People. Applies to search
+      // and execute alike, so both tools turn the typed error into guidance.
+      if (code === "not_assigned") {
+        throw new NoAgentAccessError();
+      }
       // signin_required (409): integrations can't act for this user yet (on
       // desktop: they're signed out of Houston, so the gateway has no session to
       // forward) — a normal, actionable state. Queue a signin step in THIS
@@ -233,6 +265,16 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
           "Connected apps are not set up in this Houston install. Tell the user plainly that connected apps aren't available here (a self-hoster enables them by setting COMPOSIO_API_KEY), and do not offer to connect any apps.",
         );
       }
+      // Anything else. A 4xx is a REFUSAL, and its body is gateway/provider
+      // JSON written for us, not for a person — the model reads whatever we
+      // throw and paraphrases it straight at the user, so the body is REDACTED
+      // and only the status (+ any unrecognized code, for the logs) survives. A
+      // 5xx is a transient upstream failure whose body is genuinely diagnostic.
+      if (res.status >= 400 && res.status < 500) {
+        throw new Error(
+          `integrations ${path} failed (${res.status}${code ? `, code ${code}` : ""}). The request was refused. Tell the user plainly that this could not be done right now, and never quote this message, any code, or any other technical detail to them.`,
+        );
+      }
       throw new Error(
         `integrations ${path} failed (${res.status}): ${detail.slice(0, 300)}`,
       );
@@ -240,7 +282,12 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
     return (await res.json()) as T;
   }
 
-  const search = defineTool({
+  const search = defineTool<
+    typeof SearchParams,
+    // Pinned so the result path ({ matches, actions }) and the no-access path
+    // (which adds the flag) share ONE details type.
+    { matches: number; actions: string[]; noAgentAccess?: boolean }
+  >({
     name: "integration_search",
     label: "Find an app action",
     description:
@@ -253,11 +300,27 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
       params: SearchParams,
       signal: AbortSignal | undefined,
     ) {
-      const { items } = await post<{ items: ToolMatch[] }>(
-        "search",
-        { query: params.query },
-        signal,
-      );
+      let items: ToolMatch[];
+      try {
+        ({ items } = await post<{ items: ToolMatch[] }>(
+          "search",
+          { query: params.query },
+          signal,
+        ));
+      } catch (err) {
+        // The user may not use this agent at all: not a search failure, a
+        // permission state someone who manages the agent fixes. Return the
+        // guidance so the model relays it in Houston's voice.
+        if (err instanceof NoAgentAccessError) {
+          return {
+            content: [
+              { type: "text" as const, text: NO_AGENT_ACCESS_GUIDANCE },
+            ],
+            details: { matches: 0, actions: [], noAgentAccess: true },
+          };
+        }
+        throw err;
+      }
       if (items.length === 0) {
         // Genuinely empty: not a policy block, not "unavailable" - no such app
         // or action was found. The prompt tells the model to say so plainly.
@@ -304,10 +367,10 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
 
   const execute = defineTool<
     typeof ExecuteParams,
-    // Pinned so the success path ({ action }) and the walled-off path
-    // ({ action, appTurnedOff: true }) share ONE details type — the flag is
+    // Pinned so the success path ({ action }) and the refused paths (walled-off
+    // app, no access to the agent) share ONE details type — each flag is
     // present only in its state.
-    { action: string; appTurnedOff?: boolean }
+    { action: string; appTurnedOff?: boolean; noAgentAccess?: boolean }
   >({
     name: "integration_execute",
     label: "Run an app action",
@@ -346,6 +409,16 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
               },
             ],
             details: { action, appTurnedOff: true },
+          };
+        }
+        // The user may not use this agent at all — same shape: an expected
+        // permission state, returned as guidance rather than a failure.
+        if (err instanceof NoAgentAccessError) {
+          return {
+            content: [
+              { type: "text" as const, text: NO_AGENT_ACCESS_GUIDANCE },
+            ],
+            details: { action: params.action, noAgentAccess: true },
           };
         }
         throw err;


### PR DESCRIPTION
Part of HOU-967 (the gateway root-cause fix is gethouston/cloud#193 — it carries the Fixes line).

When the gateway denies an integration call with `403 not_assigned`, the runtime tool threw the raw JSON and the model paraphrased it to the user as 'the integrations aren't assigned to this agent' — jargon that exists nowhere in the product and has no UI fix path.

- `not_assigned` is now classified on both search and execute: the model gets plain guidance (the user needs access to this agent; whoever manages it can add them under Permissions → People), returned not thrown, marked as an expected user-fixable state.
- Any unrecognized 4xx is redacted to status + code — gateway JSON can never again reach a non-technical user (the 409 test's leaked paramsHash is gone too).
- Stale `knowledge-base/teams.md` paragraphs describing the deleted grants layer rewritten to the current model.

Tests: integrations tool 24/24 (new: not_assigned guidance on both paths asserting no raw JSON; unknown-4xx redaction); full runtime suite green except the pre-existing, unrelated `opus-5-catalog` local-env failure (fails identically on clean origin/main); repo typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)