### PR TITLE
feat: personal-only AI accounts in team spaces

### DIFF
--- a/app/src/components/ai-hub/ai-hub-view.tsx
+++ b/app/src/components/ai-hub/ai-hub-view.tsx
@@ -6,23 +6,13 @@ import {
 } from "@houston-ai/core";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useCapabilities } from "../../hooks/use-capabilities";
 import { useProviderConnections } from "../../hooks/use-provider-connections";
 import type { CatalogModel } from "../../lib/ai-hub/catalog-types";
 import { searchModels } from "../../lib/ai-hub/search";
 import { useHubCatalog } from "../../lib/ai-hub/use-hub-catalog";
-import { newEngineActive } from "../../lib/engine";
-import { osIsTauri } from "../../lib/os-bridge";
-import {
-  EMPTY_PROVIDER_CAPABILITIES,
-  getConnectProviders,
-  type ProviderInfo,
-} from "../../lib/providers";
-import { searchProviders } from "../provider-browser/provider-filtering";
-import {
-  groupProviders,
-  providerOwnedSide,
-} from "../provider-browser/provider-grouping";
+import type { ProviderInfo } from "../../lib/providers";
+import { isTeamWorkspace } from "../../lib/space-id";
+import { useWorkspaceStore } from "../../stores/workspaces";
 import { PageContainer } from "../shell/page-shell";
 import { ConnectedProvidersStrip } from "./connected-providers-strip";
 import { HubHero } from "./hub-hero";
@@ -30,16 +20,20 @@ import { HubModalStack } from "./hub-modal-stack";
 import { HubSkeleton } from "./hub-skeleton";
 import { ModelDirectory } from "./model-directory";
 import { ProvidersPane } from "./providers-pane";
+import { useHubProviders } from "./use-hub-providers";
 
 /**
  * The AI models hub: a top-level marketplace surface in the shared
  * {@link CatalogShell} grammar (the same layout as the Integrations page) —
- * the hero, then ONE search field over everything, the consolidated
- * **Connected** strip of provider rows OUTSIDE the tabs (a row opens that
- * provider's modal), then the **Available** discovery tabs with live count
- * chips: **Providers** ({@link ProvidersPane}: the not-yet-connected catalog)
- * and **Models** (the cross-provider directory). The one query narrows the
- * Connected strip and both tabs' content at once.
+ * the hero, the "Your accounts" note in a team space (HOU-976: an agent there
+ * runs on the AI account of whoever messages it, so every member connects their
+ * own here), then ONE
+ * search field over everything, the consolidated **Connected** strip of provider
+ * rows OUTSIDE the tabs (a row opens that provider's modal), then the
+ * **Available** discovery tabs with live count chips: **Providers**
+ * ({@link ProvidersPane}: the not-yet-connected catalog) and **Models** (the
+ * cross-provider directory). The one query narrows the Connected strip and both
+ * tabs' content at once.
  * A provider row or model row opens a centered MODAL (`ProviderModal` /
  * `ModelModal`); the connect-dialog stack renders once here for every surface
  * underneath. (Workspace model policy lives on the Admin page.)
@@ -55,45 +49,17 @@ export function AiHubView() {
   const [openProvider, setOpenProvider] = useState<ProviderInfo | null>(null);
   const [openModel, setOpenModel] = useState<CatalogModel | null>(null);
 
-  const { capabilities } = useCapabilities();
-  const newEngine = newEngineActive();
-  const providerCapabilities =
-    capabilities ?? (newEngine ? EMPTY_PROVIDER_CAPABILITIES : undefined);
-  // The connect cards this deployment can show (merged OpenCode account, engine
-  // + capability gated) — the same set the catalog counts its offers from.
-  const connectProviders = useMemo(
-    () =>
-      getConnectProviders({
-        newEngine,
-        desktop: osIsTauri(),
-        capabilities: providerCapabilities,
-      }),
-    [newEngine, providerCapabilities],
-  );
-  // The user's own providers live in the strip; only the ones we CONFIRMED are
-  // not connected browse in the tab, so the tab's `+` connect is never offered
-  // for an account that may already be signed in (HOU-979). A provider whose
-  // probe came back unconfirmable rides the strip with its own checking dot.
-  // Until the first status probe resolves everything counts as available (the
-  // pane holds a skeleton and the counts stay hidden meanwhile).
-  const groups = useMemo(
-    () => groupProviders(connectProviders, connections.connectionState),
-    [connectProviders, connections.connectionState],
-  );
-  const available = groups.available;
-  const owned = useMemo(() => providerOwnedSide(groups), [groups]);
+  const { available, owned, connectedMatches, availableMatches, searching } =
+    useHubProviders(connections, query);
 
-  // The page query narrows both provider sections; `searching` uncaps the
-  // Connected strip's preview and switches the count chips to shown-count.
-  const searching = query.trim() !== "";
-  const connectedMatches = useMemo(
-    () => searchProviders(owned, query),
-    [owned, query],
-  );
-  const availableMatches = useMemo(
-    () => searchProviders(available, query),
-    [available, query],
-  );
+  // In a TEAM space the accounts on this page are the viewer's OWN: an agent
+  // runs every turn on the AI account of the person who messaged it. Saying so
+  // once, above the catalog, is what keeps a member from reading these rows as
+  // the team's shared connections. A personal space has one account and nothing
+  // to qualify, so it renders no note at all and looks exactly as it shipped.
+  const workspaceId = useWorkspaceStore((s) => s.current?.id);
+  const teamSpace = isTeamWorkspace(workspaceId ?? "");
+
   // Models tab chip: models matching the page query (facets narrow further).
   const modelMatches = useMemo(
     () => (catalog ? searchModels(catalog.models, query) : []),
@@ -158,6 +124,16 @@ export function AiHubView() {
         ) : (
           <>
             <HubHero modelCount={catalog.modelCount} />
+            {teamSpace && (
+              <div className="flex flex-col gap-1">
+                <h2 className="text-sm font-medium text-ink">
+                  {t("accounts.title")}
+                </h2>
+                <p className="text-sm text-ink-muted">
+                  {t("accounts.description")}
+                </p>
+              </div>
+            )}
             <CatalogShell
               controls={
                 <CatalogSearchField

--- a/app/src/components/ai-hub/provider-modal-footer.tsx
+++ b/app/src/components/ai-hub/provider-modal-footer.tsx
@@ -1,0 +1,58 @@
+import { Button } from "@houston-ai/core";
+import { useTranslation } from "react-i18next";
+import type { ProviderConnections } from "../../hooks/use-provider-connections.ts";
+import type { ProviderInfo } from "../../lib/providers.ts";
+
+/**
+ * The provider modal's connected footer: which provider is signed in, the
+ * disconnect action, and the optional "Set as default". A local
+ * (OpenAI-compatible) provider disconnects through the bridge teardown instead of
+ * a credential sign-out, hence the separate `onDisconnectLocal`.
+ *
+ * Extracted from `provider-modal.tsx` to keep that file inside the size budget.
+ */
+export function ProviderModalFooter({
+  provider,
+  connections,
+  isLocal,
+  disconnecting,
+  onDisconnectLocal,
+  onSetDefault,
+}: {
+  provider: ProviderInfo;
+  connections: ProviderConnections;
+  /** The provider is a local OpenAI-compatible server. */
+  isLocal: boolean;
+  /** A local disconnect is in flight. */
+  disconnecting: boolean;
+  onDisconnectLocal: () => void;
+  onSetDefault?: (provider: ProviderInfo) => void;
+}) {
+  const { t } = useTranslation("aiHub");
+  const busy = connections.busy[provider.id];
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="min-w-0 truncate text-[13px] text-ink-muted">
+        {t("providerModal.signedInWith", { provider: provider.name })}
+      </span>
+      <div className="flex shrink-0 items-center gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() =>
+            isLocal ? onDisconnectLocal() : connections.signOut(provider)
+          }
+          disabled={busy === "signingOut" || disconnecting}
+        >
+          {isLocal ? t("providerModal.disconnect") : t("providerModal.signOut")}
+        </Button>
+        {onSetDefault && (
+          <Button size="sm" onClick={() => onSetDefault(provider)}>
+            {t("providerModal.setDefault")}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/ai-hub/provider-modal.tsx
+++ b/app/src/components/ai-hub/provider-modal.tsx
@@ -9,14 +9,11 @@
  * `ProviderConnections`, exactly as the old provider-settings drove it.
  */
 
-import { Button } from "@houston-ai/core";
 import { X } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { useLocalBridgeStatus } from "../../hooks/use-local-bridge-status.ts";
 import type { ProviderConnections } from "../../hooks/use-provider-connections.ts";
 import type { HubCatalog } from "../../lib/ai-hub/catalog-types.ts";
-import { disconnectLocalModel } from "../../lib/local-model-connect.ts";
 import type { ProviderInfo } from "../../lib/providers.ts";
 import { BrandMark } from "../provider-browser/brand-mark.tsx";
 import {
@@ -28,6 +25,8 @@ import { LiveStatus, SpecChip } from "./hub-badges.tsx";
 import { ModalShell } from "./modal-shell.tsx";
 import { ModelsBrowser } from "./models-browser.tsx";
 import { ConnectButton } from "./provider-modal-connect-button.tsx";
+import { ProviderModalFooter } from "./provider-modal-footer.tsx";
+import { useProviderModalLocal } from "./use-provider-modal-local.ts";
 
 export function ProviderModal({
   provider,
@@ -49,46 +48,33 @@ export function ProviderModal({
 }) {
   const { t } = useTranslation("aiHub");
   // Tri-state (HOU-979): only a CONFIRMED connection gets the live badge, the
-  // sign-out footer, and the local-bridge treatment; only a CONFIRMED
-  // disconnection gets the Connect CTA. An unconfirmable probe gets neither —
-  // a muted "Checking" stands in, so the modal never guesses in either
-  // direction about an account it cannot see.
+  // sign-out footer and the local-bridge treatment; only a CONFIRMED
+  // disconnection gets the Connect CTA. An unconfirmable probe gets neither, so
+  // the modal never guesses in either direction.
   const connection = connections.connectionState(provider);
   const connected = connection === "connected";
   const checking = connection === "checking";
-  const busy = connections.busy[provider.id];
   const models = useMemo(
     () => providerModels(catalog, provider),
     [catalog, provider],
   );
   const isLocal = provider.auth === "openaiCompatible";
 
-  // Local model: the bridge's live online/offline state + a "disconnect" that
-  // also tears the tunnel down (not just clears the credential). The tunnel pill
-  // shows ONLY when THIS session owns/owned a bridge; a direct/manual endpoint
-  // (or a tunnel another machine manages) reads as normally connected instead.
-  const localConnected = isLocal && connected;
+  // Local model: the bridge state + a disconnect that tears the tunnel down.
   const {
-    status: bridge,
-    ownsBridge,
-    appName: bridgeAppName,
-    reconnect: reconnectBridge,
+    showTunnelPill,
+    showConnectedBadge,
+    bridge,
+    bridgeAppName,
+    reconnectBridge,
     reconnecting,
-  } = useLocalBridgeStatus(localConnected);
-  const showTunnelPill = localConnected && ownsBridge;
-  const showConnectedBadge = connected && (!isLocal || !ownsBridge);
-  const [disconnecting, setDisconnecting] = useState(false);
-  const disconnectLocal = useCallback(async () => {
-    setDisconnecting(true);
-    try {
-      await disconnectLocalModel();
-      connections.refresh();
-    } catch {
-      // disconnectLocalModel already toasted the real reason (Report-bug).
-    } finally {
-      setDisconnecting(false);
-    }
-  }, [connections]);
+    disconnecting,
+    disconnectLocal,
+  } = useProviderModalLocal({
+    isLocal,
+    connected,
+    onDisconnected: connections.refresh,
+  });
 
   const header = (
     <div className="flex items-start gap-3 px-5 pt-5 pb-4">
@@ -133,28 +119,14 @@ export function ProviderModal({
   );
 
   const footer = connected ? (
-    <div className="flex items-center justify-between gap-3">
-      <span className="min-w-0 truncate text-[13px] text-ink-muted">
-        {t("providerModal.signedInWith", { provider: provider.name })}
-      </span>
-      <div className="flex shrink-0 items-center gap-2">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() =>
-            isLocal ? void disconnectLocal() : connections.signOut(provider)
-          }
-          disabled={busy === "signingOut" || disconnecting}
-        >
-          {isLocal ? t("providerModal.disconnect") : t("providerModal.signOut")}
-        </Button>
-        {onSetDefault && (
-          <Button size="sm" onClick={() => onSetDefault(provider)}>
-            {t("providerModal.setDefault")}
-          </Button>
-        )}
-      </div>
-    </div>
+    <ProviderModalFooter
+      provider={provider}
+      connections={connections}
+      isLocal={isLocal}
+      disconnecting={disconnecting}
+      onDisconnectLocal={() => void disconnectLocal()}
+      onSetDefault={onSetDefault}
+    />
   ) : undefined;
 
   return (

--- a/app/src/components/ai-hub/use-hub-providers.ts
+++ b/app/src/components/ai-hub/use-hub-providers.ts
@@ -1,0 +1,80 @@
+/**
+ * Which providers the AI hub shows, split into "yours" and "available" and
+ * narrowed by the page's ONE search query. Lifted out of `AiHubView` so the page
+ * stays a layout and this set of derivations lives in one place.
+ *
+ * The user's own providers ride the strip; only the ones we CONFIRMED are not
+ * connected browse in the tab, so the tab's `+` connect is never offered for an
+ * account that may already be signed in (HOU-979). A provider whose probe came
+ * back unconfirmable rides the strip with its own checking dot. Until the first
+ * status probe resolves everything counts as available (the pane holds a skeleton
+ * and the counts stay hidden meanwhile).
+ */
+
+import { useMemo } from "react";
+import { useCapabilities } from "../../hooks/use-capabilities";
+import type { ProviderConnections } from "../../hooks/use-provider-connections";
+import { newEngineActive } from "../../lib/engine";
+import { osIsTauri } from "../../lib/os-bridge";
+import {
+  EMPTY_PROVIDER_CAPABILITIES,
+  getConnectProviders,
+  type ProviderInfo,
+} from "../../lib/providers";
+import { searchProviders } from "../provider-browser/provider-filtering";
+import {
+  groupProviders,
+  providerOwnedSide,
+} from "../provider-browser/provider-grouping";
+
+export interface HubProviders {
+  /** Confirmed-not-connected providers: the browse tab's catalog. */
+  available: ProviderInfo[];
+  /** The user's own side (connected + still checking): the Connected strip. */
+  owned: ProviderInfo[];
+  /** `owned` narrowed by the page query. */
+  connectedMatches: ProviderInfo[];
+  /** `available` narrowed by the page query. */
+  availableMatches: ProviderInfo[];
+  /** Whether the page query is active (uncaps the strip, switches the chips). */
+  searching: boolean;
+}
+
+export function useHubProviders(
+  connections: ProviderConnections,
+  query: string,
+): HubProviders {
+  const { capabilities } = useCapabilities();
+  const newEngine = newEngineActive();
+  const providerCapabilities =
+    capabilities ?? (newEngine ? EMPTY_PROVIDER_CAPABILITIES : undefined);
+  // The connect cards this deployment can show (merged OpenCode account, engine
+  // + capability gated) — the same set the catalog counts its offers from.
+  const connectProviders = useMemo(
+    () =>
+      getConnectProviders({
+        newEngine,
+        desktop: osIsTauri(),
+        capabilities: providerCapabilities,
+      }),
+    [newEngine, providerCapabilities],
+  );
+  const groups = useMemo(
+    () => groupProviders(connectProviders, connections.connectionState),
+    [connectProviders, connections.connectionState],
+  );
+  const available = groups.available;
+  const owned = useMemo(() => providerOwnedSide(groups), [groups]);
+
+  const searching = query.trim() !== "";
+  const connectedMatches = useMemo(
+    () => searchProviders(owned, query),
+    [owned, query],
+  );
+  const availableMatches = useMemo(
+    () => searchProviders(available, query),
+    [available, query],
+  );
+
+  return { available, owned, connectedMatches, availableMatches, searching };
+}

--- a/app/src/components/ai-hub/use-provider-modal-local.ts
+++ b/app/src/components/ai-hub/use-provider-modal-local.ts
@@ -1,0 +1,77 @@
+/**
+ * The LOCAL-model half of the provider modal: the bridge's live online/offline
+ * state, and a "disconnect" that tears the tunnel down rather than merely
+ * clearing a credential.
+ *
+ * Extracted from `provider-modal.tsx` so that file stays a composition of a
+ * header, a model list and a footer. Nothing here is account-scoped (HOU-976): a
+ * local OpenAI-compatible endpoint is agent CONFIGURATION, not a credential, so
+ * there is no personal-versus-team question to ask about it.
+ */
+
+import { useCallback, useState } from "react";
+import { useLocalBridgeStatus } from "../../hooks/use-local-bridge-status.ts";
+import { disconnectLocalModel } from "../../lib/local-model-connect.ts";
+
+export interface ProviderModalLocal {
+  /** Show the tunnel pill: THIS session owns/owned the bridge. */
+  showTunnelPill: boolean;
+  /**
+   * Show the green Connected badge. A session-owned tunnel reports its state
+   * through the pill instead, so the two never stack.
+   */
+  showConnectedBadge: boolean;
+  /** The bridge's live state, for the pill. */
+  bridge: ReturnType<typeof useLocalBridgeStatus>["status"];
+  /** The local app's name (e.g. "LM Studio") for the offline hint. */
+  bridgeAppName?: string;
+  reconnectBridge: () => void;
+  reconnecting: boolean;
+  /** A local disconnect is in flight. */
+  disconnecting: boolean;
+  disconnectLocal: () => Promise<void>;
+}
+
+/**
+ * `isLocal` is the provider kind; `connected` is whether THIS modal's account is
+ * confirmed connected. A direct/manual endpoint (or a tunnel another machine
+ * manages) owns no bridge here and so reads as normally connected instead.
+ */
+export function useProviderModalLocal(opts: {
+  isLocal: boolean;
+  connected: boolean;
+  onDisconnected: () => void;
+}): ProviderModalLocal {
+  const localConnected = opts.isLocal && opts.connected;
+  const {
+    status: bridge,
+    ownsBridge,
+    appName: bridgeAppName,
+    reconnect: reconnectBridge,
+    reconnecting,
+  } = useLocalBridgeStatus(localConnected);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const { onDisconnected } = opts;
+  const disconnectLocal = useCallback(async () => {
+    setDisconnecting(true);
+    try {
+      await disconnectLocalModel();
+      onDisconnected();
+    } catch {
+      // disconnectLocalModel already toasted the real reason (Report-bug).
+    } finally {
+      setDisconnecting(false);
+    }
+  }, [onDisconnected]);
+
+  return {
+    showTunnelPill: localConnected && ownsBridge,
+    showConnectedBadge: opts.connected && (!opts.isLocal || !ownsBridge),
+    bridge,
+    bridgeAppName,
+    reconnectBridge,
+    reconnecting,
+    disconnecting,
+    disconnectLocal,
+  };
+}

--- a/app/src/components/chat-model-selector-labels.ts
+++ b/app/src/components/chat-model-selector-labels.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ModelPickerLabels } from "@houston-ai/core";
-import type { Capabilities } from "@houston-ai/engine-client";
+import type { Capabilities, CredentialScope } from "@houston-ai/engine-client";
 import type { useTranslation } from "react-i18next";
 import { canSeeAiModelsPage } from "../lib/org-roles.ts";
 
@@ -15,18 +15,18 @@ import { canSeeAiModelsPage } from "../lib/org-roles.ts";
  *
  * A team space with no credential used to render a blank provider list with no
  * explanation, which reads as a broken app rather than as the honest first state
- * of a new space. The three variants are the three genuinely different
- * situations, and they differ in whether the viewer can do anything about it:
+ * of a new space. Two variants, because there are two genuinely different
+ * situations — and NEITHER is "ask an admin":
  *
- *  - `personal`        — single player. Their own space, their own connect.
- *  - `teamCanConnect`  — a team space, viewed by someone who can reach the AI
- *                        Models hub (owner / admin).
- *  - `teamAskAdmin`    — a team space, viewed by a plain member. Provider
- *                        connections are org-level and the hub is not theirs to
- *                        open, so pointing them at it would dead-end; name who
- *                        can fix it instead.
+ *  - `personal` — single player. Their own space, their own connect.
+ *  - `team`     — a team space. Every agent there runs on the AI account of
+ *                 whoever messages it (HOU-976), so the person reading this is
+ *                 always the person who can fix it. The old third variant
+ *                 ("ask a team owner or admin to connect an AI model") is gone
+ *                 with the shared team account it described: there is no
+ *                 credential an admin could connect on a member's behalf.
  */
-export type PickerEmptyState = "personal" | "teamCanConnect" | "teamAskAdmin";
+export type PickerEmptyState = "personal" | "team";
 
 /** The empty-state copy to use, and whether its action may render at all. */
 export interface PickerEmptyStateDecision {
@@ -42,16 +42,13 @@ export interface PickerEmptyStateDecision {
  * Resolve the empty-state variant + whether its action may render, for the
  * active space and viewer.
  *
- * `capabilitiesLoaded` is load-bearing, not defensive (HOU-979). `role` is
- * per-space and arrives with capabilities; the underlying
- * {@link canSeeAiModelsPage} answers TRUE for capabilities that have not
- * arrived (the single-player default), so deciding early showed a plain team
- * member a Connect action for a beat and then withdrew it. Until they land we
- * make no promise: no action, and the copy that assumes the least. The surface
- * holds its neutral loading state through that window anyway
- * (`use-picker-view-models` folds the same signal into `catalogState`), so the
- * conservative variant is a belt-and-braces default, never a visible flash of
- * "ask an admin" at an owner.
+ * The COPY now depends only on which kind of space this is — the story is the
+ * same for every viewer of a team space, because every one of them connects
+ * their own account (HOU-976). `capabilitiesLoaded` still gates the ACTION
+ * (HOU-979): the surface must not promise a Connect before it knows the
+ * deployment describes a hub at all. The surface holds its neutral loading
+ * state through that window anyway (`use-picker-view-models` folds the same
+ * signal into `catalogState`), so this is belt-and-braces.
  *
  * A capabilities load that FAILS is not "still loading": it settles on the
  * permissive single-player default, since an undescribed deployment is that.
@@ -61,13 +58,29 @@ export function pickerEmptyState(opts: {
   capabilities: Capabilities | null;
   capabilitiesLoaded: boolean;
 }): PickerEmptyStateDecision {
-  const canConnect =
-    opts.capabilitiesLoaded && canSeeAiModelsPage(opts.capabilities);
-  if (!opts.teamSpace) return { variant: "personal", canConnect };
   return {
-    variant: canConnect ? "teamCanConnect" : "teamAskAdmin",
-    canConnect,
+    variant: opts.teamSpace ? "team" : "personal",
+    canConnect:
+      opts.capabilitiesLoaded && canSeeAiModelsPage(opts.capabilities),
   };
+}
+
+/**
+ * The name of the ACCOUNT a provider's models run on, for a picker row's
+ * subtitle (HOU-976): "your account" / "team account".
+ *
+ * `null` scope means the deployment never said which account answered — desktop,
+ * self-host, a personal space, a gateway predating the field — and returns
+ * `undefined`, which leaves the subtitle exactly as it reads today. Kept beside
+ * `buildLabels` because this is the picker's other i18n boundary: the pure row
+ * builders take the finished string as data.
+ */
+export function pickerAccountLabel(
+  t: ReturnType<typeof useTranslation<"chat">>[0],
+  scope: CredentialScope | null,
+): string | undefined {
+  if (scope === null) return undefined;
+  return t(`modelSelector.picker.account.${scope}`);
 }
 
 /**

--- a/app/src/components/shell/provider-api-key-dialog.tsx
+++ b/app/src/components/shell/provider-api-key-dialog.tsx
@@ -7,7 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@houston-ai/core";
-import { ExternalLink, Eye, EyeOff } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -16,6 +16,7 @@ import {
 } from "../../lib/api-key-connect-error";
 import type { ProviderInfo } from "../../lib/providers";
 import { tauriProvider, tauriSystem } from "../../lib/tauri";
+import { ProviderApiKeyField } from "./provider-api-key-field";
 
 /**
  * The host's own reason for a rejected connect ("openrouter rejected this API
@@ -58,15 +59,16 @@ const REASON_COPY: Record<
 export function ProviderApiKeyDialog({ provider, onClose }: Props) {
   const { t } = useTranslation("providers");
   const [key, setKey] = useState("");
-  const [show, setShow] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Reset per-open state so a stale key / error / reveal never leaks across opens.
+  // Reset per-open state so a stale key or error never leaks across opens. The
+  // REVEAL toggle is not reset here and does not need to be: it lives inside
+  // `ProviderApiKeyField`, which unmounts with the dialog and so comes back
+  // hidden on its own.
   useEffect(() => {
     if (provider) {
       setKey("");
-      setShow(false);
       setError(null);
       setSubmitting(false);
     }
@@ -139,39 +141,15 @@ export function ProviderApiKeyDialog({ provider, onClose }: Props) {
             </Button>
           )}
 
-          <div className="space-y-1.5">
-            <label
-              htmlFor="provider-api-key"
-              className="text-[13px] font-medium"
-            >
-              {t("apiKey.label")}
-            </label>
-            <div className="relative">
-              <input
-                id="provider-api-key"
-                type={show ? "text" : "password"}
-                autoComplete="off"
-                autoFocus
-                value={key}
-                onChange={(e) => setKey(e.target.value)}
-                placeholder={t("apiKey.placeholder")}
-                className="w-full rounded-md border bg-input px-3 py-2 pr-10 text-[13px] font-mono focus:outline-none focus:ring-2 focus:ring-focus"
-                disabled={submitting}
-              />
-              <button
-                type="button"
-                onClick={() => setShow((v) => !v)}
-                aria-label={show ? t("apiKey.hide") : t("apiKey.show")}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-ink-muted hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-focus rounded"
-              >
-                {show ? (
-                  <EyeOff className="size-4" />
-                ) : (
-                  <Eye className="size-4" />
-                )}
-              </button>
-            </div>
-          </div>
+          <ProviderApiKeyField
+            label={t("apiKey.label")}
+            placeholder={t("apiKey.placeholder")}
+            showLabel={t("apiKey.show")}
+            hideLabel={t("apiKey.hide")}
+            value={key}
+            disabled={submitting}
+            onChange={setKey}
+          />
 
           {error && (
             <p className="text-[12px] text-danger" role="alert">

--- a/app/src/components/shell/provider-api-key-field.tsx
+++ b/app/src/components/shell/provider-api-key-field.tsx
@@ -1,0 +1,61 @@
+import { Eye, EyeOff } from "lucide-react";
+import { useState } from "react";
+
+/**
+ * The API-key entry field: a labelled password input with a reveal toggle.
+ *
+ * Its own component so {@link ProviderApiKeyDialog} stays the flow (submit and
+ * verification verdicts) rather than also owning input chrome. Paste is never blocked and the reveal state resets with the
+ * field's own mount, so a revealed key can't survive a reopen.
+ */
+export function ProviderApiKeyField({
+  label,
+  placeholder,
+  showLabel,
+  hideLabel,
+  value,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  placeholder: string;
+  /** Accessible name for the reveal toggle while the key is hidden. */
+  showLabel: string;
+  /** Accessible name for the reveal toggle while the key is visible. */
+  hideLabel: string;
+  value: string;
+  disabled: boolean;
+  onChange: (value: string) => void;
+}) {
+  const [show, setShow] = useState(false);
+
+  return (
+    <div className="space-y-1.5">
+      <label htmlFor="provider-api-key" className="text-[13px] font-medium">
+        {label}
+      </label>
+      <div className="relative">
+        <input
+          id="provider-api-key"
+          type={show ? "text" : "password"}
+          autoComplete="off"
+          // biome-ignore lint/a11y/noAutofocus: only ever rendered inside the api-key dialog, which exists to receive this one value; the inline field it replaced autofocused too (the rule tolerated it there because the <input> sat lexically inside <Dialog>).
+          autoFocus
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className="w-full rounded-md border bg-input px-3 py-2 pr-10 text-[13px] font-mono focus:outline-none focus:ring-2 focus:ring-focus"
+          disabled={disabled}
+        />
+        <button
+          type="button"
+          onClick={() => setShow((v) => !v)}
+          aria-label={show ? hideLabel : showLabel}
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-ink-muted hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-focus rounded"
+        >
+          {show ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/shell/provider-error-card.tsx
+++ b/app/src/components/shell/provider-error-card.tsx
@@ -25,6 +25,10 @@ import { useEffect } from "react";
 import { queryKeys } from "../../lib/query-keys";
 import { UnauthenticatedCard } from "./provider-error-cards/auth";
 import {
+  RateLimitedCard,
+  UsageLimitPausedCard,
+} from "./provider-error-cards/limits";
+import {
   ContextOverflowCard,
   ModelUnavailableCard,
   QuotaExhaustedCard,
@@ -38,8 +42,6 @@ import {
   MalformedResponseCard,
   NetworkUnreachableCard,
   ProviderInternalCard,
-  RateLimitedCard,
-  UsageLimitPausedCard,
 } from "./provider-error-cards/transient";
 
 interface ProviderErrorCardProps {

--- a/app/src/components/shell/provider-error-cards/limits.tsx
+++ b/app/src/components/shell/provider-error-cards/limits.tsx
@@ -1,0 +1,102 @@
+/**
+ * The LIMIT variants — rate-limited and usage-limit-paused. Both mean "this
+ * account has no room right now": rate-limited clears in seconds (so it offers a
+ * retry), the plan-window pause clears at a stated time (so it does not).
+ *
+ * Neither offers another ACCOUNT to continue on, because in a team space there
+ * is no other account: every turn runs on the AI account of whoever sent it
+ * (HOU-976). The limit is the sender's own to wait out, which is exactly what
+ * these cards say.
+ *
+ * Split from the sibling `transient.tsx` (network / provider-internal /
+ * malformed, which recover by retrying now) so each file stays inside the
+ * file-size budget. All render on the unified `RowCard` (HOU-467).
+ */
+
+import type { ProviderError } from "@houston-ai/chat";
+import { Clock, TimerResetIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { RowCard } from "../../cards/row-card";
+import { RowCardButton } from "../../cards/row-card-button";
+import { providerLabel, RetryButton } from "./shared";
+
+interface LimitProps {
+  onRetry?: () => Promise<void> | void;
+  onSwitchModel?: () => void;
+}
+
+export function RateLimitedCard({
+  error,
+  onRetry,
+  onSwitchModel,
+}: LimitProps & {
+  error: Extract<ProviderError, { kind: "rate_limited" }>;
+}) {
+  const { t } = useTranslation("shell");
+  const provider = providerLabel(error.provider);
+  const body = error.retry_after_seconds
+    ? t("providerError.rateLimited.bodyWithRetry", {
+        provider,
+        seconds: error.retry_after_seconds,
+      })
+    : t("providerError.rateLimited.body", { provider });
+  return (
+    <div className="w-full px-1 py-2">
+      <RowCard
+        media={<Clock className="size-5" />}
+        title={t("providerError.rateLimited.title")}
+        description={body}
+        // `undefined`, never an always-rendered fragment: `RowCard` tests the
+        // slot for null, so an empty fragment still mounts the action <span> and
+        // its `gap-2` — a phantom column on a card with no buttons. Same rule as
+        // `UsageLimitPausedCard` below.
+        action={
+          onRetry || onSwitchModel ? (
+            <>
+              {onRetry && (
+                <RetryButton
+                  onRetry={onRetry}
+                  label={t("providerError.rateLimited.retry")}
+                />
+              )}
+              {onSwitchModel && (
+                <RowCardButton
+                  label={t("providerError.rateLimited.switchModel")}
+                  onClick={onSwitchModel}
+                  variant="outline"
+                />
+              )}
+            </>
+          ) : undefined
+        }
+      />
+    </div>
+  );
+}
+
+/**
+ * Plan-window usage limit (Anthropic's 5-hour subscription session limit).
+ * Distinct from RateLimited: retrying now fails, so waiting for the stated reset
+ * is the recovery — which leaves this card deliberately action-less.
+ */
+export function UsageLimitPausedCard({
+  error,
+}: {
+  error: Extract<ProviderError, { kind: "usage_limit_paused" }>;
+}) {
+  const { t } = useTranslation("shell");
+  const body = error.resets_at
+    ? t("providerError.usageLimitPaused.bodyWithReset", {
+        time: error.resets_at,
+      })
+    : t("providerError.usageLimitPaused.body");
+  return (
+    <div className="w-full px-1 py-2">
+      <RowCard
+        media={<TimerResetIcon className="size-5" />}
+        title={t("providerError.usageLimitPaused.title")}
+        description={body}
+      />
+    </div>
+  );
+}

--- a/app/src/components/shell/provider-error-cards/quota.tsx
+++ b/app/src/components/shell/provider-error-cards/quota.tsx
@@ -8,11 +8,16 @@
  * conversation onto a larger-window model. All render on the unified `RowCard`
  * (HOU-467), with their CTAs mounted as `RowCardButton`s in the card's action
  * slot.
+ *
+ * Per-user AI accounts (HOU-976) touch ModelUnavailable alone: it names the
+ * PERSONAL plan that lacks the model, so a member does not go asking an admin to
+ * fix a plan that is theirs. Absent credential context leaves the copy untouched.
  */
 
 import type { ProviderError } from "@houston-ai/chat";
 import { AlertTriangleIcon, XCircleIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { credentialScopeOf } from "../../../lib/credential-scope";
 import { RowCard } from "../../cards/row-card";
 import { RowCardButton } from "../../cards/row-card-button";
 import { providerLabel } from "./shared";
@@ -30,27 +35,29 @@ export function QuotaExhaustedCard({
 }) {
   const { t } = useTranslation("shell");
   const provider = providerLabel(error.provider);
+  const body = error.resets_at
+    ? t("providerError.quotaExhausted.bodyWithReset", {
+        provider,
+        time: error.resets_at,
+      })
+    : t("providerError.quotaExhausted.body", { provider });
   return (
     <div className="w-full px-1 py-2">
       <RowCard
         media={<XCircleIcon className="size-5" />}
         title={t("providerError.quotaExhausted.title")}
-        description={
-          error.resets_at
-            ? t("providerError.quotaExhausted.bodyWithReset", {
-                provider,
-                time: error.resets_at,
-              })
-            : t("providerError.quotaExhausted.body", { provider })
-        }
+        description={body}
+        // `undefined`, not `false`: `RowCard`'s slot test is `!= null`, and
+        // `false` passes it — an action-less card would still mount the empty
+        // action <span> and its gap.
         action={
-          onSwitchModel && (
+          onSwitchModel ? (
             <RowCardButton
               variant="outline"
               label={t("providerError.quotaExhausted.switchProvider")}
               onClick={onSwitchModel}
             />
-          )
+          ) : undefined
         }
       />
     </div>
@@ -73,14 +80,17 @@ export function ContextOverflowCard({
         media={<AlertTriangleIcon className="size-5" />}
         title={t("providerError.contextOverflow.title")}
         description={t("providerError.contextOverflow.body", { model })}
+        // `undefined`, not `false`: `RowCard`'s slot test is `!= null`, and
+        // `false` passes it — an action-less card would still mount the empty
+        // action <span> and its gap.
         action={
-          onSwitchModel && (
+          onSwitchModel ? (
             <RowCardButton
               variant="outline"
               label={t("providerError.contextOverflow.switchModel")}
               onClick={onSwitchModel}
             />
-          )
+          ) : undefined
         }
       />
     </div>
@@ -99,33 +109,44 @@ export function ModelUnavailableCard({
   const { t } = useTranslation("shell");
   const provider = providerLabel(error.provider);
   const fallback = error.suggested_fallback;
+  // Name WHOSE plan lacks the model when the wire says the turn ran on the
+  // sender's own account (HOU-976). A member reading "your {{provider}}
+  // account" would otherwise reasonably read it as the team's, and go asking an
+  // admin to fix a plan that is theirs. No credential context (desktop,
+  // self-host, personal space, routine) keeps the body byte-identical.
+  const personal = credentialScopeOf(error.credential) === "personal";
   return (
     <div className="w-full px-1 py-2">
       <RowCard
         media={<AlertTriangleIcon className="size-5" />}
         title={t("providerError.modelUnavailable.title")}
-        description={t("providerError.modelUnavailable.body", {
-          provider,
-          model: error.model,
-        })}
+        description={t(
+          personal
+            ? "providerError.credential.modelUnavailableBody"
+            : "providerError.modelUnavailable.body",
+          { provider, model: error.model },
+        )}
+        // Same `undefined`-not-a-fragment rule as the card above.
         action={
-          <>
-            {fallback && onApplyModel && (
-              <RowCardButton
-                label={t("providerError.modelUnavailable.switchToFallback", {
-                  model: fallback,
-                })}
-                onClick={() => onApplyModel(fallback)}
-              />
-            )}
-            {onSwitchModel && (
-              <RowCardButton
-                variant="outline"
-                label={t("providerError.modelUnavailable.pickAnother")}
-                onClick={onSwitchModel}
-              />
-            )}
-          </>
+          (fallback && onApplyModel) || onSwitchModel ? (
+            <>
+              {fallback && onApplyModel && (
+                <RowCardButton
+                  label={t("providerError.modelUnavailable.switchToFallback", {
+                    model: fallback,
+                  })}
+                  onClick={() => onApplyModel(fallback)}
+                />
+              )}
+              {onSwitchModel && (
+                <RowCardButton
+                  variant="outline"
+                  label={t("providerError.modelUnavailable.pickAnother")}
+                  onClick={onSwitchModel}
+                />
+              )}
+            </>
+          ) : undefined
         }
       />
     </div>

--- a/app/src/components/shell/provider-error-cards/transient.tsx
+++ b/app/src/components/shell/provider-error-cards/transient.tsx
@@ -1,99 +1,22 @@
 /**
- * Transient typed-provider-error variants — rate-limited, usage-limit-paused,
- * network, provider-internal, malformed-response. They share the "wait"
- * recovery shape; rate-limited/network/internal offer a retry (and the
- * network/internal ones a status-page link), while usage-limit-paused is
- * informational — the user waits for the plan window to reset. All render on
- * the unified `RowCard` (HOU-467).
+ * Transient typed-provider-error variants that recover by RETRYING NOW —
+ * network-unreachable, provider-internal, malformed-response. The failure is
+ * infrastructure, not the account: nothing about which AI account ran the turn
+ * changes the remedy, so these carry no credential-scope affordance.
+ *
+ * The account-shaped limits (rate-limited, usage-limit-paused) live in the
+ * sibling `limits.tsx` — they recover by waiting or by moving to another account.
+ * All render on the unified `RowCard` (HOU-467).
  */
 
 import type { ProviderError } from "@houston-ai/chat";
-import {
-  AlertTriangleIcon,
-  Clock,
-  ServerCrashIcon,
-  TimerResetIcon,
-  WifiOffIcon,
-} from "lucide-react";
+import { AlertTriangleIcon, ServerCrashIcon, WifiOffIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { RowCard } from "../../cards/row-card";
-import { RowCardButton } from "../../cards/row-card-button";
 import { providerLabel, RetryButton, StatusPageButton } from "./shared";
 
 interface BaseProps {
   onRetry?: () => Promise<void> | void;
-  onSwitchModel?: () => void;
-}
-
-export function RateLimitedCard({
-  error,
-  onRetry,
-  onSwitchModel,
-}: BaseProps & {
-  error: Extract<ProviderError, { kind: "rate_limited" }>;
-}) {
-  const { t } = useTranslation("shell");
-  const provider = providerLabel(error.provider);
-  const body = error.retry_after_seconds
-    ? t("providerError.rateLimited.bodyWithRetry", {
-        provider,
-        seconds: error.retry_after_seconds,
-      })
-    : t("providerError.rateLimited.body", { provider });
-  return (
-    <div className="w-full px-1 py-2">
-      <RowCard
-        media={<Clock className="size-5" />}
-        title={t("providerError.rateLimited.title")}
-        description={body}
-        action={
-          <>
-            {onRetry && (
-              <RetryButton
-                onRetry={onRetry}
-                label={t("providerError.rateLimited.retry")}
-              />
-            )}
-            {onSwitchModel && (
-              <RowCardButton
-                label={t("providerError.rateLimited.switchModel")}
-                onClick={onSwitchModel}
-                variant="outline"
-              />
-            )}
-          </>
-        }
-      />
-    </div>
-  );
-}
-
-/**
- * Plan-window usage limit (Anthropic's 5-hour subscription session limit).
- * Distinct from RateLimited: retrying now fails, so there is no action — the
- * user just waits for the reset. We surface the reset time when the engine
- * could resolve it.
- */
-export function UsageLimitPausedCard({
-  error,
-}: {
-  error: Extract<ProviderError, { kind: "usage_limit_paused" }>;
-}) {
-  const { t } = useTranslation("shell");
-  const body = error.resets_at
-    ? t("providerError.usageLimitPaused.bodyWithReset", {
-        time: error.resets_at,
-      })
-    : t("providerError.usageLimitPaused.body");
-  return (
-    <div className="w-full px-1 py-2">
-      <RowCard
-        media={<TimerResetIcon className="size-5" />}
-        title={t("providerError.usageLimitPaused.title")}
-        description={body}
-      />
-    </div>
-  );
 }
 
 export function NetworkUnreachableCard({

--- a/app/src/hooks/use-picker-view-models.tsx
+++ b/app/src/hooks/use-picker-view-models.tsx
@@ -10,6 +10,7 @@
 import type { ModelPickerModel, ModelPickerProvider } from "@houston-ai/core";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { pickerAccountLabel } from "../components/chat-model-selector-labels";
 import {
   encodeModelPickerId,
   resolveSelectedModelId,
@@ -18,6 +19,7 @@ import {
   buildPickerModels,
   buildPickerProviders,
 } from "../lib/chat-model-picker-map";
+import { statusCredentialScope } from "../lib/credential-scope";
 import { newEngineActive } from "../lib/engine";
 import { osIsTauri } from "../lib/os-bridge";
 import {
@@ -84,12 +86,30 @@ export function usePickerViewModels(opts: {
     [t],
   );
 
+  // Which ACCOUNT a provider's models run on (HOU-976 §6). The status row says
+  // whose credential answered the probe; `statusCredentialScope` maps an absent
+  // field — every deployment with no acting identity — to null, and
+  // `pickerAccountLabel` maps null to no label, so the row subtitle is
+  // byte-identical to what shipped before per-user accounts.
+  const accountLabelOf = useCallback(
+    (providerId: string) =>
+      pickerAccountLabel(t, statusCredentialScope(statuses[providerId])),
+    [t, statuses],
+  );
+
   // Build the (potentially 300+) rows only while the picker is open — the
   // panel is unmounted otherwise, so there is nothing to feed when closed.
   const models = useMemo(
     () =>
-      isOpen ? buildPickerModels({ visibleProviders, statuses, describe }) : [],
-    [isOpen, visibleProviders, statuses, describe],
+      isOpen
+        ? buildPickerModels({
+            visibleProviders,
+            statuses,
+            describe,
+            accountLabelOf,
+          })
+        : [],
+    [isOpen, visibleProviders, statuses, describe, accountLabelOf],
   );
   const withModels = useMemo(
     () => new Set(models.map((m) => m.providerId)),

--- a/app/src/lib/chat-model-picker-map.test.mjs
+++ b/app/src/lib/chat-model-picker-map.test.mjs
@@ -121,6 +121,10 @@ test("buildPickerModels: the describe callback localizes a provider row's descri
   assert.equal(m.description, "t:m1:curated desc");
 });
 
+// The per-provider account label (HOU-976 §6) is covered in
+// `app/tests/picker-account-label.test.ts` — the GATED suite. Do not add cases
+// here: nothing runs `src/lib/*.test.mjs`.
+
 // ── curated-first ranking ─────────────────────────────────────────────────
 
 test("rankCuratedFirst: curated ids lead in curation order, rest keep input order", () => {

--- a/app/src/lib/chat-model-picker-map.ts
+++ b/app/src/lib/chat-model-picker-map.ts
@@ -17,6 +17,15 @@
  * capability / price / context enrichment was dropped with the model detail
  * panel it used to feed.
  *
+ * PER-USER AI ACCOUNTS (HOU-976 §6): there is deliberately NO extra filtering
+ * here. `configured` / `auth_state` on a status row is already resolved for the
+ * ACTING identity by the pod that answered `GET /providers`, so "connected"
+ * means "connected for whoever is asking" and the existing connection filter IS
+ * the intersect. We do not model per-plan model entitlements client-side either:
+ * a personal plan that lacks a model must fail the turn honestly as
+ * `ModelUnavailable` rather than have the row quietly disappear. All this layer
+ * adds is the account LABEL on each row (`accountLabelOf`).
+ *
  * Ranking: with the sort menu gone, the pi catalog's raw order (often
  * oldest-first) would bury the flagships, so each provider's rows are re-ranked
  * CURATED-FIRST — the models with a `PROVIDER_OVERRIDES` entry lead, in their
@@ -26,7 +35,7 @@
 
 import type { ModelPickerModel, ModelPickerProvider } from "@houston-ai/core";
 import { encodeModelPickerId } from "./chat-model-picker-ids.ts";
-import { pickerModelRows } from "./model-picker.ts";
+import { pickerModelRows, withAccountLabel } from "./model-picker.ts";
 import {
   type ProviderConnectionStatus,
   providerConnectionState,
@@ -75,19 +84,24 @@ function providerModelRows(
   describe:
     | ((providerId: string, modelId: string, fallback: string) => string)
     | undefined,
+  accountLabelOf: ((providerId: string) => string | undefined) | undefined,
 ): ModelPickerModel[] {
   const rows = pickerModelRows(
     p.models,
     statuses[p.id]?.active_model,
     p.subtitle,
   );
+  // The account label is appended AFTER localization, so it qualifies the
+  // translated description rather than the catalog English it fell back to.
+  const accountLabel = accountLabelOf?.(p.id);
   return rankCuratedFirst(rows, curatedModelIds(p.id)).map((row) => ({
     id: encodeModelPickerId(p.id, row.id),
     providerId: p.id,
     name: row.label,
-    description: describe
-      ? describe(p.id, row.id, row.description)
-      : row.description,
+    description: withAccountLabel(
+      describe ? describe(p.id, row.id, row.description) : row.description,
+      accountLabel,
+    ),
   }));
 }
 
@@ -101,10 +115,24 @@ export function buildPickerModels(opts: {
   visibleProviders: readonly ProviderInfo[];
   statuses: Record<string, StatusModel | undefined>;
   describe?: (providerId: string, modelId: string, fallback: string) => string;
+  /**
+   * The already-translated name of the ACCOUNT a provider's models run on
+   * ("your account" / "team account", HOU-976 §6), or undefined for a provider
+   * whose deployment never said. Injected as data exactly like `describe`, so
+   * this module stays i18n-free.
+   */
+  accountLabelOf?: (providerId: string) => string | undefined;
 }): ModelPickerModel[] {
   const models: ModelPickerModel[] = [];
   for (const p of opts.visibleProviders) {
-    models.push(...providerModelRows(p, opts.statuses, opts.describe));
+    models.push(
+      ...providerModelRows(
+        p,
+        opts.statuses,
+        opts.describe,
+        opts.accountLabelOf,
+      ),
+    );
   }
   return models;
 }

--- a/app/src/lib/claude-credential-push.ts
+++ b/app/src/lib/claude-credential-push.ts
@@ -1,0 +1,51 @@
+/**
+ * The desktop → cloud Anthropic credential push, with its retry loop, as a
+ * dependency-injected function so the whole thing is node-testable
+ * (`app/tests/claude-credential-push.test.ts`). The surrounding
+ * `claude-login-remote` module drags the Tauri/store import chain, exactly like
+ * the sibling `claude-push-retry`.
+ */
+
+import {
+  isTransientPushError,
+  PUSH_RETRY_DELAYS_MS,
+} from "./claude-push-retry.ts";
+
+/** The engine method this drives: `HoustonClient.pushClaudeOAuthCredential`. */
+export type ClaudeCredentialPush = (credentialJson: string) => Promise<void>;
+
+export type ClaudeCredentialPushResult =
+  | { ok: true }
+  | { ok: false; error: unknown };
+
+/**
+ * Push once, retrying only TRANSIENT failures (a waking pod, a gateway blip) on
+ * the shared backoff. Never throws: the caller decides how loud the outcome is,
+ * because on the desktop a failure degrades to the setup-token paste flow rather
+ * than a dead spinner.
+ *
+ * `sleep` and `onRetry` are injectable so a test can run the loop without waiting
+ * and without a logger.
+ */
+export async function pushClaudeCredentialWithRetry(opts: {
+  push: ClaudeCredentialPush;
+  credentialJson: string;
+  sleep?: (ms: number) => Promise<void>;
+  onRetry?: (attempt: number, delayMs: number) => void;
+}): Promise<ClaudeCredentialPushResult> {
+  const sleep =
+    opts.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await opts.push(opts.credentialJson);
+      return { ok: true };
+    } catch (error) {
+      const delay = PUSH_RETRY_DELAYS_MS[attempt];
+      if (delay === undefined || !isTransientPushError(error)) {
+        return { ok: false, error };
+      }
+      opts.onRetry?.(attempt + 1, delay);
+      await sleep(delay);
+    }
+  }
+}

--- a/app/src/lib/claude-login-remote.ts
+++ b/app/src/lib/claude-login-remote.ts
@@ -36,10 +36,7 @@
  */
 
 import { useUIStore } from "../stores/ui";
-import {
-  isTransientPushError,
-  PUSH_RETRY_DELAYS_MS,
-} from "./claude-push-retry";
+import { pushClaudeCredentialWithRetry } from "./claude-credential-push";
 import { getEngine } from "./engine";
 import i18n from "./i18n";
 import { logger } from "./logger";
@@ -58,17 +55,6 @@ type Announce = (
 
 /** Poll until the engine reads the provider connected, or the window elapses. */
 type Confirm = (provider: string) => Promise<boolean>;
-
-/**
- * `getEngine()` is typed as the legacy engine-client, but the running instance
- * is the v3 host adapter, which adds this control-plane method. Feature-detected
- * exactly like `providerStatuses` in `tauri.ts`.
- */
-type ClaudeCredentialPusher = {
-  pushClaudeOAuthCredential?: (credentialJson: string) => Promise<void>;
-};
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 export type ClaudeHandoffResult =
   | { ok: true }
@@ -99,27 +85,20 @@ async function pushMintedClaudeCredential(): Promise<ClaudeHandoffResult> {
   // unsynchronized source of the routing id: right after a space switch the
   // store can still hold the previous space's agents, so a freshly minted
   // credential would be pushed at an agent the active space does not have.
-  const engine = getEngine() as unknown as ClaudeCredentialPusher;
-  try {
-    if (!engine.pushClaudeOAuthCredential) {
-      throw new Error("This engine can't receive a pushed credential.");
-    }
-    for (let attempt = 0; ; attempt++) {
-      try {
-        await engine.pushClaudeOAuthCredential(credentialJson);
-        return { ok: true };
-      } catch (err) {
-        const delay = PUSH_RETRY_DELAYS_MS[attempt];
-        if (delay === undefined || !isTransientPushError(err)) throw err;
-        logger.warn(
-          `[claude-login] credential push failed (attempt ${attempt + 1}); retrying in ${delay}ms`,
-        );
-        await sleep(delay);
-      }
-    }
-  } catch (err) {
-    return { ok: false, reason: "push-failed", error: err };
-  }
+  //
+  // `pushClaudeOAuthCredential` is declared on `HoustonClient` itself (the legacy
+  // client rejects loudly, the v3 adapter implements it), so this needs no cast.
+  const result = await pushClaudeCredentialWithRetry({
+    push: (json) => getEngine().pushClaudeOAuthCredential(json),
+    credentialJson,
+    onRetry: (attempt, delay) =>
+      logger.warn(
+        `[claude-login] credential push failed (attempt ${attempt}); retrying in ${delay}ms`,
+      ),
+  });
+  return result.ok
+    ? { ok: true }
+    : { ok: false, reason: "push-failed", error: result.error };
 }
 
 /**

--- a/app/src/lib/credential-scope.ts
+++ b/app/src/lib/credential-scope.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure, DOM/i18n-free logic for PER-USER AI accounts (HOU-976).
+ *
+ * In a TEAM space every turn runs on the AI account of the person who sent it —
+ * there is no shared team AI account to resolve against, and no scope to
+ * address on the wire. What is left for the client is honesty: reading WHICH
+ * account the server says answered, so a surface can label it. The decisions
+ * are gathered here so each is unit-tested without a React renderer
+ * (`app/tests/credential-scope.test.ts`).
+ *
+ * ABSENCE IS THE OLD WORLD. Every per-scope wire field is optional and omitted
+ * whenever the turn/request carried no acting identity — desktop, self-host, a
+ * personal space, routines. Every helper below therefore treats "no scope
+ * information" as "one account, nothing to disambiguate", which is exactly the
+ * rendering that shipped before this feature.
+ */
+
+import type { CredentialScope } from "@houston-ai/engine-client";
+
+/**
+ * The per-scope credential context a provider error / status row may carry.
+ * Structurally identical in `@houston-ai/chat` and `@houston-ai/engine-client`;
+ * spelled locally so this module stays dependency-light and both shapes pass in.
+ */
+export interface CredentialContext {
+  scope?: CredentialScope;
+}
+
+/**
+ * The account a provider's models are offered on, or `null` when the deployment
+ * never said. `null` means the picker labels the row exactly as it did before
+ * this feature — one account, no qualifier.
+ */
+export function credentialScopeOf(
+  row: CredentialContext | undefined,
+): CredentialScope | null {
+  return row?.scope === "personal" || row?.scope === "team" ? row.scope : null;
+}
+
+/**
+ * The same read for a probed `ProviderStatus`, whose field is spelled
+ * `credentialScope` rather than `scope`.
+ *
+ * It exists because every field of {@link CredentialContext} is optional, so a
+ * status object passed to {@link credentialScopeOf} type-checks and silently
+ * answers `null` forever. One named reader per shape is what makes that
+ * impossible instead of merely unlikely.
+ */
+export function statusCredentialScope(
+  status: { credentialScope?: CredentialScope } | undefined,
+): CredentialScope | null {
+  return credentialScopeOf({ scope: status?.credentialScope });
+}

--- a/app/src/lib/model-picker.ts
+++ b/app/src/lib/model-picker.ts
@@ -38,3 +38,26 @@ export function pickerModelRows(
     ? [{ id: runtimeModelId, label: runtimeModelId, description: subtitle }]
     : [];
 }
+
+/**
+ * Name the ACCOUNT a model runs on at the end of its row subtitle (HOU-976 §6):
+ * "Best for complex work · your account".
+ *
+ * In a team space a provider may be connected twice — the member's own account
+ * and the team's shared one — and which of them answered is the difference
+ * between a limit that is theirs to wait out and one to raise with an admin. The
+ * label sits AFTER the model's own description so the reading order stays
+ * model-first; provenance is the qualifier, not the headline.
+ *
+ * `accountLabel` is undefined on every deployment that never said (desktop,
+ * self-host, a personal space, a gateway predating the field), and then the
+ * subtitle is returned verbatim — the picker reads exactly as it did before this
+ * feature. i18n-free by design: the caller passes the already-translated label.
+ */
+export function withAccountLabel(
+  description: string,
+  accountLabel: string | undefined,
+): string {
+  if (!accountLabel) return description;
+  return description ? `${description} · ${accountLabel}` : accountLabel;
+}

--- a/app/src/lib/org-roles.ts
+++ b/app/src/lib/org-roles.ts
@@ -57,20 +57,29 @@ export function canSeeMembers(caps: Capabilities | null | undefined): boolean {
 }
 
 /**
- * Should the global AI Models hub be visible to this caller? In a Teams
- * workspace the hub is owner/admin territory: AI provider connections are
- * org-level (one credential per org — whoever connects, every member's agents
- * work; C6), so a plain member has no account to connect there. Members pick
- * their own model per agent in the composer instead. Everyone else —
- * single-player and non-Teams multiplayer — keeps the hub unchanged. A
- * cosmetic gate: the gateway is the real enforcer (a member's provider-connect
- * POST already 403s); this only hides an affordance that would be dead for a
- * plain member.
+ * Should the global AI Models hub be visible to this caller? ALWAYS — for
+ * everyone, in every deployment (HOU-976).
+ *
+ * It used to be owner/admin territory in a Teams workspace, on the premise that
+ * AI provider connections were org-level and a plain member therefore had no
+ * account to connect. That premise is gone: a team space has NO shared AI
+ * account — every turn runs on the AI account of the member who sent it — so the
+ * hub is where each of them connects their own. Hiding it left the only surface
+ * that can manage a personal account unreachable by the person who owns it, with
+ * no admin able to connect one on their behalf.
+ *
+ * Opening the hub does NOT widen anything else: the TEAM's own consumption is
+ * not on it. Per-account usage on a hub card is the caller's own account
+ * (HOU-789), while the space-wide roll-up lives in Admin > Usage behind
+ * {@link canSeeOrganization} (HOU-788), which is untouched.
+ *
+ * Kept as a function (rather than deleted at every call site) because it names
+ * WHY the surface is visible, and because the gateway remains the real enforcer
+ * of every write behind it.
  */
 export function canSeeAiModelsPage(
-  caps: Capabilities | null | undefined,
+  _caps: Capabilities | null | undefined,
 ): boolean {
-  if (isMultiplayer(caps) && caps?.teams === true) return canSeeMembers(caps);
   return true;
 }
 

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -15,6 +15,7 @@ import type {
   AddCustomIntegrationInput,
   AgentAssignment,
   CommunitySkillPreview,
+  CredentialScope,
   CustomEndpoint,
   EditableProfileUpdate,
   ComposioAppEntry as EngineComposioAppEntry,
@@ -1350,6 +1351,13 @@ export interface ProviderStatus {
    * chat model picker can show + select it. Absent for catalog-backed providers.
    */
   active_model?: string;
+  /**
+   * WHOSE credential produced this probe (HOU-976). Absent on desktop,
+   * self-host, and any deployment with no acting identity — there is exactly one
+   * credential there and nothing to disambiguate, so every pre-HOU-976 surface
+   * reads the shape it always read.
+   */
+  credentialScope?: CredentialScope;
 }
 
 /**
@@ -1384,6 +1392,10 @@ export const tauriProvider = {
         authenticated: p.authState === "authenticated",
         cli_name: p.cliName,
         active_model: p.activeModel,
+        // Copy the credential attribution THROUGH (HOU-976). This mapping only
+        // keeps fields it names explicitly, so omitting it would silently
+        // swallow which account answered. Absent stays absent.
+        credentialScope: p.credentialScope,
       };
     }),
   /**
@@ -1422,6 +1434,10 @@ export const tauriProvider = {
             authenticated: p.authState === "authenticated",
             cli_name: p.cliName,
             active_model: p.activeModel,
+            // Same explicit copy-through as checkStatus (HOU-976): the batched
+            // path feeds the chat model picker, which is where the account label
+            // is actually rendered.
+            credentialScope: p.credentialScope,
           };
         });
         return out;

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -30,6 +30,10 @@
     "models_one": "{{count}} model",
     "models_other": "{{count}} models"
   },
+  "accounts": {
+    "title": "Your accounts",
+    "description": "Every agent in this team space runs on the AI account of whoever messages it, so the accounts you connect here are your own."
+  },
   "directory": {
     "search": "Search {{count}}+ models",
     "searchFew": "Search models",

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -194,14 +194,14 @@
           "title": "No providers connected yet.",
           "hint": "Connect an AI model to start chatting."
         },
-        "teamCanConnect": {
-          "title": "This team space has no AI connection yet.",
-          "hint": "Connect an AI model for this team and everyone here can use it."
-        },
-        "teamAskAdmin": {
-          "title": "This team space has no AI connection yet.",
-          "hint": "Ask a team owner or admin to connect an AI model for this space."
+        "team": {
+          "title": "You have not connected an AI account yet.",
+          "hint": "Connect your own AI account and this team's agents will answer you."
         }
+      },
+      "account": {
+        "personal": "your account",
+        "team": "team account"
       },
       "hiddenByWorkspace_one": "{{count}} more model is turned off in your workspace",
       "hiddenByWorkspace_other": "{{count}} more models are turned off in your workspace"

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -347,6 +347,9 @@
       "switchToFallback": "Switch to {{model}}",
       "pickAnother": "Pick another model"
     },
+    "credential": {
+      "modelUnavailableBody": "{{model}} is not available on your personal {{provider}} account."
+    },
     "unauthenticated": {
       "title": "Sign in to {{provider}} again",
       "bodyTokenExpired": "Your {{provider}} session expired. Reconnect to continue.",

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -30,6 +30,10 @@
     "models_one": "{{count}} modelo",
     "models_other": "{{count}} modelos"
   },
+  "accounts": {
+    "title": "Tus cuentas",
+    "description": "Cada agente de este espacio de equipo usa la cuenta de IA de quien le escribe, así que las cuentas que conectas aquí son las tuyas."
+  },
   "directory": {
     "search": "Busca {{count}}+ modelos",
     "searchFew": "Buscar modelos",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -194,14 +194,14 @@
           "title": "Aún no hay proveedores conectados.",
           "hint": "Conecta un modelo de IA para empezar a chatear."
         },
-        "teamCanConnect": {
-          "title": "Este espacio de equipo aún no tiene una conexión de IA.",
-          "hint": "Conecta un modelo de IA para este equipo y todos aquí podrán usarlo."
-        },
-        "teamAskAdmin": {
-          "title": "Este espacio de equipo aún no tiene una conexión de IA.",
-          "hint": "Pídele a un propietario o administrador del equipo que conecte un modelo de IA para este espacio."
+        "team": {
+          "title": "Aún no has conectado una cuenta de IA.",
+          "hint": "Conecta tu propia cuenta de IA y los agentes de este equipo te responderán."
         }
+      },
+      "account": {
+        "personal": "tu cuenta",
+        "team": "cuenta del equipo"
       },
       "hiddenByWorkspace_one": "{{count}} modelo más está desactivado en tu espacio de trabajo",
       "hiddenByWorkspace_other": "{{count}} modelos más están desactivados en tu espacio de trabajo"

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -347,6 +347,9 @@
       "switchToFallback": "Cambiar a {{model}}",
       "pickAnother": "Elegir otro modelo"
     },
+    "credential": {
+      "modelUnavailableBody": "{{model}} no está disponible en tu cuenta personal de {{provider}}."
+    },
     "unauthenticated": {
       "title": "Conéctate a {{provider}} de nuevo",
       "bodyTokenExpired": "Tu sesión de {{provider}} expiró. Vuelve a conectarte para continuar.",

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -30,6 +30,10 @@
     "models_one": "{{count}} modelo",
     "models_other": "{{count}} modelos"
   },
+  "accounts": {
+    "title": "Suas contas",
+    "description": "Cada agente deste espaço de equipe usa a conta de IA de quem escreve para ele, então as contas que você conecta aqui são as suas."
+  },
   "directory": {
     "search": "Busque {{count}}+ modelos",
     "searchFew": "Buscar modelos",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -194,14 +194,14 @@
           "title": "Nenhum provedor conectado ainda.",
           "hint": "Conecte um modelo de IA para começar a conversar."
         },
-        "teamCanConnect": {
-          "title": "Este espaço de equipe ainda não tem uma conexão de IA.",
-          "hint": "Conecte um modelo de IA para esta equipe e todos aqui poderão usar."
-        },
-        "teamAskAdmin": {
-          "title": "Este espaço de equipe ainda não tem uma conexão de IA.",
-          "hint": "Peça a um proprietário ou administrador da equipe para conectar um modelo de IA para este espaço."
+        "team": {
+          "title": "Você ainda não conectou uma conta de IA.",
+          "hint": "Conecte sua própria conta de IA e os agentes desta equipe vão responder você."
         }
+      },
+      "account": {
+        "personal": "sua conta",
+        "team": "conta da equipe"
       },
       "hiddenByWorkspace_one": "{{count}} modelo a mais está desativado no seu espaço de trabalho",
       "hiddenByWorkspace_other": "{{count}} modelos a mais estão desativados no seu espaço de trabalho"

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -332,6 +332,9 @@
       "switchToFallback": "Trocar para {{model}}",
       "pickAnother": "Escolher outro modelo"
     },
+    "credential": {
+      "modelUnavailableBody": "O modelo {{model}} não está disponível na sua conta pessoal {{provider}}."
+    },
     "unauthenticated": {
       "title": "Conecte-se ao {{provider}} novamente",
       "bodyTokenExpired": "Sua sessão do {{provider}} expirou. Reconecte para continuar.",

--- a/app/tests/card-unification.test.ts
+++ b/app/tests/card-unification.test.ts
@@ -48,9 +48,10 @@ describe("HOU-467 / HOU-529 card unification", () => {
   });
 
   it("RateLimitedCard becomes a RowCard with a clock + icon-free buttons", () => {
-    const src = read(
-      "../src/components/shell/provider-error-cards/transient.tsx",
-    );
+    // The account-shaped limit variants live in `limits.tsx` since HOU-976 split
+    // them from the retry-now transients; `transient.tsx` keeps network /
+    // provider-internal / malformed.
+    const src = read("../src/components/shell/provider-error-cards/limits.tsx");
     ok(src.includes("RateLimitedCard"), "card still exists");
     ok(src.includes("RowCard"), "rate-limit migrated to RowCard");
     // The rate-limit retry is the shared `RetryButton` — a text-only
@@ -67,10 +68,14 @@ describe("HOU-467 / HOU-529 card unification", () => {
       "rate-limit shows a clock, not the provider logo",
     );
     ok(!src.includes("ProviderGlyph"), "rate-limit dropped the provider glyph");
-    // Every transient variant now renders on the unified RowCard — none remain
-    // on the old ErrorCard layout.
+    // Every limit + transient variant renders on the unified RowCard — none
+    // remain on the old ErrorCard layout.
+    ok(!src.includes("ErrorCard"), "all limit variants migrated off ErrorCard");
+    const transient = read(
+      "../src/components/shell/provider-error-cards/transient.tsx",
+    );
     ok(
-      !src.includes("ErrorCard"),
+      transient.includes("RowCard") && !transient.includes("ErrorCard"),
       "all transient variants migrated off ErrorCard",
     );
 

--- a/app/tests/claude-credential-push.test.ts
+++ b/app/tests/claude-credential-push.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  type ClaudeCredentialPush,
+  pushClaudeCredentialWithRetry,
+} from "../src/lib/claude-credential-push.ts";
+
+/**
+ * The desktop Anthropic browser login's credential push, retry loop included.
+ *
+ * WHOSE account the mint lands on is decided server-side from the space the push
+ * is made in (HOU-976), so the push itself carries a credential and nothing
+ * else — the cases below pin the retry contract and the one-argument wire that
+ * keeps a scope from creeping back in.
+ */
+
+/** A pusher that records exactly what it was called with. */
+function recorder(outcomes: unknown[] = []) {
+  const calls: string[] = [];
+  const push: ClaudeCredentialPush = async (json) => {
+    calls.push(json);
+    const outcome = outcomes[calls.length - 1];
+    if (outcome) throw outcome;
+  };
+  return { calls, push };
+}
+
+/** Retries must not really wait; the delays themselves are pinned elsewhere. */
+const noSleep = async () => {};
+
+describe("pushClaudeCredentialWithRetry", () => {
+  it("pushes the credential, and nothing else", async () => {
+    // One argument, by construction: there is no account to address, so there is
+    // no scope for a caller to get backwards.
+    const { calls, push } = recorder();
+    const result = await pushClaudeCredentialWithRetry({
+      push,
+      credentialJson: '{"claudeAiOauth":{}}',
+      sleep: noSleep,
+    });
+    assert.deepEqual(result, { ok: true });
+    assert.deepEqual(calls, ['{"claudeAiOauth":{}}']);
+  });
+
+  it("re-sends the SAME credential on every retry", async () => {
+    // A waking pod 503s the first push; the retry must carry the same mint, not
+    // a re-read of a dir the first attempt may already have discarded.
+    const { calls, push } = recorder([{ status: 503 }, { status: 503 }]);
+    const result = await pushClaudeCredentialWithRetry({
+      push,
+      credentialJson: '{"claudeAiOauth":{}}',
+      sleep: noSleep,
+    });
+    assert.deepEqual(result, { ok: true });
+    assert.deepEqual(calls, [
+      '{"claudeAiOauth":{}}',
+      '{"claudeAiOauth":{}}',
+      '{"claudeAiOauth":{}}',
+    ]);
+  });
+
+  it("a terminal failure is reported, never retried", async () => {
+    const refused = { status: 403 };
+    const { calls, push } = recorder([refused]);
+    const result = await pushClaudeCredentialWithRetry({
+      push,
+      credentialJson: "{}",
+      sleep: noSleep,
+    });
+    assert.deepEqual(result, { ok: false, error: refused });
+    assert.equal(calls.length, 1);
+  });
+
+  it("gives up after the retry budget and reports the last failure", async () => {
+    const down = { status: 500 };
+    const { calls, push } = recorder([down, down, down, down, down]);
+    const result = await pushClaudeCredentialWithRetry({
+      push,
+      credentialJson: "{}",
+      sleep: noSleep,
+    });
+    assert.deepEqual(result, { ok: false, error: down });
+    // One initial attempt plus one per backoff delay.
+    assert.equal(calls.length, 4);
+  });
+});

--- a/app/tests/credential-scope-ui.test.ts
+++ b/app/tests/credential-scope-ui.test.ts
@@ -1,0 +1,122 @@
+import { ok } from "node:assert";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+/**
+ * HOU-976 personal-only — the RENDERING contracts the pure decisions cannot
+ * cover. The node runner has no DOM, so (per the repo's React-test idiom) these
+ * assert on component source.
+ *
+ * The model: a TEAM space has no shared AI account. Every agent runs on the AI
+ * account of whoever messages it, so the hub a member opens manages THEIR
+ * accounts, an empty picker is theirs to fix, and no surface may offer to
+ * continue on somebody else's account or send them off to find an admin.
+ */
+
+const read = (rel: string) =>
+  readFileSync(new URL(rel, import.meta.url), "utf8");
+
+const CREDENTIAL_SURFACES = [
+  "../src/components/shell/provider-error-cards/auth.tsx",
+  "../src/components/shell/provider-error-cards/limits.tsx",
+  "../src/components/shell/provider-error-cards/quota.tsx",
+  "../src/components/shell/provider-reconnect-card.tsx",
+  "../src/components/ai-hub/ai-hub-view.tsx",
+  "../src/components/ai-hub/provider-modal.tsx",
+  "../src/components/ai-hub/provider-modal-footer.tsx",
+  "../src/components/ai-hub/provider-modal-connect-button.tsx",
+];
+
+describe("no surface offers another account", () => {
+  it("the connect / reconnect / limit surfaces name no account to switch to", () => {
+    // There is nothing to switch to: the sender's own account is the only one a
+    // team space has. A CTA that promised otherwise could only fail.
+    for (const rel of CREDENTIAL_SURFACES) {
+      const src = read(rel);
+      ok(
+        !/continueOnTeam|teamFallback|credentialPin/.test(src),
+        `${rel}: still references a team-account fallback or pin`,
+      );
+    }
+  });
+
+  it("no credential call carries a scope argument", () => {
+    // WHOSE account a write lands on is the server's call, derived from the
+    // space it is made in. A client-sent scope could only restate that or
+    // contradict it.
+    for (const rel of CREDENTIAL_SURFACES) {
+      const src = read(rel);
+      ok(
+        !/credentialScope\s*:/.test(src),
+        `${rel}: passes a credentialScope on a credential call`,
+      );
+    }
+  });
+});
+
+describe("a member with nothing connected can serve themselves", () => {
+  it("the picker's team empty state points at the viewer, never at an admin", () => {
+    // The one copy path a team space has. If a role-shaped variant ever returns,
+    // the ask-your-admin dead end comes back with it.
+    const labels = read("../src/components/chat-model-selector-labels.ts");
+    ok(
+      !/teamAskAdmin|teamCanConnect/.test(labels),
+      "no role-shaped empty-state variants remain",
+    );
+    const chat = JSON.parse(read("../src/locales/en/chat.json")) as {
+      modelSelector: {
+        picker: {
+          noProviders: Record<string, { title: string; hint: string }>;
+        };
+      };
+    };
+    const noProviders = chat.modelSelector.picker.noProviders;
+    ok(noProviders.team, "a team space has its own empty-state copy");
+    ok(
+      /your own AI account/i.test(noProviders.team.hint),
+      "and it tells the viewer to connect their OWN account",
+    );
+    ok(
+      !/admin|owner/i.test(
+        `${noProviders.team.title} ${noProviders.team.hint}`,
+      ),
+      "with nobody else to go ask",
+    );
+  });
+
+  it("the hub says whose accounts these are, in a team space only", () => {
+    // A member opening the hub must not read these rows as the team's shared
+    // connections — there are none. One heading carries that, and only where
+    // there is more than one person in the space to confuse it with.
+    const view = read("../src/components/ai-hub/ai-hub-view.tsx");
+    ok(view.includes("isTeamWorkspace"), "the note is gated on a team space");
+    ok(view.includes('t("accounts.title")'), "and renders the heading");
+    ok(view.includes("<h2"), "as a real heading, not body text");
+  });
+});
+
+describe("designed states", () => {
+  it("every RowCard action slot collapses to undefined, never to a fragment or false", () => {
+    // `RowCard` tests its action slot with `!= null`, so BOTH an empty fragment
+    // and `false` mount the action <span> and its `gap-2`: a phantom button
+    // column on a card that has no buttons. The only two safe shapes are a plain
+    // element and a ternary whose else-branch is `undefined`.
+    for (const file of ["limits.tsx", "quota.tsx"]) {
+      const src = read(`../src/components/shell/provider-error-cards/${file}`);
+      const slots = src
+        .split("action={")
+        .slice(1)
+        .map((rest) => rest.slice(0, rest.indexOf("\n        }")));
+      ok(slots.length > 0, `${file}: has action slots to check`);
+      for (const slot of slots) {
+        const conditional = slot.includes("? (");
+        ok(
+          conditional
+            ? slot.includes(": undefined")
+            : slot.trimStart()[0] === "<",
+          `${file}: an action slot may only be a plain element or a \`… ? … : undefined\` (got: ${slot.trim().slice(0, 60)})`,
+        );
+      }
+    }
+  });
+});

--- a/app/tests/credential-scope.test.ts
+++ b/app/tests/credential-scope.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  credentialScopeOf,
+  statusCredentialScope,
+} from "../src/lib/credential-scope.ts";
+import { withAccountLabel } from "../src/lib/model-picker.ts";
+
+/**
+ * HOU-976 — per-user AI accounts, decision by decision.
+ *
+ * In a TEAM space every turn runs on the AI account of the person who sent it;
+ * there is no shared team AI account, and no client-side scope to address. What
+ * survives on this side is READING the server's verdict so a surface can label
+ * the account honestly — that is all these helpers do.
+ *
+ * The invariant every case below defends: ABSENCE IS THE OLD WORLD. The scope
+ * is omitted whenever a turn or request carried no acting identity (desktop,
+ * self-host, a personal space, a routine), and each helper must then produce
+ * exactly the behavior that shipped before this feature — one account, nothing
+ * to disambiguate, no new chrome.
+ */
+
+describe("credentialScopeOf", () => {
+  it("passes the two real scopes through", () => {
+    assert.equal(credentialScopeOf({ scope: "personal" }), "personal");
+    assert.equal(credentialScopeOf({ scope: "team" }), "team");
+  });
+
+  it("null whenever the deployment never said", () => {
+    assert.equal(credentialScopeOf(undefined), null);
+    assert.equal(credentialScopeOf({}), null);
+  });
+});
+
+describe("statusCredentialScope", () => {
+  it("reads the PROBE's field name, which is not the wire sidecar's", () => {
+    // A `ProviderStatus` spells it `credentialScope`. Handing one to
+    // `credentialScopeOf` (which reads `scope`) type-checks — every field of
+    // CredentialContext is optional — and then answers null forever.
+    assert.equal(
+      statusCredentialScope({ credentialScope: "personal" }),
+      "personal",
+    );
+    assert.equal(statusCredentialScope({ credentialScope: "team" }), "team");
+  });
+
+  it("null whenever the probe never said", () => {
+    assert.equal(statusCredentialScope(undefined), null);
+    assert.equal(statusCredentialScope({}), null);
+  });
+});
+
+describe("withAccountLabel (picker row subtitle)", () => {
+  it("appends the account after the model's own description", () => {
+    // Model first, provenance as the qualifier.
+    assert.equal(
+      withAccountLabel("Best for complex work", "your account"),
+      "Best for complex work · your account",
+    );
+  });
+
+  it("a description-less row shows the account alone", () => {
+    assert.equal(withAccountLabel("", "team account"), "team account");
+  });
+
+  it("no label leaves the subtitle verbatim", () => {
+    assert.equal(
+      withAccountLabel("Best for complex work", undefined),
+      "Best for complex work",
+    );
+    assert.equal(withAccountLabel("", undefined), "");
+  });
+});

--- a/app/tests/org-roles.test.ts
+++ b/app/tests/org-roles.test.ts
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepStrictEqual, notStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import type { Capabilities, OrgRole } from "@houston-ai/engine-client";
 import {
@@ -77,23 +77,29 @@ describe("canSeeMembers / canManageMembers", () => {
   });
 });
 
-describe("canSeeAiModelsPage", () => {
-  const teams = (role: OrgRole): Capabilities =>
-    caps({ multiplayer: true, role, teams: true });
+const teams = (role: OrgRole): Capabilities =>
+  caps({ multiplayer: true, role, teams: true });
 
-  it("single-player keeps the AI Models hub", () => {
-    strictEqual(canSeeAiModelsPage(caps()), true);
-    strictEqual(canSeeAiModelsPage(null), true);
+describe("canSeeAiModelsPage (HOU-976)", () => {
+  // Six role/deployment cases used to be spelled out here against a function
+  // that now returns a constant, so not one of them could fail. The gate itself
+  // needs exactly one line; what CAN regress is the SEPARATION below.
+  it("is true for everyone, in every deployment", () => {
+    strictEqual(canSeeAiModelsPage(teams("user")), true);
   });
 
-  it("non-Teams multiplayer keeps it for every role", () => {
-    strictEqual(canSeeAiModelsPage(multiplayer("user")), true);
-  });
-
-  it("in a Teams workspace only owner/admin see it (providers are org-level)", () => {
-    strictEqual(canSeeAiModelsPage(teams("owner")), true);
-    strictEqual(canSeeAiModelsPage(teams("admin")), true);
-    strictEqual(canSeeAiModelsPage(teams("user")), false);
+  it("does not carry the owner/admin matrix that guards team consumption", () => {
+    // Opening the hub (every member connects their OWN AI account there) must
+    // not widen the space-wide spend surface with it: the team roll-up lives in
+    // Admin > Usage, which still rides the owner/admin matrix (`canSeeMembers`,
+    // through `canSeeOrganization`). Re-uniting the two would either hide the
+    // hub from the member whose own account it exists to manage, or open the
+    // space's spend to every member.
+    strictEqual(canSeeMembers(teams("user")), false);
+    notStrictEqual(
+      canSeeAiModelsPage(teams("user")),
+      canSeeMembers(teams("user")),
+    );
   });
 });
 

--- a/app/tests/picker-account-label.test.ts
+++ b/app/tests/picker-account-label.test.ts
@@ -1,0 +1,101 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { buildPickerModels } from "../src/lib/chat-model-picker-map.ts";
+
+/**
+ * The chat model picker names WHOSE AI account a provider's models run on
+ * (HOU-976 §6): a member on their own account reads "your account", a member
+ * running on the team's reads "team account", and a deployment that reports no
+ * scope at all reads exactly what it read before the feature existed.
+ *
+ * These live here, in the GATED suite (`pnpm test` globs `tests/*.test.ts`),
+ * rather than beside `chat-model-picker-map.ts`: the colocated
+ * `src/lib/*.test.mjs` files are run by no script and no CI job, so coverage
+ * placed there is coverage nobody enforces. The pure `withAccountLabel` rule and
+ * the scope decisions this reads from are in `credential-scope.test.ts`.
+ */
+
+/** A normal catalogued provider: one curated model, a non-empty subtitle. */
+const testProv = {
+  id: "testprov",
+  name: "Test",
+  subtitle: "sub",
+  models: [{ id: "m1", label: "M1 label", description: "curated desc" }],
+};
+const orProv = {
+  id: "openrouter",
+  name: "OpenRouter",
+  subtitle: "",
+  models: [
+    { id: "vendor/or-1", label: "OR One label", description: "or curated" },
+  ],
+};
+/** The local OpenAI-compatible provider: no catalog, model reported at runtime. */
+const localProv = {
+  id: "openai-compatible",
+  name: "Local",
+  subtitle: "Ollama",
+  models: [],
+};
+
+describe("picker rows name the AI account (HOU-976)", () => {
+  it("appends the account to a row's subtitle", () => {
+    const [m] = buildPickerModels({
+      visibleProviders: [testProv],
+      statuses: {},
+      accountLabelOf: (id) => (id === "testprov" ? "your account" : undefined),
+    });
+    strictEqual(m.description, "curated desc · your account");
+  });
+
+  it("qualifies the LOCALIZED description, not the catalog English", () => {
+    // Order matters: the label must sit after the translated text, else a
+    // Spanish picker reads an English fallback with a Spanish suffix.
+    const [m] = buildPickerModels({
+      visibleProviders: [testProv],
+      statuses: {},
+      describe: (_p, id, fallback) => `t:${id}:${fallback}`,
+      accountLabelOf: () => "team account",
+    });
+    strictEqual(m.description, "t:m1:curated desc · team account");
+  });
+
+  it("labels per provider: one scoped row does not label its neighbour", () => {
+    const rows = buildPickerModels({
+      visibleProviders: [testProv, orProv],
+      statuses: {},
+      accountLabelOf: (id) =>
+        id === "openrouter" ? "team account" : undefined,
+    });
+    strictEqual(rows[0].description, "curated desc");
+    strictEqual(rows[1].description, "or curated · team account");
+  });
+
+  it("is byte-identical to today with no scope reported", () => {
+    // Absence is the old world: desktop, self-host and a personal space report
+    // no scope, so their rows must be indistinguishable from the pre-HOU-976
+    // ones. Asserted as a deep-equal against the label-less build, so a future
+    // change that starts emitting an empty qualifier fails here.
+    const before = buildPickerModels({
+      visibleProviders: [testProv],
+      statuses: {},
+    });
+    deepStrictEqual(
+      buildPickerModels({
+        visibleProviders: [testProv],
+        statuses: {},
+        accountLabelOf: () => undefined,
+      }),
+      before,
+    );
+  });
+
+  it("labels the catalog-less local provider's dynamic row too", () => {
+    const [m] = buildPickerModels({
+      visibleProviders: [localProv],
+      statuses: { "openai-compatible": { active_model: "llama3.1" } },
+      accountLabelOf: () => "your account",
+    });
+    strictEqual(m.description, "Ollama · your account");
+  });
+});

--- a/app/tests/picker-empty-state.test.ts
+++ b/app/tests/picker-empty-state.test.ts
@@ -4,14 +4,18 @@ import type { Capabilities, OrgRole } from "@houston-ai/engine-client";
 import { pickerEmptyState } from "../src/components/chat-model-selector-labels.ts";
 
 /**
- * HOU-979 — the chat picker's empty state, and who may act on it.
+ * HOU-979 / HOU-976 — the chat picker's empty state, and who may act on it.
  *
- * Provider connections are ORG-level in a team space, so a plain member cannot
- * open the AI Models hub. The bug these pin: the decision read capabilities
- * that had not arrived yet, and the underlying role check answers TRUE for
- * absent capabilities (the single-player default) — so a member was shown a
- * Connect action for a beat and then had it swapped for "ask an admin". A
- * promise made and withdrawn is worse than no promise.
+ * HOU-976 removed the ask-your-admin ending entirely. A team space has no shared
+ * AI account for an admin to connect on anyone's behalf: every agent runs on the
+ * AI account of whoever messages it, so the member staring at an empty picker is
+ * always the person who can fix it. There is no role that changes the story.
+ *
+ * The bug these still pin (HOU-979): the decision read capabilities that had not
+ * arrived yet, and the underlying role check answers TRUE for absent capabilities
+ * (the single-player default) — so the surface promised a Connect action before
+ * it knew a hub existed at all. A promise made and withdrawn is worse than no
+ * promise, which is why `capabilitiesLoaded` remains the gate on the ACTION.
  */
 
 const team = (role: OrgRole): Capabilities => ({
@@ -39,38 +43,36 @@ test("a personal space tells the personal story and offers the action", () => {
   );
 });
 
-test("a team space viewed by an owner offers the action", () => {
-  assert.deepEqual(
-    pickerEmptyState({
-      teamSpace: true,
-      capabilities: team("owner"),
-      capabilitiesLoaded: true,
-    }),
-    { variant: "teamCanConnect", canConnect: true },
-  );
-});
-
-test("a team space viewed by a plain member names who can, and offers nothing", () => {
-  assert.deepEqual(
-    pickerEmptyState({
-      teamSpace: true,
-      capabilities: team("user"),
-      capabilitiesLoaded: true,
-    }),
-    { variant: "teamAskAdmin", canConnect: false },
-  );
+test("a team space tells ONE story, whoever is looking (HOU-976)", () => {
+  // Owner and plain member get the identical decision: connect YOUR account.
+  // Any divergence here would be a role-shaped copy path, which is exactly the
+  // ask-your-admin dead end personal-only deleted.
+  const owner = pickerEmptyState({
+    teamSpace: true,
+    capabilities: team("owner"),
+    capabilitiesLoaded: true,
+  });
+  const member = pickerEmptyState({
+    teamSpace: true,
+    capabilities: team("user"),
+    capabilitiesLoaded: true,
+  });
+  assert.deepEqual(owner, { variant: "team", canConnect: true });
+  assert.deepEqual(member, owner);
 });
 
 test("withholds the action entirely until capabilities have LOADED", () => {
-  // The regression: mid-fetch `capabilities` is null, which the role check
-  // reads as single-player (permissive) — so the member briefly got a CTA.
+  // Mid-fetch `capabilities` is null, which the role check reads permissively —
+  // so without this gate the surface promises a Connect before it knows the
+  // deployment describes a hub at all. The COPY does not waver meanwhile: it
+  // never depended on the viewer, so there is nothing to withdraw.
   const midFetch = pickerEmptyState({
     teamSpace: true,
     capabilities: null,
     capabilitiesLoaded: false,
   });
   assert.equal(midFetch.canConnect, false);
-  assert.equal(midFetch.variant, "teamAskAdmin");
+  assert.equal(midFetch.variant, "team");
 
   // Personal spaces are gated by the same rule, so no surface can offer an
   // action into a hub whose access we have not established yet.
@@ -85,8 +87,7 @@ test("withholds the action entirely until capabilities have LOADED", () => {
 });
 
 test("a capabilities load that FAILED settles on the single-player default", () => {
-  // Failed is not pending: an undescribed deployment is the single-player one,
-  // and pinning a lone desktop user at "ask an admin" would be its own bug.
+  // Failed is not pending: an undescribed deployment is the single-player one.
   assert.deepEqual(
     pickerEmptyState({
       teamSpace: false,

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -862,6 +862,11 @@ Press motion is transitioned on `background-color` + **`scale`** (not
 `transform`): Tailwind v4's `scale-*` utilities set the standalone `scale`
 property, so naming `transform` would silently leave the press un-eased.
 
+**In a team space the strip is the VIEWER's own accounts** (HOU-976): the status
+and usage probes behind it resolve against the acting member's credential, so
+two members open the same hub and see different Connected rows. There is no
+shared team account to show beside them.
+
 **The strip's mount is NOT the gate.** The strip is the hub's "yours" side, so
 its membership means "the user's accounts" and by design includes rows whose
 probe could not be confirmed (`providerOwnedSide` = connected ∪ checking,

--- a/knowledge-base/anthropic-credentials.md
+++ b/knowledge-base/anthropic-credentials.md
@@ -30,6 +30,7 @@ refresh-less and remain safe to replace on every serve cycle.
 | Desktop (macOS) | Keychain item scoped to `<HOUSTON_HOME>/claude-login` (`claude auth login` writes it) | The SDK/CLI, in place |
 | Desktop (Linux/Win) / self-host | `<HOUSTON_HOME>/claude-login/.credentials.json` | The SDK/CLI, in place |
 | Managed cloud pod | Gateway Pg store (`/v1/pod/credentials`), captured at connect; pod materialization is access-only | The **gateway only** (single rotator; anthropic entry in `internal/credentials`, JSON grant) |
+| Managed cloud pod, **personal** account (HOU-976) | Gateway Pg store keyed **(org, user, provider)**; served access-only per turn as `CLAUDE_CODE_OAUTH_TOKEN`, **never materialized to disk** | The **gateway only**, same single rotator, per row |
 | Setup-token paste (any) | `auth.json` `api_key` entry (never expires) | Nobody |
 
 ## The flows
@@ -58,8 +59,19 @@ refresh-less and remain safe to replace on every serve cycle.
   (Rust) extracts it — file first, then the Keychain item
   `Claude Code-credentials-<sha256(dir)[:8]>` (the CLI scopes the service name
   by config dir; account = username) — and pushes it: host route
-  `POST /agents/:id/credential/claude-oauth` → central store put (access +
-  refresh) + materialize on the pod. Once the push settles the local copy is
+  `POST /agents/:id/credential/claude-oauth` → central store put
+  (access + refresh) + materialize on the pod. **The desktop path names NO
+  account** (HOU-976): `launchLogin(provider)` → `beginClaudeBrowserLogin` →
+  `finishRemoteClaudeLogin` → `pushClaudeCredentialWithRetry`
+  (`app/src/lib/claude-credential-push.ts`, the node-testable retry loop) →
+  `pushClaudeOAuthCredential(json)`, and the setup-token paste FALLBACK is
+  likewise scope-free. WHOSE row the push lands on is the gateway's call, derived
+  from the space the request is made in: a team space has no shared AI account, so
+  it is the acting member's own; a personal space has exactly one. A scope
+  threaded down this path could only restate that or contradict it, which is why
+  the URL is asserted WHOLE in `packages/web/tests/credential-write-urls.test.ts`
+  — byte identity, so one cannot creep back as a query param, a path segment or a
+  second query. Once the push settles the local copy is
   DESTROYED (`discard_claude_handoff_credential`): the gateway is that
   family's only rotator from then on. Every space the user connects mints its
   own family this way; there is deliberately NO path that seeds a space from a
@@ -81,10 +93,16 @@ refresh-less and remain safe to replace on every serve cycle.
   no_credentials` for that provider; reconnecting restores the credential and
   the app's normal unauthenticated auto-resume retries the undelivered prompt.
   Unpinned no-provider requests retain their `409 no_provider` contract. This is
-  what survives pod recycles:
-  `/data` is an emptyDir in prod and store-sync EXCLUDES both credential files.
+  what survives pod recycles: `/data` is an emptyDir in prod, and no credential
+  file syncs to the object store — but by two DIFFERENT mechanisms, which matters
+  when you add one. `auth.json` and the entire `auth-users/` subtree are dropped
+  **unconditionally** inside `excluded()` (`packages/runtime-client/src/
+  object-sync/hydrate.ts`, matched by path suffix / segment) so no caller can
+  configure the leak back in; `claude-login/.credentials.json` is merely a
+  NAMED ENTRY in the caller-supplied list (`STORE_SYNC_EXCLUDES`,
+  `packages/host/src/store-sync/daemon.ts`).
 
-## The five traps (each was a live bug)
+## The six traps (each was a live bug, or a guarded near-miss)
 
 1. **`USER` must reach the SDK subprocess.** The CLI names its Keychain
    *account* after the username; `buildClaudeEnv`'s allowlist passes
@@ -128,6 +146,62 @@ refresh-less and remain safe to replace on every serve cycle.
    the built-in PowerShell dir on the child PATH, and the login spawn adds
    `CREATE_NO_WINDOW`. Never PATH-scan for `bash.exe` there —
    `System32\bash.exe` is WSL and wedges the CLI.
+6. **A PERSONAL anthropic family must never reach — or be READ FROM — the shared
+   claude-login dir** (HOU-976). One pod serves every member of a team space, and
+   `<HOUSTON_HOME>/claude-login/.credentials.json` is pod-wide: it is the TEAM's
+   credential — meaning the workspace-level one the no-acting-identity `"team"`
+   scope addresses, not an account a team space offers its members (it offers
+   none; each member's turns run on their own). So nothing legitimately routes a
+   member's turn there, and every path that could is guarded. Both directions
+   are, and the read side has three moments, not one.
+
+   **WRITE.** Materializing a member's family there would (a) leak their
+   credential to every other member of that space and (b) create a SECOND rotator
+   beside the gateway, which is trap #4 with a shared file instead of a shared
+   copy. So `packages/runtime/src/backends/claude/credentials-file.ts`
+   hard-refuses to write when the acting scope is personal (guarded + tested).
+
+   **READ.** Three separate moments could authenticate a personal turn as the
+   team; all three live in `backends/claude/`:
+   - *Session creation* with no personal token → `scope-guard.ts`
+     `assertAnthropicScopeCredential` refuses, on the turn path AND the one-shot
+     path (titles, anonymize). Its message must keep the `No provider connected.`
+     prefix — that sentinel is what renders the typed reconnect card.
+   - *Mid-turn 401* → `scope-guard.ts` `anthropicCredentialStorageDir`. The
+     personal token is served ACCESS-ONLY, so it can die while the turn is still
+     running, and the Claude CLI then runs its OWN recovery: it re-reads its
+     credential store — `<dir>/.credentials.json`, or the dir-scoped macOS
+     Keychain item — and adopts whatever access token is there. Pointed at the
+     shared dir that is the team's, adopted with no error and no card. **The SDK's
+     `getOAuthToken` callback does NOT close this** (verified against the Claude
+     Code build the pinned SDK spawns, 2.1.201 / `@anthropic-ai/claude-agent-sdk`
+     0.3.201): the CLI only registers it when `CLAUDE_CODE_ENTRYPOINT` is
+     `claude-desktop` / `local-agent` / `claude-vscode` and the SDK pins ours to
+     `sdk-ts`; it is skipped whenever the stored credential has a refresh token;
+     and even when it runs it only PRECEDES the disk read, so a null return falls
+     straight through (`tengu_oauth_401_recovered_from_disk`). The lever is the
+     store's LOCATION: for a personal scope we set
+     `CLAUDE_SECURESTORAGE_CONFIG_DIR` to `<dataDir>/auth-users/<hash>.claude-storage`,
+     which relocates the CLI's credential store (the file AND the Keychain service
+     name, which is hashed from that dir) and **nothing else** —
+     `CLAUDE_CONFIG_DIR` keeps owning the `projects/` transcript tree, so resume,
+     the sessions store and cross-member conversation continuity are untouched.
+     Recovery then finds nothing, the 401 stands, and the member gets the honest
+     auth card. Team / desktop / self-host set no override at all, so that env is
+     byte-identical. Re-verify this seam on an SDK bump: it is the CLI's own
+     mechanism, but it is not part of the SDK's typed `Options`.
+   - *The "connected" status surface* → `credential-status.ts`
+     `anthropicCredentialCached()` returns false under a personal scope, so a
+     member is never shown connected on a credential that is not theirs.
+
+   A personal anthropic turn is served access-only via `CLAUDE_CODE_OAUTH_TOKEN`,
+   which outranks the config-dir credential anyway (trap #3). The runtime's
+   per-identity credential material lives under `<dataDir>/auth-users/` — the auth
+   file, its served-providers manifest, and the `.claude-storage` dir above. That
+   whole subtree is dropped from store-sync **unconditionally** by `excluded()`
+   (NOT via the configurable list, which is what carries
+   `claude-login/.credentials.json` — see "Per-turn serve" above) and is denied to
+   the agent's own file tools by `session/tools/fs-guard.ts`.
 
 ## "Connected" means USABLE, not present (all providers)
 

--- a/knowledge-base/provider-errors.md
+++ b/knowledge-base/provider-errors.md
@@ -38,10 +38,10 @@ now removed.)
 
 | Variant                    | When it fires                                                                          | UI CTAs                                              |
 |----------------------------|-----------------------------------------------------------------------------------------|------------------------------------------------------|
-| `RateLimited`              | Per-minute / short-window throttle. Wait helps.                                         | Retry, Switch model, optional `retry_after_seconds`. |
-| `QuotaExhausted`           | Long-window / billing-period limit. Wait won't help.                                    | Upgrade plan (`upgrade_url`), Switch provider.       |
+| `RateLimited`              | Per-minute / short-window throttle. Wait helps.                                         | Retry, Switch model, optional `retry_after_seconds`.  |
+| `QuotaExhausted`           | Long-window / billing-period limit. Wait won't help.                                    | Upgrade plan (`upgrade_url`), Switch provider.        |
 | `UsageLimitPaused`         | Plan-window limit hit (today: Anthropic claude-code's 5-hour subscription session limit). Fires from `rate_limit_event` `status:"rejected"` (structured `resetsAt` epoch), a `429` result whose body names a session/usage limit + reset, or the stderr "usage limit ... reset at" banner. Retrying now fails — wait for the reset. | Chat: `UsageLimitPausedCard` (title + "resets at {time}" from `resets_at`, plus Switch model — a different provider has its own limit). Routines surface "Waiting · resumes at HH:MM" via `routine_run.paused_until`. |
-| `ModelUnavailable`         | The requested model isn't available to this account (preview, deprecated, regioned).    | Switch to `suggested_fallback`, Pick another model.  |
+| `ModelUnavailable`         | The requested model isn't available to this account (preview, deprecated, regioned).    | Switch to `suggested_fallback`, Pick another model. Names the PERSONAL account in the body when `credential.scope === "personal"` (see below). |
 | `Unauthenticated`          | Auth missing/expired/invalid. `cause` narrows the body copy.                            | Reconnect (drives `tauriProvider.launchLogin`); the card then WAITS on the `ProviderLoginComplete` WS event (launchLogin resolves at CLI spawn, not completion) and flips to a green "Reconnected" state with a "Send my message" CTA (`providerError.unauthenticated.sendAgain`, only shown when there's a failed prompt to resend) or a disabled "Signed in" badge, or shows the failure and re-arms with "Reconnect". |
 | `NetworkUnreachable`       | Cannot reach the provider's API (DNS, connect refused, ECONNRESET).                     | Retry, Check status page.                            |
 | `ProviderInternal`         | 5xx from upstream, transient infra failure.                                             | Retry, Check status page.                            |
@@ -50,6 +50,42 @@ now removed.)
 | `SpawnFailed`              | CLI couldn't even spawn (binary missing, killed by OS).                                  | Report bug.                                          |
 | `Cancelled`                | User pressed Stop. Distinct so the UI shows nothing (no toast, no retry).                | none (rendered as `null`).                           |
 | `Unknown`                  | No classifier matched. Carries `raw_excerpt` (≤500 chars).                              | Report bug.                                          |
+
+### `credential` — WHOSE account failed (HOU-976)
+
+Every variant except `Cancelled` may carry one extra field:
+
+```ts
+credential?: { scope: "personal" | "team" }
+```
+
+It is **omitted entirely** unless the turn carried an acting identity, so it is
+absent on desktop, self-host, a personal space and every routine run — there is
+one credential there and nothing to disambiguate. Treat absence as "render exactly
+as before"; never default it.
+
+Populated in `packages/runtime/src/ai/provider-error.ts` from the per-identity
+serve record (`packages/runtime/src/auth/served-scope.ts`), which remembers what
+the gateway resolved for each `(acting identity, provider)` pair.
+
+**It NAMES the account; it unlocks nothing.** In a team space every turn runs on
+the AI account of the person who sent it and there is no other account to reach
+for, so this field buys exactly one thing: a card that tells the truth. "Your
+Anthropic account is rate limited" is a true sentence where a generic one is not,
+and a member whose model is refused learns it is THEIR plan that lacks it, not
+somebody else's. No card gains an ACTION from `credential` — a CTA offering
+another account could only ever fail, because the space holds none.
+
+Today one card reads it: `ModelUnavailableCard` switches its body to
+`shell:providerError.credential.modelUnavailableBody` when
+`credentialScopeOf(error.credential) === "personal"`
+(`app/src/lib/credential-scope.ts`, the one home for these reads). Reconnect is
+deliberately UNSCOPED on both the unauthenticated card and the in-chat
+`ProviderReconnectCard` (`tauriProvider.launchLogin(provider)`): the account that
+failed is the caller's own by construction, so there is nothing to target and a
+scope argument could only contradict the gateway.
+
+Full picture: `knowledge-base/teams.md` → "Per-user AI accounts".
 
 ## The classifier trait
 
@@ -336,5 +372,5 @@ unchanged.
 | Protocol     | `engine/houston-engine-protocol/src/lib.rs` (re-exports `ProviderError`)          |
 | TS type      | `ui/chat/src/types.ts`                                                            |
 | Card router  | `app/src/components/shell/provider-error-card.tsx`                                |
-| Card pieces  | `app/src/components/shell/provider-error-cards/`                                  |
+| Card pieces  | `app/src/components/shell/provider-error-cards/` — `limits.tsx` (rate-limited + usage-limit-paused), `quota.tsx` (quota-exhausted + model-unavailable, the one that names the account), `transient.tsx` (retry-now infra: network / internal / malformed), `auth.tsx`, `terminal.tsx`, `shared.tsx` (`AsyncActionButton` / `RetryButton` / `StatusPageButton`) |
 | i18n         | `app/src/locales/{en,es,pt}/shell.json` → `providerError.*`                       |

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -102,15 +102,22 @@ that also take `Pick<Agent, "access" | "assigned">` live in `agent-access.ts`
   The old `canSeeIntegrationsPage` gate was removed with the Teams policy mode.)
 - `canSeeAiModelsPage(caps)` — the gate for the global **AI Models hub** (sidebar
   nav, render branch, tour step), which is also where each connected account's
-  usage renders (HOU-789): a Teams **plain member** → false, else true. Unlike
-  Composio, AI provider connections are **org-level** (one credential
-  per org — whoever connects, every member's agents work; `cloud/docs/contracts/C6`),
-  so a member has no per-provider account to house anywhere — they pick their model
-  per agent in the composer. The hub is therefore owner/admin-only in Teams; a member
-  loses its nav entirely. This also removes a dead affordance: a member's
-  provider-connect POST already 403s at the gateway. (There is no org-wide model
-  ceiling; model policy is per agent, in the **Permissions** view's per-agent
-  detail (its AI Models tab), below.)
+  usage renders (HOU-789): **TRUE for everyone, always** since HOU-976. It used
+  to be owner/admin-only in Teams, on the premise that AI provider connections
+  were org-level and a member therefore had no account to connect. That premise
+  is gone: in a team space every turn runs on the AI account of the person who
+  sent it, so a member's own account is the ONLY thing that can answer them and
+  the hub is the only surface where they connect it. No role could connect one on
+  their behalf, which is why there is no owner/admin half left to gate. See
+  **Per-user AI accounts** below. (There is still no org-wide model ceiling;
+  model policy is per agent, in the **Permissions** view's per-agent detail (its
+  AI Models tab), below.)
+  Opening the hub widened nothing else. The usage on a hub card is the VIEWER's
+  own account, and the space-wide roll-up lives in **Settings > Admin > Usage**,
+  still behind `canSeeOrganization` (owner/admin, team space) — the two were
+  never one gate after HOU-788 moved Admin into Settings. **No role carries
+  AI-credential authority in a team space**: owner, manager and member are
+  identical there, because each can only ever address their own account.
 - **Settings > Time worked is NOT behind that gate** (HOU-790). The old Usage
   screen inherited `canSeeAiModelsPage` because it carried the org-level provider
   accounts; what is left is only the per-agent running-time analytics, so it
@@ -494,15 +501,21 @@ per team, each `{ id: "org:" + slug, kind: "org" }` where `slug` is `[a-f0-9]{16
   `providerOwnedSide()` is the render order the browse surfaces use.
 - **A team space with no credential explains itself.** When statuses settle with
   nothing connected, the picker's level 1 shows an honest empty state instead of
-  a blank panel: `personal` / `teamCanConnect` / `teamAskAdmin`
-  (`app/src/components/chat-model-selector-labels.ts`, copy under
-  `chat:modelSelector.picker.noProviders.*`). A plain member gets no CTA and no
-  "Connect more providers…" footer at all — provider connections are org-level,
-  so `canSeeAiModelsPage` is false for them and the hub would dead-end. The
-  decision is gated on capabilities having LOADED (`canSeeAiModelsPage` answers
-  TRUE for absent capabilities, which flashed a CTA at a member and withdrew it);
-  `use-picker-view-models` folds the same signal into `catalogState`, so the
-  picker holds its neutral loading state through that window.
+  a blank panel. `pickerEmptyState` (`app/src/components/chat-model-selector-labels.ts`,
+  copy under `chat:modelSelector.picker.noProviders.*`) has exactly TWO variants,
+  `personal` / `team`, because the copy depends only on which KIND of space this
+  is: every viewer of a team space has the same story ("You have not connected an
+  AI account yet." / "Connect your own AI account and this team's agents will
+  answer you."), since every one of them connects their own account and nobody
+  can connect it for them. There is deliberately no role-shaped variant: an
+  "ask a team owner or admin" line would be a dead end, because no role can
+  connect the credential this viewer is missing.
+  The ACTION stays gated on capabilities having LOADED (`canConnect`) — the
+  surface must not promise a Connect before it knows the deployment describes a
+  hub at all; `use-picker-view-models` folds the same signal into `catalogState`,
+  so the picker holds its neutral loading state through that window. A
+  capabilities load that FAILS is not "still loading": it settles on the
+  permissive single-player default, since an undescribed deployment is that.
 - **Boot with NO space settles honestly** (HOU-979). If `loadWorkspaces` fails
   (or yields no current workspace) `loadAgents` never runs, and every `loaded`
   gate hung: the boot splash never lifted and the provider probe never fired.
@@ -687,7 +700,10 @@ hides the "Add models" list, all copy passed in.
 
 - **Per-agent ceiling** — Agent Settings > **Access** > **AI models**
   (`agent-admin-model.tsx` → `AgentModelsSection`, a thin wrapper over the shared
-  editor). The whole AI-hub catalog is the selectable universe (there is no org-wide
+  editor). Manager-only, `readOnly` honoured. It answers WHICH models only —
+  there is no per-agent choice of WHOSE account, because a team space has no
+  account to choose between (see **Per-user AI accounts** below).
+  The whole AI-hub catalog is the selectable universe (there is no org-wide
   ceiling to narrow it). Copy under `teams:agentAdmin.models.*`. The per-agent model
   ceiling ALSO surfaces (via `AgentAdminModel`) in the Permissions agent detail's AI Models
   tab (`permissions/agent-detail.tsx`), same editor, same wire. (The AI Models hub's
@@ -733,6 +749,118 @@ hides the "Add models" list, all copy passed in.
   `{allowedToolkits?, allowedModels?}`. Hooks: `useAgentModelChoice` /
   `useSetAgentModelChoice` (`hooks/queries/use-agent-model-choice.ts`),
   `useSetAgentAllowedModels` (`hooks/queries/use-agent-settings.ts`).
+
+---
+
+## Per-user AI accounts (HOU-976)
+
+A team space has **no shared AI credential**. Every turn runs on the AI account
+of the person who sent it, and on nothing else: the gateway resolves the ACTING
+member's own credential row and stops there. A miss is an honest
+`404 personal_not_connected` → the provider not-connected card, and the member
+connects their own account in the AI Models hub. That is the entire remedy, so
+it must be self-serve: there is no fallback account, no per-agent choice of
+account, no one-turn override, and no role that can connect an account on
+somebody else's behalf.
+
+This is why every AI-credential role gate is gone (`canSeeAiModelsPage` is
+unconditionally true — see the role-matrix section above). A gate can only be
+justified by an authority someone actually has; nobody has authority over
+anybody else's AI account here.
+
+Storage is per **(org, user, provider)**, not (user, provider): connecting in a
+team space is consent for THAT team's agents only, and leaving a team takes the
+credential with the membership. A user in three team spaces connects three times.
+
+**The discriminator is ALWAYS server-side.** A request resolves a per-user
+credential when it carries an acting identity AND its org is a team space — two
+facts only the gateway holds. It is NOT a query param, NOT a body field, and NOT
+a signed claim the client may assert. **The client sends no scope anywhere**: no
+`?scope=` on any credential or auth route, no `credentialScope` on a send body,
+no scope argument on any credential function. A client-sent scope could only
+restate what the gateway already knows or contradict it, and a contradiction
+churns every recorded and golden request while adding nothing the gateway did
+not already have. Two tests hold the line: `packages/web/tests/credential-write-urls.test.ts`
+asserts each credential/auth URL WHOLE (byte identity, so a scope re-entering as
+a query param, a path segment or a second query fails whichever form it takes),
+and `app/tests/credential-scope-ui.test.ts` asserts no credential surface passes
+a scope or names another account.
+
+**Absence is the old world.** With NO acting identity — desktop, self-host, a
+personal space, the setup runtime, a fired routine — every path addresses the
+single workspace credential exactly as it did before this feature, byte for byte.
+That is the `"team"` scope key (`TEAM_SCOPE_KEY` in
+`packages/host/src/credentials/scope-key.ts`, `TEAM_CREDENTIAL_SCOPE` in
+`packages/runtime/src/session/acting-context.ts`): one name for "the one shared
+row", not a second account a team space can reach. `setup-runtime` credential
+writes stay owner/admin for the unrelated reason that they provision a Deployment
++ PVC.
+
+**Isolation is the whole implementation.** Only a gateway-SIGNED acting-as token
+can select a member's own credentials (`credentialScopeKeyFor`); a routine's bare
+creator sub deliberately cannot, and a token whose payload can't be decoded gets
+its own digest-named scope rather than falling back to the shared row — a garbled
+token must never READ the workspace credential. Both sides of the host↔runtime
+seam derive the key the same way, on purpose, or one member would read a
+different row per adapter. Downstream of the key: the runtime's credential store
+resolves the scope on every `read()` pi makes inside `prepareRequest`
+(`auth/credential-store.ts`, per-scope `auth.json` under `<dataDir>/auth-users/`),
+login and serve-sync are scoped the same way, the served-scope record and
+credential-health marks are keyed per `(scope, provider)`, `report-revoked` echoes
+the scope it observed and forwards the acting token, the host's remote-store cache
+is per scope, and the whole `auth-users/` subtree is denied to the agent's file
+tools (`session/tools/fs-guard.ts`) and dropped unconditionally from store-sync.
+The Anthropic-specific guards (the pod-shared `claude-login` write refusal, the
+`CLAUDE_SECURESTORAGE_CONFIG_DIR` relocation that closes mid-turn 401 recovery,
+the cached-status guard) are documented in `knowledge-base/anthropic-credentials.md`
+traps #4 and #6 — read those before touching any of it.
+
+**Attribution is read-only.** Two optional wire fields name WHOSE account
+answered, and nothing else: `ProviderError.credential.scope` on a failed turn
+(`packages/protocol/src/provider-error.ts`) and `credentialScope` on a
+`GET /providers` row (`ProviderInfo`). Both come from the runtime's per-identity
+serve record (`packages/runtime/src/auth/served-scope.ts`), which remembers what
+the gateway resolved for each `(acting identity, provider)` pair. They exist so a
+surface can say a TRUE sentence — "your Anthropic account is rate limited" rather
+than a generic one — and they unlock no action, because there is no other account
+to offer. Their `"personal"` value is the acting member's own account, the only
+one a TEAM space has; `"team"` is the single workspace-level credential of a
+personal space / desktop / self-host, reported for the surfaces that predate the
+distinction. Both fields are omitted without an acting identity, so treat absence
+as "one credential, nothing to disambiguate".
+
+**Client surface**
+
+- **The hub is one list, labelled once.** In a team space `ai-hub-view.tsx`
+  renders a "Your accounts" heading + description above the catalog
+  (`aiHub:accounts.title` / `accounts.description`: every agent in this team
+  space runs on the AI account of whoever messages it, so the accounts here are
+  your own). Saying it once, above the rows, is what keeps a member from reading
+  them as the team's shared connections. A personal space has one account and
+  nothing to qualify, so it renders no note at all and looks exactly as it
+  shipped. There are no account sections, no per-section status, and no scope on
+  any connect the hub performs.
+- **Reconnect is unscoped** (`tauriProvider.launchLogin(provider)`), on the
+  unauthenticated card and the in-chat reconnect card alike. The account that
+  failed is the caller's own by construction, so there is nothing to target.
+- **Failure copy names the account** where it changes the meaning:
+  `ModelUnavailableCard` reads `credentialScopeOf(error.credential) === "personal"`
+  (`app/src/lib/credential-scope.ts`) and switches to
+  `shell:providerError.credential.modelUnavailableBody`, so a member learns it is
+  THEIR plan that lacks the model. No card gains an action from `credential`.
+- **Model picker**: a `GET /providers` row's `credentialScope` becomes the row
+  subtitle via `statusCredentialScope` + `pickerAccountLabel`
+  (`chat:modelSelector.picker.account.*`). Absent ⇒ today's subtitle, unchanged.
+  There is deliberately NO client-side per-plan entitlement filtering beyond
+  `configured`: a personal plan that lacks a model fails the turn honestly as
+  `ModelUnavailable`.
+
+Both readers are gathered in `app/src/lib/credential-scope.ts` and unit-tested
+without a renderer (`app/tests/credential-scope.test.ts`). There are two of them
+rather than one generic reader because every field of the shape is optional: a
+`ProviderStatus` passed to `credentialScopeOf` would type-check and answer `null`
+forever, so one named reader per shape makes that impossible instead of merely
+unlikely.
 
 ---
 

--- a/packages/host/src/channel/capture-credential.ts
+++ b/packages/host/src/channel/capture-credential.ts
@@ -12,18 +12,38 @@ type ExportedCredential = {
   enterpriseUrl?: string;
 };
 
-/** Store a full runtime credential centrally, then remove its refresh token. */
+/**
+ * Store a full runtime credential centrally, then remove its refresh token.
+ *
+ * Scoped by `actingAs` end to end (HOU-976): the runtime keeps one auth file per
+ * member, so the export must be read AS that member, the central write must land
+ * on that member's row, and the scrub must clear that member's file — mixing the
+ * three would capture one member's credential into another's row. Undefined (the
+ * desktop, self-host, every pre-HOU-976 caller) is the single shared scope,
+ * byte-identical to before.
+ */
 export async function captureRuntimeCredential(args: {
   endpoint: RuntimeEndpoint;
   credentials: CredentialStore;
   workspaceId: string;
   provider?: string;
   requireRefresh?: boolean;
+  actingAs?: string;
 }): Promise<CaptureResult> {
-  const { endpoint, credentials, workspaceId, provider, requireRefresh } = args;
+  const {
+    endpoint,
+    credentials,
+    workspaceId,
+    provider,
+    requireRefresh,
+    actingAs,
+  } = args;
   const query = provider ? `?provider=${encodeURIComponent(provider)}` : "";
   const exported = await fetch(`${endpoint.baseUrl}/auth/export${query}`, {
-    headers: { Authorization: `Bearer ${endpoint.token}` },
+    headers: {
+      Authorization: `Bearer ${endpoint.token}`,
+      ...(actingAs ? { "x-houston-acting-as": actingAs } : {}),
+    },
   });
   if (!exported.ok) {
     return {
@@ -39,14 +59,17 @@ export async function captureRuntimeCredential(args: {
       return { ok: false, status: 400, error: "agent is not connected yet" };
     if (!credential.provider || !credential.key)
       return { ok: false, status: 400, error: "agent is not connected yet" };
-    await credentials.put({
-      workspaceId,
-      provider: credential.provider,
-      kind: "api_key",
-      accessToken: credential.key,
-      refreshToken: "",
-      expiresAt: Number.MAX_SAFE_INTEGER,
-    });
+    await credentials.put(
+      {
+        workspaceId,
+        provider: credential.provider,
+        kind: "api_key",
+        accessToken: credential.key,
+        refreshToken: "",
+        expiresAt: Number.MAX_SAFE_INTEGER,
+      },
+      { actingAs },
+    );
     return { ok: true, provider: credential.provider };
   }
   if (
@@ -57,19 +80,23 @@ export async function captureRuntimeCredential(args: {
   ) {
     return { ok: false, status: 400, error: "agent is not connected yet" };
   }
-  await credentials.put({
-    workspaceId,
-    provider: credential.provider,
-    kind: "oauth",
-    accessToken: credential.access,
-    refreshToken: credential.refresh,
-    accountId: credential.accountId,
-    expiresAt: credential.expires,
-    enterpriseUrl: credential.enterpriseUrl,
-  });
+  await credentials.put(
+    {
+      workspaceId,
+      provider: credential.provider,
+      kind: "oauth",
+      accessToken: credential.access,
+      refreshToken: credential.refresh,
+      accountId: credential.accountId,
+      expiresAt: credential.expires,
+      enterpriseUrl: credential.enterpriseUrl,
+    },
+    { actingAs },
+  );
   const scrub = await scrubRuntimeRefreshToken(
     `${endpoint.baseUrl}/auth/scrub-refresh`,
     endpoint.token,
+    actingAs,
   );
   if (!scrub.ok) {
     return {

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -299,6 +299,9 @@ export class ProxyChannel implements RuntimeChannel {
       credentials: this.opts.credentials,
       workspaceId: ctx.agent.workspaceId,
       provider,
+      // The connecting MEMBER's own credential (HOU-976): read from their
+      // runtime auth file, stored on their row, scrubbed from their file.
+      actingAs: ctx.actingAs,
     });
   }
 
@@ -309,7 +312,9 @@ export class ProxyChannel implements RuntimeChannel {
    * single runtime's local auth.json alone would be undone by the next re-serve.
    */
   async forgetCredential(ctx: ChannelCtx, provider: string): Promise<void> {
-    await this.opts.credentials.remove(ctx.agent.workspaceId, provider);
+    await this.opts.credentials.remove(ctx.agent.workspaceId, provider, {
+      actingAs: ctx.actingAs,
+    });
   }
 
   /**
@@ -334,6 +339,7 @@ export class ProxyChannel implements RuntimeChannel {
         headers: {
           "content-type": "application/json",
           Authorization: `Bearer ${endpoint.token}`,
+          ...(ctx.actingAs ? { "x-houston-acting-as": ctx.actingAs } : {}),
         },
         body: JSON.stringify({ key: apiKey }),
       },
@@ -351,14 +357,17 @@ export class ProxyChannel implements RuntimeChannel {
         body?.reason,
       );
     }
-    await this.opts.credentials.put({
-      workspaceId: ctx.agent.workspaceId,
-      provider,
-      accessToken: apiKey,
-      refreshToken: "",
-      expiresAt: 0,
-      kind: "api_key",
-    });
+    await this.opts.credentials.put(
+      {
+        workspaceId: ctx.agent.workspaceId,
+        provider,
+        accessToken: apiKey,
+        refreshToken: "",
+        expiresAt: 0,
+        kind: "api_key",
+      },
+      { actingAs: ctx.actingAs },
+    );
   }
 
   /**
@@ -400,6 +409,7 @@ export class ProxyChannel implements RuntimeChannel {
       const existing = await this.opts.credentials.get(
         ctx.agent.workspaceId,
         "anthropic",
+        { actingAs: ctx.actingAs },
       );
       if (existing) return;
     } else if (cred.expiresAt && cred.expiresAt < Date.now() - STALE_SKEW_MS) {
@@ -433,7 +443,7 @@ export class ProxyChannel implements RuntimeChannel {
       },
       // Belt-and-braces under the gateway's atomic row lock: a concurrent
       // write between the probe above and this put still cannot be clobbered.
-      { ifAbsent: opts?.ifAbsent },
+      { ifAbsent: opts?.ifAbsent, actingAs: ctx.actingAs },
     );
     const endpoint = await this.opts.launcher.ensureAwake(ctx.agent);
     const res = await fetch(
@@ -443,6 +453,7 @@ export class ProxyChannel implements RuntimeChannel {
         headers: {
           "content-type": "application/json",
           Authorization: `Bearer ${endpoint.token}`,
+          ...(ctx.actingAs ? { "x-houston-acting-as": ctx.actingAs } : {}),
         },
         // The CLI envelope, forwarded verbatim so the pod writes the exact file.
         body: JSON.stringify({ claudeAiOauth: cred }),

--- a/packages/host/src/channel/scrub-refresh.ts
+++ b/packages/host/src/channel/scrub-refresh.ts
@@ -1,16 +1,25 @@
 const SCRUB_ATTEMPTS = 3;
 const SCRUB_RETRY_DELAY_MS = 100;
 
+/**
+ * `actingAs` scopes the scrub to ONE member's auth file (HOU-976) — the runtime
+ * keeps one per acting identity, and an unscoped scrub would clear the shared
+ * file while the member's own refresh token stayed on the pod.
+ */
 export async function scrubRuntimeRefreshToken(
   url: string,
   token: string,
+  actingAs?: string,
 ): Promise<{ ok: true } | { ok: false; detail: string }> {
   let detail = "";
   for (let attempt = 1; attempt <= SCRUB_ATTEMPTS; attempt += 1) {
     try {
       const response = await fetch(url, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        headers: {
+          Authorization: `Bearer ${token}`,
+          ...(actingAs ? { "x-houston-acting-as": actingAs } : {}),
+        },
       });
       if (response.ok) return { ok: true };
       detail = await response.text().catch(() => "");

--- a/packages/host/src/credentials/contract.test.ts
+++ b/packages/host/src/credentials/contract.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, statSync } from "node:fs";
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "vitest";
@@ -55,4 +55,54 @@ test("FileCredentialStore enforces owner-only permissions", async () => {
   const store = new FileCredentialStore(path);
   await store.put(cred());
   expect(statSync(path).mode & 0o777).toBe(0o600);
+});
+
+/**
+ * The on-disk guarantee that makes the HOU-976 scope key safe to ship without a
+ * migration: a credentials.json written by a PRE-scope build still loads (its
+ * records carry no `scopeKey`, which reads as the team's), and a desktop that
+ * never sees an acting identity keeps writing the exact historical record shape.
+ * A regression here silently signs every existing desktop user out.
+ */
+test("FileCredentialStore reads a pre-scope file and keeps the team record shape", async () => {
+  const path = join(
+    mkdtempSync(join(tmpdir(), "houston-cred-legacy-")),
+    "creds.json",
+  );
+  // Exactly what an older build persisted: an array of bare credentials.
+  const legacy = cred({ accountId: "acct-legacy" });
+  writeFileSync(path, JSON.stringify([legacy], null, 2));
+
+  const store = new FileCredentialStore(path);
+  expect(await store.get("ws_1", "openai-codex")).toEqual(legacy);
+
+  // A team write re-persists the SAME shape — no scopeKey key appears.
+  await store.put(cred({ accessToken: "rotated" }));
+  const onDisk = JSON.parse(readFileSync(path, "utf8")) as unknown[];
+  expect(onDisk).toHaveLength(1);
+  expect(Object.hasOwn(onDisk[0] as object, "scopeKey")).toBe(false);
+});
+
+/** A member's row round-trips across a restart, keyed to that member alone. */
+test("FileCredentialStore persists a member's row separately from the team's", async () => {
+  const path = join(
+    mkdtempSync(join(tmpdir(), "houston-cred-scope-")),
+    "creds.json",
+  );
+  const acting = {
+    actingAs: `acting-v1.${Buffer.from(
+      JSON.stringify({ sub: "sub-alice" }),
+    ).toString("base64url")}.sig`,
+  };
+  const first = new FileCredentialStore(path);
+  await first.put(cred({ accessToken: "team-tok" }));
+  await first.put(cred({ accessToken: "alice-tok" }), acting);
+
+  const reopened = new FileCredentialStore(path);
+  expect((await reopened.get("ws_1", "openai-codex"))?.accessToken).toBe(
+    "team-tok",
+  );
+  expect(
+    (await reopened.get("ws_1", "openai-codex", acting))?.accessToken,
+  ).toBe("alice-tok");
 });

--- a/packages/host/src/credentials/file-store.ts
+++ b/packages/host/src/credentials/file-store.ts
@@ -9,7 +9,17 @@ import {
 import { dirname } from "node:path";
 import { accessDigestMatches } from "@houston/protocol/access-digest";
 import type { WorkspaceId } from "../domain/types";
-import type { CredentialStore, WorkspaceCredential } from "../ports";
+import type {
+  CredentialActing,
+  CredentialStore,
+  WorkspaceCredential,
+} from "../ports";
+import {
+  credentialScopeKey,
+  isPersonalScopeKey,
+  TEAM_SCOPE_KEY,
+} from "./scope-key";
+import { scopedKey } from "./store";
 
 /**
  * File-backed connect-once credential store for the LOCAL profile: the host —
@@ -18,9 +28,23 @@ import type { CredentialStore, WorkspaceCredential } from "../ports";
  * token lives here (host-readable), never in a runtime's environment, so a
  * prompt-injected agent reading `env` finds only a short-lived access token —
  * the same Gate #2 guarantee as cloud, just single-tenant.
+ *
+ * SCOPE (HOU-976): rows are keyed by acting identity as well as (workspace,
+ * provider). Desktop and self-host never carry one (the acting header is dropped
+ * off the gateway — routes/agents.ts `trustedActingAs`), so their key AND their
+ * on-disk record stay byte-identical to the pre-HOU-976 shape: an existing
+ * credentials.json loads with no migration and never gains a field. Only a
+ * member's row persists `scopeKey`, and only the profiles that can produce one
+ * write it — the dev launcher runs the managed-cloud posture
+ * (`HOUSTON_MANAGED_CLOUD=1`) without the credential-gateway env that would
+ * select RemoteCredentialStore, so this adapter really does see members there.
  */
+
+/** One persisted row: the credential plus WHOSE it is (absent = the team's). */
+type StoredCredential = WorkspaceCredential & { scopeKey?: string };
+
 export class FileCredentialStore implements CredentialStore {
-  private creds = new Map<string, WorkspaceCredential>();
+  private creds = new Map<string, StoredCredential>();
 
   constructor(private readonly path: string) {
     mkdirSync(dirname(path), { recursive: true });
@@ -28,17 +52,24 @@ export class FileCredentialStore implements CredentialStore {
       try {
         const raw = JSON.parse(
           readFileSync(path, "utf8"),
-        ) as WorkspaceCredential[];
+        ) as StoredCredential[];
         for (const c of raw)
-          this.creds.set(this.key(c.workspaceId, c.provider), c);
+          this.creds.set(
+            scopedKey(c.workspaceId, c.provider, c.scopeKey ?? TEAM_SCOPE_KEY),
+            c,
+          );
       } catch {
         // A corrupt file means the user reconnects — never crash boot over it.
       }
     }
   }
 
-  private key(workspaceId: string, provider: string): string {
-    return `${workspaceId}:${provider}`;
+  private key(
+    workspaceId: string,
+    provider: string,
+    acting: CredentialActing | undefined,
+  ): string {
+    return scopedKey(workspaceId, provider, credentialScopeKey(acting));
   }
 
   private flush(): void {
@@ -54,33 +85,50 @@ export class FileCredentialStore implements CredentialStore {
   async get(
     workspaceId: WorkspaceId,
     provider: string,
+    acting?: CredentialActing,
   ): Promise<WorkspaceCredential | null> {
-    return this.creds.get(this.key(workspaceId, provider)) ?? null;
+    const stored = this.creds.get(this.key(workspaceId, provider, acting));
+    if (!stored) return null;
+    // `scopeKey` is this store's own bookkeeping, not part of the port's shape.
+    const { scopeKey: _scopeKey, ...cred } = stored;
+    return cred;
   }
 
   async put(
     cred: WorkspaceCredential,
-    opts?: { ifAbsent?: boolean },
+    opts?: { ifAbsent?: boolean } & CredentialActing,
   ): Promise<void> {
-    const key = this.key(cred.workspaceId, cred.provider);
+    const scopeKey = credentialScopeKey(opts);
+    const key = scopedKey(cred.workspaceId, cred.provider, scopeKey);
     if (opts?.ifAbsent && this.creds.has(key)) return;
-    this.creds.set(key, { ...cred });
+    this.creds.set(key, {
+      ...cred,
+      // Omitted for the team so its record keeps its exact historical shape.
+      ...(isPersonalScopeKey(scopeKey) ? { scopeKey } : {}),
+    });
     this.flush();
   }
 
-  async remove(workspaceId: WorkspaceId, provider: string): Promise<void> {
-    this.creds.delete(this.key(workspaceId, provider));
+  async remove(
+    workspaceId: WorkspaceId,
+    provider: string,
+    acting?: CredentialActing,
+  ): Promise<void> {
+    this.creds.delete(this.key(workspaceId, provider, acting));
     this.flush();
   }
 
   /** Compare-and-delete under this process's single-threaded map access — the
-   *  local equivalent of the gateway's row lock (HOU-952). */
+   *  local equivalent of the gateway's row lock (HOU-952). Only the REPORTER's
+   *  own row is eligible: both rows can hold the same token, and dropping the
+   *  wrong one signs somebody else out. */
   async removeIfAccess(
     workspaceId: WorkspaceId,
     provider: string,
     accessSha256: string,
+    opts?: { scope?: "personal" | "team" } & CredentialActing,
   ): Promise<boolean> {
-    const key = this.key(workspaceId, provider);
+    const key = this.key(workspaceId, provider, opts);
     const current = this.creds.get(key);
     if (!current || !accessDigestMatches(current.accessToken, accessSha256))
       return false;

--- a/packages/host/src/credentials/gateway-wire.ts
+++ b/packages/host/src/credentials/gateway-wire.ts
@@ -11,6 +11,7 @@ export interface GatewayCredential {
   expires: number;
   accountId?: string | null;
   enterpriseUrl?: string | null;
+  scope?: "personal" | "team";
 }
 
 /**
@@ -42,6 +43,7 @@ export function credentialFromGateway(
     ...(typeof body.enterpriseUrl === "string"
       ? { enterpriseUrl: body.enterpriseUrl }
       : {}),
+    scope: body.scope === "personal" ? "personal" : "team",
   };
 }
 

--- a/packages/host/src/credentials/remote-store.test.ts
+++ b/packages/host/src/credentials/remote-store.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import type { CredentialStore, WorkspaceCredential } from "../ports";
-import { RemoteCredentialStore } from "./remote-store";
+import { RemoteCredentialStore, scopeKeyOf } from "./remote-store";
 
 type FetchCall = { url: string; init?: RequestInit };
 
@@ -58,6 +58,10 @@ function requestBody(call: FetchCall): Record<string, unknown> {
   return JSON.parse(call.init.body) as Record<string, unknown>;
 }
 
+function actingAs(sub = "member-1"): string {
+  return `header.${Buffer.from(JSON.stringify({ sub })).toString("base64url")}.sig`;
+}
+
 test("get maps a 200 gateway credential and strips refresh", async () => {
   const { calls, fetchImpl } = fakeFetch((call) => {
     expect(call.url).toBe(PATH);
@@ -82,6 +86,7 @@ test("get maps a 200 gateway credential and strips refresh", async () => {
     expiresAt: 1_730_000_000_000,
     accountId: "acct-1",
     enterpriseUrl: "acme.ghe.com",
+    scope: "team",
   });
 });
 
@@ -167,6 +172,77 @@ test("positive cache absorbs repeated gets within the TTL", async () => {
   expect((await s.get("ws_1", "openai-codex"))?.accessToken).toBe("AT-cached");
   expect((await s.get("ws_2", "openai-codex"))?.workspaceId).toBe("ws_2");
   expect(calls).toHaveLength(1);
+});
+
+test("cache is isolated between the team and each acting user", async () => {
+  let calls = 0;
+  const { fetchImpl } = fakeFetch(() =>
+    json(gatewayCredential({ access: `AT-${++calls}` })),
+  );
+  const s = store(fetchImpl);
+
+  expect((await s.get("ws_1", "openai-codex"))?.accessToken).toBe("AT-1");
+  expect(
+    (await s.get("ws_1", "openai-codex", { actingAs: actingAs("a") }))
+      ?.accessToken,
+  ).toBe("AT-2");
+  expect(
+    (await s.get("ws_1", "openai-codex", { actingAs: actingAs("b") }))
+      ?.accessToken,
+  ).toBe("AT-3");
+});
+
+test("a personal get never adopts the legacy fallback", async () => {
+  const fallback: CredentialStore = {
+    get: async () => ({
+      workspaceId: "ws_1",
+      provider: "openai-codex",
+      accessToken: "AT-legacy",
+      refreshToken: "RT-legacy",
+      expiresAt: 123,
+    }),
+    put: async () => {},
+    remove: async () => {},
+    removeIfAccess: async () => false,
+  };
+  const { calls, fetchImpl } = fakeFetch(() =>
+    json({ error: "personal credential not connected" }, 404),
+  );
+
+  expect(
+    await store(fetchImpl, fallback).get("ws_1", "openai-codex", {
+      actingAs: actingAs(),
+    }),
+  ).toBeNull();
+  expect(calls).toHaveLength(1);
+  expect(calls[0]?.init?.method).toBeUndefined();
+});
+
+test("forwards the acting header on GET, PUT, and DELETE", async () => {
+  const token = actingAs();
+  const { calls, fetchImpl } = fakeFetch((call) => {
+    if (call.init?.method === "PUT" || call.init?.method === "DELETE")
+      return json({ ok: true });
+    return json(gatewayCredential());
+  });
+  const s = store(fetchImpl);
+  const acting = { actingAs: token };
+
+  await s.get("ws_1", "openai-codex", acting);
+  await s.put(
+    {
+      workspaceId: "ws_1",
+      provider: "openai-codex",
+      accessToken: "AT",
+      refreshToken: "RT",
+      expiresAt: 123,
+    },
+    acting,
+  );
+  await s.remove("ws_1", "openai-codex", acting);
+  expect(calls).toHaveLength(3);
+  for (const call of calls)
+    expect(headers(call)["x-houston-acting-as"]).toBe(token);
 });
 
 test("put with ifAbsent sends the gateway's fill-only header (HOU-855)", async () => {
@@ -342,4 +418,78 @@ test("remove deletes remotely and invalidates the provider cache", async () => {
     "DELETE",
     "GET",
   ]);
+});
+
+test("a personal revoked-token report says both WHICH row and WHOSE", async () => {
+  // The gateway keys personal credentials by (org, user, provider): the scope
+  // header alone leaves it unable to pick a row, so it refuses and the revoked
+  // token keeps 401ing that member's turns (HOU-952/HOU-976).
+  const token = actingAs("member-1");
+  const { calls, fetchImpl } = fakeFetch(() => json({ removed: true }));
+
+  expect(
+    await store(fetchImpl).removeIfAccess("ws_1", "openai-codex", "sha-1", {
+      scope: "personal",
+      actingAs: token,
+    }),
+  ).toBe(true);
+
+  expect(calls[0]?.init?.method).toBe("DELETE");
+  expect(headers(calls[0] as FetchCall)).toMatchObject({
+    Authorization: "Bearer pod-token",
+    "x-houston-acting-as": token,
+    "x-houston-credential-scope": "personal",
+    "x-houston-if-access-sha256": "sha-1",
+  });
+});
+
+test("a member's revoked-token report evicts only that member's cache entry", async () => {
+  let served = 0;
+  const { calls, fetchImpl } = fakeFetch((call) => {
+    if (call.init?.method === "DELETE") return json({ removed: true });
+    return json(gatewayCredential({ access: `AT-${++served}` }));
+  });
+  const s = store(fetchImpl);
+  const alice = { actingAs: actingAs("alice") };
+  const bob = { actingAs: actingAs("bob") };
+
+  expect((await s.get("ws_1", "openai-codex", alice))?.accessToken).toBe(
+    "AT-1",
+  );
+  expect((await s.get("ws_1", "openai-codex", bob))?.accessToken).toBe("AT-2");
+  await s.removeIfAccess("ws_1", "openai-codex", "sha-1", {
+    scope: "personal",
+    ...alice,
+  });
+
+  // Bob's credential is untouched by Alice's report: still cached, no refetch.
+  expect((await s.get("ws_1", "openai-codex", bob))?.accessToken).toBe("AT-2");
+  // Alice's is gone, so hers is re-resolved from the gateway.
+  expect((await s.get("ws_1", "openai-codex", alice))?.accessToken).toBe(
+    "AT-3",
+  );
+  expect(calls.map((c) => c.init?.method ?? "GET")).toEqual([
+    "GET",
+    "GET",
+    "DELETE",
+    "GET",
+  ]);
+});
+
+test("a cache key never embeds the acting token itself", async () => {
+  // The same rule as the runtime's credentialScopeKeyFor: these keys reach log
+  // lines and diagnostics, so an unreadable token is named by digest.
+  const unreadable = [
+    "no-payload-segment",
+    `header.${Buffer.from(JSON.stringify({ sub: 7 })).toString("base64url")}.sig`,
+    "header.!!not-base64-json!!.sig",
+  ];
+
+  const keys = unreadable.map((token) =>
+    scopeKeyOf({ actingAs: token }, "openai-codex"),
+  );
+  for (const [i, key] of keys.entries())
+    expect(key).not.toContain(unreadable[i]);
+  // Isolation is unchanged: distinct unreadable tokens keep distinct scopes.
+  expect(new Set(keys).size).toBe(unreadable.length);
 });

--- a/packages/host/src/credentials/remote-store.ts
+++ b/packages/host/src/credentials/remote-store.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceId } from "../domain/types";
 import {
+  type CredentialActing,
   type CredentialStore,
   isApiKeyCredential,
   type WorkspaceCredential,
@@ -9,6 +10,7 @@ import {
   type GatewayCredential,
   isNotConnected404,
 } from "./gateway-wire";
+import { credentialScopeKey } from "./scope-key";
 
 const CACHE_TTL_MS = 15_000;
 type CachedCredential = Omit<WorkspaceCredential, "workspaceId">;
@@ -58,37 +60,48 @@ export class RemoteCredentialStore implements CredentialStore {
   async get(
     workspaceId: WorkspaceId,
     provider: string,
+    acting?: CredentialActing,
   ): Promise<WorkspaceCredential | null> {
-    const cached = this.cache.get(provider);
+    const cacheKey = scopeKeyOf(acting, provider);
+    const cached = this.cache.get(cacheKey);
     if (cached && cached.until > Date.now())
       return this.withWorkspace(workspaceId, cached.value);
 
-    const remote = await this.fetchRemote(provider);
+    const remote = await this.fetchRemote(provider, acting);
     if (remote) {
-      this.cache.set(provider, this.cacheEntry(remote));
+      this.cache.set(cacheKey, this.cacheEntry(remote));
       return this.withWorkspace(workspaceId, remote);
     }
 
-    const adopted = await this.adoptFallback(workspaceId, provider);
-    this.cache.set(provider, this.cacheEntry(adopted));
+    const adopted = acting?.actingAs
+      ? null
+      : await this.adoptFallback(workspaceId, provider);
+    this.cache.set(cacheKey, this.cacheEntry(adopted));
     return this.withWorkspace(workspaceId, adopted);
   }
 
   async put(
     cred: WorkspaceCredential,
-    opts?: { ifAbsent?: boolean },
+    opts?: { ifAbsent?: boolean } & CredentialActing,
   ): Promise<void> {
     // ifAbsent rides to the gateway as `x-houston-if-absent`, whose PUT is
     // atomic under the per-(org, provider) row lock — the authoritative guard
     // against clobbering a live rotated refresh token with a cached snapshot.
-    await this.putRemote(cred.provider, cred, { ifAbsent: opts?.ifAbsent });
-    this.cache.delete(cred.provider);
+    await this.putRemote(cred.provider, cred, {
+      ifAbsent: opts?.ifAbsent,
+      acting: opts,
+    });
+    this.cache.delete(scopeKeyOf(opts, cred.provider));
   }
 
-  async remove(workspaceId: WorkspaceId, provider: string): Promise<void> {
+  async remove(
+    workspaceId: WorkspaceId,
+    provider: string,
+    acting?: CredentialActing,
+  ): Promise<void> {
     const res = await this.fetchImpl(this.url(provider), {
       method: "DELETE",
-      headers: this.authHeaders(),
+      headers: this.authHeaders({}, acting),
     });
     // Sign-out is idempotent, like the file store: the gateway's "not
     // connected" 404 means the row is already gone (another pod removed it, or
@@ -99,8 +112,8 @@ export class RemoteCredentialStore implements CredentialStore {
     // Clear the legacy adoption source too — leaving the file entry would let
     // the next get()'s 404-adoption silently resurrect the credential the user
     // just removed, org-wide.
-    await this.fallback?.remove(workspaceId, provider);
-    this.cache.delete(provider);
+    if (!acting?.actingAs) await this.fallback?.remove(workspaceId, provider);
+    this.cache.delete(scopeKeyOf(acting, provider));
   }
 
   /**
@@ -118,13 +131,20 @@ export class RemoteCredentialStore implements CredentialStore {
     workspaceId: WorkspaceId,
     provider: string,
     accessSha256: string,
+    opts?: { scope?: "personal" | "team" } & CredentialActing,
   ): Promise<boolean> {
     const res = await this.fetchImpl(this.url(provider), {
       method: "DELETE",
-      headers: {
-        ...this.authHeaders(),
-        "x-houston-if-access-sha256": accessSha256,
-      },
+      // The scope says WHICH kind of row; the acting header (authHeaders) says
+      // WHOSE. A personal row is keyed by (org, user, provider), so without the
+      // acting identity the gateway cannot address it and refuses the report.
+      headers: this.authHeaders(
+        {
+          ...(opts?.scope ? { "x-houston-credential-scope": opts.scope } : {}),
+          "x-houston-if-access-sha256": accessSha256,
+        },
+        opts,
+      ),
     });
     // Idempotent like remove(): an already-gone row is the outcome we wanted.
     if (res.status !== 200 && !(await isNotConnected404(res)))
@@ -137,8 +157,12 @@ export class RemoteCredentialStore implements CredentialStore {
     // legacy fallback entry alone on a superseded report is deliberate: they
     // may describe the credential that SUPERSEDED the revoked one.
     if (removed) {
-      this.cache.delete(provider);
-      await this.fallback?.remove(workspaceId, provider);
+      // Only the REPORTING identity's entry. Evicting every member's key would
+      // cost every other member of this pod a gateway round-trip for a row that
+      // is still theirs and still live.
+      this.cache.delete(scopeKeyOf(opts, provider));
+      if (opts?.scope !== "personal")
+        await this.fallback?.remove(workspaceId, provider);
     }
     return removed;
   }
@@ -156,9 +180,10 @@ export class RemoteCredentialStore implements CredentialStore {
 
   private async fetchRemote(
     provider: string,
+    acting?: CredentialActing,
   ): Promise<CachedCredential | null> {
     const res = await this.fetchImpl(this.url(provider), {
-      headers: this.authHeaders(),
+      headers: this.authHeaders({}, acting),
     });
     if (await isNotConnected404(res)) return null;
     if (res.status === 502) {
@@ -187,14 +212,17 @@ export class RemoteCredentialStore implements CredentialStore {
   private async putRemote(
     provider: string,
     cred: WorkspaceCredential,
-    opts: { ifAbsent?: boolean } = {},
+    opts: { ifAbsent?: boolean; acting?: CredentialActing } = {},
   ): Promise<void> {
     const res = await this.fetchImpl(this.url(provider), {
       method: "PUT",
-      headers: this.authHeaders({
-        "content-type": "application/json",
-        ...(opts.ifAbsent ? { "x-houston-if-absent": "1" } : {}),
-      }),
+      headers: this.authHeaders(
+        {
+          "content-type": "application/json",
+          ...(opts.ifAbsent ? { "x-houston-if-absent": "1" } : {}),
+        },
+        opts.acting,
+      ),
       body: JSON.stringify({
         kind: isApiKeyCredential(cred) ? "api_key" : "oauth",
         access: cred.accessToken,
@@ -227,8 +255,13 @@ export class RemoteCredentialStore implements CredentialStore {
 
   private authHeaders(
     extra: Record<string, string> = {},
+    acting?: CredentialActing,
   ): Record<string, string> {
-    return { Authorization: `Bearer ${this.podToken}`, ...extra };
+    return {
+      Authorization: `Bearer ${this.podToken}`,
+      ...(acting?.actingAs ? { "x-houston-acting-as": acting.actingAs } : {}),
+      ...extra,
+    };
   }
 
   private async errorFromResponse(
@@ -243,4 +276,16 @@ export class RemoteCredentialStore implements CredentialStore {
       }`,
     );
   }
+}
+
+/**
+ * The cache key for one (acting identity, provider). The identity half is the
+ * SHARED scope derivation (credentials/scope-key.ts), so this adapter and the
+ * local ones resolve the same member to the same row. Exported for its test.
+ */
+export function scopeKeyOf(
+  acting: CredentialActing | undefined,
+  provider: string,
+): string {
+  return `${credentialScopeKey(acting)}|${provider}`;
 }

--- a/packages/host/src/credentials/scope-key.ts
+++ b/packages/host/src/credentials/scope-key.ts
@@ -1,0 +1,64 @@
+import { createHash } from "node:crypto";
+import type { CredentialActing } from "../ports";
+
+/**
+ * WHOSE credentials a store call addresses, as one opaque key (HOU-976).
+ *
+ * The gateway resolves personal-vs-team per (org, user, provider) and mints the
+ * acting-as token that names the member; every credential adapter has to agree
+ * on how that token becomes a storage key, or the same member reads a different
+ * row in two adapters. So the derivation lives here, once, and is shared by the
+ * managed-pod adapter (remote-store.ts) and the local ones (store.ts,
+ * file-store.ts).
+ *
+ * Mirrors the runtime's own rule (`packages/runtime/src/session/acting-context.ts`
+ * `credentialScopeKeyFor`) deliberately: the same identity must resolve to the
+ * same scope on both sides of the host↔runtime seam.
+ */
+
+/** The scope key of a call with no acting identity: the one shared row. */
+export const TEAM_SCOPE_KEY = "team";
+
+/**
+ * The scope key for an acting identity. `"team"` with no token — desktop,
+ * self-host, routines, and every pre-HOU-976 call — so those paths keep
+ * addressing the single shared credential exactly as before.
+ *
+ * A token whose payload we cannot read is NOT the team: falling back to the
+ * shared key would let a garbled token READ the team credential. It gets its own
+ * isolated key, named by a DIGEST of the token — this key reaches log lines, so
+ * the token itself must never be it.
+ */
+export function credentialScopeKey(
+  acting: CredentialActing | undefined,
+): string {
+  const token = acting?.actingAs;
+  if (!token) return TEAM_SCOPE_KEY;
+  const payload = token.split(".")[1];
+  if (!payload) return unreadableScopeKey(token);
+  try {
+    const decoded = JSON.parse(
+      Buffer.from(
+        payload.replace(/-/g, "+").replace(/_/g, "/"),
+        "base64",
+      ).toString("utf8"),
+    ) as { sub?: unknown };
+    return typeof decoded.sub === "string"
+      ? `u:${decoded.sub}`
+      : unreadableScopeKey(token);
+  } catch {
+    return unreadableScopeKey(token);
+  }
+}
+
+/** Whether a scope key addresses one member's own row rather than the team's. */
+export function isPersonalScopeKey(key: string): boolean {
+  return key !== TEAM_SCOPE_KEY;
+}
+
+function unreadableScopeKey(token: string): string {
+  return `u:unreadable-${createHash("sha256")
+    .update(token)
+    .digest("hex")
+    .slice(0, 16)}`;
+}

--- a/packages/host/src/credentials/store.ts
+++ b/packages/host/src/credentials/store.ts
@@ -1,6 +1,11 @@
 import { accessDigestMatches } from "@houston/protocol/access-digest";
 import type { WorkspaceId } from "../domain/types";
-import type { CredentialStore, WorkspaceCredential } from "../ports";
+import type {
+  CredentialActing,
+  CredentialStore,
+  WorkspaceCredential,
+} from "../ports";
+import { credentialScopeKey, isPersonalScopeKey } from "./scope-key";
 
 /**
  * Connect-once credential storage (the OPEN in-memory adapter). The control
@@ -12,42 +17,75 @@ import type { CredentialStore, WorkspaceCredential } from "../ports";
  * (PgCredentialStore) was retired with `@houston/host-cloud` (git history).
  * Every adapter is held to one shared contract
  * (credentials/contract.test.ts → runCredentialStoreContract).
+ *
+ * SCOPE (HOU-976): the acting identity is part of the key, not decoration.
+ * Accepting `acting` and ignoring it would serve one member's subscription to
+ * another member and let either delete the other's connection — and this adapter
+ * IS reachable with a member identity: the dev launcher runs the managed-cloud
+ * profile (`HOUSTON_MANAGED_CLOUD=1`, so acting headers are honored) without the
+ * credential-gateway env that would select RemoteCredentialStore instead.
  */
 
 export class MemoryCredentialStore implements CredentialStore {
   private readonly creds = new Map<string, WorkspaceCredential>();
-  private key(workspaceId: string, provider: string): string {
-    return `${workspaceId}:${provider}`;
+  private key(
+    workspaceId: string,
+    provider: string,
+    acting: CredentialActing | undefined,
+  ): string {
+    return scopedKey(workspaceId, provider, credentialScopeKey(acting));
   }
   async get(
     workspaceId: WorkspaceId,
     provider: string,
+    acting?: CredentialActing,
   ): Promise<WorkspaceCredential | null> {
-    return this.creds.get(this.key(workspaceId, provider)) ?? null;
+    return this.creds.get(this.key(workspaceId, provider, acting)) ?? null;
   }
   async put(
     cred: WorkspaceCredential,
-    opts?: { ifAbsent?: boolean },
+    opts?: { ifAbsent?: boolean } & CredentialActing,
   ): Promise<void> {
-    const key = this.key(cred.workspaceId, cred.provider);
+    const key = this.key(cred.workspaceId, cred.provider, opts);
     if (opts?.ifAbsent && this.creds.has(key)) return;
     this.creds.set(key, { ...cred });
   }
-  async remove(workspaceId: WorkspaceId, provider: string): Promise<void> {
-    this.creds.delete(this.key(workspaceId, provider));
+  async remove(
+    workspaceId: WorkspaceId,
+    provider: string,
+    acting?: CredentialActing,
+  ): Promise<void> {
+    this.creds.delete(this.key(workspaceId, provider, acting));
   }
   /** Compare-and-delete: only the reported token goes, never whatever
-   *  replaced it (HOU-952). */
+   *  replaced it (HOU-952) — and only in the REPORTER's own row. */
   async removeIfAccess(
     workspaceId: WorkspaceId,
     provider: string,
     accessSha256: string,
+    opts?: { scope?: "personal" | "team" } & CredentialActing,
   ): Promise<boolean> {
-    const key = this.key(workspaceId, provider);
+    const key = this.key(workspaceId, provider, opts);
     const current = this.creds.get(key);
     if (!current || !accessDigestMatches(current.accessToken, accessSha256))
       return false;
     this.creds.delete(key);
     return true;
   }
+}
+
+/**
+ * The storage key for one (workspace, provider) row in a scope. The TEAM key
+ * omits the scope entirely so it is byte-identical to its pre-HOU-976 form —
+ * which is what lets FileCredentialStore read an existing desktop file with no
+ * migration.
+ */
+export function scopedKey(
+  workspaceId: string,
+  provider: string,
+  scopeKey: string,
+): string {
+  return isPersonalScopeKey(scopeKey)
+    ? `${workspaceId}:${scopeKey}:${provider}`
+    : `${workspaceId}:${provider}`;
 }

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -345,18 +345,22 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     beforeTurn: sharedMirror ? () => sharedMirror.beforeTurn() : undefined,
   });
   const credentialHealer = opts.credentials
-    ? new CredentialServeHealer(async ({ workspaceId, agentId, provider }) => {
-        const agent = await store.getAgent(agentId);
-        if (!agent || agent.workspaceId !== workspaceId) return false;
-        const result = await captureRuntimeCredential({
-          endpoint: await launcher.ensureAwake(agent),
-          credentials,
-          workspaceId,
-          provider,
-          requireRefresh: true,
-        });
-        return result.ok;
-      })
+    ? new CredentialServeHealer(
+        async ({ workspaceId, agentId, provider, actingAs }) => {
+          const agent = await store.getAgent(agentId);
+          if (!agent || agent.workspaceId !== workspaceId) return false;
+          const result = await captureRuntimeCredential({
+            endpoint: await launcher.ensureAwake(agent),
+            credentials,
+            workspaceId,
+            provider,
+            requireRefresh: true,
+            // The member whose serve missed — their runtime file, their row.
+            actingAs,
+          });
+          return result.ok;
+        },
+      )
     : undefined;
 
   // Integrations (platform model): the desktop holds NO provider key — the

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -145,6 +145,8 @@ export interface RuntimeLauncher {
 export interface ChannelCtx {
   workspace: Workspace;
   agent: Agent;
+  /** Gateway-minted acting identity for per-user credential operations. */
+  actingAs?: string;
   /**
    * The request body, already drained by the route. The turn path reads it
    * before dispatch to stamp mission attribution (activity-attribution.ts);
@@ -344,6 +346,8 @@ export interface WorkspaceCredential {
    * and it's served back so the runtime points the model at the enterprise API.
    */
   enterpriseUrl?: string;
+  /** Scope selected by the gateway when this credential was served. */
+  scope?: "personal" | "team";
 }
 
 /** A credential is an API key when explicitly tagged, or by the expiresAt=0 sentinel. */
@@ -352,10 +356,16 @@ export function isApiKeyCredential(cred: WorkspaceCredential): boolean {
 }
 
 /** Stores + serves the one connect-once credential per (workspace, provider). */
+export interface CredentialActing {
+  /** The gateway-minted acting-as token verbatim; undefined = team scope. */
+  actingAs?: string;
+}
+
 export interface CredentialStore {
   get(
     workspaceId: WorkspaceId,
     provider: string,
+    acting?: CredentialActing,
   ): Promise<WorkspaceCredential | null>;
   /**
    * Upsert (overwrite in place on refresh). `ifAbsent` makes it a FILL, not a
@@ -365,8 +375,15 @@ export interface CredentialStore {
    * makes the next central refresh trip the provider's refresh-token-reuse
    * detection, revoking the whole family (HOU-855).
    */
-  put(cred: WorkspaceCredential, opts?: { ifAbsent?: boolean }): Promise<void>;
-  remove(workspaceId: WorkspaceId, provider: string): Promise<void>;
+  put(
+    cred: WorkspaceCredential,
+    opts?: { ifAbsent?: boolean } & CredentialActing,
+  ): Promise<void>;
+  remove(
+    workspaceId: WorkspaceId,
+    provider: string,
+    acting?: CredentialActing,
+  ): Promise<void>;
   /**
    * Compare-and-delete: drop the credential only while its access token still
    * hashes to `accessSha256`. Resolves to whether anything was removed.
@@ -377,11 +394,18 @@ export interface CredentialStore {
    * arrives from a turn that may have started before the user reconnected, and
    * an unconditional remove would then delete the credential they just
    * created. A digest mismatch means the report is stale: no-op, not an error.
+   *
+   * `scope` says WHICH kind of row the reported token came from; for a personal
+   * one, `actingAs` says WHOSE (HOU-976). Personal credentials are keyed by
+   * (workspace, user, provider), so a remote store with no acting identity
+   * cannot address the row at all — the report would be rejected and the
+   * revoked token would keep 401ing that member's turns until it expires.
    */
   removeIfAccess(
     workspaceId: WorkspaceId,
     provider: string,
     accessSha256: string,
+    opts?: { scope?: "personal" | "team" } & CredentialActing,
   ): Promise<boolean>;
 }
 

--- a/packages/host/src/routes/agents-acting.test.ts
+++ b/packages/host/src/routes/agents-acting.test.ts
@@ -1,0 +1,203 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, expect, test } from "vitest";
+import type {
+  CaptureResult,
+  ChannelCtx,
+  RuntimeChannel,
+  RuntimeState,
+} from "../ports";
+import { MemoryWorkspaceStore } from "../store/memory";
+import { type AgentRouteDeps, handleAgents } from "./agents";
+
+/**
+ * The acting-as trust seam on the four CREDENTIAL routes (C2/C5). The gateway is
+ * the trust boundary: only it can mint `x-houston-acting-as`, so only a
+ * gateway-fronted host may read one. Off the gateway (desktop / self-host) the
+ * client talks to this server directly, so an inbound header is forged input —
+ * and a forged one here does real damage: the runtime files the credential into
+ * a per-user `auth-users/<hash>.json` scope instead of the shared `auth.json`,
+ * so the user connects a provider and every agent still reads as disconnected.
+ *
+ * Mirrors channel/proxy-acting.test.ts (the dispatch/relay side of the same
+ * seam) one level up, at the routes that read the header themselves.
+ */
+
+/** A well-formed acting-v1 header a client could trivially forge itself. */
+const FORGED = `acting-v1.${Buffer.from(
+  JSON.stringify({ sub: "mallory", name: "Mallory" }),
+  "utf8",
+).toString("base64url")}.not-a-real-signature`;
+
+const CLAUDE_ENVELOPE = {
+  claudeAiOauth: {
+    accessToken: "sk-ant-oat-ACCESS",
+    refreshToken: "sk-ant-ort-REFRESH",
+    expiresAt: 1_800_000_000_000,
+  },
+};
+
+/**
+ * The four credential routes, each with the minimum body its validator demands
+ * (an api-key provider pi-ai knows; a complete claudeAiOauth envelope) so every
+ * request actually reaches the channel instead of stopping at a 400.
+ */
+const ROUTES = [
+  { path: "credential/capture", body: { provider: "openrouter" } },
+  { path: "credential/forget", body: { provider: "openrouter" } },
+  {
+    path: "credential/api-key",
+    body: { provider: "openrouter", apiKey: "sk-or-test" },
+  },
+  { path: "credential/claude-oauth", body: CLAUDE_ENVELOPE },
+] as const;
+
+/**
+ * A record-only channel: every credential operation captures the ChannelCtx the
+ * route handed it and succeeds. What the runtime would DO with `actingAs` is
+ * ProxyChannel's business (proxy-acting.test.ts) — here only the ctx matters.
+ */
+class RecordingChannel implements RuntimeChannel {
+  readonly seen: ChannelCtx[] = [];
+
+  async dispatch(): Promise<void> {}
+  async fireTurn(): Promise<void> {}
+  async cancelTurn(): Promise<boolean> {
+    return false;
+  }
+  async busy(): Promise<boolean> {
+    return false;
+  }
+  async runtimeStatus(): Promise<RuntimeState | "unknown"> {
+    return "unknown";
+  }
+  async teardown(): Promise<void> {}
+  async captureCredential(
+    ctx: ChannelCtx,
+    provider?: string,
+  ): Promise<CaptureResult> {
+    this.seen.push(ctx);
+    return { ok: true, provider: provider ?? "openrouter" };
+  }
+  async saveApiKeyCredential(ctx: ChannelCtx): Promise<void> {
+    this.seen.push(ctx);
+  }
+  async saveClaudeOAuthCredential(ctx: ChannelCtx): Promise<void> {
+    this.seen.push(ctx);
+  }
+  async saveCustomEndpoint(ctx: ChannelCtx): Promise<void> {
+    this.seen.push(ctx);
+  }
+  async forgetCredential(ctx: ChannelCtx): Promise<void> {
+    this.seen.push(ctx);
+  }
+}
+
+interface Fixture {
+  base: string;
+  close: () => void;
+  channel: RecordingChannel;
+  agentId: string;
+}
+
+/** Boot handleAgents over real HTTP so a client-supplied header rides req.headers. */
+async function boot(opts: { gatewayFronted: boolean }): Promise<Fixture> {
+  const store = new MemoryWorkspaceStore({ defaultRuntime: "gke" });
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "Sales",
+  });
+  const channel = new RecordingChannel();
+  const deps: AgentRouteDeps = {
+    store,
+    channels: { gke: channel },
+    gatewayFronted: opts.gatewayFronted,
+  };
+
+  const s = createServer((req, res) => {
+    const url = new URL(req.url || "/", "http://x");
+    // Single-principal host: the bearer names the acting user.
+    const userId = req.headers.authorization?.replace(/^Bearer /, "") || "";
+    void handleAgents(
+      deps,
+      userId,
+      req.method || "GET",
+      url.pathname,
+      url,
+      req,
+      res,
+    )
+      .then((handled) => {
+        if (!handled) {
+          res.writeHead(404);
+          res.end();
+        }
+      })
+      .catch((err) => {
+        res.writeHead(500);
+        res.end(String(err));
+      });
+  });
+  await new Promise<void>((r) => s.listen(0, "127.0.0.1", () => r()));
+  return {
+    base: `http://127.0.0.1:${(s.address() as AddressInfo).port}`,
+    close: () => s.close(),
+    channel,
+    agentId: agent.id,
+  };
+}
+
+function post(fx: Fixture, path: string, body: unknown, actingAs?: string) {
+  return fetch(`${fx.base}/agents/${encodeURIComponent(fx.agentId)}/${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer alice",
+      "Content-Type": "application/json",
+      ...(actingAs ? { "x-houston-acting-as": actingAs } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe.each(ROUTES)("POST /agents/:id/$path — acting-as trust", ({
+  path,
+  body,
+}) => {
+  test("desktop profile: a forged acting-as header is IGNORED", async () => {
+    const fx = await boot({ gatewayFronted: false });
+    try {
+      const res = await post(fx, path, body, FORGED);
+      expect(res.status).toBe(200);
+      expect(fx.channel.seen).toHaveLength(1);
+      // The credential must land in the workspace's shared scope, exactly as it
+      // would with no header at all.
+      expect(fx.channel.seen[0]?.actingAs).toBeUndefined();
+    } finally {
+      fx.close();
+    }
+  });
+
+  test("desktop profile: a forged header changes nothing vs no header", async () => {
+    const fx = await boot({ gatewayFronted: false });
+    try {
+      expect((await post(fx, path, body)).status).toBe(200);
+      expect((await post(fx, path, body, FORGED)).status).toBe(200);
+      const [withoutHeader, withHeader] = fx.channel.seen;
+      expect(withHeader?.actingAs).toBe(withoutHeader?.actingAs);
+    } finally {
+      fx.close();
+    }
+  });
+
+  test("gateway-fronted profile: the minted header reaches the channel verbatim", async () => {
+    const fx = await boot({ gatewayFronted: true });
+    try {
+      const res = await post(fx, path, body, FORGED);
+      expect(res.status).toBe(200);
+      expect(fx.channel.seen[0]?.actingAs).toBe(FORGED);
+    } finally {
+      fx.close();
+    }
+  });
+});

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -53,6 +53,27 @@ import { handleTriggerStatus } from "./trigger-status";
 export type { AgentRouteDeps } from "./agent-authz";
 
 /**
+ * The acting identity a credential route may act on (C2/C5) — the ONE gate the
+ * credential routes below share, so a fifth route cannot reopen the hole by
+ * reading the header itself. The gateway is the trust boundary: it mints
+ * `x-houston-acting-as`, and no pod can verify the signature. Off the gateway
+ * (desktop / self-host) clients reach this host directly, so an inbound header
+ * is untrusted client input — honoring it would let any client file the user's
+ * credential into a per-user scope (`auth-users/<hash>.json`) instead of the
+ * workspace's shared `auth.json`, leaving every agent reading as disconnected.
+ * Same stance as the routine actor below and as ProxyChannel's relay
+ * (channel/proxy.ts).
+ */
+function trustedActingAs(
+  deps: AgentRouteDeps,
+  req: IncomingMessage,
+): string | undefined {
+  if (!deps.gatewayFronted) return undefined;
+  const value = req.headers[ACTING_AS_HEADER];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/**
  * The agent as the wire serves it: the record plus the deployment extras — the
  * real directory (`dir`, local profile only) and the Rust-era legacy `color`
  * (read from `.houston/agent.json`; the client overlay outranks it, see
@@ -346,6 +367,7 @@ export async function handleAgents(
   // new) serves from it. Must precede the generic dispatch.
   const capture = path.match(/^\/agents\/([^/]+)\/credential\/capture$/);
   if (capture && method === "POST") {
+    const actingAs = trustedActingAs(deps, req);
     const agentId = capture[1] ? decodeURIComponent(capture[1]) : undefined;
     if (!agentId) {
       json(res, 404, { error: "not found" });
@@ -369,7 +391,7 @@ export async function handleAgents(
     const provider =
       typeof body.provider === "string" ? body.provider : undefined;
     const result = await channel.captureCredential(
-      { workspace: authz.workspace, agent: authz.agent },
+      { workspace: authz.workspace, agent: authz.agent, actingAs },
       provider,
     );
     if (result.ok) json(res, 200, { ok: true, provider: result.provider });
@@ -387,6 +409,7 @@ export async function handleAgents(
   // agent from it — the provider showed connected again. Must precede dispatch.
   const forget = path.match(/^\/agents\/([^/]+)\/credential\/forget$/);
   if (forget && method === "POST") {
+    const actingAs = trustedActingAs(deps, req);
     const agentId = forget[1] ? decodeURIComponent(forget[1]) : undefined;
     if (!agentId) {
       json(res, 404, { error: "not found" });
@@ -408,7 +431,7 @@ export async function handleAgents(
       return true;
     }
     await channel.forgetCredential(
-      { workspace: authz.workspace, agent: authz.agent },
+      { workspace: authz.workspace, agent: authz.agent, actingAs },
       provider,
     );
     if (
@@ -438,6 +461,7 @@ export async function handleAgents(
   // standing runtime so it reads as connected at once). Must precede dispatch.
   const apiKey = path.match(/^\/agents\/([^/]+)\/credential\/api-key$/);
   if (apiKey && method === "POST") {
+    const actingAs = trustedActingAs(deps, req);
     const agentId = apiKey[1] ? decodeURIComponent(apiKey[1]) : undefined;
     if (!agentId) {
       json(res, 404, { error: "not found" });
@@ -468,7 +492,7 @@ export async function handleAgents(
     }
     try {
       await channel.saveApiKeyCredential(
-        { workspace: authz.workspace, agent: authz.agent },
+        { workspace: authz.workspace, agent: authz.agent, actingAs },
         provider,
         key.trim(),
       );
@@ -496,6 +520,7 @@ export async function handleAgents(
     /^\/agents\/([^/]+)\/credential\/claude-oauth$/,
   );
   if (claudeOAuth && method === "POST") {
+    const actingAs = trustedActingAs(deps, req);
     const agentId = claudeOAuth[1]
       ? decodeURIComponent(claudeOAuth[1])
       : undefined;
@@ -524,7 +549,7 @@ export async function handleAgents(
     }
     try {
       await channel.saveClaudeOAuthCredential(
-        { workspace: authz.workspace, agent: authz.agent },
+        { workspace: authz.workspace, agent: authz.agent, actingAs },
         parsed.value,
         // `?if_absent=1` marks a fill-only push of a CACHED snapshot (the
         // desktop reconcile) — never allowed to clobber a live central

--- a/packages/host/src/routes/credential-healer.test.ts
+++ b/packages/host/src/routes/credential-healer.test.ts
@@ -1,0 +1,122 @@
+import { expect, test } from "vitest";
+import {
+  type CredentialHeal,
+  CredentialServeHealer,
+} from "./credential-healer";
+
+const HEAL_COOLDOWN_MS = 5 * 60_000;
+
+function actingAs(sub: string): string {
+  return `header.${Buffer.from(JSON.stringify({ sub })).toString("base64url")}.sig`;
+}
+
+/** A heal that records who asked and resolves when the test says so. */
+function recorder(result = true) {
+  const seen: (string | undefined)[] = [];
+  const heal: CredentialHeal = async (args) => {
+    seen.push(args.actingAs);
+    return result;
+  };
+  return { seen, heal };
+}
+
+test("a member's heal is not coalesced into another member's in-flight attempt", async () => {
+  // Both are the same (workspace, provider); only the acting identity differs.
+  // Sharing the slot would answer member B with A's result — and, worse, capture
+  // A's live credential onto B's row (HOU-976).
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const seen: (string | undefined)[] = [];
+  const healer = new CredentialServeHealer(async ({ actingAs: who }) => {
+    seen.push(who);
+    await gate;
+    return true;
+  });
+
+  const a = healer.attempt({
+    workspaceId: "ws",
+    agentId: "ws/agent",
+    provider: "openai-codex",
+    actingAs: actingAs("member-a"),
+  });
+  const b = healer.attempt({
+    workspaceId: "ws",
+    agentId: "ws/agent",
+    provider: "openai-codex",
+    actingAs: actingAs("member-b"),
+  });
+  release();
+  expect(await Promise.all([a, b])).toEqual([true, true]);
+  expect(seen).toEqual([actingAs("member-a"), actingAs("member-b")]);
+});
+
+test("the SAME member's concurrent misses still coalesce to one attempt", async () => {
+  const { seen, heal } = recorder();
+  const healer = new CredentialServeHealer(heal);
+  const token = actingAs("member-a");
+  const args = {
+    workspaceId: "ws",
+    agentId: "ws/agent",
+    provider: "openai-codex",
+    actingAs: token,
+  };
+
+  await Promise.all([healer.attempt(args), healer.attempt(args)]);
+
+  expect(seen).toEqual([token]);
+});
+
+test("one member's cooldown never mutes another member's heal", async () => {
+  const { seen, heal } = recorder();
+  // A real epoch, not 0: the cooldown compares `now - (last ?? 0)`, so a clock
+  // that starts at 0 reads a never-attempted key as one attempted this instant.
+  let now = 1_700_000_000_000;
+  const healer = new CredentialServeHealer(heal, () => now);
+  const base = {
+    workspaceId: "ws",
+    agentId: "ws/agent",
+    provider: "openai-codex",
+  };
+
+  await healer.attempt({ ...base, actingAs: actingAs("member-a") });
+  now += 1_000;
+  // Within A's cooldown window: A is refused, B is not.
+  expect(
+    await healer.attempt({ ...base, actingAs: actingAs("member-a") }),
+  ).toBe(false);
+  expect(
+    await healer.attempt({ ...base, actingAs: actingAs("member-b") }),
+  ).toBe(true);
+  // …and A heals again once ITS own window has passed.
+  now += HEAL_COOLDOWN_MS;
+  expect(
+    await healer.attempt({ ...base, actingAs: actingAs("member-a") }),
+  ).toBe(true);
+
+  expect(seen).toEqual([
+    actingAs("member-a"),
+    actingAs("member-b"),
+    actingAs("member-a"),
+  ]);
+});
+
+test("no acting identity keeps the single shared slot (desktop, self-host)", async () => {
+  const { seen, heal } = recorder();
+  // A real epoch, not 0: the cooldown compares `now - (last ?? 0)`, so a clock
+  // that starts at 0 reads a never-attempted key as one attempted this instant.
+  let now = 1_700_000_000_000;
+  const healer = new CredentialServeHealer(heal, () => now);
+  const args = {
+    workspaceId: "ws",
+    agentId: "ws/agent",
+    provider: "openai-codex",
+  };
+
+  expect(await healer.attempt(args)).toBe(true);
+  now += 1_000;
+  expect(await healer.attempt(args)).toBe(false);
+
+  expect(seen).toEqual([undefined]);
+});

--- a/packages/host/src/routes/credential-healer.ts
+++ b/packages/host/src/routes/credential-healer.ts
@@ -1,12 +1,21 @@
+import { credentialScopeKey } from "../credentials/scope-key";
+
 const HEAL_COOLDOWN_MS = 5 * 60_000;
 
 export type CredentialHeal = (args: {
   workspaceId: string;
   agentId: string;
   provider: string;
+  /** WHOSE credential to heal; undefined = the single shared scope (HOU-976). */
+  actingAs?: string;
 }) => Promise<boolean>;
 
-/** Coalesces serve-miss recovery and limits each provider to one attempt/5m. */
+/**
+ * Coalesces serve-miss recovery and limits each provider to one attempt/5m.
+ *
+ * Per (workspace, SCOPE, provider): one member's miss must not hand its result
+ * to another member's serve, nor spend the cooldown that member needs (HOU-976).
+ */
 export class CredentialServeHealer {
   private readonly inFlight = new Map<string, Promise<boolean>>();
   private readonly attemptedAt = new Map<string, number>();
@@ -17,7 +26,7 @@ export class CredentialServeHealer {
   ) {}
 
   attempt(args: Parameters<CredentialHeal>[0]): Promise<boolean> {
-    const key = `${args.workspaceId}:${args.provider}`;
+    const key = `${args.workspaceId}:${credentialScopeKey({ actingAs: args.actingAs })}:${args.provider}`;
     const existing = this.inFlight.get(key);
     if (existing) return existing;
     if (this.now() - (this.attemptedAt.get(key) ?? 0) < HEAL_COOLDOWN_MS)

--- a/packages/host/src/routes/credential-revoked.test.ts
+++ b/packages/host/src/routes/credential-revoked.test.ts
@@ -1,0 +1,163 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { expect, test } from "vitest";
+import type {
+  CredentialActing,
+  CredentialStore,
+  CredentialVault,
+} from "../ports";
+import { handleSandboxCredentialRevoked } from "./credential-revoked";
+
+/**
+ * The revoked-token report is a DELETE trigger for someone else's credential,
+ * so what the route passes DOWN is the safety-critical part: the digest that
+ * makes the delete conditional, and — for a personal credential — the acting
+ * identity that says WHOSE row it is (HOU-976). A personal report without it
+ * cannot be actioned at all: the gateway keys those rows by (org, user,
+ * provider) and answers 400, leaving the dead token to 401 every turn until it
+ * expires (HOU-952).
+ */
+
+const vault: CredentialVault = {
+  sandboxToken: () => "sbx",
+  validateSandboxToken: (t) =>
+    t === "sbx" ? { workspaceId: "w1", agentId: "a1" } : null,
+};
+
+type Reported = {
+  workspaceId: string;
+  provider: string;
+  accessSha256: string;
+  opts?: { scope?: "personal" | "team" } & CredentialActing;
+};
+
+function capturingStore(removed = true): {
+  credentials: CredentialStore;
+  reports: Reported[];
+} {
+  const reports: Reported[] = [];
+  const credentials: CredentialStore = {
+    get: async () => null,
+    put: async () => {},
+    remove: async () => {},
+    removeIfAccess: async (workspaceId, provider, accessSha256, opts) => {
+      reports.push({ workspaceId, provider, accessSha256, opts });
+      return removed;
+    },
+  };
+  return { credentials, reports };
+}
+
+function mockReq(body: unknown, token = "sbx"): IncomingMessage {
+  const buf = Buffer.from(JSON.stringify(body));
+  return {
+    headers: { authorization: `Bearer ${token}` },
+    async *[Symbol.asyncIterator]() {
+      yield buf;
+    },
+  } as unknown as IncomingMessage;
+}
+
+function mockRes(): {
+  res: ServerResponse;
+  out: { status?: number; body: Record<string, unknown> };
+} {
+  const out: { status?: number; body: Record<string, unknown> } = { body: {} };
+  const res = {
+    writeHead(status: number) {
+      out.status = status;
+    },
+    end(buf: Buffer | string) {
+      out.body = JSON.parse(buf.toString()) as Record<string, unknown>;
+    },
+  } as unknown as ServerResponse;
+  return { res, out };
+}
+
+const post = (credentials: CredentialStore, body: unknown, token = "sbx") => {
+  const { res, out } = mockRes();
+  return handleSandboxCredentialRevoked(
+    { vault, credentials },
+    "POST",
+    "/sandbox/credential/revoked",
+    new URL("http://x/sandbox/credential/revoked"),
+    mockReq(body, token),
+    res,
+  ).then((handled) => ({ handled, ...out }));
+};
+
+const ACTING = "acting-v1.payload.sig";
+
+test("a personal report forwards the acting identity to the store", async () => {
+  const { credentials, reports } = capturingStore();
+
+  const { handled, status, body } = await post(credentials, {
+    provider: "anthropic",
+    accessSha256: "d".repeat(64),
+    scope: "personal",
+    actingAs: ACTING,
+  });
+
+  expect(handled).toBe(true);
+  expect(status).toBe(200);
+  expect(body).toEqual({ ok: true, removed: true });
+  expect(reports).toEqual([
+    {
+      workspaceId: "w1",
+      provider: "anthropic",
+      accessSha256: "d".repeat(64),
+      opts: { scope: "personal", actingAs: ACTING },
+    },
+  ]);
+});
+
+test("a team report has no acting identity to forward", async () => {
+  const { credentials, reports } = capturingStore(false);
+
+  const { status, body } = await post(credentials, {
+    provider: "anthropic",
+    accessSha256: "e".repeat(64),
+  });
+
+  // `removed:false` is the ordinary superseded case, still a 200.
+  expect(status).toBe(200);
+  expect(body).toEqual({ ok: true, removed: false });
+  expect(reports[0]?.opts).toEqual({ scope: "team", actingAs: undefined });
+});
+
+test("a non-string acting identity is dropped, not passed through", async () => {
+  const { credentials, reports } = capturingStore();
+
+  await post(credentials, {
+    provider: "anthropic",
+    accessSha256: "f".repeat(64),
+    scope: "personal",
+    actingAs: { sub: "nope" },
+  });
+
+  expect(reports[0]?.opts?.actingAs).toBeUndefined();
+});
+
+test("a report with no token identity is refused, never actioned", async () => {
+  const { credentials, reports } = capturingStore();
+
+  const { status } = await post(credentials, {
+    provider: "anthropic",
+    actingAs: ACTING,
+  });
+
+  expect(status).toBe(400);
+  expect(reports).toEqual([]);
+});
+
+test("an unauthenticated report never reaches the store", async () => {
+  const { credentials, reports } = capturingStore();
+
+  const { status } = await post(
+    credentials,
+    { provider: "anthropic", accessSha256: "a".repeat(64) },
+    "forged",
+  );
+
+  expect(status).toBe(401);
+  expect(reports).toEqual([]);
+});

--- a/packages/host/src/routes/credential-revoked.ts
+++ b/packages/host/src/routes/credential-revoked.ts
@@ -41,10 +41,18 @@ export async function handleSandboxCredentialRevoked(
   const body = (await readJson(req).catch(() => null)) as {
     provider?: unknown;
     accessSha256?: unknown;
+    scope?: unknown;
+    actingAs?: unknown;
   } | null;
   const provider = typeof body?.provider === "string" ? body.provider : "";
   const accessSha256 =
     typeof body?.accessSha256 === "string" ? body.accessSha256.trim() : "";
+  const scope = body?.scope === "personal" ? "personal" : "team";
+  // WHOSE row, for a personal credential: the reporter's acting-as token, which
+  // the store forwards so the gateway can key the delete by (org, user,
+  // provider). A team report has none, and must stay valid without one.
+  const actingAs =
+    typeof body?.actingAs === "string" ? body.actingAs : undefined;
   if (!provider || !accessSha256) {
     // Refuse rather than guess: a report without a token identity could only
     // be actioned as an unconditional delete, which is the one thing this
@@ -57,6 +65,7 @@ export async function handleSandboxCredentialRevoked(
     claim.workspaceId,
     provider,
     accessSha256,
+    { scope, actingAs },
   );
   // Both outcomes are success. `removed:false` means the report was superseded
   // — the workspace reconnected, or a sibling runtime reported the same dead

--- a/packages/host/src/routes/credential.ts
+++ b/packages/host/src/routes/credential.ts
@@ -61,21 +61,32 @@ export async function handleSandboxCredential(
     );
     return true;
   }
+  // WHOSE credential this serve is for (HOU-976). The gateway mints the header;
+  // absent (desktop, self-host, every pre-HOU-976 pod) means the single shared
+  // scope, so the whole path below is byte-identical to before.
+  const actingHeader = req.headers["x-houston-acting-as"];
+  const actingAs = Array.isArray(actingHeader) ? actingHeader[0] : actingHeader;
+  const acting = actingAs ? { actingAs } : undefined;
   let deadError: RemoteCredentialDeadError | undefined;
   let cred = null;
   try {
-    cred = await deps.credentials.get(claim.workspaceId, provider);
+    cred = await deps.credentials.get(claim.workspaceId, provider, acting);
   } catch (error) {
     if (!(error instanceof RemoteCredentialDeadError)) throw error;
     deadError = error;
   }
   if (!cred && deps.credentialHealer) {
+    // Self-heal reads the runtime's LIVE credential and pushes it centrally —
+    // as this member, or a warm pod would capture whoever's file it found into
+    // the wrong row (and one member's cooldown would mute everyone else's).
     const healed = await deps.credentialHealer.attempt({
       workspaceId: claim.workspaceId,
       agentId: claim.agentId,
       provider,
+      actingAs,
     });
-    if (healed) cred = await deps.credentials.get(claim.workspaceId, provider);
+    if (healed)
+      cred = await deps.credentials.get(claim.workspaceId, provider, acting);
   }
   if (!cred) {
     if (deadError) throw deadError;
@@ -93,7 +104,7 @@ export async function handleSandboxCredential(
   if (isExpiring(cred) && cred.refreshToken) {
     try {
       cred = await refreshCredential(cred);
-      await deps.credentials.put(cred);
+      await deps.credentials.put(cred, acting);
     } catch (err) {
       if (err instanceof RefreshRejectedError) {
         // The OAuth server rejected the refresh token itself (invalid_grant /
@@ -107,7 +118,7 @@ export async function handleSandboxCredential(
           `[sandbox/credential] refresh token rejected for ${cred.provider}, disconnecting:`,
           err.message,
         );
-        await deps.credentials.remove(claim.workspaceId, cred.provider);
+        await deps.credentials.remove(claim.workspaceId, cred.provider, acting);
         json(
           res,
           404,
@@ -158,6 +169,7 @@ export async function handleSandboxCredential(
     // Copilot Enterprise domain (not a secret) so the runtime sets the right API
     // base URL; null for individual Copilot and every other provider.
     enterpriseUrl: cred.enterpriseUrl ?? null,
+    scope: cred.scope ?? "team",
   });
   return true;
 }

--- a/packages/host/src/routes/provider-usage.ts
+++ b/packages/host/src/routes/provider-usage.ts
@@ -57,7 +57,16 @@ export async function handleSandboxProviderUsage(
     json(res, 400, { error: `no central usage probe for ${provider}` });
     return true;
   }
-  const cred = await deps.credentials.get(claim.workspaceId, provider);
+  // WHOSE Copilot account this quota is for (HOU-976): the runtime forwards the
+  // gateway-minted acting-as token, exactly as it does for the credential serve.
+  // Absent (desktop, self-host, every pre-HOU-976 pod) = the single shared row.
+  const actingHeader = req.headers["x-houston-acting-as"];
+  const actingAs = Array.isArray(actingHeader) ? actingHeader[0] : actingHeader;
+  const cred = await deps.credentials.get(
+    claim.workspaceId,
+    provider,
+    actingAs ? { actingAs } : undefined,
+  );
   if (!cred?.refreshToken) {
     // Same authoritative marker as /sandbox/credential: the store's own
     // "not connected" answer, never a bare route-level 404.

--- a/packages/host/src/store-sync/daemon.ts
+++ b/packages/host/src/store-sync/daemon.ts
@@ -14,13 +14,18 @@ const DEFAULT_INTERVAL_MS = 300_000;
 // also hydrate back on the next wake — a hydrate cap smaller than what sync
 // allows out is a delayed crash-loop (writes succeed today, the wake after
 // the next sleep fails forever). The gap below 10Gi leaves room for the
-// excluded scratch (tmp files, auth.json) that lives on the emptyDir but
-// never syncs.
+// excluded scratch (tmp files, runtime credentials) that lives on the emptyDir
+// but never syncs.
 const DEFAULT_MAX_HYDRATE_BYTES = 9 * 1024 * 1024 * 1024;
 // Warn while the agent is WRITING (actionable), not when a later wake fails:
 // crossing this fraction of the hydrate cap logs loudly on every sync.
 const SIZE_WARN_FRACTION = 0.8;
 
+/**
+ * Extra pod-local paths that must not reach the store. The runtime credential
+ * material (`auth.json`, `auth-users/`) is deliberately absent: `excluded()`
+ * drops it unconditionally, so no caller can configure the leak back in.
+ */
 export const STORE_SYNC_EXCLUDES = [
   "credentials.json",
   "claude-login/.credentials.json",

--- a/packages/host/src/testing/credential-contract.ts
+++ b/packages/host/src/testing/credential-contract.ts
@@ -1,6 +1,8 @@
 import { accessDigest } from "@houston/protocol/access-digest";
 import { describe, expect, test } from "vitest";
+import type { WorkspaceId } from "../domain/types";
 import {
+  type CredentialActing,
   type CredentialStore,
   isApiKeyCredential,
   type WorkspaceCredential,
@@ -18,6 +20,16 @@ import {
  * suite that also consumed it was retired with `@houston/host-cloud` (git
  * history); the contract stays exported as the behavioral bar for any
  * out-of-repo adapter.
+ *
+ * SCOPE (HOU-976). Every method takes an optional acting identity, because one
+ * pod serves every member of a team space: a member's credential is a DIFFERENT
+ * row from the team's. So the whole suite runs TWICE — once with no acting
+ * identity (the team scope: desktop, self-host, and every pre-HOU-976 caller,
+ * whose calls are byte-identical to what they always were) and once as a member.
+ * `describe("cross-scope isolation")` then pins what only two scopes together can
+ * show: a member's credential is never visible to, nor removable by, the team or
+ * another member. Without those, an adapter that silently DROPS the acting
+ * identity passes every invariant while serving one member's account to another.
  *
  * The contract treats the stored value as a faithful copy: a `put` followed by a
  * `get` must return every field that was put (a refresh persists access AND
@@ -59,25 +71,102 @@ export function expectRoundTrip(
   expect(isApiKeyCredential(got)).toBe(isApiKeyCredential(put));
 }
 
+/**
+ * A member's acting-as token, minted the way the gateway mints it
+ * (`acting-v1.<base64url payload>.sig`) so an adapter that partitions by
+ * identity can read the payload's `sub` exactly as it does in production (see
+ * credentials/remote-store.ts).
+ */
+function actingFor(sub: string): CredentialActing {
+  const payload = Buffer.from(
+    JSON.stringify({ sub, agent: "acme", exp: 9_000_000_000 }),
+  ).toString("base64url");
+  return { actingAs: `acting-v1.${payload}.sig` };
+}
+
+const ALICE = actingFor("sub-alice");
+const BOB = actingFor("sub-bob");
+
+/** One pass of the contract: WHOSE credentials every call in it addresses. */
+interface ScopeRun {
+  label: string;
+  /** The acting identity carried by every call; undefined = the team scope. */
+  acting: CredentialActing | undefined;
+  /**
+   * `removeIfAccess`'s opts for this pass. Carries the acting identity as well
+   * as `scope`: the digest says WHICH token was reported, but only the identity
+   * says whose row holds it, and a compare-and-delete that cannot name the row
+   * would have to scan every member's (MAJOR 7 / MINOR 16).
+   */
+  removeScope: ({ scope: "personal" | "team" } & CredentialActing) | undefined;
+}
+
+const SCOPE_RUNS: readonly ScopeRun[] = [
+  // The team pass must stay byte-identical to the pre-HOU-976 suite: no acting
+  // identity, no opts — the exact calls desktop and self-host make.
+  { label: "team scope", acting: undefined, removeScope: undefined },
+  {
+    label: "member scope",
+    acting: ALICE,
+    removeScope: { scope: "personal", ...ALICE },
+  },
+];
+
+/** The store's four operations, pre-bound to one scope run. */
+function opsFor(store: CredentialStore, run: ScopeRun) {
+  return {
+    get: (workspaceId: WorkspaceId, provider: string) =>
+      store.get(workspaceId, provider, run.acting),
+    put: (c: WorkspaceCredential) => store.put(c, run.acting),
+    remove: (workspaceId: WorkspaceId, provider: string) =>
+      store.remove(workspaceId, provider, run.acting),
+    removeIfAccess: (
+      workspaceId: WorkspaceId,
+      provider: string,
+      accessSha256: string,
+    ) =>
+      store.removeIfAccess(
+        workspaceId,
+        provider,
+        accessSha256,
+        run.removeScope,
+      ),
+  };
+}
+
 export function runCredentialStoreContract(
   name: string,
   make: () => CredentialStore,
 ): void {
   describe(`CredentialStore contract: ${name}`, () => {
+    for (const run of SCOPE_RUNS) runScopeInvariants(run, make);
+    runCrossScopeInvariants(make);
+  });
+}
+
+/**
+ * Every single-scope invariant, asserted identically for the team and for a
+ * member — the same credential lifecycle has to hold whichever row it lives in.
+ */
+function runScopeInvariants(run: ScopeRun, make: () => CredentialStore): void {
+  describe(run.label, () => {
+    /** A fresh store with this run's scope bound to it. */
+    const fresh = () => opsFor(make(), run);
+
     test("get is null before a put", async () => {
-      const s = make();
+      const s = fresh();
       expect(await s.get("ws_1", "openai-codex")).toBeNull();
     });
 
     test("put → get round-trips every field", async () => {
-      const s = make();
+      const s = fresh();
       const c = cred({ accountId: "acct-9", expiresAt: 1_888_000_000_000 });
       await s.put(c);
       expectRoundTrip(await s.get("ws_1", "openai-codex"), c);
     });
 
     test("an api-key credential round-trips with kind and no refresh/expiry", async () => {
-      const s = make();
+      const s = fresh();
       const apiKey = cred({
         provider: "opencode",
         accessToken: "sk-opencode-zen",
@@ -90,7 +179,7 @@ export function runCredentialStoreContract(
     });
 
     test("put on the same (workspace, provider) overwrites in place (refresh)", async () => {
-      const s = make();
+      const s = fresh();
       await s.put(cred());
       await s.put(
         cred({
@@ -106,7 +195,7 @@ export function runCredentialStoreContract(
     });
 
     test("workspaces and providers are isolated keys", async () => {
-      const s = make();
+      const s = fresh();
       await s.put(cred({ workspaceId: "ws_a" }));
       await s.put(cred({ workspaceId: "ws_b", accessToken: "bb" }));
       await s.put(
@@ -120,7 +209,7 @@ export function runCredentialStoreContract(
     });
 
     test("remove deletes the credential and is idempotent", async () => {
-      const s = make();
+      const s = fresh();
       await s.put(cred());
       await s.remove("ws_1", "openai-codex");
       expect(await s.get("ws_1", "openai-codex")).toBeNull();
@@ -130,7 +219,7 @@ export function runCredentialStoreContract(
     });
 
     test("remove is scoped to one (workspace, provider) — siblings survive", async () => {
-      const s = make();
+      const s = fresh();
       await s.put(cred({ workspaceId: "ws_a" }));
       await s.put(cred({ workspaceId: "ws_b", accessToken: "bb" }));
       await s.remove("ws_a", "openai-codex");
@@ -142,7 +231,7 @@ export function runCredentialStoreContract(
     // to compare before deleting, or the report becomes a new way to sign a
     // workspace out.
     test("removeIfAccess drops the reported token", async () => {
-      const s = make();
+      const s = fresh();
       await s.put(cred({ accessToken: "revoked-tok" }));
       expect(
         await s.removeIfAccess(
@@ -157,7 +246,7 @@ export function runCredentialStoreContract(
     test("removeIfAccess spares a credential that moved on", async () => {
       // The reporting turn began BEFORE the user reconnected. Deleting here
       // would destroy the credential they just created.
-      const s = make();
+      const s = fresh();
       await s.put(cred({ accessToken: "freshly-reconnected" }));
       expect(
         await s.removeIfAccess("ws_1", "openai-codex", accessDigest("old-tok")),
@@ -168,20 +257,108 @@ export function runCredentialStoreContract(
     });
 
     test("removeIfAccess on an absent credential is false, not an error", async () => {
-      const s = make();
+      const s = fresh();
       expect(
         await s.removeIfAccess("ws_1", "openai-codex", accessDigest("any")),
       ).toBe(false);
     });
 
     test("removeIfAccess is scoped to one (workspace, provider)", async () => {
-      const s = make();
+      const s = fresh();
       await s.put(cred({ workspaceId: "ws_a", accessToken: "same" }));
       await s.put(cred({ workspaceId: "ws_b", accessToken: "same" }));
       await s.removeIfAccess("ws_a", "openai-codex", accessDigest("same"));
       expect(await s.get("ws_a", "openai-codex")).toBeNull();
       // An identical token in ANOTHER workspace is a different credential.
       expect((await s.get("ws_b", "openai-codex"))?.accessToken).toBe("same");
+    });
+  });
+}
+
+/**
+ * What only two scopes together can prove (HOU-976): the acting identity is part
+ * of the key, not decoration. A store that accepts `acting` and ignores it
+ * satisfies every invariant above while serving one member's subscription to
+ * another member — and, worse, letting either delete the other's connection.
+ */
+function runCrossScopeInvariants(make: () => CredentialStore): void {
+  describe("cross-scope isolation", () => {
+    test("a member's put is invisible to the team, and the team's to the member", async () => {
+      const s = make();
+      await s.put(cred({ accessToken: "alice-tok" }), ALICE);
+      expect(await s.get("ws_1", "openai-codex")).toBeNull();
+
+      const t = make();
+      await t.put(cred({ accessToken: "team-tok" }));
+      expect(await t.get("ws_1", "openai-codex", ALICE)).toBeNull();
+    });
+
+    test("two members are isolated from each other", async () => {
+      const s = make();
+      await s.put(cred({ accessToken: "alice-tok" }), ALICE);
+      await s.put(cred({ accessToken: "bob-tok" }), BOB);
+      expect((await s.get("ws_1", "openai-codex", ALICE))?.accessToken).toBe(
+        "alice-tok",
+      );
+      expect((await s.get("ws_1", "openai-codex", BOB))?.accessToken).toBe(
+        "bob-tok",
+      );
+      // Neither member's connect ever became the team's.
+      expect(await s.get("ws_1", "openai-codex")).toBeNull();
+    });
+
+    test("a member's remove leaves the team credential connected", async () => {
+      const s = make();
+      await s.put(cred({ accessToken: "team-tok" }));
+      await s.put(cred({ accessToken: "alice-tok" }), ALICE);
+      await s.remove("ws_1", "openai-codex", ALICE);
+      expect(await s.get("ws_1", "openai-codex", ALICE)).toBeNull();
+      expect((await s.get("ws_1", "openai-codex"))?.accessToken).toBe(
+        "team-tok",
+      );
+    });
+
+    test("the team's remove leaves a member's credential connected", async () => {
+      const s = make();
+      await s.put(cred({ accessToken: "team-tok" }));
+      await s.put(cred({ accessToken: "alice-tok" }), ALICE);
+      await s.remove("ws_1", "openai-codex");
+      expect(await s.get("ws_1", "openai-codex")).toBeNull();
+      expect((await s.get("ws_1", "openai-codex", ALICE))?.accessToken).toBe(
+        "alice-tok",
+      );
+    });
+
+    // The revoke report (HOU-952) crosses scopes too: the gateway can serve the
+    // TEAM's token to a member's turn, so a report names WHICH scope's row it
+    // saw. Both rows can legitimately hold the same token — the scope is what
+    // decides, and dropping the wrong one signs somebody else out.
+    test("a personal revoke report never drops the team's row", async () => {
+      const s = make();
+      await s.put(cred({ accessToken: "same" }));
+      await s.put(cred({ accessToken: "same" }), ALICE);
+      await s.removeIfAccess("ws_1", "openai-codex", accessDigest("same"), {
+        scope: "personal",
+        ...ALICE,
+      });
+      expect((await s.get("ws_1", "openai-codex"))?.accessToken).toBe("same");
+      // The reporter's OWN row is the one that went.
+      expect(await s.get("ws_1", "openai-codex", ALICE)).toBeNull();
+    });
+
+    test("a team revoke report never drops a member's row", async () => {
+      const s = make();
+      await s.put(cred({ accessToken: "same" }));
+      await s.put(cred({ accessToken: "same" }), ALICE);
+      expect(
+        await s.removeIfAccess("ws_1", "openai-codex", accessDigest("same"), {
+          scope: "team",
+        }),
+      ).toBe(true);
+      expect(await s.get("ws_1", "openai-codex")).toBeNull();
+      expect((await s.get("ws_1", "openai-codex", ALICE))?.accessToken).toBe(
+        "same",
+      );
     });
   });
 }

--- a/packages/protocol/src/conversation.ts
+++ b/packages/protocol/src/conversation.ts
@@ -88,6 +88,14 @@ export interface ProviderInfo {
   isActive: boolean;
   activeModel: string;
   models: string[];
+  /**
+   * WHOSE credential produced `configured` (HOU-976), so the model picker can
+   * label a row "your account". OMITTED unless the request carried an acting
+   * identity — desktop, self-host, routines and every pre-HOU-976 caller see
+   * the exact shape they saw before, so treat absence as "one credential,
+   * nothing to disambiguate".
+   */
+  credentialScope?: "personal" | "team";
 }
 
 // ── Per-account provider usage (GET /providers/usage) ───────────────────────

--- a/packages/protocol/src/provider-error.ts
+++ b/packages/protocol/src/provider-error.ts
@@ -45,6 +45,22 @@ export type ModelUnavailableReason =
 export type QuotaScope = "free_tier" | "paid_plan" | "organization" | "unknown";
 
 /**
+ * WHICH credential ran the failed turn. Present only on a managed-cloud turn
+ * that carried an acting identity — absent on desktop, self-host, and any turn
+ * with no acting identity, where there is exactly one credential and nothing to
+ * name.
+ *
+ * It exists so a failure card can be HONEST about whose account hit the wall
+ * (HOU-976): in a team space every turn runs on the acting member's own AI
+ * account, so "your Anthropic account is rate limited" is a true sentence and a
+ * generic one is not. There is no fallback to offer — a team space has no shared
+ * AI credential — so this only names, it never unlocks an action.
+ */
+export interface ProviderErrorCredential {
+  scope: "personal" | "team";
+}
+
+/**
  * A typed provider/auth/model failure for a turn's model request. Mirrors the
  * relevant subset of the frontend `ProviderError` union (`@houston-ai/chat`) so
  * it renders as the matching inline card (UnauthenticatedCard / RateLimitedCard /
@@ -70,6 +86,8 @@ export type ProviderError =
        * which marks a send the ENGINE refused before persisting anything.
        */
       undelivered_prompt?: string;
+      /** WHOSE credential ran this turn (HOU-976); absent without an acting identity. */
+      credential?: ProviderErrorCredential;
     }
   | {
       kind: "rate_limited";
@@ -77,6 +95,8 @@ export type ProviderError =
       model: string | null;
       retry_after_seconds: number | null;
       message: string;
+      /** WHOSE credential ran this turn (HOU-976); absent without an acting identity. */
+      credential?: ProviderErrorCredential;
     }
   | {
       /**
@@ -93,6 +113,8 @@ export type ProviderError =
       /** Reset hint when the provider gives one; null = open-ended (top up / upgrade). */
       resets_at: string | null;
       message: string;
+      /** WHOSE credential ran this turn (HOU-976); absent without an acting identity. */
+      credential?: ProviderErrorCredential;
     }
   | {
       /**
@@ -109,6 +131,8 @@ export type ProviderError =
       reason: ModelUnavailableReason;
       suggested_fallback: string | null;
       message: string;
+      /** WHOSE credential ran this turn (HOU-976); absent without an acting identity. */
+      credential?: ProviderErrorCredential;
     }
   | {
       /**
@@ -129,12 +153,28 @@ export type ProviderError =
       context_window_tokens: number | null;
       prompt_tokens: number | null;
       message: string;
+      /** WHOSE credential ran this turn (HOU-976); absent without an acting identity. */
+      credential?: ProviderErrorCredential;
     }
   | {
       kind: "provider_internal";
       provider: string;
       http_status: number | null;
       message: string;
+      /** WHOSE credential ran this turn (HOU-976); absent without an acting identity. */
+      credential?: ProviderErrorCredential;
     }
-  | { kind: "network_unreachable"; provider: string; message: string }
-  | { kind: "unknown"; provider: string; raw_excerpt: string };
+  | {
+      kind: "network_unreachable";
+      provider: string;
+      message: string;
+      /** WHOSE credential ran this turn (HOU-976); absent without an acting identity. */
+      credential?: ProviderErrorCredential;
+    }
+  | {
+      kind: "unknown";
+      provider: string;
+      raw_excerpt: string;
+      /** WHOSE credential ran this turn (HOU-976); absent without an acting identity. */
+      credential?: ProviderErrorCredential;
+    };

--- a/packages/runtime-client/src/client-send.test.ts
+++ b/packages/runtime-client/src/client-send.test.ts
@@ -60,3 +60,16 @@ test("sendMessage carries the per-turn auto (Autopilot) mode on the wire", async
   await client.sendMessage("c1", "hi", { nonce: "n1", mode: "auto" });
   expect(bodies[0]).toEqual({ text: "hi", nonce: "n1", mode: "auto" });
 });
+
+/**
+ * PERSONAL-ONLY (HOU-976): a send NEVER addresses an AI account. In a team space
+ * every turn runs on the sender's own account, decided gateway-side from the
+ * space it lands in, so the body carries no credential field of any kind — this
+ * pins that the send wire is byte-identical to its pre-feature shape.
+ */
+test("a send carries no credential field of any kind", async () => {
+  const { client, bodies } = capture();
+  await client.sendMessage("c1", "hi", { nonce: "n1", provider: "anthropic" });
+  expect(bodies[0]).not.toHaveProperty("credentialScope");
+  expect(JSON.stringify(bodies[0])).not.toContain("credential");
+});

--- a/packages/runtime-client/src/object-sync/hydrate.test.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.test.ts
@@ -1,4 +1,5 @@
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -112,6 +113,81 @@ test("exclusions support basenames, subtrees, temp files, and runtime auth", () 
     true,
   );
   expect(excluded("claude-login/projects/cache.json", excludes)).toBe(false);
+});
+
+/**
+ * The store-sync daemon's excludes, including the root-relative `auth-users/`
+ * entry it used to carry: the per-member credential directory must stay
+ * excluded at EVERY depth even when no caller configures it, because a
+ * root-relative pattern can never match the real nested key.
+ */
+const DAEMON_EXCLUDES = [
+  "credentials.json",
+  "auth-users/",
+  "claude-login/.credentials.json",
+  "db/",
+];
+
+const POD_AUTH_USERS = "workspaces/W/A/.houston/runtime/auth-users";
+
+test("per-member credential files are excluded at any depth", () => {
+  // The daemon runs with rootDir = HOUSTON_HOME, so the real key is nested
+  // under the agent's runtime dir — the shape that leaked one member's tokens.
+  expect(excluded(`${POD_AUTH_USERS}/abc123.json`, DAEMON_EXCLUDES)).toBe(true);
+  expect(
+    excluded(`${POD_AUTH_USERS}/abc123.served-providers.json`, DAEMON_EXCLUDES),
+  ).toBe(true);
+  expect(excluded("auth-users/abc123.json", DAEMON_EXCLUDES)).toBe(true);
+  // The per-turn layout puts the same directory one level down.
+  expect(excluded("data/auth-users/abc123.json", DAEMON_EXCLUDES)).toBe(true);
+  // The TEAM served-providers manifest is shared state and DOES sync: the
+  // segment rule must not swallow everything named after credentials.
+  expect(
+    excluded(
+      "workspaces/W/A/.houston/runtime/served-providers.json",
+      DAEMON_EXCLUDES,
+    ),
+  ).toBe(false);
+});
+
+test("nested auth-users files never sync out to the shared store", async () => {
+  const { storeRoot, store, work } = setup();
+  const authUsersDir = join(work, ...POD_AUTH_USERS.split("/"));
+  mkdirSync(authUsersDir, { recursive: true });
+  writeFileSync(join(authUsersDir, "abc123.json"), '{"access":"AT-alice"}');
+  writeFileSync(
+    join(authUsersDir, "abc123.served-providers.json"),
+    '["anthropic"]',
+  );
+  mkdirSync(join(work, "workspaces", "W", "A", "workspace"), {
+    recursive: true,
+  });
+  writeFileSync(join(work, "workspaces", "W", "A", "workspace", "n.txt"), "n");
+
+  const result = await syncBack(store, "", work, new Map(), {
+    excludes: DAEMON_EXCLUDES,
+  });
+  expect(result.uploaded).toEqual(["workspaces/W/A/workspace/n.txt"]);
+  expect([...result.manifest.keys()]).toEqual([
+    "workspaces/W/A/workspace/n.txt",
+  ]);
+  expect((await store.list("")).some((key) => key.includes("auth-users"))).toBe(
+    false,
+  );
+  expect(existsSync(join(storeRoot, ...POD_AUTH_USERS.split("/")))).toBe(false);
+});
+
+test("nested auth-users objects never hydrate into a pod", async () => {
+  const { storeRoot, store, work } = setup();
+  seed(storeRoot, "", {
+    [`${POD_AUTH_USERS}/abc123.json`]: '{"access":"AT-alice"}',
+    "workspaces/W/A/workspace/n.txt": "n",
+  });
+  const manifest = await hydrate(store, "", work, {
+    excludes: DAEMON_EXCLUDES,
+  });
+  expect([...manifest.keys()]).toEqual(["workspaces/W/A/workspace/n.txt"]);
+  expect(existsSync(join(work, ...POD_AUTH_USERS.split("/")))).toBe(false);
 });
 
 test("an unchanged workspace uploads nothing and remains in the manifest", async () => {

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -35,6 +35,13 @@ export function excluded(rel: string, excludes: string[]): boolean {
   const normalized = norm(rel);
   if (normalized.endsWith(".tmp")) return true;
   if (normalized.endsWith(".houston/runtime/auth.json")) return true;
+  // Per-member credential files. Their directory's depth differs per deployment
+  // (`<agent>/.houston/runtime/auth-users/` on a standing pod, `data/auth-users/`
+  // in the per-turn layout), so it must be matched by SEGMENT the same way
+  // auth.json is matched by suffix — a root-relative pattern misses the real
+  // key. Unconditional, not caller-configurable: this is credential material,
+  // and one member's tokens reaching the shared store leaks them to the space.
+  if (normalized.split("/").includes("auth-users")) return true;
   return excludes.some((exclude) => {
     const pattern = norm(exclude);
     if (pattern.endsWith("/")) {

--- a/packages/runtime-client/src/types.ts
+++ b/packages/runtime-client/src/types.ts
@@ -23,6 +23,7 @@ export type {
   PendingInteraction,
   ProviderAuth,
   ProviderError,
+  ProviderErrorCredential,
   ProviderId,
   ProviderInfo,
   ProviderUsage,

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -1,5 +1,6 @@
 import { getOverflowPatterns } from "@earendil-works/pi-ai";
 import type { AuthFailureCause, ProviderError } from "@houston/runtime-client";
+import { servedScopeFor } from "../auth/served-scope";
 
 /**
  * Classify a failed model request into a typed `ProviderError` so the chat can
@@ -169,8 +170,8 @@ const COPILOT_BASE_FALLBACK = "gpt-4.1";
 const EXCERPT_MAX = 300;
 
 /**
- * Map a failed model request to a typed `ProviderError`. Pure — every branch is
- * unit-tested against verbatim provider strings (`provider-error.test.ts`).
+ * Map a failed model request to a typed `ProviderError`, then stamp WHOSE
+ * credential ran the turn (`stampCredentialScope`).
  *
  * Precedence is deliberate: auth first (a 401/session-kill is unambiguous and
  * the most actionable, and a session-kill body can also mention "limit"), then
@@ -180,6 +181,32 @@ const EXCERPT_MAX = 300;
 export function classifyProviderError(
   input: ProviderErrorInput,
 ): ProviderError {
+  return stampCredentialScope(classify(input));
+}
+
+/**
+ * Attach the credential context of the turn that failed: WHICH credential the
+ * gateway served for this provider under the ambient acting identity (HOU-976),
+ * so the card can name the account that hit the wall rather than the provider
+ * alone. It unlocks no action — a team space has no shared AI credential to
+ * offer instead.
+ *
+ * A no-op without an acting identity (desktop, self-host, routines) and for a
+ * provider this runtime was never served, so the wire shape is unchanged
+ * everywhere it was before. Exported for the paths that SYNTHESIZE a provider
+ * error instead of classifying one.
+ */
+export function stampCredentialScope(err: ProviderError): ProviderError {
+  const served = servedScopeFor(err.provider);
+  if (!served) return err;
+  return { ...err, credential: { scope: served } };
+}
+
+/**
+ * The classification itself. Pure — every branch is unit-tested against
+ * verbatim provider strings (`provider-error.test.ts`).
+ */
+function classify(input: ProviderErrorInput): ProviderError {
   const { provider } = input;
   const model = input.model ?? null;
   const message = input.message?.trim() || "Unknown provider error";

--- a/packages/runtime/src/ai/providers.ts
+++ b/packages/runtime/src/ai/providers.ts
@@ -8,6 +8,7 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 // purely dynamic providers (radius) with no static catalog entry.
 import { type BuiltinProvider, getModel } from "@earendil-works/pi-ai/compat";
 import { authFailureActive } from "../auth/credential-health";
+import { servedScopeFor } from "../auth/served-scope";
 import { authStorage, providerConnected } from "../auth/storage";
 import { config } from "../config";
 import { endpointReachableCached } from "./endpoint-reachability";
@@ -521,8 +522,14 @@ function safeModelIds(provider: ProviderId): string[] {
  *  status-surface truth (`providerUsable`): the frontend maps it straight to
  *  authenticated/unauthenticated for the AI Models page and the chat model
  *  picker, so it must mean "this provider's models can actually answer",
- *  not merely "some credential/config artifact exists". */
+ *  not merely "some credential/config artifact exists".
+ *
+ *  `credentialScope` names WHOSE credential produced `configured` (HOU-976), so
+ *  the picker can label a row "your account". Absent unless the request carries
+ *  an acting identity — desktop, self-host and every pre-HOU-976 caller see the
+ *  exact shape they saw before. */
 function providerRow(id: ProviderId, name: string, active: ProviderId | null) {
+  const servedScope = servedScopeFor(id);
   return {
     id,
     name,
@@ -530,6 +537,7 @@ function providerRow(id: ProviderId, name: string, active: ProviderId | null) {
     isActive: id === active,
     activeModel: modelFor(id),
     models: safeModelIds(id),
+    ...(servedScope ? { credentialScope: servedScope } : {}),
   };
 }
 

--- a/packages/runtime/src/ai/usage/anthropic.ts
+++ b/packages/runtime/src/ai/usage/anthropic.ts
@@ -3,6 +3,10 @@ import { readFileSync } from "node:fs";
 import { authStorage } from "../../auth/storage";
 import { claudeCredentialsFile } from "../../backends/claude/paths";
 import {
+  currentCredentialScope,
+  isPersonalScope,
+} from "../../session/acting-context";
+import {
   clampPercent,
   type ProviderUsage,
   type ProviderUsageWindow,
@@ -36,15 +40,21 @@ const KEYCHAIN_SERVICE = "Claude Code-credentials";
  *   3. auth.json — a cloud-served OAuth credential's access token, or the
  *      degraded setup-token fallback (`sk-ant-oat01…`, itself an OAuth token).
  *
+ * Sources 1 and 2 are POD-WIDE team material, so a personal scope skips them
+ * (HOU-976): a member's usage row must be read with the member's own credential,
+ * never the team's. Their own auth.json entry is source 3.
+ *
  * Returns null when nothing is readable — the row reports `unauthenticated`.
  */
 export async function resolveAnthropicToken(
   keychain: () => Promise<string | null> = readKeychainCredential,
 ): Promise<string | null> {
-  const fromFile = tokenFromCredentialJson(readCredentialFile());
-  if (fromFile) return fromFile;
-  const fromKeychain = tokenFromCredentialJson(await keychain());
-  if (fromKeychain) return fromKeychain;
+  if (!isPersonalScope(currentCredentialScope().key)) {
+    const fromFile = tokenFromCredentialJson(readCredentialFile());
+    if (fromFile) return fromFile;
+    const fromKeychain = tokenFromCredentialJson(await keychain());
+    if (fromKeychain) return fromKeychain;
+  }
   const cred = authStorage.get("anthropic");
   if (cred?.type === "oauth" && cred.access) return cred.access;
   if (cred?.type === "api_key" && cred.key) return cred.key;

--- a/packages/runtime/src/ai/usage/copilot.ts
+++ b/packages/runtime/src/ai/usage/copilot.ts
@@ -1,6 +1,7 @@
 import { serveModeOn } from "../../auth/serve";
 import { authStorage, type KeyStore } from "../../auth/storage";
 import { config } from "../../config";
+import { currentCredentialScope } from "../../session/acting-context";
 import {
   clampPercent,
   type ProviderUsage,
@@ -171,10 +172,17 @@ export async function fetchCopilotUsage(
   // access-only entry) → the host holds the token; delegate the probe there.
   // Its marked 404 means the central store has no Copilot connection either.
   if (serve && cred) {
+    // WHOSE Copilot account to read the quota of (HOU-976) — the same acting
+    // identity the credential serve carries, or the host would answer with the
+    // shared row's quota for a member running on their own account.
+    const { actingAs } = currentCredentialScope();
     const res = await fetchImpl(
       `${serve.controlPlaneUrl}/sandbox/provider-usage?provider=${provider}`,
       {
-        headers: { Authorization: `Bearer ${serve.sandboxToken}` },
+        headers: {
+          Authorization: `Bearer ${serve.sandboxToken}`,
+          ...(actingAs ? { "x-houston-acting-as": actingAs } : {}),
+        },
         signal: AbortSignal.timeout(15_000),
       },
     );

--- a/packages/runtime/src/auth/auth-file.ts
+++ b/packages/runtime/src/auth/auth-file.ts
@@ -1,4 +1,16 @@
-import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  isPersonalScope,
+  TEAM_CREDENTIAL_SCOPE,
+} from "../session/acting-context";
 
 /**
  * Pure auth.json file logic (no config import — tests drive it with explicit
@@ -6,6 +18,81 @@ import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
  * written with refresh="", and the post-connect scrub strips whatever pi's own
  * device-code login wrote. See serve.ts for the config-bound wrappers.
  */
+
+/** Where a personal scope's credential files live, under the data dir. */
+const AUTH_USERS_DIR = "auth-users";
+
+/**
+ * The credential file for one scope inside `dataDir`.
+ *
+ * The TEAM scope keeps `<dataDir>/auth.json` — same path, same bytes as before
+ * HOU-976, so desktop / self-host / every pre-existing pod is untouched. A
+ * personal scope gets `<dataDir>/auth-users/<sha256(sub)[:16]>.json`: the sub is
+ * hashed because it is an opaque identity we will not spread across a shared
+ * pod's filesystem, and 16 hex chars (64 bits) is collision-free at team sizes.
+ */
+export function authPathIn(dataDir: string, scopeKey: string): string {
+  if (!isPersonalScope(scopeKey)) return join(dataDir, "auth.json");
+  return join(dataDir, AUTH_USERS_DIR, `${scopeFileStem(scopeKey)}.json`);
+}
+
+/** The served-providers manifest for one scope (sibling of its auth file). */
+export function servedProvidersPathIn(
+  dataDir: string,
+  scopeKey: string,
+): string {
+  if (!isPersonalScope(scopeKey)) return join(dataDir, "served-providers.json");
+  return join(
+    dataDir,
+    AUTH_USERS_DIR,
+    `${scopeFileStem(scopeKey)}.served-providers.json`,
+  );
+}
+
+/**
+ * The Claude CLI's own credential store for one PERSONAL scope — a sibling
+ * directory of that scope's auth file, handed to the SDK subprocess as
+ * `CLAUDE_SECURESTORAGE_CONFIG_DIR` (backends/claude/scope-guard.ts explains
+ * why, and why it is NOT `CLAUDE_CONFIG_DIR`).
+ *
+ * It lives under `auth-users/` deliberately, not beside the shared login dir:
+ * that path segment is already excluded from store-sync unconditionally
+ * (runtime-client `object-sync/hydrate.ts`) and denied to the agent's own file
+ * tools (session/tools/fs-guard.ts), so anything the CLI ever writes here — a
+ * `.credentials.json`, its `.oauth_refresh.lock` — can neither reach the shared
+ * object store nor be read by the model. Houston writes nothing into it; it
+ * exists so the CLI's credential lookups resolve to a dir that holds NOTHING
+ * instead of the pod-shared team credential.
+ *
+ * There is deliberately no team-scope form: the team's credential store IS the
+ * shared login dir, so a team turn sets no override at all.
+ */
+export function claudeSecureStorageDirIn(
+  dataDir: string,
+  scopeKey: string,
+): string {
+  if (!isPersonalScope(scopeKey))
+    throw new Error(
+      `the "${TEAM_CREDENTIAL_SCOPE}" scope has no per-identity Claude credential store; it reads the shared login dir`,
+    );
+  return join(
+    dataDir,
+    AUTH_USERS_DIR,
+    `${scopeFileStem(scopeKey)}.claude-storage`,
+  );
+}
+
+/** The hashed file stem for a `u:<sub>` scope key. Rejects anything else. */
+function scopeFileStem(scopeKey: string): string {
+  if (!scopeKey.startsWith("u:"))
+    throw new Error(
+      `credential scope key must be "${TEAM_CREDENTIAL_SCOPE}" or "u:<sub>", got "${scopeKey}"`,
+    );
+  return createHash("sha256")
+    .update(scopeKey.slice("u:".length))
+    .digest("hex")
+    .slice(0, 16);
+}
 
 /**
  * The pi auth.json entry shape per provider. Two variants, matching pi's own
@@ -45,6 +132,13 @@ export type ServedCredential = {
   /** GitHub Copilot Enterprise domain, served so the runtime can set the right
    *  API base URL; null/absent = individual Copilot. See `PiCred.enterpriseUrl`. */
   enterpriseUrl?: string | null;
+  /**
+   * WHOSE credential the gateway resolved for this serve (HOU-976). Absent from
+   * a pre-HOU-976 gateway, read as `"team"` — the only thing it could have been.
+   * Never written into auth.json; it drives the provider-error stamp and the
+   * `/providers` row instead (auth/served-scope.ts).
+   */
+  scope?: "personal" | "team";
 };
 
 /** The auth.json contents at `path`, or {} when absent/corrupt. */
@@ -58,6 +152,12 @@ export function readAuthFile(path: string): Record<string, PiCred> {
 }
 
 function writeJsonAtomic(path: string, contents: unknown): void {
+  // A personal scope's first write creates `auth-users/` (a no-op for the team
+  // scope's long-existing data dir). The 0700/0600 modes only keep OTHER UNIX
+  // USERS out, and even that is umask-masked; the agent's own tools run as the
+  // SAME uid as the runtime, so what actually stops them reading a team member's
+  // token is the file-tool deny rule in session/tools/fs-guard.ts.
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   const tmp = `${path}.tmp`;
   writeFileSync(tmp, JSON.stringify(contents), { mode: 0o600 }); // atomic write
   renameSync(tmp, path);

--- a/packages/runtime/src/auth/credential-health.ts
+++ b/packages/runtime/src/auth/credential-health.ts
@@ -1,10 +1,13 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { endpointFileIn, OPENAI_COMPATIBLE } from "../ai/openai-compatible";
 import { claudeCredentialsFile } from "../backends/claude/paths";
 import { config } from "../config";
-import { readAuthFile } from "./auth-file";
+import {
+  currentCredentialScope,
+  isPersonalScope,
+} from "../session/acting-context";
+import { authPathIn, readAuthFile } from "./auth-file";
 
 /**
  * Turn-time truth fed back into provider status.
@@ -36,8 +39,18 @@ import { readAuthFile } from "./auth-file";
  * state could wedge a provider off after an out-of-band fix.
  */
 
-/** provider id → fingerprint of the credential that failed authentication. */
+/**
+ * `${scopeKey}:${provider}` → fingerprint of the credential that failed
+ * authentication. Keyed by acting identity (HOU-976) because on a shared pod
+ * two members hold two different credentials for the same provider: one
+ * member's dead token must not report the OTHER member's provider disconnected.
+ */
 const failed = new Map<string, string>();
+
+/** The mark key for a provider under the CURRENT acting identity. */
+function markFor(id: string): string {
+  return `${currentCredentialScope().key}:${id}`;
+}
 
 function digest(value: string | Buffer): string {
   return createHash("sha256").update(value).digest("hex");
@@ -60,11 +73,17 @@ function fileFingerprint(path: string): string {
  * OpenAI-compatible provider carries its endpoint config (same placeholder
  * key, different server = a different "credential": reconfiguring the
  * endpoint must heal a failure mark).
+ *
+ * Everything read here belongs to the CURRENT acting identity (HOU-976). The
+ * shared-dir credentials file is the exception in reverse: it is team material,
+ * so it only counts in the team scope — otherwise another member's credential
+ * push would heal (or re-break) a member's own mark.
  */
 function credentialFingerprint(id: string): string {
-  const cred = readAuthFile(join(config.dataDir, "auth.json"))[id];
+  const { key } = currentCredentialScope();
+  const cred = readAuthFile(authPathIn(config.dataDir, key))[id];
   const stored = cred ? digest(JSON.stringify(cred)) : "absent";
-  if (id === "anthropic")
+  if (id === "anthropic" && !isPersonalScope(key))
     return `${stored}|${fileFingerprint(claudeCredentialsFile())}`;
   if (id === OPENAI_COMPATIBLE)
     return `${stored}|${fileFingerprint(endpointFileIn(config.dataDir))}`;
@@ -74,14 +93,14 @@ function credentialFingerprint(id: string): string {
 /** Record that a turn failed authentication on this provider's current
  *  credential. `fingerprint` is injectable for tests. */
 export function noteAuthFailure(id: string, fingerprint?: string): void {
-  failed.set(id, fingerprint ?? credentialFingerprint(id));
+  failed.set(markFor(id), fingerprint ?? credentialFingerprint(id));
 }
 
 /** Heal the mark without a credential change — a turn that COMPLETED on this
  *  provider proved the credential works (exec-turn / turn-session call this on
  *  every clean turn; cheap no-op when nothing is marked). */
 export function clearAuthFailure(id: string): void {
-  failed.delete(id);
+  failed.delete(markFor(id));
 }
 
 /**
@@ -91,10 +110,11 @@ export function clearAuthFailure(id: string): void {
  * path (nothing marked) does no IO. `fingerprint` is injectable for tests.
  */
 export function authFailureActive(id: string, fingerprint?: string): boolean {
-  const marked = failed.get(id);
+  const mark = markFor(id);
+  const marked = failed.get(mark);
   if (marked === undefined) return false;
   if (marked !== (fingerprint ?? credentialFingerprint(id))) {
-    failed.delete(id);
+    failed.delete(mark);
     return false;
   }
   return true;

--- a/packages/runtime/src/auth/credential-scope.test.ts
+++ b/packages/runtime/src/auth/credential-scope.test.ts
@@ -1,0 +1,242 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { config } from "../config";
+import {
+  credentialScopeKeyFor,
+  runWithActingContext,
+  TEAM_CREDENTIAL_SCOPE,
+} from "../session/acting-context";
+import { authPathIn, servedProvidersPathIn, writeAuthFile } from "./auth-file";
+import {
+  authFailureActive,
+  noteAuthFailure,
+  resetAuthFailures,
+} from "./credential-health";
+import { HoustonAuthStore } from "./credential-store";
+import { exportCredential } from "./export";
+
+/**
+ * Per-acting-user credentials on a SHARED pod (HOU-976 §2.6). One pod serves
+ * every member of a team space, so the credential store must resolve WHOSE
+ * credential a call addresses from the ambient acting identity — with the
+ * no-identity path (desktop / self-host / routines) staying byte-identical.
+ */
+
+/** A gateway-shaped acting-as token: `acting-v1.<payload>.<sig>`. The runtime
+ *  only READS the payload (the gateway verified it), so a stub sig is faithful. */
+function actingToken(sub: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ sub, agent: "acme", exp: 9_000_000_000 }),
+  ).toString("base64url");
+  return `acting-v1.${payload}.sig`;
+}
+
+function tmpDataDir(): string {
+  return mkdtempSync(join(tmpdir(), "houston-scope-"));
+}
+
+const apiKey = (key: string) => ({ type: "api_key" as const, key });
+
+afterEach(() => resetAuthFailures());
+
+// ---- the headline: two identities, two files, concurrently ----
+
+test("two concurrent operations under different acting subs resolve different credential files", async () => {
+  const dir = tmpDataDir();
+  const store = new HoustonAuthStore(join(dir, "auth.json"));
+  const alice = { actingAs: actingToken("sub-alice") };
+  const bob = { actingAs: actingToken("sub-bob") };
+
+  // Alice's write is a `modify` parked mid-flight (pi's OAuth refresh shape).
+  // Bob writes the SAME provider while it is parked: if the two identities
+  // shared a cache, a file, or a per-provider chain, one of these would lose.
+  let releaseAlice!: () => void;
+  const parked = new Promise<void>((r) => (releaseAlice = r));
+  const aliceWrite = runWithActingContext(alice, () =>
+    store.modify("openrouter", async () => {
+      await parked;
+      return apiKey("sk-alice");
+    }),
+  );
+  const bobWrite = runWithActingContext(bob, async () => {
+    store.set("openrouter", apiKey("sk-bob"));
+    // Bob reads his own value while Alice's write is still in flight.
+    expect(store.get("openrouter")).toEqual(apiKey("sk-bob"));
+    releaseAlice();
+  });
+  await Promise.all([aliceWrite, bobWrite]);
+
+  // Each identity reads back its OWN credential…
+  expect(runWithActingContext(alice, () => store.get("openrouter"))).toEqual(
+    apiKey("sk-alice"),
+  );
+  expect(runWithActingContext(bob, () => store.get("openrouter"))).toEqual(
+    apiKey("sk-bob"),
+  );
+  // …out of two DIFFERENT files on disk…
+  const alicePath = runWithActingContext(alice, () => store.currentPath());
+  const bobPath = runWithActingContext(bob, () => store.currentPath());
+  expect(alicePath).not.toBe(bobPath);
+  expect(JSON.parse(readFileSync(alicePath, "utf8"))).toEqual({
+    openrouter: apiKey("sk-alice"),
+  });
+  expect(JSON.parse(readFileSync(bobPath, "utf8"))).toEqual({
+    openrouter: apiKey("sk-bob"),
+  });
+  // …neither of which is the team file, which nothing here may create.
+  expect(existsSync(join(dir, "auth.json"))).toBe(false);
+  expect(readdirSync(join(dir, "auth-users")).sort()).toEqual(
+    [alicePath, bobPath].map((p) => p.split("/").pop()).sort(),
+  );
+  // The team scope sees neither member's credential.
+  expect(store.get("openrouter")).toBeUndefined();
+});
+
+test("one identity's concurrent writes still serialize behind the per-provider chain", async () => {
+  const dir = tmpDataDir();
+  const store = new HoustonAuthStore(join(dir, "auth.json"));
+  const alice = { actingAs: actingToken("sub-alice") };
+  const order: string[] = [];
+  let release!: () => void;
+  const parked = new Promise<void>((r) => (release = r));
+  const first = runWithActingContext(alice, () =>
+    store.modify("openai-codex", async () => {
+      order.push("first-start");
+      await parked;
+      order.push("first-end");
+      return apiKey("sk-1");
+    }),
+  );
+  const second = runWithActingContext(alice, () =>
+    store.modify("openai-codex", async (current) => {
+      order.push("second-start");
+      // The second writer observes the first's committed value — same identity,
+      // same file, one chain.
+      expect(current).toEqual(apiKey("sk-1"));
+      return apiKey("sk-2");
+    }),
+  );
+  release();
+  await Promise.all([first, second]);
+  expect(order).toEqual(["first-start", "first-end", "second-start"]);
+  expect(runWithActingContext(alice, () => store.get("openai-codex"))).toEqual(
+    apiKey("sk-2"),
+  );
+});
+
+// ---- the no-identity guarantee: desktop / self-host are untouched ----
+
+test("no acting identity: auth.json only — same path, same bytes, no auth-users dir", () => {
+  const dir = tmpDataDir();
+  const path = join(dir, "auth.json");
+  const store = new HoustonAuthStore(path);
+  store.set("openrouter", apiKey("sk-desktop"));
+
+  expect(store.currentPath()).toBe(path);
+  expect(readFileSync(path, "utf8")).toBe(
+    JSON.stringify({ openrouter: { type: "api_key", key: "sk-desktop" } }),
+  );
+  // The per-user tree is never even created on a single-credential install.
+  expect(existsSync(join(dir, "auth-users"))).toBe(false);
+  expect(readdirSync(dir)).toEqual(["auth.json"]);
+});
+
+test("a routine's acting USER never selects a personal scope (routines run on the team account)", () => {
+  const dir = tmpDataDir();
+  const store = new HoustonAuthStore(join(dir, "auth.json"));
+  // `actingUser` is a bare sub with no signed identity behind it (D10).
+  const path = runWithActingContext({ actingUser: "sub-alice" }, () =>
+    store.currentPath(),
+  );
+  expect(path).toBe(join(dir, "auth.json"));
+});
+
+// ---- scope keys + paths ----
+
+test("scope keys: no token is the team; a token is its sub; an unreadable token is neither", () => {
+  expect(credentialScopeKeyFor(undefined)).toBe(TEAM_CREDENTIAL_SCOPE);
+  expect(credentialScopeKeyFor(actingToken("sub-alice"))).toBe("u:sub-alice");
+  // A token we cannot read must NOT resolve to the shared credential, and the
+  // key must never carry the token itself (it reaches logs and file names).
+  const unreadable = credentialScopeKeyFor("acting-v1.@@@.sig");
+  expect(unreadable).not.toBe(TEAM_CREDENTIAL_SCOPE);
+  expect(unreadable).toMatch(/^u:unreadable-[0-9a-f]{16}$/);
+});
+
+test("scope paths: the team keeps auth.json; a member gets a hashed file under auth-users", () => {
+  expect(authPathIn("/data", TEAM_CREDENTIAL_SCOPE)).toBe("/data/auth.json");
+  expect(servedProvidersPathIn("/data", TEAM_CREDENTIAL_SCOPE)).toBe(
+    "/data/served-providers.json",
+  );
+  const personal = authPathIn("/data", "u:sub-alice");
+  expect(personal).toMatch(/^\/data\/auth-users\/[0-9a-f]{16}\.json$/);
+  // The sub itself never lands on disk.
+  expect(personal).not.toContain("sub-alice");
+  expect(servedProvidersPathIn("/data", "u:sub-alice")).toBe(
+    personal.replace(/\.json$/, ".served-providers.json"),
+  );
+  // A malformed key is a hard error, never a silent fall back to the team file.
+  expect(() => authPathIn("/data", "alice")).toThrow(
+    /credential scope key must be/,
+  );
+});
+
+// ---- health marks ----
+
+test("a member's broken-credential mark does not disconnect another member's provider", () => {
+  const alice = { actingAs: actingToken("sub-alice") };
+  const bob = { actingAs: actingToken("sub-bob") };
+  runWithActingContext(alice, () => noteAuthFailure("openrouter", "fp-alice"));
+  expect(
+    runWithActingContext(alice, () =>
+      authFailureActive("openrouter", "fp-alice"),
+    ),
+  ).toBe(true);
+  expect(
+    runWithActingContext(bob, () => authFailureActive("openrouter", "fp-bob")),
+  ).toBe(false);
+  // Nor the team's.
+  expect(authFailureActive("openrouter", "fp-team")).toBe(false);
+});
+
+// ---- connect-once capture ----
+
+test("connect-once capture exports the ACTING member's credential, not the team's", () => {
+  const prevDataDir = config.dataDir;
+  config.dataDir = tmpDataDir();
+  try {
+    const oauth = (access: string) => ({
+      type: "oauth" as const,
+      access,
+      refresh: `rt-${access}`,
+      expires: 1_900_000_000_000,
+    });
+    writeAuthFile(authPathIn(config.dataDir, TEAM_CREDENTIAL_SCOPE), {
+      "openai-codex": oauth("at-team"),
+    });
+    writeAuthFile(authPathIn(config.dataDir, "u:sub-alice"), {
+      "openai-codex": oauth("at-alice"),
+    });
+
+    // The team capture path (no acting identity) is unchanged…
+    expect(exportCredential("openai-codex")?.access).toBe("at-team");
+    // …and a member's connect captures THEIR credential. Exporting the team's
+    // would store one refresh-token family under two rows: two rotators.
+    expect(
+      runWithActingContext(
+        { actingAs: actingToken("sub-alice") },
+        () => exportCredential("openai-codex")?.access,
+      ),
+    ).toBe("at-alice");
+    // A member who connected nothing exports nothing (never the team's).
+    expect(
+      runWithActingContext({ actingAs: actingToken("sub-bob") }, () =>
+        exportCredential("openai-codex"),
+      ),
+    ).toBeNull();
+  } finally {
+    config.dataDir = prevDataDir;
+  }
+});

--- a/packages/runtime/src/auth/credential-store.ts
+++ b/packages/runtime/src/auth/credential-store.ts
@@ -1,68 +1,141 @@
+import { dirname } from "node:path";
 import type {
   Credential,
   CredentialInfo,
   CredentialStore,
 } from "@earendil-works/pi-ai";
-import { type PiCred, readAuthFile, writeAuthFile } from "./auth-file";
+import {
+  currentCredentialScope,
+  TEAM_CREDENTIAL_SCOPE,
+} from "../session/acting-context";
+import {
+  authPathIn,
+  type PiCred,
+  readAuthFile,
+  writeAuthFile,
+} from "./auth-file";
 
 /**
- * Houston's single-user credential store: pi-ai's `CredentialStore` contract
- * over the SAME dataDir/auth.json (atomic 0600 writes via auth-file.ts) plus
- * the synchronous `get`/`has`/`set`/`remove`/`reload` surface Houston's
- * turn-time paths need (`providerConnected` runs on the sync turn path, and
- * serve.ts writes auth.json directly then calls `reload()`).
+ * Houston's credential store: pi-ai's `CredentialStore` contract over
+ * dataDir/auth.json (atomic 0600 writes via auth-file.ts) plus the synchronous
+ * `get`/`has`/`set`/`remove`/`reload` surface Houston's turn-time paths need
+ * (`providerConnected` runs on the sync turn path, and serve.ts writes auth.json
+ * directly then calls `reload()`).
  *
  * pi ≤0.80.6 exported its own `AuthStorage` facade for this; 0.80.8 made
  * credential storage explicitly app-owned ("Login/logout orchestration is
  * app-owned" — pi-ai `CredentialStore`), with `ModelRuntime` doing auth
  * orchestration over whatever store the app provides. This is that store.
  *
+ * SCOPE (HOU-976). One pod serves every member of a team space, so the store is
+ * per acting identity: every method resolves `currentCredentialScope()` and
+ * reads/writes THAT scope's file. `modelRuntime` needs no change — pi calls
+ * `credentials.read(providerId)` inside `prepareRequest` on every `stream()`, so
+ * the read happens inside the turn's `AsyncLocalStorage` subtree.
+ *  - no acting identity → `<dataDir>/auth.json`, the pre-HOU-976 path and bytes
+ *    (desktop, self-host, routines, every request without the header);
+ *  - `u:<sub>` → `<dataDir>/auth-users/<sha256(sub)[:16]>.json`, same writer.
+ * One entry per identity the pod has served — bounded by the space's membership.
+ *
  * `modify` is the ONLY write path pi uses (OAuth refresh runs inside it), and
- * it is serialized per provider so concurrent requests cannot double-refresh a
- * rotated token. Houston is one process per data dir (host + runtime share the
- * process; the serve path's direct writers live here too), so an in-process
- * chain is the whole mutual-exclusion story — matching auth-file.ts, which has
- * always written auth.json without a cross-process lock.
+ * it is serialized per (scope, provider) so concurrent requests cannot
+ * double-refresh a rotated token. Two members touch two files with two chains;
+ * one member's concurrent turns share one file behind one chain. Houston is one
+ * process per data dir (host + runtime share the process; the serve path's
+ * direct writers live here too), so an in-process chain is the whole
+ * mutual-exclusion story — matching auth-file.ts, which has always written
+ * auth.json without a cross-process lock.
  */
-export class HoustonAuthStore implements CredentialStore {
-  private cache: Record<string, Credential>;
+interface ScopeState {
+  readonly path: string;
+  cache: Record<string, Credential>;
   /** Per-provider tail of the serialized `modify` chain. */
-  private chains = new Map<string, Promise<unknown>>();
+  readonly chains: Map<string, Promise<unknown>>;
+}
 
-  constructor(private readonly authPath: string) {
-    this.cache = readAuthFile(authPath) as Record<string, Credential>;
+export class HoustonAuthStore implements CredentialStore {
+  /** Scope key → that scope's file, cache and write chains. */
+  private readonly scopes = new Map<string, ScopeState>();
+  /** The data dir the personal scopes' files live under. */
+  private readonly dataDir: string;
+
+  /** `authPath` is the TEAM file; personal scopes derive from its directory. */
+  constructor(authPath: string) {
+    this.dataDir = dirname(authPath);
+    // Read the team file at construction, exactly as before: the desktop's
+    // sync turn path expects a warm cache with no first-read latency. Bound to
+    // the TEAM key explicitly — the constructor's path is the team file whatever
+    // identity happens to be ambient at construction.
+    this.scopes.set(TEAM_CREDENTIAL_SCOPE, {
+      path: authPath,
+      cache: readAuthFile(authPath) as Record<string, Credential>,
+      chains: new Map(),
+    });
   }
 
-  /** Re-read auth.json after a direct file write (the serve path). */
+  /** The current acting identity's file + cache, opened on first use. */
+  private scoped(): ScopeState {
+    const { key } = currentCredentialScope();
+    const open = this.scopes.get(key);
+    if (open) return open;
+    const path = authPathIn(this.dataDir, key);
+    const state: ScopeState = {
+      path,
+      cache: readAuthFile(path) as Record<string, Credential>,
+      chains: new Map(),
+    };
+    this.scopes.set(key, state);
+    return state;
+  }
+
+  /** Re-read the current scope's auth file after a direct write (serve path). */
   reload(): void {
-    this.cache = readAuthFile(this.authPath) as Record<string, Credential>;
+    const state = this.scoped();
+    state.cache = readAuthFile(state.path) as Record<string, Credential>;
   }
 
   /** Sync read of the stored credential (possibly expired) — status/turn use. */
   get(providerId: string): Credential | undefined {
-    return this.cache[providerId];
+    return this.scoped().cache[providerId];
   }
 
   has(providerId: string): boolean {
-    return this.cache[providerId] !== undefined;
+    return this.get(providerId) !== undefined;
   }
 
   /** Sync store (connect flows: pasted key, captured setup token). */
   set(providerId: string, credential: Credential): void {
-    this.cache = { ...this.cache, [providerId]: credential };
-    this.persist();
+    this.setIn(this.scoped(), providerId, credential);
   }
 
   /** Sync removal (logout). Absent entries are a no-op. */
   remove(providerId: string): void {
-    if (this.cache[providerId] === undefined) return;
-    const { [providerId]: _gone, ...rest } = this.cache;
-    this.cache = rest;
-    this.persist();
+    this.removeIn(this.scoped(), providerId);
   }
 
-  private persist(): void {
-    writeAuthFile(this.authPath, this.cache as Record<string, PiCred>);
+  /** The file the CURRENT scope reads and writes — diagnostics and tests. */
+  currentPath(): string {
+    return this.scoped().path;
+  }
+
+  private setIn(
+    state: ScopeState,
+    providerId: string,
+    credential: Credential,
+  ): void {
+    state.cache = { ...state.cache, [providerId]: credential };
+    this.persist(state);
+  }
+
+  private removeIn(state: ScopeState, providerId: string): void {
+    if (state.cache[providerId] === undefined) return;
+    const { [providerId]: _gone, ...rest } = state.cache;
+    state.cache = rest;
+    this.persist(state);
+  }
+
+  private persist(state: ScopeState): void {
+    writeAuthFile(state.path, state.cache as Record<string, PiCred>);
   }
 
   // ---- pi-ai CredentialStore ----
@@ -72,7 +145,7 @@ export class HoustonAuthStore implements CredentialStore {
   }
 
   async list(): Promise<readonly CredentialInfo[]> {
-    return Object.entries(this.cache).map(([providerId, cred]) => ({
+    return Object.entries(this.scoped().cache).map(([providerId, cred]) => ({
       providerId,
       type: cred.type,
     }));
@@ -82,25 +155,23 @@ export class HoustonAuthStore implements CredentialStore {
     providerId: string,
     fn: (current: Credential | undefined) => Promise<Credential | undefined>,
   ): Promise<Credential | undefined> {
-    const prev = this.chains.get(providerId) ?? Promise.resolve();
+    // The scope is resolved HERE and the queued work is BOUND to it: a chained
+    // continuation must write the file of the caller that queued it, never
+    // whichever identity happens to be ambient when the chain drains.
+    const state = this.scoped();
+    const prev = state.chains.get(providerId) ?? Promise.resolve();
+    const apply = async () => {
+      const next = await fn(state.cache[providerId]);
+      // Contract: `undefined` leaves the entry unchanged (NOT a delete).
+      if (next !== undefined) this.setIn(state, providerId, next);
+      return state.cache[providerId];
+    };
     // Chain regardless of the previous op's outcome; rejections from `fn`
     // still propagate to THIS caller below.
-    const run = prev.then(
-      async () => {
-        const next = await fn(this.get(providerId));
-        // Contract: `undefined` leaves the entry unchanged (NOT a delete).
-        if (next !== undefined) this.set(providerId, next);
-        return this.get(providerId);
-      },
-      async () => {
-        const next = await fn(this.get(providerId));
-        if (next !== undefined) this.set(providerId, next);
-        return this.get(providerId);
-      },
-    );
+    const run = prev.then(apply, apply);
     // The chain tail must never carry a rejection forward (it would replay
     // into unrelated later writes); the caller's `run` still rejects.
-    this.chains.set(
+    state.chains.set(
       providerId,
       run.catch(() => undefined),
     );
@@ -113,12 +184,11 @@ export class HoustonAuthStore implements CredentialStore {
 
   /** Serialize deletes against in-flight `modify` chains too. */
   private modifyDelete(providerId: string): Promise<void> {
-    const prev = this.chains.get(providerId) ?? Promise.resolve();
-    const run = prev.then(
-      () => this.remove(providerId),
-      () => this.remove(providerId),
-    );
-    this.chains.set(
+    const state = this.scoped();
+    const prev = state.chains.get(providerId) ?? Promise.resolve();
+    const drop = () => this.removeIn(state, providerId);
+    const run = prev.then(drop, drop);
+    state.chains.set(
       providerId,
       run.catch(() => undefined),
     );

--- a/packages/runtime/src/auth/export.ts
+++ b/packages/runtime/src/auth/export.ts
@@ -1,6 +1,6 @@
-import { join } from "node:path";
 import { config } from "../config";
-import { type PiCred, readAuthFile } from "./auth-file";
+import { currentCredentialScope } from "../session/acting-context";
+import { authPathIn, type PiCred, readAuthFile } from "./auth-file";
 
 export type ExportedCredential = {
   provider: string;
@@ -50,10 +50,16 @@ export function selectExportCredential(
  * provider, falls back to the first connected OAuth provider. Returns null when
  * the (requested) provider isn't connected — also the post-scrub state, so
  * capture must run before scrub.
+ *
+ * Reads the ACTING identity's file (HOU-976): the host forwards the acting-as
+ * token on `/auth/export`, and a member's connect must capture the credential
+ * THEY just connected. Exporting the team's instead would hand the gateway one
+ * refresh-token family to store under two rows — two rotators for one family,
+ * the HOU-950 failure mode.
  */
 export function exportCredential(provider?: string): ExportedCredential | null {
   return selectExportCredential(
-    readAuthFile(join(config.dataDir, "auth.json")),
+    readAuthFile(authPathIn(config.dataDir, currentCredentialScope().key)),
     provider,
   );
 }

--- a/packages/runtime/src/auth/login-scope.test.ts
+++ b/packages/runtime/src/auth/login-scope.test.ts
@@ -1,0 +1,174 @@
+import type { AuthInteraction } from "@earendil-works/pi-ai";
+import { expect, test, vi } from "vitest";
+import { runWithActingContext } from "../session/acting-context";
+import { cancelLogin, getAuthStatus, startLogin } from "./login";
+import { modelRuntime } from "./storage";
+
+/**
+ * Per-member OAuth logins on a SHARED pod (HOU-976 §2.6). One runtime serves
+ * EVERY member of a team space and each request runs inside its own acting
+ * identity, so an in-flight login belongs to the acting MEMBER — keying it by
+ * provider alone handed member B member A's one-time device code (B would have
+ * connected A's provider account) and let B's cancel tear down A's flow.
+ */
+
+/** A gateway-shaped acting-as token: the runtime only READS the payload. */
+function actingToken(sub: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ sub, agent: "acme", exp: 9_000_000_000 }),
+  ).toString("base64url");
+  return `acting-v1.${payload}.sig`;
+}
+
+const alice = { actingAs: actingToken("sub-alice") };
+const bob = { actingAs: actingToken("sub-bob") };
+
+/** github-copilot's device-code grant: it binds no port, so both flows coexist. */
+const PROVIDER = "github-copilot";
+
+type Flow = { userCode: string; signal: AbortSignal | undefined };
+
+/**
+ * Stub pi's OAuth login with a device-code flow that mints a DISTINCT one-time
+ * code per call and then polls forever (like a real grant awaiting the user), so
+ * a reused login is visible as a repeated code.
+ */
+function stubDeviceCodeLogin() {
+  const flows: Flow[] = [];
+  const oauthLogin = vi.fn((interaction: AuthInteraction) => {
+    const userCode = `CODE-${flows.length + 1}`;
+    flows.push({ userCode, signal: interaction.signal });
+    interaction.notify({
+      type: "device_code",
+      userCode,
+      verificationUri: "https://github.com/login/device",
+    });
+    return new Promise<never>(() => {});
+  });
+  const spy = vi.spyOn(modelRuntime, "getProvider").mockImplementation(
+    (id: string) =>
+      ({
+        id,
+        name: id,
+        auth: { oauth: { name: id, login: oauthLogin } },
+      }) as never,
+  );
+  return { flows, oauthLogin, restore: () => spy.mockRestore() };
+}
+
+/** The login row `/auth/status` reports for PROVIDER in the current scope. */
+async function loginRow() {
+  return (await getAuthStatus()).providers.find((p) => p.provider === PROVIDER)
+    ?.login;
+}
+
+test("a member's in-flight login is never handed to another member (cross-scope device code)", async () => {
+  const pi = stubDeviceCodeLogin();
+  try {
+    const aliceInfo = await runWithActingContext(alice, () =>
+      startLogin(PROVIDER, true),
+    );
+    // Bob asks to connect the SAME provider while Alice's flow is in flight.
+    const bobInfo = await runWithActingContext(bob, () =>
+      startLogin(PROVIDER, true),
+    );
+
+    expect(aliceInfo.kind).toBe("device_code");
+    expect(bobInfo.kind).toBe("device_code");
+    // Bob must NOT receive Alice's one-time code: pasting it would connect
+    // ALICE's GitHub account under Bob's credential.
+    expect(bobInfo).not.toBe(aliceInfo);
+    expect(bobInfo).not.toEqual(aliceInfo);
+    // Bob's own login actually ran (two pi flows, two distinct codes).
+    expect(pi.oauthLogin).toHaveBeenCalledTimes(2);
+    expect(pi.flows.map((f) => f.userCode)).toEqual(["CODE-1", "CODE-2"]);
+
+    // Alice's flow is untouched and still hers.
+    expect(await runWithActingContext(alice, loginRow)).toMatchObject({
+      status: "awaiting_user",
+      info: aliceInfo,
+    });
+    expect(await runWithActingContext(bob, loginRow)).toMatchObject({
+      status: "awaiting_user",
+      info: bobInfo,
+    });
+  } finally {
+    runWithActingContext(alice, () => cancelLogin(PROVIDER));
+    runWithActingContext(bob, () => cancelLogin(PROVIDER));
+    pi.restore();
+  }
+});
+
+test("a member's cancel never tears down another member's in-flight login", async () => {
+  const pi = stubDeviceCodeLogin();
+  try {
+    const aliceInfo = await runWithActingContext(alice, () =>
+      startLogin(PROVIDER, true),
+    );
+    await runWithActingContext(bob, () => startLogin(PROVIDER, true));
+
+    // Bob dismisses HIS dialog. Alice is still typing her code.
+    runWithActingContext(bob, () => cancelLogin(PROVIDER));
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Alice's poller was not aborted…
+    expect(pi.flows[0]?.signal?.aborted).toBe(false);
+    // …only Bob's own.
+    expect(pi.flows[1]?.signal?.aborted).toBe(true);
+    // …and Alice's login is still live and reachable under her identity.
+    expect(await runWithActingContext(alice, loginRow)).toMatchObject({
+      status: "awaiting_user",
+      info: aliceInfo,
+    });
+    // Bob's slot is freed, so his retry starts clean.
+    expect(await runWithActingContext(bob, loginRow)).toBeNull();
+  } finally {
+    runWithActingContext(alice, () => cancelLogin(PROVIDER));
+    pi.restore();
+  }
+});
+
+test("same member, same provider: a second connect click reuses the live login", async () => {
+  const pi = stubDeviceCodeLogin();
+  try {
+    const first = await runWithActingContext(alice, () =>
+      startLogin(PROVIDER, true),
+    );
+    const again = await runWithActingContext(alice, () =>
+      startLogin(PROVIDER, true),
+    );
+    // Idempotent within one identity: one pi flow, one code (a second flow would
+    // strand the first poller and invalidate the code the user is typing).
+    expect(again).toBe(first);
+    expect(pi.oauthLogin).toHaveBeenCalledTimes(1);
+  } finally {
+    runWithActingContext(alice, () => cancelLogin(PROVIDER));
+    pi.restore();
+  }
+});
+
+test("no acting identity: the team scope keeps its own slot, untouched by members", async () => {
+  const pi = stubDeviceCodeLogin();
+  try {
+    // Desktop / self-host: no acting identity, exactly as before HOU-976.
+    const team = await startLogin(PROVIDER, true);
+    expect(await startLogin(PROVIDER, true)).toBe(team);
+    expect(await loginRow()).toMatchObject({
+      status: "awaiting_user",
+      info: team,
+    });
+
+    // A member's flow and cancel leave the team's login alone…
+    await runWithActingContext(alice, () => startLogin(PROVIDER, true));
+    runWithActingContext(alice, () => cancelLogin(PROVIDER));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(pi.flows[0]?.signal?.aborted).toBe(false);
+    expect(await loginRow()).toMatchObject({ status: "awaiting_user" });
+
+    // …and the team's own cancel still frees the team slot.
+    cancelLogin(PROVIDER);
+    expect(await loginRow()).toBeNull();
+  } finally {
+    pi.restore();
+  }
+});

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -18,6 +18,10 @@ import {
   logoutAnthropicCredential,
   refreshAnthropicCredential,
 } from "../backends/claude/credential-status";
+import {
+  currentCredentialScope,
+  isPersonalScope,
+} from "../session/acting-context";
 import { runAnthropicSetupTokenLogin } from "./anthropic-setup-token";
 import { preflightCodexCallbackPort } from "./codex-port-preflight";
 import { authStorage, modelRuntime, providerConnected } from "./storage";
@@ -49,7 +53,24 @@ type LoginState = {
   timer?: ReturnType<typeof setTimeout>;
 };
 
-const active = new Map<ProviderId, LoginState>();
+/**
+ * In-flight logins, keyed by `<credential scope>:<provider>` — see `activeKey`.
+ */
+const active = new Map<string, LoginState>();
+
+/**
+ * The `active` slot an in-flight login occupies. Scoped, because ONE runtime
+ * serves every member of a team space (HOU-976) and each request runs inside its
+ * own acting identity: a provider-only key handed member B the one-time device
+ * code member A was still typing (B would have connected A's provider account),
+ * and let B's cancel/logout tear down A's flow. Every read AND write of `active`
+ * goes through here so no site can forget the scope. The team scope (desktop,
+ * self-host, every no-identity request) keeps its own `team:<provider>` slot, so
+ * its behavior is unchanged.
+ */
+function activeKey(provider: ProviderId): string {
+  return `${currentCredentialScope().key}:${provider}`;
+}
 
 /**
  * Overall cap on an in-flight login. An abandoned flow is not just stale UI
@@ -114,9 +135,13 @@ function clearLoginExpiry(state: LoginState): void {
  */
 function armLoginExpiry(provider: ProviderId, state: LoginState): void {
   clearLoginExpiry(state);
+  // Resolve the slot NOW, while the arming request's acting identity is still
+  // ambient: a stale timer must only ever tear down the state it was armed for,
+  // never another scope's login for the same provider.
+  const key = activeKey(provider);
   const timer = setTimeout(() => {
     // Stand down if the flow settled or was replaced/cancelled meanwhile.
-    if (active.get(provider) !== state) return;
+    if (active.get(key) !== state) return;
     if (state.status !== "starting" && state.status !== "awaiting_user") return;
     // Record the outcome BEFORE aborting: the login promise's rejection
     // handler sees the abort as a benign unwind and leaves this in place.
@@ -214,7 +239,7 @@ async function runProviderOAuthLogin(
 
 /** One /auth/status row for a provider id (curated or uncurated pi). */
 function authStatusRow(id: ProviderId, name: string) {
-  const st = active.get(id);
+  const st = active.get(activeKey(id));
   // Copilot Enterprise: surface the connected credential's company domain so the
   // connect UI can tell the Enterprise card apart from individual Copilot (both
   // are the same engine provider; the domain is the only difference). `get` is
@@ -262,12 +287,14 @@ export async function startLogin(
     throw new Error(`${providerId} does not use OAuth sign-in`);
   const provider = providerId;
 
-  // Idempotent: reuse an in-flight login. This must run BEFORE the port
-  // preflight below: an in-flight Codex browser login is ITSELF holding the
-  // fixed callback port (pi's in-process server), so probing first would
-  // mistake our own flow for a squatter and turn every retry click into
-  // "Another app is using the sign-in port" for the whole abandonment window.
-  const existing = active.get(provider);
+  // Idempotent: reuse an in-flight login — the ACTING member's own, never
+  // another member's. This must run BEFORE the port preflight below: an
+  // in-flight Codex browser login is ITSELF holding the fixed callback port
+  // (pi's in-process server), so probing first would mistake our own flow for a
+  // squatter and turn every retry click into "Another app is using the sign-in
+  // port" for the whole abandonment window.
+  const key = activeKey(provider);
+  const existing = active.get(key);
   if (
     existing &&
     (existing.status === "starting" || existing.status === "awaiting_user") &&
@@ -298,7 +325,7 @@ export async function startLogin(
     status: "starting",
     abort: new AbortController(),
   };
-  active.set(provider, state);
+  active.set(key, state);
   armLoginExpiry(provider, state);
 
   let resolveInfo!: (i: LoginInfo) => void;
@@ -430,9 +457,10 @@ export async function startLogin(
 export function setApiKey(providerId: string, key: string): void {
   const trimmed = assertApiKeyConnectable(providerId, key);
   authStorage.set(providerId, { type: "api_key", key: trimmed });
-  const state = active.get(providerId as ProviderId);
+  const slot = activeKey(providerId as ProviderId);
+  const state = active.get(slot);
   if (state) clearLoginExpiry(state);
-  active.delete(providerId as ProviderId);
+  active.delete(slot);
 }
 
 /**
@@ -485,9 +513,10 @@ export function setCustomEndpoint(
  */
 export function cancelLogin(providerId: string): void {
   if (!known(providerId)) throw new Error(`unknown provider: ${providerId}`);
-  const state = active.get(providerId);
+  const key = activeKey(providerId);
+  const state = active.get(key);
   if (!state || state.status === "complete") return;
-  active.delete(providerId);
+  active.delete(key);
   clearLoginExpiry(state);
   state.abort?.abort();
   state.rejectPaste?.(new Error("login cancelled"));
@@ -495,7 +524,7 @@ export function cancelLogin(providerId: string): void {
 
 /** Paste-code completion (Anthropic remote path). */
 export function completeLogin(providerId: string, code: string): void {
-  const state = active.get(providerId as ProviderId);
+  const state = active.get(activeKey(providerId as ProviderId));
   if (!state?.resolvePaste)
     throw new Error(`no active login for ${providerId}`);
   state.resolvePaste(code);
@@ -508,14 +537,25 @@ export async function logout(providerId: string): Promise<void> {
   // provider's OAuth token inside `modify` cannot be undone when that refresh
   // lands and re-persists the rotated credential.
   await authStorage.delete(providerId);
-  const state = active.get(providerId);
+  const key = activeKey(providerId);
+  const state = active.get(key);
   if (state) clearLoginExpiry(state);
-  active.delete(providerId);
+  active.delete(key);
   // Anthropic's primary credential is the browser-login one cached in the shared
   // dir (Keychain / file), NOT auth.json — so clear it via `claude auth logout`
   // and reset the probe cache, else the card would re-read connected on the next
   // poll. `authStorage.remove` above still clears the degraded fallback token.
-  if (providerId === "anthropic") await logoutAnthropicCredential();
+  //
+  // That shared dir is POD-WIDE team material (HOU-976): a member disconnecting
+  // their OWN anthropic account must stop at their own file, or one member's
+  // sign-out would sign the whole space out. Logged, never silent.
+  if (providerId === "anthropic") {
+    if (isPersonalScope(currentCredentialScope().key))
+      console.log(
+        "[oauth:anthropic] personal disconnect: leaving the pod-shared Claude login dir (team credential) in place",
+      );
+    else await logoutAnthropicCredential();
+  }
   // Disconnecting the local provider also forgets its endpoint (else the next
   // turn would re-resolve a base URL with no (real) key behind it); the
   // endpoint write also drops its runtime provider registration.

--- a/packages/runtime/src/auth/report-revoked.test.ts
+++ b/packages/runtime/src/auth/report-revoked.test.ts
@@ -1,11 +1,14 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { ProviderError } from "@houston/protocol";
 import { accessDigest } from "@houston/protocol/access-digest";
-import { expect, test } from "vitest";
+import { afterEach, expect, test } from "vitest";
 import { config } from "../config";
+import { runWithActingContext } from "../session/acting-context";
+import { authPathIn, servedProvidersPathIn } from "./auth-file";
 import { reportRevokedServedToken } from "./report-revoked";
+import { recordServedScope, resetServedScopes } from "./served-scope";
 
 /**
  * The reporter is a DELETE trigger for a workspace-wide credential, so the
@@ -69,6 +72,35 @@ function servedAnthropic(dataDir: string, access = "served-access"): void {
   );
 }
 
+/** The same, but in ONE member's files — where a per-identity serve sync lands. */
+function servedAnthropicFor(
+  dataDir: string,
+  scopeKey: string,
+  access: string,
+): void {
+  const authPath = authPathIn(dataDir, scopeKey);
+  mkdirSync(dirname(authPath), { recursive: true });
+  writeFileSync(
+    authPath,
+    JSON.stringify({
+      anthropic: { type: "oauth", access, refresh: "", expires: 0 },
+    }),
+  );
+  writeFileSync(
+    servedProvidersPathIn(dataDir, scopeKey),
+    JSON.stringify(["anthropic"]),
+  );
+}
+
+function actingToken(sub: string): string {
+  const payload = Buffer.from(JSON.stringify({ sub })).toString("base64url");
+  return `acting-v1.${payload}.sig`;
+}
+
+const alice = { actingAs: actingToken("sub-alice") };
+
+afterEach(() => resetServedScopes());
+
 const revoked: ProviderError = {
   kind: "unauthenticated",
   provider: "anthropic",
@@ -89,6 +121,36 @@ test("reports a revoked served token, naming it by digest only", async () => {
   expect(captured?.body.accessSha256).toBe(accessDigest("the-revoked-token"));
   // The token itself must never leave the runtime.
   expect(JSON.stringify(captured?.body)).not.toContain("the-revoked-token");
+});
+
+test("a member's report names the acting identity, not just the scope", async () => {
+  // Without the acting token the gateway cannot tell WHICH member's row a
+  // personal digest-delete targets, so it answers 400 and the dead token
+  // survives — the whole HOU-952 failure this path exists to end.
+  const captured = await withServeMode(
+    (dir) => servedAnthropicFor(dir, "u:sub-alice", "alice-revoked-token"),
+    () =>
+      runWithActingContext(alice, () => {
+        recordServedScope("anthropic", "personal");
+        reportRevokedServedToken(revoked);
+      }),
+  );
+
+  expect(captured?.body.actingAs).toBe(alice.actingAs);
+  expect(captured?.body.scope).toBe("personal");
+  expect(captured?.body.accessSha256).toBe(accessDigest("alice-revoked-token"));
+});
+
+test("a team report carries no acting identity at all", async () => {
+  // Desktop, self-host and every pre-HOU-976 turn: the body stays exactly what
+  // it was, so an older control plane sees no new field.
+  const captured = await withServeMode(
+    (dir) => servedAnthropic(dir),
+    () => reportRevokedServedToken(revoked),
+  );
+
+  expect(captured?.body.scope).toBe("team");
+  expect(Object.hasOwn(captured?.body ?? {}, "actingAs")).toBe(false);
 });
 
 test("does NOT report a non-terminal auth failure", async () => {

--- a/packages/runtime/src/auth/report-revoked.ts
+++ b/packages/runtime/src/auth/report-revoked.ts
@@ -1,8 +1,14 @@
-import { join } from "node:path";
 import type { ProviderError } from "@houston/protocol";
 import { accessDigest } from "@houston/protocol/access-digest";
 import { config } from "../config";
-import { readAuthFile, readServedProvidersAt } from "./auth-file";
+import { currentCredentialScope } from "../session/acting-context";
+import {
+  authPathIn,
+  readAuthFile,
+  readServedProvidersAt,
+  servedProvidersPathIn,
+} from "./auth-file";
+import { servedScopeFor } from "./served-scope";
 
 /**
  * Tell the control plane when a provider REVOKES a token it served us.
@@ -52,13 +58,20 @@ async function reportRevoked(err: ProviderError): Promise<void> {
   if (!config.controlPlaneUrl || !config.sandboxToken) return;
 
   const provider = err.provider;
+  // Everything below is read for the ACTING identity (HOU-976): a member reports
+  // the token THEY were served, and the gateway must delete that row, not the
+  // team's. Absent identity resolves to the one shared file, as before.
+  const { key, actingAs } = currentCredentialScope();
   const served = readServedProvidersAt(
-    join(config.dataDir, "served-providers.json"),
+    servedProvidersPathIn(config.dataDir, key),
   );
   if (!served.includes(provider)) return;
 
-  const cred = readAuthFile(join(config.dataDir, "auth.json"))[provider];
+  const cred = readAuthFile(authPathIn(config.dataDir, key))[provider];
   if (cred?.type !== "oauth" || !cred.access) return;
+  // WHICH row the gateway served us. Unknown (a pre-HOU-976 gateway sends no
+  // scope) reads as the team row — the only thing it could have been.
+  const scope = servedScopeFor(provider) ?? "team";
 
   try {
     const res = await fetch(
@@ -74,6 +87,12 @@ async function reportRevoked(err: ProviderError): Promise<void> {
           // The token is named, never shipped: the control plane holds its own
           // copy and compares digests.
           accessSha256: accessDigest(cred.access),
+          scope,
+          // The scope alone says "a member's row", not WHOSE: the gateway keys
+          // personal credentials by (org, user, provider) and answers 400
+          // without an acting identity. Sent only when there is one, so a team
+          // report stays the body a pre-HOU-976 control plane expects.
+          ...(actingAs ? { actingAs } : {}),
         }),
         signal: AbortSignal.timeout(REPORT_TIMEOUT_MS),
       },

--- a/packages/runtime/src/auth/serve-scope.test.ts
+++ b/packages/runtime/src/auth/serve-scope.test.ts
@@ -1,0 +1,225 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { classifyProviderError } from "../ai/provider-error";
+import { config } from "../config";
+import { runWithActingContext } from "../session/acting-context";
+import { authPathIn } from "./auth-file";
+import { syncServedCredential } from "./serve";
+import { resetServedScopes, servedScopeFor } from "./served-scope";
+
+/**
+ * Serve-mode hydration is PER ACTING IDENTITY (HOU-976 §2.6.4): a member's sync
+ * forwards their acting-as token, writes only their own credential file, and
+ * remembers WHOSE credential the gateway resolved so a turn's provider error can
+ * offer "continue on the team account" honestly.
+ */
+
+function actingToken(sub: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ sub, agent: "acme", exp: 9_000_000_000 }),
+  ).toString("base64url");
+  return `acting-v1.${payload}.sig`;
+}
+
+const alice = { actingAs: actingToken("sub-alice") };
+const bob = { actingAs: actingToken("sub-bob") };
+
+/** The host's authoritative "not connected" 404 (see routes/credential.ts). */
+const notConnected404 = () =>
+  new Response(null, {
+    status: 404,
+    headers: { "x-houston-not-connected": "1" },
+  });
+
+/** Records the acting-as header each probe carried, and serves ONE provider. */
+function serveOnly(
+  provider: string,
+  body: Record<string, unknown>,
+): { fetchImpl: typeof globalThis.fetch; actingSeen: Set<string> } {
+  const actingSeen = new Set<string>();
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    actingSeen.add(headers.get("x-houston-acting-as") ?? "(none)");
+    const asked = new URL(String(input)).searchParams.get("provider");
+    if (asked !== provider) return notConnected404();
+    return new Response(JSON.stringify(body), { status: 200 });
+  }) as unknown as typeof globalThis.fetch;
+  return { fetchImpl, actingSeen };
+}
+
+async function withServeMode(
+  fetchImpl: typeof globalThis.fetch,
+  run: () => Promise<void>,
+): Promise<void> {
+  const prev = {
+    url: config.controlPlaneUrl,
+    token: config.sandboxToken,
+    dataDir: config.dataDir,
+    fetch: globalThis.fetch,
+  };
+  config.controlPlaneUrl = "http://control-plane.test";
+  config.sandboxToken = "sbx-token";
+  config.dataDir = mkdtempSync(join(tmpdir(), "houston-serve-scope-"));
+  globalThis.fetch = fetchImpl;
+  try {
+    await run();
+  } finally {
+    globalThis.fetch = prev.fetch;
+    config.controlPlaneUrl = prev.url;
+    config.sandboxToken = prev.token;
+    config.dataDir = prev.dataDir;
+  }
+}
+
+afterEach(() => resetServedScopes());
+
+test("a member's serve sync writes ONLY that member's file and forwards their token", async () => {
+  const { fetchImpl, actingSeen } = serveOnly("openrouter", {
+    provider: "openrouter",
+    kind: "api_key",
+    access: "sk-alice-personal",
+    expires: 0,
+    accountId: null,
+    scope: "personal",
+  });
+  await withServeMode(fetchImpl, async () => {
+    const applied = await runWithActingContext(alice, () =>
+      syncServedCredential(),
+    );
+    expect(applied).toEqual(["openrouter"]);
+    // Every probe proved WHO it was for.
+    expect([...actingSeen]).toEqual([alice.actingAs]);
+    // The credential landed in Alice's file, and NOT in the team's.
+    const alicePath = authPathIn(config.dataDir, "u:sub-alice");
+    expect(JSON.parse(readFileSync(alicePath, "utf8"))).toEqual({
+      openrouter: { type: "api_key", key: "sk-alice-personal" },
+    });
+    expect(existsSync(join(config.dataDir, "auth.json"))).toBe(false);
+    expect(existsSync(join(config.dataDir, "served-providers.json"))).toBe(
+      false,
+    );
+    // One member synced, so exactly one member's files exist.
+    expect(readdirSync(join(config.dataDir, "auth-users")).sort()).toEqual(
+      [
+        alicePath.split("/").pop(),
+        `${alicePath
+          .split("/")
+          .pop()
+          ?.replace(/\.json$/, "")}.served-providers.json`,
+      ].sort(),
+    );
+  });
+});
+
+test("the gateway's scope verdict is remembered per member, not process-wide", async () => {
+  const { fetchImpl } = serveOnly("openrouter", {
+    provider: "openrouter",
+    kind: "api_key",
+    access: "sk-alice-personal",
+    expires: 0,
+    accountId: null,
+    scope: "personal",
+  });
+  await withServeMode(fetchImpl, async () => {
+    await runWithActingContext(alice, () => syncServedCredential());
+    expect(
+      runWithActingContext(alice, () => servedScopeFor("openrouter")),
+    ).toBe("personal");
+    // Bob never synced: nothing may be attributed to him…
+    expect(
+      runWithActingContext(bob, () => servedScopeFor("openrouter")),
+    ).toBeUndefined();
+    // …nor to a turn with no acting identity at all.
+    expect(servedScopeFor("openrouter")).toBeUndefined();
+  });
+});
+
+test("no acting identity: the sync keeps writing auth.json and records no scope", async () => {
+  const { fetchImpl, actingSeen } = serveOnly("openrouter", {
+    provider: "openrouter",
+    kind: "api_key",
+    access: "sk-team",
+    expires: 0,
+    accountId: null,
+  });
+  await withServeMode(fetchImpl, async () => {
+    const applied = await syncServedCredential();
+    expect(applied).toEqual(["openrouter"]);
+    expect([...actingSeen]).toEqual(["(none)"]);
+    expect(
+      JSON.parse(readFileSync(join(config.dataDir, "auth.json"), "utf8")),
+    ).toEqual({ openrouter: { type: "api_key", key: "sk-team" } });
+    expect(existsSync(join(config.dataDir, "auth-users"))).toBe(false);
+    expect(servedScopeFor("openrouter")).toBeUndefined();
+  });
+});
+
+test("two members' concurrent syncs do not share one in-flight result", async () => {
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    const acting = headers.get("x-houston-acting-as");
+    const asked = new URL(String(input)).searchParams.get("provider");
+    // Alice has a personal openrouter key; Bob has nothing connected.
+    if (acting !== alice.actingAs || asked !== "openrouter")
+      return notConnected404();
+    return new Response(
+      JSON.stringify({
+        provider: "openrouter",
+        kind: "api_key",
+        access: "sk-alice-personal",
+        expires: 0,
+        accountId: null,
+        scope: "personal",
+      }),
+      { status: 200 },
+    );
+  }) as unknown as typeof globalThis.fetch;
+  await withServeMode(fetchImpl, async () => {
+    const [aliceApplied, bobApplied] = await Promise.all([
+      runWithActingContext(alice, () => syncServedCredential()),
+      runWithActingContext(bob, () => syncServedCredential()),
+    ]);
+    expect(aliceApplied).toEqual(["openrouter"]);
+    expect(bobApplied).toEqual([]);
+    expect(existsSync(authPathIn(config.dataDir, "u:sub-bob"))).toBe(false);
+  });
+});
+
+test("a turn's provider error carries the credential scope only for the member it ran for", async () => {
+  const { fetchImpl } = serveOnly("openrouter", {
+    provider: "openrouter",
+    kind: "api_key",
+    access: "sk-alice-personal",
+    expires: 0,
+    accountId: null,
+    scope: "personal",
+  });
+  const rateLimited = {
+    provider: "openrouter",
+    model: "some-model",
+    message: "429 rate limit exceeded",
+  };
+  await withServeMode(fetchImpl, async () => {
+    await runWithActingContext(alice, () => syncServedCredential());
+    // Alice's turn: the card can name the account that hit the limit.
+    expect(
+      runWithActingContext(alice, () => classifyProviderError(rateLimited)),
+    ).toEqual({
+      kind: "rate_limited",
+      provider: "openrouter",
+      model: "some-model",
+      retry_after_seconds: null,
+      message: "429 rate limit exceeded",
+      credential: { scope: "personal" },
+    });
+    // Bob's turn, and a turn with no identity, are stamped with nothing —
+    // the desktop/self-host shape, unchanged.
+    expect(
+      runWithActingContext(bob, () => classifyProviderError(rateLimited))
+        .credential,
+    ).toBeUndefined();
+    expect(classifyProviderError(rateLimited).credential).toBeUndefined();
+  });
+});

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -1,15 +1,18 @@
-import { join } from "node:path";
 import { PROVIDERS } from "../ai/providers";
 import { config } from "../config";
+import { currentCredentialScope } from "../session/acting-context";
 import {
   applyServedCredential,
+  authPathIn,
   readServedProvidersAt,
   removeServedCredentialAt,
   type ServedCredential,
   scrubRefreshTokensAt,
+  servedProvidersPathIn,
   writeServedProvidersAt,
 } from "./auth-file";
 import { logServeProbeFailure, noteServeProbeOk } from "./serve-log";
+import { forgetServedScope, recordServedScope } from "./served-scope";
 import { authStorage } from "./storage";
 
 /**
@@ -34,9 +37,15 @@ import { authStorage } from "./storage";
  * the runtime's normal "No provider connected" error.
  */
 
-const authPathFor = () => join(config.dataDir, "auth.json");
+/**
+ * Both paths resolve through the CURRENT acting identity (HOU-976): a member's
+ * sync writes that member's file only. With no acting identity these are
+ * `<dataDir>/auth.json` and `<dataDir>/served-providers.json` — unchanged.
+ */
+const authPathFor = () =>
+  authPathIn(config.dataDir, currentCredentialScope().key);
 const servedManifestPathFor = () =>
-  join(config.dataDir, "served-providers.json");
+  servedProvidersPathIn(config.dataDir, currentCredentialScope().key);
 
 /**
  * Marker the host sets on its /sandbox/credential 404: the credential store's
@@ -76,15 +85,22 @@ export function scrubRefreshTokens(): string[] {
  * run N syncs that each rewrite auth.json at once — a write race. A turn and a
  * status poll can also overlap. One sync, one auth.json write, every caller gets
  * the same result.
+ *
+ * Sharing is PER ACTING IDENTITY (HOU-976): two members' syncs write two
+ * different files and must not collapse into one another's result, so the
+ * in-flight promise is keyed by scope.
  */
-let serveSyncInFlight: Promise<string[]> | null = null;
+const serveSyncInFlight = new Map<string, Promise<string[]>>();
 
 export function syncServedCredential(): Promise<string[]> {
-  if (serveSyncInFlight) return serveSyncInFlight;
-  serveSyncInFlight = runServedSync().finally(() => {
-    serveSyncInFlight = null;
+  const { key } = currentCredentialScope();
+  const inFlight = serveSyncInFlight.get(key);
+  if (inFlight) return inFlight;
+  const run = runServedSync().finally(() => {
+    serveSyncInFlight.delete(key);
   });
-  return serveSyncInFlight;
+  serveSyncInFlight.set(key, run);
+  return run;
 }
 
 /**
@@ -111,11 +127,18 @@ type ServeProbe =
 /** One provider's central lookup. Never throws — an internal serve hiccup for
  *  ONE provider must not strand the others. */
 async function probeProvider(id: string): Promise<ServeProbe> {
+  // WHO this serve is for: the host forwards the acting-as token to the gateway,
+  // which resolves personal-vs-team for THIS provider and reports its verdict
+  // on the body. Absent → the team credential, exactly as before HOU-976.
+  const { actingAs } = currentCredentialScope();
   try {
     const res = await fetch(
       `${config.controlPlaneUrl}/sandbox/credential?provider=${id}`,
       {
-        headers: { Authorization: `Bearer ${config.sandboxToken}` },
+        headers: {
+          Authorization: `Bearer ${config.sandboxToken}`,
+          ...(actingAs ? { "x-houston-acting-as": actingAs } : {}),
+        },
         signal: AbortSignal.timeout(SERVE_FETCH_TIMEOUT_MS),
       },
     );
@@ -167,19 +190,33 @@ async function runServedSync(): Promise<string[]> {
     if (probe.state !== "error") noteServeProbeOk(probe.id);
     if (probe.state === "served") {
       const didApply = applyServedCredential(authPathFor(), probe.cred);
+      // WHOSE credential this was, remembered for the provider-error stamp and
+      // the /providers row. Recorded on the gateway's ANSWER, not on the write:
+      // a skipped apply is the mid-capture guard over this same scope's own
+      // fresh login, never another member's credential. A pre-HOU-976 gateway
+      // omits `scope`; the only thing it could have served is the team one.
+      recordServedScope(
+        probe.id,
+        probe.cred.scope === "personal" ? "personal" : "team",
+      );
       if (didApply) applied.push(probe.id);
       if (didApply && !manifest.has(probe.id)) {
         manifest.add(probe.id);
         manifestDirty = true;
       }
-    } else if (probe.state === "not-connected" && manifest.has(probe.id)) {
-      // A refresh-bearing OAuth entry still survives inside
-      // removeServedCredentialAt: that's the device-code connect mid-capture.
-      if (removeServedCredentialAt(authPathFor(), probe.id))
-        removed.push(probe.id);
-      manifest.delete(probe.id);
-      manifestDirty = true;
-    } else if (probe.state === "error") {
+    } else if (probe.state === "not-connected") {
+      // Nothing is served for this scope any more, so no stale verdict may be
+      // stamped on a later error.
+      forgetServedScope(probe.id);
+      if (manifest.has(probe.id)) {
+        // A refresh-bearing OAuth entry still survives inside
+        // removeServedCredentialAt: that's the device-code connect mid-capture.
+        if (removeServedCredentialAt(authPathFor(), probe.id))
+          removed.push(probe.id);
+        manifest.delete(probe.id);
+        manifestDirty = true;
+      }
+    } else {
       // Dedup lives in serve-log.ts: every turn and hydrating route re-probes,
       // so a persistent gateway failure must not emit one Sentry error each.
       logServeProbeFailure(probe.id, probe.detail);

--- a/packages/runtime/src/auth/served-scope.ts
+++ b/packages/runtime/src/auth/served-scope.ts
@@ -1,0 +1,72 @@
+import {
+  currentCredentialScope,
+  isPersonalScope,
+} from "../session/acting-context";
+
+/**
+ * WHICH credential the gateway actually served, per (acting identity, provider).
+ *
+ * The gateway resolves whose credential answers at serve time (HOU-976) and
+ * reports its verdict on the serve body. The runtime remembers it so two
+ * surfaces can be honest about it without re-asking:
+ *  - a turn's `ProviderError` carries `credential` (ai/provider-error.ts), so a
+ *    rate-limited turn can name the account that hit the wall instead of the
+ *    provider alone;
+ *  - the `/providers` rows carry the scope their `configured` came from
+ *    (ai/providers.ts), so the model picker can label it.
+ *
+ * Lives in its own module rather than in serve.ts because ai/providers.ts reads
+ * it and serve.ts imports ai/providers.ts — the reverse edge would close the
+ * storage → providers → serve init cycle that already broke the engine bundle
+ * once (see auth/report-revoked.ts).
+ *
+ * Only IDENTITY-BEARING scopes are recorded: with no acting identity there is
+ * exactly one credential and nothing to disambiguate, so desktop / self-host /
+ * routine turns record nothing and every consumer stays byte-identical.
+ * In-memory only, like credential-health.ts: a restart re-learns it from the
+ * next serve.
+ */
+export type ServedCredentialScope = "personal" | "team";
+
+/** `${scopeKey}:${provider}` → the gateway's verdict for that pair. */
+const served = new Map<string, ServedCredentialScope>();
+
+function markFor(scopeKey: string, provider: string): string {
+  return `${scopeKey}:${provider}`;
+}
+
+/** Record what the CURRENT scope's serve resolved to for `provider`. */
+export function recordServedScope(
+  provider: string,
+  scope: ServedCredentialScope,
+): void {
+  const { key } = currentCredentialScope();
+  if (!isPersonalScope(key)) return;
+  served.set(markFor(key, provider), scope);
+}
+
+/** Forget a provider the CURRENT scope is no longer served (an authoritative
+ *  "not connected"), so a stale scope can never be stamped on a later error. */
+export function forgetServedScope(provider: string): void {
+  const { key } = currentCredentialScope();
+  if (!isPersonalScope(key)) return;
+  served.delete(markFor(key, provider));
+}
+
+/**
+ * The gateway's verdict for `provider` under the CURRENT acting identity, or
+ * undefined when this runtime has no acting identity (desktop / self-host /
+ * routine) or has never served that provider for it.
+ */
+export function servedScopeFor(
+  provider: string,
+): ServedCredentialScope | undefined {
+  const { key } = currentCredentialScope();
+  if (!isPersonalScope(key)) return undefined;
+  return served.get(markFor(key, provider));
+}
+
+/** Tests only: forget every recorded verdict. */
+export function resetServedScopes(): void {
+  served.clear();
+}

--- a/packages/runtime/src/auth/storage.ts
+++ b/packages/runtime/src/auth/storage.ts
@@ -6,10 +6,15 @@ import { config } from "../config";
 import { HoustonAuthStore } from "./credential-store";
 
 /**
- * Single-user credential store, persisted to dataDir/auth.json (mode 0600).
+ * Houston's credential store, persisted to dataDir/auth.json (mode 0600).
  * Houston-owned (see credential-store.ts): pi's `ModelRuntime` runs OAuth
  * refresh through its serialized `modify`, so all agent sessions transparently
  * use the current subscription token.
+ *
+ * Scope-aware since HOU-976: the constructor names the TEAM file, and every
+ * call resolves the ambient acting identity, so a member's turns on a shared
+ * pod read and write their own `auth-users/<hash>.json` instead. With no acting
+ * identity (desktop, self-host) it is exactly this one file.
  */
 export const authStorage = new HoustonAuthStore(
   join(config.dataDir, "auth.json"),
@@ -77,7 +82,9 @@ export function credentialUsable(
  * dir (Keychain / `.credentials.json`), read only by the `claude` binary. So it
  * counts as connected when EITHER a usable setup-token/served entry is in
  * auth.json OR the shared-dir credential signal reads logged-in
- * (`anthropicCredentialCached`, warmed by `getAuthStatus`).
+ * (`anthropicCredentialCached`, warmed by `getAuthStatus`). That shared dir is
+ * TEAM material, so `anthropicCredentialCached` reports false under a personal
+ * scope — a member's "connected" must come from their own credential.
  *
  * Pure over its inputs (store + the cached probe) so the rule stays testable.
  */

--- a/packages/runtime/src/backends/claude/backend.test.ts
+++ b/packages/runtime/src/backends/claude/backend.test.ts
@@ -1,6 +1,29 @@
-import { afterEach, beforeEach, expect, test } from "vitest";
-import { buildClaudeEnv, type ClaudeToken } from "./backend";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Options } from "@anthropic-ai/claude-agent-sdk";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { runWithActingContext } from "../../session/acting-context";
+import type { ResolvedModel } from "../types";
+import {
+  buildClaudeEnv,
+  type ClaudeBackendDeps,
+  type ClaudeToken,
+  createClaudeBackend,
+} from "./backend";
 import { claudeLoginConfigDir } from "./paths";
+
+// Capture the `baseOptions` the backend hands a session WITHOUT running the SDK:
+// the whole point of the scope guard is that a refused turn never builds an env
+// at all, so "was a session constructed, and with which env" is the assertion.
+const { built } = vi.hoisted(() => ({ built: [] as Options[] }));
+vi.mock("./session", () => ({
+  ClaudeSession: class {
+    constructor(deps: { baseOptions: Options }) {
+      built.push(deps.baseOptions);
+    }
+  },
+}));
 
 // buildClaudeEnv reads process.env; snapshot the three credential vars so a test
 // that plants a stale one can't leak into another.
@@ -14,6 +37,7 @@ let saved: Record<string, string | undefined>;
 beforeEach(() => {
   saved = Object.fromEntries(CREDS.map((k) => [k, process.env[k]]));
   for (const k of CREDS) delete process.env[k];
+  built.length = 0;
 });
 afterEach(() => {
   for (const k of CREDS) {
@@ -140,6 +164,71 @@ test("Houston host secrets never reach the subprocess env", () => {
       else process.env[k] = v;
     }
   }
+});
+
+/**
+ * The READ-side mirror of the credentials-file scope guard (HOU-976, and
+ * knowledge-base/anthropic-credentials.md traps #4 + #6): `CLAUDE_CONFIG_DIR` is
+ * the POD-SHARED login dir holding the TEAM's `.credentials.json`. Handing it to
+ * the SDK with no personal token in the env makes a member's turn authenticate as
+ * the team AND lets the SDK self-refresh the team's refresh-token family — a
+ * second rotator beside the gateway, plus a cross-member credential leak.
+ */
+function actingToken(sub: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ sub, agent: "acme", exp: 9_000_000_000 }),
+  ).toString("base64url");
+  return `acting-v1.${payload}.sig`;
+}
+
+const alice = { actingAs: actingToken("sub-alice") };
+
+const MODEL: ResolvedModel = {
+  provider: "anthropic",
+  id: "claude-sonnet-4-6",
+  contextWindow: 200_000,
+};
+
+function backendDeps(readToken: ClaudeBackendDeps["readToken"]) {
+  // A real directory: the tool policy's workspace clamp realpath()s the cwd.
+  const workspaceDir = mkdtempSync(join(tmpdir(), "claude-backend-scope-"));
+  return {
+    workspaceDir,
+    dataDir: workspaceDir,
+    readToken,
+    toolSelection: { toolNames: [], includeRunCode: false },
+    systemPrompt: "houston",
+  } satisfies ClaudeBackendDeps;
+}
+
+test("a personal scope with NO personal token refuses the session", async () => {
+  const backend = createClaudeBackend(backendDeps(() => undefined));
+  await expect(
+    runWithActingContext(alice, () =>
+      backend.createSession({ conversationId: "c1", model: MODEL }),
+    ),
+  ).rejects.toThrow(/^No provider connected\./);
+  // No session, and therefore no env pinned at the pod-shared login dir.
+  expect(built).toEqual([]);
+});
+
+test("a personal scope with its OWN token proceeds (env token outranks the dir)", async () => {
+  const backend = createClaudeBackend(backendDeps(() => oauth));
+  await runWithActingContext(alice, () =>
+    backend.createSession({ conversationId: "c1", model: MODEL }),
+  );
+  expect(built).toHaveLength(1);
+  expect(built[0]?.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-x");
+});
+
+test("the team scope still pins the shared login dir with no token (unchanged)", async () => {
+  // Desktop / self-host / every pre-HOU-976 request: the SDK legitimately reads
+  // the credential cached in its own login dir. Byte-identical to before.
+  const backend = createClaudeBackend(backendDeps(() => undefined));
+  await backend.createSession({ conversationId: "c1", model: MODEL });
+  expect(built).toHaveLength(1);
+  expect(built[0]?.env?.CLAUDE_CONFIG_DIR).toBe(claudeLoginConfigDir());
+  expect(built[0]?.env?.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
 });
 
 test("browser-login path: shared config dir, NO token env (SDK reads the cached cred)", () => {

--- a/packages/runtime/src/backends/claude/backend.ts
+++ b/packages/runtime/src/backends/claude/backend.ts
@@ -11,6 +11,10 @@ import { buildClaudeEnv } from "./claude-env";
 import { buildHoustonMcpServer, HOUSTON_MCP_SERVER_NAME } from "./custom-tools";
 import { toSdkModel } from "./model";
 import { claudeLoginConfigDir } from "./paths";
+import {
+  anthropicCredentialStorageDir,
+  assertAnthropicScopeCredential,
+} from "./scope-guard";
 import { type ClaudeQuery, ClaudeSession } from "./session";
 import { createSessionsStore } from "./sessions-store";
 import { buildSystemPrompt } from "./system-prompt";
@@ -66,6 +70,19 @@ export class ClaudeBackendUnavailableError extends Error {
  * subprocess environment, so `buildClaudeEnv` builds it from an ALLOWLIST — the
  * few operational vars the SDK needs plus the config dir and the one connected
  * credential — never spreading `process.env` (see `./claude-env`).
+ *
+ * That shared dir is why a PERSONAL scope with no personal token is REFUSED
+ * before the SDK is touched (`assertAnthropicScopeCredential`): on a managed pod
+ * the dir holds the TEAM's credential, so a member's turn would authenticate as
+ * the team and the SDK would self-refresh the team's refresh-token family in
+ * place — a second rotator beside the gateway, and one member's account paying
+ * for another's turn (see `./scope-guard` and
+ * knowledge-base/anthropic-credentials.md traps #4 and #6). Team scope (desktop,
+ * self-host, every pre-HOU-976 request) and any scope that DOES carry a token are
+ * unaffected. A personal scope that DOES carry a token additionally gets its own
+ * credential-store dir (`anthropicCredentialStorageDir`), because that token is
+ * access-only and can expire MID-TURN — at which point the CLI's own 401 recovery
+ * would otherwise re-read that shared dir and finish the turn on the team account.
  */
 export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
   return {
@@ -74,6 +91,13 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
     // `anthropic`, so it must register under exactly that.
     id: "anthropic",
     async createSession(opts: CreateSessionOptions): Promise<HarnessSession> {
+      // Read the credential ONCE and decide before anything else: a personal
+      // scope with no personal token must never reach the SDK, whose config dir
+      // is the pod-shared (team) one. Refusing here also keeps the failure a
+      // typed reconnect card instead of a mid-turn surprise.
+      const token = deps.readToken();
+      assertAnthropicScopeCredential(token);
+
       let query: ClaudeQuery;
       let houstonMcp: ReturnType<typeof buildHoustonMcpServer>;
       try {
@@ -105,7 +129,14 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
       const pathToClaudeCodeExecutable = resolveClaudeExecutable();
       const baseOptions: Options = {
         cwd: deps.workspaceDir,
-        env: buildClaudeEnv(claudeLoginConfigDir(), deps.readToken()),
+        env: buildClaudeEnv(
+          claudeLoginConfigDir(),
+          token,
+          // Personal scope: the CLI's credential store moves off the shared dir,
+          // so a mid-turn 401 cannot recover onto the team credential. Team
+          // scope: undefined, i.e. unchanged (see `./scope-guard`).
+          anthropicCredentialStorageDir(deps.dataDir),
+        ),
         ...(pathToClaudeCodeExecutable ? { pathToClaudeCodeExecutable } : {}),
         settingSources: [],
         tools: policy.tools,

--- a/packages/runtime/src/backends/claude/claude-env.ts
+++ b/packages/runtime/src/backends/claude/claude-env.ts
@@ -1,3 +1,4 @@
+import { isAbsolute } from "node:path";
 import type { ClaudeToken } from "./backend";
 
 /**
@@ -120,10 +121,17 @@ function tokenEnv(token: ClaudeToken | undefined): Record<string, string> {
  * never survive alongside a user's OAuth token — it was never copied — so a
  * subscription turn cannot silently bill the machine's API key. Shared by the
  * turn backend and the one-shot title path (`./title`) so both isolate identically.
+ *
+ * `credentialStorageDir` relocates the CLI's OWN credential store away from
+ * `configDir` — set for a PERSONAL scope only, and always via
+ * `anthropicCredentialStorageDir` (`./scope-guard`), which documents why.
+ * Undefined (team / desktop / self-host) sets nothing, leaving this env
+ * byte-identical to before that guard existed.
  */
 export function buildClaudeEnv(
   configDir: string,
   token: ClaudeToken | undefined,
+  credentialStorageDir?: string,
 ): Record<string, string> {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
@@ -132,6 +140,18 @@ export function buildClaudeEnv(
     }
   }
   env.CLAUDE_CONFIG_DIR = configDir;
+  if (credentialStorageDir !== undefined) {
+    // The CLI reads an EMPTY `CLAUDE_SECURESTORAGE_CONFIG_DIR` as `~/.houston`'s
+    // neighbour `~/.claude` — the machine user's PERSONAL credential (trap #2) —
+    // and a RELATIVE one against the subprocess cwd, which is the agent's
+    // workspace, so credential material would land in user-visible files. Both
+    // are worse than the leak this var closes, so neither is accepted.
+    if (!isAbsolute(credentialStorageDir))
+      throw new Error(
+        `the Claude credential store must be an absolute path, got "${credentialStorageDir}"`,
+      );
+    env.CLAUDE_SECURESTORAGE_CONFIG_DIR = credentialStorageDir;
+  }
   // Belt-and-braces: the credential keys are not in the allowlist, but assert the
   // invariant so a future allowlist edit can never re-admit an ambient one.
   for (const key of CREDENTIAL_ENV_VARS) delete env[key];

--- a/packages/runtime/src/backends/claude/credential-recovery-scope.test.ts
+++ b/packages/runtime/src/backends/claude/credential-recovery-scope.test.ts
@@ -1,0 +1,301 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Options } from "@anthropic-ai/claude-agent-sdk";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { runWithActingContext } from "../../session/acting-context";
+import type { ResolvedModel } from "../types";
+import {
+  buildClaudeEnv,
+  type ClaudeBackendDeps,
+  type ClaudeToken,
+  createClaudeBackend,
+} from "./backend";
+import { claudeCredentialsFile, claudeLoginConfigDir } from "./paths";
+import { anthropicCredentialStorageDir } from "./scope-guard";
+import type { ClaudeQuery } from "./session";
+import { titleWithClaude } from "./title";
+
+/**
+ * MID-TURN 401 RECOVERY, per credential scope (HOU-976; knowledge-base/
+ * anthropic-credentials.md trap #6).
+ *
+ * A personal Anthropic credential is served ACCESS-ONLY per turn, so it can
+ * expire while the turn is still running. The Claude CLI then runs its own 401
+ * recovery, which re-reads its credential store and adopts whatever access token
+ * it finds — and that store is normally the POD-SHARED claude-login dir, i.e.
+ * the TEAM's credential. The member's turn would continue on the team account
+ * with no message and no card.
+ *
+ * The recovery lives inside the CLI subprocess, so what these tests pin is the
+ * one thing Houston controls and the recovery is a pure function of: WHERE that
+ * subprocess is told to look. `cliCredentialStoreDir` /
+ * `recoverAccessTokenAfter401` below transcribe the CLI's own rules so the
+ * assertion is about the real consequence ("would this turn continue on the team
+ * token?"), not merely about an env var's presence.
+ */
+
+/**
+ * The CLI's credential-store resolution, transcribed from the Claude Code build
+ * the pinned SDK spawns (2.1.201, bundled in `@anthropic-ai/claude-agent-sdk`
+ * 0.3.201 — internally `UJ()` for the dir and `oF()` for the macOS Keychain
+ * service name, which is hashed from the SAME dir):
+ * `CLAUDE_SECURESTORAGE_CONFIG_DIR` wins over `CLAUDE_CONFIG_DIR`, and an EMPTY
+ * value means `~/.claude` — the machine user's own credential (trap #2), which is
+ * why `buildClaudeEnv` refuses a non-absolute value outright.
+ */
+function cliCredentialStoreDir(env: Record<string, string>): string {
+  const override = env.CLAUDE_SECURESTORAGE_CONFIG_DIR;
+  if (override !== undefined) return override || join(homedir(), ".claude");
+  return env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude");
+}
+
+/**
+ * The CLI's mid-turn 401 recovery, transcribed from the same build (`M5d`): an
+ * env-supplied access token carries no refresh token, so the recovery re-reads
+ * `.credentials.json` from its credential store and ADOPTS
+ * `claudeAiOauth.accessToken` whenever that differs from the token that just
+ * 401'd (`tengu_oauth_401_recovered_from_disk`). Returns the token the turn would
+ * silently continue on, or undefined when the recovery finds nothing — in which
+ * case the 401 stands and the turn surfaces the honest typed auth error.
+ */
+function recoverAccessTokenAfter401(
+  env: Record<string, string>,
+  failedAccessToken: string,
+): string | undefined {
+  let raw: string;
+  try {
+    raw = readFileSync(
+      join(cliCredentialStoreDir(env), ".credentials.json"),
+      "utf8",
+    );
+  } catch {
+    return undefined; // no credential store to recover from
+  }
+  const found = (
+    JSON.parse(raw) as { claudeAiOauth?: { accessToken?: string } }
+  ).claudeAiOauth?.accessToken;
+  return found && found !== failedAccessToken ? found : undefined;
+}
+
+// Capture the `baseOptions` the backend hands a session WITHOUT running the SDK
+// (same seam as backend.test.ts): the env IS the contract under test.
+const { built } = vi.hoisted(() => ({ built: [] as Options[] }));
+vi.mock("./session", () => ({
+  ClaudeSession: class {
+    constructor(deps: { baseOptions: Options }) {
+      built.push(deps.baseOptions);
+    }
+  },
+}));
+
+const MODEL: ResolvedModel = {
+  id: "claude-sonnet-5",
+  provider: "anthropic",
+} as ResolvedModel;
+
+/** The TEAM credential materialized on the pod-shared login dir. */
+const TEAM_ACCESS_TOKEN = "sk-ant-oat01-TEAM-account";
+/** The member's OWN served access token — the one that expires mid-turn. */
+const MEMBER_ACCESS_TOKEN = "sk-ant-oat01-alice-served";
+const memberToken: ClaudeToken = {
+  kind: "oauth-token",
+  value: MEMBER_ACCESS_TOKEN,
+};
+
+function actingToken(sub: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ sub, agent: "acme", exp: 9_000_000_000 }),
+  ).toString("base64url");
+  return `acting-v1.${payload}.sig`;
+}
+const alice = { actingAs: actingToken("sub-alice") };
+const bob = { actingAs: actingToken("sub-bob") };
+
+let home: string;
+let dataDir: string;
+let savedHome: string | undefined;
+
+beforeEach(() => {
+  built.length = 0;
+  savedHome = process.env.HOUSTON_HOME;
+  home = mkdtempSync(join(tmpdir(), "claude-401-home-"));
+  process.env.HOUSTON_HOME = home;
+  dataDir = mkdtempSync(join(tmpdir(), "claude-401-data-"));
+  // The pod's shared login dir, holding the TEAM's credential exactly as
+  // `credentials-file.ts` materializes it for a team-scope connect.
+  mkdirSync(claudeLoginConfigDir(), { recursive: true });
+  writeFileSync(
+    claudeCredentialsFile(),
+    JSON.stringify({
+      claudeAiOauth: {
+        accessToken: TEAM_ACCESS_TOKEN,
+        refreshToken: "team-refresh",
+        expiresAt: Date.now() + 3_600_000,
+      },
+    }),
+  );
+});
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.HOUSTON_HOME;
+  else process.env.HOUSTON_HOME = savedHome;
+});
+
+function backendDeps(): ClaudeBackendDeps {
+  // A real directory: the tool policy's workspace clamp realpath()s the cwd.
+  const workspaceDir = mkdtempSync(join(tmpdir(), "claude-401-ws-"));
+  return {
+    workspaceDir,
+    dataDir,
+    readToken: () => memberToken,
+    toolSelection: { toolNames: [], includeRunCode: false },
+    systemPrompt: "houston",
+  } satisfies ClaudeBackendDeps;
+}
+
+async function turnEnv(
+  ctx?: Parameters<typeof runWithActingContext>[0],
+): Promise<Record<string, string>> {
+  const backend = createClaudeBackend(backendDeps());
+  await runWithActingContext(ctx, () =>
+    backend.createSession({ conversationId: "c1", model: MODEL }),
+  );
+  const env = built.at(-1)?.env;
+  if (!env) throw new Error("no session was built");
+  return env as Record<string, string>;
+}
+
+test("a personal-scope turn's 401 recovery cannot adopt the pod-shared team token", async () => {
+  // THE BUG: the member's served access token expires mid-turn. With the CLI
+  // pointed at the pod-shared login dir it re-reads the TEAM's credential from
+  // disk and finishes the turn on it — no error, no card, one member's prompt
+  // billed to (and reading as) another account.
+  const env = await turnEnv(alice);
+
+  const recovered = recoverAccessTokenAfter401(env, MEMBER_ACCESS_TOKEN);
+  expect(recovered).not.toBe(TEAM_ACCESS_TOKEN);
+  // Nothing at all to recover onto: the 401 stands and the turn surfaces the
+  // honest typed auth error instead of silently continuing.
+  expect(recovered).toBeUndefined();
+});
+
+test("a team-scope turn's 401 recovery still reads the shared login dir (unchanged)", async () => {
+  // Desktop, self-host, and every pre-HOU-976 request: that dir holds this
+  // identity's OWN credential, and recovering from it is correct. Byte-identical
+  // to before the guard existed.
+  const env = await turnEnv(undefined);
+
+  expect(env.CLAUDE_SECURESTORAGE_CONFIG_DIR).toBeUndefined();
+  expect(recoverAccessTokenAfter401(env, "sk-ant-oat01-expired")).toBe(
+    TEAM_ACCESS_TOKEN,
+  );
+});
+
+test("a routine's bare acting-user turn keeps the team store (no signed identity)", async () => {
+  // `actingUser` alone cannot select a member's credentials (acting-context.ts),
+  // so an in-pod routine runs on the team account — including its recovery.
+  const env = await turnEnv({ actingUser: "sub-alice" });
+
+  expect(env.CLAUDE_SECURESTORAGE_CONFIG_DIR).toBeUndefined();
+  expect(recoverAccessTokenAfter401(env, "sk-ant-oat01-expired")).toBe(
+    TEAM_ACCESS_TOKEN,
+  );
+});
+
+test("a personal scope keeps the SHARED config dir, so transcripts and resume are untouched", async () => {
+  // The whole reason the credential store is relocated on its own: the
+  // `projects/` transcript tree, resume ids and the sessions store all hang off
+  // CLAUDE_CONFIG_DIR, and two members continuing one conversation must keep
+  // seeing the same transcript.
+  const env = await turnEnv(alice);
+
+  expect(env.CLAUDE_CONFIG_DIR).toBe(claudeLoginConfigDir());
+  expect(typeof env.CLAUDE_SECURESTORAGE_CONFIG_DIR).toBe("string");
+  expect(env.CLAUDE_SECURESTORAGE_CONFIG_DIR).not.toBe(claudeLoginConfigDir());
+  expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(MEMBER_ACCESS_TOKEN);
+});
+
+test("each member gets their OWN credential store, never a shared one", async () => {
+  const aliceEnv = await turnEnv(alice);
+  const bobEnv = await turnEnv(bob);
+
+  expect(aliceEnv.CLAUDE_SECURESTORAGE_CONFIG_DIR).not.toBe(
+    bobEnv.CLAUDE_SECURESTORAGE_CONFIG_DIR,
+  );
+  // Under `auth-users/`, whose whole subtree is excluded from store-sync and
+  // denied to the agent's own file tools — so a credential the CLI ever wrote
+  // there can neither sync out nor be read by the model.
+  for (const dir of [
+    aliceEnv.CLAUDE_SECURESTORAGE_CONFIG_DIR,
+    bobEnv.CLAUDE_SECURESTORAGE_CONFIG_DIR,
+  ]) {
+    expect(dir).toContain(join(dataDir, "auth-users"));
+    // The acting identity itself is never spelled out on a shared pod's
+    // filesystem — the scope key is hashed (auth/auth-file.ts).
+    expect(dir).not.toContain("sub-alice");
+    expect(dir).not.toContain("sub-bob");
+  }
+});
+
+test("the one-shot path (titles, anonymize) isolates identically", async () => {
+  // Same pod-shared config dir, same 401, same leak — so the same guard. A title
+  // that quietly ran on the team account would be invisible in the UI.
+  let env: Record<string, string> = {};
+  const query: ClaudeQuery = ({ options }) => {
+    env = options.env as Record<string, string>;
+    return (async function* () {})();
+  };
+  await runWithActingContext(alice, () =>
+    titleWithClaude({
+      excerpt: "hello",
+      titlePrompt: "title it",
+      workspaceDir: "/ws",
+      readToken: () => memberToken,
+      dataDir,
+      query,
+    }),
+  );
+
+  expect(env.CLAUDE_CONFIG_DIR).toBe(claudeLoginConfigDir());
+  expect(recoverAccessTokenAfter401(env, MEMBER_ACCESS_TOKEN)).toBeUndefined();
+});
+
+test("a personal scope with no data dir fails loud instead of inheriting the team store", () => {
+  // The one way a future SDK call site could regress this is by forgetting to
+  // thread its data dir through. That must be an error, not a silent fallback.
+  expect(() =>
+    runWithActingContext(alice, () => anthropicCredentialStorageDir(undefined)),
+  ).toThrow(/cannot isolate the Claude credential store/);
+  // The team scope needs no data dir at all — it legitimately reads its own dir.
+  expect(anthropicCredentialStorageDir(undefined)).toBeUndefined();
+});
+
+test("a non-absolute credential store is refused (it would resolve inside the workspace, or at ~/.claude)", () => {
+  // The CLI resolves a relative value against the subprocess cwd — the agent's
+  // workspace — and an EMPTY one against `~/.claude`, the machine user's PERSONAL
+  // credential (trap #2). Both are worse than the leak this closes.
+  expect(() => buildClaudeEnv("/cfg", memberToken, "auth-users/x")).toThrow(
+    /must be an absolute path/,
+  );
+  expect(() => buildClaudeEnv("/cfg", memberToken, "")).toThrow(
+    /must be an absolute path/,
+  );
+});
+
+test("an ambient CLAUDE_SECURESTORAGE_CONFIG_DIR never reaches the subprocess", async () => {
+  // It is not in the passthrough allowlist, so a stray host value can neither
+  // hijack a personal turn's store nor strand a team turn on an empty one.
+  const prev = process.env.CLAUDE_SECURESTORAGE_CONFIG_DIR;
+  process.env.CLAUDE_SECURESTORAGE_CONFIG_DIR = "/tmp/ambient-store";
+  try {
+    expect(
+      (await turnEnv(undefined)).CLAUDE_SECURESTORAGE_CONFIG_DIR,
+    ).toBeUndefined();
+    expect((await turnEnv(alice)).CLAUDE_SECURESTORAGE_CONFIG_DIR).not.toBe(
+      "/tmp/ambient-store",
+    );
+  } finally {
+    if (prev === undefined) delete process.env.CLAUDE_SECURESTORAGE_CONFIG_DIR;
+    else process.env.CLAUDE_SECURESTORAGE_CONFIG_DIR = prev;
+  }
+});

--- a/packages/runtime/src/backends/claude/credential-status.ts
+++ b/packages/runtime/src/backends/claude/credential-status.ts
@@ -1,5 +1,9 @@
 import { execFile } from "node:child_process";
 import { rmSync } from "node:fs";
+import {
+  currentCredentialScope,
+  isPersonalScope,
+} from "../../session/acting-context";
 import { buildClaudeEnv } from "./backend";
 import { resolveClaudeExecutable } from "./binary-path";
 import { claudeCredentialFileUsable } from "./credentials-file";
@@ -144,8 +148,16 @@ export async function refreshAnthropicCredential(
  * failed with the reconnect card. macOS-local caches in the Keychain (no file
  * to read), so a missing/dead file falls back to the last `claude auth status`
  * probe result (warmed by `getAuthStatus`).
+ *
+ * SCOPE (HOU-976): the shared login dir is POD-WIDE — one file, one Keychain
+ * entry, serving every member of a team space — so it is the TEAM's credential.
+ * A personal scope must not read it as its own: that would report a member
+ * "connected" on a credential that is not theirs and then run their turns on
+ * it. Under a personal scope the answer comes from that member's own auth file
+ * alone (`providerConnected`).
  */
 export function anthropicCredentialCached(): boolean {
+  if (isPersonalScope(currentCredentialScope().key)) return false;
   if (claudeCredentialFileUsable(claudeCredentialsFile())) return true;
   return cache ?? false;
 }

--- a/packages/runtime/src/backends/claude/credentials-file-scope.test.ts
+++ b/packages/runtime/src/backends/claude/credentials-file-scope.test.ts
@@ -1,0 +1,69 @@
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { runWithActingContext } from "../../session/acting-context";
+import {
+  anthropicCredentialCached,
+  resetAnthropicCredentialCache,
+} from "./credential-status";
+import { writeClaudeOAuthCredentialFile } from "./credentials-file";
+import { claudeCredentialsFile } from "./paths";
+
+/**
+ * The pod-shared Claude login dir is TEAM material (HOU-976 §2.6.5, and
+ * knowledge-base/anthropic-credentials.md trap #4): one file per pod, read by
+ * every member's SDK subprocess and self-refreshed in place. A MEMBER's
+ * credential must never reach it — that would both hand their refresh-token
+ * family to the rest of the space and create a second rotator for it.
+ */
+
+function actingToken(sub: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ sub, agent: "acme", exp: 9_000_000_000 }),
+  ).toString("base64url");
+  return `acting-v1.${payload}.sig`;
+}
+
+const alice = { actingAs: actingToken("sub-alice") };
+
+const CRED = {
+  accessToken: "sk-ant-oat-access",
+  refreshToken: "sk-ant-ort-refresh",
+  expiresAt: 1_800_000_000_000,
+  scopes: ["user:inference"],
+  subscriptionType: "max",
+};
+
+afterEach(() => resetAnthropicCredentialCache(false));
+
+test("a personal scope REFUSES to materialize the pod-shared Claude credential file", () => {
+  const dir = mkdtempSync(join(tmpdir(), "claude-login-scope-"));
+  expect(() =>
+    runWithActingContext(alice, () =>
+      writeClaudeOAuthCredentialFile(dir, CRED),
+    ),
+  ).toThrow(/refusing to materialize a personal Anthropic credential/);
+  // Loud refusal, and nothing on disk: not even a half-written tmp file.
+  expect(existsSync(dir)).toBe(true);
+  expect(existsSync(claudeCredentialsFile(dir))).toBe(false);
+  expect(existsSync(`${claudeCredentialsFile(dir)}.tmp`)).toBe(false);
+});
+
+test("the team scope still materializes it verbatim (desktop push, unchanged)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "claude-login-scope-"));
+  writeClaudeOAuthCredentialFile(dir, CRED);
+  expect(JSON.parse(readFileSync(claudeCredentialsFile(dir), "utf8"))).toEqual({
+    claudeAiOauth: CRED,
+  });
+});
+
+test("a personal scope never reads the shared login dir as its own connection", () => {
+  // The shared-dir probe says "logged in" — that is the TEAM's anthropic
+  // account. A member's status must come from their own credential alone.
+  resetAnthropicCredentialCache(true);
+  expect(anthropicCredentialCached()).toBe(true);
+  expect(runWithActingContext(alice, () => anthropicCredentialCached())).toBe(
+    false,
+  );
+});

--- a/packages/runtime/src/backends/claude/credentials-file.ts
+++ b/packages/runtime/src/backends/claude/credentials-file.ts
@@ -3,6 +3,10 @@ import {
   type ClaudeOAuthCredential,
   parseClaudeOAuthEnvelope,
 } from "@houston/runtime-client";
+import {
+  currentCredentialScope,
+  isPersonalScope,
+} from "../../session/acting-context";
 import { claudeCredentialsFile } from "./paths";
 
 /**
@@ -23,11 +27,25 @@ import { claudeCredentialsFile } from "./paths";
  *
  * Atomic (tmp + rename) at mode 0600 so a concurrent reader never sees a
  * half-written file and the token is owner-only on disk.
+ *
+ * HARD SCOPE GUARD (HOU-976). This file is POD-WIDE: one path, shared by every
+ * member of a team space. Materializing a MEMBER's credential into it would
+ * (1) hand their Anthropic refresh-token family to every other member of the
+ * space and (2) create a second rotator for that family — Anthropic invalidates
+ * the previous holder on refresh, so the pod's self-refreshing SDK and the
+ * gateway would take turns killing each other's token
+ * (knowledge-base/anthropic-credentials.md trap #4). A personal scope therefore
+ * REFUSES, loudly: personal Anthropic on a managed pod is served access-only per
+ * turn via `CLAUDE_CODE_OAUTH_TOKEN`, which outranks this file anyway (trap #3).
  */
 export function writeClaudeOAuthCredentialFile(
   configDir: string,
   cred: ClaudeOAuthCredential,
 ): void {
+  if (isPersonalScope(currentCredentialScope().key))
+    throw new Error(
+      "refusing to materialize a personal Anthropic credential into the pod-shared Claude login dir: it would be readable by every other member of this space and would create a second refresh-token rotator",
+    );
   mkdirSync(configDir, { recursive: true });
   const path = claudeCredentialsFile(configDir);
   const tmp = `${path}.tmp`;

--- a/packages/runtime/src/backends/claude/errors.test.ts
+++ b/packages/runtime/src/backends/claude/errors.test.ts
@@ -182,3 +182,40 @@ test("the verbatim provider text is logged once it is reduced to a card", () => 
     expect.stringContaining("401 expired"),
   );
 });
+
+/**
+ * The enum-mapped cards bypass `classifyProviderError`, which is where every
+ * other provider error gets its credential stamp — so they must stamp it
+ * themselves. Without it, a member whose OWN Anthropic account is rate limited
+ * reads a card that blames "Anthropic" in the abstract, on the provider whose
+ * limits users hit most (HOU-976).
+ */
+test("an enum-mapped card carries the acting identity's credential stamp", async () => {
+  const { runWithActingContext } = await import("../../session/acting-context");
+  const { recordServedScope, resetServedScopes } = await import(
+    "../../auth/served-scope"
+  );
+  resetServedScopes();
+  const actingAs = `acting-v1.${Buffer.from(
+    JSON.stringify({ sub: "sub-claude", agent: "acme", exp: 9_000_000_000 }),
+  ).toString("base64url")}.sig`;
+  runWithActingContext({ actingAs }, () => {
+    recordServedScope("anthropic", "personal");
+    expect(
+      mapSdkError("rate_limit", { message: "429 slow down", model: "m" }),
+    ).toMatchObject({
+      kind: "rate_limited",
+      credential: { scope: "personal" },
+    });
+    expect(
+      mapSdkError("authentication_failed", {
+        message: "401 expired",
+        model: "m",
+      }),
+    ).toMatchObject({
+      kind: "unauthenticated",
+      credential: { scope: "personal" },
+    });
+  });
+  resetServedScopes();
+});

--- a/packages/runtime/src/backends/claude/errors.ts
+++ b/packages/runtime/src/backends/claude/errors.ts
@@ -3,6 +3,7 @@ import type { AuthFailureCause, ProviderError } from "@houston/runtime-client";
 import {
   classifyProviderError,
   extractRetryAfterSeconds,
+  stampCredentialScope,
 } from "../../ai/provider-error";
 import { logProviderError } from "../../ai/provider-error-log";
 import { noteAuthFailure } from "../../auth/credential-health";
@@ -45,7 +46,15 @@ export function mapSdkError(
   const message = ctx.message.trim() || "Unknown provider error";
   const model = ctx.model;
   const status = ctx.status ?? null;
-  const mapped = mapSdkEnum(error, message, model, status, ctx);
+  // The enum mappings build their card directly, so they bypass
+  // `classifyProviderError` — the one place every OTHER provider error picks up
+  // WHOSE credential ran the turn. Stamp it here or a personal-scope member's
+  // rate-limit / auth card loses `credential` and cannot offer "continue on the
+  // team account" (HOU-976 §5), on the provider whose limits users hit most.
+  // A no-op without an acting identity, so desktop/self-host cards are
+  // unchanged. The fall-through path is already stamped inside classifyText.
+  const enumMapped = mapSdkEnum(error, message, model, status, ctx);
+  const mapped = enumMapped ? stampCredentialScope(enumMapped) : null;
   // Fall-through cases delegate to classifyText, which logs for itself.
   if (mapped) {
     logProviderError(mapped, { model, status, sdkError: error });

--- a/packages/runtime/src/backends/claude/one-shot.ts
+++ b/packages/runtime/src/backends/claude/one-shot.ts
@@ -7,6 +7,10 @@ import {
 import { resolveClaudeExecutable } from "./binary-path";
 import { toSdkModel } from "./model";
 import { claudeLoginConfigDir } from "./paths";
+import {
+  anthropicCredentialStorageDir,
+  assertAnthropicScopeCredential,
+} from "./scope-guard";
 import type { ClaudeQuery } from "./session";
 import { createStreamTranslator } from "./translate";
 
@@ -29,6 +33,14 @@ export interface ClaudeOneShotParams {
   systemPrompt: string;
   workspaceDir: string;
   readToken: () => ClaudeToken | undefined;
+  /**
+   * The runtime's data dir. Required whenever this can run under a PERSONAL
+   * scope (every production caller — pass `config.dataDir`): it locates that
+   * member's isolated Claude credential store, without which a mid-turn 401
+   * would recover onto the pod-shared team credential. Omitting it is a hard
+   * error on the personal path, never a silent fallback (`./scope-guard`).
+   */
+  dataDir?: string;
   /** pi model id to run with; mapped to the SDK model string. */
   modelId?: string;
   /** Injected for tests; production lazily imports the optional SDK. */
@@ -38,6 +50,16 @@ export interface ClaudeOneShotParams {
 export async function oneShotWithClaude(
   p: ClaudeOneShotParams,
 ): Promise<string> {
+  // Same read-side scope refusal a turn applies (see `./scope-guard`): this path
+  // pins the same pod-shared `CLAUDE_CONFIG_DIR`, so a personal scope with no
+  // personal token would authenticate as the team and let the SDK self-refresh
+  // the team's credential. Decided before the SDK is imported or the env built,
+  // reading the credential exactly once. Its mid-flight sibling — the isolated
+  // credential store that keeps a 401 from recovering onto the team account —
+  // rides `buildClaudeEnv` below.
+  const token = p.readToken();
+  assertAnthropicScopeCredential(token);
+
   let query = p.query;
   if (!query) {
     try {
@@ -53,7 +75,11 @@ export async function oneShotWithClaude(
   const pathToClaudeCodeExecutable = resolveClaudeExecutable();
   const options: Options = {
     cwd: p.workspaceDir,
-    env: buildClaudeEnv(claudeLoginConfigDir(), p.readToken()),
+    env: buildClaudeEnv(
+      claudeLoginConfigDir(),
+      token,
+      anthropicCredentialStorageDir(p.dataDir),
+    ),
     ...(pathToClaudeCodeExecutable ? { pathToClaudeCodeExecutable } : {}),
     settingSources: [],
     allowedTools: [],

--- a/packages/runtime/src/backends/claude/read-token.ts
+++ b/packages/runtime/src/backends/claude/read-token.ts
@@ -24,6 +24,12 @@ import type { ClaudeToken } from "./backend";
  * expected), but a STORED value we can't classify (unexpected PiCred variant,
  * or an unrecognized prefix) returns `undefined` AND logs the concrete reason,
  * so a bad/corrupt entry surfaces in the logs instead of vanishing.
+ *
+ * SCOPE (HOU-976): `store.get` resolves the ambient acting identity, so on a
+ * shared pod this returns the ACTING member's anthropic token — read inside the
+ * turn's async subtree by every caller (conversation-cache, summarize,
+ * anonymize). Nothing here may fall back to the pod-shared login dir: that is
+ * the team's credential (credential-status.ts).
  */
 const [OAUTH_TOKEN_PREFIX, API_KEY_PREFIX] = ANTHROPIC_TOKEN_PREFIXES;
 

--- a/packages/runtime/src/backends/claude/scope-guard.test.ts
+++ b/packages/runtime/src/backends/claude/scope-guard.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "vitest";
+import { runWithActingContext } from "../../session/acting-context";
+import type { ClaudeToken } from "./backend";
+import { assertAnthropicScopeCredential } from "./scope-guard";
+
+/**
+ * The SDK always gets the POD-SHARED `CLAUDE_CONFIG_DIR`, so "no token in the
+ * env" means "authenticate from whatever credential is cached in that dir". For
+ * a member acting under a personal scope that credential is the TEAM's, and the
+ * SDK self-refreshes it (knowledge-base/anthropic-credentials.md traps #4/#6).
+ */
+function actingToken(sub: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ sub, agent: "acme", exp: 9_000_000_000 }),
+  ).toString("base64url");
+  return `acting-v1.${payload}.sig`;
+}
+
+const alice = { actingAs: actingToken("sub-alice") };
+const oauth: ClaudeToken = { kind: "oauth-token", value: "sk-ant-oat01-x" };
+const apiKey: ClaudeToken = { kind: "api-key", value: "sk-ant-api03-x" };
+
+test("a personal scope with no personal token throws", () => {
+  expect(() =>
+    runWithActingContext(alice, () =>
+      assertAnthropicScopeCredential(undefined),
+    ),
+  ).toThrow(/^No provider connected\./);
+});
+
+test("the refusal message carries the not-connected sentinel verbatim", () => {
+  // The chat surfaces a typed `unauthenticated` / `no_credentials` reconnect card
+  // ONLY for messages matching this phrase (ai/provider-error.ts's
+  // NO_CREDENTIALS_PATTERNS, session/chat.ts's regex). Reword the prefix and the
+  // member gets a generic `unknown` error with no reconnect flow.
+  let message = "";
+  try {
+    runWithActingContext(alice, () =>
+      assertAnthropicScopeCredential(undefined),
+    );
+  } catch (err) {
+    message = err instanceof Error ? err.message : String(err);
+  }
+  expect(message.startsWith("No provider connected.")).toBe(true);
+  // Honest, non-technical copy: names the account, never a file or a config dir.
+  expect(message).toContain("Anthropic account");
+  expect(message).not.toMatch(/config|dir|file|credentials\.json/i);
+});
+
+test("a personal scope with its own OAuth token is a no-op", () => {
+  // A served env token outranks the config-dir credential inside the SDK, so the
+  // member runs on their own account (trap #3).
+  expect(() =>
+    runWithActingContext(alice, () => assertAnthropicScopeCredential(oauth)),
+  ).not.toThrow();
+});
+
+test("a personal scope with its own API key is a no-op", () => {
+  expect(() =>
+    runWithActingContext(alice, () => assertAnthropicScopeCredential(apiKey)),
+  ).not.toThrow();
+});
+
+test("the team scope with no token is a no-op (desktop / self-host / pre-HOU-976)", () => {
+  // The dir the SDK reads IS this identity's own login cache here. Nothing to
+  // refuse, and the guard must not change that path at all.
+  expect(() => assertAnthropicScopeCredential(undefined)).not.toThrow();
+  expect(() =>
+    runWithActingContext({ actingUser: "sub-alice" }, () =>
+      assertAnthropicScopeCredential(undefined),
+    ),
+  ).not.toThrow();
+});

--- a/packages/runtime/src/backends/claude/scope-guard.ts
+++ b/packages/runtime/src/backends/claude/scope-guard.ts
@@ -1,0 +1,97 @@
+import { claudeSecureStorageDirIn } from "../../auth/auth-file";
+import {
+  currentCredentialScope,
+  isPersonalScope,
+} from "../../session/acting-context";
+import type { ClaudeToken } from "./backend";
+
+/**
+ * The READ-side mirror of `credentials-file.ts`'s write refusal, at TURN START
+ * (HOU-976; see knowledge-base/anthropic-credentials.md traps #4 and #6). Its
+ * mid-turn sibling is `anthropicCredentialStorageDir` below — one guard covers
+ * who STARTS a turn, the other who can RESUME it after a 401.
+ *
+ * Every Claude Agent SDK call pins `CLAUDE_CONFIG_DIR` to the pod-shared
+ * `claudeLoginConfigDir()`, which on a managed pod holds the TEAM's cached
+ * credential. That is correct for the team scope (and for desktop / self-host,
+ * where the dir is the user's own `claude auth login` cache). It is NOT correct
+ * for a member acting under a PERSONAL scope with no personal token: with no
+ * credential in the env the SDK falls back to that cached credential, so the
+ * member's turn would silently run on the TEAM account AND the SDK would
+ * self-refresh the team's refresh-token family in place. Anthropic rotates the
+ * refresh token on every use and invalidates the previous holder, so that makes
+ * the pod a SECOND rotator beside the gateway (trap #4) on top of leaking one
+ * account's usage across members (trap #6).
+ *
+ * A personal token PRESENT is fine and proceeds: an env credential OUTRANKS the
+ * config-dir credential inside the SDK (trap #3), and personal Anthropic is
+ * deliberately served access-only per turn.
+ *
+ * The message MUST start with `No provider connected.` — that sentinel is what
+ * `ai/provider-error.ts` (`NO_CREDENTIALS_PATTERNS`) and `session/chat.ts` match
+ * to render the typed `unauthenticated` / `no_credentials` reconnect card with
+ * the undelivered prompt, instead of a generic `unknown` error.
+ */
+export function assertAnthropicScopeCredential(
+  token: ClaudeToken | undefined,
+): void {
+  if (token) return;
+  if (!isPersonalScope(currentCredentialScope().key)) return;
+  throw new Error(
+    "No provider connected. Your Anthropic account is not connected to this space yet. Connect it to keep chatting on Claude.",
+  );
+}
+
+/**
+ * WHERE the SDK subprocess may look for a cached Claude credential — the
+ * read-side guard for MID-TURN 401 RECOVERY, and the reason a personal turn
+ * cannot silently finish on the team account.
+ *
+ * `assertAnthropicScopeCredential` above only settles who STARTS the turn. A
+ * personal Anthropic credential is served ACCESS-ONLY per turn, so it can expire
+ * while the turn is still running; the CLI then runs its own 401 recovery, which
+ * RE-READS its credential store and adopts whatever access token it finds there
+ * (`<dir>/.credentials.json` on Linux, the dir-scoped Keychain item on macOS).
+ * That store is normally the pod-shared claude-login dir, i.e. the TEAM's
+ * credential — so without this guard the member's turn would continue, with no
+ * message and no card, billing and reading as the team account (trap #6).
+ *
+ * The SDK's `getOAuthToken` callback is NOT a usable guard for this. Three
+ * independent reasons, all read out of the Claude Code build the pinned SDK
+ * spawns (2.1.201, bundled in `@anthropic-ai/claude-agent-sdk` 0.3.201):
+ *  1. the CLI only registers the callback when `CLAUDE_CODE_ENTRYPOINT` is one of
+ *     `claude-desktop` / `local-agent` / `claude-vscode`; the SDK pins ours to
+ *     `sdk-ts`, so it is never wired up;
+ *  2. it is skipped entirely when the stored credential carries a refresh token
+ *     (the CLI refreshes that family in place instead — trap #4);
+ *  3. even when it does run it merely PRECEDES the disk read; returning null
+ *     falls straight through to it (`tengu_oauth_401_recovered_from_disk`).
+ * So the only real lever is the store's LOCATION. `CLAUDE_SECURESTORAGE_CONFIG_DIR`
+ * moves the CLI's credential store — the file AND the Keychain service name,
+ * which is hashed from this dir — on its own, WITHOUT moving anything else that
+ * lives in `CLAUDE_CONFIG_DIR`. That split is the whole point: the shared config
+ * dir keeps owning the `projects/` transcript tree, so resume, the sessions store
+ * and cross-member conversation continuity stay exactly as they are, and only the
+ * credential lookup is isolated. A personal turn's recovery then finds nothing,
+ * the 401 stands, and the turn surfaces the honest typed auth error.
+ *
+ * Returns undefined for the TEAM scope (desktop, self-host, every pre-HOU-976
+ * request): no override is set, so that subprocess env is byte-identical to
+ * before this guard existed — and the credential in the login dir is that
+ * identity's OWN, which is exactly what it should read.
+ */
+export function anthropicCredentialStorageDir(
+  dataDir: string | undefined,
+): string | undefined {
+  const { key } = currentCredentialScope();
+  if (!isPersonalScope(key)) return undefined;
+  // A personal scope with no data dir to isolate into must FAIL, never quietly
+  // inherit the shared store: that silent inheritance is the exact bug this
+  // guard exists to close. Reachable only if a new SDK call site forgets to
+  // thread its data dir through.
+  if (!dataDir)
+    throw new Error(
+      "cannot isolate the Claude credential store for a personal scope: no data dir was given, and falling back to the pod-shared login dir would run this turn on the team credential",
+    );
+  return claudeSecureStorageDirIn(dataDir, key);
+}

--- a/packages/runtime/src/backends/claude/title.test.ts
+++ b/packages/runtime/src/backends/claude/title.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, expect, test } from "vitest";
+import { runWithActingContext } from "../../session/acting-context";
 import type { ClaudeToken } from "./backend";
+import { claudeLoginConfigDir } from "./paths";
 import type { ClaudeQuery } from "./session";
 import { titleWithClaude } from "./title";
 
@@ -76,4 +78,42 @@ test("titleWithClaude scrubs a stale API key when an OAuth token is connected", 
   expect(env().CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-x");
   expect(env().ANTHROPIC_API_KEY).toBeUndefined();
   expect(env().ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+});
+
+function actingToken(sub: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ sub, agent: "acme", exp: 9_000_000_000 }),
+  ).toString("base64url");
+  return `acting-v1.${payload}.sig`;
+}
+
+test("a one-shot under a personal scope with no personal token refuses", async () => {
+  // The one-shot path pins the same POD-SHARED CLAUDE_CONFIG_DIR a turn does, so
+  // it needs the same read-side scope guard: a member's throwaway call must never
+  // authenticate as the team account and self-refresh its credential.
+  const { query, env } = capturingQuery();
+  await expect(
+    runWithActingContext({ actingAs: actingToken("sub-alice") }, () =>
+      titleWithClaude({
+        excerpt: "hello",
+        titlePrompt: "title it",
+        workspaceDir: "/ws",
+        readToken: () => undefined,
+        query,
+      }),
+    ),
+  ).rejects.toThrow(/^No provider connected\./);
+  expect(env().CLAUDE_CONFIG_DIR).toBeUndefined();
+});
+
+test("a one-shot on the team scope with no token still runs (unchanged)", async () => {
+  const { query, env } = capturingQuery();
+  await titleWithClaude({
+    excerpt: "hello",
+    titlePrompt: "title it",
+    workspaceDir: "/ws",
+    readToken: () => undefined,
+    query,
+  });
+  expect(env().CLAUDE_CONFIG_DIR).toBe(claudeLoginConfigDir());
 });

--- a/packages/runtime/src/backends/claude/title.ts
+++ b/packages/runtime/src/backends/claude/title.ts
@@ -24,6 +24,8 @@ export interface ClaudeTitleParams {
   titlePrompt: string;
   workspaceDir: string;
   readToken: () => ClaudeToken | undefined;
+  /** The runtime's data dir — see `ClaudeOneShotParams.dataDir`. */
+  dataDir?: string;
   /** pi model id to title with; mapped to the SDK model string. */
   modelId?: string;
   /** Injected for tests; production lazily imports the optional SDK. */
@@ -50,6 +52,7 @@ export async function titleWithClaude(p: ClaudeTitleParams): Promise<string> {
     systemPrompt: p.titlePrompt,
     workspaceDir: p.workspaceDir,
     readToken: p.readToken,
+    dataDir: p.dataDir,
     modelId: p.modelId,
     query: p.query,
   });

--- a/packages/runtime/src/backends/claude/tool-policy.test.ts
+++ b/packages/runtime/src/backends/claude/tool-policy.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, realpathSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
 import type {
@@ -132,6 +132,31 @@ test("canUseTool denies an absolute-path escape", async () => {
   expect(r.behavior).toBe("deny");
   if (r.behavior === "deny")
     expect(r.message).toMatch(/outside the agent workspace/);
+});
+
+test("canUseTool denies the in-workspace credential files (Read/Write/Grep)", async () => {
+  // The runtime's dataDir lives under the workspace root, so these paths pass
+  // containment; the guard's credential deny is the only thing that stops them.
+  const ws = workspace();
+  const runtime = join(ws, ".houston", "runtime");
+  mkdirSync(join(runtime, "auth-users"), { recursive: true });
+  writeFileSync(join(runtime, "auth.json"), "{}");
+  const can = makeCanUseTool(ws);
+  const denied = [
+    ["Read", { file_path: join(runtime, "auth.json") }],
+    ["Write", { file_path: ".houston/runtime/auth.json" }],
+    [
+      "Read",
+      { file_path: ".houston/runtime/auth-users/deadbeefdeadbeef.json" },
+    ],
+    ["Grep", { pattern: "access", path: ".houston/runtime/auth-users" }],
+  ] as const;
+  for (const [tool, input] of denied) {
+    const r = await decide(can, tool, input);
+    expect(r.behavior, `${tool} ${JSON.stringify(input)}`).toBe("deny");
+    if (r.behavior === "deny")
+      expect(r.message).toMatch(/holds the sign-in credentials/);
+  }
 });
 
 test("canUseTool denies a `..` traversal escape", async () => {

--- a/packages/runtime/src/session/acting-context.ts
+++ b/packages/runtime/src/session/acting-context.ts
@@ -1,4 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { createHash } from "node:crypto";
+import { decodeActingAuthor } from "./attribution";
 
 /**
  * WHO the current turn is acting as (C2), captured from the host→runtime message
@@ -21,6 +23,53 @@ import { AsyncLocalStorage } from "node:async_hooks";
 export interface ActingContext {
   actingAs?: string;
   actingUser?: string;
+  /**
+   * WHOSE credentials this subtree resolves — derived from `actingAs` (see
+   * `credentialScopeKeyFor`), precomputed here because the credential store
+   * resolves it on every `read()` pi makes inside `prepareRequest`.
+   */
+  credentialScopeKey?: string;
+}
+
+/** The credential scope of a request with no acting identity: the shared file. */
+export const TEAM_CREDENTIAL_SCOPE = "team";
+
+/** WHOSE credentials the current async subtree resolves. */
+export interface CredentialScope {
+  /** `"team"`, or `u:<sub>` for a per-member scope. */
+  key: string;
+  /** The acting-as token to forward when serving this scope's credential. */
+  actingAs?: string;
+}
+
+/**
+ * The credential scope key an acting-as token resolves to.
+ *
+ * Only `actingAs` (the gateway-SIGNED per-turn token) can select a member's own
+ * credentials. `actingUser` deliberately cannot: a fired routine carries the
+ * creator's bare sub with no signed identity behind it, so in-pod routines run
+ * on the team account (HOU-976 D10).
+ */
+export function credentialScopeKeyFor(actingAs: string | undefined): string {
+  if (!actingAs) return TEAM_CREDENTIAL_SCOPE;
+  const sub = decodeActingAuthor(actingAs)?.userId;
+  if (sub) return `u:${sub}`;
+  // A token whose payload we cannot read is NOT the team: falling back to the
+  // shared scope would let a garbled token read the team credential. It gets
+  // its own isolated scope, keyed by a DIGEST of the token — this key reaches
+  // log lines and file names, so the token itself must never be it. Loud,
+  // because it means the gateway sent us something malformed and the request
+  // will surface as "not connected".
+  const digest = createHash("sha256").update(actingAs).digest("hex");
+  console.warn(
+    "[acting] acting-as token payload is unreadable; isolating its credential scope instead of falling back to the team credential",
+  );
+  return `u:unreadable-${digest.slice(0, 16)}`;
+}
+
+/** Whether a scope key addresses one member's own credentials. */
+export function isPersonalScope(key: string): boolean {
+  return key !== TEAM_CREDENTIAL_SCOPE;
 }
 
 const store = new AsyncLocalStorage<ActingContext>();
@@ -33,10 +82,43 @@ export function runWithActingContext<T>(
   // No identity to carry (local single-user, or neither header present): run
   // plainly so the tools see `undefined` and attach nothing.
   if (!ctx || (!ctx.actingAs && !ctx.actingUser)) return fn();
-  return store.run(ctx, fn);
+  return store.run(
+    { ...ctx, credentialScopeKey: credentialScopeKeyFor(ctx.actingAs) },
+    fn,
+  );
 }
 
 /** The current turn's acting context, or undefined outside a turn. */
 export function currentActingContext(): ActingContext | undefined {
   return store.getStore();
+}
+
+/**
+ * WHOSE credentials the current async subtree must resolve. `{ key: "team" }`
+ * outside any acting identity — desktop, self-host, and every pre-HOU-976
+ * request — so those paths keep reading the one shared auth.json.
+ */
+export function currentCredentialScope(): CredentialScope {
+  const ctx = store.getStore();
+  if (!ctx?.actingAs) return { key: TEAM_CREDENTIAL_SCOPE };
+  return {
+    key: ctx.credentialScopeKey ?? credentialScopeKeyFor(ctx.actingAs),
+    actingAs: ctx.actingAs,
+  };
+}
+
+/**
+ * The C2 acting-as identity carried by a runtime request's headers, or
+ * undefined. Read at the transport edge (server.ts wraps EVERY request) so the
+ * credential scope, the integration tools and message attribution all see the
+ * same identity.
+ */
+export function actingFromHeaders(headers: {
+  [key: string]: string | string[] | undefined;
+}): ActingContext | undefined {
+  const one = (v: string | string[] | undefined) =>
+    Array.isArray(v) ? v[0] : v;
+  const actingAs = one(headers["x-houston-acting-as"]);
+  const actingUser = one(headers["x-houston-acting-user"]);
+  return actingAs || actingUser ? { actingAs, actingUser } : undefined;
 }

--- a/packages/runtime/src/session/anonymize.ts
+++ b/packages/runtime/src/session/anonymize.ts
@@ -67,6 +67,9 @@ export async function anonymizeTexts(
           systemPrompt: ANONYMIZE_PROMPT,
           workspaceDir: config.workspaceDir,
           readToken: () => readAnthropicToken(authStorage),
+          // Locates the acting member's isolated Claude credential store, so a
+          // 401 here can never recover onto the team credential (HOU-976).
+          dataDir: config.dataDir,
           modelId: resolveModel().id,
         })
       : await oneShotText({

--- a/packages/runtime/src/session/chat-failure.test.ts
+++ b/packages/runtime/src/session/chat-failure.test.ts
@@ -12,6 +12,10 @@ process.env.HOUSTON_WORKSPACE_DIR = process.env.HOUSTON_DATA_DIR;
 const { runTurn } = await import("./chat");
 const { getHistory } = await import("../store/conversations");
 const { subscribe } = await import("./bus");
+const { recordServedScope, resetServedScopes } = await import(
+  "../auth/served-scope"
+);
+const { runWithActingContext } = await import("./acting-context");
 
 /**
  * A turn that fails BEFORE executing (a pin naming an unknown provider — a
@@ -103,4 +107,45 @@ test("a turn failing before execution publishes the nonce-stamped echo before th
   expect(frames.indexOf(user as never)).toBeLessThan(
     frames.indexOf(error as never),
   );
+});
+
+/**
+ * A pre-execution failure is SYNTHESIZED here rather than classified by
+ * ai/provider-error.ts, so it has to stamp the credential context itself
+ * (HOU-976). Without the stamp a member whose OWN account is not connected gets
+ * a card that never says whose account is missing, which is the one fact that
+ * tells them the fix is theirs to make.
+ */
+test("a pre-execution failure under a personal scope stamps the credential context", async () => {
+  resetServedScopes();
+  const acting = {
+    actingAs: `acting-v1.${Buffer.from(
+      JSON.stringify({ sub: "sub-stamp", agent: "acme", exp: 9_000_000_000 }),
+    ).toString("base64url")}.sig`,
+  };
+  await runWithActingContext(acting, async () => {
+    recordServedScope("openai-compatible", "personal");
+    await runTurn("conv-fail-4", "who am I?", undefined, {
+      provider: "openai-compatible",
+    });
+  });
+
+  const assistant = getHistory("conv-fail-4")?.messages.at(-1);
+  expect(assistant?.providerError).toMatchObject({
+    kind: "unauthenticated",
+    provider: "openai-compatible",
+    cause: "no_credentials",
+    credential: { scope: "personal" },
+  });
+  resetServedScopes();
+});
+
+/** The team scope records no served verdict, so the wire shape is unchanged. */
+test("a pre-execution failure with no acting identity carries no credential stamp", async () => {
+  resetServedScopes();
+  await runTurn("conv-fail-5", "who am I?", undefined, {
+    provider: "openai-compatible",
+  });
+  const assistant = getHistory("conv-fail-5")?.messages.at(-1);
+  expect(assistant?.providerError).not.toHaveProperty("credential");
 });

--- a/packages/runtime/src/session/chat.ts
+++ b/packages/runtime/src/session/chat.ts
@@ -2,6 +2,7 @@ import { rmSync } from "node:fs";
 import { join } from "node:path";
 import type { TurnMode } from "@houston/protocol";
 import type { ChatMessage } from "@houston/runtime-client";
+import { stampCredentialScope } from "../ai/provider-error";
 import {
   activeProvider,
   canonicalPinProvider,
@@ -104,14 +105,18 @@ export async function runTurn(
       turnId,
     });
     const message = `No provider connected for ${canonicalPinnedProvider}. Connect it first.`;
+    // Synthesized, so it must stamp the credential context itself (see the
+    // getConversation catch below): the card names WHOSE account is missing the
+    // provider, which in a team space is the acting member's own. A no-op
+    // without an acting identity, so the desktop wire shape is unchanged.
     appendAssistantMessage(id, "", {
-      providerError: {
+      providerError: stampCredentialScope({
         kind: "unauthenticated",
         provider: canonicalPinnedProvider,
         cause: "no_credentials",
         message,
         undelivered_prompt: text,
-      },
+      }),
       turnId,
     });
     publish(id, { type: "error", data: { message }, turnId });
@@ -165,20 +170,28 @@ export async function runTurn(
     const message = errMessage(err);
     const notConnected =
       /no local model configured|no provider connected/i.test(message);
+    // This error is SYNTHESIZED, not classified, so it must stamp the
+    // credential context itself — `classifyProviderError` does it for every
+    // error that goes through the classifier, and a card without the stamp
+    // cannot say WHOSE account is not connected: in a team space every turn
+    // runs on the acting member's own AI account (HOU-976). A no-op without an
+    // acting identity, so the desktop wire shape is unchanged.
     appendAssistantMessage(id, "", {
-      providerError: notConnected
-        ? {
-            kind: "unauthenticated",
-            provider: pin?.provider ?? "",
-            cause: "no_credentials",
-            message,
-            undelivered_prompt: text,
-          }
-        : {
-            kind: "unknown",
-            provider: pin?.provider ?? "unknown",
-            raw_excerpt: message,
-          },
+      providerError: stampCredentialScope(
+        notConnected
+          ? {
+              kind: "unauthenticated",
+              provider: pin?.provider ?? "",
+              cause: "no_credentials",
+              message,
+              undelivered_prompt: text,
+            }
+          : {
+              kind: "unknown",
+              provider: pin?.provider ?? "unknown",
+              raw_excerpt: message,
+            },
+      ),
       turnId,
     });
     publish(id, { type: "error", data: { message }, turnId });

--- a/packages/runtime/src/session/summarize.ts
+++ b/packages/runtime/src/session/summarize.ts
@@ -131,6 +131,9 @@ async function claudeTitle(excerpt: string, modelId?: string): Promise<string> {
       titlePrompt: TITLE_PROMPT,
       workspaceDir: config.workspaceDir,
       readToken: () => readAnthropicToken(authStorage),
+      // Locates the acting member's isolated Claude credential store, so a 401
+      // here can never recover onto the team credential (HOU-976).
+      dataDir: config.dataDir,
       modelId: modelId ?? resolveModel().id,
     });
   } catch (err) {

--- a/packages/runtime/src/session/tools/clamped-fs.test.ts
+++ b/packages/runtime/src/session/tools/clamped-fs.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "vitest";
@@ -108,6 +114,69 @@ test("find: hostile search path throws before any fd spawn", async () => {
   await expect(exec("find", { pattern: "auth*", path: ".." })).rejects.toThrow(
     "outside the agent workspace",
   );
+});
+
+/**
+ * The runtime's dataDir lives INSIDE the workspace (`<agentDir>/.houston/
+ * runtime`), so containment cannot protect the credential files — every team
+ * member's provider tokens sit on a path the file tools can otherwise resolve.
+ * Drive pi's real tools at them and prove the deny wall holds end to end.
+ */
+// Canonical root: on macOS /tmp is a symlink, and an absolute path through it
+// would be rejected as an escape before the credential deny even runs.
+const runtimeDir = join(realpathSync(ws), ".houston", "runtime");
+mkdirSync(join(runtimeDir, "auth-users"), { recursive: true });
+writeFileSync(
+  join(runtimeDir, "auth.json"),
+  JSON.stringify({ a: "TEAMTOKEN" }),
+);
+writeFileSync(
+  join(runtimeDir, "auth-users", "deadbeefdeadbeef.json"),
+  JSON.stringify({ a: "MEMBERTOKEN" }),
+);
+writeFileSync(join(runtimeDir, "served-providers.json"), '["anthropic"]');
+
+test("read: credential files inside the workspace are denied, ordinary data is not", async () => {
+  for (const path of [
+    ".houston/runtime/auth.json",
+    ".houston/runtime/auth-users/deadbeefdeadbeef.json",
+    join(runtimeDir, "auth.json"),
+  ]) {
+    await expect(exec("read", { path }), path).rejects.toThrow(
+      /sign-in credentials/,
+    );
+  }
+  const ok = await exec("read", {
+    path: ".houston/runtime/served-providers.json",
+  });
+  expect(JSON.stringify(ok.content)).toContain("anthropic");
+});
+
+test("write/edit cannot overwrite a credential file either", async () => {
+  await expect(
+    exec("write", { path: ".houston/runtime/auth.json", content: "{}" }),
+  ).rejects.toThrow(/sign-in credentials/);
+  await expect(
+    exec("edit", {
+      path: ".houston/runtime/auth-users/deadbeefdeadbeef.json",
+      edits: [{ oldText: "MEMBERTOKEN", newText: "owned" }],
+    }),
+  ).rejects.toThrow(/sign-in credentials/);
+  expect(
+    readFileSync(
+      join(runtimeDir, "auth-users", "deadbeefdeadbeef.json"),
+      "utf8",
+    ),
+  ).toContain("MEMBERTOKEN");
+});
+
+test("ls and grep cannot enumerate or search the credential dir", async () => {
+  await expect(
+    exec("ls", { path: ".houston/runtime/auth-users" }),
+  ).rejects.toThrow(/sign-in credentials/);
+  await expect(
+    exec("grep", { pattern: "access", path: ".houston/runtime/auth-users" }),
+  ).rejects.toThrow(/sign-in credentials/);
 });
 
 test("non-string path is rejected, not coerced", async () => {

--- a/packages/runtime/src/session/tools/fs-guard.test.ts
+++ b/packages/runtime/src/session/tools/fs-guard.test.ts
@@ -8,7 +8,7 @@ import {
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { expect, test } from "vitest";
-import { PathEscapeError, WorkspaceGuard } from "./fs-guard";
+import { PathDeniedError, PathEscapeError, WorkspaceGuard } from "./fs-guard";
 
 /**
  * Gate #1 unit wall: every path shape a prompt-injected model could supply to
@@ -119,6 +119,119 @@ test("guard root is canonical even when the configured root holds symlinks (macO
   // macOS; the guard must compare against the canonical form or every
   // in-workspace path would be rejected.
   expect(guard.clamp("notes.txt").startsWith(guard.root)).toBe(true);
+});
+
+/**
+ * The runtime's own dataDir is a CHILD of the workspace root on every profile
+ * (`<agentDir>/.houston/runtime`, see host.ts), so containment alone leaves
+ * every team member's live provider tokens readable by the agent's file tools.
+ * These cover the deny wall: the credential FAMILY is refused at any depth, by
+ * both walls, for reads and writes — while ordinary `.houston` data stays open.
+ */
+function credentialRoot(): { root: string; guard: WorkspaceGuard } {
+  // Canonical from the start: on macOS /tmp is itself a symlink, and an absolute
+  // path through it would be rejected as an escape before the deny even runs.
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "houston-cred-")));
+  const runtime = join(root, ".houston", "runtime");
+  mkdirSync(join(runtime, "auth-users"), { recursive: true });
+  writeFileSync(join(runtime, "auth.json"), '{"anthropic":{"access":"tok"}}');
+  writeFileSync(
+    join(runtime, "auth-users", "deadbeefdeadbeef.json"),
+    '{"anthropic":{"access":"tok"}}',
+  );
+  writeFileSync(
+    join(runtime, "auth-users", "deadbeefdeadbeef.served-providers.json"),
+    '["anthropic"]',
+  );
+  writeFileSync(join(runtime, "served-providers.json"), '["anthropic"]');
+  writeFileSync(join(root, ".houston", "activity.json"), "[]");
+  mkdirSync(join(root, ".houston", "conversations"), { recursive: true });
+  writeFileSync(join(root, ".houston", "conversations", "c1.json"), "{}");
+  writeFileSync(join(root, "CLAUDE.md"), "# agent");
+  mkdirSync(join(root, "workspace"), { recursive: true });
+  writeFileSync(join(root, "workspace", "notes.txt"), "notes");
+  mkdirSync(join(root, "claude-login"), { recursive: true });
+  writeFileSync(join(root, "claude-login", ".credentials.json"), "{}");
+  return { root, guard: new WorkspaceGuard(root) };
+}
+
+const CREDENTIAL_PATHS = [
+  ".houston/runtime/auth.json",
+  ".houston/runtime/auth-users/deadbeefdeadbeef.json",
+  ".houston/runtime/auth-users/deadbeefdeadbeef.served-providers.json",
+  "./x/../.houston/runtime/auth.json",
+  "claude-login/.credentials.json",
+];
+
+test("clamp denies every credential path shape (relative, traversal, absolute)", () => {
+  const { root, guard } = credentialRoot();
+  for (const p of CREDENTIAL_PATHS) {
+    expect(() => guard.clamp(p), p).toThrow(PathDeniedError);
+    expect(() => guard.clamp(join(root, p)), `absolute ${p}`).toThrow(
+      PathDeniedError,
+    );
+  }
+});
+
+test("assertInside denies credential paths pi already resolved (inner wall)", () => {
+  const { guard } = credentialRoot();
+  for (const p of CREDENTIAL_PATHS) {
+    expect(() => guard.assertInside(join(guard.root, p)), p).toThrow(
+      PathDeniedError,
+    );
+  }
+});
+
+test("the credential deny is depth-independent and case-insensitive", () => {
+  const { guard } = credentialRoot();
+  // A deeper (or shallower) layout must not become readable, and a
+  // case-insensitive filesystem would otherwise serve auth.json for AUTH.JSON.
+  expect(() => guard.clamp("auth.json")).toThrow(PathDeniedError);
+  expect(() => guard.clamp("a/b/c/auth-users/x.json")).toThrow(PathDeniedError);
+  expect(() => guard.clamp(".houston/runtime/AUTH.json")).toThrow(
+    PathDeniedError,
+  );
+  expect(() => guard.clamp(".houston/runtime/Auth-Users/x.json")).toThrow(
+    PathDeniedError,
+  );
+});
+
+test("a symlink inside the workspace cannot launder a credential path", () => {
+  const { guard, root } = credentialRoot();
+  symlinkSync(
+    join(root, ".houston", "runtime", "auth.json"),
+    join(root, "innocent.txt"),
+  );
+  expect(() => guard.clamp("innocent.txt")).toThrow(PathDeniedError);
+});
+
+test("the deny message never quotes credential contents", () => {
+  const { guard } = credentialRoot();
+  let message = "";
+  try {
+    guard.clamp(".houston/runtime/auth.json");
+  } catch (err) {
+    message = (err as Error).message;
+  }
+  expect(message).not.toContain("tok");
+  expect(message).not.toContain("anthropic");
+});
+
+test("ordinary .houston data and workspace files stay allowed", () => {
+  const { guard } = credentialRoot();
+  for (const p of [
+    ".houston/activity.json",
+    // The TEAM served-providers manifest is a provider-name list, not a secret.
+    ".houston/runtime/served-providers.json",
+    ".houston/conversations/c1.json",
+    "CLAUDE.md",
+    "workspace/notes.txt",
+  ]) {
+    expect(guard.clamp(p), p).toBe(join(guard.root, p));
+    expect(guard.assertInside(join(guard.root, p)), p).toBe(
+      join(guard.root, p),
+    );
+  }
 });
 
 test("prefix-sibling directory does not pass the containment check", () => {

--- a/packages/runtime/src/session/tools/fs-guard.ts
+++ b/packages/runtime/src/session/tools/fs-guard.ts
@@ -1,6 +1,14 @@
 import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
 import { fileURLToPath } from "node:url";
 
 /**
@@ -16,9 +24,28 @@ import { fileURLToPath } from "node:url";
  * Shared roots (the org-shared mirror) get the same discipline — agents edit
  * the org original there by design. Callers rewrite the tool's path param to the clamped result, so a
  * normalization divergence from pi cannot escape an allowed root.
+ *
+ * Containment alone is NOT enough: the runtime's own dataDir sits INSIDE the
+ * workspace root (`<agentDir>/.houston/runtime`, wired in the host's
+ * `dataDirFor`), so the credential files — `auth.json`, every team member's
+ * `auth-users/<hash>.json`, and a materialized `claude-login/.credentials.json`
+ * — resolve to legal in-workspace paths. On a shared team pod that would let one
+ * prompt-injected agent read the whole space's live provider tokens with no bash
+ * tool at all. Hence the second rule below: a DENY list of credential path
+ * segments that every allowed root enforces, for reads and writes alike.
  */
 
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
+
+/**
+ * Path segments that mark runtime credential material, matched anywhere under
+ * an allowed root. Matching by SEGMENT (not by full path) is what makes the rule
+ * survive a layout change: moving the data dir deeper or shallower cannot open a
+ * hole. It deliberately over-denies — a user file that happens to be named
+ * `auth.json` is refused too, which is the safe direction for a wall whose
+ * failure mode is leaking every team member's access token.
+ */
+const DENIED_SEGMENTS = new Set(["auth.json", "auth-users", "claude-login"]);
 
 interface RootBoundary {
   canonical: string;
@@ -39,6 +66,20 @@ export class PathEscapeError extends Error {
       `Path is outside the agent workspace: ${raw} (file tools can only touch files under ${root})`,
     );
     this.name = "PathEscapeError";
+  }
+}
+
+/**
+ * A path inside an allowed root that holds sign-in credentials. The message is
+ * shown verbatim in a tool result, so it stays plain-language and never echoes
+ * anything but the path the model itself supplied.
+ */
+export class PathDeniedError extends Error {
+  constructor(raw: string) {
+    super(
+      `This file holds the sign-in credentials for the connected accounts, so it cannot be read or changed: ${raw}. Those accounts are already connected for you, and nothing in that file is needed to do the work.`,
+    );
+    this.name = "PathDeniedError";
   }
 }
 
@@ -99,10 +140,12 @@ export class WorkspaceGuard {
   }
 
   /**
-   * Resolve a model-supplied path and require it to land inside the workspace.
-   * Returns the absolute path to hand to the tool. Throws PathEscapeError on
-   * any escape: absolute path outside the root, `..` traversal, `~`, `@`- or
-   * file://-prefixed absolutes, or a symlink whose target leaves the root.
+   * Resolve a model-supplied path and require it to land inside an allowed
+   * root, on something that is not credential material. Returns the absolute
+   * path to hand to the tool. Throws PathEscapeError on any escape (absolute
+   * path outside every root, `..` traversal, `~`, `@`- or file://-prefixed
+   * absolutes, or a symlink whose target leaves the roots) and PathDeniedError
+   * on the runtime's credential files.
    */
   clamp(raw: string | undefined): string {
     return this.resolveAndAssert(raw, [
@@ -136,12 +179,25 @@ export class WorkspaceGuard {
     raw: string,
     allowedRoots: RootBoundary[],
   ): string {
-    const real = this.realNearest(abs);
-    for (const allowedRoot of allowedRoots) {
-      const lexicallyInside =
+    // Lexical containment first, so a path that never belonged here reads as an
+    // ESCAPE (a sibling `auth.json` outside every root is not "denied", it is
+    // out of bounds). The credential rule then runs on the cheap lexical form,
+    // before `realNearest`'s syscalls.
+    const inside = allowedRoots.filter(
+      (allowedRoot) =>
         this.contains(abs, allowedRoot.lexical) ||
-        this.contains(abs, allowedRoot.canonical);
-      if (lexicallyInside && this.contains(real, allowedRoot.canonical)) {
+        this.contains(abs, allowedRoot.canonical),
+    );
+    if (!inside.length) throw new PathEscapeError(raw, this.root);
+    if (inside.some((allowedRoot) => this.isCredential(abs, allowedRoot)))
+      throw new PathDeniedError(raw);
+    const real = this.realNearest(abs);
+    for (const allowedRoot of inside) {
+      if (this.contains(real, allowedRoot.canonical)) {
+        // A symlink inside an allowed root pointing at `auth.json` must not
+        // launder it, so the resolved form is judged too.
+        if (this.isCredential(real, allowedRoot))
+          throw new PathDeniedError(raw);
         return abs;
       }
     }
@@ -150,6 +206,24 @@ export class WorkspaceGuard {
 
   private contains(abs: string, root: string): boolean {
     return abs === root || abs.startsWith(root + sep);
+  }
+
+  /**
+   * Whether any segment of `abs` BELOW the allowed root it sits in names
+   * credential material. Judged relative to that root so a directory named
+   * `claude-login` ABOVE it (it appears as `..` from the root) can never deny
+   * the whole tree. Lower-cased because macOS and Windows filesystems are
+   * case-insensitive by default, so `AUTH.JSON` would otherwise open the very
+   * file `auth.json` denies.
+   */
+  private isCredential(abs: string, boundary: RootBoundary): boolean {
+    const base = this.contains(abs, boundary.canonical)
+      ? boundary.canonical
+      : boundary.lexical;
+    for (const segment of relative(base, abs).split(sep)) {
+      if (DENIED_SEGMENTS.has(segment.toLowerCase())) return true;
+    }
+    return false;
   }
 
   /**

--- a/packages/runtime/src/transport/conversation-routes.ts
+++ b/packages/runtime/src/transport/conversation-routes.ts
@@ -1,5 +1,5 @@
 import { normalizeTurnMode, parseMentions } from "@houston/protocol";
-import type { ActingContext } from "../session/acting-context";
+import { actingFromHeaders } from "../session/acting-context";
 import { evict, isTurnRunning } from "../session/bus";
 import {
   cancelTurn,
@@ -236,15 +236,4 @@ function positiveInt(raw: string | null, min = 1): number | undefined {
   if (raw === null) return undefined;
   const n = Number.parseInt(raw, 10);
   return Number.isInteger(n) && n >= min ? n : undefined;
-}
-
-/** Extract the C2 acting-as identity from a message request's headers, or undefined. */
-function actingFromHeaders(
-  headers: RouteContext["req"]["headers"],
-): ActingContext | undefined {
-  const one = (v: string | string[] | undefined) =>
-    Array.isArray(v) ? v[0] : v;
-  const actingAs = one(headers["x-houston-acting-as"]);
-  const actingUser = one(headers["x-houston-acting-user"]);
-  return actingAs || actingUser ? { actingAs, actingUser } : undefined;
 }

--- a/packages/runtime/src/transport/server-acting.test.ts
+++ b/packages/runtime/src/transport/server-acting.test.ts
@@ -1,0 +1,78 @@
+import type { Server } from "node:http";
+import { expect, test, vi } from "vitest";
+import { config } from "../config";
+import {
+  type CredentialScope,
+  currentCredentialScope,
+} from "../session/acting-context";
+
+/**
+ * EVERY runtime request must run inside the acting identity its headers carry
+ * (HOU-976 §2.6.2), not just the message route: `/providers`, `/auth/status`,
+ * `/auth/:p/login` and `/auth/export` all read or write a credential, and the
+ * serve sync they trigger writes a credential FILE. The provider route stands in
+ * for all of them here — the wrap is in one place, `createRuntimeServer`.
+ */
+const { seen } = vi.hoisted(() => ({
+  seen: [] as unknown[],
+}));
+vi.mock("./provider-routes", () => ({
+  handleProviderRoute: async (ctx: {
+    path: string;
+    res: { writeHead: (s: number) => void; end: (b?: string) => void };
+  }) => {
+    if (ctx.path !== "/providers") return false;
+    // Captured from inside the request handler, where the credential store,
+    // serve sync and health marks all resolve their scope.
+    seen.push(currentCredentialScope());
+    ctx.res.writeHead(200);
+    ctx.res.end("{}");
+    return true;
+  },
+}));
+
+const { createRuntimeServer } = await import("./server");
+
+function actingToken(sub: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ sub, agent: "acme", exp: 9_000_000_000 }),
+  ).toString("base64url");
+  return `acting-v1.${payload}.sig`;
+}
+
+function listen(server: Server): Promise<string> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string")
+        throw new Error("test server did not bind a TCP port");
+      resolve(`http://127.0.0.1:${addr.port}`);
+    });
+  });
+}
+
+test("the request's acting identity is the ambient credential scope for every route", async () => {
+  const server = createRuntimeServer();
+  const baseUrl = await listen(server);
+  const token = actingToken("sub-alice");
+  try {
+    const auth = config.token
+      ? { Authorization: `Bearer ${config.token}` }
+      : undefined;
+    let res = await fetch(`${baseUrl}/providers`, {
+      headers: { ...auth, "x-houston-acting-as": token },
+    });
+    expect(res.status).toBe(200);
+    // Same route, no header: the team scope, exactly as before HOU-976.
+    res = await fetch(`${baseUrl}/providers`, { headers: auth });
+    expect(res.status).toBe(200);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  }
+  expect(seen).toEqual([
+    { key: "u:sub-alice", actingAs: token } satisfies CredentialScope,
+    { key: "team" } satisfies CredentialScope,
+  ]);
+});

--- a/packages/runtime/src/transport/server-providers-scope.test.ts
+++ b/packages/runtime/src/transport/server-providers-scope.test.ts
@@ -1,0 +1,268 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import type { Server } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterAll, afterEach, expect, test, vi } from "vitest";
+
+/**
+ * `GET /providers` END-TO-END under two acting identities (HOU-976).
+ *
+ * server-acting.test.ts proves the transport wrap reaches a route, but it mocks
+ * `./provider-routes` away — so the REAL route's per-scope behavior was never
+ * exercised. This suite runs the unmocked route through an actual HTTP server
+ * and asserts the two things a member's model picker depends on:
+ *  1. each identity's `configured` comes from ITS OWN credential file, and no
+ *     member's connection is ever visible to another member or to the team;
+ *  2. the row names WHOSE credential produced `configured` (`credentialScope`),
+ *     and stays byte-identical to the pre-HOU-976 shape for a request with no
+ *     acting identity.
+ *
+ * The ONE stub: `refreshAnthropicCredential`, which `GET /providers` calls to
+ * warm the shared-dir probe. It SPAWNS `claude auth status`, so a developer's
+ * real Claude login would flip the anthropic row to connected and make the
+ * result machine-dependent (and every request pay a subprocess). Nothing else is
+ * mocked — `anthropicCredentialCached` (the sync signal the rows actually read)
+ * stays real, and answers from this suite's empty `HOUSTON_HOME`.
+ */
+vi.mock("../backends/claude/credential-status", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../backends/claude/credential-status")
+  >()),
+  refreshAnthropicCredential: async () => false,
+}));
+
+/** The gateway's per-turn acting-as token, minted exactly as the gateway does. */
+function actingToken(sub: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ sub, agent: "acme", exp: 9_000_000_000 }),
+  ).toString("base64url");
+  return `acting-v1.${payload}.sig`;
+}
+
+const ALICE = actingToken("sub-alice");
+const BOB = actingToken("sub-bob");
+const CONTROL_PLANE = "http://control-plane.test";
+
+const dataDir = mkdtempSync(join(tmpdir(), "houston-providers-scope-"));
+// The runtime reads its data dir from the environment at import time, so it is
+// pinned BEFORE the modules under test load. HOUSTON_HOME roots the shared
+// claude-login dir inside this empty temp tree too, so the real anthropic
+// signal cannot read a credential off the developer's machine.
+const prevEnv = {
+  dataDir: process.env.HOUSTON_DATA_DIR,
+  home: process.env.HOUSTON_HOME,
+};
+process.env.HOUSTON_DATA_DIR = dataDir;
+process.env.HOUSTON_HOME = dataDir;
+
+// auth-file.ts is config-free (pure path + file logic), so importing it here to
+// compute the per-scope paths does not pin the data dir before the assignment
+// above — the modules that DO read config are imported after it.
+const { authPathIn } = await import("../auth/auth-file");
+
+/**
+ * Seed one scope's credential file the way production writes it: the team scope's
+ * `<dataDir>/auth.json`, a member's `<dataDir>/auth-users/<sha256(sub)[:16]>.json`.
+ * Written before the store is constructed, so its warm team cache and every
+ * lazily-opened personal cache read these bytes.
+ */
+function seedScope(scopeKey: string, providers: Record<string, string>): void {
+  const path = authPathIn(dataDir, scopeKey);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(
+    path,
+    JSON.stringify(
+      Object.fromEntries(
+        Object.entries(providers).map(([provider, key]) => [
+          provider,
+          { type: "api_key", key },
+        ]),
+      ),
+    ),
+  );
+}
+
+seedScope("team", { deepseek: "sk-team-deepseek" });
+seedScope("u:sub-alice", { openrouter: "sk-alice-openrouter" });
+seedScope("u:sub-bob", { google: "sk-bob-gemini" });
+
+const { config } = await import("../config");
+const { createRuntimeServer } = await import("./server");
+const { resetServedScopes } = await import("../auth/served-scope");
+
+interface ProviderRow {
+  id: string;
+  configured: boolean;
+  credentialScope?: "personal" | "team";
+}
+
+function listen(server: Server): Promise<string> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string")
+        throw new Error("test server did not bind a TCP port");
+      resolve(`http://127.0.0.1:${addr.port}`);
+    });
+  });
+}
+
+/** Run `fn` against a live runtime server, always closing the port after. */
+async function withServer(
+  fn: (get: (actingAs?: string) => Promise<ProviderRow[]>) => Promise<void>,
+): Promise<void> {
+  const server = createRuntimeServer();
+  const baseUrl = await listen(server);
+  const auth = config.token
+    ? { Authorization: `Bearer ${config.token}` }
+    : undefined;
+  const get = async (actingAs?: string): Promise<ProviderRow[]> => {
+    const res = await fetch(`${baseUrl}/providers`, {
+      headers: {
+        ...auth,
+        ...(actingAs ? { "x-houston-acting-as": actingAs } : {}),
+      },
+    });
+    expect(res.status).toBe(200);
+    return (await res.json()) as ProviderRow[];
+  };
+  try {
+    await fn(get);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  }
+}
+
+function row(rows: ProviderRow[], id: string): ProviderRow {
+  const found = rows.find((r) => r.id === id);
+  if (!found) throw new Error(`no /providers row for ${id}`);
+  return found;
+}
+
+/** Which providers a request saw as connected — the picker's whole input. */
+function configuredIds(rows: ProviderRow[]): string[] {
+  return rows.filter((r) => r.configured).map((r) => r.id);
+}
+
+afterEach(() => {
+  resetServedScopes();
+  config.controlPlaneUrl = "";
+  config.sandboxToken = "";
+});
+
+// The env pins above outlive this file's module graph, so they are handed back —
+// a worker shared with another suite must not inherit this temp data dir.
+afterAll(() => {
+  restoreEnv("HOUSTON_DATA_DIR", prevEnv.dataDir);
+  restoreEnv("HOUSTON_HOME", prevEnv.home);
+});
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+test("GET /providers answers each acting identity from its OWN credential file", async () => {
+  // Serve mode off: this is the file-backed truth alone (a pod between syncs, a
+  // self-hosted deployment), so nothing here can come from a gateway response.
+  config.controlPlaneUrl = "";
+  config.sandboxToken = "";
+
+  await withServer(async (get) => {
+    const alice = await get(ALICE);
+    expect(configuredIds(alice)).toEqual(["openrouter"]);
+
+    // Bob is the inverse: his own key, and NOT a byte of Alice's or the team's.
+    const bob = await get(BOB);
+    expect(configuredIds(bob)).toEqual(["google"]);
+
+    // No header: the team file, exactly as desktop / self-host / every
+    // pre-HOU-976 caller sees it — neither member's connection leaks in.
+    const team = await get();
+    expect(configuredIds(team)).toEqual(["deepseek"]);
+
+    // With no serve verdict recorded, no row carries the scope labels — the
+    // pre-HOU-976 row shape, unchanged for every identity.
+    for (const rows of [alice, bob, team]) {
+      for (const r of rows) {
+        expect(r).not.toHaveProperty("credentialScope");
+      }
+    }
+  });
+});
+
+test("GET /providers labels WHOSE credential served each acting identity", async () => {
+  config.controlPlaneUrl = CONTROL_PLANE;
+  config.sandboxToken = "sbx-token";
+  const realFetch = globalThis.fetch;
+  // Stands in for the gateway's /sandbox/credential: Alice is served her OWN
+  // openrouter key, Bob is served the TEAM's Gemini key (the two verdicts the
+  // picker labels differently), and every other pair is an authoritative
+  // "not connected". Requests to the test server itself pass through.
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input instanceof Request ? input.url : input);
+    if (!url.startsWith(CONTROL_PLANE)) return realFetch(input, init);
+    const actingAs = new Headers(init?.headers).get("x-houston-acting-as");
+    const provider = new URL(url).searchParams.get("provider");
+    const served =
+      actingAs === ALICE && provider === "openrouter"
+        ? {
+            provider,
+            kind: "api_key",
+            access: "sk-alice-openrouter",
+            expires: 0,
+            accountId: null,
+            scope: "personal",
+          }
+        : actingAs === BOB && provider === "google"
+          ? {
+              provider,
+              kind: "api_key",
+              access: "sk-team-gemini",
+              expires: 0,
+              accountId: null,
+              scope: "team",
+            }
+          : null;
+    return served
+      ? new Response(JSON.stringify(served), { status: 200 })
+      : new Response(null, {
+          status: 404,
+          headers: { "x-houston-not-connected": "1" },
+        });
+  }) as typeof globalThis.fetch;
+
+  try {
+    await withServer(async (get) => {
+      const alice = await get(ALICE);
+      expect(row(alice, "openrouter")).toMatchObject({
+        configured: true,
+        credentialScope: "personal",
+      });
+      // Bob's provider is untouched for Alice, and an unserved row carries no
+      // stale label.
+      expect(row(alice, "google").configured).toBe(false);
+      expect(row(alice, "google")).not.toHaveProperty("credentialScope");
+
+      const bob = await get(BOB);
+      expect(row(bob, "google")).toMatchObject({
+        configured: true,
+        credentialScope: "team",
+      });
+      expect(row(bob, "openrouter").configured).toBe(false);
+      expect(row(bob, "openrouter")).not.toHaveProperty("credentialScope");
+
+      // A request with no acting identity keeps the team file and the exact
+      // pre-HOU-976 row shape: one credential, nothing to disambiguate.
+      const team = await get();
+      expect(configuredIds(team)).toEqual(["deepseek"]);
+      for (const r of team) {
+        expect(r).not.toHaveProperty("credentialScope");
+      }
+    });
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});

--- a/packages/runtime/src/transport/server.ts
+++ b/packages/runtime/src/transport/server.ts
@@ -1,6 +1,10 @@
 import { createServer } from "node:http";
 import { primeAnthropicCredential } from "../backends/claude/credential-status";
 import { config } from "../config";
+import {
+  actingFromHeaders,
+  runWithActingContext,
+} from "../session/acting-context";
 import { anyTurnRunning } from "../session/bus";
 import { handleAnonymizeRoute } from "./anonymize-route";
 import { handleConversationRoute } from "./conversation-routes";
@@ -47,9 +51,19 @@ async function handle(ctx: RouteContext) {
   json(ctx.res, 404, { error: "not found" });
 }
 
+/**
+ * Every runtime request runs inside the acting identity its headers carry
+ * (HOU-976), so credential resolution is scope-correct on ALL of them — not just
+ * the message route: `GET /providers`, `/auth/status`, `/auth/:p/login`,
+ * `/auth/export` and the serve sync they trigger each read or write a
+ * credential. The per-turn wrap in session/exec-turn.ts STAYS: a turn outlives
+ * the request that started it.
+ */
 export function createRuntimeServer() {
   return createServer((req, res) => {
-    handle(routeContext(req, res)).catch((e) => {
+    runWithActingContext(actingFromHeaders(req.headers), () =>
+      handle(routeContext(req, res)),
+    ).catch((e) => {
       console.error("[server] unhandled:", e);
       if (!res.headersSent) json(res, 500, { error: "internal error" });
       else if (!res.writableEnded) res.end();

--- a/packages/web/e2e/ai-models-ia.spec.ts
+++ b/packages/web/e2e/ai-models-ia.spec.ts
@@ -15,17 +15,23 @@ import {
  *    workspace-wide
  *    "Defaults for every agent" model ceiling was removed as overengineering, and
  *    the AI Models hub's "Workspace policy" tab stays gone — the hub keeps only
- *    Providers / Models. AI provider connections are org-level (C6), so a plain
- *    member has no account or policy to act on in the hub and loses its nav.
+ *    Providers / Models.
+ *  - ACCOUNTS (HOU-976) are per PERSON and only per person: a team space has no
+ *    shared AI account at all — every agent runs on the AI account of whoever
+ *    messages it — so the hub is visible to EVERYONE and shows each viewer their
+ *    own accounts, with no role-gated section inside it. The space-wide spend
+ *    roll-up did NOT open up with it: it lives in Settings > Admin, behind the
+ *    unchanged owner/admin gate.
  *  - Each member's own model pick lives in the composer, not the hub.
  *  - USAGE (how much of each connected AI account is left) belongs to the
  *    account, so it renders on the hub's Connected row. There is no separate
  *    usage screen anywhere (HOU-789).
  *
  * The Teams-shaped state single-player can't reach is armed via the fake host's
- * `/__test__/capabilities` (advertise `multiplayer` + `teams` + a `role`) and
- * `/__test__/agent-settings` (the agent model ceiling); the `/v1/org` view load
- * is served by the fake host. See `@houston/fake-host` README +
+ * `/__test__/capabilities` (advertise `multiplayer` + `teams` + a `role`),
+ * `/__test__/workspaces` (the C8 team-space row the hub's account note keys
+ * off) and `/__test__/agent-settings` (the agent model ceiling); the `/v1/org`
+ * view load is served by the fake host. See `@houston/fake-host` README +
  * `knowledge-base/ui-testing.md`.
  */
 
@@ -36,11 +42,44 @@ const OWNER_CAPS = {
   role: "owner",
 };
 
+/** Teams + Spaces, so the switcher can reach an armed TEAM space. The hub's
+ *  "Your accounts" note exists only there — a personal space has one account. */
+const SPACES_CAPS = { multiplayer: true, teams: true, spaces: true };
+
+/** The armed team space (id `org:<16-hex>`), reachable through the switcher. */
+const TEAM = { slug: "00000000000000ab", name: "Acme Team" };
+
 async function armCapabilities(
   request: APIRequestContext,
   caps: Record<string, unknown>,
 ): Promise<void> {
   await request.post(`${FAKE_HOST_URL}/__test__/capabilities`, { data: caps });
+}
+
+/** Arm the team-space row the C8 workspaces bridge serves. */
+async function armTeamWorkspace(request: APIRequestContext): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/workspaces`, {
+    data: { teams: [TEAM] },
+  });
+}
+
+/** A stable nav anchor that is ALWAYS present, so absence assertions never race
+ *  an unrendered sidebar. */
+const settlesShell = (page: Page) =>
+  expect(page.locator('[data-tour-target="nav-settings"]')).toBeVisible();
+
+/** Switch space through the REAL switcher UI the shell renders. */
+async function switchToTeam(page: Page): Promise<void> {
+  await page
+    .locator('[data-tour-target="spaceSwitcher"] button')
+    .first()
+    .click();
+  await page.getByRole("menuitem", { name: TEAM.name }).click();
+}
+
+/** Open the AI Models hub from the sidebar. */
+async function openHub(page: Page): Promise<void> {
+  await page.locator('[data-tour-target="nav-ai-hub"]').click();
 }
 
 /** Open Settings > Permissions (the agent list is the top level; per-agent
@@ -69,24 +108,96 @@ test("Teams owner: the AI hub keeps only Providers / Models, the Workspace polic
   );
 });
 
-// ── 2. Plain member: no AI Models nav ──────────────────────────────────────
+// ── 2. Plain member: the hub is theirs, but only their own accounts ─────────
 
-test("Teams member: the AI Models nav item is gone, the rest of the shell stays", async ({
+test("Teams member: the AI Models nav is there, and no usage screen is", async ({
   page,
   request,
 }) => {
-  // A plain member never sees the hub: providers are org-level and the model
-  // policy is per-agent, manager-owned. They pick their own model per agent in
-  // the composer.
-  await armCapabilities(request, { ...OWNER_CAPS, role: "user" });
+  // HOU-976 reversed the old rule. A member has their OWN AI account to connect,
+  // and the hub is the only surface that can manage it, so it is never hidden.
+  // No usage nav rides in with it: account usage belongs to the account (it
+  // renders on the hub's Connected row, HOU-789) and the space-wide roll-up
+  // stays in Settings > Admin.
+  await armCapabilities(request, { ...SPACES_CAPS, role: "user" });
+  await armTeamWorkspace(request);
   await page.goto("/");
+  await settlesShell(page);
 
-  await expect(page.locator('[data-tour-target="nav-ai-hub"]')).toHaveCount(0);
-  // Mission Control and Settings remain — only AI Models is gated off.
+  await expect(page.locator('[data-tour-target="nav-ai-hub"]')).toBeVisible();
+  await expect(page.locator('[data-tour-target="nav-usage"]')).toHaveCount(0);
   await expect(
     page.locator('[data-tour-target="nav-dashboard"]'),
   ).toBeVisible();
-  await expect(page.locator('[data-tour-target="nav-settings"]')).toBeVisible();
+});
+
+test("Teams member in a team space: the hub is theirs, and says so", async ({
+  page,
+  request,
+}) => {
+  // A member with nothing connected must land on a surface that tells them the
+  // accounts here are their own and lets them connect one — no Team account
+  // section to mistake for theirs, and nobody to go ask. This is the whole
+  // self-serve promise of personal-only (HOU-976).
+  await armCapabilities(request, { ...SPACES_CAPS, role: "user" });
+  await armTeamWorkspace(request);
+  await page.goto("/");
+  await settlesShell(page);
+  await switchToTeam(page);
+  await openHub(page);
+
+  await expect(
+    page.getByRole("heading", { name: "Your accounts" }),
+  ).toBeVisible();
+  await expect(page.getByText("Team account", { exact: true })).toHaveCount(0);
+  // …and the connect the note promises is right there, on every provider this
+  // member has not connected yet. No approval step, nobody to go ask.
+  await expect(
+    page.getByRole("button", { name: "Connect OpenAI" }),
+  ).toBeVisible();
+});
+
+test("Teams owner in a team space: the same one surface, no account choice", async ({
+  page,
+  request,
+}) => {
+  // An owner has no extra AI-credential authority in a team space any more:
+  // there is no shared account to manage, so they see exactly what a member
+  // sees. A choice control here would be offering an account that cannot exist.
+  await armCapabilities(request, { ...SPACES_CAPS, role: "owner" });
+  await armTeamWorkspace(request);
+  await page.goto("/");
+  await settlesShell(page);
+  await switchToTeam(page);
+  await openHub(page);
+
+  await expect(
+    page.getByRole("heading", { name: "Your accounts" }),
+  ).toBeVisible();
+  await expect(page.getByRole("radio", { name: "Team account" })).toHaveCount(
+    0,
+  );
+  await expect(page.getByText("Team account", { exact: true })).toHaveCount(0);
+});
+
+test("personal space: the hub renders NO account note at all", async ({
+  page,
+  request,
+}) => {
+  // The migration guarantee, asserted. One account means nothing to
+  // disambiguate, so the hub must look exactly like the pre-HOU-976 surface:
+  // no heading, no extra chrome.
+  await armCapabilities(request, { ...SPACES_CAPS, role: "owner" });
+  await armTeamWorkspace(request);
+  await page.goto("/");
+  await settlesShell(page);
+  await openHub(page);
+
+  await expect(page.getByText("Your accounts")).toHaveCount(0);
+  await expect(page.getByText("Team account", { exact: true })).toHaveCount(0);
+  // The hub itself is fully there, so the absence above is the frame, not a
+  // failed render.
+  await expect(page.getByRole("tab", { name: "Providers" })).toBeVisible();
 });
 
 // ── 3. Per-agent model ceiling editor ──────────────────────────────────────
@@ -163,4 +274,53 @@ test("account usage renders on the hub's Connected row and nowhere else", async 
   await expect(settingsRow(page, "organization")).toBeVisible();
   await expect(settingsRow(page, "permissions")).toBeVisible();
   await expect(settingsRow(page, "time-worked")).toHaveCount(0);
+});
+
+// ── 5. A member connects, and their own turns are configured (HOU-976) ─────
+
+test("a team-space member's connect configures THEIR turns, with no scope on the wire", async ({
+  page,
+  request,
+}) => {
+  // The end-to-end promise of personal-only. Two halves:
+  //
+  //  1. the hub a member opens is already showing THEIR resolution — the
+  //     Connected strip lists the providers that answer their own messages, and
+  //     the catalog offers a connect for the ones that do not yet;
+  //  2. that connect names no account on the wire. WHOSE credential it writes is
+  //     the gateway's call, derived from the space the request lands in. A
+  //     `?scope=` creeping back in would re-introduce a client-side resolution
+  //     the server now owns, and it is the one regression that would be
+  //     invisible in the UI.
+  await armCapabilities(request, { ...SPACES_CAPS, role: "user" });
+  await armTeamWorkspace(request);
+
+  const credentialCalls: string[] = [];
+  await page.route("**/*", async (route) => {
+    const url = route.request().url();
+    if (/\/credential\/|\/auth\//.test(url)) credentialCalls.push(url);
+    await route.continue();
+  });
+
+  await page.goto("/");
+  await settlesShell(page);
+  await switchToTeam(page);
+  await openHub(page);
+
+  // What already answers for THIS member. The strip is per-viewer by
+  // construction: it renders the provider status probe, which the pod resolves
+  // against the acting identity's own credential file.
+  await expect(page.getByRole("heading", { name: /^Connected/ })).toBeVisible();
+
+  // And the self-serve connect for one that does not.
+  await page.getByRole("button", { name: "Connect OpenAI" }).click();
+
+  // The login round-trip fired…
+  await expect
+    .poll(() => credentialCalls.length, { timeout: 15_000 })
+    .toBeGreaterThan(0);
+  // …and not one request named an account.
+  for (const url of credentialCalls) {
+    expect(url).not.toContain("scope=");
+  }
 });

--- a/packages/web/e2e/permissions.spec.ts
+++ b/packages/web/e2e/permissions.spec.ts
@@ -245,6 +245,14 @@ test("agent Settings: a plain member sees access read-only (states visible, no c
     page.getByRole("heading", { name: "Which apps can this agent use?" }),
   ).toBeVisible();
   await expect(page.getByRole("radio", { name: "Any app" })).toBeDisabled();
+
+  // AI models likewise: a member SEES the agent's model ceiling with every
+  // control disabled. Read-only must never mean hidden. (There is no AI-account
+  // policy on an agent — every turn runs on the sender's own account, HOU-976.)
+  // `exact` disambiguates the settings rail's "AI models" row from the sidebar's
+  // "AI Models" hub entry, which a member now sees too (HOU-976).
+  await page.getByRole("button", { name: "AI models", exact: true }).click();
+  await expect(page.getByRole("radio", { name: "Any model" })).toBeDisabled();
 });
 
 test("Admin People roster shows a member's gateway display name, email as a secondary line", async ({

--- a/packages/web/src/engine-adapter/client/chat-send-mixin.ts
+++ b/packages/web/src/engine-adapter/client/chat-send-mixin.ts
@@ -10,7 +10,8 @@ import {
   noteAutoResumeStarted,
   removeQueuedSend,
 } from "../send-queue";
-import { DEFAULT_AGENT_PATH, wireTurnPin } from "../synthetic";
+import { DEFAULT_AGENT_PATH } from "../synthetic";
+import { wireTurnPin } from "../turn-pin";
 import { observeConversation, streamTurn } from "../turn-stream";
 import { setActivityStatus } from "./activity-status";
 import type { BaseCtor } from "./mixin";

--- a/packages/web/src/engine-adapter/client/provider-api-key.ts
+++ b/packages/web/src/engine-adapter/client/provider-api-key.ts
@@ -1,0 +1,74 @@
+import { emitEvent } from "../bus";
+import * as controlPlane from "../control-plane";
+import { credentialSiblings, toNewProvider } from "../synthetic";
+import type { AdapterContext } from "./context";
+import { requireProviderRouting } from "./provider-routing";
+
+/**
+ * Connect an API-key provider (OpenCode Zen / Go, OpenRouter, Gemini, Bedrock):
+ * the user pastes a key, no OAuth dance. Cloud stores it centrally (and pushes
+ * it into the agent runtime) via the control plane; local writes it straight to
+ * the single runtime. On success it fires `ProviderLoginComplete` so the connect
+ * dialog closes and the provider card flips to connected — the same signal the
+ * OAuth flow emits. A failure rejects so the caller surfaces the real reason
+ * (never swallowed).
+ */
+export async function connectApiKey(
+  ctx: AdapterContext,
+  name: string,
+  apiKey: string,
+): Promise<void> {
+  const pid = toNewProvider(name);
+  if (!pid) throw new Error(`provider ${name} not supported`);
+  // OpenCode's Zen + Go gateways share one opencode.ai key (pi reads
+  // OPENCODE_API_KEY for both), so store the pasted key under every sibling
+  // gateway — one connect lights up both. `pid` (the connected id) is the one
+  // that becomes active; the order of the writes doesn't affect that.
+  const targets = credentialSiblings(pid);
+  if (ctx.cp) {
+    // Refuse rather than guess: an unsettled list leaves only the raw pref,
+    // which after a switch names the PREVIOUS space's agent (HOU-979).
+    requireProviderRouting(ctx);
+    // First-run pre-agent: store through the setup runtime instead — the key
+    // lands on this space's central store and the agent created next reads it.
+    // No per-agent settings exist yet to flip.
+    const agentId = ctx.providerAgentId();
+    if (!agentId) {
+      for (const target of targets) {
+        await controlPlane.setSetupApiKey(ctx.cp, target, apiKey);
+      }
+      emitEvent("ProviderLoginComplete", {
+        provider: name,
+        success: true,
+        error: null,
+      });
+      return;
+    }
+    for (const target of targets) {
+      await controlPlane.setApiKey(ctx.cp, agentId, target, apiKey);
+    }
+    // CLAIM (don't set) the active provider: it becomes active only when the
+    // agent doesn't already resolve to one — a first connect on a fresh agent.
+    // Connecting a credential is not a model pick (HOU-695): unconditionally
+    // activating it here used to flip every open chat onto the new provider
+    // (paste an OpenCode key mid-Codex-chat → the next turn answers, bills, and
+    // quota-errors on OpenCode). Switching stays the model picker's job.
+    // Settings are PER-AGENT on the host, so this MUST go through the agent's
+    // runtime client.
+    await controlPlane
+      .runtimeClientFor(ctx.cp, agentId)
+      .claimActiveProvider(pid);
+  } else {
+    for (const target of targets) {
+      await ctx.engine.setApiKey(target, apiKey);
+    }
+    await ctx.engine.claimActiveProvider(pid);
+  }
+  // One completion event for the single account the user connected (never one
+  // per gateway), so the connect dialog closes and exactly one card flips.
+  emitEvent("ProviderLoginComplete", {
+    provider: name,
+    success: true,
+    error: null,
+  });
+}

--- a/packages/web/src/engine-adapter/client/provider-credentials-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-credentials-mixin.ts
@@ -5,14 +5,13 @@ import * as controlPlane from "../control-plane";
 import { credentialSiblings, toNewProvider } from "../synthetic";
 import { isHoustonEngineError } from "./errors";
 import type { BaseCtor } from "./mixin";
+import { connectApiKey } from "./provider-api-key";
 import { pushClaudeCredential } from "./provider-claude-push";
-import {
-  requireProviderAgentId,
-  requireProviderRouting,
-} from "./provider-routing";
+import { requireProviderAgentId } from "./provider-routing";
 
 export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
   class ProviderCredentials extends Base {
+    /** Disconnect a provider account. */
     async providerLogout(name: string): Promise<void> {
       const pid = toNewProvider(name);
       if (!pid) return;
@@ -54,67 +53,12 @@ export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
     }
 
     /**
-     * Connect an API-key provider (OpenCode Zen / Go): the user pastes a key, no
-     * OAuth dance. Cloud stores it centrally (and pushes it into the agent runtime)
-     * via the control plane; local writes it straight to the single runtime. On
-     * success we fire `ProviderLoginComplete` so the connect dialog closes and the
-     * provider card flips to connected — the same signal the OAuth flow emits. A
-     * failure rejects so the caller surfaces the real reason (never swallowed).
+     * Connect an API-key provider by pasted key — see {@link connectApiKey} for
+     * the whole flow (sibling gateways, the pre-agent setup path, the active
+     * provider claim, and the completion event).
      */
     async setProviderApiKey(name: string, apiKey: string): Promise<void> {
-      const pid = toNewProvider(name);
-      if (!pid) throw new Error(`provider ${name} not supported`);
-      // OpenCode's Zen + Go gateways share one opencode.ai key (pi reads
-      // OPENCODE_API_KEY for both), so store the pasted key under every sibling
-      // gateway — one connect lights up both. `pid` (the connected id) is the one
-      // that becomes active; the order of the writes doesn't affect that.
-      const targets = credentialSiblings(pid);
-      if (this.ctx.cp) {
-        // Refuse rather than guess: an unsettled list leaves only the raw pref,
-        // which after a switch names the PREVIOUS space's agent (HOU-979).
-        requireProviderRouting(this.ctx);
-        // First-run pre-agent: store through the setup runtime instead — the key
-        // lands on this space's central store and the agent created next reads
-        // it. No per-agent settings exist yet to flip.
-        const agentId = this.ctx.providerAgentId();
-        if (!agentId) {
-          for (const target of targets) {
-            await controlPlane.setSetupApiKey(this.ctx.cp, target, apiKey);
-          }
-          emitEvent("ProviderLoginComplete", {
-            provider: name,
-            success: true,
-            error: null,
-          });
-          return;
-        }
-        for (const target of targets) {
-          await controlPlane.setApiKey(this.ctx.cp, agentId, target, apiKey);
-        }
-        // CLAIM (don't set) the active provider: it becomes active only when the
-        // agent doesn't already resolve to one — a first connect on a fresh
-        // agent. Connecting a credential is not a model pick (HOU-695):
-        // unconditionally activating it here used to flip every open chat onto
-        // the new provider (paste an OpenCode key mid-Codex-chat → the next turn
-        // answers, bills, and quota-errors on OpenCode). Switching stays the
-        // model picker's job. Settings are PER-AGENT on the host, so this MUST
-        // go through the agent's runtime client.
-        await controlPlane
-          .runtimeClientFor(this.ctx.cp, agentId)
-          .claimActiveProvider(pid);
-      } else {
-        for (const target of targets) {
-          await this.ctx.engine.setApiKey(target, apiKey);
-        }
-        await this.ctx.engine.claimActiveProvider(pid);
-      }
-      // One completion event for the single account the user connected (never one
-      // per gateway), so the connect dialog closes and exactly one card flips.
-      emitEvent("ProviderLoginComplete", {
-        provider: name,
-        success: true,
-        error: null,
-      });
+      await connectApiKey(this.ctx, name, apiKey);
     }
 
     /**

--- a/packages/web/src/engine-adapter/client/provider-login-failure.ts
+++ b/packages/web/src/engine-adapter/client/provider-login-failure.ts
@@ -1,0 +1,43 @@
+import { EngineError } from "@houston/runtime-client";
+import { PROVIDER_LOGIN_PORT_BUSY_ERROR } from "@houston-ai/core";
+import { emitEvent } from "../bus";
+
+/** Typed runtime failure kinds the app localizes: the raw runtime message is
+ *  swapped for the matching `@houston-ai/core` sentinel so the toast mapping
+ *  (app/src/lib/provider-login-error.ts) can match by value, exactly like the
+ *  client-side timeout sentinels. Unknown kinds pass the real message through
+ *  verbatim (beta policy). */
+const SENTINEL_BY_KIND: Record<string, string> = {
+  codex_callback_port_busy: PROVIDER_LOGIN_PORT_BUSY_ERROR,
+};
+
+/**
+ * Surface a login-launch failure the runtime tagged with a stable `kind` (today:
+ * the OpenAI/Codex sign-in port 1455 is held by another app) as a normal
+ * `ProviderLoginComplete` failure — the same channel the completion toast and
+ * the reconnect card already read — so its actionable message reaches the user.
+ * A raw `startLogin` rejection is otherwise flattened to a generic "sign-in
+ * failed" toast (the REST body's real `error` string never reaches the caller).
+ * Returns true when handled (the caller must NOT rethrow); false to rethrow
+ * unchanged, preserving every untyped failure's existing path.
+ */
+export function surfaceTypedLoginFailure(
+  displayProvider: string,
+  err: unknown,
+): boolean {
+  if (!(err instanceof EngineError)) return false;
+  let parsed: { error?: unknown; kind?: unknown };
+  try {
+    parsed = JSON.parse(err.body) as { error?: unknown; kind?: unknown };
+  } catch {
+    return false;
+  }
+  if (typeof parsed.kind !== "string" || typeof parsed.error !== "string")
+    return false;
+  emitEvent("ProviderLoginComplete", {
+    provider: displayProvider,
+    success: false,
+    error: SENTINEL_BY_KIND[parsed.kind] ?? parsed.error,
+  });
+  return true;
+}

--- a/packages/web/src/engine-adapter/client/provider-login-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-login-mixin.ts
@@ -1,12 +1,12 @@
 import { EngineError } from "@houston/runtime-client";
-import { PROVIDER_LOGIN_PORT_BUSY_ERROR } from "@houston-ai/core";
 import { emitEvent } from "../bus";
 import * as controlPlane from "../control-plane";
 import { toNewProvider, toOldProvider } from "../synthetic";
 import type { BaseCtor } from "./mixin";
+import { surfaceTypedLoginFailure } from "./provider-login-failure";
 import {
+  loginKey,
   pollProviderConnect,
-  SETUP_LOGIN_KEY,
   stopLoginWatch,
   watchLoginCompletion,
 } from "./provider-login-poll";
@@ -17,46 +17,6 @@ function benignCancelMiss(e: unknown): void {
   if (e instanceof EngineError && e.status === 404) return;
   throw e;
 }
-
-/**
- * Surface a login-launch failure the runtime tagged with a stable `kind` (today:
- * the OpenAI/Codex sign-in port 1455 is held by another app) as a normal
- * `ProviderLoginComplete` failure — the same channel the completion toast and
- * the reconnect card already read — so its actionable message reaches the user.
- * A raw `startLogin` rejection is otherwise flattened to a generic "sign-in
- * failed" toast (the REST body's real `error` string never reaches the caller).
- * Returns true when handled (the caller must NOT rethrow); false to rethrow
- * unchanged, preserving every untyped failure's existing path.
- */
-function surfaceTypedLoginFailure(
-  displayProvider: string,
-  err: unknown,
-): boolean {
-  if (!(err instanceof EngineError)) return false;
-  let parsed: { error?: unknown; kind?: unknown };
-  try {
-    parsed = JSON.parse(err.body) as { error?: unknown; kind?: unknown };
-  } catch {
-    return false;
-  }
-  if (typeof parsed.kind !== "string" || typeof parsed.error !== "string")
-    return false;
-  emitEvent("ProviderLoginComplete", {
-    provider: displayProvider,
-    success: false,
-    error: SENTINEL_BY_KIND[parsed.kind] ?? parsed.error,
-  });
-  return true;
-}
-
-/** Typed runtime failure kinds the app localizes: the raw runtime message is
- *  swapped for the matching `@houston-ai/core` sentinel so the toast mapping
- *  (app/src/lib/provider-login-error.ts) can match by value, exactly like the
- *  client-side timeout sentinels. Unknown kinds pass the real message through
- *  verbatim (beta policy). */
-const SENTINEL_BY_KIND: Record<string, string> = {
-  codex_callback_port_busy: PROVIDER_LOGIN_PORT_BUSY_ERROR,
-};
 
 export function ProviderLoginMixin<TBase extends BaseCtor>(Base: TBase) {
   class ProviderLogin extends Base {
@@ -175,7 +135,7 @@ export function ProviderLoginMixin<TBase extends BaseCtor>(Base: TBase) {
         // Key mirrors pollProviderConnect: the agent's id, or the setup-runtime
         // sentinel when the first-run login started before any agent existed.
         const agentId = this.ctx.providerAgentId();
-        this.ctx.activeLogins.delete(`${agentId ?? SETUP_LOGIN_KEY}:${pid}`); // stop the poll
+        this.ctx.activeLogins.delete(loginKey(agentId, pid)); // stop the poll
         // Kill the runtime-side login too, in the same runtime the login started
         // in (the agent's sandbox, or the hidden setup runtime pre-agent) —
         // otherwise it keeps polling the provider until timeout and a retry

--- a/packages/web/src/engine-adapter/client/provider-login-poll.ts
+++ b/packages/web/src/engine-adapter/client/provider-login-poll.ts
@@ -17,7 +17,17 @@ import { retryCredentialCapture } from "./provider-capture-retry";
  * `activeLogins` key segment for a login started before any agent existed
  * (first-run: it runs in the host's hidden setup runtime, not an agent's).
  */
-export const SETUP_LOGIN_KEY = "__setup__";
+const SETUP_LOGIN_KEY = "__setup__";
+
+/**
+ * The in-flight-login key for one (runtime, provider) pair — the shape
+ * `ctx.activeLogins` is keyed by. A null `agentId` is the pre-agent first-run
+ * login, which runs in the hidden setup runtime. Shared by the connect poll and
+ * the cancel path so the two can never disagree about which login they mean.
+ */
+export function loginKey(agentId: string | null, pid: string): string {
+  return `${agentId ?? SETUP_LOGIN_KEY}:${pid}`;
+}
 
 /**
  * True iff this provider's login is genuinely DONE — not merely `configured`.
@@ -98,7 +108,7 @@ export async function pollProviderConnect(
 ): Promise<void> {
   const cp = ctx.cp;
   if (!cp) return;
-  const key = `${agentId ?? SETUP_LOGIN_KEY}:${pid}`;
+  const key = loginKey(agentId, pid);
   ctx.activeLogins.add(key);
   const engine = agentId
     ? runtimeClientFor(cp, agentId)

--- a/packages/web/src/engine-adapter/client/provider-status-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-status-mixin.ts
@@ -1,4 +1,5 @@
 import type {
+  CredentialScope,
   ProviderStatus,
   ProviderUsage,
 } from "../../../../../ui/engine-client/src/types";
@@ -30,7 +31,14 @@ export function ProviderStatusMixin<TBase extends BaseCtor>(Base: TBase) {
     ): Promise<ProviderStatus[]> {
       const byId = new Map<
         string,
-        { configured?: boolean; activeModel?: string }
+        {
+          configured?: boolean;
+          activeModel?: string;
+          // WHOSE credential answered (HOU-976). Absent on desktop, self-host,
+          // and any pre-HOU-976 pod — see the spread below, which keeps the
+          // mapped status byte-identical there.
+          credentialScope?: CredentialScope;
+        }
       >();
       // "unauthenticated" is only ever a CONFIRMED answer from the engine. An
       // unreachable engine (cold pod still waking after a relaunch/update, a
@@ -71,6 +79,11 @@ export function ProviderStatusMixin<TBase extends BaseCtor>(Base: TBase) {
           installSource: "managed",
           cliPath: null,
           activeModel: p?.activeModel || undefined,
+          // Carry the credential attribution through (HOU-976) — spread
+          // CONDITIONALLY, never as explicit `undefined` keys: a pre-HOU-976
+          // pod (and every desktop/self-host answer) must map to exactly the
+          // object shape the provider-status tests already assert on.
+          ...(p?.credentialScope ? { credentialScope: p.credentialScope } : {}),
         } as ProviderStatus;
       });
     }

--- a/packages/web/src/engine-adapter/cp/agent-teams.ts
+++ b/packages/web/src/engine-adapter/cp/agent-teams.ts
@@ -35,6 +35,11 @@ export async function getAgentSettings(
   return (await res.json()) as AgentSettings;
 }
 
+/**
+ * Replace this agent's manager-set settings. The gateway READ-THEN-MERGES the
+ * body, so forwarding only the keys the caller set is the whole contract — a
+ * one-ceiling PUT leaves the other untouched.
+ */
 export async function setAgentSettings(
   cfg: ControlPlaneConfig,
   agentSlugOrId: string,

--- a/packages/web/src/engine-adapter/cp/credentials.ts
+++ b/packages/web/src/engine-adapter/cp/credentials.ts
@@ -5,6 +5,16 @@ import type {
 import { type ControlPlaneConfig, cpFetch } from "./fetch";
 
 /**
+ * NO credential write below carries a scope, in any form (HOU-976). WHOSE
+ * account a write lands on is the SERVER's call, decided from the space the
+ * request is made in: a team space has no shared AI credential, so the write is
+ * the acting member's own; a personal space has exactly one. A client-sent scope
+ * could only ever restate what the gateway already knows, or contradict it —
+ * `credential-write-urls.test.ts` pins these URLs byte-for-byte so no query
+ * param can creep back in.
+ */
+
+/**
  * Connect-once: after a device-code connect lands on one agent, capture its
  * credential into the workspace's central store so every agent (existing + new)
  * shares the connection. Idempotent; safe to call on each successful connect.
@@ -96,6 +106,7 @@ export async function setApiKey(
  * (base URL + model + optional key) to the agent's standing runtime, which
  * persists it. LOCAL-only — a non-local deployment 400s on the openaiCompatible
  * capability, and cpFetch throws the host's error message.
+ *
  */
 export async function setCustomEndpoint(
   cfg: ControlPlaneConfig,

--- a/packages/web/src/engine-adapter/send-queue-merge.ts
+++ b/packages/web/src/engine-adapter/send-queue-merge.ts
@@ -6,9 +6,9 @@ import type {
 /**
  * How N held sends become ONE (see send-queue.ts): the per-field merge rules for
  * a flush. Every field of the combined request comes from the LAST entry (the
- * most recent picker state) EXCEPT the three derived here, which must reflect
- * ALL the merged entries — the combined send says everything the user typed, so
- * it must also carry everything that text implied.
+ * most recent picker state) EXCEPT the ones derived here, which must reflect ALL
+ * the merged entries — the combined send says everything the user typed, so it
+ * must also carry everything that text implied.
  */
 
 /** The fields a flush derives from the whole queue rather than its last entry. */

--- a/packages/web/src/engine-adapter/synthetic.ts
+++ b/packages/web/src/engine-adapter/synthetic.ts
@@ -1,8 +1,4 @@
-import {
-  canonicalModelId,
-  canonicalProviderId,
-  migrateProviderModel,
-} from "@houston/domain";
+import { migrateProviderModel } from "@houston/domain";
 import type { Agent, Workspace } from "../../../../ui/engine-client/src/types";
 
 /**
@@ -105,73 +101,6 @@ const OPENCODE_GATEWAYS: readonly NewProviderId[] = ["opencode", "opencode-go"];
  */
 export function credentialSiblings(pid: NewProviderId): NewProviderId[] {
   return OPENCODE_GATEWAYS.includes(pid) ? [...OPENCODE_GATEWAYS] : [pid];
-}
-
-/**
- * Map a send's app-dialect provider/model/effort overrides to the per-turn
- * WIRE pin (engine ids) — pure, so the send-time mapping is unit-tested
- * without the HTTP client. This is what keeps every conversation on ITS OWN
- * picked provider (HOU-695): the composer forwards the chat's effective
- * provider/model on each send, and the runtime runs the turn on exactly that
- * pin instead of falling back to the agent-wide settings.
- *
- * Fail-soft — never a hard turn failure, and never a pin the user can't see:
- * - a legacy alias maps to its engine id (openai→openai-codex); any other
- *   non-empty provider passes through unchanged, since the pi-ai catalog is open
- *   and the adapter can't enumerate every valid id — the frontend's
- *   effective-provider resolution (against the live catalog) already drops stale
- *   providers before send, and the runtime is the final authority;
- * - a model the mapped provider doesn't own drops just the model (the turn
- *   runs the provider's default) with a diagnostic — an unknown PINNED model
- *   id would hard-fail the turn (the runtime validates pins strictly);
- * - a model with no provider can't be ownership-checked, so it is dropped too;
- * - effort passes through verbatim; an effort-only send still pins it.
- * - mode passes through verbatim; a mode-only send still pins it.
- */
-export function wireTurnPin(req: {
-  provider?: string;
-  model?: string;
-  effort?: string;
-  mode?: "execute" | "plan" | "auto";
-}):
-  | {
-      provider?: string;
-      model?: string;
-      effort?: string;
-      mode?: "execute" | "plan" | "auto";
-    }
-  | undefined {
-  const pin: {
-    provider?: string;
-    model?: string;
-    effort?: string;
-    mode?: "execute" | "plan" | "auto";
-  } = {};
-  if (req.provider) {
-    const provider = canonicalProviderId(req.provider);
-    if (provider) {
-      pin.provider = provider;
-      if (req.model) {
-        const model = canonicalModelId(provider, req.model);
-        if (model) pin.model = model;
-        else
-          console.warn(
-            `[engine-adapter] "${req.model}" is not a known ${provider} model; pinning the provider only`,
-          );
-      }
-    } else {
-      console.warn(
-        `[engine-adapter] unknown provider "${req.provider}"; the turn uses the engine's own resolution`,
-      );
-    }
-  } else if (req.model) {
-    console.warn(
-      `[engine-adapter] model "${req.model}" sent without a provider; the turn uses the engine's own resolution`,
-    );
-  }
-  if (req.effort) pin.effort = req.effort;
-  if (req.mode) pin.mode = req.mode;
-  return pin.provider || pin.effort || pin.mode ? pin : undefined;
 }
 
 /**

--- a/packages/web/src/engine-adapter/turn-pin.ts
+++ b/packages/web/src/engine-adapter/turn-pin.ts
@@ -1,0 +1,73 @@
+import { canonicalModelId, canonicalProviderId } from "@houston/domain";
+
+// The send-time app-dialect -> engine-wire pin mapping. Its own module because
+// it is a self-contained pure function with its own test file, and synthetic.ts
+// (where it used to live) is the synthetic workspace/agent + provider-id dialect
+// module, not the send wire.
+
+/**
+ * Map a send's app-dialect provider/model/effort overrides to the per-turn
+ * WIRE pin (engine ids) — pure, so the send-time mapping is unit-tested
+ * without the HTTP client. This is what keeps every conversation on ITS OWN
+ * picked provider (HOU-695): the composer forwards the chat's effective
+ * provider/model on each send, and the runtime runs the turn on exactly that
+ * pin instead of falling back to the agent-wide settings.
+ *
+ * Fail-soft — never a hard turn failure, and never a pin the user can't see:
+ * - a legacy alias maps to its engine id (openai→openai-codex); any other
+ *   non-empty provider passes through unchanged, since the pi-ai catalog is open
+ *   and the adapter can't enumerate every valid id — the frontend's
+ *   effective-provider resolution (against the live catalog) already drops stale
+ *   providers before send, and the runtime is the final authority;
+ * - a model the mapped provider doesn't own drops just the model (the turn
+ *   runs the provider's default) with a diagnostic — an unknown PINNED model
+ *   id would hard-fail the turn (the runtime validates pins strictly);
+ * - a model with no provider can't be ownership-checked, so it is dropped too;
+ * - effort passes through verbatim; an effort-only send still pins it.
+ * - mode passes through verbatim; a mode-only send still pins it.
+ */
+export function wireTurnPin(req: {
+  provider?: string;
+  model?: string;
+  effort?: string;
+  mode?: "execute" | "plan" | "auto";
+}):
+  | {
+      provider?: string;
+      model?: string;
+      effort?: string;
+      mode?: "execute" | "plan" | "auto";
+    }
+  | undefined {
+  const pin: {
+    provider?: string;
+    model?: string;
+    effort?: string;
+    mode?: "execute" | "plan" | "auto";
+  } = {};
+  if (req.provider) {
+    const provider = canonicalProviderId(req.provider);
+    if (provider) {
+      pin.provider = provider;
+      if (req.model) {
+        const model = canonicalModelId(provider, req.model);
+        if (model) pin.model = model;
+        else
+          console.warn(
+            `[engine-adapter] "${req.model}" is not a known ${provider} model; pinning the provider only`,
+          );
+      }
+    } else {
+      console.warn(
+        `[engine-adapter] unknown provider "${req.provider}"; the turn uses the engine's own resolution`,
+      );
+    }
+  } else if (req.model) {
+    console.warn(
+      `[engine-adapter] model "${req.model}" sent without a provider; the turn uses the engine's own resolution`,
+    );
+  }
+  if (req.effort) pin.effort = req.effort;
+  if (req.mode) pin.mode = req.mode;
+  return pin.provider || pin.effort || pin.mode ? pin : undefined;
+}

--- a/packages/web/tests/credential-write-urls.test.ts
+++ b/packages/web/tests/credential-write-urls.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, expect, test } from "vitest";
+import {
+  captureCredential,
+  forgetCredential,
+  pushClaudeOAuthCredential,
+  setApiKey,
+  setCustomEndpoint,
+} from "../src/engine-adapter/cp/credentials";
+import { runtimeClientFor } from "../src/engine-adapter/cp/runtime-clients";
+
+/**
+ * HOU-976 personal-only, the URL contract: a credential write NEVER names an
+ * account, in any form.
+ *
+ * WHOSE credential a call resolves to is decided entirely server-side, from the
+ * space the request lands in — a team space has no shared AI account, so the
+ * write is the acting member's own; a personal space has exactly one. A client
+ * that also sent a scope could only restate that or contradict it, and the
+ * shipped `?scope=personal` did the second: it churned every recorded/golden
+ * request while adding nothing the gateway did not already know.
+ *
+ * This is a BYTE-IDENTITY test, not a shape test. Every URL below is asserted
+ * whole, so a scope re-entering as a query param, a path segment or a second
+ * query is a failure whichever form it takes.
+ */
+
+const cfg = { baseUrl: "http://gw.test", token: "t" };
+
+let restore: (() => void) | undefined;
+afterEach(() => {
+  restore?.();
+  restore = undefined;
+});
+
+/** Swap the global fetch (what `cpFetch` resolves at call time) and record URLs. */
+function capture() {
+  const urls: string[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: RequestInfo | URL) => {
+    urls.push(String(url));
+    return new Response("{}", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+  restore = () => {
+    globalThis.fetch = original;
+  };
+  return urls;
+}
+
+test("every credential write sends a bare, query-less URL", async () => {
+  const urls = capture();
+  await captureCredential(cfg, "agent-1", "anthropic");
+  await pushClaudeOAuthCredential(cfg, "agent-1", "{}");
+  await forgetCredential(cfg, "agent-1", "anthropic");
+  await setApiKey(cfg, "agent-1", "openrouter", "k");
+  await setCustomEndpoint(cfg, "agent-1", {
+    baseUrl: "http://localhost:1234/v1",
+    model: "local",
+  });
+  expect(urls).toEqual([
+    "http://gw.test/agents/agent-1/credential/capture",
+    "http://gw.test/agents/agent-1/credential/claude-oauth",
+    "http://gw.test/agents/agent-1/credential/forget",
+    "http://gw.test/agents/agent-1/credential/api-key",
+    "http://gw.test/agents/agent-1/provider/openai-compatible",
+  ]);
+  for (const url of urls) {
+    expect(url).not.toContain("?");
+    expect(url).not.toContain("scope");
+  }
+});
+
+test("the per-agent runtime client's auth routes carry no scope either", async () => {
+  // The auth routes used to be wrapped in a fetch that appended
+  // `?scope=personal` to anything containing `/auth/`. The wrapper is gone, so
+  // these read exactly as they did before the feature: the login's OWN
+  // `deviceAuth` query and nothing beside it, and no query at all otherwise.
+  const urls = capture();
+  const engine = runtimeClientFor(cfg, "agent-1");
+  await engine.logout("anthropic");
+  await engine.startLogin("anthropic").catch(() => {});
+  await engine.startLogin("anthropic", false).catch(() => {});
+  expect(urls).toEqual([
+    "http://gw.test/agents/agent-1/auth/anthropic/logout",
+    "http://gw.test/agents/agent-1/auth/anthropic/login",
+    "http://gw.test/agents/agent-1/auth/anthropic/login?deviceAuth=false",
+  ]);
+  for (const url of urls) expect(url).not.toContain("scope");
+});
+
+test("the agent id is percent-encoded, and that is the whole URL", async () => {
+  // A slash-bearing agent id must stay inside its own path segment; nothing is
+  // appended after it, so there is no suffix for it to swallow.
+  const urls = capture();
+  await forgetCredential(cfg, "Houston/Bo", "anthropic");
+  expect(urls).toEqual([
+    "http://gw.test/agents/Houston%2FBo/credential/forget",
+  ]);
+});

--- a/packages/web/tests/wire-turn-pin.test.ts
+++ b/packages/web/tests/wire-turn-pin.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { wireTurnPin } from "../src/engine-adapter/synthetic";
+import { wireTurnPin } from "../src/engine-adapter/turn-pin";
 
 /**
  * The send-time app→engine pin mapping (HOU-695): every send forwards the

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -154,6 +154,7 @@ export type ProviderError =
       model: string | null;
       retry_after_seconds: number | null;
       message: string;
+      credential?: ProviderErrorCredential;
     }
   | {
       kind: "quota_exhausted";
@@ -163,6 +164,7 @@ export type ProviderError =
       /** Human-readable reset hint (e.g. "Jul 1st, 2026 1:16 PM"); null when open-ended. */
       resets_at: string | null;
       message: string;
+      credential?: ProviderErrorCredential;
     }
   | {
       kind: "usage_limit_paused";
@@ -170,6 +172,7 @@ export type ProviderError =
       /** Human-readable reset hint (e.g. "3:30 PM" or "5pm (America/Bogota)"); null if unknown. */
       resets_at: string | null;
       message: string;
+      credential?: ProviderErrorCredential;
     }
   | {
       kind: "model_unavailable";
@@ -178,6 +181,7 @@ export type ProviderError =
       reason: ModelUnavailableReason;
       suggested_fallback: string | null;
       message: string;
+      credential?: ProviderErrorCredential;
     }
   | {
       kind: "unauthenticated";
@@ -200,6 +204,7 @@ export type ProviderError =
        * `failed_prompt` the re-send must never render a second one.
        */
       undelivered_prompt?: string;
+      credential?: ProviderErrorCredential;
     }
   | {
       /**
@@ -215,28 +220,61 @@ export type ProviderError =
       context_window_tokens: number | null;
       prompt_tokens: number | null;
       message: string;
+      credential?: ProviderErrorCredential;
     }
-  | { kind: "network_unreachable"; provider: string; message: string }
+  | {
+      kind: "network_unreachable";
+      provider: string;
+      message: string;
+      credential?: ProviderErrorCredential;
+    }
   | {
       kind: "provider_internal";
       provider: string;
       http_status: number | null;
       message: string;
+      credential?: ProviderErrorCredential;
     }
   | {
       kind: "session_resume_missing";
       provider: string;
       session_id: string;
+      credential?: ProviderErrorCredential;
     }
-  | { kind: "malformed_response"; provider: string; message: string }
+  | {
+      kind: "malformed_response";
+      provider: string;
+      message: string;
+      credential?: ProviderErrorCredential;
+    }
   | {
       kind: "spawn_failed";
       provider: string;
       cli_name: string;
       message: string;
+      credential?: ProviderErrorCredential;
     }
   | { kind: "cancelled"; provider: string }
-  | { kind: "unknown"; provider: string; raw_excerpt: string };
+  | {
+      kind: "unknown";
+      provider: string;
+      raw_excerpt: string;
+      credential?: ProviderErrorCredential;
+    };
+
+/**
+ * WHICH credential ran the failed turn. Mirrors `@houston/protocol`'s
+ * `ProviderErrorCredential`.
+ *
+ * Present only on a managed-cloud turn that carried an acting identity — absent
+ * on desktop, self-host and any turn with no acting identity, where there is one
+ * credential and nothing to name. It lets a failure card say whose account hit
+ * the wall (in a team space, always the acting member's own); it unlocks no
+ * action, because a team space has no shared AI credential to fall back on.
+ */
+export interface ProviderErrorCredential {
+  scope: "personal" | "team";
+}
 
 export type QuotaScope = "free_tier" | "paid_plan" | "organization" | "unknown";
 

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -1205,6 +1205,21 @@ export class HoustonClient {
     });
   }
   /**
+   * Push a desktop-minted Anthropic OAuth credential to the acting space's agent
+   * pod.
+   *
+   * The v3 host adapter is the real implementation — a remote pod cannot read this
+   * machine's Keychain, so only a cloud deployment needs the push. The legacy Rust
+   * engine is always CO-LOCATED with its credential dir and has no such route, so
+   * reject loudly rather than pretend to succeed (no silent failure). Declared
+   * here so the shared app typechecks against both clients (shim parity).
+   */
+  pushClaudeOAuthCredential(_credentialJson: string): Promise<void> {
+    return Promise.reject(
+      new Error("Pushing a Claude credential requires the new engine."),
+    );
+  }
+  /**
    * Connect an OpenAI-compatible (local) server by base URL + model. The legacy
    * Rust engine has no such provider — it's new-engine + desktop only, and the
    * connect UI is gated on `newEngineActive()` + desktop, so this is never hit

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -1170,6 +1170,19 @@ export interface CommunitySkillPreview {
 export type CliInstallSource = "bundled" | "managed" | "path" | "missing";
 export type ProviderAuthState = "authenticated" | "unauthenticated" | "unknown";
 
+/**
+ * WHOSE AI-provider account ANSWERED a probe or ran a turn (HOU-976). A READ,
+ * never an address: the server decides whose credential a call resolves to from
+ * the space it is made in, so no client request carries a scope.
+ *
+ * `"personal"` is the acting member's own account, which is the only account a
+ * TEAM space has. `"team"` is the single workspace-level credential of a
+ * personal space / self-host / desktop, reported for the surfaces that predate
+ * the distinction. Absent means the deployment never said, which is the same
+ * "one account, nothing to disambiguate" world.
+ */
+export type CredentialScope = "personal" | "team";
+
 export interface ProviderStatus {
   provider: string;
   cliInstalled: boolean;
@@ -1186,6 +1199,13 @@ export interface ProviderStatus {
    * can show + select it. Absent for providers whose models live in the catalog.
    */
   activeModel?: string;
+  /**
+   * WHOSE credential produced this probe's answer (HOU-976). Absent on desktop,
+   * self-host, and any deployment/turn with no acting identity — there is
+   * exactly one credential there and nothing to disambiguate, so every
+   * pre-HOU-976 surface reads the shape it always read.
+   */
+  credentialScope?: CredentialScope;
 }
 
 /**


### PR DESCRIPTION
## What

A team-space agent always acts with the acting user's OWN AI subscription (integrations already worked per-person). A member with nothing connected sees an honest connect prompt in the AI hub — self-serve for every member, no ask-your-admin dead end. Nothing ever runs on a teammate's account. Desktop/self-host byte-identical (pinned by tests).

## How

- Engine: per-acting-user credential isolation inside shared pods — scoped auth stores (one file per member), scoped OAuth login flows, scoped serve-sync and health marks, hard guards on the pod-shared Claude credential file (session creation, mid-turn 401 recovery via the CLI's secure-storage dir override, status probes), store-sync exclusion, fs-guard denies so agent file tools cannot read credential material, revoked reports carrying served scope + acting identity.
- App: AI hub opens for every member with "Your accounts"; provider cards and the model picker name whose account answered; provider-limit and reconnect cards target the right account.
- Wire: credential URLs byte-identical to pre-feature — the gateway resolves scope by org kind (cloud PR gethouston/cloud#208, merged).
- Rebased onto latest main with upstream's HOU-788/789 IA and credential self-heal work semantically merged; our scoping extended into upstream's new capture/heal/usage paths (incl. a pre-existing unscoped Copilot quota probe).

## Verification

Biome + 25-project typecheck + boundaries clean; app 2585 tests, host 1226, runtime 940, runtime-client 149, web 308; locales in sync (en/es/pt); full Playwright e2e **247 passed, 0 failed**; two adversarial review rounds with every finding reproduced-then-fixed (5 credential-leak blockers among them).

Sibling PR: gethouston/cloud#208 (merged).

Fixes HOU-976

🤖 Generated with [Claude Code](https://claude.com/claude-code)