### PR TITLE
fix(runtime-client): defuse WebKit's duplicate fetch-body error surface (HOU-1007)

### DIFF
--- a/packages/runtime-client/src/sse-read.test.ts
+++ b/packages/runtime-client/src/sse-read.test.ts
@@ -52,6 +52,38 @@ test("an async onEvent is awaited before the next frame is parsed (ordering)", a
   expect(order).toEqual(["start:1", "end:1", "start:2", "end:2"]);
 });
 
+test("a transport error rejects the read without leaking the reader's closed rejection", async () => {
+  // Simulates WebKit's behavior on a dropped connection: the pending read()
+  // rejects AND `reader.closed` rejects without the spec's handled flag. The
+  // read error must reach the caller exactly once — the closed rejection must
+  // never surface as an unhandled rejection.
+  const transportErr = new TypeError("Load failed");
+  let rejectClosed!: (e: unknown) => void;
+  const reader = {
+    closed: new Promise<never>((_, rej) => {
+      rejectClosed = rej;
+    }),
+    read: () => Promise.reject(transportErr),
+    releaseLock: () => {},
+    cancel: () => Promise.resolve(),
+  };
+  const body = {
+    getReader: () => reader,
+  } as unknown as ReadableStream<Uint8Array>;
+
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    await expect(readEventStream(body, () => {})).rejects.toBe(transportErr);
+    rejectClosed(transportErr);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(unhandled).toEqual([]);
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+});
+
 test("a malformed data line rejects — a garbled stream must surface", async () => {
   await expect(
     readEventStream(streamOf("data: {not json}\n\n"), () => {}),

--- a/packages/runtime-client/src/sse-read.ts
+++ b/packages/runtime-client/src/sse-read.ts
@@ -32,6 +32,13 @@ export async function readEventStream(
   options?: ReadEventStreamOptions,
 ): Promise<void> {
   const reader = body.getReader();
+  // WebKit surfaces a fetch body's transport error twice: the pending read()
+  // rejects (propagated to the caller below) AND `reader.closed` rejects
+  // without the handled flag the spec requires, so Safari/WKWebView fires a
+  // stackless "Load failed" unhandledrejection even when every caller handles
+  // the read error. Defuse the duplicate surface; the real error still reaches
+  // the caller through read().
+  reader.closed.catch(() => {});
   const decoder = new TextDecoder();
   let buf = "";
   while (true) {


### PR DESCRIPTION
## Problem

Sentry [HOUSTON-APP-4PG](https://houston-cd.sentry.io/issues/7555911741/) — `unhandled_rejection: Load failed`, 856 events / 116 users, all desktop (WKWebView) against managed-cloud. Every event's breadcrumbs show the same 5ms sequence:

```
[events] global stream error: TypeError: Load failed   ← handled, log-only, loop reconnects
[global:unhandledrejection] Load failed                ← the SAME error, stackless, toasted
```

When the network drops (sleep/wake, wifi change), the long-lived `GET /v1/events` SSE read fails. `streamGlobalEvents` catches the `read()` rejection and routes it to `onError` as designed — but WebKit surfaces a fetch body's transport error **twice**: the pending `read()` rejects, and `reader.closed` also rejects **without the handled flag the Streams spec requires**. Safari/WKWebView then fires a stackless `unhandledrejection`, which the global handler toasts at the user and reports to Sentry.

## Fix

`readEventStream` (`packages/runtime-client/src/sse-read.ts`) is the single `getReader()` site — the global events loop, the chat turn stream, and the host relay all go through it. Attach a no-op rejection handler to `reader.closed` there. The real error still reaches every caller through `read()` — nothing is silenced; only WebKit's duplicate surface is defused.

## Testing

- New regression test: a stub reader whose `closed` rejects after `read()` rejects (WebKit's behavior) — asserts the read error propagates exactly once and no `unhandledRejection` fires. Hangs/fails without the fix, green with it.
- `@houston/runtime-client` vitest: 137 passed. `@houston/host`: 1088 passed. Biome clean, full typecheck clean.

Closes HOU-1007