### PR TITLE
fix(providers): degrade Claude sign-in to the paste flow when the helper binary can't run (HOU-1135)

### DIFF
--- a/app/src-tauri/src/claude_login/cpu.rs
+++ b/app/src-tauri/src/claude_login/cpu.rs
@@ -1,0 +1,41 @@
+//! CPU capability gate for the bundled Claude Code helper.
+//!
+//! The `claude` sidecar is a Bun-compiled binary, and Bun's x86-64 builds
+//! require AVX2 (Haswell, 2013+). On an older x86-64 machine (e.g. a 2012
+//! MacBookPro10,1 — Ivy Bridge) the child dies instantly with SIGILL and an
+//! empty stderr, which surfaced as an inscrutable "Claude sign-in failed
+//! (exit signal)" toast the user retried in vain (HOUSTON-APP-543). Detect
+//! the gap BEFORE spawning so the frontend can route a remote-engine login to
+//! the runtime's paste flow — which needs no local helper — instead of
+//! burning the attempt.
+
+/// Why the bundled helper cannot run on this machine, or `None` when it can.
+/// The string is diagnostic (logs/Sentry); the frontend shows translated copy.
+pub(super) fn unsupported_reason() -> Option<String> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if !std::arch::is_x86_feature_detected!("avx2") {
+            return Some(
+                "the Claude sign-in helper needs an x86-64 CPU with AVX2 (2013 or newer) \
+                 and this machine's CPU predates it"
+                    .to_string(),
+            );
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsupported_reason_is_none_on_supported_hardware() {
+        // Every CI/dev host (Apple Silicon, AVX2-era x86-64) can run the
+        // helper; the interesting arm — a pre-AVX2 x86-64 — has no CI
+        // representation, so this pins the common-path contract instead:
+        // no false positives that would dump capable machines into the
+        // paste flow.
+        assert_eq!(unsupported_reason(), None);
+    }
+}

--- a/app/src-tauri/src/claude_login/mod.rs
+++ b/app/src-tauri/src/claude_login/mod.rs
@@ -24,9 +24,13 @@
 //! Two Tauri events carry the flow to the webview:
 //!   * `claude-login://url`  — payload is the authorize URL `String` (emitted at
 //!     most once, when the CLI prints its `visit:` line).
-//!   * `claude-login://done` — payload `{ success: bool, error: string | null }`.
+//!   * `claude-login://done` — payload
+//!     `{ success: bool, error: string | null, helperUnavailable?: bool }`.
 //!     A `null` error on `success: false` is a benign CANCEL (the frontend
 //!     treats it as a silent dismissal, not a failure to toast).
+//!     `helperUnavailable: true` means the helper binary cannot run on this
+//!     machine at all (pre-AVX2 CPU, signal death) — the frontend degrades a
+//!     remote-engine login to the runtime's paste flow instead of toasting.
 //!
 //! Cancel + child kill run through `ClaudeLoginState`; the background task that
 //! owns the child polls a shared cancel flag and tears the child down when set.
@@ -41,6 +45,7 @@
 // resolves the sibling `__cmd__*` items in the module where the command lives, so
 // a re-export of just the fn would not carry them.
 pub(crate) mod code_input;
+mod cpu;
 pub(crate) mod credential;
 pub(crate) mod discard;
 mod resolve;
@@ -122,6 +127,23 @@ pub async fn start_claude_login(
     state: State<'_, ClaudeLoginState>,
     handoff: bool,
 ) -> Result<(), String> {
+    // Don't spawn a binary that dies instantly with SIGILL: Bun-compiled
+    // helpers need AVX2 on x86-64, and a pre-2013 CPU produced only an
+    // inscrutable "exit signal" toast users retried in vain
+    // (HOUSTON-APP-543). Report through the `done` event — not `Err` — so
+    // the frontend's one failure router can degrade a remote-engine login
+    // to the runtime's paste flow.
+    if let Some(reason) = cpu::unsupported_reason() {
+        let error = format!("Claude sign-in helper cannot run: {reason}");
+        tracing::error!("[claude-login] {error}");
+        app.emit(
+            EVENT_DONE,
+            serde_json::json!({ "success": false, "error": error, "helperUnavailable": true }),
+        )
+        .map_err(|e| format!("Could not report the sign-in result: {e}"))?;
+        return Ok(());
+    }
+
     let config_dir = config_dir_for(handoff);
     // The CLI writes the cached credential here; it must exist first.
     std::fs::create_dir_all(&config_dir).map_err(|e| {

--- a/app/src-tauri/src/claude_login/runner.rs
+++ b/app/src-tauri/src/claude_login/runner.rs
@@ -100,6 +100,13 @@ where
         }
         Ok(LoginOutcome::Exited(Ok(status))) => {
             let tail = collect_stderr(stderr_task).await;
+            // A signal death is never a user decision (declines exit with a
+            // code; our own cancel/timeout kills take the branches below) —
+            // it means the helper binary cannot run here at all, e.g. SIGILL
+            // from a pre-AVX2 CPU (HOUSTON-APP-543). Flag it so the frontend
+            // can degrade to the runtime's paste flow instead of toasting an
+            // error a retry can only reproduce.
+            let helper_unavailable = status.code().is_none();
             let code = status
                 .code()
                 .map(|c| c.to_string())
@@ -110,7 +117,10 @@ where
                 error.push_str(tail.trim());
             }
             tracing::error!("[claude-login] {error}");
-            emit(EVENT_DONE, json!({ "success": false, "error": error }));
+            emit(
+                EVENT_DONE,
+                json!({ "success": false, "error": error, "helperUnavailable": helper_unavailable }),
+            );
         }
         Ok(LoginOutcome::Exited(Err(e))) => {
             let error = format!("Claude sign-in could not be monitored: {e}");
@@ -312,6 +322,31 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn run_login_flags_a_signal_killed_helper_as_unavailable() {
+        // A helper that dies from a signal (the shape of a Bun binary
+        // SIGILL-ing on a pre-AVX2 CPU, HOUSTON-APP-543) must carry the
+        // `helperUnavailable` flag so the frontend can degrade to the
+        // runtime's paste flow instead of a dead retry loop.
+        let dir = unique_tmp_dir("sigill");
+        let script = write_fake_claude(&dir, "claude", "#!/bin/sh\nkill -ILL $$\n");
+        let config_dir = dir.join("config");
+
+        let (events, emit) = collect();
+        run_login(&script, &config_dir, Arc::new(AtomicBool::new(false)), emit).await;
+
+        let got = events.lock().expect("events lock");
+        let done = got.last().expect("done event");
+        assert_eq!(done.0, EVENT_DONE);
+        assert_eq!(done.1["success"], json!(false));
+        assert_eq!(done.1["helperUnavailable"], json!(true));
+        let error = done.1["error"].as_str().expect("error string");
+        assert!(error.contains("exit signal"), "error was: {error}");
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn run_login_reports_failure_on_nonzero_exit() {
         let dir = unique_tmp_dir("fail");
         let script = write_fake_claude(
@@ -339,6 +374,9 @@ mod tests {
             error.contains("authentication was declined"),
             "error was: {error}"
         );
+        // A plain non-zero exit (e.g. a declined authorization) is NOT a
+        // helper-can't-run condition — it must never reroute to the paste flow.
+        assert_eq!(done.1["helperUnavailable"], json!(false));
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/app/src/lib/claude-login-failure.ts
+++ b/app/src/lib/claude-login-failure.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure routing for a failed desktop Claude sign-in — kept dependency-free so
+ * node:test can pin the contract without Tauri in the room.
+ *
+ * The native helper's `claude-login://done` failure payloads come in three
+ * shapes, and each wants a different surface:
+ *   * `error: null` — the user cancelled; dismiss silently.
+ *   * `helperUnavailable: true` — the helper BINARY cannot run on this
+ *     machine (pre-AVX2 CPU, signal death; HOUSTON-APP-543). Retrying the
+ *     browser login can only reproduce it, so a remote engine degrades to the
+ *     runtime's paste flow (which needs no local helper) and a co-located one
+ *     gets a translated explanation.
+ *   * anything else — a real login failure (declined, timed out, shell gate);
+ *     toast the reason verbatim.
+ */
+
+/** Payload of the native `claude-login://done` event. */
+export interface ClaudeLoginDone {
+  success: boolean;
+  error: string | null;
+  /** The helper binary cannot run on this machine at all. */
+  helperUnavailable?: boolean;
+}
+
+export type ClaudeLoginFailureRoute =
+  /** Benign cancel: clear the pending card, no toast. */
+  | { kind: "silent" }
+  /** Remote engine + unrunnable helper: start the runtime's paste flow. */
+  | { kind: "paste-fallback"; reason: string }
+  /** Co-located engine + unrunnable helper: translated explanation. */
+  | { kind: "helper-unsupported" }
+  /** A real login failure: surface the helper's reason. */
+  | { kind: "error"; error: string };
+
+export function classifyClaudeLoginFailure(
+  done: ClaudeLoginDone,
+  remoteEngine: boolean,
+): ClaudeLoginFailureRoute {
+  if (done.helperUnavailable) {
+    return remoteEngine
+      ? { kind: "paste-fallback", reason: done.error ?? "helper unavailable" }
+      : { kind: "helper-unsupported" };
+  }
+  if (done.error === null) return { kind: "silent" };
+  return { kind: "error", error: done.error };
+}

--- a/app/src/lib/claude-login-remote.ts
+++ b/app/src/lib/claude-login-remote.ts
@@ -153,8 +153,12 @@ export async function finishRemoteClaudeLogin(
  * friendly toast. Calls `providerLogin` DIRECTLY (not `launchLogin`, which would
  * re-enter the desktop browser login). If even starting the paste flow fails,
  * `announce(false)` clears the pending row so nothing spins forever.
+ *
+ * Exported for `claude-login.ts`: a helper that cannot RUN on this machine
+ * (pre-AVX2 CPU, signal death — HOUSTON-APP-543) degrades the same way, since
+ * the paste flow runs in the (remote) runtime and needs no local binary.
  */
-function fallbackToPaste(
+export function fallbackToPaste(
   frontendProviderId: string,
   reason: unknown,
   announce: Announce,

--- a/app/src/lib/claude-login.ts
+++ b/app/src/lib/claude-login.ts
@@ -36,7 +36,14 @@
  * how one family ended up behind several rotating stores (HOU-950 root cause).
  */
 
-import { finishRemoteClaudeLogin } from "./claude-login-remote";
+import {
+  type ClaudeLoginDone,
+  classifyClaudeLoginFailure,
+} from "./claude-login-failure";
+import {
+  fallbackToPaste,
+  finishRemoteClaudeLogin,
+} from "./claude-login-remote";
 import { isRemoteEngine } from "./engine";
 import { publishLocalHoustonEvent } from "./events";
 import i18n from "./i18n";
@@ -60,11 +67,6 @@ const LOGIN_TIMEOUT_MS = 15 * 60_000;
  *  credential as connected (the /providers probe re-reads `claude auth status`). */
 const CONFIRM_TIMEOUT_MS = 30_000;
 const CONFIRM_POLL_MS = 800;
-
-interface ClaudeLoginDone {
-  success: boolean;
-  error: string | null;
-}
 
 /** Announce the outcome on the client bus so every provider surface reacts. */
 function announce(provider: string, success: boolean, error: string | null) {
@@ -168,9 +170,26 @@ export async function beginClaudeBrowserLogin(
         cleanup();
         const { success, error } = ev.payload;
         if (!success) {
-          // The browser login itself failed (declined) or was cancelled
-          // (error: null → silent dismissal). Not a remote-handoff failure.
-          announce(frontendProviderId, false, error);
+          // The browser login failed before any remote handoff: declined,
+          // cancelled (silent), or the helper binary can't run on this
+          // machine at all — the router decides which surface each gets.
+          const route = classifyClaudeLoginFailure(ev.payload, handoff);
+          switch (route.kind) {
+            case "paste-fallback":
+              // The paste flow runs in the remote runtime; no local helper
+              // needed (HOUSTON-APP-543: pre-AVX2 Macs SIGILL the helper).
+              fallbackToPaste(frontendProviderId, route.reason, announce);
+              break;
+            case "helper-unsupported":
+              announce(
+                frontendProviderId,
+                false,
+                i18n.t("providers:claudeLogin.helperUnsupported"),
+              );
+              break;
+            default:
+              announce(frontendProviderId, false, error);
+          }
           return;
         }
         if (handoff) {

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -117,7 +117,8 @@
     "timeout": "Claude sign-in timed out. Please try connecting again.",
     "confirmTimeout": "Signed in to Claude, but Houston could not confirm the connection. Please try again.",
     "autoFailedTitle": "Couldn't finish connecting automatically",
-    "autoFailedBody": "Paste a Claude setup token to finish connecting."
+    "autoFailedBody": "Paste a Claude setup token to finish connecting.",
+    "helperUnsupported": "This computer's processor is too old to run the Claude sign-in helper, so a Claude subscription can't be connected on this machine."
   },
   "localModel": {
     "title": "Connect a local model",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -117,7 +117,8 @@
     "timeout": "El inicio de sesión de Claude expiró. Intenta conectarte de nuevo.",
     "confirmTimeout": "Iniciaste sesión en Claude, pero Houston no pudo confirmar la conexión. Inténtalo de nuevo.",
     "autoFailedTitle": "No se pudo completar la conexión automáticamente",
-    "autoFailedBody": "Pega un token de configuración de Claude para terminar de conectar."
+    "autoFailedBody": "Pega un token de configuración de Claude para terminar de conectar.",
+    "helperUnsupported": "El procesador de este computador es demasiado antiguo para ejecutar el asistente de inicio de sesión de Claude, así que no se puede conectar una suscripción de Claude en esta máquina."
   },
   "localModel": {
     "title": "Conecta un modelo local",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -117,7 +117,8 @@
     "timeout": "O login do Claude expirou. Tente conectar novamente.",
     "confirmTimeout": "Você entrou no Claude, mas o Houston não conseguiu confirmar a conexão. Tente novamente.",
     "autoFailedTitle": "Não foi possível concluir a conexão automaticamente",
-    "autoFailedBody": "Cole um token de configuração do Claude para concluir a conexão."
+    "autoFailedBody": "Cole um token de configuração do Claude para concluir a conexão.",
+    "helperUnsupported": "O processador deste computador é muito antigo para executar o assistente de login do Claude, então não é possível conectar uma assinatura do Claude nesta máquina."
   },
   "localModel": {
     "title": "Conecte um modelo local",

--- a/app/tests/claude-login-failure.test.ts
+++ b/app/tests/claude-login-failure.test.ts
@@ -1,0 +1,68 @@
+import { deepStrictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { classifyClaudeLoginFailure } from "../src/lib/claude-login-failure.ts";
+
+describe("classifyClaudeLoginFailure", () => {
+  it("routes an unrunnable helper on a remote engine to the paste flow", () => {
+    // HOUSTON-APP-543: a pre-AVX2 Mac SIGILLs the Bun-compiled helper; the
+    // runtime's paste flow needs no local binary, so cloud users still connect.
+    deepStrictEqual(
+      classifyClaudeLoginFailure(
+        {
+          success: false,
+          error: "Claude sign-in failed (exit signal)",
+          helperUnavailable: true,
+        },
+        true,
+      ),
+      {
+        kind: "paste-fallback",
+        reason: "Claude sign-in failed (exit signal)",
+      },
+    );
+  });
+
+  it("explains an unrunnable helper on a co-located engine instead", () => {
+    // No remote runtime to paste into — the surface is a translated message.
+    deepStrictEqual(
+      classifyClaudeLoginFailure(
+        { success: false, error: "helper died", helperUnavailable: true },
+        false,
+      ),
+      { kind: "helper-unsupported" },
+    );
+  });
+
+  it("keeps a cancel silent", () => {
+    deepStrictEqual(
+      classifyClaudeLoginFailure({ success: false, error: null }, true),
+      { kind: "silent" },
+    );
+  });
+
+  it("keeps a real login failure a plain error, never the paste flow", () => {
+    // A declined authorization exits with a CODE, not a signal — rerouting it
+    // to the paste flow would hide the user's own decision from them.
+    deepStrictEqual(
+      classifyClaudeLoginFailure(
+        {
+          success: false,
+          error: "Claude sign-in failed (exit 1): declined",
+          helperUnavailable: false,
+        },
+        true,
+      ),
+      { kind: "error", error: "Claude sign-in failed (exit 1): declined" },
+    );
+  });
+
+  it("tolerates a flagged payload with no reason string", () => {
+    deepStrictEqual(
+      classifyClaudeLoginFailure(
+        { success: false, error: null, helperUnavailable: true },
+        true,
+      ),
+      { kind: "paste-fallback", reason: "helper unavailable" },
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Sentry [HOUSTON-APP-543](https://houston-cd.sentry.io/issues/7645446609/) — `Claude sign-in failed (exit signal)` on macOS, 74 events. **Not** a regression from #1199: it started on 0.5.35/0.5.39, before the cwd fix shipped. Every event is the same hardware profile: MacBookPro10,1 (2012, Ivy Bridge) on macOS 13.6.4 — one user retrying across three releases and getting the same dead toast every time.

## Root cause

The bundled `claude` helper is a Bun-compiled binary, and Bun's x86-64 builds require **AVX2** (Haswell, 2013+). On a pre-AVX2 CPU the child dies instantly with SIGILL — an empty stderr and a signal exit, which the runner rendered as the inscrutable "(exit signal)". Retrying can only reproduce it; nothing tells the user (or us) why.

## Fix

Two layers produce one signal, `helperUnavailable: true`, on the `claude-login://done` payload:

- **Pre-flight** (`claude_login/cpu.rs`): `start_claude_login` checks `is_x86_feature_detected!("avx2")` on x86-64 and skips the doomed spawn entirely, with a diagnostic reason in the log/Sentry.
- **Runtime flag** (`runner.rs`): any *signal* death of the helper sets the flag too (a signal is never a user decision — declines exit with a code; our own cancel/timeout kills take separate branches). This also catches non-CPU kill causes (Gatekeeper, AV).

The frontend routes failures through a new pure router (`classifyClaudeLoginFailure`):

- **Remote engine (the v0.5+ cloud default)** → degrade to the runtime's existing **setup-token paste flow** (`fallbackToPaste`), which runs on the pod and needs no local binary — so users on old machines can still connect their Claude subscription, nothing to install.
- **Co-located engine** → a translated explanation (en/es/pt: `claudeLogin.helperUnsupported`) instead of the raw signal text.
- Declines/cancels are untouched: a plain non-zero exit never reroutes to the paste flow.

## Tests

- Rust: `run_login_flags_a_signal_killed_helper_as_unavailable` (fake helper SIGILLs itself), inverse assertion on the existing decline test, `cpu::unsupported_reason` no-false-positives pin. `cargo test --lib`: 208 passed.
- TS: `app/tests/claude-login-failure.test.ts` pins all four routes (5 cases). `cd app && pnpm test`: 2596 passed.
- `pnpm tsgo --noEmit`, `pnpm check-locales` (en/es/pt in sync), `pnpm check` (Biome) all clean.


Fixes HOU-1135. Follow-up to remove the paste-token friction entirely (pod-side login relay): HOU-1136.
