### PR TITLE
fix(website): guide print view hides fixed site chrome

### DIFF
--- a/website/src/guides/bootcamp-0a1/index.html
+++ b/website/src/guides/bootcamp-0a1/index.html
@@ -587,6 +587,12 @@ a.cbtn.onink:hover{border-color:var(--on-ink);opacity:1}
   .guide-shell{width:min(1150px, calc(100% - 32px)); margin:0 auto; padding:0 40px}
   @media (max-width:920px){ .guide-shell{width:calc(100% - 24px); padding:0 18px} }
 
+
+  /* print: hide the fixed site chrome (it overlaps/repeats in print) */
+  @media print{
+    .lnav, .lfoot, .guide-toolbar, .gprog{display:none !important}
+    main.subpage{padding-top:0 !important; padding-bottom:0 !important}
+  }
 </style>
 {% endblock %}
 {% block subpageContent %}

--- a/website/src/guides/bootcamp-0a1/index.html
+++ b/website/src/guides/bootcamp-0a1/index.html
@@ -592,6 +592,7 @@ a.cbtn.onink:hover{border-color:var(--on-ink);opacity:1}
   @media print{
     .lnav, .lfoot, .guide-toolbar, .gprog{display:none !important}
     main.subpage{padding-top:0 !important; padding-bottom:0 !important}
+    .hcta, .toolcard, .qrcard, .mk{break-inside:avoid}
   }
 </style>
 {% endblock %}

--- a/website/src/guides/es/bootcamp-0a1/index.html
+++ b/website/src/guides/es/bootcamp-0a1/index.html
@@ -604,6 +604,7 @@ a.cbtn.onink:hover{border-color:var(--on-ink);opacity:1}
   @media print{
     .lnav, .lfoot, .guide-toolbar, .gprog{display:none !important}
     main.subpage{padding-top:0 !important; padding-bottom:0 !important}
+    .hcta, .toolcard, .qrcard, .mk{break-inside:avoid}
   }
 </style>
 {% endblock %}

--- a/website/src/guides/es/bootcamp-0a1/index.html
+++ b/website/src/guides/es/bootcamp-0a1/index.html
@@ -599,6 +599,12 @@ a.cbtn.onink:hover{border-color:var(--on-ink);opacity:1}
   .gvideo .vchaps a:hover{border-color:var(--line-strong); color:var(--ink)}
   .gvideo .vchaps a svg{width:13px; height:13px; flex:none}
   @media print{ .gvideo{display:none !important} }
+
+  /* print: hide the fixed site chrome (it overlaps/repeats in print) */
+  @media print{
+    .lnav, .lfoot, .guide-toolbar, .gprog{display:none !important}
+    main.subpage{padding-top:0 !important; padding-bottom:0 !important}
+  }
 </style>
 {% endblock %}
 {% block subpageContent %}

--- a/website/src/guides/es/revenue-manager/index.html
+++ b/website/src/guides/es/revenue-manager/index.html
@@ -330,6 +330,12 @@ lang: es
   .guide-cta a{color:var(--on-ink); text-decoration:underline; text-underline-offset:3px}
   .guide-cta .btn-white{color:var(--ground-deep)}
   @media (max-width:920px){ .guide-shell{width:calc(100% - 24px); padding:0 18px} }
+
+  /* print: hide the fixed site chrome (it overlaps/repeats in print) */
+  @media print{
+    .lnav, .lfoot, .guide-toolbar, .gprog{display:none !important}
+    main.subpage{padding-top:0 !important; padding-bottom:0 !important}
+  }
 </style>
 {% endblock %}
 {% block subpageContent %}

--- a/website/src/guides/es/sdr-linkedin/index.html
+++ b/website/src/guides/es/sdr-linkedin/index.html
@@ -471,6 +471,12 @@ lang: es
   }
 
   @media print{ .mc-head .hm, .have .hic svg{filter:none} }
+
+  /* print: hide the fixed site chrome (it overlaps/repeats in print) */
+  @media print{
+    .lnav, .lfoot, .guide-toolbar, .gprog{display:none !important}
+    main.subpage{padding-top:0 !important; padding-bottom:0 !important}
+  }
 </style>
 {% endblock %}
 {% block subpageContent %}

--- a/website/src/guides/revenue-manager/index.html
+++ b/website/src/guides/revenue-manager/index.html
@@ -323,6 +323,12 @@ lang: en
   .guide-cta a{color:var(--on-ink); text-decoration:underline; text-underline-offset:3px}
   .guide-cta .btn-white{color:var(--ground-deep)}
   @media (max-width:920px){ .guide-shell{width:calc(100% - 24px); padding:0 18px} }
+
+  /* print: hide the fixed site chrome (it overlaps/repeats in print) */
+  @media print{
+    .lnav, .lfoot, .guide-toolbar, .gprog{display:none !important}
+    main.subpage{padding-top:0 !important; padding-bottom:0 !important}
+  }
 </style>
 {% endblock %}
 {% block subpageContent %}

--- a/website/src/guides/sdr-linkedin/index.html
+++ b/website/src/guides/sdr-linkedin/index.html
@@ -471,6 +471,12 @@ lang: en
   }
 
   @media print{ .mc-head .hm, .have .hic svg{filter:none} }
+
+  /* print: hide the fixed site chrome (it overlaps/repeats in print) */
+  @media print{
+    .lnav, .lfoot, .guide-toolbar, .gprog{display:none !important}
+    main.subpage{padding-top:0 !important; padding-bottom:0 !important}
+  }
 </style>
 {% endblock %}
 {% block subpageContent %}


### PR DESCRIPTION
The v4 chrome has no print rules, so the fixed `.lnav` printed on top of the guide hero (and fixed elements repeat per page in Chrome print). All six guide pages (bootcamp-0a1, revenue-manager, sdr-linkedin, EN+ES) get a print block in their page CSS: hide `.lnav`/`.lfoot`/`.guide-toolbar`/`.gprog`, zero the subpage nav offset. Bootcamp pages also keep their cards whole across page breaks.

Verified locally: `?print` PDF renders with no nav overlap.

Follow-up PR regenerates the guide PDFs from production so their baked link URLs stop pointing at the localhost preview (all six existing PDFs have localhost links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)