### PR TITLE
fix(web): cloud web boots to sign-in; skip pre-auth language/agreement gates (HOU-1014)

### DIFF
--- a/packages/web/e2e/sign-in.spec.ts
+++ b/packages/web/e2e/sign-in.spec.ts
@@ -198,3 +198,28 @@ test.describe("returning user (last sign-in continue)", () => {
     ).toBeVisible();
   });
 });
+
+/**
+ * HOU-1014: on the cloud web app (identity configured) the sign-in screen is
+ * the FIRST screen. The first-run language picker and the agreement gate are
+ * desktop/self-host concepts — pre-auth their preference writes 401 at the
+ * gateway, which dead-ended the agreement's Continue on the deployed web app.
+ * A fresh browser (no seeded gate prefs) must land directly on sign-in.
+ */
+test("a fresh browser lands on sign-in, never the language or agreement gates", async ({
+  page,
+}) => {
+  // Undo the shared boot seed's gate prefs — this init script runs after
+  // seedPage's, so the app boots like a genuinely fresh visitor.
+  await page.addInitScript(() => {
+    localStorage.removeItem("houston.pref.locale");
+    localStorage.removeItem("houston.pref.legal_acceptance");
+  });
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("button", { name: "Continue with Google" }),
+  ).toBeVisible();
+  await expect(page.getByText("Choose your language")).toHaveCount(0);
+  await expect(page.getByText("Elige tu idioma")).toHaveCount(0);
+});

--- a/packages/web/src/app-tree.tsx
+++ b/packages/web/src/app-tree.tsx
@@ -11,6 +11,9 @@
  * Boot order matches the desktop entry:
  *   QueryClientProvider > ErrorBoundary > TooltipProvider > EngineGate >
  *   I18nextProvider > LanguageGate > DisclaimerGate > App
+ * EXCEPT on the cloud web build (identity configured), where the first-run
+ * language/agreement gates are skipped: sign-in is the first screen, and the
+ * account's stored locale applies after auth (see AppTree below, HOU-1014).
  */
 
 import { AgentFilePreviewHost } from "@houston/app/components/agent-file-preview-host";
@@ -18,12 +21,15 @@ import { DisclaimerGate } from "@houston/app/components/shell/disclaimer-gate";
 import { LanguageGate } from "@houston/app/components/shell/language-gate";
 import { QueryPersistenceProvider } from "@houston/app/components/shell/query-persistence-provider";
 import { WorkspaceLoading } from "@houston/app/components/shell/workspace-loading";
+import { useLocalePreference } from "@houston/app/hooks/use-locale-preference";
+import { useSession } from "@houston/app/hooks/use-session";
 import { IdentityKeyedApp } from "@houston/app/identity-keyed-app";
 import { analytics, classifyAnalyticsError } from "@houston/app/lib/analytics";
 import { isEngineReady, whenEngineReady } from "@houston/app/lib/engine";
 import { showErrorToast } from "@houston/app/lib/error-toast";
 import { installGlobalErrorHandlers } from "@houston/app/lib/global-error-handlers";
 import i18n from "@houston/app/lib/i18n";
+import { isIdentityConfigured } from "@houston/app/lib/identity";
 import { initFrontendLogging, logger } from "@houston/app/lib/logger";
 import { queryClient } from "@houston/app/lib/query-client";
 import { initSentry } from "@houston/app/lib/sentry";
@@ -131,8 +137,45 @@ function EngineGate({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }
 
+/**
+ * Cloud web (identity configured): apply the signed-in account's stored locale
+ * WITHOUT blocking any screen. Mounted only once a session exists — signed out,
+ * the gateway would 401 the preference reads anyway (and the sign-in screen
+ * renders in the browser-detected language). Keyed by uid so a fresh sign-in
+ * or an account switch re-resolves the preference.
+ */
+function SignedInLocaleSync() {
+  const session = useSession();
+  const uid = session.data?.uid;
+  if (!uid) return null;
+  return <LocaleSyncOnce key={uid} />;
+}
+
+function LocaleSyncOnce() {
+  // Mounted purely for the hook's apply-on-arrival effect (it swaps the live
+  // i18n language when the account's `locale` preference resolves).
+  useLocalePreference();
+  return null;
+}
+
 // No StrictMode — matches app/src/main.tsx (portal/listener double-mount churn).
 export default function AppTree() {
+  // Cloud web build (Firebase identity baked in): sign-in is the FIRST screen.
+  // The first-run language picker + agreement are desktop/self-host concepts —
+  // pre-auth they can't even persist (the gateway 401s preference writes, which
+  // dead-ended the agreement's Continue, HOU-1014). Language defaults to the
+  // browser and the account's stored preference applies after sign-in
+  // (SignedInLocaleSync); Settings keeps its picker for changes.
+  const cloudWeb = isIdentityConfigured();
+  const app = (
+    <>
+      <IdentityKeyedApp />
+      {/* Global workspace-file preview (chat file clicks) —
+          mirrors app/src/main.tsx. */}
+      <AgentFilePreviewHost />
+    </>
+  );
+
   return (
     <QueryClientProvider client={queryClient}>
       <ErrorBoundary>
@@ -144,14 +187,16 @@ export default function AppTree() {
                     overlays every gate/screen without disturbing layout or clicks.
                     Renders null off the preview deployment. */}
                 <PreviewBadge />
-                <LanguageGate>
-                  <DisclaimerGate>
-                    <IdentityKeyedApp />
-                    {/* Global workspace-file preview (chat file clicks) —
-                        mirrors app/src/main.tsx. */}
-                    <AgentFilePreviewHost />
-                  </DisclaimerGate>
-                </LanguageGate>
+                {cloudWeb ? (
+                  <>
+                    <SignedInLocaleSync />
+                    {app}
+                  </>
+                ) : (
+                  <LanguageGate>
+                    <DisclaimerGate>{app}</DisclaimerGate>
+                  </LanguageGate>
+                )}
               </I18nextProvider>
             </QueryPersistenceProvider>
           </EngineGate>


### PR DESCRIPTION
## Why

On the deployed cloud web app (houston-web-preview.web.app), a fresh visitor saw the first-run **language picker** and **agreement** BEFORE sign-in. Those gates persist through gateway preference endpoints, which 401 without a bearer — so the agreement's Continue dead-ended with an error (compounded by the missing web.app CORS origins, fixed separately in gethouston/cloud). Product call from Daniel: web users should land on the **login page first**, no language/agreement gates.

## What

`packages/web/src/app-tree.tsx` (web-owned composition, no `app/` changes):
- When `isIdentityConfigured()` (the cloud web build bakes Firebase config), `LanguageGate` + `DisclaimerGate` are skipped — `App`'s own auth guard renders `SignInScreen` as the first screen.
- A new non-blocking `SignedInLocaleSync` mounts `useLocalePreference()` only once a session exists (keyed by uid), so a returning account's stored language still applies right after sign-in; signed out, nothing fetches (the reads would 401) and the sign-in screen renders in the browser-detected language. Settings keeps its language picker.
- Desktop (Tauri) and self-host web (no identity baked) keep the gates exactly as before — their engine preference writes work unauthenticated.

## Tests

New case in `e2e/sign-in.spec.ts` (the `auth` Playwright project, which bakes a Firebase key so `isIdentityConfigured()` is true): clears the shared boot seed's gate prefs so the app boots like a genuinely fresh visitor, then asserts the sign-in screen renders and no language picker appears. On main this fails (the picker renders); with this change it passes.

## Caveat worth an explicit ack

The agreement/disclaimer no longer renders for cloud web users at all. If legal acceptance must be captured for cloud accounts, the right home is the signup flow or a post-auth gate — say the word and I'll add a post-auth variant instead.

## Verify

- `pnpm --filter houston-web typecheck`
- `pnpm --filter houston-web test:e2e` (includes the new auth-project case)
- Manual: after the next staging deploy, open houston-web-preview.web.app in a fresh profile — you should land on sign-in directly (needs the CORS PR in gethouston/cloud deployed for API calls to work from the web.app domain).

HOU-1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)