### PR TITLE
fix(runtime): classify opencode 'Streaming response failed' as provider_internal (HOU-929)

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -709,7 +709,7 @@ export function useAgentChatPanel({
             const cfg = await tauriConfig.read(path);
             await tauriConfig.write(path, {
               ...cfg,
-              provider: prov as "anthropic" | "openai",
+              provider: prov,
               model: mod,
             });
           }

--- a/app/src/data/config.ts
+++ b/app/src/data/config.ts
@@ -5,7 +5,9 @@ import { readAgentJson, writeAgentJson } from "./agent-file";
 
 export interface Config {
   name?: string;
-  provider?: "anthropic" | "openai";
+  // A pi provider id (`anthropic`, `openai-codex`, `opencode`, …). Open string:
+  // the catalog is ~35 providers and drifts (see protocol `ProviderId`).
+  provider?: string;
   model?: string;
   // The active vocabulary is `low|medium|high|xhigh`; a legacy `"max"` may still
   // sit in older on-disk configs. It is tolerated on read and normalized to

--- a/app/src/lib/agent-setup.ts
+++ b/app/src/lib/agent-setup.ts
@@ -27,7 +27,7 @@ export async function finishAgentSetup(
       agentPath,
       {
         ...cfg,
-        provider: opts.provider as "anthropic" | "openai",
+        provider: opts.provider,
         model: opts.model,
       },
       // Post-create setup rides as a held request that lands when the engine

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -403,6 +403,34 @@ test("opencode ModelError 'is not supported' under 401 → model_unavailable, no
     expect(err.model).toBe("minimax-m3-free");
 });
 
+// opencode.ai's gateway reports an upstream stream break as "Streaming response
+// failed" — no status, no JSON envelope in the worst case (HOU-929's verbatim
+// report). It is a transient server-side failure (retry helps), so it must read
+// as provider_internal (Retry + status page), never the report-bug `unknown`.
+test("opencode 'Streaming response failed' → provider_internal, not unknown (HOU-929)", () => {
+  const err = classifyProviderError({
+    provider: "opencode",
+    model: "qwen3-coder",
+    message: "Streaming response failed",
+  });
+  expect(err).toEqual({
+    kind: "provider_internal",
+    provider: "opencode",
+    http_status: null,
+    message: "Streaming response failed",
+  });
+});
+
+test("opencode stream failure classifies inside a JSON error envelope too", () => {
+  const err = classifyProviderError({
+    provider: "opencode-go",
+    model: null,
+    message:
+      '{"type":"error","error":{"type":"APIError","message":"Streaming response failed"}}',
+  });
+  expect(err.kind).toBe("provider_internal");
+});
+
 test("a genuine opencode 401 invalid key still reads as unauthenticated", () => {
   // The fix must not blunt real auth failures: an invalid key under 401 stays a
   // reconnect prompt.

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -319,7 +319,10 @@ function isServerError(lower: string, status: number | null): boolean {
     lower.includes("service unavailable") ||
     lower.includes("bad gateway") ||
     lower.includes("gateway timeout") ||
-    lower.includes("overloaded")
+    lower.includes("overloaded") ||
+    // opencode.ai's gateway body when its upstream stream breaks mid-response —
+    // often with no status at all. Transient; retry helps (HOU-929).
+    lower.includes("streaming response failed")
   );
 }
 

--- a/ui/agent-schemas/src/config.schema.json
+++ b/ui/agent-schemas/src/config.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "name": { "type": "string" },
-    "provider": { "type": "string", "enum": ["anthropic", "openai", "gemini"] },
+    "provider": { "type": "string" },
     "model": { "type": "string" },
     "effort": {
       "type": "string",


### PR DESCRIPTION
## Summary

Fixes HOU-929.

A user on 0.5.28 (Windows) hit `provider_error:unknown:opencode — Streaming response failed`. Two defects, both evidenced in the report's logs:

**1. Unclassified OpenCode stream failure → report-bug card instead of Retry.**
opencode.ai's gateway reports an upstream stream break as `Streaming response failed` — often with no HTTP status and sometimes no JSON envelope. It matched no pattern in `classifyProviderError`, so it fell through to `unknown` (the "Report bug" card). It is a transient server-side failure (retry helps — the same error is widely reported against opencode's own CLI, e.g. anomalyco/opencode#38024), so it now classifies as `provider_internal`, which renders the Retry + status-page card. Pattern added to `isServerError` in `packages/runtime/src/ai/provider-error.ts`; precedence keeps auth/quota/rate-limit/overflow verdicts untouched.

**2. Stale agent-file config provider enum warn-spamming every read/write.**
The same logs show `config: schema validation failed … allowedValues [anthropic, openai, gemini]` on every config read AND `writing data that fails validation` on writes — for any agent whose config carries a current provider id (`opencode`, `openai-codex`, `google`, …). Provider is an open string on the wire (protocol `ProviderId`: "the catalog is ~35 providers and drifts"), so the schema (`ui/agent-schemas/src/config.schema.json`) and the app `Config` type now accept any string. The two `as "anthropic" | "openai"` casts that papered over the old union are removed.

## Reproduce (before the fix)

Deterministic, at the classifier (the live failure needs an OpenCode Zen key plus a flaky upstream — the classifier is pure and tested against verbatim provider strings by design):

```
git stash -- packages/runtime/src/ai/provider-error.ts   # revert only the fix
pnpm --filter @houston/runtime exec vitest run src/ai/provider-error.test.ts
```

The two new HOU-929 tests fail: `classifyProviderError({ provider: "opencode", model: "qwen3-coder", message: "Streaming response failed" })` returns `kind: "unknown"` — the exact `provider_error:unknown:opencode` from the report. In-app, that renders the generic "Report bug" card with no retry.

For defect 2: set an agent's `.houston/config/config.json` provider to `opencode` and open the app — the frontend log warn-spams `config: schema validation failed` on every read/write.

## Verify (after the fix)

```
pnpm --filter @houston/runtime exec vitest run src/ai/provider-error.test.ts   # 43/43, incl. 2 new HOU-929 cases
pnpm --filter @houston/runtime test    # 849 passed
cd app && pnpm tsgo --noEmit && pnpm test   # 2420 passed
pnpm --filter houston-web typecheck
pnpm check   # Biome clean
```

In-app: an OpenCode turn that hits the gateway stream break now shows the `ProviderInternal` card (Retry + Check status page) instead of "Report bug", and agents configured with any current provider id no longer log schema-validation warnings.