### PR TITLE
chore(pi): update pi dependencies to 0.84.0 (PRODUCT-1243)

### DIFF
--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -372,8 +372,8 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
         label: "GPT-5 Mini",
         description: "OpenAI's fast, lightweight model. Needs Copilot Pro.",
       },
-      "gemini-3-flash-preview": {
-        label: "Gemini 3 Flash",
+      "gemini-3.6-flash": {
+        label: "Gemini 3.6 Flash",
         description: "Google's fast model. Needs Copilot Pro.",
       },
     },

--- a/app/src/lib/providers.test.mjs
+++ b/app/src/lib/providers.test.mjs
@@ -64,7 +64,7 @@ const SAMPLE_CATALOG = [
     tm("claude-haiku-4.5", 200000),
     rm("gpt-5.5", 400000),
     rm("gpt-5-mini", 264000),
-    rm("gemini-3-flash-preview", 128000),
+    rm("gemini-3.6-flash", 128000),
   ]),
   prov("opencode", "apiKey", [
     rm("claude-sonnet-4-6", 1000000),
@@ -604,7 +604,7 @@ test("VISIBLE_MODELS curation filters the hydrated catalog per provider", () => 
   assert.equal(getProvider("github-copilot").models.length, 7);
   assert.ok(
     getProvider("github-copilot").models.some(
-      (m) => m.id === "gemini-3-flash-preview",
+      (m) => m.id === "gemini-3.6-flash",
     ),
   );
 });

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -19,8 +19,8 @@
     "typecheck": "tsgo -p tsconfig.json"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.83.0",
-    "@earendil-works/pi-coding-agent": "0.83.0",
+    "@earendil-works/pi-ai": "0.84.0",
+    "@earendil-works/pi-coding-agent": "0.84.0",
     "@executor-js/plugin-mcp": "1.5.37",
     "@executor-js/plugin-openapi": "1.5.37",
     "@executor-js/sdk": "1.5.37",

--- a/packages/host/src/credentials/oauth-token-exchange.ts
+++ b/packages/host/src/credentials/oauth-token-exchange.ts
@@ -92,7 +92,7 @@ function isPreConnectFailure(err: unknown): boolean {
 }
 
 /** A hung token endpoint would otherwise stall every credential serve. */
-const REFRESH_TIMEOUT_MS = 10_000;
+export const REFRESH_TIMEOUT_MS = 10_000;
 
 /**
  * The error code of an OAuth failure body, in either shape we see in the wild:

--- a/packages/host/src/credentials/refresh.ts
+++ b/packages/host/src/credentials/refresh.ts
@@ -2,6 +2,7 @@ import { githubCopilotProvider } from "@earendil-works/pi-ai/providers/github-co
 import { isApiKeyCredential, type WorkspaceCredential } from "../ports";
 import {
   exchangeRefreshToken,
+  REFRESH_TIMEOUT_MS,
   TransientRefreshError,
 } from "./oauth-token-exchange";
 
@@ -84,13 +85,18 @@ export async function refreshCredential(
     // at the company's GitHub: pi-ai hits `api.<domain>/copilot_internal/v2/token`
     // instead of github.com. Absent => individual Copilot. Preserve it on the
     // refreshed credential so the next refresh keeps targeting the same GHE.
-    const r = await copilotOAuth.refresh({
-      type: "oauth",
-      access: cred.accessToken,
-      refresh: cred.refreshToken,
-      expires: cred.expiresAt,
-      ...(cred.enterpriseUrl ? { enterpriseUrl: cred.enterpriseUrl } : {}),
-    });
+    const r = await copilotOAuth.refresh(
+      {
+        type: "oauth",
+        access: cred.accessToken,
+        refresh: cred.refreshToken,
+        expires: cred.expiresAt,
+        ...(cred.enterpriseUrl ? { enterpriseUrl: cred.enterpriseUrl } : {}),
+      },
+      // pi ≥0.84 requires a concrete abort signal; bound it like our own
+      // token exchange so a hung endpoint can't stall the credential serve.
+      AbortSignal.timeout(REFRESH_TIMEOUT_MS),
+    );
     return {
       workspaceId: cred.workspaceId,
       provider: cred.provider,

--- a/packages/host/src/turn/connect.ts
+++ b/packages/host/src/turn/connect.ts
@@ -122,6 +122,10 @@ export class ConnectManager {
 
     void oauth
       .login({
+        // pi ≥0.84 requires a concrete abort signal. Bound the poll loop to
+        // the bus state's TTL: the device code expires well before, and an
+        // orphaned flow (user never approves) must not poll forever.
+        signal: AbortSignal.timeout(STATE_TTL_SEC * 1000),
         prompt: async (p) => {
           // Headless: always the device-code path. The manual-code/text
           // prompts exist for other providers' flows and must never fire

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -13,8 +13,8 @@
     "typecheck": "tsgo -p tsconfig.json"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.83.0",
-    "@earendil-works/pi-coding-agent": "0.83.0",
+    "@earendil-works/pi-ai": "0.84.0",
+    "@earendil-works/pi-coding-agent": "0.84.0",
     "@google-cloud/storage": "7.21.0",
     "@houston/protocol": "workspace:*",
     "@houston/runtime-client": "workspace:*",

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -1,4 +1,7 @@
-import type { AuthInteraction, AuthPrompt } from "@earendil-works/pi-ai";
+import type {
+  AuthPrompt,
+  ProviderAuthInteraction,
+} from "@earendil-works/pi-ai";
 import type { LoginInfo } from "@houston/runtime-client";
 import {
   type CustomEndpointInput,
@@ -229,7 +232,7 @@ const known = (id: string): id is ProviderId => isProvider(id);
  */
 async function runProviderOAuthLogin(
   provider: ProviderId,
-  interaction: AuthInteraction,
+  interaction: ProviderAuthInteraction,
 ): Promise<void> {
   const oauth = modelRuntime.getProvider(provider)?.auth.oauth;
   if (!oauth) throw new Error(`${provider} has no OAuth sign-in flow`);
@@ -321,9 +324,10 @@ export async function startLogin(
     await preflightCodexCallbackPort();
   }
 
+  const abort = new AbortController();
   const state: LoginState = {
     status: "starting",
-    abort: new AbortController(),
+    abort,
   };
   active.set(key, state);
   armLoginExpiry(provider, state);
@@ -351,8 +355,8 @@ export async function startLogin(
   // - text (Copilot's opening GitHub-Enterprise question) → auto-answered,
   //   else it would deadlock the flow before the device code appears;
   // - manual_code → the client-relayed paste promise.
-  const interaction: AuthInteraction = {
-    signal: state.abort?.signal,
+  const interaction: ProviderAuthInteraction = {
+    signal: abort.signal,
     notify: (event) => {
       switch (event.type) {
         case "auth_url":

--- a/packages/runtime/src/session/compaction-guard.ts
+++ b/packages/runtime/src/session/compaction-guard.ts
@@ -123,9 +123,18 @@ export function makeCompactionGuard(
       }
 
       try {
-        // Same auth pi's own compaction resolves (model-registry).
+        // Same auth pi's own compaction resolves (model-registry). Since pi
+        // 0.84 the headers carry `null` deletion markers; pi's default path
+        // strips them before compact(), so the bounded path must too.
         const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
         if (!auth.ok || !auth.apiKey) return undefined;
+        const headers = auth.headers
+          ? Object.fromEntries(
+              Object.entries(auth.headers).filter(
+                (entry): entry is [string, string] => entry[1] !== null,
+              ),
+            )
+          : undefined;
         const bounded: Preparation = {
           ...prep,
           messagesToSummarize: history.kept,
@@ -135,7 +144,7 @@ export function makeCompactionGuard(
           bounded,
           model,
           auth.apiKey,
-          auth.headers,
+          headers,
           event.customInstructions,
           event.signal,
           undefined,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,11 +424,11 @@ importers:
   packages/host:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.83.0
-        version: 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: 0.84.0
+        version: 0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
-        specifier: 0.83.0
-        version: 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: 0.84.0
+        version: 0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@executor-js/plugin-mcp':
         specifier: 1.5.37
         version: 1.5.37(effect@4.0.0-beta.59)(ioredis@5.11.1)(react@19.2.7)(typeorm@0.3.30(ioredis@5.11.1))
@@ -507,11 +507,11 @@ importers:
   packages/runtime:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.83.0
-        version: 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: 0.83.0
-        version: 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@google-cloud/storage':
         specifier: 7.21.0
         version: 7.21.0
@@ -1508,22 +1508,34 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  '@earendil-works/pi-agent-core@0.83.0':
-    resolution: {integrity: sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g==}
+  '@earendil-works/pi-agent-core@0.84.0':
+    resolution: {integrity: sha512-L1lw0lwR5LXCzGEeHD9XNEruU2bg0H8clOA8ySdGMHvxutp8GC+yZL6MZp4tqQRnLKP3gHmY7TrWzQ3YnFdJYQ==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.83.0':
-    resolution: {integrity: sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.83.0':
-    resolution: {integrity: sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw==}
+  '@earendil-works/pi-ai@0.84.0':
+    resolution: {integrity: sha512-N9RDk8q0eglGiy+NqTZ3Ev2j+6oFNXSAJa8b0CYhvWB9HGiKZjsoCESXkUvMDLybrn0wXp75sdsoBzEtHxk9kA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-tui@0.83.0':
-    resolution: {integrity: sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA==}
+  '@earendil-works/pi-client@0.84.0':
+    resolution: {integrity: sha512-fHXgw1FdLDh+uw42SvTkJRBfgc3nsrslghvbRFEAxdjfcOxJt7hPsTj4HHNK96wMy1f+zvQYL8Y2znvFoZ8JDA==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-coding-agent@0.84.0':
+    resolution: {integrity: sha512-oxEU7BT9xuVT6UKNwUNDzNP5dVGb+DZRGfaEyMyAab8dRlqTSxxyhSlMAxmYsu//YOeasj9E8n2+px1BzIai0g==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-protocol@0.84.0':
+    resolution: {integrity: sha512-Fc28cCYGg5+aRnMzbAD7QAi6Xl//kbETyFroLHCs3Zf4oaXH9L2gzBqVLVAwrKIKeS0uffUrmihocGTECfKW6Q==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-telemetry@0.84.0':
+    resolution: {integrity: sha512-g6hLxEfAUk3zJlDmFWhWHJNcYXYiNGeWuJC9YkcHpkdkj0gxD4uaMNNNU3QsAEJXW9Qcxnl21+U8GfhVsc8C5g==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-tui@0.84.0':
+    resolution: {integrity: sha512-nbs0FeZJ5rWDD6VpKfXXmYbEHnHqb40V9glE2l9f8ftoWpsP8nw0WcXK8jOjfRsDPnT9dJHy3dItOHdn/AFGjA==}
     engines: {node: '>=22.19.0'}
 
   '@effect/platform-node-shared@4.0.0-beta.97':
@@ -5435,6 +5447,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  grok-mermaid@0.2.2:
+    resolution: {integrity: sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==}
+    engines: {node: '>=18'}
+
   gtoken@7.1.0:
     resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
     engines: {node: '>=14.0.0'}
@@ -7258,6 +7274,10 @@ packages:
     resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
 
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -8163,9 +8183,10 @@ snapshots:
       react: 19.2.7
       tslib: 2.8.1
 
-  '@earendil-works/pi-agent-core@0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+  '@earendil-works/pi-agent-core@0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
     dependencies:
-      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-telemetry': 0.84.0
       diff: 8.0.4
       ignore: 7.0.5
       typebox: 1.3.7
@@ -8178,9 +8199,10 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-agent-core@0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-telemetry': 0.84.0
       diff: 8.0.4
       ignore: 7.0.5
       typebox: 1.3.7
@@ -8193,10 +8215,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+  '@earendil-works/pi-ai@0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@earendil-works/pi-telemetry': 0.84.0
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))
       '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
@@ -8214,10 +8237,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@earendil-works/pi-telemetry': 0.84.0
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
       '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
@@ -8235,16 +8259,23 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+  '@earendil-works/pi-client@0.84.0':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
-      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
-      '@earendil-works/pi-tui': 0.83.0
+      '@earendil-works/pi-protocol': 0.84.0
+
+  '@earendil-works/pi-coding-agent@0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-client': 0.84.0
+      '@earendil-works/pi-protocol': 0.84.0
+      '@earendil-works/pi-tui': 0.84.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
       diff: 8.0.4
       glob: 13.0.6
+      grok-mermaid: 0.2.2
       highlight.js: 10.7.3
       hosted-git-info: 9.0.3
       ignore: 7.0.5
@@ -8253,7 +8284,7 @@ snapshots:
       proper-lockfile: 4.1.2
       semver: 7.8.0
       typebox: 1.3.7
-      undici: 8.5.0
+      undici: 8.9.0
       yaml: 2.9.0
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.9
@@ -8265,16 +8296,19 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.83.0
+      '@earendil-works/pi-agent-core': 0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-client': 0.84.0
+      '@earendil-works/pi-protocol': 0.84.0
+      '@earendil-works/pi-tui': 0.84.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
       diff: 8.0.4
       glob: 13.0.6
+      grok-mermaid: 0.2.2
       highlight.js: 10.7.3
       hosted-git-info: 9.0.3
       ignore: 7.0.5
@@ -8283,7 +8317,7 @@ snapshots:
       proper-lockfile: 4.1.2
       semver: 7.8.0
       typebox: 1.3.7
-      undici: 8.5.0
+      undici: 8.9.0
       yaml: 2.9.0
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.9
@@ -8295,7 +8329,13 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-tui@0.83.0':
+  '@earendil-works/pi-protocol@0.84.0':
+    dependencies:
+      typebox: 1.3.7
+
+  '@earendil-works/pi-telemetry@0.84.0': {}
+
+  '@earendil-works/pi-tui@0.84.0':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
@@ -12412,6 +12452,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  grok-mermaid@0.2.2: {}
+
   gtoken@7.1.0:
     dependencies:
       gaxios: 6.7.1
@@ -14689,6 +14731,8 @@ snapshots:
   undici@7.28.0: {}
 
   undici@8.5.0: {}
+
+  undici@8.9.0: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
## Summary

Updates both pi dependencies — `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` — from 0.83.0 to 0.84.0 in `packages/runtime` and `packages/host` (PRODUCT-1243), adapting the four call sites that pi 0.84's breaking changes actually touch.

## Breaking changes handled

- **`packages/runtime/src/auth/login.ts`** — provider OAuth `login()` now takes a `ProviderAuthInteraction` whose `signal` is a **required** `AbortSignal`. The login flow's own `AbortController` (already created per login for cancel/abandonment) is now threaded through as the concrete signal.
- **`packages/runtime/src/session/compaction-guard.ts`** — `ModelRegistry.getApiKeyAndHeaders()` now returns `ProviderHeaders` (`Record<string, string | null>`) preserving `null` header-deletion markers. The bounded-compaction guard strips the `null` markers before calling pi's `compact()` (which still takes `Record<string, string>`), mirroring exactly what pi's own default compaction path does internally (`withoutDeletedHeaders`).
- **`packages/host/src/credentials/refresh.ts`** — `OAuthAuth.refresh(credential, signal)` now requires an `AbortSignal`. The GitHub Copilot token exchange is bounded with the same 10s `REFRESH_TIMEOUT_MS` our own OAuth token exchange already uses (now exported from `oauth-token-exchange.ts`), so a hung endpoint can't stall the credential serve.
- **`packages/host/src/turn/connect.ts`** — the headless Codex device-code `oauth.login()` now requires a concrete signal. It's bounded to the connect flow's bus-state TTL (30 min; device codes expire well before), so an orphaned flow can no longer poll forever.

## Breaking changes verified NOT to apply

- `message_update` events now emit only `assistantMessageEvent` deltas (cumulative `message` / `assistantMessageEvent.partial` removed): Houston consumes pi **in-process** via `AgentSession.subscribe` and `backends/pi/wire.ts` already assembles deltas; the `partial` field in `host/src/turn/relay-dialect.ts` is Houston's own `ConversationSnapshot` field, unrelated.
- Provider refresh context (`context.stored` / `context.publish()`): no handwritten `refreshModels` or `context.store` access anywhere in runtime/host.
- `ModelRegistry.refresh()` / `ModelRuntime.setRuntimeApiKey()` signature changes: never called in production code (deliberately — see the comments in `auth/login.ts`).
- v4 session/`SessionRepo` overhaul and required `FileSystem.renameFile()`: the `SessionManager` surface Houston uses is unchanged, and Houston implements no custom pi `FileSystem`.
- `ModelsStreamTransforms` → `ModelsRequestTransforms`: not referenced.

## Verification

Before the fix (on `main`): `pnpm install` with the deps at 0.84.0 fails `pnpm --filter @houston/runtime typecheck` (2 errors: `login.ts` interaction signal, `compaction-guard.ts` `ProviderHeaders`) and `pnpm --filter @houston/host typecheck` (2 errors: `refresh.ts` arity, `connect.ts` missing `signal`).

After this branch, all gates pass locally:
- `pnpm --filter @houston/runtime test` — 110 files, 1011 tests ✅
- `pnpm --filter @houston/host test` — 146 files, 1286 tests ✅
- `pnpm --filter @houston/domain test` — 16 files, 191 tests ✅
- `pnpm typecheck` (all 27 workspace projects, incl. app + web shim parity) ✅
- `pnpm check` (Biome) ✅
- `pnpm check:boundaries` ✅

Manual smoke: `pnpm dev`, then run a chat turn (delta streaming + tool calls through `wire.ts`), a `/compact` on a long conversation, a Codex device-code connect, and a Copilot-credentialed turn past the ~25-min token expiry to exercise the central refresh.

Note for release: this bump touches `packages/{runtime,host}` + `pnpm-lock.yaml`, so the next release build requires a fresh host sidecar (`scripts/build-host-sidecar.sh`) — the stamp guard enforces this. Per the gateway-catalog contract, the pi bump rides the engine roll; no cloud-repo PR needed.