### PR TITLE
fix(app): setup chats open on a connected provider, not the stored one (PRODUCT-1236)

### DIFF
--- a/app/src/components/integrations/use-integration-chat-setup.ts
+++ b/app/src/components/integrations/use-integration-chat-setup.ts
@@ -1,9 +1,11 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useActivity, useAllConversations } from "../../hooks/queries";
+import { useConnectedProviders } from "../../hooks/use-connected-providers";
 import { readAgentModelOverrides } from "../../lib/agent-model-overrides";
 import { analytics } from "../../lib/analytics";
+import { connectedProviderIds } from "../../lib/connected-providers";
 import { createMission } from "../../lib/create-mission";
 import { genericErrorDescription } from "../../lib/error-report";
 import {
@@ -42,6 +44,13 @@ export function useIntegrationChatSetup() {
   const agents = useAgentStore((s) => s.agents);
   const getAgentDef = useAgentCatalogStore((s) => s.getById);
   const [pending, setPending] = useState(false);
+  // The kickoff runs on a provider the user is actually signed into, never on
+  // an agent-configured one they never connected (PRODUCT-1236). `null` = the
+  // scan could not confirm, so the pin defers to the stored provider. A ref, so
+  // `start` reads the latest scan without being re-created on every refetch
+  // (the derived list is a fresh array each render).
+  const connectedProvidersRef = useRef<readonly string[] | null>(null);
+  connectedProvidersRef.current = connectedProviderIds(useConnectedProviders());
 
   const paths = useMemo(() => agents.map((a) => a.folderPath), [agents]);
 
@@ -139,10 +148,12 @@ export function useIntegrationChatSetup() {
             modeOverride: DEFAULT_TURN_MODE,
             // Pin the agent's configured brain onto the kickoff turn — an
             // unpinned send resolves inside the runtime and lands on the
-            // provider default (Sonnet), not the model the user picked.
+            // provider default (Sonnet), not the model the user picked — gated
+            // on the providers the user has actually connected.
             ...(await readAgentModelOverrides(
               agent.folderPath,
               tauriConfig.read,
+              connectedProvidersRef.current,
             )),
             buildPrompt: () => encodeIntegrationSetupMessage(),
           },

--- a/app/src/components/tabs/routine-run-overrides.ts
+++ b/app/src/components/tabs/routine-run-overrides.ts
@@ -9,10 +9,19 @@ import { DEFAULT_TURN_MODE } from "../../lib/turn-mode";
  * unpinned send resolves inside the runtime and lands on the provider default
  * (Sonnet), not their choice. Shared by every setup-chat start so the pin is
  * applied identically.
+ *
+ * `connected` is REQUIRED (never optional): a kickoff that cannot say which
+ * providers the user is signed into is exactly the bug PRODUCT-1236 reported —
+ * the pin then lands on the agent's stored provider even when the user never
+ * connected it. Pass the confirmed set, or `null` when it could not be
+ * confirmed (see `useConnectedProviders`).
  */
-export async function readAgentRunOverrides(path: string) {
+export async function readAgentRunOverrides(
+  path: string,
+  connected: readonly string[] | null,
+) {
   return {
     modeOverride: DEFAULT_TURN_MODE,
-    ...(await readAgentModelOverrides(path, tauriConfig.read)),
+    ...(await readAgentModelOverrides(path, tauriConfig.read, connected)),
   };
 }

--- a/app/src/components/tabs/use-routine-chat-setup.ts
+++ b/app/src/components/tabs/use-routine-chat-setup.ts
@@ -4,14 +4,10 @@ import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useActivity } from "../../hooks/queries";
 import { useCapabilities } from "../../hooks/use-capabilities";
-import { useProviderStatuses } from "../../hooks/use-provider-statuses";
+import { useConnectedProviders } from "../../hooks/use-connected-providers";
 import { analytics } from "../../lib/analytics";
+import { connectedProviderIds } from "../../lib/connected-providers";
 import { createMission } from "../../lib/create-mission";
-import {
-  providerConnectionState,
-  providerIsConnected,
-} from "../../lib/provider-connection";
-import { providerName } from "../../lib/providers";
 import { queryKeys } from "../../lib/query-keys";
 import {
   encodeRoutineModifyMessage,
@@ -54,31 +50,15 @@ export function useRoutineChatSetup(
   const missionTitle = t("setupChat.missionTitle");
 
   // The kickoffs name the user's connected providers so the agent never pins
-  // a routine to one that isn't (e.g. "use deepseek" with no DeepSeek login).
-  // While statuses are still loading, `null` keeps the prompt generic instead
-  // of wrongly claiming nothing is connected — and so does an UNCONFIRMABLE
-  // probe (HOU-979): "we could not check" is not "nothing is connected", so it
-  // defers to the generic prompt rather than naming a partial list as if it
-  // were the whole truth. Membership itself is the ONE shared derivation.
-  //
-  // A FAILED probe (HOU-1153) is the same "we could not check", and it arrives
-  // with NO statuses rather than a map of `unknown`s — so it must defer through
-  // `isError`, or an empty map would be handed to the kickoff as a confident
-  // "you have nothing connected".
-  const providerStatuses = useProviderStatuses();
-  const statusValues = Object.values(providerStatuses.statuses);
-  const statusesUnconfirmable = statusValues.some(
-    (s) => providerConnectionState(s, false) === "checking",
-  );
+  // a routine to one that isn't (e.g. "use deepseek" with no DeepSeek login),
+  // and the SAME set decides which provider the kickoff turn itself runs on
+  // (PRODUCT-1236) — an agent configured for a provider the user never
+  // connected must not open its setup chat there. `null` (still loading,
+  // failed, or unconfirmable) keeps both decisions deferred rather than
+  // claiming nothing is connected; the derivation is shared
+  // (`confirmedConnectedProviders`).
   const connectedProvidersRef = useRef<ConnectedProviderRef[] | null>(null);
-  connectedProvidersRef.current =
-    providerStatuses.isLoading ||
-    providerStatuses.isError ||
-    statusesUnconfirmable
-      ? null
-      : statusValues
-          .filter((s) => providerIsConnected(s))
-          .map((s) => ({ id: s.provider, name: providerName(s.provider) }));
+  connectedProvidersRef.current = useConnectedProviders();
 
   // Every unlinked, live create-chat for this agent — a person can be building
   // several at once (legacy reaction drafts included).
@@ -115,8 +95,12 @@ export function useRoutineChatSetup(
         const { conversationId } = await createMission(agent, "", {
           title: missionTitle,
           agentMode: mode,
-          // Pin the agent's configured brain onto the kickoff turn (see helper).
-          ...(await readAgentRunOverrides(path)),
+          // Pin the agent's configured brain onto the kickoff turn, gated on
+          // what the user has actually connected (see helper).
+          ...(await readAgentRunOverrides(
+            path,
+            connectedProviderIds(connectedProvidersRef.current),
+          )),
           // Setup chats always run as Ask first: the interview needs ask_user
           // (auto strips it) and must never open read-only in Planner.
           modeOverride: "execute",
@@ -162,7 +146,10 @@ export function useRoutineChatSetup(
             agentMode: mode,
             // Same brain pin as startDraft (see readAgentRunOverrides), and the
             // same Ask first pin — setup chats are interactive by design.
-            ...(await readAgentRunOverrides(path)),
+            ...(await readAgentRunOverrides(
+              path,
+              connectedProviderIds(connectedProvidersRef.current),
+            )),
             modeOverride: "execute",
           },
         );

--- a/app/src/components/tabs/use-skill-chat-setup.ts
+++ b/app/src/components/tabs/use-skill-chat-setup.ts
@@ -2,7 +2,9 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useActivity } from "../../hooks/queries";
+import { useConnectedProviders } from "../../hooks/use-connected-providers";
 import { analytics } from "../../lib/analytics";
+import { connectedProviderIds } from "../../lib/connected-providers";
 import { createMission } from "../../lib/create-mission";
 import { skillDisplayTitle } from "../../lib/humanize-skill-name";
 import { logger } from "../../lib/logger";
@@ -43,6 +45,14 @@ export function useSkillChatSetup(
   const { data: rawItems } = useActivity(path);
   const [pending, setPending] = useState(false);
   const shareNewSkill = useOrgSkillDefault(agent);
+
+  // Which providers the user is actually signed into — the kickoff turn must
+  // run on one of them, never on an agent-configured provider they never
+  // connected (PRODUCT-1236). `null` = could not confirm, so the pin defers to
+  // the stored provider. Held in a ref so the start callbacks read the latest
+  // scan without re-creating on every status refetch.
+  const connectedProvidersRef = useRef<readonly string[] | null>(null);
+  connectedProvidersRef.current = connectedProviderIds(useConnectedProviders());
 
   const mode = SKILL_SETUP_AGENT_MODE;
   const missionTitle = t("setupChat.missionTitle");
@@ -122,8 +132,9 @@ export function useSkillChatSetup(
       const { conversationId } = await createMission(agent, "", {
         title: missionTitle,
         agentMode: mode,
-        // Pin the agent's configured brain onto the kickoff turn (see helper).
-        ...(await readAgentRunOverrides(path)),
+        // Pin the agent's configured brain onto the kickoff turn, gated on
+        // what the user has actually connected (see helper).
+        ...(await readAgentRunOverrides(path, connectedProvidersRef.current)),
         // Setup chats always run as Ask first: the interview needs ask_user
         // (auto strips it) and must never open read-only in Planner.
         modeOverride: "execute",
@@ -165,7 +176,10 @@ export function useSkillChatSetup(
             agentMode: mode,
             // Same brain pin as startDraft, and the same Ask first pin —
             // setup chats are interactive by design.
-            ...(await readAgentRunOverrides(path)),
+            ...(await readAgentRunOverrides(
+              path,
+              connectedProvidersRef.current,
+            )),
             modeOverride: "execute",
           },
         );

--- a/app/src/hooks/use-connected-providers.ts
+++ b/app/src/hooks/use-connected-providers.ts
@@ -1,0 +1,13 @@
+import { confirmedConnectedProviders } from "../lib/connected-providers";
+import type { ConnectedProviderRef } from "../lib/setup-chat-prompt-shared";
+import { useProviderStatuses } from "./use-provider-statuses";
+
+/**
+ * The user's confirmed connected providers, or `null` while that cannot be
+ * confirmed (see `confirmedConnectedProviders`). Reads the shared provider-status
+ * query, so mounting this in several setup surfaces costs no extra round-trip.
+ */
+export function useConnectedProviders(): ConnectedProviderRef[] | null {
+  const { statuses, isLoading, isError } = useProviderStatuses();
+  return confirmedConnectedProviders({ statuses, isLoading, isError });
+}

--- a/app/src/lib/agent-model-overrides.ts
+++ b/app/src/lib/agent-model-overrides.ts
@@ -10,12 +10,14 @@
  * provider default (Sonnet). The config only reaches a turn as the pins each
  * send forwards, which is exactly what the chat panel's `effectiveProvider` /
  * `effectiveModel` do; this is the same resolution for kickoffs created
- * outside a panel.
+ * outside a panel — INCLUDING the panel's auth gate, so a kickoff never opens
+ * on a provider the user has not connected (PRODUCT-1236).
  */
 
 import {
   getDefaultModel,
   normalizeLegacyModel,
+  PROVIDERS,
   validEffortOrDefault,
   validModelOrNull,
   validProviderOrNull,
@@ -34,25 +36,66 @@ interface BrainConfig {
 }
 
 /**
+ * The provider a kickoff may actually run on (PRODUCT-1236).
+ *
+ * A setup chat's kickoff is a FRESH, message-less turn, so it follows the chat
+ * composer's initial-selection rule (`resolveEffectiveProvider` case 2): the
+ * configured provider is honored only while the user is signed into it,
+ * otherwise the turn opens on a provider they ARE signed into. A pin is never
+ * auth-gated downstream — the runtime honors `providerOverride` verbatim and
+ * surfaces a provider error rather than switching — so pinning the agent's
+ * stored `anthropic` for an OpenAI-only user is what made every routine/skill
+ * creation chat open on a provider they never connected.
+ *
+ * `connected === null` means the scan could not confirm anything (still
+ * loading, failed, or an unconfirmable probe): defer to the stored provider
+ * rather than switch on a guess. A confirmed-empty set has nothing better to
+ * offer, so the stored provider stands and its sign-in error is the surface.
+ */
+function usableProvider(
+  configured: string | null,
+  connected: readonly string[] | null,
+): string | null {
+  if (!connected) return configured;
+  if (configured && connected.includes(configured)) return configured;
+  // Registry order, not scan order, so the substitute is deterministic
+  // regardless of how the caller enumerated statuses.
+  return PROVIDERS.find((p) => connected.includes(p.id))?.id ?? configured;
+}
+
+/**
  * Resolve the kickoff pins from a loaded agent config, mirroring the chat
- * panel's chain: a stored provider counts only while it's still offered; the
- * stored model (legacy aliases normalized) must belong to it, else the
- * provider's catalog default; effort is clamped to what that model accepts.
- * No valid stored provider → no pins at all, so the runtime resolves the turn
- * exactly as before (its active provider), never a half-pin the runtime would
- * reject.
+ * panel's chain: a stored provider counts only while it's still offered AND the
+ * user is signed into it (see `usableProvider`); the stored model (legacy
+ * aliases normalized) must belong to it, else the provider's catalog default;
+ * effort is clamped to what that model accepts. Nothing to pin → no pins at
+ * all, so the runtime resolves the turn exactly as before (its active
+ * provider), never a half-pin the runtime would reject.
+ *
+ * When the stored provider is signed out and another one is connected, the pin
+ * moves to that provider WHOLE: the stored model and effort belong to the
+ * provider the user left behind, so the substitute takes its own catalog
+ * default instead of carrying a model the new provider cannot run.
+ *
+ * @param connected provider ids the user is confirmed signed into, or `null`
+ *   when that could not be confirmed (see `confirmedConnectedProviders`).
  */
 export function resolveAgentModelOverrides(
   cfg: BrainConfig,
+  connected: readonly string[] | null = null,
 ): AgentModelOverrides {
-  const provider = validProviderOrNull(cfg.provider);
+  const configured = validProviderOrNull(cfg.provider);
+  const provider = usableProvider(configured, connected);
   if (!provider) return {};
+  const stored = provider === configured;
   const model =
-    validModelOrNull(provider, normalizeLegacyModel(cfg.model)) ??
-    getDefaultModel(provider);
-  const effort = cfg.effort
-    ? validEffortOrDefault(provider, model, cfg.effort)
-    : undefined;
+    (stored
+      ? validModelOrNull(provider, normalizeLegacyModel(cfg.model))
+      : null) ?? getDefaultModel(provider);
+  const effort =
+    stored && cfg.effort
+      ? validEffortOrDefault(provider, model, cfg.effort)
+      : undefined;
   return {
     providerOverride: provider,
     modelOverride: model,
@@ -62,16 +105,17 @@ export function resolveAgentModelOverrides(
 
 /**
  * Read + resolve in one step for send paths that need the configured brain.
- * A failed config read falls back to no pins; the send itself still surfaces
- * its own errors.
+ * A failed config read falls back to the connected provider (or no pins when
+ * there is none); the send itself still surfaces its own errors.
  */
 export async function readAgentModelOverrides(
   agentPath: string,
   readConfig: (path: string) => Promise<BrainConfig>,
+  connected: readonly string[] | null = null,
 ): Promise<AgentModelOverrides> {
   try {
-    return resolveAgentModelOverrides(await readConfig(agentPath));
+    return resolveAgentModelOverrides(await readConfig(agentPath), connected);
   } catch {
-    return {};
+    return resolveAgentModelOverrides({}, connected);
   }
 }

--- a/app/src/lib/connected-providers.ts
+++ b/app/src/lib/connected-providers.ts
@@ -1,0 +1,61 @@
+/**
+ * "Which providers has this user actually connected?" as ONE derivation, for
+ * the surfaces that must answer it outside a chat panel (the routine, skill and
+ * custom-integration setup-chat kickoffs).
+ *
+ * The answer is deliberately three-valued, and `null` is the load-bearing case:
+ * a scan that is still loading (`isLoading`), that FAILED (`isError` — an
+ * unreachable engine resolves every provider as `unknown`, HOU-1153), or that
+ * carries any unconfirmable probe (HOU-979) is NOT evidence that nothing is
+ * connected. Handing an empty list to a caller in that state would let it act
+ * on a fabricated "you have nothing connected"; `null` says "we could not
+ * check", and every caller must defer rather than switch.
+ */
+
+import {
+  type ProviderConnectionStatus,
+  providerConnectionState,
+  providerIsConnected,
+} from "./provider-connection.ts";
+import { providerName } from "./providers.ts";
+import type { ConnectedProviderRef } from "./setup-chat-prompt-shared.ts";
+
+/** A status row as the provider scan reports it (id + the connection fields). */
+export interface ScannedProviderStatus extends ProviderConnectionStatus {
+  provider: string;
+}
+
+/** The provider scan's result, exactly as `useProviderStatuses` returns it. */
+export interface ProviderScan {
+  statuses: Record<string, ScannedProviderStatus>;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+/**
+ * The user's CONFIRMED connected providers, or `null` when the scan cannot
+ * answer (see the module doc). Order follows the scan so the kickoff prompts
+ * keep listing providers as the engine reported them.
+ */
+export function confirmedConnectedProviders(
+  scan: ProviderScan,
+): ConnectedProviderRef[] | null {
+  const values = Object.values(scan.statuses);
+  const unconfirmable = values.some(
+    (status) => providerConnectionState(status, false) === "checking",
+  );
+  if (scan.isLoading || scan.isError || unconfirmable) return null;
+  return values
+    .filter((status) => providerIsConnected(status))
+    .map((status) => ({
+      id: status.provider,
+      name: providerName(status.provider),
+    }));
+}
+
+/** The ids of a (possibly unconfirmable) connected set, preserving `null`. */
+export function connectedProviderIds(
+  connected: readonly ConnectedProviderRef[] | null,
+): string[] | null {
+  return connected ? connected.map((provider) => provider.id) : null;
+}

--- a/app/tests/agent-model-overrides.test.ts
+++ b/app/tests/agent-model-overrides.test.ts
@@ -4,7 +4,10 @@ import {
   readAgentModelOverrides,
   resolveAgentModelOverrides,
 } from "../src/lib/agent-model-overrides.ts";
-import { hydrateProviderCatalog } from "../src/lib/providers.ts";
+import {
+  getDefaultModel,
+  hydrateProviderCatalog,
+} from "../src/lib/providers.ts";
 import { SAMPLE_CATALOG } from "./fixtures/sample-catalog.ts";
 
 before(() => hydrateProviderCatalog(SAMPLE_CATALOG));
@@ -68,6 +71,91 @@ describe("resolveAgentModelOverrides", () => {
   });
 });
 
+// PRODUCT-1236: a setup-chat kickoff is a fresh, message-less turn, so it must
+// follow the composer's initial-selection rule and never open on a provider the
+// user has not connected. A pin is honored verbatim downstream, so an
+// unconnected one is a guaranteed provider error, not a silent switch.
+describe("resolveAgentModelOverrides + connected providers", () => {
+  it("moves the pin to a connected provider when the configured one is signed out (the reported bug: OpenAI-only user, agent configured for Anthropic)", () => {
+    const pins = resolveAgentModelOverrides(
+      { provider: "anthropic", model: "claude-opus-4-8" },
+      ["openai"],
+    );
+    strictEqual(pins.providerOverride, "openai");
+    // The substitute takes its OWN default — the stored model belongs to the
+    // provider the user never connected.
+    strictEqual(pins.modelOverride, getDefaultModel("openai"));
+  });
+
+  it("drops a stored effort when the pin moves (it was clamped for the other provider's model)", () => {
+    const pins = resolveAgentModelOverrides(
+      { provider: "anthropic", model: "claude-opus-4-8", effort: "high" },
+      ["openai"],
+    );
+    strictEqual(pins.providerOverride, "openai");
+    strictEqual(pins.effortOverride, undefined);
+  });
+
+  it("keeps the configured provider when the user IS connected to it", () => {
+    deepStrictEqual(
+      resolveAgentModelOverrides(
+        { provider: "anthropic", model: "claude-opus-4-8" },
+        ["openai", "anthropic"],
+      ),
+      { providerOverride: "anthropic", modelOverride: "claude-opus-4-8" },
+    );
+  });
+
+  it("picks the substitute in registry order, not scan order", () => {
+    const first = resolveAgentModelOverrides({ provider: "anthropic" }, [
+      "deepseek",
+      "openai",
+    ]);
+    const reversed = resolveAgentModelOverrides({ provider: "anthropic" }, [
+      "openai",
+      "deepseek",
+    ]);
+    strictEqual(first.providerOverride, reversed.providerOverride);
+  });
+
+  it("pins a connected provider even when the config names none (never leave the turn to the runtime's Sonnet default)", () => {
+    const pins = resolveAgentModelOverrides({}, ["openai"]);
+    strictEqual(pins.providerOverride, "openai");
+    strictEqual(pins.modelOverride, getDefaultModel("openai"));
+  });
+
+  it("defers to the configured provider when connectivity is unconfirmable (null is not 'nothing is connected')", () => {
+    deepStrictEqual(
+      resolveAgentModelOverrides(
+        { provider: "anthropic", model: "claude-opus-4-8" },
+        null,
+      ),
+      { providerOverride: "anthropic", modelOverride: "claude-opus-4-8" },
+    );
+  });
+
+  it("keeps the configured provider when nothing at all is connected (its sign-in error is the surface)", () => {
+    deepStrictEqual(
+      resolveAgentModelOverrides(
+        { provider: "anthropic", model: "claude-opus-4-8" },
+        [],
+      ),
+      { providerOverride: "anthropic", modelOverride: "claude-opus-4-8" },
+    );
+  });
+
+  it("still yields no pins when nothing is configured and nothing is connected", () => {
+    deepStrictEqual(resolveAgentModelOverrides({}, []), {});
+  });
+
+  it("substitutes for a provider Houston no longer offers, too", () => {
+    const pins = resolveAgentModelOverrides({ provider: "gemini-cli" }, [
+      "openai",
+    ]);
+    strictEqual(pins.providerOverride, "openai");
+  });
+});
+
 describe("readAgentModelOverrides", () => {
   it("reads the config and resolves it", async () => {
     const pins = await readAgentModelOverrides("/a", async (path) => {
@@ -80,6 +168,15 @@ describe("readAgentModelOverrides", () => {
     });
   });
 
+  it("forwards the connected set to the resolver", async () => {
+    const pins = await readAgentModelOverrides(
+      "/a",
+      async () => ({ provider: "anthropic", model: "claude-opus-4-8" }),
+      ["openai"],
+    );
+    strictEqual(pins.providerOverride, "openai");
+  });
+
   it("falls back to no pins when the config read fails", async () => {
     deepStrictEqual(
       await readAgentModelOverrides("/a", async () => {
@@ -87,5 +184,12 @@ describe("readAgentModelOverrides", () => {
       }),
       {},
     );
+  });
+
+  it("falls back to a connected provider when the config read fails", async () => {
+    const pins = await readAgentModelOverrides("/a", async () => {
+      throw new Error("boom");
+    }, ["openai"]);
+    strictEqual(pins.providerOverride, "openai");
   });
 });

--- a/app/tests/connected-providers.test.ts
+++ b/app/tests/connected-providers.test.ts
@@ -1,0 +1,97 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { before, describe, it } from "node:test";
+import {
+  confirmedConnectedProviders,
+  connectedProviderIds,
+  type ScannedProviderStatus,
+} from "../src/lib/connected-providers.ts";
+import { hydrateProviderCatalog } from "../src/lib/providers.ts";
+import { SAMPLE_CATALOG } from "./fixtures/sample-catalog.ts";
+
+before(() => hydrateProviderCatalog(SAMPLE_CATALOG));
+
+function status(
+  provider: string,
+  auth_state: ScannedProviderStatus["auth_state"],
+): ScannedProviderStatus {
+  return { provider, cli_installed: true, auth_state };
+}
+
+function scan(
+  statuses: ScannedProviderStatus[],
+  flags: { isLoading?: boolean; isError?: boolean } = {},
+) {
+  return {
+    statuses: Object.fromEntries(statuses.map((s) => [s.provider, s])),
+    isLoading: flags.isLoading ?? false,
+    isError: flags.isError ?? false,
+  };
+}
+
+describe("confirmedConnectedProviders", () => {
+  it("returns only the confirmed-authenticated providers", () => {
+    deepStrictEqual(
+      confirmedConnectedProviders(
+        scan([
+          status("openai", "authenticated"),
+          status("anthropic", "unauthenticated"),
+        ]),
+      )?.map((p) => p.id),
+      ["openai"],
+    );
+  });
+
+  it("returns an empty list when the scan settled with nothing connected", () => {
+    deepStrictEqual(
+      confirmedConnectedProviders(scan([status("openai", "unauthenticated")])),
+      [],
+    );
+  });
+
+  it("returns null while the scan is still loading", () => {
+    strictEqual(
+      confirmedConnectedProviders(scan([], { isLoading: true })),
+      null,
+    );
+  });
+
+  it("returns null when the scan failed (HOU-1153: not 'nothing is connected')", () => {
+    strictEqual(
+      confirmedConnectedProviders(
+        scan([status("openai", "authenticated")], { isError: true }),
+      ),
+      null,
+    );
+  });
+
+  it("returns null when ANY probe is unconfirmable (HOU-979)", () => {
+    strictEqual(
+      confirmedConnectedProviders(
+        scan([
+          status("openai", "authenticated"),
+          status("anthropic", "unknown"),
+        ]),
+      ),
+      null,
+    );
+  });
+
+  it("names each provider for the kickoff prompts", () => {
+    const connected = confirmedConnectedProviders(
+      scan([status("anthropic", "authenticated")]),
+    );
+    strictEqual(!!connected?.[0]?.name.length, true);
+  });
+});
+
+describe("connectedProviderIds", () => {
+  it("maps refs to ids", () => {
+    deepStrictEqual(connectedProviderIds([{ id: "openai", name: "ChatGPT" }]), [
+      "openai",
+    ]);
+  });
+
+  it("preserves the unconfirmable null rather than collapsing it to an empty list", () => {
+    strictEqual(connectedProviderIds(null), null);
+  });
+});

--- a/app/tests/provider-statuses-gate.test.ts
+++ b/app/tests/provider-statuses-gate.test.ts
@@ -280,16 +280,31 @@ describe("the picker hook is actually wired to the gate", () => {
     // The throw replaces a map of `unknown`s with no statuses at all. Consumers
     // that read "somebody is checking" as "do not act yet" would otherwise see
     // an empty map and act on it as a confident "nothing is connected" — the
-    // migration reconnect card firing at a user who IS connected, and the
-    // routine kickoff prompt telling the agent the user has no providers.
+    // migration reconnect card firing at a user who IS connected, and the setup
+    // chats telling the agent the user has no providers (and PRODUCT-1236,
+    // switching their kickoff off the configured provider on that same
+    // fabricated evidence).
     for (const path of [
       "../src/hooks/use-migration-reconnect.ts",
-      "../src/components/tabs/use-routine-chat-setup.ts",
+      // The ONE derivation the setup chats read through (`useConnectedProviders`).
+      "../src/lib/connected-providers.ts",
     ]) {
       strictEqual(
         /isError/.test(read(path)),
         true,
         `${path} defers on isError`,
+      );
+    }
+    // ...and the setup chats must go through it rather than re-deriving.
+    for (const path of [
+      "../src/components/tabs/use-routine-chat-setup.ts",
+      "../src/components/tabs/use-skill-chat-setup.ts",
+      "../src/components/integrations/use-integration-chat-setup.ts",
+    ]) {
+      strictEqual(
+        read(path).includes("useConnectedProviders"),
+        true,
+        `${path} reads the shared connected-provider derivation`,
       );
     }
   });


### PR DESCRIPTION
## Root cause

The routine, skill and custom-integration **creation chats** pin their kickoff turn to the agent's stored brain (`.houston/config/config.json`) via `readAgentModelOverrides` — but that resolver only validated the stored provider against the *catalog*, never against what the user is actually signed into.

A pin is honored verbatim downstream: `resolveModel(override, providerOverride)` in the runtime (and `resolveCloudTurn` server-side) deliberately never auth-gates a pin — a disconnected pin surfaces as *this turn's provider error*, never a silent switch. So an agent whose config still said `anthropic` opened every creation chat on Anthropic for a user who had only connected OpenAI. Worse, `createMission` stamps the same pin onto the activity row, and `activityProvider` then wins the composer's preference chain for the life of that chat.

The chat composer already gets this right for a fresh, message-less conversation (`resolveEffectiveProvider` case 2, the #483 fix): honor the preferred provider only while it's authenticated, else open on one the user IS signed into. A kickoff is exactly that case — it just builds its pin before any panel exists, so it bypassed the gate.

## The fix

- `resolveAgentModelOverrides` / `readAgentModelOverrides` take the confirmed-connected provider set. When the stored provider is confirmed signed out and another one is connected, the pin moves to that provider **whole** — its own catalog default model, and the stored effort dropped (both belonged to the provider the user never connected). Substitute picked in registry order, so it is deterministic regardless of scan order.
- Unconfirmable connectivity is `null`, not `[]`: still loading, a failed probe (HOU-1153), or any `unknown` status (HOU-979) defers to the stored provider rather than switching on fabricated evidence. Nothing connected at all also keeps the stored provider — its sign-in error is the honest surface.
- `readAgentRunOverrides` takes the set as a **required** argument, so a new setup chat cannot silently reintroduce the bug.
- One shared derivation (`lib/connected-providers.ts` + `useConnectedProviders`) replaces the copy `use-routine-chat-setup` had inline; the skill and custom-integration chats — same seam, same defect — now read it too. It is the same set the routine kickoff prompt already names to the agent.

## Verification

**Before (reproduces the bug), on `main`:**
1. Connect only OpenAI/ChatGPT in AI Models; make sure Anthropic is signed out.
2. Set an agent's brain to Anthropic in the model picker (or use an agent created while Anthropic was the default — check `~/.houston/workspaces/<ws>/<Agent>/.houston/config/config.json` says `"provider": "anthropic"`).
3. Automations tab → **New routine** (and Skills → **Create with AI**, and Integrations → **Add custom integration**).
4. The chat opens pinned to Anthropic and the kickoff turn fails with an Anthropic provider/sign-in error card, on a provider the user never connected.

**After (this branch):**
1. Same setup, steps 1–3.
2. Each setup chat opens on OpenAI (composer shows the connected provider; the activity row is stamped with it) and the kickoff interview runs.
3. Sign into Anthropic as well and start another chat: it opens on Anthropic again — a connected configured provider is still honored.
4. With the engine unreachable (statuses unconfirmable), the pin still falls back to the configured provider — no guessing.

**Automated:** `cd app && pnpm test` (2745 pass; new cases in `app/tests/agent-model-overrides.test.ts` + `app/tests/connected-providers.test.ts`), `pnpm typecheck` (all 27 projects), `pnpm check`.

## Known remaining symptom (not in this PR)

The issue also reports that after manually switching to OpenAI the conversation does not continue automatically, and prompting it to continue loses the earlier context. That is a distinct failure of the *errored-turn recovery* path and needs a live repro against a running engine to diagnose without guessing. This fix removes its trigger for the reported scenario (the chat no longer opens on a disconnected provider in the first place); if it still reproduces after a deliberate mid-chat provider switch, it deserves its own issue.