### PR TITLE
chore(website): bump sitemap lastmod for updated guide pages

### DIFF
--- a/website/src/sitemap.xml
+++ b/website/src/sitemap.xml
@@ -6,10 +6,10 @@
   <url><loc>https://gethouston.ai/changelog/</loc><lastmod>2026-06-28</lastmod></url>
   <url><loc>https://gethouston.ai/guides/</loc><lastmod>2026-07-02</lastmod></url>
   <url><loc>https://gethouston.ai/guides/es/</loc><lastmod>2026-07-02</lastmod></url>
-  <url><loc>https://gethouston.ai/guides/revenue-manager/</loc><lastmod>2026-07-02</lastmod></url>
-  <url><loc>https://gethouston.ai/guides/es/revenue-manager/</loc><lastmod>2026-07-02</lastmod></url>
-  <url><loc>https://gethouston.ai/guides/sdr-linkedin/</loc><lastmod>2026-07-08</lastmod></url>
-  <url><loc>https://gethouston.ai/guides/es/sdr-linkedin/</loc><lastmod>2026-07-08</lastmod></url>
+  <url><loc>https://gethouston.ai/guides/revenue-manager/</loc><lastmod>2026-08-03</lastmod></url>
+  <url><loc>https://gethouston.ai/guides/es/revenue-manager/</loc><lastmod>2026-08-03</lastmod></url>
+  <url><loc>https://gethouston.ai/guides/sdr-linkedin/</loc><lastmod>2026-08-03</lastmod></url>
+  <url><loc>https://gethouston.ai/guides/es/sdr-linkedin/</loc><lastmod>2026-08-03</lastmod></url>
   <url><loc>https://gethouston.ai/guides/bootcamp-0a1/</loc><lastmod>2026-08-03</lastmod></url>
   <url><loc>https://gethouston.ai/guides/es/bootcamp-0a1/</loc><lastmod>2026-08-03</lastmod></url>
   <url><loc>https://gethouston.ai/developers/</loc><lastmod>2026-07-12</lastmod></url>


### PR DESCRIPTION
The four RM/SDR guide URLs changed today (#1214 print fix) but still carried July lastmod dates. Also retriggers Website Deploy: the run for #1216 failed on the "Deploy to Cloudflare Pages" step (looks transient), so the regenerated PDFs are not live yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)