### PR TITLE
fix(web): transient session-refresh failure reads as connectivity, not a 401 auth error (HOU-1106)

### DIFF
--- a/app/tests/network-transport-error.test.ts
+++ b/app/tests/network-transport-error.test.ts
@@ -61,6 +61,17 @@ describe("isNetworkTransportError", () => {
     strictEqual(isNetworkTransportError(new TypeError("fetch failed")), true);
   });
 
+  it("matches the adapter's synthetic transient-session-refresh failure (HOU-1106)", () => {
+    // packages/web/src/engine-adapter/session-refresh.ts mints exactly this
+    // message when the token refresh loses to a settling reconnect. If the
+    // classifier stops matching it, that failure regresses to a red bug toast
+    // + Sentry report — keep the two in lockstep.
+    strictEqual(
+      isNetworkTransportError(new TypeError("Load failed (session refresh)")),
+      true,
+    );
+  });
+
   it("never matches a coding-bug TypeError", () => {
     strictEqual(
       isNetworkTransportError(new TypeError("undefined is not a function")),

--- a/packages/web/src/engine-adapter/cp/events.ts
+++ b/packages/web/src/engine-adapter/cp/events.ts
@@ -70,7 +70,11 @@ export function subscribeEvents(
     fetch: (input, init) => fetch(input, init),
     signal: ac.signal,
     onUnauthorized: () => {
-      void refreshLiveToken();
+      // Fire-and-forget: the stream's own retry loop re-attempts the connect,
+      // so a refresh beaten transiently by the network (the transport-shaped
+      // throw, HOU-1106) has nothing to surface here — swallow it, or it
+      // becomes an unhandled rejection.
+      void refreshLiveToken().catch(() => {});
     },
     // The catch-up seam (HOU-981). This feed has NO replay cursor: every event
     // emitted while the stream was down is lost for good, and the surfaces it

--- a/packages/web/src/engine-adapter/cp/fetch.ts
+++ b/packages/web/src/engine-adapter/cp/fetch.ts
@@ -68,8 +68,13 @@ const signedOutResponse = () =>
  * (HOU-687): the bearer is read LIVE per attempt (never a pinned copy), and a
  * 401 triggers one single-flight session refresh and one replay with the fresh
  * token. A 401 that survives the refresh is returned as-is — a real sign-out
- * must surface, not spin. With no refresher installed (static tokens, tests)
- * the refresh resolves null and this degrades to a plain live-token fetch.
+ * must surface, not spin. A refresh beaten TRANSIENTLY by the network (a
+ * sleep-wake reconnect still settling — HOU-1106) throws the transport-shaped
+ * TypeError `refreshLiveToken` mints, exactly as if the request itself had
+ * dropped: `transientRetryFetch` re-attempts reads (re-running the refresh
+ * each time), and a persistent failure surfaces as connectivity, never as a
+ * bogus auth error. With no refresher installed (static tokens, tests) the
+ * refresh resolves null and this degrades to a plain live-token fetch.
  *
  * With NO bearer at all in hosted mode the request is not sent: the refresher
  * is asked once (bridging the boot race where queries fire before the restored

--- a/packages/web/src/engine-adapter/session-refresh.ts
+++ b/packages/web/src/engine-adapter/session-refresh.ts
@@ -9,6 +9,17 @@
  * client: auth ownership stays with the shell that configured it. No refresher
  * installed (static-token hosts, dev bearers, tests) → refresh resolves null
  * and the original 401 stands.
+ *
+ * The refresher's answer is three-valued, and the distinction is load-bearing
+ * (HOU-1106): a token means refreshed, null means the session is terminally
+ * gone (a real sign-out — the caller lets its 401 surface), and a TRANSIENT
+ * failure — the identity service unreachable while a sleep-wake reconnect
+ * settles — THROWS. Both installers already speak this contract: the desktop's
+ * `refreshNow()` rethrows `IdentityError("network")` precisely so callers
+ * retry instead of signing the user out, and the web's `getIdToken(true)`
+ * throws FirebaseError `auth/network-request-failed`. Flattening that throw to
+ * null (as this seam once did) turned every wake-from-sleep refresh race into
+ * a bogus "invalid or expired token" red toast + Sentry report.
  */
 
 declare global {
@@ -24,10 +35,28 @@ declare global {
 let inflight: Promise<string | null> | null = null;
 
 /**
- * Force-refresh the hosted session and resolve the new access token, or null
- * when there is no refresher or the refresh failed (a real sign-out — the
- * caller lets its 401 surface). Concurrent callers share one refresh; a caller
- * arriving after it settles starts a new one.
+ * A refresher failure that means "couldn't reach the identity service", not
+ * "the session is gone": the desktop's typed `IdentityError("network")`, the
+ * Firebase SDK's `auth/network-request-failed`, or a raw fetch transport
+ * rejection (always a TypeError). Anything else is treated as terminal, so an
+ * unexpected refresher bug still surfaces as the 401 it produced.
+ */
+const isTransientRefreshFailure = (err: unknown): boolean => {
+  if (err instanceof TypeError) return true;
+  const code = (err as { code?: unknown } | null)?.code;
+  return code === "network" || code === "auth/network-request-failed";
+};
+
+/**
+ * Force-refresh the hosted session. Resolves the new access token; resolves
+ * null when there is no refresher or the session is terminally gone (a real
+ * sign-out — the caller lets its 401 surface); THROWS a transport-shaped
+ * `TypeError` when the refresher failed transiently. The message starts with
+ * "Load failed" on purpose: that is the prefix the app's connectivity
+ * classifier (`isNetworkTransportError`, HOU-1085) keys on, so a refresh
+ * beaten by a settling reconnect surfaces as the one deduped connectivity
+ * notice — never as an auth error or a Sentry report. Concurrent callers
+ * share one refresh; a caller arriving after it settles starts a new one.
  */
 export function refreshLiveToken(): Promise<string | null> {
   const refresh =
@@ -37,7 +66,12 @@ export function refreshLiveToken(): Promise<string | null> {
   if (!refresh) return Promise.resolve(null);
   if (!inflight) {
     inflight = refresh()
-      .catch(() => null)
+      .catch((err: unknown) => {
+        if (isTransientRefreshFailure(err)) {
+          throw new TypeError("Load failed (session refresh)", { cause: err });
+        }
+        return null;
+      })
       .finally(() => {
         inflight = null;
       });

--- a/packages/web/tests/session-refresh-transient.test.ts
+++ b/packages/web/tests/session-refresh-transient.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { isHoustonEngineError } from "../src/engine-adapter/client/errors";
+import { cpFetch } from "../src/engine-adapter/cp/fetch";
+
+// HOU-1106 (Sentry HOUSTON-APP-515): a sleep-wake reconnect leaves every live
+// query holding an expired bearer. The gateway answers 401, and the session
+// refresh — racing the same settling network — can fail TRANSIENTLY. That
+// must read as connectivity (a transport-shaped TypeError the app's
+// classifier routes to the offline toast, retried for reads), never as the
+// terminal "invalid or expired token" auth error it used to surface as.
+
+const CFG = { baseUrl: "https://gateway.example", token: "stale" };
+
+const UNAUTHORIZED = () =>
+  new Response(JSON.stringify({ error: "invalid or expired token" }), {
+    status: 401,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const OK = () =>
+  new Response(JSON.stringify([]), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+/** Gateway stub: 401 for the stale bearer, 200 once "fresh" is presented. */
+function stubGateway(): { bearers: (string | null)[] } {
+  const bearers: (string | null)[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const auth = new Headers(init?.headers).get("Authorization");
+      bearers.push(auth);
+      return auth === "Bearer fresh" ? OK() : UNAUTHORIZED();
+    }),
+  );
+  return { bearers };
+}
+
+function installRefresher(impl: () => Promise<string | null>): void {
+  vi.stubGlobal("window", { __HOUSTON_SESSION_REFRESH__: vi.fn(impl) });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+test("transient refresh failure on a read self-heals on the blind retry", async () => {
+  const gw = stubGateway();
+  // First refresh attempt loses to the settling network; the retry succeeds.
+  let calls = 0;
+  installRefresher(() => {
+    calls += 1;
+    if (calls === 1) {
+      return Promise.reject(new TypeError("Load failed"));
+    }
+    return Promise.resolve("fresh");
+  });
+  const pending = cpFetch(CFG, "/agents/a/skills");
+  await vi.advanceTimersByTimeAsync(2_000);
+  const res = await pending;
+  expect(res.status).toBe(200);
+  // stale → (refresh threw, attempt dropped) → stale again → fresh replay.
+  expect(gw.bearers).toEqual(["Bearer stale", "Bearer stale", "Bearer fresh"]);
+});
+
+test("persistent transient refresh failure surfaces as transport, not auth", async () => {
+  stubGateway();
+  installRefresher(() =>
+    Promise.reject(
+      Object.assign(new Error("network"), { code: "network" }), // desktop IdentityError shape
+    ),
+  );
+  const pending = cpFetch(CFG, "/agents/a/skills").then(
+    () => {
+      throw new Error("expected rejection");
+    },
+    (err: unknown) => err,
+  );
+  await vi.advanceTimersByTimeAsync(5_000);
+  const err = await pending;
+  // The exact message the app's isNetworkTransportError classifier keys on:
+  // this failure takes the connectivity path (info toast, no Sentry).
+  expect(err).toBeInstanceOf(TypeError);
+  expect((err as TypeError).message).toBe("Load failed (session refresh)");
+  expect(isHoustonEngineError(err)).toBe(false);
+});
+
+test("firebase network-request-failed is transient too", async () => {
+  stubGateway();
+  installRefresher(() =>
+    Promise.reject(
+      Object.assign(new Error("net"), { code: "auth/network-request-failed" }),
+    ),
+  );
+  const pending = cpFetch(CFG, "/agents/a/skills").then(
+    () => {
+      throw new Error("expected rejection");
+    },
+    (err: unknown) => err,
+  );
+  await vi.advanceTimersByTimeAsync(5_000);
+  expect(await pending).toBeInstanceOf(TypeError);
+});
+
+test("terminal refresh (null) still surfaces the real 401 — a sign-out must not hide", async () => {
+  stubGateway();
+  installRefresher(() => Promise.resolve(null));
+  const pending = cpFetch(CFG, "/agents/a/skills").then(
+    () => {
+      throw new Error("expected rejection");
+    },
+    (err: unknown) => err,
+  );
+  await vi.advanceTimersByTimeAsync(5_000);
+  const err = await pending;
+  expect(isHoustonEngineError(err)).toBe(true);
+  expect((err as { status: number }).status).toBe(401);
+});
+
+test("an unexpected refresher bug is treated as terminal, not connectivity", async () => {
+  stubGateway();
+  installRefresher(() => Promise.reject(new Error("refresher exploded")));
+  const pending = cpFetch(CFG, "/agents/a/skills").then(
+    () => {
+      throw new Error("expected rejection");
+    },
+    (err: unknown) => err,
+  );
+  await vi.advanceTimersByTimeAsync(5_000);
+  const err = await pending;
+  expect(isHoustonEngineError(err)).toBe(true);
+  expect((err as { status: number }).status).toBe(401);
+});
+
+test("refresh succeeding replays with the fresh bearer (HOU-687 unchanged)", async () => {
+  const gw = stubGateway();
+  installRefresher(() => Promise.resolve("fresh"));
+  const res = await cpFetch(CFG, "/agents/a/skills");
+  expect(res.status).toBe(200);
+  expect(gw.bearers).toEqual(["Bearer stale", "Bearer fresh"]);
+});


### PR DESCRIPTION
Fixes HOU-1106 (Sentry HOUSTON-APP-515: `list_skills: invalid or expired token (engine error 401)` — 42 events / 11 users since 2026-07-23).

## Root cause

A sleep-wake reconnect fires every live query with the Firebase ID token that expired during sleep. The gateway answers 401 and `gatewayAuthFetch` (HOU-687) asks the session-refresh seam for a fresh bearer. Both refreshers deliberately signal *transient* failure by throwing — the desktop's `refreshNow()` rethrows `IdentityError("network")` precisely so callers retry instead of signing out, and the web's `getIdToken(true)` throws `auth/network-request-failed`. The refresh call targets `securetoken.googleapis.com` (cold DNS/TLS) while the reconnect is still settling, so it routinely loses the race even as the warm gateway connection answers 401s.

But the adapter's `refreshLiveToken()` did `.catch(() => null)`, flattening that transient throw into the *terminal* "real sign-out" answer. The stale-token 401 then stood, `cpFetch` threw `HoustonEngineError(401, "invalid or expired token")`, and the surfacing layer treated a connectivity blip as an auth failure: a red "we have a problem" toast pair per query plus a Sentry report — instead of the HOU-1085 connectivity path (one deduped info toast, no capture).

## Fix

- `session-refresh.ts`: the seam contract is now honestly three-valued — token, `null` only for terminal sign-out, and a transport-shaped `TypeError("Load failed (session refresh)")` for transient refresher failures (desktop `IdentityError("network")`, Firebase `auth/network-request-failed`, raw fetch `TypeError`). Unknown refresher errors stay terminal so a real bug still surfaces as its 401.
- `cp/fetch.ts`: the throw propagates through `gatewayAuthFetch`. `transientRetryFetch` blind-retries reads (~2s window), re-running the refresh each attempt — the burst **self-heals** as soon as the reconnect settles. A persistent failure surfaces via `isNetworkTransportError` as the existing connectivity notice, never a bogus auth error or Sentry noise.
- `cp/events.ts`: the SSE `onUnauthorized` fire-and-forget refresh gets a `.catch` so the new throw can't become an unhandled rejection.

## Tests

- `packages/web/tests/session-refresh-transient.test.ts` (new, 6 cases): transient failure self-heals on the blind retry; persistent transient failure rejects with the transport `TypeError` (not `HoustonEngineError`); Firebase network code is transient; refresher `null` and unexpected refresher bugs still surface the real 401; the plain HOU-687 refresh/replay path is unchanged.
- `app/tests/network-transport-error.test.ts`: lockstep tripwire asserting the classifier matches the adapter-minted message.

Gates: houston-web vitest 359/359 · app node:test 2588/2588 · `pnpm typecheck` (all 27 projects) · shim parity · Biome clean.

## Repro (before)

1. On a desktop build signed into managed cloud, put the Mac to sleep (or cut the network) for >1h so the Firebase ID token expires.
2. Wake it and reconnect; while the network is still settling, open a screen that fires gateway reads (skills/activities lists).
3. Red "we have a problem" + "report sent" toast pairs appear and Sentry receives `<source>: invalid or expired token (engine error 401)` events — grouped under HOUSTON-APP-515.

Deterministic harness repro: stub `window.__HOUSTON_SESSION_REFRESH__` to reject with `IdentityError("network")` and answer gateway calls 401 — on `main`, the new test file's "persistent transient refresh failure" case fails (it gets `HoustonEngineError 401`).

## Verify (after)

1. Same wake-from-sleep sequence: the app shows at most one "You're offline"-style info toast (the HOU-1085 dedup), then recovers silently once the network settles — queries replay with the freshly minted token, and no new HOUSTON-APP-515 events are recorded for the session.
2. `pnpm --filter houston-web exec vitest run tests/session-refresh-transient.test.ts` — 6/6 pass.
3. Real sign-out still surfaces: with a revoked refresh token, gateway calls still fail with the 401 auth error (covered by the terminal-null test case).