### PR TITLE
fix(runtime): carry conversation context across the pi ⇄ Claude backend switch (HOU-951)

### DIFF
--- a/packages/runtime/src/backends/claude/backend.ts
+++ b/packages/runtime/src/backends/claude/backend.ts
@@ -125,11 +125,22 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
         permissionMode: "default",
       };
 
+      const sessionsStore = createSessionsStore(
+        deps.dataDir,
+        deps.workspaceDir,
+      );
+      // A cross-backend rebuild (opts.fresh) must NOT resume a stale SDK
+      // session from before the conversation left this backend: the history
+      // arrives as a transcript replay on the first prompt (HOU-951), and the
+      // old SDK session is missing everything said on the other backend since.
+      // Dropping the mapping (transcript stays on disk) makes the first prompt
+      // open a brand-new SDK session, whose id is then stored as usual.
+      if (opts.fresh) sessionsStore.remove(opts.conversationId);
       return new ClaudeSession({
         query,
         conversationId: opts.conversationId,
         baseOptions,
-        sessionsStore: createSessionsStore(deps.dataDir, deps.workspaceDir),
+        sessionsStore,
         model: toSdkModel(opts.model.id),
         thinkingLevel: opts.thinkingLevel,
       });

--- a/packages/runtime/src/backends/pi/backend.ts
+++ b/packages/runtime/src/backends/pi/backend.ts
@@ -63,10 +63,20 @@ export function createPiBackend(deps: PiBackendDeps): HarnessBackend {
         model: opts.model as unknown as Model<Api>,
         ...(opts.thinkingLevel ? { thinkingLevel: opts.thinkingLevel } : {}),
         modelRuntime: deps.modelRuntime,
-        sessionManager: SessionManager.continueRecent(
-          deps.workspaceDir,
-          join(deps.dataDir, "sessions", opts.conversationId),
-        ),
+        // A cross-backend rebuild (opts.fresh) mints a NEW session file in the
+        // conversation's dir instead of reopening the most recent one: the
+        // history arrives as a transcript replay on the first prompt (HOU-951),
+        // and a conversation returning to pi after a Claude era must not resume
+        // its stale pre-switch session on top of that replay.
+        sessionManager: opts.fresh
+          ? SessionManager.create(
+              deps.workspaceDir,
+              join(deps.dataDir, "sessions", opts.conversationId),
+            )
+          : SessionManager.continueRecent(
+              deps.workspaceDir,
+              join(deps.dataDir, "sessions", opts.conversationId),
+            ),
         resourceLoader: loader,
         tools: toolNamesForMode(opts.mode, deps.tools),
         customTools: deps.customTools,

--- a/packages/runtime/src/backends/types.ts
+++ b/packages/runtime/src/backends/types.ts
@@ -76,6 +76,15 @@ export interface CreateSessionOptions {
    * WORKSPACE.md / USER.md files instead.
    */
   context?: ProvidedContext;
+  /**
+   * Start a brand-new backend-native session, ignoring any prior session this
+   * backend persisted for the conversation. Set on a cross-BACKEND rebuild
+   * (HOU-951): the conversation's history is carried over as a transcript
+   * replay on the first prompt, so resuming the backend's own stale
+   * pre-switch session would duplicate the pre-switch era and drop everything
+   * said on the other backend in between.
+   */
+  fresh?: boolean;
 }
 
 /** A pluggable turn-execution backend for a provider. */

--- a/packages/runtime/src/session/backend-switch.test.ts
+++ b/packages/runtime/src/session/backend-switch.test.ts
@@ -52,6 +52,9 @@ const { registerBackend, setDefaultBackend } = await import(
   "../backends/registry"
 );
 const { subscribe } = await import("./bus");
+const { appendAssistantMessage, appendUserMessage } = await import(
+  "../store/conversations"
+);
 type Conversation = import("./conversation-cache").Conversation;
 
 /** A session that records every prompt/setModel/dispose so the test can assert the
@@ -89,10 +92,15 @@ class SpySession implements HarnessSession {
   }
 }
 
-function spyBackend(id: string, created: SpySession[]): HarnessBackend {
+function spyBackend(
+  id: string,
+  created: SpySession[],
+  opts?: CreateSessionOptions[],
+): HarnessBackend {
   return {
     id,
-    async createSession(_opts: CreateSessionOptions): Promise<HarnessSession> {
+    async createSession(o: CreateSessionOptions): Promise<HarnessSession> {
+      opts?.push(o);
       const s = new SpySession(id);
       created.push(s);
       return s;
@@ -187,6 +195,47 @@ test("anthropic→openai REBUILDS on the pi backend — the Claude session is di
   expect((conv as unknown as { backendId: string }).backendId).toBe("pi");
   expect(conv.provider).toBe("openai-codex");
   expect(events.some((e) => e.type === "provider_switched")).toBe(true);
+});
+
+test("cross-backend rebuild carries the conversation over: fresh session + transcript replay on the first prompt (HOU-951)", async () => {
+  const piCreated: SpySession[] = [];
+  const claudeCreated: SpySession[] = [];
+  const claudeOpts: CreateSessionOptions[] = [];
+  setDefaultBackend(spyBackend("pi", piCreated));
+  registerBackend(
+    "anthropic",
+    spyBackend("anthropic", claudeCreated, claudeOpts),
+  );
+
+  // The conversation so far (ran on pi/gemini), plus THIS turn's already-recorded
+  // user message — exactly what the store holds when execTurn runs.
+  appendUserMessage("conv-replay", "my name is Zoe", { turnId: "turn-0" });
+  appendAssistantMessage("conv-replay", "Nice to meet you, Zoe!", {
+    turnId: "turn-0",
+  });
+  appendUserMessage("conv-replay", "what is my name?", { turnId: "turn-1" });
+
+  const piSession = new SpySession("pi");
+  const conv = convWith(piSession, "google", "gemini-2.5-pro");
+  modelState.model = ANTHROPIC;
+
+  await execTurn(conv, "conv-replay", "turn-1", "what is my name?", {
+    author: undefined,
+    priorAuthors: [],
+  });
+
+  // The new backend must start FRESH (never resume its stale pre-switch store).
+  expect(claudeOpts).toHaveLength(1);
+  expect(claudeOpts[0].fresh).toBe(true);
+  // The first prompt replays the prior turns so the model keeps the context…
+  const prompt = claudeCreated[0].prompts[0];
+  expect(prompt).toContain("User: my name is Zoe");
+  expect(prompt).toContain("Assistant: Nice to meet you, Zoe!");
+  // …excludes THIS turn's message from the replay (it IS the prompt's tail)…
+  expect(prompt.endsWith("what is my name?")).toBe(true);
+  expect(prompt.match(/what is my name\?/g)).toHaveLength(1);
+  // …and the user's stored message stays the plain text (no preamble in the bubble).
+  expect(prompt).not.toBe("what is my name?");
 });
 
 test("same-backend model change (openai→google, both pi) stays on the setModel fast path — no rebuild", async () => {

--- a/packages/runtime/src/session/conversation-cache.ts
+++ b/packages/runtime/src/session/conversation-cache.ts
@@ -339,9 +339,12 @@ export async function getConversation(
  * forward an anthropic model into pi's in-process Anthropic client (the
  * harness-spoofing request Anthropic blocks) or an openai id through the Claude
  * subprocess. So the old session is disposed and a fresh one opened via the
- * correct backend. The new backend starts WITHOUT the old in-memory history —
- * each backend owns its own session store and the Houston transcript is the UI
- * source of truth, so history is not (and cannot be) replayed across backends.
+ * correct backend (`fresh: true` — the new backend must not resume its own
+ * stale pre-switch session either, see CreateSessionOptions.fresh). The new
+ * session starts without backend-native history — each backend owns its own
+ * session store — so exec-turn carries the conversation over by prepending the
+ * canonical Houston transcript to the first prompt (HOU-951, see
+ * replay-transcript.ts).
  *
  * A same-backend change (pi sonnet→opus, or claude model→model) is left alone —
  * the caller keeps the cheap `setModel` fast path that preserves the live session.
@@ -369,6 +372,9 @@ export async function switchBackendIfNeeded(
     conversationId,
     model,
     mode,
+    // Never resume the new backend's own stale pre-switch session: the history
+    // arrives as a transcript replay on the first prompt (HOU-951).
+    fresh: true,
     // Preserve the conversation's startup context across the rebuild (HOU-711).
     ...(conv.context ? { context: conv.context } : {}),
   });

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -44,6 +44,7 @@ import {
 } from "./file-changes";
 import { newInteractionHolder, runWithInteractionCapture } from "./interaction";
 import { switchNeedsCompaction } from "./provider-switch";
+import { renderReplayPreamble, replayCharBudget } from "./replay-transcript";
 import { createStallWatchdog } from "./stall-watchdog";
 import { runWithTurnMode, type TurnModeRef } from "./turn-mode-context";
 
@@ -243,14 +244,34 @@ export async function execTurn(
     // Attach the turn's listeners to the SETTLED session (the rebuilt one when we
     // crossed a backend or flipped mode, else the session we entered with).
     subscribeSession();
+    // Set on a cross-backend rebuild: the canonical transcript rendered as a
+    // preamble, prepended to THIS turn's prompt so the fresh session continues
+    // the conversation instead of greeting the user anew (HOU-951).
+    let replayPrefix = "";
     if (rebuilt) {
-      // Cross-backend rebuild: the new session starts fresh (no in-memory history
-      // to compact — each backend owns its own store), so nothing is summarized.
-      // Still announce the boundary so the chat draws a divider + resets its
-      // window estimate; persisted on the assistant message below for reload.
+      // Cross-backend rebuild: the new backend cannot read the old backend's
+      // session store, so the fresh session carries the conversation over via a
+      // transcript replay from Houston's canonical store — clamped to the new
+      // model's window, newest turns kept (`summarized` reflects a lossy clamp,
+      // so the divider stays honest). Announce the boundary either way so the
+      // chat draws a divider + resets its window estimate; persisted on the
+      // assistant message below for reload.
+      const replay = renderReplayPreamble(
+        getHistory(id)?.messages ?? [],
+        turnId,
+        replayCharBudget(
+          effectiveModelWindow(
+            model.provider,
+            model.id,
+            model.contextWindow,
+            0,
+          ),
+        ),
+      );
+      replayPrefix = replay?.text ?? "";
       providerSwitch = {
         provider: model.provider,
-        summarized: false,
+        summarized: replay?.truncated ?? false,
         pre_tokens: rebuiltPreTokens,
       };
       publish(id, {
@@ -350,7 +371,11 @@ export async function execTurn(
     // prefix the prompt with `[From: <name>]\n` so the model can tell teammates
     // apart. Single-author (or authorless) turns pass `text` through unchanged —
     // today's prompts stay byte-identical, so no drift for existing users.
-    const promptText = framePrompt(text, author, priorAuthors);
+    // The replay prefix rides the prompt (not the transcript): the user's
+    // recorded message stays `text`, so the bubble never renders the preamble,
+    // while the backend-native session persists it — later rehydrates keep the
+    // carried context without replaying again.
+    const promptText = replayPrefix + framePrompt(text, author, priorAuthors);
     // Snapshot the workspace's user-visible files so the turn's diff can be
     // surfaced as a `file_changes` frame below. Same-workdir turns are
     // serialized by the workdir lock (chat.ts), so the diff is attributable to

--- a/packages/runtime/src/session/replay-transcript.test.ts
+++ b/packages/runtime/src/session/replay-transcript.test.ts
@@ -1,0 +1,95 @@
+import type { ChatMessage } from "@houston/runtime-client";
+import { expect, test } from "vitest";
+import { renderReplayPreamble, replayCharBudget } from "./replay-transcript";
+
+const msg = (
+  role: "user" | "assistant",
+  content: string,
+  extra?: Partial<ChatMessage>,
+): ChatMessage => ({ role, content, ts: 0, ...extra });
+
+test("renders prior turns and excludes the current turn's user message", () => {
+  const p = renderReplayPreamble(
+    [
+      msg("user", "translate hello to French", { turnId: "t1" }),
+      msg("assistant", "Bonjour — hello in French is «bonjour».", {
+        turnId: "t1",
+      }),
+      msg("user", "and to Spanish?", { turnId: "t2" }),
+    ],
+    "t2",
+    100_000,
+  );
+  expect(p).not.toBeNull();
+  expect(p?.text).toContain("User: translate hello to French");
+  expect(p?.text).toContain("Assistant: Bonjour");
+  // The current turn's message is delivered as the actual prompt — never doubled.
+  expect(p?.text).not.toContain("and to Spanish?");
+  expect(p?.truncated).toBe(false);
+});
+
+test("returns null for a conversation with nothing to carry", () => {
+  expect(renderReplayPreamble([], "t1", 100_000)).toBeNull();
+  // Only THIS turn's message on disk (a brand-new conversation's first turn).
+  expect(
+    renderReplayPreamble([msg("user", "hi", { turnId: "t1" })], "t1", 100_000),
+  ).toBeNull();
+});
+
+test("skips empty messages (stop markers) and renders tool-only turns as actions", () => {
+  const p = renderReplayPreamble(
+    [
+      msg("user", "check my calendar", { turnId: "t1" }),
+      msg("assistant", "", { turnId: "t1", stopped: true }),
+      msg("assistant", "", {
+        turnId: "t1",
+        tools: [{ name: "integration_execute", input: {} }],
+      }),
+    ],
+    "t2",
+    100_000,
+  );
+  expect(p?.text).toContain("[performed actions: integration_execute]");
+  expect(p?.text).not.toMatch(/Assistant: *\n/);
+});
+
+test("attributes multiplayer authors on user messages", () => {
+  const p = renderReplayPreamble(
+    [msg("user", "ship it", { author: { userId: "u1", name: "Dana" } })],
+    "t9",
+    100_000,
+  );
+  expect(p?.text).toContain("User (Dana): ship it");
+});
+
+test("keeps the newest messages when the transcript exceeds the budget", () => {
+  const p = renderReplayPreamble(
+    [
+      msg("user", `old ${"x".repeat(300)}`),
+      msg("assistant", "middle reply"),
+      msg("user", "newest question"),
+    ],
+    "t9",
+    120,
+  );
+  expect(p?.truncated).toBe(true);
+  expect(p?.text).toContain("newest question");
+  expect(p?.text).toContain("middle reply");
+  expect(p?.text).not.toContain("old x");
+  expect(p?.text).toContain("omitted");
+});
+
+test("hard-clips a single over-budget message instead of dropping everything", () => {
+  const p = renderReplayPreamble(
+    [msg("user", `${"a".repeat(500)}TAIL`)],
+    "t9",
+    100,
+  );
+  expect(p?.truncated).toBe(true);
+  expect(p?.text).toContain("TAIL");
+});
+
+test("replayCharBudget applies the fit fraction at ~4 chars/token", () => {
+  expect(replayCharBudget(200_000)).toBe(640_000);
+  expect(replayCharBudget(0)).toBe(0);
+});

--- a/packages/runtime/src/session/replay-transcript.ts
+++ b/packages/runtime/src/session/replay-transcript.ts
@@ -1,0 +1,125 @@
+import type { ChatMessage } from "@houston/runtime-client";
+
+/**
+ * Cross-BACKEND provider-switch replay (HOU-951). A switch that crosses the
+ * backend seam (pi ⇄ Claude Agent SDK) rebuilds the session on the other
+ * backend, and neither backend can read the other's session store — so the
+ * fresh session would start with zero context and greet the user as a new
+ * conversation. Houston's canonical transcript (store/conversations) has every
+ * turn regardless of which backend ran it; this module renders that transcript
+ * into a preamble exec-turn prepends to the FIRST prompt on the rebuilt
+ * session. Riding the first user prompt (not the system prompt) makes the
+ * carried context durable: both backends persist the prompt in their own
+ * session store, so later rehydrates (process restart, LRU eviction) keep it.
+ */
+
+/**
+ * Same fit fraction as the same-backend switch decision (`provider-switch.ts`)
+ * and the frontend consent dialog (`app/src/lib/provider-switch.ts`): the
+ * replayed transcript may use up to this fraction of the target window, leaving
+ * headroom for the system prompt, the new turn, and re-tokenization drift.
+ */
+const REPLAY_FIT_FRACTION = 0.8;
+
+/** ~4 chars per token — the same coarse estimate the frontend dialog uses. */
+const CHARS_PER_TOKEN = 4;
+
+/**
+ * The character budget for a replay preamble into a model whose effective
+ * window is `targetWindowTokens`.
+ */
+export function replayCharBudget(targetWindowTokens: number): number {
+  return Math.max(
+    0,
+    Math.floor(targetWindowTokens * REPLAY_FIT_FRACTION) * CHARS_PER_TOKEN,
+  );
+}
+
+export interface ReplayPreamble {
+  /** The rendered preamble, ready to prepend to the turn's prompt. */
+  text: string;
+  /** True when older messages were dropped to fit the budget (lossy carry). */
+  truncated: boolean;
+}
+
+const HEADER =
+  "[Continuing an existing conversation. The transcript below is what has " +
+  "already been said in this chat; it ran on a different AI model before " +
+  "switching to you. Continue seamlessly: keep all established context, do " +
+  "not reintroduce yourself, and do not treat this as a new conversation.]";
+
+const TRUNCATION_NOTE =
+  "(Earlier messages were omitted to fit your context window; the transcript below is the most recent part of the conversation.)";
+
+const FOOTER = "[End of transcript. The user's next message follows.]";
+
+/** One transcript line per message; empty (e.g. stop-marker) messages render to null. */
+function renderMessage(m: ChatMessage): string | null {
+  const toolNames = (m.tools ?? []).map((t) => t.name);
+  const body =
+    m.content.trim() ||
+    (toolNames.length ? `[performed actions: ${toolNames.join(", ")}]` : "");
+  if (!body) return null;
+  const speaker =
+    m.role === "user"
+      ? m.author?.name
+        ? `User (${m.author.name})`
+        : "User"
+      : "Assistant";
+  return `${speaker}: ${body}`;
+}
+
+/**
+ * Render the conversation-so-far preamble for a cross-backend rebuild, or null
+ * when there is nothing to carry (a brand-new conversation). `currentTurnId`
+ * excludes THIS turn's already-recorded user message — it is delivered as the
+ * actual prompt, so replaying it too would double it. The newest messages are
+ * kept whole and older ones dropped first when the transcript exceeds
+ * `charBudget`.
+ */
+export function renderReplayPreamble(
+  messages: ReadonlyArray<ChatMessage>,
+  currentTurnId: string,
+  charBudget: number,
+): ReplayPreamble | null {
+  if (charBudget <= 0) return null;
+  const lines: string[] = [];
+  for (const m of messages) {
+    if (m.role === "user" && m.turnId === currentTurnId) continue;
+    const line = renderMessage(m);
+    if (line) lines.push(line);
+  }
+  if (lines.length === 0) return null;
+
+  // Keep the tail: walk newest→oldest until the budget is spent. A single
+  // over-budget message is hard-clipped (its tail kept) rather than dropped —
+  // the most recent exchange is the context the user most expects to survive.
+  const kept: string[] = [];
+  let used = 0;
+  let clipped = false;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (used + line.length > charBudget) {
+      if (kept.length === 0) {
+        kept.unshift(`…${line.slice(line.length - charBudget)}`);
+        clipped = true;
+      }
+      break;
+    }
+    kept.unshift(line);
+    used += line.length + 1;
+  }
+  const truncated = clipped || kept.length < lines.length;
+  return {
+    text: [
+      HEADER,
+      ...(truncated ? [TRUNCATION_NOTE] : []),
+      "",
+      kept.join("\n\n"),
+      "",
+      FOOTER,
+      "",
+    ].join("\n"),
+    truncated,
+  };
+}


### PR DESCRIPTION
Fixes HOU-951.

## Root cause

Anthropic turns run through the Claude Agent SDK backend while every other provider (Gemini, OpenAI, OpenRouter, …) runs through the pi backend. A mid-conversation model change that crosses that seam rebuilds the session on the other backend (`switchBackendIfNeeded`) — and each backend only rehydrates its **own** session store, which knows nothing about the conversation. So the first Claude turn after a Gemini/OpenAI conversation started with zero history and the model answered as if it were a brand-new chat (and the same in the reverse direction). This contradicted the product promise in the switch consent dialog ("carrying the full prior history across"), which only held for same-backend switches.

## Fix

Houston's canonical transcript (`store/conversations`) has every turn regardless of which backend ran it, so the rebuild now carries it over:

- **`session/replay-transcript.ts` (new)** — renders the conversation-so-far as a preamble: prior user/assistant turns (this turn's already-recorded message excluded), clamped to the target model's effective window at the same 0.8 fit fraction / ~4 chars-per-token estimate the frontend consent dialog uses, keeping the newest turns when it must truncate.
- **`session/exec-turn.ts`** — on a cross-backend rebuild, prepends that preamble to the turn's prompt. The stored user message stays the plain text, so chat bubbles never render the preamble; the backend-native session persists the prompt, so the carried context survives process restarts and LRU eviction without replaying twice. A lossy (truncated) replay is surfaced as `summarized: true` on the `provider_switched` frame so the divider stays honest.
- **`backends/types.ts`, `pi/backend.ts`, `claude/backend.ts`** — new `CreateSessionOptions.fresh`, set by the rebuild: pi mints a new session file (`SessionManager.create`) instead of `continueRecent`, and the Claude backend drops its `sessions.json` mapping instead of resuming. Without this, a conversation *returning* to a backend (Claude → Gemini → Claude) would resume its stale pre-switch session on top of the replay — duplicating the old era and missing everything said in between.

## Tests

- `replay-transcript.test.ts` (new): rendering, current-turn exclusion, empty/stop-marker handling, tool-only turns, multiplayer author attribution, tail-keeping truncation, budget math.
- `backend-switch.test.ts`: new compliance case asserting the rebuilt session receives `fresh: true` and its first prompt replays prior turns exactly once, ending with the user's actual message.
- Full gates green: runtime (822), host (1074), domain (165), `pnpm typecheck`, `pnpm check`, `pnpm check:boundaries`.

## Repro (before)

1. Start a chat on a pi provider (e.g. Google Gemini): "My name is Zoe, remember it."
2. Switch the model picker to any Claude model and ask: "What is my name?"
3. The Claude turn answers it has no idea / treats it as a new conversation.

## Verify (after)

1. Same steps — the Claude turn answers "Zoe" and continues the conversation naturally.
2. Reverse direction: start on Claude, switch to Gemini/OpenAI — context also carries.
3. Round-trip (Claude → Gemini → Claude) keeps the *full* conversation including the Gemini era, instead of resuming the stale pre-switch Claude session.
