### PR TITLE
perf(shell): perceived zero-second navigation between screens

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -30,6 +30,7 @@ import { useOnboardingPending } from "./hooks/use-onboarding-pending";
 import { useOnboardingSegment } from "./hooks/use-onboarding-segment";
 import { useProviderCatalog } from "./hooks/use-provider-catalog";
 import { useReadCursorTracker } from "./hooks/use-read-cursors";
+import { useScreenPrefetch } from "./hooks/use-screen-prefetch";
 import { SessionUnavailableError, useSession } from "./hooks/use-session";
 import { useSessionEvents } from "./hooks/use-session-events";
 import { analytics } from "./lib/analytics";
@@ -76,6 +77,7 @@ export default function App() {
   // Fetch the host's pi-ai catalog once and hydrate the PROVIDERS cache app-wide,
   // so every provider/model surface renders the real runnable set from load.
   useProviderCatalog();
+  useScreenPrefetch();
   // Turn an `houston://store/install` deep link (desktop) or `?install=<slug>`
   // web param into a seeded import wizard once the shell is live.
   useStoreInstallDeepLink();

--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -1,5 +1,5 @@
 import { AIBoard, type MessageMention } from "@houston-ai/board";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useOpenAgentHref } from "../../hooks/use-open-agent-file";
 import { modelAcceptsImages } from "../../lib/providers";
@@ -7,6 +7,7 @@ import { useUIStore } from "../../stores/ui";
 import { useAttachmentRejectionDialog } from "../attachment-rejection-dialog";
 import { buildMissionBoardColumns } from "../mission-board-columns";
 import { AgentPanelAvatar } from "../shell/agent-panel-avatar";
+import { useIsActiveView } from "../shell/keep-alive-views";
 import { useShellDetailPanel } from "../shell/use-shell-detail-panel";
 import { useAgentChatPanel } from "../use-agent-chat-panel";
 import { useQueuedMessageLabels } from "../use-queued-message-labels";
@@ -27,6 +28,7 @@ import { useBoardSendQueue } from "./use-board-send-queue";
 export function MissionBoard({ source }: { source: BoardSource }) {
   const { t } = useTranslation(["dashboard", "board"]);
   const { panelContainer, setPanelOpen } = useShellDetailPanel();
+  const isActive = useIsActiveView();
   const missionPanelOpen = useUIStore((s) => s.missionPanelOpen);
   const addToast = useUIStore((s) => s.addToast);
   const queuedLabels = useQueuedMessageLabels();
@@ -53,6 +55,12 @@ export function MissionBoard({ source }: { source: BoardSource }) {
     () => source.setSelectedId(null),
     [source.setSelectedId],
   );
+  useEffect(() => {
+    if (!isActive) {
+      source.setSelectedId(null);
+      setPanelOpen(false);
+    }
+  }, [isActive, source.setSelectedId, setPanelOpen]);
   const { columns, selectionProps } = useBoardSelectionUI({
     baseColumns,
     allItems: source.allItems,

--- a/app/src/components/integrations/integrations-gate-state.ts
+++ b/app/src/components/integrations/integrations-gate-state.ts
@@ -1,0 +1,11 @@
+/** Per-identity bookkeeping for the integration session-resync backstop. */
+export const resyncedTokens = new Set<string>();
+export const readyTokens = new Set<string>();
+export const resyncingTokens = new Set<string>();
+
+/** Identity swaps must not retain JWT-keyed resync state. */
+export function resetIntegrationGateForIdentityChange(): void {
+  resyncedTokens.clear();
+  readyTokens.clear();
+  resyncingTokens.clear();
+}

--- a/app/src/components/integrations/use-integrations-gate.ts
+++ b/app/src/components/integrations/use-integrations-gate.ts
@@ -9,6 +9,11 @@ import { showErrorToast } from "../../lib/error-toast";
 import { isIdentityConfigured } from "../../lib/identity";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriIntegrations } from "../../lib/tauri";
+import {
+  readyTokens,
+  resyncedTokens,
+  resyncingTokens,
+} from "./integrations-gate-state";
 import { INTEGRATION_PROVIDER } from "./model";
 
 /**
@@ -33,6 +38,9 @@ export type IntegrationsGate =
       dismissReconnect: () => Promise<void>;
     };
 
+// Both Integrations surfaces use this hook. A session push belongs to the
+// session, not to either component mount, so revisiting either surface cannot
+// manufacture a loading gate.
 /**
  * The status / session-resync / sign-in / reconnect-notice boot logic, extracted
  * from the legacy tab with identical behavior:
@@ -60,21 +68,47 @@ export function useIntegrationsGate(): IntegrationsGate {
 
   const [signingIn, setSigningIn] = useState(false);
   const token = session?.idToken ?? null;
-  const [resynced, setResynced] = useState(false);
+  const [, setResyncVersion] = useState(0);
+  // A provider that was ready then falls back to `signin` needs a fresh push,
+  // even before the bookkeeping effect removes its old success latch.
+  const resynced =
+    !!token && resyncedTokens.has(token) && !readyTokens.has(token);
 
   useEffect(() => {
-    if (!token || ready || resynced || status.isLoading || !composio) return;
+    for (const tokens of [resyncedTokens, readyTokens, resyncingTokens]) {
+      for (const value of tokens) if (value !== token) tokens.delete(value);
+    }
+    if (!token) return;
+    if (ready) readyTokens.add(token);
+    if (!ready && readyTokens.delete(token)) resyncedTokens.delete(token);
+  }, [token, ready]);
+
+  useEffect(() => {
+    if (
+      !token ||
+      ready ||
+      resynced ||
+      status.isLoading ||
+      !composio ||
+      resyncingTokens.has(token)
+    )
+      return;
     let stale = false;
+    resyncingTokens.add(token);
     tauriIntegrations
       .setSession(token)
       .then(() =>
         qc.invalidateQueries({ queryKey: queryKeys.integrationStatus() }),
       )
+      .then(() => {
+        resyncedTokens.add(token);
+      })
       .catch(() => {
         // Surfaced by call(); the sign-in card below stays actionable.
       })
       .finally(() => {
-        if (!stale) setResynced(true);
+        resyncingTokens.delete(token);
+        if (!stale) setResyncVersion((version) => version + 1);
       });
     return () => {
       stale = true;

--- a/app/src/components/provider-browser/use-provider-browser-data.ts
+++ b/app/src/components/provider-browser/use-provider-browser-data.ts
@@ -36,7 +36,7 @@ export interface ProviderBrowserData {
  * hub catalog and model picker use.
  */
 export function useProviderBrowserData(): ProviderBrowserData {
-  const connections = useProviderConnections();
+  const connections = useProviderConnections({ alwaysActive: true });
   const { catalog } = useHubCatalog();
   const { capabilities } = useCapabilities();
   const { updatedAt } = useProviderCatalog();

--- a/app/src/components/settings/sections/connect-phone-url.ts
+++ b/app/src/components/settings/sections/connect-phone-url.ts
@@ -1,0 +1,14 @@
+interface TunnelEndpoint {
+  connected: boolean;
+  publicHost: string | null;
+}
+
+/** Builds the pairing target only for an active tunnel with a fresh code. */
+export function pairingUrl(
+  info: TunnelEndpoint | null,
+  pairingCode: string | null,
+): string | null {
+  if (!pairingCode || !info?.connected || !info.publicHost) return null;
+  const protocol = info.publicHost.startsWith("localhost") ? "http" : "https";
+  return `${protocol}://${info.publicHost}/pair/${pairingCode}`;
+}

--- a/app/src/components/settings/sections/connect-phone.tsx
+++ b/app/src/components/settings/sections/connect-phone.tsx
@@ -5,8 +5,10 @@ import { Trans, useTranslation } from "react-i18next";
 import { analytics } from "../../../lib/analytics";
 import { logger } from "../../../lib/logger";
 import { tauriTunnel } from "../../../lib/tauri";
+import { isActiveTopLevelView } from "../../../lib/top-level-views";
 import { useUIStore } from "../../../stores/ui";
 import { canResetPhoneAccess } from "./connect-phone-state";
+import { pairingUrl } from "./connect-phone-url";
 
 interface TunnelInfo {
   connected: boolean;
@@ -18,6 +20,9 @@ const STATUS_POLL_MS = 2_000;
 export function ConnectPhoneSection() {
   const { t } = useTranslation(["settings", "common"]);
   const addToast = useUIStore((s) => s.addToast);
+  const active = useUIStore((s) =>
+    isActiveTopLevelView(s.viewMode, "settings"),
+  );
 
   const [info, setInfo] = useState<TunnelInfo | null>(null);
   const [pairingCode, setPairingCode] = useState<string | null>(null);
@@ -57,6 +62,7 @@ export function ConnectPhoneSection() {
   }, [t]);
 
   useEffect(() => {
+    if (!active) return;
     mountedRef.current = true;
     void loadStatus();
     const id = setInterval(() => {
@@ -66,7 +72,7 @@ export function ConnectPhoneSection() {
       mountedRef.current = false;
       clearInterval(id);
     };
-  }, [loadStatus]);
+  }, [active, loadStatus]);
 
   useEffect(() => {
     if (info?.connected) {
@@ -76,10 +82,7 @@ export function ConnectPhoneSection() {
     }
   }, [info?.connected, mintCode]);
 
-  const qrUrl =
-    pairingCode && info?.connected && info.publicHost
-      ? `${info.publicHost.startsWith("localhost") ? "http" : "https"}://${info.publicHost}/pair/${pairingCode}`
-      : null;
+  const qrUrl = pairingUrl(info, pairingCode);
 
   const canReset = canResetPhoneAccess(info);
 

--- a/app/src/components/settings/sections/notifications.tsx
+++ b/app/src/components/settings/sections/notifications.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../../lib/notification-settings";
 import { osIsTauri, osOpenNotificationSettings } from "../../../lib/os-bridge";
 import { currentPlatformOs } from "../../../lib/platform";
+import { isActiveTopLevelView } from "../../../lib/top-level-views";
 import { useUIStore } from "../../../stores/ui";
 import { SettingsControlRow } from "../settings-row";
 
@@ -40,6 +41,9 @@ const canOpenSettings =
 export function NotificationsSection() {
   const { t } = useTranslation(["settings", "common"]);
   const addToast = useUIStore((s) => s.addToast);
+  const active = useUIStore((s) =>
+    isActiveTopLevelView(s.viewMode, "settings"),
+  );
   const [inAppEnabled, setInAppEnabled] = useState(true);
   const [osGranted, setOsGranted] = useState(true);
 
@@ -52,10 +56,11 @@ export function NotificationsSection() {
   }, []);
 
   useEffect(() => {
+    if (!active) return;
     refreshOsGranted();
     window.addEventListener("focus", refreshOsGranted);
     return () => window.removeEventListener("focus", refreshOsGranted);
-  }, [refreshOsGranted]);
+  }, [active, refreshOsGranted]);
 
   const handleToggle = async (next: boolean) => {
     setInAppEnabled(next);

--- a/app/src/components/shell/keep-alive-views.tsx
+++ b/app/src/components/shell/keep-alive-views.tsx
@@ -1,0 +1,93 @@
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+const IsActiveViewContext = createContext(true);
+
+/** Whether the surrounding kept-alive top-level view is currently visible. */
+export function useIsActiveView(): boolean {
+  return useContext(IsActiveViewContext);
+}
+
+export interface KeepAliveView {
+  id: string;
+  enabled: boolean;
+  content: ReactNode;
+}
+
+/** Lazily mounts a view once, then preserves its local state while hidden. */
+export function KeepAliveViews({
+  activeId,
+  views,
+}: {
+  activeId: string;
+  views: KeepAliveView[];
+}) {
+  const [visited, setVisited] = useState<Set<string>>(
+    () =>
+      new Set(
+        views
+          .filter((view) => view.enabled && view.id === activeId)
+          .map((view) => view.id),
+      ),
+  );
+  const enabled = new Set(
+    views.filter((view) => view.enabled).map((view) => view.id),
+  );
+
+  const visible = new Set(visited);
+  if (enabled.has(activeId)) visible.add(activeId);
+
+  const previousActiveId = useRef(activeId);
+  useLayoutEffect(() => {
+    if (previousActiveId.current !== activeId) {
+      // Radix dialogs portal to document.body, outside their kept-alive screen,
+      // so hiding the screen would leave an open modal floating over the next
+      // view with the page inert beneath it. Escape is Radix's public close
+      // contract — but a synthetic Escape also dismisses pills, popovers, and
+      // inline edits, so only fire it when we are actually leaving a kept-alive
+      // screen while a modal overlay holds the page (Radix marks that state by
+      // disabling pointer events on <body>).
+      const leftKeptAliveScreen = enabled.has(previousActiveId.current);
+      const modalOpen = document.body.style.pointerEvents === "none";
+      if (leftKeptAliveScreen && modalOpen) {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+        );
+      }
+      previousActiveId.current = activeId;
+    }
+    setVisited((current) => {
+      const next = new Set([...current].filter((id) => enabled.has(id)));
+      if (enabled.has(activeId)) next.add(activeId);
+      if (
+        next.size === current.size &&
+        [...next].every((id) => current.has(id))
+      )
+        return current;
+      return next;
+    });
+  }, [activeId, enabled]);
+
+  return views.map(
+    (view) =>
+      view.enabled &&
+      visible.has(view.id) && (
+        <div
+          key={view.id}
+          className={
+            view.id === activeId ? "flex min-h-0 flex-1 flex-col" : "hidden"
+          }
+        >
+          <IsActiveViewContext.Provider value={view.id === activeId}>
+            {view.content}
+          </IsActiveViewContext.Provider>
+        </div>
+      ),
+  );
+}

--- a/app/src/components/shell/top-level-screen-views.tsx
+++ b/app/src/components/shell/top-level-screen-views.tsx
@@ -1,0 +1,43 @@
+import {
+  AI_HUB_VIEW_ID,
+  DASHBOARD_VIEW_ID,
+  SETTINGS_VIEW_ID,
+} from "../../lib/top-level-views";
+import { AiHubView } from "../ai-hub/ai-hub-view";
+import { Dashboard } from "../dashboard";
+import { INTEGRATIONS_VIEW_ID, IntegrationsView } from "../integrations-view";
+import { ORGANIZATION_VIEW_ID, OrganizationView } from "../organization";
+import { PERMISSIONS_VIEW_ID, PermissionsView } from "../permissions";
+import { SettingsView } from "../settings/settings-view";
+import { STORE_VIEW_ID, StoreView } from "../store-view";
+import { USAGE_VIEW_ID, UsageView } from "../usage-view";
+import type { KeepAliveView } from "./keep-alive-views";
+
+/** The cached top-level screens, separated from the shell's agent-tab chrome. */
+export function topLevelScreenViews(gates: {
+  showAiModels: boolean;
+  showOrganization: boolean;
+}): KeepAliveView[] {
+  return [
+    { id: DASHBOARD_VIEW_ID, enabled: true, content: <Dashboard /> },
+    { id: AI_HUB_VIEW_ID, enabled: gates.showAiModels, content: <AiHubView /> },
+    { id: USAGE_VIEW_ID, enabled: gates.showAiModels, content: <UsageView /> },
+    { id: SETTINGS_VIEW_ID, enabled: true, content: <SettingsView /> },
+    {
+      id: INTEGRATIONS_VIEW_ID,
+      enabled: true,
+      content: <IntegrationsView />,
+    },
+    { id: STORE_VIEW_ID, enabled: true, content: <StoreView /> },
+    {
+      id: PERMISSIONS_VIEW_ID,
+      enabled: gates.showOrganization,
+      content: <PermissionsView />,
+    },
+    {
+      id: ORGANIZATION_VIEW_ID,
+      enabled: gates.showOrganization,
+      content: <OrganizationView />,
+    },
+  ];
+}

--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -40,32 +40,25 @@ import { useUIStore } from "../../stores/ui";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { AgentPersonScopeProvider } from "../agent-person-scope-context";
 import { AgentPersonScopeMenu } from "../agent-person-scope-menu";
-import { AiHubView } from "../ai-hub/ai-hub-view";
 import { CommandPalette } from "../command-palette";
-import { Dashboard } from "../dashboard";
-import { INTEGRATIONS_VIEW_ID, IntegrationsView } from "../integrations-view";
+import { INTEGRATIONS_VIEW_ID } from "../integrations-view";
 import { MissionSearchInput } from "../mission-search-input";
-import {
-  canSeeOrganization,
-  ORGANIZATION_VIEW_ID,
-  OrganizationView,
-} from "../organization";
-import { PERMISSIONS_VIEW_ID, PermissionsView } from "../permissions";
+import { canSeeOrganization, ORGANIZATION_VIEW_ID } from "../organization";
+import { PERMISSIONS_VIEW_ID } from "../permissions";
 import { ExportAgentWizard } from "../portable/export-wizard";
 import { ImportAgentWizard } from "../portable/import-wizard";
-import { SettingsView } from "../settings/settings-view";
 import { ShortcutCheatsheet } from "../shortcut-cheatsheet";
-import { STORE_VIEW_ID, StoreView } from "../store-view";
-import { USAGE_VIEW_ID, UsageView } from "../usage-view";
 import { AgentWarmingDialog } from "./agent-warming-dialog";
 import { ArchivedToggleButton } from "./archived-toggle-button";
 import { CreateAgentDialog } from "./create-workspace-dialog";
 import { DetailPanelProvider } from "./detail-panel-context";
 import { HoustonLogo } from "./experience-card";
 import { AgentRenderer } from "./experience-renderer";
+import { KeepAliveViews } from "./keep-alive-views";
 import { NotificationsBell } from "./notifications-bell";
 import { Sidebar } from "./sidebar";
 import { TeamStatusBanner } from "./team-status-banner";
+import { topLevelScreenViews } from "./top-level-screen-views";
 import { UiTour, type UiTourStep } from "./ui-tour";
 
 interface WorkspaceShellProps {
@@ -238,208 +231,205 @@ export function WorkspaceShell({
               >
                 <TeamStatusBanner />
                 <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-                  {viewMode === "dashboard" ? (
-                    <Dashboard />
-                  ) : viewMode === "ai-hub" && showAiModels ? (
-                    <AiHubView />
-                  ) : viewMode === USAGE_VIEW_ID && showAiModels ? (
-                    <UsageView />
-                  ) : viewMode === "settings" ? (
-                    <SettingsView />
-                  ) : viewMode === INTEGRATIONS_VIEW_ID ? (
-                    <IntegrationsView />
-                  ) : viewMode === STORE_VIEW_ID ? (
-                    <StoreView />
-                  ) : viewMode === PERMISSIONS_VIEW_ID && showOrganization ? (
-                    <PermissionsView />
-                  ) : viewMode === ORGANIZATION_VIEW_ID && showOrganization ? (
-                    <OrganizationView />
-                  ) : currentAgent && agentDef && isAgentView ? (
-                    <AgentPersonScopeProvider
-                      key={currentAgent.id}
-                      path={currentAgent.folderPath}
-                    >
-                      <div data-tour-target="tabs">
-                        <TabBar
-                          title={currentAgent.name}
-                          tabs={visibleAgentTabs(
-                            capabilities,
-                            currentAgent,
-                          ).map((tab) => ({
-                            id: tab.id,
-                            label: t(`agents:tabLabels.${tab.id}`, {
-                              defaultValue: tab.label,
-                            }),
-                            badge:
-                              tab.badge === "activity"
-                                ? needsYouCount
-                                : undefined,
-                          }))}
-                          activeTab={viewMode}
-                          onTabChange={setViewMode}
-                          actions={
-                            <div className="flex min-w-0 flex-1 items-center justify-end gap-2">
-                              {currentAgent && (
-                                <MissionSearchInput
-                                  value={agentMissionSearchQuery}
-                                  isSearchingText={agentMissionSearchLoading}
-                                  labels={{
-                                    placeholder: t("board:search.placeholder"),
-                                    placeholderShort: t(
-                                      "board:search.placeholderShort",
-                                    ),
-                                    clear: t("board:search.clear"),
-                                    searchingText: t(
-                                      "board:search.searchingText",
-                                    ),
-                                  }}
-                                  className="relative min-w-0 flex-1 max-w-[320px]"
-                                  onChange={(value) => {
-                                    setAgentMissionSearchQuery(
-                                      currentAgent.folderPath,
-                                      value,
-                                    );
-                                    if (viewMode !== "activity")
-                                      setViewMode("activity");
-                                  }}
-                                />
-                              )}
-                              <div className="flex shrink-0 items-center gap-2">
-                                <AgentPersonScopeMenu
-                                  agent={currentAgent}
-                                  collapsed={missionPanelOpen}
-                                />
-                                <NotificationsBell
-                                  collapsed={missionPanelOpen}
-                                />
-                                {viewMode === "activity" && (
-                                  <ArchivedToggleButton
-                                    archived={agentBoardMode === "archived"}
-                                    collapsed={missionPanelOpen}
-                                    label={t("dashboard:archived.button")}
-                                    onToggle={() =>
-                                      setAgentBoardMode(
-                                        agentBoardMode === "archived"
-                                          ? "active"
-                                          : "archived",
-                                      )
-                                    }
+                  <KeepAliveViews
+                    key={currentWorkspace?.id ?? "no-workspace"}
+                    activeId={viewMode}
+                    views={topLevelScreenViews({
+                      showAiModels,
+                      showOrganization,
+                    })}
+                  />
+                  {isAgentView &&
+                    (currentAgent && agentDef ? (
+                      <AgentPersonScopeProvider
+                        key={currentAgent.id}
+                        path={currentAgent.folderPath}
+                      >
+                        <div data-tour-target="tabs">
+                          <TabBar
+                            title={currentAgent.name}
+                            tabs={visibleAgentTabs(
+                              capabilities,
+                              currentAgent,
+                            ).map((tab) => ({
+                              id: tab.id,
+                              label: t(`agents:tabLabels.${tab.id}`, {
+                                defaultValue: tab.label,
+                              }),
+                              badge:
+                                tab.badge === "activity"
+                                  ? needsYouCount
+                                  : undefined,
+                            }))}
+                            activeTab={viewMode}
+                            onTabChange={setViewMode}
+                            actions={
+                              <div className="flex min-w-0 flex-1 items-center justify-end gap-2">
+                                {currentAgent && (
+                                  <MissionSearchInput
+                                    value={agentMissionSearchQuery}
+                                    isSearchingText={agentMissionSearchLoading}
+                                    labels={{
+                                      placeholder: t(
+                                        "board:search.placeholder",
+                                      ),
+                                      placeholderShort: t(
+                                        "board:search.placeholderShort",
+                                      ),
+                                      clear: t("board:search.clear"),
+                                      searchingText: t(
+                                        "board:search.searchingText",
+                                      ),
+                                    }}
+                                    className="relative min-w-0 flex-1 max-w-[320px]"
+                                    onChange={(value) => {
+                                      setAgentMissionSearchQuery(
+                                        currentAgent.folderPath,
+                                        value,
+                                      );
+                                      if (viewMode !== "activity")
+                                        setViewMode("activity");
+                                    }}
                                   />
                                 )}
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <Button
-                                      data-tour-target="appTour"
-                                      variant="ghost"
-                                      size={
-                                        missionPanelOpen ? "icon" : "default"
+                                <div className="flex shrink-0 items-center gap-2">
+                                  <AgentPersonScopeMenu
+                                    agent={currentAgent}
+                                    collapsed={missionPanelOpen}
+                                  />
+                                  <NotificationsBell
+                                    collapsed={missionPanelOpen}
+                                  />
+                                  {viewMode === "activity" && (
+                                    <ArchivedToggleButton
+                                      archived={agentBoardMode === "archived"}
+                                      collapsed={missionPanelOpen}
+                                      label={t("dashboard:archived.button")}
+                                      onToggle={() =>
+                                        setAgentBoardMode(
+                                          agentBoardMode === "archived"
+                                            ? "active"
+                                            : "archived",
+                                        )
                                       }
-                                      className="rounded-full"
-                                      onClick={() => setUiTourActive(true)}
-                                      aria-label={t(
-                                        "shell:tabActions.startTour",
-                                      )}
-                                    >
-                                      <Compass className="size-4" />
-                                      {!missionPanelOpen &&
-                                        t("shell:tabActions.startTour")}
-                                    </Button>
-                                  </TooltipTrigger>
-                                  {missionPanelOpen && (
-                                    <TooltipContent side="bottom">
-                                      {t("shell:tabActions.startTour")}
-                                    </TooltipContent>
+                                    />
                                   )}
-                                </Tooltip>
-                                {onStartMission && (
                                   <Tooltip>
                                     <TooltipTrigger asChild>
                                       <Button
-                                        data-tour-target="newMission"
+                                        data-tour-target="appTour"
+                                        variant="ghost"
                                         size={
                                           missionPanelOpen ? "icon" : "default"
                                         }
-                                        className={cn(
-                                          missionPanelOpen && "rounded-full",
-                                        )}
-                                        onClick={() => {
-                                          setViewMode("activity");
-                                          setAgentBoardMode("active");
-                                          setTimeout(() => {
-                                            useUIStore
-                                              .getState()
-                                              .onStartMission?.();
-                                          }, 50);
-                                        }}
+                                        className="rounded-full"
+                                        onClick={() => setUiTourActive(true)}
                                         aria-label={t(
-                                          "shell:tabActions.newMission",
+                                          "shell:tabActions.startTour",
                                         )}
                                       >
-                                        <HoustonLogo size={16} />
+                                        <Compass className="size-4" />
                                         {!missionPanelOpen &&
-                                          t("shell:tabActions.newMission")}
+                                          t("shell:tabActions.startTour")}
                                       </Button>
                                     </TooltipTrigger>
-                                    <TooltipContent side="bottom">
-                                      {missionPanelOpen
-                                        ? t("shell:tabActions.newMission")
-                                        : shortcutLabel("newMission")}
-                                    </TooltipContent>
+                                    {missionPanelOpen && (
+                                      <TooltipContent side="bottom">
+                                        {t("shell:tabActions.startTour")}
+                                      </TooltipContent>
+                                    )}
                                   </Tooltip>
-                                )}
-                                {boardActions.map((action) => (
-                                  <Button
-                                    key={action.id}
-                                    variant="secondary"
-                                    onClick={() => {
-                                      setViewMode("activity");
-                                      setAgentBoardMode("active");
-                                      setTimeout(() => action.onClick(), 50);
-                                    }}
-                                  >
-                                    {action.label}
-                                  </Button>
-                                ))}
+                                  {onStartMission && (
+                                    <Tooltip>
+                                      <TooltipTrigger asChild>
+                                        <Button
+                                          data-tour-target="newMission"
+                                          size={
+                                            missionPanelOpen
+                                              ? "icon"
+                                              : "default"
+                                          }
+                                          className={cn(
+                                            missionPanelOpen && "rounded-full",
+                                          )}
+                                          onClick={() => {
+                                            setViewMode("activity");
+                                            setAgentBoardMode("active");
+                                            setTimeout(() => {
+                                              useUIStore
+                                                .getState()
+                                                .onStartMission?.();
+                                            }, 50);
+                                          }}
+                                          aria-label={t(
+                                            "shell:tabActions.newMission",
+                                          )}
+                                        >
+                                          <HoustonLogo size={16} />
+                                          {!missionPanelOpen &&
+                                            t("shell:tabActions.newMission")}
+                                        </Button>
+                                      </TooltipTrigger>
+                                      <TooltipContent side="bottom">
+                                        {missionPanelOpen
+                                          ? t("shell:tabActions.newMission")
+                                          : shortcutLabel("newMission")}
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  )}
+                                  {boardActions.map((action) => (
+                                    <Button
+                                      key={action.id}
+                                      variant="secondary"
+                                      onClick={() => {
+                                        setViewMode("activity");
+                                        setAgentBoardMode("active");
+                                        setTimeout(() => action.onClick(), 50);
+                                      }}
+                                    >
+                                      {action.label}
+                                    </Button>
+                                  ))}
+                                </div>
                               </div>
-                            </div>
-                          }
-                        />
+                            }
+                          />
+                        </div>
+                        <main className="min-h-0 flex-1 overflow-hidden">
+                          <AgentRenderer
+                            agentDef={agentDef}
+                            agent={currentAgent}
+                            activeTabId={viewMode}
+                          />
+                        </main>
+                      </AgentPersonScopeProvider>
+                    ) : agents.length === 0 ? (
+                      <div className="flex flex-1 flex-col items-center justify-center">
+                        <Empty className="border-0">
+                          <EmptyHeader>
+                            <EmptyTitle>{t("agents:empty.title")}</EmptyTitle>
+                            <EmptyDescription>
+                              {t("agents:empty.description")}
+                            </EmptyDescription>
+                          </EmptyHeader>
+                          {canCreateAgents && (
+                            <Button
+                              className="mt-4 rounded-full"
+                              onClick={() => setCreateAgentDialogOpen(true)}
+                            >
+                              <Plus className="h-4 w-4" />
+                              {t("shell:newAgent.dialogTitle")}
+                            </Button>
+                          )}
+                        </Empty>
                       </div>
-                      <main className="min-h-0 flex-1 overflow-hidden">
-                        <AgentRenderer
-                          agentDef={agentDef}
-                          agent={currentAgent}
-                          activeTabId={viewMode}
-                        />
-                      </main>
-                    </AgentPersonScopeProvider>
-                  ) : agents.length === 0 ? (
-                    <div className="flex flex-1 flex-col items-center justify-center">
-                      <Empty className="border-0">
-                        <EmptyHeader>
-                          <EmptyTitle>{t("agents:empty.title")}</EmptyTitle>
-                          <EmptyDescription>
-                            {t("agents:empty.description")}
-                          </EmptyDescription>
-                        </EmptyHeader>
-                        {canCreateAgents && (
-                          <Button
-                            className="mt-4 rounded-full"
-                            onClick={() => setCreateAgentDialogOpen(true)}
-                          >
-                            <Plus className="h-4 w-4" />
-                            {t("shell:newAgent.dialogTitle")}
-                          </Button>
-                        )}
-                      </Empty>
-                    </div>
-                  ) : (
-                    <div className="flex flex-1 flex-col items-center justify-center">
-                      <p className="text-ink-muted text-sm">
-                        {t("shell:engineGate.starting")}
-                      </p>
-                    </div>
-                  )}
+                    ) : (
+                      <div className="flex flex-1 flex-col items-center justify-center">
+                        <p className="text-ink-muted text-sm">
+                          {t("shell:engineGate.starting")}
+                        </p>
+                      </div>
+                    ))}
                 </div>
               </main>
               {missionPanelOpen && (

--- a/app/src/components/store-view/store-browse.tsx
+++ b/app/src/components/store-view/store-browse.tsx
@@ -20,6 +20,19 @@ import { useStoreInstall } from "./use-store-install";
 /** The sentinel for "no filter", shared by the category and integration filters. */
 const ALL = "all";
 
+/** The default browse query, shared with boot prefetch so it warms this cache. */
+export function defaultStoreCatalogQueryOptions() {
+  return {
+    queryKey: ["store-catalog", "", ALL, ALL, "recent"] as const,
+    queryFn: ({ pageParam }: { pageParam: number }) =>
+      fetchStoreCatalog({ sort: "recent", page: pageParam }),
+    initialPageParam: 1,
+    getNextPageParam: (last: { hasMore: boolean }, all: unknown[]) =>
+      last.hasMore ? all.length + 1 : undefined,
+    staleTime: 60_000,
+  };
+}
+
 /**
  * The Agent Store's Browse tab: the public catalog in the app's catalog grammar
  * (search + category chips + integration filter over the flat row grid, a row

--- a/app/src/hooks/provider-connections/use-provider-login-events.ts
+++ b/app/src/hooks/provider-connections/use-provider-login-events.ts
@@ -17,6 +17,7 @@ import type {
 } from "./types";
 
 interface Args {
+  active: boolean;
   visibleProviders: readonly ProviderInfo[];
   addToast: AddToast;
   t: ProvidersT;
@@ -35,6 +36,7 @@ interface Args {
  * reads when several providers fire events concurrently.
  */
 export function useProviderLoginEvents({
+  active,
   visibleProviders,
   addToast,
   t,
@@ -44,6 +46,7 @@ export function useProviderLoginEvents({
   setPending,
 }: Args): void {
   useEffect(() => {
+    if (!active) return;
     // This surface owns `ProviderLoginUrl` while mounted — the shell's global
     // fallback stands down so the URL is never opened twice.
     const release = claimProviderLoginSurface();
@@ -149,6 +152,7 @@ export function useProviderLoginEvents({
       release();
     };
   }, [
+    active,
     visibleProviders,
     addToast,
     t,

--- a/app/src/hooks/queries/use-compute-usage.ts
+++ b/app/src/hooks/queries/use-compute-usage.ts
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriOrg } from "../../lib/tauri";
+import { isActiveTopLevelView } from "../../lib/top-level-views";
+import { useUIStore } from "../../stores/ui";
 
 /**
  * One fetch covers every client-side range (7d / 30d / 13w); the gateway
@@ -24,10 +26,13 @@ export const COMPUTE_USAGE_DAYS = 90;
  * Failures surface via `tauriOrg.computeUsage` → `call()` (toast + Report bug).
  */
 export function useComputeUsage(enabled: boolean) {
+  const active = useUIStore((s) => isActiveTopLevelView(s.viewMode, "usage"));
   return useQuery({
     queryKey: queryKeys.computeUsage(COMPUTE_USAGE_DAYS),
     queryFn: () => tauriOrg.computeUsage(COMPUTE_USAGE_DAYS),
-    enabled,
+    // The Usage surface stays mounted while hidden. Disable its observer off
+    // screen so neither its interval nor focus refetch wakes a pod-held read.
+    enabled: enabled && active,
     staleTime: 20_000,
     // The pod flushes its report on every turn start/end (edge-triggered), so
     // a 30s poll while an agent is up keeps fresh numbers visible within

--- a/app/src/hooks/queries/use-files.ts
+++ b/app/src/hooks/queries/use-files.ts
@@ -17,6 +17,7 @@ export function useFiles(agentPath: string | undefined) {
       return tauriFiles.list(agentPath);
     },
     enabled: !!agentPath,
+    staleTime: 30_000,
   });
 }
 

--- a/app/src/hooks/queries/use-instructions.ts
+++ b/app/src/hooks/queries/use-instructions.ts
@@ -10,6 +10,7 @@ export function useInstructions(agentPath: string | undefined) {
       return tauriAgent.readFile(agentPath, "CLAUDE.md").catch(() => "");
     },
     enabled: !!agentPath,
+    staleTime: 30_000,
   });
 }
 

--- a/app/src/hooks/queries/use-integrations.ts
+++ b/app/src/hooks/queries/use-integrations.ts
@@ -45,6 +45,7 @@ export function useIntegrationConnections(provider: string, enabled: boolean) {
     queryKey: queryKeys.integrationConnections(provider),
     queryFn: () => tauriIntegrations.connections(provider),
     enabled: enabled && registered,
+    staleTime: 30_000,
   });
 }
 
@@ -110,6 +111,7 @@ export function useCustomIntegrations() {
     queryKey: queryKeys.customIntegrations(),
     queryFn: () => tauriIntegrations.customList(),
     enabled: integrationsSupported(capabilities),
+    staleTime: 30_000,
   });
 }
 

--- a/app/src/hooks/queries/use-learnings.ts
+++ b/app/src/hooks/queries/use-learnings.ts
@@ -11,6 +11,7 @@ export function useLearnings(agentPath: string | undefined) {
     queryKey: queryKeys.learnings(agentPath ?? ""),
     queryFn: () => learnings.list(agentPath ?? ""),
     enabled: !!agentPath,
+    staleTime: 30_000,
   });
   // Adapt to the legacy `{ index, text }[]` shape so existing UIs keep working,
   // carrying the provenance fields through: the Memory rows show who taught a

--- a/app/src/hooks/queries/use-org-audit.ts
+++ b/app/src/hooks/queries/use-org-audit.ts
@@ -5,6 +5,8 @@ import {
 } from "../../components/organization/org-view-model";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriOrg } from "../../lib/tauri";
+import { isActiveTopLevelView } from "../../lib/top-level-views";
+import { useUIStore } from "../../stores/ui";
 
 /**
  * The org audit feed (Teams v2), newest first, paged by a before-cursor.
@@ -21,13 +23,18 @@ import { tauriOrg } from "../../lib/tauri";
  * `tauriOrg.audit` → `call()` path (toast + Report bug), no `onError` needed.
  */
 export function useOrgAudit(enabled: boolean) {
+  const active = useUIStore((s) =>
+    isActiveTopLevelView(s.viewMode, "organization"),
+  );
   return useInfiniteQuery({
     queryKey: queryKeys.orgAudit(),
     queryFn: ({ pageParam }: { pageParam: number | undefined }) =>
       tauriOrg.audit({ before: pageParam, limit: AUDIT_PAGE_SIZE }),
     initialPageParam: undefined as number | undefined,
     getNextPageParam: nextAuditCursor,
-    enabled,
+    // The Organization screen is kept alive. Its focus refresh is valuable
+    // only while the audit feed is actually visible.
+    enabled: enabled && active,
     staleTime: 30_000,
     refetchOnWindowFocus: true,
   });

--- a/app/src/hooks/queries/use-org-usage.ts
+++ b/app/src/hooks/queries/use-org-usage.ts
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriOrg } from "../../lib/tauri";
+import { isActiveTopLevelView } from "../../lib/top-level-views";
+import { useUIStore } from "../../stores/ui";
 
 /** Default usage window (contract §5: host clamps `days` to ≤ 90). */
 export const USAGE_DEFAULT_DAYS = 30;
@@ -20,10 +22,15 @@ export function useOrgUsage(
   enabled: boolean,
   days: number = USAGE_DEFAULT_DAYS,
 ) {
+  const active = useUIStore((s) =>
+    isActiveTopLevelView(s.viewMode, "organization"),
+  );
   return useQuery({
     queryKey: queryKeys.orgUsage(days),
     queryFn: () => tauriOrg.usage(days),
-    enabled,
+    // Organization remains mounted while hidden; avoid an unnecessary usage
+    // read when the app window regains focus off this screen.
+    enabled: enabled && active,
     staleTime: 5 * 60_000,
     refetchOnWindowFocus: true,
   });

--- a/app/src/hooks/queries/use-provider-usage.ts
+++ b/app/src/hooks/queries/use-provider-usage.ts
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriProvider } from "../../lib/tauri";
+import { isActiveTopLevelView } from "../../lib/top-level-views";
+import { useUIStore } from "../../stores/ui";
 
 /**
  * Live per-account provider usage for the AI Hub's Usage tab: each connected
@@ -15,10 +17,13 @@ import { tauriProvider } from "../../lib/tauri";
  * through `tauriProvider.usage` → `call()` (toast + Report bug).
  */
 export function useProviderUsage(enabled: boolean) {
+  const active = useUIStore((s) => isActiveTopLevelView(s.viewMode, "usage"));
   return useQuery({
     queryKey: queryKeys.providerUsage(),
     queryFn: () => tauriProvider.usage(),
-    enabled,
+    // Keep-alive preserves the last result, but hidden provider usage must not
+    // poll or refetch when the window regains focus.
+    enabled: enabled && active,
     staleTime: 30_000,
     refetchInterval: 60_000,
     refetchOnWindowFocus: true,

--- a/app/src/hooks/queries/use-routines.ts
+++ b/app/src/hooks/queries/use-routines.ts
@@ -11,6 +11,7 @@ export function useRoutines(agentPath: string | undefined) {
       return tauriRoutines.list(agentPath);
     },
     enabled: !!agentPath,
+    staleTime: 30_000,
   });
 }
 
@@ -25,6 +26,7 @@ export function useRoutineRuns(
       return tauriRoutines.listRuns(agentPath, routineId);
     },
     enabled: !!agentPath,
+    staleTime: 30_000,
   });
 }
 

--- a/app/src/hooks/queries/use-skills.ts
+++ b/app/src/hooks/queries/use-skills.ts
@@ -11,6 +11,7 @@ export function useSkills(agentPath: string | undefined) {
       return tauriSkills.list(agentPath);
     },
     enabled: !!agentPath,
+    staleTime: 30_000,
   });
 }
 
@@ -26,6 +27,7 @@ export function useSkillDetail(
       return tauriSkills.load(agentPath, name);
     },
     enabled: !!agentPath && !!name,
+    staleTime: 30_000,
   });
 }
 

--- a/app/src/hooks/session-notifications.ts
+++ b/app/src/hooks/session-notifications.ts
@@ -48,6 +48,7 @@ async function resolveActivityTarget(
     const activities = await queryClient.fetchQuery({
       queryKey: queryKeys.activity(agentPath),
       queryFn: () => tauriActivity.list(agentPath),
+      staleTime: 0,
     });
     const activityId = activityIdForSessionKey(activities, sessionKey);
     if (!activityId) return null;

--- a/app/src/hooks/use-provider-connections.ts
+++ b/app/src/hooks/use-provider-connections.ts
@@ -9,6 +9,11 @@ import {
   getConnectProviders,
   type ProviderInfo,
 } from "../lib/providers";
+import {
+  AI_HUB_VIEW_ID,
+  isActiveTopLevelView,
+  USAGE_VIEW_ID,
+} from "../lib/top-level-views";
 import { useUIStore } from "../stores/ui";
 import type {
   ProviderConnections,
@@ -40,9 +45,18 @@ export type {
  * Rendered once by the hub view; `dialogProps` feeds a single
  * `<ProviderConnectionDialogs>`.
  */
-export function useProviderConnections(): ProviderConnections {
+export function useProviderConnections(options?: {
+  /** Non-top-level flows unmount when hidden, so they own login events while mounted. */
+  alwaysActive?: boolean;
+}): ProviderConnections {
   const { t } = useTranslation("providers");
   const addToast = useUIStore((s) => s.addToast);
+  const providerSurfaceActive = useUIStore(
+    (s) =>
+      options?.alwaysActive ||
+      isActiveTopLevelView(s.viewMode, AI_HUB_VIEW_ID) ||
+      isActiveTopLevelView(s.viewMode, USAGE_VIEW_ID),
+  );
   const { capabilities } = useCapabilities();
   const newEngine = newEngineActive();
   const providerCapabilities =
@@ -80,18 +94,19 @@ export function useProviderConnections(): ProviderConnections {
     loadStatuses();
   }, [loadStatuses]);
 
-  // While a connect is pending, poll so the card flips to connected once the
-  // CLI credential file lands (the ProviderLoginComplete event is the primary
-  // signal; this is the backstop).
+  // While a connect is pending on its visible owner, poll so the card flips to
+  // connected once the credential lands (ProviderLoginComplete is primary).
+  // AI Hub and Usage stay mounted while hidden, so their local backstop must
+  // not keep issuing reads after the user leaves those provider surfaces.
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   useEffect(() => {
-    if (pending) {
+    if (pending && providerSurfaceActive) {
       pollRef.current = setInterval(loadStatuses, 2000);
     }
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
     };
-  }, [pending, loadStatuses]);
+  }, [pending, providerSurfaceActive, loadStatuses]);
 
   useEffect(() => {
     if (!pending) return;
@@ -104,6 +119,7 @@ export function useProviderConnections(): ProviderConnections {
   }, [pending, statuses]);
 
   useProviderLoginEvents({
+    active: providerSurfaceActive,
     visibleProviders,
     addToast,
     t,

--- a/app/src/hooks/use-screen-prefetch.ts
+++ b/app/src/hooks/use-screen-prefetch.ts
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import { defaultStoreCatalogQueryOptions } from "../components/store-view/store-browse";
+import { queryClient } from "../lib/query-client";
+import { queryKeys } from "../lib/query-keys";
+import { screenPrefetchPlan } from "../lib/screen-prefetch-plan";
+import { tauriIntegrations, tauriOrg } from "../lib/tauri";
+import { useAgentStore } from "../stores/agents";
+import { useCapabilities } from "./use-capabilities";
+
+/** Warm screen-defining reads after the host and initial agent load settle. */
+export function useScreenPrefetch() {
+  const { capabilities } = useCapabilities();
+  const agentsLoaded = useAgentStore((state) => state.loaded);
+
+  useEffect(() => {
+    if (!capabilities || !agentsLoaded) return;
+    for (const item of screenPrefetchPlan(capabilities)) {
+      if (item === "integrations") {
+        void queryClient.prefetchQuery({
+          queryKey: queryKeys.integrationStatus(),
+          queryFn: () => tauriIntegrations.status(),
+          staleTime: 30_000,
+        });
+        void queryClient.prefetchQuery({
+          queryKey: queryKeys.integrationConnections("composio"),
+          queryFn: () => tauriIntegrations.connections("composio"),
+          staleTime: 30_000,
+        });
+        void queryClient.prefetchQuery({
+          queryKey: queryKeys.integrationToolkits("composio"),
+          queryFn: () => tauriIntegrations.toolkits("composio"),
+          staleTime: 60 * 60_000,
+        });
+        void queryClient.prefetchQuery({
+          queryKey: queryKeys.customIntegrations(),
+          queryFn: () => tauriIntegrations.customList(),
+          staleTime: 30_000,
+        });
+      }
+      if (item === "organization") {
+        void queryClient.prefetchQuery({
+          queryKey: queryKeys.org(),
+          queryFn: () => tauriOrg.get(),
+          staleTime: 30_000,
+        });
+      }
+      if (item === "store-catalog") {
+        void queryClient.prefetchInfiniteQuery({
+          ...defaultStoreCatalogQueryOptions(),
+        });
+      }
+    }
+  }, [agentsLoaded, capabilities]);
+}

--- a/app/src/lib/file-bytes-cache.ts
+++ b/app/src/lib/file-bytes-cache.ts
@@ -5,7 +5,7 @@
  * file whose thumbnail had just been fetched downloaded the exact same bytes a
  * second time (HOU-970).
  *
- * Blobs live in the query cache for the default gcTime, so two rules keep it
+ * Blobs live in the query cache briefly (five minutes), so two rules keep it
  * from turning into a memory hazard:
  *
  * 1. **Keyed per file + mtime, cached only when there IS an mtime.** Bytes are
@@ -67,6 +67,7 @@ export function fetchFileBytes(
   return queryClient.fetchQuery({
     queryKey: fileBytesQueryKey(agentPath, filePath, dateModified),
     staleTime: Number.POSITIVE_INFINITY,
+    gcTime: 5 * 60_000,
     queryFn: download,
   });
 }

--- a/app/src/lib/identity-reset.ts
+++ b/app/src/lib/identity-reset.ts
@@ -1,3 +1,4 @@
+import { resetIntegrationGateForIdentityChange } from "../components/integrations/integrations-gate-state";
 import { useAgentProvisioningStore } from "../stores/agent-provisioning";
 import { useAgentStore } from "../stores/agents";
 import { useDraftStore } from "../stores/drafts";
@@ -29,6 +30,7 @@ import { queryClient } from "./query-client";
  */
 export function resetForIdentityChange(): void {
   queryClient.clear();
+  resetIntegrationGateForIdentityChange();
   useAgentStore.getState().reset();
   useWorkspaceStore.getState().reset();
   useUIStore.getState().reset();

--- a/app/src/lib/query-client.ts
+++ b/app/src/lib/query-client.ts
@@ -3,11 +3,11 @@ import { QueryClient } from "@tanstack/react-query";
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      // Data is fresh for 2 seconds — prevents rapid re-fetches
-      // when multiple components mount with the same query key
-      staleTime: 2_000,
-      // Keep unused data in cache for 5 minutes
-      gcTime: 5 * 60_000,
+      // SSE invalidation is the correctness path; this prevents needless
+      // remount fetches between events.
+      staleTime: 30_000,
+      // Keep an unvisited screen warm for a normal working session.
+      gcTime: 30 * 60_000,
       // Don't retry on error — our Tauri invoke wrapper already shows toasts
       retry: false,
       // Refetch when window regains focus (user alt-tabs back)

--- a/app/src/lib/screen-prefetch-plan.ts
+++ b/app/src/lib/screen-prefetch-plan.ts
@@ -1,0 +1,13 @@
+import type { Capabilities } from "@houston-ai/engine-client";
+
+export type ScreenPrefetch = "integrations" | "organization" | "store-catalog";
+
+export function screenPrefetchPlan(
+  capabilities: Capabilities | null | undefined,
+): ScreenPrefetch[] {
+  const plan: ScreenPrefetch[] = ["store-catalog"];
+  if (capabilities?.integrations.includes("composio"))
+    plan.push("integrations");
+  if (capabilities?.multiplayer) plan.push("organization");
+  return plan;
+}

--- a/app/src/lib/top-level-views.ts
+++ b/app/src/lib/top-level-views.ts
@@ -12,10 +12,32 @@ import { PERMISSIONS_VIEW_ID } from "../components/permissions/id.ts";
 import { STORE_VIEW_ID } from "../components/store-view/id.ts";
 import { USAGE_VIEW_ID } from "../components/usage-view/id.ts";
 
-export const TOP_LEVEL_VIEWS = new Set<string>([
-  "dashboard",
-  "settings",
-  "ai-hub",
+export {
+  INTEGRATIONS_VIEW_ID,
+  ORGANIZATION_VIEW_ID,
+  PERMISSIONS_VIEW_ID,
+  STORE_VIEW_ID,
+  USAGE_VIEW_ID,
+};
+
+export const DASHBOARD_VIEW_ID = "dashboard";
+export const SETTINGS_VIEW_ID = "settings";
+export const AI_HUB_VIEW_ID = "ai-hub";
+
+export type TopLevelViewId =
+  | typeof DASHBOARD_VIEW_ID
+  | typeof SETTINGS_VIEW_ID
+  | typeof AI_HUB_VIEW_ID
+  | typeof USAGE_VIEW_ID
+  | typeof INTEGRATIONS_VIEW_ID
+  | typeof ORGANIZATION_VIEW_ID
+  | typeof PERMISSIONS_VIEW_ID
+  | typeof STORE_VIEW_ID;
+
+export const TOP_LEVEL_VIEWS = new Set<TopLevelViewId>([
+  DASHBOARD_VIEW_ID,
+  SETTINGS_VIEW_ID,
+  AI_HUB_VIEW_ID,
   USAGE_VIEW_ID,
   INTEGRATIONS_VIEW_ID,
   ORGANIZATION_VIEW_ID,
@@ -25,7 +47,15 @@ export const TOP_LEVEL_VIEWS = new Set<string>([
 
 /** Whether a `viewMode` is a top-level (non-agent) view. */
 export function isTopLevelView(viewMode: string): boolean {
-  return TOP_LEVEL_VIEWS.has(viewMode);
+  return TOP_LEVEL_VIEWS.has(viewMode as TopLevelViewId);
+}
+
+/** Whether a kept-alive top-level surface is the one currently on screen. */
+export function isActiveTopLevelView(
+  activeViewMode: string,
+  viewId: TopLevelViewId,
+): boolean {
+  return activeViewMode === viewId;
 }
 
 /**
@@ -47,7 +77,7 @@ export function blockedTopLevelView(
   if (viewMode === ORGANIZATION_VIEW_ID) return !gates.showOrganization;
   // Permissions shares the Organization gate exactly (multiplayer owner/admin).
   if (viewMode === PERMISSIONS_VIEW_ID) return !gates.showOrganization;
-  if (viewMode === "ai-hub") return !gates.showAiModels;
+  if (viewMode === AI_HUB_VIEW_ID) return !gates.showAiModels;
   // The Usage page reads the same workspace-central provider accounts the AI
   // Models hub manages, so it shares the hub's Teams gate exactly.
   if (viewMode === USAGE_VIEW_ID) return !gates.showAiModels;

--- a/app/tests/screen-prefetch-plan.test.ts
+++ b/app/tests/screen-prefetch-plan.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { screenPrefetchPlan } from "../src/lib/screen-prefetch-plan.ts";
+
+describe("screenPrefetchPlan", () => {
+  it("includes only capability-supported screen reads", () => {
+    assert.deepStrictEqual(
+      screenPrefetchPlan({ integrations: ["custom"] } as never),
+      ["store-catalog"],
+    );
+    assert.deepStrictEqual(
+      screenPrefetchPlan({
+        integrations: ["composio"],
+        multiplayer: true,
+      } as never),
+      ["store-catalog", "integrations", "organization"],
+    );
+  });
+});

--- a/app/tests/top-level-views.test.ts
+++ b/app/tests/top-level-views.test.ts
@@ -4,7 +4,10 @@ import { INTEGRATIONS_VIEW_ID } from "../src/components/integrations-view/id.ts"
 import { ORGANIZATION_VIEW_ID } from "../src/components/organization/id.ts";
 import { USAGE_VIEW_ID } from "../src/components/usage-view/id.ts";
 import {
+  AI_HUB_VIEW_ID,
   blockedTopLevelView,
+  DASHBOARD_VIEW_ID,
+  isActiveTopLevelView,
   isTopLevelView,
 } from "../src/lib/top-level-views.ts";
 
@@ -25,6 +28,14 @@ describe("isTopLevelView", () => {
   it("treats everything else as an agent tab", () => {
     strictEqual(isTopLevelView("chat"), false);
     strictEqual(isTopLevelView("integrations"), false);
+  });
+});
+
+describe("isActiveTopLevelView", () => {
+  it("only enables work for the visible top-level screen", () => {
+    // A shared hook must use an explicit top-level id, not an arbitrary tab.
+    strictEqual(isActiveTopLevelView(USAGE_VIEW_ID, USAGE_VIEW_ID), true);
+    strictEqual(isActiveTopLevelView(DASHBOARD_VIEW_ID, USAGE_VIEW_ID), false);
   });
 });
 
@@ -50,11 +61,11 @@ describe("blockedTopLevelView", () => {
     // Same strand for the hub: a Teams member (role flipped) with a stale
     // `ai-hub` viewMode must be reported blocked and reset to the dashboard.
     strictEqual(
-      blockedTopLevelView("ai-hub", gates({ showAiModels: false })),
+      blockedTopLevelView(AI_HUB_VIEW_ID, gates({ showAiModels: false })),
       true,
     );
     strictEqual(
-      blockedTopLevelView("ai-hub", gates({ showAiModels: true })),
+      blockedTopLevelView(AI_HUB_VIEW_ID, gates({ showAiModels: true })),
       false,
     );
   });

--- a/knowledge-base/client-architecture.md
+++ b/knowledge-base/client-architecture.md
@@ -276,6 +276,25 @@ A component added, removed, or restructured is a structural change. (Full detail
 | **`app/` (= `packages/web`)** | *App-specific* composition: wiring `ui/` to SDK view-models, `t()` injection, routing, desktop chrome. Unsure if generic? Start in `app/`, extract later. |
 | **`packages/web/src/engine-adapter`** | Only web↔SDK glue and the not-yet-delegated surface (providers, `updateActivity`). **Prefer the SDK** — the adapter is shrinking, not growing. |
 
+### g. Top-level screen lifecycle and cache policy
+
+The desktop/web shell keeps visited top-level screens mounted in a workspace-keyed
+visited set. An inactive screen is `display: none`, not destroyed: local view
+state survives navigation, while view-owned polling and event ownership MUST gate
+on its active top-level view id. Switching workspace resets the keep-alive layer.
+The layer closes an open Radix dialog before hiding its source screen because
+dialogs portal outside that hidden subtree.
+
+TanStack Query defaults are 30 seconds stale time and 30 minutes garbage
+collection. SSE invalidation, not short staleness, is the correctness path.
+Boot prefetch warms defining reads for reachable top-level screens; it must only
+request advertised capabilities (for example, Composio only when advertised).
+
+**Ownership invariant:** a query hook gated on the active view belongs exclusively
+to that screen. Shared hooks, including Teams roster data used by sharing/admin
+surfaces, must use their callers' precise `enabled` flags and must never be
+view-gated.
+
 ---
 
 ## Verification matrix


### PR DESCRIPTION
## What

Moving between screens (Mission Control, Integrations, AI Hub, Usage, Store, Permissions, Organization, Settings) should feel like 0 seconds. Four changes:

- **Keep-alive screens**: a visited top-level screen stays mounted and hides with `display:none`; returning is a CSS toggle with all local state (search, filters, drill-ins, scroll) intact. Gated views unmount when their gate closes; the visited set resets per workspace/space; the agent subtree keeps its per-agent remount key from HOU-816. Screens hidden behind an open modal close the modal on navigation; Mission Control closes its detail panel when it deactivates.
- **Cache defaults**: staleTime 2s → 30s, gcTime 5m → 30m (SSE invalidation remains the correctness path; `invalidateQueries` refetches regardless of staleTime). Previously-untuned agent queries get explicit staleTime. Preview-blob cache keeps its own small gcTime.
- **Integrations gate**: the session-resync latch is shared per token across all mount points instead of re-entering a full-page loading state on every visit; failed resyncs retry instead of latching; concurrent mounts single-flight the resync.
- **Boot prefetch**: after handshake + agent load, screen-defining reads warm up (integrations only when Composio is advertised, org only when multiplayer, store catalog via the exported query options) so even first visits paint instantly.

Polls/focus-refetches owned by hidden screens are gated on screen activeness (provider pending poll, usage/compute/org, settings phone poll); onboarding/migration/setup surfaces keep the provider poll as their backstop. `knowledge-base/client-architecture.md` documents the new lifecycle and the query-ownership invariant.

Also deflakes `suggest-actions.spec.ts` (superseded by the equivalent fix that landed on main; kept main's version on rebase).

## Tests

- New: `screenPrefetchPlan` unit tests, top-level-view gating tests updated. App suite 2386 pass.
- Full chromium e2e: 182 passed, 1 skipped (fresh servers, incl. HOU-901's new integrations-accounts specs). Visual regression: 6 passed.
- Adversarially reviewed; the review's 7 blockers (fallback rendering under every screen, immortal detail panel, over-broad useOrg gating, keep-alive flex breakage, provider-login claim leak, Composio-less prefetch 404 toasts, orphaned modals) are all fixed and re-verified.

Fixes HOU-813

🤖 Generated with [Claude Code](https://claude.com/claude-code)