### PR TITLE
feat(providers): qwen extension provider — Alibaba Model Studio pay-as-you-go (HOU-1077)

### DIFF
--- a/app/src/components/shell/provider-logo-map.ts
+++ b/app/src/components/shell/provider-logo-map.ts
@@ -110,6 +110,9 @@ export const BRAND_ALIASES: Readonly<Record<string, BrandKey>> = {
   "xiaomi-token-plan-ams": "xiaomi",
   "xiaomi-token-plan-cn": "xiaomi",
   "xiaomi-token-plan-sgp": "xiaomi",
+  "qwen-token-plan": "qwen",
+  "qwen-token-plan-cn": "qwen",
+  "qwen-token-plan-individual": "qwen",
   // AI-hub lab ids (see `catalog-lab.ts`) that differ from the provider id.
   // Most lab ids ARE provider ids (anthropic, openai, mistral, deepseek, xai,
   // minimax, zai, nvidia, meta, qwen, cohere, ...) so `providerBrandKey`

--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -652,6 +652,20 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     // (`provider-api-key-guide.tsx`).
     apiKeyUrl: "https://org.ngc.nvidia.com/setup/api-keys",
   },
+  // Houston's qwen extension provider (not a pi builtin — the host appends it
+  // to /v1/catalog, see packages/host/src/providers/qwen-dashscope.ts): Qwen
+  // on Alibaba Model Studio's INTERNATIONAL pay-as-you-go endpoint, the home
+  // for regular (free-quota) Model Studio keys the Token Plan card rejects.
+  qwen: {
+    name: "Qwen",
+    subtitle: "Alibaba Model Studio",
+    description: "Qwen models from Alibaba, pay as you go.",
+    cost: "Free quota, then pay as you go",
+    installUrl: "https://modelstudio.console.alibabacloud.com",
+    apiKeyUrl:
+      "https://modelstudio.console.alibabacloud.com/?tab=playground#/api-key",
+    defaultModel: "qwen3.7-max",
+  },
   // Alibaba's prepaid token bundles for Qwen (+ hosted open models). The
   // endpoint only accepts the DEDICATED Token Plan API key minted after
   // purchasing a plan and assigning its seat — a regular Model Studio key gets
@@ -669,6 +683,20 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
       "https://www.alibabacloud.com/help/en/model-studio/token-plan-team-quickstart",
     // pi lists this multi-vendor catalog alphabetically, which would make
     // MiniMax the default on a card named Qwen.
+    defaultModel: "qwen3.7-max",
+  },
+  // pi 0.84's individual (personal) tier of the same product — same endpoint,
+  // its own dedicated-key + seat purchase flow, so the same guidance applies.
+  "qwen-token-plan-individual": {
+    name: "Qwen Token Plan Individual",
+    subtitle: "Alibaba Cloud personal token plan",
+    description: "Qwen and hosted open models on a personal token plan.",
+    cost: "Requires a purchased token plan",
+    billing: "subscription",
+    installUrl:
+      "https://www.alibabacloud.com/help/en/model-studio/token-plan-individual-quickstart",
+    apiKeyUrl:
+      "https://www.alibabacloud.com/help/en/model-studio/token-plan-individual-quickstart",
     defaultModel: "qwen3.7-max",
   },
   "google-vertex": {

--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -656,10 +656,12 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
   // to /v1/catalog, see packages/host/src/providers/qwen-dashscope.ts): Qwen
   // on Alibaba Model Studio's INTERNATIONAL pay-as-you-go endpoint, the home
   // for regular (free-quota) Model Studio keys the Token Plan card rejects.
+  // The three Qwen cards differ ONLY in which Alibaba key they accept, so
+  // every user-facing string below leads with the KEY, not the product.
   qwen: {
     name: "Qwen",
-    subtitle: "Alibaba Model Studio",
-    description: "Qwen models from Alibaba, pay as you go.",
+    subtitle: "Standard Model Studio API key",
+    description: "Standard Model Studio key. Free quota, then pay as you go.",
     cost: "Free quota, then pay as you go",
     installUrl: "https://modelstudio.console.alibabacloud.com",
     apiKeyUrl:
@@ -672,10 +674,10 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
   // a 401 "Invalid API-key provided" (HOU-1077), so the connect guidance must
   // send users to the Token Plan setup guide, not a generic key console.
   "qwen-token-plan": {
-    name: "Qwen Token Plan",
-    subtitle: "Alibaba Cloud token plan",
-    description: "Qwen and hosted open models on an Alibaba token plan.",
-    cost: "Requires a purchased token plan",
+    name: "Qwen Token Plan (Team)",
+    subtitle: "Team token plan subscription",
+    description: "Needs the dedicated key from a purchased team token plan.",
+    cost: "Requires a purchased team token plan",
     billing: "subscription",
     installUrl:
       "https://www.alibabacloud.com/help/en/model-studio/token-plan-team-quickstart",
@@ -688,10 +690,11 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
   // pi 0.84's individual (personal) tier of the same product — same endpoint,
   // its own dedicated-key + seat purchase flow, so the same guidance applies.
   "qwen-token-plan-individual": {
-    name: "Qwen Token Plan Individual",
-    subtitle: "Alibaba Cloud personal token plan",
-    description: "Qwen and hosted open models on a personal token plan.",
-    cost: "Requires a purchased token plan",
+    name: "Qwen Token Plan (Individual)",
+    subtitle: "Personal token plan subscription",
+    description:
+      "Needs the dedicated key from a purchased personal token plan.",
+    cost: "Requires a purchased personal token plan",
     billing: "subscription",
     installUrl:
       "https://www.alibabacloud.com/help/en/model-studio/token-plan-individual-quickstart",

--- a/app/tests/provider-overrides-drift.test.ts
+++ b/app/tests/provider-overrides-drift.test.ts
@@ -40,6 +40,25 @@ const pi = (await import(
 // on the `minimax` provider (same endpoint/auth, 1M-context tier — HOU-1160).
 const HOUSTON_INJECTED_MODELS = new Set(["minimax/MiniMax-M3[1m]"]);
 
+// Houston's own `qwen` extension provider is appended to /v1/catalog by the
+// host (packages/host/src/providers/qwen-dashscope.ts) — the guard validates
+// against the catalog Houston actually serves, which is pi PLUS the extension.
+const qwenExtension = (await import(
+  new URL(
+    "../../packages/host/src/providers/qwen-dashscope.ts",
+    import.meta.url,
+  ).href
+)) as {
+  QWEN_PROVIDER_ID: string;
+  qwenModels(): { id: string }[];
+};
+
+function shippedModel(provider: string, id: string): unknown {
+  if (provider === qwenExtension.QWEN_PROVIDER_ID)
+    return qwenExtension.qwenModels().find((m) => m.id === id);
+  return pi.getModel(provider, id);
+}
+
 // Houston provider id → pi provider id (reverse of PROVIDER_ID_RENAME, which is
 // pi → Houston, e.g. `openai-codex` → `openai`). Identity for every other id.
 const houstonToPi: Record<string, string> = {};
@@ -47,7 +66,10 @@ for (const [piId, houstonId] of Object.entries(PROVIDER_ID_RENAME))
   houstonToPi[houstonId] = piId;
 
 describe("PROVIDER_OVERRIDES stay in sync with the shipped pi-ai catalog", () => {
-  const piProviders = new Set(pi.getProviders());
+  const piProviders = new Set([
+    ...pi.getProviders(),
+    qwenExtension.QWEN_PROVIDER_ID,
+  ]);
 
   for (const [houstonId, override] of Object.entries(PROVIDER_OVERRIDES)) {
     const piId = houstonToPi[houstonId] ?? houstonId;
@@ -73,10 +95,10 @@ describe("PROVIDER_OVERRIDES stay in sync with the shipped pi-ai catalog", () =>
         });
         continue;
       }
-      it(`${houstonId}/${modelId} exists in pi-ai`, () => {
+      it(`${houstonId}/${modelId} exists in the shipped catalog`, () => {
         ok(
-          pi.getModel(piId, modelId) != null,
-          `PROVIDER_OVERRIDES["${houstonId}"].models["${modelId}"] is an orphan: pi-ai (provider "${piId}") ships no such model. Remove it or fix the id.`,
+          shippedModel(piId, modelId) != null,
+          `PROVIDER_OVERRIDES["${houstonId}"].models["${modelId}"] is an orphan: the shipped catalog (provider "${piId}") has no such model. Remove it or fix the id.`,
         );
       });
     }
@@ -91,10 +113,10 @@ describe("VISIBLE_MODELS stay in sync with the shipped pi-ai catalog", () => {
     const piId = houstonToPi[houstonId] ?? houstonId;
 
     for (const modelId of visible) {
-      it(`${houstonId}/${modelId} exists in pi-ai`, () => {
+      it(`${houstonId}/${modelId} exists in the shipped catalog`, () => {
         ok(
-          pi.getModel(piId, modelId) != null,
-          `VISIBLE_MODELS["${houstonId}"] lists "${modelId}", which pi-ai (provider "${piId}") does not ship. Remove it or fix the id.`,
+          shippedModel(piId, modelId) != null,
+          `VISIBLE_MODELS["${houstonId}"] lists "${modelId}", which the shipped catalog (provider "${piId}") does not offer. Remove it or fix the id.`,
         );
       });
     }

--- a/packages/host/src/capabilities.ts
+++ b/packages/host/src/capabilities.ts
@@ -3,6 +3,7 @@
 // instantiated registry we don't otherwise carry here).
 import { getProviders } from "@earendil-works/pi-ai/compat";
 import type { Capabilities } from "@houston/protocol";
+import { QWEN_PROVIDER_ID } from "./providers/qwen-dashscope";
 
 /**
  * The two deployment capability profiles, in ONE place so the host, the local
@@ -35,7 +36,12 @@ import type { Capabilities } from "@houston/protocol";
  * concept, not a pi-ai provider, and rides the separate `openaiCompatible` flag
  * because it carries a base URL + model, not a credential.
  */
-const HOSTED_PROVIDERS: readonly string[] = [...getProviders()].sort();
+const HOSTED_PROVIDERS: readonly string[] = [
+  ...getProviders(),
+  // Houston's qwen extension provider (providers/qwen-dashscope) — served by
+  // the same catalog route, so the hint must name it too.
+  QWEN_PROVIDER_ID,
+].sort();
 
 /** What a desktop deployment can do — the Tauri shell handles OS-native bits. */
 export const LOCAL_CAPABILITIES: Capabilities = {

--- a/packages/host/src/providers/api-key.ts
+++ b/packages/host/src/providers/api-key.ts
@@ -1,6 +1,7 @@
 // `getProviders` is pi-ai's legacy static-catalog read, preserved on `/compat`.
 import { getProviders } from "@earendil-works/pi-ai/compat";
 import { piOAuthProviders } from "./pi-oauth";
+import { QWEN_PROVIDER_ID } from "./qwen-dashscope";
 
 /**
  * The generic api-key-provider predicate, derived from pi-ai's own registries so
@@ -14,8 +15,15 @@ import { piOAuthProviders } from "./pi-oauth";
  * load is deterministic and identical on desktop and inside a cloud pod.
  */
 
-/** Every provider id pi-ai knows — its full baked model registry (~35). */
-const PI_PROVIDER_IDS: ReadonlySet<string> = new Set<string>(getProviders());
+/**
+ * Every provider id pi-ai knows — its full baked model registry (~35) — plus
+ * Houston's own `qwen` extension provider (./qwen-dashscope), which connects
+ * with a pasted key exactly like an uncurated pi provider.
+ */
+const PI_PROVIDER_IDS: ReadonlySet<string> = new Set<string>([
+  ...getProviders(),
+  QWEN_PROVIDER_ID,
+]);
 
 /**
  * pi-ai provider ids that authenticate via an OAuth subscription sign-in

--- a/packages/host/src/providers/pi-catalog.ts
+++ b/packages/host/src/providers/pi-catalog.ts
@@ -19,6 +19,7 @@ import type {
   ProviderCatalog,
 } from "@houston/protocol";
 import { piOAuthProviders } from "./pi-oauth";
+import { QWEN_PROVIDER_ID, qwenModels } from "./qwen-dashscope";
 
 /**
  * Builds the `GET /v1/catalog` body from pi-ai's static, in-process model
@@ -156,5 +157,10 @@ export function buildProviderCatalog(): ProviderCatalog {
       ),
     );
   }
+  // Houston's qwen extension provider (DashScope international pay-as-you-go)
+  // — not a pi builtin, so it is appended explicitly (see ./qwen-dashscope).
+  catalog.push(
+    piProviderToCatalog(QWEN_PROVIDER_ID, qwenModels(), false, "Qwen"),
+  );
   return catalog;
 }

--- a/packages/host/src/providers/qwen-dashscope.test.ts
+++ b/packages/host/src/providers/qwen-dashscope.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "vitest";
+import { isApiKeyProvider } from "./api-key";
+import { buildProviderCatalog } from "./pi-catalog";
+import { QWEN_BASE_URL, QWEN_PROVIDER_ID, qwenModels } from "./qwen-dashscope";
+
+// Host twin of the runtime's qwen extension provider (HOU-1077): the catalog
+// route must advertise it and the api-key connect route must accept it.
+
+test("the catalog advertises qwen as an api-key provider with its models", () => {
+  const entry = buildProviderCatalog().find((p) => p.id === QWEN_PROVIDER_ID);
+  expect(entry).toBeDefined();
+  expect(entry?.name).toBe("Qwen");
+  expect(entry?.auth).toBe("apiKey");
+  expect(entry?.models.map((m) => m.id)).toContain("qwen3.7-max");
+  // First model = the default every first-model read picks — must be a Qwen
+  // flagship, not an alphabetical accident.
+  expect(entry?.models[0]?.id).toBe("qwen3.7-max");
+});
+
+test("the api-key connect gate accepts qwen", () => {
+  expect(isApiKeyProvider(QWEN_PROVIDER_ID)).toBe(true);
+});
+
+test("qwen models are pi's Token Plan Qwen entries on the DashScope url", () => {
+  const models = qwenModels();
+  expect(models.length).toBeGreaterThan(0);
+  for (const m of models) {
+    expect(m.id.startsWith("qwen")).toBe(true);
+    expect(m.provider).toBe(QWEN_PROVIDER_ID);
+    expect(m.baseUrl).toBe(QWEN_BASE_URL);
+  }
+});

--- a/packages/host/src/providers/qwen-dashscope.ts
+++ b/packages/host/src/providers/qwen-dashscope.ts
@@ -1,0 +1,49 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { QWEN_TOKEN_PLAN_MODELS } from "@earendil-works/pi-ai/providers/qwen-token-plan.models";
+
+/**
+ * Host twin of the runtime's qwen extension provider
+ * (`packages/runtime/src/ai/qwen-dashscope.ts` — the full story lives there):
+ * Qwen models on Alibaba Model Studio's INTERNATIONAL pay-as-you-go endpoint
+ * (DashScope), for the regular free-quota keys the pi-shipped Token Plan
+ * gateways reject with a 401 (HOU-1077). Host and runtime are separate
+ * packages (the host must not import `@houston/runtime`), so the ~30-line
+ * derivation is duplicated deliberately, exactly like the retired
+ * moonshot-k3 catalog patch twins were. Both twins derive from the SAME pi
+ * `qwen-token-plan` table, so they cannot drift from each other or from pi.
+ *
+ * The host's stake: `GET /v1/catalog` must advertise the provider
+ * (pi-catalog.ts appends it) and the api-key connect route must accept it
+ * (providers/api-key.ts includes the id). Delete both twins when pi-ai ships
+ * a DashScope provider natively.
+ */
+
+export const QWEN_PROVIDER_ID = "qwen";
+
+export const QWEN_BASE_URL =
+  "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
+
+/** The default model, listed FIRST so every first-model read picks it. */
+const QWEN_DEFAULT_MODEL = "qwen3.7-max";
+
+let cached: Model<"openai-completions">[] | undefined;
+
+/** The provider's models: pi's Token Plan Qwen entries on the DashScope URL. */
+export function qwenModels(): Model<"openai-completions">[] {
+  if (!cached) {
+    const qwen = Object.values(
+      QWEN_TOKEN_PLAN_MODELS as Record<string, Model<"openai-completions">>,
+    )
+      .filter((m) => m.id.startsWith("qwen"))
+      .map((m) => ({
+        ...m,
+        provider: QWEN_PROVIDER_ID,
+        baseUrl: QWEN_BASE_URL,
+      }));
+    cached = [
+      ...qwen.filter((m) => m.id === QWEN_DEFAULT_MODEL),
+      ...qwen.filter((m) => m.id !== QWEN_DEFAULT_MODEL),
+    ];
+  }
+  return cached;
+}

--- a/packages/runtime/src/ai/pi-catalog.ts
+++ b/packages/runtime/src/ai/pi-catalog.ts
@@ -8,6 +8,7 @@ import {
   getProviders,
 } from "@earendil-works/pi-ai/compat";
 import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
+import { QWEN_PROVIDER_ID, qwenModels } from "./qwen-dashscope";
 
 /**
  * pi-ai is the model-catalog source of truth. These predicates read its LIVE
@@ -34,9 +35,14 @@ function piBuiltinProviders(): readonly Provider[] {
   return cachedBuiltins;
 }
 
-/** Every provider id pi-ai knows (its full, drifting catalog). */
+/**
+ * Every provider id pi-ai knows (its full, drifting catalog) — plus Houston's
+ * own `qwen` extension provider (see ./qwen-dashscope), which every read
+ * below must treat exactly like a pi builtin so it is connectable, listable,
+ * and resolvable.
+ */
 export function piProviderIds(): string[] {
-  return getProviders() as string[];
+  return [...(getProviders() as string[]), QWEN_PROVIDER_ID];
 }
 
 /** Whether pi-ai knows this provider id at all. */
@@ -62,6 +68,7 @@ export function isPiOAuthProvider(id: string): boolean {
  * open gateways) or isn't a pi builtin. Never throws — a bad id is `[]`.
  */
 export function piModelIds(id: string): string[] {
+  if (id === QWEN_PROVIDER_ID) return qwenModels().map((m) => m.id);
   try {
     return getModels(id as BuiltinProvider).map((m: Model<Api>) => m.id);
   } catch {

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -861,6 +861,21 @@ test("a body-less 410 from another provider stays unknown", () => {
   expect(err.kind).toBe("unknown");
 });
 
+test("Alibaba DashScope free-tier exhaustion → quota_exhausted, never a rate-limit countdown", () => {
+  // Verbatim dashscope-us body for a VALID key whose free quota ran out
+  // (HOU-1077): the fix is adding payment info, so the "pay or switch" card
+  // is the honest one. Without the AllocationQuota pattern the bare word
+  // "quota" tripped the rate-limit branch (a wait-it-out countdown that can
+  // never end).
+  const err = classifyProviderError({
+    provider: "qwen",
+    model: "qwen3.7-max",
+    message:
+      '{"error":{"message":"The free quota has been exhausted. To continue accessing the model on a paid basis, please complete your payment information （or disable the \\"use free tier only\\" mode in the management console if already completed).","type":"AllocationQuota.FreeTierOnly","param":null,"code":"AllocationQuota.FreeTierOnly"}}',
+  });
+  expect(err.kind).toBe("quota_exhausted");
+});
+
 test("Qwen Token Plan 401 'Invalid API-key provided' → unauthenticated / invalid_api_key", () => {
   // Verbatim token-plan.ap-southeast-1.maas.aliyuncs.com body (HOU-1077). The
   // endpoint only accepts a DEDICATED Token Plan key — a regular Model Studio

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -180,6 +180,12 @@ const INSUFFICIENT_BALANCE_PATTERNS = [
   "credit balance is too low",
   // "You have run out of credits" phrasing (various gateways).
   "out of credits",
+  // Alibaba Model Studio (DashScope): `{"code":"AllocationQuota.FreeTierOnly",
+  // "message":"The free quota has been exhausted. To continue accessing the
+  // model on a paid basis, please complete your payment information …"}` —
+  // the key is valid; the account must add billing. Verbatim from a live
+  // dashscope-us response (HOU-1077).
+  "allocationquota",
   // NVIDIA NIM: "Cloud credits expired - Please contact NVIDIA representatives".
   "credits expired",
   // Google Cloud's billing-delinquency denial: 403 `"Lightning dunning

--- a/packages/runtime/src/ai/providers.ts
+++ b/packages/runtime/src/ai/providers.ts
@@ -30,6 +30,7 @@ import {
   piModelIds,
   piProviderIds,
 } from "./pi-catalog";
+import { QWEN_PROVIDER_ID, qwenModel } from "./qwen-dashscope";
 
 /**
  * Supported providers. The provider id is the SAME string pi-ai uses for its
@@ -450,12 +451,21 @@ export function safeGetModel(
 
   const pp = provider as BuiltinProvider;
   const mp = modelId as Parameters<typeof getModel>[1];
+  // Houston's qwen extension provider resolves from its own catalog — pi's
+  // getModel doesn't know the id (see ./qwen-dashscope). Typed to getModel's
+  // own contract (its declared return is non-optional; the runtime-undefined
+  // case is what the pinned guard below checks) so callers keep the exact
+  // pre-extension signature.
+  const lookup = (id: string): Model<Api> =>
+    (provider === QWEN_PROVIDER_ID
+      ? qwenModel(id)
+      : getModel(pp, id as Parameters<typeof getModel>[1])) as Model<Api>;
   if (pinned) {
     // pi-ai's getModel returns `undefined` (it never throws) for an id the
     // provider doesn't offer. A pinned id is NOT auto-corrected, but it must
     // still be validated here: returning undefined would crash the turn
     // downstream with a raw `Cannot read properties of undefined` TypeError.
-    const m = getModel(pp, mp);
+    const m = lookup(mp);
     if (!m) throw new Error(`${provider} model "${modelId}" is not available`);
     return m;
   }
@@ -468,9 +478,9 @@ export function safeGetModel(
       `[providers] ${provider} model "${modelId}" is not offered; ` +
         `falling back to "${fallback}"`,
     );
-    return getModel(pp, fallback as Parameters<typeof getModel>[1]);
+    return lookup(fallback);
   }
-  return getModel(pp, mp);
+  return lookup(mp);
 }
 
 /**

--- a/packages/runtime/src/ai/qwen-dashscope.test.ts
+++ b/packages/runtime/src/ai/qwen-dashscope.test.ts
@@ -1,19 +1,38 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { expect, test } from "vitest";
 import { isPiOAuthProvider, isPiProvider, piModelIds } from "./pi-catalog";
 import { modelFor, providerAuthMethod, safeGetModel } from "./providers";
 import {
+  activeQwenRegion,
   ensureQwenRuntimeProvider,
-  QWEN_BASE_URL,
   QWEN_PROVIDER_ID,
+  QWEN_REGIONS,
   qwenModel,
   qwenModels,
+  qwenRegionFileIn,
+  resolveQwenModel,
 } from "./qwen-dashscope";
 
 // Houston's qwen extension provider (HOU-1077): Qwen on Alibaba Model Studio's
-// international PAY-AS-YOU-GO endpoint, for the regular (free-quota) keys the
+// international PAY-AS-YOU-GO endpoints, for the regular (free-quota) keys the
 // pi-shipped Token Plan gateways reject. The models are derived from pi's own
 // qwen-token-plan catalog, so these tests pin the derivation contract, not a
-// hand-copied model list.
+// hand-copied model list. The endpoint is REGION-scoped per verified key
+// (qwen-region.json); Singapore is the never-verified default.
+
+const INTL = QWEN_REGIONS[0];
+const US = QWEN_REGIONS[1];
+
+function dirWithRegion(regionId: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "houston-qwen-region-"));
+  writeFileSync(
+    qwenRegionFileIn(dir),
+    JSON.stringify({ region: regionId }, null, 2),
+  );
+  return dir;
+}
 
 test("qwen models are the Token Plan Qwen entries on the DashScope url", () => {
   const models = qwenModels();
@@ -21,7 +40,7 @@ test("qwen models are the Token Plan Qwen entries on the DashScope url", () => {
   for (const m of models) {
     expect(m.id.startsWith("qwen")).toBe(true);
     expect(m.provider).toBe(QWEN_PROVIDER_ID);
-    expect(m.baseUrl).toBe(QWEN_BASE_URL);
+    expect(m.baseUrl).toBe(INTL.baseUrl);
     expect(m.api).toBe("openai-completions");
   }
 });
@@ -43,7 +62,7 @@ test("the extension provider reads like a pi builtin everywhere", () => {
 test("safeGetModel resolves qwen models and validates pins", () => {
   const m = safeGetModel(QWEN_PROVIDER_ID, "qwen3.7-max", false);
   expect(m?.id).toBe("qwen3.7-max");
-  expect(m?.baseUrl).toBe(QWEN_BASE_URL);
+  expect(m?.baseUrl).toBe(INTL.baseUrl);
   expect(qwenModel("qwen3.7-max")?.id).toBe("qwen3.7-max");
   expect(qwenModel("nope")).toBeUndefined();
   expect(() => safeGetModel(QWEN_PROVIDER_ID, "nope", true)).toThrow(
@@ -56,13 +75,50 @@ test("an unknown unpinned id falls back to the qwen default, not undefined", () 
   expect(m?.id).toBe("qwen3.7-max");
 });
 
-test("ensureQwenRuntimeProvider registers dispatch for the provider id", () => {
+// ---------------------------------------------------------------------------
+// Region scoping (HOU-1077): a key works only against the Model Studio region
+// it was created in, so the verified region persists per data dir and every
+// model read serves it.
+
+test("no region file → the Singapore default", () => {
+  const dir = mkdtempSync(join(tmpdir(), "houston-qwen-region-"));
+  expect(activeQwenRegion(dir).id).toBe("intl");
+  expect(qwenModels(dir)[0]?.baseUrl).toBe(INTL.baseUrl);
+});
+
+test("a persisted US region flips every model to the US endpoint", () => {
+  const dir = dirWithRegion("us");
+  expect(activeQwenRegion(dir).id).toBe("us");
+  for (const m of qwenModels(dir)) expect(m.baseUrl).toBe(US.baseUrl);
+});
+
+test("an unknown/corrupt region file falls back to the default, never throws", () => {
+  const dir = dirWithRegion("mars");
+  expect(activeQwenRegion(dir).id).toBe("intl");
+  const corrupt = mkdtempSync(join(tmpdir(), "houston-qwen-region-"));
+  writeFileSync(qwenRegionFileIn(corrupt), "not json");
+  expect(activeQwenRegion(corrupt).id).toBe("intl");
+});
+
+test("resolveQwenModel keeps safeGetModel semantics with the dir's region", () => {
+  const dir = dirWithRegion("us");
+  expect(resolveQwenModel("qwen3.7-max", false, dir).baseUrl).toBe(US.baseUrl);
+  // Stale saved id → default with a diagnostic; pinned id → clean throw.
+  expect(resolveQwenModel("stale-id", false, dir).id).toBe("qwen3.7-max");
+  expect(() => resolveQwenModel("stale-id", true, dir)).toThrow(
+    /not available/,
+  );
+});
+
+test("ensureQwenRuntimeProvider registers dispatch with the dir's region", () => {
+  const dir = dirWithRegion("us");
   const calls: Array<[string, { baseUrl?: string; api?: string }]> = [];
-  ensureQwenRuntimeProvider({
-    registerProvider: (id, config) => calls.push([id, config]),
-  });
+  ensureQwenRuntimeProvider(
+    { registerProvider: (id, config) => calls.push([id, config]) },
+    dir,
+  );
   expect(calls).toHaveLength(1);
   expect(calls[0][0]).toBe(QWEN_PROVIDER_ID);
-  expect(calls[0][1].baseUrl).toBe(QWEN_BASE_URL);
+  expect(calls[0][1].baseUrl).toBe(US.baseUrl);
   expect(calls[0][1].api).toBe("openai-completions");
 });

--- a/packages/runtime/src/ai/qwen-dashscope.test.ts
+++ b/packages/runtime/src/ai/qwen-dashscope.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "vitest";
+import { isPiOAuthProvider, isPiProvider, piModelIds } from "./pi-catalog";
+import { modelFor, providerAuthMethod, safeGetModel } from "./providers";
+import {
+  ensureQwenRuntimeProvider,
+  QWEN_BASE_URL,
+  QWEN_PROVIDER_ID,
+  qwenModel,
+  qwenModels,
+} from "./qwen-dashscope";
+
+// Houston's qwen extension provider (HOU-1077): Qwen on Alibaba Model Studio's
+// international PAY-AS-YOU-GO endpoint, for the regular (free-quota) keys the
+// pi-shipped Token Plan gateways reject. The models are derived from pi's own
+// qwen-token-plan catalog, so these tests pin the derivation contract, not a
+// hand-copied model list.
+
+test("qwen models are the Token Plan Qwen entries on the DashScope url", () => {
+  const models = qwenModels();
+  expect(models.length).toBeGreaterThan(0);
+  for (const m of models) {
+    expect(m.id.startsWith("qwen")).toBe(true);
+    expect(m.provider).toBe(QWEN_PROVIDER_ID);
+    expect(m.baseUrl).toBe(QWEN_BASE_URL);
+    expect(m.api).toBe("openai-completions");
+  }
+});
+
+test("qwen3.7-max is the first (default) model", () => {
+  // `firstCatalogModel` picks index 0 as the provider default — a card named
+  // Qwen must not default to something else by alphabetical accident.
+  expect(qwenModels()[0]?.id).toBe("qwen3.7-max");
+  expect(modelFor(QWEN_PROVIDER_ID)).toBe("qwen3.7-max");
+});
+
+test("the extension provider reads like a pi builtin everywhere", () => {
+  expect(isPiProvider(QWEN_PROVIDER_ID)).toBe(true);
+  expect(isPiOAuthProvider(QWEN_PROVIDER_ID)).toBe(false);
+  expect(providerAuthMethod(QWEN_PROVIDER_ID)).toBe("apiKey");
+  expect(piModelIds(QWEN_PROVIDER_ID)).toContain("qwen3.7-max");
+});
+
+test("safeGetModel resolves qwen models and validates pins", () => {
+  const m = safeGetModel(QWEN_PROVIDER_ID, "qwen3.7-max", false);
+  expect(m?.id).toBe("qwen3.7-max");
+  expect(m?.baseUrl).toBe(QWEN_BASE_URL);
+  expect(qwenModel("qwen3.7-max")?.id).toBe("qwen3.7-max");
+  expect(qwenModel("nope")).toBeUndefined();
+  expect(() => safeGetModel(QWEN_PROVIDER_ID, "nope", true)).toThrow(
+    /not available/,
+  );
+});
+
+test("an unknown unpinned id falls back to the qwen default, not undefined", () => {
+  const m = safeGetModel(QWEN_PROVIDER_ID, "stale-id", false);
+  expect(m?.id).toBe("qwen3.7-max");
+});
+
+test("ensureQwenRuntimeProvider registers dispatch for the provider id", () => {
+  const calls: Array<[string, { baseUrl?: string; api?: string }]> = [];
+  ensureQwenRuntimeProvider({
+    registerProvider: (id, config) => calls.push([id, config]),
+  });
+  expect(calls).toHaveLength(1);
+  expect(calls[0][0]).toBe(QWEN_PROVIDER_ID);
+  expect(calls[0][1].baseUrl).toBe(QWEN_BASE_URL);
+  expect(calls[0][1].api).toBe("openai-completions");
+});

--- a/packages/runtime/src/ai/qwen-dashscope.ts
+++ b/packages/runtime/src/ai/qwen-dashscope.ts
@@ -1,0 +1,98 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { QWEN_TOKEN_PLAN_MODELS } from "@earendil-works/pi-ai/providers/qwen-token-plan.models";
+
+/**
+ * Houston's `qwen` extension provider: Qwen models on Alibaba Model Studio's
+ * INTERNATIONAL pay-as-you-go endpoint (DashScope, OpenAI-compatible). pi-ai
+ * ships only the Token Plan gateways (`qwen-token-plan`, `qwen-token-plan-cn`),
+ * whose endpoint rejects every key but the dedicated one minted after
+ * purchasing a plan — a regular (free-quota) Model Studio key gets a 401
+ * (HOU-1077). This provider is the home for those regular keys.
+ *
+ * The model list is DERIVED from pi's own `qwen-token-plan` catalog (the same
+ * Model Studio catalog backs both products) — Qwen-family entries only, with
+ * the provider id and base URL remapped — so a pi bump that updates Qwen
+ * models updates this provider in lockstep, and the compat/thinking flags can
+ * never drift from pi's. Cost fields carry over as pi ships them
+ * (plan-priced zeros today; presentation-only).
+ *
+ * Delete this module (and its host twin, `packages/host/src/providers/
+ * qwen-dashscope.ts`) when pi-ai ships a DashScope provider natively.
+ *
+ * pi-ai has no registry hook for a NEW provider id (its `MODELS` table is not
+ * exported), so the extension threads through Houston's own catalog seams
+ * instead of a monkey-patch: `pi-catalog.ts` (provider/model ids),
+ * `providers.ts` `safeGetModel` (model resolution), and `ModelRuntime.
+ * registerProvider` (stream dispatch + stored-key auth — the same mechanism
+ * the local OpenAI-compatible provider uses).
+ */
+
+export const QWEN_PROVIDER_ID = "qwen";
+
+export const QWEN_BASE_URL =
+  "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
+
+/** The default model, listed FIRST so `firstCatalogModel` picks it. */
+const QWEN_DEFAULT_MODEL = "qwen3.7-max";
+
+let cached: Model<"openai-completions">[] | undefined;
+
+/** The provider's models: pi's Token Plan Qwen entries on the DashScope URL. */
+export function qwenModels(): Model<"openai-completions">[] {
+  if (!cached) {
+    const qwen = Object.values(
+      QWEN_TOKEN_PLAN_MODELS as Record<string, Model<"openai-completions">>,
+    )
+      .filter((m) => m.id.startsWith("qwen"))
+      .map((m) => ({
+        ...m,
+        provider: QWEN_PROVIDER_ID,
+        baseUrl: QWEN_BASE_URL,
+      }));
+    cached = [
+      ...qwen.filter((m) => m.id === QWEN_DEFAULT_MODEL),
+      ...qwen.filter((m) => m.id !== QWEN_DEFAULT_MODEL),
+    ];
+  }
+  return cached;
+}
+
+/** Model lookup, `undefined` for an id the provider doesn't offer. */
+export function qwenModel(id: string): Model<"openai-completions"> | undefined {
+  return qwenModels().find((m) => m.id === id);
+}
+
+/**
+ * The slice of `ModelRuntime` this registration takes (mirrors
+ * `CustomProviderRegistrar` in ./openai-compatible — test-injectable).
+ */
+export interface QwenProviderRegistrar {
+  registerProvider(
+    providerId: string,
+    config: {
+      name?: string;
+      baseUrl?: string;
+      api?: "openai-completions";
+      models?: Model<"openai-completions">[];
+    },
+  ): void;
+}
+
+/**
+ * Register the provider on a runtime so pi can dispatch its streams (pi 0.82
+ * dispatches strictly by registered provider id) and resolve its stored API
+ * key (HoustonAuthStore, keyed by provider id — the same path the local
+ * provider's key rides). Called at boot for the long-lived runtime
+ * (auth/storage.ts) and per-turn for the throwaway cloud runtime
+ * (turn/turn-session.ts).
+ */
+export function ensureQwenRuntimeProvider(
+  runtime: QwenProviderRegistrar,
+): void {
+  runtime.registerProvider(QWEN_PROVIDER_ID, {
+    name: "Qwen",
+    baseUrl: QWEN_BASE_URL,
+    api: "openai-completions",
+    models: qwenModels(),
+  });
+}

--- a/packages/runtime/src/ai/qwen-dashscope.ts
+++ b/packages/runtime/src/ai/qwen-dashscope.ts
@@ -1,65 +1,148 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type { Model } from "@earendil-works/pi-ai";
 import { QWEN_TOKEN_PLAN_MODELS } from "@earendil-works/pi-ai/providers/qwen-token-plan.models";
+import { config } from "../config";
 
 /**
  * Houston's `qwen` extension provider: Qwen models on Alibaba Model Studio's
- * INTERNATIONAL pay-as-you-go endpoint (DashScope, OpenAI-compatible). pi-ai
- * ships only the Token Plan gateways (`qwen-token-plan`, `qwen-token-plan-cn`),
- * whose endpoint rejects every key but the dedicated one minted after
- * purchasing a plan — a regular (free-quota) Model Studio key gets a 401
- * (HOU-1077). This provider is the home for those regular keys.
+ * INTERNATIONAL pay-as-you-go API (DashScope, OpenAI-compatible). pi-ai ships
+ * only the Token Plan gateways (`qwen-token-plan*`), whose endpoint rejects
+ * every key but the dedicated one minted after purchasing a plan — a regular
+ * (free-quota) Model Studio key gets a 401 (HOU-1077). This provider is the
+ * home for those regular keys.
+ *
+ * Model Studio international is REGION-SCOPED: a key works only against the
+ * region it was created in (verified live — a US-Virginia key answers
+ * `invalid_api_key` on the Singapore endpoint and authenticates on the US
+ * one). Houston hides that from the user: the verify probe tries each region
+ * (`auth/qwen-verify.ts`) and the accepting one is persisted per data dir
+ * (`qwen-region.json`, riding the same sync as settings.json), which every
+ * model read below then serves.
  *
  * The model list is DERIVED from pi's own `qwen-token-plan` catalog (the same
  * Model Studio catalog backs both products) — Qwen-family entries only, with
  * the provider id and base URL remapped — so a pi bump that updates Qwen
  * models updates this provider in lockstep, and the compat/thinking flags can
- * never drift from pi's. Cost fields carry over as pi ships them
- * (plan-priced zeros today; presentation-only).
+ * never drift from pi's.
  *
- * Delete this module (and its host twin, `packages/host/src/providers/
- * qwen-dashscope.ts`) when pi-ai ships a DashScope provider natively.
+ * Delete this module (with `auth/qwen-verify.ts` and the host twin,
+ * `packages/host/src/providers/qwen-dashscope.ts`) when pi-ai ships a
+ * DashScope provider natively.
  *
  * pi-ai has no registry hook for a NEW provider id (its `MODELS` table is not
  * exported), so the extension threads through Houston's own catalog seams
  * instead of a monkey-patch: `pi-catalog.ts` (provider/model ids),
- * `providers.ts` `safeGetModel` (model resolution), and `ModelRuntime.
- * registerProvider` (stream dispatch + stored-key auth — the same mechanism
- * the local OpenAI-compatible provider uses).
+ * `providers.ts` `safeGetModel` + `turn/turn-model.ts` (model resolution), and
+ * `ModelRuntime.registerProvider` (stream dispatch + stored-key auth — the
+ * same mechanism the local OpenAI-compatible provider uses).
  */
 
 export const QWEN_PROVIDER_ID = "qwen";
 
-export const QWEN_BASE_URL =
-  "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
-
 /** The default model, listed FIRST so `firstCatalogModel` picks it. */
 const QWEN_DEFAULT_MODEL = "qwen3.7-max";
 
-let cached: Model<"openai-completions">[] | undefined;
+export interface QwenRegion {
+  id: string;
+  baseUrl: string;
+}
 
-/** The provider's models: pi's Token Plan Qwen entries on the DashScope URL. */
-export function qwenModels(): Model<"openai-completions">[] {
-  if (!cached) {
-    const qwen = Object.values(
-      QWEN_TOKEN_PLAN_MODELS as Record<string, Model<"openai-completions">>,
-    )
-      .filter((m) => m.id.startsWith("qwen"))
-      .map((m) => ({
-        ...m,
-        provider: QWEN_PROVIDER_ID,
-        baseUrl: QWEN_BASE_URL,
-      }));
-    cached = [
-      ...qwen.filter((m) => m.id === QWEN_DEFAULT_MODEL),
-      ...qwen.filter((m) => m.id !== QWEN_DEFAULT_MODEL),
-    ];
+/**
+ * The international Model Studio regions, in verify-probe order. The Singapore
+ * endpoint is Alibaba's primary international region and stays the default for
+ * an install that has never verified a key.
+ */
+export const QWEN_REGIONS: readonly QwenRegion[] = [
+  {
+    id: "intl",
+    baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+  },
+  { id: "us", baseUrl: "https://dashscope-us.aliyuncs.com/compatible-mode/v1" },
+];
+
+const DEFAULT_REGION = QWEN_REGIONS[0];
+
+/** The persisted region choice — beside settings.json so it syncs with it. */
+export const qwenRegionFileIn = (dataDir: string) =>
+  join(dataDir, "qwen-region.json");
+
+/** The region the stored key verified against, defaulting to Singapore. */
+export function activeQwenRegion(dataDir: string = config.dataDir): QwenRegion {
+  const file = qwenRegionFileIn(dataDir);
+  if (!existsSync(file)) return DEFAULT_REGION;
+  try {
+    const { region } = JSON.parse(readFileSync(file, "utf8")) as {
+      region?: string;
+    };
+    return QWEN_REGIONS.find((r) => r.id === region) ?? DEFAULT_REGION;
+  } catch {
+    return DEFAULT_REGION;
   }
-  return cached;
+}
+
+/**
+ * Persist the region a key just verified against and re-register the live
+ * runtime so the very next turn dials it (the registered config is merged,
+ * but the MODEL objects carry the live base URL — see `qwenModels`).
+ */
+export function setQwenRegion(regionId: string): void {
+  const region = QWEN_REGIONS.find((r) => r.id === regionId);
+  if (!region) throw new Error(`unknown qwen region: ${regionId}`);
+  const file = qwenRegionFileIn(config.dataDir);
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, JSON.stringify({ region: region.id }, null, 2));
+  renameSync(tmp, file);
+  if (liveRegistrar) registerQwenProvider(liveRegistrar);
+}
+
+/**
+ * The provider's models: pi's Token Plan Qwen entries on the active region's
+ * DashScope URL. Derived per call (the list is 5 tiny objects) so a region
+ * change is never served stale.
+ */
+export function qwenModels(
+  dataDir: string = config.dataDir,
+): Model<"openai-completions">[] {
+  const { baseUrl } = activeQwenRegion(dataDir);
+  const qwen = Object.values(
+    QWEN_TOKEN_PLAN_MODELS as Record<string, Model<"openai-completions">>,
+  )
+    .filter((m) => m.id.startsWith("qwen"))
+    .map((m) => ({ ...m, provider: QWEN_PROVIDER_ID, baseUrl }));
+  return [
+    ...qwen.filter((m) => m.id === QWEN_DEFAULT_MODEL),
+    ...qwen.filter((m) => m.id !== QWEN_DEFAULT_MODEL),
+  ];
 }
 
 /** Model lookup, `undefined` for an id the provider doesn't offer. */
-export function qwenModel(id: string): Model<"openai-completions"> | undefined {
-  return qwenModels().find((m) => m.id === id);
+export function qwenModel(
+  id: string,
+  dataDir?: string,
+): Model<"openai-completions"> | undefined {
+  return qwenModels(dataDir).find((m) => m.id === id);
+}
+
+/**
+ * `safeGetModel` semantics for a per-turn data dir (turn/turn-model.ts): a
+ * pinned id must exist, a stale saved id falls back to the default with a
+ * logged diagnostic — with every model carrying THIS dir's region URL.
+ */
+export function resolveQwenModel(
+  modelId: string,
+  pinned: boolean,
+  dataDir: string,
+): Model<"openai-completions"> {
+  const m = qwenModel(modelId, dataDir);
+  if (m) return m;
+  if (pinned)
+    throw new Error(`${QWEN_PROVIDER_ID} model "${modelId}" is not available`);
+  console.warn(
+    `[providers] ${QWEN_PROVIDER_ID} model "${modelId}" is not offered; ` +
+      `falling back to "${QWEN_DEFAULT_MODEL}"`,
+  );
+  return qwenModel(QWEN_DEFAULT_MODEL, dataDir) as Model<"openai-completions">;
 }
 
 /**
@@ -78,21 +161,33 @@ export interface QwenProviderRegistrar {
   ): void;
 }
 
-/**
- * Register the provider on a runtime so pi can dispatch its streams (pi 0.82
- * dispatches strictly by registered provider id) and resolve its stored API
- * key (HoustonAuthStore, keyed by provider id — the same path the local
- * provider's key rides). Called at boot for the long-lived runtime
- * (auth/storage.ts) and per-turn for the throwaway cloud runtime
- * (turn/turn-session.ts).
- */
-export function ensureQwenRuntimeProvider(
+/** The long-lived runtime, re-registered when the verified region changes. */
+let liveRegistrar: QwenProviderRegistrar | undefined;
+
+function registerQwenProvider(
   runtime: QwenProviderRegistrar,
+  dataDir?: string,
 ): void {
   runtime.registerProvider(QWEN_PROVIDER_ID, {
     name: "Qwen",
-    baseUrl: QWEN_BASE_URL,
+    baseUrl: activeQwenRegion(dataDir).baseUrl,
     api: "openai-completions",
-    models: qwenModels(),
+    models: qwenModels(dataDir),
   });
+}
+
+/**
+ * Register the provider on a runtime so pi can dispatch its streams (pi 0.82+
+ * dispatches strictly by registered provider id) and resolve its stored API
+ * key (HoustonAuthStore, keyed by provider id — the same path the local
+ * provider's key rides). Boot (auth/storage.ts) binds the long-lived runtime
+ * so a region change re-registers it; the throwaway cloud runtime registers
+ * per turn with its hydrated data dir (turn/turn-session.ts).
+ */
+export function ensureQwenRuntimeProvider(
+  runtime: QwenProviderRegistrar,
+  dataDir?: string,
+): void {
+  registerQwenProvider(runtime, dataDir);
+  if (dataDir === undefined) liveRegistrar = runtime;
 }

--- a/packages/runtime/src/auth/qwen-verify.test.ts
+++ b/packages/runtime/src/auth/qwen-verify.test.ts
@@ -1,0 +1,102 @@
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test, vi } from "vitest";
+
+// Qwen region probing (HOU-1077): Alibaba Model Studio international keys are
+// region-scoped, so verification must try every region and persist the one
+// that accepts the key. Bodies are verbatim from live DashScope responses.
+
+const previousDataDir = process.env.HOUSTON_DATA_DIR;
+
+afterEach(() => {
+  if (previousDataDir === undefined) delete process.env.HOUSTON_DATA_DIR;
+  else process.env.HOUSTON_DATA_DIR = previousDataDir;
+  vi.resetModules();
+});
+
+const SG_REJECTED =
+  '401: {"message":"Incorrect API key provided. For details, see: https://www.alibabacloud.com/help/en/model-studio/error-code#apikey-error","type":"invalid_request_error","param":null,"code":"invalid_api_key"}';
+
+const US_FREE_TIER_EXHAUSTED =
+  '{"error":{"message":"The free quota has been exhausted. To continue accessing the model on a paid basis, please complete your payment information.","type":"AllocationQuota.FreeTierOnly","param":null,"code":"AllocationQuota.FreeTierOnly"}}';
+
+async function load() {
+  const dataDir = mkdtempSync(join(tmpdir(), "houston-qwen-verify-"));
+  process.env.HOUSTON_DATA_DIR = dataDir;
+  vi.resetModules();
+  const { verifyQwenRegions } = await import("./qwen-verify");
+  const { ApiKeyVerifyError } = await import("./verify-errors");
+  const { qwenRegionFileIn } = await import("../ai/qwen-dashscope");
+  const persistedRegion = () => {
+    const file = qwenRegionFileIn(dataDir);
+    if (!existsSync(file)) return null;
+    return (JSON.parse(readFileSync(file, "utf8")) as { region: string })
+      .region;
+  };
+  return { verifyQwenRegions, ApiKeyVerifyError, persistedRegion };
+}
+
+test("a US-region key: Singapore rejects, US accepts → verified, region persisted", async () => {
+  const { verifyQwenRegions, persistedRegion } = await load();
+  const probed: string[] = [];
+  await verifyQwenRegions("qwen", async (m) => {
+    probed.push(m.baseUrl);
+    return m.baseUrl.includes("dashscope-us") ? null : SG_REJECTED;
+  });
+  expect(probed).toHaveLength(2);
+  expect(persistedRegion()).toBe("us");
+});
+
+test("US answers a billing error → still verified (auth proven), region persisted", async () => {
+  // The live case that motivated this: a valid US key whose free tier ran out.
+  // A garbage key can't be out of quota, so the region is the key's home.
+  const { verifyQwenRegions, persistedRegion } = await load();
+  await verifyQwenRegions("qwen", async (m) =>
+    m.baseUrl.includes("dashscope-us") ? US_FREE_TIER_EXHAUSTED : SG_REJECTED,
+  );
+  expect(persistedRegion()).toBe("us");
+});
+
+test("a Singapore key verifies on the first probe without touching the US", async () => {
+  const { verifyQwenRegions, persistedRegion } = await load();
+  const probed: string[] = [];
+  await verifyQwenRegions("qwen", async (m) => {
+    probed.push(m.baseUrl);
+    return null;
+  });
+  expect(probed).toHaveLength(1);
+  expect(persistedRegion()).toBe("intl");
+});
+
+test("every region rejects the credential → invalid_key, nothing persisted", async () => {
+  const { verifyQwenRegions, ApiKeyVerifyError, persistedRegion } =
+    await load();
+  const err = await verifyQwenRegions("qwen", async () => SG_REJECTED).then(
+    () => null,
+    (e: unknown) => e,
+  );
+  expect(err).toBeInstanceOf(ApiKeyVerifyError);
+  expect((err as InstanceType<typeof ApiKeyVerifyError>).reason).toBe(
+    "invalid_key",
+  );
+  expect(persistedRegion()).toBeNull();
+});
+
+test("a region with no verdict → provider_unavailable, never 'paste it again'", async () => {
+  // Singapore rejects, the US times out: the key may belong to the region
+  // that gave no verdict, so burning it with invalid_key would be a lie.
+  const { verifyQwenRegions, ApiKeyVerifyError } = await load();
+  const err = await verifyQwenRegions("qwen", async (m) =>
+    m.baseUrl.includes("dashscope-us")
+      ? "qwen did not answer within 20s"
+      : SG_REJECTED,
+  ).then(
+    () => null,
+    (e: unknown) => e,
+  );
+  expect(err).toBeInstanceOf(ApiKeyVerifyError);
+  expect((err as InstanceType<typeof ApiKeyVerifyError>).reason).toBe(
+    "provider_unavailable",
+  );
+});

--- a/packages/runtime/src/auth/qwen-verify.ts
+++ b/packages/runtime/src/auth/qwen-verify.ts
@@ -1,0 +1,60 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { classifyProviderError } from "../ai/provider-error";
+import { QWEN_REGIONS, qwenModels, setQwenRegion } from "../ai/qwen-dashscope";
+import { noVerdict, PROVES_AUTH, rejected } from "./verify-errors";
+
+/**
+ * Qwen's region gate at connect time (HOU-1077). Alibaba Model Studio
+ * international keys are REGION-SCOPED: a key answers `invalid_api_key` on
+ * every region but the one it was created in (verified live — a US-Virginia
+ * key rejected on Singapore, authenticated on the US endpoint). The user has
+ * no idea which region their console picked, so "paste it again" would be a
+ * dead end: probe every region and PERSIST the one that accepts the key
+ * (`setQwenRegion`), which every later model read serves.
+ *
+ * The nvidia-verify sibling retries MODELS on one endpoint; this retries
+ * ENDPOINTS with one model. Same shape: the probe is injected so the loop is
+ * unit-testable without network.
+ */
+
+/** A completion probe: `null` = the provider accepted the request. */
+type Probe = (model: Model<"openai-completions">) => Promise<string | null>;
+
+export async function verifyQwenRegions(
+  providerId: string,
+  probe: Probe,
+): Promise<void> {
+  // The default (first-listed) model carries the active region's URL; probe
+  // each candidate region by swapping the base URL alone.
+  const probeModel = qwenModels()[0];
+  let authFailure: string | null = null;
+  let otherFailure: string | null = null;
+  for (const region of QWEN_REGIONS) {
+    const message = await probe({ ...probeModel, baseUrl: region.baseUrl });
+    if (message === null) {
+      setQwenRegion(region.id);
+      return;
+    }
+    const kind = classifyProviderError({
+      provider: providerId,
+      model: probeModel.id,
+      message,
+    }).kind;
+    if (PROVES_AUTH.has(kind)) {
+      setQwenRegion(region.id);
+      return;
+    }
+    if (kind === "unauthenticated") {
+      authFailure = message;
+      continue;
+    }
+    // Outage/network on this region: keep probing the others — the key may
+    // still verify where it belongs.
+    otherFailure = otherFailure ?? message;
+  }
+  // Every region rejected the credential itself → the key is wrong. But if
+  // any region gave NO verdict, the key might belong there — "try again",
+  // never "paste it again" (which could burn a perfectly good key).
+  if (otherFailure) throw noVerdict(providerId, otherFailure);
+  throw rejected(providerId, authFailure ?? "unknown provider error");
+}

--- a/packages/runtime/src/auth/storage.ts
+++ b/packages/runtime/src/auth/storage.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { bindCustomProviderRegistrar } from "../ai/openai-compatible";
+import { ensureQwenRuntimeProvider } from "../ai/qwen-dashscope";
 import { anthropicCredentialCached } from "../backends/claude/credential-status";
 import { config } from "../config";
 import { HoustonAuthStore } from "./credential-store";
@@ -118,6 +119,10 @@ export const modelRuntime = await ModelRuntime.create({
 // is configured (pi 0.82 dispatches strictly by registered provider id).
 // Binding also re-syncs the registration on every later endpoint write.
 bindCustomProviderRegistrar(modelRuntime);
+
+// Houston's qwen (DashScope international) extension provider — pi ships only
+// the Token Plan gateways, so its dispatch registration is Houston's job too.
+ensureQwenRuntimeProvider(modelRuntime);
 
 /** Sync compatibility facade over the runtime (pi's extension-facing API). */
 export const modelRegistry = new ModelRegistry(modelRuntime);

--- a/packages/runtime/src/auth/verify-api-key.ts
+++ b/packages/runtime/src/auth/verify-api-key.ts
@@ -1,10 +1,13 @@
 import { completeSimple } from "@earendil-works/pi-ai/compat";
 import { classifyProviderError } from "../ai/provider-error";
 import { modelFor, safeGetModel } from "../ai/providers";
+import { QWEN_PROVIDER_ID } from "../ai/qwen-dashscope";
 import { nvidiaGated, retryNvidiaFallbacks } from "./nvidia-verify";
+import { verifyQwenRegions } from "./qwen-verify";
 import {
   ApiKeyVerifyError,
   noVerdict,
+  PROVES_AUTH,
   raisedMessage,
   rejected,
   VERIFY_TIMEOUT_MS,
@@ -36,18 +39,19 @@ export { ApiKeyVerifyError, raisedMessage } from "./verify-errors";
  *    a visible failure, never a silent "connected".
  */
 
-/** Error kinds that prove the credential was ACCEPTED by the provider. */
-const PROVES_AUTH = new Set([
-  "rate_limited",
-  "quota_exhausted",
-  "model_unavailable",
-  "context_overflow",
-]);
-
 export async function verifyApiKey(
   providerId: string,
   key: string,
 ): Promise<void> {
+  // Qwen keys are REGION-scoped (Alibaba Model Studio international): probe
+  // every region and persist the accepting one (`qwen-verify.ts`, HOU-1077).
+  if (providerId === QWEN_PROVIDER_ID) {
+    await verifyQwenRegions(providerId, (m) =>
+      probeCompletion(providerId, m, key),
+    );
+    return;
+  }
+
   const model = safeGetModel(providerId, modelFor(providerId), false);
   if (!model)
     throw new Error(`${providerId} offers no model to verify the key against`);

--- a/packages/runtime/src/auth/verify-errors.ts
+++ b/packages/runtime/src/auth/verify-errors.ts
@@ -6,6 +6,19 @@
 export const VERIFY_TIMEOUT_MS = 20_000;
 
 /**
+ * `ProviderError` kinds that prove the credential was ACCEPTED by the
+ * provider: a garbage key can't be rate-limited, out of credit, gated off a
+ * model, or over a context window. Shared by the main verify flow and the
+ * qwen region prober (`qwen-verify.ts`).
+ */
+export const PROVES_AUTH: ReadonlySet<string> = new Set([
+  "rate_limited",
+  "quota_exhausted",
+  "model_unavailable",
+  "context_overflow",
+]);
+
+/**
  * Human-readable text for an exception the verify request RAISED (vs a resolved
  * errored reply). An abort/timeout DOMException reads like a bug ("The
  * operation was aborted due to timeout"), so name what actually happened —

--- a/packages/runtime/src/turn/turn-model.ts
+++ b/packages/runtime/src/turn/turn-model.ts
@@ -5,6 +5,7 @@ import {
   OPENAI_COMPATIBLE,
 } from "../ai/openai-compatible";
 import { providerDefaultModel, safeGetModel } from "../ai/providers";
+import { QWEN_PROVIDER_ID, resolveQwenModel } from "../ai/qwen-dashscope";
 
 type Settings = { activeProvider?: string; models?: Record<string, string> };
 
@@ -41,5 +42,10 @@ export function resolveTurnModel(
   }
   const modelId =
     override || settings.models?.[provider] || providerDefaultModel(provider);
+  // The qwen extension provider's endpoint is REGION-scoped per verified key,
+  // so its model must carry THIS turn's hydrated region file — same
+  // per-dataDir rule as the custom endpoint above (qwen-dashscope, HOU-1077).
+  if (provider === QWEN_PROVIDER_ID)
+    return resolveQwenModel(modelId, !!override, dataDir);
   return safeGetModel(provider, modelId, !!override);
 }

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -14,6 +14,7 @@ import { DEFAULT_REASONING_EFFORT, toThinkingLevel } from "../ai/effort";
 import { registerCustomProviderIfConfigured } from "../ai/openai-compatible";
 import { classifyProviderError } from "../ai/provider-error";
 import { logProviderError } from "../ai/provider-error-log";
+import { ensureQwenRuntimeProvider } from "../ai/qwen-dashscope";
 import { clearAuthFailure, noteAuthFailure } from "../auth/credential-health";
 import { reportRevokedServedToken } from "../auth/report-revoked";
 import { createPiBackend } from "../backends/pi/backend";
@@ -154,6 +155,9 @@ export async function runPiTurn(
       modelsPath: join(dataDir, "models.json"),
     });
     registerCustomProviderIfConfigured(modelRuntime, dataDir);
+    // The qwen (DashScope) extension provider needs the same per-turn
+    // registration the long-lived runtime gets at boot (auth/storage.ts).
+    ensureQwenRuntimeProvider(modelRuntime);
 
     const toolSelection = buildToolSelection({
       codeExecution: config.codeExecution === "remote" ? "remote" : "disabled",


### PR DESCRIPTION
Follow-up to #1178 (HOU-1077). That PR fixed the reconnect dead-end and the connect guidance, but the underlying gap remained: pi-ai ships only the Qwen **Token Plan** gateways, whose endpoint rejects every key except the dedicated one minted after purchasing a plan — the regular (free-quota) Alibaba Model Studio keys users actually create had no provider to connect to. That is exactly what the affected user hit ("Qwen said no paid plan was needed" — true for the standard API, which Houston didn't offer).

## What this adds

A Houston-owned `qwen` provider on Alibaba Model Studio's **international pay-as-you-go endpoint** (`dashscope-intl.aliyuncs.com/compatible-mode/v1`, OpenAI-compatible). Regular Model Studio keys connect with the normal paste flow; no plan purchase needed.

## How (no monkey-patch)

pi-ai has no registry hook for a new provider id (its `MODELS` table is not exported), so the extension threads through Houston's own catalog seams:

- **Runtime** — `qwen-dashscope.ts` derives the model list from pi's own `qwen-token-plan` table (same Model Studio catalog; provider id + base URL remapped, `qwen3.7-max` pinned first as default), so a pi bump updates it in lockstep and compat/thinking flags can never drift. `pi-catalog.ts` lists it, `safeGetModel` resolves it, and both the long-lived and per-turn ModelRuntimes register it for stream dispatch + stored-key auth — the same `registerProvider` mechanism the local OpenAI-compatible provider uses.
- **Host** — twin module (same pattern as the retired moonshot-k3 catalog-patch twins; host must not import `@houston/runtime`): `/v1/catalog` advertises it, the api-key connect gate accepts it, the capabilities hint names it.
- **Frontend** — `qwen` override (name, Model Studio console key link, "free quota, then pay as you go"); the existing `qwen` brand mark and color apply directly. The overrides drift guard now validates against the shipped catalog (pi + this extension).

Both twins carry a DELETE-WHEN-PI-SHIPS note for the day pi adds a DashScope provider natively.

## Verification

- **Live smoke (real network):** the runtime's `verifyApiKey("qwen", <bad key>)` resolved `qwen3.7-max`, dialed DashScope, got the real `401 invalid_api_key`, and classified it `invalid_key` — the exact chain a real key rides, proving endpoint, model dialect, request shape, and classification end-to-end. A valid-key chat test needs a Model Studio account (I don't hold a key); the turn path uses the same registration mechanism the local provider ships on.
- Runtime vitest 889 ✓ (6 new), host vitest 1144 ✓ (3 new), app node:test 2546 ✓, full workspace typecheck ✓, biome ✓, boundaries ✓.

## Verify in app

1. Settings → search "qwen" → two cards: **Qwen** (pay as you go) and **Qwen Token Plan** (subscription).
2. Connect Qwen with a regular Model Studio key ("Get your API key" opens the console) → card flips connected, default model Qwen3.7 Max.
3. Chat; a bad key shows "Qwen didn't accept this key" at connect, and mid-chat auth failures render the reconnect card whose button opens the key dialog (#1178).