### PR TITLE
feat(store): app-native chrome, featured row, and quieter cards for the in-app Agent Store

### DIFF
--- a/app/src/components/store-view/my-agents-panel.tsx
+++ b/app/src/components/store-view/my-agents-panel.tsx
@@ -25,7 +25,6 @@ import {
 } from "./my-agents-labels";
 import { actionLink } from "./store-link";
 import { STORE_SITE_URL, useMyStoreAgents } from "./use-my-store-agents";
-import { useStoreInstall } from "./use-store-install";
 
 type Sort = "recent" | "installs";
 
@@ -47,7 +46,6 @@ export function MyAgentsPanel({
   const setCreatorEditorOpen = useUIStore((s) => s.setCreatorEditorOpen);
   const [signingIn, setSigningIn] = useState(false);
   const [sort, setSort] = useState<Sort>("recent");
-  const { install } = useStoreInstall();
 
   const navLink = actionLink((href) => {
     if (href === "edit-profile") setCreatorEditorOpen(true);
@@ -141,9 +139,6 @@ export function MyAgentsPanel({
       loading={loading}
       failed={my.isError}
       onRetry={() => void my.refetch()}
-      onTryAgent={(agent) => {
-        if (agent.slug) void install(agent.slug);
-      }}
       labels={{ loadFailed: t("loadFailed"), retry: t("retry") }}
       owner={{
         editHref: "edit-profile",

--- a/app/src/components/store-view/store-browse.tsx
+++ b/app/src/components/store-view/store-browse.tsx
@@ -4,15 +4,20 @@ import {
   fetchStoreCreators,
   type StoreCatalogAgent,
 } from "@houston-ai/engine-client";
-import { StoreHomeScreen } from "@houston-ai/store";
+import {
+  CatalogControls,
+  StoreHomeScreen,
+  type StoreHomeState,
+} from "@houston-ai/store";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { showErrorToast } from "../../lib/error-toast";
 import {
   isStoreCategory,
   storeCategoryLabelKey,
 } from "../../lib/store-categories";
+import { PageHeaderTools } from "../shell/page-header/page-header-tools";
 import { actionLink } from "./store-link";
 import {
   agentCardLabels,
@@ -54,6 +59,14 @@ export function StoreBrowse({
   const { t } = useTranslation("store");
   const { install } = useStoreInstall();
   const { t: tPortable } = useTranslation("portable");
+  // The browse state lives HERE, not in the shared screen: the search and
+  // filters render in the page header (the app's grammar for a screen's
+  // tools), so the screen runs in controlled mode and only shows results.
+  const [state, setState] = useState<StoreHomeState>({
+    query: "",
+    view: "agents",
+    sort: "installs",
+  });
   const options = storeBrowseQueryOptions();
   const catalog = useQuery(options.catalog);
   const categories = useQuery(options.categories);
@@ -95,26 +108,56 @@ export function StoreBrowse({
     ]);
   };
   return (
-    <StoreHomeScreen
-      onTryAgent={(agent) => {
-        if (agent.slug) void install(agent.slug);
-      }}
-      rows={rows}
-      agentHref={(agent) => `agent:${agent.id}`}
-      creatorHref={(creator) => `creator:${creator.handle}`}
-      LinkComponent={LinkComponent}
-      loading={catalog.isPending || categories.isPending || creators.isPending}
-      failed={catalog.isError || categories.isError || creators.isError}
-      onRetry={retry}
-      labels={{
-        hero: t("browse.heroTitle"),
-        empty: t("empty"),
-        loadFailed: t("loadFailed"),
-        retry: t("retry"),
-        ...catalogControlLabels(t),
-        agentCard: agentCardLabels(t),
-        creatorCard: creatorCardLabels(t),
-      }}
-    />
+    <>
+      <PageHeaderTools>
+        {(inStrip) => {
+          const controls = (
+            <CatalogControls
+              categories={rows.categories}
+              {...state}
+              onQueryChange={(query) => setState((s) => ({ ...s, query }))}
+              onCategoryChange={(category) =>
+                setState((s) => ({ ...s, category }))
+              }
+              onViewChange={(view) => setState((s) => ({ ...s, view }))}
+              onSortChange={(sort) => setState((s) => ({ ...s, sort }))}
+              variant={inStrip ? "strip" : "row"}
+              labels={catalogControlLabels(t)}
+            />
+          );
+          return inStrip ? (
+            controls
+          ) : (
+            <div className="mx-auto w-full max-w-[1040px] px-6 pt-6 md:px-8">
+              {controls}
+            </div>
+          );
+        }}
+      </PageHeaderTools>
+      <StoreHomeScreen
+        onTryAgent={(agent) => {
+          if (agent.slug) void install(agent.slug);
+        }}
+        rows={rows}
+        state={state}
+        agentHref={(agent) => `agent:${agent.id}`}
+        creatorHref={(creator) => `creator:${creator.handle}`}
+        LinkComponent={LinkComponent}
+        loading={
+          catalog.isPending || categories.isPending || creators.isPending
+        }
+        failed={catalog.isError || categories.isError || creators.isError}
+        onRetry={retry}
+        labels={{
+          empty: t("empty"),
+          loadFailed: t("loadFailed"),
+          retry: t("retry"),
+          featuredAgents: t("browse.featuredAgents"),
+          allAgents: t("browse.allAgents"),
+          agentCard: agentCardLabels(t),
+          creatorCard: creatorCardLabels(t),
+        }}
+      />
+    </>
   );
 }

--- a/app/src/components/store-view/store-browse.tsx
+++ b/app/src/components/store-view/store-browse.tsx
@@ -140,6 +140,7 @@ export function StoreBrowse({
         }}
         rows={rows}
         state={state}
+        featured
         agentHref={(agent) => `agent:${agent.id}`}
         creatorHref={(creator) => `creator:${creator.handle}`}
         LinkComponent={LinkComponent}
@@ -152,6 +153,7 @@ export function StoreBrowse({
           empty: t("empty"),
           loadFailed: t("loadFailed"),
           retry: t("retry"),
+          creators: t("browse.creators"),
           featuredAgents: t("browse.featuredAgents"),
           allAgents: t("browse.allAgents"),
           agentCard: agentCardLabels(t),

--- a/app/src/components/store-view/store-header.tsx
+++ b/app/src/components/store-view/store-header.tsx
@@ -1,0 +1,136 @@
+import type { StoreCatalogAgent } from "@houston-ai/engine-client";
+import { ChevronRight, Store } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { PageHeader } from "../shell/page-header/page-header";
+import { PageHeaderBackChip } from "../shell/page-header/page-header-back-chip";
+import type { HeaderThresholds } from "../shell/page-header/page-header-layout";
+import {
+  type PageHeaderTabItem,
+  PageHeaderTabs,
+} from "../shell/page-header/page-header-tabs";
+
+export type StorePane = "browse" | "my-agents";
+
+/**
+ * Browse is the limiting case: its tools ride the strip. The left cluster is
+ * ~210px (Agent Store 130 + Profile 75 + their 2px gap); the strip-variant
+ * controls are ~556px (search 224 + category 150 + view 110 + sort 48 + three
+ * 8px gaps); the frame's px-5 is 40px and the zone gap 12. `210 + 556 + 40 +
+ * 12 = 818`, rounded UP to 840. No compact middle mode: the controls have no
+ * shorter honest form, so below this they stack. The drilled panes render no
+ * tools, so the threshold changes nothing for them — a chip plus one lozenge
+ * simply truncates.
+ */
+export const STORE_HEADER_THRESHOLDS: HeaderThresholds = { oneRowMin: 840 };
+
+/**
+ * The store strip on both levels, one navigation grammar with the rest of the
+ * app:
+ *
+ *     (🏪 Agent Store)(Profile)                 — browsing / your profile
+ *     (‹ 🏪 Agent Store) (@maria)               — a creator's page
+ *     (‹ 🏪 Agent Store) (@maria › Site Builder) — an agent's page
+ *
+ * **A drilled place is ONE lozenge, growing segments.** An agent belongs to
+ * its creator the way a pinned agent belongs to its team, and it borrows the
+ * team lozenge's answer (`team-chrome.tsx`): chevron-joined segments inside a
+ * single lozenge, never a second lozenge beside the first. Clicking it goes
+ * up one segment — the agent's lozenge opens its creator — mirroring how the
+ * team lozenge sheds its pinned agent.
+ *
+ * **The owner segment always shows.** A listing always names its creator, so
+ * an agent's lozenge never appears ownerless: `@handle` when the creator has
+ * one (a page exists, the click goes there), the plain display name when they
+ * never claimed one (no page, the click has nowhere up to go). A row reached
+ * through a creator's page may arrive without its own enrichment, so the
+ * handle falls back to the page it was opened from.
+ *
+ * Per the drilled-header rules on {@link PageHeaderBackChip}, the drilled
+ * lozenge is text-only; the Store glyph rides only the top-level identity and
+ * the back chip.
+ */
+export function StoreHeader({
+  pane,
+  detailAgent,
+  creatorHandle,
+  onBrowse,
+  onMyAgents,
+  onOpenCreator,
+}: {
+  pane: StorePane;
+  detailAgent: StoreCatalogAgent | null;
+  creatorHandle: string | null;
+  onBrowse: () => void;
+  onMyAgents: () => void;
+  onOpenCreator: (handle: string) => void;
+}) {
+  const { t } = useTranslation("store");
+
+  if (!detailAgent && !creatorHandle) {
+    const items: PageHeaderTabItem<StorePane>[] = [
+      {
+        id: "browse",
+        heading: true,
+        label: (
+          <>
+            <Store aria-hidden className="size-4 shrink-0" />
+            <span className="min-w-0 truncate">{t("title")}</span>
+          </>
+        ),
+      },
+      { id: "my-agents", label: t("header.profile") },
+    ];
+    return (
+      <PageHeader>
+        <PageHeaderTabs
+          items={items}
+          active={pane}
+          label={t("header.tabsLabel")}
+          onSelect={(next) => (next === "browse" ? onBrowse() : onMyAgents())}
+        />
+      </PageHeader>
+    );
+  }
+
+  const handle = detailAgent
+    ? (detailAgent.creator.handle ?? creatorHandle)
+    : creatorHandle;
+  const owner = handle ? `@${handle}` : detailAgent?.creator.displayName;
+  const place = (
+    <>
+      {owner && <span className="min-w-0 truncate">{owner}</span>}
+      {detailAgent && (
+        <>
+          {owner && (
+            <ChevronRight
+              aria-hidden
+              className="size-3.5 shrink-0 opacity-60"
+            />
+          )}
+          <span className="min-w-0 truncate">{detailAgent.name}</span>
+        </>
+      )}
+    </>
+  );
+  const up = () => {
+    if (detailAgent && handle) onOpenCreator(handle);
+  };
+
+  return (
+    <PageHeader>
+      <div className="flex min-w-0 items-center gap-2">
+        <PageHeaderBackChip
+          label={t("title")}
+          icon={<Store aria-hidden className="size-4 shrink-0" />}
+          onClick={onBrowse}
+        />
+        <PageHeaderTabs
+          items={[{ id: "place", heading: true, label: place }]}
+          active="place"
+          label={t("header.tabsLabel")}
+          onSelect={up}
+        />
+      </div>
+    </PageHeader>
+  );
+}

--- a/app/src/components/store-view/store-header.tsx
+++ b/app/src/components/store-view/store-header.tsx
@@ -12,16 +12,18 @@ import {
 export type StorePane = "browse" | "my-agents";
 
 /**
- * Browse is the limiting case: its tools ride the strip. The left cluster is
- * ~210px (Agent Store 130 + Profile 75 + their 2px gap); the strip-variant
- * controls are ~556px (search 224 + category 150 + view 110 + sort 48 + three
- * 8px gaps); the frame's px-5 is 40px and the zone gap 12. `210 + 556 + 40 +
- * 12 = 818`, rounded UP to 840. No compact middle mode: the controls have no
- * shorter honest form, so below this they stack. The drilled panes render no
- * tools, so the threshold changes nothing for them — a chip plus one lozenge
- * simply truncates.
+ * Browse is the limiting case: its tools ride the strip. Budgeted in the
+ * WIDEST locale (Spanish), as the admin header does: the left cluster is
+ * ~250px (Tienda de agentes ~175 + Perfil ~72 + their 2px gap); the
+ * strip-variant controls are ~610px (search 224 + category pill capped at
+ * max-w-36 → ~192 + Creadores ~120 + sort 48 + three 8px gaps); the frame's
+ * px-5 is 40px and the zone gap 12. `250 + 610 + 40 + 12 = 912`, rounded UP
+ * to 920. No compact middle mode: the controls have no shorter honest form,
+ * so below this they stack. The drilled panes render no tools, so the
+ * threshold changes nothing for them — a chip plus one lozenge simply
+ * truncates.
  */
-export const STORE_HEADER_THRESHOLDS: HeaderThresholds = { oneRowMin: 840 };
+export const STORE_HEADER_THRESHOLDS: HeaderThresholds = { oneRowMin: 920 };
 
 /**
  * The store strip on both levels, one navigation grammar with the rest of the

--- a/app/src/components/store-view/store-shared-labels.ts
+++ b/app/src/components/store-view/store-shared-labels.ts
@@ -2,12 +2,9 @@ import type { TFunction } from "i18next";
 
 export function agentCardLabels(t: TFunction<"store">) {
   return {
-    skill: t("shared.skill"),
-    skills: t("shared.skills"),
     newAgent: t("shared.newAgent"),
     installs: t("shared.installs"),
     tryNow: t("shared.tryNow"),
-    verified: t("creator.verified"),
   };
 }
 

--- a/app/src/components/store-view/store-view.tsx
+++ b/app/src/components/store-view/store-view.tsx
@@ -2,25 +2,23 @@ import {
   fetchStoreAgent,
   type StoreCatalogAgent,
 } from "@houston-ai/engine-client";
-import { StoreNav } from "@houston-ai/store";
 import { useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
 import { useMyStoreProfile } from "../../hooks/use-my-store-profile";
-import { useSession } from "../../hooks/use-session";
 import { reportError } from "../../lib/error-report";
 import { useUIStore } from "../../stores/ui";
+import { PageHeaderToolsProvider } from "../shell/page-header/page-header-tools";
 import { CreatorProfilePane } from "./creator/creator-profile-pane";
 import { MyAgentsPanel } from "./my-agents-panel";
 import { CreatorProfileEditorDialog } from "./profile/creator-profile-editor";
 import { StoreBrowse } from "./store-browse";
 import { StoreDetailPane } from "./store-detail-pane";
-import { actionLink } from "./store-link";
-
-type StorePane = "browse" | "my-agents";
+import {
+  STORE_HEADER_THRESHOLDS,
+  StoreHeader,
+  type StorePane,
+} from "./store-header";
 
 export function StoreView() {
-  const { t } = useTranslation("store");
-  const { data: session } = useSession();
   const { profile: myProfile } = useMyStoreProfile();
   const [pane, setPane] = useState<StorePane>("browse");
   const [detailAgent, setDetailAgent] = useState<StoreCatalogAgent | null>(
@@ -78,67 +76,61 @@ export function StoreView() {
     setCreatorHandle(null);
     setPane("my-agents");
   };
-  const navLink = actionLink(showBrowse);
-  const navUser = session
-    ? {
-        avatarUrl: session.photoUrl ?? undefined,
-        initial: (session.displayName || session.email || "?")
-          .trim()
-          .charAt(0)
-          .toUpperCase(),
-      }
-    : null;
-
   return (
-    <div className="h-full overflow-auto">
-      <StoreNav
-        homeHref="store:browse"
-        brandLabel={t("title")}
-        account={{ user: navUser, onOpen: showMyAgents }}
-        labels={{
-          account: t("tabs.myAgents"),
-          signIn: t("nav.signIn"),
-        }}
-        LinkComponent={navLink}
-      />
-      {detailAgent || creatorHandle || pane === "my-agents" ? (
-        <main className="mx-auto w-full max-w-[1040px] px-6 pt-6 pb-16 md:px-8">
-          {detailAgent ? (
-            <StoreDetailPane
-              agent={detailAgent}
+    <PageHeaderToolsProvider thresholds={STORE_HEADER_THRESHOLDS}>
+      <div className="flex h-full flex-col">
+        <StoreHeader
+          pane={pane}
+          detailAgent={detailAgent}
+          creatorHandle={creatorHandle}
+          onBrowse={showBrowse}
+          onMyAgents={showMyAgents}
+          onOpenCreator={openCreator}
+        />
+        <div className="flex-1 overflow-auto">
+          {detailAgent || creatorHandle || pane === "my-agents" ? (
+            <main className="mx-auto w-full max-w-[1040px] px-6 pt-6 pb-16 md:px-8">
+              {detailAgent ? (
+                <StoreDetailPane
+                  agent={detailAgent}
+                  onOpenAgent={setDetailAgent}
+                  onOpenCreator={openCreator}
+                />
+              ) : creatorHandle ? (
+                // ONE profile page per creator: your own handle lands on the owner
+                // view (edit affordances), anyone else's on the public view.
+                creatorHandle === myProfile?.handle ? (
+                  <MyAgentsPanel
+                    onOpenAgentSlug={(slug) => {
+                      useUIStore.getState().setStoreFocusSlug(slug);
+                    }}
+                  />
+                ) : (
+                  <CreatorProfilePane
+                    handle={creatorHandle}
+                    onOpenAgent={setDetailAgent}
+                  />
+                )
+              ) : (
+                <MyAgentsPanel
+                  onOpenAgentSlug={(slug) => {
+                    useUIStore.getState().setStoreFocusSlug(slug);
+                  }}
+                />
+              )}
+            </main>
+          ) : (
+            <StoreBrowse
               onOpenAgent={setDetailAgent}
               onOpenCreator={openCreator}
             />
-          ) : creatorHandle ? (
-            // ONE profile page per creator: your own handle lands on the owner
-            // view (edit affordances), anyone else's on the public view.
-            creatorHandle === myProfile?.handle ? (
-              <MyAgentsPanel
-                onOpenAgentSlug={(slug) => {
-                  useUIStore.getState().setStoreFocusSlug(slug);
-                }}
-              />
-            ) : (
-              <CreatorProfilePane
-                handle={creatorHandle}
-                onOpenAgent={setDetailAgent}
-              />
-            )
-          ) : (
-            <MyAgentsPanel
-              onOpenAgentSlug={(slug) => {
-                useUIStore.getState().setStoreFocusSlug(slug);
-              }}
-            />
           )}
-        </main>
-      ) : (
-        <StoreBrowse onOpenAgent={setDetailAgent} onOpenCreator={openCreator} />
-      )}
-      <CreatorProfileEditorDialog
-        open={creatorEditorOpen}
-        onOpenChange={setCreatorEditorOpen}
-      />
-    </div>
+        </div>
+        <CreatorProfileEditorDialog
+          open={creatorEditorOpen}
+          onOpenChange={setCreatorEditorOpen}
+        />
+      </div>
+    </PageHeaderToolsProvider>
   );
 }

--- a/app/src/locales/en/store.json
+++ b/app/src/locales/en/store.json
@@ -1,5 +1,9 @@
 {
   "title": "Agent Store",
+  "header": {
+    "profile": "Profile",
+    "tabsLabel": "Agent Store pages"
+  },
   "subtitle": "Ready-made agents from the Houston community. Install one and make it yours.",
   "searchPlaceholder": "Search agents",
   "clearSearch": "Clear search",
@@ -30,7 +34,6 @@
     "learnings_other": "Comes with {{count}} learnings from real use"
   },
   "browse": {
-    "heroTitle": "Hire your next teammate",
     "searchPlaceholder": "Search agents and creators",
     "allCategories": "All categories",
     "agents": "Agents",
@@ -40,11 +43,11 @@
     "alphabetical": "Alphabetical",
     "publish": "Publish an agent",
     "sortRecent": "Recent",
-    "sortInstalls": "Most installed"
+    "sortInstalls": "Most installed",
+    "featuredAgents": "Featured agents",
+    "allAgents": "All agents"
   },
   "shared": {
-    "skill": "skill",
-    "skills": "skills",
     "newAgent": "New",
     "installs": "installs",
     "creatorFallbackBio": "Creator on the Agent Store",
@@ -53,10 +56,6 @@
     "tryNow": "Try it now"
   },
   "installFailed": "Houston could not fetch that agent from the store. Try again in a moment.",
-  "tabs": {
-    "browse": "Browse",
-    "myAgents": "My agents"
-  },
   "allIntegrations": "All integrations",
   "report": {
     "open": "Report",
@@ -183,11 +182,6 @@
     "empty": "No installs yet in this period.",
     "loadFailed": "Your analytics could not be loaded. Please try again.",
     "barLabel": "{{day}}: {{count}}"
-  },
-  "nav": {
-    "toLight": "Switch to light mode",
-    "toDark": "Switch to dark mode",
-    "signIn": "Sign in"
   },
   "me": {
     "signedOutTitle": "Your agents",

--- a/app/src/locales/es/store.json
+++ b/app/src/locales/es/store.json
@@ -1,5 +1,9 @@
 {
   "title": "Tienda de agentes",
+  "header": {
+    "profile": "Perfil",
+    "tabsLabel": "Páginas de la Tienda de agentes"
+  },
   "subtitle": "Agentes listos para usar, creados por la comunidad de Houston. Instala uno y hazlo tuyo.",
   "searchPlaceholder": "Buscar agentes",
   "clearSearch": "Borrar búsqueda",
@@ -30,7 +34,6 @@
     "learnings_other": "Incluye {{count}} aprendizajes de uso real"
   },
   "browse": {
-    "heroTitle": "Contrata a tu próximo compañero de equipo",
     "searchPlaceholder": "Buscar agentes y creadores",
     "allCategories": "Todas las categorías",
     "agents": "Agentes",
@@ -40,11 +43,11 @@
     "alphabetical": "Orden alfabético",
     "publish": "Publicar un agente",
     "sortRecent": "Recientes",
-    "sortInstalls": "Mas instalados"
+    "sortInstalls": "Mas instalados",
+    "featuredAgents": "Agentes destacados",
+    "allAgents": "Todos los agentes"
   },
   "shared": {
-    "skill": "habilidad",
-    "skills": "habilidades",
     "newAgent": "Nuevo",
     "installs": "instalaciones",
     "creatorFallbackBio": "Creador en la Tienda de agentes",
@@ -53,10 +56,6 @@
     "tryNow": "Pruebalo ahora"
   },
   "installFailed": "Houston no pudo traer ese agente de la tienda. Intenta de nuevo en un momento.",
-  "tabs": {
-    "browse": "Explorar",
-    "myAgents": "Mis agentes"
-  },
   "allIntegrations": "Todas las integraciones",
   "report": {
     "open": "Reportar",
@@ -183,11 +182,6 @@
     "empty": "Aún no hay instalaciones en este período.",
     "loadFailed": "No se pudieron cargar tus estadísticas. Inténtalo de nuevo.",
     "barLabel": "{{day}}: {{count}}"
-  },
-  "nav": {
-    "toLight": "Cambiar a modo claro",
-    "toDark": "Cambiar a modo oscuro",
-    "signIn": "Iniciar sesion"
   },
   "me": {
     "signedOutTitle": "Tus agentes",

--- a/app/src/locales/pt/store.json
+++ b/app/src/locales/pt/store.json
@@ -1,5 +1,9 @@
 {
   "title": "Loja de agentes",
+  "header": {
+    "profile": "Perfil",
+    "tabsLabel": "Páginas da Loja de agentes"
+  },
   "subtitle": "Agentes prontos para usar, criados pela comunidade Houston. Instale um e deixe do seu jeito.",
   "searchPlaceholder": "Buscar agentes",
   "clearSearch": "Limpar busca",
@@ -30,7 +34,6 @@
     "learnings_other": "Vem com {{count}} aprendizados de uso real"
   },
   "browse": {
-    "heroTitle": "Contrate seu próximo colega de equipe",
     "searchPlaceholder": "Buscar agentes e criadores",
     "allCategories": "Todas as categorias",
     "agents": "Agentes",
@@ -40,11 +43,11 @@
     "alphabetical": "Ordem alfabética",
     "publish": "Publicar um agente",
     "sortRecent": "Recentes",
-    "sortInstalls": "Mais instalados"
+    "sortInstalls": "Mais instalados",
+    "featuredAgents": "Agentes em destaque",
+    "allAgents": "Todos os agentes"
   },
   "shared": {
-    "skill": "habilidade",
-    "skills": "habilidades",
     "newAgent": "Novo",
     "installs": "instalações",
     "creatorFallbackBio": "Criador na Loja de agentes",
@@ -53,10 +56,6 @@
     "tryNow": "Experimente agora"
   },
   "installFailed": "O Houston não conseguiu buscar esse agente na loja. Tente de novo em instantes.",
-  "tabs": {
-    "browse": "Explorar",
-    "myAgents": "Meus agentes"
-  },
   "allIntegrations": "Todas as integrações",
   "report": {
     "open": "Denunciar",
@@ -183,11 +182,6 @@
     "empty": "Ainda não há instalações neste período.",
     "loadFailed": "Não foi possível carregar suas estatísticas. Tente de novo.",
     "barLabel": "{{day}}: {{count}}"
-  },
-  "nav": {
-    "toLight": "Mudar para modo claro",
-    "toDark": "Mudar para modo escuro",
-    "signIn": "Entrar"
   },
   "me": {
     "signedOutTitle": "Seus agentes",

--- a/ui/store/src/components/agent-card.tsx
+++ b/ui/store/src/components/agent-card.tsx
@@ -51,7 +51,7 @@ export function AgentCard({
 }) {
   const labels = { ...defaults, ...provided };
   return (
-    <div className="group relative flex flex-col rounded-[20px] bg-chip-subtle p-6 ring-1 ring-transparent transition-all duration-150 hover:bg-chip hover:ring-line">
+    <div className="group relative flex h-full flex-col rounded-[20px] bg-chip-subtle p-6 ring-1 ring-transparent transition-all duration-150 hover:bg-chip hover:ring-line">
       <LinkComponent
         href={href}
         aria-label={agent.name}

--- a/ui/store/src/components/agent-card.tsx
+++ b/ui/store/src/components/agent-card.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { cn } from "@houston-ai/core";
+import { Plus, Sparkle } from "lucide-react";
 import { integrationLogoUrl, resolveIntegrationLabels } from "../integrations";
 import type { StoreAgentRow, StoreLinkComponent } from "../types";
 import { AgentTile } from "./agent-tile";
@@ -8,16 +10,12 @@ const PlainLink: StoreLinkComponent = (props) => <a {...props} />;
 const compactNumber = new Intl.NumberFormat("en", { notation: "compact" });
 
 export interface AgentCardLabels {
-  skill: string;
-  skills: string;
   newAgent: string;
   installs: string;
   tryNow: string;
 }
 
 const defaults: AgentCardLabels = {
-  skill: "skill",
-  skills: "skills",
   newAgent: "New",
   installs: "installs",
   tryNow: "Try it now",
@@ -25,27 +23,33 @@ const defaults: AgentCardLabels = {
 
 /**
  * THE agent card. A div with a full-card link OVERLAY (never a button nested
- * in an anchor), so the visible Try button can sit above it validly. Hover
- * shifts colour and reveals the hairline — never position.
+ * in an anchor), so the visible corner affordance can sit above it validly.
+ * Hover shifts colour and reveals the hairline — never position.
+ *
+ * Deliberately quiet: the tile and ONE bordered corner affordance up top —
+ * the install `+`, or whatever the surface passes as `action` (the owner grid
+ * puts its pencil menu there; two circles in one corner is how the pencil
+ * ends up painted over the plus). Then air, name, two lines of description,
+ * the integrations it uses, and a creator-plus-installs baseline.
  */
 export function AgentCard({
   agent,
   href,
   LinkComponent = PlainLink,
   onTry,
+  action,
   labels: provided,
 }: {
   agent: StoreAgentRow;
   href: string;
   LinkComponent?: StoreLinkComponent;
-  /** The surface's install action for the visible Try button. */
+  /** The surface's install action for the visible `+` affordance. */
   onTry?: (agent: StoreAgentRow) => void;
+  /** Replaces the `+` in the corner — the card has ONE corner affordance. */
+  action?: React.ReactNode;
   labels?: Partial<AgentCardLabels>;
 }) {
   const labels = { ...defaults, ...provided };
-  const logos = resolveIntegrationLabels(agent.integrations.slice(0, 4));
-  const overflow = agent.integrations.length - logos.length;
-  const skillsCount = agent.skills?.length ?? 0;
   return (
     <div className="group relative flex flex-col rounded-[20px] bg-chip-subtle p-6 ring-1 ring-transparent transition-all duration-150 hover:bg-chip hover:ring-line">
       <LinkComponent
@@ -55,71 +59,113 @@ export function AgentCard({
       >
         {""}
       </LinkComponent>
-      <span className="pointer-events-none flex items-center gap-4">
-        <AgentTile agent={agent} />
-        <span className="flex min-w-0 flex-col">
-          <span className="truncate font-semibold text-[16px] text-ink tracking-tight">
-            {agent.name}
-          </span>
-          <span className="mt-1 flex items-center gap-2 text-[13px] text-ink-muted">
-            {skillsCount > 0 ? (
-              <>
-                {skillsCount} {skillsCount === 1 ? labels.skill : labels.skills}
-                {logos.length > 0 ? <span aria-hidden>·</span> : null}
-              </>
-            ) : null}
-            <span className="flex items-center gap-1.5">
-              {logos.map(({ slug, label }) => (
-                <img
-                  key={slug}
-                  src={integrationLogoUrl(slug)}
-                  alt={label}
-                  title={label}
-                  className="size-3.5"
-                />
-              ))}
-              {overflow > 0 ? <span>+{overflow}</span> : null}
-            </span>
-          </span>
-        </span>
+      <span className="pointer-events-none flex items-start justify-between gap-3">
+        <AgentTile agent={agent} size="sm" />
+        {action ??
+          (onTry ? (
+            <button
+              type="button"
+              onClick={() => onTry(agent)}
+              aria-label={labels.tryNow}
+              title={labels.tryNow}
+              className={cornerActionClasses}
+            >
+              <Plus aria-hidden className="size-4" />
+            </button>
+          ) : null)}
       </span>
-      <span className="pointer-events-none mt-4 line-clamp-3 text-[14px] text-ink/85 leading-[1.55]">
+      <span className="pointer-events-none mt-12 truncate font-semibold text-[16px] text-ink tracking-tight">
+        {agent.name}
+      </span>
+      <span className="pointer-events-none mt-1.5 line-clamp-2 text-[14px] text-ink-muted leading-[1.55]">
         {agent.tagline ?? agent.description}
       </span>
-      <span className="pointer-events-none mt-4 flex items-center justify-between gap-3 text-[12px] text-ink-muted">
-        <span className="flex min-w-0 items-center gap-1.5">
+      <IntegrationLogos slugs={agent.integrations} className="mt-4" />
+      <span className="pointer-events-none mt-auto flex items-center justify-between gap-3 pt-6 text-[13px] text-ink-muted">
+        <span className="flex min-w-0 items-center gap-2">
           <CreatorFaceSmall creator={agent.creator} />
           <span className="truncate">{agent.creator.displayName}</span>
-          <span aria-hidden>·</span>
-          <span className="shrink-0 tabular-nums">
-            {agent.installsCount === 0
-              ? labels.newAgent
-              : `${compactNumber.format(agent.installsCount)} ${labels.installs}`}
-          </span>
         </span>
-        {onTry ? (
-          <button
-            type="button"
-            onClick={() => onTry(agent)}
-            className="pointer-events-auto relative z-10 shrink-0 rounded-full bg-action px-3.5 py-1.5 font-medium text-[12px] text-action-text transition-opacity duration-150 hover:opacity-90"
-          >
-            {labels.tryNow}
-          </button>
-        ) : null}
+        <AgentInstalls
+          count={agent.installsCount}
+          newAgent={labels.newAgent}
+          installs={labels.installs}
+        />
       </span>
     </div>
   );
 }
 
-function CreatorFaceSmall({ creator }: Pick<StoreAgentRow, "creator">) {
+/** The one corner affordance's dress, shared so an owner pencil sits exactly
+ *  where the public `+` does. */
+export const cornerActionClasses =
+  "pointer-events-auto relative z-10 grid size-8 shrink-0 place-items-center rounded-full border border-line text-ink-muted transition-colors duration-150 hover:bg-hover hover:text-ink";
+
+/** The quiet install tally every card baseline shares: a sparkle and the
+ *  compact count, or the new-agent word while there is nothing to count. */
+export function AgentInstalls({
+  count,
+  newAgent,
+  installs,
+}: {
+  count: number;
+  newAgent: string;
+  installs: string;
+}) {
+  return count === 0 ? (
+    <span className="shrink-0">{newAgent}</span>
+  ) : (
+    <span className="flex shrink-0 items-center gap-1 tabular-nums">
+      <Sparkle aria-hidden className="size-3.5" />
+      {compactNumber.format(count)}
+      <span className="sr-only">{installs}</span>
+    </span>
+  );
+}
+
+/** Up to four integration marks and a truthful overflow count — what the
+ *  agent works WITH, said in logos, never in words. Renders nothing for an
+ *  agent that uses none. */
+export function IntegrationLogos({
+  slugs,
+  className,
+}: {
+  slugs: string[];
+  className?: string;
+}) {
+  const logos = resolveIntegrationLabels(slugs.slice(0, 4));
+  const overflow = slugs.length - logos.length;
+  if (logos.length === 0) return null;
+  return (
+    <span
+      className={cn(
+        "pointer-events-none flex items-center gap-1.5 text-[12px] text-ink-muted",
+        className,
+      )}
+    >
+      {logos.map(({ slug, label }) => (
+        <img
+          key={slug}
+          src={integrationLogoUrl(slug)}
+          alt={label}
+          title={label}
+          className="size-4"
+        />
+      ))}
+      {overflow > 0 ? <span>+{overflow}</span> : null}
+    </span>
+  );
+}
+
+export function CreatorFaceSmall({ creator }: Pick<StoreAgentRow, "creator">) {
   return creator.avatarUrl ? (
     <img
       src={creator.avatarUrl}
       alt=""
-      className="size-4 rounded-full object-cover"
+      className="size-5 rounded-full object-cover"
     />
   ) : (
-    <span className="grid size-4 place-items-center rounded-full bg-chip text-[9px] text-ink-muted">
+    <span className="grid size-5 place-items-center rounded-full bg-chip text-[10px] text-ink-muted">
       {creator.displayName.charAt(0).toUpperCase()}
     </span>
   );

--- a/ui/store/src/components/agent-tile.tsx
+++ b/ui/store/src/components/agent-tile.tsx
@@ -25,17 +25,16 @@ export function agentTone(
   return `var(--ht-agent-${TONES[Math.abs(hash) % TONES.length]})`;
 }
 
+const TILE_SIZE = { sm: "size-11", md: "size-14", lg: "size-24" } as const;
+
 export function AgentTile({
   agent,
   size = "md",
 }: {
   agent: StoreAgentRow;
-  size?: "md" | "lg";
+  size?: "sm" | "md" | "lg";
 }) {
-  const tileClass = cn(
-    "shrink-0 rounded-full object-cover",
-    size === "lg" ? "size-24" : "size-14",
-  );
+  const tileClass = cn("shrink-0 rounded-full object-cover", TILE_SIZE[size]);
   if (agent.icon?.kind === "url") {
     return <img src={agent.icon.value} alt="" className={tileClass} />;
   }
@@ -48,11 +47,18 @@ export function AgentTile({
       }}
     >
       {agent.icon?.kind === "emoji" ? (
-        <span className={size === "lg" ? "text-4xl" : "text-2xl"}>
+        <span
+          className={
+            size === "lg" ? "text-4xl" : size === "sm" ? "text-xl" : "text-2xl"
+          }
+        >
           {agent.icon.value}
         </span>
       ) : (
-        <HoustonHelmet color="currentColor" size={size === "lg" ? 38 : 28} />
+        <HoustonHelmet
+          color="currentColor"
+          size={size === "lg" ? 38 : size === "sm" ? 22 : 28}
+        />
       )}
     </span>
   );

--- a/ui/store/src/components/agent-tile.tsx
+++ b/ui/store/src/components/agent-tile.tsx
@@ -25,6 +25,12 @@ export function agentTone(
   return `var(--ht-agent-${TONES[Math.abs(hash) % TONES.length]})`;
 }
 
+/** The ONE tone field: every surface that paints an agent's colour (tile,
+ *  featured hero) uses this gradient, so the dress cannot drift. */
+export function agentToneBackground(tone: string) {
+  return `linear-gradient(145deg, color-mix(in oklab, ${tone} 88%, white 12%), ${tone} 55%, color-mix(in oklab, ${tone} 82%, black 18%))`;
+}
+
 const TILE_SIZE = { sm: "size-11", md: "size-14", lg: "size-24" } as const;
 
 export function AgentTile({
@@ -42,9 +48,7 @@ export function AgentTile({
   return (
     <span
       className={cn(tileClass, "grid place-items-center text-white/90")}
-      style={{
-        background: `linear-gradient(145deg, color-mix(in oklab, ${tone} 88%, white 12%), ${tone} 55%, color-mix(in oklab, ${tone} 82%, black 18%))`,
-      }}
+      style={{ background: agentToneBackground(tone) }}
     >
       {agent.icon?.kind === "emoji" ? (
         <span

--- a/ui/store/src/components/catalog-controls.tsx
+++ b/ui/store/src/components/catalog-controls.tsx
@@ -165,9 +165,15 @@ function Menu({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button type="button" aria-label={ariaLabel} className={pill}>
-          {trigger}
           {typeof trigger === "string" ? (
-            <ChevronDown className="size-4 text-ink-muted" />
+            // A category name is user/vocabulary text ("Atención al cliente");
+            // the pill caps and truncates it instead of pushing the strip wide.
+            <span className="max-w-36 truncate">{trigger}</span>
+          ) : (
+            trigger
+          )}
+          {typeof trigger === "string" ? (
+            <ChevronDown className="size-4 shrink-0 text-ink-muted" />
           ) : null}
         </button>
       </DropdownMenuTrigger>

--- a/ui/store/src/components/catalog-controls.tsx
+++ b/ui/store/src/components/catalog-controls.tsx
@@ -56,6 +56,7 @@ export function CatalogControls({
   onCategoryChange,
   onViewChange,
   onSortChange,
+  variant = "row",
   labels: provided,
 }: {
   categories: StoreCategoryRow[];
@@ -67,14 +68,26 @@ export function CatalogControls({
   onCategoryChange: (category?: string) => void;
   onViewChange: (view: CatalogView) => void;
   onSortChange: (sort: CatalogSort) => void;
+  /**
+   * `row` is the site's full-width toolbar: the search grows to fill the
+   * measure and the cluster wraps. `strip` rides inside a host's header row
+   * beside other chrome, so the search holds a fixed width and nothing wraps.
+   */
+  variant?: "row" | "strip";
   labels?: Partial<typeof defaults>;
 }) {
   const labels = { ...defaults, ...provided };
   const activeCategory = categories.find((item) => item.slug === category);
   return (
-    <div className="flex w-full min-w-0 flex-wrap items-center gap-3">
+    <div
+      className={
+        variant === "strip"
+          ? "flex min-w-0 items-center gap-2"
+          : "flex w-full min-w-0 flex-wrap items-center gap-3"
+      }
+    >
       <form
-        className="min-w-64 flex-1"
+        className={variant === "strip" ? "w-56 shrink-0" : "min-w-64 flex-1"}
         onSubmit={(event) => event.preventDefault()}
       >
         <CatalogSearchField

--- a/ui/store/src/components/featured-agent-card.tsx
+++ b/ui/store/src/components/featured-agent-card.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { HoustonHelmet } from "@houston-ai/core";
+import type { StoreAgentRow, StoreLinkComponent } from "../types";
+import {
+  type AgentCardLabels,
+  AgentInstalls,
+  IntegrationLogos,
+} from "./agent-card";
+import { agentTone } from "./agent-tile";
+
+const PlainLink: StoreLinkComponent = (props) => <a {...props} />;
+
+const defaults: Pick<AgentCardLabels, "newAgent" | "installs"> = {
+  newAgent: "New",
+  installs: "installs",
+};
+
+/**
+ * The wide card the featured row wears: the CREATOR is the hero — their
+ * photo fills the field, because a featured agent is an endorsement of the
+ * person behind it — and under it the agent's name, two lines of what it
+ * does, the integrations it uses, and the quiet baseline the regular card
+ * ends on. A creator without a photo hands the field to the agent's tone and
+ * mark. Same overlay-link grammar as the regular card: the whole card is the
+ * way in, nothing else competes.
+ */
+export function FeaturedAgentCard({
+  agent,
+  href,
+  LinkComponent = PlainLink,
+  labels: provided,
+}: {
+  agent: StoreAgentRow;
+  href: string;
+  LinkComponent?: StoreLinkComponent;
+  labels?: Partial<Pick<AgentCardLabels, "newAgent" | "installs">>;
+}) {
+  const labels = { ...defaults, ...provided };
+  const tone = agentTone(agent);
+  return (
+    <div className="group relative flex flex-col overflow-hidden rounded-[20px] bg-chip-subtle ring-1 ring-transparent transition-all duration-150 hover:bg-chip hover:ring-line">
+      <LinkComponent
+        href={href}
+        aria-label={agent.name}
+        className="absolute inset-0 z-10 rounded-[20px] focus-visible:ring-2 focus-visible:ring-focus/50 focus-visible:outline-none"
+      >
+        {""}
+      </LinkComponent>
+      <span className="pointer-events-none block aspect-[2/1] w-full">
+        {agent.creator.avatarUrl ? (
+          <img
+            src={agent.creator.avatarUrl}
+            alt=""
+            className="size-full object-cover"
+          />
+        ) : (
+          <span
+            className="grid size-full place-items-center text-white/90"
+            style={{
+              background: `linear-gradient(145deg, color-mix(in oklab, ${tone} 88%, white 12%), ${tone} 55%, color-mix(in oklab, ${tone} 82%, black 18%))`,
+            }}
+          >
+            {agent.icon?.kind === "emoji" ? (
+              <span className="text-6xl">{agent.icon.value}</span>
+            ) : (
+              <HoustonHelmet color="currentColor" size={56} />
+            )}
+          </span>
+        )}
+      </span>
+      <span className="pointer-events-none flex flex-col p-5">
+        <span className="truncate font-semibold text-[17px] text-ink tracking-tight">
+          {agent.name}
+        </span>
+        <span className="mt-1 line-clamp-2 text-[14px] text-ink-muted leading-[1.55]">
+          {agent.tagline ?? agent.description}
+        </span>
+        <IntegrationLogos slugs={agent.integrations} className="mt-3" />
+        <span className="mt-3 flex items-center justify-between gap-3 text-[13px] text-ink-muted">
+          <span className="min-w-0 truncate">{agent.creator.displayName}</span>
+          <AgentInstalls
+            count={agent.installsCount}
+            newAgent={labels.newAgent}
+            installs={labels.installs}
+          />
+        </span>
+      </span>
+    </div>
+  );
+}

--- a/ui/store/src/components/featured-agent-card.tsx
+++ b/ui/store/src/components/featured-agent-card.tsx
@@ -7,7 +7,7 @@ import {
   AgentInstalls,
   IntegrationLogos,
 } from "./agent-card";
-import { agentTone } from "./agent-tile";
+import { agentTone, agentToneBackground } from "./agent-tile";
 
 const PlainLink: StoreLinkComponent = (props) => <a {...props} />;
 
@@ -21,9 +21,9 @@ const defaults: Pick<AgentCardLabels, "newAgent" | "installs"> = {
  * photo fills the field, because a featured agent is an endorsement of the
  * person behind it — and under it the agent's name, two lines of what it
  * does, the integrations it uses, and the quiet baseline the regular card
- * ends on. A creator without a photo hands the field to the agent's tone and
- * mark. Same overlay-link grammar as the regular card: the whole card is the
- * way in, nothing else competes.
+ * ends on. A creator without a photo hands the field to the agent's own
+ * picture, or failing that its tone and mark. Same overlay-link grammar as
+ * the regular card: the whole card is the way in, nothing else competes.
  */
 export function FeaturedAgentCard({
   agent,
@@ -54,12 +54,16 @@ export function FeaturedAgentCard({
             alt=""
             className="size-full object-cover"
           />
+        ) : agent.icon?.kind === "url" ? (
+          <img
+            src={agent.icon.value}
+            alt=""
+            className="size-full object-cover"
+          />
         ) : (
           <span
             className="grid size-full place-items-center text-white/90"
-            style={{
-              background: `linear-gradient(145deg, color-mix(in oklab, ${tone} 88%, white 12%), ${tone} 55%, color-mix(in oklab, ${tone} 82%, black 18%))`,
-            }}
+            style={{ background: agentToneBackground(tone) }}
           >
             {agent.icon?.kind === "emoji" ? (
               <span className="text-6xl">{agent.icon.value}</span>

--- a/ui/store/src/components/owned-agent-card.tsx
+++ b/ui/store/src/components/owned-agent-card.tsx
@@ -113,7 +113,7 @@ export function OwnedAgentCard({
         ? labels.visibilityUnlisted
         : null;
   return (
-    <div className="relative">
+    <div className="h-full">
       <AgentCard
         agent={agent}
         href={href}

--- a/ui/store/src/components/owned-agent-card.tsx
+++ b/ui/store/src/components/owned-agent-card.tsx
@@ -19,7 +19,11 @@ import type {
   StoreCategoryRow,
   StoreLinkComponent,
 } from "../types";
-import { AgentCard, type AgentCardLabels } from "./agent-card";
+import {
+  AgentCard,
+  type AgentCardLabels,
+  cornerActionClasses,
+} from "./agent-card";
 import { EditListingDialog } from "./edit-listing-dialog";
 import type { EditListingDialogLabels } from "./edit-listing-model";
 import {
@@ -65,8 +69,6 @@ export interface OwnedAgentCardProps {
   onEditSave?: (identity: OwnedAgentIdentity) => Promise<void>;
   /** The store's category vocabulary for the Edit-listing dialog. */
   categories?: StoreCategoryRow[];
-  /** The surface's install action for the visible Try button. */
-  onTry?: (agent: OwnedAgentRow) => void;
   /** The agent's public link, for the Share dialog's copy affordance. */
   shareHref?: string | null;
   labels?: Partial<OwnedAgentCardLabels>;
@@ -77,9 +79,11 @@ export interface OwnedAgentCardProps {
 }
 
 /**
- * THE owner's agent card: the PUBLIC AgentCard verbatim, wearing a corner
- * state badge (only when not publicly listed) and a visible pencil menu —
- * Edit listing… · Share… · Delete. Visibility lives in the Share dialog.
+ * THE owner's agent card: the PUBLIC AgentCard verbatim, with the pencil
+ * menu — Edit listing… · Share… · Delete — as ITS corner affordance (the
+ * card's `action` slot, so it sits exactly where a visitor's `+` would, never
+ * stacked on top of one) and a state badge beside it while the listing is
+ * not publicly visible. Visibility lives in the Share dialog.
  */
 export function OwnedAgentCard({
   agent,
@@ -89,7 +93,6 @@ export function OwnedAgentCard({
   onDelete,
   onEditSave,
   categories,
-  onTry,
   shareHref,
   labels: overrides,
   shareLabels,
@@ -115,44 +118,45 @@ export function OwnedAgentCard({
         agent={agent}
         href={href}
         LinkComponent={LinkComponent}
-        onTry={onTry}
         labels={cardLabels}
+        action={
+          <span className="pointer-events-auto relative z-10 flex shrink-0 items-center gap-2">
+            {stateBadge && <Badge variant="secondary">{stateBadge}</Badge>}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  aria-label={labels.manage}
+                  disabled={busy}
+                  className={`${cornerActionClasses} p-0`}
+                >
+                  <Pencil className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                {onEditSave && (
+                  <DropdownMenuItem onSelect={() => setEditOpen(true)}>
+                    <SquarePen className="size-4" />
+                    {labels.edit}
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuItem onSelect={() => setShareOpen(true)}>
+                  <Share2 className="size-4" />
+                  {labels.share}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  variant="destructive"
+                  onSelect={() => setConfirmOpen(true)}
+                >
+                  {labels.delete}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </span>
+        }
       />
-      <div className="absolute top-4 right-4 flex items-center gap-2">
-        {stateBadge && <Badge variant="secondary">{stateBadge}</Badge>}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              aria-label={labels.manage}
-              disabled={busy}
-              className="size-8 rounded-full p-0 text-ink-muted hover:text-ink"
-            >
-              <Pencil className="size-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            {onEditSave && (
-              <DropdownMenuItem onSelect={() => setEditOpen(true)}>
-                <SquarePen className="size-4" />
-                {labels.edit}
-              </DropdownMenuItem>
-            )}
-            <DropdownMenuItem onSelect={() => setShareOpen(true)}>
-              <Share2 className="size-4" />
-              {labels.share}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              variant="destructive"
-              onSelect={() => setConfirmOpen(true)}
-            >
-              {labels.delete}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
       {onEditSave && (
         <EditListingDialog
           agent={agent}

--- a/ui/store/src/components/owned-agent-grid.tsx
+++ b/ui/store/src/components/owned-agent-grid.tsx
@@ -38,14 +38,12 @@ export function OwnedAgentGrid({
   agents,
   owner,
   agentHref,
-  onTryAgent,
   agentCardLabels,
   LinkComponent,
 }: {
   agents: OwnedAgentRow[];
   owner: CreatorProfileOwner;
   agentHref: (agent: OwnedAgentRow) => string;
-  onTryAgent?: (agent: OwnedAgentRow) => void;
   agentCardLabels?: Partial<AgentCardLabels>;
   LinkComponent?: StoreLinkComponent;
 }) {
@@ -58,7 +56,6 @@ export function OwnedAgentGrid({
           agent={agent}
           href={agentHref(agent)}
           busy={owner.busyId === agent.id}
-          onTry={onTryAgent}
           shareHref={owner.shareHrefFor?.(agent)}
           onShareSelect={(next) => owner.onShareSelect(agent.id, next)}
           onDelete={() => owner.onDelete(agent.id)}

--- a/ui/store/src/index.ts
+++ b/ui/store/src/index.ts
@@ -30,6 +30,7 @@ export {
   MAX_LISTING_TAGS,
   normalizeListingTags,
 } from "./components/edit-listing-model";
+export { FeaturedAgentCard } from "./components/featured-agent-card";
 export { AgentGrid, CreatorGrid } from "./components/grids";
 export type {
   InstallsPanelLabels,
@@ -111,6 +112,7 @@ export type {
 export {
   filterStoreAgents,
   filterStoreCreators,
+  splitFeaturedAgents,
 } from "./screens/store-home-model";
 export {
   STORE_HOME_HERO_CLASS,

--- a/ui/store/src/screens/creator-profile-screen.tsx
+++ b/ui/store/src/screens/creator-profile-screen.tsx
@@ -94,7 +94,6 @@ export function CreatorProfileScreen({
                 agents={agents}
                 owner={owner}
                 agentHref={agentHref}
-                onTryAgent={onTryAgent}
                 agentCardLabels={agentCardLabels}
                 LinkComponent={LinkComponent}
               />

--- a/ui/store/src/screens/creator-profile-screen.tsx
+++ b/ui/store/src/screens/creator-profile-screen.tsx
@@ -55,7 +55,7 @@ export function CreatorProfileScreen({
   loading?: boolean;
   failed?: boolean;
   onRetry?: () => void;
-  /** The surface's install action for the cards' visible Try button. */
+  /** The surface's install action for the cards' `+` install affordance. */
   onTryAgent?: (agent: OwnedAgentRow) => void;
   owner?: CreatorProfileOwner;
 }) {

--- a/ui/store/src/screens/store-home-model.ts
+++ b/ui/store/src/screens/store-home-model.ts
@@ -55,6 +55,32 @@ export function filterStoreAgents(
   );
 }
 
+/**
+ * The unfiltered agents view leads with a featured pair above the full grid.
+ * The catalog carries no curation flag, so "featured" is what the numbers
+ * already say: the two most-installed agents, and only when two have installs
+ * to show — one featured card in a two-wide row reads as a gap, not a
+ * feature. Any query, category, or the creators view collapses back to the
+ * plain grid, and the grid never repeats what the featured row already shows.
+ */
+export function splitFeaturedAgents(
+  agents: StoreAgentRow[],
+  state: StoreHomeState,
+): { featured: StoreAgentRow[]; rest: StoreAgentRow[] } {
+  const all = filterStoreAgents(agents, state);
+  if (state.query || state.category) return { featured: [], rest: all };
+  const featured = all
+    .toSorted((a, b) => b.installsCount - a.installsCount)
+    .slice(0, 2)
+    .filter((agent) => agent.installsCount > 0);
+  if (featured.length < 2) return { featured: [], rest: all };
+  const featuredIds = new Set(featured.map((agent) => agent.id));
+  return {
+    featured,
+    rest: all.filter((agent) => !featuredIds.has(agent.id)),
+  };
+}
+
 export function filterStoreCreators(
   creators: CreatorDirectoryRow[],
   query: string,

--- a/ui/store/src/screens/store-home-model.ts
+++ b/ui/store/src/screens/store-home-model.ts
@@ -62,13 +62,16 @@ export function filterStoreAgents(
  * to show — one featured card in a two-wide row reads as a gap, not a
  * feature. Any query, category, or the creators view collapses back to the
  * plain grid, and the grid never repeats what the featured row already shows.
+ * Hosts opt in via {@link StoreHomeScreenProps.featured}; this split is only
+ * honest over the full catalog, never over one server page of it.
  */
 export function splitFeaturedAgents(
   agents: StoreAgentRow[],
   state: StoreHomeState,
 ): { featured: StoreAgentRow[]; rest: StoreAgentRow[] } {
   const all = filterStoreAgents(agents, state);
-  if (state.query || state.category) return { featured: [], rest: all };
+  if (state.query || state.category || state.view !== "agents")
+    return { featured: [], rest: all };
   const featured = all
     .toSorted((a, b) => b.installsCount - a.installsCount)
     .slice(0, 2)

--- a/ui/store/src/screens/store-home-results.tsx
+++ b/ui/store/src/screens/store-home-results.tsx
@@ -1,6 +1,7 @@
 import type { AgentCardLabels } from "../components/agent-card";
 import { CatalogEmpty, FilteredEmpty } from "../components/catalog-empty";
 import type { CreatorCardLabels } from "../components/creator-card";
+import { FeaturedAgentCard } from "../components/featured-agent-card";
 import { AgentGrid, CreatorGrid } from "../components/grids";
 import type { StoreLinkComponent } from "../types";
 import type { StoreHomeRows, StoreHomeState } from "./store-home-model";
@@ -27,11 +28,14 @@ export function StoreHomeResults({
   labels: {
     creators: string;
     empty: string;
+    featuredAgents: string;
+    allAgents: string;
     agentCard?: Partial<AgentCardLabels>;
     creatorCard?: Partial<CreatorCardLabels>;
   };
 }) {
-  const agents = filterStoreAgents(rows.agents, state);
+  const { featured, rest } = splitFeaturedAgents(rows.agents, state);
+  const agents = featured.length ? [...featured, ...rest] : rest;
   const creators = filterStoreCreators(rows.creators, state.query);
   const filtered = Boolean(state.query || state.category);
   if (
@@ -59,10 +63,33 @@ export function StoreHomeResults({
   }
   return (
     <div className="flex w-full flex-col gap-14">
-      {agents.length ? (
-        <section className="flex flex-col gap-10">
+      {featured.length ? (
+        <section className="flex flex-col gap-5">
+          <h2 className="font-display text-xl font-semibold tracking-tight">
+            {labels.featuredAgents}
+          </h2>
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+            {featured.map((agent) => (
+              <FeaturedAgentCard
+                key={agent.id}
+                agent={agent}
+                href={agentHref(agent)}
+                LinkComponent={LinkComponent}
+                labels={labels.agentCard}
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+      {rest.length ? (
+        <section className="flex flex-col gap-5">
+          {featured.length ? (
+            <h2 className="font-display text-xl font-semibold tracking-tight">
+              {labels.allAgents}
+            </h2>
+          ) : null}
           <AgentGrid
-            agents={agents}
+            agents={rest}
             agentHref={agentHref}
             LinkComponent={LinkComponent}
             onTry={onTryAgent}
@@ -88,4 +115,4 @@ export function StoreHomeResults({
   );
 }
 
-import { filterStoreAgents, filterStoreCreators } from "./store-home-model";
+import { filterStoreCreators, splitFeaturedAgents } from "./store-home-model";

--- a/ui/store/src/screens/store-home-results.tsx
+++ b/ui/store/src/screens/store-home-results.tsx
@@ -9,6 +9,7 @@ import type { StoreHomeRows, StoreHomeState } from "./store-home-model";
 export function StoreHomeResults({
   rows,
   state,
+  featured: featuredEnabled,
   agentHref,
   creatorHref,
   LinkComponent,
@@ -19,6 +20,8 @@ export function StoreHomeResults({
 }: {
   rows: StoreHomeRows;
   state: StoreHomeState;
+  /** Host opt-in for the featured pair — see StoreHomeScreenProps.featured. */
+  featured?: boolean;
   agentHref: (agent: StoreHomeRows["agents"][number]) => string;
   creatorHref: (creator: StoreHomeRows["creators"][number]) => string;
   LinkComponent?: StoreLinkComponent;
@@ -34,7 +37,9 @@ export function StoreHomeResults({
     creatorCard?: Partial<CreatorCardLabels>;
   };
 }) {
-  const { featured, rest } = splitFeaturedAgents(rows.agents, state);
+  const { featured, rest } = featuredEnabled
+    ? splitFeaturedAgents(rows.agents, state)
+    : { featured: [], rest: filterStoreAgents(rows.agents, state) };
   const agents = featured.length ? [...featured, ...rest] : rest;
   const creators = filterStoreCreators(rows.creators, state.query);
   const filtered = Boolean(state.query || state.category);
@@ -95,9 +100,11 @@ export function StoreHomeResults({
             onTry={onTryAgent}
             labels={labels.agentCard}
           />
-          {!state.query ? pagination : null}
         </section>
       ) : null}
+      {/* Outside the grid section: a page whose every agent went featured
+          still has more catalog behind it. */}
+      {!state.query ? pagination : null}
       {state.query && creators.length ? (
         <section className="flex flex-col gap-5">
           <h2 className="font-display text-xl font-semibold tracking-tight">
@@ -115,4 +122,8 @@ export function StoreHomeResults({
   );
 }
 
-import { filterStoreCreators, splitFeaturedAgents } from "./store-home-model";
+import {
+  filterStoreAgents,
+  filterStoreCreators,
+  splitFeaturedAgents,
+} from "./store-home-model";

--- a/ui/store/src/screens/store-home-screen.tsx
+++ b/ui/store/src/screens/store-home-screen.tsx
@@ -37,6 +37,13 @@ export interface StoreHomeScreenProps {
    * `CatalogControls`. Absent, the screen is the site's self-contained page.
    */
   state?: StoreHomeState;
+  /**
+   * Lead the unfiltered agents view with the featured pair. An explicit
+   * host opt-in, NOT inferred: a server-paginated surface (the website) must
+   * not present page N's two biggest rows as curated picks, and only the
+   * surface knows whether it is on the one true first page.
+   */
+  featured?: boolean;
   initialState?: Partial<StoreHomeState>;
   onStateChange?: (state: StoreHomeState) => void;
   agentHref: (agent: StoreHomeRows["agents"][number]) => string;

--- a/ui/store/src/screens/store-home-screen.tsx
+++ b/ui/store/src/screens/store-home-screen.tsx
@@ -20,6 +20,8 @@ const defaults = {
   sortAgents: "Sort agents",
   mostInstalled: "Most installed",
   alphabetical: "Alphabetical",
+  featuredAgents: "Featured agents",
+  allAgents: "All agents",
   empty: "No agents here yet. Try another category or search.",
   loadFailed:
     "The store could not be reached. Check your connection and try again.",
@@ -28,6 +30,13 @@ const defaults = {
 
 export interface StoreHomeScreenProps {
   rows: StoreHomeRows;
+  /**
+   * Controlled mode: the host owns the browse state and renders the search
+   * and filter controls in its own chrome (Houston's app puts them in its
+   * page header), so the screen renders results only — no hero, no
+   * `CatalogControls`. Absent, the screen is the site's self-contained page.
+   */
+  state?: StoreHomeState;
   initialState?: Partial<StoreHomeState>;
   onStateChange?: (state: StoreHomeState) => void;
   agentHref: (agent: StoreHomeRows["agents"][number]) => string;
@@ -48,16 +57,18 @@ export interface StoreHomeScreenProps {
 
 export function StoreHomeScreen(props: StoreHomeScreenProps) {
   const labels = { ...defaults, ...props.labels };
+  const controlled = props.state !== undefined;
   const initialQuery = props.initialState?.query;
   const initialCategory = props.initialState?.category;
   const initialView = props.initialState?.view;
   const initialSort = props.initialState?.sort;
-  const [state, setState] = useState<StoreHomeState>({
+  const [ownState, setState] = useState<StoreHomeState>({
     query: "",
     view: "agents",
     sort: "installs",
     ...props.initialState,
   });
+  const state = props.state ?? ownState;
   useEffect(() => {
     setState((current) => {
       const next = {
@@ -82,18 +93,28 @@ export function StoreHomeScreen(props: StoreHomeScreenProps) {
   return (
     <main className="min-h-full w-full text-ink">
       {props.navigation}
-      <div className="mx-auto w-full max-w-[1040px] px-6 pt-12 pb-16 md:px-8">
+      <div
+        className={
+          controlled
+            ? "mx-auto w-full max-w-[1040px] px-6 pt-6 pb-16 md:px-8"
+            : "mx-auto w-full max-w-[1040px] px-6 pt-12 pb-16 md:px-8"
+        }
+      >
         <div className="flex flex-col items-center gap-16">
-          <h1 className={STORE_HOME_HERO_CLASS}>{labels.hero}</h1>
-          <CatalogControls
-            categories={props.rows.categories}
-            {...state}
-            onQueryChange={(query) => update({ query })}
-            onCategoryChange={(category) => update({ category })}
-            onViewChange={(view: CatalogView) => update({ view })}
-            onSortChange={(sort: CatalogSort) => update({ sort })}
-            labels={labels}
-          />
+          {!controlled && (
+            <>
+              <h1 className={STORE_HOME_HERO_CLASS}>{labels.hero}</h1>
+              <CatalogControls
+                categories={props.rows.categories}
+                {...state}
+                onQueryChange={(query) => update({ query })}
+                onCategoryChange={(category) => update({ category })}
+                onViewChange={(view: CatalogView) => update({ view })}
+                onSortChange={(sort: CatalogSort) => update({ sort })}
+                labels={labels}
+              />
+            </>
+          )}
           {props.loading ? (
             <StoreScreenLoading />
           ) : props.failed ? (

--- a/ui/store/tests/catalog-components.test.ts
+++ b/ui/store/tests/catalog-components.test.ts
@@ -3,7 +3,13 @@ import { describe, it } from "node:test";
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { AgentCard, agentTone, CreatorCard } from "../src/index.ts";
+import {
+  AgentCard,
+  agentTone,
+  CatalogControls,
+  CreatorCard,
+  FeaturedAgentCard,
+} from "../src/index.ts";
 import type { CreatorDirectoryRow, StoreAgentRow } from "../src/types.ts";
 
 Object.assign(globalThis, { React });
@@ -35,22 +41,41 @@ describe("AgentCard", () => {
     );
   });
 
-  it("shows skill and compact install metadata", () => {
-    const one = renderToStaticMarkup(
-      createElement(AgentCard, {
-        agent: { ...agent, skills: [{ slug: "one" }] },
-        href: "/a/inbox-zero",
-      }),
+  it("keeps the baseline quiet: New while uncounted, compact count after", () => {
+    const fresh = renderToStaticMarkup(
+      createElement(AgentCard, { agent, href: "/a/inbox-zero" }),
     );
-    assert.match(one, /1 skill/);
-    assert.match(one, /New/);
+    assert.match(fresh, />New</);
     const installed = renderToStaticMarkup(
       createElement(AgentCard, {
         agent: { ...agent, installsCount: 12500 },
         href: "/a/inbox-zero",
       }),
     );
-    assert.match(installed, /13K installs/);
+    assert.match(installed, /13K/);
+    assert.match(installed, /installs/);
+  });
+
+  it("says what the agent works with in logos", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentCard, { agent, href: "/a/inbox-zero" }),
+    );
+    assert.match(html, /alt="Google Calendar"/);
+  });
+
+  it("offers install as a labelled quiet affordance only when the surface can", () => {
+    const withTry = renderToStaticMarkup(
+      createElement(AgentCard, {
+        agent,
+        href: "/a/inbox-zero",
+        onTry: () => {},
+      }),
+    );
+    assert.match(withTry, /aria-label="Try it now"/);
+    const without = renderToStaticMarkup(
+      createElement(AgentCard, { agent, href: "/a/inbox-zero" }),
+    );
+    assert.doesNotMatch(without, /aria-label="Try it now"/);
   });
 });
 
@@ -74,5 +99,55 @@ describe("CreatorCard", () => {
     assert.match(html, /3 agents/);
     assert.match(html, /13K installs/);
     assert.match(html, /href="\/creators\/ana%2Fteam"/);
+  });
+});
+
+describe("CatalogControls", () => {
+  const props = {
+    categories: [],
+    view: "agents" as const,
+    sort: "installs" as const,
+    query: "",
+    onQueryChange: () => {},
+    onCategoryChange: () => {},
+    onViewChange: () => {},
+    onSortChange: () => {},
+  };
+  it("grows the search and wraps in the site's row form", () => {
+    const html = renderToStaticMarkup(createElement(CatalogControls, props));
+    assert.match(html, /flex-wrap/);
+    assert.match(html, /flex-1/);
+  });
+  it("holds a fixed search and never wraps in the strip form", () => {
+    const html = renderToStaticMarkup(
+      createElement(CatalogControls, { ...props, variant: "strip" as const }),
+    );
+    assert.doesNotMatch(html, /flex-wrap/);
+    assert.match(html, /w-56/);
+  });
+});
+
+describe("FeaturedAgentCard", () => {
+  it("hands the hero to the creator's photo when they have one", () => {
+    const html = renderToStaticMarkup(
+      createElement(FeaturedAgentCard, {
+        agent: {
+          ...agent,
+          creator: { displayName: "Felipe", avatarUrl: "https://x/y.png" },
+        },
+        href: "/a/inbox-zero",
+      }),
+    );
+    assert.match(html, /src="https:\/\/x\/y\.png"/);
+    assert.match(html, />Inbox Zero</);
+    assert.match(html, />Description</);
+  });
+
+  it("falls back to the agent's tone field without a photo", () => {
+    const html = renderToStaticMarkup(
+      createElement(FeaturedAgentCard, { agent, href: "/a/inbox-zero" }),
+    );
+    assert.match(html, /linear-gradient/);
+    assert.match(html, /alt="Google Calendar"/);
   });
 });

--- a/ui/store/tests/store-screens.test.ts
+++ b/ui/store/tests/store-screens.test.ts
@@ -88,12 +88,62 @@ describe("StoreHomeScreen", () => {
       splitFeaturedAgents(rows, { ...base, query: "writer" }).featured.length,
       0,
     );
-    // ...and one installed agent alone is not a featured row.
+    // ...and one installed agent alone is not a featured row...
     assert.equal(
       splitFeaturedAgents([{ ...agent, installsCount: 0 }, rows[1]], base)
         .featured.length,
       0,
     );
+    // ...and the creators view never features.
+    assert.equal(
+      splitFeaturedAgents(rows, { ...base, view: "creators" as const }).featured
+        .length,
+      0,
+    );
+  });
+
+  it("features only where the host opted in — never on a server page", () => {
+    const rows = {
+      agents: [
+        agent,
+        { ...agent, id: "two", name: "Writer", installsCount: 9 },
+      ],
+      creators: [],
+      categories: [],
+    };
+    const shared = {
+      rows,
+      agentHref: () => "/agent",
+      creatorHref: () => "/creator",
+    };
+    const site = renderToStaticMarkup(
+      React.createElement(StoreHomeScreen, shared),
+    );
+    assert.doesNotMatch(site, />Featured agents</);
+    const app = renderToStaticMarkup(
+      React.createElement(StoreHomeScreen, { ...shared, featured: true }),
+    );
+    assert.match(app, />Featured agents</);
+  });
+
+  it("keeps pagination reachable when the featured pair absorbs every result", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(StoreHomeScreen, {
+        rows: {
+          agents: [
+            agent,
+            { ...agent, id: "two", name: "Writer", installsCount: 9 },
+          ],
+          creators: [],
+          categories: [],
+        },
+        featured: true,
+        agentHref: () => "/agent",
+        creatorHref: () => "/creator",
+        pagination: React.createElement("nav", null, "NEXT-PAGE"),
+      }),
+    );
+    assert.match(html, />NEXT-PAGE</);
   });
 
   it("owns agent filtering and sorting", () => {

--- a/ui/store/tests/store-screens.test.ts
+++ b/ui/store/tests/store-screens.test.ts
@@ -8,6 +8,7 @@ import {
   filterStoreAgents,
   STORE_HOME_HERO_CLASS,
   StoreHomeScreen,
+  splitFeaturedAgents,
 } from "../src/index.ts";
 import type { StoreAgentRow } from "../src/types.ts";
 
@@ -42,6 +43,57 @@ describe("StoreHomeScreen", () => {
     ]) {
       assert.ok(STORE_HOME_HERO_CLASS.includes(token));
     }
+  });
+
+  it("renders results only in controlled mode — the host owns the chrome", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(StoreHomeScreen, {
+        rows: { agents: [agent], creators: [], categories: [] },
+        state: {
+          query: "",
+          view: "agents" as const,
+          sort: "installs" as const,
+        },
+        agentHref: () => "/agent",
+        creatorHref: () => "/creator",
+      }),
+    );
+    assert.doesNotMatch(html, />Hire your next teammate</);
+    assert.doesNotMatch(html, /Search agents and creators/);
+    assert.match(html, />Researcher</);
+  });
+
+  it("leads the unfiltered view with the two most-installed as featured", () => {
+    const base = {
+      query: "",
+      view: "agents" as const,
+      sort: "installs" as const,
+    };
+    const rows = [
+      agent,
+      { ...agent, id: "two", name: "Writer", installsCount: 9 },
+      { ...agent, id: "three", name: "Planner", installsCount: 4 },
+    ];
+    const split = splitFeaturedAgents(rows, base);
+    assert.deepEqual(
+      split.featured.map((item) => item.id),
+      ["two", "three"],
+    );
+    assert.deepEqual(
+      split.rest.map((item) => item.id),
+      ["one"],
+    );
+    // A search collapses back to the plain grid...
+    assert.equal(
+      splitFeaturedAgents(rows, { ...base, query: "writer" }).featured.length,
+      0,
+    );
+    // ...and one installed agent alone is not a featured row.
+    assert.equal(
+      splitFeaturedAgents([{ ...agent, installsCount: 0 }, rows[1]], base)
+        .featured.length,
+      0,
+    );
   });
 
   it("owns agent filtering and sorting", () => {


### PR DESCRIPTION
## What

The in-app Agent Store stops looking like a webpage and adopts the app's navigation grammar:

- **Header**: the standard PageHeader replaces the website's StoreNav. Top level is `(🏪 Agent Store)(Profile)`; drilling into a creator or agent shows a back chip plus ONE chevron-segmented place lozenge (`‹ Agent Store | @maria › Site Builder`), the same grammar as the team screen. The owner segment always names the creator; it links to their page when they have a claimed handle.
- **Search + filters in the header**: browse search, category, agents/creators toggle and sort ride the header strip (PageHeaderTools), stacking honestly below ~920px. `StoreHomeScreen` gained a controlled mode (host owns state → results only, no marketing hero); the website keeps its hero and inline toolbar.
- **Quiet cards**: tile + ONE bordered corner affordance (`+` install, or the owner pencil via the new `action` slot — previously the pencil painted over the `+`), name, two-line description, integration logos, creator + sparkle-count baseline.
- **Featured agents**: the unfiltered app browse leads with the two most-installed agents as wide cards (creator photo hero → agent icon image → tone field), above an "All agents" grid. Featuring is an explicit host opt-in, so the server-paginated website never presents page N's biggest rows as curated picks.

## Review

Two adversarial reviewers (Codex + Claude): 1 finding from Codex (pagination unreachable when the featured pair absorbs a page — fixed test-first), 7 from Claude (i18n heading regression, website featured-row leak, hero fallbacks, owner-grid alignment, threshold budgeted in Spanish, dead props, doc drift — all fixed). ui/store 41 tests, app 3,369 tests, all typechecks + Biome + check-locales green. Visual baselines 8/8 green, unchanged.

Local full-e2e runs are red on the dev machine for main too (module-serving stalls under parallel agent sessions; failures are all "stuck at Loading Houston…" with the vite HMR socket unserved) — CI is the arbiter for this PR.

No Linear issue — built to Julian's in-session spec. Possibly related: PRODUCT-1259 ("agentstore broken at some sizes") — not auto-closed, needs in-app verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
