### PR TITLE
fix(host): workspace listings survive files changing mid-walk (HOU-1176)

### DIFF
--- a/packages/host/src/vfs/fs-walk-race.test.ts
+++ b/packages/host/src/vfs/fs-walk-race.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, expect, test, vi } from "vitest";
+import { FsVfs } from "./fs";
+
+// HOU-1176: an agent workspace is written WHILE it is listed — the agent saves
+// files during a turn, pi creates/removes its auth.json.lock dir on every
+// credential refresh, and writeBytes renames a temp over its target. A walk that
+// trusts readdir's answer to still be true by the time it stats/scans an entry
+// 500s the whole request ("ENOENT … stat '…/activity.json.1.t67fze.tmp'"), which
+// the user sees as an error toast on the Files tab. A vanished entry must simply
+// be absent from the listing; every other error stays loud.
+
+// Hooks fire INSIDE the fs call the walk is making, which is the only way to
+// land a delete in the window between readdir and stat deterministically.
+const hooks = vi.hoisted(() => ({
+  beforeStat: (_path: string) => {},
+  beforeReaddir: (_path: string) => {},
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    stat: (path: string, ...rest: unknown[]) => {
+      hooks.beforeStat(String(path));
+      return (actual.stat as (...a: unknown[]) => unknown)(path, ...rest);
+    },
+    readdir: (path: string, ...rest: unknown[]) => {
+      hooks.beforeReaddir(String(path));
+      return (actual.readdir as (...a: unknown[]) => unknown)(path, ...rest);
+    },
+  };
+});
+
+beforeEach(() => {
+  hooks.beforeStat = () => {};
+  hooks.beforeReaddir = () => {};
+});
+
+const newVfs = () => {
+  const root = mkdtempSync(join(tmpdir(), "vfs-walk-race-"));
+  return { root, vfs: new FsVfs(root) };
+};
+const names = (keys: string[]) => keys.map((k) => k.split("/").pop());
+
+test("a file that vanishes between readdir and stat is skipped, not fatal", async () => {
+  const { vfs } = newVfs();
+  await vfs.writeText("a/keep.txt", "kept");
+  await vfs.writeText("a/doomed.txt", "gone in a moment");
+
+  hooks.beforeStat = (path) => {
+    if (path.endsWith("doomed.txt")) rmSync(path);
+  };
+
+  expect(names(await vfs.list("a"))).toEqual(["keep.txt"]);
+});
+
+test("a subdirectory removed mid-walk is skipped, not fatal", async () => {
+  const { root, vfs } = newVfs();
+  await vfs.writeText("a/keep.txt", "kept");
+  await vfs.writeText("a/lock/held", ""); // pi's auth.json.lock shape
+
+  // The parent's readdir has already named `lock`; it disappears in the window
+  // before the walk descends into it.
+  hooks.beforeReaddir = (path) => {
+    if (path === join(root, "a/lock")) rmSync(path, { recursive: true });
+  };
+
+  expect(names(await vfs.list("a"))).toEqual(["keep.txt"]);
+});
+
+test("a real failure still throws — only vanished entries are skipped", async () => {
+  const { vfs } = newVfs();
+  await vfs.writeText("a/f.txt", "x");
+
+  hooks.beforeStat = (path) => {
+    if (path.endsWith("f.txt"))
+      throw Object.assign(new Error("EACCES: permission denied"), {
+        code: "EACCES",
+      });
+  };
+
+  await expect(vfs.list("a")).rejects.toThrow(/EACCES/);
+});
+
+test("in-flight atomic-write temps never appear in a listing", async () => {
+  const { root, vfs } = newVfs();
+  await vfs.writeText("a/activity.json", "[]");
+
+  // A concurrent writeBytes' scratch file, exactly as it exists mid-write…
+  writeFileSync(join(root, "a/activity.json.1.t67fze.houston.tmp"), "[]");
+  // …while a user file that merely ends in .tmp stays visible.
+  writeFileSync(join(root, "a/backup.tmp"), "mine");
+
+  expect(names(await vfs.list("a"))).toEqual(["activity.json", "backup.tmp"]);
+});
+
+test("listing a prefix deleted mid-request answers empty, never throws", async () => {
+  const { root, vfs } = newVfs();
+  await vfs.writeText("a/f.txt", "x");
+  rmSync(join(root, "a"), { recursive: true });
+
+  expect(await vfs.listDetailed("a")).toEqual([]);
+});

--- a/packages/host/src/vfs/fs.ts
+++ b/packages/host/src/vfs/fs.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { type Dirent, existsSync } from "node:fs";
 import {
   mkdir,
   readdir,
@@ -10,6 +10,30 @@ import {
 } from "node:fs/promises";
 import { dirname, join, sep } from "node:path";
 import { assertSafeKey, decodeText, type ObjectStat, type Vfs } from "./vfs";
+
+/**
+ * Suffix of the scratch file `writeBytes` renames into place. Distinctive on
+ * purpose: a listing hides exactly these and nothing a user could legitimately
+ * name (`notes.tmp`, `backup.1.tmp` stay visible).
+ */
+const ATOMIC_TMP_SUFFIX = ".houston.tmp";
+const isAtomicTemp = (name: string) => name.endsWith(ATOMIC_TMP_SUFFIX);
+
+/**
+ * An entry that disappeared (or whose parent turned into a file) between the
+ * readdir that named it and the syscall that reads it. The workspace is live —
+ * the agent writes files during a turn, pi creates and removes its
+ * `auth.json.lock` dir around every credential refresh, and `writeBytes` renames
+ * a temp over its target — so a walk ALWAYS races. A vanished entry is simply
+ * not in the listing; anything else (EACCES, EIO) still throws, per the
+ * no-silent-failures policy. Without this, one unlucky rename 500'd the whole
+ * request: HOU-1176 (`GET /files` → "ENOENT … stat '…/activity.json.<n>.<x>.tmp'"),
+ * plus the same crash in `list_skills`, `delete_file` and `save_attachments`.
+ */
+function isVanished(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
 
 /**
  * Real-filesystem Vfs — the local profile's adapter. Keys map 1:1 to paths
@@ -31,27 +55,48 @@ export class FsVfs implements Vfs {
     dir: string,
     out: { path: string; size: number; mtimeMs: number; birthMs: number }[],
   ): Promise<void> {
-    const entries = await readdir(dir, { withFileTypes: true });
+    let entries: Dirent[];
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch (err) {
+      if (isVanished(err)) return; // directory removed mid-walk
+      throw err;
+    }
     for (const e of entries) {
       const p = join(dir, e.name);
       if (e.isDirectory()) await this.walk(p, out);
       else if (e.isFile()) {
-        const s = await stat(p);
-        out.push({
-          path: p,
-          size: s.size,
-          mtimeMs: s.mtimeMs,
-          birthMs: s.birthtimeMs,
-        });
+        // Our own in-flight atomic writes are not workspace content: they are
+        // about to be renamed away, and surfacing them would leak scratch rows
+        // into the Files tab and orphan tmp objects into the store sync.
+        if (isAtomicTemp(e.name)) continue;
+        try {
+          const s = await stat(p);
+          out.push({
+            path: p,
+            size: s.size,
+            mtimeMs: s.mtimeMs,
+            birthMs: s.birthtimeMs,
+          });
+        } catch (err) {
+          if (isVanished(err)) continue; // file removed/renamed mid-walk
+          throw err;
+        }
       }
     }
   }
 
   private async statsUnder(prefix: string): Promise<ObjectStat[]> {
     const dir = this.pathFor(prefix);
-    // A prefix that resolves to a plain file has no keys UNDER it — same answer
-    // an object store gives. Walking it would readdir() a file and throw.
-    if (!existsSync(dir) || !(await stat(dir)).isDirectory()) return [];
+    // A missing prefix, or one that resolves to a plain file, has no keys UNDER
+    // it — the same answer an object store gives. Walking it would readdir() a
+    // file and throw.
+    try {
+      if (!(await stat(dir)).isDirectory()) return [];
+    } catch (err) {
+      if (isVanished(err)) return [];
+      throw err;
+    }
     const found: {
       path: string;
       size: number;
@@ -105,9 +150,11 @@ export class FsVfs implements Vfs {
     // Atomic tmp+rename: a plain in-place write let concurrent readers catch a
     // TRUNCATED file — list_conversations 500'd ("not valid JSON") whenever a
     // read raced an activity.json write. The tmp lives in the same directory
-    // (rename is only atomic within one filesystem) with a unique suffix so
-    // two concurrent writers never collide on it.
-    const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+    // (rename is only atomic within one filesystem) with a unique infix so
+    // two concurrent writers never collide on it, and the ATOMIC_TMP_SUFFIX so
+    // a concurrent walk knows to skip it.
+    const unique = `${process.pid}.${Math.random().toString(36).slice(2, 8)}`;
+    const tmp = `${path}.${unique}${ATOMIC_TMP_SUFFIX}`;
     await writeFile(tmp, content);
     await rename(tmp, path);
   }


### PR DESCRIPTION
Closes HOU-1176.

## Root cause

`FsVfs.walk` (`packages/host/src/vfs/fs.ts`) `readdir`s a directory and then `stat`s each entry, trusting the listing to still be true when it gets there. An agent workspace is live: the agent writes files during a turn, pi creates and removes its `auth.json.lock` dir on every credential refresh, and `writeBytes` renames a scratch file over its target. When an entry vanishes inside that window, the ENOENT escapes the walk and 500s the whole request. The user sees an error toast:

```
list_project_files: ENOENT: no such file or directory, stat
'/data/workspaces/.../.houston/activity/activity.json.1.t67fze.tmp' (engine error 500)
```

`activity.json` is rewritten constantly during a turn, so opening the Files tab while the agent works is enough to hit it.

Same walk, same crash, in three other Sentry families:

| Sentry | events / users (14d) | symptom |
|---|---|---|
| 7646879919 | 11 / 7 | `list_project_files`: stat of `activity.json.<pid>.<rand>.tmp` |
| 7615128701 | 122 / 63 | `list_skills`: scandir of a removed `.agents/skills/<slug>` |
| 7614029702 | 37 / 11 | scandir of pi's `.houston/runtime/auth.json.lock` |
| 7629777050 / 7627617991 | 3 / 2 | `save_attachments`, `delete_file` |

## The fix

1. **Skip entries that vanish mid-walk.** `ENOENT`/`ENOTDIR` from the `readdir` of a subdirectory or the `stat` of a file means the entry is gone — it simply isn't in the listing. Every other error (`EACCES`, `EIO`) still throws, per the no-silent-failures policy. The prefix `stat` gets the same treatment, replacing an `existsSync` + `stat` pair that raced the same way.
2. **Stop listing our own in-flight atomic-write scratch files.** They now carry a distinctive `.houston.tmp` suffix, so a concurrent walk skips them by name instead of racing them. This also stops scratch rows appearing in the Files tab and orphan tmp objects reaching the store sync. A user file that merely ends in `.tmp` (`backup.tmp`) stays visible.

## Verification

New `packages/host/src/vfs/fs-walk-race.test.ts` drives each race deterministically (a hooked `node:fs/promises` deletes the entry inside the window rather than relying on timing). Confirmed red before the fix, green after:

```
# without the fix
× a file that vanishes between readdir and stat is skipped, not fatal
× a subdirectory removed mid-walk is skipped, not fatal
× in-flight atomic-write temps never appear in a listing
✓ a real failure still throws — only vanished entries are skipped

# with the fix
Tests  5 passed (5)
```

**Before (reproduce the bug):** on a build without this change, open an agent's Files tab while a turn is running (or `curl` `GET /agents/<id>/files` in a loop against a pod during a turn). Within a few requests one 500s with `ENOENT ... stat '.../activity.json.<pid>.<rand>.tmp'` and the UI shows an error toast.

**After (verify the fix):**
- `pnpm --filter @houston/host exec vitest run src/vfs/` → 24 passed
- `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test` → all green (host 1271, runtime 110 files, domain 16 files)
- `pnpm check` / `pnpm check:boundaries` / `pnpm -r typecheck` clean
- Manually: same loop of `GET /agents/<id>/files` during an active turn now returns 200 every time, and no `*.houston.tmp` rows appear in the listing.

Host-only change; no client or protocol surface moves.