### PR TITLE
fix(host): stop double-watching the workspaces tree on managed pods (HOU-1237)

### DIFF
--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -568,6 +568,9 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     ? new StoreSyncDaemon({
         ...opts.storeSync,
         rootDir: dirname(opts.workspacesRoot),
+        // FsWatcher above already watches this subtree for reactivity —
+        // don't pay for a second, redundant inotify watch over it (HOU-1237).
+        watchExcludeDirs: [opts.workspacesRoot],
         log: severityLog,
       })
     : undefined;

--- a/packages/host/src/store-sync/daemon.test.ts
+++ b/packages/host/src/store-sync/daemon.test.ts
@@ -84,6 +84,30 @@ test("uploads created files after the quiet period", async () => {
   await daemon.stop();
 });
 
+test("a change inside an excluded watch subtree still syncs via the periodic pass (HOU-1237)", async () => {
+  const remoteRoot = mkdtempSync(join(tmpdir(), "store-sync-remote-"));
+  const localRoot = mkdtempSync(join(tmpdir(), "store-sync-local-"));
+  const excludedDir = join(localRoot, "excluded");
+  mkdirSync(excludedDir, { recursive: true });
+  const daemon = new StoreSyncDaemon({
+    store: new LocalDirStore(remoteRoot),
+    rootDir: localRoot,
+    quietMs: 20,
+    intervalMs: 250,
+    watchExcludeDirs: [excludedDir],
+    log: () => {},
+  });
+  await daemon.hydrate();
+  daemon.start();
+  writeFileSync(join(excludedDir, "created.txt"), "created");
+  await eventually(() => {
+    expect(
+      readFileSync(join(remoteRoot, "excluded", "created.txt"), "utf8"),
+    ).toBe("created");
+  });
+  await daemon.stop();
+});
+
 test("deletes remotely when a hydrated file is deleted locally", async () => {
   const { daemon, localRoot, remoteRoot } = setup();
   writeFileSync(join(remoteRoot, "delete-me.txt"), "old");

--- a/packages/host/src/store-sync/daemon.ts
+++ b/packages/host/src/store-sync/daemon.ts
@@ -38,6 +38,13 @@ export interface StoreSyncOptions {
   store: ObjectStore;
   rootDir: string;
   excludes?: string[];
+  /**
+   * Absolute paths the filesystem watcher never descends into (HOU-1237,
+   * distinct from `excludes` above — object-store keys, not watch paths).
+   * The unfiltered periodic sync still covers them, so this only trades a
+   * ~3s debounce for the interval one inside the excluded subtree.
+   */
+  watchExcludeDirs?: string[];
   quietMs?: number;
   intervalMs?: number;
   maxHydrateBytes?: number;
@@ -92,6 +99,7 @@ export class StoreSyncDaemon {
     this.started = true;
     try {
       this.watcher = watchTree(this.opts.rootDir, () => this.markDirty(), {
+        excludeDirs: this.opts.watchExcludeDirs,
         // Fires at most once (ENOSPC on the pod's inotify budget — HOU-841);
         // the tree watch keeps whatever coverage it already has, and the
         // periodic pass guarantees eventual sync regardless.

--- a/packages/host/src/watch/watch-tree.test.ts
+++ b/packages/host/src/watch/watch-tree.test.ts
@@ -21,11 +21,13 @@ function linuxWatch(
   events: Array<{ type: string; rel: string }>,
   onError: (err: unknown) => void = () => {},
   watchDir?: WatchDirFn,
+  excludeDirs?: string[],
 ): TreeWatch {
   return watchTree(root, (type, rel) => events.push({ type, rel }), {
     onError,
     platform: "linux",
     watchDir,
+    excludeDirs,
   });
 }
 
@@ -159,6 +161,28 @@ test(".git is never watched (HOU-1232)", async () => {
     expect(watchedDirs).not.toContain(join(root, ".git"));
     expect(watchedDirs).not.toContain(join(root, ".git", "objects"));
     expect(events.some((e) => e.rel.startsWith(".git/"))).toBe(false);
+  } finally {
+    watcher.close();
+  }
+});
+
+test("excludeDirs is never watched, even for a pre-existing subtree (HOU-1237)", async () => {
+  const root = mkdtempSync(join(tmpdir(), "houston-tree-"));
+  mkdirSync(join(root, "workspaces", "deep"), { recursive: true });
+  const excluded = join(root, "workspaces");
+  const watchedDirs: string[] = [];
+  const watchDir: WatchDirFn = (dir, cb) => {
+    watchedDirs.push(dir);
+    return watch(dir, cb);
+  };
+  const events: Array<{ type: string; rel: string }> = [];
+  const watcher = linuxWatch(root, events, () => {}, watchDir, [excluded]);
+  try {
+    await new Promise((r) => setTimeout(r, 100));
+    writeFileSync(join(root, "workspaces", "deep", "file.txt"), "x");
+    await new Promise((r) => setTimeout(r, 200));
+    expect(watchedDirs).not.toContain(excluded);
+    expect(watchedDirs).not.toContain(join(excluded, "deep"));
   } finally {
     watcher.close();
   }

--- a/packages/host/src/watch/watch-tree.ts
+++ b/packages/host/src/watch/watch-tree.ts
@@ -29,6 +29,8 @@ export interface TreeWatchOptions {
   platform?: NodeJS.Platform;
   /** Test override for the per-directory watch (Linux strategy only). */
   watchDir?: WatchDirFn;
+  /** Absolute paths never descended into (Linux strategy only) — HOU-1237. */
+  excludeDirs?: string[];
 }
 
 export interface TreeWatch {
@@ -41,14 +43,12 @@ export interface TreeWatch {
  * macOS/Windows: native `fs.watch(root, { recursive: true })` (FSEvents /
  * ReadDirectoryChangesW) — one OS handle for the whole tree.
  *
- * Linux: Node has no native recursive watch; its userland fallback
- * (`internal/fs/recursive_watch`) registers one inotify watch per FILE and
- * re-registers on every file that appears — atomic-write temp files included.
- * inotify watches are a kernel budget shared by every pod on the node, so a
- * busy tree exhausts it and every later file op throws ENOSPC (HOU-841).
- * A directory inotify watch already reports create/modify/delete of its
- * direct children, so this strategy watches DIRECTORIES only: watch count
- * drops from files+dirs to dirs, and file churn registers nothing new.
+ * Linux: Node's userland recursive fallback registers one inotify watch per
+ * FILE, re-registering on every file that appears (atomic-write temp files
+ * included) — a busy tree exhausts the kernel's per-pod-shared budget and
+ * every later file op throws ENOSPC (HOU-841). A directory watch already
+ * reports its direct children's create/modify/delete, so this strategy
+ * watches DIRECTORIES only: file churn registers nothing new.
  */
 export function watchTree(
   root: string,
@@ -57,7 +57,13 @@ export function watchTree(
 ): TreeWatch {
   const platform = opts.platform ?? process.platform;
   if (platform !== "linux") return watchNative(root, listener, opts.onError);
-  return new DirTreeWatcher(root, listener, opts.onError, opts.watchDir);
+  return new DirTreeWatcher(
+    root,
+    listener,
+    opts.onError,
+    opts.watchDir,
+    opts.excludeDirs,
+  );
 }
 
 function watchNative(
@@ -94,6 +100,7 @@ class DirTreeWatcher implements TreeWatch {
     private readonly listener: TreeWatchListener,
     private readonly onError: (err: unknown) => void,
     private readonly watchDir: WatchDirFn = (dir, cb) => watch(dir, cb),
+    private readonly excludeDirs: string[] = [],
   ) {
     this.addDir(root, true);
   }
@@ -110,14 +117,15 @@ class DirTreeWatcher implements TreeWatch {
     this.onError(err);
   }
 
+  // .git is reactivity-dead; excludeDirs skips a subtree another watcher
+  // owns (HOU-1237) — matters for a rename-reached pre-existing dir too.
+  private isSkipped(dir: string): boolean {
+    return basename(dir) === ".git" || this.excludeDirs.includes(dir);
+  }
+
   private addDir(dir: string, isRoot = false): void {
     if (this.closed || this.degraded || this.watchers.has(dir)) return;
-    // .git is never watched: agentFileEventType (packages/domain) already
-    // classifies every .git/ path as a null event, so a watch there only
-    // spends inotify budget for changes nobody sees. Checked here (not just
-    // in the readdir scan below) because a rename event for a pre-existing
-    // dir can call addDir directly, bypassing that scan.
-    if (!isRoot && basename(dir) === ".git") return;
+    if (!isRoot && this.isSkipped(dir)) return;
     let watcher: FSWatcher;
     try {
       watcher = this.watchDir(dir, (eventType, filename) =>


### PR DESCRIPTION
## Summary

- `StoreSyncDaemon` watches `dirname(workspacesRoot)` (`/data`), which recursively re-includes `workspacesRoot` (`/data/workspaces`) — already watched independently by `FsWatcher` for UI reactivity. Two `DirTreeWatcher` instances end up covering the same, largely overlapping tree on every managed pod, roughly doubling inotify consumption for zero additional value: the daemon's watcher only needs to know *something* changed (`markDirty()` ignores path/type entirely), not what.
- Adds `excludeDirs` to `watchTree`/`DirTreeWatcher` (exact absolute-path match, Linux strategy only — the macOS/Windows native recursive watch has no per-subtree granularity) and wires `StoreSyncDaemon`'s construction in `host.ts` to exclude `workspacesRoot`.
- Correctness is preserved: `syncOnce()`'s periodic pass (every 5 minutes in prod, `DEFAULT_INTERVAL_MS`) scans the full `rootDir` unfiltered by the watch tree regardless of the `dirty` flag, so a write inside the now-excluded subtree still gets synced — just on the periodic cadence instead of the ~3s debounce, never data loss.

Traced while investigating the already-merged #1242 (HOU-1232): comparing Sentry HOUSTON-APP-51V (`watch '/data/workspaces'`, the crash-inducing issue #1242 fixed) against the related HOUSTON-APP-51W (`watch '/data'`, unresolved, zero agent overlap with 51V) led back to this redundant double-watch. 51W is lower severity — `StoreSyncDaemon.start()` already wraps its `watchTree` call in try/catch and degrades to the periodic fallback, so it doesn't crash pods — but it's real waste and a direct contributor to hitting the inotify budget at all on a crowded/under-provisioned node.

Linear: HOU-1237

## Test plan

- [x] `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test` — 271 files / 2474 tests pass, including two new cases: `watch-tree.test.ts`'s `"excludeDirs is never watched, even for a pre-existing subtree"` and `daemon.test.ts`'s `"a change inside an excluded watch subtree still syncs via the periodic pass"`.
- [x] `pnpm check:fix` — Biome clean.
- [x] `pnpm check:boundaries` — clean.
- [x] `pnpm -r typecheck` (pre-commit hook) — clean across all 27 workspace projects.

### Reproduce (before this fix)

Construct a `StoreSyncDaemon` whose `rootDir` contains a subdirectory also watched by a separate `FsWatcher` (as `host.ts` does with `workspacesRoot`) — there was no way to exclude that subtree from the daemon's own recursive watch, so both watchers independently opened an inotify watch per directory in it.

### Verify (after)

`pnpm --filter @houston/host test -- src/watch/watch-tree.test.ts src/store-sync/daemon.test.ts` — the new `watch-tree.test.ts` case confirms no watch handle ever opens under an `excludeDirs` path (including via the rename-event path, not just the initial scan), and the new `daemon.test.ts` case confirms a file written inside that excluded subtree still reaches the remote store, proving the periodic-sync fallback preserves correctness.