### PR TITLE
fix(auth): make login work again right after logout (PRODUCT-1235)

### DIFF
--- a/app/src/lib/delete-account-flow.ts
+++ b/app/src/lib/delete-account-flow.ts
@@ -1,10 +1,11 @@
 // The full client side of account deletion (HOU-991): server purge, then a
-// slightly-deeper-than-sign-out local teardown. On top of `signOut()` this
-// also purges `houston.*` localStorage keys (sidebar layout, read cursors,
-// migration outcome) that plain sign-out deliberately keeps for a returning
-// user. The on-disk `~/.houston` tree is left alone ON PURPOSE: those are the
-// user's local files (deliberate product decision — deletion removes the
-// hosted account and data, never the user's machine-local files).
+// slightly-deeper-than-sign-out local teardown. On top of `signOut()` (which
+// already purges the ACCOUNT-scoped `houston.*` keys, PRODUCT-1235) this
+// purges ALL `houston.*` localStorage keys, including the device-level ones
+// sign-out keeps (host connection, standalone local data). The on-disk
+// `~/.houston` tree is left alone ON PURPOSE: those are the user's local
+// files (deliberate product decision — deletion removes the hosted account
+// and data, never the user's machine-local files).
 
 import { analytics } from "./analytics";
 import { purgeHoustonLocalState } from "./houston-local-state";

--- a/app/src/lib/houston-local-state.ts
+++ b/app/src/lib/houston-local-state.ts
@@ -9,15 +9,50 @@ export interface KeyedStorage {
 }
 
 /** Remove every `houston.*` key (sidebar layout, read cursors, agent colors,
- *  migration outcome, onboarding mirrors) from the given storage. Used by the
- *  account-deletion teardown (HOU-991) — plain sign-out deliberately leaves
- *  these so a returning user finds their world intact. Snapshot the keys
- *  first: removal renumbers the indices mid-walk. */
+ *  migration outcome, onboarding mirrors — AND the device-level keys below)
+ *  from the given storage. Used by the account-deletion teardown (HOU-991),
+ *  which erases this device's whole Houston footprint. Plain sign-out uses the
+ *  narrower `purgeAccountLocalState`. Snapshot the keys first: removal
+ *  renumbers the indices mid-walk. */
 export function purgeHoustonLocalState(storage: KeyedStorage): void {
   const doomed: string[] = [];
   for (let i = 0; i < storage.length; i++) {
     const key = storage.key(i);
     if (key?.startsWith("houston.")) doomed.push(key);
+  }
+  for (const key of doomed) storage.removeItem(key);
+}
+
+/**
+ * `houston.*` key prefixes that belong to the DEVICE (or to browser-local data
+ * that is nobody's hosted account), not to the signed-in account, so sign-out
+ * must keep them:
+ *
+ *  - `houston.web.engine` (+ its `.new` successor) — which host this browser
+ *    connects to (self-host URL). Signing out of an account must not make the
+ *    browser forget its engine.
+ *  - `houston.web.agents` / `houston.web.agentfile:` — the standalone
+ *    (no-host) adapter's local agent store: the browser analog of the
+ *    `~/.houston` tree, which sign-out never wipes (HOU-991).
+ */
+const DEVICE_LOCAL_KEY_PREFIXES = [
+  "houston.web.engine",
+  "houston.web.agents",
+  "houston.web.agentfile:",
+] as const;
+
+/** Remove every ACCOUNT-scoped `houston.*` key — prefs mirrors, sidebar
+ *  layouts, read cursors, agent colors, onboarding mirrors, provider-status
+ *  caches, the last-sign-in hint — while keeping the device-level keys above.
+ *  Runs on every sign-out (PRODUCT-1235): no trace of the outgoing account may
+ *  survive into the next sign-in. */
+export function purgeAccountLocalState(storage: KeyedStorage): void {
+  const doomed: string[] = [];
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i);
+    if (!key?.startsWith("houston.")) continue;
+    if (DEVICE_LOCAL_KEY_PREFIXES.some((p) => key.startsWith(p))) continue;
+    doomed.push(key);
   }
   for (const key of doomed) storage.removeItem(key);
 }

--- a/app/src/lib/houston-local-state.ts
+++ b/app/src/lib/houston-local-state.ts
@@ -34,11 +34,18 @@ export function purgeHoustonLocalState(storage: KeyedStorage): void {
  *  - `houston.web.agents` / `houston.web.agentfile:` — the standalone
  *    (no-host) adapter's local agent store: the browser analog of the
  *    `~/.houston` tree, which sign-out never wipes (HOU-991).
+ *  - `houston.pendingAgentMoves` — the crash-recovery ticket for an in-flight
+ *    C8 agent move (HOU-817). The gateway's move lock outlives the mover and
+ *    ONLY a re-POST of the recorded move can free the agent; wiping the ticket
+ *    at sign-out would leave the agent 503-locked forever. Tenancy is safe:
+ *    the gateway refuses a wrong-account resume and `useMoveResume` keeps the
+ *    record for the owning account's next sign-in.
  */
 const DEVICE_LOCAL_KEY_PREFIXES = [
   "houston.web.engine",
   "houston.web.agents",
   "houston.web.agentfile:",
+  "houston.pendingAgentMoves",
 ] as const;
 
 /** Remove every ACCOUNT-scoped `houston.*` key — prefs mirrors, sidebar

--- a/app/src/lib/identity-cache-reset.ts
+++ b/app/src/lib/identity-cache-reset.ts
@@ -1,0 +1,45 @@
+// The query-cache half of the identity reset (`identity-reset.ts`), split into
+// a dependency-light module (query keys only) so `app/tests` can exercise it
+// under node:test without the zustand/engine import chains.
+
+import type { QueryClient } from "@tanstack/react-query";
+import { queryKeys } from "./query-keys.ts";
+
+/**
+ * Query-key roots that OUTLIVE an identity change.
+ *
+ *  - `session` — the identity `Session | null` cache, the ONLY signal the auth
+ *    gates (`HostedEngineGate`, `IdentityKeyedApp`, `App`) re-render on. It must
+ *    be purged by VALUE (the sign-out/switch paths write it through
+ *    `cacheSession`), never by removing the query: `queryClient.clear()` (and
+ *    `removeQueries` without this exemption) destroys the `Query` object while
+ *    those mounted observers are still attached to it, and the next
+ *    `setQueryData` builds a REPLACEMENT query with zero observers. Observers
+ *    only re-bind on a render, the gates have no other render trigger, so the
+ *    next sign-in's session write reaches nobody: the app sits on the sign-in
+ *    screen until relaunch while the keychain already holds the new account
+ *    (PRODUCT-1235). Mirrors `SPACE_INVARIANT_KEY_ROOTS` in `space-cache.ts`.
+ *
+ * The onboarding roots that the SPACE reset also preserves are deliberately
+ * NOT here: they are user-scoped, so an identity change must drop them.
+ */
+const IDENTITY_INVARIANT_KEY_ROOTS: ReadonlySet<string> = new Set([
+  String(queryKeys.session()[0]),
+]);
+
+/**
+ * Drop every cached query belonging to the outgoing identity — plus the
+ * mutation cache — while keeping the `["session"]` query OBJECT (and its
+ * observers) alive. The session's stale value is overwritten by the caller's
+ * own `cacheSession` write in the same tick, so no cross-identity data
+ * survives; what survives is the subscription that lets that write render.
+ */
+export function resetQueryCacheForIdentityChange(
+  queryClient: QueryClient,
+): void {
+  queryClient.removeQueries({
+    predicate: (query) =>
+      !IDENTITY_INVARIANT_KEY_ROOTS.has(String(query.queryKey[0])),
+  });
+  queryClient.getMutationCache().clear();
+}

--- a/app/src/lib/identity-reset.ts
+++ b/app/src/lib/identity-reset.ts
@@ -5,6 +5,7 @@ import { useDraftStore } from "../stores/drafts";
 import { useUIStore } from "../stores/ui";
 import { useWorkspaceStore } from "../stores/workspaces";
 import { setActiveOrg } from "./engine";
+import { resetQueryCacheForIdentityChange } from "./identity-cache-reset";
 import { queryClient } from "./query-client";
 
 /**
@@ -15,13 +16,15 @@ import { queryClient } from "./query-client";
  * this is pure client-side stale memory. Three things outlive an identity swap
  * and must be wiped, or the incoming account inherits the outgoing one's world:
  *
- *  1. The in-memory query cache. `queryClient.clear()` (stronger than
- *     `removeQueries`) is deliberate: query keys are NOT user-scoped — the
- *     gateway resolves the caller from the bearer + `x-houston-org` header — so
- *     EVERY cached read (agents, org, provider-connection states) belongs to the
+ *  1. The in-memory query cache. Query keys are NOT user-scoped — the gateway
+ *     resolves the caller from the bearer + `x-houston-org` header — so EVERY
+ *     cached read (agents, org, provider-connection states) belongs to the
  *     outgoing identity and would otherwise be served to the next account via
- *     stale-while-revalidate. Mirrors `resetCacheForSpaceChange`, but for the
- *     whole identity rather than one space.
+ *     stale-while-revalidate. `removeQueries` (never `queryClient.clear()`)
+ *     with the `["session"]` query exempted: removing the session query
+ *     orphans the auth gates' mounted observers, so the next sign-in's session
+ *     write renders nothing and the app freezes on the sign-in screen until
+ *     relaunch (PRODUCT-1235) — see `identity-cache-reset.ts`.
  *  2. The zustand stores. They live outside React and survive the sign-out
  *     unmount, so their agents / workspaces / view state would carry over.
  *  3. The active-space pin (`x-houston-org`). A stale team slug from the
@@ -29,7 +32,7 @@ import { queryClient } from "./query-client";
  *     the gateway would 403 them `not_member`.
  */
 export function resetForIdentityChange(): void {
-  queryClient.clear();
+  resetQueryCacheForIdentityChange(queryClient);
   resetIntegrationGateForIdentityChange();
   useAgentStore.getState().reset();
   useWorkspaceStore.getState().reset();

--- a/app/src/lib/sign-in-establish.ts
+++ b/app/src/lib/sign-in-establish.ts
@@ -62,8 +62,10 @@ function trackSignIn(
 
 // Device-local hint for the sign-in screen, stamped at BOTH terminal success
 // points (desktop + web) so every path — OAuth loopback, deep-link, email OTP —
-// records it once. Deliberately NOT cleared by `signOut()`: it must survive so
-// the next sign-in can suggest how the user signed in last time.
+// records it once. Cleared by `signOut()` along with every other account trace
+// (PRODUCT-1235), so it only survives when the session ends WITHOUT a sign-out
+// (expiry, revocation, secure-storage faults) — exactly the cases where "sign
+// back in the way you did last time" is the right suggestion.
 function rememberLastSignIn(session: Session): void {
   writeLastSignIn({ provider: session.provider, email: session.email });
 }

--- a/app/src/lib/sign-out.ts
+++ b/app/src/lib/sign-out.ts
@@ -7,6 +7,7 @@
 import { cancelAllConnectFlows } from "../stores/connect-flow";
 import { analytics } from "./analytics";
 import { emitAuthError } from "./auth-error-bus";
+import { purgeAccountLocalState } from "./houston-local-state";
 import { clearSession, stopProactiveRefresh } from "./identity";
 import { cancelPendingAuthorize } from "./identity/desktop-oauth";
 import { resetForIdentityChange } from "./identity-reset";
@@ -66,6 +67,11 @@ export async function signOut(): Promise<void> {
     // (HOU-712). Contained: an IndexedDB rejection must not skip the in-memory
     // reset below, or the outgoing account's world rides into the next sign-in.
     await clearPersistedLocalData();
+    // And the account-scoped `houston.*` localStorage mirrors — prefs, layouts,
+    // read cursors, onboarding + last-sign-in hints (PRODUCT-1235). Device-level
+    // keys (host connection, standalone local data) survive; see
+    // `houston-local-state.ts`.
+    purgeAccountLocalState(window.localStorage);
   } catch (e) {
     localDataFailure = e;
     logger.error(`[auth] sign-out could not wipe persisted local data: ${e}`);

--- a/app/tests/account-local-purge.test.ts
+++ b/app/tests/account-local-purge.test.ts
@@ -35,11 +35,12 @@ test("purgeAccountLocalState removes account traces, keeps device keys", () => {
     ["houston.web.cp.agentColors", "{}"],
     ["houston.sdk.some-state", "{}"],
     ["houston.theme.cache", "dark"],
-    // Device-level — must survive sign-out.
+    // Device-level / recovery — must survive sign-out.
     ["houston.web.engine.new", '{"url":"https://my-vps.example"}'],
     ["houston.web.engine", '{"url":"legacy"}'],
     ["houston.web.agents", "[]"],
     ["houston.web.agentfile:ws/agent", "data"],
+    ["houston.pendingAgentMoves", '[{"agentId":"a1"}]'],
     // Not ours — never touched.
     ["other-app.key", "keep"],
   ]);
@@ -47,6 +48,7 @@ test("purgeAccountLocalState removes account traces, keeps device keys", () => {
   purgeAccountLocalState(keyedStorage(store));
 
   assert.deepStrictEqual([...store.keys()].sort(), [
+    "houston.pendingAgentMoves",
     "houston.web.agentfile:ws/agent",
     "houston.web.agents",
     "houston.web.engine",

--- a/app/tests/account-local-purge.test.ts
+++ b/app/tests/account-local-purge.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert";
+import { test } from "node:test";
+import {
+  type KeyedStorage,
+  purgeAccountLocalState,
+} from "../src/lib/houston-local-state.ts";
+
+// PRODUCT-1235: sign-out must erase every account-scoped houston.* localStorage
+// trace so the next sign-in (any account) starts clean — while keeping the
+// device-level keys (host connection, standalone local data).
+
+function keyedStorage(store: Map<string, string>): KeyedStorage {
+  return {
+    get length() {
+      return store.size;
+    },
+    key(i: number) {
+      return [...store.keys()][i] ?? null;
+    },
+    removeItem(k: string) {
+      store.delete(k);
+    },
+  };
+}
+
+test("purgeAccountLocalState removes account traces, keeps device keys", () => {
+  const store = new Map<string, string>([
+    // Account-scoped — must go.
+    ["houston.pref.last_agent_id", "agent-1"],
+    ["houston.sidebar-layout", "{}"],
+    ["houston.read-cursors.u1", "{}"],
+    ["houston.onboarding-completed.u1", "true"],
+    ["houston.last-sign-in", '{"provider":"google"}'],
+    ["houston.providerStatusCache.v2", "{}"],
+    ["houston.web.cp.agentColors", "{}"],
+    ["houston.sdk.some-state", "{}"],
+    ["houston.theme.cache", "dark"],
+    // Device-level — must survive sign-out.
+    ["houston.web.engine.new", '{"url":"https://my-vps.example"}'],
+    ["houston.web.engine", '{"url":"legacy"}'],
+    ["houston.web.agents", "[]"],
+    ["houston.web.agentfile:ws/agent", "data"],
+    // Not ours — never touched.
+    ["other-app.key", "keep"],
+  ]);
+
+  purgeAccountLocalState(keyedStorage(store));
+
+  assert.deepStrictEqual([...store.keys()].sort(), [
+    "houston.web.agentfile:ws/agent",
+    "houston.web.agents",
+    "houston.web.engine",
+    "houston.web.engine.new",
+    "other-app.key",
+  ]);
+});
+
+test("purgeAccountLocalState survives index renumbering mid-walk", () => {
+  const store = new Map<string, string>([
+    ["houston.a", "1"],
+    ["houston.b", "2"],
+    ["houston.c", "3"],
+    ["plain", "keep"],
+  ]);
+
+  purgeAccountLocalState(keyedStorage(store));
+
+  assert.deepStrictEqual([...store.keys()], ["plain"]);
+});

--- a/app/tests/identity-cache-reset.test.ts
+++ b/app/tests/identity-cache-reset.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert";
+import { afterEach, describe, it } from "node:test";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { resetQueryCacheForIdentityChange } from "../src/lib/identity-cache-reset.ts";
+
+// PRODUCT-1235: after sign-out, the next sign-in did NOTHING until a relaunch.
+// The identity reset used `queryClient.clear()`, which destroys the
+// `["session"]` Query while the auth gates' observers are still attached; the
+// next `setQueryData` builds a replacement Query with zero observers, so the
+// sign-in's session write renders nothing. The reset must purge every
+// identity-scoped query WITHOUT breaking the session query's subscriptions.
+
+const queryClient = new QueryClient();
+
+// TanStack batches observer notifications through a setTimeout(0) scheduler;
+// observer callbacks land on the next macrotask.
+const flushNotifications = () =>
+  new Promise((resolve) => setTimeout(resolve, 1));
+
+/** A mounted `useSession` stand-in: an observer subscribed to `["session"]`. */
+function observeSession(seen: unknown[]): () => void {
+  const observer = new QueryObserver(queryClient, {
+    queryKey: ["session"],
+    queryFn: () => null,
+    staleTime: Number.POSITIVE_INFINITY,
+    enabled: false,
+  });
+  return observer.subscribe((result) => {
+    seen.push(result.data);
+  });
+}
+
+afterEach(() => {
+  queryClient.clear();
+});
+
+describe("resetQueryCacheForIdentityChange", () => {
+  it("drops identity-scoped queries — active-observer data AND inactive data", () => {
+    queryClient.setQueryData(["agents"], [{ id: "outgoing-account-agent" }]);
+    queryClient.setQueryData(["onboarding-completed", "u1"], true);
+
+    resetQueryCacheForIdentityChange(queryClient);
+
+    assert.strictEqual(queryClient.getQueryData(["agents"]), undefined);
+    assert.strictEqual(
+      queryClient.getQueryData(["onboarding-completed", "u1"]),
+      undefined,
+    );
+  });
+
+  it("clears the mutation cache (parity with the old queryClient.clear())", () => {
+    queryClient
+      .getMutationCache()
+      .build(queryClient, { mutationFn: async () => null });
+    assert.strictEqual(queryClient.getMutationCache().getAll().length, 1);
+
+    resetQueryCacheForIdentityChange(queryClient);
+
+    assert.strictEqual(queryClient.getMutationCache().getAll().length, 0);
+  });
+
+  it("keeps the session query's observers live so the next sign-in renders (PRODUCT-1235)", async () => {
+    queryClient.setQueryData(["session"], { uid: "outgoing" });
+    const seen: unknown[] = [];
+    const unsubscribe = observeSession(seen);
+
+    resetQueryCacheForIdentityChange(queryClient);
+    // What `cacheSession` does when the next account signs in.
+    queryClient.setQueryData(["session"], { uid: "incoming" });
+    await flushNotifications();
+    unsubscribe();
+
+    assert.deepStrictEqual(seen.at(-1), { uid: "incoming" });
+  });
+
+  it("canary: queryClient.clear() orphans those observers — never go back to it", async () => {
+    queryClient.setQueryData(["session"], { uid: "outgoing" });
+    const seen: unknown[] = [];
+    const unsubscribe = observeSession(seen);
+
+    queryClient.clear();
+    queryClient.setQueryData(["session"], { uid: "incoming" });
+    await flushNotifications();
+    unsubscribe();
+
+    // The write landed on a rebuilt, observer-less query: nobody saw it. This
+    // is the exact mechanism behind the PRODUCT-1235 freeze.
+    assert.notDeepStrictEqual(seen.at(-1), { uid: "incoming" });
+    assert.deepStrictEqual(queryClient.getQueryData(["session"]), {
+      uid: "incoming",
+    });
+  });
+});


### PR DESCRIPTION
Fixes PRODUCT-1235 (login does nothing after logout until the app is reopened).

## Root cause

`signOut()` → `resetForIdentityChange()` called `queryClient.clear()`. In TanStack Query v5, `clear()` destroys and removes every `Query` object — including `["session"]` — **without detaching the mounted observers** still bound to it. The very next `setQueryData(["session"], …)` (from `cacheSession(null)`) builds a brand-new `Query` under the same hash with **zero observers**. Observers only re-bind during a React render, and the auth gates (`HostedEngineGate` / `IdentityKeyedApp`) have no other render trigger.

So when the user signs in again in the same run, `establishDesktopSession` writes the new session into that orphaned query: no observer fires, nothing re-renders, the app "does nothing" — while the keychain/localStorage already holds the new account, which is why a relaunch comes up signed in. Same mechanics on desktop and web (shared code); the in-place account-switch path (`cacheSession`'s identity-change guard) hit it too.

## Fix

- **New `app/src/lib/identity-cache-reset.ts`**: the identity reset now purges the cache with `removeQueries` + a predicate that exempts the `["session"]` key root (mirroring the existing `SPACE_INVARIANT_KEY_ROOTS` pattern in `space-cache.ts`), plus an explicit mutation-cache clear for parity with the old `clear()`. The session query object — and the auth gates' subscriptions — stay alive; its value is overwritten by the caller's own `cacheSession` write in the same tick, so no cross-identity data survives.
- **Sign-out now cleans every account trace**: `purgeAccountLocalState` removes the account-scoped `houston.*` localStorage keys (pref mirrors, sidebar layouts, read cursors, agent colors, onboarding mirrors, provider-status caches, and the `houston.last-sign-in` hint — a deliberate behavior change: the hint now only survives non-sign-out session endings like expiry). Device-level keys survive: `houston.web.engine*` (host connection config) and the standalone adapter's local data (`houston.web.agents`, `houston.web.agentfile:`), the browser analog of the never-wiped `~/.houston` tree. Account deletion keeps its stronger full purge.

## Tests

- `app/tests/identity-cache-reset.test.ts` — the regression test (session observers survive the reset and see the next sign-in) plus a **canary reproducing the bug**: with `queryClient.clear()`, the observer provably never sees the next session write.
- `app/tests/account-local-purge.test.ts` — account keys purged, device keys preserved, index-renumbering walk.
- Full gates: `cd app && pnpm test` (2732 pass), `pnpm tsgo --noEmit`, `pnpm --filter houston-web typecheck`, `pnpm check` — all green.

## Verify

**Before (repro):** desktop or web → sign in as account A → avatar menu → Log out → sign in as account B (or A). Nothing happens; the sign-in screen stays. Quit + reopen → you are signed in as B.

**After:** same steps → the app transitions into the signed-in shell immediately after the OAuth/OTP completes, with account B's world (no stale agents/orgs/prefs from A). Also verify: sign out → relaunch → sign-in screen shows no "last signed in as…" hint for A; and a self-hosted web browser keeps its configured engine URL across sign-out.