### PR TITLE
test(e2e): re-press ⌘K until the palette answers

### DIFF
--- a/packages/web/e2e/support/palette.ts
+++ b/packages/web/e2e/support/palette.ts
@@ -1,0 +1,26 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+/**
+ * Open the ⌘K command palette and hand back its search input.
+ *
+ * The shortcut is a window keydown listener the shell attaches in an effect,
+ * and effects run AFTER the paint that puts the rail's ready-marker on screen —
+ * so a spec that presses the instant that marker shows can land its one
+ * keystroke before the listener exists, and a keypress, unlike a locator
+ * action, has no auto-retry. On a busy CI runner that race is real: the press
+ * is dropped, the palette never opens, and the spec hangs to its timeout.
+ *
+ * So the press itself retries: press, give the dialog a beat to answer, press
+ * again only while it stays shut. The guard on a visible input keeps the
+ * shortcut's toggle from closing a palette that did open.
+ */
+export async function openPalette(page: Page): Promise<Locator> {
+  const search = page.getByPlaceholder("Search agents, tasks, actions...");
+  await expect(async () => {
+    if (!(await search.isVisible())) {
+      await page.keyboard.press("ControlOrMeta+KeyK");
+    }
+    await expect(search).toBeVisible({ timeout: 1_000 });
+  }).toPass();
+  return search;
+}

--- a/packages/web/e2e/teams-nav.spec.ts
+++ b/packages/web/e2e/teams-nav.spec.ts
@@ -5,6 +5,7 @@ import {
 } from "@houston/fake-host";
 import type { Page } from "@playwright/test";
 import { expect, test } from "./support/fixtures";
+import { openPalette } from "./support/palette";
 import { litRows, rail, screen } from "./support/team-nav";
 import { startGuidedTour } from "./support/tour-nav";
 
@@ -74,9 +75,7 @@ test("the command palette's agent jump opens that agent's team board", async ({
   await page.goto("/");
   await expect(page.getByText("Your teams")).toBeVisible();
 
-  await page.keyboard.press("ControlOrMeta+KeyK");
-  const search = page.getByPlaceholder("Search agents, tasks, actions...");
-  await expect(search).toBeVisible();
+  const search = await openPalette(page);
   await search.fill("Houston");
   await page.getByRole("option", { name: "Houston", exact: true }).click();
 
@@ -99,8 +98,8 @@ test("the palette's recent missions open the mission's chat on that team board",
   await page.goto("/");
   await expect(page.getByText("Your teams")).toBeVisible();
 
-  await page.keyboard.press("ControlOrMeta+KeyK");
-  await page.getByPlaceholder("Search agents, tasks, actions...").fill("Tokyo");
+  const search = await openPalette(page);
+  await search.fill("Tokyo");
   await page.getByRole("option", { name: /Plan a trip to Tokyo/ }).click();
 
   // The published target (`activityPanelId`) has exactly one consumer now — the
@@ -166,9 +165,7 @@ test("a team the user holds no membership in is drawn, and the palette jumps int
       .filter({ hasText: SEED_AGENT_NAME }),
   ).toHaveCount(1);
 
-  await page.keyboard.press("ControlOrMeta+KeyK");
-  const search = page.getByPlaceholder("Search agents, tasks, actions...");
-  await expect(search).toBeVisible();
+  const search = await openPalette(page);
   await search.fill(SEED_AGENT_NAME);
   await page
     .getByRole("option", { name: SEED_AGENT_NAME, exact: true })


### PR DESCRIPTION
## What

Fixes the `main` CI failure in [run 31329194483](https://github.com/gethouston/houston/actions/runs/31329194483/job/93284552598): `teams-nav.spec.ts` › *the palette's recent missions open the mission's chat on that team board* timed out 30s waiting for the palette's search input, on both attempts.

## Why it failed

The ⌘K shortcut is a `window` keydown listener the shell attaches in an effect (`useKeyboardShortcuts()` in `workspace-shell.tsx`), and effects run **after** the paint that puts the spec's ready-marker ("Your teams") on screen. The spec pressed ⌘K the instant that marker showed, so on a slow CI runner the single keystroke landed before the listener existed. A keypress, unlike a locator action, has no auto-retry — the press was dropped, the palette never opened, and the spec hung to its timeout.

The failure snapshot proves it: only `CommandDialog`'s always-mounted sr-only header ("Command palette" / "Jump anywhere in Houston" — rendered outside `DialogContent`, so present even when closed) is in the tree. The dialog itself never opened.

## Fix

New `e2e/support/palette.ts` → `openPalette(page)`: presses ⌘K inside an `expect(...).toPass()` loop, re-pressing **only while the input stays hidden** so the shortcut's toggle can't close a palette that did open, and returns the search input. All three palette-open sites in `teams-nav.spec.ts` now go through it (the other two had the same latent race).

App behavior is untouched — for a human the listener is attached long before any keypress; this is purely a test-timing hardening, same family as c89321bf.

## Verification

- `pnpm test:e2e e2e/teams-nav.spec.ts` — 4/4 pass locally
- `pnpm --filter houston-web typecheck:e2e` clean, Biome clean