### PR TITLE
fix(app): first setup message follows the app language (PRODUCT-1257)

### DIFF
--- a/app/src/lib/agent-setup-mission.ts
+++ b/app/src/lib/agent-setup-mission.ts
@@ -19,34 +19,7 @@ import { analytics } from "./analytics";
 import { createMission } from "./create-mission";
 import { showErrorToast } from "./error-toast";
 import i18n from "./i18n";
-
-const LANGUAGE_NOTE = `**LANGUAGE — read this first.** Detect the user's language from the chat so far (or from your own instructions if the chat is still empty) and reply in that same language for this entire first conversation. For Spanish use Latin-American neutral (tú, computador). For Portuguese use Brazilian (você). Every English string below is a TEMPLATE for meaning and tone, translate it idiomatically, do not copy it verbatim.`;
-
-/**
- * Build the hidden setup-mission prompt for the named agent. Adapted from the
- * old intro directive: same reply-in-the-user's-language idiom and
- * non-technical voice (never mention files, folders, configs, or internals),
- * now framed as a live interview that persists each answer immediately.
- */
-export function buildSetupMissionPrompt(agentName: string): string {
-  return `This is ${agentName}'s very first conversation with the user. Make a warm, human first impression and help the user set you up so you deliver real value fast. Keep every reply short and warm. Never mention files, folders, configs, or any technical internals, speak in terms of the work you do for them. This is the user's first impression of you.
-
-${LANGUAGE_NOTE}
-
-Do this, in order:
-
-1. Introduce yourself in 2 or 3 short sentences, grounded in YOUR OWN instructions: who you are and what you can take off the user's plate. Be specific to what you were set up to do, not generic.
-
-2. Then propose 2 or 3 concrete example missions you could do for them right now, as a short list, and ask which one they would like to start with (or what else they need).
-
-3. Then interview the user about how you should work for them, and IMMEDIATELY save everything they tell you, through your normal abilities, as they say it. Never batch it up for later:
-   - Lasting preferences and facts about how you should behave (their tone, their name, standing do's and don'ts, context about them and their work) go into your instructions.
-   - A repeatable procedure they want you to follow again later gets saved as a Skill.
-   - Anything they want to happen on a schedule becomes a Routine: ask what time it should run and confirm with them before you create it.
-   Capture each thing the moment the user says it, then briefly confirm what you saved in one short line before moving on.
-
-Keep replies short and warm throughout.`;
-}
+import { buildSetupMissionPrompt } from "./setup-mission-prompt";
 
 /**
  * Auto-start the agent's self-setup mission and open its chat. Fire-and-forget
@@ -68,7 +41,7 @@ export async function startAgentSetupMission(
       i18n.t("agentOnboarding:setupMission.kickoff"),
       {
         title: i18n.t("agentOnboarding:setupMission.title"),
-        buildPrompt: () => buildSetupMissionPrompt(agent.name),
+        buildPrompt: () => buildSetupMissionPrompt(agent.name, i18n.language),
         providerOverride: opts.provider,
         modelOverride: opts.model,
         effortOverride: "medium",

--- a/app/src/lib/setup-mission-prompt.ts
+++ b/app/src/lib/setup-mission-prompt.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure builder for the hidden self-setup mission prompt (flow lives in
+ * `agent-setup-mission.ts`). Kept free of i18n/store/engine-client imports so
+ * the node:test suite can load it directly.
+ *
+ * The language directive must be explicit: the localized kickoff bubble rides
+ * `displayText` only and never reaches the engine, so on a brand-new agent
+ * there is no chat to "detect" the user's language from — the model would only
+ * see English instructions and introduce itself in English (PRODUCT-1257). The
+ * active app locale is the ground truth, so the prompt states it outright.
+ */
+
+import { outputLanguageName } from "../components/onboarding/personal-assistant-seeds.ts";
+
+function languageNote(languageName: string): string {
+  return `**LANGUAGE — read this first.** The user's app is set to ${languageName}. Write this ENTIRE conversation in ${languageName}: your introduction, every question you ask, and every choice or option you offer the user. For Spanish use Latin-American neutral (tú, computador). For Portuguese use Brazilian (você). If the user writes to you in a different language, switch to theirs and stay there. Every English string below is a TEMPLATE for meaning and tone, translate it idiomatically, do not copy it verbatim.`;
+}
+
+/**
+ * Build the hidden setup-mission prompt for the named agent. Adapted from the
+ * old intro directive: same non-technical voice (never mention files, folders,
+ * configs, or internals), framed as a live interview that persists each answer
+ * immediately. `locale` is the active app language (e.g. `"es"`), which pins
+ * the language of the whole first conversation.
+ */
+export function buildSetupMissionPrompt(
+  agentName: string,
+  locale: string,
+): string {
+  const languageName = outputLanguageName(locale);
+  return `This is ${agentName}'s very first conversation with the user. Make a warm, human first impression and help the user set you up so you deliver real value fast. Keep every reply short and warm. Never mention files, folders, configs, or any technical internals, speak in terms of the work you do for them. This is the user's first impression of you.
+
+${languageNote(languageName)}
+
+Do this, in order:
+
+1. Introduce yourself in 2 or 3 short sentences, grounded in YOUR OWN instructions: who you are and what you can take off the user's plate. Be specific to what you were set up to do, not generic.
+
+2. Then propose 2 or 3 concrete example missions you could do for them right now, as a short list, and ask which one they would like to start with (or what else they need).
+
+3. Then interview the user about how you should work for them, and IMMEDIATELY save everything they tell you, through your normal abilities, as they say it. Never batch it up for later:
+   - Lasting preferences and facts about how you should behave (their tone, their name, standing do's and don'ts, context about them and their work) go into your instructions.
+   - A repeatable procedure they want you to follow again later gets saved as a Skill.
+   - Anything they want to happen on a schedule becomes a Routine: ask what time it should run and confirm with them before you create it.
+   Capture each thing the moment the user says it, then briefly confirm what you saved in one short line before moving on.
+
+Keep replies short and warm throughout.`;
+}

--- a/app/tests/setup-mission-prompt.test.ts
+++ b/app/tests/setup-mission-prompt.test.ts
@@ -1,0 +1,38 @@
+import { doesNotMatch, match, ok } from "node:assert";
+import { describe, it } from "node:test";
+import { buildSetupMissionPrompt } from "../src/lib/setup-mission-prompt.ts";
+
+// PRODUCT-1257: the engine never sees the localized kickoff bubble, so the
+// prompt must pin the conversation language from the app locale explicitly —
+// "detect it from the chat" has nothing to detect on a brand-new agent.
+describe("buildSetupMissionPrompt", () => {
+  it("pins Spanish for an es locale", () => {
+    const prompt = buildSetupMissionPrompt("Jarvis", "es");
+    match(prompt, /The user's app is set to Spanish/);
+    match(prompt, /Write this ENTIRE conversation in Spanish/);
+  });
+
+  it("pins Portuguese for a regioned pt-BR locale", () => {
+    const prompt = buildSetupMissionPrompt("Jarvis", "pt-BR");
+    match(prompt, /The user's app is set to Portuguese/);
+  });
+
+  it("pins English for en and falls back to English for unknown locales", () => {
+    match(buildSetupMissionPrompt("Jarvis", "en"), /set to English/);
+    match(buildSetupMissionPrompt("Jarvis", "fr"), /set to English/);
+  });
+
+  it("no longer asks the model to detect the language from the chat", () => {
+    doesNotMatch(
+      buildSetupMissionPrompt("Jarvis", "es"),
+      /[Dd]etect the user's language/,
+    );
+  });
+
+  it("keeps the agent name and the interview structure", () => {
+    const prompt = buildSetupMissionPrompt("Jarvis", "es");
+    ok(prompt.startsWith("This is Jarvis's very first conversation"));
+    match(prompt, /saved as a Skill/);
+    match(prompt, /becomes a Routine/);
+  });
+});


### PR DESCRIPTION
Fixes PRODUCT-1257.

## Root cause

The agent's self-setup mission sends a hidden English prompt to the engine (`buildPrompt`), while the localized kickoff bubble ("Ayúdame a configurarte") rides `displayText` only and **never reaches the model**. The prompt's language directive said *"detect the user's language from the chat so far (or from your own instructions if the chat is still empty)"* — but on a brand-new agent there is no chat and the agent's instructions are English, so the model had zero signal that the user speaks Spanish and delivered its intro and setup questions in English.

## Fix

The active app locale is the ground truth for a first conversation, so the prompt now states it explicitly instead of asking the model to guess:

- `buildSetupMissionPrompt(agentName, locale)` moved to a pure module `app/src/lib/setup-mission-prompt.ts` (loadable by node:test without i18n/store imports).
- The language note now reads *"The user's app is set to Spanish. Write this ENTIRE conversation in Spanish: your introduction, every question you ask, and every choice or option you offer"* — resolved via the existing `outputLanguageName()` helper (`es`/`es-419` → Spanish, `pt-BR` → Portuguese, unknown → English). If the user later writes in another language, the agent follows them.
- `startAgentSetupMission` passes `i18n.language` at mission start. Both entry points (create-workspace dialog, import wizard) go through it.

## Reproduce (before)

1. Set the app language to Spanish (Ajustes → Idioma, or first-run language gate).
2. Create a new agent (e.g. "Jarvis").
3. The setup mission opens with the Spanish bubble "Ayúdame a configurarte", but the agent introduces itself and asks its setup questions in English.

## Verify (after)

1. Same steps: Spanish app, create a new agent.
2. The agent's first message, example missions, and every ask_user option arrive in Spanish (Latin-American neutral). Same for Portuguese (`pt`), and English stays English.

## Tests

- New `app/tests/setup-mission-prompt.test.ts` (5 cases: es, pt-BR, en + unknown fallback, no more "detect" instruction, structure intact).
- `cd app && pnpm test` — 2736 tests pass. `pnpm tsgo --noEmit`, `pnpm --filter houston-web typecheck`, `pnpm check` all clean.