### PR TITLE
fix(app): stop Windows shortcut icons going blank after MSI updates (PRODUCT-1233)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,6 +2075,7 @@ name = "houston-app"
 version = "0.5.41"
 dependencies = [
  "arboard",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "dirs 5.0.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -114,6 +114,9 @@ notify-rust = "4.11"
 # file is useless to another user. See `src/auth.rs` storage module.
 [target."cfg(target_os = \"windows\")".dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Security_Cryptography", "Win32_System_JobObjects", "Win32_System_Threading", "Win32_UI_Shell"] }
+# PowerShell -EncodedCommand payload for the icon-repair pass
+# (src/windows_icon_repair.rs) — dodges Windows argv re-quoting.
+base64 = "0.22"
 # Same reason as notify-rust on Linux, but notify-rust's action handling is
 # XDG/D-Bus-only — on Windows we use the WinRT toast's `on_activated` callback
 # to catch the click. This is the crate notify-rust uses under the hood.

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ mod oauth_loopback;
 mod shell_env;
 mod store_deep_link;
 mod window_focus;
+mod windows_icon_repair;
 
 use engine_supervisor::{
     reserve_free_port, resolve_engine_binary, spawn_supervisor, wait_until_host_healthy,
@@ -323,6 +324,12 @@ pub fn run() {
                     );
                 }
             }
+
+            // MSI upgrades break taskbar-pin/desktop icons (PRODUCT-1233);
+            // once per installed version, repair stale shortcut icons and
+            // refresh the shell icon cache on a background thread.
+            #[cfg(target_os = "windows")]
+            windows_icon_repair::spawn_repair(app.package_info().version.to_string());
             {
                 use tauri_plugin_deep_link::DeepLinkExt;
                 let handle = app.handle().clone();

--- a/app/src-tauri/src/windows_icon_repair.rs
+++ b/app/src-tauri/src/windows_icon_repair.rs
@@ -51,7 +51,8 @@ fn repair_script(exe_path: &str) -> String {
         r#"$exe = {exe}
 $dirs = @(
   (Join-Path $env:APPDATA 'Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar'),
-  [Environment]::GetFolderPath('Desktop')
+  [Environment]::GetFolderPath('Desktop'),
+  [Environment]::GetFolderPath('CommonDesktopDirectory')
 )
 $shell = New-Object -ComObject WScript.Shell
 $installerCache = Join-Path $env:windir 'Installer'
@@ -61,7 +62,10 @@ foreach ($dir in $dirs) {{
     try {{
       $lnk = $shell.CreateShortcut($file.FullName)
       if (-not $lnk.TargetPath -or ($lnk.TargetPath -ine $exe)) {{ continue }}
-      $icon = ($lnk.IconLocation -split ',')[0].Trim()
+      $raw = $lnk.IconLocation
+      $comma = $raw.LastIndexOf(',')
+      $icon = if ($comma -ge 0) {{ $raw.Substring(0, $comma) }} else {{ $raw }}
+      $icon = [Environment]::ExpandEnvironmentVariables($icon.Trim().Trim('"'))
       if (-not $icon -or ($icon -ieq $exe)) {{ continue }}
       $dead = -not (Test-Path -LiteralPath $icon)
       $cached = $icon.StartsWith($installerCache, [System.StringComparison]::OrdinalIgnoreCase)
@@ -184,11 +188,16 @@ mod tests {
     }
 
     #[test]
-    fn repair_script_embeds_exe_and_targets_pins_and_desktop() {
+    fn repair_script_embeds_exe_and_targets_pins_and_desktops() {
         let script = repair_script(r"C:\Program Files\Houston\Houston.exe");
         assert!(script.contains(r"$exe = 'C:\Program Files\Houston\Houston.exe'"));
         assert!(script.contains(r"User Pinned\TaskBar"));
+        // Both desktops: the per-machine MSI writes its shortcut to the
+        // PUBLIC desktop; user-copied shortcuts live on the user's.
         assert!(script.contains("GetFolderPath('Desktop')"));
+        assert!(script.contains("GetFolderPath('CommonDesktopDirectory')"));
+        // Icon path parsed from the LAST comma (paths may contain commas).
+        assert!(script.contains("LastIndexOf(',')"));
         // Only rewrites icons that are dead or in the installer icon cache.
         assert!(script.contains("$dead -or $cached"));
         // Never retargets the shortcut itself, only its icon.

--- a/app/src-tauri/src/windows_icon_repair.rs
+++ b/app/src-tauri/src/windows_icon_repair.rs
@@ -1,0 +1,198 @@
+//! Heal blank Houston icons on Windows (PRODUCT-1233).
+//!
+//! Every Houston release is a WiX MajorUpgrade: the MSI ProductCode changes
+//! and Windows deletes the old `C:\Windows\Installer\<ProductCode>\` folder —
+//! the exact folder the Start Menu shortcut's MSI icon used to live in. Any
+//! taskbar pin the user made from that shortcut keeps the dead icon path
+//! forever, so after a background update the pin degrades to the blank
+//! default icon. The vendored WiX template (`wix/main.wxs`) stops NEW
+//! shortcuts from referencing the installer icon cache; this module repairs
+//! installs pinned before the fix, and refreshes the shell icon cache to heal
+//! desktop icons that were blanked while the updater had `Houston.exe`
+//! removed mid-upgrade.
+//!
+//! Once per installed version (i.e. on the first launch after every update —
+//! the only moment breakage can occur), a background thread:
+//!   1. rewrites the icon location of any user `.lnk` (taskbar pins, desktop)
+//!      that targets this exe but points at a missing icon file or into
+//!      `C:\Windows\Installer\`, so it uses the exe's own embedded icon;
+//!   2. runs `ie4uinit.exe -show` to make Explorer re-resolve cached icons.
+//!
+//! Failures are logged (this is unprompted background repair, not a
+//! user-initiated action — same policy as the runtime deep-link
+//! registration in `lib.rs`).
+
+/// Marker file (under `houston_dir()`) recording the last app version that
+/// completed the repair pass, so the pass runs once per installed version.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+const MARKER_FILE: &str = ".windows-icon-repair-version";
+
+/// Whether the repair pass should run: only when the marker doesn't record
+/// the current version yet.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn should_run(marker: Option<&str>, current_version: &str) -> bool {
+    marker.map(str::trim) != Some(current_version.trim())
+}
+
+/// Escape a string for a single-quoted PowerShell literal.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn ps_single_quoted(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "''"))
+}
+
+/// Build the PowerShell repair script. Scans the user's taskbar-pin folder
+/// and desktop for `.lnk` files targeting `exe_path` whose icon reference is
+/// dead or lives in the per-ProductCode installer icon cache, and repoints
+/// them at the exe itself. Per-shortcut failures are swallowed so one odd
+/// `.lnk` can't abort the sweep; a top-level failure exits non-zero.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn repair_script(exe_path: &str) -> String {
+    format!(
+        r#"$exe = {exe}
+$dirs = @(
+  (Join-Path $env:APPDATA 'Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar'),
+  [Environment]::GetFolderPath('Desktop')
+)
+$shell = New-Object -ComObject WScript.Shell
+$installerCache = Join-Path $env:windir 'Installer'
+foreach ($dir in $dirs) {{
+  if (-not $dir -or -not (Test-Path -LiteralPath $dir)) {{ continue }}
+  foreach ($file in Get-ChildItem -LiteralPath $dir -Filter '*.lnk' -File -ErrorAction SilentlyContinue) {{
+    try {{
+      $lnk = $shell.CreateShortcut($file.FullName)
+      if (-not $lnk.TargetPath -or ($lnk.TargetPath -ine $exe)) {{ continue }}
+      $icon = ($lnk.IconLocation -split ',')[0].Trim()
+      if (-not $icon -or ($icon -ieq $exe)) {{ continue }}
+      $dead = -not (Test-Path -LiteralPath $icon)
+      $cached = $icon.StartsWith($installerCache, [System.StringComparison]::OrdinalIgnoreCase)
+      if ($dead -or $cached) {{
+        $lnk.IconLocation = "$exe,0"
+        $lnk.Save()
+      }}
+    }} catch {{}}
+  }}
+}}"#,
+        exe = ps_single_quoted(exe_path)
+    )
+}
+
+/// Spawn the once-per-version repair pass on a background thread.
+#[cfg(target_os = "windows")]
+pub fn spawn_repair(version: String) {
+    std::thread::spawn(move || {
+        let marker_path = crate::houston_dir().join(MARKER_FILE);
+        let marker = std::fs::read_to_string(&marker_path).ok();
+        if !should_run(marker.as_deref(), &version) {
+            return;
+        }
+        match run_repair() {
+            Ok(()) => {
+                tracing::info!("[icon-repair] shortcut icons repaired for v{version}");
+                // houston_dir() may not exist yet on a fresh install (the
+                // host creates it on boot, possibly after this thread runs).
+                let write = std::fs::create_dir_all(marker_path.parent().unwrap_or(&marker_path))
+                    .and_then(|()| std::fs::write(&marker_path, &version));
+                if let Err(e) = write {
+                    // Next launch retries the (idempotent) pass.
+                    tracing::warn!("[icon-repair] marker write failed: {e}");
+                }
+            }
+            Err(e) => tracing::warn!("[icon-repair] repair pass failed: {e}"),
+        }
+    });
+}
+
+/// Run the `.lnk` sweep, then refresh Explorer's icon cache.
+#[cfg(target_os = "windows")]
+fn run_repair() -> Result<(), String> {
+    use base64::Engine as _;
+    use std::os::windows::process::CommandExt;
+    use std::path::Path;
+
+    // Keep the spawned consoles invisible (PROCESS_CREATION_FLAGS value).
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    // System32-as-cwd breaks PowerShell child spawns (see shell_env notes);
+    // anchor both children at the install dir instead.
+    let cwd = exe
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| "exe has no parent dir".to_string())?;
+
+    // -EncodedCommand (base64 UTF-16LE) dodges Windows argv re-quoting.
+    let script = repair_script(&exe.to_string_lossy());
+    let utf16: Vec<u8> = script
+        .encode_utf16()
+        .flat_map(|unit| unit.to_le_bytes())
+        .collect();
+    let encoded = base64::engine::general_purpose::STANDARD.encode(utf16);
+
+    let sweep = std::process::Command::new("powershell.exe")
+        .args(["-NoProfile", "-NonInteractive", "-EncodedCommand", &encoded])
+        .current_dir(&cwd)
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .map_err(|e| format!("powershell spawn: {e}"))?;
+    if !sweep.status.success() {
+        return Err(format!(
+            "lnk sweep exited {}: {}",
+            sweep.status,
+            String::from_utf8_lossy(&sweep.stderr)
+        ));
+    }
+
+    // `-show` re-resolves cached shell icons in place (the same refresh
+    // Squirrel/Electron run after their updates).
+    let refresh = std::process::Command::new("ie4uinit.exe")
+        .arg("-show")
+        .current_dir(&cwd)
+        .creation_flags(CREATE_NO_WINDOW)
+        .status()
+        .map_err(|e| format!("ie4uinit spawn: {e}"))?;
+    if !refresh.success() {
+        return Err(format!("ie4uinit -show exited {refresh}"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runs_when_marker_missing_or_stale() {
+        assert!(should_run(None, "0.6.0"));
+        assert!(should_run(Some("0.5.9"), "0.6.0"));
+        assert!(should_run(Some(""), "0.6.0"));
+    }
+
+    #[test]
+    fn skips_when_marker_matches_current_version() {
+        assert!(!should_run(Some("0.6.0"), "0.6.0"));
+        // Tolerates the trailing newline an edited marker might carry.
+        assert!(!should_run(Some("0.6.0\n"), "0.6.0"));
+    }
+
+    #[test]
+    fn ps_single_quoted_escapes_embedded_quotes() {
+        assert_eq!(ps_single_quoted("plain"), "'plain'");
+        assert_eq!(
+            ps_single_quoted(r"C:\Users\O'Brien\Houston.exe"),
+            r"'C:\Users\O''Brien\Houston.exe'"
+        );
+    }
+
+    #[test]
+    fn repair_script_embeds_exe_and_targets_pins_and_desktop() {
+        let script = repair_script(r"C:\Program Files\Houston\Houston.exe");
+        assert!(script.contains(r"$exe = 'C:\Program Files\Houston\Houston.exe'"));
+        assert!(script.contains(r"User Pinned\TaskBar"));
+        assert!(script.contains("GetFolderPath('Desktop')"));
+        // Only rewrites icons that are dead or in the installer icon cache.
+        assert!(script.contains("$dead -or $cached"));
+        // Never retargets the shortcut itself, only its icon.
+        assert!(script.contains(r#"$lnk.IconLocation = "$exe,0""#));
+        assert!(!script.contains("TargetPath ="));
+    }
+}

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -68,7 +68,8 @@
     },
     "windows": {
       "wix": {
-        "language": ["en-US"]
+        "language": ["en-US"],
+        "template": "wix/main.wxs"
       },
       "webviewInstallMode": {
         "type": "embedBootstrapper"

--- a/app/src-tauri/wix/main.wxs
+++ b/app/src-tauri/wix/main.wxs
@@ -1,0 +1,401 @@
+<!--
+  Vendored copy of tauri-bundler's WiX template (tauri-cli v2.11.4,
+  crates/tauri-bundler/src/bundle/windows/msi/main.wxs), wired up via
+  bundle.windows.wix.template in tauri.conf.json.
+
+  ONE deliberate change from upstream (PRODUCT-1233): the Start Menu shortcut
+  no longer sets Icon="ProductIcon". An MSI shortcut icon is extracted to
+  C:\Windows\Installer\<ProductCode>\ and referenced by absolute path from the
+  .lnk. Every Houston update is a WiX MajorUpgrade with a fresh ProductCode,
+  so that folder is deleted on upgrade and any taskbar pin the user made from
+  the shortcut keeps pointing at the dead path forever - the pinned icon
+  degrades to the blank default. Without the attribute the shortcut (and pins
+  made from it) take the icon embedded in Houston.exe, whose path is stable
+  across updates. ARPPRODUCTICON (the Apps-list icon) is unaffected.
+
+  When bumping @tauri-apps/cli, re-diff this file against the matching
+  upstream tag and re-apply that single removal.
+-->
+<?if $(sys.BUILDARCH)="x86"?>
+    <?define Win64 = "no" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
+<?elseif $(sys.BUILDARCH)="x64"?>
+    <?define Win64 = "yes" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+<?elseif $(sys.BUILDARCH)="arm64"?>
+    <?define Win64 = "yes" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+<?else?>
+    <?error Unsupported value of sys.BUILDARCH=$(sys.BUILDARCH)?>
+<?endif?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Product
+            Id="*"
+            Name="{{product_name}}"
+            UpgradeCode="{{upgrade_code}}"
+            Language="!(loc.TauriLanguage)"
+            Manufacturer="{{manufacturer}}"
+            Version="{{version}}">
+
+        <Package Id="*"
+                 Keywords="Installer"
+                 InstallerVersion="450"
+                 Languages="0"
+                 Compressed="yes"
+                 InstallScope="perMachine"
+                 SummaryCodepage="!(loc.TauriCodepage)"/>
+
+        <!-- https://docs.microsoft.com/en-us/windows/win32/msi/reinstallmode -->
+        <!-- reinstall all files; rewrite all registry entries; reinstall all shortcuts -->
+        <Property Id="REINSTALLMODE" Value="amus" />
+
+        <!-- Auto launch app after installation, useful for passive mode which usually used in updates -->
+        <Property Id="AUTOLAUNCHAPP" Secure="yes" />
+        <!-- Property to forward cli args to the launched app to not lose those of the pre-update instance -->
+        <Property Id="LAUNCHAPPARGS" Secure="yes" />
+
+        {{#if allow_downgrades}}
+            <MajorUpgrade Schedule="afterInstallInitialize" AllowDowngrades="yes" />
+        {{else}}
+            <MajorUpgrade Schedule="afterInstallInitialize" DowngradeErrorMessage="!(loc.DowngradeErrorMessage)" AllowSameVersionUpgrades="yes" />
+        {{/if}}
+
+        <InstallExecuteSequence>
+            <RemoveShortcuts>Installed AND NOT UPGRADINGPRODUCTCODE</RemoveShortcuts>
+        </InstallExecuteSequence>
+
+        <Media Id="1" Cabinet="app.cab" EmbedCab="yes" />
+
+        {{#if banner_path}}
+        <WixVariable Id="WixUIBannerBmp" Value="{{banner_path}}" />
+        {{/if}}
+        {{#if dialog_image_path}}
+        <WixVariable Id="WixUIDialogBmp" Value="{{dialog_image_path}}" />
+        {{/if}}
+        {{#if license}}
+        <WixVariable Id="WixUILicenseRtf" Value="{{license}}" />
+        {{/if}}
+
+        <Icon Id="ProductIcon" SourceFile="{{icon_path}}"/>
+        <Property Id="ARPPRODUCTICON" Value="ProductIcon" />
+        <Property Id="ARPNOREPAIR" Value="yes" Secure="yes" />      <!-- Remove repair -->
+        <SetProperty Id="ARPNOMODIFY" Value="1" After="InstallValidate" Sequence="execute"/>
+
+        {{#if homepage}}
+        <Property Id="ARPURLINFOABOUT" Value="{{homepage}}"/>
+        <Property Id="ARPHELPLINK" Value="{{homepage}}"/>
+        <Property Id="ARPURLUPDATEINFO" Value="{{homepage}}"/>
+        {{/if}}
+
+        <!-- NOTE: The order of RegistrySearch elements below matters. In WIX, when multiple
+             RegistrySearch elements are listed under a single Property, the LAST successful
+             match wins. We list the NSIS default-key search first and the MSI InstallDir
+             search second so that the MSI-specific path takes priority when both keys exist. -->
+        <Property Id="INSTALLDIR">
+          <!-- First attempt: Search for the default key value (this is how the nsis installer stores the path) -->
+          <RegistrySearch Id="PrevInstallDirNoName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Type="raw" />
+
+          <!-- Second attempt: Search for "InstallDir" which takes priority if found (this is how the msi installer stores the path) -->
+          <RegistrySearch Id="PrevInstallDirWithName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="InstallDir" Type="raw" />
+        </Property>
+
+        <!-- launch app checkbox -->
+        <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="!(loc.LaunchApp)" />
+        <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1"/>
+        <CustomAction Id="LaunchApplication" Impersonate="yes" FileKey="Path" ExeCommand="[LAUNCHAPPARGS]" Return="asyncNoWait" />
+
+        <UI>
+            <!-- launch app checkbox -->
+            <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchApplication">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed</Publish>
+
+            <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
+
+            {{#unless license}}
+            <!-- Skip license dialog -->
+            <Publish Dialog="WelcomeDlg"
+                     Control="Next"
+                     Event="NewDialog"
+                     Value="InstallDirDlg"
+                     Order="2">1</Publish>
+            <Publish Dialog="InstallDirDlg"
+                     Control="Back"
+                     Event="NewDialog"
+                     Value="WelcomeDlg"
+                     Order="2">1</Publish>
+            {{/unless}}
+        </UI>
+
+        <UIRef Id="WixUI_InstallDir" />
+
+        <Directory Id="TARGETDIR" Name="SourceDir">
+            <Directory Id="DesktopFolder" Name="Desktop">
+                <Component Id="ApplicationShortcutDesktop" Guid="*">
+                    <Shortcut Id="ApplicationDesktopShortcut" Name="{{product_name}}" Description="Runs {{product_name}}" Target="[!Path]" WorkingDirectory="INSTALLDIR" />
+                    <RemoveFolder Id="DesktopFolder" On="uninstall" />
+                    <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Desktop Shortcut" Type="integer" Value="1" KeyPath="yes" />
+                </Component>
+            </Directory>
+            <Directory Id="$(var.PlatformProgramFilesFolder)" Name="PFiles">
+                <Directory Id="INSTALLDIR" Name="{{product_name}}"/>
+            </Directory>
+            <Directory Id="ProgramMenuFolder">
+                <Directory Id="ApplicationProgramsFolder" Name="{{product_name}}"/>
+            </Directory>
+        </Directory>
+
+        <DirectoryRef Id="INSTALLDIR">
+            <Component Id="RegistryEntries" Guid="*">
+                <RegistryKey Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}">
+                    <RegistryValue Name="InstallDir" Type="string" Value="[INSTALLDIR]" KeyPath="yes" />
+                </RegistryKey>
+                <!-- Change the Root to HKCU for perUser installations -->
+                {{#each deep_link_protocols as |protocol| ~}}
+                <RegistryKey Root="HKLM" Key="Software\Classes\\{{protocol}}">
+                    <RegistryValue Type="string" Name="URL Protocol" Value=""/>
+                    <RegistryValue Type="string" Value="URL:{{bundle_id}} protocol"/>
+                    <RegistryKey Key="DefaultIcon">
+                        <RegistryValue Type="string" Value="&quot;[!Path]&quot;,0" />
+                    </RegistryKey>
+                    <RegistryKey Key="shell\open\command">
+                        <RegistryValue Type="string" Value="&quot;[!Path]&quot; &quot;%1&quot;" />
+                    </RegistryKey>
+                </RegistryKey>
+                {{/each~}}
+            </Component>
+            <Component Id="Path" Guid="{{path_component_guid}}" Win64="$(var.Win64)">
+                <File Id="Path" Source="{{main_binary_path}}" KeyPath="yes" Checksum="yes"/>
+                {{#each file_associations as |association| ~}}
+                {{#each association.ext as |ext| ~}}
+                <ProgId Id="{{../../product_name}}.{{ext}}" Advertise="yes" Description="{{association.description}}">
+                    <Extension Id="{{ext}}" Advertise="yes">
+                        <Verb Id="open" Command="Open with {{../../product_name}}" Argument="&quot;%1&quot;" />
+                    </Extension>
+                </ProgId>
+                {{/each~}}
+                {{/each~}}
+            </Component>
+            {{#each binaries as |bin| ~}}
+            <Component Id="{{ bin.id }}" Guid="{{bin.guid}}" Win64="$(var.Win64)">
+                <File Id="Bin_{{ bin.id }}" Source="{{bin.path}}" KeyPath="yes"/>
+            </Component>
+            {{/each~}}
+            {{#if enable_elevated_update_task}}
+            <Component Id="UpdateTask" Guid="C492327D-9720-4CD5-8DB8-F09082AF44BE" Win64="$(var.Win64)">
+                <File Id="UpdateTask" Source="update.xml" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="UpdateTaskInstaller" Guid="011F25ED-9BE3-50A7-9E9B-3519ED2B9932" Win64="$(var.Win64)">
+                <File Id="UpdateTaskInstaller" Source="install-task.ps1" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="UpdateTaskUninstaller" Guid="D4F6CC3F-32DC-5FD0-95E8-782FFD7BBCE1" Win64="$(var.Win64)">
+                <File Id="UpdateTaskUninstaller" Source="uninstall-task.ps1" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            {{/if}}
+            {{resources}}
+            <Component Id="CMP_UninstallShortcut" Guid="*">
+
+                <Shortcut Id="UninstallShortcut"
+						  Name="Uninstall {{product_name}}"
+						  Description="Uninstalls {{product_name}}"
+						  Target="[System64Folder]msiexec.exe"
+						  Arguments="/x [ProductCode]" />
+
+				<RemoveFolder Id="INSTALLDIR"
+							  On="uninstall" />
+
+				<RegistryValue Root="HKCU"
+							   Key="Software\\{{manufacturer}}\\{{product_name}}"
+							   Name="Uninstaller Shortcut"
+							   Type="integer"
+							   Value="1"
+							   KeyPath="yes" />
+            </Component>
+        </DirectoryRef>
+
+        <DirectoryRef Id="ApplicationProgramsFolder">
+            <Component Id="ApplicationShortcut" Guid="*">
+                <!-- PRODUCT-1233: no Icon attribute here on purpose - see the
+                     header comment. The shortcut icon must come from the exe,
+                     never from the per-ProductCode installer icon cache. -->
+                <Shortcut Id="ApplicationStartMenuShortcut"
+                    Name="{{product_name}}"
+                    Description="Runs {{product_name}}"
+                    Target="[!Path]"
+                    WorkingDirectory="INSTALLDIR">
+                    <ShortcutProperty Key="System.AppUserModel.ID" Value="{{bundle_id}}"/>
+                </Shortcut>
+                <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+                <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Start Menu Shortcut" Type="integer" Value="1" KeyPath="yes"/>
+           </Component>
+        </DirectoryRef>
+
+        {{#each merge_modules as |msm| ~}}
+        <DirectoryRef Id="TARGETDIR">
+            <Merge Id="{{ msm.name }}" SourceFile="{{ msm.path }}" DiskId="1" Language="!(loc.TauriLanguage)" />
+        </DirectoryRef>
+
+        <Feature Id="{{ msm.name }}" Title="{{ msm.name }}" AllowAdvertise="no" Display="hidden" Level="1">
+            <MergeRef Id="{{ msm.name }}"/>
+        </Feature>
+        {{/each~}}
+
+        <Feature
+                Id="MainProgram"
+                Title="Application"
+                Description="!(loc.InstallAppFeature)"
+                Level="1"
+                ConfigurableDirectory="INSTALLDIR"
+                AllowAdvertise="no"
+                Display="expand"
+                Absent="disallow">
+
+            <ComponentRef Id="RegistryEntries"/>
+
+            {{#each resource_file_ids as |resource_file_id| ~}}
+                <ComponentRef Id="{{ resource_file_id }}"/>
+            {{/each~}}
+
+            {{#if enable_elevated_update_task}}
+                <ComponentRef Id="UpdateTask" />
+                <ComponentRef Id="UpdateTaskInstaller" />
+                <ComponentRef Id="UpdateTaskUninstaller" />
+            {{/if}}
+
+            <Feature Id="ShortcutsFeature"
+                Title="Shortcuts"
+                Level="1">
+                <ComponentRef Id="Path"/>
+                <ComponentRef Id="CMP_UninstallShortcut" />
+                <ComponentRef Id="ApplicationShortcut" />
+                <ComponentRef Id="ApplicationShortcutDesktop" />
+            </Feature>
+
+            <Feature
+                Id="Environment"
+                Title="PATH Environment Variable"
+                Description="!(loc.PathEnvVarFeature)"
+                Level="1"
+                Absent="allow">
+            <ComponentRef Id="Path"/>
+            {{#each binaries as |bin| ~}}
+            <ComponentRef Id="{{ bin.id }}"/>
+            {{/each~}}
+            </Feature>
+        </Feature>
+
+        <Feature Id="External" AllowAdvertise="no" Absent="disallow">
+            {{#each component_group_refs as |id| ~}}
+            <ComponentGroupRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each component_refs as |id| ~}}
+            <ComponentRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each feature_group_refs as |id| ~}}
+            <FeatureGroupRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each feature_refs as |id| ~}}
+            <FeatureRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each merge_refs as |id| ~}}
+            <MergeRef Id="{{ id }}"/>
+            {{/each~}}
+        </Feature>
+
+        {{#if install_webview}}
+        <!-- WebView2 -->
+        <Property Id="INSTALLED_WEBVIEW2_VERSION">
+            <RegistrySearch Id="Webview2VersionSystemx64" Root="HKLM" Key="SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw" />
+            <RegistrySearch Id="Webview2VersionSystemx86" Root="HKLM" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw" />
+            <RegistrySearch Id="Webview2VersionUser" Root="HKCU" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw"/>
+        </Property>
+
+        {{#if download_bootstrapper}}
+        <!-- Download webview bootstrapper mode -->
+        <CustomAction Id='DownloadAndInvokeBootstrapper' Directory="INSTALLDIR" Execute="deferred" ExeCommand='powershell.exe -NoProfile -windowstyle hidden try [\{] [\[]Net.ServicePointManager[\]]::SecurityProtocol = [\[]Net.SecurityProtocolType[\]]::Tls12 [\}] catch [\{][\}]; Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/p/?LinkId=2124703" -OutFile "$env:TEMP\MicrosoftEdgeWebview2Setup.exe" ; Start-Process -FilePath "$env:TEMP\MicrosoftEdgeWebview2Setup.exe" -ArgumentList ({{webview_installer_args}} &apos;/install&apos;) -Wait' Return='check'/>
+        <InstallExecuteSequence>
+            <Custom Action='DownloadAndInvokeBootstrapper' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR INSTALLED_WEBVIEW2_VERSION)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{#if webview2_bootstrapper_path}}
+        <!-- Embedded webview bootstrapper mode -->
+        <Binary Id="MicrosoftEdgeWebview2Setup.exe" SourceFile="{{webview2_bootstrapper_path}}"/>
+        <CustomAction Id='InvokeBootstrapper' BinaryKey='MicrosoftEdgeWebview2Setup.exe' Execute="deferred" ExeCommand='{{webview_installer_args}} /install' Return='check' />
+        <InstallExecuteSequence>
+            <Custom Action='InvokeBootstrapper' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR INSTALLED_WEBVIEW2_VERSION)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{#if webview2_installer_path}}
+        <!-- Embedded offline installer -->
+        <Binary Id="MicrosoftEdgeWebView2RuntimeInstaller.exe" SourceFile="{{webview2_installer_path}}"/>
+        <CustomAction Id='InvokeStandalone' BinaryKey='MicrosoftEdgeWebView2RuntimeInstaller.exe' Execute="deferred" ExeCommand='{{webview_installer_args}} /install' Return='check' />
+        <InstallExecuteSequence>
+            <Custom Action='InvokeStandalone' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR INSTALLED_WEBVIEW2_VERSION)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{#if minimum_webview2_version}}
+        <!-- Update WebView2 if minimum version requirement not met -->
+        <Property Id="MINIMUM_WEBVIEW2_VERSION" Value="{{minimum_webview2_version}}" />
+        <Property Id="EDGEUPDATE_PATH">
+            <RegistrySearch Id="EdgeUpdateLocalMachine64" Root="HKLM" Key="SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate" Name="path" Type="raw" />
+            <RegistrySearch Id="EdgeUpdateLocalMachine32" Root="HKLM" Key="SOFTWARE\Microsoft\EdgeUpdate" Name="path" Type="raw"/>
+            <RegistrySearch Id="EdgeUpdateCurrentUser" Root="HKCU" Key="SOFTWARE\Microsoft\EdgeUpdate" Name="path" Type="raw"/>
+        </Property>
+        <!-- Chromium updater docs: https://source.chromium.org/chromium/chromium/src/+/main:docs/updater/user_manual.md -->
+        <!-- Modified from "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft EdgeWebView\ModifyPath" -->
+        <CustomAction Id="UpdateWebView2ViaEdgeUpdate" Execute="deferred" Property="EDGEUPDATE_PATH" Return="check" Impersonate="no" ExeCommand="/install appguid={F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}&amp;needsadmin=true" />
+        <InstallExecuteSequence>
+            <Custom Action='UpdateWebView2ViaEdgeUpdate' Before='InstallFinalize'>
+                <![CDATA[
+                  NOT REMOVE
+                  AND INSTALLED_WEBVIEW2_VERSION
+                  AND (INSTALLED_WEBVIEW2_VERSION < MINIMUM_WEBVIEW2_VERSION)
+                ]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{/if}}
+
+        {{#if enable_elevated_update_task}}
+        <!-- Install an elevated update task within Windows Task Scheduler -->
+        <CustomAction
+            Id="CreateUpdateTask"
+            Return="check"
+            Directory="INSTALLDIR"
+            Execute="commit"
+            Impersonate="yes"
+            ExeCommand="powershell.exe -WindowStyle hidden .\install-task.ps1" />
+        <InstallExecuteSequence>
+            <Custom Action='CreateUpdateTask' Before='InstallFinalize'>
+                NOT(REMOVE)
+            </Custom>
+        </InstallExecuteSequence>
+        <!-- Remove elevated update task during uninstall -->
+        <CustomAction
+            Id="DeleteUpdateTask"
+            Return="check"
+            Directory="INSTALLDIR"
+            ExeCommand="powershell.exe -WindowStyle hidden .\uninstall-task.ps1" />
+        <InstallExecuteSequence>
+            <Custom Action="DeleteUpdateTask" Before='InstallFinalize'>
+                (REMOVE = "ALL") AND NOT UPGRADINGPRODUCTCODE
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        <InstallExecuteSequence>
+          <Custom Action="LaunchApplication" After="InstallFinalize">AUTOLAUNCHAPP AND NOT Installed</Custom>
+        </InstallExecuteSequence>
+
+        <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize"/>
+    </Product>
+</Wix>


### PR DESCRIPTION
Fixes PRODUCT-1233 (app icon disappearing on Windows — taskbar pins and desktop).

## Root cause

Houston ships Windows as a WiX MSI and auto-updates in the background. Two defects in the stock Tauri bundler setup:

1. **Taskbar pins (deterministic).** The stock Start Menu shortcut sets `Icon="ProductIcon"`. An MSI shortcut icon is extracted to `C:\Windows\Installer\{ProductCode}\` and referenced by absolute path from the `.lnk`. Every Houston release is a WiX MajorUpgrade with a fresh `ProductCode` (`Product Id="*"`), and Windows deletes the old folder on upgrade — so any pin the user made from that shortcut keeps pointing at a deleted icon file forever. First background update after pinning ⇒ blank white icon, which is why users see it happen "out of nowhere".
2. **Desktop icons (racy).** `MajorUpgrade Schedule="afterInstallInitialize"` uninstalls the old product (removing `Houston.exe`) before laying down the new one. If Explorer re-resolves shortcut icons during that window it caches the blank fallback for the exe path, and the stale cache entry sticks.

Upstream Tauri still has the `Icon="ProductIcon"` attribute on `dev`, so no CLI bump fixes this.

## Fix

- **`app/src-tauri/wix/main.wxs`** — vendored copy of the tauri-cli v2.11.4 MSI template (wired via `bundle.windows.wix.template`) with one deliberate change: the Start Menu shortcut no longer sets `Icon="ProductIcon"`, so shortcuts (and pins made from them) take the icon embedded in `Houston.exe`, whose path is stable across updates. `ARPPRODUCTICON` (Apps-list icon) is untouched. Provenance + re-sync instructions are in the file header. *(Vendored upstream template, hence >200 lines — one attribute changed.)*
- **`app/src-tauri/src/windows_icon_repair.rs`** — heals already-broken installs. Once per installed version (first launch after every update, exactly when breakage can occur), a background thread rewrites the icon location of any user `.lnk` (taskbar-pin folder + desktop) that targets the current exe but references a missing icon file or one under `C:\Windows\Installer\`, then runs `ie4uinit.exe -show` to refresh Explorer's icon cache (the same post-update refresh Squirrel/Electron use). PowerShell runs via `-EncodedCommand` (no argv re-quoting), hidden window, install dir as cwd.

## Verification

**Repro before the fix** (Windows):
1. Install Houston from the MSI, pin it to the taskbar from the Start Menu entry.
2. `Get-ItemProperty` isn't needed — inspect the pin: `(New-Object -ComObject WScript.Shell).CreateShortcut("$env:APPDATA\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\Houston.lnk").IconLocation` → points into `C:\Windows\Installer\{GUID}\`.
3. Install the next version's MSI (or let the auto-updater run). The referenced folder is gone; the pinned icon renders as the blank default.

**After the fix:**
1. Build an MSI from this branch (`cd app && pnpm tauri build --target x86_64-pc-windows-msvc`), install, and check the new Start Menu shortcut: its `IconLocation` is empty/exe-based, not `C:\Windows\Installer\...`.
2. On an install with an already-blank pin: launch the app once, wait a few seconds — the pin's `IconLocation` is rewritten to `<path>\Houston.exe,0` and the icon renders again (`[icon-repair]` lines appear in the app log).
3. Upgrade again from a pinned state: icon survives.

## Tests

- 4 new unit tests for the repair gating + PowerShell script construction (`cargo test windows_icon_repair`; full shell suite: 216 passed).
- `cargo check` clean on macOS and `--target x86_64-pc-windows-gnu` (compiles the `cfg(windows)` path).
- Biome clean on the config edit.