### PR TITLE
fix(app): Windows file dialogs survive accented paths (PRODUCT-1260)

### DIFF
--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -21,6 +21,11 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 dirs = "5"
 percent-encoding = "2"
+# Windows dialog helpers round-trip chosen paths as base64(UTF-8) because
+# PowerShell's redirected stdout uses the OEM code page (commands/dialogs.rs);
+# also the -EncodedCommand payload for the icon-repair pass
+# (src/windows_icon_repair.rs). Shared dep so the decoder is testable everywhere.
+base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 tauri-plugin-notification = "2"
 # Rust-side clipboard read for the Claude sign-in auto-finish (the webview's
@@ -114,9 +119,6 @@ notify-rust = "4.11"
 # file is useless to another user. See `src/auth.rs` storage module.
 [target."cfg(target_os = \"windows\")".dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Security_Cryptography", "Win32_System_JobObjects", "Win32_System_Threading", "Win32_UI_Shell"] }
-# PowerShell -EncodedCommand payload for the icon-repair pass
-# (src/windows_icon_repair.rs) — dodges Windows argv re-quoting.
-base64 = "0.22"
 # Same reason as notify-rust on Linux, but notify-rust's action handling is
 # XDG/D-Bus-only — on Windows we use the WinRT toast's `on_activated` callback
 # to catch the click. This is the crate notify-rust uses under the hood.

--- a/app/src-tauri/src/commands/dialogs.rs
+++ b/app/src-tauri/src/commands/dialogs.rs
@@ -22,6 +22,31 @@ fn powershell_escape(s: &str) -> String {
     s.replace('\'', "''")
 }
 
+/// Decode a Windows dialog script's stdout into the chosen path.
+///
+/// The scripts print the path base64(UTF-8)-encoded rather than raw:
+/// PowerShell encodes redirected stdout in the console's OEM code page
+/// (cp850 on Spanish Windows), so an accented character anywhere in the
+/// chosen path (`C:\Users\Muñoz\…`) arrived here as bytes that are not
+/// valid UTF-8, turned into U+FFFD, and the save then failed with
+/// "El sistema no puede encontrar la ruta especificada. (os error 3)"
+/// (PRODUCT-1260). Base64 keeps the pipe pure ASCII, which every code
+/// page maps identically. Empty output means the user cancelled.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn decode_dialog_path(stdout: &[u8]) -> Result<Option<String>, String> {
+    use base64::Engine as _;
+    let trimmed = String::from_utf8_lossy(stdout).trim().to_string();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(trimmed.as_bytes())
+        .map_err(|e| format!("The dialog returned an unreadable path: {e}"))?;
+    let path = String::from_utf8(bytes)
+        .map_err(|e| format!("The dialog returned an unreadable path: {e}"))?;
+    Ok(if path.is_empty() { None } else { Some(path) })
+}
+
 #[cfg(target_os = "macos")]
 pub(crate) async fn save_dialog(
     prompt: &str,
@@ -61,7 +86,7 @@ $dlg = New-Object System.Windows.Forms.SaveFileDialog
 $dlg.FileName = '{}'
 $dlg.Filter = '{}'
 if ($dlg.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {{
-    Write-Output $dlg.FileName
+    Write-Output ([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($dlg.FileName)))
 }}
 "#,
         powershell_escape(default_name),
@@ -72,8 +97,7 @@ if ($dlg.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {{
         .output()
         .await
         .map_err(|e| format!("Failed to open save dialog: {e}"))?;
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    Ok(if path.is_empty() { None } else { Some(path) })
+    decode_dialog_path(&output.stdout)
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
@@ -121,7 +145,7 @@ Add-Type -AssemblyName System.Windows.Forms | Out-Null
 $dlg = New-Object System.Windows.Forms.OpenFileDialog
 $dlg.Filter = '{}'
 if ($dlg.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {{
-    Write-Output $dlg.FileName
+    Write-Output ([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($dlg.FileName)))
 }}
 "#,
         powershell_escape(filter),
@@ -131,8 +155,7 @@ if ($dlg.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {{
         .output()
         .await
         .map_err(|e| format!("Failed to open file dialog: {e}"))?;
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    Ok(if path.is_empty() { None } else { Some(path) })
+    decode_dialog_path(&output.stdout)
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
@@ -141,4 +164,40 @@ pub(crate) async fn open_dialog(
     _win_filter: Option<&str>,
 ) -> Result<Option<String>, String> {
     Err("Open dialog not yet implemented on this platform.".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_dialog_path;
+    use base64::Engine as _;
+
+    fn b64(s: &str) -> Vec<u8> {
+        base64::engine::general_purpose::STANDARD
+            .encode(s.as_bytes())
+            .into_bytes()
+    }
+
+    #[test]
+    fn decodes_accented_path() {
+        // The PRODUCT-1260 shape: an accented Windows user folder that the
+        // old raw-stdout decoding mangled into a nonexistent directory.
+        let mut out = b64("C:\\Users\\Muñoz\\Descargas\\reporte.xlsx");
+        out.extend_from_slice(b"\r\n");
+        assert_eq!(
+            decode_dialog_path(&out).unwrap(),
+            Some("C:\\Users\\Muñoz\\Descargas\\reporte.xlsx".to_string()),
+        );
+    }
+
+    #[test]
+    fn empty_output_is_a_cancel() {
+        assert_eq!(decode_dialog_path(b"").unwrap(), None);
+        assert_eq!(decode_dialog_path(b"  \r\n").unwrap(), None);
+        assert_eq!(decode_dialog_path(&b64("")).unwrap(), None);
+    }
+
+    #[test]
+    fn garbage_output_errors_instead_of_saving_nowhere() {
+        assert!(decode_dialog_path(b"not base64!!").is_err());
+    }
 }


### PR DESCRIPTION
Fixes two of the three PRODUCT-1260 bugs (the third, Google Ads developer-token quota, is operator-side — steps in the Linear issue).

## 1. Windows downloads fail: "No se pudo guardar el archivo" (Sentry HOUSTON-APP-53A)

**Root cause.** The Windows save/open dialogs shell out to PowerShell and read the chosen path from stdout. PowerShell encodes redirected stdout in the console's OEM code page (cp850 on Spanish Windows), but the shell decoded those bytes as UTF-8. Any accented character in the chosen path (e.g. a Spanish Windows user folder) was replaced with U+FFFD, so `tokio::fs::write` targeted a directory that does not exist and failed with `El sistema no puede encontrar la ruta especificada. (os error 3)`. Every download this user tried toasted "No se pudo guardar el archivo" regardless of file name, library, or extension — matching their own elimination testing.

**Fix.** The PowerShell dialog scripts now print the path base64(UTF-8)-encoded, keeping the pipe pure ASCII (identical in every code page); the shell decodes it back (`decode_dialog_path`). Empty stdout still means cancel; undecodable output errors loudly instead of writing nowhere. Covers `save_dialog` and `open_dialog`: workspace downloads, chat file downloads, portable agent share/import. `base64` moved to shared deps so the decoder is unit-testable everywhere.

**Verify.** Before: on Windows with an accent in the destination path (user folder like `Muñoz`), any Download → error toast + Sentry os error 3. After: file writes, "Saved" toast with Reveal. `cd app/src-tauri && cargo test` (219 passed, 3 new decoder tests), `cargo check --target x86_64-pc-windows-gnu` (0 errors).

## 2. HighLevel connect dies with "OAuth provider rejected the token exchange: Request failed with status code 422"

**Root cause.** Composio's hosted connect page asks the user for every required initiation field it wasn't given. For `highlevel` that is `user_type` ("Token Type"), a free-text box whose value the token exchange relays verbatim — HighLevel 422s anything except `Location`/`Company`. The reporting user pasted their GHL private-integration token (`pit-…`) into it (support had told them to use the token if asked), so every retry 422'd. Verified against prod Composio: the failed account `ca_i8tquJrddFhr` has `user_type: "pit-…"`; an account connected with `user_type: "Location"` (`ca_djvTSutVYdj_`) is ACTIVE on the same auth config.

**Fix.** The host now sends `connection_data: { user_type: "Location" }` when minting the highlevel link session, so the hosted page never shows the question and the exchange always gets a value HighLevel accepts (Location = the sub-account token most HighLevel actions require; Composio's own field description recommends it). Verified live against prod Composio with a throwaway link session: the pre-auth connected account carries `user_type: Location` (test account deleted).

**Verify.** Before: connect HighLevel, type anything but Location/Company in "Token Type" → 422 card. After (engine roll): the hosted page skips straight to the GHL login/chooser; connecting a sub-account turns the integration Active. `pnpm --filter @houston/host test` (1336 passed, 1 new test asserting the link body).

PRODUCT-1260