### PR TITLE
fix(ci): daily cloud cut fires ~07:05 Bogotá, not 08:30 (HOU-1013)

### DIFF
--- a/.github/workflows/daily-cloud-cut.yml
+++ b/.github/workflows/daily-cloud-cut.yml
@@ -33,12 +33,17 @@
 #   the write we need is the PAT's, not the job token's. (Read-only check-run
 #   queries still use GITHUB_TOKEN; those don't need to trigger anything.)
 #
-# WHY WEEKDAYS-ONLY AT 11:52 UTC (AND NOT ON A ROUND MINUTE):
+# WHY WEEKDAYS-ONLY AT 10:22 UTC (AND NOT ON A ROUND MINUTE):
 #   The team QAs in the 08:30 America/Bogota daily, which runs Mon–Fri. Bogotá is
-#   UTC-5 all year (Colombia observes no DST), so 11:52 UTC == 06:52 Bogotá. The
-#   release build takes ~30 min; GitHub's schedule queue is best-effort and
-#   routinely fires 30–120 min late, so we cut early to absorb the delay and
-#   still have the draft ready before 08:30. The :52 minute is deliberate:
+#   UTC-5 all year (Colombia observes no DST). GitHub's schedule queue is
+#   best-effort: at the previous 11:52 UTC slot the observed delivery delay was
+#   +88 to +128 min (avg ~103), so the cut ACTUALLY started 08:20–09:00 Bogotá —
+#   on top of the daily, with no draft ready (HOU-1013). The target is a cut
+#   that actually starts ~07:05 Bogotá (12:05 UTC), so the nominal slot is
+#   12:05 minus the average delay: 10:22 UTC == 05:22 Bogotá. With the observed
+#   delay range the cut starts 06:50–07:30 Bogotá, and the ~30-min build has
+#   the draft ready by ~08:00. Firing early is harmless (the draft just waits);
+#   firing after 08:30 is the failure mode. The :22 minute is deliberate:
 #   :00/:15/:30/:45 are the most congested cron slots on GitHub and get the
 #   worst delays. `cron: '1-5'` skips weekends — no daily, no cut.
 #
@@ -57,9 +62,10 @@ name: Daily cloud cut
 
 on:
   schedule:
-    # 11:52 UTC, Mon–Fri == 06:52 America/Bogota (UTC-5, no DST). Early + on an
-    # off-peak minute because GitHub's cron queue runs late — see the header.
-    - cron: "52 11 * * 1-5"
+    # 10:22 UTC, Mon–Fri == 05:22 America/Bogota (UTC-5, no DST). Nominal slot
+    # is ~103 min before the ~07:05 Bogotá target because GitHub's cron queue
+    # delivers that late — see the header.
+    - cron: "22 10 * * 1-5"
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
Fixes HOU-1013.

## Root cause

The daily cut's cron already *targets* 11:52 UTC (06:52 Bogotá), but GitHub's schedule queue is best-effort and delivered every recent scheduled run **88–128 minutes late** (avg ~103 min):

| date | cron target (UTC) | actually fired (UTC) | Bogotá |
|------|------|------|------|
| 07-27 | 11:52 | 14:00 | 09:00 |
| 07-28 | 11:52 | 13:20 | 08:20 |
| 07-29 | 11:52 | 13:25 | 08:25 |

So the cut — the step that kicks off the draft-release build — actually started at ~08:30 Bogotá, right on top of the daily, with no draft ready to QA. Writing "7:05" into the cron literally (12:05 UTC) would make it fire ~08:40–09:15, even later.

## Fix

Schedule the nominal slot ~103 min ahead of the desired start, following the same approach as the two prior schedule moves (58103ef8, 93355d58): `52 11 * * 1-5` → `22 10 * * 1-5` (05:22 Bogotá nominal, still an off-peak minute). With the observed delay range the cut actually starts **06:50–07:30 Bogotá (~07:05 on average)** and the ~30-min build has the draft ready by ~08:00. Firing early is harmless (the draft just waits); firing after 08:30 is the failure mode.

## Before

`gh run list --workflow daily-cloud-cut.yml --json event,createdAt --jq '.[] | select(.event=="schedule") | .createdAt'` → runs created 13:20–14:00 UTC (08:20–09:00 Bogotá); the draft prerelease appears after the 08:30 daily has started.

## After (verify over the next 1–2 weekday mornings)

1. Same `gh run list` command: scheduled runs should be created ~11:50–12:35 UTC (06:50–07:35 Bogotá).
2. The `cloud-v*` draft prerelease on the releases page should exist before 08:30 Bogotá.
3. If GitHub's delay at the new 10:22 slot differs materially, re-tune the nominal minute by the newly observed offset (the header documents the arithmetic).