### PR TITLE
feat(teams): live space list + member-visibility fixes from Felipe's Jul 31 round

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -33,6 +33,7 @@ import { useReadCursorTracker } from "./hooks/use-read-cursors";
 import { useScreenPrefetch } from "./hooks/use-screen-prefetch";
 import { SessionUnavailableError, useSession } from "./hooks/use-session";
 import { useSessionEvents } from "./hooks/use-session-events";
+import { useSpacesLiveRefresh } from "./hooks/use-spaces-live-refresh";
 import { analytics } from "./lib/analytics";
 import { shouldAllowNativeContextMenu } from "./lib/context-menu";
 import { newEngineActive } from "./lib/engine";
@@ -69,6 +70,9 @@ export default function App() {
   useReadCursorTracker();
   useNotificationNudges();
   useAgentInvalidation();
+  // A team the user was just added to appears in the switcher without a
+  // relaunch (quiet focus + interval re-list; spaces-capable hosts only).
+  useSpacesLiveRefresh();
   useAnalyticsSubscriber();
   useIntegrationSessionSync();
   // Keep the Agent Store adapter pointed at the gateway with the user's session

--- a/app/src/hooks/use-spaces-live-refresh.ts
+++ b/app/src/hooks/use-spaces-live-refresh.ts
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import { useWorkspaceStore } from "../stores/workspaces";
+import { useCapabilities } from "./use-capabilities";
+
+/**
+ * Keeps the space list live while the app is open (C8 spaces): a user who is
+ * added to a team must see it appear without relaunching Houston — the
+ * member-added email says "pick it from the workspace switcher", so the
+ * switcher has to be current by the time they look.
+ *
+ * Why polling: the gateway's /v1/events hub is per-replica (an event emitted
+ * on the replica that handled the member-add would miss a subscriber connected
+ * to the other one), so there is no reliable membership push today. A quiet
+ * re-list on window focus (the "read the email → switch back to Houston"
+ * moment) plus a slow interval covers both the foreground and the left-open
+ * cases without any spinner or toast: `refreshWorkspaces` never flips
+ * `loading` and its failures are log-only.
+ *
+ * Gated on `capabilities.spaces` — the deployment says whether spaces exist;
+ * single-player hosts never poll.
+ */
+const SPACES_REFRESH_INTERVAL_MS = 60_000;
+
+export function useSpacesLiveRefresh(): void {
+  const { capabilities } = useCapabilities();
+  const spacesOn = capabilities?.spaces === true;
+  const refreshWorkspaces = useWorkspaceStore((s) => s.refreshWorkspaces);
+
+  useEffect(() => {
+    if (!spacesOn) return;
+    const refresh = () => void refreshWorkspaces();
+    window.addEventListener("focus", refresh);
+    const interval = setInterval(refresh, SPACES_REFRESH_INTERVAL_MS);
+    return () => {
+      window.removeEventListener("focus", refresh);
+      clearInterval(interval);
+    };
+  }, [spacesOn, refreshWorkspaces]);
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -239,6 +239,16 @@ async function surfaceError(
 export const tauriWorkspaces = {
   list: () =>
     call<Workspace[]>("list_workspaces", () => getEngine().listWorkspaces()),
+  /** Background space-list sync (the live-spaces refresher): failures are
+   *  logged only — the next tick retries, and a red toast per poll would turn
+   *  an offline hour into a toast storm. User-initiated loads use `list`. */
+  listQuiet: () =>
+    call<Workspace[]>(
+      "list_workspaces",
+      () => getEngine().listWorkspaces(),
+      undefined,
+      { surface: false },
+    ),
   create: (name: string) =>
     call<Workspace>("create_workspace", () =>
       getEngine().createWorkspace({ name }),

--- a/app/src/lib/workspace-refresh.ts
+++ b/app/src/lib/workspace-refresh.ts
@@ -1,0 +1,51 @@
+import type { Workspace } from "./types";
+
+/**
+ * What a background space-list refresh should do with a freshly-listed set
+ * (the live-spaces poll, `useSpacesLiveRefresh`). Pure so the merge decision is
+ * unit-tested without the store's engine/preference side effects — the store
+ * applies the plan.
+ *
+ *  - `unchanged` — same spaces, same names: touch nothing (the common tick).
+ *  - `update`    — the list changed but the active space survives: swap the
+ *                  list in place, adopting the fresh current object so a
+ *                  server-side rename of the active space shows too. No
+ *                  re-pin, no cache reset — the active org is the same.
+ *  - `reselect`  — the ACTIVE space vanished (the user was removed from that
+ *                  team while the app was open): land on the default/first
+ *                  space; the store must then re-pin the active org and reset
+ *                  the space-scoped caches exactly like a user-driven switch —
+ *                  staying pinned to a space the gateway now 403s would strand
+ *                  every request.
+ */
+export type SpacesRefreshPlan =
+  | { kind: "unchanged" }
+  | { kind: "update"; workspaces: Workspace[]; current: Workspace | null }
+  | { kind: "reselect"; workspaces: Workspace[]; current: Workspace | null };
+
+export function planSpacesRefresh(
+  previous: Workspace[],
+  current: Workspace | null,
+  fresh: Workspace[],
+): SpacesRefreshPlan {
+  const sameList =
+    fresh.length === previous.length &&
+    fresh.every((w) => {
+      const old = previous.find((o) => o.id === w.id);
+      return old !== undefined && old.name === w.name;
+    });
+  if (sameList) return { kind: "unchanged" };
+
+  if (current !== null) {
+    const stillCurrent = fresh.find((w) => w.id === current.id);
+    if (stillCurrent === undefined) {
+      return {
+        kind: "reselect",
+        workspaces: fresh,
+        current: fresh.find((w) => w.isDefault) ?? fresh[0] ?? null,
+      };
+    }
+    return { kind: "update", workspaces: fresh, current: stillCurrent };
+  }
+  return { kind: "update", workspaces: fresh, current: null };
+}

--- a/app/src/locales/en/teams.json
+++ b/app/src/locales/en/teams.json
@@ -264,15 +264,15 @@
     "open": "Open {{name}}"
   },
   "createTeam": {
-    "trigger": "Create team",
-    "title": "Create a team",
-    "description": "Teams let you share agents and work together. You can invite people once it exists.",
-    "nameLabel": "Team name",
+    "trigger": "Create organization",
+    "title": "Create an organization",
+    "description": "Organizations let you share agents and work together. You can invite people once it exists.",
+    "nameLabel": "Organization name",
     "namePlaceholder": "e.g. Marketing",
-    "submit": "Create team",
+    "submit": "Create organization",
     "creating": "Creating…",
     "tooLong": "Keep the name under {{max}} characters.",
-    "successTitle": "Team \"{{name}}\" created",
+    "successTitle": "Organization \"{{name}}\" created",
     "successBody": "Invite people so you can work together.",
     "successAction": "Invite your team"
   },

--- a/app/src/locales/es/teams.json
+++ b/app/src/locales/es/teams.json
@@ -264,15 +264,15 @@
     "open": "Abrir {{name}}"
   },
   "createTeam": {
-    "trigger": "Crear equipo",
-    "title": "Crear un equipo",
-    "description": "Los equipos te permiten compartir agentes y trabajar en conjunto. Puedes invitar a personas una vez que exista.",
-    "nameLabel": "Nombre del equipo",
+    "trigger": "Crear organización",
+    "title": "Crear una organización",
+    "description": "Las organizaciones te permiten compartir agentes y trabajar en conjunto. Puedes invitar a personas una vez que exista.",
+    "nameLabel": "Nombre de la organización",
     "namePlaceholder": "p. ej. Marketing",
-    "submit": "Crear equipo",
+    "submit": "Crear organización",
     "creating": "Creando…",
     "tooLong": "Usa un nombre de menos de {{max}} caracteres.",
-    "successTitle": "Equipo \"{{name}}\" creado",
+    "successTitle": "Organización \"{{name}}\" creada",
     "successBody": "Invita a otras personas para trabajar juntos.",
     "successAction": "Invita a tu equipo"
   },

--- a/app/src/locales/pt/teams.json
+++ b/app/src/locales/pt/teams.json
@@ -264,15 +264,15 @@
     "open": "Abrir {{name}}"
   },
   "createTeam": {
-    "trigger": "Criar equipe",
-    "title": "Criar uma equipe",
-    "description": "As equipes permitem compartilhar agentes e trabalhar em conjunto. Você pode convidar pessoas depois que ela existir.",
-    "nameLabel": "Nome da equipe",
+    "trigger": "Criar organização",
+    "title": "Criar uma organização",
+    "description": "As organizações permitem compartilhar agentes e trabalhar em conjunto. Você pode convidar pessoas depois que ela existir.",
+    "nameLabel": "Nome da organização",
     "namePlaceholder": "ex.: Marketing",
-    "submit": "Criar equipe",
+    "submit": "Criar organização",
     "creating": "Criando…",
     "tooLong": "Use um nome com menos de {{max}} caracteres.",
-    "successTitle": "Equipe \"{{name}}\" criada",
+    "successTitle": "Organização \"{{name}}\" criada",
     "successBody": "Convide pessoas para trabalharem juntas.",
     "successAction": "Convide sua equipe"
   },

--- a/app/src/stores/workspaces.ts
+++ b/app/src/stores/workspaces.ts
@@ -6,6 +6,7 @@ import { resetCacheForSpaceChange } from "../lib/space-cache";
 import { orgSlugFromWorkspaceId } from "../lib/space-id";
 import { tauriPreferences, tauriWorkspaces } from "../lib/tauri";
 import type { Workspace } from "../lib/types";
+import { planSpacesRefresh } from "../lib/workspace-refresh";
 import { resolveActiveWorkspace } from "../lib/workspace-switch";
 
 interface WorkspaceState {
@@ -24,6 +25,13 @@ interface WorkspaceState {
    *  has no workspace (a neutral empty state). */
   loadError: boolean;
   loadWorkspaces: () => Promise<void>;
+  /** Background space-list sync (HOU live-spaces): re-lists quietly and merges
+   *  changes in place — a space the user was just added to appears without a
+   *  relaunch, and a space they were removed from disappears (falling back to
+   *  the default space when it was the active one). Never flips `loading`, so
+   *  no screen re-splashes; failures are logged by the wire layer and simply
+   *  retried on the next tick. */
+  refreshWorkspaces: () => Promise<void>;
   setCurrent: (ws: Workspace) => void;
   create: (name: string) => Promise<Workspace>;
   delete: (id: string) => Promise<void>;
@@ -35,7 +43,7 @@ interface WorkspaceState {
   reset: () => void;
 }
 
-export const useWorkspaceStore = create<WorkspaceState>((set) => ({
+export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   workspaces: [],
   current: null,
   // Start "not settled" so App.tsx renders the loading splash on first paint
@@ -74,6 +82,31 @@ export const useWorkspaceStore = create<WorkspaceState>((set) => ({
       set({ loadError: true });
     } finally {
       set({ loading: false, loaded: true });
+    }
+  },
+
+  refreshWorkspaces: async () => {
+    const before = get();
+    // Never race the boot load or a user-initiated reload; they own `loading`.
+    if (!before.loaded || before.loading) return;
+    let fresh: Workspace[];
+    try {
+      fresh = await tauriWorkspaces.listQuiet();
+    } catch {
+      return; // logged by the wire layer; the next tick retries
+    }
+    const prev = get();
+    if (prev.loading) return; // a real load started mid-flight; it wins
+    const plan = planSpacesRefresh(prev.workspaces, prev.current, fresh);
+    if (plan.kind === "unchanged") return;
+    set({ workspaces: plan.workspaces, current: plan.current });
+    if (plan.kind === "reselect" && plan.current) {
+      // The active space vanished (removed from the team while the app was
+      // open): re-pin like setCurrent — staying pinned to a space the gateway
+      // now 403s would strand every request.
+      tauriPreferences.set("last_workspace_id", plan.current.id);
+      const orgChanged = setActiveOrg(orgSlugFromWorkspaceId(plan.current.id));
+      resetCacheForSpaceChange(queryClient, orgChanged);
     }
   },
 

--- a/app/tests/workspace-refresh.test.ts
+++ b/app/tests/workspace-refresh.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import type { Workspace } from "../src/lib/types.ts";
+import { planSpacesRefresh } from "../src/lib/workspace-refresh.ts";
+
+// The live-spaces poll (HOU: "a new org must appear without relaunching").
+// planSpacesRefresh is the pure merge decision the workspace store applies on
+// every background re-list; these pin its three outcomes.
+
+const ws = (id: string, name: string, isDefault = false): Workspace => ({
+  id,
+  name,
+  isDefault,
+  createdAt: "2026-07-31T00:00:00Z",
+});
+
+const personal = ws("Houston", "Personal", true);
+const teamA = ws("org:aaaaaaaaaaaaaaaa", "Marketing");
+const teamB = ws("org:bbbbbbbbbbbbbbbb", "Sales");
+
+describe("planSpacesRefresh", () => {
+  it("is unchanged when the list and names match (the common tick)", () => {
+    const plan = planSpacesRefresh([personal, teamA], personal, [
+      personal,
+      teamA,
+    ]);
+    assert.strictEqual(plan.kind, "unchanged");
+  });
+
+  it("updates in place when a new team appears, keeping the selection", () => {
+    const plan = planSpacesRefresh([personal], personal, [personal, teamA]);
+    assert.strictEqual(plan.kind, "update");
+    assert.deepStrictEqual(
+      plan.kind === "update" && plan.workspaces.map((w) => w.id),
+      [personal.id, teamA.id],
+    );
+    assert.strictEqual(plan.kind === "update" && plan.current?.id, personal.id);
+  });
+
+  it("adopts the fresh current object on a server-side rename", () => {
+    const renamed = { ...teamA, name: "Marketing LATAM" };
+    const plan = planSpacesRefresh([personal, teamA], teamA, [
+      personal,
+      renamed,
+    ]);
+    assert.strictEqual(plan.kind, "update");
+    assert.strictEqual(
+      plan.kind === "update" && plan.current?.name,
+      "Marketing LATAM",
+    );
+  });
+
+  it("reselects the default space when the active one vanished", () => {
+    const plan = planSpacesRefresh([personal, teamA, teamB], teamA, [
+      personal,
+      teamB,
+    ]);
+    assert.strictEqual(plan.kind, "reselect");
+    assert.strictEqual(
+      plan.kind === "reselect" && plan.current?.id,
+      personal.id,
+    );
+  });
+
+  it("keeps a null selection null while still updating the list", () => {
+    const plan = planSpacesRefresh([], null, [personal]);
+    assert.strictEqual(plan.kind, "update");
+    assert.strictEqual(plan.kind === "update" && plan.current, null);
+  });
+
+  it("treats a pure removal of a non-active space as an update", () => {
+    const plan = planSpacesRefresh([personal, teamA, teamB], personal, [
+      personal,
+      teamA,
+    ]);
+    assert.strictEqual(plan.kind, "update");
+    assert.strictEqual(plan.kind === "update" && plan.current?.id, personal.id);
+  });
+});

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -512,6 +512,19 @@ per team, each `{ id: "org:" + slug, kind: "org" }` where `slug` is `[a-f0-9]{16
   the workspace store's `loadError` for the Settings retry.
 - **Restore last space**: `resolveActiveWorkspace` (`app/src/lib/workspace-switch.ts`)
   restores the persisted `last_workspace_id`, else default, else first.
+- **Live space list (no relaunch needed)**: `useSpacesLiveRefresh`
+  (`app/src/hooks/use-spaces-live-refresh.ts`, mounted in App, gated on
+  `caps.spaces`) quietly re-lists workspaces on window focus + a 60s interval so
+  a team the user was just added to appears without reopening the app (the
+  member-added email points at the switcher). Merge decision is pure —
+  `planSpacesRefresh` (`app/src/lib/workspace-refresh.ts`, unit-tested):
+  unchanged ⇒ no-op; changed ⇒ swap the list keeping the selection; active
+  space VANISHED (kicked from the team) ⇒ fall back to default/first and re-pin
+  + reset caches like a user switch. The store's `refreshWorkspaces` never
+  flips `loading` (no re-splash) and uses `tauriWorkspaces.listQuiet`
+  (`surface:false` — a background poll must not toast per offline tick). Why
+  polling, not events: the gateway /v1/events hub is per-replica, so a
+  membership event emitted on one replica misses subscribers on the other.
 
 ### Create-team
 
@@ -519,7 +532,10 @@ The switcher's create action routes on `caps.spaces`
 (`app/src/components/shell/sidebar-chrome.tsx`): a Spaces host opens the
 **Create-team dialog** (`create-team-dialog.tsx`, validation in
 `create-team-model.ts`: trimmed, non-empty, `<= 60` chars, and the gateway
-re-validates); a non-spaces host keeps the local "create workspace" action. On
+re-validates); a non-spaces host keeps the local "create workspace" action.
+User-facing copy says **"Create organization"** (the `teams:createTeam.*`
+locale block, renamed from "Create team" per Felipe, Jul 2026) — code
+identifiers keep the `createTeam` name. On
 success `useCreateTeam` (`app/src/hooks/queries/use-orgs.ts`) invalidates the
 spaces list and reloads the workspace store so the new team bridges in as an
 `org:*` workspace. `POST /v1/orgs` is NOT idempotent: a lost response is


### PR DESCRIPTION
## What

Two of Felipe's Jul 31 asks, one PR (both live in the teams surface):

### 1. A new org appears without relaunching (HOU-1095)

The space list was a boot-time zustand load — a user added to a team while Houston was open never saw it until quit+reopen. `useSpacesLiveRefresh` (mounted in App, gated on `capabilities.spaces`) quietly re-lists on window focus + a 60s interval:

- **Pure merge** (`planSpacesRefresh`, unit-tested): unchanged → no-op; changed → swap the list keeping the selection (adopting a server-side rename of the active space); active space **vanished** (removed from the team) → fall back to the default space with the same re-pin + cache reset a user-driven switch does.
- **No UX noise**: `refreshWorkspaces` never flips `loading` (no re-splash) and lists via `tauriWorkspaces.listQuiet` (`surface:false`) — a background poll must not toast every offline tick; failures log and the next tick retries.
- **Why polling, not events**: the gateway /v1/events hub is per-replica; a membership event emitted on the replica that handled the add would miss subscribers connected to the other.

Pairs with the cloud member-added email (gethouston/cloud#209) whose copy says "pick it from the workspace switcher".

### 2. "Create organization" copy (HOU-1096)

Renames the whole `createTeam` locale block in en/es/pt — trigger button, dialog title, description, name label, submit, success toast — so the flow is not half team / half organization. Sentence case per house style. Code identifiers keep `createTeam`; the rest of the app's "team" wording is untouched (full terminology sweep = separate decision).

## Tests / verification

- 6 new unit tests for `planSpacesRefresh`; app suite 2578 passing.
- `tsgo --noEmit` (app + full workspace), `check-locales` (en/es/pt in sync), Biome, web typecheck + Tauri shim parity all green.
- KB updated: `knowledge-base/teams.md` (switcher live-refresh + copy note).

Fixes HOU-1095
Fixes HOU-1096

🤖 Generated with [Claude Code](https://claude.com/claude-code)