### PR TITLE
fix(runtime): map + classify the live unknown provider-error families (HOU-1156)

### DIFF
--- a/app/src/components/shell/provider-error-cards/terminal.tsx
+++ b/app/src/components/shell/provider-error-cards/terminal.tsx
@@ -74,12 +74,28 @@ export function UnknownErrorCard({
 }) {
   const { t } = useTranslation("shell");
   const provider = providerLabel(error.provider);
+  const raw = error.raw_excerpt.trim();
   return (
     <div className="w-full px-1 py-2">
       <RowCard
         media={<CloudOffIcon className="size-5" />}
         title={t("providerError.unknown.title")}
-        description={t("providerError.unknown.body", { provider })}
+        description={
+          // The provider's verbatim text rides under the body: for an
+          // unclassified failure it is the ONLY identifying detail the user
+          // (and our bug reports) have — Anthropic's "accept the new terms in
+          // claude.ai" arrives exactly here (HOU-1156).
+          raw ? (
+            <>
+              {t("providerError.unknown.body", { provider })}
+              <span className="mt-1 block font-mono text-[10px] text-ink/50 [overflow-wrap:anywhere]">
+                {t("providerError.unknown.rawLabel")}: {raw}
+              </span>
+            </>
+          ) : (
+            t("providerError.unknown.body", { provider })
+          )
+        }
         action={
           <ReportBugButton
             command={`provider_error:unknown:${error.provider}`}

--- a/knowledge-base/provider-errors.md
+++ b/knowledge-base/provider-errors.md
@@ -16,6 +16,46 @@
 Skim the table of contents and load the section that
 touches what you are doing.
 
+## Current map (TS engine) — where every error card comes from
+
+The full audit behind this section is HOU-1156 (2026-08). Eight wire kinds
+(`packages/protocol/src/provider-error.ts`): `unauthenticated`, `rate_limited`,
+`quota_exhausted`, `model_unavailable`, `context_overflow`, `provider_internal`,
+`network_unreachable`, `unknown`. The frontend union (`ui/chat/src/types.ts`)
+additionally still declares the Rust-era kinds `usage_limit_paused`,
+`session_resume_missing`, `malformed_response`, `spawn_failed`, `cancelled` —
+no TS backend emits them; their cards are dormant.
+
+**Entry points → classifier:**
+
+| Path | Where | Notes |
+|------|-------|-------|
+| pi backend (all non-Anthropic-SDK providers) | `packages/runtime/src/backends/pi/wire.ts` (`turn_end`, `stopReason:"error"`) | status read from pi diagnostics, else parsed from the message. Held until `agent_settled`; discarded if pi recovers (HOU-1057). |
+| Claude Agent SDK backend | `packages/runtime/src/backends/claude/translate.ts` → `errors.ts` (`mapSdkError`: SDK enum table, falls through to `classifyText`) | one card per turn (`emittedError` latch); dangling resume auto-retries fresh (HOU-892). |
+| Thrown turn failures | `packages/runtime/src/session/exec-turn.ts` catch, `packages/runtime/src/turn/turn-session.ts` catch | pi raises missing credentials at prompt time — this catch is where they become the reconnect card (HOU-718). |
+| Pre-session guards | `packages/runtime/src/session/chat.ts` (`getConversation` catch + serve-mode pin guard) | synthesized, not classified; typed card persisted, but the LIVE frame is still a generic `error` frame. |
+
+**Classifier:** `packages/runtime/src/ai/provider-error.ts` — pure, every branch
+unit-tested against verbatim provider strings (`provider-error.test.ts`).
+Precedence: auth → quota/billing (before rate-limit: both ride 429, HOU-1154) →
+rate-limit → context overflow → 5xx → network → model-unavailable → `unknown`
+(which keeps a **300-char** `raw_excerpt` — the UnknownErrorCard renders it, so
+an unclassified card is never content-free).
+
+**The triage loop (how WE find out):** every classified failure logs exactly
+once through `packages/runtime/src/ai/provider-error-log.ts` — expected kinds
+(rate limit, quota, 5xx, network, overflow, model-unavailable, and
+`unauthenticated`/`no_credentials`) at WARN (Sentry breadcrumb), everything
+else — `unknown` and real auth failures — at ERROR (Sentry event). The Sentry
+client fingerprints `[provider_error]` lines by `(provider, kind)`
+(`packages/runtime-client/src/sentry/client.ts`), so each family is its own
+countable issue. The ritual: search Sentry for `kind=unknown`, and promote any
+family that repeats into a classifier pattern (verbatim fixture first — see the
+HOU-1156 batch: Codex `WebSocket closed 1006` → network, OpenRouter
+`Stream ended without finish_reason` → provider_internal, Gemini gRPC
+`UNAVAILABLE`/embedded `"code": 5xx` → provider_internal, Google billing
+`dunning` → quota, opencode `RegionError` → model_unavailable).
+
 ## TL;DR
 
 Every AI provider's CLI failure collapses into one variant of the
@@ -49,7 +89,7 @@ now removed.)
 | `MalformedResponse`        | CLI emitted unparseable JSON mid-stream.                                                 | Retry.                                               |
 | `SpawnFailed`              | CLI couldn't even spawn (binary missing, killed by OS).                                  | Report bug.                                          |
 | `Cancelled`                | User pressed Stop. Distinct so the UI shows nothing (no toast, no retry).                | none (rendered as `null`).                           |
-| `Unknown`                  | No classifier matched. Carries `raw_excerpt` (≤500 chars).                              | Report bug.                                          |
+| `Unknown`                  | No classifier matched. Carries `raw_excerpt` (≤300 chars), rendered on the card (HOU-1156). | Report bug.                                      |
 
 ### `credential` — WHOSE account failed (HOU-976)
 

--- a/packages/runtime-client/src/sentry/client.test.ts
+++ b/packages/runtime-client/src/sentry/client.test.ts
@@ -104,6 +104,27 @@ describe("createEngineSentry", () => {
     expect(frames[frames.length - 1]?.filename).toMatch(/client\.test\.ts$/);
   });
 
+  it("captureLog: [provider_error] lines fingerprint by (provider, kind)", async () => {
+    // Without this, every provider_error line groups on the identical
+    // synthetic thread stack at the log helper and Sentry shows ONE issue for
+    // every family (HOU-1156).
+    const { sentry, events } = testSentry();
+    sentry.captureLog("ERROR", [
+      "[provider_error] provider=openai-codex model=gpt-5.5 status=? kind=unknown :: WebSocket closed 1006",
+    ]);
+    sentry.captureLog("ERROR", ["a non-provider failure"]);
+    await sentry.flush();
+
+    expect(events).toHaveLength(2);
+    expect(events[0]?.fingerprint).toEqual([
+      "provider_error",
+      "openai-codex",
+      "unknown",
+    ]);
+    // Everything else keeps default grouping.
+    expect(events[1]?.fingerprint).toBeUndefined();
+  });
+
   it("captureLog: Node process warnings via console.error stay breadcrumbs", async () => {
     const { sentry, events } = testSentry();
     sentry.captureLog("ERROR", [

--- a/packages/runtime-client/src/sentry/client.ts
+++ b/packages/runtime-client/src/sentry/client.ts
@@ -68,6 +68,21 @@ function redactCredentials(message: string): string {
 const NODE_PROCESS_WARNING = /^\(node:\d+\)/;
 
 /**
+ * The stable line `logProviderError` (runtime `ai/provider-error-log.ts`)
+ * emits for every classified provider failure. Provider and kind are enough to
+ * name a family; anything finer (model, the verbatim text) is unbounded
+ * cardinality and stays in the message.
+ */
+const PROVIDER_ERROR_LINE = /^\[provider_error\] provider=(\S+) .*?kind=(\S+)/;
+
+function providerErrorFingerprint(
+  message: string,
+): { fingerprint: string[] } | null {
+  const m = PROVIDER_ERROR_LINE.exec(message);
+  return m ? { fingerprint: ["provider_error", m[1] ?? "", m[2] ?? ""] } : null;
+}
+
+/**
  * Plain fetch transport — the one path that works identically on Node 22
  * (pods, self-host, dev) and inside the Bun-compiled sidecar. The heavier
  * `@sentry/node` SDK is deliberately NOT used: its OpenTelemetry require-hooks
@@ -216,6 +231,14 @@ export function createEngineSentry(
             scope.captureEvent({
               message,
               level: "error",
+              // Grouping: bare-string events would otherwise group on the
+              // synthetic thread stack, which is identical for every line a
+              // shared log helper emits — 90 days of `[provider_error]` lines
+              // (Codex WebSocket drops, Gemini 503s, billing denials, …)
+              // collapsed into ONE Sentry issue titled by whichever message
+              // came first (HOU-1156). Fingerprint those lines by
+              // (provider, kind) so each family is its own countable issue.
+              ...(providerErrorFingerprint(message) ?? {}),
               threads: {
                 values: [
                   {

--- a/packages/runtime/src/ai/provider-error-log.ts
+++ b/packages/runtime/src/ai/provider-error-log.ts
@@ -42,6 +42,14 @@ export function logProviderError(
     `[provider_error] provider=${error.provider} model=${ctx.model ?? "?"} ` +
     `status=${ctx.status ?? "?"}${ctx.sdkError ? ` error=${ctx.sdkError}` : ""} ` +
     `kind=${error.kind} :: ${verbatim}`;
-  if (EXPECTED_KINDS.has(error.kind)) console.warn(line);
+  // `no_credentials` is the one auth cause that is an expected USER state, not
+  // broken custody: the provider was simply never connected (or the user
+  // logged out with it still selected). It became loggable when the
+  // pre-session guards started reporting (HOU-1156) — keep it a warning or
+  // every fresh install fires Sentry errors.
+  const expected =
+    EXPECTED_KINDS.has(error.kind) ||
+    (error.kind === "unauthenticated" && error.cause === "no_credentials");
+  if (expected) console.warn(line);
   else console.error(line);
 }

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -744,3 +744,100 @@ test("overflow text without numbers still classifies, with null token counts", (
     expect(err.prompt_tokens).toBeNull();
   }
 });
+
+// HOU-1156: verbatim shapes of the `unknown` families the 90-day Sentry audit
+// surfaced — each was rendering the content-free "Something unexpected
+// happened" card. Fixtures mirror the real payloads (identifiers synthetic).
+
+test("Codex 'WebSocket closed 1006' → network_unreachable, not unknown (HOU-1156)", () => {
+  // pi-ai flattens an abnormal mid-turn drop of Codex's WebSocket to this
+  // exact string — no status, no body. 584 events / 137 users in 90 days.
+  const err = classifyProviderError({
+    provider: "openai-codex",
+    model: "gpt-5.5",
+    message: "WebSocket closed 1006",
+  });
+  expect(err).toEqual({
+    kind: "network_unreachable",
+    provider: "openai-codex",
+    message: "WebSocket closed 1006",
+  });
+});
+
+test("openrouter 'Stream ended without finish_reason' → provider_internal (HOU-1156)", () => {
+  const err = classifyProviderError({
+    provider: "openrouter",
+    model: "openrouter/free",
+    message: "Stream ended without finish_reason",
+  });
+  expect(err.kind).toBe("provider_internal");
+});
+
+test("Google gRPC UNAVAILABLE overload → provider_internal with the embedded 503 (HOU-1156)", () => {
+  const err = classifyProviderError({
+    provider: "google",
+    model: "gemini-3.5-flash",
+    message:
+      'got status: UNAVAILABLE. {"error":{"code":503,"message":"This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.","status":"UNAVAILABLE"}}',
+  });
+  expect(err.kind).toBe("provider_internal");
+  if (err.kind === "provider_internal") expect(err.http_status).toBe(503);
+});
+
+test("Google double-encoded 429 body → rate_limited via the embedded code (HOU-1156)", () => {
+  // The status lives ONLY inside the escaped inner JSON: `\"code\": 429`.
+  const err = classifyProviderError({
+    provider: "google",
+    model: "gemini-3-flash-preview",
+    message:
+      '{"error":{"message":"{\\n  \\"error\\": {\\n    \\"code\\": 429,\\n    \\"message\\": \\"Resource has been exhausted (e.g. check quota).\\",\\n    \\"status\\": \\"RESOURCE_EXHAUSTED\\"\\n  }\\n}"}}',
+  });
+  expect(err.kind).toBe("rate_limited");
+});
+
+test("Google billing dunning denial → quota_exhausted, not unknown (HOU-1156)", () => {
+  // 403 whose body names a billing-delinquency ("dunning") decision: paying,
+  // not reconnecting, is the fix.
+  const err = classifyProviderError({
+    provider: "google",
+    model: "gemini-3.5-flash",
+    message:
+      '{"error":{"message":"{\\n  \\"error\\": {\\n    \\"code\\": 403,\\n    \\"message\\": \\"Lightning dunning decision is deny for project: projects/000000000000\\",\\n    \\"status\\": \\"PERMISSION_DENIED\\"\\n  }\\n}"}}',
+  });
+  expect(err.kind).toBe("quota_exhausted");
+});
+
+test("opencode RegionError → model_unavailable / region_restricted (HOU-1156)", () => {
+  // The credential is fine and nothing resets: only the MODEL needs a region
+  // opt-in, so the switch-model card is the honest surface.
+  const err = classifyProviderError({
+    provider: "opencode-go",
+    model: "deepseek-v4-flash",
+    message:
+      '403: {"type":"RegionError","message":"The latest version of this model is only available hosted in China and requires explicit opt in: https://opencode.ai/workspace"}',
+  });
+  expect(err.kind).toBe("model_unavailable");
+  if (err.kind === "model_unavailable")
+    expect(err.reason).toBe("region_restricted");
+});
+
+test("embedded code extraction stays out of 1xx-3xx (HOU-1156)", () => {
+  // A stray non-HTTP application code must never veto the auth branch.
+  expect(extractHttpStatus('{"code": 200, "message": "ok-ish"}')).toBeNull();
+  expect(extractHttpStatus('{"error":{"code":503}}')).toBe(503);
+  expect(extractHttpStatus('{"code": "invalid_api_key"}')).toBeNull();
+});
+
+test("Anthropic consumer-terms 400 stays unknown with the actionable excerpt (HOU-1156)", () => {
+  // No taxonomy kind fits (nothing to retry, reconnect, or pay for) — the
+  // provider's own sentence IS the remedy, and the unknown card now shows it.
+  const message =
+    "API Error: 400 We've updated our Consumer Terms and Privacy Policy. You'll need to accept them in claude.ai with the email in /status to continue.";
+  const err = classifyProviderError({
+    provider: "anthropic",
+    model: null,
+    message,
+  });
+  expect(err.kind).toBe("unknown");
+  if (err.kind === "unknown") expect(err.raw_excerpt).toBe(message);
+});

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -118,6 +118,12 @@ const MODEL_UNAVAILABLE_PATTERNS = [
   // for integrator "vscode-chat". Available models: […]` — same plan-doesn't-
   // serve-this-model failure as its older `model_not_supported` code (HOU-977).
   "requested model is not available",
+  // opencode.ai's region gate: 403 `{"type":"RegionError","message":"The
+  // latest version of this model is only available hosted in China and
+  // requires explicit opt in: <url>"}` — the credential is fine; the MODEL
+  // needs a region opt-in, so the switch-model card is the honest one
+  // (HOU-1156). The type name carries the `region_restricted` reason.
+  "regionerror",
 ];
 
 /**
@@ -155,6 +161,10 @@ const INSUFFICIENT_BALANCE_PATTERNS = [
   "out of credits",
   // NVIDIA NIM: "Cloud credits expired - Please contact NVIDIA representatives".
   "credits expired",
+  // Google Cloud's billing-delinquency denial: 403 `"Lightning dunning
+  // decision is deny for project: projects/…"` — the project's billing is past
+  // due, so paying (not reconnecting) is the fix (HOU-1156).
+  "dunning decision is deny",
 ];
 
 /**
@@ -312,7 +322,7 @@ function classify(input: ProviderErrorInput): ProviderError {
       kind: "model_unavailable",
       provider,
       model,
-      reason: "unknown",
+      reason: modelUnavailableReason(lower),
       // Offer a concrete switch target only when we know one AND it isn't the
       // failing model itself (a base Copilot model never reports unavailable).
       suggested_fallback:
@@ -408,7 +418,19 @@ function isServerError(lower: string, status: number | null): boolean {
     // Deliberately NOT a bare `finish_reason:` match: `content_filter` (a
     // policy refusal, not an outage) must keep falling through to `unknown`.
     lower.includes("finish_reason: error") ||
-    lower.includes("finish_reason: network_error")
+    lower.includes("finish_reason: network_error") ||
+    // OpenRouter when the upstream closes the stream without ever sending a
+    // finish_reason — the same mid-generation upstream death as
+    // `finish_reason: error` above (HOU-930 family), flattened by pi-ai with
+    // no status and no body (HOU-1156).
+    lower.includes("stream ended without finish_reason") ||
+    // Google (Gemini) overload arrives as a gRPC-style prefix with the real
+    // status buried in nested JSON: `got status: UNAVAILABLE. {"error":
+    // {"code":503,"message":"This model is currently experiencing high
+    // demand …"}}`. The embedded `"code"` extractor usually recovers the 503;
+    // these keep the verdict when the body is truncated (HOU-1156).
+    lower.includes("got status: unavailable") ||
+    lower.includes("experiencing high demand")
   );
 }
 
@@ -421,6 +443,12 @@ function isNetwork(lower: string): boolean {
     lower.includes("etimedout") ||
     lower.includes("eai_again") ||
     lower.includes("socket hang up") ||
+    // Codex rides a WebSocket to the ChatGPT backend; pi-ai flattens an
+    // abnormal mid-turn drop to `WebSocket closed 1006` — no close frame, the
+    // transport died (sleep, flaky Wi-Fi, a server-side hang-up). Transient;
+    // retry helps. This was the single largest unclassified card in
+    // production (HOU-1156: 584 events / 137 users in 90 days).
+    lower.includes("websocket closed") ||
     lower.includes("network error") ||
     lower.includes("connection refused") ||
     lower.includes("connection reset")
@@ -429,6 +457,19 @@ function isNetwork(lower: string): boolean {
 
 function isModelUnavailable(lower: string): boolean {
   return MODEL_UNAVAILABLE_PATTERNS.some((p) => lower.includes(p));
+}
+
+/**
+ * The card copy keys off the message either way; the tag exists for the
+ * frontend union. Only region gating is identifiable from real payloads today
+ * (opencode.ai's RegionError / "hosted in China" opt-in body).
+ */
+function modelUnavailableReason(
+  lower: string,
+): "region_restricted" | "unknown" {
+  return lower.includes("regionerror") || lower.includes("hosted in china")
+    ? "region_restricted"
+    : "unknown";
 }
 
 function isContextOverflow(message: string): boolean {
@@ -498,6 +539,14 @@ export function extractHttpStatus(message: string): number | null {
     const n = Number(labelled[1]);
     if (n >= 100 && n <= 599) return n;
   }
+  // Some providers carry the status ONLY as a JSON `"code"` field — Google's
+  // nested `{"error":{"code":503,…}}`, often double-encoded so the quote
+  // arrives escaped (`\"code\": 503`). Last resort, and restricted to 4xx/5xx:
+  // a 3-digit `"code"` in that range is an HTTP status in every payload we
+  // have seen, while accepting 1xx–3xx would let a stray application code veto
+  // the auth branch's known-non-auth-status check (HOU-1156).
+  const embedded = message.match(/"code"\s*:\s*"?([45]\d{2})\b/);
+  if (embedded) return Number(embedded[1]);
   return null;
 }
 

--- a/packages/runtime/src/session/chat.ts
+++ b/packages/runtime/src/session/chat.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import type { TurnMode } from "@houston/protocol";
 import type { ChatMessage } from "@houston/runtime-client";
 import { stampCredentialScope } from "../ai/provider-error";
+import { logProviderError } from "../ai/provider-error-log";
 import {
   activeProvider,
   canonicalPinProvider,
@@ -176,24 +177,25 @@ export async function runTurn(
     // cannot say WHOSE account is not connected: in a team space every turn
     // runs on the acting member's own AI account (HOU-976). A no-op without an
     // acting identity, so the desktop wire shape is unchanged.
-    appendAssistantMessage(id, "", {
-      providerError: stampCredentialScope(
-        notConnected
-          ? {
-              kind: "unauthenticated",
-              provider: pin?.provider ?? "",
-              cause: "no_credentials",
-              message,
-              undelivered_prompt: text,
-            }
-          : {
-              kind: "unknown",
-              provider: pin?.provider ?? "unknown",
-              raw_excerpt: message,
-            },
-      ),
-      turnId,
-    });
+    const synthesized = stampCredentialScope(
+      notConnected
+        ? {
+            kind: "unauthenticated",
+            provider: pin?.provider ?? "",
+            cause: "no_credentials",
+            message,
+            undelivered_prompt: text,
+          }
+        : {
+            kind: "unknown",
+            provider: pin?.provider ?? "unknown",
+            raw_excerpt: message,
+          },
+    );
+    // Synthesized outside the classifier = outside its log site too; without
+    // this, a pre-session failure was a card we never heard about (HOU-1156).
+    logProviderError(synthesized, { model: pin?.model ?? null });
+    appendAssistantMessage(id, "", { providerError: synthesized, turnId });
     publish(id, { type: "error", data: { message }, turnId });
     return;
   }

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -13,6 +13,7 @@ import {
   OPENAI_COMPATIBLE,
 } from "../ai/openai-compatible";
 import { classifyProviderError } from "../ai/provider-error";
+import { logProviderError } from "../ai/provider-error-log";
 import {
   activeEffort,
   canonicalPinProvider,
@@ -570,6 +571,11 @@ export async function execTurn(
         model: pin?.model ?? null,
         message: errMessage(err),
       });
+    // The streamed path logged when it classified; a THROWN failure only
+    // becomes visible to Sentry if this catch logs it too — before this,
+    // every thrown `unknown` was a card in a user's chat that we never heard
+    // about (HOU-1156).
+    if (!providerError) logProviderError(thrown, { model: pin?.model ?? null });
     // An auth throw with NOTHING streamed = pi's prompt-time credential guard,
     // which raises BEFORE recording the user message in pi's session store —
     // neither the live context nor a rebuild will ever see it. Carry the text

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -13,6 +13,7 @@ import type {
 import { DEFAULT_REASONING_EFFORT, toThinkingLevel } from "../ai/effort";
 import { registerCustomProviderIfConfigured } from "../ai/openai-compatible";
 import { classifyProviderError } from "../ai/provider-error";
+import { logProviderError } from "../ai/provider-error-log";
 import { clearAuthFailure, noteAuthFailure } from "../auth/credential-health";
 import { reportRevokedServedToken } from "../auth/report-revoked";
 import { createPiBackend } from "../backends/pi/backend";
@@ -339,6 +340,10 @@ export async function runPiTurn(
         model: pin?.model ?? null,
         message,
       });
+      // The streamed path logged when it classified; a THROWN failure is
+      // invisible to Sentry unless this catch logs it too (HOU-1156;
+      // mirrors exec-turn).
+      logProviderError(thrown, { model: pin?.model ?? null });
       // Prompt-time credential guard: pi raised BEFORE recording the user
       // message in its session store, so the reconnect retry must re-deliver
       // the text (mirrors exec-turn).


### PR DESCRIPTION
## HOU-1156

The issue asked for a map of the errors we show and a guarantee that they are clear for users and, most importantly, for ourselves. A 90-day Sentry audit (searching `kind=unknown` over the `[provider_error]` log lines) found two structural problems and a short list of live unclassified families.

### Root causes

1. **Users saw nothing identifying.** The `unknown` card said only "Something unexpected happened" — `raw_excerpt` was carried on the wire, bundled into bug reports, and displayed nowhere. (The `providerError.unknown.rawLabel` i18n key existed in en/es/pt but was referenced by zero code.)
2. **We saw almost nothing either.** Bare-string Sentry events group on the synthetic thread stack at the log helper, which is identical for every line `logProviderError` emits — so 90 days of Codex WebSocket drops, Gemini 503s, billing denials, and auth failures collapsed into ONE Sentry issue titled by whichever message came first. On top of that, thrown (non-streamed) failures never called `logProviderError` at all: every thrown `unknown` was a card in a user's chat we never heard about.

### Live unknown families found and classified

| Family | Volume (90d) | Now |
|---|---|---|
| openai-codex `WebSocket closed 1006` | 584 ev / 137 users | `network_unreachable` (retry + status page) |
| Gemini gRPC `got status: UNAVAILABLE` / high demand | recurring | `provider_internal` with the embedded 503 |
| openrouter `Stream ended without finish_reason` | recurring | `provider_internal` (HOU-930 family) |
| Google `Lightning dunning decision is deny` (billing) | low | `quota_exhausted` |
| opencode `RegionError` (China opt-in) | low | `model_unavailable` / `region_restricted` |
| Anthropic 400 consumer-terms / document-removed | low | stays `unknown`, but the card now shows the provider's own actionable sentence |

(`No conversation found with session ID` was already fixed by #1094; residual events are from pre-update clients.)

### Changes

- **`packages/runtime/src/ai/provider-error.ts`** — new narrow patterns (each tied to a verbatim payload in the tests) + a last-resort embedded-JSON `"code": 4xx/5xx` status extractor (Google nests the real status inside double-encoded JSON; restricted to 4xx/5xx so a stray application code can never veto the auth branch).
- **`app/.../provider-error-cards/terminal.tsx`** — `UnknownErrorCard` renders `raw_excerpt` under the body (muted mono line, existing `rawLabel` key). An unclassified card is never content-free again.
- **`packages/runtime-client/src/sentry/client.ts`** — `[provider_error]` lines fingerprint by `(provider, kind)`: one countable Sentry issue per family.
- **`exec-turn.ts` / `turn-session.ts` / `chat.ts`** — thrown and synthesized classifications now log through `logProviderError`. `unauthenticated/no_credentials` demoted to the expected (WARN/breadcrumb) tier so never-connected fresh installs don't fire Sentry errors.
- **`knowledge-base/provider-errors.md`** — new "Current map (TS engine)" section: entry points → classifier, the Sentry triage loop, and the promote-repeat-unknowns ritual; corrected the excerpt length (300, not 500).

### Verify — before

1. Disconnect Wi-Fi mid-turn on a Codex (OpenAI) chat, or replay a turn whose `AssistantMessage.errorMessage` is `WebSocket closed 1006`: the chat shows "Something unexpected happened … Report bug" with no detail.
2. In Sentry, search `[provider_error]` issues: one issue contains every family.

### Verify — after

1. Same repro: the chat shows "Cannot reach OpenAI — check your internet, then try again" with Retry + status page. Unit: `pnpm --filter @houston/runtime test` → `provider-error.test.ts` HOU-1156 fixtures.
2. Any surviving `unknown` card shows "Raw output: <provider text>" under the body.
3. New Sentry events carry `fingerprint: [provider_error, <provider>, <kind>]` — one issue per family (`client.test.ts`).

### Gates

runtime 964 ✓ · runtime-client 150 ✓ · app unit 2615 ✓ · app/web tsgo ✓ · check-locales ✓ · biome ✓ · boundaries ✓