### PR TITLE
feat(runtime): pod-side Claude login relay — mint the subscription credential on the engine pod (PRODUCT-1136)

### DIFF
--- a/app/src/components/shell/provider-login-dialog.tsx
+++ b/app/src/components/shell/provider-login-dialog.tsx
@@ -99,10 +99,12 @@ export function ProviderLoginDialog({
   // isn't parseable; we then just omit the hint.
   const host = providerLoginUrlHost(url);
 
-  // Setup-token paste flow (Claude/Anthropic): `url` is a docs reference, not a
-  // sign-in page. We surface the runtime's step-by-step `instructions` above the
-  // paste field and demote the url to a small "Reference" link, rather than the
-  // Open/Copy/reveal button row meant for a real OAuth URL.
+  // Runtime paste flows (Claude/Anthropic): the runtime's step-by-step
+  // `instructions` sit above the paste field and say what the link is for —
+  // the pod-side CLI relay sends the real authorize URL (opening it IS step
+  // one), the setup-token fallback a docs reference. Either way the link is
+  // labeled by destination host and only ever opened on click, rather than
+  // the Open/Copy/reveal button row meant for a bare OAuth URL.
   const isAuthCode = !!instructions;
 
   const handleCopyUrl = async () => {
@@ -162,9 +164,9 @@ export function ProviderLoginDialog({
         <div className="space-y-4">
           {isAuthCode ? (
             <>
-              {/* Setup-token steps from the runtime, shown prominently above
-                  the paste field. The docs `url` is only a small reference
-                  link (opened on click) — never auto-opened. */}
+              {/* The runtime's steps, shown prominently above the paste
+                  field; the link below is the one they refer to — never
+                  auto-opened. */}
               <p className="rounded-md border bg-chip-subtle/40 p-3 text-[13px] whitespace-pre-line">
                 {instructions}
               </p>
@@ -177,7 +179,7 @@ export function ProviderLoginDialog({
                   onClick={() => void tauriSystem.openUrl(url)}
                 >
                   <ExternalLink className="size-3.5" />
-                  {t("providerLogin.reference")}
+                  {t("providerLogin.openLink", { host })}
                 </Button>
               )}
             </>

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -28,8 +28,8 @@
   "providerLogin": {
     "title": "Finish signing in to {{name}}",
     "description": "Open the sign-in page in your browser, complete sign-in, then paste the verification code back here.",
-    "authCodeDescription": "Paste a setup token to finish connecting {{name}}.",
-    "reference": "Reference",
+    "authCodeDescription": "Follow the steps to finish connecting {{name}}.",
+    "openLink": "Open {{host}}",
     "openUrl": "Open URL",
     "copyUrl": "Copy URL",
     "urlCopied": "URL copied to clipboard",
@@ -124,7 +124,7 @@
     "timeout": "Claude sign-in timed out. Please try connecting again.",
     "confirmTimeout": "Signed in to Claude, but Houston could not confirm the connection. Please try again.",
     "autoFailedTitle": "Couldn't finish connecting automatically",
-    "autoFailedBody": "Paste a Claude setup token to finish connecting.",
+    "autoFailedBody": "Finish connecting Claude in the dialog that opens.",
     "helperUnsupported": "This computer's processor is too old to run the Claude sign-in helper, so a Claude subscription can't be connected on this machine."
   },
   "localModel": {

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -28,8 +28,8 @@
   "providerLogin": {
     "title": "Termina de iniciar sesión en {{name}}",
     "description": "Abre la página de inicio de sesión en tu navegador, completa el inicio de sesión y luego pega aquí el código de verificación.",
-    "authCodeDescription": "Pega un token de configuración para terminar de conectar {{name}}.",
-    "reference": "Referencia",
+    "authCodeDescription": "Sigue los pasos para terminar de conectar {{name}}.",
+    "openLink": "Abrir {{host}}",
     "openUrl": "Abrir URL",
     "copyUrl": "Copiar URL",
     "urlCopied": "URL copiada al portapapeles",
@@ -124,7 +124,7 @@
     "timeout": "El inicio de sesión de Claude expiró. Intenta conectarte de nuevo.",
     "confirmTimeout": "Iniciaste sesión en Claude, pero Houston no pudo confirmar la conexión. Inténtalo de nuevo.",
     "autoFailedTitle": "No se pudo completar la conexión automáticamente",
-    "autoFailedBody": "Pega un token de configuración de Claude para terminar de conectar.",
+    "autoFailedBody": "Termina de conectar Claude en el diálogo que se abre.",
     "helperUnsupported": "El procesador de este computador es demasiado antiguo para ejecutar el asistente de inicio de sesión de Claude, así que no se puede conectar una suscripción de Claude en esta máquina."
   },
   "localModel": {

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -28,8 +28,8 @@
   "providerLogin": {
     "title": "Termine de entrar em {{name}}",
     "description": "Abra a página de login no seu navegador, finalize o login e cole aqui o código de verificação.",
-    "authCodeDescription": "Cole um token de configuração para terminar de conectar {{name}}.",
-    "reference": "Referência",
+    "authCodeDescription": "Siga os passos para terminar de conectar {{name}}.",
+    "openLink": "Abrir {{host}}",
     "openUrl": "Abrir URL",
     "copyUrl": "Copiar URL",
     "urlCopied": "URL copiada para a área de transferência",
@@ -124,7 +124,7 @@
     "timeout": "O login do Claude expirou. Tente conectar novamente.",
     "confirmTimeout": "Você entrou no Claude, mas o Houston não conseguiu confirmar a conexão. Tente novamente.",
     "autoFailedTitle": "Não foi possível concluir a conexão automaticamente",
-    "autoFailedBody": "Cole um token de configuração do Claude para concluir a conexão.",
+    "autoFailedBody": "Conclua a conexão do Claude no diálogo que se abre.",
     "helperUnsupported": "O processador deste computador é muito antigo para executar o assistente de login do Claude, então não é possível conectar uma assinatura do Claude nesta máquina."
   },
   "localModel": {

--- a/packages/runtime/src/auth/anthropic-cli-login.test.ts
+++ b/packages/runtime/src/auth/anthropic-cli-login.test.ts
@@ -191,6 +191,43 @@ test("an abort (cancel/expiry) is a cancellation, never a fallback — even pre-
   expect(removed).toHaveLength(1);
 });
 
+test("a clean exit that never printed a URL is fallback-eligible, not a success", async () => {
+  // A fresh mint dir has no cached session, so exit 0 without an authorize URL
+  // cannot be a mint — resolving would report success while the client's
+  // dialog never opened.
+  const child = new FakeChild();
+  const { io } = fakeIo(child);
+  const store = vi.fn();
+  const run = runAnthropicCliLogin(
+    { onAuth: vi.fn(), onManualCodeInput: () => new Promise(() => {}) },
+    { store },
+    io,
+  );
+  await tick();
+  child.emit("close", 0, null);
+  await expect(run).rejects.toBeInstanceOf(CliLoginUnavailableError);
+  expect(store).not.toHaveBeenCalled();
+});
+
+test("a synchronously-throwing stdin write neither crashes nor changes the outcome", async () => {
+  const child = new FakeChild();
+  child.stdin.write = () => {
+    throw new Error("ERR_STREAM_DESTROYED");
+  };
+  const { io } = fakeIo(child);
+  const store = vi.fn();
+  const run = runAnthropicCliLogin(
+    { onAuth: vi.fn(), onManualCodeInput: () => Promise.resolve("code#state") },
+    { store },
+    io,
+  );
+  child.stdout.write(VISIT_LINE);
+  await tick();
+  child.emit("close", 0, null);
+  await run;
+  expect(store).toHaveBeenCalledTimes(1);
+});
+
 test("exit 0 with an unreadable mint is a real error and still scrubs", async () => {
   const child = new FakeChild();
   const { io, removed } = fakeIo(child, {

--- a/packages/runtime/src/auth/anthropic-cli-login.test.ts
+++ b/packages/runtime/src/auth/anthropic-cli-login.test.ts
@@ -1,0 +1,312 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import type { ClaudeOAuthCredential } from "@houston/runtime-client";
+import { expect, test, vi } from "vitest";
+import {
+  CLI_LOGIN_INSTRUCTIONS,
+  type CliLoginIo,
+  CliLoginUnavailableError,
+  podCliLoginAvailable,
+  runAnthropicCliLogin,
+  runAnthropicConnect,
+  storeMintedClaudeCredential,
+} from "./anthropic-cli-login";
+import { PASTE_INSTRUCTIONS } from "./anthropic-setup-token";
+
+/**
+ * A scriptable stand-in for the spawned CLI: real streams (so the driver's
+ * readline and stdin writes run for real), scripted exits. Matches the Rust
+ * runner tests' fake-`claude`-binary approach without a subprocess.
+ */
+class FakeChild extends EventEmitter {
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  stdin = new PassThrough();
+  stdinData = "";
+  killed = false;
+  constructor() {
+    super();
+    this.stdin.on("data", (c) => {
+      this.stdinData += String(c);
+    });
+  }
+  kill(): boolean {
+    this.killed = true;
+    return true;
+  }
+  asChild(): ChildProcessWithoutNullStreams {
+    return this as unknown as ChildProcessWithoutNullStreams;
+  }
+}
+
+const MINTED: ClaudeOAuthCredential = {
+  accessToken: "sk-ant-oat01-access",
+  refreshToken: "refresh-1",
+  expiresAt: 4102444800000,
+  subscriptionType: "max",
+};
+
+function fakeIo(
+  child: FakeChild,
+  overrides: Partial<CliLoginIo> = {},
+): { io: CliLoginIo; removed: string[] } {
+  const removed: string[] = [];
+  return {
+    removed,
+    io: {
+      makeMintDir: () => "/tmp/mint-under-test",
+      removeMintDir: (d) => {
+        removed.push(d);
+      },
+      spawn: () => child.asChild(),
+      readCredential: () => MINTED,
+      platform: "linux",
+      env: {},
+      urlTimeoutMs: 1_000,
+      exitTimeoutMs: 5_000,
+      ...overrides,
+    },
+  };
+}
+
+const tick = () => new Promise((r) => setImmediate(r));
+
+const VISIT_LINE =
+  "Please visit: https://claude.com/cai/oauth/authorize?code=true&state=s1\n";
+
+test("happy path: URL relayed, pasted code fed to stdin, credential stored, mint dir scrubbed", async () => {
+  const child = new FakeChild();
+  const { io, removed } = fakeIo(child);
+  const onAuth = vi.fn();
+  const store = vi.fn();
+  const run = runAnthropicCliLogin(
+    { onAuth, onManualCodeInput: () => Promise.resolve("  code#state1  ") },
+    { store },
+    io,
+  );
+  child.stdout.write(VISIT_LINE);
+  await tick();
+  expect(onAuth).toHaveBeenCalledExactlyOnceWith({
+    url: "https://claude.com/cai/oauth/authorize?code=true&state=s1",
+    instructions: CLI_LOGIN_INSTRUCTIONS,
+  });
+  expect(child.stdinData).toBe("code#state1\n");
+  child.emit("close", 0, null);
+  await run;
+  expect(store).toHaveBeenCalledExactlyOnceWith(MINTED);
+  expect(removed).toEqual(["/tmp/mint-under-test"]);
+});
+
+test("a spawn error (no binary in this image) is fallback-eligible", async () => {
+  const child = new FakeChild();
+  const { io, removed } = fakeIo(child);
+  const run = runAnthropicCliLogin(
+    { onAuth: vi.fn(), onManualCodeInput: () => new Promise(() => {}) },
+    { store: vi.fn() },
+    io,
+  );
+  child.emit("error", new Error("spawn claude ENOENT"));
+  await expect(run).rejects.toBeInstanceOf(CliLoginUnavailableError);
+  expect(removed).toHaveLength(1);
+});
+
+test("silence past the URL window is fallback-eligible and kills the child", async () => {
+  const child = new FakeChild();
+  const { io } = fakeIo(child, { urlTimeoutMs: 20 });
+  await expect(
+    runAnthropicCliLogin(
+      { onAuth: vi.fn(), onManualCodeInput: () => new Promise(() => {}) },
+      { store: vi.fn() },
+      io,
+    ),
+  ).rejects.toThrow(CliLoginUnavailableError);
+  expect(child.killed).toBe(true);
+});
+
+test("a pre-URL non-zero exit is fallback-eligible and carries the stderr tail", async () => {
+  const child = new FakeChild();
+  const { io } = fakeIo(child);
+  const run = runAnthropicCliLogin(
+    { onAuth: vi.fn(), onManualCodeInput: () => new Promise(() => {}) },
+    { store: vi.fn() },
+    io,
+  );
+  child.stderr.write("unknown command: auth");
+  await tick();
+  child.emit("close", 1, null);
+  await expect(run).rejects.toThrow(
+    /Claude sign-in failed \(exit 1\): unknown command: auth/,
+  );
+  await expect(run).rejects.toBeInstanceOf(CliLoginUnavailableError);
+});
+
+test("a post-URL failure (declined approval) is a real error, never a fallback", async () => {
+  const child = new FakeChild();
+  const { io, removed } = fakeIo(child);
+  const run = runAnthropicCliLogin(
+    { onAuth: vi.fn(), onManualCodeInput: () => new Promise(() => {}) },
+    { store: vi.fn() },
+    io,
+  );
+  child.stdout.write(VISIT_LINE);
+  await tick();
+  child.stderr.write("authentication was declined");
+  await tick();
+  child.emit("close", 1, null);
+  await expect(run).rejects.toThrow(/authentication was declined/);
+  await expect(run).rejects.not.toBeInstanceOf(CliLoginUnavailableError);
+  expect(removed).toHaveLength(1);
+});
+
+test("a post-URL signal death is a real error, never a fallback", async () => {
+  const child = new FakeChild();
+  const { io } = fakeIo(child);
+  const run = runAnthropicCliLogin(
+    { onAuth: vi.fn(), onManualCodeInput: () => new Promise(() => {}) },
+    { store: vi.fn() },
+    io,
+  );
+  child.stdout.write(VISIT_LINE);
+  await tick();
+  child.emit("close", null, "SIGKILL");
+  await expect(run).rejects.toThrow(/Claude sign-in failed \(SIGKILL\)/);
+  await expect(run).rejects.not.toBeInstanceOf(CliLoginUnavailableError);
+});
+
+test("an abort (cancel/expiry) is a cancellation, never a fallback — even pre-URL", async () => {
+  const child = new FakeChild();
+  const { io, removed } = fakeIo(child);
+  const abort = new AbortController();
+  const run = runAnthropicCliLogin(
+    { onAuth: vi.fn(), onManualCodeInput: () => new Promise(() => {}) },
+    { store: vi.fn(), signal: abort.signal },
+    io,
+  );
+  await tick();
+  abort.abort();
+  await expect(run).rejects.toThrow(/login cancelled/);
+  await expect(run).rejects.not.toBeInstanceOf(CliLoginUnavailableError);
+  expect(child.killed).toBe(true);
+  expect(removed).toHaveLength(1);
+});
+
+test("exit 0 with an unreadable mint is a real error and still scrubs", async () => {
+  const child = new FakeChild();
+  const { io, removed } = fakeIo(child, {
+    readCredential: () => {
+      throw new Error("left no credential");
+    },
+  });
+  const run = runAnthropicCliLogin(
+    { onAuth: vi.fn(), onManualCodeInput: () => new Promise(() => {}) },
+    { store: vi.fn() },
+    io,
+  );
+  child.stdout.write(VISIT_LINE);
+  await tick();
+  child.emit("close", 0, null);
+  await expect(run).rejects.toThrow(/left no credential/);
+  expect(removed).toHaveLength(1);
+});
+
+test("runAnthropicConnect degrades to the setup-token flow when the relay is unavailable", async () => {
+  const child = new FakeChild();
+  const { io } = fakeIo(child, { env: { HOUSTON_CLAUDE_POD_LOGIN: "0" } });
+  const onAuth = vi.fn();
+  const storeToken = vi.fn();
+  await runAnthropicConnect(
+    {
+      onAuth,
+      onManualCodeInput: () => Promise.resolve("sk-ant-oat01-pasted"),
+    },
+    { storeCredential: vi.fn(), storeToken },
+    io,
+  );
+  expect(onAuth).toHaveBeenCalledExactlyOnceWith(
+    expect.objectContaining({ instructions: PASTE_INSTRUCTIONS }),
+  );
+  expect(storeToken).toHaveBeenCalledExactlyOnceWith("sk-ant-oat01-pasted");
+});
+
+test("runAnthropicConnect surfaces a post-URL failure without switching flows", async () => {
+  const child = new FakeChild();
+  const { io } = fakeIo(child);
+  const storeToken = vi.fn();
+  const run = runAnthropicConnect(
+    { onAuth: vi.fn(), onManualCodeInput: () => new Promise(() => {}) },
+    { storeCredential: vi.fn(), storeToken },
+    io,
+  );
+  child.stdout.write(VISIT_LINE);
+  await tick();
+  child.emit("close", 1, null);
+  await expect(run).rejects.toThrow(/exit 1/);
+  expect(storeToken).not.toHaveBeenCalled();
+});
+
+test("podCliLoginAvailable gates the kill switch and macOS", () => {
+  expect(podCliLoginAvailable("linux", {})).toEqual({ ok: true });
+  expect(podCliLoginAvailable("win32", {})).toEqual({ ok: true });
+  expect(
+    podCliLoginAvailable("linux", { HOUSTON_CLAUDE_POD_LOGIN: "0" }).ok,
+  ).toBe(false);
+  expect(podCliLoginAvailable("darwin", {}).ok).toBe(false);
+});
+
+function mintSink(opts: { serve: boolean; personal: boolean }) {
+  const calls: {
+    stored?: unknown;
+    materialized?: { dir: string; cred: ClaudeOAuthCredential };
+    warmed: boolean;
+  } = { warmed: false };
+  return {
+    calls,
+    io: {
+      storage: {
+        set: (_provider: string, cred: unknown) => {
+          calls.stored = cred;
+        },
+      },
+      serveMode: () => opts.serve,
+      personalScope: () => opts.personal,
+      materialize: (dir: string, cred: ClaudeOAuthCredential) => {
+        calls.materialized = { dir, cred };
+      },
+      loginDir: () => "/data/claude-login",
+      warmProbe: async () => {
+        calls.warmed = true;
+      },
+    },
+  };
+}
+
+test("mint sink, team + serve mode: full entry in auth.json, access-only file, warmed probe", async () => {
+  const { io, calls } = mintSink({ serve: true, personal: false });
+  await storeMintedClaudeCredential(MINTED, io);
+  expect(calls.stored).toEqual({
+    type: "oauth",
+    access: "sk-ant-oat01-access",
+    refresh: "refresh-1",
+    expires: 4102444800000,
+  });
+  expect(calls.materialized).toEqual({
+    dir: "/data/claude-login",
+    cred: { ...MINTED, refreshToken: "" },
+  });
+  expect(calls.warmed).toBe(true);
+});
+
+test("mint sink, team + self-host: the materialized file keeps the refresh token", async () => {
+  const { io, calls } = mintSink({ serve: false, personal: false });
+  await storeMintedClaudeCredential(MINTED, io);
+  expect(calls.materialized?.cred).toEqual(MINTED);
+});
+
+test("mint sink, personal scope: never touches the pod-shared file", async () => {
+  const { io, calls } = mintSink({ serve: true, personal: true });
+  await storeMintedClaudeCredential(MINTED, io);
+  expect(calls.stored).toBeDefined();
+  expect(calls.materialized).toBeUndefined();
+  expect(calls.warmed).toBe(false);
+});

--- a/packages/runtime/src/auth/anthropic-cli-login.ts
+++ b/packages/runtime/src/auth/anthropic-cli-login.ts
@@ -1,0 +1,367 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { createInterface } from "node:readline";
+import type { ClaudeOAuthCredential } from "@houston/runtime-client";
+import { refreshAnthropicCredential } from "../backends/claude/credential-status";
+import { writeClaudeOAuthCredentialFile } from "../backends/claude/credentials-file";
+import {
+  extractVisitUrl,
+  makeMintDir,
+  readMintedCredential,
+  removeMintDir,
+  spawnLoginCli,
+} from "../backends/claude/login-cli";
+import { claudeLoginConfigDir } from "../backends/claude/paths";
+import {
+  currentCredentialScope,
+  isPersonalScope,
+} from "../session/acting-context";
+import { runAnthropicSetupTokenLogin } from "./anthropic-setup-token";
+import { serveModeOn } from "./serve";
+import { authStorage } from "./storage";
+
+/**
+ * Pod-side Claude (subscription) connect: mint the OAuth credential ON the
+ * engine pod by driving the pod's own `claude auth login --claudeai`, so a
+ * user installs NOTHING locally — the desktop helper binary (which SIGILLs on
+ * pre-AVX2 CPUs) and the `claude setup-token` terminal detour both stop being
+ * requirements. Zero wire change: the authorize URL rides the existing
+ * `auth_code` LoginInfo to the client, and the code the user pastes (the
+ * claude.ai approval page always shows one here — the pod's localhost callback
+ * listener is unreachable from the user's browser, the deterministic Windows
+ * fallback of HOU-839) comes back through `completeLogin` into the CLI's stdin.
+ *
+ * Custody after the mint follows the standing doctrine
+ * (knowledge-base/anthropic-credentials.md): the full credential seeds
+ * auth.json so the client's connect-once capture (`captureCredential` → the
+ * runtime's `GET /auth/export` → central store put → refresh scrub) makes the
+ * gateway the family's single rotator, and the team-scope pod materializes the
+ * CLI's own file exactly like a desktop push would (access-only in serve mode).
+ * The throwaway mint dir is scrubbed win or lose.
+ *
+ * Where the CLI cannot run — the binary is absent (the CLOUD-only per-turn
+ * image strips it), the platform hides the mint in a Keychain (macOS), the
+ * kill switch is set, or the spawned child dies/goes silent BEFORE printing
+ * its authorize URL (the probed Ink-TUI deadlock shape: zero bytes, no clean
+ * error) — the flow degrades to the setup-token paste dialog, the previous
+ * behavior and the terminal fallback. After the URL reached the user, a
+ * failure is a real sign-in failure (declined approval, bad code) and
+ * surfaces as one; silently restarting as a different dialog would be worse.
+ */
+
+/** What the user sees next to the paste box (the `auth_code` dialog). */
+export const CLI_LOGIN_INSTRUCTIONS =
+  "Open the link below and approve the sign-in in your browser. When claude.ai shows you a code, copy it and paste it here.";
+
+/**
+ * Kill switch. `HOUSTON_CLAUDE_POD_LOGIN=0` pins the setup-token paste flow —
+ * the operational lever if a CLI update ever breaks the piped readline contract
+ * in production (and what keeps `login.test.ts` off real subprocess spawns).
+ */
+export const POD_LOGIN_ENV = "HOUSTON_CLAUDE_POD_LOGIN";
+
+/**
+ * A failure mode that means "this pod cannot run the CLI login at all" — the
+ * only failures that degrade to the setup-token flow. Thrown exclusively
+ * BEFORE the authorize URL is emitted, so a fallback never yanks a dialog the
+ * user is already following.
+ */
+export class CliLoginUnavailableError extends Error {}
+
+export type CliLoginCallbacks = {
+  /** Surface the authorize URL + paste instructions to the client (auth_code). */
+  onAuth: (info: { url: string; instructions: string }) => void;
+  /** Resolves with the user's pasted approval code (completeLogin's promise). */
+  onManualCodeInput: () => Promise<string>;
+};
+
+/** Subprocess/filesystem seams, injectable in tests (`./login-cli` reals). */
+export type CliLoginIo = {
+  makeMintDir: () => string;
+  removeMintDir: (dir: string) => void;
+  spawn: (mintDir: string) => ChildProcessWithoutNullStreams;
+  readCredential: (mintDir: string) => ClaudeOAuthCredential;
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+  /**
+   * How long the CLI gets to print its `visit:` line. Must undercut
+   * `startLogin`'s 15s info race with room for the fallback's instant emit; a
+   * CLI that goes silent past this is treated as unable to run here.
+   */
+  urlTimeoutMs: number;
+  /**
+   * Backstop child lifetime. The abandoned-login expiry (login.ts, 10 min)
+   * aborts first in every wired flow; this only reaps a child nothing owns.
+   */
+  exitTimeoutMs: number;
+};
+
+export const defaultCliLoginIo: CliLoginIo = {
+  makeMintDir,
+  removeMintDir,
+  spawn: spawnLoginCli,
+  readCredential: readMintedCredential,
+  platform: process.platform,
+  env: process.env,
+  urlTimeoutMs: 10_000,
+  exitTimeoutMs: 15 * 60_000,
+};
+
+/**
+ * Whether this runtime may attempt the pod-side CLI login at all. macOS is
+ * excluded because the CLI caches the mint in the dir-scoped Keychain there —
+ * no file for `readMintedCredential` to extract (and no macOS pod exists; a
+ * co-located mac uses the desktop's own login, which owns Keychain reads).
+ */
+export function podCliLoginAvailable(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): { ok: true } | { ok: false; reason: string } {
+  if (env[POD_LOGIN_ENV] === "0")
+    return { ok: false, reason: `${POD_LOGIN_ENV}=0` };
+  if (platform === "darwin")
+    return {
+      ok: false,
+      reason: "macOS caches the mint in the Keychain, not a readable file",
+    };
+  return { ok: true };
+}
+
+/** Longest stderr tail kept for the failure message (desktop parity). */
+const STDERR_TAIL_MAX = 2_000;
+
+/**
+ * Drive one spawned login child to a terminal outcome: relay its authorize
+ * URL, feed it the pasted code, and classify how it ends. Every pre-URL death
+ * (spawn error, signal, non-zero exit, silence past `urlTimeoutMs`) rejects
+ * `CliLoginUnavailableError` = fallback-eligible; post-URL failures and
+ * cancellation reject plain errors. Always settles before killing, so a kill's
+ * own close event can never reclassify the outcome.
+ */
+function driveLoginChild(
+  child: ChildProcessWithoutNullStreams,
+  cb: CliLoginCallbacks,
+  signal: AbortSignal | undefined,
+  io: CliLoginIo,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let urlSeen = false;
+    let settled = false;
+    let stderrTail = "";
+    const tail = () => {
+      const t = stderrTail.trim();
+      return t ? `: ${t}` : "";
+    };
+
+    let urlTimer: NodeJS.Timeout | undefined;
+    let exitTimer: NodeJS.Timeout | undefined;
+    const settle = (outcome: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (urlTimer) clearTimeout(urlTimer);
+      if (exitTimer) clearTimeout(exitTimer);
+      signal?.removeEventListener("abort", onAbort);
+      outcome();
+    };
+    const fail = (e: Error) => settle(() => reject(e));
+    // The fallback gate: only a failure the user never saw a URL for may
+    // degrade to the setup-token dialog.
+    const failClassified = (detail: string) =>
+      fail(urlSeen ? new Error(detail) : new CliLoginUnavailableError(detail));
+
+    const onAbort = () => {
+      // Settle first: the kill's close event must not re-label a user cancel
+      // as a fallback-eligible signal death.
+      fail(new Error("login cancelled"));
+      child.kill();
+    };
+
+    urlTimer = setTimeout(() => {
+      failClassified(
+        `the pod Claude CLI printed no authorize URL within ${io.urlTimeoutMs / 1000}s`,
+      );
+      child.kill();
+    }, io.urlTimeoutMs);
+    urlTimer.unref?.();
+    exitTimer = setTimeout(() => {
+      fail(new Error("Claude sign-in timed out"));
+      child.kill();
+    }, io.exitTimeoutMs);
+    exitTimer.unref?.();
+
+    child.on("error", (e) =>
+      failClassified(`the pod Claude CLI could not run: ${e.message}`),
+    );
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderrTail = (stderrTail + String(chunk)).slice(-STDERR_TAIL_MAX);
+    });
+    // A dead readline (pasted after a decline already closed stdin) is the
+    // close handler's outcome to report, not a crash.
+    child.stdin.on("error", () => {});
+
+    createInterface({ input: child.stdout }).on("line", (line) => {
+      if (urlSeen) return;
+      const url = extractVisitUrl(line);
+      if (!url) return;
+      urlSeen = true;
+      if (urlTimer) clearTimeout(urlTimer);
+      cb.onAuth({ url, instructions: CLI_LOGIN_INSTRUCTIONS });
+    });
+
+    cb.onManualCodeInput().then(
+      (code) => {
+        // Answers the CLI's `Paste code here if prompted >` readline.
+        if (!settled && child.stdin.writable)
+          child.stdin.write(`${code.trim()}\n`);
+      },
+      () => {
+        // Cancel/expiry rejected the paste promise; the abort teardown (or the
+        // fallback flow now awaiting this same promise) owns the outcome.
+      },
+    );
+
+    child.on("close", (code, sig) => {
+      if (sig) {
+        // A signal is never a user decision (declines exit with a code) — the
+        // desktop's `helperUnavailable` rule, which pre-URL means fallback.
+        failClassified(`Claude sign-in failed (${sig})${tail()}`);
+        return;
+      }
+      if (code !== 0) {
+        failClassified(`Claude sign-in failed (exit ${code})${tail()}`);
+        return;
+      }
+      settle(resolve);
+    });
+
+    if (signal) {
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+}
+
+/**
+ * Run the pod-side CLI login end to end: spawn against a fresh mint dir, relay
+ * URL + code, then extract the minted credential and hand it to `store`. The
+ * mint dir is removed on every path — after a successful extraction the only
+ * durable copies are the ones `store` placed deliberately.
+ */
+export async function runAnthropicCliLogin(
+  cb: CliLoginCallbacks,
+  deps: {
+    store: (cred: ClaudeOAuthCredential) => Promise<void> | void;
+    signal?: AbortSignal;
+  },
+  io: CliLoginIo = defaultCliLoginIo,
+): Promise<void> {
+  const gate = podCliLoginAvailable(io.platform, io.env);
+  if (!gate.ok) throw new CliLoginUnavailableError(gate.reason);
+  const mintDir = io.makeMintDir();
+  try {
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = io.spawn(mintDir);
+    } catch (e) {
+      throw new CliLoginUnavailableError(
+        `could not spawn the pod Claude CLI: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+    await driveLoginChild(child, cb, deps.signal, io);
+    const cred = io.readCredential(mintDir);
+    await deps.store(cred);
+  } finally {
+    io.removeMintDir(mintDir);
+  }
+}
+
+/** Storage/materialization seams for the mint sink, injectable in tests. */
+export type MintSinkIo = {
+  storage: Pick<typeof authStorage, "set">;
+  serveMode: () => boolean;
+  personalScope: () => boolean;
+  materialize: (configDir: string, cred: ClaudeOAuthCredential) => void;
+  loginDir: () => string;
+  warmProbe: () => Promise<unknown>;
+};
+
+const defaultMintSinkIo: MintSinkIo = {
+  storage: authStorage,
+  serveMode: serveModeOn,
+  personalScope: () => isPersonalScope(currentCredentialScope().key),
+  materialize: writeClaudeOAuthCredentialFile,
+  loginDir: claudeLoginConfigDir,
+  warmProbe: () => refreshAnthropicCredential(undefined, { force: true }),
+};
+
+/**
+ * Place a pod-minted credential exactly where the sanctioned flows expect it.
+ *
+ * 1. auth.json (the ACTING scope's file, via the scope-aware store): the full
+ *    access+refresh entry is what `GET /auth/export` hands the host's
+ *    connect-once capture — central store put, then refresh scrub — making the
+ *    gateway the family's single rotator, the same end state as a desktop
+ *    push. Until that capture lands, the serve sync's mid-capture guard
+ *    (`applyServedCredential` refuses over a refresh-bearing entry) protects
+ *    it, like every other provider's device-code connect window.
+ * 2. Team scope only: materialize the CLI's own shared-dir file exactly like a
+ *    desktop push (`handleClaudeOAuthCredential`) — full credential on
+ *    self-host so the SDK self-refreshes in place, access-only in serve mode
+ *    (trap #4), then warm the connected probe so status flips immediately. A
+ *    personal scope must never touch the pod-shared file (HOU-976) — the
+ *    member's turns ride the per-turn served `CLAUDE_CODE_OAUTH_TOKEN`.
+ */
+export async function storeMintedClaudeCredential(
+  cred: ClaudeOAuthCredential,
+  io: MintSinkIo = defaultMintSinkIo,
+): Promise<void> {
+  io.storage.set("anthropic", {
+    type: "oauth",
+    access: cred.accessToken,
+    refresh: cred.refreshToken ?? "",
+    expires: cred.expiresAt ?? 0,
+  });
+  if (io.personalScope()) return;
+  io.materialize(
+    io.loginDir(),
+    io.serveMode() ? { ...cred, refreshToken: "" } : cred,
+  );
+  await io.warmProbe();
+}
+
+/**
+ * The anthropic connect `startLogin` runs: the pod-side CLI relay, degrading
+ * to the setup-token paste flow only when the relay is unavailable on this pod
+ * (`CliLoginUnavailableError` — always pre-URL, so the dialog never switches
+ * under the user). Both flows share the same `auth_code` wire shape and the
+ * same single-shot paste promise.
+ */
+export async function runAnthropicConnect(
+  cb: CliLoginCallbacks,
+  deps: {
+    storeCredential?: (cred: ClaudeOAuthCredential) => Promise<void> | void;
+    storeToken: (key: string) => void;
+    signal?: AbortSignal;
+  },
+  io: CliLoginIo = defaultCliLoginIo,
+): Promise<void> {
+  try {
+    await runAnthropicCliLogin(
+      cb,
+      {
+        store: deps.storeCredential ?? storeMintedClaudeCredential,
+        signal: deps.signal,
+      },
+      io,
+    );
+    return;
+  } catch (e) {
+    if (!(e instanceof CliLoginUnavailableError)) throw e;
+    console.warn(
+      `[claude-login] pod CLI sign-in unavailable (${e.message}); degrading to the setup-token paste flow`,
+    );
+  }
+  await runAnthropicSetupTokenLogin(
+    { onAuth: cb.onAuth, onManualCodeInput: cb.onManualCodeInput },
+    { store: deps.storeToken },
+  );
+}

--- a/packages/runtime/src/auth/anthropic-cli-login.ts
+++ b/packages/runtime/src/auth/anthropic-cli-login.ts
@@ -209,9 +209,16 @@ function driveLoginChild(
 
     cb.onManualCodeInput().then(
       (code) => {
-        // Answers the CLI's `Paste code here if prompted >` readline.
-        if (!settled && child.stdin.writable)
-          child.stdin.write(`${code.trim()}\n`);
+        // Answers the CLI's `Paste code here if prompted >` readline. A write
+        // racing the child's death may throw synchronously; the close handler
+        // owns that outcome, and this floating then-chain must never carry an
+        // unhandled rejection.
+        try {
+          if (!settled && child.stdin.writable)
+            child.stdin.write(`${code.trim()}\n`);
+        } catch {
+          // Stream torn down between the check and the write.
+        }
       },
       () => {
         // Cancel/expiry rejected the paste promise; the abort teardown (or the
@@ -228,6 +235,17 @@ function driveLoginChild(
       }
       if (code !== 0) {
         failClassified(`Claude sign-in failed (exit ${code})${tail()}`);
+        return;
+      }
+      if (!urlSeen) {
+        // A fresh mint dir has no cached session, so a real login ALWAYS
+        // prints the authorize URL first — a clean exit without one is a CLI
+        // that cannot run this flow here, not a mint. Resolving would store
+        // nothing while `startLogin`'s info race times out on a dialog that
+        // never opened.
+        failClassified(
+          `the pod Claude CLI exited without printing an authorize URL${tail()}`,
+        );
         return;
       }
       settle(resolve);

--- a/packages/runtime/src/auth/anthropic-setup-token.ts
+++ b/packages/runtime/src/auth/anthropic-setup-token.ts
@@ -36,7 +36,7 @@ export const ANTHROPIC_TOKEN_PREFIXES = [
 export const ANTHROPIC_TOKEN_HELP_URL =
   "https://docs.claude.com/en/docs/claude-code/cli-reference";
 
-const PASTE_INSTRUCTIONS =
+export const PASTE_INSTRUCTIONS =
   "Run `claude setup-token` in your terminal, then paste the token it prints (starts with sk-ant-oat01). A console API key (sk-ant-api03) also works.";
 
 export type SetupTokenCallbacks = {

--- a/packages/runtime/src/auth/login.test.ts
+++ b/packages/runtime/src/auth/login.test.ts
@@ -1,5 +1,6 @@
 import { createServer, type Server } from "node:net";
 import { expect, test, vi } from "vitest";
+import { POD_LOGIN_ENV } from "./anthropic-cli-login";
 import {
   CODEX_OAUTH_CALLBACK_PORT,
   CodexCallbackPortInUseError,
@@ -20,6 +21,12 @@ import {
   startLogin,
 } from "./login";
 import { modelRuntime } from "./storage";
+
+// Pin the anthropic tests to the setup-token paste flow: without the kill
+// switch, `startLogin("anthropic")` would try to spawn a real `claude` binary
+// on any machine that has one. The relay has its own subprocess-free tests
+// (anthropic-cli-login.test.ts).
+process.env[POD_LOGIN_ENV] = "0";
 
 /** Occupy the fixed Codex callback port, like a running Codex CLI would. */
 function occupyCodexCallbackPort(): Promise<Server> {

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -25,18 +25,20 @@ import {
   currentCredentialScope,
   isPersonalScope,
 } from "../session/acting-context";
-import { runAnthropicSetupTokenLogin } from "./anthropic-setup-token";
+import { runAnthropicConnect } from "./anthropic-cli-login";
 import { preflightCodexCallbackPort } from "./codex-port-preflight";
 import { authStorage, modelRuntime, providerConnected } from "./storage";
 
 /**
  * Multi-provider OAuth login, driven server-side and relayed to the webapp.
  *
- * - anthropic (Claude): the sanctioned setup-token flow. The direct OAuth PKCE
- *   replay is server-blocked since 2026-04, so we drive Anthropic's own
- *   `claude setup-token` (or take a pasted token) and store the resulting
- *   `sk-ant-oat01…` as an api_key. Same `auth_code` + completeLogin wire shape as
- *   before — see auth/anthropic-setup-token.ts.
+ * - anthropic (Claude): the pod-side CLI relay — the pod's own
+ *   `claude auth login --claudeai` mints the credential where the gateway
+ *   captures it, the user just approves in the browser and pastes the code
+ *   claude.ai shows (nothing installed locally). Degrades to the sanctioned
+ *   setup-token paste flow where the CLI can't run (the direct OAuth PKCE
+ *   replay stays server-blocked since 2026-04). Both ride the same `auth_code`
+ *   + completeLogin wire shape — see auth/anthropic-cli-login.ts.
  * - openai-codex (ChatGPT/Codex): the CLIENT picks. A co-located desktop client
  *   sends `deviceAuth: false` and gets the browser/loopback login — the user
  *   approves in their own browser and the localhost callback finishes it, no
@@ -398,13 +400,15 @@ export async function startLogin(
     },
   };
 
-  // Anthropic uses the sanctioned setup-token flow (the direct OAuth replay is
-  // server-blocked), NOT pi's OAuth login. It emits the same `auth_code`
-  // wire shape and reuses the paste promise, then stores the captured token as an
-  // api_key credential — see auth/anthropic-setup-token.ts.
+  // Anthropic connects through the pod's own Claude CLI (NOT pi's OAuth
+  // login): the authorize URL rides the `auth_code` wire shape and the paste
+  // promise feeds the approval code back to the CLI's stdin. Where the CLI
+  // can't run, the flow degrades to the sanctioned setup-token paste dialog,
+  // which stores the pasted token as an api_key credential — see
+  // auth/anthropic-cli-login.ts.
   const login: Promise<unknown> =
     provider === "anthropic"
-      ? runAnthropicSetupTokenLogin(
+      ? runAnthropicConnect(
           {
             onAuth: ({ url, instructions }) => {
               state.info = { kind: "auth_code", url, instructions };
@@ -414,8 +418,9 @@ export async function startLogin(
             onManualCodeInput: () => pastePromise,
           },
           {
-            store: (key) =>
+            storeToken: (key) =>
               authStorage.set("anthropic", { type: "api_key", key }),
+            signal: abort.signal,
           },
         )
       : runProviderOAuthLogin(provider, interaction);

--- a/packages/runtime/src/backends/claude/auth-cli.ts
+++ b/packages/runtime/src/backends/claude/auth-cli.ts
@@ -26,9 +26,11 @@ export type ProbeAnswer =
 /**
  * Resolve the spawnable `claude` binary: the bundled sibling inside the compiled
  * desktop sidecar, else `claude` on PATH (dev / self-host). A missing sibling in
- * a packaged build surfaces as an `execFile` ENOENT below, never a silent success.
+ * a packaged build surfaces as an `execFile` ENOENT below, never a silent
+ * success. Shared with the pod-side login relay (`./login-cli`), which spawns
+ * the same binary the SDK's turns resolve.
  */
-function claudeBinary(): string {
+export function claudeBinary(): string {
   try {
     return resolveClaudeExecutable() ?? "claude";
   } catch {

--- a/packages/runtime/src/backends/claude/login-cli.test.ts
+++ b/packages/runtime/src/backends/claude/login-cli.test.ts
@@ -1,0 +1,85 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { extractVisitUrl, readMintedCredential, stripOsc8 } from "./login-cli";
+
+const ESC = "\u001b";
+const BEL = "\u0007";
+const OSC_OPEN = `${ESC}]8;;https://claude.com/cai/oauth/authorize${BEL}`;
+const OSC_CLOSE = `${ESC}]8;;${BEL}`;
+
+test("extractVisitUrl finds the bare authorize URL after the marker", () => {
+  expect(
+    extractVisitUrl(
+      "Please visit: https://claude.com/cai/oauth/authorize?code=true&state=abc",
+    ),
+  ).toBe("https://claude.com/cai/oauth/authorize?code=true&state=abc");
+});
+
+test("extractVisitUrl strips OSC-8 hyperlink wrapping (CLI ≥2.1.201)", () => {
+  const line = `visit: ${OSC_OPEN}https://claude.com/cai/oauth/authorize?state=x${OSC_CLOSE}`;
+  expect(extractVisitUrl(line)).toBe(
+    "https://claude.com/cai/oauth/authorize?state=x",
+  );
+});
+
+test("extractVisitUrl trims trailing sentence punctuation", () => {
+  expect(extractVisitUrl("visit: https://claude.com/a).")).toBe(
+    "https://claude.com/a",
+  );
+});
+
+test("extractVisitUrl rejects non-http tokens and markerless lines", () => {
+  expect(extractVisitUrl("visit: file:///etc/passwd")).toBeNull();
+  expect(extractVisitUrl("visit:")).toBeNull();
+  expect(extractVisitUrl("no marker here https://claude.com")).toBeNull();
+});
+
+test("stripOsc8 leaves plain lines untouched", () => {
+  const line = "visit: https://claude.com/x now";
+  expect(stripOsc8(line)).toBe(line);
+});
+
+let dir: string | undefined;
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+  dir = undefined;
+});
+
+function mintDirWith(contents?: string): string {
+  dir = mkdtempSync(join(tmpdir(), "login-cli-test-"));
+  if (contents !== undefined)
+    writeFileSync(join(dir, ".credentials.json"), contents);
+  return dir;
+}
+
+test("readMintedCredential parses the CLI envelope", () => {
+  const d = mintDirWith(
+    JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "sk-ant-oat01-a",
+        refreshToken: "r",
+        expiresAt: 42,
+        subscriptionType: "max",
+      },
+    }),
+  );
+  expect(readMintedCredential(d)).toMatchObject({
+    accessToken: "sk-ant-oat01-a",
+    refreshToken: "r",
+    expiresAt: 42,
+  });
+});
+
+test("readMintedCredential throws user-fit errors for absent/garbled files", () => {
+  expect(() => readMintedCredential(mintDirWith())).toThrow(
+    /left no credential/,
+  );
+  expect(() => readMintedCredential(mintDirWith("not json"))).toThrow(
+    /could not be read/,
+  );
+  expect(() =>
+    readMintedCredential(mintDirWith(JSON.stringify({ claudeAiOauth: {} }))),
+  ).toThrow(/malformed/);
+});

--- a/packages/runtime/src/backends/claude/login-cli.ts
+++ b/packages/runtime/src/backends/claude/login-cli.ts
@@ -1,0 +1,125 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type ClaudeOAuthCredential,
+  parseClaudeOAuthEnvelope,
+} from "@houston/runtime-client";
+import { claudeBinary } from "./auth-cli";
+import { buildClaudeEnv } from "./backend";
+import { claudeCredentialsFile } from "./paths";
+
+/**
+ * Subprocess + parsing mechanics for the pod-side Claude login relay: spawning
+ * `claude auth login --claudeai` against a throwaway mint dir and reading what
+ * it leaves behind. The desktop's Rust runner
+ * (`app/src-tauri/src/claude_login/{resolve,runner}.rs`) is the production-
+ * proven reference for this child-process contract — `auth login --claudeai`
+ * is a plain readline stdio flow (NOT the Ink TUI that `claude setup-token`
+ * is), prints its authorize URL on a `visit:` line, and answers its
+ * `Paste code here if prompted >` prompt from stdin.
+ *
+ * Kept separate from `auth/anthropic-cli-login.ts` so the flow driver there
+ * stays free of subprocess/filesystem mechanics (and stays injectable in
+ * tests) — the same split as `auth-cli.ts` / `credential-status.ts`.
+ */
+
+/**
+ * The mint dir lives under the OS temp dir, NOT `HOUSTON_HOME`: the store-sync
+ * daemon ships `claude-login/.credentials.json` as a NAMED exclude
+ * (`packages/host/src/store-sync/daemon.ts`), so a new credential path inside
+ * the synced tree would leak token material to the object store on hosts that
+ * predate it. The temp dir is pod-local (never synced, gone on recycle), the
+ * dir itself is removed after every attempt, and `mkdtemp` gives each login its
+ * own dir so concurrent member logins can never read each other's mint.
+ */
+export function makeMintDir(): string {
+  return mkdtempSync(join(tmpdir(), "claude-login-mint-"));
+}
+
+/** Best-effort scrub of a mint dir (its tmpfs dies with the pod anyway). */
+export function removeMintDir(dir: string): void {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // Unreadable/racing tmp entry — nothing durable survives outside the pod.
+  }
+}
+
+/**
+ * Strip OSC-8 hyperlink escape sequences (`ESC]8;…;URI BEL|ESC\`): current
+ * CLIs wrap the authorize URL in them even on a pipe, which would hide the
+ * `visit:` marker's URL token from a plain substring scan.
+ */
+export function stripOsc8(line: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: OSC-8 is delimited by ESC/BEL by definition
+  return line.replace(/\u001b\]8;[^\u0007\u001b]*(?:\u0007|\u001b\\)/g, "");
+}
+
+const VISIT_MARKER = "visit:";
+
+/**
+ * The authorize URL from one stdout line, or null. Mirrors the desktop's
+ * `extract_visit_url` (`resolve.rs`): find the `visit:` marker, take the next
+ * whitespace-separated token, accept only http(s), and trim the trailing
+ * sentence punctuation the CLI sometimes appends.
+ */
+export function extractVisitUrl(line: string): string | null {
+  const clean = stripOsc8(line);
+  const idx = clean.indexOf(VISIT_MARKER);
+  if (idx < 0) return null;
+  const token = clean
+    .slice(idx + VISIT_MARKER.length)
+    .trim()
+    .split(/\s+/)[0];
+  if (!token || !(token.startsWith("http://") || token.startsWith("https://")))
+    return null;
+  return token.replace(/[.)]+$/, "");
+}
+
+/**
+ * The credential the CLI cached for the mint dir. On Linux (the pod) and
+ * Windows the CLI writes `<CLAUDE_CONFIG_DIR>/.credentials.json`; the relay is
+ * gated off macOS (`podCliLoginAvailable`), whose Keychain the runtime cannot
+ * read. Throws with a user-fit message — by this point the CLI exited 0, so a
+ * missing/garbled file is a real handoff failure, never a fallback trigger.
+ */
+export function readMintedCredential(mintDir: string): ClaudeOAuthCredential {
+  let raw: string;
+  try {
+    raw = readFileSync(claudeCredentialsFile(mintDir), "utf8");
+  } catch {
+    throw new Error(
+      "Claude sign-in finished, but the CLI left no credential to hand off. Try connecting again.",
+    );
+  }
+  let body: unknown;
+  try {
+    body = JSON.parse(raw) as unknown;
+  } catch {
+    throw new Error(
+      "Claude sign-in finished, but the minted credential could not be read. Try connecting again.",
+    );
+  }
+  const parsed = parseClaudeOAuthEnvelope(body);
+  if (!parsed.ok)
+    throw new Error(
+      `Claude sign-in finished, but the minted credential is malformed (${parsed.error}). Try connecting again.`,
+    );
+  return parsed.value;
+}
+
+/**
+ * Spawn the login CLI against the mint dir. Same env discipline as every other
+ * `claude auth` spawn (`buildClaudeEnv`: allowlisted env, credential vars
+ * scrubbed, `CLAUDE_CONFIG_DIR` = the mint dir) and the desktop's cwd rule
+ * (home, never the inherited cwd — an agent workspace must not shape the CLI).
+ */
+export function spawnLoginCli(mintDir: string): ChildProcessWithoutNullStreams {
+  return spawn(claudeBinary(), ["auth", "login", "--claudeai"], {
+    env: buildClaudeEnv(mintDir, undefined),
+    cwd: homedir(),
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}

--- a/packages/runtime/src/backends/claude/login-cli.ts
+++ b/packages/runtime/src/backends/claude/login-cli.ts
@@ -38,12 +38,18 @@ export function makeMintDir(): string {
   return mkdtempSync(join(tmpdir(), "claude-login-mint-"));
 }
 
-/** Best-effort scrub of a mint dir (its tmpfs dies with the pod anyway). */
+/**
+ * Best-effort scrub of a mint dir. A pod's tmpfs dies with the pod, but a
+ * self-host machine's /tmp can outlive the process — so a failure is loudly
+ * logged (path only, never contents): a lingering mint holds a refresh token.
+ */
 export function removeMintDir(dir: string): void {
   try {
     rmSync(dir, { recursive: true, force: true });
-  } catch {
-    // Unreadable/racing tmp entry — nothing durable survives outside the pod.
+  } catch (e) {
+    console.warn(
+      `[claude-login] could not remove the login mint dir ${dir} — remove it manually, it may hold credential material: ${e instanceof Error ? e.message : String(e)}`,
+    );
   }
 }
 


### PR DESCRIPTION
Fixes PRODUCT-1136.

## Why

Connecting a Claude subscription previously required minting the OAuth credential on the user's machine: the desktop spawns a bundled `claude` helper (which SIGILLs outright on pre-AVX2 CPUs — Sentry HOUSTON-APP-543, 103 events) and then pushes the credential to the pod, a handoff that fails in transit for real users (`push_claude_oauth_credential` family: ~101 events / ~50 users in 4 days, with HOUSTON-APP-564's 19 events landing users in a paste flow whose instructions require installing the Claude CLI). The product requirement is: users install nothing.

## What

The runtime now mints the credential **on the engine pod** by driving the pod's own `claude auth login --claudeai` — the same binary every turn already resolves, and the same piped-readline child contract the desktop runner has proven in production.

- **`backends/claude/login-cli.ts`** — subprocess + parsing mechanics: spawn with `CLAUDE_CONFIG_DIR` pointed at a `mkdtemp` mint dir (outside the store-sync tree — the sync excludes are exact-key, so a mint under `HOUSTON_HOME` would leak to the object store on older hosts), `visit:`-marker URL extraction with OSC-8 stripping, envelope read of `<mintDir>/.credentials.json`.
- **`auth/anthropic-cli-login.ts`** — the flow driver: the authorize URL rides the existing `auth_code` LoginInfo (zero protocol change, zero cloud-repo change), the pasted approval code answers the CLI's `Paste code here if prompted >` readline, and the minted credential is sunk exactly where the sanctioned flows expect it: a full entry in the acting scope's auth.json (so the client's existing connect-once capture → central store put → refresh scrub makes the gateway the family's **single rotator**, trap #4), plus the team-scope materialized file exactly like a desktop push (access-only in serve mode; personal scope never touches the pod-shared file, HOU-976). The mint dir is scrubbed win or lose.
- **`auth/login.ts`** — the anthropic seam now runs the relay and degrades to the setup-token paste flow **only** when the relay is unavailable on this pod: binary absent (the cloud per-turn image strips it), macOS (Keychain mint, unreadable), `HOUSTON_CLAUDE_POD_LOGIN=0` (kill switch), or a child that dies/goes silent before printing its URL — which also deterministically catches the feared Ink-TUI piped-stdio deadlock. Every unavailability is pre-URL by construction, so the dialog never switches under the user; post-URL failures (declined approval, bad code) surface as real sign-in errors. Cancellation is never misclassified as fallback.
- **Dialog copy** (`provider-login-dialog.tsx` + en/es/pt locales) — the `auth_code` header goes flow-neutral and the link is labeled by destination host: it is the primary action for the relay, still the docs reference for the fallback.

No client routing changes needed: web "Connect Claude" and the PRODUCT-1135 desktop degrade path already call `providerLogin` → runtime `startLogin`, and `pollProviderConnect` already captures + scrubs on completion.

## Net UX on any hardware

Click Connect → approve in the browser → paste the one code claude.ai shows. Nothing installed.

## Tests

- 21 new tests: `login-cli.test.ts` (URL/OSC-8/envelope parsing) and `anthropic-cli-login.test.ts` (fake-child driver: happy path, ENOENT/silence/pre-URL-exit fallbacks, post-URL decline/signal as real errors, abort never falls back, mint scrub on every path, sink serve/self-host/personal-scope matrix).
- `login.test.ts` pins its anthropic tests to the setup-token path via the kill switch so no machine's real `claude` is spawned.
- Full runs green: runtime 1044 tests, app 2767 tests, `tsgo` typecheck both packages, biome clean on touched files.

## Before / after

**Reproduce the gap before this change** (as a cloud/web user, or any desktop where the helper can't run):
1. Open Houston web against a managed pod → Settings → AI Models → Connect Claude.
2. The dialog instructs: "Run `claude setup-token` in your terminal…" — i.e. install something. That is the entire fallback surface for pre-AVX2 desktops (HOUSTON-APP-543) and for credential-push failures (HOUSTON-APP-564).

**Verify after deploy** (engine image containing this change):
1. Same click path → the dialog now shows "Open the link below and approve the sign-in in your browser…" with an `Open claude.com` link and a paste box.
2. Approve in the browser; claude.ai shows a code; paste it. The card flips to Connected without any local CLI.
3. On the pod: `<HOUSTON_HOME>/claude-login/.credentials.json` exists (refresh-stripped under serve mode), auth.json's anthropic refresh token is scrubbed after capture, and no `claude-login-mint-*` dir remains in `/tmp`.
4. Degrade check: set `HOUSTON_CLAUDE_POD_LOGIN=0` on the runtime (or use an image without the SDK binary) → the same click lands on the setup-token dialog, previous behavior.