### PR TITLE
fix(sdk): chat feed dedupes re-delivered turn content by turn identity (HOU-1214)

### DIFF
--- a/packages/sdk/src/modules/turns/history.ts
+++ b/packages/sdk/src/modules/turns/history.ts
@@ -42,6 +42,22 @@ export interface FeedFrame {
    * crosses the SDK/bridge boundary unchanged.
    */
   ts?: number;
+  /**
+   * The turn this frame's source message belongs to (`ChatMessage.turnId`) —
+   * the identity the VM fold dedupes on (HOU-1214): a live sink re-delivering
+   * this turn's content (a running-sync replay over a seeded feed, a settle
+   * re-push) updates the SAME entries instead of appending duplicates.
+   * Optional/additive: absent on pre-turn-id transcripts, which keep the
+   * append-only fold.
+   */
+  turnId?: string;
+  /**
+   * This frame's position among the turn's `tool_call`s (or `tool_result`s) —
+   * the per-turn index that pairs a replayed tool row with the seeded entry it
+   * duplicates (tool rows are many-per-turn, so `turnId` alone can't). Only on
+   * tool frames, and only when `turnId` is present.
+   */
+  toolIndex?: number;
 }
 
 /** Identity provider map — the SDK default (carry the pi id through). */
@@ -61,8 +77,11 @@ export function historyToFeed(
   const out: FeedFrame[] = [];
   for (const m of messages) {
     // Every frame folded from a message carries that message's epoch-ms `ts`
-    // (additive; a pre-`ts` transcript simply folds frames with `ts: undefined`).
+    // (additive; a pre-`ts` transcript simply folds frames with `ts: undefined`)
+    // and its `turnId` — the dedup identity the VM fold matches live re-pushes
+    // against (HOU-1214).
     const ts = m.ts;
+    const turn = m.turnId !== undefined ? { turnId: m.turnId } : {};
     if (m.role === "user") {
       out.push({
         feed_type: "user_message",
@@ -73,6 +92,7 @@ export function historyToFeed(
         author: m.author,
         mentions: m.mentions,
         ts,
+        ...turn,
       });
       continue;
     }
@@ -87,6 +107,7 @@ export function historyToFeed(
           pre_tokens: m.providerSwitch.pre_tokens,
         },
         ts,
+        ...turn,
       });
     }
     // A persisted proactive compaction: replay the boundary divider so it
@@ -99,6 +120,7 @@ export function historyToFeed(
           pre_tokens: m.compaction.pre_tokens,
         },
         ts,
+        ...turn,
       });
     }
     // A persisted provider failure: replay the typed card so the inline
@@ -111,6 +133,7 @@ export function historyToFeed(
           provider: mapProvider(m.providerError.provider),
         },
         ts,
+        ...turn,
       });
     }
     // Replay the turn's reasoning BEFORE its tool calls — the live VM keeps a
@@ -118,26 +141,33 @@ export function historyToFeed(
     // (ahead of the tools), so a reload renders the mission log in the same
     // order a live watcher saw (HOU-717).
     if (m.thinking) {
-      out.push({ feed_type: "thinking", data: m.thinking, ts });
+      out.push({ feed_type: "thinking", data: m.thinking, ts, ...turn });
     }
-    for (const t of m.tools ?? []) {
+    (m.tools ?? []).forEach((t, toolIndex) => {
+      // Tool rows are many-per-turn, so each carries its per-turn index — the
+      // pair (turnId, toolIndex) is what a replayed live push dedupes against.
+      const index = m.turnId !== undefined ? { toolIndex } : {};
       out.push({
         feed_type: "tool_call",
         data: { name: t.name, input: t.input ?? {} },
         ts,
+        ...turn,
+        ...index,
       });
       out.push({
         feed_type: "tool_result",
         data: { content: t.result ?? "", is_error: !!t.isError },
         ts,
+        ...turn,
+        ...index,
       });
-    }
+    });
     if (m.content)
-      out.push({ feed_type: "assistant_text", data: m.content, ts });
+      out.push({ feed_type: "assistant_text", data: m.content, ts, ...turn });
     // A persisted file-change summary: replay it AFTER the assistant text so
     // the chat attaches it to this turn's assistant message on reload.
     if (m.fileChanges) {
-      out.push({ feed_type: "file_changes", data: m.fileChanges, ts });
+      out.push({ feed_type: "file_changes", data: m.fileChanges, ts, ...turn });
     }
     // A turn the user interrupted persisted `stopped`: replay the standard
     // "Stopped by user" system line so the transcript reads identically after a
@@ -145,7 +175,12 @@ export function historyToFeed(
     // (`finishErr`'s system_message, after the turn's text/tools). A stopped
     // turn never carries a `pendingInteraction`, so no card competes with it.
     if (m.stopped) {
-      out.push({ feed_type: "system_message", data: STOPPED_BY_USER, ts });
+      out.push({
+        feed_type: "system_message",
+        data: STOPPED_BY_USER,
+        ts,
+        ...turn,
+      });
     }
     if (m.usage) {
       out.push({
@@ -157,6 +192,7 @@ export function historyToFeed(
           usage: m.usage,
         },
         ts,
+        ...turn,
       });
     }
   }

--- a/packages/sdk/src/modules/turns/turn-frames.ts
+++ b/packages/sdk/src/modules/turns/turn-frames.ts
@@ -31,18 +31,22 @@ export function applyTurnFrame(
       push(s, { feed_type: "thinking_streaming", data: s.thinking });
       break;
     case "tool_start":
-      s.toolsSeen++;
+      // `toolIndex` = position among the turn's tool calls — with the turn id
+      // the identity a replayed row dedupes on in the VM fold (HOU-1214).
       push(s, {
         feed_type: "tool_call",
         data: { name: ev.data.name, input: ev.data.args },
+        toolIndex: s.toolsSeen,
       });
+      s.toolsSeen++;
       break;
     case "tool_end":
-      s.toolResultsSeen++;
       push(s, {
         feed_type: "tool_result",
         data: { content: ev.data.content ?? "", is_error: ev.data.isError },
+        toolIndex: s.toolResultsSeen,
       });
+      s.toolResultsSeen++;
       break;
     case "usage":
       // Stash the turn's usage; finishOk attaches it to the final_result.

--- a/packages/sdk/src/modules/turns/turn-settle.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.ts
@@ -28,6 +28,14 @@ export interface TurnState {
   /** The turn's prompt — carried on the not-connected card so "Send again"
    *  can resend the exact text the runtime refused (it was never delivered). */
   prompt: string | null;
+  /**
+   * OUR turn's wire id, once known (nonce-matched echo / attaching sync — the
+   * sink owns adoption; see `turn-identity.ts`). Every {@link push} stamps it
+   * on the item so the VM fold can dedupe re-delivered turn content by
+   * identity (HOU-1214). Undefined until adopted (and forever on legacy
+   * servers that stamp no turn ids — those keep the append-only fold).
+   */
+  turnId: string | undefined;
   text: string;
   thinking: string;
   /**
@@ -76,6 +84,7 @@ export function newTurnState(
     output,
     provider: send?.provider ?? null,
     prompt: send?.prompt ?? null,
+    turnId: undefined,
     text: "",
     thinking: "",
     toolsSeen: 0,
@@ -88,9 +97,15 @@ export function newTurnState(
   };
 }
 
-/** Emit one FeedItem for this turn's session — the sink and settles share it. */
-export const push = (s: TurnState, item: unknown): void =>
-  s.output.pushFeedItem(s.agentPath, s.sessionKey, item);
+/** Emit one FeedItem for this turn's session — the sink and settles share it.
+ *  Stamps the turn's id (once adopted) so the VM fold dedupes re-delivered
+ *  content by identity (HOU-1214); an item never carries its own. */
+export const push = (s: TurnState, item: object): void =>
+  s.output.pushFeedItem(
+    s.agentPath,
+    s.sessionKey,
+    s.turnId === undefined ? item : { ...item, turnId: s.turnId },
+  );
 
 const invisibleFinal = (s: TurnState) =>
   push(s, {

--- a/packages/sdk/src/modules/turns/turn-sink.ts
+++ b/packages/sdk/src/modules/turns/turn-sink.ts
@@ -33,8 +33,6 @@ type SyncTool = {
  */
 export class TurnSink {
   private readonly s: TurnState;
-  /** OUR turn's id, once known (nonce-matched echo / attaching sync). */
-  private turnId: string | undefined;
   /** Evidence a turn was in flight on our watch (frames or a running sync). */
   private sawRunning = false;
   private sawSync = false;
@@ -114,7 +112,7 @@ export class TurnSink {
       this.onUser(ev);
       return;
     }
-    switch (classifyFrame(this.turnId, ev.turnId)) {
+    switch (classifyFrame(this.s.turnId, ev.turnId)) {
       case "foreign":
         // Narrow adoption for a stamped TERMINAL frame with no adopted id
         // after our send was ACCEPTED: a turn that fails before executing
@@ -127,9 +125,9 @@ export class TurnSink {
         if (
           (ev.type === "error" || ev.type === "done") &&
           this.accepted &&
-          this.turnId === undefined
+          this.s.turnId === undefined
         ) {
-          this.turnId = ev.turnId;
+          this.s.turnId = ev.turnId;
           break;
         }
         return; // another turn's frame — never fold it into ours
@@ -154,14 +152,14 @@ export class TurnSink {
     // history hydration covers observed turns), so echoes are never rendered.
     if (this.o.mode === "turn" && this.o.nonce === ev.data.nonce) {
       // OUR echo: the turn started — adopt its id (absent on legacy servers).
-      this.turnId = ev.turnId;
+      this.s.turnId = ev.turnId;
       this.accepted = true;
       this.sawRunning = true;
       this.s.delivered = true; // the engine echoed our send — it landed
       this.cancelPresettlePoll(); // the turn is demonstrably live on the stream
       return;
     }
-    if (classifyFrame(this.turnId, ev.turnId) === "boundary") {
+    if (classifyFrame(this.s.turnId, ev.turnId) === "boundary") {
       // Another writer started the NEXT turn: ours is over, terminal lost.
       this.settleFromHistorySoon();
     }
@@ -221,14 +219,14 @@ export class TurnSink {
     tools?: SyncTool[];
   }): void {
     const mayAdopt = this.o.mode === "observer" || this.accepted;
-    switch (classifyRunningSync(this.turnId, data.turnId, mayAdopt)) {
+    switch (classifyRunningSync(this.s.turnId, data.turnId, mayAdopt)) {
       case "foreign":
         return; // another writer's turn, seen pre-send — not ours to render
       case "boundary":
         this.settleFromHistorySoon(); // ours ended; a new turn runs
         return;
       case "adopt":
-        this.turnId = data.turnId;
+        this.s.turnId = data.turnId;
         break;
       case "ours":
         break;
@@ -269,27 +267,32 @@ export class TurnSink {
     const tools = data.tools ?? [];
     // A tool whose call we already pushed may have ENDED while we were away —
     // close it first (tools run serially, so results land in call order).
+    // Every tool push carries its per-turn `toolIndex` so the VM fold can
+    // dedupe a replayed row against a history-seeded one (HOU-1214).
     while (s.toolResultsSeen < Math.min(s.toolsSeen, tools.length)) {
       const t = tools[s.toolResultsSeen];
       if (t.isError === undefined) break;
       push(s, {
         feed_type: "tool_result",
         data: { content: t.content ?? "", is_error: t.isError },
+        toolIndex: s.toolResultsSeen,
       });
       s.toolResultsSeen++;
     }
     // Then the calls we never saw, each with its result when it already ended.
     while (s.toolsSeen < tools.length) {
       const t = tools[s.toolsSeen];
-      s.toolsSeen++;
       push(s, {
         feed_type: "tool_call",
         data: { name: t.name, input: t.input ?? {} },
+        toolIndex: s.toolsSeen,
       });
+      s.toolsSeen++;
       if (t.isError !== undefined) {
         push(s, {
           feed_type: "tool_result",
           data: { content: t.content ?? "", is_error: t.isError },
+          toolIndex: s.toolResultsSeen,
         });
         s.toolResultsSeen++;
       }
@@ -318,7 +321,7 @@ export class TurnSink {
     void reloadAndSettle(
       this.s,
       this.o.reloadHistory,
-      this.turnId,
+      this.s.turnId,
       this.o.historyGuard,
       this.o.stop,
     );
@@ -371,7 +374,7 @@ export class TurnSink {
     const settled = await presettleFromHistory(
       this.s,
       this.o.reloadHistory,
-      this.turnId,
+      this.s.turnId,
       this.o.historyGuard,
       () => this.sawRunning,
     );

--- a/packages/sdk/src/modules/turns/turn-stream.test.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.test.ts
@@ -9,6 +9,7 @@ import { EngineError } from "@houston/runtime-client";
 import { afterEach, expect, test } from "vitest";
 import { ScopeStore } from "../../store";
 import type { FeedOutput } from "./feed-output";
+import { historyToFeed } from "./history";
 import { TURN_DIED_MESSAGE } from "./settle-from-history";
 import {
   SEND_IN_FLIGHT_MESSAGE,
@@ -872,7 +873,9 @@ test("frames from the NEXT turn are a boundary: our turn settles from history by
   );
 
   const texts = items.filter((i) => i.feed_type === "assistant_text");
-  expect(texts).toEqual([{ feed_type: "assistant_text", data: "Hello full" }]);
+  expect(texts).toEqual([
+    { feed_type: "assistant_text", data: "Hello full", turnId: "t-1" },
+  ]);
   // The foreign turn's frames were never folded into ours.
   expect(items.some((i) => String(i.data ?? "").includes("FOREIGN"))).toBe(
     false,
@@ -927,6 +930,7 @@ test("a resync naming a DIFFERENT running turn settles ours; a dead turn settles
   expect(items).toContainEqual({
     feed_type: "system_message",
     data: TURN_DIED_MESSAGE,
+    turnId: "t-1",
   });
   expect(sessionStatuses).toEqual(["running", "error"]);
 });
@@ -973,7 +977,9 @@ test("a running resync for OUR turn replaces accumulated text — empty partial 
   expect(streaming).toEqual(["Hello wor", "", "Restarted"]);
   // ...so the settle carries only what the server actually produced.
   const texts = items.filter((i) => i.feed_type === "assistant_text");
-  expect(texts).toEqual([{ feed_type: "assistant_text", data: "Restarted" }]);
+  expect(texts).toEqual([
+    { feed_type: "assistant_text", data: "Restarted", turnId: "t-1" },
+  ]);
 });
 
 // ── Fatal classification + failure budget ────────────────────────────────────
@@ -1147,6 +1153,7 @@ test("an observer mid-render settles visibly when the failure budget runs out", 
   expect(items).toContainEqual({
     feed_type: "system_message",
     data: STREAM_LOST_MESSAGE,
+    turnId: "t-9",
   });
   expect(sessionStatuses).toEqual(["running", "error"]);
 });
@@ -1209,7 +1216,9 @@ test("handoff on 202: the observer is disposed and the turn resumes from its cur
   expect(observerAborted).toBe(true);
   expect(afters).toEqual([undefined, 4]); // resumed exactly from the observer's cursor
   const texts = items.filter((i) => i.feed_type === "assistant_text");
-  expect(texts).toEqual([{ feed_type: "assistant_text", data: "yo" }]);
+  expect(texts).toEqual([
+    { feed_type: "assistant_text", data: "yo", turnId: "t-B" },
+  ]);
   expect(finals(items)).toHaveLength(1);
 });
 
@@ -1608,7 +1617,9 @@ test("a transport-failed send whose turn actually started renders and settles no
   expect(sessionStatuses).not.toContain("error");
   expect(finals(items)).toHaveLength(1);
   const texts = items.filter((i) => i.feed_type === "assistant_text");
-  expect(texts).toEqual([{ feed_type: "assistant_text", data: "Done" }]);
+  expect(texts).toEqual([
+    { feed_type: "assistant_text", data: "Done", turnId: "t-1" },
+  ]);
   // No misleading transport-error line reached the feed.
   expect(items.map((i) => i.data)).not.toContain("Load failed");
   expect(items.map((i) => i.data)).not.toContain(SEND_LOST_MESSAGE);
@@ -2002,4 +2013,178 @@ test("a stamped error BEFORE the send is accepted stays foreign (replay tail is 
   sink.dispose();
 
   expect(sink.settled).toBe(false);
+});
+
+// ── HOU-1214: a seeded feed meeting a replayed turn never duplicates content ──
+// The cloud race this reproduces: the runtime persists the reply BEFORE it
+// publishes the terminal frame, so a chat-open history read can seed the full
+// transcript while the conversation snapshot still says `running`. The observer
+// that attaches right after then receives a running sync replaying the whole
+// turn (partial text, thinking, tools) over a feed that already shows it — and
+// used to append every piece a second time, permanently ("Correo enviado" ×4).
+
+test("HOU-1214: observing a turn already seeded from history duplicates nothing", async () => {
+  const reply = "Correo enviado";
+  const messages: ChatMessage[] = [
+    { role: "user", content: "manda el correo", ts: 1, turnId: "t-1" },
+    {
+      role: "assistant",
+      content: reply,
+      ts: 2,
+      turnId: "t-1",
+      thinking: "drafting…",
+      tools: [
+        {
+          name: "integration_execute",
+          input: { tool: "GMAIL_SEND_EMAIL" },
+          result: "sent",
+          isError: false,
+        },
+      ],
+      usage: { context_tokens: 10, output_tokens: 5, cached_tokens: 0 },
+    },
+  ];
+  const store = new ScopeStore();
+  const vm = new ConversationVmOutput(store);
+  vm.seedHistory("Houston/Bo", "activity-1214", historyToFeed(messages), {
+    earliestLoaded: 0,
+    total: messages.length,
+  });
+
+  const { engine } = fakeEngine(
+    [
+      (o) => {
+        // The stale-running snapshot replays the ENTIRE finished turn…
+        o.onEvent({
+          type: "sync",
+          data: {
+            running: true,
+            partial: reply,
+            seq: 5,
+            turnId: "t-1",
+            thinking: "drafting…",
+            tools: [
+              {
+                name: "integration_execute",
+                input: { tool: "GMAIL_SEND_EMAIL" },
+                isError: false,
+                content: "sent",
+              },
+            ],
+          },
+          seq: 5,
+        });
+        // …then the terminal frame lands.
+        o.onEvent({ type: "done", data: null, turnId: "t-1", seq: 6 });
+      },
+    ],
+    messages,
+  );
+  observeConversation(
+    engine,
+    "Houston/Bo",
+    "activity-1214",
+    vm,
+    messages.length,
+    registry,
+    fast,
+  );
+
+  const feedOf = () =>
+    (
+      store.getSnapshot(
+        conversationScope("Houston/Bo", "activity-1214"),
+      ) as ConversationVM
+    ).feed;
+  await waitFor(
+    () =>
+      (
+        store.getSnapshot(
+          conversationScope("Houston/Bo", "activity-1214"),
+        ) as ConversationVM
+      ).sessionStatus === "completed",
+  );
+
+  const counts = feedOf().reduce<Record<string, number>>((acc, f) => {
+    acc[f.feed_type] = (acc[f.feed_type] ?? 0) + 1;
+    return acc;
+  }, {});
+  // One of everything — the replay folded into the seeded entries in place.
+  expect(counts).toEqual({
+    user_message: 1,
+    thinking: 1,
+    tool_call: 1,
+    tool_result: 1,
+    assistant_text: 1,
+    final_result: 1,
+  });
+  const texts = feedOf().filter((f) => f.feed_type === "assistant_text");
+  expect(texts.map((f) => f.data)).toEqual([reply]);
+  // The seeded final_result kept its persisted usage (the context indicator).
+  const final = feedOf().find((f) => f.feed_type === "final_result");
+  expect((final?.data as { usage: unknown }).usage).toEqual({
+    context_tokens: 10,
+    output_tokens: 5,
+    cached_tokens: 0,
+  });
+});
+
+test("HOU-1214: repeated seed+observe cycles stay duplicate-free (the ×4 accumulator)", async () => {
+  const reply = "Correo enviado";
+  const messages: ChatMessage[] = [
+    { role: "user", content: "manda el correo", ts: 1, turnId: "t-1" },
+    { role: "assistant", content: reply, ts: 2, turnId: "t-1" },
+  ];
+  const store = new ScopeStore();
+  const vm = new ConversationVmOutput(store);
+
+  // Every ConversationsChanged invalidation refires the windowed read → seed →
+  // observe. Each observer sees the stale-running snapshot replay the turn.
+  for (let round = 0; round < 4; round++) {
+    vm.seedHistory("Houston/Bo", "activity-1214b", historyToFeed(messages), {
+      earliestLoaded: 0,
+      total: messages.length,
+    });
+    const { engine } = fakeEngine(
+      [
+        (o) => {
+          o.onEvent(sync(true, reply, 5 + round, { turnId: "t-1" }));
+          o.onEvent({
+            type: "done",
+            data: null,
+            turnId: "t-1",
+            seq: 6 + round,
+          });
+        },
+      ],
+      messages,
+    );
+    observeConversation(
+      engine,
+      "Houston/Bo",
+      "activity-1214b",
+      vm,
+      messages.length,
+      registry,
+      fast,
+    );
+    await waitFor(
+      () =>
+        (
+          store.getSnapshot(
+            conversationScope("Houston/Bo", "activity-1214b"),
+          ) as ConversationVM
+        ).sessionStatus === "completed",
+    );
+    registry.disposeAll();
+  }
+
+  const feed = (
+    store.getSnapshot(
+      conversationScope("Houston/Bo", "activity-1214b"),
+    ) as ConversationVM
+  ).feed;
+  expect(
+    feed.filter((f) => f.feed_type === "assistant_text").map((f) => f.data),
+  ).toEqual([reply]);
 });

--- a/packages/sdk/src/modules/turns/vm-output.test.ts
+++ b/packages/sdk/src/modules/turns/vm-output.test.ts
@@ -630,3 +630,120 @@ test("a pushed item carries its mentions; an unmentioning push carries no key", 
   expect(snap().feed[0]?.mentions).toEqual([{ userId: "user_a", name: "Ada" }]);
   expect(snap().feed[1]).not.toHaveProperty("mentions");
 });
+
+// ── HOU-1214: turn-identity dedup — re-delivered content updates, never appends ──
+
+test("a streaming push for a turn whose reply is already seeded adopts that bubble (HOU-1214)", () => {
+  const { vm, snap } = harness();
+  vm.seedHistory("a", "c1", [
+    { feed_type: "user_message", data: "hi", turnId: "t-1" },
+    { feed_type: "assistant_text", data: "Correo enviado", turnId: "t-1" },
+  ]);
+  // The stale-running replay: same turn, cumulative partial.
+  vm.pushFeedItem("a", "c1", {
+    feed_type: "assistant_text_streaming",
+    data: "Correo enviado",
+    turnId: "t-1",
+  });
+  vm.pushFeedItem("a", "c1", {
+    feed_type: "assistant_text",
+    data: "Correo enviado",
+    turnId: "t-1",
+  });
+
+  const texts = snap().feed.filter((f) => f.feed_type === "assistant_text");
+  expect(texts).toHaveLength(1);
+  expect(snap().feed).toHaveLength(2); // user + the ONE reply
+});
+
+test("a settle re-push (assistant_text, no open stream) folds into the seeded entry", () => {
+  const { vm, snap } = harness();
+  vm.seedHistory("a", "c1", [
+    { feed_type: "assistant_text", data: "done", turnId: "t-1" },
+  ]);
+  vm.pushFeedItem("a", "c1", {
+    feed_type: "assistant_text",
+    data: "done",
+    turnId: "t-1",
+  });
+  expect(snap().feed).toHaveLength(1);
+});
+
+test("tool rows dedupe by (turnId, toolIndex); a NEW index still appends", () => {
+  const { vm, snap } = harness();
+  vm.seedHistory("a", "c1", [
+    {
+      feed_type: "tool_call",
+      data: { name: "ls", input: {} },
+      turnId: "t-1",
+      toolIndex: 0,
+    },
+    {
+      feed_type: "tool_result",
+      data: { content: "ok", is_error: false },
+      turnId: "t-1",
+      toolIndex: 0,
+    },
+  ]);
+  // Replayed rows — same identity, no growth.
+  vm.pushFeedItem("a", "c1", {
+    feed_type: "tool_call",
+    data: { name: "ls", input: {} },
+    turnId: "t-1",
+    toolIndex: 0,
+  });
+  vm.pushFeedItem("a", "c1", {
+    feed_type: "tool_result",
+    data: { content: "ok", is_error: false },
+    turnId: "t-1",
+    toolIndex: 0,
+  });
+  expect(snap().feed).toHaveLength(2);
+  // A genuinely new call of the same turn appends.
+  vm.pushFeedItem("a", "c1", {
+    feed_type: "tool_call",
+    data: { name: "read", input: {} },
+    turnId: "t-1",
+    toolIndex: 1,
+  });
+  expect(snap().feed).toHaveLength(3);
+});
+
+test("final_result keeps its FIRST data — a re-settle's empty final never clobbers usage", () => {
+  const usage = { context_tokens: 9, output_tokens: 1, cached_tokens: 0 };
+  const { vm, snap } = harness();
+  vm.seedHistory("a", "c1", [
+    {
+      feed_type: "final_result",
+      data: { result: "done", cost_usd: null, duration_ms: null, usage },
+      turnId: "t-1",
+    },
+  ]);
+  vm.pushFeedItem("a", "c1", {
+    feed_type: "final_result",
+    data: { result: "", cost_usd: null, duration_ms: null, usage: null },
+    turnId: "t-1",
+  });
+  expect(snap().feed).toHaveLength(1);
+  expect((snap().feed[0]?.data as { usage: unknown }).usage).toEqual(usage);
+});
+
+test("pushes without a turnId keep the append-only fold (legacy servers)", () => {
+  const { vm, snap } = harness();
+  vm.seedHistory("a", "c1", [{ feed_type: "assistant_text", data: "done" }]);
+  vm.pushFeedItem("a", "c1", { feed_type: "assistant_text", data: "done" });
+  expect(snap().feed).toHaveLength(2); // no identity — cannot dedup safely
+});
+
+test("identical text from a DIFFERENT turn still appends (dedup is by identity, not content)", () => {
+  const { vm, snap } = harness();
+  vm.seedHistory("a", "c1", [
+    { feed_type: "assistant_text", data: "done", turnId: "t-1" },
+  ]);
+  vm.pushFeedItem("a", "c1", {
+    feed_type: "assistant_text",
+    data: "done",
+    turnId: "t-2",
+  });
+  expect(snap().feed).toHaveLength(2);
+});

--- a/packages/sdk/src/modules/turns/vm-output.test.ts
+++ b/packages/sdk/src/modules/turns/vm-output.test.ts
@@ -747,3 +747,52 @@ test("identical text from a DIFFERENT turn still appends (dedup is by identity, 
   });
   expect(snap().feed).toHaveLength(2);
 });
+
+test("a NEW turn's streaming push never reuses a stale open bubble from a prior turn", () => {
+  const { vm, snap } = harness();
+  // Turn A streams, then its sink dies with NO terminal status (external
+  // teardown keeps live state) — the streaming registration stays open.
+  vm.pushFeedItem("a", "c1", {
+    feed_type: "assistant_text_streaming",
+    data: "turn A partial",
+    turnId: "t-A",
+  });
+  // Turn B's stream arrives on the same conversation.
+  vm.pushFeedItem("a", "c1", {
+    feed_type: "assistant_text_streaming",
+    data: "turn B",
+    turnId: "t-B",
+  });
+
+  expect(snap().feed).toHaveLength(2); // B opened its own bubble
+  expect(snap().feed[0]?.data).toBe("turn A partial"); // A's content survives
+  expect(snap().feed[1]?.data).toBe("turn B");
+  expect(snap().feed[1]?.turnId).toBe("t-B");
+});
+
+test("file_changes and provider_error dedupe by turn like the reply does", () => {
+  const { vm, snap } = harness();
+  vm.seedHistory("a", "c1", [
+    {
+      feed_type: "file_changes",
+      data: { created: ["a.md"], modified: [] },
+      turnId: "t-1",
+    },
+    {
+      feed_type: "provider_error",
+      data: { kind: "rate_limited", provider: "anthropic" },
+      turnId: "t-1",
+    },
+  ]);
+  vm.pushFeedItem("a", "c1", {
+    feed_type: "file_changes",
+    data: { created: ["a.md"], modified: [] },
+    turnId: "t-1",
+  });
+  vm.pushFeedItem("a", "c1", {
+    feed_type: "provider_error",
+    data: { kind: "rate_limited", provider: "anthropic" },
+    turnId: "t-1",
+  });
+  expect(snap().feed).toHaveLength(2);
+});

--- a/packages/sdk/src/modules/turns/vm-output.ts
+++ b/packages/sdk/src/modules/turns/vm-output.ts
@@ -61,6 +61,8 @@ interface HistoryFrame {
   ts?: number;
   author?: FeedAuthor;
   mentions?: FeedMention[];
+  turnId?: string;
+  toolIndex?: number;
 }
 
 /** A single reactive feed entry: a stable id plus the machinery's push payload. */
@@ -117,6 +119,23 @@ export interface FeedItemVM {
    * data); a surface that does not render it simply ignores it.
    */
   failed?: boolean;
+  /**
+   * The turn this entry belongs to — the dedup identity (HOU-1214). Carried
+   * from the history fold's `FeedFrame.turnId` on seeded entries and from the
+   * turn state on live pushes, so a re-delivered copy of a turn's content (a
+   * running-sync replay over a seeded feed, a settle re-push after a resync)
+   * UPDATES the entry already on screen instead of appending a duplicate.
+   * Optional/additive: absent on pre-turn-id transcripts and optimistic sends;
+   * entries without it keep the append-only fold.
+   */
+  turnId?: string;
+  /**
+   * This entry's index among its turn's `tool_call`s / `tool_result`s — with
+   * {@link turnId}, the identity that pairs a replayed tool row with the entry
+   * it duplicates (tool rows are many-per-turn). Optional/additive, tool rows
+   * only.
+   */
+  toolIndex?: number;
 }
 
 /** A message queued while a turn runs — rendered in the composer, removable. */
@@ -186,6 +205,32 @@ const FINAL_OF: Record<string, string> = {
   assistant_text: "assistant_text_streaming",
   thinking: "thinking_streaming",
 };
+
+/** Streaming feed_type -> the final feed_type that closes it (FINAL_OF inverted). */
+const STREAMED_AS: Record<string, string> = {
+  assistant_text_streaming: "assistant_text",
+  thinking_streaming: "thinking",
+};
+
+/**
+ * Feed types a turn produces exactly ONCE, deduped by `turnId` alone
+ * (HOU-1214). Tool rows are many-per-turn and dedupe by (turnId, toolIndex)
+ * instead; everything else stays append-only.
+ */
+const SINGLETON_TYPES = new Set(["assistant_text", "thinking", "final_result"]);
+
+/** Last matching entry — local helper (`Array.findLast` is ES2023; the SDK
+ *  targets ES2022 and runs in older WKWebViews). */
+function findLast<T>(
+  arr: readonly T[],
+  pred: (v: T) => boolean,
+): T | undefined {
+  for (let i = arr.length - 1; i >= 0; i--) {
+    const v = arr[i];
+    if (v !== undefined && pred(v)) return v;
+  }
+  return undefined;
+}
 
 /**
  * How many conversations' folded transcripts are retained in memory at once.
@@ -293,18 +338,12 @@ export class ConversationVmOutput implements FeedOutput {
   ): void {
     const s = this.state(agentPath, sessionKey);
     // History frames carry their source `ChatMessage.ts` (absent for a pre-`ts`
-    // transcript) and, in multiplayer, its `author` + `mentions`; pass all three
-    // through verbatim — a seeded frame is historical, so it is never stamped
-    // with the wall clock the way a live push is, and its author and mentions
-    // are the persisted ones.
-    s.feed = frames.map((f) => ({
-      id: `f${s.seq++}`,
-      feed_type: f.feed_type,
-      data: f.data,
-      ...(f.ts !== undefined ? { ts: f.ts } : {}),
-      ...(f.author !== undefined ? { author: f.author } : {}),
-      ...(f.mentions !== undefined ? { mentions: f.mentions } : {}),
-    }));
+    // transcript), in multiplayer its `author` + `mentions`, and their turn
+    // identity (`turnId`/`toolIndex` — what live re-pushes dedupe against,
+    // HOU-1214); pass all of them through verbatim — a seeded frame is
+    // historical, so it is never stamped with the wall clock the way a live
+    // push is, and its author and mentions are the persisted ones.
+    s.feed = frames.map((f) => this.mintHistoryEntry(s, f));
     s.streaming.clear();
     // A windowed server read stamps its window; a cache paint / full-history
     // seed passes none and CLEARS any prior stamp — the feed no longer maps to
@@ -327,33 +366,48 @@ export class ConversationVmOutput implements FeedOutput {
     window: HistoryWindowVM,
   ): void {
     const s = this.state(agentPath, sessionKey);
-    s.feed = [
-      ...frames.map((f) => ({
-        id: `f${s.seq++}`,
-        feed_type: f.feed_type,
-        data: f.data,
-        ...(f.ts !== undefined ? { ts: f.ts } : {}),
-        ...(f.author !== undefined ? { author: f.author } : {}),
-        ...(f.mentions !== undefined ? { mentions: f.mentions } : {}),
-      })),
-      ...s.feed,
-    ];
+    s.feed = [...frames.map((f) => this.mintHistoryEntry(s, f)), ...s.feed];
     s.historyWindow = window;
     this.publish(agentPath, sessionKey, s);
   }
 
+  /** Mint one seeded feed entry from a history frame (seed + prepend share it). */
+  private mintHistoryEntry(s: ConvState, f: HistoryFrame): FeedItemVM {
+    return {
+      id: `f${s.seq++}`,
+      feed_type: f.feed_type,
+      data: f.data,
+      ...(f.ts !== undefined ? { ts: f.ts } : {}),
+      ...(f.author !== undefined ? { author: f.author } : {}),
+      ...(f.mentions !== undefined ? { mentions: f.mentions } : {}),
+      ...(f.turnId !== undefined ? { turnId: f.turnId } : {}),
+      ...(f.toolIndex !== undefined ? { toolIndex: f.toolIndex } : {}),
+    };
+  }
+
   pushFeedItem(agentPath: string, sessionKey: string, item: unknown): void {
     const s = this.state(agentPath, sessionKey);
-    const { feed_type, data, ts, pending, fails_pending, author, mentions } =
-      item as {
-        feed_type: string;
-        data: unknown;
-        ts?: number;
-        pending?: boolean;
-        fails_pending?: boolean;
-        author?: FeedAuthor;
-        mentions?: FeedMention[];
-      };
+    const {
+      feed_type,
+      data,
+      ts,
+      pending,
+      fails_pending,
+      author,
+      mentions,
+      turnId,
+      toolIndex,
+    } = item as {
+      feed_type: string;
+      data: unknown;
+      ts?: number;
+      pending?: boolean;
+      fails_pending?: boolean;
+      author?: FeedAuthor;
+      mentions?: FeedMention[];
+      turnId?: string;
+      toolIndex?: number;
+    };
     // An optimistic (pending) push is NOT server evidence, so it never confirms a
     // sibling optimistic bubble — two queued prompts both keep their clock. ANY
     // other push resolves EVERY currently pending entry at once: a
@@ -365,18 +419,20 @@ export class ConversationVmOutput implements FeedOutput {
     }
     const finalOf = FINAL_OF[feed_type];
     if (feed_type.endsWith("_streaming")) {
-      this.upsertStreaming(s, feed_type, data, ts);
+      this.upsertStreaming(s, feed_type, data, ts, turnId);
     } else if (finalOf !== undefined && s.streaming.has(finalOf)) {
       const id = s.streaming.get(finalOf);
       const entry = s.feed.find((f) => f.id === id);
       if (entry) {
         // Finalizing an open stream mutates the SAME entry: keep its original
-        // `ts` (the bubble is timed by when it opened), only swap type + data.
+        // `ts` (the bubble is timed by when it opened), only swap type + data
+        // (and stamp the turn identity when the push knows it).
         entry.feed_type = feed_type;
         entry.data = data;
+        if (turnId !== undefined) entry.turnId ??= turnId;
       }
       s.streaming.delete(finalOf);
-    } else {
+    } else if (!this.upsertByTurn(s, feed_type, data, turnId, toolIndex)) {
       // A fresh entry: carry a supplied `ts`, else stamp the wall clock now; an
       // optimistic push carries `pending: true` until server evidence clears it,
       // and (multiplayer) the sender's `author` plus the teammates the message
@@ -390,9 +446,68 @@ export class ConversationVmOutput implements FeedOutput {
         ...(pending === true ? { pending: true } : {}),
         ...(author !== undefined ? { author } : {}),
         ...(mentions !== undefined ? { mentions } : {}),
+        ...(turnId !== undefined ? { turnId } : {}),
+        ...(toolIndex !== undefined ? { toolIndex } : {}),
       });
     }
     this.publish(agentPath, sessionKey, s);
+  }
+
+  /**
+   * Turn-identity dedup (HOU-1214): fold a pushed item into the entry the SAME
+   * turn already put on this feed, instead of appending a duplicate. This is
+   * what makes the fold idempotent under re-delivery — a running-sync replay
+   * over a history-seeded feed (the reply persists BEFORE the terminal frame,
+   * so a chat-open read can seed it while the snapshot still says `running`), a
+   * stale-running snapshot replaying a finished turn, or a settle-from-history
+   * re-push all UPDATE what is already on screen. Returns whether it consumed
+   * the push; false (no identity, or first delivery) keeps the append path.
+   */
+  private upsertByTurn(
+    s: ConvState,
+    feed_type: string,
+    data: unknown,
+    turnId: string | undefined,
+    toolIndex: number | undefined,
+  ): boolean {
+    if (turnId === undefined) return false;
+    if (SINGLETON_TYPES.has(feed_type)) {
+      // Also match the type's open/orphaned streaming counterpart — a dead
+      // sink can leave one behind, and the re-delivered final must close it,
+      // not sit next to it.
+      const streaming = FINAL_OF[feed_type];
+      const entry = findLast(
+        s.feed,
+        (f) =>
+          f.turnId === turnId &&
+          (f.feed_type === feed_type || f.feed_type === streaming),
+      );
+      if (!entry) return false;
+      // `final_result` keeps its FIRST data: the seeded copy carries the
+      // turn's persisted usage, which a re-settle's invisible final (empty
+      // usage) must not clobber — the context indicator reads it.
+      if (feed_type !== "final_result") {
+        entry.feed_type = feed_type;
+        entry.data = data;
+      }
+      return true;
+    }
+    if (
+      (feed_type === "tool_call" || feed_type === "tool_result") &&
+      toolIndex !== undefined
+    ) {
+      const entry = findLast(
+        s.feed,
+        (f) =>
+          f.turnId === turnId &&
+          f.feed_type === feed_type &&
+          f.toolIndex === toolIndex,
+      );
+      if (!entry) return false;
+      entry.data = data;
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -426,6 +541,7 @@ export class ConversationVmOutput implements FeedOutput {
     feed_type: string,
     data: unknown,
     ts?: number,
+    turnId?: string,
   ): void {
     const existingId = s.streaming.get(feed_type);
     if (existingId !== undefined) {
@@ -437,9 +553,35 @@ export class ConversationVmOutput implements FeedOutput {
         return;
       }
     }
+    // No open run — but the SAME turn's bubble may already be on the feed
+    // (HOU-1214): a history seed painted the persisted reply while the
+    // snapshot still said `running`, or a prior sink's entry survived a
+    // terminal status. Adopt that entry as this run's target instead of
+    // opening a duplicate; its feed_type is left as-is (a final stays final —
+    // deltas only ever touch data) and the final flush closes it in place.
+    if (turnId !== undefined) {
+      const finalType = STREAMED_AS[feed_type];
+      const entry = findLast(
+        s.feed,
+        (f) =>
+          f.turnId === turnId &&
+          (f.feed_type === feed_type || f.feed_type === finalType),
+      );
+      if (entry) {
+        entry.data = data;
+        s.streaming.set(feed_type, entry.id);
+        return;
+      }
+    }
     // Opening the stream's entry: carry a supplied `ts`, else stamp now.
     const id = `f${s.seq++}`;
-    s.feed.push({ id, feed_type, data, ts: ts ?? Date.now() });
+    s.feed.push({
+      id,
+      feed_type,
+      data,
+      ts: ts ?? Date.now(),
+      ...(turnId !== undefined ? { turnId } : {}),
+    });
     s.streaming.set(feed_type, id);
   }
 

--- a/packages/sdk/src/modules/turns/vm-output.ts
+++ b/packages/sdk/src/modules/turns/vm-output.ts
@@ -215,9 +215,17 @@ const STREAMED_AS: Record<string, string> = {
 /**
  * Feed types a turn produces exactly ONCE, deduped by `turnId` alone
  * (HOU-1214). Tool rows are many-per-turn and dedupe by (turnId, toolIndex)
- * instead; everything else stays append-only.
+ * instead. `system_message` is deliberately NOT here — a turn can legitimately
+ * carry several (a stop line plus a reload-failure line). Everything else
+ * stays append-only.
  */
-const SINGLETON_TYPES = new Set(["assistant_text", "thinking", "final_result"]);
+const SINGLETON_TYPES = new Set([
+  "assistant_text",
+  "thinking",
+  "final_result",
+  "file_changes",
+  "provider_error",
+]);
 
 /** Last matching entry — local helper (`Array.findLast` is ES2023; the SDK
  *  targets ES2022 and runs in older WKWebViews). */
@@ -418,19 +426,17 @@ export class ConversationVmOutput implements FeedOutput {
       else this.clearPending(s);
     }
     const finalOf = FINAL_OF[feed_type];
+    const run =
+      finalOf !== undefined ? this.openRun(s, finalOf, turnId) : undefined;
     if (feed_type.endsWith("_streaming")) {
       this.upsertStreaming(s, feed_type, data, ts, turnId);
-    } else if (finalOf !== undefined && s.streaming.has(finalOf)) {
-      const id = s.streaming.get(finalOf);
-      const entry = s.feed.find((f) => f.id === id);
-      if (entry) {
-        // Finalizing an open stream mutates the SAME entry: keep its original
-        // `ts` (the bubble is timed by when it opened), only swap type + data
-        // (and stamp the turn identity when the push knows it).
-        entry.feed_type = feed_type;
-        entry.data = data;
-        if (turnId !== undefined) entry.turnId ??= turnId;
-      }
+    } else if (finalOf !== undefined && run !== undefined) {
+      // Finalizing an open stream mutates the SAME entry: keep its original
+      // `ts` (the bubble is timed by when it opened), only swap type + data
+      // (and stamp the turn identity when the push knows it).
+      run.feed_type = feed_type;
+      run.data = data;
+      if (turnId !== undefined) run.turnId ??= turnId;
       s.streaming.delete(finalOf);
     } else if (!this.upsertByTurn(s, feed_type, data, turnId, toolIndex)) {
       // A fresh entry: carry a supplied `ts`, else stamp the wall clock now; an
@@ -536,6 +542,35 @@ export class ConversationVmOutput implements FeedOutput {
       }
   }
 
+  /**
+   * The open streaming run's entry for `streamingType`, or undefined. A
+   * registration whose entry belongs to a DIFFERENT turn than the push is
+   * STALE — a prior turn's bubble a dead sink left open — and reusing it would
+   * splice the new turn's content into the old turn's entry (keeping the old
+   * identity); it is dropped instead, side-effectfully, so callers fall
+   * through to adopt-or-append. A registration whose entry vanished from the
+   * feed (a reseed raced the push) is dropped the same way.
+   */
+  private openRun(
+    s: ConvState,
+    streamingType: string,
+    turnId: string | undefined,
+  ): FeedItemVM | undefined {
+    const id = s.streaming.get(streamingType);
+    if (id === undefined) return undefined;
+    const entry = s.feed.find((f) => f.id === id);
+    if (
+      entry !== undefined &&
+      (turnId === undefined ||
+        entry.turnId === undefined ||
+        entry.turnId === turnId)
+    ) {
+      return entry;
+    }
+    s.streaming.delete(streamingType);
+    return undefined;
+  }
+
   private upsertStreaming(
     s: ConvState,
     feed_type: string,
@@ -543,15 +578,14 @@ export class ConversationVmOutput implements FeedOutput {
     ts?: number,
     turnId?: string,
   ): void {
-    const existingId = s.streaming.get(feed_type);
-    if (existingId !== undefined) {
-      const entry = s.feed.find((f) => f.id === existingId);
-      if (entry) {
-        // A streaming delta updates data only — the entry keeps the `ts` it was
-        // stamped with when the stream opened.
-        entry.data = data;
-        return;
-      }
+    const entry = this.openRun(s, feed_type, turnId);
+    if (entry) {
+      // A streaming delta updates data only — the entry keeps the `ts` it was
+      // stamped with when the stream opened (and adopts the turn identity the
+      // moment a push knows it).
+      entry.data = data;
+      if (turnId !== undefined) entry.turnId ??= turnId;
+      return;
     }
     // No open run — but the SAME turn's bubble may already be on the feed
     // (HOU-1214): a history seed painted the persisted reply while the

--- a/packages/sdk/tests/turns-history.contract.test.ts
+++ b/packages/sdk/tests/turns-history.contract.test.ts
@@ -64,11 +64,13 @@ describe("turns/history — fold persisted transcript", () => {
         data: "Ping",
         author: undefined,
         ts: expect.any(Number),
+        turnId: expect.any(String),
       },
       {
         feed_type: "assistant_text",
         data: cannedReply("Ping"),
         ts: expect.any(Number),
+        turnId: expect.any(String),
       },
       {
         feed_type: "final_result",
@@ -79,6 +81,7 @@ describe("turns/history — fold persisted transcript", () => {
           usage: seedUsage,
         },
         ts: expect.any(Number),
+        turnId: expect.any(String),
       },
     ]);
     // Each folded frame carries its source ChatMessage.ts (epoch ms).

--- a/packages/sdk/tests/turns.contract.test.ts
+++ b/packages/sdk/tests/turns.contract.test.ts
@@ -85,7 +85,14 @@ describe("turn send → stream → settle", () => {
       feed: [
         // The optimistic push — the ONE user bubble (its echo never renders).
         { id: "f0", feed_type: "user_message", data: "Ping" },
-        { id: "f1", feed_type: "assistant_text", data: cannedReply("Ping") },
+        {
+          id: "f1",
+          feed_type: "assistant_text",
+          data: cannedReply("Ping"),
+          // Live pushes carry the adopted turn id — the VM fold's dedup
+          // identity (HOU-1214).
+          turnId: expect.any(String) as unknown as string,
+        },
         {
           id: "f2",
           feed_type: "final_result",
@@ -95,6 +102,7 @@ describe("turn send → stream → settle", () => {
             duration_ms: null,
             usage: seedUsage,
           },
+          turnId: expect.any(String) as unknown as string,
         },
       ],
     } satisfies ConversationVM);

--- a/packages/web/src/engine-adapter/cache-persist.ts
+++ b/packages/web/src/engine-adapter/cache-persist.ts
@@ -36,6 +36,11 @@ export function cachePersistOutput(): FeedOutput {
           // the message's @mention chips (HOU-944).
           ...(f.author !== undefined ? { author: f.author } : {}),
           ...(f.mentions !== undefined ? { mentions: f.mentions } : {}),
+          // Turn identity survives too (HOU-1214): a cache-painted feed must
+          // stay dedupable against a live replay, or the duplication returns
+          // on exactly the cold opens the cache exists for.
+          ...(f.turnId !== undefined ? { turnId: f.turnId } : {}),
+          ...(f.toolIndex !== undefined ? { toolIndex: f.toolIndex } : {}),
         })),
       );
     },

--- a/packages/web/src/engine-adapter/conversation-cache-types.ts
+++ b/packages/web/src/engine-adapter/conversation-cache-types.ts
@@ -34,6 +34,16 @@ export interface CachedFrame {
    * mentioned nobody and on records written before this field existed.
    */
   mentions?: { userId: string; name?: string }[];
+  /**
+   * The turn this frame belongs to — the VM fold's dedup identity (HOU-1214),
+   * carried so a cache-painted feed folds a live replay of the same turn into
+   * the entries already on screen instead of duplicating them. Absent on
+   * records written before this field existed (those keep the append fold).
+   */
+  turnId?: string;
+  /** With {@link turnId}, this tool row's per-turn index (HOU-1214). Tool
+   *  frames only; same absence semantics as `turnId`. */
+  toolIndex?: number;
 }
 
 /** A stored transcript: its frames plus a write stamp (prune order). */

--- a/packages/web/src/engine-adapter/conversation-cache.ts
+++ b/packages/web/src/engine-adapter/conversation-cache.ts
@@ -137,6 +137,10 @@ export async function writeCachedConversation(
         ...(f.ts !== undefined ? { ts: f.ts } : {}),
         ...(f.author !== undefined ? { author: f.author } : {}),
         ...(f.mentions !== undefined ? { mentions: f.mentions } : {}),
+        // Turn identity (HOU-1214): a cache-painted feed must stay dedupable
+        // against a live replay of the same turn.
+        ...(f.turnId !== undefined ? { turnId: f.turnId } : {}),
+        ...(f.toolIndex !== undefined ? { toolIndex: f.toolIndex } : {}),
       })),
       updatedAt: Date.now(),
     });


### PR DESCRIPTION
Fixes HOU-1214 — the agent's last message rendering 2–4× in chat ("Correo enviado" ×4) while the underlying action ran once. Reproduced on staging; the persisted transcripts on the agent pods were clean, confirming the duplication is client-side.

## Root cause

The conversation VM feed had **no per-turn identity** — dedup relied solely on the in-memory open-streaming map, which any history seed or terminal status clears (`vm-output.ts`). Three cloud-frequent paths then append the same content again:

1. **Seed-then-observe race.** The runtime persists the reply *before* publishing the terminal frame. A chat-open history read (refired on every `ConversationsChanged`) seeds the feed *including* the reply while the conversation snapshot still says `running`; the observer attaching right after receives a running `sync` and replays the whole turn (partial text, thinking, tools) as **new** feed entries.
2. **Stale-running snapshots** (dead pump, relay replica change) replay a finished turn into every attaching observer the same way.
3. **Settle-from-history re-push.** `finishOk` unconditionally pushes `assistant_text` when no streaming entry is open — one more copy per lost-terminal settle / pre-settled poll.

Each copy is then **permanent**: `decideServerSeed` compares frames-after-last-user-message and judges the corrupted feed *richer* than the server fold (`skip`), so no later authoritative read heals it. Copies accumulate to ×3, ×4 across reopen/invalidation cycles.

## Fix

Make the feed fold **idempotent by turn identity**:

- `historyToFeed` stamps `turnId` (from `ChatMessage.turnId`) on every folded frame, plus a per-turn `toolIndex` on tool rows; live sink pushes carry the same identity (`TurnState.turnId`, stamped by `push`).
- `ConversationVmOutput.pushFeedItem` upserts by that identity: singleton-per-turn types (`assistant_text`, `thinking`, `final_result`, `file_changes`, `provider_error`) fold in place; tool rows pair by `(turnId, toolIndex)`; a streaming push **adopts** the same turn's seeded bubble instead of opening a duplicate; a stale open-streaming registration from a different turn is dropped, never reused.
- `final_result` keeps its first data so a re-settle's empty invisible final never clobbers persisted usage (context indicator).
- The conversation cache carries the identity (`writeCachedConversation`, settle-time persist), so cache-painted feeds stay dedupable on cold opens.
- Frames without `turnId` (legacy servers, old cache records) keep today's append-only behavior. All fields are additive on the VM contract.

## Verification

- New regression tests reproduce the exact race (seed → observe over a stale-running snapshot → replay → `done`) and the ×4 accumulator (4 seed+observe cycles): **both fail on the unfixed fold**, pass with the fix.
- Unit tests cover: streaming-adopts-seeded-bubble, settle re-push, tool-row `(turnId, toolIndex)` dedup, `final_result` keep-first, legacy no-`turnId` append preserved, identical-text-different-turn still appends, cross-turn stale streaming target, `file_changes`/`provider_error` singletons.
- `pnpm --filter @houston/sdk test` 406/406 · workspace `pnpm typecheck` · `houston-web` typecheck + shim parity · `app` tsgo + node:test · Biome clean.
- Independent adversarial review of the diff (Codex); its confirmed findings (cache identity strip, cross-turn streaming reuse, missed singleton types) are fixed in the second commit.

## Repro before / verify after

Before (staging or any cloud env, pre-fix build): open a chat, send a message that triggers an action (e.g. send an email), and while the turn is finishing close/reopen the chat (or let `ConversationsChanged` invalidations refire) — the final reply renders 2–4×, and stays duplicated on every reopen.

After: same flow — the reply renders exactly once; repeated open/observe cycles (the regression test drives 4) leave a single bubble, and tool/thinking rows don't double.