### PR TITLE
fix(runtime): classify undici 'terminated' stream break as provider_internal (HOU-902)

### DIFF
--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -635,6 +635,56 @@ test("'Provider finish_reason: content_filter' stays unknown — a refusal, not 
   expect(err.kind).toBe("unknown");
 });
 
+// undici's fetch abort: a bare `TypeError: terminated` fires when the HTTP
+// socket to the gateway closes while the streamed body is still being read —
+// pi-ai flattens it to the single word "terminated", no status, no body
+// (HOU-902's verbatim report, provider opencode-go). The stream had already
+// started, so it's the same mid-response break as HOU-929 detected one layer
+// lower: provider_internal (Retry card), never the report-bug `unknown`.
+test("undici 'terminated' mid-stream socket close → provider_internal, not unknown (HOU-902)", () => {
+  const err = classifyProviderError({
+    provider: "opencode-go",
+    model: null,
+    message: "terminated",
+  });
+  expect(err).toEqual({
+    kind: "provider_internal",
+    provider: "opencode-go",
+    http_status: null,
+    message: "terminated",
+  });
+});
+
+test("'TypeError: terminated' wrapper classifies the same way", () => {
+  const err = classifyProviderError({
+    provider: "opencode-go",
+    model: "qwen3-coder",
+    message: "TypeError: terminated",
+  });
+  expect(err.kind).toBe("provider_internal");
+});
+
+test("a body merely CONTAINING 'terminated' does not read as an outage", () => {
+  // Whole-message match only: an account-termination notice is not transient.
+  const err = classifyProviderError({
+    provider: "opencode-go",
+    model: null,
+    message: "Your account has been terminated for abuse",
+  });
+  expect(err.kind).toBe("unknown");
+});
+
+test("session-kill bodies ending in 'terminated' still win the reconnect card", () => {
+  // Auth precedence is untouched: `(app_session_terminated)` style bodies are
+  // claimed by the auth branch before the server-error branch ever runs.
+  const err = classifyProviderError({
+    provider: "openai-codex",
+    model: null,
+    message: "Your session was terminated",
+  });
+  expect(err.kind).toBe("unauthenticated");
+});
+
 test("a genuine opencode 401 invalid key still reads as unauthenticated", () => {
   // The fix must not blunt real auth failures: an invalid key under 401 stays a
   // reconnect prompt.

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -472,7 +472,20 @@ function isServerError(lower: string, status: number | null): boolean {
     // status, so the 5xx short-circuit above never sees it. The body itself
     // says retry helps; without this pattern it degraded to the report-bug
     // `unknown` card (HOU-898).
-    lower.includes("error occurred while processing your request")
+    lower.includes("error occurred while processing your request") ||
+    // undici's fetch abort — the bare `terminated` (TypeError) — fires from
+    // Socket.onHttpSocketClose when the socket drops while the streamed body
+    // is still being read. The response had already STARTED (an unreachable
+    // network reads "fetch failed"/"socket hang up" instead, via `isNetwork`),
+    // so this is the gateway killing the stream mid-response — the same break
+    // HOU-929 caught when opencode reported it in-body; here it surfaces from
+    // the transport itself instead of an error body (HOU-902's verbatim
+    // report, provider opencode-go). Whole-message match on purpose: a
+    // session-kill body ("app_session_terminated") is claimed by the auth
+    // branch, and an "account terminated" style body must never read as a
+    // transient outage.
+    lower === "terminated" ||
+    lower.endsWith(": terminated")
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes HOU-902: a turn on the OpenCode Go gateway failed with the bare error text `terminated` and surfaced as `provider_error:unknown:opencode-go` — the generic report-bug card — instead of a retryable error card.

Rebased onto main after #1224 (HOU-1156) merged; see "Interaction with #1224" below.

## Root cause

`terminated` is undici's `TypeError` raised from `Socket.onHttpSocketClose` when the HTTP socket to the provider closes while the streamed response body is still being read (confirmed via Sentry HOUSTON-APP-51T, still occurring as of 2026-08-01, exact stack: `Fetch.onAborted → Fetch.terminate → onHttpSocketClose`). pi-ai flattens it to the single word `terminated` — no status, no body — and `classifyProviderError` had no pattern for it, so it fell through to `unknown`.

## Fix

The stream had already started when the socket dropped (an unreachable network reads `fetch failed` / `socket hang up` instead), so this is the same mid-response gateway break HOU-929 caught when opencode reported it in-body: classified as `provider_internal`, which renders the Retry + status-page card.

Matched on the **whole message** only (`terminated` or a `*: terminated` wrapper), deliberately not a substring:
- session-kill bodies (`app_session_terminated`, "Your session was terminated") are still claimed first by the auth branch → reconnect card unchanged
- an "account has been terminated" style body still reads as `unknown`, never a transient outage

## Interaction with #1224 (HOU-1156)

#1224 mapped the other live `unknown` families but did not cover bare `terminated` — this pattern lands in the same `isServerError` list, beside its `stream ended without finish_reason` / Gemini UNAVAILABLE additions. The reclassification also composes with #1224's logging changes:

- `logProviderError` treats `provider_internal` as an **expected** kind, so these events drop from the Sentry ERROR tier (they previously fired as `kind=unknown` errors, e.g. HOUSTON-APP-51T's family) to WARN breadcrumbs — correct for a transient break the card already handles with Retry.
- Post-#1224 fingerprinting groups `[provider_error]` lines by `(provider, kind)`, so any residual events count under one `(opencode-go, provider_internal)` issue instead of the mixed pre-#1224 bucket.
- The `unknown` fallback card #1224 taught to render `raw_excerpt` no longer applies here — the user gets the Retry card, not a card showing the bare word "terminated".

## Verification

**Before the fix (repro):** send a chat turn on the OpenCode provider and have the gateway drop the socket mid-stream (or run `classifyProviderError({ provider: "opencode-go", model: null, message: "terminated" })`) → `kind: "unknown"`, the report-bug card.

**After the fix:** the same input returns `kind: "provider_internal"` → the Retry card. Covered by 4 new unit tests in `packages/runtime/src/ai/provider-error.test.ts` (bare `terminated`, `TypeError: terminated` wrapper, substring non-match, auth precedence).

- `pnpm --filter @houston/runtime test` — 997/997 pass (rebased on main incl. #1224's suite)
- `pnpm check` (Biome) — clean
- full workspace typecheck — clean
