### PR TITLE
fix: stop spurious provider disconnects, misattributed reconnect cards, and dead-end composer

### DIFF
--- a/app/src/components/chat-connect-ai-empty-state.tsx
+++ b/app/src/components/chat-connect-ai-empty-state.tsx
@@ -1,11 +1,10 @@
 /**
- * The composer's "no AI model connected" state: what stands where the chat
- * input normally is, until the user connects a provider.
+ * The composer's "no AI connected" state: what stands where the chat input
+ * normally is, until the user connects an AI.
  *
  * It sits in the composer slot (`chat-panel.tsx` hides the whole `ChatInput`
- * while a `replace`-mode override is present), so it stays COMPACT — roughly
- * the height of the input it replaces, tighter padding than a full-pane empty
- * state, title at body size rather than the `Empty` default display size.
+ * while a `replace`-mode override is present) and renders the standard
+ * `Empty` presentation, same idiom as `mission-board-empty-state`.
  *
  * The copy is the model picker's own no-providers copy (`noProviders.*`): the
  * two surfaces tell the user the same thing about the same fact, so they say it
@@ -39,12 +38,12 @@ export function ChatConnectAiEmptyState({
 }: ChatConnectAiEmptyStateProps) {
   const { t } = useTranslation("chat");
   return (
-    <Empty className="border-0 gap-4 p-4 md:p-4">
-      <EmptyHeader className="gap-1.5">
+    <Empty className="border-0">
+      <EmptyHeader>
         <EmptyMedia variant="icon">
           <PlugZapIcon />
         </EmptyMedia>
-        <EmptyTitle className="text-base font-medium">
+        <EmptyTitle>
           {t(`modelSelector.picker.noProviders.${variant}.title`)}
         </EmptyTitle>
         <EmptyDescription>

--- a/app/src/components/chat-connect-ai-empty-state.tsx
+++ b/app/src/components/chat-connect-ai-empty-state.tsx
@@ -1,0 +1,68 @@
+/**
+ * The composer's "no AI model connected" state: what stands where the chat
+ * input normally is, until the user connects a provider.
+ *
+ * It sits in the composer slot (`chat-panel.tsx` hides the whole `ChatInput`
+ * while a `replace`-mode override is present), so it stays COMPACT — roughly
+ * the height of the input it replaces, tighter padding than a full-pane empty
+ * state, title at body size rather than the `Empty` default display size.
+ *
+ * The copy is the model picker's own no-providers copy (`noProviders.*`): the
+ * two surfaces tell the user the same thing about the same fact, so they say it
+ * in the same words. `onConnect` is withheld for a viewer who cannot open the AI
+ * Hub, which renders the story with no button rather than a dead end.
+ */
+
+import {
+  Button,
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@houston-ai/core";
+import { PlugZapIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { PickerEmptyState } from "./chat-model-selector-labels.ts";
+
+interface ChatConnectAiEmptyStateProps {
+  /** Which no-providers story to tell: personal space or team space. */
+  variant: PickerEmptyState;
+  /** Opens the AI Hub. Omitted when the viewer cannot reach it. */
+  onConnect?: () => void;
+}
+
+export function ChatConnectAiEmptyState({
+  variant,
+  onConnect,
+}: ChatConnectAiEmptyStateProps) {
+  const { t } = useTranslation("chat");
+  return (
+    <Empty className="border-0 gap-4 p-4 md:p-4">
+      <EmptyHeader className="gap-1.5">
+        <EmptyMedia variant="icon">
+          <PlugZapIcon />
+        </EmptyMedia>
+        <EmptyTitle className="text-base font-medium">
+          {t(`modelSelector.picker.noProviders.${variant}.title`)}
+        </EmptyTitle>
+        <EmptyDescription>
+          {t(`modelSelector.picker.noProviders.${variant}.hint`)}
+        </EmptyDescription>
+      </EmptyHeader>
+      {onConnect ? (
+        <EmptyContent>
+          <Button
+            className="rounded-full"
+            size="sm"
+            variant="outline"
+            onClick={onConnect}
+          >
+            {t("modelSelector.picker.noProviders.action")}
+          </Button>
+        </EmptyContent>
+      ) : null}
+    </Empty>
+  );
+}

--- a/app/src/components/chat-effective-provider.ts
+++ b/app/src/components/chat-effective-provider.ts
@@ -1,4 +1,25 @@
 /**
+ * The provider this chat has evidence for, strongest first: the turn's own
+ * activity pin, then the agent's configured provider, then the provider the
+ * chat last actually used. `null` when there is no evidence at all.
+ *
+ * Empty strings are ABSENT, not picks: an empty id reaches us from records the
+ * engine could not attribute (`provider: ""`), and treating one as a choice
+ * would both freeze the composer on nothing and label an error card with a
+ * blank provider name. This is THE preference chain — `resolveEffectiveProvider`
+ * (composer) and `errorCardProvider` (error cards) differ only in what they do
+ * when it yields nothing: the composer falls back to `"anthropic"`, the card
+ * stays generic rather than guessing a provider the user may never have used.
+ */
+export function preferredProvider(
+  activityProvider: string | null,
+  agentProvider: string | null,
+  lastUsedProvider: string | null,
+): string | null {
+  return activityProvider || agentProvider || lastUsedProvider || null;
+}
+
+/**
  * Provider the chat composer should use. Drives the model-selector dropdown and
  * the provider forwarded to the engine on send. Mirrors the engine's
  * `ResolveMode::Interactive`.
@@ -47,7 +68,8 @@ export function resolveEffectiveProvider(
   unconfirmedProviders: readonly string[] = [],
 ): string {
   const preferred =
-    activityProvider ?? agentProvider ?? lastUsedProvider ?? "anthropic";
+    preferredProvider(activityProvider, agentProvider, lastUsedProvider) ??
+    "anthropic";
 
   // Mid-conversation: freeze. Honor `preferred` as-is even when logged out so a
   // logout surfaces the reconnect card instead of silently switching providers.

--- a/app/src/components/chat-model-selector-labels.ts
+++ b/app/src/components/chat-model-selector-labels.ts
@@ -33,7 +33,7 @@ export interface PickerEmptyStateDecision {
   variant: PickerEmptyState;
   /**
    * Whether the viewer can reach the AI Models hub — gates BOTH the empty
-   * state's button and the picker's "Connect more providers…" footer.
+   * state's button and the picker's "Connect another AI…" footer.
    */
   canConnect: boolean;
 }

--- a/app/src/components/shell/provider-error-cards/auth-presentation.ts
+++ b/app/src/components/shell/provider-error-cards/auth-presentation.ts
@@ -32,30 +32,6 @@ export function authCauseBodyKey(cause: UnauthCause): string {
   }
 }
 
-/**
- * Which surface the Reconnect button opens. Only OAuth providers have a browser
- * sign-in; sending an api-key provider through `launchLogin` is a guaranteed
- * 400 ("nvidia does not use OAuth sign-in") that flips the card to its failed
- * phase and dead-ends the user (HOU-1077) — those reconnect by re-pasting the
- * key in the same connect dialog settings uses. The local provider keeps its
- * guided endpoint dialog.
- */
-export type ReconnectSurface =
-  | "oauth_login"
-  | "api_key_dialog"
-  | "local_model_dialog";
-
-export function reconnectSurface(
-  providerId: string,
-  auth: "oauth" | "apiKey" | "openaiCompatible" | undefined,
-): ReconnectSurface {
-  if (providerId === "openai-compatible") return "local_model_dialog";
-  if (auth === "apiKey") return "api_key_dialog";
-  // OAuth — or an id the catalog doesn't resolve, where only the engine knows
-  // the method: the engine-side launch keeps its own non-OAuth guard.
-  return "oauth_login";
-}
-
 /** The action a button fires. A `badge` button is a disabled status pill. */
 export type AuthCardAction = "reconnect" | "cancel";
 
@@ -73,8 +49,49 @@ export interface AuthCardPresentation {
 }
 
 /**
+ * The `done` phase, parameterised by its title only: the bodies never name a
+ * provider, so the generic (unknown-provider) card reuses them verbatim and
+ * differs solely in the title it confirms with.
+ */
+function donePresentation(args: {
+  titleKey: string;
+  hasFailedPrompt: boolean;
+  hasRetry: boolean;
+}): AuthCardPresentation {
+  const { titleKey, hasFailedPrompt, hasRetry } = args;
+
+  if (hasFailedPrompt) {
+    return {
+      variant: "done",
+      titleKey,
+      bodyKey: `${K}.reconnectedResending`,
+      button: { kind: "badge", labelKey: `${K}.signedIn` },
+    };
+  }
+  if (hasRetry) {
+    return {
+      variant: "done",
+      titleKey,
+      bodyKey: `${K}.reconnectedResuming`,
+      button: { kind: "badge", labelKey: `${K}.signedIn` },
+    };
+  }
+  return {
+    variant: "done",
+    titleKey,
+    bodyKey: `${K}.reconnectedBody`,
+    button: null,
+  };
+}
+
+/**
  * Resolve the card's title/body/button from its phase.
  *
+ * - `hasProvider: false`: the error named no provider (nothing is connected at
+ *   all), so EVERY provider-named string is off the table — `{{provider}}`
+ *   would interpolate to an empty string, and the old guess ("anthropic") lied.
+ *   The card becomes a generic "connect an AI provider" prompt whose action
+ *   opens the AI Hub instead of a sign-in that cannot be launched.
  * - `done` with a retry handler: the resume already auto-fired, so the pill
  *   is a disabled "Signed in" badge. The body says what resumed: the refused
  *   send's message (`hasFailedPrompt`) or the interrupted task.
@@ -84,35 +101,41 @@ export interface AuthCardPresentation {
  */
 export function resolveAuthCardPresentation(args: {
   phase: LoginPhase;
+  hasProvider: boolean;
   hasFailedPrompt: boolean;
   hasRetry: boolean;
   causeBodyKey: string;
 }): AuthCardPresentation {
-  const { phase, hasFailedPrompt, hasRetry, causeBodyKey } = args;
+  const { phase, hasProvider, hasFailedPrompt, hasRetry, causeBodyKey } = args;
+
+  if (!hasProvider) {
+    if (phase === "done") {
+      return donePresentation({
+        titleKey: `${K}.reconnectedTitleGeneric`,
+        hasFailedPrompt,
+        hasRetry,
+      });
+    }
+    // idle / failed / waiting alike: the generic action never leaves the app
+    // for a browser, so there is no browser wait to narrate or cancel.
+    return {
+      variant: "active",
+      titleKey: `${K}.titleGeneric`,
+      bodyKey: `${K}.bodyGeneric`,
+      button: {
+        kind: "action",
+        labelKey: `${K}.connectProvider`,
+        action: "reconnect",
+      },
+    };
+  }
 
   if (phase === "done") {
-    if (hasFailedPrompt) {
-      return {
-        variant: "done",
-        titleKey: `${K}.reconnectedTitle`,
-        bodyKey: `${K}.reconnectedResending`,
-        button: { kind: "badge", labelKey: `${K}.signedIn` },
-      };
-    }
-    if (hasRetry) {
-      return {
-        variant: "done",
-        titleKey: `${K}.reconnectedTitle`,
-        bodyKey: `${K}.reconnectedResuming`,
-        button: { kind: "badge", labelKey: `${K}.signedIn` },
-      };
-    }
-    return {
-      variant: "done",
+    return donePresentation({
       titleKey: `${K}.reconnectedTitle`,
-      bodyKey: `${K}.reconnectedBody`,
-      button: null,
-    };
+      hasFailedPrompt,
+      hasRetry,
+    });
   }
 
   if (phase === "waiting") {

--- a/app/src/components/shell/provider-error-cards/auth.tsx
+++ b/app/src/components/shell/provider-error-cards/auth.tsx
@@ -2,50 +2,29 @@
  * UnauthenticatedCard — drives the user back into the provider's connect flow.
  * Body copy varies by cause (see `authCauseBodyKey`) so the user understands WHY
  * they must reconnect. The state -> title/body/button mapping lives in
- * `./auth-presentation`; this component owns only the side effects.
+ * `./auth-presentation`; every side effect (launch, cancel, auto-resume) lives
+ * in `./use-provider-login`. This component only renders what those two decide.
  *
- * Reconnect lifecycle (the button must not fire-and-forget): `launchLogin`
- * resolves when the engine STARTS sign-in, not when the user finishes in the
- * browser — completion arrives later as the `ProviderLoginComplete` event. So
- * the card holds a "finish in your browser" state (the pill becomes a Cancel
- * that frees the login slot and re-arms) until that event flips it to a green
- * confirmation, the failure, or a benign cancel.
- *
- * Signing in IS the remaining intent, so a successful reconnect resumes the
- * conversation automatically (once), then shows a disabled "Signed in" badge.
- * What gets sent depends on what failed: a refused SEND (`failed_prompt`: the
- * message never reached the engine) resends the original prompt; a mid-turn
- * failure sends a hidden auto-continue nudge (that turn already has
- * server-side context) — the split lives in the panel's `onRetry`.
- *
- * Every launch is cancelLogin -> launchLogin: the engine keeps one login slot
- * per provider and rejects a second launch as "already pending", so a relaunch
- * frees the slot first (cancelLogin is idempotent). The benign completion our
- * own cancel triggers is ignored via `relaunchingRef` so the card does not
- * flicker to idle mid-relaunch.
+ * When the error names NO provider (nothing is connected yet), the card drops
+ * every brand-specific element — glyph, name, sign-in launch — and becomes a
+ * generic "connect an AI provider" prompt that opens the AI Hub. Any provider's
+ * successful connect then satisfies it and triggers the same auto-resume.
  */
 
 import type { ProviderError } from "@houston-ai/chat";
-import type { HoustonEvent } from "@houston-ai/core";
-import { CheckCircle2Icon } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { CheckCircle2Icon, PlugZapIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { subscribeHoustonEvents } from "../../../lib/events";
-import { getProvider } from "../../../lib/providers";
-import { tauriProvider } from "../../../lib/tauri";
-import { useUIStore } from "../../../stores/ui";
 import { RowCard } from "../../cards/row-card";
 import { RowCardButton } from "../../cards/row-card-button";
 import { ProviderGlyph } from "../provider-logos";
 import {
   type AuthCardButton,
   authCauseBodyKey,
-  type LoginPhase,
-  reconnectSurface,
   resolveAuthCardPresentation,
 } from "./auth-presentation";
 import { ReconnectDialog } from "./reconnect-dialog";
 import { providerLabel } from "./shared";
+import { useProviderLogin } from "./use-provider-login";
 
 export function UnauthenticatedCard({
   error,
@@ -55,105 +34,13 @@ export function UnauthenticatedCard({
   onRetry?: () => Promise<void> | void;
 }) {
   const { t } = useTranslation(["shell", "common"]);
-  const setAuthRequired = useUIStore((s) => s.setAuthRequired);
-  const [phase, setPhase] = useState<LoginPhase>("idle");
-  const [launching, setLaunching] = useState(false);
-  const [failureDetail, setFailureDetail] = useState<string | null>(null);
-  const [retrying, setRetrying] = useState(false);
-  const [showConnectDialog, setShowConnectDialog] = useState(false);
-  const relaunchingRef = useRef(false);
-  // The auto-resend must fire ONCE per card — a second fire (the provider can
-  // complete several logins while the chat stays open) would double-send.
-  const autoResendFiredRef = useRef(false);
+  const login = useProviderLogin(error, onRetry);
+  const hasProvider = !!error.provider;
   const provider = providerLabel(error.provider);
-  // In a ref so the subscription mounts once (resubscribing per render could
-  // drop a completion event in the gap).
-  const onRetryRef = useRef(onRetry);
-  onRetryRef.current = onRetry;
-
-  useEffect(() => {
-    return subscribeHoustonEvents((ev: HoustonEvent) => {
-      if (ev.type !== "ProviderLoginComplete") return;
-      if (ev.data.provider !== error.provider) return;
-      if (ev.data.success) {
-        setPhase("done");
-        setFailureDetail(null);
-        // Login succeeded — clear the global flag so other surfaces (store
-        // reconnect card, error suppression) stop treating it as signed out.
-        if (useUIStore.getState().authRequired === error.provider) {
-          setAuthRequired(null);
-        }
-        if (onRetryRef.current && !autoResendFiredRef.current) {
-          autoResendFiredRef.current = true;
-          setRetrying(true);
-          void Promise.resolve(onRetryRef.current())
-            // The send surfaces its own failure (toast + Report bug); this
-            // catch only stops an unhandled rejection.
-            .catch(() => {})
-            .finally(() => setRetrying(false));
-        }
-      } else if (ev.data.error) {
-        setPhase("failed");
-        setFailureDetail(ev.data.error);
-      } else if (!relaunchingRef.current) {
-        // Benign cancel (user gave up on the OAuth tab) — re-arm quietly.
-        // Skipped when WE issued the cancel as the first half of a relaunch:
-        // the new login is spawning and the card must stay in its waiting state.
-        setPhase("idle");
-      }
-    });
-  }, [error.provider, setAuthRequired]);
-
-  // Which surface Reconnect opens: OAuth's browser login, the api-key paste
-  // dialog, or the local endpoint dialog. Non-OAuth providers must NEVER hit
-  // launchLogin — the engine 400s ("nvidia does not use OAuth sign-in") and
-  // the card dead-ends in its failed phase with no way out (HOU-1077). Both
-  // dialogs fire the same `ProviderLoginComplete` on a successful connect, so
-  // the auto-resume above runs for every surface.
-  const surface = reconnectSurface(
-    error.provider,
-    getProvider(error.provider)?.auth,
-  );
-
-  const reconnect = async () => {
-    if (launching) return;
-    if (surface !== "oauth_login") {
-      setFailureDetail(null);
-      setShowConnectDialog(true);
-      setPhase("waiting");
-      return;
-    }
-    setLaunching(true);
-    relaunchingRef.current = true;
-    setFailureDetail(null);
-    try {
-      await tauriProvider.cancelLogin(error.provider);
-      await tauriProvider.launchLogin(error.provider);
-      setPhase("waiting");
-    } catch {
-      setPhase("failed");
-    } finally {
-      relaunchingRef.current = false;
-      setLaunching(false);
-    }
-  };
-
-  const cancelSignIn = async () => {
-    // Dialog surfaces: nothing engine-side to cancel — close and re-arm.
-    if (surface !== "oauth_login") {
-      setShowConnectDialog(false);
-      setPhase("idle");
-      return;
-    }
-    try {
-      await tauriProvider.cancelLogin(error.provider);
-    } finally {
-      setPhase("idle");
-    }
-  };
 
   const pres = resolveAuthCardPresentation({
-    phase,
+    phase: login.phase,
+    hasProvider,
     hasFailedPrompt: !!error.failed_prompt,
     hasRetry: !!onRetry,
     causeBodyKey: authCauseBodyKey(error.cause),
@@ -170,18 +57,18 @@ export function UnauthenticatedCard({
           label={t(button.labelKey)}
           onClick={() => {}}
           disabled
-          loading={retrying}
+          loading={login.retrying}
           variant="outline"
         />
       );
     }
-    const handler = button.action === "cancel" ? cancelSignIn : reconnect;
+    const isCancel = button.action === "cancel";
     return (
       <RowCardButton
         label={t(button.labelKey)}
-        onClick={handler}
-        loading={button.action === "reconnect" ? launching : false}
-        variant={button.action === "cancel" ? "outline" : "default"}
+        onClick={isCancel ? login.cancelSignIn : login.reconnect}
+        loading={isCancel ? false : login.launching}
+        variant={isCancel ? "outline" : "default"}
       />
     );
   };
@@ -192,24 +79,30 @@ export function UnauthenticatedCard({
         media={
           pres.variant === "done" ? (
             <CheckCircle2Icon className="size-5 text-green-600" />
-          ) : (
+          ) : hasProvider ? (
             <ProviderGlyph providerId={error.provider} />
+          ) : (
+            // No id to draw: the glyph would fall back to a Monogram seeded
+            // from "" — an empty tile. A plug icon reads as "connect one".
+            <PlugZapIcon className="size-5" />
           )
         }
         title={t(pres.titleKey, { provider })}
-        description={t(pres.bodyKey, { provider, detail: failureDetail ?? "" })}
+        description={t(pres.bodyKey, {
+          provider,
+          detail: login.failureDetail ?? "",
+        })}
         action={renderButton(pres.button)}
       />
 
-      <ReconnectDialog
-        surface={surface}
-        providerId={error.provider}
-        open={showConnectDialog}
-        onClose={() => {
-          setShowConnectDialog(false);
-          setPhase((p) => (p === "waiting" ? "idle" : p));
-        }}
-      />
+      {login.surface && (
+        <ReconnectDialog
+          surface={login.surface}
+          providerId={error.provider}
+          open={login.showConnectDialog}
+          onClose={login.closeConnectDialog}
+        />
+      )}
     </div>
   );
 }

--- a/app/src/components/shell/provider-error-cards/not-connected.ts
+++ b/app/src/components/shell/provider-error-cards/not-connected.ts
@@ -1,4 +1,5 @@
 import type { FeedItem, ProviderError } from "@houston-ai/chat";
+import { preferredProvider } from "../../chat-effective-provider.ts";
 
 /**
  * Pure helpers for the not-connected reconnect card (HOU-676).
@@ -18,14 +19,39 @@ import type { FeedItem, ProviderError } from "@houston-ai/chat";
 /**
  * Label a provider-error card with THIS chat's provider when the engine
  * couldn't name one. Never rewrites a card that already names a provider —
- * a foreign provider's card must stay honest about who failed.
+ * a foreign provider's card must stay honest about who failed. With no
+ * provider to fill in (`null`), the card is left unlabeled rather than
+ * guessed at: see `errorCardProvider`.
  */
 export function resolveProviderErrorForChat(
   err: ProviderError,
-  chatProvider: string,
+  chatProvider: string | null,
 ): ProviderError {
   if (err.provider) return err;
+  if (!chatProvider) return err;
   return { ...err, provider: chatProvider };
+}
+
+/**
+ * The provider an UNLABELED error card may be attributed to — evidence only.
+ *
+ * Same evidence chain the composer resolves against (`preferredProvider`), so
+ * the two can never drift; what differs is the last resort. The composer's
+ * "anthropic" default is right for a fresh composer and wrong here: a guessed
+ * label sends the user to the wrong sign-in — OpenAI users were told to
+ * "Connect Anthropic". No evidence returns `null`, so the card stays generic
+ * and asks for no specific provider.
+ */
+export function errorCardProvider(args: {
+  activityProvider: string | null;
+  agentProvider: string | null;
+  lastUsedProvider: string | null;
+}): string | null {
+  return preferredProvider(
+    args.activityProvider,
+    args.agentProvider,
+    args.lastUsedProvider,
+  );
 }
 
 /**

--- a/app/src/components/shell/provider-error-cards/reconnect-dialog.tsx
+++ b/app/src/components/shell/provider-error-cards/reconnect-dialog.tsx
@@ -1,7 +1,7 @@
 import { getProvider } from "../../../lib/providers";
 import { LocalModelDialog } from "../local-model-dialog";
 import { ProviderApiKeyDialog } from "../provider-api-key-dialog";
-import type { ReconnectSurface } from "./auth-presentation";
+import type { ReconnectSurface } from "./reconnect-surface";
 
 /**
  * The non-OAuth reconnect surfaces of the `UnauthenticatedCard`: the SAME

--- a/app/src/components/shell/provider-error-cards/reconnect-surface.ts
+++ b/app/src/components/shell/provider-error-cards/reconnect-surface.ts
@@ -1,0 +1,28 @@
+/**
+ * Which connect surface a provider reconnects through. Routing, not copy — the
+ * card's state -> title/body/button mapping lives in `./auth-presentation`, the
+ * lifecycle in `./use-provider-login`, and the dialogs in `./reconnect-dialog`.
+ */
+
+/**
+ * Only OAuth providers have a browser sign-in; sending an api-key provider
+ * through `launchLogin` is a guaranteed 400 ("nvidia does not use OAuth
+ * sign-in") that flips the card to its failed phase and dead-ends the user
+ * (HOU-1077) — those reconnect by re-pasting the key in the same connect dialog
+ * settings uses. The local provider keeps its guided endpoint dialog.
+ */
+export type ReconnectSurface =
+  | "oauth_login"
+  | "api_key_dialog"
+  | "local_model_dialog";
+
+export function reconnectSurface(
+  providerId: string,
+  auth: "oauth" | "apiKey" | "openaiCompatible" | undefined,
+): ReconnectSurface {
+  if (providerId === "openai-compatible") return "local_model_dialog";
+  if (auth === "apiKey") return "api_key_dialog";
+  // OAuth — or an id the catalog doesn't resolve, where only the engine knows
+  // the method: the engine-side launch keeps its own non-OAuth guard.
+  return "oauth_login";
+}

--- a/app/src/components/shell/provider-error-cards/use-provider-login.ts
+++ b/app/src/components/shell/provider-error-cards/use-provider-login.ts
@@ -1,0 +1,188 @@
+/**
+ * The reconnect lifecycle behind `UnauthenticatedCard` — every side effect the
+ * card has, with none of its rendering. The component reads the phase this
+ * returns and maps it to copy through `resolveAuthCardPresentation`.
+ *
+ * The button must not fire-and-forget: `launchLogin` resolves when the engine
+ * STARTS sign-in, not when the user finishes in the browser — completion
+ * arrives later as the `ProviderLoginComplete` event. So the hook holds a
+ * "waiting" phase (the card turns its pill into a Cancel that frees the login
+ * slot and re-arms) until that event flips it to `done`, `failed`, or back to
+ * idle on a benign cancel.
+ *
+ * Signing in IS the remaining intent, so a successful reconnect resumes the
+ * conversation automatically (once). What gets sent depends on what failed: a
+ * refused SEND (`failed_prompt`: the message never reached the engine) resends
+ * the original prompt; a mid-turn failure sends a hidden auto-continue nudge
+ * (that turn already has server-side context) — the split lives in the panel's
+ * `onRetry`.
+ *
+ * Every launch is cancelLogin -> launchLogin: the engine keeps one login slot
+ * per provider and rejects a second launch as "already pending", so a relaunch
+ * frees the slot first (cancelLogin is idempotent). The benign completion our
+ * own cancel triggers is ignored via `relaunchingRef` so the card does not
+ * flicker to idle mid-relaunch.
+ */
+
+import type { ProviderError } from "@houston-ai/chat";
+import type { HoustonEvent } from "@houston-ai/core";
+import { useEffect, useRef, useState } from "react";
+import { subscribeHoustonEvents } from "../../../lib/events";
+import { getProvider } from "../../../lib/providers";
+import { tauriProvider } from "../../../lib/tauri";
+import { AI_HUB_VIEW_ID } from "../../../lib/top-level-views";
+import { useUIStore } from "../../../stores/ui";
+import type { LoginPhase } from "./auth-presentation";
+import { type ReconnectSurface, reconnectSurface } from "./reconnect-surface";
+
+export interface ProviderLogin {
+  phase: LoginPhase;
+  /** A launch is in flight (the Reconnect pill spins). */
+  launching: boolean;
+  /** The engine's reason for a failed sign-in, interpolated into the body. */
+  failureDetail: string | null;
+  /** The auto-resume is running (the "Signed in" badge spins). */
+  retrying: boolean;
+  showConnectDialog: boolean;
+  /** Which surface Reconnect opens; `null` when the error names no provider. */
+  surface: ReconnectSurface | null;
+  reconnect: () => Promise<void>;
+  cancelSignIn: () => Promise<void>;
+  closeConnectDialog: () => void;
+}
+
+export function useProviderLogin(
+  error: Extract<ProviderError, { kind: "unauthenticated" }>,
+  onRetry?: () => Promise<void> | void,
+): ProviderLogin {
+  const setAuthRequired = useUIStore((s) => s.setAuthRequired);
+  const setViewMode = useUIStore((s) => s.setViewMode);
+  const [phase, setPhase] = useState<LoginPhase>("idle");
+  const [launching, setLaunching] = useState(false);
+  const [failureDetail, setFailureDetail] = useState<string | null>(null);
+  const [retrying, setRetrying] = useState(false);
+  const [showConnectDialog, setShowConnectDialog] = useState(false);
+  const relaunchingRef = useRef(false);
+  // The auto-resend must fire ONCE per card — a second fire (the provider can
+  // complete several logins while the chat stays open) would double-send.
+  const autoResendFiredRef = useRef(false);
+  // In a ref so the subscription mounts once (resubscribing per render could
+  // drop a completion event in the gap).
+  const onRetryRef = useRef(onRetry);
+  onRetryRef.current = onRetry;
+
+  useEffect(() => {
+    return subscribeHoustonEvents((ev: HoustonEvent) => {
+      if (ev.type !== "ProviderLoginComplete") return;
+      if (error.provider) {
+        if (ev.data.provider !== error.provider) return;
+      } else if (!ev.data.success) {
+        // No provider on the error: ANY connect satisfies this card, so a
+        // SUCCESS must not be filtered out — the auto-resume below has to
+        // fire. A failure is a different story: this card launched nothing,
+        // so an unrelated provider's failed or abandoned login says nothing
+        // about it and must not move its phase.
+        return;
+      }
+      if (ev.data.success) {
+        setPhase("done");
+        setFailureDetail(null);
+        // Login succeeded — clear the global flag so other surfaces (store
+        // reconnect card, error suppression) stop treating it as signed out.
+        // Keyed off the COMPLETED provider (identical to `error.provider` on
+        // the guarded path above, and the only known id on the generic one).
+        if (useUIStore.getState().authRequired === ev.data.provider) {
+          setAuthRequired(null);
+        }
+        if (onRetryRef.current && !autoResendFiredRef.current) {
+          autoResendFiredRef.current = true;
+          setRetrying(true);
+          void Promise.resolve(onRetryRef.current())
+            // The send surfaces its own failure (toast + Report bug); this
+            // catch only stops an unhandled rejection.
+            .catch(() => {})
+            .finally(() => setRetrying(false));
+        }
+      } else if (ev.data.error) {
+        setPhase("failed");
+        setFailureDetail(ev.data.error);
+      } else if (!relaunchingRef.current) {
+        // Benign cancel (user gave up on the OAuth tab) — re-arm quietly.
+        // Skipped when WE issued the cancel as the first half of a relaunch:
+        // the new login is spawning and the card must stay in its waiting state.
+        setPhase("idle");
+      }
+    });
+  }, [error.provider, setAuthRequired]);
+
+  // Which surface Reconnect opens: OAuth's browser login, the api-key paste
+  // dialog, or the local endpoint dialog. Non-OAuth providers must NEVER hit
+  // launchLogin — the engine 400s ("nvidia does not use OAuth sign-in") and
+  // the card dead-ends in its failed phase with no way out (HOU-1077). Both
+  // dialogs fire the same `ProviderLoginComplete` on a successful connect, so
+  // the auto-resume above runs for every surface. No provider = no surface:
+  // `reconnectSurface` defaults unknown ids to that same dead-ending login.
+  const surface = error.provider
+    ? reconnectSurface(error.provider, getProvider(error.provider)?.auth)
+    : null;
+
+  const reconnect = async () => {
+    if (launching) return;
+    // Nothing to sign in to: hand the user the AI Hub, the one surface that
+    // lists every provider and owns the connect flow (OAuth / api-key / local).
+    if (!surface) {
+      setViewMode(AI_HUB_VIEW_ID);
+      return;
+    }
+    if (surface !== "oauth_login") {
+      setFailureDetail(null);
+      setShowConnectDialog(true);
+      setPhase("waiting");
+      return;
+    }
+    setLaunching(true);
+    relaunchingRef.current = true;
+    setFailureDetail(null);
+    try {
+      await tauriProvider.cancelLogin(error.provider);
+      await tauriProvider.launchLogin(error.provider);
+      setPhase("waiting");
+    } catch {
+      setPhase("failed");
+    } finally {
+      relaunchingRef.current = false;
+      setLaunching(false);
+    }
+  };
+
+  const cancelSignIn = async () => {
+    // Dialog surfaces: nothing engine-side to cancel — close and re-arm.
+    if (surface !== "oauth_login") {
+      setShowConnectDialog(false);
+      setPhase("idle");
+      return;
+    }
+    try {
+      await tauriProvider.cancelLogin(error.provider);
+    } finally {
+      setPhase("idle");
+    }
+  };
+
+  const closeConnectDialog = () => {
+    setShowConnectDialog(false);
+    setPhase((p) => (p === "waiting" ? "idle" : p));
+  };
+
+  return {
+    phase,
+    launching,
+    failureDetail,
+    retrying,
+    showConnectDialog,
+    surface,
+    reconnect,
+    cancelSignIn,
+    closeConnectDialog,
+  };
+}

--- a/app/src/components/tabs/use-agent-shared-skills.ts
+++ b/app/src/components/tabs/use-agent-shared-skills.ts
@@ -4,6 +4,7 @@ import { useCapabilities } from "../../hooks/use-capabilities";
 import { analytics } from "../../lib/analytics";
 import { logger } from "../../lib/logger";
 import { queryKeys } from "../../lib/query-keys";
+import { sharedSkillsAvailable } from "../../lib/shared-skills-availability";
 import { tauriSharedSkills, tauriSkillsManifest } from "../../lib/tauri";
 import type { SkillSummary } from "../../lib/types";
 import { useWorkspaceStore } from "../../stores/workspaces";
@@ -34,22 +35,32 @@ export function useAgentSharedSkills(agentPath: string): {
   const queryClient = useQueryClient();
   const { capabilities } = useCapabilities();
   const workspaceId = useWorkspaceStore((s) => s.current?.id ?? null);
-  const available = capabilities?.sharedSkills === true && workspaceId !== null;
+  const advertised =
+    capabilities?.sharedSkills === true && workspaceId !== null;
 
   const shared = useQuery({
     queryKey: queryKeys.sharedSkills(workspaceId ?? ""),
     queryFn: () => tauriSharedSkills.list(workspaceId ?? ""),
-    enabled: available,
+    enabled: advertised,
     staleTime: Number.POSITIVE_INFINITY,
     refetchOnWindowFocus: false,
   });
+  // The manifest is agent-local and independent of the store, so it loads in
+  // PARALLEL with the store query — gating it on the store's answer would
+  // serialize two round trips for every configured deployment.
   const manifest = useQuery({
     queryKey: queryKeys.skillsManifest(agentPath),
     queryFn: () => tauriSkillsManifest.get(agentPath),
-    enabled: available,
+    enabled: advertised,
     staleTime: Number.POSITIVE_INFINITY,
     refetchOnWindowFocus: false,
   });
+
+  // The gateway advertises `capabilities.sharedSkills` unconditionally, even
+  // where no skill store is actually bound — so the store's own answer is the
+  // last word: the section hides rather than showing a permanently empty
+  // "From your workspace" (HOU-1153).
+  const available = sharedSkillsAvailable(advertised, shared.data);
 
   const [busy, setBusy] = useState<string | null>(null);
   const setEnabled = async (slug: string, on: boolean) => {

--- a/app/src/components/tabs/use-routine-chat-setup.ts
+++ b/app/src/components/tabs/use-routine-chat-setup.ts
@@ -60,6 +60,11 @@ export function useRoutineChatSetup(
   // probe (HOU-979): "we could not check" is not "nothing is connected", so it
   // defers to the generic prompt rather than naming a partial list as if it
   // were the whole truth. Membership itself is the ONE shared derivation.
+  //
+  // A FAILED probe (HOU-1153) is the same "we could not check", and it arrives
+  // with NO statuses rather than a map of `unknown`s — so it must defer through
+  // `isError`, or an empty map would be handed to the kickoff as a confident
+  // "you have nothing connected".
   const providerStatuses = useProviderStatuses();
   const statusValues = Object.values(providerStatuses.statuses);
   const statusesUnconfirmable = statusValues.some(
@@ -67,7 +72,9 @@ export function useRoutineChatSetup(
   );
   const connectedProvidersRef = useRef<ConnectedProviderRef[] | null>(null);
   connectedProvidersRef.current =
-    providerStatuses.isLoading || statusesUnconfirmable
+    providerStatuses.isLoading ||
+    providerStatuses.isError ||
+    statusesUnconfirmable
       ? null
       : statusValues
           .filter((s) => providerIsConnected(s))

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -162,6 +162,7 @@ import { SelectedSkillChip } from "./selected-skill-chip";
 import { ProviderErrorCard } from "./shell/provider-error-card";
 import {
   continuesTaskAfterReconnect,
+  errorCardProvider,
   isInlineAuthCard,
   providerErrorRetryText,
   reconnectContinueText,
@@ -1874,6 +1875,15 @@ export function useAgentChatPanel({
     },
     [attachmentLabels],
   );
+  // What an UNLABELED provider-error card may be attributed to: evidence
+  // only, never the composer's "anthropic" last resort — a guessed label sends
+  // the user to the wrong sign-in (OpenAI users were told to "Connect
+  // Anthropic"). No evidence leaves the card generic.
+  const cardProvider = errorCardProvider({
+    activityProvider,
+    agentProvider,
+    lastUsedProvider,
+  });
   const renderSystemMessage = useCallback(
     (msg: ChatMessage) => {
       if (msg.compaction)
@@ -1918,11 +1928,12 @@ export function useAgentChatPanel({
       // OpenAI reconnect card never appeared in chat.
       if (msg.providerError) {
         // The not-connected card arrives provider-less (the refusal can't name
-        // one — nothing was connected); label it with THIS chat's provider so
-        // its reconnect flow targets the provider the send actually used.
+        // one — nothing was connected); label it only from evidence of what
+        // this chat actually used, so its reconnect flow targets that provider
+        // and never a guessed one.
         const providerError = resolveProviderErrorForChat(
           msg.providerError,
-          displayModelPin.provider,
+          cardProvider,
         );
         return (
           <ProviderErrorCard
@@ -1979,7 +1990,15 @@ export function useAgentChatPanel({
       if (isProviderAuthMessage(msg.content)) return null;
       return undefined;
     },
-    [displayModelPin, turnMode, selectModel, path, selectedSessionKey, t],
+    [
+      displayModelPin,
+      cardProvider,
+      turnMode,
+      selectModel,
+      path,
+      selectedSessionKey,
+      t,
+    ],
   );
   // The welcome chat's greeting (HOU-713): a hardcoded, localized agent
   // message derived from the `welcome-` session key — prepended at render

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -58,6 +58,7 @@ import {
   useSkills,
 } from "../hooks/queries";
 import { useCapabilities } from "../hooks/use-capabilities";
+import { useConnectAiComposer } from "../hooks/use-connect-ai-composer";
 import {
   useConversationFeed,
   useConversationVm,
@@ -541,7 +542,11 @@ export function useAgentChatPanel({
   // rather than a stale preference, so a no-provider agent never lands on a
   // logged-out account (#483) — and an unconfirmable probe is kept separate, so
   // it neither becomes a fallback target nor disqualifies the preferred one.
-  const { statuses: providerStatuses } = useProviderStatuses();
+  const {
+    statuses: providerStatuses,
+    isLoading: providerStatusesLoading,
+    isError: providerStatusesError,
+  } = useProviderStatuses();
   const authedProviders = useMemo(
     () =>
       Object.values(providerStatuses)
@@ -556,6 +561,18 @@ export function useAgentChatPanel({
         .map((s) => s.provider),
     [providerStatuses],
   );
+
+  // With nothing connected the composer had no honest job: its picker showed a
+  // phantom model (the effective-provider default) and its textarea accepted a
+  // message no provider could answer. The whole input area is replaced by one
+  // CTA into the AI Hub, and returns by itself once a provider connects (the
+  // status query is invalidated on ProviderLoginComplete).
+  const connectAiComposer = useConnectAiComposer({
+    connectedCount: authedProviders.length,
+    checkingCount: unconfirmedProviders.length,
+    statusesLoading: providerStatusesLoading,
+    statusesError: providerStatusesError,
+  });
 
   // This conversation's reactive feed — the SDK conversation VM, the app's one
   // turn-state source (history seeded by the adapter on load; live turns
@@ -1484,6 +1501,11 @@ export function useAgentChatPanel({
     mode: "above" | "replace";
   }>(() => {
     const none = { node: undefined, mode: "above" as const };
+    // No AI model connected wins over everything: there is no provider to run a
+    // stepper's turn or a plan against either, so the connect CTA is the only
+    // thing the composer slot can honestly offer.
+    if (connectAiComposer.node)
+      return { mode: "replace" as const, node: connectAiComposer.node };
     if (!agent || !activeInteraction) return none;
     // Abandoned interactions stay suppressed while this conversation is open,
     // whatever their kind, and the composer stands alone.
@@ -1798,6 +1820,7 @@ export function useAgentChatPanel({
       ),
     };
   }, [
+    connectAiComposer.node,
     agent,
     activeInteraction,
     interactionKey,
@@ -2058,6 +2081,13 @@ export function useAgentChatPanel({
       // One card per chat, and the inline one carries the true provider.
       const hasInlineAuthCard = feedItems.some(isInlineAuthCard);
       if (hasInlineAuthCard) return null;
+      // The connect-AI empty state already owns the one "connect a model" CTA
+      // for this chat, and it says the truer thing (nothing is connected at
+      // all, versus this provider needs reconnecting). Two CTAs stacked would
+      // just make the user choose between them. Inline historical
+      // provider-error cards in the transcript are untouched — they are a
+      // record of what happened, not an action.
+      if (connectAiComposer.active) return null;
       const signalKey = providerAuthSignalKey(feedItems);
       // Always hand the card THIS chat's provider so it can match the global
       // `authRequired` flag against the provider this chat actually uses — a
@@ -2070,7 +2100,7 @@ export function useAgentChatPanel({
         />
       );
     },
-    [effectiveProvider],
+    [effectiveProvider, connectAiComposer.active],
   );
 
   // Shared-agent clarity (contract §6): when the agent is shared with more than

--- a/app/src/hooks/use-chat-model-picker.tsx
+++ b/app/src/hooks/use-chat-model-picker.tsx
@@ -1,6 +1,6 @@
 /**
  * The interaction half of `ChatModelSelector`: owns the popover open state and
- * the select handler, wires the "Connect more providers…" footer to the AI Hub,
+ * the select handler, wires the "Connect another AI…" footer to the AI Hub,
  * and wraps the derived view-models (`usePickerViewModels`) into the single
  * object the container's JSX renders. Split from both the component and the
  * derivation hook so each stays under the file-size budget.
@@ -114,7 +114,7 @@ export function useChatModelPicker(opts: {
     [onSelect, setOpen],
   );
 
-  // "Connect more providers…" leaves chat for the AI Hub — the one surface that
+  // "Connect another AI…" leaves chat for the AI Hub — the one surface that
   // lists every provider and owns the full connect flow (OAuth / api-key /
   // local). The per-provider inline connect cards are gone: disconnected
   // providers never appear in the picker anymore.

--- a/app/src/hooks/use-connect-ai-composer.tsx
+++ b/app/src/hooks/use-connect-ai-composer.tsx
@@ -1,0 +1,87 @@
+/**
+ * Wires the connect-AI composer replacement: reads the remaining world signals
+ * (catalog, capabilities, active space), applies the pure rule
+ * (`shouldReplaceComposerWithConnectAi`), and returns the node the chat panel
+ * hands to `composerOverride` in `replace` mode.
+ *
+ * The connection counts come in as PROPS rather than being re-derived here: the
+ * chat panel already computes them from the ONE shared derivation
+ * (`providerIsConnected` / `providerConnectionState`), and a second derivation
+ * is exactly how two surfaces drift apart about whether a provider is connected.
+ *
+ * Reactivity is free: `useProviderStatuses` (whose settled counts feed this) is
+ * a TanStack query invalidated on `ProviderLoginComplete`, so connecting a
+ * provider re-probes, the count goes above zero, and the composer returns with
+ * no manual wiring.
+ */
+
+import { type ReactNode, useCallback, useMemo } from "react";
+import { ChatConnectAiEmptyState } from "../components/chat-connect-ai-empty-state.tsx";
+import { pickerEmptyState } from "../components/chat-model-selector-labels.ts";
+import { shouldReplaceComposerWithConnectAi } from "../lib/composer-connect-ai.ts";
+import { isTeamWorkspace } from "../lib/space-id.ts";
+import { AI_HUB_VIEW_ID } from "../lib/top-level-views.ts";
+import { useUIStore } from "../stores/ui";
+import { useWorkspaceStore } from "../stores/workspaces";
+import { useCapabilities } from "./use-capabilities";
+import { useProviderCatalog } from "./use-provider-catalog";
+
+export interface ConnectAiComposer {
+  /** True while the empty state stands in for the composer. */
+  active: boolean;
+  /** The replacement node, or null when the normal composer stands. */
+  node: ReactNode | null;
+}
+
+export function useConnectAiComposer(opts: {
+  /** Providers confirmed connected. */
+  connectedCount: number;
+  /** Providers whose probe is still inconclusive. */
+  checkingCount: number;
+  /** `useProviderStatuses().isLoading`. */
+  statusesLoading: boolean;
+  /** `useProviderStatuses().isError`. */
+  statusesError: boolean;
+}): ConnectAiComposer {
+  const { connectedCount, checkingCount, statusesLoading, statusesError } =
+    opts;
+  const { capabilities, isLoading: capabilitiesLoading } = useCapabilities();
+  const { isReady: catalogReady } = useProviderCatalog();
+  const workspaceId = useWorkspaceStore((s) => s.current?.id ?? null);
+  const setViewMode = useUIStore((s) => s.setViewMode);
+
+  // Same decision the picker's empty state makes, from the same helper: which
+  // story to tell, and whether this viewer may act on it at all.
+  const { variant, canConnect } = pickerEmptyState({
+    teamSpace: workspaceId ? isTeamWorkspace(workspaceId) : false,
+    capabilities,
+    capabilitiesLoaded: !capabilitiesLoading,
+  });
+
+  const active = shouldReplaceComposerWithConnectAi({
+    statusesLoading,
+    statusesError,
+    connectedCount,
+    checkingCount,
+    catalogReady,
+    capabilitiesLoaded: !capabilitiesLoading,
+  });
+
+  const goToAiHub = useCallback(
+    () => setViewMode(AI_HUB_VIEW_ID),
+    [setViewMode],
+  );
+
+  const node = useMemo<ReactNode | null>(
+    () =>
+      active ? (
+        <ChatConnectAiEmptyState
+          variant={variant}
+          onConnect={canConnect ? goToAiHub : undefined}
+        />
+      ) : null,
+    [active, variant, canConnect, goToAiHub],
+  );
+
+  return { active, node };
+}

--- a/app/src/hooks/use-migration-reconnect.ts
+++ b/app/src/hooks/use-migration-reconnect.ts
@@ -58,10 +58,17 @@ export function useMigrationReconnect(): MigrationReconnectState {
     staleTime: 30_000,
   });
 
-  const { statuses, isLoading: statusesLoading } = useProviderStatuses();
+  const {
+    statuses,
+    isLoading: statusesLoading,
+    isError: statusesError,
+  } = useProviderStatuses();
   // Both provider signals come from the ONE shared derivation (HOU-979): an
   // `unknown` probe is "not yet known", never "not connected", so it defers the
-  // gate rather than firing it at a migrated user who IS connected.
+  // gate rather than firing it at a migrated user who IS connected. A FAILED
+  // probe says exactly the same thing and arrives with no statuses at all
+  // (HOU-1153), so it defers through `statusesError` below — without that the
+  // empty map would read as a confident "nothing is connected".
   const { hasProvider, unconfirmable } = migrationProviderSignals(
     Object.values(statuses),
   );
@@ -89,6 +96,7 @@ export function useMigrationReconnect(): MigrationReconnectState {
       (coLocated && migratedQuery.isLoading) ||
       dismissedQuery.isLoading ||
       statusesLoading ||
+      statusesError ||
       unconfirmable,
   });
 

--- a/app/src/hooks/use-provider-statuses.ts
+++ b/app/src/hooks/use-provider-statuses.ts
@@ -35,7 +35,7 @@ export interface ProviderStatusesState {
    * but `unknown`s, which means the engine was unreachable (HOU-1153). Consumers
    * that make a claim about the world (the connect-AI composer's "you have no
    * AI connected") must fail closed on this; the picker settles on its
-   * "Connect more providers" state, because a spinner with no end is worse.
+   * "Connect another AI" state, because a spinner with no end is worse.
    */
   isError: boolean;
 }

--- a/app/src/hooks/use-provider-statuses.ts
+++ b/app/src/hooks/use-provider-statuses.ts
@@ -2,9 +2,12 @@ import { useQuery } from "@tanstack/react-query";
 import { newEngineActive } from "../lib/engine";
 import { osIsTauri } from "../lib/os-bridge";
 import {
+  classifyStatusScan,
+  ProviderProbeUnreachableError,
   providerProbeReady,
   providerStatusesLoading,
   providerStatusesQueryKey,
+  providerStatusesRefetchInterval,
 } from "../lib/provider-statuses-query";
 import {
   EMPTY_PROVIDER_CAPABILITIES,
@@ -27,6 +30,13 @@ export interface ProviderStatusesState {
    * flickers back to "checking".
    */
   isLoading: boolean;
+  /**
+   * The probe FAILED — including the case where it "succeeded" with nothing
+   * but `unknown`s, which means the engine was unreachable (HOU-1153). Consumers
+   * that make a claim about the world (the connect-AI composer's "you have no
+   * AI connected") must fail closed on this; the picker settles on its
+   * "Connect more providers" state, because a spinner with no end is worse.
+   */
   isError: boolean;
 }
 
@@ -56,6 +66,17 @@ export interface ProviderStatusesState {
  * The gate is the natural refetch trigger too: `enabled` flipping true once
  * agents settle makes TanStack fetch the new space's key immediately, with no
  * hand-rolled effect.
+ *
+ * UNREACHABLE IS AN ERROR (HOU-1153). The engine adapter's batched probe never
+ * rejects: a host still booting, a cold pod, or unsettled per-agent routing all
+ * resolve every provider as `unknown`. Taken at face value that is a settled
+ * answer, so nothing ever retried — the picker sat on "Loading providers…"
+ * indefinitely and the connect-AI composer never appeared. Here the RESULT is
+ * classified (`classifyStatusScan`) and an information-free scan is thrown, so
+ * the query carries a real error state and a bounded re-probe
+ * (`providerStatusesRefetchInterval`) lands the definitive answer seconds later
+ * with no user action. The AI-hub's sibling hook keeps consuming the raw
+ * all-unknown shape on purpose — it has a last-known snapshot to protect.
  */
 export function useProviderStatuses(): ProviderStatusesState {
   const { capabilities } = useCapabilities();
@@ -92,10 +113,28 @@ export function useProviderStatuses(): ProviderStatusesState {
       // ONE round-trip for every provider (HOU-650): on the new engine this is a
       // single listProviders(), versus the old per-provider probe that fired N
       // identical round-trips to the agent's sandbox each time the picker opened.
-      return tauriProvider.checkAllStatuses(providers.map((p) => p.id));
+      const ids = providers.map((p) => p.id);
+      const scan = await tauriProvider.checkAllStatuses(ids);
+      // The adapter never rejects — an unreachable engine resolves every
+      // provider as `unknown` (HOU-1153). Reject on that shape so this query
+      // has an ERROR state: without it the picker read "every provider is
+      // checking" as a settled answer and spun forever.
+      if (classifyStatusScan(ids, scan) === "unreachable")
+        throw new ProviderProbeUnreachableError();
+      return scan;
     },
     enabled: probeReady,
     staleTime: 30_000,
+    // The client default is `retry: false`; a probe against a host that is
+    // merely booting deserves one immediate second chance before the picker
+    // settles on its empty state. Deliberately small — the re-probe below is
+    // what actually carries the recovery, on a predictable cadence rather than
+    // an ever-growing backoff.
+    retry: 1,
+    // Self-heal: keep re-probing while the last answer was a failure, and stop
+    // dead once a definitive one lands.
+    refetchInterval: (query) =>
+      providerStatusesRefetchInterval({ status: query.state.status }),
   });
 
   return {

--- a/app/src/lib/chat-model-picker-map.test.mjs
+++ b/app/src/lib/chat-model-picker-map.test.mjs
@@ -206,7 +206,7 @@ test("buildPickerProviders: keeps only providers that own models, with connectio
     [
       ["testprov", "connected"],
       // No status + not loading → disconnected (the picker hides it; the only
-      // path to it is the "Connect more providers…" footer).
+      // path to it is the "Connect another AI…" footer).
       ["openrouter", "disconnected"],
     ],
   );

--- a/app/src/lib/composer-connect-ai.ts
+++ b/app/src/lib/composer-connect-ai.ts
@@ -1,6 +1,6 @@
 /**
  * The one rule that decides whether the chat composer is replaced by the
- * "Connect an AI model" empty state.
+ * "Connect AI" empty state.
  *
  * Why it exists: with NO provider connected the composer still rendered a full
  * input row — a model picker showing a phantom model (the effective-provider

--- a/app/src/lib/composer-connect-ai.ts
+++ b/app/src/lib/composer-connect-ai.ts
@@ -1,0 +1,58 @@
+/**
+ * The one rule that decides whether the chat composer is replaced by the
+ * "Connect an AI model" empty state.
+ *
+ * Why it exists: with NO provider connected the composer still rendered a full
+ * input row — a model picker showing a phantom model (the effective-provider
+ * default resolves to `anthropic` even when nothing is logged in) and a textarea
+ * that accepts a message no provider can answer. Typing into a dead end is the
+ * worst possible first state, so the whole input area is swapped for one honest
+ * CTA into the AI Hub.
+ *
+ * The rule is deliberately CONSERVATIVE — every uncertain signal keeps the
+ * normal composer, because a composer that flashes away and back on boot reads
+ * as a broken app, while a composer that lingers one beat too long reads as
+ * nothing at all. Concretely, we replace only when all four of these hold:
+ *
+ *  1. the provider probe has SETTLED (`statusesLoading` false — which already
+ *     folds in the space gate; see `provider-statuses-query.ts`) and did not
+ *     fail: an errored probe knows nothing, it does not know "zero";
+ *  2. nothing is still "checking" — an unconfirmable probe may yet confirm;
+ *  3. the provider catalog and the deployment capabilities have both landed, so
+ *     we are not judging emptiness against a half-hydrated world; and
+ *  4. exactly zero providers are confirmed connected.
+ *
+ * Pure and dependency-free so the whole decision is unit-testable without a
+ * React renderer or a QueryClient.
+ */
+
+/** Every signal the decision reads. */
+export interface ConnectAiComposerSignals {
+  /** `useProviderStatuses().isLoading` — first probe, no cached data yet. */
+  statusesLoading: boolean;
+  /** `useProviderStatuses().isError` — the probe failed outright. */
+  statusesError: boolean;
+  /** Providers confirmed connected (`providerIsConnected`). */
+  connectedCount: number;
+  /** Providers whose probe is inconclusive (`providerConnectionState` "checking"). */
+  checkingCount: number;
+  /** `useProviderCatalog().isReady` — the runnable provider/model set landed. */
+  catalogReady: boolean;
+  /** `useCapabilities()` settled — the deployment described itself. */
+  capabilitiesLoaded: boolean;
+}
+
+/**
+ * Whether the composer should be replaced by the connect-AI empty state.
+ *
+ * See the module comment for why every branch below fails CLOSED (keeps the
+ * normal composer) rather than guessing at emptiness.
+ */
+export function shouldReplaceComposerWithConnectAi(
+  signals: ConnectAiComposerSignals,
+): boolean {
+  if (signals.statusesLoading || signals.statusesError) return false;
+  if (!signals.catalogReady || !signals.capabilitiesLoaded) return false;
+  if (signals.checkingCount > 0) return false;
+  return signals.connectedCount === 0;
+}

--- a/app/src/lib/provider-statuses-query.ts
+++ b/app/src/lib/provider-statuses-query.ts
@@ -19,6 +19,9 @@
  * two hooks cannot drift apart again.
  */
 
+import { scanIsUnreachable } from "../hooks/provider-connections/unreachable-scan.ts";
+import type { ProviderStatus } from "./tauri.ts";
+
 /** The agent-store signals the gate reads. */
 export interface AgentsSettledSignals {
   /** True once `loadAgents` has settled at least once (even on failure). */
@@ -76,4 +79,64 @@ export function providerStatusesLoading(opts: {
 }): boolean {
   if (opts.hasData) return false;
   return opts.queryIsLoading || !opts.probeReady;
+}
+
+/**
+ * What a resolved `checkAllStatuses` scan is actually worth (HOU-1153).
+ *
+ * The engine adapter's batched `providerStatuses()` NEVER rejects: an
+ * unreachable engine (a host still booting, a cold pod, a wedged sidecar), and
+ * the window where per-agent routing has not settled, both resolve every
+ * provider as `unknown`. That shape is indistinguishable from a fetch that
+ * succeeded, so the picker's query settled "successfully" knowing nothing —
+ * `unknown` renders as `checking`, and the picker spun on "Loading providers…"
+ * for good while the connect-AI composer (which fails closed on anything
+ * `checking`) never appeared.
+ *
+ * So the picker classifies the RESULT instead of trusting the resolution. An
+ * all-unknown scan is a probe FAILURE and must be thrown, which is what buys
+ * the retry, the honest error state, and the re-probe below.
+ *
+ * The AI hub's sibling hook keeps consuming the raw all-unknown shape on
+ * purpose — it has a last-known painted snapshot to protect, so it drops the
+ * scan silently rather than surfacing a failure.
+ */
+export type StatusScanClassification = "definitive" | "unreachable";
+
+/** Classify a scan; see {@link StatusScanClassification}. */
+export function classifyStatusScan(
+  probedIds: readonly string[],
+  byId: Record<string, ProviderStatus>,
+): StatusScanClassification {
+  return scanIsUnreachable(probedIds, byId) ? "unreachable" : "definitive";
+}
+
+/** The rejection an unreachable scan produces, so the failure is typed rather
+ *  than a bare string the UI would have to pattern-match. */
+export class ProviderProbeUnreachableError extends Error {
+  constructor() {
+    super("Could not reach the engine to check provider connections.");
+    this.name = "ProviderProbeUnreachableError";
+  }
+}
+
+/** How often the picker re-probes while the last answer was a failure. Short
+ *  enough that a host which was merely booting is picked up within a beat of
+ *  becoming ready, long enough not to hammer one that is genuinely down. */
+export const PROVIDER_STATUS_REPROBE_MS = 5_000;
+
+/**
+ * The self-heal timer (HOU-1153): while the last probe FAILED, keep re-probing;
+ * the moment a definitive answer lands, stop.
+ *
+ * This is what closes the loop with no user action — a host that answered
+ * "still booting" is reachable seconds later, and the next tick lands the real
+ * statuses. `pending` deliberately gets no timer: TanStack's own retry/backoff
+ * owns the first-fetch window, and a second schedule on top of it would stack
+ * overlapping probes.
+ */
+export function providerStatusesRefetchInterval(query: {
+  status: "pending" | "error" | "success";
+}): number | false {
+  return query.status === "error" ? PROVIDER_STATUS_REPROBE_MS : false;
 }

--- a/app/src/lib/shared-skills-availability.ts
+++ b/app/src/lib/shared-skills-availability.ts
@@ -1,0 +1,64 @@
+// The "does this deployment run shared skills at all?" classifier. Dependency-
+// free so it is node-testable directly (app/tests/shared-skills-availability.test.ts)
+// and importable from anywhere.
+//
+// Sibling of `network-transport-error.ts` and `missing-skill.ts`: a small,
+// typed predicate over an engine error shape, used to decide how a failure is
+// SURFACED — never to decide whether it is reported.
+
+/**
+ * The gateway's word for "no blob store is bound to this deployment, so there
+ * is no workspace skill store" (`cloud/internal/edge/shared_skills_routes.go`,
+ * `sharedSkillsNotConfigured`). It answers `503 {"error": <this>}` for every
+ * shared-skills route.
+ *
+ * The gateway's `/v1/capabilities` cannot be used to gate the call instead: it
+ * reports `sharedSkills: true` unconditionally, independent of whether the
+ * blob store is actually bound, so the 503 body is the only honest signal the
+ * client gets. (Fixing the capability flag is a gateway change; until then the
+ * client must read the wire.)
+ */
+export const SHARED_SKILLS_UNCONFIGURED = "shared skills not configured";
+
+/**
+ * True when a shared-skills call failed because the deployment does not run
+ * shared skills.
+ *
+ * This is feature ABSENCE, not failure: nothing broke, nothing is retryable,
+ * and there is no bug to report. The Skills surfaces render their empty state
+ * and the polling stops, instead of a red "Houston, we have a problem!" toast
+ * re-firing every time a Skills view mounts (HOU-1153). Every OTHER shared-
+ * skills failure — a real 5xx, an auth rejection, a malformed answer — is
+ * rethrown and toasts exactly as before, so the no-silent-failures policy
+ * holds.
+ *
+ * Keys on the structural `.status` + body the `HoustonEngineError` carries,
+ * never on the rendered message string.
+ */
+export function isSharedSkillsUnconfiguredError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as { status?: unknown; body?: unknown };
+  if (e.status !== 503) return false;
+  const body = e.body as { error?: unknown } | null;
+  return body?.error === SHARED_SKILLS_UNCONFIGURED;
+}
+
+/**
+ * Whether a shared-skills surface should render at all.
+ *
+ * Two signals, and the store's own answer is the last word: the gateway
+ * reports `capabilities.sharedSkills: true` unconditionally, so `advertised`
+ * alone would render a workspace-store section that can never hold anything.
+ * `configured: false` — the typed answer `tauriSharedSkills.list` returns for
+ * a deployment with no store — hides it instead.
+ *
+ * While the list is still loading (`undefined`) the surface stays available:
+ * the optimistic default keeps the section from flickering out and back in on
+ * every deployment that DOES serve the store.
+ */
+export function sharedSkillsAvailable(
+  advertised: boolean,
+  list: { configured: boolean } | undefined,
+): boolean {
+  return advertised && list?.configured !== false;
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -57,6 +57,7 @@ import { isMissingSkillError } from "./missing-skill";
 import { isNetworkTransportError } from "./network-transport-error";
 import { osIsTauri, osPickDirectory } from "./os-bridge";
 import { normalizeLegacyModel } from "./providers";
+import { isSharedSkillsUnconfiguredError } from "./shared-skills-availability";
 import { isNeedsUpgradeError, isPersonalSpaceError } from "./team-status-model";
 import { isToolkitOauthUnavailableError } from "./toolkit-oauth-unavailable";
 import type {
@@ -767,10 +768,33 @@ export const tauriSkills = {
 };
 
 export const tauriSharedSkills = {
-  list: (workspaceId: string) =>
-    call("list_shared_skills", async () => {
-      const result = await getEngine().listSharedSkills(workspaceId);
+  /**
+   * The workspace skill store, or the typed "this deployment has no store"
+   * answer.
+   *
+   * A deployment with no blob store bound answers every shared-skills route
+   * `503 {"error":"shared skills not configured"}` — feature ABSENCE, not a
+   * failure. Left as a rejection it re-fired the red bug toast (and a Sentry
+   * issue) every time a Skills surface mounted, and kept the query in an error
+   * state that refetched forever (HOU-1153). Resolving it to
+   * `configured: false` lets the surfaces render their empty state once and
+   * stop asking.
+   *
+   * This is NOT a silent fallback: `call` still logs the failure to the
+   * frontend log tail, the predicate is typed on the wire body rather than a
+   * message string, and every OTHER failure is rethrown to toast and report
+   * exactly as before.
+   */
+  list: async (workspaceId: string) => {
+    try {
+      const result = await call(
+        "list_shared_skills",
+        () => getEngine().listSharedSkills(workspaceId),
+        undefined,
+        { silence: isSharedSkillsUnconfiguredError },
+      );
       return {
+        configured: true,
         diagnostics: result.diagnostics,
         items: result.items.map((s) => ({
           name: s.name,
@@ -797,7 +821,11 @@ export const tauriSharedSkills = {
           prompt_template: s.promptTemplate ?? null,
         })),
       };
-    }),
+    } catch (err) {
+      if (!isSharedSkillsUnconfiguredError(err)) throw err;
+      return { configured: false, diagnostics: [], items: [] };
+    }
+  },
   load: (workspaceId: string, slug: string) =>
     call<SkillDetail>("load_shared_skill", () =>
       getEngine().loadSharedSkill(workspaceId, slug),

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -182,21 +182,21 @@
     },
     "picker": {
       "searchPlaceholder": "Search models…",
-      "connectMore": "Connect more providers…",
+      "connectMore": "Connect another AI…",
       "back": "Back",
       "providersLabel": "Providers",
       "modelsLabel": "Models",
-      "loading": "Loading providers…",
+      "loading": "Loading AIs…",
       "empty": "No models found.",
       "noProviders": {
-        "action": "Connect an AI model",
+        "action": "Connect AI",
         "personal": {
-          "title": "No providers connected yet.",
-          "hint": "Connect an AI model to start chatting."
+          "title": "Connect an AI to chat with Houston",
+          "hint": "Houston answers using an AI like Claude or ChatGPT. Connect one to get started."
         },
         "team": {
-          "title": "You have not connected an AI account yet.",
-          "hint": "Connect your own AI account and this team's agents will answer you."
+          "title": "Connect your AI to chat with this team's agents",
+          "hint": "Team agents answer using your own AI account. Connect yours to get started."
         }
       },
       "account": {
@@ -224,7 +224,8 @@
       "gemini-3_1-flash-lite": "Lightweight and quick for simpler tasks.",
       "gemma-4-26b-a4b-it": "Google's open Gemma model. Fast and efficient.",
       "gemma-4-31b-it": "Google's open Gemma model. More capable."
-    }
+    },
+    "connectMore": "Connect another AI…"
   },
   "reasoning": {
     "thinking": "Thinking...",

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -354,9 +354,9 @@
     },
     "unauthenticated": {
       "title": "Sign in to {{provider}} again",
-      "titleGeneric": "Connect an AI provider",
-      "bodyGeneric": "Houston needs an AI provider connected before it can answer.",
-      "connectProvider": "Connect a provider",
+      "titleGeneric": "Connect an AI",
+      "bodyGeneric": "Houston needs an AI connected before it can answer.",
+      "connectProvider": "Connect AI",
       "reconnectedTitleGeneric": "Connected",
       "bodyTokenExpired": "Your {{provider}} session expired. Reconnect to continue.",
       "bodyNoCredentials": "Houston needs you to sign in to {{provider}} before it can answer.",

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -354,6 +354,10 @@
     },
     "unauthenticated": {
       "title": "Sign in to {{provider}} again",
+      "titleGeneric": "Connect an AI provider",
+      "bodyGeneric": "Houston needs an AI provider connected before it can answer.",
+      "connectProvider": "Connect a provider",
+      "reconnectedTitleGeneric": "Connected",
       "bodyTokenExpired": "Your {{provider}} session expired. Reconnect to continue.",
       "bodyNoCredentials": "Houston needs you to sign in to {{provider}} before it can answer.",
       "bodyInvalidApiKey": "The {{provider}} API key Houston has is no longer valid. Update it and try again.",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -182,21 +182,21 @@
     },
     "picker": {
       "searchPlaceholder": "Busca modelos…",
-      "connectMore": "Conecta más proveedores…",
+      "connectMore": "Conectar otra IA…",
       "back": "Atrás",
       "providersLabel": "Proveedores",
       "modelsLabel": "Modelos",
-      "loading": "Cargando proveedores…",
+      "loading": "Cargando IAs…",
       "empty": "No se encontraron modelos.",
       "noProviders": {
-        "action": "Conectar un modelo de IA",
+        "action": "Conectar IA",
         "personal": {
-          "title": "Aún no hay proveedores conectados.",
-          "hint": "Conecta un modelo de IA para empezar a chatear."
+          "title": "Conecta una IA para chatear con Houston",
+          "hint": "Houston responde usando una IA como Claude o ChatGPT. Conecta una para comenzar."
         },
         "team": {
-          "title": "Aún no has conectado una cuenta de IA.",
-          "hint": "Conecta tu propia cuenta de IA y los agentes de este equipo te responderán."
+          "title": "Conecta tu IA para chatear con los agentes de este equipo",
+          "hint": "Los agentes del equipo responden usando tu propia cuenta de IA. Conecta la tuya para comenzar."
         }
       },
       "account": {
@@ -224,7 +224,8 @@
       "gemini-3_1-flash-lite": "Ligero y veloz para tareas más simples.",
       "gemma-4-26b-a4b-it": "Modelo abierto Gemma de Google. Rápido y eficiente.",
       "gemma-4-31b-it": "Modelo abierto Gemma de Google. Más capaz."
-    }
+    },
+    "connectMore": "Conectar otra IA…"
   },
   "reasoning": {
     "thinking": "Pensando...",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -354,6 +354,10 @@
     },
     "unauthenticated": {
       "title": "Conéctate a {{provider}} de nuevo",
+      "titleGeneric": "Conecta un proveedor de IA",
+      "bodyGeneric": "Houston necesita un proveedor de IA conectado para poder responder.",
+      "connectProvider": "Conectar un proveedor",
+      "reconnectedTitleGeneric": "Conectado",
       "bodyTokenExpired": "Tu sesión de {{provider}} expiró. Vuelve a conectarte para continuar.",
       "bodyNoCredentials": "Houston necesita que inicies sesión en {{provider}} antes de responder.",
       "bodyInvalidApiKey": "La clave de API de {{provider}} que tiene Houston ya no es válida. Actualízala y vuelve a intentar.",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -354,9 +354,9 @@
     },
     "unauthenticated": {
       "title": "Conéctate a {{provider}} de nuevo",
-      "titleGeneric": "Conecta un proveedor de IA",
-      "bodyGeneric": "Houston necesita un proveedor de IA conectado para poder responder.",
-      "connectProvider": "Conectar un proveedor",
+      "titleGeneric": "Conecta una IA",
+      "bodyGeneric": "Houston necesita una IA conectada para poder responder.",
+      "connectProvider": "Conectar IA",
       "reconnectedTitleGeneric": "Conectado",
       "bodyTokenExpired": "Tu sesión de {{provider}} expiró. Vuelve a conectarte para continuar.",
       "bodyNoCredentials": "Houston necesita que inicies sesión en {{provider}} antes de responder.",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -182,21 +182,21 @@
     },
     "picker": {
       "searchPlaceholder": "Busque modelos…",
-      "connectMore": "Conecte mais provedores…",
+      "connectMore": "Conectar outra IA…",
       "back": "Voltar",
       "providersLabel": "Provedores",
       "modelsLabel": "Modelos",
-      "loading": "Carregando provedores…",
+      "loading": "Carregando IAs…",
       "empty": "Nenhum modelo encontrado.",
       "noProviders": {
-        "action": "Conectar um modelo de IA",
+        "action": "Conectar IA",
         "personal": {
-          "title": "Nenhum provedor conectado ainda.",
-          "hint": "Conecte um modelo de IA para começar a conversar."
+          "title": "Conecte uma IA para conversar com o Houston",
+          "hint": "O Houston responde usando uma IA como Claude ou ChatGPT. Conecte uma para começar."
         },
         "team": {
-          "title": "Você ainda não conectou uma conta de IA.",
-          "hint": "Conecte sua própria conta de IA e os agentes desta equipe vão responder você."
+          "title": "Conecte sua IA para conversar com os agentes desta equipe",
+          "hint": "Os agentes da equipe respondem usando sua própria conta de IA. Conecte a sua para começar."
         }
       },
       "account": {
@@ -224,7 +224,8 @@
       "gemini-3_1-flash-lite": "Leve e veloz para tarefas mais simples.",
       "gemma-4-26b-a4b-it": "Modelo aberto Gemma do Google. Rápido e eficiente.",
       "gemma-4-31b-it": "Modelo aberto Gemma do Google. Mais capaz."
-    }
+    },
+    "connectMore": "Conectar outra IA…"
   },
   "reasoning": {
     "thinking": "Pensando...",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -339,9 +339,9 @@
     },
     "unauthenticated": {
       "title": "Conecte-se ao {{provider}} novamente",
-      "titleGeneric": "Conecte um provedor de IA",
-      "bodyGeneric": "O Houston precisa de um provedor de IA conectado para poder responder.",
-      "connectProvider": "Conectar um provedor",
+      "titleGeneric": "Conecte uma IA",
+      "bodyGeneric": "O Houston precisa de uma IA conectada para poder responder.",
+      "connectProvider": "Conectar IA",
       "reconnectedTitleGeneric": "Conectado",
       "bodyTokenExpired": "Sua sessão do {{provider}} expirou. Reconecte para continuar.",
       "bodyNoCredentials": "O Houston precisa que você entre no {{provider}} antes de responder.",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -339,6 +339,10 @@
     },
     "unauthenticated": {
       "title": "Conecte-se ao {{provider}} novamente",
+      "titleGeneric": "Conecte um provedor de IA",
+      "bodyGeneric": "O Houston precisa de um provedor de IA conectado para poder responder.",
+      "connectProvider": "Conectar um provedor",
+      "reconnectedTitleGeneric": "Conectado",
       "bodyTokenExpired": "Sua sessão do {{provider}} expirou. Reconecte para continuar.",
       "bodyNoCredentials": "O Houston precisa que você entre no {{provider}} antes de responder.",
       "bodyInvalidApiKey": "A chave de API do {{provider}} que o Houston tem não é mais válida. Atualize e tente de novo.",

--- a/app/tests/auth-card-presentation.test.ts
+++ b/app/tests/auth-card-presentation.test.ts
@@ -2,9 +2,9 @@ import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
   authCauseBodyKey,
-  reconnectSurface,
   resolveAuthCardPresentation,
 } from "../src/components/shell/provider-error-cards/auth-presentation.ts";
+import { reconnectSurface } from "../src/components/shell/provider-error-cards/reconnect-surface.ts";
 
 // The card once labeled two opposite actions "Try again". These assert the
 // state -> title/body/button mapping so each phase names its real action:
@@ -84,6 +84,7 @@ describe("resolveAuthCardPresentation", () => {
     deepStrictEqual(
       resolveAuthCardPresentation({
         phase: "idle",
+        hasProvider: true,
         hasFailedPrompt: false,
         hasRetry: false,
         causeBodyKey: CAUSE,
@@ -105,6 +106,7 @@ describe("resolveAuthCardPresentation", () => {
     deepStrictEqual(
       resolveAuthCardPresentation({
         phase: "waiting",
+        hasProvider: true,
         hasFailedPrompt: true,
         hasRetry: true,
         causeBodyKey: CAUSE,
@@ -126,6 +128,7 @@ describe("resolveAuthCardPresentation", () => {
     deepStrictEqual(
       resolveAuthCardPresentation({
         phase: "failed",
+        hasProvider: true,
         hasFailedPrompt: false,
         hasRetry: true,
         causeBodyKey: CAUSE,
@@ -147,6 +150,7 @@ describe("resolveAuthCardPresentation", () => {
     deepStrictEqual(
       resolveAuthCardPresentation({
         phase: "done",
+        hasProvider: true,
         hasFailedPrompt: true,
         hasRetry: true,
         causeBodyKey: CAUSE,
@@ -167,6 +171,7 @@ describe("resolveAuthCardPresentation", () => {
     deepStrictEqual(
       resolveAuthCardPresentation({
         phase: "done",
+        hasProvider: true,
         hasFailedPrompt: false,
         hasRetry: true,
         causeBodyKey: CAUSE,
@@ -184,13 +189,157 @@ describe("resolveAuthCardPresentation", () => {
   });
 
   it("done without a retry handler: no button at all", () => {
+    deepStrictEqual(
+      resolveAuthCardPresentation({
+        phase: "done",
+        hasProvider: true,
+        hasFailedPrompt: false,
+        hasRetry: false,
+        causeBodyKey: CAUSE,
+      }),
+      {
+        variant: "done",
+        titleKey: "providerError.unauthenticated.reconnectedTitle",
+        bodyKey: "providerError.unauthenticated.reconnectedBody",
+        button: null,
+      },
+    );
+  });
+});
+
+// An unauthenticated error can arrive with NO provider (nothing connected at
+// all). Every string above interpolates `{{provider}}`, so the whole card has
+// to switch to provider-free copy: naming an empty provider read as broken, and
+// the guess it replaced ("anthropic") named a provider the user never had.
+describe("resolveAuthCardPresentation without a provider", () => {
+  it("idle: generic title + body, and the button says Connect a provider", () => {
+    deepStrictEqual(
+      resolveAuthCardPresentation({
+        phase: "idle",
+        hasProvider: false,
+        hasFailedPrompt: false,
+        hasRetry: false,
+        causeBodyKey: CAUSE,
+      }),
+      {
+        variant: "active",
+        titleKey: "providerError.unauthenticated.titleGeneric",
+        bodyKey: "providerError.unauthenticated.bodyGeneric",
+        button: {
+          kind: "action",
+          labelKey: "providerError.unauthenticated.connectProvider",
+          action: "reconnect",
+        },
+      },
+    );
+  });
+
+  it("failed: the same generic prompt, never the provider-named failure body", () => {
+    deepStrictEqual(
+      resolveAuthCardPresentation({
+        phase: "failed",
+        hasProvider: false,
+        hasFailedPrompt: false,
+        hasRetry: true,
+        causeBodyKey: CAUSE,
+      }),
+      {
+        variant: "active",
+        titleKey: "providerError.unauthenticated.titleGeneric",
+        bodyKey: "providerError.unauthenticated.bodyGeneric",
+        button: {
+          kind: "action",
+          labelKey: "providerError.unauthenticated.connectProvider",
+          action: "reconnect",
+        },
+      },
+    );
+  });
+
+  it("the cause body is ignored: every cause key names a provider", () => {
     const pres = resolveAuthCardPresentation({
-      phase: "done",
+      phase: "idle",
+      hasProvider: false,
       hasFailedPrompt: false,
       hasRetry: false,
-      causeBodyKey: CAUSE,
+      causeBodyKey: authCauseBodyKey("token_expired"),
     });
-    strictEqual(pres.variant, "done");
-    strictEqual(pres.button, null);
+    strictEqual(pres.bodyKey, "providerError.unauthenticated.bodyGeneric");
+  });
+
+  it("waiting cannot be provider-named either (the generic action opens no browser)", () => {
+    deepStrictEqual(
+      resolveAuthCardPresentation({
+        phase: "waiting",
+        hasProvider: false,
+        hasFailedPrompt: false,
+        hasRetry: true,
+        causeBodyKey: CAUSE,
+      }),
+      {
+        variant: "active",
+        titleKey: "providerError.unauthenticated.titleGeneric",
+        bodyKey: "providerError.unauthenticated.bodyGeneric",
+        button: {
+          kind: "action",
+          labelKey: "providerError.unauthenticated.connectProvider",
+          action: "reconnect",
+        },
+      },
+    );
+  });
+
+  it("done: generic confirmation title, unchanged resume bodies + Signed-in badge", () => {
+    deepStrictEqual(
+      resolveAuthCardPresentation({
+        phase: "done",
+        hasProvider: false,
+        hasFailedPrompt: true,
+        hasRetry: true,
+        causeBodyKey: CAUSE,
+      }),
+      {
+        variant: "done",
+        titleKey: "providerError.unauthenticated.reconnectedTitleGeneric",
+        bodyKey: "providerError.unauthenticated.reconnectedResending",
+        button: {
+          kind: "badge",
+          labelKey: "providerError.unauthenticated.signedIn",
+        },
+      },
+    );
+    deepStrictEqual(
+      resolveAuthCardPresentation({
+        phase: "done",
+        hasProvider: false,
+        hasFailedPrompt: false,
+        hasRetry: true,
+        causeBodyKey: CAUSE,
+      }),
+      {
+        variant: "done",
+        titleKey: "providerError.unauthenticated.reconnectedTitleGeneric",
+        bodyKey: "providerError.unauthenticated.reconnectedResuming",
+        button: {
+          kind: "badge",
+          labelKey: "providerError.unauthenticated.signedIn",
+        },
+      },
+    );
+    deepStrictEqual(
+      resolveAuthCardPresentation({
+        phase: "done",
+        hasProvider: false,
+        hasFailedPrompt: false,
+        hasRetry: false,
+        causeBodyKey: CAUSE,
+      }),
+      {
+        variant: "done",
+        titleKey: "providerError.unauthenticated.reconnectedTitleGeneric",
+        bodyKey: "providerError.unauthenticated.reconnectedBody",
+        button: null,
+      },
+    );
   });
 });

--- a/app/tests/chat-effective-provider.test.ts
+++ b/app/tests/chat-effective-provider.test.ts
@@ -1,6 +1,33 @@
 import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
-import { resolveEffectiveProvider } from "../src/components/chat-effective-provider.ts";
+import {
+  preferredProvider,
+  resolveEffectiveProvider,
+} from "../src/components/chat-effective-provider.ts";
+
+// ONE preference chain, shared by the composer and the error cards. It used to
+// be written twice with different operators (`??` here, `||` in
+// `errorCardProvider`), so an empty-string provider counted as a real pick on
+// one path and as absent on the other.
+describe("preferredProvider", () => {
+  it("takes the strongest evidence first", () => {
+    strictEqual(preferredProvider("openai", "anthropic", "gemini"), "openai");
+    strictEqual(preferredProvider(null, "anthropic", "gemini"), "anthropic");
+    strictEqual(preferredProvider(null, null, "gemini"), "gemini");
+  });
+
+  it("returns null with no evidence at all", () => {
+    strictEqual(preferredProvider(null, null, null), null);
+  });
+
+  it("treats an empty string as absent, not as a pick", () => {
+    // `provider: ""` is what an unattributed record carries. Honoring it would
+    // freeze the composer on nothing and label an error card blank.
+    strictEqual(preferredProvider("", "anthropic", null), "anthropic");
+    strictEqual(preferredProvider("", "", "gemini"), "gemini");
+    strictEqual(preferredProvider("", "", ""), null);
+  });
+});
 
 describe("resolveEffectiveProvider", () => {
   it("uses an explicit (activity/agent) provider for a fresh chat when it is connected", () => {
@@ -81,6 +108,15 @@ describe("resolveEffectiveProvider", () => {
       resolveEffectiveProvider(null, null, null, ["openai"], false),
       "openai",
     );
+  });
+
+  it("ignores an empty-string activity provider and uses the next evidence", () => {
+    strictEqual(
+      resolveEffectiveProvider("", "openai", null, ["openai"], true),
+      "openai",
+    );
+    // Nothing but empty strings = no preference, so the default applies.
+    strictEqual(resolveEffectiveProvider("", "", "", [], true), "anthropic");
   });
 
   it("keeps the preferred fallback when statuses haven't loaded (empty)", () => {

--- a/app/tests/composer-connect-ai.test.ts
+++ b/app/tests/composer-connect-ai.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  type ConnectAiComposerSignals,
+  shouldReplaceComposerWithConnectAi,
+} from "../src/lib/composer-connect-ai.ts";
+
+/**
+ * The composer's connect-AI empty state.
+ *
+ * The bug: with NO provider connected the composer still rendered its full
+ * input row — a model picker showing a phantom model (the effective-provider
+ * default resolves to `anthropic` whether or not anyone is logged in) and a
+ * textarea that accepted a message no provider could answer. The fix replaces
+ * the whole input area with one CTA into the AI Hub.
+ *
+ * What these pin is the ANTI-FLASH half of it. "Zero connected" is a claim only
+ * a settled world can make, and a composer that vanishes on boot and comes back
+ * a beat later reads as a broken app. So every uncertain signal — probe
+ * loading, probe errored, a provider still "checking", a half-hydrated catalog
+ * or capabilities — must keep the normal composer.
+ */
+
+/** A settled, genuinely empty world: every gate open, nothing connected. */
+const settledEmpty: ConnectAiComposerSignals = {
+  statusesLoading: false,
+  statusesError: false,
+  connectedCount: 0,
+  checkingCount: 0,
+  catalogReady: true,
+  capabilitiesLoaded: true,
+};
+
+test("a settled world with zero connected providers replaces the composer", () => {
+  assert.equal(shouldReplaceComposerWithConnectAi(settledEmpty), true);
+});
+
+test("a still-loading provider probe keeps the composer", () => {
+  assert.equal(
+    shouldReplaceComposerWithConnectAi({
+      ...settledEmpty,
+      statusesLoading: true,
+    }),
+    false,
+  );
+});
+
+test("a failed provider probe keeps the composer (it knows nothing, not zero)", () => {
+  assert.equal(
+    shouldReplaceComposerWithConnectAi({
+      ...settledEmpty,
+      statusesError: true,
+    }),
+    false,
+  );
+});
+
+test("a provider still checking keeps the composer", () => {
+  assert.equal(
+    shouldReplaceComposerWithConnectAi({ ...settledEmpty, checkingCount: 1 }),
+    false,
+  );
+});
+
+test("an unhydrated provider catalog keeps the composer", () => {
+  assert.equal(
+    shouldReplaceComposerWithConnectAi({
+      ...settledEmpty,
+      catalogReady: false,
+    }),
+    false,
+  );
+});
+
+test("capabilities still loading keeps the composer", () => {
+  assert.equal(
+    shouldReplaceComposerWithConnectAi({
+      ...settledEmpty,
+      capabilitiesLoaded: false,
+    }),
+    false,
+  );
+});
+
+test("one connected provider keeps the composer", () => {
+  assert.equal(
+    shouldReplaceComposerWithConnectAi({ ...settledEmpty, connectedCount: 1 }),
+    false,
+  );
+});
+
+test("a connected provider wins even while another is still checking", () => {
+  assert.equal(
+    shouldReplaceComposerWithConnectAi({
+      ...settledEmpty,
+      connectedCount: 1,
+      checkingCount: 1,
+    }),
+    false,
+  );
+});
+
+/**
+ * The wiring these three lock is not derivable from the pure helper, and the
+ * node test runner has no DOM — so they assert on component source, the repo's
+ * idiom for React contracts (see `card-unification.test.ts`).
+ */
+const read = (rel: string) =>
+  readFileSync(new URL(rel, import.meta.url), "utf8");
+
+test("the empty state replaces the composer rather than stacking above it", () => {
+  const src = read("../src/components/use-agent-chat-panel.tsx");
+  assert.match(
+    src,
+    /if \(connectAiComposer\.node\)\s*\n?\s*return \{ mode: "replace" as const, node: connectAiComposer\.node \};/,
+    "the connect-AI branch returns replace mode, which hides the whole ChatInput",
+  );
+});
+
+test("the reconnect card is suppressed while the empty state owns the CTA", () => {
+  const src = read("../src/components/use-agent-chat-panel.tsx");
+  const afterMessages = src.slice(src.indexOf("const afterMessages"));
+  const suppression = afterMessages.indexOf(
+    "if (connectAiComposer.active) return null;",
+  );
+  const card = afterMessages.indexOf("<ProviderReconnectCard");
+  assert.ok(
+    suppression > -1,
+    "afterMessages bails out on the connect-AI state",
+  );
+  assert.ok(
+    suppression < card,
+    "it bails out BEFORE rendering the reconnect card, so only one CTA shows",
+  );
+});
+
+test("the empty state reuses the picker's no-providers copy", () => {
+  const src = read("../src/components/chat-connect-ai-empty-state.tsx");
+  assert.ok(
+    src.includes("modelSelector.picker.noProviders.action"),
+    "the CTA label is the picker's existing action key",
+  );
+  // Split around the interpolation so this assertion is not itself a template
+  // placeholder in a plain string (which biome rightly flags).
+  const perVariant = (leaf: string) =>
+    `modelSelector.picker.noProviders.$\{variant}.${leaf}`;
+  assert.ok(
+    src.includes(perVariant("title")),
+    "the title is the picker's existing per-variant key",
+  );
+  assert.ok(
+    src.includes(perVariant("hint")),
+    "the hint is the picker's existing per-variant key",
+  );
+  assert.ok(
+    src.includes("onConnect ? ("),
+    "no button at all for a viewer who cannot reach the AI Hub",
+  );
+});

--- a/app/tests/not-connected-card.test.ts
+++ b/app/tests/not-connected-card.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import type { FeedItem, ProviderError } from "@houston-ai/chat";
 import {
   continuesTaskAfterReconnect,
+  errorCardProvider,
   isInlineAuthCard,
   providerErrorRetryText,
   reconnectContinueText,
@@ -38,6 +39,88 @@ describe("resolveProviderErrorForChat", () => {
       message: "session expired",
     };
     deepStrictEqual(resolveProviderErrorForChat(wireCard, "openai"), wireCard);
+  });
+
+  it("leaves the card unlabeled when there is no provider evidence", () => {
+    // A guessed label sends the user to the WRONG sign-in — better a generic
+    // card than "Connect Anthropic" shown to someone on OpenAI.
+    const resolved = resolveProviderErrorForChat(notConnectedCard, null);
+    strictEqual(resolved.provider, "");
+    deepStrictEqual(resolved, notConnectedCard);
+  });
+
+  it("never turns an evidence-less card into the composer's default", () => {
+    const resolved = resolveProviderErrorForChat(
+      notConnectedCard,
+      errorCardProvider({
+        activityProvider: null,
+        agentProvider: null,
+        lastUsedProvider: null,
+      }),
+    );
+    strictEqual(resolved.provider, "");
+  });
+});
+
+describe("errorCardProvider", () => {
+  it("prefers the turn's activity provider over weaker evidence", () => {
+    strictEqual(
+      errorCardProvider({
+        activityProvider: "openai",
+        agentProvider: "anthropic",
+        lastUsedProvider: "google",
+      }),
+      "openai",
+    );
+  });
+
+  it("falls back to the agent's provider, then the last used one", () => {
+    strictEqual(
+      errorCardProvider({
+        activityProvider: null,
+        agentProvider: "anthropic",
+        lastUsedProvider: "google",
+      }),
+      "anthropic",
+    );
+    strictEqual(
+      errorCardProvider({
+        activityProvider: null,
+        agentProvider: null,
+        lastUsedProvider: "google",
+      }),
+      "google",
+    );
+  });
+
+  it("treats empty strings as absent evidence", () => {
+    strictEqual(
+      errorCardProvider({
+        activityProvider: "",
+        agentProvider: "",
+        lastUsedProvider: "openai",
+      }),
+      "openai",
+    );
+    strictEqual(
+      errorCardProvider({
+        activityProvider: "",
+        agentProvider: "",
+        lastUsedProvider: "",
+      }),
+      null,
+    );
+  });
+
+  it("returns null with no evidence — never a guessed default", () => {
+    strictEqual(
+      errorCardProvider({
+        activityProvider: null,
+        agentProvider: null,
+        lastUsedProvider: null,
+      }),
+      null,
+    );
   });
 });
 

--- a/app/tests/provider-statuses-gate.test.ts
+++ b/app/tests/provider-statuses-gate.test.ts
@@ -1,11 +1,16 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
+import { providerConnectionState } from "../src/lib/provider-connection.ts";
 import {
+  classifyStatusScan,
+  PROVIDER_STATUS_REPROBE_MS,
   providerProbeReady,
   providerStatusesLoading,
   providerStatusesQueryKey,
+  providerStatusesRefetchInterval,
 } from "../src/lib/provider-statuses-query.ts";
+import type { ProviderStatus } from "../src/lib/tauri.ts";
 
 /**
  * HOU-979 — the CHAT PICKER's status query must be as space-safe as the AI
@@ -127,6 +132,120 @@ describe("the loading signal the picker reads", () => {
   });
 });
 
+/**
+ * HOU-1153 — an unreachable probe must be an ERROR, not a successful
+ * "everything is unknown".
+ *
+ * Symptom it closes: on desktop with zero providers connected the adapter's
+ * batched `providerStatuses()` swallows every failure (and skips the call
+ * outright while agent routing is unsettled), resolving all ~35 providers as
+ * `unknown`. That is a SUCCESSFUL query as far as TanStack is concerned, so
+ * nothing retried: `unknown` maps to `checking`, the picker sat on "Loading
+ * providers…" forever, and the connect-AI composer empty state — which fails
+ * closed while anything is `checking` — never fired. The scan carries no
+ * information, so the honest shape is a rejected query that keeps re-probing.
+ */
+const scanStatus = (
+  id: string,
+  auth_state: ProviderStatus["auth_state"],
+): ProviderStatus => ({
+  provider: id,
+  cli_installed: true,
+  auth_state,
+  authenticated: auth_state === "authenticated",
+  cli_name: id,
+});
+
+describe("classifying a status scan", () => {
+  it("calls an all-unknown scan unreachable — it carries no information", () => {
+    strictEqual(
+      classifyStatusScan(["anthropic", "openai"], {
+        anthropic: scanStatus("anthropic", "unknown"),
+        openai: scanStatus("openai", "unknown"),
+      }),
+      "unreachable",
+    );
+  });
+
+  it("calls a scan with any CONFIRMED answer definitive", () => {
+    strictEqual(
+      classifyStatusScan(["anthropic", "openai"], {
+        anthropic: scanStatus("anthropic", "unknown"),
+        openai: scanStatus("openai", "unauthenticated"),
+      }),
+      "definitive",
+    );
+  });
+
+  it("calls an all-unauthenticated scan definitive — zero connected IS an answer", () => {
+    // The exact shape the bug hid: a fresh install with nothing connected must
+    // settle here so the composer can offer its connect-AI empty state.
+    strictEqual(
+      classifyStatusScan(["anthropic"], {
+        anthropic: scanStatus("anthropic", "unauthenticated"),
+      }),
+      "definitive",
+    );
+  });
+
+  it("calls an empty probe set definitive — nothing was asked, nothing failed", () => {
+    strictEqual(classifyStatusScan([], {}), "definitive");
+  });
+});
+
+describe("the self-heal re-probe interval", () => {
+  it("re-probes on a bounded interval while the last probe failed", () => {
+    strictEqual(
+      providerStatusesRefetchInterval({ status: "error" }),
+      PROVIDER_STATUS_REPROBE_MS,
+    );
+    strictEqual(PROVIDER_STATUS_REPROBE_MS > 0, true);
+  });
+
+  it("stops the moment a definitive answer arrives", () => {
+    // Otherwise a settled picker would poll the engine forever for nothing.
+    strictEqual(providerStatusesRefetchInterval({ status: "success" }), false);
+  });
+
+  it("does not poll while the first probe is still in flight", () => {
+    // TanStack's own retry/backoff owns that window; a second timer on top
+    // would stack overlapping probes.
+    strictEqual(providerStatusesRefetchInterval({ status: "pending" }), false);
+  });
+});
+
+describe("what the picker paints once the probe has ERRORED", () => {
+  it("settles on 'nothing connected' rather than spinning forever", () => {
+    // The end of the chain the throw buys. TanStack's `isLoading` is
+    // `isPending && isFetching`, so an errored query is NOT loading...
+    const isLoading = providerStatusesLoading({
+      hasData: false,
+      queryIsLoading: false,
+      probeReady: true,
+    });
+    strictEqual(isLoading, false);
+    // ...which makes every provider's absent status a settled `disconnected`,
+    // not the `checking` that pinned the level-1 list on its loading state.
+    // `providerListLoading([...disconnected], "ready") === false` is pinned on
+    // the other side of the seam in ui/core's model-picker-catalog tests, so
+    // the picker lands on its "Connect more providers" empty state.
+    strictEqual(providerConnectionState(undefined, isLoading), "disconnected");
+  });
+
+  it("keeps painting the last known statuses when a refetch errors", () => {
+    // Data + error is a background self-heal tick failing: never regress a
+    // connected picker into an empty one.
+    strictEqual(
+      providerStatusesLoading({
+        hasData: true,
+        queryIsLoading: false,
+        probeReady: true,
+      }),
+      false,
+    );
+  });
+});
+
 describe("the picker hook is actually wired to the gate", () => {
   const hook = read("../src/hooks/use-provider-statuses.ts");
 
@@ -136,6 +255,43 @@ describe("the picker hook is actually wired to the gate", () => {
     strictEqual(hook.includes("providerProbeReady"), true);
     strictEqual(hook.includes("enabled: probeReady"), true);
     strictEqual(hook.includes("providerStatusesLoading"), true);
+  });
+
+  it("throws on an unreachable scan and self-heals on an interval", () => {
+    strictEqual(hook.includes("classifyStatusScan"), true);
+    strictEqual(hook.includes("ProviderProbeUnreachableError"), true);
+    strictEqual(hook.includes("providerStatusesRefetchInterval"), true);
+    // The client-wide default is `retry: false`, so the retry/backoff this
+    // relies on has to be opted into explicitly on THIS query.
+    strictEqual(/retry:\s*\d/.test(hook), true);
+  });
+
+  it("leaves the AI hub's sibling hook consuming the all-unknown shape", () => {
+    // The hub deliberately keeps painting its last-known snapshot on an
+    // unreachable scan; it must NOT start throwing.
+    const hub = read(
+      "../src/hooks/provider-connections/use-provider-statuses.ts",
+    );
+    strictEqual(hub.includes("scanIsUnreachable"), true);
+    strictEqual(hub.includes("ProviderProbeUnreachableError"), false);
+  });
+
+  it("makes every consumer that DEFERRED on 'unknown' defer on the error too", () => {
+    // The throw replaces a map of `unknown`s with no statuses at all. Consumers
+    // that read "somebody is checking" as "do not act yet" would otherwise see
+    // an empty map and act on it as a confident "nothing is connected" — the
+    // migration reconnect card firing at a user who IS connected, and the
+    // routine kickoff prompt telling the agent the user has no providers.
+    for (const path of [
+      "../src/hooks/use-migration-reconnect.ts",
+      "../src/components/tabs/use-routine-chat-setup.ts",
+    ]) {
+      strictEqual(
+        /isError/.test(read(path)),
+        true,
+        `${path} defers on isError`,
+      );
+    }
   });
 
   it("reads the SAME agent-store signals the AI hub's sibling hook gates on", () => {

--- a/app/tests/shared-skills-availability.test.ts
+++ b/app/tests/shared-skills-availability.test.ts
@@ -1,0 +1,142 @@
+import { match, strictEqual } from "node:assert";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import {
+  isSharedSkillsUnconfiguredError,
+  SHARED_SKILLS_UNCONFIGURED,
+  sharedSkillsAvailable,
+} from "../src/lib/shared-skills-availability.ts";
+
+const read = (relativePath: string) =>
+  readFileSync(new URL(relativePath, import.meta.url), "utf8");
+
+// HOU-1153: the classifier that tells "this deployment has no workspace skill
+// store" (feature absence — render the empty state, stop asking) apart from a
+// shared-skills call that genuinely FAILED (toast + report, unchanged). A false
+// positive here silently drops a real bug report, so it must be exact.
+
+/** The shape `HoustonEngineError` carries: the status plus the parsed body. */
+const engineError = (status: number, body: unknown) => ({
+  status,
+  body,
+  message: "engine error",
+});
+
+describe("isSharedSkillsUnconfiguredError", () => {
+  it("matches the gateway's 503 for a deployment with no skill store", () => {
+    strictEqual(
+      isSharedSkillsUnconfiguredError(
+        engineError(503, { error: SHARED_SKILLS_UNCONFIGURED }),
+      ),
+      true,
+    );
+  });
+
+  it("uses the gateway's exact wire string", () => {
+    // Mirrors cloud/internal/edge/shared_skills_routes.go.
+    strictEqual(SHARED_SKILLS_UNCONFIGURED, "shared skills not configured");
+  });
+
+  it("does NOT match a waking pod — that one is retried, not hidden", () => {
+    strictEqual(
+      isSharedSkillsUnconfiguredError(
+        engineError(503, {
+          error: "engine unavailable",
+          detail: "agent is waking",
+        }),
+      ),
+      false,
+    );
+  });
+
+  it("does NOT match other shared-skills failures", () => {
+    // A real outage, an auth rejection, a missing workspace: all still toast.
+    strictEqual(
+      isSharedSkillsUnconfiguredError(engineError(503, { error: "down" })),
+      false,
+    );
+    strictEqual(
+      isSharedSkillsUnconfiguredError(engineError(500, { error: "boom" })),
+      false,
+    );
+    strictEqual(
+      isSharedSkillsUnconfiguredError(engineError(401, { error: "no auth" })),
+      false,
+    );
+    strictEqual(
+      isSharedSkillsUnconfiguredError(
+        engineError(404, { error: "workspace not found" }),
+      ),
+      false,
+    );
+  });
+
+  it("never matches the same status carried on a different body shape", () => {
+    // A 503 alone must not silence the surface — the reason has to be there.
+    strictEqual(isSharedSkillsUnconfiguredError(engineError(503, null)), false);
+    strictEqual(isSharedSkillsUnconfiguredError(engineError(503, {})), false);
+    strictEqual(
+      isSharedSkillsUnconfiguredError(
+        engineError(503, { detail: SHARED_SKILLS_UNCONFIGURED }),
+      ),
+      false,
+    );
+  });
+
+  it("never matches a non-engine throw", () => {
+    strictEqual(isSharedSkillsUnconfiguredError(undefined), false);
+    strictEqual(isSharedSkillsUnconfiguredError(null), false);
+    strictEqual(
+      isSharedSkillsUnconfiguredError(new Error(SHARED_SKILLS_UNCONFIGURED)),
+      false,
+    );
+    strictEqual(
+      isSharedSkillsUnconfiguredError(SHARED_SKILLS_UNCONFIGURED),
+      false,
+    );
+  });
+});
+
+describe("sharedSkillsAvailable", () => {
+  it("hides the surface when the deployment has no store", () => {
+    // The gateway said `capabilities.sharedSkills: true` and the store said no.
+    strictEqual(sharedSkillsAvailable(true, { configured: false }), false);
+  });
+
+  it("shows the surface when the store answered", () => {
+    strictEqual(sharedSkillsAvailable(true, { configured: true }), true);
+  });
+
+  it("stays optimistic while the store list is still loading", () => {
+    // No flicker out-and-back on deployments that DO serve the store.
+    strictEqual(sharedSkillsAvailable(true, undefined), true);
+  });
+
+  it("never overrides a deployment that doesn't advertise the capability", () => {
+    strictEqual(sharedSkillsAvailable(false, { configured: true }), false);
+    strictEqual(sharedSkillsAvailable(false, undefined), false);
+  });
+});
+
+describe("the list_shared_skills surfacing policy", () => {
+  const tauri = read("../src/lib/tauri.ts");
+
+  it("silences ONLY the unconfigured case at the call site", () => {
+    // No red bug toast and no Sentry issue for feature absence; `call` still
+    // logs it, and every other failure surfaces exactly as before.
+    match(
+      tauri,
+      /"list_shared_skills",[\s\S]{0,240}silence: isSharedSkillsUnconfiguredError/,
+    );
+  });
+
+  it("converts only the typed error into the feature-absent value", () => {
+    // The rethrow is the no-silent-failures guarantee: anything that is not
+    // the gateway's "not configured" 503 keeps propagating.
+    match(tauri, /if \(!isSharedSkillsUnconfiguredError\(err\)\) throw err;/);
+    match(
+      tauri,
+      /return \{ configured: false, diagnostics: \[\], items: \[\] \}/,
+    );
+  });
+});

--- a/knowledge-base/anthropic-credentials.md
+++ b/knowledge-base/anthropic-credentials.md
@@ -102,6 +102,74 @@ refresh-less and remain safe to replace on every serve cycle.
   NAMED ENTRY in the caller-supplied list (`STORE_SYNC_EXCLUDES`,
   `packages/host/src/store-sync/daemon.ts`).
 
+## Central refresh — the single-rotator rule, enforced in process
+
+"One refresh-token family = one rotator" (trap #4 below) is the RULE;
+`packages/host/src/credentials/refresh-coalescer.ts` is what enforces it INSIDE
+one host. Every OAuth refresh now goes through the
+process-wide `sharedCredentialRefresher` — both the serve route
+(`routes/credential.ts`) and the turn path (`turn/fresh-credential.ts`, split out
+of `start-turn.ts` precisely so it lands in the same flight; it brings its own
+injected refresher rather than keeping a private rotator).
+
+- **Single-flight + 30s result cache, keyed (workspace, SCOPE, provider)** — scope
+  in the key so one member's rotation is never handed to another member's serve
+  (HOU-976). One runtime process per agent serves per turn AND per `/providers`
+  poll, so an expiring credential produced N simultaneous refreshes of the SAME
+  refresh token; a rotating provider (openai-codex) answers the first and rejects
+  the rest with `invalid_grant`, which the serve route read as "the session ended"
+  and deleted the credential. The user watched their provider disconnect itself.
+  The cache holds FULL credentials, so every write sweeps aged-out entries; a
+  failure is never cached, and `forget()` drops one key after a disconnect
+  (in-flight state is deliberately untouched — evicting a live flight would open a
+  second concurrent exchange of the same rotating token).
+- **The flight re-reads the credential inside the critical section** (`load`): a
+  sibling host may have rotated it already, and serving that costs nothing while
+  refreshing again would burn a rotated token. `null` there means the user
+  disconnected mid-flight → `CredentialGoneError`, which the serve route answers
+  with the marked 404 and the turn path reads as "no credential". A queued refresh
+  can therefore never RESURRECT the row the user just deleted.
+
+### What may sign a user out (`credentials/oauth-token-exchange.ts`)
+
+One `grant_type=refresh_token` POST, 10s timeout, three failure classes — only
+the first is destructive:
+
+- **`RefreshRejectedError`** — a 400/401 whose body names `invalid_grant` or
+  `refresh_token_invalidated` (both shapes parsed: RFC 6749's `{"error":"…"}` and
+  OpenAI's nested `{"error":{"code":"…"}}`). Terminal: dead until the user
+  reconnects. `invalid_client` is deliberately NOT terminal — it condemns
+  Houston's ONE hardcoded public client id, not the user's token, so honoring it
+  would delete every workspace's credential on its next refresh with no path back.
+  An unparseable body yields no code and stays non-terminal.
+- **`TransientRefreshError`** — the request provably never left this process
+  (`ENOTFOUND` / `EAI_AGAIN` / `ECONNREFUSED` on the fetch's `cause`). The ONLY
+  retryable class (`refreshCredential`, default 2 attempts, jittered 250-500ms).
+  `ECONNRESET` is excluded: a reset can land after the grant was consumed.
+- **plain `Error`** — timeout, abort, 5xx, 429, any other 4xx. One attempt, never
+  retried: the endpoint may already have consumed the rotating refresh token and
+  rotated it into a response we never read, so a second POST spends a grant we no
+  longer hold and earns `invalid_grant` — signing the user out over a blip. The
+  serve route serves the stored token best-effort and the next serve tries again.
+
+### A rejected refresh deletes ONLY the token that was rejected
+
+`credentials/disconnect.ts` `disconnectRejectedCredential` is the whole policy
+behind the serve route's `RefreshRejectedError` branch. It calls
+`credentials.removeIfAccess(...)` with the digest of the REJECTED access token
+(`accessDigest` — the same "name the token, never ship it" rule the revoked-token
+report follows), so a reconnect, or a sibling host's rotation, that landed in the
+window between our read and the endpoint's verdict survives untouched. Dropped →
+the marked 404 (`x-houston-not-connected`), the runtime removes its served entry
+(provenance-gated) and the provider reads signed out; the credential IS the
+switch. Not dropped → re-read the store and serve the SUPERSEDING credential
+through the route's remaining checks (anthropic staleness included). A re-read
+answering the same digest is confirmation, not supersession — `RemoteCredentialStore`
+serves `get` from a short-lived cache — and still ends in the marked 404. Either
+way the coalescer's cached result for that key is forgotten, and a failure of the
+re-read itself degrades to "absent" rather than escaping as a 500 in place of the
+404 the runtime knows how to act on.
+
 ## The six traps (each was a live bug, or a guarded near-miss)
 
 1. **`USER` must reach the SDK subprocess.** The CLI names its Keychain
@@ -132,7 +200,8 @@ refresh-less and remain safe to replace on every serve cycle.
    after the push (exclusive handoff), and cached snapshots are never pushed.
    No locking or freshness check makes a shared family safe; the invalidation
    happens at Anthropic. Separate spaces get separate families (Anthropic
-   allows many concurrent families per account).
+   allows many concurrent families per account). Inside a single host the rule
+   is enforced by the coalescer — see "Central refresh" above.
 5. **Windows: the CLI needs a shell BEFORE it does anything — even
    `auth login`.** At startup on Windows the CLI exits 1 unless it finds Git
    Bash or PowerShell (`pwsh` on PATH → three pwsh install dirs → plain
@@ -242,3 +311,29 @@ export → gateway PUT → runtime scrub transaction, then re-reads and serves t
 gateway-verified access token in the same request. A successful scrub leaves
 the pod access-only and restores the gateway as the credential family's single
 refresh-token rotator; transport failures never trigger an upload.
+
+### The anthropic probe: unanswerable is NOT signed out
+
+macOS caches the browser login in the Keychain (nothing to stat), so the only
+cross-platform "is anthropic connected?" signal is asking the binary:
+`claude auth status --json`, scoped to the shared login dir with the ambient
+credential env scrubbed (`packages/runtime/src/backends/claude/auth-cli.ts` —
+subprocess mechanics live there so `credential-status.ts` stays pure cache
+policy). A subprocess can fail to ANSWER, and reading that as "logged out" is what
+flapped a signed-in user's chat to "Connect Anthropic" mid-session. So the probe
+is three-valued: `{known: true, loggedIn}` ONLY when stdout parses as JSON with a
+boolean `loggedIn`; a killed/timed-out child, empty stdout, non-JSON, or an
+unrecognized shape is `{known: false, reason}`. A non-zero exit is NOT itself a
+failure — `claude auth status` exits non-zero while printing a valid
+`{"loggedIn": false}`. Only ENOENT (no binary at all) rejects.
+
+`credential-status.ts` then treats an unknown answer as no answer: the cache keeps
+its LAST KNOWN value, the concrete reason is logged, and a 15s respawn backoff
+stops the `/providers` poll cadence spawning a subprocess per request. That branch
+deliberately does NOT stamp the TTL clock — the clock times how fresh the cached
+ANSWER is, and stamping it made the two knobs stack (after the backoff expired the
+30s connected TTL kept blocking, freezing status for 30s instead of the 15s the
+backoff promises). TTLs are asymmetric on purpose: connected 30s (stable — our own
+login/logout routes force a refresh), disconnected 2s (must flip within a poll
+cycle of the user signing in). `force` bypasses both TTL and backoff, and
+concurrent callers share one in-flight subprocess.

--- a/knowledge-base/client-architecture.md
+++ b/knowledge-base/client-architecture.md
@@ -105,8 +105,9 @@ end-state is that it dissolves into direct SDK consumption
   (`client/context.ts`, held by `client/base.ts` as `this.ctx` — the single source
   of truth for `engine`/`sdk`/`authFetch`/`activeLogins`/routing helpers).
   `control-plane.ts` is a barrel re-exporting `cp/*` modules (`fetch.ts` is the
-  shared transport: `cpFetch`, `gatewayAuthFetch`, `transientRetryFetch`) — the ONE
-  import site callers and `vi.mock` use. Every file is ≤200 lines. Unsupported
+  shared transport: `cpFetch`, `gatewayAuthFetch`; `transient-retry.ts` is the
+  read-retry layer) — the ONE import site callers and `vi.mock` use. Every file
+  is ≤200 lines. Unsupported
   legacy desktop/Rust methods throw explicitly (`client/legacy-unsupported-mixin.ts`);
   there is no catch-all Proxy returning silent `[]`.
 
@@ -132,6 +133,34 @@ method: it builds the public MCP / A2A / missions addresses client-side
 (`lib/agent-connect-model.ts`) from the gateway origin
 (`window.__HOUSTON_ENGINE__.baseUrl`), the hosted agent id (= public slug), and
 the org slug (team workspace id, else the personal membership from `GET /v1/orgs`).
+
+**Gateway 5xx are not one thing — read the body before you toast (HOU-1170).**
+The managed cloud sleeps one engine pod per agent, so a normal chat open fires a
+burst of reads at a pod that may still be booting. `cp/transient-retry.ts` is the
+ONE place the gateway's 5xx bodies are parsed, turning prose into the typed
+`UnavailableReason` union and picking that reason's backoff:
+
+| Gateway answer | Reason | Client behavior |
+| --- | --- | --- |
+| `503 {"error":"engine unavailable","detail":"agent is waking"}` (+`Retry-After`) | `engine-waking` | 4 extra attempts, `WAKE_RETRY_DELAYS_MS` = 15s of client patience on top of the gateway's own 8s `ensure-awake` leg per attempt. No toast unless the budget is spent. |
+| `503 {"error":"shared skills not configured"}` | `feature-absent` | Answered on the first attempt — retrying a deployment shape is pure waste. |
+| any other 502/503/504, or a transport drop | `handoff` | The original 2 blind retries (~2s, HOU-731). |
+
+Two rules that fall out of this and are easy to get wrong:
+- **`Retry-After` is unreadable.** The gateway sends no
+  `Access-Control-Expose-Headers`, and `Retry-After` is not CORS-safelisted, so a
+  browser cannot see it cross-origin. Classify on the BODY (read off a
+  `res.clone()` so the caller's parse is untouched).
+- **`capabilities.sharedSkills` lies.** The gateway hardcodes it `true` even with
+  no blob store bound, so it cannot gate the call. The 503 body is the only
+  honest signal: `tauriSharedSkills.list` resolves it to `configured: false`
+  (`app/src/lib/shared-skills-availability.ts`) so the surface renders its empty
+  state once and the query stops refetching — the capability flag itself is a
+  gateway-side fix.
+
+This does NOT weaken **no silent failures**: a wake 503 retried to success is not
+a failure the user's action produced, and an exhausted budget, a non-503, or any
+unrecognized body still throws and toasts exactly as before.
 
 **Strict-additive / iOS-safe rule.** `@houston/sdk` is consumed by BOTH web AND
 the native iOS app (via the JavaScriptCore bridge, `bridge/entry.ts`). iOS reaches

--- a/knowledge-base/provider-errors.md
+++ b/knowledge-base/provider-errors.md
@@ -134,6 +134,21 @@ deliberately not filtered by provider on this path (a FAILURE always is: this ca
 launched nothing, so an unrelated abandoned login says nothing about it) — and
 fires the same one-shot auto-resume.
 
+**The composer itself is gated on zero connected providers.** Before any error
+can happen, `useAgentChatPanel` replaces the ENTIRE chat input (textarea + the
+footer with the model picker, which otherwise shows a phantom model from the
+effective-provider default) with `ChatConnectAiEmptyState` — reusing the
+picker's `chat:modelSelector.picker.noProviders.*` copy and a "Connect an AI
+model" CTA into the AI Hub. Decision helper: `shouldReplaceComposerWithConnectAi`
+(`app/src/lib/composer-connect-ai.ts`) — CONFIRMED-zero only: statuses loaded
+without error, catalog ready, capabilities loaded, zero connected AND zero
+still-checking providers; any uncertainty falls back to the normal composer
+(no startup flash). Wiring: `app/src/hooks/use-connect-ai-composer.tsx` →
+first branch of `composerOverrideState` (`mode: "replace"`). While active it
+also suppresses the store `ProviderReconnectCard` (one CTA, not two).
+`ProviderLoginComplete` invalidation restores the composer with no extra
+wiring. E2E: `packages/web/e2e/connect-ai-empty-state.spec.ts`.
+
 **Feed dedup upgrades the label in place** (`ui/chat/src/feed-to-messages.ts`).
 Provider-error cards dedupe per turn on KIND ALONE; `provider` is deliberately out
 of the key, because the same failure routinely arrives unlabeled on one channel

--- a/knowledge-base/provider-errors.md
+++ b/knowledge-base/provider-errors.md
@@ -42,7 +42,7 @@ now removed.)
 | `QuotaExhausted`           | Long-window / billing-period limit. Wait won't help.                                    | Upgrade plan (`upgrade_url`), Switch provider.        |
 | `UsageLimitPaused`         | Plan-window limit hit (today: Anthropic claude-code's 5-hour subscription session limit). Fires from `rate_limit_event` `status:"rejected"` (structured `resetsAt` epoch), a `429` result whose body names a session/usage limit + reset, or the stderr "usage limit ... reset at" banner. Retrying now fails — wait for the reset. | Chat: `UsageLimitPausedCard` (title + "resets at {time}" from `resets_at`, plus Switch model — a different provider has its own limit). Routines surface "Waiting · resumes at HH:MM" via `routine_run.paused_until`. |
 | `ModelUnavailable`         | The requested model isn't available to this account (preview, deprecated, regioned).    | Switch to `suggested_fallback`, Pick another model. Names the PERSONAL account in the body when `credential.scope === "personal"` (see below). |
-| `Unauthenticated`          | Auth missing/expired/invalid. `cause` narrows the body copy.                            | Reconnect (drives `tauriProvider.launchLogin`); the card then WAITS on the `ProviderLoginComplete` WS event (launchLogin resolves at CLI spawn, not completion) and flips to a green "Reconnected" state with a "Send my message" CTA (`providerError.unauthenticated.sendAgain`, only shown when there's a failed prompt to resend) or a disabled "Signed in" badge, or shows the failure and re-arms with "Reconnect". |
+| `Unauthenticated`          | Auth missing/expired/invalid. `cause` narrows the body copy.                            | Reconnect, through the surface `reconnectSurface` picks (OAuth browser login / api-key dialog / local-endpoint dialog). The card then WAITS on the `ProviderLoginComplete` event (launchLogin resolves at spawn, not completion) and flips to a green "Reconnected" card with a disabled "Signed in" badge while the one-shot auto-resume runs, or shows the failure and re-arms with "Reconnect". **Names no provider → the generic variant** (plug icon, "Connect an AI provider", CTA opens the AI Hub) — see Attribution below. |
 | `NetworkUnreachable`       | Cannot reach the provider's API (DNS, connect refused, ECONNRESET).                     | Retry, Check status page.                            |
 | `ProviderInternal`         | 5xx from upstream, transient infra failure.                                             | Retry, Check status page.                            |
 | `SessionResumeMissing`     | Resume target is gone or unrecoverable. Codex: `no rollout found`. Anthropic: claude exits with `result/error_during_execution/duration_ms:0` on the very first stdout line — the `~/.claude/projects/<encoded-cwd>/<id>.jsonl` transcript is corrupt. Both runners auto-restart fresh; the card is informational. | Try again (re-sends after the auto-restart in case the fresh attempt also failed). |
@@ -86,6 +86,86 @@ failed is the caller's own by construction, so there is nothing to target and a
 scope argument could only contradict the gateway.
 
 Full picture: `knowledge-base/teams.md` → "Per-user AI accounts".
+
+## Attribution — `provider` is EVIDENCE, never a guess
+
+A card naming the WRONG provider is worse than one naming none: it sends the user
+to a sign-in that fixes nothing. Both halves shipped that bug — a GPT-5.6 user got
+a "Connect Gemini" card (the engine labelled the throw with the conversation's
+cached provider), and an OpenAI user was told to "Connect Anthropic" (the client
+filled an empty label from the composer's default). So every layer now either
+proves the provider or leaves the field empty, and the empty case has its own
+rendering.
+
+**Engine** (`packages/runtime/src/session/exec-turn.ts`). The catch attributes a
+thrown turn to `turnProvider` — the provider `resolveModel` actually resolved this
+turn onto, stamped the instant it returns. Then, in order: the turn's own PIN
+(canonicalized exactly as `resolveModel` would have, `canonicalPinProvider`, so a
+routine pinned to `openai` still names `openai-codex`), then `""` for a typed card
+/ `"unknown"` for the unknown-kind card (whose copy and bug-report id interpolate
+the word, so an empty string leaves a dangling `provider_error:unknown:`).
+`conv.provider` is NEVER read for attribution: it is the CACHED session's LAST
+provider, written only at conversation build, a backend switch, or after a
+successful `setModel`, so a turn that threw before that write inherited whatever
+provider the conversation happened to be created on. The label is only half of it
+— `noteAuthFailure` and `reportRevokedServedToken` are gated on a NON-EMPTY
+provider, so a `resolveModel` throw can no longer mark an innocent provider
+unusable or POST a revocation for the id `""`.
+
+**Client.** `resolveProviderErrorForChat`
+(`app/src/components/shell/provider-error-cards/not-connected.ts`) still fills an
+EMPTY provider in, but only with what `errorCardProvider` supplies, and that is
+the shared evidence chain `preferredProvider`
+(`app/src/components/chat-effective-provider.ts`): the turn's activity pin → the
+agent's configured provider → the chat's last-used provider, with empty strings
+treated as ABSENT rather than as a pick. The composer
+(`resolveEffectiveProvider`) runs the SAME chain and differs only in its last
+resort — it defaults to `"anthropic"`, the card does not. No evidence → `null` →
+the card keeps `provider: ""`.
+
+**The generic card.** `UnauthenticatedCard` with no provider drops every
+brand-specific element (glyph → plug icon, no provider name, no sign-in launch)
+and renders the `providerError.unauthenticated` generic keyset — `titleGeneric` /
+`bodyGeneric` / `connectProvider`, plus `reconnectedTitleGeneric` for the done
+phase (en/es/pt). Its CTA opens the AI Hub: with no provider there is no
+`surface`, and `launchLogin` on an unknown id 400s and dead-ends the card. ANY
+provider's successful `ProviderLoginComplete` then satisfies it — a SUCCESS is
+deliberately not filtered by provider on this path (a FAILURE always is: this card
+launched nothing, so an unrelated abandoned login says nothing about it) — and
+fires the same one-shot auto-resume.
+
+**Feed dedup upgrades the label in place** (`ui/chat/src/feed-to-messages.ts`).
+Provider-error cards dedupe per turn on KIND ALONE; `provider` is deliberately out
+of the key, because the same failure routinely arrives unlabeled on one channel
+and labeled on the other, and keying on it rendered BOTH. When the card already
+shown is the unlabeled one and a duplicate names the provider, the merge copies
+the LABEL ONLY onto the existing payload (same message key, so no React remount):
+the first card is the one carrying the retry state (`undelivered_prompt` /
+`failed_prompt` / `credential` / `retry_after_seconds` / `raw_excerpt`, often a
+more specific `cause`), and replacing it wholesale left auto-resume with nothing
+to re-send (HOU-718). Accepted edge: a mid-turn backend switch where BOTH
+providers fail unauthenticated collapses to one card.
+
+## `token_revoked`: loose for COPY, strict for DESTRUCTION
+
+Both classifiers (`packages/runtime/src/ai/provider-error.ts`
+`TERMINAL_SESSION_PATTERNS`, `backends/claude/errors.ts`) map loose phrasings —
+"your session has ended", "please log in again" — to `cause: "token_revoked"`,
+because "your access was revoked, sign in again" is the right thing to SAY about
+any 401 that reads terminal, and being wrong there costs one needless reconnect
+prompt. It is NOT the right thing to DO. The revoked-token report
+(`packages/runtime/src/auth/report-revoked.ts` → `POST
+/sandbox/credential/revoked`) deletes the credential for every runtime in the
+workspace, so it gates on its OWN strict list of machine-emitted markers:
+`token_revoked`, `has been revoked`, `access revoked`, `app_session_terminated`,
+`refresh_token_invalidated`. Anchored phrases, never the bare word "revoked" —
+that also matches a negation ("was not revoked") and unrelated fields
+(`"revoked_scopes": []`), each of which would sign a whole workspace out of a live
+credential. Add loose phrasings to the classifier freely; add to the report's list
+almost never (a missed report costs a manual reconnect; a false one destroys a
+working credential workspace-wide). Same asymmetry drives the host's terminal
+refresh codes — `knowledge-base/anthropic-credentials.md` → "What may sign a user
+out".
 
 ## The classifier trait
 
@@ -139,7 +219,7 @@ naming a reset ("You've hit your session limit · resets 3:30pm") →
 `allowed_warning` SILENT (a warning is still allowed), maps `rejected` →
 `UsageLimitPaused` reading the structured `resetsAt` epoch
 (`anthropic_classify::format_reset_time`), and leaves genuine throttles as
-`RateLimited`. Feed dedup by `(kind, provider)` collapses the mid-stream + the
+`RateLimited`. Feed dedup (per turn, by KIND) collapses the mid-stream + the
 terminal card to one. Before this, every `allowed_warning` raised a spurious
 RateLimited card and the session limit showed a per-minute "Retry" card with
 claude's raw English body — see Esteban / 2026-06-11.
@@ -165,8 +245,9 @@ emits `ProviderError::Unauthenticated` once (deduped via
 `CodexAccumulator::auth_card_emitted`), fires after `thread.started` so it
 persists, and renders the same login-button `UnauthenticatedCard` Claude
 gets. Transient reconnects keep the deferred marker. The frontend
-(`feed-to-messages`) also dedupes provider-error cards by `(kind, provider)`
-so the transient stderr card and the persisted stdout card collapse to one.
+(`feed-to-messages`) also dedupes provider-error cards per turn by KIND alone,
+so the transient stderr card and the persisted stdout card collapse to one (a
+labeled duplicate upgrades the unlabeled card in place — see Attribution).
 
 Codex prints the kill in more than one phrasing — `is_auth_error` /
 `is_terminal_auth_error` cover both "Your session has ended. Please log in
@@ -209,8 +290,12 @@ rendered in `ChatPanel.afterMessages`) AUTO-DISMISSES for codex: its 3s
 `checkStatus` poll sees `~/.codex/auth.json` still present and clears
 `authRequired`, so the login button flashes then vanishes. So
 `use-agent-chat-panel.afterMessages` suppresses the store card whenever the
-feed already carries an inline `provider_error` `unauthenticated` card for
-this chat's provider — the persisted inline card is the stable surface.
+feed already carries an inline `provider_error` `unauthenticated` card
+(`isInlineAuthCard`), REGARDLESS of which provider that card names — it carries
+the provider the turn actually failed on, which outranks the chat-provider
+resolution chain, and a stale activity record once rendered a second, wrong-
+provider store card beside the correct inline one. The persisted inline card is
+the stable surface.
 (The underlying probe false-positive is still unfixed; it needs a
 server-validating auth check.)
 
@@ -228,6 +313,19 @@ button now names its real action, `providerReconnect.signInAgain` ("Sign in
 again"), instead of borrowing the shared `common:actions.tryAgain`; the
 now-unused `providerReconnect.reconnect` / `providerReconnect.tryAgain` i18n
 keys were deleted.
+
+The inline card is split by CONCERN, not by variant, and the split is the reason
+each half is testable: `auth.tsx` renders only what the other three decide,
+`auth-presentation.ts` maps phase → copy, `use-provider-login.ts` owns every side
+effect (cancelLogin → launchLogin relaunch, the `ProviderLoginComplete`
+subscription, the one-shot auto-resume, the AI-Hub fallback when no provider is
+named), and `reconnect-surface.ts` routes a provider id to its connect surface.
+That last one exists because sending an api-key provider through `launchLogin` is
+a guaranteed 400 ("nvidia does not use OAuth sign-in") that flips the card to its
+failed phase and dead-ends the user (HOU-1077): api-key providers reconnect
+through the same paste dialog Settings uses, `openai-compatible` through the
+guided endpoint dialog, and both fire the same `ProviderLoginComplete` so the
+auto-resume runs on every surface.
 
 **Where the card actually mounts (don't let this regress).** A
 `FeedItem::ProviderError` becomes a `ChatMessage` with `providerError` set
@@ -372,5 +470,7 @@ unchanged.
 | Protocol     | `engine/houston-engine-protocol/src/lib.rs` (re-exports `ProviderError`)          |
 | TS type      | `ui/chat/src/types.ts`                                                            |
 | Card router  | `app/src/components/shell/provider-error-card.tsx`                                |
-| Card pieces  | `app/src/components/shell/provider-error-cards/` — `limits.tsx` (rate-limited + usage-limit-paused), `quota.tsx` (quota-exhausted + model-unavailable, the one that names the account), `transient.tsx` (retry-now infra: network / internal / malformed), `auth.tsx`, `terminal.tsx`, `shared.tsx` (`AsyncActionButton` / `RetryButton` / `StatusPageButton`) |
+| Card pieces  | `app/src/components/shell/provider-error-cards/` — `limits.tsx` (rate-limited + usage-limit-paused), `quota.tsx` (quota-exhausted + model-unavailable, the one that names the account), `transient.tsx` (retry-now infra: network / internal / malformed), `terminal.tsx`, `shared.tsx` (`AsyncActionButton` / `RetryButton` / `StatusPageButton`) |
+| Auth card    | same dir, four files: `auth.tsx` (render only) · `auth-presentation.ts` (phase → copy) · `use-provider-login.ts` (launch / cancel / auto-resume lifecycle) · `reconnect-surface.ts` (which connect surface an id opens), with `reconnect-dialog.tsx` for the two non-OAuth ones |
+| Attribution  | engine `packages/runtime/src/session/exec-turn.ts` (`turnProvider` → pin → `""`) · client `provider-error-cards/not-connected.ts` (`errorCardProvider`) over `app/src/components/chat-effective-provider.ts` (`preferredProvider`) · dedup/label merge `ui/chat/src/feed-to-messages.ts` |
 | i18n         | `app/src/locales/{en,es,pt}/shell.json` → `providerError.*`                       |

--- a/packages/host/src/channel/probe-wake.ts
+++ b/packages/host/src/channel/probe-wake.ts
@@ -1,0 +1,81 @@
+import type { ServerResponse } from "node:http";
+import type { ChannelCtx, RuntimeEndpoint, RuntimeLauncher } from "../ports";
+import { json } from "../routes/http";
+
+/**
+ * Idempotent, read-only status probes the client fires on mount (provider
+ * picker, usage meter, connect dialog). They report what a runtime *knows*, so
+ * an unanswered one costs the user nothing but a retry — unlike a turn, where
+ * waiting out the cold boot IS the point. Deliberately narrow: GET only, exact
+ * paths, no route that mutates or streams. `rest` is the dispatch remainder
+ * (routes/agents.ts, routes/setup-runtime.ts), i.e. no leading slash.
+ */
+const PROBE_ROUTES = new Set(["providers", "providers/usage", "auth/status"]);
+
+/**
+ * How long a probe waits for a cold runtime before answering "ask again". Long
+ * enough that an already-warm (or nearly-warm) runtime answers for real, short
+ * enough that the picker never looks hung: the alternative was holding the
+ * socket for the launcher's whole boot budget (60s) behind one spinner.
+ */
+const PROBE_WAKE_DEADLINE_MS = 1_500;
+
+/**
+ * Wake the agent's runtime for one dispatched request, and say where to reach
+ * it — or null when the request has already been ANSWERED (503) and the caller
+ * must stop.
+ *
+ * Everything but a read-only probe awaits the wake outright: a turn, an SSE
+ * subscription or a login has nothing useful to say before its runtime is up.
+ * A probe instead RACES the wake against a short deadline and, when the boot is
+ * slower, answers 503 + `Retry-After` so the socket is freed in milliseconds
+ * instead of minutes (the provider picker's spinner used to sit on exactly
+ * this, for a full cold boot, on every zero-provider desktop launch).
+ *
+ * Two properties make that safe:
+ * - The boot is NEVER aborted. `ensureAwake` keeps running in the background,
+ *   so the client's retry a couple of seconds later meets a live runtime rather
+ *   than paying for a fresh cold start.
+ * - It cannot double-spawn. `ensureAwake` is single-flight per agent
+ *   (launcher/process.ts `booting`), so the retry — and every other caller
+ *   arriving meanwhile — joins the SAME spawn.
+ *
+ * The launcher's own `status` is deliberately not consulted: mid-boot it
+ * already reports "running" (the live-set entry exists before the child is
+ * healthy), which is exactly the case this guards. A warm runtime costs nothing
+ * here — `ensureAwake` resolves at once and wins the race.
+ */
+export async function wakeForDispatch(
+  launcher: RuntimeLauncher,
+  ctx: ChannelCtx,
+  method: string,
+  rest: string,
+  res: ServerResponse,
+): Promise<RuntimeEndpoint | null> {
+  const wake = launcher.ensureAwake(ctx.agent);
+  if (method !== "GET" || !PROBE_ROUTES.has(rest)) return wake;
+
+  // A boot that fails after this request has been answered has no one left to
+  // tell; the next probe re-triggers the spawn and surfaces the failure then.
+  // (A failure BEFORE the deadline still rejects out of the race below.)
+  wake.catch(() => {});
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const tooSlow = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), PROBE_WAKE_DEADLINE_MS);
+    timer.unref?.();
+  });
+  try {
+    const endpoint = await Promise.race([wake, tooSlow]);
+    if (endpoint) return endpoint;
+  } finally {
+    clearTimeout(timer);
+  }
+  json(
+    res,
+    503,
+    { error: "the agent's runtime is still starting, try again shortly" },
+    { "Retry-After": "2" },
+  );
+  return null;
+}

--- a/packages/host/src/channel/proxy-probe.test.ts
+++ b/packages/host/src/channel/proxy-probe.test.ts
@@ -1,0 +1,310 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { MemoryCredentialStore } from "../credentials/store";
+import type { Agent, Workspace } from "../domain/types";
+import type { ForwardRequest, RuntimeEndpoint } from "../ports";
+import { ProxyChannel } from "./proxy";
+
+/**
+ * HOU cold-boot probe behavior: the desktop fires read-only status probes
+ * (providers, provider usage, auth status) the moment a chat or the provider
+ * picker mounts. On a sleeping runtime those used to hold the HTTP socket for
+ * the WHOLE cold boot (up to the 60s health budget), so the picker spinner sat
+ * there. They must answer fast with a retryable 503 while the boot continues in
+ * the background — a turn (or any other route) still waits for the runtime.
+ */
+
+const ws: Workspace = {
+  id: "w1",
+  ownerUserId: "alice",
+  kind: "personal",
+  name: "Personal",
+  slug: "alice",
+  runtime: "local",
+  createdAt: 1,
+};
+const agent: Agent = {
+  id: "agent-1",
+  workspaceId: "w1",
+  name: "Sales",
+  createdAt: 1,
+};
+const ctx = { workspace: ws, agent };
+
+const urlFor = (rest: string) => new URL(`http://host/agents/agent-1/${rest}`);
+const request = () => ({ headers: {} }) as unknown as IncomingMessage;
+
+function fakeRes() {
+  const captured = {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    body: "",
+    writeHead(status: number, headers: Record<string, string> = {}) {
+      captured.statusCode = status;
+      Object.assign(captured.headers, headers);
+      return captured;
+    },
+    end(chunk?: Buffer) {
+      captured.body = chunk ? chunk.toString() : "";
+      return captured;
+    },
+  };
+  return captured;
+}
+
+const res = () => fakeRes();
+const asServerResponse = (r: ReturnType<typeof fakeRes>) =>
+  r as unknown as ServerResponse;
+
+/**
+ * A launcher whose runtime is asleep and whose boot is released by the test —
+ * single-flight like the real ProcessLauncher: every caller during a boot rides
+ * the SAME spawn, so a racing probe can never double-spawn.
+ */
+function coldRuntime() {
+  const endpoint: RuntimeEndpoint = {
+    baseUrl: "http://127.0.0.1:5000",
+    token: "rt-token",
+  };
+  let settle!: () => void;
+  let abort!: (err: Error) => void;
+  let spawns = 0;
+  let awake = false;
+  const sleeps: string[] = [];
+  const boot = new Promise<RuntimeEndpoint>((resolve, reject) => {
+    settle = () => {
+      awake = true;
+      resolve(endpoint);
+    };
+    abort = reject;
+  });
+  return {
+    endpoint,
+    sleeps,
+    get spawns() {
+      return spawns;
+    },
+    ready: () => settle(),
+    crash: (err: Error) => abort(err),
+    launcher: {
+      async ensureAwake() {
+        if (awake) return endpoint;
+        if (spawns === 0) spawns++;
+        return boot;
+      },
+      async sleep(agentId: string) {
+        sleeps.push(agentId);
+      },
+      async destroy() {},
+      async status() {
+        // Mid-boot the real launcher already reports "running" (the live-set
+        // entry exists before the child is healthy) — the probe path must not
+        // trust it as "reachable".
+        return "running" as const;
+      },
+    },
+  };
+}
+
+function channelFor(rt: ReturnType<typeof coldRuntime>) {
+  const forwarded: ForwardRequest[] = [];
+  const channel = new ProxyChannel({
+    launcher: rt.launcher,
+    proxy: {
+      async forward(_endpoint, req) {
+        forwarded.push(req);
+      },
+    },
+    credentials: new MemoryCredentialStore(),
+    forwardActingHeader: false,
+  });
+  return { channel, forwarded };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+test("a provider probe answers 503 + Retry-After instead of holding the socket through a cold boot", async () => {
+  const rt = coldRuntime();
+  const { channel, forwarded } = channelFor(rt);
+  const out = res();
+
+  const dispatched = channel.dispatch(
+    ctx,
+    "GET",
+    "providers",
+    urlFor("providers"),
+    request(),
+    asServerResponse(out),
+  );
+  let answered = false;
+  void dispatched.then(() => {
+    answered = true;
+  });
+
+  await vi.advanceTimersByTimeAsync(100);
+  expect(answered).toBe(false); // a fast boot must still be awaited
+
+  await vi.advanceTimersByTimeAsync(1_500);
+  await dispatched;
+
+  expect(out.statusCode).toBe(503);
+  expect(out.headers["Retry-After"]).toBe("2");
+  expect(JSON.parse(out.body)).toMatchObject({ error: expect.any(String) });
+  expect(forwarded).toEqual([]); // nothing reached a runtime that isn't up
+});
+
+test("the deadlined probe leaves the boot running, so the client's retry lands on a live runtime", async () => {
+  const rt = coldRuntime();
+  const { channel, forwarded } = channelFor(rt);
+
+  await (async () => {
+    const first = channel.dispatch(
+      ctx,
+      "GET",
+      "providers",
+      urlFor("providers"),
+      request(),
+      asServerResponse(res()),
+    );
+    await vi.advanceTimersByTimeAsync(1_500);
+    await first;
+  })();
+
+  // The boot was NOT aborted — it completes on its own moments later.
+  expect(rt.sleeps).toEqual([]);
+  rt.ready();
+
+  const out = res();
+  await channel.dispatch(
+    ctx,
+    "GET",
+    "providers",
+    urlFor("providers"),
+    request(),
+    asServerResponse(out),
+  );
+
+  expect(forwarded.map((f) => f.path)).toEqual(["/providers"]);
+  expect(out.statusCode).toBe(0); // untouched: the proxy owns the response now
+  expect(rt.spawns).toBe(1); // one shared boot, never a second spawn
+});
+
+test.each([
+  "providers",
+  "providers/usage",
+  "auth/status",
+])("the read-only probe route %s fast-fails on a cold runtime", async (rest) => {
+  const rt = coldRuntime();
+  const { channel, forwarded } = channelFor(rt);
+  const out = res();
+
+  const dispatched = channel.dispatch(
+    ctx,
+    "GET",
+    rest,
+    urlFor(rest),
+    request(),
+    asServerResponse(out),
+  );
+  await vi.advanceTimersByTimeAsync(1_500);
+  await dispatched;
+
+  expect(out.statusCode).toBe(503);
+  expect(forwarded).toEqual([]);
+});
+
+test("a warm runtime forwards a probe immediately, with no deadline in play", async () => {
+  const rt = coldRuntime();
+  rt.ready(); // already awake
+  const { channel, forwarded } = channelFor(rt);
+  const out = res();
+
+  await channel.dispatch(
+    ctx,
+    "GET",
+    "providers",
+    urlFor("providers"),
+    request(),
+    asServerResponse(out),
+  );
+
+  expect(forwarded.map((f) => f.path)).toEqual(["/providers"]);
+  expect(out.statusCode).toBe(0);
+});
+
+test("a non-probe route keeps waiting for the whole cold boot", async () => {
+  const rt = coldRuntime();
+  const { channel, forwarded } = channelFor(rt);
+
+  const dispatched = channel.dispatch(
+    ctx,
+    "GET",
+    "events",
+    urlFor("events"),
+    request(),
+    asServerResponse(res()),
+  );
+  let answered = false;
+  void dispatched.then(() => {
+    answered = true;
+  });
+
+  await vi.advanceTimersByTimeAsync(30_000);
+  expect(answered).toBe(false); // the SSE stream waits for its runtime
+
+  rt.ready();
+  await dispatched;
+  expect(forwarded.map((f) => f.path)).toEqual(["/events"]);
+});
+
+test("a probe whose boot fails before the deadline surfaces the failure", async () => {
+  const rt = coldRuntime();
+  const { channel } = channelFor(rt);
+
+  const dispatched = channel.dispatch(
+    ctx,
+    "GET",
+    "providers",
+    urlFor("providers"),
+    request(),
+    asServerResponse(res()),
+  );
+  rt.crash(new Error("runtime exited before becoming healthy"));
+
+  await expect(dispatched).rejects.toThrow("exited before becoming healthy");
+});
+
+test("a boot that fails AFTER the probe was answered is not an unhandled rejection", async () => {
+  const rt = coldRuntime();
+  const { channel } = channelFor(rt);
+  const unhandled = vi.fn();
+  process.on("unhandledRejection", unhandled);
+  try {
+    const dispatched = channel.dispatch(
+      ctx,
+      "GET",
+      "providers",
+      urlFor("providers"),
+      request(),
+      asServerResponse(res()),
+    );
+    await vi.advanceTimersByTimeAsync(1_500);
+    await dispatched;
+
+    // Real timers from here: Node only reports an unhandled rejection once the
+    // microtask queue drains on a real event-loop turn.
+    vi.useRealTimers();
+    rt.crash(new Error("runtime exited before becoming healthy"));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(unhandled).not.toHaveBeenCalled();
+  } finally {
+    process.off("unhandledRejection", unhandled);
+  }
+});

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -14,6 +14,7 @@ import {
 import { MAX_JSON_BYTES, readBody } from "../routes/read-body";
 import { captureRuntimeCredential } from "./capture-credential";
 import { errorCodeFrom, TurnFireError } from "./fire-error";
+import { wakeForDispatch } from "./probe-wake";
 
 /**
  * Forwards one authorized request to a standing runtime and streams the reply
@@ -71,8 +72,17 @@ export class ProxyChannel implements RuntimeChannel {
     req: IncomingMessage,
     res: ServerResponse,
   ): Promise<void> {
-    // First touch spins the runtime up (a GKE cold start can take a minute or two).
-    const endpoint = await this.opts.launcher.ensureAwake(ctx.agent);
+    // First touch spins the runtime up (a GKE cold start can take a minute or
+    // two). Read-only probes don't hold the socket for all of it — they answer
+    // "retry shortly" and let the boot finish in the background.
+    const endpoint = await wakeForDispatch(
+      this.opts.launcher,
+      ctx,
+      method,
+      rest,
+      res,
+    );
+    if (!endpoint) return; // already answered 503; the boot lives on
 
     // Collect the raw body for non-GET so arbitrary payloads ({text}, {code},
     // {activeProvider}) pass through untouched. Strip the caller's `token` auth

--- a/packages/host/src/credentials/disconnect.test.ts
+++ b/packages/host/src/credentials/disconnect.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "vitest";
+import type { CredentialStore, WorkspaceCredential } from "../ports";
+import { disconnectRejectedCredential } from "./disconnect";
+import { RemoteCredentialDeadError } from "./remote-store";
+
+/**
+ * Compare-and-delete: the token endpoint's rejection condemns exactly ONE
+ * credential, and the store can move on while the endpoint is still answering.
+ * The re-read decides whether the rejection still applies — and it must never
+ * hand the CONDEMNED credential back as a supersession.
+ */
+
+const rejected: WorkspaceCredential = {
+  workspaceId: "w1",
+  provider: "openai-codex",
+  accessToken: "AT-dead",
+  refreshToken: "rt.dead",
+  expiresAt: 1,
+};
+
+function store(over: Partial<CredentialStore> = {}): CredentialStore {
+  return {
+    get: async () => null,
+    put: async () => {},
+    remove: async () => {},
+    removeIfAccess: async () => false,
+    ...over,
+  };
+}
+
+const disconnect = (credentials: CredentialStore) =>
+  disconnectRejectedCredential({
+    credentials,
+    workspaceId: "w1",
+    rejected,
+    reason: "invalid_grant",
+  });
+
+test("a matching credential is dropped and the caller told it is gone", async () => {
+  const removals: string[] = [];
+  const result = await disconnect(
+    store({
+      removeIfAccess: async (_w, _p, accessSha256) => {
+        removals.push(accessSha256);
+        return true;
+      },
+      get: async () => {
+        throw new Error("must not re-read after a successful delete");
+      },
+    }),
+  );
+  expect(result).toBeNull();
+  expect(removals).toHaveLength(1);
+});
+
+test("a genuinely superseding credential is handed back to be served", async () => {
+  const superseding: WorkspaceCredential = {
+    ...rejected,
+    accessToken: "AT-reconnected",
+    refreshToken: "rt.fresh",
+    expiresAt: Date.now() + 3_600_000,
+  };
+  expect(await disconnect(store({ get: async () => superseding }))).toBe(
+    superseding,
+  );
+});
+
+test("the re-read never resurrects the credential that was just rejected", async () => {
+  // RemoteCredentialStore answers `get` from a 15s cache, so the read that
+  // follows a failed compare-and-delete can return the VERY credential the
+  // endpoint rejected. Serving it as a supersession keeps a dead token alive
+  // and loops the same rejection on every turn.
+  expect(await disconnect(store({ get: async () => ({ ...rejected }) }))).toBe(
+    null,
+  );
+});
+
+test("a failing re-read reads as absent, not as a 500 escaping the route", async () => {
+  // This runs inside the serve route's catch. A gateway blip here would escape
+  // as an unhandled 500 instead of the marked 404 the runtime knows how to act
+  // on.
+  expect(
+    await disconnect(
+      store({
+        get: async () => {
+          throw new RemoteCredentialDeadError("gateway said the row is dead");
+        },
+      }),
+    ),
+  ).toBeNull();
+});

--- a/packages/host/src/credentials/disconnect.ts
+++ b/packages/host/src/credentials/disconnect.ts
@@ -1,0 +1,89 @@
+import { accessDigest } from "@houston/protocol/access-digest";
+import type { WorkspaceId } from "../domain/types";
+import type {
+  CredentialActing,
+  CredentialStore,
+  WorkspaceCredential,
+} from "../ports";
+import { sharedCredentialRefresher } from "./refresh-coalescer";
+
+/**
+ * What the control plane does when the OAuth server rejects a refresh TOKEN
+ * (invalid_grant / refresh_token_invalidated — see oauth-token-exchange.ts).
+ * That verdict never heals on retry: the credential is dead until the user
+ * reconnects, and leaving it in place loops the same rejection on every serve
+ * while turns fail on an expired access token.
+ *
+ * So the credential goes — but only the one that was rejected. This is the same
+ * rule the revoked-token report follows (HOU-952): the rejection condemns
+ * exactly the credential the refresher was handed, and time passes between
+ * reading it and the endpoint answering. A reconnect, or a sibling host that
+ * rotated the token in that window, leaves a VALID row here; an unconditional
+ * delete would sign the user out of the connection they just made. The digest
+ * names the dead token, so compare-and-delete can drop it and nothing else.
+ */
+export async function disconnectRejectedCredential(args: {
+  credentials: CredentialStore;
+  workspaceId: WorkspaceId;
+  /** The credential whose refresh was rejected — the only one this may drop. */
+  rejected: WorkspaceCredential;
+  /** WHOSE credential it is (HOU-976); undefined = the shared team row. */
+  acting?: CredentialActing;
+  /** The rejection's message, for the disconnect log line. */
+  reason: string;
+}): Promise<WorkspaceCredential | null> {
+  const { credentials, workspaceId, rejected, acting } = args;
+  // The digest names the DEAD token. The caller hands us the credential IT
+  // read, which the coalescer may have re-read and rotated past in the same
+  // cycle — digesting the caller's copy is the fail-safe direction: a mismatch
+  // deletes nothing, and the next serve re-reads and settles the question.
+  const deadDigest = accessDigest(rejected.accessToken);
+  const dropped = await credentials.removeIfAccess(
+    workspaceId,
+    rejected.provider,
+    deadDigest,
+    // The scope says WHICH kind of row; the acting identity says WHOSE.
+    { scope: rejected.scope, ...acting },
+  );
+  // Either way this key's coalesced state is worthless: a dropped credential
+  // must never be served from the result cache, and a superseded one has to be
+  // re-read rather than refreshed again with the token just rejected.
+  sharedCredentialRefresher.forget(workspaceId, rejected.provider, acting);
+  if (dropped) {
+    console.error(
+      `[credential-disconnect] refresh token rejected for ${rejected.provider}, disconnecting:`,
+      args.reason,
+    );
+    return null;
+  }
+  // The store moved on under us — the rejection was about a credential nobody
+  // holds any more. Hand back what the store holds NOW so the caller can serve
+  // it (through its own checks); null when the row is simply gone. This read
+  // runs inside the serve route's catch, so a gateway blip here must read as
+  // "absent" rather than escape as a 500 in place of the marked 404 the runtime
+  // knows how to act on.
+  const current = await credentials
+    .get(workspaceId, rejected.provider, acting)
+    .catch((error: unknown) => {
+      console.error(
+        `[credential-disconnect] could not re-read the ${rejected.provider} credential after a rejected refresh:`,
+        error instanceof Error ? error.message : error,
+      );
+      return null;
+    });
+  // RemoteCredentialStore answers `get` from a short-lived cache, so this read
+  // can return the VERY credential the endpoint just rejected. That is not a
+  // supersession — it is confirmation the dead token is still the stored one,
+  // and serving it would loop the same rejection on every turn.
+  if (current && accessDigest(current.accessToken) !== deadDigest) {
+    console.info(
+      `[credential-disconnect] refresh token rejected for ${rejected.provider}, but the stored credential changed underneath: leaving it in place`,
+    );
+    return current;
+  }
+  console.info(
+    `[credential-disconnect] refresh token rejected for ${rejected.provider}; the stored credential is`,
+    current ? "still the rejected one" : "already gone",
+  );
+  return null;
+}

--- a/packages/host/src/credentials/oauth-token-exchange.ts
+++ b/packages/host/src/credentials/oauth-token-exchange.ts
@@ -1,0 +1,182 @@
+import type { WorkspaceCredential } from "../ports";
+
+/**
+ * ONE standard `grant_type=refresh_token` exchange against a provider's token
+ * endpoint, plus the classification of its failures. Split from `refresh.ts` so
+ * the credential-lifecycle policy there (when to refresh, how many times, what
+ * the serve route does with each outcome) reads without the HTTP detail.
+ */
+
+/**
+ * OAuth error codes that condemn the refresh TOKEN itself. `invalid_grant` is
+ * RFC 6749's verdict on the grant; `refresh_token_invalidated` is what OpenAI
+ * answers when the session was ended server-side (observed — the serve route
+ * and its tests have relied on that disconnect since the flow shipped).
+ *
+ * RFC 6749's `invalid_client` is deliberately ABSENT: it condemns the client
+ * credentials we send — one hardcoded public client id shared by every install
+ * — not the user's token. Were the provider to retire that id, treating it as
+ * terminal would delete every workspace's credential on its next refresh, with
+ * no path back.
+ */
+const TERMINAL_ERROR_CODES = [
+  "invalid_grant",
+  "refresh_token_invalidated",
+] as const;
+
+/** The only codes that may sign a user out. */
+export type TerminalErrorCode = (typeof TERMINAL_ERROR_CODES)[number];
+
+const TERMINAL: ReadonlySet<string> = new Set(TERMINAL_ERROR_CODES);
+
+const isTerminalCode = (code: string): code is TerminalErrorCode =>
+  TERMINAL.has(code);
+
+/**
+ * The token endpoint's verdict on the refresh token itself — a 400/401 whose
+ * body names a `TerminalErrorCode`. Unlike a network blip, a 5xx, or an
+ * unattributed 4xx from an edge node, this never heals on retry: the credential
+ * is dead until the user reconnects the provider. The serve route DELETES the
+ * credential on this error, so nothing else may throw it — a misclassified
+ * transient failure silently signs the user out.
+ */
+export class RefreshRejectedError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code: TerminalErrorCode,
+  ) {
+    super(message);
+    this.name = "RefreshRejectedError";
+  }
+}
+
+/**
+ * A failure that provably happened BEFORE the request left this process, so the
+ * grant cannot have been consumed. Only these may be retried.
+ *
+ * Everything else — a timeout, an abort, a 5xx, a 429, a mid-stream reset — is
+ * ambiguous: the endpoint may already have consumed the rotating refresh token
+ * and rotated it into a response we never read. Retrying then POSTs a spent
+ * grant, earns `invalid_grant`, and the serve route DELETES the user's
+ * credential over what was only a blip. Those surface as plain `Error`s: the
+ * route serves the stored token best-effort and the next serve tries again.
+ */
+export class TransientRefreshError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "TransientRefreshError";
+  }
+}
+
+/**
+ * Socket-level failure codes that mean no byte of the POST reached the server.
+ * `ECONNRESET` is NOT here: a reset can land after the request was written and
+ * the grant consumed.
+ */
+const PRE_CONNECT_CODES: ReadonlySet<string> = new Set([
+  "ENOTFOUND", // DNS said the host does not exist
+  "EAI_AGAIN", // DNS lookup failed / timed out
+  "ECONNREFUSED", // the port answered with a refusal
+]);
+
+/**
+ * True when a thrown fetch failure provably predates the connection. undici
+ * raises `TypeError: fetch failed` and hangs the real reason off `cause`; an
+ * `AbortError`/`TimeoutError` DOMException has no such cause and is ambiguous
+ * by construction.
+ */
+function isPreConnectFailure(err: unknown): boolean {
+  const code = (err as { cause?: { code?: unknown } } | null)?.cause?.code;
+  return typeof code === "string" && PRE_CONNECT_CODES.has(code);
+}
+
+/** A hung token endpoint would otherwise stall every credential serve. */
+const REFRESH_TIMEOUT_MS = 10_000;
+
+/**
+ * The error code of an OAuth failure body, in either shape we see in the wild:
+ * RFC 6749's `{"error":"invalid_grant"}` and OpenAI's nested
+ * `{"error":{"code":"refresh_token_invalidated"}}`. An unparseable or otherwise
+ * shaped body yields `null`, which keeps the failure non-terminal: we never
+ * disconnect a user over a response we could not read. The raw body still
+ * reaches them through the thrown message, so nothing is swallowed.
+ */
+function oauthErrorCode(body: string): string | null {
+  let parsed: { error?: unknown };
+  try {
+    parsed = JSON.parse(body) as { error?: unknown };
+  } catch {
+    return null; // an HTML error page from an edge node, a truncated body, ...
+  }
+  if (typeof parsed.error === "string") return parsed.error;
+  const nested = (parsed.error as { code?: unknown } | null)?.code;
+  return typeof nested === "string" ? nested : null;
+}
+
+/**
+ * Perform one refresh exchange. Throws `RefreshRejectedError` (terminal — the
+ * user must reconnect), `TransientRefreshError` (the request never left this
+ * process; safe to retry), or a plain `Error` (stop, but the caller keeps
+ * serving the stored token rather than disconnecting).
+ */
+export async function exchangeRefreshToken(
+  cfg: { tokenUrl: string; clientId: string },
+  cred: WorkspaceCredential,
+): Promise<WorkspaceCredential> {
+  let res: Response;
+  try {
+    res = await fetch(cfg.tokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: cfg.clientId,
+        refresh_token: cred.refreshToken,
+      }),
+      signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS),
+    });
+  } catch (err) {
+    const message = `OAuth refresh request failed for ${cred.provider}: ${String(err)}`;
+    throw isPreConnectFailure(err)
+      ? new TransientRefreshError(message, { cause: err })
+      : new Error(message, { cause: err });
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    const message = `OAuth refresh failed (${res.status}) for ${cred.provider}: ${body.slice(0, 200)}`;
+    const code = oauthErrorCode(body);
+    // A 5xx/429 gets no retry either: the endpoint may have consumed the grant
+    // before failing, and a second POST would spend a token we no longer hold.
+    if (
+      (res.status === 400 || res.status === 401) &&
+      code !== null &&
+      isTerminalCode(code)
+    ) {
+      throw new RefreshRejectedError(message, res.status, code);
+    }
+    throw new Error(message);
+  }
+  const json = (await res.json()) as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+  };
+  if (
+    !json.access_token ||
+    !json.refresh_token ||
+    typeof json.expires_in !== "number"
+  ) {
+    throw new Error(
+      `OAuth refresh response missing fields for ${cred.provider}`,
+    );
+  }
+  return {
+    workspaceId: cred.workspaceId,
+    provider: cred.provider,
+    accessToken: json.access_token,
+    refreshToken: json.refresh_token, // rotation-safe: persist whatever comes back
+    accountId: cred.accountId, // the refresh endpoint doesn't return it; it's stable
+    expiresAt: Date.now() + json.expires_in * 1000,
+  };
+}

--- a/packages/host/src/credentials/refresh-coalescer.test.ts
+++ b/packages/host/src/credentials/refresh-coalescer.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import type { WorkspaceCredential } from "../ports";
+import {
+  CredentialGoneError,
+  CredentialRefreshCoalescer,
+} from "./refresh-coalescer";
+
+/**
+ * The serve path refreshes ONE credential per (workspace, scope, provider) at a
+ * time. openai-codex rotates the refresh token on every use, so a concurrent
+ * burst (one runtime process per agent, each serving per turn AND per
+ * /providers poll) used to spend the same refresh token N times: the first
+ * exchange wins, the rest come back invalid_grant, and the route reads that as
+ * "session ended" and deletes the user's credential.
+ */
+
+/** Fake clock shared by the coalescer's TTL and refresh.ts's isExpiring. */
+let clock = 1_700_000_000_000;
+
+function tick(ms: number) {
+  clock += ms;
+  vi.setSystemTime(clock);
+}
+
+beforeEach(() => {
+  clock = 1_700_000_000_000;
+  vi.useFakeTimers();
+  vi.setSystemTime(clock);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const now = () => clock;
+
+function cred(over: Partial<WorkspaceCredential> = {}): WorkspaceCredential {
+  return {
+    workspaceId: "w1",
+    provider: "openai-codex",
+    accessToken: "AT-old",
+    refreshToken: "RT-old",
+    expiresAt: clock + 1_000, // inside the 120s skew → expiring
+    ...over,
+  };
+}
+
+/** A rotated credential: new access + refresh, an hour of life. */
+function rotated(suffix = ""): WorkspaceCredential {
+  return cred({
+    accessToken: `AT-new${suffix}`,
+    refreshToken: `RT-new${suffix}`,
+    expiresAt: clock + 3_600_000,
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function harness(
+  doRefresh: (c: WorkspaceCredential) => Promise<WorkspaceCredential>,
+  load: () => Promise<WorkspaceCredential | null>,
+) {
+  const calls: WorkspaceCredential[] = [];
+  const persisted: WorkspaceCredential[] = [];
+  const coalescer = new CredentialRefreshCoalescer(async (c) => {
+    calls.push(c);
+    return doRefresh(c);
+  }, now);
+  const run = (acting?: { actingAs: string }) =>
+    coalescer.run({
+      workspaceId: "w1",
+      provider: "openai-codex",
+      acting,
+      load,
+      persist: async (c) => {
+        persisted.push(c);
+      },
+    });
+  return { coalescer, calls, persisted, run };
+}
+
+test("a concurrent burst produces exactly one refresh and one persist", async () => {
+  const gate = deferred<WorkspaceCredential>();
+  const expiring = cred();
+  const { calls, persisted, run } = harness(
+    () => gate.promise,
+    async () => expiring,
+  );
+
+  const flights = [run(), run(), run(), run(), run()];
+  gate.resolve(rotated());
+  const results = await Promise.all(flights);
+
+  expect(calls).toHaveLength(1);
+  expect(calls[0]?.refreshToken).toBe("RT-old"); // the token spent exactly once
+  expect(persisted).toHaveLength(1);
+  for (const result of results) expect(result).toBe(results[0]);
+  expect(results[0]?.accessToken).toBe("AT-new");
+});
+
+test("a fresh result answers later serves without refreshing, until the TTL", async () => {
+  const expiring = cred();
+  const { calls, run } = harness(
+    async () => rotated(),
+    async () => expiring,
+  );
+
+  await run();
+  expect(calls).toHaveLength(1);
+
+  tick(29_000); // inside the result TTL, rotated token still valid
+  await run();
+  expect(calls).toHaveLength(1);
+
+  tick(2_000); // past the TTL → the store is consulted again
+  await run();
+  expect(calls).toHaveLength(2);
+});
+
+test("a credential someone else already rotated is served without a refresh", async () => {
+  const alreadyFresh = rotated("-elsewhere");
+  const { calls, persisted, run } = harness(
+    async () => {
+      throw new Error("must not refresh");
+    },
+    async () => alreadyFresh,
+  );
+
+  await expect(run()).resolves.toBe(alreadyFresh);
+  expect(calls).toHaveLength(0);
+  expect(persisted).toHaveLength(0);
+});
+
+test("a rejected refresh is not cached: every caller sees it and the next retries", async () => {
+  const expiring = cred();
+  let attempts = 0;
+  const { calls, run } = harness(
+    async () => {
+      attempts++;
+      throw new Error(`invalid_grant #${attempts}`);
+    },
+    async () => expiring,
+  );
+
+  const flights = [run(), run(), run()];
+  const settled = await Promise.allSettled(flights);
+  for (const s of settled) {
+    expect(s.status).toBe("rejected");
+    expect((s as PromiseRejectedResult).reason).toBeInstanceOf(Error);
+  }
+  expect(calls).toHaveLength(1);
+
+  await expect(run()).rejects.toThrow("invalid_grant #2");
+  expect(calls).toHaveLength(2);
+});
+
+test("two acting identities refresh independently", async () => {
+  const expiring = cred();
+  const { calls, run } = harness(
+    async () => rotated(),
+    async () => expiring,
+  );
+
+  // {"sub":"u1"} / {"sub":"u2"} payloads → distinct credential scope keys.
+  await Promise.all([
+    run({ actingAs: "h.eyJzdWIiOiJ1MSJ9.s" }),
+    run({ actingAs: "h.eyJzdWIiOiJ1MiJ9.s" }),
+  ]);
+
+  expect(calls).toHaveLength(2);
+});
+
+test("forget drops a cached result so the next serve refreshes again", async () => {
+  const expiring = cred();
+  const { coalescer, calls, run } = harness(
+    async () => rotated(),
+    async () => expiring,
+  );
+
+  await run();
+  await run();
+  expect(calls).toHaveLength(1);
+
+  coalescer.forget("w1", "openai-codex");
+  await run();
+  expect(calls).toHaveLength(2);
+});
+
+test("a credential deleted mid-flight is never refreshed back into existence", async () => {
+  // The user hit Disconnect while a refresh was queued. Refreshing the copy the
+  // caller read, then persisting it, RECREATES the row they just deleted — and
+  // hands their agents a live token for a connection they revoked.
+  const gate = deferred<WorkspaceCredential>();
+  const reading = deferred<void>();
+  let stored: WorkspaceCredential | null = cred();
+  const { calls, persisted, run } = harness(
+    () => gate.promise,
+    async () => {
+      await reading.promise;
+      return stored;
+    },
+  );
+
+  const flight = run();
+  stored = null; // Disconnect lands before the critical section re-reads.
+  reading.resolve();
+
+  await expect(flight).rejects.toBeInstanceOf(CredentialGoneError);
+  expect(calls).toHaveLength(0);
+  expect(persisted).toHaveLength(0);
+});
+
+test("forget never evicts a live flight, so single-flight survives it", async () => {
+  // disconnect.ts awaits store I/O before calling forget(). A new serve can open
+  // a flight in that window; evicting it would let the NEXT serve open a second
+  // concurrent exchange against the same rotating refresh token.
+  const gate = deferred<WorkspaceCredential>();
+  const expiring = cred();
+  const { coalescer, calls, run } = harness(
+    () => gate.promise,
+    async () => expiring,
+  );
+
+  const first = run();
+  coalescer.forget("w1", "openai-codex"); // the late disconnect cleanup
+  const second = run();
+
+  gate.resolve(rotated());
+  expect(await second).toBe(await first);
+  expect(calls).toHaveLength(1);
+});
+
+test("a settled flight only clears its own slot, never a successor's", async () => {
+  const first = deferred<WorkspaceCredential>();
+  const second = deferred<WorkspaceCredential>();
+  const expiring = cred();
+  const gates = [first, second];
+  const { coalescer, calls, run } = harness(
+    () => (gates.shift() ?? second).promise,
+    async () => expiring,
+  );
+
+  const a = run();
+  coalescer.reset(); // A's slot is dropped wholesale while A is still running
+  const b = run(); // B claims a fresh slot for the same key
+
+  first.reject(new Error("A lost"));
+  await expect(a).rejects.toThrow("A lost");
+
+  const c = run(); // must join B rather than open a THIRD exchange
+  second.resolve(rotated());
+  expect(await c).toBe(await b);
+  expect(calls).toHaveLength(2);
+});
+
+test("caching a result sweeps entries that aged past the TTL", async () => {
+  // The cache holds full credentials (access AND refresh tokens). Without a
+  // sweep it grows one entry per (workspace, scope, provider) ever served and
+  // keeps live secrets in memory for the life of the process.
+  const expiring = cred();
+  const { coalescer, run } = harness(
+    async () => rotated(),
+    async () => expiring,
+  );
+  const cache = (coalescer as unknown as { results: Map<string, unknown> })
+    .results;
+
+  await run({ actingAs: "h.eyJzdWIiOiJ1MSJ9.s" });
+  expect(cache.size).toBe(1);
+
+  tick(31_000); // u1's entry is now stale
+  await run({ actingAs: "h.eyJzdWIiOiJ1MiJ9.s" });
+  expect([...cache.keys()]).toHaveLength(1); // u1 swept, only u2 remains
+});
+
+test("run forwards its refresh options to the refresher", async () => {
+  const seen: unknown[] = [];
+  const coalescer = new CredentialRefreshCoalescer(async (c, opts) => {
+    seen.push(opts);
+    return { ...c, accessToken: "AT-new", expiresAt: clock + 3_600_000 };
+  }, now);
+  const sleep = async () => {};
+  await coalescer.run({
+    workspaceId: "w1",
+    provider: "openai-codex",
+    load: async () => cred(),
+    persist: async () => {},
+    refreshOpts: { sleep },
+  });
+  expect(seen).toEqual([{ sleep }]);
+});
+
+test("a per-call doRefresh override replaces the constructor's refresher", async () => {
+  const { coalescer } = harness(
+    async () => {
+      throw new Error("the default refresher must not run");
+    },
+    async () => cred(),
+  );
+  const result = await coalescer.run({
+    workspaceId: "w1",
+    provider: "openai-codex",
+    load: async () => cred(),
+    persist: async () => {},
+    doRefresh: async (c) => ({
+      ...c,
+      accessToken: "AT-injected",
+      expiresAt: clock + 3_600_000,
+    }),
+  });
+  expect(result.accessToken).toBe("AT-injected");
+});

--- a/packages/host/src/credentials/refresh-coalescer.ts
+++ b/packages/host/src/credentials/refresh-coalescer.ts
@@ -1,0 +1,198 @@
+import type { CredentialActing, WorkspaceCredential } from "../ports";
+import { isExpiring, type RefreshOptions, refreshCredential } from "./refresh";
+import { credentialScopeKey } from "./scope-key";
+
+/**
+ * How long a freshly rotated credential answers serves without touching the
+ * store or the token endpoint. Long enough to absorb the burst a single turn
+ * start produces (every agent runtime serves per turn AND per `/providers`
+ * poll), far shorter than any access-token lifetime.
+ */
+const REFRESH_RESULT_TTL_MS = 30_000;
+
+/** Performs one exchange. Shaped exactly like `refreshCredential`. */
+export type CredentialRefresher = (
+  cred: WorkspaceCredential,
+  opts?: RefreshOptions,
+) => Promise<WorkspaceCredential>;
+
+export type CredentialRefreshRun = {
+  workspaceId: string;
+  provider: string;
+  /** WHOSE credential this refresh is for; undefined = the shared team scope. */
+  acting?: CredentialActing;
+  /**
+   * Re-read the credential centrally, inside the critical section. This — not
+   * the copy the caller already read — is what gets refreshed: another host
+   * process (or an earlier flight) may have rotated it in the meantime, and
+   * `null` means the user disconnected mid-flight.
+   */
+  load: () => Promise<WorkspaceCredential | null>;
+  /** Persist the rotated credential before it is handed to anyone. */
+  persist: (cred: WorkspaceCredential) => Promise<void>;
+  /** Retry/backoff knobs for this exchange (tests inject a no-op sleep). */
+  refreshOpts?: RefreshOptions;
+  /**
+   * Refresher for THIS call, overriding the coalescer's own. The turn dispatch
+   * path carries an injected refresher in its dependency bundle and still has
+   * to land in the process-wide flight — one rotator per credential is the
+   * whole point, so it brings its refresher to the shared coalescer rather than
+   * keeping a private one.
+   */
+  doRefresh?: CredentialRefresher;
+};
+
+/**
+ * The credential vanished between the caller's read and the critical section —
+ * the user disconnected the provider mid-flight. Refreshing and persisting the
+ * copy the caller still holds would RECREATE the row they just deleted, so the
+ * flight stops here and the serve route answers "not connected".
+ */
+export class CredentialGoneError extends Error {
+  constructor(provider: string) {
+    super(`${provider} credential was disconnected during refresh`);
+    this.name = "CredentialGoneError";
+  }
+}
+
+/**
+ * Single-flights OAuth refreshes per (workspace, SCOPE, provider).
+ *
+ * The control plane is the SINGLE refresher of each workspace's subscription
+ * token (see refresh.ts) — but nothing enforced it on the serve path. A desktop
+ * install runs one runtime process per agent, and each one serves per turn and
+ * per `/providers` poll, so an expiring credential produced N simultaneous
+ * refreshes of the SAME refresh token. Providers that rotate refresh tokens on
+ * use (openai-codex) answer the first one and reject the rest with
+ * `invalid_grant` — a RefreshRejectedError, which the serve route reads as "the
+ * session ended" and deletes the credential. The user sees their provider
+ * spontaneously disconnect. Coalescing makes the burst exactly one exchange.
+ *
+ * Scope is part of the key: one member's refresh must never hand its rotated
+ * token to another member's serve (HOU-976).
+ */
+export class CredentialRefreshCoalescer {
+  private readonly inFlight = new Map<string, Promise<WorkspaceCredential>>();
+  private readonly results = new Map<
+    string,
+    { cred: WorkspaceCredential; at: number }
+  >();
+
+  constructor(
+    private readonly doRefresh: CredentialRefresher = refreshCredential,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  /**
+   * Resolve to a non-expiring credential, refreshing at most once per key at a
+   * time. Rejects with whatever the refresh threw (the caller decides whether
+   * that kills the credential or serves the stale token) — a failure is never
+   * cached, so the next serve retries.
+   */
+  run(args: CredentialRefreshRun): Promise<WorkspaceCredential> {
+    const key = this.keyOf(args.workspaceId, args.provider, args.acting);
+
+    const cached = this.results.get(key);
+    if (cached) {
+      if (
+        this.now() - cached.at < REFRESH_RESULT_TTL_MS &&
+        !isExpiring(cached.cred)
+      )
+        return Promise.resolve(cached.cred);
+      this.results.delete(key);
+    }
+
+    const existing = this.inFlight.get(key);
+    if (existing) return existing;
+
+    // Identity-checked self-removal: a flight owns its slot and clears only
+    // that slot, never a successor's. Deleting blindly would let a settling
+    // loser evict the live flight that replaced it, and the next serve would
+    // open a SECOND concurrent exchange against the same rotating token.
+    const flight: Promise<WorkspaceCredential> = this.refreshOnce(
+      key,
+      args,
+    ).finally(() => {
+      if (this.inFlight.get(key) === flight) this.inFlight.delete(key);
+    });
+    this.inFlight.set(key, flight);
+    return flight;
+  }
+
+  /**
+   * Drop the cached RESULT for one key (e.g. the credential died) so the next
+   * serve re-reads the store instead of answering from a stale rotation.
+   *
+   * In-flight state is deliberately untouched: callers reach here after store
+   * I/O, by which time a NEW flight may own the slot. Evicting it would strand
+   * that flight's waiters behind a second concurrent exchange of the same
+   * rotating refresh token — the exact failure the coalescer exists to prevent.
+   * A live flight re-reads the store inside its own critical section anyway.
+   */
+  forget(workspaceId: string, provider: string, acting?: CredentialActing) {
+    this.results.delete(this.keyOf(workspaceId, provider, acting));
+  }
+
+  /** Drop all state. Tests only — a process holds one coalescer for its life. */
+  reset() {
+    this.results.clear();
+    this.inFlight.clear();
+  }
+
+  private async refreshOnce(
+    key: string,
+    args: CredentialRefreshRun,
+  ): Promise<WorkspaceCredential> {
+    // Re-read INSIDE the critical section: another host process (or an earlier
+    // flight whose result already aged out) may have rotated the token
+    // already. Serving that costs nothing; refreshing again would burn a
+    // rotated refresh token and revoke the family.
+    const loaded = await args.load();
+    // Gone, not merely stale: the user disconnected the provider while this
+    // flight was queued. Falling back to the copy the caller read — refreshing
+    // it and persisting the result — would recreate the row they deleted and
+    // hand their agents a live token for a revoked connection.
+    if (loaded === null) throw new CredentialGoneError(args.provider);
+    if (!isExpiring(loaded)) {
+      this.remember(key, loaded);
+      return loaded;
+    }
+
+    const refresh = args.doRefresh ?? this.doRefresh;
+    const rotated = await refresh(loaded, args.refreshOpts);
+    await args.persist(rotated);
+    this.remember(key, rotated);
+    console.info(
+      `[credential-refresh] rotated ${rotated.provider} credential for workspace ${args.workspaceId}`,
+    );
+    return rotated;
+  }
+
+  /**
+   * Cache one rotation and sweep whatever aged out. The entries hold FULL
+   * credentials (access and refresh tokens), so without the sweep the map keeps
+   * one live secret per (workspace, scope, provider) ever served, for the life
+   * of the process.
+   */
+  private remember(key: string, cred: WorkspaceCredential) {
+    const at = this.now();
+    for (const [k, entry] of this.results)
+      if (at - entry.at >= REFRESH_RESULT_TTL_MS) this.results.delete(k);
+    this.results.set(key, { cred, at });
+  }
+
+  private keyOf(
+    workspaceId: string,
+    provider: string,
+    acting: CredentialActing | undefined,
+  ): string {
+    return `${workspaceId}:${credentialScopeKey(acting)}:${provider}`;
+  }
+}
+
+/**
+ * The process-wide refresher. One instance, so every serve of the same
+ * credential lands in the same flight — a per-request coalescer would coalesce
+ * nothing.
+ */
+export const sharedCredentialRefresher = new CredentialRefreshCoalescer();

--- a/packages/host/src/credentials/refresh.test.ts
+++ b/packages/host/src/credentials/refresh.test.ts
@@ -1,6 +1,26 @@
-import { expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 import { isApiKeyCredential, type WorkspaceCredential } from "../ports";
-import { isExpiring, RefreshRejectedError, refreshCredential } from "./refresh";
+import { RefreshRejectedError } from "./oauth-token-exchange";
+import { isExpiring, refreshCredential } from "./refresh";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** A minimal OAuth credential for a provider present in the OAUTH map. */
+const oauthCred: WorkspaceCredential = {
+  workspaceId: "ws_1",
+  provider: "openai-codex",
+  accessToken: "at.stale",
+  refreshToken: "rt",
+  expiresAt: 1, // expired -> must refresh
+};
+
+const okBody = JSON.stringify({
+  access_token: "at.fresh",
+  refresh_token: "rt.rotated",
+  expires_in: 3600,
+});
 
 /**
  * The connect-once refresher is OAuth-only. An API-key credential never expires
@@ -52,51 +72,220 @@ test("isExpiring is true for an already-expired oauth token", () => {
   ).toBe(true);
 });
 
-test("a 401 from the token endpoint throws RefreshRejectedError (terminal)", async () => {
-  // The OAuth server's own verdict on the refresh token (invalid_grant /
-  // refresh_token_invalidated) must be distinguishable from a transient
-  // failure — the serve route disconnects on it instead of retrying forever.
-  const realFetch = globalThis.fetch;
-  globalThis.fetch = (async () =>
-    new Response(
-      JSON.stringify({ error: { code: "refresh_token_invalidated" } }),
-      { status: 401 },
-    )) as typeof fetch;
-  try {
-    await expect(
-      refreshCredential({
-        workspaceId: "ws_1",
-        provider: "openai-codex",
-        accessToken: "at",
-        refreshToken: "rt.dead",
-        expiresAt: 1,
-      }),
-    ).rejects.toBeInstanceOf(RefreshRejectedError);
-  } finally {
-    globalThis.fetch = realFetch;
-  }
+/**
+ * Terminality is what disconnects a user: the serve route DELETES the
+ * credential on a RefreshRejectedError. Only the OAuth server's explicit
+ * verdict on the GRANT itself (`invalid_grant`, `refresh_token_invalidated`)
+ * earns that. Everything else — an unattributed 400 from an edge node, an
+ * `invalid_client` aimed at OUR client id, a 5xx, a 429, a dropped connection —
+ * must surface as a plain Error so the route falls back to the stored token and
+ * the user keeps working.
+ */
+
+/** Stub `fetch` with a queue of per-call responders. */
+function stubFetch(responders: Array<() => Response | Promise<Response>>) {
+  const fetchMock = vi.fn(async () => {
+    const next = responders.shift();
+    if (!next) throw new Error("unexpected extra fetch call");
+    return await next();
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+const reject = (status: number, body: string) => () =>
+  new Response(body, { status });
+
+async function refreshError(opts?: Parameters<typeof refreshCredential>[1]) {
+  return await refreshCredential(oauthCred, opts).then(
+    () => null,
+    (e: unknown) => e,
+  );
+}
+
+test("a 400 invalid_grant is terminal, carries its code, and is not retried", async () => {
+  const fetchMock = stubFetch([
+    reject(400, JSON.stringify({ error: "invalid_grant" })),
+  ]);
+  const err = await refreshError();
+  expect(err).toBeInstanceOf(RefreshRejectedError);
+  expect((err as RefreshRejectedError).code).toBe("invalid_grant");
+  expect((err as RefreshRejectedError).status).toBe(400);
+  // A 4xx may already have rotated the token — retrying would spend the new one.
+  expect(fetchMock).toHaveBeenCalledTimes(1);
 });
 
-test("a 5xx from the token endpoint is NOT a terminal rejection", async () => {
-  const realFetch = globalThis.fetch;
-  globalThis.fetch = (async () =>
-    new Response("upstream sad", { status: 503 })) as typeof fetch;
-  try {
-    const err = await refreshCredential({
-      workspaceId: "ws_1",
-      provider: "openai-codex",
-      accessToken: "at",
-      refreshToken: "rt",
-      expiresAt: 1,
-    }).then(
-      () => null,
-      (e: unknown) => e,
-    );
-    expect(err).toBeInstanceOf(Error);
-    expect(err).not.toBeInstanceOf(RefreshRejectedError);
-  } finally {
-    globalThis.fetch = realFetch;
-  }
+test("a 401 invalid_client is NOT terminal: it condemns OUR client id, not the user's token", async () => {
+  // RFC 6749 `invalid_client` is a verdict on the client credentials Houston
+  // sends — a hardcoded public client id shared by every install. If the
+  // provider ever retires it, treating this as terminal would delete EVERY
+  // workspace's credential on its next refresh, with no way back.
+  stubFetch([reject(401, JSON.stringify({ error: "invalid_client" }))]);
+  const err = await refreshError();
+  expect(err).toBeInstanceOf(Error);
+  expect(err).not.toBeInstanceOf(RefreshRejectedError);
+  expect((err as Error).message).toContain("invalid_client");
+});
+
+test("a 400 with a non-grant error code is NOT terminal and is not retried", async () => {
+  // A transient edge-node 400 used to sign the user out permanently.
+  const fetchMock = stubFetch([
+    reject(400, JSON.stringify({ error: "server_error" })),
+  ]);
+  const err = await refreshError();
+  expect(err).toBeInstanceOf(Error);
+  expect(err).not.toBeInstanceOf(RefreshRejectedError);
+  expect((err as Error).message).toContain("server_error"); // raw body preserved
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test("a 400 with an unparseable body is NOT terminal", async () => {
+  const fetchMock = stubFetch([reject(400, "<html>gateway hiccup</html>")]);
+  const err = await refreshError();
+  expect(err).toBeInstanceOf(Error);
+  expect(err).not.toBeInstanceOf(RefreshRejectedError);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test("a 401 refresh_token_invalidated is terminal in OpenAI's nested shape", async () => {
+  // The session was ended server-side. This is the shape the serve route has
+  // disconnected on since the flow shipped — the body discrimination must not
+  // quietly drop it and strand the user on a token that can never work again.
+  stubFetch([
+    reject(
+      401,
+      JSON.stringify({ error: { code: "refresh_token_invalidated" } }),
+    ),
+  ]);
+  const err = await refreshError();
+  expect(err).toBeInstanceOf(RefreshRejectedError);
+  expect((err as RefreshRejectedError).code).toBe("refresh_token_invalidated");
+});
+
+test("a 401 naming an unrecognised code is NOT terminal", async () => {
+  stubFetch([reject(401, JSON.stringify({ error: { code: "edge_hiccup" } }))]);
+  const err = await refreshError();
+  expect(err).toBeInstanceOf(Error);
+  expect(err).not.toBeInstanceOf(RefreshRejectedError);
+});
+
+/**
+ * Retry is a ROTATION decision, not a politeness one. openai-codex rotates the
+ * refresh token on use, so a retry is only safe when the first attempt provably
+ * never reached the server. A timeout, an abort, a 5xx, a 429 — every one of
+ * those can happen AFTER the endpoint consumed the grant and rotated it; the
+ * retry then POSTs a spent token, earns `invalid_grant`, and the serve route
+ * deletes the user's credential over a blip. Only pre-connection transport
+ * failures (DNS, refused connection) qualify.
+ */
+
+/** An undici `TypeError: fetch failed` carrying the socket-level cause. */
+const transportFailure = (code: string) => () => {
+  const cause = Object.assign(
+    new Error(`getaddrinfo ${code} auth.openai.com`),
+    {
+      code,
+    },
+  );
+  throw new TypeError("fetch failed", { cause });
+};
+
+test("a pre-connection transport failure is retried (nothing reached the server)", async () => {
+  const fetchMock = stubFetch([
+    transportFailure("ENOTFOUND"),
+    () => new Response(okBody, { status: 200 }),
+  ]);
+  const sleep = vi.fn(async (_ms: number) => {});
+  const fresh = await refreshCredential(oauthCred, { sleep });
+  expect(fresh.accessToken).toBe("at.fresh");
+  expect(fresh.refreshToken).toBe("rt.rotated");
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+  expect(sleep).toHaveBeenCalledTimes(1);
+  expect(sleep.mock.calls[0]?.[0]).toBeGreaterThanOrEqual(250);
+  expect(sleep.mock.calls[0]?.[0]).toBeLessThanOrEqual(500);
+});
+
+test("ECONNREFUSED is retried; an ambiguous ECONNRESET is not", async () => {
+  const refused = stubFetch([
+    transportFailure("ECONNREFUSED"),
+    () => new Response(okBody, { status: 200 }),
+  ]);
+  expect(
+    (await refreshCredential(oauthCred, { sleep: async () => {} })).accessToken,
+  ).toBe("at.fresh");
+  expect(refused).toHaveBeenCalledTimes(2);
+
+  // A reset can land after the POST was written and the grant consumed.
+  const reset = stubFetch([
+    transportFailure("ECONNRESET"),
+    () => new Response(okBody, { status: 200 }),
+  ]);
+  const err = await refreshError({ sleep: async () => {} });
+  expect(err).toBeInstanceOf(Error);
+  expect(err).not.toBeInstanceOf(RefreshRejectedError);
+  expect(reset).toHaveBeenCalledTimes(1);
+});
+
+test("a timed-out request is NOT retried: the server may already have rotated", async () => {
+  // The bug this pins: attempt 1 times out AFTER the endpoint consumed the
+  // rotating refresh token; attempt 2 spends the spent token, gets
+  // `invalid_grant`, and the serve route deletes the user's credential.
+  const fetchMock = stubFetch([
+    () => {
+      throw new DOMException("The operation was aborted.", "TimeoutError");
+    },
+    reject(400, JSON.stringify({ error: "invalid_grant" })),
+  ]);
+  const err = await refreshError({ sleep: async () => {} });
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(err).toBeInstanceOf(Error);
+  expect(err).not.toBeInstanceOf(RefreshRejectedError);
+});
+
+test("a 5xx is NOT retried and is not terminal", async () => {
+  const fetchMock = stubFetch([
+    reject(503, "upstream sad"),
+    reject(400, JSON.stringify({ error: "invalid_grant" })),
+  ]);
+  const err = await refreshError({ sleep: async () => {} });
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(err).toBeInstanceOf(Error);
+  expect(err).not.toBeInstanceOf(RefreshRejectedError);
+  expect((err as Error).message).toContain("503");
+});
+
+test("a 429 is NOT retried and is not terminal", async () => {
+  const fetchMock = stubFetch([
+    reject(429, "slow down"),
+    reject(400, JSON.stringify({ error: "invalid_grant" })),
+  ]);
+  const err = await refreshError({ sleep: async () => {} });
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(err).toBeInstanceOf(Error);
+  expect(err).not.toBeInstanceOf(RefreshRejectedError);
+});
+
+test("exhausted retries surface a plain Error, never a terminal rejection", async () => {
+  const fetchMock = stubFetch([
+    transportFailure("EAI_AGAIN"),
+    transportFailure("EAI_AGAIN"),
+  ]);
+  const err = await refreshError({ attempts: 2, sleep: async () => {} });
+  expect(err).toBeInstanceOf(Error);
+  expect(err).not.toBeInstanceOf(RefreshRejectedError);
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+test("the token request carries an abort signal so a hung endpoint can't stall a serve", async () => {
+  const fetchMock = vi.fn(
+    async (_url: unknown, init?: RequestInit) =>
+      new Response(okBody, {
+        status: init?.signal instanceof AbortSignal ? 200 : 418,
+      }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  const fresh = await refreshCredential(oauthCred);
+  expect(fresh.accessToken).toBe("at.fresh");
 });
 
 test("refreshCredential mints a fresh GitHub Copilot token from the stored GitHub token", async () => {

--- a/packages/host/src/credentials/refresh.ts
+++ b/packages/host/src/credentials/refresh.ts
@@ -1,9 +1,9 @@
 import { githubCopilotProvider } from "@earendil-works/pi-ai/providers/github-copilot";
+import { isApiKeyCredential, type WorkspaceCredential } from "../ports";
 import {
-  type CredentialStore,
-  isApiKeyCredential,
-  type WorkspaceCredential,
-} from "../ports";
+  exchangeRefreshToken,
+  TransientRefreshError,
+} from "./oauth-token-exchange";
 
 /**
  * pi-ai's Copilot OAuth flow, reached through the provider's `auth.oauth`
@@ -27,21 +27,18 @@ const OAUTH: Record<string, { tokenUrl: string; clientId: string }> = {
   // anthropic uses a different (PKCE) refresh; added when Claude connect lands.
 };
 
-/**
- * The token endpoint's verdict on the refresh token itself (HTTP 400/401:
- * `invalid_grant`, `refresh_token_invalidated`, ...). Unlike a network blip or
- * a 5xx, this never heals on retry — the credential is dead until the user
- * reconnects the provider.
- */
-export class RefreshRejectedError extends Error {
-  constructor(
-    message: string,
-    readonly status: number,
-  ) {
-    super(message);
-    this.name = "RefreshRejectedError";
-  }
+export interface RefreshOptions {
+  /** Total attempts, including the first. Default 2. */
+  attempts?: number;
+  /** Injectable delay (tests pass a spy; production waits for real). */
+  sleep?: (ms: number) => Promise<void>;
 }
+
+const realSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Jittered ~250-500ms — spreads a fleet's retries off a recovering resolver. */
+const backoffMs = (): number => 250 + Math.floor(Math.random() * 250);
 
 /**
  * True if the access token is within `skewMs` of expiry (or already expired). An
@@ -59,9 +56,16 @@ export function isExpiring(
  * Exchange the refresh token for a new access (+ rotated refresh) token. Throws
  * on any failure — a stale token is never returned silently. An API-key
  * credential has nothing to refresh and is returned unchanged.
+ *
+ * ONLY failures that provably predate the connection (DNS, refused socket) are
+ * retried, up to `opts.attempts` (default 2) with a jittered backoff. Anything
+ * that could have reached the server — a timeout, an abort, a 5xx, a 429, any
+ * 4xx — is NEVER retried: the endpoint may already have consumed the rotating
+ * refresh token, and a second attempt would spend a grant we no longer hold.
  */
 export async function refreshCredential(
   cred: WorkspaceCredential,
+  opts: RefreshOptions = {},
 ): Promise<WorkspaceCredential> {
   if (isApiKeyCredential(cred)) return cred;
 
@@ -102,57 +106,21 @@ export async function refreshCredential(
   if (!cfg)
     throw new Error(`no OAuth refresh config for provider ${cred.provider}`);
 
-  const res = await fetch(cfg.tokenUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      grant_type: "refresh_token",
-      client_id: cfg.clientId,
-      refresh_token: cred.refreshToken,
-    }),
-  });
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    const message = `OAuth refresh failed (${res.status}) for ${cred.provider}: ${body.slice(0, 200)}`;
-    if (res.status === 400 || res.status === 401)
-      throw new RefreshRejectedError(message, res.status);
-    throw new Error(message);
+  const attempts = Math.max(1, opts.attempts ?? 2);
+  const sleep = opts.sleep ?? realSleep;
+  let transient: TransientRefreshError | undefined;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (attempt > 0) await sleep(backoffMs());
+    try {
+      return await exchangeRefreshToken(cfg, cred);
+    } catch (err) {
+      // Terminal rejections and unretryable 4xx propagate immediately.
+      if (!(err instanceof TransientRefreshError)) throw err;
+      transient = err;
+    }
   }
-  const json = (await res.json()) as {
-    access_token?: string;
-    refresh_token?: string;
-    expires_in?: number;
-  };
-  if (
-    !json.access_token ||
-    !json.refresh_token ||
-    typeof json.expires_in !== "number"
-  ) {
-    throw new Error(
-      `OAuth refresh response missing fields for ${cred.provider}`,
-    );
-  }
-  return {
-    workspaceId: cred.workspaceId,
-    provider: cred.provider,
-    accessToken: json.access_token,
-    refreshToken: json.refresh_token, // rotation-safe: persist whatever comes back
-    accountId: cred.accountId, // the refresh endpoint doesn't return it; it's stable
-    expiresAt: Date.now() + json.expires_in * 1000,
-  };
-}
-
-/**
- * Return a currently-valid access token for a stored credential, refreshing it
- * (and persisting the rotated token back to the store) when it's near expiry.
- * This is what the per-turn "serve" endpoint calls.
- */
-export async function validAccessToken(
-  store: CredentialStore,
-  cred: WorkspaceCredential,
-): Promise<string> {
-  if (!isExpiring(cred)) return cred.accessToken;
-  const fresh = await refreshCredential(cred);
-  await store.put(fresh);
-  return fresh.accessToken;
+  // Exhausted: never a RefreshRejectedError, so the serve route keeps the
+  // credential and falls back to the stored token instead of signing the user
+  // out over an outage.
+  throw transient ?? new Error(`OAuth refresh failed for ${cred.provider}`);
 }

--- a/packages/host/src/launcher/runtime-spawner.test.ts
+++ b/packages/host/src/launcher/runtime-spawner.test.ts
@@ -1,20 +1,29 @@
 import { EventEmitter } from "node:events";
-import { beforeEach, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import type { Agent } from "../domain/types";
 
 const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
 vi.mock("node:child_process", () => ({ spawn: spawnMock }));
 
+import { ProcessLauncher } from "./process";
 import { RuntimeProcessSpawner } from "./runtime-spawner";
+
+/** A stand-in ChildProcess: an emitter with the bits the spawner touches. */
+function fakeChild() {
+  return Object.assign(new EventEmitter(), {
+    stdout: null,
+    stderr: null,
+    kill: vi.fn(),
+  });
+}
 
 beforeEach(() => {
   spawnMock.mockReset();
-  spawnMock.mockReturnValue(
-    Object.assign(new EventEmitter(), {
-      stdout: null,
-      stderr: null,
-      kill: vi.fn(),
-    }),
-  );
+  spawnMock.mockReturnValue(fakeChild());
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 test("spawn exposes a configured shared-skills directory to the runtime", () => {
@@ -51,4 +60,91 @@ test("spawn omits the shared-skills env when no filesystem mirror is available",
     env: Record<string, string | undefined>;
   };
   expect(options.env).not.toHaveProperty("HOUSTON_SHARED_SKILLS_DIR");
+});
+
+test("a child that fails to spawn ('error', never 'exit') still fires the exit callback, exactly once", () => {
+  // A missing/unstaged runtime binary emits 'error' + 'close' and NEVER 'exit'.
+  // Listening for 'exit' alone left the launcher's abort hook silent, so the
+  // boot polled a corpse for the whole 60s health budget.
+  const child = fakeChild();
+  spawnMock.mockReturnValue(child);
+  const handle = new RuntimeProcessSpawner({ command: ["runtime"] }).spawn({
+    workspaceDir: "/data/agent",
+    dataDir: "/data/agent/data",
+    token: "secret",
+    port: 4317,
+  });
+
+  let exits = 0;
+  handle.onExit?.(() => exits++);
+  child.emit("error", new Error("spawn ENOENT"));
+  expect(exits).toBe(1);
+
+  // The trailing events of the same death must not fire the callback again.
+  child.emit("close", 1, null);
+  child.emit("exit", 1, null);
+  expect(exits).toBe(1);
+});
+
+test("each onExit registration gets its own one-shot callback", () => {
+  // The launcher registers separately for the boot abort and for sleep's
+  // "wait until the child is actually gone" — both must be told.
+  const child = fakeChild();
+  spawnMock.mockReturnValue(child);
+  const handle = new RuntimeProcessSpawner({ command: ["runtime"] }).spawn({
+    workspaceDir: "/data/agent",
+    dataDir: "/data/agent/data",
+    token: "secret",
+    port: 4317,
+  });
+
+  const fired: string[] = [];
+  handle.onExit?.(() => fired.push("boot"));
+  handle.onExit?.(() => fired.push("sleep"));
+  child.emit("exit", 0, null);
+  child.emit("close", 0, null);
+
+  expect(fired).toEqual(["boot", "sleep"]);
+});
+
+test("a runtime that fails to spawn aborts the boot instead of burning the health budget", () => {
+  vi.useFakeTimers();
+  const child = fakeChild();
+  spawnMock.mockReturnValue(child);
+  const agent: Agent = {
+    id: "sales",
+    workspaceId: "w1",
+    name: "Sales",
+    createdAt: 0,
+  };
+  const launcher = new ProcessLauncher({
+    spawner: new RuntimeProcessSpawner({ command: ["missing-runtime"] }),
+    workspaceDirFor: () => "/data/agent",
+    dataDirFor: () => "/data/agent/data",
+    mintToken: () => "secret",
+    allocatePort: async () => 4317,
+    // Stands in for the production /health poll against a port nobody bound:
+    // it keeps trying until the 60s budget runs out.
+    waitHealthy: () =>
+      new Promise((_, reject) => {
+        setTimeout(() => reject(new Error("never became healthy")), 60_000);
+      }),
+  });
+
+  const started = Date.now();
+  let failure: string | undefined;
+  const boot = launcher.ensureAwake(agent).catch((err: Error) => {
+    failure = err.message;
+  });
+
+  return (async () => {
+    await vi.advanceTimersByTimeAsync(0); // let the spawn actually happen
+    child.emit("error", new Error("spawn ENOENT"));
+    await vi.advanceTimersByTimeAsync(0);
+    await boot;
+
+    expect(failure).toBe("runtime exited before becoming healthy");
+    expect(Date.now() - started).toBeLessThan(1_000); // not the 60s budget
+    expect(await launcher.status("sales")).toBe("asleep");
+  })();
 });

--- a/packages/host/src/launcher/runtime-spawner.ts
+++ b/packages/host/src/launcher/runtime-spawner.ts
@@ -73,10 +73,30 @@ export class RuntimeProcessSpawner implements RuntimeSpawner {
           /* already gone */
         }
       },
-      // Fires once when the child exits — whether we killed it or it crashed on
-      // its own. The launcher uses this to drop a dead runtime from its live-set
-      // so a crash doesn't leave a phantom "running" entry behind.
-      onExit: (cb) => child.once("exit", cb),
+      // Fires once when the child is gone — whether we killed it, it crashed on
+      // its own, or it never started at all. The launcher uses this to drop a
+      // dead runtime from its live-set (no phantom "running" entry) and to
+      // abort a boot in flight.
+      //
+      // All THREE events matter, and which one lands depends on how the child
+      // died: a normal death emits 'exit' then 'close'; a child that never
+      // spawned (missing/unstaged runtime binary → ENOENT) emits 'error' and
+      // 'close' and NEVER 'exit'. Listening for 'exit' alone made that failure
+      // invisible, so the launcher polled a corpse's port for the whole 60s
+      // health budget before failing the user's first message. Whichever fires
+      // first wins and the others are unsubscribed, so each registration's
+      // callback runs exactly once (and no listener outlives the child).
+      onExit: (cb) => {
+        const fire = () => {
+          child.off("exit", fire);
+          child.off("close", fire);
+          child.off("error", fire);
+          cb();
+        };
+        child.once("exit", fire);
+        child.once("close", fire);
+        child.once("error", fire);
+      },
     };
   }
 }

--- a/packages/host/src/routes/credential.test.ts
+++ b/packages/host/src/routes/credential.test.ts
@@ -1,5 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { expect, test } from "vitest";
+import { accessDigest } from "@houston/protocol/access-digest";
+import { beforeEach, expect, test } from "vitest";
+import { sharedCredentialRefresher } from "../credentials/refresh-coalescer";
 import { RemoteCredentialDeadError } from "../credentials/remote-store";
 import { MemoryCredentialStore } from "../credentials/store";
 import type { CredentialStore, CredentialVault } from "../ports";
@@ -30,9 +32,12 @@ const vault: CredentialVault = {
     t === "sbx" ? { workspaceId: "w1", agentId: "a1" } : null,
 };
 
-function mockReq(token = "sbx"): IncomingMessage {
+function mockReq(token = "sbx", actingAs?: string): IncomingMessage {
   return {
-    headers: { authorization: `Bearer ${token}` },
+    headers: {
+      authorization: `Bearer ${token}`,
+      ...(actingAs ? { "x-houston-acting-as": actingAs } : {}),
+    },
   } as unknown as IncomingMessage;
 }
 
@@ -73,6 +78,8 @@ const call = (
   opts: {
     gatewayFronted?: boolean;
     credentialHealer?: CredentialServeHealer;
+    /** WHOSE credential this serve is for (HOU-976); absent = the team row. */
+    actingAs?: string;
   } = {},
 ) =>
   handleSandboxCredential(
@@ -85,12 +92,19 @@ const call = (
     "GET",
     "/sandbox/credential",
     new URL(`http://x/sandbox/credential?provider=${provider}`),
-    mockReq(),
+    mockReq("sbx", opts.actingAs),
     out.res,
   );
 
 /** A far-future expiry: not "expiring" for any test run. */
 const FRESH_EXPIRES = Date.now() + 60 * 60 * 1000;
+
+/** A gateway-minted acting-as token naming one member (its payload carries the sub). */
+const ACTING = `h.${Buffer.from(JSON.stringify({ sub: "u-1" })).toString("base64url")}.sig`;
+
+// The refresher is process-wide (that is what makes it coalesce). Clear its
+// single-flight + result cache so tests can't serve each other's tokens.
+beforeEach(() => sharedCredentialRefresher.reset());
 
 test("serve miss heals once and serves the fresh central credential", async () => {
   const credentials = new MemoryCredentialStore();
@@ -246,6 +260,117 @@ test("a terminally-rejected refresh disconnects the credential (marked 404)", as
   }
 });
 
+test("a rejected refresh keeps a credential that was rotated underneath", async () => {
+  // The rejection condemns ONE token, and the store can move on while the token
+  // endpoint is still answering — a reconnect, or a sibling host that rotated
+  // the credential. A blind remove here would delete the connection the user
+  // just made and sign them out for someone else's dead token. Compare-and-
+  // delete: the digest doesn't match, nothing is dropped, and the serve
+  // continues with what the store holds NOW.
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "openai-codex",
+    accessToken: "expired-AT",
+    refreshToken: "rt.dead",
+    expiresAt: 1,
+  });
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    // Racing the exchange: this lands after the refresher re-read the store and
+    // before its rejection reaches the route.
+    await credentials.put({
+      workspaceId: "w1",
+      provider: "openai-codex",
+      accessToken: "reconnected-AT",
+      refreshToken: "rt.fresh",
+      expiresAt: FRESH_EXPIRES,
+    });
+    return new Response(JSON.stringify({ error: "invalid_grant" }), {
+      status: 400,
+    });
+  }) as typeof fetch;
+  try {
+    const r = mockRes();
+    expect(await call(credentials, "openai-codex", r)).toBe(true);
+    expect(r.out.status).toBe(200);
+    expect(r.out.body.access).toBe("reconnected-AT");
+    expect((await credentials.get("w1", "openai-codex"))?.accessToken).toBe(
+      "reconnected-AT",
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("a rejected personal refresh never touches the team credential", async () => {
+  // Scope is part of the delete, not decoration (HOU-976): one member's dead
+  // subscription must not disconnect the workspace's shared one. The store call
+  // carries both WHICH kind of row (scope) and WHOSE (the acting identity).
+  const memory = new MemoryCredentialStore();
+  const removals: {
+    accessSha256: string;
+    opts?: { scope?: "personal" | "team"; actingAs?: string };
+  }[] = [];
+  const credentials: CredentialStore = {
+    get: (workspaceId, provider, acting) =>
+      memory.get(workspaceId, provider, acting),
+    put: (cred, opts) => memory.put(cred, opts),
+    remove: (workspaceId, provider, acting) =>
+      memory.remove(workspaceId, provider, acting),
+    removeIfAccess: (workspaceId, provider, accessSha256, opts) => {
+      removals.push({ accessSha256, opts });
+      return memory.removeIfAccess(workspaceId, provider, accessSha256, opts);
+    },
+  };
+  await memory.put({
+    workspaceId: "w1",
+    provider: "openai-codex",
+    accessToken: "team-AT",
+    refreshToken: "rt.team",
+    expiresAt: FRESH_EXPIRES,
+  });
+  await memory.put(
+    {
+      workspaceId: "w1",
+      provider: "openai-codex",
+      accessToken: "member-AT",
+      refreshToken: "rt.dead",
+      expiresAt: 1,
+      scope: "personal",
+    },
+    { actingAs: ACTING },
+  );
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ error: "invalid_grant" }), {
+      status: 400,
+    })) as typeof fetch;
+  try {
+    const r = mockRes();
+    expect(
+      await call(credentials, "openai-codex", r, { actingAs: ACTING }),
+    ).toBe(true);
+    expect(r.out.status).toBe(404);
+    expect(r.out.headers?.["x-houston-not-connected"]).toBe("1");
+    // The member's row is gone; the team's is untouched.
+    expect(await memory.get("w1", "openai-codex", { actingAs: ACTING })).toBe(
+      null,
+    );
+    expect((await memory.get("w1", "openai-codex"))?.accessToken).toBe(
+      "team-AT",
+    );
+    expect(removals).toEqual([
+      {
+        accessSha256: accessDigest("member-AT"),
+        opts: { scope: "personal", actingAs: ACTING },
+      },
+    ]);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
 test("a transient refresh failure keeps serving the existing token", async () => {
   const credentials = new MemoryCredentialStore();
   await credentials.put({
@@ -256,8 +381,11 @@ test("a transient refresh failure keeps serving the existing token", async () =>
     expiresAt: 1,
   });
   const realFetch = globalThis.fetch;
-  globalThis.fetch = (async () =>
-    new Response("upstream sad", { status: 503 })) as typeof fetch;
+  let exchanges = 0;
+  globalThis.fetch = (async () => {
+    exchanges++;
+    return new Response("upstream sad", { status: 503 });
+  }) as typeof fetch;
   try {
     const r = mockRes();
     expect(await call(credentials, "openai-codex", r)).toBe(true);
@@ -265,6 +393,100 @@ test("a transient refresh failure keeps serving the existing token", async () =>
     expect(r.out.body.access).toBe("maybe-still-good-AT");
     // A blip must not sign the workspace out.
     expect(await credentials.get("w1", "openai-codex")).not.toBeNull();
+    // And it must not be retried: a 5xx can land after the endpoint already
+    // rotated the refresh token, so attempt 2 would spend a spent grant.
+    expect(exchanges).toBe(1);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("a credential disconnected mid-refresh answers marked 404 without a delete", async () => {
+  // The user hit Disconnect between the route's read and the coalescer's
+  // critical section. Refreshing anyway recreates the row they deleted; the
+  // route must simply report "not connected".
+  const memory = new MemoryCredentialStore();
+  await memory.put({
+    workspaceId: "w1",
+    provider: "openai-codex",
+    accessToken: "expiring-AT",
+    refreshToken: "rt.rotating",
+    expiresAt: 1,
+  });
+  let reads = 0;
+  let removals = 0;
+  const credentials: CredentialStore = {
+    get: async (workspaceId, provider, acting) =>
+      ++reads === 1 ? memory.get(workspaceId, provider, acting) : null,
+    put: (cred, opts) => memory.put(cred, opts),
+    remove: (workspaceId, provider, acting) =>
+      memory.remove(workspaceId, provider, acting),
+    removeIfAccess: async () => {
+      removals++;
+      return false;
+    },
+  };
+  const realFetch = globalThis.fetch;
+  let exchanges = 0;
+  globalThis.fetch = (async () => {
+    exchanges++;
+    throw new Error("the token endpoint must never be called");
+  }) as typeof fetch;
+  try {
+    const r = mockRes();
+    expect(await call(credentials, "openai-codex", r)).toBe(true);
+    expect(r.out.status).toBe(404);
+    expect(r.out.headers?.["x-houston-not-connected"]).toBe("1");
+    expect(exchanges).toBe(0);
+    expect(removals).toBe(0);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("concurrent serves of an expiring credential refresh it exactly once", async () => {
+  // One runtime process per agent serves per turn AND per /providers poll, so
+  // the same expiring credential lands here several times at once. openai-codex
+  // rotates the refresh token on use: refreshing twice makes the second
+  // exchange invalid_grant, which the route reads as "session ended" and the
+  // user's provider disconnects itself. One burst = one exchange.
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "openai-codex",
+    accessToken: "expiring-AT",
+    refreshToken: "rt.rotating",
+    expiresAt: 1,
+  });
+  let exchanges = 0;
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    exchanges++;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    return new Response(
+      JSON.stringify({
+        access_token: "rotated-AT",
+        refresh_token: "rt.rotated",
+        expires_in: 3600,
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof fetch;
+  try {
+    const a = mockRes();
+    const b = mockRes();
+    await Promise.all([
+      call(credentials, "openai-codex", a),
+      call(credentials, "openai-codex", b),
+    ]);
+    expect(exchanges).toBe(1);
+    expect(a.out.status).toBe(200);
+    expect(b.out.status).toBe(200);
+    expect(a.out.body.access).toBe("rotated-AT");
+    expect(b.out.body.access).toBe("rotated-AT");
+    expect((await credentials.get("w1", "openai-codex"))?.refreshToken).toBe(
+      "rt.rotated",
+    );
   } finally {
     globalThis.fetch = realFetch;
   }

--- a/packages/host/src/routes/credential.ts
+++ b/packages/host/src/routes/credential.ts
@@ -1,9 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { disconnectRejectedCredential } from "../credentials/disconnect";
+import { RefreshRejectedError } from "../credentials/oauth-token-exchange";
+import { isExpiring } from "../credentials/refresh";
 import {
-  isExpiring,
-  RefreshRejectedError,
-  refreshCredential,
-} from "../credentials/refresh";
+  CredentialGoneError,
+  sharedCredentialRefresher,
+} from "../credentials/refresh-coalescer";
 import { RemoteCredentialDeadError } from "../credentials/remote-store";
 import {
   type CredentialStore,
@@ -12,6 +14,18 @@ import {
 } from "../ports";
 import type { CredentialServeHealer } from "./credential-healer";
 import { bearer, json } from "./http";
+
+/**
+ * The store's authoritative "not connected" answer, and the ONLY way this route
+ * writes a 404. The marker is load-bearing: the runtime drops a served
+ * credential only on a MARKED 404 — a bare one (old host, wrong control-plane
+ * URL) must never read as a logout — so it can never be forgotten at one of the
+ * several places that degrade to "not connected".
+ */
+function notConnected(res: ServerResponse, error: string): true {
+  json(res, 404, { error }, { "x-houston-not-connected": "1" });
+  return true;
+}
 
 /**
  * Sandbox-facing (connect-once): an agent runtime serves a FRESH subscription
@@ -52,15 +66,8 @@ export async function handleSandboxCredential(
   // make this host a second rotator of a refresh token family the pod already
   // owns. The marked 404 is the store's authoritative "not served here" answer;
   // the runtime's provenance manifest keeps it from deleting anything local.
-  if (provider === "anthropic" && !deps.gatewayFronted) {
-    json(
-      res,
-      404,
-      { error: "anthropic is not served on this deployment" },
-      { "x-houston-not-connected": "1" },
-    );
-    return true;
-  }
+  if (provider === "anthropic" && !deps.gatewayFronted)
+    return notConnected(res, "anthropic is not served on this deployment");
   // WHOSE credential this serve is for (HOU-976). The gateway mints the header;
   // absent (desktop, self-host, every pre-HOU-976 pod) means the single shared
   // scope, so the whole path below is byte-identical to before.
@@ -90,54 +97,67 @@ export async function handleSandboxCredential(
   }
   if (!cred) {
     if (deadError) throw deadError;
-    // The marker makes this 404 the store's own authoritative "not connected"
-    // answer. The runtime only drops served credentials on marked 404s — a bare
-    // 404 (old host, wrong control-plane URL) must never read as a logout.
-    json(
-      res,
-      404,
-      { error: "workspace not connected" },
-      { "x-houston-not-connected": "1" },
-    );
-    return true;
+    return notConnected(res, "workspace not connected");
   }
   if (isExpiring(cred) && cred.refreshToken) {
+    const refreshing = cred.provider;
     try {
-      cred = await refreshCredential(cred);
-      await deps.credentials.put(cred, acting);
+      // Single-flight: one runtime process per agent serves this per turn AND
+      // per /providers poll, so the same expiring credential arrives here N
+      // times at once. Refreshing it N times rotates the refresh token N times;
+      // every loser gets invalid_grant and the catch below disconnects the
+      // user. The coalescer makes the burst one exchange.
+      cred = await sharedCredentialRefresher.run({
+        workspaceId: claim.workspaceId,
+        provider: refreshing,
+        acting,
+        load: () => deps.credentials.get(claim.workspaceId, refreshing, acting),
+        persist: (c) => deps.credentials.put(c, acting),
+      });
     } catch (err) {
-      if (err instanceof RefreshRejectedError) {
-        // The OAuth server rejected the refresh token itself (invalid_grant /
-        // refresh_token_invalidated — e.g. the session was ended server-side).
-        // That never heals: retrying every serve loops this error forever
-        // while turns fail on the expired access token. Drop the dead
-        // credential and answer the marked 404 so the runtime removes its
-        // served entry (provenance-gated) and the provider reads signed-out
-        // with the reconnect flow — the credential IS the switch.
-        console.error(
-          `[sandbox/credential] refresh token rejected for ${cred.provider}, disconnecting:`,
-          err.message,
-        );
-        await deps.credentials.remove(claim.workspaceId, cred.provider, acting);
-        json(
-          res,
-          404,
-          { error: `${cred.provider} session ended; reconnect the provider` },
-          { "x-houston-not-connected": "1" },
-        );
-        return true;
+      if (err instanceof CredentialGoneError) {
+        // The user disconnected the provider while this refresh was queued.
+        // Nothing was refreshed and nothing was written; the store's answer is
+        // simply "not connected", and there is no dead token to compare-and-
+        // delete.
+        return notConnected(res, "workspace not connected");
       }
-      // No refresh path for this provider, or a transient failure (network,
-      // 5xx). Serve the existing token best-effort instead of 500-ing every
-      // turn: it may still be valid, and a genuinely expired one surfaces as a
-      // clear auth error on the real API call. This also stops the runtime's
-      // multi-provider serve loop from spamming serve 500s for a stale, unused
-      // credential (e.g. a leftover Claude login while the agent runs
-      // OpenCode).
-      console.error(
-        `[sandbox/credential] refresh failed for ${cred.provider}, serving existing token:`,
-        err instanceof Error ? err.message : err,
-      );
+      if (err instanceof RefreshRejectedError) {
+        // The refresh TOKEN itself was rejected — dead until the user
+        // reconnects. The policy (compare-and-delete, never a blind remove)
+        // lives in credentials/disconnect.ts; it answers with the credential
+        // that superseded ours, or null when the dead one is confirmed gone.
+        const superseding = await disconnectRejectedCredential({
+          credentials: deps.credentials,
+          workspaceId: claim.workspaceId,
+          rejected: cred,
+          acting,
+          reason: err.message,
+        });
+        // Confirmed dead: the marked 404 makes the runtime drop its served
+        // entry (provenance-gated) and the provider reads signed-out with the
+        // reconnect flow — the credential IS the switch. Otherwise serve what
+        // the store holds NOW, through every check below (anthropic staleness
+        // included).
+        if (!superseding)
+          return notConnected(
+            res,
+            `${cred.provider} session ended; reconnect the provider`,
+          );
+        cred = superseding;
+      } else {
+        // No refresh path for this provider, or a transient failure (network,
+        // 5xx). Serve the existing token best-effort instead of 500-ing every
+        // turn: it may still be valid, and a genuinely expired one surfaces as
+        // a clear auth error on the real API call. This also stops the
+        // runtime's multi-provider serve loop from spamming serve 500s for a
+        // stale, unused credential (e.g. a leftover Claude login while the
+        // agent runs OpenCode).
+        console.error(
+          `[sandbox/credential] refresh failed for ${cred.provider}, serving existing token:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
     }
   }
   // Never serve a STALE anthropic token. Unlike every other provider, a served
@@ -147,15 +167,8 @@ export async function handleSandboxCredential(
   // still-working self-refreshing credential. Degrading to the marked 404
   // makes the runtime drop the served entry (provenance-gated) and fall back
   // to that file path instead.
-  if (cred.provider === "anthropic" && isExpiring(cred)) {
-    json(
-      res,
-      404,
-      { error: "anthropic credential is stale" },
-      { "x-houston-not-connected": "1" },
-    );
-    return true;
-  }
+  if (cred.provider === "anthropic" && isExpiring(cred))
+    return notConnected(res, "anthropic credential is stale");
   // Access token ONLY (Gate #2): the refresh token never leaves this process.
   // A stolen sandbox credential is then worth minutes, not an account. The
   // ChatGPT backend needs accountId, so that still ships. `kind` tells the

--- a/packages/host/src/store-sync/daemon.test.ts
+++ b/packages/host/src/store-sync/daemon.test.ts
@@ -12,8 +12,12 @@ import {
   type ObjectStore,
   ObjectTooLargeError,
 } from "@houston/runtime-client/object-sync";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { StoreSyncDaemon } from "./daemon";
+
+// Headroom over eventually()'s 15s deadline; the default 5s test timeout
+// left none and made these watcher-driven tests flake under suite load.
+vi.setConfig({ testTimeout: 20_000 });
 
 function setup() {
   const remoteRoot = mkdtempSync(join(tmpdir(), "store-sync-remote-"));
@@ -24,13 +28,20 @@ function setup() {
     store,
     rootDir: localRoot,
     quietMs: 20,
-    intervalMs: 60_000,
+    // Short interval: macOS FSEvents subscriptions activate asynchronously,
+    // so a write landing right after start() can be missed by the watcher.
+    // The periodic sync is the daemon's designed fallback for exactly that;
+    // give it a test-scale period instead of the production 5 minutes.
+    intervalMs: 250,
     log: (message, err) => logs.push({ message, err }),
   });
   return { daemon, localRoot, logs, remoteRoot, store };
 }
 
-async function eventually(assertion: () => void, timeoutMs = 5_000) {
+// Generous deadline: these tests ride real FS-watcher events and debounce
+// timers, which slip well past the nominal quiet period when the suite runs
+// under full-worker load. Polling keeps green runs fast regardless.
+async function eventually(assertion: () => void, timeoutMs = 15_000) {
   const deadline = Date.now() + timeoutMs;
   let error: unknown;
   while (Date.now() < deadline) {
@@ -217,6 +228,7 @@ test("warns only after synced data crosses 80% of the hydration cap", async () =
     store: new LocalDirStore(remoteRoot),
     rootDir: localRoot,
     quietMs: 20,
+    intervalMs: 250, // see setup(): fallback for missed watcher startup events
     maxHydrateBytes: 1000,
     log: (message) => logs.push(message),
   });
@@ -247,6 +259,7 @@ test("final sync warns when the tree is past 80% of the cap", async () => {
     store: new LocalDirStore(remoteRoot),
     rootDir: localRoot,
     quietMs: 20,
+    intervalMs: 250, // see setup(): fallback for missed watcher startup events
     maxHydrateBytes: 1000,
     log: (message) => logs.push(message),
   });

--- a/packages/host/src/store-sync/shared-mirror.test.ts
+++ b/packages/host/src/store-sync/shared-mirror.test.ts
@@ -4,8 +4,12 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import type { ManifestObjectStore } from "@houston/runtime-client/object-sync";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { SharedMirrorController } from "./shared-mirror";
+
+// Headroom over eventually()'s 15s deadline; the default 5s test timeout
+// left none and made these watcher-driven tests flake under suite load.
+vi.setConfig({ testTimeout: 20_000 });
 
 const md5 = (body: Buffer) => createHash("md5").update(body).digest("base64");
 
@@ -41,13 +45,30 @@ function memoryStore(initial: Record<string, string>) {
   return { objects, store, uploads };
 }
 
-async function eventually(assertion: () => void): Promise<void> {
-  const deadline = Date.now() + 2_000;
+/**
+ * Polls the assertion, periodically rewriting `file` with the SAME bytes.
+ * macOS FSEvents subscriptions activate asynchronously, so a write landing
+ * right after the controller starts can be missed entirely; the controller
+ * has no periodic fallback, so only a fresh FS event recovers. Identical
+ * bytes are hash-skipped by syncSharedMirror, so retouches never add
+ * uploads once a push has landed.
+ */
+async function eventuallyWithRetouch(
+  file: string,
+  content: string,
+  assertion: () => void,
+): Promise<void> {
+  const deadline = Date.now() + 15_000;
+  let lastTouch = Date.now();
   while (Date.now() < deadline) {
     try {
       assertion();
       return;
     } catch {
+      if (Date.now() - lastTouch > 1_000) {
+        writeFileSync(file, content);
+        lastTouch = Date.now();
+      }
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
   }
@@ -152,7 +173,9 @@ test("the watcher debounces local edits into a prompt push-only cycle", async ()
 
   writeFileSync(file, "a local v2");
   writeFileSync(file, "a local v3");
-  await eventually(() => expect(remote.uploads).toEqual(["skills/a/SKILL.md"]));
+  await eventuallyWithRetouch(file, "a local v3", () =>
+    expect(remote.uploads).toEqual(["skills/a/SKILL.md"]),
+  );
 
   expect(remote.objects.get("skills/a/SKILL.md")?.toString()).toBe(
     "a local v3",
@@ -231,8 +254,9 @@ test("a watcher push failure logs the real error and retries next cycle", async 
   });
   controller.wake();
   await controller.beforeTurn();
-  writeFileSync(join(mirrorDir, "skills", "a", "SKILL.md"), "retry this edit");
-  await eventually(() =>
+  const retryFile = join(mirrorDir, "skills", "a", "SKILL.md");
+  writeFileSync(retryFile, "retry this edit");
+  await eventuallyWithRetouch(retryFile, "retry this edit", () =>
     expect(logs).toContainEqual({
       message: "[shared-mirror] watcher push failed; using current mirror",
       error: expect.objectContaining({ message: "shared PUT unavailable" }),

--- a/packages/host/src/turn/fresh-credential.test.ts
+++ b/packages/host/src/turn/fresh-credential.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, expect, test } from "vitest";
+import { sharedCredentialRefresher } from "../credentials/refresh-coalescer";
+import { MemoryCredentialStore } from "../credentials/store";
+import type { CredentialStore, WorkspaceCredential } from "../ports";
+import type { TurnDeps } from "./deps";
+import { freshCredential } from "./fresh-credential";
+
+/**
+ * The per-turn credential comes from the SAME coalescer the serve route uses.
+ * A second, uncoalesced rotator would spend the workspace's rotating refresh
+ * token concurrently with the serve path — the first exchange wins and the
+ * loser's `invalid_grant` disconnects the user.
+ */
+
+const FRESH = () => Date.now() + 3_600_000;
+
+beforeEach(() => sharedCredentialRefresher.reset());
+
+async function expiringStore(): Promise<MemoryCredentialStore> {
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "ws1",
+    provider: "openai-codex",
+    accessToken: "AT-old",
+    refreshToken: "rt.rotating",
+    expiresAt: 1,
+  });
+  return credentials;
+}
+
+const turnDeps = (
+  credentials: CredentialStore,
+  refresh: (cred: WorkspaceCredential) => Promise<WorkspaceCredential>,
+): TurnDeps => ({ credentials, refresh }) as unknown as TurnDeps;
+
+test("freshCredential spends the rotating refresh token exactly once per burst", async () => {
+  const credentials = await expiringStore();
+  let refreshes = 0;
+  const deps = turnDeps(credentials, async (cred) => {
+    refreshes++;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    return {
+      ...cred,
+      accessToken: "AT-new",
+      refreshToken: "rt.rotated",
+      expiresAt: FRESH(),
+    };
+  });
+
+  const [a, b] = await Promise.all([
+    freshCredential(deps, "ws1", "openai-codex"),
+    freshCredential(deps, "ws1", "openai-codex"),
+  ]);
+
+  expect(refreshes).toBe(1);
+  expect(a?.accessToken).toBe("AT-new");
+  expect(b).toBe(a);
+  expect((await credentials.get("ws1", "openai-codex"))?.refreshToken).toBe(
+    "rt.rotated",
+  );
+});
+
+test("freshCredential reports a mid-refresh disconnect as not-connected", async () => {
+  const memory = await expiringStore();
+  let reads = 0;
+  const credentials: CredentialStore = {
+    get: async (workspaceId, provider, acting) =>
+      ++reads === 1 ? memory.get(workspaceId, provider, acting) : null,
+    put: (cred, opts) => memory.put(cred, opts),
+    remove: (workspaceId, provider, acting) =>
+      memory.remove(workspaceId, provider, acting),
+    removeIfAccess: async () => false,
+  };
+  const deps = turnDeps(credentials, async () => {
+    throw new Error("a deleted credential must never be refreshed");
+  });
+
+  expect(await freshCredential(deps, "ws1", "openai-codex")).toBeNull();
+});

--- a/packages/host/src/turn/fresh-credential.ts
+++ b/packages/host/src/turn/fresh-credential.ts
@@ -1,0 +1,43 @@
+import { isExpiring } from "../credentials/refresh";
+import {
+  CredentialGoneError,
+  sharedCredentialRefresher,
+} from "../credentials/refresh-coalescer";
+import type { WorkspaceCredential } from "../ports";
+import type { TurnDeps } from "./deps";
+
+/**
+ * The workspace's credential for `provider`, refreshed centrally when expiring
+ * (an API-key credential never expires, so it's served as-is). Null = the
+ * workspace hasn't connected that provider.
+ *
+ * The refresh goes through the process-wide coalescer — the SAME one the serve
+ * route uses. Rotating providers (openai-codex) invalidate the old refresh token
+ * on every use, so a private rotator here would race the serve path: the first
+ * exchange wins, the loser gets `invalid_grant`, and the user's provider
+ * disconnects itself. `deps.refresh` rides along as this call's refresher, so
+ * the dependency bundle stays injectable without owning a second flight.
+ */
+export async function freshCredential(
+  deps: TurnDeps,
+  wsId: string,
+  provider: string,
+): Promise<WorkspaceCredential | null> {
+  const cred = await deps.credentials.get(wsId, provider);
+  if (!cred) return null;
+  if (!isExpiring(cred)) return cred;
+  try {
+    return await sharedCredentialRefresher.run({
+      workspaceId: wsId,
+      provider,
+      load: () => deps.credentials.get(wsId, provider),
+      persist: (c) => deps.credentials.put(c),
+      doRefresh: deps.refresh,
+    });
+  } catch (err) {
+    // Disconnected mid-flight: nothing was refreshed or written, and the answer
+    // is the same one an absent row gives — this workspace has no credential.
+    if (err instanceof CredentialGoneError) return null;
+    throw err;
+  }
+}

--- a/packages/host/src/turn/start-turn.ts
+++ b/packages/host/src/turn/start-turn.ts
@@ -1,15 +1,11 @@
 import type { ServerResponse } from "node:http";
 import type { ChatMessage } from "@houston/protocol";
 import { readEventStream } from "@houston/runtime-client";
-import { isExpiring } from "../credentials/refresh";
 import type { Agent, Workspace } from "../domain/types";
-import {
-  isApiKeyCredential,
-  type TurnPin,
-  type WorkspaceCredential,
-} from "../ports";
+import { isApiKeyCredential, type TurnPin } from "../ports";
 import { resolveCloudTurn } from "./cloud-provider";
 import { json, prefixFor, type TurnDeps } from "./deps";
+import { freshCredential } from "./fresh-credential";
 import { TurnQuotaError } from "./quota";
 
 /**
@@ -18,25 +14,6 @@ import { TurnQuotaError } from "./quota";
  * access credential included), and pump the runtime's SSE frames into the
  * relay where this conversation's subscribers receive them.
  */
-
-/**
- * The workspace's credential for `provider`, refreshed centrally when expiring
- * (an API-key credential never expires, so it's served as-is). Null = the
- * workspace hasn't connected that provider.
- */
-export async function freshCredential(
-  deps: TurnDeps,
-  wsId: string,
-  provider: string,
-): Promise<WorkspaceCredential | null> {
-  let cred = await deps.credentials.get(wsId, provider);
-  if (!cred) return null;
-  if (isExpiring(cred)) {
-    cred = await deps.refresh(cred);
-    await deps.credentials.put(cred);
-  }
-  return cred;
-}
 
 /** Outcome of asking the per-turn runtime to start a turn. */
 export type TurnStart =

--- a/packages/runtime-client/src/client.ts
+++ b/packages/runtime-client/src/client.ts
@@ -123,8 +123,15 @@ export class HoustonEngineClient {
   }
 
   // --- providers, settings & auth (subscription OAuth) ---
-  listProviders() {
-    return this.json<ProviderInfo[]>("/providers");
+  /**
+   * Every provider the runtime knows, with its `configured` flag and active
+   * model. `opts.signal` bounds the call: this is the status probe's only
+   * round-trip, and a host that accepts the connection but never answers (a
+   * wedged sidecar, a pod stuck mid-boot) would otherwise leave the caller
+   * pending forever with no failure to react to (HOU-1153).
+   */
+  listProviders(opts?: { signal?: AbortSignal }) {
+    return this.json<ProviderInfo[]>("/providers", { signal: opts?.signal });
   }
   /**
    * Live per-account usage for every CONNECTED provider — rate-limit windows

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -48,6 +48,26 @@ test("Codex session-kill → unauthenticated / token_revoked (terminal, not tran
   if (err.kind === "unauthenticated") expect(err.cause).toBe("token_revoked");
 });
 
+test.each([
+  "401 Your session has ended. Please log in again.",
+  "401 Unauthorized. Please login again to continue.",
+  "401 Unauthorized: session terminated",
+])("loose terminal phrasing still reads token_revoked: %s", (message) => {
+  // The CARD copy stays generous: any 401 that reads terminal should say "your
+  // access was revoked, sign in again". What these phrasings must NOT do is
+  // trigger the workspace-wide revoked-token report — that gate keeps its own
+  // strict marker list in `auth/report-revoked.ts` (tested there), so a
+  // provider wording a transient blip this way can no longer delete a live
+  // credential for every runtime in the workspace.
+  const err = classifyProviderError({
+    provider: "openai-codex",
+    model: "gpt-5.1-codex",
+    message,
+  });
+  expect(err.kind).toBe("unauthenticated");
+  if (err.kind === "unauthenticated") expect(err.cause).toBe("token_revoked");
+});
+
 test("pi prompt-time 'No API key found' → unauthenticated / no_credentials (HOU-718)", () => {
   // pi RAISES this (formatNoApiKeyFoundMessage) when the user logged out of a
   // provider that stayed selected — it never arrives as an errored

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -31,7 +31,17 @@ export interface ProviderErrorInput {
   status?: number | null;
 }
 
-/** Terminal server-side session-kill markers: the provider ENDED the session. */
+/**
+ * Terminal server-side session-kill markers: the provider ENDED the session.
+ *
+ * Loose on purpose — these drive CARD COPY ("your access was revoked, sign in
+ * again"), which is the right thing to say about any 401 that reads terminal,
+ * and being wrong costs nothing but a reconnect prompt. They must never drive a
+ * destructive action: the workspace-wide revoked-token report gates on its own,
+ * strict marker list (`auth/report-revoked.ts`), so a provider that phrases a
+ * transient blip as "please log in again" cannot delete a live credential. Add
+ * loose phrasings here freely; add to that list almost never.
+ */
 const TERMINAL_SESSION_PATTERNS = [
   "app_session_terminated",
   "your session has ended",

--- a/packages/runtime/src/auth/report-revoked.test.ts
+++ b/packages/runtime/src/auth/report-revoked.test.ts
@@ -58,18 +58,23 @@ async function withServeMode(
   }
 }
 
-/** A served anthropic oauth credential on disk, as a serve sync would leave it. */
-function servedAnthropic(dataDir: string, access = "served-access"): void {
+/** A served oauth credential on disk, as a serve sync would leave it. */
+function servedOauth(dataDir: string, provider: string, access: string): void {
   writeFileSync(
     join(dataDir, "auth.json"),
     JSON.stringify({
-      anthropic: { type: "oauth", access, refresh: "", expires: 0 },
+      [provider]: { type: "oauth", access, refresh: "", expires: 0 },
     }),
   );
   writeFileSync(
     join(dataDir, "served-providers.json"),
-    JSON.stringify(["anthropic"]),
+    JSON.stringify([provider]),
   );
+}
+
+/** The common case: anthropic, the provider most turns run on. */
+function servedAnthropic(dataDir: string, access = "served-access"): void {
+  servedOauth(dataDir, "anthropic", access);
 }
 
 /** The same, but in ONE member's files — where a per-identity serve sync lands. */
@@ -165,6 +170,91 @@ test("does NOT report a non-terminal auth failure", async () => {
       } as ProviderError),
   );
   expect(captured).toBeNull();
+});
+
+test.each([
+  [
+    "a session that merely 'ended'",
+    "401 Your session has ended. Please log in again.",
+  ],
+  [
+    "a bare re-login prompt",
+    "401 Unauthorized. Please login again to continue.",
+  ],
+  ["prose about a terminated session", "401 Unauthorized: session terminated"],
+])("does NOT report %s — loose copy, no confirmed revocation", async (_label, message) => {
+  // These phrasings legitimately produce the `token_revoked` CARD (both
+  // classifiers map them), but providers also reach for them on transient
+  // auth blips. Reporting one deletes the workspace's credential on a single
+  // failed turn, so the destructive half needs a machine-emitted marker.
+  const captured = await withServeMode(
+    (dir) => servedAnthropic(dir),
+    () => reportRevokedServedToken({ ...revoked, message }),
+  );
+  expect(captured).toBeNull();
+});
+
+test.each([
+  [
+    "a negated revocation",
+    "401 Unauthorized: the token was checked and has not been revoked",
+  ],
+  ["an unrelated field that merely spells it", '401 {"revoked_scopes":[]}'],
+])("does NOT report %s — the marker must be anchored", async (_label, message) => {
+  // The bare substring "revoked" reads a NEGATION and a field name as a
+  // confirmed revocation, and this gate deletes the credential for every
+  // runtime in the workspace. The anchored phrases ("has been revoked",
+  // "access revoked", "token_revoked") survive neither.
+  const captured = await withServeMode(
+    (dir) => servedAnthropic(dir),
+    () => reportRevokedServedToken({ ...revoked, message }),
+  );
+  expect(captured).toBeNull();
+});
+
+test.each([
+  [
+    "the provider stating it outright",
+    '401 {"error":{"message":"OAuth access token has been revoked"}}',
+  ],
+  ["a structured revocation code", '401 {"error":{"code":"token_revoked"}}'],
+  ["prose naming the access", "401 Unauthorized: access revoked by the admin"],
+])("reports %s (anchored marker)", async (_label, message) => {
+  // The anthropic path (backends/claude/errors.ts) hands the provider's verbatim
+  // text straight through, so these are the shapes the strict list must keep
+  // catching after anchoring.
+  const captured = await withServeMode(
+    (dir) => servedAnthropic(dir, "the-revoked-token"),
+    () => reportRevokedServedToken({ ...revoked, message }),
+  );
+  expect(captured?.body.accessSha256).toBe(accessDigest("the-revoked-token"));
+});
+
+test.each([
+  [
+    "Codex's structured session kill",
+    "OpenAI API error (401): Your session has ended. Please log in again. (app_session_terminated)",
+  ],
+  [
+    "OpenAI's invalidated refresh token",
+    '401 {"error":{"code":"refresh_token_invalidated"}}',
+  ],
+])("reports %s", async (_label, message) => {
+  const captured = await withServeMode(
+    (dir) => servedOauth(dir, "openai-codex", "codex-revoked-token"),
+    () =>
+      reportRevokedServedToken({
+        ...revoked,
+        provider: "openai-codex",
+        message,
+      }),
+  );
+
+  expect(captured?.url).toBe(
+    "http://control-plane.test/sandbox/credential/revoked",
+  );
+  expect(captured?.body.provider).toBe("openai-codex");
+  expect(captured?.body.accessSha256).toBe(accessDigest("codex-revoked-token"));
 });
 
 test("does NOT report a credential this runtime owns locally", async () => {

--- a/packages/runtime/src/auth/report-revoked.ts
+++ b/packages/runtime/src/auth/report-revoked.ts
@@ -24,18 +24,20 @@ import { servedScopeFor } from "./served-scope";
  * claiming "Connected". This is the other half — the workspace's other runtimes
  * cannot learn it from our memory.
  *
- * Deliberately narrow. Three gates, each of which would otherwise let a report
+ * Deliberately narrow. Four gates, each of which would otherwise let a report
  * sign a workspace out of a credential that is fine:
  *
  *  1. `token_revoked` ONLY, never `unauthenticated` at large. The broad kind
  *     covers transient provider auth blips and misconfigured keys; the terminal
  *     cause is the one that means "this token is dead forever" (see
  *     protocol/provider-error.ts).
- *  2. Serve mode, and the provider must be in the SERVED manifest. A credential
+ *  2. The provider's own words must CONFIRM the revocation, not merely read
+ *     like one (`REVOCATION_CONFIRMED_PATTERNS`).
+ *  3. Serve mode, and the provider must be in the SERVED manifest. A credential
  *     this runtime owns locally (a desktop keychain login) is none of the
  *     control plane's business, and reporting it would ask the store to delete
  *     a row that never backed this turn.
- *  3. OAuth only. An api_key has no revocation semantics worth acting on here,
+ *  4. OAuth only. An api_key has no revocation semantics worth acting on here,
  *     and treating one as revoked would delete a key the user still wants.
  *
  * Fire-and-forget and never throws: this runs inside error handling for a turn
@@ -46,8 +48,54 @@ export function reportRevokedServedToken(err: ProviderError): void {
   void reportRevoked(err).catch(() => {});
 }
 
+/**
+ * Message markers that CONFIRM a server-side revocation — the ONLY texts allowed
+ * to trigger the workspace-wide delete.
+ *
+ * `token_revoked` is deliberately generous on the CARD side: both classifiers
+ * (`ai/provider-error.ts` and `backends/claude/errors.ts`) also map loose
+ * phrasings — "your session has ended", "please log in again" — to it, because
+ * "your access was revoked, sign in again" is the right thing to SAY about any
+ * terminal-looking 401. It is not the right thing to DO: providers reach for
+ * that copy for transient auth blips too, and one such turn would otherwise
+ * delete the credential for every runtime in the workspace.
+ *
+ * So presentation and destruction are split here, and the destructive half
+ * takes only unambiguous, machine-emitted revocation markers:
+ *  - `token_revoked` — the structured code providers return for it.
+ *  - `has been revoked` / `access revoked` — the provider stating it outright in
+ *    prose ("401 OAuth access token has been revoked"). ANCHORED phrases, never
+ *    the bare word: "revoked" alone also matches a NEGATION ("the scope was not
+ *    revoked") and unrelated fields ("revoked_scopes": []), each of which would
+ *    delete a live credential for the whole workspace. Neither anchored phrase
+ *    survives a negation — "has not been revoked" does not contain "has been
+ *    revoked".
+ *  - `app_session_terminated` — ChatGPT/Codex's structured code for a login
+ *    session killed server-side (it rides ALONG with the loose prose above,
+ *    which is exactly why the code, not the prose, is the signal).
+ *  - `refresh_token_invalidated` — OpenAI's code for the same thing on the token
+ *    endpoint; the host treats it as terminal too (`credentials/oauth-token-exchange.ts`).
+ *
+ * Prose like "session terminated" is deliberately NOT here: the harm is
+ * lopsided. A missed report costs the user a manual reconnect (the pre-HOU-952
+ * status quo); a false one destroys a working credential workspace-wide.
+ */
+const REVOCATION_CONFIRMED_PATTERNS = [
+  "token_revoked",
+  "has been revoked",
+  "access revoked",
+  "app_session_terminated",
+  "refresh_token_invalidated",
+];
+
+function revocationConfirmed(message: string): boolean {
+  const lower = message.toLowerCase();
+  return REVOCATION_CONFIRMED_PATTERNS.some((p) => lower.includes(p));
+}
+
 async function reportRevoked(err: ProviderError): Promise<void> {
   if (err.kind !== "unauthenticated" || err.cause !== "token_revoked") return;
+  if (!revocationConfirmed(err.message)) return;
   // Serve mode, read straight off config rather than through serve.ts's
   // serveModeOn(). That import is what broke the engine bundle: serve.ts sits
   // in an async-initialized cycle (storage -> providers -> serve), so pulling

--- a/packages/runtime/src/auth/storage.test.ts
+++ b/packages/runtime/src/auth/storage.test.ts
@@ -55,7 +55,10 @@ test("providerConnected(anthropic): the shared-dir credential probe counts with 
   expect(providerConnected(store, "anthropic")).toBe(false);
   // The browser login populated the shared dir → the probe reads logged-in,
   // even though auth.json holds no anthropic credential.
-  await refreshAnthropicCredential(async () => true);
+  await refreshAnthropicCredential(async () => ({
+    known: true,
+    loggedIn: true,
+  }));
   expect(providerConnected(store, "anthropic")).toBe(true);
   // Sign out clears the shared-dir credential → disconnected again.
   resetAnthropicCredentialCache(false);
@@ -64,7 +67,11 @@ test("providerConnected(anthropic): the shared-dir credential probe counts with 
 
 test("providerConnected(anthropic): a pasted setup token also counts (degraded fallback)", async () => {
   const store = tmpStore();
-  await refreshAnthropicCredential(async () => false); // shared dir empty
+  // shared dir empty → the probe ANSWERS logged-out
+  await refreshAnthropicCredential(async () => ({
+    known: true,
+    loggedIn: false,
+  }));
   expect(providerConnected(store, "anthropic")).toBe(false);
   store.set("anthropic", { type: "api_key", key: "sk-ant-oat01-x" });
   expect(providerConnected(store, "anthropic")).toBe(true);
@@ -118,7 +125,10 @@ test("providerConnected: an EXPIRED access-only oauth entry no longer counts as 
   expect(providerConnected(store, "openai-codex")).toBe(true);
 
   // Anthropic's auth.json entry follows the same rule (the probe stays off).
-  await refreshAnthropicCredential(async () => false);
+  await refreshAnthropicCredential(async () => ({
+    known: true,
+    loggedIn: false,
+  }));
   resetAnthropicCredentialCache(false);
   store.set("anthropic", {
     type: "oauth",

--- a/packages/runtime/src/backends/claude/auth-cli.test.ts
+++ b/packages/runtime/src/backends/claude/auth-cli.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "vitest";
+import { readProbeOutcome } from "./auth-cli";
+
+/**
+ * The single rule this file guards: only a parsed boolean `loggedIn` is an
+ * ANSWER. Every other outcome of `claude auth status --json` used to collapse
+ * into "logged out", which flipped a signed-in user's card to "Connect
+ * Anthropic" mid-session.
+ */
+
+test("a parsed boolean loggedIn is the only KNOWN answer", () => {
+  expect(readProbeOutcome(null, '{"loggedIn":true}')).toEqual({
+    known: true,
+    loggedIn: true,
+  });
+  // Non-zero exit + valid JSON is still a real answer: `claude auth status`
+  // exits non-zero when signed out.
+  expect(
+    readProbeOutcome(
+      Object.assign(new Error("exit 1"), {}),
+      '{"loggedIn":false}',
+    ),
+  ).toEqual({ known: true, loggedIn: false });
+});
+
+test("a killed child is UNKNOWN, not logged out (the 10s timeout path)", () => {
+  const killed = Object.assign(new Error("timed out"), {
+    killed: true,
+    signal: "SIGTERM" as const,
+  });
+  expect(readProbeOutcome(killed, "")).toEqual({
+    known: false,
+    reason: "probe killed (SIGTERM)",
+  });
+});
+
+test("empty, non-JSON, and shape-less output are UNKNOWN", () => {
+  expect(readProbeOutcome(null, "   ")).toMatchObject({ known: false });
+  expect(readProbeOutcome(null, "not json at all")).toMatchObject({
+    known: false,
+  });
+  // A future/unknown CLI shape must not be read as a sign-out either.
+  expect(readProbeOutcome(null, '{"status":"ok"}')).toMatchObject({
+    known: false,
+  });
+  expect(readProbeOutcome(null, '{"loggedIn":"yes"}')).toMatchObject({
+    known: false,
+  });
+});

--- a/packages/runtime/src/backends/claude/auth-cli.ts
+++ b/packages/runtime/src/backends/claude/auth-cli.ts
@@ -1,0 +1,120 @@
+import { execFile } from "node:child_process";
+import { buildClaudeEnv } from "./backend";
+import { resolveClaudeExecutable } from "./binary-path";
+import { claudeLoginConfigDir } from "./paths";
+
+/**
+ * The two `claude auth` subprocesses Houston spawns against its SHARED login dir
+ * (`claudeLoginConfigDir()`): the status probe and the logout. Both scrub the
+ * ambient credential env (`buildClaudeEnv` with no token) so a stray
+ * `ANTHROPIC_API_KEY` on the host can't answer for the credential we're asking
+ * about — we want ONLY what is cached for that dir.
+ *
+ * Kept separate from `credential-status.ts` so the cache/TTL policy there stays
+ * free of subprocess mechanics (and stays injectable in tests).
+ */
+
+/**
+ * What a probe can tell us. `known: false` is NOT "logged out" — it is "the
+ * subprocess failed to answer" (timeout, kill, garbled output). Conflating the
+ * two is what made the Anthropic card flap to "Connect Anthropic" mid-session.
+ */
+export type ProbeAnswer =
+  | { known: true; loggedIn: boolean }
+  | { known: false; reason: string };
+
+/**
+ * Resolve the spawnable `claude` binary: the bundled sibling inside the compiled
+ * desktop sidecar, else `claude` on PATH (dev / self-host). A missing sibling in
+ * a packaged build surfaces as an `execFile` ENOENT below, never a silent success.
+ */
+function claudeBinary(): string {
+  try {
+    return resolveClaudeExecutable() ?? "claude";
+  } catch {
+    // Bun-compiled but the sibling wasn't staged — fall back to PATH; the spawn
+    // error (if `claude` is truly absent) is logged by the caller.
+    return "claude";
+  }
+}
+
+/**
+ * Read a status-probe outcome. KNOWN only when stdout parses as JSON carrying a
+ * boolean `loggedIn` — anything else (killed child, empty stdout, non-JSON, a
+ * shape we don't recognize) is "couldn't tell", never "logged out". A non-zero
+ * exit is NOT itself a failure: `claude auth status` exits non-zero while still
+ * printing a valid `{"loggedIn": false}`.
+ *
+ * Pure over its inputs so every branch is testable without a subprocess.
+ */
+export function readProbeOutcome(
+  err: (Error & { killed?: boolean; signal?: NodeJS.Signals | null }) | null,
+  stdout: string,
+): ProbeAnswer {
+  // `timeout` kills the child: no output, no verdict.
+  if (err?.killed || err?.signal) {
+    return {
+      known: false,
+      reason: `probe killed (${err.signal ?? "timeout"})`,
+    };
+  }
+  if (!stdout.trim())
+    return { known: false, reason: "probe produced no output" };
+  let parsed: { loggedIn?: unknown };
+  try {
+    parsed = JSON.parse(stdout) as { loggedIn?: unknown };
+  } catch {
+    return { known: false, reason: "probe output was not JSON" };
+  }
+  if (typeof parsed.loggedIn !== "boolean") {
+    return { known: false, reason: "no boolean `loggedIn` in output" };
+  }
+  return { known: true, loggedIn: parsed.loggedIn };
+}
+
+/**
+ * `claude auth status --json`, scoped to the shared login dir. Rejects on ENOENT
+ * (no binary to ask — its own failure mode); every other outcome is read by
+ * `readProbeOutcome`.
+ */
+export function spawnStatusProbe(): Promise<ProbeAnswer> {
+  const env = buildClaudeEnv(claudeLoginConfigDir(), undefined);
+  return new Promise<ProbeAnswer>((resolve, reject) => {
+    execFile(
+      claudeBinary(),
+      ["auth", "status", "--json"],
+      { env, timeout: 10_000 },
+      (err, stdout) => {
+        if (err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+          reject(err);
+          return;
+        }
+        resolve(readProbeOutcome(err, stdout));
+      },
+    );
+  });
+}
+
+/**
+ * `claude auth logout` for the shared dir — clears the Keychain entry. Rejects
+ * on failure so the caller can surface it (a logout the user asked for must
+ * either clear the credential or report why it couldn't). ENOENT resolves: there
+ * is no bundled binary to log out with, and nothing was ever cached through it.
+ */
+export function spawnClaudeLogout(): Promise<void> {
+  const env = buildClaudeEnv(claudeLoginConfigDir(), undefined);
+  return new Promise<void>((resolve, reject) => {
+    execFile(
+      claudeBinary(),
+      ["auth", "logout"],
+      { env, timeout: 10_000 },
+      (err) => {
+        if (err && (err as NodeJS.ErrnoException).code !== "ENOENT") {
+          reject(err);
+          return;
+        }
+        resolve();
+      },
+    );
+  });
+}

--- a/packages/runtime/src/backends/claude/credential-status.test.ts
+++ b/packages/runtime/src/backends/claude/credential-status.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, expect, test, vi } from "vitest";
+import type { CredentialProbe } from "./credential-status";
 import {
   anthropicCredentialCached,
   logoutAnthropicCredential,
@@ -12,8 +13,29 @@ import { claudeCredentialsFile } from "./paths";
 
 afterEach(() => {
   resetAnthropicCredentialCache(false);
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
+
+/** A probe that ANSWERS (the only kind that may move the cache). */
+const answers = (loggedIn: boolean): CredentialProbe => {
+  return async () => ({ known: true, loggedIn });
+};
+
+/** A probe that counts its spawns, so TTL/backoff assertions are exact. */
+function countingProbe(answer: Awaited<ReturnType<CredentialProbe>>): {
+  probe: CredentialProbe;
+  calls: () => number;
+} {
+  let calls = 0;
+  return {
+    probe: async () => {
+      calls += 1;
+      return answer;
+    },
+    calls: () => calls,
+  };
+}
 
 /** Point HOUSTON_HOME (and thus claudeCredentialsFile) at a throwaway dir. */
 function withHoustonHome(fn: (credFile: string) => void): void {
@@ -54,59 +76,155 @@ function writeCredFile(path: string): void {
 
 test("a logged-in probe warms the cache", async () => {
   resetAnthropicCredentialCache(false);
-  expect(await refreshAnthropicCredential(async () => true)).toBe(true);
+  expect(await refreshAnthropicCredential(answers(true))).toBe(true);
   expect(anthropicCredentialCached()).toBe(true);
 });
 
-test("a logged-out probe reads as not connected", async () => {
+test("a probe that ANSWERS logged-out reads as not connected", async () => {
   resetAnthropicCredentialCache(true);
-  expect(await refreshAnthropicCredential(async () => false)).toBe(false);
+  expect(await refreshAnthropicCredential(answers(false))).toBe(false);
   expect(anthropicCredentialCached()).toBe(false);
 });
 
-test("a failing probe reads as NOT connected and logs the reason (no silent failure)", async () => {
+test("a THROWING probe keeps the last known answer (a broken probe is not a sign-out)", async () => {
+  // The flapping bug: `claude auth status` failing to run said "not connected"
+  // with full confidence, so a signed-in user watched the card turn into
+  // "Connect Anthropic" mid-session. A failure to ASK is not an answer.
   const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
   resetAnthropicCredentialCache(true);
   const got = await refreshAnthropicCredential(async () => {
     throw new Error("claude spawn failed");
   });
+  expect(got).toBe(true);
+  expect(anthropicCredentialCached()).toBe(true);
+  expect(warn).toHaveBeenCalled();
+});
+
+test("an UNKNOWN answer keeps the last known value and logs the reason", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  resetAnthropicCredentialCache(true);
+  const got = await refreshAnthropicCredential(async () => ({
+    known: false,
+    reason: "timeout",
+  }));
+  expect(got).toBe(true);
+  expect(anthropicCredentialCached()).toBe(true);
+  expect(warn.mock.calls[0]?.[0]).toContain("timeout");
+});
+
+test("an unknown answer never INVENTS a connection either (disconnected stays disconnected)", async () => {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  resetAnthropicCredentialCache(false);
+  const got = await refreshAnthropicCredential(async () => ({
+    known: false,
+    reason: "ENOENT",
+  }));
   expect(got).toBe(false);
   expect(anthropicCredentialCached()).toBe(false);
-  expect(warn).toHaveBeenCalled();
 });
 
 test("rapid refreshes coalesce to ONE probe within the TTL (no subprocess spam)", async () => {
   resetAnthropicCredentialCache(false);
-  let calls = 0;
-  const probe = async () => {
-    calls += 1;
-    return true;
-  };
+  const { probe, calls } = countingProbe({ known: true, loggedIn: true });
   // Two back-to-back refreshes: the second reuses the fresh result.
   await refreshAnthropicCredential(probe);
   await refreshAnthropicCredential(probe);
-  expect(calls).toBe(1);
+  expect(calls()).toBe(1);
+});
+
+test("a CONNECTED answer is reused for 30s; a stale one re-probes", async () => {
+  vi.useFakeTimers();
+  resetAnthropicCredentialCache(false);
+  const { probe, calls } = countingProbe({ known: true, loggedIn: true });
+  await refreshAnthropicCredential(probe);
+  expect(calls()).toBe(1);
+  vi.advanceTimersByTime(5_000);
+  await refreshAnthropicCredential(probe);
+  expect(calls()).toBe(1); // connected is stable: no subprocess per poll
+  vi.advanceTimersByTime(31_000);
+  await refreshAnthropicCredential(probe);
+  expect(calls()).toBe(2);
+});
+
+test("a DISCONNECTED answer re-probes within seconds (sign-in must flip fast)", async () => {
+  vi.useFakeTimers();
+  resetAnthropicCredentialCache(true);
+  const { probe, calls } = countingProbe({ known: true, loggedIn: false });
+  await refreshAnthropicCredential(probe);
+  expect(calls()).toBe(1);
+  vi.advanceTimersByTime(3_000);
+  await refreshAnthropicCredential(probe);
+  expect(calls()).toBe(2);
+});
+
+test("an unknown answer backs off: polls within 15s spawn nothing, force still probes", async () => {
+  vi.useFakeTimers();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  resetAnthropicCredentialCache(true);
+  const { probe, calls } = countingProbe({ known: false, reason: "timeout" });
+  // /providers and /providers/usage both refresh on every poll cycle; a broken
+  // probe must not mean a subprocess per request.
+  await refreshAnthropicCredential(probe);
+  vi.advanceTimersByTime(5_000);
+  await refreshAnthropicCredential(probe);
+  vi.advanceTimersByTime(5_000);
+  expect(await refreshAnthropicCredential(probe)).toBe(true); // last known
+  expect(calls()).toBe(1);
+  // A login/logout route forces the question regardless of the backoff.
+  await refreshAnthropicCredential(probe, { force: true });
+  expect(calls()).toBe(2);
+  // And the throttle expires on its own, on the backoff's own clock (the forced
+  // probe above re-armed it).
+  vi.advanceTimersByTime(16_000);
+  await refreshAnthropicCredential(probe);
+  expect(calls()).toBe(3);
+});
+
+test("an unknown answer arms ONLY the backoff — the TTL clock keeps timing the last real answer", async () => {
+  vi.useFakeTimers();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  // Primed connected (the 30s TTL), then the probe stops answering.
+  resetAnthropicCredentialCache(true);
+  const { probe, calls } = countingProbe({ known: false, reason: "timeout" });
+  await refreshAnthropicCredential(probe);
+  expect(calls()).toBe(1);
+  vi.advanceTimersByTime(16_000);
+  await refreshAnthropicCredential(probe);
+  // Stamping the TTL clock on a NON-answer used to stack the two knobs: the 15s
+  // backoff expired but the 30s connected TTL then blocked the retry, so a
+  // recovered probe stayed unasked for twice as long as the backoff promises.
+  expect(calls()).toBe(2);
+});
+
+test("the backoff outlasts the 2s disconnected TTL, so a broken probe isn't re-spawned per poll", async () => {
+  vi.useFakeTimers();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  resetAnthropicCredentialCache(false);
+  const { probe, calls } = countingProbe({ known: false, reason: "no output" });
+  await refreshAnthropicCredential(probe);
+  vi.advanceTimersByTime(3_000); // past the disconnected TTL…
+  await refreshAnthropicCredential(probe);
+  expect(calls()).toBe(1); // …but inside the backoff
+  vi.advanceTimersByTime(13_000);
+  await refreshAnthropicCredential(probe);
+  expect(calls()).toBe(2);
 });
 
 test("force bypasses the TTL and re-probes", async () => {
   resetAnthropicCredentialCache(false);
-  let calls = 0;
-  const probe = async () => {
-    calls += 1;
-    return true;
-  };
+  const { probe, calls } = countingProbe({ known: true, loggedIn: true });
   await refreshAnthropicCredential(probe);
   await refreshAnthropicCredential(probe, { force: true });
-  expect(calls).toBe(2);
+  expect(calls()).toBe(2);
 });
 
 test("concurrent refreshes share one in-flight probe", async () => {
   resetAnthropicCredentialCache(false);
   let calls = 0;
-  const probe = async () => {
+  const probe: CredentialProbe = async () => {
     calls += 1;
     await new Promise((r) => setTimeout(r, 10));
-    return true;
+    return { known: true, loggedIn: true };
   };
   await Promise.all([
     refreshAnthropicCredential(probe),

--- a/packages/runtime/src/backends/claude/credential-status.ts
+++ b/packages/runtime/src/backends/claude/credential-status.ts
@@ -1,13 +1,15 @@
-import { execFile } from "node:child_process";
 import { rmSync } from "node:fs";
 import {
   currentCredentialScope,
   isPersonalScope,
 } from "../../session/acting-context";
-import { buildClaudeEnv } from "./backend";
-import { resolveClaudeExecutable } from "./binary-path";
+import {
+  type ProbeAnswer,
+  spawnClaudeLogout,
+  spawnStatusProbe,
+} from "./auth-cli";
 import { claudeCredentialFileUsable } from "./credentials-file";
-import { claudeCredentialsFile, claudeLoginConfigDir } from "./paths";
+import { claudeCredentialsFile } from "./paths";
 
 /**
  * Whether a Claude credential is cached FOR Houston's shared login dir.
@@ -16,8 +18,7 @@ import { claudeCredentialsFile, claudeLoginConfigDir } from "./paths";
  * only the `claude` binary can read it — the macOS Keychain (no file to stat) or
  * `<dir>/.credentials.json` on Linux — and that lookup is SCOPED BY
  * `CLAUDE_CONFIG_DIR`. So the one reliable, cross-platform "is anthropic
- * connected?" signal is to ask the binary itself: `claude auth status --json`
- * with `CLAUDE_CONFIG_DIR` pinned to `claudeLoginConfigDir()`, and read
+ * connected?" signal is to ask the binary itself (`auth-cli.ts`) and read
  * `loggedIn`. There is no artifact we can stat on macOS.
  *
  * That probe is a subprocess, so we cache its result: `providerConnected`
@@ -25,79 +26,50 @@ import { claudeCredentialsFile, claudeLoginConfigDir } from "./paths";
  * `getAuthStatus` (the frontend's poll) live-refreshes it — warming the cache
  * for the sync path. The degraded setup-token fallback stores its token in
  * auth.json instead, and `providerConnected` counts that separately.
+ *
+ * A probe that fails to ANSWER is NOT a logged-out answer. Treating it as one is
+ * what flapped the card to "Connect Anthropic" on a signed-in user, so an
+ * unknown answer leaves the cache alone, logs the reason, and backs off instead
+ * of re-spawning a subprocess per poll.
  */
 
-/** Last known `claude auth status` result for the shared login dir. */
+export type { ProbeAnswer };
+
+/** The probe: resolve a `claude` credential's presence for the shared dir. */
+export type CredentialProbe = () => Promise<ProbeAnswer>;
+
+/** Last KNOWN `claude auth status` result for the shared login dir. */
 let cache: boolean | undefined;
 
 /** When the cache was last populated (ms epoch), for the coalescing TTL. */
 let lastProbeAt = 0;
 
+/** While in the future, skip re-spawning a probe that just failed to answer. */
+let unknownBackoffUntil = 0;
+
 /** An in-flight probe, so concurrent callers share ONE subprocess. */
 let inFlight: Promise<boolean> | null = null;
 
 /**
- * How long a fresh probe result is reused before re-spawning `claude auth
- * status`. The frontend polls `/providers` and `/auth/status` on a tight React
- * Query cadence and each hits this; without coalescing every poll would spawn a
- * subprocess. Short enough that a just-connected user flips within a poll cycle,
- * long enough to collapse a burst of polls into one spawn.
+ * How long a fresh result is reused before re-spawning the probe. The frontend
+ * polls `/providers` and `/providers/usage` on a tight React Query cadence and
+ * each hits this. Asymmetric on purpose: a CONNECTED answer is stable (our own
+ * routes force a refresh after a login/logout), while a DISCONNECTED one must
+ * flip within a poll cycle of the user signing in.
  */
-const PROBE_TTL_MS = 2_000;
+const TTL_CONNECTED_MS = 30_000;
+const TTL_DISCONNECTED_MS = 2_000;
 
-/** The probe: resolve a `claude` credential's presence for the shared dir. */
-export type CredentialProbe = () => Promise<boolean>;
+/** How long an unanswerable probe is left alone (no subprocess per poll). */
+const UNKNOWN_BACKOFF_MS = 15_000;
 
 /**
- * Resolve the spawnable `claude` binary: the bundled sibling inside the compiled
- * desktop sidecar, else `claude` on PATH (dev / self-host). A missing sibling in
- * a packaged build surfaces as an `execFile` ENOENT below (logged, cache=false),
- * never a silent success.
- */
-function claudeBinary(): string {
-  try {
-    return resolveClaudeExecutable() ?? "claude";
-  } catch {
-    // Bun-compiled but the sibling wasn't staged — fall back to PATH; the spawn
-    // error (if `claude` is truly absent) is logged by `refreshAnthropicCredential`.
-    return "claude";
-  }
-}
-
-/** Default probe: `claude auth status --json`, scoped to the shared login dir. */
-function spawnStatusProbe(): Promise<boolean> {
-  // Scrub ambient credential env vars (buildClaudeEnv with no token) so a stray
-  // ANTHROPIC_API_KEY on the host can't make the probe read as connected — we
-  // want ONLY the credential cached for `claudeLoginConfigDir()`.
-  const env = buildClaudeEnv(claudeLoginConfigDir(), undefined);
-  return new Promise<boolean>((resolve, reject) => {
-    execFile(
-      claudeBinary(),
-      ["auth", "status", "--json"],
-      { env, timeout: 10_000 },
-      (err, stdout) => {
-        // A non-zero exit ("Not logged in") is not an error for our purposes:
-        // parse whatever JSON we got. A spawn failure (ENOENT) IS an error.
-        if (err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-          reject(err);
-          return;
-        }
-        try {
-          const parsed = JSON.parse(stdout) as { loggedIn?: unknown };
-          resolve(parsed.loggedIn === true);
-        } catch {
-          resolve(false);
-        }
-      },
-    );
-  });
-}
-
-/**
- * Re-probe the shared-dir credential and update the cache. Never throws: a spawn
- * failure logs the concrete reason and reads as NOT connected (the safe answer),
- * so a bad probe surfaces in the logs instead of vanishing. `probe` is injected
- * in tests.
+ * Re-probe the shared-dir credential and update the cache. Never throws.
+ *
+ * An answer we can't trust (thrown spawn error, timeout, garbage) does NOT
+ * overwrite the cache: it logs the concrete reason, returns the LAST KNOWN
+ * value, and sets a backoff so the poll cadence doesn't spawn a subprocess per
+ * request while the probe is broken. `probe` is injected in tests.
  */
 export async function refreshAnthropicCredential(
   probe: CredentialProbe = spawnStatusProbe,
@@ -105,27 +77,43 @@ export async function refreshAnthropicCredential(
 ): Promise<boolean> {
   // Reuse a fresh-enough result so a burst of status polls collapses to one
   // spawn. `force` (after a materialize/logout that changed the credential)
-  // bypasses the TTL; the first probe (cache still undefined) always runs.
-  if (
-    !opts.force &&
-    cache !== undefined &&
-    Date.now() - lastProbeAt < PROBE_TTL_MS
-  ) {
-    return cache;
+  // bypasses BOTH the TTL and the unknown backoff; the first probe (cache still
+  // undefined, no backoff) always runs.
+  const now = Date.now();
+  if (!opts.force) {
+    if (now < unknownBackoffUntil) return cache ?? false;
+    const ttl = cache === true ? TTL_CONNECTED_MS : TTL_DISCONNECTED_MS;
+    if (cache !== undefined && now - lastProbeAt < ttl) return cache;
   }
   // Coalesce concurrent callers onto one in-flight subprocess.
   if (inFlight) return inFlight;
   inFlight = (async () => {
+    let answer: ProbeAnswer;
     try {
-      cache = await probe();
+      answer = await probe();
     } catch (err) {
-      console.warn(
-        `[claude] could not read anthropic credential status (${err instanceof Error ? err.message : String(err)}); treating as not connected`,
-      );
-      cache = false;
+      answer = {
+        known: false,
+        reason: err instanceof Error ? err.message : String(err),
+      };
     }
-    lastProbeAt = Date.now();
-    return cache;
+    if (answer.known) {
+      cache = answer.loggedIn;
+      unknownBackoffUntil = 0;
+      // Only an ANSWER refreshes the TTL clock — see the else branch.
+      lastProbeAt = Date.now();
+    } else {
+      unknownBackoffUntil = Date.now() + UNKNOWN_BACKOFF_MS;
+      // The TTL clock is deliberately NOT stamped here: it times how fresh the
+      // cached ANSWER is, and this probe produced none. Stamping it made the
+      // two knobs stack instead of compose — after the 15s backoff expired, the
+      // 30s connected TTL kept blocking, so a broken probe froze the status for
+      // 30s rather than the 15s this backoff promises.
+      console.warn(
+        `[claude] could not read anthropic credential status (${answer.reason}); keeping the last known answer (${cache ?? false})`,
+      );
+    }
+    return cache ?? false;
   })();
   try {
     return await inFlight;
@@ -139,15 +127,13 @@ export async function refreshAnthropicCredential(
  * `activeProvider`/`providerConnected`.
  *
  * On the POD (Linux) the credential is materialized as a file — a sync read is
- * instant, needs no subprocess, and is correct the moment the file is written,
- * so there is no cold-start race and no probe spam on the turn path. The file
- * must actually be USABLE (`claudeCredentialFileUsable`), not merely present: a
- * stale materialized file whose token expired with no refresh token used to
- * short-circuit this to "connected" — even shadowing a probe that correctly
- * said logged-out — so the AI Models page showed Connected while every turn
- * failed with the reconnect card. macOS-local caches in the Keychain (no file
- * to read), so a missing/dead file falls back to the last `claude auth status`
- * probe result (warmed by `getAuthStatus`).
+ * instant, needs no subprocess, and is correct the moment the file is written.
+ * The file must actually be USABLE (`claudeCredentialFileUsable`), not merely
+ * present: a stale file whose token expired with no refresh token used to
+ * short-circuit this to "connected" — even shadowing a probe that correctly said
+ * logged-out — so the AI Models page showed Connected while every turn failed
+ * with the reconnect card. macOS-local caches in the Keychain (no file to read),
+ * so a missing/dead file falls back to the last probe result.
  *
  * SCOPE (HOU-976): the shared login dir is POD-WIDE — one file, one Keychain
  * entry, serving every member of a team space — so it is the TEAM's credential.
@@ -173,48 +159,29 @@ export function primeAnthropicCredential(): void {
  */
 export function resetAnthropicCredentialCache(value = false): void {
   cache = value;
-  // Zero the TTL so the next `refreshAnthropicCredential` re-probes immediately
-  // (a logout/reset must reflect right away, not after the TTL window).
+  // Zero the TTL and the backoff so the next `refreshAnthropicCredential`
+  // re-probes immediately (a logout/reset must reflect right away).
   lastProbeAt = 0;
+  unknownBackoffUntil = 0;
   inFlight = null;
 }
 
 /**
- * Clear the browser-login credential for the shared dir: `claude auth logout`.
- * Resets the cache. Rejects on failure so the caller can surface it (no silent
- * failure — a logout the user asked for must either clear the keychain or report
- * why it couldn't).
+ * Clear the browser-login credential for the shared dir. Rejects on failure so
+ * the caller can surface it (no silent failure). The materialized file goes too
+ * — on the pod its existence IS the connected signal — and the cache is reset
+ * either way, so a failed keychain logout still reports disconnected locally
+ * rather than leaving a stale "connected".
  */
-export function logoutAnthropicCredential(): Promise<void> {
-  const env = buildClaudeEnv(claudeLoginConfigDir(), undefined);
-  return new Promise<void>((resolve, reject) => {
-    execFile(
-      claudeBinary(),
-      ["auth", "logout"],
-      { env, timeout: 10_000 },
-      (err) => {
-        // Remove the materialized file too (the pod's connected signal is the
-        // file's existence); `claude auth logout` clears the Keychain, but the
-        // file — if any — must go for the sync signal to flip off.
-        try {
-          rmSync(claudeCredentialsFile(), { force: true });
-        } catch {
-          // Best-effort; the status cache reset below still reports disconnected.
-        }
-        resetAnthropicCredentialCache(false);
-        // ENOENT = no bundled binary to log out with; nothing was cached through
-        // it either, so treat the local logout as done rather than blocking the
-        // user on a helper that isn't there.
-        if (err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-          resolve();
-          return;
-        }
-        if (err) {
-          reject(err);
-          return;
-        }
-        resolve();
-      },
-    );
-  });
+export async function logoutAnthropicCredential(): Promise<void> {
+  try {
+    await spawnClaudeLogout();
+  } finally {
+    try {
+      rmSync(claudeCredentialsFile(), { force: true });
+    } catch {
+      // Best-effort; the cache reset below still reports disconnected.
+    }
+    resetAnthropicCredentialCache(false);
+  }
 }

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { WireEvent } from "@houston/runtime-client";
-import { afterAll, expect, test, vi } from "vitest";
+import { afterAll, afterEach, expect, test, vi } from "vitest";
 import type { HarnessSession } from "../backends/types";
 
 /**
@@ -22,20 +22,48 @@ process.env.HOUSTON_WORKSPACE_DIR = mkdtempSync(
 );
 
 // Pin a fixed, connected model so the turn runs without touching real auth, and
-// keep every other providers export intact for the import graph.
+// keep every other providers export intact for the import graph. `resolveModel`
+// reads a hoisted ref so a test can make the RESOLUTION itself fail (the one
+// case where a turn genuinely has no provider to name).
+const DEFAULT_MODEL = {
+  provider: "openai",
+  id: "gpt-x",
+  contextWindow: 1_000_000,
+  reasoning: false,
+};
+const resolution = vi.hoisted(() => ({
+  run: (): {
+    provider: string;
+    id: string;
+    contextWindow: number;
+    reasoning: boolean;
+  } => ({
+    provider: "openai",
+    id: "gpt-x",
+    contextWindow: 1_000_000,
+    reasoning: false,
+  }),
+}));
 vi.mock("../ai/providers", async (importOriginal) => {
   const real = await importOriginal<typeof import("../ai/providers")>();
   return {
     ...real,
     activeEffort: () => undefined,
-    resolveModel: () => ({
-      provider: "openai",
-      id: "gpt-x",
-      contextWindow: 1_000_000,
-      reasoning: false,
-    }),
+    resolveModel: () => resolution.run(),
   };
 });
+
+// The credential status surface + the control-plane revocation report are both
+// driven from execTurn's catch; spy on them to prove a mis-resolved turn never
+// marks (or signs out) a provider it never ran on.
+vi.mock("../auth/credential-health", async (importOriginal) => {
+  const real =
+    await importOriginal<typeof import("../auth/credential-health")>();
+  return { ...real, noteAuthFailure: vi.fn(), clearAuthFailure: vi.fn() };
+});
+vi.mock("../auth/report-revoked", () => ({
+  reportRevokedServedToken: vi.fn(),
+}));
 
 // Stub the backend seam (no rebuild) — and, crucially, avoid conversation-cache's
 // module-load side effects (which build the real pi + Claude backends).
@@ -61,7 +89,14 @@ const { appendAssistantMessage, appendUserMessage } = await import(
   "../store/conversations"
 );
 const { switchModeIfNeeded } = await import("./conversation-cache");
+const { noteAuthFailure } = await import("../auth/credential-health");
+const { reportRevokedServedToken } = await import("../auth/report-revoked");
 
+afterEach(() => {
+  resolution.run = () => ({ ...DEFAULT_MODEL });
+  vi.mocked(noteAuthFailure).mockClear();
+  vi.mocked(reportRevokedServedToken).mockClear();
+});
 afterAll(() => vi.restoreAllMocks());
 
 /** The pendingInteraction persisted on `id`'s assistant message, or undefined. */
@@ -75,9 +110,16 @@ function persistedInteraction(id: string): unknown {
 
 type Conv = Parameters<typeof execTurn>[0];
 
-/** A minimal Conversation whose session runs `script` when prompted. */
+/**
+ * A minimal Conversation whose session runs `script` when prompted.
+ * `opts.provider` seeds the CACHED session's last provider (the stale value the
+ * error path must never attribute a failure to) and `opts.setModel` lets a test
+ * fail the turn at the mid-turn re-point, i.e. BEFORE `conv.provider` is
+ * rewritten.
+ */
 function fakeConv(
   script: (emit: (e: WireEvent) => void) => Promise<void> | void,
+  opts: { provider?: string; setModel?: () => never } = {},
 ): Conv {
   const listeners = new Set<(e: WireEvent) => void>();
   const session: HarnessSession = {
@@ -92,7 +134,9 @@ function fakeConv(
     },
     async abort() {},
     dispose() {},
-    async setModel() {},
+    async setModel() {
+      opts.setModel?.();
+    },
     async compact() {},
     setThinkingLevel() {},
     getContextUsage() {
@@ -102,7 +146,7 @@ function fakeConv(
   return {
     session,
     queue: Promise.resolve(),
-    provider: "openai",
+    provider: opts.provider ?? "openai",
     model: "gpt-x",
     backendId: "pi",
     mode: "execute",
@@ -431,6 +475,202 @@ test("an unrecognized throw keeps the generic error frame and the unknown card",
   );
   expect(error?.data.message).toContain("flux capacitor");
   expect(persistedProviderError(id)).toMatchObject({ kind: "unknown" });
+});
+
+/**
+ * WHO a thrown turn is blamed on. The turn re-resolves its model every time, so
+ * a failure between that resolution and the `conv.provider` write belongs to the
+ * RESOLVED provider — `conv.provider` still holds whatever the cached session
+ * last ran on, which for a fresh conversation is the registry-order fallback.
+ * Blaming it put "Connect Gemini" cards in front of GPT-5.6 users and, on an
+ * auth throw, marked the innocent provider unusable workspace-wide.
+ */
+test("a throw before the provider write is attributed to the RESOLVED provider, never the cached one", async () => {
+  resolution.run = () => ({ ...DEFAULT_MODEL, provider: "openai-codex" });
+  const id = "exec-throw-attribution";
+  const { events, unsub } = collect(id);
+  // The session was built on google; this turn resolved onto openai-codex and
+  // dies at the mid-turn re-point — before `conv.provider` is rewritten.
+  const conv = fakeConv(() => {}, {
+    provider: "google",
+    setModel: () => {
+      throw new Error("the flux capacitor came loose");
+    },
+  });
+
+  await execTurn(conv, id, "turn-1", "hey", {
+    author: undefined,
+    priorAuthors: [],
+  });
+  unsub();
+
+  expect(persistedProviderError(id)).toEqual({
+    kind: "unknown",
+    provider: "openai-codex",
+    raw_excerpt: "the flux capacitor came loose",
+  });
+  // The stale cached provider never reaches the card.
+  expect(conv.provider).toBe("google");
+  expect(events.some((e) => e.type === "done")).toBe(false);
+});
+
+test("an auth throw marks the RESOLVED provider unusable and reports it revoked", async () => {
+  resolution.run = () => ({ ...DEFAULT_MODEL, provider: "openai-codex" });
+  const id = "exec-throw-auth-attribution";
+  const conv = fakeConv(() => {}, {
+    provider: "google",
+    setModel: () => {
+      throw new Error(
+        "No API key found for openai-codex.\n\nUse /login to log into a provider via OAuth or API key.",
+      );
+    },
+  });
+
+  await execTurn(conv, id, "turn-1", "hey", {
+    author: undefined,
+    priorAuthors: [],
+  });
+
+  // Symmetry with the clean path's clearAuthFailure(model.provider).
+  expect(noteAuthFailure).toHaveBeenCalledWith("openai-codex");
+  expect(reportRevokedServedToken).toHaveBeenCalledWith(
+    expect.objectContaining({ provider: "openai-codex" }),
+  );
+});
+
+/**
+ * The one turn with no honest provider to name: `resolveModel` itself failed, so
+ * the turn ran on NOTHING. It reports the empty id (chat.ts's pre-session
+ * failure emits the same shape, and the client renders the generic "connect an
+ * AI provider" card) and must touch neither the credential status surface nor
+ * the control plane — marking "" unusable, or POSTing a revocation for it, is
+ * the corruption this guard exists to prevent.
+ */
+test("a resolveModel failure names no provider and never marks or reports one", async () => {
+  resolution.run = () => {
+    throw new Error("No provider connected. Connect an AI provider first.");
+  };
+  const id = "exec-throw-unresolved";
+  const { events, unsub } = collect(id);
+  const conv = fakeConv(() => {}, { provider: "google" });
+
+  await execTurn(conv, id, "turn-1", "hey", {
+    author: undefined,
+    priorAuthors: [],
+  });
+  unsub();
+
+  const frame = events.find(
+    (e): e is Extract<WireEvent, { type: "provider_error" }> =>
+      e.type === "provider_error",
+  );
+  expect(frame?.data).toMatchObject({
+    kind: "unauthenticated",
+    cause: "no_credentials",
+    provider: "",
+  });
+  expect(persistedProviderError(id)).toMatchObject({
+    kind: "unauthenticated",
+    provider: "",
+  });
+  expect(noteAuthFailure).not.toHaveBeenCalled();
+  expect(reportRevokedServedToken).not.toHaveBeenCalled();
+});
+
+/**
+ * ...but a turn that CARRIED a pin is not provider-less: the pin is the user's
+ * own statement of what to run on, honest evidence even when the resolution
+ * failed (a routine pinned to a provider whose saved model id went stale). The
+ * canonical id is what every consumer keys on, so the pin is canonicalized the
+ * same way `resolveModel` would have.
+ */
+test("a resolveModel failure with a PINNED provider names that provider (canonicalized)", async () => {
+  resolution.run = () => {
+    throw new Error(
+      "No API key found for openai-codex.\n\nUse /login to log into a provider via OAuth or API key.",
+    );
+  };
+  const id = "exec-throw-unresolved-pinned";
+  const { events, unsub } = collect(id);
+  const conv = fakeConv(() => {}, { provider: "google" });
+
+  await execTurn(
+    conv,
+    id,
+    "turn-1",
+    "hey",
+    { author: undefined, priorAuthors: [] },
+    { provider: "openai", model: "gpt-x" },
+  );
+  unsub();
+
+  const frame = events.find(
+    (e): e is Extract<WireEvent, { type: "provider_error" }> =>
+      e.type === "provider_error",
+  );
+  // "openai" is the pin's alias for the Codex row — canonical, as resolveModel
+  // would have resolved it.
+  expect(frame?.data).toMatchObject({
+    kind: "unauthenticated",
+    provider: "openai-codex",
+  });
+  expect(persistedProviderError(id)).toMatchObject({
+    provider: "openai-codex",
+  });
+  // A NAMED provider unlocks the status surface too: the pinned credential is
+  // the one that is missing, so "Connected" would be a lie for it.
+  expect(noteAuthFailure).toHaveBeenCalledWith("openai-codex");
+});
+
+test("an unclassifiable resolveModel failure with a pin still names the pinned provider", async () => {
+  resolution.run = () => {
+    throw new Error('openai-codex model "gpt-1999" is not available');
+  };
+  const id = "exec-throw-unresolved-pinned-unknown";
+  const conv = fakeConv(() => {}, { provider: "google" });
+
+  await execTurn(
+    conv,
+    id,
+    "turn-1",
+    "hey",
+    { author: undefined, priorAuthors: [] },
+    { provider: "openai", model: "gpt-1999" },
+  );
+
+  // An empty provider on the unknown card renders "is not available on your
+  //  account" (double space) — the pin is the honest label.
+  expect(persistedProviderError(id)).toMatchObject({
+    provider: "openai-codex",
+  });
+});
+
+/**
+ * With NO pin and nothing to classify, the unknown card still needs a word to
+ * interpolate: `""` renders "could not classify this  error" and a
+ * `provider_error:unknown:` report id. `"unknown"` is the same choice chat.ts
+ * makes for its pre-session unknown failure.
+ */
+test("an unclassifiable, unpinned resolveModel failure persists the provider as 'unknown'", async () => {
+  resolution.run = () => {
+    throw new Error("the flux capacitor came loose");
+  };
+  const id = "exec-throw-unresolved-unknown";
+  const conv = fakeConv(() => {}, { provider: "google" });
+
+  await execTurn(conv, id, "turn-1", "hey", {
+    author: undefined,
+    priorAuthors: [],
+  });
+
+  expect(persistedProviderError(id)).toEqual({
+    kind: "unknown",
+    provider: "unknown",
+    raw_excerpt: "the flux capacitor came loose",
+  });
+  // Still nothing to mark or sign out: the turn ran on no credential.
+  expect(noteAuthFailure).not.toHaveBeenCalled();
+  expect(reportRevokedServedToken).not.toHaveBeenCalled();
 });
 
 test("pin.mode is threaded into switchModeIfNeeded for the turn", async () => {

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -215,6 +215,31 @@ export async function execTurn(
   // the markers on the partial message.
   let providerSwitch: ChatMessage["providerSwitch"];
   let compaction: ChatMessage["compaction"];
+  /**
+   * The provider this turn actually resolved onto — the only honest label for a
+   * throw. `conv.provider` is the CACHED session's LAST provider (written only
+   * at conversation build, a backend switch, or after a successful `setModel`
+   * below), so a turn that throws before that write would be attributed to
+   * whatever provider the conversation happened to be created on: a GPT-5.6
+   * user got a "Connect Gemini" card, and — worse — the auth-failure mark and
+   * the revoked-token report below would fire on an innocent provider.
+   * Undefined ONLY when `resolveModel` itself failed, in which case the turn
+   * ran on nothing and must name no provider.
+   */
+  let turnProvider: string | undefined;
+  /**
+   * WHO a failed turn names when `resolveModel` never returned a provider. The
+   * turn's PIN is the next-best evidence: it is the user's (or the routine's)
+   * own statement of what this turn was to run on, so a routine pinned to
+   * `openai-codex` whose saved model id went stale still gets a card that names
+   * Codex instead of a blank. Canonicalized exactly as `resolveModel` would have
+   * (`openai` → `openai-codex`), so every consumer keys on the same id.
+   * `fallback` is what remains when the turn carried no pin either — and it
+   * differs by call site, see each below.
+   */
+  const attributedProvider = (fallback: string) =>
+    turnProvider ??
+    (pin?.provider ? canonicalPinProvider(pin.provider) : fallback);
   try {
     // Resolve the model for THIS turn from current settings (a routine's
     // provider/model pin wins, else the workspace's active provider/model).
@@ -225,6 +250,10 @@ export async function execTurn(
     // firing on ITS provider no matter what other chats picked in between.
     // A bad model id throws here → surfaces as the turn's error event.
     const model = resolveModel(pin?.model, pin?.provider);
+    // From here on, EVERY failure of this turn belongs to this provider — the
+    // canonical id (resolveModel already applied canonicalPinProvider), so the
+    // catch's health mark and revocation report name the row that actually ran.
+    turnProvider = model.provider;
     // The turn's execution mode: the pin's, else execute. Never inherited from
     // Settings. Routine fire paths pin auto; an actually unpinned turn is execute.
     // Held in a MUTABLE ref: a mid-turn Mode-pill switch (`POST
@@ -566,7 +595,13 @@ export async function execTurn(
     const thrown =
       providerError ??
       classifyProviderError({
-        provider: pin?.provider ?? conv.provider,
+        // The provider the turn RESOLVED onto, never the cached session's last
+        // one; else the turn's pin. Empty only when neither exists: "provider
+        // unknown" is the established shape for a TYPED card (chat.ts's
+        // pre-session failure emits it too — the client repairs the label from
+        // the error's own evidence), and it renders the generic "connect an AI
+        // provider" card rather than naming a provider this turn never reached.
+        provider: attributedProvider(""),
         model: pin?.model ?? null,
         message: errMessage(err),
       });
@@ -585,7 +620,14 @@ export async function execTurn(
     // so feed it into the status surface here — e.g. a refresh-bearing entry
     // whose refresh token was rejected raises at prompt time, before any
     // stream exists (auth/credential-health.ts).
-    if (thrown.kind === "unauthenticated" && !providerError) {
+    // Guarded on a NAMED provider: a throw from resolveModel itself carries the
+    // empty id, and marking "" unusable (or POSTing a revocation for it) would
+    // corrupt the status surface with a provider that does not exist.
+    if (
+      thrown.kind === "unauthenticated" &&
+      !providerError &&
+      thrown.provider
+    ) {
       noteAuthFailure(canonicalPinProvider(thrown.provider));
       // A REVOKED served token is invisible to the control plane (HOU-952).
       reportRevokedServedToken(thrown);
@@ -598,8 +640,13 @@ export async function execTurn(
       providerSwitch,
       compaction,
       providerError: typed ?? {
+        // The UNKNOWN card interpolates this word into its copy ("we could not
+        // classify this <provider> error") and into the bug-report id, so an
+        // empty string leaves a double space and a dangling
+        // `provider_error:unknown:` — hence "unknown" rather than "" here, the
+        // same choice chat.ts makes for its pre-session unknown failure.
         kind: "unknown",
-        provider: pin?.provider ?? conv.provider,
+        provider: attributedProvider("unknown"),
         raw_excerpt: errMessage(err),
       },
       turnId,

--- a/packages/web/e2e/connect-ai-empty-state.spec.ts
+++ b/packages/web/e2e/connect-ai-empty-state.spec.ts
@@ -19,14 +19,14 @@ test("composer is replaced by the connect-AI empty state when no provider is con
   await page.goto("/");
   await page.locator('[data-tour-target="newMission"]').click();
 
-  await expect(
-    page.getByRole("button", { name: "Connect an AI model" }),
-  ).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByRole("button", { name: "Connect AI" })).toBeVisible({
+    timeout: 15_000,
+  });
   await expect(
     page.getByPlaceholder("What should the agent work on?"),
   ).toHaveCount(0);
 
-  await page.getByRole("button", { name: "Connect an AI model" }).click();
+  await page.getByRole("button", { name: "Connect AI" }).click();
   await expect(page.getByRole("heading", { name: "AI Models" })).toBeVisible();
 });
 
@@ -38,7 +38,5 @@ test("composer renders normally while the provider is connected", async ({
   await expect(
     page.getByPlaceholder("What should the agent work on?"),
   ).toBeVisible();
-  await expect(
-    page.getByRole("button", { name: "Connect an AI model" }),
-  ).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Connect AI" })).toHaveCount(0);
 });

--- a/packages/web/e2e/connect-ai-empty-state.spec.ts
+++ b/packages/web/e2e/connect-ai-empty-state.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "./support/fixtures";
+
+/**
+ * With zero providers connected, the whole composer (textarea + footer with
+ * the model picker) is replaced by the connect-AI empty state, so the user is
+ * never shown a phantom model chip or a dead-end input. The CTA routes to the
+ * AI Hub. With a provider connected, the composer renders exactly as before.
+ */
+test("composer is replaced by the connect-AI empty state when no provider is connected", async ({
+  page,
+  request,
+  fakeHost,
+}) => {
+  await request.post(
+    `${fakeHost.url}/agents/houston-assistant/auth/anthropic/logout`,
+    { headers: { authorization: "Bearer e2e-token" } },
+  );
+
+  await page.goto("/");
+  await page.locator('[data-tour-target="newMission"]').click();
+
+  await expect(
+    page.getByRole("button", { name: "Connect an AI model" }),
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(
+    page.getByPlaceholder("What should the agent work on?"),
+  ).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Connect an AI model" }).click();
+  await expect(page.getByRole("heading", { name: "AI Models" })).toBeVisible();
+});
+
+test("composer renders normally while the provider is connected", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.locator('[data-tour-target="newMission"]').click();
+  await expect(
+    page.getByPlaceholder("What should the agent work on?"),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Connect an AI model" }),
+  ).toHaveCount(0);
+});

--- a/packages/web/src/engine-adapter/client/provider-status-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-status-mixin.ts
@@ -7,6 +7,16 @@ import { toNewProvider } from "../synthetic";
 import type { BaseCtor } from "./mixin";
 import { providerRoutingSettled } from "./provider-routing";
 
+/**
+ * How long the batched status probe waits for the runtime before calling it
+ * unreachable (HOU-1153). A host that accepts the connection but never answers
+ * — a wedged desktop sidecar, a pod stuck mid-boot — used to leave this promise
+ * pending for the life of the app, which the picker rendered as a permanent
+ * "Loading providers…". A bounded probe turns that into the same "unknown"
+ * answer any other unreachable engine produces, which the caller retries.
+ */
+const PROBE_TIMEOUT_MS = 15_000;
+
 export function ProviderStatusMixin<TBase extends BaseCtor>(Base: TBase) {
   // Internal label only (the exported factory is the contract). Named to avoid
   // shadowing the imported ui `ProviderStatus` type the verbatim bodies return.
@@ -45,6 +55,12 @@ export function ProviderStatusMixin<TBase extends BaseCtor>(Base: TBase) {
       // network drop) reports "unknown" instead: fabricating "unauthenticated"
       // flips every provider card to Connect and blocks the local-model tunnel
       // auto-reconnect, for connections that are still registered server-side.
+      //
+      // What an all-"unknown" scan is WORTH is the caller's call, and the two
+      // callers differ on purpose (HOU-1153): the AI hub keeps painting its
+      // last-known snapshot, while the chat picker classifies it as a probe
+      // failure and re-probes until a definitive answer lands. This method
+      // stays non-throwing so both readings remain possible.
       let reachable = false;
       try {
         // Do NOT probe before the active space's agent list has settled
@@ -57,7 +73,10 @@ export function ProviderStatusMixin<TBase extends BaseCtor>(Base: TBase) {
         if (providerRoutingSettled(this.ctx)) {
           const engine = this.ctx.providerEngine();
           if (engine) {
-            for (const p of await engine.listProviders()) byId.set(p.id, p);
+            const list = await engine.listProviders({
+              signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+            });
+            for (const p of list) byId.set(p.id, p);
             reachable = true;
           }
         }

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -74,3 +74,4 @@ export * from "./cp/retry";
 export * from "./cp/runtime-clients";
 export * from "./cp/skills";
 export * from "./cp/spaces-billing";
+export * from "./cp/transient-retry";

--- a/packages/web/src/engine-adapter/cp/fetch.ts
+++ b/packages/web/src/engine-adapter/cp/fetch.ts
@@ -1,6 +1,7 @@
 import { HoustonEngineError, SIGNED_OUT_ERROR } from "../client/errors";
 import { refreshLiveToken } from "../session-refresh";
 import { appVersionHeader, noteUpgradeRequired } from "../update-floor";
+import { transientRetryFetch } from "./transient-retry";
 
 /**
  * Control-plane mode for the web adapter.
@@ -123,52 +124,12 @@ export function gatewayAuthFetch(
   };
 }
 
-/** Gateway statuses that mean "rolling deploy / pod handoff in progress", not a
- *  real answer: worth a brief blind retry for reads. */
-const TRANSIENT_STATUSES = new Set([502, 503, 504]);
-/** Two retries, ~2s total — bridges a gateway roll's LB handoff, without
- *  masking a real outage for long. */
-const TRANSIENT_RETRY_DELAYS_MS = [500, 1500];
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
 /**
- * Wrap a fetch so GET/HEAD attempts ride through a rolling deploy / pod
- * handoff: transient gateway statuses and network-level drops (connection
- * refused/reset mid-roll) get two brief blind retries. Writes never
- * blind-retry — a thrown network error on a POST may have reached the
- * gateway; the caller decides.
- */
-export function transientRetryFetch(inner: typeof fetch): typeof fetch {
-  return async (input, init) => {
-    const method = (init?.method ?? "GET").toUpperCase();
-    const retriable = method === "GET" || method === "HEAD";
-    let res: Response | undefined;
-    let failure: unknown;
-    for (let i = 0; ; i++) {
-      failure = undefined;
-      res = undefined;
-      try {
-        res = await inner(input, init);
-      } catch (err) {
-        failure = err;
-      }
-      const transient = res === undefined || TRANSIENT_STATUSES.has(res.status);
-      if (!transient || !retriable || i >= TRANSIENT_RETRY_DELAYS_MS.length) {
-        break;
-      }
-      await sleep(TRANSIENT_RETRY_DELAYS_MS[i]);
-    }
-    if (res === undefined) throw failure;
-    return res;
-  };
-}
-
-/**
- * The shared gateway JSON fetch: live-bearer auth + active-space header + a
- * transient-retry wrapper on reads, with a non-2xx surfaced as a
- * {@link HoustonEngineError} carrying the host's reason. Every control-plane
- * module routes its requests through here.
+ * The shared gateway JSON fetch: live-bearer auth + active-space header + the
+ * reason-aware read retry (`./transient-retry` — a rolling deploy gets ~2s of
+ * patience, a pod the gateway says is still waking gets a cold-start budget),
+ * with a non-2xx surfaced as a {@link HoustonEngineError} carrying the host's
+ * reason. Every control-plane module routes its requests through here.
  */
 export async function cpFetch(
   cfg: ControlPlaneConfig,

--- a/packages/web/src/engine-adapter/cp/retry.ts
+++ b/packages/web/src/engine-adapter/cp/retry.ts
@@ -1,11 +1,13 @@
 /**
  * Bounded transient retry for control-plane READS that boot the app.
  *
- * `cpFetch` already blind-retries 502/503/504 twice (~2s, `transientRetryFetch`)
- * — enough to ride a load-balancer handoff, nowhere near a pod cold start or a
- * longer gateway roll. Reads whose failure has a lasting consequence (the
- * workspace list decides which SPACE the whole session runs in) wrap themselves
- * here for a second, slower layer of attempts before they give up and throw.
+ * `cpFetch` already retries 502/503/504 (`transientRetryFetch`) on a schedule
+ * chosen from the gateway's own reason: ~2s for a load-balancer handoff, ~15s
+ * when the gateway says the agent's pod is waking. Neither covers a longer
+ * gateway roll, and neither knows which reads MATTER. Reads whose failure has a
+ * lasting consequence (the workspace list decides which SPACE the whole session
+ * runs in) wrap themselves here for a second, slower layer of attempts before
+ * they give up and throw.
  *
  * Deliberately NOT applied to every read: a retry costs the user latency, and
  * most reads are re-triggered cheaply by the query layer.

--- a/packages/web/src/engine-adapter/cp/runtime-clients.ts
+++ b/packages/web/src/engine-adapter/cp/runtime-clients.ts
@@ -1,9 +1,6 @@
 import { HoustonEngineClient } from "@houston/runtime-client";
-import {
-  type ControlPlaneConfig,
-  gatewayAuthFetch,
-  transientRetryFetch,
-} from "./fetch";
+import { type ControlPlaneConfig, gatewayAuthFetch } from "./fetch";
+import { transientRetryFetch } from "./transient-retry";
 
 /**
  * A runtime client scoped to ONE agent, via the control plane's transparent proxy.

--- a/packages/web/src/engine-adapter/cp/runtime-clients.ts
+++ b/packages/web/src/engine-adapter/cp/runtime-clients.ts
@@ -34,12 +34,21 @@ export function runtimeClientFor(
  * first agent exists — the host runs it in a dedicated hidden runtime whose
  * captured credential lands on the personal workspace, so the agent created
  * right after is already connected.
+ *
+ * Reads ride the SAME transient-retry wrapper the per-agent client uses. This
+ * runtime is cold BY DEFINITION — first-run reaches it before anything has ever
+ * run — and the host now answers its probe routes (`/providers`,
+ * `/providers/usage`, `/auth/status`) with 503 + `Retry-After` while it boots
+ * (HOU-1153). Without the wrapper first-run setup took that 503 as a real
+ * failure, while an agent probe one route over quietly retried and succeeded.
  */
 export function setupRuntimeClientFor(
   cfg: ControlPlaneConfig,
 ): HoustonEngineClient {
   return new HoustonEngineClient({
     baseUrl: `${cfg.baseUrl}/setup-runtime`,
-    fetch: gatewayAuthFetch(cfg.token, () => cfg.activeOrgSlug),
+    fetch: transientRetryFetch(
+      gatewayAuthFetch(cfg.token, () => cfg.activeOrgSlug),
+    ),
   });
 }

--- a/packages/web/src/engine-adapter/cp/transient-retry.ts
+++ b/packages/web/src/engine-adapter/cp/transient-retry.ts
@@ -1,0 +1,166 @@
+/**
+ * The read-retry transport: what a 502/503/504 from the gateway MEANS, and how
+ * long a read waits on each meaning.
+ *
+ * The managed cloud runs one engine pod per agent and lets it sleep. Opening a
+ * chat fires a burst of reads (`read_agent_file`, `list_routines`,
+ * `get_skills_manifest`, `list_project_files`) at a pod that may still be
+ * booting, and the gateway answers each of them 503. Those 503s are NOT all the
+ * same event, and treating them alike is what made a normal cold start look
+ * like a crash (HOU-1153):
+ *
+ *  - **The pod is waking.** The gateway's dispatch self-heal path
+ *    (`cloud/internal/edge/agents/routes.go` → `wakeBlocking`) runs ONE 8s
+ *    ensure-awake leg and, if the pod still isn't ready, answers
+ *    `503 {"error":"engine unavailable","detail":"agent is waking"}` plus a
+ *    `Retry-After` — an explicit "ask me again", not a failure. Nothing went
+ *    wrong; the answer simply isn't ready yet.
+ *  - **The deployment does not run this feature.** The shared-skills routes
+ *    answer `503 {"error":"shared skills not configured"}` when the gateway has
+ *    no blob store bound (`cloud/internal/edge/shared_skills_routes.go`). That
+ *    is a deployment SHAPE, permanent for the session: retrying burns round
+ *    trips to be told the same thing.
+ *  - **Anything else** — a gateway roll, a load-balancer handoff, a host that
+ *    is restarting — heals in about a second, which is what the original two
+ *    blind retries were sized for (HOU-731).
+ *
+ * `Retry-After` is deliberately NOT read: the gateway sends no
+ * `Access-Control-Expose-Headers`, so a browser cannot see that header on a
+ * cross-origin gateway response. The BODY is readable, and it carries the same
+ * information, so the body is the contract this file keys on.
+ *
+ * ── Why suppressing the wake toast is not a silent failure ──────────────────
+ * The no-silent-failures policy (`CLAUDE.md`) requires every failure a
+ * user-initiated action produces to reach the user. A wake 503 that this layer
+ * retries to success is not a failure the action produced — the action
+ * SUCCEEDED, a little later. Toasting it would report a non-problem and train
+ * users to ignore the red toast. When the budget below is exhausted the error
+ * is rethrown verbatim and toasts exactly as before, and every other 503 shape
+ * keeps its old, short patience. Suppression is bounded by success; nothing is
+ * swallowed.
+ */
+
+/** Gateway/host statuses that are never a real answer to a read. */
+const TRANSIENT_STATUSES = new Set([502, 503, 504]);
+
+/**
+ * The gateway's own words. These strings are the wire contract
+ * (`cloud/internal/edge/**`); they are parsed HERE and nowhere else, so the
+ * rest of the client reasons over the typed {@link UnavailableReason} union
+ * rather than over prose.
+ */
+const ENGINE_UNAVAILABLE = "engine unavailable";
+const AGENT_IS_WAKING = "agent is waking";
+export const SHARED_SKILLS_UNCONFIGURED = "shared skills not configured";
+
+/** Why a read got no answer — the typed form of the gateway's 5xx body. */
+export type UnavailableReason =
+  /** The agent's engine pod is cold-starting; the gateway asked us to retry. */
+  | "engine-waking"
+  /** This deployment does not run the feature at all. Retrying cannot help. */
+  | "feature-absent"
+  /** A gateway roll, an LB handoff, a dropped connection — heals in ~a second. */
+  | "handoff";
+
+/**
+ * Two brief blind retries, ~2s total — bridges a gateway roll's LB handoff
+ * without masking a real outage for long (HOU-731).
+ */
+export const HANDOFF_RETRY_DELAYS_MS = [500, 1_500] as const;
+
+/**
+ * Four extra attempts, 15s of client-side patience, for a pod the gateway has
+ * told us is still waking.
+ *
+ * Sized against the gateway, not guessed. Each attempt costs the gateway one
+ * `ensure-awake` long-poll leg of up to 8s (`wakeWaitMs`) before it answers
+ * "still waking", and the answer advertises `Retry-After: 2` (the control
+ * plane's `retryAfterMs`). So five attempts spaced 2s/3s/5s/5s cover roughly
+ * 15s of our own waiting plus up to ~40s of gateway-side wake watching — well
+ * past a healthy pod boot, which is seconds.
+ *
+ * Bounded on purpose. Past this the honest answer is an error the user can
+ * retry, not a screen that hangs: a pod that has not come up in that long is a
+ * crashloop or a capacity problem, and the toast is the bug report we want.
+ */
+export const WAKE_RETRY_DELAYS_MS = [2_000, 3_000, 5_000, 5_000] as const;
+
+/** A feature this deployment does not run: answer now, do not retry. */
+const NO_RETRY_DELAYS_MS = [] as const;
+
+/**
+ * Classify a 5xx body. Unrecognized shapes fall back to `"handoff"` — the
+ * conservative default, since it keeps the pre-existing behavior for every
+ * error the gateway has not taught us to read.
+ */
+export function classifyUnavailableBody(body: unknown): UnavailableReason {
+  const b = body as { error?: unknown; detail?: unknown } | null;
+  if (b?.error === SHARED_SKILLS_UNCONFIGURED) return "feature-absent";
+  if (b?.error === ENGINE_UNAVAILABLE && b?.detail === AGENT_IS_WAKING) {
+    return "engine-waking";
+  }
+  return "handoff";
+}
+
+/** The backoff schedule a reason earns. Empty = answer the first response. */
+export function retryDelaysFor(reason: UnavailableReason): readonly number[] {
+  switch (reason) {
+    case "engine-waking":
+      return WAKE_RETRY_DELAYS_MS;
+    case "feature-absent":
+      return NO_RETRY_DELAYS_MS;
+    case "handoff":
+      return HANDOFF_RETRY_DELAYS_MS;
+  }
+}
+
+/**
+ * Read a transient response's reason WITHOUT disturbing the body the caller
+ * will parse: the classification runs on a clone. A body that isn't the JSON
+ * the gateway documents (an HTML error page from an intermediary, an empty
+ * 502) classifies as `"handoff"` and keeps the old short patience — the
+ * response itself is still returned and still surfaces.
+ */
+async function reasonFor(res: Response): Promise<UnavailableReason> {
+  try {
+    return classifyUnavailableBody(await res.clone().json());
+  } catch {
+    return "handoff";
+  }
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Wrap a fetch so GET/HEAD attempts ride through a rolling deploy, a pod
+ * handoff, or an engine pod that is still cold-starting: transient gateway
+ * statuses and network-level drops are retried on the schedule their
+ * {@link UnavailableReason} earns. Writes never blind-retry — a thrown network
+ * error on a POST may have reached the gateway; the caller decides.
+ */
+export function transientRetryFetch(inner: typeof fetch): typeof fetch {
+  return async (input, init) => {
+    const method = (init?.method ?? "GET").toUpperCase();
+    const retriable = method === "GET" || method === "HEAD";
+    let res: Response | undefined;
+    let failure: unknown;
+    for (let i = 0; ; i++) {
+      failure = undefined;
+      res = undefined;
+      try {
+        res = await inner(input, init);
+      } catch (err) {
+        failure = err;
+      }
+      const transient = res === undefined || TRANSIENT_STATUSES.has(res.status);
+      if (!transient || !retriable) break;
+      // A transport-level drop has no body to read; it is the handoff case by
+      // definition (offline, connection reset mid-roll).
+      const delays = retryDelaysFor(res ? await reasonFor(res) : "handoff");
+      if (i >= delays.length) break;
+      await sleep(delays[i]);
+    }
+    if (res === undefined) throw failure;
+    return res;
+  };
+}

--- a/packages/web/tests/provider-statuses-batch.test.ts
+++ b/packages/web/tests/provider-statuses-batch.test.ts
@@ -123,6 +123,21 @@ test("an unreachable runtime reports every card UNKNOWN without throwing", async
   expect(statuses.map((s) => s.authState)).toEqual(["unknown", "unknown"]);
 });
 
+test("the probe is bounded by an abort signal, so a wedged host cannot pend forever", async () => {
+  // HOU-1153: a host that accepts the connection but never answers (wedged
+  // sidecar, pod stuck mid-boot) left this promise pending for the life of the
+  // app — which the picker rendered as a permanent "Loading providers…". The
+  // timeout turns it into the ordinary unreachable answer, which the caller
+  // classifies as a failure and re-probes.
+  listProviders.mockResolvedValue([]);
+
+  await (await settledClient()).providerStatuses(["anthropic"]);
+
+  const [opts] = listProviders.mock.calls[0];
+  expect(opts.signal).toBeInstanceOf(AbortSignal);
+  expect(opts.signal.aborted).toBe(false);
+});
+
 test("a reachable runtime still gives a confirmed unauthenticated for absent providers", async () => {
   listProviders.mockResolvedValue([{ id: "anthropic", configured: true }]);
 

--- a/packages/web/tests/transient-retry-fetch.test.ts
+++ b/packages/web/tests/transient-retry-fetch.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, expect, test, vi } from "vitest";
 import {
   runtimeClientFor,
+  setupRuntimeClientFor,
   transientRetryFetch,
 } from "../src/engine-adapter/control-plane";
 
@@ -79,6 +80,30 @@ test("a POST never blind-retries", async () => {
   const res = await doFetch("https://gw.example/x", { method: "POST" });
   expect(res.status).toBe(503);
   expect(inner).toHaveBeenCalledTimes(1);
+});
+
+test("the SETUP runtime's provider probe bridges a cold-boot 503 too", async () => {
+  // HOU-1153: the host answers probe routes 503 + Retry-After while the runtime
+  // cold-boots, and the setup runtime is cold BY DEFINITION — first-run reaches
+  // it before anything has ever run there. It was built on a bare auth fetch,
+  // so that 503 surfaced as a hard failure while the identical probe against an
+  // agent's runtime quietly retried.
+  vi.useFakeTimers();
+  let calls = 0;
+  globalThis.fetch = vi.fn(async () => {
+    calls++;
+    if (calls === 1) return json(503, { error: "runtime starting" });
+    return json(200, [{ id: "anthropic", configured: false }]);
+  }) as unknown as typeof fetch;
+
+  const engine = setupRuntimeClientFor({
+    baseUrl: "https://gw.example",
+    token: "tok",
+  });
+  const pending = engine.listProviders();
+  await vi.advanceTimersByTimeAsync(500);
+  expect(await pending).toEqual([{ id: "anthropic", configured: false }]);
+  expect(calls).toBe(2);
 });
 
 test("runtimeClientFor's history read bridges a transient 503", async () => {

--- a/packages/web/tests/transient-retry-fetch.test.ts
+++ b/packages/web/tests/transient-retry-fetch.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, expect, test, vi } from "vitest";
 import {
+  classifyUnavailableBody,
+  cpFetch,
+  HANDOFF_RETRY_DELAYS_MS,
+  retryDelaysFor,
   runtimeClientFor,
   setupRuntimeClientFor,
   transientRetryFetch,
+  WAKE_RETRY_DELAYS_MS,
 } from "../src/engine-adapter/control-plane";
 
 /**
@@ -10,7 +15,15 @@ import {
  * handoff (transient 5xx, network-level drops) with two brief blind retries,
  * so a history load hit mid-roll resolves instead of rendering an empty chat.
  * Writes never blind-retry.
+ *
+ * HOU-1153 makes that patience reason-aware: a 503 the gateway labels
+ * "agent is waking" earns a cold-start budget (so a burst of chat-open reads
+ * against a sleeping pod resolves instead of toasting), and a 503 that means
+ * "this deployment doesn't run the feature" earns none.
  */
+const sum = (xs: readonly number[]) => xs.reduce((a, b) => a + b, 0);
+/** The gateway's exact wake answer (cloud/internal/edge/agents/routes.go). */
+const wakingBody = { error: "engine unavailable", detail: "agent is waking" };
 
 const originalFetch = globalThis.fetch;
 
@@ -124,4 +137,144 @@ test("runtimeClientFor's history read bridges a transient 503", async () => {
   const history = await pending;
   expect(history.messages).toEqual([]);
   expect(calls).toBe(2);
+});
+
+// ── HOU-1153: the wake-transient 503 ────────────────────────────────────────
+
+test("the gateway's 5xx vocabulary maps to typed reasons", () => {
+  expect(classifyUnavailableBody(wakingBody)).toBe("engine-waking");
+  expect(
+    classifyUnavailableBody({ error: "shared skills not configured" }),
+  ).toBe("feature-absent");
+  // A wake-shaped error WITHOUT the waking detail is a real failure (the
+  // gateway exhausted its 290s hold, or ensure-awake itself broke) — it keeps
+  // the short handoff patience so the toast is not delayed by 15s.
+  expect(
+    classifyUnavailableBody({ error: "engine unavailable", detail: "boom" }),
+  ).toBe("handoff");
+  expect(classifyUnavailableBody({ error: "rolling" })).toBe("handoff");
+  expect(classifyUnavailableBody(null)).toBe("handoff");
+
+  expect(retryDelaysFor("engine-waking")).toBe(WAKE_RETRY_DELAYS_MS);
+  expect(retryDelaysFor("handoff")).toBe(HANDOFF_RETRY_DELAYS_MS);
+  expect(retryDelaysFor("feature-absent")).toEqual([]);
+});
+
+test("the wake budget is bounded to ~15s of client-side patience", () => {
+  // Sized against the gateway's 8s ensure-awake leg + its Retry-After: 2.
+  // Bounded on purpose — past this the honest answer is a toast, not a hang.
+  expect(sum(WAKE_RETRY_DELAYS_MS)).toBe(15_000);
+  expect(sum(WAKE_RETRY_DELAYS_MS)).toBeLessThanOrEqual(20_000);
+});
+
+test("a read against a waking pod retries past the handoff budget and resolves", async () => {
+  vi.useFakeTimers();
+  const inner = vi
+    .fn<typeof fetch>()
+    .mockResolvedValueOnce(json(503, wakingBody))
+    .mockResolvedValueOnce(json(503, wakingBody))
+    .mockResolvedValueOnce(json(503, wakingBody))
+    .mockResolvedValueOnce(json(200, { content: "board" }));
+  const doFetch = transientRetryFetch(inner);
+
+  const pending = doFetch("https://gw.example/agents/a1/agentfile/board.json");
+  // The old handoff budget spent all three of its attempts inside ~2s and gave
+  // up; the wake schedule is still on its second attempt at that point.
+  await vi.advanceTimersByTimeAsync(sum(HANDOFF_RETRY_DELAYS_MS));
+  expect(inner).toHaveBeenCalledTimes(2);
+
+  await vi.advanceTimersByTimeAsync(sum(WAKE_RETRY_DELAYS_MS));
+  const res = await pending;
+  expect(res.status).toBe(200);
+  expect(inner).toHaveBeenCalledTimes(4);
+});
+
+test("cpFetch resolves a waking read to its body — no error to toast", async () => {
+  vi.useFakeTimers();
+  let calls = 0;
+  globalThis.fetch = vi.fn(async () => {
+    calls++;
+    return calls === 1 ? json(503, wakingBody) : json(200, { items: [] });
+  }) as unknown as typeof fetch;
+
+  const pending = cpFetch(
+    { baseUrl: "https://gw.example", token: "tok" },
+    "/agents/a1/routines",
+  );
+  await vi.advanceTimersByTimeAsync(WAKE_RETRY_DELAYS_MS[0]);
+  const res = await pending;
+  expect(res.status).toBe(200);
+  // The classifier read the 503 off a CLONE, so the resolved body is intact.
+  expect(await res.json()).toEqual({ items: [] });
+  expect(calls).toBe(2);
+});
+
+test("a pod that never wakes surfaces the 503 once the budget is spent", async () => {
+  vi.useFakeTimers();
+  const inner = vi.fn<typeof fetch>().mockResolvedValue(json(503, wakingBody));
+  const doFetch = transientRetryFetch(inner);
+
+  const pending = doFetch("https://gw.example/agents/a1/routines");
+  await vi.advanceTimersByTimeAsync(sum(WAKE_RETRY_DELAYS_MS));
+  const res = await pending;
+  // No silent failure: the exhausted budget hands the caller the real 503,
+  // which cpFetch throws as a HoustonEngineError and the app toasts.
+  expect(res.status).toBe(503);
+  expect(inner).toHaveBeenCalledTimes(WAKE_RETRY_DELAYS_MS.length + 1);
+});
+
+test("cpFetch throws the gateway's reason once the wake budget is spent", async () => {
+  vi.useFakeTimers();
+  globalThis.fetch = vi.fn(async () =>
+    json(503, wakingBody),
+  ) as unknown as typeof fetch;
+
+  const pending = cpFetch(
+    { baseUrl: "https://gw.example", token: "tok" },
+    "/agents/a1/routines",
+  ).catch((err: unknown) => err);
+  await vi.advanceTimersByTimeAsync(sum(WAKE_RETRY_DELAYS_MS));
+  const err = (await pending) as { status: number; message: string };
+  expect(err.status).toBe(503);
+  expect(err.message).toContain("engine unavailable");
+});
+
+test("a non-503 error never retries — it toasts immediately", async () => {
+  const inner = vi
+    .fn<typeof fetch>()
+    .mockResolvedValue(json(500, { error: "boom" }));
+  const doFetch = transientRetryFetch(inner);
+  // 500 is not in the transient set: one attempt, straight to the surface.
+  expect((await doFetch("https://gw.example/x")).status).toBe(500);
+  expect(inner).toHaveBeenCalledTimes(1);
+
+  const notFound = vi
+    .fn<typeof fetch>()
+    .mockResolvedValue(json(404, { error: "agent not found" }));
+  expect(
+    (await transientRetryFetch(notFound)("https://gw.example/x")).status,
+  ).toBe(404);
+  expect(notFound).toHaveBeenCalledTimes(1);
+});
+
+test("a feature this deployment doesn't run is answered without retrying", async () => {
+  const inner = vi
+    .fn<typeof fetch>()
+    .mockResolvedValue(json(503, { error: "shared skills not configured" }));
+  const doFetch = transientRetryFetch(inner);
+
+  // No fake timers: if this retried at all the test would hang on real sleeps.
+  const res = await doFetch("https://gw.example/v1/workspaces/w/shared-skills");
+  expect(res.status).toBe(503);
+  expect(await res.json()).toEqual({ error: "shared skills not configured" });
+  expect(inner).toHaveBeenCalledTimes(1);
+});
+
+test("a POST against a waking pod still never blind-retries", async () => {
+  const inner = vi.fn<typeof fetch>().mockResolvedValue(json(503, wakingBody));
+  const res = await transientRetryFetch(inner)("https://gw.example/x", {
+    method: "POST",
+  });
+  expect(res.status).toBe(503);
+  expect(inner).toHaveBeenCalledTimes(1);
 });

--- a/ui/chat/src/feed-to-messages.ts
+++ b/ui/chat/src/feed-to-messages.ts
@@ -80,14 +80,20 @@ export interface ChatMessage {
 export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
   const messages: ChatMessage[] = [];
   let cur: ChatMessage | null = null;
-  // One provider-error card per (kind, provider) PER TURN. The engine can
-  // surface the same failure on two channels — e.g. codex auth lands on both
-  // the stdout parser (persisted) and the transient stderr classifier — and a
-  // backoff loop should never stack identical reconnect cards. Keep the
-  // first. The set resets at every user_message: a NEW turn that fails the
-  // same way (e.g. the session dies again after a successful reconnect) must
-  // show a fresh card, not be swallowed by the previous turn's.
-  let seenProviderErrors = new Set<string>();
+  // One provider-error card per KIND per turn, mapped to the index of the
+  // card already pushed. The engine can surface the same failure on two
+  // channels — e.g. codex auth lands on both the stdout parser (persisted) and
+  // the transient stderr classifier — and a backoff loop should never stack
+  // identical reconnect cards. Keep the first. A turn runs on ONE provider, so
+  // `provider` is deliberately NOT part of the key: the same failure often
+  // arrives unlabeled (`provider: ""`) on one channel and labeled ("openai") on
+  // the other, and keying on it rendered both. The map resets at every
+  // user_message: a NEW turn that fails the same way (e.g. the session dies
+  // again after a successful reconnect) must show a fresh card, not be
+  // swallowed by the previous turn's. Accepted edge: if the backend is switched
+  // mid-turn and BOTH providers fail unauthenticated, the two failures collapse
+  // into one card — rare, and a turn ultimately resolves onto one provider.
+  let seenProviderErrors = new Map<ProviderError["kind"], number>();
   // A failed turn surfaces BOTH a typed error card (provider_error /
   // tool_runtime_error) and the engine's session-status echo, which ui/core
   // (`use-session-events`) materializes as a raw `"Session error: …"`
@@ -152,7 +158,7 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
       case "user_message": {
         flush();
         // New turn — provider-error dedup + error-echo suppression are per turn.
-        seenProviderErrors = new Set<string>();
+        seenProviderErrors = new Map<ProviderError["kind"], number>();
         turnHadErrorCard = false;
         const { source, text } = extractSource(item.data);
         messages.push({
@@ -293,11 +299,31 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
         // A real error card covered this turn (even if a duplicate is collapsed
         // below) — lets the trailing session-status echo be suppressed.
         turnHadErrorCard = true;
-        // Collapse duplicates (same kind + provider) to a single card.
-        const providerErrorKey = `${item.data.kind}:${item.data.provider}`;
-        if (seenProviderErrors.has(providerErrorKey)) break;
-        seenProviderErrors.add(providerErrorKey);
+        // Collapse duplicates of the same kind to a single card. When the card
+        // already shown is the unlabeled one and this duplicate names the
+        // provider, upgrade the payload in place — same message key, so the
+        // card gains its provider label without React remounting it.
+        const seenIndex = seenProviderErrors.get(item.data.kind);
+        if (seenIndex !== undefined) {
+          const seen = messages[seenIndex];
+          if (seen.providerError && !seen.providerError.provider) {
+            // Merge ONLY the label. The duplicate is the same failure seen on
+            // a thinner channel: the first card is the one that carried the
+            // retry state (`undelivered_prompt` / `failed_prompt` /
+            // `credential` / `retry_after_seconds` / `raw_excerpt`, and often a
+            // more specific `cause`), so replacing the payload wholesale left
+            // auto-resume with nothing to re-send (HOU-718).
+            if (item.data.provider) {
+              seen.providerError = {
+                ...seen.providerError,
+                provider: item.data.provider,
+              };
+            }
+          }
+          break;
+        }
         flush();
+        seenProviderErrors.set(item.data.kind, messages.length);
         messages.push({
           key: `${keyFor("provider-error", item)}-${item.data.kind}`,
           from: "system",

--- a/ui/chat/tests/feed-to-messages.test.ts
+++ b/ui/chat/tests/feed-to-messages.test.ts
@@ -214,3 +214,101 @@ describe("tool_call placeholder dedup across the narration flush", () => {
     strictEqual(messages[2].tools[0].result?.content, "listing");
   });
 });
+
+// A turn runs on ONE provider, so provider-error cards dedup by KIND alone.
+// The same failure reaches the chat on two channels and one of them often
+// omits the provider name (`provider: ""`); keying the dedup on the provider
+// let the unlabeled and the labeled card both render as separate reconnect
+// cards for a single failure.
+describe("provider-error dedup keys on kind, not provider", () => {
+  const authError = (provider: string, id: string): FeedItem => ({
+    feed_type: "provider_error",
+    data: {
+      kind: "unauthenticated",
+      provider,
+      cause: "unknown",
+      message: "Your session has ended.",
+    },
+    id,
+  });
+
+  it("upgrades the unlabeled card in place when a labeled one follows", () => {
+    const messages = feedItemsToMessages([
+      user("hi"),
+      authError("", "e1"),
+      authError("openai", "e2"),
+    ]);
+    const cards = messages.filter((m) => m.providerError);
+    strictEqual(cards.length, 1);
+    strictEqual(cards[0].providerError?.provider, "openai");
+    // Same key as the first card: the payload is upgraded in place, so React
+    // keeps the mounted card instead of remounting it.
+    strictEqual(cards[0].key, "provider-error-e1-unauthenticated");
+  });
+
+  // The upgrade adds a LABEL, it does not replace the payload. Only the first
+  // card carries the retry state (`undelivered_prompt` / `failed_prompt` /
+  // `credential` / `retry_after_seconds`), so overwriting the whole payload
+  // left auto-resume with nothing to re-send (HOU-718's failure mode).
+  it("keeps the first card's retry state when upgrading its label", () => {
+    const messages = feedItemsToMessages([
+      user("hi"),
+      {
+        feed_type: "provider_error",
+        data: {
+          kind: "unauthenticated",
+          provider: "",
+          cause: "no_credentials",
+          message: "Your session has ended.",
+          undelivered_prompt: "original ask",
+        },
+        id: "e1",
+      } as FeedItem,
+      authError("openai", "e2"),
+    ]);
+    const cards = messages.filter((m) => m.providerError);
+    strictEqual(cards.length, 1);
+    const card = cards[0].providerError;
+    strictEqual(card?.provider, "openai");
+    strictEqual(
+      card?.kind === "unauthenticated" ? card.undelivered_prompt : undefined,
+      "original ask",
+    );
+    // The more specific cause survives the generic duplicate too.
+    strictEqual(
+      card?.kind === "unauthenticated" ? card.cause : undefined,
+      "no_credentials",
+    );
+  });
+
+  it("keeps the label when the labeled card arrives first", () => {
+    const messages = feedItemsToMessages([
+      user("hi"),
+      authError("openai", "e1"),
+      authError("", "e2"),
+    ]);
+    const cards = messages.filter((m) => m.providerError);
+    strictEqual(cards.length, 1);
+    strictEqual(cards[0].providerError?.provider, "openai");
+    strictEqual(cards[0].key, "provider-error-e1-unauthenticated");
+  });
+
+  it("collapses two identically labeled cards", () => {
+    const messages = feedItemsToMessages([
+      user("hi"),
+      authError("openai", "e1"),
+      authError("openai", "e2"),
+    ]);
+    strictEqual(messages.filter((m) => m.providerError).length, 1);
+  });
+
+  it("gives each turn its own card", () => {
+    const messages = feedItemsToMessages([
+      user("first"),
+      authError("", "e1"),
+      user("second"),
+      authError("", "e2"),
+    ]);
+    strictEqual(messages.filter((m) => m.providerError).length, 2);
+  });
+});

--- a/ui/core/src/components/model-picker/catalog.ts
+++ b/ui/core/src/components/model-picker/catalog.ts
@@ -6,7 +6,7 @@
  *
  * The one hard rule everything here enforces: only CONNECTED providers and their
  * models are ever visible. Disconnected providers simply do not appear — the only
- * path to them is the picker's "Connect more providers…" footer.
+ * path to them is the picker's "Connect another AI…" footer.
  */
 
 import type {

--- a/ui/core/src/components/model-picker/model-picker.tsx
+++ b/ui/core/src/components/model-picker/model-picker.tsx
@@ -29,7 +29,7 @@ const SEARCH_THRESHOLD = 8;
  * always-visible back header. On level 2 an in-dropdown search appears once the
  * provider's list runs long (> 8 rows) and filters it via cmdk's built-in
  * scorer; short lists omit it. Disconnected providers never appear — the paths
- * to them are the "Connect more providers…" footer and, when NOTHING is
+ * to them are the "Connect another AI…" footer and, when NOTHING is
  * connected, level 1's explained empty state (which carries the same action).
  *
  * cmdk provides the accessible input, list semantics, and ↑↓/Enter roving; this

--- a/ui/core/src/components/model-picker/types.ts
+++ b/ui/core/src/components/model-picker/types.ts
@@ -66,15 +66,16 @@ export interface ModelPickerLabels {
 
 export const DEFAULT_MODEL_PICKER_LABELS: ModelPickerLabels = {
   searchPlaceholder: "Search models…",
-  connectMore: "Connect more providers…",
+  connectMore: "Connect another AI…",
   back: "Back",
   providersLabel: "Providers",
   modelsLabel: "Models",
-  loading: "Loading providers…",
+  loading: "Loading AIs…",
   empty: "No models found.",
-  noProviders: "No providers connected yet.",
-  noProvidersHint: "Connect an AI model to start chatting.",
-  noProvidersAction: "Connect an AI model",
+  noProviders: "Connect an AI to chat with Houston",
+  noProvidersHint:
+    "Houston answers using an AI like Claude or ChatGPT. Connect one to get started.",
+  noProvidersAction: "Connect AI",
 };
 
 export interface ModelPickerProps {


### PR DESCRIPTION
## What this fixes

Users saw constant "Connect Anthropic/Gemini" cards while chatting on OpenAI models, real credential loss ("access was revoked"), a composer that showed a phantom model when nothing was connected, and scary error toasts on every chat open.

### Engine / host
- **Single-flight credential refresh** (`CredentialRefreshCoalescer`): concurrent serves no longer race the same rotating refresh token; the loser can no longer delete the credential. Compare-and-delete only removes the exact rejected token; a superseding credential is served instead; a mid-flight disconnect can't resurrect a deleted row.
- **Safe terminal classification**: only `invalid_grant` / `refresh_token_invalidated` sign a user out; `invalid_client` (our client id, not the user's token) and transient 400s/timeouts/5xx serve the stale token best-effort. Retries only on provably pre-connect network failures.
- **Honest error attribution**: thrown turn errors carry the provider the turn actually resolved onto (then the wire pin), never the stale conversation provider; the destructive `noteAuthFailure`/revocation-report pair can no longer fire on a guessed or empty provider. Revocation reports require anchored markers; "log in again" prose can't delete credentials.
- **Anthropic status probe**: a timed-out/garbled `claude auth status` is *unknown*, not signed-out; last known state holds with backoff, so no more flapping.
- **Probe routes fast-fail during runtime boot** (503 + Retry-After while the boot continues); failed spawns abort immediately instead of burning the 60s health budget.

### Client
- **Evidence-only card labels**: reconnect cards name a provider only when the error or the chat's own evidence names one; the `?? "anthropic"` guess is gone from the card path. One card per turn (label upgrades in place, retry state preserved).
- **Connect-AI empty state**: with zero providers connected, the whole composer (including the phantom model chip) is replaced by "Connect an AI to chat with Houston" with a Connect AI CTA into the AI Hub. Copy de-jargoned everywhere (no more "providers"), en/es/pt.
- **Status scans resolve**: an unreachable provider scan is a retried error, not an eternal "checking" spinner; probes have timeouts and self-heal on a 5s interval.
- **Pod-wake 503s retry to success** instead of toasting; "shared skills not configured" renders as feature-absent, not an error.

### Tests
Every fix landed test-first where reproducible: race tests for the coalescer, rotation-safety for the retry policy, attribution tests for exec-turn, Playwright e2e for the empty state (verified against both the fake host and a real host with a genuine cold runtime boot and zero credentials). Also de-flaked the store-sync watcher tests (FSEvents startup race).

Sibling PR (dev-launcher credential env parity): gethouston/cloud#213.

Fixes HOU-1153

🤖 Generated with [Claude Code](https://claude.com/claude-code)