### PR TITLE
fix(chat): hard-wrapped URL labels render inline, not as a clipped pill (HOU-1071)

### DIFF
--- a/packages/web/e2e/chat-link-pill.spec.ts
+++ b/packages/web/e2e/chat-link-pill.spec.ts
@@ -1,0 +1,57 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * HOU-1071: a long URL the agent hard-wraps inside a markdown link label
+ * (`[https://…-␠␠\n…/edit](href)`) must render as an inline clickable link,
+ * never as the labeled button pill — the pill clips the wrapped URL into an
+ * unreadable black bar. Seeded through `/__test__/chat-history`, so this
+ * exercises the REAL browser pipeline: history → feed → Streamdown →
+ * `classifyMarkdownLink` → the `a` override in `ui/chat`.
+ */
+
+const MISSION_ID = "act-hou-1071";
+const CONVERSATION_ID = `activity-${MISSION_ID}`;
+
+const HREF =
+  "https://docs.google.com/spreadsheets/d/1JOOOml-rR9HmaliG4UX6UxZipaFoFE3zB13FWiPz-Y/edit?usp=sharing";
+/** The label as agents actually emit it: hard-wrapped with trailing spaces. */
+const WRAPPED_LABEL =
+  "https://docs.google.com/spreadsheets/d/1JOOOml-  \nrR9HmaliG4UX6UxZipaFoFE3zB13FWiPz-Y/edit";
+const REASSEMBLED =
+  "https://docs.google.com/spreadsheets/d/1JOOOml-rR9HmaliG4UX6UxZipaFoFE3zB13FWiPz-Y/edit";
+
+test("hard-wrapped URL label renders inline, not as a clipped pill (HOU-1071)", async ({
+  page,
+  request,
+}) => {
+  await request.post(`${FAKE_HOST_URL}/agents/houston-assistant/activities`, {
+    data: { id: MISSION_ID, title: "Link rendering", status: "needs_you" },
+  });
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-history`, {
+    data: {
+      conversationId: CONVERSATION_ID,
+      messages: [
+        { role: "user", content: "share the sheet", ts: 1 },
+        {
+          role: "assistant",
+          content: `Sheet's live, open it here: [${WRAPPED_LABEL}](${HREF})`,
+          ts: 2,
+        },
+      ],
+    },
+  });
+
+  await page.goto("/");
+  await page.getByText("Link rendering").first().click();
+
+  // The inline anchor: full href, whitespace-free reassembled URL as text.
+  const link = page.locator(`a[href="${HREF}"]`);
+  await expect(link).toBeVisible({ timeout: 15_000 });
+  await expect(link).toHaveText(REASSEMBLED);
+
+  // And no button pill wearing the URL (the clipped-black-bar regression).
+  await expect(
+    page.locator("button", { hasText: "docs.google.com" }),
+  ).toHaveCount(0);
+});

--- a/ui/chat/src/ai-elements/message.tsx
+++ b/ui/chat/src/ai-elements/message.tsx
@@ -39,7 +39,7 @@ import {
 } from "react";
 import { defaultRehypePlugins, Streamdown } from "streamdown";
 import { MarkdownCodeBlock } from "../markdown-code-block";
-import { classifyMarkdownLink } from "../markdown-link";
+import { classifyMarkdownLink, collapsedUrlText } from "../markdown-link";
 import { MentionMarkdownSpan } from "../mention-chip.tsx";
 import type { MentionRehypeOptions } from "../mention-rehype.ts";
 import { mentionRehypePlugin } from "../mention-rehype.ts";
@@ -506,7 +506,11 @@ export const MessageResponse = memo(
           // the underline is the whole affordance. Only the assistant's prose,
           // on the plain canvas, may keep it hover-enhanced.
           if (kind === "autolink") {
-            if (!fn) return <span>{children}</span>;
+            // A URL label markdown broke across lines flattens with a
+            // softbreak in it (HOU-1071) — show the reassembled URL, not
+            // the raw children with a stray space mid-URL.
+            const label = collapsedUrlText(children) ?? children;
+            if (!fn) return <span>{label}</span>;
             return (
               <a
                 href={url}
@@ -517,19 +521,21 @@ export const MessageResponse = memo(
                 }}
                 className={AUTOLINK_CLASS}
               >
-                {children}
+                {label}
               </a>
             );
           }
           // Labeled link (text distinct from URL) → button with text + icon.
           // max-w-full + truncate: a long label ellipsizes instead of
           // overflowing the fixed-height pill as clipped wrapped lines.
+          // overflow-hidden: even a child that defeats truncate (a <br>, an
+          // image) stays clipped inside the pill's rounded bounds.
           return (
             <Button
               type="button"
               size="sm"
               variant="default"
-              className="max-w-full"
+              className="max-w-full overflow-hidden"
               onClick={onOpen}
             >
               <span className="min-w-0 truncate">{children}</span>

--- a/ui/chat/src/markdown-link.ts
+++ b/ui/chat/src/markdown-link.ts
@@ -38,6 +38,12 @@ export function markdownLinkText(children: unknown): string | null {
     children !== null &&
     "props" in children
   ) {
+    // A hard break inside a link label (agents hard-wrap long URLs with
+    // trailing spaces or a backslash, HOU-1071) renders as a childless
+    // <br> element — line-break hints are whitespace, not "not text".
+    const type = (children as { type?: unknown }).type;
+    if (type === "br") return "\n";
+    if (type === "wbr") return "";
     const props = (children as { props: unknown }).props;
     if (typeof props === "object" && props !== null && "children" in props) {
       return markdownLinkText((props as { children: unknown }).children);

--- a/ui/chat/src/markdown-link.ts
+++ b/ui/chat/src/markdown-link.ts
@@ -56,7 +56,11 @@ const URL_TEXT = /^https?:\/\/\S+$/;
  * including relative paths like `perfil.md`), when the text is a web URL in
  * its own right (the label being a URL is exactly the case where a pill
  * renders broken), or when it equals the decoded href (micromark
- * percent-encodes hrefs it normalizes).
+ * percent-encodes hrefs it normalizes). The URL test also runs on the
+ * whitespace-collapsed text: agents hard-wrap long URLs inside a
+ * `[label](href)`, and the softbreak flattens into the label as "\n"
+ * (HOU-1071) — without collapsing, that label fell into the pill branch
+ * and clipped the URL into an unreadable black bar.
  */
 export function classifyMarkdownLink(
   href: string | null | undefined,
@@ -66,11 +70,25 @@ export function classifyMarkdownLink(
   const text = markdownLinkText(children);
   if (text === null) return "labeled";
   if (text === href) return "autolink";
-  if (URL_TEXT.test(text)) return "autolink";
+  if (URL_TEXT.test(text.replace(/\s+/g, ""))) return "autolink";
   try {
     if (decodeURI(href) === text) return "autolink";
   } catch {
     // Malformed percent-encoding in the href — treat as labeled.
   }
   return "labeled";
+}
+
+/**
+ * Display text for an autolink whose label is a URL that markdown broke
+ * across lines (the HOU-1071 shape): the whitespace-free URL to render
+ * instead of the raw children, which would show a stray space mid-URL.
+ * Null when the children should render as-is — the common case, which
+ * keeps Streamdown's streaming animation wrappers intact.
+ */
+export function collapsedUrlText(children: unknown): string | null {
+  const text = markdownLinkText(children);
+  if (text === null) return null;
+  const collapsed = text.replace(/\s+/g, "");
+  return collapsed !== text && URL_TEXT.test(collapsed) ? collapsed : null;
 }

--- a/ui/chat/tests/markdown-link.test.ts
+++ b/ui/chat/tests/markdown-link.test.ts
@@ -28,6 +28,16 @@ describe("markdownLinkText", () => {
     );
   });
 
+  it("treats <br>/<wbr> break elements as whitespace, not non-text (HOU-1071)", () => {
+    // A hard break inside a link label renders as a childless <br> element;
+    // returning null here dropped wrapped-URL labels into the clipped pill.
+    assert.equal(
+      markdownLinkText(["https://a.com/x-", { type: "br", props: {} }, "\ny"]),
+      "https://a.com/x-\n\ny",
+    );
+    assert.equal(markdownLinkText({ type: "wbr", props: {} }), "");
+  });
+
   it("returns null for non-text nodes", () => {
     assert.equal(markdownLinkText({ href: "x" }), null);
     assert.equal(markdownLinkText(["text", { type: "img" }]), null);
@@ -87,6 +97,19 @@ describe("classifyMarkdownLink", () => {
         "https://docs.google.com/spreadsheets/d/1JOOOml-rR9Hmali/edit?usp=sharing",
         "https://docs.google.com/spreadsheets/d/1JOOOml-\nrR9Hmali/edit",
       ),
+      "autolink",
+    );
+  });
+
+  it("URL label hard-broken with <br> is an autolink (HOU-1071 live shape)", () => {
+    // Trailing-space / backslash hard breaks render the wrapped label as
+    // [text, <br>, text] — the exact shape from the issue screenshot.
+    assert.equal(
+      classifyMarkdownLink("https://docs.google.com/spreadsheets/d/1JO/edit", [
+        "https://docs.google.com/spreadsheets/d/",
+        { type: "br", props: {} },
+        "\n1JO/edit",
+      ]),
       "autolink",
     );
   });

--- a/ui/chat/tests/markdown-link.test.ts
+++ b/ui/chat/tests/markdown-link.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import {
   classifyMarkdownLink,
+  collapsedUrlText,
   markdownLinkText,
 } from "../src/markdown-link.ts";
 
@@ -77,6 +78,19 @@ describe("classifyMarkdownLink", () => {
     );
   });
 
+  it("URL label hard-wrapped across lines is an autolink (HOU-1071)", () => {
+    // Agents wrap long URLs inside [label](href); the softbreak flattens
+    // into the label as "\n". Pre-fix this fell into the pill branch and
+    // clipped the URL into an unreadable black bar.
+    assert.equal(
+      classifyMarkdownLink(
+        "https://docs.google.com/spreadsheets/d/1JOOOml-rR9Hmali/edit?usp=sharing",
+        "https://docs.google.com/spreadsheets/d/1JOOOml-\nrR9Hmali/edit",
+      ),
+      "autolink",
+    );
+  });
+
   it("labeled markdown link is labeled", () => {
     assert.equal(
       classifyMarkdownLink("https://example.com/report.pdf", "Open report"),
@@ -113,5 +127,23 @@ describe("classifyMarkdownLink", () => {
     // useOpenAgentHref resolves non-URL hrefs against the agent dir;
     // classification only cares whether the visible text equals the href.
     assert.equal(classifyMarkdownLink("perfil.md", "perfil.md"), "autolink");
+  });
+});
+
+describe("collapsedUrlText", () => {
+  it("reassembles a URL label markdown broke across lines", () => {
+    assert.equal(
+      collapsedUrlText("https://docs.google.com/spreadsheets/d/1JO-\nrR9/edit"),
+      "https://docs.google.com/spreadsheets/d/1JO-rR9/edit",
+    );
+  });
+
+  it("returns null for an unwrapped URL so streaming children render as-is", () => {
+    assert.equal(collapsedUrlText("https://example.com"), null);
+  });
+
+  it("returns null for plain labels and non-text children", () => {
+    assert.equal(collapsedUrlText("Open the sheet"), null);
+    assert.equal(collapsedUrlText({ href: "x" }), null);
   });
 });


### PR DESCRIPTION
## Root cause

Agents hard-wrap long URLs inside a markdown link: `[https://docs.google.com/spreadsheets/d/LONG-` ⏎ `ID/edit](href)`. The softbreak flattens into the link label as a newline, so `classifyMarkdownLink` missed both the `text === href` check and the `^https?://\S+$` regex and dropped the link into the **labeled** branch — the dark button pill, which clips the URL into the unreadable black bar in the issue screenshot. (The earlier fix dd5f95ce covered URL labels without whitespace; this shape slipped through.)

## Fix

- `classifyMarkdownLink` now also tests the **whitespace-collapsed** label against the URL regex, so a URL broken across lines classifies as an autolink (inline, clickable, wraps gracefully via `overflow-wrap: anywhere`) instead of a pill.
- New `collapsedUrlText` helper: the autolink renders the reassembled whitespace-free URL, so no stray space appears mid-URL. Unwrapped labels still render their original children, keeping Streamdown's streaming animation intact.
- Defense in depth: the labeled pill gets `overflow-hidden`, so even a child that defeats `truncate` (a `<br>`, an image) can never paint outside the pill's rounded bounds again.

An inline wrapping link was chosen over a horizontally scrollable pill: it matches the existing autolink design intent (see the header comment in `markdown-link.ts`) and how every mainstream chat surface treats long URLs.

## Before

Agent message containing a long wrapped URL label rendered a black pill with the URL clipped/ellipsized outside its rounded bounds.

Repro (before this change): render `MessageResponse` with
```md
Open it here: [https://docs.google.com/spreadsheets/d/1JOOOml-
rR9HmaliG4UX6UxZipaFoFE3zB13FWiPz-Y/edit](https://docs.google.com/spreadsheets/d/1JOOOml-rR9HmaliG4UX6UxZipaFoFE3zB13FWiPz-Y/edit?usp=sharing)
```
→ `classifyMarkdownLink` returns `labeled` → `<button>` pill.

## After

Same markdown → `autolink` → inline `<a>` with the full href and the whitespace-free visible URL, wrapping across lines inside the bubble.

## Verification

- `pnpm --filter @houston-ai/chat test` — 351 pass, including new regression tests: wrapped-URL label → autolink (HOU-1071), `collapsedUrlText` reassembly + as-is passthrough, genuinely labeled links still get the pill.
- `pnpm typecheck` (ui + app + web) and `pnpm check` — clean.
- Manual: send the markdown above from an agent in a chat; the link renders inline and opens the sheet in the system browser.