### PR TITLE
feat(providers): MiniMax token/coding plan support + pi 0.83.0 (HOU-1160, HOU-1150)

### DIFF
--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -565,15 +565,23 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     name: "MiniMax",
     subtitle: "Global API",
     description: "Fast, affordable models for agent work.",
-    cost: "Pay-as-you-go on your MiniMax account",
+    cost: "Coding/token plan or pay-as-you-go on your MiniMax account",
     installUrl: "https://platform.minimax.io",
     apiKeyUrl:
       "https://platform.minimax.io/user-center/basic-information/interface-key",
-    defaultModel: "MiniMax-M3",
+    // The 1M-context tier MiniMax's Coding/Token plan bills against; also works
+    // pay-as-you-go. A subscription key run on bare MiniMax-M3 reads as
+    // "usage ran out" (HOU-1160), so this is the connect default.
+    defaultModel: "MiniMax-M3[1m]",
     models: {
+      "MiniMax-M3[1m]": {
+        label: "MiniMax M3 (1M)",
+        description:
+          "Best default. 1M-context tier for the MiniMax coding/token plan or pay-as-you-go.",
+      },
       "MiniMax-M3": {
         label: "MiniMax M3",
-        description: "Best default. Long-context multimodal model.",
+        description: "Long-context multimodal model, pay-as-you-go.",
       },
       "MiniMax-M2.7": {
         label: "MiniMax M2.7",

--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -565,7 +565,9 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     name: "MiniMax",
     subtitle: "Global API",
     description: "Fast, affordable models for agent work.",
-    cost: "Coding/token plan or pay-as-you-go on your MiniMax account",
+    // The Coding Plan key is separate from a pay-as-you-go key and they are NOT
+    // interchangeable (HOU-1160) — the card must say which one to paste.
+    cost: "Coding Plan subscription (paste that plan's API key) or pay-as-you-go",
     installUrl: "https://platform.minimax.io",
     apiKeyUrl:
       "https://platform.minimax.io/user-center/basic-information/interface-key",

--- a/app/tests/provider-overrides-drift.test.ts
+++ b/app/tests/provider-overrides-drift.test.ts
@@ -33,6 +33,13 @@ const pi = (await import(
   getProviders(): string[];
 };
 
+// Models Houston hand-builds ON a pi provider that pi-ai's catalog does NOT ship,
+// so they are legitimately absent from `getModel` yet still valid to curate. Keyed
+// `${piProvider}/${modelId}`. Today: MiniMax's token/coding-plan SKU, injected by
+// the host catalog (`withMinimaxTokenPlan`) and the runtime (`buildMinimaxTokenPlanModel`)
+// on the `minimax` provider (same endpoint/auth, 1M-context tier — HOU-1160).
+const HOUSTON_INJECTED_MODELS = new Set(["minimax/MiniMax-M3[1m]"]);
+
 // Houston provider id → pi provider id (reverse of PROVIDER_ID_RENAME, which is
 // pi → Houston, e.g. `openai-codex` → `openai`). Identity for every other id.
 const houstonToPi: Record<string, string> = {};
@@ -53,6 +60,7 @@ describe("PROVIDER_OVERRIDES stay in sync with the shipped pi-ai catalog", () =>
     });
 
     for (const modelId of Object.keys(override.models ?? {})) {
+      if (HOUSTON_INJECTED_MODELS.has(`${piId}/${modelId}`)) continue;
       it(`${houstonId}/${modelId} exists in pi-ai`, () => {
         ok(
           pi.getModel(piId, modelId) != null,

--- a/app/tests/provider-overrides-drift.test.ts
+++ b/app/tests/provider-overrides-drift.test.ts
@@ -60,7 +60,19 @@ describe("PROVIDER_OVERRIDES stay in sync with the shipped pi-ai catalog", () =>
     });
 
     for (const modelId of Object.keys(override.models ?? {})) {
-      if (HOUSTON_INJECTED_MODELS.has(`${piId}/${modelId}`)) continue;
+      if (HOUSTON_INJECTED_MODELS.has(`${piId}/${modelId}`)) {
+        // Self-expiring exemption: the moment pi-ai ships this id natively, the
+        // hand-built injection (host withMinimaxTokenPlan + runtime
+        // buildMinimaxTokenPlanModel) and this exemption are dead weight —
+        // fail loudly so they get removed instead of shadowing pi's entry.
+        it(`${houstonId}/${modelId} is still absent from pi-ai (injected by Houston)`, () => {
+          ok(
+            pi.getModel(piId, modelId) == null,
+            `pi-ai now ships "${modelId}" natively for "${piId}": remove the Houston injection (host withMinimaxTokenPlan / runtime buildMinimaxTokenPlanModel) and this HOUSTON_INJECTED_MODELS exemption.`,
+          );
+        });
+        continue;
+      }
       it(`${houstonId}/${modelId} exists in pi-ai`, () => {
         ok(
           pi.getModel(piId, modelId) != null,

--- a/packages/domain/src/provider-model-catalog.ts
+++ b/packages/domain/src/provider-model-catalog.ts
@@ -72,7 +72,8 @@ export const DEFAULT_MODEL: Partial<Record<ProviderId, string>> = {
   deepseek: "deepseek-v4-flash",
   google: "gemini-3.5-flash",
   "amazon-bedrock": "anthropic.claude-sonnet-4-6",
-  minimax: "MiniMax-M3",
+  // The token/coding-plan SKU (1M context) — see runtime `ai/minimax.ts` (HOU-1160).
+  minimax: "MiniMax-M3[1m]",
   // No catalog default — the model is whatever the user's local server serves.
   "openai-compatible": "",
 };
@@ -127,7 +128,15 @@ export const VALID_MODELS: Partial<Record<ProviderId, ReadonlySet<string>>> = {
     "gpt-5.6-sol",
     "gpt-5.6-terra",
   ]),
-  minimax: new Set(["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M3"]),
+  // `MiniMax-M3[1m]` is the token/coding-plan SKU: hand-built on the minimax
+  // provider (not in pi's catalog), so it must be a VALID id here or the migration
+  // rewrites it to bare `MiniMax-M3` (HOU-1160).
+  minimax: new Set([
+    "MiniMax-M3[1m]",
+    "MiniMax-M2.7",
+    "MiniMax-M2.7-highspeed",
+    "MiniMax-M3",
+  ]),
   deepseek: new Set(["deepseek-v4-flash", "deepseek-v4-pro"]),
 };
 

--- a/packages/domain/src/provider-model.test.ts
+++ b/packages/domain/src/provider-model.test.ts
@@ -55,7 +55,12 @@ const PI_MODELS: Record<string, Set<string>> = {
     "gpt-5.6-sol",
     "gpt-5.6-terra",
   ]),
-  minimax: new Set(["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M3"]),
+  minimax: new Set([
+    "MiniMax-M3[1m]",
+    "MiniMax-M2.7",
+    "MiniMax-M2.7-highspeed",
+    "MiniMax-M3",
+  ]),
   deepseek: new Set(["deepseek-v4-flash", "deepseek-v4-pro"]),
 };
 
@@ -187,9 +192,19 @@ test("MiniMax global provider uses the pi-ai catalog, not minimax-cn", () => {
 
   const fallback = migrateProviderModel("minimax", "MiniMax-M1");
   expect(fallback.provider).toBe("minimax");
-  expect(fallback.model).toBe("MiniMax-M3");
+  expect(fallback.model).toBe("MiniMax-M3[1m]");
   expect(fallback.diagnostics[0]?.message).toContain("MiniMax-M1");
   assertValid(fallback, "minimax fallback");
+});
+
+test("MiniMax token-plan SKU MiniMax-M3[1m] is kept verbatim, never rewritten", () => {
+  // The subscription/coding-plan model id — hand-built on the minimax provider
+  // (not in pi's catalog) but a valid id, so migration must NOT rewrite it to the
+  // pay-as-you-go SKU (HOU-1160).
+  const r = migrateProviderModel("minimax", "MiniMax-M3[1m]");
+  expect(r).toMatchObject({ provider: "minimax", model: "MiniMax-M3[1m]" });
+  expect(r.diagnostics).toEqual([]);
+  assertValid(r, "minimax/MiniMax-M3[1m]");
 });
 
 test("deepseek provider models migrate against its finite pi catalog", () => {

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -19,8 +19,8 @@
     "typecheck": "tsgo -p tsconfig.json"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.82.1",
-    "@earendil-works/pi-coding-agent": "0.82.1",
+    "@earendil-works/pi-ai": "0.83.0",
+    "@earendil-works/pi-coding-agent": "0.83.0",
     "@executor-js/plugin-mcp": "1.5.37",
     "@executor-js/plugin-openapi": "1.5.37",
     "@executor-js/sdk": "1.5.37",

--- a/packages/host/src/providers.test.ts
+++ b/packages/host/src/providers.test.ts
@@ -77,10 +77,13 @@ test("OpenRouter, DeepSeek, Gemini, Bedrock, and MiniMax are registered but LOCA
   expect(isCloudProvider("amazon-bedrock")).toBe(false);
   expect(isCloudProvider("minimax")).toBe(false);
   expect(hostProvider("minimax")?.models).toEqual([
+    "MiniMax-M3[1m]",
     "MiniMax-M2.7",
     "MiniMax-M2.7-highspeed",
     "MiniMax-M3",
   ]);
+  // The token/coding-plan SKU is the connect default (HOU-1160).
+  expect(hostProvider("minimax")?.defaultModel).toBe("MiniMax-M3[1m]");
 });
 
 test("openai-compatible is registered, NOT api-key, and LOCAL-only", () => {

--- a/packages/host/src/providers.ts
+++ b/packages/host/src/providers.ts
@@ -144,8 +144,15 @@ export const PROVIDERS: readonly HostProvider[] = [
     // `cloud: false` = off the legacy cloudrun per-turn listing only; served
     // everywhere else (desktop AND the managed pod, via the full pi-ai catalog).
     cloud: false,
-    models: ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M3"],
-    defaultModel: "MiniMax-M3",
+    // `MiniMax-M3[1m]` is the subscription token/coding-plan SKU (1M context); it
+    // leads because it is the connect default (HOU-1160). Bare ids stay selectable.
+    models: [
+      "MiniMax-M3[1m]",
+      "MiniMax-M2.7",
+      "MiniMax-M2.7-highspeed",
+      "MiniMax-M3",
+    ],
+    defaultModel: "MiniMax-M3[1m]",
   },
   {
     id: "openai-compatible",

--- a/packages/host/src/providers/pi-catalog.test.ts
+++ b/packages/host/src/providers/pi-catalog.test.ts
@@ -4,6 +4,7 @@ import {
   buildProviderCatalog,
   piModelToCatalogEntry,
   piProviderToCatalog,
+  withMinimaxTokenPlan,
 } from "./pi-catalog";
 
 /**
@@ -136,4 +137,24 @@ test("buildProviderCatalog serves the full pi-ai registry", () => {
       }
     }
   }
+});
+
+test("catalog surfaces MiniMax's token-plan model MiniMax-M3[1m]", () => {
+  // HOU-1160: pi-ai's minimax catalog has no `[1m]` variant, so the catalog must
+  // inject it (cloned from MiniMax-M3) or the picker can't offer the token-plan SKU.
+  const minimax = buildProviderCatalog().find((p) => p.id === "minimax");
+  expect(minimax).toBeDefined();
+  const ids = minimax?.models.map((m) => m.id) ?? [];
+  expect(ids).toContain("MiniMax-M3[1m]");
+  expect(ids).toContain("MiniMax-M3");
+  // The clone keeps M3's 1M context window and pricing.
+  const tokenPlan = minimax?.models.find((m) => m.id === "MiniMax-M3[1m]");
+  const base = minimax?.models.find((m) => m.id === "MiniMax-M3");
+  expect(tokenPlan?.contextWindow).toBe(base?.contextWindow);
+  expect(tokenPlan?.pricing).toEqual(base?.pricing);
+});
+
+test("withMinimaxTokenPlan is a no-op without the base MiniMax-M3 model", () => {
+  const noBase: Model<Api>[] = [];
+  expect(withMinimaxTokenPlan(noBase)).toEqual([]);
 });

--- a/packages/host/src/providers/pi-catalog.ts
+++ b/packages/host/src/providers/pi-catalog.ts
@@ -36,6 +36,36 @@ import { piOAuthProviders } from "./pi-oauth";
 /** A pi-ai model of any api — the mappers never look at the `TApi` specifics. */
 type PiModel = Model<Api>;
 
+/** MiniMax's token/coding-plan model id (1M-context tier); see runtime `ai/minimax.ts`. */
+const MINIMAX_TOKEN_PLAN_MODEL_ID = "MiniMax-M3[1m]";
+const MINIMAX_BASE_MODEL_ID = "MiniMax-M3";
+/**
+ * Display name for the token-plan model. Deliberately bracket-FREE: the AI Models
+ * hub folds models by a name-derived key that strips bracketed suffixes, so a name
+ * of `MiniMax-M3[1m]` would collapse onto `MiniMax-M3` and vanish. "1M" (the tier's
+ * 1M-context window) keeps the key distinct while staying honest.
+ */
+const MINIMAX_TOKEN_PLAN_MODEL_NAME = "MiniMax-M3 1M";
+
+/**
+ * pi-ai's `minimax` catalog ships only pay-as-you-go ids. Surface MiniMax's
+ * subscription "token plan" model (`MiniMax-M3[1m]`, same endpoint/auth, 1M context)
+ * so it appears in the picker — cloned from `MiniMax-M3` (its base SKU) with the wire
+ * id overridden. Skips silently if pi ever drops the base model. Keep in sync with the
+ * runtime's `buildMinimaxTokenPlanModel` (HOU-1160).
+ */
+export function withMinimaxTokenPlan(models: PiModel[]): PiModel[] {
+  const base = models.find((m) => m.id === MINIMAX_BASE_MODEL_ID);
+  if (!base || models.some((m) => m.id === MINIMAX_TOKEN_PLAN_MODEL_ID))
+    return models;
+  const tokenPlan: PiModel = {
+    ...base,
+    id: MINIMAX_TOKEN_PLAN_MODEL_ID,
+    name: MINIMAX_TOKEN_PLAN_MODEL_NAME,
+  };
+  return [tokenPlan, ...models];
+}
+
 /** Map one pi-ai `Model` to a wire `CatalogModelEntry`. Pure and deterministic. */
 export function piModelToCatalogEntry(model: PiModel): CatalogModelEntry {
   const entry: CatalogModelEntry = {
@@ -116,10 +146,11 @@ export function buildProviderCatalog(): ProviderCatalog {
 
   const catalog: ProviderCatalog = [];
   for (const id of getProviders()) {
+    const models = getModels(id as BuiltinProvider);
     catalog.push(
       piProviderToCatalog(
         id,
-        getModels(id as BuiltinProvider),
+        id === "minimax" ? withMinimaxTokenPlan(models) : models,
         oauthIds.has(id),
         providerDisplayName(id, oauthNames),
       ),

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -13,8 +13,8 @@
     "typecheck": "tsgo -p tsconfig.json"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.82.1",
-    "@earendil-works/pi-coding-agent": "0.82.1",
+    "@earendil-works/pi-ai": "0.83.0",
+    "@earendil-works/pi-coding-agent": "0.83.0",
     "@google-cloud/storage": "7.21.0",
     "@houston/protocol": "workspace:*",
     "@houston/runtime-client": "workspace:*",

--- a/packages/runtime/src/ai/minimax.ts
+++ b/packages/runtime/src/ai/minimax.ts
@@ -1,0 +1,62 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { getModel } from "@earendil-works/pi-ai/compat";
+
+/**
+ * MiniMax "token plan" (a.k.a. coding plan) support.
+ *
+ * MiniMax sells a subscription "Token Plan" (platform.minimax.io/subscribe/token-plan)
+ * whose key is SEPARATE from a pay-as-you-go key and NOT interchangeable. Both plans
+ * talk to the SAME Anthropic-compatible endpoint (`https://api.minimax.io/anthropic`,
+ * which pi-ai's `minimax` provider already targets), but MiniMax's official Claude
+ * Code config for the plan uses the model id `MiniMax-M3[1m]` (the 1M-context coding
+ * tier) — NOT the bare `MiniMax-M3` that pi-ai ships. A token-plan user pointed at
+ * bare `MiniMax-M3` is billed against pay-as-you-go (empty balance) and sees
+ * "API usage ran out" (HOU-1160).
+ *
+ * pi-ai's `minimax` catalog has no `[1m]` variant, so we hand-build the model on the
+ * SAME provider (same endpoint, same `anthropic-messages` api, same api-key auth) —
+ * mirroring the openai-compatible hand-built path. The `minimax` provider is a
+ * built-in pi provider, so pi's stream dispatch (`requireProvider("minimax")`) runs
+ * the hand-built model verbatim, sending `MiniMax-M3[1m]` as the wire model id.
+ */
+
+export const MINIMAX_PROVIDER = "minimax";
+
+/** The base pay-as-you-go model the token-plan variant is derived from. */
+export const MINIMAX_BASE_MODEL_ID = "MiniMax-M3";
+
+/** MiniMax's documented token/coding-plan model id (1M-context tier). */
+export const MINIMAX_TOKEN_PLAN_MODEL_ID = "MiniMax-M3[1m]";
+
+/**
+ * Build the token-plan pi model by cloning pi-ai's `MiniMax-M3` (same provider,
+ * baseUrl, api, pricing, 1M context window) and overriding only the wire id. Throws
+ * if pi ever drops the base model, so a turn fails with a readable reason rather than
+ * a downstream `undefined` TypeError (beta no-silent-failure).
+ */
+export function buildMinimaxTokenPlanModel(): Model<Api> {
+  const base = getModel(MINIMAX_PROVIDER, MINIMAX_BASE_MODEL_ID);
+  if (!base)
+    throw new Error(
+      `minimax base model "${MINIMAX_BASE_MODEL_ID}" is unavailable; cannot build the token-plan model`,
+    );
+  return {
+    ...base,
+    id: MINIMAX_TOKEN_PLAN_MODEL_ID,
+    name: MINIMAX_TOKEN_PLAN_MODEL_ID,
+  };
+}
+
+/**
+ * The token-plan model when (provider, modelId) name it, else undefined. Kept as a
+ * single predicate so every resolution seam (safeGetModel, the picker id list) agrees
+ * on what the extra minimax id is.
+ */
+export function minimaxTokenPlanModelFor(
+  provider: string,
+  modelId: string,
+): Model<Api> | undefined {
+  if (provider === MINIMAX_PROVIDER && modelId === MINIMAX_TOKEN_PLAN_MODEL_ID)
+    return buildMinimaxTokenPlanModel();
+  return undefined;
+}

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -428,6 +428,27 @@ test("opencode CreditsError classifies off the body even with no parsed status",
   expect(err.kind).toBe("quota_exhausted");
 });
 
+test("MiniMax 'insufficient balance (1008)' under 500 → quota_exhausted, not provider_internal", () => {
+  // MiniMax's Anthropic-compatible endpoint ships its out-of-quota error as an
+  // HTTP 500 api_error (the HOU-1160 "usage ran out" report). The
+  // insufficient-balance body check runs BEFORE the 5xx branch — this test pins
+  // that load-bearing order: a 500-status quota body must show the "pay or
+  // switch" card (a token-plan user on the wrong SKU can act on that), never a
+  // retryable-looking server error.
+  const err = classifyProviderError({
+    provider: "minimax",
+    model: "MiniMax-M3",
+    message:
+      '{"type":"error","error":{"type":"api_error","message":"insufficient balance (1008)"}}',
+    status: 500,
+  });
+  expect(err.kind).toBe("quota_exhausted");
+  if (err.kind === "quota_exhausted") {
+    expect(err.resets_at).toBeNull();
+    expect(err.message).toContain("insufficient balance");
+  }
+});
+
 test("opencode ModelError 'is not supported' under 401 → model_unavailable, not a reconnect", () => {
   const err = classifyProviderError({
     provider: "opencode",

--- a/packages/runtime/src/ai/providers.test.ts
+++ b/packages/runtime/src/ai/providers.test.ts
@@ -20,6 +20,7 @@ import {
   providerDefaultModel,
   resolveModel,
   safeGetModel,
+  safeModelIds,
 } from "./providers";
 
 /**
@@ -91,7 +92,7 @@ test("providerDefaultModel returns each provider's catalog default", () => {
   expect(providerDefaultModel("amazon-bedrock")).toBe(
     "anthropic.claude-sonnet-4-6",
   );
-  expect(providerDefaultModel("minimax")).toBe("MiniMax-M3");
+  expect(providerDefaultModel("minimax")).toBe("MiniMax-M3[1m]");
   // Unknown falls back to the Codex default (never throws / undefined).
   expect(providerDefaultModel("nope")).toBe("gpt-5.5");
 });
@@ -108,6 +109,25 @@ test("MiniMax uses pi-ai's global minimax provider and model catalog", () => {
   expect(
     (safeGetModel("minimax", "MiniMax-M3", false) as { id?: string }).id,
   ).toBe("MiniMax-M3");
+});
+
+test("MiniMax token-plan model MiniMax-M3[1m] resolves on the minimax provider", () => {
+  // The token/coding-plan SKU is hand-built (not in pi's catalog): it must resolve
+  // to a real model on the minimax provider (same endpoint/auth), verbatim id, for
+  // both a saved pick and a hard pin — never fall back to the pay-as-you-go SKU or
+  // throw "not available" (HOU-1160).
+  for (const pinned of [false, true]) {
+    const m = safeGetModel("minimax", "MiniMax-M3[1m]", pinned) as {
+      id?: string;
+      provider?: string;
+      baseUrl?: string;
+    };
+    expect(m.id).toBe("MiniMax-M3[1m]");
+    expect(m.provider).toBe("minimax");
+    expect(m.baseUrl).toBe("https://api.minimax.io/anthropic");
+  }
+  // It is also offered in the picker id list (so it survives the saved-id gate).
+  expect(safeModelIds("minimax")).toContain("MiniMax-M3[1m]");
 });
 
 test("safeGetModel keeps a valid saved id but falls back on a stale one", () => {

--- a/packages/runtime/src/ai/providers.ts
+++ b/packages/runtime/src/ai/providers.ts
@@ -13,6 +13,11 @@ import { authStorage, providerConnected } from "../auth/storage";
 import { config } from "../config";
 import { endpointReachableCached } from "./endpoint-reachability";
 import {
+  MINIMAX_PROVIDER,
+  MINIMAX_TOKEN_PLAN_MODEL_ID,
+  minimaxTokenPlanModelFor,
+} from "./minimax";
+import {
   buildActiveCustomModel,
   customEndpointConfigured,
   customModelId,
@@ -421,6 +426,12 @@ export function safeGetModel(
   modelId: string,
   pinned: boolean,
 ) {
+  // MiniMax token/coding plan: pi-ai's minimax catalog has no `[1m]` variant, so
+  // hand-build it (same provider/endpoint/auth) before consulting pi's getModel —
+  // otherwise a saved id falls back to the pay-as-you-go SKU and a pinned id throws.
+  const minimaxTokenPlan = minimaxTokenPlanModelFor(provider, modelId);
+  if (minimaxTokenPlan) return minimaxTokenPlan;
+
   const pp = provider as BuiltinProvider;
   const mp = modelId as Parameters<typeof getModel>[1];
   if (pinned) {
@@ -508,13 +519,17 @@ export function resolveModel(
   return safeGetModel(provider, override || modelFor(provider), !!override);
 }
 
-function safeModelIds(provider: ProviderId): string[] {
+export function safeModelIds(provider: ProviderId): string[] {
   // The OpenAI-compatible provider has no pi catalog; its only "model" is the
   // single one the user configured on the endpoint.
   if (provider === OPENAI_COMPATIBLE) {
     const m = customModelId();
     return m ? [m] : [];
   }
+  // MiniMax's token-plan model (`MiniMax-M3[1m]`) is hand-built, not in pi's
+  // catalog — surface it in the picker alongside pi's pay-as-you-go minimax ids.
+  if (provider === MINIMAX_PROVIDER)
+    return [MINIMAX_TOKEN_PLAN_MODEL_ID, ...piModelIds(provider)];
   return piModelIds(provider);
 }
 

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -57,8 +57,14 @@ export const config = {
   geminiModel: env.HOUSTON_GEMINI_MODEL || "gemini-3.5-flash",
   /** Default Amazon Bedrock model (API-key provider). A pi-ai `amazon-bedrock` model id. */
   bedrockModel: env.HOUSTON_BEDROCK_MODEL || "anthropic.claude-sonnet-4-6",
-  /** Default MiniMax global model (API-key provider). A pi-ai `minimax` model id. */
-  minimaxModel: env.HOUSTON_MINIMAX_MODEL || "MiniMax-M3",
+  /**
+   * Default MiniMax model (API-key provider). Defaults to the token/coding-plan
+   * SKU `MiniMax-M3[1m]` (1M-context): MiniMax's Anthropic endpoint documents this
+   * id, and a subscription-plan key billed against bare `MiniMax-M3` reads as
+   * "usage ran out" (HOU-1160). Pay-as-you-go keys accept it too (same model,
+   * larger context ceiling). Bare `MiniMax-M3`/`M2.7` stay selectable.
+   */
+  minimaxModel: env.HOUSTON_MINIMAX_MODEL || "MiniMax-M3[1m]",
   /** Default OpenRouter model (API-key provider). A pi-ai `openrouter` model id. */
   openrouterModel:
     env.HOUSTON_OPENROUTER_MODEL || "anthropic/claude-sonnet-4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,11 +424,11 @@ importers:
   packages/host:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.82.1
-        version: 0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: 0.83.0
+        version: 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
-        specifier: 0.82.1
-        version: 0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: 0.83.0
+        version: 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@executor-js/plugin-mcp':
         specifier: 1.5.37
         version: 1.5.37(effect@4.0.0-beta.59)(ioredis@5.11.1)(react@19.2.7)(typeorm@0.3.30(ioredis@5.11.1))
@@ -507,11 +507,11 @@ importers:
   packages/runtime:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.82.1
-        version: 0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.83.0
+        version: 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: 0.82.1
-        version: 0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.83.0
+        version: 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@google-cloud/storage':
         specifier: 7.21.0
         version: 7.21.0
@@ -1505,22 +1505,22 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  '@earendil-works/pi-agent-core@0.82.1':
-    resolution: {integrity: sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg==}
+  '@earendil-works/pi-agent-core@0.83.0':
+    resolution: {integrity: sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.82.1':
-    resolution: {integrity: sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.82.1':
-    resolution: {integrity: sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA==}
+  '@earendil-works/pi-ai@0.83.0':
+    resolution: {integrity: sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-tui@0.82.1':
-    resolution: {integrity: sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ==}
+  '@earendil-works/pi-coding-agent@0.83.0':
+    resolution: {integrity: sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.83.0':
+    resolution: {integrity: sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA==}
     engines: {node: '>=22.19.0'}
 
   '@effect/platform-node-shared@4.0.0-beta.97':
@@ -7165,6 +7165,9 @@ packages:
   typebox@1.1.38:
     resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
 
+  typebox@1.3.7:
+    resolution: {integrity: sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -8157,12 +8160,12 @@ snapshots:
       react: 19.2.7
       tslib: 2.8.1
 
-  '@earendil-works/pi-agent-core@0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+  '@earendil-works/pi-agent-core@0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
     dependencies:
-      '@earendil-works/pi-ai': 0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       diff: 8.0.4
       ignore: 7.0.5
-      typebox: 1.1.38
+      typebox: 1.3.7
       yaml: 2.9.0
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -8172,12 +8175,12 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-agent-core@0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       diff: 8.0.4
       ignore: 7.0.5
-      typebox: 1.1.38
+      typebox: 1.3.7
       yaml: 2.9.0
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -8187,7 +8190,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+  '@earendil-works/pi-ai@0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -8199,7 +8202,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       openai: 6.26.0(ws@8.21.0)(zod@4.3.6)
       partial-json: 0.1.7
-      typebox: 1.1.38
+      typebox: 1.3.7
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -8208,7 +8211,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -8220,7 +8223,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
       partial-json: 0.1.7
-      typebox: 1.1.38
+      typebox: 1.3.7
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -8229,11 +8232,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+  '@earendil-works/pi-coding-agent@0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
-      '@earendil-works/pi-ai': 0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
-      '@earendil-works/pi-tui': 0.82.1
+      '@earendil-works/pi-agent-core': 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-tui': 0.83.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -8246,7 +8249,7 @@ snapshots:
       minimatch: 10.2.5
       proper-lockfile: 4.1.2
       semver: 7.8.0
-      typebox: 1.1.38
+      typebox: 1.3.7
       undici: 8.5.0
       yaml: 2.9.0
     optionalDependencies:
@@ -8259,11 +8262,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.82.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.82.1
+      '@earendil-works/pi-agent-core': 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.83.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -8276,7 +8279,7 @@ snapshots:
       minimatch: 10.2.5
       proper-lockfile: 4.1.2
       semver: 7.8.0
-      typebox: 1.1.38
+      typebox: 1.3.7
       undici: 8.5.0
       yaml: 2.9.0
     optionalDependencies:
@@ -8289,7 +8292,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-tui@0.82.1':
+  '@earendil-works/pi-tui@0.83.0':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
@@ -14637,6 +14640,8 @@ snapshots:
       mime-types: 3.0.2
 
   typebox@1.1.38: {}
+
+  typebox@1.3.7: {}
 
   typed-array-buffer@1.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

Two changes on one branch (as requested):

- **HOU-1160 — MiniMax token/coding plan support.** A user on MiniMax's subscription **Token Plan** (`platform.minimax.io/subscribe/token-plan`) reported the API "isn't working" with **"API usage ran out."**
- **HOU-1150 — Update pi** `0.82.1 → 0.83.0` (host + runtime).

## Root cause (HOU-1160)

MiniMax's Token/Coding plan and pay-as-you-go both hit the **same** Anthropic-compatible endpoint (`https://api.minimax.io/anthropic`) that pi-ai's `minimax` provider already targets, and MiniMax authenticates via `X-Api-Key` — which pi already sends (verified by probing the live endpoint). So the endpoint and auth header were **not** the problem.

The difference is the **model id**: MiniMax's official Claude Code config for the plan uses **`MiniMax-M3[1m]`** (the 1M-context coding tier) as the model — pi-ai only ships bare `MiniMax-M3`, and the token-plan key is *separate from and not interchangeable with* a pay-as-you-go key. A token-plan user pointed at bare `MiniMax-M3` is billed against pay-as-you-go (empty balance) → **"API usage ran out."**

## The fix

pi-ai's `minimax` catalog has no `[1m]` variant, so we hand-build the model on the **same** provider (same endpoint, `anthropic-messages` api, api-key auth) — mirroring the existing `openai-compatible` hand-built path — and thread it through every seam that would otherwise reject or hide a non-catalog id:

- **runtime** (`ai/minimax.ts`, `ai/providers.ts`): `safeGetModel` resolves `MiniMax-M3[1m]` to a real model (clone of `MiniMax-M3`, wire id overridden) for both saved and pinned picks; `safeModelIds` lists it in the chat picker.
- **host** `/v1/catalog` (`providers/pi-catalog.ts`): injects the model so it appears in the AI Models hub. Its catalog display name is **bracket-free** (`MiniMax-M3 1M`) because the hub folds models by a name-derived key that strips bracketed suffixes — otherwise it would collapse onto `MiniMax-M3` and vanish.
- **domain** (`provider-model-catalog.ts`): added to `VALID_MODELS`/`DEFAULT_MODEL` so the migration doesn't rewrite it to the pay-as-you-go SKU.
- **frontend** (`provider-overrides.ts`): connect default + a clear picker label (`MiniMax M3 (1M)`); drift-guard exception for the deliberately-injected id.

`MiniMax-M3[1m]` is now the MiniMax **connect default** (it also works pay-as-you-go — same model, larger context ceiling). Bare `MiniMax-M3` / `M2.7` / `M2.7-highspeed` stay selectable.

## Product note (single provider vs. separate one)

Implemented as **one "MiniMax" provider** with `MiniMax-M3[1m]` as the default, rather than a separate "MiniMax Token Plan" provider. Rationale: MiniMax's docs use `MiniMax-M3[1m]` as *the* model for this endpoint, so there's effectively one correct config; a second provider would add a "which MiniMax do I pick?" decision a non-technical user can get wrong. Trivially switchable if we prefer the two-provider shape.

## Caveat

I could not verify against a live token-plan key (we don't have one). The root cause is strongly evidenced by MiniMax's official docs + live endpoint probing, and the change is additive/low-risk, but final confirmation needs a real subscription key — see verification steps below.

## Cloud path (verified — this works in the hosted product)

The whole fix rides the normal engine roll; **no cloud-repo PR is needed**:

1. **Engine pod**: pods run this repo's host/runtime, so model resolution, the picker list, and the connect default land with the next roll.
2. **Gateway catalog**: houston CI boots the built engine and packages its live `/v1/catalog` into the `engine-pod-catalog:<sha>` artifact; cloud's `roll-engine` workflow applies it to the gateway-catalog ConfigMap in lockstep. Verified by booting this branch's host and probing `/v1/catalog` live: `MiniMax-M3[1m]` is present (ctx 1M, cloned pricing).
3. **Gateway never blocks the id**: `ClampModel` has no hardcoded model list (provider+model pins pass verbatim under a nil ceiling), and stored per-user model choices accept any non-empty id.
4. **Hosted web UI**: the connect surface lists providers straight from `/v1/catalog`, so MiniMax + the new default appear after the roll.

Cloud notes: (a) the affected user's stored model choice is not auto-migrated — after the roll they pick "MiniMax M3 (1M)" once in the picker; (b) a Teams org whose per-agent allowed-models ceiling enumerates MiniMax models would need `MiniMax-M3[1m]` added to that ceiling (admin config, not code).

## Review pass (independent Codex review + manual seam trace)

Verified: the hand-built model dispatches correctly in pi 0.83 across session creation, model switching, routine pins, and both runtime boot modes (pi dispatches by `model.provider`, not catalog membership). Follow-ups applied on this branch:

- Regression test pinning MiniMax's real out-of-quota payload (HTTP **500** `api_error` "insufficient balance (1008)") to `quota_exhausted` — the body check runs before the 5xx branch, so the user gets the pay-or-switch card, never a retryable-looking server error.
- The drift-guard exemption for the injected id now **fails loudly if pi-ai ever ships `MiniMax-M3[1m]` natively**, so the injection gets removed instead of shadowing pi's entry.
- Connect-card copy now says the Coding Plan key (separate from pay-as-you-go, not interchangeable) is the one to paste.

Known accepted limitations: a token-plan user manually switching to bare `MiniMax-M3` still hits the plan mismatch (inherent to keeping both SKUs selectable; the quota card now explains it); the AI-hub "subscription" filter classes the token-plan offer as pay-as-you-go (cosmetic).

## Tests / checks

- Full workspace typecheck (all 27 packages, incl. app + web shim-parity) — green (pre-commit hook).
- vitest: runtime **950**, domain **186**, host **1217** — pass on pi 0.83.0.
- app node:test **2603** pass; Biome clean; `check-locales` in sync; `check:boundaries` OK.
- New coverage: runtime resolves `MiniMax-M3[1m]` (saved + pinned) to the minimax endpoint; host `/v1/catalog` surfaces it (context/pricing cloned); domain keeps it verbatim through migration.

## Verify the bug (before)

1. Get a MiniMax **Token Plan** key (no pay-as-you-go balance).
2. On `main`, connect the MiniMax provider with that key → the only M3 option sends bare `MiniMax-M3`.
3. Send a chat turn → **"API usage ran out."**

## Verify the fix (after)

1. On this branch, connect MiniMax with the Token Plan key → default model is **MiniMax M3 (1M)** (`MiniMax-M3[1m]`).
2. Send a chat turn → it answers (billed against the token plan).
3. The picker also lists bare `MiniMax-M3` / `M2.7` for pay-as-you-go users.

Closes HOU-1160. Also resolves HOU-1150.

