### PR TITLE
fix(providers): recognize NVIDIA's Public API Endpoints account gate (HOU-890)

### DIFF
--- a/app/src/components/provider-browser/provider-grouping.ts
+++ b/app/src/components/provider-browser/provider-grouping.ts
@@ -201,6 +201,7 @@ export type ProviderDescriptionKey =
   | "google"
   | "amazon-bedrock"
   | "minimax"
+  | "nvidia"
   | "openai-compatible";
 
 /**
@@ -222,6 +223,7 @@ const DESCRIPTION_KEY_BY_ID = {
   google: "google",
   "amazon-bedrock": "amazon-bedrock",
   minimax: "minimax",
+  nvidia: "nvidia",
   "openai-compatible": "openai-compatible",
 } satisfies Record<string, ProviderDescriptionKey>;
 

--- a/app/src/components/shell/provider-api-key-dialog.tsx
+++ b/app/src/components/shell/provider-api-key-dialog.tsx
@@ -56,6 +56,17 @@ const REASON_COPY: Record<
   provider_unavailable: "apiKey.errorProviderUnavailable",
 };
 
+/**
+ * NVIDIA's `key_restricted` is an ACCOUNT gate, not key settings: NVIDIA has
+ * to enable "Public API Endpoints" on the account's org, so the generic
+ * "create a new key" remedy would send users in circles (HOU-890).
+ */
+function reasonCopyKey(providerId: string, reason: ApiKeyConnectReason) {
+  if (providerId === "nvidia" && reason === "key_restricted")
+    return "apiKey.errorNvidiaAccountGated" as const;
+  return REASON_COPY[reason];
+}
+
 export function ProviderApiKeyDialog({ provider, onClose }: Props) {
   const { t } = useTranslation("providers");
   const [key, setKey] = useState("");
@@ -100,7 +111,9 @@ export function ProviderApiKeyDialog({ provider, onClose }: Props) {
       // Sentry capture already happened in the tauri call wrapper.
       const reason = apiKeyConnectReason(err);
       if (reason) {
-        setError(t(REASON_COPY[reason], { name: provider.name }));
+        setError(
+          t(reasonCopyKey(provider.id, reason), { name: provider.name }),
+        );
       } else {
         const detail = verifyFailureDetail(err);
         console.error(`[provider_api_key_submit] ${detail}`);

--- a/app/src/components/shell/provider-api-key-dialog.tsx
+++ b/app/src/components/shell/provider-api-key-dialog.tsx
@@ -17,6 +17,7 @@ import {
 import type { ProviderInfo } from "../../lib/providers";
 import { tauriProvider, tauriSystem } from "../../lib/tauri";
 import { ProviderApiKeyField } from "./provider-api-key-field";
+import { ProviderApiKeyGuide } from "./provider-api-key-guide";
 
 /**
  * The host's own reason for a rejected connect ("openrouter rejected this API
@@ -153,6 +154,8 @@ export function ProviderApiKeyDialog({ provider, onClose }: Props) {
               {t("apiKey.getKey")}
             </Button>
           )}
+
+          <ProviderApiKeyGuide providerId={provider.id} />
 
           <ProviderApiKeyField
             label={t("apiKey.label")}

--- a/app/src/components/shell/provider-api-key-guide.tsx
+++ b/app/src/components/shell/provider-api-key-guide.tsx
@@ -1,0 +1,33 @@
+import { useTranslation } from "react-i18next";
+
+/**
+ * Per-provider "how to get your key" walkthrough inside the connect dialog.
+ * Only providers whose key page needs a non-obvious choice get one — NVIDIA
+ * first (HOU-890): a working key must be an NGC Personal Key with the
+ * "Public API Endpoints" service included, a picker the quick
+ * build.nvidia.com key flow never shows, so without these steps users mint
+ * keys that fail on every chat model.
+ */
+const GUIDES = {
+  nvidia: [
+    "apiKey.guide.nvidia1",
+    "apiKey.guide.nvidia2",
+    "apiKey.guide.nvidia3",
+  ],
+} as const;
+
+export function ProviderApiKeyGuide({ providerId }: { providerId: string }) {
+  const { t } = useTranslation("providers");
+  const steps = GUIDES[providerId as keyof typeof GUIDES];
+  if (!steps) return null;
+  return (
+    <div className="rounded-xl bg-chip-subtle px-4 py-3">
+      <p className="text-sm font-medium text-ink">{t("apiKey.guide.title")}</p>
+      <ol className="mt-1.5 list-decimal space-y-1 pl-4 text-[13px] leading-relaxed text-ink-muted marker:text-ink-muted">
+        {steps.map((key) => (
+          <li key={key}>{t(key)}</li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -646,7 +646,11 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     subtitle: "NIM inference",
     cost: "Free credits, then pay as you go",
     installUrl: "https://build.nvidia.com",
-    apiKeyUrl: "https://build.nvidia.com/settings/api-keys",
+    // The NGC Personal Key page, NOT build.nvidia.com's quick key flow: only
+    // NGC offers the "Public API Endpoints" service picker a working key
+    // needs (HOU-890) — the connect dialog walks the user through it
+    // (`provider-api-key-guide.tsx`).
+    apiKeyUrl: "https://org.ngc.nvidia.com/setup/api-keys",
   },
   // Alibaba's prepaid token bundles for Qwen (+ hosted open models). The
   // endpoint only accepts the DEDICATED Token Plan API key minted after

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -134,6 +134,9 @@
     "minimax": {
       "description": "Fast, affordable models tuned for agent work."
     },
+    "nvidia": {
+      "description": "Free NVIDIA-hosted models: Llama, Nemotron, GPT-OSS and more."
+    },
     "openai-compatible": {
       "description": "Run models on your own computer with Ollama, LM Studio, and friends."
     }

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -74,6 +74,7 @@
     "cancel": "Cancel",
     "errorInvalidKey": "{{name}} didn't accept this key. Check it and paste it again.",
     "errorKeyRestricted": "This key is blocked by settings in your {{name}} account. Create a new key without restrictions using the button above, then paste it here.",
+    "errorNvidiaAccountGated": "Your key looks valid, but your NVIDIA account can't use the chat API yet. Ask NVIDIA support to enable \"Public API Endpoints\" for your account, then connect again. A new key won't help until they do.",
     "errorProviderUnavailable": "We couldn't reach {{name}} to check your key, so nothing was saved. Please try again in a moment."
   },
   "copilot": {

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -74,7 +74,7 @@
     "cancel": "Cancel",
     "errorInvalidKey": "{{name}} didn't accept this key. Check it and paste it again.",
     "errorKeyRestricted": "This key is blocked by settings in your {{name}} account. Create a new key without restrictions using the button above, then paste it here.",
-    "errorNvidiaAccountGated": "Your key looks valid, but it can't use NVIDIA's chat API. Generate a Personal Key at org.ngc.nvidia.com/setup/api-keys with \"Public API Endpoints\" under Services Included, then paste that key here. If that option doesn't appear, ask NVIDIA support to enable it for your account.",
+    "errorNvidiaAccountGated": "Your key is valid, but NVIDIA isn't serving any chat models to your account right now. Make sure your key is a Personal Key from org.ngc.nvidia.com with \"Public API Endpoints\" under Services Included. If it still fails, ask NVIDIA support to enable model access for your account.",
     "errorProviderUnavailable": "We couldn't reach {{name}} to check your key, so nothing was saved. Please try again in a moment."
   },
   "copilot": {

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -74,7 +74,7 @@
     "cancel": "Cancel",
     "errorInvalidKey": "{{name}} didn't accept this key. Check it and paste it again.",
     "errorKeyRestricted": "This key is blocked by settings in your {{name}} account. Create a new key without restrictions using the button above, then paste it here.",
-    "errorNvidiaAccountGated": "Your key looks valid, but your NVIDIA account can't use the chat API yet. Ask NVIDIA support to enable \"Public API Endpoints\" for your account, then connect again. A new key won't help until they do.",
+    "errorNvidiaAccountGated": "Your key looks valid, but it can't use NVIDIA's chat API. Generate a Personal Key at org.ngc.nvidia.com/setup/api-keys with \"Public API Endpoints\" under Services Included, then paste that key here. If that option doesn't appear, ask NVIDIA support to enable it for your account.",
     "errorProviderUnavailable": "We couldn't reach {{name}} to check your key, so nothing was saved. Please try again in a moment."
   },
   "copilot": {

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -72,6 +72,12 @@
     "save": "Connect",
     "saving": "Connecting...",
     "cancel": "Cancel",
+    "guide": {
+      "title": "How to get your key",
+      "nvidia1": "Open the NVIDIA key page with the button above and sign in, or create a free account.",
+      "nvidia2": "Click \"Generate Personal Key\" and under \"Services Included\" check \"Public API Endpoints\".",
+      "nvidia3": "Copy the key that starts with \"nvapi-\" and paste it below."
+    },
     "errorInvalidKey": "{{name}} didn't accept this key. Check it and paste it again.",
     "errorKeyRestricted": "This key is blocked by settings in your {{name}} account. Create a new key without restrictions using the button above, then paste it here.",
     "errorNvidiaAccountGated": "Your key is valid, but NVIDIA isn't serving any chat models to your account right now. Make sure your key is a Personal Key from org.ngc.nvidia.com with \"Public API Endpoints\" under Services Included. If it still fails, ask NVIDIA support to enable model access for your account.",

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -134,6 +134,9 @@
     "minimax": {
       "description": "Modelos rápidos y económicos ajustados para el trabajo con agentes."
     },
+    "nvidia": {
+      "description": "Modelos gratis alojados por NVIDIA: Llama, Nemotron, GPT-OSS y más."
+    },
     "openai-compatible": {
       "description": "Ejecuta modelos en tu propio computador con Ollama, LM Studio y similares."
     }

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -74,6 +74,7 @@
     "cancel": "Cancelar",
     "errorInvalidKey": "{{name}} no aceptó esta clave. Revísala y pégala de nuevo.",
     "errorKeyRestricted": "Esta clave está bloqueada por la configuración de tu cuenta de {{name}}. Crea una clave nueva sin restricciones con el botón de arriba y pégala aquí.",
+    "errorNvidiaAccountGated": "Tu clave parece válida, pero tu cuenta de NVIDIA todavía no puede usar la API de chat. Pide al soporte de NVIDIA que habilite \"Public API Endpoints\" para tu cuenta y vuelve a conectar. Una clave nueva no servirá hasta que lo hagan.",
     "errorProviderUnavailable": "No pudimos conectar con {{name}} para verificar tu clave, así que no se guardó nada. Inténtalo de nuevo en un momento."
   },
   "copilot": {

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -72,6 +72,12 @@
     "save": "Conectar",
     "saving": "Conectando...",
     "cancel": "Cancelar",
+    "guide": {
+      "title": "Cómo obtener tu clave",
+      "nvidia1": "Abre la página de claves de NVIDIA con el botón de arriba e inicia sesión, o crea una cuenta gratis.",
+      "nvidia2": "Haz clic en \"Generate Personal Key\" y en \"Services Included\" marca \"Public API Endpoints\".",
+      "nvidia3": "Copia la clave que empieza con \"nvapi-\" y pégala abajo."
+    },
     "errorInvalidKey": "{{name}} no aceptó esta clave. Revísala y pégala de nuevo.",
     "errorKeyRestricted": "Esta clave está bloqueada por la configuración de tu cuenta de {{name}}. Crea una clave nueva sin restricciones con el botón de arriba y pégala aquí.",
     "errorNvidiaAccountGated": "Tu clave es válida, pero NVIDIA no está sirviendo modelos de chat a tu cuenta en este momento. Asegúrate de que tu clave sea una Personal Key de org.ngc.nvidia.com con \"Public API Endpoints\" en Services Included. Si aun así falla, pide al soporte de NVIDIA que habilite el acceso a modelos para tu cuenta.",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -74,7 +74,7 @@
     "cancel": "Cancelar",
     "errorInvalidKey": "{{name}} no aceptó esta clave. Revísala y pégala de nuevo.",
     "errorKeyRestricted": "Esta clave está bloqueada por la configuración de tu cuenta de {{name}}. Crea una clave nueva sin restricciones con el botón de arriba y pégala aquí.",
-    "errorNvidiaAccountGated": "Tu clave parece válida, pero tu cuenta de NVIDIA todavía no puede usar la API de chat. Pide al soporte de NVIDIA que habilite \"Public API Endpoints\" para tu cuenta y vuelve a conectar. Una clave nueva no servirá hasta que lo hagan.",
+    "errorNvidiaAccountGated": "Tu clave parece válida, pero no puede usar la API de chat de NVIDIA. Genera una Personal Key en org.ngc.nvidia.com/setup/api-keys con \"Public API Endpoints\" en Services Included y pega esa clave aquí. Si esa opción no aparece, pide al soporte de NVIDIA que la habilite para tu cuenta.",
     "errorProviderUnavailable": "No pudimos conectar con {{name}} para verificar tu clave, así que no se guardó nada. Inténtalo de nuevo en un momento."
   },
   "copilot": {

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -74,7 +74,7 @@
     "cancel": "Cancelar",
     "errorInvalidKey": "{{name}} no aceptó esta clave. Revísala y pégala de nuevo.",
     "errorKeyRestricted": "Esta clave está bloqueada por la configuración de tu cuenta de {{name}}. Crea una clave nueva sin restricciones con el botón de arriba y pégala aquí.",
-    "errorNvidiaAccountGated": "Tu clave parece válida, pero no puede usar la API de chat de NVIDIA. Genera una Personal Key en org.ngc.nvidia.com/setup/api-keys con \"Public API Endpoints\" en Services Included y pega esa clave aquí. Si esa opción no aparece, pide al soporte de NVIDIA que la habilite para tu cuenta.",
+    "errorNvidiaAccountGated": "Tu clave es válida, pero NVIDIA no está sirviendo modelos de chat a tu cuenta en este momento. Asegúrate de que tu clave sea una Personal Key de org.ngc.nvidia.com con \"Public API Endpoints\" en Services Included. Si aun así falla, pide al soporte de NVIDIA que habilite el acceso a modelos para tu cuenta.",
     "errorProviderUnavailable": "No pudimos conectar con {{name}} para verificar tu clave, así que no se guardó nada. Inténtalo de nuevo en un momento."
   },
   "copilot": {

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -134,6 +134,9 @@
     "minimax": {
       "description": "Modelos rápidos e acessíveis ajustados para o trabalho com agentes."
     },
+    "nvidia": {
+      "description": "Modelos grátis hospedados pela NVIDIA: Llama, Nemotron, GPT-OSS e mais."
+    },
     "openai-compatible": {
       "description": "Rode modelos no seu próprio computador com Ollama, LM Studio e afins."
     }

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -74,7 +74,7 @@
     "cancel": "Cancelar",
     "errorInvalidKey": "{{name}} não aceitou esta chave. Confira e cole de novo.",
     "errorKeyRestricted": "Esta chave está bloqueada pelas configurações da sua conta {{name}}. Crie uma chave nova sem restrições usando o botão acima e cole aqui.",
-    "errorNvidiaAccountGated": "Sua chave parece válida, mas não pode usar a API de chat da NVIDIA. Gere uma Personal Key em org.ngc.nvidia.com/setup/api-keys com \"Public API Endpoints\" em Services Included e cole essa chave aqui. Se essa opção não aparecer, peça ao suporte da NVIDIA para habilitar na sua conta.",
+    "errorNvidiaAccountGated": "Sua chave é válida, mas a NVIDIA não está servindo modelos de chat para a sua conta neste momento. Confira se sua chave é uma Personal Key de org.ngc.nvidia.com com \"Public API Endpoints\" em Services Included. Se ainda falhar, peça ao suporte da NVIDIA para habilitar o acesso aos modelos na sua conta.",
     "errorProviderUnavailable": "Não conseguimos acessar {{name}} para verificar sua chave, então nada foi salvo. Tente de novo em instantes."
   },
   "copilot": {

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -74,7 +74,7 @@
     "cancel": "Cancelar",
     "errorInvalidKey": "{{name}} não aceitou esta chave. Confira e cole de novo.",
     "errorKeyRestricted": "Esta chave está bloqueada pelas configurações da sua conta {{name}}. Crie uma chave nova sem restrições usando o botão acima e cole aqui.",
-    "errorNvidiaAccountGated": "Sua chave parece válida, mas sua conta NVIDIA ainda não pode usar a API de chat. Peça ao suporte da NVIDIA para habilitar \"Public API Endpoints\" na sua conta e conecte de novo. Uma chave nova não vai ajudar até que eles façam isso.",
+    "errorNvidiaAccountGated": "Sua chave parece válida, mas não pode usar a API de chat da NVIDIA. Gere uma Personal Key em org.ngc.nvidia.com/setup/api-keys com \"Public API Endpoints\" em Services Included e cole essa chave aqui. Se essa opção não aparecer, peça ao suporte da NVIDIA para habilitar na sua conta.",
     "errorProviderUnavailable": "Não conseguimos acessar {{name}} para verificar sua chave, então nada foi salvo. Tente de novo em instantes."
   },
   "copilot": {

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -74,6 +74,7 @@
     "cancel": "Cancelar",
     "errorInvalidKey": "{{name}} não aceitou esta chave. Confira e cole de novo.",
     "errorKeyRestricted": "Esta chave está bloqueada pelas configurações da sua conta {{name}}. Crie uma chave nova sem restrições usando o botão acima e cole aqui.",
+    "errorNvidiaAccountGated": "Sua chave parece válida, mas sua conta NVIDIA ainda não pode usar a API de chat. Peça ao suporte da NVIDIA para habilitar \"Public API Endpoints\" na sua conta e conecte de novo. Uma chave nova não vai ajudar até que eles façam isso.",
     "errorProviderUnavailable": "Não conseguimos acessar {{name}} para verificar sua chave, então nada foi salvo. Tente de novo em instantes."
   },
   "copilot": {

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -72,6 +72,12 @@
     "save": "Conectar",
     "saving": "Conectando...",
     "cancel": "Cancelar",
+    "guide": {
+      "title": "Como obter sua chave",
+      "nvidia1": "Abra a página de chaves da NVIDIA com o botão acima e faça login, ou crie uma conta grátis.",
+      "nvidia2": "Clique em \"Generate Personal Key\" e em \"Services Included\" marque \"Public API Endpoints\".",
+      "nvidia3": "Copie a chave que começa com \"nvapi-\" e cole abaixo."
+    },
     "errorInvalidKey": "{{name}} não aceitou esta chave. Confira e cole de novo.",
     "errorKeyRestricted": "Esta chave está bloqueada pelas configurações da sua conta {{name}}. Crie uma chave nova sem restrições usando o botão acima e cole aqui.",
     "errorNvidiaAccountGated": "Sua chave é válida, mas a NVIDIA não está servindo modelos de chat para a sua conta neste momento. Confira se sua chave é uma Personal Key de org.ngc.nvidia.com com \"Public API Endpoints\" em Services Included. Se ainda falhar, peça ao suporte da NVIDIA para habilitar o acesso aos modelos na sua conta.",

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -791,6 +791,60 @@ test("NVIDIA NIM 403 'Authorization failed' → unauthenticated / invalid_api_ke
   if (err.kind === "unauthenticated") expect(err.cause).toBe("invalid_api_key");
 });
 
+test("NVIDIA body-less 410 (Public API Endpoints gate) → unauthenticated (HOU-890)", () => {
+  // Verbatim OpenAI-SDK flattening of integrate.api.nvidia.com's empty 410:
+  // the key authenticated (a bad key answers 403 "Authorization failed"), but
+  // the account's org lacks the "Public API Endpoints" permission, so EVERY
+  // chat completion dies while /v1/models still works. Routed to the reconnect
+  // surface, whose re-verify names NVIDIA's remedy (key_restricted).
+  const err = classifyProviderError({
+    provider: "nvidia",
+    model: "google/gemma-3-12b-it",
+    message: "410 status code (no body)",
+  });
+  expect(err.kind).toBe("unauthenticated");
+  if (err.kind === "unauthenticated") expect(err.cause).toBe("invalid_api_key");
+});
+
+test("NVIDIA body-less 404 (same gate, NVIDIA's newer status) → unauthenticated (HOU-890)", () => {
+  const err = classifyProviderError({
+    provider: "nvidia",
+    model: "google/gemma-3-12b-it",
+    message: "404 status code (no body)",
+  });
+  expect(err.kind).toBe("unauthenticated");
+});
+
+test("NVIDIA 404 'Function not found for account' → unauthenticated (HOU-890)", () => {
+  const err = classifyProviderError({
+    provider: "nvidia",
+    model: "meta/llama-3.3-70b-instruct",
+    message: "404 Function not found for account",
+  });
+  expect(err.kind).toBe("unauthenticated");
+});
+
+test("NVIDIA 404 WITH a real error body stays out of the gate branch", () => {
+  // A JSON detail sentence means a specific failure (e.g. a retired model id),
+  // not the account gate — must keep falling through, never the reconnect card.
+  const err = classifyProviderError({
+    provider: "nvidia",
+    model: "meta/llama-3.1-70b-instruct",
+    message:
+      '404: {"status":404,"title":"Not Found","detail":"Model meta/llama-3.1-70b-instruct not found"}',
+  });
+  expect(err.kind).toBe("unknown");
+});
+
+test("a body-less 410 from another provider stays unknown", () => {
+  const err = classifyProviderError({
+    provider: "openrouter",
+    model: "some/model",
+    message: "410 status code (no body)",
+  });
+  expect(err.kind).toBe("unknown");
+});
+
 test("Qwen Token Plan 401 'Invalid API-key provided' → unauthenticated / invalid_api_key", () => {
   // Verbatim token-plan.ap-southeast-1.maas.aliyuncs.com body (HOU-1077). The
   // endpoint only accepts a DEDICATED Token Plan key — a regular Model Studio

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -791,47 +791,63 @@ test("NVIDIA NIM 403 'Authorization failed' → unauthenticated / invalid_api_ke
   if (err.kind === "unauthenticated") expect(err.cause).toBe("invalid_api_key");
 });
 
-test("NVIDIA body-less 410 (Public API Endpoints gate) → unauthenticated (HOU-890)", () => {
+test("NVIDIA body-less 410 (per-account model gate) → model_unavailable with the broad fallback (HOU-890)", () => {
   // Verbatim OpenAI-SDK flattening of integrate.api.nvidia.com's empty 410:
   // the key authenticated (a bad key answers 403 "Authorization failed"), but
-  // the account's org lacks the "Public API Endpoints" permission, so EVERY
-  // chat completion dies while /v1/models still works. Routed to the reconnect
-  // surface, whose re-verify names NVIDIA's remedy (key_restricted).
+  // THIS model isn't served for the account, while /v1/models still lists it.
+  // The switch-model card with a one-click broadly-served target is the
+  // honest surface — re-keying can never fix a gated model.
   const err = classifyProviderError({
     provider: "nvidia",
     model: "google/gemma-3-12b-it",
     message: "410 status code (no body)",
   });
-  expect(err.kind).toBe("unauthenticated");
-  if (err.kind === "unauthenticated") expect(err.cause).toBe("invalid_api_key");
+  expect(err.kind).toBe("model_unavailable");
+  if (err.kind === "model_unavailable")
+    expect(err.suggested_fallback).toBe("meta/llama-3.3-70b-instruct");
 });
 
-test("NVIDIA body-less 404 (same gate, NVIDIA's newer status) → unauthenticated (HOU-890)", () => {
+test("NVIDIA body-less 404 (same gate, NVIDIA's newer status) → model_unavailable (HOU-890)", () => {
   const err = classifyProviderError({
     provider: "nvidia",
     model: "google/gemma-3-12b-it",
     message: "404 status code (no body)",
   });
-  expect(err.kind).toBe("unauthenticated");
+  expect(err.kind).toBe("model_unavailable");
 });
 
-test("NVIDIA 404 'Function not found for account' → unauthenticated (HOU-890)", () => {
+test("NVIDIA 404 'Not found for account' body → model_unavailable (HOU-890)", () => {
+  // Verbatim shape from a live partially-gated account (uuids/ids synthetic):
+  // gemma/kimi/glm answered this while llama/gpt-oss served fine on the SAME
+  // key — proof the gate is per-model, not per-key.
+  const err = classifyProviderError({
+    provider: "nvidia",
+    model: "moonshotai/kimi-k2.6",
+    message:
+      '404: {"status":404,"title":"Not Found","detail":"Function \'23d4f03a-0000-4adb-a183-000000000000\': Not found for account \'AAAA_0TTwo6g9X0i9D1GDz8lMxxCukw55Lpk8aPhW0I\'"}',
+  });
+  expect(err.kind).toBe("model_unavailable");
+});
+
+test("NVIDIA gate on the broad fallback itself offers no fallback", () => {
   const err = classifyProviderError({
     provider: "nvidia",
     model: "meta/llama-3.3-70b-instruct",
-    message: "404 Function not found for account",
+    message: "404 status code (no body)",
   });
-  expect(err.kind).toBe("unauthenticated");
+  expect(err.kind).toBe("model_unavailable");
+  if (err.kind === "model_unavailable")
+    expect(err.suggested_fallback).toBeNull();
 });
 
-test("NVIDIA 404 WITH a real error body stays out of the gate branch", () => {
-  // A JSON detail sentence means a specific failure (e.g. a retired model id),
-  // not the account gate — must keep falling through, never the reconnect card.
+test("NVIDIA 404 WITH an unrelated error body stays out of the gate branch", () => {
+  // A detail sentence that names neither a function nor the account means a
+  // different failure — must keep falling through to `unknown`.
   const err = classifyProviderError({
     provider: "nvidia",
     model: "meta/llama-3.1-70b-instruct",
     message:
-      '404: {"status":404,"title":"Not Found","detail":"Model meta/llama-3.1-70b-instruct not found"}',
+      '404: {"status":404,"title":"Not Found","detail":"Model meta/llama-3.1-70b-instruct does not exist"}',
   });
   expect(err.kind).toBe("unknown");
 });

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -222,21 +222,23 @@ const COPILOT_BASE_FALLBACK = "gpt-4.1";
 const EXCERPT_MAX = 300;
 
 /**
- * NVIDIA's account-level "Public API Endpoints" gate (HOU-890). Since mid-2026
- * integrate.api.nvidia.com serves POST /chat/completions only to NVIDIA
- * accounts whose org carries the "Public API Endpoints" permission; an account
- * without it fails EVERY completion with a body-less 410 or a 404 ("Function
- * not found for account") — while /v1/models still lists everything and the
- * key itself passes auth (a bad key answers 403 "Authorization failed"
- * instead, already classified via INVALID_KEY_PATTERNS). Re-keying never
- * fixes it; only NVIDIA enabling the permission does — so the connect-time
- * verifier throws `key_restricted` off this same predicate and the chat
- * classifier routes it to the reconnect surface, whose re-verify then names
- * that remedy. Body-less statuses arrive from the OpenAI SDK flattened to
- * `<status> status code (no body)`; a REAL NVIDIA failure (e.g. a retired
- * model id) carries a JSON body with a detail sentence and must not trip this.
+ * NVIDIA's per-account model gate (HOU-890). integrate.api.nvidia.com serves
+ * each hosted model ("function") per account: since mid-2026 an account may
+ * lack the whole "Public API Endpoints" permission (every completion fails)
+ * or, verified live against a real key, just PART of the catalog — gemma /
+ * kimi / glm / nemotron answered `404 Function '<uuid>': Not found for
+ * account '<id>'` while llama / gpt-oss / minimax served fine on the same
+ * key. /v1/models still lists everything and the key itself passes auth (a
+ * bad key answers 403 "Authorization failed" instead, already classified via
+ * INVALID_KEY_PATTERNS). The statuses also arrive body-less (a 410 wave in
+ * July, then 404s) — the OpenAI SDK flattens those to `<status> status code
+ * (no body)`. Re-keying never fixes a gated model; switching models usually
+ * does — so the chat classifier turns this into `model_unavailable` with a
+ * broadly-served fallback, and the connect-time verifier retries those
+ * fallbacks before giving a verdict (`key_restricted` only when every probe
+ * is gated).
  */
-export function isNvidiaEndpointGated(
+export function isNvidiaFunctionGated(
   provider: string,
   lowerMessage: string,
   status: number | null,
@@ -245,9 +247,19 @@ export function isNvidiaEndpointGated(
   if (status !== 404 && status !== 410) return false;
   return (
     lowerMessage.includes("(no body)") ||
-    lowerMessage.includes("function not found")
+    lowerMessage.includes("function not found") ||
+    lowerMessage.includes("not found for account")
   );
 }
+
+/**
+ * The NVIDIA model offered as the one-click switch target on a gated model's
+ * `model_unavailable` card — served to every account we have evidence from
+ * (including the partially-gated one above). Duplicated from the runtime's
+ * NVIDIA default on purpose, like COPILOT_BASE_FALLBACK, so this classifier
+ * stays pure.
+ */
+const NVIDIA_BROAD_FALLBACK = "meta/llama-3.3-70b-instruct";
 
 /**
  * Map a failed model request to a typed `ProviderError`, then stamp WHOSE
@@ -293,16 +305,20 @@ function classify(input: ProviderErrorInput): ProviderError {
   const lower = message.toLowerCase();
   const status = input.status ?? extractHttpStatus(message);
 
-  // NVIDIA's "Public API Endpoints" account gate reads as an auth failure on
-  // purpose: the reconnect card is the same surface its 403 key rejection
-  // already uses (HOU-1077), and reconnecting re-runs verification, which
-  // names the real remedy. Checked before `isAuth`, whose known-non-auth
-  // status guard would veto the 404/410.
-  if (isNvidiaEndpointGated(provider, lower, status)) {
+  // NVIDIA's per-account model gate: the credential is fine, THIS model is
+  // simply not served for the account (`isNvidiaFunctionGated`), so the
+  // honest card is switch-model with a broadly-served one-click target —
+  // never the reconnect card (re-keying can't fix it) and never the generic
+  // unknown card. Checked first: the body-less 404/410 carries none of the
+  // wording the later branches key on.
+  if (model && isNvidiaFunctionGated(provider, lower, status)) {
     return {
-      kind: "unauthenticated",
+      kind: "model_unavailable",
       provider,
-      cause: "invalid_api_key",
+      model,
+      reason: "unknown",
+      suggested_fallback:
+        model === NVIDIA_BROAD_FALLBACK ? null : NVIDIA_BROAD_FALLBACK,
       message,
     };
   }

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -222,6 +222,34 @@ const COPILOT_BASE_FALLBACK = "gpt-4.1";
 const EXCERPT_MAX = 300;
 
 /**
+ * NVIDIA's account-level "Public API Endpoints" gate (HOU-890). Since mid-2026
+ * integrate.api.nvidia.com serves POST /chat/completions only to NVIDIA
+ * accounts whose org carries the "Public API Endpoints" permission; an account
+ * without it fails EVERY completion with a body-less 410 or a 404 ("Function
+ * not found for account") — while /v1/models still lists everything and the
+ * key itself passes auth (a bad key answers 403 "Authorization failed"
+ * instead, already classified via INVALID_KEY_PATTERNS). Re-keying never
+ * fixes it; only NVIDIA enabling the permission does — so the connect-time
+ * verifier throws `key_restricted` off this same predicate and the chat
+ * classifier routes it to the reconnect surface, whose re-verify then names
+ * that remedy. Body-less statuses arrive from the OpenAI SDK flattened to
+ * `<status> status code (no body)`; a REAL NVIDIA failure (e.g. a retired
+ * model id) carries a JSON body with a detail sentence and must not trip this.
+ */
+export function isNvidiaEndpointGated(
+  provider: string,
+  lowerMessage: string,
+  status: number | null,
+): boolean {
+  if (provider !== "nvidia") return false;
+  if (status !== 404 && status !== 410) return false;
+  return (
+    lowerMessage.includes("(no body)") ||
+    lowerMessage.includes("function not found")
+  );
+}
+
+/**
  * Map a failed model request to a typed `ProviderError`, then stamp WHOSE
  * credential ran the turn (`stampCredentialScope`).
  *
@@ -265,6 +293,19 @@ function classify(input: ProviderErrorInput): ProviderError {
   const lower = message.toLowerCase();
   const status = input.status ?? extractHttpStatus(message);
 
+  // NVIDIA's "Public API Endpoints" account gate reads as an auth failure on
+  // purpose: the reconnect card is the same surface its 403 key rejection
+  // already uses (HOU-1077), and reconnecting re-runs verification, which
+  // names the real remedy. Checked before `isAuth`, whose known-non-auth
+  // status guard would veto the 404/410.
+  if (isNvidiaEndpointGated(provider, lower, status)) {
+    return {
+      kind: "unauthenticated",
+      provider,
+      cause: "invalid_api_key",
+      message,
+    };
+  }
   if (isAuth(lower, status)) {
     return {
       kind: "unauthenticated",

--- a/packages/runtime/src/ai/providers.ts
+++ b/packages/runtime/src/ai/providers.ts
@@ -206,11 +206,27 @@ function saveSettings(s: Settings) {
   renameSync(tmp, settingsFile);
 }
 
+/**
+ * Uncurated providers whose alphabetically-first catalog model is a bad
+ * default. NVIDIA serves each hosted model per ACCOUNT (HOU-890): the
+ * catalog's first row (google/gemma-3-12b-it) answers `404 Function not
+ * found for account` for many accounts, so defaulting to it broke both key
+ * verification and the first chat; meta/llama-3.3-70b-instruct is served to
+ * every account we have evidence from (keep in sync with the classifier's
+ * NVIDIA_BROAD_FALLBACK and the verifier's NVIDIA_VERIFY_FALLBACKS).
+ */
+const UNCURATED_DEFAULT_MODEL: Record<string, string> = {
+  nvidia: "meta/llama-3.3-70b-instruct",
+};
+
 function defaultModel(provider: ProviderId): string {
   const found = PROVIDERS.find((p) => p.id === provider);
   if (found) return found.defaultModel;
-  // Uncurated pi provider: no configured default, so start on the first model
-  // pi lists for it rather than hard-failing the picker/turn.
+  // Uncurated pi provider: no configured default, so start on the hand-picked
+  // override when one exists (and pi still lists it), else the first model pi
+  // lists, rather than hard-failing the picker/turn.
+  const preferred = UNCURATED_DEFAULT_MODEL[provider];
+  if (preferred && piModelIds(provider).includes(preferred)) return preferred;
   const first = firstCatalogModel(provider);
   if (first) return first;
   throw new Error(`unknown provider: ${provider}`);

--- a/packages/runtime/src/auth/nvidia-verify.ts
+++ b/packages/runtime/src/auth/nvidia-verify.ts
@@ -1,0 +1,66 @@
+import { extractHttpStatus, isNvidiaFunctionGated } from "../ai/provider-error";
+import { safeGetModel } from "../ai/providers";
+import { ApiKeyVerifyError } from "./verify-errors";
+
+/**
+ * NVIDIA's per-account model gate at connect time (HOU-890). NVIDIA serves
+ * each hosted model ("function") per account, so the verify probe's model
+ * being gated proves nothing about the KEY — verified live: the same key
+ * answered `404 Not found for account` on gemma and 200 on llama. Before any
+ * verdict, retry broadly-served models; only when EVERY probe is gated is the
+ * account behind the "Public API Endpoints" wall, and that verdict must be
+ * `key_restricted` — NOT invalid_key ("paste it again") and NOT
+ * provider_unavailable ("try again in a moment"), neither of which can work.
+ */
+
+/** A completion probe: `null` = the provider accepted the request. */
+type Probe = (model: ReturnType<typeof safeGetModel>) => Promise<string | null>;
+
+/**
+ * Models served to every NVIDIA account we have evidence from — small, fast,
+ * non-reasoning rows so the extra probes stay well inside the dialog's
+ * patience. The first is also the runtime's NVIDIA default model
+ * (`UNCURATED_DEFAULT_MODEL`) and the classifier's suggested fallback.
+ */
+const NVIDIA_VERIFY_FALLBACKS = [
+  "meta/llama-3.3-70b-instruct",
+  "meta/llama-3.1-8b-instruct",
+];
+
+export function nvidiaGated(providerId: string, message: string): boolean {
+  return isNvidiaFunctionGated(
+    providerId,
+    message.toLowerCase(),
+    extractHttpStatus(message),
+  );
+}
+
+/**
+ * Resolve a gated first probe: `null` = a fallback model verified the key.
+ * A non-gated failure is returned so the caller's normal classification (403
+ * bad key, network, …) owns the verdict; all-gated throws `key_restricted`.
+ */
+export async function retryNvidiaFallbacks(
+  providerId: string,
+  triedModelId: string,
+  gatedMessage: string,
+  probe: Probe,
+): Promise<string | null> {
+  for (const id of NVIDIA_VERIFY_FALLBACKS) {
+    if (id === triedModelId) continue;
+    let fallback: ReturnType<typeof safeGetModel>;
+    try {
+      fallback = safeGetModel(providerId, id, true);
+    } catch {
+      continue; // catalog drift — this fallback id no longer exists
+    }
+    const message = await probe(fallback);
+    if (message === null) return null;
+    if (!nvidiaGated(providerId, message)) return message;
+    gatedMessage = message;
+  }
+  throw new ApiKeyVerifyError(
+    `${providerId} accepted the key, but this NVIDIA account is not being served any of the chat models Houston tried (${gatedMessage})`,
+    "key_restricted",
+  );
+}

--- a/packages/runtime/src/auth/verify-api-key.test.ts
+++ b/packages/runtime/src/auth/verify-api-key.test.ts
@@ -156,6 +156,50 @@ test("a gated model (together's 'Unable to access model') proves auth — verifi
   await expect(verifyApiKey("together", "sk-valid")).resolves.toBeUndefined();
 });
 
+test("nvidia: a body-less 410 (Public API Endpoints gate) rejects as key_restricted", async () => {
+  // The key PASSED auth (a bad key answers 403 "Authorization failed"), but
+  // the NVIDIA account's org lacks the "Public API Endpoints" permission, so
+  // every completion dies with an empty 410/404 (HOU-890). Re-pasting a key
+  // can never fix it, so the verdict must be key_restricted with NVIDIA's
+  // remedy — NOT provider_unavailable ("try again in a moment") and NOT
+  // invalid_key ("paste it again").
+  completeSimple.mockResolvedValue(
+    reply({ stopReason: "error", errorMessage: "410 status code (no body)" }),
+  );
+  await expect(verifyApiKey("nvidia", "nvapi-valid")).rejects.toMatchObject({
+    name: "ApiKeyVerifyError",
+    reason: "key_restricted",
+    message: expect.stringMatching(/Public API Endpoints/),
+  });
+});
+
+test("nvidia: 404 'Function not found for account' rejects as key_restricted", async () => {
+  completeSimple.mockResolvedValue(
+    reply({
+      stopReason: "error",
+      errorMessage: "404 Function not found for account",
+    }),
+  );
+  await expect(verifyApiKey("nvidia", "nvapi-valid")).rejects.toMatchObject({
+    reason: "key_restricted",
+  });
+});
+
+test("nvidia: 403 'Authorization failed' still rejects as invalid_key", async () => {
+  // A genuinely bad or revoked key — the HOU-1077 classification must keep
+  // owning this shape; only the 404/410 gate reads key_restricted.
+  completeSimple.mockResolvedValue(
+    reply({
+      stopReason: "error",
+      errorMessage:
+        '403: {"status":403,"title":"Forbidden","detail":"Authorization failed"}',
+    }),
+  );
+  await expect(verifyApiKey("nvidia", "nvapi-bad")).rejects.toMatchObject({
+    reason: "invalid_key",
+  });
+});
+
 test("an abort/timeout maps to a readable did-not-answer message", () => {
   // Tested on the pure mapper: rejecting the mocked completeSimple with an
   // abort-named error trips vitest's runner (it attributes the error object to

--- a/packages/runtime/src/auth/verify-api-key.test.ts
+++ b/packages/runtime/src/auth/verify-api-key.test.ts
@@ -17,7 +17,7 @@ vi.mock("@earendil-works/pi-ai/compat", async (importOriginal) => ({
 }));
 vi.mock("../ai/providers", () => ({
   modelFor: () => "test-model",
-  safeGetModel: (provider: string) =>
+  safeGetModel: (provider: string, modelId: string) =>
     provider === "google"
       ? {
           id: "gemini-3.5-flash",
@@ -25,7 +25,7 @@ vi.mock("../ai/providers", () => ({
           api: "google-generative-ai",
           baseUrl: "https://generativelanguage.googleapis.com/v1beta",
         }
-      : { id: "test-model", provider: "openrouter" },
+      : { id: modelId ?? "test-model", provider },
 }));
 
 import {
@@ -156,32 +156,54 @@ test("a gated model (together's 'Unable to access model') proves auth — verifi
   await expect(verifyApiKey("together", "sk-valid")).resolves.toBeUndefined();
 });
 
-test("nvidia: a body-less 410 (Public API Endpoints gate) rejects as key_restricted", async () => {
-  // The key PASSED auth (a bad key answers 403 "Authorization failed"), but
-  // the NVIDIA account's org lacks the "Public API Endpoints" permission, so
-  // every completion dies with an empty 410/404 (HOU-890). Re-pasting a key
-  // can never fix it, so the verdict must be key_restricted with NVIDIA's
-  // remedy — NOT provider_unavailable ("try again in a moment") and NOT
-  // invalid_key ("paste it again").
-  completeSimple.mockResolvedValue(
-    reply({ stopReason: "error", errorMessage: "410 status code (no body)" }),
-  );
+const nvidiaGate = (model: string) =>
+  reply({
+    stopReason: "error",
+    errorMessage: `404: {"status":404,"title":"Not Found","detail":"Function '23d4f03a-0000-4adb-a183-000000000000': Not found for account 'AAAA_synthetic'"} (${model})`,
+  });
+
+test("nvidia: a gated probe model retries a broadly-served fallback — key verified", async () => {
+  // Live evidence (HOU-890): the SAME key answered `404 Not found for
+  // account` on gemma and 200 on llama — NVIDIA gates models per account, so
+  // one gated probe proves nothing about the key. The verifier must try the
+  // fallback list before any verdict.
+  completeSimple
+    .mockResolvedValueOnce(nvidiaGate("test-model"))
+    .mockResolvedValueOnce(reply({}));
+  await expect(verifyApiKey("nvidia", "nvapi-valid")).resolves.toBeUndefined();
+  expect(completeSimple).toHaveBeenCalledTimes(2);
+  // The fallback probe ran against a model NVIDIA serves broadly.
+  const fallbackModel = completeSimple.mock.calls[1][0] as { id: string };
+  expect(fallbackModel.id).toBe("meta/llama-3.3-70b-instruct");
+});
+
+test("nvidia: every probe gated rejects as key_restricted", async () => {
+  // The account-level "Public API Endpoints" wall: primary + both fallbacks
+  // all answer the gate. NOT provider_unavailable ("try again in a moment")
+  // and NOT invalid_key ("paste it again") — neither remedy can work.
+  completeSimple.mockResolvedValue(nvidiaGate("any"));
   await expect(verifyApiKey("nvidia", "nvapi-valid")).rejects.toMatchObject({
     name: "ApiKeyVerifyError",
     reason: "key_restricted",
-    message: expect.stringMatching(/Public API Endpoints/),
+    message: expect.stringMatching(/not being served/),
   });
+  expect(completeSimple).toHaveBeenCalledTimes(3);
 });
 
-test("nvidia: 404 'Function not found for account' rejects as key_restricted", async () => {
-  completeSimple.mockResolvedValue(
-    reply({
-      stopReason: "error",
-      errorMessage: "404 Function not found for account",
-    }),
-  );
-  await expect(verifyApiKey("nvidia", "nvapi-valid")).rejects.toMatchObject({
-    reason: "key_restricted",
+test("nvidia: a gated probe then a 403 on the fallback rejects as invalid_key", async () => {
+  // A non-gate failure on a fallback probe hands the verdict to the normal
+  // classification path — here NVIDIA's bad-key rejection.
+  completeSimple
+    .mockResolvedValueOnce(nvidiaGate("test-model"))
+    .mockResolvedValueOnce(
+      reply({
+        stopReason: "error",
+        errorMessage:
+          '403: {"status":403,"title":"Forbidden","detail":"Authorization failed"}',
+      }),
+    );
+  await expect(verifyApiKey("nvidia", "nvapi-bad")).rejects.toMatchObject({
+    reason: "invalid_key",
   });
 });
 

--- a/packages/runtime/src/auth/verify-api-key.ts
+++ b/packages/runtime/src/auth/verify-api-key.ts
@@ -1,18 +1,29 @@
 import { completeSimple } from "@earendil-works/pi-ai/compat";
-import {
-  classifyProviderError,
-  extractHttpStatus,
-  isNvidiaEndpointGated,
-} from "../ai/provider-error";
+import { classifyProviderError } from "../ai/provider-error";
 import { modelFor, safeGetModel } from "../ai/providers";
+import { nvidiaGated, retryNvidiaFallbacks } from "./nvidia-verify";
+import {
+  ApiKeyVerifyError,
+  noVerdict,
+  raisedMessage,
+  rejected,
+  VERIFY_TIMEOUT_MS,
+} from "./verify-errors";
+
+export type { ApiKeyVerifyReason } from "./verify-errors";
+// The stable public surface (host routes, login, tests) predates the module
+// split — keep serving it from here.
+export { ApiKeyVerifyError, raisedMessage } from "./verify-errors";
 
 /**
  * Prove a pasted API key actually authenticates before it is stored (HOU: any
  * pasted string — even "aa" — used to read "connected" and only fail on the
  * first chat turn). One 1-token completion against the model a chat would use,
  * with the CANDIDATE key passed per-request (`StreamOptions.apiKey`) so nothing
- * touches auth.json until the provider accepts it. Google is the exception —
- * see `verifyGoogleApiKey`.
+ * touches auth.json until the provider accepts it. Two provider exceptions:
+ * Google rides the models-LIST endpoint (`verifyGoogleApiKey`), and NVIDIA
+ * retries broadly-served models when the probe model is gated per-account
+ * (`nvidia-verify.ts`, HOU-890).
  *
  * Accept/reject is decided on the shared `ProviderError` taxonomy:
  *  - the completion succeeds → verified;
@@ -24,7 +35,6 @@ import { modelFor, safeGetModel } from "../ai/providers";
  *    and the key is NOT stored. Beta policy: a connect that can't be proven is
  *    a visible failure, never a silent "connected".
  */
-const VERIFY_TIMEOUT_MS = 20_000;
 
 /** Error kinds that prove the credential was ACCEPTED by the provider. */
 const PROVES_AUTH = new Set([
@@ -33,48 +43,6 @@ const PROVES_AUTH = new Set([
   "model_unavailable",
   "context_overflow",
 ]);
-
-/**
- * Human-readable text for an exception the verify request RAISED (vs a resolved
- * errored reply). An abort/timeout DOMException reads like a bug ("The
- * operation was aborted due to timeout"), so name what actually happened —
- * that text reaches the user verbatim through the connect dialog.
- */
-export function raisedMessage(e: unknown, providerId: string): string {
-  if (
-    e instanceof Error &&
-    (e.name === "TimeoutError" || e.name === "AbortError")
-  ) {
-    return `${providerId} did not answer within ${VERIFY_TIMEOUT_MS / 1000}s`;
-  }
-  return e instanceof Error ? e.message : String(e);
-}
-
-/**
- * Why a key failed verification, carried on the wire (`/auth/:provider/api-key`
- * 401 body `reason`) so the connect dialog can show actionable copy instead of
- * a generic failure:
- *  - `invalid_key` — the provider rejected the credential itself; re-paste.
- *  - `key_restricted` — the key authenticates but its OWN settings block
- *    Houston (Google: the Gemini API is not enabled on the key's Cloud
- *    project, or a referrer/IP allowlist a server-side call can never
- *    satisfy); the fix is a new unrestricted key, not re-pasting this one.
- *  - `provider_unavailable` — no verdict (5xx / network / timeout); retry.
- */
-export type ApiKeyVerifyReason =
-  | "invalid_key"
-  | "key_restricted"
-  | "provider_unavailable";
-
-export class ApiKeyVerifyError extends Error {
-  constructor(
-    message: string,
-    public readonly reason: ApiKeyVerifyReason,
-  ) {
-    super(message);
-    this.name = "ApiKeyVerifyError";
-  }
-}
 
 export async function verifyApiKey(
   providerId: string,
@@ -89,7 +57,39 @@ export async function verifyApiKey(
     return;
   }
 
-  let message: string;
+  let message = await probeCompletion(providerId, model, key);
+  if (message === null) return;
+
+  // NVIDIA serves each model per account (HOU-890): the probe model being
+  // gated proves nothing about the KEY, so retry broadly-served models before
+  // any verdict (all-gated throws key_restricted from nvidia-verify.ts).
+  if (nvidiaGated(providerId, message)) {
+    message = await retryNvidiaFallbacks(providerId, model.id, message, (m) =>
+      probeCompletion(providerId, m, key),
+    );
+    if (message === null) return;
+  }
+
+  const classified = classifyProviderError({
+    provider: providerId,
+    model: model.id,
+    message,
+  });
+  if (PROVES_AUTH.has(classified.kind)) return;
+  if (classified.kind === "unauthenticated")
+    throw rejected(providerId, message);
+  throw noVerdict(providerId, message);
+}
+
+/**
+ * One 1-token completion probe. `null` = the provider ACCEPTED the request
+ * (key verified); otherwise the failure text for classification.
+ */
+async function probeCompletion(
+  providerId: string,
+  model: Parameters<typeof completeSimple>[0],
+  key: string,
+): Promise<string | null> {
   try {
     const reply = await completeSimple(
       model,
@@ -102,42 +102,13 @@ export async function verifyApiKey(
         signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
       },
     );
-    if (reply.stopReason !== "error") return;
-    message = reply.errorMessage ?? "unknown provider error";
+    if (reply.stopReason !== "error") return null;
+    return reply.errorMessage ?? "unknown provider error";
   } catch (e) {
     // pi raises (rather than resolving an errored message) for pre-request
     // failures; a timeout lands here too. Same classification path.
-    message = raisedMessage(e, providerId);
+    return raisedMessage(e, providerId);
   }
-
-  // NVIDIA's "Public API Endpoints" account gate (HOU-890): the key passed
-  // auth (a bad key answers 403), but the ACCOUNT cannot call chat completions
-  // until NVIDIA enables that permission. Checked before classification, which
-  // deliberately reads this shape as `unauthenticated` for the chat surface —
-  // here that verdict would say "re-paste the key", the one remedy that can't
-  // work, so the typed reason must be `key_restricted` with NVIDIA's fix.
-  if (
-    isNvidiaEndpointGated(
-      providerId,
-      message.toLowerCase(),
-      extractHttpStatus(message),
-    )
-  ) {
-    throw new ApiKeyVerifyError(
-      `${providerId} accepted the key, but this NVIDIA account cannot call the chat API until NVIDIA enables its "Public API Endpoints" permission (${message})`,
-      "key_restricted",
-    );
-  }
-
-  const classified = classifyProviderError({
-    provider: providerId,
-    model: model.id,
-    message,
-  });
-  if (PROVES_AUTH.has(classified.kind)) return;
-  if (classified.kind === "unauthenticated")
-    throw rejected(providerId, message);
-  throw noVerdict(providerId, message);
 }
 
 /**
@@ -189,18 +160,4 @@ async function googleErrorMessage(res: Response): Promise<string> {
     // Not JSON — surface the raw body below.
   }
   return text || `status ${res.status}`;
-}
-
-function rejected(providerId: string, message: string): ApiKeyVerifyError {
-  return new ApiKeyVerifyError(
-    `${providerId} rejected this API key — check the key and paste it again (${message})`,
-    "invalid_key",
-  );
-}
-
-function noVerdict(providerId: string, message: string): ApiKeyVerifyError {
-  return new ApiKeyVerifyError(
-    `could not verify the ${providerId} API key: ${message} — the key was not saved; try again`,
-    "provider_unavailable",
-  );
 }

--- a/packages/runtime/src/auth/verify-api-key.ts
+++ b/packages/runtime/src/auth/verify-api-key.ts
@@ -1,5 +1,9 @@
 import { completeSimple } from "@earendil-works/pi-ai/compat";
-import { classifyProviderError } from "../ai/provider-error";
+import {
+  classifyProviderError,
+  extractHttpStatus,
+  isNvidiaEndpointGated,
+} from "../ai/provider-error";
 import { modelFor, safeGetModel } from "../ai/providers";
 
 /**
@@ -104,6 +108,25 @@ export async function verifyApiKey(
     // pi raises (rather than resolving an errored message) for pre-request
     // failures; a timeout lands here too. Same classification path.
     message = raisedMessage(e, providerId);
+  }
+
+  // NVIDIA's "Public API Endpoints" account gate (HOU-890): the key passed
+  // auth (a bad key answers 403), but the ACCOUNT cannot call chat completions
+  // until NVIDIA enables that permission. Checked before classification, which
+  // deliberately reads this shape as `unauthenticated` for the chat surface —
+  // here that verdict would say "re-paste the key", the one remedy that can't
+  // work, so the typed reason must be `key_restricted` with NVIDIA's fix.
+  if (
+    isNvidiaEndpointGated(
+      providerId,
+      message.toLowerCase(),
+      extractHttpStatus(message),
+    )
+  ) {
+    throw new ApiKeyVerifyError(
+      `${providerId} accepted the key, but this NVIDIA account cannot call the chat API until NVIDIA enables its "Public API Endpoints" permission (${message})`,
+      "key_restricted",
+    );
   }
 
   const classified = classifyProviderError({

--- a/packages/runtime/src/auth/verify-errors.ts
+++ b/packages/runtime/src/auth/verify-errors.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared vocabulary of key-verification failures (`verify-api-key.ts` is the
+ * entry point; `nvidia-verify.ts` throws these too).
+ */
+
+export const VERIFY_TIMEOUT_MS = 20_000;
+
+/**
+ * Human-readable text for an exception the verify request RAISED (vs a resolved
+ * errored reply). An abort/timeout DOMException reads like a bug ("The
+ * operation was aborted due to timeout"), so name what actually happened —
+ * that text reaches the user verbatim through the connect dialog.
+ */
+export function raisedMessage(e: unknown, providerId: string): string {
+  if (
+    e instanceof Error &&
+    (e.name === "TimeoutError" || e.name === "AbortError")
+  ) {
+    return `${providerId} did not answer within ${VERIFY_TIMEOUT_MS / 1000}s`;
+  }
+  return e instanceof Error ? e.message : String(e);
+}
+
+/**
+ * Why a key failed verification, carried on the wire (`/auth/:provider/api-key`
+ * 401 body `reason`) so the connect dialog can show actionable copy instead of
+ * a generic failure:
+ *  - `invalid_key` — the provider rejected the credential itself; re-paste.
+ *  - `key_restricted` — the key authenticates but something on the ACCOUNT's
+ *    side blocks Houston (Google: the Gemini API is not enabled on the key's
+ *    Cloud project, or a referrer/IP allowlist a server-side call can never
+ *    satisfy; NVIDIA: no chat model is being served to the account); the fix
+ *    lives in the provider's account settings, not in re-pasting this key.
+ *  - `provider_unavailable` — no verdict (5xx / network / timeout); retry.
+ */
+export type ApiKeyVerifyReason =
+  | "invalid_key"
+  | "key_restricted"
+  | "provider_unavailable";
+
+export class ApiKeyVerifyError extends Error {
+  constructor(
+    message: string,
+    public readonly reason: ApiKeyVerifyReason,
+  ) {
+    super(message);
+    this.name = "ApiKeyVerifyError";
+  }
+}
+
+export function rejected(
+  providerId: string,
+  message: string,
+): ApiKeyVerifyError {
+  return new ApiKeyVerifyError(
+    `${providerId} rejected this API key — check the key and paste it again (${message})`,
+    "invalid_key",
+  );
+}
+
+export function noVerdict(
+  providerId: string,
+  message: string,
+): ApiKeyVerifyError {
+  return new ApiKeyVerifyError(
+    `could not verify the ${providerId} API key: ${message} — the key was not saved; try again`,
+    "provider_unavailable",
+  );
+}

--- a/packages/web/e2e/nvidia-connect-guide.spec.ts
+++ b/packages/web/e2e/nvidia-connect-guide.spec.ts
@@ -1,0 +1,55 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * NVIDIA's connect dialog ships a step-by-step key guide (HOU-890): a working
+ * key must be an NGC Personal Key with the "Public API Endpoints" service
+ * included — a picker build.nvidia.com's quick key flow never shows — so the
+ * dialog walks non-technical users through the NGC page. Guards that the guide
+ * renders for NVIDIA and that the generic api-key dialog stays guide-free
+ * (OpenRouter shows none).
+ *
+ * Reaching first-run: onboarding shows when the v3 host reports ZERO agents,
+ * so we delete the seeded agent over the API before boot (same entry as
+ * onboarding-connect.spec.ts).
+ */
+test("NVIDIA connect dialog shows the NGC Personal Key guide", async ({
+  page,
+  request,
+}) => {
+  const agents = (await (
+    await request.get(`${FAKE_HOST_URL}/agents`)
+  ).json()) as { id: string }[];
+  for (const agent of agents) {
+    await request.delete(`${FAKE_HOST_URL}/agents/${agent.id}`);
+  }
+
+  await page.goto("/");
+  await page.getByRole("button", { name: /Operations/ }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Connect your AI" }),
+  ).toBeVisible();
+
+  // NVIDIA is not featured — search surfaces it from the full catalog.
+  const search = page.getByPlaceholder("Search providers");
+  await search.fill("nvidia");
+  await page.getByRole("button", { name: "Connect NVIDIA" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("How to get your key")).toBeVisible();
+  await expect(dialog.getByText(/Generate Personal Key/)).toBeVisible();
+  await expect(dialog.getByText(/Public API Endpoints/)).toBeVisible();
+  await expect(dialog.getByText(/nvapi-/)).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
+
+  // The guide is NVIDIA-only: a generic api-key provider shows no steps.
+  await search.fill("openrouter");
+  await page.getByRole("button", { name: "Connect OpenRouter" }).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await expect(
+    page.getByRole("dialog").getByText("How to get your key"),
+  ).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

HOU-890: NVIDIA users fail with **410/404 status code (no body)** on chats and "We couldn't reach NVIDIA to check your key, so nothing was saved" at connect. Sentry: HOUSTON-APP-4WX (52 events / 22 users, still firing on 0.5.43).

### Root cause (verified live against a real key)

**NVIDIA serves each hosted model ("function") per account.** A live probe with a valid NGC Personal Key (Public API Endpoints scope enabled) showed the SAME key getting `404 {"detail":"Function '<uuid>': Not found for account '<id>'"}` on gemma / kimi / glm / nemotron while llama-3.3 / llama-3.1 / gpt-oss / minimax answered 200 — and `/v1/models` lists all 102 either way. Some accounts are missing the whole "Public API Endpoints" permission (every model gated; the NVIDIA forum wave since May), others just part of the catalog.

Houston's key verification probes ONE model — `modelFor()`, which for uncurated providers is the alphabetically-first catalog row: **`google/gemma-3-12b-it`, gated for many accounts**. So valid keys failed verification ("couldn't reach NVIDIA… try again", a retry loop that can't succeed), and the same model as chat default meant first chats died on the generic unknown-error card. The OpenAI SDK flattens NVIDIA's `{status,title,detail}` bodies (no `error` key) to `<status> status code (no body)`, which is why Sentry never showed the detail.

### Fix

- **Verify retries broadly-served models** (`packages/runtime/src/auth/nvidia-verify.ts`): a gated probe tries `meta/llama-3.3-70b-instruct` then `meta/llama-3.1-8b-instruct` before any verdict; a success verifies the key, a non-gate failure goes to normal classification, and only all-gated throws `key_restricted`. (`verify-api-key.ts` split with `verify-errors.ts` under the 200-line rule; stable exports re-served.)
- **NVIDIA default model** (`packages/runtime/src/ai/providers.ts`): `UNCURATED_DEFAULT_MODEL` pins nvidia to `meta/llama-3.3-70b-instruct` instead of the alphabetical first row, so new connects chat on a model that actually serves.
- **Mid-chat classification** (`packages/runtime/src/ai/provider-error.ts`): `isNvidiaFunctionGated` (nvidia + 404/410 + body-less / "function not found" / "not found for account") → `model_unavailable` with a one-click `meta/llama-3.3-70b-instruct` fallback — the switch-model card, since re-keying can never fix a gated model. A 404 with an unrelated body deliberately stays out.
- **Dialog copy** (en/es/pt): the residual all-models-gated error names the real remedy — check the key is an NGC Personal Key with "Public API Endpoints" under Services Included (org.ngc.nvidia.com), and NVIDIA support if it still fails. NVIDIA-specific override for `key_restricted` in `provider-api-key-dialog.tsx`.

### Before (reproduce)

1. Use an NVIDIA key whose account doesn't serve gemma (curl `/v1/chat/completions` with `google/gemma-3-12b-it` → `404 Function … Not found for account`, while `meta/llama-3.3-70b-instruct` → 200).
2. Settings → AI Models → NVIDIA → paste key → Connect → "We couldn't reach NVIDIA to check your key… try again in a moment", forever.
3. Mid-chat on a gated model: generic error card, `410/404 status code (no body)`.

### After (verify)

1. Same key connects: verification falls back to llama-3.3 and succeeds.
2. New NVIDIA connects default to `meta/llama-3.3-70b-instruct`; chats work.
3. Picking a gated model mid-chat renders the switch-model card with a one-click "Switch to meta/llama-3.3-70b-instruct" button.
4. A fully-gated account gets the honest key_restricted copy (NGC Personal Key check → NVIDIA support). Bad keys still read invalid_key (403 path pinned by tests).

### Tests

- `provider-error.test.ts`: 6 cases — 410/404 body-less and "Not found for account" (verbatim live shape, ids synthetic) → `model_unavailable` + fallback; fallback-on-fallback → null; unrelated-body 404 and other-provider 410 stay `unknown`.
- `verify-api-key.test.ts`: gated probe → fallback verifies (asserts the fallback model id); all-gated → `key_restricted`; gated-then-403 → `invalid_key`.
- Full runs: runtime 1011 ✓, host+domain 1271 ✓, app node:test 2700 ✓, tsgo app/web ✓, check-locales ✓, Biome ✓.
