### PR TITLE
fix(chat): labeled links wear the same Slack chip as bare URLs (PRODUCT-1152)

### DIFF
--- a/packages/web/e2e/chat-link-pill.spec.ts
+++ b/packages/web/e2e/chat-link-pill.spec.ts
@@ -8,7 +8,10 @@ import { expect, test } from "./support/fixtures";
  * unreadable black bar.
  *
  * HOU-1152: a long URL's visible text shortens to its head plus an ellipsis
- * (Slack-style) while the href keeps the full destination.
+ * (Slack-style) while the href keeps the full destination — and EVERY link
+ * variant wears that one chip: the labeled `[Open the deck](…)` link (which
+ * kept the pre-Slack solid button pill through the first pass) and a URL a
+ * person pasted into their own bubble included.
  *
  * Seeded through `/__test__/chat-history`, so this exercises the REAL
  * browser pipeline: history → feed → Streamdown → `classifyMarkdownLink` →
@@ -105,4 +108,59 @@ test("bare long URL displays shortened with the full href intact (HOU-1152)", as
   await expect(link).toBeVisible({ timeout: 15_000 });
   await expect(link).toHaveText(SHORTENED);
   await expect(link).toHaveAttribute("title", REASSEMBLED);
+});
+
+test("a labeled link is the same inline chip as a bare URL, never a button pill (HOU-1152)", async ({
+  page,
+  request,
+}) => {
+  const missionId = "act-hou-1152-labeled";
+  const labeledHref =
+    "https://docs.google.com/presentation/d/1qObQZ8EL3Yc/edit";
+  const label = "Open the deck";
+  await request.post(`${FAKE_HOST_URL}/agents/houston-assistant/activities`, {
+    data: { id: missionId, title: "Labeled link", status: "needs_you" },
+  });
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-history`, {
+    data: {
+      conversationId: `activity-${missionId}`,
+      messages: [
+        // The person's own pasted URL, in the human bubble.
+        { role: "user", content: `deck please: ${REASSEMBLED}`, ts: 1 },
+        {
+          role: "assistant",
+          content: `Done: [${label}](${labeledHref})`,
+          ts: 2,
+        },
+      ],
+    },
+  });
+
+  await page.goto("/");
+  await page.getByText("Labeled link").first().click();
+
+  // The labeled link: an inline anchor wearing its label verbatim (a label is
+  // the author's words, not a URL to shorten), with the destination on hover.
+  const labeled = page.locator(`a[href="${labeledHref}"]`);
+  await expect(labeled).toBeVisible({ timeout: 15_000 });
+  await expect(labeled).toHaveText(label);
+  await expect(labeled).toHaveAttribute("title", labeledHref);
+
+  // Not the old solid button pill — the one link variant that still looked
+  // like a call to action while every other link had become a chip.
+  await expect(page.locator("button", { hasText: label })).toHaveCount(0);
+
+  // Same chip anatomy as a bare URL: inline flow on the soft link tint.
+  const labeledStyle = await labeled.evaluate((el) => {
+    const s = getComputedStyle(el);
+    return { background: s.backgroundColor, display: s.display };
+  });
+  expect(labeledStyle.display).toBe("inline");
+  expect(labeledStyle.background).toMatch(/\/ 0\.1\)$/);
+
+  // And the URL the PERSON pasted shortens exactly like the agent's does —
+  // the human path renders plain text, but a chip is a chip on both sides.
+  const pasted = page.locator(`a[href="${REASSEMBLED}"]`);
+  await expect(pasted).toHaveText(SHORTENED);
+  await expect(pasted).toHaveAttribute("title", REASSEMBLED);
 });

--- a/ui/chat/src/ai-elements/message.tsx
+++ b/ui/chat/src/ai-elements/message.tsx
@@ -16,11 +16,7 @@ import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
 import type { UIMessage } from "ai";
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  ExternalLinkIcon,
-} from "lucide-react";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import type {
   AnchorHTMLAttributes,
   ComponentProps,
@@ -488,40 +484,31 @@ export const MessageResponse = memo(
               return <>{custom}</>;
             }
           }
-          // Bare URL the agent dropped in chat → inline link chip that
-          // opens in the system browser (issue #358), not dead text. Only
-          // render it interactive when there's an open handler; otherwise it
+          // Every remaining link — the bare URL the agent dropped in chat
+          // (issue #358) and the labeled `[Open report](…)` alike — is the
+          // same inline chip that opens in the system browser (HOU-1152).
+          // A labeled link used to render as a solid button pill, the one
+          // variant still wearing the pre-Slack styling; a descriptive label
+          // is not a call to action and reading it as a second link shape
+          // made the same message look like two different products.
+          //
+          // Only an autolink shortens: a URL label markdown broke across
+          // lines flattens with a softbreak in it (HOU-1071), so show the
+          // reassembled URL rather than raw children with a stray space
+          // mid-URL, scheme-stripped and capped (HOU-1152). A label is the
+          // author's own words and renders verbatim, wrapping inline instead
+          // of clipping the way the fixed-height pill did.
+          const label =
+            kind === "autolink"
+              ? (autolinkDisplay(children) ?? children)
+              : children;
+          // Only interactive when there's an open handler; otherwise it
           // would look clickable but do nothing.
-          if (kind === "autolink") {
-            // A URL label markdown broke across lines flattens with a
-            // softbreak in it (HOU-1071) — show the reassembled URL, not
-            // the raw children with a stray space mid-URL, scheme-stripped
-            // and capped Slack-style (HOU-1152); the href keeps the full
-            // destination.
-            const label = autolinkDisplay(children) ?? children;
-            if (!fn) return <span>{label}</span>;
-            return (
-              <Autolink href={url} onOpen={onOpen}>
-                {label}
-              </Autolink>
-            );
-          }
-          // Labeled link (text distinct from URL) → button with text + icon.
-          // max-w-full + truncate: a long label ellipsizes instead of
-          // overflowing the fixed-height pill as clipped wrapped lines.
-          // overflow-hidden: even a child that defeats truncate (a <br>, an
-          // image) stays clipped inside the pill's rounded bounds.
+          if (!fn) return <span>{label}</span>;
           return (
-            <Button
-              type="button"
-              size="sm"
-              variant="default"
-              className="max-w-full overflow-hidden"
-              onClick={onOpen}
-            >
-              <span className="min-w-0 truncate">{children}</span>
-              <ExternalLinkIcon size={11} strokeWidth={2} />
-            </Button>
+            <Autolink href={url} onOpen={onOpen}>
+              {label}
+            </Autolink>
           );
         },
       };

--- a/ui/chat/src/autolink.tsx
+++ b/ui/chat/src/autolink.tsx
@@ -2,11 +2,15 @@ import { LinkIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
 /**
- * A URL rendered inline in a chat message — the Slack-style link chip
- * (HOU-1152): `link`-token blue on a soft `link` tint with a chain glyph,
- * shared by the markdown autolink override (`MessageResponse`) and the
- * plain-text path (`plain-message-text.tsx`) so a link looks identical
- * whether its message rendered markdown or not.
+ * A link rendered inline in a chat message — the Slack-style link chip
+ * (HOU-1152): `link`-token blue on a soft `link` tint with a chain glyph.
+ * EVERY link in chat wears it: bare URLs, labeled `[Open report](…)` links
+ * (which rendered as a solid button pill until HOU-1152's follow-up), and
+ * URLs a person pasted into their own bubble. One shape, so a message with
+ * two kinds of link doesn't read as two different products. Shared by the
+ * markdown override (`MessageResponse`) and the plain-text path
+ * (`plain-message-text.tsx`) so a link looks identical whether its message
+ * rendered markdown or not.
  *
  * The chip background is the resting affordance (hover only ADDS the
  * underline, never carries it alone). `box-decoration-break: clone` keeps

--- a/ui/chat/src/markdown-link.ts
+++ b/ui/chat/src/markdown-link.ts
@@ -9,7 +9,11 @@
  *                Never a button pill — a pill clips a long URL into an
  *                unreadable black bar.
  * - `labeled`  — the link has descriptive text distinct from the URL
- *                (`[Open report](https://…)`). Render the labeled button.
+ *                (`[Open report](https://…)`). Renders as the SAME inline
+ *                link chip as an autolink, wearing the label instead of the
+ *                shortened URL (HOU-1152): every link in a message reads as
+ *                one thing. The kind still matters — a labeled link shows its
+ *                label verbatim, an autolink shortens its URL.
  */
 export type MarkdownLinkKind = "plain" | "autolink" | "labeled";
 

--- a/ui/chat/src/plain-message-text.tsx
+++ b/ui/chat/src/plain-message-text.tsx
@@ -10,12 +10,17 @@
  *   conversation reads identically on both render paths. Offsets index into
  *   the NFC-normalized text, so this component slices its own normalized copy.
  * - Bare URLs (HOU-960 / #358): a pasted link stays a clickable link chip
- *   inside the bubble — the same anatomy as the markdown autolink, without a
- *   handler it degrades to plain text rather than a dead-looking link.
+ *   inside the bubble — the same anatomy as the markdown autolink, including
+ *   its scheme-stripped, length-capped display text (HOU-1152), so a link the
+ *   person pasted and a link the agent replied with read identically. Verbatim
+ *   is about the person's PROSE; the chip is presentation and the full
+ *   destination stays in the href. Without a handler it degrades to plain text
+ *   rather than a dead-looking link.
  */
 
 import { Fragment, type ReactNode } from "react";
 import { Autolink } from "./autolink";
+import { autolinkDisplay } from "./markdown-link";
 import { MentionChip } from "./mention-chip";
 import { findMentionSpans, type MentionTarget } from "./mention-spans.ts";
 import { normalizeMentionText } from "./mention-text.ts";
@@ -51,7 +56,7 @@ function linkify(
     }
     parts.push(
       <Autolink key={keyBase + start} href={url} onOpen={() => onOpenLink(url)}>
-        {url}
+        {autolinkDisplay(url) ?? url}
       </Autolink>,
     );
     cursor = start + url.length;

--- a/ui/showcase/specimens/areas/chat/chat-message-parts.ts
+++ b/ui/showcase/specimens/areas/chat/chat-message-parts.ts
@@ -34,7 +34,7 @@ export const messageProps: readonly SpecimenProp[] = [
   {
     name: "onOpenLink",
     type: "(url: string) => void",
-    note: "MessageResponse. Opens a link the agent wrote. Without it links render as inert text, never as a button that does nothing.",
+    note: "MessageResponse. Opens a link the agent wrote. Every link — bare URL or labeled — renders as the same inline chip; without this handler they degrade to inert text rather than a chip that does nothing.",
   },
   {
     name: "renderLink",


### PR DESCRIPTION
## Root cause

PR #1238 converted chat links to the Slack-style chip, but only two of the three render paths came along. The `labeled` branch of the markdown `a` override in `ui/chat/src/ai-elements/message.tsx` still returned a solid `Button variant="default"` — so `[Open the deck](url)` kept the pre-Slack pill while every bare URL beside it was a blue chip. One assistant message could show two different link shapes, and the surviving one was exactly the styling PRODUCT-1152 asked us to drop.

A second, smaller gap: a URL a *person* pasted (the `plain-message-text.tsx` path, human bubbles) rendered the raw string — `https://` intact, uncapped — while the agent's identical link showed scheme-stripped and shortened.

## The fix

- **One chip for every link.** The markdown override routes both `autolink` and `labeled` through the shared `Autolink` component. Only an autolink shortens its text: a label is the author's own words, so it renders verbatim and wraps inline (`box-decoration-break: clone` keeps the rounded ends) instead of ellipsizing inside a fixed-height pill. The full destination stays in the href and on hover, unchanged.
- **The human path shortens too.** Pasted URLs go through `autolinkDisplay`, so a chip reads identically whether the person or the agent wrote it. What stays verbatim is the person's *prose* (HOU-1051) — the chip is presentation.
- Dead `ExternalLinkIcon` import dropped; the `labeled` doc comment and the showcase prop note now describe what actually renders.

## Verification

**Before:** seed a chat with `Bare URL: <long url>` and `Labeled: [Open the deck](url)` in one assistant turn. The bare URL is a blue chip; the labeled link is a solid black pill with an external-link glyph.

**After:** both are the same blue chip on the soft link tint, with the chain glyph. The pasted URL in the user's own bubble is scheme-stripped and capped like the rest. Verified by screenshot in light and dark.

Gates: `pnpm check`, `pnpm typecheck`, `pnpm check:boundaries`, `pnpm check:parity`, `pnpm --filter @houston-ai/chat test` (361 pass), `pnpm --filter houston-web typecheck:e2e`, `test:visual` (8 pass), and `test:e2e chat-link-pill chat-senders` (6 pass) — including a new `chat-link-pill` case that asserts the labeled link is an inline anchor on the tint with no button pill, plus the pasted-URL shortening.