### PR TITLE
fix(providers): pin the Claude sign-in child's cwd so the CLI's shell probe can't self-filter (HOUSTON-APP-4YP)

### DIFF
--- a/app/src-tauri/src/claude_login/resolve.rs
+++ b/app/src-tauri/src/claude_login/resolve.rs
@@ -72,6 +72,14 @@ pub(super) fn build_login_command(bin: &Path, config_dir: &Path) -> Command {
     for (key, value) in crate::shell_env::claude_shell_env() {
         cmd.env(key, value);
     }
+    // Spawn from the user's home dir, NOT the inherited cwd: the CLI's shell
+    // probe discards which() hits inside its own cwd, so an inherited
+    // `C:\Windows\System32` (autostart / deep-link launches) silently filters
+    // out the very PowerShell the env repair above made reachable
+    // (HOUSTON-APP-4YP's post-repair residue).
+    if let Some(cwd) = crate::shell_env::claude_spawn_cwd() {
+        cmd.current_dir(cwd);
+    }
     #[cfg(windows)]
     {
         // `claude.exe` is a console binary and this GUI app has no console:
@@ -195,6 +203,16 @@ mod tests {
         assert_eq!(extract_visit_url("Opening browser to sign in"), None);
         // Marker but no http(s) token.
         assert_eq!(extract_visit_url("please visit: the docs"), None);
+    }
+
+    #[test]
+    fn build_login_command_pins_cwd_to_home() {
+        // The login child must never inherit the app's cwd — an inherited
+        // `C:\Windows\System32` makes the CLI's shell probe filter out the
+        // built-in PowerShell and fail the sign-in (HOUSTON-APP-4YP).
+        let cmd = build_login_command(Path::new("/nonexistent/claude"), Path::new("/tmp/config"));
+        let expected = crate::shell_env::claude_spawn_cwd().expect("home dir resolves");
+        assert_eq!(cmd.as_std().get_current_dir(), Some(expected.as_path()));
     }
 
     #[test]

--- a/app/src-tauri/src/shell_env.rs
+++ b/app/src-tauri/src/shell_env.rs
@@ -20,6 +20,27 @@
 //! On non-Windows this contributes nothing — the CLI has no shell gate there.
 
 use std::ffi::OsString;
+use std::path::PathBuf;
+
+/// Working directory for a child that will execute the Claude Code CLI.
+///
+/// The env repair below is not enough on its own: the CLI's Windows shell
+/// gate resolves `pwsh`/`powershell` with a which()-style lookup that
+/// DISCARDS any hit living under the child's current working directory (a
+/// cwd-hijack guard inside the CLI). A Houston launch that inherits
+/// `C:\Windows\System32` as cwd — the autostart Run key and `houston://`
+/// deep-link activations do — therefore filters out the built-in PowerShell
+/// 5.1 under `System32\WindowsPowerShell\v1.0`, and on a machine with no Git
+/// Bash and no PowerShell 7 the CLI exits 1 even though the PATH repair made
+/// `powershell` resolvable (HOUSTON-APP-4YP, still firing after the repair
+/// shipped). Pin the child to the user's home directory instead: it always
+/// exists and no shell binary lives under it. `None` (no resolvable home)
+/// keeps the inherited cwd — never fail a spawn over this.
+pub fn claude_spawn_cwd() -> Option<PathBuf> {
+    let var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    let home = PathBuf::from(std::env::var_os(var)?);
+    home.is_dir().then_some(home)
+}
 
 /// Env pairs to merge into a child that will execute the Claude Code CLI.
 /// Empty on non-Windows and on Windows machines that need no repair.
@@ -177,5 +198,13 @@ mod tests {
     #[test]
     fn claude_shell_env_is_inert_off_windows() {
         assert!(claude_shell_env().is_empty());
+    }
+
+    #[test]
+    fn claude_spawn_cwd_is_an_existing_home_dir() {
+        // Every CI/dev host has a resolvable home; the contract is "an
+        // existing directory the CLI's cwd-filter can't collide with".
+        let cwd = claude_spawn_cwd().expect("home dir resolves");
+        assert!(cwd.is_dir());
     }
 }


### PR DESCRIPTION
## Problem

Sentry [HOUSTON-APP-4YP](https://houston-cd.sentry.io/issues/7623733551/) — `Claude sign-in failed (exit 1): Claude Code on Windows requires either Git for Windows (for bash) or PowerShell` — is still firing through **0.5.39** (194 events / 14d), even though #1014 repairs the child PATH so the CLI's `powershell` fallback should always resolve.

## Root cause

Extracted the gate logic from the bundled `claude.exe` (agent-sdk 0.3.201). On Windows the CLI resolves a shell as: Git Bash (absolute paths + `where git`) → `Bun.which("pwsh")` → absolute pwsh fallbacks → `Bun.which("powershell")`. But **every `Bun.which` result is passed through a cwd-hijack guard that discards hits located inside the process's own cwd**.

When Houston is launched with an inherited cwd of `C:\Windows\System32` — the autostart Run key and `houston://` deep-link activations do exactly that — `System32\WindowsPowerShell\v1.0\powershell.exe` sits *inside* the cwd and is filtered out. On a machine with no Git and no PowerShell 7, the gate exits 1 no matter what PATH says. The #1014 PATH repair never had a chance on those launches.

## Fix

Spawn the sign-in child from the user's home directory (`shell_env::claude_spawn_cwd()`, applied in `build_login_command`): it always exists and no shell binary lives under it, so the CLI's cwd filter can't collide with the PowerShell it needs. No resolvable home ⇒ keep the inherited cwd rather than fail the spawn.

Turn-time CLI spawns already run with `cwd: workspaceDir` (`packages/runtime/src/backends/claude/backend.ts`), so the login helper was the one remaining spawn that inherited the app's cwd.

Users need to install nothing — connect + approve in the browser works again on stock Windows machines.

## Tests

- `shell_env::tests::claude_spawn_cwd_is_an_existing_home_dir`
- `claude_login::resolve::tests::build_login_command_pins_cwd_to_home` (regression: the login child must never inherit the app's cwd)
- `cargo test --lib`: 206 passed; `cargo check` clean; `cargo fmt` applied.