### PR TITLE
fix(runtime): hold a pi turn's provider error until the prompt settles (HOU-1057)

### DIFF
--- a/packages/runtime/src/backends/pi/session.test.ts
+++ b/packages/runtime/src/backends/pi/session.test.ts
@@ -180,7 +180,7 @@ test("subscribe maps a turn_end with usage to a usage frame", () => {
   ]);
 });
 
-test("subscribe surfaces an errored turn_end as a typed provider_error", () => {
+test("subscribe surfaces an errored turn_end as a typed provider_error once the prompt settles", () => {
   const { stub, session } = make();
   const events: WireEvent[] = [];
   session.subscribe((e) => events.push(e));
@@ -195,6 +195,9 @@ test("subscribe surfaces an errored turn_end as a typed provider_error", () => {
       }),
     ),
   );
+  // Held until the prompt settles — pi may still auto-recover (HOU-1057).
+  expect(events).toEqual([]);
+  stub.emit({ type: "agent_settled" } as AgentSessionEvent);
 
   expect(events).toEqual([
     {

--- a/packages/runtime/src/backends/pi/wire.test.ts
+++ b/packages/runtime/src/backends/pi/wire.test.ts
@@ -378,6 +378,97 @@ test("translator resets its block state on agent_start (a new turn starts fresh)
   });
 });
 
+// --- createWireTranslator: provider errors gated on the prompt's outcome
+// (HOU-1057) ------------------------------------------------------------------
+
+const agentSettled = () =>
+  ({ type: "agent_settled" }) as unknown as AgentSessionEvent;
+
+/** An errored turn_end shaped like a GPT-5.5 context-overflow rejection. */
+const overflowTurnEnd = () =>
+  turnEnd(
+    failedAssistantMessage(
+      "error",
+      "Your input exceeds the context window of this model.",
+      { provider: "openai-codex", model: "gpt-5.5" },
+    ),
+  );
+
+test("translator suppresses an errored turn_end that pi recovers from (HOU-1057)", () => {
+  // The false "chat got too long, switch model" card: one request overflowed,
+  // pi compacted and retried INSIDE the same prompt, and the turn answered
+  // normally — but the errored turn_end had already painted a terminal card.
+  // The error must be held, and a later clean assistant turn must drop it.
+  const translate = createWireTranslator();
+  expect(translate(overflowTurnEnd())).toBeNull();
+  // pi's recovery re-runs the prompt and it succeeds.
+  translate(agentStart());
+  expect(
+    translate(
+      turnEnd(assistantMessage(usage({ totalTokens: 50, output: 10 }))),
+    ),
+  ).toEqual({
+    type: "usage",
+    data: { context_tokens: 40, output_tokens: 10, cached_tokens: 0 },
+  });
+  // The prompt settles clean: no provider_error ever reaches the chat.
+  expect(translate(agentSettled())).toBeNull();
+});
+
+test("translator flushes the held error at agent_settled when recovery never happened", () => {
+  // A failure pi could NOT recover (compaction declined, retries exhausted):
+  // the card must still surface — at settle time, before prompt() resolves.
+  const translate = createWireTranslator();
+  expect(translate(overflowTurnEnd())).toBeNull();
+  const flushed = translate(agentSettled());
+  expect(flushed?.type).toBe("provider_error");
+  expect(flushed && "data" in flushed && flushed.data).toMatchObject({
+    kind: "context_overflow",
+    provider: "openai-codex",
+  });
+  // Once flushed, nothing leaks into the next prompt.
+  expect(translate(agentSettled())).toBeNull();
+});
+
+test("translator keeps the NEWEST failure when a retry fails again", () => {
+  // Overflow recovery retried the prompt and the retry itself failed for a
+  // different reason — the flushed card must name the final failure.
+  const translate = createWireTranslator();
+  expect(translate(overflowTurnEnd())).toBeNull();
+  translate(agentStart());
+  expect(
+    translate(
+      turnEnd(
+        failedAssistantMessage("error", "401 Unauthorized: token expired", {
+          provider: "openai-codex",
+          model: "gpt-5.5",
+        }),
+      ),
+    ),
+  ).toBeNull();
+  const flushed = translate(agentSettled());
+  expect(flushed && "data" in flushed && flushed.data).toMatchObject({
+    kind: "unauthenticated",
+  });
+});
+
+test("translator does NOT treat an aborted turn as recovery — the error still flushes", () => {
+  const translate = createWireTranslator();
+  expect(translate(overflowTurnEnd())).toBeNull();
+  translate(agentStart());
+  translate(
+    turnEnd(
+      failedAssistantMessage("aborted", undefined, {
+        usage: usage({ totalTokens: 10, output: 2 }),
+      }),
+    ),
+  );
+  // An aborted turn is neutral (the Stop is its own surface) — the held error
+  // still flushes at settle so a real failure is never silently dropped.
+  const flushed = translate(agentSettled());
+  expect(flushed?.type).toBe("provider_error");
+});
+
 test("toWire clips an oversized tool result to the preview cap", () => {
   const ev = {
     type: "tool_execution_end",

--- a/packages/runtime/src/backends/pi/wire.ts
+++ b/packages/runtime/src/backends/pi/wire.ts
@@ -81,6 +81,19 @@ export function normalizeUsage(u: unknown): TokenUsage | null {
  * thinking blocks. The separator rides a delta (never emitted standalone), so
  * an empty block can't leave a dangling break. State resets on `agent_start`
  * so a long-lived subscriber never bleeds one turn's blocks into the next.
+ *
+ * It also gates provider errors on the PROMPT's outcome, not the request's
+ * (HOU-1057). pi recovers from mid-prompt failures on its own — a
+ * context-overflow rejection triggers compact-and-retry, a transient 429/529
+ * auto-retries — all inside the same `prompt()` call, so an errored `turn_end`
+ * is not yet a failed turn. Emitting it immediately painted a terminal "chat
+ * got too long, switch model" card over a conversation pi then compacted and
+ * answered normally. Instead the classified error is HELD: a later successful
+ * assistant `turn_end` proves recovery and drops it; `agent_settled` — emitted
+ * exactly once per prompt, after every retry/recovery path — flushes it if the
+ * failure stood, so a real failure still surfaces (and still does so before
+ * `prompt()` resolves, which exec-turn's settle path relies on). An `aborted`
+ * turn_end is neutral: the user's Stop is its own terminal surface.
  */
 export function createWireTranslator(): (
   e: AgentSessionEvent,
@@ -89,6 +102,7 @@ export function createWireTranslator(): (
   let sawThinking = false;
   let sepText = false;
   let sepThinking = false;
+  let heldError: Extract<WireEvent, { type: "provider_error" }> | null = null;
   return (e) => {
     if (e.type === "agent_start") {
       sawText = sawThinking = sepText = sepThinking = false;
@@ -96,8 +110,32 @@ export function createWireTranslator(): (
       const t = e.assistantMessageEvent.type;
       if (t === "text_start" && sawText) sepText = true;
       if (t === "thinking_start" && sawThinking) sepThinking = true;
+    } else if (e.type === "agent_settled") {
+      // The prompt is over — retries and overflow recovery included. If the
+      // last word was still an error, it is now truly terminal: surface it.
+      const out = heldError;
+      heldError = null;
+      return out;
     }
     const wire = toWire(e);
+    if (e.type === "turn_end") {
+      if (wire?.type === "provider_error") {
+        // Newest failure wins: a retry that fails again replaces the held
+        // classification, so the flushed card names the final reason.
+        heldError = wire;
+        return null;
+      }
+      const msg = e.message;
+      if (
+        heldError &&
+        msg?.role === "assistant" &&
+        msg.stopReason !== "error" &&
+        msg.stopReason !== "aborted"
+      ) {
+        // A clean assistant turn after the failure — pi's recovery worked.
+        heldError = null;
+      }
+    }
     if (wire?.type === "text") {
       sawText = true;
       if (sepText) {
@@ -160,7 +198,11 @@ export function toWire(e: AgentSessionEvent): WireEvent | null {
       // `errorMessage`. Classify that into a TYPED provider_error so the chat
       // renders the matching reconnect / rate-limit card; dropping it left the
       // turn a silent, empty success ("no response, no error" — the bug that made
-      // Copilot look dead). "aborted" is the user's own Stop (already surfaced
+      // Copilot look dead). NOTE: raw `toWire` returns the frame immediately, but
+      // the stateful translator above holds it until `agent_settled` — pi may
+      // still recover this prompt (overflow compact-and-retry, transient
+      // auto-retry), and only an unrecovered failure reaches the chat (HOU-1057).
+      // "aborted" is the user's own Stop (already surfaced
       // verbatim by cancelTurn as "Stopped by user"), so it falls through here to
       // the usage path, never double-reported.
       const msg = e.message;


### PR DESCRIPTION
## HOU-1057 — False context length warning appears despite auto-compaction

### Answer to "is the autocompaction even working?"

Yes — twice over, and that's exactly why the card was false:

1. Houston's proactive autocompact (`exec-turn.ts`, 93% threshold) runs before every prompt.
2. When a request still overflows mid-prompt (fill can jump past the window between turns, or the registry window can overstate the provider's real limit), **pi has its own overflow recovery**: it strips the errored message, compacts, and auto-retries the prompt (`_checkCompaction` in pi-coding-agent). That recovery ran in the reported session — which is why the agent "was actually doing the work" and streamed the full answer after the card.

### Root cause of the false card

pi delivers each failed model request as a `turn_end` whose assistant message has `stopReason: "error"`. Houston's pi wire translator classified it and emitted a terminal `provider_error` frame **immediately** — before pi's compact-and-retry (or transient auto-retry) had run. The chat rendered the terminal "This chat got too long for its model / Switch model" card, then the same prompt recovered and answered normally underneath it.

### Fix

The stateful wire translator (`packages/runtime/src/backends/pi/wire.ts`) now gates provider errors on the **prompt's** outcome, not the request's:

- an errored `turn_end`'s classified error is **held**, not emitted;
- a later clean assistant `turn_end` proves recovery → the held error is dropped (newest failure wins if the retry fails again);
- `agent_settled` — emitted exactly once per prompt, after every retry/recovery path, and before `prompt()` resolves — flushes the held error, so an unrecovered failure still surfaces as the typed card and exec-turn's settle path is unchanged. An aborted turn stays neutral (the user's Stop is its own surface) and never masks a held error.

No UI changes; both the desktop host and the cloud per-turn runtime inherit the fix through the shared translator.

### Reproduce (before)

1. Chat on a pi provider (e.g. GPT-5.5) with a conversation whose context fill sits just under the model's window (or run with `HOUSTON_AUTOCOMPACT_THRESHOLD=100` and grow the chat past the window).
2. Send a message that pushes the request over the window.
3. Observe: the "This chat got too long for its model" card appears immediately, yet the agent then thinks, runs tools, and streams a full answer under it.

### Verify (after)

1. Same setup: the card no longer appears; pi compacts and the turn completes seamlessly.
2. A genuinely unrecoverable failure (e.g. revoked credential, or overflow with compaction unable to help) still shows its typed error card when the turn settles.
3. `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test` — new translator tests cover suppression-on-recovery, flush-on-settle, newest-failure-wins, and abort neutrality.
