### PR TITLE
fix(providers): api-key providers reconnect via the key dialog; NVIDIA/Qwen auth rejections classified (HOU-1077)

### DIFF
--- a/app/src/components/shell/provider-error-cards/auth-presentation.ts
+++ b/app/src/components/shell/provider-error-cards/auth-presentation.ts
@@ -32,6 +32,30 @@ export function authCauseBodyKey(cause: UnauthCause): string {
   }
 }
 
+/**
+ * Which surface the Reconnect button opens. Only OAuth providers have a browser
+ * sign-in; sending an api-key provider through `launchLogin` is a guaranteed
+ * 400 ("nvidia does not use OAuth sign-in") that flips the card to its failed
+ * phase and dead-ends the user (HOU-1077) — those reconnect by re-pasting the
+ * key in the same connect dialog settings uses. The local provider keeps its
+ * guided endpoint dialog.
+ */
+export type ReconnectSurface =
+  | "oauth_login"
+  | "api_key_dialog"
+  | "local_model_dialog";
+
+export function reconnectSurface(
+  providerId: string,
+  auth: "oauth" | "apiKey" | "openaiCompatible" | undefined,
+): ReconnectSurface {
+  if (providerId === "openai-compatible") return "local_model_dialog";
+  if (auth === "apiKey") return "api_key_dialog";
+  // OAuth — or an id the catalog doesn't resolve, where only the engine knows
+  // the method: the engine-side launch keeps its own non-OAuth guard.
+  return "oauth_login";
+}
+
 /** The action a button fires. A `badge` button is a disabled status pill. */
 export type AuthCardAction = "reconnect" | "cancel";
 

--- a/app/src/components/shell/provider-error-cards/auth.tsx
+++ b/app/src/components/shell/provider-error-cards/auth.tsx
@@ -36,14 +36,15 @@ import { tauriProvider } from "../../../lib/tauri";
 import { useUIStore } from "../../../stores/ui";
 import { RowCard } from "../../cards/row-card";
 import { RowCardButton } from "../../cards/row-card-button";
-import { LocalModelDialog } from "../local-model-dialog";
 import { ProviderGlyph } from "../provider-logos";
 import {
   type AuthCardButton,
   authCauseBodyKey,
   type LoginPhase,
+  reconnectSurface,
   resolveAuthCardPresentation,
 } from "./auth-presentation";
+import { ReconnectDialog } from "./reconnect-dialog";
 import { providerLabel } from "./shared";
 
 export function UnauthenticatedCard({
@@ -59,7 +60,7 @@ export function UnauthenticatedCard({
   const [launching, setLaunching] = useState(false);
   const [failureDetail, setFailureDetail] = useState<string | null>(null);
   const [retrying, setRetrying] = useState(false);
-  const [showCustomDialog, setShowCustomDialog] = useState(false);
+  const [showConnectDialog, setShowConnectDialog] = useState(false);
   const relaunchingRef = useRef(false);
   // The auto-resend must fire ONCE per card — a second fire (the provider can
   // complete several logins while the chat stays open) would double-send.
@@ -103,16 +104,22 @@ export function UnauthenticatedCard({
     });
   }, [error.provider, setAuthRequired]);
 
+  // Which surface Reconnect opens: OAuth's browser login, the api-key paste
+  // dialog, or the local endpoint dialog. Non-OAuth providers must NEVER hit
+  // launchLogin — the engine 400s ("nvidia does not use OAuth sign-in") and
+  // the card dead-ends in its failed phase with no way out (HOU-1077). Both
+  // dialogs fire the same `ProviderLoginComplete` on a successful connect, so
+  // the auto-resume above runs for every surface.
+  const surface = reconnectSurface(
+    error.provider,
+    getProvider(error.provider)?.auth,
+  );
+
   const reconnect = async () => {
     if (launching) return;
-    // A local OpenAI-compatible server has no OAuth flow — reconnect by
-    // re-connecting the local model in its dialog, not launchLogin (which
-    // would throw "does not use OAuth sign-in" and dead-end the card). A
-    // successful connect fires the same `ProviderLoginComplete` event
-    // (`setProviderCustomEndpoint`), so the auto-resume above still runs.
-    if (error.provider === "openai-compatible") {
+    if (surface !== "oauth_login") {
       setFailureDetail(null);
-      setShowCustomDialog(true);
+      setShowConnectDialog(true);
       setPhase("waiting");
       return;
     }
@@ -132,9 +139,9 @@ export function UnauthenticatedCard({
   };
 
   const cancelSignIn = async () => {
-    // Local model: nothing engine-side to cancel — close the dialog and re-arm.
-    if (error.provider === "openai-compatible") {
-      setShowCustomDialog(false);
+    // Dialog surfaces: nothing engine-side to cancel — close and re-arm.
+    if (surface !== "oauth_login") {
+      setShowConnectDialog(false);
       setPhase("idle");
       return;
     }
@@ -194,16 +201,12 @@ export function UnauthenticatedCard({
         action={renderButton(pres.button)}
       />
 
-      {/* The local model's reconnect surface: the same guided dialog the AI
-          Models section opens. A successful connect fires
-          ProviderLoginComplete, which flips this card to done and auto-resumes
-          the task; closing without connecting re-arms the button. */}
-      <LocalModelDialog
-        provider={
-          showCustomDialog ? (getProvider(error.provider) ?? null) : null
-        }
+      <ReconnectDialog
+        surface={surface}
+        providerId={error.provider}
+        open={showConnectDialog}
         onClose={() => {
-          setShowCustomDialog(false);
+          setShowConnectDialog(false);
           setPhase((p) => (p === "waiting" ? "idle" : p));
         }}
       />

--- a/app/src/components/shell/provider-error-cards/reconnect-dialog.tsx
+++ b/app/src/components/shell/provider-error-cards/reconnect-dialog.tsx
@@ -1,0 +1,34 @@
+import { getProvider } from "../../../lib/providers";
+import { LocalModelDialog } from "../local-model-dialog";
+import { ProviderApiKeyDialog } from "../provider-api-key-dialog";
+import type { ReconnectSurface } from "./auth-presentation";
+
+/**
+ * The non-OAuth reconnect surfaces of the `UnauthenticatedCard`: the SAME
+ * connect dialogs the AI Models section opens — the api-key paste dialog for
+ * api-key providers, the guided endpoint dialog for the local provider. A
+ * successful connect fires `ProviderLoginComplete`, which flips the card to
+ * done and auto-resumes the task; closing without connecting re-arms the
+ * button (the card's `onClose`). OAuth providers render nothing — their
+ * reconnect is the browser login, not a dialog.
+ */
+export function ReconnectDialog({
+  surface,
+  providerId,
+  open,
+  onClose,
+}: {
+  surface: ReconnectSurface;
+  providerId: string;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const provider = open ? (getProvider(providerId) ?? null) : null;
+  if (surface === "api_key_dialog") {
+    return <ProviderApiKeyDialog provider={provider} onClose={onClose} />;
+  }
+  if (surface === "local_model_dialog") {
+    return <LocalModelDialog provider={provider} onClose={onClose} />;
+  }
+  return null;
+}

--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -638,6 +638,25 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     installUrl: "https://build.nvidia.com",
     apiKeyUrl: "https://build.nvidia.com/settings/api-keys",
   },
+  // Alibaba's prepaid token bundles for Qwen (+ hosted open models). The
+  // endpoint only accepts the DEDICATED Token Plan API key minted after
+  // purchasing a plan and assigning its seat — a regular Model Studio key gets
+  // a 401 "Invalid API-key provided" (HOU-1077), so the connect guidance must
+  // send users to the Token Plan setup guide, not a generic key console.
+  "qwen-token-plan": {
+    name: "Qwen Token Plan",
+    subtitle: "Alibaba Cloud token plan",
+    description: "Qwen and hosted open models on an Alibaba token plan.",
+    cost: "Requires a purchased token plan",
+    billing: "subscription",
+    installUrl:
+      "https://www.alibabacloud.com/help/en/model-studio/token-plan-team-quickstart",
+    apiKeyUrl:
+      "https://www.alibabacloud.com/help/en/model-studio/token-plan-team-quickstart",
+    // pi lists this multi-vendor catalog alphabetically, which would make
+    // MiniMax the default on a card named Qwen.
+    defaultModel: "qwen3.7-max",
+  },
   "google-vertex": {
     name: "Google Vertex AI",
     subtitle: "Gemini on Google Cloud",

--- a/app/tests/auth-card-presentation.test.ts
+++ b/app/tests/auth-card-presentation.test.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
   authCauseBodyKey,
+  reconnectSurface,
   resolveAuthCardPresentation,
 } from "../src/components/shell/provider-error-cards/auth-presentation.ts";
 
@@ -39,6 +40,42 @@ describe("authCauseBodyKey", () => {
       authCauseBodyKey("mystery" as never),
       "providerError.unauthenticated.bodyUnknown",
     );
+  });
+});
+
+describe("reconnectSurface", () => {
+  // Reconnect once sent EVERY provider through launchLogin, which the engine
+  // 400s for non-OAuth providers ("nvidia does not use OAuth sign-in") — the
+  // card flipped to failed with no way out (HOU-1077). API-key providers must
+  // reconnect through the key paste dialog instead.
+  it("api-key providers open the key dialog, never the OAuth login", () => {
+    strictEqual(reconnectSurface("nvidia", "apiKey"), "api_key_dialog");
+    strictEqual(reconnectSurface("google", "apiKey"), "api_key_dialog");
+    strictEqual(
+      reconnectSurface("qwen-token-plan", "apiKey"),
+      "api_key_dialog",
+    );
+  });
+
+  it("OAuth providers keep the browser login", () => {
+    strictEqual(reconnectSurface("anthropic", "oauth"), "oauth_login");
+    strictEqual(reconnectSurface("openai-codex", "oauth"), "oauth_login");
+  });
+
+  it("the local provider keeps its guided endpoint dialog, whatever the catalog says", () => {
+    strictEqual(
+      reconnectSurface("openai-compatible", "openaiCompatible"),
+      "local_model_dialog",
+    );
+    strictEqual(
+      reconnectSurface("openai-compatible", undefined),
+      "local_model_dialog",
+    );
+  });
+
+  it("an id the catalog cannot resolve falls back to the OAuth login", () => {
+    // Only the engine knows the method then; its launch keeps the non-OAuth guard.
+    strictEqual(reconnectSurface("mystery", undefined), "oauth_login");
   });
 });
 

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -559,6 +559,37 @@ test("NVIDIA NIM expired cloud credits → quota_exhausted", () => {
   expect(err.kind).toBe("quota_exhausted");
 });
 
+test("NVIDIA NIM 403 'Authorization failed' → unauthenticated / invalid_api_key", () => {
+  // Verbatim integrate.api.nvidia.com rejection of a bad or revoked key
+  // (HOU-1077): a 403 whose body names neither "unauthorized" nor
+  // "authentication", so it used to fall through to `unknown` — the generic
+  // error card mid-chat, and "could not verify" instead of "didn't accept
+  // this key" at connect time.
+  const err = classifyProviderError({
+    provider: "nvidia",
+    model: "meta/llama-3.1-70b-instruct",
+    message:
+      '403: {"status":403,"title":"Forbidden","detail":"Authorization failed"}',
+  });
+  expect(err.kind).toBe("unauthenticated");
+  if (err.kind === "unauthenticated") expect(err.cause).toBe("invalid_api_key");
+});
+
+test("Qwen Token Plan 401 'Invalid API-key provided' → unauthenticated / invalid_api_key", () => {
+  // Verbatim token-plan.ap-southeast-1.maas.aliyuncs.com body (HOU-1077). The
+  // endpoint only accepts a DEDICATED Token Plan key — a regular Model Studio
+  // key lands here. "API-key" is hyphenated; the cause must still read
+  // invalid_api_key so the card says the key itself was refused.
+  const err = classifyProviderError({
+    provider: "qwen-token-plan",
+    model: "qwen3.7-max",
+    message:
+      '401: {"message":"Invalid API-key provided. For details, see: https://www.alibabacloud.com/help/en/model-studio/error-code#apikey-error","id":"76019e5d-2f21-45dd-88c3-40d23773d800","type":"invalid_request_error","code":"invalid_api_key"}',
+  });
+  expect(err.kind).toBe("unauthenticated");
+  if (err.kind === "unauthenticated") expect(err.cause).toBe("invalid_api_key");
+});
+
 // ---------------------------------------------------------------------------
 // Context overflow — the conversation no longer fits the model's window.
 // The Jan fixture is the VERBATIM llama.cpp rejection from the production

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -47,6 +47,16 @@ const INVALID_KEY_PATTERNS = [
   "incorrect api key",
   "invalid x-api-key",
   "no auth credentials",
+  // Alibaba Model Studio / Qwen Token Plan gateways: 401
+  // `{"message":"Invalid API-key provided. …","code":"invalid_api_key"}` —
+  // "API-key" is hyphenated, so the plain "invalid api key" pattern misses it.
+  "invalid api-key",
+  // NVIDIA NIM rejects a bad/revoked key with 403
+  // `{"status":403,"title":"Forbidden","detail":"Authorization failed"}` —
+  // no "unauthorized"/"authentication" wording, so without this pattern it
+  // classified `unknown` (generic error card instead of the reconnect card,
+  // and "could not verify" instead of "didn't accept this key") (HOU-1077).
+  "authorization failed",
 ];
 
 /**


### PR DESCRIPTION
Fixes HOU-1077 (NVIDIA and Qwen not working).

## Root causes

**1. The reconnect card dead-ends for every api-key provider.** When a turn fails `unauthenticated` on an api-key provider (NVIDIA, Google Gemini, Qwen Token Plan, ...), the inline card's Reconnect button called `launchLogin` — which the engine rejects with `400 {"error":"nvidia does not use OAuth sign-in"}` — so the card flipped to "The NVIDIA sign-in did not finish. Sign in again." forever, with no working path back. Sentry: `HOUSTON-APP-4VN` (nvidia, 25 events), `HOUSTON-APP-509` (google, 27 events).

**2. Two real rejection bodies classified as `unknown`.** NVIDIA NIM rejects a bad/revoked key with `403 {"title":"Forbidden","detail":"Authorization failed"}` (live-probed) and Alibaba's Token Plan endpoint answers a wrong key with `401 "Invalid API-key provided. …"` (hyphenated). The 403 body carried none of the classifier's auth keywords, so mid-chat it rendered the generic "Something unexpected went wrong" toast instead of the reconnect card, and at connect time "could not verify" instead of "didn't accept this key".

**3. Qwen Token Plan had zero connect guidance.** The endpoint (`token-plan.ap-southeast-1.maas.aliyuncs.com`) only accepts the dedicated Token Plan key minted after purchasing a plan and assigning its seat — a regular Model Studio key gets the exact 401 the user hit (`HOUSTON-APP-4WX`). The card had no name override, no "Get your API key" link, no cost hint, and defaulted to pi's alphabetically-first model (MiniMax, on a card named Qwen).

## Changes

- `UnauthenticatedCard`: Reconnect now routes by a pure `reconnectSurface()` — api-key providers open the same key paste dialog settings uses (extracted `ReconnectDialog`), the local provider keeps its endpoint dialog, OAuth keeps the browser login. Both dialogs already fire `ProviderLoginComplete`, so the card's done-flip + auto-resume work unchanged.
- Runtime classifier: `"authorization failed"` and `"invalid api-key"` join `INVALID_KEY_PATTERNS` (both tied to verbatim bodies in tests). The 401/403 status gate keeps them narrow.
- `provider-overrides`: `qwen-token-plan` gets name/subtitle/description, a "requires a purchased token plan" cost line, the Token Plan setup-guide link as install/api-key URL, and `defaultModel: qwen3.7-max`.

## Repro (before)

1. Connect NVIDIA with a key from build.nvidia.com (accepted), chat until a turn fails auth (e.g. revoke the key) → "Sign in to NVIDIA again" card → click Reconnect → "The NVIDIA sign-in did not finish. Sign in again." — unrecoverable loop, plus a `launch_provider_login … 400` Sentry event.
2. Connect "Qwen Token Plan" with a regular Alibaba Model Studio key → 401 "didn't accept this key" with no guidance on which key the endpoint needs, and no "Get your API key" button.

## Verify (after)

1. Same NVIDIA scenario → clicking Reconnect opens the "Connect NVIDIA" key dialog; pasting a valid key flips the card to the green "Signed in" state and auto-resumes the conversation.
2. `pnpm --filter @houston/runtime test` — the two new verbatim-body tests pass (NVIDIA 403 and Qwen 401 → `unauthenticated / invalid_api_key`).
3. The Qwen Token Plan connect dialog now shows "Get your API key" linking the Token Plan quickstart; the card reads "Requires a purchased token plan" and defaults to Qwen3.7 Max.

Gates: biome clean, `@houston/runtime` vitest 874 pass, app node:test 2535 pass, app + web tsgo clean, boundaries clean.