### PR TITLE
fix: solo chats keep classic presentation in multiplayer

### DIFF
--- a/app/src/components/use-chat-sender-avatars.tsx
+++ b/app/src/components/use-chat-sender-avatars.tsx
@@ -22,6 +22,7 @@ import { type ReactNode, useCallback, useMemo } from "react";
 import { useUserProfiles } from "../hooks/queries/use-user-profiles";
 import { useCapabilities } from "../hooks/use-capabilities";
 import { useMyProfile } from "../hooks/use-my-profile";
+import { chatSenderMode } from "../lib/chat-sender-mode";
 import { shortUserLabel } from "../lib/mission-people";
 import { isMultiplayer } from "../lib/org-roles";
 import type { Agent } from "../lib/types";
@@ -46,13 +47,12 @@ function authorIdsIn(feedItems: FeedItem[]): string[] {
 
 export interface ChatSenderIdentity {
   /**
-   * `true` = attribute EVERY turn (the deployment is multiplayer, so sender
-   * identity is a property of the deployment). NEVER `false`: `undefined` hands
-   * the decision to `ui/chat`'s ≥2-distinct-authors heuristic, which is the
-   * right answer everywhere else — including the capabilities-loading window
-   * (a shared transcript must not paint unattributed and then pop names in) and
-   * any host that serves an authored transcript without advertising
-   * multiplayer, where a hard `false` would actively SUPPRESS attribution.
+   * `true` = attribute EVERY turn once multiplayer plus the transcript proves a
+   * teammate participated. NEVER `false`: `undefined` hands the decision to
+   * `ui/chat`'s ≥2-distinct-authors heuristic. That remains the right fallback
+   * while the viewer profile is resolving and for authored transcripts from a
+   * host that does not advertise multiplayer, where hard `false` would actively
+   * suppress attribution.
    */
   showSenders: true | undefined;
   /** The agent's display name, shown on its rows. */
@@ -73,13 +73,17 @@ export function useChatSenderAvatars(
   feedItems: FeedItem[],
 ): ChatSenderIdentity {
   const { capabilities } = useCapabilities();
-  const showSenders = isMultiplayer(capabilities) || undefined;
   const myProfile = useMyProfile();
 
   // Every authored id in the transcript — empty in single-player, where no
   // message carries an author, and the batched profiles query is multiplayer
   // gated on top of that (see `profilesQueryEnabled`).
   const authorIds = useMemo(() => authorIdsIn(feedItems), [feedItems]);
+  const showSenders = chatSenderMode(
+    authorIds,
+    myProfile?.userId,
+    isMultiplayer(capabilities),
+  );
   const { profiles } = useUserProfiles(authorIds);
 
   const agentColor = agent?.color;

--- a/app/src/lib/chat-sender-mode.ts
+++ b/app/src/lib/chat-sender-mode.ts
@@ -1,0 +1,23 @@
+/**
+ * Forces group-chat sender presentation only when the transcript proves that
+ * someone besides the viewer participated. `undefined` preserves ui/chat's
+ * distinct-author fallback without ever suppressing it with `false`.
+ */
+export function chatSenderMode(
+  authorIds: string[],
+  viewerUserId: string | undefined,
+  multiplayer: boolean,
+): true | undefined {
+  if (!multiplayer) return undefined;
+
+  const distinctAuthorIds = new Set(authorIds);
+  if (
+    (viewerUserId !== undefined &&
+      authorIds.some((authorId) => authorId !== viewerUserId)) ||
+    distinctAuthorIds.size >= 2
+  ) {
+    return true;
+  }
+
+  return undefined;
+}

--- a/app/tests/chat-sender-identity.test.ts
+++ b/app/tests/chat-sender-identity.test.ts
@@ -7,13 +7,10 @@ import { describe, it } from "node:test";
  * repo's React-test idiom) these assert on the hook's source — they pin two
  * decisions that are invisible in a screenshot and easy to regress:
  *
- *  1. `showSenders` is `true` or `undefined`, NEVER `false`. `true` forces
- *     attribution on in a multiplayer deployment; `undefined` hands the call to
- *     `ui/chat`'s ≥2-distinct-authors heuristic — which is what must govern
- *     during the capabilities-loading window (else a shared transcript paints
- *     unattributed and then pops names in) and on any host that serves an
- *     authored transcript without advertising multiplayer. A hard `false` would
- *     make that heuristic unreachable and SUPPRESS attribution.
+ *  1. `showSenders` is `true` or `undefined`, NEVER `false`. The pure selector
+ *     forces attribution only for a multiplayer transcript that proves another
+ *     person participated; `undefined` preserves ui/chat's distinct-authors
+ *     fallback. A hard `false` would make that heuristic unreachable.
  *  2. The sender face carries the author's stable `id`, which is what gives the
  *     initials fallback their opaque `person.*` tone — one person, one tone,
  *     identical to their face on every board card.
@@ -25,10 +22,10 @@ const src = readFileSync(
 );
 
 describe("chat sender identity", () => {
-  it("never passes a hard `false` for showSenders", () => {
+  it("uses the transcript-aware selector and never passes a hard `false`", () => {
     ok(
-      src.includes("isMultiplayer(capabilities) || undefined"),
-      "showSenders is true in multiplayer, undefined everywhere else",
+      src.includes("chatSenderMode("),
+      "showSenders comes from the transcript-aware selector",
     );
     ok(
       !/showSenders\s*[:=]\s*false/.test(src),

--- a/app/tests/chat-sender-mode.test.ts
+++ b/app/tests/chat-sender-mode.test.ts
@@ -1,0 +1,24 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { chatSenderMode } from "../src/lib/chat-sender-mode.ts";
+
+describe("chatSenderMode", () => {
+  it("keeps a viewer-and-agent chat in the classic layout in multiplayer", () => {
+    strictEqual(chatSenderMode(["viewer"], "viewer", true), undefined);
+  });
+
+  it("forces group presentation when a teammate authored a message", () => {
+    strictEqual(chatSenderMode(["viewer", "teammate"], "viewer", true), true);
+  });
+
+  it("recognizes multiple people before the viewer profile resolves", () => {
+    strictEqual(chatSenderMode(["ada", "bo"], undefined, true), true);
+  });
+
+  it("does not force sender presentation outside multiplayer", () => {
+    strictEqual(
+      chatSenderMode(["viewer", "teammate"], "viewer", false),
+      undefined,
+    );
+  });
+});

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -868,13 +868,16 @@ rare hard failure stays silent and consumers fall back via React Query's `isErro
 
 ## Chat sender attribution (HOU-943, HOU-960)
 
-In a shared chat every turn says who sent it, on WhatsApp-group semantics: a
-group chat labels the people you talk TO and never you, and a name is an answer
-to "who is talking now", so it prints once per change of speaker rather than
-once per message. The trigger is the DEPLOYMENT, not the thread —
-`isMultiplayer(capabilities)` — so a shared chat attributes its first message,
-not only once a second person writes. Single-player renders no sender
-presentation at all: no name, no face, no reserved column (byte-identical
+In a multiplayer chat, group presentation starts only when the transcript proves
+someone besides the viewer participated: a user-message author differs from the
+resolved viewer id, or the transcript has at least two distinct author ids while
+that profile is still resolving. It follows WhatsApp-group semantics: a group
+chat labels the people you talk TO and never you, and a name is an answer to
+"who is talking now", so it prints once per change of speaker rather than once
+per message. A viewer-and-agent transcript keeps the classic single-player
+layout. The app passes `true` for the proven group case and otherwise omits the
+prop, preserving `ui/chat`'s distinct-authors fallback. Single-player renders
+no sender presentation at all: no name, no face, no reserved column (byte-identical
 transcript).
 
 **The identity travels on the view-model.** A message's author is already stored
@@ -940,7 +943,8 @@ signed-in-but-not-yet-resolved window both render today's layout) and
 viewer's own row is no longer labelled on screen).
 
 **App wiring.** `use-chat-sender-avatars.tsx` resolves it: `showSenders` from
-capabilities, `agentLabel` from the agent, faces from the SAME batched
+the multiplayer transcript and resolved viewer profile, `agentLabel` from the
+agent, faces from the SAME batched
 `useUserProfiles` lookup the board face stacks use (ids collected from the feed's
 authors, own rows via `useMyProfile`, `PersonFace` initials fallback), and
 `senderNameClass` = `personNameToneClass(author.userId)` for a human,

--- a/packages/web/e2e/chat-senders.spec.ts
+++ b/packages/web/e2e/chat-senders.spec.ts
@@ -59,17 +59,19 @@ const FOLLOWED_UP = "Exclude the churned accounts";
 const MINE = "Also flag the renewals";
 
 /**
- * Arm the transcript. `authored: false` seeds the same words with no author —
- * a single-player conversation.
+ * Arm the transcript. `solo` gives every user turn to the viewer, proving that
+ * multiplayer alone does not make a viewer-and-agent conversation a group chat.
  *
  * Ada writes twice in a row on purpose: her second message is the run
  * continuation that must render bare.
  */
 async function seedTranscript(
   request: APIRequestContext,
-  authored: boolean,
+  presentation: "group" | "solo",
 ): Promise<void> {
-  const author = (who: typeof ADA) => (authored ? { author: who } : {});
+  const author = (who: typeof ADA) => ({
+    author: presentation === "solo" ? SELF : who,
+  });
   await request.post(`${FAKE_HOST_URL}/__test__/chat-history`, {
     data: {
       conversationId: CONVERSATION_ID,
@@ -123,7 +125,7 @@ test("a shared chat gives every speaker a side, a face and a name", async ({
 }) => {
   await armMultiplayer(request);
   await seedMission(request);
-  await seedTranscript(request, true);
+  await seedTranscript(request, "group");
   await signInAsViewer(page);
   await openMission(page);
 
@@ -182,12 +184,13 @@ test("a shared chat gives every speaker a side, a face and a name", async ({
   await expect(mine.locator(".sr-only")).toHaveText("You");
 });
 
-test("a single-player chat shows no sender on any turn", async ({
+test("a solo chat in multiplayer shows no sender on any turn", async ({
   page,
   request,
 }) => {
+  await armMultiplayer(request);
   await seedMission(request);
-  await seedTranscript(request, false);
+  await seedTranscript(request, "solo");
   await signInAsViewer(page);
   await openMission(page);
 


### PR DESCRIPTION
## What

Group-chat sender presentation (sender faces + name lines, agent rows included) no longer turns on for every conversation in a multiplayer deployment. It now starts only when the transcript proves someone besides the viewer participated: a user-message author differing from the resolved viewer id, or two distinct author ids while the viewer profile is still resolving. A viewer-and-agent conversation renders the classic single-player layout.

## How

- New pure selector `chatSenderMode(authorIds, viewerUserId, multiplayer): true | undefined` in `app/src/lib/chat-sender-mode.ts`; `use-chat-sender-avatars.tsx` wires it. Never `false`: `undefined` preserves ui/chat's distinct-authors fallback.
- ui/chat alignment rules (`isPeerRow`/`isOwnMessage`) untouched.
- KB `knowledge-base/teams.md` chat-attribution section rewritten to the new rule.

## Verification

- `pnpm check` clean, `cd app && pnpm tsgo --noEmit && pnpm test` (2,306 passing), `pnpm --filter houston-web typecheck`
- Full Playwright e2e suite on worktree-private ports: **171 passed, 1 skipped, 0 failed** (chat-senders spec covers solo-in-multiplayer classic rendering, group attribution, wordless-turn byline)

Fixes HOU-969

🤖 Generated with [Claude Code](https://claude.com/claude-code)