### PR TITLE
fix(website): download gate country menus stay open and on screen (PRODUCT-1240)

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -75,6 +75,10 @@ jobs:
         working-directory: website
         run: npm ci
 
+      - name: Unit tests
+        working-directory: website
+        run: npm test
+
       # env.js falls back to an empty posthogKey and base.njk then silently
       # omits the whole PostHog snippet, so a missing secret would ship a site
       # with no analytics and a green build. Fail loudly instead.

--- a/website/package.json
+++ b/website/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "npx @11ty/eleventy",
     "check:locales": "node scripts/check-locales.mjs",
+    "test": "node --test \"test/*.test.mjs\"",
     "dev": "npx @11ty/eleventy --serve",
     "deploy": "npm run build && npx --yes firebase-tools@15 deploy --only hosting:gethouston-site --project gethouston --non-interactive"
   },

--- a/website/src/_includes/landing/scripts-download.njk
+++ b/website/src/_includes/landing/scripts-download.njk
@@ -8,6 +8,8 @@
   };
 </script>
 <script defer src="/assets/download-gate-countries.js"></script>
+<script defer src="/assets/download-gate-placement.js"></script>
+<script defer src="/assets/download-gate-anchor.js"></script>
 <script defer src="/assets/download-gate-dropdown.js"></script>
 <script defer src="/assets/download-gate-form.js"></script>
 <script defer src="/assets/download-gate.js"></script>

--- a/website/src/assets/css/dl-dropdown.css
+++ b/website/src/assets/css/dl-dropdown.css
@@ -90,8 +90,14 @@
   outline: none;
   box-shadow: none;
 }
+/* The list absorbs whatever height is left after the search row. min-height:0
+   lets it shrink past its content so the max-height download-gate-dropdown.js
+   measures against the visual viewport actually takes effect — otherwise a menu
+   opened with a phone keyboard up keeps its full height and its last rows sit
+   under the keyboard, unreachable. */
 .dl-dd-list {
-  max-height: 300px;
+  flex: 1 1 auto;
+  min-height: 0;
   margin: 0;
   padding: 6px;
   overflow-y: auto;

--- a/website/src/assets/download-gate-anchor.js
+++ b/website/src/assets/download-gate-anchor.js
@@ -1,0 +1,92 @@
+// Keeps a fixed-position menu pinned to its toggle for as long as it is open.
+//
+// The rule this module exists to enforce: an anchor that moved is a menu that
+// must be re-placed, never a menu that must be closed. The download gate used
+// to close on resize and on any scroll it did not recognise, which is what made
+// both country menus disappear mid-pick — open() focuses the search box, the
+// phone keyboard slides in, and the resize/scroll that follows killed the menu
+// the user was still reading.
+(() => {
+  // On mobile the software keyboard shrinks the *visual* viewport while the
+  // layout viewport (what window.innerHeight reports) stays put. Measuring
+  // against innerHeight is what drops the menu behind the keyboard.
+  function viewportBox() {
+    var vv = window.visualViewport;
+    if (!vv) {
+      return {
+        top: 0,
+        left: 0,
+        width: window.innerWidth,
+        height: window.innerHeight,
+      };
+    }
+    return {
+      top: vv.offsetTop,
+      left: vv.offsetLeft,
+      width: vv.width,
+      height: vv.height,
+    };
+  }
+
+  function create(opts) {
+    var toggle = opts.toggle;
+    var menu = opts.menu;
+    var queued = false;
+
+    function position() {
+      var placement = window.HoustonDropdownPlacement;
+      var anchor = toggle.getBoundingClientRect();
+      var view = viewportBox();
+      // Size first so the measured height reflects the clamp, then place.
+      var box = placement.fit(anchor, view, opts.menuWidth);
+      menu.style.width = `${box.width}px`;
+      menu.style.maxHeight = `${box.maxHeight}px`;
+      var spot = placement.place(
+        anchor,
+        view,
+        opts.menuWidth,
+        menu.offsetHeight,
+      );
+      menu.style.top = `${spot.top}px`;
+      menu.style.left = `${spot.left}px`;
+    }
+
+    function sync() {
+      if (queued) return;
+      queued = true;
+      window.requestAnimationFrame(() => {
+        queued = false;
+        if (!opts.isOpen()) return;
+        var anchor = toggle.getBoundingClientRect();
+        // The toggle is gone (modal closed, step swapped): nothing to pin to.
+        if (!anchor.width && !anchor.height) {
+          opts.onDetached();
+          return;
+        }
+        position();
+      });
+    }
+
+    // A scroll inside the menu moves the list, not the anchor.
+    function onScroll(event) {
+      var target = event.target;
+      var node = target && target.nodeType === 1 ? target : null;
+      if (node && menu.contains(node)) return;
+      sync();
+    }
+
+    function bind(add) {
+      var method = add ? "addEventListener" : "removeEventListener";
+      window[method]("scroll", onScroll, true);
+      window[method]("resize", sync);
+      if (window.visualViewport) {
+        window.visualViewport[method]("resize", sync);
+        window.visualViewport[method]("scroll", sync);
+      }
+    }
+
+    return { position: position, sync: sync, bind: bind };
+  }
+
+  window.HoustonDropdownAnchor = { create: create };
+})();

--- a/website/src/assets/download-gate-dropdown.js
+++ b/website/src/assets/download-gate-dropdown.js
@@ -59,7 +59,6 @@
     var selectedId = null;
     var activeIndex = -1;
     var opened = false;
-    var queued = false;
     var typed = "";
     var typedAt = 0;
 
@@ -127,41 +126,17 @@
       setActive(shown.length ? 0 : -1, false);
     }
 
-    function position() {
-      var rect = toggle.getBoundingClientRect();
-      var width = opts.menuWidth || Math.max(Math.round(rect.width), 260);
-      menu.style.width = `${width}px`;
-      var height = menu.offsetHeight;
-      var top = rect.bottom + 6;
-      if (top + height > window.innerHeight - 8) {
-        const above = rect.top - 6 - height;
-        top = above >= 8 ? above : Math.max(8, window.innerHeight - 8 - height);
-      }
-      var maxLeft = window.innerWidth - width - 8;
-      menu.style.top = `${top}px`;
-      menu.style.left = `${Math.max(8, Math.min(rect.left, maxLeft))}px`;
-    }
+    // Follows the toggle instead of closing when the viewport moves.
+    var anchor = window.HoustonDropdownAnchor.create({
+      toggle: toggle,
+      menu: menu,
+      menuWidth: opts.menuWidth,
+      isOpen: () => opened,
+      onDetached: () => close(),
+    });
 
     function onDocumentClick(event) {
       if (!root.contains(event.target)) close();
-    }
-
-    // A scroll inside the menu is the menu's own; a scroll of the modal card
-    // only moves the anchor, so reposition instead of closing.
-    function onScroll(event) {
-      var target = event.target;
-      var node = target && target.nodeType === 1 ? target : null;
-      if (node && menu.contains(node)) return;
-      if (node?.closest?.(".dl-card")) {
-        if (queued) return;
-        queued = true;
-        window.requestAnimationFrame(() => {
-          queued = false;
-          if (opened) position();
-        });
-        return;
-      }
-      close();
     }
 
     function open() {
@@ -174,11 +149,14 @@
         search.setAttribute("aria-expanded", "true");
       }
       render();
-      position();
-      focusTarget().focus();
+      anchor.position();
+      // preventScroll keeps iOS from scrolling the document to reveal the
+      // search box, which would immediately drag the anchor out from under us.
+      focusTarget().focus({ preventScroll: true });
       document.addEventListener("click", onDocumentClick);
-      window.addEventListener("scroll", onScroll, true);
-      window.addEventListener("resize", close);
+      anchor.bind(true);
+      // The keyboard animates in after focus; re-place once it has settled.
+      anchor.sync();
     }
 
     function close() {
@@ -190,8 +168,7 @@
       if (search) search.setAttribute("aria-expanded", "false");
       focusTarget().removeAttribute("aria-activedescendant");
       document.removeEventListener("click", onDocumentClick);
-      window.removeEventListener("scroll", onScroll, true);
-      window.removeEventListener("resize", close);
+      anchor.bind(false);
     }
 
     // fromUi selections dismiss the menu and hand focus back to the toggle;
@@ -252,7 +229,7 @@
     if (search) {
       search.addEventListener("input", () => {
         render();
-        position();
+        anchor.position();
       });
     }
     root.addEventListener("keydown", (event) => {

--- a/website/src/assets/download-gate-placement.js
+++ b/website/src/assets/download-gate-placement.js
@@ -1,0 +1,74 @@
+// Placement math for the download gate's fixed-position dropdown menus.
+// Split out of download-gate-dropdown.js so it stays pure (numbers in, numbers
+// out) and can be unit-tested without a DOM — see test/placement.test.mjs.
+//
+// Coordinates are layout-viewport pixels, the space `position: fixed` and
+// getBoundingClientRect() both speak. On mobile the *visual* viewport is the
+// part the user can actually see (the software keyboard covers the rest), so
+// callers pass it in and the menu is clamped to it. Without that clamp the
+// menu is happily positioned underneath the keyboard and the country the user
+// wants is unreachable.
+(() => {
+  var GUTTER = 8; // breathing room against the viewport edges
+  var OFFSET = 6; // gap between the toggle and the menu
+  var MIN_HEIGHT = 132; // never squash below ~3 rows; overlap the anchor first
+  var MAX_HEIGHT = 360; // matches .dl-dd-menu's CSS ceiling
+
+  function clamp(value, min, max) {
+    // A viewport smaller than the menu can invert the bounds; min wins.
+    return max < min ? min : Math.min(Math.max(value, min), max);
+  }
+
+  // anchor: the toggle's bounding rect ({top, bottom, left, width}).
+  // view:   the visual viewport ({top, left, width, height}), where top/left
+  //         are its offset inside the layout viewport.
+  // Returns the width/max-height to apply before measuring, then place() is
+  // called again with the measured height to get the final top/left.
+  function fit(anchor, view, preferredWidth) {
+    var width = Math.min(
+      preferredWidth || Math.max(Math.round(anchor.width), 260),
+      Math.max(120, view.width - GUTTER * 2),
+    );
+    var viewTop = view.top + GUTTER;
+    var viewBottom = view.top + view.height - GUTTER;
+    var below = viewBottom - (anchor.bottom + OFFSET);
+    var above = anchor.top - OFFSET - viewTop;
+    // Flip up only when below cannot hold a usable menu and above is roomier.
+    var placeAbove = below < MIN_HEIGHT && above > below;
+    var room = Math.max(placeAbove ? above : below, MIN_HEIGHT);
+    return {
+      width: Math.round(width),
+      maxHeight: Math.round(Math.min(room, MAX_HEIGHT)),
+      placeAbove: placeAbove,
+    };
+  }
+
+  function place(anchor, view, preferredWidth, measuredHeight) {
+    var box = fit(anchor, view, preferredWidth);
+    var height = Math.min(measuredHeight, box.maxHeight);
+    var viewTop = view.top + GUTTER;
+    var viewBottom = view.top + view.height - GUTTER;
+    var top = box.placeAbove
+      ? anchor.top - OFFSET - height
+      : anchor.bottom + OFFSET;
+    var left = anchor.left;
+    return {
+      width: box.width,
+      maxHeight: box.maxHeight,
+      placeAbove: box.placeAbove,
+      top: Math.round(clamp(top, viewTop, viewBottom - height)),
+      left: Math.round(
+        clamp(
+          left,
+          view.left + GUTTER,
+          view.left + view.width - box.width - GUTTER,
+        ),
+      ),
+    };
+  }
+
+  var api = { fit: fit, place: place, MIN_HEIGHT: MIN_HEIGHT };
+  if (typeof window !== "undefined") window.HoustonDropdownPlacement = api;
+  if (typeof globalThis !== "undefined")
+    globalThis.HoustonDropdownPlacement = api;
+})();

--- a/website/src/assets/download-gate.js
+++ b/website/src/assets/download-gate.js
@@ -181,7 +181,13 @@
     });
   });
   overlay.addEventListener("click", (event) => {
-    if (event.target === overlay) closeModal();
+    if (event.target !== overlay) return;
+    // The dropdown menus are fixed-positioned, so they can hang over the
+    // backdrop. A near-miss on a country row must not throw away the whole
+    // filled-in form: with a menu open the backdrop only dismisses the menu
+    // (the dropdown's own outside-click handler does that), same as Escape.
+    if (document.querySelector(".dl-dd.open")) return;
+    closeModal();
   });
   closeButton.addEventListener("click", closeModal);
   document.addEventListener("keydown", (event) => {

--- a/website/test/placement.test.mjs
+++ b/website/test/placement.test.mjs
@@ -1,0 +1,111 @@
+// Placement math for the download gate's country / country-code dropdowns.
+// The asset is a browser IIFE that hangs its API off `window`, so it is read
+// and evaluated with a stub window rather than imported.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(
+  join(here, "..", "src", "assets", "download-gate-placement.js"),
+  "utf8",
+);
+const stub = {};
+new Function("window", source)(stub);
+const { fit, place, MIN_HEIGHT } = stub.HoustonDropdownPlacement;
+
+const GUTTER = 8;
+const OFFSET = 6;
+const MENU = 353; // what the 200-row menu measures at its CSS ceiling
+
+/** A toggle rect as getBoundingClientRect() would report it. */
+function anchor(top, { height = 44, left = 30, width = 330 } = {}) {
+  return { top, bottom: top + height, left, width };
+}
+
+/** A visual viewport; `top` is its offset inside the layout viewport. */
+function view(width, height, { top = 0, left = 0 } = {}) {
+  return { top, left, width, height };
+}
+
+test("opens below the toggle when there is room", () => {
+  const spot = place(anchor(200), view(1280, 800), 0, MENU);
+  assert.equal(spot.placeAbove, false);
+  assert.equal(spot.top, 200 + 44 + OFFSET);
+  assert.equal(spot.left, 30);
+});
+
+test("flips above when the space below cannot hold a usable menu", () => {
+  const spot = place(anchor(600), view(1280, 700), 0, MENU);
+  assert.equal(spot.placeAbove, true);
+  assert.equal(spot.top + Math.min(MENU, spot.maxHeight) <= 600 - OFFSET, true);
+});
+
+test("never places the menu outside the visual viewport", () => {
+  for (const [w, h] of [
+    [1280, 800],
+    [390, 844],
+    [390, 400],
+    [320, 480],
+    [740, 360],
+  ]) {
+    for (const top of [0, 100, 250, h - 60]) {
+      const spot = place(anchor(top), view(w, h), 0, MENU);
+      const height = Math.min(MENU, spot.maxHeight);
+      assert.ok(spot.top >= GUTTER, `top ${spot.top} at ${w}x${h}/${top}`);
+      assert.ok(
+        spot.top + height <= h - GUTTER,
+        `bottom ${spot.top + height} > ${h - GUTTER} at ${w}x${h}/${top}`,
+      );
+      assert.ok(spot.left >= GUTTER, `left ${spot.left} at ${w}x${h}/${top}`);
+      assert.ok(
+        spot.left + spot.width <= w - GUTTER,
+        `right overflow at ${w}x${h}/${top}`,
+      );
+    }
+  }
+});
+
+// The regression PRODUCT-1240 was reported for: the software keyboard covers
+// the bottom half of the screen, so the layout viewport still says 844px tall
+// while only the top ~340px is visible. Measuring against the layout viewport
+// put the menu under the keyboard and the country was unreachable.
+test("keeps the menu above a software keyboard", () => {
+  const keyboardView = view(390, 336);
+  const spot = place(anchor(240), keyboardView, 0, MENU);
+  const height = Math.min(MENU, spot.maxHeight);
+  assert.ok(
+    spot.top + height <= 336 - GUTTER,
+    `menu bottom ${spot.top + height} falls under the keyboard`,
+  );
+  assert.ok(spot.maxHeight >= MIN_HEIGHT, "menu squashed below a usable size");
+});
+
+test("respects a visual viewport offset from pinch-zoom scrolling", () => {
+  const spot = place(
+    anchor(300),
+    view(390, 300, { top: 120, left: 40 }),
+    0,
+    MENU,
+  );
+  const height = Math.min(MENU, spot.maxHeight);
+  assert.ok(spot.top >= 120 + GUTTER, `top ${spot.top} above the visual box`);
+  assert.ok(spot.top + height <= 120 + 300 - GUTTER, "bottom past visual box");
+  assert.ok(spot.left >= 40 + GUTTER, `left ${spot.left} left of visual box`);
+});
+
+test("honours an explicit menu width but keeps it on screen", () => {
+  assert.equal(fit(anchor(100), view(1280, 800), 290).width, 290);
+  const narrow = fit(anchor(100), view(320, 640), 290);
+  assert.ok(
+    narrow.width <= 320 - GUTTER * 2,
+    `width ${narrow.width} overflows`,
+  );
+});
+
+test("falls back to the toggle width, floored at 260", () => {
+  assert.equal(fit(anchor(100, { width: 330 }), view(1280, 800), 0).width, 330);
+  assert.equal(fit(anchor(100, { width: 120 }), view(1280, 800), 0).width, 260);
+});


### PR DESCRIPTION
Fixes **PRODUCT-1240** — "Change country is not working on the form for downloading the app".

Both menus in the download gate (the phone country code and the country list) would close on their own mid-pick, or open somewhere the user could not reach.

## Root cause

Two independent halves, both in `download-gate-dropdown.js`.

**1. Viewport movement was treated as a dismissal.**

```js
window.addEventListener("resize", close);   // ← literally bound to close
```

and the scroll handler fell through to `close()` for anything it did not recognise as "inside the menu" or "the modal card" — including a `scroll` whose target is the `document`.

`open()` focuses the search input, which on a phone summons the software keyboard. The `resize` / `scroll` that follows killed the menu roughly a frame after it appeared. On iOS the browser also scrolls the document to reveal a focused input, which hit the same path. Desktop was not immune: window resize, browser zoom, and any other scroll container on the page all closed the menu.

**2. Placement measured against the wrong viewport.**

`position()` used `window.innerHeight`. A software keyboard shrinks the **visual** viewport and leaves the **layout** viewport alone, so the menu was positioned under the keyboard — visible to the code, invisible to the user — and its height was never clamped to the space actually available, so the lower rows had nowhere to go. That is the "cannot select a country" half of the report.

## The fix

An anchor that moved is a menu that must be **re-placed**, never a menu that must be **closed**.

- Card scroll, page scroll, resize, keyboard show/hide and pinch-zoom now all reposition on a `requestAnimationFrame`. The menu closes only when the toggle itself is gone (modal closed, step swapped) or on the normal outside-click / Escape / selection paths.
- Placement measures against `window.visualViewport` when present, picks whichever side of the toggle has more room, and clamps `max-height` so the list is always fully on screen and scrollable. `.dl-dd-list` got `flex: 1 1 auto; min-height: 0` so that clamp actually takes effect.
- `focus({ preventScroll: true })` on open, so iOS does not yank the anchor out from under the menu it just opened.

**Also fixed, same family:** with a menu open, a click on the modal backdrop now dismisses only the menu instead of closing the gate and discarding the filled-in form. This mirrors the Escape-key behaviour that was already there, and it matters because the menus are fixed-positioned and can hang over the backdrop — a near-miss on a country row used to lose everything typed.

## Structure

The two pieces I rewrote are now their own modules, which also brings `download-gate-dropdown.js` from 296 down to 273 lines:

- `download-gate-placement.js` — pure placement math, numbers in / numbers out, no DOM.
- `download-gate-anchor.js` — the pin-to-anchor lifecycle (measure the visual viewport, reposition, bind/unbind).

## Tests

`website/` had no test runner; it now has `npm test` (`node --test`), wired into the deploy workflow so it actually gates. 7 unit tests cover the placement math, including the exact regression:

```
✔ opens below the toggle when there is room
✔ flips above when the space below cannot hold a usable menu
✔ never places the menu outside the visual viewport   (5 viewport sizes × 4 anchor positions)
✔ keeps the menu above a software keyboard
✔ respects a visual viewport offset from pinch-zoom scrolling
✔ honours an explicit menu width but keeps it on screen
✔ falls back to the toggle width, floored at 260
```

## Verification

Run the site locally:

```bash
cd website && npm install && npx @11ty/eleventy --serve
open http://localhost:8080/#download
```

**Before the fix** (reproduces on `main`), with the gate open:

1. Open the Country menu, then resize the browser window even one pixel — the menu closes instantly.
2. Open the Country menu and run `document.dispatchEvent(new Event('scroll'))` in the console — the menu closes.
3. On a phone (or DevTools device emulation with the keyboard simulated), tap the Country field — the menu opens, the keyboard slides in, and the menu disappears before you can pick anything. When it does survive, its lower rows sit under the keyboard.

**After the fix**, the same three steps: the menu stays open and re-anchors to the field; on a short/keyboard viewport it is clamped above the keyboard and the whole 200-country list stays scrollable.

Regression pass done in a real browser on both menus: open, filter, arrow-key navigation, Enter and click selection, Escape, outside click, and the backdrop guard — plus `resize`, document `scroll`, and `visualViewport` `resize` no longer closing either menu.

Gates: `npm test`, `npx @11ty/eleventy` build, `npm run check:locales`, and Biome all clean.
