### PR TITLE
fix(sentry): stop updater poll failures from flooding Sentry (HOU-1104)

### DIFF
--- a/app/src-tauri/src/logging.rs
+++ b/app/src-tauri/src/logging.rs
@@ -15,6 +15,12 @@ static GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 ///   - `sentry_tracing::layer()` → INFO+ events become Sentry breadcrumbs;
 ///     ERROR events become standalone Sentry events. No-op if `sentry::init`
 ///     hasn't been called (e.g. empty SENTRY_DSN), so safe to always include.
+///     Exception: `tauri_plugin_updater` ERRORs stay breadcrumbs — the plugin
+///     logs one on every failed background update poll (machine offline,
+///     GitHub down, transient non-2xx from the release manifest), and the
+///     frontend already owns that failure (5-min poll retry, update-floor
+///     fallback URL, install-error card), so a standalone Sentry event per
+///     poll is noise.
 ///
 /// Result: when a Rust panic or explicit `tracing::error!` lands in Sentry,
 /// the last ~100 INFO/WARN log lines auto-attach as breadcrumbs — the
@@ -52,8 +58,26 @@ pub fn init(data_dir: &Path) {
     tracing_subscriber::registry()
         .with(filter)
         .with(fmt_layer)
-        .with(sentry_tracing::layer())
+        .with(sentry_tracing::layer().event_filter(|metadata| {
+            if demote_error_to_breadcrumb(metadata.target()) {
+                sentry_tracing::EventFilter::Breadcrumb
+            } else {
+                sentry_tracing::default_event_filter(metadata)
+            }
+        }))
         .init();
+}
+
+/// Targets whose ERROR logs must NOT become standalone Sentry events.
+///
+/// `tauri_plugin_updater` fires `log::error!` on every unsuccessful update
+/// check — including the expected ones (offline, GitHub unreachable or
+/// returning a transient non-2xx for the channel manifest). The check
+/// failure is fully handled in the frontend updater hooks, so Sentry only
+/// needs the breadcrumb trail, not an event per 5-minute poll
+/// (Sentry HOUSTON-APP-14).
+fn demote_error_to_breadcrumb(target: &str) -> bool {
+    target.starts_with("tauri_plugin_updater")
 }
 
 fn logs_dir() -> PathBuf {
@@ -144,6 +168,19 @@ fn tail_file(path: &Path, n: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn updater_plugin_errors_are_demoted_to_breadcrumbs() {
+        assert!(demote_error_to_breadcrumb("tauri_plugin_updater::updater"));
+        assert!(demote_error_to_breadcrumb("tauri_plugin_updater"));
+    }
+
+    #[test]
+    fn app_errors_still_become_sentry_events() {
+        assert!(!demote_error_to_breadcrumb("houston_app"));
+        assert!(!demote_error_to_breadcrumb("houston_app::engine_supervisor"));
+        assert!(!demote_error_to_breadcrumb("tauri_plugin_sentry"));
+    }
 
     #[test]
     fn latest_log_matching_uses_newest_rotated_backend_log() {


### PR DESCRIPTION
## Linear

HOU-1104

## Sentry issue

HOUSTON-APP-14 (7512539469) — "update endpoint did not respond with a successful status code". 897 error events since May 28, still firing daily (last seen today on `houston-app@0.5.37`), across every release since 0.5.9. `userCount: 0` — no user impact.

## Root cause

1. `tauri-plugin-updater` fires `log::error!` (updater.rs:509) on ANY non-2xx from the update manifest endpoint. Both channel endpoints (`cloud-latest/latest-cloud.json` for cloud desktop builds, `latest/download/latest.json` for local) return 200 today — the failures are transient: GitHub hiccups/rate limits, offline or captive-portal networks, plus the brief asset-swap window while the cloud-updater-manifest workflow re-clobbers `latest-cloud.json` on each `cloud-v*` publish.
2. The shell's `sentry_tracing` layer (`app/src-tauri/src/logging.rs`) promotes every ERROR-level Rust log to a standalone Sentry event, so each failed poll (every 5 minutes + focus rechecks) became an error event.

The failure is already owned at the right layer: `check()` rejects, `use-update-machine.ts` catches and the next poll retries; the update-floor screen has its own gateway-driven fallback; install failures surface their own error card. The plugin's log line carries no status code and nothing actionable — pure duplicate noise.

## Fix

Custom `event_filter` on the `sentry_tracing` layer: ERROR logs whose target starts with `tauri_plugin_updater` become Sentry **breadcrumbs** instead of standalone events. Everything else keeps the default mapping. The line still lands in `backend.log` unchanged and rides along as a breadcrumb on any real event. Covers both the cloud and local update channels (same binary path).

History: PR #998 implemented this same fix in July and was closed unmerged; the noise continued, so this re-applies it fresh on current main.

## Before (repro)

1. Run a packaged production build (updater only polls when `import.meta.env.PROD`).
2. Make the manifest endpoint return a non-2xx — e.g. cut network after DNS is cached, sit behind a captive portal, or point the updater endpoint at a 404 URL.
3. Each 5-minute poll logs `update endpoint did not respond with a successful status code` at ERROR and a new event appears on Sentry issue 7512539469.

## After (verify)

1. Same setup — the line still appears in `~/.houston/logs/backend.log` at ERROR, but no new Sentry event is created; it shows up only as a breadcrumb on subsequent real events.
2. Watch Sentry issue 7512539469: event volume drops to zero for releases carrying this change.
3. `cargo test` in `app/src-tauri`: 204 passed, 0 failed — includes two new unit tests for the demotion predicate (`updater_plugin_errors_are_demoted_to_breadcrumbs`, `app_errors_still_become_sentry_events`).
