### PR TITLE
fix(board): don't let Space from inner controls close the mission rename editor

### DIFF
--- a/packages/web/e2e/board.spec.ts
+++ b/packages/web/e2e/board.spec.ts
@@ -273,6 +273,36 @@ test("moves a mission to the Done column", async ({ page }) => {
   ).toBeVisible();
 });
 
+/**
+ * HOU-932: the card wrapper's Enter/Space handler had no target guard, so a
+ * Space bubbling out of the inline rename input was preventDefault-ed and
+ * opened the mission — the editor unmounted mid-word and the space never
+ * landed. Renaming to a MULTI-WORD title is the whole regression.
+ */
+test("renames a mission to a multi-word title without the space closing the editor", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const card = page.locator('[data-kanban-card="act-1"]');
+  await card.hover();
+  await card.getByRole("button", { name: "Change title" }).click();
+
+  // Type char-by-char (a `fill` would set the value in one shot and never
+  // deliver the Space keydown this guards).
+  const input = card.getByRole("textbox");
+  await expect(input).toHaveValue("Plan a trip to Tokyo");
+  await input.fill("");
+  await input.pressSequentially("Two words");
+
+  // The editor survived the space with the whole string intact, and the
+  // mission's chat never opened behind it.
+  await expect(input).toHaveValue("Two words");
+  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+
+  await input.press("Enter");
+  await expect(card.getByText("Two words")).toBeVisible();
+});
+
 test("deletes a mission from the board", async ({ page }) => {
   await page.goto("/");
   const card = page.locator('[data-kanban-card="act-2"]'); // "Draft the launch email"

--- a/ui/board/src/kanban-card.tsx
+++ b/ui/board/src/kanban-card.tsx
@@ -168,7 +168,14 @@ export function KanbanCard({
           onSelect();
         }}
         onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
+          // Only the card itself opens on Enter/Space; key events from a focused
+          // inner control (the rename input, the multi-select checkbox) bubble
+          // here but carry a different target — swallowing their Space would
+          // eat the typed character and open the mission instead.
+          if (
+            e.target === e.currentTarget &&
+            (e.key === "Enter" || e.key === " ")
+          ) {
             e.preventDefault();
             onSelect();
           }

--- a/ui/board/src/kanban-list-item.tsx
+++ b/ui/board/src/kanban-list-item.tsx
@@ -50,7 +50,12 @@ export function KanbanListItem({
         tabIndex={0}
         onClick={onSelect}
         onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
+          // Only the row itself opens on Enter/Space; key events from a focused
+          // inner control bubble here but carry a different target.
+          if (
+            e.target === e.currentTarget &&
+            (e.key === "Enter" || e.key === " ")
+          ) {
             e.preventDefault();
             onSelect();
           }

--- a/ui/skills/src/skill-row.tsx
+++ b/ui/skills/src/skill-row.tsx
@@ -29,7 +29,13 @@ export function SkillRow({ skill, onClick, onDelete }: SkillRowProps) {
       type="button"
       onClick={onClick}
       onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
+        // Only the row itself opens on Enter/Space; key events from a focused
+        // inner control (the overflow menu trigger) bubble here but carry a
+        // different target.
+        if (
+          e.target === e.currentTarget &&
+          (e.key === "Enter" || e.key === " ")
+        ) {
           e.preventDefault();
           onClick();
         }


### PR DESCRIPTION
## Summary
- Renaming a mission and pressing Space closed the rename editor and opened the mission instead: the kanban card wrapper's Enter/Space activation handler had no target guard, so the Space bubbling out of the inline rename input was preventDefault-ed and triggered card selection, remounting the board and discarding the in-progress title.
- Guard the handler on `e.target === e.currentTarget` (the `routine-row` precedent). This also un-breaks Space on the card's bulk-select checkbox.
- Apply the same guard to the latent copies of the pattern in `kanban-list-item.tsx` and `skill-row.tsx`.
- Add a Playwright regression test that renames a card to a multi-word title and asserts the editor survives the space and the detail panel stays closed (verified to fail without the fix).

## Testing
- `pnpm --filter houston-web typecheck` + `typecheck:e2e` pass.
- `playwright test board.spec.ts` — 9 passed, including the new regression test.
- With the guard reverted, the new test fails exactly as the bug reproduces (editor unmounts on first space).

Fixes HOU-932

🤖 Generated with [Claude Code](https://claude.com/claude-code)