### PR TITLE
fix(auth): ChatGPT sign-in survives a lost engine login (HOU-1113)

### DIFF
--- a/app/src/lib/codex-loopback.ts
+++ b/app/src/lib/codex-loopback.ts
@@ -17,6 +17,7 @@
 import { shouldUseCodexLoopback } from "../components/shell/provider-login-url";
 import { useUIStore } from "../stores/ui";
 import { runCodexDeviceCodeFallback } from "./codex-device-code-fallback";
+import { recoverFailedCodexRelay } from "./codex-relay-recovery";
 import { genericErrorDescription, logAndReportError } from "./error-report";
 import i18n from "./i18n";
 import {
@@ -41,6 +42,25 @@ const CODEX_OAUTH_CALLBACK_EVENT = "codex-oauth://callback";
 const CALLBACK_TIMEOUT_MS = 5 * 60_000;
 
 type Unlisten = Awaited<ReturnType<typeof legacyListen>>;
+
+/**
+ * The armed relay attempt per provider, torn down by {@link
+ * cancelCodexLoopback}. Without this, a CANCELLED sign-in left its callback
+ * listener armed for the full 5-minute window: approving the abandoned
+ * browser tab afterwards relayed a code into a login the engine no longer
+ * held — a doomed "no active login" submit and a spurious error toast (or,
+ * worse, an unwanted auto-restarted sign-in) for a flow the user gave up on.
+ */
+const activeLoopbackCleanups = new Map<string, () => void>();
+
+/**
+ * Tear down the armed loopback relay for a provider (listener + timeout), so
+ * a late browser approval can't relay into a cancelled login. Called from
+ * `cancelLogin`'s engine-call choke point; a no-op when nothing is armed.
+ */
+export function cancelCodexLoopback(frontendProviderId: string): void {
+  activeLoopbackCleanups.get(frontendProviderId)?.();
+}
 
 /** Reuse the existing "couldn't open sign-in" toast key with the provider's
  *  display name; falls back to the raw id for an unknown provider. */
@@ -78,17 +98,39 @@ function fallBackToDeviceCode(
   });
 }
 
-/** Relay the callback's query string to the engine. `submitLoginCode`'s
- *  engine-call wrapper already surfaces a failure toast + Sentry report, so the
- *  catch here only keeps the promise from floating unhandled. */
+/** Last auto-restart per provider (see `recoverFailedCodexRelay`'s cooldown). */
+const relayRestartAt = new Map<string, number>();
+
+/**
+ * Relay the callback's query string to the engine. The submit runs with
+ * `surface: false` because the failure that actually happens in the wild — the
+ * engine pod recycled mid-consent, answering "no active login" (HOU-1113) — is
+ * RECOVERABLE: restart the same browser sign-in and OpenAI redirects the
+ * already-consented app straight through. `recoverFailedCodexRelay` owns the
+ * one-restart budget and the dead-end surface (Sentry + failure toast), so a
+ * recovered relay never shows the user an error for a sign-in that succeeds.
+ */
 async function relayCodexCode(
   frontendProviderId: string,
   payload: string,
 ): Promise<void> {
   try {
-    await tauriProvider.submitLoginCode(frontendProviderId, payload);
+    await tauriProvider.submitLoginCode(frontendProviderId, payload, {
+      surface: false,
+    });
   } catch (err) {
-    console.error("[codex-loopback] submitLoginCode failed:", err);
+    await recoverFailedCodexRelay(err, {
+      report: (cause) => logAndReportError("codex_loopback_relay", cause),
+      restartLogin: () =>
+        tauriProvider.launchLogin(frontendProviderId, {
+          deviceAuth: false,
+          toast: false,
+        }),
+      fail: (cause) => failCodexLogin(frontendProviderId, cause),
+      lastRestartAt: () => relayRestartAt.get(frontendProviderId) ?? null,
+      noteRestart: () => relayRestartAt.set(frontendProviderId, Date.now()),
+      now: () => Date.now(),
+    });
   }
 }
 
@@ -119,7 +161,11 @@ export async function beginCodexBrowserLogin(
       unlisten();
       unlisten = null;
     }
+    // Only this attempt's own registration — a newer begin may have replaced it.
+    if (activeLoopbackCleanups.get(frontendProviderId) === cleanup)
+      activeLoopbackCleanups.delete(frontendProviderId);
   };
+  activeLoopbackCleanups.set(frontendProviderId, cleanup);
 
   // Register the callback listener BEFORE binding the loopback so a fast
   // redirect can't race ahead of us.

--- a/app/src/lib/codex-relay-recovery.ts
+++ b/app/src/lib/codex-relay-recovery.ts
@@ -1,0 +1,84 @@
+/**
+ * Lost-login recovery for the desktop Codex/OpenAI loopback relay.
+ *
+ * The relay's final step hands the OAuth callback code to the engine
+ * (`submitLoginCode` → the runtime's `completeLogin`). In managed cloud the
+ * login state lives in the runtime process's MEMORY, and the pod serving it
+ * can be recycled while the user is on OpenAI's consent screen (Sentry
+ * 7625496858 shows the gateway 503 burst of exactly that mid-login). The
+ * fresh process answers `no active login for openai-codex`, and the old
+ * behavior dead-ended there: a raw `engine request failed (400): {...}` toast
+ * the user could only screenshot (HOU-1113).
+ *
+ * The code itself is unsalvageable — its PKCE verifier died with the old
+ * process — but the RECOVERY is cheap: restart the same browser sign-in.
+ * OpenAI redirects an already-consented app straight through, so the retried
+ * flow usually completes with zero extra clicks. One restart per cooldown
+ * window, so an engine that keeps losing state degrades to the failure toast
+ * instead of a browser-tab loop.
+ *
+ * Pure sequencing over injected effects so the policy is unit-testable
+ * (node:test can't import the real tauri/store modules).
+ */
+
+/**
+ * The engine no longer holds the login this relayed code belongs to — the
+ * runtime's `completeLogin` threw `no active login for <provider>` (see
+ * packages/runtime/src/auth/login.ts). Matched on the message because the
+ * host serves it as a bare-string 400 with no typed kind.
+ */
+export function isLoginSessionLostError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes("no active login");
+}
+
+/**
+ * Longer than one full browser dance (consent + redirect take well under the
+ * relay's own 5-minute callback window), so a restarted flow that loses its
+ * login AGAIN surfaces the failure instead of opening browser tabs forever.
+ */
+export const RELAY_RESTART_COOLDOWN_MS = 5 * 60_000;
+
+export interface CodexRelayRecoveryOps {
+  /** Log + Sentry-capture the lost-login failure. NOT a toast: when the
+   *  restart works the user never needed to know, and when it can't run the
+   *  dead-end path below owns the user-facing surface. */
+  report(cause: unknown): void;
+  /** Restart the SAME browser sign-in (`deviceAuth: false`, no toast). The
+   *  fresh `ProviderLoginUrl` event re-enters the loopback relay. */
+  restartLogin(): Promise<void>;
+  /** Dead-end failure toast — the relay failed and no restart could run. */
+  fail(cause: unknown): void;
+  /** Last auto-restart for this provider, ms epoch, or null if none yet. */
+  lastRestartAt(): number | null;
+  /** Record that an auto-restart ran now. */
+  noteRestart(): void;
+  now(): number;
+}
+
+/**
+ * Handle a failed relay submit. A lost login within the cooldown budget
+ * restarts the sign-in; anything else (a different error, budget spent, the
+ * restart itself failing) dead-ends with the failure toast. Never rejects —
+ * the caller is an event handler with nobody above it to catch.
+ */
+export async function recoverFailedCodexRelay(
+  cause: unknown,
+  ops: CodexRelayRecoveryOps,
+): Promise<void> {
+  ops.report(cause);
+  const last = ops.lastRestartAt();
+  const canRestart =
+    isLoginSessionLostError(cause) &&
+    (last === null || ops.now() - last >= RELAY_RESTART_COOLDOWN_MS);
+  if (!canRestart) {
+    ops.fail(cause);
+    return;
+  }
+  ops.noteRestart();
+  try {
+    await ops.restartLogin();
+  } catch (err) {
+    ops.fail(err);
+  }
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -41,6 +41,7 @@ import {
   beginClaudeBrowserLogin,
   cancelClaudeBrowserLogin,
 } from "./claude-login";
+import { cancelCodexLoopback } from "./codex-loopback";
 import { COMPOSIO_ALREADY_CONNECTED_KIND } from "./composio-already-connected";
 import { getEngine, isRemoteEngine } from "./engine";
 import { engineCallSurface } from "./engine-call-policy";
@@ -1695,9 +1696,20 @@ export const tauriProvider = {
    * `ProviderLoginUrl` WS event, the UI shows the dialog, and this
    * call relays the code back to the CLI's stdin.
    */
-  submitLoginCode: (provider: string, code: string) =>
-    call<void>("submit_provider_login_code", () =>
-      getEngine().submitProviderLoginCode(provider, code),
+  submitLoginCode: (
+    provider: string,
+    code: string,
+    // `surface: false` is the codex loopback relay's contract: a lost-login
+    // failure is recoverable (auto-restarted sign-in), so the relay owns the
+    // FINAL surface itself — see codex-relay-recovery.ts. Every other caller
+    // keeps the default toast + capture.
+    opts?: Pick<EngineCallOptions, "surface">,
+  ) =>
+    call<void>(
+      "submit_provider_login_code",
+      () => getEngine().submitProviderLoginCode(provider, code),
+      undefined,
+      opts,
     ),
   /**
    * Abort an in-flight sign-in the user gave up on (closed the OAuth
@@ -1710,6 +1722,11 @@ export const tauriProvider = {
    */
   cancelLogin: (provider: string) =>
     call<void>("cancel_provider_login", () => {
+      // A Codex loopback relay may be armed for this provider: tear down its
+      // callback listener too, so approving the abandoned browser tab later
+      // can't relay a code into the login this cancel just killed ("no active
+      // login" + a spurious toast). No-op for every other flow.
+      cancelCodexLoopback(provider);
       // Anthropic on the desktop ran the native browser login (not the runtime),
       // so its cancel must kill THAT child — the runtime's cancelProviderLogin
       // would be a no-op and leave the `claude` helper running. Mirror the

--- a/app/tests/codex-relay-recovery.test.ts
+++ b/app/tests/codex-relay-recovery.test.ts
@@ -1,0 +1,108 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  type CodexRelayRecoveryOps,
+  isLoginSessionLostError,
+  RELAY_RESTART_COOLDOWN_MS,
+  recoverFailedCodexRelay,
+} from "../src/lib/codex-relay-recovery.ts";
+
+// HOU-1113 — the engine pod serving a Codex sign-in can be recycled while the
+// user sits on OpenAI's consent screen; the relayed callback code then hits a
+// fresh process that answers `no active login for openai-codex`, and the old
+// behavior dead-ended with a raw 400 toast. The relay now restarts the same
+// browser sign-in once per cooldown window (OpenAI redirects an
+// already-consented app straight through). These pin that policy.
+
+const LOST = new Error(
+  'engine request failed (400): {"error":"no active login for openai-codex"}',
+);
+
+function recordingOps(overrides: Partial<CodexRelayRecoveryOps> = {}): {
+  ops: CodexRelayRecoveryOps;
+  calls: string[];
+  failures: unknown[];
+} {
+  const calls: string[] = [];
+  const failures: unknown[] = [];
+  const ops: CodexRelayRecoveryOps = {
+    report: () => calls.push("report"),
+    restartLogin: async () => {
+      calls.push("restart");
+    },
+    fail: (cause) => {
+      calls.push("fail");
+      failures.push(cause);
+    },
+    lastRestartAt: () => null,
+    noteRestart: () => calls.push("note"),
+    now: () => 1_000_000,
+    ...overrides,
+  };
+  return { ops, calls, failures };
+}
+
+describe("isLoginSessionLostError", () => {
+  it("matches the runtime's no-active-login 400", () => {
+    strictEqual(isLoginSessionLostError(LOST), true);
+  });
+
+  it("rejects unrelated failures", () => {
+    strictEqual(isLoginSessionLostError(new Error("Load failed")), false);
+    strictEqual(isLoginSessionLostError("engine request failed (500)"), false);
+  });
+});
+
+describe("recoverFailedCodexRelay", () => {
+  it("restarts the sign-in on a lost login, with no failure toast", async () => {
+    const { ops, calls } = recordingOps();
+    await recoverFailedCodexRelay(LOST, ops);
+    deepStrictEqual(calls, ["report", "note", "restart"]);
+  });
+
+  it("notes the restart BEFORE launching, so a racing relay cannot double-restart", async () => {
+    const { ops, calls } = recordingOps({
+      restartLogin: async () => {
+        throw new Error("launch failed");
+      },
+    });
+    await recoverFailedCodexRelay(LOST, ops);
+    deepStrictEqual(calls, ["report", "note", "fail"]);
+  });
+
+  it("dead-ends a second lost login inside the cooldown window", async () => {
+    const { ops, calls, failures } = recordingOps({
+      lastRestartAt: () => 1_000_000 - RELAY_RESTART_COOLDOWN_MS + 1,
+    });
+    await recoverFailedCodexRelay(LOST, ops);
+    deepStrictEqual(calls, ["report", "fail"]);
+    deepStrictEqual(failures, [LOST]);
+  });
+
+  it("restarts again once the cooldown has elapsed", async () => {
+    const { ops, calls } = recordingOps({
+      lastRestartAt: () => 1_000_000 - RELAY_RESTART_COOLDOWN_MS,
+    });
+    await recoverFailedCodexRelay(LOST, ops);
+    deepStrictEqual(calls, ["report", "note", "restart"]);
+  });
+
+  it("dead-ends any non-lost-login failure without restarting", async () => {
+    const err = new Error("Load failed");
+    const { ops, calls, failures } = recordingOps();
+    await recoverFailedCodexRelay(err, ops);
+    deepStrictEqual(calls, ["report", "fail"]);
+    deepStrictEqual(failures, [err]);
+  });
+
+  it("surfaces a restart launch failure as the dead-end", async () => {
+    const launchErr = new Error("browser refused");
+    const { ops, failures } = recordingOps({
+      restartLogin: async () => {
+        throw launchErr;
+      },
+    });
+    await recoverFailedCodexRelay(LOST, ops);
+    deepStrictEqual(failures, [launchErr]);
+  });
+});

--- a/packages/web/e2e/files.spec.ts
+++ b/packages/web/e2e/files.spec.ts
@@ -952,8 +952,13 @@ test("renames and deletes a file from the context menu", async ({ page }) => {
   const input = page.getByRole("textbox");
   await expect(input).toHaveValue("Q3 report.pdf");
   await input.fill("Q3 final.pdf");
+  // Guard the fill before committing: the rename field selects its basename a
+  // frame after mounting, and when that frame lands mid-fill the inserted text
+  // only replaced the selection ("Q3 final.pdf.pdf"). Substring matchers below
+  // would let that corruption slide to a confusing dialog assertion.
+  await expect(input).toHaveValue("Q3 final.pdf");
   await input.press("Enter");
-  await expect(page.getByText("Q3 final.pdf")).toBeVisible();
+  await expect(page.getByText("Q3 final.pdf", { exact: true })).toBeVisible();
 
   // Deleting is confirmed first, by NAME, and cancelling leaves the file alone.
   await page.getByText("Q3 final.pdf").click({ button: "right" });

--- a/packages/web/src/engine-adapter/client/provider-login-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-login-mixin.ts
@@ -6,6 +6,7 @@ import type { BaseCtor } from "./mixin";
 import { surfaceTypedLoginFailure } from "./provider-login-failure";
 import {
   loginKey,
+  pinnedLoginAgentId,
   pollProviderConnect,
   stopLoginWatch,
   watchLoginCompletion,
@@ -123,28 +124,51 @@ export function ProviderLoginMixin<TBase extends BaseCtor>(Base: TBase) {
     async submitProviderLoginCode(name: string, code: string): Promise<void> {
       const pid = toNewProvider(name);
       if (!pid) return;
-      // Same target the login started in: the agent's runtime, or the setup
-      // runtime when first-run connected pre-agent.
-      const engine = this.ctx.cp ? this.ctx.providerEngine() : this.ctx.engine;
+      const cp = this.ctx.cp;
+      if (!cp) {
+        await this.ctx.engine.completeLogin(pid, code);
+        return;
+      }
+      // The SAME runtime the login STARTED in, pinned by the connect poll's
+      // `activeLogins` entry — never re-derived here: `providerAgentId()`'s
+      // answer moves when the first agent materializes mid-login (onboarding
+      // tears the setup pod down at that moment), and the relayed OAuth code
+      // then landed on a pod that never saw the login — "no active login for
+      // openai-codex" (HOU-1113). Live derivation is only the fallback when no
+      // pin exists (the poll already ended, or a legacy paste dialog).
+      const pinned = pinnedLoginAgentId(this.ctx, pid);
+      const engine =
+        pinned === undefined
+          ? this.ctx.providerEngine()
+          : pinned === null
+            ? controlPlane.setupRuntimeClientFor(cp)
+            : controlPlane.runtimeClientFor(cp, pinned);
       await engine.completeLogin(pid, code);
     }
     async cancelProviderLogin(name?: string): Promise<void> {
       const pid = name ? toNewProvider(name) : undefined;
       if (!name || !pid) return;
       if (this.ctx.cp) {
-        // Key mirrors pollProviderConnect: the agent's id, or the setup-runtime
-        // sentinel when the first-run login started before any agent existed.
-        const agentId = this.ctx.providerAgentId();
+        // The pinned key mirrors what pollProviderConnect registered at start:
+        // the agent's id, or the setup-runtime sentinel when the first-run
+        // login started before any agent existed. Pinned — NOT re-derived via
+        // providerAgentId(), whose answer moves once the first agent
+        // materializes mid-login: the delete would then miss the poll's real
+        // key (the poll keeps running) and the cancel would land on a runtime
+        // that never saw the login (HOU-1113).
+        const pinned = pinnedLoginAgentId(this.ctx, pid);
+        const agentId =
+          pinned === undefined ? this.ctx.providerAgentId() : pinned;
         this.ctx.activeLogins.delete(loginKey(agentId, pid)); // stop the poll
         // Kill the runtime-side login too, in the same runtime the login started
         // in (the agent's sandbox, or the hidden setup runtime pre-agent) —
         // otherwise it keeps polling the provider until timeout and a retry
         // collides with the stale flow ("sign-in already pending", HOU-664 /
         // the HOU-438 failure class).
-        await this.ctx
-          .providerEngine()
-          .cancelLogin(pid)
-          .catch(benignCancelMiss);
+        const engine = agentId
+          ? this.ctx.providerEngineFor(agentId)
+          : controlPlane.setupRuntimeClientFor(this.ctx.cp);
+        await engine.cancelLogin(pid).catch(benignCancelMiss);
         return;
       }
       stopLoginWatch(this.ctx, name);

--- a/packages/web/src/engine-adapter/client/provider-login-poll.ts
+++ b/packages/web/src/engine-adapter/client/provider-login-poll.ts
@@ -30,6 +30,31 @@ export function loginKey(agentId: string | null, pid: string): string {
 }
 
 /**
+ * The runtime the in-flight login for `pid` is pinned to, recovered from the
+ * `activeLogins` key the connect poll registered when the login STARTED: an
+ * agent id, `null` for the hidden setup runtime, `undefined` when no login is
+ * in flight. Submit and cancel MUST route by this pin, never re-derive at call
+ * time — `providerAgentId()`'s answer moves when the first agent materializes
+ * mid-login (onboarding), and the relayed OAuth code then landed on a pod that
+ * never saw the login: "no active login for openai-codex" (HOU-1113). With
+ * concurrent entries (a retry started before the old poll ended) the LAST
+ * match wins — Set iteration is insertion-ordered, so that is the newest login.
+ */
+export function pinnedLoginAgentId(
+  ctx: AdapterContext,
+  pid: ProviderId,
+): string | null | undefined {
+  const suffix = `:${pid}`;
+  let pinned: string | null | undefined;
+  for (const key of ctx.activeLogins) {
+    if (!key.endsWith(suffix)) continue;
+    const agent = key.slice(0, -suffix.length);
+    pinned = agent === SETUP_LOGIN_KEY ? null : agent;
+  }
+  return pinned;
+}
+
+/**
  * True iff this provider's login is genuinely DONE — not merely `configured`.
  * A stale stored credential leaves `configured: true` while the just-launched
  * OAuth is still `awaiting_user`, and treating that as success completed the

--- a/packages/web/tests/provider-login-pinning.test.ts
+++ b/packages/web/tests/provider-login-pinning.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+// HOU-1113 — the submit/cancel side of a cloud provider login must land on the
+// SAME runtime the login started in. `providerAgentId()` re-derived at call
+// time moves when the first agent materializes mid-login (onboarding tears the
+// setup pod down at that moment), so the relayed OAuth code hit a pod that
+// never saw the login: `no active login for openai-codex`. These pin the
+// routing to the connect poll's `activeLogins` registration.
+
+const mocks = vi.hoisted(() => ({
+  agentComplete: vi.fn<() => Promise<void>>(),
+  setupComplete: vi.fn<() => Promise<void>>(),
+  agentCancel: vi.fn<() => Promise<void>>(),
+  setupCancel: vi.fn<() => Promise<void>>(),
+  runtimeClientFor: vi.fn(),
+}));
+
+vi.mock("../src/engine-adapter/control-plane", () => ({
+  captureCredential: vi.fn(),
+  captureSetupCredential: vi.fn(),
+  runtimeClientFor: mocks.runtimeClientFor.mockImplementation(() => ({
+    completeLogin: mocks.agentComplete,
+    cancelLogin: mocks.agentCancel,
+  })),
+  setupRuntimeClientFor: () => ({
+    completeLogin: mocks.setupComplete,
+    cancelLogin: mocks.setupCancel,
+  }),
+}));
+
+beforeEach(() => {
+  mocks.agentComplete.mockReset().mockResolvedValue();
+  mocks.setupComplete.mockReset().mockResolvedValue();
+  mocks.agentCancel.mockReset().mockResolvedValue();
+  mocks.setupCancel.mockReset().mockResolvedValue();
+  mocks.runtimeClientFor.mockClear();
+});
+
+const { pinnedLoginAgentId, loginKey } = await import(
+  "../src/engine-adapter/client/provider-login-poll"
+);
+const { ProviderLoginMixin } = await import(
+  "../src/engine-adapter/client/provider-login-mixin"
+);
+
+type Ctx = {
+  cp: { baseUrl: string; token: string };
+  activeLogins: Set<string>;
+  providerEngine: () => unknown;
+  providerEngineFor: (id: string) => unknown;
+  providerAgentId: () => string | null;
+};
+
+function makeClient(ctx: Ctx) {
+  const Client = ProviderLoginMixin(
+    class {
+      ctx: Ctx;
+      constructor(c: Ctx) {
+        this.ctx = c;
+      }
+    } as never,
+  );
+  return new Client(ctx) as InstanceType<typeof Client> & { ctx: Ctx };
+}
+
+function context(overrides: Partial<Ctx> = {}): Ctx {
+  return {
+    cp: { baseUrl: "https://example.test", token: "token" },
+    activeLogins: new Set<string>(),
+    // Re-derivation must NOT be consulted when a pin exists.
+    providerEngine: () => {
+      throw new Error("re-derived routing instead of using the pin");
+    },
+    providerEngineFor: (id: string) => mocks.runtimeClientFor(undefined, id),
+    providerAgentId: () => null,
+    ...overrides,
+  };
+}
+
+test("pinnedLoginAgentId: no in-flight login → undefined", () => {
+  expect(
+    pinnedLoginAgentId(context() as never, "openai-codex"),
+  ).toBeUndefined();
+});
+
+test("pinnedLoginAgentId: setup-runtime login → null", () => {
+  const ctx = context();
+  ctx.activeLogins.add(loginKey(null, "openai-codex"));
+  expect(pinnedLoginAgentId(ctx as never, "openai-codex")).toBeNull();
+});
+
+test("pinnedLoginAgentId: agent login → the agent id", () => {
+  const ctx = context();
+  ctx.activeLogins.add(loginKey("agent-1", "openai-codex"));
+  expect(pinnedLoginAgentId(ctx as never, "openai-codex")).toBe("agent-1");
+});
+
+test("pinnedLoginAgentId: newest of concurrent logins wins", () => {
+  const ctx = context();
+  ctx.activeLogins.add(loginKey(null, "openai-codex"));
+  ctx.activeLogins.add(loginKey("agent-1", "openai-codex"));
+  expect(pinnedLoginAgentId(ctx as never, "openai-codex")).toBe("agent-1");
+});
+
+test("pinnedLoginAgentId: a dash-suffixed provider never cross-matches", () => {
+  const ctx = context();
+  ctx.activeLogins.add(loginKey("agent-1", "openai-codex"));
+  expect(pinnedLoginAgentId(ctx as never, "codex")).toBeUndefined();
+});
+
+test("submit routes to the setup runtime the login started in, even after an agent appears", async () => {
+  const ctx = context({
+    // The first agent materialized mid-login: live derivation now names it.
+    providerAgentId: () => "agent-1",
+  });
+  ctx.activeLogins.add(loginKey(null, "openai-codex"));
+
+  await makeClient(ctx).submitProviderLoginCode("openai", "code=abc&state=xyz");
+
+  expect(mocks.setupComplete).toHaveBeenCalledWith(
+    "openai-codex",
+    "code=abc&state=xyz",
+  );
+  expect(mocks.agentComplete).not.toHaveBeenCalled();
+});
+
+test("submit routes to the pinned agent runtime when the login started there", async () => {
+  const ctx = context();
+  ctx.activeLogins.add(loginKey("agent-1", "openai-codex"));
+
+  await makeClient(ctx).submitProviderLoginCode("openai", "code=abc");
+
+  expect(mocks.runtimeClientFor).toHaveBeenCalledWith(ctx.cp, "agent-1");
+  expect(mocks.setupComplete).not.toHaveBeenCalled();
+});
+
+test("cancel tears down the pinned setup login, not the re-derived agent", async () => {
+  const ctx = context({ providerAgentId: () => "agent-1" });
+  const key = loginKey(null, "openai-codex");
+  ctx.activeLogins.add(key);
+
+  await makeClient(ctx).cancelProviderLogin("openai");
+
+  expect(ctx.activeLogins.has(key)).toBe(false);
+  expect(mocks.setupCancel).toHaveBeenCalledWith("openai-codex");
+  expect(mocks.agentCancel).not.toHaveBeenCalled();
+});

--- a/ui/agent/src/inline-rename.tsx
+++ b/ui/agent/src/inline-rename.tsx
@@ -29,7 +29,12 @@ export function useInlineRename(
     setRenaming(true);
     requestAnimationFrame(() => {
       const input = inputRef.current;
-      if (!input) return;
+      // Focus can beat this frame: a fast user (or an automated fill, which
+      // focuses in one task and inserts text in the next) may already be
+      // mid-edit, and re-selecting the basename now would make their next
+      // keystroke replace part of what they typed (the e2e-caught
+      // "Q3 final.pdf.pdf" corruption). First-focus only.
+      if (!input || document.activeElement === input) return;
       input.focus();
       const dot = name.lastIndexOf(".");
       input.setSelectionRange(0, dot > 0 ? dot : name.length);


### PR DESCRIPTION
Fixes HOU-1113.

## Root cause

Users connecting ChatGPT in managed cloud hit a dead-end toast: `engine request failed (400): {"error":"no active login for openai-codex"}` (Sentry issue 7625496858 — 22 users since July 21; the reporting user retried 5 times in 12 minutes and failed every time).

The desktop relays the OAuth callback code to the engine, whose login state lives in the runtime process's memory (`packages/runtime/src/auth/login.ts`, keyed `active` map). Two defects turned any mid-login disruption into that dead end:

1. **Routing re-derivation (deterministic bug).** `submitProviderLoginCode` / `cancelProviderLogin` picked their target runtime at call time via `providerAgentId()`. During first-run onboarding the login starts in the hidden **setup runtime** — and the moment the first agent materializes (which also tears the setup pod down), `providerAgentId()` starts answering the agent's pod. The relayed code then landed on a runtime that never saw the login.

2. **No recovery from genuinely lost state.** The Sentry breadcrumbs show gateway 503 bursts mid-consent — the setup pod recycled while the user sat on OpenAI's consent screen. The fresh process has an empty login map, and the client had no recovery: raw 400 JSON toast, dead end.

Bonus defect: cancelling a sign-in left the desktop loopback listener armed for its full 5-minute window, so approving the abandoned browser tab later fired a doomed relay and a spurious error toast.

## Fix

- **Pin login routing** (`packages/web/src/engine-adapter/client/`): submit and cancel now route by the pin the connect poll registered when the login *started* (`activeLogins` key: agent id or setup sentinel), falling back to live derivation only when no pin exists. New helper `pinnedLoginAgentId`.
- **Auto-restart recovery** (`app/src/lib/codex-relay-recovery.ts`, wired in `codex-loopback.ts`): a relay submit that fails with `no active login` restarts the same browser sign-in once per 5-minute cooldown, with no error toast. OpenAI redirects an already-consented app straight through, so the retried flow usually completes with zero extra clicks. A restart that can't run (or a second loss inside the window) surfaces the localized failure toast + Sentry report (no-silent-failures policy preserved via the `surface: false` retry contract in `tauri.ts`).
- **Cancel teardown**: `cancelLogin` now tears down the armed loopback listener (`cancelCodexLoopback`), so a late browser approval can't relay into a killed login.

The pod-recycle trigger itself is cloud-infra (why the setup pod churns mid-login) and worth a separate look in the cloud repo; this PR makes the client survive it either way.

## Tests

- `packages/web/tests/provider-login-pinning.test.ts` (vitest, 8 tests): pin resolution incl. the mid-login agent-materialization case; submit/cancel routing to the pinned runtime.
- `app/tests/codex-relay-recovery.test.ts` (node:test, 7 tests): lost-login detection, restart-once policy, cooldown, dead-end sequencing.
- Full suites green: `packages/web` vitest (60 files), `app` node:test (64 files, 368 tests), `pnpm -r typecheck`, `pnpm check` (Biome).

## Repro (before the fix)

1. On a managed-cloud desktop build, start onboarding and click **Connect ChatGPT** (browser opens via the loopback relay).
2. While on OpenAI's consent screen, have the engine pod serving the login recycle (in dev: restart the host pane; in cloud this is the observed 503 burst) — or have the first agent finish creating so provider routing flips off the setup runtime.
3. Approve in the browser → red toast `engine request failed (400): {"error":"no active login for openai-codex"}`, provider stays disconnected. Retries repeat the failure.

## Verify (after the fix)

1. Same setup; flip routing mid-login (create the first agent while the consent screen is open) → the approved code lands on the setup runtime and the connect completes.
2. Same setup; restart the engine mid-consent, then approve → no error toast; a new browser tab opens, auto-redirects, and the connect completes.
3. Cancel a ChatGPT sign-in in-app, then approve the leftover browser tab → no toast, no relay.
4. Unit: `cd app && pnpm test` and `cd packages/web && npx vitest run tests/provider-login-pinning.test.ts`.

## Rebased on main (2026-08-04)

Rebased over the merged auth/provider work; re-verified all gates on top (app node:test 2691 ✓ · web vitest 340 ✓ · app/web tsgo ✓ · biome ✓). How the new mainline changes relate:

- **#1224 (HOU-1156, provider-error classification + Sentry fingerprinting)**: no interaction. `no active login for openai-codex` is a host *login-route* 400, not a turn-time `ProviderError`, so it never enters the classifier; this PR's relay recovery keys on that message with its own Sentry source (`codex_loopback_relay`).
- **#1226 (HOU-1153, `transientRetryFetch` on the setup/agent runtime clients)**: complementary, not overlapping. That wrapper retries **GET/HEAD only**, so it makes the *status reads* survive a waking setup pod; the login **submit** (`completeLogin`, POST) is exempt from it by design and still dead-ended on lost state — which is exactly what this PR's pinned routing + one-shot restart recover.
- **#1228 (HOU-1112, Microsoft GCIP loopback)**: separate identity sign-in path (`app/src/lib/identity/`); no shared code with the Codex provider relay.


## CI flake fixed at the root (run 30909129039)

Shard 3 failed on `files.spec.ts › renames and deletes a file from the context menu` — unrelated to this PR's auth changes, but a real race, so it's fixed here rather than rerolled: the inline-rename field selects its basename one rAF after mounting, and when focus beats that frame (a fast typist, or Playwright's two-task fill: focus, then insert), the late selection makes the insertion replace only the basename — the file genuinely became `Q3 final.pdf.pdf`, and the spec's substring matchers let it slide to the trash-dialog assertion. `useInlineRename` now skips the select when the input is already focused, and the spec asserts the filled value before committing (exact-match on the renamed entry), so any regression fails at the fill. Full `files.spec.ts` (34 tests) green locally.
