### PR TITLE
feat(onboarding): show the Skip onboarding escape hatch from the very first screen

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -441,6 +441,18 @@ export default function App() {
             onContinue={async (segment) => {
               await onboardingSegment.saveSegment(segment);
             }}
+            onSkip={() => {
+              // Terminal escape hatch, mirroring the orchestrator's
+              // skipOnboarding. The segment screen mounts BEFORE the
+              // orchestrator, so no pending flag or tutorialActive exists yet:
+              // marking completed is the whole teardown, and it flips this
+              // route to the shell synchronously (query cache set first).
+              analytics.track("onboarding_skipped", {
+                step: "segment",
+                source: "escape_hatch",
+              });
+              void markCompleted();
+            }}
           />
         )
       ) : firstRunRoute === "onboarding" ? (

--- a/app/src/components/onboarding/personal-assistant-onboarding.tsx
+++ b/app/src/components/onboarding/personal-assistant-onboarding.tsx
@@ -350,11 +350,11 @@ export function PersonalAssistantOnboarding({
         />
       )}
 
-      {/* Hidden until the assistant is provisioned, because `markCompleted`
-          is permanent and skipping with zero agents would strand the user in
-          an empty shell. Hidden on the finished screen, whose primary CTA
-          already exits. */}
-      {agent && step !== "finished" && (
+      {/* Available from the very first step: a zero-agent skip lands on the
+          shell's empty state, whose "New agent" CTA is the way back (only
+          agent-creating users ever mount onboarding). Hidden on the finished
+          screen, whose primary CTA already exits. */}
+      {step !== "finished" && (
         <SkipOnboardingButton
           onSkip={() => skipOnboarding(step, "escape_hatch")}
         />

--- a/app/src/components/onboarding/segment-screen.tsx
+++ b/app/src/components/onboarding/segment-screen.tsx
@@ -12,6 +12,7 @@ import {
 import { HoustonLogo } from "../shell/experience-card";
 import { FirstRunScreen } from "./first-run-screen";
 import { SetupCard } from "./setup-card";
+import { SkipOnboardingButton } from "./skip-onboarding-button";
 
 interface SegmentOption {
   id: OnboardingSegment;
@@ -21,11 +22,15 @@ interface SegmentOption {
 interface OnboardingSegmentScreenProps {
   onContinue: (segment: OnboardingSegment) => Promise<void>;
   saving: boolean;
+  /** Terminal escape hatch: marks onboarding completed and lands on the
+   *  shell's empty state, leaving the segment question unanswered. */
+  onSkip: () => void;
 }
 
 export function OnboardingSegmentScreen({
   onContinue,
   saving,
+  onSkip,
 }: OnboardingSegmentScreenProps) {
   const { t } = useTranslation(["setup", "common"]);
   const [selected, setSelected] = useState<OnboardingSegment | null>(null);
@@ -121,6 +126,7 @@ export function OnboardingSegmentScreen({
           </div>
         </div>
       </SetupCard>
+      <SkipOnboardingButton onSkip={onSkip} />
     </FirstRunScreen>
   );
 }

--- a/app/src/components/onboarding/skip-onboarding-button.tsx
+++ b/app/src/components/onboarding/skip-onboarding-button.tsx
@@ -4,9 +4,9 @@ import { useTranslation } from "react-i18next";
 /**
  * Support escape hatch pinned to the bottom of the first-run screen, on the
  * gutter below the card: a broken onboarding step must never trap the user,
- * and support can always say "click Skip onboarding". The orchestrator gates
- * it on a provisioned assistant, because completion is permanent and skipping
- * with zero agents would strand the user in an empty shell.
+ * and support can always say "click Skip onboarding". Shown from the first
+ * step onward — a zero-agent skip lands on the shell's empty state, whose
+ * "New agent" CTA is the recovery path.
  */
 export function SkipOnboardingButton({ onSkip }: { onSkip: () => void }) {
   const { t } = useTranslation("setup");

--- a/app/tests/onboarding-escape-hatch.test.ts
+++ b/app/tests/onboarding-escape-hatch.test.ts
@@ -12,14 +12,26 @@ describe("onboarding skip escape hatch", () => {
   const button = read(
     "../src/components/onboarding/skip-onboarding-button.tsx",
   );
+  const segment = read("../src/components/onboarding/segment-screen.tsx");
+  const app = read("../src/App.tsx");
 
-  it("pins a global skip button below the card, gated on a provisioned assistant", () => {
-    // Gate matters: `markCompleted` is permanent, so a skip before the
-    // assistant exists would strand the user in an empty shell forever.
-    assert.match(onboarding, /\{agent && step !== "finished" && \(/);
+  it("pins a global skip button below the card, from the very first step", () => {
+    // No agent gate: a zero-agent skip lands on the shell's empty state,
+    // whose "New agent" CTA is the way back (only agent-creating users ever
+    // mount onboarding). Only the finished screen hides it — its own CTA exits.
+    assert.match(onboarding, /\{step !== "finished" && \(/);
+    assert.doesNotMatch(onboarding, /\{agent && step !== "finished"/);
     assert.match(onboarding, /skipOnboarding\(step, "escape_hatch"\)/);
     assert.match(button, /variant="ghost"/);
     assert.match(button, /tutorial\.nav\.skipOnboarding/);
+  });
+
+  it("shows the same escape hatch on the segment screen", () => {
+    // The segment screen mounts BEFORE the orchestrator (App-level route), so
+    // it carries its own SkipOnboardingButton; App.tsx supplies the terminal
+    // handler (analytics + markCompleted — no pending flag exists yet).
+    assert.match(segment, /<SkipOnboardingButton onSkip=\{onSkip\} \/>/);
+    assert.match(app, /step: "segment",\s*source: "escape_hatch"/);
   });
 
   it("routes every skip source through the one terminal teardown", () => {

--- a/app/tests/onboarding-required-email.test.ts
+++ b/app/tests/onboarding-required-email.test.ts
@@ -55,12 +55,16 @@ describe("required onboarding email path", () => {
 });
 
 describe("required onboarding role selection", () => {
-  it("removes the helper and skip, and keeps every subtitle to five words", () => {
+  it("keeps the in-card helper and skip removed, subtitles to five words", () => {
     const screen = read("../src/components/onboarding/segment-screen.tsx");
     const locales = ["en", "es", "pt"] as const;
 
-    assert.doesNotMatch(screen, /\bonSkip\b/);
+    // The question itself stays required: no in-card helper or per-question
+    // skip copy. The ONLY skip on this screen is the global bottom-of-screen
+    // SkipOnboardingButton escape hatch, which exits ALL of onboarding
+    // (covered in onboarding-escape-hatch.test.ts).
     assert.doesNotMatch(screen, /onboardingSegment\.(?:helper|skip)/);
+    assert.match(screen, /<SkipOnboardingButton onSkip=\{onSkip\} \/>/);
 
     for (const locale of locales) {
       const setup = JSON.parse(read(`../src/locales/${locale}/setup.json`)) as {

--- a/packages/web/e2e/onboarding-skip.spec.ts
+++ b/packages/web/e2e/onboarding-skip.spec.ts
@@ -7,58 +7,93 @@ import { expect, test } from "./support/fixtures";
  * never trap the user — support can say "click Skip onboarding".
  *
  * Two properties guarded here:
- *   1. GATING: the button is HIDDEN until the assistant is provisioned.
- *      `markCompleted` is permanent, so a skip before the agent exists would
- *      strand the user in an empty agentless shell with no way back into
- *      onboarding.
- *   2. EXIT: once visible, clicking it is a terminal exit — onboarding
- *      unmounts and the workspace shell takes over.
- *
- * Reaching the gated state: empty the host's agents (first-run = zero agents),
- * answer the segment question, connect a featured API-key provider (Google
- * Gemini, the fake host accepts any key), which fires the silent background
- * assistant provisioning and lands on the "Your AI is connected!" celebration.
+ *   1. AVAILABILITY: the button is visible from the very FIRST screen (the
+ *      segment question) and every step after it, before any assistant
+ *      exists. A zero-agent skip is safe: the workspace shell's empty state
+ *      offers a "New agent" CTA, and onboarding only ever mounts for users
+ *      allowed to create agents.
+ *   2. EXIT: clicking it is a terminal exit — onboarding unmounts and the
+ *      workspace shell takes over on its zero-agent empty state. The segment
+ *      screen's exit is a separate code path (App-level markCompleted, no
+ *      orchestrator mounted yet), so both exits are exercised.
  */
-test("skip-onboarding escape hatch hides before provisioning and exits to the shell", async ({
-  page,
-  request,
-}) => {
+async function resetToFirstRun(
+  request: Parameters<Parameters<typeof test>[2]>[0]["request"],
+) {
   const agents = (await (
     await request.get(`${FAKE_HOST_URL}/agents`)
   ).json()) as { id: string }[];
   for (const agent of agents) {
     await request.delete(`${FAKE_HOST_URL}/agents/${agent.id}`);
   }
+  // The fake host is shared across this worker's tests, and an earlier skip
+  // persists the durable flags — clear them so every test boots first-run.
+  // (localStorage mirrors reset for free: fresh browser context per test.)
+  for (const key of [
+    "onboarding_completed",
+    "onboarding_pending",
+    "houston_onboarding_segment",
+  ]) {
+    await request.put(`${FAKE_HOST_URL}/v1/preferences/${key}`, {
+      data: { value: null },
+    });
+  }
+}
+
+test("skip-onboarding escape hatch shows on the connect step and exits to the shell", async ({
+  page,
+  request,
+}) => {
+  await resetToFirstRun(request);
 
   await page.goto("/");
+  // Segment question: the escape hatch is already present on the very first
+  // first-run screen, before the orchestrator (and any agent) exists.
+  await expect(
+    page.getByRole("button", { name: "Skip onboarding" }),
+  ).toBeVisible();
   await page.getByRole("button", { name: /Operations/ }).click();
   await page.getByRole("button", { name: "Continue" }).click();
 
-  // Connect step: no agent exists yet, so the escape hatch must be absent.
+  // Connect step: no agent exists yet, but the escape hatch is already there.
   await expect(
     page.getByRole("heading", { name: "Connect your AI" }),
   ).toBeVisible();
   const skip = page.getByRole("button", { name: "Skip onboarding" });
-  await expect(skip).toHaveCount(0);
-
-  // Connect an API-key provider; the fake host accepts the pasted key and the
-  // orchestrator provisions the assistant in the background.
-  await page.getByRole("button", { name: "Connect Google Gemini" }).click();
-  const dialog = page.getByRole("dialog");
-  await dialog.getByPlaceholder("Paste your API key").fill("e2e-fake-key");
-  await dialog.getByRole("button", { name: "Connect", exact: true }).click();
-
-  // Celebration screen: once the background provisioning lands, the escape
-  // hatch appears at the bottom of the screen.
-  await expect(
-    page.getByRole("heading", { name: "Your AI is connected!" }),
-  ).toBeVisible();
   await expect(skip).toBeVisible();
 
-  // Terminal exit: onboarding unmounts and the workspace shell takes over.
+  // Terminal exit before any assistant was provisioned: onboarding unmounts
+  // and the shell's zero-agent empty state takes over, with the "New agent"
+  // recovery CTA.
   await skip.click();
   await expect(
-    page.getByRole("heading", { name: "Your AI is connected!" }),
+    page.getByRole("heading", { name: "Connect your AI" }),
   ).toHaveCount(0);
   await expect(skip).toHaveCount(0);
+  await expect(page.getByText("No agents yet")).toBeVisible();
+  // Scoped to main: the sidebar carries its own "New agent" icon button.
+  await expect(
+    page.getByRole("main").getByRole("button", { name: "New agent" }),
+  ).toBeVisible();
+});
+
+test("skip-onboarding escape hatch exits straight from the segment screen", async ({
+  page,
+  request,
+}) => {
+  await resetToFirstRun(request);
+
+  await page.goto("/");
+  const skip = page.getByRole("button", { name: "Skip onboarding" });
+  await expect(skip).toBeVisible();
+
+  // Skip without answering the segment question: App-level terminal exit
+  // (markCompleted only — no orchestrator, no pending flag) lands on the
+  // shell's zero-agent empty state.
+  await skip.click();
+  await expect(skip).toHaveCount(0);
+  await expect(page.getByText("No agents yet")).toBeVisible();
+  await expect(
+    page.getByRole("main").getByRole("button", { name: "New agent" }),
+  ).toBeVisible();
 });


### PR DESCRIPTION
## What

The global "Skip onboarding" escape hatch was gated on a provisioned assistant, so it only appeared after the AI-connect step. It now shows on **every** first-run screen except the finished one — including the segment (role) question and the "Connect your AI" picker.

## Why the old gate is safe to drop

The gate existed because `markCompleted` is permanent and a zero-agent skip was considered a permanent strand. But the shell's zero-agent empty state offers a "New agent" CTA, and onboarding only ever mounts for users allowed to create agents — so an early skip always has a recovery path.

## How

- **personal-assistant-onboarding**: drop the `agent &&` gate on `SkipOnboardingButton` (renders on all steps except `finished`, whose own CTA exits).
- **segment-screen + App**: the segment screen mounts *before* the orchestrator, so App.tsx supplies its own terminal handler — `onboarding_skipped` analytics (`step: "segment"`, `source: "escape_hatch"`) + `markCompleted`, which flips the route to the shell synchronously. No pending flag or `tutorialActive` exists yet at that point, so that is the whole teardown; the segment question stays unanswered.
- The earlier product decision removing the **in-card** per-question skip/helper on the role screen stands — this is the global exit only. The guard test in `onboarding-required-email.test.ts` was updated to encode exactly that distinction.

## Tests

- `app/tests/onboarding-escape-hatch.test.ts`: no agent gate; segment screen carries the hatch; App wires the segment skip.
- `packages/web/e2e/onboarding-skip.spec.ts`: two exits exercised — straight from the segment screen (App-level path) and from the connect step (orchestrator path), both landing on the zero-agent shell with the "New agent" CTA. The shared fake host's durable flags are cleared per test so each boots first-run.
- Gates: Biome clean, app + web typechecks, 2692 app unit tests, visual-regression suite unchanged (first-run baseline captures the language gate, not these screens).