### PR TITLE
feat(catalog): always-visible clear X on catalog search + clear after install

### DIFF
--- a/app/src/components/ai-hub/ai-hub-view.tsx
+++ b/app/src/components/ai-hub/ai-hub-view.tsx
@@ -164,6 +164,7 @@ export function AiHubView() {
                   value={query}
                   onChange={setQuery}
                   label={t("search.placeholder")}
+                  clearLabel={t("search.clear")}
                 />
               }
               installedTitle={t("sections.connected")}

--- a/app/src/components/integrations-view/catalog-category-section.tsx
+++ b/app/src/components/integrations-view/catalog-category-section.tsx
@@ -43,6 +43,7 @@ export function CatalogCategorySection({
   section,
   surface,
   connectFlow,
+  onConnected,
   owns,
   statusOf,
   onOpen,
@@ -52,6 +53,7 @@ export function CatalogCategorySection({
   /** This catalog's half of every row's origin key. */
   surface: string;
   connectFlow: ConnectFlow;
+  onConnected?: (toolkit: string) => void;
   /** Does THIS row own its app's inline connect state? */
   owns: (slug: string, origin: string) => boolean;
   /** This app's broken-connection status, if it has one. */
@@ -83,7 +85,11 @@ export function CatalogCategorySection({
               key={tk.slug}
               display={appDisplay(tk.slug, tk)}
               onOpen={() => onOpen(tk, origin)}
-              onConnect={() => void connectFlow.connect(tk.slug, origin)}
+              onConnect={() =>
+                void connectFlow.connect(tk.slug, origin).then((attempt) => {
+                  if (attempt.outcome === "active") onConnected?.(tk.slug);
+                })
+              }
               connectFlow={connectFlow}
               owns={owns(tk.slug, origin)}
               status={statusOf(tk.slug)}

--- a/app/src/components/integrations-view/catalog-controls.tsx
+++ b/app/src/components/integrations-view/catalog-controls.tsx
@@ -53,6 +53,7 @@ export function CatalogControls({
         value={query}
         onChange={onQueryChange}
         label={t("home.searchPlaceholder")}
+        clearLabel={t("home.clearSearch")}
         className="flex-1"
       />
       <FilterCombobox

--- a/app/src/components/integrations-view/catalog-pane.tsx
+++ b/app/src/components/integrations-view/catalog-pane.tsx
@@ -33,6 +33,7 @@ export function CatalogPane({
   category,
   isLoading,
   connectFlow,
+  onConnected,
   onRemove,
   allowlist = null,
   lockedFix,
@@ -50,6 +51,7 @@ export function CatalogPane({
   category: string;
   isLoading: boolean;
   connectFlow: ConnectFlow;
+  onConnected?: (toolkit: string) => void;
   /** Disconnect an app's half-made connection (the app modal's Remove). */
   onRemove: (toolkit: string) => void;
   /** The Teams effective allowlist (`null` = unrestricted, no locks ever). */
@@ -71,6 +73,7 @@ export function CatalogPane({
           catalog={catalog}
           connections={connections}
           connectFlow={connectFlow}
+          onConnected={onConnected}
           surface={surface}
           query={query}
           category={category}

--- a/app/src/components/integrations-view/category-catalog.tsx
+++ b/app/src/components/integrations-view/category-catalog.tsx
@@ -47,6 +47,7 @@ export function CategoryCatalog({
   catalog,
   connections,
   connectFlow,
+  onConnected,
   surface,
   query,
   category,
@@ -57,6 +58,7 @@ export function CategoryCatalog({
   catalog: IntegrationToolkit[];
   connections: IntegrationConnection[];
   connectFlow: ConnectFlow;
+  onConnected?: (toolkit: string) => void;
   /** This catalog's half of every row's origin key — which surface the row
    *  belongs to (the global page vs. one agent's tab). */
   surface: string;
@@ -104,6 +106,7 @@ export function CategoryCatalog({
               section={section}
               surface={surface}
               connectFlow={connectFlow}
+              onConnected={onConnected}
               // The spotlight repeats category rows: only the copy that owns
               // this app expands, so the panel appears exactly once.
               owns={(slug, origin) => owners.get(slug) === origin}
@@ -126,7 +129,11 @@ export function CategoryCatalog({
         onConnect={(toolkit) => {
           const origin = info?.origin;
           setInfo(null);
-          if (origin) void connectFlow.connect(toolkit, origin);
+          if (origin) {
+            void connectFlow.connect(toolkit, origin).then((attempt) => {
+              if (attempt.outcome === "active") onConnected?.(toolkit);
+            });
+          }
         }}
         onRemove={(toolkit) => {
           setInfo(null);

--- a/app/src/components/integrations-view/integrations-ready.tsx
+++ b/app/src/components/integrations-view/integrations-ready.tsx
@@ -14,6 +14,7 @@ import {
   useConnectFlow,
   useConnectionSelection,
 } from "../integrations";
+import { matchesQuery } from "../integrations/browse-model";
 import { PageHeader } from "../shell/page-shell";
 import { CatalogControls } from "./catalog-controls";
 import { CatalogPane } from "./catalog-pane";
@@ -116,6 +117,17 @@ export function IntegrationsReady({
           category={category}
           isLoading={apps.isLoading}
           connectFlow={connectFlow}
+          onConnected={(toolkit) =>
+            setQuery((currentQuery) => {
+              if (!currentQuery.trim()) return currentQuery;
+              const app = apps.catalogData.find(
+                (item) => item.slug === toolkit,
+              );
+              return app && matchesQuery(app, currentQuery.trim().toLowerCase())
+                ? ""
+                : currentQuery;
+            })
+          }
           onRemove={(toolkit) => disconnect.mutate(toolkit)}
         />
       ),

--- a/app/src/components/integrations-view/use-catalog-surface.ts
+++ b/app/src/components/integrations-view/use-catalog-surface.ts
@@ -3,7 +3,7 @@ import type {
   IntegrationConnection,
   IntegrationToolkit,
 } from "@houston-ai/engine-client";
-import { useMemo, useState } from "react";
+import { type Dispatch, type SetStateAction, useMemo, useState } from "react";
 import {
   type FilteredInstalled,
   filterInstalledBy,
@@ -17,7 +17,7 @@ export interface CatalogSurface {
   tab: string;
   setTab: (value: string) => void;
   query: string;
-  setQuery: (value: string) => void;
+  setQuery: Dispatch<SetStateAction<string>>;
   category: string;
   setCategory: (value: string) => void;
   /** True while the shared query or category is narrowing both sections — the

--- a/app/src/components/integrations/custom-integrations-section.tsx
+++ b/app/src/components/integrations/custom-integrations-section.tsx
@@ -106,6 +106,7 @@ export function CustomIntegrationsSection({
                 value={query}
                 onChange={setQuery}
                 label={t("custom.searchPlaceholder")}
+                clearLabel={t("custom.clearSearch")}
                 className="flex-1"
               />
               {addButton}

--- a/app/src/components/mission-search-input.tsx
+++ b/app/src/components/mission-search-input.tsx
@@ -1,5 +1,5 @@
-import { Input } from "@houston-ai/core";
-import { Loader2, Search, X } from "lucide-react";
+import { Input, SearchClearButton } from "@houston-ai/core";
+import { Loader2, Search } from "lucide-react";
 import { useLayoutEffect, useRef, useState } from "react";
 
 interface MissionSearchInputLabels {
@@ -37,6 +37,7 @@ export function MissionSearchInput({
   onChange,
 }: MissionSearchInputProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   // Visible placeholder: the full text, or the short one when it wouldn't fit.
   const [placeholder, setPlaceholder] = useState(labels.placeholder);
   const { placeholder: full, placeholderShort } = labels;
@@ -73,6 +74,7 @@ export function MissionSearchInput({
     <div ref={wrapperRef} className={className ?? "relative"}>
       <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-ink-muted" />
       <Input
+        ref={inputRef}
         type="text"
         role="searchbox"
         value={value}
@@ -89,14 +91,13 @@ export function MissionSearchInput({
         />
       )}
       {value && (
-        <button
-          type="button"
-          onClick={() => onChange("")}
-          className="absolute right-2 top-1/2 flex size-6 -translate-y-1/2 items-center justify-center rounded-full text-ink-muted transition-colors hover:bg-hover hover:text-ink"
-          aria-label={labels.clear}
-        >
-          <X className="size-3.5" />
-        </button>
+        <SearchClearButton
+          label={labels.clear}
+          onClear={() => {
+            onChange("");
+            inputRef.current?.focus();
+          }}
+        />
       )}
     </div>
   );

--- a/app/src/components/store-view/store-browse.tsx
+++ b/app/src/components/store-view/store-browse.tsx
@@ -130,7 +130,10 @@ export function StoreBrowse() {
   );
 
   const handleInstall = async (slug: string) => {
-    if (await install(slug)) setDetailAgent(null);
+    if (await install(slug)) {
+      setSearch("");
+      setDetailAgent(null);
+    }
   };
 
   return (
@@ -140,6 +143,7 @@ export function StoreBrowse() {
           value={search}
           onChange={setSearch}
           label={t("searchPlaceholder")}
+          clearLabel={t("clearSearch")}
           className="flex-1"
         />
         {integrations.length > 0 && (

--- a/app/src/components/tabs/agent-integrations/agent-integrations-body.tsx
+++ b/app/src/components/tabs/agent-integrations/agent-integrations-body.tsx
@@ -11,6 +11,7 @@ import {
   CustomIntegrationsSection,
   type PermissionsFix,
 } from "../../integrations";
+import { matchesQuery } from "../../integrations/browse-model";
 import { CatalogControls } from "../../integrations-view/catalog-controls";
 import { CatalogPane } from "../../integrations-view/catalog-pane";
 import { InstalledStrip } from "../../integrations-view/installed-strip";
@@ -122,6 +123,15 @@ export function AgentIntegrationsBody({
           category={category}
           isLoading={catalogLoading}
           connectFlow={connectFlow}
+          onConnected={(toolkit) =>
+            setQuery((currentQuery) => {
+              if (!currentQuery.trim()) return currentQuery;
+              const app = catalog.find((item) => item.slug === toolkit);
+              return app && matchesQuery(app, currentQuery.trim().toLowerCase())
+                ? ""
+                : currentQuery;
+            })
+          }
           onRemove={onDisconnect}
           allowlist={allowlist}
           lockedFix={permissionsFix}

--- a/app/src/components/tabs/skills-content.tsx
+++ b/app/src/components/tabs/skills-content.tsx
@@ -95,7 +95,14 @@ export function SkillsContent({
     onQueryChange: setQuery,
     // Read-only mode never offers the Store either: no community callbacks.
     onSearch: readOnly ? undefined : onSearch,
-    onInstallCommunity: readOnly ? undefined : onInstallCommunity,
+    onInstallCommunity:
+      readOnly || !onInstallCommunity
+        ? undefined
+        : async (skill, signal) => {
+            const result = await onInstallCommunity(skill, signal);
+            if (!signal?.aborted) setQuery("");
+            return result;
+          },
     onPreviewCommunity,
     installedSkillNames,
   });
@@ -131,6 +138,7 @@ export function SkillsContent({
                   value={query}
                   onChange={setQuery}
                   label={t("grid.searchSkills")}
+                  clearLabel={t("grid.clearSearch")}
                 />
               )
             }

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -16,6 +16,7 @@
   },
   "search": {
     "placeholder": "Search AI models and providers",
+    "clear": "Clear search",
     "showAll": "Show all {{count}} providers"
   },
   "card": {

--- a/app/src/locales/en/integrations.json
+++ b/app/src/locales/en/integrations.json
@@ -87,6 +87,7 @@
       "custom": "Custom integrations"
     },
     "searchPlaceholder": "Search integrations",
+    "clearSearch": "Clear search",
     "allCategories": "All categories",
     "categoryFilter": "Filter by category",
     "connect": "Connect",
@@ -109,6 +110,7 @@
     "description": "Connect an API or MCP server that isn't in the app catalog.",
     "addButton": "Add custom integration",
     "searchPlaceholder": "Search custom integrations...",
+    "clearSearch": "Clear search",
     "empty": "No custom integrations yet. Add one to connect a tool that isn't in the catalog.",
     "emptyTitle": "No custom integrations yet",
     "noResults": "No custom integrations match your search.",

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -9,6 +9,7 @@
     "yourSkillsHeading": "Your skills",
     "availableHeading": "Available",
     "searchSkills": "Search skills",
+    "clearSearch": "Clear search",
     "noMatchingSkills": "No skills match your search",
     "showAllSkills": "Show all {{count}} skills"
   },

--- a/app/src/locales/en/store.json
+++ b/app/src/locales/en/store.json
@@ -2,6 +2,7 @@
   "title": "Agent Store",
   "subtitle": "Ready-made agents from the Houston community. Install one and make it yours.",
   "searchPlaceholder": "Search agents",
+  "clearSearch": "Clear search",
   "allCategories": "All",
   "sort": {
     "recent": "Newest",

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -16,6 +16,7 @@
   },
   "search": {
     "placeholder": "Busca modelos y proveedores de IA",
+    "clear": "Borrar búsqueda",
     "showAll": "Ver los {{count}} proveedores"
   },
   "card": {

--- a/app/src/locales/es/integrations.json
+++ b/app/src/locales/es/integrations.json
@@ -87,6 +87,7 @@
       "custom": "Integraciones personalizadas"
     },
     "searchPlaceholder": "Buscar integraciones",
+    "clearSearch": "Borrar búsqueda",
     "allCategories": "Todas las categorías",
     "categoryFilter": "Filtrar por categoría",
     "connect": "Conectar",
@@ -109,6 +110,7 @@
     "description": "Conecta una API o un servidor MCP que no esté en el catálogo de aplicaciones.",
     "addButton": "Agregar integración personalizada",
     "searchPlaceholder": "Buscar integraciones personalizadas...",
+    "clearSearch": "Borrar búsqueda",
     "empty": "Aún no tienes integraciones personalizadas. Agrega una para conectar una herramienta que no esté en el catálogo.",
     "emptyTitle": "Aún no tienes integraciones personalizadas",
     "noResults": "Ninguna integración personalizada coincide con tu búsqueda.",

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -9,6 +9,7 @@
     "yourSkillsHeading": "Tus skills",
     "availableHeading": "Disponibles",
     "searchSkills": "Buscar skills",
+    "clearSearch": "Borrar búsqueda",
     "noMatchingSkills": "Ninguna skill coincide con tu búsqueda",
     "showAllSkills": "Ver las {{count}} skills"
   },

--- a/app/src/locales/es/store.json
+++ b/app/src/locales/es/store.json
@@ -2,6 +2,7 @@
   "title": "Tienda de agentes",
   "subtitle": "Agentes listos para usar, creados por la comunidad de Houston. Instala uno y hazlo tuyo.",
   "searchPlaceholder": "Buscar agentes",
+  "clearSearch": "Borrar búsqueda",
   "allCategories": "Todos",
   "sort": {
     "recent": "Más nuevos",

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -16,6 +16,7 @@
   },
   "search": {
     "placeholder": "Busque modelos e provedores de IA",
+    "clear": "Limpar busca",
     "showAll": "Ver todos os {{count}} provedores"
   },
   "card": {

--- a/app/src/locales/pt/integrations.json
+++ b/app/src/locales/pt/integrations.json
@@ -87,6 +87,7 @@
       "custom": "Integrações personalizadas"
     },
     "searchPlaceholder": "Buscar integrações",
+    "clearSearch": "Limpar busca",
     "allCategories": "Todas as categorias",
     "categoryFilter": "Filtrar por categoria",
     "connect": "Conectar",
@@ -109,6 +110,7 @@
     "description": "Conecte uma API ou servidor MCP que não está no catálogo de aplicativos.",
     "addButton": "Adicionar integração personalizada",
     "searchPlaceholder": "Buscar integrações personalizadas...",
+    "clearSearch": "Limpar busca",
     "empty": "Você ainda não tem integrações personalizadas. Adicione uma para conectar uma ferramenta que não está no catálogo.",
     "emptyTitle": "Você ainda não tem integrações personalizadas",
     "noResults": "Nenhuma integração personalizada corresponde à sua busca.",

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -9,6 +9,7 @@
     "yourSkillsHeading": "Suas skills",
     "availableHeading": "Disponíveis",
     "searchSkills": "Buscar skills",
+    "clearSearch": "Limpar busca",
     "noMatchingSkills": "Nenhuma skill corresponde à sua busca",
     "showAllSkills": "Ver todas as {{count}} skills"
   },

--- a/app/src/locales/pt/store.json
+++ b/app/src/locales/pt/store.json
@@ -2,6 +2,7 @@
   "title": "Loja de agentes",
   "subtitle": "Agentes prontos para usar, criados pela comunidade Houston. Instale um e deixe do seu jeito.",
   "searchPlaceholder": "Buscar agentes",
+  "clearSearch": "Limpar busca",
   "allCategories": "Todos",
   "sort": {
     "recent": "Mais novos",

--- a/knowledge-base/agent-store.md
+++ b/knowledge-base/agent-store.md
@@ -106,7 +106,9 @@ no client writes them.
 The store is browsable INSIDE the app (`app/src/components/store-view/`,
 view id `agent-store` in `TOP_LEVEL_VIEWS`): a sidebar + command-palette
 destination rendering the public catalog in the shared catalog family
-(`CatalogRow`/`CatalogGrid`/`CatalogDetailDialog`/`CatalogSearchField`).
+(`CatalogRow`/`CatalogGrid`/`CatalogDetailDialog`/`CatalogSearchField`): search
+has an always-available clear X when text is present, and a successful install
+clears the catalog search.
 Reads go straight to the gateway's anonymous CORS-open endpoints via
 `ui/engine-client/src/store-catalog.ts` — no account, no engine round-trip;
 base resolution mirrors the publish adapter (`__HOUSTON_STORE__` →

--- a/knowledge-base/integrations.md
+++ b/knowledge-base/integrations.md
@@ -415,8 +415,11 @@ integrations** tab (§2, `teams.md`).
   catalog size via `home.descriptionCount`), then the shell:
   (0) the ONE **controls** row (`catalog-controls.tsx` → `CatalogControls`): a
   `CatalogSearchField` (`home.searchPlaceholder`) + the searchable A-Z category
-  `FilterCombobox`. It sits ABOVE both sections and its query + category narrow the
-  Installed strip AND the Integrations tab together. The surface owns that state in
+  `FilterCombobox`. The search field has an always-available clear X whenever it
+  contains text. A successful connect clears the query only when the landed app
+  still matches it, so a later OAuth completion cannot erase a newer search. It
+  sits ABOVE both sections and its query + category narrow the Installed strip AND
+  the Integrations tab together. The surface owns that state in
   the shared `use-catalog-surface.ts` hook (`useCatalogSurface` → `tab`, `query`,
   `category`, `filtering`, `shown`, `installedCount`, `availableCount`), used verbatim
   by the global page and the per-agent tab so the two-section wiring lives in ONE

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -138,7 +138,9 @@ The agent's Skills section (`app/src/components/tabs/skills-content.tsx`) is
 the shared **catalog layout** (the ui/core `CatalogShell`, same two-section grammar
 as the Integrations surfaces and the AI hub, no page header — the nav label carries
 it): ONE top `CatalogSearchField` (`grid.searchSkills`) — the page's single query,
-owned by `skills-content.tsx` — over the consolidated **Your skills** section
+owned by `skills-content.tsx` — with an always-available clear X when text is
+present, and a successful install clearing the query — over the consolidated
+**Your skills** section
 (`grid.yourSkillsHeading`, an `lg` `CatalogSectionHeader` + count chip; installed-skill
 ROWS, not tiles) and the **Available** section (`grid.availableHeading`) holding two
 discovery tabs — **Store** (`skills:tabs.store`, the skills.sh marketplace) and

--- a/packages/web/e2e/integrations-browse.spec.ts
+++ b/packages/web/e2e/integrations-browse.spec.ts
@@ -1,5 +1,6 @@
 import { FAKE_HOST_URL } from "@houston/fake-host";
 import type { APIRequestContext, Page } from "@playwright/test";
+import { activatePendingConnection } from "./support/activate-pending-connection";
 import { expect, test } from "./support/fixtures";
 
 /**
@@ -102,6 +103,45 @@ test("searching filters the category sections live", async ({
   await expect(
     page.getByRole("heading", { name: "Productivity" }),
   ).toBeVisible();
+});
+
+test("catalog search clears manually and after its matching app connects", async ({
+  page,
+  request,
+}) => {
+  await armCapabilities(request, { integrations: ["composio"] });
+  await openIntegrationsPage(page);
+
+  const search = page.getByRole("textbox", { name: "Search integrations" });
+  const clear = page.getByRole("button", { name: "Clear search" });
+  await expect(clear).toHaveCount(0);
+
+  await search.fill("Slack");
+  await expect(clear).toBeVisible();
+  await clear.click();
+  await expect(search).toHaveValue("");
+
+  await search.fill("Slack");
+  await page.getByRole("button", { name: "Connect Slack" }).first().click();
+  await activatePendingConnection(request, "slack");
+
+  await expect(search).toHaveValue("", { timeout: 15_000 });
+});
+
+test("a delayed connection preserves a newer non-matching search", async ({
+  page,
+  request,
+}) => {
+  await armCapabilities(request, { integrations: ["composio"] });
+  await openIntegrationsPage(page);
+
+  const search = page.getByRole("textbox", { name: "Search integrations" });
+  await search.fill("Slack");
+  await page.getByRole("button", { name: "Connect Slack" }).first().click();
+  await search.fill("Notion");
+  await activatePendingConnection(request, "slack");
+
+  await expect(search).toHaveValue("Notion", { timeout: 15_000 });
 });
 
 test("a row's + connects INLINE, exactly once, leaving every other row usable", async ({

--- a/packages/web/e2e/interaction.spec.ts
+++ b/packages/web/e2e/interaction.spec.ts
@@ -1,4 +1,5 @@
 import { FAKE_HOST_URL } from "@houston/fake-host";
+import { activatePendingConnection } from "./support/activate-pending-connection";
 import { expect, test } from "./support/fixtures";
 
 /**
@@ -797,27 +798,7 @@ test("reconsiders a skipped connect step: Back offers Connect again and reports 
   // Connect it. The fake host mints a PENDING connection on connect; flip it
   // active (models the OAuth completing) so the card self-reports and advances.
   await connect.click();
-  await expect
-    .poll(
-      async () => {
-        const res = await request.get(
-          `${FAKE_HOST_URL}/v1/integrations/composio/connections`,
-        );
-        const { items } = (await res.json()) as {
-          items: { toolkit: string; connectionId: string; status: string }[];
-        };
-        const pending = items.find(
-          (c) => c.toolkit === "slack" && c.status === "pending",
-        );
-        if (!pending) return false;
-        await request.post(`${FAKE_HOST_URL}/__test__/integrations-activate`, {
-          data: { connectionId: pending.connectionId },
-        });
-        return true;
-      },
-      { timeout: 10_000 },
-    )
-    .toBe(true);
+  await activatePendingConnection(request, "slack");
 
   // The connection lands -> Slack advances to the GitHub step (2 of 2). Decline
   // GitHub genuinely ("Skip") to finish the sequence.
@@ -1377,27 +1358,7 @@ test("pressing Enter connects a lone connect step", async ({
 
   // Enter fired startConnect: the fake host mints a PENDING slack connection.
   // Flip it active (models the OAuth completing) so the card self-reports.
-  await expect
-    .poll(
-      async () => {
-        const res = await request.get(
-          `${FAKE_HOST_URL}/v1/integrations/composio/connections`,
-        );
-        const { items } = (await res.json()) as {
-          items: { toolkit: string; connectionId: string; status: string }[];
-        };
-        const pending = items.find(
-          (c) => c.toolkit === "slack" && c.status === "pending",
-        );
-        if (!pending) return false;
-        await request.post(`${FAKE_HOST_URL}/__test__/integrations-activate`, {
-          data: { connectionId: pending.connectionId },
-        });
-        return true;
-      },
-      { timeout: 10_000 },
-    )
-    .toBe(true);
+  await activatePendingConnection(request, "slack");
 
   // The connection lands -> the card self-reports and resumes the agent (the
   // composed "Connected Slack." resume plus its echo can appear more than once).

--- a/packages/web/e2e/support/activate-pending-connection.ts
+++ b/packages/web/e2e/support/activate-pending-connection.ts
@@ -1,0 +1,31 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import { type APIRequestContext, expect } from "@playwright/test";
+
+/** Complete a fake-host OAuth hand-off once its pending connection exists. */
+export async function activatePendingConnection(
+  request: APIRequestContext,
+  toolkit: string,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get(
+          `${FAKE_HOST_URL}/v1/integrations/composio/connections`,
+        );
+        const { items } = (await response.json()) as {
+          items: { toolkit: string; connectionId: string; status: string }[];
+        };
+        const pending = items.find(
+          (connection) =>
+            connection.toolkit === toolkit && connection.status === "pending",
+        );
+        if (!pending) return false;
+        await request.post(`${FAKE_HOST_URL}/__test__/integrations-activate`, {
+          data: { connectionId: pending.connectionId },
+        });
+        return true;
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(true);
+}

--- a/ui/core/src/components/catalog.tsx
+++ b/ui/core/src/components/catalog.tsx
@@ -2,7 +2,9 @@
 
 import { Search } from "lucide-react";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { useRef } from "react";
 import { cn } from "../utils";
+import { SearchClearButton } from "./search-clear-button";
 
 /**
  * The flat "catalog plane" family — the browse-page grammar shared by every
@@ -119,24 +121,38 @@ export function CatalogSearchField({
   value,
   onChange,
   label,
+  clearLabel = "Clear search",
   className,
 }: {
   value: string;
   onChange: (value: string) => void;
   label: string;
+  clearLabel?: string;
   className?: string;
 }) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
   return (
     <div className={cn("relative", className)}>
-      <Search className="-translate-y-1/2 absolute top-1/2 left-3 size-4 text-ink-muted" />
+      <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-ink-muted" />
       <input
+        ref={inputRef}
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={label}
         aria-label={label}
-        className="h-9 w-full rounded-full border border-line-input bg-input pr-4 pl-10 text-ink text-sm placeholder:text-ink-muted focus:outline-none focus:ring-2 focus:ring-focus/20"
+        className="h-9 w-full rounded-full border border-line-input bg-input pr-9 pl-10 text-ink text-sm placeholder:text-ink-muted focus:outline-none focus:ring-2 focus:ring-focus/20"
       />
+      {value && (
+        <SearchClearButton
+          label={clearLabel}
+          onClear={() => {
+            onChange("");
+            inputRef.current?.focus();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/ui/core/src/components/search-clear-button.tsx
+++ b/ui/core/src/components/search-clear-button.tsx
@@ -1,0 +1,21 @@
+import { X } from "lucide-react";
+
+/** A compact clear affordance for search fields. */
+export function SearchClearButton({
+  label = "Clear search",
+  onClear,
+}: {
+  label?: string;
+  onClear: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClear}
+      className="absolute right-2 top-1/2 flex size-6 -translate-y-1/2 items-center justify-center rounded-full text-ink-muted transition-colors hover:bg-hover hover:text-ink"
+      aria-label={label}
+    >
+      <X className="size-3.5" />
+    </button>
+  );
+}

--- a/ui/core/src/index.ts
+++ b/ui/core/src/index.ts
@@ -35,6 +35,7 @@ export * from "./components/popover";
 export * from "./components/progress";
 export * from "./components/resizable";
 export * from "./components/scroll-area";
+export * from "./components/search-clear-button";
 export * from "./components/select";
 export * from "./components/separator";
 export * from "./components/sheet";


### PR DESCRIPTION
## What

- `CatalogSearchField` (shared by the integrations catalog, custom integrations, Agent Store, Skills, and AI Hub search bars) now shows a clear X button whenever there is text. Clearing refocuses the input. The X is a new shared `SearchClearButton` primitive in `@houston-ai/core`, also reused by `MissionSearchInput` (removing the previous duplicate markup).
- After a successful install the catalog search resets so users see the full catalog again with their new item under Installed:
  - Integrations: clears when the connect flow lands (`outcome === "active"`), and only if the landed app still matches the live query, since connects can settle minutes after OAuth while the user is already searching for something else.
  - Agent Store: clears on successful install.
  - Skills: clears on successful community install (skipped when the install signal aborted).
- Clear-label strings localized in en/es/pt across the 5 surfaces.

## Tests

- New e2e in `integrations-browse.spec.ts`: manual X clear, X hidden when empty, clear after a connect lands, and no clear when the user has since typed a different query. Shared `activatePendingConnection` helper extracted to `e2e/support/` (deduplicates two copies in `interaction.spec.ts`).
- Full runs green: biome, repo typecheck, app tsgo, check-locales, app unit tests, houston-web typecheck, e2e (integrations-browse, integrations-ia, interaction, agents, files: 51 passed), visual regression (6 passed).

## Docs

- KB updated: `knowledge-base/integrations.md`, `skills.md`, `agent-store.md`.

Fixes HOU-812

🤖 Generated with [Claude Code](https://claude.com/claude-code)