### PR TITLE
feat(skills): global Skills manager in the sidebar (HOU-792)

### DIFF
--- a/app/src/components/shell/sidebar-chrome.tsx
+++ b/app/src/components/shell/sidebar-chrome.tsx
@@ -1,11 +1,19 @@
 import type { SidebarLabels, SidebarNavItemEntry } from "@houston-ai/layout";
 import { WorkspaceSwitcher } from "@houston-ai/layout";
 import type { TFunction } from "i18next";
-import { Blocks, Boxes, LayoutDashboard, Settings, Store } from "lucide-react";
+import {
+  Blocks,
+  Boxes,
+  LayoutDashboard,
+  LibraryBig,
+  Settings,
+  Store,
+} from "lucide-react";
 import { useState } from "react";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { hasSpaces } from "../../lib/org-roles";
 import { INTEGRATIONS_VIEW_ID } from "../integrations-view";
+import { SKILLS_VIEW_ID } from "../skills-view/id";
 import { STORE_VIEW_ID } from "../store-view";
 import { CreateTeamDialog } from "./create-team-dialog";
 
@@ -40,6 +48,13 @@ export function buildSidebarNavItems(args: {
       icon: <Blocks className="h-4 w-4" />,
       onClick: () => setViewMode(INTEGRATIONS_VIEW_ID),
       dataAttrs: { "data-tour-target": "nav-integrations" },
+    },
+    {
+      id: SKILLS_VIEW_ID,
+      label: t("shell:sidebar.skills"),
+      icon: <LibraryBig className="h-4 w-4" />,
+      onClick: () => setViewMode(SKILLS_VIEW_ID),
+      dataAttrs: { "data-tour-target": "nav-skills" },
     },
     ...(showAiModels
       ? [

--- a/app/src/components/shell/top-level-screen-views.tsx
+++ b/app/src/components/shell/top-level-screen-views.tsx
@@ -7,6 +7,7 @@ import { AiHubView } from "../ai-hub/ai-hub-view";
 import { Dashboard } from "../dashboard";
 import { INTEGRATIONS_VIEW_ID, IntegrationsView } from "../integrations-view";
 import { SettingsView } from "../settings/settings-view";
+import { SKILLS_VIEW_ID, SkillsView } from "../skills-view";
 import { STORE_VIEW_ID, StoreView } from "../store-view";
 import type { KeepAliveView } from "./keep-alive-views";
 
@@ -29,6 +30,7 @@ export function topLevelScreenViews(gates: {
       enabled: true,
       content: <IntegrationsView />,
     },
+    { id: SKILLS_VIEW_ID, enabled: true, content: <SkillsView /> },
     { id: STORE_VIEW_ID, enabled: true, content: <StoreView /> },
   ];
 }

--- a/app/src/components/skills-view/agent-select-list.tsx
+++ b/app/src/components/skills-view/agent-select-list.tsx
@@ -1,0 +1,73 @@
+import { cn, HoustonAvatar, resolveAgentColor } from "@houston-ai/core";
+import { Check } from "lucide-react";
+import type { Agent } from "../../lib/types";
+
+/**
+ * The multi-select agent list the global Skills dialogs share (HOU-792): one
+ * always-visible row per agent with a trailing check ring — pressed state, not
+ * hover-revealed. Locked rows (e.g. "already has this skill") keep their
+ * avatar+name but swap the ring for a muted note and don't toggle.
+ */
+export function AgentSelectList({
+  agents,
+  selected,
+  onToggle,
+  lockedIds,
+  lockedNote,
+}: {
+  agents: Agent[];
+  /** Selected agent ids. */
+  selected: ReadonlySet<string>;
+  onToggle: (agent: Agent) => void;
+  /** Agents that can't be toggled; they render `lockedNote` instead of a ring. */
+  lockedIds?: ReadonlySet<string>;
+  lockedNote?: string;
+}) {
+  return (
+    <ul className="flex max-h-56 flex-col gap-1 overflow-y-auto pr-1">
+      {agents.map((agent) => {
+        const locked = lockedIds?.has(agent.id) ?? false;
+        const checked = !locked && selected.has(agent.id);
+        return (
+          <li key={agent.id}>
+            <button
+              type="button"
+              aria-pressed={checked}
+              disabled={locked}
+              onClick={() => onToggle(agent)}
+              className={cn(
+                "flex w-full items-center gap-3 rounded-lg px-2 py-1.5 text-left transition-colors",
+                locked ? "opacity-60" : "hover:bg-hover",
+              )}
+            >
+              <HoustonAvatar
+                color={resolveAgentColor(agent.color)}
+                diameter={24}
+              />
+              <span className="min-w-0 flex-1 truncate text-sm text-ink">
+                {agent.name}
+              </span>
+              {locked ? (
+                <span className="shrink-0 text-xs text-ink-muted">
+                  {lockedNote}
+                </span>
+              ) : (
+                <span
+                  aria-hidden
+                  className={cn(
+                    "flex size-5 shrink-0 items-center justify-center rounded-full border transition-colors",
+                    checked
+                      ? "border-action bg-action text-action-text"
+                      : "border-line-input",
+                  )}
+                >
+                  {checked && <Check className="size-3.5" />}
+                </span>
+              )}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/app/src/components/skills-view/choose-chat-agent-dialog.tsx
+++ b/app/src/components/skills-view/choose-chat-agent-dialog.tsx
@@ -1,0 +1,66 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  HoustonAvatar,
+  resolveAgentColor,
+} from "@houston-ai/core";
+import { useTranslation } from "react-i18next";
+import type { Agent } from "../../lib/types";
+
+/**
+ * "Who should build it with you?" — the single pick before the global page's
+ * create-with-AI chat (HOU-792). The guided chat runs ON one agent (the
+ * skill is created there first, then assignable from the manage dialog), so
+ * a workspace with several agents chooses the builder here. A one-agent
+ * workspace never sees this — the page skips straight to the chat.
+ */
+export function ChooseChatAgentDialog({
+  open,
+  onOpenChange,
+  agents,
+  onPick,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  agents: Agent[];
+  onPick: (agent: Agent) => void;
+}) {
+  const { t } = useTranslation("skills");
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader className="min-w-0">
+          <DialogTitle>{t("global.chatPick.title")}</DialogTitle>
+          <DialogDescription>
+            {t("global.chatPick.description")}
+          </DialogDescription>
+        </DialogHeader>
+        <ul className="flex max-h-72 flex-col gap-1 overflow-y-auto pr-1">
+          {agents.map((agent) => (
+            <li key={agent.id}>
+              <button
+                type="button"
+                onClick={() => {
+                  onPick(agent);
+                  onOpenChange(false);
+                }}
+                className="flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-hover"
+              >
+                <HoustonAvatar
+                  color={resolveAgentColor(agent.color)}
+                  diameter={28}
+                />
+                <span className="min-w-0 flex-1 truncate text-sm text-ink">
+                  {agent.name}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/skills-view/global-custom-tab.tsx
+++ b/app/src/components/skills-view/global-custom-tab.tsx
@@ -1,0 +1,67 @@
+import { Button, CatalogSectionHeader } from "@houston-ai/core";
+import { Plus } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { HoustonLibrarySkill } from "../../lib/houston-skill-library";
+import { HoustonSkillShelves } from "../tabs/houston-skill-shelves";
+import { useHoustonSkillLibraryData } from "../tabs/use-houston-skill-library";
+
+/**
+ * The global page's Custom skills tab (HOU-792): the same sources the
+ * per-agent tab offers — build one with an agent (primary), add one manually
+ * (the multi-agent from-scratch dialog), or pull a curated skill from the
+ * Houston library — but every install routes through the caller, which opens
+ * the pick-agents dialog and fans the copy out.
+ */
+export function GlobalCustomTab({
+  onCreateWithAi,
+  onAddClick,
+  onInstallLibrary,
+  installing,
+  installedSkillNames,
+}: {
+  /** Start the create-with-AI chat (agent picked first when several). */
+  onCreateWithAi: () => void;
+  /** Open the manual from-scratch dialog (multi-agent). */
+  onAddClick: () => void;
+  /** A library row's install click — opens the pick-agents flow. */
+  onInstallLibrary: (skill: HoustonLibrarySkill) => void;
+  /** Slug currently fanning out (drives that row's spinner), or null. */
+  installing: string | null;
+  /** Slugs installed on ANY agent — those rows show the quiet check. */
+  installedSkillNames?: Set<string>;
+}) {
+  const { t } = useTranslation("skills");
+  const library = useHoustonSkillLibraryData();
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-ink-muted">
+          {t("tabs.customEmptyDescription")}
+        </p>
+        <div className="flex items-center gap-2">
+          <Button type="button" onClick={onCreateWithAi}>
+            {t("tabs.createSkill")}
+          </Button>
+          <Button type="button" variant="outline" onClick={onAddClick}>
+            <Plus className="size-4" />
+            {t("grid.addSkill")}
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <CatalogSectionHeader title={t("library.heading")} size="lg" />
+        <HoustonSkillShelves
+          groups={library.data ?? []}
+          loading={library.isLoading}
+          failed={library.isError}
+          retry={() => void library.refetch()}
+          install={onInstallLibrary}
+          installing={installing}
+          installedSkillNames={installedSkillNames}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/skills-view/global-skill-chat.tsx
+++ b/app/src/components/skills-view/global-skill-chat.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef } from "react";
+import { skillDisplayTitle } from "../../lib/humanize-skill-name";
+import type { Agent, SkillSummary } from "../../lib/types";
+import { SkillSetupChat } from "../tabs/skill-setup-chat";
+import { useSkillChatSetup } from "../tabs/use-skill-chat-setup";
+import { useSkillSetupView } from "../tabs/use-skill-setup-view";
+
+/**
+ * The global Skills page's create-with-AI chat (HOU-792): mounts the same
+ * per-agent setup-chat machinery (HOU-791) for the PICKED agent and starts a
+ * fresh create draft immediately. The chat renders in the shell's right-hand
+ * panel (via {@link SkillSetupChat}) while the global page stays on the left;
+ * the draft→skill claim swap keeps the same conversation running once the
+ * agent writes the SKILL.md. Closing the pane (X / Escape) unmounts this via
+ * `onClose`.
+ */
+export function GlobalSkillChat({
+  agent,
+  skills,
+  onClose,
+  onEditSkill,
+}: {
+  /** The agent the chat runs on — the skill is created there first. */
+  agent: Agent;
+  /** That agent's current skill list (drives the draft→skill claim swap). */
+  skills: SkillSummary[] | undefined;
+  onClose: () => void;
+  /** The chat header's "Edit manually" for a claimed skill — opens the
+   *  global manage dialog. */
+  onEditSkill: (slug: string) => void;
+}) {
+  const chatSetup = useSkillChatSetup(agent, skills);
+  const view = useSkillSetupView(agent, skills, chatSetup);
+  const { selected, startCreate } = view;
+
+  // Kick off exactly one fresh create draft per mount (the host keys this
+  // component per open, so "New skill" always means new).
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    void startCreate();
+  }, [startCreate]);
+
+  // The selection clearing AFTER it was seen non-null means the chat was
+  // closed (pane X, Escape) or the start failed — either way this host is
+  // done. Guarded on an observed selection: on the mount commit this effect
+  // runs while `selected` is still null (startCreate's set lands next
+  // render), and closing then would tear the chat down before it ever opened.
+  const sawSelectionRef = useRef(false);
+  useEffect(() => {
+    if (selected !== null) {
+      sawSelectionRef.current = true;
+      return;
+    }
+    if (sawSelectionRef.current) onClose();
+  }, [selected, onClose]);
+
+  if (selected?.kind === "draft") {
+    const activity = selected.activityId
+      ? (chatSetup.draftActivities.find((a) => a.id === selected.activityId) ??
+        null)
+      : null;
+    return (
+      <SkillSetupChat
+        agent={agent}
+        activity={activity}
+        kind="draft"
+        onClose={view.deselect}
+      />
+    );
+  }
+  if (selected?.kind === "skill") {
+    const skill = skills?.find((s) => s.name === selected.slug);
+    if (!skill) return null;
+    return (
+      <SkillSetupChat
+        agent={agent}
+        activity={chatSetup.activityFor(skill)}
+        kind="skill"
+        skillName={skillDisplayTitle(skill)}
+        skillSlug={skill.name}
+        onClose={view.deselect}
+        onEditManually={() => onEditSkill(skill.name)}
+      />
+    );
+  }
+  return null;
+}

--- a/app/src/components/skills-view/global-skill-chat.tsx
+++ b/app/src/components/skills-view/global-skill-chat.tsx
@@ -17,13 +17,17 @@ import { useSkillSetupView } from "../tabs/use-skill-setup-view";
 export function GlobalSkillChat({
   agent,
   skills,
+  initial,
   onClose,
   onEditSkill,
 }: {
-  /** The agent the chat runs on — the skill is created there first. */
+  /** The agent the chat runs on — a created skill lands there first. */
   agent: Agent;
   /** That agent's current skill list (drives the draft→skill claim swap). */
   skills: SkillSummary[] | undefined;
+  /** What to open: a fresh create draft, or an EXISTING skill's chat (the
+   *  manage dialog's "Edit in chat"). */
+  initial: { kind: "create" } | { kind: "skill"; slug: string };
   onClose: () => void;
   /** The chat header's "Edit manually" for a claimed skill — opens the
    *  global manage dialog. */
@@ -31,16 +35,17 @@ export function GlobalSkillChat({
 }) {
   const chatSetup = useSkillChatSetup(agent, skills);
   const view = useSkillSetupView(agent, skills, chatSetup);
-  const { selected, startCreate } = view;
+  const { selected, startCreate, openSkillChat } = view;
 
-  // Kick off exactly one fresh create draft per mount (the host keys this
-  // component per open, so "New skill" always means new).
+  // Open exactly once per mount (the host keys this component per open, so
+  // "New skill" always means new, and Edit-in-chat always lands on its skill).
   const startedRef = useRef(false);
   useEffect(() => {
     if (startedRef.current) return;
     startedRef.current = true;
-    void startCreate();
-  }, [startCreate]);
+    if (initial.kind === "create") void startCreate();
+    else openSkillChat(initial.slug);
+  }, [initial, startCreate, openSkillChat]);
 
   // The selection clearing AFTER it was seen non-null means the chat was
   // closed (pane X, Escape) or the start failed — either way this host is

--- a/app/src/components/skills-view/id.ts
+++ b/app/src/components/skills-view/id.ts
@@ -1,0 +1,8 @@
+/**
+ * The `viewMode` value for the top-level Skills page (HOU-792).
+ *
+ * `"skills"` itself is taken — it is a per-agent Agent Settings screen id — so
+ * this mirrors the `integrations-home` precedent: a `-home` suffix keeps the
+ * global view id outside `STANDARD_TAB_IDS` and the agent-admin screen space.
+ */
+export const SKILLS_VIEW_ID = "skills-home";

--- a/app/src/components/skills-view/index.ts
+++ b/app/src/components/skills-view/index.ts
@@ -1,0 +1,2 @@
+export { SKILLS_VIEW_ID } from "./id";
+export { SkillsView } from "./skills-view";

--- a/app/src/components/skills-view/install-skill-dialog.tsx
+++ b/app/src/components/skills-view/install-skill-dialog.tsx
@@ -8,29 +8,35 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@houston-ai/core";
-import type { CommunitySkill } from "@houston-ai/skills";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { humanizeSkillName } from "../../lib/humanize-skill-name";
 import type { Agent } from "../../lib/types";
 import { AgentSelectList } from "./agent-select-list";
 
+/** What the picker needs to know about the skill being added. */
+export interface InstallSkillTarget {
+  /** The slug the copy will land under (drives the already-has locks). */
+  slug: string;
+  /** Display name for the dialog title. */
+  name: string;
+}
+
 /**
- * "Add to which agents?" — the picker between a marketplace install click and
- * the per-agent fan-out (HOU-792: skills are stored ON agents, so a global
- * install is N copies). Agents that already hold the slug are locked out;
- * everyone else starts selected — the global page's default intent is "my
- * agents", narrowed by unticking.
+ * "Add to which agents?" — the picker between an install click (marketplace
+ * OR Houston library) and the per-agent fan-out (HOU-792: skills are stored
+ * ON agents, so a global install is N copies). Agents that already hold the
+ * slug are locked out; everyone else starts selected — the global page's
+ * default intent is "my agents", narrowed by unticking.
  */
 export function InstallSkillDialog({
-  skill,
+  target,
   agents,
   hasSkill,
   onConfirm,
   onCancel,
 }: {
-  /** The pending marketplace install; null keeps the dialog closed. */
-  skill: CommunitySkill | null;
+  /** The pending install; null keeps the dialog closed. */
+  target: InstallSkillTarget | null;
   agents: Agent[];
   /** Whether this agent already holds the slug (locks its row). */
   hasSkill: (agent: Agent, slug: string) => boolean;
@@ -40,9 +46,9 @@ export function InstallSkillDialog({
   const { t } = useTranslation(["skills", "common"]);
   const [unticked, setUnticked] = useState<Set<string>>(new Set());
 
-  if (!skill) return null;
+  if (!target) return null;
   const lockedIds = new Set(
-    agents.filter((a) => hasSkill(a, skill.skillId)).map((a) => a.id),
+    agents.filter((a) => hasSkill(a, target.slug)).map((a) => a.id),
   );
   const targets = agents.filter(
     (a) => !lockedIds.has(a.id) && !unticked.has(a.id),
@@ -60,9 +66,7 @@ export function InstallSkillDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader className="min-w-0">
           <DialogTitle className="truncate">
-            {t("skills:global.install.title", {
-              name: humanizeSkillName(skill.skillId),
-            })}
+            {t("skills:global.install.title", { name: target.name })}
           </DialogTitle>
           <DialogDescription>
             {t("skills:global.install.description")}

--- a/app/src/components/skills-view/install-skill-dialog.tsx
+++ b/app/src/components/skills-view/install-skill-dialog.tsx
@@ -1,0 +1,103 @@
+import {
+  AsyncButton,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@houston-ai/core";
+import type { CommunitySkill } from "@houston-ai/skills";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { humanizeSkillName } from "../../lib/humanize-skill-name";
+import type { Agent } from "../../lib/types";
+import { AgentSelectList } from "./agent-select-list";
+
+/**
+ * "Add to which agents?" — the picker between a marketplace install click and
+ * the per-agent fan-out (HOU-792: skills are stored ON agents, so a global
+ * install is N copies). Agents that already hold the slug are locked out;
+ * everyone else starts selected — the global page's default intent is "my
+ * agents", narrowed by unticking.
+ */
+export function InstallSkillDialog({
+  skill,
+  agents,
+  hasSkill,
+  onConfirm,
+  onCancel,
+}: {
+  /** The pending marketplace install; null keeps the dialog closed. */
+  skill: CommunitySkill | null;
+  agents: Agent[];
+  /** Whether this agent already holds the slug (locks its row). */
+  hasSkill: (agent: Agent, slug: string) => boolean;
+  onConfirm: (targets: Agent[]) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const { t } = useTranslation(["skills", "common"]);
+  const [unticked, setUnticked] = useState<Set<string>>(new Set());
+
+  if (!skill) return null;
+  const lockedIds = new Set(
+    agents.filter((a) => hasSkill(a, skill.skillId)).map((a) => a.id),
+  );
+  const targets = agents.filter(
+    (a) => !lockedIds.has(a.id) && !unticked.has(a.id),
+  );
+  const selected = new Set(targets.map((a) => a.id));
+  const close = (open: boolean) => {
+    if (!open) {
+      setUnticked(new Set());
+      onCancel();
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={close}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader className="min-w-0">
+          <DialogTitle className="truncate">
+            {t("skills:global.install.title", {
+              name: humanizeSkillName(skill.skillId),
+            })}
+          </DialogTitle>
+          <DialogDescription>
+            {t("skills:global.install.description")}
+          </DialogDescription>
+        </DialogHeader>
+        <AgentSelectList
+          agents={agents}
+          selected={selected}
+          onToggle={(agent) =>
+            setUnticked((prev) => {
+              const next = new Set(prev);
+              if (next.has(agent.id)) next.delete(agent.id);
+              else next.add(agent.id);
+              return next;
+            })
+          }
+          lockedIds={lockedIds}
+          lockedNote={t("skills:global.alreadyHasIt")}
+        />
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={() => close(false)}>
+            {t("common:actions.cancel")}
+          </Button>
+          <AsyncButton
+            type="button"
+            disabled={targets.length === 0}
+            onClick={async () => {
+              await onConfirm(targets);
+              setUnticked(new Set());
+            }}
+          >
+            {t("skills:global.install.confirm", { count: targets.length })}
+          </AsyncButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/skills-view/manage-skill-body.tsx
+++ b/app/src/components/skills-view/manage-skill-body.tsx
@@ -1,4 +1,5 @@
 import { AsyncButton, Button, DialogFooter, Textarea } from "@houston-ai/core";
+import { MessageCircle } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { Agent } from "../../lib/types";
@@ -18,6 +19,7 @@ export function ManageSkillBody({
   onSave,
   onDeleteEverywhere,
   onCancel,
+  onEditInChat,
 }: {
   /** The canonical copy's full SKILL.md (frontmatter + body). */
   initialContent: string;
@@ -31,6 +33,9 @@ export function ManageSkillBody({
   }) => Promise<void>;
   onDeleteEverywhere: () => void;
   onCancel: () => void;
+  /** Open the skill's guided setup chat instead of editing raw markdown
+   *  (HOU-791's primary edit path). Omit to hide the button. */
+  onEditInChat?: () => void;
 }) {
   const { t } = useTranslation(["skills", "common"]);
   const [content, setContent] = useState(initialContent);
@@ -87,6 +92,12 @@ export function ManageSkillBody({
         >
           {t("common:actions.delete")}
         </Button>
+        {onEditInChat && (
+          <Button type="button" variant="outline" onClick={onEditInChat}>
+            <MessageCircle className="size-4" />
+            {t("skills:global.manage.editInChat")}
+          </Button>
+        )}
         <Button type="button" variant="ghost" onClick={onCancel}>
           {t("common:actions.cancel")}
         </Button>

--- a/app/src/components/skills-view/manage-skill-body.tsx
+++ b/app/src/components/skills-view/manage-skill-body.tsx
@@ -1,0 +1,103 @@
+import { AsyncButton, Button, DialogFooter, Textarea } from "@houston-ai/core";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { Agent } from "../../lib/types";
+import { AgentSelectList } from "./agent-select-list";
+
+/**
+ * The ready-state body of the global skill dialog: the full SKILL.md in a
+ * monospace editor (the same treatment as the per-agent edit modal) over the
+ * agent assignment list. Owns the draft state; mounted with a `key` per skill
+ * so switching rows reseeds it. Save hands the parent the draft + whether the
+ * content changed — the parent turns that into the write/delete fan-out.
+ */
+export function ManageSkillBody({
+  initialContent,
+  agents,
+  assignedIds,
+  onSave,
+  onDeleteEverywhere,
+  onCancel,
+}: {
+  /** The canonical copy's full SKILL.md (frontmatter + body). */
+  initialContent: string;
+  agents: Agent[];
+  /** Ids of the agents currently holding a copy. */
+  assignedIds: ReadonlySet<string>;
+  onSave: (draft: {
+    content: string;
+    contentDirty: boolean;
+    afterIds: Set<string>;
+  }) => Promise<void>;
+  onDeleteEverywhere: () => void;
+  onCancel: () => void;
+}) {
+  const { t } = useTranslation(["skills", "common"]);
+  const [content, setContent] = useState(initialContent);
+  const [selected, setSelected] = useState<Set<string>>(new Set(assignedIds));
+
+  const contentDirty = content !== initialContent;
+  const assignmentDirty =
+    selected.size !== assignedIds.size ||
+    [...selected].some((id) => !assignedIds.has(id));
+  const dirty = contentDirty || assignmentDirty;
+  // Unassigning everyone IS deletion — that path goes through the explicit
+  // Delete button, so an empty selection can't ride an innocuous-looking Save.
+  const savable = dirty && selected.size > 0;
+
+  return (
+    <>
+      <div className="flex min-w-0 flex-col gap-4">
+        <Textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          aria-label={t("skills:addDialog.scratch.bodyLabel")}
+          placeholder={t("skills:detail.instructionsPlaceholder")}
+          className="h-64 resize-none overflow-y-auto font-mono text-sm"
+        />
+        <div className="flex flex-col gap-1.5">
+          <span className="text-sm font-medium text-ink">
+            {t("skills:global.manage.agentsLabel")}
+          </span>
+          <AgentSelectList
+            agents={agents}
+            selected={selected}
+            onToggle={(agent) =>
+              setSelected((prev) => {
+                const next = new Set(prev);
+                if (next.has(agent.id)) next.delete(agent.id);
+                else next.add(agent.id);
+                return next;
+              })
+            }
+          />
+          {selected.size === 0 && (
+            <p className="text-xs text-ink-muted">
+              {t("skills:global.manage.keepOneAgent")}
+            </p>
+          )}
+        </div>
+      </div>
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="ghost"
+          className="mr-auto text-danger hover:text-danger"
+          onClick={onDeleteEverywhere}
+        >
+          {t("common:actions.delete")}
+        </Button>
+        <Button type="button" variant="ghost" onClick={onCancel}>
+          {t("common:actions.cancel")}
+        </Button>
+        <AsyncButton
+          type="button"
+          disabled={!savable}
+          onClick={() => onSave({ content, contentDirty, afterIds: selected })}
+        >
+          {t("skills:detail.saveChanges")}
+        </AsyncButton>
+      </DialogFooter>
+    </>
+  );
+}

--- a/app/src/components/skills-view/manage-skill-dialog.tsx
+++ b/app/src/components/skills-view/manage-skill-dialog.tsx
@@ -33,6 +33,7 @@ export function ManageSkillDialog({
   onApply,
   onDeleteEverywhere,
   onClose,
+  onEditInChat,
 }: {
   /** The open row; null keeps the dialog closed. */
   row: WorkspaceSkillRow | null;
@@ -44,6 +45,8 @@ export function ManageSkillDialog({
   ) => Promise<void>;
   onDeleteEverywhere: (row: WorkspaceSkillRow) => Promise<void>;
   onClose: () => void;
+  /** Open the skill's guided setup chat (closes this dialog first). */
+  onEditInChat?: (row: WorkspaceSkillRow) => void;
 }) {
   const { t } = useTranslation(["skills", "common"]);
   const canonicalPath = row?.agents[0]?.folderPath;
@@ -106,6 +109,14 @@ export function ManageSkillDialog({
               onSave={save}
               onDeleteEverywhere={() => setConfirmDelete(true)}
               onCancel={onClose}
+              onEditInChat={
+                onEditInChat
+                  ? () => {
+                      onClose();
+                      onEditInChat(row);
+                    }
+                  : undefined
+              }
             />
           ) : error ? (
             <p className="text-sm text-ink-muted">

--- a/app/src/components/skills-view/manage-skill-dialog.tsx
+++ b/app/src/components/skills-view/manage-skill-dialog.tsx
@@ -1,0 +1,170 @@
+import {
+  ConfirmDialog,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Skeleton,
+} from "@houston-ai/core";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useSkillDetail } from "../../hooks/queries";
+import { skillDisplayTitle } from "../../lib/humanize-skill-name";
+import type { Agent } from "../../lib/types";
+import {
+  planSkillAssignment,
+  type WorkspaceSkillRow,
+} from "../../lib/workspace-skills";
+import { ManageSkillBody } from "./manage-skill-body";
+
+/**
+ * The global skill's one detail surface (HOU-792): edit the SKILL.md and
+ * choose which agents hold a copy, in one dialog. The canonical content is the
+ * FIRST holder's copy; a save writes it to newly assigned agents always, and
+ * to existing holders only when the content itself was edited (an
+ * assignment-only save never clobbers a divergent per-agent copy). Removals
+ * are destructive, so a save that unassigns agents confirms first, naming
+ * them; Delete removes the skill from every holder behind the same handshake.
+ */
+export function ManageSkillDialog({
+  row,
+  agents,
+  onApply,
+  onDeleteEverywhere,
+  onClose,
+}: {
+  /** The open row; null keeps the dialog closed. */
+  row: WorkspaceSkillRow | null;
+  agents: Agent[];
+  onApply: (
+    row: WorkspaceSkillRow,
+    args: { content: string; contentDirty: boolean },
+    plan: { writes: string[]; deletes: string[] },
+  ) => Promise<void>;
+  onDeleteEverywhere: (row: WorkspaceSkillRow) => Promise<void>;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation(["skills", "common"]);
+  const canonicalPath = row?.agents[0]?.folderPath;
+  const { data: detail, error } = useSkillDetail(canonicalPath, row?.slug);
+  const [pendingRemove, setPendingRemove] = useState<{
+    args: { content: string; contentDirty: boolean };
+    plan: { writes: string[]; deletes: string[] };
+  } | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  if (!row) return null;
+  const assignedIds = new Set(row.agents.map((a) => a.id));
+  const pathsFor = (ids: Set<string>) =>
+    agents.filter((a) => ids.has(a.id)).map((a) => a.folderPath);
+  const namesFor = (paths: string[]) =>
+    agents
+      .filter((a) => paths.includes(a.folderPath))
+      .map((a) => a.name)
+      .join(", ");
+
+  const save = async (draft: {
+    content: string;
+    contentDirty: boolean;
+    afterIds: Set<string>;
+  }) => {
+    const args = { content: draft.content, contentDirty: draft.contentDirty };
+    const plan = planSkillAssignment({
+      contentDirty: draft.contentDirty,
+      before: pathsFor(assignedIds),
+      after: pathsFor(draft.afterIds),
+    });
+    if (plan.deletes.length > 0) {
+      setPendingRemove({ args, plan });
+      return;
+    }
+    await onApply(row, args, plan);
+    onClose();
+  };
+
+  return (
+    <>
+      <Dialog open onOpenChange={(open) => !open && onClose()}>
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader className="min-w-0">
+            <DialogTitle className="truncate">
+              {skillDisplayTitle(row.summary)}
+            </DialogTitle>
+            {row.summary.description && (
+              <DialogDescription className="line-clamp-2">
+                {row.summary.description}
+              </DialogDescription>
+            )}
+          </DialogHeader>
+          {detail ? (
+            <ManageSkillBody
+              key={`${row.slug}:${canonicalPath}`}
+              initialContent={detail.content}
+              agents={agents}
+              assignedIds={assignedIds}
+              onSave={save}
+              onDeleteEverywhere={() => setConfirmDelete(true)}
+              onCancel={onClose}
+            />
+          ) : error ? (
+            <p className="text-sm text-ink-muted">
+              {t("skills:detail.loadFailed")}
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-4 w-2/3" />
+              <Skeleton className="h-4 w-1/2" />
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        open={pendingRemove !== null}
+        onOpenChange={(open) => !open && setPendingRemove(null)}
+        title={t("skills:global.manage.removeConfirmTitle", {
+          count: pendingRemove?.plan.deletes.length ?? 0,
+        })}
+        description={t("skills:global.manage.removeConfirmDescription", {
+          names: namesFor(pendingRemove?.plan.deletes ?? []),
+        })}
+        confirmLabel={t("skills:detail.saveChanges")}
+        cancelLabel={t("common:actions.cancel")}
+        onConfirm={() => {
+          const pending = pendingRemove;
+          setPendingRemove(null);
+          if (!pending) return;
+          void onApply(row, pending.args, pending.plan)
+            .then(onClose)
+            .catch(() => {
+              // Failures already toasted by the fan-out (`call` wrapper);
+              // catching only prevents an unhandled rejection. Dialog stays
+              // open so the user can retry.
+            });
+        }}
+      />
+      <ConfirmDialog
+        open={confirmDelete}
+        onOpenChange={setConfirmDelete}
+        title={t("skills:global.manage.deleteConfirmTitle", {
+          name: skillDisplayTitle(row.summary),
+        })}
+        description={t("skills:global.manage.deleteConfirmDescription", {
+          count: row.agents.length,
+          names: row.agents.map((a) => a.name).join(", "),
+        })}
+        confirmLabel={t("common:actions.delete")}
+        cancelLabel={t("common:actions.cancel")}
+        onConfirm={() => {
+          setConfirmDelete(false);
+          void onDeleteEverywhere(row)
+            .then(onClose)
+            .catch(() => {
+              // Same contract as above: failures are already toasted.
+            });
+        }}
+      />
+    </>
+  );
+}

--- a/app/src/components/skills-view/new-skill-dialog.tsx
+++ b/app/src/components/skills-view/new-skill-dialog.tsx
@@ -1,0 +1,186 @@
+import {
+  AsyncButton,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Textarea,
+} from "@houston-ai/core";
+import { toSlug } from "@houston-ai/skills";
+import { useId, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { Agent } from "../../lib/types";
+import { AgentSelectList } from "./agent-select-list";
+
+/**
+ * The global "New skill" dialog (HOU-792): the from-scratch fields the
+ * per-agent Add dialog carries (title, one-liner, instructions — same i18n
+ * keys) PLUS the agent multi-select, because a skill created from the global
+ * page is written to every picked agent. Agents already holding the derived
+ * slug lock out live as the user types the title.
+ */
+export function NewSkillDialog({
+  open,
+  onOpenChange,
+  agents,
+  hasSkill,
+  onCreate,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  agents: Agent[];
+  hasSkill: (agent: Agent, slug: string) => boolean;
+  onCreate: (
+    input: { name: string; description: string; content: string },
+    targets: Agent[],
+  ) => Promise<void>;
+}) {
+  const { t } = useTranslation(["skills", "common"]);
+  const fieldId = useId();
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [body, setBody] = useState("");
+  const [unticked, setUnticked] = useState<Set<string>>(new Set());
+
+  const slug = useMemo(() => toSlug(title), [title]);
+  const lockedIds = useMemo(
+    () =>
+      new Set(
+        slug ? agents.filter((a) => hasSkill(a, slug)).map((a) => a.id) : [],
+      ),
+    [agents, hasSkill, slug],
+  );
+  const targets = agents.filter(
+    (a) => !lockedIds.has(a.id) && !unticked.has(a.id),
+  );
+  const ready =
+    title.trim() !== "" &&
+    slug !== "" &&
+    description.trim() !== "" &&
+    body.trim() !== "" &&
+    targets.length > 0;
+
+  const reset = () => {
+    setTitle("");
+    setDescription("");
+    setBody("");
+    setUnticked(new Set());
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) reset();
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader className="min-w-0">
+          <DialogTitle>{t("skills:global.create.title")}</DialogTitle>
+          <DialogDescription>
+            {t("skills:global.create.description")}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex min-w-0 flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor={`${fieldId}-title`}
+              className="text-sm font-medium text-ink"
+            >
+              {t("skills:addDialog.scratch.titleLabel")}
+            </label>
+            <Input
+              id={`${fieldId}-title`}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={t("skills:addDialog.scratch.titlePlaceholder")}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor={`${fieldId}-description`}
+              className="text-sm font-medium text-ink"
+            >
+              {t("skills:addDialog.scratch.descriptionLabel")}
+            </label>
+            <Input
+              id={`${fieldId}-description`}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={t("skills:addDialog.scratch.descriptionPlaceholder")}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor={`${fieldId}-body`}
+              className="text-sm font-medium text-ink"
+            >
+              {t("skills:addDialog.scratch.bodyLabel")}
+            </label>
+            <Textarea
+              id={`${fieldId}-body`}
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder={t("skills:addDialog.scratch.bodyPlaceholder")}
+              className="h-32 resize-none overflow-y-auto font-mono text-sm"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <span className="text-sm font-medium text-ink">
+              {t("skills:global.create.agentsLabel")}
+            </span>
+            <AgentSelectList
+              agents={agents}
+              selected={new Set(targets.map((a) => a.id))}
+              onToggle={(agent) =>
+                setUnticked((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(agent.id)) next.delete(agent.id);
+                  else next.add(agent.id);
+                  return next;
+                })
+              }
+              lockedIds={lockedIds}
+              lockedNote={t("skills:global.alreadyHasIt")}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => {
+              reset();
+              onOpenChange(false);
+            }}
+          >
+            {t("common:actions.cancel")}
+          </Button>
+          <AsyncButton
+            type="button"
+            disabled={!ready}
+            onClick={async () => {
+              await onCreate(
+                {
+                  name: title.trim(),
+                  description: description.trim(),
+                  content: body,
+                },
+                targets,
+              );
+              reset();
+              onOpenChange(false);
+            }}
+          >
+            {t("skills:global.create.confirm", { count: targets.length })}
+          </AsyncButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/skills-view/skills-view.tsx
+++ b/app/src/components/skills-view/skills-view.tsx
@@ -152,6 +152,7 @@ export function SkillsView() {
         onApply={actions.applySkillChanges}
         onDeleteEverywhere={actions.deleteSkillEverywhere}
         onClose={() => setManaging(null)}
+        onEditInChat={chat.openForSkill}
       />
       <NewSkillDialog
         open={creating}

--- a/app/src/components/skills-view/skills-view.tsx
+++ b/app/src/components/skills-view/skills-view.tsx
@@ -1,0 +1,175 @@
+import {
+  Button,
+  CatalogSearchField,
+  CatalogShell,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+  Spinner,
+} from "@houston-ai/core";
+import type { CommunitySkill } from "@houston-ai/skills";
+import { Plus } from "lucide-react";
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { Agent } from "../../lib/types";
+import type { WorkspaceSkillRow } from "../../lib/workspace-skills";
+import { useAgentStore } from "../../stores/agents";
+import { PageContainer, PageHeader } from "../shell/page-shell";
+import { InstallSkillDialog } from "./install-skill-dialog";
+import { ManageSkillDialog } from "./manage-skill-dialog";
+import { NewSkillDialog } from "./new-skill-dialog";
+import { useGlobalStoreTab } from "./use-global-store-tab";
+import { useSkillsViewActions } from "./use-skills-view-actions";
+import { useWorkspaceSkills } from "./use-workspace-skills";
+import { useWorkspaceSkillRows } from "./workspace-skill-rows";
+
+/** A marketplace install waiting on the pick-agents dialog. */
+interface PendingInstall {
+  skill: CommunitySkill;
+  resolve: (slug: string) => void;
+  reject: (err: unknown) => void;
+}
+
+/** Approximate skills.sh size, shown on the Available chip (async store, no
+ *  cheap total — same label the per-agent tab shows). */
+const SKILL_STORE_SIZE_LABEL = "9000+";
+
+/**
+ * The top-level Skills page (sidebar "Skills", HOU-792): one place to see and
+ * manage skills across every agent in the workspace. Skills still live ON each
+ * agent — this surface aggregates the per-agent lists and fans installs,
+ * creates, edits and removals out to the picked agents through the existing
+ * agent-scoped routes (no shared store, nothing new server-side).
+ */
+export function SkillsView() {
+  const { t } = useTranslation("skills");
+  const agents = useAgentStore((s) => s.agents);
+  const { rows, installedSkillNames, listsByPath, loading } =
+    useWorkspaceSkills(agents);
+  const actions = useSkillsViewActions();
+
+  const [query, setQuery] = useState("");
+  const [managing, setManaging] = useState<WorkspaceSkillRow | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [pendingInstall, setPendingInstall] = useState<PendingInstall | null>(
+    null,
+  );
+
+  const hasSkill = useCallback(
+    (agent: Agent, slug: string) =>
+      (listsByPath.get(agent.folderPath) ?? []).some((s) => s.name === slug),
+    [listsByPath],
+  );
+
+  // The marketplace card hands us the install click as a promise; park it
+  // behind the pick-agents dialog and settle it with the fan-out's outcome
+  // (a cancel rejects — the card quietly re-enables, nothing toasts).
+  const handleInstall = useCallback(
+    (skill: CommunitySkill) =>
+      new Promise<string>((resolve, reject) => {
+        setPendingInstall({ skill, resolve, reject });
+      }),
+    [],
+  );
+
+  const { installed, installedCount } = useWorkspaceSkillRows(
+    rows,
+    query,
+    setManaging,
+  );
+  const tabs = useGlobalStoreTab({
+    browsePath: agents[0]?.folderPath,
+    query,
+    onQueryChange: setQuery,
+    onInstall: handleInstall,
+    installedSkillNames,
+  });
+
+  return (
+    <div className="h-full overflow-y-auto [scrollbar-gutter:stable]">
+      <PageContainer className="flex flex-col gap-6 py-10">
+        <PageHeader
+          title={t("global.pageTitle")}
+          subtitle={t("global.pageSubtitle")}
+          trailing={
+            agents.length > 0 ? (
+              <Button type="button" onClick={() => setCreating(true)}>
+                <Plus className="size-4" />
+                {t("global.newSkill")}
+              </Button>
+            ) : undefined
+          }
+        />
+        {agents.length === 0 ? (
+          <Empty>
+            <EmptyHeader>
+              <EmptyTitle>{t("global.noAgentsTitle")}</EmptyTitle>
+              <EmptyDescription>
+                {t("global.noAgentsDescription")}
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : loading && rows.length === 0 ? (
+          <div className="flex items-center gap-2 text-sm text-ink-muted">
+            <Spinner className="size-3.5" />
+            {t("grid.loading")}
+          </div>
+        ) : (
+          <CatalogShell
+            controls={
+              <CatalogSearchField
+                value={query}
+                onChange={setQuery}
+                label={t("grid.searchSkills")}
+              />
+            }
+            installedTitle={t("grid.yourSkillsHeading")}
+            installedCount={installedCount}
+            installed={installed}
+            availableTitle={t("grid.availableHeading")}
+            availableCount={SKILL_STORE_SIZE_LABEL}
+            tabs={tabs}
+          />
+        )}
+      </PageContainer>
+      <ManageSkillDialog
+        row={managing}
+        agents={agents}
+        onApply={actions.applySkillChanges}
+        onDeleteEverywhere={actions.deleteSkillEverywhere}
+        onClose={() => setManaging(null)}
+      />
+      <NewSkillDialog
+        open={creating}
+        onOpenChange={setCreating}
+        agents={agents}
+        hasSkill={hasSkill}
+        onCreate={actions.createForAgents}
+      />
+      <InstallSkillDialog
+        skill={pendingInstall?.skill ?? null}
+        agents={agents}
+        hasSkill={hasSkill}
+        onConfirm={async (targets) => {
+          const pending = pendingInstall;
+          if (!pending) return;
+          try {
+            pending.resolve(
+              await actions.installToAgents(pending.skill, targets),
+            );
+          } catch (err) {
+            // Failure toasts already fired inside the fan-out; rejecting only
+            // re-enables the marketplace card.
+            pending.reject(err);
+          }
+          setPendingInstall(null);
+        }}
+        onCancel={() => {
+          pendingInstall?.reject(new Error("install canceled"));
+          setPendingInstall(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/app/src/components/skills-view/skills-view.tsx
+++ b/app/src/components/skills-view/skills-view.tsx
@@ -8,7 +8,6 @@ import {
   EmptyTitle,
   Spinner,
 } from "@houston-ai/core";
-import type { CommunitySkill } from "@houston-ai/skills";
 import { Plus } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -16,20 +15,14 @@ import type { Agent } from "../../lib/types";
 import type { WorkspaceSkillRow } from "../../lib/workspace-skills";
 import { useAgentStore } from "../../stores/agents";
 import { PageContainer, PageHeader } from "../shell/page-shell";
-import { InstallSkillDialog } from "./install-skill-dialog";
 import { ManageSkillDialog } from "./manage-skill-dialog";
 import { NewSkillDialog } from "./new-skill-dialog";
-import { useGlobalStoreTab } from "./use-global-store-tab";
+import { useGlobalChatFlow } from "./use-global-chat-flow";
+import { useGlobalInstallFlow } from "./use-global-install-flow";
+import { useGlobalSkillTabs } from "./use-global-skill-tabs";
 import { useSkillsViewActions } from "./use-skills-view-actions";
 import { useWorkspaceSkills } from "./use-workspace-skills";
 import { useWorkspaceSkillRows } from "./workspace-skill-rows";
-
-/** A marketplace install waiting on the pick-agents dialog. */
-interface PendingInstall {
-  skill: CommunitySkill;
-  resolve: (slug: string) => void;
-  reject: (err: unknown) => void;
-}
 
 /** Approximate skills.sh size, shown on the Available chip (async store, no
  *  cheap total — same label the per-agent tab shows). */
@@ -37,10 +30,12 @@ const SKILL_STORE_SIZE_LABEL = "9000+";
 
 /**
  * The top-level Skills page (sidebar "Skills", HOU-792): one place to see and
- * manage skills across every agent in the workspace. Skills still live ON each
- * agent — this surface aggregates the per-agent lists and fans installs,
+ * manage skills across every agent in the workspace. Skills still live ON
+ * each agent — this surface aggregates the per-agent lists and fans installs,
  * creates, edits and removals out to the picked agents through the existing
- * agent-scoped routes (no shared store, nothing new server-side).
+ * agent-scoped routes (no shared store, nothing new server-side). "New skill"
+ * opens the guided create chat in the shell's right-hand panel (the Routines
+ * split) while this page stays on the left.
  */
 export function SkillsView() {
   const { t } = useTranslation("skills");
@@ -50,11 +45,9 @@ export function SkillsView() {
   const actions = useSkillsViewActions();
 
   const [query, setQuery] = useState("");
+  const [tab, setTab] = useState("store");
   const [managing, setManaging] = useState<WorkspaceSkillRow | null>(null);
   const [creating, setCreating] = useState(false);
-  const [pendingInstall, setPendingInstall] = useState<PendingInstall | null>(
-    null,
-  );
 
   const hasSkill = useCallback(
     (agent: Agent, slug: string) =>
@@ -62,28 +55,41 @@ export function SkillsView() {
     [listsByPath],
   );
 
-  // The marketplace card hands us the install click as a promise; park it
-  // behind the pick-agents dialog and settle it with the fan-out's outcome
-  // (a cancel rejects — the card quietly re-enables, nothing toasts).
-  const handleInstall = useCallback(
-    (skill: CommunitySkill) =>
-      new Promise<string>((resolve, reject) => {
-        setPendingInstall({ skill, resolve, reject });
-      }),
-    [],
+  // The chat's "Edit manually" targets the freshly claimed skill; its row may
+  // still be settling into the aggregate, so a miss is a quiet no-op (the row
+  // click covers it once the list refreshes).
+  const openManageBySlug = useCallback(
+    (slug: string) => {
+      const row = rows.find((r) => r.slug === slug);
+      if (row) setManaging(row);
+    },
+    [rows],
   );
+
+  const chat = useGlobalChatFlow({
+    agents,
+    listsByPath,
+    onEditSkill: openManageBySlug,
+  });
+  const install = useGlobalInstallFlow({ agents, hasSkill, actions });
 
   const { installed, installedCount } = useWorkspaceSkillRows(
     rows,
     query,
     setManaging,
   );
-  const tabs = useGlobalStoreTab({
+  const tabs = useGlobalSkillTabs({
     browsePath: agents[0]?.folderPath,
     query,
     onQueryChange: setQuery,
-    onInstall: handleInstall,
+    onInstall: install.handleInstallCommunity,
     installedSkillNames,
+    custom: {
+      onCreateWithAi: chat.startCreate,
+      onAddClick: () => setCreating(true),
+      onInstallLibrary: install.handleInstallLibrary,
+      installing: install.libraryInstalling,
+    },
   });
 
   return (
@@ -94,7 +100,7 @@ export function SkillsView() {
           subtitle={t("global.pageSubtitle")}
           trailing={
             agents.length > 0 ? (
-              <Button type="button" onClick={() => setCreating(true)}>
+              <Button type="button" onClick={chat.startCreate}>
                 <Plus className="size-4" />
                 {t("global.newSkill")}
               </Button>
@@ -128,11 +134,18 @@ export function SkillsView() {
             installedCount={installedCount}
             installed={installed}
             availableTitle={t("grid.availableHeading")}
-            availableCount={SKILL_STORE_SIZE_LABEL}
+            // The store-size label belongs to the Store tab only.
+            availableCount={
+              tab === "store" ? SKILL_STORE_SIZE_LABEL : undefined
+            }
             tabs={tabs}
+            value={tab}
+            onValueChange={setTab}
           />
         )}
       </PageContainer>
+      {chat.node}
+      {install.dialogNode}
       <ManageSkillDialog
         row={managing}
         agents={agents}
@@ -146,29 +159,6 @@ export function SkillsView() {
         agents={agents}
         hasSkill={hasSkill}
         onCreate={actions.createForAgents}
-      />
-      <InstallSkillDialog
-        skill={pendingInstall?.skill ?? null}
-        agents={agents}
-        hasSkill={hasSkill}
-        onConfirm={async (targets) => {
-          const pending = pendingInstall;
-          if (!pending) return;
-          try {
-            pending.resolve(
-              await actions.installToAgents(pending.skill, targets),
-            );
-          } catch (err) {
-            // Failure toasts already fired inside the fan-out; rejecting only
-            // re-enables the marketplace card.
-            pending.reject(err);
-          }
-          setPendingInstall(null);
-        }}
-        onCancel={() => {
-          pendingInstall?.reject(new Error("install canceled"));
-          setPendingInstall(null);
-        }}
       />
     </div>
   );

--- a/app/src/components/skills-view/use-global-chat-flow.tsx
+++ b/app/src/components/skills-view/use-global-chat-flow.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+import { useCallback, useRef, useState } from "react";
+import type { Agent, SkillSummary } from "../../lib/types";
+import { ChooseChatAgentDialog } from "./choose-chat-agent-dialog";
+import { GlobalSkillChat } from "./global-skill-chat";
+
+/**
+ * The global page's create-with-AI entry (HOU-792): "New skill" picks the
+ * agent that hosts the guided chat (skipped straight to the chat when the
+ * workspace has exactly one), then mounts {@link GlobalSkillChat} keyed per
+ * open so every click starts a FRESH draft — the chat renders in the shell's
+ * right panel while the page stays on the left.
+ */
+export function useGlobalChatFlow(opts: {
+  agents: Agent[];
+  listsByPath: Map<string, SkillSummary[] | undefined>;
+  /** The chat's "Edit manually" — opens the global manage dialog. */
+  onEditSkill: (slug: string) => void;
+}): { node: ReactNode; startCreate: () => void } {
+  const { agents, listsByPath, onEditSkill } = opts;
+  const [chat, setChat] = useState<{ agent: Agent; nonce: number } | null>(
+    null,
+  );
+  const [pickOpen, setPickOpen] = useState(false);
+  const nonceRef = useRef(0);
+
+  const openFor = useCallback((agent: Agent) => {
+    nonceRef.current += 1;
+    setChat({ agent, nonce: nonceRef.current });
+  }, []);
+
+  const startCreate = useCallback(() => {
+    if (agents.length === 0) return;
+    if (agents.length === 1) openFor(agents[0]);
+    else setPickOpen(true);
+  }, [agents, openFor]);
+
+  const close = useCallback(() => setChat(null), []);
+
+  const node = (
+    <>
+      {chat && (
+        <GlobalSkillChat
+          key={`${chat.agent.id}:${chat.nonce}`}
+          agent={chat.agent}
+          skills={listsByPath.get(chat.agent.folderPath)}
+          onClose={close}
+          onEditSkill={onEditSkill}
+        />
+      )}
+      <ChooseChatAgentDialog
+        open={pickOpen}
+        onOpenChange={setPickOpen}
+        agents={agents}
+        onPick={openFor}
+      />
+    </>
+  );
+
+  return { node, startCreate };
+}

--- a/app/src/components/skills-view/use-global-chat-flow.tsx
+++ b/app/src/components/skills-view/use-global-chat-flow.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { useCallback, useRef, useState } from "react";
 import type { Agent, SkillSummary } from "../../lib/types";
+import type { WorkspaceSkillRow } from "../../lib/workspace-skills";
 import { ChooseChatAgentDialog } from "./choose-chat-agent-dialog";
 import { GlobalSkillChat } from "./global-skill-chat";
 
@@ -16,24 +17,48 @@ export function useGlobalChatFlow(opts: {
   listsByPath: Map<string, SkillSummary[] | undefined>;
   /** The chat's "Edit manually" — opens the global manage dialog. */
   onEditSkill: (slug: string) => void;
-}): { node: ReactNode; startCreate: () => void } {
+}): {
+  node: ReactNode;
+  startCreate: () => void;
+  /** The manage dialog's "Edit in chat": the skill's own chat, hosted on its
+   *  first holder (the canonical copy's agent). */
+  openForSkill: (row: WorkspaceSkillRow) => void;
+} {
   const { agents, listsByPath, onEditSkill } = opts;
-  const [chat, setChat] = useState<{ agent: Agent; nonce: number } | null>(
-    null,
-  );
+  const [chat, setChat] = useState<{
+    agent: Agent;
+    initial: { kind: "create" } | { kind: "skill"; slug: string };
+    nonce: number;
+  } | null>(null);
   const [pickOpen, setPickOpen] = useState(false);
   const nonceRef = useRef(0);
 
-  const openFor = useCallback((agent: Agent) => {
-    nonceRef.current += 1;
-    setChat({ agent, nonce: nonceRef.current });
-  }, []);
+  const openFor = useCallback(
+    (
+      agent: Agent,
+      initial: { kind: "create" } | { kind: "skill"; slug: string } = {
+        kind: "create",
+      },
+    ) => {
+      nonceRef.current += 1;
+      setChat({ agent, initial, nonce: nonceRef.current });
+    },
+    [],
+  );
 
   const startCreate = useCallback(() => {
     if (agents.length === 0) return;
     if (agents.length === 1) openFor(agents[0]);
     else setPickOpen(true);
   }, [agents, openFor]);
+
+  const openForSkill = useCallback(
+    (row: WorkspaceSkillRow) => {
+      const holder = agents.find((a) => a.id === row.agents[0]?.id);
+      if (holder) openFor(holder, { kind: "skill", slug: row.slug });
+    },
+    [agents, openFor],
+  );
 
   const close = useCallback(() => setChat(null), []);
 
@@ -44,6 +69,7 @@ export function useGlobalChatFlow(opts: {
           key={`${chat.agent.id}:${chat.nonce}`}
           agent={chat.agent}
           skills={listsByPath.get(chat.agent.folderPath)}
+          initial={chat.initial}
           onClose={close}
           onEditSkill={onEditSkill}
         />
@@ -52,10 +78,10 @@ export function useGlobalChatFlow(opts: {
         open={pickOpen}
         onOpenChange={setPickOpen}
         agents={agents}
-        onPick={openFor}
+        onPick={(agent) => openFor(agent)}
       />
     </>
   );
 
-  return { node, startCreate };
+  return { node, startCreate, openForSkill };
 }

--- a/app/src/components/skills-view/use-global-install-flow.tsx
+++ b/app/src/components/skills-view/use-global-install-flow.tsx
@@ -1,0 +1,112 @@
+import type { CommunitySkill } from "@houston-ai/skills";
+import type { ReactNode } from "react";
+import { useCallback, useState } from "react";
+import type { HoustonLibrarySkill } from "../../lib/houston-skill-library";
+import {
+  humanizeSkillName,
+  skillDisplayTitle,
+} from "../../lib/humanize-skill-name";
+import type { Agent } from "../../lib/types";
+import { InstallSkillDialog } from "./install-skill-dialog";
+import type { useSkillsViewActions } from "./use-skills-view-actions";
+
+/** An install parked behind the pick-agents dialog. */
+type PendingInstall =
+  | {
+      kind: "community";
+      skill: CommunitySkill;
+      resolve: (slug: string) => void;
+      reject: (err: unknown) => void;
+    }
+  | { kind: "library"; skill: HoustonLibrarySkill };
+
+/**
+ * The global page's one pick-agents install flow (HOU-792): both install
+ * sources — a skills.sh marketplace card and a Houston-library row — park
+ * their click here, the shared dialog chooses the agents, and the matching
+ * fan-out runs. The marketplace card hands its click over as a promise
+ * (settled with the fan-out's outcome; a cancel rejects quietly so the card
+ * just re-enables), the library row via a busy-slug it can spin on.
+ */
+export function useGlobalInstallFlow(opts: {
+  agents: Agent[];
+  hasSkill: (agent: Agent, slug: string) => boolean;
+  actions: ReturnType<typeof useSkillsViewActions>;
+}): {
+  dialogNode: ReactNode;
+  handleInstallCommunity: (skill: CommunitySkill) => Promise<string>;
+  handleInstallLibrary: (skill: HoustonLibrarySkill) => void;
+  /** The library slug currently picking/fanning out (its row spins). */
+  libraryInstalling: string | null;
+} {
+  const { agents, hasSkill, actions } = opts;
+  const [pending, setPending] = useState<PendingInstall | null>(null);
+  const [libraryBusy, setLibraryBusy] = useState<string | null>(null);
+
+  const handleInstallCommunity = useCallback(
+    (skill: CommunitySkill) =>
+      new Promise<string>((resolve, reject) => {
+        setPending({ kind: "community", skill, resolve, reject });
+      }),
+    [],
+  );
+
+  const handleInstallLibrary = useCallback((skill: HoustonLibrarySkill) => {
+    setLibraryBusy(skill.slug);
+    setPending({ kind: "library", skill });
+  }, []);
+
+  const settle = useCallback(() => {
+    setPending(null);
+    setLibraryBusy(null);
+  }, []);
+
+  const target = pending
+    ? pending.kind === "community"
+      ? {
+          slug: pending.skill.skillId,
+          name: humanizeSkillName(pending.skill.skillId),
+        }
+      : {
+          slug: pending.skill.slug,
+          name: skillDisplayTitle({
+            name: pending.skill.slug,
+            title: pending.skill.title,
+          }),
+        }
+    : null;
+
+  const dialogNode = (
+    <InstallSkillDialog
+      target={target}
+      agents={agents}
+      hasSkill={hasSkill}
+      onConfirm={async (targets) => {
+        const p = pending;
+        if (!p) return;
+        try {
+          if (p.kind === "community")
+            p.resolve(await actions.installToAgents(p.skill, targets));
+          else await actions.installLibraryToAgents(p.skill, targets);
+        } catch (err) {
+          // Failure toasts already fired inside the fan-out; a community
+          // rejection only re-enables the marketplace card.
+          if (p.kind === "community") p.reject(err);
+        }
+        settle();
+      }}
+      onCancel={() => {
+        if (pending?.kind === "community")
+          pending.reject(new Error("install canceled"));
+        settle();
+      }}
+    />
+  );
+
+  return {
+    dialogNode,
+    handleInstallCommunity,
+    handleInstallLibrary,
+    libraryInstalling: libraryBusy,
+  };
+}

--- a/app/src/components/skills-view/use-global-skill-tabs.tsx
+++ b/app/src/components/skills-view/use-global-skill-tabs.tsx
@@ -3,28 +3,36 @@ import type { CommunitySkill } from "@houston-ai/skills";
 import { SkillMarketplaceSection } from "@houston-ai/skills";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import type { HoustonLibrarySkill } from "../../lib/houston-skill-library";
 import { skillIntegrationSlugs } from "../../lib/skill-integrations";
 import { tauriSkills } from "../../lib/tauri";
 import { IntegrationBadges } from "../integrations";
 import { useSkillMarketplaceSectionLabels } from "../tabs/use-skill-surface-labels";
+import { GlobalCustomTab } from "./global-custom-tab";
 
 /**
- * The global page's skills.sh Store tab (HOU-792) — the same
- * {@link SkillMarketplaceSection} the per-agent tab mounts, with two twists:
- * search/preview are read-only marketplace proxies, so they ride ANY owned
- * agent (the first — the hosted gateway only proxies agent-scoped routes);
- * and install goes through the caller's `onInstall`, which opens the
- * pick-agents dialog before fanning out. Returns no tab without an agent to
- * browse through.
+ * The global page's discovery tabs (HOU-792): **Store** — the same
+ * {@link SkillMarketplaceSection} the per-agent tab mounts, its search/preview
+ * riding ANY owned agent (read-only marketplace proxies; the hosted gateway
+ * only proxies agent-scoped routes) — and **Custom skills** — build with an
+ * agent, add manually, or pull from the Houston library. Every install routes
+ * through the caller's pick-agents flow. No agent → no tabs (the page shows
+ * its empty state instead).
  */
-export function useGlobalStoreTab(opts: {
-  /** The agent id the read-only marketplace calls ride; undefined = no tab. */
+export function useGlobalSkillTabs(opts: {
+  /** The agent id the read-only marketplace calls ride; undefined = no tabs. */
   browsePath: string | undefined;
   query: string;
   onQueryChange: (q: string) => void;
   onInstall: (skill: CommunitySkill) => Promise<string>;
   /** Slugs installed on ANY agent — the "installed" check marks. */
   installedSkillNames: Set<string>;
+  custom: {
+    onCreateWithAi: () => void;
+    onAddClick: () => void;
+    onInstallLibrary: (skill: HoustonLibrarySkill) => void;
+    installing: string | null;
+  };
 }): CatalogShellTab[] {
   const { t } = useTranslation("skills");
   const marketplaceLabels = useSkillMarketplaceSectionLabels();
@@ -72,6 +80,19 @@ export function useGlobalStoreTab(opts: {
           // The page's "Available" section header names this area, so the
           // marketplace drops its own redundant heading.
           labels={{ ...marketplaceLabels, heading: undefined }}
+        />
+      ),
+    },
+    {
+      value: "custom",
+      label: t("tabs.custom"),
+      content: (
+        <GlobalCustomTab
+          onCreateWithAi={opts.custom.onCreateWithAi}
+          onAddClick={opts.custom.onAddClick}
+          onInstallLibrary={opts.custom.onInstallLibrary}
+          installing={opts.custom.installing}
+          installedSkillNames={opts.installedSkillNames}
         />
       ),
     },

--- a/app/src/components/skills-view/use-global-store-tab.tsx
+++ b/app/src/components/skills-view/use-global-store-tab.tsx
@@ -1,0 +1,79 @@
+import type { CatalogShellTab } from "@houston-ai/core";
+import type { CommunitySkill } from "@houston-ai/skills";
+import { SkillMarketplaceSection } from "@houston-ai/skills";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { skillIntegrationSlugs } from "../../lib/skill-integrations";
+import { tauriSkills } from "../../lib/tauri";
+import { IntegrationBadges } from "../integrations";
+import { useSkillMarketplaceSectionLabels } from "../tabs/use-skill-surface-labels";
+
+/**
+ * The global page's skills.sh Store tab (HOU-792) — the same
+ * {@link SkillMarketplaceSection} the per-agent tab mounts, with two twists:
+ * search/preview are read-only marketplace proxies, so they ride ANY owned
+ * agent (the first — the hosted gateway only proxies agent-scoped routes);
+ * and install goes through the caller's `onInstall`, which opens the
+ * pick-agents dialog before fanning out. Returns no tab without an agent to
+ * browse through.
+ */
+export function useGlobalStoreTab(opts: {
+  /** The agent id the read-only marketplace calls ride; undefined = no tab. */
+  browsePath: string | undefined;
+  query: string;
+  onQueryChange: (q: string) => void;
+  onInstall: (skill: CommunitySkill) => Promise<string>;
+  /** Slugs installed on ANY agent — the "installed" check marks. */
+  installedSkillNames: Set<string>;
+}): CatalogShellTab[] {
+  const { t } = useTranslation("skills");
+  const marketplaceLabels = useSkillMarketplaceSectionLabels();
+  const { browsePath, onInstall } = opts;
+
+  const handleSearch = useCallback(
+    (query: string, signal?: AbortSignal) => {
+      if (!browsePath) return Promise.resolve([]);
+      return tauriSkills.searchCommunity(browsePath, query, signal);
+    },
+    [browsePath],
+  );
+  const handlePreview = useCallback(
+    (skill: CommunitySkill, signal?: AbortSignal) => {
+      if (!browsePath) throw new Error("no agent to browse through");
+      return tauriSkills.previewCommunity(
+        browsePath,
+        skill.source,
+        skill.skillId,
+        signal,
+      );
+    },
+    [browsePath],
+  );
+
+  if (!browsePath) return [];
+  return [
+    {
+      value: "store",
+      label: t("tabs.store"),
+      content: (
+        <SkillMarketplaceSection
+          onSearch={handleSearch}
+          onInstall={onInstall}
+          onPreview={handlePreview}
+          installedSkillNames={opts.installedSkillNames}
+          renderIntegrations={(slugs) => (
+            <IntegrationBadges
+              toolkits={skillIntegrationSlugs(slugs)}
+              label={t("detail.integrations")}
+            />
+          )}
+          query={opts.query}
+          onQueryChange={opts.onQueryChange}
+          // The page's "Available" section header names this area, so the
+          // marketplace drops its own redundant heading.
+          labels={{ ...marketplaceLabels, heading: undefined }}
+        />
+      ),
+    },
+  ];
+}

--- a/app/src/components/skills-view/use-skills-view-actions.ts
+++ b/app/src/components/skills-view/use-skills-view-actions.ts
@@ -3,6 +3,10 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { analytics } from "../../lib/analytics";
+import {
+  type HoustonLibrarySkill,
+  withFeaturedFrontmatter,
+} from "../../lib/houston-skill-library";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriAgent, tauriSkills } from "../../lib/tauri";
 import type { Agent } from "../../lib/types";
@@ -122,6 +126,37 @@ export function useSkillsViewActions() {
     [addToast, invalidateSkills, t],
   );
 
+  /** Houston-library install, fanned out to the picked agents — the same
+   *  full-file copy the per-agent library uses, N times. */
+  const installLibraryToAgents = useCallback(
+    async (skill: HoustonLibrarySkill, targets: Agent[]): Promise<void> => {
+      const settled = await Promise.allSettled(
+        targets.map((agent) =>
+          tauriAgent.writeFile(
+            agent.folderPath,
+            skillMdPath(skill.slug),
+            withFeaturedFrontmatter(skill.content),
+          ),
+        ),
+      );
+      invalidateSkills(targets.map((a) => a.folderPath));
+      const okCount = settled.filter((r) => r.status === "fulfilled").length;
+      if (okCount > 0) {
+        analytics.track("skill_installed", {
+          skill_slug: skill.slug,
+          source: "houston",
+        });
+        addToast({
+          title: t("global.installedTo", { count: okCount }),
+          variant: "success",
+        });
+      }
+      // Failures already toasted with their real reason by `call`.
+      if (okCount === 0) throw new Error("install failed for every agent");
+    },
+    [addToast, invalidateSkills, t],
+  );
+
   /** One global save: write the canonical content to `writes`, remove the copy
    *  from `deletes` (both agent folderPaths). Throws if anything failed so the
    *  dialog stays open; the failed calls have already toasted their reason. */
@@ -165,6 +200,7 @@ export function useSkillsViewActions() {
 
   return {
     installToAgents,
+    installLibraryToAgents,
     createForAgents,
     applySkillChanges,
     deleteSkillEverywhere,

--- a/app/src/components/skills-view/use-skills-view-actions.ts
+++ b/app/src/components/skills-view/use-skills-view-actions.ts
@@ -1,0 +1,172 @@
+import { type CommunitySkill, classifySkillError } from "@houston-ai/skills";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { analytics } from "../../lib/analytics";
+import { queryKeys } from "../../lib/query-keys";
+import { tauriAgent, tauriSkills } from "../../lib/tauri";
+import type { Agent } from "../../lib/types";
+import type { WorkspaceSkillRow } from "../../lib/workspace-skills";
+import { useUIStore } from "../../stores/ui";
+
+const skillMdPath = (slug: string) => `.agents/skills/${slug}/SKILL.md`;
+
+/**
+ * The global Skills page's fan-out actions (HOU-792): every operation is N
+ * calls to the existing per-agent routes (skills are stored ON each agent —
+ * there is no shared store, and the hosted gateway only proxies agent-scoped
+ * routes). Failures surface per the no-silent-failures rule: the `call`
+ * wrapper already toasts write/delete failures with the real reason; community
+ * installs ride `toast: false`, so this hook toasts those itself, naming the
+ * agents that failed.
+ */
+export function useSkillsViewActions() {
+  const { t } = useTranslation("skills");
+  const qc = useQueryClient();
+  const addToast = useUIStore((s) => s.addToast);
+
+  const invalidateSkills = useCallback(
+    (paths: string[]) => {
+      for (const path of paths) {
+        qc.invalidateQueries({ queryKey: queryKeys.skills(path) });
+        qc.invalidateQueries({ queryKey: ["skill-detail", path] });
+      }
+    },
+    [qc],
+  );
+
+  /** skills.sh install, fanned out to the picked agents. Resolves the slug for
+   *  the marketplace card's installed check; rejects if nothing installed. */
+  const installToAgents = useCallback(
+    async (skill: CommunitySkill, targets: Agent[]): Promise<string> => {
+      const settled = await Promise.allSettled(
+        targets.map((agent) =>
+          tauriSkills.installCommunity(
+            agent.folderPath,
+            skill.source,
+            skill.skillId,
+          ),
+        ),
+      );
+      invalidateSkills(targets.map((a) => a.folderPath));
+      const failures = settled
+        .map((r, i) => ({ r, agent: targets[i] }))
+        .filter(({ r }) => r.status === "rejected");
+      const okCount = settled.length - failures.length;
+      if (okCount > 0) {
+        analytics.track("skill_installed", {
+          skill_slug: skill.skillId,
+          source: "community",
+        });
+        addToast({
+          title: t("global.installedTo", { count: okCount }),
+          variant: "success",
+        });
+      }
+      if (failures.length > 0) {
+        const allAlready = failures.every(
+          ({ r }) =>
+            r.status === "rejected" &&
+            classifySkillError(r.reason) === "already_installed",
+        );
+        if (allAlready && okCount === 0) {
+          addToast({ title: t("store.installFailedAlready"), variant: "info" });
+        } else if (!allAlready) {
+          addToast({
+            title: t("global.installFailedFor", {
+              names: failures.map(({ agent }) => agent.name).join(", "),
+            }),
+            variant: "error",
+          });
+        }
+      }
+      if (okCount === 0) throw new Error("install failed for every agent");
+      const first = settled.find((r) => r.status === "fulfilled");
+      return first?.status === "fulfilled" ? first.value : skill.skillId;
+    },
+    [addToast, invalidateSkills, t],
+  );
+
+  /** From-scratch create, fanned out. Targets already holding the slug are the
+   *  dialog's concern (it filters them); a real failure keeps the dialog open. */
+  const createForAgents = useCallback(
+    async (
+      input: { name: string; description: string; content: string },
+      targets: Agent[],
+    ): Promise<void> => {
+      const settled = await Promise.allSettled(
+        targets.map((agent) =>
+          tauriSkills.create(
+            agent.folderPath,
+            input.name,
+            input.description,
+            input.content,
+          ),
+        ),
+      );
+      invalidateSkills(targets.map((a) => a.folderPath));
+      const okCount = settled.filter((r) => r.status === "fulfilled").length;
+      if (okCount > 0) {
+        analytics.track("skill_installed", {
+          skill_slug: input.name,
+          source: "scratch",
+        });
+        addToast({
+          title: t("global.createdFor", { count: okCount }),
+          variant: "success",
+        });
+      }
+      // Failures already toasted with their real reason by the `call` wrapper.
+      if (okCount === 0) throw new Error("create failed for every agent");
+    },
+    [addToast, invalidateSkills, t],
+  );
+
+  /** One global save: write the canonical content to `writes`, remove the copy
+   *  from `deletes` (both agent folderPaths). Throws if anything failed so the
+   *  dialog stays open; the failed calls have already toasted their reason. */
+  const applySkillChanges = useCallback(
+    async (
+      row: WorkspaceSkillRow,
+      args: { content: string; contentDirty: boolean },
+      plan: { writes: string[]; deletes: string[] },
+    ): Promise<void> => {
+      const settled = await Promise.allSettled([
+        ...plan.writes.map((path) =>
+          tauriAgent.writeFile(path, skillMdPath(row.slug), args.content),
+        ),
+        ...plan.deletes.map((path) => tauriSkills.delete(path, row.slug)),
+      ]);
+      invalidateSkills([...plan.writes, ...plan.deletes]);
+      if (args.contentDirty)
+        analytics.track("skill_edited", { skill_slug: row.slug });
+      if (settled.some((r) => r.status === "rejected"))
+        throw new Error("skill update failed for some agents");
+      addToast({ title: t("global.skillUpdated"), variant: "success" });
+    },
+    [addToast, invalidateSkills, t],
+  );
+
+  /** Remove the skill from every agent that holds it. */
+  const deleteSkillEverywhere = useCallback(
+    async (row: WorkspaceSkillRow): Promise<void> => {
+      const paths = row.agents.map((a) => a.folderPath);
+      const settled = await Promise.allSettled(
+        paths.map((path) => tauriSkills.delete(path, row.slug)),
+      );
+      invalidateSkills(paths);
+      analytics.track("skill_deleted", { skill_slug: row.slug });
+      if (settled.some((r) => r.status === "rejected"))
+        throw new Error("skill delete failed for some agents");
+      addToast({ title: t("global.skillRemoved"), variant: "success" });
+    },
+    [addToast, invalidateSkills, t],
+  );
+
+  return {
+    installToAgents,
+    createForAgents,
+    applySkillChanges,
+    deleteSkillEverywhere,
+  };
+}

--- a/app/src/components/skills-view/use-workspace-skills.ts
+++ b/app/src/components/skills-view/use-workspace-skills.ts
@@ -1,0 +1,61 @@
+import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { queryKeys } from "../../lib/query-keys";
+import { tauriSkills } from "../../lib/tauri";
+import type { Agent, SkillSummary } from "../../lib/types";
+import {
+  aggregateWorkspaceSkills,
+  type WorkspaceSkillRow,
+} from "../../lib/workspace-skills";
+
+/**
+ * Every agent's skill list, aggregated for the global Skills page (HOU-792).
+ *
+ * One query PER agent on the same `queryKeys.skills(path)` keys the per-agent
+ * tab uses, so `SkillsChanged` events and the existing mutations refresh this
+ * page for free. Fetched once per mount and then event-driven only — in hosted
+ * mode each fetch fans out to that agent's pod and resets its idle-sleep
+ * clock, so focus/staleness sweeps are disabled exactly like
+ * `useAllConversations`.
+ */
+export function useWorkspaceSkills(agents: Agent[]): {
+  rows: WorkspaceSkillRow[];
+  /** Lowercase slugs installed on ANY agent — the store's "installed" marks. */
+  installedSkillNames: Set<string>;
+  /** folderPath → that agent's current list (undefined while loading). */
+  listsByPath: Map<string, SkillSummary[] | undefined>;
+  loading: boolean;
+} {
+  const { lists, loading } = useQueries({
+    queries: agents.map((agent) => ({
+      queryKey: queryKeys.skills(agent.folderPath),
+      queryFn: () => tauriSkills.list(agent.folderPath),
+      staleTime: Number.POSITIVE_INFINITY,
+      refetchOnWindowFocus: false,
+    })),
+    combine: (results) => ({
+      lists: results.map((r) => r.data),
+      loading: results.some((r) => r.isLoading),
+    }),
+  });
+
+  const listsByPath = useMemo(
+    () =>
+      new Map<string, SkillSummary[] | undefined>(
+        agents.map((agent, i) => [agent.folderPath, lists[i]]),
+      ),
+    [agents, lists],
+  );
+
+  const rows = useMemo(
+    () => aggregateWorkspaceSkills(agents, listsByPath),
+    [agents, listsByPath],
+  );
+
+  const installedSkillNames = useMemo(
+    () => new Set(rows.map((row) => row.slug.toLowerCase())),
+    [rows],
+  );
+
+  return { rows, installedSkillNames, listsByPath, loading };
+}

--- a/app/src/components/skills-view/workspace-skill-rows.tsx
+++ b/app/src/components/skills-view/workspace-skill-rows.tsx
@@ -22,8 +22,9 @@ import { SkillIcon } from "../skill-icon";
 /** Avatars a row shows before collapsing the rest into "+N". */
 const ROW_AVATAR_CAP = 3;
 
-/** The overlapping holder stack: who has this skill, at a glance. */
-function AgentStack({ agents }: { agents: WorkspaceSkillAgent[] }) {
+/** The overlapping holder stack: who has this skill, at a glance. Shared
+ *  with the per-agent Custom tab's "From your other agents" rows. */
+export function AgentStack({ agents }: { agents: WorkspaceSkillAgent[] }) {
   const shown = agents.slice(0, ROW_AVATAR_CAP);
   const extra = agents.length - shown.length;
   return (

--- a/app/src/components/skills-view/workspace-skill-rows.tsx
+++ b/app/src/components/skills-view/workspace-skill-rows.tsx
@@ -1,0 +1,110 @@
+import {
+  CATALOG_INSTALLED_PREVIEW_CAP,
+  CatalogGrid,
+  CatalogRow,
+  CatalogShowMore,
+  HoustonAvatar,
+  resolveAgentColor,
+} from "@houston-ai/core";
+import { ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { skillDisplayTitle } from "../../lib/humanize-skill-name";
+import { installedPreview } from "../../lib/installed-preview";
+import {
+  filterWorkspaceSkills,
+  type WorkspaceSkillAgent,
+  type WorkspaceSkillRow,
+} from "../../lib/workspace-skills";
+import { SkillIcon } from "../skill-icon";
+
+/** Avatars a row shows before collapsing the rest into "+N". */
+const ROW_AVATAR_CAP = 3;
+
+/** The overlapping holder stack: who has this skill, at a glance. */
+function AgentStack({ agents }: { agents: WorkspaceSkillAgent[] }) {
+  const shown = agents.slice(0, ROW_AVATAR_CAP);
+  const extra = agents.length - shown.length;
+  return (
+    <span className="flex items-center">
+      {shown.map((agent, i) => (
+        <span
+          key={agent.id}
+          title={agent.name}
+          className={i > 0 ? "-ml-1.5" : undefined}
+        >
+          <HoustonAvatar color={resolveAgentColor(agent.color)} diameter={20} />
+        </span>
+      ))}
+      {extra > 0 && (
+        <span className="-ml-1.5 flex h-5 min-w-5 items-center justify-center rounded-full bg-chip px-1 text-[10px] tabular-nums text-chip-text">
+          +{extra}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * The global page's **Your skills** strip (HOU-792): the per-agent strip's row
+ * grammar, aggregated per slug across the workspace — each row carries the
+ * stack of agents holding a copy, and opens the manage dialog. Preview-capped
+ * behind "Show all" at rest; an active query drops the cap.
+ */
+export function useWorkspaceSkillRows(
+  rows: WorkspaceSkillRow[],
+  query: string,
+  onOpen: (row: WorkspaceSkillRow) => void,
+): { installedCount: number; installed: ReactNode | undefined } {
+  const { t } = useTranslation("skills");
+  const [expanded, setExpanded] = useState(false);
+  const filtered = useMemo(
+    () => filterWorkspaceSkills(rows, query),
+    [rows, query],
+  );
+  const searching = query.trim() !== "";
+  const { visible, showExpander } = installedPreview(filtered, {
+    searching,
+    expanded,
+    cap: CATALOG_INSTALLED_PREVIEW_CAP,
+  });
+
+  const installed =
+    filtered.length === 0 ? undefined : (
+      <>
+        <CatalogGrid>
+          {visible.map((row) => (
+            <CatalogRow
+              key={row.slug}
+              icon={
+                <SkillIcon
+                  image={row.summary.image}
+                  bubbleClassName="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-line-input"
+                />
+              }
+              title={skillDisplayTitle(row.summary)}
+              description={row.summary.description || undefined}
+              trailing={
+                <div className="flex shrink-0 items-center gap-2">
+                  <AgentStack agents={row.agents} />
+                  <ChevronRight
+                    aria-hidden
+                    className="size-4 shrink-0 text-ink-muted"
+                  />
+                </div>
+              }
+              onClick={() => onOpen(row)}
+            />
+          ))}
+        </CatalogGrid>
+        {showExpander && (
+          <CatalogShowMore onClick={() => setExpanded(true)}>
+            {t("grid.showAllSkills", { count: filtered.length })}
+          </CatalogShowMore>
+        )}
+      </>
+    );
+
+  return { installedCount: filtered.length, installed };
+}

--- a/app/src/components/tabs/agent-skill-manage-dialog.tsx
+++ b/app/src/components/tabs/agent-skill-manage-dialog.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+import type { Agent } from "../../lib/types";
+import type { WorkspaceSkillRow } from "../../lib/workspace-skills";
+import { useAgentStore } from "../../stores/agents";
+import { ManageSkillDialog } from "../skills-view/manage-skill-dialog";
+import { useSkillsViewActions } from "../skills-view/use-skills-view-actions";
+import { useWorkspaceSkills } from "../skills-view/use-workspace-skills";
+
+/**
+ * The per-agent Skills tab's skill dialog (HOU-792): the SAME manage dialog
+ * the global page opens — content, "Agents with this skill" assignment, Edit
+ * in chat, Delete — resolved for one clicked slug. Rendered only while a
+ * skill is open, so the cross-agent aggregation (one request per agent;
+ * hosted mode wakes pods) runs only for an open dialog; until every list has
+ * answered the dialog stays closed rather than showing a wrong holder set.
+ *
+ * The CURRENT agent is pinned first among the holders, so the content shown
+ * (and copied to newly assigned agents) is THIS agent's copy — on the tab of
+ * Agent B you edit Agent B's version, never a divergent sibling's.
+ */
+export function AgentSkillManageDialog({
+  agent,
+  slug,
+  onClose,
+  onEditInChat,
+}: {
+  agent: Agent;
+  /** The open skill's directory slug. */
+  slug: string;
+  onClose: () => void;
+  /** "Edit in chat" — opens the skill's setup chat in the side panel. */
+  onEditInChat: (slug: string) => void;
+}) {
+  const agents = useAgentStore((s) => s.agents);
+  const { rows, loading } = useWorkspaceSkills(agents);
+  const actions = useSkillsViewActions();
+
+  const row = useMemo<WorkspaceSkillRow | null>(() => {
+    if (loading) return null;
+    const found = rows.find((r) => r.slug === slug);
+    if (!found) return null;
+    const holdsHere = found.agents.some((a) => a.id === agent.id);
+    if (!holdsHere) return found;
+    return {
+      ...found,
+      agents: [
+        found.agents.find((a) => a.id === agent.id) ?? found.agents[0],
+        ...found.agents.filter((a) => a.id !== agent.id),
+      ],
+    };
+  }, [rows, loading, slug, agent.id]);
+
+  return (
+    <ManageSkillDialog
+      row={row}
+      agents={agents}
+      onApply={actions.applySkillChanges}
+      onDeleteEverywhere={actions.deleteSkillEverywhere}
+      onClose={onClose}
+      onEditInChat={(open) => onEditInChat(open.slug)}
+    />
+  );
+}

--- a/app/src/components/tabs/other-agent-skill-preview.tsx
+++ b/app/src/components/tabs/other-agent-skill-preview.tsx
@@ -1,0 +1,102 @@
+import type { CommunitySkill, SkillPreviewState } from "@houston-ai/skills";
+import { SkillPreviewModal } from "@houston-ai/skills";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useSkillDetail } from "../../hooks/queries";
+import { skillBodyOf } from "../../lib/houston-skill-library";
+import { skillIntegrationSlugs } from "../../lib/skill-integrations";
+import type { WorkspaceSkillRow } from "../../lib/workspace-skills";
+import { IntegrationBadges } from "../integrations";
+import { useSkillMarketplaceSectionLabels } from "./use-skill-surface-labels";
+
+interface Props {
+  /** The row under preview; null keeps the modal closed. */
+  row: WorkspaceSkillRow | null;
+  onClose: () => void;
+  install: (row: WorkspaceSkillRow) => void;
+  /** Slug currently installing (drives the button's spinner), or null. */
+  installing: string | null;
+  /** Lowercase slugs already on THIS agent — flips the button to Installed. */
+  installedSkillNames?: Set<string>;
+}
+
+/**
+ * The "From your other agents" preview (HOU-792): the same
+ * {@link SkillPreviewModal} the marketplace and the Houston library open —
+ * title, description, connected apps, category, and the full step-by-step
+ * body behind the expander — so a cross-agent row NEVER installs on click;
+ * the modal's Install button is the one commit point. Unlike the bundled
+ * library, the body lives on the holder agent, so it loads on open (the
+ * skeleton state) through the same `useSkillDetail` cache the manage dialog
+ * reads. The by-line names the holder: "From the {agent} agent".
+ */
+export function OtherAgentSkillPreview({
+  row,
+  onClose,
+  install,
+  installing,
+  installedSkillNames,
+}: Props) {
+  const { t } = useTranslation("skills");
+  const marketplaceLabels = useSkillMarketplaceSectionLabels();
+  const { data: detail, error } = useSkillDetail(
+    row?.agents[0]?.folderPath,
+    row?.slug,
+  );
+
+  const modalSkill: CommunitySkill | null = useMemo(
+    () =>
+      row
+        ? {
+            id: row.slug,
+            skillId: row.slug,
+            name: row.slug,
+            installs: 0,
+            source: `agent/${row.agents[0]?.id ?? ""}`,
+          }
+        : null,
+    [row],
+  );
+  const preview: SkillPreviewState = useMemo(() => {
+    if (!row) return { status: "loading" };
+    if (error) return { status: "error" };
+    if (!detail) return { status: "loading" };
+    return {
+      status: "loaded",
+      preview: {
+        title: row.summary.title,
+        description: row.summary.description,
+        image: row.summary.image,
+        category: row.summary.category,
+        tags: row.summary.tags,
+        integrations: row.summary.integrations,
+        content: skillBodyOf(detail.content) || null,
+      },
+    };
+  }, [row, detail, error]);
+
+  return (
+    <SkillPreviewModal
+      open={row !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      skill={modalSkill}
+      preview={preview}
+      installing={installing !== null && installing === row?.slug}
+      installed={!!row && !!installedSkillNames?.has(row.slug.toLowerCase())}
+      onInstall={() => row && install(row)}
+      renderIntegrations={(slugs) => (
+        <IntegrationBadges
+          toolkits={skillIntegrationSlugs(slugs)}
+          label={t("detail.integrations")}
+        />
+      )}
+      labels={{
+        ...marketplaceLabels.preview,
+        bySource: () =>
+          t("library.fromAgent", { agent: row?.agents[0]?.name ?? "" }),
+      }}
+    />
+  );
+}

--- a/app/src/components/tabs/other-agent-skills.tsx
+++ b/app/src/components/tabs/other-agent-skills.tsx
@@ -1,0 +1,138 @@
+import {
+  CatalogAddButton,
+  CatalogGrid,
+  CatalogRow,
+  CatalogSectionHeader,
+} from "@houston-ai/core";
+import { useQueryClient } from "@tanstack/react-query";
+import { Check } from "lucide-react";
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { analytics } from "../../lib/analytics";
+import { skillDisplayTitle } from "../../lib/humanize-skill-name";
+import { logger } from "../../lib/logger";
+import { queryKeys } from "../../lib/query-keys";
+import { tauriAgent, tauriSkills } from "../../lib/tauri";
+import type { Agent } from "../../lib/types";
+import type { WorkspaceSkillRow } from "../../lib/workspace-skills";
+import { useAgentStore } from "../../stores/agents";
+import { SkillIcon } from "../skill-icon";
+import { useWorkspaceSkills } from "../skills-view/use-workspace-skills";
+import { AgentStack } from "../skills-view/workspace-skill-rows";
+
+/**
+ * "From your other agents" (HOU-792): the user's own skills that live on
+ * OTHER agents in the workspace, offered on THIS agent's Custom tab so a
+ * skill built for Agent A is one click away on Agent B. Skills are per-agent
+ * copies, so install = read the holder's SKILL.md and write it here — the
+ * same copy primitive the Houston library uses. Rows already installed here
+ * show a quiet check (never filtered out mid-session — no list jumps).
+ *
+ * Mounted only inside the Custom tab's content, so the cross-agent skill
+ * fan-out (one request per OTHER agent; hosted mode wakes their pods) runs
+ * only when the user actually opens the tab.
+ */
+export function OtherAgentSkills({
+  agent,
+  installedSkillNames,
+}: {
+  agent: Agent;
+  /** Lowercase slugs already on THIS agent — their rows show the check. */
+  installedSkillNames?: Set<string>;
+}) {
+  const { t } = useTranslation("skills");
+  const queryClient = useQueryClient();
+  const agents = useAgentStore((s) => s.agents);
+  const others = agents.filter((a) => a.id !== agent.id);
+  const { rows } = useWorkspaceSkills(others);
+  const [installing, setInstalling] = useState<string | null>(null);
+
+  const install = useCallback(
+    async (row: WorkspaceSkillRow) => {
+      if (installing) return;
+      setInstalling(row.slug);
+      try {
+        // The holder's copy verbatim (full SKILL.md, frontmatter intact).
+        const detail = await tauriSkills.load(
+          row.agents[0].folderPath,
+          row.slug,
+        );
+        await tauriAgent.writeFile(
+          agent.folderPath,
+          `.agents/skills/${row.slug}/SKILL.md`,
+          detail.content,
+        );
+        analytics.track("skill_installed", {
+          skill_slug: row.slug,
+          source: "agent-copy",
+        });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.skills(agent.folderPath),
+        });
+      } catch (err) {
+        // call() already toasted the load/write failure; log so the
+        // rejection isn't silent.
+        logger.error(`[skills] copy ${row.slug} from agent failed: ${err}`);
+      } finally {
+        setInstalling(null);
+      }
+    },
+    [agent.folderPath, installing, queryClient],
+  );
+
+  if (others.length === 0 || rows.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <CatalogSectionHeader
+        title={t("fromYourAgents.heading")}
+        count={rows.length}
+        size="lg"
+      />
+      <CatalogGrid>
+        {rows.map((row) => {
+          const title = skillDisplayTitle(row.summary);
+          const installedHere = installedSkillNames?.has(
+            row.slug.toLowerCase(),
+          );
+          return (
+            <CatalogRow
+              key={row.slug}
+              icon={
+                <SkillIcon
+                  image={row.summary.image}
+                  bubbleClassName="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-line-input"
+                />
+              }
+              title={title}
+              description={row.summary.description || undefined}
+              trailing={
+                <div className="flex shrink-0 items-center gap-2">
+                  <AgentStack agents={row.agents} />
+                  {installedHere ? (
+                    <span
+                      role="img"
+                      aria-label={t("fromYourAgents.installedAria", {
+                        name: title,
+                      })}
+                      className="flex size-7 items-center justify-center text-ink-muted"
+                    >
+                      <Check aria-hidden className="size-4" />
+                    </span>
+                  ) : (
+                    <CatalogAddButton
+                      label={t("fromYourAgents.installAria", { name: title })}
+                      busy={installing === row.slug}
+                      disabled={installing !== null}
+                      onClick={() => void install(row)}
+                    />
+                  )}
+                </div>
+              }
+            />
+          );
+        })}
+      </CatalogGrid>
+    </div>
+  );
+}

--- a/app/src/components/tabs/other-agent-skills.tsx
+++ b/app/src/components/tabs/other-agent-skills.tsx
@@ -19,14 +19,17 @@ import { useAgentStore } from "../../stores/agents";
 import { SkillIcon } from "../skill-icon";
 import { useWorkspaceSkills } from "../skills-view/use-workspace-skills";
 import { AgentStack } from "../skills-view/workspace-skill-rows";
+import { OtherAgentSkillPreview } from "./other-agent-skill-preview";
 
 /**
  * "From your other agents" (HOU-792): the user's own skills that live on
  * OTHER agents in the workspace, offered on THIS agent's Custom tab so a
- * skill built for Agent A is one click away on Agent B. Skills are per-agent
- * copies, so install = read the holder's SKILL.md and write it here — the
- * same copy primitive the Houston library uses. Rows already installed here
- * show a quiet check (never filtered out mid-session — no list jumps).
+ * skill built for Agent A is one click away on Agent B. A row (and its +)
+ * opens the PREVIEW modal — the shared marketplace/library treatment, with
+ * the body loaded from the holder agent — and installing is the modal's one
+ * commit point: read the holder's SKILL.md verbatim, write it here (the
+ * Houston-library copy primitive). Rows already installed here show a quiet
+ * check (never filtered out mid-session — no list jumps).
  *
  * Mounted only inside the Custom tab's content, so the cross-agent skill
  * fan-out (one request per OTHER agent; hosted mode wakes their pods) runs
@@ -46,6 +49,7 @@ export function OtherAgentSkills({
   const others = agents.filter((a) => a.id !== agent.id);
   const { rows } = useWorkspaceSkills(others);
   const [installing, setInstalling] = useState<string | null>(null);
+  const [preview, setPreview] = useState<WorkspaceSkillRow | null>(null);
 
   const install = useCallback(
     async (row: WorkspaceSkillRow) => {
@@ -106,6 +110,7 @@ export function OtherAgentSkills({
               }
               title={title}
               description={row.summary.description || undefined}
+              onClick={() => setPreview(row)}
               trailing={
                 <div className="flex shrink-0 items-center gap-2">
                   <AgentStack agents={row.agents} />
@@ -123,8 +128,12 @@ export function OtherAgentSkills({
                     <CatalogAddButton
                       label={t("fromYourAgents.installAria", { name: title })}
                       busy={installing === row.slug}
-                      disabled={installing !== null}
-                      onClick={() => void install(row)}
+                      onClick={(e) => {
+                        // The + previews too (the library convention): the
+                        // modal's Install is the one commit point.
+                        e.stopPropagation();
+                        setPreview(row);
+                      }}
                     />
                   )}
                 </div>
@@ -133,6 +142,13 @@ export function OtherAgentSkills({
           );
         })}
       </CatalogGrid>
+      <OtherAgentSkillPreview
+        row={preview}
+        onClose={() => setPreview(null)}
+        install={(row) => void install(row)}
+        installing={installing}
+        installedSkillNames={installedSkillNames}
+      />
     </div>
   );
 }

--- a/app/src/components/tabs/skill-custom-tab.tsx
+++ b/app/src/components/tabs/skill-custom-tab.tsx
@@ -7,12 +7,14 @@ import {
 import type { Activity } from "@houston-ai/engine-client";
 import { Plus, Sparkles, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import type { Agent } from "../../lib/types";
 import { HoustonSkillShelves } from "./houston-skill-shelves";
+import { OtherAgentSkills } from "./other-agent-skills";
 import { useHoustonSkillLibrary } from "./use-houston-skill-library";
 
 interface Props {
   /** The agent the library installs into (and whose drafts these are). */
-  agentPath: string;
+  agent: Agent;
   /** Unclaimed create-chats — each resumes right where the interview left off. */
   drafts: Activity[];
   onResumeDraft: (activityId: string) => void;
@@ -33,7 +35,7 @@ interface Props {
  * ({@link HoustonSkillShelves}).
  */
 export function SkillCustomTab({
-  agentPath,
+  agent,
   drafts,
   onResumeDraft,
   onDiscardDraft,
@@ -42,7 +44,7 @@ export function SkillCustomTab({
   installedSkillNames,
 }: Props) {
   const { t } = useTranslation("skills");
-  const library = useHoustonSkillLibrary(agentPath);
+  const library = useHoustonSkillLibrary(agent.folderPath);
 
   return (
     <div className="flex flex-col gap-6">
@@ -91,6 +93,13 @@ export function SkillCustomTab({
           </Button>
         </div>
       </div>
+
+      {/* The user's own skills living on OTHER agents (HOU-792) — one click
+          copies a skill built for Agent A onto this agent. */}
+      <OtherAgentSkills
+        agent={agent}
+        installedSkillNames={installedSkillNames}
+      />
 
       <div className="flex flex-col gap-3">
         <CatalogSectionHeader title={t("library.heading")} size="lg" />

--- a/app/src/components/tabs/skill-discovery-tabs.tsx
+++ b/app/src/components/tabs/skill-discovery-tabs.tsx
@@ -4,6 +4,7 @@ import type { CommunitySkill, CommunitySkillPreview } from "@houston-ai/skills";
 import { SkillMarketplaceSection } from "@houston-ai/skills";
 import { useTranslation } from "react-i18next";
 import { skillIntegrationSlugs } from "../../lib/skill-integrations";
+import type { Agent } from "../../lib/types";
 import { IntegrationBadges } from "../integrations";
 import { SkillCustomTab } from "./skill-custom-tab";
 import { useSkillMarketplaceSectionLabels } from "./use-skill-surface-labels";
@@ -21,8 +22,8 @@ import { useSkillMarketplaceSectionLabels } from "./use-skill-surface-labels";
 export function useSkillDiscoveryTabs(opts: {
   showCustom: boolean;
   /** The agent whose Skills surface this is — the Custom tab's Houston
-   *  library installs into it. */
-  agentPath: string;
+   *  library installs into it, and the cross-agent section excludes it. */
+  agent: Agent;
   onAddClick: () => void;
   /** Custom tab (HOU-791): start a new agent-guided create chat. */
   onCreateWithAi: () => void;
@@ -86,7 +87,7 @@ export function useSkillDiscoveryTabs(opts: {
             label: t("tabs.custom"),
             content: (
               <SkillCustomTab
-                agentPath={opts.agentPath}
+                agent={opts.agent}
                 drafts={opts.drafts}
                 onResumeDraft={opts.onResumeDraft}
                 onDiscardDraft={opts.onDiscardDraft}

--- a/app/src/components/tabs/skill-setup-chat.tsx
+++ b/app/src/components/tabs/skill-setup-chat.tsx
@@ -1,10 +1,12 @@
 import { Button } from "@houston-ai/core";
 import type { Activity } from "@houston-ai/engine-client";
-import { ArrowLeft, Loader2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Loader2, X } from "lucide-react";
+import { useEffect, useMemo } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { skillChatTurnContext } from "../../lib/skill-chat-prompts";
 import type { Agent, AgentDefinition } from "../../lib/types";
+import { useShellDetailPanel } from "../shell/use-shell-detail-panel";
 import { RoutineSetupChatBoard } from "./routine-setup-chat-board";
 
 interface Props {
@@ -26,7 +28,7 @@ interface Props {
    *  bound skill. Unused for drafts (nothing exists to pin yet). */
   skillSlug?: string;
   /** Close the pane and clear the selection (the catalog stays put). Wired
-   *  to the panel chrome's close X. */
+   *  to the panel chrome's close X and Escape. */
   onClose: () => void;
   /** The manual escape hatch (HOU-791 keeps it): opens the raw markdown edit
    *  modal for THIS skill. Only offered on an installed skill's chat. */
@@ -34,18 +36,18 @@ interface Props {
 }
 
 /**
- * A custom skill's setup chat, rendered INLINE inside the Skills section
- * (HOU-791 — mirrors the custom-integration setup chat). The guided chat is a
- * real mission under the hood, but every board filters it out via the
- * skill-setup sentinel — so this owns its OWN local container div and portals
- * the chat's detail panel into it, keeping the chat embedded on the Skills
- * page.
+ * A custom skill's setup chat, rendered in the SHELL'S right-hand detail
+ * panel — the same split the Routines tab and the mission board use: the
+ * Skills catalog stays visible on the left while the conversation opens as
+ * its own screen card on the right. Mounting this component IS what opens
+ * the panel (and unmounting closes it), so every host — the per-agent Skills
+ * tab and the global Skills page — gets the split without extra wiring.
  *
- * The shared {@link RoutineSetupChatBoard} does the AIBoard mount + full
- * `useAgentChatPanel` wiring — crucially `composerOverride`, which renders the
- * ask_user question cards the create interview depends on. The auto
- * "Mission: {title}" header line is overridden to read "Skill: {name}" (or
- * the create title for a draft).
+ * The guided chat is a real mission under the hood, but every board filters
+ * it out via the skill-setup sentinel — its only home is this panel. The
+ * shared {@link RoutineSetupChatBoard} does the AIBoard mount + full
+ * `useAgentChatPanel` wiring — crucially `composerOverride`, which renders
+ * the ask_user question cards the create interview depends on.
  */
 export function SkillSetupChat({
   agent,
@@ -57,7 +59,36 @@ export function SkillSetupChat({
   onEditManually,
 }: Props) {
   const { t } = useTranslation("skills");
-  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const { panelContainer, setPanelOpen } = useShellDetailPanel();
+
+  // Mount = panel open, unmount = panel closed. Same contract as
+  // routines-tab.tsx, centralized here so both Skills hosts share it.
+  useEffect(() => {
+    setPanelOpen(true);
+    return () => setPanelOpen(false);
+  }, [setPanelOpen]);
+
+  // Escape closes the panel (routines parity). Radix menus/dialogs mark their
+  // own Escape handled (`defaultPrevented`); a focused composer gets the FIRST
+  // Escape to blur (app convention), the pane only on the next one.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape" || e.defaultPrevented) return;
+      const el = document.activeElement;
+      const editable =
+        el instanceof HTMLElement &&
+        (el.tagName === "INPUT" ||
+          el.tagName === "TEXTAREA" ||
+          el.isContentEditable);
+      if (editable) {
+        el.blur();
+        return;
+      }
+      onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
 
   // The Skills section has no ambient AgentDefinition. RoutineSetupChatBoard
   // needs one only for its agent-modes list, which a setup chat never uses —
@@ -76,32 +107,35 @@ export function SkillSetupChat({
       ? t("setupChat.missionTitle")
       : t("setupChat.skillLabel", { name: skillName ?? "" });
 
-  // The way back to the Skills section, always visible at the pane's left —
-  // the same affordance the custom-integration setup chat leads with.
-  const backButton = (
-    <Button
-      variant="ghost"
-      size="icon-sm"
-      onClick={onClose}
-      aria-label={t("setupChat.back")}
-    >
-      <ArrowLeft className="size-4" />
-    </Button>
-  );
-
-  // Draft still being created, or a skill chat still loading: keep the pane
-  // shape stable over a calm loading state rather than flashing an empty box,
-  // with the way back reachable the whole time.
+  // Draft still being created, or a skill chat still loading: a slim header
+  // (same shape + close as the live panel's) keeps the panel dismissable
+  // while it settles — portaled into the shell panel like the live board, so
+  // the pre-model state shares the same surface.
   if (!activity) {
-    return (
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-line">
-        <div className="border-line border-b px-4 py-3">{backButton}</div>
+    const surface = (
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="shrink-0 bg-background px-4 py-3 dark:bg-transparent">
+          <div className="mx-auto flex w-full max-w-3xl items-center gap-3">
+            <span className="min-w-0 flex-1 truncate text-sm font-medium text-ink">
+              {missionLabel}
+            </span>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label={t("setupChat.close")}
+              className="flex size-7 shrink-0 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-hover/50 hover:text-ink"
+            >
+              <X className="size-4" strokeWidth={1.75} />
+            </button>
+          </div>
+        </div>
         <div className="flex min-h-0 flex-1 items-center justify-center gap-2 text-ink-muted">
           <Loader2 className="size-4 animate-spin" />
           <span className="text-sm">{t("setupChat.opening")}</span>
         </div>
       </div>
     );
+    return panelContainer ? createPortal(surface, panelContainer) : null;
   }
 
   const sessionKey = activity.session_key ?? `activity-${activity.id}`;
@@ -115,35 +149,32 @@ export function SkillSetupChat({
       </Button>
     ) : undefined;
 
+  // The board renders its detail panel straight into the shell panel via
+  // `panelContainer`; its own list never shows, so the board itself stays
+  // hidden (the portal escapes the `hidden` wrapper). One mount, one panel.
   return (
-    // Fills the section's whole height (the Automations chat look) — the
-    // pane is flex-1 against the settings column, never a fixed box.
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-line">
-      <div ref={setContainer} className="min-h-0 flex-1" />
-      <div className="hidden">
-        <RoutineSetupChatBoard
-          agent={agent}
-          agentDef={agentDef}
-          activity={activity}
-          sessionKey={sessionKey}
-          panelContainer={container}
-          panelLeading={backButton}
-          missionLabel={missionLabel}
-          panelActions={editManuallyButton}
-          onPanelClose={onClose}
-          // Every send re-asserts which skill this chat manages — the model
-          // must never have to remember it from the kickoff alone (it was
-          // observed asking "which skill?" inside a skill's own chat).
-          promptContext={
-            kind === "skill" && skillSlug
-              ? skillChatTurnContext({
-                  slug: skillSlug,
-                  displayName: skillName ?? "",
-                })
-              : undefined
-          }
-        />
-      </div>
+    <div className="hidden">
+      <RoutineSetupChatBoard
+        agent={agent}
+        agentDef={agentDef}
+        activity={activity}
+        sessionKey={sessionKey}
+        panelContainer={panelContainer}
+        missionLabel={missionLabel}
+        panelActions={editManuallyButton}
+        onPanelClose={onClose}
+        // Every send re-asserts which skill this chat manages — the model
+        // must never have to remember it from the kickoff alone (it was
+        // observed asking "which skill?" inside a skill's own chat).
+        promptContext={
+          kind === "skill" && skillSlug
+            ? skillChatTurnContext({
+                slug: skillSlug,
+                displayName: skillName ?? "",
+              })
+            : undefined
+        }
+      />
     </div>
   );
 }

--- a/app/src/components/tabs/skills-content.tsx
+++ b/app/src/components/tabs/skills-content.tsx
@@ -85,7 +85,7 @@ export function SkillsContent({
       : null;
   const tabs = useSkillDiscoveryTabs({
     showCustom: addDialogProps !== null,
-    agentPath: agent.folderPath,
+    agent,
     onAddClick: () => setDialogOpen(true),
     onCreateWithAi: chat.startCreate,
     drafts: chat.drafts,
@@ -124,43 +124,39 @@ export function SkillsContent({
 
   return (
     <>
-      {/* An open setup chat owns the section (HOU-791): the catalog steps
-          aside so the conversation gets the room, and closing the chat
-          returns it. The dialogs below stay mounted — the chat header's
-          Edit-manually opens the modal over the chat. */}
+      {/* An open setup chat renders in the SHELL'S right-hand panel (the
+          Routines split, HOU-792): the catalog below stays visible on the
+          left while the conversation runs beside it. The chat node itself is
+          a portal (plus a hidden board mount), so both render together. The
+          dialogs stay mounted — the chat header's Edit-manually opens the
+          modal over the chat. */}
       {chat.chatNode}
-      {!chat.chatNode && (
-        <>
-          <CatalogShell
-            controls={
-              (tabs.length > 0 || sorted.length > 0) && (
-                <CatalogSearchField
-                  value={query}
-                  onChange={setQuery}
-                  label={t("grid.searchSkills")}
-                  clearLabel={t("grid.clearSearch")}
-                />
-              )
-            }
-            installedTitle={t("grid.yourSkillsHeading")}
-            installedCount={installedCount}
-            installed={installed}
-            availableTitle={t("grid.availableHeading")}
-            // The store-size label belongs to the Store tab only; on Custom
-            // the chip would contradict the visible content.
-            availableCount={
-              tab === "store" ? SKILL_STORE_SIZE_LABEL : undefined
-            }
-            tabs={tabs}
-            value={tab}
-            onValueChange={setTab}
-          />
-          {noInstalledMatches && (
-            <p className="text-[13px] text-ink-muted">
-              {t("grid.noMatchingSkills")}
-            </p>
-          )}
-        </>
+      <CatalogShell
+        controls={
+          (tabs.length > 0 || sorted.length > 0) && (
+            <CatalogSearchField
+              value={query}
+              onChange={setQuery}
+              label={t("grid.searchSkills")}
+              clearLabel={t("grid.clearSearch")}
+            />
+          )
+        }
+        installedTitle={t("grid.yourSkillsHeading")}
+        installedCount={installedCount}
+        installed={installed}
+        availableTitle={t("grid.availableHeading")}
+        // The store-size label belongs to the Store tab only; on Custom
+        // the chip would contradict the visible content.
+        availableCount={tab === "store" ? SKILL_STORE_SIZE_LABEL : undefined}
+        tabs={tabs}
+        value={tab}
+        onValueChange={setTab}
+      />
+      {noInstalledMatches && (
+        <p className="text-[13px] text-ink-muted">
+          {t("grid.noMatchingSkills")}
+        </p>
       )}
       {addDialogProps && (
         <AddSkillDialog

--- a/app/src/components/tabs/skills-content.tsx
+++ b/app/src/components/tabs/skills-content.tsx
@@ -2,6 +2,7 @@ import { CatalogSearchField, CatalogShell, Spinner } from "@houston-ai/core";
 import { AddSkillDialog } from "@houston-ai/skills";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { AgentSkillManageDialog } from "./agent-skill-manage-dialog";
 import { useInstalledSkillsStrip } from "./installed-skills-strip";
 import { useSkillDiscoveryTabs } from "./skill-discovery-tabs";
 import { SkillEditorDialogs } from "./skill-editor-dialogs";
@@ -57,20 +58,27 @@ export function SkillsContent({
   const dialogLabels = useSkillDialogLabels();
   const [tab, setTab] = useState("store");
   const [dialogOpen, setDialogOpen] = useState(false);
+  // The open skill's MANAGE dialog (HOU-792) — the same content + agents +
+  // Edit-in-chat dialog the global page opens. Writable surfaces only; the
+  // raw edit modal stays the read-only fallback.
+  const [managingSlug, setManagingSlug] = useState<string | null>(null);
   // The ONE page search: it filters the installed strip AND drives the Store.
   const [query, setQuery] = useState("");
-  // The chat layer (HOU-791): a row click opens the skill's setup chat; the
-  // modal stays the read-only fallback + the chat's Edit-manually target.
+  // The chat layer (HOU-791): the manage dialog's "Edit in chat" opens the
+  // skill's setup chat in the shell's right panel; the chat header's
+  // Edit-manually comes back to the manage dialog (read-only mode falls back
+  // to the raw modal instead).
   const chat = useSkillsChatSurface({
     agent,
     skills,
     loading,
     readOnly,
-    onEditSkill,
+    onEditSkill: readOnly ? onEditSkill : setManagingSlug,
   });
+  // A row click opens the manage dialog (read-only: the raw modal).
   const { sorted, installedCount, installed } = useInstalledSkillsStrip(
     skills,
-    chat.openRow,
+    readOnly ? onEditSkill : setManagingSlug,
     query,
   );
   const editingSkill = sorted.find((s) => s.name === editingSkillName) ?? null;
@@ -164,6 +172,17 @@ export function SkillsContent({
           onOpenChange={setDialogOpen}
           {...addDialogProps}
           labels={dialogLabels}
+        />
+      )}
+      {managingSlug !== null && !readOnly && (
+        <AgentSkillManageDialog
+          agent={agent}
+          slug={managingSlug}
+          onClose={() => setManagingSlug(null)}
+          onEditInChat={(slug) => {
+            setManagingSlug(null);
+            chat.openChatFor(slug);
+          }}
         />
       )}
       <SkillEditorDialogs

--- a/app/src/components/tabs/use-houston-skill-library.ts
+++ b/app/src/components/tabs/use-houston-skill-library.ts
@@ -21,17 +21,15 @@ export interface HoustonLibraryGroup {
 }
 
 /**
- * The Custom tab's Houston skill library: every skill the release-bundled
- * pre-set agents ship (translated variant when the app runs es/pt), plus the
- * one-click install that writes the SKILL.md into THIS agent. The bundle is
- * static per release, so the parse runs once per locale and never refetches.
+ * The library CONTENT alone — the bundled store templates parsed into shelf
+ * groups, agent-agnostic and static per release/locale. Split from
+ * {@link useHoustonSkillLibrary} so the global Skills page can render the
+ * same shelves with its own pick-agents install flow (HOU-792).
  */
-export function useHoustonSkillLibrary(agentPath: string) {
+export function useHoustonSkillLibraryData() {
   const { i18n } = useTranslation();
   const locale = i18n.language;
-  const queryClient = useQueryClient();
-
-  const query = useQuery({
+  return useQuery({
     queryKey: ["houston-skill-library", locale.toLowerCase().split("-")[0]],
     staleTime: Number.POSITIVE_INFINITY,
     queryFn: async (): Promise<HoustonLibraryGroup[]> => {
@@ -48,6 +46,17 @@ export function useHoustonSkillLibrary(agentPath: string) {
       return groups.filter((g) => g.skills.length > 0);
     },
   });
+}
+
+/**
+ * The Custom tab's Houston skill library: every skill the release-bundled
+ * pre-set agents ship (translated variant when the app runs es/pt), plus the
+ * one-click install that writes the SKILL.md into THIS agent. The bundle is
+ * static per release, so the parse runs once per locale and never refetches.
+ */
+export function useHoustonSkillLibrary(agentPath: string) {
+  const queryClient = useQueryClient();
+  const query = useHoustonSkillLibraryData();
 
   // One install at a time; the slug in flight drives that row's spinner.
   const [installing, setInstalling] = useState<string | null>(null);

--- a/app/src/components/tabs/use-skills-chat-surface.tsx
+++ b/app/src/components/tabs/use-skills-chat-surface.tsx
@@ -29,6 +29,9 @@ export function useSkillsChatSurface(opts: {
   chatNode: ReactNode | null;
   /** Row click: the skill's chat (writable) or the manual modal (read-only). */
   openRow: (name: string) => void;
+  /** Open a skill's chat WITHOUT the re-click toggle — the manage dialog's
+   *  "Edit in chat" must land on the chat even when it is already open. */
+  openChatFor: (name: string) => void;
   /** Unclaimed create-chats, shown as resumable rows on the Custom tab. */
   drafts: Activity[];
   resumeDraft: (activityId: string) => void;
@@ -56,6 +59,7 @@ export function useSkillsChatSurface(opts: {
     return {
       chatNode: null,
       openRow: onEditSkill,
+      openChatFor: () => {},
       drafts: [],
       resumeDraft: () => {},
       discardDraft: () => {},
@@ -94,6 +98,13 @@ export function useSkillsChatSurface(opts: {
   return {
     chatNode,
     openRow: view.openSkillChat,
+    openChatFor: (name: string) => {
+      // openSkillChat toggles a re-click closed; skip the call when this
+      // skill's chat is already the open one so the intent "go to the chat"
+      // never closes it.
+      if (selected?.kind === "skill" && selected.slug === name) return;
+      view.openSkillChat(name);
+    },
     drafts: chatSetup.draftActivities,
     resumeDraft: view.resumeDraft,
     discardDraft: view.discardDraft,

--- a/app/src/lib/top-level-views.ts
+++ b/app/src/lib/top-level-views.ts
@@ -12,9 +12,10 @@
  * some screen of its own is.
  */
 import { INTEGRATIONS_VIEW_ID } from "../components/integrations-view/id.ts";
+import { SKILLS_VIEW_ID } from "../components/skills-view/id.ts";
 import { STORE_VIEW_ID } from "../components/store-view/id.ts";
 
-export { INTEGRATIONS_VIEW_ID, STORE_VIEW_ID };
+export { INTEGRATIONS_VIEW_ID, SKILLS_VIEW_ID, STORE_VIEW_ID };
 
 export const DASHBOARD_VIEW_ID = "dashboard";
 export const SETTINGS_VIEW_ID = "settings";
@@ -25,6 +26,7 @@ export type TopLevelViewId =
   | typeof SETTINGS_VIEW_ID
   | typeof AI_HUB_VIEW_ID
   | typeof INTEGRATIONS_VIEW_ID
+  | typeof SKILLS_VIEW_ID
   | typeof STORE_VIEW_ID;
 
 export const TOP_LEVEL_VIEWS = new Set<TopLevelViewId>([
@@ -32,6 +34,7 @@ export const TOP_LEVEL_VIEWS = new Set<TopLevelViewId>([
   SETTINGS_VIEW_ID,
   AI_HUB_VIEW_ID,
   INTEGRATIONS_VIEW_ID,
+  SKILLS_VIEW_ID,
   STORE_VIEW_ID,
 ]);
 

--- a/app/src/lib/workspace-skills.ts
+++ b/app/src/lib/workspace-skills.ts
@@ -1,0 +1,101 @@
+import { skillDisplayTitle } from "./humanize-skill-name.ts";
+import type { SkillSummary } from "./types.ts";
+
+/**
+ * The pure model behind the global Skills page (HOU-792): skills live ON each
+ * agent (`<agent>/.agents/skills/<slug>/`, no shared store), so the workspace
+ * view is an aggregation — one row per slug, carrying which agents have a copy.
+ * Node-test covered; the page stays a renderer.
+ */
+
+/** The slice of an agent the aggregation carries into a row (avatar + target). */
+export interface WorkspaceSkillAgent {
+  id: string;
+  name: string;
+  folderPath: string;
+  color?: string;
+}
+
+/** One workspace-level skill: the slug, a display summary, and its holders. */
+export interface WorkspaceSkillRow {
+  slug: string;
+  /** The first holder's copy, display source for title/description/image. */
+  summary: SkillSummary;
+  /** Agents holding a copy, in the caller's agent order. */
+  agents: WorkspaceSkillAgent[];
+}
+
+/**
+ * Fold each agent's skill list into slug-keyed workspace rows. Copies of the
+ * same slug on several agents collapse into ONE row (first copy wins for
+ * display — divergent copies are unified visually here and physically on the
+ * next global save). Rows sort by slug for a stable A-Z list; an agent with no
+ * loaded list yet (query in flight) simply contributes nothing.
+ */
+export function aggregateWorkspaceSkills(
+  agents: readonly WorkspaceSkillAgent[],
+  listsByPath: ReadonlyMap<string, readonly SkillSummary[] | undefined>,
+): WorkspaceSkillRow[] {
+  const bySlug = new Map<string, WorkspaceSkillRow>();
+  for (const agent of agents) {
+    for (const summary of listsByPath.get(agent.folderPath) ?? []) {
+      const row = bySlug.get(summary.name);
+      if (row) row.agents.push(agent);
+      else
+        bySlug.set(summary.name, {
+          slug: summary.name,
+          summary,
+          agents: [agent],
+        });
+    }
+  }
+  return [...bySlug.values()].sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+/**
+ * Narrow rows by the page's one search query: a case-insensitive substring
+ * over the display title, the slug, and any holder's agent name (finding "what
+ * does Maya know?" is a first-class query here). Empty query keeps everything.
+ */
+export function filterWorkspaceSkills(
+  rows: readonly WorkspaceSkillRow[],
+  query: string,
+): WorkspaceSkillRow[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...rows];
+  return rows.filter(
+    (row) =>
+      skillDisplayTitle(row.summary).toLowerCase().includes(q) ||
+      row.slug.toLowerCase().includes(q) ||
+      row.agents.some((a) => a.name.toLowerCase().includes(q)),
+  );
+}
+
+/** What one global save must do, per agent folderPath. */
+export interface SkillAssignmentPlan {
+  /** Agents to write the canonical SKILL.md to (full file, verbatim). */
+  writes: string[];
+  /** Agents whose copy is removed. */
+  deletes: string[];
+}
+
+/**
+ * Diff an assignment edit into the minimal write/delete fan-out. Newly
+ * assigned agents always receive the canonical content; agents that already
+ * hold a copy are rewritten ONLY when the user edited the content in the
+ * global dialog (`contentDirty`) — an assignment-only save never clobbers a
+ * divergent per-agent copy it wasn't asked to touch.
+ */
+export function planSkillAssignment(args: {
+  contentDirty: boolean;
+  before: readonly string[];
+  after: readonly string[];
+}): SkillAssignmentPlan {
+  const before = new Set(args.before);
+  const after = new Set(args.after);
+  const writes = [...after].filter(
+    (path) => args.contentDirty || !before.has(path),
+  );
+  const deletes = [...before].filter((path) => !after.has(path));
+  return { writes, deletes };
+}

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -3,6 +3,7 @@
     "missionControl": "Mission Control",
     "aiModels": "AI Models",
     "integrations": "Integrations",
+    "skills": "Skills",
     "agentStore": "Agent Store",
     "settings": "Settings",
     "yourAgents": "Your Agents",

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -159,5 +159,43 @@
     "loading": "Loading skills...",
     "loadFailed": "Couldn't load the skill library.",
     "retry": "Retry"
+  },
+  "global": {
+    "pageTitle": "Skills",
+    "pageSubtitle": "Teach your agents reusable skills and choose who knows what.",
+    "newSkill": "New skill",
+    "alreadyHasIt": "Already has it",
+    "noAgentsTitle": "No agents yet",
+    "noAgentsDescription": "Create an agent first. Skills live with your agents, and this page manages them across all of them.",
+    "installedTo_one": "Added to {{count}} agent",
+    "installedTo_other": "Added to {{count}} agents",
+    "installFailedFor": "We couldn't add the skill for {{names}}",
+    "createdFor_one": "Skill created for {{count}} agent",
+    "createdFor_other": "Skill created for {{count}} agents",
+    "skillUpdated": "Skill updated",
+    "skillRemoved": "Skill removed",
+    "install": {
+      "title": "Add \"{{name}}\" to agents",
+      "description": "Choose which agents get this skill.",
+      "confirm_one": "Add to {{count}} agent",
+      "confirm_other": "Add to {{count}} agents"
+    },
+    "create": {
+      "title": "New skill",
+      "description": "Write the skill once, then choose which agents learn it.",
+      "agentsLabel": "Create for",
+      "confirm_one": "Create for {{count}} agent",
+      "confirm_other": "Create for {{count}} agents"
+    },
+    "manage": {
+      "agentsLabel": "Agents with this skill",
+      "keepOneAgent": "Keep at least one agent, or use Delete to remove the skill everywhere.",
+      "removeConfirmTitle_one": "Remove from {{count}} agent?",
+      "removeConfirmTitle_other": "Remove from {{count}} agents?",
+      "removeConfirmDescription": "Saving will remove this skill from {{names}}. This cannot be undone.",
+      "deleteConfirmTitle": "Delete \"{{name}}\"?",
+      "deleteConfirmDescription_one": "This removes the skill from {{count}} agent ({{names}}). This cannot be undone.",
+      "deleteConfirmDescription_other": "This removes the skill from {{count}} agents ({{names}}). This cannot be undone."
+    }
   }
 }

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -149,7 +149,8 @@
     "back": "Back to skills",
     "editManually": "Edit manually",
     "draftInProgress": "Skill in progress. Pick up where you left off.",
-    "discardDraft": "Discard draft"
+    "discardDraft": "Discard draft",
+    "close": "Close"
   },
   "library": {
     "heading": "From Houston's agents",
@@ -196,6 +197,15 @@
       "deleteConfirmTitle": "Delete \"{{name}}\"?",
       "deleteConfirmDescription_one": "This removes the skill from {{count}} agent ({{names}}). This cannot be undone.",
       "deleteConfirmDescription_other": "This removes the skill from {{count}} agents ({{names}}). This cannot be undone."
+    },
+    "chatPick": {
+      "title": "Who should build it with you?",
+      "description": "The chat runs with this agent, and the skill is created there first. You can share it with other agents afterwards."
     }
+  },
+  "fromYourAgents": {
+    "heading": "From your other agents",
+    "installAria": "Add {{name}} to this agent",
+    "installedAria": "{{name}} is already on this agent"
   }
 }

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -196,7 +196,8 @@
       "removeConfirmDescription": "Saving will remove this skill from {{names}}. This cannot be undone.",
       "deleteConfirmTitle": "Delete \"{{name}}\"?",
       "deleteConfirmDescription_one": "This removes the skill from {{count}} agent ({{names}}). This cannot be undone.",
-      "deleteConfirmDescription_other": "This removes the skill from {{count}} agents ({{names}}). This cannot be undone."
+      "deleteConfirmDescription_other": "This removes the skill from {{count}} agents ({{names}}). This cannot be undone.",
+      "editInChat": "Edit in chat"
     },
     "chatPick": {
       "title": "Who should build it with you?",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -3,6 +3,7 @@
     "missionControl": "Centro de misiones",
     "aiModels": "Modelos de IA",
     "integrations": "Integraciones",
+    "skills": "Skills",
     "agentStore": "Tienda de agentes",
     "settings": "Configuración",
     "yourAgents": "Tus agentes",

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -149,7 +149,8 @@
     "back": "Volver a habilidades",
     "editManually": "Editar manualmente",
     "draftInProgress": "Habilidad en construcción. Retoma donde quedaste.",
-    "discardDraft": "Descartar borrador"
+    "discardDraft": "Descartar borrador",
+    "close": "Cerrar"
   },
   "library": {
     "heading": "De los agentes de Houston",
@@ -196,6 +197,15 @@
       "deleteConfirmTitle": "¿Eliminar \"{{name}}\"?",
       "deleteConfirmDescription_one": "Esto quita la skill de {{count}} agente ({{names}}). No se puede deshacer.",
       "deleteConfirmDescription_other": "Esto quita la skill de {{count}} agentes ({{names}}). No se puede deshacer."
+    },
+    "chatPick": {
+      "title": "¿Quién la construye contigo?",
+      "description": "El chat se abre con este agente y la skill se crea ahí primero. Después puedes compartirla con otros agentes."
     }
+  },
+  "fromYourAgents": {
+    "heading": "De tus otros agentes",
+    "installAria": "Añadir {{name}} a este agente",
+    "installedAria": "{{name}} ya está en este agente"
   }
 }

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -159,5 +159,43 @@
     "loading": "Cargando habilidades...",
     "loadFailed": "No se pudo cargar la biblioteca de habilidades.",
     "retry": "Reintentar"
+  },
+  "global": {
+    "pageTitle": "Skills",
+    "pageSubtitle": "Enseña skills reutilizables a tus agentes y elige quién sabe qué.",
+    "newSkill": "Nueva skill",
+    "alreadyHasIt": "Ya la tiene",
+    "noAgentsTitle": "Aún no hay agentes",
+    "noAgentsDescription": "Primero crea un agente. Las skills viven con tus agentes, y esta página las administra en todos ellos.",
+    "installedTo_one": "Añadida a {{count}} agente",
+    "installedTo_other": "Añadida a {{count}} agentes",
+    "installFailedFor": "No pudimos añadir la skill para {{names}}",
+    "createdFor_one": "Skill creada para {{count}} agente",
+    "createdFor_other": "Skill creada para {{count}} agentes",
+    "skillUpdated": "Skill actualizada",
+    "skillRemoved": "Skill eliminada",
+    "install": {
+      "title": "Añadir \"{{name}}\" a agentes",
+      "description": "Elige qué agentes reciben esta skill.",
+      "confirm_one": "Añadir a {{count}} agente",
+      "confirm_other": "Añadir a {{count}} agentes"
+    },
+    "create": {
+      "title": "Nueva skill",
+      "description": "Escribe la skill una vez y elige qué agentes la aprenden.",
+      "agentsLabel": "Crear para",
+      "confirm_one": "Crear para {{count}} agente",
+      "confirm_other": "Crear para {{count}} agentes"
+    },
+    "manage": {
+      "agentsLabel": "Agentes con esta skill",
+      "keepOneAgent": "Mantén al menos un agente, o usa Eliminar para quitar la skill de todos.",
+      "removeConfirmTitle_one": "¿Quitar de {{count}} agente?",
+      "removeConfirmTitle_other": "¿Quitar de {{count}} agentes?",
+      "removeConfirmDescription": "Al guardar se quitará esta skill de {{names}}. Esto no se puede deshacer.",
+      "deleteConfirmTitle": "¿Eliminar \"{{name}}\"?",
+      "deleteConfirmDescription_one": "Esto quita la skill de {{count}} agente ({{names}}). No se puede deshacer.",
+      "deleteConfirmDescription_other": "Esto quita la skill de {{count}} agentes ({{names}}). No se puede deshacer."
+    }
   }
 }

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -196,7 +196,8 @@
       "removeConfirmDescription": "Al guardar se quitará esta skill de {{names}}. Esto no se puede deshacer.",
       "deleteConfirmTitle": "¿Eliminar \"{{name}}\"?",
       "deleteConfirmDescription_one": "Esto quita la skill de {{count}} agente ({{names}}). No se puede deshacer.",
-      "deleteConfirmDescription_other": "Esto quita la skill de {{count}} agentes ({{names}}). No se puede deshacer."
+      "deleteConfirmDescription_other": "Esto quita la skill de {{count}} agentes ({{names}}). No se puede deshacer.",
+      "editInChat": "Editar en el chat"
     },
     "chatPick": {
       "title": "¿Quién la construye contigo?",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -46,6 +46,7 @@
     "unreadCount_one": "{{count}} novidade não lida",
     "unreadCount_other": "{{count}} novidades não lidas",
     "integrations": "Integrações",
+    "skills": "Skills",
     "agentStore": "Loja de agentes"
   },
   "tabActions": {

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -196,7 +196,8 @@
       "removeConfirmDescription": "Ao salvar, esta skill será removida de {{names}}. Isso não pode ser desfeito.",
       "deleteConfirmTitle": "Excluir \"{{name}}\"?",
       "deleteConfirmDescription_one": "Isso remove a skill de {{count}} agente ({{names}}). Não pode ser desfeito.",
-      "deleteConfirmDescription_other": "Isso remove a skill de {{count}} agentes ({{names}}). Não pode ser desfeito."
+      "deleteConfirmDescription_other": "Isso remove a skill de {{count}} agentes ({{names}}). Não pode ser desfeito.",
+      "editInChat": "Editar no chat"
     },
     "chatPick": {
       "title": "Quem vai construir com você?",

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -149,7 +149,8 @@
     "back": "Voltar para habilidades",
     "editManually": "Editar manualmente",
     "draftInProgress": "Habilidade em construção. Continue de onde parou.",
-    "discardDraft": "Descartar rascunho"
+    "discardDraft": "Descartar rascunho",
+    "close": "Fechar"
   },
   "library": {
     "heading": "Dos agentes da Houston",
@@ -196,6 +197,15 @@
       "deleteConfirmTitle": "Excluir \"{{name}}\"?",
       "deleteConfirmDescription_one": "Isso remove a skill de {{count}} agente ({{names}}). Não pode ser desfeito.",
       "deleteConfirmDescription_other": "Isso remove a skill de {{count}} agentes ({{names}}). Não pode ser desfeito."
+    },
+    "chatPick": {
+      "title": "Quem vai construir com você?",
+      "description": "O chat abre com esse agente e a skill é criada nele primeiro. Depois você pode compartilhar com outros agentes."
     }
+  },
+  "fromYourAgents": {
+    "heading": "Dos seus outros agentes",
+    "installAria": "Adicionar {{name}} a este agente",
+    "installedAria": "{{name}} já está neste agente"
   }
 }

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -159,5 +159,43 @@
     "loading": "Carregando habilidades...",
     "loadFailed": "Não foi possível carregar a biblioteca de habilidades.",
     "retry": "Tentar novamente"
+  },
+  "global": {
+    "pageTitle": "Skills",
+    "pageSubtitle": "Ensine skills reutilizáveis aos seus agentes e escolha quem sabe o quê.",
+    "newSkill": "Nova skill",
+    "alreadyHasIt": "Já tem",
+    "noAgentsTitle": "Nenhum agente ainda",
+    "noAgentsDescription": "Crie um agente primeiro. As skills vivem com seus agentes, e esta página gerencia todas elas em um só lugar.",
+    "installedTo_one": "Adicionada a {{count}} agente",
+    "installedTo_other": "Adicionada a {{count}} agentes",
+    "installFailedFor": "Não conseguimos adicionar a skill para {{names}}",
+    "createdFor_one": "Skill criada para {{count}} agente",
+    "createdFor_other": "Skill criada para {{count}} agentes",
+    "skillUpdated": "Skill atualizada",
+    "skillRemoved": "Skill removida",
+    "install": {
+      "title": "Adicionar \"{{name}}\" a agentes",
+      "description": "Escolha quais agentes recebem esta skill.",
+      "confirm_one": "Adicionar a {{count}} agente",
+      "confirm_other": "Adicionar a {{count}} agentes"
+    },
+    "create": {
+      "title": "Nova skill",
+      "description": "Escreva a skill uma vez e escolha quais agentes vão aprender.",
+      "agentsLabel": "Criar para",
+      "confirm_one": "Criar para {{count}} agente",
+      "confirm_other": "Criar para {{count}} agentes"
+    },
+    "manage": {
+      "agentsLabel": "Agentes com esta skill",
+      "keepOneAgent": "Mantenha pelo menos um agente, ou use Excluir para remover a skill de todos.",
+      "removeConfirmTitle_one": "Remover de {{count}} agente?",
+      "removeConfirmTitle_other": "Remover de {{count}} agentes?",
+      "removeConfirmDescription": "Ao salvar, esta skill será removida de {{names}}. Isso não pode ser desfeito.",
+      "deleteConfirmTitle": "Excluir \"{{name}}\"?",
+      "deleteConfirmDescription_one": "Isso remove a skill de {{count}} agente ({{names}}). Não pode ser desfeito.",
+      "deleteConfirmDescription_other": "Isso remove a skill de {{count}} agentes ({{names}}). Não pode ser desfeito."
+    }
   }
 }

--- a/app/tests/top-level-views.test.ts
+++ b/app/tests/top-level-views.test.ts
@@ -1,6 +1,7 @@
 import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import { INTEGRATIONS_VIEW_ID } from "../src/components/integrations-view/id.ts";
+import { SKILLS_VIEW_ID } from "../src/components/skills-view/id.ts";
 import { STORE_VIEW_ID } from "../src/components/store-view/id.ts";
 import { SETTINGS_SECTION_IDS } from "../src/lib/settings-sections.ts";
 import {
@@ -20,20 +21,21 @@ describe("isTopLevelView", () => {
       SETTINGS_VIEW_ID,
       AI_HUB_VIEW_ID,
       INTEGRATIONS_VIEW_ID,
+      SKILLS_VIEW_ID,
       STORE_VIEW_ID,
     ]) {
       strictEqual(isTopLevelView(id), true, id);
     }
   });
 
-  it("is exactly those five, and no settings section doubles as one", () => {
+  it("is exactly those six, and no settings section doubles as one", () => {
     // HOU-788 folded Time worked / Permissions / Admin into Settings sections;
     // a settings section is reached THROUGH `settings`, so none of their ids may
     // also resolve as a top-level view. Checking the live section list (rather
     // than the three retired string literals) keeps this failing if a future
     // section is wired up as a top-level view by mistake, and still covers the
     // stale-persisted-`viewMode` case that motivated it.
-    strictEqual(TOP_LEVEL_VIEWS.size, 5);
+    strictEqual(TOP_LEVEL_VIEWS.size, 6);
     for (const section of SETTINGS_SECTION_IDS) {
       strictEqual(isTopLevelView(section), false, section);
     }
@@ -45,6 +47,8 @@ describe("isTopLevelView", () => {
   it("treats everything else as an agent tab", () => {
     strictEqual(isTopLevelView("chat"), false);
     strictEqual(isTopLevelView("integrations"), false);
+    // "skills" is the per-agent Agent Settings screen id, not the global page.
+    strictEqual(isTopLevelView("skills"), false);
   });
 });
 
@@ -71,6 +75,15 @@ describe("blockedTopLevelView", () => {
     // personal catalog, so a stale viewMode can never strand there.
     strictEqual(
       blockedTopLevelView(INTEGRATIONS_VIEW_ID, { showAiModels: false }),
+      false,
+    );
+  });
+
+  it("never blocks the global Skills page", () => {
+    // Skills is ungated like Integrations: it operates on the caller's own
+    // agents through per-agent routes, so every role keeps it.
+    strictEqual(
+      blockedTopLevelView(SKILLS_VIEW_ID, { showAiModels: false }),
       false,
     );
   });

--- a/app/tests/workspace-skills.test.ts
+++ b/app/tests/workspace-skills.test.ts
@@ -1,0 +1,150 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { SkillSummary } from "../src/lib/types.ts";
+import {
+  aggregateWorkspaceSkills,
+  filterWorkspaceSkills,
+  planSkillAssignment,
+  type WorkspaceSkillAgent,
+} from "../src/lib/workspace-skills.ts";
+
+const agent = (name: string): WorkspaceSkillAgent => ({
+  id: name.toLowerCase(),
+  name,
+  folderPath: `Ws/${name}`,
+});
+
+const skill = (name: string, over?: Partial<SkillSummary>): SkillSummary => ({
+  name,
+  title: null,
+  description: "",
+  version: 1,
+  tags: [],
+  created: null,
+  last_used: null,
+  category: null,
+  featured: false,
+  integrations: [],
+  image: null,
+  inputs: [],
+  prompt_template: null,
+  ...over,
+});
+
+const maya = agent("Maya");
+const noah = agent("Noah");
+const lists = (entries: [WorkspaceSkillAgent, SkillSummary[] | undefined][]) =>
+  new Map(entries.map(([a, s]) => [a.folderPath, s]));
+
+describe("aggregateWorkspaceSkills", () => {
+  it("collapses copies of the same slug into one row with all holders", () => {
+    const rows = aggregateWorkspaceSkills(
+      [maya, noah],
+      lists([
+        [maya, [skill("write-a-brief"), skill("audit-costs")]],
+        [noah, [skill("write-a-brief")]],
+      ]),
+    );
+    deepStrictEqual(
+      rows.map((r) => [r.slug, r.agents.map((a) => a.name)]),
+      [
+        ["audit-costs", ["Maya"]],
+        ["write-a-brief", ["Maya", "Noah"]],
+      ],
+    );
+  });
+
+  it("keeps the first holder's copy as the display summary", () => {
+    const rows = aggregateWorkspaceSkills(
+      [maya, noah],
+      lists([
+        [maya, [skill("write-a-brief", { description: "Maya's copy" })]],
+        [noah, [skill("write-a-brief", { description: "Noah's copy" })]],
+      ]),
+    );
+    strictEqual(rows[0].summary.description, "Maya's copy");
+  });
+
+  it("treats an agent whose list is still loading as contributing nothing", () => {
+    const rows = aggregateWorkspaceSkills(
+      [maya, noah],
+      lists([
+        [maya, [skill("write-a-brief")]],
+        [noah, undefined],
+      ]),
+    );
+    deepStrictEqual(
+      rows[0].agents.map((a) => a.name),
+      ["Maya"],
+    );
+  });
+});
+
+describe("filterWorkspaceSkills", () => {
+  const rows = aggregateWorkspaceSkills(
+    [maya, noah],
+    lists([
+      [maya, [skill("write-a-brief", { title: "Redactar un brief" })]],
+      [noah, [skill("audit-costs")]],
+    ]),
+  );
+
+  it("matches display title, slug, and holder name", () => {
+    strictEqual(
+      filterWorkspaceSkills(rows, "redactar")[0].slug,
+      "write-a-brief",
+    );
+    strictEqual(filterWorkspaceSkills(rows, "audit-")[0].slug, "audit-costs");
+    strictEqual(filterWorkspaceSkills(rows, "noah")[0].slug, "audit-costs");
+  });
+
+  it("keeps everything on an empty query", () => {
+    strictEqual(filterWorkspaceSkills(rows, "  ").length, 2);
+  });
+});
+
+describe("planSkillAssignment", () => {
+  it("writes only newly assigned agents when the content is untouched", () => {
+    deepStrictEqual(
+      planSkillAssignment({
+        contentDirty: false,
+        before: ["Ws/Maya"],
+        after: ["Ws/Maya", "Ws/Noah"],
+      }),
+      { writes: ["Ws/Noah"], deletes: [] },
+    );
+  });
+
+  it("rewrites every assigned agent when the content changed", () => {
+    deepStrictEqual(
+      planSkillAssignment({
+        contentDirty: true,
+        before: ["Ws/Maya"],
+        after: ["Ws/Maya", "Ws/Noah"],
+      }),
+      { writes: ["Ws/Maya", "Ws/Noah"], deletes: [] },
+    );
+  });
+
+  it("deletes unassigned agents and never double-lists them", () => {
+    deepStrictEqual(
+      planSkillAssignment({
+        contentDirty: true,
+        before: ["Ws/Maya", "Ws/Noah"],
+        after: ["Ws/Noah"],
+      }),
+      { writes: ["Ws/Noah"], deletes: ["Ws/Maya"] },
+    );
+  });
+
+  it("no-ops on an unchanged assignment with clean content", () => {
+    deepStrictEqual(
+      planSkillAssignment({
+        contentDirty: false,
+        before: ["Ws/Maya"],
+        after: ["Ws/Maya"],
+      }),
+      { writes: [], deletes: [] },
+    );
+  });
+});

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -162,6 +162,40 @@ never learns it exists, even though the Skills UI still lists it. Keep
    - `renderUserMessage` — decodes skill + attachment markers into cards
 6. Both **BoardTab** (per-agent kanban) and **Dashboard** (Mission Control / cross-agent kanban) consume this hook so the right panel is identical in both views.
 
+## Global Skills page (sidebar "Skills", HOU-792)
+
+Skills are stored ON each agent (`<agent>/.agents/skills/` — there is no shared
+or org-level store; that was HOU-792's misconception). The top-level **Skills**
+page (`app/src/components/skills-view/`, viewMode `skills-home`, sidebar entry
+between Integrations and AI Models) is a pure client aggregation over the
+existing per-agent routes — the host's skill routes already accept ANY agent
+the caller owns (`canUseAgent` is workspace ownership), so no backend changed:
+
+- **Your skills** — one row per slug across the workspace's agents
+  (`aggregateWorkspaceSkills` in `app/src/lib/workspace-skills.ts`,
+  node:test-covered), each with the holder agents' avatar stack. Fetching uses
+  one query per agent on the SAME `queryKeys.skills(path)` keys the per-agent
+  tab uses (`use-workspace-skills.ts`), so `SkillsChanged` invalidation
+  refreshes the page for free; fetched once per mount, never on focus (hosted:
+  a sweep wakes every pod — the `useAllConversations` discipline).
+- **Row click → manage dialog** (`manage-skill-dialog.tsx`): edit the full
+  SKILL.md (canonical copy = FIRST holder's) + toggle which agents hold it.
+  `planSkillAssignment` diffs the edit into the minimal fan-out: newly
+  assigned agents always get the canonical content (full-file
+  `tauriAgent.writeFile`, the Houston-library copy primitive); existing
+  holders are rewritten only when the content itself was edited; unassignments
+  confirm first (destructive), and Delete removes it from every holder.
+- **Store tab** — the same `SkillMarketplaceSection`; search/preview ride the
+  first agent (read-only marketplace proxies), install opens the
+  pick-agents dialog (`install-skill-dialog.tsx`; agents already holding the
+  slug lock out) and fans out `installCommunity` per picked agent.
+- **New skill** — header CTA (`new-skill-dialog.tsx`): the scratch fields +
+  agent multi-select; creates via the per-agent POST on each picked agent.
+
+The per-agent Skills tab is unchanged and stays the place for the guided
+create chat (HOU-791). The sidebar nav item made the bare "Skills" text
+ambiguous in e2e — scope selectors (see `skills-add-dialog.spec.ts`).
+
 ## Add Skills UI — the catalog-grammar Skills surface
 
 The agent's Skills section (`app/src/components/tabs/skills-content.tsx`) is

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -210,6 +210,14 @@ BOTH the per-agent Skills tab and the global page the catalog stays visible
 on the left while the conversation runs on the right (Escape closes, same as
 routines). The old swap-the-catalog-for-the-chat behavior is gone.
 
+**The manage dialog is the skill's one detail surface on BOTH pages.** A row
+click on the per-agent Skills tab opens the SAME manage dialog the global
+page uses (`agent-skill-manage-dialog.tsx` wraps it: lazy cross-agent
+aggregation while open, current agent pinned first so its copy is canonical);
+the guided chat sits behind the dialog's **Edit in chat** button
+(`onEditInChat`), which opens the side-panel chat on the skill's holder. The
+raw `SkillEditModal` remains only as the read-only fallback.
+
 **Per-agent Custom tab also shows "From your other agents"**
 (`other-agent-skills.tsx`): the user's own skills living on OTHER agents,
 one-click copyable onto this agent (load the holder's SKILL.md verbatim →

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -189,12 +189,35 @@ the caller owns (`canUseAgent` is workspace ownership), so no backend changed:
   first agent (read-only marketplace proxies), install opens the
   pick-agents dialog (`install-skill-dialog.tsx`; agents already holding the
   slug lock out) and fans out `installCommunity` per picked agent.
-- **New skill** — header CTA (`new-skill-dialog.tsx`): the scratch fields +
-  agent multi-select; creates via the per-agent POST on each picked agent.
+- **Custom skills tab** (`global-custom-tab.tsx`) — Create skill (the guided
+  chat), Add skill (the multi-agent from-scratch dialog,
+  `new-skill-dialog.tsx`), and the Houston library shelves
+  (`useHoustonSkillLibraryData`, the agent-agnostic half of the library hook);
+  library installs route through the same pick-agents flow
+  (`use-global-install-flow.tsx` unifies marketplace + library pending
+  installs behind one dialog).
+- **New skill / Create skill** — the guided create chat (HOU-791) in the
+  SHELL'S right-hand panel: `use-global-chat-flow.tsx` picks the hosting
+  agent (`choose-chat-agent-dialog.tsx`; skipped with one agent) and mounts
+  `global-skill-chat.tsx`, which drives the per-agent setup-chat machinery
+  and starts a fresh draft. The skill is created on that agent first, then
+  assignable from the manage dialog.
 
-The per-agent Skills tab is unchanged and stays the place for the guided
-create chat (HOU-791). The sidebar nav item made the bare "Skills" text
-ambiguous in e2e — scope selectors (see `skills-add-dialog.spec.ts`).
+**Setup chats are side-by-side everywhere (the Routines split).**
+`skill-setup-chat.tsx` portals into the shell detail panel
+(`useShellDetailPanel`) and owns the panel-open flag on mount/unmount, so on
+BOTH the per-agent Skills tab and the global page the catalog stays visible
+on the left while the conversation runs on the right (Escape closes, same as
+routines). The old swap-the-catalog-for-the-chat behavior is gone.
+
+**Per-agent Custom tab also shows "From your other agents"**
+(`other-agent-skills.tsx`): the user's own skills living on OTHER agents,
+one-click copyable onto this agent (load the holder's SKILL.md verbatim →
+`writeFile` here — the Houston-library copy primitive). Mounted only inside
+the tab content so the cross-agent fan-out runs only when the tab opens.
+
+The sidebar nav item made the bare "Skills" text ambiguous in e2e — scope
+selectors (see `skills-add-dialog.spec.ts`).
 
 ## Add Skills UI — the catalog-grammar Skills surface
 

--- a/packages/web/e2e/skills-add-dialog.spec.ts
+++ b/packages/web/e2e/skills-add-dialog.spec.ts
@@ -21,7 +21,12 @@ test("GitHub install button keeps a stable width across label changes", async ({
   // Settings (job-description) → Skills row → the Custom skills tab's
   // empty-state CTA opens the GitHub / From-scratch dialog.
   await page.locator('[data-tour-target="tab-job-description"]').click();
-  await page.getByText("Skills", { exact: true }).click();
+  // Scoped to the Agent Settings rail: the sidebar's global Skills nav item
+  // (HOU-792) also carries the bare "Skills" text.
+  await page
+    .getByLabel("Agent settings")
+    .getByRole("button", { name: "Skills" })
+    .click();
   await page.getByRole("tab", { name: "Custom skills" }).click();
   await page.getByRole("button", { name: "Add skill" }).click();
 

--- a/ui/skills/src/index.ts
+++ b/ui/skills/src/index.ts
@@ -6,6 +6,7 @@ export type {
 } from "./add-skill-dialog";
 // Components
 export { AddSkillDialog } from "./add-skill-dialog";
+export { toSlug } from "./add-skill-dialog-scratch-model";
 export type { ScratchViewLabels } from "./add-skill-dialog-scratch-view";
 export type { InstalledSkillEditorState } from "./installed-skill-editor-model";
 export {


### PR DESCRIPTION
## HOU-792

### Root cause / finding

The issue's premise ("custom skills are saved at the org level rather than the agent level") turned out to be **factually inverted**: every skill path in the codebase — CRUD routes, the HOU-791 skill builder, marketplace installs, the pi runtime loader — resolves strictly to the per-agent `<agent>/.agents/skills/` directory. There is no org-level skills storage anywhere, so skills were never leaking between agents.

What WAS missing is the other half of that observation: there was no way to manage skills across agents at all. Per product direction, this PR embraces cross-agent skills with a global **Skills** section in the left sidebar.

### What this adds

A new top-level **Skills** page (viewMode `skills-home`, sidebar entry between Integrations and AI Models) — a pure client-side aggregation over the **existing per-agent routes**. The host already authorizes skill operations for any agent the caller owns (`canUseAgent` = workspace ownership), so **zero backend changes** were needed — which also keeps it working against the hosted gateway, which only proxies `/agents/:slug/*`.

- **Your skills** — one row per slug aggregated across the workspace's agents, with an avatar stack showing which agents hold it. Queries reuse the per-agent `queryKeys.skills(path)` keys, so `SkillsChanged` events keep the page live for free; fetched once per mount, never on focus (the `useAllConversations` pod-waking discipline).
- **Manage dialog** (row click) — edit the full SKILL.md and toggle which agents hold the skill. `planSkillAssignment` diffs the edit into a minimal fan-out: newly assigned agents always receive the canonical content; existing holders are rewritten only when the content was actually edited (an assignment-only save never clobbers a divergent per-agent copy); unassignments require an explicit confirm naming the agents; Delete removes it from every holder behind a confirm.
- **skills.sh Store tab** — the same `SkillMarketplaceSection` as the per-agent tab; installing opens a pick-agents dialog (agents that already have the skill are locked out) and fans out per-agent installs, with per-failure toasts naming the agents.
- **New skill** — header CTA with the from-scratch fields plus an agent multi-select; creates on every picked agent. Agents already holding the derived slug lock out live as you type.

Pure models (`aggregateWorkspaceSkills`, `filterWorkspaceSkills`, `planSkillAssignment`) live in `app/src/lib/workspace-skills.ts`, node:test-covered. i18n shipped for en/es/pt. KB updated (`knowledge-base/skills.md`).

Note on visual baselines: the new sidebar row lands inside the visual suite's committed 1% `maxDiffPixelRatio`, so the board baselines still pass unchanged and were deliberately not re-recorded.

### Repro (before)

1. Open Houston. There is no global place to see or manage skills — the sidebar has no Skills section.
2. To give three agents the same skill you must open each agent's Agent Settings → Skills and install/create it three times; there is no way to copy or unassign a skill across agents.

### Verify (after)

1. `pnpm dev`, open the app: the sidebar shows **Skills** between Integrations and AI Models.
2. The page lists every skill across the workspace's agents, each row showing the holder agents' avatars; search matches title, slug, and agent name.
3. Install a store skill: the pick-agents dialog appears; confirm installs it to each picked agent (check each agent's own Skills tab shows it).
4. Click a row: edit the content and toggle an agent on → Save writes the copy to that agent. Toggle an agent off → Save asks for confirmation naming the agent, then removes only that copy.
5. **New skill** creates the skill on every selected agent.
6. Gates: `pnpm check`, app `tsgo --noEmit` + `pnpm test` (2270 pass), `pnpm --filter houston-web test:e2e` (165 pass), `test:visual` (6 pass), `check:parity`, `check:boundaries`, `check-locales` — all green.