### PR TITLE
fix(host): agent renames (and deletes) can no longer resurrect the old directory (HOU-827)

### DIFF
--- a/packages/host/src/channel/proxy-quiesce.test.ts
+++ b/packages/host/src/channel/proxy-quiesce.test.ts
@@ -4,12 +4,18 @@ import type { Agent, Workspace } from "../domain/types";
 import { ProxyChannel } from "./proxy";
 
 /**
- * quiesce — the rename precondition. Idempotence regression: quiescing an
+ * withQuiesced — the rename precondition. Idempotence regression: quiescing an
  * agent whose runtime is ABSENT (never woken, or already torn down) must be a
  * no-op success, NOT a launcher sleep. The launcher's sleep contract rejects
  * sleeping an unknown sandbox (FakeLauncher throws "cannot sleep sandbox for
  * unknown agent"), and the dual-profile suite proved a blind sleep turns a
  * plain rename into a 500 on the cloud profile while local answered 200.
+ *
+ * HOU-827 regression: the hold latch must span the sleep AND the callback —
+ * the app's reconnect storm dispatches with the old id within ~500ms of the
+ * runtime dying, and an unlatched window let ensureAwake boot a fresh runtime
+ * into the directory being renamed. And it must be RELEASED afterward, even
+ * when the callback throws, or the agent is bricked.
  */
 
 const ws: Workspace = {
@@ -46,6 +52,10 @@ function channelWith(state: "running" | "asleep" | "absent", calls: string[]) {
         calls.push("status");
         return state;
       },
+      hold(agentId: string) {
+        calls.push(`hold:${agentId}`);
+        return () => calls.push(`release:${agentId}`);
+      },
     },
     proxy: { async forward() {} },
     credentials: new MemoryCredentialStore(),
@@ -53,22 +63,87 @@ function channelWith(state: "running" | "asleep" | "absent", calls: string[]) {
   });
 }
 
-test("quiesce of an absent runtime is a no-op success (never calls sleep)", async () => {
+test("withQuiesced on an absent runtime never sleeps, still runs fn under the hold", async () => {
   const calls: string[] = [];
   await expect(
-    channelWith("absent", calls).quiesce(ctx),
-  ).resolves.toBeUndefined();
-  expect(calls).toEqual(["status"]);
+    channelWith("absent", calls).withQuiesced(ctx, async () => {
+      calls.push("fn");
+      return "renamed";
+    }),
+  ).resolves.toBe("renamed");
+  expect(calls).toEqual(["hold:agent-1", "status", "fn", "release:agent-1"]);
 });
 
-test("quiesce sleeps a running runtime", async () => {
+test("withQuiesced sleeps a running runtime before fn, releases after", async () => {
   const calls: string[] = [];
-  await channelWith("running", calls).quiesce(ctx);
-  expect(calls).toEqual(["status", "sleep:agent-1"]);
+  await channelWith("running", calls).withQuiesced(ctx, async () => {
+    calls.push("fn");
+  });
+  expect(calls).toEqual([
+    "hold:agent-1",
+    "status",
+    "sleep:agent-1",
+    "fn",
+    "release:agent-1",
+  ]);
 });
 
-test("quiesce sleeps an asleep runtime too (sleep is idempotent for existing sandboxes)", async () => {
+test("withQuiesced sleeps an asleep runtime too (sleep is idempotent for existing sandboxes)", async () => {
   const calls: string[] = [];
-  await channelWith("asleep", calls).quiesce(ctx);
-  expect(calls).toEqual(["status", "sleep:agent-1"]);
+  await channelWith("asleep", calls).withQuiesced(ctx, async () => {
+    calls.push("fn");
+  });
+  expect(calls).toEqual([
+    "hold:agent-1",
+    "status",
+    "sleep:agent-1",
+    "fn",
+    "release:agent-1",
+  ]);
+});
+
+test("a throwing fn still releases the hold (the agent is not bricked)", async () => {
+  const calls: string[] = [];
+  await expect(
+    channelWith("running", calls).withQuiesced(ctx, async () => {
+      throw new Error("name already taken");
+    }),
+  ).rejects.toThrow("name already taken");
+  expect(calls).toEqual([
+    "hold:agent-1",
+    "status",
+    "sleep:agent-1",
+    "release:agent-1",
+  ]);
+});
+
+test("a failing sleep surfaces AND releases the hold (fn never runs)", async () => {
+  const calls: string[] = [];
+  const channel = new ProxyChannel({
+    launcher: {
+      async ensureAwake() {
+        return { baseUrl: "http://runtime.local", token: "sbx-token" };
+      },
+      async sleep() {
+        throw new Error("runtime is still alive after SIGTERM and SIGKILL");
+      },
+      async destroy() {},
+      async status() {
+        return "running" as const;
+      },
+      hold(agentId: string) {
+        calls.push(`hold:${agentId}`);
+        return () => calls.push(`release:${agentId}`);
+      },
+    },
+    proxy: { async forward() {} },
+    credentials: new MemoryCredentialStore(),
+    forwardActingHeader: false,
+  });
+  await expect(
+    channel.withQuiesced(ctx, async () => {
+      calls.push("fn");
+    }),
+  ).rejects.toThrow("still alive");
+  expect(calls).toEqual(["hold:agent-1", "release:agent-1"]);
 });

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -275,19 +275,33 @@ export class ProxyChannel implements RuntimeChannel {
     return this.opts.launcher.status(ctx.agent.id);
   }
 
-  async quiesce(ctx: ChannelCtx): Promise<void> {
+  async withQuiesced<T>(ctx: ChannelCtx, fn: () => Promise<T>): Promise<T> {
     // Sleep, not destroy: the runtime's state stays on disk and the next
     // dispatch respawns it (pi's continueRecent restores its sessions). The
-    // launcher's sleep waits for the child to ACTUALLY exit, so a caller that
-    // needs the agent's directory quiet (rename) can rely on it.
+    // launcher's sleep waits for the child to ACTUALLY exit — escalating to
+    // SIGKILL and failing loudly rather than reporting a live child asleep —
+    // so a caller that needs the agent's directory quiet (rename) can rely
+    // on it.
     //
-    // Quiesce is idempotent by contract: an absent runtime is ALREADY quiet.
-    // The launcher's sleep deliberately rejects sleeping an unknown sandbox
+    // The hold spans sleep AND fn: the app reconnects its streams within
+    // ~500ms of the runtime dying and dispatches with the OLD id; without
+    // the latch, ensureAwake spawned a fresh runtime bound to the directory
+    // being renamed, and its first write resurrected the old name (HOU-827).
+    //
+    // Idempotent by contract: an absent runtime is ALREADY quiet. The
+    // launcher's sleep deliberately rejects sleeping an unknown sandbox
     // (a genuine sleep-of-absent elsewhere is a bug it must not paper over),
     // so only an existing runtime is slept — renaming a never-woken agent
     // must succeed, not 500.
-    if ((await this.opts.launcher.status(ctx.agent.id)) === "absent") return;
-    await this.opts.launcher.sleep(ctx.agent.id);
+    const release = this.opts.launcher.hold?.(ctx.agent.id) ?? (() => {});
+    try {
+      if ((await this.opts.launcher.status(ctx.agent.id)) !== "absent") {
+        await this.opts.launcher.sleep(ctx.agent.id);
+      }
+      return await fn();
+    } finally {
+      release();
+    }
   }
 
   async teardown(ctx: ChannelCtx): Promise<void> {

--- a/packages/host/src/launcher/process.test.ts
+++ b/packages/host/src/launcher/process.test.ts
@@ -183,20 +183,97 @@ test("sleep resolves only after the child has ACTUALLY exited", async () => {
   expect(await launcher.status("slow")).toBe("asleep");
 });
 
-test("sleep gives up waiting after its bound when a child hangs on SIGTERM", async () => {
+test("a child that ignores SIGTERM is SIGKILLed; sleep resolves once it actually dies", async () => {
+  let exitCb: (() => void) | undefined;
+  const signals: string[] = [];
+  const spawner: RuntimeSpawner = {
+    spawn() {
+      return {
+        port: 5000,
+        kill: () => signals.push("TERM"), // ignored — wedged drain
+        forceKill: () => {
+          signals.push("KILL");
+          exitCb?.();
+        },
+        onExit: (cb) => {
+          exitCb = cb;
+        },
+      };
+    },
+  };
+  const launcher = new ProcessLauncher(opts(spawner));
+  await launcher.ensureAwake(agent("wedged"));
+  await launcher.sleep("wedged", 20, 20);
+  expect(signals).toEqual(["TERM", "KILL"]);
+  expect(await launcher.status("wedged")).toBe("asleep");
+});
+
+test("sleep REJECTS when the child survives even SIGKILL — a live child is never reported asleep (HOU-827)", async () => {
+  // The old contract resolved silently after the bound, and the rename then
+  // moved the directory under a live child whose next write resurrected the
+  // old-named folder. Fail closed instead: the PATCH surfaces a 500 and the
+  // directory does not move.
   const spawner: RuntimeSpawner = {
     spawn() {
       return {
         port: 5000,
         kill: () => {},
-        onExit: () => {}, // exit never fires — a truly hung process
+        forceKill: () => {},
+        onExit: () => {}, // exit never fires — a truly unkillable process
       };
     },
   };
   const launcher = new ProcessLauncher(opts(spawner));
   await launcher.ensureAwake(agent("hung"));
-  await launcher.sleep("hung", 20); // bounded — resolves despite no exit
-  expect(await launcher.status("hung")).toBe("asleep");
+  await expect(launcher.sleep("hung", 20, 20)).rejects.toThrow(
+    "refusing to report it asleep",
+  );
+  // status stays truthful: the process is still alive.
+  expect(await launcher.status("hung")).toBe("running");
+});
+
+test("ensureAwake during a drain waits for the exit instead of racing a second child over the directory", async () => {
+  let exitCb: (() => void) | undefined;
+  let spawned = 0;
+  const spawner: RuntimeSpawner = {
+    spawn() {
+      spawned += 1;
+      const mine = spawned;
+      return {
+        port: 5000 + mine,
+        kill: () => {
+          // First child exits 30ms after SIGTERM — a realistic drain.
+          if (mine === 1) setTimeout(() => exitCb?.(), 30);
+        },
+        onExit: (cb) => {
+          if (mine === 1) exitCb = cb;
+        },
+      };
+    },
+  };
+  const launcher = new ProcessLauncher(opts(spawner));
+  await launcher.ensureAwake(agent("drainy"));
+  const sleeping = launcher.sleep("drainy", 5_000);
+  // Arrives mid-drain (the entry still exists, child still alive): must not
+  // be handed the dying child's port, must not spawn until the drain ends.
+  const endpoint = await launcher.ensureAwake(agent("drainy"));
+  await sleeping;
+  expect(spawned).toBe(2);
+  expect(endpoint.baseUrl).toBe("http://127.0.0.1:5002");
+});
+
+test("hold() blocks ensureAwake for the id until released (the rename latch)", async () => {
+  const { spawner } = recordingSpawner();
+  const launcher = new ProcessLauncher(opts(spawner));
+  const release = launcher.hold("held-agent");
+  await expect(launcher.ensureAwake(agent("held-agent"))).rejects.toThrow(
+    "is being renamed",
+  );
+  // Other agents are unaffected.
+  await launcher.ensureAwake(agent("other-agent"));
+  release();
+  release(); // idempotent
+  await launcher.ensureAwake(agent("held-agent"));
 });
 
 test("a runtime that never becomes healthy is killed and not cached (the turn errors visibly)", async () => {

--- a/packages/host/src/launcher/process.test.ts
+++ b/packages/host/src/launcher/process.test.ts
@@ -262,6 +262,35 @@ test("ensureAwake during a drain waits for the exit instead of racing a second c
   expect(endpoint.baseUrl).toBe("http://127.0.0.1:5002");
 });
 
+test("a hold acquired MID-BOOT aborts the boot before the child spawns", async () => {
+  // The port-allocation await is the one window where a boot exists but no
+  // running entry does — invisible to sleep(). A rename that begins inside
+  // it must abort the boot, not let a runtime come up bound to the old
+  // directory mid-move.
+  let releasePort: ((port: number) => void) | undefined;
+  let spawned = 0;
+  const spawner: RuntimeSpawner = {
+    spawn() {
+      spawned += 1;
+      return { port: 5000, kill: () => {} };
+    },
+  };
+  const launcher = new ProcessLauncher(
+    opts(spawner, {
+      allocatePort: () =>
+        new Promise<number>((resolve) => {
+          releasePort = resolve;
+        }),
+    }),
+  );
+  const boot = launcher.ensureAwake(agent("mid-boot"));
+  const release = launcher.hold("mid-boot");
+  releasePort?.(5001);
+  await expect(boot).rejects.toThrow("is being renamed");
+  expect(spawned).toBe(0);
+  release();
+});
+
 test("hold() blocks ensureAwake for the id until released (the rename latch)", async () => {
   const { spawner } = recordingSpawner();
   const launcher = new ProcessLauncher(opts(spawner));

--- a/packages/host/src/launcher/process.ts
+++ b/packages/host/src/launcher/process.ts
@@ -11,6 +11,13 @@ export interface RuntimeHandle {
   port: number;
   kill(): void;
   /**
+   * Non-negotiable kill (SIGKILL) for a child that ignored kill()'s SIGTERM.
+   * The launcher escalates to this before it will report the runtime gone —
+   * a rename must never proceed over a live child (HOU-827). Optional for
+   * test stubs whose processes cannot wedge.
+   */
+  forceKill?(): void;
+  /**
    * Register a one-shot callback fired when the underlying process exits on its
    * own (crash, OOM, the runtime's own SIGTERM handler). Lets the launcher reap
    * a dead child from its live-set so a phantom "running" entry never hands a
@@ -71,6 +78,14 @@ export interface ProcessLauncherOptions {
 interface Running {
   handle: RuntimeHandle;
   token: string;
+  /**
+   * Present while a sleep() is waiting for this child to actually exit. The
+   * entry stays in the live-set for the whole drain: deleting it up front
+   * made status() report "asleep" for a process that was still alive, and a
+   * dispatch arriving in that window respawned a SECOND runtime over the
+   * same directory (HOU-827's resurrect vector during a rename).
+   */
+  draining?: Promise<void>;
 }
 
 /** Default free-port allocator: bind :0, read the assigned port, release it. */
@@ -128,6 +143,8 @@ async function pollHealth(port: number): Promise<void> {
 export class ProcessLauncher implements RuntimeLauncher {
   private readonly running = new Map<AgentId, Running>();
   private readonly booting = new Map<AgentId, Promise<RuntimeEndpoint>>();
+  /** Refcounted rename latch — see hold(). */
+  private readonly held = new Map<AgentId, number>();
   private readonly allocatePort: () => Promise<number>;
   private readonly waitHealthy: (port: number, token: string) => Promise<void>;
 
@@ -137,6 +154,15 @@ export class ProcessLauncher implements RuntimeLauncher {
   }
 
   async ensureAwake(agent: Agent): Promise<RuntimeEndpoint> {
+    // Held = a rename is moving this id's directory RIGHT NOW. Refuse loudly:
+    // the app's own reconnect storm (SSE resume within ~500ms, watchdog polls,
+    // provider probes) arrives with the old id during the quiesce window, and
+    // a runtime spawned for it would be born pointing at the directory being
+    // renamed — its module-eval alone re-mkdirs the old tree (HOU-827).
+    if (this.held.has(agent.id))
+      throw new Error(
+        `agent '${agent.id}' is being renamed — retry with its new id`,
+      );
     // Single-flight per agent: the `running` entry exists BEFORE the child is
     // healthy (so sleep/shutdown can kill a mid-boot process), so a concurrent
     // caller must not read it as "awake" — it would be handed a port nobody has
@@ -146,6 +172,14 @@ export class ProcessLauncher implements RuntimeLauncher {
     const inflight = this.booting.get(agent.id);
     if (inflight) return inflight;
     const existing = this.running.get(agent.id);
+    if (existing?.draining) {
+      // A sleep is mid-drain: the process is alive but dying. Its port is a
+      // corpse-to-be, and spawning now would race two children over one
+      // directory — wait the drain out, then re-enter (respawn or, if the
+      // child refused to die, hand back the live entry).
+      await existing.draining.catch(() => {});
+      return this.ensureAwake(agent);
+    }
     if (existing)
       return {
         baseUrl: `http://127.0.0.1:${existing.handle.port}`,
@@ -159,6 +193,23 @@ export class ProcessLauncher implements RuntimeLauncher {
     } finally {
       this.booting.delete(agent.id);
     }
+  }
+
+  /**
+   * Latch an agent id against respawn while an operation invalidates its
+   * id→directory mapping (rename). Refcounted so overlapping holds compose;
+   * the returned release is idempotent per acquisition.
+   */
+  hold(agentId: AgentId): () => void {
+    this.held.set(agentId, (this.held.get(agentId) ?? 0) + 1);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const n = (this.held.get(agentId) ?? 1) - 1;
+      if (n <= 0) this.held.delete(agentId);
+      else this.held.set(agentId, n);
+    };
   }
 
   private async spawnUntilHealthy(agent: Agent): Promise<RuntimeEndpoint> {
@@ -227,29 +278,73 @@ export class ProcessLauncher implements RuntimeLauncher {
     return endpoint;
   }
 
-  async sleep(agentId: AgentId, timeoutMs = 5_000): Promise<void> {
+  async sleep(
+    agentId: AgentId,
+    timeoutMs = 5_000,
+    forceTimeoutMs = 2_000,
+  ): Promise<void> {
     const r = this.running.get(agentId);
     if (!r) return; // already asleep — pi's continueRecent restores on next wake
-    // Subscribe to the exit BEFORE killing, then wait (bounded) for the child
-    // to ACTUALLY be gone: callers sleep an agent to get its directory quiet
-    // (a rename is about to move it; on Windows a live child's cwd even locks
-    // it), and SIGTERM alone resolves while the process is still flushing.
+    // Single-flight: a concurrent sleep joins the drain already in progress
+    // (and shares its outcome) instead of double-killing or — worse — seeing
+    // the entry gone and reporting "asleep" while the child still lives.
+    if (r.draining) return r.draining;
     // Handles without onExit (test stubs) count as already exited — same
     // posture as shutdownAllAndWait.
-    const exited = r.handle.onExit
-      ? new Promise<void>((resolve) => r.handle.onExit?.(() => resolve()))
-      : undefined;
-    r.handle.kill();
-    this.running.delete(agentId);
-    if (exited) {
-      await Promise.race([
-        exited,
-        new Promise<void>((resolve) => {
-          const timer = setTimeout(resolve, timeoutMs);
-          timer.unref?.();
-        }),
-      ]);
+    if (!r.handle.onExit) {
+      r.handle.kill();
+      this.running.delete(agentId);
+      return;
     }
+    const drain = this.drainUntilExit(agentId, r, timeoutMs, forceTimeoutMs);
+    r.draining = drain;
+    try {
+      await drain;
+    } finally {
+      r.draining = undefined;
+    }
+  }
+
+  /**
+   * Kill the child and wait for it to ACTUALLY be gone: callers sleep an
+   * agent to get its directory quiet (a rename is about to move it; on
+   * Windows a live child's cwd even locks it), and SIGTERM alone resolves
+   * while the process is still flushing. A child that outlives the SIGTERM
+   * budget (wedged drain, blocked event loop) is SIGKILLed; one that
+   * survives even that fails the sleep LOUDLY — resolving silently here is
+   * what let a rename proceed under a live runtime, whose next write
+   * resurrected the old-named directory (HOU-827). The live-set entry is
+   * removed only once the exit is confirmed, so status() stays truthful for
+   * the whole drain.
+   */
+  private async drainUntilExit(
+    agentId: AgentId,
+    r: Running,
+    timeoutMs: number,
+    forceTimeoutMs: number,
+  ): Promise<void> {
+    // Subscribe BEFORE killing so a fast exit cannot be missed.
+    const exited = new Promise<boolean>((resolve) =>
+      r.handle.onExit?.(() => resolve(true)),
+    );
+    const expire = (ms: number) =>
+      new Promise<boolean>((resolve) => {
+        const timer = setTimeout(() => resolve(false), ms);
+        timer.unref?.();
+      });
+    r.handle.kill();
+    let gone = await Promise.race([exited, expire(timeoutMs)]);
+    if (!gone) {
+      r.handle.forceKill?.();
+      gone = await Promise.race([exited, expire(forceTimeoutMs)]);
+    }
+    if (!gone)
+      throw new Error(
+        `runtime for '${agentId}' is still alive after SIGTERM and SIGKILL — refusing to report it asleep`,
+      );
+    // The crash reaper (onExit in spawnUntilHealthy) usually got here first;
+    // guard against clobbering a respawn that raced in after it.
+    if (this.running.get(agentId) === r) this.running.delete(agentId);
   }
 
   async destroy(agentId: AgentId): Promise<void> {

--- a/packages/host/src/launcher/process.ts
+++ b/packages/host/src/launcher/process.ts
@@ -215,6 +215,15 @@ export class ProcessLauncher implements RuntimeLauncher {
   private async spawnUntilHealthy(agent: Agent): Promise<RuntimeEndpoint> {
     const token = this.opts.mintToken(agent);
     const port = await this.allocatePort();
+    // Re-check the latch after the first await: a boot that entered before
+    // hold() was acquired is invisible to sleep() until the running entry
+    // exists (set synchronously below), so this port-allocation gap was the
+    // one window where a rename's quiesce could miss a runtime entirely and
+    // let it come up bound to the old directory mid-move.
+    if (this.held.has(agent.id))
+      throw new Error(
+        `agent '${agent.id}' is being renamed — retry with its new id`,
+      );
     const cred = this.opts.credentialServing;
     const handle = this.opts.spawner.spawn({
       workspaceDir: this.opts.workspaceDirFor(agent),

--- a/packages/host/src/launcher/runtime-spawner.ts
+++ b/packages/host/src/launcher/runtime-spawner.ts
@@ -65,10 +65,21 @@ export class RuntimeProcessSpawner implements RuntimeSpawner {
     return {
       port: spec.port,
       kill: () => {
-        // SIGTERM lets the runtime drain; it exits on its own. A hung process is
-        // reaped by the supervisor's process-tree teardown, not here.
+        // SIGTERM lets the runtime drain; it exits on its own.
         try {
           child.kill("SIGTERM");
+        } catch {
+          /* already gone */
+        }
+      },
+      forceKill: () => {
+        // Escalation for a child that ignored the SIGTERM (wedged drain,
+        // blocked event loop). The launcher only reports the runtime asleep
+        // once it has ACTUALLY exited — a rename must never run over a live
+        // child (HOU-827) — so a hung process is ended here, not left for the
+        // supervisor's app-quit teardown.
+        try {
+          child.kill("SIGKILL");
         } catch {
           /* already gone */
         }

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -304,10 +304,23 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
 
   // agent.id is "<Workspace>/<Agent>" — split it back into the on-disk dir.
   const agentDir = (id: string) => join(opts.workspacesRoot, ...id.split("/"));
+  // Spawns fail closed on a stale id: after a rename (or delete) the old id
+  // maps to a directory that no longer exists, and a runtime spawned against
+  // it would recreate the tree on its first mkdir-recursive write — the
+  // HOU-827 ghost agent. Any late dispatch still holding the old id (client
+  // caches, a scheduler tick that crossed the rename) errors visibly instead.
+  const liveAgentDir = (id: string) => {
+    const dir = agentDir(id);
+    if (!existsSync(dir))
+      throw new Error(
+        `agent directory for '${id}' is gone (renamed or deleted?)`,
+      );
+    return dir;
+  };
   const launcher = new ProcessLauncher({
     spawner,
-    workspaceDirFor: (a) => agentDir(a.id),
-    dataDirFor: (a) => join(agentDir(a.id), ".houston", "runtime"),
+    workspaceDirFor: (a) => liveAgentDir(a.id),
+    dataDirFor: (a) => join(liveAgentDir(a.id), ".houston", "runtime"),
     sharedSkillsDirFor: sharedMirrorDir
       ? () => join(sharedMirrorDir, "skills")
       : opts.gatewayFronted

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -158,6 +158,15 @@ export interface RuntimeLauncher {
   /** Permanently delete the runtime. Keeps the volume unless dropVolume. */
   destroy(agentId: AgentId, opts?: { dropVolume?: boolean }): Promise<void>;
   status(agentId: AgentId): Promise<RuntimeState>;
+  /**
+   * Latch an agent id against ensureAwake for the duration of an operation
+   * that invalidates its id→storage mapping (rename). Returns the release.
+   * While held, ensureAwake throws instead of spawning: a runtime born in
+   * this window would point at the OLD storage and recreate it on its first
+   * write (HOU-827). Optional: launchers whose storage is keyed by a stable
+   * id (pods) need no latch.
+   */
+  hold?(agentId: AgentId): () => void;
 }
 
 /** The (workspace, agent) pair every channel operation is scoped to. */
@@ -254,17 +263,22 @@ export interface RuntimeChannel {
     items: { id: string; text: string }[],
   ): Promise<{ id: string; text: string; summary: string }[]>;
   /**
-   * Stop the agent's STANDING runtime (kill / scale to zero), persisting its
-   * state — destroying nothing; the runtime respawns on the next dispatch.
-   * Called before operations that move the agent's on-disk identity (rename):
+   * Run `fn` with the agent's STANDING runtime stopped (kill / scale to zero,
+   * persisting its state — destroying nothing; the runtime respawns on the
+   * next dispatch) AND the agent id latched against respawn until `fn`
+   * settles. For operations that move the agent's on-disk identity (rename):
    * a live local runtime holds absolute paths into the old directory (cwd,
    * data dir) and its next write would resurrect the old-named folder, which
-   * the directory-derived local store re-lists as an agent with the OLD name.
-   * On Windows the live child's cwd also locks the directory against the
-   * rename itself. Optional: channels with no standing runtime (per-turn)
-   * have nothing to quiesce and omit it.
+   * the directory-derived local store re-lists as an agent with the OLD name;
+   * on Windows the live child's cwd also locks the directory against the
+   * rename itself. The latch matters as much as the stop (HOU-827): the app
+   * reconnects its streams within ~500ms of the runtime dying, and a dispatch
+   * on the still-old id during the stop window would boot a FRESH runtime
+   * bound to the old path — resurrecting it with zero further user activity.
+   * Optional: channels with no standing runtime (per-turn) have nothing to
+   * quiesce and omit it.
    */
-  quiesce?(ctx: ChannelCtx): Promise<void>;
+  withQuiesced?<T>(ctx: ChannelCtx, fn: () => Promise<T>): Promise<T>;
   /** Tear down the agent's runtime-side state (volume / object prefix) before record deletion. */
   teardown(ctx: ChannelCtx): Promise<void>;
   /**

--- a/packages/host/src/routes/agents-rename.test.ts
+++ b/packages/host/src/routes/agents-rename.test.ts
@@ -19,9 +19,13 @@ import { handleAgents } from "./agents";
  * runtime kept running with absolute paths into the OLD directory; the
  * runtime's next write resurrected the old-named folder, which the
  * directory-derived store re-listed as an agent with the old name ("my rename
- * reverted"). The route must quiesce the standing runtime BEFORE the store
- * rename — and surface a quiesce failure instead of renaming under a live
- * runtime. Also covers the legacy Rust-era color riding rename/list payloads.
+ * reverted"). The route must run the store rename INSIDE the channel's
+ * quiesced span (runtime stopped with a confirmed exit AND the id latched
+ * against respawn until the directory has moved — HOU-827's second vector was
+ * the app's reconnect storm booting a fresh runtime into the old directory
+ * during the stop window) — and surface a quiesce failure instead of renaming
+ * under a live runtime. Also covers the legacy Rust-era color riding
+ * rename/list payloads.
  */
 
 class SpyChannel implements RuntimeChannel {
@@ -46,9 +50,10 @@ class SpyChannel implements RuntimeChannel {
   async busy() {
     return false;
   }
-  async quiesce(ctx: ChannelCtx) {
+  async withQuiesced<T>(ctx: ChannelCtx, fn: () => Promise<T>): Promise<T> {
     if (this.quiesceError) throw this.quiesceError;
     this.calls.push(`quiesce:${ctx.agent.id}`);
+    return await fn();
   }
   async teardown() {}
   async captureCredential(): Promise<CaptureResult> {
@@ -235,7 +240,7 @@ test("an agent with no legacy metadata serves no color at all", async () => {
   expect("color" in json).toBe(false);
 });
 
-test("ProxyChannel.quiesce sleeps the agent's runtime without destroying it", async () => {
+test("ProxyChannel.withQuiesced sleeps the agent's runtime without destroying it", async () => {
   const { ProxyChannel } = await import("../channel/proxy");
   const slept: string[] = [];
   const destroyed: string[] = [];
@@ -263,7 +268,7 @@ test("ProxyChannel.quiesce sleeps the agent's runtime without destroying it", as
   const ws = await memory.getWorkspace(workspaceId);
   const agent = await memory.getAgent(agentId);
   if (!ws || !agent) throw new Error("fixture agent missing");
-  await proxy.quiesce({ workspace: ws, agent });
+  await proxy.withQuiesced({ workspace: ws, agent }, async () => {});
   expect(slept).toEqual([agentId]);
   expect(destroyed).toEqual([]);
 });

--- a/packages/host/src/routes/agents-rename.test.ts
+++ b/packages/host/src/routes/agents-rename.test.ts
@@ -55,7 +55,9 @@ class SpyChannel implements RuntimeChannel {
     this.calls.push(`quiesce:${ctx.agent.id}`);
     return await fn();
   }
-  async teardown() {}
+  async teardown(ctx: ChannelCtx) {
+    this.calls.push(`teardown:${ctx.agent.id}`);
+  }
   async captureCredential(): Promise<CaptureResult> {
     return { ok: true, provider: "anthropic" };
   }
@@ -286,4 +288,25 @@ test("rename trims the submitted name before storing it", async () => {
   const { status, json } = await rename("  Marketing  ");
   expect(status).toBe(200);
   expect(json.name).toBe("Marketing");
+});
+
+test("DELETE runs inside the quiesced span too (a stale dispatch must not resurrect a deleted agent)", async () => {
+  const path = `/agents/${encodeURIComponent(agentId)}`;
+  const response = res();
+  const handled = await handleAgents(
+    deps(channel),
+    "alice",
+    "DELETE",
+    path,
+    new URL(path, "http://host.local"),
+    reqWithBody({}),
+    response,
+  );
+  expect(handled).toBe(true);
+  expect(response.status).toBe(200);
+  // The teardown + record drop happen INSIDE the latch: quiesce first, so a
+  // dispatch landing between teardown and directory removal cannot respawn a
+  // runtime into the doomed directory (HOU-827's sibling for delete).
+  expect(calls).toEqual([`quiesce:${agentId}`, `teardown:${agentId}`]);
+  expect(await memory.getAgent(agentId)).toBeNull();
 });

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -371,14 +371,22 @@ export async function handleAgents(
 
     // DELETE: tear the agent's runtime-side state down first (so a failure is
     // retryable with the record intact), then drop the record. Errors surface —
-    // never a silent orphan.
+    // never a silent orphan. Same quiesced span as rename (HOU-827's sibling):
+    // a stale dispatch landing between the teardown and the directory removal
+    // would respawn a runtime into the doomed directory, whose next write
+    // recreates it — a DELETED agent reappearing in the sidebar.
     const channel = channelFor(deps, authz.workspace);
     if (!channel) {
       noChannel(res, authz.workspace.runtime);
       return true;
     }
-    await channel.teardown({ workspace: authz.workspace, agent: authz.agent });
-    await deps.store.deleteAgent(agentId);
+    const ctx = { workspace: authz.workspace, agent: authz.agent };
+    const doDelete = async () => {
+      await channel.teardown(ctx);
+      await deps.store.deleteAgent(agentId);
+    };
+    if (channel.withQuiesced) await channel.withQuiesced(ctx, doDelete);
+    else await doDelete();
     deps.events?.emit(authz.workspace.ownerUserId, {
       type: "AgentsChanged",
       workspaceId: authz.workspace.id,

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -327,29 +327,33 @@ export async function handleAgents(
         return true;
       }
       const name = renameCheck.name;
-      // Quiesce the agent's standing runtime BEFORE the rename moves its
-      // directory. A warm local runtime holds absolute paths into the OLD
-      // directory (cwd + HOUSTON_DATA_DIR) and stays keyed under the OLD id in
-      // the launcher, so a rename under it leaks the process and its next
-      // write (conversation store, usage ledger, logs — all mkdir-recursive)
+      // Rename inside the channel's quiesced span: the standing runtime is
+      // stopped (confirmed exit — SIGKILL escalation, loud failure) AND the
+      // id is latched against respawn until the directory has moved. A warm
+      // local runtime holds absolute paths into the OLD directory (cwd +
+      // HOUSTON_DATA_DIR), so a rename under it leaks the process and its
+      // next write (conversation store, usage ledger — all mkdir-recursive)
       // RESURRECTS the old-named folder, which the directory-derived local
-      // store then re-lists as an agent with the old name ("my rename
-      // reverted"). On Windows the live child's cwd even locks the directory
-      // against the rename itself. The runtime respawns on the next dispatch
-      // (pi's continueRecent restores its sessions from the renamed tree). A
-      // quiesce failure surfaces — never rename under a live runtime.
-      if (name !== authz.agent.name) {
-        const channel = channelFor(deps, authz.workspace);
-        if (channel?.quiesce) {
-          await channel.quiesce({
-            workspace: authz.workspace,
-            agent: authz.agent,
-          });
-        }
-      }
+      // store re-lists as an agent with the old name ("my rename reverted").
+      // The latch closes the second half of HOU-827: the app's reconnect
+      // storm dispatches with the OLD id within ~500ms of the stop, and an
+      // unlatched ensureAwake booted a fresh runtime into the directory
+      // being renamed. On Windows the live child's cwd even locks the
+      // directory against the rename itself. The runtime respawns on the
+      // next dispatch (pi's continueRecent restores its sessions from the
+      // renamed tree). A quiesce failure surfaces — never rename under a
+      // live runtime.
+      const doRename = () => deps.store.renameAgent(agentId, name);
+      const channel = channelFor(deps, authz.workspace);
       let renamed: Agent;
       try {
-        renamed = await deps.store.renameAgent(agentId, name);
+        renamed =
+          name !== authz.agent.name && channel?.withQuiesced
+            ? await channel.withQuiesced(
+                { workspace: authz.workspace, agent: authz.agent },
+                doRename,
+              )
+            : await doRename();
       } catch (err) {
         if (err instanceof AgentNameConflictError) {
           json(res, 409, { error: err.message });


### PR DESCRIPTION
HOU-827 still reproduced on v0.5.40 despite #1030. Two independent deep-dive passes over the rename path converged on the same root cause: **#1030's quiesce created its own race window**, and its failure mode was silent.

## Root cause

On the local host an agent's id IS its directory (`<Workspace>/<Agent>`), and the agent list is a directory scan — anything that recreates the old-named directory brings the agent back.

1. **The quiesce window was unlatched.** `ProcessLauncher.sleep()` deleted the launcher's `running` entry BEFORE the child actually exited, so `status()` reported 'asleep' for a live process. The runtime's SIGTERM handler takes ~3s to exit (`server.close` waits out the SSE socket, then the fallback timer fires), and in that window the app — whose streams just died — is maximally chatty: SSE resume reconnects within 0–500ms, the send-queue watchdog probes at 2s, provider probes poll at 3s, all still keyed by the OLD id. Any of those dispatches hit `ensureAwake`, which saw no entry and **booted a fresh runtime bound to the old directory** (its module-eval alone `mkdir -p`s the tree). The rename then moved the directory under it, and the new child's next write resurrected the old name. Reproduces from the completely ordinary pattern 'send a message, rename the agent while it's replying'.
2. **The 5s exit wait resolved silently on timeout** with no SIGKILL escalation, so a slow/wedged child also let the rename proceed under a live runtime — zero telemetry when it happened.
3. Narrow variants: a boot sitting in its port-allocation await was invisible to `sleep()` entirely; and DELETE had the same class of bug (stale dispatch between teardown and `rmSync` → a deleted agent reappears).

## Fix (layered, each independently sufficient for its vector)

- `sleep()` keeps the entry until the exit is **confirmed** — status stays truthful through the drain — escalates SIGTERM→SIGKILL, and **throws** rather than report a live child asleep. `ensureAwake` joins an in-flight drain instead of racing a second child over one directory.
- A refcounted **hold latch**: the channel port `quiesce(ctx)` becomes `withQuiesced(ctx, fn)`; the store rename runs inside the span, `ensureAwake` on a held id throws, and a boot that crosses the latch mid-flight aborts before spawning. DELETE's teardown + record drop run inside the same span.
- The local host's launcher path mapping **fails closed**: spawning an agent whose directory is gone (renamed/deleted) errors visibly instead of recreating the tree — closing every remaining stale-id respawn vector (late client dispatches, scheduler ticks that crossed the rename).

The hosted-cloud half of HOU-827 (the gateway's informer projecting the stale create-time name annotation back over renamed registry rows — a deterministic ≤10-min revert for cloud users) is fixed separately in the cloud repo.

## Tests

- New: SIGKILL-escalation resolve; **sleep rejects when the child survives SIGKILL** (the old silent-timeout contract is inverted, with the old test replaced); ensureAwake-waits-out-a-drain; hold-blocks-ensureAwake; mid-boot latch abort; withQuiesced hold/release ordering incl. throwing fn and failing sleep; DELETE-inside-the-span.
- Full `@houston/host` suite: 145 files, 1278 passed. Biome, `check:boundaries`, and all workspace typechecks clean.

## Repro before / verify after

**Before (≤ v0.5.40 desktop):** open an agent, send a message, and while it's replying rename the agent (or rename and keep the chat open so streams reconnect). The rename lands; within moments-to-minutes the old name is back in the sidebar (the old directory reappears under `~/.houston/workspaces/<Workspace>/`).
**After:** same steps — the rename sticks; the old directory never reappears; a dispatch caught in the ~3s window surfaces a visible 'agent is being renamed' error instead of silently resurrecting the agent. A wedged runtime now fails the rename loudly (500) instead of corrupting state.

## Known follow-ups (not blocking)

- Remap the frontend send-queue/watchdog to the new agent id on rename so a message queued mid-rename is delivered rather than erroring (today it errors visibly, previously it silently resurrected the old directory).
- The runtime's shutdown doesn't kill detached tool children (e.g. a long-running Bash started by a turn); one holding an absolute old path could still recreate files under it. Requires runtime-side process-group teardown.

HOU-827