### PR TITLE
ci(store): gate the agentstore image build on the site's full dep closure

### DIFF
--- a/.github/workflows/agentstore-image.yml
+++ b/.github/workflows/agentstore-image.yml
@@ -100,8 +100,17 @@ jobs:
           BUILD=true
           if [ -n "$BASE" ] && [ "$BASE" != "0000000000000000000000000000000000000000" ] \
               && git fetch --depth=1 origin "$BASE" 2>/dev/null; then
+            # The full workspace-dependency closure of the site build: the app
+            # itself, its direct workspace deps (@houston/agentstore-contract,
+            # @houston/agentstore-client, @houston-ai/core, @houston-ai/store),
+            # and their transitive dep @houston/design-tokens. A change in ANY
+            # of these alters the compiled bundle, so all must gate the build —
+            # ui/store was missed when the redesign made the site consume the
+            # shared screens, which would have shipped app-only store changes.
             if git diff --name-only "$BASE" "${{ github.sha }}" -- \
-                agentstore packages/agentstore-contract .github/workflows/agentstore-image.yml \
+                agentstore packages/agentstore-contract packages/agentstore-client \
+                ui/core ui/store packages/design-tokens \
+                .github/workflows/agentstore-image.yml \
                 | grep -q .; then
               BUILD=true
             else

--- a/knowledge-base/agent-store.md
+++ b/knowledge-base/agent-store.md
@@ -328,7 +328,9 @@ Houston surfaces (SDK: profile/creator/analytics methods on
 - **Frontend image** `.github/workflows/agentstore-image.yml` builds + pushes the
   container to Artifact Registry, then fires a `repository_dispatch` to
   `gethouston/cloud`, which does the GKE roll. Deploy paths: a push to `main`
-  touching `agentstore/**` / `packages/agentstore-contract/**` dispatches
+  touching the site's workspace-dependency closure (`agentstore/**`,
+  `packages/agentstore-{contract,client}/**`, `ui/{core,store}/**`,
+  `packages/design-tokens/**`) dispatches
   `roll-agentstore` → cloud's `roll-agentstore-staging.yml` rolls STAGING;
   **PROD (agents.gethouston.ai) ships on the ship train** — publishing a
   `cloud-v*` release runs `ship-train.yml`'s `promote-agentstore` job, which


### PR DESCRIPTION
## What

Extends `agentstore-image.yml`'s build gate from `agentstore/` + `packages/agentstore-contract/` to the site's full workspace-dependency closure: adds `packages/agentstore-client`, `ui/core`, `ui/store`, and `packages/design-tokens`. KB deploy paragraph updated to match.

## Why

Since the redesign the website compiles the shared screens (`@houston-ai/store`), `@houston-ai/core`, the client SDK, and design tokens into its bundle — but the gate didn't watch those paths, so a change made only there would silently skip the image rebuild and ship app-only (the same class of drift as the two-week prod freeze, one layer down).

## Verification

- YAML parsed clean; the gate change is a path-list extension inside the existing diff check.
- Full workspace typecheck green (pre-commit hook).
- Dep closure derived from `agentstore/package.json` + transitive workspace deps (Dockerfile builds from repo root, so all of them feed the bundle).

No Linear issue — CI gap found while shipping the store nav fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)