### PR TITLE
fix(runtime): OpenRouter 'Provider finish_reason: error' classifies as provider_internal (HOU-930)

### DIFF
--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -469,6 +469,46 @@ test("opencode stream failure classifies inside a JSON error envelope too", () =
   expect(err.kind).toBe("provider_internal");
 });
 
+// OpenRouter ends the stream with `finish_reason: "error"` when its UPSTREAM
+// provider dies mid-generation; pi-ai flattens that to the bare string
+// `Provider finish_reason: error` — no status, no body (HOU-930's verbatim
+// report). Server-side and transient, so it must read as provider_internal
+// (Retry card), never the report-bug `unknown`.
+test("openrouter 'Provider finish_reason: error' → provider_internal, not unknown (HOU-930)", () => {
+  const err = classifyProviderError({
+    provider: "openrouter",
+    model: "anthropic/claude-sonnet-4.5",
+    message: "Provider finish_reason: error",
+  });
+  expect(err).toEqual({
+    kind: "provider_internal",
+    provider: "openrouter",
+    http_status: null,
+    message: "Provider finish_reason: error",
+  });
+});
+
+test("'Provider finish_reason: network_error' → provider_internal too", () => {
+  // pi-ai's dedicated mapping for gateways that name the upstream break
+  // "network_error" — the provider's network, not the user's, so it must NOT
+  // read as network_unreachable ("check your connection" would be wrong).
+  const err = classifyProviderError({
+    provider: "openrouter",
+    model: null,
+    message: "Provider finish_reason: network_error",
+  });
+  expect(err.kind).toBe("provider_internal");
+});
+
+test("'Provider finish_reason: content_filter' stays unknown — a refusal, not an outage", () => {
+  const err = classifyProviderError({
+    provider: "openrouter",
+    model: "openai/gpt-5.5",
+    message: "Provider finish_reason: content_filter",
+  });
+  expect(err.kind).toBe("unknown");
+});
+
 test("a genuine opencode 401 invalid key still reads as unauthenticated", () => {
   // The fix must not blunt real auth failures: an invalid key under 401 stays a
   // reconnect prompt.

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -374,7 +374,18 @@ function isServerError(lower: string, status: number | null): boolean {
     lower.includes("overloaded") ||
     // opencode.ai's gateway body when its upstream stream breaks mid-response —
     // often with no status at all. Transient; retry helps (HOU-929).
-    lower.includes("streaming response failed")
+    lower.includes("streaming response failed") ||
+    // OpenAI-compatible streams that END with an abnormal `finish_reason`:
+    // OpenRouter answers `finish_reason: "error"` when the UPSTREAM provider
+    // died mid-generation (its error detail rides a separate field pi-ai does
+    // not surface), and some gateways emit `"network_error"` for the same
+    // break. pi-ai flattens both to `Provider finish_reason: <reason>` with no
+    // status and no body. Server-side and transient — retry helps — so they
+    // read as provider_internal, never the report-bug `unknown` (HOU-930).
+    // Deliberately NOT a bare `finish_reason:` match: `content_filter` (a
+    // policy refusal, not an outage) must keep falling through to `unknown`.
+    lower.includes("finish_reason: error") ||
+    lower.includes("finish_reason: network_error")
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes HOU-930.

**Root cause:** OpenRouter ends its SSE stream with `finish_reason: "error"` when the *upstream* provider dies mid-generation. pi-ai's `mapStopReason` flattens any abnormal finish_reason to the bare string `Provider finish_reason: <reason>` — no HTTP status, no body. Our `ProviderError` classifier (`packages/runtime/src/ai/provider-error.ts`) had no pattern for that string, so it fell through to `unknown`: the user got the generic report-bug card (which auto-filed this issue) instead of the honest "provider had an internal error — Retry" card.

**Fix:** `isServerError` now matches `finish_reason: error` and `finish_reason: network_error` → `provider_internal` (server-side, transient, retry helps — same precedent as opencode's "Streaming response failed", HOU-929). Deliberately NOT a bare `finish_reason:` match: `content_filter` is a policy refusal, not an outage, and keeps falling through to `unknown`. `network_error` maps to `provider_internal` rather than `network_unreachable` because it is the provider's upstream network that broke, not the user's — a "check your connection" card would be wrong advice.

The frontend already renders `provider_internal` (retry + status link), so no UI work.

Side note: the report's other log symptom (`config: writing data that fails validation — provider must be anthropic|openai|gemini`) was already fixed on main; `ui/agent-schemas/src/config.schema.json` now types `provider` as a plain string.

## Reproduction (before the fix)

1. Connect OpenRouter and pin a model whose upstream is flaky (or simulate: have the OpenAI-compatible endpoint stream a chunk with `choices[0].finish_reason = "error"`).
2. Send a message; the upstream provider errors mid-generation.
3. The turn ends with `provider_error:unknown:openrouter` — the generic "something went wrong / report bug" card, and an auto-filed Linear issue.

Unit-level: `classifyProviderError({ provider: "openrouter", model: "anthropic/claude-sonnet-4.5", message: "Provider finish_reason: error" })` returned `{ kind: "unknown", … }`.

## Verification (after the fix)

- `pnpm --filter @houston/runtime test` — 952 passed, including three new cases in `provider-error.test.ts`: `error` → `provider_internal`, `network_error` → `provider_internal`, `content_filter` stays `unknown`.
- `pnpm --filter @houston/host --filter @houston/domain test` — all green; `pnpm check` (Biome) clean; full workspace typecheck clean (pre-commit hook).
- Live: repeat the reproduction — the chat now shows the provider-internal Retry card naming OpenRouter, and no `provider_error:unknown` bug report is filed.