### PR TITLE
feat(chat): custom integration actions brand the mission log (HOU-1049)

### DIFF
--- a/app/src/components/integrations/app-display.ts
+++ b/app/src/components/integrations/app-display.ts
@@ -113,3 +113,44 @@ export function toolkitOfActionSlug(
   }
   return best ?? a.split("_")[0] ?? "";
 }
+
+/**
+ * A CUSTOM integration's executor address, parsed for the chat's branded row
+ * (HOU-1049). Custom actions ride `integration_execute` like Composio ones,
+ * but their action is an executor ADDRESS —
+ * `tools.<integration>.<owner>.<connection>.<namespace...>.<tool>` (the
+ * host's CUSTOM_ACTION_PREFIX grammar) — which the Composio slug matching
+ * above can never brand. `null` for anything that isn't a well-formed
+ * address, so Composio slugs fall through untouched.
+ */
+export interface CustomActionRef {
+  /** The custom integration's slug (the definition the user added). */
+  slug: string;
+  /** The tool's own name — the LAST address segment (namespaces dropped). */
+  tool: string;
+}
+
+export function customActionOf(action: string): CustomActionRef | null {
+  if (!action.startsWith("tools.")) return null;
+  const segments = action.split(".");
+  if (segments.length < 5) return null;
+  const slug = segments[1];
+  const tool = segments[segments.length - 1];
+  return slug && tool ? { slug, tool } : null;
+}
+
+/** "listJobs" → "list_jobs", so the shared Composio gerund humanizer can
+ *  read an executor tool name ("Listing jobs"). */
+export function camelToSnakeCase(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}
+
+/** The no-list fallback name for a custom slug ("acme-crm" → "Acme Crm") —
+ *  shown only until (or unless) the definitions list resolves the real name. */
+export function prettifyCustomSlug(slug: string): string {
+  return slug
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((w) => w[0].toUpperCase() + w.slice(1))
+    .join(" ");
+}

--- a/app/src/components/use-action-brand-resolver.ts
+++ b/app/src/components/use-action-brand-resolver.ts
@@ -1,21 +1,36 @@
 import { type ChatActionBrand, humanizeActionGerund } from "@houston-ai/chat";
 import { useCallback, useMemo } from "react";
-import { toolkitOfActionSlug } from "./integrations/app-display";
+import { useCustomIntegrations } from "../hooks/queries";
+import {
+  camelToSnakeCase,
+  customActionOf,
+  prettifyCustomSlug,
+  toolkitOfActionSlug,
+} from "./integrations/app-display";
 import { useReadyToolkitCatalog } from "./integrations/use-toolkit-catalog";
 import { useToolkitBrandResolver } from "./use-toolkit-brand-resolver";
 
 /**
- * A read-only resolver from a Composio ACTION slug (e.g. `GMAIL_SEND_EMAIL`) to
- * the process-block header's branded row — the app-side counterpart to
- * `ui/chat`'s `resolveActionBrand` port (ui/chat stays Composio-unaware).
+ * A read-only resolver from an `integration_execute` ACTION to the process
+ * block header's branded row — the app-side counterpart to `ui/chat`'s
+ * `resolveActionBrand` port (ui/chat stays provider-unaware).
  *
- * It composes three pieces the app already owns: the action's toolkit is the
- * longest catalog slug that prefixes it (`toolkitOfActionSlug`), that toolkit
- * resolves to a name + logo through the shared brand resolver, and the action
- * humanizes to a present-tense label ("Sending email"). A catalog MISS still
- * yields a branded row — the prettified toolkit name with NO logo — so the row
- * degrades gracefully and never shows a raw slug or a broken image. Stable
- * across renders unless the catalog moves.
+ * Two action grammars, one row:
+ *
+ * - A CUSTOM executor address (`tools.<slug>....<tool>`, HOU-1049) brands as
+ *   the integration's own name — from the custom definitions list, else the
+ *   prettified slug (a gateway-fronted web surface may null the list) — with
+ *   the wrench glyph (`icon: "tool"`, these integrations have no logo) and
+ *   the humanized tool name ("Listing jobs").
+ * - A Composio action slug (e.g. `GMAIL_SEND_EMAIL`) resolves its toolkit as
+ *   the longest catalog slug prefixing it (`toolkitOfActionSlug`), that
+ *   toolkit resolves to a name + logo through the shared brand resolver, and
+ *   the action humanizes to a present-tense label ("Sending email"). A
+ *   catalog MISS still yields a branded row — the prettified toolkit name
+ *   with NO logo — so the row degrades gracefully and never shows a raw slug
+ *   or a broken image.
+ *
+ * Stable across renders unless the catalog or the custom list moves.
  */
 export function useActionBrandResolver(): (
   action: string,
@@ -26,10 +41,24 @@ export function useActionBrandResolver(): (
     () => (catalogData ?? []).map((tk) => tk.slug),
     [catalogData],
   );
+  const custom = useCustomIntegrations();
+  const customDefs = custom.data;
   const resolveBrand = useToolkitBrandResolver();
   return useCallback(
     (action) => {
       if (!action) return undefined;
+      const customRef = customActionOf(action);
+      if (customRef) {
+        const def = (customDefs ?? []).find((d) => d.slug === customRef.slug);
+        return {
+          name: def?.name ?? prettifyCustomSlug(customRef.slug),
+          icon: "tool",
+          actionLabel: humanizeActionGerund(
+            camelToSnakeCase(customRef.tool),
+            "",
+          ),
+        };
+      }
       const toolkit = toolkitOfActionSlug(action, slugs);
       const brand = resolveBrand(toolkit);
       if (!brand) return undefined;
@@ -39,6 +68,6 @@ export function useActionBrandResolver(): (
         actionLabel: humanizeActionGerund(action, toolkit),
       };
     },
-    [slugs, resolveBrand],
+    [slugs, customDefs, resolveBrand],
   );
 }

--- a/app/tests/app-display.test.ts
+++ b/app/tests/app-display.test.ts
@@ -1,9 +1,12 @@
-import { strictEqual } from "node:assert";
+import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import type { IntegrationToolkit } from "@houston-ai/engine-client";
 import {
   appDisplay,
+  camelToSnakeCase,
+  customActionOf,
   fallbackLogo,
+  prettifyCustomSlug,
   prettifyToolkit,
   toolkitOfActionSlug,
 } from "../src/components/integrations/app-display.ts";
@@ -105,5 +108,40 @@ describe("toolkitOfActionSlug", () => {
   it("falls back to the first underscore segment when the catalog has no match", () => {
     strictEqual(toolkitOfActionSlug("NOTION_CREATE_PAGE", catalog), "notion");
     strictEqual(toolkitOfActionSlug("STRIPE_REFUND", []), "stripe");
+  });
+});
+
+describe("customActionOf (HOU-1049)", () => {
+  it("parses a custom executor address into slug + tool", () => {
+    deepStrictEqual(customActionOf("tools.anakin.org.default.jobs.listJobs"), {
+      slug: "anakin",
+      tool: "listJobs",
+    });
+    // No namespace segment: the tool is still the last segment.
+    deepStrictEqual(customActionOf("tools.acme-crm.org.default.search"), {
+      slug: "acme-crm",
+      tool: "search",
+    });
+  });
+
+  it("never claims a Composio slug or a malformed address", () => {
+    strictEqual(customActionOf("GMAIL_SEND_EMAIL"), null);
+    strictEqual(customActionOf("tools.anakin.org"), null);
+    strictEqual(customActionOf(""), null);
+  });
+});
+
+describe("custom brand fallbacks (HOU-1049)", () => {
+  it("camelToSnakeCase feeds the shared gerund humanizer", () => {
+    strictEqual(camelToSnakeCase("listJobs"), "list_jobs");
+    strictEqual(camelToSnakeCase("postOperation"), "post_operation");
+    strictEqual(camelToSnakeCase("search"), "search");
+    strictEqual(camelToSnakeCase("get_user"), "get_user");
+  });
+
+  it("prettifyCustomSlug is the no-list name fallback", () => {
+    strictEqual(prettifyCustomSlug("anakin"), "Anakin");
+    strictEqual(prettifyCustomSlug("acme-crm"), "Acme Crm");
+    strictEqual(prettifyCustomSlug("my_api"), "My Api");
   });
 });

--- a/ui/chat/src/chat-action-brand-line.tsx
+++ b/ui/chat/src/chat-action-brand-line.tsx
@@ -1,4 +1,5 @@
 import { HoustonHelmet } from "@houston-ai/core";
+import { Wrench } from "lucide-react";
 import { useState } from "react";
 import { Shimmer } from "./ai-elements/shimmer";
 import type { ChatActionBrand } from "./chat-process-header";
@@ -32,7 +33,11 @@ export function ChatActionBrandLine({
   const showLogo = brand.logoUrl && !failed;
   return (
     <span className="inline-flex min-w-0 max-w-full items-center gap-1.5 text-xs">
-      {showLogo ? (
+      {brand.icon === "tool" ? (
+        // A logo-less integration kind (custom API/MCP, HOU-1049): the wrench
+        // says "your own tool", where the helmet would read as Houston itself.
+        <Wrench aria-hidden className="size-3.5 shrink-0" />
+      ) : showLogo ? (
         <img
           alt=""
           className="size-3.5 shrink-0 rounded object-contain"

--- a/ui/chat/src/chat-process-header.ts
+++ b/ui/chat/src/chat-process-header.ts
@@ -25,6 +25,10 @@ import { getToolActionLabel, toolShortName } from "./tool-labels.ts";
 export interface ChatActionBrand {
   name: string;
   logoUrl?: string;
+  /** A glyph standing in for a brand logo when the integration has none:
+   *  `"tool"` renders a wrench (custom API/MCP integrations, HOU-1049).
+   *  Takes precedence over `logoUrl`; absent → logo, else the helmet. */
+  icon?: "tool";
   actionLabel: string;
 }
 


### PR DESCRIPTION
## What

When an agent runs a **custom** integration action, the mission log now shows a branded header row like the Composio ones: a 🛠️ wrench glyph + the integration's name + the humanized action — e.g. **`🛠️ Anakin.io · Listing jobs`** — instead of the generic "Using an app".

## Why

A Composio execute already upgrades the header (`[logo] Gmail · Sending email`) via the app-side action-brand resolver, but a custom integration's action is an executor **address** (`tools.<slug>.org.default.<…>.<tool>`) that the Composio slug matching can never resolve — so the log gave no clue *which* integration ran.

## How

- `customActionOf` (app-display.ts, pure + node-tested) parses the address grammar; Composio slugs fall through untouched.
- The resolver brands the row with the integration's own name from the custom definitions list (prettified slug fallback where the list nulls, e.g. a gateway-fronted web surface), the humanized tool name (`listJobs` → "Listing jobs", reusing the shared gerund humanizer via a camelCase→snake bridge), and the new `icon: "tool"` variant.
- `ChatActionBrand` grows the optional `icon` field and `ChatActionBrandLine` renders a wrench for it — these integrations have no logo, and the helmet fallback would read as Houston itself. ui/chat stays provider-unaware.

## Verify

- `cd app && pnpm test` — new cases in `app-display.test.ts` pin the address parser, the camelCase bridge, and the slug prettifier (2461 pass).
- In-product: run any custom integration action in chat → the mission-log header shows the wrench + integration name + action; Composio actions keep their logos; unknown tools keep the helmet.

Gates: workspace typecheck, Biome, `check:parity`, visual baselines all green.