### PR TITLE
fix(docker): copy patches/ into root-context images so pnpm install survives patchedDependencies

### DIFF
--- a/packages/code-sandbox/Dockerfile
+++ b/packages/code-sandbox/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update \
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# pnpm hashes every patchedDependencies file at install time (even for
+# filtered installs), so patches/ must ship with the workspace manifests.
+COPY patches/ ./patches/
 COPY packages/code-sandbox/ ./packages/code-sandbox/
 RUN pnpm install --frozen-lockfile --prod --filter @houston/code-sandbox... \
     && chown -R node:node /app

--- a/packages/runtime/Dockerfile
+++ b/packages/runtime/Dockerfile
@@ -24,6 +24,9 @@ RUN corepack enable
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# pnpm hashes every patchedDependencies file at install time (even for
+# filtered installs), so patches/ must ship with the workspace manifests.
+COPY patches/ ./patches/
 COPY packages/protocol/ ./packages/protocol/
 COPY packages/runtime-client/ ./packages/runtime-client/
 COPY packages/runtime/ ./packages/runtime/

--- a/selfhost/Dockerfile
+++ b/selfhost/Dockerfile
@@ -30,6 +30,9 @@ RUN corepack enable
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# pnpm hashes every patchedDependencies file at install time (even for
+# filtered installs), so patches/ must ship with the workspace manifests.
+COPY patches/ /app/patches/
 COPY selfhost/bundle.mjs /app/selfhost/bundle.mjs
 COPY ui/agent-schemas/ /app/ui/agent-schemas/
 COPY packages/agentstore-contract/ /app/packages/agentstore-contract/
@@ -61,6 +64,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches/ /app/patches/
 COPY ui/agent-schemas/ /app/ui/agent-schemas/
 COPY packages/agentstore-contract/ /app/packages/agentstore-contract/
 COPY packages/protocol/ /app/packages/protocol/


### PR DESCRIPTION
## What

PR #1182 (HOU-1083) added a pnpm patch for `@executor-js/sdk@1.5.37` (`patches/@executor-js__sdk@1.5.37.patch`, referenced from `pnpm-workspace.yaml`). pnpm hashes every `patchedDependencies` file at the start of a `--frozen-lockfile` install, even when the patched package is outside the install filter, so every root-context Docker image that copies `pnpm-workspace.yaml` without `patches/` now fails with:

```
ENOENT: no such file or directory, open '/app/patches/@executor-js__sdk@1.5.37.patch'
```

This broke **Build & push engine-pod** on main (last two pushes), which in turn blocks the daily cloud cut's green-main guard — no new draft release can be cut until this lands.

## Fix

Add `COPY patches/` next to the workspace-manifest COPY in every affected Dockerfile:

- `selfhost/Dockerfile` — both stages (`bundle-builder` + `host-base`); this is the engine-pod image
- `packages/runtime/Dockerfile` — per-turn runtime image (same latent bug)
- `packages/code-sandbox/Dockerfile` — same latent bug

`agentstore/Dockerfile` (`COPY . .`) and `packages/web/Dockerfile` (no pnpm install) are unaffected. Root `.dockerignore` is denylist-style, so `patches/` reaches the build context.

## Verification

`docker build --target bundle-builder -f selfhost/Dockerfile .` — the exact stage that failed in CI — completes successfully with this change (it fails at `pnpm install` without it).