### PR TITLE
fix(app): offline gateway bursts surface one connectivity toast, not bug toasts + Sentry noise (HOU-1085)

### DIFF
--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -370,7 +370,10 @@ export function classifyAnalyticsError(message: string): string {
   if (
     lower.includes("network") ||
     lower.includes("fetch") ||
-    lower.includes("timeout")
+    lower.includes("timeout") ||
+    // WebKit's transport-failure message (HOU-1085) names neither "network"
+    // nor "fetch" — without this line an offline burst classifies as unknown.
+    lower.includes("load failed")
   )
     return "network";
   if (lower.includes("permission") || lower.includes("denied"))

--- a/app/src/lib/error-toast.ts
+++ b/app/src/lib/error-toast.ts
@@ -83,6 +83,34 @@ export function showExpectedStateToast(
   useUIStore.getState().addToast({ title, description, variant: "info" });
 }
 
+/**
+ * Surface a transport-level network failure (device offline, host unreachable
+ * — HOU-1085) as ONE informational connectivity toast. A connectivity drop
+ * fails every live query at once, so the toast dedupes on its (constant)
+ * displayed body: the burst reads as one problem. No Sentry capture and no
+ * green "report sent" toast — nothing in Houston broke and there is nothing
+ * for us to fix; the raw diagnostic still reaches the frontend log via the
+ * caller's `logger.error` plus the `[toast:…]` line here. The analytics event
+ * fires only past the dedupe, mirroring `showErrorToast`.
+ */
+export function showConnectivityErrorToast(
+  command: string,
+  message: string,
+): void {
+  console.error(`[toast:${command}] ${message}`);
+  const description = i18n.t("shell:errorToast.offlineDescription");
+  if (isDuplicateToast(description, Date.now())) return;
+  analytics.track("app_error_shown", {
+    source: command,
+    error_kind: classifyAnalyticsError(message),
+  });
+  useUIStore.getState().addToast({
+    title: i18n.t("shell:errorToast.offlineTitle"),
+    description,
+    variant: "info",
+  });
+}
+
 export function showErrorToast(
   command: string,
   message: string,

--- a/app/src/lib/network-transport-error.ts
+++ b/app/src/lib/network-transport-error.ts
@@ -1,0 +1,36 @@
+// The "is this failure just connectivity?" classifier for the error-surfacing
+// layer. Dependency-free so it is node-testable directly
+// (app/tests/network-transport-error.test.ts) and importable from anywhere.
+//
+// Distinct from `isTransientEngineError` (the retry classifier): that one asks
+// "worth another attempt?" and matches ANY TypeError. This one gates the
+// bug-report surface (red toast + Sentry), so it must NEVER match a coding-bug
+// TypeError ("undefined is not a function") — it keys on the small fixed set of
+// messages browsers use for fetch transport failures.
+
+/**
+ * The messages `fetch` transport rejections carry, per engine:
+ *  - WebKit (our Tauri webview): "Load failed", sometimes suffixed with the
+ *    host — "Load failed (gateway.gethouston.ai)" — plus the CFNetwork
+ *    phrasings older WebKits surface ("The network connection was lost.",
+ *    "The Internet connection appears to be offline.", "A server with the
+ *    specified hostname could not be found.", "Could not connect to the
+ *    server.", "The request timed out.").
+ *  - Chromium: "Failed to fetch".
+ *  - Firefox: "NetworkError when attempting to fetch resource.".
+ *  - Node/undici (web dev, tests): "fetch failed".
+ */
+const TRANSPORT_MESSAGE =
+  /^load failed|^failed to fetch|^networkerror|^fetch failed|network connection was lost|internet connection appears to be offline|hostname could not be found|could not connect to the server|request timed out/i;
+
+/**
+ * A transport-level network failure: the device is offline or the host is
+ * unreachable, and the request never produced a response. Browsers report
+ * every such failure as a `TypeError` with an engine-specific message
+ * (HOU-1085: a sleep-wake burst fails every live gateway query at once with
+ * WebKit's "Load failed"). These are an expected, explainable environment
+ * state — surfaced as a connectivity toast, never the red bug pair + Sentry.
+ */
+export function isNetworkTransportError(err: unknown): boolean {
+  return err instanceof TypeError && TRANSPORT_MESSAGE.test(err.message);
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -51,6 +51,7 @@ import { isUploadTooLargeError } from "./files-upload-limits";
 import i18n from "./i18n";
 import { logger } from "./logger";
 import { isMissingSkillError } from "./missing-skill";
+import { isNetworkTransportError } from "./network-transport-error";
 import { osIsTauri, osPickDirectory } from "./os-bridge";
 import { normalizeLegacyModel } from "./providers";
 import { isNeedsUpgradeError, isPersonalSpaceError } from "./team-status-model";
@@ -203,6 +204,19 @@ async function surfaceError(
     options,
   );
   if (!shouldToast && !shouldCapture) return;
+
+  // Expected environment state, not a bug: a transport-level network failure
+  // (device offline / host unreachable — HOU-1085). A sleep-wake or network
+  // drop fails EVERY live gateway query at once with WebKit's "Load failed";
+  // that burst must read as one connectivity notice, not a storm of red bug
+  // toasts and a pile of un-actionable Sentry issues. The toast dedupes on its
+  // constant body; no Sentry capture — nothing in Houston broke, and the raw
+  // diagnostic is already in the log tail above.
+  if (isNetworkTransportError(err)) {
+    const { showConnectivityErrorToast } = await import("./error-toast");
+    showConnectivityErrorToast(label, message);
+    return;
+  }
 
   const [{ showErrorToast }, { reportError }] = await Promise.all([
     import("./error-toast"),

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -63,7 +63,9 @@
     "genericDescription": "Something unexpected went wrong. Please try again.",
     "reportSentTitle": "Houston, report sent",
     "reportSentDescription": "Reference #{{id}}.",
-    "copyId": "Copy code"
+    "copyId": "Copy code",
+    "offlineTitle": "Houston, connection lost",
+    "offlineDescription": "We can't reach Houston right now. Check your internet connection and try again."
   },
   "agentDelete": {
     "title": "Delete agent?",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -63,7 +63,9 @@
     "genericDescription": "Algo inesperado salió mal. Inténtalo de nuevo.",
     "reportSentTitle": "Houston, reporte enviado",
     "reportSentDescription": "Referencia #{{id}}.",
-    "copyId": "Copiar código"
+    "copyId": "Copiar código",
+    "offlineTitle": "Houston, sin conexión",
+    "offlineDescription": "No podemos conectarnos a Houston en este momento. Revisa tu conexión a internet e inténtalo de nuevo."
   },
   "agentDelete": {
     "title": "¿Eliminar el agente?",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -63,7 +63,9 @@
     "genericDescription": "Algo inesperado deu errado. Tente novamente.",
     "reportSentTitle": "Houston, relatório enviado",
     "reportSentDescription": "Referência #{{id}}.",
-    "copyId": "Copiar código"
+    "copyId": "Copiar código",
+    "offlineTitle": "Houston, sem conexão",
+    "offlineDescription": "Não conseguimos conectar ao Houston agora. Verifique sua conexão com a internet e tente novamente."
   },
   "agentDelete": {
     "title": "Excluir o agente?",

--- a/app/tests/error-toast-locale-shape.test.ts
+++ b/app/tests/error-toast-locale-shape.test.ts
@@ -27,4 +27,26 @@ describe("errorToast locale shape", () => {
       ok(!/engine error|fetch|http|\{/i.test(text));
     });
   }
+
+  // HOU-1085: the connectivity toast body has the same failure mode — a
+  // missing key would render `shell:errorToast.offlineDescription` verbatim to
+  // every offline user.
+  for (const locale of LOCALES) {
+    it(`${locale} has a usable errorToast offline pair`, () => {
+      const shell = JSON.parse(
+        readFileSync(
+          join(import.meta.dirname, `../src/locales/${locale}/shell.json`),
+          "utf8",
+        ),
+      ) as { errorToast?: Record<string, unknown> };
+      for (const key of ["offlineTitle", "offlineDescription"]) {
+        const value = shell.errorToast?.[key];
+        strictEqual(typeof value, "string");
+        const text = value as string;
+        ok(text.length > 0, "must not be empty");
+        ok(!text.includes("—"), "no em dashes in user-facing copy");
+        ok(!/engine error|fetch|http|\{/i.test(text));
+      }
+    });
+  }
 });

--- a/app/tests/network-transport-error.test.ts
+++ b/app/tests/network-transport-error.test.ts
@@ -1,0 +1,84 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { isNetworkTransportError } from "../src/lib/network-transport-error.ts";
+
+// HOU-1085: the surfacing-layer classifier that keeps connectivity drops out
+// of the red bug-toast + Sentry pipeline. It must catch every browser engine's
+// fetch transport message, and must NEVER catch a coding-bug TypeError — a
+// false positive here silently drops a real bug report.
+describe("isNetworkTransportError", () => {
+  it("matches WebKit's transport failures, with and without the host suffix", () => {
+    strictEqual(isNetworkTransportError(new TypeError("Load failed")), true);
+    strictEqual(
+      isNetworkTransportError(
+        new TypeError("Load failed (gateway.gethouston.ai)"),
+      ),
+      true,
+    );
+    strictEqual(
+      isNetworkTransportError(
+        new TypeError("The network connection was lost."),
+      ),
+      true,
+    );
+    strictEqual(
+      isNetworkTransportError(
+        new TypeError("The Internet connection appears to be offline."),
+      ),
+      true,
+    );
+    strictEqual(
+      isNetworkTransportError(
+        new TypeError(
+          "A server with the specified hostname could not be found.",
+        ),
+      ),
+      true,
+    );
+    strictEqual(
+      isNetworkTransportError(
+        new TypeError("Could not connect to the server."),
+      ),
+      true,
+    );
+    strictEqual(
+      isNetworkTransportError(new TypeError("The request timed out.")),
+      true,
+    );
+  });
+
+  it("matches Chromium, Firefox and undici transport failures", () => {
+    strictEqual(
+      isNetworkTransportError(new TypeError("Failed to fetch")),
+      true,
+    );
+    strictEqual(
+      isNetworkTransportError(
+        new TypeError("NetworkError when attempting to fetch resource."),
+      ),
+      true,
+    );
+    strictEqual(isNetworkTransportError(new TypeError("fetch failed")), true);
+  });
+
+  it("never matches a coding-bug TypeError", () => {
+    strictEqual(
+      isNetworkTransportError(new TypeError("undefined is not a function")),
+      false,
+    );
+    strictEqual(
+      isNetworkTransportError(
+        new TypeError("Cannot read properties of undefined"),
+      ),
+      false,
+    );
+  });
+
+  it("requires the TypeError shape — same message on other errors stays a bug", () => {
+    strictEqual(isNetworkTransportError(new Error("Load failed")), false);
+    strictEqual(isNetworkTransportError("Load failed"), false);
+    strictEqual(isNetworkTransportError({ status: 503 }), false);
+    strictEqual(isNetworkTransportError(null), false);
+    strictEqual(isNetworkTransportError(undefined), false);
+  });
+});

--- a/packages/web/src/engine-adapter/client/project-files-mixin.ts
+++ b/packages/web/src/engine-adapter/client/project-files-mixin.ts
@@ -1,5 +1,4 @@
 import type { ProjectFile } from "../../../../../ui/engine-client/src/types";
-import { HoustonEngineError } from "../client/errors";
 import * as controlPlane from "../control-plane";
 import type { BaseCtor } from "./mixin";
 
@@ -26,6 +25,9 @@ export function ProjectFilesMixin<TBase extends BaseCtor>(Base: TBase) {
     // In cloud mode the workspace is a GCS prefix served by the control plane at
     // /agents/:id/files*. agentPath IS the agentId here (folderPath = agent.id).
     // In synthetic/local web mode there is no real workspace, so these are inert.
+    // Routed through cpFetch so reads ride the same transient-retry path as
+    // every other control-plane call (HOU-1085: a bare gatewayAuthFetch here
+    // gave files listings zero retries through a brief network blip).
     private async cpFilesFetch(
       agentId: string,
       path: string,
@@ -33,23 +35,11 @@ export function ProjectFilesMixin<TBase extends BaseCtor>(Base: TBase) {
     ): Promise<Response> {
       if (!this.ctx.cp)
         throw new Error("cpFilesFetch called without a control-plane config");
-      const cp = this.ctx.cp;
-      const res = await controlPlane.gatewayAuthFetch(
-        cp.token,
-        () => cp.activeOrgSlug,
-      )(`${cp.baseUrl}/agents/${encodeURIComponent(agentId)}/${path}`, {
-        ...init,
-        headers: {
-          "Content-Type": "application/json",
-          ...init?.headers,
-        },
-      });
-      if (!res.ok)
-        throw new HoustonEngineError(
-          res.status,
-          await res.json().catch(() => ({})),
-        );
-      return res;
+      return controlPlane.cpFetch(
+        this.ctx.cp,
+        `/agents/${encodeURIComponent(agentId)}/${path}`,
+        init,
+      );
     }
     async listProjectFiles(agentPath: string): Promise<ProjectFile[]> {
       if (!this.ctx.cp) return [];


### PR DESCRIPTION
## Problem

Sentry: https://houston-cd.sentry.io/issues/7555911741/ — `list_project_files: Load failed (gateway.gethouston.ai)`, **1,272 events / 132 users** since June 16.

When the device loses connectivity (sleep-wake, network change, DNS drop), every live gateway query fails at once with WebKit's transport `TypeError` ("Load failed" — the host suffix is WebKit's own wording; breadcrumbs show 14+ gateway GETs failing in the same millisecond). Each failing `call()` in `app/src/lib/tauri.ts` then ran the full "Houston bug" surface: red "we have a problem" toast + green "report sent" + Sentry capture. Sentry groups per command label, so this issue is just the `list_project_files` slice of a whole family of connectivity noise.

Being offline is an expected, explainable environment state — exactly the existing `showExpectedStateToast` carve-out (`needs_upgrade`, `personal_space`), not a bug to report.

## Fix

- **`isNetworkTransportError`** (new `app/src/lib/network-transport-error.ts`): surfacing-layer classifier for fetch transport TypeErrors. Matches the fixed per-engine message set (WebKit "Load failed" + CFNetwork phrasings, Chromium "Failed to fetch", Firefox "NetworkError…", undici "fetch failed") and never a coding-bug TypeError — a false positive would silently drop a real bug report.
- **`surfaceError`** routes those to a new **`showConnectivityErrorToast`**: ONE deduped info toast ("We can't reach Houston right now. Check your internet connection and try again.", en/es/pt), `app_error_shown` analytics kept, **no Sentry capture**. Runs after `engineCallSurface`, so aborts and explicit toast+capture opt-outs keep their silence, and the raw diagnostic still reaches the frontend log.
- **`classifyAnalyticsError`** now classifies "load failed" as `network` (these events were tagged `error_kind: unknown`).
- **`cpFilesFetch`** (`project-files-mixin.ts`) now rides `cpFetch`, gaining the standard `transientRetryFetch` for files reads — it was the one control-plane path on a bare `gatewayAuthFetch` with zero retries through a brief blip. Behavior otherwise identical (same URL, headers, `HoustonEngineError` on non-2xx); writes still never blind-retry.

## Tests

- `app/tests/network-transport-error.test.ts`: per-engine matches incl. the host-suffixed WebKit form; coding-bug TypeErrors and non-TypeError shapes rejected.
- `app/tests/error-toast-locale-shape.test.ts`: offline title/body present + authored (no em dashes, no diagnostics) in all three locales.

## Gates

- `pnpm check` clean (Biome)
- `cd app && pnpm tsgo --noEmit` ✓, `pnpm check-locales` ✓ (23 namespaces in sync)
- `cd app && pnpm test` — 2,552 pass / 0 fail
- `pnpm --filter houston-web typecheck` ✓ (shim parity + tsgo)

Linear: HOU-1085