### PR TITLE
Per-mission models, connected-provider defaults, credential single-rotator + self-heal, Ask First missions

### DIFF
--- a/app/src/components/board/use-mission-control-archived-send.ts
+++ b/app/src/components/board/use-mission-control-archived-send.ts
@@ -5,8 +5,8 @@ import { useTranslation } from "react-i18next";
 import { analytics } from "../../lib/analytics";
 import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { classifyFileKind } from "../../lib/file-kind";
-import { tauriAttachments, tauriChat, tauriConfig } from "../../lib/tauri";
-import { readAgentTurnMode } from "../../lib/turn-mode";
+import { tauriAttachments, tauriChat } from "../../lib/tauri";
+import { DEFAULT_TURN_MODE } from "../../lib/turn-mode";
 import type { Agent, AgentDefinition } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 
@@ -62,7 +62,7 @@ export function useMissionControlArchivedSend({
           mode: mode?.promptFile,
           providerOverride,
           modelOverride,
-          modeOverride: await readAgentTurnMode(agentPath, tauriConfig.read),
+          modeOverride: DEFAULT_TURN_MODE,
           mentions,
         });
         analytics.track("chat_message_sent", {

--- a/app/src/components/integrations/use-integration-chat-setup.ts
+++ b/app/src/components/integrations/use-integration-chat-setup.ts
@@ -13,7 +13,7 @@ import {
 } from "../../lib/integration-chat-setup";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriActivity, tauriConfig } from "../../lib/tauri";
-import { readAgentTurnMode } from "../../lib/turn-mode";
+import { DEFAULT_TURN_MODE } from "../../lib/turn-mode";
 import type { Agent } from "../../lib/types";
 import { useAgentCatalogStore } from "../../stores/agent-catalog";
 import { useAgentStore } from "../../stores/agents";
@@ -136,10 +136,7 @@ export function useIntegrationChatSetup() {
           {
             title: t("custom.setupChat.missionTitle"),
             agentMode: INTEGRATION_SETUP_AGENT_MODE,
-            modeOverride: await readAgentTurnMode(
-              agent.folderPath,
-              tauriConfig.read,
-            ),
+            modeOverride: DEFAULT_TURN_MODE,
             // Pin the agent's configured brain onto the kickoff turn — an
             // unpinned send resolves inside the runtime and lands on the
             // provider default (Sonnet), not the model the user picked.

--- a/app/src/components/mission-control-send.ts
+++ b/app/src/components/mission-control-send.ts
@@ -20,6 +20,7 @@
 // the extension for runtime-value imports). Vite/TSC accept it because
 // `allowImportingTsExtensions: true` is set in `app/tsconfig.json`.
 import { normalizeLegacyModel } from "../lib/providers.ts";
+import { DEFAULT_TURN_MODE } from "../lib/turn-mode.ts";
 
 /** Minimal shape needed for override resolution; mirrors `ActivityItem`. */
 export interface ActivityOverrideSource {
@@ -61,5 +62,16 @@ export function resolveActivityOverride(
   return {
     providerOverride: activity.provider,
     modelOverride: normalizeLegacyModel(activity.model ?? null) ?? undefined,
+  };
+}
+
+/** Assemble a Mission Control follow-up's provider/model and session mode pins. */
+export function resolveMissionControlSendOverrides(
+  sessionKey: string,
+  activities: ActivityOverrideSource[] | undefined,
+): SendOverrides {
+  return {
+    ...resolveActivityOverride(sessionKey, activities),
+    modeOverride: DEFAULT_TURN_MODE,
   };
 }

--- a/app/src/components/onboarding/create-personal-assistant.ts
+++ b/app/src/components/onboarding/create-personal-assistant.ts
@@ -1,4 +1,5 @@
 import { logger } from "../../lib/logger";
+import { toCanonicalProviderId } from "../../lib/provider-overrides";
 import { tauriConfig } from "../../lib/tauri";
 import type { Agent } from "../../lib/types";
 import { useAgentStore } from "../../stores/agents";
@@ -55,8 +56,8 @@ async function applyProviderModel(
       agentPath,
       {
         ...cfg,
-        ...(options.provider === "anthropic" || options.provider === "openai"
-          ? { provider: options.provider }
+        ...(options.provider
+          ? { provider: toCanonicalProviderId(options.provider) }
           : {}),
         ...(options.model ? { model: options.model } : {}),
       },

--- a/app/src/components/onboarding/use-create-assistant.ts
+++ b/app/src/components/onboarding/use-create-assistant.ts
@@ -31,6 +31,12 @@ async function refreshAfterCreate(
   provider: string,
   model: string,
 ): Promise<void> {
+  try {
+    await tauriProvider.setLastUsed(provider, model);
+  } catch (err) {
+    logger.error(`[onboarding] last-used provider write failed: ${err}`);
+  }
+
   // Persist the account timezone so the seeded morning-briefing routine fires at
   // the user's local 7am, not the cloud pod's UTC 7am. The Routines-tab hook
   // auto-seeds this too, but it never mounts during onboarding — so a user who
@@ -40,7 +46,6 @@ async function refreshAfterCreate(
   await seedTimezoneIfUnset().catch((err) =>
     logger.error(`[onboarding] timezone seed failed: ${err}`),
   );
-  await tauriProvider.setLastUsed(provider, model);
   if (ensured.createdWorkspace) {
     analytics.track("workspace_created", { provider, source: "onboarding" });
   }

--- a/app/src/components/portable/import-wizard.tsx
+++ b/app/src/components/portable/import-wizard.tsx
@@ -34,14 +34,17 @@ import type {
 } from "@houston-ai/engine-client";
 import { invoke } from "@tauri-apps/api/core";
 import { Check } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DEFAULT_TAB_ID } from "../../agents/standard-tabs";
+import { useProviderStatuses } from "../../hooks/use-provider-statuses";
 import { finishAgentSetup } from "../../lib/agent-setup";
 import { startAgentSetupMission } from "../../lib/agent-setup-mission";
 import { analytics } from "../../lib/analytics";
+import { pickDefaultProviderModel } from "../../lib/default-provider-model";
 import { getEngine } from "../../lib/engine";
 import { genericErrorDescription } from "../../lib/error-report";
+import { providerIsConnected } from "../../lib/provider-connection";
 import { getDefaultModel } from "../../lib/providers";
 import { tauriProvider, toAgent } from "../../lib/tauri";
 import { useAgentStore } from "../../stores/agents";
@@ -77,24 +80,50 @@ export function ImportAgentWizard() {
   const [color, setColor] = useState<string>(AGENT_COLORS[0].id);
   const [provider, setProvider] = useState<string>("anthropic");
   const [model, setModel] = useState<string>(getDefaultModel("anthropic"));
+  const [lastUsed, setLastUsed] = useState<{
+    provider: string | null;
+    model: string | null;
+  } | null>(null);
+  const userPickedModelRef = useRef(false);
+  const { statuses: providerStatuses } = useProviderStatuses();
+  const connectedProviders = useMemo(
+    () =>
+      Object.values(providerStatuses)
+        .filter((status) => providerIsConnected(status))
+        .map((status) => status.provider),
+    [providerStatuses],
+  );
 
-  // Read the sticky default whenever the wizard opens so the picker starts
-  // from the user's last pick (made in the create-agent dialog, AI-assist
-  // step, or chat-tab picker). Falls back to Anthropic if nothing was ever
-  // stored (fresh install).
+  // Resolve the sticky preference against confirmed connections whenever the
+  // wizard opens. An unconfirmed probe retains the non-blocking legacy fallback
+  // until statuses arrive.
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
     tauriProvider.getLastUsed().then(({ provider: p, model: m }) => {
       if (cancelled) return;
-      const next = p ?? "anthropic";
-      setProvider(next);
-      setModel(m ?? getDefaultModel(next));
+      setLastUsed({ provider: p, model: m });
+      if (!userPickedModelRef.current && p) {
+        setProvider(p);
+        setModel(m ?? getDefaultModel(p));
+      }
     });
     return () => {
       cancelled = true;
     };
   }, [open]);
+
+  useEffect(() => {
+    if (!open || userPickedModelRef.current) return;
+    if (Object.keys(providerStatuses).length === 0) return;
+    const next = pickDefaultProviderModel({
+      lastUsedProvider: lastUsed?.provider,
+      lastUsedModel: lastUsed?.model,
+      connectedProviders,
+    });
+    setProvider(next.provider);
+    setModel(next.model);
+  }, [connectedProviders, lastUsed, open, providerStatuses]);
   const [selection, setSelection] = useState<Selection>({
     skillSlugs: new Set(),
     routineIds: new Set(),
@@ -121,6 +150,8 @@ export function ImportAgentWizard() {
     setWantScan(null);
     setName("");
     setColor(AGENT_COLORS[0].id);
+    setLastUsed(null);
+    userPickedModelRef.current = false;
     // Provider/model intentionally NOT reset here — the open-effect above
     // re-hydrates them from `tauriProvider.getLastUsed()` on the next open.
     setSelection({
@@ -129,6 +160,12 @@ export function ImportAgentWizard() {
       learningIds: new Set(),
     });
   }, []);
+
+  const handleModelChange = (nextProvider: string, nextModel: string) => {
+    userPickedModelRef.current = true;
+    setProvider(nextProvider);
+    setModel(nextModel);
+  };
 
   const runScan = async (packageId: string) => {
     setScanning(true);
@@ -199,6 +236,16 @@ export function ImportAgentWizard() {
       addToast({ variant: "error", title: t("import.errors.nameRequired") });
       return;
     }
+    const resolved = pickDefaultProviderModel({
+      lastUsedProvider: lastUsed?.provider,
+      lastUsedModel: lastUsed?.model,
+      connectedProviders,
+    });
+    const kickoffPin = userPickedModelRef.current
+      ? { provider, model }
+      : resolved.confirmed
+        ? { provider: resolved.provider, model: resolved.model }
+        : {};
     setInstalling(true);
     try {
       const installed = await getEngine().importInstall({
@@ -214,7 +261,9 @@ export function ImportAgentWizard() {
         },
       });
       // Keep the sticky last-used in sync (local, so it's cheap to await).
-      await tauriProvider.setLastUsed(provider, model);
+      if (kickoffPin.provider && kickoffPin.model) {
+        await tauriProvider.setLastUsed(kickoffPin.provider, kickoffPin.model);
+      }
       analytics.track("agent_imported", { agent_slug: installed.agentName });
       // Reveal the agent NOW — the same optimistic contract as the
       // create-agent dialog (HOU-710). `adopt` marks the agent provisioning
@@ -236,8 +285,7 @@ export function ImportAgentWizard() {
       setOpen(false);
       reset();
       void finishAgentSetup(installed.agentPath, {
-        provider,
-        model,
+        ...kickoffPin,
         routine: null,
       });
       // With the wizard dismissed, auto-start the agent's self-setup mission in
@@ -251,7 +299,7 @@ export function ImportAgentWizard() {
           color: installed.agent.color,
           folderPath: installed.agentPath,
         },
-        { provider, model },
+        kickoffPin,
         "imported",
       );
     } catch (err) {
@@ -309,10 +357,7 @@ export function ImportAgentWizard() {
               onColorChange={setColor}
               provider={provider}
               model={model}
-              onProviderChange={(p, m) => {
-                setProvider(p);
-                setModel(m);
-              }}
+              onProviderChange={handleModelChange}
             />
           )}
           {currentStep === "skills" && uploaded && (

--- a/app/src/components/shell/ai-assist-step.tsx
+++ b/app/src/components/shell/ai-assist-step.tsx
@@ -16,6 +16,8 @@ import { AiStepFooter } from "./ai-step-footer";
 interface AiAssistStepProps {
   provider: string;
   model: string;
+  providerOverride?: string;
+  modelOverride?: string;
   /** Picker changes lift to the dialog: the pair drives this generation turn
    * AND becomes the created agent's brain. Effort has no control here — the
    * engine runs reasoning models at its default (medium). */
@@ -36,6 +38,8 @@ interface AiAssistStepProps {
 export function AiAssistStep({
   provider,
   model,
+  providerOverride,
+  modelOverride,
   onModelChange,
   brief,
   onBriefChange,
@@ -63,8 +67,8 @@ export function AiAssistStep({
     abortRef.current = controller;
     try {
       const result = await tauriAgents.generateInstructions(description, {
-        provider,
-        model,
+        provider: providerOverride,
+        model: modelOverride,
         signal: controller.signal,
       });
       const name = result.name ?? "";

--- a/app/src/components/shell/create-workspace-dialog.tsx
+++ b/app/src/components/shell/create-workspace-dialog.tsx
@@ -6,14 +6,17 @@ import {
 } from "@houston-ai/core";
 import type { SuggestedRoutine } from "@houston-ai/engine-client";
 import type { RoutineFormData } from "@houston-ai/routines";
-import { type FormEvent, useEffect, useRef, useState } from "react";
+import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { STORE_TEMPLATE_IDS } from "../../agents/builtin/store-catalog";
 import { loadStoreTemplate } from "../../agents/builtin/store-template-loader";
 import { DEFAULT_TAB_ID } from "../../agents/standard-tabs";
 import { useCapabilities } from "../../hooks/use-capabilities";
+import { useProviderStatuses } from "../../hooks/use-provider-statuses";
 import { finishAgentSetup } from "../../lib/agent-setup";
 import { startAgentSetupMission } from "../../lib/agent-setup-mission";
+import { pickDefaultProviderModel } from "../../lib/default-provider-model";
+import { providerIsConnected } from "../../lib/provider-connection";
 import { getDefaultModel } from "../../lib/providers";
 import { tauriProvider } from "../../lib/tauri";
 import { useAgentCatalogStore } from "../../stores/agent-catalog";
@@ -70,12 +73,25 @@ export function CreateAgentDialog() {
   const [existingPath, setExistingPath] = useState<string | null>(null);
   const [provider, setProvider] = useState<string>("anthropic");
   const [model, setModel] = useState<string>(getDefaultModel("anthropic"));
+  const [lastUsed, setLastUsed] = useState<{
+    provider: string | null;
+    model: string | null;
+  } | null>(null);
+  const userPickedModelRef = useRef(false);
+  const { statuses: providerStatuses } = useProviderStatuses();
+  const connectedProviders = useMemo(
+    () =>
+      Object.values(providerStatuses)
+        .filter((status) => providerIsConnected(status))
+        .map((status) => status.provider),
+    [providerStatuses],
+  );
 
-  // Reset form on close. On open, load the sticky last-used provider/model —
-  // the pair becomes the new agent's brain (and the generation brain on the AI
-  // path, where the ai-assist step shows a picker to change it). Reading on
-  // open (not mount) prevents the old "stale workspace default baked into the
-  // new agent's config" bug.
+  // Reset form on close. On open, resolve the sticky preference against
+  // confirmed connections. The pair becomes the new agent's brain (and the
+  // generation brain on the AI path, where the ai-assist step shows a picker to
+  // change it). Reading on open prevents a stale workspace default from being
+  // baked into the new agent's config.
   useEffect(() => {
     if (!open) {
       setStep(1);
@@ -92,19 +108,35 @@ export function CreateAgentDialog() {
       setCreating(false);
       setSearch("");
       setExistingPath(null);
+      setLastUsed(null);
+      userPickedModelRef.current = false;
       return;
     }
     let cancelled = false;
     tauriProvider.getLastUsed().then(({ provider: p, model: m }) => {
       if (cancelled) return;
-      const nextProvider = p ?? "anthropic";
-      setProvider(nextProvider);
-      setModel(m ?? getDefaultModel(nextProvider));
+      setLastUsed({ provider: p, model: m });
+      if (!userPickedModelRef.current && p) {
+        setProvider(p);
+        setModel(m ?? getDefaultModel(p));
+      }
     });
     return () => {
       cancelled = true;
     };
   }, [open]);
+
+  useEffect(() => {
+    if (!open || userPickedModelRef.current) return;
+    if (Object.keys(providerStatuses).length === 0) return;
+    const next = pickDefaultProviderModel({
+      lastUsedProvider: lastUsed?.provider,
+      lastUsedModel: lastUsed?.model,
+      connectedProviders,
+    });
+    setProvider(next.provider);
+    setModel(next.model);
+  }, [connectedProviders, lastUsed, open, providerStatuses]);
 
   const handleClose = () => {
     setOpen(false);
@@ -115,6 +147,7 @@ export function CreateAgentDialog() {
   // surfaces its own error toast (the `call` wrapper), so the local state —
   // which is what this create actually uses — is applied regardless.
   const handleModelChange = (nextProvider: string, nextModel: string) => {
+    userPickedModelRef.current = true;
     setProvider(nextProvider);
     setModel(nextModel);
     tauriProvider.setLastUsed(nextProvider, nextModel).catch(() => {});
@@ -125,6 +158,16 @@ export function CreateAgentDialog() {
     // `creating` also gates re-entry: the submit button is disabled while in
     // flight, but Enter in the name input still fires the form's onSubmit.
     if (creating || !trimmed || !selectedConfigId || !currentWorkspace) return;
+    const resolved = pickDefaultProviderModel({
+      lastUsedProvider: lastUsed?.provider,
+      lastUsedModel: lastUsed?.model,
+      connectedProviders,
+    });
+    const kickoffPin = userPickedModelRef.current
+      ? { provider, model }
+      : resolved.confirmed
+        ? { provider: resolved.provider, model: resolved.model }
+        : {};
     setError(null);
     setCreating(true);
     // AI-generated instructions take priority over the template's claudeMd.
@@ -169,8 +212,7 @@ export function CreateAgentDialog() {
     // its own error toast on failure.
     useUIStore.getState().setViewMode(DEFAULT_TAB_ID);
     void finishAgentSetup(agentPath, {
-      provider,
-      model,
+      ...kickoffPin,
       routine: routineAccepted ? routineForm : null,
     });
     // Auto-start the agent's self-setup mission in the normal shell: it
@@ -184,7 +226,7 @@ export function CreateAgentDialog() {
         color: created.color,
         folderPath: agentPath,
       },
-      { provider, model },
+      kickoffPin,
       "created",
     );
     // Templates that declare integrations keep a connect-apps step, but inside
@@ -212,6 +254,19 @@ export function CreateAgentDialog() {
   };
 
   const selectedDef = agentDefs.find((d) => d.config.id === selectedConfigId);
+  const resolvedGenerationModel = pickDefaultProviderModel({
+    lastUsedProvider: lastUsed?.provider,
+    lastUsedModel: lastUsed?.model,
+    connectedProviders,
+  });
+  const generationPin = userPickedModelRef.current
+    ? { provider, model }
+    : resolvedGenerationModel.confirmed
+      ? {
+          provider: resolvedGenerationModel.provider,
+          model: resolvedGenerationModel.model,
+        }
+      : {};
 
   const aiReviewBackStep = (): Step =>
     routineForm ? "ai-routine" : "ai-assist";
@@ -267,6 +322,8 @@ export function CreateAgentDialog() {
           <AiAssistStep
             provider={provider}
             model={model}
+            providerOverride={generationPin.provider}
+            modelOverride={generationPin.model}
             onModelChange={handleModelChange}
             brief={brief}
             onBriefChange={setBrief}

--- a/app/src/components/tabs/routine-run-overrides.ts
+++ b/app/src/components/tabs/routine-run-overrides.ts
@@ -1,10 +1,10 @@
 import { readAgentModelOverrides } from "../../lib/agent-model-overrides";
 import { tauriConfig } from "../../lib/tauri";
-import { readAgentTurnMode } from "../../lib/turn-mode";
+import { DEFAULT_TURN_MODE } from "../../lib/turn-mode";
 
 /**
- * The agent's configured turn mode plus its provider/model/effort pins, read
- * from disk and folded into a `createMission` options object. A routine setup
+ * The default turn mode plus the agent's provider/model/effort pins, folded
+ * into a `createMission` options object. A routine setup
  * chat's kickoff turn must run on the brain the user picked for the agent — an
  * unpinned send resolves inside the runtime and lands on the provider default
  * (Sonnet), not their choice. Shared by every setup-chat start so the pin is
@@ -12,7 +12,7 @@ import { readAgentTurnMode } from "../../lib/turn-mode";
  */
 export async function readAgentRunOverrides(path: string) {
   return {
-    modeOverride: await readAgentTurnMode(path, tauriConfig.read),
+    modeOverride: DEFAULT_TURN_MODE,
     ...(await readAgentModelOverrides(path, tauriConfig.read)),
   };
 }

--- a/app/src/components/tabs/use-archived-send-message.ts
+++ b/app/src/components/tabs/use-archived-send-message.ts
@@ -6,8 +6,8 @@ import type { Activity } from "../../data/activity";
 import { analytics } from "../../lib/analytics";
 import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { classifyFileKind } from "../../lib/file-kind";
-import { tauriAttachments, tauriChat, tauriConfig } from "../../lib/tauri";
-import { readAgentTurnMode } from "../../lib/turn-mode";
+import { tauriAttachments, tauriChat } from "../../lib/tauri";
+import { DEFAULT_TURN_MODE } from "../../lib/turn-mode";
 import type { AgentDefinition } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 
@@ -60,7 +60,7 @@ export function useArchivedSendMessage({
           mode: mode?.promptFile,
           providerOverride: effectiveProvider,
           modelOverride: effectiveModel,
-          modeOverride: await readAgentTurnMode(agentPath, tauriConfig.read),
+          modeOverride: DEFAULT_TURN_MODE,
           mentions,
         });
         analytics.track("chat_message_sent", {

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -93,6 +93,7 @@ import {
   finalCredentialNames,
 } from "../lib/interaction-reply";
 import {
+  isModelAllowed,
   modelSelectorDecision,
   resolvePersonalModelPin,
 } from "../lib/model-selector-lock";
@@ -113,6 +114,7 @@ import {
   getDefaultModel,
   getProvider,
   normalizeLegacyModel,
+  PROVIDERS,
   validEffortOrDefault,
   validModelOrNull,
 } from "../lib/providers";
@@ -136,11 +138,7 @@ import {
   tauriProvider,
   withAttachmentPaths,
 } from "../lib/tauri";
-import {
-  DEFAULT_TURN_MODE,
-  normalizeTurnMode,
-  type TurnMode,
-} from "../lib/turn-mode";
+import { DEFAULT_TURN_MODE, type TurnMode } from "../lib/turn-mode";
 import type { Agent, AgentDefinition, SkillSummary } from "../lib/types";
 import { useAgentProvisioningStore } from "../stores/agent-provisioning";
 import { newConversationDraftKey, useDraftStore } from "../stores/drafts";
@@ -217,6 +215,14 @@ interface UseAgentChatPanelArgs {
   onSendReactivated?: () => void;
 }
 
+function resolveCatalogProvider(model: string): string | null {
+  return (
+    PROVIDERS.find((provider) =>
+      provider.models.some((candidate) => candidate.id === model),
+    )?.id ?? null
+  );
+}
+
 interface AgentChatPanelProps {
   /** Renders skill cards + "see more" when no Skill is in flight. */
   chatEmptyState: AIBoardProps["chatEmptyState"];
@@ -265,7 +271,7 @@ interface AgentChatPanelProps {
   afterMessages: AIBoardProps["afterMessages"];
   /** Hidden picker dialog mounted in the consumer. */
   pickerDialog: ReactNode;
-  /** Effective provider/model for sending. */
+  /** Displayed provider/model for sending. */
   effectiveProvider: string;
   effectiveModel: string;
   /** The composer's turn mode (execute | plan); consumers forward it as
@@ -443,13 +449,9 @@ export function useAgentChatPanel({
   const [agentProvider, setAgentProvider] = useState<string | null>(null);
   const [agentModel, setAgentModel] = useState<string | null>(null);
   const [agentEffort, setAgentEffort] = useState<string | null>(null);
-  // Composer "Mode" pin (execute/plan). Loaded from config as memory only; the
-  // send path forwards it as `modeOverride`. Unknown/legacy values → execute.
-  //
-  // `initialTurnMode` (when a surface passes one) seeds this AND wins over the
-  // per-agent config, so the surface opens on that mode and holds it until the
-  // user changes it in-session (the setup chat opens on Ask first). Absent, the
-  // behavior is unchanged: the global default, then the agent's remembered mode.
+  // Composer "Mode" pin (execute/plan/auto). It is session-local and every new
+  // mission resets to `initialTurnMode` or Ask First. Existing mission switches
+  // keep the current per-send pin until the user changes it.
   const [turnMode, setTurnMode] = useState<TurnMode>(
     initialTurnMode ?? DEFAULT_TURN_MODE,
   );
@@ -467,10 +469,18 @@ export function useAgentChatPanel({
         setAgentProvider((cfg.provider as string) ?? null);
         setAgentModel(normalizeLegacyModel((cfg.model as string) ?? null));
         setAgentEffort((cfg.effort as string) ?? null);
-        setTurnMode(initialTurnMode ?? normalizeTurnMode(cfg.mode));
       })
       .catch(() => {});
   }, [path, initialTurnMode]);
+
+  const previousSessionKeyRef = useRef(selectedSessionKey);
+  useEffect(() => {
+    const previousSessionKey = previousSessionKeyRef.current;
+    previousSessionKeyRef.current = selectedSessionKey;
+    if (previousSessionKey && !selectedSessionKey) {
+      setTurnMode(initialTurnMode ?? DEFAULT_TURN_MODE);
+    }
+  }, [selectedSessionKey, initialTurnMode]);
 
   // Last-used provider preference (`default_provider`, written by setLastUsed
   // on every provider pick). The fallback when neither the activity nor the
@@ -604,20 +614,51 @@ export function useAgentChatPanel({
     agentEffort,
   );
 
-  // The provider/model/effort the composer picker DISPLAYS. In personal (Teams)
-  // mode this is the acting user's stored choice, falling back to the clamped
-  // agent default; in shared mode it is the effective pin resolved above. The
-  // SEND path still forwards the effective pin (below) — the gateway strips it
-  // and re-injects each acting user's clamped choice per turn — so the two never
-  // need to agree on the wire, only on screen.
-  const displayModelPin = useMemo(
+  const personalDefaultPin = useMemo(
+    () =>
+      resolvePersonalModelPin(
+        modelChoiceInfo?.choice,
+        allowedModels,
+        {
+          provider: effectiveProvider,
+          model: effectiveModel,
+          effort: effectiveEffort,
+        },
+        null,
+        resolveCatalogProvider,
+      ),
+    [
+      modelChoiceInfo?.choice,
+      allowedModels,
+      effectiveProvider,
+      effectiveModel,
+      effectiveEffort,
+    ],
+  );
+
+  // The provider/model/effort the composer picker displays and every send
+  // forwards. In personal (Teams) mode an open mission's in-ceiling activity
+  // pin wins for provider/model, while effort stays on the personal resolution.
+  // Without a mission pin, the personal choice remains the default.
+  const rawDisplayModelPin = useMemo(
     () =>
       modelDecision.personal
-        ? resolvePersonalModelPin(modelChoiceInfo?.choice, allowedModels, {
-            provider: effectiveProvider,
-            model: effectiveModel,
-            effort: effectiveEffort,
-          })
+        ? resolvePersonalModelPin(
+            modelChoiceInfo?.choice,
+            allowedModels,
+            {
+              provider: effectiveProvider,
+              model: effectiveModel,
+              effort: effectiveEffort,
+            },
+            activityProvider && activityModel
+              ? {
+                  provider: activityProvider,
+                  model: activityModel,
+                }
+              : null,
+            resolveCatalogProvider,
+          )
         : {
             provider: effectiveProvider,
             model: effectiveModel,
@@ -627,15 +668,28 @@ export function useAgentChatPanel({
       modelDecision.personal,
       modelChoiceInfo?.choice,
       allowedModels,
+      activityProvider,
+      activityModel,
       effectiveProvider,
       effectiveModel,
       effectiveEffort,
     ],
   );
+  const displayModelPin = useMemo(
+    () => ({
+      ...rawDisplayModelPin,
+      effort: validEffortOrDefault(
+        rawDisplayModelPin.provider,
+        rawDisplayModelPin.model,
+        rawDisplayModelPin.effort,
+      ),
+    }),
+    [rawDisplayModelPin],
+  );
 
   // Converge legacy pin-less chats (created before per-conversation pins):
-  // stamp the provider/model this open conversation currently displays — and
-  // would send with — onto its activity, so a later change to the agent
+  // stamp the shared agent-derived provider/model onto its activity, so a later
+  // change to the agent
   // default can never move a chat that already ran (HOU-695). Chats created
   // now are stamped at creation (createMission); this covers the older ones,
   // once per activity per mount. Background convergence, not a user action:
@@ -672,13 +726,16 @@ export function useAgentChatPanel({
     // floors at the peak), and the figure is already labeled an estimate, so
     // it's acceptable for the post-switch turns until the new provider reports
     // its own usage and the indicator re-settles.
-    const cfg = getContextWindowConfig(effectiveProvider, effectiveModel);
+    const cfg = getContextWindowConfig(
+      displayModelPin.provider,
+      displayModelPin.model,
+    );
     return {
       contextUsage: latest,
       contextWindow:
         effectiveContextWindow(cfg, peakContextTokens) ?? undefined,
     };
-  }, [sessionFeedItems, effectiveProvider, effectiveModel]);
+  }, [sessionFeedItems, displayModelPin]);
 
   // A provider switch awaiting the user's consent (it spends tokens). Held here
   // and applied only on confirm.
@@ -724,6 +781,12 @@ export function useAgentChatPanel({
             provider: prov,
             model: mod,
           });
+        } else if (modelDecision.personal) {
+          await setModelChoice.mutateAsync({
+            provider: prov,
+            model: mod,
+            effort: validEffortOrDefault(prov, mod, displayModelPin.effort),
+          });
         } else {
           setAgentProvider(prov);
           setAgentModel(mod);
@@ -745,7 +808,15 @@ export function useAgentChatPanel({
         });
       }
     },
-    [path, selectedActivityId, addToast, t],
+    [
+      path,
+      selectedActivityId,
+      modelDecision.personal,
+      setModelChoice,
+      displayModelPin.effort,
+      addToast,
+      t,
+    ],
   );
 
   // Picking a provider/model from the dropdown. Switching to a DIFFERENT provider
@@ -760,7 +831,7 @@ export function useAgentChatPanel({
       const isProviderSwitch =
         conversationStarted &&
         !!selectedSessionKey &&
-        prov !== effectiveProvider;
+        prov !== displayModelPin.provider;
       if (!isProviderSwitch) {
         await applyProviderModel(prov, mod);
         return;
@@ -777,7 +848,7 @@ export function useAgentChatPanel({
     [
       conversationStarted,
       selectedSessionKey,
-      effectiveProvider,
+      displayModelPin.provider,
       contextUsage,
       sessionFeedItems,
       applyProviderModel,
@@ -813,10 +884,9 @@ export function useAgentChatPanel({
     [path, addToast, t],
   );
   const handleModeSelect = useCallback(
-    async (mode: TurnMode) => {
-      // Mode is per-agent composer memory (never synced to engine Settings):
-      // persist it so the pill reopens where the user left it. Optimistic flip;
-      // each send pins the pick as `modeOverride`.
+    (mode: TurnMode) => {
+      // Mode is session-local. Flip the picker optimistically and pin the pick
+      // on each send.
       //
       // A pick while a turn is STREAMING also applies to that turn (Claude
       // Code's shift+tab): the runtime mutates the executing turn's live-mode
@@ -841,42 +911,42 @@ export function useAgentChatPanel({
           });
         });
       }
-      try {
-        if (path) {
-          const cfg = await tauriConfig.read(path);
-          await tauriConfig.write(path, { ...cfg, mode });
-        }
-      } catch (err) {
-        addToast({
-          title: t("chat:errors.modelPersistFailed"),
-          description: genericErrorDescription("model_persist_failed", err),
-          variant: "error",
-        });
-      }
     },
     [path, selectedSessionKey, addToast, t, turnRunning, turnMode],
   );
 
-  // Route a composer model / effort pick. In personal (Teams) mode it writes the
-  // acting user's per-agent choice (the gateway clamps it to the ceiling and
-  // applies it per turn); in shared mode it keeps the existing agent-config /
-  // activity-pin behavior. `.mutate` fires and forgets — the tauri wrapper's
-  // `call()` surfaces any failure (e.g. `model_not_allowed`) as a toast once, so
-  // awaiting here would only double-toast.
+  // In personal (Teams) mode, a fresh-composer model pick updates the user's
+  // default. A pick inside an open mission follows the activity-pin path,
+  // including provider-switch consent, and can never write agent config.
   const selectModel = useCallback(
     (prov: string, mod: string) => {
-      if (modelDecision.personal) {
+      if (modelDecision.personal && !isModelAllowed(allowedModels, mod)) {
+        addToast({
+          title: t("chat:errors.modelNotAllowed"),
+          variant: "error",
+        });
+        return;
+      }
+      if (modelDecision.personal && !selectedActivityId) {
         setModelChoice.mutate({
           provider: prov,
           model: mod,
-          effort: displayModelPin.effort,
+          effort: validEffortOrDefault(prov, mod, displayModelPin.effort),
         });
+        // The device's sticky default too: the create-agent dialog seeds from
+        // it, so a hosted pick must register as "last used" like a shared-mode
+        // pick does (applyProviderModel writes it on the other branches).
+        tauriProvider.setLastUsed(prov, mod).catch(() => {});
         return;
       }
       void handleModelSelect(prov, mod);
     },
     [
       modelDecision.personal,
+      allowedModels,
+      addToast,
+      t,
+      selectedActivityId,
       setModelChoice,
       displayModelPin.effort,
       handleModelSelect,
@@ -886,8 +956,8 @@ export function useAgentChatPanel({
     (effort: EffortLevel) => {
       if (modelDecision.personal) {
         setModelChoice.mutate({
-          provider: displayModelPin.provider,
-          model: displayModelPin.model,
+          provider: personalDefaultPin.provider,
+          model: personalDefaultPin.model,
           effort,
         });
         return;
@@ -897,8 +967,8 @@ export function useAgentChatPanel({
     [
       modelDecision.personal,
       setModelChoice,
-      displayModelPin.provider,
-      displayModelPin.model,
+      personalDefaultPin.provider,
+      personalDefaultPin.model,
       handleEffortSelect,
     ],
   );
@@ -985,15 +1055,11 @@ export function useAgentChatPanel({
         // conversation VM itself — no app-side optimistic push.
         await tauriChat.send(path, encodedWithAttachments, sessionKey, {
           mode: mode?.promptFile,
-          // Pass the EFFECTIVE values, not just `chatProvider`. The dropdown
-          // displays `effectiveProvider` (chatProvider ?? activityProvider ??
-          // agentProvider ?? wsProvider), so the send must mirror it.
-          // Passing only `chatProvider` lets the engine fall back to its own
-          // resolution chain (which doesn't consult activity records),
-          // producing the "dropdown says Gemini, response from Claude" bug.
-          providerOverride: effectiveProvider,
-          modelOverride: effectiveModel,
-          effortOverride: effectiveEffort,
+          // The wire pin must match the picker. In Teams this may be the open
+          // mission's pin rather than the agent's effective default.
+          providerOverride: displayModelPin.provider,
+          modelOverride: displayModelPin.model,
+          effortOverride: displayModelPin.effort,
           modeOverride: turnMode,
           // A Skill send still carries whatever the user typed alongside it, so
           // the teammates they named there must ride too (HOU-944).
@@ -1022,10 +1088,9 @@ export function useAgentChatPanel({
           {
             agentMode,
             promptFile: mode?.promptFile,
-            // See note above re: effectiveProvider over chatProvider.
-            providerOverride: effectiveProvider,
-            modelOverride: effectiveModel,
-            effortOverride: effectiveEffort,
+            providerOverride: displayModelPin.provider,
+            modelOverride: displayModelPin.model,
+            effortOverride: displayModelPin.effort,
             modeOverride: turnMode,
             mentions,
             buildPrompt: async (activityId) => {
@@ -1059,9 +1124,7 @@ export function useAgentChatPanel({
       agent,
       path,
       agentModes,
-      effectiveProvider,
-      effectiveModel,
-      effectiveEffort,
+      displayModelPin,
       turnMode,
       queryClient,
     ],
@@ -1094,9 +1157,9 @@ export function useAgentChatPanel({
       );
       tauriChat
         .send(path, message, selectedSessionKey, {
-          providerOverride: effectiveProvider,
-          modelOverride: effectiveModel,
-          effortOverride: effectiveEffort,
+          providerOverride: displayModelPin.provider,
+          modelOverride: displayModelPin.model,
+          effortOverride: displayModelPin.effort,
           modeOverride: turnMode,
         })
         // Two-arg `then`, not `.then().catch()`: the rejection handler stays
@@ -1116,16 +1179,7 @@ export function useAgentChatPanel({
           },
         );
     },
-    [
-      path,
-      selectedSessionKey,
-      effectiveProvider,
-      effectiveModel,
-      effectiveEffort,
-      turnMode,
-      addToast,
-      t,
-    ],
+    [path, selectedSessionKey, displayModelPin, turnMode, addToast, t],
   );
   const renderLink = useCallback<NonNullable<AIBoardProps["renderLink"]>>(
     ({ href }) => {
@@ -1201,9 +1255,9 @@ export function useAgentChatPanel({
       if (!path || !selectedSessionKey) return;
       tauriChat
         .send(path, text, selectedSessionKey, {
-          providerOverride: effectiveProvider,
-          modelOverride: effectiveModel,
-          effortOverride: effectiveEffort,
+          providerOverride: displayModelPin.provider,
+          modelOverride: displayModelPin.model,
+          effortOverride: displayModelPin.effort,
           modeOverride: mode ?? turnMode,
         })
         // Two-arg `then`, not `.then().catch()`: the rejection handler must stay
@@ -1219,16 +1273,7 @@ export function useAgentChatPanel({
           },
         );
     },
-    [
-      path,
-      selectedSessionKey,
-      effectiveProvider,
-      effectiveModel,
-      effectiveEffort,
-      turnMode,
-      addToast,
-      t,
-    ],
+    [path, selectedSessionKey, displayModelPin, turnMode, addToast, t],
   );
 
   // Resolves a question step's `toolkit` to the app's presentational brand (logo
@@ -1845,9 +1890,9 @@ export function useAgentChatPanel({
               await tauriChat.send(path, text, selectedSessionKey, {
                 // Retry mirrors the displayed dropdown values, not just
                 // the in-memory chatProvider — see send sites above.
-                providerOverride: effectiveProvider,
-                modelOverride: effectiveModel,
-                effortOverride: effectiveEffort,
+                providerOverride: displayModelPin.provider,
+                modelOverride: displayModelPin.model,
+                effortOverride: displayModelPin.effort,
                 modeOverride: turnMode,
               });
               // The retry starts a turn: this card also renders inside an
@@ -1877,7 +1922,7 @@ export function useAgentChatPanel({
         // its reconnect flow targets the provider the send actually used.
         const providerError = resolveProviderErrorForChat(
           msg.providerError,
-          effectiveProvider,
+          displayModelPin.provider,
         );
         return (
           <ProviderErrorCard
@@ -1909,9 +1954,9 @@ export function useAgentChatPanel({
               // queued bubble; the adapter's watchdog probes immediately so a
               // stale hold clears within one round-trip (HOU-849).
               await tauriChat.send(path, text, selectedSessionKey, {
-                providerOverride: effectiveProvider,
-                modelOverride: effectiveModel,
-                effortOverride: effectiveEffort,
+                providerOverride: displayModelPin.provider,
+                modelOverride: displayModelPin.model,
+                effortOverride: displayModelPin.effort,
                 modeOverride: turnMode,
                 // A refused not-connected send left its prompt's bubble in
                 // the feed already — resending it must not add a second one.
@@ -1925,23 +1970,16 @@ export function useAgentChatPanel({
             // "Pick another model" pops the MODEL picker (not the Skills picker);
             // "Switch to <fallback>" applies it directly on the same provider.
             onSwitchModel={() => setModelPickerOpen(true)}
-            onApplyModel={(model) => selectModel(effectiveProvider, model)}
+            onApplyModel={(model) =>
+              selectModel(displayModelPin.provider, model)
+            }
           />
         );
       }
       if (isProviderAuthMessage(msg.content)) return null;
       return undefined;
     },
-    [
-      effectiveModel,
-      effectiveProvider,
-      effectiveEffort,
-      turnMode,
-      selectModel,
-      path,
-      selectedSessionKey,
-      t,
-    ],
+    [displayModelPin, turnMode, selectModel, path, selectedSessionKey, t],
   );
   // The welcome chat's greeting (HOU-713): a hardcoded, localized agent
   // message derived from the `welcome-` session key — prepended at render
@@ -2219,8 +2257,8 @@ export function useAgentChatPanel({
     mapFeedItems,
     afterMessages,
     pickerDialog,
-    effectiveProvider,
-    effectiveModel,
+    effectiveProvider: displayModelPin.provider,
+    effectiveModel: displayModelPin.model,
     turnMode,
     currentUserId,
     authorLabels,

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -32,13 +32,12 @@ import {
   tauriActivity,
   tauriAttachments,
   tauriChat,
-  tauriConfig,
 } from "../lib/tauri";
-import { readAgentTurnMode } from "../lib/turn-mode";
+import { DEFAULT_TURN_MODE } from "../lib/turn-mode";
 import type { Agent } from "../lib/types";
 import { useAgentCatalogStore } from "../stores/agent-catalog";
 import { useUIStore } from "../stores/ui";
-import { resolveActivityOverride } from "./mission-control-send";
+import { resolveMissionControlSendOverrides } from "./mission-control-send";
 import { AgentCardAvatar } from "./shell/agent-card-avatar";
 
 export function useMissionControl(agents: Agent[]) {
@@ -286,13 +285,7 @@ export function useMissionControl(agents: Agent[]) {
         // activity up and forward its override pair to keep picker and wire
         // in agreement.
         const list = await tauriActivity.list(agentPath);
-        const overrides = resolveActivityOverride(sessionKey, list);
-        // Mode is per-agent composer memory (config.mode), not per-activity:
-        // Mission Control has no live pill state, so read it at send time.
-        overrides.modeOverride = await readAgentTurnMode(
-          agentPath,
-          tauriConfig.read,
-        );
+        const overrides = resolveMissionControlSendOverrides(sessionKey, list);
         // The turn stream pushes the user bubble into the conversation VM
         // itself — no app-side optimistic push. If the conversation is
         // mid-turn the adapter holds this send; the queued bubble shows the
@@ -362,8 +355,7 @@ export function useMissionControl(agents: Agent[]) {
             providerOverride: opts?.providerOverride,
             modelOverride: opts?.modelOverride,
             mentions: opts?.mentions,
-            // Per-agent composer memory; Mission Control has no pill state.
-            modeOverride: await readAgentTurnMode(agentPath, tauriConfig.read),
+            modeOverride: DEFAULT_TURN_MODE,
             titleText: visible,
             buildPrompt: async (activityId) => {
               const saved = await tauriAttachments.save(

--- a/app/src/data/activity-bulk.ts
+++ b/app/src/data/activity-bulk.ts
@@ -34,11 +34,18 @@ export function applyActivityPatch(
   patch: ActivityUpdate,
   timestamp: string,
 ): Activity {
-  const { pending_interaction, ...rest } = patch;
+  const { pending_interaction, provider, model, ...rest } = patch;
   const defined = Object.fromEntries(
     Object.entries(rest).filter(([, v]) => v !== undefined),
   );
   const merged: Activity = { ...item, ...defined, updated_at: timestamp };
+  // `provider` / `model` are the mission's model pin: `null` DELETES the key
+  // (the schema has no null type) so the mission falls back to the engine's
+  // own resolution — the warming flush clears a pin its pod cannot honor.
+  if (provider === null) delete merged.provider;
+  else if (provider !== undefined) merged.provider = provider;
+  if (model === null) delete merged.model;
+  else if (model !== undefined) merged.model = model;
   const outcome = resolveInteractionPatch({
     patched: pending_interaction,
     stored: merged.pending_interaction,

--- a/app/src/data/activity.ts
+++ b/app/src/data/activity.ts
@@ -55,8 +55,9 @@ export interface ActivityUpdate {
   routine_id?: string;
   routine_run_id?: string;
   skill_slug?: string;
-  provider?: string;
-  model?: string;
+  /** The mission's model pin; `null` DELETES the key (see `applyActivityPatch`). */
+  provider?: string | null;
+  model?: string | null;
   /**
    * The mission's persisted pending interaction.
    *  - a VALID interaction object REPLACES the stored one (per-step dismissal

--- a/app/src/data/config.ts
+++ b/app/src/data/config.ts
@@ -14,11 +14,9 @@ export interface Config {
   // `xhigh` at the UI boundary (see `normalizeEffort`), so it stays here.
   effort?: "low" | "medium" | "high" | "xhigh" | "max";
   /**
-   * Composer "Mode" selector memory ONLY: the last mode the user picked for this
-   * agent, so the pill reopens where they left it. Per-agent, local. It is NEVER
-   * synced to engine Settings — the actual execute/plan/auto pin rides each send
-   * as `modeOverride` (an unpinned turn is `execute`). Unknown values normalize to
-   * `execute` at the UI boundary (see `normalizeTurnMode`).
+   * Legacy/portable config field retained for on-disk compatibility. The app
+   * does not read or write it; the session-local composer mode rides each send
+   * as `modeOverride` and defaults to `execute` for a new mission.
    */
   mode?: "execute" | "plan" | "auto";
   [extra: string]: unknown;

--- a/app/src/hooks/queries/use-agent-model-choice.ts
+++ b/app/src/hooks/queries/use-agent-model-choice.ts
@@ -59,20 +59,32 @@ export function useAgentModelChoice(agentId: string, enabled: boolean) {
  * validates the model is within the agent's `allowedModels` ceiling (else it
  * answers `model_not_allowed`) and clamps the acting user's turns to it. No
  * `onError` toast: `tauriAgentModelChoice.set` routes through `call()`, which
- * surfaces + reports the failure once; adding one here would double-toast. On
- * success the choice query is invalidated so the picker reflects the new pick.
+ * surfaces + reports the failure once; adding one here would double-toast. The
+ * cache updates optimistically so a racing send sees the new pin, rolls back on
+ * failure, and refetches after the request settles.
  */
 export function useSetAgentModelChoice(agentId: string) {
   const qc = useQueryClient();
+  const key = queryKeys.agentModelChoice(agentId);
   return useMutation({
     mutationFn: (choice: AgentModelChoice) =>
       tauriAgentModelChoice.set(agentId, {
         ...choice,
         provider: toCanonicalProviderId(choice.provider),
       }),
-    onSuccess: () =>
-      qc.invalidateQueries({
-        queryKey: queryKeys.agentModelChoice(agentId),
-      }),
+    onMutate: async (choice) => {
+      await qc.cancelQueries({ queryKey: key });
+      const prev = qc.getQueryData<AgentModelChoiceInfo | null>(key);
+      if (prev) {
+        qc.setQueryData<AgentModelChoiceInfo>(key, { ...prev, choice });
+      }
+      return { prev };
+    },
+    onError: (_err, _choice, ctx) => {
+      if (ctx?.prev !== undefined) qc.setQueryData(key, ctx.prev);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: key });
+    },
   });
 }

--- a/app/src/lib/agent-model-overrides.ts
+++ b/app/src/lib/agent-model-overrides.ts
@@ -61,9 +61,9 @@ export function resolveAgentModelOverrides(
 }
 
 /**
- * Read + resolve in one step (the send-path convenience, mirrors
- * `readAgentTurnMode`). A failed config read falls back to no pins — the safe
- * default for a preference lookup; the send itself still surfaces its errors.
+ * Read + resolve in one step for send paths that need the configured brain.
+ * A failed config read falls back to no pins; the send itself still surfaces
+ * its own errors.
  */
 export async function readAgentModelOverrides(
   agentPath: string,

--- a/app/src/lib/agent-setup.ts
+++ b/app/src/lib/agent-setup.ts
@@ -15,27 +15,25 @@ import { tauriConfig, tauriRoutines } from "./tauri";
  */
 export async function finishAgentSetup(
   agentPath: string,
-  opts: { provider: string; model: string; routine: RoutineFormData | null },
+  opts: { provider?: string; model?: string; routine: RoutineFormData | null },
 ): Promise<void> {
-  try {
-    // Always write provider/model to the agent's own config. With workspace
-    // defaults retired, the agent is the single source of truth — leaving the
-    // field blank would make the engine resolver fall back to its platform
-    // default rather than the user's pick.
-    const cfg = await tauriConfig.read(agentPath);
-    await tauriConfig.write(
-      agentPath,
-      {
-        ...cfg,
-        provider: opts.provider,
-        model: opts.model,
-      },
-      // Post-create setup rides as a held request that lands when the engine
-      // wakes (HOU-649) — never blocked by the warming-write dialog.
-      { allowWhileWarming: true },
-    );
-  } catch (e) {
-    logger.error(`[new-agent] provider/model write failed: ${e}`);
+  if (opts.provider || opts.model) {
+    try {
+      const cfg = await tauriConfig.read(agentPath);
+      await tauriConfig.write(
+        agentPath,
+        {
+          ...cfg,
+          ...(opts.provider ? { provider: opts.provider } : {}),
+          ...(opts.model ? { model: opts.model } : {}),
+        },
+        // Post-create setup rides as a held request that lands when the engine
+        // wakes (HOU-649) — never blocked by the warming-write dialog.
+        { allowWhileWarming: true },
+      );
+    } catch (e) {
+      logger.error(`[new-agent] provider/model write failed: ${e}`);
+    }
   }
 
   if (opts.routine) {

--- a/app/src/lib/default-provider-model.ts
+++ b/app/src/lib/default-provider-model.ts
@@ -1,0 +1,39 @@
+import { getDefaultModel, PROVIDERS, validModelOrNull } from "./providers.ts";
+
+export interface PickDefaultProviderModelOptions {
+  lastUsedProvider: string | null | undefined;
+  lastUsedModel: string | null | undefined;
+  connectedProviders: ReadonlySet<string> | readonly string[];
+}
+
+/**
+ * Selects a new agent's provider only from confirmed connections when any
+ * exist, preserving the stored model only when it remains valid for that
+ * provider. An empty confirmed set retains the non-blocking legacy fallback.
+ */
+export function pickDefaultProviderModel({
+  lastUsedProvider,
+  lastUsedModel,
+  connectedProviders,
+}: PickDefaultProviderModelOptions): {
+  provider: string;
+  model: string;
+  confirmed: boolean;
+} {
+  const connected = new Set(connectedProviders);
+  const confirmedProvider =
+    lastUsedProvider && connected.has(lastUsedProvider)
+      ? lastUsedProvider
+      : PROVIDERS.find((candidate) => connected.has(candidate.id))?.id;
+  const provider = confirmedProvider ?? lastUsedProvider ?? "anthropic";
+
+  return {
+    provider,
+    model:
+      provider === lastUsedProvider
+        ? (validModelOrNull(provider, lastUsedModel) ??
+          getDefaultModel(provider))
+        : getDefaultModel(provider),
+    confirmed: confirmedProvider !== undefined,
+  };
+}

--- a/app/src/lib/model-selector-lock.ts
+++ b/app/src/lib/model-selector-lock.ts
@@ -10,10 +10,10 @@
  * multiplayer Teams org the composer's model + effort pickers are shown for
  * EVERYONE (plain members included), their option list is clamped to the agent's
  * allowed-models ceiling, and they read+write the ACTING user's PERSONAL
- * per-agent choice rather than the shared agent config. Single-player /
- * self-host is unchanged: shared config, no ceiling, every model. The gateway is
- * the sole enforcer of the ceiling (it clamps every turn to the acting user's
- * choice); these helpers only shape the affordance.
+ * per-agent choice as the default for new missions. An open mission's in-ceiling
+ * activity pin wins. Single-player / self-host is unchanged: shared config, no
+ * ceiling, every model. These helpers mirror the gateway's resolution so the
+ * picker shows the pin that the next turn will run.
  */
 
 import type {
@@ -103,34 +103,44 @@ export interface ModelPin {
 
 /**
  * The provider/model/effort the composer should DISPLAY in personal (Teams)
- * mode. The priority mirrors the gateway's per-turn clamp so the picker shows
- * what will actually run:
- *  1. the user's stored `choice` when present;
- *  2. else, when a ceiling exists and the shared `fallback` model is outside it,
- *     the ceiling's first model carried on the fallback provider (the gateway
+ * mode. The priority mirrors the gateway's per-turn resolution so the picker
+ * shows what will actually run:
+ *  1. an open mission's pin when its model remains inside the ceiling, carrying
+ *     the personal resolution's effort because activities have no effort field;
+ *  2. the user's stored `choice` when present;
+ *  3. else, when a ceiling exists and the shared `fallback` model is outside it,
+ *     the ceiling's first model carried on its catalogued provider (the gateway
  *     forces first-of-ceiling for a member who has not picked yet);
- *  3. else the shared `fallback` (agent / pod default) unchanged.
+ *  4. else the shared `fallback` (agent / pod default) unchanged.
  */
 export function resolvePersonalModelPin(
   choice: AgentModelChoice | null | undefined,
   allowedModels: string[] | null | undefined,
   fallback: ModelPin,
+  missionPin: ModelPin | null,
+  resolveProvider: (model: string) => string | null,
 ): ModelPin {
-  if (choice)
+  const personalPin = choice
+    ? {
+        provider: choice.provider,
+        model: choice.model,
+        effort: choice.effort,
+      }
+    : allowedModels != null &&
+        allowedModels.length > 0 &&
+        !allowedModels.includes(fallback.model)
+      ? {
+          provider: resolveProvider(allowedModels[0]) ?? fallback.provider,
+          model: allowedModels[0],
+          effort: fallback.effort,
+        }
+      : fallback;
+  if (missionPin && isModelAllowed(allowedModels, missionPin.model)) {
     return {
-      provider: choice.provider,
-      model: choice.model,
-      effort: choice.effort,
+      provider: missionPin.provider,
+      model: missionPin.model,
+      effort: personalPin.effort,
     };
-  if (
-    allowedModels != null &&
-    allowedModels.length > 0 &&
-    !allowedModels.includes(fallback.model)
-  )
-    return {
-      provider: fallback.provider,
-      model: allowedModels[0],
-      effort: fallback.effort,
-    };
-  return fallback;
+  }
+  return personalPin;
 }

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1412,6 +1412,27 @@ export const tauriProvider = {
         return out;
       },
     ),
+  checkAllStatusesForAgent: (agentId: string, ids: readonly string[]) =>
+    call<Record<string, ProviderStatus>>(
+      "check_agent_provider_statuses",
+      async () => {
+        const list = await getEngine().providerStatusesForAgent(agentId, ids);
+        const out: Record<string, ProviderStatus> = {};
+        ids.forEach((id, index) => {
+          const status = list[index];
+          if (!status) return;
+          out[id] = {
+            provider: status.provider,
+            cli_installed: status.cliInstalled,
+            auth_state: status.authState,
+            authenticated: status.authState === "authenticated",
+            cli_name: status.cliName,
+            active_model: status.activeModel,
+          };
+        });
+        return out;
+      },
+    ),
   getDefault: () =>
     call<string>(
       "get_default_provider",

--- a/app/src/lib/turn-mode.ts
+++ b/app/src/lib/turn-mode.ts
@@ -14,13 +14,12 @@
  * shift+tab semantics): the runtime's executing turn adopts it at its next
  * tool decision.
  *
- * The user's last pick is remembered per-agent in `.houston/config` (composer
- * memory only — never synced to engine Settings), so unknown/legacy values on
- * read normalize back to {@link DEFAULT_TURN_MODE}.
+ * Mode is session-local and defaults to `execute` for every new mission. A
+ * user's in-session pick applies to subsequent sends in that session only.
  */
 export type TurnMode = "execute" | "plan" | "auto";
 
-export const DEFAULT_TURN_MODE: TurnMode = "plan";
+export const DEFAULT_TURN_MODE: TurnMode = "execute";
 
 /** Tolerant read: the three known values pass through as-is; anything else
  *  (a stale value, `undefined`, a typo) falls back to {@link DEFAULT_TURN_MODE}. */
@@ -29,22 +28,4 @@ export function normalizeTurnMode(value: unknown): TurnMode {
   if (value === "auto") return "auto";
   if (value === "execute") return "execute";
   return DEFAULT_TURN_MODE;
-}
-
-/**
- * The agent's remembered turn mode, for send paths that assemble their own
- * overrides (Mission Control, archived resumes) instead of holding the chat
- * panel's live pill state. A failed config read falls back to
- * {@link DEFAULT_TURN_MODE} — the safe default for a preference lookup; the
- * send itself still surfaces its own errors.
- */
-export async function readAgentTurnMode(
-  agentPath: string,
-  readConfig: (path: string) => Promise<{ mode?: string }>,
-): Promise<TurnMode> {
-  try {
-    return normalizeTurnMode((await readConfig(agentPath)).mode);
-  } catch {
-    return DEFAULT_TURN_MODE;
-  }
 }

--- a/app/src/lib/warming-send-pin.ts
+++ b/app/src/lib/warming-send-pin.ts
@@ -1,0 +1,35 @@
+export interface WarmingPin {
+  provider?: string;
+  model?: string;
+  effort?: string;
+}
+
+export async function verifyWarmingSendPin(args: {
+  agentId: string;
+  activityId?: string;
+  pin: WarmingPin;
+  timeoutMs?: number;
+  probe: (agentId: string, provider: string) => Promise<boolean>;
+  clearActivityPin: (agentId: string, activityId: string) => Promise<void>;
+}): Promise<WarmingPin> {
+  if (!args.pin.provider) return args.pin;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = Symbol("provider-probe-timeout");
+  let configured: boolean | typeof timedOut;
+  try {
+    configured = await Promise.race([
+      args.probe(args.agentId, args.pin.provider),
+      new Promise<typeof timedOut>((resolve) => {
+        timer = setTimeout(resolve, args.timeoutMs ?? 3_000, timedOut);
+      }),
+    ]);
+  } catch {
+    return args.pin;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+  if (configured === timedOut || configured) return args.pin;
+  if (args.activityId)
+    await args.clearActivityPin(args.agentId, args.activityId);
+  return {};
+}

--- a/app/src/lib/warming-sends.ts
+++ b/app/src/lib/warming-sends.ts
@@ -28,7 +28,8 @@ import { showErrorToast } from "./error-toast";
 import i18n from "./i18n";
 import { logger } from "./logger";
 import { refreshMissionTitle } from "./mission-title";
-import { tauriActivity, tauriChat } from "./tauri";
+import { tauriActivity, tauriChat, tauriProvider } from "./tauri";
+import { verifyWarmingSendPin } from "./warming-send-pin";
 
 /** Prompt builders keyed by send id — in-memory only, lost on reload. */
 const promptBuilders = new Map<string, () => Promise<string> | string>();
@@ -197,6 +198,36 @@ export async function flushWarmingSends(
     }
     // Row-only entry (the welcome mission): the row IS the payload.
     if (send.rowOnly) continue;
+    const activityId =
+      rowId ??
+      (send.sessionKey.startsWith("activity-")
+        ? send.sessionKey.slice("activity-".length)
+        : undefined);
+    const pin = await verifyWarmingSendPin({
+      agentId: entry.agentPath,
+      activityId,
+      pin: {
+        provider: send.provider,
+        model: send.model,
+        effort: send.effort,
+      },
+      probe: async (agentId, provider) => {
+        const statuses = await tauriProvider.checkAllStatusesForAgent(agentId, [
+          provider,
+        ]);
+        return statuses[provider]?.authenticated === true;
+      },
+      clearActivityPin: async (agentId, id) => {
+        try {
+          await tauriActivity.update(agentId, id, {
+            provider: null,
+            model: null,
+          });
+        } catch (error) {
+          logger.error(`[warming-sends] activity pin clear failed: ${error}`);
+        }
+      },
+    });
     // The bubble is already on screen (pushed at queue time, or restored on
     // rehydrate) — never double it. If the scope is somehow empty (renamed
     // agent moved the VM scope), let the turn push it.
@@ -206,9 +237,9 @@ export async function flushWarmingSends(
     try {
       await tauriChat.send(entry.agentPath, prompt, send.sessionKey, {
         mode: send.promptFile,
-        providerOverride: send.provider,
-        modelOverride: send.model,
-        effortOverride: send.effort,
+        providerOverride: pin.provider,
+        modelOverride: pin.model,
+        effortOverride: pin.effort,
         modeOverride: send.mode,
         mentions: send.mentions,
         suppressUserBubble: suppress,
@@ -226,8 +257,8 @@ export async function flushWarmingSends(
           agentPath: entry.agentPath,
           activityId: rowId,
           text: send.titleText,
-          provider: send.provider,
-          model: send.model,
+          provider: pin.provider,
+          model: pin.model,
         });
       }
     } catch (e) {

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -110,6 +110,7 @@
     "sessionStart": "Failed to start session: {{error}}",
     "stopSession": "Couldn't stop the mission: {{error}}",
     "modelPersistFailed": "Failed to save model preference",
+    "modelNotAllowed": "This model isn't allowed for this agent",
     "missionRowFailed": "We could not save this mission to your board. Your message was still sent.",
     "interactionDismissFailed": "Couldn't dismiss the request."
   },

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -110,6 +110,7 @@
     "sessionStart": "No se pudo iniciar la sesión: {{error}}",
     "stopSession": "No se pudo detener la misión: {{error}}",
     "modelPersistFailed": "No se pudo guardar la preferencia de modelo",
+    "modelNotAllowed": "Este modelo no está permitido para este agente",
     "missionRowFailed": "No pudimos guardar esta misión en tu tablero. Tu mensaje sí fue enviado.",
     "interactionDismissFailed": "No pudimos descartar la solicitud."
   },

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -110,6 +110,7 @@
     "sessionStart": "Não foi possível iniciar a sessão: {{error}}",
     "stopSession": "Não foi possível parar a missão: {{error}}",
     "modelPersistFailed": "Não foi possível salvar a preferência de modelo",
+    "modelNotAllowed": "Este modelo não é permitido para este agente",
     "missionRowFailed": "Não conseguimos salvar esta missão no seu quadro. Sua mensagem foi enviada.",
     "interactionDismissFailed": "Não foi possível descartar a solicitação."
   },

--- a/app/tests/default-provider-model.test.ts
+++ b/app/tests/default-provider-model.test.ts
@@ -1,0 +1,87 @@
+import { deepStrictEqual, notStrictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { pickDefaultProviderModel } from "../src/lib/default-provider-model.ts";
+import { getDefaultModel, PROVIDERS } from "../src/lib/providers.ts";
+
+describe("pickDefaultProviderModel", () => {
+  it("keeps a connected last-used provider and valid model", () => {
+    deepStrictEqual(
+      pickDefaultProviderModel({
+        lastUsedProvider: "openrouter",
+        lastUsedModel: "custom/live-model",
+        connectedProviders: ["anthropic", "openrouter"],
+      }),
+      {
+        provider: "openrouter",
+        model: "custom/live-model",
+        confirmed: true,
+      },
+    );
+  });
+
+  it("uses the first canonical connected provider when last-used is disconnected", () => {
+    const connectedProviders = ["anthropic", "openai"];
+    const firstConnected = PROVIDERS.find((provider) =>
+      connectedProviders.includes(provider.id),
+    )?.id;
+    notStrictEqual(firstConnected, undefined);
+
+    deepStrictEqual(
+      pickDefaultProviderModel({
+        lastUsedProvider: "openrouter",
+        lastUsedModel: "custom/live-model",
+        connectedProviders,
+      }),
+      {
+        provider: firstConnected,
+        model: getDefaultModel(firstConnected as string),
+        confirmed: true,
+      },
+    );
+  });
+
+  it("replaces an invalid last-used model with the provider default", () => {
+    deepStrictEqual(
+      pickDefaultProviderModel({
+        lastUsedProvider: "anthropic",
+        lastUsedModel: "retired-model",
+        connectedProviders: ["anthropic"],
+      }),
+      {
+        provider: "anthropic",
+        model: getDefaultModel("anthropic"),
+        confirmed: true,
+      },
+    );
+  });
+
+  it("falls back to Anthropic when no provider or model was stored", () => {
+    deepStrictEqual(
+      pickDefaultProviderModel({
+        lastUsedProvider: null,
+        lastUsedModel: null,
+        connectedProviders: [],
+      }),
+      {
+        provider: "anthropic",
+        model: getDefaultModel("anthropic"),
+        confirmed: false,
+      },
+    );
+  });
+
+  it("retains the legacy last-used fallback while statuses are empty", () => {
+    deepStrictEqual(
+      pickDefaultProviderModel({
+        lastUsedProvider: "openrouter",
+        lastUsedModel: "custom/live-model",
+        connectedProviders: new Set<string>(),
+      }),
+      {
+        provider: "openrouter",
+        model: "custom/live-model",
+        confirmed: false,
+      },
+    );
+  });
+});

--- a/app/tests/mission-control-send.test.ts
+++ b/app/tests/mission-control-send.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   type ActivityOverrideSource,
   resolveActivityOverride,
+  resolveMissionControlSendOverrides,
 } from "../src/components/mission-control-send.ts";
 
 const opus47Activity: ActivityOverrideSource = {
@@ -130,5 +131,20 @@ describe("resolveActivityOverride (Mission Control send-path override drop fix)"
       providerOverride: "anthropic",
       modelOverride: "claude-opus-4-8",
     });
+  });
+});
+
+describe("resolveMissionControlSendOverrides", () => {
+  it("pins caller-assembled sends to Ask First", () => {
+    deepStrictEqual(
+      resolveMissionControlSendOverrides(`activity-${opus47Activity.id}`, [
+        opus47Activity,
+      ]),
+      {
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-7",
+        modeOverride: "execute",
+      },
+    );
   });
 });

--- a/app/tests/model-selector-lock.test.ts
+++ b/app/tests/model-selector-lock.test.ts
@@ -122,35 +122,88 @@ describe("resolvePersonalModelPin", () => {
         { provider: "openai", model: "gpt-5.5", effort: "low" },
         ["gpt-5.5"],
         fallback,
+        null,
+        () => null,
       ),
       { provider: "openai", model: "gpt-5.5", effort: "low" },
     );
   });
 
   it("keeps the fallback when there is no ceiling", () => {
-    deepStrictEqual(resolvePersonalModelPin(null, null, fallback), fallback);
     deepStrictEqual(
-      resolvePersonalModelPin(undefined, undefined, fallback),
+      resolvePersonalModelPin(null, null, fallback, null, () => null),
+      fallback,
+    );
+    deepStrictEqual(
+      resolvePersonalModelPin(undefined, undefined, fallback, null, () => null),
       fallback,
     );
   });
 
   it("keeps the fallback when its model is inside the ceiling", () => {
     deepStrictEqual(
-      resolvePersonalModelPin(null, ["claude", "gpt-5.5"], fallback),
+      resolvePersonalModelPin(
+        null,
+        ["claude", "gpt-5.5"],
+        fallback,
+        null,
+        () => null,
+      ),
       fallback,
     );
   });
 
-  it("snaps to the ceiling's first model when the fallback is outside it", () => {
+  it("snaps to the ceiling model's owning provider", () => {
     deepStrictEqual(
-      resolvePersonalModelPin(null, ["gpt-5.5", "gemini"], fallback),
-      { provider: "anthropic", model: "gpt-5.5", effort: "high" },
+      resolvePersonalModelPin(
+        null,
+        ["gpt-5.5", "gemini"],
+        fallback,
+        null,
+        (model) => (model === "gpt-5.5" ? "openai" : null),
+      ),
+      { provider: "openai", model: "gpt-5.5", effort: "high" },
+    );
+  });
+
+  it("keeps the fallback provider when the snapped model is unknown", () => {
+    deepStrictEqual(
+      resolvePersonalModelPin(null, ["unknown"], fallback, null, () => null),
+      { provider: "anthropic", model: "unknown", effort: "high" },
     );
   });
 
   it("keeps the fallback for an empty ceiling (no model to snap to)", () => {
-    deepStrictEqual(resolvePersonalModelPin(null, [], fallback), fallback);
+    deepStrictEqual(
+      resolvePersonalModelPin(null, [], fallback, null, () => null),
+      fallback,
+    );
+  });
+
+  it("uses an in-ceiling mission pin while keeping personal effort", () => {
+    deepStrictEqual(
+      resolvePersonalModelPin(
+        { provider: "openai", model: "gpt-5.5", effort: "low" },
+        ["claude", "gpt-5.5"],
+        fallback,
+        { provider: "anthropic", model: "claude" },
+        () => null,
+      ),
+      { provider: "anthropic", model: "claude", effort: "low" },
+    );
+  });
+
+  it("ignores an out-of-ceiling mission pin", () => {
+    deepStrictEqual(
+      resolvePersonalModelPin(
+        { provider: "openai", model: "gpt-5.5", effort: "low" },
+        ["gpt-5.5"],
+        fallback,
+        { provider: "anthropic", model: "claude" },
+        () => null,
+      ),
+      { provider: "openai", model: "gpt-5.5", effort: "low" },
+    );
   });
 });
 

--- a/app/tests/turn-mode.test.ts
+++ b/app/tests/turn-mode.test.ts
@@ -1,15 +1,9 @@
 import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
-import {
-  DEFAULT_TURN_MODE,
-  normalizeTurnMode,
-  readAgentTurnMode,
-} from "../src/lib/turn-mode.ts";
+import { DEFAULT_TURN_MODE, normalizeTurnMode } from "../src/lib/turn-mode.ts";
 
-// The composer "Mode" pin is loaded from per-agent config, which is untyped on
-// disk. `normalizeTurnMode` is the read-side guard: only the three known mode
-// strings pass through as-is; everything else falls back to the default mode
-// so a stale or garbage value never strands the composer in an unknown mode.
+// `normalizeTurnMode` remains the read-side guard for legacy/live pins: only
+// the three known mode values may cross the UI boundary.
 describe("normalizeTurnMode", () => {
   it("keeps the three known modes", () => {
     strictEqual(normalizeTurnMode("plan"), "plan");
@@ -33,41 +27,7 @@ describe("normalizeTurnMode", () => {
     strictEqual(normalizeTurnMode({ mode: "plan" }), DEFAULT_TURN_MODE);
   });
 
-  it("defaults to plan (fresh agents open in Planner)", () => {
-    strictEqual(DEFAULT_TURN_MODE, "plan");
-  });
-});
-
-describe("readAgentTurnMode", () => {
-  it("reads and normalizes the agent's remembered mode", async () => {
-    strictEqual(
-      await readAgentTurnMode("Agent", async () => ({ mode: "plan" })),
-      "plan",
-    );
-    strictEqual(
-      await readAgentTurnMode("Agent", async () => ({ mode: "auto" })),
-      "auto",
-    );
-    strictEqual(
-      await readAgentTurnMode("Agent", async () => ({ mode: "execute" })),
-      "execute",
-    );
-    strictEqual(
-      await readAgentTurnMode("Agent", async () => ({ mode: "legacy" })),
-      DEFAULT_TURN_MODE,
-    );
-    strictEqual(
-      await readAgentTurnMode("Agent", async () => ({})),
-      DEFAULT_TURN_MODE,
-    );
-  });
-
-  it("falls back to the default mode when the config read fails", async () => {
-    strictEqual(
-      await readAgentTurnMode("Agent", async () => {
-        throw new Error("missing config");
-      }),
-      DEFAULT_TURN_MODE,
-    );
+  it("falls back to Ask First as the product default", () => {
+    strictEqual(DEFAULT_TURN_MODE, "execute");
   });
 });

--- a/app/tests/warming-send-pin.test.ts
+++ b/app/tests/warming-send-pin.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { verifyWarmingSendPin } from "../src/lib/warming-send-pin.ts";
+
+const pin = { provider: "anthropic", model: "sonnet", effort: "high" };
+
+describe("warming send provider pin", () => {
+  it("drops a missing provider and clears the activity pin", async () => {
+    const cleared: Array<[string, string]> = [];
+    const result = await verifyWarmingSendPin({
+      agentId: "new-agent",
+      activityId: "mission-1",
+      pin,
+      probe: async () => false,
+      clearActivityPin: async (agent, activity) => {
+        cleared.push([agent, activity]);
+      },
+    });
+    assert.deepEqual(result, {});
+    assert.deepEqual(cleared, [["new-agent", "mission-1"]]);
+  });
+
+  it("preserves a pin configured on the new pod", async () => {
+    const result = await verifyWarmingSendPin({
+      agentId: "new-agent",
+      activityId: "mission-1",
+      pin,
+      probe: async () => true,
+      clearActivityPin: async () => assert.fail("must not clear"),
+    });
+    assert.deepEqual(result, pin);
+  });
+
+  it("preserves a pin when the bounded probe times out", async () => {
+    const result = await verifyWarmingSendPin({
+      agentId: "new-agent",
+      activityId: "mission-1",
+      pin,
+      timeoutMs: 1,
+      probe: () => new Promise(() => {}),
+      clearActivityPin: async () => assert.fail("must not clear"),
+    });
+    assert.deepEqual(result, pin);
+  });
+});

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -575,11 +575,20 @@ the border/shadow/radius. The library component is props-only and i18n-agnostic
   selector: the chat composer AND the import flow (`portable/import-wizard.tsx`)
   render it with `agent={null}` (never locks — there is no agent yet). The old
   hand-rolled `InlineModelSelector` (curated-only, hid disconnected providers) is
-  gone. The **create-agent dialog has NO model picker**: `naming-step.tsx` and
-  `ai-assist-step.tsx` silently use the sticky last-used provider/model
-  (loaded on dialog open in `create-workspace-dialog.tsx`, baked into the new
-  agent via `finishAgentSetup`); users change the model later from the chat
-  composer.
+  gone. The create-agent dialog's `naming-step.tsx` uses the sticky default,
+  while `ai-assist-step.tsx` exposes the shared picker. Both resolve against
+  CONFIRMED-CONNECTED providers (HOU-1065): `pickDefaultProviderModel`
+  (`app/src/lib/default-provider-model.ts`, unit-tested) keeps last-used only when
+  connected, else falls to the first connected provider in `PROVIDERS` order, else
+  the legacy anthropic fallback. Loaded on dialog open in
+  `create-workspace-dialog.tsx` (re-resolves as provider statuses land, latched off
+  once the user picks; an EMPTY statuses map is indeterminate and never resets the
+  seed). Create, import, and AI generation re-resolve from CURRENT statuses at
+  action time. An explicit picker choice is pinned; a confirmed default is
+  pinned; if nothing is confirmed, the visible legacy fallback is NOT written
+  by `finishAgentSetup` and is NOT passed as a turn override. The import wizard
+  (`portable/import-wizard.tsx`) follows the same rule. Users can change the
+  model later from the chat composer.
 - **Only ever offers runnable `(provider, model)` pairs.** The mapping
   (`app/src/lib/chat-model-picker-map.ts`, pure + unit-tested) encodes each row
   id as `` `${provider}::${model}` `` (split on the FIRST `::`), decoded on

--- a/knowledge-base/anthropic-credentials.md
+++ b/knowledge-base/anthropic-credentials.md
@@ -1,4 +1,4 @@
-# Anthropic credential lifecycle (Claude subscription OAuth)
+# Subscription OAuth credential lifecycle
 
 Anthropic is the one provider whose turns run through the **Claude Agent SDK**
 (a `claude` subprocess), not pi — so its credential plumbing is different from
@@ -7,13 +7,29 @@ is unusable" cluster (reconnect card after every send locally, cloud connect
 timing out into the setup-token paste dialog, mid-session sign-outs) came from
 the traps at the bottom — read them before touching any of this.
 
+## OpenAI Codex OAuth rotation
+
+OpenAI Codex refresh tokens rotate on use. In managed cloud the gateway is the
+only rotator and central credential storage is authoritative; a pod may consume
+only access tokens with `refresh=""`. Sharing one refresh-token family between
+the gateway and a pod lets either side invalidate the other's copy.
+
+Device-code connect is the narrow exception. pi first writes the complete new
+credential into the pod's `auth.json`; the host then captures access + refresh
+into central storage and immediately calls `POST /auth/scrub-refresh`. Capture
+is successful only after that scrub succeeds, and both capture and scrub use
+bounded retries. While this sequence is in flight, serve sync must preserve any
+local OAuth entry with a non-empty refresh token. That entry is the newly minted
+credential awaiting capture, whereas normal served entries are always
+refresh-less and remain safe to replace on every serve cycle.
+
 ## Where the credential lives, per deployment
 
 | Deployment | Source of truth | Who refreshes |
 |---|---|---|
 | Desktop (macOS) | Keychain item scoped to `<HOUSTON_HOME>/claude-login` (`claude auth login` writes it) | The SDK/CLI, in place |
 | Desktop (Linux/Win) / self-host | `<HOUSTON_HOME>/claude-login/.credentials.json` | The SDK/CLI, in place |
-| Managed cloud pod | Gateway Pg store (`/v1/pod/credentials`), captured at connect | The **gateway only** (single rotator; anthropic entry in `internal/credentials`, JSON grant) |
+| Managed cloud pod | Gateway Pg store (`/v1/pod/credentials`), captured at connect; pod materialization is access-only | The **gateway only** (single rotator; anthropic entry in `internal/credentials`, JSON grant) |
 | Setup-token paste (any) | `auth.json` `api_key` entry (never expires) | Nobody |
 
 ## The flows
@@ -57,7 +73,15 @@ the traps at the bottom — read them before touching any of this.
   the pod host serves a gateway-refreshed ACCESS-ONLY token
   (`routes/credential.ts`), the runtime writes it to `auth.json`
   (`refresh=""`), and the SDK consumes it via `CLAUDE_CODE_OAUTH_TOKEN`
-  (`backends/claude/read-token.ts`). This is what survives pod recycles:
+  (`backends/claude/read-token.ts`). The connect-time
+  `POST /auth/anthropic/oauth-credential` materialization is also access-only
+  whenever serve mode is on, so the SDK can never rotate the gateway's refresh
+  family from the pod. After serve sync, a pinned turn whose canonical provider
+  is definitively not configured is refused with `unauthenticated /
+  no_credentials` for that provider; reconnecting restores the credential and
+  the app's normal unauthenticated auto-resume retries the undelivered prompt.
+  Unpinned no-provider requests retain their `409 no_provider` contract. This is
+  what survives pod recycles:
   `/data` is an emptyDir in prod and store-sync EXCLUDES both credential files.
 
 ## The five traps (each was a live bug)
@@ -82,7 +106,10 @@ the traps at the bottom — read them before touching any of this.
    single rotator for pods; the desktop CLI is the single rotator locally; the
    central-store copy on a desktop host is an inert marker (never served,
    never refreshed — TS `credentials/refresh.ts` deliberately has no anthropic
-   entry). HOU-950 corollary: a family must never be COPIED between rotating
+   entry). A serve-mode pod therefore strips the refresh token from both its
+   served `auth.json` entry and its connect-time materialized Claude credential;
+   only desktop/self-host materialization retains the full credential for local
+   SDK refresh. HOU-950 corollary: a family must never be COPIED between rotating
    stores — a remote login mints in the handoff dir and the local copy dies
    after the push (exclusive handoff), and cached snapshots are never pushed.
    No locking or freshness check makes a shared family safe; the invalidation
@@ -132,3 +159,12 @@ actually serve a turn:
 The TURN path deliberately keeps looser gating (`providerConfigured`): a turn
 on a suspect provider should run and surface its REAL typed card (network /
 reconnect), and a clean turn is what heals a stale failure mark.
+
+On a managed engine pod, an authoritative central serve miss (the gateway's
+marked not-connected response or a dead-credential response) also self-heals
+from a full refresh-bearing credential still owned by that same pod runtime.
+The host single-flights and cools down recovery per provider, reuses the normal
+export → gateway PUT → runtime scrub transaction, then re-reads and serves the
+gateway-verified access token in the same request. A successful scrub leaves
+the pod access-only and restores the gateway as the credential family's single
+refresh-token rotator; transport failures never trigger an upload.

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -637,16 +637,26 @@ configure surfaces are gated:
   personal membership in `GET /v1/orgs`).
 - **Model / effort pickers** (`chat-model-selector.tsx`,
   `chat-effort-selector.tsx`) are NOT hidden/locked for members (E8 reversed E7).
-  In a Teams org the composer shows them to EVERYONE, clamps the option list to
-  the agent's `allowedModels` ceiling, and reads+writes the caller's PERSONAL
-  per-agent choice (`useAgentModelChoice` / `useSetAgentModelChoice`) — never the
-  shared agent config. The gateway clamps every turn to the acting user's choice
-  (client picker is convenience only). A single-model ceiling renders read-only
+  In a Teams org the composer shows them to EVERYONE and clamps the option list to
+  the agent's `allowedModels` ceiling. **Model scope is per MISSION (HOU-1064):**
+  a pick made with a mission open writes that mission's activity pin (same
+  activity-pin path as single-player, provider-switch consent included) and moves
+  only that conversation; a pick in a fresh composer writes the caller's PERSONAL
+  per-agent choice (`useAgentModelChoice` / `useSetAgentModelChoice`, optimistic
+  cache update) — the default the user's NEXT missions start on. The picker
+  displays the open mission's in-ceiling pin first, else the personal choice; an
+  out-of-ceiling personal pick toasts `chat:errors.modelNotAllowed` instead of
+  silently no-oping. Every send forwards the displayed pin on the wire and the
+  gateway honors it when in-ceiling (see Enforcement below). A member never
+  writes the shared agent config. A single-model ceiling renders read-only
   but still visible. Single-player / self-host is unchanged: shared config, no
   ceiling. The pure decision + clamp + resting-pin helpers live in
   `app/src/lib/model-selector-lock.ts` (`modelSelectorDecision`, `isModelAllowed`,
-  `resolvePersonalModelPin`, and `hiddenModelCount`, the count of DISTINCT blocked
-  models across provider rows); the composer wires them in `use-agent-chat-panel.tsx`.
+  `resolvePersonalModelPin` — mission pin wins in-ceiling; the ceiling snap
+  resolves the model's OWNING provider via an injected catalog lookup — and
+  `hiddenModelCount`, the count of DISTINCT blocked models across provider rows);
+  the composer wires them in `use-agent-chat-panel.tsx`, revalidating the
+  displayed effort against the pinned model (`validEffortOrDefault`).
   **The picker no longer hides blocked models silently:** when the ceiling narrows the
   universe it renders a non-interactive footer "N more models are turned off in your
   workspace" (`chat:modelSelector.picker.hiddenByWorkspace_one/_other`), fed by
@@ -706,11 +716,15 @@ hides the "Add models" list, all copy passed in.
   catalog, plus any unknown ids), not raw ids — falling back to the raw id count only
   while the catalog is still loading.
 - **Per-user choice** — each acting user's own `{provider, model, effort?}` for one
-  shared agent (`gateway.agent_model_choices`), read/written by the composer pickers in
-  multiplayer (see "Manager-only configure surfaces" above), never the shared config.
-- **Enforcement** — the gateway is the sole enforcer: it clamps every turn to the acting
-  user's choice ∩ ceiling and strips any client-supplied model/provider. The client picker
-  is convenience only.
+  shared agent (`gateway.agent_model_choices`), written by the composer picker when NO
+  mission is open (it is the default for the user's next missions), never the shared
+  config. A pick with a mission open writes that mission's activity pin instead (HOU-1064).
+- **Enforcement** — the gateway is the sole enforcer of the CEILING: an in-ceiling
+  per-conversation body pin is honored verbatim (casing normalized to the ceiling's,
+  provider backfilled from the stored choice when the wire omits it); a pin-less or
+  out-of-ceiling turn falls back to the acting user's choice ∩ ceiling, else
+  first-of-ceiling. A client can never run a model outside the ceiling
+  (`cloud/internal/edge/agents/model.go`, contract `C7-teams.md`).
 - Types: `AgentSettings.allowedModels` (the agent's whole model ceiling),
   `AgentModelChoice` (`{provider, model, effort?}`),
   `AgentModelChoiceInfo` (`{choice, allowedModels}`).

--- a/packages/domain/src/activities.ts
+++ b/packages/domain/src/activities.ts
@@ -161,11 +161,18 @@ export function applyActivityUpdate(
   nowIso: string,
   author?: ActivityContributor,
 ): Activity {
-  const { pending_interaction, ...rest } = update;
+  const { pending_interaction, provider, model, ...rest } = update;
   const defined = Object.fromEntries(
     Object.entries(rest).filter(([, v]) => v !== undefined),
   );
   const next = { ...current, ...defined, updated_at: nowIso } as Activity;
+  // `provider`/`model` are the mission's model pin: `null` deletes the key so
+  // the mission falls back to the engine's own resolution (the warming flush
+  // clears a pin its pod cannot honor).
+  if (provider === null) delete next.provider;
+  else if (provider !== undefined) next.provider = provider;
+  if (model === null) delete next.model;
+  else if (model !== undefined) next.model = model;
   // PATCH bodies are untrusted at runtime (an old client or a stale message can
   // carry a pre-step shape the compile-time type can't catch), and closing a
   // mission answers whatever it was waiting on. Both rules live once, in

--- a/packages/domain/src/domain.test.ts
+++ b/packages/domain/src/domain.test.ts
@@ -223,6 +223,24 @@ test("activity update: pending_interaction set / clear / untouched", () => {
   expect("pending_interaction" in cleared).toBe(false);
 });
 
+test("activity update: null clears provider and model while omission preserves", () => {
+  const current = createActivity(
+    { title: "Pinned", provider: "anthropic", model: "sonnet" },
+    "a1",
+    NOW,
+  );
+  expect(
+    applyActivityUpdate(current, { status: "running" }, NOW),
+  ).toMatchObject({ provider: "anthropic", model: "sonnet" });
+  const cleared = applyActivityUpdate(
+    current,
+    { provider: null, model: null },
+    NOW,
+  );
+  expect("provider" in cleared).toBe(false);
+  expect("model" in cleared).toBe(false);
+});
+
 test("activity update: an invalid (pre-step legacy) pending_interaction is not persisted", () => {
   const current = applyActivityUpdate(
     createActivity({ title: "T" }, "a1", NOW),

--- a/packages/host/src/channel/capture-credential.test.ts
+++ b/packages/host/src/channel/capture-credential.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, expect, test, vi } from "vitest";
+import type { CredentialStore, WorkspaceCredential } from "../ports";
+import { captureRuntimeCredential } from "./capture-credential";
+
+afterEach(() => vi.unstubAllGlobals());
+
+test("full export stores once then scrubs once", async () => {
+  const stored: WorkspaceCredential[] = [];
+  let scrubCalls = 0;
+  const credentials: CredentialStore = {
+    get: async () => null,
+    put: async (credential) => {
+      stored.push(credential);
+    },
+    remove: async () => {},
+    removeIfAccess: async () => false,
+  };
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/auth/export"))
+        return Response.json({
+          provider: "openai-codex",
+          access: "AT",
+          refresh: "RT",
+          expires: 123,
+        });
+      if (url.endsWith("/auth/scrub-refresh")) {
+        scrubCalls++;
+        return Response.json({ ok: true });
+      }
+      return new Response("not found", { status: 404 });
+    }),
+  );
+
+  expect(
+    await captureRuntimeCredential({
+      endpoint: { baseUrl: "http://runtime", token: "runtime-token" },
+      credentials,
+      workspaceId: "workspace",
+      provider: "openai-codex",
+      requireRefresh: true,
+    }),
+  ).toEqual({ ok: true, provider: "openai-codex" });
+  expect(stored).toHaveLength(1);
+  expect(stored[0]?.refreshToken).toBe("RT");
+  expect(scrubCalls).toBe(1);
+});
+
+test("heal mode rejects an api-key export before storing", async () => {
+  let puts = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      Response.json({ provider: "openrouter", kind: "api_key", key: "sk" }),
+    ),
+  );
+  const result = await captureRuntimeCredential({
+    endpoint: { baseUrl: "http://runtime", token: "runtime-token" },
+    credentials: {
+      get: async () => null,
+      put: async () => {
+        puts++;
+      },
+      remove: async () => {},
+      removeIfAccess: async () => false,
+    },
+    workspaceId: "workspace",
+    provider: "openrouter",
+    requireRefresh: true,
+  });
+  expect(result.ok).toBe(false);
+  expect(puts).toBe(0);
+});

--- a/packages/host/src/channel/capture-credential.ts
+++ b/packages/host/src/channel/capture-credential.ts
@@ -1,0 +1,84 @@
+import type { CaptureResult, CredentialStore, RuntimeEndpoint } from "../ports";
+import { scrubRuntimeRefreshToken } from "./scrub-refresh";
+
+type ExportedCredential = {
+  provider?: string;
+  kind?: "oauth" | "api_key";
+  access?: string;
+  refresh?: string;
+  expires?: number;
+  key?: string;
+  accountId?: string;
+  enterpriseUrl?: string;
+};
+
+/** Store a full runtime credential centrally, then remove its refresh token. */
+export async function captureRuntimeCredential(args: {
+  endpoint: RuntimeEndpoint;
+  credentials: CredentialStore;
+  workspaceId: string;
+  provider?: string;
+  requireRefresh?: boolean;
+}): Promise<CaptureResult> {
+  const { endpoint, credentials, workspaceId, provider, requireRefresh } = args;
+  const query = provider ? `?provider=${encodeURIComponent(provider)}` : "";
+  const exported = await fetch(`${endpoint.baseUrl}/auth/export${query}`, {
+    headers: { Authorization: `Bearer ${endpoint.token}` },
+  });
+  if (!exported.ok) {
+    return {
+      ok: false,
+      status: 502,
+      error: "could not read agent credential",
+      detail: await exported.text().catch(() => ""),
+    };
+  }
+  const credential = (await exported.json()) as ExportedCredential;
+  if (credential.kind === "api_key") {
+    if (requireRefresh)
+      return { ok: false, status: 400, error: "agent is not connected yet" };
+    if (!credential.provider || !credential.key)
+      return { ok: false, status: 400, error: "agent is not connected yet" };
+    await credentials.put({
+      workspaceId,
+      provider: credential.provider,
+      kind: "api_key",
+      accessToken: credential.key,
+      refreshToken: "",
+      expiresAt: Number.MAX_SAFE_INTEGER,
+    });
+    return { ok: true, provider: credential.provider };
+  }
+  if (
+    !credential.provider ||
+    !credential.access ||
+    !credential.refresh ||
+    typeof credential.expires !== "number"
+  ) {
+    return { ok: false, status: 400, error: "agent is not connected yet" };
+  }
+  await credentials.put({
+    workspaceId,
+    provider: credential.provider,
+    kind: "oauth",
+    accessToken: credential.access,
+    refreshToken: credential.refresh,
+    accountId: credential.accountId,
+    expiresAt: credential.expires,
+    enterpriseUrl: credential.enterpriseUrl,
+  });
+  const scrub = await scrubRuntimeRefreshToken(
+    `${endpoint.baseUrl}/auth/scrub-refresh`,
+    endpoint.token,
+  );
+  if (!scrub.ok) {
+    return {
+      ok: false,
+      status: 502,
+      error:
+        "credential stored, but the agent sandbox could not be scrubbed of the refresh token — reconnect to retry",
+      detail: scrub.detail,
+    };
+  }
+  return { ok: true, provider: credential.provider };
+}

--- a/packages/host/src/channel/contract.test.ts
+++ b/packages/host/src/channel/contract.test.ts
@@ -194,6 +194,8 @@ let proxyCustomEndpointBody: unknown = null;
 let proxyClaudeOAuthBody: unknown = null;
 /** When set, the fake runtime rejects /auth/:provider/api-key with this reply. */
 let proxyApiKeyRejection: { status: number; body: unknown } | null = null;
+let proxyScrubFailuresRemaining = 0;
+let proxyScrubCalls = 0;
 
 beforeAll(async () => {
   proxyRuntime = createServer((req, res) => {
@@ -242,7 +244,14 @@ beforeAll(async () => {
       });
       return;
     }
-    if (path === "/auth/scrub-refresh") return reply(200, { ok: true });
+    if (path === "/auth/scrub-refresh") {
+      proxyScrubCalls += 1;
+      if (proxyScrubFailuresRemaining > 0) {
+        proxyScrubFailuresRemaining -= 1;
+        return reply(503, { error: "scrub unavailable" });
+      }
+      return reply(200, { ok: true });
+    }
     // API-key connect pushes the pasted key into the standing runtime.
     if (path.match(/^\/auth\/[^/]+\/api-key$/)) {
       return proxyApiKeyRejection
@@ -266,6 +275,8 @@ afterAll(() => proxyRuntime.close());
 function makeProxyFixture(): ChannelFixture {
   proxyConnected = false; // each fixture starts disconnected
   proxyApiKeyRejection = null;
+  proxyScrubFailuresRemaining = 0;
+  proxyScrubCalls = 0;
   const credentials = new MemoryCredentialStore();
   const launcher = new FakeLauncher({ baseUrl: proxyRuntimeUrl, token: "sbx" });
   const proxy: RuntimeProxy = { forward };
@@ -358,6 +369,36 @@ function makeTurnFixture(): ChannelFixture {
 
 runRuntimeChannelContract("ProxyChannel", makeProxyFixture);
 runRuntimeChannelContract("TurnChannel", makeTurnFixture);
+
+describe("captureCredential scrub coupling (ProxyChannel)", () => {
+  test("retries scrub and succeeds only after the runtime is scrubbed", async () => {
+    const { channel, credentials } = makeProxyFixture();
+    proxyConnected = true;
+    proxyScrubFailuresRemaining = 2;
+
+    const result = await channel.captureCredential(ctx, "openai-codex");
+
+    expect(result).toEqual({ ok: true, provider: "openai-codex" });
+    expect(proxyScrubCalls).toBe(3);
+    expect(await credentials.get(ws.id, "openai-codex")).not.toBeNull();
+  });
+
+  test("reports capture failure when refresh scrubbing persistently fails", async () => {
+    const { channel } = makeProxyFixture();
+    proxyConnected = true;
+    proxyScrubFailuresRemaining = 3;
+
+    const result = await channel.captureCredential(ctx, "openai-codex");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(502);
+      expect(result.error).toContain("could not be scrubbed");
+      expect(result.detail).toContain("scrub unavailable");
+    }
+    expect(proxyScrubCalls).toBe(3);
+  });
+});
 
 // The runtime's live key verification can REFUSE a pasted key; the typed
 // `reason` on its 401 body must survive the proxy hop so the route (and from

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -12,6 +12,7 @@ import {
   type TurnPin,
 } from "../ports";
 import { MAX_JSON_BYTES, readBody } from "../routes/read-body";
+import { captureRuntimeCredential } from "./capture-credential";
 import { errorCodeFrom, TurnFireError } from "./fire-error";
 
 /**
@@ -293,81 +294,12 @@ export class ProxyChannel implements RuntimeChannel {
     ctx: ChannelCtx,
     provider?: string,
   ): Promise<CaptureResult> {
-    const endpoint = await this.opts.launcher.ensureAwake(ctx.agent);
-    const q = provider ? `?provider=${encodeURIComponent(provider)}` : "";
-    const exp = await fetch(`${endpoint.baseUrl}/auth/export${q}`, {
-      headers: { Authorization: `Bearer ${endpoint.token}` },
-    });
-    if (!exp.ok) {
-      return {
-        ok: false,
-        status: 502,
-        error: "could not read agent credential",
-        detail: await exp.text().catch(() => ""),
-      };
-    }
-    const c = (await exp.json()) as {
-      provider?: string;
-      kind?: "oauth" | "api_key";
-      access?: string;
-      refresh?: string;
-      expires?: number;
-      key?: string;
-      accountId?: string;
-      enterpriseUrl?: string;
-    };
-
-    // API-key provider: store the key as a non-refreshing, non-expiring
-    // credential. Nothing to scrub (no refresh token ever sat in the sandbox).
-    if (c.kind === "api_key") {
-      if (!c.provider || !c.key) {
-        return { ok: false, status: 400, error: "agent is not connected yet" };
-      }
-      await this.opts.credentials.put({
-        workspaceId: ctx.agent.workspaceId,
-        provider: c.provider,
-        kind: "api_key",
-        accessToken: c.key,
-        refreshToken: "",
-        expiresAt: Number.MAX_SAFE_INTEGER,
-      });
-      return { ok: true, provider: c.provider };
-    }
-
-    if (
-      !c.provider ||
-      !c.access ||
-      !c.refresh ||
-      typeof c.expires !== "number"
-    ) {
-      return { ok: false, status: 400, error: "agent is not connected yet" };
-    }
-    await this.opts.credentials.put({
+    return captureRuntimeCredential({
+      endpoint: await this.opts.launcher.ensureAwake(ctx.agent),
+      credentials: this.opts.credentials,
       workspaceId: ctx.agent.workspaceId,
-      provider: c.provider,
-      kind: "oauth",
-      accessToken: c.access,
-      refreshToken: c.refresh,
-      accountId: c.accountId,
-      expiresAt: c.expires,
-      // Copilot Enterprise domain, so the central refresh targets the company's
-      // GitHub. Absent for every other OAuth provider (and individual Copilot).
-      enterpriseUrl: c.enterpriseUrl,
+      provider,
     });
-    const scrub = await fetch(`${endpoint.baseUrl}/auth/scrub-refresh`, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${endpoint.token}` },
-    });
-    if (!scrub.ok) {
-      return {
-        ok: false,
-        status: 502,
-        error:
-          "credential stored, but the agent sandbox could not be scrubbed of the refresh token — reconnect to retry",
-        detail: await scrub.text().catch(() => ""),
-      };
-    }
-    return { ok: true, provider: c.provider };
   }
 
   /**

--- a/packages/host/src/channel/scrub-refresh.test.ts
+++ b/packages/host/src/channel/scrub-refresh.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { scrubRuntimeRefreshToken } from "./scrub-refresh";
+
+afterEach(() => vi.unstubAllGlobals());
+
+test("retries failed scrubs and succeeds on the third attempt", async () => {
+  const fetch = vi
+    .fn<typeof globalThis.fetch>()
+    .mockResolvedValueOnce(new Response("unavailable", { status: 503 }))
+    .mockResolvedValueOnce(new Response("unavailable", { status: 503 }))
+    .mockResolvedValueOnce(new Response(null, { status: 200 }));
+  vi.stubGlobal("fetch", fetch);
+
+  await expect(
+    scrubRuntimeRefreshToken("https://runtime.test/auth/scrub-refresh", "sbx"),
+  ).resolves.toEqual({ ok: true });
+  expect(fetch).toHaveBeenCalledTimes(3);
+});
+
+test("returns the final detail after persistent scrub failure", async () => {
+  const fetch = vi
+    .fn<typeof globalThis.fetch>()
+    .mockImplementation(
+      async () => new Response("still unsafe", { status: 503 }),
+    );
+  vi.stubGlobal("fetch", fetch);
+
+  await expect(
+    scrubRuntimeRefreshToken("https://runtime.test/auth/scrub-refresh", "sbx"),
+  ).resolves.toEqual({ ok: false, detail: "still unsafe" });
+  expect(fetch).toHaveBeenCalledTimes(3);
+});

--- a/packages/host/src/channel/scrub-refresh.ts
+++ b/packages/host/src/channel/scrub-refresh.ts
@@ -1,0 +1,26 @@
+const SCRUB_ATTEMPTS = 3;
+const SCRUB_RETRY_DELAY_MS = 100;
+
+export async function scrubRuntimeRefreshToken(
+  url: string,
+  token: string,
+): Promise<{ ok: true } | { ok: false; detail: string }> {
+  let detail = "";
+  for (let attempt = 1; attempt <= SCRUB_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (response.ok) return { ok: true };
+      detail = await response.text().catch(() => "");
+    } catch (err) {
+      detail = err instanceof Error ? err.message : String(err);
+    }
+    if (attempt < SCRUB_ATTEMPTS)
+      await new Promise((resolve) =>
+        setTimeout(resolve, SCRUB_RETRY_DELAY_MS * attempt),
+      );
+  }
+  return { ok: false, detail };
+}

--- a/packages/host/src/credentials/remote-store.test.ts
+++ b/packages/host/src/credentials/remote-store.test.ts
@@ -252,6 +252,15 @@ test("a 404 without the gateway error body is a transport error, not a logout", 
   expect(calls).toHaveLength(2);
 });
 
+test("a gateway dead-credential 502 is classified for serve recovery", async () => {
+  const { fetchImpl } = fakeFetch(() =>
+    json({ error: "credential refresh rejected: session ended" }, 502),
+  );
+  await expect(store(fetchImpl).get("ws_1", "openai-codex")).rejects.toThrow(
+    "reported a dead credential",
+  );
+});
+
 test("remove treats the gateway's not-connected 404 as already signed out and clears the fallback", async () => {
   let fallbackCred: WorkspaceCredential | null = {
     workspaceId: "ws_1",

--- a/packages/host/src/credentials/remote-store.ts
+++ b/packages/host/src/credentials/remote-store.ts
@@ -22,6 +22,9 @@ export interface RemoteCredentialStoreOptions {
   fetchImpl?: typeof fetch;
 }
 
+/** The gateway positively identified the stored credential as unusable. */
+export class RemoteCredentialDeadError extends Error {}
+
 /**
  * Managed-pod credential store: the pod never owns refresh-token rotation. The
  * gateway is the single refresher for org credentials (OpenAI refresh tokens
@@ -158,6 +161,20 @@ export class RemoteCredentialStore implements CredentialStore {
       headers: this.authHeaders(),
     });
     if (await isNotConnected404(res)) return null;
+    if (res.status === 502) {
+      const body = await res
+        .clone()
+        .text()
+        .catch(() => "");
+      if (
+        /refresh|credential.*(dead|expired|invalid|reject)|session.*ended/i.test(
+          body,
+        )
+      )
+        throw new RemoteCredentialDeadError(
+          `credential gateway GET ${provider} reported a dead credential`,
+        );
+    }
     if (res.status !== 200)
       throw await this.errorFromResponse(res, "GET", provider);
 

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -9,6 +9,7 @@ import type {
 } from "@houston/runtime-client/object-sync";
 import { SingleUserVerifier } from "../auth/verify";
 import { LOCAL_CAPABILITIES } from "../capabilities";
+import { captureRuntimeCredential } from "../channel/capture-credential";
 import { ProxyChannel } from "../channel/proxy";
 import { FileCredentialStore } from "../credentials/file-store";
 import { RemoteSharedEndpointStore } from "../credentials/remote-shared-endpoint-store";
@@ -34,6 +35,7 @@ import { migrateChatHistory } from "../migrate/chat-history";
 import { LocalPaths } from "../paths";
 import type { ChannelCtx } from "../ports";
 import { forward } from "../proxy/route";
+import { CredentialServeHealer } from "../routes/credential-healer";
 import { ChannelRoutineFirer } from "../schedule/firer";
 import { Scheduler } from "../schedule/scheduler";
 import { type ControlPlaneDeps, createControlPlaneServer } from "../server";
@@ -342,6 +344,20 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     forwardActingHeader: opts.gatewayFronted ?? false,
     beforeTurn: sharedMirror ? () => sharedMirror.beforeTurn() : undefined,
   });
+  const credentialHealer = opts.credentials
+    ? new CredentialServeHealer(async ({ workspaceId, agentId, provider }) => {
+        const agent = await store.getAgent(agentId);
+        if (!agent || agent.workspaceId !== workspaceId) return false;
+        const result = await captureRuntimeCredential({
+          endpoint: await launcher.ensureAwake(agent),
+          credentials,
+          workspaceId,
+          provider,
+          requireRefresh: true,
+        });
+        return result.ok;
+      })
+    : undefined;
 
   // Integrations (platform model): the desktop holds NO provider key — the
   // gateway adapter forwards every call to Houston's cloud host with the user's
@@ -480,6 +496,7 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     verifier: new SingleUserVerifier({ token: opts.token, userId: LOCAL_USER }),
     store,
     credentials,
+    credentialHealer,
     sharedEndpoints,
     vault,
     vfs,

--- a/packages/host/src/routes/agent-data-activities-race.test.ts
+++ b/packages/host/src/routes/agent-data-activities-race.test.ts
@@ -115,3 +115,23 @@ test("a concurrent patch never erases a concurrent create", async () => {
   expect(items.map((i) => i.id).sort()).toEqual(["id-a", "id-b"]);
   expect(items.find((i) => i.id === "id-a")?.status).toBe("done");
 });
+
+test("activity PATCH validates and deletes null provider/model pins", async () => {
+  const store = slowStore();
+  await post(store, {
+    id: "id-pinned",
+    title: "Pinned",
+    provider: "anthropic",
+    model: "sonnet",
+  });
+  const cleared = await patch(store, "id-pinned", {
+    provider: null,
+    model: null,
+  });
+  expect(cleared.status).toBe(200);
+  expect(storedItems(store)[0]).not.toHaveProperty("provider");
+  expect(storedItems(store)[0]).not.toHaveProperty("model");
+
+  const invalid = await patch(store, "id-pinned", { provider: 42 });
+  expect(invalid.status).toBe(400);
+});

--- a/packages/host/src/routes/agent-data-activities.ts
+++ b/packages/host/src/routes/agent-data-activities.ts
@@ -13,6 +13,7 @@ import type {
   HoustonEvent,
   NewActivity,
 } from "@houston/protocol";
+import { activityUpdateSchema } from "@houston/protocol";
 import { withDocLock } from "./doc-lock";
 import { json, readJson } from "./http";
 
@@ -78,7 +79,12 @@ export async function handleActivitiesData(
   }
 
   if (method === "PATCH" && itemId) {
-    const update = await readJson(req);
+    const parsed = activityUpdateSchema.safeParse(await readJson(req));
+    if (!parsed.success) {
+      json(res, 400, { error: "invalid activity update" });
+      return;
+    }
+    const update = parsed.data;
     const next = await locked(async () => {
       const { items } = await loadActivities(store, root);
       const current = items.find((a) => a.id === itemId);

--- a/packages/host/src/routes/credential-healer.ts
+++ b/packages/host/src/routes/credential-healer.ts
@@ -1,0 +1,48 @@
+const HEAL_COOLDOWN_MS = 5 * 60_000;
+
+export type CredentialHeal = (args: {
+  workspaceId: string;
+  agentId: string;
+  provider: string;
+}) => Promise<boolean>;
+
+/** Coalesces serve-miss recovery and limits each provider to one attempt/5m. */
+export class CredentialServeHealer {
+  private readonly inFlight = new Map<string, Promise<boolean>>();
+  private readonly attemptedAt = new Map<string, number>();
+
+  constructor(
+    private readonly heal: CredentialHeal,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  attempt(args: Parameters<CredentialHeal>[0]): Promise<boolean> {
+    const key = `${args.workspaceId}:${args.provider}`;
+    const existing = this.inFlight.get(key);
+    if (existing) return existing;
+    if (this.now() - (this.attemptedAt.get(key) ?? 0) < HEAL_COOLDOWN_MS)
+      return Promise.resolve(false);
+
+    this.attemptedAt.set(key, this.now());
+    console.info(
+      `[sandbox/credential] heal attempted provider=${args.provider} agent=${args.agentId}`,
+    );
+    const attempt = this.heal(args)
+      .then((healed) => {
+        console.info(
+          `[sandbox/credential] ${healed ? "healed" : "heal failed"} provider=${args.provider} agent=${args.agentId}`,
+        );
+        return healed;
+      })
+      .catch((error) => {
+        console.error(
+          `[sandbox/credential] heal failed provider=${args.provider} agent=${args.agentId}:`,
+          error instanceof Error ? error.message : String(error),
+        );
+        return false;
+      })
+      .finally(() => this.inFlight.delete(key));
+    this.inFlight.set(key, attempt);
+    return attempt;
+  }
+}

--- a/packages/host/src/routes/credential.test.ts
+++ b/packages/host/src/routes/credential.test.ts
@@ -1,8 +1,10 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { expect, test } from "vitest";
+import { RemoteCredentialDeadError } from "../credentials/remote-store";
 import { MemoryCredentialStore } from "../credentials/store";
-import type { CredentialVault } from "../ports";
+import type { CredentialStore, CredentialVault } from "../ports";
 import { handleSandboxCredential } from "./credential";
+import { CredentialServeHealer } from "./credential-healer";
 
 /**
  * The sandbox credential endpoint must keep serving a turn even when the stored
@@ -65,13 +67,21 @@ function mockRes(): {
 }
 
 const call = (
-  credentials: MemoryCredentialStore,
+  credentials: CredentialStore,
   provider: string,
   out: ReturnType<typeof mockRes>,
-  opts: { gatewayFronted?: boolean } = {},
+  opts: {
+    gatewayFronted?: boolean;
+    credentialHealer?: CredentialServeHealer;
+  } = {},
 ) =>
   handleSandboxCredential(
-    { vault, credentials, gatewayFronted: opts.gatewayFronted },
+    {
+      vault,
+      credentials,
+      gatewayFronted: opts.gatewayFronted,
+      credentialHealer: opts.credentialHealer,
+    },
     "GET",
     "/sandbox/credential",
     new URL(`http://x/sandbox/credential?provider=${provider}`),
@@ -81,6 +91,108 @@ const call = (
 
 /** A far-future expiry: not "expiring" for any test run. */
 const FRESH_EXPIRES = Date.now() + 60 * 60 * 1000;
+
+test("serve miss heals once and serves the fresh central credential", async () => {
+  const credentials = new MemoryCredentialStore();
+  let heals = 0;
+  const credentialHealer = new CredentialServeHealer(async () => {
+    heals++;
+    await credentials.put({
+      workspaceId: "w1",
+      provider: "openai-codex",
+      accessToken: "AT-healed",
+      refreshToken: "",
+      expiresAt: FRESH_EXPIRES,
+    });
+    return true;
+  });
+  const first = mockRes();
+  expect(
+    await call(credentials, "openai-codex", first, { credentialHealer }),
+  ).toBe(true);
+  expect(first.out.body.access).toBe("AT-healed");
+  expect(heals).toBe(1);
+
+  await credentials.remove("w1", "openai-codex");
+  const second = mockRes();
+  await call(credentials, "openai-codex", second, { credentialHealer });
+  expect(second.out.status).toBe(404);
+  expect(heals).toBe(1);
+});
+
+test("concurrent dead serves single-flight their heal", async () => {
+  const credentials = new MemoryCredentialStore();
+  let heals = 0;
+  const credentialHealer = new CredentialServeHealer(async () => {
+    heals++;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await credentials.put({
+      workspaceId: "w1",
+      provider: "openai-codex",
+      accessToken: "AT-one-flight",
+      refreshToken: "",
+      expiresAt: FRESH_EXPIRES,
+    });
+    return true;
+  });
+  const a = mockRes();
+  const b = mockRes();
+  await Promise.all([
+    call(credentials, "openai-codex", a, { credentialHealer }),
+    call(credentials, "openai-codex", b, { credentialHealer }),
+  ]);
+  expect(heals).toBe(1);
+  expect(a.out.body.access).toBe("AT-one-flight");
+  expect(b.out.body.access).toBe("AT-one-flight");
+});
+
+test("transport errors never trigger credential healing", async () => {
+  let heals = 0;
+  const credentials: CredentialStore = {
+    get: async () => {
+      throw new Error("network unavailable");
+    },
+    put: async () => {},
+    remove: async () => {},
+    removeIfAccess: async () => false,
+  };
+  const credentialHealer = new CredentialServeHealer(async () => {
+    heals++;
+    return true;
+  });
+  await expect(
+    call(credentials, "openai-codex", mockRes(), { credentialHealer }),
+  ).rejects.toThrow("network unavailable");
+  expect(heals).toBe(0);
+});
+
+test("a gateway-classified dead credential triggers healing", async () => {
+  const fresh = new MemoryCredentialStore();
+  let reads = 0;
+  const credentials: CredentialStore = {
+    get: async (workspaceId, provider) => {
+      reads++;
+      if (reads === 1) throw new RemoteCredentialDeadError("dead");
+      return fresh.get(workspaceId, provider);
+    },
+    put: (credential) => fresh.put(credential),
+    remove: (workspaceId, provider) => fresh.remove(workspaceId, provider),
+    removeIfAccess: async () => false,
+  };
+  const credentialHealer = new CredentialServeHealer(async () => {
+    await credentials.put({
+      workspaceId: "w1",
+      provider: "openai-codex",
+      accessToken: "AT-recaptured",
+      refreshToken: "",
+      expiresAt: FRESH_EXPIRES,
+    });
+    return true;
+  });
+  const result = mockRes();
+  await call(credentials, "openai-codex", result, { credentialHealer });
+  expect(result.out.body.access).toBe("AT-recaptured");
+});
 
 test("serves the existing token when refresh has no config (no 500)", async () => {
   const credentials = new MemoryCredentialStore();

--- a/packages/host/src/routes/credential.ts
+++ b/packages/host/src/routes/credential.ts
@@ -4,11 +4,13 @@ import {
   RefreshRejectedError,
   refreshCredential,
 } from "../credentials/refresh";
+import { RemoteCredentialDeadError } from "../credentials/remote-store";
 import {
   type CredentialStore,
   type CredentialVault,
   isApiKeyCredential,
 } from "../ports";
+import type { CredentialServeHealer } from "./credential-healer";
 import { bearer, json } from "./http";
 
 /**
@@ -24,6 +26,7 @@ export async function handleSandboxCredential(
     vault: CredentialVault;
     credentials: CredentialStore;
     gatewayFronted?: boolean;
+    credentialHealer?: CredentialServeHealer;
   },
   method: string,
   path: string,
@@ -58,8 +61,24 @@ export async function handleSandboxCredential(
     );
     return true;
   }
-  let cred = await deps.credentials.get(claim.workspaceId, provider);
+  let deadError: RemoteCredentialDeadError | undefined;
+  let cred = null;
+  try {
+    cred = await deps.credentials.get(claim.workspaceId, provider);
+  } catch (error) {
+    if (!(error instanceof RemoteCredentialDeadError)) throw error;
+    deadError = error;
+  }
+  if (!cred && deps.credentialHealer) {
+    const healed = await deps.credentialHealer.attempt({
+      workspaceId: claim.workspaceId,
+      agentId: claim.agentId,
+      provider,
+    });
+    if (healed) cred = await deps.credentials.get(claim.workspaceId, provider);
+  }
   if (!cred) {
+    if (deadError) throw deadError;
     // The marker makes this 404 the store's own authoritative "not connected"
     // answer. The runtime only drops served credentials on marked 404s — a bare
     // 404 (old host, wrong control-plane URL) must never read as a logout.

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -38,6 +38,7 @@ import {
 import { handleAgents, podActivityStatus } from "./routes/agents";
 import { handleCatalog } from "./routes/catalog";
 import { handleSandboxCredential } from "./routes/credential";
+import type { CredentialServeHealer } from "./routes/credential-healer";
 import { handleSandboxCredentialRevoked } from "./routes/credential-revoked";
 import {
   type CustomIntegrationDeps,
@@ -97,6 +98,8 @@ export interface ControlPlaneDeps {
   sharedEndpoints?: SharedEndpointStore;
   /** Validates per-sandbox HMAC tokens (the sandbox-facing credential endpoint). */
   vault: CredentialVault;
+  /** Managed-pod recovery for an absent/dead central credential row. */
+  credentialHealer?: CredentialServeHealer;
   /**
    * RuntimeChannel per workspace hosting model (gke → ProxyChannel, cloudrun →
    * TurnChannel; the local profile adds its own in P4). A workspace whose

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -29,10 +29,15 @@
   ],
   "scripts": {
     "build": "tsgo -p tsconfig.json",
+    "test": "vitest run",
     "typecheck": "tsgo -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@typescript/native-preview": "7.0.0-dev.20260607.1",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "3.2.6"
   }
 }

--- a/packages/protocol/src/domain/activity.test.ts
+++ b/packages/protocol/src/domain/activity.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+import { activityUpdateSchema } from "./activity";
+
+describe("activityUpdateSchema", () => {
+  test("accepts null provider/model as explicit clears", () => {
+    expect(activityUpdateSchema.parse({ provider: null, model: null })).toEqual(
+      { provider: null, model: null },
+    );
+  });
+
+  test("rejects invalid pin values and unknown fields", () => {
+    expect(activityUpdateSchema.safeParse({ provider: 3 }).success).toBe(false);
+    expect(activityUpdateSchema.safeParse({ surprise: true }).success).toBe(
+      false,
+    );
+  });
+});

--- a/packages/protocol/src/domain/activity.ts
+++ b/packages/protocol/src/domain/activity.ts
@@ -2,6 +2,7 @@
 // .houston schemas (ui/agent-schemas) — files-first: the wire mirrors disk.
 // `claude_session_id` is a legacy field name baked into user data; it stays.
 
+import { z } from "zod";
 import type { PendingInteraction } from "./interaction";
 
 /** A human who started or collaborated on a mission. Server-stamped from the
@@ -66,6 +67,24 @@ export interface Activity {
   mentioned?: ActivityMention[];
 }
 
+export const activityUpdateSchema = z
+  .object({
+    title: z.string().optional(),
+    description: z.string().optional(),
+    status: z.string().optional(),
+    claude_session_id: z.string().nullable().optional(),
+    session_key: z.string().optional(),
+    agent: z.string().optional(),
+    worktree_path: z.string().nullable().optional(),
+    routine_id: z.string().optional(),
+    routine_run_id: z.string().optional(),
+    skill_slug: z.string().optional(),
+    provider: z.string().nullable().optional(),
+    model: z.string().nullable().optional(),
+    pending_interaction: z.custom<PendingInteraction>().nullable().optional(),
+  })
+  .strict();
+
 export interface ActivityUpdate {
   title?: string;
   description?: string;
@@ -77,8 +96,8 @@ export interface ActivityUpdate {
   routine_id?: string;
   routine_run_id?: string;
   skill_slug?: string;
-  provider?: string;
-  model?: string;
+  provider?: string | null;
+  model?: string | null;
   /** Set to record a new pending interaction; `null` clears it explicitly. */
   pending_interaction?: PendingInteraction | null;
 }

--- a/packages/runtime/src/ai/providers.ts
+++ b/packages/runtime/src/ai/providers.ts
@@ -222,7 +222,7 @@ export function modelFor(provider: ProviderId): string {
  * is "connected" iff it has a STORED credential (`providerConnected`, the HOU-557
  * stored-only rule — env vars / overrides don't count and aren't logout-clearable).
  */
-function providerConfigured(id: ProviderId): boolean {
+export function providerConfigured(id: ProviderId): boolean {
   if (id === OPENAI_COMPATIBLE) return customEndpointConfigured();
   return providerConnected(authStorage, id);
 }
@@ -463,7 +463,7 @@ export function safeGetModel(
  * platform-key OpenAI as its own provider, THIS alias and the frontend rename
  * must be removed together.
  */
-function canonicalPinProvider(id: string): string {
+export function canonicalPinProvider(id: string): string {
   return id === "openai" ? "openai-codex" : id;
 }
 

--- a/packages/runtime/src/auth/auth-file.test.ts
+++ b/packages/runtime/src/auth/auth-file.test.ts
@@ -2,7 +2,11 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "vitest";
-import { applyServedCredential, readAuthFile } from "./auth-file";
+import {
+  applyServedCredential,
+  readAuthFile,
+  writeAuthFile,
+} from "./auth-file";
 
 /**
  * The connect-once serve path writes the host's served credential into the
@@ -52,4 +56,26 @@ test("applyServedCredential omits enterpriseUrl for individual Copilot", () => {
   if (cred?.type === "oauth") {
     expect(cred.enterpriseUrl).toBeUndefined();
   }
+});
+
+test("applyServedCredential does not clobber a refresh-bearing login", () => {
+  const path = scratch();
+  const pending = {
+    type: "oauth" as const,
+    access: "fresh-access",
+    refresh: "fresh-refresh",
+    expires: Date.now() + 600_000,
+  };
+  writeAuthFile(path, { "openai-codex": pending });
+
+  expect(
+    applyServedCredential(path, {
+      provider: "openai-codex",
+      access: "old-central-access",
+      expires: Date.now() + 300_000,
+      accountId: null,
+    }),
+  ).toBe(false);
+  expect(readAuthFile(path)["openai-codex"]).toEqual(pending);
+  rmSync(path, { force: true });
 });

--- a/packages/runtime/src/auth/auth-file.ts
+++ b/packages/runtime/src/auth/auth-file.ts
@@ -76,7 +76,19 @@ export function writeAuthFile(
  * with an empty refresh field (Gate #2); an API key is written as pi's
  * `api_key` variant (no refresh, no expiry — there is nothing to scrub).
  */
-export function applyServedCredential(path: string, c: ServedCredential): void {
+export function hasRefreshToken(cred: PiCred | undefined): boolean {
+  return cred?.type === "oauth" && cred.refresh.length > 0;
+}
+
+export function applyServedCredential(
+  path: string,
+  c: ServedCredential,
+): boolean {
+  const merged = readAuthFile(path);
+  // pi's device-code login has completed locally, but the host has not captured
+  // and scrubbed it yet. Serving the old central row here would destroy the only
+  // refresh token before /auth/export can hand it to the gateway.
+  if (hasRefreshToken(merged[c.provider])) return false;
   const entry: PiCred =
     c.kind === "api_key"
       ? { type: "api_key", key: c.access }
@@ -91,9 +103,9 @@ export function applyServedCredential(path: string, c: ServedCredential): void {
           // not a secret, and refresh="" stays scrubbed).
           ...(c.enterpriseUrl ? { enterpriseUrl: c.enterpriseUrl } : {}),
         };
-  const merged = readAuthFile(path);
   merged[c.provider] = entry;
   writeAuthFile(path, merged);
+  return true;
 }
 
 /**
@@ -157,7 +169,7 @@ export function removeServedCredentialAt(
   const cred = auth[provider];
   if (
     !cred ||
-    (cred.type === "oauth" && cred.refresh) ||
+    hasRefreshToken(cred) ||
     (cred.type !== "oauth" && cred.type !== "api_key")
   ) {
     return false;

--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -373,7 +373,7 @@ test("a served credential is written WITHOUT a refresh token", () => {
   expect(JSON.stringify(auth)).not.toContain("RT"); // nothing refresh-like anywhere
 });
 
-test("a served credential overwrites a refresh-bearing entry from device-code login", () => {
+test("a served credential preserves a refresh-bearing entry mid-capture", () => {
   const path = freshAuthPath();
   // What pi's own login leaves behind:
   writeFileSync(
@@ -387,12 +387,44 @@ test("a served credential overwrites a refresh-bearing entry from device-code lo
       },
     }),
   );
-  applyServedCredential(path, {
-    provider: "openai-codex",
-    access: "AT-new",
-    expires: 2,
-    accountId: null,
+  expect(
+    applyServedCredential(path, {
+      provider: "openai-codex",
+      access: "AT-new",
+      expires: 2,
+      accountId: null,
+    }),
+  ).toBe(false);
+  const auth = readAuth(path);
+  expect(auth["openai-codex"]).toEqual({
+    type: "oauth",
+    access: "AT-old",
+    refresh: "RT-SECRET",
+    expires: 1,
   });
+});
+
+test("a served credential replaces an existing refresh-less entry", () => {
+  const path = freshAuthPath();
+  writeFileSync(
+    path,
+    JSON.stringify({
+      "openai-codex": {
+        type: "oauth",
+        access: "AT-old",
+        refresh: "",
+        expires: 1,
+      },
+    }),
+  );
+  expect(
+    applyServedCredential(path, {
+      provider: "openai-codex",
+      access: "AT-new",
+      expires: 2,
+      accountId: null,
+    }),
+  ).toBe(true);
   const auth = readAuth(path);
   const codex = auth["openai-codex"];
   if (!codex) throw new Error("expected openai-codex entry in auth file");

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -23,9 +23,11 @@ import { authStorage } from "./storage";
  * not a permanent account takeover.
  *
  * The one exception is the device-code connect flow: pi's own login writes the
- * full credential (access + refresh) locally. The control plane captures it
- * into the central store immediately afterwards and then calls
- * POST /auth/scrub-refresh, which rewrites every entry with refresh="".
+ * full credential (access + refresh) locally. Serve sync must not overwrite that
+ * refresh-bearing entry with an older central access token while capture is in
+ * progress. The control plane captures it into the central store immediately
+ * afterwards and then calls POST /auth/scrub-refresh, which rewrites every entry
+ * with refresh=""; normal serving resumes after that scrub.
  *
  * Best-effort on sync: a transient control-plane blip leaves the existing
  * (still-valid) auth.json in place; a missing connection surfaces downstream as
@@ -164,9 +166,9 @@ async function runServedSync(): Promise<string[]> {
   for (const probe of probes) {
     if (probe.state !== "error") noteServeProbeOk(probe.id);
     if (probe.state === "served") {
-      applyServedCredential(authPathFor(), probe.cred);
-      applied.push(probe.id);
-      if (!manifest.has(probe.id)) {
+      const didApply = applyServedCredential(authPathFor(), probe.cred);
+      if (didApply) applied.push(probe.id);
+      if (didApply && !manifest.has(probe.id)) {
         manifest.add(probe.id);
         manifestDirty = true;
       }

--- a/packages/runtime/src/backends/claude/credentials-file.ts
+++ b/packages/runtime/src/backends/claude/credentials-file.ts
@@ -9,24 +9,20 @@ import { claudeCredentialsFile } from "./paths";
  * Materialize a pushed Claude subscription OAuth credential as the CLI's own
  * `<CLAUDE_CONFIG_DIR>/.credentials.json` — the exact file the Claude Agent SDK
  * and `claude auth status` read on Linux (the hosted pod). Written verbatim in
- * the CLI envelope (`{claudeAiOauth:{…}}`) so the SDK can self-refresh from the
- * refresh token in place.
+ * the CLI envelope (`{claudeAiOauth:{…}}`). On desktop/self-host the full
+ * credential lets the SDK self-refresh in place. A managed serve-mode pod must
+ * receive an access-only value: the gateway is the refresh family's single
+ * rotator, and materializing its refresh token here would violate trap #4 in
+ * knowledge-base/anthropic-credentials.md.
  *
- * Role after the connect-once serve landed: the file is the pod's IMMEDIATE
- * connected signal at push time and the FALLBACK credential when no served
- * token is available (control plane briefly unreachable, or it can't refresh
- * anthropic yet). Steady-state on a managed pod, the per-turn served access
- * token rides `CLAUDE_CODE_OAUTH_TOKEN` and OUTRANKS this file inside the SDK
- * (see backends/claude/read-token.ts and knowledge-base/
- * anthropic-credentials.md) — which is exactly why the host must never serve
- * a stale anthropic token (routes/credential.ts guards it).
+ * On a managed pod the file is only an immediate, access-only connected signal
+ * at push time. Steady-state, the per-turn served access token rides
+ * `CLAUDE_CODE_OAUTH_TOKEN` and outranks this file inside the SDK (see
+ * backends/claude/read-token.ts). The file cannot be a refresh fallback because
+ * the gateway remains the family's only sanctioned rotator.
  *
  * Atomic (tmp + rename) at mode 0600 so a concurrent reader never sees a
- * half-written file and the token is owner-only on disk. The refresh token in
- * this file stays on the single-tenant, network-policied pod — a documented,
- * EXPLICITLY scoped departure from Gate #2 (see cloud/INTEGRATION.md); it is
- * never written into the multi-tenant per-turn Cloud Run process, which keeps
- * Anthropic off there.
+ * half-written file and the token is owner-only on disk.
  */
 export function writeClaudeOAuthCredentialFile(
   configDir: string,

--- a/packages/runtime/src/backends/pi/wire.test.ts
+++ b/packages/runtime/src/backends/pi/wire.test.ts
@@ -5,6 +5,10 @@ import type {
 } from "@earendil-works/pi-ai";
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import { expect, test } from "vitest";
+import {
+  authFailureActive,
+  resetAuthFailures,
+} from "../../auth/credential-health";
 import { createWireTranslator, normalizeUsage, toWire } from "./wire";
 
 /** A valid pi `Usage` for fixtures; `cost` is required by the type. */
@@ -170,6 +174,22 @@ test("toWire maps an errored turn_end to a typed provider_error frame", () => {
         "OpenAI API error (401): Your session has ended. Please log in again. (app_session_terminated)",
     },
   });
+});
+
+test("toWire marks raw openai auth failures against openai-codex", () => {
+  resetAuthFailures();
+  toWire(
+    turnEnd(
+      failedAssistantMessage("error", "401 Unauthorized: token expired", {
+        provider: "openai",
+        model: "gpt-5.1-codex",
+      }),
+    ),
+  );
+
+  expect(authFailureActive("openai-codex")).toBe(true);
+  expect(authFailureActive("openai")).toBe(false);
+  resetAuthFailures();
 });
 
 test("toWire surfaces a pi-internal turn error (the Copilot no-response bug) as a typed provider_error", () => {

--- a/packages/runtime/src/backends/pi/wire.ts
+++ b/packages/runtime/src/backends/pi/wire.ts
@@ -7,6 +7,7 @@ import {
 } from "@houston/runtime-client";
 import { classifyProviderError } from "../../ai/provider-error";
 import { logProviderError } from "../../ai/provider-error-log";
+import { canonicalPinProvider } from "../../ai/providers";
 import { noteAuthFailure } from "../../auth/credential-health";
 import { reportRevokedServedToken } from "../../auth/report-revoked";
 
@@ -188,7 +189,7 @@ export function toWire(e: AgentSessionEvent): WireEvent | null {
         // turn just ran on cannot authenticate, so "Connected" would be a lie
         // until it changes (auth/credential-health.ts).
         if (classified.kind === "unauthenticated") {
-          noteAuthFailure(classified.provider);
+          noteAuthFailure(canonicalPinProvider(classified.provider));
           // A REVOKED served token is invisible to the control plane (HOU-952).
           reportRevokedServedToken(classified);
         }

--- a/packages/runtime/src/session/chat-pinned-provider.test.ts
+++ b/packages/runtime/src/session/chat-pinned-provider.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+process.env.HOUSTON_DATA_DIR = mkdtempSync(
+  join(tmpdir(), "houston-chat-pinned-"),
+);
+process.env.HOUSTON_WORKSPACE_DIR = process.env.HOUSTON_DATA_DIR;
+
+const providerState = vi.hoisted(() => ({ configured: false }));
+vi.mock("../ai/providers", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../ai/providers")>();
+  return {
+    ...real,
+    providerConfigured: () => providerState.configured,
+    resolveModel: () => {
+      throw new Error("execution path reached");
+    },
+  };
+});
+
+const { config } = await import("../config");
+const { runTurn } = await import("./chat");
+const { getHistory } = await import("../store/conversations");
+
+let previousControlPlaneUrl: string;
+let previousSandboxToken: string;
+
+beforeEach(() => {
+  previousControlPlaneUrl = config.controlPlaneUrl;
+  previousSandboxToken = config.sandboxToken;
+  config.controlPlaneUrl = "https://control.test";
+  config.sandboxToken = "sandbox-token";
+  providerState.configured = false;
+});
+
+afterEach(() => {
+  config.controlPlaneUrl = previousControlPlaneUrl;
+  config.sandboxToken = previousSandboxToken;
+});
+
+test("serve mode refuses an absent pinned provider with no_credentials", async () => {
+  await runTurn("pinned-absent", "finish the task", undefined, {
+    provider: "openai",
+  });
+
+  expect(
+    getHistory("pinned-absent")?.messages.at(-1)?.providerError,
+  ).toMatchObject({
+    kind: "unauthenticated",
+    provider: "openai-codex",
+    cause: "no_credentials",
+    undelivered_prompt: "finish the task",
+  });
+});
+
+test("serve mode lets a configured pinned provider reach execution", async () => {
+  providerState.configured = true;
+
+  await runTurn("pinned-configured", "finish the task", undefined, {
+    provider: "openai",
+  });
+
+  expect(
+    getHistory("pinned-configured")?.messages.at(-1)?.providerError,
+  ).toMatchObject({
+    kind: "unknown",
+    raw_excerpt: "execution path reached",
+  });
+});
+
+test("outside serve mode preserves the disconnected pin bypass", async () => {
+  config.controlPlaneUrl = "";
+  config.sandboxToken = "";
+
+  await runTurn("pinned-local", "finish the task", undefined, {
+    provider: "openai",
+  });
+
+  expect(
+    getHistory("pinned-local")?.messages.at(-1)?.providerError,
+  ).toMatchObject({
+    kind: "unknown",
+    raw_excerpt: "execution path reached",
+  });
+});

--- a/packages/runtime/src/session/chat.ts
+++ b/packages/runtime/src/session/chat.ts
@@ -2,8 +2,14 @@ import { rmSync } from "node:fs";
 import { join } from "node:path";
 import type { TurnMode } from "@houston/protocol";
 import type { ChatMessage } from "@houston/runtime-client";
-import { activeProvider, resolveModel } from "../ai/providers";
-import { syncServedCredentialSafe } from "../auth/serve";
+import {
+  activeProvider,
+  canonicalPinProvider,
+  isProvider,
+  providerConfigured,
+  resolveModel,
+} from "../ai/providers";
+import { serveModeOn, syncServedCredentialSafe } from "../auth/serve";
 import { cleanupClaudeConversation } from "../backends/claude/cleanup";
 import { config } from "../config";
 import {
@@ -82,13 +88,43 @@ export async function runTurn(
   // Mint the turn's wire identity up front so even a turn that fails before
   // executing (the guards below) terminates under one id.
   const turnId = crypto.randomUUID();
+  const canonicalPinnedProvider = pin?.provider
+    ? canonicalPinProvider(pin.provider)
+    : undefined;
+  if (
+    serveModeOn() &&
+    canonicalPinnedProvider &&
+    isProvider(canonicalPinnedProvider) &&
+    !providerConfigured(canonicalPinnedProvider)
+  ) {
+    appendUserMessage(id, text, { turnId, displayText, mentions });
+    publish(id, {
+      type: "user",
+      data: { content: text, ts: Date.now(), nonce, mentions },
+      turnId,
+    });
+    const message = `No provider connected for ${canonicalPinnedProvider}. Connect it first.`;
+    appendAssistantMessage(id, "", {
+      providerError: {
+        kind: "unauthenticated",
+        provider: canonicalPinnedProvider,
+        cause: "no_credentials",
+        message,
+        undelivered_prompt: text,
+      },
+      turnId,
+    });
+    publish(id, { type: "error", data: { message }, turnId });
+    return;
+  }
   // The message route already synced the credential and confirmed a provider via
   // ensureProviderForTurn. Re-check here as a cheap guard for the narrow window
   // where the provider is logged out mid-turn: getConversation returns a CACHED
   // session without re-running resolveModel()'s connect guard, so without this a
   // now-credential-less turn could still reach session.prompt() and hang with no
-  // terminal event. A provider-pinned turn (a routine) skips the guard — its
-  // pin is never auth-gated; a failure surfaces as the turn's provider error.
+  // terminal event. Local provider-pinned turns retain their historical bypass.
+  // In serve mode the gate above refuses only a definitively absent canonical
+  // pinned provider, after the route's served-credential sync has completed.
   if (!pin?.provider && !activeProvider()) {
     publish(id, {
       type: "error",

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -13,7 +13,11 @@ import {
   OPENAI_COMPATIBLE,
 } from "../ai/openai-compatible";
 import { classifyProviderError } from "../ai/provider-error";
-import { activeEffort, resolveModel } from "../ai/providers";
+import {
+  activeEffort,
+  canonicalPinProvider,
+  resolveModel,
+} from "../ai/providers";
 import { recordTokenSpend } from "../ai/usage/ledger";
 import { clearAuthFailure, noteAuthFailure } from "../auth/credential-health";
 import { reportRevokedServedToken } from "../auth/report-revoked";
@@ -582,7 +586,7 @@ export async function execTurn(
     // whose refresh token was rejected raises at prompt time, before any
     // stream exists (auth/credential-health.ts).
     if (thrown.kind === "unauthenticated" && !providerError) {
-      noteAuthFailure(thrown.provider);
+      noteAuthFailure(canonicalPinProvider(thrown.provider));
       // A REVOKED served token is invisible to the control plane (HOU-952).
       reportRevokedServedToken(thrown);
     }

--- a/packages/runtime/src/transport/conversation-routes-provider-gate.test.ts
+++ b/packages/runtime/src/transport/conversation-routes-provider-gate.test.ts
@@ -1,0 +1,80 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { beforeEach, expect, test, vi } from "vitest";
+
+const chat = vi.hoisted(() => ({
+  ensuredProvider: null as string | null,
+  ensureProviderForTurn: vi.fn(async () => chat.ensuredProvider),
+  runTurn: vi.fn(async () => {}),
+}));
+vi.mock("../session/chat", () => ({
+  cancelTurn: vi.fn(),
+  disposeConversation: vi.fn(),
+  ensureProviderForTurn: chat.ensureProviderForTurn,
+  runTurn: chat.runTurn,
+  setLiveTurnMode: vi.fn(),
+}));
+
+const { handleConversationRoute } = await import("./conversation-routes");
+
+function req(body: unknown): IncomingMessage {
+  const request = Readable.from([
+    Buffer.from(JSON.stringify(body)),
+  ]) as IncomingMessage;
+  request.headers = {};
+  return request;
+}
+
+function response(): {
+  res: ServerResponse;
+  out: { status?: number; body?: unknown };
+} {
+  const out: { status?: number; body?: unknown } = {};
+  const res = {
+    writeHead(status: number) {
+      out.status = status;
+    },
+    end(body: Buffer) {
+      out.body = JSON.parse(body.toString());
+    },
+  } as unknown as ServerResponse;
+  return { res, out };
+}
+
+async function post(body: unknown) {
+  const { res, out } = response();
+  await handleConversationRoute({
+    method: "POST",
+    path: "/conversations/test/messages",
+    url: new URL("http://runtime.test/conversations/test/messages"),
+    req: req(body),
+    res,
+  });
+  return out;
+}
+
+beforeEach(() => {
+  chat.ensuredProvider = null;
+  chat.ensureProviderForTurn.mockClear();
+  chat.runTurn.mockClear();
+});
+
+test("unpinned no-provider keeps the 409 no_provider contract", async () => {
+  const out = await post({ text: "hello" });
+
+  expect(out).toEqual({
+    status: 409,
+    body: {
+      error: "No provider connected. Connect an AI provider first.",
+      code: "no_provider",
+    },
+  });
+  expect(chat.runTurn).not.toHaveBeenCalled();
+});
+
+test("a pinned turn still enters runTurn for its serve-mode credential gate", async () => {
+  const out = await post({ text: "hello", provider: "openai" });
+
+  expect(out.status).toBe(202);
+  expect(chat.runTurn).toHaveBeenCalledOnce();
+});

--- a/packages/runtime/src/transport/provider-routes-claude-oauth.test.ts
+++ b/packages/runtime/src/transport/provider-routes-claude-oauth.test.ts
@@ -24,6 +24,7 @@ import {
   claudeCredentialsFile,
   claudeLoginConfigDir,
 } from "../backends/claude/paths";
+import { config } from "../config";
 import { handleProviderRoute } from "./provider-routes";
 
 function mockRes(): {
@@ -69,18 +70,26 @@ const VALID = {
 };
 
 let prevHome: string | undefined;
+let previousControlPlaneUrl: string;
+let previousSandboxToken: string;
 
 beforeEach(() => {
   prevHome = process.env.HOUSTON_HOME;
   process.env.HOUSTON_HOME = mkdtempSync(join(tmpdir(), "claude-route-"));
+  previousControlPlaneUrl = config.controlPlaneUrl;
+  previousSandboxToken = config.sandboxToken;
+  config.controlPlaneUrl = "";
+  config.sandboxToken = "";
   refreshSpy.mockClear();
 });
 afterEach(() => {
   if (prevHome === undefined) delete process.env.HOUSTON_HOME;
   else process.env.HOUSTON_HOME = prevHome;
+  config.controlPlaneUrl = previousControlPlaneUrl;
+  config.sandboxToken = previousSandboxToken;
 });
 
-test("materializes .credentials.json under the login config dir and warms the signal", async () => {
+test("outside serve mode materializes the full credential and warms the signal", async () => {
   const { handled, out } = await post(VALID);
   expect(handled).toBe(true);
   expect(out.status).toBe(200);
@@ -90,6 +99,25 @@ test("materializes .credentials.json under the login config dir and warms the si
   expect(JSON.parse(readFileSync(path, "utf8"))).toEqual(VALID);
   // The connected signal is warmed exactly once on success.
   expect(refreshSpy).toHaveBeenCalledTimes(1);
+});
+
+test("in serve mode materializes an access-only credential", async () => {
+  config.controlPlaneUrl = "https://control.test";
+  config.sandboxToken = "sandbox-token";
+
+  const { out } = await post(VALID);
+
+  expect(out.status).toBe(200);
+  expect(
+    JSON.parse(
+      readFileSync(claudeCredentialsFile(claudeLoginConfigDir()), "utf8"),
+    ),
+  ).toEqual({
+    claudeAiOauth: {
+      ...VALID.claudeAiOauth,
+      refreshToken: "",
+    },
+  });
 });
 
 test("malformed body → 400, nothing written, signal not warmed", async () => {

--- a/packages/runtime/src/transport/provider-routes.ts
+++ b/packages/runtime/src/transport/provider-routes.ts
@@ -18,7 +18,11 @@ import {
   setCustomEndpoint,
   startLogin,
 } from "../auth/login";
-import { scrubRefreshTokens, syncServedCredentialSafe } from "../auth/serve";
+import {
+  scrubRefreshTokens,
+  serveModeOn,
+  syncServedCredentialSafe,
+} from "../auth/serve";
 import { ApiKeyVerifyError, verifyApiKey } from "../auth/verify-api-key";
 import { refreshAnthropicCredential } from "../backends/claude/credential-status";
 import { writeClaudeOAuthCredentialFile } from "../backends/claude/credentials-file";
@@ -145,11 +149,12 @@ async function handleOpenAiCompatible(ctx: RouteContext) {
 /**
  * Materialize a desktop-pushed Claude subscription OAuth credential (host→pod).
  * Writes the CLI's `<CLAUDE_CONFIG_DIR>/.credentials.json` so the Claude Agent
- * SDK + `claude auth status` read as logged-in and the SDK self-refreshes from
- * the refresh token in place. The body is the pinned CLI envelope, validated
- * STRICTLY — a malformed push is a clear 400 (the desktop falls back to paste),
- * a write failure a 500. On success the connected signal is warmed so status
- * flips immediately. The token is never logged.
+ * SDK + `claude auth status` read as logged-in. Desktop/self-host keeps the full
+ * credential so the SDK self-refreshes; serve mode strips the refresh token so
+ * the gateway remains the family's single rotator. The body is the pinned CLI
+ * envelope, validated STRICTLY — a malformed push is a clear 400 (the desktop
+ * falls back to paste), a write failure a 500. On success the connected signal
+ * is warmed so status flips immediately. The token is never logged.
  */
 async function handleClaudeOAuthCredential(ctx: RouteContext) {
   const parsed = parseClaudeOAuthEnvelope(
@@ -160,7 +165,10 @@ async function handleClaudeOAuthCredential(ctx: RouteContext) {
     return;
   }
   try {
-    writeClaudeOAuthCredentialFile(claudeLoginConfigDir(), parsed.value);
+    writeClaudeOAuthCredentialFile(
+      claudeLoginConfigDir(),
+      serveModeOn() ? { ...parsed.value, refreshToken: "" } : parsed.value,
+    );
   } catch (e) {
     json(ctx.res, 500, {
       error: `could not materialize the Claude credential: ${e instanceof Error ? e.message : String(e)}`,

--- a/packages/web/src/engine-adapter/activities.ts
+++ b/packages/web/src/engine-adapter/activities.ts
@@ -97,12 +97,16 @@ export function updateActivity(
   // `pending_interaction: null` clears it, a value sets it, absent leaves it —
   // the same contract as the domain's applyActivityUpdate (null is an
   // update-only signal; the Activity itself never stores null).
-  const { pending_interaction, ...rest } = updates;
+  const { pending_interaction, provider, model, ...rest } = updates;
   const next: Activity = {
     ...items[idx],
     ...rest,
     updated_at: new Date().toISOString(),
   };
+  if (provider === null) delete next.provider;
+  else if (provider !== undefined) next.provider = provider;
+  if (model === null) delete next.model;
+  else if (model !== undefined) next.model = model;
   if (pending_interaction) next.pending_interaction = pending_interaction;
   else if (pending_interaction === null) delete next.pending_interaction;
   items[idx] = next;

--- a/packages/web/src/engine-adapter/client/context.ts
+++ b/packages/web/src/engine-adapter/client/context.ts
@@ -290,6 +290,11 @@ export class AdapterContext {
       : setupRuntimeClientFor(this._cp);
   }
 
+  /** Runtime client pinned to a specific agent, independent of UI selection. */
+  providerEngineFor(agentId: string): HoustonEngineClient {
+    return this._cp ? runtimeClientFor(this._cp, agentId) : this.engine;
+  }
+
   /** The one config both deployments share: the gateway in cloud mode, the
    *  local/self-host host otherwise — each serves `/v1/preferences/:key`. */
   prefConfig(): ControlPlaneConfig {

--- a/packages/web/src/engine-adapter/client/provider-capture-retry.ts
+++ b/packages/web/src/engine-adapter/client/provider-capture-retry.ts
@@ -1,0 +1,21 @@
+const CAPTURE_ATTEMPTS = 3;
+const CAPTURE_RETRY_DELAY_MS = 250;
+
+export async function retryCredentialCapture(
+  capture: () => Promise<void>,
+  wait: (ms: number) => Promise<unknown> = (ms) =>
+    new Promise((resolve) => setTimeout(resolve, ms)),
+): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= CAPTURE_ATTEMPTS; attempt += 1) {
+    try {
+      await capture();
+      return;
+    } catch (err) {
+      lastError = err;
+      if (attempt < CAPTURE_ATTEMPTS)
+        await wait(CAPTURE_RETRY_DELAY_MS * attempt);
+    }
+  }
+  throw lastError;
+}

--- a/packages/web/src/engine-adapter/client/provider-login-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-login-mixin.ts
@@ -5,13 +5,18 @@ import * as controlPlane from "../control-plane";
 import { toNewProvider, toOldProvider } from "../synthetic";
 import type { BaseCtor } from "./mixin";
 import {
-  benignCancelMiss,
   pollProviderConnect,
   SETUP_LOGIN_KEY,
   stopLoginWatch,
   watchLoginCompletion,
 } from "./provider-login-poll";
 import { requireProviderRouting } from "./provider-routing";
+
+/** A missing login already satisfies cancel's postcondition (HOU-676). */
+function benignCancelMiss(e: unknown): void {
+  if (e instanceof EngineError && e.status === 404) return;
+  throw e;
+}
 
 /**
  * Surface a login-launch failure the runtime tagged with a stable `kind` (today:

--- a/packages/web/src/engine-adapter/client/provider-login-poll.ts
+++ b/packages/web/src/engine-adapter/client/provider-login-poll.ts
@@ -1,4 +1,4 @@
-import { EngineError, type ProviderId } from "@houston/runtime-client";
+import type { ProviderId } from "@houston/runtime-client";
 import {
   PROVIDER_CONNECT_TIMEOUT_ERROR,
   PROVIDER_LOGIN_TIMEOUT_ERROR,
@@ -11,24 +11,13 @@ import {
   setupRuntimeClientFor,
 } from "../control-plane";
 import type { AdapterContext } from "./context";
+import { retryCredentialCapture } from "./provider-capture-retry";
 
 /**
  * `activeLogins` key segment for a login started before any agent existed
  * (first-run: it runs in the host's hidden setup runtime, not an agent's).
  */
 export const SETUP_LOGIN_KEY = "__setup__";
-
-/**
- * Treat a 404 on login/cancel as benign: it means no login was pending (or an
- * older host lacks the cancel route), so cancel's postcondition — the login
- * slot is free — already holds. The reconnect card's every press goes
- * cancel → launch, so propagating this 404 aborted the chain and the login
- * never launched (HOU-676). Every other failure still propagates.
- */
-export function benignCancelMiss(e: unknown): void {
-  if (e instanceof EngineError && e.status === 404) return;
-  throw e;
-}
 
 /**
  * True iff this provider's login is genuinely DONE — not merely `configured`.
@@ -156,7 +145,9 @@ export async function pollProviderConnect(
         // agent (existing + new + the one onboarding creates next) shares it.
         try {
           if (agentId) {
-            await captureCredential(cp, agentId, pid);
+            await retryCredentialCapture(() =>
+              captureCredential(cp, agentId, pid),
+            );
           } else {
             await captureSetupCredential(cp, pid);
           }
@@ -176,9 +167,13 @@ export async function pollProviderConnect(
             });
             return;
           }
-          // With an agent, the credential already lives in ITS runtime — the
-          // connect works for this agent; only workspace-wide sharing failed.
-          console.error("[connect] workspace credential capture failed", e);
+          emitEvent("ProviderLoginComplete", {
+            provider: oldProvider,
+            success: false,
+            error:
+              e instanceof Error ? e.message : "Saving the connected AI failed",
+          });
+          return;
         }
         emitEvent("ProviderLoginComplete", {
           provider: oldProvider,

--- a/packages/web/src/engine-adapter/client/provider-status-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-status-mixin.ts
@@ -74,6 +74,31 @@ export function ProviderStatusMixin<TBase extends BaseCtor>(Base: TBase) {
         } as ProviderStatus;
       });
     }
+
+    async providerStatusesForAgent(
+      agentId: string,
+      names: readonly string[],
+    ): Promise<ProviderStatus[]> {
+      const byId = new Map(
+        (await this.ctx.providerEngineFor(agentId).listProviders()).map((p) => [
+          p.id,
+          p,
+        ]),
+      );
+      return names.map((name) => {
+        const provider = toNewProvider(name);
+        const status = provider ? byId.get(provider) : undefined;
+        return {
+          provider: name,
+          cliInstalled: true,
+          authState: status?.configured ? "authenticated" : "unauthenticated",
+          cliName: name,
+          installSource: "managed",
+          cliPath: null,
+          activeModel: status?.activeModel || undefined,
+        } as ProviderStatus;
+      });
+    }
     /**
      * Live per-account usage for every connected provider (rate-limit windows
      * + prepaid balances), served by the runtime's `GET /providers/usage`.

--- a/packages/web/tests/provider-login-capture.test.ts
+++ b/packages/web/tests/provider-login-capture.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { bus } from "../src/engine-adapter/bus";
+
+const mocks = vi.hoisted(() => ({
+  captureCredential: vi.fn<() => Promise<void>>(),
+  claimActiveProvider: vi.fn<() => Promise<void>>(),
+  authStatus: vi.fn(),
+}));
+
+vi.mock("../src/engine-adapter/control-plane", () => ({
+  captureCredential: mocks.captureCredential,
+  captureSetupCredential: vi.fn(),
+  runtimeClientFor: () => ({
+    authStatus: mocks.authStatus,
+    claimActiveProvider: mocks.claimActiveProvider,
+  }),
+  setupRuntimeClientFor: vi.fn(),
+}));
+
+const { pollProviderConnect } = await import(
+  "../src/engine-adapter/client/provider-login-poll"
+);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.captureCredential.mockReset();
+  mocks.claimActiveProvider.mockReset().mockResolvedValue();
+  mocks.authStatus.mockReset().mockResolvedValue({
+    providers: [
+      {
+        provider: "openai-codex",
+        configured: true,
+        login: { status: "complete" },
+      },
+    ],
+  });
+});
+
+afterEach(() => vi.useRealTimers());
+
+function context() {
+  return {
+    cp: { baseUrl: "https://example.test", token: "token" },
+    activeLogins: new Set<string>(),
+  } as never;
+}
+
+async function runAndCollect() {
+  const events: unknown[] = [];
+  const unsubscribe = bus.on((event) => events.push(event));
+  const polling = pollProviderConnect(
+    context(),
+    "agent-1",
+    "openai-codex",
+    "openai",
+  );
+  await vi.runAllTimersAsync();
+  await polling;
+  unsubscribe();
+  return events;
+}
+
+test("capture retries transient failures before reporting login success", async () => {
+  mocks.captureCredential
+    .mockRejectedValueOnce(new Error("capture unavailable"))
+    .mockRejectedValueOnce(new Error("capture unavailable"))
+    .mockResolvedValueOnce();
+
+  const events = await runAndCollect();
+
+  expect(mocks.captureCredential).toHaveBeenCalledTimes(3);
+  expect(events).toContainEqual({
+    type: "ProviderLoginComplete",
+    data: { provider: "openai", success: true, error: null },
+  });
+});
+
+test("persistent capture failure reports login failure", async () => {
+  mocks.captureCredential.mockRejectedValue(new Error("capture unavailable"));
+
+  const events = await runAndCollect();
+
+  expect(mocks.captureCredential).toHaveBeenCalledTimes(3);
+  expect(events).toContainEqual({
+    type: "ProviderLoginComplete",
+    data: {
+      provider: "openai",
+      success: false,
+      error: "capture unavailable",
+    },
+  });
+  expect(events).not.toContainEqual({
+    type: "ProviderLoginComplete",
+    data: { provider: "openai", success: true, error: null },
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,6 +466,10 @@ importers:
         version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/protocol:
+    dependencies:
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260607.1
@@ -473,6 +477,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      vitest:
+        specifier: 3.2.6
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/runtime:
     dependencies:

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -1108,6 +1108,12 @@ export class HoustonClient {
   providerStatus(name: string): Promise<ProviderStatus> {
     return this.request("GET", `/providers/${this.seg(name)}/status`);
   }
+  providerStatusesForAgent(
+    _agentId: string,
+    names: readonly string[],
+  ): Promise<ProviderStatus[]> {
+    return Promise.all(names.map((name) => this.providerStatus(name)));
+  }
   /**
    * Live per-account usage for every CONNECTED provider — rate-limit windows
    * (Claude 5h/weekly, Codex session/weekly, Copilot quotas) and prepaid

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -779,8 +779,8 @@ export interface ActivityUpdate {
   routine_id?: string;
   routine_run_id?: string;
   skill_slug?: string;
-  provider?: string;
-  model?: string;
+  provider?: string | null;
+  model?: string | null;
   /** Set to record a new pending interaction; `null` clears it explicitly. */
   pending_interaction?: PendingInteraction | null;
 }


### PR DESCRIPTION
## What this ships

**Per-mission models (HOU-1064).** A model pick inside an open mission pins that mission only — including multiplayer Teams mode, where a pick previously moved the per-(user, agent) choice shared by every conversation. The picker displays the mission's in-ceiling pin, every send forwards the displayed pin, ceiling snaps resolve the model's owning provider, displayed effort is revalidated per model, and personal choices update optimistically. Companion gateway change: gethouston/cloud PR (linked below) — the gateway now honors an in-ceiling per-conversation pin verbatim.

**Connected-provider defaults (HOU-1065).** The create-agent dialog and import wizard no longer hardcode anthropic/Sonnet: defaults resolve against confirmed-connected providers at open and at submit time, and when nothing is confirmed connected the kickoff carries no pin at all — the engine resolves a connected provider or surfaces the real connect flow. Onboarding writes any connected provider into the assistant's config, and the sticky last-used preference can no longer be silently lost (hosted picks now update it too).

**Credential single-rotator + self-heal (HOU-1073).** Root causes of "every new agent's first message is broken": the connect flow materialized full refresh-bearing credentials onto pods (whose SDK rotation burned the gateway's central copy), and the connect flow's own status polling clobbered fresh logins before capture could export them. Now: serve-apply never overwrites a refresh-bearing local entry, capture retries and reports honest failure, the scrub is coupled to capture, serve-mode pods materialize Anthropic access-only, a pinned turn on a definitively absent provider yields the real connect card instead of an SDK 401, a serve miss self-heals by re-capturing a warm pod's live credential (single-flight + cooldown), and the warming kickoff verifies its pin against the new pod — dropping the pin and the mission's stamp when the provider is absent (ActivityUpdate provider/model are now nullable to support clearing).

**Ask First missions (HOU-1080).** Every new mission opens in Ask First: the default turn mode is execute and the per-agent remembered mode is removed; a mid-mission pick applies to that session (and live turn) only.

## Verification
- app node:test 2536/2536 · runtime 881 · host 1141 · domain 181 · protocol 29 · web 301 — all green post-rebase onto main
- workspace typecheck, biome, locales (en/es/pt), `check:boundaries` green
- Adversarially reviewed (two independent review passes); all confirmed findings fixed
- Chat/board Playwright specs green; the create-agent-dialog specs could not run in the CI-less sandbox (vite warm-up timeout) — flagged for in-app review

## Ops note
Orgs whose central Anthropic/OpenAI credential is already burned need one reconnect after release; the self-heal also repairs the row automatically from any warm pod that still holds a live credential.

Sibling PR: gethouston/cloud (gateway pin honoring) — link in first comment.

Fixes HOU-1064
Fixes HOU-1065
Fixes HOU-1073
Fixes HOU-1080

🤖 Generated with [Claude Code](https://claude.com/claude-code)