### PR TITLE
feat(chat): guarantee the plan approval card; trim it to two choices

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -1176,11 +1176,11 @@ export function useAgentChatPanel({
 
   // ── Plan-ready override (plan_ready) ──────────────────────────────────
   // When the model finishes planning it calls `plan_ready`, arriving as a lone
-  // `{kind:"plan_ready", summary}` step (like ask_user). The card offers three
-  // ways forward; "Keep planning" dismisses it LOCALLY (composer returns, mode
-  // stays plan) by remembering THIS plan's summary — a later, different plan
+  // `{kind:"plan_ready", summary}` step (like ask_user). The card offers two
+  // ways forward; its dismiss X retires it LOCALLY (composer returns, mode
+  // stays plan) by remembering THIS plan's summary. A later, different plan
   // re-shows the card. The dismissal is per-conversation, so it resets when the
-  // open session changes.
+  // open session changes or a new turn starts.
   const [dismissedPlanReady, setDismissedPlanReady] = useState<string | null>(
     null,
   );
@@ -1194,19 +1194,28 @@ export function useAgentChatPanel({
     string | null
   >(null);
   // The user can abandon any pending interaction by its dismiss X, or an
-  // above-card offer by typing a fresh composer message. The plan-ready card
-  // marks itself abandoned when its integrated row submits. Remembering the
-  // interaction key suppresses its card uniformly, per conversation.
+  // above-card offer by typing a fresh composer message. Remembering the
+  // interaction key suppresses its card uniformly until the next turn starts.
   const [abandonedInteractionKey, setAbandonedInteractionKey] = useState<
     string | null
   >(null);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedSessionKey is the intentional change-trigger that clears the dismissals and the abandoned-interaction key when the open conversation switches, so a dismissed plan/offer or abandoned interaction never suppresses a new chat's card.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedSessionKey is the intentional change-trigger that clears all four suppression states when the open conversation switches, so a dismissed or abandoned card never suppresses a new chat's card. The effect body deliberately reads none of it.
   useEffect(() => {
     setDismissedPlanReady(null);
     setDismissedSuggestReusable(null);
     setDismissedSuggestActions(null);
     setAbandonedInteractionKey(null);
   }, [selectedSessionKey]);
+  // A running turn has already null-cleared the prior pending interaction in
+  // the engine. Reset local suppression at its start so a later offer belongs
+  // to this turn, not to an earlier plan or suggestion with a reused step id.
+  useEffect(() => {
+    if (!turnRunning) return;
+    setDismissedPlanReady(null);
+    setDismissedSuggestReusable(null);
+    setDismissedSuggestActions(null);
+    setAbandonedInteractionKey(null);
+  }, [turnRunning]);
 
   // Clear the PERSISTED pending interaction on the open activity so its card
   // never reappears on reload, then repaint the board + transcript. Used both by
@@ -1304,11 +1313,8 @@ export function useAgentChatPanel({
       askFirstDescription: t("chat:planReady.askFirstDescription"),
       autopilotTitle: t("chat:planReady.autopilotTitle"),
       autopilotDescription: t("chat:planReady.autopilotDescription"),
-      keepPlanningTitle: t("chat:planReady.keepPlanningTitle"),
-      keepPlanningDescription: t("chat:planReady.keepPlanningDescription"),
-      // Borrowed from the interaction-card family on purpose: the plan card's
-      // trailing row is the same shared component with the same wording.
-      declinePlaceholder: t("chat:interaction.declinePlaceholder"),
+      dismiss: t("chat:questionCard.dismiss"),
+      feedbackPlaceholder: t("chat:planReady.feedbackPlaceholder"),
       send: t("chat:questionCard.send"),
     }),
     [t],
@@ -1487,7 +1493,7 @@ export function useAgentChatPanel({
             onRunAutopilot={() =>
               startPlan("auto", t("chat:planReady.runAutopilotMessage"))
             }
-            onKeepPlanning={() => setDismissedPlanReady(summary)}
+            onDismiss={() => setDismissedPlanReady(summary)}
             // No abandon bookkeeping: the turn start null-clears the pending
             // interaction and deriveActiveInteraction hides the card while the
             // turn runs. Keying the conversation-wide abandoned key here would

--- a/app/src/lib/plan-ready.ts
+++ b/app/src/lib/plan-ready.ts
@@ -23,12 +23,14 @@ export type NonPlanReadyStep = Exclude<
  *  - `stepper` — anything else with at least one non-plan_ready step → the
  *                existing ChatInteractionCard, over the plan_ready-free steps
  *                (defensive: a plan_ready step never enters the stepper).
- *  - `none`    — a lone plan_ready step the user dismissed ("Keep planning"),
+ *  - `none`    — a lone plan_ready step the user dismissed,
  *                or nothing renderable → the composer returns.
  *
- * `dismissed` is the summary of the plan_ready step the user chose to keep
- * planning on: a LATER, different plan (different summary) re-shows the card.
- * Pure so the branch is unit-tested without the panel's event plumbing.
+ * `dismissed` is the summary of the plan_ready step the user dismissed. It
+ * only suppresses a matching offer during the current idle
+ * window; the panel clears it when a new turn starts, so reused step ids and
+ * summaries never suppress a later turn's card. Pure so the branch is
+ * unit-tested without the panel's event plumbing.
  */
 export type PlanReadyOverride =
   | { kind: "card"; summary: string }

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -89,8 +89,7 @@
     "askFirstDescription": "Gets things done, asks before sensitive actions.",
     "autopilotTitle": "Continue in Autopilot mode",
     "autopilotDescription": "Finishes it on its own. No questions asked.",
-    "keepPlanningTitle": "Keep planning",
-    "keepPlanningDescription": "Stay here and adjust the plan.",
+    "feedbackPlaceholder": "Give feedback on the plan...",
     "startWorkingMessage": "Go ahead with the plan.",
     "runAutopilotMessage": "Go ahead and finish it on your own."
   },

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -89,8 +89,7 @@
     "askFirstDescription": "Hace las cosas y te pregunta antes de acciones delicadas.",
     "autopilotTitle": "Continuar en modo Piloto automático",
     "autopilotDescription": "Lo termina por su cuenta. Sin preguntas.",
-    "keepPlanningTitle": "Seguir planificando",
-    "keepPlanningDescription": "Sigue aquí y ajusta el plan.",
+    "feedbackPlaceholder": "Da tu opinión sobre el plan...",
     "startWorkingMessage": "Adelante con el plan.",
     "runAutopilotMessage": "Adelante, termínalo por tu cuenta."
   },

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -89,8 +89,7 @@
     "askFirstDescription": "Faz as coisas e pergunta antes de ações sensíveis.",
     "autopilotTitle": "Continuar no modo Piloto automático",
     "autopilotDescription": "Termina sozinho. Sem perguntas.",
-    "keepPlanningTitle": "Continuar planejando",
-    "keepPlanningDescription": "Fique aqui e ajuste o plano.",
+    "feedbackPlaceholder": "Dê sua opinião sobre o plano...",
     "startWorkingMessage": "Pode seguir com o plano.",
     "runAutopilotMessage": "Pode terminar por conta própria."
   },

--- a/app/tests/plan-ready.test.ts
+++ b/app/tests/plan-ready.test.ts
@@ -27,9 +27,21 @@ describe("resolvePlanReadyOverride", () => {
     });
   });
 
-  it("returns the composer once THIS plan is dismissed (Keep planning)", () => {
+  it("returns the composer once THIS plan is dismissed", () => {
     deepStrictEqual(resolvePlanReadyOverride([planReady], planReady.summary), {
       kind: "none",
+    });
+  });
+
+  it("renders an empty-summary fallback until the panel resets on the next turn", () => {
+    const fallback: InteractionStep = {
+      kind: "plan_ready",
+      id: "p1",
+      summary: "",
+    };
+    deepStrictEqual(resolvePlanReadyOverride([fallback], null), {
+      kind: "card",
+      summary: "",
     });
   });
 

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,14 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v46 - 2026-07-29
+
+`plan-ready-card` now accepts the runtime's deterministic empty-summary
+backstop. The optional lede and its collapsed hint are absent when no summary is
+available; the title, two continuation choices, header dismiss X, and integrated
+feedback input remain fully actionable. The dismiss X locally returns the
+composer without sending, and the input now explicitly invites plan feedback.
+
 ## v45 - 2026-07-28
 
 The plan-ready card now belongs fully to the shared interaction-card family. Its

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 45
+version: 46
 
 components:
   - id: agent-avatar
@@ -461,32 +461,34 @@ components:
 
   - id: plan-ready-card
     title: Plan-ready card
-    purpose: In-chat surface shown when the agent finishes planning (plan mode) and calls plan_ready; presents a compact approval lede and three ways forward, while the complete plan remains in the transcript.
-    anatomy: [modal-shell, title, collapse-chevron, clamped-plan-lede, coworker-row, autopilot-row, keep-planning-row, trailing-free-text-row]
+    purpose: In-chat surface shown when the agent finishes planning (plan mode) and calls plan_ready; presents an optional compact approval lede and two ways forward, while the complete plan remains in the transcript.
+    anatomy: [modal-shell, title, collapse-chevron, dismiss-x, optional-clamped-plan-lede, coworker-row, autopilot-row, trailing-feedback-row]
     states: [default, collapsed, disabled]
     variants: [default]
     behavior: >-
       Rendered from a pending interaction carrying a single plan_ready step
       (summary), exactly like ask_user reaches the frontend. The complete plan
-      is the assistant's preceding transcript message; this card clamps its
-      summary to two lines as a lede above three always-visible option rows built in the composer mode
+      is the assistant's preceding transcript message; a non-empty summary
+      clamps to two lines as a lede above two always-visible option rows built in the composer mode
       menu's idiom: each a full-width row with its icon inline with the title
-      (Handshake / Rocket / ListTodo, matching the mode selector) and a
+      (Handshake / Rocket, matching the mode selector) and a
       one-line description below, rounded-xl hover background, nothing
       hover-gated. "Continue in Coworker mode" starts a normal (execute) turn
       confirming the plan; "Continue in Autopilot mode" starts an autopilot
       (auto) turn; both flip the composer Mode pill to match and send a visible
-      user message. "Keep planning" dismisses the card LOCALLY (the composer
+      user message. The header dismiss X dismisses the card LOCALLY (the composer
       returns, mode stays plan) without sending; a later, different plan
       re-shows the card. Primary emphasis comes from row order + title weight,
       not a filled button. The shared InteractionModal shell bounds the expanded
       body to 40vh with scrolling and has a visible-at-rest chevron that collapses
-      the card to its title, muted summary hint, and expand control. Its fixed
-      trailing free-text row is the only text input on screen: typing an
+      the card to its title, optional muted summary hint, and expand control. An
+      empty backstop summary renders no lede or collapsed hint, leaving the
+      title to carry the collapsed state. Its fixed
+      trailing feedback row is the only text input on screen, labeled "Give feedback on the plan...": typing an
       instruction sends a visible plan-mode user follow-up and retires the card.
       Disabled gates the rows and free-text input while the chevron remains
       available for reading the transcript.
-    a11y: title then clamped plan lede read in order; the labeled collapse and expand control is visible at rest; three labeled row buttons and the shared free-text input are keyboard-reachable; each row has a foreground-color icon inline with its title; disabled state marks the surface aria-disabled and gates every action.
+    a11y: title, then the clamped plan lede when a summary is present, read in order; the labeled collapse and expand controls plus labeled dismiss X are visible at rest; two labeled row buttons and the shared feedback input are keyboard-reachable; each row has a foreground-color icon inline with its title; disabled state marks the surface aria-disabled and gates every action.
     since: 9
 
   - id: suggest-reusable-card

--- a/knowledge-base/architecture.md
+++ b/knowledge-base/architecture.md
@@ -239,14 +239,15 @@ agree (fixing the old divergence where a reloaded stopped turn re-derived as
 `done`). Type-to-abandon (sending a fresh message while a card is up) already
 null-clears the interaction at the next turn's start — unchanged. `suggest_reusable`
 "Not now" also clears the persisted interaction (no stop marker); `plan_ready`
-"Keep planning" stays local-only.
+header dismissal stays local-only.
 
 **Plan approval.** Plan mode writes the complete plan as the normal assistant
 message, then calls `plan_ready` with a one- or two-sentence lede. The compact
 plan-ready card shares the bounded, collapsible interaction shell and offers
-Ask first, Autopilot, or Keep planning. The card never owns the complete plan,
+Ask first or Autopilot. Its header dismiss X returns the composer locally. The card never owns the complete plan,
 so long plans remain readable in the transcript. Its trailing shared free-text
-row is the only input while the card is shown; a typed instruction starts a
+row is the only input while the card is shown and explicitly invites feedback;
+a typed instruction starts a
 visible plan-mode follow-up and retires the pending card.
 
 **Reflection step (suggest_reusable).** The prompt names the agent's
@@ -290,8 +291,12 @@ accidentally end up read-only.
 (`read, ls, grep, find, ask_user`, `packages/runtime/src/session/tool-selection.ts`)
 with `edit, write, bash, run_code`, and every integration tool dropped — plus a
 system-prompt overlay (`PLAN_MODE_OVERLAY`,
-`packages/runtime/src/session/plan-overlay.ts`) that tells the model to
-investigate and propose a plan rather than act.
+`packages/runtime/src/session/mode-overlays.ts`) that tells the model to
+investigate and propose a plan rather than act. Every Plan mode turn must end
+with `ask_user` when it needs an answer or `plan_ready` when approval is ready.
+`exec-turn` also backstops a clean plan turn that produced assistant text but
+recorded no interaction by attaching and persisting an empty-summary
+`plan_ready`, so the approval card is never dependent on prompt compliance.
 
 `auto` (Autopilot) is fire-and-forget: it keeps full read/write/act power but
 **removes the two blocking tools** — `ask_user` and `request_connection` — so

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -161,6 +161,123 @@ test("the done frame omits pendingInteraction when the model asked nothing", asy
   expect(persistedInteraction(id)).toBeUndefined();
 });
 
+test("a clean plan turn with assistant output falls back to an empty plan_ready", async () => {
+  const id = "exec-plan-fallback";
+  const { events, unsub } = collect(id);
+  const conv = fakeConv((emit) =>
+    emit({ type: "text", data: "Here is the plan." }),
+  );
+
+  await execTurn(
+    conv,
+    id,
+    "turn-1",
+    "plan it",
+    { author: undefined, priorAuthors: [] },
+    { mode: "plan" },
+  );
+  unsub();
+
+  const fallback = { steps: [{ kind: "plan_ready", id: "p1", summary: "" }] };
+  const done = events.find(
+    (e): e is Extract<WireEvent, { type: "done" }> => e.type === "done",
+  );
+  expect(done?.pendingInteraction).toEqual(fallback);
+  expect(persistedInteraction(id)).toEqual(fallback);
+});
+
+test("a plan turn with a recorded question keeps that interaction instead of falling back", async () => {
+  const id = "exec-plan-question";
+  const { events, unsub } = collect(id);
+  const conv = fakeConv((emit) => {
+    emit({ type: "text", data: "I need one detail." });
+    recordQuestions([{ kind: "question", id: "q1", question: "Which date?" }]);
+  });
+
+  await execTurn(
+    conv,
+    id,
+    "turn-1",
+    "plan it",
+    { author: undefined, priorAuthors: [] },
+    { mode: "plan" },
+  );
+  unsub();
+
+  const done = events.find(
+    (e): e is Extract<WireEvent, { type: "done" }> => e.type === "done",
+  );
+  expect(done?.pendingInteraction).toEqual({
+    steps: [{ kind: "question", id: "q1", question: "Which date?" }],
+  });
+});
+
+test("a tool-only plan turn (no assistant text) never receives the plan fallback", async () => {
+  const id = "exec-plan-tool-only-no-fallback";
+  const { events, unsub } = collect(id);
+  const conv = fakeConv(() => {
+    // No text frames at all: the model only ran tools and went silent.
+  });
+
+  await execTurn(
+    conv,
+    id,
+    "turn-1",
+    "plan it",
+    { author: undefined, priorAuthors: [] },
+    { mode: "plan" },
+  );
+  unsub();
+
+  const done = events.find(
+    (e): e is Extract<WireEvent, { type: "done" }> => e.type === "done",
+  );
+  expect(done?.pendingInteraction).toBeUndefined();
+  expect(persistedInteraction(id)).toBeUndefined();
+});
+
+test("a mid-turn execute-to-plan flip still receives the plan fallback", async () => {
+  const id = "exec-flip-plan-fallback";
+  const { events, unsub } = collect(id);
+  // The Mode-pill flip lands on conv.liveMode while the turn runs; the
+  // execute-built toolset has no plan_ready, so the backstop must fire.
+  const conv = fakeConv((emit) => {
+    emit({ type: "text", data: "Here is the plan you asked for." });
+    if (conv.liveMode) conv.liveMode.current = "plan";
+  });
+
+  await execTurn(conv, id, "turn-1", "plan it from now on", {
+    author: undefined,
+    priorAuthors: [],
+  });
+  unsub();
+
+  const fallback = { steps: [{ kind: "plan_ready", id: "p1", summary: "" }] };
+  const done = events.find(
+    (e): e is Extract<WireEvent, { type: "done" }> => e.type === "done",
+  );
+  expect(done?.pendingInteraction).toEqual(fallback);
+  expect(persistedInteraction(id)).toEqual(fallback);
+});
+
+test("an execute turn never receives the plan fallback", async () => {
+  const id = "exec-execute-no-plan-fallback";
+  const { events, unsub } = collect(id);
+  const conv = fakeConv((emit) => emit({ type: "text", data: "All done." }));
+
+  await execTurn(conv, id, "turn-1", "do it", {
+    author: undefined,
+    priorAuthors: [],
+  });
+  unsub();
+
+  const done = events.find(
+    (e): e is Extract<WireEvent, { type: "done" }> => e.type === "done",
+  );
+  expect(done?.pendingInteraction).toBeUndefined();
+  expect(persistedInteraction(id)).toBeUndefined();
+});
+
 test("a provider_error turn emits no done — the pending interaction never rides an error", async () => {
   const id = "exec-pending-provider-error";
   const { events, unsub } = collect(id);
@@ -182,6 +299,31 @@ test("a provider_error turn emits no done — the pending interaction never ride
   expect(events.some((e) => e.type === "done")).toBe(false);
   expect(events.some((e) => e.type === "provider_error")).toBe(true);
   // The recorded interaction must NOT be persisted on a failed turn either.
+  expect(persistedInteraction(id)).toBeUndefined();
+});
+
+test("a provider-error plan turn never receives the plan fallback", async () => {
+  const id = "exec-plan-error-no-fallback";
+  const { events, unsub } = collect(id);
+  const conv = fakeConv((emit) => {
+    emit({ type: "text", data: "Partial plan." });
+    emit({
+      type: "provider_error",
+      data: { kind: "unknown", provider: "openai", raw_excerpt: "boom" },
+    });
+  });
+
+  await execTurn(
+    conv,
+    id,
+    "turn-1",
+    "plan it",
+    { author: undefined, priorAuthors: [] },
+    { mode: "plan" },
+  );
+  unsub();
+
+  expect(events.some((e) => e.type === "done")).toBe(false);
   expect(persistedInteraction(id)).toBeUndefined();
 });
 
@@ -364,6 +506,28 @@ test("a user stop mid-prompt persists stopped:true, drops the pending interactio
   expect(meta?.pendingInteraction).toBeUndefined();
   // The marker is cleared so it never bleeds into the next turn.
   expect((conv as { stoppedTurnId?: string }).stoppedTurnId).toBeUndefined();
+});
+
+test("a stopped plan turn never receives the plan fallback", async () => {
+  const id = "exec-plan-stop-no-fallback";
+  const { events, unsub } = collect(id);
+  const conv: Conv = fakeConv((emit) => {
+    emit({ type: "text", data: "Partial plan." });
+    (conv as { stoppedTurnId?: string }).stoppedTurnId = "turn-stop";
+  });
+
+  await execTurn(
+    conv,
+    id,
+    "turn-stop",
+    "plan it",
+    { author: undefined, priorAuthors: [] },
+    { mode: "plan" },
+  );
+  unsub();
+
+  expect(events.some((e) => e.type === "done")).toBe(false);
+  expect(persistedInteraction(id)).toBeUndefined();
 });
 
 test("a completed turn (no stop) leaves stopped absent", async () => {

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -42,7 +42,11 @@ import {
   type FileSnapshot,
   snapshotWorkspace,
 } from "./file-changes";
-import { newInteractionHolder, runWithInteractionCapture } from "./interaction";
+import {
+  newInteractionHolder,
+  planReadyFallback,
+  runWithInteractionCapture,
+} from "./interaction";
 import { switchNeedsCompaction } from "./provider-switch";
 import { renderReplayPreamble, replayCharBudget } from "./replay-transcript";
 import { createStallWatchdog } from "./stall-watchdog";
@@ -471,6 +475,20 @@ export async function execTurn(
     // assistant message so both the boundary divider and the reconnect /
     // rate-limit card survive a history reload. A provider failure lands HERE
     // (pi resolves the turn, it does not throw) with empty text, not in the catch.
+    // Models occasionally write a complete plan but omit the final tool call.
+    // A clean plan turn with visible assistant output must always leave the user
+    // an approval path. Recorded interactions still win (including ask_user).
+    // Check the LIVE mode too: a mid-turn execute→plan flip tells the model to
+    // lay out a plan while its execute-built toolset has no plan_ready at all,
+    // so the backstop is the ONLY way that flow gets its approval card.
+    const pendingInteraction =
+      !providerError &&
+      !stopped &&
+      (mode === "plan" || liveMode.current === "plan") &&
+      assistantText.trim() &&
+      !interaction.pending
+        ? planReadyFallback()
+        : interaction.pending;
     appendAssistantMessage(id, assistantText, {
       tools,
       thinking: thinkingText || undefined,
@@ -493,7 +511,7 @@ export async function execTurn(
       // stopped turn never carries it either — the user walked away mid-ask, so
       // nothing should re-render a card.
       pendingInteraction:
-        providerError || stopped ? undefined : interaction.pending,
+        providerError || stopped ? undefined : pendingInteraction,
       turnId,
     });
     // Fold this turn's token usage into the local spend ledger — the usage
@@ -522,9 +540,7 @@ export async function execTurn(
         type: "done",
         data: null,
         turnId,
-        ...(interaction.pending
-          ? { pendingInteraction: interaction.pending }
-          : {}),
+        ...(pendingInteraction ? { pendingInteraction } : {}),
       });
     }
   } catch (err) {

--- a/packages/runtime/src/session/interaction.ts
+++ b/packages/runtime/src/session/interaction.ts
@@ -219,6 +219,13 @@ export function recordPlanReady(input: { summary: string }): void {
   };
 }
 
+/** The deterministic plan-mode completion offer when the model wrote a plan
+ * without calling `plan_ready`. Kept beside `recordPlanReady` so both shapes
+ * remain deliberately identical. */
+export function planReadyFallback(): PendingInteraction {
+  return { steps: [{ kind: "plan_ready", id: "p1", summary: "" }] };
+}
+
 /**
  * Record the single suggest-reusable step for this turn (the model called
  * `suggest_reusable` on a clean finish to offer saving the work as a Skill,

--- a/packages/runtime/src/session/mode-overlays.test.ts
+++ b/packages/runtime/src/session/mode-overlays.test.ts
@@ -45,6 +45,8 @@ test("the plan overlay establishes the read-only, plan-then-approve contract", (
   const lower = PLAN_MODE_OVERLAY.toLowerCase();
   expect(lower).toContain("plan mode");
   expect(lower).toContain("must not change anything");
+  expect(lower).toContain("end every plan mode turn");
+  expect(lower).toContain("ask_user");
   // The full plan stays in the assistant message and plan_ready asks what is next.
   expect(lower).toContain("approval");
   expect(lower).toContain("plan_ready");

--- a/packages/runtime/src/session/mode-overlays.ts
+++ b/packages/runtime/src/session/mode-overlays.ts
@@ -9,10 +9,11 @@ import type { TurnMode } from "@houston/protocol";
  * user approves before anything is done.
  *
  * Voice: the target user is non-technical (see the product prompt rules), so the
- * overlay names no files, JSON, or CLIs — it speaks in plain outcomes. The one
- * tool it names is `plan_ready` (the plan-presentation tool), so the model
- * writes its finished plan in the transcript and uses the approval card only
- * to choose what happens next.
+ * overlay names no files, JSON, or CLIs — it speaks in plain outcomes. The only
+ * tools it names are `ask_user` and `plan_ready`: every plan turn must end in
+ * one of them, so the model writes its finished plan in the transcript and the
+ * approval card only chooses what happens next. (exec-turn backstops the rule:
+ * a clean plan turn that ends with neither still gets a plan_ready attached.)
  */
 export const PLAN_MODE_OVERLAY = [
   "You are in Plan mode. Here you help the user think through and design an approach before anything is actually done.",
@@ -21,7 +22,7 @@ export const PLAN_MODE_OVERLAY = [
   "- Do not create, edit, or delete anything. If you find yourself wanting to act, describe what you would do instead of doing it.",
   "- Work out a clear, step-by-step plan: what you understand the goal to be, the approach you recommend, the steps involved, and anything the user needs to decide.",
   "- Write the plan in plain, friendly language the user can follow. Keep it concrete and specific to their situation.",
-  "- When your plan is ready, write the FULL plan as your normal assistant message. Make it easy to scan, with headings and bullets when helpful. Then call plan_ready with a short 1-2 sentence summary. The user reads the full plan in the chat; the approval card only asks whether to start now, finish it independently, or keep planning together. Do not ask for approval in the message. End your turn right after the tool call.",
+  "- End EVERY Plan mode turn by calling ask_user when you need an answer, or plan_ready when the plan is ready for approval. Never end with neither. When the plan is ready, write the FULL plan as your normal assistant message, then call plan_ready with only a short 1-2 sentence summary. The user reads the full plan in the chat; the approval card only asks whether to start now, finish it independently, or keep planning together. Do not ask for approval in the message. End your turn right after the tool call.",
 ].join("\n");
 
 /**

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -24,6 +24,7 @@ import {
 } from "../session/file-changes";
 import {
   newInteractionHolder,
+  planReadyFallback,
   runWithInteractionCapture,
 } from "../session/interaction";
 import { buildToolSelection } from "../session/tool-selection";
@@ -291,6 +292,16 @@ export async function runPiTurn(
     // returns no `outcome.error` — the per-turn server's trailing terminal is a
     // no-op for the already-settled client, and reporting an error here would make
     // it send a SECOND, generic error frame on top of the typed card.
+    // Mirrors exec-turn's plan-mode backstop: a clean plan turn with visible
+    // assistant output but no recorded interaction still owes the user an
+    // approval card (models occasionally write the plan and skip plan_ready).
+    const pendingInteraction =
+      !providerError &&
+      mode === "plan" &&
+      assistantText.trim() &&
+      !interaction.pending
+        ? planReadyFallback()
+        : interaction.pending;
     appendAssistantMessageAt(conversationsDir, conversationId, assistantText, {
       tools,
       usage,
@@ -300,7 +311,7 @@ export async function runPiTurn(
       // pending question only when the turn ended without a provider error, so
       // a reload of this cloud conversation settles to `needs_you`, not a false
       // `done`. Mirrors exec-turn — only the clean turn carries it.
-      pendingInteraction: providerError ? undefined : interaction.pending,
+      pendingInteraction: providerError ? undefined : pendingInteraction,
       turnId,
     });
     if (fileChanges) emit({ type: "file_changes", data: fileChanges });
@@ -309,7 +320,7 @@ export async function runPiTurn(
     if (!providerError) clearAuthFailure(provider);
     // Carry the pending question only on a clean turn — never alongside a
     // provider error (mirrors exec-turn: only the clean `done` carries it).
-    return providerError ? {} : { pendingInteraction: interaction.pending };
+    return providerError ? {} : { pendingInteraction };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     // Classify the throw before reporting a generic outcome error: pi RAISES

--- a/packages/sdk/src/modules/turns/turn-settle.test.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.test.ts
@@ -149,6 +149,27 @@ test("a persisted pendingInteraction recovers on reload: needs_you + the interac
   expect(statuses).toEqual([["completed", undefined]]);
 });
 
+test("an empty-summary plan_ready settles to needs_you like every blocking interaction", () => {
+  const interaction: PendingInteraction = {
+    steps: [{ kind: "plan_ready", id: "p1", summary: "" }],
+  };
+  const { s } = run(
+    [
+      { role: "user", content: "plan it", ts: 1, turnId: "t-1" },
+      {
+        role: "assistant",
+        content: "Here is the plan.",
+        ts: 2,
+        turnId: "t-1",
+        pendingInteraction: interaction,
+      },
+    ],
+    "t-1",
+  );
+  expect(s.terminal).toBe("needs_you");
+  expect(s.pendingInteraction).toEqual(interaction);
+});
+
 test("a legacy pre-step pendingInteraction on a persisted reply is ignored, not adopted", () => {
   // Written by an older build: no `steps`. Adopting it would crash every
   // consumer that reads interaction.steps ("undefined is not an object").

--- a/packages/web/e2e/plan-ready.spec.ts
+++ b/packages/web/e2e/plan-ready.spec.ts
@@ -2,7 +2,7 @@ import { FAKE_HOST_URL } from "@houston/fake-host";
 import { expect, test } from "./support/fixtures";
 import { startMission } from "./support/mission";
 
-/** Plan-ready renders a compact lede above three explicit continuation choices. */
+/** Plan-ready renders a compact lede above two explicit continuation choices. */
 
 test("keeps a large plan approval compact, collapsible, and actionable", async ({
   page,
@@ -49,7 +49,7 @@ test("keeps a large plan approval compact, collapsible, and actionable", async (
   await page.getByRole("button", { name: "Expand plan approval" }).click();
   await expect(lede).toBeVisible();
   const integratedInput = page.getByPlaceholder(
-    "Or tell it what to do instead...",
+    "Give feedback on the plan...",
     { exact: true },
   );
   await expect(integratedInput).toBeVisible();
@@ -75,4 +75,92 @@ test("keeps a large plan approval compact, collapsible, and actionable", async (
   ).toBeVisible();
   await expect(page.getByText("Plan ready", { exact: true })).toBeHidden();
   await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
+});
+
+test("renders an empty-summary plan card without a lede and keeps its input actionable", async ({
+  page,
+  request,
+}) => {
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
+    data: {
+      interaction: { steps: [{ kind: "plan_ready", id: "p1", summary: "" }] },
+    },
+  });
+  await startMission(page, "prepare the launch");
+
+  await expect(page.getByText("Plan ready", { exact: true })).toBeVisible({
+    timeout: 15_000,
+  });
+  // No lede on an empty summary — scope to the card; board mission cards
+  // elsewhere on the page also use line-clamp-2.
+  const card = page
+    .locator("div.overflow-clip")
+    .filter({ hasText: "Plan ready" });
+  await expect(card).toHaveCount(1);
+  await expect(card.locator(".line-clamp-2")).toHaveCount(0);
+  // The row buttons' accessible names include their description line, so
+  // match by substring (Playwright's default), never exact.
+  await expect(
+    page.getByRole("button", { name: "Continue in Ask first mode" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Continue in Autopilot mode" }),
+  ).toBeVisible();
+  await expect(card.getByRole("button", { name: /Continue in/ })).toHaveCount(
+    2,
+  );
+
+  const input = page.getByPlaceholder("Give feedback on the plan...", {
+    exact: true,
+  });
+  await input.fill("Add a launch checklist.");
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+  await expect(
+    page
+      .locator(".is-user")
+      .filter({ hasText: "Add a launch checklist." })
+      .first(),
+  ).toBeVisible({ timeout: 15_000 });
+});
+
+test("a dismissed plan card does not suppress a plan card from the next turn", async ({
+  page,
+  request,
+}) => {
+  const interaction = {
+    steps: [{ kind: "plan_ready", id: "p1", summary: "Ready to proceed." }],
+  };
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
+    data: { interaction },
+  });
+  await startMission(page, "prepare the launch");
+  await expect(page.getByText("Plan ready", { exact: true })).toBeVisible({
+    timeout: 15_000,
+  });
+  await page
+    .locator("div.overflow-clip")
+    .filter({ hasText: "Plan ready" })
+    .getByRole("button", { name: "Dismiss", exact: true })
+    .click();
+  await expect(page.getByText("Plan ready", { exact: true })).toHaveCount(0);
+
+  const composer = page.getByPlaceholder("Send a follow-up...", {
+    exact: true,
+  });
+  await composer.fill("Revise the plan.");
+  await composer.press("Enter");
+  // Wait for this turn to settle before staging another offer. Staging while a
+  // turn remains open attaches the interaction to that earlier done frame.
+  await expect(
+    page.getByText('Roger that. You said: "Revise the plan."'),
+  ).toBeVisible();
+
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
+    data: { interaction },
+  });
+  await composer.fill("Show the revised plan.");
+  await composer.press("Enter");
+  await expect(page.getByText("Plan ready", { exact: true })).toBeVisible({
+    timeout: 15_000,
+  });
 });

--- a/ui/chat/src/chat-plan-ready-card-model.ts
+++ b/ui/chat/src/chat-plan-ready-card-model.ts
@@ -16,9 +16,8 @@ export interface ChatPlanReadyLabels {
   askFirstDescription: string;
   autopilotTitle: string;
   autopilotDescription: string;
-  keepPlanningTitle: string;
-  keepPlanningDescription: string;
-  declinePlaceholder: string;
+  dismiss: string;
+  feedbackPlaceholder: string;
   send: string;
 }
 
@@ -32,20 +31,20 @@ export const DEFAULT_PLAN_READY_LABELS: ChatPlanReadyLabels = {
   askFirstDescription: "Gets things done, asks before sensitive actions.",
   autopilotTitle: "Continue in Autopilot mode",
   autopilotDescription: "Finishes it on its own. No questions asked.",
-  keepPlanningTitle: "Keep planning",
-  keepPlanningDescription: "Stay here and adjust the plan.",
-  declinePlaceholder: "Or tell it what to do instead...",
+  dismiss: "Dismiss",
+  feedbackPlaceholder: "Give feedback on the plan...",
   send: "Send",
 };
 
 /** Shared by the card and its DOM-free tests: summaries stay a compact lede. */
 export const PLAN_READY_LEDE_CLASS_NAME = "line-clamp-2";
 
+/** Empty fallback summaries deliberately render no lede or collapsed hint. */
+export const hasPlanReadySummary = (summary: string): boolean =>
+  summary.trim().length > 0;
+
 /** Stable key for each action, so the .tsx wires the right callback + icon. */
-export type PlanReadyActionKey =
-  | "startWorking"
-  | "runAutopilot"
-  | "keepPlanning";
+export type PlanReadyActionKey = "startWorking" | "runAutopilot";
 
 /** One resolved row descriptor: its stable key, its localized title +
  *  description, and whether it is disabled. Icons are internal to the .tsx. */
@@ -57,11 +56,11 @@ export interface PlanReadyAction {
 }
 
 /**
- * The three options in render order: Continue in Ask first mode (execute) ->
- * Continue in Autopilot mode (auto) -> Keep planning (dismiss). Rendered as
+ * The two options in render order: Continue in Ask first mode (execute) ->
+ * Continue in Autopilot mode (auto). Rendered as
  * full-width mode-menu rows (icon inline with the title, description below).
  * Primary emphasis comes from row order + title weight, not a filled button.
- * `disabled` gates ALL three uniformly, so the whole card reads as inert while
+ * `disabled` gates both uniformly, so the whole card reads as inert while
  * another turn is active. Pure so the ordering/content/disabled mapping is
  * unit-tested without a DOM.
  */
@@ -80,12 +79,6 @@ export function resolvePlanReadyActions(
       key: "runAutopilot",
       title: labels.autopilotTitle,
       description: labels.autopilotDescription,
-      disabled,
-    },
-    {
-      key: "keepPlanning",
-      title: labels.keepPlanningTitle,
-      description: labels.keepPlanningDescription,
       disabled,
     },
   ];

--- a/ui/chat/src/chat-plan-ready-card.tsx
+++ b/ui/chat/src/chat-plan-ready-card.tsx
@@ -2,9 +2,10 @@
 
 import { cn } from "@houston-ai/core";
 import type { LucideIcon } from "lucide-react";
-import { Handshake, ListTodo, Rocket } from "lucide-react";
+import { Handshake, Rocket } from "lucide-react";
 import {
   type ChatPlanReadyLabels,
+  hasPlanReadySummary,
   PLAN_READY_LEDE_CLASS_NAME,
   type PlanReadyActionKey,
   resolvePlanReadyActions,
@@ -20,7 +21,7 @@ export interface ChatPlanReadyCardProps {
   disabled?: boolean;
   onStartWorking: () => void;
   onRunAutopilot: () => void;
-  onKeepPlanning: () => void;
+  onDismiss?: () => void;
   onSubmit: (text: string) => void;
   labels: ChatPlanReadyLabels;
 }
@@ -28,7 +29,6 @@ export interface ChatPlanReadyCardProps {
 const ACTION_ICONS: Record<PlanReadyActionKey, LucideIcon> = {
   startWorking: Handshake,
   runAutopilot: Rocket,
-  keepPlanning: ListTodo,
 };
 
 /** The compact next-step chooser after a plan. The complete plan stays in the
@@ -39,14 +39,14 @@ export function ChatPlanReadyCard({
   disabled = false,
   onStartWorking,
   onRunAutopilot,
-  onKeepPlanning,
+  onDismiss,
   onSubmit,
   labels,
 }: ChatPlanReadyCardProps) {
+  const hasSummary = hasPlanReadySummary(summary);
   const handlers: Record<PlanReadyActionKey, () => void> = {
     startWorking: onStartWorking,
     runAutopilot: onRunAutopilot,
-    keepPlanning: onKeepPlanning,
   };
   const actions = resolvePlanReadyActions(labels, disabled);
 
@@ -54,11 +54,13 @@ export function ChatPlanReadyCard({
     <InteractionModal
       body={
         <div className="flex flex-col gap-4">
-          <p
-            className={`${PLAN_READY_LEDE_CLASS_NAME} text-ink text-sm leading-relaxed`}
-          >
-            {summary}
-          </p>
+          {hasSummary ? (
+            <p
+              className={`${PLAN_READY_LEDE_CLASS_NAME} text-ink text-sm leading-relaxed`}
+            >
+              {summary}
+            </p>
+          ) : null}
           <div className="flex flex-col gap-2">
             {actions.map((action) => {
               const Icon = ACTION_ICONS[action.key];
@@ -89,14 +91,16 @@ export function ChatPlanReadyCard({
         </div>
       }
       collapseLabel={labels.collapse}
-      collapsedHint={summary}
+      collapsedHint={hasSummary ? summary : undefined}
       disabled={disabled}
+      dismissLabel={labels.dismiss}
       expandLabel={labels.expand}
+      onDismiss={onDismiss}
       trailing={
         <InlineTextRow
           disabled={disabled}
           onSubmit={onSubmit}
-          placeholder={labels.declinePlaceholder}
+          placeholder={labels.feedbackPlaceholder}
           sendLabel={labels.send}
         />
       }

--- a/ui/chat/tests/chat-plan-ready-card.test.ts
+++ b/ui/chat/tests/chat-plan-ready-card.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   type ChatPlanReadyLabels,
   DEFAULT_PLAN_READY_LABELS,
+  hasPlanReadySummary,
   resolvePlanReadyActions,
 } from "../src/chat-plan-ready-card-model.ts";
 
@@ -14,18 +15,17 @@ const LABELS: ChatPlanReadyLabels = {
   askFirstDescription: "Gets things done, asks before sensitive actions.",
   autopilotTitle: "Continue in Autopilot mode",
   autopilotDescription: "Finishes it on its own. No questions asked.",
-  keepPlanningTitle: "Keep planning",
-  keepPlanningDescription: "Stay here and adjust the plan.",
-  declinePlaceholder: "Or tell it what to do instead...",
+  dismiss: "Dismiss",
+  feedbackPlaceholder: "Give feedback on the plan...",
   send: "Send",
 };
 
 describe("resolvePlanReadyActions", () => {
-  it("resolves the three actions in render order", () => {
+  it("resolves the two actions in render order", () => {
     const actions = resolvePlanReadyActions(LABELS, false);
     assert.deepEqual(
       actions.map((a) => a.key),
-      ["startWorking", "runAutopilot", "keepPlanning"],
+      ["startWorking", "runAutopilot"],
     );
   });
 
@@ -42,12 +42,6 @@ describe("resolvePlanReadyActions", () => {
         key: "runAutopilot",
         title: "Continue in Autopilot mode",
         description: "Finishes it on its own. No questions asked.",
-        disabled: false,
-      },
-      {
-        key: "keepPlanning",
-        title: "Keep planning",
-        description: "Stay here and adjust the plan.",
         disabled: false,
       },
     ]);
@@ -76,10 +70,9 @@ describe("DEFAULT_PLAN_READY_LABELS", () => {
       DEFAULT_PLAN_READY_LABELS.autopilotTitle,
       "Continue in Autopilot mode",
     );
-    assert.equal(DEFAULT_PLAN_READY_LABELS.keepPlanningTitle, "Keep planning");
     assert.equal(
-      DEFAULT_PLAN_READY_LABELS.declinePlaceholder,
-      "Or tell it what to do instead...",
+      DEFAULT_PLAN_READY_LABELS.feedbackPlaceholder,
+      "Give feedback on the plan...",
     );
     assert.equal(DEFAULT_PLAN_READY_LABELS.send, "Send");
     for (const value of Object.values(DEFAULT_PLAN_READY_LABELS)) {
@@ -96,8 +89,13 @@ describe("plan-ready lede contract", () => {
       [
         { key: "startWorking", title: "Continue in Ask first mode" },
         { key: "runAutopilot", title: "Continue in Autopilot mode" },
-        { key: "keepPlanning", title: "Keep planning" },
       ],
     );
+  });
+
+  it("omits the lede and collapsed hint for an empty fallback summary", () => {
+    assert.equal(hasPlanReadySummary(""), false);
+    assert.equal(hasPlanReadySummary("  \n\t"), false);
+    assert.equal(hasPlanReadySummary("Ready to start."), true);
   });
 });


### PR DESCRIPTION
## What

Fixes the reported plan-mode dead end (a written markdown plan with no approval card, leaving the user with no way to act) and applies the follow-up card feedback:

**The card can no longer fail to appear**
- Runtime backstop: a clean plan-mode turn with visible assistant output but no recorded interaction gets a lone empty-summary `plan_ready` attached to the done frame and persisted. Covers both backends via `exec-turn`, the mid-turn execute→plan flip (where the session's execute-built toolset cannot even call `plan_ready`), and the stateless cloud per-turn runtime.
- The plan-mode overlay now hard-requires every turn to end in `ask_user` or `plan_ready` — never neither; the backstop catches violations.
- Suppression-state fix: dismissed plan/suggestion offers and the abandoned-interaction key now reset when a new turn starts. Every `plan_ready` step shares the id `p1`, so a single dismissal used to permanently suppress every later plan card in the conversation — the likely cause of the report.
- A backstop card (empty summary) renders title + actions + input with no lede.

**Card trim (user feedback)**
- The redundant "Keep planning" row is gone — the integrated input IS keep-planning, now labeled "Give feedback on the plan..." (new `planReady.feedbackPlaceholder`, en/es/pt; the connect/sign-in cards keep their own wording).
- Its dismissal role moved to the family-standard header X (summary-keyed, composer returns).

## Verification

- Runtime (95 files, incl. new backstop tests: fallback fires / recorded interaction wins / execute mode / provider error / stopped / tool-only turn / mid-turn flip), SDK (40), app (2,381), ui/chat (313) — green
- `pnpm -r typecheck`, `pnpm check`, `pnpm check:parity` (inventory v46), `pnpm check-locales`, `cargo` untouched
- Playwright on isolated ports: plan-ready (3, incl. empty-summary card and dismissal-does-not-leak) + interaction + suggest-actions = 29/29
- Adversarial review pass applied (caught the mid-turn-flip gap, the cloud-path gap, and an inventory `since` regression)

Fixes HOU-974
Fixes HOU-766

🤖 Generated with [Claude Code](https://claude.com/claude-code)