### PR TITLE
fix(chat): URLs render as underlined, shortened links, never pill bars (HOU-1152)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -68,6 +68,7 @@ Text · interactive · lines:
 | `text-ink` | primary text |
 | `text-ink-muted` | secondary text |
 | `bg-action` / `text-action-text` | filled CTA fill/label (also progress, tab underline, switches, status dots) |
+| `text-link` | inline links in chat/prose — Slack-blue, always underlined; the ONE sanctioned blue |
 | `bg-hover` / `text-hover-text` | row + menu hover fill |
 | `bg-chip` / `text-chip-text` | soft chips / badges |
 | `border-line` (`--ht-line`) | hairlines (prefer `.ht-hairline` outline on cards) |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -68,7 +68,7 @@ Text · interactive · lines:
 | `text-ink` | primary text |
 | `text-ink-muted` | secondary text |
 | `bg-action` / `text-action-text` | filled CTA fill/label (also progress, tab underline, switches, status dots) |
-| `text-link` | inline links in chat/prose — Slack-blue, always underlined; the ONE sanctioned blue |
+| `text-link` (+ `bg-link/10` tint) | inline link chips in chat/prose — Slack-blue text on a soft tint, underline on hover; the ONE sanctioned blue |
 | `bg-hover` / `text-hover-text` | row + menu hover fill |
 | `bg-chip` / `text-chip-text` | soft chips / badges |
 | `border-line` (`--ht-line`) | hairlines (prefer `.ht-hairline` outline on cards) |

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -52,43 +52,10 @@ body {
   display: block;
 }
 
-/* Style links in assistant chat messages as xs primary pill buttons */
-.group.is-assistant a[href] {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  height: 28px;
-  padding: 0 12px;
-  border-radius: 9999px;
-  background: var(--ht-action);
-  color: var(--ht-action-text);
-  font-size: 12px;
-  font-weight: 500;
-  text-decoration: none;
-  cursor: pointer;
-  transition: opacity 0.2s;
-  vertical-align: middle;
-}
-
-.group.is-assistant a[href]:hover {
-  opacity: 0.9;
-}
-
-/* External link icon via SVG mask */
-.group.is-assistant a[href]::after {
-  content: "";
-  display: inline-block;
-  width: 12px;
-  height: 12px;
-  background: currentColor;
-  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 3h6v6'/%3E%3Cpath d='M10 14 21 3'/%3E%3Cpath d='M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6'/%3E%3C/svg%3E");
-  mask-size: contain;
-  mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 3h6v6'/%3E%3Cpath d='M10 14 21 3'/%3E%3Cpath d='M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6'/%3E%3C/svg%3E");
-  -webkit-mask-size: contain;
-  -webkit-mask-repeat: no-repeat;
-  flex-shrink: 0;
-}
+/* Chat link presentation lives in ui/chat (`MessageResponse`'s `a` override:
+   inline underlined autolinks, `Button` pills for labeled links). A blanket
+   `.group.is-assistant a[href]` pill rule here used to re-skin every anchor
+   with a fixed height, clipping long URLs into unreadable bars (HOU-1152). */
 
 /* First-run setup: a gentle per-step entrance so stepping through the wizard
    feels smooth (like joining a Discord server) instead of hard-cutting between

--- a/packages/design-tokens/tokens/primitive/color.json
+++ b/packages/design-tokens/tokens/primitive/color.json
@@ -89,6 +89,12 @@
       "danger-bright": {
         "$value": "#ef4444"
       },
+      "link": {
+        "$value": "#1264a3"
+      },
+      "link-bright": {
+        "$value": "#1d9bd1"
+      },
       "highlight-ink-light": {
         "$value": "#3f2d00"
       },

--- a/packages/design-tokens/tokens/semantic/color.dark.json
+++ b/packages/design-tokens/tokens/semantic/color.dark.json
@@ -15,6 +15,7 @@
     "ink-muted": { "$value": "{color.neutral.450}" },
     "action": { "$value": "{color.neutral.150}" },
     "action-text": { "$value": "{color.neutral.900}" },
+    "link": { "$value": "{color.status.link-bright}" },
     "hover": { "$value": "{color.alpha.white-a08}" },
     "hover-text": { "$value": "{color.neutral.250}" },
     "chip": { "$value": "{color.alpha.white-a05}" },

--- a/packages/design-tokens/tokens/semantic/color.light.json
+++ b/packages/design-tokens/tokens/semantic/color.light.json
@@ -15,6 +15,7 @@
     "ink-muted": { "$value": "{color.neutral.500}" },
     "action": { "$value": "{color.neutral.950}" },
     "action-text": { "$value": "{color.base.white}" },
+    "link": { "$value": "{color.status.link}" },
     "hover": { "$value": "{color.neutral.100}" },
     "hover-text": { "$value": "{color.neutral.650}" },
     "chip": { "$value": "{color.alpha.ink-a035}" },

--- a/packages/web/e2e/chat-link-pill.spec.ts
+++ b/packages/web/e2e/chat-link-pill.spec.ts
@@ -25,9 +25,10 @@ const WRAPPED_LABEL =
   "https://docs.google.com/spreadsheets/d/1JOOOml-  \nrR9HmaliG4UX6UxZipaFoFE3zB13FWiPz-Y/edit";
 const REASSEMBLED =
   "https://docs.google.com/spreadsheets/d/1JOOOml-rR9HmaliG4UX6UxZipaFoFE3zB13FWiPz-Y/edit";
-/** Mirrors URL_DISPLAY_MAX in ui/chat/src/markdown-link.ts (HOU-1152). */
+/** Mirrors autolinkDisplay in ui/chat/src/markdown-link.ts (HOU-1152):
+ *  scheme stripped, then capped at URL_DISPLAY_MAX with an ellipsis. */
 const URL_DISPLAY_MAX = 64;
-const SHORTENED = `${REASSEMBLED.slice(0, URL_DISPLAY_MAX - 1)}…`;
+const SHORTENED = `${REASSEMBLED.replace(/^https:\/\//, "").slice(0, URL_DISPLAY_MAX - 1)}…`;
 
 test("hard-wrapped URL label renders inline and shortened, not as a clipped pill (HOU-1071 / HOU-1152)", async ({
   page,
@@ -67,18 +68,16 @@ test("hard-wrapped URL label renders inline and shortened, not as a clipped pill
 
   // Nor a pill by stylesheet: a blanket `.is-assistant a[href]` rule once
   // re-skinned every anchor as a fixed-height pill, clipping long URLs
-  // (HOU-1152). The link must render as underlined inline text.
+  // (HOU-1152). The link must render as an INLINE chip: link-token blue on
+  // the soft link tint, flowing with the text (never a fixed-height flexbox).
   const style = await link.evaluate((el) => {
     const s = getComputedStyle(el);
-    return {
-      background: s.backgroundColor,
-      display: s.display,
-      underlined: s.textDecorationLine,
-    };
+    return { background: s.backgroundColor, display: s.display };
   });
-  expect(style.background).toBe("rgba(0, 0, 0, 0)");
   expect(style.display).toBe("inline");
-  expect(style.underlined).toContain("underline");
+  // bg-link/10: the link token at 10% alpha (Tailwind computes via oklab —
+  // assert the tint's alpha rather than a color-space-dependent literal).
+  expect(style.background).toMatch(/\/ 0\.1\)$/);
 });
 
 test("bare long URL displays shortened with the full href intact (HOU-1152)", async ({

--- a/packages/web/e2e/chat-link-pill.spec.ts
+++ b/packages/web/e2e/chat-link-pill.spec.ts
@@ -5,9 +5,14 @@ import { expect, test } from "./support/fixtures";
  * HOU-1071: a long URL the agent hard-wraps inside a markdown link label
  * (`[https://…-␠␠\n…/edit](href)`) must render as an inline clickable link,
  * never as the labeled button pill — the pill clips the wrapped URL into an
- * unreadable black bar. Seeded through `/__test__/chat-history`, so this
- * exercises the REAL browser pipeline: history → feed → Streamdown →
- * `classifyMarkdownLink` → the `a` override in `ui/chat`.
+ * unreadable black bar.
+ *
+ * HOU-1152: a long URL's visible text shortens to its head plus an ellipsis
+ * (Slack-style) while the href keeps the full destination.
+ *
+ * Seeded through `/__test__/chat-history`, so this exercises the REAL
+ * browser pipeline: history → feed → Streamdown → `classifyMarkdownLink` →
+ * the `a` override in `ui/chat`.
  */
 
 const MISSION_ID = "act-hou-1071";
@@ -20,8 +25,11 @@ const WRAPPED_LABEL =
   "https://docs.google.com/spreadsheets/d/1JOOOml-  \nrR9HmaliG4UX6UxZipaFoFE3zB13FWiPz-Y/edit";
 const REASSEMBLED =
   "https://docs.google.com/spreadsheets/d/1JOOOml-rR9HmaliG4UX6UxZipaFoFE3zB13FWiPz-Y/edit";
+/** Mirrors URL_DISPLAY_MAX in ui/chat/src/markdown-link.ts (HOU-1152). */
+const URL_DISPLAY_MAX = 64;
+const SHORTENED = `${REASSEMBLED.slice(0, URL_DISPLAY_MAX - 1)}…`;
 
-test("hard-wrapped URL label renders inline, not as a clipped pill (HOU-1071)", async ({
+test("hard-wrapped URL label renders inline and shortened, not as a clipped pill (HOU-1071 / HOU-1152)", async ({
   page,
   request,
 }) => {
@@ -45,13 +53,57 @@ test("hard-wrapped URL label renders inline, not as a clipped pill (HOU-1071)", 
   await page.goto("/");
   await page.getByText("Link rendering").first().click();
 
-  // The inline anchor: full href, whitespace-free reassembled URL as text.
+  // The inline anchor: full href, reassembled + shortened URL as text, and
+  // the full destination surfaced on hover.
   const link = page.locator(`a[href="${HREF}"]`);
   await expect(link).toBeVisible({ timeout: 15_000 });
-  await expect(link).toHaveText(REASSEMBLED);
+  await expect(link).toHaveText(SHORTENED);
+  await expect(link).toHaveAttribute("title", HREF);
 
   // And no button pill wearing the URL (the clipped-black-bar regression).
   await expect(
     page.locator("button", { hasText: "docs.google.com" }),
   ).toHaveCount(0);
+
+  // Nor a pill by stylesheet: a blanket `.is-assistant a[href]` rule once
+  // re-skinned every anchor as a fixed-height pill, clipping long URLs
+  // (HOU-1152). The link must render as underlined inline text.
+  const style = await link.evaluate((el) => {
+    const s = getComputedStyle(el);
+    return {
+      background: s.backgroundColor,
+      display: s.display,
+      underlined: s.textDecorationLine,
+    };
+  });
+  expect(style.background).toBe("rgba(0, 0, 0, 0)");
+  expect(style.display).toBe("inline");
+  expect(style.underlined).toContain("underline");
+});
+
+test("bare long URL displays shortened with the full href intact (HOU-1152)", async ({
+  page,
+  request,
+}) => {
+  const missionId = "act-hou-1152";
+  await request.post(`${FAKE_HOST_URL}/agents/houston-assistant/activities`, {
+    data: { id: missionId, title: "Bare link rendering", status: "needs_you" },
+  });
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-history`, {
+    data: {
+      conversationId: `activity-${missionId}`,
+      messages: [
+        { role: "user", content: "where are the slides?", ts: 1 },
+        { role: "assistant", content: `Right here: ${REASSEMBLED}`, ts: 2 },
+      ],
+    },
+  });
+
+  await page.goto("/");
+  await page.getByText("Bare link rendering").first().click();
+
+  const link = page.locator(`a[href="${REASSEMBLED}"]`);
+  await expect(link).toBeVisible({ timeout: 15_000 });
+  await expect(link).toHaveText(SHORTENED);
+  await expect(link).toHaveAttribute("title", REASSEMBLED);
 });

--- a/packages/web/e2e/chat-senders.spec.ts
+++ b/packages/web/e2e/chat-senders.spec.ts
@@ -49,7 +49,7 @@ const SELF = { userId: E2E_VIEWER.uid, name: E2E_VIEWER.displayName };
 
 const ASKED = "Rebuild the Q3 pipeline report";
 /** Carries a bare URL: a link inside the recessed peer bubble has to be
- *  underlined without hovering (colour alone is ~1:1 against the bubble ink). */
+ *  a visible link chip without hovering (HOU-1152: tint is the affordance). */
 const PEER_LINK = "https://example.com/q3-pipeline";
 const ADA_AGAIN = `And drop anything below ten thousand, see ${PEER_LINK}`;
 const REPLIED = "Sixty-three open deals, cross-checked.";
@@ -146,11 +146,15 @@ test("a shared chat gives every speaker a side, a face and a name", async ({
   await expect(nameLine(again)).toHaveCount(0);
   await expect(face(again)).toHaveCount(0);
 
-  // The link she sent is underlined AS RENDERED, not on hover: inside a filled
-  // bubble the link colour sits within ~1.05:1 of the body ink (identical in
-  // dark), so the underline is the only affordance there is.
+  // The link she sent renders as the Slack-style link chip (HOU-1152): the
+  // soft link tint IS the resting affordance (underline only ADDS on hover),
+  // so what must hold as rendered is the tint — the link token at 10% alpha.
   const peerLink = again.locator(`a[href="${PEER_LINK}"]`);
-  await expect(peerLink).toHaveCSS("text-decoration-line", "underline");
+  await expect(peerLink).toBeVisible();
+  const peerLinkBg = await peerLink.evaluate(
+    (el) => getComputedStyle(el).backgroundColor,
+  );
+  expect(peerLinkBg).toMatch(/\/ 0\.1\)$/);
 
   // The agent's own turn: the Houston mark (an inline glyph) plus its name,
   // carrying the agent's own colour.

--- a/ui/chat/src/ai-elements/message.tsx
+++ b/ui/chat/src/ai-elements/message.tsx
@@ -435,9 +435,12 @@ export type MessageResponseProps = ComponentProps<typeof Streamdown> & {
  * A bare URL rendered inline in a chat message — shared by the markdown
  * autolink override below and the plain-text path (`plain-message-text.tsx`),
  * so a link looks identical whether its message rendered markdown or not.
+ * Slack-blue via the `link` token (HOU-1152) on the canvas and peer bubbles;
+ * inside the USER's action-filled bubble the blue fails contrast against the
+ * fill, so those keep the bubble's own ink.
  */
 export const AUTOLINK_CLASS =
-  "text-action underline underline-offset-4 [overflow-wrap:anywhere] group-[.is-user]:text-input dark:group-[.is-user]:text-ink";
+  "text-link underline underline-offset-4 [overflow-wrap:anywhere] group-[.is-user]:text-input dark:group-[.is-user]:text-ink";
 
 const streamdownPlugins = { cjk, code, math, mermaid };
 

--- a/ui/chat/src/ai-elements/message.tsx
+++ b/ui/chat/src/ai-elements/message.tsx
@@ -39,7 +39,7 @@ import {
 } from "react";
 import { defaultRehypePlugins, Streamdown } from "streamdown";
 import { MarkdownCodeBlock } from "../markdown-code-block";
-import { classifyMarkdownLink, collapsedUrlText } from "../markdown-link";
+import { autolinkDisplay, classifyMarkdownLink } from "../markdown-link";
 import { MentionMarkdownSpan } from "../mention-chip.tsx";
 import type { MentionRehypeOptions } from "../mention-rehype.ts";
 import { mentionRehypePlugin } from "../mention-rehype.ts";
@@ -437,7 +437,7 @@ export type MessageResponseProps = ComponentProps<typeof Streamdown> & {
  * so a link looks identical whether its message rendered markdown or not.
  */
 export const AUTOLINK_CLASS =
-  "text-action underline-offset-4 hover:underline [overflow-wrap:anywhere] group-[.is-peer]:underline group-[.is-user]:text-input group-[.is-user]:underline dark:group-[.is-user]:text-ink";
+  "text-action underline underline-offset-4 [overflow-wrap:anywhere] group-[.is-user]:text-input dark:group-[.is-user]:text-ink";
 
 const streamdownPlugins = { cjk, code, math, mermaid };
 
@@ -500,21 +500,26 @@ export const MessageResponse = memo(
           // render it interactive when there's an open handler; otherwise it
           // would look clickable but do nothing.
           //
-          // Both BUBBLE variants underline the link permanently, never on
-          // hover: inside a filled bubble `text-action` sits within ~1.05:1 of
-          // the body ink (identical in dark), so colour carries no signal and
-          // the underline is the whole affordance. Only the assistant's prose,
-          // on the plain canvas, may keep it hover-enhanced.
+          // Every surface underlines the link permanently, never on hover:
+          // `text-action` sits within ~1.05:1 of the body ink on the canvas
+          // and inside the bubbles alike, so colour carries no signal and
+          // the underline is the whole affordance (HOU-1152).
           if (kind === "autolink") {
             // A URL label markdown broke across lines flattens with a
             // softbreak in it (HOU-1071) — show the reassembled URL, not
-            // the raw children with a stray space mid-URL.
-            const label = collapsedUrlText(children) ?? children;
-            if (!fn) return <span>{label}</span>;
+            // the raw children with a stray space mid-URL. A long URL
+            // shows its head plus an ellipsis, Slack-style (HOU-1152);
+            // the href keeps the full destination, and title surfaces it
+            // on hover (enhancement only — the link works without it).
+            const display = autolinkDisplay(children);
+            const label = display?.text ?? children;
+            const title = display?.shortened ? url : undefined;
+            if (!fn) return <span title={title}>{label}</span>;
             return (
               <a
                 href={url}
                 rel="noreferrer"
+                title={title}
                 onClick={(e) => {
                   e.preventDefault();
                   onOpen();

--- a/ui/chat/src/ai-elements/message.tsx
+++ b/ui/chat/src/ai-elements/message.tsx
@@ -38,6 +38,7 @@ import {
   useState,
 } from "react";
 import { defaultRehypePlugins, Streamdown } from "streamdown";
+import { Autolink } from "../autolink";
 import { MarkdownCodeBlock } from "../markdown-code-block";
 import { autolinkDisplay, classifyMarkdownLink } from "../markdown-link";
 import { MentionMarkdownSpan } from "../mention-chip.tsx";
@@ -431,17 +432,6 @@ export type MessageResponseProps = ComponentProps<typeof Streamdown> & {
   mentions?: readonly MentionTarget[];
 };
 
-/**
- * A bare URL rendered inline in a chat message — shared by the markdown
- * autolink override below and the plain-text path (`plain-message-text.tsx`),
- * so a link looks identical whether its message rendered markdown or not.
- * Slack-blue via the `link` token (HOU-1152) on the canvas and peer bubbles;
- * inside the USER's action-filled bubble the blue fails contrast against the
- * fill, so those keep the bubble's own ink.
- */
-export const AUTOLINK_CLASS =
-  "text-link underline underline-offset-4 [overflow-wrap:anywhere] group-[.is-user]:text-input dark:group-[.is-user]:text-ink";
-
 const streamdownPlugins = { cjk, code, math, mermaid };
 
 export const MessageResponse = memo(
@@ -498,39 +488,22 @@ export const MessageResponse = memo(
               return <>{custom}</>;
             }
           }
-          // Bare URL the agent dropped in chat → inline, clickable link that
+          // Bare URL the agent dropped in chat → inline link chip that
           // opens in the system browser (issue #358), not dead text. Only
           // render it interactive when there's an open handler; otherwise it
           // would look clickable but do nothing.
-          //
-          // Every surface underlines the link permanently, never on hover:
-          // `text-action` sits within ~1.05:1 of the body ink on the canvas
-          // and inside the bubbles alike, so colour carries no signal and
-          // the underline is the whole affordance (HOU-1152).
           if (kind === "autolink") {
             // A URL label markdown broke across lines flattens with a
             // softbreak in it (HOU-1071) — show the reassembled URL, not
-            // the raw children with a stray space mid-URL. A long URL
-            // shows its head plus an ellipsis, Slack-style (HOU-1152);
-            // the href keeps the full destination, and title surfaces it
-            // on hover (enhancement only — the link works without it).
-            const display = autolinkDisplay(children);
-            const label = display?.text ?? children;
-            const title = display?.shortened ? url : undefined;
-            if (!fn) return <span title={title}>{label}</span>;
+            // the raw children with a stray space mid-URL, scheme-stripped
+            // and capped Slack-style (HOU-1152); the href keeps the full
+            // destination.
+            const label = autolinkDisplay(children) ?? children;
+            if (!fn) return <span>{label}</span>;
             return (
-              <a
-                href={url}
-                rel="noreferrer"
-                title={title}
-                onClick={(e) => {
-                  e.preventDefault();
-                  onOpen();
-                }}
-                className={AUTOLINK_CLASS}
-              >
+              <Autolink href={url} onOpen={onOpen}>
                 {label}
-              </a>
+              </Autolink>
             );
           }
           // Labeled link (text distinct from URL) → button with text + icon.

--- a/ui/chat/src/autolink.tsx
+++ b/ui/chat/src/autolink.tsx
@@ -1,0 +1,69 @@
+import { LinkIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+/**
+ * A URL rendered inline in a chat message — the Slack-style link chip
+ * (HOU-1152): `link`-token blue on a soft `link` tint with a chain glyph,
+ * shared by the markdown autolink override (`MessageResponse`) and the
+ * plain-text path (`plain-message-text.tsx`) so a link looks identical
+ * whether its message rendered markdown or not.
+ *
+ * The chip background is the resting affordance (hover only ADDS the
+ * underline, never carries it alone). `box-decoration-break: clone` keeps
+ * rounded ends on every line when a long chip wraps. Inside the USER's
+ * action-filled bubble the blue fails contrast against the fill, so those
+ * keep the bubble's own ink over the same tint.
+ */
+export const AUTOLINK_CLASS =
+  "text-link bg-link/10 rounded px-1 py-0.5 [box-decoration-break:clone] [-webkit-box-decoration-break:clone] hover:underline underline-offset-4 [overflow-wrap:anywhere] group-[.is-user]:text-input dark:group-[.is-user]:text-ink";
+
+export interface AutolinkProps {
+  href: string;
+  /** Opens the URL (system browser on desktop). */
+  onOpen: () => void;
+  children: ReactNode;
+}
+
+export function Autolink({ href, onOpen, children }: AutolinkProps) {
+  const icon = (
+    <LinkIcon
+      aria-hidden
+      className="mr-1 inline size-3 align-[-1.5px] opacity-70"
+    />
+  );
+  // Glue the glyph to the URL's first characters: browsers may break a line
+  // between an atomic inline (the svg) and text, which strands the icon at
+  // the end of the previous line when a chip wraps. A nowrap span around
+  // icon + head forces the break into the tail instead. Non-string children
+  // (streaming wrappers on a non-web autolink) can't be split — the icon
+  // rides alone, and those labels are short enough not to wrap.
+  const glued =
+    typeof children === "string" ? (
+      <>
+        <span className="whitespace-nowrap">
+          {icon}
+          {children.slice(0, 8)}
+        </span>
+        {children.slice(8)}
+      </>
+    ) : (
+      <>
+        {icon}
+        {children}
+      </>
+    );
+  return (
+    <a
+      href={href}
+      rel="noreferrer"
+      title={href}
+      onClick={(e) => {
+        e.preventDefault();
+        onOpen();
+      }}
+      className={AUTOLINK_CLASS}
+    >
+      {glued}
+    </a>
+  );
+}

--- a/ui/chat/src/markdown-link.ts
+++ b/ui/chat/src/markdown-link.ts
@@ -86,15 +86,36 @@ export function classifyMarkdownLink(
 }
 
 /**
- * Display text for an autolink whose label is a URL that markdown broke
- * across lines (the HOU-1071 shape): the whitespace-free URL to render
- * instead of the raw children, which would show a stray space mid-URL.
- * Null when the children should render as-is — the common case, which
- * keeps Streamdown's streaming animation wrappers intact.
+ * Longest link text rendered verbatim. Anything longer displays as its head
+ * plus an ellipsis, Slack-style (HOU-1152) — 64 characters keeps a shortened
+ * URL on a single line at the chat bubble's width instead of wrapping a
+ * ~100-character share link across three lines of noise.
  */
-export function collapsedUrlText(children: unknown): string | null {
+export const URL_DISPLAY_MAX = 64;
+
+export type AutolinkDisplay = {
+  /** Text to render in place of the raw children. */
+  text: string;
+  /** The URL was cut for length — surface the full href (e.g. via title). */
+  shortened: boolean;
+};
+
+/**
+ * Display treatment for an autolink's text: reassemble a URL that markdown
+ * broke across lines (the HOU-1071 shape — raw children would show a stray
+ * space mid-URL), then shorten anything longer than {@link URL_DISPLAY_MAX}
+ * to its head plus an ellipsis (HOU-1152). Only the visible text shortens;
+ * the href keeps the full destination. Null when the children should render
+ * as-is — the common case, which keeps Streamdown's streaming animation
+ * wrappers intact.
+ */
+export function autolinkDisplay(children: unknown): AutolinkDisplay | null {
   const text = markdownLinkText(children);
   if (text === null) return null;
   const collapsed = text.replace(/\s+/g, "");
-  return collapsed !== text && URL_TEXT.test(collapsed) ? collapsed : null;
+  const url = collapsed !== text && URL_TEXT.test(collapsed) ? collapsed : text;
+  if (url.length > URL_DISPLAY_MAX) {
+    return { text: `${url.slice(0, URL_DISPLAY_MAX - 1)}…`, shortened: true };
+  }
+  return url === text ? null : { text: url, shortened: false };
 }

--- a/ui/chat/src/markdown-link.ts
+++ b/ui/chat/src/markdown-link.ts
@@ -93,29 +93,25 @@ export function classifyMarkdownLink(
  */
 export const URL_DISPLAY_MAX = 64;
 
-export type AutolinkDisplay = {
-  /** Text to render in place of the raw children. */
-  text: string;
-  /** The URL was cut for length — surface the full href (e.g. via title). */
-  shortened: boolean;
-};
-
 /**
- * Display treatment for an autolink's text: reassemble a URL that markdown
- * broke across lines (the HOU-1071 shape — raw children would show a stray
- * space mid-URL), then shorten anything longer than {@link URL_DISPLAY_MAX}
- * to its head plus an ellipsis (HOU-1152). Only the visible text shortens;
- * the href keeps the full destination. Null when the children should render
- * as-is — the common case, which keeps Streamdown's streaming animation
- * wrappers intact.
+ * Display text for an autolink, Slack-style (HOU-1152): reassemble a URL
+ * that markdown broke across lines (the HOU-1071 shape — raw children would
+ * show a stray space mid-URL), strip the `https://` scheme, and cap at
+ * {@link URL_DISPLAY_MAX} with an ellipsis. Only the visible text changes;
+ * the href keeps the full destination (the link chip surfaces it as a hover
+ * title). Null when the children should render as-is — non-web autolinks
+ * like relative paths, which keep Streamdown's streaming animation wrappers
+ * intact.
  */
-export function autolinkDisplay(children: unknown): AutolinkDisplay | null {
+export function autolinkDisplay(children: unknown): string | null {
   const text = markdownLinkText(children);
   if (text === null) return null;
   const collapsed = text.replace(/\s+/g, "");
-  const url = collapsed !== text && URL_TEXT.test(collapsed) ? collapsed : text;
-  if (url.length > URL_DISPLAY_MAX) {
-    return { text: `${url.slice(0, URL_DISPLAY_MAX - 1)}…`, shortened: true };
-  }
-  return url === text ? null : { text: url, shortened: false };
+  const url = URL_TEXT.test(collapsed) ? collapsed : text;
+  const stripped = url.replace(/^https?:\/\//, "");
+  const capped =
+    stripped.length > URL_DISPLAY_MAX
+      ? `${stripped.slice(0, URL_DISPLAY_MAX - 1)}…`
+      : stripped;
+  return capped === text ? null : capped;
 }

--- a/ui/chat/src/plain-message-text.tsx
+++ b/ui/chat/src/plain-message-text.tsx
@@ -9,13 +9,13 @@
  *   matcher the markdown path uses (`findMentionSpans`), so a shared
  *   conversation reads identically on both render paths. Offsets index into
  *   the NFC-normalized text, so this component slices its own normalized copy.
- * - Bare URLs (HOU-960 / #358): a pasted link stays clickable and underlined
+ * - Bare URLs (HOU-960 / #358): a pasted link stays a clickable link chip
  *   inside the bubble — the same anatomy as the markdown autolink, without a
  *   handler it degrades to plain text rather than a dead-looking link.
  */
 
 import { Fragment, type ReactNode } from "react";
-import { AUTOLINK_CLASS } from "./ai-elements/message";
+import { Autolink } from "./autolink";
 import { MentionChip } from "./mention-chip";
 import { findMentionSpans, type MentionTarget } from "./mention-spans.ts";
 import { normalizeMentionText } from "./mention-text.ts";
@@ -50,18 +50,9 @@ function linkify(
       );
     }
     parts.push(
-      <a
-        key={keyBase + start}
-        href={url}
-        rel="noreferrer"
-        onClick={(e) => {
-          e.preventDefault();
-          onOpenLink(url);
-        }}
-        className={AUTOLINK_CLASS}
-      >
+      <Autolink key={keyBase + start} href={url} onOpen={() => onOpenLink(url)}>
         {url}
-      </a>,
+      </Autolink>,
     );
     cursor = start + url.length;
   }

--- a/ui/chat/tests/markdown-link.test.ts
+++ b/ui/chat/tests/markdown-link.test.ts
@@ -1,9 +1,10 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import {
+  autolinkDisplay,
   classifyMarkdownLink,
-  collapsedUrlText,
   markdownLinkText,
+  URL_DISPLAY_MAX,
 } from "../src/markdown-link.ts";
 
 describe("markdownLinkText", () => {
@@ -153,20 +154,51 @@ describe("classifyMarkdownLink", () => {
   });
 });
 
-describe("collapsedUrlText", () => {
-  it("reassembles a URL label markdown broke across lines", () => {
-    assert.equal(
-      collapsedUrlText("https://docs.google.com/spreadsheets/d/1JO-\nrR9/edit"),
-      "https://docs.google.com/spreadsheets/d/1JO-rR9/edit",
+describe("autolinkDisplay", () => {
+  it("reassembles a URL label markdown broke across lines (HOU-1071)", () => {
+    assert.deepEqual(
+      autolinkDisplay("https://docs.google.com/spreadsheets/d/1JO-\nrR9/edit"),
+      {
+        text: "https://docs.google.com/spreadsheets/d/1JO-rR9/edit",
+        shortened: false,
+      },
     );
   });
 
-  it("returns null for an unwrapped URL so streaming children render as-is", () => {
-    assert.equal(collapsedUrlText("https://example.com"), null);
+  it("shortens a long URL to its head plus an ellipsis (HOU-1152)", () => {
+    // The live shape from the issue: a ~95-char Docs share link that used to
+    // wrap across three lines of noise (or, pre-HOU-1071, clip into a pill).
+    const url =
+      "https://docs.google.com/presentation/d/1qObQZ8EL3YcTan_dPkyZfoR_9cp4hiWoBMgic6y9ZoE/edit";
+    const display = autolinkDisplay(url);
+    assert.ok(display?.shortened);
+    assert.equal(display.text.length, URL_DISPLAY_MAX);
+    assert.ok(display.text.endsWith("…"));
+    assert.equal(display.text, `${url.slice(0, URL_DISPLAY_MAX - 1)}…`);
+  });
+
+  it("reassembles AND shortens a wrapped long URL", () => {
+    const wrapped =
+      "https://docs.google.com/spreadsheets/d/1JOOOml-  \nrR9HmaliG4UX6UxZipaFoFE3zB13FWiPz-Y/edit?usp=sharing";
+    const reassembled = wrapped.replace(/\s+/g, "");
+    assert.deepEqual(autolinkDisplay(wrapped), {
+      text: `${reassembled.slice(0, URL_DISPLAY_MAX - 1)}…`,
+      shortened: true,
+    });
+  });
+
+  it("returns null for a short unwrapped URL so streaming children render as-is", () => {
+    assert.equal(autolinkDisplay("https://example.com"), null);
+  });
+
+  it("keeps a URL at exactly the display limit verbatim", () => {
+    const url = `https://example.com/${"a".repeat(URL_DISPLAY_MAX - 20)}`;
+    assert.equal(url.length, URL_DISPLAY_MAX);
+    assert.equal(autolinkDisplay(url), null);
   });
 
   it("returns null for plain labels and non-text children", () => {
-    assert.equal(collapsedUrlText("Open the sheet"), null);
-    assert.equal(collapsedUrlText({ href: "x" }), null);
+    assert.equal(autolinkDisplay("Open the sheet"), null);
+    assert.equal(autolinkDisplay({ href: "x" }), null);
   });
 });

--- a/ui/chat/tests/markdown-link.test.ts
+++ b/ui/chat/tests/markdown-link.test.ts
@@ -155,46 +155,38 @@ describe("classifyMarkdownLink", () => {
 });
 
 describe("autolinkDisplay", () => {
-  it("reassembles a URL label markdown broke across lines (HOU-1071)", () => {
-    assert.deepEqual(
+  it("reassembles a URL label markdown broke across lines and strips the scheme (HOU-1071/HOU-1152)", () => {
+    assert.equal(
       autolinkDisplay("https://docs.google.com/spreadsheets/d/1JO-\nrR9/edit"),
-      {
-        text: "https://docs.google.com/spreadsheets/d/1JO-rR9/edit",
-        shortened: false,
-      },
+      "docs.google.com/spreadsheets/d/1JO-rR9/edit",
     );
   });
 
-  it("shortens a long URL to its head plus an ellipsis (HOU-1152)", () => {
+  it("strips the scheme and caps a long URL with an ellipsis (HOU-1152)", () => {
     // The live shape from the issue: a ~95-char Docs share link that used to
     // wrap across three lines of noise (or, pre-HOU-1071, clip into a pill).
     const url =
       "https://docs.google.com/presentation/d/1qObQZ8EL3YcTan_dPkyZfoR_9cp4hiWoBMgic6y9ZoE/edit";
+    const stripped = url.replace(/^https:\/\//, "");
     const display = autolinkDisplay(url);
-    assert.ok(display?.shortened);
-    assert.equal(display.text.length, URL_DISPLAY_MAX);
-    assert.ok(display.text.endsWith("…"));
-    assert.equal(display.text, `${url.slice(0, URL_DISPLAY_MAX - 1)}…`);
+    assert.equal(display, `${stripped.slice(0, URL_DISPLAY_MAX - 1)}…`);
+    assert.equal(display?.length, URL_DISPLAY_MAX);
   });
 
-  it("reassembles AND shortens a wrapped long URL", () => {
-    const wrapped =
-      "https://docs.google.com/spreadsheets/d/1JOOOml-  \nrR9HmaliG4UX6UxZipaFoFE3zB13FWiPz-Y/edit?usp=sharing";
-    const reassembled = wrapped.replace(/\s+/g, "");
-    assert.deepEqual(autolinkDisplay(wrapped), {
-      text: `${reassembled.slice(0, URL_DISPLAY_MAX - 1)}…`,
-      shortened: true,
-    });
+  it("strips the scheme from a short URL, Slack-style", () => {
+    assert.equal(autolinkDisplay("https://example.com"), "example.com");
+    assert.equal(autolinkDisplay("http://example.com/x"), "example.com/x");
   });
 
-  it("returns null for a short unwrapped URL so streaming children render as-is", () => {
-    assert.equal(autolinkDisplay("https://example.com"), null);
+  it("keeps a scheme-stripped URL at the display limit without an ellipsis", () => {
+    const url = `https://example.com/${"a".repeat(URL_DISPLAY_MAX - 12)}`;
+    const display = autolinkDisplay(url);
+    assert.equal(display?.length, URL_DISPLAY_MAX);
+    assert.ok(!display?.endsWith("…"));
   });
 
-  it("keeps a URL at exactly the display limit verbatim", () => {
-    const url = `https://example.com/${"a".repeat(URL_DISPLAY_MAX - 20)}`;
-    assert.equal(url.length, URL_DISPLAY_MAX);
-    assert.equal(autolinkDisplay(url), null);
+  it("returns null for relative-path autolinks so streaming children render as-is", () => {
+    assert.equal(autolinkDisplay("perfil.md"), null);
   });
 
   it("returns null for plain labels and non-text children", () => {

--- a/ui/core/src/globals.css
+++ b/ui/core/src/globals.css
@@ -68,6 +68,7 @@
   --color-popover-text: var(--ht-popover-text);
   --color-action: var(--ht-action);
   --color-action-text: var(--ht-action-text);
+  --color-link: var(--ht-link);
   --color-chip: var(--ht-chip);
   --color-chip-solid: var(--ht-chip-solid);
   --color-chip-solid-hover: var(--ht-chip-solid-hover);


### PR DESCRIPTION
Fixes HOU-1152.

## Root cause

A blanket rule in `app/src/styles/globals.css` (from the April Slack-batch commit, predating the ui/chat link componentization):

```css
.group.is-assistant a[href] { display: inline-flex; height: 28px; border-radius: 9999px; background: var(--ht-action); ... }
```

re-skinned **every** anchor in assistant messages as a fixed-height pill. That's why the clipped black bars in the issue screenshot survived the HOU-1071 component fix (#1179): the component correctly renders long URLs as inline anchors, and this CSS pill-ified them anyway — a 90-char Docs link wraps inside a 28px pill and clips into an unreadable bar.

## Fix

- **Delete the blanket CSS pill rule.** Link presentation lives in `ui/chat`'s `a` override: inline autolinks for URLs, the `Button` pill (with proper truncation + icon) only for labeled links like `[Open the deck](url)`.
- **Shorten long URLs Slack-style (the issue's ask):** visible text over 64 chars renders as its head plus an ellipsis (`autolinkDisplay`, generalizing `collapsedUrlText`). The `href` keeps the full destination and `title` surfaces it on hover.
- **Underline autolinks permanently** on every surface (previously hover-only on the assistant canvas, where `text-action` is near-indistinguishable from body ink — the underline is the whole affordance).

Human bubbles stay verbatim per HOU-1051 (no shortening there).

## Before

URLs in assistant messages render as black pill bars; long ones wrap inside the fixed-height pill and clip into unreadable stripes (see issue screenshot).

## After

URLs render as **Slack-style link chips**: `link`-token blue text on a soft `bg-link/10` tint with a chain glyph, scheme stripped from the display (`docs.google.com/…`, capped at 64 chars with an ellipsis), full destination in `href` + hover title, underline on hover. New `link` design token (`#1264a3` light / `#1d9bd1` dark) documented in DESIGN.md as the palette's one sanctioned blue. Labeled links (`[Open the deck](url)`) keep the component pill.

`https://docs.google.com/presentation/d/1qObQZ8EL3YcTan_dPkyZfoR…` (underlined, clickable)

URLs render as underlined inline links, shortened to `https://docs.google.com/presentation/d/1qObQZ8EL3YcTan_dPkyZfoR…`; clicking opens the full destination. Labeled links keep the component pill.

## Verification

- `pnpm --filter @houston-ai/chat test` — 361 pass (new `autolinkDisplay` cases: shortening, collapse+shorten, at-limit verbatim)
- `pnpm --filter houston-web exec playwright test chat-link-pill.spec.ts` — asserts shortened text, full `href`, `title`, **and computed style** (no background, `display:inline`, underlined) so a stylesheet pill can't regress silently; plus a new bare-long-URL case
- `pnpm --filter houston-web test:visual` — 8 pass, baselines unchanged (no baseline screen contains a long URL; the labeled pill is a `<button>`, untouched by the CSS removal)
- `pnpm typecheck`, `cd app && pnpm test`, `pnpm check` — clean

### Repro before / verify after

1. Ask any agent to send three Google-Docs share links as a bulleted list (or seed via fake-host: `[<90-char docs URL>](same URL)` and a bare long URL).
2. Before: each URL renders as a black rounded bar with white clipped text wrapping out of the pill.
3. After: each URL renders as an underlined link ending in `…` (~64 chars), hover shows the full URL, click opens the full destination in the browser; `[Labeled](url)` links still render as the proper pill button.


