### PR TITLE
fix(chat): allow video and audio attachments in the composer (HOU-971)

### DIFF
--- a/app/src/lib/attachment-validation.ts
+++ b/app/src/lib/attachment-validation.ts
@@ -28,6 +28,11 @@ export interface ComposerAttachmentRejection<T extends ComposerAttachmentFile> {
   reason: ComposerAttachmentRejectReason;
 }
 
+// Only archives and executables are blocked: the agent can't act on them and
+// expanding them can flood the workspace. Every other binary — video and audio
+// included — is a legitimate workspace file the agent processes with its shell
+// and code tools (and the Files tab accepts them already), so the composer
+// must too. Size is bounded separately by MAX_COMPOSER_ATTACHMENT_BYTES.
 const BLOCKED_EXTENSIONS = new Set([
   "7z",
   "apk",
@@ -95,11 +100,7 @@ export function validateComposerAttachment(
     return { kind: "blockedType", extension };
   }
   const mime = (file.type ?? "").toLowerCase();
-  if (
-    BLOCKED_MIME_TYPES.has(mime) ||
-    mime.startsWith("audio/") ||
-    mime.startsWith("video/")
-  ) {
+  if (BLOCKED_MIME_TYPES.has(mime)) {
     return { kind: "blockedType", extension };
   }
   if (policy?.modelAcceptsImages === false && isImageAttachment(file)) {

--- a/app/tests/attachment-validation.test.ts
+++ b/app/tests/attachment-validation.test.ts
@@ -31,6 +31,44 @@ describe("composer attachment validation", () => {
     strictEqual(result.rejected.length, 1);
   });
 
+  it("accepts video and audio files like any other workspace file", () => {
+    strictEqual(
+      validateComposerAttachment({
+        name: "demo.mp4",
+        size: 50 * 1024 * 1024,
+        type: "video/mp4",
+      }),
+      null,
+    );
+    strictEqual(
+      validateComposerAttachment({
+        name: "meeting.m4a",
+        size: 12 * 1024 * 1024,
+        type: "audio/mp4",
+      }),
+      null,
+    );
+    strictEqual(
+      validateComposerAttachment({
+        name: "clip.mov",
+        size: 1024,
+        type: "",
+      }),
+      null,
+    );
+  });
+
+  it("still applies the size cap to media files", () => {
+    deepStrictEqual(
+      validateComposerAttachment({
+        name: "feature-film.mp4",
+        size: MAX_COMPOSER_ATTACHMENT_BYTES + 1,
+        type: "video/mp4",
+      }),
+      { kind: "tooLarge", maxBytes: MAX_COMPOSER_ATTACHMENT_BYTES },
+    );
+  });
+
   it("rejects files above the engine per-file limit", () => {
     const reason = validateComposerAttachment({
       name: "huge.pdf",


### PR DESCRIPTION
## Summary

Fixes HOU-971.

**Root cause:** the chat composer's attachment validation (`app/src/lib/attachment-validation.ts`) rejected every `audio/*` and `video/*` MIME type outright, regardless of size. Attaching any video — even a tiny one — popped the "Some files were not attached" dialog with "This file type cannot be used here." The block dates from the Rust-engine attachment pipeline (April 2026) and no longer matches the product: uploads land in the agent's durable `uploads/` workspace folder, media files are ordinary workspace files the agent can process with its shell/code tools, and the Files tab already accepts them (the composer was the only door that refused).

**Fix:** drop the blanket audio/video rejection. Archives and executables stay blocked, and the existing 100 MB per-file cap still applies (an oversized video now gets the honest "This file is larger than 100 MB" reason instead of a type refusal).

## Before (reproduce the bug)

1. Open any agent chat.
2. Drag a small `.mp4` (or `.mov`, `.mp3`, `.m4a`) onto the composer, or pick it via the attach button.
3. Dialog: "Some files were not attached" → "This file type cannot be used here." — for any size.

## After (verify)

1. Same steps: the file attaches, uploads into the agent's `uploads/` folder, and appears in the Files tab.
2. The agent receives the workspace path and can operate on the file with its tools.
3. A video **over 100 MB** is still rejected, now with the size reason ("This file is larger than 100 MB").
4. Archives/executables (`.zip`, `.dmg`, `.exe`, …) are still rejected with the type reason.

## Tests

- `cd app && pnpm test` — 2262 pass, including new cases: video/audio accepted (by MIME and by bare extension), size cap still enforced on media, archives still blocked.
- `pnpm check` (Biome) and full workspace `pnpm typecheck` green.