### PR TITLE
fix(integrations): typed refusal + friendly copy for OAuth-only toolkits with no app (HOU-1110)

### DIFF
--- a/app/src/components/integrations/use-connect-flow.ts
+++ b/app/src/components/integrations/use-connect-flow.ts
@@ -2,9 +2,11 @@ import type { IntegrationToolkit } from "@houston-ai/engine-client";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { analytics } from "../../lib/analytics";
 import { logAndReportError } from "../../lib/error-report";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriIntegrations, tauriSystem } from "../../lib/tauri";
+import { isToolkitOauthUnavailableError } from "../../lib/toolkit-oauth-unavailable";
 import {
   connectFlowRegistry,
   useConnectFlowStore,
@@ -128,8 +130,35 @@ export function useConnectFlow(opts: { agentId?: string }): ConnectFlow {
         // Agent context: pass the agent slug so the gateway enforces the
         // agent's effective allowlist on connect (Teams v2). Undefined on the
         // account-level Integrations page.
-        mintLink: (slug) =>
-          tauriIntegrations.connect(INTEGRATION_PROVIDER, slug, agentId),
+        //
+        // An OAuth-unavailable refusal (the toolkit only signs in via OAuth
+        // and Houston has no app registered for it yet — HOU-1110, highlevel)
+        // is a Houston-side setup gap, not a crash: the engine call is
+        // silenced for it, so THIS is its one surface — friendly copy, plus an
+        // analytics event so demand for the missing app stays visible.
+        mintLink: async (slug) => {
+          try {
+            return await tauriIntegrations.connect(
+              INTEGRATION_PROVIDER,
+              slug,
+              agentId,
+            );
+          } catch (err) {
+            if (isToolkitOauthUnavailableError(err)) {
+              analytics.track("integration_connect_unavailable", {
+                integration_slug: slug,
+              });
+              addToast({
+                title: t("connectResult.unavailableTitle", {
+                  app: appName(slug),
+                }),
+                description: t("connectResult.unavailable"),
+                variant: "error",
+              });
+            }
+            throw err;
+          }
+        },
         openUrl: (url) => tauriSystem.openUrl(url),
         readConnection: (connectionId) =>
           tauriIntegrations.connection(INTEGRATION_PROVIDER, connectionId),
@@ -150,7 +179,17 @@ export function useConnectFlow(opts: { agentId?: string }): ConnectFlow {
       entry.promise = run;
       return { outcome: await run, initiated: true };
     },
-    [agentId, announce, qc, setNotice, setOrigin, setStep],
+    [
+      agentId,
+      announce,
+      appName,
+      addToast,
+      t,
+      qc,
+      setNotice,
+      setOrigin,
+      setStep,
+    ],
   );
 
   const reopen = useCallback(async (toolkit: string) => {

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -99,6 +99,10 @@ export type AnalyticsEventName =
   | "conversation_map_back_to_latest_clicked"
   // Feature adoption
   | "integration_connected"
+  // A connect was refused because Houston has no OAuth app registered for the
+  // toolkit (HOU-1110) — carries `integration_slug`, so demand for a missing
+  // app registration stays visible without a Sentry issue per click.
+  | "integration_connect_unavailable"
   | "integration_disconnected"
   | "custom_integration_started"
   // A custom integration landed via the manual add form (carries

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -57,6 +57,7 @@ import { isNetworkTransportError } from "./network-transport-error";
 import { osIsTauri, osPickDirectory } from "./os-bridge";
 import { normalizeLegacyModel } from "./providers";
 import { isNeedsUpgradeError, isPersonalSpaceError } from "./team-status-model";
+import { isToolkitOauthUnavailableError } from "./toolkit-oauth-unavailable";
 import type {
   Agent,
   CommunitySkillResult,
@@ -1838,10 +1839,15 @@ export const tauriIntegrations = {
     ),
   /** Begin an app connection. `agent` (the agent slug) scopes the connect to a
    *  per-agent surface so the gateway applies the agent's allowlist + auto-grant
-   *  (Teams v2); omit it for the account-level Integrations page. */
+   *  (Teams v2); omit it for the account-level Integrations page. An
+   *  OAuth-unavailable refusal (a Houston-side setup gap, HOU-1110) is expected
+   *  + explainable: the connect flow surfaces its own copy, so no raw toast. */
   connect: (provider: string, toolkit: string, agent?: string) =>
-    call("integration_connect", () =>
-      getEngine().connectIntegration(provider, toolkit, agent),
+    call(
+      "integration_connect",
+      () => getEngine().connectIntegration(provider, toolkit, agent),
+      { provider, toolkit },
+      { silence: isToolkitOauthUnavailableError },
     ),
   connection: (provider: string, connectionId: string) =>
     call("integration_connection", () =>

--- a/app/src/lib/toolkit-oauth-unavailable.ts
+++ b/app/src/lib/toolkit-oauth-unavailable.ts
@@ -1,0 +1,38 @@
+/**
+ * The typed reason a connect was refused because the toolkit only offers OAuth
+ * and no OAuth app is registered for it (HOU-1110: highlevel) — a Houston-side
+ * setup gap, not a user error and not a crash. The host tags it with a stable
+ * `code` in its 400 body (`composio-auth-config.ts`); the connect flow keys
+ * friendly copy on it instead of relaying the operator remedy to an end user.
+ */
+export const TOOLKIT_OAUTH_UNAVAILABLE = "toolkit_oauth_unavailable";
+
+/** The transitional match for a cloud gateway that predates the typed code: it
+ *  still relays the raw auth-config error as a 500 whose `detail` carries this
+ *  marker. Remove once the gateway's counterpart change is deployed. */
+const LEGACY_DETAIL_MARKER = "only offers OAuth";
+
+/**
+ * True when a thrown connect error means the toolkit cannot be connected until
+ * Houston registers an OAuth app for it. Duck-typed on the error's `body`
+ * (raw text from the local runtime-client's `EngineError`, parsed JSON from the
+ * cloud control plane's `HoustonEngineError`) — this app-level helper must not
+ * import either class.
+ */
+export function isToolkitOauthUnavailableError(err: unknown): boolean {
+  if (!err || typeof err !== "object" || !("body" in err)) return false;
+  let body = (err as { body?: unknown }).body;
+  if (typeof body === "string") {
+    try {
+      body = JSON.parse(body);
+    } catch {
+      return false;
+    }
+  }
+  const { code, detail } = (body ?? {}) as {
+    code?: unknown;
+    detail?: unknown;
+  };
+  if (code === TOOLKIT_OAUTH_UNAVAILABLE) return true;
+  return typeof detail === "string" && detail.includes(LEGACY_DETAIL_MARKER);
+}

--- a/app/src/locales/en/integrations.json
+++ b/app/src/locales/en/integrations.json
@@ -28,6 +28,8 @@
     "connected": "{{app}} is connected",
     "timeoutTitle": "Still waiting for {{app}}",
     "timeout": "We stopped checking for now. When you finish signing in, connect {{app}} again.",
+    "unavailableTitle": "{{app}} can't be connected yet",
+    "unavailable": "The Houston team still needs to finish setting up this app. Please check back soon.",
     "failedTitle": "{{app}} could not be connected",
     "failed": "Something went wrong while signing in. Please try connecting it again."
   },

--- a/app/src/locales/es/integrations.json
+++ b/app/src/locales/es/integrations.json
@@ -28,6 +28,8 @@
     "connected": "{{app}} está conectada",
     "timeoutTitle": "Seguimos esperando {{app}}",
     "timeout": "Dejamos de revisar por ahora. Cuando termines de iniciar sesión, conecta {{app}} de nuevo.",
+    "unavailableTitle": "Aún no se puede conectar {{app}}",
+    "unavailable": "El equipo de Houston todavía necesita terminar de configurar esta app. Vuelve a intentarlo pronto.",
     "failedTitle": "No se pudo conectar {{app}}",
     "failed": "Algo salió mal al iniciar sesión. Inténtalo de nuevo."
   },

--- a/app/src/locales/pt/integrations.json
+++ b/app/src/locales/pt/integrations.json
@@ -28,6 +28,8 @@
     "connected": "O {{app}} está conectado",
     "timeoutTitle": "Ainda esperando o {{app}}",
     "timeout": "Paramos de verificar por enquanto. Quando terminar de entrar, conecte o {{app}} de novo.",
+    "unavailableTitle": "Ainda não é possível conectar o {{app}}",
+    "unavailable": "A equipe do Houston ainda precisa terminar de configurar este app. Tente de novo em breve.",
     "failedTitle": "Não foi possível conectar o {{app}}",
     "failed": "Algo deu errado ao entrar. Tente conectar novamente."
   },

--- a/app/tests/toolkit-oauth-unavailable.test.ts
+++ b/app/tests/toolkit-oauth-unavailable.test.ts
@@ -1,0 +1,84 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { isToolkitOauthUnavailableError } from "../src/lib/toolkit-oauth-unavailable.ts";
+
+// The two adapter error shapes the connect flow can catch: the cloud control
+// plane throws with a PARSED JSON body (HoustonEngineError), the local
+// runtime-client with the RAW response text (EngineError). Both must be
+// recognized when they carry the typed code, plus the transitional gateway
+// shape (a 500 whose `detail` carries the raw auth-config message) until the
+// gateway's counterpart change deploys.
+
+const cloudError = (body: unknown) => Object.assign(new Error("x"), { body });
+const localError = (text: string) =>
+  Object.assign(new Error("x"), { body: text });
+
+describe("isToolkitOauthUnavailableError", () => {
+  it("matches the typed code on a parsed cloud error body", () => {
+    strictEqual(
+      isToolkitOauthUnavailableError(
+        cloudError({ error: "…", code: "toolkit_oauth_unavailable" }),
+      ),
+      true,
+    );
+  });
+
+  it("matches the typed code on a raw local error body", () => {
+    strictEqual(
+      isToolkitOauthUnavailableError(
+        localError(
+          JSON.stringify({ error: "…", code: "toolkit_oauth_unavailable" }),
+        ),
+      ),
+      true,
+    );
+  });
+
+  it("matches the legacy gateway 500 shape via its detail marker", () => {
+    strictEqual(
+      isToolkitOauthUnavailableError(
+        localError(
+          JSON.stringify({
+            detail:
+              'composio: toolkit "highlevel" only offers OAuth and Composio has no managed app for it — register a developer OAuth app for it in the Composio dashboard, then connecting will reuse that auth config',
+            error: "integrations route failed",
+          }),
+        ),
+      ),
+      true,
+    );
+  });
+
+  it("rejects other typed codes", () => {
+    strictEqual(
+      isToolkitOauthUnavailableError(
+        cloudError({ error: "…", code: "toolkit_no_auth" }),
+      ),
+      false,
+    );
+  });
+
+  it("rejects other gateway 500 details", () => {
+    strictEqual(
+      isToolkitOauthUnavailableError(
+        localError(
+          JSON.stringify({
+            detail: "composio POST /api/v3/auth_configs → 500: upstream hiccup",
+            error: "integrations route failed",
+          }),
+        ),
+      ),
+      false,
+    );
+  });
+
+  it("rejects unparseable bodies, bodyless errors, and non-objects", () => {
+    strictEqual(isToolkitOauthUnavailableError(localError("<html>")), false);
+    strictEqual(isToolkitOauthUnavailableError(new Error("x")), false);
+    strictEqual(isToolkitOauthUnavailableError(null), false);
+    strictEqual(
+      isToolkitOauthUnavailableError("toolkit_oauth_unavailable"),
+      false,
+    );
+  });
+});

--- a/packages/host/src/integrations/composio-auth-config.ts
+++ b/packages/host/src/integrations/composio-auth-config.ts
@@ -99,8 +99,20 @@ interface RawToolkitDetail {
  *  connect page, so only those are connectable fallbacks. */
 const OAUTH_MODES = new Set(["OAUTH1", "OAUTH1A", "OAUTH2"]);
 
+/** OAuth-only + unmanaged is a KNOWN deployment gap, not a server fault: typed
+ *  as a 400 the route relays verbatim, so the frontend can key friendly copy on
+ *  the code (HOU-1110: highlevel surfaced this as a raw 500 with the operator
+ *  remedy shown to an end user). The `.message` keeps the remedy for logs and
+ *  self-host operators; `body.error` is the fallback a generic surface shows. */
+export const TOOLKIT_OAUTH_UNAVAILABLE = "toolkit_oauth_unavailable";
+
 function oauthOnlyError(toolkit: string): Error {
-  return new Error(
+  return new IntegrationUpstreamError(
+    400,
+    {
+      error: `connecting ${toolkit} is not available yet: it needs an OAuth app registered in the Composio dashboard`,
+      code: TOOLKIT_OAUTH_UNAVAILABLE,
+    },
     `composio: toolkit '${toolkit}' only offers OAuth and Composio has no managed app for it — register a developer OAuth app for it in the Composio dashboard, then connecting will reuse that auth config`,
   );
 }

--- a/packages/host/src/integrations/composio.test.ts
+++ b/packages/host/src/integrations/composio.test.ts
@@ -380,9 +380,11 @@ test("a gone managed app with no collectible fallback names the remedy, not the 
     }
     return { status: 404 };
   });
-  await expect(provider.connect(USER, "ghostmanaged")).rejects.toThrow(
-    /only offers OAuth.*Composio dashboard/,
-  );
+  const err = await provider.connect(USER, "ghostmanaged").catch((e) => e);
+  expect(err).toBeInstanceOf(IntegrationUpstreamError);
+  expect(err.status).toBe(400);
+  expect(err.body).toMatchObject({ code: "toolkit_oauth_unavailable" });
+  expect(err.message).toMatch(/only offers OAuth.*Composio dashboard/);
 });
 
 test("a managed create that fails for a non-400 reason surfaces raw, no fallback", async () => {
@@ -432,9 +434,11 @@ test("connect refuses an OAuth-only toolkit with no managed app, naming the reme
     }
     return { status: 404 };
   });
-  await expect(provider.connect(USER, "oauthonly")).rejects.toThrow(
-    /only offers OAuth.*Composio dashboard/,
-  );
+  const err = await provider.connect(USER, "oauthonly").catch((e) => e);
+  expect(err).toBeInstanceOf(IntegrationUpstreamError);
+  expect(err.status).toBe(400);
+  expect(err.body).toMatchObject({ code: "toolkit_oauth_unavailable" });
+  expect(err.message).toMatch(/only offers OAuth.*Composio dashboard/);
 });
 
 test("connect on a NO_AUTH toolkit is a clean 400, not a doomed Composio POST", async () => {


### PR DESCRIPTION
Fixes HOU-1110. Also fixes HOU-1116 (twitter: same root cause, different toolkit slug — see the duplicate-closed #1202).

## Root cause (HOU-1110)

Connecting **HighLevel** fails because the Composio toolkit `highlevel` only offers OAuth2 and Composio has **no managed OAuth app** for it (confirmed against Composio's docs: "Composio Managed App Available? No"). Houston's auth-config resolution correctly refuses — nothing can complete that OAuth dance without a registered developer app — but the refusal surfaced as a raw **500** whose operator-remedy text ("register a developer OAuth app in the Composio dashboard") was toasted verbatim to a non-technical end user (Sentry event `67348de9212142b483f076847a0c4c1b`, thrown by the Go gateway's copy of the same logic).

**Making HighLevel actually connectable is an ops action, not a code change**: register a GoHighLevel developer OAuth app for the `highlevel` toolkit in the Composio dashboard (prod project). Once an enabled auth config exists, `resolveAuthConfig` reuses it and connect works with no deploy.

## What this PR changes

- **Host** (`packages/host/src/integrations/composio-auth-config.ts`): the OAuth-only refusal is now a typed `IntegrationUpstreamError(400, { error, code: "toolkit_oauth_unavailable" })` the route relays verbatim (same pattern as `toolkit_no_auth`), instead of a plain `Error` → opaque 500. The `.message` keeps the operator remedy for logs/self-hosters.
- **App**: new `isToolkitOauthUnavailableError` helper (duck-typed on the error body, mirroring `api-key-connect-error.ts`) matching the typed code **and**, transitionally, the current gateway 500 `detail` shape until the gateway ships its counterpart. The connect flow silences the raw jargon toast for this case and shows friendly i18n copy (en/es/pt): "*{app} can't be connected yet — the Houston team still needs to finish setting up this app.*" A new `integration_connect_unavailable` analytics event (with `integration_slug`) keeps demand for missing app registrations visible without a Sentry issue per click.

## Follow-ups (not in this PR)

- **Ops**: register the GoHighLevel OAuth app in the Composio dashboard — the actual enabler for HighLevel.
- **Cloud repo**: mirror the typed 400 in `internal/integrations/authconfig.go` so the gateway path stops 500ing (the app already handles both shapes).

## Verification

Before: click Connect on HighLevel (Integrations tab or the in-chat connect card) → red toast "engine request failed (500): {\"detail\":\"composio: toolkit \"highlevel\" only offers OAuth…\"}" + a Sentry issue.

After: same click → one friendly toast "HighLevel can't be connected yet", row settles to its failed state, `integration_connect_unavailable` tracked; server responds 400 `{error, code: "toolkit_oauth_unavailable"}` on the direct path.

Tests: host vitest (139 files / 1208 pass, incl. two assertions upgraded to check status+code), app `pnpm test` (2594 pass, new `toolkit-oauth-unavailable.test.ts`), `tsgo --noEmit`, `check-locales`, `check:boundaries`, Biome clean.
