### PR TITLE
fix(skills): skills-manifest read degrades on a pre-HOU-1027 pod instead of toasting (HOU-1105)

### DIFF
--- a/packages/web/src/engine-adapter/cp/skills.ts
+++ b/packages/web/src/engine-adapter/cp/skills.ts
@@ -3,6 +3,7 @@ import type {
   SkillSummary,
   SkillsManifest,
 } from "../../../../../ui/engine-client/src/types";
+import { HoustonEngineError } from "../client/errors";
 import { agentPath, type ControlPlaneConfig, cpFetch } from "./fetch";
 
 type HostSkillSummary = Omit<SkillSummary, "inputs" | "promptTemplate">;
@@ -158,12 +159,25 @@ export async function deleteSharedSkill(
   );
 }
 
+/**
+ * A 404 reads as the empty manifest, not an error: an engine pod predating the
+ * skills-manifest route (HOU-1027 rolls out to cloud pods only as they
+ * re-wake) has nothing enabled — the same degenerate state as a missing file,
+ * which ADR 0003 defines as valid. Every other failure propagates, and the
+ * write below stays loud: a toggle that didn't persist must never look saved.
+ */
 export async function getSkillsManifest(
   cfg: ControlPlaneConfig,
   agentId: string,
 ): Promise<SkillsManifest> {
-  const res = await cpFetch(cfg, `${agentPath(agentId)}/skills-manifest`);
-  return (await res.json()) as SkillsManifest;
+  try {
+    const res = await cpFetch(cfg, `${agentPath(agentId)}/skills-manifest`);
+    return (await res.json()) as SkillsManifest;
+  } catch (err) {
+    if (err instanceof HoustonEngineError && err.status === 404)
+      return { version: 1, enabled: [] };
+    throw err;
+  }
 }
 
 export async function putSkillsManifest(

--- a/packages/web/tests/gateway-404-fallbacks.test.ts
+++ b/packages/web/tests/gateway-404-fallbacks.test.ts
@@ -5,7 +5,9 @@ import {
 } from "../src/engine-adapter/client";
 import {
   getMyProfile,
+  getSkillsManifest,
   listInstalledConfigs,
+  putSkillsManifest,
 } from "../src/engine-adapter/control-plane";
 
 /**
@@ -156,4 +158,39 @@ test("every other /v1/me/profile failure still propagates — never swallowed", 
   await expect(getMyProfile(CFG)).rejects.toThrow(
     "profile exploded (engine error 500)",
   );
+});
+
+/**
+ * HOU-1105 (Sentry HOUSTON-APP-544): the per-agent shared-skills manifest
+ * route shipped with HOU-1027, but cloud engine pods pick it up only as they
+ * re-wake onto the new image — a freshly auto-updated desktop talking to an
+ * old pod 404'd and red-toasted on a read the user never initiated. A missing
+ * manifest means "nothing enabled" (ADR 0003), so the read degrades to the
+ * empty manifest; the write stays loud so a toggle never silently no-ops.
+ */
+
+test("a 404 on the skills-manifest read is the empty manifest — no toast (HOU-1105)", async () => {
+  const calls = stubFetch(json(404, { error: "not found" }));
+
+  await expect(getSkillsManifest(CFG, "a1")).resolves.toEqual({
+    version: 1,
+    enabled: [],
+  });
+  expect(calls).toEqual(["https://gateway.example/agents/a1/skills-manifest"]);
+});
+
+test("every other skills-manifest read failure still propagates", async () => {
+  stubFetch(json(500, { error: "manifest exploded" }));
+
+  await expect(getSkillsManifest(CFG, "a1")).rejects.toThrow(
+    "manifest exploded (engine error 500)",
+  );
+});
+
+test("the skills-manifest WRITE still surfaces a 404 — a toggle must never silently no-op", async () => {
+  stubFetch(json(404, { error: "not found" }));
+
+  await expect(
+    putSkillsManifest(CFG, "a1", { version: 1, enabled: ["research"] }),
+  ).rejects.toThrow("not found (engine error 404)");
 });


### PR DESCRIPTION
Fixes HOU-1105 (Sentry HOUSTON-APP-544).

## Root cause

The per-agent shared-skills manifest route (`GET/PUT /agents/:id/skills-manifest`) shipped host-side with HOU-1027 (#1159), but cloud engine pods only pick up the new image as they sleep and re-wake. The desktop auto-updated to 0.5.39 immediately, so a fresh client against an old pod got a 404 from the pod host (the gateway forwards `/agents/{slug}/*` verbatim), and `getSkillsManifest` propagated it into the query error path: a red **"not found (engine error 404)"** toast on a background read the user never initiated. 15 events / 4 users within ~3h of the rollout.

## Fix

Apply the repo's established gateway-404 degrade posture (HOU-688 / HOU-944, `gateway-404-fallbacks.test.ts`) to the manifest **read**: a 404 resolves to the empty manifest `{version: 1, enabled: []}` — the exact state ADR 0003 already defines as valid for a missing manifest file ("absence is never an error", `packages/domain/src/skills-manifest.ts`). Every other failure still propagates, and the **PUT** stays loud so a shared-skill toggle against an old pod surfaces instead of silently no-opping.

The fallback is skew-only in practice: the desktop's bundled sidecar always matches the client, so it can only trigger against a lagging cloud pod, and it self-heals as pods re-wake onto a post-#1159 image.

## Reproduce (before the fix)

1. Run a 0.5.39 desktop signed into managed cloud, with an agent whose engine pod is on a pre-#1159 image (any pod that stayed awake across the 2026-07-30 merge, or point the client at a host checkout before f1d0321c).
2. Open the agent's Skills view (fires the `skills-manifest` query).
3. Red toast: "not found (engine error 404)", plus a Sentry `get_skills_manifest` event.

## Verify (after the fix)

1. Same setup; open the Skills view.
2. No toast; shared skills simply show as not enabled (the honest pre-HOU-1027 state). `vitest run tests/gateway-404-fallbacks.test.ts` in `packages/web` covers all three postures: 404-read → empty manifest, 500-read → propagates, 404-write → propagates.
3. Sentry HOUSTON-APP-544 event volume drops to zero on releases carrying this fix.

## Gates

- `pnpm --filter houston-web test` — 62 files / 356 tests pass (3 new)
- `pnpm --filter houston-web typecheck` + full workspace typecheck (pre-commit) — clean
- `pnpm check` (Biome) — clean