### PR TITLE
fix(host): stop file-watch ENOSPC crash-looping the engine pod (HOU-1232)

### DIFF
--- a/packages/host/src/watch/watch-tree.test.ts
+++ b/packages/host/src/watch/watch-tree.test.ts
@@ -122,6 +122,48 @@ test("an unwatchable root throws to the caller", () => {
   expect(() => linuxWatch(missing, [])).toThrow();
 });
 
+test("ENOSPC on the root degrades instead of crashing the caller (HOU-1232)", () => {
+  const root = mkdtempSync(join(tmpdir(), "houston-tree-"));
+  const onError = vi.fn();
+  const watchDir: WatchDirFn = () => {
+    throw Object.assign(new Error("ENOSPC: watchers exhausted"), {
+      code: "ENOSPC",
+    });
+  };
+  let watcher: TreeWatch | undefined;
+  expect(() => {
+    watcher = linuxWatch(root, [], onError, watchDir);
+  }).not.toThrow();
+  expect(onError).toHaveBeenCalledTimes(1);
+  watcher?.close();
+});
+
+test(".git is never watched (HOU-1232)", async () => {
+  const root = mkdtempSync(join(tmpdir(), "houston-tree-"));
+  mkdirSync(join(root, ".git", "objects"), { recursive: true });
+  const watchedDirs: string[] = [];
+  const watchDir: WatchDirFn = (dir, cb) => {
+    watchedDirs.push(dir);
+    return watch(dir, cb);
+  };
+  const events: Array<{ type: string; rel: string }> = [];
+  const watcher = linuxWatch(root, events, () => {}, watchDir);
+  try {
+    await new Promise((r) => setTimeout(r, 100));
+    writeFileSync(join(root, ".git", "objects", "pack"), "x");
+    await new Promise((r) => setTimeout(r, 200));
+    // The one true guarantee: no watch handle ever opens under .git — a
+    // parent directory's own watch can still surface a shallow notification
+    // for its ".git" child changing (harmless; classify.ts nulls it anyway),
+    // but nothing should ever report from inside it.
+    expect(watchedDirs).not.toContain(join(root, ".git"));
+    expect(watchedDirs).not.toContain(join(root, ".git", "objects"));
+    expect(events.some((e) => e.rel.startsWith(".git/"))).toBe(false);
+  } finally {
+    watcher.close();
+  }
+});
+
 test("a removed subtree releases its watchers", async () => {
   const root = mkdtempSync(join(tmpdir(), "houston-tree-"));
   mkdirSync(join(root, "gone", "deep"), { recursive: true });

--- a/packages/host/src/watch/watch-tree.ts
+++ b/packages/host/src/watch/watch-tree.ts
@@ -5,7 +5,7 @@ import {
   statSync,
   watch,
 } from "node:fs";
-import { join, relative, sep } from "node:path";
+import { basename, join, relative, sep } from "node:path";
 import { isBenignRecursiveWatchRace } from "./watcher-race";
 
 export type TreeWatchListener = (eventType: string, relPath: string) => void;
@@ -95,7 +95,6 @@ class DirTreeWatcher implements TreeWatch {
     private readonly onError: (err: unknown) => void,
     private readonly watchDir: WatchDirFn = (dir, cb) => watch(dir, cb),
   ) {
-    // Parity with fs.watch: an unwatchable root throws to the caller.
     this.addDir(root, true);
   }
 
@@ -113,16 +112,28 @@ class DirTreeWatcher implements TreeWatch {
 
   private addDir(dir: string, isRoot = false): void {
     if (this.closed || this.degraded || this.watchers.has(dir)) return;
+    // .git is never watched: agentFileEventType (packages/domain) already
+    // classifies every .git/ path as a null event, so a watch there only
+    // spends inotify budget for changes nobody sees. Checked here (not just
+    // in the readdir scan below) because a rename event for a pre-existing
+    // dir can call addDir directly, bypassing that scan.
+    if (!isRoot && basename(dir) === ".git") return;
     let watcher: FSWatcher;
     try {
       watcher = this.watchDir(dir, (eventType, filename) =>
         this.onDirEvent(dir, eventType, filename),
       );
     } catch (err) {
-      if (isRoot) throw err;
+      const isMissing = (err as NodeJS.ErrnoException).code === "ENOENT";
+      // Parity with fs.watch: a root that doesn't exist is a caller/setup
+      // bug worth failing loudly on. Anything else on root — ENOSPC (the
+      // inotify budget is spent) chief among them — degrades exactly like a
+      // mid-tree failure below: a crashed pod serves nobody, a pod that boots
+      // with no live watching still serves the store-sync daemon's fallback.
+      if (isRoot && isMissing) throw err;
       // A dir deleted between the parent event and this watch is the normal
       // transient-dir race (see watcher-race.ts) — just skip it.
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      if (!isRoot && isMissing) return;
       this.degraded = true;
       this.reportOnce(err);
       return;


### PR DESCRIPTION
## Summary

- `DirTreeWatcher` (`packages/host/src/watch/watch-tree.ts`) unconditionally rethrew any error on the workspace root's watch, including `ENOSPC`. That propagates through `FsWatcher.start()` → `host.start()` → `main.ts`'s `catch { fatal(...) }`, exiting the pod non-zero. The orchestrator restarts it, it hits the same `ENOSPC`, and it crash-loops forever — even though the identical failure on a *non-root* directory already degrades gracefully via `onError` and keeps serving. Now only a genuinely-missing root (`ENOENT`) rethrows; everything else (ENOSPC chief among them) degrades the same way a mid-tree failure already does, so the host boots (without live file-watching until restart, falling back to the store-sync daemon's periodic sync).
- Excludes `.git` from the recursive watch. `agentFileEventType` (`packages/domain/src/reactivity.ts`) already classifies every `.git/`-prefixed path as a null event (no reactivity value), so watching it only burns inotify budget for changes nobody sees — a direct contributor to exhausting the budget in the first place.

This is a follow-up to the already-released HOU-1004 (terraform-pinned `fs.inotify.max_user_watches=524288` on all prod nodes), which explicitly flagged this as out of scope: "Per-pod watch usage is unbounded — one agent cloning a repo with `node_modules` could still eat a node's budget." That gap is exactly what's still recurring in Sentry HOUSTON-APP-51V after HOU-1004 shipped — 8 distinct agent pods currently crash-looping today.

Linear: HOU-1232

## Test plan

- [x] `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test` — 271 files / 2465 tests pass, including two new cases in `watch-tree.test.ts`: ENOSPC on root degrades instead of throwing, and `.git` is never watched (including via the rename-event path, not just the initial scan).
- [x] `pnpm check:fix` — Biome clean, no fixes needed.
- [x] `pnpm check:boundaries` — clean.
- [x] `pnpm -r typecheck` (pre-commit hook) — clean across all 27 workspace projects.

### Reproduce the bug (before this fix)

1. On a Linux host, set `fs.inotify.max_user_watches` low enough to exhaust quickly (e.g. `sudo sysctl -w fs.inotify.max_user_watches=64`).
2. Boot the host against a workspace root (`packages/host`, `pnpm dev` or `tsx src/local/main.ts` equivalent) — or in a unit test, construct `watchTree(root, listener, { platform: "linux", watchDir: () => { throw Object.assign(new Error("ENOSPC"), { code: "ENOSPC" }) } })` before this fix and observe it throws synchronously instead of calling `onError`.
3. Observe `host.start()` rejects, `main.ts` calls `fatal(...)`, and the process exits non-zero — in prod this repeats indefinitely as the orchestrator restarts the pod into the same failure.

### Verify the fix (after)

1. `pnpm --filter @houston/host test -- src/watch/watch-tree.test.ts` — `"ENOSPC on the root degrades instead of crashing the caller (HOU-1232)"` passes: constructing the watcher with a root-level ENOSPC no longer throws, `onError` fires exactly once, and the watcher stays usable (`close()` succeeds).
2. `"an unwatchable root throws to the caller"` (pre-existing test, unchanged) still passes: a truly nonexistent root still throws — the ENOENT case is untouched.
3. `".git is never watched (HOU-1232)"` passes: no watch handle ever opens for `.git` or its children, including via the rename-notification path (not just the initial directory scan).