### PR TITLE
style(agent): archived toggle becomes a floating outline icon button over the board

### DIFF
--- a/app/src/components/shell/archived-toggle-button.tsx
+++ b/app/src/components/shell/archived-toggle-button.tsx
@@ -1,41 +1,40 @@
-import {
-  Button,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@houston-ai/core";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@houston-ai/core";
 import { Archive } from "lucide-react";
 
 interface ArchivedToggleButtonProps {
   archived: boolean;
-  collapsed: boolean;
   label: string;
   onToggle: () => void;
 }
 
-/** Activity-header control for switching between live and archived missions. */
+/**
+ * Floating control for switching between live and archived missions: a round
+ * action-colored button anchored over the board's bottom-right corner. Icon
+ * only, so the label rides on a tooltip and the aria-label; `aria-pressed`
+ * carries the mode for assistive tech while the ring marks it visually.
+ */
 export function ArchivedToggleButton({
   archived,
-  collapsed,
   label,
   onToggle,
 }: ArchivedToggleButtonProps) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Button
+        <button
+          type="button"
           data-tour-target="archivedMissions"
-          variant={archived ? "secondary" : "ghost"}
-          size={collapsed ? "icon" : "default"}
-          className="rounded-full"
+          className={`absolute right-6 bottom-6 z-20 flex size-12 items-center justify-center rounded-full border border-line-input bg-input text-ink transition-[background-color,color,transform] hover:bg-hover hover:text-hover-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 active:scale-95 ${
+            archived ? "ring-2 ring-focus ring-offset-2" : ""
+          }`}
           onClick={onToggle}
           aria-label={label}
+          aria-pressed={archived}
         >
-          <Archive className="size-4" />
-          {!collapsed && label}
-        </Button>
+          <Archive className="size-5" />
+        </button>
       </TooltipTrigger>
-      {collapsed && <TooltipContent side="bottom">{label}</TooltipContent>}
+      <TooltipContent side="left">{label}</TooltipContent>
     </Tooltip>
   );
 }

--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -49,7 +49,6 @@ import { ExportAgentWizard } from "../portable/export-wizard";
 import { ImportAgentWizard } from "../portable/import-wizard";
 import { ShortcutCheatsheet } from "../shortcut-cheatsheet";
 import { AgentWarmingDialog } from "./agent-warming-dialog";
-import { ArchivedToggleButton } from "./archived-toggle-button";
 import { CreateAgentDialog } from "./create-workspace-dialog";
 import { DetailPanelProvider } from "./detail-panel-context";
 import { HoustonLogo } from "./experience-card";
@@ -78,7 +77,6 @@ export function WorkspaceShell({
   const getById = useAgentCatalogStore((s) => s.getById);
   const viewMode = useUIStore((s) => s.viewMode);
   const setViewMode = useUIStore((s) => s.setViewMode);
-  const agentBoardMode = useUIStore((s) => s.agentBoardMode);
   const setAgentBoardMode = useUIStore((s) => s.setAgentBoardMode);
   const onStartMission = useUIStore((s) => s.onStartMission);
   const boardActions = useUIStore((s) => s.boardActions);
@@ -300,20 +298,6 @@ export function WorkspaceShell({
                                   <NotificationsBell
                                     collapsed={missionPanelOpen}
                                   />
-                                  {viewMode === "activity" && (
-                                    <ArchivedToggleButton
-                                      archived={agentBoardMode === "archived"}
-                                      collapsed={missionPanelOpen}
-                                      label={t("dashboard:archived.button")}
-                                      onToggle={() =>
-                                        setAgentBoardMode(
-                                          agentBoardMode === "archived"
-                                            ? "active"
-                                            : "archived",
-                                        )
-                                      }
-                                    />
-                                  )}
                                   <Tooltip>
                                     <TooltipTrigger asChild>
                                       <Button

--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -1,21 +1,35 @@
+import { useTranslation } from "react-i18next";
 import type { TabProps } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 import { MissionBoard } from "../board/mission-board";
 import { useAgentBoardSource } from "../board/use-agent-board-source";
+import { ArchivedToggleButton } from "../shell/archived-toggle-button";
 import ArchivedTab from "./archived-tab";
 
 /**
  * A single agent's mission board. All the wiring lives in the shared
- * `<MissionBoard>`; this tab only builds the per-agent data source.
+ * `<MissionBoard>`; this tab only builds the per-agent data source and
+ * floats the archived toggle over whichever surface is showing.
  */
 export default function BoardTab({ agent, agentDef }: TabProps) {
+  const { t } = useTranslation(["dashboard"]);
   const mode = useUIStore((s) => s.agentBoardMode);
+  const setAgentBoardMode = useUIStore((s) => s.setAgentBoardMode);
   const source = useAgentBoardSource(agent, agentDef);
-  if (mode === "archived")
-    return <ArchivedTab agent={agent} agentDef={agentDef} />;
   return (
-    <div className="flex flex-col h-full">
-      <MissionBoard source={source} />
+    <div className="relative flex h-full flex-col">
+      {mode === "archived" ? (
+        <ArchivedTab agent={agent} agentDef={agentDef} />
+      ) : (
+        <MissionBoard source={source} />
+      )}
+      <ArchivedToggleButton
+        archived={mode === "archived"}
+        label={t("dashboard:archived.button")}
+        onToggle={() =>
+          setAgentBoardMode(mode === "archived" ? "active" : "archived")
+        }
+      />
     </div>
   );
 }


### PR DESCRIPTION
## What

Design follow-up to the HOU-814 tab restructure: the Archived control moves out of the tab-bar actions cluster into a round outline button floating over the board's bottom-right corner (and over the archived list, to toggle back).

- Outline style: hairline `border-line-input` on the `bg-input` surface, `text-ink` icon, no shadow; `hover:bg-hover`; token-only colors so both themes adapt.
- Icon-only: label rides on a tooltip and `aria-label`; `aria-pressed` plus a focus ring carry the active state.
- Mounted by the board tab itself, so the workspace shell toolbar no longer special-cases the activity view. Tour anchor (`data-tour-target="archivedMissions"`) unchanged.

Screenshot-verified in light and dark, at rest and active.

## Tests

`agent-archived-button.spec.ts` (toggle + reset-on-tab-switch) and `tour.spec.ts` pass unchanged — the accessible name and anchor are stable. Biome + typecheck clean.

Follow-up polish to HOU-814. No Linear issue — small design iteration requested in review of the shipped tab restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)