### PR TITLE
fix(release): channel-aware changelog range + draft-aware Slack link (HOU-972)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,17 @@ jobs:
           else
             echo "No $AUTHORED — falling back to auto-generated changelog"
 
-            PREV_TAG=$(git tag --sort=-v:refname --list 'v*' | grep -v "^${GITHUB_REF_NAME}$" | head -1)
+            # Diff against the previous tag on the SAME channel. A cloud-v*
+            # pre-release diffs against the previous cloud-v* cut; a local v*
+            # release against the previous v*. The glob 'v*' never matches
+            # cloud-v* tags, so a single shared glob made every cloud draft
+            # diff against the last LOCAL release — weeks of commits in the
+            # notes instead of one day's train (HOU-972).
+            case "$GITHUB_REF_NAME" in
+              cloud-*) TAG_GLOB='cloud-v*' ;;
+              *)       TAG_GLOB='v*' ;;
+            esac
+            PREV_TAG=$(git tag --sort=-v:refname --list "$TAG_GLOB" | grep -v "^${GITHUB_REF_NAME}$" | head -1)
             if [ -z "$PREV_TAG" ]; then
               echo "No previous tag; diffing against HEAD~50"
               RANGE="HEAD~50..HEAD"
@@ -2174,7 +2184,15 @@ jobs:
           fi
 
           VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${GITHUB_REF_NAME}"
+          # The release is still a DRAFT here, and a draft is NOT served at
+          # releases/tag/<tag> — that page shows the bare tag (source-only
+          # assets, no notes, no DMGs) and 404s outright once the daily cut's
+          # cleanup deletes a superseded draft's tag. Link the draft's real
+          # html_url (releases/tag/untagged-…), which collaborators can open
+          # and which shows the notes + installer assets (HOU-972). Fall back
+          # to the tag URL only if the lookup fails.
+          RELEASE_URL=$(gh release view "$GITHUB_REF_NAME" --json url --jq .url 2>/dev/null) \
+            || RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${GITHUB_REF_NAME}"
 
           # First ~700 chars of the release-notes body, skipping the leading "## Houston X.Y.Z" header line.
           NOTES_PREVIEW=$(tail -n +2 release-notes.md | head -c 700)


### PR DESCRIPTION
Fixes HOU-972.

## Root cause

**1. Release notes spanned weeks of changes.** The auto-changelog in `release.yml` resolved the previous tag with `git tag --list 'v*'`. That glob never matches `cloud-v*` tags, so every cloud pre-release diffed against the newest **local** `v*` release instead of the previous cloud cut. Live numbers: `cloud-v0.5.31` diffed against `v0.5.6` (July 13) — **308 commits** — instead of `cloud-v0.5.29` — **20 commits**. This one range feeds every surface: the GitHub release body, the Slack draft announcement preview, and the in-app update dialog (`latest-cloud.json` embeds the same notes).

**2. Slack "View on GitHub" broken / no artifacts or notes visible.** The button linked `releases/tag/<tag>`, but at notify time the release is still a **draft**. GitHub serves nothing at that URL for a draft — the page shows only the bare tag with source-only assets (why the team saw no installers and no notes), and it 404s entirely once the daily cut's cleanup deletes a superseded draft's tag (why `cloud-v0.5.30` was a 404). The DMG buttons already worked because they used the draft's real `untagged-…` asset URLs from the API.

## Fix

- Compute `PREV_TAG` from the same channel as the tag being built: `cloud-v*` tags diff against the previous `cloud-v*`, local `v*` against the previous `v*`.
- Resolve the Slack `RELEASE_URL` via `gh release view --json url`, which returns the draft's real `html_url` (the `releases/tag/untagged-…` page collaborators can open, showing notes + installer assets), with the old tag URL as fallback.

## Before (reproduce the bug)

1. Look at the Slack post for `cloud-v0.5.31` (#houston-drafts, Jul 28): the Features list includes PRs merged before `cloud-v0.5.29` shipped, going back to July 13.
2. Locally: `git tag --sort=-v:refname --list 'v*' | head -1` → `v0.5.6`, and `git log v0.5.6..cloud-v0.5.31 --no-merges --oneline | wc -l` → 308.
3. Click "View on GitHub" on an older draft announcement (e.g. `cloud-v0.5.30`) → 404; on the current one → bare tag page with no DMGs and no notes.

## After (verify)

1. Let the next daily cut run (or dispatch **Daily cloud cut** manually). In the release.yml `prep` job log, the "Build release notes" step should print `RANGE` based on the previous `cloud-v*` tag, and the printed `release-notes.md` should contain only commits merged since that cut.
2. The Slack post's notes preview should match that short list, and its "View on GitHub" button should open the draft release page showing the notes and all installer assets.
3. The in-app update dialog (after publish) shows the same single-train notes.

Simulated output of the fixed builder for `cloud-v0.5.31` (against real tags): `PREV_TAG=cloud-v0.5.29`, 20 commits, 10 feat + 7 fix entries.