### PR TITLE
fix(website): hero fold fills the viewport in browsers with minimal chrome

### DIFF
--- a/knowledge-base/website-landing.md
+++ b/knowledge-base/website-landing.md
@@ -17,6 +17,14 @@ hero (black) → multiplayer (white) → parallel/multi-agent (black, full-bleed
 FAQ (white) → footer (black). `#multiplayer/#parallel/#compound/#stack` are
 one-viewport stories (`min-height: 100svh`, centered, ≥881px only).
 
+The hero fold also fills the viewport (`min-height: 100svh` on `.hero-fold`),
+whatever the browser chrome's height (Chrome's tab bar vs Arc/Zen's none):
+its natural height (496px `.win-body` floor) already ≈ fills Chrome, and any
+taller viewport's slack flows down a flex stretch chain
+(`.hero-visual → .hero-stage → .win → .win-body`, landing-hero.css) so the
+app window's bottom stays flush with the fold's dissolve — never a white gap
+before #multiplayer.
+
 `.section.is-dark` = full-bleed near-black band; content keeps the shared
 measure via `.section.is-dark > *`. Dark-ground variants exist for the
 segmented pill, `.acol`/`.share-mock` (white ring + deep black shadow), and

--- a/website/src/assets/css/landing-hero.css
+++ b/website/src/assets/css/landing-hero.css
@@ -39,6 +39,12 @@
   align-items: center;
   padding: 110px 40px 0;
   overflow: hidden;
+  /* The fold always fills the viewport, whatever the browser chrome's height
+     (Chrome's tab bar vs Arc/Zen's none). The window's natural height already
+     ≈ fills Chrome; any slack flows into the app window below (see the
+     stretch chain on .hero-visual/.hero-stage), never into a white gap. */
+  min-height: 100vh;
+  min-height: 100svh;
 }
 
 /* ── The statement — centered, white on black, system-crisp ──────────────── */
@@ -99,20 +105,43 @@
   margin-top: clamp(40px, 6vh, 64px);
   display: flex;
   justify-content: center;
+  /* Absorb whatever viewport height the fold's min-height adds beyond the
+     natural composition: the whole stretch chain (visual → stage → win →
+     win-body) grows so the window's bottom stays flush with the fold's edge,
+     dissolving into the ground exactly as at its natural height. */
+  flex: 1;
 }
 .hero-stage {
   position: relative;
   width: 100%;
   max-width: 1120px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
 }
 .hero-stage .win {
   position: relative;
   z-index: 1;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
   box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.08),
     0 2px 4px rgba(0, 0, 0, 0.4),
     0 28px 56px -22px rgba(0, 0, 0, 0.5),
     0 56px 110px -52px rgba(0, 0, 0, 0.6);
+}
+/* 496px stays the window's floor (its Chrome-fitted natural height); flex lets
+   it grow in taller viewports — the board's columns take the extra rows. */
+.hero-stage .win-body {
+  height: auto;
+  min-height: 496px;
+  flex: 1;
+}
+@media (max-width: 900px) {
+  /* Mirror the shared mock's narrow collapse: content-sized, no forced floor. */
+  .hero-stage .win-body {
+    min-height: 0;
+  }
 }
 /* Progressive dissolve across the fold's lower edge: a masked backdrop-filter
    blurs the window's bottom while a gradient in the hero's own ground color


### PR DESCRIPTION
## What

The landing hero was content-sized (496px `.win-body` floor, ~1080px total), which coincidentally matched Chrome's viewport height. In browsers with less UI chrome (Arc, Zen) the taller viewport let the next white section peek in below the fold.

## Fix

`website/src/assets/css/landing-hero.css` only:
- `.hero-fold` gets `min-height: 100svh` (with `100vh` fallback) — the fold always fills the viewport.
- Viewport slack flows down a flex stretch chain (`.hero-visual → .hero-stage → .win → .win-body`) so the app window itself extends and its bottom stays flush with the existing dissolve band. 496px stays as the window's floor; the ≤900px collapse keeps `min-height: 0`.

Also documents the behavior in `knowledge-base/website-landing.md`.

## Verification

Deterministic before/after headless-Chrome screenshots (reduced-motion, so the demo animation can't add noise):
- Chrome-like viewport (1440×775): 0 changed pixels. Mobile (390×780): byte-identical.
- Tall viewport (1440×1200): before showed a ~200px white band below the hero; after, the board extends to the fold's bottom with the dissolve intact.
- Very tall (1440×1400) and narrow-tall (800×900) degrade gracefully — reads like a maximized app window.

No Linear issue — user-reported directly in the working session (visual bug on the public landing page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)