### PR TITLE
feat(chat): Updates made reviews external-artifact actions with links (PRODUCT-1196)

### DIFF
--- a/app/src/components/turn-file-summary.tsx
+++ b/app/src/components/turn-file-summary.tsx
@@ -1,12 +1,10 @@
-import { cn } from "@houston-ai/core";
-import type { TFunction } from "i18next";
-import { ChevronDownIcon, Lightbulb, Play, ScrollText } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCapabilities } from "../hooks/use-capabilities";
 import { useOpenAgentFile } from "../hooks/use-open-agent-file";
 import { isAgentManager } from "../lib/agent-access";
-import { fileNameOf } from "../lib/agent-file-paths";
+import { genericErrorDescription } from "../lib/error-report";
+import { tauriSystem } from "../lib/tauri";
 import {
   groupTurnSummaryItems,
   type SemanticUpdateKind,
@@ -14,7 +12,8 @@ import {
 } from "../lib/turn-summary-items";
 import { useAgentStore } from "../stores/agents";
 import { useUIStore } from "../stores/ui";
-import { getFileIcon } from "./file-card";
+import { TurnSummarySection } from "./turn-summary-section";
+import { useActionBrandResolver } from "./use-action-brand-resolver";
 
 interface TurnFileSummaryProps {
   items: TurnSummaryItem[];
@@ -24,8 +23,13 @@ interface TurnFileSummaryProps {
 export function TurnFileSummary({ items, agentPath }: TurnFileSummaryProps) {
   const { t } = useTranslation("chat");
   const { capabilities } = useCapabilities();
-  const [openUpdates, setOpenUpdates] = useState(false);
+  // "Updates made" starts EXPANDED (PRODUCT-1196): it is the turn's receipt,
+  // and a collapsed receipt was read as "nothing happened". New files keep
+  // their collapsed default — they are secondary.
+  const [openUpdates, setOpenUpdates] = useState(true);
   const [openFiles, setOpenFiles] = useState(false);
+  const addToast = useUIStore((s) => s.addToast);
+  const resolveBrand = useActionBrandResolver();
 
   const { openFile: handleOpen } = useOpenAgentFile(agentPath);
 
@@ -51,116 +55,51 @@ export function TurnFileSummary({ items, agentPath }: TurnFileSummaryProps) {
     [agentPath, capabilities],
   );
 
+  const handleOpenUrl = useCallback(
+    (url: string) => {
+      tauriSystem.openUrl(url).catch((err) => {
+        addToast({
+          variant: "error",
+          title: t("summary.openLinkFailedTitle"),
+          description: genericErrorDescription("open_summary_link", err),
+        });
+      });
+    },
+    [addToast, t],
+  );
+
   if (items.length === 0) return null;
   const groups = groupTurnSummaryItems(items);
 
   return (
     <div className="mt-3 flex flex-col gap-2">
       {groups.updates.length > 0 && (
-        <SummarySection
+        <TurnSummarySection
           title={t("summary.updatesMade")}
           items={groups.updates}
           open={openUpdates}
+          done
           onOpenChange={setOpenUpdates}
           onOpenFile={handleOpen}
           onOpenSemantic={handleOpenSemantic}
+          onOpenUrl={handleOpenUrl}
+          resolveBrand={resolveBrand}
           t={t}
         />
       )}
       {groups.files.length > 0 && (
-        <SummarySection
+        <TurnSummarySection
           title={t("summary.newFiles", { count: groups.files.length })}
           items={groups.files}
           open={openFiles}
           onOpenChange={setOpenFiles}
           onOpenFile={handleOpen}
           onOpenSemantic={handleOpenSemantic}
+          onOpenUrl={handleOpenUrl}
+          resolveBrand={resolveBrand}
           t={t}
         />
       )}
     </div>
   );
-}
-
-function SummarySection({
-  title,
-  items,
-  open,
-  onOpenChange,
-  onOpenFile,
-  onOpenSemantic,
-  t,
-}: {
-  title: string;
-  items: TurnSummaryItem[];
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onOpenFile: (path: string) => void;
-  onOpenSemantic: (kind: SemanticUpdateKind) => void;
-  t: TFunction<"chat">;
-}) {
-  return (
-    <div className="rounded-lg border border-line/50 bg-chip overflow-hidden">
-      <button
-        type="button"
-        onClick={() => onOpenChange(!open)}
-        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-ink-muted hover:text-ink transition-colors"
-      >
-        <ChevronDownIcon
-          className={cn(
-            "h-4 w-4 transition-transform",
-            open ? "rotate-0" : "-rotate-90",
-          )}
-        />
-        <span>{title}</span>
-      </button>
-      {open && (
-        <div className="border-t border-line/50 divide-y divide-line/50">
-          {items.map((item) => {
-            const key = item.kind === "file" ? item.path : item.update;
-            const Icon = itemIcon(item);
-            return (
-              <button
-                key={key}
-                type="button"
-                onClick={() =>
-                  item.kind === "file"
-                    ? onOpenFile(item.path)
-                    : onOpenSemantic(item.update)
-                }
-                className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left hover:bg-hover transition-colors"
-              >
-                <Icon className="h-4 w-4 text-ink-muted shrink-0" />
-                <span className="truncate">{itemLabel(item, t)}</span>
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function semanticIcon(kind: SemanticUpdateKind) {
-  if (kind === "instructions") return ScrollText;
-  if (kind === "skills") return Play;
-  return Lightbulb;
-}
-
-function itemIcon(item: TurnSummaryItem) {
-  if (item.kind === "semantic") return semanticIcon(item.update);
-  const fileName = fileNameOf(item.path);
-  const ext = fileName.includes(".")
-    ? fileName.split(".").pop()?.toLowerCase()
-    : undefined;
-  return getFileIcon(ext);
-}
-
-function itemLabel(item: TurnSummaryItem, t: TFunction<"chat">): string {
-  if (item.kind === "semantic") {
-    if (item.update === "instructions") return t("summary.instructionsUpdated");
-    if (item.update === "skills") return t("summary.skillsUpdated");
-    return t("summary.learningsUpdated");
-  }
-  return fileNameOf(item.path);
 }

--- a/app/src/components/turn-summary-section.tsx
+++ b/app/src/components/turn-summary-section.tsx
@@ -1,0 +1,199 @@
+import type { ChatActionBrand } from "@houston-ai/chat";
+import { cn } from "@houston-ai/core";
+import type { TFunction } from "i18next";
+import {
+  CheckCircle2,
+  ChevronDownIcon,
+  ExternalLink,
+  Globe,
+  Lightbulb,
+  Play,
+  ScrollText,
+  Wrench,
+} from "lucide-react";
+import { useState } from "react";
+import { fileNameOf } from "../lib/agent-file-paths";
+import type {
+  SemanticUpdateKind,
+  TurnSummaryItem,
+} from "../lib/turn-summary-items";
+import { getFileIcon } from "./file-card";
+
+/**
+ * One collapsible group of the turn-end summary ("Updates made" / "N new
+ * files"). Three row species: agent files (open in preview/OS), semantic
+ * updates (jump to the matching tab), and external-artifact integration rows
+ * (PRODUCT-1196) — branded `Gmail · Sent email` rows that open the artifact's
+ * URL when the action's result named one, with a visible external-link glyph
+ * (never hover-gated). `done` renders the header's success checkmark.
+ */
+export function TurnSummarySection({
+  title,
+  items,
+  open,
+  done,
+  onOpenChange,
+  onOpenFile,
+  onOpenSemantic,
+  onOpenUrl,
+  resolveBrand,
+  t,
+}: {
+  title: string;
+  items: TurnSummaryItem[];
+  open: boolean;
+  done?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onOpenFile: (path: string) => void;
+  onOpenSemantic: (kind: SemanticUpdateKind) => void;
+  onOpenUrl: (url: string) => void;
+  resolveBrand: (action: string) => ChatActionBrand | undefined;
+  t: TFunction<"chat">;
+}) {
+  return (
+    <div className="rounded-lg border border-line/50 bg-chip overflow-hidden">
+      <button
+        type="button"
+        onClick={() => onOpenChange(!open)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-ink-muted hover:text-ink transition-colors"
+      >
+        <ChevronDownIcon
+          className={cn(
+            "h-4 w-4 transition-transform",
+            open ? "rotate-0" : "-rotate-90",
+          )}
+        />
+        <span>{title}</span>
+        {done && (
+          <CheckCircle2 aria-hidden className="h-4 w-4 shrink-0 text-success" />
+        )}
+      </button>
+      {open && (
+        <div className="border-t border-line/50 divide-y divide-line/50">
+          {items.map((item) =>
+            item.kind === "integration" ? (
+              <IntegrationUpdateRow
+                key={`${item.action}|${item.url ?? ""}`}
+                action={item.action}
+                url={item.url}
+                brand={resolveBrand(item.action)}
+                onOpenUrl={onOpenUrl}
+              />
+            ) : (
+              <button
+                key={item.kind === "file" ? item.path : item.update}
+                type="button"
+                onClick={() =>
+                  item.kind === "file"
+                    ? onOpenFile(item.path)
+                    : onOpenSemantic(item.update)
+                }
+                className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left hover:bg-hover transition-colors"
+              >
+                <ItemIcon item={item} />
+                <span className="truncate">{itemLabel(item, t)}</span>
+              </button>
+            ),
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * An external-artifact row: the app's logo (wrench for custom integrations,
+ * globe when no brand art resolves or the favicon 404s) + `{name} · {Sent
+ * email}`. With a URL the whole row is a button that opens the artifact and
+ * wears a visible external-link glyph; without one it is a plain fact row.
+ */
+function IntegrationUpdateRow({
+  action,
+  url,
+  brand,
+  onOpenUrl,
+}: {
+  action: string;
+  url?: string;
+  brand: ChatActionBrand | undefined;
+  onOpenUrl: (url: string) => void;
+}) {
+  const [logoFailed, setLogoFailed] = useState(false);
+  // The brand resolver only misses on an empty action; still, never render a
+  // raw slug — de-underscore it into words as the last resort.
+  const label = brand
+    ? `${brand.name} · ${brand.doneLabel ?? brand.actionLabel}`
+    : action.replace(/_/g, " ").toLowerCase();
+  const icon =
+    brand?.icon === "tool" ? (
+      <Wrench aria-hidden className="h-4 w-4 text-ink-muted shrink-0" />
+    ) : brand?.logoUrl && !logoFailed ? (
+      <img
+        alt=""
+        className="h-4 w-4 shrink-0 rounded object-contain"
+        decoding="async"
+        loading="lazy"
+        onError={() => setLogoFailed(true)}
+        src={brand.logoUrl}
+      />
+    ) : (
+      <Globe aria-hidden className="h-4 w-4 text-ink-muted shrink-0" />
+    );
+  const body = (
+    <>
+      {icon}
+      <span className="truncate">{label}</span>
+      {url && (
+        <ExternalLink
+          aria-hidden
+          className="h-3.5 w-3.5 text-ink-muted shrink-0 ml-auto"
+        />
+      )}
+    </>
+  );
+  const rowClass = "w-full flex items-center gap-2 px-3 py-2 text-sm text-left";
+  if (!url) return <div className={rowClass}>{body}</div>;
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenUrl(url)}
+      className={cn(rowClass, "hover:bg-hover transition-colors")}
+    >
+      {body}
+    </button>
+  );
+}
+
+function ItemIcon({
+  item,
+}: {
+  item: Exclude<TurnSummaryItem, { kind: "integration" }>;
+}) {
+  if (item.kind === "semantic") {
+    const Icon =
+      item.update === "instructions"
+        ? ScrollText
+        : item.update === "skills"
+          ? Play
+          : Lightbulb;
+    return <Icon className="h-4 w-4 text-ink-muted shrink-0" />;
+  }
+  const fileName = fileNameOf(item.path);
+  const ext = fileName.includes(".")
+    ? fileName.split(".").pop()?.toLowerCase()
+    : undefined;
+  const Icon = getFileIcon(ext);
+  return <Icon className="h-4 w-4 text-ink-muted shrink-0" />;
+}
+
+function itemLabel(
+  item: Exclude<TurnSummaryItem, { kind: "integration" }>,
+  t: TFunction<"chat">,
+): string {
+  if (item.kind === "semantic") {
+    if (item.update === "instructions") return t("summary.instructionsUpdated");
+    if (item.update === "skills") return t("summary.skillsUpdated");
+    return t("summary.learningsUpdated");
+  }
+  return fileNameOf(item.path);
+}

--- a/app/src/components/use-action-brand-resolver.ts
+++ b/app/src/components/use-action-brand-resolver.ts
@@ -1,4 +1,8 @@
-import { type ChatActionBrand, humanizeActionGerund } from "@houston-ai/chat";
+import {
+  type ChatActionBrand,
+  humanizeActionDone,
+  humanizeActionGerund,
+} from "@houston-ai/chat";
 import { useCallback, useMemo } from "react";
 import {
   useCustomIntegrationsFor,
@@ -63,6 +67,7 @@ export function useActionBrandResolver(): (
             camelToSnakeCase(customRef.tool),
             "",
           ),
+          doneLabel: humanizeActionDone(camelToSnakeCase(customRef.tool), ""),
         };
       }
       const toolkit = toolkitOfActionSlug(action, slugs);
@@ -72,6 +77,7 @@ export function useActionBrandResolver(): (
         name: brand.name,
         logoUrl: brand.logoUrl,
         actionLabel: humanizeActionGerund(action, toolkit),
+        doneLabel: humanizeActionDone(action, toolkit),
       };
     },
     [slugs, customDefs, resolveBrand],

--- a/app/src/lib/integration-artifact-url.ts
+++ b/app/src/lib/integration-artifact-url.ts
@@ -1,0 +1,116 @@
+/**
+ * Where on the web is the artifact an integration action touched? Resolution
+ * for the turn-end "Updates made" rows (PRODUCT-1196): first mine the action's
+ * result payload for an artifact-like URL, then fall back to synthesizing the
+ * canonical URL for well-known apps from the ids the action carried. Pure and
+ * DOM-free so the app's node:test suite covers it directly.
+ */
+
+// Keys that never point at the artifact itself, even though they end in
+// url/link (brand art, signed API downloads). Compared against the key
+// lowercased with separators stripped.
+const IGNORED_KEY = /(avatar|icon|image|photo|thumbnail|logo|download|upload)/;
+// Keys that near-certainly ARE the artifact's canonical web location.
+const PREFERRED_KEY =
+  /(webviewlink|htmllink|htmlurl|permalink|publicurl|spreadsheeturl|weburl|browserurl|shareurl|pageurl|eventurl|issueurl)/;
+// Hosts that are API surfaces, not something a person opens.
+const API_HOST = /^https?:\/\/(api\.|[^/]*googleapis\.com)/i;
+
+function scoreKey(rawKey: string, value: string): number {
+  const key = rawKey.toLowerCase().replace(/[_-]/g, "");
+  if (IGNORED_KEY.test(key) || API_HOST.test(value)) return 0;
+  if (PREFERRED_KEY.test(key)) return 2;
+  if (/(url|link)$/.test(key)) return 1;
+  return 0;
+}
+
+/**
+ * The most artifact-like `https` URL in an `integration_execute` result
+ * payload, or undefined. Walks the parsed JSON breadth-first (shallow fields
+ * outrank buried ones) scoring key names; when the payload does not parse —
+ * the runtime truncates oversized results mid-document — falls back to a
+ * key/value regex over the raw text.
+ */
+export function externalUrlOf(content: string): string | undefined {
+  let best: { score: number; url: string } | undefined;
+  const consider = (key: string, value: unknown) => {
+    if (typeof value !== "string" || !/^https?:\/\//.test(value)) return;
+    const score = scoreKey(key, value);
+    if (score > 0 && (!best || score > best.score))
+      best = { score, url: value };
+  };
+  try {
+    const queue: unknown[] = [JSON.parse(content)];
+    let visited = 0;
+    while (queue.length > 0 && visited < 2000) {
+      const node = queue.shift();
+      visited++;
+      if (Array.isArray(node)) {
+        queue.push(...node.slice(0, 50));
+      } else if (node && typeof node === "object") {
+        for (const [key, value] of Object.entries(node)) {
+          consider(key, value);
+          if (value && typeof value === "object") queue.push(value);
+        }
+      }
+      if (best?.score === 2) break;
+    }
+  } catch {
+    // Truncated or non-JSON payload: scan the raw text for `"key": "https..."`
+    // pairs instead — same scoring, no structure.
+    const pair = /"([^"\\]{1,64})"\s*:\s*"(https?:\/\/[^"\\]+)"/g;
+    for (let m = pair.exec(content); m !== null; m = pair.exec(content)) {
+      consider(m[1], m[2]);
+    }
+  }
+  return best?.url;
+}
+
+/** A record view of an unknown value; non-objects flatten to empty. */
+export function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * Well-known artifacts whose canonical URL is derivable from ids the action
+ * already carries, for results that name no URL at all (Gmail's send returns
+ * only message ids; Sheets edits return the spreadsheet id).
+ */
+export function synthesizedUrl(
+  action: string,
+  params: Record<string, unknown>,
+  data: Record<string, unknown>,
+): string | undefined {
+  // Composio nests some payloads one level down (`data.response_data`).
+  const sources = [params, data, asRecord(data.response_data)];
+  const id = (...keys: string[]) => {
+    for (const k of keys) {
+      for (const source of sources) {
+        const v = source[k];
+        if (typeof v === "string" && v.length > 0) return v;
+      }
+    }
+    return undefined;
+  };
+  const a = action.toUpperCase();
+  if (a.startsWith("GOOGLESHEETS")) {
+    const sheet = id("spreadsheet_id", "spreadsheetId");
+    if (sheet) return `https://docs.google.com/spreadsheets/d/${sheet}`;
+  }
+  if (a.startsWith("GOOGLEDOCS")) {
+    const doc = id("document_id", "documentId");
+    if (doc) return `https://docs.google.com/document/d/${doc}`;
+  }
+  if (a.startsWith("GMAIL")) {
+    const message = id("thread_id", "threadId", "id");
+    if (message) return `https://mail.google.com/mail/u/0/#all/${message}`;
+  }
+  if (a.startsWith("AIRTABLE")) {
+    const base = id("base_id", "baseId");
+    const table = id("table_id", "tableId", "table_id_or_name");
+    if (base && table) return `https://airtable.com/${base}/${table}`;
+  }
+  return undefined;
+}

--- a/app/src/lib/turn-integration-updates.ts
+++ b/app/src/lib/turn-integration-updates.ts
@@ -1,0 +1,129 @@
+import type { ToolEntry } from "@houston-ai/chat";
+import {
+  asRecord,
+  externalUrlOf,
+  synthesizedUrl,
+} from "./integration-artifact-url.ts";
+
+/**
+ * External-artifact rows for the turn-end "Updates made" summary
+ * (PRODUCT-1196): every successful `integration_execute` WRITE action (sent an
+ * email, edited a sheet, updated a record...) becomes a reviewable row, with a
+ * click-through URL whenever the action's result (or its parameters) can name
+ * one. Read actions (fetch/list/search) never appear — the summary reviews
+ * what the agent CHANGED in the outside world, not what it looked at.
+ *
+ * Pure and DOM-free so the app's node:test suite covers it directly.
+ */
+export interface TurnIntegrationUpdate {
+  kind: "integration";
+  /** The action slug exactly as executed (Composio slug or custom executor
+   *  address) — the brand resolver turns it into `Gmail · Sent email`. */
+  action: string;
+  /** The external artifact, when the result named one. Absent = a plain row. */
+  url?: string;
+}
+
+// Mutation verbs. An action counts as an external WRITE when any
+// underscore-separated token of its slug is one of these — token-scanned (not
+// prefix-stripped) because the toolkit catalog is not available here to strip
+// the app prefix ("GOOGLESHEETS_BATCH_UPDATE" hits via "update").
+const WRITE_VERBS = new Set([
+  "send",
+  "create",
+  "update",
+  "delete",
+  "remove",
+  "add",
+  "insert",
+  "append",
+  "upload",
+  "write",
+  "edit",
+  "set",
+  "move",
+  "reply",
+  "post",
+  "forward",
+  "archive",
+  "publish",
+  "submit",
+  "schedule",
+  "invite",
+  "share",
+  "assign",
+  "complete",
+  "cancel",
+  "rename",
+  "duplicate",
+  "copy",
+  "star",
+  "upsert",
+  "patch",
+  "modify",
+  "merge",
+  "trash",
+]);
+
+/** "listJobs" → "list_jobs", so a custom executor tool name token-scans the
+ *  same way a Composio slug does. */
+function toSnakeTokens(name: string): string[] {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .split(/[._-]/)
+    .filter(Boolean);
+}
+
+/** True when the action mutates an external artifact. Handles both grammars:
+ *  a Composio slug (`GMAIL_SEND_EMAIL`) and a custom executor address
+ *  (`tools.<slug>.<owner>.<connection>...<tool>`, scanned by its tool name). */
+export function isExternalWriteAction(action: string): boolean {
+  const subject = action.startsWith("tools.")
+    ? (action.split(".").at(-1) ?? "")
+    : action;
+  return toSnakeTokens(subject).some((t) => WRITE_VERBS.has(t));
+}
+
+/**
+ * The external-artifact rows of a turn. Only SUCCESSFUL write actions qualify;
+ * the execute tool also returns non-error guidance texts (app turned off,
+ * stale slug) — those are prose, never the `{`/`[` JSON (or bare "Done.") a
+ * real success emits, so they are filtered by shape. Identical (action, url)
+ * repeats collapse into one row; distinct artifacts keep their own.
+ */
+export function integrationUpdatesOf(
+  tools: ToolEntry[],
+): TurnIntegrationUpdate[] {
+  const updates: TurnIntegrationUpdate[] = [];
+  const seen = new Set<string>();
+  for (const tool of tools) {
+    if (!tool.result || tool.result.is_error) continue;
+    const short = tool.name.includes("__")
+      ? (tool.name.split("__").at(-1) ?? tool.name)
+      : tool.name;
+    if (short !== "integration_execute") continue;
+    const input = asRecord(tool.input);
+    const action = input.action;
+    if (typeof action !== "string" || !isExternalWriteAction(action)) continue;
+    const content = tool.result.content.trimStart();
+    const succeeded =
+      content.startsWith("{") || content.startsWith("[") || content === "Done.";
+    if (!succeeded) continue;
+    let data: Record<string, unknown> = {};
+    try {
+      data = asRecord(JSON.parse(tool.result.content));
+    } catch {
+      // Truncated payload: URL extraction falls back to a raw-text scan and
+      // synthesis works from the action's params alone.
+    }
+    const url =
+      externalUrlOf(tool.result.content) ??
+      synthesizedUrl(action, asRecord(input.params), data);
+    const key = `${action}|${url ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    updates.push({ kind: "integration", action, ...(url ? { url } : {}) });
+  }
+  return updates;
+}

--- a/app/src/lib/turn-summary-items.ts
+++ b/app/src/lib/turn-summary-items.ts
@@ -1,12 +1,17 @@
 import type { FileChangeEntry, ToolEntry } from "@houston-ai/chat";
-import { fileNameOf, toWorkspaceRelative } from "./agent-file-paths";
+import { fileNameOf, toWorkspaceRelative } from "./agent-file-paths.ts";
+import {
+  integrationUpdatesOf,
+  type TurnIntegrationUpdate,
+} from "./turn-integration-updates.ts";
 
 export type SemanticUpdateKind = "instructions" | "skills" | "learnings";
 export type FileUpdateKind = "created" | "modified";
 
 export type TurnSummaryItem =
   | { kind: "file"; path: string; change: FileUpdateKind }
-  | { kind: "semantic"; update: SemanticUpdateKind };
+  | { kind: "semantic"; update: SemanticUpdateKind }
+  | TurnIntegrationUpdate;
 
 export interface TurnSummaryGroups {
   updates: TurnSummaryItem[];
@@ -167,6 +172,9 @@ export function buildTurnSummaryItems(
   }
 
   return [
+    // External-artifact actions lead: they are the updates the user most wants
+    // to review (and click through to) at a glance (PRODUCT-1196).
+    ...integrationUpdatesOf(tools),
     ...Array.from(semantic).map((update) => ({
       kind: "semantic" as const,
       update,
@@ -180,7 +188,7 @@ export function groupTurnSummaryItems(
 ): TurnSummaryGroups {
   return {
     updates: items.filter(
-      (item) => item.kind === "semantic" || item.change === "modified",
+      (item) => item.kind !== "file" || item.change === "modified",
     ),
     files: items.filter(isCreatedFile),
   };

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -242,7 +242,8 @@
     "newFiles_other": "{{count}} new files",
     "instructionsUpdated": "Instructions updated",
     "skillsUpdated": "Skills updated",
-    "learningsUpdated": "Learnings updated"
+    "learningsUpdated": "Learnings updated",
+    "openLinkFailedTitle": "Couldn’t open the link"
   },
   "filesUpdated_one": "1 file updated",
   "filesUpdated_other": "{{count}} files updated",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -242,7 +242,8 @@
     "newFiles_other": "{{count}} archivos nuevos",
     "instructionsUpdated": "Instrucciones actualizadas",
     "skillsUpdated": "Skills actualizados",
-    "learningsUpdated": "Aprendizajes actualizados"
+    "learningsUpdated": "Aprendizajes actualizados",
+    "openLinkFailedTitle": "No se pudo abrir el enlace"
   },
   "filesUpdated_one": "1 archivo actualizado",
   "filesUpdated_other": "{{count}} archivos actualizados",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -242,7 +242,8 @@
     "newFiles_other": "{{count}} arquivos novos",
     "instructionsUpdated": "Instruções atualizadas",
     "skillsUpdated": "Skills atualizados",
-    "learningsUpdated": "Aprendizados atualizados"
+    "learningsUpdated": "Aprendizados atualizados",
+    "openLinkFailedTitle": "Não foi possível abrir o link"
   },
   "filesUpdated_one": "1 arquivo atualizado",
   "filesUpdated_other": "{{count}} arquivos atualizados",

--- a/app/tests/turn-integration-updates.test.ts
+++ b/app/tests/turn-integration-updates.test.ts
@@ -1,0 +1,220 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  externalUrlOf,
+  synthesizedUrl,
+} from "../src/lib/integration-artifact-url.ts";
+import {
+  integrationUpdatesOf,
+  isExternalWriteAction,
+} from "../src/lib/turn-integration-updates.ts";
+import {
+  buildTurnSummaryItems,
+  groupTurnSummaryItems,
+} from "../src/lib/turn-summary-items.ts";
+
+const ok = (content: string) => ({ content, is_error: false });
+
+describe("isExternalWriteAction", () => {
+  it("accepts mutation slugs", () => {
+    strictEqual(isExternalWriteAction("GMAIL_SEND_EMAIL"), true);
+    strictEqual(isExternalWriteAction("GOOGLESHEETS_BATCH_UPDATE"), true);
+    strictEqual(isExternalWriteAction("AIRTABLE_CREATE_RECORD"), true);
+    strictEqual(isExternalWriteAction("NOTION_ADD_PAGE_CONTENT"), true);
+  });
+
+  it("rejects read slugs", () => {
+    strictEqual(isExternalWriteAction("GMAIL_FETCH_EMAILS"), false);
+    strictEqual(isExternalWriteAction("GOOGLESHEETS_GET_SPREADSHEET"), false);
+    strictEqual(isExternalWriteAction("SLACK_LIST_CHANNELS"), false);
+    strictEqual(isExternalWriteAction("LINEAR_SEARCH_ISSUES"), false);
+  });
+
+  it("does not confuse app names containing verb-like words", () => {
+    strictEqual(isExternalWriteAction("SENDGRID_GET_STATS"), false);
+  });
+
+  it("reads a custom executor address by its tool name", () => {
+    strictEqual(
+      isExternalWriteAction("tools.acme-crm.owner.conn.jobs.createJob"),
+      true,
+    );
+    strictEqual(
+      isExternalWriteAction("tools.acme-crm.owner.conn.jobs.listJobs"),
+      false,
+    );
+  });
+});
+
+describe("externalUrlOf", () => {
+  it("prefers canonical artifact keys over generic url keys", () => {
+    const url = externalUrlOf(
+      JSON.stringify({
+        selfLink: "https://example.com/generic",
+        file: { webViewLink: "https://docs.google.com/document/d/abc/edit" },
+      }),
+    );
+    strictEqual(url, "https://docs.google.com/document/d/abc/edit");
+  });
+
+  it("skips API hosts and brand art", () => {
+    const url = externalUrlOf(
+      JSON.stringify({
+        url: "https://api.airtable.com/v0/app123",
+        iconUrl: "https://cdn.example.com/icon.png",
+        record_url: "https://airtable.com/app123/tbl456/rec789",
+      }),
+    );
+    strictEqual(url, "https://airtable.com/app123/tbl456/rec789");
+  });
+
+  it("returns undefined when nothing artifact-like exists", () => {
+    strictEqual(
+      externalUrlOf(JSON.stringify({ id: "19x", threadId: "19x" })),
+      undefined,
+    );
+  });
+
+  it("falls back to a raw-text scan on truncated JSON", () => {
+    const truncated = `{
+  "permalink": "https://myworkspace.slack.com/archives/C1/p2",
+  "blob": "AAAA[result truncated: it exceeded the 256 KB tool-result limit`;
+    strictEqual(
+      externalUrlOf(truncated),
+      "https://myworkspace.slack.com/archives/C1/p2",
+    );
+  });
+});
+
+describe("synthesizedUrl", () => {
+  it("builds the spreadsheet URL from the action params", () => {
+    strictEqual(
+      synthesizedUrl("GOOGLESHEETS_BATCH_UPDATE", { spreadsheet_id: "S1" }, {}),
+      "https://docs.google.com/spreadsheets/d/S1",
+    );
+  });
+
+  it("builds the Gmail thread URL from the response data", () => {
+    strictEqual(
+      synthesizedUrl("GMAIL_SEND_EMAIL", {}, { id: "m1", threadId: "t1" }),
+      "https://mail.google.com/mail/u/0/#all/t1",
+    );
+    strictEqual(
+      synthesizedUrl(
+        "GMAIL_SEND_EMAIL",
+        {},
+        { response_data: { id: "m1", threadId: "t1" } },
+      ),
+      "https://mail.google.com/mail/u/0/#all/t1",
+    );
+  });
+
+  it("builds the Airtable table URL from base + table params", () => {
+    strictEqual(
+      synthesizedUrl(
+        "AIRTABLE_UPDATE_RECORD",
+        { base_id: "app1", table_id_or_name: "tbl1" },
+        {},
+      ),
+      "https://airtable.com/app1/tbl1",
+    );
+  });
+
+  it("knows nothing about other apps", () => {
+    strictEqual(
+      synthesizedUrl("SLACK_SEND_MESSAGE", { channel: "C1" }, {}),
+      undefined,
+    );
+  });
+});
+
+describe("integrationUpdatesOf", () => {
+  it("keeps successful writes, drops reads, errors, and guidance texts", () => {
+    const updates = integrationUpdatesOf([
+      {
+        name: "mcp__houston__integration_execute",
+        input: { action: "GMAIL_SEND_EMAIL", params: {} },
+        result: ok(JSON.stringify({ id: "m1", threadId: "t1" })),
+      },
+      {
+        name: "integration_execute",
+        input: { action: "GMAIL_FETCH_EMAILS", params: {} },
+        result: ok(JSON.stringify({ messages: [] })),
+      },
+      {
+        name: "integration_execute",
+        input: { action: "SLACK_SEND_MESSAGE", params: {} },
+        result: { content: "boom", is_error: true },
+      },
+      {
+        name: "integration_execute",
+        input: { action: "NOTION_CREATE_PAGE", params: {} },
+        result: ok("This action's app is turned off for this agent, so..."),
+      },
+      {
+        name: "Write",
+        input: { file_path: "/tmp/a.md" },
+        result: ok("ok"),
+      },
+    ]);
+    deepStrictEqual(updates, [
+      {
+        kind: "integration",
+        action: "GMAIL_SEND_EMAIL",
+        url: "https://mail.google.com/mail/u/0/#all/t1",
+      },
+    ]);
+  });
+
+  it("collapses identical repeats but keeps distinct artifacts", () => {
+    const send = (thread: string) => ({
+      name: "integration_execute",
+      input: { action: "GMAIL_SEND_EMAIL", params: {} },
+      result: ok(JSON.stringify({ threadId: thread })),
+    });
+    const updates = integrationUpdatesOf([send("t1"), send("t1"), send("t2")]);
+    strictEqual(updates.length, 2);
+    strictEqual(updates[0].url?.endsWith("t1"), true);
+    strictEqual(updates[1].url?.endsWith("t2"), true);
+  });
+
+  it("accepts a bare Done. result with no payload", () => {
+    const updates = integrationUpdatesOf([
+      {
+        name: "integration_execute",
+        input: { action: "TRELLO_MOVE_CARD", params: {} },
+        result: ok("Done."),
+      },
+    ]);
+    deepStrictEqual(updates, [
+      { kind: "integration", action: "TRELLO_MOVE_CARD" },
+    ]);
+  });
+});
+
+describe("turn summary grouping", () => {
+  it("puts integration rows first in Updates made", () => {
+    const items = buildTurnSummaryItems(
+      [
+        {
+          name: "integration_execute",
+          input: {
+            action: "GOOGLESHEETS_BATCH_UPDATE",
+            params: { spreadsheet_id: "S1" },
+          },
+          result: ok(JSON.stringify({ spreadsheetId: "S1" })),
+        },
+        {
+          name: "Edit",
+          input: { file_path: "Personal/Assistant/notes.md" },
+          result: ok("ok"),
+        },
+      ],
+      "Personal/Assistant",
+    );
+    const groups = groupTurnSummaryItems(items);
+    strictEqual(groups.updates[0].kind, "integration");
+    strictEqual(groups.updates.length, 2);
+    strictEqual(groups.files.length, 0);
+  });
+});

--- a/ui/chat/src/action-labels.ts
+++ b/ui/chat/src/action-labels.ts
@@ -1,0 +1,116 @@
+// Integration-action slug → human label. Pure and DOM-free so the node:test
+// suite can import it; both the process-block header (present tense) and the
+// turn-end "Updates made" summary (past tense, PRODUCT-1196) resolve their
+// labels here, from one verb table family.
+
+// Present-progressive forms for the common Composio action verbs. English only,
+// by the same rule as `tool-labels.ts`: `ui/` stays i18n-agnostic and the app
+// does not localize tool verbs, so an integration action reads in English in
+// every locale (matching the in-pane tool rows). An unmapped verb is capitalized
+// as-is, never conjugated — a wrong gerund reads worse than the plain word.
+const ACTION_GERUNDS: Record<string, string> = {
+  send: "Sending",
+  create: "Creating",
+  get: "Getting",
+  fetch: "Fetching",
+  list: "Listing",
+  search: "Searching",
+  find: "Finding",
+  update: "Updating",
+  delete: "Deleting",
+  move: "Moving",
+  reply: "Replying",
+  post: "Posting",
+  add: "Adding",
+  remove: "Removing",
+};
+
+// Past-tense forms for the same verbs (plus the mutation verbs the turn-end
+// "Updates made" summary lists, PRODUCT-1196), so a completed action reads as
+// a fact ("Sent email"), not a step in progress.
+const ACTION_DONE: Record<string, string> = {
+  send: "Sent",
+  create: "Created",
+  get: "Got",
+  fetch: "Fetched",
+  list: "Listed",
+  search: "Searched",
+  find: "Found",
+  update: "Updated",
+  delete: "Deleted",
+  move: "Moved",
+  reply: "Replied",
+  post: "Posted",
+  add: "Added",
+  remove: "Removed",
+  upload: "Uploaded",
+  insert: "Inserted",
+  append: "Appended",
+  edit: "Edited",
+  archive: "Archived",
+  forward: "Forwarded",
+  publish: "Published",
+  schedule: "Scheduled",
+  share: "Shared",
+  invite: "Invited",
+  copy: "Copied",
+  submit: "Submitted",
+  write: "Wrote",
+  star: "Starred",
+  cancel: "Canceled",
+  rename: "Renamed",
+  assign: "Assigned",
+  complete: "Completed",
+  set: "Set",
+};
+
+/** Capitalize the first letter, lowercase the rest ("SEND" -> "Send"). */
+function capitalizeWord(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+}
+
+/** The action slug's words with the toolkit prefix stripped (case-insensitive,
+ *  incl. multi-word toolkits like `google_maps`); empty when the slug is
+ *  nothing but the prefix. */
+function actionWords(action: string, toolkit: string): string[] {
+  const prefix = `${toolkit.toLowerCase()}_`;
+  const rest =
+    toolkit.length > 0 && action.toLowerCase().startsWith(prefix)
+      ? action.slice(prefix.length)
+      : action;
+  return rest.split("_").filter((w) => w.length > 0);
+}
+
+function humanizeAction(
+  action: string,
+  toolkit: string,
+  verbs: Record<string, string>,
+): string {
+  const words = actionWords(action, toolkit);
+  if (words.length === 0) {
+    // The action is nothing but the toolkit prefix ("GMAIL_"): no verb to
+    // conjugate, so fall back to the capitalized whole slug.
+    const whole = action.split("_").filter((w) => w.length > 0);
+    return whole.map(capitalizeWord).join(" ");
+  }
+  const [verb, ...tail] = words;
+  const head = verbs[verb.toLowerCase()] ?? capitalizeWord(verb);
+  return [head, ...tail.map((w) => w.toLowerCase())].join(" ");
+}
+
+/** A present-tense human label for a Composio action slug, for the process-block
+ *  header's branded row ("GMAIL_SEND_EMAIL" + toolkit "gmail" -> "Sending
+ *  email"). Strips the toolkit prefix, turns the leading verb into its gerund,
+ *  and lowercases the rest. An unmapped verb (or a slug that is all prefix)
+ *  falls back to the capitalized de-underscored remainder without conjugation
+ *  ("GMAIL_SYNC_CONTACTS" -> "Sync contacts"). Pure, node-tested. */
+export function humanizeActionGerund(action: string, toolkit: string): string {
+  return humanizeAction(action, toolkit, ACTION_GERUNDS);
+}
+
+/** The past-tense counterpart of {@link humanizeActionGerund}
+ *  ("GMAIL_SEND_EMAIL" + "gmail" -> "Sent email"), for surfaces that report a
+ *  completed action — the turn-end "Updates made" rows (PRODUCT-1196). */
+export function humanizeActionDone(action: string, toolkit: string): string {
+  return humanizeAction(action, toolkit, ACTION_DONE);
+}

--- a/ui/chat/src/chat-process-header.ts
+++ b/ui/chat/src/chat-process-header.ts
@@ -32,6 +32,11 @@ export interface ChatActionBrand {
    *  Takes precedence over `logoUrl`; absent → logo, else the helmet. */
   icon?: "tool";
   actionLabel: string;
+  /** The past-tense counterpart of `actionLabel` ("Sent email"), for surfaces
+   *  that report a COMPLETED action — the turn-end "Updates made" rows
+   *  (PRODUCT-1196). Optional and additive; absent falls back to
+   *  `actionLabel`. */
+  doneLabel?: string;
 }
 
 export interface ChatProcessLabels {

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -6,6 +6,7 @@ export {
   MAX_ATTACHMENT_FILES,
   TooManyAttachmentFilesError,
 } from "@houston-ai/core";
+export { humanizeActionDone, humanizeActionGerund } from "./action-labels";
 export type {
   ConversationContentProps,
   ConversationDownloadProps,
@@ -308,10 +309,7 @@ export type {
   StepFooterApi,
 } from "./interaction-card";
 export { ChatInteractionCard } from "./interaction-card";
-export {
-  humanizeActionGerund,
-  prettifyToolkit,
-} from "./interaction-card-model";
+export { prettifyToolkit } from "./interaction-card-model";
 // The always-visible single-line free-text row every non-question step carries
 // (connect / sign-in / credential decline-with-instruction).
 export { InlineTextRow } from "./interaction-decline-row";

--- a/ui/chat/src/interaction-card-model.ts
+++ b/ui/chat/src/interaction-card-model.ts
@@ -85,58 +85,6 @@ export function prettifyToolkit(toolkit: string): string {
     .join(" ");
 }
 
-// Present-progressive forms for the common Composio action verbs. English only,
-// by the same rule as `tool-labels.ts`: `ui/` stays i18n-agnostic and the app
-// does not localize tool verbs, so an integration action reads in English in
-// every locale (matching the in-pane tool rows). An unmapped verb is capitalized
-// as-is, never conjugated — a wrong gerund reads worse than the plain word.
-const ACTION_GERUNDS: Record<string, string> = {
-  send: "Sending",
-  create: "Creating",
-  get: "Getting",
-  fetch: "Fetching",
-  list: "Listing",
-  search: "Searching",
-  find: "Finding",
-  update: "Updating",
-  delete: "Deleting",
-  move: "Moving",
-  reply: "Replying",
-  post: "Posting",
-  add: "Adding",
-  remove: "Removing",
-};
-
-/** Capitalize the first letter, lowercase the rest ("SEND" -> "Send"). */
-function capitalizeWord(word: string): string {
-  return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
-}
-
-/** A present-tense human label for a Composio action slug, for the process-block
- *  header's branded row ("GMAIL_SEND_EMAIL" + toolkit "gmail" -> "Sending
- *  email"). Strips the toolkit prefix (case-insensitive, incl. multi-word
- *  toolkits like `google_maps`), turns the leading verb into its gerund, and
- *  lowercases the rest. An unmapped verb (or a slug that is all prefix) falls
- *  back to the capitalized de-underscored remainder without conjugation
- *  ("GMAIL_SYNC_CONTACTS" -> "Sync contacts"). Pure, node-tested. */
-export function humanizeActionGerund(action: string, toolkit: string): string {
-  const prefix = `${toolkit.toLowerCase()}_`;
-  const rest =
-    toolkit.length > 0 && action.toLowerCase().startsWith(prefix)
-      ? action.slice(prefix.length)
-      : action;
-  const words = rest.split("_").filter((w) => w.length > 0);
-  if (words.length === 0) {
-    // The action is nothing but the toolkit prefix ("GMAIL_"): no verb to
-    // conjugate, so fall back to the capitalized whole slug.
-    const whole = action.split("_").filter((w) => w.length > 0);
-    return whole.map(capitalizeWord).join(" ");
-  }
-  const [verb, ...tail] = words;
-  const head = ACTION_GERUNDS[verb.toLowerCase()] ?? capitalizeWord(verb);
-  return [head, ...tail.map((w) => w.toLowerCase())].join(" ");
-}
-
 /** The option label for a question step, or null when the id is unknown. */
 export function optionLabel(
   step: ChatInteractionStep,

--- a/ui/chat/tests/interaction-card-model.test.ts
+++ b/ui/chat/tests/interaction-card-model.test.ts
@@ -1,6 +1,9 @@
 import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
-import { humanizeActionGerund } from "../src/interaction-card-model.ts";
+import {
+  humanizeActionDone,
+  humanizeActionGerund,
+} from "../src/action-labels.ts";
 
 // The process-block header's branded row narrates an integration action in
 // present tense. The verb becomes its gerund; the toolkit prefix is stripped
@@ -51,5 +54,32 @@ describe("humanizeActionGerund", () => {
       humanizeActionGerund("HUBSPOT_GET_CONTACT_BY_ID", "hubspot"),
       "Getting contact by id",
     );
+  });
+});
+
+// The turn-end "Updates made" rows narrate a COMPLETED action (PRODUCT-1196):
+// same prefix-stripping, past-tense verbs, same never-mis-conjugate fallback.
+describe("humanizeActionDone", () => {
+  it("strips the toolkit prefix and uses the past tense", () => {
+    strictEqual(humanizeActionDone("GMAIL_SEND_EMAIL", "gmail"), "Sent email");
+    strictEqual(
+      humanizeActionDone("GOOGLESHEETS_BATCH_UPDATE", "googlesheets"),
+      "Batch update",
+    );
+    strictEqual(
+      humanizeActionDone("AIRTABLE_UPDATE_RECORD", "airtable"),
+      "Updated record",
+    );
+  });
+
+  it("falls back to a capitalized remainder for an unmapped verb", () => {
+    strictEqual(
+      humanizeActionDone("GMAIL_SYNC_CONTACTS", "gmail"),
+      "Sync contacts",
+    );
+  });
+
+  it("conjugates a custom executor tool name without a toolkit", () => {
+    strictEqual(humanizeActionDone("create_job", ""), "Created job");
   });
 });


### PR DESCRIPTION
## Summary

PRODUCT-1196. The turn-end **Updates made** section now does what its name promises: it is a reviewable receipt of what the agent changed, including in the outside world.

**Root cause of the gap:** the summary was built exclusively from file-tool calls (`Write`/`Edit`/`Bash` output paths), so external work — sending an email, editing a Google Sheet, updating an Airtable record — never appeared, and the section defaulted to collapsed, reading as "nothing happened".

### What changed

- **External-artifact rows** (`app/src/lib/turn-integration-updates.ts`): every successful `integration_execute` WRITE action becomes a branded row (`Gmail · Sent email`) in Updates made. Read actions (fetch/list/search) are excluded — the section reviews what the agent *changed*, not what it looked at. Failed calls and the tool's non-error guidance texts (app turned off, stale slug) are filtered out.
- **Click-through URLs** (`app/src/lib/integration-artifact-url.ts`): the row opens the artifact when the result payload names an artifact-like URL (key-scored: `webViewLink`/`permalink`/`*_url`, API hosts and brand art excluded; raw-text fallback for truncated payloads), or when the canonical URL is derivable from ids the action carried (Google Sheets, Google Docs, Gmail, Airtable). A visible external-link glyph marks clickable rows — names with hyperlinks, never raw URLs.
- **Expanded by default + checkmark**: Updates made starts open with a success checkmark in its header. New files keeps its collapsed default.
- **Past-tense action labels** (`ui/chat/src/action-labels.ts`): the verb table family moved to its own module and gained `humanizeActionDone` ("Sent email"); `ChatActionBrand` carries an additive optional `doneLabel`, filled by the app's brand resolver for both Composio slugs and custom executor addresses.
- Row rendering extracted to `app/src/components/turn-summary-section.tsx` (file-size limit); URL-open failures surface as a toast (new `summary.openLinkFailedTitle` key in en/es/pt).

### Verification

Before the fix (repro):
1. Connect Gmail (or any app) to an agent and ask it to send an email / edit a sheet.
2. When the turn settles, the mission log shows the tool ran, but **Updates made shows nothing** about it (or doesn't render at all), and when it does render for file edits it is collapsed by default.

After the fix:
1. Same ask. When the turn settles, **Updates made is expanded**, its header shows a checkmark, and a row like `Gmail · Sent email` (app logo, no raw slug/URL) appears first.
2. Rows with a resolvable artifact show an external-link glyph; clicking opens the sheet/thread/record in the browser.
3. Read-only turns (e.g. "check my inbox") add no integration rows.

### Tests

- `app/tests/turn-integration-updates.test.ts` (16 new): write/read classification incl. custom executor addresses and verb-like app names, URL scoring, API-host/brand-art exclusion, truncated-JSON fallback, URL synthesis, guidance-text filtering, dedup, grouping order.
- `ui/chat/tests/interaction-card-model.test.ts`: past-tense humanizer cases.
- Gates: `pnpm check` (Biome), `pnpm typecheck`, `pnpm check:boundaries`, `cd app && pnpm test` (2783 pass), `pnpm check-locales`, `ui/chat pnpm test` (386 pass). Visual baselines unaffected (the chat baseline scenario runs no tools).