### PR TITLE
fix: team-space provider statuses tell the truth in every surface

### DIFF
--- a/app/src/components/ai-hub/ai-hub-view.tsx
+++ b/app/src/components/ai-hub/ai-hub-view.tsx
@@ -19,7 +19,10 @@ import {
   type ProviderInfo,
 } from "../../lib/providers";
 import { searchProviders } from "../provider-browser/provider-filtering";
-import { groupProviders } from "../provider-browser/provider-grouping";
+import {
+  groupProviders,
+  providerOwnedSide,
+} from "../provider-browser/provider-grouping";
 import { PageContainer } from "../shell/page-shell";
 import { ConnectedProvidersStrip } from "./connected-providers-strip";
 import { HubHero } from "./hub-hero";
@@ -67,20 +70,25 @@ export function AiHubView() {
       }),
     [newEngine, providerCapabilities],
   );
-  // Connected providers live in the strip; only the rest browse in the tab.
+  // The user's own providers live in the strip; only the ones we CONFIRMED are
+  // not connected browse in the tab, so the tab's `+` connect is never offered
+  // for an account that may already be signed in (HOU-979). A provider whose
+  // probe came back unconfirmable rides the strip with its own checking dot.
   // Until the first status probe resolves everything counts as available (the
   // pane holds a skeleton and the counts stay hidden meanwhile).
-  const { connected, available } = useMemo(
-    () => groupProviders(connectProviders, connections.isConnected),
-    [connectProviders, connections.isConnected],
+  const groups = useMemo(
+    () => groupProviders(connectProviders, connections.connectionState),
+    [connectProviders, connections.connectionState],
   );
+  const available = groups.available;
+  const owned = useMemo(() => providerOwnedSide(groups), [groups]);
 
   // The page query narrows both provider sections; `searching` uncaps the
   // Connected strip's preview and switches the count chips to shown-count.
   const searching = query.trim() !== "";
   const connectedMatches = useMemo(
-    () => searchProviders(connected, query),
-    [connected, query],
+    () => searchProviders(owned, query),
+    [owned, query],
   );
   const availableMatches = useMemo(
     () => searchProviders(available, query),
@@ -163,7 +171,7 @@ export function AiHubView() {
                 connections.ready
                   ? searching
                     ? connectedMatches.length
-                    : connected.length
+                    : owned.length
                   : undefined
               }
               availableTitle={t("sections.available")}
@@ -171,6 +179,7 @@ export function AiHubView() {
                 connections.ready && connectedMatches.length > 0 ? (
                   <ConnectedProvidersStrip
                     providers={connectedMatches}
+                    connectionState={connections.connectionState}
                     searching={searching}
                     onOpen={setOpenProvider}
                   />

--- a/app/src/components/ai-hub/connected-providers-strip.tsx
+++ b/app/src/components/ai-hub/connected-providers-strip.tsx
@@ -9,6 +9,7 @@ import { ChevronRight } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { installedPreview } from "../../lib/installed-preview";
+import type { ProviderConnectionState } from "../../lib/provider-connection";
 import {
   providerCostLine,
   providerDescription,
@@ -33,14 +34,23 @@ import { BrandMark } from "../provider-browser/brand-mark";
  * {@link CATALOG_INSTALLED_PREVIEW_CAP} rows behind a "Show all" expander so a
  * well-stocked strip never buries the tabs; while `searching` every match shows
  * uncapped (searching IS looking past the preview).
+ *
+ * The strip is the "yours" side, so it also carries the providers whose probe
+ * could not be confirmed (HOU-979): they belong with the user's accounts rather
+ * than in the browse tab's connect-me list, but they must NOT borrow the green
+ * Connected dot. Each row reads its own state and shows the pending dot instead
+ * — honest, and still no Connect CTA anywhere on this strip.
  */
 export function ConnectedProvidersStrip({
   providers,
+  connectionState,
   searching,
   onOpen,
 }: {
-  /** The connected providers to render — already narrowed by the page query. */
+  /** The user's providers to render — already narrowed by the page query. */
   providers: readonly ProviderInfo[];
+  /** Per-provider connection state, from the ONE shared derivation. */
+  connectionState: (provider: ProviderInfo) => ProviderConnectionState;
   /** Whether the page query is active (uncaps the preview). */
   searching: boolean;
   onOpen: (provider: ProviderInfo) => void;
@@ -62,6 +72,7 @@ export function ConnectedProvidersStrip({
         {rows.map((provider) => {
           const description =
             providerCostLine(provider.id) ?? providerDescription(provider.id);
+          const checking = connectionState(provider) === "checking";
           return (
             <CatalogRow
               key={provider.id}
@@ -70,7 +81,10 @@ export function ConnectedProvidersStrip({
               description={description || undefined}
               onClick={() => onOpen(provider)}
               statusDot={
-                <StatusDot status="active" srLabel={t("card.connected")} />
+                <StatusDot
+                  status={checking ? "pending" : "active"}
+                  srLabel={t(checking ? "card.checking" : "card.connected")}
+                />
               }
               trailing={
                 <ChevronRight

--- a/app/src/components/ai-hub/model-modal.tsx
+++ b/app/src/components/ai-hub/model-modal.tsx
@@ -61,9 +61,14 @@ export function ModelModal({
       ),
     [model.offers, cardByGateway],
   );
+  // Offers the user can already run sort first. `checking` ranks with them
+  // rather than with the connect-me offers (HOU-979): it is the "yours" side,
+  // and its row renders its own neutral treatment, never a Connect CTA.
   const offers = sortOffers([...providerByOffer.keys()], (offer) => {
     const provider = providerByOffer.get(offer);
-    return provider ? connections.isConnected(provider) : false;
+    return provider
+      ? connections.connectionState(provider) !== "disconnected"
+      : false;
   });
 
   const specs = buildSpecs(model, i18n.language, t);

--- a/app/src/components/ai-hub/model-offer-row.tsx
+++ b/app/src/components/ai-hub/model-offer-row.tsx
@@ -3,9 +3,11 @@
  * A hub-local row (NOT the shared `RowCard`, which draws its own media box) that
  * pairs the provider's colorful `BrandMark` tile with its name, echoing the
  * models card grid's BrandMark tiles. Shows either a per-1M price line or a
- * subscription label. Not
- * connected -> a Connect pill; connected -> a live status and a row that opens
- * the provider modal.
+ * subscription label. Connected -> a live status and a row that opens the
+ * provider modal; CONFIRMED not connected -> a Connect pill; unconfirmable ->
+ * a muted "Checking" and no action at all, because offering Connect for an
+ * account that may already be signed in is exactly the guess the tri-state
+ * exists to prevent (HOU-979).
  */
 
 import type { ReactNode } from "react";
@@ -58,7 +60,9 @@ export function ModelOfferRow({
     </span>
   );
 
-  if (connections.isConnected(provider)) {
+  const connection = connections.connectionState(provider);
+
+  if (connection === "connected") {
     return (
       <button
         type="button"
@@ -68,6 +72,14 @@ export function ModelOfferRow({
       >
         {row(<LiveStatus label={t("card.connected")} />)}
       </button>
+    );
+  }
+
+  if (connection === "checking") {
+    return row(
+      <span className="px-2 text-[13px] text-ink-muted">
+        {t("card.checking")}
+      </span>,
     );
   }
 

--- a/app/src/components/ai-hub/provider-modal.tsx
+++ b/app/src/components/ai-hub/provider-modal.tsx
@@ -48,7 +48,14 @@ export function ProviderModal({
   onSetDefault?: (provider: ProviderInfo) => void;
 }) {
   const { t } = useTranslation("aiHub");
-  const connected = connections.isConnected(provider);
+  // Tri-state (HOU-979): only a CONFIRMED connection gets the live badge, the
+  // sign-out footer, and the local-bridge treatment; only a CONFIRMED
+  // disconnection gets the Connect CTA. An unconfirmable probe gets neither —
+  // a muted "Checking" stands in, so the modal never guesses in either
+  // direction about an account it cannot see.
+  const connection = connections.connectionState(provider);
+  const connected = connection === "connected";
+  const checking = connection === "checking";
   const busy = connections.busy[provider.id];
   const models = useMemo(
     () => providerModels(catalog, provider),
@@ -98,6 +105,7 @@ export function ProviderModal({
             <SpecChip>{t("card.models", { count: models.length })}</SpecChip>
           )}
           {showConnectedBadge && <LiveStatus label={t("card.connected")} />}
+          {checking && <SpecChip>{t("card.checking")}</SpecChip>}
         </div>
         {showTunnelPill && (
           <LocalModelStatusPill
@@ -109,7 +117,7 @@ export function ProviderModal({
         )}
       </div>
       <div className="flex shrink-0 items-center gap-1">
-        {!connected && (
+        {connection === "disconnected" && (
           <ConnectButton provider={provider} connections={connections} />
         )}
         <button

--- a/app/src/components/chat-effective-provider.ts
+++ b/app/src/components/chat-effective-provider.ts
@@ -32,6 +32,11 @@
  * @param hasMessages whether the open conversation already has turns. Once true,
  *   the provider is frozen (no auth-driven switch) so logging out mid-chat shows
  *   the reconnect card rather than silently moving to another connected provider.
+ * @param unconfirmedProviders provider ids whose probe came back `unknown` — we
+ *   could not confirm them either way (HOU-979). They are NOT fallback targets
+ *   (switching onto one would be a guess), but neither are they evidence that
+ *   `preferred` is signed out, so an unconfirmed `preferred` defers rather than
+ *   being auth-switched away from.
  */
 export function resolveEffectiveProvider(
   activityProvider: string | null,
@@ -39,6 +44,7 @@ export function resolveEffectiveProvider(
   lastUsedProvider: string | null,
   authenticatedProviders: string[],
   hasMessages: boolean,
+  unconfirmedProviders: readonly string[] = [],
 ): string {
   const preferred =
     activityProvider ?? agentProvider ?? lastUsedProvider ?? "anthropic";
@@ -50,5 +56,7 @@ export function resolveEffectiveProvider(
   // Fresh composer (initial selection): never default onto a disconnected
   // provider — use `preferred` when connected, else any connected provider.
   if (authenticatedProviders.includes(preferred)) return preferred;
+  // Only a CONFIRMED sign-out earns the switch. Defer on an unconfirmable one.
+  if (unconfirmedProviders.includes(preferred)) return preferred;
   return authenticatedProviders[0] ?? preferred;
 }

--- a/app/src/components/chat-model-selector-labels.ts
+++ b/app/src/components/chat-model-selector-labels.ts
@@ -6,11 +6,81 @@
  */
 
 import type { ModelPickerLabels } from "@houston-ai/core";
+import type { Capabilities } from "@houston-ai/engine-client";
 import type { useTranslation } from "react-i18next";
+import { canSeeAiModelsPage } from "../lib/org-roles.ts";
 
-/** Build the picker's labels from the chat-namespace translator. */
+/**
+ * Which "nothing is connected" story the picker tells (HOU-979).
+ *
+ * A team space with no credential used to render a blank provider list with no
+ * explanation, which reads as a broken app rather than as the honest first state
+ * of a new space. The three variants are the three genuinely different
+ * situations, and they differ in whether the viewer can do anything about it:
+ *
+ *  - `personal`        — single player. Their own space, their own connect.
+ *  - `teamCanConnect`  — a team space, viewed by someone who can reach the AI
+ *                        Models hub (owner / admin).
+ *  - `teamAskAdmin`    — a team space, viewed by a plain member. Provider
+ *                        connections are org-level and the hub is not theirs to
+ *                        open, so pointing them at it would dead-end; name who
+ *                        can fix it instead.
+ */
+export type PickerEmptyState = "personal" | "teamCanConnect" | "teamAskAdmin";
+
+/** The empty-state copy to use, and whether its action may render at all. */
+export interface PickerEmptyStateDecision {
+  variant: PickerEmptyState;
+  /**
+   * Whether the viewer can reach the AI Models hub — gates BOTH the empty
+   * state's button and the picker's "Connect more providers…" footer.
+   */
+  canConnect: boolean;
+}
+
+/**
+ * Resolve the empty-state variant + whether its action may render, for the
+ * active space and viewer.
+ *
+ * `capabilitiesLoaded` is load-bearing, not defensive (HOU-979). `role` is
+ * per-space and arrives with capabilities; the underlying
+ * {@link canSeeAiModelsPage} answers TRUE for capabilities that have not
+ * arrived (the single-player default), so deciding early showed a plain team
+ * member a Connect action for a beat and then withdrew it. Until they land we
+ * make no promise: no action, and the copy that assumes the least. The surface
+ * holds its neutral loading state through that window anyway
+ * (`use-picker-view-models` folds the same signal into `catalogState`), so the
+ * conservative variant is a belt-and-braces default, never a visible flash of
+ * "ask an admin" at an owner.
+ *
+ * A capabilities load that FAILS is not "still loading": it settles on the
+ * permissive single-player default, since an undescribed deployment is that.
+ */
+export function pickerEmptyState(opts: {
+  teamSpace: boolean;
+  capabilities: Capabilities | null;
+  capabilitiesLoaded: boolean;
+}): PickerEmptyStateDecision {
+  const canConnect =
+    opts.capabilitiesLoaded && canSeeAiModelsPage(opts.capabilities);
+  if (!opts.teamSpace) return { variant: "personal", canConnect };
+  return {
+    variant: canConnect ? "teamCanConnect" : "teamAskAdmin",
+    canConnect,
+  };
+}
+
+/**
+ * Build the picker's labels from the chat-namespace translator.
+ *
+ * `emptyState` only swaps the no-providers copy; every other label is shared.
+ * The CTA label is always supplied — whether the action RENDERS is decided by
+ * the consumer passing (or withholding) `onConnectMore`, so a member never sees
+ * a button into a surface they cannot open.
+ */
 export function buildLabels(
   t: ReturnType<typeof useTranslation<"chat">>[0],
+  emptyState: PickerEmptyState,
 ): Partial<ModelPickerLabels> {
   const k = (key: string) => t(`modelSelector.picker.${key}`);
   return {
@@ -21,6 +91,8 @@ export function buildLabels(
     modelsLabel: k("modelsLabel"),
     loading: k("loading"),
     empty: k("empty"),
-    noProviders: k("noProviders"),
+    noProviders: k(`noProviders.${emptyState}.title`),
+    noProvidersHint: k(`noProviders.${emptyState}.hint`),
+    noProvidersAction: k("noProviders.action"),
   };
 }

--- a/app/src/components/provider-browser/provider-browser-sections.tsx
+++ b/app/src/components/provider-browser/provider-browser-sections.tsx
@@ -42,7 +42,7 @@ export function makeProviderRow({
       description={
         providerCostLine(provider.id) ?? providerDescription(provider.id)
       }
-      connected={connections.isConnected(provider)}
+      connection={connections.connectionState(provider)}
       connecting={connections.busy[provider.id] === "connecting"}
       signingOut={connections.busy[provider.id] === "signingOut"}
       onConnect={connections.connect}

--- a/app/src/components/provider-browser/provider-browser.tsx
+++ b/app/src/components/provider-browser/provider-browser.tsx
@@ -35,7 +35,7 @@ import {
   type ProviderQuickFilter,
   searchProviders,
 } from "./provider-filtering";
-import { groupProviders } from "./provider-grouping";
+import { groupProviders, providerOwnedSide } from "./provider-grouping";
 import { useProviderAutoSelect } from "./use-provider-auto-select";
 
 export interface ProviderBrowserProps {
@@ -117,10 +117,13 @@ export function ProviderBrowser({
     expanded,
     searching,
   );
-  const { connected, available } = groupProviders(
-    displayed,
-    connections.isConnected,
-  );
+  // The Connected section is the "yours" side: confirmed connections plus the
+  // ones still resolving (their rows render their own "Checking" and offer no
+  // action). Only CONFIRMED-disconnected providers reach Available, which is the
+  // section whose rows carry a live Connect button (HOU-979).
+  const groups = groupProviders(displayed, connections.connectionState);
+  const owned = providerOwnedSide(groups);
+  const available = groups.available;
   const row = makeProviderRow({ connections, catalog });
 
   return (
@@ -154,8 +157,8 @@ export function ProviderBrowser({
         />
       ) : (
         <div className="flex flex-col gap-8">
-          <Section label={t("sections.connected")} count={connected.length}>
-            {connected.map(row)}
+          <Section label={t("sections.connected")} count={owned.length}>
+            {owned.map(row)}
           </Section>
           <Section label={t("sections.available")} count={available.length}>
             {available.map(row)}

--- a/app/src/components/provider-browser/provider-grouping.ts
+++ b/app/src/components/provider-browser/provider-grouping.ts
@@ -13,6 +13,7 @@ import type {
   CatalogOffer,
   HubCatalog,
 } from "../../lib/ai-hub/catalog-types.ts";
+import type { ProviderConnectionState } from "../../lib/provider-connection.ts";
 import { PROVIDER_OVERRIDES } from "../../lib/provider-overrides.ts";
 import {
   getConnectProviders,
@@ -20,25 +21,56 @@ import {
   providerGatewayIds,
 } from "../../lib/providers.ts";
 
-/** Connected providers first, otherwise catalog order is preserved. */
+/**
+ * Active providers split by connection state, catalog order preserved within
+ * each bucket. One bucket per state of the ONE derivation (HOU-979) — no
+ * surface has to collapse the tri-state on its own and get it wrong.
+ */
 export interface ProviderGroups {
+  /** CONFIRMED connected. The only bucket that may claim "Connected". */
   connected: ProviderInfo[];
+  /**
+   * Not confirmable right now (unreachable engine, waking pod, a space whose
+   * agent list is still settling). Renders on the CONNECTED side of every
+   * browse surface — never under a heading that says it is available to
+   * connect, and never with a Connect CTA: offering one for an account that
+   * may well be signed in is the guess the tri-state exists to prevent.
+   */
+  checking: ProviderInfo[];
+  /** CONFIRMED not connected. The only bucket that gets a Connect CTA. */
   available: ProviderInfo[];
 }
 
 /**
- * Split active providers into Connected / Available, preserving the incoming
- * (catalog) order within each group. Connected cards render first.
+ * Split active providers by connection state, preserving the incoming (catalog)
+ * order within each group.
  */
 export function groupProviders(
   providers: readonly ProviderInfo[],
-  isConnected: (p: ProviderInfo) => boolean,
+  connectionState: (p: ProviderInfo) => ProviderConnectionState,
 ): ProviderGroups {
-  const connected: ProviderInfo[] = [];
-  const available: ProviderInfo[] = [];
-  for (const provider of providers)
-    (isConnected(provider) ? connected : available).push(provider);
-  return { connected, available };
+  const groups: ProviderGroups = {
+    connected: [],
+    checking: [],
+    available: [],
+  };
+  for (const provider of providers) {
+    const state = connectionState(provider);
+    if (state === "connected") groups.connected.push(provider);
+    else if (state === "checking") groups.checking.push(provider);
+    else groups.available.push(provider);
+  }
+  return groups;
+}
+
+/**
+ * The providers a browse surface shows on the "yours" side: confirmed connected
+ * first, then the ones still resolving. Both are rendered by row components that
+ * read the state themselves, so a `checking` row shows its own treatment rather
+ * than borrowing the connected one.
+ */
+export function providerOwnedSide(groups: ProviderGroups): ProviderInfo[] {
+  return [...groups.connected, ...groups.checking];
 }
 
 /** The `card.*` i18n key describing how a provider connects. */

--- a/app/src/components/provider-browser/provider-row.tsx
+++ b/app/src/components/provider-browser/provider-row.tsx
@@ -17,6 +17,7 @@
 import { AsyncButton, Button } from "@houston-ai/core";
 import { Loader2, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import type { ProviderConnectionState } from "../../lib/provider-connection";
 import type { ProviderInfo } from "../../lib/providers";
 import { LiveStatus } from "../ai-hub/hub-badges";
 import { BrandMark } from "./brand-mark";
@@ -31,7 +32,12 @@ interface ProviderRowProps {
   modelCount: number;
   /** Muted one-line secondary: the friendly cost prose or provider description. */
   description: string;
-  connected: boolean;
+  /**
+   * The card's connection state. `checking` (an unconfirmable probe) renders a
+   * muted, non-actionable "Checking" in place of both the Connected dot and the
+   * Connect / Sign out buttons: claiming either would be a guess (HOU-979).
+   */
+  connection: ProviderConnectionState;
   connecting: boolean;
   signingOut: boolean;
   onConnect: (provider: ProviderInfo) => void;
@@ -43,7 +49,7 @@ export function ProviderRow({
   provider,
   modelCount,
   description,
-  connected,
+  connection,
   connecting,
   signingOut,
   onConnect,
@@ -51,6 +57,7 @@ export function ProviderRow({
   onSignOut,
 }: ProviderRowProps) {
   const { t } = useTranslation("aiHub");
+  const connected = connection === "connected";
 
   return (
     <div className="flex items-center gap-3 rounded-xl bg-chip px-3 py-2.5 text-left">
@@ -74,7 +81,14 @@ export function ProviderRow({
       </div>
 
       <div className="flex shrink-0 items-center gap-1">
-        {connected ? (
+        {connection === "checking" ? (
+          // Not confirmable right now (engine unreachable, pod waking, the
+          // space's agent list still settling). Say exactly that instead of
+          // offering an action whose premise we can't verify.
+          <span className="px-3 text-[13px] text-ink-muted">
+            {t("card.checking")}
+          </span>
+        ) : connected ? (
           <Button
             size="sm"
             variant="ghost"

--- a/app/src/components/shell/provider-reconnect-card.tsx
+++ b/app/src/components/shell/provider-reconnect-card.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { reconnectCardShouldClear } from "../../lib/provider-connection";
 import { getProvider } from "../../lib/providers";
 import { tauriProvider } from "../../lib/tauri";
 import { useUIStore } from "../../stores/ui";
@@ -9,7 +10,6 @@ import { LocalModelDialog } from "./local-model-dialog";
 import { ProviderGlyph } from "./provider-logos";
 import { resolveReconnectCardPresentation } from "./provider-reconnect-presentation";
 import {
-  providerIsAuthenticated,
   providerReconnectSignalState,
   reconnectProviderForChat,
 } from "./provider-reconnect-state";
@@ -78,23 +78,28 @@ export function ProviderReconnectCard({
     };
   }, [providerId, shouldCheckSignal, signalKey]);
 
+  // Confirmation poll: the card clears the moment a FRESH probe reports the
+  // provider connected. The clear rule lives in the shared derivation
+  // (`reconnectCardShouldClear`) so this card, the hub badge and the picker all
+  // read one `ProviderStatus` the same way (HOU-979). A probe that fails is not
+  // evidence of anything: it is skipped, never latched, so a reconnect that
+  // succeeded across an errored tick still clears on the next tick.
   useEffect(() => {
     if (!activeProviderId) return;
     let cancelled = false;
     const check = async () => {
-      try {
-        const status = await tauriProvider.checkStatus(activeProviderId);
-        if (cancelled) return;
-        if (providerIsAuthenticated(status)) {
-          // Only clear the global flag if it belongs to the provider we just
-          // confirmed — otherwise an OpenAI chat re-auth would wipe a pending
-          // Claude reconnect (or vice-versa).
-          if (authRequired === activeProviderId) setAuthRequired(null);
-          if (signalKey) setResolvedSignal(signalKey);
-          setLoginLaunched(false);
-        }
-      } catch {
-        // Keep the reconnect card visible; the next poll may succeed.
+      const probe = await tauriProvider
+        .checkStatus(activeProviderId)
+        .then((status) => ({ ok: true, status }) as const)
+        .catch(() => ({ ok: false }) as const);
+      if (cancelled) return;
+      if (reconnectCardShouldClear(probe)) {
+        // Only clear the global flag if it belongs to the provider we just
+        // confirmed — otherwise an OpenAI chat re-auth would wipe a pending
+        // Claude reconnect (or vice-versa).
+        if (authRequired === activeProviderId) setAuthRequired(null);
+        if (signalKey) setResolvedSignal(signalKey);
+        setLoginLaunched(false);
       }
     };
     void check();

--- a/app/src/components/shell/provider-reconnect-state.ts
+++ b/app/src/components/shell/provider-reconnect-state.ts
@@ -1,12 +1,22 @@
-type ProviderAuthState = "authenticated" | "unauthenticated" | "unknown";
+import {
+  type ProviderConnectionStatus,
+  providerIsConnected,
+} from "../../lib/provider-connection.ts";
 
-interface ProviderReconnectStatus {
-  cli_installed: boolean;
-  auth_state: ProviderAuthState;
-}
+type ProviderReconnectStatus = ProviderConnectionStatus & {
+  auth_state: NonNullable<ProviderConnectionStatus["auth_state"]>;
+};
 
 export type ProviderReconnectSignalState = "needs_auth" | "resolved";
 
+/**
+ * Whether a chat's feed auth signal is a real "sign in again" prompt.
+ *
+ * Only a CONFIRMED signed-out probe raises the card. An `unknown` probe is
+ * "checking", not "signed out", so it resolves the signal instead of flashing a
+ * reconnect prompt at a provider that may well be connected — and a missing CLI
+ * is not something reconnecting can fix.
+ */
 export function providerReconnectSignalState(
   status: ProviderReconnectStatus,
 ): ProviderReconnectSignalState {
@@ -15,28 +25,11 @@ export function providerReconnectSignalState(
     : "resolved";
 }
 
+/** CONFIRMED connected. Thin alias over the ONE derivation (HOU-979). */
 export function providerIsAuthenticated(
   status: ProviderReconnectStatus,
 ): boolean {
-  return status.cli_installed && status.auth_state === "authenticated";
-}
-
-/**
- * Whether the settings UI should present a provider as connected (show
- * "Sign out" instead of the "Connect" CTA).
- *
- * Mirrors providerReconnectSignalState: only a *confirmed* signed-out state
- * counts as disconnected. An "unknown" probe result — `claude auth status`
- * timed out or returned a format the classifier doesn't recognize, which is
- * common for Anthropic (the reason #76 introduced this gating) — is NOT
- * treated as disconnected. Claude usually still works in that state, so a
- * "Connect" button is wrong and, worse, never clears after a successful
- * sign-in because the follow-up probe is unknown too.
- */
-export function providerAppearsConnected(
-  status: ProviderReconnectStatus,
-): boolean {
-  return status.cli_installed && status.auth_state !== "unauthenticated";
+  return providerIsConnected(status);
 }
 
 /**

--- a/app/src/components/tabs/use-routine-chat-setup.ts
+++ b/app/src/components/tabs/use-routine-chat-setup.ts
@@ -7,6 +7,10 @@ import { useCapabilities } from "../../hooks/use-capabilities";
 import { useProviderStatuses } from "../../hooks/use-provider-statuses";
 import { analytics } from "../../lib/analytics";
 import { createMission } from "../../lib/create-mission";
+import {
+  providerConnectionState,
+  providerIsConnected,
+} from "../../lib/provider-connection";
 import { providerName } from "../../lib/providers";
 import { queryKeys } from "../../lib/query-keys";
 import {
@@ -52,14 +56,22 @@ export function useRoutineChatSetup(
   // The kickoffs name the user's connected providers so the agent never pins
   // a routine to one that isn't (e.g. "use deepseek" with no DeepSeek login).
   // While statuses are still loading, `null` keeps the prompt generic instead
-  // of wrongly claiming nothing is connected.
+  // of wrongly claiming nothing is connected — and so does an UNCONFIRMABLE
+  // probe (HOU-979): "we could not check" is not "nothing is connected", so it
+  // defers to the generic prompt rather than naming a partial list as if it
+  // were the whole truth. Membership itself is the ONE shared derivation.
   const providerStatuses = useProviderStatuses();
+  const statusValues = Object.values(providerStatuses.statuses);
+  const statusesUnconfirmable = statusValues.some(
+    (s) => providerConnectionState(s, false) === "checking",
+  );
   const connectedProvidersRef = useRef<ConnectedProviderRef[] | null>(null);
-  connectedProvidersRef.current = providerStatuses.isLoading
-    ? null
-    : Object.values(providerStatuses.statuses)
-        .filter((s) => s.authenticated)
-        .map((s) => ({ id: s.provider, name: providerName(s.provider) }));
+  connectedProvidersRef.current =
+    providerStatuses.isLoading || statusesUnconfirmable
+      ? null
+      : statusValues
+          .filter((s) => providerIsConnected(s))
+          .map((s) => ({ id: s.provider, name: providerName(s.provider) }));
 
   // Every unlinked, live create-chat for this agent — a person can be building
   // several at once (legacy reaction drafts included).

--- a/app/src/components/usage-view/usage-view.tsx
+++ b/app/src/components/usage-view/usage-view.tsx
@@ -51,9 +51,12 @@ export function UsageView() {
       }),
     [newEngine, providerCapabilities],
   );
+  // CONFIRMED connections only: a provider whose probe could not be confirmed
+  // has no usage to show, and listing it here would render an account row with
+  // nothing behind it (HOU-979).
   const { connected } = useMemo(
-    () => groupProviders(connectProviders, connections.isConnected),
-    [connectProviders, connections.isConnected],
+    () => groupProviders(connectProviders, connections.connectionState),
+    [connectProviders, connections.connectionState],
   );
   // Hosted cloud meters how long each agent's engine runs; only gateways that
   // serve the data advertise it. Mount-gating here also gates the query, so

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -94,6 +94,10 @@ import {
 import { osIsTauri } from "../lib/os-bridge";
 import { resolvePlanReadyOverride } from "../lib/plan-ready";
 import {
+  providerConnectionState,
+  providerIsConnected,
+} from "../lib/provider-connection";
+import {
   decideHandoffMode,
   estimateConversationTokens,
   type ProviderHandoffMode,
@@ -496,14 +500,24 @@ export function useAgentChatPanel({
     pinForSelected?.model ?? selectedActivity?.model ?? null,
   );
 
-  // Which providers the user is actually logged into (reactive + cached). The
-  // fallback below picks an authenticated one rather than a stale preference,
-  // so a no-provider agent never lands on a logged-out CLI (#483).
+  // Which providers the user is actually logged into (reactive + cached), read
+  // through the ONE shared derivation (HOU-979) rather than the denormalized
+  // `authenticated` flag. The fallback below picks a CONFIRMED-connected one
+  // rather than a stale preference, so a no-provider agent never lands on a
+  // logged-out account (#483) — and an unconfirmable probe is kept separate, so
+  // it neither becomes a fallback target nor disqualifies the preferred one.
   const { statuses: providerStatuses } = useProviderStatuses();
   const authedProviders = useMemo(
     () =>
       Object.values(providerStatuses)
-        .filter((s) => s.authenticated)
+        .filter((s) => providerIsConnected(s))
+        .map((s) => s.provider),
+    [providerStatuses],
+  );
+  const unconfirmedProviders = useMemo(
+    () =>
+      Object.values(providerStatuses)
+        .filter((s) => providerConnectionState(s, false) === "checking")
         .map((s) => s.provider),
     [providerStatuses],
   );
@@ -551,6 +565,7 @@ export function useAgentChatPanel({
     lastUsedProvider,
     authedProviders,
     hasMessages,
+    unconfirmedProviders,
   );
   const effectiveModel =
     validModelOrNull(effectiveProvider, activityModel) ??

--- a/app/src/hooks/migration-reconnect-trigger.ts
+++ b/app/src/hooks/migration-reconnect-trigger.ts
@@ -6,6 +6,40 @@
  * here.
  */
 
+import {
+  type ProviderConnectionStatus,
+  providerConnectionState,
+  providerIsConnected,
+} from "../lib/provider-connection.ts";
+
+/**
+ * The two provider signals the gate reads, derived from the probe's statuses
+ * through the ONE shared derivation (HOU-979).
+ */
+export interface MigrationProviderSignals {
+  /** At least one provider is CONFIRMED connected. */
+  hasProvider: boolean;
+  /**
+   * At least one provider's probe came back `unknown`. "We could not check" is
+   * not "nothing is connected": reading it as the latter puts a migrated user
+   * who IS connected behind the reconnect gate. It folds into `loading` below
+   * so the gate DEFERS instead of firing on an answer we do not have.
+   */
+  unconfirmable: boolean;
+}
+
+/** Derive both provider signals from the probed statuses. */
+export function migrationProviderSignals(
+  statuses: readonly ProviderConnectionStatus[],
+): MigrationProviderSignals {
+  return {
+    hasProvider: statuses.some((s) => providerIsConnected(s)),
+    unconfirmable: statuses.some(
+      (s) => providerConnectionState(s, false) === "checking",
+    ),
+  };
+}
+
 /** Inputs to the "reconnect your AI" decision. */
 export interface MigrationReconnectInputs {
   /** Active backend is the new TS host (the only build that migrates). */

--- a/app/src/hooks/provider-connections/types.ts
+++ b/app/src/hooks/provider-connections/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { ProviderConnectionState } from "../../lib/provider-connection";
 import type { ProviderInfo } from "../../lib/providers";
 import type { ProviderStatus } from "../../lib/tauri";
 import type { ToastItem } from "../../stores/ui";
@@ -77,8 +78,15 @@ export interface ProviderConnections {
   probed: boolean;
   /** Re-probe every visible provider. */
   refresh(): Promise<void>;
-  /** Whether a provider reads as connected (`providerAppearsConnected` over its status). */
-  isConnected(p: ProviderInfo): boolean;
+  /**
+   * The ONE per-provider reader (HOU-979). Every badge, CTA and grouping reads
+   * the full tri-state: `unknown` shows a neutral, visible "checking" instead
+   * of claiming Connected (the old behavior, which left a team space's hub
+   * reporting connections it could not see) or offering Connect for an account
+   * that is in fact connected. There is deliberately no boolean sibling — one
+   * existed, and every surface that reached for it collapsed the third state.
+   */
+  connectionState(p: ProviderInfo): ProviderConnectionState;
   /** Start a connect. Branches on `p.auth` / `copilotConnect` (may open a dialog). */
   connect(p: ProviderInfo): void;
   /** Abort an in-flight sign-in so the engine slot frees up for a retry. */

--- a/app/src/hooks/provider-connections/use-connection-readers.ts
+++ b/app/src/hooks/provider-connections/use-connection-readers.ts
@@ -1,0 +1,38 @@
+import { useCallback } from "react";
+import {
+  type ProviderConnectionState,
+  providerConnectionState,
+} from "../../lib/provider-connection";
+import type { ProviderInfo } from "../../lib/providers";
+import type { ProviderStatus } from "../../lib/tauri";
+
+/** The per-provider reader every hub surface asks the connections layer. */
+export interface ProviderConnectionReaders {
+  connectionState(p: ProviderInfo): ProviderConnectionState;
+}
+
+/**
+ * Turn the probed status map into the hub's connection reader, derived from the
+ * ONE shared derivation (`lib/provider-connection.ts`, HOU-979).
+ *
+ * Kept beside the probing hook rather than inline in `use-provider-connections`
+ * so that file stays under the size budget.
+ *
+ * ONE reader, deliberately: a boolean sibling shipped alongside this and every
+ * surface that reached for it collapsed the third state — an `unknown` probe
+ * grouped as "available to connect" and drew a Connect CTA for an account that
+ * may well be signed in. A missing status while `loading`, and an `unknown`
+ * probe, both land on `checking`: visible, neutral, non-actionable. Never a
+ * false Connected, never a Connect button on an unconfirmable account.
+ */
+export function useConnectionReaders(
+  statuses: Record<string, ProviderStatus | undefined>,
+  loading: boolean,
+): ProviderConnectionReaders {
+  const connectionState = useCallback(
+    (p: ProviderInfo): ProviderConnectionState =>
+      providerConnectionState(statuses[p.id], loading),
+    [statuses, loading],
+  );
+  return { connectionState };
+}

--- a/app/src/hooks/provider-connections/use-provider-statuses.ts
+++ b/app/src/hooks/provider-connections/use-provider-statuses.ts
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { providerAppearsConnected } from "../../components/shell/provider-reconnect-state";
 import { analytics } from "../../lib/analytics";
+import { providerIsConnected } from "../../lib/provider-connection";
 import {
+  activeProviderStatusScope,
   loadCachedProviderStatuses,
+  providerProbeScopeChanged,
   saveCachedProviderStatuses,
 } from "../../lib/provider-status-cache";
 import { type ProviderInfo, providerGatewayIds } from "../../lib/providers";
@@ -87,7 +89,17 @@ export function useProviderStatuses(
     const gatewayIds = [
       ...new Set(visibleProviders.flatMap((p) => providerGatewayIds(p))),
     ];
+    // Pin the space this probe belongs to BEFORE the round-trip. A probe fired
+    // in the personal space that resolves after a switch describes a world the
+    // user has left, so it is DROPPED WHOLE (HOU-979): painting it would stamp
+    // personal statuses onto the team's cards, and everything below — the
+    // transition analytics and the persist — would then be about the wrong
+    // space. The switch re-seeds and re-probes for the new space itself, so
+    // nothing is lost. Past this guard the captured scope IS the active one,
+    // which is why the persist below needs no scope argument.
+    const scope = activeProviderStatusScope();
     const byId = await tauriProvider.checkAllStatuses(gatewayIds);
+    if (providerProbeScopeChanged(scope)) return;
     if (scanIsUnreachable(gatewayIds, byId)) {
       // The engine was unreachable — the scan carries no information. Keep
       // painting the last-known snapshot (never overwrite it, or the persisted
@@ -107,8 +119,8 @@ export function useProviderStatuses(
       for (const prov of visibleProviders) {
         const prev = prevStatuses.current[prov.id];
         const cur = next[prov.id];
-        const wasConnected = prev ? providerAppearsConnected(prev) : false;
-        const isConnected = cur ? providerAppearsConnected(cur) : false;
+        const wasConnected = providerIsConnected(prev);
+        const isConnected = providerIsConnected(cur);
         if (!wasConnected && isConnected) {
           analytics.track("provider_configured", { provider: prov.id });
         }
@@ -118,7 +130,9 @@ export function useProviderStatuses(
     hasBaseline.current = true;
     setLoading(false);
     setProbed(true);
-    // Persist the confirmed scan so the NEXT visit paints instantly.
+    // Persist the confirmed scan under the space it was probed IN so the NEXT
+    // visit to that space paints instantly. The guard above already proved that
+    // space is still the active one, so the ambient default is that scope.
     saveCachedProviderStatuses(next);
   }, [visibleProviders]);
 
@@ -140,11 +154,11 @@ export function useProviderStatuses(
   }, [currentWorkspaceId]);
 
   // Re-probe LIVE after a switch, but ONLY once the new space's agents have
-  // loaded. The probe routes per-agent (last_agent_id + knownAgentIds in the
-  // engine adapter), so firing it before `loadAgents` settles would hit the OLD
-  // space's agent under the new org header — the sidebar switch handler awaits
-  // loadAgents, which repopulates knownAgentIds for the new org. Gating on the
-  // agent store's settled state closes that window.
+  // loaded. The probe routes per-agent (the engine adapter's `agentList`, which
+  // `setActiveOrg` clears on a switch), so firing it before `loadAgents` settles
+  // would hit the OLD space's agent under the new org header — the sidebar
+  // switch handler awaits loadAgents, which repopulates the list for the new
+  // org. Gating on the agent store's settled state closes that window.
   useEffect(() => {
     if (probedWorkspaceIdRef.current === currentWorkspaceId) return;
     if (!agentsLoaded || agentsLoading) return;

--- a/app/src/hooks/use-chat-model-picker.tsx
+++ b/app/src/hooks/use-chat-model-picker.tsx
@@ -14,10 +14,16 @@ import {
 } from "@houston-ai/core";
 import { type ReactNode, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { buildLabels } from "../components/chat-model-selector-labels";
+import {
+  buildLabels,
+  pickerEmptyState,
+} from "../components/chat-model-selector-labels";
 import { BrandMark } from "../components/provider-browser/brand-mark";
 import { decodeModelPickerId } from "../lib/chat-model-picker-ids";
+import { isTeamWorkspace } from "../lib/space-id";
 import { useUIStore } from "../stores/ui";
+import { useWorkspaceStore } from "../stores/workspaces";
+import { useCapabilities } from "./use-capabilities";
 import { usePickerViewModels } from "./use-picker-view-models";
 
 /** Everything `ChatModelSelector`'s JSX needs to render the picker. */
@@ -31,8 +37,13 @@ export interface ChatModelPicker {
   catalogState: ReturnType<typeof usePickerViewModels>["catalogState"];
   labels: Partial<ModelPickerLabels>;
   onSelect: (id: string) => void;
-  /** Opens the AI Hub, the app's provider-connection surface. */
-  onConnectMore: () => void;
+  /**
+   * Opens the AI Hub, the app's provider-connection surface. Undefined for a
+   * viewer who cannot open it (a plain team member: provider connections are
+   * org-level, so the hub is owner/admin-only), which drops both the footer row
+   * and the empty state's button rather than offering a dead end.
+   */
+  onConnectMore?: () => void;
   renderProviderIcon: (providerId: string, className?: string) => ReactNode;
 }
 
@@ -66,6 +77,19 @@ export function useChatModelPicker(opts: {
   const { provider, model, onSelect, open, onOpenChange } = opts;
   const { t } = useTranslation("chat");
   const setViewMode = useUIStore((s) => s.setViewMode);
+  const { capabilities, isLoading: capabilitiesLoading } = useCapabilities();
+  const workspaceId = useWorkspaceStore((s) => s.current?.id ?? null);
+  // Provider connections are ORG-level in a team space, so only the roles that
+  // can open the AI Models hub can act on an empty picker; everyone else is told
+  // who can. The decision (including the capabilities-loaded gate that keeps a
+  // plain member from being shown a Connect action we then withdraw) is pure —
+  // see `pickerEmptyState`.
+  const { variant: emptyState, canConnect: canConnectProviders } =
+    pickerEmptyState({
+      teamSpace: workspaceId ? isTeamWorkspace(workspaceId) : false,
+      capabilities,
+      capabilitiesLoaded: !capabilitiesLoading,
+    });
 
   // Merge controlled + uncontrolled open so selecting a row closes the picker
   // even when no parent owns the state (the old dropdown auto-closed on pick).
@@ -94,12 +118,16 @@ export function useChatModelPicker(opts: {
   // lists every provider and owns the full connect flow (OAuth / api-key /
   // local). The per-provider inline connect cards are gone: disconnected
   // providers never appear in the picker anymore.
-  const onConnectMore = useCallback(() => {
+  const goToAiHub = useCallback(() => {
     setOpen(false);
     setViewMode("ai-hub");
   }, [setOpen, setViewMode]);
+  const onConnectMore = canConnectProviders ? goToAiHub : undefined;
 
-  const labels = useMemo<Partial<ModelPickerLabels>>(() => buildLabels(t), [t]);
+  const labels = useMemo<Partial<ModelPickerLabels>>(
+    () => buildLabels(t, emptyState),
+    [t, emptyState],
+  );
 
   return {
     isOpen,

--- a/app/src/hooks/use-houston-init.ts
+++ b/app/src/hooks/use-houston-init.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import { DEFAULT_TAB_ID } from "../agents/standard-tabs";
-import { providerAppearsConnected } from "../components/shell/provider-reconnect-state";
 import { analytics } from "../lib/analytics";
+import { providerNotConfirmedDisconnected } from "../lib/provider-connection";
 import { tauriPreferences, tauriProvider, tauriRoutines } from "../lib/tauri";
 import { useAgentCatalogStore } from "../stores/agent-catalog";
 import { useAgentStore } from "../stores/agents";
@@ -16,6 +16,7 @@ export function useHoustonInit() {
   const loadConfigs = useAgentCatalogStore((s) => s.loadConfigs);
   const loadWorkspaces = useWorkspaceStore((s) => s.loadWorkspaces);
   const loadAgents = useAgentStore((s) => s.loadAgents);
+  const settleAgentsEmpty = useAgentStore((s) => s.settleEmpty);
   const setCurrent = useAgentStore((s) => s.setCurrent);
   const setClaudeAvailable = useUIStore((s) => s.setClaudeAvailable);
   const setViewMode = useUIStore((s) => s.setViewMode);
@@ -72,6 +73,14 @@ export function useHoustonInit() {
               ),
           ),
         );
+      } else {
+        // No space resolved, so `loadAgents` never runs. Settle the store
+        // instead of leaving `loaded` false forever: the boot splash and the
+        // provider probe both gate on it, and a load that can never arrive is
+        // an infinite spinner, not a wait. The failure itself is already
+        // surfaced (the workspace call toasts + reports, and the store's
+        // `loadError` drives the Settings retry).
+        settleAgentsEmpty();
       }
 
       if (lastAgentId) {
@@ -88,10 +97,11 @@ export function useHoustonInit() {
         const defaultProv = await tauriProvider.getDefault();
         if (defaultProv) {
           const status = await tauriProvider.checkStatus(defaultProv);
-          // appears-connected (not confirmed-authenticated): an "unknown"
-          // probe against a still-waking pod must not degrade first-load
-          // gating for a provider that is in fact connected server-side.
-          setClaudeAvailable(providerAppearsConnected(status));
+          // The PERMISSIVE read (not confirmed-connected): an "unknown" probe
+          // against a still-waking pod must not degrade first-load gating for
+          // a provider that is in fact connected server-side. This gate never
+          // paints a "Connected" badge, so leniency here is safe.
+          setClaudeAvailable(providerNotConfirmedDisconnected(status));
         } else {
           // No provider configured — track as activation drop-off signal
           analytics.track("provider_not_configured");
@@ -107,6 +117,7 @@ export function useHoustonInit() {
     loadConfigs,
     loadWorkspaces,
     loadAgents,
+    settleAgentsEmpty,
     setCurrent,
     setClaudeAvailable,
     setViewMode,

--- a/app/src/hooks/use-local-bridge-autoreconnect.ts
+++ b/app/src/hooks/use-local-bridge-autoreconnect.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from "react";
-import { providerAppearsConnected } from "../components/shell/provider-reconnect-state";
 import {
   isBridgeOpInFlight,
   LOCAL_PROVIDER_ID,
@@ -10,6 +9,7 @@ import {
   osLocalBridgeStatus,
   osSavedBridgeTarget,
 } from "../lib/os-bridge";
+import { providerNotConfirmedDisconnected } from "../lib/provider-connection";
 import { tauriProvider } from "../lib/tauri";
 
 /**
@@ -63,7 +63,7 @@ export function useLocalBridgeAutoReconnect(enabled: boolean): void {
       const provider = await tauriProvider
         .checkStatus(LOCAL_PROVIDER_ID)
         .catch(() => null);
-      if (provider && !providerAppearsConnected(provider)) return;
+      if (provider && !providerNotConfirmedDisconnected(provider)) return;
 
       await reconnectLocalModel().catch(() => {
         // reconnectLocalModel already toasted the real reason (Report-bug).

--- a/app/src/hooks/use-migration-reconnect.ts
+++ b/app/src/hooks/use-migration-reconnect.ts
@@ -4,7 +4,10 @@ import { useCallback } from "react";
 import { isCoLocatedEngine, newEngineActive } from "../lib/engine";
 import { queryKeys } from "../lib/query-keys";
 import { tauriPreferences, tauriSystem } from "../lib/tauri";
-import { shouldShowMigrationReconnect } from "./migration-reconnect-trigger";
+import {
+  migrationProviderSignals,
+  shouldShowMigrationReconnect,
+} from "./migration-reconnect-trigger";
 import { useProviderStatuses } from "./use-provider-statuses";
 
 export interface MigrationReconnectState {
@@ -56,7 +59,12 @@ export function useMigrationReconnect(): MigrationReconnectState {
   });
 
   const { statuses, isLoading: statusesLoading } = useProviderStatuses();
-  const hasProvider = Object.values(statuses).some((s) => s.authenticated);
+  // Both provider signals come from the ONE shared derivation (HOU-979): an
+  // `unknown` probe is "not yet known", never "not connected", so it defers the
+  // gate rather than firing it at a migrated user who IS connected.
+  const { hasProvider, unconfirmable } = migrationProviderSignals(
+    Object.values(statuses),
+  );
 
   const dismissMutation = useMutation({
     mutationFn: async () => {
@@ -80,7 +88,8 @@ export function useMigrationReconnect(): MigrationReconnectState {
     loading:
       (coLocated && migratedQuery.isLoading) ||
       dismissedQuery.isLoading ||
-      statusesLoading,
+      statusesLoading ||
+      unconfirmable,
   });
 
   return { show, dismiss };

--- a/app/src/hooks/use-picker-view-models.tsx
+++ b/app/src/hooks/use-picker-view-models.tsx
@@ -48,7 +48,7 @@ export function usePickerViewModels(opts: {
   const { provider, model, isOpen } = opts;
   const { t } = useTranslation("chat");
   const { statuses, isLoading } = useProviderStatuses();
-  const { capabilities } = useCapabilities();
+  const { capabilities, isLoading: capabilitiesLoading } = useCapabilities();
   // The pi-ai catalog hydrates `PROVIDERS` IN PLACE with no React signal, so the
   // `getVisibleProviders` memo below must re-key on `updatedAt` — otherwise the
   // picker stays pinned to the empty override-only seed captured on first render.
@@ -117,7 +117,14 @@ export function usePickerViewModels(opts: {
   // The pi-ai catalog is the source of the runnable set, so the picker is
   // "loading" until it resolves and "ready" after. This drives the picker's
   // neutral level-1 loading state (#342 guard) while providers resolve.
-  const catalogState: "loading" | "ready" = catalogReady ? "ready" : "loading";
+  //
+  // Capabilities join it: they GATE the visible provider set, and the empty
+  // state they lead to makes a claim about the viewer ("connect one" vs "ask an
+  // admin") that depends on a role we don't have yet. Settling early flashed a
+  // connect CTA at a plain team member and then withdrew it (HOU-979). Not
+  // knowing yet is exactly what the neutral loading state is for.
+  const catalogState: "loading" | "ready" =
+    catalogReady && !capabilitiesLoading ? "ready" : "loading";
 
   const currentModel = getModel(provider, model);
   const currentProvider = getProvider(provider);

--- a/app/src/hooks/use-provider-connections.ts
+++ b/app/src/hooks/use-provider-connections.ts
@@ -1,9 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  providerAppearsConnected,
-  providerIsAuthenticated,
-} from "../components/shell/provider-reconnect-state";
+import { providerIsAuthenticated } from "../components/shell/provider-reconnect-state";
 import { useCopilotConnect } from "../components/shell/use-copilot-connect";
 import { newEngineActive } from "../lib/engine";
 import { osIsTauri } from "../lib/os-bridge";
@@ -18,6 +15,7 @@ import type {
   ProviderLoginDialogState,
   ProviderPending,
 } from "./provider-connections/types";
+import { useConnectionReaders } from "./provider-connections/use-connection-readers";
 import { useProviderConnectActions } from "./provider-connections/use-provider-connect-actions";
 import { useProviderLoginEvents } from "./provider-connections/use-provider-login-events";
 import { useProviderStatuses } from "./provider-connections/use-provider-statuses";
@@ -127,13 +125,8 @@ export function useProviderConnections(): ProviderConnections {
     setCustomEndpointDialog,
   });
 
-  const isConnected = useCallback(
-    (p: ProviderInfo) => {
-      const s = statuses[p.id];
-      return s ? providerAppearsConnected(s) : false;
-    },
-    [statuses],
-  );
+  // The ONE connection reader, from the ONE shared derivation (HOU-979).
+  const { connectionState } = useConnectionReaders(statuses, loading);
 
   // `signOut` opens the confirm; the actual logout runs on confirm.
   const signOut = useCallback((p: ProviderInfo) => setConfirmSignOutFor(p), []);
@@ -180,7 +173,7 @@ export function useProviderConnections(): ProviderConnections {
     ready: !loading,
     probed,
     refresh: loadStatuses,
-    isConnected,
+    connectionState,
     connect,
     cancel,
     signOut,

--- a/app/src/hooks/use-provider-statuses.ts
+++ b/app/src/hooks/use-provider-statuses.ts
@@ -2,11 +2,18 @@ import { useQuery } from "@tanstack/react-query";
 import { newEngineActive } from "../lib/engine";
 import { osIsTauri } from "../lib/os-bridge";
 import {
+  providerProbeReady,
+  providerStatusesLoading,
+  providerStatusesQueryKey,
+} from "../lib/provider-statuses-query";
+import {
   EMPTY_PROVIDER_CAPABILITIES,
   getVisibleProviders,
 } from "../lib/providers";
 import { queryKeys } from "../lib/query-keys";
 import { type ProviderStatus, tauriProvider } from "../lib/tauri";
+import { useAgentStore } from "../stores/agents";
+import { useWorkspaceStore } from "../stores/workspaces";
 import { useCapabilities } from "./use-capabilities";
 import { useProviderCatalog } from "./use-provider-catalog";
 
@@ -33,6 +40,22 @@ export interface ProviderStatusesState {
  * invalidated when a provider login completes (see use-agent-invalidation.ts);
  * `staleTime` keeps repeat opens instant, and the default window-focus refetch
  * picks up out-of-band auth changes.
+ *
+ * SPACE SAFETY (HOU-979). Provider connections are tenant data and the probe
+ * routes per-agent, so this query carries the SAME two guards the AI-hub's
+ * sibling hook has:
+ *
+ *  1. the active workspace id is part of the key, so team and personal never
+ *     share a cache entry (the active space is only a request header — without
+ *     this they collide and one space can serve the other's statuses); and
+ *  2. the query is disabled until the CURRENT space's agent list has settled,
+ *     so the probe is never routed at the previous space's agent under the new
+ *     org header (which 404s and stamps every provider `unknown` — the picker
+ *     then rendered no providers at all).
+ *
+ * The gate is the natural refetch trigger too: `enabled` flipping true once
+ * agents settle makes TanStack fetch the new space's key immediately, with no
+ * hand-rolled effect.
  */
 export function useProviderStatuses(): ProviderStatusesState {
   const { capabilities } = useCapabilities();
@@ -46,11 +69,20 @@ export function useProviderStatuses(): ProviderStatusesState {
   // first mount. `useProviderCatalog` shares the `["provider-catalog"]` query, so
   // this reads the cache and never triggers a second catalog fetch.
   const { updatedAt: catalogUpdatedAt } = useProviderCatalog();
+  const workspaceId = useWorkspaceStore((s) => s.current?.id ?? null);
+  const agentsLoading = useAgentStore((s) => s.loading);
+  const agentsLoaded = useAgentStore((s) => s.loaded);
+  const probeReady = providerProbeReady({
+    loaded: agentsLoaded,
+    loading: agentsLoading,
+  });
+
   const query = useQuery({
-    queryKey: [
-      ...queryKeys.providerStatuses(capabilities?.providers ?? null),
+    queryKey: providerStatusesQueryKey({
+      base: queryKeys.providerStatuses(capabilities?.providers ?? null),
       catalogUpdatedAt,
-    ],
+      workspaceId,
+    }),
     queryFn: async (): Promise<Record<string, ProviderStatus>> => {
       const providers = getVisibleProviders({
         newEngine,
@@ -62,12 +94,17 @@ export function useProviderStatuses(): ProviderStatusesState {
       // identical round-trips to the agent's sandbox each time the picker opened.
       return tauriProvider.checkAllStatuses(providers.map((p) => p.id));
     },
+    enabled: probeReady,
     staleTime: 30_000,
   });
 
   return {
     statuses: query.data ?? {},
-    isLoading: query.isLoading,
+    isLoading: providerStatusesLoading({
+      hasData: query.data !== undefined,
+      queryIsLoading: query.isLoading,
+      probeReady,
+    }),
     isError: query.isError,
   };
 }

--- a/app/src/lib/chat-model-picker-map.ts
+++ b/app/src/lib/chat-model-picker-map.ts
@@ -26,11 +26,11 @@
 
 import type { ModelPickerModel, ModelPickerProvider } from "@houston-ai/core";
 import { encodeModelPickerId } from "./chat-model-picker-ids.ts";
+import { pickerModelRows } from "./model-picker.ts";
 import {
-  type ProviderConnection,
-  pickerModelRows,
-  providerPickerState,
-} from "./model-picker.ts";
+  type ProviderConnectionStatus,
+  providerConnectionState,
+} from "./provider-connection.ts";
 import { PROVIDER_OVERRIDES } from "./provider-overrides.ts";
 import type { ProviderInfo } from "./providers.ts";
 
@@ -111,13 +111,15 @@ export function buildPickerModels(opts: {
 
 /**
  * Build the picker's provider list: every visible provider that owns ≥1 model
- * (`withModels`), each carrying its connection state. `providerPickerState`
- * already returns the `connected | checking | disconnected` vocabulary the
- * picker expects, including the #342 "checking" state while statuses load.
+ * (`withModels`), each carrying its connection state. The shared
+ * `providerConnectionState` (the ONE derivation, HOU-979) already returns the
+ * `connected | checking | disconnected` vocabulary the picker expects,
+ * including the neutral "checking" state while statuses load or come back
+ * `unknown`.
  */
 export function buildPickerProviders(opts: {
   visibleProviders: readonly ProviderInfo[];
-  statuses: Record<string, ProviderConnection | undefined>;
+  statuses: Record<string, ProviderConnectionStatus | undefined>;
   isLoading: boolean;
   withModels: Set<string>;
 }): ModelPickerProvider[] {
@@ -126,6 +128,6 @@ export function buildPickerProviders(opts: {
     .map((p) => ({
       id: p.id,
       name: p.name,
-      connection: providerPickerState(opts.statuses[p.id], opts.isLoading),
+      connection: providerConnectionState(opts.statuses[p.id], opts.isLoading),
     }));
 }

--- a/app/src/lib/claude-login-remote.ts
+++ b/app/src/lib/claude-login-remote.ts
@@ -35,7 +35,6 @@
  * bug in the push must never leave the user on a dead spinner.
  */
 
-import { useAgentStore } from "../stores/agents";
 import { useUIStore } from "../stores/ui";
 import {
   isTransientPushError,
@@ -66,10 +65,7 @@ type Confirm = (provider: string) => Promise<boolean>;
  * exactly like `providerStatuses` in `tauri.ts`.
  */
 type ClaudeCredentialPusher = {
-  pushClaudeOAuthCredential?: (
-    agentId: string | null,
-    credentialJson: string,
-  ) => Promise<void>;
+  pushClaudeOAuthCredential?: (credentialJson: string) => Promise<void>;
 };
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -98,9 +94,11 @@ async function pushMintedClaudeCredential(): Promise<ClaudeHandoffResult> {
     return { ok: false, reason: "no-credential", error: err };
   }
 
-  const agents = useAgentStore.getState();
-  const agentId = agents.current?.id ?? agents.agents[0]?.id ?? null;
-
+  // The target pod is resolved by the engine adapter's ONE space-validated
+  // accessor (HOU-979). Picking it here off the agent STORE was a third,
+  // unsynchronized source of the routing id: right after a space switch the
+  // store can still hold the previous space's agents, so a freshly minted
+  // credential would be pushed at an agent the active space does not have.
   const engine = getEngine() as unknown as ClaudeCredentialPusher;
   try {
     if (!engine.pushClaudeOAuthCredential) {
@@ -108,7 +106,7 @@ async function pushMintedClaudeCredential(): Promise<ClaudeHandoffResult> {
     }
     for (let attempt = 0; ; attempt++) {
       try {
-        await engine.pushClaudeOAuthCredential(agentId, credentialJson);
+        await engine.pushClaudeOAuthCredential(credentialJson);
         return { ok: true };
       } catch (err) {
         const delay = PUSH_RETRY_DELAYS_MS[attempt];

--- a/app/src/lib/model-picker.test.mjs
+++ b/app/src/lib/model-picker.test.mjs
@@ -1,59 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { pickerModelRows, providerPickerState } from "./model-picker.ts";
+import { pickerModelRows } from "./model-picker.ts";
 
-const CONNECTED = { cli_installed: true, authenticated: true };
-const INSTALLED_UNAUTH = { cli_installed: true, authenticated: false };
-const MISSING = { cli_installed: false, authenticated: false };
-
-test("providerPickerState: known statuses map to connected / disconnected", () => {
-  assert.equal(providerPickerState(CONNECTED, false), "connected");
-  // A connected status wins even if a background refetch is in flight.
-  assert.equal(providerPickerState(CONNECTED, true), "connected");
-  assert.equal(providerPickerState(INSTALLED_UNAUTH, false), "disconnected");
-  assert.equal(providerPickerState(MISSING, false), "disconnected");
-});
-
-test("providerPickerState: missing status is 'checking' only while loading", () => {
-  // The #342 fix: before statuses resolve, providers read as 'checking', NOT
-  // 'disconnected', so the picker never shows a false "Not connected".
-  assert.equal(providerPickerState(undefined, true), "checking");
-  // Not loading + no status (e.g. the fetch failed) degrades to disconnected
-  // rather than spinning forever.
-  assert.equal(providerPickerState(undefined, false), "disconnected");
-});
-
-test("providerPickerState: an 'unknown' probe (engine unreachable) is 'checking', never 'disconnected'", () => {
-  // A cold pod waking after a relaunch/update answers every status probe with
-  // auth_state "unknown". That is not a confirmed disconnect: collapsing to
-  // "Not connected" is the #342 flicker all over again.
-  const unknown = {
-    cli_installed: true,
-    authenticated: false,
-    auth_state: "unknown",
-  };
-  assert.equal(providerPickerState(unknown, false), "checking");
-  assert.equal(providerPickerState(unknown, true), "checking");
-  // Confirmed states keep their meaning when auth_state is present.
-  assert.equal(
-    providerPickerState(
-      { cli_installed: true, authenticated: true, auth_state: "authenticated" },
-      false,
-    ),
-    "connected",
-  );
-  assert.equal(
-    providerPickerState(
-      {
-        cli_installed: true,
-        authenticated: false,
-        auth_state: "unauthenticated",
-      },
-      false,
-    ),
-    "disconnected",
-  );
-});
+// The provider CONNECTION derivation moved to `provider-connection.ts` (one home
+// for every surface, HOU-979); its cases live in `app/tests/provider-connection.test.ts`.
 
 test("pickerModelRows: a catalogued provider shows its catalog, ignoring the runtime model", () => {
   const catalog = [

--- a/app/src/lib/model-picker.ts
+++ b/app/src/lib/model-picker.ts
@@ -1,61 +1,15 @@
 /**
- * Pure decision helpers for the chat model picker (ChatModelSelector).
+ * Pure model-row helpers for the chat model picker (ChatModelSelector).
  *
- * Split out from the component so the visibility / connection logic is
- * unit-testable without a React renderer (the app has no component test
- * runner — see the sibling *.test.mjs files for the node:test pattern) and so
- * the container stays under the file-size budget.
+ * Split out from the component so the row-building logic is unit-testable
+ * without a React renderer (the app has no component test runner — see
+ * `app/tests/*.test.ts` for the node:test pattern) and so the container stays
+ * under the file-size budget.
  *
- * Background (issue #342): provider connection status is fetched
- * asynchronously. Before it resolves, the picker must NOT collapse to a single
- * "Not connected" provider — it shows every provider in a neutral "checking"
- * state until the real status arrives. These helpers encode exactly that.
+ * The provider CONNECTION derivation used to live here too, in a copy that
+ * disagreed with the AI hub's. It now has exactly one home for every surface:
+ * `provider-connection.ts` (HOU-979).
  */
-
-/** Minimal shape of a provider status these helpers need. */
-export interface ProviderConnection {
-  cli_installed: boolean;
-  authenticated: boolean;
-  /** Tri-state probe result. "unknown" = the engine was unreachable (a cold
-   *  pod still waking): not confirmable either way. Optional so legacy
-   *  callers that only carry the boolean keep working. */
-  auth_state?: "authenticated" | "unauthenticated" | "unknown";
-}
-
-/**
- * Per-provider state the picker renders:
- * - `connected`    — CLI installed AND authenticated; models selectable.
- * - `disconnected` — status known but not usable; hidden unless it's the
- *                    active provider, where it shows a "Not connected" hint.
- * - `checking`     — status not yet known and a fetch is in flight; shown with
- *                    a neutral "Checking..." hint, models disabled. This is the
- *                    state that prevents the #342 flicker.
- */
-export type ProviderPickerState = "connected" | "disconnected" | "checking";
-
-/**
- * Resolve a provider's picker state from its (possibly missing) status and
- * whether the status query is still loading. An absent status while loading is
- * `checking`; an absent status when NOT loading (e.g. the fetch failed) is
- * treated as `disconnected` so the picker degrades to the same safe view it had
- * before — never stuck spinning.
- */
-export function providerPickerState(
-  status: ProviderConnection | undefined,
-  isLoading: boolean,
-): ProviderPickerState {
-  if (status) {
-    // An "unknown" probe (engine unreachable, cold pod waking) is not a
-    // confirmed disconnect: keep the neutral "checking" state instead of
-    // collapsing every provider to "Not connected" (the #342 flicker, now
-    // reachable in cloud builds whenever the pod is waking).
-    if (status.auth_state === "unknown") return "checking";
-    return status.cli_installed && status.authenticated
-      ? "connected"
-      : "disconnected";
-  }
-  return isLoading ? "checking" : "disconnected";
-}
 
 /** A model row rendered under a provider in the chat picker. */
 export interface PickerModelRow {

--- a/app/src/lib/provider-connection.ts
+++ b/app/src/lib/provider-connection.ts
@@ -1,0 +1,134 @@
+/**
+ * The ONE derivation of "is this provider connected?" (HOU-979).
+ *
+ * Before this module the same `ProviderStatus` meant opposite things in three
+ * places, and the disagreement was the bug:
+ *
+ *  - the chat model picker read `cli_installed && authenticated`, so an
+ *    `unknown` probe was NOT connected and the catalog dropped the provider —
+ *    the picker rendered nothing at all;
+ *  - the AI Models hub read `cli_installed && auth_state !== "unauthenticated"`,
+ *    so the SAME `unknown` probe still read "Connected";
+ *  - the in-chat reconnect card cleared only on a confirmed `authenticated`, so
+ *    it stayed up forever against `unknown`.
+ *
+ * One provider, one truth. `unknown` is a THIRD state — "we could not confirm"
+ * (engine unreachable, cold pod waking, agent routing not settled yet) — and it
+ * renders as a visible, neutral `checking` everywhere: never "Connected", never
+ * silently hidden. Only a CONFIRMED `authenticated` is `connected`; only a
+ * CONFIRMED `unauthenticated` (or a missing CLI) is `disconnected`.
+ */
+
+/** Tri-state probe result as the engine reports it. */
+export type ProviderAuthState = "authenticated" | "unauthenticated" | "unknown";
+
+/**
+ * The minimal status shape the derivation needs. `authenticated` is the app's
+ * denormalized mirror of `auth_state === "authenticated"`; it is honored only
+ * when `auth_state` is absent, so a status carrying both can never disagree
+ * with itself.
+ */
+export interface ProviderConnectionStatus {
+  cli_installed: boolean;
+  authenticated?: boolean;
+  auth_state?: ProviderAuthState;
+}
+
+/**
+ * Per-provider connection state every surface renders from:
+ * - `connected`    — confirmed authenticated; models are selectable, the hub
+ *                    shows the Connected dot + Sign out.
+ * - `checking`     — not confirmable yet (no status while a probe is in flight,
+ *                    or an `unknown` probe). Neutral, visible, non-actionable.
+ * - `disconnected` — confirmed not usable; the hub offers Connect.
+ */
+export type ProviderConnectionState = "connected" | "checking" | "disconnected";
+
+/**
+ * Resolve a provider's connection state from its (possibly missing) status.
+ *
+ * `probing` says whether a status is still expected: an absent status while a
+ * probe is in flight is `checking`; an absent status once probing has settled
+ * (nothing came back for this provider) is `disconnected`, so a surface never
+ * spins forever.
+ *
+ * ORDER MATTERS. `unknown` is tested FIRST, ahead of the missing-CLI check, so
+ * the contract holds without exception: an unconfirmable probe is ALWAYS
+ * `checking`. The old picker read it that way, and the alternative reports a
+ * confident `disconnected` from a status whose every field is a guess.
+ */
+export function providerConnectionState(
+  status: ProviderConnectionStatus | undefined,
+  probing: boolean,
+): ProviderConnectionState {
+  if (!status) return probing ? "checking" : "disconnected";
+  if (status.auth_state === "unknown") return "checking";
+  if (!status.cli_installed) return "disconnected";
+  if (status.auth_state === undefined) {
+    // Legacy/partial status with only the denormalized boolean.
+    return status.authenticated ? "connected" : "disconnected";
+  }
+  return status.auth_state === "authenticated" ? "connected" : "disconnected";
+}
+
+/**
+ * CONFIRMED connected. The single predicate behind every "Connected" badge,
+ * every "Sign out" affordance, and every `disconnected -> connected` analytics
+ * transition. An `unknown` probe is deliberately false here — it is `checking`,
+ * which the surface must render as such rather than as either extreme.
+ */
+export function providerIsConnected(
+  status: ProviderConnectionStatus | undefined,
+): boolean {
+  return providerConnectionState(status, false) === "connected";
+}
+
+/**
+ * The PERMISSIVE read: "nothing has confirmed this provider is signed out".
+ *
+ * NOT a connected predicate — it is true for `unknown` — so it must never drive
+ * a Connected badge or hide a Connect CTA. It exists for the two decisions where
+ * acting on an unconfirmable probe is the destructive choice:
+ *
+ *  - the local-model tunnel auto-reconnect (a fabricated "not connected" against
+ *    a still-waking pod killed the tunnel for the whole session), and
+ *  - the first-load `claudeAvailable` gate (an unconfirmable probe must not
+ *    degrade onboarding for a provider that IS connected server-side).
+ *
+ * It deliberately does NOT reduce to `providerConnectionState(...) !==
+ * "disconnected"` for a status carrying no `auth_state`. The predicate this
+ * replaced (`cli_installed && auth_state !== "unauthenticated"`) read an ABSENT
+ * probe result as "not confirmed signed out"; the strict derivation reads the
+ * same status as `disconnected` via the denormalized boolean. Keeping the
+ * lenient semantics here is the whole point of having two predicates — the
+ * strict one owns every badge and CTA.
+ */
+export function providerNotConfirmedDisconnected(
+  status: ProviderConnectionStatus | undefined,
+): boolean {
+  if (!status) return false;
+  if (status.auth_state === undefined) return status.cli_installed;
+  return providerConnectionState(status, false) !== "disconnected";
+}
+
+/** The outcome of one reconnect-card confirmation probe. */
+export type ProviderProbeOutcome =
+  | { ok: true; status: ProviderConnectionStatus }
+  | { ok: false };
+
+/**
+ * Whether the in-chat reconnect card should clear.
+ *
+ * Clearing is driven ONLY by a fresh probe that CONFIRMS the provider is
+ * connected. Two consequences, both deliberate:
+ *
+ *  - a failed probe (network blip, pod waking) is not evidence of anything, so
+ *    it neither clears the card nor latches it shut: it is simply skipped, and
+ *    the very next probe that confirms `connected` clears the card. A reconnect
+ *    that succeeded across an errored poll therefore still clears.
+ *  - an `unknown` probe is `checking`, not `connected`, so it does not clear —
+ *    but with the probe routing fixed it also no longer occurs indefinitely.
+ */
+export function reconnectCardShouldClear(probe: ProviderProbeOutcome): boolean {
+  return probe.ok && providerIsConnected(probe.status);
+}

--- a/app/src/lib/provider-status-cache.ts
+++ b/app/src/lib/provider-status-cache.ts
@@ -28,10 +28,29 @@ const LEGACY_CACHE_KEY = "houston.providerStatusCache.v1";
  * `window.__HOUSTON_ACTIVE_ORG__`, or the fixed `"personal"` scope when no
  * team is active (null/absent global — the same signal the engine adapter uses
  * to send no `x-houston-org` header).
+ *
+ * Exported so a probe can capture its scope when it STARTS and check it again
+ * when it resolves — see {@link providerProbeScopeChanged}.
  */
-function activeScope(): string {
+export function activeProviderStatusScope(): string {
   if (typeof window === "undefined") return "personal";
   return window.__HOUSTON_ACTIVE_ORG__ ?? "personal";
+}
+
+/**
+ * Whether a probe that STARTED in `startedIn` has been overtaken by a space
+ * switch (C8) — the active scope is no longer the one it was fired for.
+ *
+ * A probe describes exactly one space. If the user switched while it was in
+ * flight, its answer describes a world they have left: painting it would stamp
+ * the old space's connected cards onto the new one, and persisting it would put
+ * them under the new space's cache key (HOU-979). So a probe that returns true
+ * here is DROPPED WHOLE — not merely skipped on the persist. Dropping it is
+ * safe because the switch itself re-seeds from the new scope's snapshot and
+ * fires a fresh probe for it.
+ */
+export function providerProbeScopeChanged(startedIn: string): boolean {
+  return activeProviderStatusScope() !== startedIn;
 }
 
 function scopedCacheKey(scope: string): string {
@@ -80,7 +99,7 @@ type StatusStore = Pick<Storage, "getItem" | "setItem">;
  */
 export function loadCachedProviderStatuses(
   storage: StatusStore = localStorage,
-  scope: string = activeScope(),
+  scope: string = activeProviderStatusScope(),
 ): Record<string, ProviderStatus> {
   try {
     const raw = storage.getItem(scopedCacheKey(scope));
@@ -102,7 +121,7 @@ export function loadCachedProviderStatuses(
 export function saveCachedProviderStatuses(
   statuses: Record<string, ProviderStatus>,
   storage: StatusStore = localStorage,
-  scope: string = activeScope(),
+  scope: string = activeProviderStatusScope(),
 ): void {
   try {
     storage.setItem(scopedCacheKey(scope), JSON.stringify(statuses));

--- a/app/src/lib/provider-statuses-query.ts
+++ b/app/src/lib/provider-statuses-query.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure query-shape rules for the CHAT PICKER's provider-status query
+ * (`hooks/use-provider-statuses.ts`), split out so the space-safety gate is
+ * unit-testable without a React renderer or a QueryClient.
+ *
+ * Why a gate exists at all (HOU-979): the status probe routes PER AGENT (the
+ * engine adapter picks the agent whose runtime it asks, and the gateway pins
+ * the space with `x-houston-org`). A space switch wipes the query cache
+ * (`lib/space-cache.ts`), which immediately refires this query — but the
+ * adapter has no validated agent list for the NEW space until `loadAgents`
+ * re-resolves. The probe would then ask
+ * `/v1/agents/<old-agent>/providers` under the NEW org header, gets 404/403,
+ * and every provider comes back `unknown` — which used to leave the picker
+ * showing nothing at all until the next `ProviderLoginComplete`.
+ *
+ * The sibling AI-hub hook (`hooks/provider-connections/use-provider-statuses.ts`)
+ * already gates its re-probe on the new space's agents having settled; these
+ * helpers give the picker the SAME gate plus a space-scoped query key, so the
+ * two hooks cannot drift apart again.
+ */
+
+/** The agent-store signals the gate reads. */
+export interface AgentsSettledSignals {
+  /** True once `loadAgents` has settled at least once (even on failure). */
+  loaded: boolean;
+  /** True while a `loadAgents` is in flight. */
+  loading: boolean;
+}
+
+/**
+ * Whether the CURRENT space's agent list has settled, so a per-agent provider
+ * probe would be routed at this space's agents rather than the previous one's.
+ *
+ * `loaded` alone is not enough: it stays true across a switch while the
+ * re-`loadAgents` runs, which is exactly the window the misrouted probe fired
+ * in. Both signals together mean "settled, for this space".
+ */
+export function providerProbeReady(agents: AgentsSettledSignals): boolean {
+  return agents.loaded && !agents.loading;
+}
+
+/**
+ * The picker's status query key.
+ *
+ * `workspaceId` is folded in because provider connections are TENANT data while
+ * the space is only a request header: without it, personal and team collide on
+ * one key, so a switch could serve the previous space's statuses via
+ * stale-while-revalidate. A distinct key per space means the new space starts
+ * from no data (a visible "checking"), never from another tenant's answer.
+ *
+ * `catalogUpdatedAt` stays in the key so statuses are re-probed for the FULL
+ * provider set the moment the pi-ai catalog hydrates `PROVIDERS` in place.
+ */
+export function providerStatusesQueryKey(opts: {
+  base: readonly string[];
+  catalogUpdatedAt: number;
+  workspaceId: string | null;
+}): readonly unknown[] {
+  return [...opts.base, opts.catalogUpdatedAt, opts.workspaceId];
+}
+
+/**
+ * Whether the picker should render its neutral "checking" state.
+ *
+ * A disabled query is NOT "loading" as far as TanStack is concerned (it is
+ * pending but not fetching), so reading `query.isLoading` alone would report
+ * "settled with no statuses" during the gate's window — and the picker filters
+ * unconnected providers out, so it would paint an empty list and an honest-
+ * looking "no providers connected" empty state at the exact moment we know
+ * nothing. While the gate is closed and no data has arrived, we ARE checking.
+ */
+export function providerStatusesLoading(opts: {
+  hasData: boolean;
+  queryIsLoading: boolean;
+  probeReady: boolean;
+}): boolean {
+  if (opts.hasData) return false;
+  return opts.queryIsLoading || !opts.probeReady;
+}

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -23,6 +23,7 @@
     "connectName": "Connect {{name}}",
     "connecting": "Connecting",
     "connected": "Connected",
+    "checking": "Checking",
     "signOut": "Sign out",
     "cancel": "Cancel",
     "models_one": "{{count}} model",

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -179,7 +179,21 @@
       "modelsLabel": "Models",
       "loading": "Loading providers…",
       "empty": "No models found.",
-      "noProviders": "No providers connected yet.",
+      "noProviders": {
+        "action": "Connect an AI model",
+        "personal": {
+          "title": "No providers connected yet.",
+          "hint": "Connect an AI model to start chatting."
+        },
+        "teamCanConnect": {
+          "title": "This team space has no AI connection yet.",
+          "hint": "Connect an AI model for this team and everyone here can use it."
+        },
+        "teamAskAdmin": {
+          "title": "This team space has no AI connection yet.",
+          "hint": "Ask a team owner or admin to connect an AI model for this space."
+        }
+      },
       "hiddenByWorkspace_one": "{{count}} more model is turned off in your workspace",
       "hiddenByWorkspace_other": "{{count}} more models are turned off in your workspace"
     },

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -23,6 +23,7 @@
     "connectName": "Conectar {{name}}",
     "connecting": "Conectando",
     "connected": "Conectado",
+    "checking": "Verificando",
     "signOut": "Cerrar sesión",
     "cancel": "Cancelar",
     "models_one": "{{count}} modelo",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -179,7 +179,21 @@
       "modelsLabel": "Modelos",
       "loading": "Cargando proveedores…",
       "empty": "No se encontraron modelos.",
-      "noProviders": "Aún no hay proveedores conectados.",
+      "noProviders": {
+        "action": "Conectar un modelo de IA",
+        "personal": {
+          "title": "Aún no hay proveedores conectados.",
+          "hint": "Conecta un modelo de IA para empezar a chatear."
+        },
+        "teamCanConnect": {
+          "title": "Este espacio de equipo aún no tiene una conexión de IA.",
+          "hint": "Conecta un modelo de IA para este equipo y todos aquí podrán usarlo."
+        },
+        "teamAskAdmin": {
+          "title": "Este espacio de equipo aún no tiene una conexión de IA.",
+          "hint": "Pídele a un propietario o administrador del equipo que conecte un modelo de IA para este espacio."
+        }
+      },
       "hiddenByWorkspace_one": "{{count}} modelo más está desactivado en tu espacio de trabajo",
       "hiddenByWorkspace_other": "{{count}} modelos más están desactivados en tu espacio de trabajo"
     },

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -23,6 +23,7 @@
     "connectName": "Conectar {{name}}",
     "connecting": "Conectando",
     "connected": "Conectado",
+    "checking": "Verificando",
     "signOut": "Sair",
     "cancel": "Cancelar",
     "models_one": "{{count}} modelo",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -179,7 +179,21 @@
       "modelsLabel": "Modelos",
       "loading": "Carregando provedores…",
       "empty": "Nenhum modelo encontrado.",
-      "noProviders": "Nenhum provedor conectado ainda.",
+      "noProviders": {
+        "action": "Conectar um modelo de IA",
+        "personal": {
+          "title": "Nenhum provedor conectado ainda.",
+          "hint": "Conecte um modelo de IA para começar a conversar."
+        },
+        "teamCanConnect": {
+          "title": "Este espaço de equipe ainda não tem uma conexão de IA.",
+          "hint": "Conecte um modelo de IA para esta equipe e todos aqui poderão usar."
+        },
+        "teamAskAdmin": {
+          "title": "Este espaço de equipe ainda não tem uma conexão de IA.",
+          "hint": "Peça a um proprietário ou administrador da equipe para conectar um modelo de IA para este espaço."
+        }
+      },
       "hiddenByWorkspace_one": "{{count}} modelo a mais está desativado no seu espaço de trabalho",
       "hiddenByWorkspace_other": "{{count}} modelos a mais estão desativados no seu espaço de trabalho"
     },

--- a/app/src/stores/agents.ts
+++ b/app/src/stores/agents.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { selectCurrentAgent } from "../lib/agent-selection";
 import { analytics } from "../lib/analytics";
+import { getEngine, isEngineReady } from "../lib/engine";
 import {
   tauriAgents,
   tauriPreferences,
@@ -43,6 +44,16 @@ interface AgentState {
     workspaceId: string,
     options?: { silent?: boolean },
   ) => Promise<void>;
+  /**
+   * Settle with no agents, for a boot that resolved NO workspace to list them
+   * for — the workspace load failed (already toasted + reported by `call()`,
+   * and recorded as `loadError` for the Settings retry) or the account has
+   * none. `loadAgents` is never called in that path, so without this `loaded`
+   * stays false forever and every gate reading it hangs: the boot splash never
+   * lifts and the provider probe never runs (HOU-979). Settled-empty is the
+   * honest state — there is no space, so there are no agents.
+   */
+  settleEmpty: () => void;
   setCurrent: (agent: Agent) => void;
   /**
    * Reveal a freshly created agent: mark it provisioning (HOU-693), append it
@@ -97,6 +108,16 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       // as the same empty state the legacy wire shows on a failed load.
       set({ loading: false, loaded: true });
     }
+  },
+
+  settleEmpty: () => {
+    // Also tell the engine client no list is coming, so provider routing falls
+    // back to the persisted selection instead of refusing every call while it
+    // waits on a `listAgents` that will never run (HOU-979). Guarded because
+    // this settles UI state and must never itself throw; a client that isn't
+    // built yet starts in the same unrouted state anyway.
+    if (isEngineReady()) getEngine().noteAgentsUnavailable();
+    set({ agents: [], current: null, loading: false, loaded: true });
   },
 
   setCurrent: (agent) => {

--- a/app/tests/chat-effective-provider.test.ts
+++ b/app/tests/chat-effective-provider.test.ts
@@ -160,3 +160,38 @@ describe("resolveEffectiveProvider — frozen once a conversation has messages",
     );
   });
 });
+
+describe("resolveEffectiveProvider — an UNCONFIRMABLE probe defers (HOU-979)", () => {
+  it("does NOT auth-switch away from a preferred provider we could not confirm", () => {
+    // `unknown` is not "signed out". Switching a fresh composer off Anthropic
+    // because its probe came back unconfirmable would answer (and bill) under a
+    // provider the user never chose, on evidence we do not have.
+    strictEqual(
+      resolveEffectiveProvider(null, "anthropic", null, ["openrouter"], false, [
+        "anthropic",
+      ]),
+      "anthropic",
+    );
+  });
+
+  it("still auth-switches off a CONFIRMED logged-out preference", () => {
+    // The unconfirmable list names a DIFFERENT provider, so the preferred one
+    // is genuinely confirmed signed out and #483's switch still applies.
+    strictEqual(
+      resolveEffectiveProvider(null, "openai", null, ["openrouter"], false, [
+        "deepseek",
+      ]),
+      "openrouter",
+    );
+  });
+
+  it("never picks an unconfirmable provider as the FALLBACK", () => {
+    // Deferring is not the same as trusting: with the preference confirmed
+    // signed out and nothing confirmed connected, we stay on `preferred` (which
+    // surfaces the reconnect card) rather than guessing onto an unknown.
+    strictEqual(
+      resolveEffectiveProvider(null, "openai", null, [], false, ["openrouter"]),
+      "openai",
+    );
+  });
+});

--- a/app/tests/migration-reconnect-trigger.test.ts
+++ b/app/tests/migration-reconnect-trigger.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { shouldShowMigrationReconnect } from "../src/hooks/migration-reconnect-trigger.ts";
+import {
+  migrationProviderSignals,
+  shouldShowMigrationReconnect,
+} from "../src/hooks/migration-reconnect-trigger.ts";
+import type { ProviderConnectionStatus } from "../src/lib/provider-connection.ts";
 
 // The "show" case: a migrated user, on the new engine, with no provider and no
 // prior dismissal, once every signal has resolved.
@@ -68,6 +72,62 @@ test("loading wins over every show condition", () => {
       ...SHOW,
       hasProvider: true,
       loading: true,
+    }),
+    false,
+  );
+});
+
+// HOU-979: the gate used to read the denormalized `authenticated` flag, so an
+// `unknown` probe (unreachable engine, waking pod, a space whose agent list is
+// still settling) read as "no provider" — and a migrated user who IS connected
+// got the reconnect screen. The signals now come from the ONE derivation, and
+// an unconfirmable answer defers the gate instead of firing it.
+
+const probe = (
+  over: Partial<ProviderConnectionStatus>,
+): ProviderConnectionStatus => ({
+  cli_installed: true,
+  auth_state: "authenticated",
+  authenticated: true,
+  ...over,
+});
+
+test("a CONFIRMED connection reports hasProvider and nothing unconfirmable", () => {
+  assert.deepEqual(migrationProviderSignals([probe({})]), {
+    hasProvider: true,
+    unconfirmable: false,
+  });
+});
+
+test("a CONFIRMED sign-out reports neither a provider nor an unknown", () => {
+  assert.deepEqual(
+    migrationProviderSignals([
+      probe({ auth_state: "unauthenticated", authenticated: false }),
+    ]),
+    { hasProvider: false, unconfirmable: false },
+  );
+});
+
+test("an UNKNOWN probe is unconfirmable, never a confirmed absence", () => {
+  const signals = migrationProviderSignals([
+    probe({ auth_state: "unknown", authenticated: false }),
+  ]);
+  assert.equal(signals.hasProvider, false);
+  assert.equal(signals.unconfirmable, true);
+});
+
+test("the gate DEFERS on an unconfirmable probe instead of showing", () => {
+  // The exact regression: statuses settle `unknown` for a migrated user whose
+  // provider is in fact connected. Firing here would demand a reconnect they
+  // do not need; the unconfirmable signal folds into `loading` so it does not.
+  const { hasProvider, unconfirmable } = migrationProviderSignals([
+    probe({ auth_state: "unknown", authenticated: false }),
+  ]);
+  assert.equal(
+    shouldShowMigrationReconnect({
+      ...SHOW,
+      hasProvider,
+      loading: unconfirmable,
     }),
     false,
   );

--- a/app/tests/picker-empty-state.test.ts
+++ b/app/tests/picker-empty-state.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Capabilities, OrgRole } from "@houston-ai/engine-client";
+import { pickerEmptyState } from "../src/components/chat-model-selector-labels.ts";
+
+/**
+ * HOU-979 — the chat picker's empty state, and who may act on it.
+ *
+ * Provider connections are ORG-level in a team space, so a plain member cannot
+ * open the AI Models hub. The bug these pin: the decision read capabilities
+ * that had not arrived yet, and the underlying role check answers TRUE for
+ * absent capabilities (the single-player default) — so a member was shown a
+ * Connect action for a beat and then had it swapped for "ask an admin". A
+ * promise made and withdrawn is worse than no promise.
+ */
+
+const team = (role: OrgRole): Capabilities => ({
+  profile: "cloud",
+  revealInOs: false,
+  terminal: false,
+  tunnel: false,
+  codeExecution: "remote-sandbox",
+  providers: [],
+  openaiCompatible: false,
+  integrations: [],
+  multiplayer: true,
+  teams: true,
+  role,
+});
+
+test("a personal space tells the personal story and offers the action", () => {
+  assert.deepEqual(
+    pickerEmptyState({
+      teamSpace: false,
+      capabilities: null,
+      capabilitiesLoaded: true,
+    }),
+    { variant: "personal", canConnect: true },
+  );
+});
+
+test("a team space viewed by an owner offers the action", () => {
+  assert.deepEqual(
+    pickerEmptyState({
+      teamSpace: true,
+      capabilities: team("owner"),
+      capabilitiesLoaded: true,
+    }),
+    { variant: "teamCanConnect", canConnect: true },
+  );
+});
+
+test("a team space viewed by a plain member names who can, and offers nothing", () => {
+  assert.deepEqual(
+    pickerEmptyState({
+      teamSpace: true,
+      capabilities: team("user"),
+      capabilitiesLoaded: true,
+    }),
+    { variant: "teamAskAdmin", canConnect: false },
+  );
+});
+
+test("withholds the action entirely until capabilities have LOADED", () => {
+  // The regression: mid-fetch `capabilities` is null, which the role check
+  // reads as single-player (permissive) — so the member briefly got a CTA.
+  const midFetch = pickerEmptyState({
+    teamSpace: true,
+    capabilities: null,
+    capabilitiesLoaded: false,
+  });
+  assert.equal(midFetch.canConnect, false);
+  assert.equal(midFetch.variant, "teamAskAdmin");
+
+  // Personal spaces are gated by the same rule, so no surface can offer an
+  // action into a hub whose access we have not established yet.
+  assert.equal(
+    pickerEmptyState({
+      teamSpace: false,
+      capabilities: null,
+      capabilitiesLoaded: false,
+    }).canConnect,
+    false,
+  );
+});
+
+test("a capabilities load that FAILED settles on the single-player default", () => {
+  // Failed is not pending: an undescribed deployment is the single-player one,
+  // and pinning a lone desktop user at "ask an admin" would be its own bug.
+  assert.deepEqual(
+    pickerEmptyState({
+      teamSpace: false,
+      capabilities: null,
+      capabilitiesLoaded: true,
+    }),
+    { variant: "personal", canConnect: true },
+  );
+});

--- a/app/tests/provider-connection.test.ts
+++ b/app/tests/provider-connection.test.ts
@@ -1,0 +1,232 @@
+import { strictEqual } from "node:assert";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import {
+  type ProviderConnectionStatus,
+  providerConnectionState,
+  providerIsConnected,
+  providerNotConfirmedDisconnected,
+  reconnectCardShouldClear,
+} from "../src/lib/provider-connection.ts";
+
+/**
+ * HOU-979 — one provider status, ONE meaning.
+ *
+ * The bug these pin: the same `unknown` probe meant "invisible" to the chat
+ * picker's catalog, "Connected" to the AI hub's badge, and "keep the reconnect
+ * card up forever" to the in-chat card. `unknown` is now a third state,
+ * `checking`, everywhere.
+ */
+
+const read = (relativePath: string) =>
+  readFileSync(new URL(relativePath, import.meta.url), "utf8");
+
+const status = (
+  over: Partial<ProviderConnectionStatus> = {},
+): ProviderConnectionStatus => ({
+  cli_installed: true,
+  auth_state: "authenticated",
+  authenticated: true,
+  ...over,
+});
+
+describe("provider connection state", () => {
+  it("treats a confirmed authenticated probe as connected", () => {
+    strictEqual(providerConnectionState(status(), false), "connected");
+    strictEqual(providerConnectionState(status(), true), "connected");
+  });
+
+  it("treats a confirmed unauthenticated probe as disconnected", () => {
+    strictEqual(
+      providerConnectionState(
+        status({ auth_state: "unauthenticated", authenticated: false }),
+        false,
+      ),
+      "disconnected",
+    );
+  });
+
+  it("treats an UNKNOWN probe as checking, never connected and never hidden", () => {
+    const unknown = status({ auth_state: "unknown", authenticated: false });
+    strictEqual(providerConnectionState(unknown, false), "checking");
+    strictEqual(providerConnectionState(unknown, true), "checking");
+    // The exact regression: the hub used to read this as Connected.
+    strictEqual(providerIsConnected(unknown), false);
+    // …and the picker used to read it as disconnected, which dropped the
+    // provider from the catalog entirely.
+    strictEqual(
+      providerConnectionState(unknown, false) === "disconnected",
+      false,
+    );
+  });
+
+  it("is never connected when the CLI is missing", () => {
+    for (const auth of ["authenticated", "unauthenticated"] as const) {
+      strictEqual(
+        providerConnectionState(
+          status({ cli_installed: false, auth_state: auth }),
+          false,
+        ),
+        "disconnected",
+      );
+    }
+  });
+
+  it("tests UNKNOWN before the missing-CLI check — unknown is ALWAYS checking", () => {
+    // Precedence, not a detail: the old picker asked "unknown?" first, and a
+    // status whose auth_state is unknown is a status whose every other field is
+    // a guess too. Reporting a confident `disconnected` off `cli_installed:
+    // false` there would resurrect the exact "provider silently vanishes"
+    // behavior the tri-state replaced.
+    strictEqual(
+      providerConnectionState(
+        status({ cli_installed: false, auth_state: "unknown" }),
+        false,
+      ),
+      "checking",
+    );
+  });
+
+  it("maps a missing status to checking only while probing", () => {
+    strictEqual(providerConnectionState(undefined, true), "checking");
+    // Settled with nothing for this provider: degrade, never spin forever.
+    strictEqual(providerConnectionState(undefined, false), "disconnected");
+  });
+
+  it("honors the denormalized boolean only when auth_state is absent", () => {
+    strictEqual(
+      providerConnectionState(
+        { cli_installed: true, authenticated: true },
+        false,
+      ),
+      "connected",
+    );
+    strictEqual(
+      providerConnectionState(
+        { cli_installed: true, authenticated: false },
+        false,
+      ),
+      "disconnected",
+    );
+    // A status carrying both can never disagree with itself: auth_state wins.
+    strictEqual(
+      providerConnectionState(
+        { cli_installed: true, authenticated: true, auth_state: "unknown" },
+        false,
+      ),
+      "checking",
+    );
+  });
+});
+
+describe("the permissive read (tunnel autoreconnect / first-load gate)", () => {
+  it("tolerates an unknown probe, which the connected predicate does not", () => {
+    const unknown = status({ auth_state: "unknown", authenticated: false });
+    strictEqual(providerNotConfirmedDisconnected(unknown), true);
+    strictEqual(providerIsConnected(unknown), false);
+  });
+
+  it("still respects a CONFIRMED signed-out state", () => {
+    strictEqual(
+      providerNotConfirmedDisconnected(
+        status({ auth_state: "unauthenticated", authenticated: false }),
+      ),
+      false,
+    );
+  });
+
+  it("keeps the OLD lenient reading when auth_state is absent", () => {
+    // The predicate this replaced was `cli_installed && auth_state !==
+    // "unauthenticated"`, so a status with NO probe result was never a
+    // confirmation of "signed out". Routing this case through the strict
+    // derivation instead reads the denormalized `authenticated: false` as
+    // disconnected — which would kill the local-model tunnel and degrade the
+    // first-load gate on exactly the statuses that say nothing (HOU-979).
+    strictEqual(
+      providerNotConfirmedDisconnected({
+        cli_installed: true,
+        authenticated: false,
+      }),
+      true,
+    );
+    strictEqual(
+      providerNotConfirmedDisconnected({ cli_installed: true }),
+      true,
+    );
+    // A missing CLI is still a confirmation, exactly as the old predicate read it.
+    strictEqual(
+      providerNotConfirmedDisconnected({
+        cli_installed: false,
+        authenticated: false,
+      }),
+      false,
+    );
+    // And an absent status still confirms nothing to act on.
+    strictEqual(providerNotConfirmedDisconnected(undefined), false);
+  });
+
+  it("is used only where leniency is the safe choice, never for a badge", () => {
+    // Guard against it creeping back into a "Connected" surface. The two
+    // sanctioned consumers are the tunnel auto-reconnect and the first-load
+    // claudeAvailable gate; neither paints a connection badge.
+    for (const file of [
+      "../src/hooks/use-local-bridge-autoreconnect.ts",
+      "../src/hooks/use-houston-init.ts",
+    ]) {
+      strictEqual(
+        read(file).includes("providerNotConfirmedDisconnected"),
+        true,
+        `${file} uses the permissive read`,
+      );
+    }
+    // The hub's badge + the picker mapping must use the strict derivation.
+    strictEqual(
+      read("../src/hooks/use-provider-connections.ts").includes(
+        "providerNotConfirmedDisconnected",
+      ),
+      false,
+      "the hub never uses the permissive read",
+    );
+    strictEqual(
+      read("../src/lib/chat-model-picker-map.ts").includes(
+        "providerConnectionState",
+      ),
+      true,
+      "the picker maps through the shared derivation",
+    );
+  });
+});
+
+describe("reconnect card clear rule", () => {
+  it("clears on a fresh probe that CONFIRMS the provider is connected", () => {
+    strictEqual(reconnectCardShouldClear({ ok: true, status: status() }), true);
+  });
+
+  it("does not clear on a confirmed signed-out probe", () => {
+    strictEqual(
+      reconnectCardShouldClear({
+        ok: true,
+        status: status({ auth_state: "unauthenticated", authenticated: false }),
+      }),
+      false,
+    );
+  });
+
+  it("does not clear on an unknown probe, which confirms nothing", () => {
+    strictEqual(
+      reconnectCardShouldClear({
+        ok: true,
+        status: status({ auth_state: "unknown", authenticated: false }),
+      }),
+      false,
+    );
+  });
+
+  it("does not latch on an errored probe: the NEXT confirming probe still clears", () => {
+    // The reconnect-succeeded-across-an-errored-poll case. A failed probe is
+    // simply skipped; it must not set any sticky state, so the following
+    // confirming probe clears the card exactly as if the error never happened.
+    strictEqual(reconnectCardShouldClear({ ok: false }), false);
+    strictEqual(reconnectCardShouldClear({ ok: true, status: status() }), true);
+  });
+});

--- a/app/tests/provider-grouping.test.ts
+++ b/app/tests/provider-grouping.test.ts
@@ -15,12 +15,14 @@ import {
   providerBilling,
   providerDescriptionKey,
   providerModels,
+  providerOwnedSide,
 } from "../src/components/provider-browser/provider-grouping.ts";
 import type {
   CatalogModel,
   CatalogOffer,
   HubCatalog,
 } from "../src/lib/ai-hub/catalog-types.ts";
+import type { ProviderConnectionState } from "../src/lib/provider-connection.ts";
 import { providerCostLine } from "../src/lib/provider-overrides.ts";
 import type { ProviderInfo } from "../src/lib/providers.ts";
 
@@ -52,19 +54,60 @@ function catalogOf(byProvider: Record<string, CatalogModel[]>): HubCatalog {
 }
 
 describe("groupProviders", () => {
-  it("puts connected first and preserves catalog order within groups", () => {
-    const a = provider("a");
-    const b = provider("b");
-    const c = provider("c");
-    const connectedIds = new Set(["b"]);
-    const groups = groupProviders([a, b, c], (p) => connectedIds.has(p.id));
+  it("splits by connection state and preserves catalog order within groups", () => {
+    const state: Record<string, ProviderConnectionState> = {
+      a: "disconnected",
+      b: "connected",
+      c: "disconnected",
+      d: "checking",
+      e: "connected",
+    };
+    const groups = groupProviders(
+      ["a", "b", "c", "d", "e"].map((id) => provider(id)),
+      (p) => state[p.id] ?? "disconnected",
+    );
     deepStrictEqual(
       groups.connected.map((p) => p.id),
-      ["b"],
+      ["b", "e"],
+    );
+    deepStrictEqual(
+      groups.checking.map((p) => p.id),
+      ["d"],
     );
     deepStrictEqual(
       groups.available.map((p) => p.id),
       ["a", "c"],
+    );
+  });
+
+  // HOU-979: `Available` is the ONLY section whose rows carry a live Connect
+  // button, so an unconfirmable provider must never land there — offering
+  // Connect for an account that may already be signed in is exactly the guess
+  // the tri-state exists to prevent. It rides the "yours" side instead, where
+  // the row renders its own neutral Checking treatment.
+  it("keeps an unconfirmable provider out of Available and on the owned side", () => {
+    const groups = groupProviders([provider("a")], () => "checking");
+    deepStrictEqual(groups.available, []);
+    deepStrictEqual(groups.connected, []);
+    deepStrictEqual(
+      providerOwnedSide(groups).map((p) => p.id),
+      ["a"],
+    );
+  });
+
+  it("never claims an unconfirmable provider is connected", () => {
+    // The owned side is a RENDER order, not a claim: `connected` — the bucket
+    // the green dot and the usage rows read — stays confirmed-only.
+    const groups = groupProviders([provider("a"), provider("b")], (p) =>
+      p.id === "a" ? "connected" : "checking",
+    );
+    deepStrictEqual(
+      groups.connected.map((p) => p.id),
+      ["a"],
+    );
+    deepStrictEqual(
+      providerOwnedSide(groups).map((p) => p.id),
+      ["a", "b"],
     );
   });
 });

--- a/app/tests/provider-reconnect-state.test.ts
+++ b/app/tests/provider-reconnect-state.test.ts
@@ -1,7 +1,6 @@
 import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
-  providerAppearsConnected,
   providerIsAuthenticated,
   providerReconnectSignalState,
   reconnectProviderForChat,
@@ -37,29 +36,12 @@ describe("provider reconnect signal state", () => {
       "resolved",
     );
   });
-
-  it("treats connected only as installed plus authenticated", () => {
-    strictEqual(
-      providerIsAuthenticated({
-        cli_installed: true,
-        auth_state: "authenticated",
-      }),
-      true,
-    );
-    strictEqual(
-      providerIsAuthenticated({
-        cli_installed: false,
-        auth_state: "authenticated",
-      }),
-      false,
-    );
-  });
 });
 
-describe("provider appears connected (settings card)", () => {
+describe("provider is authenticated (the confirmed-connected predicate)", () => {
   it("treats authenticated as connected", () => {
     strictEqual(
-      providerAppearsConnected({
+      providerIsAuthenticated({
         cli_installed: true,
         auth_state: "authenticated",
       }),
@@ -67,16 +49,21 @@ describe("provider appears connected (settings card)", () => {
     );
   });
 
-  it("treats unknown as connected so a working provider keeps its connected state", () => {
+  it("treats unknown as NOT connected (HOU-979)", () => {
+    // Reversed deliberately. The old `providerAppearsConnected` counted an
+    // unconfirmable probe as connected, which is how a team space whose
+    // per-agent probe 404'd kept reporting "Connected" in the AI hub while the
+    // chat picker showed no providers at all. `unknown` is now `checking`
+    // everywhere: never Connected, never silently hidden.
     strictEqual(
-      providerAppearsConnected({ cli_installed: true, auth_state: "unknown" }),
-      true,
+      providerIsAuthenticated({ cli_installed: true, auth_state: "unknown" }),
+      false,
     );
   });
 
   it("treats confirmed unauthenticated as disconnected", () => {
     strictEqual(
-      providerAppearsConnected({
+      providerIsAuthenticated({
         cli_installed: true,
         auth_state: "unauthenticated",
       }),
@@ -86,11 +73,11 @@ describe("provider appears connected (settings card)", () => {
 
   it("is never connected when the CLI is missing", () => {
     strictEqual(
-      providerAppearsConnected({ cli_installed: false, auth_state: "unknown" }),
+      providerIsAuthenticated({ cli_installed: false, auth_state: "unknown" }),
       false,
     );
     strictEqual(
-      providerAppearsConnected({
+      providerIsAuthenticated({
         cli_installed: false,
         auth_state: "authenticated",
       }),

--- a/app/tests/provider-status-cache.test.ts
+++ b/app/tests/provider-status-cache.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  activeProviderStatusScope,
   loadCachedProviderStatuses,
+  providerProbeScopeChanged,
   purgeLegacyProviderStatusCache,
   saveCachedProviderStatuses,
 } from "../src/lib/provider-status-cache.ts";
@@ -25,6 +27,8 @@ function memoryStorage(initial: Record<string, string> = {}) {
 // so the DEFAULT scope resolves to "personal".
 const key = (scope: string) => `houston.providerStatusCache.v2.${scope}`;
 const LEGACY_KEY = "houston.providerStatusCache.v1";
+/** A team space's org slug, in the gateway's `[a-f0-9]{16}` shape. */
+const TEAM_ORG = "00000000000000ab";
 
 const CONNECTED: ProviderStatus = {
   provider: "anthropic",
@@ -124,5 +128,61 @@ test("the scoped default resolves to the personal scope without a window", () =>
   // The default-scope write lands under the personal key.
   assert.deepEqual(JSON.parse(storage.getItem(key("personal")) ?? "null"), {
     anthropic: CONNECTED,
+  });
+});
+
+// HOU-979: a probe describes exactly one space. `providerProbeScopeChanged` is
+// the rule the hub's probe applies when it resolves — the whole result is
+// dropped when the user switched mid-flight, so no cross-space status is ever
+// painted or persisted. Exercised here directly (the decision is pure; the hook
+// only calls it).
+
+/** Run `fn` with the active space pinned to `org` (null ⇒ personal). */
+function inSpace<T>(org: string | null, fn: () => T): T {
+  const previous = (globalThis as { window?: unknown }).window;
+  (
+    globalThis as { window?: { __HOUSTON_ACTIVE_ORG__?: string | null } }
+  ).window = { __HOUSTON_ACTIVE_ORG__: org };
+  try {
+    return fn();
+  } finally {
+    (globalThis as { window?: unknown }).window = previous;
+  }
+}
+
+test("a probe that resolves in the space it started in is kept", () => {
+  inSpace(TEAM_ORG, () => {
+    const startedIn = activeProviderStatusScope();
+    assert.equal(startedIn, TEAM_ORG);
+    // Nothing switched while it was in flight.
+    assert.equal(providerProbeScopeChanged(startedIn), false);
+  });
+});
+
+test("a probe overtaken by a space switch is dropped, both ways", () => {
+  // Started personal, resolved inside a team…
+  const startedPersonal = inSpace(null, activeProviderStatusScope);
+  assert.equal(startedPersonal, "personal");
+  inSpace(TEAM_ORG, () => {
+    assert.equal(providerProbeScopeChanged(startedPersonal), true);
+  });
+
+  // …and the reverse: started in the team, resolved back in personal.
+  const startedInTeam = inSpace(TEAM_ORG, activeProviderStatusScope);
+  inSpace(null, () => {
+    assert.equal(providerProbeScopeChanged(startedInTeam), true);
+  });
+});
+
+test("a dropped probe writes nothing under the space it resolved in", () => {
+  const storage = memoryStorage();
+  // The hub's probe returns EARLY on a changed scope, so the persist below never
+  // runs — the team's key stays empty rather than holding personal statuses.
+  const startedIn = inSpace(null, activeProviderStatusScope);
+  inSpace(TEAM_ORG, () => {
+    if (!providerProbeScopeChanged(startedIn))
+      saveCachedProviderStatuses({ anthropic: CONNECTED }, storage);
+    assert.deepEqual(loadCachedProviderStatuses(storage, TEAM_ORG), {});
+    assert.deepEqual(loadCachedProviderStatuses(storage, "personal"), {});
   });
 });

--- a/app/tests/provider-statuses-gate.test.ts
+++ b/app/tests/provider-statuses-gate.test.ts
@@ -1,0 +1,150 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import {
+  providerProbeReady,
+  providerStatusesLoading,
+  providerStatusesQueryKey,
+} from "../src/lib/provider-statuses-query.ts";
+
+/**
+ * HOU-979 — the CHAT PICKER's status query must be as space-safe as the AI
+ * hub's, which the HOU-906 space fix only reached.
+ *
+ * Symptom it closes: switching into a team space wiped the query cache, which
+ * refired this query while the engine adapter still held the PREVIOUS space's
+ * agents. The per-agent probe 404'd under the new org header, every provider
+ * came back `unknown`, and the picker rendered no providers at all until the
+ * next `ProviderLoginComplete`.
+ */
+
+const read = (relativePath: string) =>
+  readFileSync(new URL(relativePath, import.meta.url), "utf8");
+
+describe("the probe gate", () => {
+  it("is closed until the agent list has settled at least once", () => {
+    strictEqual(providerProbeReady({ loaded: false, loading: false }), false);
+    strictEqual(providerProbeReady({ loaded: false, loading: true }), false);
+  });
+
+  it("is closed while a RE-load runs, which is the space-switch window", () => {
+    // `loaded` stays true across a switch while `loadAgents` re-runs for the new
+    // space. Gating on `loaded` alone would leave exactly the window the
+    // misrouted probe fired in open.
+    strictEqual(providerProbeReady({ loaded: true, loading: true }), false);
+  });
+
+  it("is open once the current space's agents are settled", () => {
+    strictEqual(providerProbeReady({ loaded: true, loading: false }), true);
+  });
+});
+
+describe("the query key", () => {
+  it("separates spaces so one space never serves another's statuses", () => {
+    const base = ["provider-statuses", "anthropic"];
+    const personal = providerStatusesQueryKey({
+      base,
+      catalogUpdatedAt: 7,
+      workspaceId: "personal",
+    });
+    const team = providerStatusesQueryKey({
+      base,
+      catalogUpdatedAt: 7,
+      workspaceId: "org:00000000000000ab",
+    });
+    deepStrictEqual(personal, [
+      "provider-statuses",
+      "anthropic",
+      7,
+      "personal",
+    ]);
+    strictEqual(JSON.stringify(personal) === JSON.stringify(team), false);
+  });
+
+  it("still re-keys on the catalog hydration", () => {
+    const base = ["provider-statuses"];
+    const before = providerStatusesQueryKey({
+      base,
+      catalogUpdatedAt: 0,
+      workspaceId: null,
+    });
+    const after = providerStatusesQueryKey({
+      base,
+      catalogUpdatedAt: 1,
+      workspaceId: null,
+    });
+    strictEqual(JSON.stringify(before) === JSON.stringify(after), false);
+  });
+});
+
+describe("the loading signal the picker reads", () => {
+  it("reports checking while the gate is closed, not 'settled with nothing'", () => {
+    // The trap: a DISABLED TanStack query is pending but not fetching, so
+    // `isLoading` is false. Reading it raw would tell the picker statuses had
+    // settled empty, which filters every provider out and paints the honest
+    // "no providers connected" empty state at the exact moment we know nothing.
+    strictEqual(
+      providerStatusesLoading({
+        hasData: false,
+        queryIsLoading: false,
+        probeReady: false,
+      }),
+      true,
+    );
+  });
+
+  it("reports checking while the first fetch is in flight", () => {
+    strictEqual(
+      providerStatusesLoading({
+        hasData: false,
+        queryIsLoading: true,
+        probeReady: true,
+      }),
+      true,
+    );
+  });
+
+  it("stops checking once data has arrived, even mid-refetch", () => {
+    strictEqual(
+      providerStatusesLoading({
+        hasData: true,
+        queryIsLoading: true,
+        probeReady: false,
+      }),
+      false,
+    );
+  });
+
+  it("reports settled once the gate is open and the fetch resolved", () => {
+    strictEqual(
+      providerStatusesLoading({
+        hasData: false,
+        queryIsLoading: false,
+        probeReady: true,
+      }),
+      false,
+    );
+  });
+});
+
+describe("the picker hook is actually wired to the gate", () => {
+  const hook = read("../src/hooks/use-provider-statuses.ts");
+
+  it("keys the query by the active workspace and gates the fetch", () => {
+    strictEqual(hook.includes("providerStatusesQueryKey"), true);
+    strictEqual(hook.includes("useWorkspaceStore"), true);
+    strictEqual(hook.includes("providerProbeReady"), true);
+    strictEqual(hook.includes("enabled: probeReady"), true);
+    strictEqual(hook.includes("providerStatusesLoading"), true);
+  });
+
+  it("reads the SAME agent-store signals the AI hub's sibling hook gates on", () => {
+    const hub = read(
+      "../src/hooks/provider-connections/use-provider-statuses.ts",
+    );
+    for (const signal of ["s.loaded", "s.loading"]) {
+      strictEqual(hook.includes(signal), true, `picker reads ${signal}`);
+      strictEqual(hub.includes(signal), true, `hub reads ${signal}`);
+    }
+  });
+});

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -414,6 +414,81 @@ per team, each `{ id: "org:" + slug, kind: "org" }` where `slug` is `[a-f0-9]{16
   re-probes on a workspace-id change, gating the live probe on the new space's
   agents having loaded (the probe routes per-agent, so it must not fire at the old
   agent under the new org header). The old un-scoped `.v1` key is orphaned + purged.
+  A probe now also pins `activeProviderStatusScope()` when it STARTS and discards
+  its result if the space changed mid-flight, so a personal probe that resolves
+  after a switch can neither paint nor persist under the team's key (HOU-979).
+- **Provider ROUTING is space-validated, and refuses rather than guesses**
+  (HOU-979, `packages/web/src/engine-adapter/client/provider-routing.ts`). Every
+  provider connect/probe goes to a specific agent's runtime; the only space-aware
+  source for that id is the adapter's `agentList` (the CURRENT space's last
+  `listAgents`). The persisted `last_agent_id` pref is NOT space-aware, so the
+  three formerly independent sources (`providerAgentId()`, the raw-pref
+  `requireAgentId()`, and the agent STORE read in `claude-login-remote.ts`)
+  collapsed onto one: `requireProviderAgentId(ctx)`. Before the list settles,
+  writes throw "This space is still loading", the status probe returns `unknown`
+  with NO request, and the Claude credential push degrades to the setup runtime
+  (space-correct: same central store, same org header). `requireAgentId()` stays
+  for routes that genuinely mean the agent the user has OPEN (project files,
+  per-agent prefs).
+  **`agentList` is a THREE-state machine (`context.ts`), not a nullable list** —
+  the distinction is what keeps the guard both effective and non-bricking:
+  - `pending` — no list for THIS space yet. Writes refuse, the probe skips.
+    **`setActiveOrg` resets to `pending` on a real slug change**, so the guard is
+    not first-boot-only: a Connect clicked mid-switch used to route at the space
+    just left. Re-pinning the SAME slug (the client rebuild / bearer rotation in
+    `lib/engine.ts`) is a no-op.
+  - `unavailable` — a list was asked for and could not be had: `listAgents`
+    threw (`agents-mixin` notes it, then rethrows so the failure still surfaces),
+    or boot resolved no workspace to list agents for and the app called
+    `client.noteAgentsUnavailable()`. Routing degrades to the pre-HOU-979
+    pref-based path so connect + the picker keep working. Never downgrades a list
+    we already have; a later successful `listAgents` restores strict validation.
+  - `known` — the space's own ids; the pref is validated against them.
+
+  `GET /v1/catalog` deliberately does NOT send `x-houston-org`: the gateway's
+  catalog handler ignores the request entirely (one global snapshot,
+  `cloud/internal/edge/catalog.go`), so the header buys nothing and newly exposes
+  a 403 from `ResolveOrg` on a stale slug — which would pin the picker at
+  "Loading providers…" forever through `useProviderCatalog`'s `isSuccess` gate.
+- **One provider-connection derivation** (`app/src/lib/provider-connection.ts`,
+  HOU-979). `unknown` used to mean opposite things per surface: invisible to the
+  chat picker's catalog, "Connected" to the AI hub's badge, "card never clears"
+  to the in-chat reconnect card. It is now the third state, `checking`,
+  everywhere — never Connected, never silently hidden. `unknown` is tested FIRST,
+  ahead of the missing-CLI check: an unconfirmable probe is ALWAYS `checking`.
+  `providerIsConnected` is the ONLY connected predicate (badges, analytics
+  transitions); `providerNotConfirmedDisconnected` is the permissive read,
+  sanctioned ONLY for the tunnel auto-reconnect and the first-load
+  `claudeAvailable` gate, never for a badge — and it keeps the OLD lenient
+  reading when `auth_state` is absent (`cli_installed`), which the strict
+  derivation deliberately does not. The chat picker's
+  `hooks/use-provider-statuses.ts` carries the same agents-settled gate +
+  a workspace-scoped query key as the hub's sibling hook
+  (`lib/provider-statuses-query.ts` holds the pure rules).
+  **The connections layer exposes ONE reader, `connectionState`** — no boolean
+  sibling, because every surface that reached for one collapsed the third state.
+  `groupProviders` returns three buckets (`connected` / `checking` /
+  `available`): only `connected` may claim Connected (the hub's strip dot, the
+  Usage page's account rows), only `available` gets a Connect CTA, and
+  `providerOwnedSide()` is the render order the browse surfaces use.
+- **A team space with no credential explains itself.** When statuses settle with
+  nothing connected, the picker's level 1 shows an honest empty state instead of
+  a blank panel: `personal` / `teamCanConnect` / `teamAskAdmin`
+  (`app/src/components/chat-model-selector-labels.ts`, copy under
+  `chat:modelSelector.picker.noProviders.*`). A plain member gets no CTA and no
+  "Connect more providers…" footer at all — provider connections are org-level,
+  so `canSeeAiModelsPage` is false for them and the hub would dead-end. The
+  decision is gated on capabilities having LOADED (`canSeeAiModelsPage` answers
+  TRUE for absent capabilities, which flashed a CTA at a member and withdrew it);
+  `use-picker-view-models` folds the same signal into `catalogState`, so the
+  picker holds its neutral loading state through that window.
+- **Boot with NO space settles honestly** (HOU-979). If `loadWorkspaces` fails
+  (or yields no current workspace) `loadAgents` never runs, and every `loaded`
+  gate hung: the boot splash never lifted and the provider probe never fired.
+  `useHoustonInit` now calls the agent store's `settleEmpty()`, which settles the
+  store AND tells the client `noteAgentsUnavailable()`. The failure itself is
+  already surfaced by `lib/tauri.ts`'s `call()` (toast + Sentry) and recorded as
+  the workspace store's `loadError` for the Settings retry.
 - **Restore last space**: `resolveActiveWorkspace` (`app/src/lib/workspace-switch.ts`)
   restores the persisted `last_workspace_id`, else default, else first.
 

--- a/packages/web/src/engine-adapter/client/agents-mixin.ts
+++ b/packages/web/src/engine-adapter/client/agents-mixin.ts
@@ -16,7 +16,19 @@ export function AgentsMixin<TBase extends BaseCtor>(Base: TBase) {
   class Agents extends Base {
     async listAgents(workspaceId: string): Promise<Agent[]> {
       if (this.ctx.cp) {
-        const list = await controlPlane.listAgents(this.ctx.cp);
+        let list: Agent[];
+        try {
+          list = await controlPlane.listAgents(this.ctx.cp);
+        } catch (e) {
+          // A FAILED list is not "not loaded yet" (HOU-979). Left as the latter
+          // it never resolves, so the provider probe skipped itself forever
+          // (a permanent "Loading providers…") and every connect / sign-out
+          // threw "still loading" with no way back. Record that no list is
+          // coming so provider routing degrades to the pref-based path, and
+          // rethrow — the caller still surfaces the failure.
+          this.ctx.noteAgentsUnavailable();
+          throw e;
+        }
         // CP agent ids are global (the list ignores workspaceId), so this list is
         // the full truth the selection pref must exist in. Pruning here heals a
         // stale pref at boot, before the first-run connect surface mounts; the

--- a/packages/web/src/engine-adapter/client/base.ts
+++ b/packages/web/src/engine-adapter/client/base.ts
@@ -45,6 +45,20 @@ export class HoustonClientBase {
   }
 
   /**
+   * Tell the client the active space's agent list is NOT coming — boot resolved
+   * no workspace to list agents for (the workspace load failed, or the account
+   * has none), so `listAgents` is never called.
+   *
+   * Without it, provider routing waits on a list that can never arrive: every
+   * connect throws "still loading" and the probe skips itself, so the picker and
+   * the AI hub spin forever. This settles them onto the pref-based path
+   * (HOU-979). A later successful `listAgents` supersedes it.
+   */
+  noteAgentsUnavailable(): void {
+    this.ctx.noteAgentsUnavailable();
+  }
+
+  /**
    * Point this client at a new engine endpoint in place. The desktop shell
    * calls this whenever a config lands on an already-built client: the
    * sidecar restarting on a fresh random port (HOU-432), and every hosted

--- a/packages/web/src/engine-adapter/client/context.ts
+++ b/packages/web/src/engine-adapter/client/context.ts
@@ -33,6 +33,29 @@ export interface HoustonClientOptions {
 export const LAST_AGENT_PREF = "houston.pref.last_agent_id";
 
 /**
+ * What the client knows about the ACTIVE SPACE's agents — the only
+ * space-validated source for routing provider calls (HOU-979).
+ *
+ * Three states, not two, because "we have no list" hides two opposite
+ * situations and collapsing them produced two separate bugs:
+ *
+ *  - `pending` — no list has resolved for THIS space yet (boot, or the window
+ *    right after a space switch). The persisted `last_agent_id` still names the
+ *    space the user just LEFT, so there is nothing safe to route on: provider
+ *    calls refuse and the probe reports "checking".
+ *  - `unavailable` — a list was asked for and could not be had (the request
+ *    failed, or boot resolved no workspace to list agents for). Waiting forever
+ *    on a list that is not coming bricks connect + the picker, so this degrades
+ *    to the pre-HOU-979 behavior: route on the pref, probe for real. A later
+ *    successful list upgrades back to `known` and strict validation returns.
+ *  - `known` — the space's own agent ids. The pref is validated against them.
+ */
+export type AgentListState =
+  | { readonly kind: "pending" }
+  | { readonly kind: "unavailable" }
+  | { readonly kind: "known"; readonly ids: readonly string[] };
+
+/**
  * The single, shared state + routing seam behind `HoustonClient`. Every method
  * cluster (the mixins under `client/`) reads `cp`/`engine`/`sdk` from the ONE
  * `AdapterContext` — no per-cluster copy. `cp` is a getter over a privately-held
@@ -145,9 +168,20 @@ export class AdapterContext {
    * live `ControlPlaneConfig` in place — shared by every per-request fetch and
    * the long-lived per-agent runtime clients (whose auth-fetch re-reads it per
    * attempt) — so a switch takes effect at once. No-op off-cloud (`_cp === null`).
+   *
+   * A REAL space change also invalidates {@link agentList} (HOU-979): the ids it
+   * holds belong to the space being left, and every one of them 404s under the
+   * new `x-houston-org`. Without this the guard was first-boot-only — a Connect
+   * clicked mid-switch still routed at the previous space's agent. Back to
+   * `pending` means provider calls refuse (and the probe reports "checking")
+   * until the new space's `listAgents` lands. Re-pinning the SAME slug (the
+   * client rebuild in `lib/engine.ts`, a same-space reselect) changes nothing.
    */
   setActiveOrg(slug: string | null): void {
-    if (this._cp) this._cp.activeOrgSlug = slug;
+    if (!this._cp) return;
+    if ((this._cp.activeOrgSlug ?? null) === (slug ?? null)) return;
+    this._cp.activeOrgSlug = slug;
+    this._agentList = { kind: "pending" };
   }
 
   /** The CP agent the user has selected (persisted as last_agent_id), or null. */
@@ -160,16 +194,34 @@ export class AdapterContext {
     }
   }
 
-  /**
-   * The control plane's agent ids as of the last `listAgents`, in list order;
-   * `null` until a list has resolved. Ground truth for
-   * {@link providerAgentId}: the pref can go stale, this cannot.
-   */
-  knownAgentIds: string[] | null = null;
+  private _agentList: AgentListState = { kind: "pending" };
 
-  /** Record the live agent-id set (called by every cp `listAgents`). */
+  /**
+   * What we know about the ACTIVE space's agents. Ground truth for
+   * {@link providerAgentId} and for `provider-routing.ts` — the pref can go
+   * stale, a resolved list cannot.
+   */
+  get agentList(): AgentListState {
+    return this._agentList;
+  }
+
+  /** Record the live agent-id set (called by every successful cp `listAgents`). */
   noteAgentList(ids: string[]): void {
-    this.knownAgentIds = ids;
+    this._agentList = { kind: "known", ids };
+  }
+
+  /**
+   * Record that the active space's agent list could NOT be obtained — a failed
+   * `listAgents`, or a boot that resolved no workspace to list agents for.
+   *
+   * Never downgrades a list we already have: a background refresh failing is
+   * not a reason to drop validation we can still do. It only converts the
+   * "nothing yet" state into "nothing is coming", which is what lets provider
+   * calls degrade to the pref instead of refusing forever.
+   */
+  noteAgentsUnavailable(): void {
+    if (this._agentList.kind === "pending")
+      this._agentList = { kind: "unavailable" };
   }
 
   /**
@@ -184,14 +236,18 @@ export class AdapterContext {
    *      provision + a lingering Deployment);
    *   3. else `null` → the hidden setup runtime (true first-run, zero agents).
    *
-   * Before the first list resolves the pref is trusted as-is (boot prunes a
-   * stale pref via `dropLastAgentPref` right when the list lands).
+   * With no `known` list there is nothing to validate against, so this falls
+   * back to the raw pref. That is only safe once the list is known NOT to be
+   * coming (`unavailable`); while it is still `pending`, provider callers must
+   * not route at all — see `provider-routing.ts`, which refuses rather than
+   * trust a pref that may still name the space the user just left.
    */
   providerAgentId(): string | null {
     const id = this.currentAgentId();
-    if (this.knownAgentIds === null) return id;
-    if (id && this.knownAgentIds.includes(id)) return id;
-    return this.knownAgentIds[0] ?? null;
+    const list = this._agentList;
+    if (list.kind !== "known") return id;
+    if (id && list.ids.includes(id)) return id;
+    return list.ids[0] ?? null;
   }
 
   /**
@@ -209,7 +265,11 @@ export class AdapterContext {
     }
   }
 
-  /** The selected agent id, or a user-facing error if none is open. */
+  /**
+   * The SELECTED agent id, or a user-facing error if none is open. For routes
+   * that genuinely mean "the agent the user has open" (project files, per-agent
+   * prefs), where falling back to another agent would touch the wrong data.
+   */
   requireAgentId(): string {
     const id = this.currentAgentId();
     if (!id) throw new Error("Open an agent first, then connect its account.");

--- a/packages/web/src/engine-adapter/client/provider-claude-push.ts
+++ b/packages/web/src/engine-adapter/client/provider-claude-push.ts
@@ -1,0 +1,40 @@
+import {
+  pushClaudeOAuthCredential,
+  pushSetupClaudeOAuthCredential,
+} from "../control-plane";
+import type { AdapterContext } from "./context";
+import { providerRoutingSettled } from "./provider-routing";
+
+/**
+ * Push a desktop-extracted Anthropic OAuth credential (the `claude` CLI's
+ * `.credentials.json` JSON) to the ACTIVE SPACE's agent pod, which stores and
+ * materializes it on the PVC.
+ *
+ * The desktop calls this for a REMOTE engine after a successful browser login —
+ * the pod can't read this machine's Keychain. Cloud-only: a co-located engine
+ * shares the credential dir with its local runtime, so it never reaches here (a
+ * call without a control plane is a programming error).
+ *
+ * TARGET RESOLUTION (HOU-979). The agent is resolved HERE, from the one
+ * space-validated accessor. The caller used to pass it in, read straight off the
+ * agent STORE — a third, unsynchronized source of the routing id that could name
+ * the previous space's agent right after a switch. With no agent in this space
+ * (first-run onboarding, the cloud-migration wizard) OR with the space's agent
+ * list not yet settled, the push goes to the hidden SETUP runtime instead: the
+ * same central store under the same `x-houston-org`, so it is always
+ * space-correct, and the agents created or migrated next are already connected.
+ * A guess at a specific agent is the one thing that is never acceptable.
+ */
+export async function pushClaudeCredential(
+  ctx: AdapterContext,
+  credentialJson: string,
+): Promise<void> {
+  const cp = ctx.cp;
+  if (!cp) throw new Error("Pushing a Claude credential needs a cloud engine.");
+  const agentId = providerRoutingSettled(ctx) ? ctx.providerAgentId() : null;
+  if (agentId) {
+    await pushClaudeOAuthCredential(cp, agentId, credentialJson);
+    return;
+  }
+  await pushSetupClaudeOAuthCredential(cp, credentialJson);
+}

--- a/packages/web/src/engine-adapter/client/provider-credentials-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-credentials-mixin.ts
@@ -5,6 +5,11 @@ import * as controlPlane from "../control-plane";
 import { credentialSiblings, toNewProvider } from "../synthetic";
 import { isHoustonEngineError } from "./errors";
 import type { BaseCtor } from "./mixin";
+import { pushClaudeCredential } from "./provider-claude-push";
+import {
+  requireProviderAgentId,
+  requireProviderRouting,
+} from "./provider-routing";
 
 export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
   class ProviderCredentials extends Base {
@@ -22,7 +27,10 @@ export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
         // before every turn — so the next message re-hydrated the agent and the
         // provider showed connected again. Forget the central credential FIRST so
         // no in-flight turn can re-serve it, then clear the runtime's local copy.
-        const agentId = this.ctx.requireAgentId();
+        // SPACE-VALIDATED id (HOU-979): the raw pref can still name the
+        // previous space's agent, and forgetting a credential through a foreign
+        // agent's route is a cross-space write.
+        const agentId = requireProviderAgentId(this.ctx);
         for (const target of targets) {
           await controlPlane.forgetCredential(this.ctx.cp, agentId, target);
           await controlPlane
@@ -37,35 +45,12 @@ export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
     }
 
     /**
-     * Push a desktop-extracted Anthropic OAuth credential (the `claude` CLI's
-     * `.credentials.json` JSON) to the given agent's pod, which stores + materializes
-     * it on the PVC. With NO agent selected yet (first-run onboarding, the
-     * cloud-migration wizard) it goes to the hidden SETUP runtime instead —
-     * same central store, so the agents created or migrated after are already
-     * connected. The desktop calls this for a REMOTE engine after a successful
-     * browser login — the pod can't read this machine's Keychain. Cloud-only:
-     * a co-located engine shares the credential dir with its local runtime, so it
-     * never reaches here (a call without a control plane is a programming error).
+     * Push a desktop-extracted Anthropic OAuth credential to this space's pod
+     * (or, with no settled agent, its setup runtime). See `provider-claude-push`
+     * for the target-resolution rule.
      */
-    async pushClaudeOAuthCredential(
-      agentId: string | null,
-      credentialJson: string,
-    ): Promise<void> {
-      if (!this.ctx.cp) {
-        throw new Error("Pushing a Claude credential needs a cloud engine.");
-      }
-      if (agentId) {
-        await controlPlane.pushClaudeOAuthCredential(
-          this.ctx.cp,
-          agentId,
-          credentialJson,
-        );
-        return;
-      }
-      await controlPlane.pushSetupClaudeOAuthCredential(
-        this.ctx.cp,
-        credentialJson,
-      );
+    async pushClaudeOAuthCredential(credentialJson: string): Promise<void> {
+      await pushClaudeCredential(this.ctx, credentialJson);
     }
 
     /**
@@ -85,9 +70,12 @@ export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
       // that becomes active; the order of the writes doesn't affect that.
       const targets = credentialSiblings(pid);
       if (this.ctx.cp) {
+        // Refuse rather than guess: an unsettled list leaves only the raw pref,
+        // which after a switch names the PREVIOUS space's agent (HOU-979).
+        requireProviderRouting(this.ctx);
         // First-run pre-agent: store through the setup runtime instead — the key
-        // lands on the personal workspace and the agent created next reads it.
-        // No per-agent settings exist yet to flip.
+        // lands on this space's central store and the agent created next reads
+        // it. No per-agent settings exist yet to flip.
         const agentId = this.ctx.providerAgentId();
         if (!agentId) {
           for (const target of targets) {
@@ -140,7 +128,8 @@ export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
      */
     async setProviderCustomEndpoint(endpoint: CustomEndpoint): Promise<void> {
       if (this.ctx.cp) {
-        const agentId = this.ctx.requireAgentId();
+        // Space-validated, like every other provider write (HOU-979).
+        const agentId = requireProviderAgentId(this.ctx);
         await controlPlane.setCustomEndpoint(this.ctx.cp, agentId, endpoint);
         await controlPlane
           .runtimeClientFor(this.ctx.cp, agentId)

--- a/packages/web/src/engine-adapter/client/provider-login-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-login-mixin.ts
@@ -11,6 +11,7 @@ import {
   stopLoginWatch,
   watchLoginCompletion,
 } from "./provider-login-poll";
+import { requireProviderRouting } from "./provider-routing";
 
 /**
  * Surface a login-launch failure the runtime tagged with a stable `kind` (today:
@@ -117,6 +118,10 @@ export function ProviderLoginMixin<TBase extends BaseCtor>(Base: TBase) {
       // `user_code`, which opens the code panel); a co-located desktop client gets
       // a loopback `url` (user_code null) that the handler opens straight in the
       // browser. `provider` MUST be the old/frontend id (the dialog's contract).
+      // Refuse before the space's agent list has settled (HOU-979): the only
+      // other candidate is the raw pref, which after a switch names the PREVIOUS
+      // space's agent — the login would run in that space's pod.
+      requireProviderRouting(this.ctx);
       const agentId = this.ctx.providerAgentId();
       const old = toOldProvider(pid);
       const engine = agentId

--- a/packages/web/src/engine-adapter/client/provider-routing.ts
+++ b/packages/web/src/engine-adapter/client/provider-routing.ts
@@ -1,0 +1,55 @@
+import type { AdapterContext } from "./context";
+
+/**
+ * The space-safety rules for routing PROVIDER calls (HOU-979).
+ *
+ * Cloud routes provider connects and probes at a specific agent's runtime, and
+ * the ONLY space-validated source for that id is `ctx.agentList` — the set the
+ * CURRENT space's last `listAgents` returned (cleared by `setActiveOrg` the
+ * moment the space changes). The persisted `last_agent_id` pref is not
+ * space-aware: right after a space switch it still names an agent that belongs
+ * to the space the user just left, so routing on it produces
+ * `/v1/agents/<other-space-agent>/…` under the NEW `x-houston-org` header. That
+ * 404/403 is what surfaced as "the chat picker shows no providers", "the
+ * reconnect card never clears", and "the AI hub still says Connected".
+ *
+ * So: one accessor, and an explicit refusal instead of a guess. Free functions
+ * over the context (like `provider-login-poll` / `provider-claude-push`) rather
+ * than more methods on it, so this whole concern reads in one place.
+ *
+ * Strictness applies ONLY while a list is still expected. A list that was asked
+ * for and could not be had (`unavailable`) must not brick the app: refusing
+ * forever left the picker pinned on "Loading providers…" and every connect
+ * throwing "still loading", with no retry. There the client degrades to the
+ * pre-HOU-979 pref-based routing, and the next successful list restores strict
+ * validation.
+ */
+
+/**
+ * Whether provider calls can be routed at all yet. Always true off-cloud: one
+ * local runtime, nothing to pick.
+ */
+export function providerRoutingSettled(ctx: AdapterContext): boolean {
+  return !ctx.cp || ctx.agentList.kind !== "pending";
+}
+
+/** Refuse a provider call rather than guess its target. */
+export function requireProviderRouting(ctx: AdapterContext): void {
+  if (providerRoutingSettled(ctx)) return;
+  throw new Error(
+    "This space is still loading. Try connecting again in a moment.",
+  );
+}
+
+/**
+ * The agent id every provider WRITE must target: the space-validated
+ * `ctx.providerAgentId()`, never the raw pref. `ctx.requireAgentId()` is
+ * deliberately not this — it means "the agent the user has open", for routes
+ * (project files, per-agent prefs) where another agent would be the wrong data.
+ */
+export function requireProviderAgentId(ctx: AdapterContext): string {
+  requireProviderRouting(ctx);
+  const id = ctx.providerAgentId();
+  if (!id) throw new Error("Open an agent first, then connect its account.");
+  return id;
+}

--- a/packages/web/src/engine-adapter/client/provider-status-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-status-mixin.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../../../../ui/engine-client/src/types";
 import { toNewProvider } from "../synthetic";
 import type { BaseCtor } from "./mixin";
+import { providerRoutingSettled } from "./provider-routing";
 
 export function ProviderStatusMixin<TBase extends BaseCtor>(Base: TBase) {
   // Internal label only (the exported factory is the contract). Named to avoid
@@ -38,10 +39,19 @@ export function ProviderStatusMixin<TBase extends BaseCtor>(Base: TBase) {
       // auto-reconnect, for connections that are still registered server-side.
       let reachable = false;
       try {
-        const engine = this.ctx.providerEngine();
-        if (engine) {
-          for (const p of await engine.listProviders()) byId.set(p.id, p);
-          reachable = true;
+        // Do NOT probe before the active space's agent list has settled
+        // (HOU-979). The probe routes per-agent, so the only id available then
+        // is the raw pref — which right after a space switch still names the
+        // PREVIOUS space's agent. Asking `/v1/agents/<other-space-agent>/…`
+        // under the new `x-houston-org` 404s, and the catch below would report
+        // "unknown" anyway; skipping the request reaches the same honest
+        // "checking" answer without a cross-space call.
+        if (providerRoutingSettled(this.ctx)) {
+          const engine = this.ctx.providerEngine();
+          if (engine) {
+            for (const p of await engine.listProviders()) byId.set(p.id, p);
+            reachable = true;
+          }
         }
       } catch {
         /* engine unreachable → every card reports "unknown" below */

--- a/packages/web/tests/provider-space-routing.test.ts
+++ b/packages/web/tests/provider-space-routing.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+/**
+ * HOU-979 — provider calls must be routed at the ACTIVE SPACE's agent, or not
+ * routed at all.
+ *
+ * Provider connects and probes go to a specific agent's runtime. The only
+ * space-validated source for that id is the client's `agentList`, the set the
+ * CURRENT space's last `listAgents` returned; the persisted `last_agent_id` pref
+ * is not space-aware, so right after a switch it still names the PREVIOUS
+ * space's agent. Routing on it produces `/v1/agents/<other-space-agent>/…` under
+ * the new `x-houston-org` — a 404/403 that surfaced as "no providers in the
+ * picker" and a reconnect card that never cleared.
+ *
+ * These tests pin the rules that close it:
+ *   1. an unsettled agent list makes the PROBE report "unknown" (checking) with
+ *      no cross-space request at all;
+ *   2. an unsettled agent list makes every provider WRITE refuse rather than
+ *      guess;
+ *   3. once settled, the id used is the validated one — the stale pref is
+ *      ignored in favor of the space's own agent;
+ *   4. SWITCHING SPACES un-settles it again, so the guard is not first-boot-only
+ *      (a Connect clicked mid-switch used to route at the space just left); and
+ *   5. strictness applies only while a list is still EXPECTED — a list that
+ *      failed, or one that will never be asked for, degrades to the pref-based
+ *      routing instead of bricking connect + the picker forever.
+ */
+
+const { listProviders, cpListAgents, forgetCredential, runtimeLogout } =
+  vi.hoisted(() => ({
+    listProviders: vi.fn(),
+    cpListAgents: vi.fn(),
+    forgetCredential: vi.fn(),
+    runtimeLogout: vi.fn(),
+  }));
+
+vi.mock("../src/engine-adapter/control-plane", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../src/engine-adapter/control-plane")
+    >();
+  return {
+    ...actual,
+    listAgents: cpListAgents,
+    forgetCredential,
+    runtimeClientFor: vi.fn(() => ({
+      listProviders,
+      logout: runtimeLogout,
+    })),
+  };
+});
+
+import { HoustonClient } from "../src/engine-adapter/client";
+
+const PREF = "houston.pref.last_agent_id";
+
+/** The agent the user last selected — in the space they have just LEFT. */
+const STALE_PREF_AGENT = "agent-from-the-other-space";
+/** The only agent the space we are now in actually has. */
+const THIS_SPACE_AGENT = "agent-in-this-space";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  const store = new Map<string, string>([[PREF, STALE_PREF_AGENT]]);
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
+  listProviders
+    .mockReset()
+    .mockResolvedValue([{ id: "anthropic", configured: true }]);
+  cpListAgents.mockReset().mockResolvedValue([{ id: THIS_SPACE_AGENT }]);
+  forgetCredential.mockReset().mockResolvedValue(undefined);
+  runtimeLogout.mockReset().mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+function client() {
+  return new HoustonClient({
+    baseUrl: "http://gateway",
+    token: "t",
+    controlPlane: true,
+  });
+}
+
+test("the probe reports UNKNOWN, and makes no request, before the space's agents settle", async () => {
+  const statuses = await client().providerStatuses(["anthropic"]);
+
+  // "checking", not a fabricated answer either way…
+  expect(statuses.map((s) => s.authState)).toEqual(["unknown"]);
+  // …and, crucially, nothing was asked of the previous space's agent.
+  expect(listProviders).not.toHaveBeenCalled();
+});
+
+test("the probe runs once the space's agents have settled", async () => {
+  const c = client();
+  await c.listAgents("ws");
+
+  const statuses = await c.providerStatuses(["anthropic"]);
+
+  expect(statuses.map((s) => s.authState)).toEqual(["authenticated"]);
+  expect(listProviders).toHaveBeenCalledTimes(1);
+});
+
+test("a provider WRITE refuses before the space's agents settle, rather than guessing", async () => {
+  await expect(client().providerLogout("anthropic")).rejects.toThrow(
+    /still loading/i,
+  );
+  expect(forgetCredential).not.toHaveBeenCalled();
+
+  await expect(
+    client().setProviderApiKey("opencode", "sk-test"),
+  ).rejects.toThrow(/still loading/i);
+
+  await expect(client().providerLogin("anthropic")).rejects.toThrow(
+    /still loading/i,
+  );
+});
+
+test("a settled write targets the SPACE's agent, never the stale pref", async () => {
+  const c = client();
+  await c.listAgents("ws");
+
+  await c.providerLogout("anthropic");
+
+  // `listAgents` prunes the pref (it names an agent this space doesn't have),
+  // and the write routes at the space's own agent.
+  expect(localStorage.getItem(PREF)).toBeNull();
+  for (const call of forgetCredential.mock.calls) {
+    expect(call[1]).toBe(THIS_SPACE_AGENT);
+  }
+  expect(forgetCredential).toHaveBeenCalled();
+});
+
+// ---------------------------------------------------------------------------
+// (4) A SPACE SWITCH un-settles routing again.
+//
+// The guard read "have we ever loaded a list?", and nothing ever cleared that
+// list — so it only ever protected the first boot. Click Connect during a
+// switch and the write still went to the space the user had just left, under
+// the NEW org header.
+// ---------------------------------------------------------------------------
+
+const ORG_A = "00000000000000aa";
+const ORG_B = "00000000000000bb";
+/** The agent that exists in space A — and NOT in space B. */
+const AGENT_IN_A = "agent-in-space-a";
+/** The agent space B has. */
+const AGENT_IN_B = "agent-in-space-b";
+
+test("switching spaces un-settles routing until the NEW space's list lands", async () => {
+  const c = client();
+
+  // In space A, with A's list loaded: routing is settled and writes work.
+  c.setActiveOrg(ORG_A);
+  cpListAgents.mockResolvedValue([{ id: AGENT_IN_A }]);
+  await c.listAgents("ws");
+  expect((await c.providerStatuses(["anthropic"]))[0].authState).toBe(
+    "authenticated",
+  );
+
+  // The user switches to space B. B's `listAgents` has not resolved yet, and
+  // the only id we hold belongs to A.
+  c.setActiveOrg(ORG_B);
+  listProviders.mockClear();
+
+  // The probe reports "checking" and asks NOTHING of A's agent…
+  const midSwitch = await c.providerStatuses(["anthropic"]);
+  expect(midSwitch.map((s) => s.authState)).toEqual(["unknown"]);
+  expect(listProviders).not.toHaveBeenCalled();
+
+  // …and a Connect clicked right now refuses instead of writing into A.
+  forgetCredential.mockClear();
+  await expect(c.providerLogout("anthropic")).rejects.toThrow(/still loading/i);
+  expect(forgetCredential).not.toHaveBeenCalled();
+
+  // Once B's list lands, routing settles again — at B's OWN agent.
+  cpListAgents.mockResolvedValue([{ id: AGENT_IN_B }]);
+  await c.listAgents("ws");
+  expect((await c.providerStatuses(["anthropic"]))[0].authState).toBe(
+    "authenticated",
+  );
+  await c.providerLogout("anthropic");
+  for (const call of forgetCredential.mock.calls) {
+    expect(call[1]).toBe(AGENT_IN_B);
+  }
+});
+
+test("re-pinning the SAME space does not un-settle a loaded list", async () => {
+  // `lib/engine.ts` re-applies the recorded active space on every client
+  // rebuild / bearer rotation. That must not be read as a switch, or a token
+  // refresh would drop routing mid-session.
+  const c = client();
+  c.setActiveOrg(ORG_A);
+  await c.listAgents("ws");
+
+  c.setActiveOrg(ORG_A);
+
+  expect((await c.providerStatuses(["anthropic"]))[0].authState).toBe(
+    "authenticated",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (5) A list that is NOT COMING must degrade, never brick.
+//
+// The regression the strictness introduced: one failed `listAgents` at boot
+// left routing "not loaded yet" forever. The probe skipped itself on every
+// call (a permanent "Loading providers…") and every connect / sign-out threw
+// "still loading", with no retry anywhere. A failure is not a pending load.
+// ---------------------------------------------------------------------------
+
+test("a FAILED agent list degrades to pref-based routing instead of bricking", async () => {
+  const c = client();
+  cpListAgents.mockRejectedValue(new Error("gateway blew up"));
+
+  // The failure still reaches the caller — it is surfaced, not swallowed.
+  await expect(c.listAgents("ws")).rejects.toThrow(/gateway blew up/);
+
+  // The probe RUNS (no permanent "checking"), through the persisted selection.
+  const statuses = await c.providerStatuses(["anthropic"]);
+  expect(statuses.map((s) => s.authState)).toEqual(["authenticated"]);
+  expect(listProviders).toHaveBeenCalledTimes(1);
+
+  // …and connect / sign-out work again rather than throwing "still loading".
+  await c.providerLogout("anthropic");
+  expect(forgetCredential).toHaveBeenCalled();
+  for (const call of forgetCredential.mock.calls) {
+    expect(call[1]).toBe(STALE_PREF_AGENT);
+  }
+});
+
+test("a later SUCCESSFUL list restores strict validation after a failure", async () => {
+  const c = client();
+  cpListAgents.mockRejectedValueOnce(new Error("blip"));
+  await expect(c.listAgents("ws")).rejects.toThrow(/blip/);
+
+  // The retry succeeds: the pref is pruned and writes route at the real agent.
+  await c.listAgents("ws");
+
+  forgetCredential.mockClear();
+  await c.providerLogout("anthropic");
+  expect(localStorage.getItem(PREF)).toBeNull();
+  for (const call of forgetCredential.mock.calls) {
+    expect(call[1]).toBe(THIS_SPACE_AGENT);
+  }
+});
+
+test("a failure never downgrades a list we already have", async () => {
+  // A background refresh failing is not a reason to drop validation we can
+  // still do — the ids from the last good list are still this space's ids.
+  const c = client();
+  await c.listAgents("ws");
+  cpListAgents.mockRejectedValueOnce(new Error("blip"));
+  await expect(c.listAgents("ws")).rejects.toThrow(/blip/);
+
+  forgetCredential.mockClear();
+  await c.providerLogout("anthropic");
+  for (const call of forgetCredential.mock.calls) {
+    expect(call[1]).toBe(THIS_SPACE_AGENT);
+  }
+});
+
+test("noteAgentsUnavailable settles routing when no list will ever be asked for", async () => {
+  // Boot resolved NO workspace (the workspace load failed), so `listAgents` is
+  // never called at all. Without this the picker and the AI hub spin forever on
+  // a list that cannot arrive.
+  const c = client();
+
+  c.noteAgentsUnavailable();
+
+  const statuses = await c.providerStatuses(["anthropic"]);
+  expect(statuses.map((s) => s.authState)).toEqual(["authenticated"]);
+  await c.providerLogout("anthropic");
+  expect(forgetCredential).toHaveBeenCalled();
+});

--- a/packages/web/tests/provider-statuses-batch.test.ts
+++ b/packages/web/tests/provider-statuses-batch.test.ts
@@ -9,7 +9,10 @@ import { afterEach, beforeEach, expect, test, vi } from "vitest";
  * card's status from it. These tests pin that single-round-trip contract.
  */
 
-const listProviders = vi.fn();
+const { listProviders, cpListAgents } = vi.hoisted(() => ({
+  listProviders: vi.fn(),
+  cpListAgents: vi.fn(),
+}));
 
 vi.mock("../src/engine-adapter/control-plane", async (importOriginal) => {
   const actual =
@@ -18,6 +21,7 @@ vi.mock("../src/engine-adapter/control-plane", async (importOriginal) => {
     >();
   return {
     ...actual,
+    listAgents: cpListAgents,
     // Every provider/auth call resolves to the same fake runtime client, so we
     // can count how many times the adapter reaches for the provider list.
     runtimeClientFor: vi.fn(() => ({ listProviders })),
@@ -36,16 +40,29 @@ beforeEach(() => {
     removeItem: () => {},
   };
   listProviders.mockReset();
+  cpListAgents.mockReset();
+  cpListAgents.mockResolvedValue([{ id: "agent-1" }]);
 });
 
 afterEach(() => vi.clearAllMocks());
 
-function client() {
-  return new HoustonClient({
+/**
+ * A client whose ACTIVE SPACE has already listed its agents.
+ *
+ * Every probe test settles the list first because the probe routes per-agent:
+ * until a `listAgents` has resolved for this space, the only candidate id is
+ * the persisted pref, which after a space switch still names the PREVIOUS
+ * space's agent — so the adapter deliberately reports "unknown" instead of
+ * asking a foreign agent's route (HOU-979; the last test pins that).
+ */
+async function settledClient() {
+  const c = new HoustonClient({
     baseUrl: "http://host",
     token: "t",
     controlPlane: true,
   });
+  await c.listAgents("ws");
+  return c;
 }
 
 test("providerStatuses fetches the provider list ONCE for many cards", async () => {
@@ -63,7 +80,7 @@ test("providerStatuses fetches the provider list ONCE for many cards", async () 
     "openrouter", // absent from the list
     "not-a-provider", // unmapped id
   ];
-  const statuses = await client().providerStatuses(names);
+  const statuses = await (await settledClient()).providerStatuses(names);
 
   // The whole point: N cards, ONE round-trip.
   expect(listProviders).toHaveBeenCalledTimes(1);
@@ -84,7 +101,7 @@ test("providerStatuses fetches the provider list ONCE for many cards", async () 
 test("providerStatus delegates to the batch (one fetch, correct entry)", async () => {
   listProviders.mockResolvedValue([{ id: "anthropic", configured: true }]);
 
-  const status = await client().providerStatus("anthropic");
+  const status = await (await settledClient()).providerStatus("anthropic");
 
   expect(listProviders).toHaveBeenCalledTimes(1);
   expect(status.authState).toBe("authenticated");
@@ -98,7 +115,10 @@ test("an unreachable runtime reports every card UNKNOWN without throwing", async
   // signed-out state).
   listProviders.mockRejectedValue(new Error("sandbox unreachable"));
 
-  const statuses = await client().providerStatuses(["anthropic", "opencode"]);
+  const statuses = await (await settledClient()).providerStatuses([
+    "anthropic",
+    "opencode",
+  ]);
 
   expect(statuses.map((s) => s.authState)).toEqual(["unknown", "unknown"]);
 });
@@ -106,7 +126,10 @@ test("an unreachable runtime reports every card UNKNOWN without throwing", async
 test("a reachable runtime still gives a confirmed unauthenticated for absent providers", async () => {
   listProviders.mockResolvedValue([{ id: "anthropic", configured: true }]);
 
-  const statuses = await client().providerStatuses(["anthropic", "opencode"]);
+  const statuses = await (await settledClient()).providerStatuses([
+    "anthropic",
+    "opencode",
+  ]);
 
   expect(statuses.map((s) => s.authState)).toEqual([
     "authenticated",

--- a/packages/web/tests/stale-agent-pref.test.ts
+++ b/packages/web/tests/stale-agent-pref.test.ts
@@ -200,20 +200,21 @@ test("provider login falls back to a live agent when the selected pref is stale 
   expect(setupRuntimeClientFor).not.toHaveBeenCalled();
 });
 
-test("before any agent list resolves, the selected pref is trusted as-is", async () => {
+test("before any agent list resolves, a connect REFUSES instead of trusting the pref", async () => {
+  // Reversed by HOU-979. The pref used to be trusted as-is here, on the theory
+  // that boot prunes a stale one the moment the list lands. That holds for a
+  // DELETED agent but not for a SPACE SWITCH: the pref is not space-aware, so
+  // between the switch and the new `listAgents` it names an agent that belongs
+  // to the space the user just left. Starting a login there would run the OAuth
+  // flow in another space's pod under this space's `x-houston-org` header.
+  // Refusing for the moment the list takes to resolve is the honest trade.
   store.set(PREF, "ws/Selected");
-  const startLogin = vi.fn().mockResolvedValue({
-    kind: "device_code",
-    verificationUri: "https://auth.example/device",
-    userCode: "ABCD-1234",
-  });
+  const startLogin = vi.fn();
   runtimeClientFor.mockReturnValue({ startLogin });
 
   const c = client();
-  await c.providerLogin("openai"); // no listAgents ran yet
+  await expect(c.providerLogin("openai")).rejects.toThrow(/still loading/i);
 
-  expect(runtimeClientFor).toHaveBeenCalledWith(
-    expect.anything(),
-    "ws/Selected",
-  );
+  expect(startLogin).not.toHaveBeenCalled();
+  expect(runtimeClientFor).not.toHaveBeenCalled();
 });

--- a/packages/web/tests/uncurated-provider-connect.test.ts
+++ b/packages/web/tests/uncurated-provider-connect.test.ts
@@ -11,14 +11,19 @@ import { afterEach, beforeEach, expect, test, vi } from "vitest";
  * only Codex is renamed; every other id flows to the engine verbatim.
  */
 
-const { setApiKey, claimActiveProvider, forgetCredential, logout } = vi.hoisted(
-  () => ({
-    setApiKey: vi.fn(),
-    claimActiveProvider: vi.fn(),
-    forgetCredential: vi.fn(),
-    logout: vi.fn(),
-  }),
-);
+const {
+  setApiKey,
+  claimActiveProvider,
+  forgetCredential,
+  logout,
+  cpListAgents,
+} = vi.hoisted(() => ({
+  setApiKey: vi.fn(),
+  claimActiveProvider: vi.fn(),
+  forgetCredential: vi.fn(),
+  logout: vi.fn(),
+  cpListAgents: vi.fn(),
+}));
 
 vi.mock("../src/engine-adapter/control-plane", async (importOriginal) => {
   const actual =
@@ -27,6 +32,7 @@ vi.mock("../src/engine-adapter/control-plane", async (importOriginal) => {
     >();
   return {
     ...actual,
+    listAgents: cpListAgents,
     setApiKey,
     forgetCredential,
     runtimeClientFor: vi.fn(() => ({ claimActiveProvider, logout })),
@@ -50,16 +56,25 @@ beforeEach(() => {
   claimActiveProvider.mockReset().mockResolvedValue(undefined);
   forgetCredential.mockReset().mockResolvedValue(undefined);
   logout.mockReset().mockResolvedValue(undefined);
+  cpListAgents.mockReset().mockResolvedValue([{ id: "agent-1" }]);
 });
 
 afterEach(() => vi.clearAllMocks());
 
-function client() {
-  return new HoustonClient({
+/**
+ * A client whose active space has already listed its agents. Provider writes
+ * refuse until that resolves, because the persisted pref is not space-aware and
+ * would otherwise route this space's connect at the previous space's agent
+ * (HOU-979, pinned in `provider-space-routing.test.ts`).
+ */
+async function client() {
+  const c = new HoustonClient({
     baseUrl: "http://host",
     token: "t",
     controlPlane: true,
   });
+  await c.listAgents("ws");
+  return c;
 }
 
 test("toNewProvider renames only Codex and passes every other id through", () => {
@@ -93,7 +108,7 @@ test("credentialSiblings fans out only the OpenCode gateways", () => {
 });
 
 test("setProviderApiKey connects an uncurated pi provider instead of throwing", async () => {
-  await client().setProviderApiKey("mistral", "sk-mistral-key");
+  await (await client()).setProviderApiKey("mistral", "sk-mistral-key");
 
   expect(setApiKey).toHaveBeenCalledTimes(1);
   expect(setApiKey.mock.calls[0].slice(2)).toEqual([
@@ -104,7 +119,7 @@ test("setProviderApiKey connects an uncurated pi provider instead of throwing", 
 });
 
 test("providerLogout clears an uncurated pi provider instead of no-oping", async () => {
-  await client().providerLogout("groq");
+  await (await client()).providerLogout("groq");
 
   expect(forgetCredential).toHaveBeenCalledTimes(1);
   expect(forgetCredential.mock.calls[0][2]).toBe("groq");

--- a/ui/core/src/components/model-picker/catalog.ts
+++ b/ui/core/src/components/model-picker/catalog.ts
@@ -49,6 +49,20 @@ export function providerListLoading(
 }
 
 /**
+ * Whether level 1 has SETTLED on "nothing is connected here" — the state that
+ * earns the explained empty state (title, hint, primary action) instead of a
+ * bare list. Strictly the complement of {@link providerListLoading} over an
+ * empty connected set, so the two can never both be true.
+ */
+export function providerListEmpty(
+  providers: readonly ModelPickerProvider[],
+  catalogState: ModelPickerCatalogState,
+): boolean {
+  if (providerListLoading(providers, catalogState)) return false;
+  return connectedProviders(providers).length === 0;
+}
+
+/**
  * The models to show at level 2 for a provider: that provider's rows in input
  * order, but only when the provider is actually connected (a stale/disconnected
  * id yields nothing).

--- a/ui/core/src/components/model-picker/model-picker.tsx
+++ b/ui/core/src/components/model-picker/model-picker.tsx
@@ -8,6 +8,7 @@ import { Command, CommandEmpty, CommandInput, CommandList } from "../command";
 import {
   connectedProviderIds,
   modelsForProvider,
+  providerListEmpty,
   providerListLoading,
   connectedProviders as selectConnectedProviders,
 } from "./catalog";
@@ -27,8 +28,9 @@ const SEARCH_THRESHOLD = 8;
  * providers; clicking one drills into its models (level 2), reached back via the
  * always-visible back header. On level 2 an in-dropdown search appears once the
  * provider's list runs long (> 8 rows) and filters it via cmdk's built-in
- * scorer; short lists omit it. Disconnected providers never appear — the only
- * path to them is the "Connect more providers…" footer.
+ * scorer; short lists omit it. Disconnected providers never appear — the paths
+ * to them are the "Connect more providers…" footer and, when NOTHING is
+ * connected, level 1's explained empty state (which carries the same action).
  *
  * cmdk provides the accessible input, list semantics, and ↑↓/Enter roving; this
  * component owns which rows show. All data comes in as props and all actions go
@@ -65,6 +67,9 @@ export function ModelPicker({
   );
 
   const view = nav.view;
+  // The empty state carries its own action, so the footer is suppressed there.
+  const showEmptyState =
+    view.level === "providers" && providerListEmpty(providers, catalogState);
   const providerModels = useMemo(
     () =>
       view.level === "models"
@@ -173,6 +178,7 @@ export function ModelPicker({
             labels={labels}
             renderProviderIcon={renderProviderIcon}
             onEnter={enterProvider}
+            onConnect={onConnectMore}
           />
         ) : (
           <ModelRows
@@ -182,7 +188,7 @@ export function ModelPicker({
           />
         )}
 
-        {onConnectMore && (
+        {onConnectMore && !showEmptyState && (
           <ConnectMore label={labels.connectMore} onSelect={onConnectMore} />
         )}
 

--- a/ui/core/src/components/model-picker/provider-list.tsx
+++ b/ui/core/src/components/model-picker/provider-list.tsx
@@ -1,5 +1,6 @@
 import { Check, ChevronRight, Loader2 } from "lucide-react";
 import type * as React from "react";
+import { Button } from "../button";
 import { CommandItem } from "../command";
 import { ProviderIcon } from "./provider-icon";
 import type { ModelPickerLabels, ModelPickerProvider } from "./types";
@@ -8,9 +9,9 @@ import type { ModelPickerLabels, ModelPickerProvider } from "./types";
  * Level 1: the connected providers, in the shared dropdown idiom. Each row is a
  * `CommandItem` so ↑↓/Enter roving works; Enter (or click) drills into that
  * provider's models. A neutral loading state stands in for an empty list while
- * statuses resolve (#342 guard); a truly empty connected set shows the "no
- * providers" hint instead. A check marks the current provider; a trailing chevron
- * signals the drill-in to its models.
+ * statuses resolve (#342 guard); a truly empty connected set shows the explained
+ * empty state below instead. A check marks the current provider; a trailing
+ * chevron signals the drill-in to its models.
  */
 export function ProviderList({
   providers,
@@ -19,6 +20,7 @@ export function ProviderList({
   labels,
   renderProviderIcon,
   onEnter,
+  onConnect,
 }: {
   providers: ModelPickerProvider[];
   loading: boolean;
@@ -29,6 +31,8 @@ export function ProviderList({
     className?: string,
   ) => React.ReactNode;
   onEnter: (providerId: string) => void;
+  /** Empty-state action. Omit to render the empty state with no action. */
+  onConnect?: () => void;
 }) {
   if (loading) {
     return (
@@ -38,10 +42,24 @@ export function ProviderList({
       </div>
     );
   }
+  // Settled, and nothing is connected. Say so honestly and offer the way out
+  // rather than leaving a blank panel the user has to interpret: an empty
+  // provider list is the normal first state of a brand-new team space, not an
+  // error.
   if (providers.length === 0) {
     return (
-      <div className="px-4 py-10 text-center text-sm text-ink-muted">
-        {labels.noProviders}
+      <div className="flex flex-col items-center gap-2 px-6 py-10 text-center">
+        <p className="text-pretty text-sm font-medium text-ink">
+          {labels.noProviders}
+        </p>
+        <p className="text-pretty text-xs text-ink-muted">
+          {labels.noProvidersHint}
+        </p>
+        {onConnect && (
+          <Button size="sm" className="mt-2" onClick={onConnect}>
+            {labels.noProvidersAction}
+          </Button>
+        )}
       </div>
     );
   }

--- a/ui/core/src/components/model-picker/types.ts
+++ b/ui/core/src/components/model-picker/types.ts
@@ -49,6 +49,19 @@ export interface ModelPickerLabels {
   empty: string;
   /** Empty state when no provider is connected yet. */
   noProviders: string;
+  /**
+   * One line under {@link noProviders} explaining what to do about it. The
+   * consumer owns the wording, which differs by context (a personal space, a
+   * team space the caller can connect for, a team space where only an admin
+   * can) — the picker only renders it.
+   */
+  noProvidersHint: string;
+  /**
+   * Label for the empty state's primary action, which calls `onConnectMore`.
+   * Omit `onConnectMore` when the viewer has no way to connect, and the action
+   * is not rendered at all.
+   */
+  noProvidersAction: string;
 }
 
 export const DEFAULT_MODEL_PICKER_LABELS: ModelPickerLabels = {
@@ -60,6 +73,8 @@ export const DEFAULT_MODEL_PICKER_LABELS: ModelPickerLabels = {
   loading: "Loading providers…",
   empty: "No models found.",
   noProviders: "No providers connected yet.",
+  noProvidersHint: "Connect an AI model to start chatting.",
+  noProvidersAction: "Connect an AI model",
 };
 
 export interface ModelPickerProps {

--- a/ui/core/tests/model-picker-catalog.test.ts
+++ b/ui/core/tests/model-picker-catalog.test.ts
@@ -4,6 +4,7 @@ import {
   connectedProviderIds,
   connectedProviders,
   modelsForProvider,
+  providerListEmpty,
   providerListLoading,
 } from "../src/components/model-picker/catalog.ts";
 import type {
@@ -94,5 +95,49 @@ describe("providerListLoading (#342 flicker guard)", () => {
       providerListLoading([provider("a", "disconnected")], "ready"),
       false,
     );
+  });
+});
+
+describe("the explained empty state (HOU-979)", () => {
+  it("shows only once level 1 has SETTLED on nothing connected", () => {
+    assert.equal(
+      providerListEmpty([provider("a", "disconnected")], "ready"),
+      true,
+    );
+    assert.equal(providerListEmpty([], "ready"), true);
+  });
+
+  it("never shows while statuses or the catalog are still resolving", () => {
+    // The whole point of the third state: a "checking" provider must read as
+    // loading, not as an honest "this space has no AI connection".
+    assert.equal(
+      providerListEmpty([provider("a", "checking")], "ready"),
+      false,
+    );
+    assert.equal(providerListEmpty([], "loading"), false);
+  });
+
+  it("never shows when something IS connected", () => {
+    assert.equal(
+      providerListEmpty([provider("a", "connected")], "ready"),
+      false,
+    );
+  });
+
+  it("is mutually exclusive with the loading state", () => {
+    const cases: [ModelPickerProvider[], "ready" | "loading"][] = [
+      [[], "ready"],
+      [[], "loading"],
+      [[provider("a", "checking")], "ready"],
+      [[provider("a", "disconnected")], "ready"],
+      [[provider("a", "connected")], "loading"],
+    ];
+    for (const [providers, catalogState] of cases) {
+      assert.equal(
+        providerListEmpty(providers, catalogState) &&
+          providerListLoading(providers, catalogState),
+        false,
+      );
+    }
   });
 });

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -280,6 +280,15 @@ export class HoustonClient {
   }
 
   /**
+   * Tell the client the active space's agent list is not coming (boot resolved
+   * no workspace to list agents for). Only the v3 host adapter acts on it — it
+   * routes provider calls at a specific agent's runtime and would otherwise wait
+   * on that list forever (HOU-979). This client addresses one runtime directly,
+   * so there is nothing to settle.
+   */
+  noteAgentsUnavailable(): void {}
+
+  /**
    * The active-space header for one request, or `{}` when personal (`null`).
    * Called INSIDE each `build()` closure so it is evaluated per attempt — a
    * `setActiveOrg` mid-flight lands on the next retry, same discipline as the


### PR DESCRIPTION
Fixes HOU-979

**Symptoms** (team space, cloud-v0.5.32): chat picker offered no providers; sending produced the reconnect card; reconnecting reported success but the card persisted; the AI Models hub said Connected the whole time. Personal space fine. Server-side C6 (connect push, per-turn podcreds) verified space-correct — the user's reconnect had in fact stored the team credential; the client couldn't see it.

**Root causes + fixes**
- The chat picker's provider-status hook was missed by the HOU-906 space fix: no agents-settled gate, no space in its query key — the space-switch cache wipe refired it against the previous space's agent ids, 404s stamped every provider `unknown`, and nothing refired it. Now gated + space-keyed, mirroring the hub hook.
- `unknown` meant opposite things per surface (picker: hidden; hub: Connected; reconnect card: never clears). One shared derivation now: `unknown` = visible *checking* everywhere — never Connected, never hidden, never a Connect CTA (7 consumer surfaces upgraded).
- A credential-less team space renders an honest empty state + connect CTA (role-aware: members are told to ask an owner/admin), instead of an unexplained empty list.
- Provider connect/probe routing collapsed onto one space-validated agent source with a three-state list (`pending/unavailable/known`): a Connect click mid-switch can no longer target the previous space's agent, and a failed agent list degrades to the old behavior instead of bricking connects.
- Hub probe pins its save scope pre-flight (a probe resolving after a switch is dropped, never written under the wrong space); a failed workspace load settles the boot gate with the standard error surface instead of pinning the splash forever.

**Process**: implemented → independently adversarially reviewed (3 high, 4 medium, 3 low findings — including a first-boot-only guard, a permanent-brick regression, and a catalog header change justified by a false premise, reverted) → all ten fixed → full chromium e2e suite 165 passed, all scoped suites green, locales in sync, parity/boundaries clean. The 2 remaining app-test failures are the pre-existing `claude-opus-5` pi-catalog-drift assertions (fail identically on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)