### PR TITLE
fix(runtime): Codex 'WebSocket closed <code>' classifies as provider_internal, not network_unreachable (HOU-848)

### DIFF
--- a/knowledge-base/provider-errors.md
+++ b/knowledge-base/provider-errors.md
@@ -51,7 +51,8 @@ client fingerprints `[provider_error]` lines by `(provider, kind)`
 (`packages/runtime-client/src/sentry/client.ts`), so each family is its own
 countable issue. The ritual: search Sentry for `kind=unknown`, and promote any
 family that repeats into a classifier pattern (verbatim fixture first — see the
-HOU-1156 batch: Codex `WebSocket closed 1006` → network, OpenRouter
+HOU-1156 batch: Codex `WebSocket closed 1006` → provider_internal (HOU-848:
+the socket drops pod-side, so the check-your-connection card was wrong), OpenRouter
 `Stream ended without finish_reason` → provider_internal, Gemini gRPC
 `UNAVAILABLE`/embedded `"code": 5xx` → provider_internal, Google billing
 `dunning` → quota, opencode `RegionError` → model_unavailable).

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -571,6 +571,41 @@ test("'Provider finish_reason: network_error' → provider_internal too", () => 
   expect(err.kind).toBe("provider_internal");
 });
 
+// Codex's WebSocket transport dying mid-turn arrives as the bare string
+// `WebSocket closed <code>` — no status, no body (HOU-848's verbatim report;
+// 584 Sentry events across 137 users read as `unknown`). HOU-1156 first
+// classified it network_unreachable, but every production event comes from a
+// cloud engine pod — "check your internet" points at the wrong network. A
+// dropped socket is a transient server-side stream break — retry helps — so
+// it reads as provider_internal (Retry card), never the report-bug `unknown`
+// and never the check-your-connection card.
+test("codex 'WebSocket closed 1006' → provider_internal, not unknown (HOU-848)", () => {
+  const err = classifyProviderError({
+    provider: "openai-codex",
+    model: "gpt-5.5",
+    message: "WebSocket closed 1006",
+  });
+  expect(err).toEqual({
+    kind: "provider_internal",
+    provider: "openai-codex",
+    http_status: null,
+    message: "WebSocket closed 1006",
+  });
+});
+
+test("other observed close codes classify the same way", () => {
+  // 1000 (server closed the socket cleanly mid-turn) and 1012 (service
+  // restart) both appear in the same Sentry bucket — same transient verdict.
+  for (const code of [1000, 1012]) {
+    const err = classifyProviderError({
+      provider: "openai-codex",
+      model: "gpt-5.6-sol",
+      message: `WebSocket closed ${code}`,
+    });
+    expect(err.kind).toBe("provider_internal");
+  }
+});
+
 test("'Provider finish_reason: content_filter' stays unknown — a refusal, not an outage", () => {
   const err = classifyProviderError({
     provider: "openrouter",
@@ -768,21 +803,9 @@ test("overflow text without numbers still classifies, with null token counts", (
 // HOU-1156: verbatim shapes of the `unknown` families the 90-day Sentry audit
 // surfaced — each was rendering the content-free "Something unexpected
 // happened" card. Fixtures mirror the real payloads (identifiers synthetic).
-
-test("Codex 'WebSocket closed 1006' → network_unreachable, not unknown (HOU-1156)", () => {
-  // pi-ai flattens an abnormal mid-turn drop of Codex's WebSocket to this
-  // exact string — no status, no body. 584 events / 137 users in 90 days.
-  const err = classifyProviderError({
-    provider: "openai-codex",
-    model: "gpt-5.5",
-    message: "WebSocket closed 1006",
-  });
-  expect(err).toEqual({
-    kind: "network_unreachable",
-    provider: "openai-codex",
-    message: "WebSocket closed 1006",
-  });
-});
+// (The Codex `WebSocket closed <code>` family from that audit lives with the
+// mid-stream break tests above — reclassified network_unreachable →
+// provider_internal by HOU-848.)
 
 test("openrouter 'Stream ended without finish_reason' → provider_internal (HOU-1156)", () => {
   const err = classifyProviderError({

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -440,7 +440,19 @@ function isServerError(lower: string, status: number | null): boolean {
     // demand …"}}`. The embedded `"code"` extractor usually recovers the 503;
     // these keep the verdict when the body is truncated (HOU-1156).
     lower.includes("got status: unavailable") ||
-    lower.includes("experiencing high demand")
+    lower.includes("experiencing high demand") ||
+    // Codex (ChatGPT OAuth) rides a WebSocket transport; when that socket dies
+    // mid-turn pi-ai flattens it to `WebSocket closed <code>` — no status, no
+    // body (HOU-848: codes 1006 abnormal closure, 1000 server closed mid-turn,
+    // 1012 service restart, all seen in the wild). HOU-1156 first classified
+    // this as network_unreachable, but every production event originates on a
+    // cloud engine pod, where "check your internet" points at the wrong
+    // network — the pod↔OpenAI socket broke, not the user's connection. The
+    // provider_internal card ("<provider> is having a problem, try again") is
+    // the honest one in both deployments: retry is the remedy either way, and
+    // a genuinely dead local network fails the NEXT attempt with fetch/ECONN
+    // errors that still route to network_unreachable below.
+    lower.includes("websocket closed")
   );
 }
 
@@ -453,12 +465,6 @@ function isNetwork(lower: string): boolean {
     lower.includes("etimedout") ||
     lower.includes("eai_again") ||
     lower.includes("socket hang up") ||
-    // Codex rides a WebSocket to the ChatGPT backend; pi-ai flattens an
-    // abnormal mid-turn drop to `WebSocket closed 1006` — no close frame, the
-    // transport died (sleep, flaky Wi-Fi, a server-side hang-up). Transient;
-    // retry helps. This was the single largest unclassified card in
-    // production (HOU-1156: 584 events / 137 users in 90 days).
-    lower.includes("websocket closed") ||
     lower.includes("network error") ||
     lower.includes("connection refused") ||
     lower.includes("connection reset")


### PR DESCRIPTION
Fixes HOU-848. Rebased on main after #1224 (HOU-1156) merged — this PR is now the verdict refinement on top of it.

## Context

#1224 already promoted the Codex `WebSocket closed <code>` family out of `kind: unknown` (it was the biggest unclassified bucket: 584 events / 137 users in 90 days), but classified it as `network_unreachable` — the card that says **"Check your internet, then try again."**

## Why provider_internal instead

- Every production occurrence of this family originates on a **cloud engine pod** (all sampled Sentry events carry `engine-pod@…` releases). The pod↔OpenAI websocket broke; the user's internet is demonstrably fine (they're talking to the gateway). "Check your internet" blames the wrong network.
- `provider_internal` ("OpenAI is having a problem. Try again in a moment.") is honest in both deployments: retry is the remedy either way, and if the user's local network really is dead, the next attempt fails with `fetch failed` / `ECONN*` which still routes to `network_unreachable`.
- It matches the rest of the mid-stream break family: HOU-929 (`Streaming response failed`) and HOU-930 (`Provider finish_reason: error`) both read `provider_internal`.

## Changes

- Move `websocket closed` from `isNetwork` to `isServerError` (which runs first) with the rationale in place.
- Replace #1224's `network_unreachable` websocket test with `provider_internal` expectations; add coverage for observed close codes 1000 and 1012 alongside 1006.
- Update the `knowledge-base/provider-errors.md` HOU-1156 triage-loop line to record the reclassification.

## Before (with #1224's verdict)

`classifyProviderError({ provider: "openai-codex", model: "gpt-5.5", message: "WebSocket closed 1006" })` → `kind: "network_unreachable"` → the WifiOff card telling a cloud user to check their internet.

## After

Same input → `kind: "provider_internal"`, `http_status: null` → the retryable provider-problem card with the OpenAI status-page link.

Verify: `pnpm --filter @houston/runtime test` — 994 tests pass, including the HOU-848 cases for close codes 1006/1000/1012. Post-ship, Sentry's `(openai-codex, network_unreachable)` fingerprint bucket for this family should go quiet in favor of `provider_internal` (expected tier, breadcrumb only).