### PR TITLE
fix(runtime): surface the skills index to the Claude backend — Anthropic skill turns ran blind (HOU-894)

### DIFF
--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -116,6 +116,36 @@ Composio-catalog concern that belongs to `app/`. Its heading copy is
 200-line law: `skill-edit-modal-labels.ts` (labels + defaults) and
 `skill-edit-modal-parts.tsx` (the body/footer states).
 
+## How skills reach the model (both backends)
+
+Skill INVOCATION is just a user message (`Use the <skill> skill.` — see the
+marker section below), so the model must already know what skills exist and
+where their files live. Each runtime backend surfaces that index in its system
+prompt:
+
+- **pi backend** (every non-Anthropic provider): `DefaultResourceLoader`
+  (`packages/runtime/src/session/resource-loader.ts`) loads
+  `<workspace>/.agents/skills` (or `HOUSTON_SKILLS_DIR`) and pi's own
+  system-prompt builder appends an `<available_skills>` XML section — each
+  skill's `name`, `description`, and the absolute SKILL.md `<location>` — plus
+  the instruction to Read the file when the task matches.
+- **Claude backend** (Anthropic provider, the Claude Agent SDK subprocess):
+  the SDK's native skill machinery is deliberately OFF (`settingSources: []`,
+  `Skill` in `disallowedTools` — nothing on disk may leak in), so
+  `buildSystemPrompt` (`packages/runtime/src/backends/claude/system-prompt.ts`)
+  appends the IDENTICAL `<available_skills>` section itself, reusing pi's
+  exported `loadSkillsFromDir` + `formatSkillsForPrompt` on the same directory.
+  Before HOU-894 this section was missing entirely: an Anthropic session had no
+  idea what skills existed, so "Use the <skill> skill." turns ran blind —
+  agents improvised the procedure, spun for minutes, and never completed
+  (the legacy Rust engine never had this gap; its claude CLI discovered the
+  `.claude/skills` mirror natively).
+
+Loader parity rule (pi's, now both backends): a SKILL.md with **no
+`description:` frontmatter is silently dropped from the index** — the model
+never learns it exists, even though the Skills UI still lists it. Keep
+`description` mandatory in anything that writes skills.
+
 ## Render pipeline
 
 1. **Engine** parses SKILL.md frontmatter via `serde_yml` (`engine/houston-skills/src/format.rs`). Unknown fields are silently ignored — old skills with `icon:` / `starter_prompt:` still parse.

--- a/packages/runtime/src/backends/claude/system-prompt.test.ts
+++ b/packages/runtime/src/backends/claude/system-prompt.test.ts
@@ -39,6 +39,60 @@ test("a non-workspace cwd gets only the base prompt (no context section)", () =>
   expect(prompt).toBe("You are Houston.");
 });
 
+function writeSkill(dir: string, slug: string, frontmatter: string): void {
+  const skillDir = join(dir, ".agents", "skills", slug);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, "SKILL.md"),
+    `---\n${frontmatter}\n---\n\n## Procedure\nDo the thing.\n`,
+  );
+}
+
+test("workspace skills are indexed with their SKILL.md locations (HOU-894)", () => {
+  const dir = freshWorkspace();
+  writeSkill(
+    dir,
+    "marketing-report",
+    "name: marketing-report\ndescription: Weekly marketing report with brand guidelines",
+  );
+
+  const prompt = buildSystemPrompt(dir, "You are Houston.");
+  expect(prompt).toContain("<available_skills>");
+  expect(prompt).toContain("<name>marketing-report</name>");
+  expect(prompt).toContain("Weekly marketing report with brand guidelines");
+  // The location is the absolute path the Read tool loads the procedure from.
+  expect(prompt).toContain(
+    join(dir, ".agents", "skills", "marketing-report", "SKILL.md"),
+  );
+});
+
+test("no skills directory means no skills section", () => {
+  const dir = freshWorkspace();
+  const prompt = buildSystemPrompt(dir, "You are Houston.");
+  expect(prompt).not.toContain("<available_skills>");
+});
+
+test("a skill without a description is dropped (pi loader parity)", () => {
+  const dir = freshWorkspace();
+  writeSkill(dir, "bare-skill", "name: bare-skill");
+  writeSkill(dir, "good-skill", "name: good-skill\ndescription: A real one");
+
+  const prompt = buildSystemPrompt(dir, "You are Houston.");
+  expect(prompt).toContain("<name>good-skill</name>");
+  expect(prompt).not.toContain("bare-skill");
+});
+
+test("the skills index lands before the mode overlay", () => {
+  const dir = freshWorkspace();
+  writeSkill(dir, "plan-me", "name: plan-me\ndescription: Plan something");
+
+  const prompt = buildSystemPrompt(dir, "You are Houston.", "plan");
+  const skillsAt = prompt.indexOf("<available_skills>");
+  const overlayAt = prompt.indexOf("You are in Plan mode.");
+  expect(skillsAt).toBeGreaterThan(-1);
+  expect(overlayAt).toBeGreaterThan(skillsAt);
+});
+
 test("group context is appended after the workspace/user section", () => {
   const dir = freshWorkspace();
   writeFileSync(join(dir, "WORKSPACE.md"), "Acme Corp.");

--- a/packages/runtime/src/backends/claude/system-prompt.ts
+++ b/packages/runtime/src/backends/claude/system-prompt.ts
@@ -1,6 +1,11 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import {
+  formatSkillsForPrompt,
+  loadSkillsFromDir,
+} from "@earendil-works/pi-coding-agent";
 import type { TurnMode } from "@houston/protocol";
+import { config } from "../../config";
 import { withModeOverlay } from "../../session/mode-overlays";
 import {
   buildGroupContextSection,
@@ -43,10 +48,33 @@ export function buildSystemPrompt(
   // shared context. Null for ungrouped agents.
   const group = buildGroupContextSection(cwd);
   const withGroup = group ? `${withContext}\n\n${group}` : withContext;
-  // Mode overlay LAST — after Houston's prompt, the context file, AND both
-  // context sections — so the plan (read-only) or auto (Autopilot) mandate is the
-  // final word the model reads. Execute passes through unchanged.
-  return withModeOverlay(withGroup, mode);
+  // Skills index (HOU-894): the SAME <available_skills> section pi appends for
+  // every other provider — name + description + the SKILL.md path to Read. The
+  // SDK's own skill discovery is off (`settingSources: []`, `Skill` disallowed),
+  // so without this an Anthropic session had NO idea what skills exist or where
+  // their files live, and a "Use the <skill> skill." turn ran blind.
+  const withSkills = withGroup + buildSkillsSection(cwd);
+  // Mode overlay LAST — after Houston's prompt, the context file, both context
+  // sections, AND the skills index — so the plan (read-only) or auto (Autopilot)
+  // mandate is the final word the model reads. Execute passes through unchanged.
+  return withModeOverlay(withSkills, mode);
+}
+
+/**
+ * The `<available_skills>` index for the workspace's skills dir, or "" when
+ * there are none. Reuses pi's own loader + formatter so both backends surface
+ * the IDENTICAL section from the IDENTICAL directory (`HOUSTON_SKILLS_DIR`
+ * override, else `<cwd>/.agents/skills` — mirroring `makeAgentLoader`), with
+ * the same rules: a skill with no `description:` is dropped, and every entry
+ * carries the absolute SKILL.md `<location>` for the Read tool. Skill paths sit
+ * inside the workspace, so the Gate #1 clamp lets the model read them. Plan
+ * mode keeps the section — Read stays available there.
+ */
+function buildSkillsSection(cwd: string): string {
+  const dir = config.skillsDirOverride || join(cwd, ".agents", "skills");
+  if (!existsSync(dir)) return "";
+  const { skills } = loadSkillsFromDir({ dir, source: "path" });
+  return formatSkillsForPrompt(skills);
 }
 
 /** The first workspace-root context file's contents, or null when none exists. */


### PR DESCRIPTION
## Summary

Fixes HOU-894 — skills taking forever and never completing, reported as "it's as if it were not reading the skill file" on the cloud version.

### Root cause

Skill invocation is a plain user message (`Use the <skill> skill.`), so the model must already know from its system prompt which skills exist and where their `SKILL.md` files live. The two runtime backends diverged:

- **pi backend** (every non-Anthropic provider): pi's system-prompt builder appends an `<available_skills>` XML section — each skill's name, description, and the absolute `SKILL.md` path to Read. Skills work.
- **Claude Agent SDK backend** (the `anthropic` provider — the compliance-gated path both cloud pods and the TS-host desktop use): the SDK's native skill machinery is deliberately off (`settingSources: []`, `Skill` in `disallowedTools`), and `buildSystemPrompt` never injected any skills index of its own. **An Anthropic session had zero knowledge of the workspace's skills** — the model improvised the procedure from the skill's name alone, wandered, retried, and never followed the authored steps. The legacy Rust engine never had this gap (its bundled claude CLI discovered the `.claude/skills` mirror natively), which is why legacy worked and the current engine didn't.

This matches the field reports exactly: Claude "keeps thinking and thinking" while the same skill on ChatGPT (pi backend) produced the report; "same skills I had in legacy are NOT working on the cloud version… as if it were not reading the skill file".

### Fix

`packages/runtime/src/backends/claude/system-prompt.ts` now appends the **identical** `<available_skills>` section pi emits, reusing pi's exported `loadSkillsFromDir` + `formatSkillsForPrompt` on the same directory (`HOUSTON_SKILLS_DIR` override, else `<cwd>/.agents/skills`), placed before the mode overlay so the plan/auto mandate stays the final word. Skill paths are inside the workspace, so the Gate #1 clamp permits the Read.

### Repro (before the fix)

1. Give an agent a skill, e.g. `.agents/skills/marketing-report/SKILL.md` with a distinctive multi-step procedure.
2. Select an **Anthropic** model and run the skill from the picker ("Use the marketing-report skill.").
3. The turn never reads the SKILL.md (no Read of that path in the session transcript) and the output ignores the authored procedure; the same skill on a GPT model reads the file and follows it.

Unit-level repro: `git stash` the src change and run `pnpm --filter @houston/runtime exec vitest run src/backends/claude/system-prompt.test.ts` → the 3 new tests fail (no `<available_skills>` in the prompt).

### Verify (after the fix)

1. `pnpm --filter @houston/runtime test` — 821 tests green, including the new ones asserting the section's presence, the absolute SKILL.md location, the no-description drop rule, and ordering before the mode overlay.
2. Same manual flow as above on an Anthropic model: the session transcript now shows a Read of `.agents/skills/<slug>/SKILL.md` right after the skill message, and the turn follows the authored procedure.

### Notes for reviewers

- A SKILL.md with no `description:` frontmatter is dropped from the index (pi's loader rule, now documented in `knowledge-base/skills.md`). The Skills UI still lists such skills — worth a follow-up if we want the UI to warn.
- Not addressed here (contributing, separate concern): the Claude backend's conservative Bash path-token clamp denies any command containing an absolute/`~`/`..` token outside the workspace, which is the "escapes the sandbox" narration users see; skills whose procedures touch `/tmp` or `~` will still get denials on Anthropic models.