### PR TITLE
fix(auth): fall back to the device-code sign-in when the Codex loopback can't run (HOU-1063)

### DIFF
--- a/app/src-tauri/src/codex_oauth_loopback.rs
+++ b/app/src-tauri/src/codex_oauth_loopback.rs
@@ -3,9 +3,11 @@
 //! OpenAI's Codex OAuth client has a SINGLE registered redirect URI —
 //! `http://localhost:1455/auth/callback` — so unlike the GCIP sign-in
 //! loopback (which picks the first free port from a small candidate list) this
-//! listener MUST bind port 1455 exactly. There is no fallback: if 1455 is held
-//! by another process the flow cannot complete, so we surface a clear error
-//! instead of silently retrying elsewhere.
+//! listener MUST bind port 1455 exactly. `localhost` does resolve to both
+//! loopback families though, so when a foreign process holds 127.0.0.1:1455
+//! the listener salvages the flow on [::1]:1455 (browsers try ::1 first). Only
+//! when BOTH families are unavailable does it error — the frontend then falls
+//! back to the device-code sign-in instead of dead-ending.
 //!
 //! On the callback we forward the RAW query string (`code=...&state=...`) to
 //! the webview via the `codex-oauth://callback` Tauri event; the PKCE exchange
@@ -93,8 +95,16 @@ fn abort_active_listener() {
 }
 
 /// Bind the fixed redirect port, absorbing the short window in which an
-/// aborted predecessor's socket is still being torn down. Every retry
-/// exhausted means a foreign process owns the port for real.
+/// aborted predecessor's socket is still being torn down.
+///
+/// OpenAI redirects to `localhost`, which resolves to BOTH loopback families,
+/// and browsers attempt `::1` before `127.0.0.1` on modern OS defaults (RFC
+/// 6724 precedence — Windows and macOS alike). A foreign squatter usually
+/// holds only the IPv4 side (Sentry 7639120568: EADDRINUSE on fresh attempts),
+/// so when 127.0.0.1 is taken the callback can still be caught on `[::1]` —
+/// salvage the one-click flow there instead of failing. Every retry exhausted
+/// on both families means the port is unavailable for real (the frontend then
+/// falls back to the device-code sign-in).
 async fn bind_codex_port(port: u16) -> Result<TcpListener, String> {
     let mut last_err = None;
     for attempt in 0..BIND_RETRIES {
@@ -104,6 +114,23 @@ async fn bind_codex_port(port: u16) -> Result<TcpListener, String> {
         match TcpListener::bind(("127.0.0.1", port)).await {
             Ok(listener) => return Ok(listener),
             Err(e) => last_err = Some(e),
+        }
+        match TcpListener::bind(("::1", port)).await {
+            Ok(listener) => {
+                tracing::warn!(
+                    "[codex-oauth-loopback] 127.0.0.1:{port} is taken ({e}); \
+                     salvaged the callback listener on [::1]:{port}",
+                    e = last_err
+                        .as_ref()
+                        .expect("v4 bind failed on this iteration"),
+                );
+                return Ok(listener);
+            }
+            // The v4 error stays the primary diagnostic: v4 is where foreign
+            // squatters live, and "no IPv6 loopback" would only mislead.
+            Err(e) => {
+                tracing::debug!("[codex-oauth-loopback] [::1]:{port} bind also failed: {e}");
+            }
         }
     }
     let e = last_err.expect("BIND_RETRIES > 0 guarantees an error was recorded");
@@ -221,16 +248,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bind_fails_with_actionable_error_when_a_foreign_process_holds_the_port() {
+    async fn bind_fails_with_actionable_error_when_both_loopback_families_are_held() {
         // A real squatter (e.g. an actual Codex CLI mid-login) never releases
         // the port, so the retry loop must exhaust and surface the remedy.
+        // Both families squatted: the [::1] salvage below must not apply.
         // Ephemeral port: tests must never touch the real 1455.
-        let squatter = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
-        let port = squatter.local_addr().unwrap().port();
+        let squatter_v4 = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = squatter_v4.local_addr().unwrap().port();
+        let _squatter_v6 = TcpListener::bind(("::1", port)).await.unwrap();
 
         let err = bind_codex_port(port).await.unwrap_err();
         assert!(err.contains("close other AI coding tools"), "err: {err}");
         assert!(err.contains(&port.to_string()), "err: {err}");
+    }
+
+    #[tokio::test]
+    async fn bind_salvages_the_ipv6_loopback_when_only_ipv4_is_squatted() {
+        // The Sentry-7639120568 wild shape: a foreign process owns
+        // 127.0.0.1:<port> outright. OpenAI redirects to `localhost`, which
+        // browsers resolve to ::1 first, so binding [::1] keeps the one-click
+        // flow alive without the device-code fallback ever showing.
+        let _squatter_v4 = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = _squatter_v4.local_addr().unwrap().port();
+
+        let salvaged = bind_codex_port(port).await.expect("salvage on [::1]");
+        let addr = salvaged.local_addr().unwrap();
+        assert_eq!(addr.port(), port);
+        assert!(addr.ip().is_ipv6(), "expected [::1], got {addr}");
     }
 
     #[tokio::test]

--- a/app/src/lib/codex-device-code-fallback.ts
+++ b/app/src/lib/codex-device-code-fallback.ts
@@ -1,0 +1,57 @@
+/**
+ * Device-code fallback for the desktop Codex/OpenAI loopback relay.
+ *
+ * OpenAI's OAuth client has ONE registered redirect URI on the FIXED local
+ * port 1455, so when another process on the user's machine owns that port the
+ * one-click relay simply cannot run — Houston can neither pick another port
+ * nor free the squatter. Shipped builds still hit this in the wild (Sentry
+ * 7639120568: the bind fails with EADDRINUSE even on a fresh first attempt),
+ * and the old behavior dead-ended the user: no browser, an error toast, then
+ * the 5-minute connect timeout — during onboarding, a wall.
+ *
+ * The device-code grant needs NO local port: the runtime polls OpenAI while
+ * the user types a one-time code, and every login surface (onboarding picker,
+ * AI hub, settings, shell fallback) already renders the code dialog when a
+ * `ProviderLoginUrl` event carries a `user_code`. So instead of dead-ending,
+ * restart the SAME sign-in as a device-code login.
+ *
+ * Sequencing is load-bearing: the in-flight loopback login must be CANCELLED
+ * before the relaunch — the runtime's `startLogin` idempotently reuses an
+ * in-flight login, so relaunching without cancelling would hand back the same
+ * authorize URL (and the dead loopback) instead of a device code. The cancel
+ * also stops the client's connect poll, so no stale timeout toast fires over
+ * the fresh dialog.
+ *
+ * Pure sequencing over injected effects so the policy is unit-testable
+ * (node:test can't import the real tauri/store modules).
+ */
+
+export interface CodexDeviceCodeFallbackOps {
+  /** Log + Sentry-capture the relay failure. NOT a toast: when the fallback
+   *  works, the code dialog is the user-facing surface — a "sign-in failed"
+   *  toast under a working dialog reads as a contradiction. */
+  report(cause: unknown): void;
+  /** Cancel the in-flight loopback login (runtime slot + client poll). */
+  cancelLogin(): Promise<void>;
+  /** Relaunch the sign-in as a device-code grant (`deviceAuth: true`). */
+  launchDeviceCodeLogin(): Promise<void>;
+  /** Dead-end failure toast — only when the fallback itself failed. */
+  fail(cause: unknown): void;
+}
+
+/**
+ * Run the fallback for a relay that could not start. Never rejects — the
+ * caller is an event handler with nobody above it to catch.
+ */
+export async function runCodexDeviceCodeFallback(
+  cause: unknown,
+  ops: CodexDeviceCodeFallbackOps,
+): Promise<void> {
+  ops.report(cause);
+  try {
+    await ops.cancelLogin();
+    await ops.launchDeviceCodeLogin();
+  } catch (err) {
+    ops.fail(err);
+  }
+}

--- a/app/src/lib/codex-loopback.ts
+++ b/app/src/lib/codex-loopback.ts
@@ -16,7 +16,8 @@
 
 import { shouldUseCodexLoopback } from "../components/shell/provider-login-url";
 import { useUIStore } from "../stores/ui";
-import { genericErrorDescription } from "./error-report";
+import { runCodexDeviceCodeFallback } from "./codex-device-code-fallback";
+import { genericErrorDescription, logAndReportError } from "./error-report";
 import i18n from "./i18n";
 import {
   legacyListen,
@@ -54,6 +55,29 @@ function failCodexLogin(frontendProviderId: string, err: unknown): void {
   });
 }
 
+/**
+ * The relay could not run on this machine (the fixed port 1455 is owned by
+ * another process, or the browser refused to open): restart the SAME sign-in
+ * as a device-code login instead of dead-ending into the connect timeout.
+ * Cancel-first ordering and the no-toast-on-success policy live in
+ * codex-device-code-fallback.ts; this only binds the real desktop effects.
+ */
+function fallBackToDeviceCode(
+  frontendProviderId: string,
+  cause: unknown,
+): Promise<void> {
+  return runCodexDeviceCodeFallback(cause, {
+    report: (err) => logAndReportError("codex_loopback_login", err),
+    cancelLogin: () => tauriProvider.cancelLogin(frontendProviderId),
+    launchDeviceCodeLogin: () =>
+      tauriProvider.launchLogin(frontendProviderId, {
+        deviceAuth: true,
+        toast: false,
+      }),
+    fail: (err) => failCodexLogin(frontendProviderId, err),
+  });
+}
+
 /** Relay the callback's query string to the engine. `submitLoginCode`'s
  *  engine-call wrapper already surfaces a failure toast + Sentry report, so the
  *  catch here only keeps the promise from floating unhandled. */
@@ -71,10 +95,11 @@ async function relayCodexCode(
 /**
  * Drive the desktop Codex/OpenAI browser sign-in: listen for the loopback
  * callback, bind the native listener, open the authorize URL, and relay the
- * code back to the engine. Surfaces a toast and cleans up the listener on any
- * setup failure; never leaves an orphaned listener on any path (success, error,
- * or timeout). Resolves once the browser has been opened (the callback is
- * handled asynchronously); never rejects.
+ * code back to the engine. On any setup failure it cleans up the listener and
+ * falls back to the device-code sign-in (`fallBackToDeviceCode`) — a toast
+ * only fires if that fallback fails too. Never leaves an orphaned listener on
+ * any path (success, error, or timeout). Resolves once the browser has been
+ * opened (the callback is handled asynchronously); never rejects.
  */
 export async function beginCodexBrowserLogin(
   frontendProviderId: string,
@@ -106,7 +131,7 @@ export async function beginCodexBrowserLogin(
     });
   } catch (err) {
     cleanup();
-    failCodexLogin(frontendProviderId, err);
+    await fallBackToDeviceCode(frontendProviderId, err);
     return;
   }
 
@@ -117,7 +142,7 @@ export async function beginCodexBrowserLogin(
     await osOpenUrl(authorizeUrl);
   } catch (err) {
     cleanup();
-    failCodexLogin(frontendProviderId, err);
+    await fallBackToDeviceCode(frontendProviderId, err);
   }
 }
 
@@ -152,8 +177,8 @@ export function tryBeginCodexLoopbackLogin(ev: {
   // Codex/OpenAI against a REMOTE engine on desktop: bind our OWN local
   // 127.0.0.1:1455 listener and relay the callback code, so ChatGPT sign-in
   // works with zero device code. pi's 1455 is in the pod, so no collision.
-  // beginCodexBrowserLogin surfaces its own failure toast and never leaves an
-  // orphaned listener.
+  // beginCodexBrowserLogin falls back to the device-code sign-in when the
+  // relay can't run and never leaves an orphaned listener.
   void beginCodexBrowserLogin(ev.provider, ev.url);
   return true;
 }

--- a/app/tests/codex-device-code-fallback.test.ts
+++ b/app/tests/codex-device-code-fallback.test.ts
@@ -1,0 +1,87 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  type CodexDeviceCodeFallbackOps,
+  runCodexDeviceCodeFallback,
+} from "../src/lib/codex-device-code-fallback.ts";
+
+// HOU-1063 — with OpenAI's fixed local callback port (1455) owned by another
+// process, the desktop loopback relay cannot run and the connect click used
+// to dead-end: no browser, an error toast, then the 5-minute connect timeout.
+// During onboarding that was a wall. The relay now restarts the sign-in as a
+// device-code grant (no local port needed); these pin the sequencing that
+// makes the fallback correct.
+
+function recordingOps(overrides: Partial<CodexDeviceCodeFallbackOps> = {}) {
+  const calls: string[] = [];
+  const failures: unknown[] = [];
+  const ops: CodexDeviceCodeFallbackOps = {
+    report: () => calls.push("report"),
+    cancelLogin: async () => {
+      calls.push("cancel");
+    },
+    launchDeviceCodeLogin: async () => {
+      calls.push("launch");
+    },
+    fail: (cause) => {
+      calls.push("fail");
+      failures.push(cause);
+    },
+    ...overrides,
+  };
+  return { ops, calls, failures };
+}
+
+describe("runCodexDeviceCodeFallback", () => {
+  it("reports the relay failure, then cancels BEFORE relaunching as device code", async () => {
+    // Cancel-first is load-bearing: the runtime's startLogin idempotently
+    // reuses an in-flight login, so relaunching without cancelling would hand
+    // back the same dead loopback URL instead of a device code.
+    const { ops, calls } = recordingOps();
+    await runCodexDeviceCodeFallback(new Error("port 1455 unavailable"), ops);
+    deepStrictEqual(calls, ["report", "cancel", "launch"]);
+  });
+
+  it("does not toast when the fallback succeeds — the code dialog is the surface", async () => {
+    const { ops, calls } = recordingOps();
+    await runCodexDeviceCodeFallback(new Error("port busy"), ops);
+    strictEqual(calls.includes("fail"), false);
+  });
+
+  it("surfaces the relaunch failure when the fallback itself dies", async () => {
+    const boom = new Error("engine unreachable");
+    const { ops, calls, failures } = recordingOps({
+      launchDeviceCodeLogin: async () => {
+        throw boom;
+      },
+    });
+    await runCodexDeviceCodeFallback(new Error("port busy"), ops);
+    deepStrictEqual(calls, ["report", "cancel", "fail"]);
+    deepStrictEqual(failures, [boom]);
+  });
+
+  it("skips the relaunch and surfaces the failure when cancel fails", async () => {
+    // Launching over an uncancelled login would reuse the dead loopback flow;
+    // better to fail loudly than to re-show a sign-in that cannot complete.
+    const boom = new Error("cancel rejected");
+    const { ops, calls, failures } = recordingOps({
+      cancelLogin: async () => {
+        throw boom;
+      },
+    });
+    await runCodexDeviceCodeFallback(new Error("port busy"), ops);
+    deepStrictEqual(calls, ["report", "fail"]);
+    deepStrictEqual(failures, [boom]);
+  });
+
+  it("never rejects, even when every effect fails", async () => {
+    const { ops } = recordingOps({
+      cancelLogin: async () => {
+        throw new Error("cancel died");
+      },
+    });
+    // A rejection here would be an unhandled rejection in the event handler
+    // that drives the relay — resolving is part of the contract.
+    await runCodexDeviceCodeFallback(new Error("port busy"), ops);
+  });
+});


### PR DESCRIPTION
## Root cause

OpenAI's Codex OAuth client has a single registered redirect URI on the **fixed** port 1455 (`http://localhost:1455/auth/callback`), so on a remote-engine desktop the connect flow must bind that port locally to catch the callback. When another process on the user's machine owns it, the relay cannot start at all.

PR #1158 (shipped in 0.5.35) fixed Houston's own retry self-collision on that port — but Sentry 7639120568 keeps firing on 0.5.35 Windows installs with `EADDRINUSE` (os error 10048) on a **fresh first attempt**, including the new "wait a few minutes" copy that proves the fixed code path ran and exhausted its bind retries. Something outside Houston holds the port.

The user experience was a dead end: click Connect → no browser opens → an error toast → five minutes later the `connectTimedOut` toast from the connect poll. During onboarding ("Connect your AI", step 1 of 3) that is a hard wall.

## Fix — two layers, so users (almost) never see anything unusual

**Layer 1 (shell): salvage the callback on `[::1]:1455`.** `localhost` resolves to BOTH loopback families, and browsers attempt `::1` before `127.0.0.1` on modern Windows/macOS (RFC 6724 precedence — the affected user's Edge included). The wild squatters hold only the IPv4 side, so when `127.0.0.1:1455` is taken the listener now binds `[::1]:1455` and the **one-click browser flow keeps working invisibly** — no new UI at all. (`app/src-tauri/src/codex_oauth_loopback.rs`)

**Layer 2 (frontend): device-code fallback instead of a dead end.** Only when BOTH loopback families are unavailable (or the browser can't be opened) does the app restart the same sign-in as a device-code login — no local port needed, and every login surface already renders the one-time-code dialog. Cancel-first ordering is load-bearing: the runtime's `startLogin` idempotently reuses an in-flight login, so relaunching without cancelling would hand back the same dead loopback URL. The cancel also stops the 5-minute connect poll so no stale timeout toast fires over the dialog. (`app/src/lib/codex-device-code-fallback.ts` — pure sequencing + tests; wired in `app/src/lib/codex-loopback.ts`)

The relay failure still reaches the log + Sentry; the failure toast now only fires if the fallback itself fails.

## Before (reproduction)

1. On a machine where another process holds port 1455 on IPv4 (e.g. `nc -l 127.0.0.1 1455`), sign in to a hosted-cloud workspace and reach onboarding's "Connect your AI" step (or AI Models in settings).
2. Click **Connect** on OpenAI.
3. No browser opens; a "couldn't open the sign-in" toast appears, and ~5 minutes later the "connection didn't complete in time" toast. There is no way forward.

## After (verification)

1. Squat only `127.0.0.1:1455` → click **Connect**: the browser opens and the normal one-click flow completes (callback caught on `[::1]:1455`). No visible difference from a healthy machine.
2. Squat BOTH `127.0.0.1:1455` and `[::1]:1455` → click **Connect**: the one-time-code dialog opens; completing it in any browser connects the provider.
3. With 1455 free, the flow is byte-for-byte unchanged.
4. Gates: `cd app/src-tauri && cargo test` (188 pass, incl. new salvage/both-families tests), `cd app && pnpm test` (2467 pass), `pnpm tsgo --noEmit`, `pnpm --filter houston-web typecheck`, `pnpm check` — all green.

HOU-1063