### PR TITLE
fix(agents): remount agent view on switch and guard selection races

### DIFF
--- a/app/src/components/agent-person-scope-context.tsx
+++ b/app/src/components/agent-person-scope-context.tsx
@@ -5,16 +5,12 @@ import {
   useMemo,
   useState,
 } from "react";
-import {
-  DEFAULT_SCOPE,
-  type PersonScope,
-  reconcileAgentScope,
-} from "../lib/agent-person-scope";
+import { DEFAULT_SCOPE, type PersonScope } from "../lib/agent-person-scope";
 
 interface AgentPersonScopeValue {
   /** Agent path this scope belongs to. */
   path: string;
-  /** The reconciled scope for THIS frame (reset to the default on agent switch). */
+  /** The scope for this keyed agent view. */
   scope: PersonScope;
   setScope: (scope: PersonScope) => void;
 }
@@ -27,15 +23,8 @@ const AgentPersonScopeContext = createContext<AgentPersonScopeValue | null>(
  * Holds the per-agent PERSON SCOPE and shares it across the agent view so the
  * header trigger ({@link AgentPersonScopeMenu}) and the board filter
  * ({@link useAgentBoardScope}) — which sit in different subtrees — read and
- * write ONE selection. Wraps the whole agent view (tab bar + board), keyed by
- * agent path.
- *
- * The scope is per-agent and resets to {@link DEFAULT_SCOPE} (me) on agent
- * switch. The view is reused across agents, so the reset happens during render
- * via {@link reconcileAgentScope}: `reconciled` is the single source of truth
- * for this frame — persisted to state AND handed to consumers below — so the
- * reset lands before the filtered board commits (no one-frame flash of the
- * previous agent's scope).
+ * write ONE selection. The whole agent view is keyed by agent identity, so a
+ * fresh provider starts at {@link DEFAULT_SCOPE} for every agent.
  */
 export function AgentPersonScopeProvider({
   path,
@@ -45,16 +34,10 @@ export function AgentPersonScopeProvider({
   children: ReactNode;
 }) {
   const [scope, setScope] = useState<PersonScope>(DEFAULT_SCOPE);
-  const [trackedPath, setTrackedPath] = useState(path);
-  const reconciled = reconcileAgentScope({ trackedPath, path, scope });
-  if (trackedPath !== path) {
-    setTrackedPath(path);
-    setScope(reconciled);
-  }
 
   const value = useMemo<AgentPersonScopeValue>(
-    () => ({ path, scope: reconciled, setScope }),
-    [path, reconciled],
+    () => ({ path, scope, setScope }),
+    [path, scope],
   );
   return (
     <AgentPersonScopeContext.Provider value={value}>

--- a/app/src/components/board/use-agent-board-selection.ts
+++ b/app/src/components/board/use-agent-board-selection.ts
@@ -10,16 +10,13 @@ import { useSelectionSet } from "./use-selection-set";
 /**
  * Per-agent multi-select + bulk actions for the board tab. The selection
  * set + UI live in {@link useSelectionSet}; this layer wires the agent-scoped
- * bulk mutations. The selection resets whenever `resetKey` changes (the tab
- * is reused across agents, so a selection must not bleed between them). Bulk
- * actions clear the selection on success; failures propagate so the caller
- * surfaces a toast (no silent swallow).
+ * bulk mutations. Bulk actions clear the selection on success; failures
+ * propagate so the caller surfaces a toast (no silent swallow).
  */
 export function useAgentBoardSelection(
   agentPath: string | undefined,
-  resetKey: string,
 ): BoardSelectionModel {
-  const { selectedIds, toggle, selectAll, clear } = useSelectionSet(resetKey);
+  const { selectedIds, toggle, selectAll, clear } = useSelectionSet();
   const bulkUpdate = useBulkUpdateActivity(agentPath);
   const bulkDelete = useBulkDeleteActivity(agentPath);
 

--- a/app/src/components/board/use-agent-board-source.tsx
+++ b/app/src/components/board/use-agent-board-source.tsx
@@ -17,8 +17,7 @@ import { useAgentNewMission } from "./use-agent-new-mission";
  * Builds the {@link BoardSource} for a single agent's board tab: per-agent
  * data + send, multi-select, the default-mode "New mission" flow, and the
  * cross-agent navigation handoff (a notification / command-palette / Mission
- * Control click publishes its target via `activityPanelId`, which this reused
- * tab reconciles on agent switch).
+ * Control click publishes its target via `activityPanelId`).
  */
 export function useAgentBoardSource(
   agent: Agent,
@@ -46,32 +45,13 @@ export function useAgentBoardSource(
   const [selectedId, setSelectedId] = useState<string | null>(pendingId);
   const [highlightedId, setHighlightedId] = useState<string | null>(pendingId);
 
-  // `selectedId`/`highlightedId` are per-agent, but this tab is reused across
-  // agents. On switch, adopt the published cross-agent target (if any) during
-  // render — `missionPanelOpen` still describes the agent we left, so deferring
-  // to the consume effect below would strand the nav.
-  const [trackedAgentId, setTrackedAgentId] = useState(agent.id);
-  if (trackedAgentId !== agent.id) {
-    setTrackedAgentId(agent.id);
-    const next = resolvePendingActivitySelection({
-      pendingActivityId: pendingId,
-      forceOpen: pendingForceOpen,
-      agentSwitched: true,
-      selectedId,
-      missionPanelOpen,
-    });
-    setSelectedId(next);
-    setHighlightedId(next);
-  }
-
   useEffect(() => {
     if (!pendingId) return;
-    // Same-agent nav (the switch case is handled above): honor the guard so we
-    // don't yank the user out of an open conversation or a New Mission composer.
+    // Preserve an open same-agent conversation or New Mission composer unless
+    // this is an explicit, force-open navigation.
     const next = resolvePendingActivitySelection({
       pendingActivityId: pendingId,
       forceOpen: pendingForceOpen,
-      agentSwitched: false,
       selectedId,
       missionPanelOpen,
     });
@@ -93,7 +73,7 @@ export function useAgentBoardSource(
     pendingAgentMode: newMission.pendingAgentMode,
     setPendingAgentMode: newMission.setPendingAgentMode,
   });
-  const selection = useAgentBoardSelection(path, agent.id);
+  const selection = useAgentBoardSelection(path);
 
   // Attribution + person-scope narrowing (hosted Teams only; off-multiplayer
   // identity pass-through), on the active cards BEFORE text search, as the cross

--- a/app/src/components/board/use-cross-agent-selection.ts
+++ b/app/src/components/board/use-cross-agent-selection.ts
@@ -19,17 +19,15 @@ import { useSelectionSet } from "./use-selection-set";
  * Failures propagate so the caller surfaces a toast (no silent swallow).
  */
 export function useCrossAgentSelection({
-  resetKey,
   paths,
   agentPathForId,
 }: {
-  resetKey: string;
   /** Every agent path on the Mission Control view (for query invalidation). */
   paths: string[];
   /** Resolve a mission id to its owning agent path. */
   agentPathForId: (id: string) => string | undefined;
 }): BoardSelectionModel {
-  const { selectedIds, toggle, selectAll, clear } = useSelectionSet(resetKey);
+  const { selectedIds, toggle, selectAll, clear } = useSelectionSet();
   const qc = useQueryClient();
 
   const invalidate = useCallback(

--- a/app/src/components/board/use-mission-control-source.tsx
+++ b/app/src/components/board/use-mission-control-source.tsx
@@ -118,7 +118,6 @@ export function useMissionControlSource(
     [mc.items],
   );
   const selection = useCrossAgentSelection({
-    resetKey: filterPath || "all",
     paths,
     agentPathForId,
   });

--- a/app/src/components/board/use-selection-set.ts
+++ b/app/src/components/board/use-selection-set.ts
@@ -1,21 +1,15 @@
 import type { KanbanItem } from "@houston-ai/board";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { selectAllIds } from "../../lib/mission-selection";
 
 /**
  * The multi-select set half of a {@link BoardSelectionModel}, identical for
  * the per-agent board and cross-agent Mission Control. Only the bulk dispatch
  * (move / archive / delete) differs, so each selection hook layers its own
- * mutations on top of this shared state. Resets whenever `resetKey` changes
- * so a reused board can't carry a stale selection into a new scope.
+ * mutations on top of this shared state.
  */
-export function useSelectionSet(resetKey: string) {
+export function useSelectionSet() {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: resetKey is a prop-derived reset trigger; the effect must re-run when it changes to clear stale selections across scope transitions
-  useEffect(() => {
-    setSelectedIds(new Set());
-  }, [resetKey]);
 
   const toggle = useCallback((item: KanbanItem) => {
     setSelectedIds((prev) => {

--- a/app/src/components/shell/experience-renderer.tsx
+++ b/app/src/components/shell/experience-renderer.tsx
@@ -36,7 +36,11 @@ export function AgentRenderer({
                 </div>
               }
             >
-              <TabComponent agent={agent} agentDef={agentDef} />
+              <TabComponent
+                agent={agent}
+                agentDef={agentDef}
+                isActive={isActive}
+              />
             </Suspense>
           </div>
         );

--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -255,7 +255,10 @@ export function WorkspaceShell({
                   ) : viewMode === ORGANIZATION_VIEW_ID && showOrganization ? (
                     <OrganizationView />
                   ) : currentAgent && agentDef && isAgentView ? (
-                    <AgentPersonScopeProvider path={currentAgent.folderPath}>
+                    <AgentPersonScopeProvider
+                      key={currentAgent.id}
+                      path={currentAgent.folderPath}
+                    >
                       <div data-tour-target="tabs">
                         <TabBar
                           title={currentAgent.name}

--- a/app/src/components/tabs/routines-tab-model.ts
+++ b/app/src/components/tabs/routines-tab-model.ts
@@ -19,6 +19,11 @@ export type Selection =
   | { kind: "routine"; routineId: string }
   | { kind: "draft"; activityId: string | null };
 
+/** Only the visible Automations tab may control the shared shell panel. */
+export function shouldSyncRoutinesPanel(isActive: boolean): boolean {
+  return isActive;
+}
+
 /**
  * Adopt the freshly-created draft id, but only if the user is still waiting on
  * the pending null-draft (a functional setState guard): a failed start (no id)

--- a/app/src/components/tabs/routines-tab.tsx
+++ b/app/src/components/tabs/routines-tab.tsx
@@ -1,7 +1,7 @@
 import { Badge, Button, cn } from "@houston-ai/core";
 import { RoutinesGrid, TimezonePicker } from "@houston-ai/routines";
 import { Plus } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useRoutineRuns, useRoutines } from "../../hooks/queries";
 import { useRoutineLabels } from "../../hooks/use-routine-labels";
@@ -9,7 +9,10 @@ import { analytics } from "../../lib/analytics";
 import type { TabProps } from "../../lib/types";
 import { useShellDetailPanel } from "../shell/use-shell-detail-panel";
 import { useRoutineLeadingIcon } from "./routine-leading-icon";
-import { latestRunByRoutine } from "./routines-tab-model";
+import {
+  latestRunByRoutine,
+  shouldSyncRoutinesPanel,
+} from "./routines-tab-model";
 import { RoutinesTabPane } from "./routines-tab-pane";
 import { useRoutineChatSetup } from "./use-routine-chat-setup";
 import { useRoutineTabHandlers } from "./use-routine-tab-handlers";
@@ -29,7 +32,11 @@ import { useRoutinesTabView } from "./use-routines-tab-view";
  * only open their chat, toggle, run, or delete — no manual editor. Mutations
  * live in `useRoutineTabHandlers`; selection lives in `useRoutinesTabView`.
  */
-export default function RoutinesTab({ agent, agentDef }: TabProps) {
+export default function RoutinesTab({
+  agent,
+  agentDef,
+  isActive = false,
+}: TabProps) {
   const { t } = useTranslation("routines");
   const labels = useRoutineLabels();
   const path = agent.folderPath;
@@ -39,22 +46,30 @@ export default function RoutinesTab({ agent, agentDef }: TabProps) {
   const lastRuns = latestRunByRoutine(allRuns);
 
   const chatSetup = useRoutineChatSetup(agent, routines);
-  const nav = useRoutinesTabView(agent, routines, chatSetup);
+  const nav = useRoutinesTabView(routines, chatSetup);
   const triggers = useRoutineTriggers(agent, routines);
   const h = useRoutineTabHandlers(agent);
 
   // The chat opens in the SAME shell-level panel the Activity board uses (a
   // sibling of the main card, not a pane nested in this tab). A selection owns
-  // that panel; the tab owns the open flag for the whole selection lifecycle —
-  // the pre-model intake/draft surfaces have no board to drive it themselves.
+  // that panel while Automations is visible; the pre-model intake/draft
+  // surfaces have no board to drive it themselves.
   const { selected } = nav;
   const { panelContainer, setPanelOpen } = useShellDetailPanel();
   useEffect(() => {
+    if (!shouldSyncRoutinesPanel(isActive)) return;
     setPanelOpen(!!selected);
-  }, [selected, setPanelOpen]);
-  // Close the panel when the tab unmounts (tab or agent switch) so no stale,
-  // empty shell panel is ever left behind next to the next surface.
-  useEffect(() => () => setPanelOpen(false), [setPanelOpen]);
+  }, [isActive, selected, setPanelOpen]);
+  // All agent tabs stay mounted. Only the active Routines tab may close its
+  // shell panel, otherwise an inactive tab can clobber a mission navigation.
+  const isActiveRef = useRef(isActive);
+  isActiveRef.current = isActive;
+  useEffect(
+    () => () => {
+      if (isActiveRef.current) setPanelOpen(false);
+    },
+    [setPanelOpen],
+  );
   // Per-row identity glyph — the triggering app's logo (or a webhook mark) for
   // event routines, the grid's default clock for schedule ones.
   const leadingIcon = useRoutineLeadingIcon(triggers.triggersEnabled);

--- a/app/src/components/tabs/use-routines-tab-view.ts
+++ b/app/src/components/tabs/use-routines-tab-view.ts
@@ -2,7 +2,6 @@ import type { Routine } from "@houston-ai/engine-client";
 import { useCallback, useEffect, useState } from "react";
 import { analytics } from "../../lib/analytics";
 import { encodeRoutineIntakeHandoffMessage } from "../../lib/routine-chat-handoff";
-import type { Agent } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 import type { IntakeResult } from "./automation-intake";
 import {
@@ -24,20 +23,10 @@ import type { useRoutineChatSetup } from "./use-routine-chat-setup";
  * state, effects, and the selection handlers.
  */
 export function useRoutinesTabView(
-  agent: Agent,
   routines: Routine[] | undefined,
   chatSetup: ReturnType<typeof useRoutineChatSetup>,
 ) {
   const [selected, setSelected] = useState<Selection | null>(null);
-
-  // The tab is reused across agents (keyed by tab); clear the selection on
-  // agent switch so nothing — not even a half-finished intake — ever bleeds
-  // between agents' Automations tabs.
-  const [trackedAgentId, setTrackedAgentId] = useState(agent.id);
-  if (trackedAgentId !== agent.id) {
-    setTrackedAgentId(agent.id);
-    setSelected(null);
-  }
 
   // A session-finished notification (#401) lands as a one-shot activity id;
   // resolvePendingActivity selects its routine/draft chat, or clears a

--- a/app/src/lib/agent-invalidation-plan.ts
+++ b/app/src/lib/agent-invalidation-plan.ts
@@ -111,7 +111,7 @@ export function planInvalidation(
     case "SessionStatus":
       if (ev.data.status === "completed" || ev.data.status === "error") {
         const agentPath = ev.data.agent_path;
-        plan.invalidate.push(["activity"]);
+        plan.invalidate.push(queryKeys.activity(agentPath));
         plan.patchAllConversations.push(agentPath);
         // Cloud has NO file watcher and no post-turn sync diff, so a running
         // agent that writes its own CLAUDE.md / skills / learnings / files

--- a/app/src/lib/agent-person-scope.ts
+++ b/app/src/lib/agent-person-scope.ts
@@ -5,7 +5,7 @@ import { missionMatchesPerson } from "./mission-people.ts";
  * Pure, DOM-free model for the per-agent header PERSON SCOPE (the compact
  * dropdown beside the Share button that narrows an agent's board to one
  * person). No React, no store, no Supabase — so the default, the matching
- * semantics, the menu ordering, and the reset-on-agent-switch rule are all
+ * semantics and the menu ordering are all
  * unit-testable in isolation and shared verbatim by the header trigger
  * ({@link AgentPersonScopeMenu}) and the board filter ({@link useAgentBoardScope}).
  *
@@ -26,37 +26,6 @@ export type PersonScope =
  * instead of a neutral "Everyone" that hides the control's meaning.
  */
 export const DEFAULT_SCOPE: PersonScope = { kind: "me" };
-
-/**
- * Reconcile a reused agent view's scope across agent switches.
- *
- * The scope provider wraps the agent view, but the view (and its provider
- * instance) is REUSED when the user switches agents. A person or "everyone"
- * chosen for the PREVIOUS agent is meaningless on the next one — a teammate may
- * not be on any of its missions, so the board would render empty under a
- * trigger showing a stranger. So on a path (agent) change the scope snaps back
- * to {@link DEFAULT_SCOPE} (me); with no switch it survives, since plain
- * re-renders and data refreshes must not silently drop the user's choice.
- *
- * The caller feeds the returned value both to state AND to the frame it renders,
- * so the reset lands before the filtered board commits (no one-frame flash of
- * the previous agent's scope). Mirrors the sibling render-phase reset in
- * {@link resolvePendingActivitySelection}.
- */
-export function reconcileAgentScope({
-  trackedPath,
-  path,
-  scope,
-}: {
-  /** Agent path this provider instance last reconciled to. */
-  trackedPath: string;
-  /** Agent path being rendered now. */
-  path: string;
-  /** The currently selected scope. */
-  scope: PersonScope;
-}): PersonScope {
-  return trackedPath === path ? scope : DEFAULT_SCOPE;
-}
 
 /**
  * Does this mission belong under `scope` for the signed-in `selfId`?

--- a/app/src/lib/agent-selection.ts
+++ b/app/src/lib/agent-selection.ts
@@ -13,3 +13,21 @@ export function selectCurrentAgent(
   if (!current) return agents[0];
   return agents.find((a) => a.id === current.id) ?? agents[0];
 }
+
+export function shouldApplyAgentLoad(
+  generation: number,
+  latestGeneration: number,
+): boolean {
+  return generation === latestGeneration;
+}
+
+export function selectLoadedAgent(
+  agents: Agent[],
+  current: Agent | null,
+  selectionBeforeLoad: string | undefined,
+): Agent | null {
+  if (current?.id !== selectionBeforeLoad) {
+    return agents.find((agent) => agent.id === current?.id) ?? current ?? null;
+  }
+  return selectCurrentAgent(agents, current);
+}

--- a/app/src/lib/notification-nav.ts
+++ b/app/src/lib/notification-nav.ts
@@ -100,8 +100,6 @@ export interface PendingActivityArgs {
   pendingActivityId: string | null;
   /** Explicit user navigation, such as a notification click, may replace an open chat. */
   forceOpen?: boolean;
-  /** True only at the moment the board's active agent changed under it. */
-  agentSwitched: boolean;
   /** Activity whose chat is currently open on the board, or null. */
   selectedId: string | null;
   /** Whether a chat / New Mission panel is currently open over the board. */
@@ -109,30 +107,22 @@ export interface PendingActivityArgs {
 }
 
 /**
- * Decide which activity a reused BoardTab should select when an
+ * Decide which activity the active BoardTab should select when an
  * `activityPanelId` nav is published (notification click, command palette,
  * Mission Control). Returns the activity id to open, or null to open nothing.
  *
- * The cross-agent rule: when the agent just switched, always adopt the target.
- * The guards that protect the current view — an open conversation (`selectedId`)
- * and a New Mission composer (`missionPanelOpen`) — describe the agent we just
- * LEFT. This board instance is reused across agents and `missionPanelOpen` lives
- * in the global UI store, so right after a switch it still reads the previous
- * agent's value (it lags until AIBoard reconciles) and would otherwise swallow
- * the nav, stranding the user on the right agent with no chat open. Without a
- * switch, keep the guards: a nav must not yank the user out of an open
- * conversation or composer on the agent they're already looking at.
+ * The keyed agent subtree mounts a fresh board for cross-agent navigation. This
+ * helper therefore owns only same-agent guards: a passive nav must not yank the
+ * user out of an open conversation or composer.
  */
 export function resolvePendingActivitySelection({
   pendingActivityId,
   forceOpen = false,
-  agentSwitched,
   selectedId,
   missionPanelOpen,
 }: PendingActivityArgs): string | null {
   if (!pendingActivityId) return null;
   if (forceOpen) return pendingActivityId;
-  if (agentSwitched) return pendingActivityId;
   if (selectedId || missionPanelOpen) return null;
   return pendingActivityId;
 }

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -101,6 +101,8 @@ export interface Agent {
 export interface TabProps {
   agent: Agent;
   agentDef: AgentDefinition;
+  /** Whether this mounted tab owns the visible agent surface. */
+  isActive?: boolean;
 }
 
 /** Skill summary returned by list_skills */

--- a/app/src/stores/agents.ts
+++ b/app/src/stores/agents.ts
@@ -1,5 +1,8 @@
 import { create } from "zustand";
-import { selectCurrentAgent } from "../lib/agent-selection";
+import {
+  selectLoadedAgent,
+  shouldApplyAgentLoad,
+} from "../lib/agent-selection";
 import { analytics } from "../lib/analytics";
 import { getEngine, isEngineReady } from "../lib/engine";
 import {
@@ -15,6 +18,8 @@ import { useDraftStore } from "./drafts";
 export interface CreatedAgent {
   agent: Agent;
 }
+
+let loadAgentsGeneration = 0;
 
 function startAgentSideEffects(agent: Agent) {
   tauriPreferences.set("last_agent_id", agent.id);
@@ -92,16 +97,20 @@ export const useAgentStore = create<AgentState>((set, get) => ({
 
   loadAgents: async (workspaceId, options) => {
     const silent = options?.silent ?? false;
+    const generation = ++loadAgentsGeneration;
+    const selectionBeforeLoad = get().current?.id;
     if (!silent) set({ loading: true });
     try {
       const agents = await tauriAgents.list(workspaceId);
+      if (!shouldApplyAgentLoad(generation, loadAgentsGeneration)) return;
       const current = get().current;
-      const selected = selectCurrentAgent(agents, current);
+      const selected = selectLoadedAgent(agents, current, selectionBeforeLoad);
       set({ agents, current: selected, loading: false, loaded: true });
       if (selected && selected.id !== current?.id) {
         startAgentSideEffects(selected);
       }
     } catch (e) {
+      if (!shouldApplyAgentLoad(generation, loadAgentsGeneration)) return;
       console.error("[agents] Failed to load:", e);
       // Settled (with the failure already logged + toasted upstream): the boot
       // gate must not hang on `loaded` forever; an empty-but-failed list reads
@@ -111,6 +120,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   },
 
   settleEmpty: () => {
+    loadAgentsGeneration++;
     // Also tell the engine client no list is coming, so provider routing falls
     // back to the persisted selection instead of refusing every call while it
     // waits on a `listAgents` that will never run (HOU-979). Guarded because
@@ -191,6 +201,9 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     // the returned record instead of patching only `name`, or the stale path
     // later reaches tauriWatcher.start and the watch fails with a "neither a
     // file nor a directory" error toast (#298).
+    // Reject a roster snapshot started before the rename. It still carries the
+    // removed folder path and would restart its watcher after this mutation.
+    loadAgentsGeneration++;
     const updated = await tauriAgents.rename(workspaceId, id, newName);
     // A rename can change both id and folderPath; a warm-up probe pointed at
     // the old path would 404 and wrongly read as "ready" (HOU-693).
@@ -214,6 +227,8 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     }));
   },
 
-  reset: () =>
-    set({ agents: [], current: null, loading: false, loaded: false }),
+  reset: () => {
+    loadAgentsGeneration++;
+    set({ agents: [], current: null, loading: false, loaded: false });
+  },
 }));

--- a/app/tests/agent-invalidation-plan.test.ts
+++ b/app/tests/agent-invalidation-plan.test.ts
@@ -56,7 +56,7 @@ describe("planInvalidation — unrelated cases keep their exact effects", () => 
     deepStrictEqual(plan.patchAllConversations, [PATH]);
   });
 
-  it("SessionStatus (completed) invalidates the broad activity prefix", () => {
+  it("SessionStatus (completed) invalidates only that agent's activity", () => {
     const plan = planInvalidation(
       {
         type: "SessionStatus",
@@ -69,7 +69,8 @@ describe("planInvalidation — unrelated cases keep their exact effects", () => 
       },
       {},
     );
-    ok(invalidates(plan, ["activity"]));
+    ok(invalidates(plan, queryKeys.activity(PATH)));
+    strictEqual(invalidates(plan, ["activity"]), false);
     deepStrictEqual(plan.patchAllConversations, [PATH]);
   });
 

--- a/app/tests/agent-person-scope.test.ts
+++ b/app/tests/agent-person-scope.test.ts
@@ -6,12 +6,11 @@ import {
   DEFAULT_SCOPE,
   missionMatchesScope,
   type PersonScope,
-  reconcileAgentScope,
 } from "../src/lib/agent-person-scope.ts";
 
 // The per-agent header person scope: pure model. Covers the default ("me"), the
 // matching semantics (incl. unattributed missions staying visible), the menu
-// ordering, and the reset-to-default-on-agent-switch rule.
+// and ordering.
 
 const me: PersonScope = { kind: "me" };
 const everyone: PersonScope = { kind: "everyone" };
@@ -20,51 +19,6 @@ const person = (userId: string): PersonScope => ({ kind: "person", userId });
 describe("DEFAULT_SCOPE", () => {
   it("is 'me' — the board opens on the signed-in user", () => {
     deepStrictEqual(DEFAULT_SCOPE, { kind: "me" });
-  });
-});
-
-describe("reconcileAgentScope — reset to default (me) on agent switch", () => {
-  it("keeps the chosen scope while the agent (path) is unchanged", () => {
-    // Plain re-renders and data refreshes re-run this each frame; none may drop
-    // the user's choice.
-    deepStrictEqual(
-      reconcileAgentScope({
-        trackedPath: "/ws/AgentA",
-        path: "/ws/AgentA",
-        scope: person("mate"),
-      }),
-      person("mate"),
-    );
-    deepStrictEqual(
-      reconcileAgentScope({
-        trackedPath: "/ws/AgentA",
-        path: "/ws/AgentA",
-        scope: everyone,
-      }),
-      everyone,
-    );
-  });
-
-  it("snaps back to 'me' when the agent changes, dropping the stale person", () => {
-    // The leak: scoping agent A to teammate X then switching to agent B must NOT
-    // carry X over (B may not have X on any mission — the board would render
-    // empty under a stranger's face). Reconcile resets to the default.
-    deepStrictEqual(
-      reconcileAgentScope({
-        trackedPath: "/ws/AgentA",
-        path: "/ws/AgentB",
-        scope: person("mate"),
-      }),
-      DEFAULT_SCOPE,
-    );
-    deepStrictEqual(
-      reconcileAgentScope({
-        trackedPath: "/ws/AgentA",
-        path: "/ws/AgentB",
-        scope: everyone,
-      }),
-      DEFAULT_SCOPE,
-    );
   });
 });
 

--- a/app/tests/agent-selection.test.ts
+++ b/app/tests/agent-selection.test.ts
@@ -1,6 +1,10 @@
-import { strictEqual } from "node:assert";
+import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
-import { selectCurrentAgent } from "../src/lib/agent-selection.ts";
+import {
+  selectCurrentAgent,
+  selectLoadedAgent,
+  shouldApplyAgentLoad,
+} from "../src/lib/agent-selection.ts";
 import type { Agent } from "../src/lib/types.ts";
 
 function agent(id: string, name = id): Agent {
@@ -45,5 +49,36 @@ describe("agent selection", () => {
     const selected = selectCurrentAgent([], agent("missing", "Deleted"));
 
     strictEqual(selected, null);
+  });
+
+  it("uses the refreshed record for a selection made while a roster read is in flight", () => {
+    const ada = agent("ada");
+    const oldGrace = agent("grace", "Old Grace");
+    const refreshedGrace = agent("grace", "Grace");
+
+    strictEqual(
+      selectLoadedAgent([ada, refreshedGrace], oldGrace, ada.id),
+      refreshedGrace,
+    );
+  });
+
+  it("keeps a mid-flight selection missing from this stale roster", () => {
+    const ada = agent("ada");
+    const grace = agent("grace");
+
+    strictEqual(selectLoadedAgent([ada], grace, ada.id), grace);
+  });
+
+  it("falls back when the unchanged selection was removed", () => {
+    const ada = agent("ada");
+
+    strictEqual(selectLoadedAgent([ada], agent("grace"), "grace"), ada);
+  });
+
+  it("rejects an older response after a newer roster load starts", () => {
+    deepStrictEqual(
+      [shouldApplyAgentLoad(1, 2), shouldApplyAgentLoad(2, 2)],
+      [false, true],
+    );
   });
 });

--- a/app/tests/notification-nav.test.ts
+++ b/app/tests/notification-nav.test.ts
@@ -115,28 +115,10 @@ describe("activityIdForSessionKey", () => {
 });
 
 describe("resolvePendingActivitySelection", () => {
-  // The reported bug: send on agent A, close its chat, switch to agent B,
-  // OPEN a chat on B (missionPanelOpen=true), then click A's notification.
-  // The switch to A must open A's activity even though B's panel state is
-  // still hanging around in the global store. Before the fix this returned
-  // null and the click landed on the agent with no chat open.
-  it("opens the pending target on an agent switch, ignoring the previous agent's open panel", () => {
-    strictEqual(
-      resolvePendingActivitySelection({
-        pendingActivityId: "act-A",
-        agentSwitched: true,
-        selectedId: "act-B", // belongs to the agent we left
-        missionPanelOpen: true, // stale: that agent's chat was open
-      }),
-      "act-A",
-    );
-  });
-
-  it("clears selection on a plain sidebar switch with no pending target", () => {
+  it("returns null when no same-agent navigation is pending", () => {
     strictEqual(
       resolvePendingActivitySelection({
         pendingActivityId: null,
-        agentSwitched: true,
         selectedId: "act-B",
         missionPanelOpen: true,
       }),
@@ -148,7 +130,6 @@ describe("resolvePendingActivitySelection", () => {
     strictEqual(
       resolvePendingActivitySelection({
         pendingActivityId: "act-A",
-        agentSwitched: false,
         selectedId: null,
         missionPanelOpen: false,
       }),
@@ -160,7 +141,6 @@ describe("resolvePendingActivitySelection", () => {
     strictEqual(
       resolvePendingActivitySelection({
         pendingActivityId: "act-A",
-        agentSwitched: false,
         selectedId: "act-Z",
         missionPanelOpen: true,
       }),
@@ -173,7 +153,6 @@ describe("resolvePendingActivitySelection", () => {
       resolvePendingActivitySelection({
         pendingActivityId: "act-A",
         forceOpen: true,
-        agentSwitched: false,
         selectedId: "act-Z",
         missionPanelOpen: true,
       }),
@@ -186,7 +165,6 @@ describe("resolvePendingActivitySelection", () => {
       resolvePendingActivitySelection({
         pendingActivityId: "act-A",
         forceOpen: true,
-        agentSwitched: false,
         selectedId: null,
         missionPanelOpen: true,
       }),
@@ -198,7 +176,6 @@ describe("resolvePendingActivitySelection", () => {
     strictEqual(
       resolvePendingActivitySelection({
         pendingActivityId: "act-A",
-        agentSwitched: false,
         selectedId: null, // composer open: no card selected
         missionPanelOpen: true,
       }),
@@ -210,7 +187,6 @@ describe("resolvePendingActivitySelection", () => {
     strictEqual(
       resolvePendingActivitySelection({
         pendingActivityId: null,
-        agentSwitched: false,
         selectedId: null,
         missionPanelOpen: false,
       }),

--- a/app/tests/routines-tab-model.test.ts
+++ b/app/tests/routines-tab-model.test.ts
@@ -5,8 +5,16 @@ import {
   adoptDraft,
   deselectIfOn,
   latestRunByRoutine,
+  shouldSyncRoutinesPanel,
   toggleRoutine,
 } from "../src/components/tabs/routines-tab-model.ts";
+
+describe("shouldSyncRoutinesPanel", () => {
+  it("prevents an inactive routines tab from closing a mission panel", () => {
+    strictEqual(shouldSyncRoutinesPanel(false), false);
+    strictEqual(shouldSyncRoutinesPanel(true), true);
+  });
+});
 
 describe("routines tab model — adoptDraft", () => {
   it("adopts the fresh id only while still waiting on the null draft", () => {

--- a/packages/web/e2e/files.spec.ts
+++ b/packages/web/e2e/files.spec.ts
@@ -1,3 +1,5 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import { createAgent } from "./support/create-agent";
 import { expect, test } from "./support/fixtures";
 
 /**
@@ -75,6 +77,43 @@ test("grid is the default: cards, folder navigation, breadcrumbs", async ({
   // The root crumb (the agent's name) walks back up.
   await crumbs.getByRole("button").first().click();
   await expect(page.getByText("Q3 report.pdf")).toBeVisible();
+});
+
+test("never shows the previous agent's files while the next read is in flight", async ({
+  page,
+  request,
+}) => {
+  await page.goto("/");
+
+  // Create the target before arming the held reads, then return to the seeded
+  // agent and reload so the target's files query is cold when selected.
+  await createAgent(page, "Research Bot");
+  await page
+    .getByRole("button", { name: "Houston", exact: true })
+    .last()
+    .click();
+  await page.getByRole("button", { name: "Files", exact: true }).click();
+  await expect(page.getByText("Q3 report.pdf")).toBeVisible();
+  await page.reload();
+  await page.getByRole("button", { name: "Files", exact: true }).click();
+  await page.getByText("Docs", { exact: true }).click();
+  await expect(page.getByText("sales.csv")).toBeVisible();
+
+  await request.post(`${FAKE_HOST_URL}/__test__/hold-agent-reads`, {
+    data: { ms: 8_000 },
+  });
+  await page
+    .getByRole("button", { name: "Research Bot", exact: true })
+    .last()
+    .click();
+
+  await expect(page.getByText("Q3 report.pdf")).toHaveCount(0, {
+    timeout: 3_000,
+  });
+  await expect(page.getByText("sales.csv")).toHaveCount(0, { timeout: 3_000 });
+  await expect(
+    page.getByRole("navigation", { name: "Folder path" }).getByText("Docs"),
+  ).toHaveCount(0, { timeout: 3_000 });
 });
 
 test("list view keeps kind, size, and both date columns", async ({ page }) => {


### PR DESCRIPTION
## What

Users sometimes saw the previous agent's missions and files after switching agents. Three verified causes, three fixes:

- **Reused subtree**: the agent view was never remounted across agents; every hook had to hand-roll its own reset, and several didn't (files browser open folder/sort, board panel/hydration refs, mission-search caches, send loading map). The subtree is now keyed by `currentAgent.id`, and the now-unreachable per-hook reconcilers were removed. Ride-along fix: the routines tab no longer closes a mission panel it doesn't own on remount, which also repairs cross-agent mission navigation (notification/mention/palette) rendering in the inline fallback instead of the shell panel.
- **Selection race**: a stale in-flight `loadAgents` response could yank selection back to `agents[0]` after the user had already switched (the intermittent "both board and files flipped back" symptom). Roster loads are generation-guarded; a mid-flight user selection is honored even when the stale response doesn't contain it; `rename`/`reset`/`settleEmpty` invalidate pending generations so a pre-mutation snapshot can't restore a dead agent id or restart the file watcher on the old folder (#298 class).
- **Over-broad invalidation**: SessionStatus completed/error invalidated every agent's board (`["activity"]`); it now invalidates only the emitting agent's key. Mission Control still updates via `patchAllConversations` (unchanged).

## Tests

- Unit: selection guard tests that fail against the old behavior (present / absent / deleted mid-flight cases), rename-mid-flight generation invalidation, narrowed invalidation plan, routines panel ownership gate. App suite: 2322 pass.
- e2e: new Files variant of the held-read regression (previous agent's files + breadcrumb must vanish while the next read is held), alongside the existing board variant. Runs green: files, agents, board, server-events, mentions-inbox, routines specs, archived-button (50 passed).

Fixes HOU-816

🤖 Generated with [Claude Code](https://claude.com/claude-code)