### PR TITLE
fix(chat): suggestion pill click prefills the composer instead of sending (HOU-1050)

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -1450,8 +1450,14 @@ export function useAgentChatPanel({
                   void clearPersistedInteraction();
                 }}
                 onSelect={(action) => {
-                  setDismissedSuggestActions(actions.step.id);
-                  sendInteractionMessage(action.message);
+                  // HOU-1050: a pill click PREFILLS the composer instead of
+                  // sending, so the user can edit the prompt (or pick another
+                  // pill — each click replaces the draft) before deciding to
+                  // send. The pills stay up until the actual send abandons the
+                  // interaction (onComposerSubmit) or the X dismisses it.
+                  useDraftStore
+                    .getState()
+                    .setDraftText(draftKey, action.message);
                 }}
               />
             ) : null}
@@ -1733,6 +1739,7 @@ export function useAgentChatPanel({
     saveReusable,
     interactionLabels,
     sendInteractionMessage,
+    draftKey,
     clearPersistedInteraction,
     dismissActiveInteraction,
     resolveBrand,

--- a/packages/web/e2e/suggest-actions.spec.ts
+++ b/packages/web/e2e/suggest-actions.spec.ts
@@ -12,7 +12,7 @@ async function startMission(page: import("@playwright/test").Page) {
   });
 }
 
-test("suggested action pills stay above the composer, send visibly, and dismiss", async ({
+test("suggested action pills prefill the composer, send on confirm, and dismiss", async ({
   page,
   request,
 }) => {
@@ -50,12 +50,30 @@ test("suggested action pills stay above the composer, send visibly, and dismiss"
       .getByText("prepare the update")
       .first(),
   ).toBeVisible();
-  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
+  const followUp = page.getByPlaceholder("Send a follow-up...");
+  await expect(followUp).toBeVisible();
+  // HOU-1050: a pill click prefills the composer instead of sending, and the
+  // pills stay up so the user can still pick a different one (each click
+  // replaces the draft).
   await page.getByRole("button", { name: "Draft an email" }).click();
+  await expect(followUp).toHaveValue("Draft the email.");
+  await expect(
+    page.locator(".is-user").filter({ hasText: "Draft the email." }),
+  ).toHaveCount(0);
+  await page.getByRole("button", { name: "Share update" }).click();
+  await expect(followUp).toHaveValue("Share the update.");
+  await page.getByRole("button", { name: "Draft an email" }).click();
+  await expect(followUp).toHaveValue("Draft the email.");
+  // Confirming with Enter runs the normal composer send and retires the pills.
+  await followUp.press("Enter");
   await expect(
     page.locator(".is-user").filter({ hasText: "Draft the email." }),
   ).toBeVisible();
-  // Wait for the pill-click turn to fully settle BEFORE staging the next offer:
+  await expect(
+    page.getByRole("button", { name: "Share update", exact: true }),
+  ).toHaveCount(0);
+  // Wait for the prefilled send's turn to fully settle BEFORE staging the next
+  // offer:
   // staging while that turn is still open races it onto the wrong done frame,
   // where the upcoming composer send would abandon it.
   await expect(


### PR DESCRIPTION
## Summary

HOU-1050: clicking a suggested-action pill in the chat composer sent `action.message` immediately (`sendInteractionMessage` in `use-agent-chat-panel.tsx`), giving the user no chance to review or edit the prompt.

The click now writes `action.message` into the composer draft store (`useDraftStore.setDraftText`, the same path dictation uses), so the text lands in the chat input and the user decides whether to modify it or send it.

Behavior details:
- Each pill click **replaces** the draft, so the user can compare suggestions by clicking between them.
- The pills stay visible after a click; they retire through the existing paths — the real composer send abandons the interaction (`onComposerSubmit`), or the X dismisses it.
- App-side change only; `ui/` stays presentational (no library or protocol changes).

## Testing

- Updated `packages/web/e2e/suggest-actions.spec.ts` to assert the new behavior: click fills the input without producing a user bubble, a second click replaces the draft, Enter sends and retires the pills. Passes locally.
- `cd app && pnpm test` (2438 node:test pass), `pnpm tsgo --noEmit` in app and all workspaces, `pnpm --filter houston-web typecheck` + `typecheck:e2e`, `pnpm check` (Biome clean).

## Verify

**Before the fix (reproduce):** start a mission that ends with suggested-action pills above the composer; clicking a pill immediately sends the suggestion as a user message.

**After the fix:** clicking a pill puts the suggestion text into the chat input (nothing is sent); edit it or press Enter/send to submit, after which the pills disappear.