### PR TITLE
fix(web): no gateway calls without a session; web account-switch resets caches (HOU-1014)

### DIFF
--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -64,6 +64,19 @@ function cacheSession(session: Session | null): void {
   queryClient.setQueryData<Session | null>(SESSION_QUERY_KEY, session);
 }
 
+/**
+ * Session mirror for shells that own their own auth listener (web `CloudApp`
+ * and its `onIdTokenChanged` stream): routes an externally-observed session
+ * change through the same identity-change guard as the in-app flows, so an
+ * account switch on those shells drops the outgoing account's query cache and
+ * stores exactly like the desktop path does (HOU-903). Writing the session
+ * query directly would skip that guard and leak the previous account's world
+ * into the next sign-in.
+ */
+export function applyExternalSession(session: Session | null): void {
+  cacheSession(session);
+}
+
 // Public re-exports: the post-hand-off error bus (auth-error-bus.ts) and the
 // loopback-cancel seam (desktop-oauth.ts) the sign-in screen calls on unmount —
 // benign on web and when nothing is pending.

--- a/app/src/lib/error-toast.ts
+++ b/app/src/lib/error-toast.ts
@@ -1,3 +1,4 @@
+import { isSignedOutEngineError } from "@houston-ai/engine-client";
 import { useUIStore } from "../stores/ui";
 import { analytics, classifyAnalyticsError } from "./analytics";
 import i18n from "./i18n";
@@ -117,6 +118,16 @@ export function showErrorToast(
   originalError?: unknown,
   options?: ErrorToastOptions,
 ): void {
+  // A hosted call answered by the transport's synthetic signed-out 401 is an
+  // EXPECTED lifecycle state (sign-out / account switch): the sign-in screen is
+  // the surface, nothing is broken, and there is no bug to report — so no red
+  // toast and no Sentry capture. Everything else still surfaces loudly (beta
+  // policy); a REAL rejected bearer never takes this branch because the
+  // transport only mints the synthetic body when no session exists at all.
+  if (isSignedOutEngineError(originalError)) {
+    console.warn(`[toast:${command}] suppressed: signed-out engine call`);
+    return;
+  }
   const addToast = useUIStore.getState().addToast;
   const description =
     options?.userMessage ?? i18n.t("shell:errorToast.genericDescription");

--- a/packages/host/src/store-sync/shared-mirror.test.ts
+++ b/packages/host/src/store-sync/shared-mirror.test.ts
@@ -30,8 +30,12 @@ function memoryStore(initial: Record<string, string>) {
       await writeFile(destination, body);
     },
     async upload(source, key) {
+      // Read BEFORE recording: `eventually()` polls `uploads`, and recording
+      // first opens a window where the upload is visible but `objects` still
+      // holds the previous bytes — a flaky TOCTOU on slow runners.
+      const body = await readFile(source);
+      objects.set(key, body);
       uploads.push(key);
-      objects.set(key, await readFile(source));
     },
   };
   return { objects, store, uploads };

--- a/packages/web/src/cloud-login.tsx
+++ b/packages/web/src/cloud-login.tsx
@@ -1,9 +1,5 @@
-import {
-  identityConfig,
-  SESSION_QUERY_KEY,
-  type Session,
-} from "@houston/app/lib/identity";
-import { queryClient } from "@houston/app/lib/query-client";
+import { applyExternalSession } from "@houston/app/lib/auth";
+import { identityConfig, type Session } from "@houston/app/lib/identity";
 import {
   initWebAuth,
   webOnIdTokenChanged,
@@ -54,9 +50,14 @@ export function CloudApp({ controlPlaneUrl }: { controlPlaneUrl: string }) {
     // Mirror the live SDK session into the engine bearer AND the ["session"]
     // TanStack cache (the shared auth gate source). onIdTokenChanged fires on
     // sign-in, sign-out, and every silent refresh, so the bearer stays fresh.
+    // The session cache write goes through applyExternalSession — NOT a direct
+    // setQueryData — so a uid change (account switch) trips the HOU-903
+    // identity-change reset and the previous account's caches/stores are
+    // dropped before the new account's world loads. The bearer is applied
+    // FIRST so post-reset refetches already carry the new identity.
     const unsub = webOnIdTokenChanged((session: Session | null) => {
       apply(session?.idToken ?? "");
-      queryClient.setQueryData<Session | null>(SESSION_QUERY_KEY, session);
+      applyExternalSession(session);
     });
     // The 401 → refresh → replay seam (HOU-687): the adapter's gatewayAuthFetch
     // calls this to force-mint a fresh ID token when the gateway rejects the

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -17,7 +17,12 @@
  * TypeError instead of resolving to `[]`.
  */
 export type { HoustonClientOptions } from "./client/context";
-export { HoustonEngineError, isHoustonEngineError } from "./client/errors";
+export {
+  HoustonEngineError,
+  isHoustonEngineError,
+  isSignedOutEngineError,
+  SIGNED_OUT_ERROR,
+} from "./client/errors";
 export { isProviderLoginComplete } from "./client/provider-login-poll";
 
 import { ActivitiesMixin } from "./client/activities-mixin";

--- a/packages/web/src/engine-adapter/client/errors.ts
+++ b/packages/web/src/engine-adapter/client/errors.ts
@@ -39,3 +39,23 @@ export class HoustonEngineError extends Error {
 export function isHoustonEngineError(e: unknown): e is HoustonEngineError {
   return e instanceof HoustonEngineError;
 }
+
+/**
+ * The synthetic body `gatewayAuthFetch` answers with when a hosted call is
+ * attempted with no session at all (signed out, or mid account-switch). No
+ * network request is made for these.
+ */
+export const SIGNED_OUT_ERROR = "signed_out";
+
+/**
+ * True for the adapter's synthetic signed-out 401. Signed-out is an EXPECTED
+ * lifecycle state — the sign-in screen is the surface — so callers use this to
+ * skip the error-toast/report path a real failure would take.
+ */
+export function isSignedOutEngineError(e: unknown): boolean {
+  return (
+    isHoustonEngineError(e) &&
+    e.status === 401 &&
+    (e.body as { error?: unknown } | null)?.error === SIGNED_OUT_ERROR
+  );
+}

--- a/packages/web/src/engine-adapter/cp/fetch.ts
+++ b/packages/web/src/engine-adapter/cp/fetch.ts
@@ -1,4 +1,4 @@
-import { HoustonEngineError } from "../client/errors";
+import { HoustonEngineError, SIGNED_OUT_ERROR } from "../client/errors";
 import { refreshLiveToken } from "../session-refresh";
 import { appVersionHeader, noteUpgradeRequired } from "../update-floor";
 
@@ -44,6 +44,25 @@ export function liveToken(fallback: string): string {
   return fallback;
 }
 
+/** True in hosted control-plane mode (the cloud web app and the desktop cloud
+ *  profile both set the flag). Local hosts never set it, so the signed-out
+ *  short-circuit below cannot affect them. */
+const inControlPlaneMode = (): boolean =>
+  typeof window !== "undefined" &&
+  (window as { __HOUSTON_CP__?: boolean }).__HOUSTON_CP__ === true;
+
+/** The local answer for a hosted call attempted with no session: the same 401
+ *  shape a gateway rejection produces, minted WITHOUT a network round trip.
+ *  Signed-out is an expected lifecycle state (the sign-in screen is already the
+ *  surface), so hammering the gateway with unauthenticated requests would only
+ *  produce console/toast noise — and the error-toast layer recognizes this body
+ *  and stays quiet (HOU-1014). */
+const signedOutResponse = () =>
+  new Response(JSON.stringify({ error: SIGNED_OUT_ERROR }), {
+    status: 401,
+    headers: { "Content-Type": "application/json" },
+  });
+
 /**
  * A `fetch` for gateway calls that keeps auth invisible across cloud restarts
  * (HOU-687): the bearer is read LIVE per attempt (never a pinned copy), and a
@@ -51,6 +70,11 @@ export function liveToken(fallback: string): string {
  * token. A 401 that survives the refresh is returned as-is — a real sign-out
  * must surface, not spin. With no refresher installed (static tokens, tests)
  * the refresh resolves null and this degrades to a plain live-token fetch.
+ *
+ * With NO bearer at all in hosted mode the request is not sent: the refresher
+ * is asked once (bridging the boot race where queries fire before the restored
+ * session's token is mirrored), and when it confirms there is no session the
+ * call resolves to a synthetic signed-out 401 locally.
  */
 export function gatewayAuthFetch(
   fallbackToken: string,
@@ -74,10 +98,16 @@ export function gatewayAuthFetch(
       if (appVersion) headers.set("X-Houston-App-Version", appVersion);
       return fetch(input, { ...init, headers });
     };
+    const bearer = liveToken(fallbackToken);
+    if (!bearer && inControlPlaneMode()) {
+      const fresh = await refreshLiveToken();
+      if (!fresh) return signedOutResponse();
+      return noteUpgradeRequired(await send(fresh));
+    }
     // Every returned response passes noteUpgradeRequired: a gateway that
     // enforces the version floor answers ANY request with 426, and the desktop
     // shell must learn about it from whichever call happens to hit it first.
-    const res = await send(liveToken(fallbackToken));
+    const res = await send(bearer);
     if (res.status !== 401) return noteUpgradeRequired(res);
     const fresh = await refreshLiveToken();
     if (!fresh) return res;

--- a/packages/web/src/engine-adapter/index.ts
+++ b/packages/web/src/engine-adapter/index.ts
@@ -16,6 +16,8 @@ export {
   HoustonClient,
   HoustonEngineError,
   isHoustonEngineError,
+  isSignedOutEngineError,
+  SIGNED_OUT_ERROR,
 } from "./client";
 // Local conversation cache (HOU-712): sign-out wipes the per-user cached
 // transcripts so nothing lingers on a shared machine. The scope helper also

--- a/packages/web/tests/shim-report-bug.test.ts
+++ b/packages/web/tests/shim-report-bug.test.ts
@@ -137,7 +137,6 @@ test("report_bug refreshes and replays once on a 401", async () => {
 test("report_bug with no token yet still reaches the gateway after a refresh", async () => {
   setCloudWindow({ token: "", refresh: async () => "minted" });
   const calls = stubFetch(
-    json(401, { error: "unauthorized" }),
     json(200, {
       id: "HOU-3",
     }),
@@ -146,9 +145,10 @@ test("report_bug with no token yet still reaches the gateway after a refresh", a
   const id = await invoke<string | null>("report_bug", { payload: {} });
 
   expect(id).toBe("HOU-3");
-  // No bearer to send on the first attempt, so no Authorization header at all;
-  // the refresh mints one and the replay carries it.
-  expect(calls.map((c) => bearer(c.init))).toEqual([null, "Bearer minted"]);
+  // No bearer yet → the transport asks the refresher BEFORE sending, so no
+  // unauthenticated request goes out at all and the single attempt already
+  // carries the minted token (HOU-1014).
+  expect(calls.map((c) => bearer(c.init))).toEqual(["Bearer minted"]);
 });
 
 test("report_bug surfaces the gateway's reason when the refresh cannot save it", async () => {

--- a/packages/web/tests/signed-out-fetch.test.ts
+++ b/packages/web/tests/signed-out-fetch.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { isSignedOutEngineError } from "../src/engine-adapter/client";
+import { HoustonEngineError } from "../src/engine-adapter/client/errors";
+import { cpFetch } from "../src/engine-adapter/cp/fetch";
+
+/**
+ * HOU-1014: a hosted gateway call attempted with NO session must not go to the
+ * network — the sign-out / account-switch window used to fire every mounted
+ * query with an empty bearer, producing a storm of real 401s, red toasts, and
+ * Sentry reports for an expected lifecycle state. The transport now answers a
+ * synthetic signed-out 401 locally (after giving the refresher one chance to
+ * bridge the boot race), and the error is marked so the toast layer stays
+ * quiet. Local (non-control-plane) hosts are exempt — their token handling is
+ * unchanged.
+ */
+
+type TestWindow = {
+  __HOUSTON_CP__?: boolean;
+  __HOUSTON_SESSION_REFRESH__?: () => Promise<string | null>;
+};
+
+const originalFetch = globalThis.fetch;
+let calls: { url: string; auth: string | null }[];
+
+beforeEach(() => {
+  calls = [];
+  (globalThis as { window?: TestWindow }).window = { __HOUSTON_CP__: true };
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    calls.push({ url: String(input), auth: headers.get("Authorization") });
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete (globalThis as { window?: TestWindow }).window;
+  vi.restoreAllMocks();
+});
+
+const cfg = { baseUrl: "https://gw.test", token: "" };
+
+test("no session at all → synthetic signed-out 401, zero network calls", async () => {
+  const err = await cpFetch(cfg, "/v1/workspaces").catch((e: unknown) => e);
+  expect(err).toBeInstanceOf(HoustonEngineError);
+  expect((err as HoustonEngineError).status).toBe(401);
+  expect(isSignedOutEngineError(err)).toBe(true);
+  expect(calls).toHaveLength(0);
+});
+
+test("empty bearer but a live refresher (boot race) → one refreshed request", async () => {
+  (globalThis as { window?: TestWindow }).window = {
+    __HOUSTON_CP__: true,
+    __HOUSTON_SESSION_REFRESH__: () => Promise.resolve("fresh-token"),
+  };
+  const res = await cpFetch(cfg, "/v1/workspaces");
+  expect(res.status).toBe(200);
+  expect(calls).toHaveLength(1);
+  expect(calls[0].auth).toBe("Bearer fresh-token");
+});
+
+test("a real 401 from the gateway is NOT marked signed-out", async () => {
+  (globalThis as { window?: TestWindow }).window = {
+    __HOUSTON_CP__: true,
+    __HOUSTON_ENGINE__: { baseUrl: "https://gw.test", token: "expired" },
+  } as TestWindow;
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ error: "missing bearer token" }), {
+      status: 401,
+    })) as typeof fetch;
+  const err = await cpFetch(
+    { ...cfg, token: "expired" },
+    "/v1/workspaces",
+  ).catch((e: unknown) => e);
+  expect(err).toBeInstanceOf(HoustonEngineError);
+  expect((err as HoustonEngineError).status).toBe(401);
+  expect(isSignedOutEngineError(err)).toBe(false);
+});
+
+test("local (non-control-plane) host keeps its unauthenticated behavior", async () => {
+  (globalThis as { window?: TestWindow }).window = {};
+  const res = await cpFetch(cfg, "/v1/health");
+  expect(res.status).toBe(200);
+  expect(calls).toHaveLength(1);
+  expect(calls[0].auth).toBeNull();
+});

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -2741,3 +2741,22 @@ export class HoustonEngineError extends Error {
 export function isHoustonEngineError(e: unknown): e is HoustonEngineError {
   return e instanceof HoustonEngineError;
 }
+
+/**
+ * The synthetic body the hosted transport answers with when a gateway call is
+ * attempted with no session at all (signed out, or mid account-switch).
+ */
+export const SIGNED_OUT_ERROR = "signed_out";
+
+/**
+ * True for the transport's synthetic signed-out 401. Signed-out is an EXPECTED
+ * lifecycle state — the sign-in screen is the surface — so callers use this to
+ * skip the error-toast/report path a real failure would take.
+ */
+export function isSignedOutEngineError(e: unknown): boolean {
+  return (
+    isHoustonEngineError(e) &&
+    e.status === 401 &&
+    (e.body as { error?: unknown } | null)?.error === SIGNED_OUT_ERROR
+  );
+}


### PR DESCRIPTION
## Problem

Signing out (or switching accounts) on the hosted web app fired every mounted query with an empty bearer: a storm of real 401s in the console, red "we have a problem" toasts, and Sentry reports — for an expected lifecycle state where the sign-in screen is already the surface. After signing in as a DIFFERENT account, the client also kept querying the previous account's agents (stale cache), collecting 404s.

## Fix

Three seams, all centralized — no per-hook changes:

1. **Transport (`gatewayAuthFetch`)**: a hosted (control-plane-mode) call with NO bearer no longer goes to the network. The single-flight refresher gets one chance first — which bridges the boot race where queries beat the session mirror, and as a bonus removes the unauthenticated first request + 401 + replay dance on every cold boot — then the transport answers a synthetic `401 {error: "signed_out"}` locally. Local/self-host (non-CP) hosts are exempt.
2. **Toast layer**: `showErrorToast` recognizes the synthetic body via the new `isSignedOutEngineError` export and skips the red toast + Sentry pair (one quiet console line remains). A REAL rejected bearer can never take this branch — the synthetic body is only minted when no session exists at all, and a genuine gateway 401 keeps its normal loud path (pinned by test).
3. **Web account switch**: `CloudApp`'s session mirror now routes through the new `applyExternalSession` → `cacheSession` instead of writing the session query directly — so a uid change trips the existing HOU-903 identity-change reset on web exactly like desktop, and the previous account's query cache/stores are dropped before the new account's world loads.

`isSignedOutEngineError`/`SIGNED_OUT_ERROR` are exported from both the adapter and `ui/engine-client` (app typecheck resolves the package, runtime resolves the alias).

## Tests

- New `packages/web/tests/signed-out-fetch.test.ts`: signed-out → synthetic 401 + zero network calls; boot race → refresh-first single authenticated request; real gateway 401 NOT marked signed-out; non-CP hosts unchanged.
- `shim-report-bug.test.ts` no-token case re-pinned to the new refresh-first single-request behavior (previously asserted an unauthenticated first attempt).
- Full suites green: 305 web (vitest), 2552 app (node:test), all-package typecheck, Biome.

## Known residue (out of scope, noted for a follow-up)

- `/v1/integrations/session` + `/v1/integrations/custom/definitions` + per-agent `/providers` 404s in cloud mode: the client unconditionally calls routes only the desktop/self-host TS host implements; the Go gateway has none of them. Pre-existing, unrelated to auth.
- The adapter's per-agent runtime-client/SSE singletons are not torn down by the identity reset; if stale-agent traffic is still observed after this fix, that is the next place to look.