### PR TITLE
fix(runtime): refuse a served google 'API key' that is an OAuth token (HOU-1107)

### DIFF
--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { accessDigest } from "@houston/protocol/access-digest";
 import { expect, test } from "vitest";
 import { PROVIDERS } from "../ai/providers";
 import { config } from "../config";
@@ -14,6 +15,7 @@ import {
 } from "./auth-file";
 import { selectExportCredential } from "./export";
 import { syncServedCredential } from "./serve";
+import { resetDeadKeyReportsForTest } from "./served-key-guard";
 
 /** The host's authoritative "not connected" 404 (see routes/credential.ts). */
 const notConnected404 = () =>
@@ -610,5 +612,93 @@ test("scrub leaves api-key entries untouched (no refresh token to strip)", () =>
   expect(auth["amazon-bedrock"]).toEqual({
     type: "api_key",
     key: "bedrock-KEEP",
+  });
+});
+
+// --- Dead served google keys (HOU-1107 / Sentry HOUSTON-APP-4Y9) ---
+
+/** Serves a google api_key credential; captures revoked-token reports. */
+function deadGoogleFetch(access: string) {
+  const reports: Array<Record<string, unknown>> = [];
+  let signalReport: (() => void) | undefined;
+  const reportSeen = new Promise<void>((resolve) => {
+    signalReport = resolve;
+  });
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/sandbox/credential/revoked") {
+      reports.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      signalReport?.();
+      return new Response(JSON.stringify({ ok: true, removed: true }), {
+        status: 200,
+      });
+    }
+    if (url.searchParams.get("provider") === "google") {
+      return new Response(
+        JSON.stringify({
+          provider: "google",
+          kind: "api_key",
+          access,
+          expires: Number.MAX_SAFE_INTEGER,
+          accountId: null,
+        }),
+        { status: 200 },
+      );
+    }
+    return notConnected404();
+  }) as unknown as typeof globalThis.fetch;
+  return { fetchImpl, reports, reportSeen };
+}
+
+test("a served google 'api key' that is an OAuth token is refused, removed, and reported", async () => {
+  resetDeadKeyReportsForTest();
+  const { fetchImpl, reports, reportSeen } =
+    deadGoogleFetch("ya29.a0DeadToken");
+  await withServeMode(fetchImpl, async () => {
+    const path = join(config.dataDir, "auth.json");
+    const manifestPath = join(config.dataDir, "served-providers.json");
+    // An earlier (unguarded) sync already applied the dead key to this pod.
+    writeFileSync(
+      path,
+      JSON.stringify({ google: { type: "api_key", key: "ya29.a0DeadToken" } }),
+    );
+    writeServedProvidersAt(manifestPath, ["google"]);
+
+    // Refused: never applied, and the previously-applied copy is dropped so
+    // google reads not-connected (the visible connect card) instead of
+    // burning every turn on a doomed 401.
+    expect(await syncServedCredential()).toEqual([]);
+    expect(readAuth(path).google).toBeUndefined();
+    expect(readServedProvidersAt(manifestPath)).toEqual([]);
+
+    // Reported by digest so the store deletes the central row (HOU-952
+    // pipeline) — the whole workspace heals, not just this pod.
+    await reportSeen;
+    expect(reports).toEqual([
+      {
+        provider: "google",
+        accessSha256: accessDigest("ya29.a0DeadToken"),
+        scope: "team",
+      },
+    ]);
+
+    // A second sync re-serves the same dead key (the delete is idempotent on
+    // the store side); the report is deduped for the pod's lifetime.
+    expect(await syncServedCredential()).toEqual([]);
+    expect(reports.length).toBe(1);
+  });
+});
+
+test("a served google key with the real AIza shape is applied normally", async () => {
+  resetDeadKeyReportsForTest();
+  const { fetchImpl, reports } = deadGoogleFetch("AIzaSyServedRealKey");
+  await withServeMode(fetchImpl, async () => {
+    expect(await syncServedCredential()).toEqual(["google"]);
+    const auth = readAuth(join(config.dataDir, "auth.json"));
+    expect(auth.google).toEqual({
+      type: "api_key",
+      key: "AIzaSyServedRealKey",
+    });
+    expect(reports).toEqual([]);
   });
 });

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -12,6 +12,7 @@ import {
   writeServedProvidersAt,
 } from "./auth-file";
 import { logServeProbeFailure, noteServeProbeOk } from "./serve-log";
+import { reportDeadServedApiKey, servedApiKeyIsDead } from "./served-key-guard";
 import { forgetServedScope, recordServedScope } from "./served-scope";
 import { authStorage } from "./storage";
 
@@ -188,6 +189,23 @@ async function runServedSync(): Promise<string[]> {
   let manifestDirty = false;
   for (const probe of probes) {
     if (probe.state !== "error") noteServeProbeOk(probe.id);
+    if (probe.state === "served" && servedApiKeyIsDead(probe.cred)) {
+      // A served "API key" that can never authenticate (a legacy OAuth token
+      // stored as a google key — HOU-1107) must not reach auth.json: applying
+      // it burns every turn on a doomed 401 and the next sync re-applies it.
+      // Refuse it, drop any previously-applied copy (provenance-gated like the
+      // not-connected path below), and report the dead central row so the
+      // store stops serving it to the whole workspace (HOU-952 pipeline).
+      reportDeadServedApiKey(probe.cred);
+      forgetServedScope(probe.id);
+      if (manifest.has(probe.id)) {
+        if (removeServedCredentialAt(authPathFor(), probe.id))
+          removed.push(probe.id);
+        manifest.delete(probe.id);
+        manifestDirty = true;
+      }
+      continue;
+    }
     if (probe.state === "served") {
       const didApply = applyServedCredential(authPathFor(), probe.cred);
       // WHOSE credential this was, remembered for the provider-error stamp and

--- a/packages/runtime/src/auth/served-key-guard.test.ts
+++ b/packages/runtime/src/auth/served-key-guard.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "vitest";
+import type { ServedCredential } from "./auth-file";
+import { servedApiKeyIsDead } from "./served-key-guard";
+
+const served = (over: Partial<ServedCredential>): ServedCredential => ({
+  provider: "google",
+  access: "AIzaSyExample-Key",
+  expires: Number.MAX_SAFE_INTEGER,
+  accountId: null,
+  kind: "api_key",
+  ...over,
+});
+
+test("a google api_key that is an OAuth access token reads dead", () => {
+  // The legacy family behind HOUSTON-APP-4Y9: pre-verification pastes stored
+  // OAuth material as google "API keys".
+  expect(servedApiKeyIsDead(served({ access: "ya29.a0AfH6SMBx" }))).toBe(true);
+  expect(
+    servedApiKeyIsDead(served({ access: "eyJhbGciOiJSUzI1NiJ9.x.y" })),
+  ).toBe(true);
+  expect(servedApiKeyIsDead(served({ access: "aa" }))).toBe(true);
+});
+
+test("a real Gemini key (AIza…) is never refused", () => {
+  expect(servedApiKeyIsDead(served({}))).toBe(false);
+});
+
+test("the guard is google-only and api_key-only", () => {
+  // Other providers' key shapes are not this crisp — never judge them here.
+  expect(
+    servedApiKeyIsDead(served({ provider: "openrouter", access: "ya29.x" })),
+  ).toBe(false);
+  // A google oauth serve is a different (already-guarded) story: pi resolves
+  // it to no-auth, and the store cannot serve one past its expiry.
+  expect(servedApiKeyIsDead(served({ kind: "oauth", access: "ya29.x" }))).toBe(
+    false,
+  );
+  // A pre-kind wire (kind absent) is written as oauth, not api_key.
+  expect(
+    servedApiKeyIsDead(served({ kind: undefined, access: "ya29.x" })),
+  ).toBe(false);
+});

--- a/packages/runtime/src/auth/served-key-guard.ts
+++ b/packages/runtime/src/auth/served-key-guard.ts
@@ -1,0 +1,112 @@
+import { accessDigest } from "@houston/protocol/access-digest";
+import { config } from "../config";
+import { currentCredentialScope } from "../session/acting-context";
+import type { ServedCredential } from "./auth-file";
+
+/**
+ * Guard against a served "API key" that can never authenticate (HOU-1107,
+ * Sentry HOUSTON-APP-4Y9: 404 failed Gemini turns across 110 users, all
+ * managed-cloud).
+ *
+ * Before the paste-a-key live verification existed, any pasted string was
+ * stored as a connected google credential; users pasted OAuth access tokens
+ * (`ya29.…`, JWTs) instead of Gemini API keys, and those were captured into
+ * the central store as `api_key` rows. The store treats api_key rows as
+ * never-expiring and has no google refresher, so it serves the dead token to
+ * every pod forever; pi sends it as `x-goog-api-key` and Google answers
+ * 401 UNAUTHENTICATED (`ACCESS_TOKEN_TYPE_UNSUPPORTED`) on every turn — with
+ * the serve sync re-applying the credential before the next one.
+ *
+ * Refusing the credential here (serve.ts) turns the burning 401 into the
+ * honest state — google reads not-connected, the UI shows the connect card —
+ * and the report below deletes the central row so the whole workspace heals,
+ * not just this pod. New pastes cannot recreate these rows: verify-api-key.ts
+ * live-verifies a google key against the models-list endpoint.
+ */
+
+/**
+ * True when the served credential is a google "api_key" whose value cannot be
+ * a Gemini API key. Every Google Cloud API key starts with `AIza` (a
+ * documented, stable prefix); the legacy garbage never does — it is OAuth
+ * material (`ya29.…` user tokens, `eyJ…` JWTs). Scoped to google only: no
+ * other provider has this legacy family, and other providers' key shapes are
+ * not this crisp.
+ */
+export function servedApiKeyIsDead(cred: ServedCredential): boolean {
+  return (
+    cred.provider === "google" &&
+    cred.kind === "api_key" &&
+    !cred.access.startsWith("AIza")
+  );
+}
+
+/** One report per (scope, provider, token) per pod lifetime — the serve sync
+ *  runs on every turn and hydrating route, and the store's delete is already
+ *  idempotent, so repeats are pure noise. */
+const reported = new Set<string>();
+
+/**
+ * Tell the control plane the served key is dead so it stops serving it —
+ * the same digest-named compare-and-delete the revoked-token path uses
+ * (HOU-952: routes/credential-revoked.ts → store removeIfAccess). The token
+ * is named by digest, never shipped; a report racing a user's reconnect
+ * cannot delete the fresh credential.
+ *
+ * Fire-and-forget and never throws: this runs inside the serve sync, and a
+ * reporting hiccup must not fail the hydration it rides on.
+ */
+export function reportDeadServedApiKey(cred: ServedCredential): void {
+  void report(cred).catch(() => {});
+}
+
+async function report(cred: ServedCredential): Promise<void> {
+  if (!config.controlPlaneUrl || !config.sandboxToken) return;
+  const { key, actingAs } = currentCredentialScope();
+  const digest = accessDigest(cred.access);
+  const dedupe = `${key}:${cred.provider}:${digest}`;
+  if (reported.has(dedupe)) return;
+  reported.add(dedupe);
+  console.error(
+    `[serve] served ${cred.provider} credential is not an API key (an OAuth-type token that can never authenticate) — refusing it and reporting the dead central row`,
+  );
+  try {
+    const res = await fetch(
+      `${config.controlPlaneUrl}/sandbox/credential/revoked`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.sandboxToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          provider: cred.provider,
+          accessSha256: digest,
+          scope: cred.scope === "personal" ? "personal" : "team",
+          ...(actingAs ? { actingAs } : {}),
+        }),
+        signal: AbortSignal.timeout(REPORT_TIMEOUT_MS),
+      },
+    );
+    if (!res.ok) {
+      // Let a later sync retry against a control plane that answers.
+      reported.delete(dedupe);
+      console.warn(
+        `[serve] dead-key report for ${cred.provider} failed: ${res.status}`,
+      );
+    }
+  } catch (err) {
+    reported.delete(dedupe);
+    console.warn(
+      `[serve] dead-key report for ${cred.provider} failed:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+/** One stalled control-plane socket must not outlive the sync it rides on. */
+const REPORT_TIMEOUT_MS = 10_000;
+
+/** Test-only: clear the per-pod report dedupe. */
+export function resetDeadKeyReportsForTest(): void {
+  reported.clear();
+}

--- a/packages/runtime/src/transport/server-providers-scope.test.ts
+++ b/packages/runtime/src/transport/server-providers-scope.test.ts
@@ -220,7 +220,9 @@ test("GET /providers labels WHOSE credential served each acting identity", async
           ? {
               provider,
               kind: "api_key",
-              access: "sk-team-gemini",
+              // AIza-shaped: a served google key of any other shape is the
+              // dead legacy family served-key-guard.ts refuses (HOU-1107).
+              access: "AIzaTeamGemini",
               expires: 0,
               accountId: null,
               scope: "team",


### PR DESCRIPTION
## Root cause

Sentry `HOUSTON-APP-4Y9`: 404 failed Gemini turns across 110 users, all managed-cloud, every one a 401 `UNAUTHENTICATED` / `ACCESS_TOKEN_TYPE_UNSUPPORTED` from `generativelanguage.googleapis.com`.

Google's reason code means the request presented an OAuth-type token where the Gemini API expects an API key. pi's google provider is API-key-only (`x-goog-api-key`), so the value stored as the key is itself OAuth material (`ya29.…` / JWT). These come from a legacy family: before the paste-a-key live verification existed, any pasted string was stored as a connected google credential; users pasted OAuth access tokens instead of `AIza…` keys and those were captured into the central store as `api_key` rows. The store treats `api_key` rows as never-expiring and has no google refresher, so it serves the dead token to every pod in the workspace forever — and the serve sync re-applies it before every turn, so nothing can heal. Same disease as HOU-952 (dead credential served as healthy), different organ.

## Fix

New `served-key-guard.ts` at the serve seam (`runServedSync`):

- A served `google` credential of `kind=api_key` whose value does not start with `AIza` (the documented, stable prefix of every Google Cloud API key) can never authenticate. It is never written to `auth.json`, and a previously-applied copy is dropped — provenance-gated exactly like the not-connected path — so google reads not-connected and the user gets the visible connect card instead of a burning 401.
- The dead credential is reported through the existing revoked-token pipeline (`POST /sandbox/credential/revoked`, digest-named compare-and-delete — the HOU-952 plumbing, which is kind-agnostic end to end), so the central row is deleted and the whole workspace heals, not just this pod. One report per (scope, provider, token) per pod lifetime.

New pastes cannot recreate these rows: `verify-api-key.ts` live-verifies google keys against the models-list endpoint, which rejects OAuth tokens.

The guard is deliberately google-only: no other provider has this legacy family, and no other provider's key shape is this crisp.

## Reproduce (before)

1. Seed a workspace's central store with a google credential `kind=api_key`, access `ya29.<anything>` (any legacy affected workspace already has one).
2. Start a Gemini turn on a managed pod: the serve sync writes `{type:"api_key", key:"ya29.…"}` into `auth.json`, pi sends it as `x-goog-api-key`, and Google answers the 401 above. Every retry fails identically; reconnect pressure never clears the central row.

## Verify (after)

1. Same setup on a patched engine: the first serve sync logs `[serve] served google credential is not an API key…`, google never lands in `auth.json`, and the gateway logs `provider revoked a served token; disconnecting org credential` and deletes the row.
2. The client shows Google Gemini as not connected; pasting a real `AIza…` key verifies, captures centrally, and Gemini turns succeed.
3. `HOUSTON-APP-4Y9` event rate decays to zero after the engine roll.

## Tests

- `served-key-guard.test.ts`: shape predicate (ya29/JWT/garbage dead; `AIza…` never refused; google-only, api_key-only).
- `serve.test.ts`: full sync — dead key refused + previously-applied copy removed + reported by digest with the HOU-952 body shape + report deduped across syncs; `AIza…` key applied normally.
- Gates: runtime 945 ✓, host 1208 ✓, biome ✓, boundaries ✓, tsgo ✓.