### PR TITLE
fix(integrations): unconnectable OAuth-only toolkit is an expected state, not a 500 (HOU-1116)

### DIFF
--- a/app/src/components/integrations/use-connect-flow.ts
+++ b/app/src/components/integrations/use-connect-flow.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { logAndReportError } from "../../lib/error-report";
+import { isUnconnectableToolkitError } from "../../lib/integration-connect-error";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriIntegrations, tauriSystem } from "../../lib/tauri";
 import {
@@ -128,8 +129,31 @@ export function useConnectFlow(opts: { agentId?: string }): ConnectFlow {
         // Agent context: pass the agent slug so the gateway enforces the
         // agent's effective allowlist on connect (Teams v2). Undefined on the
         // account-level Integrations page.
-        mintLink: (slug) =>
-          tauriIntegrations.connect(INTEGRATION_PROVIDER, slug, agentId),
+        //
+        // An app Houston cannot offer OAuth for yet (`toolkit_oauth_unmanaged`
+        // — twitter, HOU-1116) is an expected state, not a bug: `call()` keeps
+        // it off Sentry and the red toast, and the copy here names the real
+        // reason instead of the generic "something went wrong".
+        mintLink: async (slug) => {
+          try {
+            return await tauriIntegrations.connect(
+              INTEGRATION_PROVIDER,
+              slug,
+              agentId,
+            );
+          } catch (err) {
+            if (isUnconnectableToolkitError(err)) {
+              addToast({
+                title: t("connectResult.unavailableTitle", {
+                  app: appName(slug),
+                }),
+                description: t("connectResult.unavailable"),
+                variant: "info",
+              });
+            }
+            throw err;
+          }
+        },
         openUrl: (url) => tauriSystem.openUrl(url),
         readConnection: (connectionId) =>
           tauriIntegrations.connection(INTEGRATION_PROVIDER, connectionId),
@@ -150,7 +174,17 @@ export function useConnectFlow(opts: { agentId?: string }): ConnectFlow {
       entry.promise = run;
       return { outcome: await run, initiated: true };
     },
-    [agentId, announce, qc, setNotice, setOrigin, setStep],
+    [
+      agentId,
+      addToast,
+      announce,
+      appName,
+      qc,
+      setNotice,
+      setOrigin,
+      setStep,
+      t,
+    ],
   );
 
   const reopen = useCallback(async (toolkit: string) => {

--- a/app/src/lib/integration-connect-error.ts
+++ b/app/src/lib/integration-connect-error.ts
@@ -1,0 +1,38 @@
+/**
+ * Detection for the `toolkit_oauth_unmanaged` connect rejection (HOU-1116:
+ * twitter). The toolkit only offers OAuth and Composio has no managed app for
+ * it, so connecting is impossible until an OAuth app is registered for it in
+ * the Composio dashboard — an EXPECTED, operator-side state, not a Houston
+ * bug. `call()` silences the generic red toast + Sentry report and the connect
+ * flow explains it with its own copy instead.
+ *
+ * The code arrives in different shapes per deployment: the direct engine
+ * adapter throws an `EngineError` whose `body`/message embed the host's JSON
+ * (`{"error":..., "code":"toolkit_oauth_unmanaged"}`), while the cloud gateway
+ * re-wraps that body under a `detail` string. A structured `code` read plus a
+ * substring fallback covers both without coupling to either wrapper.
+ */
+export const TOOLKIT_OAUTH_UNMANAGED = "toolkit_oauth_unmanaged";
+
+export function isUnconnectableToolkitError(err: unknown): boolean {
+  const e = err as
+    | { code?: unknown; body?: unknown; message?: unknown }
+    | null
+    | undefined;
+  if (e?.code === TOOLKIT_OAUTH_UNMANAGED) return true;
+  const body = e?.body;
+  if (
+    body &&
+    typeof body === "object" &&
+    (body as { code?: unknown }).code === TOOLKIT_OAUTH_UNMANAGED
+  ) {
+    return true;
+  }
+  if (typeof body === "string" && body.includes(TOOLKIT_OAUTH_UNMANAGED)) {
+    return true;
+  }
+  return (
+    typeof e?.message === "string" &&
+    e.message.includes(TOOLKIT_OAUTH_UNMANAGED)
+  );
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -51,6 +51,7 @@ import {
 } from "./engine-mode";
 import { isUploadTooLargeError } from "./files-upload-limits";
 import i18n from "./i18n";
+import { isUnconnectableToolkitError } from "./integration-connect-error";
 import { logger } from "./logger";
 import { isMissingSkillError } from "./missing-skill";
 import { isNetworkTransportError } from "./network-transport-error";
@@ -1838,10 +1839,16 @@ export const tauriIntegrations = {
     ),
   /** Begin an app connection. `agent` (the agent slug) scopes the connect to a
    *  per-agent surface so the gateway applies the agent's allowlist + auto-grant
-   *  (Teams v2); omit it for the account-level Integrations page. */
+   *  (Teams v2); omit it for the account-level Integrations page. An
+   *  OAuth-only toolkit with no registered OAuth app (`toolkit_oauth_unmanaged`
+   *  — HOU-1116) is an expected state the connect flow explains with its own
+   *  copy, not a bug toast + Sentry report. */
   connect: (provider: string, toolkit: string, agent?: string) =>
-    call("integration_connect", () =>
-      getEngine().connectIntegration(provider, toolkit, agent),
+    call(
+      "integration_connect",
+      () => getEngine().connectIntegration(provider, toolkit, agent),
+      undefined,
+      { silence: isUnconnectableToolkitError },
     ),
   connection: (provider: string, connectionId: string) =>
     call("integration_connection", () =>

--- a/app/src/locales/en/integrations.json
+++ b/app/src/locales/en/integrations.json
@@ -29,7 +29,9 @@
     "timeoutTitle": "Still waiting for {{app}}",
     "timeout": "We stopped checking for now. When you finish signing in, connect {{app}} again.",
     "failedTitle": "{{app}} could not be connected",
-    "failed": "Something went wrong while signing in. Please try connecting it again."
+    "failed": "Something went wrong while signing in. Please try connecting it again.",
+    "unavailableTitle": "{{app}} can't be connected yet",
+    "unavailable": "This app needs extra setup on Houston's side before accounts can connect. We're working on it, please check back later."
   },
   "grants": {
     "disconnect": {

--- a/app/src/locales/es/integrations.json
+++ b/app/src/locales/es/integrations.json
@@ -29,7 +29,9 @@
     "timeoutTitle": "Seguimos esperando {{app}}",
     "timeout": "Dejamos de revisar por ahora. Cuando termines de iniciar sesión, conecta {{app}} de nuevo.",
     "failedTitle": "No se pudo conectar {{app}}",
-    "failed": "Algo salió mal al iniciar sesión. Inténtalo de nuevo."
+    "failed": "Algo salió mal al iniciar sesión. Inténtalo de nuevo.",
+    "unavailableTitle": "Aún no se puede conectar {{app}}",
+    "unavailable": "Esta app necesita configuración adicional de parte de Houston antes de poder conectar cuentas. Estamos trabajando en ello, vuelve a intentarlo más tarde."
   },
   "grants": {
     "disconnect": {

--- a/app/src/locales/pt/integrations.json
+++ b/app/src/locales/pt/integrations.json
@@ -29,7 +29,9 @@
     "timeoutTitle": "Ainda esperando o {{app}}",
     "timeout": "Paramos de verificar por enquanto. Quando terminar de entrar, conecte o {{app}} de novo.",
     "failedTitle": "Não foi possível conectar o {{app}}",
-    "failed": "Algo deu errado ao entrar. Tente conectar novamente."
+    "failed": "Algo deu errado ao entrar. Tente conectar novamente.",
+    "unavailableTitle": "Ainda não é possível conectar o {{app}}",
+    "unavailable": "Este app precisa de configuração adicional do lado da Houston antes de conectar contas. Estamos trabalhando nisso, tente novamente mais tarde."
   },
   "grants": {
     "disconnect": {

--- a/app/tests/integration-connect-error.test.ts
+++ b/app/tests/integration-connect-error.test.ts
@@ -1,0 +1,68 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  isUnconnectableToolkitError,
+  TOOLKIT_OAUTH_UNMANAGED,
+} from "../src/lib/integration-connect-error.ts";
+
+describe("unconnectable-toolkit classifier (HOU-1116)", () => {
+  it("matches a structured top-level code", () => {
+    strictEqual(
+      isUnconnectableToolkitError({ code: TOOLKIT_OAUTH_UNMANAGED }),
+      true,
+    );
+  });
+
+  it("matches a parsed JSON body carrying the code", () => {
+    strictEqual(
+      isUnconnectableToolkitError({
+        status: 400,
+        body: {
+          error: "composio: toolkit 'twitter'…",
+          code: TOOLKIT_OAUTH_UNMANAGED,
+        },
+      }),
+      true,
+    );
+  });
+
+  it("matches an EngineError whose body is the host's raw JSON string", () => {
+    // packages/runtime-client EngineError keeps the response text verbatim.
+    strictEqual(
+      isUnconnectableToolkitError({
+        status: 400,
+        body: '{"error":"composio: toolkit \'twitter\' only offers OAuth…","code":"toolkit_oauth_unmanaged"}',
+        message:
+          'engine request failed (400): {"error":"…","code":"toolkit_oauth_unmanaged"}',
+      }),
+      true,
+    );
+  });
+
+  it("matches the cloud gateway's re-wrapped detail (message only)", () => {
+    // The prod shape from the HOU-1116 Sentry event: the gateway folds the
+    // engine body into a `detail` string, so only the message carries the code.
+    strictEqual(
+      isUnconnectableToolkitError(
+        new Error(
+          'engine request failed (400): {"detail":"{\\"error\\":\\"composio: toolkit \\\\\\"twitter\\\\\\"…\\",\\"code\\":\\"toolkit_oauth_unmanaged\\"}","error":"integrations route failed"}',
+        ),
+      ),
+      true,
+    );
+  });
+
+  it("rejects other coded rejections and plain failures", () => {
+    strictEqual(
+      isUnconnectableToolkitError({
+        status: 400,
+        body: { code: "toolkit_no_auth" },
+      }),
+      false,
+    );
+    strictEqual(isUnconnectableToolkitError(new Error("network down")), false);
+    strictEqual(isUnconnectableToolkitError(null), false);
+    strictEqual(isUnconnectableToolkitError(undefined), false);
+    strictEqual(isUnconnectableToolkitError("boom"), false);
+  });
+});

--- a/packages/host/src/integrations/composio-auth-config.ts
+++ b/packages/host/src/integrations/composio-auth-config.ts
@@ -99,9 +99,16 @@ interface RawToolkitDetail {
  *  connect page, so only those are connectable fallbacks. */
 const OAUTH_MODES = new Set(["OAUTH1", "OAUTH1A", "OAUTH2"]);
 
-function oauthOnlyError(toolkit: string): Error {
-  return new Error(
-    `composio: toolkit '${toolkit}' only offers OAuth and Composio has no managed app for it — register a developer OAuth app for it in the Composio dashboard, then connecting will reuse that auth config`,
+/** A coded 400, not a plain Error: connecting such a toolkit (twitter —
+ *  HOU-1116) is impossible until the OPERATOR registers a developer OAuth app
+ *  in the Composio dashboard, so the client must receive an expected,
+ *  explainable state it can render calmly, never an opaque 500. */
+function oauthOnlyError(toolkit: string): IntegrationUpstreamError {
+  const detail = `composio: toolkit '${toolkit}' only offers OAuth and Composio has no managed app for it — register a developer OAuth app for it in the Composio dashboard, then connecting will reuse that auth config`;
+  return new IntegrationUpstreamError(
+    400,
+    { error: detail, code: "toolkit_oauth_unmanaged" },
+    detail,
   );
 }
 

--- a/packages/host/src/integrations/composio.test.ts
+++ b/packages/host/src/integrations/composio.test.ts
@@ -380,9 +380,16 @@ test("a gone managed app with no collectible fallback names the remedy, not the 
     }
     return { status: 404 };
   });
-  await expect(provider.connect(USER, "ghostmanaged")).rejects.toThrow(
-    /only offers OAuth.*Composio dashboard/,
+  const failure = await provider.connect(USER, "ghostmanaged").then(
+    () => null,
+    (err: unknown) => err,
   );
+  expect(failure).toBeInstanceOf(IntegrationUpstreamError);
+  expect((failure as IntegrationUpstreamError).status).toBe(400);
+  expect((failure as IntegrationUpstreamError).body).toMatchObject({
+    code: "toolkit_oauth_unmanaged",
+  });
+  expect(String(failure)).toMatch(/only offers OAuth.*Composio dashboard/);
 });
 
 test("a managed create that fails for a non-400 reason surfaces raw, no fallback", async () => {
@@ -432,9 +439,16 @@ test("connect refuses an OAuth-only toolkit with no managed app, naming the reme
     }
     return { status: 404 };
   });
-  await expect(provider.connect(USER, "oauthonly")).rejects.toThrow(
-    /only offers OAuth.*Composio dashboard/,
+  const failure = await provider.connect(USER, "oauthonly").then(
+    () => null,
+    (err: unknown) => err,
   );
+  expect(failure).toBeInstanceOf(IntegrationUpstreamError);
+  expect((failure as IntegrationUpstreamError).status).toBe(400);
+  expect((failure as IntegrationUpstreamError).body).toMatchObject({
+    code: "toolkit_oauth_unmanaged",
+  });
+  expect(String(failure)).toMatch(/only offers OAuth.*Composio dashboard/);
 });
 
 test("connect on a NO_AUTH toolkit is a clean 400, not a doomed Composio POST", async () => {


### PR DESCRIPTION
## HOU-1116 — Can't connect X integration

### Root cause
The Composio `twitter` toolkit only offers OAuth and Composio has no managed OAuth app for it, and no developer OAuth app is registered for it in our Composio project. `resolveAuthConfig` correctly refuses to mint an auth config, but `oauthOnlyError` threw a plain `Error`, which fell past `relayIntegrationUpstreamError` and surfaced as an opaque 500 (`integrations route failed`) — a red bug toast with raw JSON, a Sentry error (event `28b148e2822247408cbf11be38b7930d`), and an inline "No se pudo conectar" with no explanation.

### Fix
- **Host**: `oauthOnlyError` is now a coded 400 `IntegrationUpstreamError` with `code: "toolkit_oauth_unmanaged"`, mirroring the existing `toolkit_no_auth` pattern. The operator remedy stays in the message.
- **App**: new `isUnconnectableToolkitError` classifier (covers the structured body, the raw `EngineError` body string, and the cloud gateway's `detail`-wrapped shape). `call()` silences the generic bug toast + Sentry capture for it, and the connect flow shows a calm, translated info toast instead: "X can't be connected yet" (en/es/pt).

Note: this makes the state honest; actually enabling X connects requires registering an X developer OAuth app in the Composio dashboard (operational, not in this repo).

### Repro (before)
1. Sign in on cloud/web, open Integrations, find **Twitter**, click **+**.
2. Connect dies with a red "could not be connected" toast carrying raw `engine request failed (500): {"detail":"composio: toolkit \"twitter\" only offers OAuth…"}`, the row shows "Could not connect", and a Sentry `integration_connect` error is filed.

### Verify (after)
1. Same steps: click **+** on Twitter.
2. The engine returns a clean 400 with `code: toolkit_oauth_unmanaged"`; the app shows the info toast "Twitter can't be connected yet" with the explanation, no red bug toast, no Sentry event.
3. Tests: `pnpm --filter @houston/host test` (composio auth-config coded-400 assertions), `cd app && pnpm test` (classifier unit tests incl. the prod gateway-wrapped shape), `pnpm check-locales`, `pnpm check`, app+web typechecks — all green.

Once an X OAuth app is registered in Composio, the same connect flow works with no further code change (`resolveAuthConfig` reuses the enabled auth config).