### PR TITLE
fix(runtime): classify pi 0.82 'Provider is not configured' as no-credentials (HOU-956)

### DIFF
--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -91,6 +91,22 @@ test("runtime 'No provider connected' → unauthenticated / no_credentials", () 
   if (err.kind === "unauthenticated") expect(err.cause).toBe("no_credentials");
 });
 
+test("pi 0.82 'Provider is not configured' → unauthenticated / no_credentials (HOU-956)", () => {
+  // pi 0.82's ModelRuntime applyAuth message when its credential store
+  // resolves nothing for the model's provider. pi catches its own raise, so
+  // this arrives as an errored AssistantMessage on a turn pinned to a
+  // disconnected provider (pins are never auth-gated). Without the pattern it
+  // classified `unknown` — the generic error card instead of the reconnect
+  // card the pin design counts on.
+  const err = classifyProviderError({
+    provider: "google",
+    model: "gemini-3.5-flash",
+    message: "Provider is not configured: google",
+  });
+  expect(err.kind).toBe("unauthenticated");
+  if (err.kind === "unauthenticated") expect(err.cause).toBe("no_credentials");
+});
+
 test("pi prompt-time OAuth guard ('Authentication failed … Run /login') → unauthenticated / token_expired", () => {
   // pi's OAuth flavor of the same prompt-time guard.
   const err = classifyProviderError({

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -65,11 +65,22 @@ const INVALID_KEY_PATTERNS = [
  * these patterns that path degraded to `unknown` (generic error card, no
  * reconnect flow, no undelivered-prompt auto-resume) the moment the SECOND
  * message of a chat hit a disconnected local model.
+ *
+ * pi 0.82's ModelRuntime renamed the missing-credential failure: `applyAuth`
+ * now raises ModelsError("auth", "Provider is not configured: <id>") when its
+ * credential store resolves nothing for the model's provider — and pi catches
+ * that internally, so it ARRIVES as an errored AssistantMessage (the wire.ts
+ * turn_end path), unlike the older prompt-time raise. A turn pinned to a
+ * disconnected provider (pins are deliberately never auth-gated) hits exactly
+ * this; without the pattern it degraded to `unknown` — the generic error card
+ * instead of the reconnect card (HOU-956: "Provider is not configured:
+ * google" after a Gemini model was picked with no google key stored).
  */
 const NO_CREDENTIALS_PATTERNS = [
   "no api key found",
   "no provider connected",
   "no local model configured",
+  "provider is not configured",
 ];
 
 /**


### PR DESCRIPTION
Fixes HOU-956.

## Root cause

pi 0.82's ModelRuntime renamed the missing-credential failure. `applyAuth` now raises `ModelsError("auth", "Provider is not configured: <id>")` when its credential store resolves nothing for the model's provider, and pi catches that raise internally, so it arrives on the turn as an errored assistant message (`stopReason: "error"`). Older pi raised `"No API key found for <id>"` at prompt time, and that wording is what `classifyProviderError`'s `NO_CREDENTIALS_PATTERNS` knew.

A turn pinned to a disconnected provider (pins are deliberately never auth-gated — a disconnected pin is supposed to surface the reconnect card) therefore degraded to `kind: "unknown"`: the generic error card with the raw text `Provider is not configured: google` and the bug-report command `provider_error:unknown:google`, exactly what the user hit after picking a Gemini model with no google credential stored.

## Fix

Add `"provider is not configured"` to `NO_CREDENTIALS_PATTERNS` in `packages/runtime/src/ai/provider-error.ts`, so the message classifies as `unauthenticated` / `no_credentials` and renders the reconnect card (with credential-health marking and undelivered-prompt auto-resume on the thrown paths). One classifier feeds every route — the pi backend's `turn_end` errored-message path (`backends/pi/wire.ts`), plus the `exec-turn` / `turn-session` catches — so all of them are covered.

## Before (reproduce the bug)

1. On a build without this fix, make sure no `google` credential is stored (`auth.json` has no `google` entry).
2. Pin a conversation/turn to a Gemini model (provider `google`) — e.g. pick a Gemini model so the turn carries a `google` provider pin — and send a message.
3. The chat shows the generic error card with the raw text `Provider is not configured: google` (report command `provider_error:unknown:google`) instead of the reconnect card.

Unit-level: `classifyProviderError({provider: "google", model: "gemini-3.5-flash", message: "Provider is not configured: google"})` returns `{kind: "unknown", …}`.

## After (verify the fix)

1. Same setup, same turn: the chat now renders the typed reconnect card for Google Gemini (unauthenticated / no_credentials), and the prompt is carried as `undelivered_prompt` for auto-resume on the thrown paths.
2. `pnpm --filter @houston/runtime test` — includes the new case `pi 0.82 'Provider is not configured' → unauthenticated / no_credentials (HOU-956)` (848 tests pass).

## Tests

- `pnpm --filter @houston/runtime test` ✅ 848 passed (new regression test included)
- `pnpm --filter @houston/host test` ✅ (one unrelated flaky `store-sync/daemon.test.ts` watcher-timing failure in the full run; passes in isolation)
- `pnpm --filter @houston/domain test` ✅ 165 passed
- `pnpm check` (Biome) ✅ clean; full workspace typecheck ✅ via pre-commit