### PR TITLE
fix(app): the shared detail panel closes with the tab that opened it (PRODUCT-1229)

### DIFF
--- a/app/src/components/board/mission-control-archived.tsx
+++ b/app/src/components/board/mission-control-archived.tsx
@@ -9,7 +9,7 @@ import { useUIStore } from "../../stores/ui";
 import { useAttachmentRejectionDialog } from "../attachment-rejection-dialog";
 import { MissionControlToolbar } from "../mission-control-toolbar";
 import { AgentPanelAvatar } from "../shell/agent-panel-avatar";
-import { useDetailPanelContainer } from "../shell/detail-panel-context";
+import { useShellDetailPanel } from "../shell/use-shell-detail-panel";
 import { ArchivedEmptyState } from "../tabs/archived-empty-state";
 import { useAgentChatPanel } from "../use-agent-chat-panel";
 import { useMissionSearch } from "../use-mission-search";
@@ -31,9 +31,8 @@ export function MissionControlArchived({
   onShowActive: () => void;
 }) {
   const { t } = useTranslation("board");
-  const panelContainer = useDetailPanelContainer();
+  const { panelContainer, setPanelOpen } = useShellDetailPanel();
   const addToast = useUIStore((s) => s.addToast);
-  const setMissionPanelOpen = useUIStore((s) => s.setMissionPanelOpen);
   const missionPanelOpen = useUIStore((s) => s.missionPanelOpen);
 
   const data = useMissionControlArchived(agents);
@@ -143,7 +142,7 @@ export function MissionControlArchived({
               isSearchingText={missionSearch.isSearchingText}
             />
           }
-          onPanelOpenChange={setMissionPanelOpen}
+          onPanelOpenChange={setPanelOpen}
           onOpenLink={openHref}
           onNotice={(message) => addToast({ title: message })}
           prepareAttachments={attachmentValidation.prepareAttachments}

--- a/app/src/components/shell/detail-panel-owners.ts
+++ b/app/src/components/shell/detail-panel-owners.ts
@@ -1,0 +1,28 @@
+/**
+ * Ownership bookkeeping for the ONE shell-level detail panel.
+ *
+ * Every surface that renders the panel (the Activity board, the Routines chat,
+ * the per-agent and Mission Control Archived lists, the skill / integration
+ * setup chats) portals into the SAME container, and all of them stay MOUNTED
+ * while hidden — agent tabs are only CSS-hidden, top-level screens are kept
+ * alive. A single shared "panel is open" boolean therefore has last-writer-wins
+ * semantics with no writer left to correct it: the tab the user navigates AWAY
+ * from keeps its `true` on the flag while it stops portaling anything in, and
+ * the shell paints an empty card next to the board (PRODUCT-1229).
+ *
+ * A claim SET fixes both halves at once. A surface that leaves releases only
+ * its own id, so it can never clobber the surface the user just navigated to
+ * (the reason the Routines tab used to skip the release entirely), and the
+ * panel is open exactly while at least one surface is actually rendering it.
+ */
+
+/** Add or drop `ownerId`; returns the SAME array when nothing changed. */
+export function setPanelOwner(
+  owners: string[],
+  ownerId: string,
+  open: boolean,
+): string[] {
+  const held = owners.includes(ownerId);
+  if (held === open) return owners;
+  return open ? [...owners, ownerId] : owners.filter((id) => id !== ownerId);
+}

--- a/app/src/components/shell/use-shell-detail-panel.ts
+++ b/app/src/components/shell/use-shell-detail-panel.ts
@@ -1,18 +1,32 @@
+import { useCallback, useEffect, useId } from "react";
 import { useUIStore } from "../../stores/ui";
 import { useDetailPanelContainer } from "./detail-panel-context";
 
 /**
  * The one shell-level detail-panel wiring, shared by every surface that opens
- * the big right-hand panel: the Activity mission board (`mission-board.tsx`) and
- * the Routines tab's chat (`routines-tab.tsx`). It hands back the shell's portal
- * container (`workspace-shell` renders it as a sibling of `<main>` while
- * `missionPanelOpen` is true) plus the setter that toggles that flag.
+ * the big right-hand panel: the Activity mission board (`mission-board.tsx`),
+ * the Routines tab's chat (`routines-tab.tsx`), the Archived lists, and the
+ * skill / integration setup chats. It hands back the shell's portal container
+ * (`workspace-shell` renders it as a sibling of `<main>` while
+ * `missionPanelOpen` is true) plus the setter that opens and closes it.
  *
  * Both surfaces render into the SAME container through this hook, so the panel
  * is provably one UI path — there is no second, forked panel shell.
+ *
+ * `setPanelOpen` is scoped to THIS caller's claim (see `detail-panel-owners`):
+ * the panel is open while at least one surface claims it, so a hidden-but-
+ * mounted tab releasing its claim can't clobber the tab the user just opened,
+ * and a tab that stops rendering the panel can't strand it open and empty.
+ * Unmounting releases the claim automatically.
  */
 export function useShellDetailPanel() {
   const panelContainer = useDetailPanelContainer();
-  const setPanelOpen = useUIStore((s) => s.setMissionPanelOpen);
+  const ownerId = useId();
+  const setOwner = useUIStore((s) => s.setMissionPanelOwner);
+  const setPanelOpen = useCallback(
+    (open: boolean) => setOwner(ownerId, open),
+    [ownerId, setOwner],
+  );
+  useEffect(() => () => setOwner(ownerId, false), [ownerId, setOwner]);
   return { panelContainer, setPanelOpen };
 }

--- a/app/src/components/tabs/archived-tab.tsx
+++ b/app/src/components/tabs/archived-tab.tsx
@@ -13,7 +13,7 @@ import { useAttachmentRejectionDialog } from "../attachment-rejection-dialog";
 import { buildArchivedBoardItems } from "../board/agent-board-items";
 import { AgentCardAvatar } from "../shell/agent-card-avatar";
 import { AgentPanelAvatar } from "../shell/agent-panel-avatar";
-import { useDetailPanelContainer } from "../shell/detail-panel-context";
+import { useShellDetailPanel } from "../shell/use-shell-detail-panel";
 import { useAgentChatPanel } from "../use-agent-chat-panel";
 import { ArchivedEmptyState } from "./archived-empty-state";
 import { ArchivedHeader } from "./archived-header";
@@ -35,11 +35,10 @@ export default function ArchivedTab({
   const { t } = useTranslation("board");
   const path = agent.folderPath;
   const openHref = useOpenAgentHref(path);
-  const panelContainer = useDetailPanelContainer();
+  const { panelContainer, setPanelOpen } = useShellDetailPanel();
   const { data: rawItems } = useActivity(path);
   const deleteActivity = useDeleteActivity(path);
   const addToast = useUIStore((s) => s.addToast);
-  const setMissionPanelOpen = useUIStore((s) => s.setMissionPanelOpen);
   const setAgentBoardMode = useUIStore((s) => s.setAgentBoardMode);
 
   const archived = useMemo(() => selectArchived(rawItems ?? []), [rawItems]);
@@ -142,7 +141,7 @@ export default function ArchivedTab({
           onLoadOlderMessages={onLoadOlderMessages}
           hasOlderMessages={hasOlderMessages}
           emptyState={emptyState}
-          onPanelOpenChange={setMissionPanelOpen}
+          onPanelOpenChange={setPanelOpen}
           onOpenLink={openHref}
           onNotice={(message) => addToast({ title: message })}
           prepareAttachments={attachmentValidation.prepareAttachments}

--- a/app/src/components/tabs/routines-tab-model.ts
+++ b/app/src/components/tabs/routines-tab-model.ts
@@ -19,11 +19,6 @@ export type Selection =
   | { kind: "routine"; routineId: string }
   | { kind: "draft"; activityId: string | null };
 
-/** Only the visible Automations tab may control the shared shell panel. */
-export function shouldSyncRoutinesPanel(isActive: boolean): boolean {
-  return isActive;
-}
-
 /**
  * Adopt the freshly-created draft id, but only if the user is still waiting on
  * the pending null-draft (a functional setState guard): a failed start (no id)

--- a/app/src/components/tabs/routines-tab.tsx
+++ b/app/src/components/tabs/routines-tab.tsx
@@ -1,7 +1,7 @@
 import { Badge, Button, cn } from "@houston-ai/core";
 import { RoutinesGrid, TimezonePicker } from "@houston-ai/routines";
 import { Plus } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useRoutineRuns, useRoutines } from "../../hooks/queries";
 import { useRoutineLabels } from "../../hooks/use-routine-labels";
@@ -10,10 +10,7 @@ import type { TabProps } from "../../lib/types";
 import { useIsActiveView } from "../shell/keep-alive-views";
 import { useShellDetailPanel } from "../shell/use-shell-detail-panel";
 import { useRoutineLeadingIcon } from "./routine-leading-icon";
-import {
-  latestRunByRoutine,
-  shouldSyncRoutinesPanel,
-} from "./routines-tab-model";
+import { latestRunByRoutine } from "./routines-tab-model";
 import { RoutinesTabPane } from "./routines-tab-pane";
 import { useRoutineChatSetup } from "./use-routine-chat-setup";
 import { useRoutineTabHandlers } from "./use-routine-tab-handlers";
@@ -65,20 +62,14 @@ export default function RoutinesTab({
   // board's inline fallback instead, which paints nothing.
   const screenActive = useIsActiveView();
   const portalContainer = isActive && screenActive ? panelContainer : null;
+  // The claim tracks exactly what this tab renders: a selection while it is the
+  // visible tab, nothing otherwise. Releasing on the way out is safe because the
+  // claim is this tab's own — it can't clobber a mission navigation that just
+  // opened the Activity board's panel (PRODUCT-1229). `useShellDetailPanel`
+  // releases it again on unmount.
   useEffect(() => {
-    if (!shouldSyncRoutinesPanel(isActive)) return;
-    setPanelOpen(!!selected);
+    setPanelOpen(isActive && !!selected);
   }, [isActive, selected, setPanelOpen]);
-  // All agent tabs stay mounted. Only the active Routines tab may close its
-  // shell panel, otherwise an inactive tab can clobber a mission navigation.
-  const isActiveRef = useRef(isActive);
-  isActiveRef.current = isActive;
-  useEffect(
-    () => () => {
-      if (isActiveRef.current) setPanelOpen(false);
-    },
-    [setPanelOpen],
-  );
   // Per-row identity glyph — the triggering app's logo (or a webhook mark) for
   // event routines, the grid's default clock for schedule ones.
   const leadingIcon = useRoutineLeadingIcon(triggers.triggersEnabled);

--- a/app/src/components/turn-file-summary.tsx
+++ b/app/src/components/turn-file-summary.tsx
@@ -42,7 +42,7 @@ export function TurnFileSummary({ items, agentPath }: TurnFileSummaryProps) {
         ui.setJobDescriptionTarget(semanticTarget(kind));
         ui.setViewMode("job-description");
       }
-      ui.setMissionPanelOpen(false);
+      ui.closeMissionPanel();
     },
     [agentPath, capabilities],
   );

--- a/app/src/stores/ui.ts
+++ b/app/src/stores/ui.ts
@@ -1,6 +1,7 @@
 import type { PortableUploadPreviewResponse } from "@houston-ai/engine-client";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { setPanelOwner } from "../components/shell/detail-panel-owners.ts";
 import type { SettingsSectionId } from "../lib/settings-sections";
 
 export interface ToastItem {
@@ -62,8 +63,22 @@ interface UIState {
   agentArchivedSearchQueries: Record<string, string>;
   /** Whether the per-agent archived-tab search is loading conversation text. */
   agentArchivedSearchLoading: Record<string, boolean>;
-  /** Whether the mission chat panel is open (hides tab bar for full-height panel) */
+  /**
+   * Whether the ONE shell-level detail panel is open (hides tab bar for
+   * full-height panel). DERIVED from `missionPanelOwners` — never set directly.
+   */
   missionPanelOpen: boolean;
+  /**
+   * Ids of the surfaces currently claiming the shell detail panel. Several
+   * surfaces render the panel (the Activity board, the Routines chat, the
+   * Archived lists, the skill / integration setup chats) and all of them stay
+   * MOUNTED while hidden, so a single last-writer-wins boolean strands the
+   * panel open as an empty card: the tab that leaves keeps its `true` on the
+   * flag while it stops portaling anything into it (PRODUCT-1229). Each
+   * surface claims and releases its OWN id via `useShellDetailPanel`, so
+   * releasing can never clobber the surface the user just navigated to.
+   */
+  missionPanelOwners: string[];
   /** Whether the mobile (<768px) sidebar drawer is open. Session-only, never
    *  persisted: a drawer restored open after a reload is a trap on a phone. */
   mobileSidebarOpen: boolean;
@@ -173,7 +188,10 @@ interface UIState {
   setAgentMissionSearchLoading: (agentPath: string, loading: boolean) => void;
   setAgentArchivedSearchQuery: (agentPath: string, query: string) => void;
   setAgentArchivedSearchLoading: (agentPath: string, loading: boolean) => void;
-  setMissionPanelOpen: (open: boolean) => void;
+  /** Claim (`open`) or release the shell detail panel for one surface. */
+  setMissionPanelOwner: (ownerId: string, open: boolean) => void;
+  /** Release every claim — the "get me out of this panel" escape hatch. */
+  closeMissionPanel: () => void;
   setMobileSidebarOpen: (open: boolean) => void;
   setPendingRoutineActivityId: (activityId: string | null) => void;
   setPendingSkillChatActivityId: (activityId: string | null) => void;
@@ -231,6 +249,7 @@ const initialUIState = {
   agentArchivedSearchQueries: {},
   agentArchivedSearchLoading: {},
   missionPanelOpen: false,
+  missionPanelOwners: [],
   mobileSidebarOpen: false,
   pendingRoutineActivityId: null,
   pendingSkillChatActivityId: null,
@@ -384,7 +403,21 @@ export const useUIStore = create<UIState>()(
           else delete next[agentPath];
           return { agentArchivedSearchLoading: next };
         }),
-      setMissionPanelOpen: (missionPanelOpen) => set({ missionPanelOpen }),
+      setMissionPanelOwner: (ownerId, open) =>
+        set((s) => {
+          const missionPanelOwners = setPanelOwner(
+            s.missionPanelOwners,
+            ownerId,
+            open,
+          );
+          if (missionPanelOwners === s.missionPanelOwners) return s;
+          return {
+            missionPanelOwners,
+            missionPanelOpen: missionPanelOwners.length > 0,
+          };
+        }),
+      closeMissionPanel: () =>
+        set({ missionPanelOwners: [], missionPanelOpen: false }),
       setMobileSidebarOpen: (mobileSidebarOpen) => set({ mobileSidebarOpen }),
       setPendingRoutineActivityId: (pendingRoutineActivityId) =>
         set({ pendingRoutineActivityId }),

--- a/app/tests/detail-panel-owners.test.ts
+++ b/app/tests/detail-panel-owners.test.ts
@@ -1,0 +1,37 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { setPanelOwner } from "../src/components/shell/detail-panel-owners.ts";
+
+describe("shell detail panel ownership", () => {
+  it("opens on the first claim and closes only when the last one is released", () => {
+    let owners: string[] = [];
+    owners = setPanelOwner(owners, "board", true);
+    deepStrictEqual(owners, ["board"]);
+    owners = setPanelOwner(owners, "routines", true);
+    deepStrictEqual(owners, ["board", "routines"]);
+    owners = setPanelOwner(owners, "board", false);
+    deepStrictEqual(owners, ["routines"]);
+    owners = setPanelOwner(owners, "routines", false);
+    deepStrictEqual(owners, []);
+  });
+
+  it("lets a departing surface release its own claim without clobbering another (PRODUCT-1229)", () => {
+    // The Routines tab holds the panel; a mission navigation opens the Activity
+    // board's panel in the same commit. Routines going hidden must drop only
+    // its own claim — the panel stays open for the board.
+    const owners = setPanelOwner(
+      setPanelOwner([], "routines", true),
+      "board",
+      true,
+    );
+    const afterLeave = setPanelOwner(owners, "routines", false);
+    deepStrictEqual(afterLeave, ["board"]);
+    strictEqual(afterLeave.length > 0, true);
+  });
+
+  it("is idempotent — a repeated claim or release keeps the same array", () => {
+    const owners = setPanelOwner([], "board", true);
+    strictEqual(setPanelOwner(owners, "board", true), owners);
+    strictEqual(setPanelOwner([], "board", false).length, 0);
+  });
+});

--- a/app/tests/routines-tab-model.test.ts
+++ b/app/tests/routines-tab-model.test.ts
@@ -5,16 +5,8 @@ import {
   adoptDraft,
   deselectIfOn,
   latestRunByRoutine,
-  shouldSyncRoutinesPanel,
   toggleRoutine,
 } from "../src/components/tabs/routines-tab-model.ts";
-
-describe("shouldSyncRoutinesPanel", () => {
-  it("prevents an inactive routines tab from closing a mission panel", () => {
-    strictEqual(shouldSyncRoutinesPanel(false), false);
-    strictEqual(shouldSyncRoutinesPanel(true), true);
-  });
-});
 
 describe("routines tab model — adoptDraft", () => {
   it("adopts the fresh id only while still waiting on the null draft", () => {

--- a/knowledge-base/client-architecture.md
+++ b/knowledge-base/client-architecture.md
@@ -333,6 +333,18 @@ to that screen. Shared hooks, including Teams roster data used by sharing/admin
 surfaces, must use their callers' precise `enabled` flags and must never be
 view-gated.
 
+**The shell detail panel is claim-counted, never a shared boolean.** Agent tabs
+are only CSS-hidden and top-level screens are kept alive, so several surfaces
+that render the ONE shell panel (Activity board, Routines chat, both Archived
+lists, skill/integration setup chats) are mounted at once. Each claims and
+releases its OWN id through `useShellDetailPanel`; `missionPanelOpen` is derived
+from the claim set (`app/src/components/shell/detail-panel-owners.ts`) and the
+hook releases on unmount. Never reintroduce a single last-writer-wins flag: the
+tab the user navigates AWAY from stops portaling but keeps its `true`, and the
+shell paints an empty card beside the board (PRODUCT-1229). The corollary is
+that a hidden surface MUST release its claim — withholding the release to avoid
+clobbering the newly-visible surface is what caused the stranded panel.
+
 ---
 
 ## Verification matrix

--- a/packages/web/e2e/shell-panel-ownership.spec.ts
+++ b/packages/web/e2e/shell-panel-ownership.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "./support/fixtures";
+
+/**
+ * The ONE shell-level detail panel is shared by every surface that opens it
+ * (the Activity board, the Routines chat, the Archived list, the skill /
+ * integration setup chats). Every agent tab stays mounted, so "is the panel
+ * open" cannot be a single last-writer-wins boolean: a tab that stops being
+ * visible has to drop ITS claim on the panel without clobbering whatever the
+ * newly-visible tab claims (PRODUCT-1229 — leaving the Routines tab with a
+ * chat open left the panel painted as an empty card over the Activity board).
+ */
+
+test("leaving the Routines tab with its chat open closes the shared panel", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  // Activity first: the board owns the panel and nothing is selected, so the
+  // panel is closed.
+  await page.locator('[data-tour-target="tab-activity"]').click();
+  await expect(page.getByTestId("mission-panel")).toBeHidden();
+
+  // Routines: the create intake opens the shared panel.
+  await page.locator('[data-tour-target="tab-routines"]').click();
+  await page.getByRole("button", { name: "New routine" }).first().click();
+  await expect(page.getByTestId("mission-panel")).toBeVisible();
+  await expect(page.getByText("How do you want to start?")).toBeVisible();
+
+  // Back to Activity: the routine chat no longer renders into the panel, so
+  // the panel must close with it — never linger as an empty card.
+  await page.locator('[data-tour-target="tab-activity"]').click();
+  await expect(page.getByTestId("mission-panel")).toBeHidden();
+});
+
+test("leaving the Activity tab with a mission open closes the shared panel", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  // A mission chat claims the panel from the board side.
+  await page.locator('[data-tour-target="tab-activity"]').click();
+  await page.getByText("Plan a trip to Tokyo").first().click();
+  await expect(page.getByTestId("mission-panel")).toBeVisible();
+
+  // Routines has nothing selected, so nothing claims the panel and it closes —
+  // the board's chat must not be left painted over the routines list.
+  await page.locator('[data-tour-target="tab-routines"]').click();
+  await expect(
+    page.getByRole("button", { name: "New routine" }).first(),
+  ).toBeVisible();
+  await expect(page.getByTestId("mission-panel")).toBeHidden();
+
+  // And returning to Activity does not resurrect a stale panel.
+  await page.locator('[data-tour-target="tab-activity"]').click();
+  await expect(page.getByTestId("mission-panel")).toBeHidden();
+});


### PR DESCRIPTION
Fixes PRODUCT-1229.

## The bug

Set up a routine, switch to the Activity tab, and a blank card sits where the
chat should be — the shell detail panel is painted, empty, next to the board.

## Root cause

`missionPanelOpen` was ONE shared boolean with last-writer-wins semantics,
written by every surface that renders the shell detail panel: the Activity
board, the Routines chat, the per-agent and Mission Control Archived lists, and
the skill / integration setup chats. All of those surfaces stay **mounted**
while hidden — agent tabs are only CSS-hidden, top-level screens are kept alive
— so there is no writer left to correct a stale `true`.

The Routines tab deliberately *skipped* writing `false` on its way out
(`shouldSyncRoutinesPanel`), because releasing a shared flag would clobber a
mission navigation that had just opened the board's panel. The result: on tab
switch it stopped portaling anything into the panel (`portalContainer` goes
null) while leaving the flag `true`. `workspace-shell` kept rendering the
container, and nothing rendered into it.

Confirmed in the repro run — the DOM node is literally
`<div data-testid="mission-panel" class="…"></div>`, empty.

## The fix

The panel is **claim-counted** instead of flagged. Each surface claims and
releases its OWN id through `useShellDetailPanel`; `missionPanelOpen` is derived
from the claim set (`app/src/components/shell/detail-panel-owners.ts`), and the
hook releases the claim on unmount.

That fixes both halves at once: a departing surface can release safely because
it can only drop its own claim, so the Routines tab now tracks exactly what it
renders (`setPanelOpen(isActive && !!selected)`) and the panel closes with it —
without any risk of clobbering the tab the user just opened. `shouldSyncRoutinesPanel`
and the `isActiveRef` unmount hack it needed are both gone.

The two Archived lists move off the raw store setter onto the same hook, so
every panel surface goes through one wiring.

## Reproduce (before)

Desktop app or web, on any agent:

1. Open an agent, go to the **Routines** tab.
2. Click **New routine** (or select an existing routine) — the chat panel opens
   on the right.
3. Click the **Activity** tab.

Before: a blank panel occupies the right side of the window, no header, no
composer, no close button — the board is squeezed to ~55% for nothing. It stays
until you open and close a mission on the board.

## Verify (after)

Same three steps: switching to Activity closes the panel and the board takes the
full width. The reverse direction also holds — open a mission on Activity, go to
Routines, and the mission chat does not linger over the routines list.

Automated:

- `pnpm --filter houston-web exec playwright test --project=chromium shell-panel-ownership.spec.ts`
  — "leaving the Routines tab with its chat open closes the shared panel" fails
  on `main` (panel visible and empty) and passes here; the Activity-side test
  guards the other direction.
- `cd app && pnpm test` — `app/tests/detail-panel-owners.test.ts` covers the
  claim set, including the release-without-clobber case.

## Checks run

- `cd app && pnpm tsgo --noEmit`, `pnpm test` (2728 pass)
- `pnpm --filter houston-web typecheck`, `pnpm check`, `cd app && pnpm check-locales`
- Playwright: chromium (244 pass), auth (8 pass), visual (8 pass) — no baseline
  changes, this is behavior only, no token or component edits.