### PR TITLE
fix(auth): stop Codex sign-in retries from colliding with Houston's own 1455 listeners (HOU-1040)

### DIFF
--- a/app/src-tauri/src/codex_oauth_loopback.rs
+++ b/app/src-tauri/src/codex_oauth_loopback.rs
@@ -12,10 +12,12 @@
 //! runs in JS exactly as it does for the browser relay. Then we serve a small
 //! "you're connected" page, pull the app window to the front, and shut down.
 
+use std::sync::Mutex;
 use std::time::Duration;
 
 use tauri::{AppHandle, Emitter};
 use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
 
 use crate::loopback_util::{read_request_target, split_target, write_response};
 
@@ -35,25 +37,34 @@ const CALLBACK_EVENT: &str = "codex-oauth://callback";
 /// `start_codex_oauth_loopback` again for a fresh attempt.
 const LISTEN_TIMEOUT: Duration = Duration::from_secs(300);
 
-/// Start a one-shot loopback listener on the fixed Codex redirect port. The
+/// The live listener task, if any. A retry click within the previous attempt's
+/// 5-minute window used to find port 1455 still held by our OWN one-shot
+/// listener and fail with "close whatever is using it" (Sentry issue
+/// 7639120568) — the abandoned listener had no teardown short of its timeout.
+/// A new start now aborts the previous task (dropping its socket) and rebinds,
+/// so the latest click always gets a fresh listener and a fresh window.
+static ACTIVE_LISTENER: Mutex<Option<JoinHandle<()>>> = Mutex::new(None);
+
+/// How long to keep retrying the bind while an aborted predecessor's socket is
+/// being dropped by the runtime. A genuinely foreign squatter (a real Codex
+/// CLI mid-login) still errors, just ~half a second later.
+const BIND_RETRIES: u32 = 20;
+const BIND_RETRY_DELAY: Duration = Duration::from_millis(25);
+
+/// Start a one-shot loopback listener on the fixed Codex redirect port,
+/// replacing any listener a previous (abandoned) attempt left running. The
 /// listener runs in a background task and shuts itself down after the first
-/// callback (or the timeout). Returns `Err` immediately if the port can't be
-/// bound so the frontend can toast the reason.
+/// callback (or the timeout). Returns `Err` if the port is held by another
+/// process so the frontend can toast the reason.
 #[tauri::command(rename_all = "snake_case")]
 pub async fn start_codex_oauth_loopback(app: AppHandle) -> Result<(), String> {
-    let listener = TcpListener::bind(("127.0.0.1", CODEX_PORT))
-        .await
-        .map_err(|e| {
-            format!(
-                "Could not start the Codex sign-in listener: port {CODEX_PORT} is unavailable ({e}). \
-                 OpenAI requires this exact port, so close whatever is using it and try again."
-            )
-        })?;
+    abort_active_listener();
+    let listener = bind_codex_port(CODEX_PORT).await?;
     tracing::info!(
         "[codex-oauth-loopback] listening on http://127.0.0.1:{CODEX_PORT}{CALLBACK_PATH}"
     );
 
-    tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         match tokio::time::timeout(LISTEN_TIMEOUT, serve_callback(&listener, &app)).await {
             Ok(Ok(())) => {}
             // The listener is a background task: the command already returned,
@@ -67,8 +78,40 @@ pub async fn start_codex_oauth_loopback(app: AppHandle) -> Result<(), String> {
             ),
         }
     });
+    *ACTIVE_LISTENER.lock().unwrap() = Some(handle);
 
     Ok(())
+}
+
+/// Abort the previous attempt's listener task, if one is still running.
+/// Aborting a task that already finished (callback served / timed out) is a
+/// no-op, so this needs no liveness check.
+fn abort_active_listener() {
+    if let Some(prev) = ACTIVE_LISTENER.lock().unwrap().take() {
+        prev.abort();
+    }
+}
+
+/// Bind the fixed redirect port, absorbing the short window in which an
+/// aborted predecessor's socket is still being torn down. Every retry
+/// exhausted means a foreign process owns the port for real.
+async fn bind_codex_port(port: u16) -> Result<TcpListener, String> {
+    let mut last_err = None;
+    for attempt in 0..BIND_RETRIES {
+        if attempt > 0 {
+            tokio::time::sleep(BIND_RETRY_DELAY).await;
+        }
+        match TcpListener::bind(("127.0.0.1", port)).await {
+            Ok(listener) => return Ok(listener),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    let e = last_err.expect("BIND_RETRIES > 0 guarantees an error was recorded");
+    Err(format!(
+        "Could not start the Codex sign-in listener: port {port} is unavailable ({e}). \
+         OpenAI requires this exact port, so close other AI coding tools \
+         (or wait a few minutes) and try again."
+    ))
 }
 
 /// Accept connections until one hits the callback path, then handle it and
@@ -175,5 +218,40 @@ mod tests {
         // The loopback serves only this one page, so nothing may be fetched.
         assert!(!SUCCESS_PAGE.contains("<img"));
         assert!(!SUCCESS_PAGE.contains("src="));
+    }
+
+    #[tokio::test]
+    async fn bind_fails_with_actionable_error_when_a_foreign_process_holds_the_port() {
+        // A real squatter (e.g. an actual Codex CLI mid-login) never releases
+        // the port, so the retry loop must exhaust and surface the remedy.
+        // Ephemeral port: tests must never touch the real 1455.
+        let squatter = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = squatter.local_addr().unwrap().port();
+
+        let err = bind_codex_port(port).await.unwrap_err();
+        assert!(err.contains("close other AI coding tools"), "err: {err}");
+        assert!(err.contains(&port.to_string()), "err: {err}");
+    }
+
+    #[tokio::test]
+    async fn bind_succeeds_after_the_previous_listener_task_is_aborted() {
+        // The Sentry-7639120568 shape: a prior sign-in attempt's one-shot
+        // listener still owns the port when the user retries. Aborting the old
+        // task and rebinding must succeed within the retry window — the abort
+        // drops the socket asynchronously, which is exactly the latency the
+        // bind retries exist to absorb.
+        let holder = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = holder.local_addr().unwrap().port();
+        let task = tokio::spawn(async move {
+            // Hold the socket like an abandoned serve_callback would.
+            let _ = holder.accept().await;
+        });
+
+        // Sanity: while the task lives, the port really is taken.
+        assert!(TcpListener::bind(("127.0.0.1", port)).await.is_err());
+
+        task.abort();
+        let rebound = bind_codex_port(port).await.expect("rebind after abort");
+        assert_eq!(rebound.local_addr().unwrap().port(), port);
     }
 }

--- a/packages/runtime/src/auth/login.test.ts
+++ b/packages/runtime/src/auth/login.test.ts
@@ -98,6 +98,37 @@ test("openai-codex browser login preflights the callback port and fails fast whe
   }
 });
 
+test("a retry click during an in-flight codex browser login reuses the flow instead of reporting its own port busy", async () => {
+  // pi binds 1455 the moment the browser flow starts. The preflight used to run
+  // BEFORE the idempotent reuse check, so a second connect click (user's
+  // browser tab hung / opened behind the window) tripped over Houston's OWN
+  // callback server: "Another app on this computer is using the sign-in port"
+  // on every retry for the whole 10-min abandonment window (Sentry issue
+  // 7639120568). Reuse must win: same info back, no error, pi invoked once.
+  const pi: { server: Server | null } = { server: null };
+  const piLogin = stubPiLogin(async (interaction) => {
+    // Simulate pi's in-process callback server holding the fixed port.
+    pi.server = await occupyCodexCallbackPort();
+    interaction.notify({ type: "auth_url", url: "https://auth.example/codex" });
+    return new Promise<never>(() => {});
+  });
+  try {
+    const first = await startLogin("openai-codex", false);
+    expect(first.kind).toBe("url");
+
+    // The retry click, with 1455 held by our own in-flight flow.
+    const second = await startLogin("openai-codex", false);
+    expect(second).toBe(first);
+    expect(piLogin.oauthLogin).toHaveBeenCalledTimes(1);
+  } finally {
+    cancelLogin("openai-codex");
+    await new Promise((r) => setTimeout(r, 50));
+    piLogin.mockRestore();
+    const server = pi.server;
+    if (server) await new Promise<void>((r) => server.close(() => r()));
+  }
+});
+
 test("openai-codex device-code login does NOT preflight the callback port", async () => {
   // The device-code flow (deviceAuth:true) binds no loopback server, so a
   // squatter on 1455 must not block it: it goes straight to pi.

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -262,22 +262,11 @@ export async function startLogin(
     throw new Error(`${providerId} does not use OAuth sign-in`);
   const provider = providerId;
 
-  // The OpenAI/Codex browser (loopback) login makes pi bind a FIXED loopback
-  // callback port (1455) in-process — and pi swallows an EADDRINUSE, stranding
-  // the flow (a browser opens, the user approves, the redirect lands on whoever
-  // holds the port, and Houston spins the whole 10-min window). Probe that exact
-  // port FIRST so a real Codex CLI / stray login becomes an instant, actionable
-  // error before any browser opens. Throwing here — BEFORE any state is added to
-  // `active` or the expiry armed — leaves the slot free for an immediate retry.
-  // The device-code path (deviceAuth) and every other provider bind nothing.
-  if (
-    provider === "openai-codex" &&
-    codexLoginMethod({ deviceAuth }) === OPENAI_CODEX_BROWSER_LOGIN_METHOD
-  ) {
-    await preflightCodexCallbackPort();
-  }
-
-  // Idempotent: reuse an in-flight login (Anthropic's loopback only binds once).
+  // Idempotent: reuse an in-flight login. This must run BEFORE the port
+  // preflight below: an in-flight Codex browser login is ITSELF holding the
+  // fixed callback port (pi's in-process server), so probing first would
+  // mistake our own flow for a squatter and turn every retry click into
+  // "Another app is using the sign-in port" for the whole abandonment window.
   const existing = active.get(provider);
   if (
     existing &&
@@ -287,6 +276,22 @@ export async function startLogin(
     // A fresh connect click deserves the full abandonment window.
     armLoginExpiry(provider, existing);
     return existing.info;
+  }
+
+  // The OpenAI/Codex browser (loopback) login makes pi bind a FIXED loopback
+  // callback port (1455) in-process — and pi swallows an EADDRINUSE, stranding
+  // the flow (a browser opens, the user approves, the redirect lands on whoever
+  // holds the port, and Houston spins the whole 10-min window). With no reusable
+  // flow of our own, probe that exact port so a real Codex CLI / stray login
+  // becomes an instant, actionable error before any browser opens. Throwing
+  // here — BEFORE any state is added to `active` or the expiry armed — leaves
+  // the slot free for an immediate retry. The device-code path (deviceAuth)
+  // and every other provider bind nothing.
+  if (
+    provider === "openai-codex" &&
+    codexLoginMethod({ deviceAuth }) === OPENAI_CODEX_BROWSER_LOGIN_METHOD
+  ) {
+    await preflightCodexCallbackPort();
   }
 
   const state: LoginState = {


### PR DESCRIPTION
## Problem

[Sentry issue 7639120568](https://houston-cd.sentry.io/issues/7639120568/?project=4511452472541184) — `codex_loopback_login: Could not start the Codex sign-in listener: port 1455 is unavailable (os error 48)`, 4 users / 9 events in one day. Users see "Couldn't open OpenAI sign-in — Another app on this computer is using the sign-in port. Close other AI coding tools and try again." on every retry, even after closing everything and rebooting.

Root cause: **both** port-1455 listeners involved in the Codex browser flow wedge themselves against the user's *own* retry clicks. No other app is involved:

1. **Runtime** (`packages/runtime/src/auth/login.ts`): `startLogin` ran `preflightCodexCallbackPort()` *before* the idempotent reuse-in-flight check. pi binds 1455 the moment the browser flow starts, so a second connect click probed the port Houston itself was holding and threw the port-busy error — the reuse path was unreachable for the Codex browser flow, for the whole 10-minute abandonment window.
2. **Desktop shell** (`app/src-tauri/src/codex_oauth_loopback.rs`, the remote-engine relay): the one-shot listener has no teardown short of its 5-minute timeout, so any retry within that window failed the bind with "close whatever is using it" — the exact Sentry error.

The typical trigger: OpenAI's auth page hangs or opens behind the window, the user clicks connect again, and every subsequent attempt fails until the timeouts lapse. Restarting doesn't help because the first click after restart re-wedges both.

## Fix

- **Runtime**: the reuse check now runs first — a retry click re-arms the abandonment clock and returns the in-flight login's info (re-opening the auth URL) instead of tripping over pi's own callback server. The preflight still runs before any *new* flow, so a genuine external squatter (a real Codex CLI mid-login) still fails fast with the actionable message.
- **Shell**: `start_codex_oauth_loopback` now aborts the previous listener task and rebinds, with short bind retries to absorb the aborted socket's async teardown. The latest click always gets a fresh listener and a fresh 5-minute window. A genuinely foreign squatter still errors (~0.5s later), and the message now adds "(or wait a few minutes)" so users aren't sent hunting for phantom apps.

## Tests

- `login.test.ts`: new test — retry during an in-flight Codex browser login (with 1455 genuinely held, as pi would) returns the same login info, no port-busy error, pi invoked once. Fails on `main` with `CodexCallbackPortInUseError`.
- `codex_oauth_loopback.rs`: new tokio tests (ephemeral ports) — bind succeeds after the previous listener task is aborted; a persistent foreign holder still errors with the actionable message.
- Full suites green: runtime vitest 852/852, `cargo test` 187/187, Biome clean, workspace typecheck clean.

## Deployment notes

- Hosted users hit the *runtime* half in their engine pod → fixed by the next engine roll, no desktop release needed for that part.
- The *shell* half needs a desktop release to reach users.