### PR TITLE
fix(providers): no spurious paste dialog when the Claude credential actually landed (HOU-1143)

### DIFF
--- a/app/src/lib/claude-login-remote.ts
+++ b/app/src/lib/claude-login-remote.ts
@@ -32,12 +32,20 @@
  * SAFETY: this ships unsupervised, so EVERY user-initiated failure here
  * (extraction not-found, malformed cred, push non-200 after retries, network)
  * degrades to the existing setup-token paste flow with a friendly toast. A
- * bug in the push must never leave the user on a dead spinner.
+ * bug in the push must never leave the user on a dead spinner. But a push
+ * TRANSPORT failure alone is not proof the credential didn't land (HOU-1143):
+ * before degrading, the settlement policy (`claude-login-settle`) asks the
+ * engine's own usability probe — connected means connected, dialog withheld.
  */
 
 import { useUIStore } from "../stores/ui";
 import { pushClaudeCredentialWithRetry } from "./claude-credential-push";
+import {
+  type ClaudeHandoffResult,
+  settleRemoteClaudeLogin,
+} from "./claude-login-settle";
 import { getEngine } from "./engine";
+import { reportError } from "./error-report";
 import i18n from "./i18n";
 import { logger } from "./logger";
 import {
@@ -55,10 +63,6 @@ type Announce = (
 
 /** Poll until the engine reads the provider connected, or the window elapses. */
 type Confirm = (provider: string) => Promise<boolean>;
-
-export type ClaudeHandoffResult =
-  | { ok: true }
-  | { ok: false; reason: "no-credential" | "push-failed"; error: unknown };
 
 /**
  * Read the handoff dir's freshly minted Claude credential and push it to the
@@ -121,8 +125,11 @@ async function discardHandoffCopy(): Promise<void> {
 
 /**
  * Extract the freshly minted Anthropic credential from the handoff dir, push
- * it to the cloud, and destroy the local copy, then confirm the connection.
- * Any failure falls back to the paste flow. Never rejects.
+ * it to the cloud, and destroy the local copy, then settle the outcome from
+ * the engine's own view (`claude-login-settle`): a push whose TRANSPORT
+ * failed but whose credential landed anyway announces success (HOU-1143 —
+ * the spurious paste dialog over a working connect), and only a genuinely
+ * disconnected anthropic falls back to the paste flow. Never rejects.
  */
 export async function finishRemoteClaudeLogin(
   frontendProviderId: string,
@@ -131,21 +138,37 @@ export async function finishRemoteClaudeLogin(
 ): Promise<void> {
   const result = await pushMintedClaudeCredential();
   await discardHandoffCopy();
-  if (!result.ok) {
-    fallbackToPaste(frontendProviderId, result.error, announce);
-    return;
-  }
-
-  // Stored + materialized on the pod. Poll until its runtime reads anthropic
-  // connected, then flip the card. A confirm timeout is NOT a handoff failure
-  // (the credential IS on the pod), so surface it like the co-located
-  // confirmTimeout rather than dropping into the paste flow.
-  const ok = await confirmConnected(frontendProviderId);
-  announce(
-    frontendProviderId,
-    ok,
-    ok ? null : i18n.t("providers:claudeLogin.confirmTimeout"),
+  const settlement = await settleRemoteClaudeLogin(result, () =>
+    confirmConnected(frontendProviderId),
   );
+  switch (settlement.kind) {
+    case "connected":
+      if (settlement.recovered) {
+        // The connect WORKED, so no user-facing failure — but the transport
+        // error that almost cost this user a manual token paste must reach
+        // Sentry, or the whole class stays invisible (HOU-1143 was reported
+        // by a user; nothing had been captured).
+        reportError(
+          "push_claude_oauth_credential",
+          "Claude credential push failed in transit, but the engine reads anthropic connected — recovered without the paste flow",
+          !result.ok ? result.error : undefined,
+        );
+      }
+      announce(frontendProviderId, true, null);
+      return;
+    case "confirm-timeout":
+      // NOT a handoff failure (the credential IS stored) — surface it like
+      // the co-located confirmTimeout rather than dropping into paste.
+      announce(
+        frontendProviderId,
+        false,
+        i18n.t("providers:claudeLogin.confirmTimeout"),
+      );
+      return;
+    case "paste":
+      fallbackToPaste(frontendProviderId, settlement.reason, announce);
+      return;
+  }
 }
 
 /**
@@ -160,9 +183,15 @@ function fallbackToPaste(
   announce: Announce,
 ): void {
   // The real reason (an extraction/push/network error, NEVER the token) goes to
-  // the log tail for the bug report, not a raw toast dump.
+  // the log tail AND to Sentry — the degrade used to be console-only, so every
+  // paste fallback in the wild was invisible until a user filed it (HOU-1143).
   console.warn(
     "[claude-login] remote credential handoff failed; falling back to paste:",
+    reason,
+  );
+  reportError(
+    "push_claude_oauth_credential",
+    "Claude credential handoff failed and anthropic reads disconnected — degrading to the setup-token paste flow",
     reason,
   );
   useUIStore.getState().addToast({

--- a/app/src/lib/claude-login-settle.ts
+++ b/app/src/lib/claude-login-settle.ts
@@ -1,0 +1,59 @@
+/**
+ * Settlement policy for the desktop → cloud Claude credential handoff: after
+ * the push has run (and the local handoff copy is discarded), decide what the
+ * login OUTCOME is. Dependency-free so it is node-testable directly
+ * (`app/tests/claude-login-settle.test.ts`), like the sibling
+ * `claude-credential-push`.
+ *
+ * The load-bearing rule (HOU-1143): a failed push TRANSPORT does not prove
+ * the credential didn't land. The gateway may hold a first-touch push through
+ * a setup-pod cold start longer than the webview's fetch timeout, the host
+ * answers 502 when the credential stored centrally but the pod materialize
+ * failed (the per-turn serve path self-heals both), and a network drop can
+ * eat a response to a push that succeeded. Every one of those used to dump
+ * the setup-token paste dialog on a user whose connect actually WORKED — so
+ * when a credential left this machine, believe the engine's own usability
+ * probe over the transport error, and only degrade to the paste flow when
+ * anthropic really reads disconnected.
+ *
+ * A failed EXTRACTION (`no-credential`) is different: nothing left the
+ * machine, so there is nothing to probe for — degrade immediately.
+ */
+
+/** Outcome of `pushMintedClaudeCredential` (extraction + push, never throws). */
+export type ClaudeHandoffResult =
+  | { ok: true }
+  | { ok: false; reason: "no-credential" | "push-failed"; error: unknown };
+
+export type ClaudeLoginSettlement =
+  /** Anthropic reads connected. `recovered` marks the HOU-1143 shape — the
+   *  push transport failed but the credential landed anyway — so the caller
+   *  can report the transport failure to Sentry without failing the user. */
+  | { kind: "connected"; recovered: boolean }
+  /** Push succeeded but the engine never read the credential connected inside
+   *  the confirm window — surface the timeout, NOT the paste dialog (the
+   *  credential is stored; the pod is just slow). */
+  | { kind: "confirm-timeout" }
+  /** The login genuinely needs the manual setup-token paste flow. */
+  | { kind: "paste"; reason: unknown };
+
+/**
+ * Decide the login outcome from the push result plus the engine's own view.
+ * `confirm` is the bounded usability poll (claude-login's `confirmConnected`):
+ * it resolves true only when the runtime can actually serve anthropic, so a
+ * stale broken credential cannot fake a recovery.
+ */
+export async function settleRemoteClaudeLogin(
+  result: ClaudeHandoffResult,
+  confirm: () => Promise<boolean>,
+): Promise<ClaudeLoginSettlement> {
+  if (result.ok) {
+    return (await confirm())
+      ? { kind: "connected", recovered: false }
+      : { kind: "confirm-timeout" };
+  }
+  if (result.reason === "push-failed" && (await confirm())) {
+    return { kind: "connected", recovered: true };
+  }
+  return { kind: "paste", reason: result.error };
+}

--- a/app/tests/claude-login-settle.test.ts
+++ b/app/tests/claude-login-settle.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  type ClaudeHandoffResult,
+  settleRemoteClaudeLogin,
+} from "../src/lib/claude-login-settle.ts";
+
+/**
+ * The remote Claude login's settlement policy (HOU-1143): the paste dialog is
+ * the LAST resort, shown only when anthropic genuinely reads disconnected —
+ * never over a connect that actually worked.
+ */
+
+/** A confirm probe with a scripted answer that records whether it ran. */
+function probe(answer: boolean) {
+  let calls = 0;
+  const confirm = async () => {
+    calls++;
+    return answer;
+  };
+  return { confirm, ran: () => calls > 0 };
+}
+
+const pushFailed: ClaudeHandoffResult = {
+  ok: false,
+  reason: "push-failed",
+  error: { status: 502 },
+};
+
+describe("settleRemoteClaudeLogin", () => {
+  it("push ok + engine confirms → connected, no recovery flag", async () => {
+    const { confirm } = probe(true);
+    assert.deepEqual(await settleRemoteClaudeLogin({ ok: true }, confirm), {
+      kind: "connected",
+      recovered: false,
+    });
+  });
+
+  it("push ok + confirm window elapses → confirm-timeout, never paste", async () => {
+    // The credential IS stored; a slow pod must not cost a manual token paste.
+    const { confirm } = probe(false);
+    assert.deepEqual(await settleRemoteClaudeLogin({ ok: true }, confirm), {
+      kind: "confirm-timeout",
+    });
+  });
+
+  it("push transport failed but anthropic reads connected → recovered success (HOU-1143)", async () => {
+    // The gateway held the push past the webview's fetch timeout (setup-pod
+    // cold start), or stored the credential and only the pod-materialize leg
+    // failed. The user's connect WORKED — no paste dialog.
+    const { confirm } = probe(true);
+    assert.deepEqual(await settleRemoteClaudeLogin(pushFailed, confirm), {
+      kind: "connected",
+      recovered: true,
+    });
+  });
+
+  it("push failed and anthropic reads disconnected → paste, carrying the push error", async () => {
+    const { confirm } = probe(false);
+    assert.deepEqual(await settleRemoteClaudeLogin(pushFailed, confirm), {
+      kind: "paste",
+      reason: { status: 502 },
+    });
+  });
+
+  it("extraction failed → paste immediately, without probing", async () => {
+    // Nothing left the machine, so a connected probe could only be reading a
+    // pre-existing credential — probing would mask a failed fresh mint.
+    const { confirm, ran } = probe(true);
+    const result: ClaudeHandoffResult = {
+      ok: false,
+      reason: "no-credential",
+      error: new Error("handoff dir empty"),
+    };
+    assert.deepEqual(await settleRemoteClaudeLogin(result, confirm), {
+      kind: "paste",
+      reason: result.error,
+    });
+    assert.equal(ran(), false);
+  });
+});


### PR DESCRIPTION
Fixes HOU-1143.

## Root cause

After a successful desktop browser OAuth against a remote (cloud) engine, the client extracts the freshly minted Anthropic credential and pushes it to the gateway. Any push failure was treated as "not connected" and unconditionally degraded to the setup-token paste flow: an info toast ("Couldn't finish connecting automatically") plus the **Finish signing in to Anthropic** dialog from the issue screenshot.

But a failed push *transport* does not prove the credential didn't land:

- On a pre-agent connect (onboarding / "create an agent"), the push is often the org's **setup pod first touch** — the gateway legitimately holds the request through provisioning + cold start (up to ~290s), longer than WKWebView's fetch timeout, so the client sees a network drop while the server-side write completes.
- The pod host **stores the credential centrally first**, then forwards it to the runtime; if only that second leg fails it answers 502 `credential stored, but the agent runtime did not accept it` (`packages/host/src/channel/proxy.ts`) — and the per-turn serve path self-heals the pod on the next turn.
- A plain network blip can eat the response to a push that succeeded.

In all three cases the user's connect actually **worked** (the reporter could immediately chat with Claude models) while the client showed a failure toast + the paste dialog. The degrade path was also `console.warn`-only, so nothing reached Sentry — its only trace is the downstream `[oauth:anthropic] abandoned login timed out` issue (HOUSTON-APP-4YZ, ~198 events) from users dismissing paste dialogs they never needed.

## Fix

New dependency-free settlement policy `app/src/lib/claude-login-settle.ts` (mirrors the `claude-credential-push` extraction pattern), driven from `finishRemoteClaudeLogin`:

- **Push ok** → confirm poll → success, or the existing confirm-timeout toast (unchanged).
- **Push transport failed** → ask the engine's *usability* probe (`/providers`-based, so a stale broken credential can't fake a recovery) before degrading. Connected → announce success and capture the transport error to Sentry (no user-facing failure). Disconnected → the existing paste fallback.
- **Extraction failed** → paste immediately, without probing (nothing left the machine; a connected probe could only be reading a pre-existing credential).
- The paste degrade path now also reports to Sentry so this failure class is observable.

## Repro (before the fix)

1. Desktop app on the hosted cloud profile, no Anthropic connected, ideally a fresh org with no agents (so the push targets the cold setup pod).
2. Connect Anthropic → complete the browser OAuth successfully.
3. Make the push leg fail while the store still lands: keep the setup pod cold (first touch) so the held request outlives the webview fetch timeout, or have the runtime's `/auth/anthropic/oauth-credential` POST return non-200 after the central store write.
4. Observe: "Couldn't finish connecting automatically" toast + the **Finish signing in to Anthropic** paste dialog — yet Claude models work in chat.

## Verify (after the fix)

1. Same setup and failure injection.
2. The connect settles as **success** ("Signed in to Anthropic" toast, card flips to connected); no paste dialog, and a `push_claude_oauth_credential` recovery event appears in Sentry.
3. A *genuine* failure (e.g. block the push entirely so nothing is stored) still degrades to the paste dialog as before — now also captured to Sentry.
4. `cd app && pnpm test` — 2614 tests pass, including the new `tests/claude-login-settle.test.ts` pinning all five outcomes.

Gates: `pnpm check` clean, `pnpm -r typecheck` clean, `pnpm check-locales` clean (no string changes).