### PR TITLE
feat(skills): agent-created skills land in the workspace store by default (HOU-1192)

### DIFF
--- a/app/src/components/skills-view/global-skill-chat.tsx
+++ b/app/src/components/skills-view/global-skill-chat.tsx
@@ -76,8 +76,29 @@ export function GlobalSkillChat({
     );
   }
   if (selected?.kind === "skill") {
-    const skill = skills?.find((s) => s.name === selected.slug);
-    if (!skill) return null;
+    // The claimed skill may have just left the agent-LOCAL list this prop
+    // carries: the org-share default (HOU-1192) moves a freshly created skill
+    // into the workspace store moments after the claim. The conversation must
+    // survive that move, so a miss falls back to a minimal row — the chat
+    // resolves its activity by the durable reverse stamp anyway.
+    const skill: SkillSummary = skills?.find(
+      (s) => s.name === selected.slug,
+    ) ?? {
+      name: selected.slug,
+      title: null,
+      description: "",
+      version: 1,
+      tags: [],
+      created: null,
+      last_used: null,
+      category: null,
+      featured: false,
+      integrations: [],
+      image: null,
+      setup_activity_id: null,
+      inputs: [],
+      prompt_template: null,
+    };
     return (
       <SkillSetupChat
         agent={agent}

--- a/app/src/components/tabs/use-org-skill-default.ts
+++ b/app/src/components/tabs/use-org-skill-default.ts
@@ -16,7 +16,6 @@ import {
   tauriSkillsManifest,
 } from "../../lib/tauri";
 import type { Agent } from "../../lib/types";
-import { useAgentStore } from "../../stores/agents";
 import { useUIStore } from "../../stores/ui";
 import { useWorkspaceStore } from "../../stores/workspaces";
 
@@ -26,10 +25,10 @@ import { useWorkspaceStore } from "../../stores/workspaces";
 const inFlight = new Set<string>();
 
 /** Per-agent serialization of THIS module's manifest read-modify-writes: two
- *  skills finishing their create chats concurrently must not race each
- *  other's GET → PUT and drop a slug (last-writer-wins). Other surfaces'
- *  manifest writers keep their own existing GET → PUT pattern; this queue
- *  only closes the race the org-share default itself introduces. */
+ *  skills finishing their create chats concurrently on the same agent must
+ *  not race each other's GET → PUT and drop a slug (last-writer-wins). Other
+ *  surfaces' manifest writers keep their own existing GET → PUT pattern; this
+ *  queue only closes the race the org-share default itself introduces. */
 const manifestQueues = new Map<string, Promise<void>>();
 function enqueueManifestWrite(
   path: string,
@@ -45,17 +44,17 @@ function enqueueManifestWrite(
 /**
  * Org skill by default (HOU-1192): returns the fire-and-forget callback the
  * claim sites invoke with a freshly agent-created skill's slug. On shared-
- * store deployments it moves the skill to the workspace store and enables it
- * for every agent (`lib/org-skill-share.ts` owns the flow + ordering); where
- * the store is absent or declines, the skill stays agent-local exactly as
- * before, so the callback is safe to call unconditionally.
+ * store deployments it moves the skill to the workspace store and installs
+ * it to the ONE agent that built it (`lib/org-skill-share.ts` owns the flow
+ * + ordering) — the other agents see it in the store, ready for the user to
+ * enable. Where the store is absent or declines, the skill stays agent-local
+ * exactly as before, so the callback is safe to call unconditionally.
  */
 export function useOrgSkillDefault(agent: Agent): (slug: string) => void {
   const { t } = useTranslation("skills");
   const queryClient = useQueryClient();
   const { capabilities } = useCapabilities();
   const workspaceId = useWorkspaceStore((s) => s.current?.id ?? null);
-  const agents = useAgentStore((s) => s.agents);
   const addToast = useUIStore((s) => s.addToast);
   // Optimistic while capabilities are still loading (`null`): the claim is a
   // one-shot signal, so deferring would drop it forever on a startup race.
@@ -70,7 +69,6 @@ export function useOrgSkillDefault(agent: Agent): (slug: string) => void {
       const key = `${workspaceId}/${slug}`;
       if (inFlight.has(key)) return;
       inFlight.add(key);
-      const agentPaths = agents.map((a) => a.folderPath);
       shareNewSkillToWorkspace(
         {
           loadLocalContent: async (path, name) => {
@@ -114,7 +112,7 @@ export function useOrgSkillDefault(agent: Agent): (slug: string) => void {
           },
           deleteLocal: (path, name) => tauriSkills.delete(path, name),
         },
-        { workspaceId, creatorPath: agent.folderPath, agentPaths, slug },
+        { workspaceId, creatorPath: agent.folderPath, slug },
       )
         .then((result) => {
           if (result.outcome !== "shared") {
@@ -126,26 +124,26 @@ export function useOrgSkillDefault(agent: Agent): (slug: string) => void {
           queryClient.invalidateQueries({
             queryKey: queryKeys.sharedSkills(workspaceId),
           });
-          for (const path of agentPaths) {
-            queryClient.invalidateQueries({
-              queryKey: queryKeys.skillsManifest(path),
-            });
-            queryClient.invalidateQueries({ queryKey: queryKeys.skills(path) });
-            queryClient.invalidateQueries({ queryKey: ["skill-detail", path] });
-          }
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.skillsManifest(agent.folderPath),
+          });
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.skills(agent.folderPath),
+          });
+          queryClient.invalidateQueries({
+            queryKey: ["skill-detail", agent.folderPath],
+          });
           analytics.track("skill_installed", {
             skill_slug: slug,
             source: "org-default",
           });
-          if (result.enableFailures.length === 0) {
-            addToast({ title: t("global.autoShared"), variant: "success" });
+          if (result.creatorEnabled) {
+            addToast({ title: t("global.createdShared"), variant: "success" });
           } else {
-            // Each failed manifest write already toasted its real reason
-            // through call() — a blanket "shared with all your agents"
-            // beside those would contradict them, so only the log ties the
-            // failures to the share.
+            // The failed manifest write already toasted its real reason
+            // through call(); a success toast beside it would contradict it.
             logger.error(
-              `[org-skill] '${slug}' enable failed for ${result.enableFailures.length} agent(s)`,
+              `[org-skill] '${slug}' creator manifest enable failed`,
             );
           }
         })
@@ -156,14 +154,6 @@ export function useOrgSkillDefault(agent: Agent): (slug: string) => void {
         )
         .finally(() => inFlight.delete(key));
     },
-    [
-      advertised,
-      workspaceId,
-      agents,
-      agent.folderPath,
-      queryClient,
-      addToast,
-      t,
-    ],
+    [advertised, workspaceId, agent.folderPath, queryClient, addToast, t],
   );
 }

--- a/app/src/components/tabs/use-org-skill-default.ts
+++ b/app/src/components/tabs/use-org-skill-default.ts
@@ -1,0 +1,169 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useCapabilities } from "../../hooks/use-capabilities";
+import { analytics } from "../../lib/analytics";
+import { logger } from "../../lib/logger";
+import { isMissingSkillError } from "../../lib/missing-skill";
+import {
+  isOrgSkillShareDeclined,
+  shareNewSkillToWorkspace,
+} from "../../lib/org-skill-share";
+import { queryKeys } from "../../lib/query-keys";
+import {
+  tauriSharedSkills,
+  tauriSkills,
+  tauriSkillsManifest,
+} from "../../lib/tauri";
+import type { Agent } from "../../lib/types";
+import { useAgentStore } from "../../stores/agents";
+import { useUIStore } from "../../stores/ui";
+import { useWorkspaceStore } from "../../stores/workspaces";
+
+/** Cross-instance dedupe: the claim can be observed by more than one mounted
+ *  hook (per-agent tab + global chat) — the first observer runs the share,
+ *  the rest see the key and skip. */
+const inFlight = new Set<string>();
+
+/** Per-agent serialization of THIS module's manifest read-modify-writes: two
+ *  skills finishing their create chats concurrently must not race each
+ *  other's GET → PUT and drop a slug (last-writer-wins). Other surfaces'
+ *  manifest writers keep their own existing GET → PUT pattern; this queue
+ *  only closes the race the org-share default itself introduces. */
+const manifestQueues = new Map<string, Promise<void>>();
+function enqueueManifestWrite(
+  path: string,
+  op: () => Promise<void>,
+): Promise<void> {
+  const next = (manifestQueues.get(path) ?? Promise.resolve())
+    .catch(() => {})
+    .then(op);
+  manifestQueues.set(path, next);
+  return next;
+}
+
+/**
+ * Org skill by default (HOU-1192): returns the fire-and-forget callback the
+ * claim sites invoke with a freshly agent-created skill's slug. On shared-
+ * store deployments it moves the skill to the workspace store and enables it
+ * for every agent (`lib/org-skill-share.ts` owns the flow + ordering); where
+ * the store is absent or declines, the skill stays agent-local exactly as
+ * before, so the callback is safe to call unconditionally.
+ */
+export function useOrgSkillDefault(agent: Agent): (slug: string) => void {
+  const { t } = useTranslation("skills");
+  const queryClient = useQueryClient();
+  const { capabilities } = useCapabilities();
+  const workspaceId = useWorkspaceStore((s) => s.current?.id ?? null);
+  const agents = useAgentStore((s) => s.agents);
+  const addToast = useUIStore((s) => s.addToast);
+  // Optimistic while capabilities are still loading (`null`): the claim is a
+  // one-shot signal, so deferring would drop it forever on a startup race.
+  // The wire's own answer closes the no-store path quietly (the classifier's
+  // 404/503 declines); only an explicit `sharedSkills: false` skips.
+  const advertised =
+    capabilities?.sharedSkills !== false && workspaceId !== null;
+
+  return useCallback(
+    (slug: string) => {
+      if (!advertised || workspaceId === null) return;
+      const key = `${workspaceId}/${slug}`;
+      if (inFlight.has(key)) return;
+      inFlight.add(key);
+      const agentPaths = agents.map((a) => a.folderPath);
+      shareNewSkillToWorkspace(
+        {
+          loadLocalContent: async (path, name) => {
+            try {
+              return (await tauriSkills.load(path, name)).content;
+            } catch (err) {
+              if (isMissingSkillError(err)) return null;
+              throw err;
+            }
+          },
+          promote: async (ws, name, content) => {
+            await tauriSharedSkills.promote(ws, name, content, {
+              silence: isOrgSkillShareDeclined,
+            });
+          },
+          enable: (path, name) =>
+            enqueueManifestWrite(path, async () => {
+              const manifest = await tauriSkillsManifest.get(path);
+              const enabled = new Set(manifest.enabled);
+              enabled.add(name);
+              await tauriSkillsManifest.set(path, {
+                version: 1,
+                enabled: [...enabled].sort(),
+              });
+            }),
+          // The delete's SkillsChanged refetch drops the local row from the
+          // merged strip; the shared row must already be in cache by then, or
+          // the ghost-skill deselect closes the open setup chat. Refresh the
+          // two caches the merge reads BEFORE the compare + delete (not
+          // inside deleteLocal — the compare must sit directly against the
+          // delete so a concurrent agent edit has the narrowest window).
+          beforeDelete: async () => {
+            await Promise.all([
+              queryClient.refetchQueries({
+                queryKey: queryKeys.sharedSkills(workspaceId),
+              }),
+              queryClient.refetchQueries({
+                queryKey: queryKeys.skillsManifest(agent.folderPath),
+              }),
+            ]);
+          },
+          deleteLocal: (path, name) => tauriSkills.delete(path, name),
+        },
+        { workspaceId, creatorPath: agent.folderPath, agentPaths, slug },
+      )
+        .then((result) => {
+          if (result.outcome !== "shared") {
+            logger.info(
+              `[org-skill] '${slug}' stayed agent-local (${result.outcome})`,
+            );
+            return;
+          }
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.sharedSkills(workspaceId),
+          });
+          for (const path of agentPaths) {
+            queryClient.invalidateQueries({
+              queryKey: queryKeys.skillsManifest(path),
+            });
+            queryClient.invalidateQueries({ queryKey: queryKeys.skills(path) });
+            queryClient.invalidateQueries({ queryKey: ["skill-detail", path] });
+          }
+          analytics.track("skill_installed", {
+            skill_slug: slug,
+            source: "org-default",
+          });
+          if (result.enableFailures.length === 0) {
+            addToast({ title: t("global.autoShared"), variant: "success" });
+          } else {
+            // Each failed manifest write already toasted its real reason
+            // through call() — a blanket "shared with all your agents"
+            // beside those would contradict them, so only the log ties the
+            // failures to the share.
+            logger.error(
+              `[org-skill] '${slug}' enable failed for ${result.enableFailures.length} agent(s)`,
+            );
+          }
+        })
+        .catch((err) =>
+          // Unexpected failures surfaced (toast + Sentry) through call()
+          // inside the deps; the skill stays agent-local and usable.
+          logger.error(`[org-skill] share of '${slug}' failed: ${err}`),
+        )
+        .finally(() => inFlight.delete(key));
+    },
+    [
+      advertised,
+      workspaceId,
+      agents,
+      agent.folderPath,
+      queryClient,
+      addToast,
+      t,
+    ],
+  );
+}

--- a/app/src/components/tabs/use-skill-chat-setup.ts
+++ b/app/src/components/tabs/use-skill-chat-setup.ts
@@ -22,6 +22,7 @@ import {
 import { tauriActivity } from "../../lib/tauri";
 import type { Agent, SkillSummary } from "../../lib/types";
 import { readAgentRunOverrides } from "./routine-run-overrides";
+import { useOrgSkillDefault } from "./use-org-skill-default";
 
 /**
  * Owns a custom skill's setup chat (HOU-791 — the Automations-tab experience
@@ -41,6 +42,7 @@ export function useSkillChatSetup(
   const queryClient = useQueryClient();
   const { data: rawItems } = useActivity(path);
   const [pending, setPending] = useState(false);
+  const shareNewSkill = useOrgSkillDefault(agent);
 
   const mode = SKILL_SETUP_AGENT_MODE;
   const missionTitle = t("setupChat.missionTitle");
@@ -90,14 +92,20 @@ export function useSkillChatSetup(
     healingRef.current = true;
     tauriActivity
       .update(path, patch.id, patch.update)
-      .then(() =>
-        queryClient.invalidateQueries({ queryKey: queryKeys.activity(path) }),
-      )
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: queryKeys.activity(path) });
+        // A forward-link stamp IS the "agent just created this skill in its
+        // create chat" moment (rule 1 only matches an unstamped chat, so it
+        // fires exactly once per creation) — apply the org-share default
+        // (HOU-1192). Orphan adoption repairs an existing skill's lost chat
+        // and must not share it.
+        if (heal?.reason === "forward_link") shareNewSkill(heal.slug);
+      })
       .catch((err) => logger.error(`[skill-chat] heal failed: ${err}`))
       .finally(() => {
         healingRef.current = false;
       });
-  }, [rawItems, skills, path, queryClient]);
+  }, [rawItems, skills, path, queryClient, shareNewSkill]);
 
   /**
    * Start a brand-new create-chat. Always creates a fresh one — "Create with

--- a/app/src/components/tabs/use-skill-setup-view.ts
+++ b/app/src/components/tabs/use-skill-setup-view.ts
@@ -82,6 +82,11 @@ export function useSkillSetupView(
     const slug = claimNewlyCreatedSkill(prev, skills, chatSetup.activities);
     if (!slug) return;
     setSelected({ kind: "skill", slug });
+    // Deliberately NO org-share default (HOU-1192) here: this claim is a
+    // list-delta heuristic, and the catalog stays interactive beside a draft
+    // chat — a store/GitHub install landing during the chat can satisfy it,
+    // and installs are specified as agent-scoped. Only the heal's forward-
+    // link stamp (provenance the agent itself wrote) triggers the share.
     tauriActivity
       .update(agent.folderPath, activityId, { skill_slug: slug })
       .then(() =>

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -111,8 +111,9 @@ export type AnalyticsEventName =
   | "custom_integration_added"
   | "skill_used"
   // A skill landed in the agent (carries `skill_slug` + `source`:
-  // community / repo / scratch) — adoption of the skills surface itself,
-  // distinct from `skill_used` (execution in chat).
+  // community / repo / scratch / promoted / workspace-enable / org-default) —
+  // adoption of the skills surface itself, distinct from `skill_used`
+  // (execution in chat).
   | "skill_installed"
   | "skill_edited"
   | "skill_deleted"

--- a/app/src/lib/org-skill-share.ts
+++ b/app/src/lib/org-skill-share.ts
@@ -1,0 +1,136 @@
+// Org skill by default (HOU-1192): a skill an agent creates in a
+// create-with-AI chat is promoted into the workspace/org skill store the
+// moment the client detects it, and enabled for every agent via the same
+// explicit per-agent manifest writes ADR 0003 prescribes — shared with the
+// other agents instead of installed to them. Dependency-injected and
+// framework-free so the whole flow is node-testable
+// (app/tests/org-skill-share.test.ts); the hook wrapper
+// (components/tabs/use-org-skill-default.ts) binds it to the engine client.
+
+/**
+ * True when the workspace store DECLINED the promotion for an expected,
+ * explainable reason — feature absence or policy, not a Houston bug:
+ *
+ * - 409: the slug already exists in the store (the agent picked a name a
+ *   workspace skill already uses; the local copy stays and shadows it).
+ * - 403: this user may not write org skills here (Teams: member role — the
+ *   gateway enforces admin-only org-skill writes).
+ * - 404: the deployment predates the shared-skills routes entirely (the
+ *   HOU-1105 rule: a missing route is feature absence, not a bug). The share
+ *   is attempted even while `/v1/capabilities` is still loading — a one-shot
+ *   claim must not be dropped on a startup race — so the wire's own answer
+ *   has to close that path quietly.
+ * - 503 "shared skills not configured": the deployment runs no store.
+ *
+ * On any of these the new skill simply stays agent-local — exactly the
+ * pre-HOU-1192 behavior. Structural on `.status` + body, never on message
+ * strings (the sibling classifiers' rule).
+ */
+export function isOrgSkillShareDeclined(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as { status?: unknown; body?: unknown };
+  if (e.status === 409 || e.status === 403 || e.status === 404) return true;
+  const body = e.body as { error?: unknown } | null;
+  return e.status === 503 && body?.error === "shared skills not configured";
+}
+
+export interface OrgSkillShareDeps {
+  /** The creator's local SKILL.md, or null when no local copy exists. */
+  loadLocalContent(agentPath: string, slug: string): Promise<string | null>;
+  /** "Share to workspace": the full SKILL.md verbatim at the exact slug. */
+  promote(workspaceId: string, slug: string, content: string): Promise<void>;
+  /** Enable the slug in one agent's shared-skills manifest. */
+  enable(agentPath: string, slug: string): Promise<void>;
+  deleteLocal(agentPath: string, slug: string): Promise<void>;
+  /** Runs after the enables and BEFORE the reload/compare/delete of the
+   *  creator's copy (the hook refreshes the caches the merged strip reads
+   *  here). Kept separate from `deleteLocal` so the compare sits directly
+   *  against the delete — anything slow in between widens the window in
+   *  which an agent's concurrent edit could be compared stale. */
+  beforeDelete?(): Promise<void>;
+}
+
+export type OrgSkillShareResult =
+  /** In the store, manifests written; `localDeleted` is false when the
+   *  creator's copy diverged mid-flight (it stays as an override). */
+  | { outcome: "shared"; enableFailures: string[]; localDeleted: boolean }
+  /** The store declined (collision / role / no store) — skill stays local. */
+  | { outcome: "kept-local" }
+  /** No local copy to share (already promoted, or deleted) — nothing to do. */
+  | { outcome: "skipped" };
+
+/**
+ * Promote a freshly agent-created skill to the workspace store and enable it
+ * for every agent. Ordering is load-bearing:
+ *
+ * 1. Promote first — until it succeeds nothing else may move.
+ * 2. Enable the CREATOR's manifest before anything else: the local copy is
+ *    only deleted after the creator can load the shared one, so there is no
+ *    window where the skill exists nowhere for the agent that just built it.
+ * 3. Other agents' manifests in parallel; individual failures are collected,
+ *    never fatal (Teams: some agents may not be manageable by this user).
+ * 4. Delete the local copy only when it is still byte-identical to what was
+ *    promoted AND the creator's enable landed — a copy the agent edited
+ *    mid-flight survives as that agent's override (never data loss).
+ *
+ * Unexpected promote failures are rethrown for the caller's surfacing path;
+ * everything else resolves.
+ */
+export async function shareNewSkillToWorkspace(
+  deps: OrgSkillShareDeps,
+  args: {
+    workspaceId: string;
+    creatorPath: string;
+    /** Every agent in the workspace, creator included. */
+    agentPaths: string[];
+    slug: string;
+  },
+): Promise<OrgSkillShareResult> {
+  const { workspaceId, creatorPath, agentPaths, slug } = args;
+  const content = await deps.loadLocalContent(creatorPath, slug);
+  if (content === null) return { outcome: "skipped" };
+
+  try {
+    await deps.promote(workspaceId, slug, content);
+  } catch (err) {
+    if (isOrgSkillShareDeclined(err)) return { outcome: "kept-local" };
+    throw err;
+  }
+
+  const enableFailures: string[] = [];
+  let creatorEnabled = false;
+  try {
+    await deps.enable(creatorPath, slug);
+    creatorEnabled = true;
+  } catch {
+    enableFailures.push(creatorPath);
+  }
+  const others = agentPaths.filter((p) => p !== creatorPath);
+  const settled = await Promise.allSettled(
+    others.map((path) => deps.enable(path, slug)),
+  );
+  settled.forEach((r, i) => {
+    const path = others[i];
+    if (r.status === "rejected" && path !== undefined)
+      enableFailures.push(path);
+  });
+
+  let localDeleted = false;
+  if (creatorEnabled) {
+    try {
+      await deps.beforeDelete?.();
+      const current = await deps.loadLocalContent(creatorPath, slug);
+      if (current === null) {
+        localDeleted = true; // already gone — nothing shadowing
+      } else if (current === content) {
+        await deps.deleteLocal(creatorPath, slug);
+        localDeleted = true;
+      }
+    } catch {
+      // The shared copy is live and the identical local one shadows it —
+      // harmless; the Skills page shows it as an override the user can drop.
+    }
+  }
+
+  return { outcome: "shared", enableFailures, localDeleted };
+}

--- a/app/src/lib/org-skill-share.ts
+++ b/app/src/lib/org-skill-share.ts
@@ -1,8 +1,9 @@
 // Org skill by default (HOU-1192): a skill an agent creates in a
 // create-with-AI chat is promoted into the workspace/org skill store the
-// moment the client detects it, and enabled for every agent via the same
-// explicit per-agent manifest writes ADR 0003 prescribes — shared with the
-// other agents instead of installed to them. Dependency-injected and
+// moment the client detects it, and enabled ONLY for the agent that built it
+// (one explicit manifest write, per ADR 0003). The other agents are NOT
+// installed to — the skill sits in the workspace store where the user can
+// enable it per agent from the Skills surfaces. Dependency-injected and
 // framework-free so the whole flow is node-testable
 // (app/tests/org-skill-share.test.ts); the hook wrapper
 // (components/tabs/use-org-skill-default.ts) binds it to the engine client.
@@ -51,25 +52,26 @@ export interface OrgSkillShareDeps {
 }
 
 export type OrgSkillShareResult =
-  /** In the store, manifests written; `localDeleted` is false when the
-   *  creator's copy diverged mid-flight (it stays as an override). */
-  | { outcome: "shared"; enableFailures: string[]; localDeleted: boolean }
+  /** In the store; `creatorEnabled` is the creator's one manifest write.
+   *  `localDeleted` is false when the creator's copy diverged mid-flight
+   *  (it stays as an override). */
+  | { outcome: "shared"; creatorEnabled: boolean; localDeleted: boolean }
   /** The store declined (collision / role / no store) — skill stays local. */
   | { outcome: "kept-local" }
   /** No local copy to share (already promoted, or deleted) — nothing to do. */
   | { outcome: "skipped" };
 
 /**
- * Promote a freshly agent-created skill to the workspace store and enable it
- * for every agent. Ordering is load-bearing:
+ * Promote a freshly agent-created skill to the workspace store and install it
+ * to the ONE agent that built it. Other agents are deliberately untouched —
+ * the store row is where the user installs it to them. Ordering is
+ * load-bearing:
  *
  * 1. Promote first — until it succeeds nothing else may move.
- * 2. Enable the CREATOR's manifest before anything else: the local copy is
- *    only deleted after the creator can load the shared one, so there is no
- *    window where the skill exists nowhere for the agent that just built it.
- * 3. Other agents' manifests in parallel; individual failures are collected,
- *    never fatal (Teams: some agents may not be manageable by this user).
- * 4. Delete the local copy only when it is still byte-identical to what was
+ * 2. Enable the CREATOR's manifest: the local copy is only deleted after the
+ *    creator can load the shared one, so there is no window where the skill
+ *    exists nowhere for the agent that just built it.
+ * 3. Delete the local copy only when it is still byte-identical to what was
  *    promoted AND the creator's enable landed — a copy the agent edited
  *    mid-flight survives as that agent's override (never data loss).
  *
@@ -78,15 +80,9 @@ export type OrgSkillShareResult =
  */
 export async function shareNewSkillToWorkspace(
   deps: OrgSkillShareDeps,
-  args: {
-    workspaceId: string;
-    creatorPath: string;
-    /** Every agent in the workspace, creator included. */
-    agentPaths: string[];
-    slug: string;
-  },
+  args: { workspaceId: string; creatorPath: string; slug: string },
 ): Promise<OrgSkillShareResult> {
-  const { workspaceId, creatorPath, agentPaths, slug } = args;
+  const { workspaceId, creatorPath, slug } = args;
   const content = await deps.loadLocalContent(creatorPath, slug);
   if (content === null) return { outcome: "skipped" };
 
@@ -97,23 +93,15 @@ export async function shareNewSkillToWorkspace(
     throw err;
   }
 
-  const enableFailures: string[] = [];
   let creatorEnabled = false;
   try {
     await deps.enable(creatorPath, slug);
     creatorEnabled = true;
   } catch {
-    enableFailures.push(creatorPath);
+    // The failed manifest write surfaced through the caller's path; the
+    // identical local copy stays (no delete below), so the creator keeps
+    // the skill either way.
   }
-  const others = agentPaths.filter((p) => p !== creatorPath);
-  const settled = await Promise.allSettled(
-    others.map((path) => deps.enable(path, slug)),
-  );
-  settled.forEach((r, i) => {
-    const path = others[i];
-    if (r.status === "rejected" && path !== undefined)
-      enableFailures.push(path);
-  });
 
   let localDeleted = false;
   if (creatorEnabled) {
@@ -132,5 +120,5 @@ export async function shareNewSkillToWorkspace(
     }
   }
 
-  return { outcome: "shared", enableFailures, localDeleted };
+  return { outcome: "shared", creatorEnabled, localDeleted };
 }

--- a/app/src/lib/skill-chat-setup.ts
+++ b/app/src/lib/skill-chat-setup.ts
@@ -123,6 +123,11 @@ export type SkillChatHeal = {
   kind: "stamp_activity";
   activityId: string;
   slug: string;
+  /** Which rule produced the heal: `forward_link` is the normal agent-created
+   *  claim (the moment a create-chat's skill first exists — the org-share
+   *  default keys on it, HOU-1192); `orphan_adoption` repairs an existing
+   *  skill's lost chat and must never trigger sharing. */
+  reason: "forward_link" | "orphan_adoption";
 };
 
 /**
@@ -156,7 +161,12 @@ export function findSkillChatHeal(
     const a = acts.find((x) => x.id === s.setup_activity_id);
     // Only stamp an unstamped activity — never reassign one.
     if (a && isSkillSetupMode(a.agent) && !a.skill_slug) {
-      return { kind: "stamp_activity", activityId: a.id, slug: s.name };
+      return {
+        kind: "stamp_activity",
+        activityId: a.id,
+        slug: s.name,
+        reason: "forward_link",
+      };
     }
   }
   if (displayTitle) {
@@ -171,6 +181,7 @@ export function findSkillChatHeal(
           kind: "stamp_activity",
           activityId: orphan.id,
           slug: match.name,
+          reason: "orphan_adoption",
         };
       }
     }

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -855,10 +855,21 @@ export const tauriSharedSkills = {
         content,
       }),
     ),
-  /** "Share to workspace": full SKILL.md verbatim, at the exact slug. */
-  promote: (workspaceId: string, slug: string, content: string) =>
-    call<SkillDetail>("promote_shared_skill", () =>
-      getEngine().promoteSharedSkill(workspaceId, slug, content),
+  /** "Share to workspace": full SKILL.md verbatim, at the exact slug. The
+   *  org-share default (HOU-1192) passes a `silence` classifier for the
+   *  expected declines (collision / role / no store) it degrades on inline;
+   *  the explicit Skills-page action passes none and toasts as before. */
+  promote: (
+    workspaceId: string,
+    slug: string,
+    content: string,
+    options?: EngineCallOptions,
+  ) =>
+    call<SkillDetail>(
+      "promote_shared_skill",
+      () => getEngine().promoteSharedSkill(workspaceId, slug, content),
+      undefined,
+      options,
     ),
   delete: (workspaceId: string, slug: string) =>
     call<void>("delete_shared_skill", () =>

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -201,9 +201,8 @@
     },
     "chatPick": {
       "title": "Who should build it with you?",
-      "description": "The chat runs with this agent. The finished skill is shared with all your agents automatically."
+      "description": "The chat runs with this agent, who also gets the skill. It lands in your workspace, so you can add it to other agents whenever you want."
     },
-    "autoShared": "Skill shared with all your agents",
     "createdShared": "Skill added to your workspace",
     "enabledForAll_one": "Enabled for {{count}} agent",
     "enabledForAll_other": "Enabled for {{count}} agents",

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -201,8 +201,9 @@
     },
     "chatPick": {
       "title": "Who should build it with you?",
-      "description": "The chat runs with this agent, and the skill is created there first. You can share it with other agents afterwards."
+      "description": "The chat runs with this agent. The finished skill is shared with all your agents automatically."
     },
+    "autoShared": "Skill shared with all your agents",
     "createdShared": "Skill added to your workspace",
     "enabledForAll_one": "Enabled for {{count}} agent",
     "enabledForAll_other": "Enabled for {{count}} agents",

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -201,8 +201,9 @@
     },
     "chatPick": {
       "title": "¿Quién la construye contigo?",
-      "description": "El chat se abre con este agente y la skill se crea ahí primero. Después puedes compartirla con otros agentes."
+      "description": "El chat se abre con este agente. La skill terminada se comparte automáticamente con todos tus agentes."
     },
+    "autoShared": "Skill compartida con todos tus agentes",
     "createdShared": "Skill agregada a tu espacio de trabajo",
     "enabledForAll_one": "Activada para {{count}} agente",
     "enabledForAll_other": "Activada para {{count}} agentes",

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -201,9 +201,8 @@
     },
     "chatPick": {
       "title": "¿Quién la construye contigo?",
-      "description": "El chat se abre con este agente. La skill terminada se comparte automáticamente con todos tus agentes."
+      "description": "El chat se abre con este agente, que también recibe la skill. Queda en tu espacio de trabajo, así puedes agregarla a otros agentes cuando quieras."
     },
-    "autoShared": "Skill compartida con todos tus agentes",
     "createdShared": "Skill agregada a tu espacio de trabajo",
     "enabledForAll_one": "Activada para {{count}} agente",
     "enabledForAll_other": "Activada para {{count}} agentes",

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -201,9 +201,8 @@
     },
     "chatPick": {
       "title": "Quem vai construir com você?",
-      "description": "O chat abre com esse agente. A skill pronta é compartilhada automaticamente com todos os seus agentes."
+      "description": "O chat abre com esse agente, que também recebe a skill. Ela fica no seu espaço de trabalho, e você pode adicioná-la a outros agentes quando quiser."
     },
-    "autoShared": "Skill compartilhada com todos os seus agentes",
     "createdShared": "Skill adicionada ao seu espaço de trabalho",
     "enabledForAll_one": "Ativada para {{count}} agente",
     "enabledForAll_other": "Ativada para {{count}} agentes",

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -201,8 +201,9 @@
     },
     "chatPick": {
       "title": "Quem vai construir com você?",
-      "description": "O chat abre com esse agente e a skill é criada nele primeiro. Depois você pode compartilhar com outros agentes."
+      "description": "O chat abre com esse agente. A skill pronta é compartilhada automaticamente com todos os seus agentes."
     },
+    "autoShared": "Skill compartilhada com todos os seus agentes",
     "createdShared": "Skill adicionada ao seu espaço de trabalho",
     "enabledForAll_one": "Ativada para {{count}} agente",
     "enabledForAll_other": "Ativada para {{count}} agentes",

--- a/app/tests/org-skill-share.test.ts
+++ b/app/tests/org-skill-share.test.ts
@@ -1,0 +1,224 @@
+import { deepStrictEqual, rejects, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  isOrgSkillShareDeclined,
+  type OrgSkillShareDeps,
+  shareNewSkillToWorkspace,
+} from "../src/lib/org-skill-share.ts";
+
+// HOU-1192: a skill created with an agent lands in the workspace store by
+// default. The flow must never lose the skill: every failure path leaves it
+// usable somewhere, and the local copy dies only when the creator can already
+// load the shared one and nothing diverged.
+
+/** The shape `HoustonEngineError` carries: the status plus the parsed body. */
+const engineError = (status: number, body: unknown = null) => ({
+  status,
+  body,
+});
+
+const ARGS = {
+  workspaceId: "ws1",
+  creatorPath: "/ws/Creator",
+  agentPaths: ["/ws/Creator", "/ws/Other", "/ws/Third"],
+  slug: "meeting-prep",
+};
+
+/** Recording fake: every dep resolves and appends to `calls`. */
+function makeDeps(overrides?: Partial<OrgSkillShareDeps>) {
+  const calls: string[] = [];
+  const deps: OrgSkillShareDeps = {
+    loadLocalContent: async (path, slug) => {
+      calls.push(`load:${path}:${slug}`);
+      return "---\nname: meeting-prep\n---\nbody";
+    },
+    promote: async (ws, slug) => {
+      calls.push(`promote:${ws}:${slug}`);
+    },
+    enable: async (path, slug) => {
+      calls.push(`enable:${path}:${slug}`);
+    },
+    deleteLocal: async (path, slug) => {
+      calls.push(`delete:${path}:${slug}`);
+    },
+    beforeDelete: async () => {
+      calls.push("beforeDelete");
+    },
+    ...overrides,
+  };
+  return { calls, deps };
+}
+
+describe("isOrgSkillShareDeclined", () => {
+  it("matches the expected declines and nothing else", () => {
+    strictEqual(isOrgSkillShareDeclined(engineError(409)), true);
+    strictEqual(isOrgSkillShareDeclined(engineError(403)), true);
+    // Route absent (pre-shared-skills deployment) = feature absence, the
+    // HOU-1105 rule — the share is attempted before capabilities resolve.
+    strictEqual(isOrgSkillShareDeclined(engineError(404)), true);
+    strictEqual(
+      isOrgSkillShareDeclined(
+        engineError(503, { error: "shared skills not configured" }),
+      ),
+      true,
+    );
+    // A plain 503 (pod waking, real outage) is NOT a decline.
+    strictEqual(isOrgSkillShareDeclined(engineError(503, null)), false);
+    strictEqual(
+      isOrgSkillShareDeclined(engineError(503, { error: "boom" })),
+      false,
+    );
+    strictEqual(isOrgSkillShareDeclined(engineError(500)), false);
+    strictEqual(isOrgSkillShareDeclined(new Error("network down")), false);
+    strictEqual(isOrgSkillShareDeclined(null), false);
+    strictEqual(isOrgSkillShareDeclined("409"), false);
+  });
+});
+
+describe("shareNewSkillToWorkspace", () => {
+  it("happy path: promote, creator first, fan-out, byte-identical delete", async () => {
+    const { calls, deps } = makeDeps();
+    const result = await shareNewSkillToWorkspace(deps, ARGS);
+    deepStrictEqual(result, {
+      outcome: "shared",
+      enableFailures: [],
+      localDeleted: true,
+    });
+    // Ordering: load → promote → creator enable → others → beforeDelete
+    // (cache refresh) → reload → delete, with the reload/compare directly
+    // against the delete so a concurrent edit has the narrowest window.
+    deepStrictEqual(calls, [
+      "load:/ws/Creator:meeting-prep",
+      "promote:ws1:meeting-prep",
+      "enable:/ws/Creator:meeting-prep",
+      "enable:/ws/Other:meeting-prep",
+      "enable:/ws/Third:meeting-prep",
+      "beforeDelete",
+      "load:/ws/Creator:meeting-prep",
+      "delete:/ws/Creator:meeting-prep",
+    ]);
+  });
+
+  it("no local copy → skipped, nothing else touched", async () => {
+    const { calls, deps } = makeDeps({
+      loadLocalContent: async () => null,
+    });
+    deepStrictEqual(await shareNewSkillToWorkspace(deps, ARGS), {
+      outcome: "skipped",
+    });
+    deepStrictEqual(calls, []);
+  });
+
+  it("store declines (collision / role / no store) → kept local, untouched", async () => {
+    for (const err of [
+      engineError(409),
+      engineError(403),
+      engineError(503, { error: "shared skills not configured" }),
+    ]) {
+      const { calls, deps } = makeDeps({
+        promote: async () => {
+          throw err;
+        },
+      });
+      deepStrictEqual(await shareNewSkillToWorkspace(deps, ARGS), {
+        outcome: "kept-local",
+      });
+      deepStrictEqual(calls, ["load:/ws/Creator:meeting-prep"]);
+    }
+  });
+
+  it("unexpected promote failure rethrows for the caller's surfacing", async () => {
+    const { deps } = makeDeps({
+      promote: async () => {
+        throw engineError(500);
+      },
+    });
+    await rejects(() => shareNewSkillToWorkspace(deps, ARGS));
+  });
+
+  it("creator enable failure → no delete (the skill must exist somewhere)", async () => {
+    const { calls, deps } = makeDeps();
+    deps.enable = async (path, slug) => {
+      calls.push(`enable:${path}:${slug}`);
+      if (path === "/ws/Creator") throw new Error("manifest write failed");
+    };
+    const result = await shareNewSkillToWorkspace(deps, ARGS);
+    deepStrictEqual(result, {
+      outcome: "shared",
+      enableFailures: ["/ws/Creator"],
+      localDeleted: false,
+    });
+    strictEqual(
+      calls.some((c) => c.startsWith("delete:")),
+      false,
+    );
+  });
+
+  it("other agents' enable failures are collected, never fatal", async () => {
+    const { deps } = makeDeps();
+    deps.enable = async (path) => {
+      if (path === "/ws/Other") throw new Error("forbidden");
+    };
+    const result = await shareNewSkillToWorkspace(deps, ARGS);
+    deepStrictEqual(result, {
+      outcome: "shared",
+      enableFailures: ["/ws/Other"],
+      localDeleted: true,
+    });
+  });
+
+  it("a copy the agent edited mid-flight survives as an override", async () => {
+    let loads = 0;
+    const { calls, deps } = makeDeps({
+      loadLocalContent: async (path, slug) => {
+        calls.push(`load:${path}:${slug}`);
+        loads += 1;
+        return loads === 1 ? "original" : "edited-mid-flight";
+      },
+    });
+    const result = await shareNewSkillToWorkspace(deps, ARGS);
+    deepStrictEqual(result, {
+      outcome: "shared",
+      enableFailures: [],
+      localDeleted: false,
+    });
+    strictEqual(
+      calls.some((c) => c.startsWith("delete:")),
+      false,
+    );
+  });
+
+  it("local copy vanishing before the delete reads as deleted", async () => {
+    let loads = 0;
+    const { calls, deps } = makeDeps({
+      loadLocalContent: async () => {
+        loads += 1;
+        return loads === 1 ? "original" : null;
+      },
+    });
+    const result = await shareNewSkillToWorkspace(deps, ARGS);
+    deepStrictEqual(result, {
+      outcome: "shared",
+      enableFailures: [],
+      localDeleted: true,
+    });
+    strictEqual(
+      calls.some((c) => c.startsWith("delete:")),
+      false,
+    );
+  });
+
+  it("a failing delete resolves shared anyway (identical copy shadows)", async () => {
+    const { deps } = makeDeps({
+      deleteLocal: async () => {
+        throw new Error("delete failed");
+      },
+    });
+    const result = await shareNewSkillToWorkspace(deps, ARGS);
+    deepStrictEqual(result, {
+      outcome: "shared",
+      enableFailures: [],
+      localDeleted: false,
+    });
+  });
+});

--- a/app/tests/org-skill-share.test.ts
+++ b/app/tests/org-skill-share.test.ts
@@ -7,9 +7,11 @@ import {
 } from "../src/lib/org-skill-share.ts";
 
 // HOU-1192: a skill created with an agent lands in the workspace store by
-// default. The flow must never lose the skill: every failure path leaves it
-// usable somewhere, and the local copy dies only when the creator can already
-// load the shared one and nothing diverged.
+// default and is installed ONLY to the agent that built it — other agents see
+// it in the store and are enabled explicitly by the user. The flow must never
+// lose the skill: every failure path leaves it usable somewhere, and the local
+// copy dies only when the creator can already load the shared one and nothing
+// diverged.
 
 /** The shape `HoustonEngineError` carries: the status plus the parsed body. */
 const engineError = (status: number, body: unknown = null) => ({
@@ -20,7 +22,6 @@ const engineError = (status: number, body: unknown = null) => ({
 const ARGS = {
   workspaceId: "ws1",
   creatorPath: "/ws/Creator",
-  agentPaths: ["/ws/Creator", "/ws/Other", "/ws/Third"],
   slug: "meeting-prep",
 };
 
@@ -76,23 +77,22 @@ describe("isOrgSkillShareDeclined", () => {
 });
 
 describe("shareNewSkillToWorkspace", () => {
-  it("happy path: promote, creator first, fan-out, byte-identical delete", async () => {
+  it("happy path: promote, creator-only enable, byte-identical delete", async () => {
     const { calls, deps } = makeDeps();
     const result = await shareNewSkillToWorkspace(deps, ARGS);
     deepStrictEqual(result, {
       outcome: "shared",
-      enableFailures: [],
+      creatorEnabled: true,
       localDeleted: true,
     });
-    // Ordering: load → promote → creator enable → others → beforeDelete
-    // (cache refresh) → reload → delete, with the reload/compare directly
-    // against the delete so a concurrent edit has the narrowest window.
+    // Ordering: load → promote → creator enable (the ONLY enable — other
+    // agents are never installed to) → beforeDelete (cache refresh) →
+    // reload → delete, with the reload/compare directly against the delete
+    // so a concurrent edit has the narrowest window.
     deepStrictEqual(calls, [
       "load:/ws/Creator:meeting-prep",
       "promote:ws1:meeting-prep",
       "enable:/ws/Creator:meeting-prep",
-      "enable:/ws/Other:meeting-prep",
-      "enable:/ws/Third:meeting-prep",
       "beforeDelete",
       "load:/ws/Creator:meeting-prep",
       "delete:/ws/Creator:meeting-prep",
@@ -140,31 +140,18 @@ describe("shareNewSkillToWorkspace", () => {
     const { calls, deps } = makeDeps();
     deps.enable = async (path, slug) => {
       calls.push(`enable:${path}:${slug}`);
-      if (path === "/ws/Creator") throw new Error("manifest write failed");
+      throw new Error("manifest write failed");
     };
     const result = await shareNewSkillToWorkspace(deps, ARGS);
     deepStrictEqual(result, {
       outcome: "shared",
-      enableFailures: ["/ws/Creator"],
+      creatorEnabled: false,
       localDeleted: false,
     });
     strictEqual(
       calls.some((c) => c.startsWith("delete:")),
       false,
     );
-  });
-
-  it("other agents' enable failures are collected, never fatal", async () => {
-    const { deps } = makeDeps();
-    deps.enable = async (path) => {
-      if (path === "/ws/Other") throw new Error("forbidden");
-    };
-    const result = await shareNewSkillToWorkspace(deps, ARGS);
-    deepStrictEqual(result, {
-      outcome: "shared",
-      enableFailures: ["/ws/Other"],
-      localDeleted: true,
-    });
   });
 
   it("a copy the agent edited mid-flight survives as an override", async () => {
@@ -179,7 +166,7 @@ describe("shareNewSkillToWorkspace", () => {
     const result = await shareNewSkillToWorkspace(deps, ARGS);
     deepStrictEqual(result, {
       outcome: "shared",
-      enableFailures: [],
+      creatorEnabled: true,
       localDeleted: false,
     });
     strictEqual(
@@ -199,7 +186,7 @@ describe("shareNewSkillToWorkspace", () => {
     const result = await shareNewSkillToWorkspace(deps, ARGS);
     deepStrictEqual(result, {
       outcome: "shared",
-      enableFailures: [],
+      creatorEnabled: true,
       localDeleted: true,
     });
     strictEqual(
@@ -217,7 +204,7 @@ describe("shareNewSkillToWorkspace", () => {
     const result = await shareNewSkillToWorkspace(deps, ARGS);
     deepStrictEqual(result, {
       outcome: "shared",
-      enableFailures: [],
+      creatorEnabled: true,
       localDeleted: false,
     });
   });

--- a/app/tests/skill-chat-setup.test.ts
+++ b/app/tests/skill-chat-setup.test.ts
@@ -247,7 +247,12 @@ describe("skill chat setup message", () => {
         [{ id: "a1", agent: SKILL_SETUP_AGENT_MODE }],
         [{ name: "weekly-update", setup_activity_id: "a1" }],
       ),
-      { kind: "stamp_activity", activityId: "a1", slug: "weekly-update" },
+      {
+        kind: "stamp_activity",
+        activityId: "a1",
+        slug: "weekly-update",
+        reason: "forward_link",
+      },
     );
     // Already stamped → nothing to do (the effect loop terminates).
     deepStrictEqual(
@@ -298,7 +303,12 @@ describe("skill chat setup message", () => {
         [{ name: "meeting-prep" }],
         skillDisplayTitle,
       ),
-      { kind: "stamp_activity", activityId: "a1", slug: "meeting-prep" },
+      {
+        kind: "stamp_activity",
+        activityId: "a1",
+        slug: "meeting-prep",
+        reason: "orphan_adoption",
+      },
     );
     // Frontmatter title wins over the humanized slug, same as everywhere.
     deepStrictEqual(
@@ -311,6 +321,7 @@ describe("skill chat setup message", () => {
         kind: "stamp_activity",
         activityId: "a1",
         slug: "preparar-reunion",
+        reason: "orphan_adoption",
       },
     );
     // Ambiguous (two skills share the display title) → never guess.

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -162,10 +162,39 @@ never learns it exists, even though the Skills UI still lists it. Keep
    - `renderUserMessage` — decodes skill + attachment markers into cards
 6. Both **BoardTab** (per-agent kanban) and **Dashboard** (Mission Control / cross-agent kanban) consume this hook so the right panel is identical in both views.
 
+## Org skill by default (HOU-1192)
+
+Since HOU-1027 a workspace also has an **org/workspace skill store** (`ws/<org>/shared/skills/`
+cloud, `<Workspace>/.shared/skills/` desktop; ADR 0003): a shared skill lives ONCE,
+agents load it via their per-agent manifest (`.houston/skills-manifest/`), and agent
+edits hit the one org copy. HOU-1192 makes that the DEFAULT for skills **created with
+an agent** (the create-with-AI chat): the moment the heal stamps the chat↔skill link
+from the skill's own forward `setup_activity_id` — the one signal with agent-written
+provenance; rule 1 only matches an unstamped chat, so it fires exactly once per
+creation — the client promotes the SKILL.md verbatim into the store, enables it in
+EVERY agent's manifest (explicit per-agent writes, per ADR 0003; this module's
+writers are serialized per agent), and deletes the creator's local copy only when it
+is still byte-identical, checked directly before the delete (a mid-flight edit
+survives as that agent's override). Flow + ordering live in
+`app/src/lib/org-skill-share.ts` (node-tested); the binding hook is
+`app/src/components/tabs/use-org-skill-default.ts`, invoked from
+`use-skill-chat-setup.ts` (heal `reason: "forward_link"` ONLY — orphan adoption and
+the list-delta fallback claim never share: the catalog stays interactive beside a
+draft chat, so a store install could satisfy the delta heuristic). The share runs
+even before `/v1/capabilities` resolves (the claim is one-shot); where the store is
+absent or declines (409 slug collision, 403 member role, 404 route absent, typed 503
+unconfigured — `isOrgSkillShareDeclined`), the skill stays agent-local exactly as
+before, silently.
+Store/GitHub installs and the per-agent from-scratch dialog remain agent-scoped
+("shared, not installed" applies to agent-created skills); the GLOBAL page's
+from-scratch dialog already creates in the store. Ad-hoc creations in a normal
+mission chat (no setup-chat claim signal) stay agent-local — share via the Skills
+page.
+
 ## Global Skills page (sidebar "Skills", HOU-792)
 
-Skills are stored ON each agent (`<agent>/.agents/skills/` — there is no shared
-or org-level store; that was HOU-792's misconception). The top-level **Skills**
+Agent-owned skills are stored ON each agent (`<agent>/.agents/skills/`); shared
+skills live once in the workspace store (see above). The top-level **Skills**
 page (`app/src/components/skills-view/`, viewMode `skills-home`, sidebar entry
 between Integrations and AI Models) is a pure client aggregation over the
 existing per-agent routes — the host's skill routes already accept ANY agent

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -171,11 +171,13 @@ edits hit the one org copy. HOU-1192 makes that the DEFAULT for skills **created
 an agent** (the create-with-AI chat): the moment the heal stamps the chat↔skill link
 from the skill's own forward `setup_activity_id` — the one signal with agent-written
 provenance; rule 1 only matches an unstamped chat, so it fires exactly once per
-creation — the client promotes the SKILL.md verbatim into the store, enables it in
-EVERY agent's manifest (explicit per-agent writes, per ADR 0003; this module's
-writers are serialized per agent), and deletes the creator's local copy only when it
-is still byte-identical, checked directly before the delete (a mid-flight edit
-survives as that agent's override). Flow + ordering live in
+creation — the client promotes the SKILL.md verbatim into the store, enables it
+ONLY in the creator's manifest (one explicit write, per ADR 0003; this module's
+manifest writers are serialized per agent), and deletes the creator's local copy
+only when it is still byte-identical, checked directly before the delete (a
+mid-flight edit survives as that agent's override). Other agents are deliberately
+NOT installed to: the skill sits in the workspace store, and the user enables it
+per agent from the Skills page / the per-agent "From your workspace" section. Flow + ordering live in
 `app/src/lib/org-skill-share.ts` (node-tested); the binding hook is
 `app/src/components/tabs/use-org-skill-default.ts`, invoked from
 `use-skill-chat-setup.ts` (heal `reason: "forward_link"` ONLY — orphan adoption and


### PR DESCRIPTION
## HOU-1192

### What this changes

A skill created **with an agent** (the create-with-AI guided chat, on the per-agent Skills tab or the global Skills page) now lands in the **workspace/org skill store by default**. It is installed (manifest-enabled) **only to the agent that built it**; the other agents see it in the workspace store, ready for the user to enable per agent from the Skills surfaces — org-level availability, not a fan-out install.

Mechanically, the client reuses the ADR 0003 primitives at the one moment it reliably knows "the agent just created this skill": the heal's **forward-link stamp** in `use-skill-chat-setup.ts` (the skill's own frontmatter `setup_activity_id` — agent-written provenance; rule 1 only matches an unstamped chat, so it fires exactly once per creation). The list-delta fallback claim deliberately does NOT share: the catalog stays interactive beside a draft chat, so a store/GitHub install landing mid-chat could satisfy that heuristic, and installs are specified as agent-scoped. At the stamp moment `useOrgSkillDefault` runs `shareNewSkillToWorkspace` (`app/src/lib/org-skill-share.ts`, dependency-injected and node-tested):

1. **Promote** the SKILL.md verbatim into the workspace store (the existing "Share to workspace" route).
2. **Enable** it in the creator's skills-manifest only (one explicit manifest write, per ADR 0003; this module's manifest writers are serialized per agent so two concurrent creations on one agent can't drop each other's slug). Other agents are deliberately untouched.
3. **Delete the creator's local copy only when it is still byte-identical** to what was promoted and the creator's manifest enable landed, with the compare sitting directly against the delete — a copy the agent edited mid-flight survives as that agent's override, so the skill can never be lost.

The share runs even while `/v1/capabilities` is still loading (the claim is one-shot; deferring would drop it on a startup race) — the wire's own answer closes the no-store path, and only an explicit `sharedSkills: false` skips.

The ongoing setup chat survives the move: the modify/turn-context prompts already teach editing a shared skill in place, the per-agent strip's merged row persists (the manifest + store caches are refreshed *before* the local file is deleted, so the ghost-skill deselect never fires), and `GlobalSkillChat` now falls back to a minimal row when the claimed skill has just left the agent-local list. The agent-picker dialog copy explains the model: the hosting agent gets the skill, and it lands in the workspace for other agents to receive on demand.

### Degrades, deliberately

Where the store is absent or declines, the skill stays agent-local exactly as before: 409 (slug collision with an existing workspace skill), 403 (Teams member role — the gateway enforces admin-only org-skill writes), 404 (a deployment predating the shared-skills routes, the HOU-1105 rule), and the typed 503 "shared skills not configured" are expected declines (`isOrgSkillShareDeclined`, structural on status+body). Any *unexpected* failure still toasts + reports through `call()` — no silent failures. The success toast ("Skill added to your workspace") shows only when the creator's enable landed; a failed manifest write surfaces through its own `call()` toast instead of being contradicted by a blanket success.

Out of scope (unchanged): store/GitHub installs and the per-agent from-scratch dialog stay agent-scoped; the global page's from-scratch dialog already created in the store; ad-hoc skill creations inside a normal mission chat have no claim signal and stay agent-local (shareable from the Skills page).

Also: `knowledge-base/skills.md` documents the behavior (and drops a stale pre-HOU-1027 claim that no org-level store exists).

### Repro (before)

1. `pnpm dev`, open Skills → New skill (or an agent's Skills tab → Create with AI), and let the agent build a skill through the guided chat.
2. When the agent confirms creation, the skill exists **only on that agent**: the global Skills page shows it as a local row with one holder, other agents' Skills tabs and pickers don't have it, and sharing requires the manual "Share to workspace" + per-agent enable steps.

### Verify (after)

1. Same flow: create a skill through the guided chat with any agent (workspace with ≥2 agents makes the effect visible).
2. Moments after the agent confirms creation, a "Skill added to your workspace" toast appears; the global Skills page shows the skill as a **workspace/shared** row, the CREATING agent has it enabled (its Skills tab lists it, no local copy on disk), and the other agents do NOT — they see it available to add (per-agent "From your workspace" section / the global row's assignment toggles).
3. The creation chat keeps working: ask for a change in the same conversation — the agent edits the one shared copy; enable the skill on a second agent and confirm it gets that same edited version.
4. On a deployment without the store (or as a Teams member without org-write rights), the same flow leaves the skill agent-local with no error surfaced — the pre-change behavior.
5. Gates: app unit tests (2701 pass, incl. new `org-skill-share` + heal-reason coverage), `pnpm tsgo --noEmit` (app + full workspace via pre-commit), `pnpm --filter houston-web typecheck`, Playwright e2e (243 passed), `pnpm check`, `pnpm check-locales`, `pnpm check:boundaries` — all green.
