### PR TITLE
fix(onboarding): sign-out no longer re-onboards returning accounts (PRODUCT-1282)

### DIFF
--- a/app/src/hooks/use-onboarding-completed.ts
+++ b/app/src/hooks/use-onboarding-completed.ts
@@ -1,14 +1,21 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import {
+  type AccountFlagRead,
+  resolveOnboardingCompleted,
+} from "../lib/onboarding-completed-policy";
 import { queryKeys } from "../lib/query-keys";
 import { tauriPreferences } from "../lib/tauri";
 import { useSession } from "./use-session";
 
 /**
- * Engine-preference key for the durable "this install has finished first-run
- * onboarding" flag. Stored as an opaque string in `~/.houston` prefs (same
- * mechanism as `onboarding_pending` / `legal_acceptance`), so it survives an
- * app restart.
+ * Preference key for the durable "this user has finished first-run onboarding"
+ * flag. An ACCOUNT preference (PRODUCT-1282): it rides `/v1/preferences/:key`
+ * on the host/gateway like `legal_acceptance`, so it survives sign-out — which
+ * purges every account-scoped localStorage key — and follows the account to
+ * new devices. A device-local copy died with the session, and the next
+ * sign-in re-onboarded a returning user whose agent list read empty for a
+ * moment (warming pod).
  */
 export const ONBOARDING_COMPLETED_KEY = "onboarding_completed";
 
@@ -18,12 +25,13 @@ function onboardingCompletedLocalKey(uid: string | null): string {
   return `houston.onboarding-completed.${uid ?? "local"}`;
 }
 
-// Device-local mirror of the completed flag (per signed-in uid). The engine
-// preference lives on the user's pod in hosted mode, so a pod blip or a failed
+// Device-local mirror of the completed flag (per signed-in uid). The account
+// preference lives behind the host/gateway, so an unreachable host or a failed
 // write would resolve `isCompleted=false` and re-onboard a real user (zero
 // cloud agents after a migration / delete-all). The mirror keeps the flag
-// reading completed per user per device even when the engine pref is
-// unreachable. localStorage failures are non-fatal (behaves as before).
+// reading completed per user per device even when the account pref is
+// unreachable. Sign-out purges it — the account pref is the durable copy.
+// localStorage failures are non-fatal (behaves as before).
 function readLocalMirror(uid: string | null): boolean {
   try {
     return localStorage.getItem(onboardingCompletedLocalKey(uid)) === "1";
@@ -58,7 +66,7 @@ export interface OnboardingCompletedState {
 }
 
 /**
- * Durable record that first-run onboarding is behind this install.
+ * Durable record that first-run onboarding is behind this account.
  *
  * `isFirstRun` (App.tsx) reports first-run from a ZERO-AGENT workspace on the v3
  * control plane. That signal cannot tell "never onboarded" apart from "onboarded
@@ -71,7 +79,8 @@ export interface OnboardingCompletedState {
  *
  * Hardened like `useOnboardingSegment`: keyed by uid (no stale value across a
  * user switch) with a uid-keyed localStorage mirror, so a failed or unreachable
- * engine pref read never DOWNGRADES a completed user back into onboarding.
+ * account pref read never DOWNGRADES a completed user back into onboarding.
+ * The merge itself is `resolveOnboardingCompleted` (pure, unit-tested).
  */
 export function useOnboardingCompleted(): OnboardingCompletedState {
   const qc = useQueryClient();
@@ -81,22 +90,28 @@ export function useOnboardingCompleted(): OnboardingCompletedState {
   const query = useQuery({
     queryKey: queryKeys.onboardingCompleted(uid),
     queryFn: async (): Promise<boolean> => {
-      let fromEngine = false;
+      let account: AccountFlagRead = "unreachable";
       try {
         const raw = await tauriPreferences.get(ONBOARDING_COMPLETED_KEY);
-        fromEngine = raw?.trim() === "1";
+        account = raw?.trim() === "1" ? "completed" : "unset";
       } catch {
-        // Engine unreachable (hosted pod waking / provisioning) — fall through
-        // to the local mirror rather than re-onboarding a completed user.
+        // Host unreachable (waking / offline) — fall through to the local
+        // mirror rather than re-onboarding a completed user.
       }
-      if (fromEngine) {
-        writeLocalMirror(uid); // refresh the mirror
-        return true;
+      const resolved = resolveOnboardingCompleted(
+        account,
+        readLocalMirror(uid),
+      );
+      if (resolved.refreshMirror) writeLocalMirror(uid);
+      if (resolved.healAccount) {
+        // The mirror says completed but the account pref is missing (pre-fix
+        // device-local completion, or a lost write): stamp it back up so the
+        // flag survives the NEXT sign-out too. Best-effort, off the boot path.
+        tauriPreferences.set(ONBOARDING_COMPLETED_KEY, "1").catch((e) => {
+          console.error("[onboarding-completed] account pref heal failed", e);
+        });
       }
-      // Upgrade-only: an unset engine pref with a set mirror still reads
-      // completed (the engine write was lost / the pod was reset), never the
-      // reverse.
-      return readLocalMirror(uid);
+      return resolved.completed;
     },
     staleTime: 30_000,
   });
@@ -104,14 +119,14 @@ export function useOnboardingCompleted(): OnboardingCompletedState {
   const { mutateAsync } = useMutation({
     mutationFn: async () => {
       // The local mirror is written FIRST: once completed, this device must
-      // never re-onboard the user even if the engine write fails.
+      // never re-onboard the user even if the account write fails.
       writeLocalMirror(uid);
       try {
         await tauriPreferences.set(ONBOARDING_COMPLETED_KEY, "1");
       } catch (e) {
-        // Best-effort: the flag is kept locally; the engine pref catches up on
-        // a later mark or stays device-local. Logged, never blocks the flow.
-        console.error("[onboarding-completed] engine pref write failed", e);
+        // Best-effort: the flag is kept locally; the next boot's queryFn heals
+        // the account pref from the mirror. Logged, never blocks the flow.
+        console.error("[onboarding-completed] account pref write failed", e);
       }
     },
     onSuccess: () => {

--- a/app/src/lib/houston-local-state.ts
+++ b/app/src/lib/houston-local-state.ts
@@ -52,7 +52,10 @@ const DEVICE_LOCAL_KEY_PREFIXES = [
  *  layouts, read cursors, agent colors, onboarding mirrors, provider-status
  *  caches, the last-sign-in hint — while keeping the device-level keys above.
  *  Runs on every sign-out (PRODUCT-1235): no trace of the outgoing account may
- *  survive into the next sign-in. */
+ *  survive into the next sign-in. Durable per-account state must therefore
+ *  live server-side: `onboarding_completed` is an ACCOUNT preference behind
+ *  `/v1/preferences/:key` (PRODUCT-1282) — wiping its device mirror here must
+ *  never re-onboard a returning user. */
 export function purgeAccountLocalState(storage: KeyedStorage): void {
   const doomed: string[] = [];
   for (let i = 0; i < storage.length; i++) {

--- a/app/src/lib/onboarding-completed-policy.ts
+++ b/app/src/lib/onboarding-completed-policy.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure resolution policy for the durable `onboarding_completed` flag
+ * (PRODUCT-1282), extracted so the merge of its two stores is unit-testable
+ * without React Query or a live host (same convention as `onboarding-flow.ts`).
+ *
+ * Two stores, upgrade-only semantics (there is no un-complete):
+ *  - the ACCOUNT preference behind `/v1/preferences/onboarding_completed` —
+ *    the durable copy: survives sign-out (which purges every account-scoped
+ *    localStorage key) and follows the account across devices;
+ *  - the per-uid localStorage MIRROR — the device fallback that keeps a
+ *    completed user completed while the host is unreachable.
+ */
+
+/** Outcome of reading the account preference. */
+export type AccountFlagRead =
+  /** The account pref is set: the user finished onboarding somewhere. */
+  | "completed"
+  /** The read succeeded and the pref is absent/blank. */
+  | "unset"
+  /** The read failed (host waking / offline) — the value is unknown. */
+  | "unreachable";
+
+export interface OnboardingCompletedResolution {
+  /** What the boot gate should treat as the flag's value. */
+  completed: boolean;
+  /** Re-stamp the device mirror (the account pref is authoritative-true). */
+  refreshMirror: boolean;
+  /** Write the account pref back up: the mirror says completed but the
+   *  account copy is missing (a pre-fix device-local completion, or a lost
+   *  write). Healing it is what makes the flag survive the NEXT sign-out. */
+  healAccount: boolean;
+}
+
+/** Merge the account pref and the device mirror. Upgrade-only: either store
+ *  saying completed wins; an unreachable account read never downgrades a
+ *  mirrored completion, and an unset one gets healed from it. */
+export function resolveOnboardingCompleted(
+  account: AccountFlagRead,
+  mirrorSet: boolean,
+): OnboardingCompletedResolution {
+  if (account === "completed") {
+    return { completed: true, refreshMirror: true, healAccount: false };
+  }
+  return {
+    completed: mirrorSet,
+    refreshMirror: false,
+    // Only heal on a SUCCESSFUL empty read: against an unreachable host the
+    // write would fail too, and a transient outage must not spam retries.
+    healAccount: mirrorSet && account === "unset",
+  };
+}

--- a/app/tests/onboarding-completed-policy.test.ts
+++ b/app/tests/onboarding-completed-policy.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert";
+import { test } from "node:test";
+import { resolveOnboardingCompleted } from "../src/lib/onboarding-completed-policy.ts";
+
+// PRODUCT-1282: the durable `onboarding_completed` flag is merged from the
+// ACCOUNT preference (survives sign-out) and the per-uid device mirror
+// (survives an unreachable host). Upgrade-only: either store saying completed
+// wins; a completed user is never routed back into first-run onboarding.
+
+test("account pref set → completed, and the device mirror is refreshed", () => {
+  assert.deepStrictEqual(resolveOnboardingCompleted("completed", false), {
+    completed: true,
+    refreshMirror: true,
+    healAccount: false,
+  });
+  assert.deepStrictEqual(resolveOnboardingCompleted("completed", true), {
+    completed: true,
+    refreshMirror: true,
+    healAccount: false,
+  });
+});
+
+test("both stores empty → genuinely fresh, first-run onboarding unchanged", () => {
+  assert.deepStrictEqual(resolveOnboardingCompleted("unset", false), {
+    completed: false,
+    refreshMirror: false,
+    healAccount: false,
+  });
+});
+
+test("mirror-only completion reads completed AND heals the account pref", () => {
+  // A pre-fix device-local completion (or a lost write): without the heal the
+  // flag would die on the next sign-out's localStorage purge all over again.
+  assert.deepStrictEqual(resolveOnboardingCompleted("unset", true), {
+    completed: true,
+    refreshMirror: false,
+    healAccount: true,
+  });
+});
+
+test("unreachable host never downgrades a mirrored completion, never heals", () => {
+  // The mirror carries the flag through the outage; a heal write would fail
+  // against the same unreachable host, so it is not attempted.
+  assert.deepStrictEqual(resolveOnboardingCompleted("unreachable", true), {
+    completed: true,
+    refreshMirror: false,
+    healAccount: false,
+  });
+});
+
+test("unreachable host with no mirror reads not-completed", () => {
+  // Nothing to upgrade from: behaves like today's boot against a cold host.
+  assert.deepStrictEqual(resolveOnboardingCompleted("unreachable", false), {
+    completed: false,
+    refreshMirror: false,
+    healAccount: false,
+  });
+});

--- a/packages/web/src/engine-adapter/client/config-prefs-mixin.ts
+++ b/packages/web/src/engine-adapter/client/config-prefs-mixin.ts
@@ -16,7 +16,11 @@ import type { BaseCtor } from "./mixin";
  * (HOU-732). Everything else (theme, last_agent_id, recent models, …) is
  * per-device UI state and stays local. `houston_onboarding_segment` is here
  * too: the segmentation question must survive across the user's devices, not
- * re-ask on every fresh install.
+ * re-ask on every fresh install. Same for `onboarding_completed`
+ * (PRODUCT-1282): sign-out purges every account-scoped localStorage key, so a
+ * device-local copy dies with the session and the next sign-in re-onboarded a
+ * returning user whose agent list read empty for a moment (warming pod). As an
+ * account key it survives sign-out and follows the account to new devices.
  */
 const ACCOUNT_PREF_KEYS = new Set([
   "timezone",
@@ -24,6 +28,7 @@ const ACCOUNT_PREF_KEYS = new Set([
   "legal_acceptance",
   "migration_reconnect_dismissed",
   "houston_onboarding_segment",
+  "onboarding_completed",
 ]);
 
 function readLocalPref(key: string): string | null {

--- a/packages/web/tests/account-preferences.test.ts
+++ b/packages/web/tests/account-preferences.test.ts
@@ -130,6 +130,40 @@ test("device keys never touch the network", async () => {
   expect(calls).toEqual([]);
 });
 
+// PRODUCT-1282: sign-out purges every account-scoped localStorage key, so a
+// device-local `onboarding_completed` died with the session and the next
+// sign-in re-onboarded a returning user. As an account key it lives behind
+// `/v1/preferences/:key`, survives sign-out, and follows the account across
+// devices; the mixin's legacy lift migrates a pre-fix device copy up once.
+test("onboarding_completed is an account key — sign-out must not erase it", async () => {
+  stubFetch(json(200, { value: "1" }));
+
+  await expect(
+    client(true).getPreference("onboarding_completed"),
+  ).resolves.toBe("1");
+  expect(calls).toEqual([
+    {
+      url: "http://host/v1/preferences/onboarding_completed",
+      method: "GET",
+      body: null,
+    },
+  ]);
+});
+
+test("a pre-fix device-local onboarding_completed is lifted to the account", async () => {
+  store.set("houston.pref.onboarding_completed", "1");
+  stubFetch(json(200, { value: null }), json(200, { value: "1" }));
+
+  await expect(
+    client(true).getPreference("onboarding_completed"),
+  ).resolves.toBe("1");
+  expect(calls.map((c) => `${c.method} ${c.url}`)).toEqual([
+    "GET http://host/v1/preferences/onboarding_completed",
+    "PUT http://host/v1/preferences/onboarding_completed",
+  ]);
+  expect(store.has("houston.pref.onboarding_completed")).toBe(false);
+});
+
 test("locale, legal_acceptance and the migration flag are account keys", async () => {
   stubFetch(
     json(200, { value: "es" }),


### PR DESCRIPTION
Fixes PRODUCT-1282.

## Problem

Signing out to switch accounts, then signing in with an account that already has agents, dropped the user into first-run onboarding (segmentation + create-your-assistant) as if they were brand new.

## Root cause

The durable `onboarding_completed` flag lived only in this device's localStorage (`houston.pref.onboarding_completed` + the per-uid mirror `houston.onboarding-completed.<uid>`). Sign-out runs `purgeAccountLocalState` (PRODUCT-1235), which removes every account-scoped `houston.*` key — both copies included. On the next sign-in the flag resolves false, so any transient zero-agent reading during boot (warming pod, empty list blip) satisfies `isFirstRun` and routes a returning user into onboarding — where the orchestrator marks `onboarding_pending` on mount and pins them there even after their agents load. Unlike `houston_onboarding_segment`, the flag was never an account preference, so nothing survived the purge.

## Fix

Promote `onboarding_completed` to an ACCOUNT preference:

- **`config-prefs-mixin.ts`** — added to `ACCOUNT_PREF_KEYS`, so it rides `/v1/preferences/onboarding_completed` (gateway in cloud mode, local host otherwise), survives sign-out, and follows the account across devices. The mixin's existing legacy lift migrates a pre-fix device-local copy up to the account on first read.
- **`use-onboarding-completed.ts`** — the merge of the account pref and the per-uid device mirror is extracted into a pure policy module (`onboarding-completed-policy.ts`). New behavior: when only the mirror says completed but the account read succeeds empty (pre-fix completion, or a lost write), the account pref is healed best-effort so the flag survives the *next* sign-out too. An unreachable host still falls back to the mirror and never downgrades, unchanged.
- **`houston-local-state.ts`** — doc note on the purge: durable per-account state must live server-side; wiping the onboarding mirror is now safe.

Existing users need no migration: the App.tsx backfill (agents present → `markCompleted()`) now stamps the account server-side on their next boot.

## Tests

- `packages/web/tests/account-preferences.test.ts`: `onboarding_completed` routes to `/v1/preferences` (never localStorage), and a pre-fix device-local copy is lifted up once.
- `app/tests/onboarding-completed-policy.test.ts`: all five merge outcomes (account-set wins + mirror refresh, both-empty stays first-run, mirror-only heals the account, unreachable never downgrades and never heals).

## Verification

- `pnpm check` (Biome) clean, `pnpm check:boundaries` clean
- `cd app && pnpm test` — 2807 pass (node:test)
- `pnpm --filter houston-web test` — 381 pass (vitest)
- `cd app && pnpm tsgo --noEmit` + `pnpm --filter houston-web typecheck` clean (full workspace typecheck also ran in the pre-commit hook)
- `e2e/onboarding-skip.spec.ts` (chromium) — 2 pass: the skip path now PUTs the flag to the fake host and the shared-worker reset already clears it