### PR TITLE
fix(runtime): OpenAI out-of-tokens failures render the quota card, not the rate-limit card (HOU-1154)

### DIFF
--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -174,18 +174,48 @@ test("Anthropic 429 → rate_limited (no retry window in body → null), carries
   });
 });
 
-test("Codex usage limit → rate_limited with retry window parsed from minutes", () => {
+// HOU-1154: the plan's tokens are SPENT — the "no more tokens" quota card, not
+// the rate-limit card the same message used to render ("Alcanzaste un límite
+// de velocidad" on an account that had simply run out of plan).
+test("Codex usage limit → quota_exhausted, not rate_limited", () => {
   const err = classifyProviderError({
     provider: "openai-codex",
     model: "gpt-5.1-codex",
     message:
       "You have hit your ChatGPT usage limit (pro plan). Try again in ~45 min.",
   });
-  expect(err.kind).toBe("rate_limited");
-  if (err.kind === "rate_limited") {
-    expect(err.retry_after_seconds).toBe(45 * 60);
+  expect(err.kind).toBe("quota_exhausted");
+  if (err.kind === "quota_exhausted") {
     expect(err.model).toBe("gpt-5.1-codex");
+    expect(err.resets_at).toBeNull();
   }
+});
+
+// HOU-1154: OpenAI's out-of-credit failure rides HTTP 429 exactly like a burst
+// limit — the `insufficient_quota` body is what separates "top up your account"
+// from "wait a moment", so it must win over the 429 short-circuit.
+test("OpenAI insufficient_quota under 429 → quota_exhausted, not rate_limited", () => {
+  const err = classifyProviderError({
+    provider: "openai",
+    model: "gpt-5.2",
+    message:
+      'OpenAI API error (429): {"error":{"message":"You exceeded your current quota, please check your plan and billing details.","type":"insufficient_quota","param":null,"code":"insufficient_quota"}}',
+  });
+  expect(err.kind).toBe("quota_exhausted");
+  if (err.kind === "quota_exhausted") expect(err.model).toBe("gpt-5.2");
+});
+
+// A genuine burst limit stays a rate limit: "quota" wording scoped to a
+// per-minute window is throttling, not exhaustion (the Gemini free-tier shape).
+test("per-minute quota body stays rate_limited", () => {
+  const err = classifyProviderError({
+    provider: "google",
+    model: "gemini-2.5-pro",
+    message:
+      "got status: 429 Too Many Requests. Quota exceeded for quota metric 'Generate Content API requests per minute'. Please retry in 21s.",
+  });
+  expect(err.kind).toBe("rate_limited");
+  if (err.kind === "rate_limited") expect(err.retry_after_seconds).toBe(21);
 });
 
 test("OpenAI 429 with retry-after header echoed → rate_limited / retry_after_seconds", () => {

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -158,6 +158,27 @@ const INSUFFICIENT_BALANCE_PATTERNS = [
 ];
 
 /**
+ * The PLAN's token/usage allowance is spent — same "pay or switch" outcome as a
+ * credit exhaustion, NOT a wait-a-moment rate limit (HOU-1154: OpenAI rendered
+ * the rate-limit card — "Alcanzaste un límite de velocidad" — when the account
+ * simply had no tokens left). Both OpenAI shapes ride HTTP 429, identical to a
+ * genuine burst limit, so the BODY decides and this check must run BEFORE the
+ * rate-limit branch:
+ *  - API key accounts: `insufficient_quota` / "You exceeded your current quota,
+ *    please check your plan and billing details."
+ *  - ChatGPT OAuth (Codex) plans: "You have hit your ChatGPT usage limit (pro
+ *    plan). Try again in ~45 min." (also `usage_limit_reached`).
+ * Bare "quota" stays in `isRateLimited`: per-minute quota bodies (Gemini's
+ * "Quota exceeded for quota metric '… requests per minute'") ARE rate limits.
+ */
+const PLAN_LIMIT_PATTERNS = [
+  "insufficient_quota",
+  "exceeded your current quota",
+  "usage limit",
+  "usage_limit",
+];
+
+/**
  * A GitHub Copilot model EVERY Copilot plan (incl. Copilot Free) serves, offered
  * as the concrete switch target on a `model_unavailable` card. Copilot's premium
  * models (Claude, GPT-5.x) require Copilot Pro; its base models (gpt-4.1 / gpt-4o)
@@ -229,8 +250,10 @@ function classify(input: ProviderErrorInput): ProviderError {
   // "Insufficient Balance" all ride it — so the status alone decides, no body
   // wording required; the text patterns catch the same failures when a gateway
   // ships them under another status (opencode's 401 CreditsError, Anthropic's
-  // 400 credit floor, Vercel's no-card block).
-  if (status === 402 || isInsufficientBalance(lower)) {
+  // 400 credit floor, Vercel's no-card block). Plan-allowance exhaustion
+  // (OpenAI `insufficient_quota`, ChatGPT usage limit) is the same verdict and
+  // MUST be decided here, before the rate-limit branch claims its 429 (HOU-1154).
+  if (status === 402 || isInsufficientBalance(lower) || isPlanLimit(lower)) {
     return {
       kind: "quota_exhausted",
       provider,
@@ -357,9 +380,9 @@ function isRateLimited(lower: string, status: number | null): boolean {
     // Bedrock prefixes throttling as "Throttling error: Too many tokens, …" —
     // semantically a rate limit, and matching it here is what keeps it out of
     // the context-overflow branch below (pi's own non-overflow exclusion).
+    // Bare "quota" belongs here (per-minute quota bodies are throttling);
+    // plan-allowance exhaustion is claimed earlier by `isPlanLimit` (HOU-1154).
     lower.includes("throttl") ||
-    lower.includes("usage limit") ||
-    lower.includes("usage_limit") ||
     lower.includes("quota")
   );
 }
@@ -436,6 +459,10 @@ function positiveInt(raw: string): number | null {
 
 function isInsufficientBalance(lower: string): boolean {
   return INSUFFICIENT_BALANCE_PATTERNS.some((p) => lower.includes(p));
+}
+
+function isPlanLimit(lower: string): boolean {
+  return PLAN_LIMIT_PATTERNS.some((p) => lower.includes(p));
 }
 
 /**


### PR DESCRIPTION
## Summary

HOU-1154: users whose OpenAI plan simply ran out of tokens saw the rate-limit card ("Alcanzaste un límite de velocidad") with a Retry button that could never succeed, instead of a card saying the plan is out of tokens.

**Root cause** — OpenAI's plan-exhaustion failures ride HTTP 429 exactly like a genuine burst limit, and the pi text classifier (`packages/runtime/src/ai/provider-error.ts`) short-circuited every 429 (plus the `usage limit` / `quota` wordings) into `rate_limited`. Both real shapes were misclassified:

- **API-key accounts**: `insufficient_quota` / "You exceeded your current quota, please check your plan and billing details."
- **ChatGPT OAuth (Codex) plans**: "You have hit your ChatGPT usage limit (pro plan). Try again in ~45 min." — a test even locked this in as `rate_limited`.

**Fix** — a `PLAN_LIMIT_PATTERNS` set (`insufficient_quota`, `exceeded your current quota`, `usage limit`/`usage_limit`) is claimed by the existing quota branch, which already runs before the rate-limit branch, so these classify as `quota_exhausted` and render the existing "plan reached its quota — upgrade or switch provider" card. Bare `quota` wording stays a rate limit: per-minute quota bodies (Gemini free tier) are throttling, not exhaustion. No protocol or frontend change — `quota_exhausted` and its localized copy already exist.

## Before (bug reproduction)

1. Connect an OpenAI account whose plan/credit is exhausted (ChatGPT plan at its usage limit, or an API key over its quota).
2. Send any chat message on an OpenAI model.
3. The turn fails with the **rate-limit card** ("Hit a rate limit" / es: "Alcanzaste un límite de velocidad") offering a Retry that always fails again.

## After (verification)

1. Same setup and send.
2. The turn shows the **quota card** ("Out of capacity — Your OpenAI plan reached its quota. Upgrade or switch to a different provider to keep going." / es: "Sin capacidad disponible — Tu plan de OpenAI llegó al límite…") with the Switch-provider CTA.
3. A genuine burst 429 (e.g. TPM limit with "Please try again in 2.5s") still shows the rate-limit card with its countdown.

Unit-level: `pnpm --filter @houston/runtime test` — new cases in `provider-error.test.ts` cover both OpenAI shapes → `quota_exhausted` and the per-minute-quota body staying `rate_limited` (951 tests green).