### PR TITLE
fix(metrics): app_to_board fires on the Everyone board; early spans survive session load (HOU-1011)

### DIFF
--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -2,7 +2,14 @@ import type { KanbanItem } from "@houston-ai/board";
 import type { FeedItem, MessageMention } from "@houston-ai/chat";
 import { messagePreviewText } from "@houston-ai/chat";
 import { useQueryClient } from "@tanstack/react-query";
-import { createElement, useCallback, useMemo, useRef, useState } from "react";
+import {
+  createElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { useAllConversations } from "../hooks/queries";
 import { useUserProfiles } from "../hooks/queries/use-user-profiles";
@@ -24,6 +31,7 @@ import {
 } from "../lib/mission-people";
 import { ARCHIVED_STATUS, DONE_STATUS } from "../lib/mission-selection";
 import { isMultiplayer } from "../lib/org-roles";
+import { perfSpans } from "../lib/perf-spans";
 import { queryKeys } from "../lib/query-keys";
 import { formatVisibleMessageText } from "../lib/queued-chat";
 import {
@@ -76,6 +84,20 @@ export function useMissionControl(agents: Agent[]) {
   // variant) paint instead, and `isLoaded` waits for a genuine, SETTLED success
   // (`sweepIsAuthoritative` — TanStack calls the placeholder paint a success
   // too) so "empty" only ever means "successfully empty".
+  // App-open → board perf mark (HOU-1011) for the DEFAULT surface: since
+  // Everyone-first scope, the first mission cards a user sees come from THIS
+  // cross-agent sweep, not a per-agent board (whose hook carries the same
+  // mark — perfSpans latches once per session, so both firing is free).
+  // Authoritative-settled only: a placeholder or failed sweep is not "the
+  // user sees their cards". The rAF waits for the paint that shows them.
+  const sweepSettled = sweepIsAuthoritative({ isSuccess, isPlaceholderData });
+  useEffect(() => {
+    if (!sweepSettled) return;
+    if (typeof requestAnimationFrame === "function")
+      requestAnimationFrame(() => perfSpans.boardRendered());
+    else perfSpans.boardRendered();
+  }, [sweepSettled]);
+
   const convos = useMemo(
     () =>
       sweptConvos ??

--- a/app/src/hooks/use-perf-spans.ts
+++ b/app/src/hooks/use-perf-spans.ts
@@ -38,9 +38,12 @@ export function usePerfSpans(): void {
     perfSpans.configure({
       async send(spans: PerfSpanObservation[]) {
         const token = tokenRef.current;
-        // No session → nothing to authenticate as; drop rather than queue
-        // forever (PostHog already mirrored the spans).
-        if (!token) return;
+        // No session yet → throw so PerfSpans RE-QUEUES the batch (bounded)
+        // instead of counting it delivered. The earliest span of a session
+        // (app_to_board) routinely beats the async session load — dropping
+        // here silently under-counted exactly the journey we care most about.
+        // The token-arrival effect below re-flushes the queue.
+        if (!token) throw new Error("session not ready");
         const res = await fetch(`${CLIENT_METRICS_URL}/v1/client-metrics`, {
           method: "POST",
           headers: {
@@ -69,4 +72,12 @@ export function usePerfSpans(): void {
     document.addEventListener("visibilitychange", onHide);
     return () => document.removeEventListener("visibilitychange", onHide);
   }, []);
+
+  // Session arrived after early spans were measured (the common cold-start
+  // order): drain the re-queued batches now instead of waiting for the next
+  // observation to schedule a flush.
+  const token = session?.idToken ?? null;
+  useEffect(() => {
+    if (token) void perfSpans.flush();
+  }, [token]);
 }

--- a/app/tests/perf-spans.test.ts
+++ b/app/tests/perf-spans.test.ts
@@ -87,6 +87,30 @@ describe("PerfSpans", () => {
     deepStrictEqual(sent.flat(), [{ span: "app_to_board", ms: 10 }]);
   });
 
+  it("holds a batch across repeated failures until the transport recovers", async () => {
+    // The session-not-ready case: send() throws until the token loads, and
+    // the earliest spans (app_to_board) must survive to the eventual flush.
+    let now = 0;
+    let ready = false;
+    const sent: PerfSpanObservation[][] = [];
+    const spans = new PerfSpans({ t0Ms: 0, now: () => now });
+    spans.configure({
+      async send(batch) {
+        if (!ready) throw new Error("session not ready");
+        sent.push(batch);
+      },
+    });
+    now = 900;
+    spans.boardRendered();
+    await spans.flush();
+    await spans.flush();
+    await spans.flush();
+    strictEqual(sent.length, 0);
+    ready = true;
+    await spans.flush();
+    deepStrictEqual(sent.flat(), [{ span: "app_to_board", ms: 900 }]);
+  });
+
   it("only moves T0 earlier", async () => {
     const { spans, sent, tick } = harness(100_000);
     spans.setLaunchT0(150_000); // late bogus stamp — ignored


### PR DESCRIPTION
Follow-up to #1169, caught during staging verification: three of the four client UX spans landed (`send_to_first_response`, `card_click_to_chat`, `app_to_first_response`) but **`app_to_board` never arrived**.

## Root causes (two)

1. **The default surface had no mark.** Since Everyone-first scope, the first mission cards a user sees render from the cross-agent sweep in `use-mission-control.ts` — the `app_to_board` mark only existed in the per-agent board hook, which the default flow never mounts. Added the same latched mark on the sweep's authoritative-settled state (placeholder/failed sweeps don't count as "cards visible"), rAF-deferred to the paint. The per-agent mark stays; `perfSpans` latches once per session so double-firing is free.
2. **Early spans lost to the session race.** The transport treated "no session token yet" as delivered-and-done, silently dropping the batch. `app_to_board` is measured seconds into the app's life — routinely before the async session load finishes — so exactly the journey we care most about was the one being dropped. The transport now throws on a missing token so `PerfSpans` re-queues the batch (bounded at 40 spans), and a token-arrival effect drains the queue immediately.

## Verification

Before: on staging (gateway `:9091`), `houston_client_app_to_board_seconds` had no samples after a full app session while the other three span families did.

After: run the app (`pnpm dev:staging`), sign in, let the Everyone board load → `curl :9091/metrics | grep app_to_board` shows `_count ≥ 1`.

Tests: new lib test locks the hold-across-failures semantics (batch survives repeated send failures until the transport recovers); full app suite 2599 green; tsgo + Biome clean.