### PR TITLE
fix(runtime): stale integration action slugs recover via re-search (PRODUCT-1266)

### DIFF
--- a/packages/runtime/src/session/tools/integrations.test.ts
+++ b/packages/runtime/src/session/tools/integrations.test.ts
@@ -551,6 +551,71 @@ test("a RELAYED upstream 403 (no code) stays a generic error, not the turned-off
   );
 });
 
+test("a stale action slug (Tool_ToolNotFound via the gateway's 502) returns re-search guidance, not a raw failure", async () => {
+  // PRODUCT-1266: in a long chat the model reuses an action slug from its
+  // context (a search result from before Composio renamed/removed the action,
+  // or an invented name — GMAIL_SEARCH_EMAILS never existed; the real slug is
+  // GMAIL_FETCH_EMAILS). The gateway wraps Composio's 404 in a 502 whose body
+  // keeps the stable "Tool_ToolNotFound" slug verbatim; the tool classifies it
+  // and RETURNS the mechanical recovery — search again — so the task completes
+  // in THIS chat instead of teaching the user that only a new mission works.
+  mockFetch(() => ({
+    status: 502,
+    body: {
+      error:
+        'composio POST /api/v3/tools/execute/GMAIL_SEARCH_EMAILS → 404: {"error":{"message":"Tool GMAIL_SEARCH_EMAILS not found","code":2401,"slug":"Tool_ToolNotFound","status":404,"suggested_fix":"Check your input."}}',
+    },
+  }));
+  const holder = newInteractionHolder();
+  const out = await runWithInteractionCapture(holder, () =>
+    run(execute, { action: "GMAIL_SEARCH_EMAILS", params: { query: "x" } }),
+  );
+  const text = (out.content[0] as { text: string }).text;
+  expect(text).toContain('"GMAIL_SEARCH_EMAILS" does not exist');
+  expect(text).toContain("Call integration_search now");
+  expect(text).toContain("Do not retry this slug");
+  // Never the upstream jargon for the model to paraphrase at the user.
+  expect(text).not.toContain("Tool_ToolNotFound");
+  expect(text).not.toContain("502");
+  expect(text).not.toContain("404");
+  expect(out.details).toEqual({
+    action: "GMAIL_SEARCH_EMAILS",
+    actionNotFound: true,
+  });
+  // A recoverable model-side state: nothing is queued for the user.
+  expect(holder.pending).toBeUndefined();
+});
+
+test("a stale action slug via the DIRECT adapter's 500 classifies identically", async () => {
+  // Self-host/dev: the direct adapter's ComposioApiError reaches the runtime
+  // as the host's generic 500 { error: message } — same stable slug inside.
+  mockFetch(() => ({
+    status: 500,
+    body: {
+      error:
+        'composio POST /api/v3/tools/execute/OLD_ACTION → 404: {"error":{"slug":"Tool_ToolNotFound","code":2401}}',
+    },
+  }));
+  const out = await run(execute, { action: "OLD_ACTION" });
+  expect((out.content[0] as { text: string }).text).toContain(
+    "Call integration_search now",
+  );
+  expect(out.details).toEqual({ action: "OLD_ACTION", actionNotFound: true });
+});
+
+test("a plain relayed 502 WITHOUT the Composio slug stays a generic transient error", async () => {
+  // Any other upstream 502 (gateway outage, provider down) must not be read as
+  // a stale slug — the classification keys on Composio's stable error slug,
+  // never the bare status.
+  mockFetch(() => ({
+    status: 502,
+    body: { error: "upstream connect timeout" },
+  }));
+  await expect(run(execute, { action: "X" })).rejects.toThrow(
+    /integrations execute failed \(502\)/,
+  );
+});
+
 test("live mode gates: a turn switched to Plan refuses execute and the connect hand-off", async () => {
   // The user flipped the Mode pill to Plan while the turn ran: acting on the
   // user's apps refuses BEFORE any network call, with the planning instruction.

--- a/packages/runtime/src/session/tools/integrations.ts
+++ b/packages/runtime/src/session/tools/integrations.ts
@@ -120,6 +120,25 @@ class NoAgentAccessError extends Error {
 }
 
 /**
+ * Thrown by `post()` when Composio reports the EXECUTED action slug does not
+ * exist at the current tool version ("Tool_ToolNotFound", code 2401). The slug
+ * came from the model's context — a search result from earlier in a long chat
+ * (Composio renames and removes actions over time) or an invented name — so the
+ * recovery is mechanical: search again, run a slug from the fresh results
+ * (PRODUCT-1266: the raw failure taught users that only a NEW chat "fixes"
+ * integrations). Classified on Composio's stable error slug, which every relay
+ * path carries verbatim inside the failure body (the cloud gateway wraps the
+ * upstream 404 in a 502, the direct adapter surfaces it as a 500) — never the
+ * bare status, which any transient upstream failure shares.
+ */
+class ActionNotFoundError extends Error {
+  constructor() {
+    super("action not found");
+    this.name = "ActionNotFoundError";
+  }
+}
+
+/**
  * What the model must say when the user may not use this agent. The gateway's
  * own wording is internal jargon ("this agent isn't assigned to you") and its
  * body is JSON — both would be paraphrased straight at a non-technical user, so
@@ -292,6 +311,14 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
           "Connected apps are not set up in this Houston install. Tell the user plainly that connected apps aren't available here (a self-hoster enables them by setting COMPOSIO_API_KEY), and do not offer to connect any apps.",
         );
       }
+      // Tool_ToolNotFound: Composio says the executed action slug does not
+      // exist at the current tool version — a stale or invented slug, fixed by
+      // searching again. The provider 404 reaches us wrapped in a relayed 5xx
+      // whose body keeps Composio's stable error slug verbatim, so that slug
+      // (not the outer status) is the classification key.
+      if (path === "execute" && detail.includes("Tool_ToolNotFound")) {
+        throw new ActionNotFoundError();
+      }
       // Anything else. A 4xx is a REFUSAL, and its body is gateway/provider
       // JSON written for us, not for a person — the model reads whatever we
       // throw and paraphrases it straight at the user, so the body is REDACTED
@@ -421,9 +448,14 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
   const execute = defineTool<
     typeof ExecuteParams,
     // Pinned so the success path ({ action }) and the refused paths (walled-off
-    // app, no access to the agent) share ONE details type — each flag is
-    // present only in its state.
-    { action: string; appTurnedOff?: boolean; noAgentAccess?: boolean }
+    // app, no access to the agent, stale slug) share ONE details type — each
+    // flag is present only in its state.
+    {
+      action: string;
+      appTurnedOff?: boolean;
+      noAgentAccess?: boolean;
+      actionNotFound?: boolean;
+    }
   >({
     name: "integration_execute",
     label: "Run an app action",
@@ -476,6 +508,22 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
               { type: "text" as const, text: NO_AGENT_ACCESS_GUIDANCE },
             ],
             details: { action: params.action, noAgentAccess: true },
+          };
+        }
+        // The action slug does not exist (any more): a stale slug remembered
+        // from earlier in the conversation, or an invented one. RETURN the
+        // mechanical recovery — search again, use a fresh slug — so the model
+        // completes the task in THIS chat instead of telling the user that
+        // integrations are broken (PRODUCT-1266).
+        if (err instanceof ActionNotFoundError) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `The action slug "${params.action}" does not exist in the app catalog. App actions are renamed and removed over time, so a slug remembered from earlier in this conversation (or guessed) may not be real any more. Call integration_search now to find the current action for what you are doing, then run integration_execute with a slug taken from those fresh results. Do not retry this slug, do not invent slugs, and never mention slugs or any other technical detail to the user.`,
+              },
+            ],
+            details: { action: params.action, actionNotFound: true },
           };
         }
         throw err;


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1266: integrations "not working" in some chats while a brand-new mission works.

**Root cause.** In a long chat the model reuses an integration action slug from its own context: a search result from before Composio renamed/removed the action, or a plausible invented name. `GMAIL_SEARCH_EMAILS` (the slug in the report) does not exist in Composio's catalog at all - the real action is `GMAIL_FETCH_EMAILS` (verified against the live Composio API, which returns the exact `Tool_ToolNotFound` 404 from the report). Composio 404s the execute, the cloud gateway wraps it in a 502 (the direct adapter path surfaces it as a 500), and `integration_execute` threw it as a raw fatal error. Nothing told the model the recovery is mechanical - search again - so the agent reported integrations as broken. A new mission always starts with a fresh `integration_search`, gets current slugs, and works, which is why "create a new mission" looked like the fix.

**The fix.** `integration_execute` (`packages/runtime/src/session/tools/integrations.ts`) now classifies Composio's stable `Tool_ToolNotFound` error slug - carried verbatim inside the relayed failure body on every deployment path - and RETURNS re-search guidance to the model instead of throwing: the slug doesn't exist, call `integration_search` now, run a slug from the fresh results, don't retry or invent slugs, don't quote technical detail to the user. The model then self-heals in the same chat. Classification keys on the stable slug, never the bare status, so a genuine transient 502/500 still surfaces as the generic error (covered by test).

## Reproduce (before the fix)

1. In any chat with Gmail connected, get the agent to run `integration_execute` with a nonexistent slug - easiest deterministic way: ask the agent verbatim *"Run the integration action GMAIL_SEARCH_EMAILS to look for emails from Stripe, do not search for the action first, just execute it."*
2. The activity shows `integrations execute failed (502): {"error":"composio POST /api/v3/tools/execute/GMAIL_SEARCH_EMAILS → 404: ... Tool_ToolNotFound ..."}` and the agent tells the user it could not use the app. Organic repro is any long chat whose earlier context contains action slugs Composio has since renamed.

## Verify (after the fix)

1. Repeat the same prompt. The execute no longer errors: the tool result tells the model the slug doesn't exist and to search again; the agent runs `integration_search`, picks `GMAIL_FETCH_EMAILS`, and completes the task in the same chat with no user intervention.
2. `pnpm --filter @houston/runtime test` - 1023 tests pass, including three new ones pinning: gateway-502 classification, direct-adapter-500 classification, and that a plain 502 without the Composio slug stays a generic transient error.

Reported by a user in an existing chat; new-mission workaround confirmed by the reporter.