### PR TITLE
fix(runtime): Google 403 PERMISSION_DENIED classifies as unauthenticated (HOU-920)

### DIFF
--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -701,6 +701,39 @@ test("Qwen Token Plan 401 'Invalid API-key provided' → unauthenticated / inval
   if (err.kind === "unauthenticated") expect(err.cause).toBe("invalid_api_key");
 });
 
+test("Google 403 PERMISSION_DENIED 'project has been denied access' → unauthenticated / invalid_api_key (HOU-920)", () => {
+  // Verbatim generativelanguage.googleapis.com body when the API key's GCP
+  // project is blocked by Google. The whole credential is unusable — every
+  // request fails — so the remedy is pasting a different key (google is an
+  // apiKey provider: the card opens the re-paste dialog, HOU-1077). The
+  // embedded `"code":403` extractor (HOU-1156) recovers the status, but a 403
+  // is deliberately auth only when the BODY names an auth failure — without
+  // the PERMISSION_DENIED patterns it fell through to `unknown`.
+  const err = classifyProviderError({
+    provider: "google",
+    model: "gemini-3.5-flash",
+    message:
+      '{"error":{"message":"{\\n  \\"error\\": {\\n    \\"code\\": 403,\\n    \\"message\\": \\"Your project has been denied access. Please contact support.\\",\\n    \\"status\\": \\"PERMISSION_DENIED\\"\\n  }\\n}\\n","code":403,"status":"Forbidden"}}',
+  });
+  expect(err.kind).toBe("unauthenticated");
+  if (err.kind === "unauthenticated") expect(err.cause).toBe("invalid_api_key");
+});
+
+test("Google PERMISSION_DENIED status label alone → unauthenticated (HOU-920)", () => {
+  // Google's other 403s ride the same canonical gRPC label (key restrictions,
+  // SERVICE_DISABLED, suspended consumer) — all mean this key/project cannot
+  // call the API, all reconnect. Anthropic's resource-level "permission_error"
+  // must NOT trip this (its own test above asserts it stays out of the
+  // reconnect card).
+  const err = classifyProviderError({
+    provider: "google",
+    model: "gemini-3.5-flash",
+    message:
+      '{"error":{"code":403,"message":"Method doesn\'t allow unregistered callers (callers without established identity). Please use API Key or other form of API consumer identity to call this API.","status":"PERMISSION_DENIED"}}',
+  });
+  expect(err.kind).toBe("unauthenticated");
+});
+
 // ---------------------------------------------------------------------------
 // Context overflow — the conversation no longer fits the model's window.
 // The Jan fixture is the VERBATIM llama.cpp rejection from the production

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -68,6 +68,17 @@ const INVALID_KEY_PATTERNS = [
   // classified `unknown` (generic error card instead of the reconnect card,
   // and "could not verify" instead of "didn't accept this key") (HOU-1077).
   "authorization failed",
+  // Google Gemini API keys: 403 with `"status": "PERMISSION_DENIED"` — the
+  // key's GCP project is blocked ("Your project has been denied access.
+  // Please contact support.") or otherwise not permitted to call the API. The
+  // whole credential is unusable, so the remedy is pasting a different key —
+  // the reconnect card, never the report-bug `unknown` card (HOU-920).
+  // "permission_denied" is Google's canonical gRPC status label; Anthropic's
+  // resource-level authZ marker is "permission_error", which deliberately
+  // stays OUT of this list (re-keying doesn't fix it — see the 403 note in
+  // `isAuth` and its test).
+  "permission_denied",
+  "project has been denied access",
 ];
 
 /**


### PR DESCRIPTION
## Summary

Fixes HOU-920. Rebased on main after #1224 (HOU-1156) merged — see the interplay notes below.

A Google Gemini turn failing with the 403 body below rendered the report-bug `unknown` card (`provider_error:unknown:google`):

```
{"error":{"message":"{\n  \"error\": {\n    \"code\": 403,\n    \"message\": \"Your project has been denied access. Please contact support.\",\n    \"status\": \"PERMISSION_DENIED\"\n  }\n}\n","code":403,"status":"Forbidden"}}
```

**Root cause:** since #1224 the embedded `"code": 403` extractor does recover the HTTP status, but a 403 is deliberately auth only when the BODY names an auth failure (Anthropic's resource-level `permission_error` must not trip the reconnect card) — and no pattern named this body, so it still fell through to `unknown`.

**Fix:** `PERMISSION_DENIED` is Google's canonical gRPC status label for "this key/GCP project cannot call this API" (project banned, key restrictions, service disabled, suspended consumer). The whole credential is unusable, and google is an apiKey provider — the actionable remedy is pasting a different key, i.e. the `unauthenticated`/`invalid_api_key` reconnect card whose Reconnect opens the re-paste-key dialog (HOU-1077). Added `permission_denied` + `project has been denied access` to `INVALID_KEY_PATTERNS`.

**Interplay with #1224 (verified by its own fixtures, all green):**
- Google's billing dunning denial also rides 403 + `PERMISSION_DENIED`; it stays `quota_exhausted` because `isAuth` defers to the balance patterns before the key patterns.
- Anthropic's 403 `permission_error` keeps falling through (its regression test still asserts it).
- Post-#1224 the `unknown` card at least shows the raw excerpt — but this family is a classified, actionable card now, and Sentry fingerprints it as its own `(google, unauthenticated)` family instead of `(google, unknown)`.

## Reproduce (before)

```ts
classifyProviderError({
  provider: "google",
  model: "gemini-3.5-flash",
  message: <the verbatim 403 PERMISSION_DENIED body above>,
})
// before: { kind: "unknown", … }  → report-bug card (raw excerpt only, post-#1224)
// after:  { kind: "unauthenticated", cause: "invalid_api_key" } → reconnect card
```

End-to-end: connect Google Gemini with an API key whose GCP project Google has blocked, send a chat message → before: "Report bug" card; after: the reconnect card offering to re-enter the key.

## Verify

```
pnpm --filter @houston/runtime test   # includes 2 new HOU-920 cases in provider-error.test.ts
```

All 995 runtime tests pass (including every HOU-1156 fixture from #1224); Biome clean; workspace typecheck clean.