### PR TITLE
fix(app): agent tabs share one detail panel, no stacked chat (HOU-1165)

### DIFF
--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -30,10 +30,28 @@ import { useBoardSendQueue } from "./use-board-send-queue";
  * the full AIBoard prop spread — and pulls the divergent pieces (data, active
  * agent, new-mission flow, bulk routing, toolbar, dialogs) from `source`.
  */
-export function MissionBoard({ source }: { source: BoardSource }) {
+export function MissionBoard({
+  source,
+  isActive: tabActive,
+}: {
+  source: BoardSource;
+  /** When this board is one agent-detail TAB (the Activity tab), the tab's own
+   *  active flag. Every agent tab stays mounted (only CSS-hidden), so without
+   *  it the board keeps its selected mission and keeps portaling a detail panel
+   *  into the shared shell panel while another tab (Routines) portals its own —
+   *  two stacked panels, the chat "split in half" (HOU-1165). Composed with the
+   *  screen-level active-view signal below. Omit for the top-level Mission
+   *  Control board, which the screen signal governs alone. */
+  isActive?: boolean;
+}) {
   const { t } = useTranslation(["dashboard", "board"]);
   const { panelContainer, setPanelOpen } = useShellDetailPanel();
-  const isActive = useIsActiveView();
+  // "Active" here means BOTH the enclosing screen is visible AND (when this is a
+  // tab) the tab is the selected one. `useIsActiveView` is only tab-accurate for
+  // top-level kept-alive screens, not agent tabs, so tab callers pass their own
+  // flag; the top-level board passes none and rides the screen signal alone.
+  const screenActive = useIsActiveView();
+  const isActive = screenActive && (tabActive ?? true);
   const missionPanelOpen = useUIStore((s) => s.missionPanelOpen);
   const addToast = useUIStore((s) => s.addToast);
   const queuedLabels = useQueuedMessageLabels();

--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -16,7 +16,11 @@ import ArchivedTab from "./archived-tab";
  * board, and the archived list carries its own labelled back button in its
  * header (HOU-1043).
  */
-export default function BoardTab({ agent, agentDef }: TabProps) {
+export default function BoardTab({
+  agent,
+  agentDef,
+  isActive = false,
+}: TabProps) {
   const { t } = useTranslation(["dashboard"]);
   const mode = useUIStore((s) => s.agentBoardMode);
   const setAgentBoardMode = useUIStore((s) => s.setAgentBoardMode);
@@ -31,7 +35,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
         <ArchivedTab agent={agent} agentDef={agentDef} onBack={showActive} />
       ) : (
         <>
-          <MissionBoard source={source} />
+          <MissionBoard source={source} isActive={isActive} />
           <ArchivedBoardButton
             label={t("dashboard:archived.button")}
             onClick={() => setAgentBoardMode("archived")}

--- a/app/src/components/tabs/routines-tab.tsx
+++ b/app/src/components/tabs/routines-tab.tsx
@@ -7,6 +7,7 @@ import { useRoutineRuns, useRoutines } from "../../hooks/queries";
 import { useRoutineLabels } from "../../hooks/use-routine-labels";
 import { analytics } from "../../lib/analytics";
 import type { TabProps } from "../../lib/types";
+import { useIsActiveView } from "../shell/keep-alive-views";
 import { useShellDetailPanel } from "../shell/use-shell-detail-panel";
 import { useRoutineLeadingIcon } from "./routine-leading-icon";
 import {
@@ -56,6 +57,14 @@ export default function RoutinesTab({
   // surfaces have no board to drive it themselves.
   const { selected } = nav;
   const { panelContainer, setPanelOpen } = useShellDetailPanel();
+  // The chat portals into the ONE shared shell panel that every tab reuses. Only
+  // the visible tab of the visible screen may portal into it — otherwise this
+  // (hidden) tab stacks its routine chat on top of the Activity tab's open
+  // mission panel, splitting the chat in half (HOU-1165). Gate the portal target
+  // on screen + tab visibility; a null container renders the (already hidden)
+  // board's inline fallback instead, which paints nothing.
+  const screenActive = useIsActiveView();
+  const portalContainer = isActive && screenActive ? panelContainer : null;
   useEffect(() => {
     if (!shouldSyncRoutinesPanel(isActive)) return;
     setPanelOpen(!!selected);
@@ -203,7 +212,7 @@ export default function RoutinesTab({
           chatSetup={chatSetup}
           accountTimezone={h.tz.timezone ?? "UTC"}
           triggersAvailable={triggers.triggersEnabled}
-          panelContainer={panelContainer}
+          panelContainer={portalContainer}
           onIntakeComplete={nav.handleIntakeComplete}
           onIntakeDismiss={nav.dismissIntake}
           onIntakeSend={nav.handleIntakeComposerSend}

--- a/packages/web/e2e/routine-setup-chat.spec.ts
+++ b/packages/web/e2e/routine-setup-chat.spec.ts
@@ -192,6 +192,39 @@ test("a routine row opens its chat in the panel and highlights as selected", asy
   await expect(page.getByText(/Roger that\./)).toBeVisible({ timeout: 15_000 });
 });
 
+test("switching tabs never stacks two chat panels in the shared shell panel (HOU-1165)", async ({
+  page,
+}) => {
+  const agentId = await seedAgentId();
+  await seedRoutine(agentId, "Morning brief");
+
+  await page.goto("/");
+
+  // Open a mission's chat on the Activity tab: the ONE shared shell panel holds
+  // exactly one conversation (each ChatPanel owns exactly one composer textarea).
+  await page.getByText("Plan a trip to Tokyo").click();
+  const panel = page.getByTestId("mission-panel");
+  await expect(panel.getByText("Mission: Plan a trip to Tokyo")).toBeVisible();
+  await expect(panel.locator("textarea")).toHaveCount(1);
+
+  // Every agent tab stays mounted (only CSS-hidden). Before HOU-1165 the hidden
+  // Activity board kept its selected mission and kept portaling its detail panel
+  // into this SAME container while the Routines tab portaled the routine's chat —
+  // two stacked panels, the chat "broken in half". The hidden tab must now yield
+  // the panel: opening a routine leaves exactly one conversation, the routine's.
+  await openRoutinesTab(page);
+  const row = page
+    .locator('[data-testid="routine-row"]')
+    .filter({ hasText: "Morning brief" });
+  await row.getByText("Morning brief").click();
+
+  await expect(panel.getByText("Routine: Morning brief")).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(panel.getByText("Mission: Plan a trip to Tokyo")).toHaveCount(0);
+  await expect(panel.locator("textarea")).toHaveCount(1);
+});
+
 test("the row switch pauses the routine on disk", async ({ page }) => {
   const agentId = await seedAgentId();
   await seedRoutine(agentId, "Pausable");


### PR DESCRIPTION
## Root cause

Every agent-detail tab (Activity, Configuration, Integrations, **Routines**, Files) stays mounted — inactive ones are only CSS-hidden (`experience-renderer.tsx`). Each tab that has a chat portals it into the **one** shared shell-level detail panel (`workspace-shell`'s `[data-testid="mission-panel"]`). `createPortal` gives no exclusivity, so if two tabs portal at once, both detail panels render into the same container, stacking vertically.

That is exactly what happened. The Activity tab's `MissionBoard` derived its "am I active?" signal from **screen-level** `useIsActiveView()`, which is `true` whenever the agent screen is visible — regardless of *which tab* is showing (that context is only installed for top-level kept-alive screens, not agent tabs). So after the user opened a mission chat on Activity and switched to the Routines tab to open a routine's chat editor, the hidden Activity board still believed it was active: it kept its selected mission and kept portaling its `KanbanDetailPanel` on top of the routine's chat. Result: the chat "broke in half" — the Activity mission composer above, a second panel header (`Personal Assistant · Routine: …` with its own close ✕) and the routine chat below.

Leaving the app idle was incidental; the bad DOM is created on the tab switch and the WKWebView repaint on return simply made it obvious.

## Fix

Enforce the real invariant: **only the visible tab of the visible screen may portal into the shared panel.** Both boards now gate on *screen-active AND tab-active*.

- `mission-board.tsx` — `MissionBoard` accepts an optional `isActive` tab flag and composes it with the screen signal (`screenActive && (tabActive ?? true)`). Its existing inactive-guard then correctly deselects the mission and closes the panel when the Activity tab is hidden. The top-level Mission Control board passes no flag and rides the screen signal alone.
- `board-tab.tsx` — forwards the `isActive` prop it already receives to `MissionBoard`.
- `routines-tab.tsx` — nulls its portal target when its tab (or the screen) is hidden, closing the symmetric hole (open a routine, switch to Activity, open a mission). The already-hidden routine board then renders its inline fallback, which paints nothing.

## Tests

New Playwright regression test in `routine-setup-chat.spec.ts`: open a mission's chat on the Activity tab, switch to Routines, open a routine — the shared panel keeps **exactly one** composer and the stale `Mission: …` panel is gone. Verified it fails on the pre-fix code (the stale mission panel survives) and passes after. Full workspace typecheck, Biome, and the routine + board e2e suites (20 tests) all pass.

## Verify

Before (repro): open an agent → Activity tab → click a mission to open its chat → switch to the Routines tab → open a routine's chat. Two stacked panels appear.
After: the same steps leave a single chat panel; switching tabs hands the one shared panel to whichever tab is visible.

Fixes HOU-1165.
