### PR TITLE
feat(teams): invite inbox — invitee-side accept/decline for pending org invites

### DIFF
--- a/app/src/components/shell/invite-card.tsx
+++ b/app/src/components/shell/invite-card.tsx
@@ -1,0 +1,120 @@
+import { AsyncButton } from "@houston-ai/core";
+import type { OrgInviteSummary } from "@houston-ai/engine-client";
+import { Mail } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  useAcceptInvite,
+  useDeclineInvite,
+} from "../../hooks/queries/use-invites";
+import {
+  type InviteActionLock,
+  inviterDisplayName,
+} from "../../lib/invite-model";
+
+/**
+ * One pending team invitation, offered where the user picks a space: directly
+ * under the workspace switcher, ALWAYS visible (never behind a hover or a menu
+ * — the switcher's dropdown would hide the whole thing behind a click, and an
+ * invitation nobody sees is an invitation nobody accepts).
+ *
+ * The inviter is named only when the gateway sends something human; today
+ * `invitedBy` is the inviter's user id, which no invitee-side read can resolve
+ * (they are not in that org yet), so the card names the TEAM instead of putting
+ * a database id in front of the user — see `inviterDisplayName`.
+ *
+ * Both actions route through hooks that own the whole surfacing story (list
+ * refresh, workspace reload, expected-state toasts), so the row here has no
+ * `catch` of its own: the card disappears when the refreshed list drops the
+ * invite.
+ *
+ * Accept and Decline EXCLUDE each other through the shared {@link
+ * InviteActionLock}, claimed synchronously before either mutation starts.
+ * `AsyncButton`'s own rage-click guard is per button and `busy` only lands on
+ * the next commit, so without the lock an Accept immediately followed by a
+ * Decline fired both calls and the loser toasted a confusing
+ * `already_member` / `invite_not_found` at a user who did nothing wrong.
+ */
+export function InviteCard({
+  invite,
+  lock,
+}: {
+  invite: OrgInviteSummary;
+  lock: InviteActionLock;
+}) {
+  const { t } = useTranslation("teams");
+  const accept = useAcceptInvite();
+  const decline = useDeclineInvite();
+  const inviter = inviterDisplayName(invite.invitedBy);
+  const busy = accept.isPending || decline.isPending;
+
+  /** Run one invite action under the lock; a second click is dropped. */
+  const runExclusive = async (act: () => Promise<unknown>) => {
+    if (!lock.claim(invite.id)) return;
+    try {
+      await act();
+    } catch {
+      // Already surfaced once: an expected gateway state by the hook's
+      // informational toast, anything else by `call()`'s bug toast.
+    } finally {
+      lock.release(invite.id);
+    }
+  };
+
+  return (
+    <li className="ht-hairline rounded-xl bg-card p-3">
+      <div className="flex items-start gap-2">
+        <Mail
+          aria-hidden="true"
+          className="mt-0.5 size-4 shrink-0 text-ink-muted"
+        />
+        {/* `min-w-0` + `break-words`: a team name is up to 200 gateway-allowed
+            characters and can be one unbroken token, which would otherwise push
+            the card past the rail's width. */}
+        <div className="min-w-0 flex-1">
+          {/* `line-clamp-3`: the gateway allows a 200-character team name, and
+              one unbroken token of those wraps to a dozen lines that push
+              Accept / Decline out of the bounded list — a lone invitation whose
+              buttons are below the fold. Three lines keep the actions in view;
+              the full name stays in the DOM for screen readers and `title`. */}
+          <p
+            className="line-clamp-3 text-sm text-ink text-balance break-words"
+            title={invite.orgName}
+          >
+            {inviter
+              ? t("inviteInbox.headlineFrom", {
+                  name: inviter,
+                  team: invite.orgName,
+                })
+              : t("inviteInbox.headline", { team: invite.orgName })}
+          </p>
+          <p className="mt-0.5 text-xs text-ink-muted break-words">
+            {t("inviteInbox.asRole", {
+              role: t(`people.roles.${invite.role}`),
+            })}
+          </p>
+        </div>
+      </div>
+      <div className="mt-2.5 flex gap-2">
+        <AsyncButton
+          size="sm"
+          className="flex-1 rounded-full"
+          disabled={busy}
+          aria-label={t("inviteInbox.acceptLabel", { team: invite.orgName })}
+          onClick={() => runExclusive(() => accept.mutateAsync(invite.id))}
+        >
+          {t("inviteInbox.accept")}
+        </AsyncButton>
+        <AsyncButton
+          size="sm"
+          variant="ghost"
+          className="flex-1 rounded-full"
+          disabled={busy}
+          aria-label={t("inviteInbox.declineLabel", { team: invite.orgName })}
+          onClick={() => runExclusive(() => decline.mutateAsync(invite.id))}
+        >
+          {t("inviteInbox.decline")}
+        </AsyncButton>
+      </div>
+    </li>
+  );
+}

--- a/app/src/components/shell/pending-invites.tsx
+++ b/app/src/components/shell/pending-invites.tsx
@@ -1,0 +1,112 @@
+import type { OrgInviteSummary } from "@houston-ai/engine-client";
+import { Mail } from "lucide-react";
+import { useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { useOrgs } from "../../hooks/queries/use-spaces";
+import { useCapabilities } from "../../hooks/use-capabilities";
+import {
+  createInviteActionLock,
+  type InviteActionLock,
+  visibleInvites,
+} from "../../lib/invite-model";
+import { hasSpaces } from "../../lib/org-roles";
+import { InviteCard } from "./invite-card";
+
+/**
+ * The invite inbox on the expanded sidebar rail: every pending invitation
+ * addressed to the caller, each with Accept / Decline. Renders nothing when
+ * there is none, so a solo user never sees the chrome.
+ *
+ * The list is BOUNDED (`max-h-72`) and scrolls inside itself. The sidebar
+ * header is a fixed, non-scrolling region above the nav, so an unbounded list
+ * would push the navigation down and get clipped by the rail's
+ * `overflow-hidden` — invitations you cannot reach. The bound is sized to TWO
+ * WHOLE cards plus the top edge of a third: at the previous `max-h-52` the
+ * second card was sliced through its own Accept / Decline row, which reads as a
+ * rendering fault rather than "scroll for more" (macOS overlay scrollbars show
+ * nothing until you scroll). A clipped card TOP is the affordance; nothing here
+ * is hover-gated, and no invite is ever hidden behind a "show more" the user
+ * has to discover.
+ */
+export function PendingInviteList({
+  invites,
+}: {
+  invites: OrgInviteSummary[];
+}) {
+  const { t } = useTranslation("teams");
+  // One lock for the whole list (it is keyed by invite id), held across
+  // re-renders so a re-paint mid-flight can't reopen a second call.
+  const lockRef = useRef<InviteActionLock | null>(null);
+  lockRef.current ??= createInviteActionLock();
+  const lock = lockRef.current;
+  if (invites.length === 0) return null;
+  return (
+    <section aria-label={t("inviteInbox.title")} className="px-2 pb-1">
+      <ul className="max-h-72 space-y-2 overflow-y-auto overscroll-contain">
+        {invites.map((invite) => (
+          <InviteCard key={invite.id} invite={invite} lock={lock} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+/**
+ * The invite inbox as the sidebar mounts it: the `headerBelow` band, a
+ * full-width row directly under the workspace switcher. It owns its own data
+ * gate so the switcher header stays about switching spaces.
+ *
+ * Spaces-gated on BOTH sides. The FETCH is gated because off a Spaces host
+ * `listOrgs` has nothing to answer; the RENDER is gated because disabling a
+ * React Query does not clear its cache, so a session that loses the capability
+ * would keep painting the last fetch's invites over a deployment whose mutators
+ * throw. `hasSpaces(null)` is false while capabilities load, so the same gate is
+ * the no-flash-on-boot rule.
+ */
+export function SidebarInviteInbox({
+  collapsed,
+  onExpand,
+}: {
+  collapsed: boolean;
+  onExpand: () => void;
+}) {
+  const { capabilities } = useCapabilities();
+  const spacesEnabled = hasSpaces(capabilities);
+  const { data: spaces } = useOrgs(spacesEnabled);
+  const invites = visibleInvites(spacesEnabled, spaces?.invites ?? []);
+  return collapsed ? (
+    <PendingInvitesRailButton count={invites.length} onExpand={onExpand} />
+  ) : (
+    <PendingInviteList invites={invites} />
+  );
+}
+
+/**
+ * The collapsed rail's stand-in for the list: the cards need width the icon
+ * rail doesn't have, so the count becomes a labelled button that expands the
+ * sidebar onto the real thing. Still no hover gating, and still impossible to
+ * miss: a user who collapsed the rail must not lose the invitation.
+ */
+export function PendingInvitesRailButton({
+  count,
+  onExpand,
+}: {
+  count: number;
+  onExpand: () => void;
+}) {
+  const { t } = useTranslation("teams");
+  if (count === 0) return null;
+  return (
+    <div className="flex justify-center px-2 pb-1">
+      <button
+        type="button"
+        onClick={onExpand}
+        aria-label={t("inviteInbox.railLabel", { count })}
+        className="ht-hairline flex h-9 items-center justify-center gap-1 rounded-lg bg-card px-2 text-ink transition-colors hover:bg-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus"
+      >
+        <Mail aria-hidden="true" className="size-4" />
+        <span className="text-xs font-medium tabular-nums">{count}</span>
+      </button>
+    </div>
+  );
+}

--- a/app/src/components/shell/sidebar-chrome.tsx
+++ b/app/src/components/shell/sidebar-chrome.tsx
@@ -111,6 +111,12 @@ export function buildSidebarLabels(t: ShellT): SidebarLabels {
  * "Create team"; otherwise it falls back to the caller's `onCreate` (the local
  * workspace-create dialog) and reads the truthful "Create workspace" label —
  * the old "createOrganization" copy was a known mislabel.
+ *
+ * Pending invitations addressed to the caller render directly BELOW this
+ * header, in the sidebar's `headerBelow` band (`SidebarInviteInbox`,
+ * `pending-invites.tsx`) — same place in the user's eye, but its own full-width
+ * row: the header line is shared with the collapse toggle, which would both
+ * squeeze the cards and drag the toggle down to the middle of them.
  */
 export function SidebarWorkspaceHeader(props: {
   t: ShellT;

--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -23,6 +23,7 @@ import { useUIStore } from "../../stores/ui";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { buildAgentSidebarLists } from "./agent-sidebar-items";
 import { GroupContextDialog } from "./group-context-dialog";
+import { SidebarInviteInbox } from "./pending-invites";
 import {
   buildSidebarLabels,
   buildSidebarNavItems,
@@ -237,6 +238,15 @@ export function Sidebar({ children }: { children: ReactNode }) {
             collapsed={effectiveCollapsed}
             onSwitch={handleWorkspaceSwitch}
             onCreate={() => setCreateWsOpen(true)}
+            onExpand={() => setSidebarCollapsed(false)}
+          />
+        }
+        // Pending team invitations: same place in the eye (right under the
+        // switcher, where a user picks a space), but their OWN full-width row —
+        // the header line belongs to the switcher and the collapse toggle.
+        headerBelow={
+          <SidebarInviteInbox
+            collapsed={effectiveCollapsed}
             onExpand={() => setSidebarCollapsed(false)}
           />
         }

--- a/app/src/hooks/queries/index.ts
+++ b/app/src/hooks/queries/index.ts
@@ -46,6 +46,7 @@ export {
   useIntegrationStatus,
   useIntegrationToolkits,
 } from "./use-integrations";
+export { useAcceptInvite, useDeclineInvite } from "./use-invites";
 export {
   useAddLearning,
   useLearnings,

--- a/app/src/hooks/queries/use-invites.ts
+++ b/app/src/hooks/queries/use-invites.ts
@@ -1,0 +1,115 @@
+import type { OrgSummary } from "@houston-ai/engine-client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
+import { analytics } from "../../lib/analytics";
+import { showExpectedStateToast } from "../../lib/error-toast";
+import {
+  classifyInviteError,
+  type InviteFailure,
+  isExpectedInviteError,
+  teamIsInSwitcher,
+} from "../../lib/invite-model";
+import { queryKeys } from "../../lib/query-keys";
+import { tauriOrg } from "../../lib/tauri";
+import { useUIStore } from "../../stores/ui";
+import { useWorkspaceStore } from "../../stores/workspaces";
+
+/**
+ * The INVITEE side of C8 team invites: accept / decline a pending invite from
+ * `GET /v1/orgs`'s `invites`. The owner's revoke is a different route and a
+ * different hook (`useDeleteInvite`, `use-org.ts`).
+ *
+ * Both hooks invalidate the spaces list on BOTH paths, not just on success:
+ * every expected rejection (`already_member`, `invite_not_found`) means the
+ * server's truth already moved on, so the stale card must disappear either way.
+ * The invalidation fires FIRST and is never awaited behind the workspace
+ * reload, so the answered card leaves the sidebar immediately rather than
+ * lingering for the length of a `GET /v1/workspaces`.
+ *
+ * Accepting also reloads the workspace store — a joined team reaches the
+ * switcher through `GET /v1/workspaces`, which is Zustand, not a query the
+ * invalidation could reach. That reload SWALLOWS its own failure (it only
+ * records `loadError`), so the success toast checks `teamIsInSwitcher` against
+ * the reloaded list before promising the team is there; when it isn't, the copy
+ * says so instead. Nothing switches the active space: joining is not the same
+ * as going there.
+ *
+ * Expected gateway states are silenced from `call()`'s red bug toast and get
+ * ONE plain informational toast here instead (`invite-model.ts` holds the
+ * taxonomy). Anything else keeps the standard toast + Sentry report.
+ */
+
+/** Copy for each expected rejection, keyed by `teams:inviteInbox.errors.*`. */
+const FAILURE_COPY = {
+  needs_upgrade: "needsUpgrade",
+  already_member: "alreadyMember",
+  invite_not_found: "gone",
+} as const satisfies Record<Exclude<InviteFailure, "unknown">, string>;
+
+export function useAcceptInvite() {
+  const { t } = useTranslation("teams");
+  const qc = useQueryClient();
+  const addToast = useUIStore((s) => s.addToast);
+  const loadWorkspaces = useWorkspaceStore((s) => s.loadWorkspaces);
+  return useMutation<OrgSummary, unknown, string>({
+    mutationFn: (inviteId: string) =>
+      tauriOrg.acceptInvite(inviteId, { silence: isExpectedInviteError }),
+    onSuccess: async (org) => {
+      analytics.track("org_invite_accepted");
+      // Prompt, un-awaited: the answered card must leave the sidebar now, not
+      // after the workspace reload below.
+      qc.invalidateQueries({ queryKey: queryKeys.orgs() });
+      await loadWorkspaces();
+      // `loadWorkspaces` resolves even when it failed, so the list itself is
+      // the only honest evidence that the team reached the switcher.
+      const inSwitcher = teamIsInSwitcher(
+        useWorkspaceStore.getState().workspaces,
+        org.slug,
+      );
+      addToast({
+        title: t("inviteInbox.joinedTitle", { team: org.name }),
+        description: inSwitcher
+          ? t("inviteInbox.joinedBody")
+          : t("inviteInbox.joinedBodyUnconfirmed"),
+        variant: "success",
+      });
+    },
+    onError: (err) => {
+      showInviteFailure(t, err);
+      qc.invalidateQueries({ queryKey: queryKeys.orgs() });
+    },
+  });
+}
+
+export function useDeclineInvite() {
+  const { t } = useTranslation("teams");
+  const qc = useQueryClient();
+  return useMutation<void, unknown, string>({
+    mutationFn: (inviteId: string) =>
+      tauriOrg.declineInvite(inviteId, { silence: isExpectedInviteError }),
+    onSuccess: () => {
+      analytics.track("org_invite_declined");
+      qc.invalidateQueries({ queryKey: queryKeys.orgs() });
+    },
+    onError: (err) => {
+      showInviteFailure(t, err);
+      qc.invalidateQueries({ queryKey: queryKeys.orgs() });
+    },
+  });
+}
+
+/**
+ * Surface an expected rejection as its own informational toast. `unknown`
+ * failures already reached the user through `call()`'s red toast + Sentry
+ * report, so they get nothing extra here (one surface per action).
+ */
+function showInviteFailure(t: TFunction<"teams">, err: unknown): void {
+  const failure = classifyInviteError(err);
+  if (failure === "unknown") return;
+  const key = FAILURE_COPY[failure];
+  showExpectedStateToast(
+    t(`inviteInbox.errors.${key}Title`),
+    t(`inviteInbox.errors.${key}Body`),
+  );
+}

--- a/app/src/lib/invite-model.ts
+++ b/app/src/lib/invite-model.ts
@@ -1,0 +1,160 @@
+import type { OrgInviteSummary } from "@houston-ai/engine-client";
+import { shareErrorCode } from "./share-via-team.ts";
+import { orgSlugFromWorkspaceId } from "./space-id.ts";
+
+/**
+ * Pure, DOM-free logic behind the INVITEE side of C8 team invites — the
+ * sidebar card that offers Accept / Decline for every pending invite addressed
+ * to the caller (`GET /v1/orgs` → `invites`). Kept out of the `.tsx` so the
+ * error taxonomy and the inviter-name rule unit-test under bare Node.
+ *
+ * The gateway is the sole enforcer: this module only decides what the user is
+ * TOLD when a call comes back, never who may join.
+ */
+
+/**
+ * The gateway rejections the invite card explains itself, mapped from the C8
+ * `POST /v1/org-invites/:id/accept` + `DELETE /v1/org-invites/:id` codes:
+ *
+ * - `needs_upgrade` (403) — the team's trial ended; joining would add a seat it
+ *   can't pay for. The invite STAYS: an upgrade makes it acceptable again.
+ * - `already_member` (409) — the caller is in that team already (a second
+ *   window, or the auto-join that runs on a brand-new account's first contact).
+ *   Not a failure: the list refresh drops the row and the team is already there.
+ * - `invite_not_found` (404) — revoked, already used, or addressed to another
+ *   email; the gateway deliberately cannot tell those apart, so neither can we.
+ * - `unknown` — anything else, which keeps the standard red bug toast.
+ */
+export type InviteFailure =
+  | "needs_upgrade"
+  | "already_member"
+  | "invite_not_found"
+  | "unknown";
+
+const EXPECTED_INVITE_CODES = new Set<InviteFailure>([
+  "needs_upgrade",
+  "already_member",
+  "invite_not_found",
+]);
+
+/** Classify an accept/decline rejection into {@link InviteFailure}. */
+export function classifyInviteError(err: unknown): InviteFailure {
+  const code = shareErrorCode(err);
+  return code !== undefined && EXPECTED_INVITE_CODES.has(code as InviteFailure)
+    ? (code as InviteFailure)
+    : "unknown";
+}
+
+/**
+ * True for a rejection the invite card explains with its own plain
+ * informational toast. `call()` silences these (no red bug toast, no Sentry
+ * report) so each one gets exactly ONE surface; every other failure keeps the
+ * standard toast + report path.
+ */
+export function isExpectedInviteError(err: unknown): boolean {
+  return classifyInviteError(err) !== "unknown";
+}
+
+/**
+ * The inviter as something a human can read, or `null` when we only hold an
+ * opaque handle.
+ *
+ * `OrgInviteSummary.invitedBy` is the INVITER'S USER ID on the shipped gateway
+ * (`principal.UserID`, `cloud/internal/edge/spaces_routes.go`), and the invitee
+ * is not a member of that org yet, so no roster read can resolve it — the
+ * profile route is scoped to co-members of the ACTIVE space. Rendering the raw
+ * value would put a database id in front of a non-technical user, so the card
+ * falls back to naming the TEAM alone.
+ *
+ * The email/display-name shape is accepted here on purpose: the moment the
+ * gateway sends something human (an email, a display name), the card names the
+ * inviter with no client change. An id-looking value never leaks through.
+ */
+export function inviterDisplayName(
+  invitedBy: string | undefined,
+): string | null {
+  const value = invitedBy?.trim();
+  if (!value) return null;
+  if (value.includes("@")) return value;
+  // A bare token with no whitespace is a handle (uid / sub), not a name.
+  return /\s/.test(value) ? value : null;
+}
+
+/**
+ * Stable order for the invite cards: by team name, then id. The gateway returns
+ * invites in store order, which can shuffle between polls; a card whose Accept
+ * button moves under the cursor is a misclick waiting to happen.
+ */
+export function sortInvites(
+  invites: readonly OrgInviteSummary[],
+): OrgInviteSummary[] {
+  return [...invites].sort(
+    (a, b) => a.orgName.localeCompare(b.orgName) || a.id.localeCompare(b.id),
+  );
+}
+
+/**
+ * The invites the sidebar may actually render, gated on the deployment serving
+ * Spaces at all.
+ *
+ * Gating the FETCH is not enough: disabling a React Query leaves its cached
+ * data in place, so a session that loses the capability (an identity change
+ * into a non-spaces deployment, a capabilities refetch that drops `spaces`)
+ * would keep painting the last fetch's invites, and acting on one would reach a
+ * mutator that throws off-cloud. `hasSpaces(null)` is also false while
+ * capabilities are in flight, so this doubles as the no-flash-on-load rule.
+ */
+export function visibleInvites(
+  spacesEnabled: boolean,
+  invites: readonly OrgInviteSummary[],
+): OrgInviteSummary[] {
+  return spacesEnabled ? sortInvites(invites) : [];
+}
+
+/**
+ * True once the just-joined team is really in the switcher, i.e. the workspace
+ * list holds its `org:<slug>` row.
+ *
+ * The workspace store's `loadWorkspaces()` resolves whether or not the reload
+ * worked (it swallows the failure into a `loadError` flag), so awaiting it
+ * proves nothing. Telling a user "switch to it from the space menu" off that
+ * bare await is a promise we cannot keep; this is the check that earns it.
+ */
+export function teamIsInSwitcher(
+  workspaces: readonly { id: string }[],
+  slug: string,
+): boolean {
+  return workspaces.some((w) => orgSlugFromWorkspaceId(w.id) === slug);
+}
+
+/**
+ * A one-action-at-a-time lock, keyed by invite id.
+ *
+ * Accept and Decline are separate mutations behind separate `AsyncButton`s, and
+ * that component's rage-click guard is per BUTTON: a rapid Accept then Decline
+ * inside the same frame passed both guards and fired both requests. Whichever
+ * lost the race came back `already_member` / `invite_not_found` and toasted a
+ * confusing state at a user who did nothing wrong. `claim` flips a plain Set
+ * SYNCHRONOUSLY, before either mutation starts, so the second click is a
+ * no-op; `release` in a `finally` keeps a failed action retryable.
+ */
+export interface InviteActionLock {
+  /** Take the invite's single action slot. `false` = an action is in flight. */
+  claim(inviteId: string): boolean;
+  /** Give the slot back (safe to call for an id that was never claimed). */
+  release(inviteId: string): void;
+}
+
+export function createInviteActionLock(): InviteActionLock {
+  const inFlight = new Set<string>();
+  return {
+    claim(inviteId) {
+      if (inFlight.has(inviteId)) return false;
+      inFlight.add(inviteId);
+      return true;
+    },
+    release(inviteId) {
+      inFlight.delete(inviteId);
+    },
+  };
+}

--- a/app/src/lib/share-via-team.ts
+++ b/app/src/lib/share-via-team.ts
@@ -31,18 +31,32 @@ export type MoveErrorKind =
   | "unknown";
 
 /**
- * Best-effort machine-readable reason from a gateway error (kind > code > body).
- * Shared by the wiring layer (to classify a rejection) and
- * {@link isExpectedShareError} (to silence expected C8 states from the generic
- * bug toast). Pure + DOM-free so it stays in this unit-tested module.
+ * Best-effort machine-readable reason from a gateway error
+ * (kind > code > body.code > body.error). Shared by the wiring layer (to
+ * classify a rejection) and {@link isExpectedShareError} (to silence expected C8
+ * states from the generic bug toast). Pure + DOM-free so it stays in this
+ * unit-tested module.
+ *
+ * `body.code` is the SHIPPED gateway shape: the Go edge answers a business
+ * rejection as a FLAT `{error: "<human sentence>", code: "<machine code>"}`
+ * (e.g. `{error: "team needs upgrade", code: "needs_upgrade"}`), while
+ * `HoustonEngineError`'s own `.code` getter only reads the NESTED
+ * `{error: {code}}` form. Without this step every flat rejection classified as
+ * its English sentence, so `needs_upgrade` / `personal_space` / `already_member`
+ * silently fell through to the red "report a bug" toast.
  */
 export function shareErrorCode(err: unknown): string | undefined {
   const e = err as
-    | { kind?: unknown; code?: unknown; body?: { error?: unknown } }
+    | {
+        kind?: unknown;
+        code?: unknown;
+        body?: { code?: unknown; error?: unknown };
+      }
     | null
     | undefined;
   if (typeof e?.kind === "string") return e.kind;
   if (typeof e?.code === "string") return e.code;
+  if (typeof e?.body?.code === "string") return e.body.code;
   const bodyError = e?.body?.error;
   if (typeof bodyError === "string") return bodyError;
   const nested = (bodyError as { code?: unknown } | undefined)?.code;

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1951,6 +1951,24 @@ export const tauriOrg = {
     call<void>("delete_org_invite", () =>
       getEngine().deleteOrgInvite(inviteId),
     ),
+  /** C8: accept an invite addressed to the caller, joining that team. Distinct
+   *  from `deleteInvite` (the owner's revoke). Callers pass `silence` for the
+   *  expected gateway states they explain themselves (see `invite-model.ts`). */
+  acceptInvite: (inviteId: string, options?: EngineCallOptions) =>
+    call(
+      "accept_org_invite",
+      () => getEngine().acceptOrgInvite(inviteId),
+      undefined,
+      options,
+    ),
+  /** C8: decline an invite addressed to the caller. */
+  declineInvite: (inviteId: string, options?: EngineCallOptions) =>
+    call<void>(
+      "decline_org_invite",
+      () => getEngine().declineOrgInvite(inviteId),
+      undefined,
+      options,
+    ),
   removeMember: (userId: string) =>
     call("remove_org_member", () => getEngine().removeOrgMember(userId)),
   setMemberRole: (

--- a/app/src/locales/en/teams.json
+++ b/app/src/locales/en/teams.json
@@ -377,5 +377,28 @@
   "personalSpace": {
     "inviteBlockedTitle": "This is your personal space",
     "inviteBlockedBody": "Your personal space is just for you. Create a team to invite people."
+  },
+  "inviteInbox": {
+    "title": "Invitations",
+    "headline": "You were invited to join {{team}}",
+    "headlineFrom": "{{name}} invited you to {{team}}",
+    "asRole": "You will join as {{role}}.",
+    "accept": "Accept",
+    "decline": "Decline",
+    "acceptLabel": "Accept the invitation to {{team}}",
+    "declineLabel": "Decline the invitation to {{team}}",
+    "railLabel_one": "{{count}} pending invitation",
+    "railLabel_other": "{{count}} pending invitations",
+    "joinedTitle": "You joined {{team}}",
+    "joinedBody": "Switch to it any time from the space menu at the top of the sidebar.",
+    "joinedBodyUnconfirmed": "We could not refresh your spaces just now. Open the space menu again in a moment to find it.",
+    "errors": {
+      "needsUpgradeTitle": "This team needs an upgrade",
+      "needsUpgradeBody": "Its trial ended, so it cannot add people right now. Ask the person who invited you to upgrade, then accept again.",
+      "alreadyMemberTitle": "You are already in this team",
+      "alreadyMemberBody": "Nothing to do. Find it in the space menu at the top of the sidebar.",
+      "goneTitle": "This invitation is no longer available",
+      "goneBody": "It was withdrawn or already used. Ask your team to send a new one."
+    }
   }
 }

--- a/app/src/locales/es/teams.json
+++ b/app/src/locales/es/teams.json
@@ -377,5 +377,28 @@
   "personalSpace": {
     "inviteBlockedTitle": "Este es tu espacio personal",
     "inviteBlockedBody": "Tu espacio personal es solo para ti. Crea un equipo para invitar a otras personas."
+  },
+  "inviteInbox": {
+    "title": "Invitaciones",
+    "headline": "Te invitaron a unirte a {{team}}",
+    "headlineFrom": "{{name}} te invitó a {{team}}",
+    "asRole": "Te unirás como {{role}}.",
+    "accept": "Aceptar",
+    "decline": "Rechazar",
+    "acceptLabel": "Aceptar la invitación a {{team}}",
+    "declineLabel": "Rechazar la invitación a {{team}}",
+    "railLabel_one": "{{count}} invitación pendiente",
+    "railLabel_other": "{{count}} invitaciones pendientes",
+    "joinedTitle": "Te uniste a {{team}}",
+    "joinedBody": "Cambia a ese espacio cuando quieras desde el menú de espacios, arriba en la barra lateral.",
+    "joinedBodyUnconfirmed": "No pudimos actualizar tus espacios en este momento. Abre el menú de espacios en un momento para encontrarlo.",
+    "errors": {
+      "needsUpgradeTitle": "Este equipo necesita mejorar su plan",
+      "needsUpgradeBody": "Su prueba terminó, así que no puede sumar personas ahora. Pídele a quien te invitó que mejore el plan y vuelve a aceptar.",
+      "alreadyMemberTitle": "Ya estás en este equipo",
+      "alreadyMemberBody": "No hay nada que hacer. Encuéntralo en el menú de espacios, arriba en la barra lateral.",
+      "goneTitle": "Esta invitación ya no está disponible",
+      "goneBody": "Se canceló o ya se usó. Pídele a tu equipo que te envíe una nueva."
+    }
   }
 }

--- a/app/src/locales/pt/teams.json
+++ b/app/src/locales/pt/teams.json
@@ -377,5 +377,28 @@
   "personalSpace": {
     "inviteBlockedTitle": "Este é o seu espaço pessoal",
     "inviteBlockedBody": "Seu espaço pessoal é só para você. Crie uma equipe para convidar pessoas."
+  },
+  "inviteInbox": {
+    "title": "Convites",
+    "headline": "Você foi convidado para entrar em {{team}}",
+    "headlineFrom": "{{name}} convidou você para {{team}}",
+    "asRole": "Você vai entrar como {{role}}.",
+    "accept": "Aceitar",
+    "decline": "Recusar",
+    "acceptLabel": "Aceitar o convite para {{team}}",
+    "declineLabel": "Recusar o convite para {{team}}",
+    "railLabel_one": "{{count}} convite pendente",
+    "railLabel_other": "{{count}} convites pendentes",
+    "joinedTitle": "Você entrou em {{team}}",
+    "joinedBody": "Mude para esse espaço quando quiser pelo menu de espaços, no topo da barra lateral.",
+    "joinedBodyUnconfirmed": "Não foi possível atualizar seus espaços agora. Abra o menu de espaços daqui a pouco para encontrar a equipe.",
+    "errors": {
+      "needsUpgradeTitle": "Esta equipe precisa de um upgrade",
+      "needsUpgradeBody": "O teste dela terminou, então ela não pode receber pessoas agora. Peça para quem convidou você fazer o upgrade e aceite de novo.",
+      "alreadyMemberTitle": "Você já está nesta equipe",
+      "alreadyMemberBody": "Não há nada a fazer. Encontre a equipe no menu de espaços, no topo da barra lateral.",
+      "goneTitle": "Este convite não está mais disponível",
+      "goneBody": "Ele foi cancelado ou já foi usado. Peça um novo convite para a sua equipe."
+    }
   }
 }

--- a/app/tests/invite-model.test.ts
+++ b/app/tests/invite-model.test.ts
@@ -1,0 +1,233 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { OrgInviteSummary } from "@houston-ai/engine-client";
+import {
+  classifyInviteError,
+  createInviteActionLock,
+  inviterDisplayName,
+  isExpectedInviteError,
+  sortInvites,
+  teamIsInSwitcher,
+  visibleInvites,
+} from "../src/lib/invite-model.ts";
+
+/**
+ * The invitee side of C8 invites. The error cases are written against the
+ * SHIPPED gateway body — a flat `{error: "<sentence>", code: "<code>"}` thrown
+ * as a `HoustonEngineError`-shaped object — because that is the only shape
+ * production ever produces; classifying on the English sentence would silently
+ * send every expected state to the red "report a bug" toast.
+ */
+function gatewayError(status: number, error: string, code?: string) {
+  return { status, body: code === undefined ? { error } : { error, code } };
+}
+
+describe("classifyInviteError", () => {
+  it("classifies the shipped flat {error, code} gateway bodies", () => {
+    strictEqual(
+      classifyInviteError(
+        gatewayError(403, "team needs upgrade", "needs_upgrade"),
+      ),
+      "needs_upgrade",
+    );
+    strictEqual(
+      classifyInviteError(
+        gatewayError(
+          409,
+          "that user is already a member of this organization",
+          "already_member",
+        ),
+      ),
+      "already_member",
+    );
+    strictEqual(
+      classifyInviteError(
+        gatewayError(404, "invite not found", "invite_not_found"),
+      ),
+      "invite_not_found",
+    );
+  });
+
+  it("classifies a bare code and a code-as-error body", () => {
+    strictEqual(
+      classifyInviteError({ code: "needs_upgrade" }),
+      "needs_upgrade",
+    );
+    strictEqual(
+      classifyInviteError({ body: { error: "already_member" } }),
+      "already_member",
+    );
+  });
+
+  it("treats anything else as unknown (keeps the standard bug toast)", () => {
+    strictEqual(classifyInviteError(gatewayError(500, "boom")), "unknown");
+    strictEqual(classifyInviteError(new Error("network")), "unknown");
+    strictEqual(classifyInviteError(null), "unknown");
+    strictEqual(classifyInviteError(undefined), "unknown");
+  });
+});
+
+describe("isExpectedInviteError", () => {
+  it("is true for exactly the three explained states", () => {
+    strictEqual(
+      isExpectedInviteError(
+        gatewayError(403, "team needs upgrade", "needs_upgrade"),
+      ),
+      true,
+    );
+    strictEqual(
+      isExpectedInviteError(
+        gatewayError(404, "invite not found", "invite_not_found"),
+      ),
+      true,
+    );
+    strictEqual(isExpectedInviteError(gatewayError(500, "boom")), false);
+  });
+});
+
+describe("inviterDisplayName", () => {
+  it("suppresses an opaque handle (the shipped invitedBy is a user id)", () => {
+    strictEqual(inviterDisplayName("a1b2c3d4e5f6"), null);
+    strictEqual(inviterDisplayName("auth0|9f8e7d"), null);
+  });
+
+  it("passes through anything a human can read", () => {
+    strictEqual(inviterDisplayName("ana@acme.com"), "ana@acme.com");
+    strictEqual(inviterDisplayName("Ana Lima"), "Ana Lima");
+  });
+
+  it("treats blank and absent alike", () => {
+    strictEqual(inviterDisplayName(undefined), null);
+    strictEqual(inviterDisplayName("   "), null);
+  });
+});
+
+describe("sortInvites", () => {
+  const invite = (id: string, orgName: string): OrgInviteSummary => ({
+    id,
+    orgName,
+    role: "user",
+  });
+
+  it("orders by team name, then id, without mutating the input", () => {
+    const input = [
+      invite("b", "Zeta"),
+      invite("c", "Acme"),
+      invite("a", "Acme"),
+    ];
+    deepStrictEqual(
+      sortInvites(input).map((i) => i.id),
+      ["a", "c", "b"],
+    );
+    deepStrictEqual(
+      input.map((i) => i.id),
+      ["b", "c", "a"],
+    );
+  });
+});
+
+describe("createInviteActionLock", () => {
+  // Accept and Decline are separate mutations behind separate AsyncButtons, and
+  // AsyncButton's rage-click guard is PER BUTTON. A rapid Accept -> Decline in
+  // the same frame therefore fired BOTH requests, and whichever lost the race
+  // came back `already_member` / `invite_not_found` and toasted nonsense at a
+  // user who had done nothing wrong. The lock is claimed SYNCHRONOUSLY, before
+  // either mutation starts, so the second click can never open a second call.
+  it("lets only the first claim through for one invite", () => {
+    const lock = createInviteActionLock();
+    strictEqual(lock.claim("inv-1"), true);
+    strictEqual(lock.claim("inv-1"), false);
+    strictEqual(lock.claim("inv-1"), false);
+  });
+
+  it("frees the invite again on release (a failed action is retryable)", () => {
+    const lock = createInviteActionLock();
+    strictEqual(lock.claim("inv-1"), true);
+    lock.release("inv-1");
+    strictEqual(lock.claim("inv-1"), true);
+  });
+
+  it("locks each invite independently", () => {
+    const lock = createInviteActionLock();
+    strictEqual(lock.claim("inv-1"), true);
+    strictEqual(lock.claim("inv-2"), true);
+    strictEqual(lock.claim("inv-1"), false);
+    lock.release("inv-1");
+    strictEqual(lock.claim("inv-1"), true);
+    strictEqual(lock.claim("inv-2"), false);
+  });
+
+  it("ignores a release for an invite it never held", () => {
+    const lock = createInviteActionLock();
+    lock.release("never-claimed");
+    strictEqual(lock.claim("never-claimed"), true);
+  });
+});
+
+describe("visibleInvites", () => {
+  const invite = (id: string, orgName: string): OrgInviteSummary => ({
+    id,
+    orgName,
+    role: "user",
+  });
+
+  // Disabling a React Query does NOT clear its cached data. A session that
+  // loses the Spaces capability (sign-out into a non-spaces deployment, a
+  // capability refetch that drops `spaces`) kept rendering the invites from the
+  // last fetch, and acting on one hit an off-cloud mutator that throws
+  // "Joining a team needs the hosted gateway" as a red bug toast. The RENDER is
+  // gated on the capability, not just the fetch.
+  it("renders nothing when the host does not serve spaces", () => {
+    deepStrictEqual(visibleInvites(false, [invite("a", "Acme")]), []);
+  });
+
+  // `hasSpaces(null)` is false while capabilities are in flight, so the same
+  // gate also means "no flash before the deployment describes itself".
+  it("renders nothing before capabilities resolve", () => {
+    deepStrictEqual(visibleInvites(false, []), []);
+  });
+
+  it("sorts the invites through when spaces are served", () => {
+    deepStrictEqual(
+      visibleInvites(true, [invite("b", "Zeta"), invite("a", "Acme")]).map(
+        (i) => i.id,
+      ),
+      ["a", "b"],
+    );
+  });
+});
+
+describe("teamIsInSwitcher", () => {
+  // `loadWorkspaces()` swallows its own failure (it only records `loadError`),
+  // so awaiting it proves NOTHING about the switcher. The joined-team toast
+  // used to promise "switch to it any time from the space menu" off that bare
+  // await, which lies whenever the refresh failed. The promise is now made only
+  // when the team is actually IN the reloaded list.
+  const ws = (id: string) => ({ id, name: "n" });
+
+  it("is true once the team bridged in as its org:<slug> row", () => {
+    strictEqual(
+      teamIsInSwitcher(
+        [ws("default"), ws("org:0123456789abcdef")],
+        "0123456789abcdef",
+      ),
+      true,
+    );
+  });
+
+  it("is false when the refresh did not bring the team in", () => {
+    strictEqual(teamIsInSwitcher([ws("default")], "0123456789abcdef"), false);
+    strictEqual(teamIsInSwitcher([], "0123456789abcdef"), false);
+  });
+
+  it("never matches a personal row or a different team", () => {
+    strictEqual(
+      teamIsInSwitcher([ws("org:fedcba9876543210")], "0123456789abcdef"),
+      false,
+    );
+    strictEqual(
+      teamIsInSwitcher([ws("0123456789abcdef")], "0123456789abcdef"),
+      false,
+    );
+  });
+});

--- a/app/tests/team-status-model.test.ts
+++ b/app/tests/team-status-model.test.ts
@@ -139,6 +139,20 @@ describe("isNeedsUpgradeError", () => {
     );
   });
 
+  // The SHIPPED gateway body: a flat `{error: "<sentence>", code}`. The
+  // `HoustonEngineError.code` getter only reads the NESTED `{error:{code}}`
+  // form, so without `shareErrorCode` reading `body.code` this rejection
+  // classified as its English sentence and fell through to the red bug toast.
+  it("matches the flat {error, code} body the Go gateway sends", () => {
+    strictEqual(
+      isNeedsUpgradeError({
+        status: 403,
+        body: { error: "team needs upgrade", code: "needs_upgrade" },
+      }),
+      true,
+    );
+  });
+
   it("ignores other errors", () => {
     strictEqual(isNeedsUpgradeError({ code: "not_owner" }), false);
     strictEqual(isNeedsUpgradeError(new Error("boom")), false);
@@ -151,6 +165,19 @@ describe("isPersonalSpaceError", () => {
     strictEqual(isPersonalSpaceError({ code: "personal_space" }), true);
     strictEqual(
       isPersonalSpaceError({ body: { error: "personal_space" } }),
+      true,
+    );
+  });
+
+  it("matches the flat {error, code} body the Go gateway sends", () => {
+    strictEqual(
+      isPersonalSpaceError({
+        status: 403,
+        body: {
+          error: "a personal space cannot have members",
+          code: "personal_space",
+        },
+      }),
       true,
     );
   });

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -368,9 +368,9 @@ contract: `cloud/docs/contracts/C8-spaces-billing.md`.
 Wire types in `ui/engine-client/src/types.ts` (`OrgSummary`, `OrgInviteSummary`,
 `OrgsList`, `BillingSummary`, `BillingCheckout`, `AgentMoveStart`,
 `AgentMoveStatus`, `Workspace.kind`). Client methods in `client.ts`: `listOrgs`,
-`createOrg`, `moveAgent`, `getMoveStatus`, `acceptInvite`, `declineInvite`,
-`getBilling`, `createCheckout`, `createPortal`, plus `setActiveOrg` (the
-active-space pin, below).
+`createOrg`, `moveAgent`, `getMoveStatus`, `acceptOrgInvite`,
+`declineOrgInvite`, `getBilling`, `createCheckout`, `createPortal`, plus
+`setActiveOrg` (the active-space pin, below).
 
 ### The switcher (`org:<slug>` workspace bridge)
 
@@ -553,6 +553,111 @@ success `useCreateTeam` (`app/src/hooks/queries/use-orgs.ts`) invalidates the
 spaces list and reloads the workspace store so the new team bridges in as an
 `org:*` workspace. `POST /v1/orgs` is NOT idempotent: a lost response is
 reconciled via `listOrgs` (`reconcileCreatedTeam`), never blind-retried.
+
+### Invite inbox (the INVITEE side)
+
+The auto-join only fires on an account's FIRST-EVER contact with the gateway, so
+for every EXISTING user a pending invite is inert until they answer it. That
+answer lives directly under the workspace switcher, in the sidebar's
+`headerBelow` band (`AppSidebar`, `ui/layout/src/sidebar.tsx`):
+
+- **Where** — `app/src/components/shell/pending-invites.tsx` (+ the row itself,
+  `invite-card.tsx`). `SidebarInviteInbox` is the mounted container (it owns the
+  capability + query gate, so the switcher header stays about switching spaces);
+  `PendingInviteList` renders one always-visible `InviteCard` per invite (team
+  name, the role you'd join as, Accept + Decline) directly beneath the switcher;
+  on the COLLAPSED rail
+  `PendingInvitesRailButton` renders a labelled count that expands the sidebar
+  onto the real cards. Deliberately NOT inside the switcher's dropdown and never
+  hover-gated: an invitation is the one thing on this surface the user has not
+  been told about, so it may not hide behind a click.
+- **Its own full-width row, NOT the header slot** — expanded, the sidebar header
+  shares its line with the collapse toggle (`flex items-center`), so cards
+  rendered inside `header` were inset by the toggle's column (right edge out of
+  line with every row below) AND dragged the vertically-centred toggle down to
+  the middle of the card stack. `AppSidebar` therefore takes a separate
+  `headerBelow` slot that spans the rail; `header` is the switcher again.
+- **Bounded, and bounded at a card boundary** — the list scrolls inside itself
+  (`max-h-72`): the sidebar header is a fixed non-scrolling region above the nav,
+  so an unbounded list would push the navigation down and get clipped by the
+  rail's `overflow-hidden`. The bound shows two WHOLE cards plus the TOP of a
+  third — at the earlier `max-h-52` the cut fell through the second card's own
+  Accept / Decline row, which reads as a rendering fault rather than "scroll for
+  more" (macOS overlay scrollbars show nothing until you scroll). Team names
+  carry `break-words` **and `line-clamp-3`**: the gateway allows 200 characters,
+  possibly one unbroken token, which otherwise wrapped to a dozen lines and
+  pushed a lone invitation's buttons below the fold (the full name stays in the
+  DOM and in `title`).
+- **Spaces-gated on BOTH sides** — the fetch via `useOrgs(hasSpaces(caps))`, the
+  RENDER via `visibleInvites(spacesEnabled, …)` (`invite-model.ts`). Gating only
+  the fetch is a bug: disabling a React Query does NOT clear its cache, so a
+  session that loses the capability keeps painting the last fetch's invites over
+  a deployment whose mutators throw off-cloud. `hasSpaces(null)` is false while
+  capabilities load, so the same gate is the no-flash-on-boot rule.
+- **Accept and Decline exclude each other** — `createInviteActionLock()`
+  (`invite-model.ts`), one lock per list, keyed by invite id, claimed
+  SYNCHRONOUSLY before either mutation starts and released in a `finally`.
+  `AsyncButton`'s rage-click guard is per BUTTON and the `busy` prop only lands
+  on the next commit, so a rapid Accept then Decline in one frame fired both
+  calls and the loser toasted `already_member` / `invite_not_found` at a user
+  who did nothing wrong.
+- **Who invited you is usually NOT shown, on purpose.**
+  `OrgInviteSummary.invitedBy` is the inviter's USER ID on the shipped gateway
+  (`principal.UserID`), and the invitee is not in that org yet, so no
+  client-side read can resolve it (`GET /v1/org/profiles` is scoped to
+  co-members of the ACTIVE space). `inviterDisplayName`
+  (`app/src/lib/invite-model.ts`) therefore shows the inviter ONLY when the
+  value is human-readable (an email or a name with whitespace) and falls back to
+  naming the TEAM alone. If the gateway ever sends a display name/email in that
+  field, the card names the inviter with no client change.
+- **Hooks** — `useAcceptInvite` / `useDeclineInvite`
+  (`app/src/hooks/queries/use-invites.ts`). Both invalidate `queryKeys.orgs()`
+  on BOTH paths, not just on success: `already_member` and `invite_not_found`
+  mean the server's truth already moved on, so the stale card must vanish either
+  way. The invalidation fires FIRST and is never awaited behind the workspace
+  reload, so the answered card leaves the sidebar immediately. Accept then
+  awaits `loadWorkspaces()` — a joined team reaches the switcher through
+  `GET /v1/workspaces`, a Zustand store no invalidation can reach. That reload
+  **swallows its own failure** (it only records `loadError`), so the toast asks
+  `teamIsInSwitcher(store.workspaces, org.slug)` before promising anything:
+  confirmed ⇒ "switch to it from the space menu" (`joinedBody`), unconfirmed ⇒
+  `joinedBodyUnconfirmed`, which says the refresh did not land instead of
+  pointing at a menu the team may not be in. **Nothing switches the active
+  space**: joining is not going there (unlike create-team, where the user asked
+  for a new home).
+- **Error taxonomy** — `invite-model.ts` `classifyInviteError` /
+  `isExpectedInviteError`: `403 needs_upgrade` (the team's trial ended; the
+  invite STAYS, an upgrade makes it acceptable again), `409 already_member`,
+  `404 invite_not_found` (revoked, used, or addressed to another email — the
+  gateway deliberately cannot tell them apart). Each is silenced from `call()`'s
+  red bug toast and gets ONE plain informational toast instead
+  (`teams:inviteInbox.errors.*`); anything else keeps the standard toast +
+  Sentry report. `needs_upgrade` gets its own invitee-shaped copy rather than
+  the generic `degrade.writeBlocked*` write-block toast.
+- **Wire** — `acceptOrgInvite` / `declineOrgInvite` in
+  `packages/web/src/engine-adapter/cp/spaces-billing.ts` (+ the mixin and the
+  `ui/engine-client` shim), app wrappers `tauriOrg.acceptInvite` /
+  `tauriOrg.declineInvite`. The routes are the CROSS-org
+  `POST /v1/org-invites/:id/accept` (`201 {org}`, unwrapped by the client) and
+  `DELETE /v1/org-invites/:id` (`204`) — NOT the org-scoped
+  `DELETE /v1/org/invites/:id`, which is the OWNER's revoke (`deleteOrgInvite` /
+  `useDeleteInvite`). Neither degrades: every rejection is a state the invitee
+  must see. Tests: `app/tests/invite-model.test.ts`,
+  `packages/web/tests/org-invites.test.ts`,
+  `ui/engine-client/tests/client-teams.test.ts`, and the end-to-end
+  `packages/web/e2e/team-invites.spec.ts` (render + placement, accept joins the
+  team into the switcher, decline, the non-red `needs_upgrade` toast, the
+  revoked-invite disappearance, the collapsed rail count, and the
+  capability-off no-render) against the fake host's C8 routes — armed with
+  `/__test__/space-invites` (`knowledge-base/ui-testing.md`).
+
+> **Gateway error bodies are FLAT `{error, code}`.** `shareErrorCode`
+> (`app/src/lib/share-via-team.ts`) now reads `body.code`, because
+> `HoustonEngineError.code` only understands the NESTED `{error: {code}}` shape.
+> Until that fix every flat rejection classified as its English SENTENCE, so
+> `needs_upgrade` / `personal_space` / `already_member` fell through to the red
+> "report a bug" toast in production while the unit tests (written against
+> synthetic `{code}` objects) stayed green.
 
 ### Share-via-team pipeline (order is law)
 
@@ -892,10 +997,11 @@ unlikely.
   > **C8 changed acceptance.** The old "one-org-per-user, consumed atomically at
   > first sign-in" rule is gone: a user can belong to many teams. A NEW user's
   > pending invites auto-accept oldest-first after the personal space is minted;
-  > an EXISTING user accepts explicitly via `acceptInvite` / declines via
-  > `declineInvite` (invites addressed to them ride `GET /v1/orgs`'s `invites`,
-  > `OrgInviteSummary`). Personal is ALWAYS minted, never replaced. See the
-  > **Spaces** section and `cloud/docs/contracts/C8-spaces-billing.md`.
+  > an EXISTING user accepts explicitly via `acceptOrgInvite` / declines via
+  > `declineOrgInvite` (invites addressed to them ride `GET /v1/orgs`'s
+  > `invites`, `OrgInviteSummary`). Personal is ALWAYS minted, never replaced.
+  > The invitee-side surface is **Spaces > Invite inbox** below; see also
+  > `cloud/docs/contracts/C8-spaces-billing.md`.
 - **Member emails** — `OrgMember.email` populated on `GET /org` when the host
   exposes it; the roster shows them.
 - **Audit** — `orgAudit({limit?, before?})` → `AuditEntry[]` newest-first

--- a/knowledge-base/ui-testing.md
+++ b/knowledge-base/ui-testing.md
@@ -102,6 +102,18 @@ e2e in an `_agent-tasks/<id>/` worktree, pick distinct ports:
   (agent ∩ org) splits the browse catalog into connectable vs locked rows
   (`integrations-locked.spec.ts`). `SEED_TOOLKIT_SLUGS` (15 A-Z apps) is exported
   for specs arming allowlists over the catalog.
+- **C8 Spaces is armable end to end.** The fake host serves the cross-org
+  surface (`fake-host/routes-spaces.ts`): `GET /v1/orgs` → `{orgs, invites}`,
+  `POST /v1/orgs`, and the INVITEE's `POST /v1/org-invites/:id/accept` (201
+  `{org}`) / `DELETE /v1/org-invites/:id` (204). Memberships have ONE source of
+  truth — the team-space rows `/v1/workspaces` bridges — so an accepted invite
+  lands in the switcher AND in `orgs` in one move. `POST /__test__/space-invites`
+  (`{invites:[{orgName, role?, invitedBy?, orgSlug?, id?, reject?}]}`) arms the
+  inbox; `reject` forces that invite's `needs_upgrade` (403) / `already_member`
+  (409) / `invite_not_found` (404), whose bodies are the gateway's flat
+  `{error, code}` — the shape the client's invite taxonomy reads. The sidebar
+  cards are capability-gated on the CLIENT, so pair with
+  `/__test__/capabilities` `{spaces:true}` (`team-invites.spec.ts`).
 
 ## CI
 

--- a/packages/fake-host/README.md
+++ b/packages/fake-host/README.md
@@ -74,6 +74,7 @@ They drive the failure/reactivity scenarios the specs assert against:
 | `/__test__/agent-settings` | `{ allowedToolkits?, orgAllowedToolkits?, allowedModels?, access? }` | Set the Teams v2 ceilings served at `/v1/agents/:slug/settings` + `/v1/org/settings` (`allowedToolkits`/`orgAllowedToolkits`: `null` = unrestricted, `[]` = none). The `effectiveAllowlist` = agent ∩ org drives the tab's connectable-vs-locked partition. Returns the merged settings. |
 | `/__test__/org` | `{ members?: [{ userId, email?, role, displayName?, photoUrl? }], agents?: [...] }` | Arm the org roster `GET /v1/org` serves (owner/admin only) and the co-member directory `GET /v1/org/people` serves to EVERY member. `displayName`/`photoUrl` are the stored GCIP profile: a member without a `displayName` is still served, and the client decides who is @mentionable. Arming also SEEDS the identity-provider fallback behind `/v1/me/profile` from the `u-self` row, so clearing a custom name/photo has something honest to fall back to. Pair with `/__test__/capabilities` `{ multiplayer:true, teams:true, role:"owner" }`. Returns `{ members, agents }`. |
 | `/__test__/workspaces` | `{ teams: [{ slug, name }] }` | Arm the team-space rows the C8 Spaces workspaces bridge serves at `GET /v1/workspaces` (alongside the always-present personal seed row). Each `slug` (exactly `[a-f0-9]{16}`) becomes an `{ id:"org:<slug>", kind:"org" }` switcher row. Pair with `/__test__/capabilities` `{ spaces:true }`. `{ teams: [] }` (and reset) restores personal-only. Returns the armed `{ teams }`. |
+| `/__test__/space-invites` | `{ invites: [{ orgName, role?, invitedBy?, orgSlug?, id?, reject? }] }` | Arm the INVITEE-side invite inbox `GET /v1/orgs` surfaces in `invites` (C8 Spaces) — the sidebar cards under the workspace switcher. Only `orgName` is required (`role` defaults to `user`, the id and the 16-hex `orgSlug` the accepted team lands under are minted). `invitedBy` is the raw gateway field: the card names the inviter only when it is human-readable (an email, or a name with whitespace). `reject` forces THAT invite's answer — `needs_upgrade` (403, invite kept), `already_member` (409, invite kept), `invite_not_found` (404, invite dropped: the revoked-behind-your-back case). The card is capability-gated on the CLIENT, so pair with `/__test__/capabilities` `{ spaces:true }`. `{ invites: [] }` (and reset) empties the inbox. Returns the normalized `{ invites }`. |
 | `/__test__/provider-usage` | `{ rows: ProviderUsage[] \| null }` | Arm the live per-account usage `GET /providers/usage` serves — what the AI Models hub's Connected rows meter with (windows, plan, credits, metered tokens, and the honest `unsupported`/`unauthenticated`/`error` rows). `null` (and reset) restores the default seed: the connected Claude subscription on plan `max`, its session window 42% used and its weekly 12%. Returns the served `{ rows }`. |
 | `/__test__/compute-usage` | `{ seed: { rows, awakeNow } \| null }` | Arm the per-agent running-time dataset `GET /v1/org/compute-usage` serves (Settings > Time worked). `null` (the default) 404s the route, mirroring desktop/self-host. Pair with `/__test__/capabilities` `{ computeUsage:true }`. Returns `{ seed }`. |
 
@@ -107,6 +108,18 @@ They drive the failure/reactivity scenarios the specs assert against:
   `POST /v1/org/members` (invite path: an unknown email mints a pending invite,
   `202 { invited:true }`, then surfaced in `/v1/org`'s `invites`;
   `DELETE /v1/org/invites/:id` revokes).
+- `/v1/orgs` + `/v1/org-invites/*` — the C8 Spaces CROSS-org surface, which
+  ignores the `x-houston-org` active-space pin: `GET /v1/orgs` →
+  `{orgs, invites}` (every team the caller belongs to, plus every pending invite
+  addressed to them), `POST /v1/orgs {name}` → `201 OrgSummary` (mints a team,
+  caller = owner), `POST /v1/org-invites/:id/accept` → `201 {org}` and
+  `DELETE /v1/org-invites/:id` → `204` (the INVITEE's own accept/decline — not
+  the owner's revoke at `/v1/org/invites/:id`). Memberships have one source of
+  truth: the same team-space rows `/v1/workspaces` bridges, so accepting an
+  invite puts the team in the switcher and in `orgs` at once. The rejection
+  bodies are flat `{error, code}`, exactly as the Go gateway writes them —
+  that `code` is what the client's invite taxonomy reads. Arm the inbox with
+  `/__test__/space-invites`.
 - `/v1/agents/:slug/settings` + `/v1/org/settings` (Teams v2, the gateway-only
   allowlist/model ceilings `getAgentSettings` / `getOrgSettings` read; GET + the
   manager/owner PUT). Seeded unrestricted; armed by `/__test__/agent-settings`.

--- a/packages/fake-host/src/router.ts
+++ b/packages/fake-host/src/router.ts
@@ -24,6 +24,7 @@ import { handleUserRoutes } from "./routes-integrations";
 import { handleMeRoutes } from "./routes-me";
 import { handleSetupRuntime } from "./routes-setup-runtime";
 import { handleSharedSkillsRoutes } from "./routes-shared-skills";
+import { handleSpaceInvitesControl, handleSpacesRoutes } from "./routes-spaces";
 import { handleTeamsRoutes } from "./routes-teams";
 import { sseResponse } from "./sse";
 import type { FakeCapabilities, TeamsSettings } from "./state";
@@ -246,6 +247,17 @@ export async function handle(req: Request): Promise<Response> {
     });
     return json({ teams: state.setTeamWorkspaces(rows) });
   }
+  // Arm the invitee-side invite inbox `GET /v1/orgs` surfaces in `invites` (C8
+  // Spaces): `{ invites: [{ orgName, role?, invitedBy?, orgSlug?, id?,
+  // reject? }] }`. Only `orgName` is required. `reject` forces that invite's
+  // accept/decline rejection (`needs_upgrade` 403 / `already_member` 409 /
+  // `invite_not_found` 404) so the error paths are reachable. Pair with
+  // `/__test__/capabilities` `{ spaces:true }` — the sidebar card is
+  // capability-gated on the CLIENT, not here. `{ invites: [] }` (and reset)
+  // empties the inbox.
+  if (path === "/__test__/space-invites" && method === "POST") {
+    return handleSpaceInvitesControl(await parseBody(req));
+  }
   // Seed a connection at a status the UI can't be clicked into: `pending` (an
   // abandoned sign-in) or `error` (the provider refused). `{toolkit, status}`.
   if (path === "/__test__/integrations-connection" && method === "POST") {
@@ -316,6 +328,10 @@ export async function handle(req: Request): Promise<Response> {
   // --- Teams v2 gateway routes (agent + org settings / allowlist ceilings) ---
   const teamsRoute = handleTeamsRoutes(method, segs, body, url);
   if (teamsRoute) return teamsRoute;
+
+  // --- C8 Spaces gateway routes (the cross-org list + the invitee's inbox) ---
+  const spacesRoute = handleSpacesRoutes(method, segs, body);
+  if (spacesRoute) return spacesRoute;
 
   // --- the caller's own editable display profile (name + photo) ---
   const meRoute = handleMeRoutes(method, segs, body);

--- a/packages/fake-host/src/routes-spaces.ts
+++ b/packages/fake-host/src/routes-spaces.ts
@@ -1,0 +1,185 @@
+/**
+ * C8 Spaces gateway routes for the fake host — the CROSS-org surface, a port of
+ * `cloud/internal/edge/spaces_routes.go`. Unlike `/v1/org` (scoped to the ACTIVE
+ * space via `x-houston-org`), these enumerate and mutate memberships regardless
+ * of the active-space pin:
+ *
+ *   - `GET  /v1/orgs`                      → `{orgs, invites}`
+ *   - `POST /v1/orgs {name}`               → `OrgSummary` (201, caller = owner)
+ *   - `POST /v1/org-invites/:id/accept`    → `{org}` (201, the invitee joins)
+ *   - `DELETE /v1/org-invites/:id`         → 204 (the invitee declines)
+ *
+ * The rejection BODIES are byte-shaped like the Go gateway's — a flat
+ * `{error, code}` — because the client's taxonomy reads that `code`
+ * (`app/src/lib/invite-model.ts` `classifyInviteError` via `shareErrorCode`).
+ * Nest it and every expected state would fall through to the red bug toast.
+ *
+ * Which invite answers which rejection is armed per invite
+ * (`FakeSpaceInvite.reject`, the `/__test__/space-invites` control), so the
+ * error paths are reachable without racing a real state change.
+ */
+
+import { json, noContent } from "./http";
+import * as state from "./state";
+import type {
+  FakeSpaceInvite,
+  OrgRole,
+  SpaceInviteRejection,
+} from "./state-store";
+
+const ORG_ROLES: readonly OrgRole[] = ["owner", "admin", "user"];
+const REJECTIONS: readonly SpaceInviteRejection[] = [
+  "needs_upgrade",
+  "already_member",
+  "invite_not_found",
+];
+
+/** A 16-lowercase-hex slug (the `org:<slug>` grammar `space-id.ts` enforces). */
+function isSlug(value: unknown): value is string {
+  return typeof value === "string" && /^[a-f0-9]{16}$/.test(value);
+}
+
+function pick<T extends string>(value: unknown, allowed: readonly T[]) {
+  return allowed.find((option) => option === value);
+}
+
+/**
+ * The `POST /__test__/space-invites` control: normalize its payload into the
+ * invitee-side inbox, replacing whatever was armed before. Only `orgName` is
+ * required — the id, the slug the accepted team lands under, and the role all
+ * default, so arming "one pending invite" is one field. A row with no usable
+ * team name is DROPPED rather than served nameless: a card headlined "You were
+ * invited to join " would be a fixture bug wearing a product bug's clothes.
+ *
+ * It lives beside the routes it arms (as `routes-teams.ts` keeps its own body
+ * parsers) so the whole C8 Spaces fixture reads in one place.
+ */
+export function handleSpaceInvitesControl(
+  body: Record<string, unknown> | undefined,
+): Response {
+  const rows = Array.isArray(body?.invites) ? body.invites : [];
+  const invites = rows.flatMap<FakeSpaceInvite>((raw, index) => {
+    const row = raw as Record<string, unknown>;
+    const orgName = typeof row?.orgName === "string" ? row.orgName : "";
+    if (!orgName) return [];
+    const reject = pick(row.reject, REJECTIONS);
+    return [
+      {
+        id: typeof row.id === "string" ? row.id : `space-invite-${index + 1}`,
+        orgName,
+        orgSlug: isSlug(row.orgSlug) ? row.orgSlug : state.mintTeamSlug(),
+        role: pick(row.role, ORG_ROLES) ?? "user",
+        ...(typeof row.invitedBy === "string"
+          ? { invitedBy: row.invitedBy }
+          : {}),
+        ...(reject ? { reject } : {}),
+      },
+    ];
+  });
+  return json({ invites: state.setSpaceInvites(invites) });
+}
+
+/** `403 needs_upgrade` — the team's trial ended; the invite is KEPT. */
+function needsUpgrade(): Response {
+  return json({ error: "team needs upgrade", code: "needs_upgrade" }, 403);
+}
+
+/** `409 already_member` — the caller is in that team already; invite KEPT. */
+function alreadyMember(): Response {
+  return json(
+    {
+      error: "that user is already a member of this organization",
+      code: "already_member",
+    },
+    409,
+  );
+}
+
+/**
+ * `404 invite_not_found` — revoked, already used, or addressed to another
+ * email. The gateway deliberately cannot tell those apart (it looks the invite
+ * up by the caller's verified email), so neither can this.
+ */
+function inviteNotFound(): Response {
+  return json({ error: "invite not found", code: "invite_not_found" }, 404);
+}
+
+/**
+ * Accept: the invite leaves the inbox and its team becomes a membership,
+ * answered as `201 {org}`. A forced `invite_not_found` also drops the invite —
+ * that models the revoked-between-fetch-and-click case, and the refetch is what
+ * makes the stale card disappear.
+ */
+function acceptInvite(inviteId: string): Response {
+  const invite = state.findSpaceInvite(inviteId);
+  if (!invite) return inviteNotFound();
+  if (invite.reject === "invite_not_found") {
+    state.removeSpaceInvite(inviteId);
+    return inviteNotFound();
+  }
+  if (invite.reject === "already_member") return alreadyMember();
+  if (invite.reject === "needs_upgrade") return needsUpgrade();
+  return json({ org: state.acceptSpaceInvite(invite) }, 201);
+}
+
+/**
+ * Decline: the invite is dropped, `204`. Billing never gates a decline (no seat
+ * is added), so `needs_upgrade` / `already_member` are not modelled here — only
+ * the gone case, which 404s exactly as the gateway's missing-invite path does.
+ */
+function declineInvite(inviteId: string): Response {
+  const invite = state.findSpaceInvite(inviteId);
+  if (!invite) return inviteNotFound();
+  state.removeSpaceInvite(inviteId);
+  if (invite.reject === "invite_not_found") return inviteNotFound();
+  return noContent();
+}
+
+/** Route a C8 Spaces request, or return `undefined` to fall through. */
+export function handleSpacesRoutes(
+  method: string,
+  segs: string[],
+  body: Record<string, unknown> | undefined,
+): Response | undefined {
+  // GET /v1/orgs — every membership + every pending invite addressed to the
+  // caller. Served unconditionally: the CLIENT gates on `capabilities.spaces`,
+  // and a host that answers here while advertising no spaces is exactly the
+  // shape the render gate has to survive.
+  if (segs[0] === "v1" && segs[1] === "orgs" && segs.length === 2) {
+    if (method === "GET") {
+      return json({
+        orgs: state.listSpaceOrgs(),
+        invites: state.listSpaceInviteWires(),
+      });
+    }
+    // POST /v1/orgs — mint a team with the caller as owner.
+    if (method === "POST") {
+      const name = typeof body?.name === "string" ? body.name.trim() : "";
+      if (!name) return json({ error: "name is required" }, 400);
+      // The gateway's own ceiling (`maxTeamNameLen`), mirrored so the create
+      // dialog's long-name rejection is reachable here too.
+      if (name.length > 200) return json({ error: "name too long" }, 400);
+      return json(state.createTeamSpace(name), 201);
+    }
+    return json({ error: "not found" }, 404);
+  }
+
+  // POST /v1/org-invites/:id/accept
+  if (
+    segs[0] === "v1" &&
+    segs[1] === "org-invites" &&
+    segs.length === 4 &&
+    segs[3] === "accept"
+  ) {
+    if (method !== "POST") return json({ error: "not found" }, 404);
+    return acceptInvite(decodeURIComponent(segs[2]));
+  }
+
+  // DELETE /v1/org-invites/:id
+  if (segs[0] === "v1" && segs[1] === "org-invites" && segs.length === 3) {
+    if (method !== "DELETE") return json({ error: "not found" }, 404);
+    return declineInvite(decodeURIComponent(segs[2]));
+  }
+
+  return undefined;
+}

--- a/packages/fake-host/src/state-spaces.ts
+++ b/packages/fake-host/src/state-spaces.ts
@@ -1,0 +1,153 @@
+/**
+ * C8 Spaces state — the CROSS-org surface `GET /v1/orgs` serves: every team the
+ * caller belongs to, plus every pending invite addressed to them (the
+ * invitee-side inbox the sidebar renders under the workspace switcher).
+ *
+ * Memberships have ONE source of truth here: the armed team-space rows
+ * (`state.teamWorkspaces` — the same rows `GET /v1/workspaces` bridges). So
+ * accepting an invite appends a row and the team appears in the switcher AND in
+ * the org list at once, exactly as it does behind the real gateway, with no
+ * second fixture to keep in sync.
+ *
+ * No PERSONAL `OrgSummary` is synthesized. The gateway lists one, but the fake
+ * host's personal space is the seed WORKSPACE (`SEED_WORKSPACE_ID`), not an org
+ * record with a slug — inventing one would put an id in `/v1/orgs` that
+ * `/v1/workspaces` contradicts. Every client surface reading this list filters
+ * to `kind:"team"` (the team picker) or matches the ACTIVE team's slug (the
+ * degraded banner), so the omission is unobservable.
+ *
+ * The `FakeSpaceInvite` / `SpaceInviteRejection` shapes live in
+ * `state-store.ts` with the rest of the wire fixtures; this module is their
+ * read/write surface, mirroring `state-teams.ts`.
+ */
+
+import type {
+  FakeSpaceInvite,
+  FakeTeamWorkspace,
+  OrgRole,
+} from "./state-store";
+import { state } from "./state-store";
+
+/**
+ * One membership as `GET /v1/orgs` serves it. Mirrors the engine-client
+ * `OrgSummary` wire shape structurally (that type lives in
+ * `@houston-ai/engine-client`, which this package does not depend on) minus the
+ * optional billing detail, which C8 omits from summaries.
+ */
+export interface OrgSummaryWire {
+  id: string;
+  slug: string;
+  name: string;
+  kind: "personal" | "team";
+  role: OrgRole;
+  memberCount: number;
+  degraded: boolean;
+}
+
+/** One invite as `GET /v1/orgs` serves it in `invites`. */
+export interface OrgInviteSummaryWire {
+  id: string;
+  orgName: string;
+  role: OrgRole;
+  invitedBy?: string;
+}
+
+/** The 16-hex slug behind a team workspace id (`org:<slug>`). */
+function slugOf(row: FakeTeamWorkspace): string {
+  return row.id.slice("org:".length);
+}
+
+/** A team-space row as the org list serves it. */
+function orgWire(row: FakeTeamWorkspace): OrgSummaryWire {
+  return {
+    id: `org-${slugOf(row)}`,
+    slug: slugOf(row),
+    name: row.name,
+    kind: "team",
+    role: row.role ?? state.capabilities.role ?? "owner",
+    memberCount: row.memberCount ?? 1,
+    degraded: false,
+  };
+}
+
+/** Every team the caller belongs to (`GET /v1/orgs` → `orgs`). */
+export function listSpaceOrgs(): OrgSummaryWire[] {
+  return state.teamWorkspaces.map(orgWire);
+}
+
+/**
+ * The pending invites `GET /v1/orgs` surfaces. `orgSlug` and the armed
+ * `reject` are fixture-only and never reach the wire — the gateway's summary
+ * carries exactly these four fields.
+ */
+export function listSpaceInviteWires(): OrgInviteSummaryWire[] {
+  return state.spaceInvites.map((invite) => ({
+    id: invite.id,
+    orgName: invite.orgName,
+    role: invite.role,
+    ...(invite.invitedBy !== undefined ? { invitedBy: invite.invitedBy } : {}),
+  }));
+}
+
+/** The armed invitee-side inbox, verbatim (fixture fields included). */
+export function getSpaceInvites(): FakeSpaceInvite[] {
+  return state.spaceInvites;
+}
+
+/** Replace (or clear, with `[]`) the invitee-side inbox. */
+export function setSpaceInvites(invites: FakeSpaceInvite[]): FakeSpaceInvite[] {
+  state.spaceInvites = invites;
+  return state.spaceInvites;
+}
+
+/** The armed invite with this id, or `undefined` (the gateway's 404 case). */
+export function findSpaceInvite(id: string): FakeSpaceInvite | undefined {
+  return state.spaceInvites.find((invite) => invite.id === id);
+}
+
+/** Drop an invite from the inbox, so the next `GET /v1/orgs` no longer has it. */
+export function removeSpaceInvite(id: string): void {
+  state.spaceInvites = state.spaceInvites.filter((invite) => invite.id !== id);
+}
+
+/**
+ * Consume an invite: it leaves the inbox and its team becomes a membership —
+ * a switcher row (`GET /v1/workspaces`) and an org-list row in one move. The
+ * joined summary is what `POST /v1/org-invites/:id/accept` answers.
+ *
+ * `memberCount` is 2 because somebody had to send the invite; the gateway
+ * reports the post-join count and a lone "1" would be a lie the UI could show.
+ */
+export function acceptSpaceInvite(invite: FakeSpaceInvite): OrgSummaryWire {
+  removeSpaceInvite(invite.id);
+  const row: FakeTeamWorkspace = {
+    id: `org:${invite.orgSlug}`,
+    name: invite.orgName,
+    role: invite.role,
+    memberCount: 2,
+  };
+  state.teamWorkspaces = [...state.teamWorkspaces, row];
+  return orgWire(row);
+}
+
+/**
+ * A fresh team-space slug: a monotonic counter in hex, so it is deterministic
+ * within a test and always matches the id grammar `space-id.ts` enforces (16
+ * lowercase hex chars). ONE counter serves both minted teams and the slugs an
+ * armed invite would join, so the two can never collide.
+ */
+export function mintTeamSlug(): string {
+  return (++state.teamSeq).toString(16).padStart(16, "0");
+}
+
+/** Mint a team with the caller as owner (`POST /v1/orgs`). */
+export function createTeamSpace(name: string): OrgSummaryWire {
+  const row: FakeTeamWorkspace = {
+    id: `org:${mintTeamSlug()}`,
+    name,
+    role: "owner",
+    memberCount: 1,
+  };
+  state.teamWorkspaces = [...state.teamWorkspaces, row];
+  return orgWire(row);
+}

--- a/packages/fake-host/src/state-store.ts
+++ b/packages/fake-host/src/state-store.ts
@@ -168,11 +168,57 @@ export interface FakeInvite {
  * `kind` is `"org"`. Armed by `/__test__/workspaces`; served alongside the
  * always-present personal seed row. Empty (the default) = personal-only, so the
  * list stays byte-identical to a single-workspace deployment.
+ *
+ * The same rows are the caller's team MEMBERSHIPS, which `GET /v1/orgs`
+ * enumerates (`state-spaces.ts`) — one source of truth, so joining a team puts
+ * it in the switcher and the org list at once, as the gateway does. `role` and
+ * `memberCount` ride along for that list; both fall back to the advertised
+ * capabilities role / a lone member when a spec armed only `{slug, name}`.
  */
 export interface FakeTeamWorkspace {
   /** `"org:" + [a-f0-9]{16}`. */
   id: string;
   name: string;
+  /** The caller's role in this team; defaults to the advertised caps role. */
+  role?: OrgRole;
+  /** People in the team; defaults to 1 (the caller alone). */
+  memberCount?: number;
+}
+
+/**
+ * A gateway rejection a spec can force on one invite, so the invitee-side
+ * error paths are reachable without racing a real state change. Mirrors the C8
+ * accept/decline codes (`cloud/internal/edge/spaces_routes.go`):
+ * `needs_upgrade` (403, the invite STAYS — an upgrade makes it acceptable
+ * again), `already_member` (409, also kept), `invite_not_found` (404, and the
+ * invite is dropped from the served list — the revoked-between-fetch-and-click
+ * case, whose refetch is what makes the stale card disappear).
+ */
+export type SpaceInviteRejection =
+  | "needs_upgrade"
+  | "already_member"
+  | "invite_not_found";
+
+/**
+ * A pending invite addressed to the CALLER (C8 Spaces), as `GET /v1/orgs`
+ * surfaces it in `invites` — the invitee-side inbox the sidebar renders under
+ * the workspace switcher. NOT {@link FakeInvite}, which is an invite the ACTIVE
+ * org's owner SENT and `GET /v1/org` surfaces to owner/admin.
+ *
+ * `orgSlug` is the 16-hex slug the joined team lands under in the workspaces
+ * bridge (`org:<slug>`); it never reaches the wire (the summary carries only
+ * `id`/`orgName`/`role`/`invitedBy`), it is what accepting turns into a
+ * membership. `invitedBy` is the inviter's user id on the shipped gateway,
+ * which the client deliberately refuses to render — a spec arms an email or a
+ * spaced name to reach the "<name> invited you" headline.
+ */
+export interface FakeSpaceInvite {
+  id: string;
+  orgName: string;
+  orgSlug: string;
+  role: OrgRole;
+  invitedBy?: string;
+  reject?: SpaceInviteRejection;
 }
 
 /**
@@ -393,9 +439,18 @@ export interface HostState {
   /**
    * The team-space rows `GET /v1/workspaces` bridges in (C8 Spaces), armed by
    * `/__test__/workspaces`. Empty (the default) = personal-only, keeping the
-   * switcher byte-identical to a single-workspace host.
+   * switcher byte-identical to a single-workspace host. The same rows are the
+   * memberships `GET /v1/orgs` enumerates.
    */
   teamWorkspaces: FakeTeamWorkspace[];
+  /**
+   * The invitee-side inbox `GET /v1/orgs` surfaces in `invites` (C8 Spaces),
+   * armed by `/__test__/space-invites`. Empty (the default) = nothing pending,
+   * so the sidebar renders no invite chrome at all.
+   */
+  spaceInvites: FakeSpaceInvite[];
+  /** Monotonic counter for minted team-space slugs (`POST /v1/orgs`). */
+  teamSeq: number;
   /** connectionId -> the acting user's connected account. */
   connections: Map<string, IntegrationConnection>;
   /** Per-user preference key -> value (locale, timezone, …). */
@@ -473,6 +528,8 @@ function freshState(): HostState {
     orgInvites: [],
     inviteSeq: 0,
     teamWorkspaces: [],
+    spaceInvites: [],
+    teamSeq: 0,
     connections,
     preferences: new Map(),
     sidebarLayouts: new Map(),

--- a/packages/fake-host/src/state.ts
+++ b/packages/fake-host/src/state.ts
@@ -28,6 +28,7 @@ export * from "./state-providers";
 export * from "./state-routines";
 export * from "./state-shared-skills";
 export * from "./state-skills";
+export * from "./state-spaces";
 export * from "./state-store";
 export * from "./state-teams";
 export * from "./state-workspace";

--- a/packages/web/e2e/README.md
+++ b/packages/web/e2e/README.md
@@ -125,6 +125,15 @@ controls arm it (documented in the `@houston/fake-host` README):
   (agent ∩ org) splits the browse catalog into connectable vs locked rows
   (`integrations-locked.spec.ts`). `null` = unrestricted, `[]` = none.
 
+**C8 Spaces arming.** The fake host serves the whole cross-org surface
+(`@houston/fake-host` `routes-spaces.ts`): `GET /v1/orgs` → `{orgs, invites}`,
+`POST /v1/orgs`, and the invitee's own `POST /v1/org-invites/:id/accept` /
+`DELETE /v1/org-invites/:id`. `POST /__test__/space-invites` arms the invite
+inbox and can force a per-invite `needs_upgrade` / `already_member` /
+`invite_not_found` rejection; pair it with `/__test__/capabilities`
+`{ spaces:true }`, because the sidebar cards are capability-gated on the client
+(`team-invites.spec.ts`).
+
 The seeded catalog (`SEED_TOOLKIT_SLUGS`, exported for specs) holds 15 A-Z apps,
 enough that a tight allowlist blocks past the locked preview cap (8) so the
 "+N more" overflow is exercisable.

--- a/packages/web/e2e/team-invites.spec.ts
+++ b/packages/web/e2e/team-invites.spec.ts
@@ -1,0 +1,278 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import type { APIRequestContext, Locator, Page } from "@playwright/test";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * C8 team invites, the INVITEE side: the invite inbox that rides the sidebar's
+ * `headerBelow` band, directly under the workspace switcher
+ * (`app/src/components/shell/pending-invites.tsx`, mounted by
+ * `SidebarInviteInbox`).
+ *
+ * The gateway auto-joins pending invites only on an account's FIRST-EVER
+ * contact, so for every existing user this surface is the only way in — which
+ * makes "does the card render, and does answering it actually move the team"
+ * the whole feature. The fake host serves the real C8 wire
+ * (`GET /v1/orgs` → `{orgs, invites}`, `POST /v1/org-invites/:id/accept` → 201
+ * `{org}`, `DELETE /v1/org-invites/:id` → 204) from `@houston/fake-host`
+ * `routes-spaces.ts`; `/__test__/space-invites` arms the inbox and can force
+ * any of the three expected rejections per invite.
+ *
+ * Accepting is asserted through the REAL switcher dropdown rather than a
+ * network spy: the point of joining is that the team is somewhere you can go.
+ */
+
+/** A Spaces host: the capability the whole surface is gated on, both sides. */
+const SPACES_CAPS = {
+  multiplayer: true,
+  teams: true,
+  spaces: true,
+  role: "owner",
+};
+
+const ACME = "Acme Team";
+
+async function armCapabilities(
+  request: APIRequestContext,
+  caps: Record<string, unknown>,
+): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/capabilities`, { data: caps });
+}
+
+async function armInvites(
+  request: APIRequestContext,
+  invites: Record<string, unknown>[],
+): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/space-invites`, {
+    data: { invites },
+  });
+}
+
+/** The invite inbox: the sidebar's `headerBelow` band. */
+const inbox = (page: Page): Locator =>
+  page.locator('[aria-label="Invitations"]');
+
+const inviteCards = (page: Page): Locator => inbox(page).getByRole("listitem");
+
+/**
+ * Assert the inbox really sits between the switcher and the nav — geometry, not
+ * DOM order, because the placement IS the design argument: an invitation
+ * belongs where the user picks a space, always visible, not inside the
+ * switcher's dropdown and not somewhere further down the rail.
+ */
+async function expectUnderTheSwitcher(page: Page): Promise<void> {
+  const switcher = await page
+    .locator('[data-tour-target="spaceSwitcher"]')
+    .boundingBox();
+  const section = await inbox(page).boundingBox();
+  const card = await inviteCards(page).first().boundingBox();
+  const firstNavItem = await page
+    .locator("[data-tour-target='nav-dashboard']")
+    .boundingBox();
+  if (!switcher || !section || !card || !firstNavItem)
+    throw new Error("sidebar header, inbox or nav is not laid out");
+  expect(section.y).toBeGreaterThanOrEqual(switcher.y + switcher.height);
+  expect(section.y + section.height).toBeLessThanOrEqual(firstNavItem.y);
+  // Full rail width: a card lines up with the rows below it rather than being
+  // inset by the collapse toggle's column (the sidebar's `headerBelow` band,
+  // not the header's own row).
+  expect(Math.abs(card.x - firstNavItem.x)).toBeLessThanOrEqual(1);
+  expect(
+    Math.abs(card.x + card.width - (firstNavItem.x + firstNavItem.width)),
+  ).toBeLessThanOrEqual(1);
+}
+
+/** Open the switcher dropdown and read back the spaces it offers. */
+async function openSwitcher(page: Page): Promise<void> {
+  await page
+    .locator('[data-tour-target="spaceSwitcher"]')
+    .locator("button")
+    .first()
+    .click();
+}
+
+test("a pending invite renders as a card under the workspace switcher", async ({
+  page,
+  request,
+}) => {
+  await armCapabilities(request, SPACES_CAPS);
+  await armInvites(request, [
+    { orgName: ACME, role: "user" },
+    { orgName: "Bravo Labs", role: "admin", invitedBy: "ada@acme.test" },
+  ]);
+  await page.goto("/");
+
+  await expect(inviteCards(page)).toHaveCount(2);
+  await expectUnderTheSwitcher(page);
+  // Sorted by team name (`sortInvites`), so the order is stable across polls
+  // and an Accept button never slides under the cursor.
+  await expect(inviteCards(page).first()).toContainText(
+    `You were invited to join ${ACME}`,
+  );
+  await expect(inviteCards(page).first()).toContainText(
+    "You will join as Member.",
+  );
+  // An inviter is named only when the gateway sent something human; an email
+  // qualifies, a bare user id does not (`inviterDisplayName`).
+  await expect(inviteCards(page).nth(1)).toContainText(
+    "ada@acme.test invited you to Bravo Labs",
+  );
+  await expect(inviteCards(page).nth(1)).toContainText(
+    "You will join as Manager.",
+  );
+});
+
+test("accepting an invite joins the team: the card goes, the space arrives", async ({
+  page,
+  request,
+}) => {
+  await armCapabilities(request, SPACES_CAPS);
+  await armInvites(request, [{ orgName: ACME, role: "user" }]);
+  await page.goto("/");
+  await expect(inviteCards(page)).toHaveCount(1);
+
+  // The switcher offers only the personal space before the join.
+  await openSwitcher(page);
+  await expect(page.getByRole("menuitem", { name: ACME })).toHaveCount(0);
+  await page.keyboard.press("Escape");
+
+  await page
+    .getByRole("button", { name: `Accept the invitation to ${ACME}` })
+    .click();
+
+  // The answered card leaves as soon as the refreshed list drops the invite.
+  await expect(inboxOrNothing(page)).toHaveCount(0);
+  // The success toast only promises the space menu once `teamIsInSwitcher`
+  // confirmed the reloaded workspace list really holds the team.
+  await expect(page.getByText(`You joined ${ACME}`)).toBeVisible();
+  await expect(
+    page.getByText("Switch to it any time from the space menu"),
+  ).toBeVisible();
+
+  // ...and it really is there. Nothing switched the active space: joining is
+  // not going there.
+  await openSwitcher(page);
+  await expect(page.getByRole("menuitem", { name: ACME })).toBeVisible();
+});
+
+test("declining an invite removes the card", async ({ page, request }) => {
+  await armCapabilities(request, SPACES_CAPS);
+  await armInvites(request, [
+    { orgName: ACME, role: "user" },
+    { orgName: "Bravo Labs", role: "user" },
+  ]);
+  await page.goto("/");
+  await expect(inviteCards(page)).toHaveCount(2);
+
+  await page
+    .getByRole("button", { name: `Decline the invitation to ${ACME}` })
+    .click();
+
+  // Only the declined one goes; a decline never touches the other invitations.
+  await expect(inviteCards(page)).toHaveCount(1);
+  await expect(inviteCards(page).first()).toContainText("Bravo Labs");
+  // A decline joins nothing, so no space appears.
+  await openSwitcher(page);
+  await expect(page.getByRole("menuitem", { name: ACME })).toHaveCount(0);
+});
+
+test("a needs_upgrade rejection explains itself in a plain toast, keeping the invite", async ({
+  page,
+  request,
+}) => {
+  await armCapabilities(request, SPACES_CAPS);
+  await armInvites(request, [
+    { orgName: ACME, role: "user", reject: "needs_upgrade" },
+  ]);
+  await page.goto("/");
+
+  await page
+    .getByRole("button", { name: `Accept the invitation to ${ACME}` })
+    .click();
+
+  const message = page.getByText("This team needs an upgrade");
+  await expect(message).toBeVisible();
+  // Informational, NOT the red bug toast: nothing is broken, so the branded
+  // "we have a problem" pair (and its auto-report) must not fire.
+  await expect(page.getByText("Houston, we have a problem!")).toHaveCount(0);
+  // The toast row itself carries no danger border (`variant:"info"`).
+  await expect(message.locator("xpath=../..")).not.toHaveClass(/border-danger/);
+
+  // The invite STAYS: an upgrade makes it acceptable again.
+  await expect(inviteCards(page)).toHaveCount(1);
+});
+
+test("an invite revoked behind the user's back disappears on the failed accept", async ({
+  page,
+  request,
+}) => {
+  await armCapabilities(request, SPACES_CAPS);
+  await armInvites(request, [
+    { orgName: ACME, role: "user", reject: "invite_not_found" },
+  ]);
+  await page.goto("/");
+
+  await page
+    .getByRole("button", { name: `Accept the invitation to ${ACME}` })
+    .click();
+
+  await expect(
+    page.getByText("This invitation is no longer available"),
+  ).toBeVisible();
+  await expect(page.getByText("Houston, we have a problem!")).toHaveCount(0);
+  // Both hooks invalidate the list on the FAILURE path too, so the stale card
+  // goes even though nothing was joined.
+  await expect(inboxOrNothing(page)).toHaveCount(0);
+});
+
+test("the collapsed rail keeps the invitation reachable as a count button", async ({
+  page,
+  request,
+}) => {
+  await armCapabilities(request, SPACES_CAPS);
+  await armInvites(request, [
+    { orgName: ACME, role: "user" },
+    { orgName: "Bravo Labs", role: "user" },
+  ]);
+  await page.goto("/");
+  await expect(inviteCards(page)).toHaveCount(2);
+
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
+
+  // The cards need width the icon rail hasn't got, so the count stands in —
+  // still always visible, never behind a hover.
+  const railButton = page.getByRole("button", {
+    name: "2 pending invitations",
+  });
+  await expect(railButton).toBeVisible();
+  await expect(inviteCards(page)).toHaveCount(0);
+
+  // Pressing it expands the rail back onto the real cards.
+  await railButton.click();
+  await expect(inviteCards(page)).toHaveCount(2);
+});
+
+test("no Spaces capability: the invite inbox renders nothing at all", async ({
+  page,
+  request,
+}) => {
+  // Invites armed, but the deployment does not serve Spaces. The RENDER gate
+  // (`visibleInvites`) is what has to hold here: gating only the fetch would
+  // leave a cached list painting cards over a host whose mutators throw.
+  await armInvites(request, [{ orgName: ACME, role: "user" }]);
+  await page.goto("/");
+
+  // Anchor on a painted shell first, so the absence below can't pass on an
+  // empty screen.
+  await expect(
+    page.locator('[data-tour-target="spaceSwitcher"]'),
+  ).toBeVisible();
+  await expect(inboxOrNothing(page)).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: /pending invitation/ }),
+  ).toHaveCount(0);
+});
+
+/** The inbox looked up without the sibling constraint — for absence checks. */
+function inboxOrNothing(page: Page): Locator {
+  return page.locator('[aria-label="Invitations"]');
+}

--- a/packages/web/src/engine-adapter/client/orgs-mixin.ts
+++ b/packages/web/src/engine-adapter/client/orgs-mixin.ts
@@ -67,6 +67,19 @@ export function OrgsMixin<TBase extends BaseCtor>(Base: TBase) {
         throw new Error("Creating a team needs the hosted gateway.");
       return controlPlane.createOrg(this.ctx.cp, name);
     }
+    // The invitee's own accept/decline (C8). Off-cloud there is no invite to
+    // act on, so both throw rather than degrade: a user who clicked Accept must
+    // never be told nothing happened.
+    async acceptOrgInvite(inviteId: string): Promise<controlPlane.OrgSummary> {
+      if (!this.ctx.cp)
+        throw new Error("Joining a team needs the hosted gateway.");
+      return controlPlane.acceptOrgInvite(this.ctx.cp, inviteId);
+    }
+    async declineOrgInvite(inviteId: string): Promise<void> {
+      if (!this.ctx.cp)
+        throw new Error("Declining an invitation needs the hosted gateway.");
+      return controlPlane.declineOrgInvite(this.ctx.cp, inviteId);
+    }
     async moveAgent(
       agentSlugOrId: string,
       toSlug: string,

--- a/packages/web/src/engine-adapter/cp/spaces-billing.ts
+++ b/packages/web/src/engine-adapter/cp/spaces-billing.ts
@@ -43,6 +43,42 @@ export async function createOrg(
 }
 
 /**
+ * Accept a pending invite addressed to the caller (C8), by the id that rides
+ * `listOrgs().invites`. Answers the joined space (the gateway wraps it as
+ * `{org}`) so the caller can name it without a second read. Never degrades —
+ * every rejection is a state the invitee must see: `404 invite_not_found`
+ * (revoked, already used, or addressed to another email — the gateway
+ * deliberately can't tell those apart), `409 already_member`, `403
+ * needs_upgrade` (the team's trial ended).
+ */
+export async function acceptOrgInvite(
+  cfg: ControlPlaneConfig,
+  inviteId: string,
+): Promise<OrgSummary> {
+  const res = await cpFetch(
+    cfg,
+    `/v1/org-invites/${encodeURIComponent(inviteId)}/accept`,
+    { method: "POST" },
+  );
+  return ((await res.json()) as { org: OrgSummary }).org;
+}
+
+/**
+ * Decline a pending invite addressed to the caller (C8) — the invitee's own
+ * `204`, NOT the owner's revoke (`deleteOrgInvite`, org-scoped at
+ * `/v1/org/invites/:id`). Never degrades: a `404 invite_not_found` must reach
+ * the UI so the stale row explains itself.
+ */
+export async function declineOrgInvite(
+  cfg: ControlPlaneConfig,
+  inviteId: string,
+): Promise<void> {
+  await cpFetch(cfg, `/v1/org-invites/${encodeURIComponent(inviteId)}`, {
+    method: "DELETE",
+  });
+}
+
+/**
  * Move an agent into a team space; returns the `moveId` to poll with
  * `getMoveStatus`. Never degrades — 403 `unsupported_move` / 409
  * `unmovable_volume` / 403 `needs_upgrade` throw so the caller surfaces them.

--- a/packages/web/tests/org-invites.test.ts
+++ b/packages/web/tests/org-invites.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { HoustonEngineError } from "../src/engine-adapter/client";
+import {
+  acceptOrgInvite,
+  declineOrgInvite,
+} from "../src/engine-adapter/control-plane";
+
+/**
+ * The INVITEE half of C8 invites on the HOSTED path — the client every cloud
+ * build actually runs. Two things have to hold and neither is free:
+ *
+ *  1. the routes are the CROSS-org `/v1/org-invites/*` pair, NOT the org-scoped
+ *     `/v1/org/invites/:id` the owner's revoke uses. One stray slash and an
+ *     invitee's Accept would hit the owner-only revoke route;
+ *  2. accept UNWRAPS the gateway's `201 {org: OrgSummary}` envelope, so the
+ *     caller can name the team it just joined.
+ *
+ * Neither call degrades: every rejection (`404 invite_not_found`,
+ * `409 already_member`, `403 needs_upgrade`) is a state the invitee must see,
+ * so it throws and the UI explains it. Mirrors `billing-degrade.test.ts`.
+ */
+
+const CFG = { baseUrl: "https://gw.example", token: "t" };
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+interface Call {
+  url: string;
+  method: string;
+}
+
+function stubFetch(status: number, body: unknown): Call[] {
+  const calls: Call[] = [];
+  globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    calls.push({ url: String(input), method: init?.method ?? "GET" });
+    return new Response(status === 204 ? null : JSON.stringify(body), {
+      status,
+      headers: status === 204 ? {} : { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+const ORG = {
+  id: "o1",
+  slug: "0123456789abcdef",
+  name: "Acme",
+  kind: "team",
+  role: "user",
+  memberCount: 4,
+  degraded: false,
+};
+
+test("acceptOrgInvite POSTs /v1/org-invites/:id/accept and unwraps {org}", async () => {
+  const calls = stubFetch(201, { org: ORG });
+  await expect(acceptOrgInvite(CFG, "inv-1")).resolves.toEqual(ORG);
+  expect(calls).toEqual([
+    { url: "https://gw.example/v1/org-invites/inv-1/accept", method: "POST" },
+  ]);
+});
+
+test("acceptOrgInvite percent-encodes the invite id", async () => {
+  const calls = stubFetch(201, { org: ORG });
+  await acceptOrgInvite(CFG, "inv/1 2");
+  expect(calls[0].url).toBe(
+    "https://gw.example/v1/org-invites/inv%2F1%202/accept",
+  );
+});
+
+test("acceptOrgInvite throws a 403 needs_upgrade instead of degrading", async () => {
+  stubFetch(403, { error: "team needs upgrade", code: "needs_upgrade" });
+  await expect(acceptOrgInvite(CFG, "inv-1")).rejects.toThrow(
+    HoustonEngineError,
+  );
+});
+
+test("acceptOrgInvite throws a 409 already_member and a 404 invite_not_found", async () => {
+  stubFetch(409, { error: "already a member", code: "already_member" });
+  await expect(acceptOrgInvite(CFG, "inv-1")).rejects.toThrow(
+    HoustonEngineError,
+  );
+  stubFetch(404, { error: "invite not found", code: "invite_not_found" });
+  await expect(acceptOrgInvite(CFG, "inv-1")).rejects.toThrow(
+    HoustonEngineError,
+  );
+});
+
+test("declineOrgInvite DELETEs /v1/org-invites/:id and resolves on 204", async () => {
+  const calls = stubFetch(204, null);
+  await expect(declineOrgInvite(CFG, "inv-2")).resolves.toBeUndefined();
+  expect(calls).toEqual([
+    { url: "https://gw.example/v1/org-invites/inv-2", method: "DELETE" },
+  ]);
+});
+
+test("declineOrgInvite throws a 404 instead of degrading", async () => {
+  stubFetch(404, { error: "invite not found", code: "invite_not_found" });
+  await expect(declineOrgInvite(CFG, "inv-2")).rejects.toThrow(
+    HoustonEngineError,
+  );
+});

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -1710,6 +1710,31 @@ export class HoustonClient {
     return this.request("POST", "/orgs", { name });
   }
   /**
+   * Accept a pending invite addressed to the caller (C8 §Wire surface), by the
+   * id that rides `listOrgs().invites`. Answers the joined space so the caller
+   * can name it without a second read. Never degrades — every rejection is a
+   * state the invitee must see: `404 invite_not_found` (revoked, already used,
+   * or addressed to another email — the gateway deliberately can't tell them
+   * apart), `409 already_member`, `403 needs_upgrade` (the team's trial ended).
+   * A POST, so `send` never auto-replays it.
+   */
+  async acceptOrgInvite(inviteId: string): Promise<OrgSummary> {
+    const res = await this.request<{ org: OrgSummary }>(
+      "POST",
+      `/org-invites/${this.seg(inviteId)}/accept`,
+    );
+    return res.org;
+  }
+  /**
+   * Decline a pending invite addressed to the caller (C8 §Wire surface) — the
+   * invitee's own `204`, NOT the owner's revoke (`deleteOrgInvite`, which is
+   * org-scoped at `/org/invites/:id`). Never degrades: a `404 invite_not_found`
+   * must reach the UI so the stale row explains itself.
+   */
+  async declineOrgInvite(inviteId: string): Promise<void> {
+    await this.request("DELETE", `/org-invites/${this.seg(inviteId)}`);
+  }
+  /**
    * Move an agent into a team space (C8 §Agent move). Returns the `moveId` to
    * poll with `getMoveStatus` to terminal `done` before inviting. Never degrades:
    * a `403 unsupported_move` / `409 unmovable_volume` / `403 needs_upgrade` must

--- a/ui/engine-client/tests/client-teams.test.ts
+++ b/ui/engine-client/tests/client-teams.test.ts
@@ -123,6 +123,36 @@ describe("HoustonClient Teams v2 — invites, audit, usage", () => {
     strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/org/invites/inv-1");
   });
 
+  // The INVITEE's own pair (C8) lives on the CROSS-org `/org-invites/*` routes,
+  // deliberately NOT the org-scoped revoke route asserted above: an invitee has
+  // no active membership in that org to scope a request with.
+  it("acceptOrgInvite POSTs /org-invites/:id/accept and unwraps {org}", async () => {
+    const org = {
+      id: "o1",
+      slug: "0123456789abcdef",
+      name: "Acme",
+      kind: "team",
+      role: "user",
+      memberCount: 2,
+      degraded: false,
+    };
+    const { client, calls } = makeClient({ org });
+    const joined = await client.acceptOrgInvite("inv-1");
+    strictEqual(calls[0].method, "POST");
+    strictEqual(
+      calls[0].url,
+      "http://127.0.0.1:9999/v1/org-invites/inv-1/accept",
+    );
+    deepStrictEqual(joined, org);
+  });
+
+  it("declineOrgInvite DELETEs /org-invites/:id", async () => {
+    const { client, calls } = makeClient();
+    await client.declineOrgInvite("inv-2");
+    strictEqual(calls[0].method, "DELETE");
+    strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/org-invites/inv-2");
+  });
+
   it("orgAudit passes before/limit query and unwraps entries", async () => {
     const entries = [
       {

--- a/ui/layout/src/sidebar.tsx
+++ b/ui/layout/src/sidebar.tsx
@@ -46,6 +46,15 @@ export interface SidebarProps {
   logo?: ReactNode;
   /** Header area rendered at the very top (e.g., space/org switcher) */
   header?: ReactNode;
+  /**
+   * A FULL-WIDTH band directly under the header, above the nav (e.g. the
+   * pending-invite inbox). Deliberately not part of `header`: expanded, the
+   * header shares its row with the collapse toggle, so anything tall put there
+   * is inset by the toggle's width AND drags the vertically-centred toggle down
+   * to the middle of the block. This slot spans the rail like every row below
+   * it and leaves the toggle on the header's own line.
+   */
+  headerBelow?: ReactNode;
   /** Nav items rendered below the header and above the items list */
   navItems?: SidebarNavItemEntry[];
   /** ID of the currently active nav item (for highlighting) */
@@ -129,6 +138,7 @@ const DEFAULT_LABELS: Required<SidebarLabels> = {
 export function AppSidebar({
   logo,
   header,
+  headerBelow,
   navItems,
   activeNavId,
   items,
@@ -255,6 +265,11 @@ export function AppSidebar({
             )}
           </div>
         )}
+
+        {/* Full-width band under the header row (see `headerBelow`). Renders in
+            both presentations: the collapsed rail needs its own stand-in for
+            whatever lives here, not a hidden one. */}
+        {headerBelow}
 
         {/* Legacy logo area (only when no header) */}
         {showLogo && !collapsed && (


### PR DESCRIPTION
Gateway counterpart merged in gethouston/cloud#210. `GET /v1/orgs` already returned pending invites, but nothing rendered them and nothing could accept — an existing account's invite was a dead end (invites only auto-join on an account's first-ever gateway contact).

- **Engine client**: `acceptOrgInvite` (POST /v1/org-invites/:id/accept, unwraps 201 `{org}`) / `declineOrgInvite` (DELETE, 204), hosted-path adapter methods, `tauriOrg` wrappers. Admin revoke untouched.
- **Hooks**: mutations with a synchronous per-invite action lock (no accept/decline double-fire), prompt orgs invalidation, and honest join feedback — the "You joined X, switch to it" toast only fires when the team verifiably reached the switcher; a failed refresh gets its own copy. `needs_upgrade` / `already_member` / `invite_not_found` render as informational toasts, everything else keeps the standard error path.
- **UI**: invite cards always visible under the workspace switcher (new `headerBelow` slot in AppSidebar for full-width alignment), capability-gated render (no stale cards after leaving a Spaces session), bounded scrollable list with word-breaking for 200-char team names, collapsed rail keeps a labelled count button. en/es/pt. Design-review screenshot loop run (3 fix passes); visual baselines confirmed untouched.
- **Pre-existing prod bug fixed**: gateway business rejections are flat `{error, code}` which the client classifier never matched — `needs_upgrade`/`personal_space` informational toasts were dead in production, falling through to the red bug toast. Now reads the flat code with regression tests against the real body shape.
- **Testing**: fake host models the C8 cross-org surface (orgs/invites/accept/decline + forced rejections); 7 new Playwright e2e specs; 30+ unit tests. Full web e2e suite 243 passed; visual suite 8 passed; adversarially reviewed with all 4 findings fixed reproduce-first.

Fixes HOU-1099

🤖 Generated with [Claude Code](https://claude.com/claude-code)