### PR TITLE
fix(runtime): OpenAI 'error occurred while processing your request' classifies as provider_internal (HOU-898)

### DIFF
--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -606,6 +606,26 @@ test("other observed close codes classify the same way", () => {
   }
 });
 
+// OpenAI's generic server-side failure — "An error occurred while processing
+// your request. You can retry your request, or …" — arrives via the Codex path
+// as "Codex error: <body>" with no HTTP status anywhere in the string, so the
+// 5xx short-circuit never fires (HOU-898's verbatim report). The body itself
+// says retry helps: provider_internal (Retry card), never the report-bug
+// `unknown`.
+test("Codex 'An error occurred while processing your request' → provider_internal, not unknown (HOU-898)", () => {
+  const err = classifyProviderError({
+    provider: "openai-codex",
+    model: "gpt-5.1-codex",
+    message:
+      "Codex error: An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID 21cbc7f3-020b-4f21-bd24-63a4bfbffe10 in your message.",
+  });
+  expect(err.kind).toBe("provider_internal");
+  if (err.kind === "provider_internal") {
+    expect(err.provider).toBe("openai-codex");
+    expect(err.http_status).toBeNull();
+  }
+});
+
 test("'Provider finish_reason: content_filter' stays unknown — a refusal, not an outage", () => {
   const err = classifyProviderError({
     provider: "openrouter",

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -452,7 +452,16 @@ function isServerError(lower: string, status: number | null): boolean {
     // the honest one in both deployments: retry is the remedy either way, and
     // a genuinely dead local network fails the NEXT attempt with fetch/ECONN
     // errors that still route to network_unreachable below.
-    lower.includes("websocket closed")
+    lower.includes("websocket closed") ||
+    // OpenAI's generic server-side failure body — "An error occurred while
+    // processing your request. You can retry your request, or contact us
+    // through our help center at help.openai.com if the error persists.
+    // Please include the request ID <uuid> …" — the standard 500/server_error
+    // wording, but the Codex path flattens it to "Codex error: <body>" with NO
+    // status, so the 5xx short-circuit above never sees it. The body itself
+    // says retry helps; without this pattern it degraded to the report-bug
+    // `unknown` card (HOU-898).
+    lower.includes("error occurred while processing your request")
   );
 }
 


### PR DESCRIPTION
## Summary

HOU-898: a Codex (ChatGPT OAuth) turn failed with OpenAI's generic server-side error body — "Codex error: An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID <uuid> in your message." — and classified as `provider_error:unknown:openai`, rendering the report-bug card instead of the retryable provider-outage card.

**Root cause:** that body is OpenAI's standard 500/`server_error` wording, but the Codex path flattens it to `Codex error: <body>` with no HTTP status anywhere in the string, so `isServerError`'s 5xx short-circuit never fires and no text pattern matched. Same failure family as HOU-930 (OpenRouter `finish_reason: error`).

**Fix:** add the narrow pattern `error occurred while processing your request` to `isServerError` in `packages/runtime/src/ai/provider-error.ts`, so the failure classifies as `provider_internal` (transient, Retry card — the body itself says retry helps). Test added with the verbatim message from the report.

**Rebased on #1224 (HOU-1156) and #1221 (HOU-848).** Those classified the other live `unknown` families and this branch now sits on top of both: the new pattern slots into the same `isServerError` block as #1224's `stream ended without finish_reason` / `got status: UNAVAILABLE` additions and #1221's `WebSocket closed <code>` pattern, and none of #1224's patterns (nor its embedded-JSON `"code"` status extractor — this body carries no JSON) already covered this message, so the fix is still needed and non-overlapping. With #1224's per-(provider, kind) Sentry fingerprinting, this family now also lands in its own countable `provider_internal` bucket instead of the shared unknown pile.

## Reproduce (before)

Run `classifyProviderError({ provider: "openai-codex", model: "gpt-5.1-codex", message: "Codex error: An error occurred while processing your request. You can retry your request, or …" })` — before this change it returns `{ kind: "unknown", ... }` (user sees the generic error/report-bug card; post-#1224 it at least shows the raw excerpt, but still no Retry affordance).

## Verify (after)

`pnpm --filter @houston/runtime test -- provider-error` — the new test `Codex 'An error occurred while processing your request' → provider_internal, not unknown (HOU-898)` passes; the same input now returns `kind: "provider_internal"` with `http_status: null`, so the chat renders the retryable provider-outage card.

## Gates

runtime 995 ✓ (incl. #1224's HOU-1156 fixtures) · biome ✓ · runtime tsgo ✓
