### PR TITLE
fix(sdk): stamp the user bubble's turnId on every adoption path (PRODUCT-1217)

### DIFF
--- a/packages/sdk/src/modules/turns/settle-from-history.ts
+++ b/packages/sdk/src/modules/turns/settle-from-history.ts
@@ -42,13 +42,14 @@ export function settleFromHistory(
   messages: ChatMessage[] | null,
   turnId: string | undefined,
   guard: (messages: ChatMessage[]) => boolean,
+  onAdoptTurnId?: (turnId: string) => void,
 ): void {
   if (messages && turnId) {
     const reply = messages.find(
       (m) => m.role === "assistant" && m.turnId === turnId,
     );
     if (reply) {
-      adoptReply(s, reply);
+      adoptReply(s, reply, onAdoptTurnId);
       return;
     }
     finishErr(s, TURN_DIED_MESSAGE);
@@ -58,7 +59,7 @@ export function settleFromHistory(
     // Legacy fallback: no turn ids anywhere — trailing reply + guard.
     const last = messages[messages.length - 1];
     if (last?.role === "assistant" && guard(messages)) {
-      adoptReply(s, last);
+      adoptReply(s, last, onAdoptTurnId);
       return;
     }
   }
@@ -68,7 +69,20 @@ export function settleFromHistory(
   else finishErr(s, TURN_DIED_MESSAGE);
 }
 
-function adoptReply(s: TurnState, reply: ChatMessage): void {
+function adoptReply(
+  s: TurnState,
+  reply: ChatMessage,
+  onAdoptTurnId?: (turnId: string) => void,
+): void {
+  // The persisted reply names the turn this settle recovers. Adopt its id
+  // FIRST: the settle's own pushes then carry the identity a later replay
+  // dedupes against (HOU-1214), and the sink's callback stamps the optimistic
+  // user bubble the lost echo left id-less — the anchor edit-and-resend
+  // (PRODUCT-1217) rewinds on.
+  if (reply.turnId !== undefined) {
+    s.turnId ??= reply.turnId;
+    onAdoptTurnId?.(reply.turnId);
+  }
   if (reply.providerError) {
     settleProviderErrorCard(s, reply.providerError);
     return;
@@ -123,6 +137,7 @@ export async function presettleFromHistory(
   turnId: string | undefined,
   guard: (messages: ChatMessage[]) => boolean,
   hasEvidence: () => boolean,
+  onAdoptTurnId?: (turnId: string) => void,
 ): Promise<boolean> {
   let messages: ChatMessage[];
   try {
@@ -138,7 +153,7 @@ export async function presettleFromHistory(
   if (s.settled || hasEvidence()) return false;
   const reply = conclusiveReply(messages, turnId, guard);
   if (!reply) return false;
-  adoptReply(s, reply);
+  adoptReply(s, reply, onAdoptTurnId);
   return true;
 }
 
@@ -175,6 +190,7 @@ export async function reloadAndSettle(
   turnId: string | undefined,
   guard: (messages: ChatMessage[]) => boolean,
   stop: () => void,
+  onAdoptTurnId?: (turnId: string) => void,
 ): Promise<void> {
   let messages: ChatMessage[] | null = null;
   try {
@@ -185,6 +201,6 @@ export async function reloadAndSettle(
       data: `Couldn't reload the conversation: ${e instanceof Error ? e.message : String(e)}`,
     });
   }
-  if (!s.settled) settleFromHistory(s, messages, turnId, guard);
+  if (!s.settled) settleFromHistory(s, messages, turnId, guard, onAdoptTurnId);
   stop();
 }

--- a/packages/sdk/src/modules/turns/turn-settle.test.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.test.ts
@@ -103,9 +103,11 @@ test("matches the assistant reply by turnId and adopts its text + usage", () => 
   // A clean settle with NO pending interaction still lands on `needs_you` —
   // the engine never writes `done`.
   expect(s.terminal).toBe("needs_you");
+  // The settle's pushes carry the adopted identity (HOU-1214 dedup).
   expect(items).toContainEqual({
     feed_type: "assistant_text",
     data: "Full reply",
+    turnId: "t-1",
   });
   const final = items.find((i) => i.feed_type === "final_result")?.data as {
     result: string;
@@ -236,6 +238,7 @@ test("a persisted stopped reply settles needs_you with the standard stop line, n
   expect(items).toContainEqual({
     feed_type: "system_message",
     data: "Stopped by user",
+    turnId: "t-1",
   });
   expect(items.some((i) => i.feed_type === "provider_error")).toBe(false);
   expect(statuses).toEqual([["error", undefined]]);
@@ -267,6 +270,7 @@ test("a stopped reply with an (illegal) pendingInteraction: stopped wins, no car
   expect(items).toContainEqual({
     feed_type: "system_message",
     data: "Stopped by user",
+    turnId: "t-1",
   });
 });
 

--- a/packages/sdk/src/modules/turns/turn-sink.ts
+++ b/packages/sdk/src/modules/turns/turn-sink.ts
@@ -127,7 +127,7 @@ export class TurnSink {
           this.accepted &&
           this.s.turnId === undefined
         ) {
-          this.s.turnId = ev.turnId;
+          this.adoptTurnId(ev.turnId);
           break;
         }
         return; // another turn's frame — never fold it into ours
@@ -152,19 +152,11 @@ export class TurnSink {
     // history hydration covers observed turns), so echoes are never rendered.
     if (this.o.mode === "turn" && this.o.nonce === ev.data.nonce) {
       // OUR echo: the turn started — adopt its id (absent on legacy servers).
-      this.s.turnId = ev.turnId;
+      this.adoptTurnId(ev.turnId);
       this.accepted = true;
       this.sawRunning = true;
       this.s.delivered = true; // the engine echoed our send — it landed
       this.cancelPresettlePoll(); // the turn is demonstrably live on the stream
-      // Stamp the id onto the optimistic bubble too, so turn-anchored
-      // affordances (edit-and-resend, PRODUCT-1217) work without a reload.
-      if (ev.turnId)
-        this.o.output.stampUserTurn?.(
-          this.o.agentPath,
-          this.o.sessionKey,
-          ev.turnId,
-        );
       return;
     }
     if (classifyFrame(this.s.turnId, ev.turnId) === "boundary") {
@@ -234,7 +226,7 @@ export class TurnSink {
         this.settleFromHistorySoon(); // ours ended; a new turn runs
         return;
       case "adopt":
-        this.s.turnId = data.turnId;
+        this.adoptTurnId(data.turnId);
         break;
       case "ours":
         break;
@@ -322,6 +314,29 @@ export class TurnSink {
     this.cancelPresettlePoll(); // a running turn on the stream: the poll is moot
   }
 
+  /**
+   * Every path that learns OUR turn's wire id funnels here: the nonce echo,
+   * a running sync's adopt, a stamped terminal frame after an accepted send,
+   * and a history settle's persisted reply. Adopting sets the push-dedup
+   * identity (HOU-1214) and stamps the optimistic user bubble so the
+   * turn-anchored edit-and-resend affordance (PRODUCT-1217) works even when
+   * the echo frame itself was never delivered — a subscription that attaches
+   * a beat late gets no replay, and the bubble used to stay id-less until a
+   * full reload. Turn mode only for the stamp: only our own send has an
+   * optimistic bubble, and an observer stamping an observed turn's id could
+   * mis-stamp a concurrent send's pending bubble.
+   */
+  private adoptTurnId(turnId: string | undefined): void {
+    if (turnId === undefined) return;
+    this.s.turnId ??= turnId;
+    if (this.o.mode === "turn")
+      this.o.output.stampUserTurn?.(
+        this.o.agentPath,
+        this.o.sessionKey,
+        turnId,
+      );
+  }
+
   private settleFromHistorySoon(): void {
     if (this.settling || this.s.settled) return;
     this.cancelPresettlePoll(); // a confirmed-lost-terminal settle supersedes the poll
@@ -332,6 +347,7 @@ export class TurnSink {
       this.s.turnId,
       this.o.historyGuard,
       this.o.stop,
+      (turnId) => this.adoptTurnId(turnId),
     );
   }
 
@@ -385,6 +401,7 @@ export class TurnSink {
       this.s.turnId,
       this.o.historyGuard,
       () => this.sawRunning,
+      (turnId) => this.adoptTurnId(turnId),
     );
     if (settled) {
       this.settling = true;

--- a/packages/sdk/src/modules/turns/turn-stream.test.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.test.ts
@@ -2188,3 +2188,86 @@ test("HOU-1214: repeated seed+observe cycles stay duplicate-free (the ×4 accumu
     feed.filter((f) => f.feed_type === "assistant_text").map((f) => f.data),
   ).toEqual([reply]);
 });
+
+// ── Edit-and-resend anchor: the missed-echo turnId stamp (PRODUCT-1217) ──────
+// The optimistic user bubble gets its turnId from the nonce-matched `user`
+// echo. A subscription that attaches a beat late misses that echo (a fresh
+// connect only gets the current sync — no replay without a cursor), and every
+// other adoption path used to leave the bubble id-less forever: the reply
+// rendered fine, but Edit (which anchors a rewind on `turnId`) never mounted
+// until a full reload. Both recovery paths must stamp the bubble.
+
+test("attach mid-turn with the echo missed: the sync adopt stamps the optimistic bubble's turnId", async () => {
+  const { engine } = fakeEngine([
+    (o) => {
+      // The attach sync names the running turn; the echo is gone for good.
+      o.onEvent(sync(true, "Roger", 1, { turnId: "turn-2" }));
+      o.onEvent({ type: "text", data: " that", seq: 2, turnId: "turn-2" });
+      o.onEvent({ type: "done", data: null, seq: 3, turnId: "turn-2" });
+    },
+  ]);
+  const store = new ScopeStore();
+  const vm = new ConversationVmOutput(store);
+
+  await streamTurn(
+    engine,
+    "Houston/Bo",
+    "activity-missed-echo",
+    "second message",
+    vm,
+    registry,
+    { tuning: fast },
+  );
+
+  const snap = store.getSnapshot(
+    conversationScope("Houston/Bo", "activity-missed-echo"),
+  ) as ConversationVM;
+  const bubble = snap.feed.find((f) => f.feed_type === "user_message");
+  expect(bubble?.data).toBe("second message");
+  expect(bubble?.turnId).toBe("turn-2");
+  expect(snap.sessionStatus).toBe("completed");
+});
+
+test("attach after the turn finished: the poll's history settle stamps the bubble from the persisted reply", async () => {
+  const history: ChatMessage[] = [
+    { role: "user", content: "second message", ts: 1, turnId: "turn-3" },
+    {
+      role: "assistant",
+      content: 'You said: "second message"',
+      ts: 2,
+      turnId: "turn-3",
+    },
+  ];
+  const { engine } = fakeEngine(
+    [
+      (o) => {
+        // Idle sync, no frames ever: the turn completed before we attached.
+        o.onEvent(sync(false, "", 0));
+        return hang(o);
+      },
+    ],
+    history,
+  );
+  const store = new ScopeStore();
+  const vm = new ConversationVmOutput(store);
+
+  await streamTurn(
+    engine,
+    "Houston/Bo",
+    "activity-presettle-stamp",
+    "second message",
+    vm,
+    registry,
+    { tuning: { ...fast, presettledPollMs: 20 } },
+  );
+
+  const snap = store.getSnapshot(
+    conversationScope("Houston/Bo", "activity-presettle-stamp"),
+  ) as ConversationVM;
+  const bubble = snap.feed.find((f) => f.feed_type === "user_message");
+  expect(bubble?.turnId).toBe("turn-3");
+  // The settle's own pushes carry the same identity (HOU-1214 dedup).
+  const reply = snap.feed.find((f) => f.feed_type === "assistant_text");
+  expect(reply?.turnId).toBe("turn-3");
+  expect(snap.sessionStatus).toBe("completed");
+});

--- a/packages/sdk/tests/bridge.contract.test.ts
+++ b/packages/sdk/tests/bridge.contract.test.ts
@@ -166,9 +166,16 @@ describe("send -> stream -> settle (bridge-fetch streaming path)", () => {
     // Every feed entry now carries a stamped epoch-ms `ts`; assert it is present
     // and numeric, then compare the rest of the VM structurally (ts stripped).
     for (const f of settled?.feed ?? []) expect(typeof f.ts).toBe("number");
+    // Every entry — the optimistic user bubble included — carries the ONE
+    // turn's server-minted id (the settle adopts it from the persisted reply
+    // and stamps the bubble; PRODUCT-1217 anchors edit-and-resend on it). The
+    // id itself is random, so assert identity and strip it from the compare.
+    const turnIds = new Set((settled?.feed ?? []).map((f) => f.turnId));
+    expect(turnIds.size).toBe(1);
+    expect([...turnIds][0]).toBeTruthy();
     expect({
       ...settled,
-      feed: (settled?.feed ?? []).map(({ ts, ...rest }) => rest),
+      feed: (settled?.feed ?? []).map(({ ts, turnId, ...rest }) => rest),
     }).toEqual({
       running: false,
       sessionStatus: "completed",


### PR DESCRIPTION
Fixes the flaky e2e that failed CI on main ([run 31236095194](https://github.com/gethouston/houston/actions/runs/31236095194/job/93048755986)): `chat.spec.ts › edits a previous user message in place and rewinds the conversation` timed out waiting for the Edit button, passed on retry, and `--fail-on-flaky-tests` failed the job.

## Root cause (from the run's Playwright trace)

The failure snapshot shows the wedge exactly: the **first** user row has its Edit action, the **second** (just-sent) row has only Copy — its bubble never got a `turnId`, and Edit is gated on `message.turnId !== undefined` (it anchors the rewind).

The optimistic user bubble only received its `turnId` from the nonce-matched `user` echo frame (`turn-sink.ts` → `stampUserTurn`). But a turn subscription that attaches a beat late **misses that echo**: a fresh connect gets only the current sync (no replay without a cursor). The sink still recovers the turn fine — the attach sync's `adopt` or the pre-settled history poll renders the reply and settles the session — yet **neither recovery path stamped the bubble**, so it stayed id-less until a full reload and Edit could never mount. On CI the fake host starts the turn within milliseconds of the 202, so the attach loses that race just often enough to flake — and the same race exists in production against a fast turn.

## Fix

Funnel every path that learns our turn's wire id through one `adoptTurnId` seam in `TurnSink`:

- the nonce-matched `user` echo (previous behavior, unchanged),
- a running sync's `adopt` (the CI race),
- a stamped terminal frame after an accepted send (fail-before-execute),
- a history settle's persisted reply (`adoptReply` — both `reloadAndSettle` and the pre-settled poll), via a new optional `onAdoptTurnId` callback.

Adoption also sets `TurnState.turnId` before the settle's pushes, so a settle-from-history now emits `assistant_text`/`final_result`/`system_message` items carrying the turn's identity — the HOU-1214 dedup these pushes previously lacked.

The bubble stamp stays **turn-mode only**: an observer stamping an observed turn's id could mis-stamp a concurrent send's pending bubble.

## Tests

- Two new SDK tests reproduce both lost-echo paths deterministically (red before the fix): attach mid-turn (sync adopt) and attach after the turn finished (pre-settled poll). Both assert the VM bubble ends up stamped.
- Updated 3 `turn-settle` expectations + the bridge contract snapshot: settle pushes now (intentionally) carry `turnId`; the bridge test additionally asserts all feed entries share the one server-minted id.

## Verification

- `@houston/sdk` vitest: 412/412
- app unit tests (`node:test`): 2783/2783
- full repo typecheck + Biome clean
- `e2e/chat.spec.ts` (chromium): 13/13, plus the edit + copy tests at `--repeat-each 5`: 10/10