### PR TITLE
perf(search): stream bounded mission-search scans instead of full-transcript waves

### DIFF
--- a/app/src/components/board/board-source.ts
+++ b/app/src/components/board/board-source.ts
@@ -118,7 +118,8 @@ export interface BoardSource {
   /**
    * Persisted chat history for one conversation. Callers forward `opts`:
    * mission search bulk-loads with `observe: false` (no per-conversation
-   * observer streams); the board's open-a-chat hydration omits it (observes).
+   * observer streams, bounded scan window); the board's open-a-chat hydration
+   * omits it (observes, tail window).
    */
   loadHistory: (
     sessionKey: string,

--- a/app/src/components/mission-highlight.ts
+++ b/app/src/components/mission-highlight.ts
@@ -15,9 +15,21 @@ function foldChar(char: string): string {
   return char.normalize("NFKD").replace(COMBINING_MARKS, "").toLowerCase();
 }
 
-/** Fold `text` for matching while recording, for each folded char, the index of
- *  the original char it came from. `map[folded.length] === text.length`, so an
- *  exclusive end position always resolves. */
+/**
+ * Fold `text` for matching while recording, for each folded char, the index of
+ * the original char it came from. `map[folded.length] === text.length`, so an
+ * exclusive end position always resolves.
+ *
+ * This walks the string CHARACTER BY CHARACTER, so it is ~100x slower than
+ * {@link foldForSearch} \u2014 it exists only because highlighting needs the
+ * folded->original index map. Give it SHORT text (a title, one chat message,
+ * a snippet); never a whole transcript (HOU-941).
+ *
+ * Per-character folding agrees with the whole-string fold everywhere except
+ * one Unicode corner: a word-final Greek sigma only lowercases to `\u03c2` when the
+ * engine can see the whole word. A phrase landing on that corner still matches
+ * (both sides of a match are whole-string folded) but gets no highlight.
+ */
 function foldWithMap(text: string): { folded: string; map: number[] } {
   let folded = "";
   const map: number[] = [];
@@ -32,10 +44,16 @@ function foldWithMap(text: string): { folded: string; map: number[] } {
   return { folded, map };
 }
 
-/** Fold a whole string for matching (case-folded, accents stripped). Shared by
- *  the search filter so matching and highlighting always agree. */
+/**
+ * Fold a whole string for matching (case-folded, accents stripped). Shared by
+ * the search filter so matching and highlighting always agree.
+ *
+ * ONE pass through the engine's native `normalize`/`replace`/`toLowerCase`.
+ * This used to delegate to {@link foldWithMap}'s per-character walk, which made
+ * folding a mission's transcript the dominant cost of a board search (HOU-941).
+ */
 export function foldForSearch(value: string): string {
-  return foldWithMap(value).folded;
+  return value.normalize("NFKD").replace(COMBINING_MARKS, "").toLowerCase();
 }
 
 const REGEXP_SPECIALS = /[.*+?^${}()|[\]\\]/g;
@@ -54,22 +72,45 @@ function phrasePattern(phrase: string): string {
 }
 
 /**
+ * Where `phrase` first occurs in ALREADY-FOLDED text, as `[start, end)` folded
+ * indices — or null. The hot path for scanned transcripts: they are folded once
+ * when they load, so a keystroke only re-runs this regex over them (HOU-941).
+ * `phrase` must already be folded.
+ */
+export function findFoldedMatch(
+  folded: string,
+  phrase: string,
+): { start: number; end: number } | null {
+  const pattern = phrasePattern(phrase);
+  if (!folded || !pattern) return null;
+  const match = new RegExp(pattern).exec(folded);
+  if (!match || match[0].length === 0) return null;
+  return { start: match.index, end: match.index + match[0].length };
+}
+
+/**
  * Whether `text` contains `phrase` (case- and accent-insensitive, whitespace
- * between words flexible). `phrase` must already be folded.
+ * between words flexible). `phrase` must already be folded. Folds `text` on
+ * every call — for SHORT text (a title, a description). Text that is matched
+ * repeatedly (a transcript) should be pre-folded and matched with
+ * {@link findFoldedMatch} instead.
  */
 export function matchesPhrase(
   text: string | undefined,
   phrase: string,
 ): boolean {
-  const pattern = phrasePattern(phrase);
-  if (!text || !pattern) return false;
-  return new RegExp(pattern).test(foldForSearch(text));
+  if (!text) return false;
+  return findFoldedMatch(foldForSearch(text), phrase) !== null;
 }
 
 /**
  * Ranges (into the ORIGINAL `text`) of every occurrence of `phrase`. `phrase`
  * must already be folded; a multi-word phrase matches contiguously (flexible
  * whitespace), never as scattered words. Sorted, with overlaps merged.
+ *
+ * Uses {@link foldWithMap}, so `text` must be SHORT — a title, one chat
+ * message, an already-cut snippet. Callers that hold a whole transcript locate
+ * the matching message first (see `mission-search-text.ts`).
  */
 export function findHighlightRanges(
   text: string,

--- a/app/src/components/mission-history-scan-wave.ts
+++ b/app/src/components/mission-history-scan-wave.ts
@@ -1,0 +1,168 @@
+import { runPool } from "../lib/async-pool.ts";
+import { matchesPhrase } from "./mission-highlight.ts";
+
+/** Transcript loads in flight at once: enough to hide per-request latency,
+ *  few enough that a big board never opens one request per mission at once. */
+export const SCAN_CONCURRENCY = 5;
+
+/**
+ * The slice of a board item a scan wave reasons about. Deliberately minimal:
+ * everything else on a card (status, people, icon) is the board's business, and
+ * keeping the shape this small is what lets the wave logic stay free of React,
+ * of the board package, and of the DOM — so it can be unit-tested directly.
+ */
+export interface ScanItem {
+  id: string;
+  title: string;
+  description?: string;
+}
+
+export interface MissionHistoryScannerPorts<T extends ScanItem> {
+  /**
+   * Loads one mission's transcript, already folded into the text the search
+   * runs over. MAY reject: a rejection is recorded as an empty transcript (so
+   * the mission is not retried on every keystroke) and surfaced once per wave.
+   */
+  loadTranscript: (item: T) => Promise<string>;
+  /** A transcript ("" for a failed load) is ready for `id`. */
+  onTranscript: (id: string, text: string) => void;
+  /** Called ONLY when the spinner actually flips — this drives a whole board's
+   *  re-render, and every settled transcript passes through here. */
+  onScanningChange: (scanning: boolean) => void;
+  /** At least one load in a wave failed. Fired once per wave, never per item. */
+  onLoadError: () => void;
+  /** Overridable for tests; production uses {@link SCAN_CONCURRENCY}. */
+  concurrency?: number;
+}
+
+export interface MissionHistoryScanner<T extends ScanItem> {
+  /** Point the scanner at the current board + phrase and launch what is
+   *  missing. Safe (and expected) to call on every render. */
+  scan: (items: readonly T[], phrase: string) => void;
+  /** Unmounted: stop starting work. In-flight loads still commit. */
+  stop: () => void;
+}
+
+/**
+ * Owns the bookkeeping behind the mission transcript scan: which missions are
+ * already scanned, which are claimed by a running wave, how many are still
+ * pending, and which phrase (the wave's generation) the board is scanning for.
+ *
+ * Kept hook-free on purpose. The React hook above it holds only the two pieces
+ * of state a component needs — the transcript map and the spinner — and hands
+ * this module the ports; every ordering hazard (a phrase superseded mid-wave)
+ * then lives in one place that a plain node:test can drive.
+ */
+export function createMissionHistoryScanner<T extends ScanItem>(
+  ports: MissionHistoryScannerPorts<T>,
+): MissionHistoryScanner<T> {
+  const limit = ports.concurrency ?? SCAN_CONCURRENCY;
+  /** Missions whose transcript is loaded (or failed — recorded as empty). */
+  const scanned = new Set<string>();
+  /** Missions claimed by a running wave, released when it settles or stops. */
+  const claimed = new Set<string>();
+  let remaining = 0;
+  let scanning = false;
+  let stopped = false;
+  /** The phrase the board is scanning for right now — a wave's generation. */
+  let phrase = "";
+  let items: readonly T[] = [];
+
+  /** Publish the spinner only when it flips, never once per settled item. */
+  const syncScanning = (): void => {
+    const next = remaining > 0;
+    if (scanning === next) return;
+    scanning = next;
+    ports.onScanningChange(next);
+  };
+
+  const commit = (id: string, text: string): void => {
+    scanned.add(id);
+    claimed.delete(id);
+    remaining -= 1;
+    ports.onTranscript(id, text);
+    syncScanning();
+  };
+
+  const launch = (generation: string): void => {
+    // Missions the phrase already matches by title or description need no
+    // transcript: they are shown as hits regardless of what the chat says.
+    const missing = items.filter(
+      (item) =>
+        !scanned.has(item.id) &&
+        !claimed.has(item.id) &&
+        !matchesPhrase(item.title, generation) &&
+        !matchesPhrase(item.description, generation),
+    );
+    if (missing.length === 0) {
+      syncScanning();
+      return;
+    }
+
+    for (const item of missing) claimed.add(item.id);
+    remaining += missing.length;
+    syncScanning();
+
+    let failed = false;
+    void runPool(
+      missing,
+      limit,
+      async (item) => {
+        try {
+          commit(item.id, await ports.loadTranscript(item));
+        } catch (err) {
+          console.error("[mission-search] history load failed", err);
+          // Record the failure as an empty transcript so the mission is not
+          // retried on every keystroke; the toast below tells the user.
+          commit(item.id, "");
+          failed = true;
+        }
+      },
+      () => stopped || phrase !== generation,
+    ).then(() => {
+      settle(missing, failed);
+    });
+  };
+
+  const settle = (wave: readonly T[], failed: boolean): void => {
+    // Release whatever this wave never got to (superseded phrase / unmount).
+    for (const item of wave) {
+      if (claimed.delete(item.id)) remaining -= 1;
+    }
+    // Then pick those releases straight back up for whatever phrase is current.
+    // A superseded wave settles LONG after the phrase that replaced it looked at
+    // the board: that wave saw these missions still claimed, skipped them, and
+    // nothing re-triggers it (the board and the phrase have not changed since).
+    // Without this re-launch, typing fast enough to supersede a wave left most
+    // transcripts unread while the spinner reported "search complete".
+    //
+    // This terminates: a re-launch only starts a load for a mission that is
+    // neither scanned nor claimed, and every STARTED load ends in `scanned`
+    // (success commits its text, failure commits ""), so each round strictly
+    // shrinks the unscanned set. A round with nothing missing starts no pool and
+    // therefore chains no further round.
+    if (!stopped && phrase) launch(phrase);
+    syncScanning();
+    if (failed) ports.onLoadError();
+  };
+
+  return {
+    scan(nextItems, nextPhrase) {
+      if (stopped) return;
+      // Every wave is tagged with the phrase that launched it: as soon as a new
+      // phrase (or an emptied box) lands here, the running wave stops starting
+      // work. In-flight loads are still committed — a transcript is a fact about
+      // the mission, not about the phrase, so the next wave reuses it.
+      items = nextItems;
+      phrase = nextPhrase;
+      if (!phrase) {
+        syncScanning();
+        return;
+      }
+      launch(phrase);
+    },
+    stop() {
+      stopped = true;
+    },
+  };
+}

--- a/app/src/components/mission-search-text.ts
+++ b/app/src/components/mission-search-text.ts
@@ -1,0 +1,91 @@
+import {
+  extractSnippet,
+  findFoldedMatch,
+  foldForSearch,
+  type MissionSnippet,
+} from "./mission-highlight.ts";
+
+/**
+ * A body of text prepared for mission search: the ORIGINAL (what a snippet
+ * renders, accents and casing intact) alongside its fold (what matching runs
+ * against).
+ *
+ * The split exists because folding is the expensive half: a mission's
+ * transcript is folded ONCE, when it loads, so every later keystroke only
+ * re-runs a regex over the cached fold (HOU-941 — re-folding every transcript
+ * per keystroke is what made search take 10-15s).
+ */
+export interface SearchableText {
+  /** The text as it should be shown to the user. */
+  text: string;
+  /** {@link foldForSearch} of `text` — never rendered, only matched. */
+  folded: string;
+}
+
+export function toSearchableText(text: string): SearchableText {
+  return { text, folded: foldForSearch(text) };
+}
+
+/** Whether the already-folded body contains the (already folded) `phrase`. */
+export function matchesSearchable(
+  source: SearchableText,
+  phrase: string,
+): boolean {
+  return findFoldedMatch(source.folded, phrase) !== null;
+}
+
+/**
+ * The "why did this match" snippet for a searchable body.
+ *
+ * The snippet is cut from the LINE(S) the match falls on, never from the whole
+ * body: highlighting needs an exact folded->original index map, and building
+ * one is a per-character walk. Searchable bodies are newline-joined messages,
+ * so one line is one message — bounded, whatever the transcript's length.
+ *
+ * Line numbers are fold-invariant (folding never adds, removes or reorders a
+ * newline), so the folded match's line span selects the same lines in the
+ * original text. A phrase whose flexible whitespace spans messages matches
+ * across lines, hence a span rather than a single line.
+ */
+export function snippetFor(
+  source: SearchableText,
+  phrase: string,
+): MissionSnippet | null {
+  const match = findFoldedMatch(source.folded, phrase);
+  if (!match) return null;
+  const firstLine = countNewlines(source.folded, match.start);
+  const lastLine = countNewlines(source.folded, match.end);
+  return extractSnippet(lineSpan(source.text, firstLine, lastLine), phrase);
+}
+
+/** How many newlines `text` holds strictly before `index`. */
+function countNewlines(text: string, index: number): number {
+  let count = 0;
+  for (
+    let at = text.indexOf("\n");
+    at !== -1 && at < index;
+    at = text.indexOf("\n", at + 1)
+  ) {
+    count++;
+  }
+  return count;
+}
+
+/** The slice of `text` covering lines `from`..`to` (0-based, inclusive). */
+function lineSpan(text: string, from: number, to: number): string {
+  const start = lineStart(text, from);
+  const lastStart = lineStart(text, to);
+  const end = text.indexOf("\n", lastStart);
+  return text.slice(start, end === -1 ? text.length : end);
+}
+
+/** Index in `text` where 0-based `line` begins (clamped to the end). */
+function lineStart(text: string, line: number): number {
+  let at = 0;
+  for (let n = 0; n < line; n++) {
+    const nl = text.indexOf("\n", at);
+    if (nl === -1) return text.length;
+    at = nl + 1;
+  }
+  return at;
+}

--- a/app/src/components/mission-search.ts
+++ b/app/src/components/mission-search.ts
@@ -1,11 +1,16 @@
 import type { KanbanItem } from "@houston-ai/board";
 import type { FeedItem } from "@houston-ai/chat";
 import {
-  extractSnippet,
   foldForSearch,
   type MissionSnippet,
   matchesPhrase,
 } from "./mission-highlight.ts";
+import {
+  matchesSearchable,
+  type SearchableText,
+  snippetFor,
+  toSearchableText,
+} from "./mission-search-text.ts";
 
 export interface MissionSearchResult<T> {
   items: T[];
@@ -60,10 +65,20 @@ export function buildMissionHistorySearchText(items: FeedItem[]): string {
   return items.map(feedItemToSearchText).filter(Boolean).join("\n");
 }
 
+/**
+ * Filter `items` by `rawQuery` over titles, descriptions and any chat history
+ * already scanned for them.
+ *
+ * `historyById` holds PRE-FOLDED transcripts (see {@link SearchableText}):
+ * matching a keystroke against them is then a regex test, not a re-fold of
+ * every mission's conversation (HOU-941). Description and history are matched
+ * as separate bodies — a snippet comes from whichever one matched, so no
+ * per-keystroke concatenation of transcript-sized strings is needed.
+ */
 export function searchMissions<T extends KanbanItem>(
   items: T[],
   rawQuery: string,
-  historyTextById: Record<string, string> = {},
+  historyById: Record<string, SearchableText> = {},
 ): MissionSearchResult<T> {
   const query = normalizeMissionSearchQuery(rawQuery);
   if (!query) {
@@ -75,15 +90,19 @@ export function searchMissions<T extends KanbanItem>(
     // A title match speaks for itself: keep it, show no snippet, and (per #411)
     // never highlight the title.
     if (matchesPhrase(item.title, query)) return true;
-    // Otherwise search the body + loaded chat history (which includes the
-    // user's own messages) and, on a match, surface a snippet showing why.
-    const text = [item.description, historyTextById[item.id]]
-      .filter(Boolean)
-      .join("\n");
-    if (!matchesPhrase(text, query)) return false;
-    const snippet = extractSnippet(text, query);
-    if (snippet) snippets[item.id] = snippet;
-    return true;
+    // Otherwise search the body, then the loaded chat history (which includes
+    // the user's own messages), and surface a snippet showing why it matched.
+    const bodies = [
+      item.description ? toSearchableText(item.description) : null,
+      historyById[item.id] ?? null,
+    ];
+    for (const body of bodies) {
+      if (!body || !matchesSearchable(body, query)) continue;
+      const snippet = snippetFor(body, query);
+      if (snippet) snippets[item.id] = snippet;
+      return true;
+    }
+    return false;
   });
 
   return { items: matched, hasQuery: true, snippets };

--- a/app/src/components/use-mission-history-scan.ts
+++ b/app/src/components/use-mission-history-scan.ts
@@ -1,15 +1,16 @@
 import type { KanbanItem } from "@houston-ai/board";
 import type { FeedItem } from "@houston-ai/chat";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { runPool } from "../lib/async-pool";
-import type { HistoryLoadOptions } from "../lib/tauri";
-import { matchesPhrase } from "./mission-highlight";
-import { buildMissionHistorySearchText } from "./mission-search";
-import { type SearchableText, toSearchableText } from "./mission-search-text";
-
-/** Transcript loads in flight at once: enough to hide per-request latency,
- *  few enough that a big board never opens one request per mission at once. */
-const SCAN_CONCURRENCY = 5;
+import { useEffect, useRef, useState } from "react";
+import type { HistoryLoadOptions } from "../lib/tauri.ts";
+import {
+  createMissionHistoryScanner,
+  type MissionHistoryScanner,
+} from "./mission-history-scan-wave.ts";
+import { buildMissionHistorySearchText } from "./mission-search.ts";
+import {
+  type SearchableText,
+  toSearchableText,
+} from "./mission-search-text.ts";
 
 /** Loaded transcripts are committed in windows of this long, so results stream
  *  onto the board as they land without re-rendering it once per mission. */
@@ -49,11 +50,11 @@ function sessionKeyFor(item: KanbanItem): string {
  * title or description, so matches deeper in the conversation (including the
  * user's own messages) still surface.
  *
- * The wave is bounded ({@link SCAN_CONCURRENCY}) and streams: each transcript
- * is folded and committed as it settles, so matches appear while the rest is
- * still loading. Changing the phrase or unmounting stops the wave from starting
- * more work — its generation no longer matches, and the next phrase re-scans
- * only what is still missing (transcripts are cached by mission id).
+ * The wave logic itself lives in `mission-history-scan-wave.ts` (bounded
+ * concurrency, per-phrase generations, claim/release, re-launch of what a
+ * superseded wave never started). This hook is only the React skin on top of
+ * it: it owns the two pieces of state a component renders and buffers the
+ * commits so a landing transcript does not re-render the whole board.
  */
 export function useMissionHistoryScan({
   items,
@@ -65,107 +66,63 @@ export function useMissionHistoryScan({
     Record<string, SearchableText>
   >({});
   const [isScanning, setIsScanning] = useState(false);
-  const scanningRef = useRef(false);
-  /** Missions whose transcript is loaded (or failed — recorded as empty). */
-  const scannedRef = useRef<Set<string>>(new Set());
-  /** Missions claimed by the running wave, released when it settles or stops. */
-  const claimedRef = useRef<Set<string>>(new Set());
   const bufferRef = useRef<Record<string, SearchableText>>({});
   const flushRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const remainingRef = useRef(0);
-  /** The phrase the board is scanning for right now — a wave's generation. */
-  const phraseRef = useRef("");
   const mountedRef = useRef(true);
+  /** The scanner reads the CALLERS' latest functions through this ref: it holds
+   *  the scan's whole memory (what is scanned, what is claimed), so a parent
+   *  that hands us a fresh `loadHistory` identity must not cost us that memory. */
+  const portsRef = useRef({ loadHistory, onHistoryLoadError });
+
+  const scannerRef = useRef<MissionHistoryScanner<KanbanItem> | null>(null);
+  if (scannerRef.current === null) {
+    const flush = () => {
+      flushRef.current = null;
+      const batch = bufferRef.current;
+      bufferRef.current = {};
+      if (!mountedRef.current || Object.keys(batch).length === 0) return;
+      setHistoryById((prev) => ({ ...prev, ...batch }));
+    };
+    scannerRef.current = createMissionHistoryScanner<KanbanItem>({
+      loadTranscript: async (item) => {
+        const history = await portsRef.current.loadHistory(
+          sessionKeyFor(item),
+          {
+            observe: false,
+          },
+        );
+        return buildMissionHistorySearchText(history);
+      },
+      onTranscript: (id, text) => {
+        bufferRef.current[id] = toSearchableText(text);
+        if (flushRef.current === null) {
+          flushRef.current = setTimeout(flush, COMMIT_INTERVAL_MS);
+        }
+      },
+      onScanningChange: (scanning) => {
+        if (mountedRef.current) setIsScanning(scanning);
+      },
+      onLoadError: () => portsRef.current.onHistoryLoadError?.(),
+    });
+  }
+
+  // Declared BEFORE the scan effect so a wave launched below always reaches the
+  // loader this render was given, never the previous one.
+  useEffect(() => {
+    portsRef.current = { loadHistory, onHistoryLoadError };
+  }, [loadHistory, onHistoryLoadError]);
+
+  useEffect(() => {
+    scannerRef.current?.scan(items, phrase);
+  }, [items, phrase]);
 
   useEffect(() => {
     return () => {
       mountedRef.current = false;
+      scannerRef.current?.stop();
       if (flushRef.current !== null) clearTimeout(flushRef.current);
     };
   }, []);
-
-  /** Publish the spinner only when it actually flips — this hook sits above a
-   *  whole board, and every settled transcript calls in here. */
-  const syncScanning = useCallback(() => {
-    const next = remainingRef.current > 0;
-    if (scanningRef.current === next) return;
-    scanningRef.current = next;
-    if (mountedRef.current) setIsScanning(next);
-  }, []);
-
-  const flush = useCallback(() => {
-    flushRef.current = null;
-    const batch = bufferRef.current;
-    bufferRef.current = {};
-    if (!mountedRef.current || Object.keys(batch).length === 0) return;
-    setHistoryById((prev) => ({ ...prev, ...batch }));
-  }, []);
-
-  const commit = useCallback(
-    (id: string, text: string) => {
-      bufferRef.current[id] = toSearchableText(text);
-      scannedRef.current.add(id);
-      claimedRef.current.delete(id);
-      remainingRef.current -= 1;
-      syncScanning();
-      if (flushRef.current === null) {
-        flushRef.current = setTimeout(flush, COMMIT_INTERVAL_MS);
-      }
-    },
-    [flush, syncScanning],
-  );
-
-  useEffect(() => {
-    // Every wave is tagged with the phrase that launched it: as soon as a new
-    // phrase (or an emptied box) lands here, the running wave stops starting
-    // work. In-flight loads are still committed — a transcript is a fact about
-    // the mission, not about the phrase, so the next wave reuses it.
-    phraseRef.current = phrase;
-    if (!phrase) {
-      syncScanning();
-      return;
-    }
-    const missing = items.filter(
-      (item) =>
-        !scannedRef.current.has(item.id) &&
-        !claimedRef.current.has(item.id) &&
-        !matchesPhrase(item.title, phrase) &&
-        !matchesPhrase(item.description, phrase),
-    );
-    if (missing.length === 0) return;
-
-    for (const item of missing) claimedRef.current.add(item.id);
-    remainingRef.current += missing.length;
-    syncScanning();
-
-    let failed = false;
-    void runPool(
-      missing,
-      SCAN_CONCURRENCY,
-      async (item) => {
-        try {
-          const history = await loadHistory(sessionKeyFor(item), {
-            observe: false,
-          });
-          commit(item.id, buildMissionHistorySearchText(history));
-        } catch (err) {
-          console.error("[mission-search] history load failed", err);
-          // Record the failure as an empty transcript so the mission is not
-          // retried on every keystroke; the toast below tells the user.
-          commit(item.id, "");
-          failed = true;
-        }
-      },
-      () => !mountedRef.current || phraseRef.current !== phrase,
-    ).then(() => {
-      // Release whatever this wave never got to (superseded phrase / unmount).
-      for (const item of missing) {
-        if (claimedRef.current.delete(item.id)) remainingRef.current -= 1;
-      }
-      syncScanning();
-      if (failed) onHistoryLoadError?.();
-    });
-  }, [commit, items, loadHistory, onHistoryLoadError, phrase, syncScanning]);
 
   return { historyById, isScanning };
 }

--- a/app/src/components/use-mission-history-scan.ts
+++ b/app/src/components/use-mission-history-scan.ts
@@ -1,0 +1,171 @@
+import type { KanbanItem } from "@houston-ai/board";
+import type { FeedItem } from "@houston-ai/chat";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { runPool } from "../lib/async-pool";
+import type { HistoryLoadOptions } from "../lib/tauri";
+import { matchesPhrase } from "./mission-highlight";
+import { buildMissionHistorySearchText } from "./mission-search";
+import { type SearchableText, toSearchableText } from "./mission-search-text";
+
+/** Transcript loads in flight at once: enough to hide per-request latency,
+ *  few enough that a big board never opens one request per mission at once. */
+const SCAN_CONCURRENCY = 5;
+
+/** Loaded transcripts are committed in windows of this long, so results stream
+ *  onto the board as they land without re-rendering it once per mission. */
+const COMMIT_INTERVAL_MS = 120;
+
+interface UseMissionHistoryScanOptions {
+  items: KanbanItem[];
+  /** The already-normalized, already-DEBOUNCED phrase. "" scans nothing. */
+  phrase: string;
+  /**
+   * Must forward the options to the history loader: the scan passes
+   * `observe: false`, which marks a BULK read — the engine adapter then reads a
+   * bounded scan window and spawns no observer stream (those are for real
+   * conversation opens).
+   */
+  loadHistory: (
+    sessionKey: string,
+    opts?: HistoryLoadOptions,
+  ) => Promise<FeedItem[]>;
+  onHistoryLoadError?: () => void;
+}
+
+export interface MissionHistoryScan {
+  /** `item.id` -> its pre-folded transcript. Absent = not scanned yet. */
+  historyById: Record<string, SearchableText>;
+  /** A scan wave is still running (some missions are not searched yet). */
+  isScanning: boolean;
+}
+
+function sessionKeyFor(item: KanbanItem): string {
+  const key = item.metadata?.sessionKey;
+  return typeof key === "string" ? key : `activity-${item.id}`;
+}
+
+/**
+ * Loads the chat history of every mission the phrase does NOT already match by
+ * title or description, so matches deeper in the conversation (including the
+ * user's own messages) still surface.
+ *
+ * The wave is bounded ({@link SCAN_CONCURRENCY}) and streams: each transcript
+ * is folded and committed as it settles, so matches appear while the rest is
+ * still loading. Changing the phrase or unmounting stops the wave from starting
+ * more work — its generation no longer matches, and the next phrase re-scans
+ * only what is still missing (transcripts are cached by mission id).
+ */
+export function useMissionHistoryScan({
+  items,
+  phrase,
+  loadHistory,
+  onHistoryLoadError,
+}: UseMissionHistoryScanOptions): MissionHistoryScan {
+  const [historyById, setHistoryById] = useState<
+    Record<string, SearchableText>
+  >({});
+  const [isScanning, setIsScanning] = useState(false);
+  const scanningRef = useRef(false);
+  /** Missions whose transcript is loaded (or failed — recorded as empty). */
+  const scannedRef = useRef<Set<string>>(new Set());
+  /** Missions claimed by the running wave, released when it settles or stops. */
+  const claimedRef = useRef<Set<string>>(new Set());
+  const bufferRef = useRef<Record<string, SearchableText>>({});
+  const flushRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const remainingRef = useRef(0);
+  /** The phrase the board is scanning for right now — a wave's generation. */
+  const phraseRef = useRef("");
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      if (flushRef.current !== null) clearTimeout(flushRef.current);
+    };
+  }, []);
+
+  /** Publish the spinner only when it actually flips — this hook sits above a
+   *  whole board, and every settled transcript calls in here. */
+  const syncScanning = useCallback(() => {
+    const next = remainingRef.current > 0;
+    if (scanningRef.current === next) return;
+    scanningRef.current = next;
+    if (mountedRef.current) setIsScanning(next);
+  }, []);
+
+  const flush = useCallback(() => {
+    flushRef.current = null;
+    const batch = bufferRef.current;
+    bufferRef.current = {};
+    if (!mountedRef.current || Object.keys(batch).length === 0) return;
+    setHistoryById((prev) => ({ ...prev, ...batch }));
+  }, []);
+
+  const commit = useCallback(
+    (id: string, text: string) => {
+      bufferRef.current[id] = toSearchableText(text);
+      scannedRef.current.add(id);
+      claimedRef.current.delete(id);
+      remainingRef.current -= 1;
+      syncScanning();
+      if (flushRef.current === null) {
+        flushRef.current = setTimeout(flush, COMMIT_INTERVAL_MS);
+      }
+    },
+    [flush, syncScanning],
+  );
+
+  useEffect(() => {
+    // Every wave is tagged with the phrase that launched it: as soon as a new
+    // phrase (or an emptied box) lands here, the running wave stops starting
+    // work. In-flight loads are still committed — a transcript is a fact about
+    // the mission, not about the phrase, so the next wave reuses it.
+    phraseRef.current = phrase;
+    if (!phrase) {
+      syncScanning();
+      return;
+    }
+    const missing = items.filter(
+      (item) =>
+        !scannedRef.current.has(item.id) &&
+        !claimedRef.current.has(item.id) &&
+        !matchesPhrase(item.title, phrase) &&
+        !matchesPhrase(item.description, phrase),
+    );
+    if (missing.length === 0) return;
+
+    for (const item of missing) claimedRef.current.add(item.id);
+    remainingRef.current += missing.length;
+    syncScanning();
+
+    let failed = false;
+    void runPool(
+      missing,
+      SCAN_CONCURRENCY,
+      async (item) => {
+        try {
+          const history = await loadHistory(sessionKeyFor(item), {
+            observe: false,
+          });
+          commit(item.id, buildMissionHistorySearchText(history));
+        } catch (err) {
+          console.error("[mission-search] history load failed", err);
+          // Record the failure as an empty transcript so the mission is not
+          // retried on every keystroke; the toast below tells the user.
+          commit(item.id, "");
+          failed = true;
+        }
+      },
+      () => !mountedRef.current || phraseRef.current !== phrase,
+    ).then(() => {
+      // Release whatever this wave never got to (superseded phrase / unmount).
+      for (const item of missing) {
+        if (claimedRef.current.delete(item.id)) remainingRef.current -= 1;
+      }
+      syncScanning();
+      if (failed) onHistoryLoadError?.();
+    });
+  }, [commit, items, loadHistory, onHistoryLoadError, phrase, syncScanning]);
+
+  return { historyById, isScanning };
+}

--- a/app/src/components/use-mission-search.ts
+++ b/app/src/components/use-mission-search.ts
@@ -1,32 +1,29 @@
 import type { KanbanItem } from "@houston-ai/board";
 import type { FeedItem } from "@houston-ai/chat";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import { useDebouncedValue } from "../hooks/use-debounced-value";
 import { analytics } from "../lib/analytics";
+import type { HistoryLoadOptions } from "../lib/tauri";
 import { matchesPhrase } from "./mission-highlight";
-import {
-  buildMissionHistorySearchText,
-  normalizeMissionSearchQuery,
-  searchMissions,
-} from "./mission-search";
+import { normalizeMissionSearchQuery, searchMissions } from "./mission-search";
+import { useMissionHistoryScan } from "./use-mission-history-scan";
+
+/**
+ * How long typing must pause before the transcript scan fires. Matching what is
+ * already loaded stays on the RAW query (it is a regex over pre-folded text, so
+ * the board narrows on every keystroke); only the network wave waits (HOU-941).
+ */
+const SCAN_DEBOUNCE_MS = 250;
 
 interface UseMissionSearchOptions {
   items: KanbanItem[];
   query: string;
-  /**
-   * Must forward the options to the history loader: search loads N missions'
-   * histories at a time and passes `observe: false` so the new-engine adapter
-   * doesn't spawn N observer streams (that's for real conversation opens).
-   */
+  /** Forwarded to {@link useMissionHistoryScan} — see its `loadHistory`. */
   loadHistory: (
     sessionKey: string,
-    opts?: { observe?: boolean },
+    opts?: HistoryLoadOptions,
   ) => Promise<FeedItem[]>;
   onHistoryLoadError?: () => void;
-}
-
-function sessionKeyFor(item: KanbanItem): string {
-  const key = item.metadata?.sessionKey;
-  return typeof key === "string" ? key : `activity-${item.id}`;
 }
 
 export function useMissionSearch({
@@ -35,24 +32,22 @@ export function useMissionSearch({
   loadHistory,
   onHistoryLoadError,
 }: UseMissionSearchOptions) {
-  const [historyTextById, setHistoryTextById] = useState<
-    Record<string, string>
-  >({});
-  const [pendingCount, setPendingCount] = useState(0);
-  const loadingIdsRef = useRef<Set<string>>(new Set());
-  const mountedRef = useRef(true);
   const phrase = normalizeMissionSearchQuery(query);
+  const debouncedPhrase = useDebouncedValue(phrase, SCAN_DEBOUNCE_MS);
+  // Clearing the box stops the scan at once — there is nothing to wait for.
+  const scanPhrase = phrase ? debouncedPhrase : "";
+
+  const { historyById, isScanning } = useMissionHistoryScan({
+    items,
+    phrase: scanPhrase,
+    loadHistory,
+    onHistoryLoadError,
+  });
 
   const result = useMemo(
-    () => searchMissions(items, query, historyTextById),
-    [items, query, historyTextById],
+    () => searchMissions(items, query, historyById),
+    [items, query, historyById],
   );
-
-  useEffect(() => {
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
 
   // One event per search session (empty → non-empty), never per keystroke.
   const searchingRef = useRef(false);
@@ -65,63 +60,24 @@ export function useMissionSearch({
     }
   }, [phrase]);
 
-  useEffect(() => {
-    if (!phrase) return;
-    // Load chat history only for missions that don't already match by title or
-    // description, so matches deeper in the conversation (including the user's
-    // own messages) still surface — even when other missions match by title.
-    const missing = items.filter(
+  // Between the last keystroke and the scan wave, the spinner has to stand for
+  // the missions nobody has looked inside yet — but only for those: with every
+  // transcript already scanned the results are final and the box must be calm.
+  const scanPending =
+    phrase !== scanPhrase &&
+    items.some(
       (item) =>
+        historyById[item.id] === undefined &&
         !matchesPhrase(item.title, phrase) &&
-        !matchesPhrase(item.description, phrase) &&
-        historyTextById[item.id] === undefined &&
-        !loadingIdsRef.current.has(item.id),
+        !matchesPhrase(item.description, phrase),
     );
-    if (missing.length === 0) return;
-
-    for (const item of missing) loadingIdsRef.current.add(item.id);
-    setPendingCount((count) => count + missing.length);
-
-    Promise.allSettled(
-      missing.map(async (item) => {
-        const history = await loadHistory(sessionKeyFor(item), {
-          observe: false,
-        });
-        return [item.id, buildMissionHistorySearchText(history)] as const;
-      }),
-    )
-      .then((settled) => {
-        const next: Record<string, string> = {};
-        let failed = false;
-
-        settled.forEach((entry, index) => {
-          const item = missing[index];
-          if (entry.status === "fulfilled") {
-            const [id, text] = entry.value;
-            next[id] = text;
-            return;
-          }
-          console.error("[mission-search] history load failed", entry.reason);
-          next[item.id] = "";
-          failed = true;
-        });
-
-        if (!mountedRef.current) return;
-        setHistoryTextById((prev) => ({ ...prev, ...next }));
-        if (failed) onHistoryLoadError?.();
-      })
-      .finally(() => {
-        for (const item of missing) loadingIdsRef.current.delete(item.id);
-        if (mountedRef.current) {
-          setPendingCount((count) => Math.max(0, count - missing.length));
-        }
-      });
-  }, [historyTextById, items, loadHistory, phrase, onHistoryLoadError]);
 
   return {
     items: result.items,
     hasQuery: result.hasQuery,
     snippets: result.snippets,
-    isSearchingText: pendingCount > 0,
+    // An emptied box is never "still searching", even while the loads the last
+    // phrase started drain.
+    isSearchingText: phrase !== "" && (isScanning || scanPending),
   };
 }

--- a/app/src/hooks/use-debounced-value.ts
+++ b/app/src/hooks/use-debounced-value.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+/**
+ * `value`, but only after it has stopped changing for `delayMs`.
+ *
+ * For work a keystroke should NOT pay for on every character — anything that
+ * costs a network round trip. Mission search hangs its transcript scan off
+ * this: typing "budget" used to fire a full history load per mission per
+ * keystroke (HOU-941), while the instant client-side filter stays on the raw
+ * value so the board still narrows as you type.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    // Already settled (mount, or the timer just landed): no timer, and above
+    // all no redundant state write — this sits above a whole board.
+    if (Object.is(value, debounced)) return;
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, debounced, delayMs]);
+
+  return debounced;
+}

--- a/app/src/lib/async-pool.ts
+++ b/app/src/lib/async-pool.ts
@@ -1,0 +1,34 @@
+/**
+ * Run `task` over `items` with at most `limit` of them in flight at a time,
+ * resolving once every started task has settled.
+ *
+ * Nothing is batched: `task` commits its own result as it settles, so a caller
+ * can stream results into the UI instead of waiting for the slowest one (the
+ * mission-search transcript scan used to `Promise.allSettled` the whole board
+ * and paint once at the end — HOU-941).
+ *
+ * `shouldStop` is consulted before each start, so a superseded run stops
+ * launching work rather than finishing a wave nobody is waiting for any more.
+ * Tasks already in flight are not interrupted; a caller that must discard their
+ * results checks its own generation inside `task`.
+ *
+ * `task` MUST NOT reject — it owns its own error handling (a rejection would
+ * take its worker down and leave the remaining items unprocessed).
+ */
+export async function runPool<T>(
+  items: readonly T[],
+  limit: number,
+  task: (item: T) => Promise<void>,
+  shouldStop: () => boolean = () => false,
+): Promise<void> {
+  let next = 0;
+  const workers = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(
+    Array.from({ length: workers }, async () => {
+      while (next < items.length) {
+        if (shouldStop()) return;
+        await task(items[next++]);
+      }
+    }),
+  );
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -358,9 +358,11 @@ export const tauriAgentModelChoice = {
 
 /**
  * How a chat history load behaves. `observe: false` marks a BULK read
- * (mission search, board scans over N conversations): the new-engine adapter
- * then skips attaching its passive in-flight-turn observer stream, which only
- * a real conversation open (the default) should do.
+ * (mission search, board scans over N conversations). The new-engine adapter
+ * then (a) skips attaching its passive in-flight-turn observer stream, which
+ * only a real conversation open should do, (b) reads the wider but still
+ * BOUNDED scan window instead of a full transcript, and (c) leaves the local
+ * conversation cache alone. See `engine-adapter/history-window.ts`.
  */
 export interface HistoryLoadOptions {
   observe?: boolean;

--- a/app/tests/async-pool.test.ts
+++ b/app/tests/async-pool.test.ts
@@ -1,0 +1,79 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { runPool } from "../src/lib/async-pool.ts";
+
+/** A promise plus its resolver, so a test decides when a task settles. */
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("runPool", () => {
+  it("never runs more than `limit` tasks at a time", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const items = Array.from({ length: 20 }, (_, i) => i);
+
+    await runPool(items, 4, async (item) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, item % 3));
+      inFlight--;
+    });
+
+    strictEqual(peak, 4);
+    strictEqual(inFlight, 0);
+  });
+
+  it("runs every item exactly once, whatever the settle order", async () => {
+    const gates = [deferred(), deferred(), deferred()];
+    const done: number[] = [];
+
+    const pool = runPool([0, 1, 2], 3, async (i) => {
+      await gates[i].promise;
+      done.push(i);
+    });
+
+    // Settle out of order: results are committed as they land, not batched.
+    gates[2].resolve();
+    await tick();
+    deepStrictEqual(done, [2]);
+    gates[0].resolve();
+    gates[1].resolve();
+    await pool;
+    deepStrictEqual(done.slice().sort(), [0, 1, 2]);
+  });
+
+  it("stops starting work once the run is superseded", async () => {
+    const started: number[] = [];
+    let generation = 1;
+    const items = Array.from({ length: 10 }, (_, i) => i);
+
+    await runPool(
+      items,
+      2,
+      async (item) => {
+        started.push(item);
+        // A phrase change lands while the first pair is in flight.
+        if (started.length === 2) generation = 2;
+        await tick();
+      },
+      () => generation !== 1,
+    );
+
+    deepStrictEqual(started, [0, 1]);
+  });
+
+  it("resolves immediately on an empty item list", async () => {
+    let ran = 0;
+    await runPool([], 4, async () => {
+      ran++;
+    });
+    strictEqual(ran, 0);
+  });
+});

--- a/app/tests/mission-highlight.test.ts
+++ b/app/tests/mission-highlight.test.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
   extractSnippet,
+  findFoldedMatch,
   findHighlightRanges,
   foldForSearch,
   matchesPhrase,
@@ -15,9 +16,64 @@ function highlighted(
   return ranges.map((r) => text.slice(r.start, r.end));
 }
 
+const COMBINING_MARKS = /[̀-ͯ]/g;
+
+/** The per-CHARACTER fold `foldForSearch` used to be (HOU-941 replaced it with
+ *  a single whole-string pass). Kept here as the reference implementation the
+ *  fast fold must agree with. */
+function foldPerChar(text: string): string {
+  let folded = "";
+  for (let i = 0; i < text.length; i++) {
+    folded += text[i]
+      .normalize("NFKD")
+      .replace(COMBINING_MARKS, "")
+      .toLowerCase();
+  }
+  return folded;
+}
+
 describe("foldForSearch", () => {
   it("lowercases and strips accents", () => {
     strictEqual(foldForSearch("São PAULO"), "sao paulo");
+  });
+
+  it("keeps the semantics of the per-character fold it replaced", () => {
+    const corpus = [
+      "São PAULO", // precomposed accents
+      "noël", // decomposed accent (base + combining mark)
+      "ÉLAN vital",
+      "Straße", // no case folding of ß, by design
+      "ﬁle ﬂow", // NFKD-expanded ligatures
+      "½ cup", // NFKD-expanded fraction
+      "ｈｅｌｌｏ", // NFKD-expanded fullwidth
+      "İstanbul", // uppercase dotted I: NFKD + lowercase
+      "Ǆungla", // a single char folding to more than one
+      "🙂 emoji", // surrogate pairs survive intact
+      "",
+    ];
+    for (const value of corpus) {
+      strictEqual(foldForSearch(value), foldPerChar(value), value);
+    }
+  });
+});
+
+describe("findFoldedMatch", () => {
+  it("locates the phrase in ALREADY-folded text", () => {
+    const folded = foldForSearch("Refresh São Paulo budget");
+    deepStrictEqual(findFoldedMatch(folded, "sao paulo"), {
+      start: 8,
+      end: 17,
+    });
+  });
+
+  it("spans flexible whitespace and reports null when absent", () => {
+    const folded = foldForSearch("do this\nmonth now");
+    const match = findFoldedMatch(folded, "this month");
+    strictEqual(match !== null, true);
+    strictEqual(folded.slice(match?.start, match?.end), "this\nmonth");
+    strictEqual(findFoldedMatch(folded, "next month"), null);
+    strictEqual(findFoldedMatch("", "budget"), null);
+    strictEqual(findFoldedMatch("text", ""), null);
   });
 });
 

--- a/app/tests/mission-history-scan-wave.test.ts
+++ b/app/tests/mission-history-scan-wave.test.ts
@@ -1,0 +1,226 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  createMissionHistoryScanner,
+  type ScanItem,
+} from "../src/components/mission-history-scan-wave.ts";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+/** Missions whose title/description contain no "b", so every phrase in these
+ *  tests can only be answered by loading the transcript. */
+function missions(count: number): ScanItem[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `m${i}`,
+    title: `Mission ${i}`,
+    description: `Notes ${i}`,
+  }));
+}
+
+interface Gate {
+  resolve: (text: string) => void;
+  reject: (err: Error) => void;
+}
+
+/** Drives the scanner with fully controlled loads: a transcript settles only
+ *  when the test says so, which is what makes the superseded-wave interleaving
+ *  reproducible instead of timing-dependent. */
+function harness(options: { concurrency?: number; failing?: string[] } = {}) {
+  const failing = new Set(options.failing ?? []);
+  const started: string[] = [];
+  const gates = new Map<string, Gate>();
+  const committed = new Map<string, string>();
+  /** Every spinner transition, in order — the flag must not blink off mid-scan. */
+  const flips: boolean[] = [];
+  let errors = 0;
+
+  const scanner = createMissionHistoryScanner<ScanItem>({
+    concurrency: options.concurrency ?? 5,
+    loadTranscript: (item) => {
+      started.push(item.id);
+      return new Promise<string>((resolve, reject) => {
+        gates.set(item.id, { resolve, reject });
+      });
+    },
+    onTranscript: (id, text) => {
+      committed.set(id, text);
+    },
+    onScanningChange: (value) => {
+      flips.push(value);
+    },
+    onLoadError: () => {
+      errors += 1;
+    },
+  });
+
+  /** Settle every open load, and keep settling whatever that starts, until the
+   *  scanner stops opening new ones. */
+  const settleAll = async (): Promise<void> => {
+    for (let round = 0; round < 50 && gates.size > 0; round++) {
+      const open = [...gates.entries()];
+      gates.clear();
+      for (const [id, gate] of open) {
+        if (failing.has(id)) gate.reject(new Error(`load failed: ${id}`));
+        else gate.resolve(`transcript ${id}`);
+      }
+      await tick();
+    }
+  };
+
+  return {
+    scanner,
+    started,
+    committed,
+    flips,
+    settleAll,
+    openGates: () => gates.size,
+    errorCount: () => errors,
+  };
+}
+
+/** Silences (and records) the load-failure diagnostic for one test. */
+async function withSilencedConsoleError(
+  body: (logged: unknown[][]) => Promise<void>,
+): Promise<void> {
+  const logged: unknown[][] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    logged.push(args);
+  };
+  try {
+    await body(logged);
+  } finally {
+    console.error = original;
+  }
+}
+
+describe("mission history scan wave", () => {
+  it("scans every mission a superseded wave never started", async () => {
+    // The regression: 20 missions, 5 in flight. Typing "b" claims all 20 and
+    // starts 5; "budget" lands while the other 15 are still claimed, so the new
+    // wave sees nothing missing and returns. When wave one settles it releases
+    // those 15 — and nothing was left to pick them up, so 15 of 20 transcripts
+    // were never read and the board said "search complete".
+    const h = harness({ concurrency: 5 });
+    const items = missions(20);
+
+    h.scanner.scan(items, "b");
+    await tick();
+    strictEqual(h.started.length, 5, "first wave starts exactly `concurrency`");
+    deepStrictEqual(h.flips, [true], "spinner is on while the wave runs");
+
+    h.scanner.scan(items, "budget");
+    await h.settleAll();
+
+    strictEqual(h.committed.size, 20, "every mission ends up scanned");
+    deepStrictEqual(
+      [...h.committed.keys()].sort(),
+      items.map((item) => item.id).sort(),
+    );
+    deepStrictEqual(
+      h.flips,
+      [true, false],
+      "spinner turns off exactly once, at the end",
+    );
+  });
+
+  it("keeps re-launching across repeated phrase changes", async () => {
+    const h = harness({ concurrency: 2 });
+    const items = missions(6);
+
+    h.scanner.scan(items, "b");
+    await tick();
+    h.scanner.scan(items, "bu");
+    await tick();
+    h.scanner.scan(items, "bud");
+    await h.settleAll();
+
+    strictEqual(h.committed.size, 6);
+    strictEqual(h.openGates(), 0, "no load is left dangling");
+    deepStrictEqual(h.flips, [true, false]);
+  });
+
+  it("never re-loads a transcript it already holds", async () => {
+    const h = harness({ concurrency: 5 });
+    const items = missions(8);
+
+    h.scanner.scan(items, "b");
+    await h.settleAll();
+    strictEqual(h.started.length, 8);
+
+    h.scanner.scan(items, "budget");
+    await h.settleAll();
+    strictEqual(h.started.length, 8, "cached transcripts are reused as-is");
+    deepStrictEqual(
+      h.flips,
+      [true, false],
+      "no second spinner for a cache hit",
+    );
+  });
+
+  it("skips missions the phrase already matches by title or description", async () => {
+    const h = harness({ concurrency: 5 });
+    const items: ScanItem[] = [
+      { id: "title", title: "Budget review", description: "Notes" },
+      { id: "body", title: "Weekly report", description: "The budget notes" },
+      { id: "deep", title: "Customer call", description: "Notes" },
+    ];
+
+    h.scanner.scan(items, "budget");
+    await h.settleAll();
+
+    deepStrictEqual(h.started, ["deep"]);
+  });
+
+  it("records a failed load as empty and surfaces the error once per wave", async () => {
+    await withSilencedConsoleError(async (logged) => {
+      const h = harness({ concurrency: 5, failing: ["m1", "m2"] });
+      const items = missions(4);
+
+      h.scanner.scan(items, "b");
+      await h.settleAll();
+
+      strictEqual(h.committed.get("m1"), "");
+      strictEqual(h.committed.get("m2"), "");
+      strictEqual(h.committed.get("m0"), "transcript m0");
+      strictEqual(h.errorCount(), 1, "two failures, one toast");
+      strictEqual(logged.length, 2);
+      strictEqual(logged[0][0], "[mission-search] history load failed");
+
+      // A failure is remembered as an empty transcript, so the next phrase does
+      // not retry it on every keystroke.
+      h.scanner.scan(items, "budget");
+      await h.settleAll();
+      strictEqual(h.started.length, 4);
+    });
+  });
+
+  it("scans nothing for an empty phrase", async () => {
+    const h = harness({ concurrency: 5 });
+
+    h.scanner.scan(missions(5), "");
+    await h.settleAll();
+
+    strictEqual(h.started.length, 0);
+    deepStrictEqual(h.flips, [], "the spinner never came on");
+  });
+
+  it("stops starting work after stop(), and commits what is in flight", async () => {
+    const h = harness({ concurrency: 2 });
+    const items = missions(6);
+
+    h.scanner.scan(items, "b");
+    await tick();
+    strictEqual(h.started.length, 2);
+
+    h.scanner.stop();
+    await h.settleAll();
+
+    strictEqual(h.started.length, 2, "no further loads are started");
+    strictEqual(h.committed.size, 2, "in-flight loads still commit");
+
+    h.scanner.scan(items, "budget");
+    await h.settleAll();
+    strictEqual(h.started.length, 2, "a stopped scanner stays stopped");
+  });
+});

--- a/app/tests/mission-search-text.test.ts
+++ b/app/tests/mission-search-text.test.ts
@@ -1,0 +1,93 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { foldForSearch } from "../src/components/mission-highlight.ts";
+import {
+  matchesSearchable,
+  snippetFor,
+  toSearchableText,
+} from "../src/components/mission-search-text.ts";
+
+describe("toSearchableText", () => {
+  it("keeps the original for display and folds it once for matching", () => {
+    const source = toSearchableText("Refresh São Paulo budget");
+    strictEqual(source.text, "Refresh São Paulo budget");
+    strictEqual(source.folded, "refresh sao paulo budget");
+  });
+});
+
+describe("matchesSearchable", () => {
+  it("matches the pre-folded text without re-folding it", () => {
+    const source = toSearchableText("Refresh São Paulo budget");
+    strictEqual(matchesSearchable(source, "sao paulo"), true);
+    strictEqual(matchesSearchable(source, "budget"), true);
+    strictEqual(matchesSearchable(source, "paulo refresh"), false);
+  });
+
+  it("agrees with matching over a transcript-shaped body", () => {
+    const source = toSearchableText(
+      ["Send the invoice", 'Grep {"pattern":"invoice"}', "Invoice sent"].join(
+        "\n",
+      ),
+    );
+    strictEqual(matchesSearchable(source, "invoice sent"), true);
+    // Messages are newline-joined, and a phrase's flexible whitespace spans
+    // that boundary — but scattered words still never match.
+    strictEqual(matchesSearchable(source, "invoice grep"), true);
+    strictEqual(matchesSearchable(source, "send invoice"), false);
+  });
+});
+
+describe("snippetFor", () => {
+  const transcript = [
+    "Kicked off the launch checklist and assigned the owners.",
+    "Then we reviewed the quarterly budget for São Paulo before moving on.",
+    "Finally we scheduled the retro for next week.",
+  ].join("\n");
+
+  it("cuts the snippet from the ORIGINAL message, accents intact", () => {
+    const snippet = snippetFor(toSearchableText(transcript), "sao paulo");
+    strictEqual(snippet !== null, true);
+    if (!snippet) return;
+    strictEqual(snippet.text.includes("São Paulo"), true);
+    // Only the matching line, never the neighbouring messages.
+    strictEqual(snippet.text.includes("retro"), false);
+    strictEqual(snippet.text.includes("checklist"), false);
+    deepStrictEqual(
+      snippet.ranges.map((r) => snippet.text.slice(r.start, r.end)),
+      ["São Paulo"],
+    );
+  });
+
+  it("spans the messages a flexible-whitespace phrase straddles", () => {
+    const source = toSearchableText("ask about this\nmonth end totals");
+    const snippet = snippetFor(source, "this month");
+    strictEqual(snippet !== null, true);
+    if (!snippet) return;
+    deepStrictEqual(
+      snippet.ranges
+        .map((r) => snippet.text.slice(r.start, r.end))
+        .map((s) => s.replace(/\s+/g, " ")),
+      ["this month"],
+    );
+  });
+
+  it("finds a match on the last line of a long transcript", () => {
+    const long = [
+      ...Array.from({ length: 400 }, (_, i) => `Routine status update ${i}`),
+      "The vendor contract is attached here.",
+    ].join("\n");
+    const source = toSearchableText(long);
+    // Fold happened once, up front: matching only reads the cached fold.
+    strictEqual(source.folded, foldForSearch(long));
+    const snippet = snippetFor(source, "vendor contract");
+    strictEqual(snippet !== null, true);
+    if (!snippet) return;
+    strictEqual(snippet.text.includes("vendor contract"), true);
+    strictEqual(snippet.text.includes("Routine status"), false);
+  });
+
+  it("is null when the phrase does not occur", () => {
+    strictEqual(snippetFor(toSearchableText(transcript), "invoice"), null);
+    strictEqual(snippetFor(toSearchableText(""), "invoice"), null);
+  });
+});

--- a/app/tests/mission-search.test.ts
+++ b/app/tests/mission-search.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeMissionSearchQuery,
   searchMissions,
 } from "../src/components/mission-search.ts";
+import { toSearchableText } from "../src/components/mission-search-text.ts";
 
 const missions = [
   {
@@ -70,7 +71,9 @@ describe("mission search", () => {
 
   it("searches loaded chat history, including the user's own messages", () => {
     const result = searchMissions(missions, "vendor contract", {
-      three: "Assistant found the vendor contract in old messages.",
+      three: toSearchableText(
+        "Assistant found the vendor contract in old messages.",
+      ),
     });
     deepStrictEqual(
       result.items.map((m) => m.id),
@@ -80,6 +83,46 @@ describe("mission search", () => {
       result.snippets.three.text.toLowerCase().includes("vendor contract"),
       true,
     );
+  });
+
+  it("snippets a history match from the ORIGINAL message, accents intact", () => {
+    const history = buildMissionHistorySearchText([
+      { feed_type: "user_message", data: "Where did we land on staffing?" },
+      {
+        feed_type: "final_result",
+        data: {
+          result: "The São Paulo office signs the lease next week.",
+          cost_usd: null,
+          duration_ms: null,
+        },
+      },
+    ]);
+    const result = searchMissions(missions, "sao paulo", {
+      three: toSearchableText(history),
+    });
+    deepStrictEqual(
+      result.items.map((m) => m.id),
+      ["three"],
+    );
+    const snippet = result.snippets.three;
+    strictEqual(snippet.text.includes("São Paulo"), true);
+    // Cut from the matching message only, not the whole transcript.
+    strictEqual(snippet.text.includes("staffing"), false);
+    deepStrictEqual(
+      snippet.ranges.map((r) => snippet.text.slice(r.start, r.end)),
+      ["São Paulo"],
+    );
+  });
+
+  it("prefers the description's own snippet over the history's", () => {
+    const result = searchMissions(missions, "budget notes", {
+      two: toSearchableText("Chat history also mentions budget notes later."),
+    });
+    deepStrictEqual(
+      result.items.map((m) => m.id),
+      ["two"],
+    );
+    strictEqual(result.snippets.two.text.includes("transcript"), true);
   });
 
   it("includes user messages, tools, files, and results in searchable text", () => {

--- a/packages/web/src/engine-adapter/client/chat-history-mixin.ts
+++ b/packages/web/src/engine-adapter/client/chat-history-mixin.ts
@@ -3,13 +3,13 @@ import type { ChatHistoryEntry } from "../../../../../ui/engine-client/src/types
 import * as controlPlane from "../control-plane";
 import {
   type CachedFrame,
-  readCachedConversation,
   writeCachedConversation,
 } from "../conversation-cache";
-import { CHAT_OPEN_WINDOW } from "../history-window";
+import { CHAT_OPEN_WINDOW, SEARCH_SCAN_WINDOW } from "../history-window";
 import { historyToFeed, isConversationNotFound } from "../translate";
 import { observeConversation, seedConversationVm } from "../turn-stream";
 import { setActivityStatus } from "./activity-status";
+import { cachedFallbackTranscript, seedFromCache } from "./history-cache";
 import { loadOlderPage } from "./load-older";
 import type { BaseCtor } from "./mixin";
 
@@ -18,7 +18,8 @@ import type { BaseCtor } from "./mixin";
  * this read twice — the board's hydrate call and the chat-history query's
  * fetch land in the same tick — and both want the identical windowed read +
  * VM seed. Sharing the in-flight promise halves the open traffic; bulk reads
- * (`observe: false`) never join it (mission search needs its own full fetch).
+ * (`observe: false`) never join it — they read a different window and take a
+ * different path through the cache.
  */
 const openLoadsInFlight = new Map<string, Promise<ChatHistoryEntry[]>>();
 
@@ -47,41 +48,39 @@ export function ChatHistoryMixin<TBase extends BaseCtor>(Base: TBase) {
       sessionKey: string,
       opts: { observe?: boolean } = {},
     ): Promise<ChatHistoryEntry[]> {
-      // Cache-first paint (HOU-712): a cloud read is HELD by the gateway for
-      // the whole engine-pod cold start, so seed the VM from the last locally
-      // persisted transcript NOW — the chat shows its messages instantly — and
-      // let the network read below revalidate whenever it lands. The seed
-      // guards in seedConversationVm keep a live or richer VM untouched, so a
-      // stale cache can never clobber fresh state.
+      const observing = opts.observe !== false;
+      // Cache-first paint on an open; a bulk scan skips it (see seedFromCache).
       let cachedFrames: CachedFrame[] | null = null;
-      if (this.ctx.cp) {
-        cachedFrames = await readCachedConversation(agentPath, sessionKey);
-        if (cachedFrames && cachedFrames.length > 0 && opts.observe !== false) {
-          seedConversationVm(agentPath, sessionKey, cachedFrames);
-        }
+      if (this.ctx.cp && observing) {
+        cachedFrames = await seedFromCache(agentPath, sessionKey);
       }
       try {
         const engine = this.ctx.cp
           ? controlPlane.runtimeClientFor(this.ctx.cp, agentPath)
           : this.ctx.engine;
-        // A conversation OPEN reads only the tail window (HOU-819) — long
-        // missions used to fetch and fold their entire transcript here, the
-        // main "chat hangs before opening" cost. Bulk reads (mission search
-        // needs full text to match against) keep the full fetch. A
-        // pre-windowing server ignores `limit` and returns everything —
-        // `offset`/`totalMessages` then default to the full-transcript shape.
-        const history = await engine.getHistory(
-          sessionKey,
-          opts.observe !== false ? { limit: CHAT_OPEN_WINDOW } : {},
-        );
+        // Every read is windowed. A conversation OPEN reads the tail window
+        // (HOU-819) — long missions used to fetch and fold their entire
+        // transcript here, the main "chat hangs before opening" cost. A BULK
+        // read (mission search scanning every mission for the phrase) reads the
+        // wider scan window (HOU-941) — full transcripts, N missions at a time,
+        // were the "search takes 15 seconds" cost. A pre-windowing server
+        // ignores `limit` and returns everything — `offset`/`totalMessages`
+        // then default to the full-transcript shape.
+        const history = await engine.getHistory(sessionKey, {
+          limit: observing ? CHAT_OPEN_WINDOW : SEARCH_SCAN_WINDOW,
+        });
         const sdkFeed = sdkHistoryToFeed(history.messages);
         const window = {
           earliestLoaded: history.offset ?? 0,
           total: history.totalMessages ?? history.messages.length,
         };
-        // Refresh the local copy on EVERY successful read (bulk scans too), so
-        // the next cold open paints the freshest transcript we ever saw.
-        if (this.ctx.cp) {
+        // Refresh the local copy on every successful OPEN, so the next cold
+        // open paints the freshest transcript we ever saw. Bulk scans are
+        // excluded (HOU-941): each write enumerates and prunes the whole store,
+        // which a board-wide search paid once per mission, and it would evict
+        // the conversations the user actually opens in favour of ones they only
+        // ever searched through.
+        if (this.ctx.cp && observing) {
           void writeCachedConversation(agentPath, sessionKey, sdkFeed);
         }
         // Observer mode: a loaded chat may have a turn in flight that THIS client
@@ -93,7 +92,7 @@ export function ChatHistoryMixin<TBase extends BaseCtor>(Base: TBase) {
         // for BULK history reads (mission search, board scans) that load N
         // conversations at a time and must not spawn N streams — only a real
         // conversation open observes (the default).
-        if (opts.observe !== false) {
+        if (observing) {
           // Seed FIRST (the chat opens complete), then attach: the observer
           // renders any in-flight turn live into the same VM. Seeding is a no-op
           // when a live stream already owns this conversation (see
@@ -126,15 +125,17 @@ export function ChatHistoryMixin<TBase extends BaseCtor>(Base: TBase) {
         // app's `call()` wrapper toasts it with the Report-bug affordance —
         // returning [] would render a fake empty chat and swallow the error.
         if (isConversationNotFound(err)) {
-          // A 404 with a locally cached transcript is NOT proof the chat never
-          // existed: an engine pod can answer 404 while its data is lost or not
-          // yet restored (volume recreation, seed self-heal window). The local
-          // copy is the user's only surviving transcript then — serve it and
-          // KEEP it (HOU-731). A truly deleted conversation drops out of the
-          // conversation list, so nothing reopens its cached ghost; the size
-          // cap prunes the orphaned entry eventually.
-          if (cachedFrames && cachedFrames.length > 0) {
-            return cachedFrames as ChatHistoryEntry[];
+          // The local copy may be the user's only surviving transcript — see
+          // cachedFallbackTranscript.
+          const fallback = this.ctx.cp
+            ? await cachedFallbackTranscript(
+                agentPath,
+                sessionKey,
+                cachedFrames,
+              )
+            : null;
+          if (fallback && fallback.length > 0) {
+            return fallback as ChatHistoryEntry[];
           }
           return [];
         }

--- a/packages/web/src/engine-adapter/client/history-cache.ts
+++ b/packages/web/src/engine-adapter/client/history-cache.ts
@@ -1,0 +1,53 @@
+/**
+ * The local conversation cache as the chat-history read uses it: the
+ * cache-first paint on an OPEN, and the transcript to fall back on when the
+ * server says the conversation is gone. The cache's own operations, scoping
+ * and disk cap live in `../conversation-cache`.
+ */
+
+import {
+  type CachedFrame,
+  readCachedConversation,
+} from "../conversation-cache";
+import { seedConversationVm } from "../turn-stream";
+
+/**
+ * Paint a chat from the last locally persisted transcript BEFORE the network
+ * read lands (HOU-712): a cloud read is HELD by the gateway for the whole
+ * engine-pod cold start, so without this the chat shows nothing until it
+ * resolves. The seed guards in `seedConversationVm` keep a live or richer VM
+ * untouched, so a stale cache can never clobber fresh state.
+ *
+ * Only a real conversation OPEN pays for this. A bulk scan paints nothing, and
+ * one IndexedDB read per mission is pure latency across a whole board of them
+ * (HOU-941) — it takes {@link cachedFallbackTranscript} instead, lazily.
+ */
+export async function seedFromCache(
+  agentPath: string,
+  sessionKey: string,
+): Promise<CachedFrame[] | null> {
+  const frames = await readCachedConversation(agentPath, sessionKey);
+  if (frames && frames.length > 0) {
+    seedConversationVm(agentPath, sessionKey, frames);
+  }
+  return frames;
+}
+
+/**
+ * The transcript to serve on a 404. A 404 with a locally cached transcript is
+ * NOT proof the chat never existed: an engine pod can answer 404 while its data
+ * is lost or not yet restored (volume recreation, seed self-heal window). The
+ * local copy is the user's only surviving transcript then — serve it and KEEP
+ * it (HOU-731). A truly deleted conversation drops out of the conversation
+ * list, so nothing reopens its cached ghost; the size cap prunes the orphan.
+ *
+ * `alreadyRead` is the open path's seed, so it never reads the cache twice; a
+ * bulk scan passes null and pays for the read only in this rare corner.
+ */
+export async function cachedFallbackTranscript(
+  agentPath: string,
+  sessionKey: string,
+  alreadyRead: CachedFrame[] | null,
+): Promise<CachedFrame[] | null> {
+  return alreadyRead ?? (await readCachedConversation(agentPath, sessionKey));
+}

--- a/packages/web/src/engine-adapter/history-window.ts
+++ b/packages/web/src/engine-adapter/history-window.ts
@@ -17,6 +17,19 @@ export const CHAT_OPEN_WINDOW = 120;
 /** Messages fetched per scroll-up load-older page. */
 export const CHAT_OLDER_PAGE = 80;
 
+/**
+ * Messages read per mission by a BULK scan — the board's mission search
+ * (HOU-941). Search reads the transcript of every mission the query doesn't
+ * already match by title or description, and reading each one in FULL made a
+ * search on a busy board sit on a spinner for 10-15 seconds.
+ *
+ * The tradeoff, deliberately taken: a match older than a conversation's last
+ * {@link SEARCH_SCAN_WINDOW} messages is not found. The window is much wider
+ * than {@link CHAT_OPEN_WINDOW} because a scan only greps text — it renders
+ * nothing — so it can afford to look far further back than a chat open.
+ */
+export const SEARCH_SCAN_WINDOW = 400;
+
 /** The minimal frame shape the seed decision reads. */
 export interface SeedFrame {
   feed_type: string;

--- a/packages/web/tests/chat-history-cache.test.ts
+++ b/packages/web/tests/chat-history-cache.test.ts
@@ -14,7 +14,10 @@ import { conversationStore } from "../src/engine-adapter/vm";
  * loadChatHistory × the local conversation cache (HOU-712): opening a cloud
  * chat paints the VM from the cached transcript IMMEDIATELY — even while the
  * gateway holds the history read for an engine-pod cold start — and every
- * successful read refreshes the cache. A 404 with a cached transcript KEEPS
+ * successful OPEN refreshes the cache. A BULK scan read (`observe: false`,
+ * mission search) leaves the cache alone (HOU-941): its window is partial and
+ * a board-wide scan must not churn/prune the store once per mission. A 404
+ * with a cached transcript KEEPS
  * and serves the local copy (HOU-731): the pod may have lost or not yet
  * restored its data, and the cache is the user's only surviving transcript.
  * Deleting the chat (user intent) is what drops the cache entry.
@@ -124,7 +127,7 @@ test("a held history read paints the chat from the cache immediately", async () 
   expect(settled).toBe(false);
 });
 
-test("a successful read refreshes the cache and reseeds the VM", async () => {
+test("a successful open refreshes the cache and reseeds the VM", async () => {
   const agentPath = "Ws/Agent";
   const sessionKey = `fresh-${convSeq++}`;
   const client = cloudClient();
@@ -144,9 +147,7 @@ test("a successful read refreshes the cache and reseeds the VM", async () => {
     return new Response("", { status: 200 });
   }) as unknown as typeof fetch;
 
-  const feed = await client.loadChatHistory(agentPath, sessionKey, {
-    observe: false,
-  });
+  const feed = await client.loadChatHistory(agentPath, sessionKey);
   expect(feed.map((f) => f.data)).toEqual([
     "cached question",
     "cached answer",
@@ -158,6 +159,40 @@ test("a successful read refreshes the cache and reseeds the VM", async () => {
     const record = await store.backend.get(key);
     expect(record?.frames.length).toBe(4);
   });
+});
+
+test("a bulk scan read leaves the cache untouched", async () => {
+  const agentPath = "Ws/Agent";
+  const sessionKey = `scan-${convSeq++}`;
+  const client = cloudClient();
+  await seedCache(agentPath, sessionKey);
+  const messages = [
+    { role: "user", content: "cached question", ts: 1 },
+    { role: "assistant", content: "cached answer", ts: 2 },
+    { role: "user", content: "new question", ts: 3 },
+    { role: "assistant", content: "new answer", ts: 4 },
+  ];
+  globalThis.fetch = vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.includes("/messages")) {
+      return json(200, { id: sessionKey, title: "t", messages });
+    }
+    return new Response("", { status: 200 });
+  }) as unknown as typeof fetch;
+
+  // Mission search's transcript scan: the read itself works…
+  const feed = await client.loadChatHistory(agentPath, sessionKey, {
+    observe: false,
+  });
+  expect(feed).toHaveLength(4);
+
+  // …but its WINDOWED result is never written back over the cached
+  // transcript (HOU-941), and the VM of the unopened chat stays unseeded.
+  await new Promise((r) => setTimeout(r, 50));
+  const key = `${GW}|user-1|${encodeURIComponent(agentPath)}|${encodeURIComponent(sessionKey)}`;
+  const record = await store.backend.get(key);
+  expect(record?.frames).toEqual(CACHED);
+  expect(vmFeed(agentPath, sessionKey)).toEqual([]);
 });
 
 test("a 404 with a cached transcript keeps and serves the local copy", async () => {


### PR DESCRIPTION
> Stacked on #1130 — merge that first; this PR auto-retargets to `main` once its base branch is deleted (or retarget manually).

## Summary
Mission search sat on a loading state for 10-15+ seconds. Four compounding causes, all fixed:
- **No debounce**: every keystroke launched a new wave of history fetches that was never canceled. Now the network wave debounces 250 ms and a superseded phrase stops the running wave from starting more work. Matching what is already loaded stays per-keystroke (it is now cheap).
- **Full transcripts**: bulk search reads fetched each mission's ENTIRE transcript (chat opens are windowed to 120 messages per HOU-819; search was not). Bulk scans now read a bounded `SEARCH_SCAN_WINDOW` (400 messages) and skip the IndexedDB conversation-cache write (a partial transcript must never be cached as complete, and each write enumerated + pruned the whole store).
- **~100× slow folding**: `foldForSearch` walked text char-by-char with per-char `normalize()` on full transcripts, per keystroke. It is now a whole-string fold; transcripts are folded ONCE at load into `SearchableText` (original + folded), so per-keystroke matching is a regex test. The char-by-char fold map survives only for highlight ranges on short snippet text.
- **All-at-once commit**: results waited on `Promise.allSettled` of every mission. A bounded pool (5 concurrent) now streams results onto the board as transcripts land, coalesced in 120 ms commit windows.

## Testing
- New unit tests: `app/tests/mission-search-text.test.ts` (fold semantics incl. accents/NFKD, snippet extraction on originals), `app/tests/async-pool.test.ts` (bounded concurrency, stop condition).
- `cd app && pnpm test`: 2276 pass. `pnpm --filter houston-web typecheck` + `typecheck:e2e` clean. Biome clean.
- Playwright `board.spec.ts`: search test and suite pass (one unrelated test flaked identically on baseline under machine load, verified by A/B with changes stashed).

## Not done (follow-up)
- `packages/sdk/src/modules/missions-search/search-text.ts` (headless port for native surfaces) still carries the old per-char fold; not on the desktop/web path.
- A server-side search endpoint (match inside conversation files in the runtime, return ids + snippets) would also eliminate the cold-runtime-spawn cost that search triggers per agent; out of scope here.

Fixes HOU-941

🤖 Generated with [Claude Code](https://claude.com/claude-code)