### PR TITLE
feat(integrations): OAuth state carries the pod routing prefix for the gateway callback (PRODUCT-1172)

### DIFF
--- a/packages/host/src/integrations/custom/manager.ts
+++ b/packages/host/src/integrations/custom/manager.ts
@@ -41,10 +41,11 @@ export class CustomIntegrationManager {
     private readonly host: CustomExecutorHost,
     private readonly onChanged: () => void,
     /** OAuth sign-in (PRODUCT-1172): the browser-reachable callback URL —
-     *  absent on deployments that cannot receive the redirect — and a fetch
-     *  seam for tests. */
+     *  absent on deployments that cannot receive the redirect — the state
+     *  routing prefix for gateway-fronted pods, and a fetch seam for tests. */
     private readonly oauth: {
       callbackUrl?: string;
+      statePrefix?: string;
       fetchFn?: typeof fetch;
     } = {},
   ) {}

--- a/packages/host/src/integrations/custom/oauth-flow.test.ts
+++ b/packages/host/src/integrations/custom/oauth-flow.test.ts
@@ -124,7 +124,7 @@ describe("beginCustomOAuth", () => {
       DEF,
       redirect,
       null,
-      fetchFn,
+      { fetchFn },
     );
     const url = new URL(authorizeUrl);
     expect(`${url.origin}${url.pathname}`).toBe(`${AS}/authorize`);
@@ -136,6 +136,18 @@ describe("beginCustomOAuth", () => {
     expect(attempt.endpoint).toBe(ENDPOINT);
     expect(attempt.codeVerifier).toBeTruthy();
     expect(attempt.resource).toBe("https://mcp.example.com");
+  });
+
+  it("a state prefix rides inside the state (gateway pod routing)", async () => {
+    const { fetchFn } = fakeAuthServer();
+    const { state, authorizeUrl } = await beginCustomOAuth(
+      DEF,
+      "https://gateway.example.com/v1/integrations/custom/oauth/callback",
+      null,
+      { fetchFn, statePrefix: "30c8c1f5631f1312.36d2bd7e4d89085e" },
+    );
+    expect(state).toMatch(/^30c8c1f5631f1312\.36d2bd7e4d89085e\.[0-9a-f]{32}$/);
+    expect(new URL(authorizeUrl).searchParams.get("state")).toBe(state);
   });
 
   it("refuses a non-https authorization endpoint (OS-opener safety)", async () => {
@@ -162,7 +174,7 @@ describe("beginCustomOAuth", () => {
       return jsonRes({ error: "no" }, 404);
     }) as typeof fetch;
     await expect(
-      beginCustomOAuth(DEF, "http://127.0.0.1:1/cb", null, fetchFn),
+      beginCustomOAuth(DEF, "http://127.0.0.1:1/cb", null, { fetchFn }),
     ).rejects.toMatchObject({ code: "oauth_failed" });
   });
 
@@ -178,12 +190,9 @@ describe("beginCustomOAuth", () => {
       tokens: { access_token: "old", token_type: "Bearer" },
       expiresAt: null,
     };
-    const { authorizeUrl } = await beginCustomOAuth(
-      DEF,
-      redirect,
-      existing,
+    const { authorizeUrl } = await beginCustomOAuth(DEF, redirect, existing, {
       fetchFn,
-    );
+    });
     expect(new URL(authorizeUrl).searchParams.get("client_id")).toBe(
       "kept-client",
     );
@@ -208,7 +217,7 @@ describe("beginCustomOAuth", () => {
       return jsonRes({ error: "no" }, 404);
     }) as typeof fetch;
     await expect(
-      beginCustomOAuth(DEF, "http://127.0.0.1:1/cb", null, fetchFn),
+      beginCustomOAuth(DEF, "http://127.0.0.1:1/cb", null, { fetchFn }),
     ).rejects.toMatchObject({ code: "oauth_failed" });
   });
 });
@@ -218,7 +227,9 @@ describe("settleCustomOAuth", () => {
     const { fetchFn } = fakeAuthServer();
     const redirect =
       "http://127.0.0.1:4318/v1/integrations/custom/oauth/callback";
-    const { attempt } = await beginCustomOAuth(DEF, redirect, null, fetchFn);
+    const { attempt } = await beginCustomOAuth(DEF, redirect, null, {
+      fetchFn,
+    });
     const bundle = await settleCustomOAuth(attempt, "the-code", fetchFn);
     expect(bundle.kind).toBe("houston-custom-oauth");
     expect(bundle.tokens.access_token).toBe("at-1");
@@ -233,7 +244,7 @@ describe("settleCustomOAuth", () => {
       DEF,
       "http://127.0.0.1:1/cb",
       null,
-      fetchFn,
+      { fetchFn },
     );
     const rejecting = (async () =>
       jsonRes({ error: "invalid_grant" }, 400)) as typeof fetch;

--- a/packages/host/src/integrations/custom/oauth-flow.ts
+++ b/packages/host/src/integrations/custom/oauth-flow.ts
@@ -71,17 +71,22 @@ const oauthFailed = (context: string, err: unknown): CustomIntegrationError =>
  * Discover + register + build the authorize URL for one MCP definition.
  * `existingClient` (from a previous grant's bundle) is reused when it still
  * names this redirect URI, so re-authenticating does not re-register.
+ * `statePrefix` (managed pods: `<orgSlug>.<agentSlug>`) rides INSIDE the
+ * state so the gateway's public callback can route the returning browser to
+ * the right pod statelessly — the random tail keeps the whole value
+ * single-use and unguessable.
  */
 export async function beginCustomOAuth(
   def: CustomIntegrationDef & { kind: "mcp" },
   redirectUri: string,
   existing: CustomOAuthBundle | null,
-  fetchFn?: typeof fetch,
+  opts: { fetchFn?: typeof fetch; statePrefix?: string } = {},
 ): Promise<{
   state: string;
   authorizeUrl: string;
   attempt: CustomOAuthAttempt;
 }> {
+  const { fetchFn, statePrefix } = opts;
   let info: Awaited<ReturnType<typeof discoverOAuthServerInfo>>;
   try {
     info = await discoverOAuthServerInfo(def.endpoint, {
@@ -117,7 +122,7 @@ export async function beginCustomOAuth(
     }
   }
 
-  const state = randomBytes(16).toString("hex");
+  const state = `${statePrefix ? `${statePrefix}.` : ""}${randomBytes(16).toString("hex")}`;
   try {
     const { authorizationUrl, codeVerifier } = await startAuthorization(
       info.authorizationServerUrl,

--- a/packages/host/src/integrations/custom/oauth-ops.ts
+++ b/packages/host/src/integrations/custom/oauth-ops.ts
@@ -28,6 +28,9 @@ export interface CustomOAuthDeps {
   /** The browser-reachable callback URL; absent = this deployment cannot
    *  receive the redirect (managed cloud until its gateway route ships). */
   callbackUrl?: string;
+  /** Gateway-fronted pods: `<orgSlug>.<agentSlug>` — minted INTO the state so
+   *  the gateway's public callback can route the browser to this pod. */
+  statePrefix?: string;
   fetchFn?: typeof fetch;
   onChanged: () => void;
 }
@@ -60,7 +63,10 @@ export async function startOAuthOp(
     def,
     deps.callbackUrl,
     existing,
-    deps.fetchFn,
+    {
+      ...(deps.fetchFn ? { fetchFn: deps.fetchFn } : {}),
+      ...(deps.statePrefix ? { statePrefix: deps.statePrefix } : {}),
+    },
   );
   deps.attempts.put(state, attempt);
   return { authorizeUrl };

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -463,6 +463,17 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     oauthCallbackBase
       ? {
           callbackUrl: `${oauthCallbackBase.replace(/\/+$/, "")}${CUSTOM_OAUTH_CALLBACK_PATH}`,
+          // A gateway-fronted pod's callback is the GATEWAY's public route:
+          // the browser lands there, and the gateway routes it to this pod by
+          // the `<org>.<agent>.` prefix minted into the state. Loopback bases
+          // (desktop, dev engines) land on this host directly and need none —
+          // but carrying it is harmless, so it rides whenever the pod knows
+          // its coordinates.
+          ...(opts.credentials
+            ? {
+                statePrefix: `${opts.credentials.orgSlug}.${opts.credentials.agentSlug}`,
+              }
+            : {}),
         }
       : {},
   );


### PR DESCRIPTION
Managed-cloud half of custom MCP OAuth sign-in (follow-up to #1263; companion cloud PR adds the public gateway callback + pod env).

A gateway-fronted pod cannot receive a browser redirect, so its authorize URL now points at the **gateway's** public callback, and the `state` is minted as `<orgSlug>.<agentSlug>.<random32hex>` whenever the pod knows its coordinates (`opts.credentials`). The gateway parses the prefix and relays the callback to the pod's own `/v1/integrations/custom/oauth/callback` — stateless routing, works across gateway replicas; the random tail keeps the state single-use and unguessable, and the pod still enforces single-use/expiry/PKCE.

Loopback deployments (desktop, dev engines without credentials) are unchanged: no prefix, callback lands on the host directly.

Verify: `pnpm --filter @houston/host test` (state-prefix case in `oauth-flow.test.ts`); on staging after both PRs deploy, `/v1/capabilities` on a pod serves `customIntegrationOAuth: true` and the Croma sign-in completes end to end.