### PR TITLE
perf(e2e): parallelize the UI suite with per-worker fake hosts (HOU-1072)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,9 +106,20 @@ jobs:
           pnpm exec vitest run scripts/check-parity.test.mjs scripts/publish-starter-agents.test.mjs scripts/lib/release-train.test.mjs
 
   web:
+    # The UI suite is split across runners with Playwright's native --shard:
+    # each shard runs 2 workers (the contention-safe density on a 4-vCPU
+    # runner — one single-threaded vite dev process serves every worker's page
+    # boots, and 4 workers starve renders past the expect budget), and the
+    # shards run concurrently, so the wall clock is one shard's slice of the
+    # suite instead of the whole serial run. Typecheck + unit tests ride
+    # shard 1 only.
     name: Web (typecheck + unit + UI tests)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v4
 
@@ -133,22 +144,25 @@ jobs:
         run: pnpm --filter houston-web exec playwright install --with-deps chromium
 
       - name: Typecheck (web)
+        if: ${{ matrix.shard == 1 }}
         run: pnpm --filter houston-web typecheck
 
       - name: Typecheck (e2e harness)
+        if: ${{ matrix.shard == 1 }}
         run: pnpm --filter houston-web typecheck:e2e
 
       - name: Unit tests (web)
+        if: ${{ matrix.shard == 1 }}
         run: pnpm --filter houston-web test
 
       - name: UI tests (Playwright)
-        run: pnpm --filter houston-web test:e2e
+        run: pnpm --filter houston-web test:e2e --shard=${{ matrix.shard }}/3
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-shard-${{ matrix.shard }}
           path: packages/web/playwright-report/
           retention-days: 14
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,20 +106,23 @@ jobs:
           pnpm exec vitest run scripts/check-parity.test.mjs scripts/publish-starter-agents.test.mjs scripts/lib/release-train.test.mjs
 
   web:
-    # The UI suite is split across runners with Playwright's native --shard:
-    # each shard runs 2 workers (the contention-safe density on a 4-vCPU
-    # runner — one single-threaded vite dev process serves every worker's page
-    # boots, and 4 workers starve renders past the expect budget), and the
-    # shards run concurrently, so the wall clock is one shard's slice of the
-    # suite instead of the whole serial run. Typecheck + unit tests ride
-    # shard 1 only.
+    # The UI suite is split across runners with Playwright's native --shard,
+    # ONE worker per runner: the shards run concurrently, so the wall clock is
+    # one shard's slice of the suite instead of the whole serial run, while
+    # each test still executes in the exact single-worker environment the
+    # suite has always been stable in on this hardware. Higher density was
+    # tried and starves renders on the 4-vCPU runner (one single-threaded vite
+    # dev process serves every worker's page boots): 4 workers blew expect
+    # budgets outright (run 30596416439), and even 2 workers left the heavy
+    # signed-in specs flaking on animation transients (run 30597930896).
+    # Typecheck + unit tests ride shard 1 only.
     name: Web (typecheck + unit + UI tests)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v4
 
@@ -156,7 +159,7 @@ jobs:
         run: pnpm --filter houston-web test
 
       - name: UI tests (Playwright)
-        run: pnpm --filter houston-web test:e2e --shard=${{ matrix.shard }}/3
+        run: pnpm --filter houston-web test:e2e --shard=${{ matrix.shard }}/6
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}

--- a/packages/fake-host/README.md
+++ b/packages/fake-host/README.md
@@ -1,7 +1,8 @@
 # @houston/fake-host
 
-An in-memory, **protocol-v3** Houston host for UI / e2e tests. A single Node
-process answers just enough of the host + per-agent runtime for the desktop UI
+An in-memory, **protocol-v3** Houston host for UI / e2e tests. A small Node
+server (one per Playwright worker in the e2e suite — see `src/config.ts`)
+answers just enough of the host + per-agent runtime for the desktop UI
 (`app/src`) to boot and run on the new-engine adapter in **host mode** — with NO
 real backend, no AI provider, no credentials. Deterministic and hermetic: the
 same click always produces the same pixels.

--- a/packages/fake-host/src/config.test.ts
+++ b/packages/fake-host/src/config.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { resolveFakeHostPort } from "./config";
+
+describe("resolveFakeHostPort", () => {
+  it("uses the default base port outside a Playwright worker", () => {
+    expect(resolveFakeHostPort({})).toBe(4399);
+  });
+
+  it("honors the per-worktree base-port override", () => {
+    expect(resolveFakeHostPort({ HOUSTON_E2E_FAKE_HOST_PORT: "4460" })).toBe(
+      4460,
+    );
+  });
+
+  it("gives each Playwright parallel slot its own port above the base", () => {
+    expect(resolveFakeHostPort({ TEST_PARALLEL_INDEX: "0" })).toBe(4400);
+    expect(resolveFakeHostPort({ TEST_PARALLEL_INDEX: "3" })).toBe(4403);
+  });
+
+  it("stacks the slot offset on top of a base-port override", () => {
+    expect(
+      resolveFakeHostPort({
+        HOUSTON_E2E_FAKE_HOST_PORT: "4460",
+        TEST_PARALLEL_INDEX: "2",
+      }),
+    ).toBe(4463);
+  });
+});

--- a/packages/fake-host/src/config.ts
+++ b/packages/fake-host/src/config.ts
@@ -7,14 +7,32 @@
  * glue and live with the harness, not here.
  */
 
-/** The in-memory fake host the app talks to instead of a real host.
- *  Overridable via HOUSTON_E2E_FAKE_HOST_PORT: parallel worktrees running e2e
- *  at once would otherwise silently reuse EACH OTHER'S servers (Playwright's
- *  reuseExistingServer sees a live port and assumes it's ours), producing
- *  bogus results against foreign code. Set a distinct port per worktree. */
-export const FAKE_HOST_PORT = Number(
-  process.env.HOUSTON_E2E_FAKE_HOST_PORT || 4399,
-);
+/**
+ * Resolve the fake host's port for the current process.
+ *
+ * The base port is overridable via HOUSTON_E2E_FAKE_HOST_PORT: parallel
+ * worktrees running e2e at once would otherwise silently reuse EACH OTHER'S
+ * servers (Playwright's reuseExistingServer sees a live port and assumes it's
+ * ours), producing bogus results against foreign code. Set a distinct base per
+ * worktree, spaced ≥ 32 apart so the per-worker slots below can't overlap.
+ *
+ * Playwright sets TEST_PARALLEL_INDEX only inside worker processes, where each
+ * parallel slot runs its OWN in-process fake host (e2e/support/fixtures.ts) —
+ * one port up per slot (base + 1 + slot), clear of the standalone
+ * `pnpm fake-host` process on the base port. A worker's specs, seed, and
+ * fixtures all resolve FAKE_HOST_URL in-worker, so they land on that worker's
+ * host with no plumbing.
+ */
+export function resolveFakeHostPort(
+  env: Record<string, string | undefined>,
+): number {
+  const base = Number(env.HOUSTON_E2E_FAKE_HOST_PORT || 4399);
+  const slot = env.TEST_PARALLEL_INDEX;
+  return slot === undefined ? base : base + 1 + Number(slot);
+}
+
+/** The in-memory fake host the app talks to instead of a real host. */
+export const FAKE_HOST_PORT = resolveFakeHostPort(process.env);
 
 export const FAKE_HOST_URL = `http://localhost:${FAKE_HOST_PORT}`;
 

--- a/packages/fake-host/src/server.ts
+++ b/packages/fake-host/src/server.ts
@@ -5,10 +5,10 @@
  * `Request -> Response` function) and exposes a lifecycle: `startFakeHost`
  * resolves once the listener is up, and the returned {@link FakeHost} closes it.
  *
- * A single process serves the whole test run — with NO real backend, no AI
- * provider, no credentials. Run standalone with
- * `pnpm --filter @houston/fake-host start`; the Playwright config starts it
- * automatically as a `webServer`.
+ * NO real backend, no AI provider, no credentials. Run standalone with
+ * `pnpm --filter @houston/fake-host start`; the Playwright config starts one
+ * as a `webServer` (for global-setup's warm-up), and each e2e worker starts
+ * its own in-process (e2e/support/fixtures.ts).
  */
 
 import { createServer } from "node:http";

--- a/packages/web/e2e/README.md
+++ b/packages/web/e2e/README.md
@@ -147,7 +147,13 @@ The `webServer` fake host on the base port only serves the main process
 per-worktree `HOUSTON_E2E_FAKE_HOST_PORT` bases ≥ 32 apart so worker slots
 can't overlap.
 
-**CI.** vite dev compiles modules on demand, and Playwright only waits for the dev
+**CI.** The web job shards the suite across runners (`test:e2e --shard=N/3`,
+see `.github/workflows/ci.yml`) with 2 workers per shard: one single-threaded
+vite dev process serves every worker's page boots, and on a 4-vCPU runner more
+than 2 concurrent renders starve past the expect budget. Throughput comes from
+the shards, density stays safe.
+
+vite dev compiles modules on demand, and Playwright only waits for the dev
 server's port to open, not for it to compile. `support/global-setup.ts` boots the
 shell once before the timed suite so the first test doesn't eat vite's cold
 compile inside its 10s assertion budget — that cold start used to time out the
@@ -202,6 +208,12 @@ Theme is pinned by setting `data-theme` on `<html>` before the app mounts
 (`visual/support.ts` `seedTheme`) — NOT the `houston.pref.theme` preference: the
 web entry (`NewEngineRoot`) never runs the desktop's `loadTheme` bootstrap, so
 that pref is inert here.
+
+The visual scripts cap parallelism at `--workers=2`: full-page screenshots are
+CPU-heavy, and at higher worker counts the pinned CI container starves renders
+past the expect budget (a first-paint anchor missed its 10s window at 4
+workers). Two workers keep the 8-shot suite fast without contention; the
+determinism rules below outrank raw speed here.
 
 **Determinism rules** (a flaky baseline is worse than none — skip a screen you
 can't make deterministic rather than commit one):

--- a/packages/web/e2e/README.md
+++ b/packages/web/e2e/README.md
@@ -147,11 +147,14 @@ The `webServer` fake host on the base port only serves the main process
 per-worktree `HOUSTON_E2E_FAKE_HOST_PORT` bases ≥ 32 apart so worker slots
 can't overlap.
 
-**CI.** The web job shards the suite across runners (`test:e2e --shard=N/3`,
-see `.github/workflows/ci.yml`) with 2 workers per shard: one single-threaded
-vite dev process serves every worker's page boots, and on a 4-vCPU runner more
-than 2 concurrent renders starve past the expect budget. Throughput comes from
-the shards, density stays safe.
+**CI.** The web job shards the suite across runners (`test:e2e --shard=N/6`,
+see `.github/workflows/ci.yml`) with ONE worker per shard: one single-threaded
+vite dev process serves every worker's page boots, and on a 4-vCPU runner
+concurrent workers starve renders — 4 workers blew expect budgets outright,
+and even 2 left the signed-in specs flaking on stuck-animation transients
+(duplicate `AnimatePresence` card ghosts). Throughput comes from the shards;
+each test runs at the single-worker density the suite has always been stable
+at.
 
 vite dev compiles modules on demand, and Playwright only waits for the dev
 server's port to open, not for it to compile. `support/global-setup.ts` boots the

--- a/packages/web/e2e/README.md
+++ b/packages/web/e2e/README.md
@@ -135,9 +135,17 @@ backs that with a real in-memory store, seeded with two missions, and unified wi
 the `/agents/:id/activities` route (same data, as in the real host) so a
 turn flipping a card's status shows up on the board.
 
-**Isolation.** One fake-host process serves the whole run, so the suite is serial
-(`workers: 1`) and `support/fixtures.ts` resets the host (`POST /__test__/reset`)
-before each test.
+**Isolation.** The suite runs fully parallel: every Playwright worker starts its
+OWN in-process fake host (`support/fixtures.ts`) on a worker-slot port —
+`FAKE_HOST_PORT` in `@houston/fake-host` reads Playwright's
+`TEST_PARALLEL_INDEX`, so a worker's specs, seed, and fixtures all resolve
+`FAKE_HOST_URL` to that worker's host with no plumbing. Workers are separate OS
+processes, so their in-memory host state never crosses; within a worker,
+`support/fixtures.ts` resets the host (`POST /__test__/reset`) before each test.
+The `webServer` fake host on the base port only serves the main process
+(global-setup's warm-up). Running several worktrees' suites at once? Space the
+per-worktree `HOUSTON_E2E_FAKE_HOST_PORT` bases ≥ 32 apart so worker slots
+can't overlap.
 
 **CI.** vite dev compiles modules on demand, and Playwright only waits for the dev
 server's port to open, not for it to compile. `support/global-setup.ts` boots the

--- a/packages/web/e2e/board.spec.ts
+++ b/packages/web/e2e/board.spec.ts
@@ -273,15 +273,19 @@ test("paints cached missions immediately while cold-start reads are held", async
 
   // Cold open: every per-agent read now stalls the way an asleep pod's do.
   await request.post(`${FAKE_HOST_URL}/__test__/hold-agent-reads`, {
-    data: { ms: 8_000 },
+    data: { ms: 20_000 },
   });
   await page.reload();
 
   // The cards must come from the locally cached aggregate — well before any
-  // held read can answer. 4s of grace for the reload+restore, far under the
-  // 8s hold.
+  // held read can answer. The grace only has to stay far under the hold to
+  // keep the proof sharp; it must ALSO absorb a full dev-server reload on a
+  // contended CI runner, which alone can blow a too-tight budget (a 4s grace
+  // under an 8s hold flaked there). 12s of grace, 20s hold: same invariant,
+  // CI-realistic slack. On success the assertion resolves at paint time, so
+  // the bigger numbers cost nothing.
   await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible({
-    timeout: 4_000,
+    timeout: 12_000,
   });
 });
 

--- a/packages/web/e2e/support/fixtures.ts
+++ b/packages/web/e2e/support/fixtures.ts
@@ -3,10 +3,18 @@
  *
  * Every test gets a page that is (a) reset to the fake host's seed and (b) primed
  * with the boot seed, so specs start from a known shell with one connected agent.
- * The fake host is a single shared process, so the suite runs with `workers: 1`
- * and resets state per test for isolation (see playwright.config.ts).
+ *
+ * Each parallel WORKER runs its own in-process fake host: `FAKE_HOST_PORT` is
+ * worker-slot-aware (see `@houston/fake-host` config.ts), and workers are
+ * separate OS processes, so their in-memory host state is isolated for free.
+ * That is what lets the suite run fully parallel; within a worker, state is
+ * still reset per test.
  */
-import { FAKE_HOST_URL } from "@houston/fake-host";
+import {
+  FAKE_HOST_PORT,
+  type FakeHost,
+  startFakeHost,
+} from "@houston/fake-host";
 import { test as base, expect, type Page } from "@playwright/test";
 import { seedPage } from "./seed";
 
@@ -17,16 +25,30 @@ interface Fixtures {
   emitHostEvent: (type: string, agentPath?: string) => Promise<void>;
 }
 
-export const test = base.extend<Fixtures>({
-  page: async ({ page, request }, use) => {
+interface WorkerFixtures {
+  /** This worker's own fake host. In-worker, `FAKE_HOST_URL` resolves to it. */
+  fakeHost: FakeHost;
+}
+
+export const test = base.extend<Fixtures, WorkerFixtures>({
+  fakeHost: [
+    // biome-ignore lint/correctness/noEmptyPattern: Playwright requires the destructuring pattern on a fixture's first parameter
+    async ({}, use) => {
+      const host = await startFakeHost(FAKE_HOST_PORT);
+      await use(host);
+      await host.stop();
+    },
+    { scope: "worker", auto: true },
+  ],
+  page: async ({ page, request, fakeHost }, use) => {
     // Server-to-server (no CORS): restore the seed before each test.
-    await request.post(`${FAKE_HOST_URL}/__test__/reset`);
+    await request.post(`${fakeHost.url}/__test__/reset`);
     await seedPage(page);
     await use(page);
   },
-  emitHostEvent: async ({ request }, use) => {
+  emitHostEvent: async ({ request, fakeHost }, use) => {
     await use(async (type, agentPath) => {
-      await request.post(`${FAKE_HOST_URL}/__test__/emit`, {
+      await request.post(`${fakeHost.url}/__test__/emit`, {
         data: { type, agentPath },
       });
     });

--- a/packages/web/e2e/support/global-setup.ts
+++ b/packages/web/e2e/support/global-setup.ts
@@ -18,6 +18,7 @@
  */
 import { chromium, type FullConfig } from "@playwright/test";
 import { AUTH_WEB_URL, WEB_URL } from "../config";
+import { signInAsViewer } from "./identity";
 import { seedPage } from "./seed";
 
 export default async function globalSetup(_config: FullConfig): Promise<void> {
@@ -39,14 +40,23 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
       .waitFor({ state: "visible", timeout: 120_000 });
 
     // Warm the identity-on server (the `auth` project) the same way. It's a
-    // SEPARATE vite process with its own cold compile, so the sign-in spec would
-    // otherwise pay it inside its assertion budget. Here it reaches SignInScreen.
+    // SEPARATE vite process with its own cold compile (dep-optimizer caches are
+    // scoped per port), so the sign-in spec would otherwise pay it inside its
+    // assertion budget. Here it reaches SignInScreen.
     const authPage = await browser.newPage();
     await seedPage(authPage);
     await authPage.goto(AUTH_WEB_URL, { timeout: 120_000 });
     await authPage
       .getByRole("button", { name: "Continue with Google" })
       .waitFor({ state: "visible", timeout: 120_000 });
+
+    // Then all the way THROUGH sign-in to the shell: the signed-in specs
+    // (identity.ts) boot the full app tree on THIS server, and that graph is
+    // not part of the SignInScreen warm-up. Cold, its compile lands on the
+    // first signed-in spec of every worker — on a contended CI runner that
+    // blew 17–30s and flaked mentions-inbox + profile-settings (run
+    // 30597316258). Same generous ceiling as the rest of the warm-up.
+    await signInAsViewer(authPage, { shellTimeout: 120_000 });
   } finally {
     await browser.close();
   }

--- a/packages/web/e2e/support/identity.ts
+++ b/packages/web/e2e/support/identity.ts
@@ -157,7 +157,15 @@ async function mockIdentityBackend(page: Page): Promise<void> {
  * Pair it with `test.use({ baseURL: AUTH_WEB_URL })` so every later `goto`,
  * and the app's own gateway calls, stay on that server.
  */
-export async function signInAsViewer(page: Page): Promise<void> {
+export async function signInAsViewer(
+  page: Page,
+  opts?: {
+    /** Budget for the post-sign-in shell to appear. global-setup's warm-up
+     *  passes a cold-compile-sized one; specs keep the default (the shell
+     *  graph is warm by the time any spec runs). */
+    shellTimeout?: number;
+  },
+): Promise<void> {
   await mockIdentityBackend(page);
   await page.goto(`${AUTH_WEB_URL}/`);
 
@@ -169,7 +177,7 @@ export async function signInAsViewer(page: Page): Promise<void> {
   // The shell is up once its header actions are (the same anchor chat.spec.ts
   // uses to open a mission).
   await expect(page.locator('[data-tour-target="newMission"]')).toBeVisible({
-    timeout: 20_000,
+    timeout: opts?.shellTimeout ?? 20_000,
   });
 }
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -15,8 +15,8 @@
     "test:e2e:webkit": "playwright test --config playwright.webkit.config.ts --fail-on-flaky-tests",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report",
-    "test:visual": "playwright test --project visual --fail-on-flaky-tests",
-    "test:visual:update": "playwright test --project visual --update-snapshots",
+    "test:visual": "playwright test --project visual --fail-on-flaky-tests --workers=2",
+    "test:visual:update": "playwright test --project visual --update-snapshots --workers=2",
     "fake-host": "pnpm --filter @houston/fake-host start",
     "check-shims": "node ../../scripts/check-tauri-shims.mjs"
   },

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -13,9 +13,11 @@ import {
  * (packages/web), on the host adapter in host mode, against an
  * in-memory fake host (@houston/fake-host) — no real backend, no AI provider.
  *
- * Two web servers boot for a run: the fake host (Node) and vite. The fake
- * host is a single shared process, so the suite is serial (`workers: 1`) and
- * resets host state per test (see support/fixtures.ts).
+ * The suite runs FULLY PARALLEL: every Playwright worker starts its own
+ * in-process fake host on a worker-slot port (see support/fixtures.ts and
+ * `@houston/fake-host` config.ts), so workers never share host state. The
+ * `webServer` fake host below serves only the main process (global-setup's
+ * warm-up); vite is shared by all workers, which is fine once warm.
  */
 export default defineConfig({
   testDir: "./e2e",
@@ -24,8 +26,11 @@ export default defineConfig({
   // pay vite's cold on-demand compile inside its assertion budget (see
   // e2e/support/global-setup.ts).
   globalSetup: "./e2e/support/global-setup.ts",
-  fullyParallel: false,
-  workers: 1,
+  fullyParallel: true,
+  // CI runners (ubuntu-latest) have 4 vCPUs; browser tests are wait-bound
+  // enough that one worker per core beats Playwright's 50% default. Locally,
+  // let Playwright pick from the machine's cores.
+  workers: process.env.CI ? 4 : undefined,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   timeout: 30_000,
@@ -46,9 +51,14 @@ export default defineConfig({
     : [["list"]],
   use: {
     baseURL: WEB_URL,
-    trace: "retain-on-failure",
+    // In CI, recording trace + video for every passing test costs real CPU
+    // across hundreds of tests (encode per test, then discarded). `retries: 1`
+    // there means a failure re-runs once with both recorded — diagnostics
+    // survive, the happy path pays nothing. Locally (retries: 0) keep the
+    // record-everything-keep-failures behavior for debugging.
+    trace: process.env.CI ? "on-first-retry" : "retain-on-failure",
     screenshot: "only-on-failure",
-    video: "retain-on-failure",
+    video: process.env.CI ? "on-first-retry" : "retain-on-failure",
   },
   projects: [
     {

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -57,14 +57,18 @@ export default defineConfig({
     : [["list"]],
   use: {
     baseURL: WEB_URL,
-    // In CI, recording trace + video for every passing test costs real CPU
-    // across hundreds of tests (encode per test, then discarded). `retries: 1`
-    // there means a failure re-runs once with both recorded — diagnostics
-    // survive, the happy path pays nothing. Locally (retries: 0) keep the
-    // record-everything-keep-failures behavior for debugging.
-    trace: process.env.CI ? "on-first-retry" : "retain-on-failure",
+    // Keep trace + video recording ON for every attempt, in CI too. Skipping
+    // them on first attempts ("on-first-retry") was tried to save encode CPU
+    // and produced first-attempt-only flakes that no retry ever reproduced:
+    // recording paces the page slightly, and the unrecorded attempts ran
+    // FASTER than the suite ever had, exposing UI races (a nav click landing
+    // with the panel never switching; AnimatePresence crossfades caught
+    // mid-flight as duplicate cards). Recording parity with every attempt is
+    // part of the environment the suite is stable in; with the suite sharded
+    // across runners the overhead is cheap.
+    trace: "retain-on-failure",
     screenshot: "only-on-failure",
-    video: process.env.CI ? "on-first-retry" : "retain-on-failure",
+    video: "retain-on-failure",
   },
   projects: [
     {

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -28,12 +28,15 @@ export default defineConfig({
   globalSetup: "./e2e/support/global-setup.ts",
   fullyParallel: true,
   // CI runners (ubuntu-latest) have 4 vCPUs, and page boots are served by ONE
-  // single-threaded vite dev process — at 4 workers the renders starve past
-  // the 10s expect budget (run 30596416439: 14 timing failures). Two workers
-  // is the contention-safe density; CI gets its throughput from sharding the
-  // suite across runners instead (ci.yml `--shard`). Locally, let Playwright
-  // pick from the machine's cores.
-  workers: process.env.CI ? 2 : undefined,
+  // single-threaded vite dev process — at 4 workers renders starve past the
+  // 10s expect budget (run 30596416439: 14 timing failures), and even at 2
+  // the heavy signed-in specs flake on animation transients (run
+  // 30597930896: stuck AnimatePresence exit ghosts duplicate kanban cards).
+  // CI therefore runs ONE worker per runner — the density the suite has
+  // always been stable at — and gets its throughput from sharding across
+  // runners (ci.yml `--shard`). Locally, let Playwright pick from the
+  // machine's cores; fast machines don't starve.
+  workers: process.env.CI ? 1 : undefined,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   timeout: 30_000,

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -27,10 +27,13 @@ export default defineConfig({
   // e2e/support/global-setup.ts).
   globalSetup: "./e2e/support/global-setup.ts",
   fullyParallel: true,
-  // CI runners (ubuntu-latest) have 4 vCPUs; browser tests are wait-bound
-  // enough that one worker per core beats Playwright's 50% default. Locally,
-  // let Playwright pick from the machine's cores.
-  workers: process.env.CI ? 4 : undefined,
+  // CI runners (ubuntu-latest) have 4 vCPUs, and page boots are served by ONE
+  // single-threaded vite dev process — at 4 workers the renders starve past
+  // the 10s expect budget (run 30596416439: 14 timing failures). Two workers
+  // is the contention-safe density; CI gets its throughput from sharding the
+  // suite across runners instead (ci.yml `--shard`). Locally, let Playwright
+  // pick from the machine's cores.
+  workers: process.env.CI ? 2 : undefined,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   timeout: 30_000,


### PR DESCRIPTION
## Summary

Fixes HOU-1072.

The "Web (typecheck + unit + UI tests)" CI job took **~26 minutes**, and ~24m40s of that was the "UI tests (Playwright)" step alone: 218 tests running **serially** (`workers: 1`) at ~6.6s each, because one shared fake-host process made parallel workers structurally impossible.

**Result: the Web job now finishes in ~7 minutes** (six concurrent shards, slowest 7m07s), and the full suite runs locally in **3.1 minutes** (was ~24).

### The fix
- **Per-worker fake hosts** — the structural unlock. Playwright workers are separate OS processes, so each worker starts its **own in-process fake host**: `FAKE_HOST_PORT` (`packages/fake-host/src/config.ts`) reads Playwright's `TEST_PARALLEL_INDEX` and resolves to `base + 1 + slot` inside a worker. Specs, `seed.ts`, and fixtures all resolve `FAKE_HOST_URL` inside the worker process, so every spec's existing `__test__` reset/emit/arm calls land on its own worker's host — **zero spec changes**. The base-port host remains the `webServer` for global-setup's warm-up. Locally the suite now uses all cores (`fullyParallel: true`; no spec has serial hooks or module-level state).
- **CI: six 1-worker shards** (native `--shard` matrix; typecheck + unit ride shard 1). CI density stays at the single-worker environment the suite has always been stable in; throughput comes from the shards. Higher density was tried and rejected with evidence: 4 workers starve renders on the 4-vCPU runner (one single-threaded vite dev process serves every page boot), and even 2 workers left heavy specs flaking.
- **Recording parity everywhere** (`trace`/`video: retain-on-failure`, unchanged from main). Skipping recording on first attempts was tried and produced first-attempt-only flakes at every density including 1 worker: recording paces the page, and unrecorded attempts ran faster than the suite ever had, exposing UI races (a nav click leaving the panel unswitched; AnimatePresence crossfades caught as duplicate kanban cards). The pacing is load-bearing, so it stays.
- **global-setup warms the identity-ON server through the signed-in shell** (not just SignInScreen) — its dep-optimizer cache is separate, so the signed-in specs' first attempt used to pay that cold compile.
- **board.spec cold-open test:** 12s grace under a 20s read-hold (was 4s/8s) — identical invariant (paints from cache strictly before any held read can answer), CI-realistic slack.
- **Visual suite capped at `--workers=2`** — full-page screenshots are CPU-heavy in the pinned container; determinism outranks speed there.
- Unit tests for the port derivation (`packages/fake-host/src/config.test.ts`); docs updated throughout.

**Known follow-up (not this PR):** wiring framer-motion to reduced motion (`MotionConfig reducedMotion="user"`) would eliminate the AnimatePresence-ghost race class outright, matching the CSS layer's existing `prefers-reduced-motion` support.

### Verification

**Before (reproduce):** on `main`, `pnpm --filter houston-web test:e2e` prints `Running 218 tests using 1 worker` and takes 20–25 min (run 30584996556: UI step 00:02:59 → 00:27:40; whole job 25m51s).

**After:**
- CI run 30598944521 (this PR, final layout): **all 12 checks green**; Web shards 5m04s–7m07s wall, concurrent.
- Full suite locally: **217 passed, 1 skipped in 3.1m** (8 workers), exit 0 under `--fail-on-flaky-tests`.
- Visual suite: 8/8, three consecutive green CI runs since the cap.
- `pnpm --filter @houston/fake-host test` (21 passed), web typechecks, `pnpm check` all green.