### PR TITLE
fix(integrations): fall back when Composio's advertised managed app is gone (HOU-1020)

### DIFF
--- a/packages/host/src/integrations/composio-auth-config.ts
+++ b/packages/host/src/integrations/composio-auth-config.ts
@@ -1,4 +1,4 @@
-import type { ComposioHttp } from "./composio-http";
+import { ComposioApiError, type ComposioHttp } from "./composio-http";
 import type { RawAuthConfig } from "./composio-wire";
 import { IntegrationUpstreamError } from "./types";
 
@@ -13,6 +13,13 @@ import { IntegrationUpstreamError } from "./types";
  *    just the container; the hosted connect link then asks the USER for their
  *    key (verified live — `connected_account_initiation.required` fields are
  *    collected on connect.composio.dev). Same Connect UX either way.
+ *
+ * The toolkit metadata is a CLAIM, not a guarantee: Composio can advertise
+ * managed auth for a toolkit whose managed OAuth app is expired or withdrawn
+ * (shopify, clockify — HOU-1020: creating the managed config 400s with
+ * "Missing required field Client id"). So candidate specs are tried in order —
+ * managed first, then the user-collectible scheme — and a 400 on the managed
+ * create falls through instead of surfacing as an opaque 502.
  *
  * The caller caches per process; a restart just re-resolves the same config.
  */
@@ -36,17 +43,26 @@ export async function resolveAuthConfig(
     return enabled.id;
   }
 
-  const created = await http.call<{ auth_config?: { id?: string } }>(
-    "/api/v3/auth_configs",
-    {
-      method: "POST",
-      body: {
-        toolkit: { slug: toolkit },
-        auth_config: await authConfigSpec(http, toolkit),
-      },
-    },
-  );
-  const id = created?.auth_config?.id;
+  const specs = await candidateSpecs(http, toolkit);
+  let id: string | undefined;
+  for (const [i, spec] of specs.entries()) {
+    try {
+      id = await createAuthConfig(http, toolkit, spec);
+      break;
+    } catch (err) {
+      // Only the MANAGED candidate's 400 is survivable — it means the
+      // advertised managed app does not actually exist. With a collectible
+      // scheme still on deck, fall through to it; without one the toolkit is
+      // OAuth-only, so name the operator remedy instead of relaying an opaque
+      // 400. Anything else — transient 5xx, a failed custom create — surfaces.
+      const managedRejected =
+        err instanceof ComposioApiError &&
+        err.status === 400 &&
+        spec.type === "use_composio_managed_auth";
+      if (!managedRejected) throw err;
+      if (i === specs.length - 1) throw oauthOnlyError(toolkit);
+    }
+  }
   if (!id) {
     throw new Error(
       `composio: creating auth config for '${toolkit}' returned no id`,
@@ -54,6 +70,21 @@ export async function resolveAuthConfig(
   }
   cache.set(toolkit, id);
   return id;
+}
+
+async function createAuthConfig(
+  http: ComposioHttp,
+  toolkit: string,
+  spec: Record<string, unknown>,
+): Promise<string | undefined> {
+  const created = await http.call<{ auth_config?: { id?: string } }>(
+    "/api/v3/auth_configs",
+    {
+      method: "POST",
+      body: { toolkit: { slug: toolkit }, auth_config: spec },
+    },
+  );
+  return created?.auth_config?.id;
 }
 
 interface RawToolkitDetail {
@@ -68,39 +99,55 @@ interface RawToolkitDetail {
  *  connect page, so only those are connectable fallbacks. */
 const OAUTH_MODES = new Set(["OAUTH1", "OAUTH1A", "OAUTH2"]);
 
-/** Managed auth when Composio offers it; else the toolkit's first scheme the
- *  hosted connect page can collect from the user (never bare custom OAuth).
- *  NO_AUTH is not a scheme either: Composio rejects auth configs for no-auth
- *  toolkits (Auth_Config_NoAuthApp), so a connect attempt on one — a stale
- *  catalog, an agent suggesting it — fails as a clean 400 the UI can show,
- *  not a 502. */
-async function authConfigSpec(
+function oauthOnlyError(toolkit: string): Error {
+  return new Error(
+    `composio: toolkit '${toolkit}' only offers OAuth and Composio has no managed app for it — register a developer OAuth app for it in the Composio dashboard, then connecting will reuse that auth config`,
+  );
+}
+
+/** The ordered auth-config specs worth attempting: managed auth when Composio
+ *  advertises it, then the toolkit's first scheme the hosted connect page can
+ *  collect from the user (never bare custom OAuth). NO_AUTH is not a scheme
+ *  either: Composio rejects auth configs for no-auth toolkits
+ *  (Auth_Config_NoAuthApp), so a connect attempt on one — a stale catalog, an
+ *  agent suggesting it — fails as a clean 400 the UI can show, not a 502. */
+async function candidateSpecs(
   http: ComposioHttp,
   toolkit: string,
-): Promise<Record<string, unknown>> {
+): Promise<Record<string, unknown>[]> {
   const detail = await http.call<RawToolkitDetail>(
     `/api/v3/toolkits/${encodeURIComponent(toolkit)}`,
   );
-  if ((detail?.composio_managed_auth_schemes ?? []).length > 0) {
-    return { type: "use_composio_managed_auth" };
-  }
   const modes = (detail?.auth_config_details ?? []).flatMap((d) =>
     d.mode ? [d.mode] : [],
   );
   const connectable = modes.filter((m) => m.toUpperCase() !== "NO_AUTH");
-  const scheme = connectable.find((m) => !OAUTH_MODES.has(m.toUpperCase()));
-  if (!scheme) {
-    if (modes.length > 0 && connectable.length === 0) {
-      throw new IntegrationUpstreamError(400, {
-        error: `${toolkit} does not need connecting; its tools work without an account`,
-        code: "toolkit_no_auth",
-      });
-    }
-    throw new Error(
-      connectable.length > 0
-        ? `composio: toolkit '${toolkit}' only offers OAuth and Composio has no managed app for it — register a developer OAuth app for it in the Composio dashboard, then connecting will reuse that auth config`
-        : `composio: toolkit '${toolkit}' offers no connectable auth scheme`,
-    );
+  const collectible = connectable.find(
+    (m) => !OAUTH_MODES.has(m.toUpperCase()),
+  );
+
+  const specs: Record<string, unknown>[] = [];
+  if ((detail?.composio_managed_auth_schemes ?? []).length > 0) {
+    specs.push({ type: "use_composio_managed_auth" });
   }
-  return { type: "use_custom_auth", authScheme: scheme, credentials: {} };
+  if (collectible) {
+    specs.push({
+      type: "use_custom_auth",
+      authScheme: collectible,
+      credentials: {},
+    });
+  }
+  if (specs.length > 0) return specs;
+
+  if (modes.length > 0 && connectable.length === 0) {
+    throw new IntegrationUpstreamError(400, {
+      error: `${toolkit} does not need connecting; its tools work without an account`,
+      code: "toolkit_no_auth",
+    });
+  }
+  throw connectable.length > 0
+    ? oauthOnlyError(toolkit)
+    : new Error(
+        `composio: toolkit '${toolkit}' offers no connectable auth scheme`,
+      );
 }

--- a/packages/host/src/integrations/composio-http.ts
+++ b/packages/host/src/integrations/composio-http.ts
@@ -12,6 +12,22 @@ export interface CallOpts {
   nullStatuses?: number[];
 }
 
+/**
+ * A non-2xx Composio reply. Carries the upstream status so callers can react
+ * to a specific rejection (auth-config fallback keys off a 400) without
+ * parsing the message; the message keeps the established
+ * `composio <METHOD> <path> → <status>: <detail>` shape end to end.
+ */
+export class ComposioApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ComposioApiError";
+  }
+}
+
 export class ComposioHttp {
   constructor(
     private readonly apiKey: string,
@@ -40,7 +56,8 @@ export class ComposioHttp {
     if (opts.nullStatuses?.includes(res.status)) return null;
     if (!res.ok) {
       const detail = await res.text().catch(() => "");
-      throw new Error(
+      throw new ComposioApiError(
+        res.status,
         `composio ${opts.method ?? "GET"} ${path} → ${res.status}${detail ? `: ${detail.slice(0, 300)}` : ""}`,
       );
     }

--- a/packages/host/src/integrations/composio.test.ts
+++ b/packages/host/src/integrations/composio.test.ts
@@ -293,6 +293,127 @@ test("connect skips bare custom OAuth and picks a user-collectible scheme (metaa
   expect(start.connectionId).toBe("ca_3");
 });
 
+test("connect falls back to a collectible scheme when the advertised managed app is gone (shopify)", async () => {
+  // HOU-1020: Composio's toolkit metadata still advertises managed OAuth for
+  // shopify/clockify, but the managed app is expired — the managed create
+  // 400s "Missing required field Client id". The connect must fall through to
+  // the toolkit's user-collectible scheme instead of dying as an opaque 502.
+  let authConfigPosts = 0;
+  const { provider, calls } = harness((url, method) => {
+    if (url.pathname === "/api/v3/auth_configs" && method === "GET") {
+      return { body: { items: [] } };
+    }
+    if (url.pathname === "/api/v3/toolkits/shopify") {
+      return {
+        body: {
+          composio_managed_auth_schemes: ["OAUTH2"],
+          auth_config_details: [{ mode: "OAUTH2" }, { mode: "API_KEY" }],
+        },
+      };
+    }
+    if (url.pathname === "/api/v3/auth_configs" && method === "POST") {
+      authConfigPosts += 1;
+      if (authConfigPosts === 1) {
+        return {
+          status: 400,
+          body: {
+            error: {
+              message:
+                'Missing required field "Client id" for auth scheme "OAUTH2" in toolkit "shopify" (Client id of the app)',
+              code: 301,
+              slug: "Auth_Config_ValidationError",
+              status: 400,
+            },
+          },
+        };
+      }
+      return { body: { auth_config: { id: "ac_shopify" } } };
+    }
+    if (url.pathname === "/api/v3.1/connected_accounts/link") {
+      return {
+        body: { redirect_url: "https://link", connected_account_id: "ca_4" },
+      };
+    }
+    return { status: 404 };
+  });
+
+  const start = await provider.connect(USER, "shopify");
+  const posts = calls.filter(
+    (c) => c.method === "POST" && c.path === "/api/v3/auth_configs",
+  );
+  expect(posts[0]?.body).toEqual({
+    toolkit: { slug: "shopify" },
+    auth_config: { type: "use_composio_managed_auth" },
+  });
+  expect(posts[1]?.body).toEqual({
+    toolkit: { slug: "shopify" },
+    auth_config: {
+      type: "use_custom_auth",
+      authScheme: "API_KEY",
+      credentials: {},
+    },
+  });
+  expect(start.connectionId).toBe("ca_4");
+});
+
+test("a gone managed app with no collectible fallback names the remedy, not the raw 400", async () => {
+  // Same lie in the metadata, but the toolkit is OAuth-only: nothing the user
+  // can self-serve, so the operator remedy surfaces instead of Composio's
+  // "Missing required field Client id" relayed as a 502.
+  const { provider } = harness((url, method) => {
+    if (url.pathname === "/api/v3/auth_configs" && method === "GET") {
+      return { body: { items: [] } };
+    }
+    if (url.pathname === "/api/v3/toolkits/ghostmanaged") {
+      return {
+        body: {
+          composio_managed_auth_schemes: ["OAUTH2"],
+          auth_config_details: [{ mode: "OAUTH2" }],
+        },
+      };
+    }
+    if (url.pathname === "/api/v3/auth_configs" && method === "POST") {
+      return {
+        status: 400,
+        body: { error: { slug: "Auth_Config_ValidationError" } },
+      };
+    }
+    return { status: 404 };
+  });
+  await expect(provider.connect(USER, "ghostmanaged")).rejects.toThrow(
+    /only offers OAuth.*Composio dashboard/,
+  );
+});
+
+test("a managed create that fails for a non-400 reason surfaces raw, no fallback", async () => {
+  // A transient 500 on the managed create is NOT evidence the managed app is
+  // gone — falling back would silently downgrade gmail-class toolkits to
+  // API-key entry on a Composio blip.
+  const { provider, calls } = harness((url, method) => {
+    if (url.pathname === "/api/v3/auth_configs" && method === "GET") {
+      return { body: { items: [] } };
+    }
+    if (url.pathname === "/api/v3/toolkits/gmail") {
+      return {
+        body: {
+          composio_managed_auth_schemes: ["OAUTH2"],
+          auth_config_details: [{ mode: "OAUTH2" }, { mode: "API_KEY" }],
+        },
+      };
+    }
+    if (url.pathname === "/api/v3/auth_configs" && method === "POST") {
+      return { status: 500, body: { error: "upstream hiccup" } };
+    }
+    return { status: 404 };
+  });
+  await expect(provider.connect(USER, "gmail")).rejects.toThrow(/→ 500/);
+  expect(
+    calls.filter(
+      (c) => c.method === "POST" && c.path === "/api/v3/auth_configs",
+    ),
+  ).toHaveLength(1);
+});
+
 test("connect refuses an OAuth-only toolkit with no managed app, naming the remedy", async () => {
   // OAuth-only + unmanaged: nothing the user can self-serve. The error names
   // the operator remedy (register a dev OAuth app in the Composio dashboard —


### PR DESCRIPTION
## Summary

HOU-1020 — two users could not connect Composio integrations: Shopify (Sentry event `7380d6fd05ef4ca0ac3bbe17ba6f6745`, 2026-07-29) and Clockify (4 events from a second user on 2026-07-28, e.g. `da3180fc`). Both died the same way:

```
composio POST /api/v3/auth_configs → 400:
  Missing required field "Client id" for auth scheme "OAUTH2" in toolkit "shopify"
```

**Root cause:** Composio's toolkit metadata still advertises managed OAuth (`composio_managed_auth_schemes: ["OAUTH2"]`) for toolkits whose managed OAuth app is expired/withdrawn (Composio's own docs for Shopify: "The default Shopify OAuth app may be under review or expired"). `resolveAuthConfig` trusted the metadata, sent `use_composio_managed_auth`, Composio 400'd, and the user saw the generic error toast behind an opaque 502. Both toolkits DO offer API_KEY, which the hosted connect page can collect from the user — the fallback path that already exists for honest metadata (the Meta Ads fix) but was never reached when the metadata lies.

## Fix

- `composio-auth-config.ts`: candidate specs are tried in order — managed when advertised, then the first user-collectible (non-OAuth) scheme. A **400 on the managed create specifically** falls through to the collectible scheme; with no collectible scheme the operator-remedy error surfaces ("register a developer OAuth app…") instead of the relayed 400. Non-400 failures and custom-create failures surface raw, so a Composio blip can never silently downgrade gmail-class toolkits to API-key entry.
- `composio-http.ts`: non-2xx replies now throw a typed `ComposioApiError` carrying the upstream status (message shape unchanged), so the fallback keys off the status instead of parsing message strings.

## Tests

3 new vitest cases in `composio.test.ts`: the shopify managed→API_KEY fallback (with Composio's real 400 body), the OAuth-only ghost-managed remedy error, and the 500-no-fallback guard. Full host suite: 1091 passed. `pnpm check` and `pnpm typecheck` clean.

## Repro (before)

1. In a build pointing at Composio directly (self-host with `COMPOSIO_API_KEY`, or desktop direct mode), open Integrations and click Connect on **Shopify** or **Clockify**.
2. Red generic toast; engine log shows `composio POST /api/v3/auth_configs → 400: … Missing required field "Client id"`.

## Verify (after)

1. Same steps: Connect on Shopify or Clockify now opens the hosted Composio connect page asking for the API key/credentials.
2. Engine log shows two auth-config POSTs: the managed 400 followed by the successful `use_custom_auth` create.
3. Managed toolkits (Gmail, Slack) still connect via Composio's OAuth app, one POST only.

Note: the hosted-cloud path goes through the gateway, which ports this same logic; the twin fix ships there separately.