### PR TITLE
fix(host): setup runtime survives the HOU-827 missing-dir guard (HOU-1239)

### DIFF
--- a/packages/host/src/local/agent-dirs.test.ts
+++ b/packages/host/src/local/agent-dirs.test.ts
@@ -1,0 +1,47 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { liveAgentDirFor } from "./agent-dirs";
+
+describe("liveAgentDirFor", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = join(
+      tmpdir(),
+      `houston-agent-dirs-${process.pid}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(root, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns an existing agent dir", () => {
+    mkdirSync(join(root, "Personal", "bob"), { recursive: true });
+    expect(liveAgentDirFor(root, "Personal/bob")).toBe(
+      join(root, "Personal", "bob"),
+    );
+  });
+
+  it("fails closed on a stale id — a spawn must never resurrect a renamed/deleted agent (HOU-827)", () => {
+    expect(() => liveAgentDirFor(root, "Personal/gone")).toThrow(
+      /agent directory for 'Personal\/gone' is gone/,
+    );
+    expect(existsSync(join(root, "Personal", "gone"))).toBe(false);
+  });
+
+  it("creates the hidden setup runtime's dir on demand — first-run provider connect has no other create path (HOU-1239)", () => {
+    const dir = liveAgentDirFor(root, "Personal/.setup/connect");
+    expect(dir).toBe(join(root, "Personal", ".setup", "connect"));
+    expect(existsSync(dir)).toBe(true);
+    // Idempotent on the next spawn.
+    expect(liveAgentDirFor(root, "Personal/.setup/connect")).toBe(dir);
+  });
+
+  it("does NOT extend the carve-out to ordinary dot-less agents nested under real workspaces", () => {
+    expect(() => liveAgentDirFor(root, "Personal/setup")).toThrow(/is gone/);
+  });
+});

--- a/packages/host/src/local/agent-dirs.ts
+++ b/packages/host/src/local/agent-dirs.ts
@@ -1,0 +1,36 @@
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+/** agent.id is "<Workspace>/<Agent>" — split it back into the on-disk dir. */
+export function agentDirFor(workspacesRoot: string, id: string): string {
+  return join(workspacesRoot, ...id.split("/"));
+}
+
+/**
+ * Resolve the directory a runtime may spawn against, failing closed on a
+ * stale id: after a rename (or delete) the old id maps to a directory that no
+ * longer exists, and a runtime spawned against it would recreate the tree on
+ * its first mkdir-recursive write — the HOU-827 ghost agent. Any late dispatch
+ * still holding the old id (client caches, a scheduler tick that crossed the
+ * rename) errors visibly instead.
+ *
+ * ONE carve-out: the hidden setup runtime's synthetic agent
+ * (`<ws>/.setup/connect`, routes/setup-runtime.ts) has no create path — its
+ * directory only ever exists because a spawn made it. Nothing user-facing can
+ * create, rename, or delete it, so the stale-id protection cannot apply;
+ * without the carve-out, first-run provider connect on a fresh cloud account
+ * 500s before any agent exists (HOU-1239).
+ */
+export function liveAgentDirFor(workspacesRoot: string, id: string): string {
+  const dir = agentDirFor(workspacesRoot, id);
+  if (!existsSync(dir)) {
+    if (id.split("/").includes(".setup")) {
+      mkdirSync(dir, { recursive: true });
+      return dir;
+    }
+    throw new Error(
+      `agent directory for '${id}' is gone (renamed or deleted?)`,
+    );
+  }
+  return dir;
+}

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -48,6 +48,7 @@ import { MemoryTurnBus } from "../turn/bus";
 import { UsageSampler } from "../usage/sampler";
 import { FsVfs } from "../vfs";
 import { FsWatcher } from "../watch/watcher";
+import { agentDirFor, liveAgentDirFor } from "./agent-dirs";
 import { formatHostListeningBanner } from "./banner";
 
 /** The single local user every request resolves to. */
@@ -302,21 +303,10 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
       onLog: opts.onRuntimeLog,
     });
 
-  // agent.id is "<Workspace>/<Agent>" — split it back into the on-disk dir.
-  const agentDir = (id: string) => join(opts.workspacesRoot, ...id.split("/"));
-  // Spawns fail closed on a stale id: after a rename (or delete) the old id
-  // maps to a directory that no longer exists, and a runtime spawned against
-  // it would recreate the tree on its first mkdir-recursive write — the
-  // HOU-827 ghost agent. Any late dispatch still holding the old id (client
-  // caches, a scheduler tick that crossed the rename) errors visibly instead.
-  const liveAgentDir = (id: string) => {
-    const dir = agentDir(id);
-    if (!existsSync(dir))
-      throw new Error(
-        `agent directory for '${id}' is gone (renamed or deleted?)`,
-      );
-    return dir;
-  };
+  // Stale-id fail-closed resolution + the setup-runtime carve-out live in
+  // agent-dirs.ts (HOU-827 / HOU-1239) so both behaviors stay unit-tested.
+  const agentDir = (id: string) => agentDirFor(opts.workspacesRoot, id);
+  const liveAgentDir = (id: string) => liveAgentDirFor(opts.workspacesRoot, id);
   const launcher = new ProcessLauncher({
     spawner,
     workspaceDirFor: (a) => liveAgentDir(a.id),


### PR DESCRIPTION
## What

Fixes HOU-1239 (Urgent): every fresh cloud account's onboarding "Connect your AI" 500s with `agent directory for 'Personal/.setup/connect' is gone (renamed or deleted?)`.

## Root cause

#1240 (HOU-827) made runtime spawns fail closed when the agent's directory doesn't exist — correct protection against stale ids resurrecting renamed/deleted agents. But the hidden setup runtime's synthetic agent (`Personal/.setup/connect`) has **no create path at all**: its directory only ever existed because the first spawn implicitly created it. Post-#1240 that first spawn is exactly what the guard forbids, so first-run provider connect dies on any clean hosted account.

Found live during HOU-991 staging verification (the first from-zero onboarding after staging's engine rolled #1240); confirmed in the setup pod: `/data/workspaces/Personal` exists, `.setup/` absent, engine 500s on every `/setup-runtime/*`.

## Fix

One carve-out at the guard: an id containing a `.setup` path segment is created on demand (mkdir recursive) instead of failing closed — nothing user-facing can create, rename, or delete the synthetic agent, so the HOU-827 stale-id protection cannot apply to it. Everything else keeps failing closed. Guard + carve-out extracted to `local/agent-dirs.ts` so both behaviors are unit-tested (4 new tests: existing dir, stale-id throw with no dir created, setup create-on-demand + idempotency, no carve-out for a dot-less `Personal/setup`).

## Urgency / roll order

- **Staging is broken now** (engine rolls 2026-08-05 23:50Z + 2026-08-06 00:49Z carry #1240).
- **Prod is NOT affected yet** — its last engine roll (2026-08-04 22:27Z) predates #1240. This must merge **before the next prod engine roll**, or new-user onboarding breaks in prod.

## Verification

Before: fresh account on staging → onboarding Connect your AI → Anthropic stuck on "Connecting", console full of `/setup-runtime/providers` 500s.
After (once staging's engine rolls this): same flow → provider list loads, OAuth completes, onboarding proceeds.

Gates: 1284 host vitest (4 new), app+web typecheck, Biome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)