### PR TITLE
fix(integrations): HighLevel connects via direct provider redirect (PRODUCT-1260)

### DIFF
--- a/packages/host/src/integrations/composio.test.ts
+++ b/packages/host/src/integrations/composio.test.ts
@@ -181,10 +181,44 @@ test("connect reuses the project's enabled auth config and mints a link session"
   expect(calls[2]?.path).toBe("/api/v3.1/connected_accounts/link");
 });
 
-test("connect pre-answers highlevel's user_type so the hosted page never asks", async () => {
+test("connect pre-answers highlevel's user_type via the direct initiate", async () => {
   const { provider, calls } = harness((url, method) => {
     if (url.pathname === "/api/v3/auth_configs" && method === "GET") {
       return { body: { items: [{ id: "ac_hl", status: "ENABLED" }] } };
+    }
+    if (url.pathname === "/api/v3/connected_accounts" && method === "POST") {
+      return {
+        body: { id: "ca_hl", redirect_url: "https://provider/oauth" },
+      };
+    }
+    return { status: 404 };
+  });
+
+  // The redirect points at the provider's OAuth page, never Composio's
+  // hosted form — there is no field left for a user to overwrite.
+  const start = await provider.connect(USER, "highlevel");
+  expect(start).toEqual({
+    redirectUrl: "https://provider/oauth",
+    connectionId: "ca_hl",
+  });
+  expect(calls[1]?.body).toEqual({
+    auth_config: { id: "ac_hl" },
+    connection: {
+      user_id: USER,
+      data: { user_type: "Location" },
+      callback_url: "https://gethouston.ai/connected",
+    },
+  });
+});
+
+test("connect falls back to the hosted link when the prefilled initiate is rejected", async () => {
+  const { provider, calls } = harness((url, method) => {
+    if (url.pathname === "/api/v3/auth_configs" && method === "GET") {
+      return { body: { items: [{ id: "ac_hl", status: "ENABLED" }] } };
+    }
+    if (url.pathname === "/api/v3/connected_accounts" && method === "POST") {
+      // The retired-for-this-org shape.
+      return { status: 400, body: { error: "initiate is retired" } };
     }
     if (url.pathname === "/api/v3.1/connected_accounts/link") {
       return {
@@ -197,11 +231,14 @@ test("connect pre-answers highlevel's user_type so the hosted page never asks", 
     return { status: 404 };
   });
 
-  await provider.connect(USER, "highlevel");
-  expect(calls[1]?.body).toEqual({
+  const start = await provider.connect(USER, "highlevel");
+  expect(start.connectionId).toBe("ca_hl");
+  // The hosted link still carries the prefill as the field's value.
+  const link = calls.find((c) =>
+    c.path.startsWith("/api/v3.1/connected_accounts/link"),
+  );
+  expect(link?.body).toMatchObject({
     auth_config_id: "ac_hl",
-    user_id: USER,
-    callback_url: "https://gethouston.ai/connected",
     connection_data: { user_type: "Location" },
   });
 });

--- a/packages/host/src/integrations/composio.test.ts
+++ b/packages/host/src/integrations/composio.test.ts
@@ -181,6 +181,31 @@ test("connect reuses the project's enabled auth config and mints a link session"
   expect(calls[2]?.path).toBe("/api/v3.1/connected_accounts/link");
 });
 
+test("connect pre-answers highlevel's user_type so the hosted page never asks", async () => {
+  const { provider, calls } = harness((url, method) => {
+    if (url.pathname === "/api/v3/auth_configs" && method === "GET") {
+      return { body: { items: [{ id: "ac_hl", status: "ENABLED" }] } };
+    }
+    if (url.pathname === "/api/v3.1/connected_accounts/link") {
+      return {
+        body: {
+          redirect_url: "https://connect.composio.dev/link/lk_1",
+          connected_account_id: "ca_hl",
+        },
+      };
+    }
+    return { status: 404 };
+  });
+
+  await provider.connect(USER, "highlevel");
+  expect(calls[1]?.body).toEqual({
+    auth_config_id: "ac_hl",
+    user_id: USER,
+    callback_url: "https://gethouston.ai/connected",
+    connection_data: { user_type: "Location" },
+  });
+});
+
 test("connect creates a Composio-managed auth config when the toolkit has one", async () => {
   const { provider, calls } = harness((url, method) => {
     if (url.pathname === "/api/v3/auth_configs" && method === "GET") {

--- a/packages/host/src/integrations/composio.ts
+++ b/packages/host/src/integrations/composio.ts
@@ -64,6 +64,19 @@ const CATALOG_TTL_MS = 60 * 60 * 1000;
  */
 const TOOL_VERSION = "latest";
 
+/**
+ * Initiation fields Houston answers FOR the user at link-mint time. The hosted
+ * connect page asks the user for every required initiation field it wasn't
+ * given; for highlevel that was a free-text "Token Type" box whose value the
+ * token exchange relays verbatim as `user_type` — HighLevel 422s anything but
+ * Location/Company, and a user pasted their private-integration token into it
+ * (PRODUCT-1260). Houston's non-technical audience should never see that
+ * question; Location is the token type most HighLevel actions require.
+ */
+const PREFILLED_CONNECTION_DATA: Record<string, Record<string, string>> = {
+  highlevel: { user_type: "Location" },
+};
+
 export interface ComposioOptions {
   /** Houston's Composio PROJECT API key (dashboard → Project Settings). */
   apiKey: string;
@@ -208,6 +221,7 @@ export class ComposioProvider implements IntegrationProvider {
       this.authConfigs,
       toolkit,
     );
+    const prefill = PREFILLED_CONNECTION_DATA[toolkit.toLowerCase()];
     const body = await this.http.call<{
       redirect_url?: string;
       connected_account_id?: string;
@@ -217,6 +231,7 @@ export class ComposioProvider implements IntegrationProvider {
         auth_config_id: authConfigId,
         user_id: userId,
         ...(this.callbackUrl ? { callback_url: this.callbackUrl } : {}),
+        ...(prefill ? { connection_data: prefill } : {}),
       },
     });
     if (!body?.redirect_url || !body.connected_account_id) {

--- a/packages/host/src/integrations/composio.ts
+++ b/packages/host/src/integrations/composio.ts
@@ -65,13 +65,16 @@ const CATALOG_TTL_MS = 60 * 60 * 1000;
 const TOOL_VERSION = "latest";
 
 /**
- * Initiation fields Houston answers FOR the user at link-mint time. The hosted
- * connect page asks the user for every required initiation field it wasn't
- * given; for highlevel that was a free-text "Token Type" box whose value the
- * token exchange relays verbatim as `user_type` — HighLevel 422s anything but
- * Location/Company, and a user pasted their private-integration token into it
- * (PRODUCT-1260). Houston's non-technical audience should never see that
- * question; Location is the token type most HighLevel actions require.
+ * Initiation fields Houston answers FOR the user at connect time. The hosted
+ * connect page asks the user for every required initiation field — and renders
+ * it as an editable text box even when a value was supplied; for highlevel
+ * that was a free-text "Token Type" box whose value the token exchange relays
+ * verbatim as `user_type` — HighLevel 422s anything but Location/Company, and
+ * a user pasted their private-integration token into it (PRODUCT-1260).
+ * Houston's non-technical audience should never see that question, so
+ * toolkits listed here connect via the direct initiate path (the provider's
+ * own OAuth page, no Composio form); Location is the token type most
+ * HighLevel actions require.
  */
 const PREFILLED_CONNECTION_DATA: Record<string, Record<string, string>> = {
   highlevel: { user_type: "Location" },
@@ -214,6 +217,15 @@ export class ComposioProvider implements IntegrationProvider {
    * Start connecting a toolkit: mint an auth-link session — Composio hosts the
    * OAuth dance and the user authorizes the APP (Gmail…), never Composio. The
    * returned connectionId is polled via connection() until it turns active.
+   *
+   * Toolkits with prefilled connection data try the legacy v3 initiate FIRST:
+   * with every required initiation field already answered it returns a
+   * redirect straight to the provider's own OAuth page, skipping Composio's
+   * hosted form entirely (the form renders even a supplied field as an
+   * editable text box, which is how PRODUCT-1260's user pasted a pit-… token
+   * over the prefill). Initiate is retired for Composio-managed auth (400s
+   * for orgs created after 2026-05-08), so any rejection falls back to the
+   * hosted link — which still carries the prefill as the field's value.
    */
   async connect(userId: string, toolkit: string): Promise<ConnectStart> {
     const authConfigId = await resolveAuthConfig(
@@ -222,6 +234,15 @@ export class ComposioProvider implements IntegrationProvider {
       toolkit,
     );
     const prefill = PREFILLED_CONNECTION_DATA[toolkit.toLowerCase()];
+    if (prefill) {
+      try {
+        return await this.initiateConnection(authConfigId, userId, prefill);
+      } catch (err) {
+        console.warn(
+          `[integrations] composio: prefilled initiate rejected for '${toolkit}', falling back to hosted link: ${String(err)}`,
+        );
+      }
+    }
     const body = await this.http.call<{
       redirect_url?: string;
       connected_account_id?: string;
@@ -241,6 +262,35 @@ export class ComposioProvider implements IntegrationProvider {
       redirectUrl: body.redirect_url,
       connectionId: body.connected_account_id,
     };
+  }
+
+  /** Direct (non-hosted) connect: POST the initiation data ourselves and get
+   *  the provider's OAuth redirect back. Only called with a complete prefill;
+   *  the response's redirect_url points at the provider (verified live:
+   *  highlevel → marketplace.gohighlevel.com's chooselocation). */
+  private async initiateConnection(
+    authConfigId: string,
+    userId: string,
+    data: Record<string, string>,
+  ): Promise<ConnectStart> {
+    const body = await this.http.call<{ id?: string; redirect_url?: string }>(
+      "/api/v3/connected_accounts",
+      {
+        method: "POST",
+        body: {
+          auth_config: { id: authConfigId },
+          connection: {
+            user_id: userId,
+            data,
+            ...(this.callbackUrl ? { callback_url: this.callbackUrl } : {}),
+          },
+        },
+      },
+    );
+    if (!body?.redirect_url || !body.id) {
+      throw new Error("composio: initiate returned no redirect_url");
+    }
+    return { redirectUrl: body.redirect_url, connectionId: body.id };
   }
 
   async connection(


### PR DESCRIPTION
## Summary

Completes the HighLevel connect fix from PRODUCT-1260 on the host side. (The first attempt rode PR #1270's branch but the PR was merged before GitHub picked the second commit up, so only the Windows-dialog fix landed there — this PR carries the integrations change.)

**Root cause.** Composio's hosted connect page asks the user for every required initiation field. For `highlevel` that is `user_type` ("Token Type") — a free-text box whose value the token exchange relays verbatim; HighLevel 422s anything except `Location`/`Company`. The reporting user pasted their GHL private-integration token (`pit-…`) into it, so every attempt failed with "OAuth provider rejected the token exchange: Request failed with status code 422".

**Fix, two layers:**
1. `PREFILLED_CONNECTION_DATA` — the host answers `user_type: Location` itself.
2. Prefilled toolkits mint via the legacy **v3 initiate** instead of the hosted link: with every required field answered it returns a redirect straight to the provider's own OAuth page. Verified live against prod Composio: the redirect 302s to `marketplace.gohighlevel.com/v2/oauth/chooselocation` — no Composio form at all, nothing left to overwrite. (Pre-filling the hosted link alone was not enough: the form still renders the supplied value as an editable text box.) Initiate is retired for Composio-managed auth on newer orgs, so a rejection logs and falls back to the hosted link, which still carries the prefill as the field value.

Mirrors gethouston/cloud PR #228 (the gateway, which serves managed-cloud users).

## Verification

Before: connect HighLevel → Composio page shows an editable "Token Type" box; a wrong value → 422 card.
After: `CLOUD_DIR` dev loop or self-host → Connect Highlevel → browser lands directly on HighLevel's login/sub-account chooser; picking a sub-account turns the card Connected.
Tests: `pnpm --filter @houston/host test` — 1379 passed; new tests pin the initiate body (prefill + user), the 400→hosted-link fallback (still carrying `connection_data`), and that non-prefilled toolkits never touch initiate.

PRODUCT-1260