### PR TITLE
fix(chat): keep the mission log live when tools follow streamed narration (HOU-1047)

### DIFF
--- a/app/src/components/use-chat-display-labels.tsx
+++ b/app/src/components/use-chat-display-labels.tsx
@@ -13,13 +13,23 @@ export function useChatDisplayLabels(): Pick<
   // tense label the process header shows as a branded row; ui/chat calls it
   // through `processLabels.resolveActionBrand`, staying Composio-unaware.
   const resolveActionBrand = useActionBrandResolver();
+  // The same astronaut deck the pre-reply indicator plays. Passed into
+  // processLabels too so the ACTIVE mission-log header keeps the personality
+  // through mid-turn reasoning gaps — the standalone indicator below is
+  // suppressed the whole time an active log trails (HOU-471/HOU-1047), so
+  // without this the header held the last tool's stale verb.
+  const loadingPhrases = useMemo(
+    () => t("loadingPhrases", { returnObjects: true }) as string[],
+    [t],
+  );
   const processLabels = useMemo(
     () => ({
       active: t("process.active"),
       complete: t("process.complete"),
+      phrases: loadingPhrases,
       resolveActionBrand,
     }),
-    [t, resolveActionBrand],
+    [t, loadingPhrases, resolveActionBrand],
   );
   const getThinkingMessage = useCallback<
     NonNullable<ChatPanelProps["getThinkingMessage"]>
@@ -39,13 +49,10 @@ export function useChatDisplayLabels(): Pick<
   // produces any output (the message is still being sent / queued), the
   // indicator is the pulsing Houston helmet beside a rotating astronaut
   // one-liner (localized copy passed in; ui/chat handles the shuffle + timer).
-  // The moment the agent is actually working (thinking or running tools) an
-  // active mission-log header is on screen reading "Thinking..." or the current
-  // step, and that line is the ONLY indicator: ChatMessages suppresses this one.
-  const loadingPhrases = useMemo(
-    () => t("loadingPhrases", { returnObjects: true }) as string[],
-    [t],
-  );
+  // The moment the agent is actually working an active mission-log header is
+  // on screen — the current step's verb, or this same phrase deck during
+  // reasoning gaps — and that line is the ONLY indicator: ChatMessages
+  // suppresses this one.
   const thinkingIndicator = useMemo(
     () => <ChatThinkingIndicator phrases={loadingPhrases} />,
     [loadingPhrases],

--- a/ui/chat/src/chat-process-block.tsx
+++ b/ui/chat/src/chat-process-block.tsx
@@ -22,6 +22,7 @@ import type { ChatProcessLabels } from "./chat-process-header";
 import { buildProcessHeader } from "./chat-process-header";
 import { ChatStatusLine } from "./chat-status-line";
 import { getMappedToolIcon } from "./tool-formatters";
+import { useRotatingPhrase } from "./use-rotating-phrase";
 
 export type { ChatActionBrand, ChatProcessLabels } from "./chat-process-header";
 
@@ -53,11 +54,20 @@ export function ChatProcessBlock({
   // The single trigger line. While active it surfaces only the one in-progress
   // action: a per-tool icon + the verb ("Reading file"), upgraded to the app
   // logo + "Gmail · Sending email" when the current tool is an integration the
-  // app resolves, or the helmet + "Thinking..." before the first tool runs;
-  // settled it reads the helmet + "Mission log". Never a count of tool calls.
+  // app resolves, or the helmet + the rotating astronaut phrases (falling back
+  // to "Thinking...") while nothing is visibly executing; settled it reads the
+  // helmet + "Mission log". Never a count of tool calls.
   const header = useMemo(
     () => buildProcessHeader({ isActive, segments, labels, toolLabels }),
     [isActive, segments, labels, toolLabels],
+  );
+
+  // The astronaut deck for the active header's reasoning gaps (the `phrase`
+  // header kind). Keyed off `isActive` rather than the current kind so ONE
+  // deck runs for the life of the active block — a quick tool flashing its
+  // verb in between doesn't reshuffle and restart the rotation.
+  const rotatingPhrase = useRotatingPhrase(
+    isActive ? labels?.phrases : undefined,
   );
 
   // Once the user opens the (now closed-by-default) pane during an active run,
@@ -83,6 +93,8 @@ export function ChatProcessBlock({
             icon={renderToolIcon(header.toolName)}
             label={header.label}
           />
+        ) : header.kind === "phrase" ? (
+          <ChatStatusLine active label={rotatingPhrase || header.fallback} />
         ) : (
           <ChatStatusLine label={header.label} active={isActive} />
         )}

--- a/ui/chat/src/chat-process-header.ts
+++ b/ui/chat/src/chat-process-header.ts
@@ -35,6 +35,18 @@ export interface ChatProcessLabels {
   /** Settled label once the mission ends and the log collapses. e.g. "Mission log". */
   complete?: string;
   /**
+   * The rotating astronaut one-liners (the localized HOU-910 deck) for the
+   * active header while nothing is visibly executing: before the first tool
+   * runs, and in the reasoning gaps after a tool finishes. Restores the
+   * personality the standalone pre-reply indicator carries — that indicator is
+   * suppressed the whole time an active log trails (HOU-471), so without this
+   * the header held the last tool's stale verb through every gap. While a tool
+   * IS running (no result yet) the concrete verb/brand still wins. Absent →
+   * the pre-existing behavior: hold the latest verb (HOU-448), static `active`
+   * label before the first tool.
+   */
+  phrases?: string[];
+  /**
    * Resolves a Composio action slug (e.g. `GMAIL_SEND_EMAIL`) to the app's
    * presentational brand for the branded header row. App-supplied (the catalog
    * lives app-side); returns `undefined` when the current tool isn't a
@@ -125,6 +137,9 @@ export function buildProcessHeaderLabel(opts: {
 export type ProcessHeader =
   | { kind: "brand"; brand: ChatActionBrand }
   | { kind: "tool"; label: string; toolName: string }
+  /** Play the rotating phrase deck; `fallback` covers the frame before the
+   *  deck's first draw (the component owns the rotation state). */
+  | { kind: "phrase"; fallback: string }
   | { kind: "text"; label: string };
 
 export function buildProcessHeader(opts: {
@@ -136,7 +151,12 @@ export function buildProcessHeader(opts: {
   const { isActive, segments, labels } = opts;
   if (isActive) {
     const tool = getCurrentActionTool(segments);
-    if (tool) {
+    const hasPhrases = (labels?.phrases?.length ?? 0) > 0;
+    // Tools run serially, so the latest tool is executing iff it has no
+    // result yet. A finished one means the model is reasoning/writing — with
+    // a phrase deck available that gap plays the deck instead of holding the
+    // stale verb (without one, the sticky-verb behavior stands, HOU-448).
+    if (tool && !(hasPhrases && tool.result)) {
       if (labels?.resolveActionBrand) {
         const action = integrationActionOf(tool);
         if (action) {
@@ -149,6 +169,9 @@ export function buildProcessHeader(opts: {
         label: buildProcessHeaderLabel(opts),
         toolName: tool.name,
       };
+    }
+    if (hasPhrases) {
+      return { kind: "phrase", fallback: labels?.active ?? DEFAULTS.active };
     }
   }
   return { kind: "text", label: buildProcessHeaderLabel(opts) };

--- a/ui/chat/src/chat-thinking-indicator.tsx
+++ b/ui/chat/src/chat-thinking-indicator.tsx
@@ -2,16 +2,8 @@
 
 import { HoustonHelmet } from "@houston-ai/core";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { useEffect, useState } from "react";
-import {
-  advanceDeck,
-  createDeck,
-  currentPhrase,
-  DEFAULT_THINKING_PHRASES,
-} from "./thinking-phrases";
-
-/** How long each one-liner stays before the next rotates in. */
-const ROTATE_MS = 4000;
+import { DEFAULT_THINKING_PHRASES } from "./thinking-phrases";
+import { useRotatingPhrase } from "./use-rotating-phrase";
 
 export interface ChatThinkingIndicatorProps {
   /** The rotating one-liners. Defaults to a small English set so ui/chat works
@@ -32,21 +24,7 @@ export function ChatThinkingIndicator({
   phrases = DEFAULT_THINKING_PHRASES,
 }: ChatThinkingIndicatorProps) {
   const reduceMotion = useReducedMotion();
-  const [phrase, setPhrase] = useState("");
-
-  useEffect(() => {
-    if (phrases.length === 0) {
-      setPhrase("");
-      return;
-    }
-    let deck = createDeck(phrases, Math.random);
-    setPhrase(currentPhrase(deck));
-    const id = window.setInterval(() => {
-      deck = advanceDeck(deck, Math.random);
-      setPhrase(currentPhrase(deck));
-    }, ROTATE_MS);
-    return () => window.clearInterval(id);
-  }, [phrases]);
+  const phrase = useRotatingPhrase(phrases);
 
   return (
     <div className="flex items-center gap-2 py-1 text-ink-muted">

--- a/ui/chat/src/feed-to-messages.ts
+++ b/ui/chat/src/feed-to-messages.ts
@@ -203,6 +203,18 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
       }
 
       case "tool_call": {
+        // HOU-1047: some providers (OpenAI's style especially) narrate BEFORE
+        // running tools, so streamed text keeps the current message open when
+        // the first tool_call arrives. Without a flush the tool fused into the
+        // text message, the grouping layer rendered its mission log INACTIVE
+        // above the text, and the chat bottom showed only the generic loading
+        // indicator while the agent worked. Mirror the thinking case: a tool
+        // call after visible content starts a fresh process-only message, so
+        // the trailing mission log stays live at the bottom of the chat.
+        const prev = getCur();
+        if (prev && prev.from === "assistant" && prev.content) {
+          flush();
+        }
         const msg = ensureAssistant(item);
         // Deduplicate: the parser emits two tool_calls per tool (null input
         // on block start, real input on block stop). Replace the placeholder.

--- a/ui/chat/src/use-rotating-phrase.ts
+++ b/ui/chat/src/use-rotating-phrase.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import { advanceDeck, createDeck, currentPhrase } from "./thinking-phrases";
+
+/** How long each one-liner stays before the next rotates in. */
+export const PHRASE_ROTATE_MS = 4000;
+
+/**
+ * The astronaut phrase rotation (HOU-910), lifted out of
+ * `ChatThinkingIndicator` so the active mission-log header can play the same
+ * deck. Phrases play from a shuffled deck (no repeats until it exhausts, then
+ * a reshuffle that avoids an immediate repeat), advancing every ~4s while
+ * `phrases` stays set. The shuffle and timer live in the effect, never in
+ * render. Pass `undefined` (or an empty list) to idle the deck — the hook
+ * returns `""` and runs no timer, so a caller can key it off an active flag
+ * and keep one continuously-running deck across brief non-phrase stretches.
+ */
+export function useRotatingPhrase(phrases: string[] | undefined): string {
+  const [phrase, setPhrase] = useState("");
+
+  useEffect(() => {
+    if (!phrases || phrases.length === 0) {
+      setPhrase("");
+      return;
+    }
+    let deck = createDeck(phrases, Math.random);
+    setPhrase(currentPhrase(deck));
+    const id = window.setInterval(() => {
+      deck = advanceDeck(deck, Math.random);
+      setPhrase(currentPhrase(deck));
+    }, PHRASE_ROTATE_MS);
+    return () => window.clearInterval(id);
+  }, [phrases]);
+
+  return phrase;
+}

--- a/ui/chat/tests/chat-process-header.test.ts
+++ b/ui/chat/tests/chat-process-header.test.ts
@@ -304,6 +304,93 @@ describe("buildProcessHeader", () => {
     );
   });
 
+  // HOU-1047 follow-up: with the astronaut deck available, the active header
+  // plays it whenever nothing is visibly executing — before the first tool and
+  // in the gaps after a tool finishes. A running tool's verb/brand still wins,
+  // and WITHOUT a deck the sticky-verb behavior (HOU-448) is unchanged.
+  describe("with rotating phrases", () => {
+    const labels = { phrases: ["Braving the meteor shower..."] };
+
+    it("plays the deck before any tool runs", () => {
+      deepStrictEqual(
+        buildProcessHeader({ isActive: true, segments: [seg([])], labels }),
+        { kind: "phrase", fallback: "Thinking..." },
+      );
+    });
+
+    it("still names a RUNNING tool (no result yet)", () => {
+      deepStrictEqual(
+        buildProcessHeader({
+          isActive: true,
+          segments: [seg([{ name: "Read" }])],
+          labels,
+        }),
+        { kind: "tool", label: "Reading file", toolName: "Read" },
+      );
+    });
+
+    it("plays the deck once the latest tool has finished (reasoning gap)", () => {
+      deepStrictEqual(
+        buildProcessHeader({
+          isActive: true,
+          segments: [seg([{ name: "Read", result: RESULT }])],
+          labels,
+        }),
+        { kind: "phrase", fallback: "Thinking..." },
+      );
+    });
+
+    it("carries the localized active label as the deck's fallback", () => {
+      deepStrictEqual(
+        buildProcessHeader({
+          isActive: true,
+          segments: [seg([])],
+          labels: { ...labels, active: "Pensando..." },
+        }),
+        { kind: "phrase", fallback: "Pensando..." },
+      );
+    });
+
+    it("still brands a RUNNING integration_execute", () => {
+      deepStrictEqual(
+        buildProcessHeader({
+          isActive: true,
+          segments: [
+            seg([
+              {
+                name: "integration_execute",
+                input: { action: "GMAIL_SEND_EMAIL" },
+              },
+            ]),
+          ],
+          labels: { ...labels, resolveActionBrand },
+        }),
+        { kind: "brand", brand },
+      );
+    });
+
+    it("keeps the sticky verb when NO deck is provided (HOU-448 unchanged)", () => {
+      deepStrictEqual(
+        buildProcessHeader({
+          isActive: true,
+          segments: [seg([{ name: "Read", result: RESULT }])],
+        }),
+        { kind: "tool", label: "Reading file", toolName: "Read" },
+      );
+    });
+
+    it("settles to the plain Mission log label, never a phrase", () => {
+      deepStrictEqual(
+        buildProcessHeader({
+          isActive: false,
+          segments: [seg([{ name: "Read", result: RESULT }])],
+          labels,
+        }),
+        { kind: "text", label: "Mission log" },
+      );
+    });
+  });
+
   it("stays plain text when settled (never branded), and a tool row with no resolver", () => {
     const segments = [
       seg([

--- a/ui/chat/tests/feed-to-messages.test.ts
+++ b/ui/chat/tests/feed-to-messages.test.ts
@@ -90,6 +90,74 @@ describe("tool_call after streamed narration (HOU-1047)", () => {
     strictEqual(earlyKey, laterKey);
   });
 
+  it("keeps the same process key when the turn settles (no remount/jump)", () => {
+    // Production symptom #2: at settle the final assistant_text finalizes the
+    // text entry (positioned before the tools), which used to re-group the
+    // tools into their own message for the first time — the log teleported
+    // from above the text to a "new" block below it. With the split applied
+    // live, the trailing block exists during the run and must settle in place:
+    // same key, active -> inactive, no remount.
+    const live = getChatDisplayItems(feedItemsToMessages(feed), "submitted");
+    const settledFeed = [
+      user("connect to anakin"),
+      finalText("Let me connect to anakin.io for you."),
+      ...feed.slice(2),
+      {
+        feed_type: "final_result",
+        data: { result: "", cost_usd: null, duration_ms: null, usage: null },
+        id: "fr1",
+      } satisfies FeedItem,
+    ];
+    const settled = getChatDisplayItems(
+      feedItemsToMessages(settledFeed),
+      "ready",
+    );
+    const liveProcess = live[live.length - 1];
+    const settledProcess = settled[settled.length - 1];
+    strictEqual(liveProcess.kind, "process");
+    strictEqual(settledProcess.kind, "process");
+    strictEqual(
+      liveProcess.kind === "process" && liveProcess.key,
+      settledProcess.kind === "process" && settledProcess.key,
+    );
+    strictEqual(
+      settledProcess.kind === "process" && settledProcess.isActive,
+      false,
+    );
+  });
+
+  it("splits a second tool phase off a tools-then-text message", () => {
+    // Claude-style opening (tools before any text) followed by narration and
+    // then ANOTHER round of tools: the first phase's log settles above the
+    // text, and the new phase must start a fresh LIVE trailing log below it —
+    // not silently grow the settled one above.
+    const multiPhase = [
+      user("top 5 hacker news"),
+      toolCall("integration_search", "c1", {}),
+      toolResult("apps", "r1"),
+      streamText("I'll fetch the current Hacker News front page."),
+      toolCall("bash", "c2", { cmd: "curl hn" }),
+    ];
+    const messages = feedItemsToMessages(multiPhase);
+    strictEqual(messages.length, 3);
+    strictEqual(messages[1].tools.length, 1);
+    strictEqual(
+      messages[1].content,
+      "I'll fetch the current Hacker News front page.",
+    );
+    strictEqual(messages[2].content, "");
+    strictEqual(messages[2].tools.length, 1);
+    const items = getChatDisplayItems(messages, "submitted");
+    const kinds = items.map((i) => i.kind);
+    // settled phase-1 log, text bubble, live phase-2 log
+    deepStrictEqual(kinds, ["message", "process", "message", "process"]);
+    const first = items[1];
+    const last = items[3];
+    strictEqual(first.kind === "process" && first.isActive, false);
+    strictEqual(last.kind === "process" && last.isActive, true);
+    strictEqual(shouldShowThinkingIndicator(items, "submitted"), false);
+  });
+
   it("settles to the text bubble above an inactive mission log", () => {
     const settled = [
       user("connect to anakin"),

--- a/ui/chat/tests/feed-to-messages.test.ts
+++ b/ui/chat/tests/feed-to-messages.test.ts
@@ -1,0 +1,148 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  getChatDisplayItems,
+  shouldShowThinkingIndicator,
+} from "../src/chat-process-groups.ts";
+import { deriveStatus } from "../src/chat-status.ts";
+import { feedItemsToMessages } from "../src/feed-to-messages.ts";
+import type { FeedItem } from "../src/types.ts";
+
+const user = (text: string): FeedItem => ({
+  feed_type: "user_message",
+  data: text,
+  id: "u1",
+});
+
+const streamText = (text: string, id = "t1"): FeedItem => ({
+  feed_type: "assistant_text_streaming",
+  data: text,
+  id,
+});
+
+const finalText = (text: string, id = "t1"): FeedItem => ({
+  feed_type: "assistant_text",
+  data: text,
+  id,
+});
+
+const toolCall = (name: string, id: string, input: unknown = {}): FeedItem => ({
+  feed_type: "tool_call",
+  data: { name, input },
+  id,
+});
+
+const toolResult = (content: string, id: string): FeedItem => ({
+  feed_type: "tool_result",
+  data: { content, is_error: false },
+  id,
+});
+
+// HOU-1047: providers that narrate BEFORE running tools (OpenAI's style —
+// "Let me connect to anakin.io…" then the actual integration calls) keep the
+// text message open when the first tool_call arrives. The tools used to fuse
+// into that text message, so the grouping layer rendered the mission log
+// INACTIVE above the text and the chat bottom showed only the generic loading
+// indicator while the agent worked. A tool call after visible content must
+// start a fresh process-only message instead.
+describe("tool_call after streamed narration (HOU-1047)", () => {
+  const feed = [
+    user("connect to anakin"),
+    streamText("Let me connect to anakin.io for you."),
+    toolCall("integration_execute", "c1", { app: "anakin" }),
+    toolResult("ok", "r1"),
+    toolCall("integration_execute", "c2", { app: "anakin" }),
+  ];
+
+  it("splits the narration and the tools into separate messages", () => {
+    const messages = feedItemsToMessages(feed);
+    strictEqual(messages.length, 3);
+    strictEqual(messages[1].from, "assistant");
+    strictEqual(messages[1].content, "Let me connect to anakin.io for you.");
+    deepStrictEqual(messages[1].tools, []);
+    strictEqual(messages[2].from, "assistant");
+    strictEqual(messages[2].content, "");
+    strictEqual(messages[2].tools.length, 2);
+  });
+
+  it("renders a live trailing mission log, not the loading indicator", () => {
+    const messages = feedItemsToMessages(feed);
+    const status = deriveStatus(feed, true);
+    strictEqual(status, "submitted");
+    const items = getChatDisplayItems(messages, status);
+    const last = items[items.length - 1];
+    strictEqual(last.kind, "process");
+    strictEqual(last.kind === "process" && last.isActive, true);
+    // The active process block IS the progress surface — the standalone
+    // thinking indicator must not double up under it.
+    strictEqual(shouldShowThinkingIndicator(items, status), false);
+  });
+
+  it("keeps the process block's key stable while more tools stream in", () => {
+    const early = getChatDisplayItems(
+      feedItemsToMessages(feed.slice(0, 4)),
+      "submitted",
+    );
+    const later = getChatDisplayItems(feedItemsToMessages(feed), "submitted");
+    const earlyKey = early.find((i) => i.kind === "process")?.key;
+    const laterKey = later.find((i) => i.kind === "process")?.key;
+    strictEqual(Boolean(earlyKey), true);
+    strictEqual(earlyKey, laterKey);
+  });
+
+  it("settles to the text bubble above an inactive mission log", () => {
+    const settled = [
+      user("connect to anakin"),
+      finalText("Let me connect to anakin.io for you. Done!"),
+      toolCall("integration_execute", "c1", { app: "anakin" }),
+      toolResult("ok", "r1"),
+      {
+        feed_type: "final_result",
+        data: { result: "", cost_usd: null, duration_ms: null, usage: null },
+        id: "fr1",
+      } satisfies FeedItem,
+    ];
+    const messages = feedItemsToMessages(settled);
+    const items = getChatDisplayItems(messages, "ready");
+    const kinds = items.map((i) => i.kind);
+    deepStrictEqual(kinds, ["message", "message", "process"]);
+    const process = items[2];
+    strictEqual(process.kind === "process" && process.isActive, false);
+  });
+});
+
+describe("tool_call placeholder dedup across the narration flush", () => {
+  it("replaces the null-input placeholder inside the fresh tools message", () => {
+    const messages = feedItemsToMessages([
+      user("go"),
+      streamText("Narrating first."),
+      toolCall("bash", "c1", null),
+      toolCall("bash", "c2", { cmd: "ls" }),
+    ]);
+    strictEqual(messages.length, 3);
+    strictEqual(messages[2].tools.length, 1);
+    deepStrictEqual(messages[2].tools[0].input, { cmd: "ls" });
+  });
+
+  it("keeps appending to a tools-only message (no spurious splits)", () => {
+    const messages = feedItemsToMessages([
+      user("go"),
+      toolCall("bash", "c1", { cmd: "ls" }),
+      toolResult("ok", "r1"),
+      toolCall("read", "c2", { path: "a.ts" }),
+    ]);
+    strictEqual(messages.length, 2);
+    strictEqual(messages[1].tools.length, 2);
+    strictEqual(messages[1].content, "");
+  });
+
+  it("matches a tool_result to the call that moved into the new message", () => {
+    const messages = feedItemsToMessages([
+      user("go"),
+      streamText("Narrating first."),
+      toolCall("bash", "c1", { cmd: "ls" }),
+      toolResult("listing", "r1"),
+    ]);
+    strictEqual(messages[2].tools[0].result?.content, "listing");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes HOU-1047.

**Symptom:** when an OpenAI-backed agent does async work (e.g. connecting to anakin.io, browsing the web), the chat shows the generic loading dot instead of live activity — and the tool usage appears stranded inside the previous message's (settled) mission log instead of a live one at the bottom.

**Root cause:** OpenAI-style turns narrate BEFORE running tools ("Let me connect to anakin.io…" → then the tool calls). The streamed narration keeps the current assistant message open in `feedItemsToMessages`, so the first `tool_call` fused into the text message. The grouping layer (`getChatDisplayItems`) flushes a process block that shares a message with content as **inactive, above the content** — so no trailing active mission log existed, and `shouldShowThinkingIndicator` fell back to the generic loading indicator. Claude-style turns (thinking → tools → text) never hit this because no text precedes the tools; the `thinking` case has always flushed a content-bearing message, but `tool_call` did not.

**Fix:** in `ui/chat/src/feed-to-messages.ts`, a `tool_call` that arrives while the current assistant message already has visible content flushes it and starts a fresh process-only message — mirroring the existing thinking-case flush. The tools become the trailing process block, which renders as the **active mission log at the bottom** (current action in the header, e.g. "Anakin · Executing") and suppresses the standalone loading indicator. Placeholder-input dedup and `tool_result` matching carry across the flush boundary unchanged (covered by tests).

## Reproduction (before the fix)

1. `pnpm dev`, open an agent whose chat provider is an OpenAI model (Codex OAuth or API key).
2. Ask for something that makes the model narrate and then run tools, e.g. "Connect to anakin.io and fetch my account details" (any integration/browse flow works).
3. The model streams a sentence like "Let me connect to anakin.io…", then runs tools: the bottom of the chat shows only the pulsing loading indicator; expanding the chevron on that last text bubble reveals the tool calls hidden in a settled "Mission log" above the text.

## Verification (after the fix)

1. Same flow as above.
2. While the tools run, the bottom of the chat shows a live mission-log line (per-tool icon/brand + the action verb, animated), no generic loading indicator, and the chevron expands the streaming log in place.
3. When the turn settles, the log header reads "Mission log" under the narration text; a reload renders the turn from history unchanged (that path already ordered tools before text).
4. `pnpm --filter @houston-ai/chat test` — 320 tests pass, including the new `feed-to-messages.test.ts` suite covering the split, the active trailing block, key stability (HOU-717 class), and dedup/result matching across the flush.