### PR TITLE
fix(app): only the workspace owner can delete a workspace (PRODUCT-1247)

### DIFF
--- a/app/src/components/settings/sections/danger.tsx
+++ b/app/src/components/settings/sections/danger.tsx
@@ -2,12 +2,15 @@ import { Button, ConfirmDialog } from "@houston-ai/core";
 import { Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useCapabilities } from "../../../hooks/use-capabilities";
+import { canDeleteWorkspace } from "../../../lib/org-roles";
 import { useAgentStore } from "../../../stores/agents";
 import { useWorkspaceStore } from "../../../stores/workspaces";
 import { SettingsControlRow } from "../settings-row";
 
 export function DangerSection() {
   const { t } = useTranslation("settings");
+  const { capabilities } = useCapabilities();
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const currentWorkspace = useWorkspaceStore((s) => s.current);
   const setCurrentWorkspace = useWorkspaceStore((s) => s.setCurrent);
@@ -16,6 +19,9 @@ export function DangerSection() {
   const [showConfirm, setShowConfirm] = useState(false);
 
   if (!currentWorkspace) return null;
+  // Owner-only (PRODUCT-1247): capabilities carry the caller's role for the
+  // ACTIVE space, which is exactly the workspace this section deletes.
+  if (!canDeleteWorkspace(capabilities)) return null;
 
   const isOnlyWorkspace = workspaces.length <= 1;
 

--- a/app/src/lib/org-roles.ts
+++ b/app/src/lib/org-roles.ts
@@ -126,6 +126,20 @@ export function canSeeBillingTab(
 }
 
 /**
+ * Can this caller DELETE the active workspace? Owner only (PRODUCT-1247) — an
+ * admin ("Manager" in the Teams UI) may run the space day-to-day but must not
+ * be able to destroy it, and a plain member never could. Single-player (null
+ * role) is always allowed: the sole user owns every local workspace, mirroring
+ * `canCreateAgents`. A cosmetic gate: the gateway is the real enforcer.
+ */
+export function canDeleteWorkspace(
+  caps: Capabilities | null | undefined,
+): boolean {
+  const role = orgRole(caps);
+  return role === null || role === "owner";
+}
+
+/**
  * The roles an owner may GRANT when adding or re-roling a member. Owner is the
  * single billing seat and is never handed out from the UI (ownership transfer
  * is out of scope for v1).

--- a/app/tests/org-roles.test.ts
+++ b/app/tests/org-roles.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import type { Capabilities, OrgRole } from "@houston-ai/engine-client";
 import {
   canCreateAgents,
+  canDeleteWorkspace,
   canManageMembers,
   canSeeAiModelsPage,
   canSeeBilling,
@@ -139,6 +140,23 @@ describe("canSeeBillingTab (C8)", () => {
     strictEqual(canSeeBillingTab(multiplayer("owner"), true), false); // no spaces flag
     strictEqual(canSeeBillingTab(caps(), true), false);
     strictEqual(canSeeBillingTab(null, true), false);
+  });
+});
+
+describe("canDeleteWorkspace (PRODUCT-1247)", () => {
+  it("single-player always allowed — the sole user owns every workspace", () => {
+    strictEqual(canDeleteWorkspace(caps()), true);
+    strictEqual(canDeleteWorkspace(null), true);
+  });
+
+  it("multiplayer: owner only — admin ('Manager' in the UI) and user cannot", () => {
+    strictEqual(canDeleteWorkspace(multiplayer("owner")), true);
+    strictEqual(canDeleteWorkspace(multiplayer("admin")), false);
+    strictEqual(canDeleteWorkspace(multiplayer("user")), false);
+  });
+
+  it("multiplayer without an explicit role denies (least privilege)", () => {
+    strictEqual(canDeleteWorkspace(caps({ multiplayer: true })), false);
   });
 });
 


### PR DESCRIPTION
Fixes PRODUCT-1247.

## Root cause

The settings Danger Zone (`app/src/components/settings/sections/danger.tsx`) rendered the **Delete workspace** action with no role gate at all. In a multiplayer team space, an org `admin` — displayed as **"Manager"** in the Teams UI (`app/src/locales/en/teams.json`) — and even a plain member saw the action and could trigger the delete. The role matrix (`app/src/lib/org-roles.ts`) had gates for agent creation, members, and billing, but none for workspace deletion.

## Fix

- Add `canDeleteWorkspace(caps)` to the role matrix: in multiplayer, **owner only**; single-player (no org, `null` role) stays allowed since the sole user owns every local workspace. Follows the matrix's least-privilege convention: a multiplayer host with a missing role field denies.
- `DangerSection` now hides itself when `canDeleteWorkspace(capabilities)` is false — capabilities carry the caller's role for the active space, which is exactly the workspace the section deletes.

Like the other matrix gates this is a cosmetic client gate (hides the affordance); the gateway remains the real enforcer. **Backend verified:** no server exposes a workspace DELETE endpoint at all — the gateway's `/v1/workspaces/{id}` accepts only PATCH (DELETE 404s) and this repo's host serves only GET/PATCH, while the cloud client adapter's `deleteWorkspace` is a no-op. So the bug was UI-only (the workspace vanished from the local list until reload); this client gate closes the only real hole. If a real team-deletion endpoint lands in the gateway later, it must enforce owner-only server-side.

## Before (reproduction)

1. In a team space, sign in as a member with the **Manager** (org `admin`) role.
2. Open **Settings** and scroll to the bottom card.
3. The **Delete workspace** row is visible and the button is enabled (when more than one workspace exists) — confirming the dialog deletes the workspace.

## After (verification)

1. Same Manager account, same team space: **Settings** no longer shows the **Delete workspace** row (plain members don't see it either).
2. As the space **owner**: the row is still there and works.
3. On single-player desktop/self-host: unchanged — the row shows and works for the sole user.
4. `cd app && pnpm test` — new `canDeleteWorkspace (PRODUCT-1247)` suite covers owner/admin/user/single-player/missing-role. Full run: 2720 pass, 0 fail. `pnpm check` and `pnpm tsgo --noEmit` clean.
