### PR TITLE
fix(app,host): validate agent names before submit instead of surfacing raw errors (HOU-1166)

### DIFF
--- a/app/src/components/portable/import-wizard.tsx
+++ b/app/src/components/portable/import-wizard.tsx
@@ -38,6 +38,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DEFAULT_TAB_ID } from "../../agents/standard-tabs";
 import { useProviderStatuses } from "../../hooks/use-provider-statuses";
+import { AGENT_NAME_MAX_LENGTH, agentNameIssue } from "../../lib/agent-name";
 import { finishAgentSetup } from "../../lib/agent-setup";
 import { startAgentSetupMission } from "../../lib/agent-setup-mission";
 import { analytics } from "../../lib/analytics";
@@ -63,11 +64,12 @@ interface Selection {
 }
 
 export function ImportAgentWizard() {
-  const { t } = useTranslation("portable");
+  const { t } = useTranslation(["portable", "agents"]);
   const open = useUIStore((s) => s.importFromFriendOpen);
   const setOpen = useUIStore((s) => s.setImportFromFriendOpen);
   const addToast = useUIStore((s) => s.addToast);
   const currentWorkspace = useWorkspaceStore((s) => s.current);
+  const existingAgents = useAgentStore((s) => s.agents);
   const adoptAgent = useAgentStore((s) => s.adopt);
 
   const [stepIndex, setStepIndex] = useState(0);
@@ -234,6 +236,24 @@ export function ImportAgentWizard() {
     if (!uploaded || !currentWorkspace) return;
     if (!name.trim()) {
       addToast({ variant: "error", title: t("import.errors.nameRequired") });
+      return;
+    }
+    // Same pre-submit rule as the create dialog (HOU-1166): reject bad shapes
+    // and duplicates with friendly copy before the install round-trip.
+    const issue = agentNameIssue(
+      name,
+      existingAgents.map((a) => a.name),
+    );
+    if (issue) {
+      addToast({
+        variant: "error",
+        title:
+          issue === "taken"
+            ? t("agents:toasts.nameConflict", { name: name.trim() })
+            : issue === "tooLong"
+              ? t("agents:nameErrors.tooLong", { max: AGENT_NAME_MAX_LENGTH })
+              : t("agents:nameErrors.invalidChars"),
+      });
       return;
     }
     const resolved = pickDefaultProviderModel({

--- a/app/src/components/shell/ai-review-step.tsx
+++ b/app/src/components/shell/ai-review-step.tsx
@@ -23,6 +23,8 @@ interface AiReviewStepProps {
   onSubmit: () => void;
   creating: boolean;
   error: string | null;
+  /** The typed name fails pre-submit validation — lock the submit. */
+  nameInvalid?: boolean;
 }
 
 export function AiReviewStep({
@@ -36,6 +38,7 @@ export function AiReviewStep({
   onSubmit,
   creating,
   error,
+  nameInvalid,
 }: AiReviewStepProps) {
   const { t } = useTranslation("shell");
   const resolvedColor = resolveAgentColor(color);
@@ -128,7 +131,7 @@ export function AiReviewStep({
         onBack={onBack}
         primaryLabel={t("naming.createAgent")}
         onPrimary={onSubmit}
-        primaryDisabled={!name.trim()}
+        primaryDisabled={!name.trim() || nameInvalid}
         primaryLoading={creating}
       />
     </div>

--- a/app/src/components/shell/create-workspace-dialog.tsx
+++ b/app/src/components/shell/create-workspace-dialog.tsx
@@ -13,6 +13,8 @@ import { loadStoreTemplate } from "../../agents/builtin/store-template-loader";
 import { DEFAULT_TAB_ID } from "../../agents/standard-tabs";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { useProviderStatuses } from "../../hooks/use-provider-statuses";
+import { AGENT_NAME_MAX_LENGTH, agentNameIssue } from "../../lib/agent-name";
+import { isAgentNameConflictError } from "../../lib/agent-name-conflict";
 import { finishAgentSetup } from "../../lib/agent-setup";
 import { startAgentSetupMission } from "../../lib/agent-setup-mission";
 import { pickDefaultProviderModel } from "../../lib/default-provider-model";
@@ -43,11 +45,12 @@ interface CreatedAgent {
 }
 
 export function CreateAgentDialog() {
-  const { t, i18n } = useTranslation("shell");
+  const { t, i18n } = useTranslation(["shell", "agents"]);
   const open = useUIStore((s) => s.createAgentDialogOpen);
   const setOpen = useUIStore((s) => s.setCreateAgentDialogOpen);
   const uiTourActive = useUIStore((s) => s.uiTourActive);
   const agentDefs = useAgentCatalogStore((s) => s.agents);
+  const existingAgents = useAgentStore((s) => s.agents);
   const createAgent = useAgentStore((s) => s.create);
   const currentWorkspace = useWorkspaceStore((s) => s.current);
   const { capabilities } = useCapabilities();
@@ -153,11 +156,41 @@ export function CreateAgentDialog() {
     tauriProvider.setLastUsed(nextProvider, nextModel).catch(() => {});
   };
 
+  // Live pre-submit validation (HOU-1166): bad shapes and duplicate names get
+  // localized inline copy under the field instead of the server's raw
+  // rejection, and the submit button locks while the name is invalid.
+  const nameIssue = agentNameIssue(
+    name,
+    existingAgents.map((a) => a.name),
+  );
+  const nameIssueMessage =
+    nameIssue === "invalidChars"
+      ? t("agents:nameErrors.invalidChars")
+      : nameIssue === "tooLong"
+        ? t("agents:nameErrors.tooLong", { max: AGENT_NAME_MAX_LENGTH })
+        : nameIssue === "taken"
+          ? t("agents:toasts.nameConflict", { name: name.trim() })
+          : null;
+
+  // Typing again clears a stale server rejection so the live validation copy
+  // (or nothing) takes over.
+  const handleNameChange = (value: string) => {
+    setName(value);
+    if (error) setError(null);
+  };
+
   const handleCreateAgent = async () => {
     const trimmed = name.trim();
     // `creating` also gates re-entry: the submit button is disabled while in
     // flight, but Enter in the name input still fires the form's onSubmit.
-    if (creating || !trimmed || !selectedConfigId || !currentWorkspace) return;
+    if (
+      creating ||
+      !trimmed ||
+      nameIssue ||
+      !selectedConfigId ||
+      !currentWorkspace
+    )
+      return;
     const resolved = pickDefaultProviderModel({
       lastUsedProvider: lastUsed?.provider,
       lastUsedModel: lastUsed?.model,
@@ -199,7 +232,13 @@ export function CreateAgentDialog() {
       created = agent;
       agentPath = agent.folderPath;
     } catch (err) {
-      setError(String(err));
+      // A 409 is the expected "name already taken" state (a sibling created
+      // it while the dialog was open) — friendly copy, not the wire error.
+      setError(
+        isAgentNameConflictError(err)
+          ? t("agents:toasts.nameConflict", { name: trimmed })
+          : String(err),
+      );
       setCreating(false);
       return;
     }
@@ -367,13 +406,14 @@ export function CreateAgentDialog() {
             name={name}
             color={color}
             instructions={generatedClaudeMd ?? ""}
-            onNameChange={setName}
+            onNameChange={handleNameChange}
             onColorChange={setColor}
             onInstructionsChange={setGeneratedClaudeMd}
             onBack={() => setStep(aiReviewBackStep())}
             onSubmit={handleCreateAgent}
             creating={creating}
-            error={error}
+            error={error ?? nameIssueMessage}
+            nameInvalid={nameIssue !== null}
           />
         ) : step === "connect" && createdAgent ? (
           <ConnectAppsStep
@@ -386,13 +426,14 @@ export function CreateAgentDialog() {
             selectedAgent={selectedDef}
             name={name}
             color={color}
-            error={error}
+            error={error ?? nameIssueMessage}
             existingPath={existingPath}
             creating={creating}
+            nameInvalid={nameIssue !== null}
             showLinkProject={selectedDef?.config.features?.includes(
               "link-project",
             )}
-            onNameChange={setName}
+            onNameChange={handleNameChange}
             onColorChange={setColor}
             onExistingPathChange={setExistingPath}
             onBack={() => setStep(1)}

--- a/app/src/components/shell/naming-step.tsx
+++ b/app/src/components/shell/naming-step.tsx
@@ -24,6 +24,8 @@ interface NamingStepProps {
   existingPath: string | null;
   /** The create request is in flight — lock the submit and show progress. */
   creating: boolean;
+  /** The typed name fails pre-submit validation — lock the submit. */
+  nameInvalid?: boolean;
   /** Show "Link existing project" option (opt-in via agent features). */
   showLinkProject?: boolean;
   onNameChange: (value: string) => void;
@@ -40,6 +42,7 @@ export function NamingStep({
   error,
   existingPath,
   creating,
+  nameInvalid,
   onNameChange,
   onColorChange,
   onExistingPathChange,
@@ -160,7 +163,7 @@ export function NamingStep({
         {error && <p className="text-xs text-danger text-center">{error}</p>}
         <Button
           type="submit"
-          disabled={!name.trim() || creating}
+          disabled={!name.trim() || nameInvalid || creating}
           className="w-full rounded-full"
         >
           {creating ? (

--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -13,6 +13,7 @@ import { DEFAULT_TAB_ID } from "../../agents/standard-tabs";
 import { useCanCreateAgents } from "../../hooks/use-can-create-agents";
 import { useSidebarLayout } from "../../hooks/use-sidebar-layout";
 import { useSurfaceGates } from "../../hooks/use-surface-gates";
+import { AGENT_NAME_MAX_LENGTH, agentNameIssue } from "../../lib/agent-name";
 import { isAgentNameConflictError } from "../../lib/agent-name-conflict";
 import { showExpectedStateToast } from "../../lib/error-toast";
 import { renameAgentWithFollowUp } from "../../lib/rename-agent-follow-up";
@@ -131,6 +132,24 @@ export function Sidebar({ children }: { children: ReactNode }) {
 
   const handleRename = async (agentId: string, newName: string) => {
     if (!currentWorkspace) return;
+    // Validate BEFORE the PATCH (HOU-1166): bad shapes and known duplicates
+    // get the expected-state toast without a round-trip. The 409 catch below
+    // stays for races (a sibling took the name after this list loaded).
+    const issue = agentNameIssue(
+      newName,
+      agents.filter((a) => a.id !== agentId).map((a) => a.name),
+    );
+    if (issue) {
+      showExpectedStateToast(
+        issue === "taken"
+          ? t("agents:toasts.nameConflict", { name: newName.trim() })
+          : issue === "tooLong"
+            ? t("agents:nameErrors.tooLong", { max: AGENT_NAME_MAX_LENGTH })
+            : t("agents:nameErrors.invalidChars"),
+        t("agents:toasts.nameConflictDescription"),
+      );
+      return;
+    }
     try {
       await renameAgentWithFollowUp({
         workspaceId: currentWorkspace.id,

--- a/app/src/lib/agent-name-conflict.ts
+++ b/app/src/lib/agent-name-conflict.ts
@@ -1,13 +1,14 @@
-import type { HoustonEngineError } from "@houston-ai/engine-client";
-
 // `PATCH /agents/:id` has exactly one 409 path: AgentNameConflictError in
 // packages/host/src/routes/agents.ts. A 409 from this call is therefore the
 // expected "name already taken" business state, not a generic failure.
-/** True when a rename collides with another agent in the workspace. */
+// Two client stacks reach that route: the legacy adapter throws
+// `HoustonEngineError`, the SDK write path (wave 2b) throws `AgentsHttpError`.
+/** True when a create/rename collides with another agent in the workspace. */
 export function isAgentNameConflictError(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
-  const engineError = err as HoustonEngineError;
+  const e = err as { name?: unknown; status?: unknown };
   return (
-    engineError.name === "HoustonEngineError" && engineError.status === 409
+    (e.name === "HoustonEngineError" || e.name === "AgentsHttpError") &&
+    e.status === 409
   );
 }

--- a/app/src/lib/agent-name.ts
+++ b/app/src/lib/agent-name.ts
@@ -1,0 +1,30 @@
+import { validateAgentName } from "@houston/sdk/agent-name";
+
+export { AGENT_NAME_MAX_LENGTH } from "@houston/sdk/agent-name";
+
+/**
+ * What's wrong with a typed agent name, pre-submit (HOU-1166). `null` means
+ * submittable; an empty name also returns `null` because the submit buttons
+ * are simply disabled for it — no error copy needed while the field is blank.
+ */
+export type AgentNameIssue = "invalidChars" | "tooLong" | "taken";
+
+/**
+ * Validate a name BEFORE it goes to the host: shape via the shared SDK rule,
+ * duplicates against the already-loaded agent list. Case-insensitive because
+ * agent folders land on case-insensitive filesystems (macOS, Windows).
+ */
+export function agentNameIssue(
+  raw: string,
+  existingNames: string[],
+): AgentNameIssue | null {
+  const v = validateAgentName(raw);
+  if (!v.ok) {
+    if (v.reason === "empty") return null;
+    return v.reason === "too_long" ? "tooLong" : "invalidChars";
+  }
+  const lower = v.name.toLowerCase();
+  return existingNames.some((n) => n.trim().toLowerCase() === lower)
+    ? "taken"
+    : null;
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -321,20 +321,27 @@ export const tauriAgents = {
     seeds?: Record<string, string>,
     existingPath?: string,
   ) =>
-    call<CreateAgentResult>("create_agent", async () => {
-      const r = await getEngine().createAgent(workspaceId, {
-        name,
-        configId,
-        color,
-        claudeMd,
-        installedPath,
-        seeds,
-        existingPath,
-      });
-      return {
-        agent: toAgent(r.agent),
-      };
-    }),
+    call<CreateAgentResult>(
+      "create_agent",
+      async () => {
+        const r = await getEngine().createAgent(workspaceId, {
+          name,
+          configId,
+          color,
+          claudeMd,
+          installedPath,
+          seeds,
+          existingPath,
+        });
+        return {
+          agent: toAgent(r.agent),
+        };
+      },
+      undefined,
+      // A 409 (name already taken) renders as friendly inline copy in the
+      // create dialog — the generic red bug toast would double-surface it.
+      { silence: isAgentNameConflictError },
+    ),
   delete: (workspaceId: string, id: string) =>
     call<void>("delete_agent", () => getEngine().deleteAgent(workspaceId, id)),
   rename: (workspaceId: string, id: string, newName: string) => {

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -49,6 +49,10 @@
     "switchedModel": "Switched to {{provider}} ({{model}})",
     "timezoneSet": "Timezone set to {{zone}}"
   },
+  "nameErrors": {
+    "invalidChars": "Agent names can't contain slashes or special characters",
+    "tooLong": "Agent names can be at most {{max}} characters"
+  },
   "empty": {
     "title": "No agents yet",
     "description": "Build your AI team and start a mission."

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -49,6 +49,10 @@
     "switchedModel": "Cambiaste a {{provider}} ({{model}})",
     "timezoneSet": "Zona horaria puesta en {{zone}}"
   },
+  "nameErrors": {
+    "invalidChars": "El nombre del agente no puede contener barras ni caracteres especiales",
+    "tooLong": "El nombre del agente puede tener máximo {{max}} caracteres"
+  },
   "empty": {
     "title": "Aún no hay agentes",
     "description": "Crea tu equipo de IA e inicia una misión."

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -49,6 +49,10 @@
     "switchedModel": "Mudou para {{provider}} ({{model}})",
     "timezoneSet": "Fuso horário definido como {{zone}}"
   },
+  "nameErrors": {
+    "invalidChars": "O nome do agente não pode conter barras nem caracteres especiais",
+    "tooLong": "O nome do agente pode ter no máximo {{max}} caracteres"
+  },
   "empty": {
     "title": "Ainda não há agentes",
     "description": "Crie sua equipe de IA e inicie uma missão."

--- a/app/tests/agent-name-conflict.test.ts
+++ b/app/tests/agent-name-conflict.test.ts
@@ -3,10 +3,27 @@ import { describe, it } from "node:test";
 import { HoustonEngineError } from "../../packages/web/src/engine-adapter/client/errors.ts";
 import { isAgentNameConflictError } from "../src/lib/agent-name-conflict.ts";
 
+// The real `AgentsHttpError` (packages/sdk/src/modules/agents/http.ts) uses a
+// TS parameter property, which `--experimental-strip-types` refuses to load —
+// mirror its wire-relevant shape (name + status) instead.
+function agentsHttpError(message: string, status: number): Error {
+  return Object.assign(new Error(message), {
+    name: "AgentsHttpError",
+    status,
+  });
+}
+
 describe("isAgentNameConflictError", () => {
   it("matches a 409 HoustonEngineError from an agent rename", () => {
     strictEqual(
       isAgentNameConflictError(new HoustonEngineError(409, { error: "taken" })),
+      true,
+    );
+  });
+
+  it("matches a 409 AgentsHttpError from the SDK write path (wave 2b)", () => {
+    strictEqual(
+      isAgentNameConflictError(agentsHttpError('{"error":"taken"}', 409)),
       true,
     );
   });
@@ -16,6 +33,10 @@ describe("isAgentNameConflictError", () => {
     strictEqual(isAgentNameConflictError("409"), false);
     strictEqual(
       isAgentNameConflictError(new HoustonEngineError(400, { error: "bad" })),
+      false,
+    );
+    strictEqual(
+      isAgentNameConflictError(agentsHttpError("missing 'name'", 400)),
       false,
     );
   });

--- a/app/tests/agent-name.test.ts
+++ b/app/tests/agent-name.test.ts
@@ -1,0 +1,34 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { agentNameIssue } from "../src/lib/agent-name.ts";
+
+describe("agentNameIssue", () => {
+  const existing = ["Personal assistant", "Bookkeeper"];
+
+  it("passes ordinary unique names", () => {
+    strictEqual(agentNameIssue("Growth Lead", existing), null);
+    strictEqual(agentNameIssue("  Growth Lead  ", existing), null);
+  });
+
+  it("stays quiet on an empty name (the submit button is just disabled)", () => {
+    strictEqual(agentNameIssue("", existing), null);
+    strictEqual(agentNameIssue("   ", existing), null);
+  });
+
+  it("flags path separators, traversal, and leading dots", () => {
+    strictEqual(agentNameIssue("hello/", existing), "invalidChars");
+    strictEqual(agentNameIssue("a\\b", existing), "invalidChars");
+    strictEqual(agentNameIssue("a..b", existing), "invalidChars");
+    strictEqual(agentNameIssue(".hidden", existing), "invalidChars");
+  });
+
+  it("flags over-long names", () => {
+    strictEqual(agentNameIssue("x".repeat(65), existing), "tooLong");
+  });
+
+  it("flags duplicates case-insensitively (agent folders land on case-insensitive filesystems)", () => {
+    strictEqual(agentNameIssue("Bookkeeper", existing), "taken");
+    strictEqual(agentNameIssue("bookkeeper", existing), "taken");
+    strictEqual(agentNameIssue("  BOOKKEEPER  ", existing), "taken");
+  });
+});

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./src/index.ts",
       "import": "./src/index.ts"
+    },
+    "./agent-name": {
+      "types": "./src/agent-name.ts",
+      "import": "./src/agent-name.ts"
     }
   },
   "files": [

--- a/packages/domain/src/agent-name.test.ts
+++ b/packages/domain/src/agent-name.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_NAME_MAX_LENGTH,
+  invalidAgentNameMessage,
+  validateAgentName,
+} from "./agent-name";
+
+describe("validateAgentName", () => {
+  it("accepts ordinary names and returns them trimmed", () => {
+    expect(validateAgentName("Personal assistant")).toEqual({
+      ok: true,
+      name: "Personal assistant",
+    });
+    expect(validateAgentName("  Bookkeeper  ")).toEqual({
+      ok: true,
+      name: "Bookkeeper",
+    });
+    expect(validateAgentName("Ana's agent (v2)")).toEqual({
+      ok: true,
+      name: "Ana's agent (v2)",
+    });
+    // Interior dots are fine; only leading dots hide the folder.
+    expect(validateAgentName("v2.0 helper").ok).toBe(true);
+  });
+
+  it("rejects empty and whitespace-only names", () => {
+    expect(validateAgentName("")).toEqual({ ok: false, reason: "empty" });
+    expect(validateAgentName("   ")).toEqual({ ok: false, reason: "empty" });
+  });
+
+  it("rejects names over the length cap", () => {
+    expect(validateAgentName("a".repeat(AGENT_NAME_MAX_LENGTH)).ok).toBe(true);
+    expect(validateAgentName("a".repeat(AGENT_NAME_MAX_LENGTH + 1))).toEqual({
+      ok: false,
+      reason: "too_long",
+    });
+  });
+
+  it("rejects path separators, '..', leading dots, and control characters", () => {
+    for (const name of [
+      "hello/",
+      "a/b",
+      "a\\b",
+      "..",
+      "a..b",
+      ".hidden",
+      "a\nb",
+      "a\u0000b",
+    ]) {
+      expect(validateAgentName(name)).toEqual({ ok: false, reason: "invalid" });
+    }
+  });
+
+  it("has a message for every reason", () => {
+    expect(invalidAgentNameMessage("empty")).toMatch(/empty/);
+    expect(invalidAgentNameMessage("too_long")).toContain(
+      String(AGENT_NAME_MAX_LENGTH),
+    );
+    expect(invalidAgentNameMessage("invalid")).toMatch(/slashes/);
+  });
+});

--- a/packages/domain/src/agent-name.ts
+++ b/packages/domain/src/agent-name.ts
@@ -1,0 +1,51 @@
+/**
+ * The ONE agent-name rule, shared by every layer that touches a name: the
+ * host's routes and workspace stores (agent names are directory names under
+ * `~/.houston/workspaces/<Workspace>/`) and, via `@houston/sdk`, the surfaces
+ * that validate BEFORE submitting (HOU-1166: the create dialog once dumped the
+ * server's raw rejection under the name field instead of validating up front).
+ */
+
+/** Hard cap on an agent's display/folder name, in characters. */
+export const AGENT_NAME_MAX_LENGTH = 64;
+
+export type InvalidAgentNameReason = "empty" | "too_long" | "invalid";
+
+export type AgentNameValidation =
+  | { ok: true; name: string }
+  | { ok: false; reason: InvalidAgentNameReason };
+
+// Path separators and ".." would escape the workspace directory; control
+// characters corrupt listings; a leading dot creates a folder the store's
+// directory scan deliberately skips, i.e. an invisible agent.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: rejecting them is the point
+const FORBIDDEN = /[/\\\u0000-\u001f\u007f]/;
+
+/**
+ * Validate a user-typed agent name. On success returns the trimmed name to
+ * use; on failure the reason, for the caller to turn into its own copy
+ * (i18n on the surfaces, {@link invalidAgentNameMessage} on the host).
+ */
+export function validateAgentName(raw: string): AgentNameValidation {
+  const name = raw.trim();
+  if (!name) return { ok: false, reason: "empty" };
+  if (name.length > AGENT_NAME_MAX_LENGTH)
+    return { ok: false, reason: "too_long" };
+  if (FORBIDDEN.test(name) || name.includes("..") || name.startsWith("."))
+    return { ok: false, reason: "invalid" };
+  return { ok: true, name };
+}
+
+/** The host's English error-body copy for a rejected name. */
+export function invalidAgentNameMessage(
+  reason: InvalidAgentNameReason,
+): string {
+  switch (reason) {
+    case "empty":
+      return "agent name must not be empty";
+    case "too_long":
+      return `agent name must be ${AGENT_NAME_MAX_LENGTH} characters or fewer`;
+    case "invalid":
+      return "agent name must not contain slashes, control characters, '..', or a leading dot";
+  }
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./activities";
+export * from "./agent-name";
 export * from "./anonymize";
 export * from "./anonymize-ai";
 export * from "./config";

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -1,4 +1,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  type InvalidAgentNameReason,
+  invalidAgentNameMessage,
+} from "@houston/domain";
 import type {
   ClaudeOAuthCredential,
   CustomEndpoint,
@@ -28,6 +32,21 @@ import type {
 export class AgentNameConflictError extends Error {
   constructor(readonly agentName: string) {
     super(`an agent named "${agentName}" already exists in this workspace`);
+  }
+}
+
+/**
+ * A name `validateAgentName` (@houston/domain) rejects — empty, over-long, or
+ * carrying path separators / control characters. Stores throw it as a typed
+ * backstop so a route that skipped pre-validation still answers 400, not a
+ * raw 500 (HOU-1166).
+ */
+export class InvalidAgentNameError extends Error {
+  constructor(
+    readonly agentName: string,
+    readonly reason: InvalidAgentNameReason,
+  ) {
+    super(invalidAgentNameMessage(reason));
   }
 }
 

--- a/packages/host/src/routes/agents-create.test.ts
+++ b/packages/host/src/routes/agents-create.test.ts
@@ -138,3 +138,44 @@ test("a failed seed write rolls back the agent record and its folder", async () 
   const root = DEFAULT_PATHS.agentRoot(ws, rolledBack);
   expect(await vfs.list(root)).toEqual([]);
 });
+
+test("an invalid name answers 400 with a clean message, not a 500 (HOU-1166)", async () => {
+  for (const bad of [
+    "hello/",
+    "back\\slash",
+    "a..b",
+    ".hidden",
+    "x".repeat(65),
+  ]) {
+    const response = res();
+    const handled = await handleAgents(
+      deps,
+      "alice",
+      "POST",
+      "/agents",
+      new URL("/agents", "http://host.local"),
+      req(JSON.stringify({ name: bad })),
+      response,
+    );
+    expect(handled).toBe(true);
+    expect(response.status).toBe(400);
+    expect(String(JSON.parse(response.body).error)).toMatch(/agent name/);
+  }
+  const ws = await store.getOrCreatePersonalWorkspace("alice");
+  expect(await store.listAgents(ws.id)).toEqual([]);
+});
+
+test("create trims the submitted name before storing it", async () => {
+  const response = res();
+  await handleAgents(
+    deps,
+    "alice",
+    "POST",
+    "/agents",
+    new URL("/agents", "http://host.local"),
+    req(JSON.stringify({ name: "  Padded  " })),
+    response,
+  );
+  expect(response.status).toBe(201);
+  expect(JSON.parse(response.body).name).toBe("Padded");
+});

--- a/packages/host/src/routes/agents-rename.test.ts
+++ b/packages/host/src/routes/agents-rename.test.ts
@@ -267,3 +267,18 @@ test("ProxyChannel.quiesce sleeps the agent's runtime without destroying it", as
   expect(slept).toEqual([agentId]);
   expect(destroyed).toEqual([]);
 });
+
+test("an invalid name answers 400 without touching runtime or store (HOU-1166)", async () => {
+  for (const bad of ["has/slash", "back\\slash", "a..b", ".hidden"]) {
+    const { status, json } = await rename(bad);
+    expect(status).toBe(400);
+    expect(String(json.error)).toMatch(/agent name/);
+  }
+  expect(calls).toEqual([]); // no quiesce, no rename
+});
+
+test("rename trims the submitted name before storing it", async () => {
+  const { status, json } = await rename("  Marketing  ");
+  expect(status).toBe(200);
+  expect(json.name).toBe("Marketing");
+});

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -1,5 +1,10 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { loadRoutineRuns, seedSchemas } from "@houston/domain";
+import {
+  invalidAgentNameMessage,
+  loadRoutineRuns,
+  seedSchemas,
+  validateAgentName,
+} from "@houston/domain";
 import {
   type CustomEndpoint,
   type HoustonEvent,
@@ -230,6 +235,13 @@ export async function handleAgents(
       json(res, 400, { error: "missing 'name'" });
       return true;
     }
+    // Surfaces validate before submitting (HOU-1166); this is the wire-level
+    // backstop, answering a clean 400 instead of a store-level 500.
+    const nameCheck = validateAgentName(name);
+    if (!nameCheck.ok) {
+      json(res, 400, { error: invalidAgentNameMessage(nameCheck.reason) });
+      return true;
+    }
     // Optional create-time content: CLAUDE.md instructions + a flat seed-file
     // map (skills, seeded .houston data, working files). Builtin templates and
     // portable installs supply these; the Rust engine wrote them on install, so
@@ -247,7 +259,10 @@ export async function handleAgents(
       seeds = parsed;
     }
     const ws = await deps.store.getOrCreatePersonalWorkspace(userId);
-    const agent = await deps.store.createAgent({ workspaceId: ws.id, name });
+    const agent = await deps.store.createAgent({
+      workspaceId: ws.id,
+      name: nameCheck.name,
+    });
     // Seed the .houston JSON schemas beside the (future) docs so the agent and
     // external tools can validate what they write. Skipped only when no vfs is
     // wired (legacy gke-only deploys); the typed-data routes 503 there anyway.
@@ -301,11 +316,17 @@ export async function handleAgents(
     }
 
     if (method === "PATCH") {
-      const { name } = await readJson(req);
-      if (!name || typeof name !== "string") {
+      const { name: rawName } = await readJson(req);
+      if (!rawName || typeof rawName !== "string") {
         json(res, 400, { error: "missing 'name'" });
         return true;
       }
+      const renameCheck = validateAgentName(rawName);
+      if (!renameCheck.ok) {
+        json(res, 400, { error: invalidAgentNameMessage(renameCheck.reason) });
+        return true;
+      }
+      const name = renameCheck.name;
       // Quiesce the agent's standing runtime BEFORE the rename moves its
       // directory. A warm local runtime holds absolute paths into the OLD
       // directory (cwd + HOUSTON_DATA_DIR) and stays keyed under the OLD id in

--- a/packages/host/src/routes/portable.ts
+++ b/packages/host/src/routes/portable.ts
@@ -2,12 +2,14 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   applyOverrides,
   filterPackage,
+  invalidAgentNameMessage,
   type PortablePackage,
   packAgent,
   packageSeed,
   portableInventory,
   seedSchemas,
   unpackAgent,
+  validateAgentName,
 } from "@houston/domain";
 import type {
   PortableExportOverrides,
@@ -142,6 +144,11 @@ export async function handlePortableAccount(
     json(res, 400, { error: "missing 'agentName' or 'archive' (base64)" });
     return true;
   }
+  const nameCheck = validateAgentName(body.agentName);
+  if (!nameCheck.ok) {
+    json(res, 400, { error: invalidAgentNameMessage(nameCheck.reason) });
+    return true;
+  }
   let pkg: PortablePackage;
   try {
     pkg = unpackAgent(new Uint8Array(Buffer.from(body.archive, "base64")));
@@ -158,7 +165,7 @@ export async function handlePortableAccount(
   const ws = await deps.store.getOrCreatePersonalWorkspace(userId);
   const agent = await deps.store.createAgent({
     workspaceId: ws.id,
-    name: body.agentName,
+    name: nameCheck.name,
   });
   const root = paths.agentRoot(ws, agent);
   await seedSchemas(deps.vfs, root);

--- a/packages/host/src/store/local.test.ts
+++ b/packages/host/src/store/local.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "vitest";
-import { AgentNameConflictError } from "../ports";
+import { AgentNameConflictError, InvalidAgentNameError } from "../ports";
 import { LocalWorkspaceStore } from "./local";
 
 /**
@@ -81,10 +81,10 @@ test("createAgent rejects a name with a slash or traversal", async () => {
   const store = new LocalWorkspaceStore(tree({ Work: [] }));
   await expect(
     store.createAgent({ workspaceId: "Work", name: "a/b" }),
-  ).rejects.toThrow("invalid agent name");
+  ).rejects.toThrow(InvalidAgentNameError);
   await expect(
     store.createAgent({ workspaceId: "Work", name: ".." }),
-  ).rejects.toThrow("invalid agent name");
+  ).rejects.toThrow(InvalidAgentNameError);
 });
 
 test("listWorkspacesForUser returns everything (single local user); listAllAgents flattens", async () => {

--- a/packages/host/src/store/local.ts
+++ b/packages/host/src/store/local.ts
@@ -7,6 +7,7 @@ import {
   statSync,
 } from "node:fs";
 import { join } from "node:path";
+import { validateAgentName } from "@houston/domain";
 import type {
   Agent,
   AgentId,
@@ -15,7 +16,11 @@ import type {
   WorkspaceId,
   WorkspaceRuntime,
 } from "../domain/types";
-import { AgentNameConflictError, type WorkspaceStore } from "../ports";
+import {
+  AgentNameConflictError,
+  InvalidAgentNameError,
+  type WorkspaceStore,
+} from "../ports";
 
 /**
  * The local profile's WorkspaceStore — the desktop tree on disk is the source
@@ -123,9 +128,8 @@ export class LocalWorkspaceStore implements WorkspaceStore {
     workspaceId: WorkspaceId;
     name: string;
   }): Promise<Agent> {
-    if (input.name.includes("/") || input.name.includes("..")) {
-      throw new Error(`invalid agent name: ${input.name}`);
-    }
+    const v = validateAgentName(input.name);
+    if (!v.ok) throw new InvalidAgentNameError(input.name, v.reason);
     mkdirSync(join(this.root, input.workspaceId, input.name), {
       recursive: true,
     });
@@ -135,8 +139,8 @@ export class LocalWorkspaceStore implements WorkspaceStore {
   async renameAgent(id: AgentId, name: string): Promise<Agent> {
     const agent = await this.getAgent(id);
     if (!agent) throw new Error(`renameAgent: unknown agent ${id}`);
-    if (name.includes("/") || name.includes(".."))
-      throw new Error(`invalid agent name: ${name}`);
+    const v = validateAgentName(name);
+    if (!v.ok) throw new InvalidAgentNameError(name, v.reason);
     if (name === agent.name) return agent;
     // Check BEFORE renameSync: moving onto an existing directory throws a raw
     // ENOTEMPTY that would surface as a 500 (#172).

--- a/packages/host/src/store/memory.ts
+++ b/packages/host/src/store/memory.ts
@@ -1,3 +1,4 @@
+import { validateAgentName } from "@houston/domain";
 import type {
   Agent,
   AgentId,
@@ -6,7 +7,11 @@ import type {
   WorkspaceId,
   WorkspaceRuntime,
 } from "../domain/types";
-import { AgentNameConflictError, type WorkspaceStore } from "../ports";
+import {
+  AgentNameConflictError,
+  InvalidAgentNameError,
+  type WorkspaceStore,
+} from "../ports";
 
 /** DNS-safe slug for a workspace (used for the K8s namespace). */
 function slugify(name: string): string {
@@ -87,6 +92,8 @@ export class MemoryWorkspaceStore implements WorkspaceStore {
     workspaceId: WorkspaceId;
     name: string;
   }): Promise<Agent> {
+    const v = validateAgentName(input.name);
+    if (!v.ok) throw new InvalidAgentNameError(input.name, v.reason);
     const agent: Agent = {
       id: this.id("agent"),
       workspaceId: input.workspaceId,
@@ -100,6 +107,8 @@ export class MemoryWorkspaceStore implements WorkspaceStore {
   async renameAgent(id: AgentId, name: string): Promise<Agent> {
     const agent = this.agents.get(id);
     if (!agent) throw new Error(`renameAgent: unknown agent ${id}`);
+    const v = validateAgentName(name);
+    if (!v.ok) throw new InvalidAgentNameError(name, v.reason);
     if (name === agent.name) return agent;
     // Same contract as the disk store: a sibling already holding the name is a
     // typed conflict, never a raw backend failure (#172).

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -14,6 +14,10 @@
     "./react": {
       "types": "./src/react/index.ts",
       "import": "./src/react/index.ts"
+    },
+    "./agent-name": {
+      "types": "./src/agent-name.ts",
+      "import": "./src/agent-name.ts"
     }
   },
   "files": [
@@ -41,6 +45,7 @@
     "vitest": "3.2.6"
   },
   "dependencies": {
+    "@houston/domain": "workspace:*",
     "@houston/protocol": "workspace:*",
     "@houston/runtime-client": "workspace:*"
   }

--- a/packages/sdk/src/agent-name.ts
+++ b/packages/sdk/src/agent-name.ts
@@ -1,0 +1,14 @@
+/**
+ * Subpath re-export of the shared agent-name rule (`@houston/sdk/agent-name`).
+ *
+ * The main barrel also re-exports these, but this dependency-free subpath is
+ * what surface code should import: it stays loadable under plain
+ * `node --experimental-strip-types` (app unit tests), where the barrels'
+ * extensionless internal imports do not resolve.
+ */
+export {
+  AGENT_NAME_MAX_LENGTH,
+  type AgentNameValidation,
+  type InvalidAgentNameReason,
+  validateAgentName,
+} from "@houston/domain/agent-name";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -11,6 +11,15 @@
  * (the kernel composes them); a host uses `new HoustonSdk(...)`, not a factory.
  */
 
+// The agent-name rule lives once in @houston/domain; surfaces import it from
+// here so they can validate BEFORE submitting instead of rendering the
+// server's rejection (HOU-1166).
+export {
+  AGENT_NAME_MAX_LENGTH,
+  type AgentNameValidation,
+  type InvalidAgentNameReason,
+  validateAgentName,
+} from "@houston/domain";
 // ===== Kernel =========================================================
 export {
   type AuthExpiryNotifier,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -566,6 +566,9 @@ importers:
 
   packages/sdk:
     dependencies:
+      '@houston/domain':
+        specifier: workspace:*
+        version: link:../domain
       '@houston/protocol':
         specifier: workspace:*
         version: link:../protocol


### PR DESCRIPTION
Fixes HOU-1166.

## Root cause

Typing a name like `hello/` in the create-agent dialog fired the request unvalidated; the server rejected it and the dialog rendered the raw wire error (`AgentsHttpError: {"error":"name must not contain '/'"}`) under the name field, plus the generic red bug toast. Three layers were missing/broken:

1. **No client-side validation** anywhere a name is typed (create dialog, AI review step, sidebar inline rename, portable import wizard).
2. **Host answered invalid names with a bare 500** (`Error("invalid agent name: …")` from the disk store); the in-memory store didn't validate at all.
3. **The friendly duplicate-name toast had regressed**: `isAgentNameConflictError` only matched the legacy `HoustonEngineError`, but since the SDK write delegation (wave 2b) renames throw `AgentsHttpError`, so a 409 surfaced as a generic bug toast + Sentry report.

## Fix

- **One rule, one place**: `validateAgentName` in `@houston/domain` (trim; 64-char cap; rejects `/`, `\`, `..`, leading dots, control chars — agent names are folder names under the workspace root, and dot-prefixed folders are invisible to the store's directory scan). Re-exported through `@houston/sdk` and a dependency-free `@houston/sdk/agent-name` subpath (loadable under `node --experimental-strip-types` for app unit tests).
- **Host**: `POST /agents`, `PATCH /agents/:id`, and the portable install route pre-validate and answer a clean 400; both workspace stores throw a typed `InvalidAgentNameError` as backstop; names are stored trimmed.
- **App**: live localized inline error (en/es/pt) + locked submit in the create dialog and AI review step; pre-flight validation with expected-state toasts on sidebar rename and import-wizard install; duplicate names pre-checked case-insensitively against the loaded agent list (agent folders land on case-insensitive filesystems).
- **409 handling repaired**: `isAgentNameConflictError` now matches both error classes; a create-time 409 (race) renders as friendly inline copy and is silenced from the generic bug toast, matching rename.

## Before the fix (repro)

1. Open the app → New agent → pick any template.
2. Type `hello/` as the name and submit.
3. The dialog shows the raw `AgentsHttpError: {"error":…}` JSON under the field (screenshot on HOU-1166), plus a red "report bug" toast. On desktop the host returned a 500.
4. Rename an agent in the sidebar to another agent's exact name → generic red bug toast instead of the "already exists" notice.

## After the fix (verify)

1. New agent → type `hello/` → localized "Agent names can't contain slashes or special characters" appears inline as you type, Create Agent is disabled, no request is sent.
2. Type a 65+ character name → "at most 64 characters" copy, submit locked.
3. Type an existing agent's name (any casing) → "An agent named X already exists" inline, submit locked.
4. Sidebar rename to `a/b` or to a sibling's name → calm expected-state toast, no bug toast, no Sentry event.
5. Valid names (including `  Padded  `, which lands trimmed) create/rename normally.
6. Wire-level: `POST /v1/agents` with `{"name":"hello/"}` → `400 {"error":"agent name must not contain slashes, control characters, '..', or a leading dot"}` (was 500).

Tests: new vitest suites for the domain validator and both routes (400 + trim), store-level typed-error tests, and app `node:test` coverage for `agentNameIssue` and both conflict error classes. All gates green: Biome, tsgo (app/ui/web/host/sdk/domain), check-locales, check:boundaries, host/domain/sdk vitest, app unit tests.

Note (out of scope, worth a follow-up): `POST /agents` with an already-existing name still silently reuses the folder on the disk store (and re-seeds it). Client-side duplicate pre-checks now block this from the UI, but a server-side 409 on create would need verifying against the cloud gateway's seeding/retry flow first.