### PR TITLE
feat(metrics): host boot-span ledger + client UX perf spans (HOU-1011)

### DIFF
--- a/app/src-tauri/src/commands/os.rs
+++ b/app/src-tauri/src/commands/os.rs
@@ -7,10 +7,34 @@
 //! desktop-only.
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::process::Command;
 
 fn expand(p: &str) -> PathBuf {
     super::expand_tilde(&PathBuf::from(p))
+}
+
+// -- Launch timestamp (HOU-1011 client perf spans) --
+
+static LAUNCH_T0_MS: OnceLock<u64> = OnceLock::new();
+
+/// Stamp "Houston's own code started" as early as `run()` allows. The webview's
+/// `performance.timeOrigin` starts only at webview creation, missing the
+/// shell's boot — this stamp is the app-open T0 the perf spans measure from.
+/// Idempotent; the first call wins.
+pub fn stamp_launch_t0() {
+    let _ = LAUNCH_T0_MS.set(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0),
+    );
+}
+
+#[tauri::command(rename_all = "snake_case")]
+pub fn launch_t0_ms() -> Option<u64> {
+    LAUNCH_T0_MS.get().copied().filter(|&ms| ms > 0)
 }
 
 // -- Directory Picker --

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -166,6 +166,10 @@ fn engine_identity_env(session_json: Option<&str>) -> Vec<(String, String)> {
 }
 
 pub fn run() {
+    // App-open T0 for the client perf spans (HOU-1011): the first line of
+    // Houston's own code. Everything the user waits for is measured from here.
+    commands::os::stamp_launch_t0();
+
     // First-launch DMG guard (macOS only). If we were double-clicked from
     // inside the installer DMG (path under /Volumes/…), show a native
     // dialog asking the user to move Houston to Applications, do the
@@ -429,6 +433,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             // OS-native glue — everything domain-related flows through the
             // engine over HTTP/WS, not Tauri IPC.
+            commands::os::launch_t0_ms,
             commands::os::pick_directory,
             commands::os::open_url,
             commands::os::open_file,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -28,6 +28,7 @@ import { useNotificationNudges } from "./hooks/use-notification-nudges";
 import { useOnboardingCompleted } from "./hooks/use-onboarding-completed";
 import { useOnboardingPending } from "./hooks/use-onboarding-pending";
 import { useOnboardingSegment } from "./hooks/use-onboarding-segment";
+import { usePerfSpans } from "./hooks/use-perf-spans";
 import { useProviderCatalog } from "./hooks/use-provider-catalog";
 import { useReadCursorTracker } from "./hooks/use-read-cursors";
 import { useScreenPrefetch } from "./hooks/use-screen-prefetch";
@@ -74,6 +75,9 @@ export default function App() {
   // relaunch (quiet focus + interval re-list; spaces-capable hosts only).
   useSpacesLiveRefresh();
   useAnalyticsSubscriber();
+  // Client UX timing spans (HOU-1011): upgrades T0 to the shell's process
+  // start and ships measured journeys to the gateway metrics ingest.
+  usePerfSpans();
   useIntegrationSessionSync();
   // Keep the Agent Store adapter pointed at the gateway with the user's session
   // token in local-sidecar mode (account-based publish; no manage tokens).

--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -2,6 +2,7 @@ import { AIBoard, type MessageMention } from "@houston-ai/board";
 import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useOpenAgentHref } from "../../hooks/use-open-agent-file";
+import { perfSpans } from "../../lib/perf-spans";
 import { modelAcceptsImages } from "../../lib/providers";
 import { useUIStore } from "../../stores/ui";
 import { useAttachmentRejectionDialog } from "../attachment-rejection-dialog";
@@ -145,7 +146,12 @@ export function MissionBoard({ source }: { source: BoardSource }) {
           columns={columns}
           selectedId={source.selectedId}
           highlightedId={source.highlightedId}
-          onSelect={source.setSelectedId}
+          onSelect={(id) => {
+            // Card-open perf mark (HOU-1011): completed when the opened
+            // conversation's messages paint (use-agent-board-data).
+            if (id) perfSpans.cardClicked();
+            source.setSelectedId(id);
+          }}
           feedItems={source.feedItems}
           isLoading={source.loading}
           onDelete={source.onDelete}

--- a/app/src/components/board/use-agent-board-data.ts
+++ b/app/src/components/board/use-agent-board-data.ts
@@ -1,6 +1,6 @@
 import type { KanbanItem } from "@houston-ai/board";
 import type { FeedItem } from "@houston-ai/chat";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
   useActivity,
@@ -16,6 +16,7 @@ import {
   canDropMission,
   DONE_STATUS,
 } from "../../lib/mission-selection";
+import { perfSpans } from "../../lib/perf-spans";
 import {
   type HistoryLoadOptions,
   tauriActivity,
@@ -51,6 +52,16 @@ export function useAgentBoardData({
   const agentModes = agentDef.config.agents;
   const addToast = useUIStore((s) => s.addToast);
   const { data: fetchedItems } = useActivity(path);
+  // App-open → board perf mark (HOU-1011): the cards' data resolved; the rAF
+  // waits for the render that paints them. Latched once per app session
+  // inside perfSpans, so re-mounts and agent switches are free no-ops.
+  const cardsResolved = fetchedItems !== undefined;
+  useEffect(() => {
+    if (!cardsResolved) return;
+    if (typeof requestAnimationFrame === "function")
+      requestAnimationFrame(() => perfSpans.boardRendered());
+    else perfSpans.boardRendered();
+  }, [cardsResolved]);
   const deleteActivity = useDeleteActivity(path);
   const updateActivity = useUpdateActivity(path);
 
@@ -99,6 +110,22 @@ export function useAgentBoardData({
   );
   const activeVm = useConversationVm(path, activeSessionKey);
   const activeFeed = activeVm?.feed ?? EMPTY_FEED;
+  // Card-click → chat perf mark (HOU-1011): the opened conversation's
+  // messages are in the feed; the rAF waits for the paint. No-ops unless a
+  // card click armed the mark (perfSpans.cardClicked in mission-board). The
+  // dep is the painted conversation's KEY (not a boolean): switching cards
+  // while both feeds are cached keeps a boolean true, but the key change is
+  // what re-fires the mark for the newly opened chat.
+  const paintedSessionKey =
+    activeSessionKey !== null && activeFeed.length > 0
+      ? activeSessionKey
+      : null;
+  useEffect(() => {
+    if (paintedSessionKey === null) return;
+    if (typeof requestAnimationFrame === "function")
+      requestAnimationFrame(() => perfSpans.chatRendered());
+    else perfSpans.chatRendered();
+  }, [paintedSessionKey]);
   const feedItems = useMemo<Record<string, FeedItem[]>>(
     () => (activeSessionKey ? { [activeSessionKey]: activeFeed } : {}),
     [activeSessionKey, activeFeed],

--- a/app/src/components/board/use-agent-board-send.ts
+++ b/app/src/components/board/use-agent-board-send.ts
@@ -8,6 +8,7 @@ import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { createMission } from "../../lib/create-mission";
 import { classifyFileKind } from "../../lib/file-kind";
 import { maybeShowFirstMissionPrompt } from "../../lib/notification-nudge";
+import { perfSpans } from "../../lib/perf-spans";
 import { queryKeys } from "../../lib/query-keys";
 import { formatVisibleMessageText } from "../../lib/queued-chat";
 import { tauriAttachments, tauriChat } from "../../lib/tauri";
@@ -143,6 +144,7 @@ export function useAgentBoardSend({
         provider: providerOverride,
         model: modelOverride,
       });
+      perfSpans.messageSent();
       analytics.track("chat_message_sent", {
         provider: providerOverride,
         model: modelOverride,
@@ -223,6 +225,7 @@ export function useAgentBoardSend({
             .getState()
             .setQueuedRowStatus(agent.id, activity.id, "running");
         }
+        perfSpans.messageSent();
         analytics.track("chat_message_sent", {
           provider: overrides.providerOverride,
           model: overrides.modelOverride,
@@ -253,6 +256,7 @@ export function useAgentBoardSend({
           },
         });
         setLoading((prev) => ({ ...prev, [sessionKey]: true }));
+        perfSpans.messageSent();
         analytics.track("chat_message_sent", {
           provider: overrides.providerOverride,
           model: overrides.modelOverride,

--- a/app/src/components/board/use-mission-control-archived-send.ts
+++ b/app/src/components/board/use-mission-control-archived-send.ts
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { analytics } from "../../lib/analytics";
 import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { classifyFileKind } from "../../lib/file-kind";
+import { perfSpans } from "../../lib/perf-spans";
 import { tauriAttachments, tauriChat } from "../../lib/tauri";
 import { DEFAULT_TURN_MODE } from "../../lib/turn-mode";
 import type { Agent, AgentDefinition } from "../../lib/types";
@@ -65,6 +66,7 @@ export function useMissionControlArchivedSend({
           modeOverride: DEFAULT_TURN_MODE,
           mentions,
         });
+        perfSpans.messageSent();
         analytics.track("chat_message_sent", {
           provider: providerOverride,
           model: modelOverride,

--- a/app/src/components/tabs/use-archived-send-message.ts
+++ b/app/src/components/tabs/use-archived-send-message.ts
@@ -6,6 +6,7 @@ import type { Activity } from "../../data/activity";
 import { analytics } from "../../lib/analytics";
 import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { classifyFileKind } from "../../lib/file-kind";
+import { perfSpans } from "../../lib/perf-spans";
 import { tauriAttachments, tauriChat } from "../../lib/tauri";
 import { DEFAULT_TURN_MODE } from "../../lib/turn-mode";
 import type { AgentDefinition } from "../../lib/types";
@@ -63,6 +64,7 @@ export function useArchivedSendMessage({
           modeOverride: DEFAULT_TURN_MODE,
           mentions,
         });
+        perfSpans.messageSent();
         analytics.track("chat_message_sent", {
           provider: effectiveProvider,
           model: effectiveModel,

--- a/app/src/hooks/use-analytics-subscriber.ts
+++ b/app/src/hooks/use-analytics-subscriber.ts
@@ -4,6 +4,7 @@ import { readAgentModelOverrides } from "../lib/agent-model-overrides";
 import { buildAiGenerationProps } from "../lib/ai-generation";
 import { analytics, classifyAnalyticsError } from "../lib/analytics";
 import { subscribeHoustonEvents } from "../lib/events";
+import { perfSpans } from "../lib/perf-spans";
 import { tauriConfig } from "../lib/tauri";
 
 /** What the `final_result` feed frame carries (ui/chat FeedEntry). */
@@ -76,6 +77,17 @@ export function useAnalyticsSubscriber() {
     const unlisten = subscribeHoustonEvents((p: HoustonEvent) => {
       switch (p.type) {
         case "FeedItem": {
+          // Perf span completion (HOU-1011): the FIRST visible agent output
+          // after a send — a streaming frame when the model streams, the
+          // finalized reply when it doesn't. perfSpans pairs it with the
+          // armed send mark and no-ops otherwise, so firing on every frame
+          // is safe (only the first one after a send completes anything).
+          if (
+            p.data.item.feed_type === "assistant_text_streaming" ||
+            p.data.item.feed_type === "assistant_text"
+          ) {
+            perfSpans.firstAssistantOutput();
+          }
           // Activation signal: user got a finalized assistant reply.
           // "assistant_text_streaming" is skipped — it fires continuously
           // during streaming and would inflate counts. "assistant_text" is

--- a/app/src/hooks/use-perf-spans.ts
+++ b/app/src/hooks/use-perf-spans.ts
@@ -1,0 +1,72 @@
+import { useEffect, useRef } from "react";
+import { analytics } from "../lib/analytics";
+import { osLaunchT0Ms } from "../lib/os-bridge";
+import { type PerfSpanObservation, perfSpans } from "../lib/perf-spans";
+import { currentPlatformOs } from "../lib/platform";
+import { useSession } from "./use-session";
+
+/**
+ * Where client perf spans land: the public gateway's `/v1/client-metrics`
+ * ingest (session-authed; the gateway folds them into Prometheus histograms
+ * for grafana.gethouston.ai). Same target in local-sidecar AND gateway-fronted
+ * modes — the route is gateway-owned, never proxied to a pod.
+ */
+const CLIENT_METRICS_URL = (
+  (import.meta.env?.VITE_CLIENT_METRICS_GATEWAY_URL as string | undefined) ??
+  "https://gateway.gethouston.ai"
+).replace(/\/+$/, "");
+
+const APP_VERSION =
+  typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "0.0.0";
+
+/**
+ * Wires the perf-span singleton (HOU-1011): upgrades T0 to the Tauri shell's
+ * process-start stamp, and installs the transport once a session exists —
+ * signed-out installs keep measuring but only mirror to PostHog (the gateway
+ * ingest requires a user). Mount once in `<App/>`, like the other one-shot
+ * app-level subscribers.
+ */
+export function usePerfSpans(): void {
+  const { data: session } = useSession();
+  const tokenRef = useRef<string | null>(null);
+  tokenRef.current = session?.idToken ?? null;
+
+  useEffect(() => {
+    void osLaunchT0Ms().then((t0) => {
+      if (t0 !== null) perfSpans.setLaunchT0(t0);
+    });
+    perfSpans.configure({
+      async send(spans: PerfSpanObservation[]) {
+        const token = tokenRef.current;
+        // No session → nothing to authenticate as; drop rather than queue
+        // forever (PostHog already mirrored the spans).
+        if (!token) return;
+        const res = await fetch(`${CLIENT_METRICS_URL}/v1/client-metrics`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            spans: spans.map((s) => ({
+              ...s,
+              platform: currentPlatformOs,
+              appVersion: APP_VERSION,
+            })),
+          }),
+        });
+        // 404 = older gateway without the ingest; treat as delivered.
+        if (!res.ok && res.status !== 404)
+          throw new Error(`client-metrics rejected: ${res.status}`);
+      },
+      mirror(span, ms) {
+        analytics.track("perf_span", { span, duration_ms: ms });
+      },
+    });
+    const onHide = () => {
+      if (document.visibilityState === "hidden") void perfSpans.flush();
+    };
+    document.addEventListener("visibilitychange", onHide);
+    return () => document.removeEventListener("visibilitychange", onHide);
+  }, []);
+}

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -165,7 +165,11 @@ export type AnalyticsEventName =
   // Reliability
   | "session_completed"
   | "session_failed"
-  | "app_error_shown";
+  | "app_error_shown"
+  // Client UX timing span (HOU-1011): PostHog mirror of the gateway's
+  // Prometheus histograms, for per-user/session drill-down. Carries `span`
+  // (which journey) + `duration_ms`.
+  | "perf_span";
 
 type AnalyticsProperty =
   | "provider"
@@ -209,7 +213,10 @@ type AnalyticsProperty =
   | "selected_segment"
   | "source_screen"
   // Org membership role (org_member_added / org_role_changed)
-  | "role";
+  | "role"
+  // Client UX timing (perf_span)
+  | "span"
+  | "duration_ms";
 
 type Props = Partial<Record<AnalyticsProperty, string | number | boolean>>;
 type UserIdentity = {
@@ -261,6 +268,8 @@ const ALLOWED_PROPS = new Set<AnalyticsProperty>([
   "selected_segment",
   "source_screen",
   "role",
+  "span",
+  "duration_ms",
 ]);
 
 // Bootstrap PostHog at module load so a configured build can capture errors

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -476,3 +476,16 @@ export function onDictationModelProgress(
     handler(ev.payload),
   );
 }
+
+/** The shell's process-start stamp (epoch ms) — the app-open T0 the perf
+ *  spans measure from (HOU-1011). `null` outside Tauri or on a shell too old
+ *  to serve the command (the caller falls back to `performance.timeOrigin`). */
+export async function osLaunchT0Ms(): Promise<number | null> {
+  if (!osIsTauri()) return null;
+  try {
+    return (await invoke<number | null>("launch_t0_ms")) ?? null;
+  } catch {
+    // Older shell without the command — the webview clock is close enough.
+    return null;
+  }
+}

--- a/app/src/lib/perf-spans.ts
+++ b/app/src/lib/perf-spans.ts
@@ -1,0 +1,145 @@
+/**
+ * Client UX timing spans (HOU-1011). Measures the four cold-journey timings —
+ * app open → board cards painted, card click → chat painted, message send →
+ * first agent output, app open → first output of the session — and ships them
+ * to the gateway's `/v1/client-metrics` ingest (Prometheus histograms behind
+ * grafana.gethouston.ai) plus a PostHog mirror for per-user drill-down.
+ *
+ * Pure module: no React, no Tauri, no fetch of its own until `configure()`
+ * injects the transport. All clocks are epoch ms (performance.timeOrigin as
+ * the web T0; the Tauri shell upgrades T0 to its process start).
+ */
+
+export type PerfSpanName =
+  | "app_to_board"
+  | "card_click_to_chat"
+  | "send_to_first_response"
+  | "app_to_first_response";
+
+export interface PerfSpanObservation {
+  span: PerfSpanName;
+  ms: number;
+}
+
+export interface PerfSpanTransport {
+  /** POST a batch to the gateway; absent session → don't call configure yet. */
+  send(spans: PerfSpanObservation[]): Promise<void>;
+  /** Per-span mirror (PostHog). Fire-and-forget. */
+  mirror?(span: PerfSpanName, ms: number): void;
+}
+
+/** Marks older than this are stale (user wandered off) — never completed. */
+const PENDING_TTL_MS = 60_000;
+const FLUSH_DELAY_MS = 5_000;
+
+export class PerfSpans {
+  private t0Ms: number;
+  private readonly onceDone = new Set<PerfSpanName>();
+  private pendingChatOpenAt: number | null = null;
+  private pendingSendAt: number | null = null;
+  private queue: PerfSpanObservation[] = [];
+  private transport: PerfSpanTransport | null = null;
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly now: () => number;
+
+  constructor(opts?: { t0Ms?: number; now?: () => number }) {
+    this.now = opts?.now ?? Date.now;
+    this.t0Ms =
+      opts?.t0Ms ??
+      (typeof performance !== "undefined"
+        ? performance.timeOrigin
+        : this.now());
+  }
+
+  /** The Tauri shell's process-start stamp — earlier than the webview's. */
+  setLaunchT0(epochMs: number): void {
+    // Only ever move T0 earlier: a late (buggy) stamp must not shrink spans.
+    if (Number.isFinite(epochMs) && epochMs < this.t0Ms) this.t0Ms = epochMs;
+  }
+
+  configure(transport: PerfSpanTransport): void {
+    this.transport = transport;
+    if (this.queue.length > 0) this.scheduleFlush();
+  }
+
+  /** Mission cards painted with resolved data. Once per app session. */
+  boardRendered(): void {
+    this.observeOnce("app_to_board", this.now() - this.t0Ms);
+  }
+
+  /** The user opened a mission card (chat panel about to load). */
+  cardClicked(): void {
+    this.pendingChatOpenAt = this.now();
+  }
+
+  /** The opened conversation's messages painted. Completes cardClicked. */
+  chatRendered(): void {
+    const at = this.take(this.pendingChatOpenAt);
+    this.pendingChatOpenAt = null;
+    if (at !== null) this.observe("card_click_to_chat", this.now() - at);
+  }
+
+  /** The user sent a message. Overwrites an unanswered previous send. */
+  messageSent(): void {
+    this.pendingSendAt = this.now();
+  }
+
+  /** First agent output (first streamed word) became visible. */
+  firstAssistantOutput(): void {
+    const at = this.take(this.pendingSendAt);
+    this.pendingSendAt = null;
+    if (at !== null) {
+      this.observe("send_to_first_response", this.now() - at);
+      this.observeOnce("app_to_first_response", this.now() - this.t0Ms);
+    }
+  }
+
+  /** Ship anything queued now (page-hide, tests). */
+  async flush(): Promise<void> {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    if (!this.transport || this.queue.length === 0) return;
+    const batch = this.queue;
+    this.queue = [];
+    try {
+      await this.transport.send(batch);
+    } catch {
+      // Re-queue once so a transient network blip isn't a lost sample; a
+      // second failure drops the batch (metrics are best-effort, never noise).
+      if (batch.length + this.queue.length <= 40) this.queue.unshift(...batch);
+    }
+  }
+
+  private take(at: number | null): number | null {
+    if (at === null) return null;
+    return this.now() - at <= PENDING_TTL_MS ? at : null;
+  }
+
+  private observeOnce(span: PerfSpanName, ms: number): void {
+    if (this.onceDone.has(span)) return;
+    this.onceDone.add(span);
+    this.observe(span, ms);
+  }
+
+  private observe(span: PerfSpanName, ms: number): void {
+    if (!Number.isFinite(ms) || ms < 0) return;
+    this.queue.push({ span, ms: Math.round(ms) });
+    this.transport?.mirror?.(span, Math.round(ms));
+    this.scheduleFlush();
+  }
+
+  private scheduleFlush(): void {
+    if (!this.transport || this.flushTimer) return;
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      void this.flush();
+    }, FLUSH_DELAY_MS);
+    // Never keep the process alive for a metrics flush (tests, shutdown).
+    (this.flushTimer as { unref?: () => void }).unref?.();
+  }
+}
+
+/** The app-wide singleton the wiring hook and call sites share. */
+export const perfSpans = new PerfSpans();

--- a/app/tests/perf-spans.test.ts
+++ b/app/tests/perf-spans.test.ts
@@ -1,0 +1,106 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { type PerfSpanObservation, PerfSpans } from "../src/lib/perf-spans.ts";
+
+function harness(startMs = 100_000) {
+  let now = startMs;
+  const sent: PerfSpanObservation[][] = [];
+  const mirrored: Array<{ span: string; ms: number }> = [];
+  const spans = new PerfSpans({ t0Ms: startMs, now: () => now });
+  spans.configure({
+    async send(batch) {
+      sent.push(batch);
+    },
+    mirror(span, ms) {
+      mirrored.push({ span, ms });
+    },
+  });
+  return { spans, sent, mirrored, tick: (ms: number) => (now += ms) };
+}
+
+describe("PerfSpans", () => {
+  it("measures app_to_board from T0, once per session", async () => {
+    const { spans, sent, tick } = harness();
+    tick(1500);
+    spans.boardRendered();
+    tick(50);
+    spans.boardRendered(); // agent switch — must not double-report
+    await spans.flush();
+    deepStrictEqual(sent.flat(), [{ span: "app_to_board", ms: 1500 }]);
+  });
+
+  it("pairs card click with the next chat paint", async () => {
+    const { spans, sent, tick } = harness();
+    spans.chatRendered(); // paint with no armed click — ignored
+    spans.cardClicked();
+    tick(320);
+    spans.chatRendered();
+    spans.chatRendered(); // second paint — mark already consumed
+    await spans.flush();
+    deepStrictEqual(sent.flat(), [{ span: "card_click_to_chat", ms: 320 }]);
+  });
+
+  it("send → first output yields both send span and once-only journey span", async () => {
+    const { spans, sent, tick } = harness();
+    spans.firstAssistantOutput(); // routine/teammate output with no send — ignored
+    tick(2000);
+    spans.messageSent();
+    tick(800);
+    spans.firstAssistantOutput();
+    spans.firstAssistantOutput(); // streaming continues — no re-report
+    tick(100);
+    spans.messageSent();
+    tick(400);
+    spans.firstAssistantOutput();
+    await spans.flush();
+    deepStrictEqual(sent.flat(), [
+      { span: "send_to_first_response", ms: 800 },
+      { span: "app_to_first_response", ms: 2800 },
+      { span: "send_to_first_response", ms: 400 },
+    ]);
+  });
+
+  it("expires stale marks instead of reporting minutes-long spans", async () => {
+    const { spans, sent, tick } = harness();
+    spans.cardClicked();
+    tick(61_000);
+    spans.chatRendered();
+    await spans.flush();
+    strictEqual(sent.flat().length, 0);
+  });
+
+  it("re-queues a failed batch once, then drops it", async () => {
+    let now = 0;
+    let failures = 0;
+    const sent: PerfSpanObservation[][] = [];
+    const spans = new PerfSpans({ t0Ms: 0, now: () => now });
+    spans.configure({
+      async send(batch) {
+        if (failures++ === 0) throw new Error("offline");
+        sent.push(batch);
+      },
+    });
+    now = 10;
+    spans.boardRendered();
+    await spans.flush(); // fails → re-queued
+    await spans.flush(); // succeeds
+    deepStrictEqual(sent.flat(), [{ span: "app_to_board", ms: 10 }]);
+  });
+
+  it("only moves T0 earlier", async () => {
+    const { spans, sent, tick } = harness(100_000);
+    spans.setLaunchT0(150_000); // late bogus stamp — ignored
+    spans.setLaunchT0(99_000); // shell start before webview — accepted
+    tick(1000);
+    spans.boardRendered();
+    await spans.flush();
+    deepStrictEqual(sent.flat(), [{ span: "app_to_board", ms: 2000 }]);
+  });
+
+  it("mirrors every observation even before any transport failure handling", async () => {
+    const { spans, mirrored, tick } = harness();
+    tick(5);
+    spans.boardRendered();
+    deepStrictEqual(mirrored, [{ span: "app_to_board", ms: 5 }]);
+  });
+});

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -33,6 +33,7 @@
     "effect": "4.0.0-beta.59",
     "fflate": "0.8.3",
     "js-yaml": "4.1.1",
+    "prom-client": "15.1.3",
     "tsx": "4.23.0"
   },
   "devDependencies": {

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -42,6 +42,8 @@ import { type ControlPlaneDeps, createControlPlaneServer } from "../server";
 import { syncSharedEndpoint } from "../shared-endpoint/sync";
 import { LocalWorkspaceStore } from "../store/local";
 import { SharedMirrorController, StoreSyncDaemon } from "../store-sync";
+import { BootTelemetry } from "../telemetry/boot";
+import { sendBootReport } from "../telemetry/boot-report";
 import { MemoryTurnBus } from "../turn/bus";
 import { UsageSampler } from "../usage/sampler";
 import { FsVfs } from "../vfs";
@@ -250,6 +252,7 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
   const vfs = new FsVfs(opts.workspacesRoot);
   const paths = new LocalPaths();
   const bus = new MemoryTurnBus();
+  const boot = new BootTelemetry();
   const events = new BusEventHub(bus);
   const vault = new EnvCredentialVault({ secret: opts.token });
   const fileCredentials = new FileCredentialStore(opts.credentialsPath);
@@ -529,6 +532,10 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     // give it the REAL directory (the agent id is a route key, not a path).
     agentDir: (_ws, a) => agentDir(a.id),
     corsOrigin: "*",
+    // Boot-span ledger behind GET /metrics (HOU-1011). Token-gated like every
+    // non-public route: timings aren't secrets, but there is no reason to
+    // widen the unauthenticated surface for them.
+    metrics: { render: () => boot.render(), contentType: boot.contentType },
   };
 
   const server = createControlPlaneServer(deps);
@@ -594,10 +601,15 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
           `[local-host] boot: ${phase} at +${process.uptime().toFixed(1)}s`,
         );
       bootStamp("module eval done");
+      boot.record("module_eval", process.uptime() * 1000);
       // The object store is authoritative in managed server mode. Hydration is
       // readiness-critical and must finish before migrations or HTTP listening;
       // failure propagates so the pod restarts without ever syncing an empty tree.
-      await syncDaemon?.hydrate();
+      if (syncDaemon) {
+        const objects = await boot.time("hydrate", () => syncDaemon.hydrate());
+        boot.setHydratedObjects(objects);
+      }
+      const migrationsT0 = Date.now();
       // Shared storage is a disposable synchronized mirror, not a readiness
       // invariant. Start its pull after authoritative agent hydration but do
       // not await the network; the first turn joins it through beforeTurn.
@@ -679,10 +691,15 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
           );
         }
       }
+      boot.record("migrations", Date.now() - migrationsT0);
       bootStamp("hydration + migrations done");
       const bind = opts.bind ?? "127.0.0.1";
-      await new Promise<void>((resolve) =>
-        server.listen(opts.port, bind, () => resolve()),
+      await boot.time(
+        "listen",
+        () =>
+          new Promise<void>((resolve) =>
+            server.listen(opts.port, bind, () => resolve()),
+          ),
       );
       // Passive migration-source mode runs no background daemons (a read-only
       // source must not fire routines, sync, or churn watch events).
@@ -703,6 +720,18 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
           redactToken: opts.redactBannerToken ?? false,
         }),
       );
+      boot.markReady();
+      // One-shot boot report to the gateway (HOU-1011): pods scale to zero, so
+      // Prometheus can't scrape a boot — push the ledger instead. Same gateway
+      // quadruple as usage reporting; absent on desktop/self-host = no report.
+      const reportBoot = () => {
+        if (!opts.usageReporting) return;
+        void sendBootReport({
+          report: opts.usageReporting,
+          telemetry: boot,
+          log: severityLog,
+        });
+      };
       if (opts.eagerRuntime) {
         // Fire-and-forget AFTER the banner: /health (and the supervisor)
         // must never wait on a runtime boot — the point is overlap, and a
@@ -711,6 +740,7 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
         // hosts one agent, and a multi-agent tree shouldn't stampede the
         // CPU it shares with the boot it is overlapping.
         void (async () => {
+          const spawnT0 = Date.now();
           for (const ws of await store.listWorkspaces()) {
             for (const agent of await store.listAgents(ws.id)) {
               await launcher.ensureAwake(agent).catch((err) => {
@@ -721,7 +751,13 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
               });
             }
           }
+          // The report waits for the spawn on purpose: it's the slowest boot
+          // step (~10s) and the whole point of the ledger (HOU-867).
+          boot.record("runtime_spawn", Date.now() - spawnT0);
+          reportBoot();
         })();
+      } else {
+        reportBoot();
       }
     },
     stop() {

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -195,6 +195,12 @@ export interface ControlPlaneDeps {
    */
   agentStoreApiUrl?: string;
   corsOrigin?: string;
+  /**
+   * Prometheus exposition for GET /metrics (HOU-1011): the boot-span ledger,
+   * rendered by prom-client. Token-gated like every non-public route. Absent →
+   * the route 404s (a test server without telemetry stays honest).
+   */
+  metrics?: { render(): Promise<string>; contentType: string };
 }
 
 function applyCors(deps: ControlPlaneDeps, res: ServerResponse): void {
@@ -313,6 +319,17 @@ async function handle(
   // (no self-subtraction, unlike the per-agent route).
   if (method === "GET" && path === "/activity") {
     return json(res, 200, await podActivityStatus(deps));
+  }
+
+  // Prometheus text exposition of the boot-span ledger (HOU-1011). Pods are
+  // never scraped in production (they push boot reports to the gateway); this
+  // route is the local/debug window onto the same numbers.
+  if (method === "GET" && path === "/metrics") {
+    if (!deps.metrics) return json(res, 404, { error: "not found" });
+    const body = await deps.metrics.render();
+    res.writeHead(200, { "content-type": deps.metrics.contentType });
+    res.end(body);
+    return;
   }
 
   if (

--- a/packages/host/src/store-sync/daemon.ts
+++ b/packages/host/src/store-sync/daemon.ts
@@ -64,7 +64,8 @@ export class StoreSyncDaemon {
 
   constructor(private readonly opts: StoreSyncOptions) {}
 
-  async hydrate(): Promise<void> {
+  /** Returns the number of objects restored (the boot telemetry records it). */
+  async hydrate(): Promise<number> {
     this.hydrated = false;
     const startedAt = Date.now();
     await mkdir(this.opts.rootDir, { recursive: true });
@@ -80,6 +81,7 @@ export class StoreSyncDaemon {
     this.opts.log(
       `[store-sync] hydrated ${manifest.size} objects in ${Date.now() - startedAt}ms`,
     );
+    return manifest.size;
   }
 
   start(): void {

--- a/packages/host/src/telemetry/boot-report.ts
+++ b/packages/host/src/telemetry/boot-report.ts
@@ -1,0 +1,53 @@
+import type { BootTelemetry } from "./boot";
+
+const RETRY_DELAY_MS = 5_000;
+
+export interface BootReportOptions {
+  /** Managed-pod gateway quadruple (same env as usage reporting). */
+  report: { url: string; orgSlug: string; agentSlug: string; podToken: string };
+  telemetry: BootTelemetry;
+  /** Failure → stderr (Sentry breadcrumb), success → info. Never throws. */
+  log: (message: string, err?: unknown) => void;
+  fetchImpl?: typeof fetch;
+  retryDelayMs?: number;
+}
+
+/**
+ * Push the boot-span ledger to the gateway once, right after this pod became
+ * ready (HOU-1011). Pods scale to zero, so Prometheus never scrapes a boot —
+ * the gateway folds these reports into its own /metrics histograms instead.
+ * One retry, then give up loudly: a lost report costs one data point, never
+ * the boot (mirrors the usage sampler's fire-and-forget posture; a 404 is an
+ * older gateway that doesn't serve the ingest yet).
+ */
+export async function sendBootReport(opts: BootReportOptions): Promise<void> {
+  const { url, orgSlug, agentSlug, podToken } = opts.report;
+  const target = `${url.replace(/\/+$/, "")}/v1/pod/boot-report/${encodeURIComponent(orgSlug)}/${encodeURIComponent(agentSlug)}`;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const body = JSON.stringify(opts.telemetry.reportPayload());
+  for (let attempt = 0; attempt < 2; attempt++) {
+    if (attempt > 0)
+      await new Promise((r) =>
+        setTimeout(r, opts.retryDelayMs ?? RETRY_DELAY_MS),
+      );
+    try {
+      const res = await fetchImpl(target, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${podToken}`,
+          "content-type": "application/json",
+        },
+        body,
+      });
+      if (res.ok) return;
+      if (res.status === 404) {
+        opts.log("[boot-report] gateway has no ingest yet (404), skipping");
+        return;
+      }
+      opts.log("[boot-report] rejected", new Error(`status ${res.status}`));
+    } catch (err) {
+      opts.log("[boot-report] send failed", err);
+    }
+  }
+  opts.log("[boot-report] giving up after retry", new Error("send failed"));
+}

--- a/packages/host/src/telemetry/boot.test.ts
+++ b/packages/host/src/telemetry/boot.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { BootTelemetry } from "./boot";
+import { sendBootReport } from "./boot-report";
+
+describe("BootTelemetry", () => {
+  it("records steps and renders prometheus exposition in seconds", async () => {
+    const boot = new BootTelemetry();
+    boot.record("hydrate", 3200);
+    boot.setHydratedObjects(42);
+    const text = await boot.render();
+    expect(text).toContain(
+      'houston_engine_boot_step_duration_seconds{step="hydrate"} 3.2',
+    );
+    expect(text).toContain("houston_engine_boot_hydrated_objects 42");
+  });
+
+  it("time() records the phase duration and passes the result through", async () => {
+    const boot = new BootTelemetry();
+    const out = await boot.time("migrations", async () => "done");
+    expect(out).toBe("done");
+    expect(boot.reportPayload().steps).toEqual([
+      { step: "migrations", ms: expect.any(Number) },
+    ]);
+  });
+
+  it("time() records even when the phase throws", async () => {
+    const boot = new BootTelemetry();
+    await expect(
+      boot.time("hydrate", async () => {
+        throw new Error("gcs down");
+      }),
+    ).rejects.toThrow("gcs down");
+    expect(boot.reportPayload().steps.map((s) => s.step)).toEqual(["hydrate"]);
+  });
+
+  it("reportPayload omits unset optionals and includes total after markReady", () => {
+    const boot = new BootTelemetry();
+    expect(boot.reportPayload()).toEqual({ steps: [] });
+    boot.markReady();
+    expect(boot.reportPayload().totalMs).toBeGreaterThan(0);
+  });
+});
+
+describe("sendBootReport", () => {
+  const report = {
+    url: "https://gw.example/",
+    orgSlug: "acme",
+    agentSlug: "helper",
+    podToken: "tok-1",
+  };
+
+  it("POSTs the payload with pod-token auth to the boot-report route", async () => {
+    const boot = new BootTelemetry();
+    boot.record("listen", 5);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 204 }));
+    await sendBootReport({ report, telemetry: boot, log: () => {}, fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [target, init] = fetchImpl.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(target).toBe("https://gw.example/v1/pod/boot-report/acme/helper");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer tok-1",
+    );
+    expect(JSON.parse(init.body as string).steps).toEqual([
+      { step: "listen", ms: 5 },
+    ]);
+  });
+
+  it("retries once on failure, then gives up loudly", async () => {
+    const boot = new BootTelemetry();
+    const log = vi.fn();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("refused");
+    });
+    await sendBootReport({
+      report,
+      telemetry: boot,
+      log,
+      fetchImpl,
+      retryDelayMs: 1,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenCalledWith(
+      "[boot-report] giving up after retry",
+      expect.any(Error),
+    );
+  });
+
+  it("treats an older gateway's 404 as done (no retry)", async () => {
+    const boot = new BootTelemetry();
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 404 }));
+    await sendBootReport({ report, telemetry: boot, log: () => {}, fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/host/src/telemetry/boot.ts
+++ b/packages/host/src/telemetry/boot.ts
@@ -1,0 +1,100 @@
+import { Gauge, Registry } from "prom-client";
+
+/**
+ * The named phases of a host boot, in the order they run. `runtime_spawn` only
+ * exists on managed pods (HOUSTON_EAGER_RUNTIME) — the desktop spawns runtimes
+ * lazily, after boot. The wire names are shared with the gateway's
+ * boot-report ingest; adding a step means whitelisting it there too.
+ */
+export type BootStep =
+  | "module_eval"
+  | "hydrate"
+  | "migrations"
+  | "listen"
+  | "runtime_spawn";
+
+/**
+ * The boot-span ledger (HOU-1011): every boot phase's duration, recorded once
+ * per process. Serves two consumers from one record:
+ *  - `GET /metrics` on this host (Prometheus text exposition, via prom-client);
+ *  - the one-shot boot report a managed pod pushes to the gateway right after
+ *    it becomes ready (pods scale to zero, so a scraper would miss the boot).
+ */
+export class BootTelemetry {
+  private readonly registry = new Registry();
+  private readonly stepSeconds: Gauge<"step">;
+  private readonly hydratedObjectsGauge: Gauge;
+  private readonly totalSeconds: Gauge;
+  private readonly steps = new Map<BootStep, number>();
+  private hydratedObjects: number | undefined;
+  private totalMs: number | undefined;
+
+  constructor() {
+    this.stepSeconds = new Gauge({
+      name: "houston_engine_boot_step_duration_seconds",
+      help: "Duration of one named host boot phase, seconds.",
+      labelNames: ["step"],
+      registers: [this.registry],
+    });
+    this.hydratedObjectsGauge = new Gauge({
+      name: "houston_engine_boot_hydrated_objects",
+      help: "Objects restored from the durable store during boot hydration.",
+      registers: [this.registry],
+    });
+    this.totalSeconds = new Gauge({
+      name: "houston_engine_boot_total_duration_seconds",
+      help: "Process start to listening banner, seconds.",
+      registers: [this.registry],
+    });
+  }
+
+  /** Prometheus exposition content type (constant, but read from the lib). */
+  get contentType(): string {
+    return this.registry.contentType;
+  }
+
+  record(step: BootStep, ms: number): void {
+    this.steps.set(step, ms);
+    this.stepSeconds.set({ step }, ms / 1000);
+  }
+
+  /** Time an async boot phase and record it, passing the result through. */
+  async time<T>(step: BootStep, fn: () => Promise<T>): Promise<T> {
+    const t0 = Date.now();
+    try {
+      return await fn();
+    } finally {
+      this.record(step, Date.now() - t0);
+    }
+  }
+
+  setHydratedObjects(count: number): void {
+    this.hydratedObjects = count;
+    this.hydratedObjectsGauge.set(count);
+  }
+
+  /** Stamp total boot time = process start → now (call at the banner). */
+  markReady(): void {
+    this.totalMs = process.uptime() * 1000;
+    this.totalSeconds.set(this.totalMs / 1000);
+  }
+
+  render(): Promise<string> {
+    return this.registry.metrics();
+  }
+
+  /** The gateway boot-report body (wire contract with the Go ingest). */
+  reportPayload(): {
+    steps: Array<{ step: BootStep; ms: number }>;
+    hydratedObjects?: number;
+    totalMs?: number;
+  } {
+    return {
+      steps: [...this.steps].map(([step, ms]) => ({ step, ms })),
+      ...(this.hydratedObjects !== undefined
+        ? { hydratedObjects: this.hydratedObjects }
+        : {}),
+      ...(this.totalMs !== undefined ? { totalMs: this.totalMs } : {}),
+    };
+  }
+}

--- a/packages/web/src/shims/tauri-core.ts
+++ b/packages/web/src/shims/tauri-core.ts
@@ -226,6 +226,11 @@ export async function invoke<T = unknown>(
         agentDirCount: 0,
       } as T;
 
+    // No shell process on the web — perf spans fall back to the webview's
+    // own performance.timeOrigin (osLaunchT0Ms treats null exactly so).
+    case "launch_t0_ms":
+      return null as T;
+
     // ── Desktop-only: surface a clear error if a user triggers them ─────
     case "start_oauth_loopback": // desktop uses a native loopback listener; web uses the firebase-js-sdk popup
     case "cancel_oauth_loopback": // frees the desktop loopback port; web has no local listener to cancel

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,9 @@ importers:
       js-yaml:
         specifier: 4.1.1
         version: 4.1.1
+      prom-client:
+        specifier: 15.1.3
+        version: 15.1.3
       tsx:
         specifier: 4.23.0
         version: 4.23.0
@@ -4589,6 +4592,9 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
@@ -6518,6 +6524,10 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
@@ -7035,6 +7045,9 @@ packages:
 
   tauri-plugin-sentry-api@0.5.0:
     resolution: {integrity: sha512-IUOMOQZafbQJbPS9eisdABt9tdJksec9ajOQRlM31DfOcdzayaUis7FK48AD5ayeNCOwJDZPs1nvlZSD8jFYiQ==}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   teeny-request@9.0.0:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
@@ -11411,6 +11424,8 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
+  bintrees@1.0.2: {}
+
   body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
@@ -13774,6 +13789,11 @@ snapshots:
 
   progress@2.0.3: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   proper-lockfile@4.1.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -14511,6 +14531,10 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.0.0-beta.8
       tslib: 2.8.1
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   teeny-request@9.0.0:
     dependencies:


### PR DESCRIPTION
Part of HOU-1011 (Prometheus-compatible endpoints for performance analytics). Companion cloud PR adds the gateway `/metrics` endpoints and the two ingests this PR reports into.

## What

**Host (engine pod) boot telemetry**
- `packages/host/src/telemetry/boot.ts`: a boot-span ledger recording each boot phase — `module_eval`, `hydrate` (GCS restore, + object count), `migrations`, `listen`, `runtime_spawn` (eager pods) — as prom-client gauges.
- `GET /metrics` on the host (token-gated, Prometheus text format).
- Managed pods POST a one-shot boot report to `{gateway}/v1/pod/boot-report/{org}/{agent}` (pod token, mirrors the usage-sampler route) right after the listening banner — pods scale to zero, so scraping would miss every boot; the gateway folds reports into histograms on its own `/metrics`.

**Client UX perf spans** (desktop + web, HOU-1011's user journeys)
- `app/src/lib/perf-spans.ts` + `usePerfSpans`: measures `app_to_board` (app open → mission cards painted), `card_click_to_chat` (card click → messages painted), `send_to_first_response` (send → **first streamed word** visible), `app_to_first_response` (composite).
- T0 = the Tauri shell's process start (`launch_t0_ms` command, stamped at the first line of `run()`); web falls back to `performance.timeOrigin`.
- Spans batch-POST to the gateway's session-authed `/v1/client-metrics` and mirror to PostHog as `perf_span` events (`span`, `duration_ms`) for per-user drill-down. No session → PostHog only.
- Paint marks ride `requestAnimationFrame` after the qualifying render; pending marks expire after 60s so wandering off never reports minutes-long spans.

## Verification

Before: no timing exists anywhere — `grep -r houston_engine_boot packages/host` on main is empty, and no `/metrics` route answers (404).

After:
1. `pnpm --filter @houston/host test` — 132 files / 1130 tests green (7 new telemetry tests).
2. `cd app && pnpm test` — green (7 new perf-span tests: latching, pairing, TTL expiry, retry-once transport, T0 monotonicity).
3. Run the host, then `curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:4318/metrics` → `houston_engine_boot_step_duration_seconds{step="..."}` lines.
4. Open the desktop app signed-in → PostHog receives `perf_span` events; the gateway ingest (cloud PR) receives the same spans.
5. Gates: `pnpm check` (Biome), `pnpm tsgo --noEmit` (app), `pnpm --filter houston-web typecheck` (shim parity incl. new `launch_t0_ms`), `cargo check`/`cargo test`, `pnpm check:boundaries`, `pnpm check-locales` — all clean.