### PR TITLE
fix(app): gateway 'engine unavailable' 503 surfaces as an agent-waking notice, not a bug (HOU-1114)

### DIFF
--- a/app/src/lib/engine-waking-error.ts
+++ b/app/src/lib/engine-waking-error.ts
@@ -1,0 +1,30 @@
+// The "is this failure just the agent's pod waking up?" classifier for the
+// error-surfacing layer (HOU-1114). Dependency-free so it is node-testable
+// directly (app/tests/engine-waking-error.test.ts) and importable from
+// anywhere.
+//
+// On the hosted profile the gateway answers a per-agent request with
+// `503 {"error": "engine unavailable"}` when the agent's engine pod is not
+// reachable yet — a freshly installed store agent still provisioning, or an
+// asleep pod mid cold-start. The request self-heals on retry once the pod is
+// up; nothing in Houston broke, so the red "we have a problem" bug toast +
+// Sentry report is the wrong surface (a user who just installed an agent read
+// it as the install failing). Keyed on the exact gateway reason string, NOT on
+// bare status 503: other 503 bodies ("setup pod unreachable", provider quota
+// pages, self-host proxies) carry different reasons and must keep surfacing as
+// real errors.
+
+/**
+ * A gateway "engine unavailable" 503: the agent's engine pod is warming up or
+ * unreachable, and the same request succeeds once it wakes. Matched
+ * structurally (name + status + message prefix) so this stays dependency-free;
+ * `HoustonEngineError` mints the message as `"<reason> (engine error <status>)"`
+ * with the gateway's reason verbatim.
+ */
+export function isEngineWakingError(err: unknown): boolean {
+  if (!(err instanceof Error) || err.name !== "HoustonEngineError") {
+    return false;
+  }
+  const status = (err as { status?: unknown }).status;
+  return status === 503 && err.message.startsWith("engine unavailable");
+}

--- a/app/src/lib/error-toast.ts
+++ b/app/src/lib/error-toast.ts
@@ -112,6 +112,32 @@ export function showConnectivityErrorToast(
   });
 }
 
+/**
+ * Surface a gateway "engine unavailable" 503 (HOU-1114) as ONE informational
+ * "your agent is waking up" toast. The agent's engine pod is provisioning (a
+ * just-installed store agent) or cold-starting; every per-agent call fails the
+ * same way until it wakes, so the toast dedupes on its constant displayed body
+ * and the burst reads as one state, not a storm. No Sentry capture and no
+ * green "report sent" toast: nothing in Houston broke and the request
+ * self-heals on retry; the raw diagnostic still reaches the frontend log via
+ * the caller's `logger.error` plus the `[toast:…]` line here. The analytics
+ * event fires only past the dedupe, mirroring `showErrorToast`.
+ */
+export function showEngineWakingToast(command: string, message: string): void {
+  console.error(`[toast:${command}] ${message}`);
+  const description = i18n.t("shell:errorToast.engineWakingDescription");
+  if (isDuplicateToast(description, Date.now())) return;
+  analytics.track("app_error_shown", {
+    source: command,
+    error_kind: classifyAnalyticsError(message),
+  });
+  useUIStore.getState().addToast({
+    title: i18n.t("shell:errorToast.engineWakingTitle"),
+    description,
+    variant: "info",
+  });
+}
+
 export function showErrorToast(
   command: string,
   message: string,

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -49,6 +49,7 @@ import {
   isLoopbackHostUrl,
   providerLoginUsesDeviceAuthByDefault,
 } from "./engine-mode";
+import { isEngineWakingError } from "./engine-waking-error";
 import { isUploadTooLargeError } from "./files-upload-limits";
 import i18n from "./i18n";
 import { logger } from "./logger";
@@ -217,6 +218,18 @@ async function surfaceError(
   if (isNetworkTransportError(err)) {
     const { showConnectivityErrorToast } = await import("./error-toast");
     showConnectivityErrorToast(label, message);
+    return;
+  }
+
+  // Expected environment state, not a bug: the gateway's "engine unavailable"
+  // 503 — the agent's engine pod is provisioning or cold-starting (HOU-1114: a
+  // just-installed store agent's background writes hit this and showed the red
+  // bug pair while the agent was in fact starting fine). The request succeeds
+  // once the pod wakes; surface it as one deduped "waking up" notice, no
+  // Sentry. The raw diagnostic is already in the log tail above.
+  if (isEngineWakingError(err)) {
+    const { showEngineWakingToast } = await import("./error-toast");
+    showEngineWakingToast(label, message);
     return;
   }
 

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -65,7 +65,9 @@
     "reportSentDescription": "Reference #{{id}}.",
     "copyId": "Copy code",
     "offlineTitle": "Houston, connection lost",
-    "offlineDescription": "We can't reach Houston right now. Check your internet connection and try again."
+    "offlineDescription": "We can't reach Houston right now. Check your internet connection and try again.",
+    "engineWakingTitle": "Houston, your agent is waking up",
+    "engineWakingDescription": "It will be ready in a moment. Try again shortly."
   },
   "agentDelete": {
     "title": "Delete agent?",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -65,7 +65,9 @@
     "reportSentDescription": "Referencia #{{id}}.",
     "copyId": "Copiar código",
     "offlineTitle": "Houston, sin conexión",
-    "offlineDescription": "No podemos conectarnos a Houston en este momento. Revisa tu conexión a internet e inténtalo de nuevo."
+    "offlineDescription": "No podemos conectarnos a Houston en este momento. Revisa tu conexión a internet e inténtalo de nuevo.",
+    "engineWakingTitle": "Houston, tu agente se está despertando",
+    "engineWakingDescription": "Estará listo en un momento. Inténtalo de nuevo en breve."
   },
   "agentDelete": {
     "title": "¿Eliminar el agente?",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -65,7 +65,9 @@
     "reportSentDescription": "Referência #{{id}}.",
     "copyId": "Copiar código",
     "offlineTitle": "Houston, sem conexão",
-    "offlineDescription": "Não conseguimos conectar ao Houston agora. Verifique sua conexão com a internet e tente novamente."
+    "offlineDescription": "Não conseguimos conectar ao Houston agora. Verifique sua conexão com a internet e tente novamente.",
+    "engineWakingTitle": "Houston, seu agente está acordando",
+    "engineWakingDescription": "Ele estará pronto em um momento. Tente novamente em breve."
   },
   "agentDelete": {
     "title": "Excluir o agente?",

--- a/app/tests/engine-waking-error.test.ts
+++ b/app/tests/engine-waking-error.test.ts
@@ -1,0 +1,62 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { isEngineWakingError } from "../src/lib/engine-waking-error.ts";
+
+// HOU-1114: the surfacing-layer classifier that keeps the gateway's
+// "engine unavailable" 503 (agent pod provisioning / cold-starting) out of the
+// red bug-toast + Sentry pipeline. It must match exactly the gateway's
+// pod-unreachable answer, and must NEVER match other 503s — a false positive
+// here silently drops a real bug report.
+
+/** The shape `HoustonEngineError` mints (structural stand-in, keeps the test
+ *  dependency-free like the classifier itself). */
+function engineError(status: number, reason?: string): Error {
+  const err = new Error(
+    reason ? `${reason} (engine error ${status})` : `engine error ${status}`,
+  ) as Error & { status: number };
+  err.name = "HoustonEngineError";
+  err.status = status;
+  return err;
+}
+
+describe("isEngineWakingError", () => {
+  it("matches the gateway's engine-unavailable 503", () => {
+    strictEqual(
+      isEngineWakingError(engineError(503, "engine unavailable")),
+      true,
+    );
+  });
+
+  it("never matches other 503 reasons", () => {
+    strictEqual(
+      isEngineWakingError(engineError(503, "setup pod unreachable")),
+      false,
+    );
+    strictEqual(isEngineWakingError(engineError(503)), false);
+  });
+
+  it("never matches the same reason on another status", () => {
+    strictEqual(
+      isEngineWakingError(engineError(502, "engine unavailable")),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError(engineError(500, "engine unavailable")),
+      false,
+    );
+  });
+
+  it("requires the HoustonEngineError shape", () => {
+    strictEqual(
+      isEngineWakingError(new Error("engine unavailable (engine error 503)")),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError("engine unavailable (engine error 503)"),
+      false,
+    );
+    strictEqual(isEngineWakingError({ status: 503 }), false);
+    strictEqual(isEngineWakingError(null), false);
+    strictEqual(isEngineWakingError(undefined), false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes HOU-1114.

A user installed an agent from the Agent Store and, while its engine pod was still provisioning, the app showed the red "Houston, we have a problem" bug toast plus an auto-filed report. Sentry event `d67b8287…` (issue HOUSTON-APP-4WZ, 92 events / 71 users since Jul 16) shows the actual failure: a background `write_agent_file` answered by the gateway with `503 {"error": "engine unavailable"}` — the pod-not-reachable-yet state, which self-heals once the pod wakes. Sibling issues (`read_agent_file`, `get_skills_manifest`, `list_conversations`, `list_skills` with the same 503) show the same window hitting every per-agent call.

**Root cause:** the error-surfacing layer treated the gateway's transient "engine unavailable" 503 like any other engine failure. Nothing in the app broke — the agent was starting up fine (the greeting turn was streaming in the screenshot) — but the user was told something went wrong.

**Fix:** classify the gateway's `engine unavailable` 503 as an expected environment state, exactly like the HOU-1085 connectivity classifier:

- `app/src/lib/engine-waking-error.ts` — dependency-free classifier, keyed on the HoustonEngineError shape + status 503 + the exact gateway reason string (other 503 bodies keep surfacing as real errors).
- `surfaceError` in `app/src/lib/tauri.ts` routes it to a deduped informational "your agent is waking up" toast (`showEngineWakingToast` in `error-toast.ts`): one notice per burst, no red bug pair, no Sentry capture. The raw diagnostic still reaches the frontend log tail.
- Localized copy (en/es/pt) under `shell:errorToast.engineWaking*`.
- Unit tests: `app/tests/engine-waking-error.test.ts` (matches the gateway answer; never matches other 503 reasons, other statuses, or non-engine errors).

## Before (reproduces the bug)

1. On a managed-cloud (hosted) build, install an agent from the Agent Store and open it right away, while its pod is still provisioning (or catch any per-agent call during a pod cold-start).
2. A background per-agent call (e.g. `write_agent_file`) gets the gateway's `503 engine unavailable`.
3. Red "Houston, we have a problem. Something unexpected went wrong." toast + green "report sent" toast appear, and a Sentry event is filed — while the agent is in fact starting normally.

## After (verify)

1. Same steps: install a store agent on a hosted build and interact during the warm-up window.
2. At most one informational toast appears: "Houston, your agent is waking up — It will be ready in a moment. Try again shortly." (localized). No red toast, no report-sent toast, no new HOUSTON-APP-4WZ events in Sentry.
3. Once the pod is up, the same actions succeed with no toast.
4. `cd app && pnpm test` — includes the new classifier suite; `pnpm check`, `pnpm check-locales`, and workspace typecheck all pass.

Real (non-waking) failures — other 503 reasons, 4xx/5xx, coding bugs — still take the red toast + Sentry path unchanged.