### PR TITLE
fix(auth): desktop Microsoft sign-in via GCIP-brokered loopback (HOU-1112)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@
 #   FIREBASE_PROJECT_ID                — Firebase / GCP Identity Platform project id
 #   GOOGLE_DESKTOP_CLIENT_ID           — Google "Desktop app" OAuth client id (loopback + PKCE)
 #   GOOGLE_DESKTOP_CLIENT_SECRET       — Google installed-app secret (non-confidential; baked in)
-#   MICROSOFT_DESKTOP_CLIENT_ID        — Microsoft/Entra public client id (PKCE, no secret)
 #   HOSTED_ENGINE_URL                  — (CLOUD channel only, tag `cloud-v*`) Base URL of the
 #                                        managed Houston Cloud gateway the desktop app connects to.
 #                                        Baked in as VITE_HOSTED_ENGINE_URL so cloud users just sign
@@ -747,7 +746,6 @@ jobs:
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
           GOOGLE_DESKTOP_CLIENT_ID: ${{ secrets.GOOGLE_DESKTOP_CLIENT_ID }}
           GOOGLE_DESKTOP_CLIENT_SECRET: ${{ secrets.GOOGLE_DESKTOP_CLIENT_SECRET }}
-          MICROSOFT_DESKTOP_CLIENT_ID: ${{ secrets.MICROSOFT_DESKTOP_CLIENT_ID }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
@@ -1454,7 +1452,6 @@ jobs:
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
           GOOGLE_DESKTOP_CLIENT_ID: ${{ secrets.GOOGLE_DESKTOP_CLIENT_ID }}
           GOOGLE_DESKTOP_CLIENT_SECRET: ${{ secrets.GOOGLE_DESKTOP_CLIENT_SECRET }}
-          MICROSOFT_DESKTOP_CLIENT_ID: ${{ secrets.MICROSOFT_DESKTOP_CLIENT_ID }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
@@ -1738,7 +1735,6 @@ jobs:
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
           GOOGLE_DESKTOP_CLIENT_ID: ${{ secrets.GOOGLE_DESKTOP_CLIENT_ID }}
           GOOGLE_DESKTOP_CLIENT_SECRET: ${{ secrets.GOOGLE_DESKTOP_CLIENT_SECRET }}
-          MICROSOFT_DESKTOP_CLIENT_ID: ${{ secrets.MICROSOFT_DESKTOP_CLIENT_ID }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
@@ -1907,7 +1903,7 @@ jobs:
       # the app's own GCP Identity Platform (Firebase Auth) sign-in — the web
       # bundle authenticates with firebase-js-sdk's popup, so FIREBASE_API_KEY is
       # load-bearing and must be present (it has no build-time default). The
-      # desktop-only OAuth vars (GOOGLE_DESKTOP_*, MICROSOFT_DESKTOP_CLIENT_ID)
+      # desktop-only OAuth vars (GOOGLE_DESKTOP_*)
       # are the loopback/PKCE flow that never runs in a browser tab, so they are
       # deliberately NOT baked here (vite.config.ts defaults them to ""). POSTHOG_*
       # /SENTRY_DSN power the shared analytics + crash reporting. The deploy

--- a/app/src-tauri/.env.example
+++ b/app/src-tauri/.env.example
@@ -19,7 +19,6 @@ FIREBASE_AUTH_DOMAIN=
 FIREBASE_PROJECT_ID=
 GOOGLE_DESKTOP_CLIENT_ID=
 GOOGLE_DESKTOP_CLIENT_SECRET=
-MICROSOFT_DESKTOP_CLIENT_ID=
 SENTRY_DSN=
 # Dev builds suppress Sentry by default so dev errors don't pollute the prod
 # project. Set to 1 (or true/yes/on) to send + symbolicate while testing crash

--- a/app/src-tauri/src/oauth_loopback/callback.rs
+++ b/app/src-tauri/src/oauth_loopback/callback.rs
@@ -9,8 +9,9 @@
 //! answered with the "stale tab" page and the listener KEEPS WAITING.
 
 use tauri::AppHandle;
-use tokio::net::TcpListener;
+use tokio::net::TcpStream;
 
+use super::listener::BoundSockets;
 use super::pages::{stale_page, success_page};
 use crate::loopback_util::{read_request_target, split_target, write_response};
 
@@ -84,19 +85,33 @@ async fn respond(stream: &mut tokio::net::TcpStream, status: &str, body: &str) {
     }
 }
 
+/// Accept one connection from whichever loopback stack the browser picked. The
+/// redirect target may be `127.0.0.1` (Google) or `localhost` (the brokered
+/// flow), and a browser resolving `localhost` may connect over `::1` — so both
+/// bound listeners are served; `v6` is absent on IPv6-less machines.
+async fn accept_any(sockets: &BoundSockets) -> Result<TcpStream, String> {
+    let accepted = match &sockets.v6 {
+        Some(v6) => tokio::select! {
+            r = sockets.v4.accept() => r,
+            r = v6.accept() => r,
+        },
+        None => sockets.v4.accept().await,
+    };
+    accepted
+        .map(|(stream, _)| stream)
+        .map_err(|e| format!("accept failed: {e}"))
+}
+
 /// Accept connections until one carries THIS attempt's callback, then handle it
 /// and return. Non-callback probes (favicon, etc.) get a 404 and stale callbacks
 /// get the stale page; in both cases we keep waiting.
 pub async fn serve_callback(
-    listener: &TcpListener,
+    sockets: &BoundSockets,
     app: &AppHandle,
     expected_state: &str,
 ) -> Result<(), String> {
     loop {
-        let (mut stream, _) = listener
-            .accept()
-            .await
-            .map_err(|e| format!("accept failed: {e}"))?;
+        let mut stream = accept_any(sockets).await?;
 
         let target = match read_request_target(&mut stream).await {
             Ok(t) => t,
@@ -137,6 +152,26 @@ pub async fn serve_callback(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn accept_any_takes_connections_from_either_stack() {
+        // A browser resolving `localhost` may arrive on `::1` while another
+        // arrives on `127.0.0.1` — both must reach the same attempt.
+        use super::super::listener::{bind_exact, BindOutcome};
+        let BindOutcome::Bound(sockets) = bind_exact(18975).await.expect("bind") else {
+            return; // port busy on this machine; nothing to prove
+        };
+        let _v4 = tokio::net::TcpStream::connect(("127.0.0.1", 18975))
+            .await
+            .expect("v4 connect");
+        accept_any(&sockets).await.expect("accepts the v4 client");
+        if sockets.v6.is_some() {
+            let _v6 = tokio::net::TcpStream::connect(("::1", 18975))
+                .await
+                .expect("v6 connect");
+            accept_any(&sockets).await.expect("accepts the v6 client");
+        }
+    }
 
     #[test]
     fn query_param_reads_a_value_or_none() {

--- a/app/src-tauri/src/oauth_loopback/listener.rs
+++ b/app/src-tauri/src/oauth_loopback/listener.rs
@@ -16,10 +16,14 @@ use super::callback::serve_callback;
 use super::state::{ActiveListener, OauthLoopbackState};
 
 /// Loopback ports we try, in order. EVERY port here must be registered as an
-/// authorized redirect URI on the **Desktop OAuth client**
-/// (`http://127.0.0.1:<port>/auth/callback`), or the browser redirect is
-/// rejected before it ever reaches us. We bind the first free one; the short
-/// list survives the rare case where another process holds a port.
+/// authorized redirect URI on BOTH desktop OAuth registrations: the Google
+/// Desktop client (`http://127.0.0.1:<port>/auth/callback`, the loopback+PKCE
+/// flow) and the Azure app's **Web** platform
+/// (`http://localhost:<port>/auth/callback`, the GCIP-brokered flow — Entra
+/// only allows `http` on the Web platform for `localhost`). We bind the first
+/// free one (or, for the brokered flow, exactly the one its authorize URL was
+/// minted for); the short list survives the rare case where another process
+/// holds a port.
 const CANDIDATE_PORTS: &[u16] = &[8975, 8976, 8977, 8978];
 
 /// How long a new attempt waits for the superseded listener to actually release
@@ -31,11 +35,56 @@ const SUPERSEDE_WAIT: Duration = Duration::from_secs(1);
 /// calls `start_oauth_loopback` again for a fresh attempt.
 const LISTEN_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// The sockets one attempt listens on. The redirect target may be spelled
+/// `127.0.0.1` (Google) or `localhost` (the GCIP-brokered flow) — and a browser
+/// resolving `localhost` may connect over IPv6 (`::1`) before falling back — so
+/// every attempt binds BOTH loopback stacks on the same port. `v6` is `None`
+/// only when this machine has no usable IPv6 loopback at all (bind refused for
+/// a reason other than the port being taken).
+pub struct BoundSockets {
+    pub v4: TcpListener,
+    pub v6: Option<TcpListener>,
+    pub port: u16,
+}
+
+/// Outcome of trying to bind one exact port on both loopback stacks.
+pub enum BindOutcome {
+    Bound(BoundSockets),
+    /// The port is held by another process on EITHER stack. A v6-only squatter
+    /// still counts: a browser resolving `localhost` to `::1` would reach the
+    /// squatter instead of us, silently eating the callback.
+    Busy,
+}
+
+fn is_busy(e: &std::io::Error) -> bool {
+    e.kind() == std::io::ErrorKind::AddrInUse
+}
+
+/// Bind `port` on `127.0.0.1` AND `::1`. `Busy` when either stack has the port
+/// taken; errors only on a non-port failure of the required v4 bind.
+pub async fn bind_exact(port: u16) -> Result<BindOutcome, String> {
+    let v4 = match TcpListener::bind(("127.0.0.1", port)).await {
+        Ok(l) => l,
+        Err(e) if is_busy(&e) => return Ok(BindOutcome::Busy),
+        Err(e) => return Err(format!("could not bind 127.0.0.1:{port}: {e}")),
+    };
+    let v6 = match TcpListener::bind(("::1", port)).await {
+        Ok(l) => Some(l),
+        Err(e) if is_busy(&e) => return Ok(BindOutcome::Busy),
+        Err(e) => {
+            // No IPv6 loopback on this machine — v4-only is fine: a browser
+            // that can't connect `::1` falls back to `127.0.0.1`.
+            tracing::info!("[oauth-loopback] no ::1 listener on port {port} ({e}); IPv4 only");
+            None
+        }
+    };
+    Ok(BindOutcome::Bound(BoundSockets { v4, v6, port }))
+}
+
 /// Everything one spawned listener task owns for the life of an attempt.
 pub struct ListenerTask {
     pub app: AppHandle,
-    pub socket: TcpListener,
-    pub port: u16,
+    pub sockets: BoundSockets,
     pub attempt_id: u64,
     pub expected_state: String,
     pub cancel_rx: oneshot::Receiver<()>,
@@ -47,13 +96,13 @@ pub struct ListenerTask {
 pub fn spawn_listener(task: ListenerTask) {
     let ListenerTask {
         app,
-        socket,
-        port,
+        sockets,
         attempt_id,
         expected_state,
         cancel_rx,
         freed_tx,
     } = task;
+    let port = sockets.port;
     tokio::spawn(async move {
         tokio::select! {
             _ = cancel_rx => {
@@ -63,7 +112,7 @@ pub fn spawn_listener(task: ListenerTask) {
             }
             result = tokio::time::timeout(
                 LISTEN_TIMEOUT,
-                serve_callback(&socket, &app, &expected_state),
+                serve_callback(&sockets, &app, &expected_state),
             ) => {
                 match result {
                     Ok(Ok(())) => {}
@@ -82,7 +131,7 @@ pub fn spawn_listener(task: ListenerTask) {
         }
         // Release the port BEFORE announcing it: a superseding start is waiting
         // on `freed` so it can rebind this very port.
-        drop(socket);
+        drop(sockets);
         // Leave the registry pointing at nothing rather than at a task that has
         // exited — but only if it still points at US (a newer generation may
         // have taken the slot already).
@@ -113,12 +162,12 @@ pub async fn supersede(prev: ActiveListener) {
     }
 }
 
-/// Bind the first available candidate port on the loopback interface.
-pub async fn bind_first_free() -> Result<(TcpListener, u16), String> {
+/// Bind the first available candidate port on both loopback stacks.
+pub async fn bind_first_free() -> Result<BoundSockets, String> {
     for &port in CANDIDATE_PORTS {
-        match TcpListener::bind(("127.0.0.1", port)).await {
-            Ok(listener) => return Ok((listener, port)),
-            Err(e) => tracing::warn!("[oauth-loopback] port {port} unavailable: {e}"),
+        match bind_exact(port).await? {
+            BindOutcome::Bound(sockets) => return Ok(sockets),
+            BindOutcome::Busy => tracing::warn!("[oauth-loopback] port {port} unavailable"),
         }
     }
     Err(format!(
@@ -138,11 +187,58 @@ mod tests {
         let Ok(squatter) = squatter else {
             return; // the port is already busy on this machine; nothing to prove
         };
-        let (listener, port) = bind_first_free().await.expect("a candidate is free");
-        assert_ne!(port, CANDIDATE_PORTS[0]);
-        assert!(CANDIDATE_PORTS.contains(&port));
-        drop(listener);
+        let sockets = bind_first_free().await.expect("a candidate is free");
+        assert_ne!(sockets.port, CANDIDATE_PORTS[0]);
+        assert!(CANDIDATE_PORTS.contains(&sockets.port));
+        drop(sockets);
         drop(squatter);
+    }
+
+    #[tokio::test]
+    async fn bind_exact_reports_a_squatted_port_as_busy() {
+        // The brokered flow minted its authorize URL for ONE port, so a squat
+        // must come back as `Busy` (step + re-mint), never as a bind of some
+        // other port the provider would then refuse to redirect to.
+        let squatter = TcpListener::bind(("127.0.0.1", CANDIDATE_PORTS[1])).await;
+        let Ok(squatter) = squatter else {
+            return;
+        };
+        match bind_exact(CANDIDATE_PORTS[1]).await.expect("no bind error") {
+            BindOutcome::Busy => {}
+            BindOutcome::Bound(_) => panic!("a squatted port must be Busy"),
+        }
+        drop(squatter);
+    }
+
+    #[tokio::test]
+    async fn bind_exact_reports_a_v6_only_squatter_as_busy() {
+        // A process holding only `[::1]:port` would receive the callbacks of
+        // browsers that resolve `localhost` to IPv6 — the port is NOT usable.
+        let squatter = TcpListener::bind(("::1", CANDIDATE_PORTS[2])).await;
+        let Ok(squatter) = squatter else {
+            return; // no IPv6 loopback on this machine; nothing to prove
+        };
+        match bind_exact(CANDIDATE_PORTS[2]).await.expect("no bind error") {
+            BindOutcome::Busy => {}
+            BindOutcome::Bound(_) => panic!("a v6-squatted port must be Busy"),
+        }
+        drop(squatter);
+    }
+
+    #[tokio::test]
+    async fn bind_exact_listens_on_both_stacks() {
+        let BindOutcome::Bound(sockets) = bind_exact(CANDIDATE_PORTS[3]).await.expect("bind")
+        else {
+            return; // the port is busy on this machine; nothing to prove
+        };
+        assert_eq!(sockets.port, CANDIDATE_PORTS[3]);
+        // v4 is always required; v6 is best-effort but expected on CI machines.
+        let v4 = tokio::net::TcpStream::connect(("127.0.0.1", sockets.port)).await;
+        assert!(v4.is_ok(), "IPv4 loopback must accept");
+        if sockets.v6.is_some() {
+            let v6 = tokio::net::TcpStream::connect(("::1", sockets.port)).await;
+            assert!(v6.is_ok(), "IPv6 loopback must accept when bound");
+        }
     }
 
     #[tokio::test]

--- a/app/src-tauri/src/oauth_loopback/mod.rs
+++ b/app/src-tauri/src/oauth_loopback/mod.rs
@@ -1,16 +1,22 @@
 //! One-shot localhost loopback listener for the OAuth sign-in redirect.
 //!
 //! Replaces the gethouston.ai relay page for the **desktop** app. After
-//! provider consent (Google / Microsoft), the identity provider 302-redirects
-//! the user's system browser straight to
-//! `http://127.0.0.1:<port>/auth/callback?code=...&state=...`. Because that's a
+//! provider consent, the browser is 302-redirected straight to the loopback:
+//! `http://127.0.0.1:<port>/auth/callback?code=...&state=...` for Google's
+//! loopback+PKCE flow, or `http://localhost:<port>/auth/callback?...` for the
+//! GCIP-BROKERED Microsoft flow (whose authorize URL is minted by GCIP
+//! `createAuthUri` for ONE exact port — hence `exact_port` + `PortBusy` below —
+//! and whose code is redeemed by GCIP server-side, never by this client). Both
+//! loopback stacks (`127.0.0.1` and `::1`) are bound, because a browser
+//! resolving `localhost` may connect over IPv6. Because the redirect is a
 //! plain HTTP navigation (not a custom `houston://` scheme), the browser shows
 //! NO "open this app?" dialog — it just loads the page. We then:
 //!   1. check the `state` is OURS (a foreign one gets the stale page and we
 //!      keep listening — see `callback.rs`),
 //!   2. hand the query to the webview via the `auth://deep-link` event so the
-//!      PKCE exchange + GCIP (Firebase) sign-in run in JS with the in-memory
-//!      verifier (see `app/src/lib/identity/*`),
+//!      code redemption + GCIP (Firebase) sign-in run in JS (PKCE verifier for
+//!      Google, `signInWithIdp` session for Microsoft — see
+//!      `app/src/lib/identity/*`),
 //!   3. serve a "you're signed in, return to Houston" page,
 //!   4. pull the app window to the front — the old macOS deep-link path never
 //!      did this, which is a big part of why users thought sign-in "hung",
@@ -45,7 +51,7 @@ use tauri::{AppHandle, State};
 use tokio::sync::oneshot;
 
 use callback::CALLBACK_PATH;
-use listener::{bind_first_free, spawn_listener, supersede, ListenerTask};
+use listener::{bind_exact, bind_first_free, spawn_listener, supersede, BindOutcome, ListenerTask};
 pub use state::OauthLoopbackState;
 use state::{ActiveListener, Claim, Installed};
 
@@ -56,8 +62,12 @@ pub enum LoopbackStart {
     /// A listener is bound and waiting for this attempt's redirect.
     #[serde(rename_all = "camelCase")]
     Listening {
-        /// The `redirect_uri` the frontend gives the provider.
+        /// The `redirect_uri` the frontend gives the provider (the `127.0.0.1`
+        /// spelling; the brokered flow derives its `localhost` continueUri from
+        /// `port` instead).
         redirect_uri: String,
+        /// The bound loopback port. Both `127.0.0.1` and `::1` listen on it.
+        port: u16,
         /// Identifies this listener; `cancel_oauth_loopback` only acts on a match.
         attempt_id: u64,
     },
@@ -66,6 +76,11 @@ pub enum LoopbackStart {
     /// treats it as a benign supersession — no error, no session: the newer
     /// attempt is the one the user is actually watching.
     Superseded,
+    /// The requested `exact_port` is held by a foreign process (only produced
+    /// when `exact_port` was given). NOT an error: the GCIP-brokered caller
+    /// minted its authorize URL for that one port, so it re-mints for the next
+    /// candidate and asks again.
+    PortBusy,
 }
 
 /// Start a one-shot loopback listener for the attempt whose CSRF `state` is
@@ -80,6 +95,7 @@ pub async fn start_oauth_loopback(
     app: AppHandle,
     state: State<'_, OauthLoopbackState>,
     expected_state: String,
+    exact_port: Option<u16>,
 ) -> Result<LoopbackStart, String> {
     // Mint the generation FIRST: it records when the user clicked, not which
     // coroutine happens to reach `install` last.
@@ -99,7 +115,22 @@ pub async fn start_oauth_loopback(
         Claim::Won(None) => {}
     }
 
-    let (listener, port) = bind_first_free().await?;
+    // The GCIP-brokered flow minted its authorize URL for ONE port, so it asks
+    // for exactly that port and steps + re-mints on `PortBusy`; the PKCE flow
+    // takes the first free candidate.
+    let sockets = match exact_port {
+        Some(port) => match bind_exact(port).await? {
+            BindOutcome::Bound(sockets) => sockets,
+            BindOutcome::Busy => {
+                tracing::info!(
+                    "[oauth-loopback] attempt {attempt_id}: exact port {port} is busy"
+                );
+                return Ok(LoopbackStart::PortBusy);
+            }
+        },
+        None => bind_first_free().await?,
+    };
+    let port = sockets.port;
     let redirect_uri = format!("http://127.0.0.1:{port}{CALLBACK_PATH}");
     tracing::info!("[oauth-loopback] attempt {attempt_id} listening on {redirect_uri}");
 
@@ -121,20 +152,19 @@ pub async fn start_oauth_loopback(
         Installed::Ok(None) => {}
         Installed::Stale { newest } => {
             // A newer click claimed the loopback while we were binding. Free
-            // the socket we just bound (dropping it releases the port) and tell
-            // the frontend this attempt lost — never install it as current.
+            // the sockets we just bound (dropping them releases the port) and
+            // tell the frontend this attempt lost — never install it as current.
             tracing::info!(
                 "[oauth-loopback] attempt {attempt_id} lost to {newest} while binding; releasing port {port}"
             );
-            drop(listener);
+            drop(sockets);
             return Ok(LoopbackStart::Superseded);
         }
     }
 
     spawn_listener(ListenerTask {
         app,
-        socket: listener,
-        port,
+        sockets,
         attempt_id,
         expected_state,
         cancel_rx,
@@ -143,6 +173,7 @@ pub async fn start_oauth_loopback(
 
     Ok(LoopbackStart::Listening {
         redirect_uri,
+        port,
         attempt_id,
     })
 }

--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -24,6 +24,7 @@ import {
   googleDesktopSession,
   microsoftDesktopSession,
 } from "./identity/desktop-signin";
+import { identityLog } from "./identity/log";
 import { osIsTauri } from "./os-bridge";
 import { applyExternalSession, cacheSession } from "./session-cache";
 import {
@@ -61,6 +62,16 @@ async function guardAuthCall(
     const err = isIdentityError(e)
       ? e
       : new IdentityError("unknown", { cause: e });
+    // The UI collapses codes into a handful of copy buckets, so without this
+    // line the failure's identity (rawCode / HTTP status) exists NOWHERE — a
+    // sign-in bug then has zero diagnostics (HOU-1112 was invisible for weeks).
+    identityLog(
+      "error",
+      `sign-in failed: ${err.code}${err.rawCode ? ` (${err.rawCode})` : ""}${
+        err.httpStatus ? ` [http ${err.httpStatus}]` : ""
+      }`,
+      "auth",
+    );
     if (opts.emit ?? true) emitAuthError(err.code);
     throw err;
   }

--- a/app/src/lib/identity/brokered-loopback.ts
+++ b/app/src/lib/identity/brokered-loopback.ts
@@ -1,0 +1,168 @@
+// The GCIP-BROKERED authorize round-trip over the desktop loopback (Microsoft).
+//
+// Unlike desktop-oauth.ts (loopback+PKCE, where THIS client redeems the code at
+// the provider's token endpoint), the authorize URL here is minted by GCIP
+// (`createAuthUri`): GCIP owns the OAuth `state` and redeems the callback
+// itself, server-side, with the provider secret held in the identity project's
+// provider config (`signInWithIdpSession`). The client never touches the
+// provider's token endpoint — which is the point: Entra refuses public-client
+// redemptions coming from a webview (AADSTS90023, the fetch's `Origin` header
+// marks them cross-origin) and GCIP refuses externally obtained Microsoft
+// tokens outright (`INVALID_CREDENTIAL_OR_PROVIDER_ID`), so a direct PKCE
+// exchange can never complete for `microsoft.com` (HOU-1112).
+//
+// The chicken-and-egg this module owns: GCIP's `state` exists only AFTER
+// minting, but minting needs the `continueUri` — port included. So each
+// candidate port is minted for FIRST and then bound EXACTLY (`exactPort`);
+// a foreign squatter answers `portBusy` and we re-mint for the next candidate.
+// The `continueUri` must be spelled `http://localhost:<port>` (not 127.0.0.1):
+// it must match the Azure app's **Web**-platform redirect URIs, and Entra only
+// allows plain http there for `localhost`. The native listener binds both
+// loopback stacks, so the browser may resolve `localhost` to either.
+//
+// Pure driver: every effect (mint, bind, listen, open) is injected, so the
+// port-stepping and cancel semantics are unit-testable (no Tauri imports).
+
+import type { OauthLoopbackStart } from "../os-bridge";
+import type { LoopbackAuthorizeOptions } from "./desktop-oauth.ts";
+import { IdentityError, isIdentityError } from "./errors.ts";
+import { identityLog } from "./log.ts";
+import { awaitLoopbackCallback } from "./oauth-attempt.ts";
+import {
+  type DeepLinkListen,
+  withBrowserOpenDeadline,
+} from "./oauth-attempt-contract.ts";
+import { parseCallbackQuery } from "./oauth-callback.ts";
+
+const LOG_CTX = "identity/brokered-loopback";
+
+/** Loopback ports to try, in order — mirrors the native candidate list, and
+ *  every one must be registered on the Azure app's Web platform as
+ *  `http://localhost:<port>/auth/callback`. */
+const CANDIDATE_PORTS = [8975, 8976, 8977, 8978];
+
+/** The effects one brokered-loopback authorize needs, injected for testability. */
+export interface BrokeredLoopbackDeps {
+  /** Mint the provider authorize URL for `continueUri` (GCIP `createAuthUri`). */
+  mint: (
+    continueUri: string,
+  ) => Promise<{ authUri: string; sessionId: string }>;
+  /** Bind the native listener on EXACTLY `port` (`osStartOauthLoopback`). */
+  startLoopback: (
+    expectedState: string,
+    exactPort: number,
+  ) => Promise<OauthLoopbackStart>;
+  /** Free a bound listener by attempt id (`osCancelOauthLoopback`, logged). */
+  releaseLoopback: (attemptId: number, why: string) => void;
+  /** Subscribe to the `auth://deep-link` callback payload. */
+  listen: DeepLinkListen;
+  /** Open the authorize URL in the system browser. */
+  openUrl: (url: string) => Promise<void>;
+}
+
+/** What `signInWithIdpSession` needs to redeem the round-trip. */
+export interface BrokeredLoopbackResult {
+  /** The full callback URL: continueUri + `?` + every param the provider sent. */
+  requestUri: string;
+  /** The `createAuthUri` session that pairs with the callback. */
+  sessionId: string;
+}
+
+/** GCIP's own CSRF `state` rides the minted URL; without it the callback could
+ *  never be validated, so refuse to open a browser we couldn't match. */
+function extractState(authUri: string): string {
+  let state: string | null;
+  try {
+    state = new URL(authUri).searchParams.get("state");
+  } catch (e) {
+    throw new IdentityError("malformed_response", {
+      rawCode: "auth_uri_unparseable",
+      cause: e,
+    });
+  }
+  if (!state) {
+    throw new IdentityError("malformed_response", {
+      rawCode: "auth_uri_missing_state",
+    });
+  }
+  return state;
+}
+
+/**
+ * Run one GCIP-brokered authorize over the loopback. Resolves the redemption
+ * pair, or `null` when the attempt was benignly cancelled (superseded /
+ * unmount / timeout). Steps to the next candidate port (re-minting) when a
+ * foreign process squats the current one.
+ */
+export async function runBrokeredLoopbackAuthorize(
+  deps: BrokeredLoopbackDeps,
+  opts?: LoopbackAuthorizeOptions,
+): Promise<BrokeredLoopbackResult | null> {
+  for (const port of CANDIDATE_PORTS) {
+    const continueUri = `http://localhost:${port}/auth/callback`;
+    const minted = await deps.mint(continueUri);
+    const expectedState = extractState(minted.authUri);
+
+    let started: OauthLoopbackStart;
+    try {
+      started = await withBrowserOpenDeadline(
+        deps.startLoopback(expectedState, port),
+        "loopback_bind",
+        {
+          // The invoke cannot be cancelled mid-flight; if the deadline wins we
+          // free the listener the moment it finally appears (see desktop-oauth).
+          releaseIfLate: (late) => {
+            if (late.status === "listening") {
+              deps.releaseLoopback(
+                late.attemptId,
+                "orphaned by the pre-browser deadline",
+              );
+            }
+          },
+        },
+      );
+    } catch (e) {
+      if (isIdentityError(e)) throw e;
+      throw new IdentityError("unknown", {
+        rawCode: "loopback_bind_failed",
+        cause: e,
+      });
+    }
+    if (started.status === "superseded") {
+      identityLog(
+        "info",
+        "brokered authorize superseded by a newer click before binding",
+        LOG_CTX,
+      );
+      return null;
+    }
+    if (started.status === "portBusy") {
+      // The minted authorize URL is tied to THIS port, so it is dropped along
+      // with its GCIP session; the next iteration mints a fresh one.
+      identityLog(
+        "warn",
+        `loopback port ${port} is busy; re-minting for the next candidate`,
+        LOG_CTX,
+      );
+      continue;
+    }
+    const { attemptId } = started;
+
+    const query = await awaitLoopbackCallback({
+      expectedState,
+      authorizeUrl: minted.authUri,
+      listen: deps.listen,
+      openUrl: deps.openUrl,
+      onBrowserOpened: opts?.onBrowserOpened,
+      parsePayload: parseCallbackQuery,
+      abandonLoopback: () =>
+        deps.releaseLoopback(attemptId, "attempt abandoned"),
+    });
+    if (query === null) return null; // benign cancel — no error, no session
+    return {
+      requestUri: `${continueUri}?${query}`,
+      sessionId: minted.sessionId,
+    };
+  }
+  throw new IdentityError("unknown", { rawCode: "loopback_ports_exhausted" });
+}

--- a/app/src/lib/identity/desktop-oauth.ts
+++ b/app/src/lib/identity/desktop-oauth.ts
@@ -1,4 +1,6 @@
-// Desktop loopback + PKCE authorize driver, shared by Google & Microsoft.
+// Desktop loopback + PKCE authorize driver (Google). Microsoft is GCIP-
+// BROKERED instead (brokered-loopback.ts): neither Entra nor GCIP accepts a
+// client-side Microsoft token exchange, so only Google runs this PKCE path.
 //
 // One call = one sign-in attempt: mint PKCE + CSRF state, ask the Rust shell to
 // bind a one-shot loopback listener (`osStartOauthLoopback` → redirect_uri),
@@ -11,9 +13,9 @@
 // Starting a new authorize CANCELS any previous pending one (benign `null`); the
 // timeout and `cancelPendingAuthorize()` also resolve `null`, so an abandoned
 // browser tab never produces a minutes-later error toast. Only a genuine
-// callback error rejects typed. The caller (google-authorize /
-// microsoft-authorize) then redeems `code` + `codeVerifier` at the provider's
-// token endpoint; a `null` here means "benign cancel — no session, no error".
+// callback error rejects typed. The caller (google-authorize) then redeems
+// `code` + `codeVerifier` at the provider's token endpoint; a `null` here
+// means "benign cancel — no session, no error".
 
 import {
   type OauthLoopbackStart,
@@ -117,8 +119,8 @@ export async function runLoopbackAuthorize(
     // Already typed (the pre-browser deadline fired) — keep the specific code.
     if (isIdentityError(e)) throw e;
     // The loopback bind failed (all ports busy). We must NOT fall back to a
-    // `houston://auth-callback` custom-scheme redirect_uri: Google/Microsoft
-    // reject custom-scheme redirects on direct OAuth (guaranteed
+    // `houston://auth-callback` custom-scheme redirect_uri: Google rejects
+    // custom-scheme redirects on direct OAuth (guaranteed
     // redirect_uri_mismatch). Surface a typed error for the generic retry UI
     // instead of letting a raw invoke rejection propagate untyped.
     throw new IdentityError("unknown", {
@@ -136,6 +138,12 @@ export async function runLoopbackAuthorize(
     );
     return null;
   }
+  if (started.status === "portBusy") {
+    // Only produced for an `exactPort` request, which this PKCE flow never
+    // makes (it binds the first free candidate). Treat a stray one as a bind
+    // failure rather than proceeding without a listener.
+    throw new IdentityError("unknown", { rawCode: "loopback_bind_failed" });
+  }
   const { redirectUri, attemptId } = started;
 
   const url = new URL(params.authorizeBase);
@@ -147,9 +155,8 @@ export async function runLoopbackAuthorize(
   q.set("code_challenge", codeChallenge);
   q.set("code_challenge_method", "S256");
   q.set("state", state);
-  // Provider-specific authorize params (e.g. Google's `access_type=offline`,
-  // Microsoft's `prompt=select_account`) come from the caller — nothing
-  // Google-only rides on every provider's URL.
+  // Provider-specific authorize params (e.g. Google's `access_type=offline`)
+  // come from the caller.
   for (const [k, v] of Object.entries(params.extraParams ?? {})) q.set(k, v);
 
   const code = await awaitLoopbackCallback({

--- a/app/src/lib/identity/desktop-signin.ts
+++ b/app/src/lib/identity/desktop-signin.ts
@@ -73,21 +73,21 @@ export async function googleDesktopSession(
 }
 
 /**
- * Microsoft: loopback tokens → `signInWithIdp` → SignInOutcome (provider
- * "microsoft.com"). Returns `null` when the loopback authorize was benignly
- * cancelled.
+ * Microsoft: GCIP-brokered loopback (`createAuthUri` → loopback → GCIP redeems
+ * the code server-side) → `signInWithIdpSession` → SignInOutcome (provider
+ * "microsoft.com"). Brokered because neither Entra nor GCIP accepts a
+ * client-side Microsoft token exchange (see microsoft-authorize.ts). Returns
+ * `null` when the authorize was benignly cancelled.
  */
 export async function microsoftDesktopSession(
   opts?: LoopbackAuthorizeOptions,
 ): Promise<SignInOutcome | null> {
   const authorized = await authorizeMicrosoftDesktop(opts);
   if (authorized === null) return null; // benign cancel
-  const { idToken, accessToken } = authorized;
-  const result = await signInWithIdp({
+  const result = await signInWithIdpSession({
     apiKey: identityConfig.apiKey,
-    providerId: "microsoft.com",
-    idToken,
-    accessToken,
+    requestUri: authorized.requestUri,
+    sessionId: authorized.sessionId,
   });
   return {
     session: sessionFromIdp(await withProfileBackfill(result), "microsoft.com"),

--- a/app/src/lib/identity/firebase-rest.ts
+++ b/app/src/lib/identity/firebase-rest.ts
@@ -119,7 +119,8 @@ export async function signInWithIdp(params: {
 
 /**
  * Session-based federated sign-in completion, the second half of the
- * GCIP-BROKERED flow (Apple): `createAuthUri` minted the authorize URL and a
+ * GCIP-BROKERED flows (Apple via the gateway deep-link bridge, Microsoft via
+ * the loopback): `createAuthUri` minted the authorize URL and a
  * `sessionId`; after the provider bounced through GCIP's handler back to the
  * loopback `continueUri`, the FULL callback URL goes back as `requestUri` and
  * GCIP redeems the pair itself — no provider token exchange on the client, no
@@ -155,11 +156,12 @@ export async function signInWithIdpSession(params: {
 
 /**
  * Mint a provider authorize URL through GCIP (`accounts:createAuthUri`) for the
- * brokered desktop flow: GCIP builds the URL (its handler is the redirect the
- * provider is registered with) and returns the `sessionId` that later pairs
- * with the callback in {@link signInWithIdpSession}. `continueUri` is where
- * GCIP's handler bounces the browser after the provider consents — the desktop
- * loopback (must be an authorized domain on the identity project).
+ * brokered desktop flows: GCIP builds the URL, carrying its own CSRF `state`,
+ * and returns the `sessionId` that later pairs with the callback in
+ * {@link signInWithIdpSession}. `continueUri` is passed to the provider
+ * VERBATIM as `redirect_uri` (GCIP does NOT bounce through its `/__/auth`
+ * handler), so it must be a redirect URI registered on the provider's app —
+ * Apple's gateway bridge, or Microsoft's `http://localhost:<port>` loopback.
  */
 export async function createAuthUri(params: {
   apiKey: string;

--- a/app/src/lib/identity/microsoft-authorize.ts
+++ b/app/src/lib/identity/microsoft-authorize.ts
@@ -1,79 +1,67 @@
-// Desktop Microsoft sign-in: loopback+PKCE authorize → PUBLIC-client token
-// exchange (NO client_secret) → id_token and/or access_token.
+// Desktop Microsoft sign-in: GCIP-BROKERED authorize over the loopback.
 //
-// Uses the `common` tenant so both work and personal Microsoft accounts sign
-// in, with `prompt=select_account` so a shared machine can switch accounts and
-// `offline_access` so a refresh token is issued. auth.ts (Wave B) feeds the
-// id_token to `signInWithIdp({ providerId: "microsoft.com" })`, falling back to
-// the access_token when no id_token is returned.
+// WHY brokered and not loopback+PKCE like Google (HOU-1112): Entra refuses a
+// public-client code redemption made from a webview (the fetch carries an
+// `Origin` header, and AADSTS90023 restricts cross-origin redemption to SPA
+// registrations), and GCIP refuses Microsoft tokens it did not obtain itself
+// (`INVALID_CREDENTIAL_OR_PROVIDER_ID`) — so a client-side token exchange can
+// never produce a Microsoft session. Instead GCIP mints the authorize URL
+// (`createAuthUri`, carrying its own CSRF `state`), the loopback catches the
+// redirect, and GCIP redeems the code server-side with the client secret from
+// the identity project's provider config (`signInWithIdpSession` in
+// desktop-signin.ts). No Microsoft client id or secret ships in this app.
+//
+// Setup (human, one-time): the Azure app's **Web** platform must list every
+// candidate loopback redirect as `http://localhost:<port>/auth/callback`
+// (Entra's Web platform only allows plain http for `localhost`), and the
+// microsoft.com provider on the identity project holds the same app's client
+// id + secret (cloud terraform `identity.tf`).
 
+import { osCancelOauthLoopback, osStartOauthLoopback } from "../os-bridge";
+import { tauriSystem } from "../tauri";
 import {
-  type LoopbackAuthorizeOptions,
-  postTokenForm,
-  runLoopbackAuthorize,
-} from "./desktop-oauth.ts";
-import { IdentityError } from "./errors.ts";
+  type BrokeredLoopbackResult,
+  runBrokeredLoopbackAuthorize,
+} from "./brokered-loopback.ts";
+import { identityConfig } from "./config.ts";
+import { listenDeepLink } from "./deep-link-listen.ts";
+import type { LoopbackAuthorizeOptions } from "./desktop-oauth.ts";
+import { createAuthUri } from "./firebase-rest.ts";
+import { identityLog } from "./log.ts";
 
-const MS_AUTHORIZE =
-  "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
-const MS_TOKEN = "https://login.microsoftonline.com/common/oauth2/v2.0/token";
-const MS_SCOPE = "openid email profile offline_access";
-
-function microsoftClientId(): string {
-  return typeof __MICROSOFT_DESKTOP_CLIENT_ID__ !== "undefined"
-    ? __MICROSOFT_DESKTOP_CLIENT_ID__
-    : "";
-}
+const LOG_CTX = "identity/microsoft-authorize";
 
 /**
- * Drive the desktop Microsoft flow. Returns whichever credential Entra minted,
- * or `null` when the authorize was benignly cancelled (superseded / unmount /
- * timeout).
+ * Drive the desktop Microsoft flow up to the redeemable (`requestUri`,
+ * `sessionId`) pair, or `null` when the authorize was benignly cancelled
+ * (superseded / unmount / timeout).
  */
-export async function authorizeMicrosoftDesktop(
+export function authorizeMicrosoftDesktop(
   opts?: LoopbackAuthorizeOptions,
-): Promise<{ idToken?: string; accessToken?: string } | null> {
-  const clientId = microsoftClientId();
-  if (!clientId) {
-    // No baked MS client id for this build — surface it, never a silent no-op.
-    throw new IdentityError("operation_not_allowed", {
-      rawCode: "microsoft_desktop_client_id_missing",
-    });
-  }
-
-  const authorized = await runLoopbackAuthorize(
+): Promise<BrokeredLoopbackResult | null> {
+  return runBrokeredLoopbackAuthorize(
     {
-      authorizeBase: MS_AUTHORIZE,
-      clientId,
-      scope: MS_SCOPE,
-      extraParams: { prompt: "select_account" },
+      mint: (continueUri) =>
+        createAuthUri({
+          apiKey: identityConfig.apiKey,
+          providerId: "microsoft.com",
+          continueUri,
+        }),
+      startLoopback: osStartOauthLoopback,
+      releaseLoopback: (attemptId, why) => {
+        // Best-effort: a failure just means the port frees at the native 300s
+        // self-timeout, so log rather than toast (same policy as desktop-oauth).
+        void osCancelOauthLoopback(attemptId).catch((e) =>
+          identityLog(
+            "warn",
+            `failed to free loopback port (${why}): ${String(e)}`,
+            LOG_CTX,
+          ),
+        );
+      },
+      listen: listenDeepLink,
+      openUrl: tauriSystem.openUrl,
     },
     opts,
   );
-  if (!authorized) return null; // benign cancel
-  const { code, redirectUri, codeVerifier } = authorized;
-
-  const body = await postTokenForm(MS_TOKEN, {
-    client_id: clientId,
-    code,
-    code_verifier: codeVerifier,
-    redirect_uri: redirectUri,
-    grant_type: "authorization_code",
-    scope: MS_SCOPE,
-  });
-
-  const idToken =
-    typeof body.id_token === "string" && body.id_token.length > 0
-      ? body.id_token
-      : undefined;
-  const accessToken =
-    typeof body.access_token === "string" && body.access_token.length > 0
-      ? body.access_token
-      : undefined;
-  if (!idToken && !accessToken) {
-    throw new IdentityError("malformed_response", {
-      rawCode: "microsoft_token_missing_credential",
-    });
-  }
-  return { idToken, accessToken };
 }

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -84,8 +84,12 @@ export function osOpenUrl(url: string): Promise<void> {
 export type OauthLoopbackStart =
   | {
       status: "listening";
-      /** `http://127.0.0.1:<port>/auth/callback` — the provider's redirect target. */
+      /** `http://127.0.0.1:<port>/auth/callback` — the redirect target for the
+       *  loopback+PKCE flow (the GCIP-brokered flow derives its `localhost`
+       *  continueUri from `port` instead). */
       redirectUri: string;
+      /** The bound loopback port; both `127.0.0.1` and `::1` listen on it. */
+      port: number;
       /** Identifies this attempt's listener. `osCancelOauthLoopback` only acts
        *  when it carries this id, so a late cancel can never free a NEWER
        *  attempt's port. */
@@ -96,6 +100,12 @@ export type OauthLoopbackStart =
        *  invocation bound nothing and released anything it held. The caller
        *  treats it as a benign supersession — no error, no session. */
       status: "superseded";
+    }
+  | {
+      /** The requested `exactPort` is held by a foreign process (only returned
+       *  when `exactPort` was given). The GCIP-brokered caller re-mints its
+       *  authorize URL for the next candidate port and asks again. */
+      status: "portBusy";
     };
 
 /** Start a one-shot localhost listener for the OAuth sign-in redirect. Keeps
@@ -106,13 +116,18 @@ export type OauthLoopbackStart =
  * old redirect can no longer consume the port this sign-in is waiting on.
  * Resolves `{ status: "superseded" }` when a NEWER click already claimed the
  * loopback (concurrent starts are ordered by when the user clicked, not by which
- * invocation finishes binding first). Desktop only; web clients have no local
- * listener and use the firebase-js-sdk popup instead. */
+ * invocation finishes binding first). `exactPort` binds that one port or
+ * resolves `{ status: "portBusy" }` — the GCIP-brokered flow mints its
+ * authorize URL for a single port up front, so it cannot accept "some other
+ * free port". Desktop only; web clients have no local listener and use the
+ * firebase-js-sdk popup instead. */
 export function osStartOauthLoopback(
   expectedState: string,
+  exactPort?: number,
 ): Promise<OauthLoopbackStart> {
   return invoke<OauthLoopbackStart>("start_oauth_loopback", {
     expected_state: expectedState,
+    ...(exactPort === undefined ? {} : { exact_port: exactPort }),
   });
 }
 

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -8,7 +8,6 @@ declare const __FIREBASE_AUTH_DOMAIN__: string;
 declare const __FIREBASE_PROJECT_ID__: string;
 declare const __GOOGLE_DESKTOP_CLIENT_ID__: string;
 declare const __GOOGLE_DESKTOP_CLIENT_SECRET__: string;
-declare const __MICROSOFT_DESKTOP_CLIENT_ID__: string;
 declare const __HOUSTON_AUTH_STORAGE_MODE__: string;
 declare const __HOUSTON_AUTH_STORAGE_SCOPE__: string;
 declare const __SENTRY_DSN__: string;

--- a/app/tests/identity-brokered-loopback.test.ts
+++ b/app/tests/identity-brokered-loopback.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import {
+  type BrokeredLoopbackDeps,
+  runBrokeredLoopbackAuthorize,
+} from "../src/lib/identity/brokered-loopback.ts";
+import { IdentityError } from "../src/lib/identity/errors.ts";
+import { cancelPendingAuthorize } from "../src/lib/identity/oauth-attempt.ts";
+
+// The GCIP-brokered loopback driver is pure (every effect injected), so the
+// port-stepping, supersession, and requestUri-assembly contracts are unit-
+// tested here; the real mint/bind/listen wiring is microsoft-authorize.ts.
+
+afterEach(() => cancelPendingAuthorize("test cleanup"));
+
+/** A deps bundle whose flow succeeds on the first port with `query`. */
+function happyDeps(query: string): BrokeredLoopbackDeps & {
+  minted: string[];
+  released: Array<{ attemptId: number; why: string }>;
+} {
+  const minted: string[] = [];
+  const released: Array<{ attemptId: number; why: string }> = [];
+  return {
+    minted,
+    released,
+    mint: async (continueUri) => {
+      minted.push(continueUri);
+      return {
+        authUri: `https://login.example.com/authorize?state=gcip-state-${minted.length}`,
+        sessionId: `session-${minted.length}`,
+      };
+    },
+    startLoopback: async () => ({
+      status: "listening",
+      redirectUri: "http://127.0.0.1:8975/auth/callback",
+      port: 8975,
+      attemptId: 7,
+    }),
+    releaseLoopback: (attemptId, why) => released.push({ attemptId, why }),
+    listen: async (onPayload) => {
+      // Deliver the provider callback as soon as the attempt subscribes.
+      queueMicrotask(() => onPayload(`houston://auth-callback?${query}`));
+      return () => {};
+    },
+    openUrl: async () => {},
+  };
+}
+
+test("assembles requestUri from the minted continueUri and the callback query", async () => {
+  const deps = happyDeps("code=abc123&state=gcip-state-1");
+  const result = await runBrokeredLoopbackAuthorize(deps);
+  assert.deepEqual(result, {
+    requestUri:
+      "http://localhost:8975/auth/callback?code=abc123&state=gcip-state-1",
+    sessionId: "session-1",
+  });
+  // The continueUri is the localhost spelling (Azure Web platform), port first
+  // candidate, minted exactly once.
+  assert.deepEqual(deps.minted, ["http://localhost:8975/auth/callback"]);
+});
+
+test("steps to the next candidate port and re-mints when a port is busy", async () => {
+  const deps = happyDeps("code=abc123&state=gcip-state-2");
+  let calls = 0;
+  const ports: number[] = [];
+  deps.startLoopback = async (_state, exactPort) => {
+    ports.push(exactPort);
+    calls += 1;
+    if (calls === 1) return { status: "portBusy" };
+    return {
+      status: "listening",
+      redirectUri: "http://127.0.0.1:8976/auth/callback",
+      port: 8976,
+      attemptId: 8,
+    };
+  };
+  const result = await runBrokeredLoopbackAuthorize(deps);
+  // A fresh authorize URL (and GCIP session) is minted for the SECOND port —
+  // the first mint is tied to the busy port and must not be reused.
+  assert.deepEqual(deps.minted, [
+    "http://localhost:8975/auth/callback",
+    "http://localhost:8976/auth/callback",
+  ]);
+  assert.deepEqual(ports, [8975, 8976]);
+  assert.equal(result?.sessionId, "session-2");
+  assert.equal(
+    result?.requestUri,
+    "http://localhost:8976/auth/callback?code=abc123&state=gcip-state-2",
+  );
+});
+
+test("every candidate port busy is a typed failure, not a silent hang", async () => {
+  const deps = happyDeps("unused");
+  deps.startLoopback = async () => ({ status: "portBusy" });
+  await assert.rejects(
+    () => runBrokeredLoopbackAuthorize(deps),
+    (e: unknown) =>
+      e instanceof IdentityError &&
+      e.code === "unknown" &&
+      e.rawCode === "loopback_ports_exhausted",
+  );
+  // One mint per candidate: 8975..8978.
+  assert.equal(deps.minted.length, 4);
+});
+
+test("supersession by a newer click resolves null (benign, no error)", async () => {
+  const deps = happyDeps("unused");
+  deps.startLoopback = async () => ({ status: "superseded" });
+  assert.equal(await runBrokeredLoopbackAuthorize(deps), null);
+});
+
+test("an authorize URL without GCIP's state refuses to open a browser", async () => {
+  const deps = happyDeps("unused");
+  deps.mint = async () => ({
+    authUri: "https://login.example.com/authorize?client_id=x",
+    sessionId: "s",
+  });
+  let opened = 0;
+  deps.openUrl = async () => {
+    opened += 1;
+  };
+  await assert.rejects(
+    () => runBrokeredLoopbackAuthorize(deps),
+    (e: unknown) =>
+      e instanceof IdentityError &&
+      e.code === "malformed_response" &&
+      e.rawCode === "auth_uri_missing_state",
+  );
+  assert.equal(opened, 0, "must not open a browser it cannot CSRF-match");
+});
+
+test("a provider error on the callback rejects typed", async () => {
+  const deps = happyDeps(
+    "error=access_denied&error_description=denied&state=gcip-state-1",
+  );
+  await assert.rejects(
+    () => runBrokeredLoopbackAuthorize(deps),
+    (e: unknown) =>
+      e instanceof IdentityError && e.code === "invalid_idp_response",
+  );
+});
+
+test("an external cancel resolves null and frees the bound port", async () => {
+  const deps = happyDeps("unused");
+  deps.listen = async () => () => {}; // never delivers a callback
+  const pending = runBrokeredLoopbackAuthorize(deps);
+  // Let the attempt subscribe + open the browser before cancelling.
+  await new Promise((r) => setTimeout(r, 10));
+  cancelPendingAuthorize("sign-in screen unmounted");
+  assert.equal(await pending, null);
+  assert.deepEqual(deps.released, [{ attemptId: 7, why: "attempt abandoned" }]);
+});

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -94,9 +94,6 @@ export default defineConfig(({ mode }) => {
       ),
       // Desktop-only: the Microsoft (Entra) native/public OAuth client for the
       // loopback + PKCE sign-in. Public client — no secret in the exchange.
-      __MICROSOFT_DESKTOP_CLIENT_ID__: JSON.stringify(
-        env.MICROSOFT_DESKTOP_CLIENT_ID ?? "",
-      ),
       __HOUSTON_AUTH_STORAGE_MODE__: JSON.stringify(authStorageMode),
       __HOUSTON_AUTH_STORAGE_SCOPE__: JSON.stringify(authStorageScope),
       __SENTRY_DSN__: JSON.stringify(env.SENTRY_DSN ?? ""),

--- a/knowledge-base/auth-migration.md
+++ b/knowledge-base/auth-migration.md
@@ -83,13 +83,14 @@ now lives in git).
   client (PKCE) with the `127.0.0.1` loopback ports as authorized redirect URIs; and an
   Azure app registration for the `microsoft.com` provider whose redirect includes those
   loopback ports (public PKCE client, no secret).
-  **CONFIRMED LIVE (2026-07-16):** the Azure app (`78465f4b-…`) has the GCIP handler
-  registered but NOT the desktop loopback URIs — personal (MSA) accounts fail after the
-  account picker with "We're unable to complete your request / invalid_request:
-  redirect_uri is not valid" on `login.live.com`. Fix: Azure Portal → the app →
-  Authentication → **Mobile and desktop applications** → add all four exact URIs
-  `http://127.0.0.1:8975/auth/callback` … `:8978` (login.live.com matches exactly;
-  it does not do Entra's port-agnostic loopback matching).
+  **RESOLVED (2026-08-03, HOU-1112):** the loopback URIs were missing/misregistered
+  AND the direct client-side exchange turned out to be impossible for Microsoft
+  (AADSTS90023 origin policy in the webview; GCIP refuses externally obtained MS
+  tokens). Desktop Microsoft is now GCIP-BROKERED over the loopback; the Azure app
+  (`78465f4b-…`) needs the four `http://localhost:<8975-8978>/auth/callback` URIs
+  on its **Web** platform (login.live.com matches exactly; Entra's Web platform
+  only allows plain http for `localhost`). See `knowledge-base/auth.md` →
+  "Microsoft — desktop".
 - **[HIGH — coord] Gateway verifier.** The issuer/JWKS swap to Firebase is a `cloud`
   Go change + `cloud/INTEGRATION.md`; the gateway must accept Firebase tokens before or
   with the client cutover. The email-OTP `POST /v1/auth/email-otp/{start,verify}`

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -58,36 +58,63 @@ the desktop bundle ships **zero** firebase-js-sdk). Every failure becomes a type
 `IdentityError`; user-initiated calls emit the `.code` on the auth-error bus AND
 rethrow (see "Error surfacing").
 
-### Google / Microsoft — desktop (loopback + PKCE → GCIP REST)
+### Google — desktop (loopback + PKCE → GCIP REST)
 
 ```
-User clicks "Continue with Google" (or Microsoft) in SignInScreen
- → auth.ts signInWithGoogle() / signInWithMicrosoft():
+User clicks "Continue with Google" in SignInScreen
+ → auth.ts signInWithGoogle():
     1. runLoopbackAuthorize(): mint PKCE verifier + CSRF state,
        osStartOauthLoopback(state) → { status, redirectUri: 127.0.0.1:
-       <8975-8978>/auth/callback, attemptId } ("superseded" → benign null),
-       open the provider authorize URL in the SYSTEM browser (onBrowserOpened()
-       frees the sign-in buttons the instant it opens; a 15s deadline bounds
-       everything up to that point, releasing a late listener if it wins)
+       <8975-8978>/auth/callback, port, attemptId } ("superseded" → benign
+       null), open the provider authorize URL in the SYSTEM browser
+       (onBrowserOpened() frees the sign-in buttons the instant it opens; a
+       15s deadline bounds everything up to that point, releasing a late
+       listener if it wins)
  → provider consent in the system browser
  → 302 → 127.0.0.1:<port>/auth/callback?code=…&state=…
  → oauth_loopback/ matches the state, emits `auth://deep-link`, brings the
    window front (a foreign state gets the stale page and we keep listening)
  → oauth-callback.ts parseCallbackUrl(): validate CSRF `state` FIRST, then code
-    2. exchange code at the provider token endpoint (google-authorize.ts /
-       microsoft-authorize.ts) → provider id_token (Google also sends its
-       installed-app client_secret; Microsoft is a public PKCE client, no secret)
+    2. exchange code at Google's token endpoint (google-authorize.ts; the
+       installed-app client_secret rides along — Google's "Desktop app"
+       clients require it even though they are non-confidential)
     3. firebase-rest.ts signInWithIdp({ providerId, idToken }) → Firebase session
     4. session-from-idp.ts assembles the Session; saveSession() → Keychain;
        cacheSession() flips the gate; startProactiveRefresh(); PostHog track
        (steps 3-4 live in sign-in-establish.ts)
 ```
 
+### Microsoft — desktop (GCIP-BROKERED over the loopback, HOU-1112)
+
+Microsoft can NOT run the Google-style client-side exchange, for two
+independently fatal reasons (both verified live):
+
+* Entra refuses a public-client code redemption made from a webview — the
+  fetch carries an `Origin` header (`http://tauri.localhost` on Windows), and
+  **AADSTS90023** restricts cross-origin redemption to SPA registrations.
+* GCIP refuses Microsoft tokens it did not obtain itself:
+  `signInWithIdp({ id_token | access_token })` for `microsoft.com` always
+  fails with `INVALID_CREDENTIAL_OR_PROVIDER_ID`, with or without a nonce.
+
+So the desktop uses the GCIP-brokered shape instead (`brokered-loopback.ts` +
+`microsoft-authorize.ts`): for each candidate port, `createAuthUri` mints the
+Entra authorize URL for `continueUri = http://localhost:<port>/auth/callback`
+(GCIP owns the CSRF `state`), `osStartOauthLoopback(state, exactPort)` binds
+EXACTLY that port (`portBusy` → re-mint for the next candidate), and after the
+loopback catches the redirect, `signInWithIdpSession({ requestUri, sessionId })`
+lets GCIP redeem the code SERVER-SIDE with the client secret from the identity
+project's provider config. No Microsoft client id or secret ships in the app.
+
 The loopback ports `8975-8978` must be **Authorized redirect URIs** on the
-**Desktop OAuth client** (Google) / Azure app registration (Microsoft). The Rust
-loopback (`app/src-tauri/src/oauth_loopback/`) forwards `?code=&state=` verbatim
-on the `auth://deep-link` event and never sees the client secret or does a token
-exchange (TS owns both).
+**Desktop OAuth client** as `http://127.0.0.1:<port>/auth/callback` (Google)
+and on the Azure app registration's **Web** platform as
+`http://localhost:<port>/auth/callback` (Microsoft — Entra only allows plain
+http on the Web platform for `localhost`, and login.live.com matches exactly,
+no port-agnostic loopback). The Rust loopback
+(`app/src-tauri/src/oauth_loopback/`) binds BOTH `127.0.0.1` and `::1` (a
+browser resolving `localhost` may pick IPv6), forwards `?code=&state=` verbatim
+on the `auth://deep-link` event, and never sees a client secret or does a token
+exchange.
 
 **The loopback is attempt-scoped** (`oauth_loopback/`: `mod.rs` commands,
 `state.rs` registry, `listener.rs` bind/supersede, `callback.rs` serve loop,

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -11,7 +11,6 @@ declare const __FIREBASE_AUTH_DOMAIN__: string;
 declare const __FIREBASE_PROJECT_ID__: string;
 declare const __GOOGLE_DESKTOP_CLIENT_ID__: string;
 declare const __GOOGLE_DESKTOP_CLIENT_SECRET__: string;
-declare const __MICROSOFT_DESKTOP_CLIENT_ID__: string;
 declare const __HOUSTON_AUTH_STORAGE_MODE__: string;
 declare const __HOUSTON_AUTH_STORAGE_SCOPE__: string;
 declare const __SENTRY_DSN__: string;

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -107,9 +107,6 @@ export default defineConfig(({ mode }) => {
       __GOOGLE_DESKTOP_CLIENT_SECRET__: JSON.stringify(
         env.GOOGLE_DESKTOP_CLIENT_SECRET ?? "",
       ),
-      __MICROSOFT_DESKTOP_CLIENT_ID__: JSON.stringify(
-        env.MICROSOFT_DESKTOP_CLIENT_ID ?? "",
-      ),
       __HOUSTON_AUTH_STORAGE_MODE__: JSON.stringify("browser"),
       __HOUSTON_AUTH_STORAGE_SCOPE__: JSON.stringify("web"),
       __SENTRY_DSN__: JSON.stringify(env.SENTRY_DSN ?? ""),


### PR DESCRIPTION
Fixes HOU-1112 (Can't login with Microsoft).

## Root cause

Three stacked problems, the first two config, the third architectural:

1. The Azure app registration was missing the desktop loopback redirect URIs entirely (later found registered as `http://localhost:<port>` with no path under the wrong platform) — every sign-in died at `AADSTS50011` / login.live.com `redirect_uri is not valid`. Fixed in the Azure portal.
2. Even with the redirect fixed, the app-side token exchange fails inside the webview: the fetch carries an `Origin` header (`http://tauri.localhost` on Windows WebView2), and Entra's **AADSTS90023** restricts cross-origin public-client redemption to SPA registrations.
3. Even with a successful token exchange, **GCIP refuses externally obtained Microsoft tokens**: `signInWithIdp({id_token|access_token})` for `microsoft.com` always returns `INVALID_CREDENTIAL_OR_PROVIDER_ID` — verified with real, valid tokens in every permutation (with/without nonce, each token alone or together, any requestUri). The direct flow as shipped could never have worked.

## Fix

Desktop Microsoft sign-in now uses the **GCIP-brokered** shape (same family as Apple, but over the loopback since Entra accepts localhost redirects):

- `createAuthUri` mints the Entra authorize URL for `continueUri = http://localhost:<port>/auth/callback`, carrying GCIP's own CSRF `state`
- the native loopback catches the redirect; `signInWithIdpSession({requestUri, sessionId})` lets GCIP redeem the code **server-side** with the client secret from the identity project's provider config
- the app no longer talks to Microsoft's token endpoint at all, and no Microsoft client id/secret ships in the app (`MICROSOFT_DESKTOP_CLIENT_ID` define removed)

Because GCIP's state only exists after minting and minting needs the port, the driver mints per candidate port and binds **exactly** that port: `start_oauth_loopback` gains `exact_port` + a `PortBusy` outcome (step + re-mint). The listener now binds **both** loopback stacks (`127.0.0.1` and `::1`) since browsers may resolve `localhost` to IPv6; a v6-only squatter counts as busy.

Also fixes the diagnostics gap that made this invisible: `guardAuthCall` now logs the failed sign-in's `code`/`rawCode`/`httpStatus` to frontend.log (the UI collapses errors into copy buckets, so failures previously left zero trace anywhere).

## Azure / GCIP config (already applied)

- Azure app `78465f4b-…` → Authentication → **Web** platform: `http://localhost:8975/auth/callback` … `:8978` (Entra only allows plain http on the Web platform for `localhost`; login.live.com matches exactly, no port-agnostic loopback)
- Identity Platform `microsoft.com` provider: enabled, same client id + secret (terraform `identity.tf`, unchanged)
- The `http://127.0.0.1:<port>` entries under "Mobile and desktop applications" are no longer used by anything and can be removed once this ships

## Repro (before)

Desktop app → Continue with Microsoft → personal account fails right after the email step ("We're unable to complete your request / invalid_request: redirect_uri is not valid"); after the portal fix, sign-in completed at Microsoft but the app showed "Sign-in isn't set up correctly. Please contact support." (token POST 400 / GCIP rejection, nothing logged).

## Verification (after)

- The exact brokered sequence (createAuthUri → localhost loopback → signInWithIdpSession) was validated **end-to-end against production GCIP + Entra with a real personal Microsoft account** before implementation: GCIP session established, `provider=microsoft.com`.
- `cargo test --lib` 210 pass (new: exact-port busy, v6-only squatter busy, dual-stack bind/accept)
- `cd app && pnpm test` 2672 pass (new: `identity-brokered-loopback.test.ts` — port stepping + re-mint, supersession, missing-state refusal, provider-error, cancel frees the port)
- `pnpm check`, `pnpm typecheck` (workspace), web shim parity, `pnpm check:boundaries` all green
- Manual after merge: desktop app → Continue with Microsoft → personal and work accounts both land signed in; retry/cancel paths keep freeing ports (re-click works)