### PR TITLE
feat: Notion-style markdown editing for every standing-context surface

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -34,6 +34,8 @@
     "@tanstack/query-async-storage-persister": "5.101.2",
     "@tanstack/react-query": "5.101.2",
     "@tanstack/react-query-persist-client": "5.101.2",
+    "@tiptap/react": "3.29.1",
+    "@tiptap/starter-kit": "3.29.1",
     "@tauri-apps/api": "2.11.1",
     "@tauri-apps/plugin-deep-link": "2.4.9",
     "@tauri-apps/plugin-notification": "2.3.3",
@@ -50,6 +52,7 @@
     "react-dom": "19.2.7",
     "react-i18next": "17.0.8",
     "tauri-plugin-sentry-api": "0.5.0",
+    "tiptap-markdown": "0.9.0",
     "zustand": "5.0.14"
   },
   "devDependencies": {

--- a/app/src/components/about-me/about-me-view.tsx
+++ b/app/src/components/about-me/about-me-view.tsx
@@ -30,8 +30,10 @@ export function AboutMeView() {
   const editor = useContextSlot("user");
 
   return (
-    <div className="flex-1 overflow-y-auto [scrollbar-gutter:stable]">
-      <PageContainer className="py-10">
+    // No page scroll: the editor page pins its document card to a fixed
+    // bottom gap, and a longer document scrolls inside the card.
+    <div className="min-h-0 flex-1">
+      <PageContainer className="flex h-full min-h-0 flex-col pt-10">
         <ContextEditorPage
           title={t("aboutMe.title")}
           subtitle={t("aboutMe.subtitle")}

--- a/app/src/components/about-me/about-me-view.tsx
+++ b/app/src/components/about-me/about-me-view.tsx
@@ -30,9 +30,11 @@ export function AboutMeView() {
   const editor = useContextSlot("user");
 
   return (
-    // No page scroll: the editor page pins its document card to a fixed
-    // bottom gap, and a longer document scrolls inside the card.
-    <div className="min-h-0 flex-1">
+    // The page column is exactly the viewport (h-full below), so the pinned
+    // document card ends at its fixed gap and its own text scrolls inside
+    // it; the outer scroller only engages as a fallback when a short window
+    // cannot hold even the card's minimum height.
+    <div className="min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable]">
       <PageContainer className="flex h-full min-h-0 flex-col pt-10">
         <ContextEditorPage
           title={t("aboutMe.title")}

--- a/app/src/components/agent/agent-admin/agent-admin-instructions.tsx
+++ b/app/src/components/agent/agent-admin/agent-admin-instructions.tsx
@@ -29,6 +29,9 @@ export function AgentAdminInstructions({
         </div>
       ) : (
         <ContextEditorBox
+          // Compact until this screen's own refactor: its column is page-
+          // scrolled with no bounded height, so fill mode has nothing to fill.
+          layout={{ rows: 12 }}
           content={instructions}
           readOnly={readOnly}
           onSave={(c) =>

--- a/app/src/components/context/context-editor-model.ts
+++ b/app/src/components/context/context-editor-model.ts
@@ -1,3 +1,12 @@
+/**
+ * How the document card holds the page. `"fill"` PINS it: the card takes the
+ * height its parents grant (a pinned page column ending at a fixed bottom
+ * gap) and longer documents scroll inside it. `{ rows }` is a compact card
+ * among other cards: a floor of that many text lines, growing with the text.
+ * A union, so no surface can fall into a mode it never chose.
+ */
+export type ContextEditorLayout = "fill" | { rows: number };
+
 export function isDirty(current: string, baseline: string): boolean {
   return current !== baseline;
 }
@@ -10,4 +19,39 @@ export function shouldReseed({
   dirty: boolean;
 }): boolean {
   return !focused && !dirty;
+}
+
+/**
+ * Markdown the WYSIWYG schema cannot represent. StarterKit carries no table,
+ * image, task-list, footnote or raw-HTML node, and tiptap-markdown DROPS what
+ * the schema can't hold — a table round-trips as its mashed cell text. These
+ * files are also written BY AGENTS, so such constructs are normal, and one
+ * keystroke in a rich editor would corrupt them on save. A document matching
+ * any of these opens in the plain-text fallback instead: no rendering, no
+ * loss. False positives (a stray `|` in prose) merely fall back to plain
+ * editing — the safe direction.
+ */
+const WYSIWYG_UNSAFE = [
+  /^\s{0,3}\|.*\|/m, // table row
+  /<[a-zA-Z][^>\n]*>/, // raw HTML tag
+  /^\s*[-*+]\s+\[[ xX]\]/m, // task list item
+  /!\[/, // image
+  /^\s{0,3}\[[^\]]+\]:\s/m, // reference-style link definition
+];
+
+/** Whether the document can round-trip through the rich editor losslessly. */
+export function isWysiwygSafe(markdown: string): boolean {
+  // A `---` fence at the very start is frontmatter (mid-document it is a
+  // horizontal rule, which the schema supports).
+  if (markdown.startsWith("---")) return false;
+  return !WYSIWYG_UNSAFE.some((pattern) => pattern.test(markdown));
+}
+
+/**
+ * The compact card's minimum height: `rows` real text lines (16px body at
+ * `leading-relaxed` = 1.625rem per line) plus the document's own `py-4`
+ * vertical padding, which `border-box` would otherwise eat out of the floor.
+ */
+export function compactMinHeight(rows: number): string {
+  return `calc(${rows * 1.625}rem + 2rem)`;
 }

--- a/app/src/components/context/context-editor-model.ts
+++ b/app/src/components/context/context-editor-model.ts
@@ -29,10 +29,14 @@ export function shouldReseed({
  * keystroke in a rich editor would corrupt them on save. A document matching
  * any of these opens in the plain-text fallback instead: no rendering, no
  * loss. False positives (a stray `|` in prose) merely fall back to plain
- * editing — the safe direction.
+ * editing — the safe direction. Known limit: the guard screens the SEED, not
+ * pastes — markdown pasted into an open rich doc lands as visible literal
+ * text (degraded, never invisibly lost).
  */
 const WYSIWYG_UNSAFE = [
-  /^\s{0,3}\|.*\|/m, // table row
+  /^\s{0,3}\|.*\|/m, // table row (piped)
+  /^\s{0,3}\|?[\s:]*-{3,}[\s:|-]*\|[\s:|-]*$/m, // table delimiter row
+  /^.*\|.*\n\s{0,3}\|?[\s:]*:?-{3,}/m, // headerless pipe table (Name | Value)
   /<[a-zA-Z][^>\n]*>/, // raw HTML tag
   /^\s*[-*+]\s+\[[ xX]\]/m, // task list item
   /!\[/, // image

--- a/app/src/components/context/context-editor-model.ts
+++ b/app/src/components/context/context-editor-model.ts
@@ -1,0 +1,13 @@
+export function isDirty(current: string, baseline: string): boolean {
+  return current !== baseline;
+}
+
+export function shouldReseed({
+  focused,
+  dirty,
+}: {
+  focused: boolean;
+  dirty: boolean;
+}): boolean {
+  return !focused && !dirty;
+}

--- a/app/src/components/context/context-editor.tsx
+++ b/app/src/components/context/context-editor.tsx
@@ -1,7 +1,15 @@
 import { cn, Spinner } from "@houston-ai/core";
-import { type ComponentProps, useEffect, useState } from "react";
+import {
+  type ComponentProps,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { PageHero } from "../shell/page-shell";
+import { isDirty, shouldReseed } from "./context-editor-model";
+import { MarkdownEditor } from "./markdown-editor";
 
 type SaveState = "idle" | "saving" | "saved";
 
@@ -16,8 +24,8 @@ type SaveState = "idle" | "saving" | "saved";
  * - **Saves on blur, says so quietly.** The slim right-aligned "Saving…/
  *   Saved" line above the box; a save fires only when the text actually
  *   changed, so tabbing through a page writes nothing.
- * - **Explains itself ONCE.** The title + one-line explanation live in the
- *   heading ({@link ContextEditorPage}'s hero, or a card's own header); the
+ * - **Explains itself ONCE.** The title + explanation live in the heading
+ *   ({@link ContextEditorPage}'s hero, or a card's own header); the
  *   box never carries a second description.
  * - **Read-only is the same face, locked.** Someone who may not edit still
  *   reads what the agents are told; the text stays legible, never hidden.
@@ -45,18 +53,62 @@ export function ContextEditorBox({
   const { t } = useTranslation("context");
   const [value, setValue] = useState(content);
   const [state, setState] = useState<SaveState>("idle");
+  const valueRef = useRef(content);
+  const baselineRef = useRef(content);
+  const focusedRef = useRef(false);
+  const awaitingSeedRef = useRef(true);
+  const contentPropRef = useRef(content);
+  const onSaveRef = useRef(onSave);
+  const readOnlyRef = useRef(readOnly);
 
-  // Re-seed from the store whenever it changes under us: another window's
-  // save, or our own landing back through the query cache.
+  onSaveRef.current = onSave;
+  readOnlyRef.current = readOnly;
   useEffect(() => {
+    if (contentPropRef.current === content) return;
+    contentPropRef.current = content;
+    if (
+      !shouldReseed({
+        focused: focusedRef.current,
+        dirty: isDirty(valueRef.current, baselineRef.current),
+      })
+    ) {
+      return;
+    }
+    awaitingSeedRef.current = true;
+    valueRef.current = content;
     setValue(content);
   }, [content]);
 
+  useEffect(
+    () => () => {
+      if (
+        readOnlyRef.current ||
+        !isDirty(valueRef.current, baselineRef.current)
+      ) {
+        return;
+      }
+      // The data layer surfaces failures; cleanup has no mounted UI to update.
+      onSaveRef.current(valueRef.current).catch(() => {});
+    },
+    [],
+  );
+
+  const handleChange = useCallback((markdown: string) => {
+    valueRef.current = markdown;
+    setValue(markdown);
+    if (awaitingSeedRef.current) {
+      baselineRef.current = markdown;
+      awaitingSeedRef.current = false;
+    }
+  }, []);
+
   const handleBlur = async () => {
-    if (readOnly || value === content) return;
+    const current = valueRef.current;
+    if (readOnly || !isDirty(current, baselineRef.current)) return;
     setState("saving");
     try {
-      await onSave(value);
+      await onSave(current);
+      baselineRef.current = current;
       setState("saved");
       window.setTimeout(() => setState("idle"), 2000);
     } catch {
@@ -88,25 +140,18 @@ export function ContextEditorBox({
         </span>
       </div>
       <section className="rounded-xl bg-chip p-3">
-        <textarea
-          aria-label={ariaLabel}
-          data-testid={dataTestId}
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
+        <MarkdownEditor
+          ariaLabel={ariaLabel}
+          dataTestId={dataTestId}
+          content={value}
+          onChange={handleChange}
           onBlur={handleBlur}
           readOnly={readOnly}
-          // A locked box must not invite writing: the greyed suggestion IS
-          // the write invitation, so the read-only face drops it.
-          placeholder={readOnly ? undefined : placeholder}
-          rows={Math.max(minRows, value.split("\n").length + 2)}
-          className={cn(
-            "w-full px-4 py-3 text-sm text-ink leading-relaxed",
-            "placeholder:text-ink-muted/60",
-            "bg-input border border-ink/[0.04] rounded-lg",
-            "outline-none resize-none",
-            "focus-visible:ring-2 focus-visible:ring-focus",
-            readOnly && "cursor-default text-ink-muted",
-          )}
+          placeholder={placeholder}
+          minRows={minRows}
+          onFocusChange={(focused) => {
+            focusedRef.current = focused;
+          }}
         />
       </section>
     </div>

--- a/app/src/components/context/context-editor.tsx
+++ b/app/src/components/context/context-editor.tsx
@@ -1,18 +1,13 @@
 import { cn, Spinner } from "@houston-ai/core";
 import { Check } from "lucide-react";
-import {
-  type ComponentProps,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import type { ComponentProps } from "react";
 import { useTranslation } from "react-i18next";
 import { PageHero } from "../shell/page-shell";
-import { isDirty, shouldReseed } from "./context-editor-model";
+import type { ContextEditorLayout } from "./context-editor-model";
 import { MarkdownEditor } from "./markdown-editor";
+import { useContextEditorSave } from "./use-context-editor-save";
 
-type SaveState = "idle" | "saving" | "saved";
+export type { ContextEditorLayout } from "./context-editor-model";
 
 /**
  * THE standing-prose editor, everywhere the product asks for one: About me,
@@ -20,23 +15,26 @@ type SaveState = "idle" | "saving" | "saved";
  * context — and whatever context surface appears next. One grammar, held by
  * this file so no surface can drift:
  *
- * - **Always open.** No invite empty state: the greyed suggestion inside the
- *   box is the invitation, and it disappears the moment the user types.
+ * - **Always open.** No invite empty state: the greyed rendered example in
+ *   the box is the invitation, gone the moment the user types.
  * - **Saves on blur, says so quietly.** The "Saving…/Saved" status sits in
  *   the toolbar's right seat; a save fires only when the text actually
- *   changed, so tabbing through a page writes nothing.
+ *   changed (`use-context-editor-save` owns the machine and its queue).
  * - **Explains itself ONCE.** The title + explanation live in the heading
- *   ({@link ContextEditorPage}'s hero, or a card's own header); the
- *   box never carries a second description.
+ *   ({@link ContextEditorPage}'s hero, or a card's own header); the box
+ *   never carries a second description.
  * - **Read-only is the same face, locked.** Someone who may not edit still
  *   reads what the agents are told; the text stays legible, never hidden.
+ * - **Never corrupts.** A document the rich schema can't represent (tables,
+ *   raw HTML — agents write these files too) opens in the plain-text
+ *   fallback instead of round-tripping lossily.
  */
 export function ContextEditorBox({
   content,
   onSave,
   placeholder,
+  layout,
   readOnly = false,
-  minRows,
   ariaLabel,
   dataTestId,
 }: {
@@ -44,82 +42,14 @@ export function ContextEditorBox({
   onSave: (content: string) => Promise<unknown>;
   /** The greyed suggestion text — a short example of what belongs here. */
   placeholder: string;
+  layout: ContextEditorLayout;
   readOnly?: boolean;
-  /** Rows floor for a compact card; omitted, the document fills the screen. */
-  minRows?: number;
   /** Accessible name when no visible heading labels the box directly. */
   ariaLabel?: string;
   dataTestId?: string;
 }) {
   const { t } = useTranslation("context");
-  const [value, setValue] = useState(content);
-  const [state, setState] = useState<SaveState>("idle");
-  const valueRef = useRef(content);
-  const baselineRef = useRef(content);
-  const focusedRef = useRef(false);
-  const awaitingSeedRef = useRef(true);
-  const contentPropRef = useRef(content);
-  const onSaveRef = useRef(onSave);
-  const readOnlyRef = useRef(readOnly);
-
-  onSaveRef.current = onSave;
-  readOnlyRef.current = readOnly;
-  useEffect(() => {
-    if (contentPropRef.current === content) return;
-    contentPropRef.current = content;
-    if (
-      !shouldReseed({
-        focused: focusedRef.current,
-        dirty: isDirty(valueRef.current, baselineRef.current),
-      })
-    ) {
-      return;
-    }
-    awaitingSeedRef.current = true;
-    valueRef.current = content;
-    setValue(content);
-  }, [content]);
-
-  useEffect(
-    () => () => {
-      if (
-        readOnlyRef.current ||
-        !isDirty(valueRef.current, baselineRef.current)
-      ) {
-        return;
-      }
-      // The data layer surfaces failures; cleanup has no mounted UI to update.
-      onSaveRef.current(valueRef.current).catch(() => {});
-    },
-    [],
-  );
-
-  const handleChange = useCallback((markdown: string) => {
-    valueRef.current = markdown;
-    setValue(markdown);
-    if (awaitingSeedRef.current) {
-      baselineRef.current = markdown;
-      awaitingSeedRef.current = false;
-    }
-  }, []);
-
-  const handleBlur = async () => {
-    const current = valueRef.current;
-    if (readOnly || !isDirty(current, baselineRef.current)) return;
-    setState("saving");
-    try {
-      await onSave(current);
-      baselineRef.current = current;
-      setState("saved");
-      window.setTimeout(() => setState("idle"), 2000);
-    } catch {
-      // The data layer owns the toast (`lib/tauri.ts` `call()` /
-      // `surfaceEngineError` on every save path) — the box only recovers so
-      // "Saving…" never sticks, and the unsaved text stays in the field for
-      // the user to retry.
-      setState("idle");
-    }
-  };
+  const save = useContextEditorSave({ content, onSave, readOnly });
 
   // Seated on the toolbar's right edge, clear of the text — a fixed seat, so
   // its appearing and fading never moves the document by a pixel.
@@ -127,14 +57,14 @@ export function ContextEditorBox({
     <span
       className={cn(
         "flex items-center gap-1 text-xs tabular-nums transition-opacity duration-200",
-        state === "idle" ? "opacity-0" : "opacity-100 text-ink-muted",
+        save.state === "idle" ? "opacity-0" : "opacity-100 text-ink-muted",
       )}
       aria-live="polite"
     >
-      {state === "saved" && <Check aria-hidden className="size-3.5" />}
-      {state === "saving"
+      {save.state === "saved" && <Check aria-hidden className="size-4" />}
+      {save.state === "saving"
         ? t("editor.saving")
-        : state === "saved"
+        : save.state === "saved"
           ? t("editor.saved")
           : ""}
     </span>
@@ -142,21 +72,20 @@ export function ContextEditorBox({
 
   return (
     // The editor is its own document card — no second frame around it. In
-    // full-page mode this box just hands its granted height down.
-    <div className={cn("w-full", minRows === undefined && "h-full min-h-0")}>
+    // fill mode this box just hands its granted height down.
+    <div className={cn("w-full", layout === "fill" && "h-full min-h-0")}>
       <MarkdownEditor
         ariaLabel={ariaLabel}
         dataTestId={dataTestId}
-        content={value}
-        onChange={handleChange}
-        onBlur={handleBlur}
+        content={save.value}
+        plain={save.plainDoc}
+        layout={layout}
+        onChange={save.handleChange}
+        onBlur={save.handleBlur}
+        onFocusChange={save.handleFocusChange}
         readOnly={readOnly}
         placeholder={placeholder}
-        minRows={minRows}
         statusSlot={status}
-        onFocusChange={(focused) => {
-          focusedRef.current = focused;
-        }}
       />
     </div>
   );
@@ -180,7 +109,7 @@ export function ContextEditorPage({
   subtitle: string;
   level?: 1 | 2;
   ready?: boolean;
-} & ComponentProps<typeof ContextEditorBox>) {
+} & Omit<ComponentProps<typeof ContextEditorBox>, "layout">) {
   return (
     // A pinned page: hero on top, the document card taking every remaining
     // pixel, and `pb-6` as THE fixed gap to the window's bottom edge — a
@@ -197,7 +126,7 @@ export function ContextEditorPage({
         // associated with it, so the title doubles as the accessible name
         // unless the caller passes a more specific one.
         <div className="min-h-0 flex-1">
-          <ContextEditorBox ariaLabel={title} {...box} />
+          <ContextEditorBox layout="fill" ariaLabel={title} {...box} />
         </div>
       ) : (
         <div className="flex items-center justify-center py-16">

--- a/app/src/components/context/context-editor.tsx
+++ b/app/src/components/context/context-editor.tsx
@@ -1,4 +1,5 @@
 import { cn, Spinner } from "@houston-ai/core";
+import { Check } from "lucide-react";
 import {
   type ComponentProps,
   useCallback,
@@ -21,8 +22,8 @@ type SaveState = "idle" | "saving" | "saved";
  *
  * - **Always open.** No invite empty state: the greyed suggestion inside the
  *   box is the invitation, and it disappears the moment the user types.
- * - **Saves on blur, says so quietly.** The slim right-aligned "Saving…/
- *   Saved" line above the box; a save fires only when the text actually
+ * - **Saves on blur, says so quietly.** The "Saving…/Saved" status sits in
+ *   the toolbar's right seat; a save fires only when the text actually
  *   changed, so tabbing through a page writes nothing.
  * - **Explains itself ONCE.** The title + explanation live in the heading
  *   ({@link ContextEditorPage}'s hero, or a card's own header); the
@@ -35,7 +36,7 @@ export function ContextEditorBox({
   onSave,
   placeholder,
   readOnly = false,
-  minRows = 12,
+  minRows,
   ariaLabel,
   dataTestId,
 }: {
@@ -44,7 +45,7 @@ export function ContextEditorBox({
   /** The greyed suggestion text — a short example of what belongs here. */
   placeholder: string;
   readOnly?: boolean;
-  /** Empty-box height; a card in a longer page wants fewer rows than a page. */
+  /** Rows floor for a compact card; omitted, the document fills the screen. */
   minRows?: number;
   /** Accessible name when no visible heading labels the box directly. */
   ariaLabel?: string;
@@ -120,40 +121,43 @@ export function ContextEditorBox({
     }
   };
 
+  // Seated on the toolbar's right edge, clear of the text — a fixed seat, so
+  // its appearing and fading never moves the document by a pixel.
+  const status = (
+    <span
+      className={cn(
+        "flex items-center gap-1 text-xs tabular-nums transition-opacity duration-200",
+        state === "idle" ? "opacity-0" : "opacity-100 text-ink-muted",
+      )}
+      aria-live="polite"
+    >
+      {state === "saved" && <Check aria-hidden className="size-3.5" />}
+      {state === "saving"
+        ? t("editor.saving")
+        : state === "saved"
+          ? t("editor.saved")
+          : ""}
+    </span>
+  );
+
   return (
-    <div className="w-full">
-      {/* The save state keeps a reserved right-edge seat, so the box never
-          shifts when it appears. */}
-      <div className="mb-1 flex items-baseline justify-end">
-        <span
-          className={cn(
-            "text-xs tabular-nums transition-opacity duration-200",
-            state === "idle" ? "opacity-0" : "opacity-100 text-ink-muted",
-          )}
-          aria-live="polite"
-        >
-          {state === "saving"
-            ? t("editor.saving")
-            : state === "saved"
-              ? t("editor.saved")
-              : ""}
-        </span>
-      </div>
-      <section className="rounded-xl bg-chip p-3">
-        <MarkdownEditor
-          ariaLabel={ariaLabel}
-          dataTestId={dataTestId}
-          content={value}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          readOnly={readOnly}
-          placeholder={placeholder}
-          minRows={minRows}
-          onFocusChange={(focused) => {
-            focusedRef.current = focused;
-          }}
-        />
-      </section>
+    // The editor is its own document card — no second frame around it. In
+    // full-page mode this box just hands its granted height down.
+    <div className={cn("w-full", minRows === undefined && "h-full min-h-0")}>
+      <MarkdownEditor
+        ariaLabel={ariaLabel}
+        dataTestId={dataTestId}
+        content={value}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        readOnly={readOnly}
+        placeholder={placeholder}
+        minRows={minRows}
+        statusSlot={status}
+        onFocusChange={(focused) => {
+          focusedRef.current = focused;
+        }}
+      />
     </div>
   );
 }
@@ -178,18 +182,23 @@ export function ContextEditorPage({
   ready?: boolean;
 } & ComponentProps<typeof ContextEditorBox>) {
   return (
-    <div className="w-full pb-12">
+    // A pinned page: hero on top, the document card taking every remaining
+    // pixel, and `pb-6` as THE fixed gap to the window's bottom edge — a
+    // longer document scrolls inside the card instead of growing the page.
+    <div className="flex h-full min-h-0 w-full flex-col pb-6">
       <PageHero
         level={level}
         title={title}
         subtitle={subtitle}
-        className="mb-3"
+        className="mb-3 shrink-0"
       />
       {ready ? (
         // The hero visually titles the box but is not programmatically
         // associated with it, so the title doubles as the accessible name
         // unless the caller passes a more specific one.
-        <ContextEditorBox ariaLabel={title} {...box} />
+        <div className="min-h-0 flex-1">
+          <ContextEditorBox ariaLabel={title} {...box} />
+        </div>
       ) : (
         <div className="flex items-center justify-center py-16">
           <Spinner className="h-5 w-5" />

--- a/app/src/components/context/markdown-editor.tsx
+++ b/app/src/components/context/markdown-editor.tsx
@@ -1,0 +1,132 @@
+import { type Editor, EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { useEffect } from "react";
+import { Markdown, type MarkdownStorage } from "tiptap-markdown";
+
+const extensions = [StarterKit, Markdown];
+
+/**
+ * The markdown the doc currently serializes to. `tiptap-markdown` registers
+ * its storage under `markdown` but does not augment @tiptap/core's `Storage`
+ * type, so the one cast lives here instead of at every call site.
+ */
+function serialized(editor: Editor): string {
+  return (
+    editor.storage as unknown as { markdown: MarkdownStorage }
+  ).markdown.getMarkdown();
+}
+
+const proseClass = [
+  "text-sm text-ink leading-relaxed",
+  "[&_h1]:text-lg [&_h1]:font-semibold [&_h2]:text-base [&_h2]:font-semibold",
+  "[&_h3]:text-base [&_h3]:font-medium [&_p]:my-1.5",
+  "[&_ul]:my-1.5 [&_ul]:list-disc [&_ul]:pl-5",
+  "[&_ol]:my-1.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-0.5",
+  "[&_blockquote]:my-2 [&_blockquote]:border-l-2 [&_blockquote]:border-line-input",
+  "[&_blockquote]:pl-3 [&_blockquote]:text-ink-muted",
+  "[&_code]:rounded-sm [&_code]:bg-chip [&_code]:px-1",
+  "[&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-chip [&_pre]:p-3",
+].join(" ");
+
+export interface MarkdownEditorProps {
+  content: string;
+  onChange: (markdown: string) => void;
+  onBlur: () => void;
+  onFocusChange?: (focused: boolean) => void;
+  readOnly?: boolean;
+  placeholder: string;
+  ariaLabel?: string;
+  dataTestId?: string;
+  minRows?: number;
+}
+
+export function MarkdownEditor({
+  content,
+  onChange,
+  onBlur,
+  onFocusChange,
+  readOnly = false,
+  placeholder,
+  ariaLabel,
+  dataTestId,
+  minRows = 12,
+}: MarkdownEditorProps) {
+  const editor = useEditor({
+    extensions,
+    content,
+    editable: !readOnly,
+    immediatelyRender: false,
+    editorProps: {
+      attributes: {
+        role: "textbox",
+        "aria-multiline": "true",
+        "aria-readonly": String(readOnly),
+        ...(ariaLabel !== undefined && { "aria-label": ariaLabel }),
+        ...(dataTestId !== undefined && { "data-testid": dataTestId }),
+        class: `min-h-full outline-none ${proseClass}`,
+      },
+    },
+    // The parent's dirty baseline is the SEEDED DOC'S OWN serialization
+    // (markdown → doc → markdown may normalize bullets/whitespace), so the
+    // baseline is announced the moment the doc exists — unconditionally,
+    // or a prop that round-trips unchanged would leave the baseline unseeded
+    // and the user's FIRST edit would read as clean.
+    onCreate: ({ editor: created }) => onChange(serialized(created)),
+    onUpdate: ({ editor: activeEditor }) => {
+      onChange(serialized(activeEditor));
+    },
+    onFocus: () => onFocusChange?.(true),
+    onBlur: () => {
+      onFocusChange?.(false);
+      onBlur();
+    },
+  });
+  const preview = useEditor({
+    extensions,
+    content: placeholder,
+    editable: false,
+    immediatelyRender: false,
+    editorProps: {
+      // Purely decorative: without this the overlay would announce as a
+      // SECOND textbox (TipTap's default role), a phantom editor to
+      // assistive tech.
+      attributes: { "aria-hidden": "true", role: "presentation" },
+    },
+  });
+
+  useEffect(() => {
+    if (!editor) return;
+    editor.setEditable(!readOnly);
+  }, [editor, readOnly]);
+
+  useEffect(() => {
+    if (!editor) return;
+    // Every keystroke echoes back as a `content` prop change (the parent is
+    // controlled on the serialized markdown). Replacing the doc on that echo
+    // would throw the cursor away mid-word, so only a GENUINELY different
+    // markdown — an external reseed — rebuilds the doc.
+    if (serialized(editor) === content) return;
+    editor.commands.setContent(content, { emitUpdate: false });
+    onChange(serialized(editor));
+  }, [content, editor, onChange]);
+
+  const empty = editor?.isEmpty ?? content.length === 0;
+
+  return (
+    <div
+      className="relative w-full rounded-lg border border-line-input bg-input px-4 py-3 text-ink has-[.ProseMirror:focus-visible]:ring-2 has-[.ProseMirror:focus-visible]:ring-focus"
+      style={{ minHeight: `${minRows * 1.5}rem` }}
+    >
+      {!readOnly && empty ? (
+        <EditorContent
+          editor={preview}
+          className={`pointer-events-none absolute inset-x-4 top-3 text-ink-muted/60 ${proseClass}`}
+        />
+      ) : null}
+      <EditorContent
+        editor={editor}
+        className={readOnly ? "cursor-default text-ink-muted" : undefined}
+      />
+    </div>
+  );
+}

--- a/app/src/components/context/markdown-editor.tsx
+++ b/app/src/components/context/markdown-editor.tsx
@@ -1,7 +1,9 @@
+import { cn } from "@houston-ai/core";
 import { type Editor, EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import { useEffect } from "react";
+import { type ReactNode, useEffect } from "react";
 import { Markdown, type MarkdownStorage } from "tiptap-markdown";
+import { MarkdownToolbar } from "./markdown-toolbar";
 
 const extensions = [StarterKit, Markdown];
 
@@ -16,15 +18,23 @@ function serialized(editor: Editor): string {
   ).markdown.getMarkdown();
 }
 
+/**
+ * The document's type: 16px body (the input floor from the polish checklist)
+ * under a modest heading ladder — a document field, not a marketing page.
+ * Headings open their block (`mt` collapses on the first child) so a doc
+ * that starts with a title sits flush with the card's padding.
+ */
 const proseClass = [
-  "text-sm text-ink leading-relaxed",
-  "[&_h1]:text-lg [&_h1]:font-semibold [&_h2]:text-base [&_h2]:font-semibold",
-  "[&_h3]:text-base [&_h3]:font-medium [&_p]:my-1.5",
-  "[&_ul]:my-1.5 [&_ul]:list-disc [&_ul]:pl-5",
-  "[&_ol]:my-1.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-0.5",
-  "[&_blockquote]:my-2 [&_blockquote]:border-l-2 [&_blockquote]:border-line-input",
+  "text-base text-ink leading-relaxed",
+  "[&_h1]:text-xl [&_h1]:font-semibold [&_h1]:mt-5 [&_h1]:mb-2 [&_h1:first-child]:mt-0",
+  "[&_h2]:text-lg [&_h2]:font-semibold [&_h2]:mt-4 [&_h2]:mb-1.5 [&_h2:first-child]:mt-0",
+  "[&_h3]:text-base [&_h3]:font-medium [&_h3]:mt-3 [&_h3]:mb-1 [&_h3:first-child]:mt-0",
+  "[&_p]:my-2 [&_p:first-child]:mt-0",
+  "[&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-5",
+  "[&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-1",
+  "[&_blockquote]:my-2 [&_blockquote]:border-l-2 [&_blockquote]:border-line",
   "[&_blockquote]:pl-3 [&_blockquote]:text-ink-muted",
-  "[&_code]:rounded-sm [&_code]:bg-chip [&_code]:px-1",
+  "[&_code]:rounded-sm [&_code]:bg-chip [&_code]:px-1 [&_code]:text-sm",
   "[&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-chip [&_pre]:p-3",
 ].join(" ");
 
@@ -37,7 +47,14 @@ export interface MarkdownEditorProps {
   placeholder: string;
   ariaLabel?: string;
   dataTestId?: string;
+  /**
+   * Rows floor for a COMPACT box (a card among other cards, like the team
+   * context). Omitted, the document fills the screen's remaining height —
+   * the default for full-page context surfaces.
+   */
   minRows?: number;
+  /** The save status node, seated on the toolbar's right edge. */
+  statusSlot?: ReactNode;
 }
 
 export function MarkdownEditor({
@@ -49,8 +66,16 @@ export function MarkdownEditor({
   placeholder,
   ariaLabel,
   dataTestId,
-  minRows = 12,
+  minRows,
+  statusSlot,
 }: MarkdownEditorProps) {
+  // Two layouts. FILL (no minRows): the card is PINNED — it takes the height
+  // its parents grant (the page column ends at a fixed bottom gap), and a
+  // longer document scrolls INSIDE it, so the card never grows and a window
+  // resize only moves its bottom edge. COMPACT (minRows): a rows floor that
+  // grows with the text, for a card among other cards.
+  const fill = minRows === undefined;
+  const minHeight = fill ? "100%" : `${minRows * 1.5}rem`;
   const editor = useEditor({
     extensions,
     content,
@@ -63,7 +88,12 @@ export function MarkdownEditor({
         "aria-readonly": String(readOnly),
         ...(ariaLabel !== undefined && { "aria-label": ariaLabel }),
         ...(dataTestId !== undefined && { "data-testid": dataTestId }),
-        class: `min-h-full outline-none ${proseClass}`,
+        // The editable node IS the whole visible page: it carries the card's
+        // content padding and min-height itself, so a click anywhere in the
+        // frame lands in the document and places the caret — a wrapper that
+        // only LOOKS like the field would be dead below the first line.
+        class: `outline-none px-5 py-4 ${proseClass}`,
+        style: `min-height: ${minHeight}`,
       },
     },
     // The parent's dirty baseline is the SEEDED DOC'S OWN serialization
@@ -113,20 +143,36 @@ export function MarkdownEditor({
   const empty = editor?.isEmpty ?? content.length === 0;
 
   return (
+    // The document CARD: the canonical floating surface on bg-card, framed
+    // with the field border (line-input, a step darker than the hairline) —
+    // this is a page you write, not a recessed gray form input.
     <div
-      className="relative w-full rounded-lg border border-line-input bg-input px-4 py-3 text-ink has-[.ProseMirror:focus-visible]:ring-2 has-[.ProseMirror:focus-visible]:ring-focus"
-      style={{ minHeight: `${minRows * 1.5}rem` }}
+      className={cn(
+        "w-full overflow-hidden rounded-xl border border-line-input bg-card text-ink has-[.ProseMirror:focus-visible]:ring-2 has-[.ProseMirror:focus-visible]:ring-focus",
+        fill && "flex h-full min-h-64 flex-col",
+      )}
     >
-      {!readOnly && empty ? (
-        <EditorContent
-          editor={preview}
-          className={`pointer-events-none absolute inset-x-4 top-3 text-ink-muted/60 ${proseClass}`}
-        />
+      {!readOnly && editor ? (
+        <MarkdownToolbar editor={editor} trailing={statusSlot} />
       ) : null}
-      <EditorContent
-        editor={editor}
-        className={readOnly ? "cursor-default text-ink-muted" : undefined}
-      />
+      <div className={cn("relative", fill && "min-h-0 flex-1 overflow-y-auto")}>
+        {!readOnly && empty ? (
+          <EditorContent
+            editor={preview}
+            className={`pointer-events-none absolute inset-0 px-5 py-4 text-ink-muted/60 ${proseClass}`}
+          />
+        ) : null}
+        {/* In fill mode the wrapper's definite height flows down (h-full) so
+            the ProseMirror node's min-height:100% resolves; a longer doc
+            simply overflows into the wrapper's own scroll. */}
+        <EditorContent
+          editor={editor}
+          className={cn(
+            fill && "h-full",
+            readOnly && "cursor-default text-ink-muted",
+          )}
+        />
+      </div>
     </div>
   );
 }

--- a/app/src/components/context/markdown-editor.tsx
+++ b/app/src/components/context/markdown-editor.tsx
@@ -1,8 +1,12 @@
 import { cn } from "@houston-ai/core";
 import { type Editor, EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import { type ReactNode, useEffect } from "react";
+import { type ReactNode, useEffect, useRef } from "react";
 import { Markdown, type MarkdownStorage } from "tiptap-markdown";
+import {
+  type ContextEditorLayout,
+  compactMinHeight,
+} from "./context-editor-model";
 import { MarkdownToolbar } from "./markdown-toolbar";
 
 const extensions = [StarterKit, Markdown];
@@ -20,15 +24,16 @@ function serialized(editor: Editor): string {
 
 /**
  * The document's type: 16px body (the input floor from the polish checklist)
- * under a modest heading ladder — a document field, not a marketing page.
- * Headings open their block (`mt` collapses on the first child) so a doc
- * that starts with a title sits flush with the card's padding.
+ * under a modest heading ladder matching the chat's markdown scale — a
+ * document field, not a marketing page. Headings open their block (`mt`
+ * collapses on the first child) so a doc that starts with a title sits flush
+ * with the card's padding.
  */
 const proseClass = [
   "text-base text-ink leading-relaxed",
   "[&_h1]:text-xl [&_h1]:font-semibold [&_h1]:mt-5 [&_h1]:mb-2 [&_h1:first-child]:mt-0",
   "[&_h2]:text-lg [&_h2]:font-semibold [&_h2]:mt-4 [&_h2]:mb-1.5 [&_h2:first-child]:mt-0",
-  "[&_h3]:text-base [&_h3]:font-medium [&_h3]:mt-3 [&_h3]:mb-1 [&_h3:first-child]:mt-0",
+  "[&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h3:first-child]:mt-0",
   "[&_p]:my-2 [&_p:first-child]:mt-0",
   "[&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-5",
   "[&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-1",
@@ -44,43 +49,120 @@ export interface MarkdownEditorProps {
   onBlur: () => void;
   onFocusChange?: (focused: boolean) => void;
   readOnly?: boolean;
+  /**
+   * Plain-text fallback: the document contains markdown the rich schema
+   * would corrupt (`isWysiwygSafe` said no), so it is edited raw —
+   * byte-preserving, no toolbar, no rendering.
+   */
+  plain?: boolean;
   placeholder: string;
   ariaLabel?: string;
   dataTestId?: string;
-  /**
-   * Rows floor for a COMPACT box (a card among other cards, like the team
-   * context). Omitted, the document fills the screen's remaining height —
-   * the default for full-page context surfaces.
-   */
-  minRows?: number;
-  /** The save status node, seated on the toolbar's right edge. */
+  layout: ContextEditorLayout;
+  /** The save status node, seated on the top bar's right edge. */
   statusSlot?: ReactNode;
 }
 
-export function MarkdownEditor({
-  content,
-  onChange,
-  onBlur,
-  onFocusChange,
-  readOnly = false,
-  placeholder,
-  ariaLabel,
-  dataTestId,
-  minRows,
-  statusSlot,
-}: MarkdownEditorProps) {
-  // Two layouts. FILL (no minRows): the card is PINNED — it takes the height
-  // its parents grant (the page column ends at a fixed bottom gap), and a
-  // longer document scrolls INSIDE it, so the card never grows and a window
-  // resize only moves its bottom edge. COMPACT (minRows): a rows floor that
-  // grows with the text, for a card among other cards.
-  const fill = minRows === undefined;
-  const minHeight = fill ? "100%" : `${minRows * 1.5}rem`;
+/** Latest-ref for the parent callbacks: TipTap binds its event handlers ONCE
+ *  at construction (and @tiptap/react never re-registers them), so handlers
+ *  must read through a ref or they hold the first render's props forever. */
+function useCallbacksRef(props: MarkdownEditorProps) {
+  const ref = useRef(props);
+  ref.current = props;
+  return ref;
+}
+
+const cardClass = (fill: boolean) =>
+  cn(
+    "w-full overflow-hidden rounded-xl border border-line-input bg-card text-ink",
+    "has-[.ProseMirror:focus-visible]:ring-2 has-[.ProseMirror:focus-visible]:ring-focus",
+    "has-[textarea:focus-visible]:ring-2 has-[textarea:focus-visible]:ring-focus",
+    fill && "flex h-full min-h-64 flex-col",
+  );
+
+export function MarkdownEditor(props: MarkdownEditorProps) {
+  return props.plain ? <PlainEditor {...props} /> : <RichEditor {...props} />;
+}
+
+/** The byte-preserving fallback face: same card, raw text, no toolbar. */
+function PlainEditor(props: MarkdownEditorProps) {
+  const { content, readOnly = false, ariaLabel, dataTestId, layout } = props;
+  const callbacks = useCallbacksRef(props);
+
+  // The seed echo the rich editor emits from onCreate: plain text never
+  // normalizes, so echoing the content verbatim settles the parent's dirty
+  // baseline the same way.
+  useEffect(() => {
+    callbacks.current.onChange(content);
+  }, [content, callbacks]);
+
+  const fill = layout === "fill";
+  return (
+    <div className={cardClass(fill)}>
+      {!readOnly && props.statusSlot ? (
+        <div className="flex shrink-0 items-center justify-end border-b border-line px-3 py-1.5">
+          {props.statusSlot}
+        </div>
+      ) : null}
+      <textarea
+        aria-label={ariaLabel}
+        data-testid={dataTestId}
+        value={content}
+        readOnly={readOnly}
+        onChange={(e) => callbacks.current.onChange(e.target.value)}
+        onFocus={() => callbacks.current.onFocusChange?.(true)}
+        onBlur={() => {
+          callbacks.current.onFocusChange?.(false);
+          callbacks.current.onBlur();
+        }}
+        className={cn(
+          "w-full resize-none bg-transparent px-5 py-4 text-base leading-relaxed text-ink outline-none",
+          fill ? "min-h-0 flex-1" : "block",
+          readOnly && "cursor-default text-ink-muted",
+        )}
+        style={fill ? undefined : { minHeight: compactMinHeight(layout.rows) }}
+      />
+    </div>
+  );
+}
+
+/** The greyed example, RENDERED (real muted headings) — decoration only. */
+function ExampleOverlay({ placeholder }: { placeholder: string }) {
+  const preview = useEditor({
+    extensions,
+    content: placeholder,
+    editable: false,
+    editorProps: {
+      // Without this the overlay would announce as a SECOND textbox
+      // (TipTap's default role): a phantom editor to assistive tech.
+      attributes: { "aria-hidden": "true", role: "presentation" },
+    },
+  });
+  return (
+    <EditorContent
+      editor={preview}
+      className={`pointer-events-none absolute inset-0 overflow-hidden px-5 py-4 text-ink-muted/60 ${proseClass}`}
+    />
+  );
+}
+
+function RichEditor(props: MarkdownEditorProps) {
+  const {
+    content,
+    readOnly = false,
+    placeholder,
+    ariaLabel,
+    dataTestId,
+    layout,
+    statusSlot,
+  } = props;
+  const callbacks = useCallbacksRef(props);
+  const fill = layout === "fill";
+
   const editor = useEditor({
     extensions,
     content,
     editable: !readOnly,
-    immediatelyRender: false,
     editorProps: {
       attributes: {
         role: "textbox",
@@ -90,37 +172,24 @@ export function MarkdownEditor({
         ...(dataTestId !== undefined && { "data-testid": dataTestId }),
         // The editable node IS the whole visible page: it carries the card's
         // content padding and min-height itself, so a click anywhere in the
-        // frame lands in the document and places the caret — a wrapper that
-        // only LOOKS like the field would be dead below the first line.
+        // frame lands in the document and places the caret.
         class: `outline-none px-5 py-4 ${proseClass}`,
-        style: `min-height: ${minHeight}`,
+        style: `min-height: ${fill ? "100%" : compactMinHeight(layout.rows)}`,
       },
     },
     // The parent's dirty baseline is the SEEDED DOC'S OWN serialization
     // (markdown → doc → markdown may normalize bullets/whitespace), so the
-    // baseline is announced the moment the doc exists — unconditionally,
-    // or a prop that round-trips unchanged would leave the baseline unseeded
+    // baseline is announced the moment the doc exists — unconditionally, or
+    // a prop that round-trips unchanged would leave the baseline unseeded
     // and the user's FIRST edit would read as clean.
-    onCreate: ({ editor: created }) => onChange(serialized(created)),
-    onUpdate: ({ editor: activeEditor }) => {
-      onChange(serialized(activeEditor));
-    },
-    onFocus: () => onFocusChange?.(true),
+    onCreate: ({ editor: created }) =>
+      callbacks.current.onChange(serialized(created)),
+    onUpdate: ({ editor: active }) =>
+      callbacks.current.onChange(serialized(active)),
+    onFocus: () => callbacks.current.onFocusChange?.(true),
     onBlur: () => {
-      onFocusChange?.(false);
-      onBlur();
-    },
-  });
-  const preview = useEditor({
-    extensions,
-    content: placeholder,
-    editable: false,
-    immediatelyRender: false,
-    editorProps: {
-      // Purely decorative: without this the overlay would announce as a
-      // SECOND textbox (TipTap's default role), a phantom editor to
-      // assistive tech.
-      attributes: { "aria-hidden": "true", role: "presentation" },
+      callbacks.current.onFocusChange?.(false);
+      callbacks.current.onBlur();
     },
   });
 
@@ -137,30 +206,19 @@ export function MarkdownEditor({
     // markdown — an external reseed — rebuilds the doc.
     if (serialized(editor) === content) return;
     editor.commands.setContent(content, { emitUpdate: false });
-    onChange(serialized(editor));
-  }, [content, editor, onChange]);
+    callbacks.current.onChange(serialized(editor));
+  }, [content, editor, callbacks]);
 
   const empty = editor?.isEmpty ?? content.length === 0;
 
   return (
-    // The document CARD: the canonical floating surface on bg-card, framed
-    // with the field border (line-input, a step darker than the hairline) —
-    // this is a page you write, not a recessed gray form input.
-    <div
-      className={cn(
-        "w-full overflow-hidden rounded-xl border border-line-input bg-card text-ink has-[.ProseMirror:focus-visible]:ring-2 has-[.ProseMirror:focus-visible]:ring-focus",
-        fill && "flex h-full min-h-64 flex-col",
-      )}
-    >
+    <div className={cardClass(fill)}>
       {!readOnly && editor ? (
         <MarkdownToolbar editor={editor} trailing={statusSlot} />
       ) : null}
       <div className={cn("relative", fill && "min-h-0 flex-1 overflow-y-auto")}>
         {!readOnly && empty ? (
-          <EditorContent
-            editor={preview}
-            className={`pointer-events-none absolute inset-0 px-5 py-4 text-ink-muted/60 ${proseClass}`}
-          />
+          <ExampleOverlay placeholder={placeholder} />
         ) : null}
         {/* In fill mode the wrapper's definite height flows down (h-full) so
             the ProseMirror node's min-height:100% resolves; a longer doc

--- a/app/src/components/context/markdown-toolbar.tsx
+++ b/app/src/components/context/markdown-toolbar.tsx
@@ -1,0 +1,103 @@
+import { Button } from "@houston-ai/core";
+import { type Editor, useEditorState } from "@tiptap/react";
+import {
+  Bold,
+  Heading1,
+  Heading2,
+  Italic,
+  List,
+  ListOrdered,
+  TextQuote,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+/**
+ * The standing-prose editor's formatting bar: always visible (never behind
+ * hover or a selection popup), because the people writing here don't know
+ * markdown exists and never will. One quiet row of ghost icon buttons on the
+ * document card's top edge; the typing shortcuts keep working underneath for
+ * whoever knows them.
+ *
+ * `onMouseDown` preventDefault on every button keeps focus and the selection
+ * INSIDE the document, so toggling a style never blurs the editor (which
+ * would fire the save) and never loses what the user selected.
+ */
+export function MarkdownToolbar({
+  editor,
+  trailing,
+}: {
+  editor: Editor;
+  /** Right-aligned status seat (the quiet Saving…/Saved), clear of the text. */
+  trailing?: ReactNode;
+}) {
+  const { t } = useTranslation("context");
+  const active = useEditorState({
+    editor,
+    selector: ({ editor: e }) => ({
+      heading: e.isActive("heading", { level: 1 }),
+      subheading: e.isActive("heading", { level: 2 }),
+      bold: e.isActive("bold"),
+      italic: e.isActive("italic"),
+      bulletList: e.isActive("bulletList"),
+      numberedList: e.isActive("orderedList"),
+      quote: e.isActive("blockquote"),
+    }),
+  });
+
+  const chain = () => editor.chain().focus();
+  const controls = [
+    {
+      key: "heading",
+      icon: Heading1,
+      run: () => chain().toggleHeading({ level: 1 }).run(),
+    },
+    {
+      key: "subheading",
+      icon: Heading2,
+      run: () => chain().toggleHeading({ level: 2 }).run(),
+    },
+    { key: "bold", icon: Bold, run: () => chain().toggleBold().run() },
+    { key: "italic", icon: Italic, run: () => chain().toggleItalic().run() },
+    {
+      key: "bulletList",
+      icon: List,
+      run: () => chain().toggleBulletList().run(),
+    },
+    {
+      key: "numberedList",
+      icon: ListOrdered,
+      run: () => chain().toggleOrderedList().run(),
+    },
+    {
+      key: "quote",
+      icon: TextQuote,
+      run: () => chain().toggleBlockquote().run(),
+    },
+  ] as const;
+
+  return (
+    <div
+      role="toolbar"
+      aria-label={t("editor.toolbar.label")}
+      className="flex items-center gap-0.5 border-b border-line px-2 py-1.5"
+    >
+      {controls.map(({ key, icon: Icon, run }) => (
+        <Button
+          key={key}
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={t(`editor.toolbar.${key}`)}
+          aria-pressed={active[key]}
+          className={active[key] ? "bg-chip text-ink" : "text-ink-muted"}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={run}
+        >
+          <Icon className="size-4" />
+        </Button>
+      ))}
+      {trailing ? <div className="ml-auto pr-1.5">{trailing}</div> : null}
+    </div>
+  );
+}

--- a/app/src/components/context/markdown-toolbar.tsx
+++ b/app/src/components/context/markdown-toolbar.tsx
@@ -77,8 +77,10 @@ export function MarkdownToolbar({
   ] as const;
 
   return (
-    <div
-      role="toolbar"
+    // A labelled fieldset, not role="toolbar": that role promises the
+    // roving-tabindex arrow-key pattern, and seven honest tab stops beat a
+    // half-implemented widget contract.
+    <fieldset
       aria-label={t("editor.toolbar.label")}
       className="flex items-center gap-0.5 border-b border-line px-2 py-1.5"
     >
@@ -90,7 +92,14 @@ export function MarkdownToolbar({
           size="icon-sm"
           aria-label={t(`editor.toolbar.${key}`)}
           aria-pressed={active[key]}
-          className={active[key] ? "bg-chip text-ink" : "text-ink-muted"}
+          // The pressed fill carries its own hover counterpart: the ghost
+          // variant's hover:bg-hover would otherwise outrank it and blank
+          // the active state exactly while the pointer is on it.
+          className={
+            active[key]
+              ? "bg-chip text-ink hover:bg-chip hover:text-ink"
+              : "text-ink-muted"
+          }
           onMouseDown={(event) => event.preventDefault()}
           onClick={run}
         >
@@ -98,6 +107,6 @@ export function MarkdownToolbar({
         </Button>
       ))}
       {trailing ? <div className="ml-auto pr-1.5">{trailing}</div> : null}
-    </div>
+    </fieldset>
   );
 }

--- a/app/src/components/context/use-context-editor-save.ts
+++ b/app/src/components/context/use-context-editor-save.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { isDirty, isWysiwygSafe, shouldReseed } from "./context-editor-model";
+
+export type SaveState = "idle" | "saving" | "saved";
+
+/**
+ * The standing-context editor's save machine: value + baseline + save state,
+ * with every write funneled through ONE promise queue — blur saves, the
+ * unmount flush, and the read-only flush — so writes reach the store in
+ * order and the same text is never submitted twice back-to-back.
+ *
+ * The dirty baseline is the SEEDED DOC'S OWN serialization (announced by the
+ * editor on create), so markdown normalization never reads as a user edit.
+ * `plainDoc` decides WYSIWYG vs plain-text fallback per seed
+ * (`isWysiwygSafe`): a document the rich schema would corrupt is edited raw.
+ */
+export function useContextEditorSave({
+  content,
+  onSave,
+  readOnly,
+}: {
+  content: string;
+  onSave: (content: string) => Promise<unknown>;
+  readOnly: boolean;
+}) {
+  const [value, setValue] = useState(content);
+  const [state, setState] = useState<SaveState>("idle");
+  const [plainDoc, setPlainDoc] = useState(() => !isWysiwygSafe(content));
+
+  const valueRef = useRef(content);
+  const baselineRef = useRef(content);
+  const focusedRef = useRef(false);
+  const awaitingSeedRef = useRef(true);
+  const contentPropRef = useRef(content);
+  const pendingExternalRef = useRef<string | null>(null);
+  const onSaveRef = useRef(onSave);
+  const readOnlyRef = useRef(readOnly);
+  const chainRef = useRef<Promise<unknown>>(Promise.resolve());
+  const lastQueuedRef = useRef<string | null>(null);
+  const savedTimerRef = useRef<number | null>(null);
+
+  onSaveRef.current = onSave;
+
+  const applyReseed = useCallback((next: string) => {
+    awaitingSeedRef.current = true;
+    valueRef.current = next;
+    // The baseline moves WITH the seed, so a blur between the seed and the
+    // editor's normalization echo can never read external text as an edit.
+    baselineRef.current = next;
+    pendingExternalRef.current = null;
+    setPlainDoc(!isWysiwygSafe(next));
+    setValue(next);
+  }, []);
+
+  const enqueueSave = useCallback((next: string) => {
+    if (lastQueuedRef.current === next) return;
+    lastQueuedRef.current = next;
+    setState("saving");
+    chainRef.current = chainRef.current
+      .then(() => onSaveRef.current(next))
+      .then(() => {
+        baselineRef.current = next;
+        setState("saved");
+        if (savedTimerRef.current !== null)
+          window.clearTimeout(savedTimerRef.current);
+        savedTimerRef.current = window.setTimeout(() => setState("idle"), 2000);
+      })
+      .catch(() => {
+        // The data layer owns the toast; recover so "Saving…" never sticks,
+        // and reset the dedupe key so a re-blur retries the write.
+        lastQueuedRef.current = baselineRef.current;
+        setState("idle");
+      });
+  }, []);
+
+  const handleChange = useCallback((markdown: string) => {
+    valueRef.current = markdown;
+    setValue(markdown);
+    if (awaitingSeedRef.current) {
+      baselineRef.current = markdown;
+      awaitingSeedRef.current = false;
+    }
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    if (readOnlyRef.current) return;
+    const current = valueRef.current;
+    if (isDirty(current, baselineRef.current)) enqueueSave(current);
+  }, [enqueueSave]);
+
+  const handleFocusChange = useCallback(
+    (focused: boolean) => {
+      focusedRef.current = focused;
+      // An external update that arrived mid-edit lands the moment the user
+      // leaves the box IF they typed nothing meanwhile — dirty text always
+      // wins (its blur save is already queued).
+      if (
+        !focused &&
+        pendingExternalRef.current !== null &&
+        !isDirty(valueRef.current, baselineRef.current)
+      ) {
+        applyReseed(pendingExternalRef.current);
+      }
+    },
+    [applyReseed],
+  );
+
+  // External content changes: reseed now when the box is idle, otherwise
+  // hold the NEWEST revision for the next blur instead of dropping it.
+  useEffect(() => {
+    if (contentPropRef.current === content) return;
+    contentPropRef.current = content;
+    const dirty = isDirty(valueRef.current, baselineRef.current);
+    if (shouldReseed({ focused: focusedRef.current, dirty })) {
+      applyReseed(content);
+    } else {
+      pendingExternalRef.current = content;
+    }
+  }, [content, applyReseed]);
+
+  // A box that turns read-only mid-edit SUBMITS what was typed rather than
+  // silently discarding it; a rejected write surfaces through the layer.
+  useEffect(() => {
+    const was = readOnlyRef.current;
+    readOnlyRef.current = readOnly;
+    if (!was && readOnly && isDirty(valueRef.current, baselineRef.current)) {
+      enqueueSave(valueRef.current);
+    }
+  }, [readOnly, enqueueSave]);
+
+  // Unmount with unsaved text: flush through the same queue. The dedupe key
+  // makes this a no-op when the blur save already carried this text.
+  useEffect(
+    () => () => {
+      if (savedTimerRef.current !== null)
+        window.clearTimeout(savedTimerRef.current);
+      if (readOnlyRef.current) return;
+      if (!isDirty(valueRef.current, baselineRef.current)) return;
+      if (lastQueuedRef.current === valueRef.current) return;
+      lastQueuedRef.current = valueRef.current;
+      // The data layer surfaces failures; cleanup has no mounted UI.
+      chainRef.current = chainRef.current
+        .then(() => onSaveRef.current(valueRef.current))
+        .catch(() => {});
+    },
+    [],
+  );
+
+  return {
+    value,
+    state,
+    plainDoc,
+    handleChange,
+    handleBlur,
+    handleFocusChange,
+  };
+}

--- a/app/src/components/context/use-context-editor-save.ts
+++ b/app/src/components/context/use-context-editor-save.ts
@@ -38,10 +38,13 @@ export function useContextEditorSave({
   const chainRef = useRef<Promise<unknown>>(Promise.resolve());
   const lastQueuedRef = useRef<string | null>(null);
   const savedTimerRef = useRef<number | null>(null);
+  const seedEpochRef = useRef(0);
+  const mountedRef = useRef(true);
 
   onSaveRef.current = onSave;
 
   const applyReseed = useCallback((next: string) => {
+    seedEpochRef.current += 1;
     awaitingSeedRef.current = true;
     valueRef.current = next;
     // The baseline moves WITH the seed, so a blur between the seed and the
@@ -55,11 +58,20 @@ export function useContextEditorSave({
   const enqueueSave = useCallback((next: string) => {
     if (lastQueuedRef.current === next) return;
     lastQueuedRef.current = next;
+    // The user's text is now the newest revision we know: an external update
+    // held from mid-edit is older by definition, and re-applying it later
+    // would regress what was just saved.
+    pendingExternalRef.current = null;
+    // A reseed that lands while this save is in flight owns the baseline;
+    // the epoch check keeps a slow completion from stamping stale text over
+    // it (which would re-save external content as an "edit").
+    const epoch = seedEpochRef.current;
     setState("saving");
     chainRef.current = chainRef.current
       .then(() => onSaveRef.current(next))
       .then(() => {
-        baselineRef.current = next;
+        if (seedEpochRef.current === epoch) baselineRef.current = next;
+        if (!mountedRef.current) return;
         setState("saved");
         if (savedTimerRef.current !== null)
           window.clearTimeout(savedTimerRef.current);
@@ -69,7 +81,7 @@ export function useContextEditorSave({
         // The data layer owns the toast; recover so "Saving…" never sticks,
         // and reset the dedupe key so a re-blur retries the write.
         lastQueuedRef.current = baselineRef.current;
-        setState("idle");
+        if (mountedRef.current) setState("idle");
       });
   }, []);
 
@@ -130,8 +142,10 @@ export function useContextEditorSave({
 
   // Unmount with unsaved text: flush through the same queue. The dedupe key
   // makes this a no-op when the blur save already carried this text.
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
       if (savedTimerRef.current !== null)
         window.clearTimeout(savedTimerRef.current);
       if (readOnlyRef.current) return;
@@ -142,9 +156,8 @@ export function useContextEditorSave({
       chainRef.current = chainRef.current
         .then(() => onSaveRef.current(valueRef.current))
         .catch(() => {});
-    },
-    [],
-  );
+    };
+  }, []);
 
   return {
     value,

--- a/app/src/components/organization/admin-section-body.tsx
+++ b/app/src/components/organization/admin-section-body.tsx
@@ -59,7 +59,17 @@ export function AdminSectionBody({
 }) {
   const { t } = useTranslation("teams");
   return (
-    <PageContainer className="pt-6 pb-10" data-admin-section-body={active}>
+    <PageContainer
+      // Company context is a pinned page (its editor card owns the bottom
+      // gap), so its container is a height-bounded column with no bottom
+      // padding of its own; every other section pads and scrolls normally.
+      className={
+        active === "companyContext"
+          ? "flex h-full min-h-0 flex-col pt-6"
+          : "pt-6 pb-10"
+      }
+      data-admin-section-body={active}
+    >
       {!ctx ? (
         <p className="py-10 text-sm text-ink-muted">
           {isLoading ? t("org.loading") : t("org.unavailable")}

--- a/app/src/components/organization/organization-view.tsx
+++ b/app/src/components/organization/organization-view.tsx
@@ -131,16 +131,10 @@ export function OrganizationView() {
           lenses={lenses}
           onSelectLens={setLens}
         />
-        {/* Company context pins its document card to a fixed bottom gap (the
-            card scrolls inside), so its frame must NOT scroll; every other
-            section scrolls the page as usual. */}
-        <div
-          className={
-            active === "companyContext"
-              ? "min-h-0 flex-1"
-              : "flex-1 overflow-y-auto [scrollbar-gutter:stable]"
-          }
-        >
+        {/* One scroller for every section. Company context sizes itself to
+            exactly this height (its card scrolls internally), so the outer
+            scroll only engages as a short-window fallback there. */}
+        <div className="flex-1 overflow-y-auto [scrollbar-gutter:stable]">
           <AdminSectionBody
             active={active}
             ctx={ctx}

--- a/app/src/components/organization/organization-view.tsx
+++ b/app/src/components/organization/organization-view.tsx
@@ -131,7 +131,16 @@ export function OrganizationView() {
           lenses={lenses}
           onSelectLens={setLens}
         />
-        <div className="flex-1 overflow-y-auto [scrollbar-gutter:stable]">
+        {/* Company context pins its document card to a fixed bottom gap (the
+            card scrolls inside), so its frame must NOT scroll; every other
+            section scrolls the page as usual. */}
+        <div
+          className={
+            active === "companyContext"
+              ? "min-h-0 flex-1"
+              : "flex-1 overflow-y-auto [scrollbar-gutter:stable]"
+          }
+        >
           <AdminSectionBody
             active={active}
             ctx={ctx}

--- a/app/src/components/team-view/team-context-editor.tsx
+++ b/app/src/components/team-view/team-context-editor.tsx
@@ -47,7 +47,7 @@ export function TeamContextEditor({
         onSave={onSave}
         readOnly={readOnly}
         placeholder={labels.placeholder}
-        minRows={6}
+        layout={{ rows: 6 }}
         ariaLabel={labels.title}
         dataTestId="team-context-input"
       />

--- a/app/src/locales/en/context.json
+++ b/app/src/locales/en/context.json
@@ -15,6 +15,16 @@
     "subtitle": "What every agent knows about you before it starts."
   },
   "editor": {
+    "toolbar": {
+      "label": "Formatting",
+      "heading": "Heading",
+      "subheading": "Subheading",
+      "bold": "Bold",
+      "italic": "Italic",
+      "bulletList": "Bulleted list",
+      "numberedList": "Numbered list",
+      "quote": "Quote"
+    },
     "saving": "Saving…",
     "saved": "Saved",
     "user": {

--- a/app/src/locales/es/context.json
+++ b/app/src/locales/es/context.json
@@ -15,6 +15,16 @@
     "subtitle": "Lo que cada agente sabe sobre ti antes de empezar."
   },
   "editor": {
+    "toolbar": {
+      "label": "Formato",
+      "heading": "Título",
+      "subheading": "Subtítulo",
+      "bold": "Negrita",
+      "italic": "Cursiva",
+      "bulletList": "Lista con viñetas",
+      "numberedList": "Lista numerada",
+      "quote": "Cita"
+    },
     "saving": "Guardando…",
     "saved": "Guardado",
     "user": {

--- a/app/src/locales/pt/context.json
+++ b/app/src/locales/pt/context.json
@@ -15,6 +15,16 @@
     "subtitle": "O que cada agente sabe sobre você antes de começar."
   },
   "editor": {
+    "toolbar": {
+      "label": "Formatação",
+      "heading": "Título",
+      "subheading": "Subtítulo",
+      "bold": "Negrito",
+      "italic": "Itálico",
+      "bulletList": "Lista com marcadores",
+      "numberedList": "Lista numerada",
+      "quote": "Citação"
+    },
     "saving": "Salvando…",
     "saved": "Salvo",
     "user": {

--- a/app/tests/context-editor-model.test.ts
+++ b/app/tests/context-editor-model.test.ts
@@ -1,0 +1,21 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  isDirty,
+  shouldReseed,
+} from "../src/components/context/context-editor-model.ts";
+
+describe("context editor dirty model", () => {
+  it("is clean only when serialized content matches its serialized baseline", () => {
+    strictEqual(isDirty("# Hello", "# Hello"), false);
+    strictEqual(isDirty("# Hello\n", "# Hello"), true);
+    strictEqual(isDirty("- one", "* one"), true);
+  });
+
+  it("reseeds only while unfocused and clean", () => {
+    strictEqual(shouldReseed({ focused: false, dirty: false }), true);
+    strictEqual(shouldReseed({ focused: true, dirty: false }), false);
+    strictEqual(shouldReseed({ focused: false, dirty: true }), false);
+    strictEqual(shouldReseed({ focused: true, dirty: true }), false);
+  });
+});

--- a/app/tests/context-editor-model.test.ts
+++ b/app/tests/context-editor-model.test.ts
@@ -38,6 +38,8 @@ describe("isWysiwygSafe — the corruption guard", () => {
       isWysiwygSafe("| Don't say | Say |\n|---|---|\n| a | b |"),
       false,
     );
+    // GFM also admits headerless pipes with no leading `|`.
+    strictEqual(isWysiwygSafe("Name | Value\n--- | ---\na | 1"), false);
   });
 
   it("refuses frontmatter at the document start, but not a mid-doc rule", () => {

--- a/app/tests/context-editor-model.test.ts
+++ b/app/tests/context-editor-model.test.ts
@@ -1,12 +1,14 @@
 import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
+  compactMinHeight,
   isDirty,
+  isWysiwygSafe,
   shouldReseed,
 } from "../src/components/context/context-editor-model.ts";
 
 describe("context editor dirty model", () => {
-  it("is clean only when serialized content matches its serialized baseline", () => {
+  it("marks any byte difference dirty (the caller compares serializations)", () => {
     strictEqual(isDirty("# Hello", "# Hello"), false);
     strictEqual(isDirty("# Hello\n", "# Hello"), true);
     strictEqual(isDirty("- one", "* one"), true);
@@ -17,5 +19,44 @@ describe("context editor dirty model", () => {
     strictEqual(shouldReseed({ focused: true, dirty: false }), false);
     strictEqual(shouldReseed({ focused: false, dirty: true }), false);
     strictEqual(shouldReseed({ focused: true, dirty: true }), false);
+  });
+});
+
+describe("isWysiwygSafe — the corruption guard", () => {
+  it("accepts everything the schema can hold", () => {
+    strictEqual(
+      isWysiwygSafe(
+        "# Title\n\nSome **bold** and *italic* text.\n\n- a list\n1. numbered\n\n> a quote\n\n---\n\n`code` and\n\n```\na fence\n```\n",
+      ),
+      true,
+    );
+    strictEqual(isWysiwygSafe(""), true);
+  });
+
+  it("refuses tables — they round-trip as mashed cell text", () => {
+    strictEqual(
+      isWysiwygSafe("| Don't say | Say |\n|---|---|\n| a | b |"),
+      false,
+    );
+  });
+
+  it("refuses frontmatter at the document start, but not a mid-doc rule", () => {
+    strictEqual(isWysiwygSafe("---\ntitle: Hello\n---\nBody"), false);
+    strictEqual(isWysiwygSafe("Above\n\n---\n\nBelow"), true);
+  });
+
+  it("refuses raw HTML, task lists, images, and reference links", () => {
+    strictEqual(isWysiwygSafe("Hi <details>Secret</details>"), false);
+    strictEqual(isWysiwygSafe("- [ ] todo\n- [x] done"), false);
+    strictEqual(isWysiwygSafe("![alt](img.png)"), false);
+    strictEqual(isWysiwygSafe("See [docs]\n\n[docs]: https://x.test"), false);
+  });
+});
+
+describe("compactMinHeight", () => {
+  it("floors at N real text lines plus the document's own padding", () => {
+    // 16px body at leading-relaxed = 1.625rem per line; py-4 = 2rem.
+    strictEqual(compactMinHeight(6), "calc(9.75rem + 2rem)");
+    strictEqual(compactMinHeight(12), "calc(19.5rem + 2rem)");
   });
 });

--- a/app/tests/context-editor.test.ts
+++ b/app/tests/context-editor.test.ts
@@ -9,7 +9,7 @@ const read = (rel: string) =>
  * The node runner has no DOM, so the ONE standing-context editor's wiring is
  * guarded on its source (the repo's React-test idiom). Each assertion stands
  * for a review finding that shipped once in the consolidated grammar: a save
- * failure that stuck the UI on "Saving…", textareas with no accessible name,
+ * failure that stuck the UI on "Saving…", editors with no accessible name,
  * and design-token violations carried over from the deleted editor.
  */
 describe("context-editor source", () => {
@@ -28,14 +28,22 @@ describe("context-editor source", () => {
   it("derives the box's accessible name from the page title", () => {
     ok(
       src.includes("<ContextEditorBox ariaLabel={title} {...box} />"),
-      "ContextEditorPage names the textarea after its hero",
+      "ContextEditorPage names the editor after its hero",
     );
   });
 
-  it("keeps the read-only face from inviting writing", () => {
+  it("uses MarkdownEditor inside the standing prose box", () => {
     ok(
-      src.includes("placeholder={readOnly ? undefined : placeholder}"),
-      "the greyed suggestion (the write invitation) drops when locked",
+      src.includes("<MarkdownEditor"),
+      "ContextEditorBox delegates its document field to MarkdownEditor",
+    );
+  });
+
+  it("guards background reseeds and flushes dirty content on unmount", () => {
+    ok(src.includes("shouldReseed({"), "prop updates use the reseed guard");
+    ok(
+      src.includes("onSaveRef.current(valueRef.current).catch(() => {})"),
+      "cleanup flushes pending content and contains its rejected promise",
     );
   });
 
@@ -44,7 +52,13 @@ describe("context-editor source", () => {
     // focus is the ring-focus idiom (which the strip's lozenges use too).
     ok(!src.includes("rgba("), "no raw shadow literal");
     ok(!src.includes("text-[11px]"), "no off-scale label size");
-    ok(src.includes("focus-visible:ring-focus"), "focus is the shared ring");
+    const markdown = read("../src/components/context/markdown-editor.tsx");
+    ok(!markdown.includes("rgba("), "no raw rgba literal");
+    ok(!/#(?:[\da-fA-F]{3}){1,2}\b/.test(markdown), "no raw hex literal");
+    ok(
+      markdown.includes("focus-visible]:ring-focus"),
+      "focus is the shared ring",
+    );
   });
 });
 

--- a/app/tests/context-editor.test.ts
+++ b/app/tests/context-editor.test.ts
@@ -8,56 +8,95 @@ const read = (rel: string) =>
 /**
  * The node runner has no DOM, so the ONE standing-context editor's wiring is
  * guarded on its source (the repo's React-test idiom). Each assertion stands
- * for a review finding that shipped once in the consolidated grammar: a save
- * failure that stuck the UI on "Saving…", editors with no accessible name,
- * and design-token violations carried over from the deleted editor.
+ * for a review finding that shipped once in the consolidated grammar.
  */
 describe("context-editor source", () => {
-  const src = read("../src/components/context/context-editor.tsx");
+  const box = read("../src/components/context/context-editor.tsx");
+  const hook = read("../src/components/context/use-context-editor-save.ts");
+  const editor = read("../src/components/context/markdown-editor.tsx");
+  const toolbar = read("../src/components/context/markdown-toolbar.tsx");
 
   it("recovers from a failed save instead of sticking on Saving…", () => {
-    // The data layer owns the toast; the box must still catch so the promise
-    // is never an unhandled rejection and the state returns to idle.
-    ok(src.includes("try {"), "save path is guarded");
+    // The data layer owns the toast; the queue must still catch so the
+    // promise is never an unhandled rejection and the state returns to idle.
     ok(
-      /catch\s*\{[\s\S]*?setState\("idle"\)/.test(src),
+      /\.catch\(\(\) => \{[\s\S]*?setState\("idle"\)/.test(hook),
       "a rejection resets the save state",
+    );
+  });
+
+  it("routes every write through one ordered queue", () => {
+    ok(hook.includes("chainRef.current = chainRef.current"), "saves chain");
+    ok(
+      hook.includes("if (lastQueuedRef.current === next) return;"),
+      "the same text is never submitted twice back-to-back",
+    );
+  });
+
+  it("guards background reseeds, holds mid-edit updates, flushes on unmount", () => {
+    ok(hook.includes("shouldReseed({"), "prop updates use the reseed guard");
+    ok(
+      hook.includes("pendingExternalRef.current = content;"),
+      "an update that lands mid-edit is held, not dropped",
+    );
+    ok(
+      /\.then\(\(\) => onSaveRef\.current\(valueRef\.current\)\)\s*\.catch/.test(
+        hook,
+      ),
+      "cleanup flushes pending content through the queue",
+    );
+  });
+
+  it("refuses to rich-edit markdown the schema would corrupt", () => {
+    ok(
+      hook.includes("isWysiwygSafe"),
+      "the corruption guard decides the editing mode",
+    );
+    ok(
+      editor.includes("function PlainEditor"),
+      "unsafe documents get the byte-preserving plain face",
     );
   });
 
   it("derives the box's accessible name from the page title", () => {
     ok(
-      src.includes("<ContextEditorBox ariaLabel={title} {...box} />"),
+      box.includes(
+        '<ContextEditorBox layout="fill" ariaLabel={title} {...box} />',
+      ),
       "ContextEditorPage names the editor after its hero",
     );
   });
 
   it("uses MarkdownEditor inside the standing prose box", () => {
     ok(
-      src.includes("<MarkdownEditor"),
+      box.includes("<MarkdownEditor"),
       "ContextEditorBox delegates its document field to MarkdownEditor",
     );
   });
 
-  it("guards background reseeds and flushes dirty content on unmount", () => {
-    ok(src.includes("shouldReseed({"), "prop updates use the reseed guard");
+  it("reads TipTap callbacks through the latest-ref, never a stale closure", () => {
+    // TipTap binds handlers once at construction and @tiptap/react never
+    // re-registers them, so every handler must dereference the ref.
+    ok(editor.includes("function useCallbacksRef"), "the latest-ref exists");
     ok(
-      src.includes("onSaveRef.current(valueRef.current).catch(() => {})"),
-      "cleanup flushes pending content and contains its rejected promise",
+      !/on(Create|Update|Focus|Blur): \(\) => on[A-Z]/.test(editor),
+      "no handler closes over raw props",
     );
   });
 
-  it("carries no design-token violations from the deleted editor", () => {
-    // DESIGN.md: no raw rgba/px shadow literals, no off-scale type sizes, and
-    // focus is the ring-focus idiom (which the strip's lozenges use too).
-    ok(!src.includes("rgba("), "no raw shadow literal");
-    ok(!src.includes("text-[11px]"), "no off-scale label size");
-    const markdown = read("../src/components/context/markdown-editor.tsx");
-    ok(!markdown.includes("rgba("), "no raw rgba literal");
-    ok(!/#(?:[\da-fA-F]{3}){1,2}\b/.test(markdown), "no raw hex literal");
+  it("carries no design-token violations in the editor or its toolbar", () => {
+    for (const src of [editor, toolbar, box]) {
+      ok(!src.includes("rgba("), "no raw shadow literal");
+      ok(!/#(?:[\da-fA-F]{3}){1,2}\b/.test(src), "no raw hex literal");
+      ok(!src.includes("text-[11px]"), "no off-scale label size");
+    }
     ok(
-      markdown.includes("focus-visible]:ring-focus"),
+      editor.includes("focus-visible]:ring-focus"),
       "focus is the shared ring",
+    );
+    ok(
+      toolbar.includes("hover:bg-chip hover:text-ink"),
+      "the pressed fill survives its own hover",
     );
   });
 });

--- a/app/tests/settings-view-gates.test.ts
+++ b/app/tests/settings-view-gates.test.ts
@@ -91,9 +91,12 @@ describe("the promoted top-level screens", () => {
     const src = read("../src/components/about-me/about-me-view.tsx");
     ok(src.includes("export function AboutMeView() {"), "no props");
     ok(!src.includes("BackBarScreen"), "no back bar at a top level");
+    // A pinned editor page: the frame is a height-bounded column and never
+    // scrolls — the document card scrolls inside itself instead.
     ok(
-      src.includes("[scrollbar-gutter:stable]"),
-      "its scroller reserves the gutter",
+      src.includes('className="min-h-0 flex-1"') &&
+        !src.includes("overflow-y-auto"),
+      "no page scroll around the pinned document card",
     );
   });
 

--- a/app/tests/settings-view-gates.test.ts
+++ b/app/tests/settings-view-gates.test.ts
@@ -91,12 +91,16 @@ describe("the promoted top-level screens", () => {
     const src = read("../src/components/about-me/about-me-view.tsx");
     ok(src.includes("export function AboutMeView() {"), "no props");
     ok(!src.includes("BackBarScreen"), "no back bar at a top level");
-    // A pinned editor page: the frame is a height-bounded column and never
-    // scrolls — the document card scrolls inside itself instead.
+    // A pinned editor page: the column is exactly the viewport (the card
+    // scrolls internally); the outer scroller stays only as the short-window
+    // fallback and keeps the shared gutter reservation.
     ok(
-      src.includes('className="min-h-0 flex-1"') &&
-        !src.includes("overflow-y-auto"),
-      "no page scroll around the pinned document card",
+      src.includes("[scrollbar-gutter:stable]"),
+      "the fallback scroller reserves the gutter",
+    );
+    ok(
+      src.includes("flex h-full min-h-0 flex-col"),
+      "the page column hands the viewport height to the pinned card",
     );
   });
 

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -169,8 +169,11 @@ Sections:
 
 - **Company context** (`company-context-tab.tsx`) — the workspace half of standing
   context, drawn with the ONE standing-prose editor
-  (`app/src/components/context/context-editor.tsx`: always-open box, saves on blur,
-  the data layer owns the failure toast). The same component draws About me, an
+  (`app/src/components/context/context-editor.tsx` + `markdown-editor.tsx`:
+  Notion-style markdown on TipTap, always-visible formatting bar, markdown
+  strings on the wire, saves on blur through one ordered write queue; documents
+  the schema can't hold — tables, raw HTML — open in a plain-text fallback so
+  agent-written files never corrupt). The same component draws About me, an
   agent's Job description (agent settings), and the team context card.
 - **People** (`members-tab.tsx` / `people-roster.tsx`) — roster + pending invites,
   **membership only**: owner mutates (add/remove/re-role, revoke invite), admin sees

--- a/packages/web/e2e/agent-onboarding.spec.ts
+++ b/packages/web/e2e/agent-onboarding.spec.ts
@@ -18,7 +18,7 @@ import { screen } from "./support/team-nav";
  *  close itself and the setup-mission panel to auto-open). */
 async function createFromScratch(page: Page, name: string) {
   await page.getByRole("button", { name: "New agent" }).click();
-  const scratch = page.getByText("Create new agent");
+  const scratch = page.getByRole("button", { name: "Create new", exact: true });
   await scratch.waitFor({ state: "visible" });
   await scratch.click();
   const nameField = page.getByPlaceholder("e.g. Product manager, Sales, Jerry");

--- a/packages/web/e2e/agent-teams.spec.ts
+++ b/packages/web/e2e/agent-teams.spec.ts
@@ -703,10 +703,14 @@ test("a team's shared context is the first card of its settings, and it saves", 
   ).toBeVisible();
 
   const box = screen(page).getByTestId("team-context-input");
-  await expect(box).toHaveValue("We ship on Fridays.");
+  await expect(box).toHaveText("We ship on Fridays.");
 
   // Saves on BLUR, the same idiom the agent's own instructions editor uses.
-  await box.fill("We ship on Fridays. Ask before promising a date.");
+  await box.click();
+  await page.keyboard.press("ControlOrMeta+A");
+  await box.pressSequentially(
+    "We ship on Fridays. Ask before promising a date.",
+  );
   await box.blur();
   const patches = () => callsTo(calls, "PATCH", `/v1/org/teams/${OPS_TEAM}`);
   await expect.poll(() => patches().length).toBe(1);
@@ -742,8 +746,9 @@ test("a team's context is READ-ONLY for someone who does not own the team", asyn
 
   await openManageAgents(page, OPS_TEAM);
   const box = screen(page).getByTestId("team-context-input");
-  await expect(box).toHaveValue("We ship on Fridays.");
-  await expect(box).toHaveAttribute("readonly", "");
+  await expect(box).toHaveText("We ship on Fridays.");
+  await expect(box).toHaveAttribute("contenteditable", "false");
+  await expect(box).toHaveAttribute("aria-readonly", "true");
 
   // Read-only all the way down to the wire: a blur writes nothing.
   await box.click();

--- a/packages/web/e2e/agent-teams.spec.ts
+++ b/packages/web/e2e/agent-teams.spec.ts
@@ -717,6 +717,22 @@ test("a team's shared context is the first card of its settings, and it saves", 
   expect(JSON.parse(patches()[0].body ?? "{}")).toEqual({
     context: "We ship on Fridays. Ask before promising a date.",
   });
+
+  // The formatting bar is the feature's whole point for non-technical users:
+  // always visible, and its buttons write MARKDOWN to the wire. Bold the
+  // text through the button (never a `**` typed by hand) and the saved
+  // context carries the markdown marks.
+  await expect(
+    screen(page).getByRole("group", { name: "Formatting" }),
+  ).toBeVisible();
+  await box.click();
+  await page.keyboard.press("ControlOrMeta+A");
+  await screen(page).getByRole("button", { name: "Bold", exact: true }).click();
+  await box.blur();
+  await expect.poll(() => patches().length).toBe(2);
+  expect(JSON.parse(patches()[1].body ?? "{}")).toEqual({
+    context: "**We ship on Fridays. Ask before promising a date.**",
+  });
 });
 
 test("a team's context is READ-ONLY for someone who does not own the team", async ({

--- a/packages/web/e2e/context-surface.spec.ts
+++ b/packages/web/e2e/context-surface.spec.ts
@@ -64,10 +64,7 @@ test("About me is a rail row of its own, owning the whole window", async ({
   // No invite empty state on a standing-context page: the editor is already
   // open, and the greyed suggestion — which names the PERSON, not the
   // company — is the invitation.
-  await expect(screen(page).getByRole("textbox")).toHaveAttribute(
-    "placeholder",
-    /I'm Juan/,
-  );
+  await expect(screen(page).getByText(/I'm Juan/)).toBeVisible();
 
   // Nothing sits above a top-level screen, so it offers no way back — a bar
   // naming the Inbox would be the old door leaking through.
@@ -86,15 +83,18 @@ test("Company context is a section of Admin, editing the workspace's half", asyn
   await openAdminSection(page, "Company context");
 
   // The WORKSPACE slot: the editor is already open (no invite empty state),
-  // and its greyed suggestion is a short 3-part example of company context.
+  // and its greyed suggestion is a short 3-part example RENDERED as real
+  // headings (the overlay is aria-hidden decoration, so it is asserted as
+  // text, never by role): the words appear, the "##" syntax never does.
   const editor = screen(page).getByRole("textbox");
-  await expect(editor).toHaveAttribute("placeholder", /## Who we are/);
-  await expect(editor).toHaveAttribute("placeholder", /## How we communicate/);
+  await expect(screen(page).getByText("Who we are")).toBeVisible();
+  await expect(screen(page).getByText("How we communicate")).toBeVisible();
+  await expect(screen(page).getByText("## Who we are")).toHaveCount(0);
 
   // And only that half. The person's context is not duplicated inside Admin —
   // it is theirs, not the admin's, which is the whole reason the two split.
   await expect(editor).toHaveCount(1);
-  await expect(editor).not.toHaveAttribute("placeholder", /I'm Juan/);
+  await expect(screen(page).getByText(/I'm Juan/)).toHaveCount(0);
 
   // The identity lozenge ("Admin") stands for this very section, so it is
   // the current one — and the section titles ITSELF: a level-2 hero naming

--- a/packages/web/e2e/support/create-agent.ts
+++ b/packages/web/e2e/support/create-agent.ts
@@ -3,8 +3,8 @@ import { expect, type Page } from "@playwright/test";
 /**
  * Create an agent through the real dialog and return to a usable shell.
  *
- * The create dialog (`create-workspace-dialog.tsx`) offers two cards — "Import
- * from the store" (navigates to the Agent Store page) and "Create new agent"
+ * The create dialog (`create-workspace-dialog.tsx`) offers two cards — "From
+ * the store" (navigates to the Agent Store page) and "Create new"
  * (the from-scratch naming step, PRODUCT-1171). On create success the dialog
  * fires the agent's self-setup mission in the normal shell
  * (`startAgentSetupMission`), switches to the board view, auto-opens the chat
@@ -18,7 +18,8 @@ import { expect, type Page } from "@playwright/test";
  */
 export async function createAgent(page: Page, name: string): Promise<void> {
   await page.getByRole("button", { name: "New agent" }).click();
-  const scratch = page.getByText("Create new agent");
+  // The card's label as the chooser ships it (`shell:newAgent.createCard`).
+  const scratch = page.getByRole("button", { name: "Create new", exact: true });
   await scratch.waitFor({ state: "visible" });
   await scratch.click();
   const nameField = page.getByPlaceholder("e.g. Product manager, Sales, Jerry");

--- a/packages/web/e2e/team-settings-manager.spec.ts
+++ b/packages/web/e2e/team-settings-manager.spec.ts
@@ -212,9 +212,13 @@ test("the team's shared context leads its settings and saves into the layout", a
   ).toBeVisible();
 
   const box = screen(page).getByTestId("team-context-input");
-  await expect(box).toHaveValue("Payroll runs on the 25th.");
+  await expect(box).toHaveText("Payroll runs on the 25th.");
 
-  await box.fill("Payroll runs on the 25th. Never guess an amount.");
+  await box.click();
+  await page.keyboard.press("ControlOrMeta+A");
+  await box.pressSequentially(
+    "Payroll runs on the 25th. Never guess an amount.",
+  );
   await box.blur();
 
   // The write lands on the group the card names, and touches no other group.
@@ -266,10 +270,10 @@ test("the member EDITS the agent they manage and reads the other one read-only",
   await openJobDescription(page, "Payroll Bot");
   const jobBox = () => page.getByLabel("Job description");
   await expect(jobBox()).toBeEditable();
-  await expect(jobBox()).toHaveAttribute(
-    "placeholder",
-    "Write instructions for your agent…",
-  );
+  await expect(jobBox()).toHaveAttribute("contenteditable", "true");
+  await expect(
+    page.getByText("Write instructions for your agent…"),
+  ).toBeVisible();
 
   // Back to the team, then into an agent of the SAME team they only use: the
   // page is reachable (it is honest — they can see what the agent is told) and
@@ -286,6 +290,9 @@ test("the member EDITS the agent they manage and reads the other one read-only",
   await expect(picker).toHaveCount(0);
   await openJobDescription(page, "Payroll Helper");
   await expect(jobBox()).not.toBeEditable();
+  await expect(jobBox()).toHaveAttribute("contenteditable", "false");
   // The locked face drops the write invitation — the user-visible tell.
-  await expect(jobBox()).not.toHaveAttribute("placeholder");
+  await expect(
+    page.getByText("Write instructions for your agent…"),
+  ).toHaveCount(0);
 });

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -42,6 +42,8 @@
     "@tanstack/query-async-storage-persister": "5.101.2",
     "@tanstack/react-query": "5.101.2",
     "@tanstack/react-query-persist-client": "5.101.2",
+    "@tiptap/react": "3.29.1",
+    "@tiptap/starter-kit": "3.29.1",
     "ajv": "8.20.0",
     "firebase": "11.10.0",
     "i18next": "26.3.4",
@@ -52,6 +54,7 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-i18next": "17.0.8",
+    "tiptap-markdown": "0.9.0",
     "zustand": "5.0.14"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,12 @@ importers:
       '@tauri-apps/plugin-updater':
         specifier: 2.10.1
         version: 2.10.1
+      '@tiptap/react':
+        specifier: 3.29.1
+        version: 3.29.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tiptap/starter-kit':
+        specifier: 3.29.1
+        version: 3.29.1
       ajv:
         specifier: 8.20.0
         version: 8.20.0
@@ -246,6 +252,9 @@ importers:
       tauri-plugin-sentry-api:
         specifier: 0.5.0
         version: 0.5.0
+      tiptap-markdown:
+        specifier: 0.9.0
+        version: 0.9.0(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))
       zustand:
         specifier: 5.0.14
         version: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
@@ -672,6 +681,12 @@ importers:
       '@tanstack/react-query-persist-client':
         specifier: 5.101.2
         version: 5.101.2(@tanstack/react-query@5.101.2(react@19.2.7))(react@19.2.7)
+      '@tiptap/react':
+        specifier: 3.29.1
+        version: 3.29.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tiptap/starter-kit':
+        specifier: 3.29.1
+        version: 3.29.1
       ajv:
         specifier: 8.20.0
         version: 8.20.0
@@ -702,6 +717,9 @@ importers:
       react-i18next:
         specifier: 17.0.8
         version: 17.0.8(i18next@26.3.4(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      tiptap-markdown:
+        specifier: 0.9.0
+        version: 0.9.0(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))
       zustand:
         specifier: 5.0.14
         version: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
@@ -4207,6 +4225,156 @@ packages:
   '@tauri-apps/plugin-updater@2.10.1':
     resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
+  '@tiptap/core@3.29.2':
+    resolution: {integrity: sha512-oKUkiPUB7noilVYxI9lNzUD4rX17sHub+PYjMfHMWHG9A3nvIy+FdePIVIIhThKWF7ijhr3eIqHY51Bn+GAFtw==}
+    peerDependencies:
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-blockquote@3.29.2':
+    resolution: {integrity: sha512-ca4OzKDh0yaxg2+Z56bC2QnWsNsFp2YMRfVig1PDXyMVFMNJpLcnhxgq/9btn+xYAlYrj8RymOeCTYREOR6Zjg==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-bold@3.29.2':
+    resolution: {integrity: sha512-elYbGxJsYnBb4leqrcjdIJuiG380BcOgN+UUzvOv+qEjfGVzHodFOMBl3qnmD6urYHNu5/qQK2S0qSSRXKCLNQ==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+
+  '@tiptap/extension-bubble-menu@3.29.2':
+    resolution: {integrity: sha512-kzcWarcpr031rZu+R3Hzut5uxb3Qj/xxMDEYZIQ3uiq1yb5vEMXj8/SIyWautk6Nu8Rr1leV3rGdR4NzhzyFAA==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-bullet-list@3.29.2':
+    resolution: {integrity: sha512-3bWcCUPbCHv0XttlMdnAtXLNYWx2pblByMgxmGsaP9FU0QnslGXty6A6gHCqI33ygRg1vrA6U5Wtpwbi5aKu5g==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.29.2
+
+  '@tiptap/extension-code-block@3.29.2':
+    resolution: {integrity: sha512-w153ct8g6dLiPTdXQ6SOIMxX4SEo5Q50AmjdEEEcJ7ZcYUcde/ScSskLHfOYmyt5ZFAiyEwr121+pux+p3/oAQ==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-code@3.29.2':
+    resolution: {integrity: sha512-c6W5UGuB7WNLpYocsgRzpO2OOTI4QjaI9jjHRMuty9z+s9DtaYM/HrRLNwVh6MopkHb+i/89Wkv8gCS34fftig==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+
+  '@tiptap/extension-document@3.29.2':
+    resolution: {integrity: sha512-YUamvefLnsqu6124GavVTI7nqcFlQJ12ROB0oSwG69eSBZYNjg1tIs05LFrBxkwf4Xgqd6YzfJ9+FeG428RvzQ==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+
+  '@tiptap/extension-dropcursor@3.29.2':
+    resolution: {integrity: sha512-KKno7cU9r1HdR48CRrsDu69/1UjZdoslq/UcE+Kx+tdhAv/aljXMkRSNzGMrBNOBDmHRgS1+58zm21WQWdQzwA==}
+    peerDependencies:
+      '@tiptap/extensions': 3.29.2
+
+  '@tiptap/extension-floating-menu@3.29.2':
+    resolution: {integrity: sha512-CBTq4Xs5aGWr65uFCIkKBms796OhmirWf/ax//iJ4fl9IfwqjwFuc2vQs9PmuwpKn9ctDHo2sMTtvyeCvIt5LQ==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': 3.29.2
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-gapcursor@3.29.2':
+    resolution: {integrity: sha512-8Q39UR4/Tit759IeW9xZIe3NMwN11GsuA3FLheDyyGn7RrW02HD3HhUDlazE54Ki4HoosjFmChPlN4Ik2ubdRQ==}
+    peerDependencies:
+      '@tiptap/extensions': 3.29.2
+
+  '@tiptap/extension-hard-break@3.29.2':
+    resolution: {integrity: sha512-eUW3LN3fq8rXnjEUeI3D2QONYdLsU3yYQm4jxlErs2h4cfwrFjgf19VSUFVmm6LrFbbQ0OnDVPeVLL6iOwDw2w==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+
+  '@tiptap/extension-heading@3.29.2':
+    resolution: {integrity: sha512-6W4aIy70Mh7BNlbG9zZ5FBLhJhU2UUEzgZJ/jwYSCcB30o8McLxJSEjhtoHiX8R78Ah2/JzBGvIe5olZlbeE4A==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+
+  '@tiptap/extension-horizontal-rule@3.29.2':
+    resolution: {integrity: sha512-8/ZPzbB9X85Mc9/7xVLZupQKBr2UVcQTGr512xtqMW+XkCQRHCph46tRo828YE13IMWI5fWn/FaNCqXG9cULSw==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-italic@3.29.2':
+    resolution: {integrity: sha512-iH63V/5wsaMnY4Jz0+meaAGhaec4AiOzOduzl6ZZr5IyGhZ1kthyW84ELt0dyLI3hNceAUhaNWc+I7+vX0aoXA==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+
+  '@tiptap/extension-link@3.29.2':
+    resolution: {integrity: sha512-DcVer5SqrexKCEP6Ip1UPxJUMvcRCCItSv0wxoGytanrimBh2smvcg6X0DWnjlsi5H0updhyl+atYCmmQXUIXA==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-list-item@3.29.2':
+    resolution: {integrity: sha512-s8vBVHHFT0Qpu7CzAZ7S1kYmSiVaDvUNvMNcZUWnxj6VPfiwmx0eXd9FsjePrRCMoM5tFmPnhFTHDxY3D/eZeQ==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.29.2
+
+  '@tiptap/extension-list-keymap@3.29.2':
+    resolution: {integrity: sha512-R+3k8OLnxdCH7Xy9ieOwUt5m2Je74u8mikothGmsYVO2Zyq48fIbmZ+X6RBPCu7DBOI2FIUhHEFbKQeDWvDNmA==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.29.2
+
+  '@tiptap/extension-list@3.29.2':
+    resolution: {integrity: sha512-WPZ9BHAPT6QeIm1vdVkuoOWvy9a8/EZeJwV2VhU8LXyTAttvzyj4rsbbHyJWvYWlUSTt/QF2AZ2zhKo7u1w3/A==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-ordered-list@3.29.2':
+    resolution: {integrity: sha512-ndCunC+UsYOpkOtL7vGnDz21UNa45WUlcO9wMT1fbuYow2QnRhsuMlCWENXI52YPPARWuQ0RDgN7q6TaxPERBg==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.29.2
+
+  '@tiptap/extension-paragraph@3.29.2':
+    resolution: {integrity: sha512-7qJj5YTr11vvjNgjDN1ypOfwTovc0QOCYcit/rskeuVgnmQZOZQzC/BbyKLLG7UGnpRLemU/mEGbW9pAqjAXkQ==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+
+  '@tiptap/extension-strike@3.29.2':
+    resolution: {integrity: sha512-aEvLAbddUQZ+FukCreV3q4G2HfNI+odE7E9U+wbq6XsSWKyo8/pDu1muz+TFKNre4blSMOQ3JQmw5UeHDKy+fg==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+
+  '@tiptap/extension-text@3.29.2':
+    resolution: {integrity: sha512-Ubko45JWWHe8glBt2PiGNF8hcbys/JNalFhiR7Y1X4iOOtAxAKJJxh3+eq+//NTlGuBPdWGp7zw8EEUp7anjKA==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+
+  '@tiptap/extension-underline@3.29.2':
+    resolution: {integrity: sha512-K7XwH/xS/5AIREWQ00VTEf/W5U0olp7j6wwit7cdd/8nHv6h6AGr1+iEApHKoLXWQZLfGQKzJlT9W61LAl+fHA==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+
+  '@tiptap/extensions@3.29.2':
+    resolution: {integrity: sha512-BCz+FCAChSYtUe4BFj97HEO+nSK+J7GxbJgZG4Hg7DT/gI+hRyeNndU8efiQAx3WGdzsFi3UxRpcF1tTQM7iMQ==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/pm@3.29.2':
+    resolution: {integrity: sha512-GCOme7xHaS+DSoaA4CDcAD3l6JyBlvZhvCyfsy2Vp6j8tEoBkZWio7soYVosmlyn7zq8/64VeFZP5s47yfG7fQ==}
+
+  '@tiptap/react@3.29.1':
+    resolution: {integrity: sha512-wiaLIUOBWB8j2IzYTWoBelDBXX3kKfU1Sh+UdjYIvk7as8DZniLW7Uw0z1hBFreU8PU/RtA10kWsnICGuaKOyQ==}
+    peerDependencies:
+      '@tiptap/core': 3.29.1
+      '@tiptap/pm': 3.29.1
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tiptap/starter-kit@3.29.1':
+    resolution: {integrity: sha512-n7njOpcJJd4L3Ma1UmipwwL7gilJ8PZHCNHNhCY+jlemRp8sGf3WoMJst4FKAqU15QaYWhQpYYgc0TWQ55Z04g==}
+
   '@tootallnate/once@2.0.1':
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
@@ -4349,8 +4517,26 @@ packages:
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
 
+  '@types/linkify-it@3.0.5':
+    resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@13.0.9':
+    resolution: {integrity: sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@1.0.5':
+    resolution: {integrity: sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -4386,6 +4572,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -5136,6 +5325,10 @@ packages:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
@@ -5246,6 +5439,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.1:
+    resolution: {integrity: sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ==}
+    engines: {node: '>=6.0.0'}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -5920,6 +6117,12 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
+  linkifyjs@4.3.3:
+    resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
+
   lint-staged@17.0.8:
     resolution: {integrity: sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==}
     engines: {node: '>=22.22.1'}
@@ -5970,6 +6173,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-it-task-lists@2.1.1:
+    resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
+
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -6061,6 +6271,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -6408,6 +6621,9 @@ packages:
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -6556,6 +6772,48 @@ packages:
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
+  prosemirror-changeset@2.4.1:
+    resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
+
+  prosemirror-commands@1.7.2:
+    resolution: {integrity: sha512-q6Q6szxqdu9Xd6EcdKsqXghu5nQdZTpB4Q9yd04WRc7/jt763e/rT60Owh0L1GYY+T46o5rD+9lEN36dZS43tw==}
+
+  prosemirror-dropcursor@1.8.3:
+    resolution: {integrity: sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==}
+
+  prosemirror-gapcursor@1.4.1:
+    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-inputrules@1.5.1:
+    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-markdown@1.13.5:
+    resolution: {integrity: sha512-ac8trNQ01ybKDRTcfUc56LZufG3oYyU4N25qSXgp8dS0U4JtzzCj7oQlKu5v09VSmS5IseYoQ2yDkTbo7f7D8Q==}
+
+  prosemirror-model@1.25.11:
+    resolution: {integrity: sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+
+  prosemirror-transform@1.12.0:
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
+
+  prosemirror-view@1.42.2:
+    resolution: {integrity: sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==}
+
   protobufjs@7.6.5:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
@@ -6566,6 +6824,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
@@ -6792,6 +7054,9 @@ packages:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
@@ -7115,6 +7380,11 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tiptap-markdown@0.9.0:
+    resolution: {integrity: sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.0.1
+
   tldts-core@7.4.8:
     resolution: {integrity: sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==}
 
@@ -7258,6 +7528,9 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -7463,6 +7736,9 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -10945,6 +11221,179 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.1
 
+  '@tiptap/core@3.29.2(@tiptap/pm@3.29.2)':
+    dependencies:
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-blockquote@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-bold@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-bubble-menu@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+      '@tiptap/pm': 3.29.2
+    optional: true
+
+  '@tiptap/extension-bullet-list@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-code-block@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-code@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-document@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-dropcursor@3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/extensions': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-floating-menu@3.29.2(@floating-ui/dom@1.7.6)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+      '@tiptap/pm': 3.29.2
+    optional: true
+
+  '@tiptap/extension-gapcursor@3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/extensions': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-hard-break@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-heading@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-horizontal-rule@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-italic@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-link@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+      '@tiptap/pm': 3.29.2
+      linkifyjs: 4.3.3
+
+  '@tiptap/extension-list-item@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-list-keymap@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-ordered-list@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-paragraph@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-strike@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-text@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-underline@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+
+  '@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/pm@3.29.2':
+    dependencies:
+      prosemirror-changeset: 2.4.1
+      prosemirror-commands: 1.7.2
+      prosemirror-dropcursor: 1.8.3
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.11
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.2
+
+  '@tiptap/react@3.29.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+      '@tiptap/pm': 3.29.2
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/use-sync-external-store': 0.0.6
+      fast-equals: 5.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@tiptap/extension-bubble-menu': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-floating-menu': 3.29.2(@floating-ui/dom@1.7.6)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+    transitivePeerDependencies:
+      - '@floating-ui/dom'
+
+  '@tiptap/starter-kit@3.29.1':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+      '@tiptap/extension-blockquote': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-bold': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))
+      '@tiptap/extension-bullet-list': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
+      '@tiptap/extension-code': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))
+      '@tiptap/extension-code-block': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-document': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))
+      '@tiptap/extension-dropcursor': 3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
+      '@tiptap/extension-gapcursor': 3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
+      '@tiptap/extension-hard-break': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))
+      '@tiptap/extension-heading': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))
+      '@tiptap/extension-horizontal-rule': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-italic': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))
+      '@tiptap/extension-link': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-list-item': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
+      '@tiptap/extension-list-keymap': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
+      '@tiptap/extension-ordered-list': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
+      '@tiptap/extension-paragraph': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))
+      '@tiptap/extension-strike': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))
+      '@tiptap/extension-text': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))
+      '@tiptap/extension-underline': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))
+      '@tiptap/extensions': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/pm': 3.29.2
+
   '@tootallnate/once@2.0.1': {}
 
   '@types/babel__core@7.20.5':
@@ -11116,9 +11565,27 @@ snapshots:
 
   '@types/katex@0.16.8': {}
 
+  '@types/linkify-it@3.0.5': {}
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@13.0.9':
+    dependencies:
+      '@types/linkify-it': 3.0.5
+      '@types/mdurl': 1.0.5
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdurl@1.0.5': {}
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/ms@2.1.0': {}
 
@@ -11156,6 +11623,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -11910,6 +12379,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  entities@4.5.0: {}
+
   entities@6.0.1: {}
 
   entities@8.0.0: {}
@@ -12068,6 +12539,8 @@ snapshots:
       pure-rand: 8.4.2
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.4.1: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -12891,6 +13364,12 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
+  linkifyjs@4.3.3: {}
+
   lint-staged@17.0.8:
     dependencies:
       listr2: 10.2.2
@@ -12945,6 +13424,17 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-it-task-lists@2.1.1: {}
+
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
 
@@ -13144,6 +13634,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.27.1: {}
+
+  mdurl@2.1.0: {}
 
   media-typer@1.1.0: {}
 
@@ -13603,6 +14095,8 @@ snapshots:
 
   openapi-types@12.1.3: {}
 
+  orderedmap@2.1.1: {}
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -13757,6 +14251,86 @@ snapshots:
 
   property-information@7.2.0: {}
 
+  prosemirror-changeset@2.4.1:
+    dependencies:
+      prosemirror-transform: 1.12.0
+
+  prosemirror-commands@1.7.2:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-dropcursor@1.8.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.2
+
+  prosemirror-gapcursor@1.4.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.42.2
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.2
+      rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-markdown@1.13.5:
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.3.0
+      prosemirror-model: 1.25.11
+
+  prosemirror-model@1.25.11:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.2
+
+  prosemirror-tables@1.8.5:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.2
+
+  prosemirror-transform@1.12.0:
+    dependencies:
+      prosemirror-model: 1.25.11
+
+  prosemirror-view@1.42.2:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
   protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -13777,6 +14351,8 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@1.1.0: {}
+
+  punycode.js@2.3.1: {}
 
   punycode@1.4.1: {}
 
@@ -14120,6 +14696,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.62.2
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
+
+  rope-sequence@1.3.4: {}
 
   roughjs@4.6.6:
     dependencies:
@@ -14533,6 +15111,14 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tiptap-markdown@0.9.0(@tiptap/core@3.29.2(@tiptap/pm@3.29.2)):
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+      '@types/markdown-it': 13.0.9
+      markdown-it: 14.3.0
+      markdown-it-task-lists: 2.1.1
+      prosemirror-markdown: 1.13.5
+
   tldts-core@7.4.8: {}
 
   tldts@7.4.8:
@@ -14627,6 +15213,8 @@ snapshots:
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  uc.micro@2.1.0: {}
 
   undici-types@6.21.0: {}
 
@@ -14922,6 +15510,8 @@ snapshots:
       - yaml
 
   void-elements@3.1.0: {}
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## What

The ONE standing-context editor (Company context, About me, agent Job description, team context card) becomes a Notion-style markdown WYSIWYG:

- **MarkdownEditor** (TipTap v3 + tiptap-markdown): typing shortcuts render live; content stays plain markdown on the wire, so agents read exactly the files they always did. The empty box shows the greyed example RENDERED as real muted headings.
- **Always-visible formatting bar** (heading/subheading/bold/italic/lists/quote) — no markdown knowledge required; the Saving/Saved status sits in its right seat.
- **Document card**: hairline-free `bg-card` surface with the field border, 16px document type scale; full-page surfaces PIN the card to a fixed bottom gap (longer docs scroll inside it), compact cards keep a rows floor (explicit `layout` union).
- **Corruption guard**: documents carrying markdown the schema can't hold (tables, raw HTML, task lists, images, frontmatter — agents write these) open in a byte-preserving plain-text fallback, decided by a unit-tested `isWysiwygSafe`.
- **Save integrity**: one ordered write queue (blur, unmount flush, read-only flush) with dedupe/retry; external updates arriving mid-edit are held and applied at blur; TipTap callbacks read through a latest-ref (its handlers bind once).

## Review + verification

Two adversarial reviewers (Codex + Claude) + a Codex verification pass on the fixes; all accepted findings fixed, including the corruption blocker and three save-lifecycle races. Also repairs main's own e2e helpers broken by the create-chooser redesign ('Create new agent' → the shipped 'Create new').

Gates: 3389 unit tests, 297 Playwright e2e, 8 visual baselines (unchanged), app/ui/web/e2e typechecks, locale parity (en/es/pt) — all green post-rebase. Verified in-app by Julian. Known upstream flake (not this PR): sidebar-dnd reorder geometry, reproducible on pristine main (macOS).

No Linear issue — WYSIWYG editing requested directly in session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)