### PR TITLE
fix(runtime): classify Copilot's 'not available for integrator' 400 as model_unavailable (HOU-977)

### DIFF
--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -269,6 +269,28 @@ test("GitHub Copilot model_not_supported → model_unavailable + gpt-4.1 fallbac
   });
 });
 
+test("Copilot 'not available for integrator' 400 → model_unavailable + gpt-4.1 fallback (HOU-977)", () => {
+  // Copilot's NEWER wording for the same plan-doesn't-serve-this-model failure:
+  // no `model_not_supported` code, just prose naming the integrator and the
+  // plan's model list. Fell through to `unknown` (generic card + auto bug
+  // report) until the pattern landed.
+  const message =
+    '400: {"message":"The requested model is not available for integrator \\"vscode-chat\\". Available models: [gpt-4.1 claude-fable-5 claude-opus-4.7 claude-opus-4.8-fast claude-opus-4.8 claude-opus-5 claude-sonnet-4.6 claude-sonnet-5]"}';
+  const err = classifyProviderError({
+    provider: "github-copilot",
+    model: "gpt-5.6-sol",
+    message,
+  });
+  expect(err).toEqual({
+    kind: "model_unavailable",
+    provider: "github-copilot",
+    model: "gpt-5.6-sol",
+    reason: "unknown",
+    suggested_fallback: "gpt-4.1",
+    message,
+  });
+});
+
 test("together.ai's gated-model body → model_unavailable, never unknown", () => {
   // The verbatim rejection together.ai answers a non-serverless model with. The
   // key authenticated fine — classifying this as `unknown` made the api-key

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -92,6 +92,10 @@ const MODEL_UNAVAILABLE_PATTERNS = [
   // …" — for models its serverless tier doesn't include. The credential
   // authenticated fine; only the model is out of reach.
   "unable to access model",
+  // GitHub Copilot's newer 400 body — `The requested model is not available
+  // for integrator "vscode-chat". Available models: […]` — same plan-doesn't-
+  // serve-this-model failure as its older `model_not_supported` code (HOU-977).
+  "requested model is not available",
 ];
 
 /**


### PR DESCRIPTION
## Summary

Fixes HOU-977.

GitHub Copilot has a newer rejection body for asking a model the user's plan doesn't serve:

```
400: {"message":"The requested model is not available for integrator \"vscode-chat\". Available models: [gpt-4.1 claude-fable-5 ...]"}
```

Unlike the older rejection (HOU-578), this body carries no `model_not_supported` code and none of the `MODEL_UNAVAILABLE_PATTERNS` wordings, so `classifyProviderError` fell through to `kind: "unknown"` — the user got the generic error card and an auto-filed bug report instead of the purpose-built **model_unavailable** card that offers switching to `gpt-4.1` (a model every Copilot plan serves, and one that is in the reporting user's available list).

**Root cause:** missing classification pattern for Copilot's new 400 wording.
**Fix:** add the narrow pattern `"requested model is not available"` to `MODEL_UNAVAILABLE_PATTERNS` in `packages/runtime/src/ai/provider-error.ts`, tied to the verbatim payload.

## Before (reproduction)

```ts
classifyProviderError({
  provider: "github-copilot",
  model: "gpt-5.6-sol",
  message: '400: {"message":"The requested model is not available for integrator \\"vscode-chat\\". Available models: [...]"}',
})
// → { kind: "unknown", provider: "github-copilot", raw_excerpt: "400: ..." }
```

In the app: pick a Copilot model the plan doesn't include (e.g. a GPT-5.x model on a plan whose integrator only serves the base + Claude set), send a message → generic "unknown provider error" card + auto bug report.

## After (verification)

Same input now classifies as:

```ts
{ kind: "model_unavailable", provider: "github-copilot", model: "gpt-5.6-sol",
  reason: "unknown", suggested_fallback: "gpt-4.1", message: ... }
```

In the app the chat renders the switch-model card with the `gpt-4.1` fallback action (`provider-error-card.tsx` already handles the variant — no UI change needed).

Run: `pnpm --filter @houston/runtime test src/ai/provider-error.test.ts` → 42 tests pass, including the new verbatim-payload test.

## Tests
- New test: `Copilot 'not available for integrator' 400 → model_unavailable + gpt-4.1 fallback (HOU-977)` with the verbatim body from the bug report.
- Full `@houston/runtime` (848), `@houston/domain` (165), `@houston/host` suites green (one pre-existing flaky `store-sync/daemon.test.ts` timing failure under full parallel load; passes in isolation).

## Notes
The deeper follow-up (out of scope here): the model picker offers pi's full static Copilot catalog (29 models) regardless of plan. pi-ai already stores `availableModelIds` on the Copilot OAuth credential and has a `filterModels` hook, but the hosted picker rides the global gateway-catalog snapshot, so per-plan filtering needs client + gateway work.