### PR TITLE
fix(app): unexpected errors report silently instead of toasting the user (HOU-1245)

### DIFF
--- a/app/src/lib/error-burst.ts
+++ b/app/src/lib/error-burst.ts
@@ -1,0 +1,46 @@
+/**
+ * Burst collapsing for the error-surfacing layer.
+ *
+ * One root cause fails N concurrent calls — a dozen queries all hitting the
+ * same rejected bearer during a cloud deploy (HOU-687), every live query at
+ * once when the device drops offline (HOU-1085) — and each of them reaches the
+ * surfacing layer independently. Only the FIRST of such a burst is a distinct
+ * event: the rest are the same problem, and re-toasting or re-counting them
+ * misrepresents one outage as a dozen.
+ *
+ * Callers key on the DISPLAYED body rather than the raw diagnostic, so a burst
+ * of technically distinct failures that all render the same generic copy also
+ * collapses into one — which is exactly how a non-technical user experiences
+ * it.
+ *
+ * Split out of `error-toast.ts` so the surviving decision stays unit-testable
+ * once the error path stopped rendering toasts (HOU-1245): the module it came
+ * from cannot be imported by `app/tests` (it pulls the engine-client barrel and
+ * the Zustand store), this one is dependency-free.
+ */
+
+export const TOAST_DEDUPE_WINDOW_MS = 5_000;
+
+export interface BurstGate {
+  /**
+   * True the first time `key` is seen, false for every repeat within the
+   * window. A repeat also REFRESHES the window, so a sustained failure loop
+   * stays collapsed instead of re-firing every `windowMs`.
+   */
+  isFirst(key: string, now: number): boolean;
+}
+
+export function createBurstGate(windowMs = TOAST_DEDUPE_WINDOW_MS): BurstGate {
+  const seen = new Map<string, number>();
+  return {
+    isFirst(key: string, now: number): boolean {
+      const last = seen.get(key);
+      seen.set(key, now);
+      // The map only ever holds keys from the current burst — evict as we go.
+      for (const [k, at] of seen) {
+        if (now - at > windowMs) seen.delete(k);
+      }
+      return last === undefined || now - last > windowMs;
+    },
+  };
+}

--- a/app/src/lib/error-toast.ts
+++ b/app/src/lib/error-toast.ts
@@ -1,71 +1,24 @@
 import { isSignedOutEngineError } from "@houston-ai/engine-client";
 import { useUIStore } from "../stores/ui";
 import { analytics, classifyAnalyticsError } from "./analytics";
+import { createBurstGate } from "./error-burst";
 import i18n from "./i18n";
 import {
   captureException as sentryCapture,
   sentrySuppressedInDev,
 } from "./sentry";
-import { devNoSendToastSpec } from "./sentry-dev";
 import { createSentryReportError } from "./sentry-report-error";
 import { markReportedToSentry } from "./sentry-reported-mark";
 
-const GREEN_TOAST_DELAY_MS = 700;
-
-/**
- * Surface an error to the user as a toast pair:
- *
- *   1. Red toast — the branded "we have a problem" title + a friendly,
- *      localized body. Shown immediately, no action button (auto-report
- *      supersedes it). The body is `options.userMessage` when the caller has
- *      authored product copy for the failure, else the generic fallback —
- *      NEVER the raw `message`: diagnostics like "Engine error 202" or
- *      WebKit's "Load failed" are developer speak, not something a
- *      non-technical user can act on (HOU-721). The raw `message` still
- *      reaches the frontend log (callers log before toasting), Sentry, and
- *      analytics classification, so genericizing the copy costs us nothing.
- *   2. Green follow-up toast — "report sent" + the Sentry event ID, ~700ms
- *      later, with a "Copy code" action that copies the FULL event id so it
- *      can be quoted to support / looked up in Sentry.
- *
- * Copy deliberately exposes the whole 32-char id (the toast text shows the
- * short prefix for readability). The wording is "report sent" — an honest
- * "the envelope left the queue" claim, NOT "we have a solution": the flush
- * confirms the transport accepted it, not that Sentry ingested or triaged it.
- *
- * `command` is a short machine-readable tag (e.g. "list_workspaces",
- * "uncaught_error") used as the Sentry tag for triage.
- *
- * Sentry not configured or not flushed → no green toast. Red toast still
- * shown. This is the right behavior for forks / personal builds and for
- * network failures where we cannot honestly say the report was sent.
- *
- * A toast whose DISPLAYED body is identical to one shown moments ago is
- * deduped (toast pair skipped, Sentry capture kept): one root cause failing N
- * concurrent calls — a dozen queries all hitting the same rejected bearer
- * during a cloud deploy (HOU-687) — must read as ONE problem, not a toast
- * storm. Keying on the displayed body (not the raw diagnostic) means a burst
- * of distinct engine failures also collapses into one generic toast, which is
- * exactly how a non-technical user should experience it.
- */
-const TOAST_DEDUPE_WINDOW_MS = 5_000;
-const recentToasts = new Map<string, number>();
-
-function isDuplicateToast(message: string, now: number): boolean {
-  const last = recentToasts.get(message);
-  recentToasts.set(message, now);
-  // The map only ever holds messages from the current burst — evict as we go.
-  for (const [msg, at] of recentToasts) {
-    if (now - at > TOAST_DEDUPE_WINDOW_MS) recentToasts.delete(msg);
-  }
-  return last !== undefined && now - last <= TOAST_DEDUPE_WINDOW_MS;
-}
+/** Collapses one root cause's burst of failures into a single counted event. */
+const errorBurst = createBurstGate();
 
 export interface ErrorToastOptions {
-  /** Authored, localized product copy to show as the toast body instead of
-   *  the generic fallback. Pass ONLY curated copy (a `t()` result), never a
-   *  raw `err.message` — raw diagnostics belong in `message`, which is
-   *  reported but not displayed. */
+  /** Authored, localized product copy for this specific failure (a `t()`
+   *  result, never a raw `err.message`). Since HOU-1245 it is no longer
+   *  displayed; it survives as the burst key, which is what keeps two
+   *  genuinely different failures counted separately while one failure hitting
+   *  N callers counts once. */
   userMessage?: string;
 }
 
@@ -100,7 +53,7 @@ export function showConnectivityErrorToast(
 ): void {
   console.error(`[toast:${command}] ${message}`);
   const description = i18n.t("shell:errorToast.offlineDescription");
-  if (isDuplicateToast(description, Date.now())) return;
+  if (!errorBurst.isFirst(description, Date.now())) return;
   analytics.track("app_error_shown", {
     source: command,
     error_kind: classifyAnalyticsError(message),
@@ -126,7 +79,7 @@ export function showConnectivityErrorToast(
 export function showEngineWakingToast(command: string, message: string): void {
   console.error(`[toast:${command}] ${message}`);
   const description = i18n.t("shell:errorToast.engineWakingDescription");
-  if (isDuplicateToast(description, Date.now())) return;
+  if (!errorBurst.isFirst(description, Date.now())) return;
   analytics.track("app_error_shown", {
     source: command,
     error_kind: classifyAnalyticsError(message),
@@ -138,6 +91,33 @@ export function showEngineWakingToast(command: string, message: string): void {
   });
 }
 
+/**
+ * Report an unexpected error — WITHOUT showing the user anything (HOU-1245).
+ *
+ * This used to render a toast pair: the red branded "Houston, we have a
+ * problem!" box, then a green "report sent — Reference #<id>" follow-up with a
+ * copy-the-code action. Both are gone. A generic red box a non-technical user
+ * cannot act on, followed by a Sentry event id that means nothing to them, cost
+ * more in alarm than it bought in information — and the errors that a user CAN
+ * act on (a name that's already taken, no microphone, an expired trial) never
+ * came through here: they have authored copy at their own call sites, and they
+ * still toast exactly as before. So do the informational states
+ * (`showConnectivityErrorToast`, `showEngineWakingToast`) above.
+ *
+ * NOTE this is a deliberate, scoped exception to the repo's no-silent-failures
+ * beta policy: silent to the USER, never silent to us. Every reporting path is
+ * untouched, so the failure still reaches:
+ *   - the frontend log, via the `console.error` below (mirrored to the log file
+ *     and bundled into a Report-bug submission);
+ *   - PostHog, via `app_error_shown` (the event name is kept despite nothing
+ *     being shown, so the existing error-rate dashboards stay continuous);
+ *   - Sentry, via `captureException` with `command` as the triage tag.
+ * Losing the toast means losing the user-reported half of a bug report, which
+ * makes those three the whole signal — do not quiet them too.
+ *
+ * `command` is a short machine-readable tag (e.g. "list_workspaces",
+ * "uncaught_error") used as the Sentry tag for triage.
+ */
 export function showErrorToast(
   command: string,
   message: string,
@@ -146,94 +126,41 @@ export function showErrorToast(
 ): void {
   // A hosted call answered by the transport's synthetic signed-out 401 is an
   // EXPECTED lifecycle state (sign-out / account switch): the sign-in screen is
-  // the surface, nothing is broken, and there is no bug to report — so no red
-  // toast and no Sentry capture. Everything else still surfaces loudly (beta
-  // policy); a REAL rejected bearer never takes this branch because the
-  // transport only mints the synthetic body when no session exists at all.
+  // the surface, nothing is broken, and there is no bug to report — so not even
+  // a Sentry capture. A REAL rejected bearer never takes this branch because
+  // the transport only mints the synthetic body when no session exists at all.
   if (isSignedOutEngineError(originalError)) {
     console.warn(`[toast:${command}] suppressed: signed-out engine call`);
     return;
   }
-  const addToast = useUIStore.getState().addToast;
-  const description =
-    options?.userMessage ?? i18n.t("shell:errorToast.genericDescription");
 
-  // The raw diagnostic no longer appears in the toast, so guarantee it in the
-  // frontend log (console.error is mirrored there) regardless of the caller.
+  // With no toast left, this line is the failure's only trace on the user's
+  // machine — guarantee it here rather than trusting each caller to log.
   console.error(`[toast:${command}] ${message}`);
 
-  if (isDuplicateToast(description, Date.now())) {
-    // Still worth the report (Sentry dedupes server-side); just not a second
-    // identical red toast within the window. The analytics event, though, tracks
-    // a SHOWN toast — so it fires only past the dedupe, else N concurrent calls
-    // failing on one root cause (HOU-687) would N-count a single problem.
-    const error = createSentryReportError(command, message, originalError);
-    if (!sentrySuppressedInDev) {
-      markReportedToSentry(originalError);
-      void sentryCapture(error, {
-        source: command,
-        error_kind: classifyAnalyticsError(message),
-      }).catch((flushErr: unknown) => {
-        console.error("[sentry] failed to flush captured error", flushErr);
-      });
-    }
-    return;
-  }
-
-  analytics.track("app_error_shown", {
-    source: command,
-    error_kind: classifyAnalyticsError(message),
-  });
-
-  addToast({
-    title: i18n.t("shell:errorToast.problemTitle"),
-    description,
-    variant: "error",
-  });
-
-  // Dev build with Sentry suppressed: don't capture (initSentry already bailed),
-  // and replace the green "report sent" toast with a dev-only notice so the
-  // developer knows the error stayed local and how to opt into sending.
-  if (sentrySuppressedInDev) {
-    setTimeout(() => {
-      addToast(devNoSendToastSpec());
-    }, GREEN_TOAST_DELAY_MS);
-    return;
-  }
-
-  markReportedToSentry(originalError);
-  const error = createSentryReportError(command, message, originalError);
-  void sentryCapture(error, {
-    source: command,
-    error_kind: classifyAnalyticsError(message),
-  })
-    .then((eventId) => {
-      if (!eventId) return;
-
-      const shortId = eventId.slice(0, 8);
-      setTimeout(() => {
-        addToast({
-          title: i18n.t("shell:errorToast.reportSentTitle"),
-          description: i18n.t("shell:errorToast.reportSentDescription", {
-            id: shortId,
-          }),
-          variant: "success",
-          action: {
-            label: i18n.t("shell:errorToast.copyId"),
-            onClick: () => {
-              void navigator.clipboard
-                .writeText(eventId)
-                .catch((copyErr: unknown) =>
-                  console.error("[sentry] copy event id failed", copyErr),
-                );
-            },
-          },
-        });
-      }, GREEN_TOAST_DELAY_MS);
-    })
-    .catch((flushErr: unknown) => {
-      console.error("[sentry] failed to flush captured error", flushErr);
+  // Burst key: the copy this failure WOULD have displayed. Analytics counts a
+  // problem, so one root cause failing N concurrent callers (HOU-687) must
+  // count once, while two distinct authored failures still count separately.
+  const surfacedAs =
+    options?.userMessage ?? i18n.t("shell:errorToast.genericDescription");
+  if (errorBurst.isFirst(surfacedAs, Date.now())) {
+    analytics.track("app_error_shown", {
+      source: command,
+      error_kind: classifyAnalyticsError(message),
     });
+  }
+
+  // Sentry keeps EVERY occurrence (it dedupes server-side, and the per-event
+  // context is what tells one user's outage from a fleet-wide one).
+  // Dev build with Sentry suppressed: initSentry already bailed, so don't.
+  if (sentrySuppressedInDev) return;
+  markReportedToSentry(originalError);
+  void sentryCapture(createSentryReportError(command, message, originalError), {
+    source: command,
+    error_kind: classifyAnalyticsError(message),
+  }).catch((flushErr: unknown) => {
+    console.error("[sentry] failed to flush captured error", flushErr);
+  });
 }
 
 export function raiseJavascriptSentrySmokeTest(): never {

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -59,11 +59,7 @@
     "nativeTriggeredDescription": "Check Sentry for sentry-native-stack-smoke-test."
   },
   "errorToast": {
-    "problemTitle": "Houston, we have a problem!",
     "genericDescription": "Something unexpected went wrong. Please try again.",
-    "reportSentTitle": "Houston, report sent",
-    "reportSentDescription": "Reference #{{id}}.",
-    "copyId": "Copy code",
     "offlineTitle": "Houston, connection lost",
     "offlineDescription": "We can't reach Houston right now. Check your internet connection and try again.",
     "engineWakingTitle": "Houston, your agent is waking up",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -59,11 +59,7 @@
     "nativeTriggeredDescription": "Revisa Sentry para sentry-native-stack-smoke-test."
   },
   "errorToast": {
-    "problemTitle": "Houston, tenemos un problema.",
     "genericDescription": "Algo inesperado salió mal. Inténtalo de nuevo.",
-    "reportSentTitle": "Houston, reporte enviado",
-    "reportSentDescription": "Referencia #{{id}}.",
-    "copyId": "Copiar código",
     "offlineTitle": "Houston, sin conexión",
     "offlineDescription": "No podemos conectarnos a Houston en este momento. Revisa tu conexión a internet e inténtalo de nuevo.",
     "engineWakingTitle": "Houston, tu agente se está despertando",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -59,11 +59,7 @@
     "nativeTriggeredDescription": "Confira o Sentry para sentry-native-stack-smoke-test."
   },
   "errorToast": {
-    "problemTitle": "Houston, temos um problema!",
     "genericDescription": "Algo inesperado deu errado. Tente novamente.",
-    "reportSentTitle": "Houston, relatório enviado",
-    "reportSentDescription": "Referência #{{id}}.",
-    "copyId": "Copiar código",
     "offlineTitle": "Houston, sem conexão",
     "offlineDescription": "Não conseguimos conectar ao Houston agora. Verifique sua conexão com a internet e tente novamente.",
     "engineWakingTitle": "Houston, seu agente está acordando",

--- a/app/tests/error-burst.test.ts
+++ b/app/tests/error-burst.test.ts
@@ -1,0 +1,62 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  createBurstGate,
+  TOAST_DEDUPE_WINDOW_MS,
+} from "../src/lib/error-burst.ts";
+
+// The surviving decision in the error path once HOU-1245 stopped rendering
+// toasts: one root cause failing N concurrent callers must be counted ONCE
+// (HOU-687), while genuinely distinct failures stay distinct. Analytics is now
+// one of only three signals left (log, PostHog, Sentry), so mis-counting here
+// directly distorts the error-rate dashboards.
+
+describe("createBurstGate", () => {
+  it("passes the first occurrence and swallows repeats in the window", () => {
+    const gate = createBurstGate();
+    strictEqual(gate.isFirst("boom", 0), true);
+    strictEqual(gate.isFirst("boom", 1), false);
+    strictEqual(gate.isFirst("boom", TOAST_DEDUPE_WINDOW_MS), false);
+  });
+
+  it("keeps distinct keys independent", () => {
+    const gate = createBurstGate();
+    strictEqual(gate.isFirst("a", 0), true);
+    strictEqual(gate.isFirst("b", 0), true);
+    strictEqual(gate.isFirst("a", 10), false);
+    strictEqual(gate.isFirst("b", 10), false);
+  });
+
+  it("passes again once the window has fully elapsed", () => {
+    const gate = createBurstGate();
+    strictEqual(gate.isFirst("boom", 0), true);
+    strictEqual(gate.isFirst("boom", TOAST_DEDUPE_WINDOW_MS + 1), true);
+  });
+
+  it("a repeat refreshes the window, so a failure loop stays collapsed", () => {
+    const gate = createBurstGate(1_000);
+    strictEqual(gate.isFirst("boom", 0), true);
+    // Every 600ms: never a full quiet window, so it must never re-fire.
+    for (let t = 600; t <= 6_000; t += 600) {
+      strictEqual(gate.isFirst("boom", t), false, `re-fired at ${t}ms`);
+    }
+  });
+
+  it("evicts stale keys instead of growing without bound", () => {
+    const gate = createBurstGate(1_000);
+    for (let i = 0; i < 500; i += 1) gate.isFirst(`key-${i}`, i);
+    // Long after the window, every one of them reads as first again — the map
+    // dropped them rather than holding 500 entries for the session.
+    strictEqual(gate.isFirst("key-0", 10_000), true);
+    strictEqual(gate.isFirst("key-499", 10_000), true);
+  });
+
+  it("honors a custom window", () => {
+    const gate = createBurstGate(100);
+    strictEqual(gate.isFirst("boom", 0), true);
+    strictEqual(gate.isFirst("boom", 100), false);
+    // That repeat reset the clock, so the next quiet window runs from t=100.
+    strictEqual(gate.isFirst("boom", 200), false);
+    strictEqual(gate.isFirst("boom", 301), true);
+  });
+});

--- a/app/tests/error-toast-not-shown.test.ts
+++ b/app/tests/error-toast-not-shown.test.ts
@@ -1,0 +1,70 @@
+import { ok } from "node:assert";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+// HOU-1245: `showErrorToast` reports an unexpected error but shows the user
+// NOTHING — the red "Houston, we have a problem!" box and the green "report
+// sent / Copy code" follow-up are both gone. Every reporting path stays.
+//
+// Asserted against the source rather than by calling the function: `error-toast`
+// pulls the `@houston-ai/engine-client` barrel and the Zustand store, neither of
+// which loads under this suite's `--experimental-strip-types` runner. The
+// invariant is worth a structural guard anyway — re-adding an `addToast` here is
+// a one-line change that no other test in the repo would catch.
+
+const SOURCE = readFileSync(
+  join(import.meta.dirname, "../src/lib/error-toast.ts"),
+  "utf8",
+);
+
+/** The text of one exported function, from its signature to the next export. */
+function bodyOf(name: string): string {
+  const start = SOURCE.indexOf(`export function ${name}(`);
+  ok(start !== -1, `${name} not found in error-toast.ts`);
+  const rest = SOURCE.slice(start + 1);
+  const end = rest.indexOf("\nexport ");
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+describe("showErrorToast shows the user nothing", () => {
+  const body = bodyOf("showErrorToast");
+
+  it("adds no toast of any kind", () => {
+    ok(!body.includes("addToast"), "showErrorToast must not add a toast");
+  });
+
+  it("does not resurrect the red or green toast copy", () => {
+    for (const key of [
+      "problemTitle",
+      "reportSentTitle",
+      "reportSentDescription",
+      "copyId",
+    ]) {
+      ok(!body.includes(key), `errorToast.${key} is retired copy`);
+    }
+  });
+
+  it("still reports to Sentry, PostHog, and the frontend log", () => {
+    ok(body.includes("sentryCapture"), "Sentry capture must survive");
+    ok(
+      body.includes('analytics.track("app_error_shown"'),
+      "PostHog must survive",
+    );
+    ok(body.includes("console.error"), "frontend log must survive");
+  });
+});
+
+describe("the informational toasts are untouched", () => {
+  // These are expected, explainable states with authored copy — NOT the generic
+  // bug pair — and they must keep reaching the user.
+  for (const name of [
+    "showExpectedStateToast",
+    "showConnectivityErrorToast",
+    "showEngineWakingToast",
+  ]) {
+    it(`${name} still shows a toast`, () => {
+      ok(bodyOf(name).includes("addToast"), `${name} must still toast`);
+    });
+  }
+});

--- a/packages/web/e2e/board.spec.ts
+++ b/packages/web/e2e/board.spec.ts
@@ -459,11 +459,16 @@ test("keeps the healthy agents' missions when one agent's reads fail", async ({
 
   await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible();
   await expect(page.getByText("Draft the launch email")).toBeVisible();
-  // Partial is not silent: the user is told the board is incomplete (beta
-  // no-silent-failures policy), rather than quietly missing an agent.
+  // HOU-1245 retired the generic error-toast pair, and this notice rode it: an
+  // incomplete sweep now recovers QUIETLY. The recovery itself is unchanged and
+  // still covered — `stepSweepRecovery` schedules the bounded re-sweep, unit
+  // tested in app/tests/all-conversations-recovery.test.ts — and the sweep's
+  // Sentry capture plus `app_error_shown` event are untouched, so WE still see
+  // it even though the user no longer does. What this asserts is only that the
+  // healthy agents' missions never depended on the toast.
   await expect(
     page.getByText("Some missions could not load. We are trying again."),
-  ).toBeVisible();
+  ).toHaveCount(0);
 });
 
 /**


### PR DESCRIPTION
Closes HOU-1245 (PRODUCT-1245).

## What was happening

Every unexpected failure routed through `showErrorToast` rendered a **pair** of toasts:

1. the red branded **"Houston, we have a problem!"** box with generic copy, and
2. ~700ms later a green **"Houston, report sent — Reference #a1b2c3d4"** follow-up with a *Copy code* action.

Both are now gone. A generic red box a non-technical user cannot act on, followed by a Sentry event id that means nothing to them, cost more in alarm than it bought in information — and in production this fires constantly for states that self-heal (a cold-starting pod, a partial mission sweep, a 401 mid session-refresh).

## What changed

`showErrorToast` is now **report-only**: it logs, counts, and captures, but shows the user nothing.

**Deliberately NOT touched** — this is scoped to the generic bug pair only:

- the ~85 curated `variant: "error"` toasts at their own call sites (name already taken, no microphone, import validation…). Those are actionable, authored, localized copy and still toast exactly as before.
- `showConnectivityErrorToast`, `showEngineWakingToast`, `showExpectedStateToast` — expected, explainable states with their own copy.

### On the no-silent-failures policy

`CLAUDE.md` makes "every error a user-initiated action can produce MUST reach the user as a visible toast" a hard rule. **This PR is a deliberate, product-owner-directed exception to it.** Worth stating plainly: silent to the **user**, never silent to **us**. Every reporting path is untouched, so a failure still reaches

- the **frontend log**, via `console.error("[toast:<command>] …")` — mirrored to the log file and bundled into a Report-bug submission;
- **PostHog**, via `app_error_shown` (event name deliberately kept even though nothing is shown now, so existing error-rate dashboards stay continuous);
- **Sentry**, via `captureException` tagged with `command`.

The trade-off to accept knowingly: we lose the user-reported half of bug reports, which makes those three signals the whole story. Sentry/PostHog error rates are now the only way we learn a release broke something.

### Incidental cleanup

- Extracted the burst gate that collapses one root cause's N concurrent failures into a single counted event (HOU-687) into `app/src/lib/error-burst.ts`. It is the only real decision left in the path, and `error-toast.ts` can't be imported by the app's `--experimental-strip-types` test runner (workspace barrel + Zustand store), so this makes it unit-testable. Behavior is preserved exactly, including the window-refresh semantics that keep a sustained failure loop collapsed.
- That split takes `error-toast.ts` from **245 → 172 lines**, back under the repo's 200-line limit it was already violating.
- Retired the four now-dead locale keys (`problemTitle`, `reportSentTitle`, `reportSentDescription`, `copyId`) across en/es/pt.

## Verification

**Before the fix** (on `main`):

1. `pnpm dev`, open the desktop app.
2. Trigger any unexpected failure — easiest is `Ctrl+Alt+Shift+J` (the JS Sentry smoke trigger), or kill the `host` pane so live queries fail.
3. Observe the red "Houston, we have a problem!" toast, followed ~700ms later by the green "report sent"/dev-mode notice.

**After the fix** (this branch), same steps:

- No toast appears at all.
- `[toast:uncaught_error] …` still lands in the frontend log (`~/.dev-houston/logs/frontend.log`).
- Sentry still receives the event (set `SENTRY_SEND_IN_DEV=1` to confirm locally), and PostHog still receives `app_error_shown`.
- A curated toast still shows: try saving an agent with an empty name, or dictation with no microphone.

**Automated:**

```
cd app && pnpm test          # 2726 pass (incl. 2 new suites)
cd app && pnpm tsgo --noEmit
cd app && pnpm check-locales
pnpm check                   # Biome clean
pnpm check:boundaries
```

New coverage: `app/tests/error-burst.test.ts` (the burst-collapse decision) and `app/tests/error-toast-not-shown.test.ts` (structural guard that `showErrorToast` adds no toast and keeps all three reporting paths, while the informational toasts still fire).

## Collateral worth reviewing

12 call sites passed **authored, localized copy** as `userMessage`, which rendered as the red toast's body. That copy no longer reaches the user either — it survives only as the burst key. Reviewers should sanity-check this list is acceptable:

`agent-provisioning` (still starting) · `files-upload-intake` (folder drop failed) · `store-browse` / `store-detail-pane` / `creator-profile-pane` (load failed) · `feedback-dialog` · `use-integrations-gate` (sign-in failed) · `all-conversations-sweep` (partial mission load) · `warming-sends` + `create-mission-warming` (mission row failed) · `agent-setup-mission` (start failed)

The most user-visible of these was the partial-sweep notice — "Some missions could not load. We are trying again." — which is also the **#1 error toast in production by affected users** (`HOUSTON-APP-538`, 183 users / 7d). `packages/web/e2e/board.spec.ts` asserted it was visible; that assertion is flipped in the second commit. The recovery it announced is unchanged: `stepSweepRecovery` still schedules the bounded re-sweep (unit tested), and the sweep still reports to Sentry + PostHog.

If any one of those should keep talking to the user, the fix is to route it to `showExpectedStateToast` (informational, no bug framing) rather than to revert this.
