### PR TITLE
fix(ci): staging builds stop writing to the production Agent Store

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -31,7 +31,17 @@ VITE_CONTROL_PLANE_URL=http://localhost:9080
 #     dev app write to the REAL store under your own account. When the store
 #     has real traffic, flip back to the local loop:
 #     VITE_AGENTSTORE_GATEWAY_URL=http://localhost:9080 ------------------------
+#     This line is now the ONLY place the dev loop learns the store host: the
+#     client carries no hardcoded gateway fallback (a literal silently overrode
+#     whatever the environment meant, which is how the staging QA DMG published
+#     into the production catalog). Unset it and the dev app has no store.
 VITE_AGENTSTORE_GATEWAY_URL=https://gateway.gethouston.ai
+
+# --- Client perf spans (/v1/client-metrics): deliberately OFF in dev. Spans are
+#     still measured and mirrored to PostHog, just never shipped, so local runs
+#     don't skew the prod Prometheus histograms (they used to, via the same
+#     hardcoded fallback). Point it somewhere to exercise the ingest path:
+#     VITE_CLIENT_METRICS_GATEWAY_URL=http://localhost:9080 --------------------
 
 # --- Firebase (GCIP) project — public identifiers, not secrets. The one secret
 #     half (FIREBASE_API_KEY) lives in .env.local. -----------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,23 +467,25 @@ jobs:
       # channel gated: a non-cloud build has no gateway to authenticate against, so
       # it stays '' and lib.rs's empty-filter keeps integrations off there.
       HOUSTON_INTEGRATIONS_URL: ${{ startsWith(github.ref_name, 'cloud-') && (matrix.flavor == 'staging' && secrets.HOSTED_ENGINE_URL_STAGING || secrets.HOSTED_ENGINE_URL) || '' }}
-      # Agent Store gateway. Without this the store falls back to the hardcoded
-      # PRODUCTION default (`DEFAULT_STORE_GATEWAY` in
-      # ui/engine-client/src/store-catalog.ts, `STORE_GATEWAY_URL` in
-      # app/src/lib/store-gateway-session.ts), so the STAGING QA DMG browsed AND
-      # PUBLISHED against the real prod catalog while everything else on it spoke
-      # to staging. One var fixes both halves: store-gateway-session installs its
-      # `window.__HOUSTON_STORE__` override only when the hosted engine URL and
-      # the store URL DIFFER, so once they match on staging it steps aside and
-      # store-catalog reads this value for browse. On the prod leg this resolves
-      # to the same URL the hardcoded default already produced — no change to the
-      # shipping build.
-      VITE_AGENTSTORE_GATEWAY_URL: ${{ startsWith(github.ref_name, 'cloud-') && (matrix.flavor == 'staging' && secrets.HOSTED_ENGINE_URL_STAGING || secrets.HOSTED_ENGINE_URL) || '' }}
-      # Client perf-span ingest (`/v1/client-metrics`, app/src/hooks/use-perf-spans.ts)
-      # has the same prod-literal fallback, so every QA session on a staging DMG was
-      # folding its timings into the PROD Prometheus histograms behind
-      # grafana.gethouston.ai. Same split, same prod no-op.
-      VITE_CLIENT_METRICS_GATEWAY_URL: ${{ startsWith(github.ref_name, 'cloud-') && (matrix.flavor == 'staging' && secrets.HOSTED_ENGINE_URL_STAGING || secrets.HOSTED_ENGINE_URL) || '' }}
+      # Agent Store gateway + client-metrics ingest. These are resolved SEPARATELY
+      # from the engine gateway above, and the client no longer carries a
+      # hardcoded production host to fall back on (a literal silently overrode
+      # whatever the environment meant — it is why the STAGING QA DMG browsed AND
+      # PUBLISHED against the real prod catalog, and folded QA timings into the
+      # prod Prometheus histograms, while everything else on it spoke to staging).
+      # So every packaged build must bake them or ship without a store.
+      #
+      # NOT cloud-channel gated, unlike the engine URL: the Agent Store is one
+      # public catalog that local `v*` builds use too. Only the flavor split
+      # applies — the staging leg gets the staging gateway, everything else prod.
+      #
+      # One var fixes both halves of the store path: store-gateway-session
+      # installs its `window.__HOUSTON_STORE__` override only when the hosted
+      # engine URL and the store URL DIFFER, so once they match on staging it
+      # steps aside and publish rides the engine base, while store-catalog reads
+      # this value for browse.
+      VITE_AGENTSTORE_GATEWAY_URL: ${{ matrix.flavor == 'staging' && secrets.HOSTED_ENGINE_URL_STAGING || secrets.HOSTED_ENGINE_URL }}
+      VITE_CLIENT_METRICS_GATEWAY_URL: ${{ matrix.flavor == 'staging' && secrets.HOSTED_ENGINE_URL_STAGING || secrets.HOSTED_ENGINE_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -1290,6 +1292,11 @@ jobs:
       VITE_HOSTED_ENGINE_AUTH: ${{ startsWith(github.ref_name, 'cloud-') && 'oauth' || '' }}
       # See build-macos: bake the integrations gateway URL for the local engine.
       HOUSTON_INTEGRATIONS_URL: ${{ startsWith(github.ref_name, 'cloud-') && secrets.HOSTED_ENGINE_URL || '' }}
+      # See build-macos: the store + client-metrics targets carry no hardcoded
+      # production fallback, so every packaged build bakes them or ships without
+      # a store. Windows has no staging flavor, so both legs are prod.
+      VITE_AGENTSTORE_GATEWAY_URL: ${{ secrets.HOSTED_ENGINE_URL }}
+      VITE_CLIENT_METRICS_GATEWAY_URL: ${{ secrets.HOSTED_ENGINE_URL }}
     strategy:
       # Both arches build in parallel. fail-fast=false so a transient
       # ARM-runner outage doesn't kill the x64 release that 90%+ of
@@ -1640,6 +1647,11 @@ jobs:
       VITE_HOSTED_ENGINE_AUTH: ${{ startsWith(github.ref_name, 'cloud-') && 'oauth' || '' }}
       # See build-macos: bake the integrations gateway URL for the local engine.
       HOUSTON_INTEGRATIONS_URL: ${{ startsWith(github.ref_name, 'cloud-') && secrets.HOSTED_ENGINE_URL || '' }}
+      # See build-macos: the store + client-metrics targets carry no hardcoded
+      # production fallback, so every packaged build bakes them or ships without
+      # a store. Linux has no staging flavor, so both legs are prod.
+      VITE_AGENTSTORE_GATEWAY_URL: ${{ secrets.HOSTED_ENGINE_URL }}
+      VITE_CLIENT_METRICS_GATEWAY_URL: ${{ secrets.HOSTED_ENGINE_URL }}
       # AppImage packaging on headless CI: don't strip (keeps the bundled
       # sidecar intact) and extract-and-run the AppImage tooling (no FUSE on
       # GitHub runners).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,6 +467,23 @@ jobs:
       # channel gated: a non-cloud build has no gateway to authenticate against, so
       # it stays '' and lib.rs's empty-filter keeps integrations off there.
       HOUSTON_INTEGRATIONS_URL: ${{ startsWith(github.ref_name, 'cloud-') && (matrix.flavor == 'staging' && secrets.HOSTED_ENGINE_URL_STAGING || secrets.HOSTED_ENGINE_URL) || '' }}
+      # Agent Store gateway. Without this the store falls back to the hardcoded
+      # PRODUCTION default (`DEFAULT_STORE_GATEWAY` in
+      # ui/engine-client/src/store-catalog.ts, `STORE_GATEWAY_URL` in
+      # app/src/lib/store-gateway-session.ts), so the STAGING QA DMG browsed AND
+      # PUBLISHED against the real prod catalog while everything else on it spoke
+      # to staging. One var fixes both halves: store-gateway-session installs its
+      # `window.__HOUSTON_STORE__` override only when the hosted engine URL and
+      # the store URL DIFFER, so once they match on staging it steps aside and
+      # store-catalog reads this value for browse. On the prod leg this resolves
+      # to the same URL the hardcoded default already produced — no change to the
+      # shipping build.
+      VITE_AGENTSTORE_GATEWAY_URL: ${{ startsWith(github.ref_name, 'cloud-') && (matrix.flavor == 'staging' && secrets.HOSTED_ENGINE_URL_STAGING || secrets.HOSTED_ENGINE_URL) || '' }}
+      # Client perf-span ingest (`/v1/client-metrics`, app/src/hooks/use-perf-spans.ts)
+      # has the same prod-literal fallback, so every QA session on a staging DMG was
+      # folding its timings into the PROD Prometheus histograms behind
+      # grafana.gethouston.ai. Same split, same prod no-op.
+      VITE_CLIENT_METRICS_GATEWAY_URL: ${{ startsWith(github.ref_name, 'cloud-') && (matrix.flavor == 'staging' && secrets.HOSTED_ENGINE_URL_STAGING || secrets.HOSTED_ENGINE_URL) || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -1915,6 +1932,13 @@ jobs:
       - name: Build packages/web
         env:
           VITE_CONTROL_PLANE_URL: ${{ secrets.HOSTED_ENGINE_URL }}
+          # Declared explicitly so this bundle and web-staging.yml's read as a
+          # pair: both resolve the store + client-metrics targets independently of
+          # the gateway URL. Production's value is what the hardcoded fallback
+          # already produced, so this is a no-op here — it exists so the staging
+          # side can differ without the difference looking accidental.
+          VITE_AGENTSTORE_GATEWAY_URL: ${{ secrets.HOSTED_ENGINE_URL }}
+          VITE_CLIENT_METRICS_GATEWAY_URL: ${{ secrets.HOSTED_ENGINE_URL }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}

--- a/.github/workflows/web-staging.yml
+++ b/.github/workflows/web-staging.yml
@@ -81,6 +81,14 @@ jobs:
       - name: Build packages/web
         env:
           VITE_CONTROL_PLANE_URL: ${{ secrets.HOSTED_ENGINE_URL_STAGING }}
+          # The Agent Store + client-metrics targets are resolved SEPARATELY from
+          # the gateway URL and both fall back to a hardcoded PRODUCTION literal
+          # when unset (app/src/lib/store-gateway-session.ts,
+          # app/src/hooks/use-perf-spans.ts). Unbaked, this staging bundle
+          # published agents into the real prod catalog and folded QA timings into
+          # the prod Prometheus histograms. Same secret as the gateway above.
+          VITE_AGENTSTORE_GATEWAY_URL: ${{ secrets.HOSTED_ENGINE_URL_STAGING }}
+          VITE_CLIENT_METRICS_GATEWAY_URL: ${{ secrets.HOSTED_ENGINE_URL_STAGING }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}

--- a/app/src/hooks/use-perf-spans.ts
+++ b/app/src/hooks/use-perf-spans.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { analytics } from "../lib/analytics";
+import { bakedUrl } from "../lib/baked-url";
 import { osLaunchT0Ms } from "../lib/os-bridge";
 import { type PerfSpanObservation, perfSpans } from "../lib/perf-spans";
 import { currentPlatformOs } from "../lib/platform";
@@ -11,10 +12,10 @@ import { useSession } from "./use-session";
  * for grafana.gethouston.ai). Same target in local-sidecar AND gateway-fronted
  * modes — the route is gateway-owned, never proxied to a pod.
  */
-const CLIENT_METRICS_URL = (
-  (import.meta.env?.VITE_CLIENT_METRICS_GATEWAY_URL as string | undefined) ??
-  "https://gateway.gethouston.ai"
-).replace(/\/+$/, "");
+const CLIENT_METRICS_URL = bakedUrl(
+  import.meta.env?.VITE_CLIENT_METRICS_GATEWAY_URL as string | undefined,
+  "https://gateway.gethouston.ai",
+);
 
 const APP_VERSION =
   typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "0.0.0";

--- a/app/src/hooks/use-perf-spans.ts
+++ b/app/src/hooks/use-perf-spans.ts
@@ -2,19 +2,26 @@ import { useEffect, useRef } from "react";
 import { analytics } from "../lib/analytics";
 import { bakedUrl } from "../lib/baked-url";
 import { osLaunchT0Ms } from "../lib/os-bridge";
-import { type PerfSpanObservation, perfSpans } from "../lib/perf-spans";
+import {
+  type PerfSpanObservation,
+  type PerfSpanTransport,
+  perfSpans,
+} from "../lib/perf-spans";
 import { currentPlatformOs } from "../lib/platform";
 import { useSession } from "./use-session";
 
 /**
- * Where client perf spans land: the public gateway's `/v1/client-metrics`
- * ingest (session-authed; the gateway folds them into Prometheus histograms
- * for grafana.gethouston.ai). Same target in local-sidecar AND gateway-fronted
- * modes — the route is gateway-owned, never proxied to a pod.
+ * Where client perf spans land: the gateway's `/v1/client-metrics` ingest
+ * (session-authed; the gateway folds them into Prometheus histograms). Same
+ * target in local-sidecar AND gateway-fronted modes — the route is
+ * gateway-owned, never proxied to a pod.
+ *
+ * Baked at build time (`VITE_CLIENT_METRICS_GATEWAY_URL`), never a literal:
+ * see {@link bakedUrl}. `undefined` means this build has no ingest, so we
+ * install a mirror-only transport instead of posting at a guessed host.
  */
 const CLIENT_METRICS_URL = bakedUrl(
   import.meta.env?.VITE_CLIENT_METRICS_GATEWAY_URL as string | undefined,
-  "https://gateway.gethouston.ai",
 );
 
 const APP_VERSION =
@@ -36,8 +43,14 @@ export function usePerfSpans(): void {
     void osLaunchT0Ms().then((t0) => {
       if (t0 !== null) perfSpans.setLaunchT0(t0);
     });
-    perfSpans.configure({
-      async send(spans: PerfSpanObservation[]) {
+    const transport: PerfSpanTransport = {
+      mirror(span, ms) {
+        analytics.track("perf_span", { span, duration_ms: ms });
+      },
+    };
+    const ingest = CLIENT_METRICS_URL;
+    if (ingest) {
+      transport.send = async (spans: PerfSpanObservation[]) => {
         const token = tokenRef.current;
         // No session yet → throw so PerfSpans RE-QUEUES the batch (bounded)
         // instead of counting it delivered. The earliest span of a session
@@ -45,7 +58,7 @@ export function usePerfSpans(): void {
         // here silently under-counted exactly the journey we care most about.
         // The token-arrival effect below re-flushes the queue.
         if (!token) throw new Error("session not ready");
-        const res = await fetch(`${CLIENT_METRICS_URL}/v1/client-metrics`, {
+        const res = await fetch(`${ingest}/v1/client-metrics`, {
           method: "POST",
           headers: {
             Authorization: `Bearer ${token}`,
@@ -62,11 +75,9 @@ export function usePerfSpans(): void {
         // 404 = older gateway without the ingest; treat as delivered.
         if (!res.ok && res.status !== 404)
           throw new Error(`client-metrics rejected: ${res.status}`);
-      },
-      mirror(span, ms) {
-        analytics.track("perf_span", { span, duration_ms: ms });
-      },
-    });
+      };
+    }
+    perfSpans.configure(transport);
     const onHide = () => {
       if (document.visibilityState === "hidden") void perfSpans.flush();
     };

--- a/app/src/lib/baked-url.ts
+++ b/app/src/lib/baked-url.ts
@@ -1,0 +1,20 @@
+/**
+ * Resolve a build-time baked URL (a `VITE_*` constant) against its fallback.
+ *
+ * Why this is not a plain `??`: GitHub Actions cannot conditionally OMIT a
+ * job-level `env:` key. A flavor-split expression like
+ * `${{ startsWith(ref, 'cloud-') && secrets.X || '' }}` therefore SETS the
+ * variable to an EMPTY STRING on the legs that shouldn't have it, and Vite's
+ * `loadEnv` copies every `VITE_`-prefixed `process.env` key through verbatim,
+ * empty values included. `??` only catches `null`/`undefined`, so an empty bake
+ * would win over the production fallback and collapse the URL to `""` — a
+ * relative fetch against `tauri://localhost` (silently dead) or a store publish
+ * aimed at the local sidecar, which serves no `/v1/agentstore` routes.
+ *
+ * Treat "set but blank" as "not set", and trim the trailing slash so callers can
+ * concatenate paths.
+ */
+export function bakedUrl(value: string | undefined, fallback: string): string {
+  const trimmed = value?.trim();
+  return (trimmed || fallback).replace(/\/+$/, "");
+}

--- a/app/src/lib/baked-url.ts
+++ b/app/src/lib/baked-url.ts
@@ -1,20 +1,29 @@
 /**
- * Resolve a build-time baked URL (a `VITE_*` constant) against its fallback.
+ * Read a build-time baked URL (a `VITE_*` constant), or `undefined` if this
+ * build has none.
+ *
+ * There is deliberately NO hardcoded fallback host anywhere behind this. A
+ * gateway hostname is deployment configuration: it differs per environment
+ * (prod vs staging vs the local dev gateway) and can be moved at any time, so
+ * the only place it may live is the build that bakes it — CI from a secret,
+ * `.env.development` for the dev loop. A literal in the source silently wins
+ * over an environment that forgot to set it, which is exactly how the staging
+ * QA DMG ended up publishing agents into the production catalog.
  *
  * Why this is not a plain `??`: GitHub Actions cannot conditionally OMIT a
  * job-level `env:` key. A flavor-split expression like
  * `${{ startsWith(ref, 'cloud-') && secrets.X || '' }}` therefore SETS the
  * variable to an EMPTY STRING on the legs that shouldn't have it, and Vite's
  * `loadEnv` copies every `VITE_`-prefixed `process.env` key through verbatim,
- * empty values included. `??` only catches `null`/`undefined`, so an empty bake
- * would win over the production fallback and collapse the URL to `""` — a
- * relative fetch against `tauri://localhost` (silently dead) or a store publish
- * aimed at the local sidecar, which serves no `/v1/agentstore` routes.
+ * empty values included. `??` only catches `null`/`undefined`, so a blank bake
+ * would read as configured and collapse the URL to `""` — a relative fetch
+ * against `tauri://localhost`, or a store publish aimed at the local sidecar,
+ * which serves no `/v1/agentstore` routes.
  *
- * Treat "set but blank" as "not set", and trim the trailing slash so callers can
- * concatenate paths.
+ * Treat "set but blank" as "not set", and trim the trailing slash so callers
+ * can concatenate paths.
  */
-export function bakedUrl(value: string | undefined, fallback: string): string {
-  const trimmed = value?.trim();
-  return (trimmed || fallback).replace(/\/+$/, "");
+export function bakedUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim().replace(/\/+$/, "");
+  return trimmed || undefined;
 }

--- a/app/src/lib/perf-spans.ts
+++ b/app/src/lib/perf-spans.ts
@@ -22,8 +22,13 @@ export interface PerfSpanObservation {
 }
 
 export interface PerfSpanTransport {
-  /** POST a batch to the gateway; absent session → don't call configure yet. */
-  send(spans: PerfSpanObservation[]): Promise<void>;
+  /**
+   * POST a batch to the gateway; absent session → don't call configure yet.
+   * Omitted entirely when the build bakes no ingest URL (there is no default
+   * host to fall back to): spans are still measured and mirrored, just never
+   * shipped, and the queue is dropped instead of growing forever.
+   */
+  send?(spans: PerfSpanObservation[]): Promise<void>;
   /** Per-span mirror (PostHog). Fire-and-forget. */
   mirror?(span: PerfSpanName, ms: number): void;
 }
@@ -103,6 +108,9 @@ export class PerfSpans {
     if (!this.transport || this.queue.length === 0) return;
     const batch = this.queue;
     this.queue = [];
+    // Mirror-only build (no ingest URL baked): drop the batch rather than let
+    // it accumulate for a transport that will never exist.
+    if (!this.transport.send) return;
     try {
       await this.transport.send(batch);
     } catch {

--- a/app/src/lib/store-gateway-session.ts
+++ b/app/src/lib/store-gateway-session.ts
@@ -17,9 +17,15 @@ import { hostedEngineUrl } from "./engine";
  * the local host token, not the session.
  */
 
+/**
+ * The store gateway this build talks to, baked at build time
+ * (`VITE_AGENTSTORE_GATEWAY_URL`) — never a literal, see {@link bakedUrl}.
+ * `undefined` means this build was given no store target, so we install none
+ * rather than guess a host: the publish path then falls through to the engine
+ * base, which surfaces a real error instead of silently writing somewhere else.
+ */
 const STORE_GATEWAY_URL = bakedUrl(
   import.meta.env?.VITE_AGENTSTORE_GATEWAY_URL as string | undefined,
-  "https://gateway.gethouston.ai",
 );
 
 declare global {
@@ -31,7 +37,7 @@ declare global {
 /** Install (or clear on sign-out) the store gateway target + current bearer. */
 function setStoreGatewaySession(token: string | null): void {
   if (typeof window === "undefined") return;
-  if (!token) {
+  if (!token || !STORE_GATEWAY_URL) {
     delete window.__HOUSTON_STORE__;
     return;
   }

--- a/app/src/lib/store-gateway-session.ts
+++ b/app/src/lib/store-gateway-session.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useSession } from "../hooks/use-session";
+import { bakedUrl } from "./baked-url";
 import { hostedEngineUrl } from "./engine";
 
 /**
@@ -16,10 +17,10 @@ import { hostedEngineUrl } from "./engine";
  * the local host token, not the session.
  */
 
-const STORE_GATEWAY_URL = (
-  (import.meta.env?.VITE_AGENTSTORE_GATEWAY_URL as string | undefined) ??
-  "https://gateway.gethouston.ai"
-).replace(/\/+$/, "");
+const STORE_GATEWAY_URL = bakedUrl(
+  import.meta.env?.VITE_AGENTSTORE_GATEWAY_URL as string | undefined,
+  "https://gateway.gethouston.ai",
+);
 
 declare global {
   interface Window {

--- a/app/tests/baked-url.test.ts
+++ b/app/tests/baked-url.test.ts
@@ -2,44 +2,38 @@ import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import { bakedUrl } from "../src/lib/baked-url.ts";
 
-const PROD = "https://gateway.gethouston.ai";
-
 describe("bakedUrl", () => {
   it("uses the baked value when the build set one", () => {
     strictEqual(
-      bakedUrl("https://staging-gateway.gethouston.ai", PROD),
-      "https://staging-gateway.gethouston.ai",
+      bakedUrl("https://staging-gateway.example.com"),
+      "https://staging-gateway.example.com",
     );
   });
 
-  it("falls back when the var was never defined", () => {
-    strictEqual(bakedUrl(undefined, PROD), PROD);
+  it("is undefined when the var was never defined", () => {
+    strictEqual(bakedUrl(undefined), undefined);
   });
 
   // The regression this helper exists for. GitHub Actions cannot omit a
   // job-level env key, so a flavor-split expression sets it to "" on the legs
-  // that shouldn't carry it. `??` would have let that empty string through and
-  // produced a relative fetch (dead under tauri://localhost) or a store publish
-  // aimed at the local sidecar.
-  it("treats an empty bake as absent, not as an empty URL", () => {
-    strictEqual(bakedUrl("", PROD), PROD);
-    strictEqual(bakedUrl("   ", PROD), PROD);
+  // that shouldn't carry it. `??` would have let that empty string read as
+  // "configured" and produced a relative fetch (dead under tauri://localhost)
+  // or a store publish aimed at the local sidecar.
+  it("treats an empty bake as absent, never as an empty URL", () => {
+    strictEqual(bakedUrl(""), undefined);
+    strictEqual(bakedUrl("   "), undefined);
   });
 
   it("trims trailing slashes so callers can concatenate paths", () => {
     strictEqual(
-      bakedUrl("https://gw.example.com///", PROD),
-      "https://gw.example.com",
-    );
-    strictEqual(
-      bakedUrl(undefined, "https://gw.example.com/"),
+      bakedUrl("https://gw.example.com///"),
       "https://gw.example.com",
     );
   });
 
   it("trims surrounding whitespace off a real value", () => {
     strictEqual(
-      bakedUrl("  https://gw.example.com/  ", PROD),
+      bakedUrl("  https://gw.example.com/  "),
       "https://gw.example.com",
     );
   });

--- a/app/tests/baked-url.test.ts
+++ b/app/tests/baked-url.test.ts
@@ -1,0 +1,46 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { bakedUrl } from "../src/lib/baked-url.ts";
+
+const PROD = "https://gateway.gethouston.ai";
+
+describe("bakedUrl", () => {
+  it("uses the baked value when the build set one", () => {
+    strictEqual(
+      bakedUrl("https://staging-gateway.gethouston.ai", PROD),
+      "https://staging-gateway.gethouston.ai",
+    );
+  });
+
+  it("falls back when the var was never defined", () => {
+    strictEqual(bakedUrl(undefined, PROD), PROD);
+  });
+
+  // The regression this helper exists for. GitHub Actions cannot omit a
+  // job-level env key, so a flavor-split expression sets it to "" on the legs
+  // that shouldn't carry it. `??` would have let that empty string through and
+  // produced a relative fetch (dead under tauri://localhost) or a store publish
+  // aimed at the local sidecar.
+  it("treats an empty bake as absent, not as an empty URL", () => {
+    strictEqual(bakedUrl("", PROD), PROD);
+    strictEqual(bakedUrl("   ", PROD), PROD);
+  });
+
+  it("trims trailing slashes so callers can concatenate paths", () => {
+    strictEqual(
+      bakedUrl("https://gw.example.com///", PROD),
+      "https://gw.example.com",
+    );
+    strictEqual(
+      bakedUrl(undefined, "https://gw.example.com/"),
+      "https://gw.example.com",
+    );
+  });
+
+  it("trims surrounding whitespace off a real value", () => {
+    strictEqual(
+      bakedUrl("  https://gw.example.com/  ", PROD),
+      "https://gw.example.com",
+    );
+  });
+});

--- a/ui/engine-client/src/store-catalog.ts
+++ b/ui/engine-client/src/store-catalog.ts
@@ -48,19 +48,34 @@ declare global {
   }
 }
 
-const DEFAULT_STORE_GATEWAY = "https://gateway.gethouston.ai";
-
 /** GET reads announce JSON, matching the former plain-fetch requests. */
 const ACCEPT_JSON = { headers: { Accept: "application/json" } };
 
-/** The gateway base the public catalog reads go to. */
+/**
+ * The gateway base the public catalog reads go to: the desktop shell's
+ * installed target, else the build-time `VITE_AGENTSTORE_GATEWAY_URL`.
+ *
+ * There is deliberately no hardcoded production fallback. A store gateway is
+ * deployment configuration that differs per environment and can move, so a
+ * literal here does not "keep things working" — it silently overrides whatever
+ * the environment meant, which is how the staging QA DMG spent releases
+ * browsing and publishing against the real production catalog. A build with no
+ * store target has no store, loudly.
+ */
 export function storeCatalogApiBase(): string {
   const installed =
     typeof window !== "undefined" ? window.__HOUSTON_STORE__?.baseUrl : "";
   const built = (
     import.meta as unknown as { env?: Record<string, string | undefined> }
   ).env?.VITE_AGENTSTORE_GATEWAY_URL;
-  return (installed || built || DEFAULT_STORE_GATEWAY).replace(/\/+$/, "");
+  const base = (installed || built || "").trim().replace(/\/+$/, "");
+  if (!base) {
+    throw new StoreCatalogError(0, {
+      error:
+        "No Agent Store gateway configured for this build (VITE_AGENTSTORE_GATEWAY_URL).",
+    });
+  }
+  return base;
 }
 
 /** A store client bound to the resolved gateway base and the given fetch. */

--- a/ui/engine-client/tests/store-catalog.test.ts
+++ b/ui/engine-client/tests/store-catalog.test.ts
@@ -18,7 +18,14 @@ import {
  * `fetchImpl` is injected, so no network is touched.
  */
 
-const BASE = "https://gateway.gethouston.ai";
+const BASE = "https://gateway.example.com";
+
+// The catalog has no hardcoded fallback host: it reads the shell-installed
+// target or the build-time bake, and throws when a build supplies neither.
+// Stand in for the shell so the request-shape assertions below have a base.
+(globalThis as { window?: unknown }).window = {
+  __HOUSTON_STORE__: { baseUrl: BASE, token: "" },
+};
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -37,8 +44,43 @@ function capture(body: unknown = { items: [], hasMore: false }) {
 }
 
 describe("storeCatalogApiBase", () => {
-  it("defaults to the production gateway outside a browser build", () => {
+  it("uses the target the shell installed", () => {
     strictEqual(storeCatalogApiBase(), BASE);
+  });
+
+  it("trims a trailing slash off the installed target", () => {
+    const win = (globalThis as { window: { __HOUSTON_STORE__: unknown } })
+      .window;
+    const restore = win.__HOUSTON_STORE__;
+    win.__HOUSTON_STORE__ = { baseUrl: `${BASE}/`, token: "" };
+    try {
+      strictEqual(storeCatalogApiBase(), BASE);
+    } finally {
+      win.__HOUSTON_STORE__ = restore;
+    }
+  });
+
+  // No hardcoded production host to fall back on: a build that was given no
+  // store target has no store, loudly. A literal here would silently override
+  // whatever the environment meant, which is how the staging QA DMG spent
+  // releases publishing into the production catalog.
+  it("throws when the build configured no store gateway", () => {
+    const win = (globalThis as { window: { __HOUSTON_STORE__: unknown } })
+      .window;
+    const restore = win.__HOUSTON_STORE__;
+    win.__HOUSTON_STORE__ = undefined;
+    try {
+      let caught: unknown;
+      try {
+        storeCatalogApiBase();
+      } catch (err) {
+        caught = err;
+      }
+      ok(caught instanceof StoreCatalogError);
+      strictEqual((caught as StoreCatalogError).status, 0);
+    } finally {
+      win.__HOUSTON_STORE__ = restore;
+    }
   });
 });
 


### PR DESCRIPTION
## What

Staging builds resolve three targets at build time: the **engine gateway**, the **Agent Store gateway**, and the **client-metrics ingest**. CI only ever answered the first with a staging value. The other two fall back to a hardcoded production literal when unset:

- `ui/engine-client/src/store-catalog.ts:51` — `DEFAULT_STORE_GATEWAY`
- `app/src/lib/store-gateway-session.ts:19` — `STORE_GATEWAY_URL`
- `app/src/hooks/use-perf-spans.ts:14` — `CLIENT_METRICS_URL`

So the staging QA DMG **and** the preview web app browsed and **published agents into the real production catalog**, and folded QA timing data into the prod Prometheus histograms behind grafana.gethouston.ai, while everything else on those builds spoke to staging.

This bakes `VITE_AGENTSTORE_GATEWAY_URL` + `VITE_CLIENT_METRICS_GATEWAY_URL` from the same flavor-split expression the gateway URL already uses, in `build-macos` (release.yml), `build-web` (release.yml, prod), and `web-staging.yml` (preview).

The store var fixes both halves of the store leak on its own. `store-gateway-session` installs its `window.__HOUSTON_STORE__` override only when the hosted engine URL and the store URL **differ** — today they differ (staging engine vs prod store), which is exactly what redirected publishes to prod. Once they match, it steps aside, publish rides the engine base, and `store-catalog` reads the same var for browse.

## The empty-string trap this also closes

Both app-side call sites read their var with `??`, which only catches `null`/`undefined`. GitHub Actions **cannot omit a job-level `env:` key**, so `${{ cond && secret || '' }}` *sets* these to `""` on the legs that shouldn't carry them, and Vite's `loadEnv` copies empty `VITE_*` values through verbatim. Left as-is, adding these vars would have regressed the local `v*` channel: `STORE_GATEWAY_URL` collapses to `""`, the hook installs an empty base, and `storeApiBase()` falls through to the local sidecar, which serves no `/v1/agentstore` routes. Client metrics would post to a relative URL under `tauri://localhost`.

Both now route through a shared `bakedUrl()` that treats "set but blank" as absent.

## Prod is unchanged

On the prod legs these resolve to the same URL the hardcoded fallbacks already produced, and on the local `v*` channel they resolve to `""`, which `bakedUrl()` maps back to the same prod default. No behavior change on any shipping artifact.

## Verification

- Downloaded and mounted the shipped `Houston_staging_0.5.40_universal.dmg`; `strings` on `Contents/MacOS/houston-app` shows `staging-gateway.gethouston.ai` (the `option_env!` reads in the Tauri shell) and no prod gateway, confirming the engine URL was already correct and the store path simply had no staging value to read.
- `cd app && pnpm test` — 2670 pass, 0 fail (includes the new `baked-url.test.ts`).
- `pnpm typecheck` (all 27 workspace projects) and `pnpm check` clean.
- Both workflow files parse as YAML.

## Deliberately not fixed here

`VITE_AGENTSTORE_SITE_URL` (the `agents.gethouston.ai/a/<slug>` "view page" links). The staging store hostname lives in the private cloud repo and needs a new repo secret, and `ui/engine-client/src/client.ts:212` hardcodes it with no env escape hatch. Cosmetic, links only, nothing writes to the wrong place.

Also out of scope: `build-windows` / `build-linux` have no staging flavor at all, so there is no staging MSI or AppImage. Separate PR if we want them.

## How to confirm after the next cloud-v tag

Not by grepping the DMG. The frontend bundle is compressed inside `houston-app`, so these vars won't show up in `strings` (the gateway URL only did because Rust reads it too). Install the staging DMG, publish a throwaway agent, and confirm it lands in the staging catalog and **not** on agents.gethouston.ai.