### PR TITLE
fix(sidebar): make agent rename discoverable and non-lossy

### DIFF
--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -12,7 +12,10 @@ import { DEFAULT_TAB_ID } from "../../agents/standard-tabs";
 import { useCanCreateAgents } from "../../hooks/use-can-create-agents";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { useSidebarLayout } from "../../hooks/use-sidebar-layout";
+import { isAgentNameConflictError } from "../../lib/agent-name-conflict";
+import { showExpectedStateToast } from "../../lib/error-toast";
 import { canSeeAiModelsPage } from "../../lib/org-roles";
+import { renameAgentWithFollowUp } from "../../lib/rename-agent-follow-up";
 import { resolveAutoCollapse } from "../../lib/sidebar-auto-collapse";
 import { isTeamWorkspace } from "../../lib/space-id";
 import { isTopLevelView } from "../../lib/top-level-views";
@@ -124,7 +127,24 @@ export function Sidebar({ children }: { children: ReactNode }) {
 
   const handleRename = async (agentId: string, newName: string) => {
     if (!currentWorkspace) return;
-    await renameAgent(currentWorkspace.id, agentId, newName);
+    try {
+      await renameAgentWithFollowUp({
+        workspaceId: currentWorkspace.id,
+        agentId,
+        name: newName,
+        renameAgent,
+        remapAgentId: sidebar.remapAgentId,
+      });
+    } catch (err) {
+      if (isAgentNameConflictError(err)) {
+        showExpectedStateToast(
+          t("agents:toasts.nameConflict", { name: newName }),
+          t("agents:toasts.nameConflictDescription"),
+        );
+        return;
+      }
+      throw err;
+    }
   };
 
   async function handleChangeColor(agentId: string, color: string) {

--- a/app/src/hooks/use-sidebar-layout.ts
+++ b/app/src/hooks/use-sidebar-layout.ts
@@ -10,6 +10,7 @@ import {
   moveGroupOp,
   moveItemOp,
   normalizeSidebarLayout,
+  remapAgentIdOp,
   renameGroupOp,
   setGroupContextOp,
   toggleGroupCollapsedOp,
@@ -35,6 +36,7 @@ export interface UseSidebarLayout {
   /** Create a group and return its new id (so the caller can focus its name). */
   createGroup: (name: string) => string | null;
   renameGroup: (id: string, name: string) => void;
+  remapAgentId: (oldId: string, newId: string) => void;
   setGroupContext: (id: string, context: string) => void;
   deleteGroup: (id: string) => void;
   toggleGroupCollapsed: (id: string) => void;
@@ -102,6 +104,8 @@ export function useSidebarLayout(
       return id;
     },
     renameGroup: (id, name) => apply((c) => renameGroupOp(c, id, name)),
+    remapAgentId: (oldId, newId) =>
+      apply((c) => remapAgentIdOp(c, oldId, newId)),
     setGroupContext: (id, context) =>
       apply((c) => setGroupContextOp(c, id, context)),
     deleteGroup: (id) => apply((c) => deleteGroupOp(c, id)),

--- a/app/src/lib/agent-name-conflict.ts
+++ b/app/src/lib/agent-name-conflict.ts
@@ -1,0 +1,13 @@
+import type { HoustonEngineError } from "@houston-ai/engine-client";
+
+// `PATCH /agents/:id` has exactly one 409 path: AgentNameConflictError in
+// packages/host/src/routes/agents.ts. A 409 from this call is therefore the
+// expected "name already taken" business state, not a generic failure.
+/** True when a rename collides with another agent in the workspace. */
+export function isAgentNameConflictError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const engineError = err as HoustonEngineError;
+  return (
+    engineError.name === "HoustonEngineError" && engineError.status === 409
+  );
+}

--- a/app/src/lib/rename-agent-follow-up.ts
+++ b/app/src/lib/rename-agent-follow-up.ts
@@ -1,0 +1,28 @@
+export interface RenamedAgent {
+  id: string;
+}
+
+interface RenameAgentFollowUpInput {
+  workspaceId: string;
+  agentId: string;
+  name: string;
+  renameAgent: (
+    workspaceId: string,
+    agentId: string,
+    name: string,
+  ) => Promise<RenamedAgent>;
+  remapAgentId: (oldId: string, newId: string) => void;
+}
+
+/** Rename an agent, preserving sidebar placement if its folder-derived id moved. */
+export async function renameAgentWithFollowUp({
+  workspaceId,
+  agentId,
+  name,
+  renameAgent,
+  remapAgentId,
+}: RenameAgentFollowUpInput): Promise<RenamedAgent> {
+  const updated = await renameAgent(workspaceId, agentId, name);
+  if (updated.id !== agentId) remapAgentId(agentId, updated.id);
+  return updated;
+}

--- a/app/src/lib/sidebar-layout-group-ops.ts
+++ b/app/src/lib/sidebar-layout-group-ops.ts
@@ -1,0 +1,67 @@
+import type { SidebarLayout } from "@houston-ai/engine-client";
+
+/** Append a new, empty, expanded group with a caller-minted id. */
+export function createGroupOp(
+  layout: SidebarLayout,
+  id: string,
+  name: string,
+): SidebarLayout {
+  return {
+    ...layout,
+    groups: [...layout.groups, { id, name, collapsed: false, agentIds: [] }],
+  };
+}
+
+/** Rename a group (no-op if the id is unknown). */
+export function renameGroupOp(
+  layout: SidebarLayout,
+  id: string,
+  name: string,
+): SidebarLayout {
+  return {
+    ...layout,
+    groups: layout.groups.map((g) => (g.id === id ? { ...g, name } : g)),
+  };
+}
+
+/** Set a group's shared context, injected into every member agent's prompt. */
+export function setGroupContextOp(
+  layout: SidebarLayout,
+  id: string,
+  context: string,
+): SidebarLayout {
+  return {
+    ...layout,
+    groups: layout.groups.map((g) => (g.id === id ? { ...g, context } : g)),
+  };
+}
+
+/** Delete a group and append its members to the default section. */
+export function deleteGroupOp(
+  layout: SidebarLayout,
+  id: string,
+): SidebarLayout {
+  const target = layout.groups.find((g) => g.id === id);
+  if (!target) return layout;
+  const freed = target.agentIds.filter(
+    (agentId) => !layout.ungroupedOrder.includes(agentId),
+  );
+  return {
+    ...layout,
+    groups: layout.groups.filter((g) => g.id !== id),
+    ungroupedOrder: [...layout.ungroupedOrder, ...freed],
+  };
+}
+
+/** Toggle a group's collapsed flag (no-op if the id is unknown). */
+export function toggleGroupCollapsedOp(
+  layout: SidebarLayout,
+  id: string,
+): SidebarLayout {
+  return {
+    ...layout,
+    groups: layout.groups.map((g) =>
+      g.id === id ? { ...g, collapsed: !g.collapsed } : g,
+    ),
+  };
+}

--- a/app/src/lib/sidebar-layout-ops.ts
+++ b/app/src/lib/sidebar-layout-ops.ts
@@ -1,5 +1,13 @@
 import type { SidebarGroup, SidebarLayout } from "@houston-ai/engine-client";
 
+export {
+  createGroupOp,
+  deleteGroupOp,
+  renameGroupOp,
+  setGroupContextOp,
+  toggleGroupCollapsedOp,
+} from "./sidebar-layout-group-ops.ts";
+
 /** The layout an unset/corrupt `sidebar_layout` preference reads as. */
 export const DEFAULT_SIDEBAR_LAYOUT: SidebarLayout = {
   groups: [],
@@ -72,71 +80,36 @@ function insertBefore(
   return [...list.slice(0, idx), id, ...list.slice(idx)];
 }
 
-/** Append a new, empty, expanded group with a caller-minted id. */
-export function createGroupOp(
+/** Replace an agent id in-place after a folder-backed rename. Existing copies
+ * of the new id are removed so the layout remains duplicate-free. */
+export function remapAgentIdOp(
   layout: SidebarLayout,
-  id: string,
-  name: string,
+  oldId: string,
+  newId: string,
 ): SidebarLayout {
+  if (oldId === newId) return layout;
+  const hasOldId =
+    layout.groups.some((group) => group.agentIds.includes(oldId)) ||
+    layout.ungroupedOrder.includes(oldId);
+  if (!hasOldId) return layout;
+  const lists = [
+    ...layout.groups.map((group) => group.agentIds),
+    layout.ungroupedOrder,
+  ];
+  const winnerListIndex = lists.findIndex((ids) => ids.includes(oldId));
+  const remap = (ids: string[], listIndex: number) =>
+    ids.flatMap((id) => {
+      if (id === newId) return [];
+      if (id === oldId) return listIndex === winnerListIndex ? [newId] : [];
+      return [id];
+    });
   return {
     ...layout,
-    groups: [...layout.groups, { id, name, collapsed: false, agentIds: [] }],
-  };
-}
-
-/** Rename a group (no-op if the id is unknown). */
-export function renameGroupOp(
-  layout: SidebarLayout,
-  id: string,
-  name: string,
-): SidebarLayout {
-  return {
-    ...layout,
-    groups: layout.groups.map((g) => (g.id === id ? { ...g, name } : g)),
-  };
-}
-
-/** Set a group's shared context, injected into every member agent's system
- *  prompt as `GROUP.md` (no-op if the id is unknown). */
-export function setGroupContextOp(
-  layout: SidebarLayout,
-  id: string,
-  context: string,
-): SidebarLayout {
-  return {
-    ...layout,
-    groups: layout.groups.map((g) => (g.id === id ? { ...g, context } : g)),
-  };
-}
-
-/** Delete a group; its members fall back to the default section (appended to
- *  `ungroupedOrder` so manual order is preserved). */
-export function deleteGroupOp(
-  layout: SidebarLayout,
-  id: string,
-): SidebarLayout {
-  const target = layout.groups.find((g) => g.id === id);
-  if (!target) return layout;
-  const freed = target.agentIds.filter(
-    (a) => !layout.ungroupedOrder.includes(a),
-  );
-  return {
-    ...layout,
-    groups: layout.groups.filter((g) => g.id !== id),
-    ungroupedOrder: [...layout.ungroupedOrder, ...freed],
-  };
-}
-
-/** Toggle a group's collapsed flag (no-op if the id is unknown). */
-export function toggleGroupCollapsedOp(
-  layout: SidebarLayout,
-  id: string,
-): SidebarLayout {
-  return {
-    ...layout,
-    groups: layout.groups.map((g) =>
-      g.id === id ? { ...g, collapsed: !g.collapsed } : g,
-    ),
+    groups: layout.groups.map((group, index) => ({
+      ...group,
+      agentIds: remap(group.agentIds, index),
+    })),
+    ungroupedOrder: remap(layout.ungroupedOrder, layout.groups.length),
   };
 }
 

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -26,6 +26,7 @@ import type {
 } from "@houston-ai/engine-client";
 import { shouldUseClaudeDesktopLogin } from "../components/shell/provider-login-url";
 import { actingUser } from "./acting-user";
+import { isAgentNameConflictError } from "./agent-name-conflict";
 import {
   blockWriteWhileWarming,
   blockWriteWhileWarmingById,
@@ -266,8 +267,12 @@ export const tauriAgents = {
   rename: (workspaceId: string, id: string, newName: string) => {
     // A rename dispatches into the agent's engine — held while it warms up.
     blockWriteWhileWarmingById(id);
-    return call<Agent>("rename_agent", async () =>
-      toAgent(await getEngine().renameAgent(workspaceId, id, newName)),
+    return call<Agent>(
+      "rename_agent",
+      async () =>
+        toAgent(await getEngine().renameAgent(workspaceId, id, newName)),
+      undefined,
+      { silence: isAgentNameConflictError },
     );
   },
   updateColor: (workspaceId: string, id: string, color: string) =>

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -43,6 +43,8 @@
   },
   "toasts": {
     "renamed": "Workspace renamed",
+    "nameConflict": "An agent named {{name}} already exists",
+    "nameConflictDescription": "Choose a different name and try again.",
     "deleted": "Workspace deleted",
     "switchedModel": "Switched to {{provider}} ({{model}})",
     "timezoneSet": "Timezone set to {{zone}}"

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -43,6 +43,8 @@
   },
   "toasts": {
     "renamed": "Espacio de trabajo renombrado",
+    "nameConflict": "Ya existe un agente llamado {{name}}",
+    "nameConflictDescription": "Elige un nombre diferente e inténtalo de nuevo.",
     "deleted": "Espacio de trabajo eliminado",
     "switchedModel": "Cambiaste a {{provider}} ({{model}})",
     "timezoneSet": "Zona horaria puesta en {{zone}}"

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -43,6 +43,8 @@
   },
   "toasts": {
     "renamed": "Espaço de trabalho renomeado",
+    "nameConflict": "Já existe um agente chamado {{name}}",
+    "nameConflictDescription": "Escolha um nome diferente e tente novamente.",
     "deleted": "Espaço de trabalho excluído",
     "switchedModel": "Mudou para {{provider}} ({{model}})",
     "timezoneSet": "Fuso horário definido como {{zone}}"

--- a/app/src/stores/agents.ts
+++ b/app/src/stores/agents.ts
@@ -73,7 +73,7 @@ interface AgentState {
     existingPath?: string,
   ) => Promise<CreatedAgent>;
   delete: (workspaceId: string, id: string) => Promise<void>;
-  rename: (workspaceId: string, id: string, newName: string) => Promise<void>;
+  rename: (workspaceId: string, id: string, newName: string) => Promise<Agent>;
   updateColor: (
     workspaceId: string,
     id: string,
@@ -203,6 +203,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     if (get().current?.id === id) {
       get().setCurrent(updated);
     }
+    return updated;
   },
 
   updateColor: async (workspaceId, id, color) => {

--- a/app/tests/agent-name-conflict.test.ts
+++ b/app/tests/agent-name-conflict.test.ts
@@ -1,0 +1,22 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { HoustonEngineError } from "../../packages/web/src/engine-adapter/client/errors.ts";
+import { isAgentNameConflictError } from "../src/lib/agent-name-conflict.ts";
+
+describe("isAgentNameConflictError", () => {
+  it("matches a 409 HoustonEngineError from an agent rename", () => {
+    strictEqual(
+      isAgentNameConflictError(new HoustonEngineError(409, { error: "taken" })),
+      true,
+    );
+  });
+
+  it("rejects undefined, non-objects, and non-conflict engine errors", () => {
+    strictEqual(isAgentNameConflictError(undefined), false);
+    strictEqual(isAgentNameConflictError("409"), false);
+    strictEqual(
+      isAgentNameConflictError(new HoustonEngineError(400, { error: "bad" })),
+      false,
+    );
+  });
+});

--- a/app/tests/rename-agent-follow-up.test.ts
+++ b/app/tests/rename-agent-follow-up.test.ts
@@ -1,0 +1,31 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { renameAgentWithFollowUp } from "../src/lib/rename-agent-follow-up.ts";
+
+describe("renameAgentWithFollowUp", () => {
+  it("remaps the sidebar when rename returns a changed id", async () => {
+    const remaps: Array<[string, string]> = [];
+    await renameAgentWithFollowUp({
+      workspaceId: "workspace",
+      agentId: "old-id",
+      name: "New name",
+      renameAgent: async () => ({ id: "new-id" }),
+      remapAgentId: (from, to) => remaps.push([from, to]),
+    });
+    deepStrictEqual(remaps, [["old-id", "new-id"]]);
+  });
+
+  it("does not remap when rename preserves the id", async () => {
+    let remapCount = 0;
+    await renameAgentWithFollowUp({
+      workspaceId: "workspace",
+      agentId: "same-id",
+      name: "New name",
+      renameAgent: async () => ({ id: "same-id" }),
+      remapAgentId: () => {
+        remapCount += 1;
+      },
+    });
+    strictEqual(remapCount, 0);
+  });
+});

--- a/app/tests/sidebar-layout-ops.test.ts
+++ b/app/tests/sidebar-layout-ops.test.ts
@@ -1,0 +1,84 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { SidebarLayout } from "@houston-ai/engine-client";
+import { remapAgentIdOp } from "../src/lib/sidebar-layout-ops.ts";
+
+const layout = (over: Partial<SidebarLayout>): SidebarLayout => ({
+  groups: [],
+  ungroupedOrder: [],
+  ...over,
+});
+
+describe("remapAgentIdOp", () => {
+  it("keeps a grouped agent at its existing position", () => {
+    const result = remapAgentIdOp(
+      layout({
+        groups: [
+          {
+            id: "group",
+            name: "Group",
+            collapsed: false,
+            agentIds: ["a", "old", "b"],
+          },
+        ],
+      }),
+      "old",
+      "new",
+    );
+    deepStrictEqual(result.groups[0]?.agentIds, ["a", "new", "b"]);
+  });
+
+  it("keeps an ungrouped agent at its existing position", () => {
+    const result = remapAgentIdOp(
+      layout({ ungroupedOrder: ["a", "old", "b"] }),
+      "old",
+      "new",
+    );
+    deepStrictEqual(result.ungroupedOrder, ["a", "new", "b"]);
+  });
+
+  it("leaves an absent id unchanged", () => {
+    const initial = layout({ ungroupedOrder: ["a", "new"] });
+    strictEqual(remapAgentIdOp(initial, "old", "new"), initial);
+  });
+
+  it("removes a duplicate when the new id is already present", () => {
+    const result = remapAgentIdOp(
+      layout({
+        groups: [
+          {
+            id: "group",
+            name: "Group",
+            collapsed: false,
+            agentIds: ["old", "new"],
+          },
+        ],
+        ungroupedOrder: ["new", "old"],
+      }),
+      "old",
+      "new",
+    );
+    deepStrictEqual(result.groups[0]?.agentIds, ["new"]);
+    deepStrictEqual(result.ungroupedOrder, []);
+  });
+
+  it("removes an existing new id from another section", () => {
+    const result = remapAgentIdOp(
+      layout({
+        groups: [
+          {
+            id: "group",
+            name: "Group",
+            collapsed: false,
+            agentIds: ["old"],
+          },
+        ],
+        ungroupedOrder: ["new"],
+      }),
+      "old",
+      "new",
+    );
+    deepStrictEqual(result.groups[0]?.agentIds, ["new"]);
+    deepStrictEqual(result.ungroupedOrder, []);
+  });
+});

--- a/packages/web/e2e/agents.spec.ts
+++ b/packages/web/e2e/agents.spec.ts
@@ -97,18 +97,10 @@ test("never shows the previous agent's missions while the next board read is in 
   });
 });
 
-/**
- * Renaming via the (hover-gated) agent kebab → Rename. The menu items are
- * Rename / Change color / Export a copy / Delete; Rename focuses an inline
- * field, which we replace and submit.
- */
+/** Renaming via the visible agent kebab → Rename focuses an inline field. */
 test("renames an agent", async ({ page }) => {
   await page.goto("/");
 
-  const agent = page
-    .getByRole("button", { name: "Houston", exact: true })
-    .last();
-  await agent.hover();
   await page.getByRole("button", { name: "Agent menu" }).click();
   await page.getByRole("menuitem", { name: "Rename" }).click();
 

--- a/packages/web/src/engine-adapter/client/errors.ts
+++ b/packages/web/src/engine-adapter/client/errors.ts
@@ -6,10 +6,10 @@
  * public surface (`HoustonEngineError`, `isHoustonEngineError`) is unchanged.
  */
 export class HoustonEngineError extends Error {
-  constructor(
-    public status: number,
-    public body: unknown,
-  ) {
+  public status: number;
+  public body: unknown;
+
+  constructor(status: number, body: unknown) {
     // Carry the host's own explanation into the message: the v3 host answers
     // errors as `{error: "reason"}` (some routes as `{error: {message}}`).
     // Dropping it here would reduce every failure to "engine error <status>"
@@ -25,6 +25,8 @@ export class HoustonEngineError extends Error {
       reason ? `${reason} (engine error ${status})` : `engine error ${status}`,
     );
     this.name = "HoustonEngineError";
+    this.status = status;
+    this.body = body;
   }
   get code(): string | undefined {
     return (this.body as { error?: { code?: string } })?.error?.code;

--- a/ui/layout/src/sidebar-classes.ts
+++ b/ui/layout/src/sidebar-classes.ts
@@ -10,19 +10,17 @@ export const sidebarItemRowClasses = {
     "flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left text-[13px] cursor-grab active:cursor-grabbing",
   icon: "shrink-0",
   name: "min-w-0 flex-1 truncate",
-  actions: "relative mr-1 flex size-7 shrink-0 items-center justify-center",
-  trailing:
-    "absolute inset-0 flex items-center justify-center pointer-events-none transition-opacity duration-100",
-  trailingWithMenu: "group-hover:opacity-0 group-focus-within:opacity-0",
-  trailingMenuOpen: "opacity-0",
+  actions: "relative mr-1 flex shrink-0 items-center gap-1",
+  trailing: "flex shrink-0 items-center justify-center pointer-events-none",
   menuButton:
-    "absolute inset-0 flex size-7 shrink-0 items-center justify-center rounded-md text-ink-muted opacity-0 pointer-events-none transition-[background-color,color,opacity] hover:bg-hover hover:text-ink focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 data-[state=open]:pointer-events-auto data-[state=open]:opacity-100",
+    "flex size-7 shrink-0 items-center justify-center rounded-md text-ink-muted/50 transition-[background-color,color] hover:bg-hover hover:text-ink focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus focus-visible:text-ink data-[state=open]:text-ink",
   collapsedTrailing:
     "pointer-events-none absolute -right-1 -top-1 flex scale-75 items-center justify-center",
 } as const;
 
 // Mercury-clean group chrome: a quiet uppercase label, hairline chevron, muted
-// count, hover-revealed "..." — no dividing lines, hierarchy carried by spacing.
+// count, and quiet always-visible "..." — no dividing lines, hierarchy carried
+// by spacing.
 export const sidebarGroupClasses = {
   header:
     "group/gh relative flex w-full min-w-0 items-center gap-1 rounded-md px-1.5 py-1 transition-colors duration-100 hover:bg-hover/40",
@@ -32,7 +30,7 @@ export const sidebarGroupClasses = {
   count:
     "shrink-0 text-[10px] font-medium tabular-nums text-ink-muted/40 transition-opacity duration-100 group-hover/gh:opacity-0",
   menuButton:
-    "absolute right-1.5 flex size-5 shrink-0 items-center justify-center rounded text-ink-muted/60 opacity-0 transition-[opacity,background-color,color] duration-100 hover:bg-hover hover:text-ink focus-visible:outline-none focus-visible:opacity-100 group-hover/gh:opacity-100 data-[state=open]:opacity-100",
+    "flex size-5 shrink-0 items-center justify-center rounded text-ink-muted/60 transition-[background-color,color] duration-100 hover:bg-hover hover:text-ink focus-visible:outline-none data-[state=open]:text-ink",
   nameInput:
     "min-w-0 flex-1 rounded border border-line bg-input px-1.5 py-0.5 text-xs outline-none focus:border-ink/30",
 } as const;

--- a/ui/layout/src/sidebar-group-header.tsx
+++ b/ui/layout/src/sidebar-group-header.tsx
@@ -31,7 +31,7 @@ export interface SidebarGroupHeaderProps {
 
 /**
  * Collapsible group header (Mercury-clean: a quiet uppercase label, a hairline
- * chevron, a muted count, and a hover-only "..." menu). The chevron + label are
+ * chevron, a muted count, and a quiet always-visible "..." menu). The chevron + label are
  * the drag handle; clicking the label toggles collapse. The label swaps to an
  * inline rename input — focused ONCE on entry (a ref-callback that re-focuses
  * every render would re-`select()` and eat all but the first keystroke).

--- a/ui/layout/src/sidebar-item-row.tsx
+++ b/ui/layout/src/sidebar-item-row.tsx
@@ -110,13 +110,7 @@ export function SidebarItemRow({
       {!isEditing && (item.trailing || hasMenu) && (
         <div className={sidebarItemRowClasses.actions}>
           {item.trailing && (
-            <span
-              className={cn(
-                sidebarItemRowClasses.trailing,
-                hasMenu && sidebarItemRowClasses.trailingWithMenu,
-                menuOpen && sidebarItemRowClasses.trailingMenuOpen,
-              )}
-            >
+            <span className={sidebarItemRowClasses.trailing}>
               {item.trailing}
             </span>
           )}

--- a/ui/layout/tests/sidebar-item-row-layout.test.ts
+++ b/ui/layout/tests/sidebar-item-row-layout.test.ts
@@ -1,7 +1,8 @@
-import { ok } from "node:assert";
+import { ok, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
   sidebarClasses,
+  sidebarGroupClasses,
   sidebarItemRowClasses,
 } from "../src/sidebar-classes.ts";
 
@@ -30,17 +31,24 @@ describe("sidebar item row layout", () => {
   it("keeps menu trigger in its own visible slot", () => {
     ok(includes(sidebarItemRowClasses.menuButton, "size-7"));
     ok(includes(sidebarItemRowClasses.menuButton, "shrink-0"));
-    ok(includes(sidebarItemRowClasses.menuButton, "opacity-0"));
-    ok(includes(sidebarItemRowClasses.menuButton, "group-hover:opacity-100"));
-    ok(
-      includes(
-        sidebarItemRowClasses.menuButton,
-        "group-focus-within:opacity-100",
-      ),
+    strictEqual(includes(sidebarItemRowClasses.menuButton, "opacity-0"), false);
+    strictEqual(
+      includes(sidebarItemRowClasses.menuButton, "pointer-events-none"),
+      false,
     );
-    ok(
-      includes(sidebarItemRowClasses.trailingWithMenu, "group-hover:opacity-0"),
+    ok(includes(sidebarItemRowClasses.menuButton, "text-ink-muted/50"));
+    strictEqual(includes(sidebarItemRowClasses.trailing, "absolute"), false);
+    strictEqual(includes(sidebarItemRowClasses.actions, "size-7"), false);
+    ok(includes(sidebarItemRowClasses.actions, "gap-1"));
+  });
+
+  it("keeps the group menu visible and quiet", () => {
+    strictEqual(includes(sidebarGroupClasses.menuButton, "opacity-0"), false);
+    strictEqual(
+      includes(sidebarGroupClasses.menuButton, "group-hover/gh:opacity-100"),
+      false,
     );
-    ok(includes(sidebarItemRowClasses.trailingMenuOpen, "opacity-0"));
+    ok(includes(sidebarGroupClasses.menuButton, "text-ink-muted/60"));
+    strictEqual(includes(sidebarGroupClasses.menuButton, "absolute"), false);
   });
 });


### PR DESCRIPTION
## What

Users reported agents can't be renamed. The rename backend (PATCH /v1/agents/:id, quiesce contract, conflict 409) was already complete and tested; the defects were all frontend:

- **Hover-gated affordance**: the sidebar agent-row kebab menu (the only rename entry point) was `opacity-0` until hover, violating the repo's no-hover-only-affordances rule. It is now always visible in a quiet muted tone, with the activity chip and the kebab in separate flex slots instead of the old hover swap (no overlap with the unread/needs-you chip). The group-header menu one line below had the same gating and got the same fix.
- **Rename dropped the agent out of its sidebar group**: on the host the agent id is `Workspace/Dir`, so rename changes the id, and `sidebar_layout` kept the old id. New pure `remapAgentIdOp` (order-independent, dedupe-safe) remaps group membership and manual order on id-changing renames.
- **Raw English 409**: a name conflict now shows a localized info toast with guidance (en/es/pt) via a typed classifier on `HoustonEngineError.status`; non-conflict errors keep propagating (no swallow).

Bonus: the remap also keeps GROUP.md context sync intact since the host rewrites it under the new folder.

## Tests

- `ui/layout` layout tests rewritten for the new visible-menu contract (23 pass).
- New unit tests: `remapAgentIdOp` (grouped/ungrouped/absent/dedupe), rename follow-up seam (changed vs unchanged id), 409 classifier (real `HoustonEngineError`, non-409, non-object). App suite: 2311 pass.
- e2e `agents.spec.ts` rename flow now clicks the kebab cold (no hover step). Runs green: agents, sidebar, sidebar-dnd, agent-sidebar-menu, tour (12 passed) + visual regression (6 passed, within threshold; sidebar eyeballed at rest: chip + kebab side by side).
- `HoustonEngineError` switched from constructor parameter properties to explicit fields (public surface unchanged) for Node strip-only test compatibility.

Fixes HOU-975

🤖 Generated with [Claude Code](https://claude.com/claude-code)