### PR TITLE
fix(integrations): secure API-key card dead-ended on unknown slugs (PRODUCT-1292)

### DIFF
--- a/app/src/components/chat-credential-interaction-card.tsx
+++ b/app/src/components/chat-credential-interaction-card.tsx
@@ -110,6 +110,15 @@ export function ChatCredentialInteractionCard({
 
   const view = list.data?.find((v) => v.slug === toolkit);
   const name = view?.name ?? toolkit;
+  // The step's slug resolves to NO registered integration (PRODUCT-1292): a
+  // key typed here has nowhere to go — every save 404ed while the card looked
+  // perfectly savable. Render the honest dead-end (Skip resumes the agent,
+  // which re-runs the setup) instead of a doomed form. Gated on a SETTLED
+  // list: while the list is loading or refetching (a just-added definition
+  // races the 30s cache) the optimistic fallback form stays, matching the
+  // form's "never block the user on the lookup" contract. `data === null`
+  // (the host doesn't serve the feature) keeps the legacy fallback too.
+  const missing = list.data != null && !list.isFetching && !view;
   // A sign-in (oauth) integration renders the SAME step as a Sign in card:
   // no key form — the button opens the service's own browser sign-in
   // (PRODUCT-1172), and the step completes itself when the grant lands.
@@ -230,6 +239,10 @@ export function ChatCredentialInteractionCard({
               </p>
             )}
           </div>
+        ) : missing ? (
+          <p className="text-balance text-ink text-sm leading-snug">
+            {t("credential.missingBody", { name })}
+          </p>
         ) : (
           <div className="flex flex-col gap-1.5">
             <p className="text-balance text-ink text-sm leading-snug">
@@ -261,7 +274,7 @@ export function ChatCredentialInteractionCard({
               label={t("interaction.skip")}
               onClick={() => onSkip(name, mode)}
             />
-            {oauth ? (
+            {missing ? null : oauth ? (
               <Button
                 className="gap-1.5"
                 disabled={signIn.isPending}

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -283,6 +283,7 @@
   "credential": {
     "title": "Add your {{name}} key",
     "subtitle": "Paste it below. It is stored securely and never shown in chat.",
+    "missingBody": "{{name}} isn't set up yet, so there's nowhere to save this key. Choose Skip to continue and it will be set up properly first.",
     "save": "Save key",
     "saving": "Saving...",
     "saved": "Key saved",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -283,6 +283,7 @@
   "credential": {
     "title": "Agrega tu clave de {{name}}",
     "subtitle": "Pégala abajo. Se guarda de forma segura y nunca se muestra en el chat.",
+    "missingBody": "{{name}} aún no está configurado, así que no hay dónde guardar esta clave. Elige Omitir para continuar y que primero se configure bien.",
     "save": "Guardar clave",
     "saving": "Guardando...",
     "saved": "Clave guardada",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -283,6 +283,7 @@
   "credential": {
     "title": "Adicione sua chave de {{name}}",
     "subtitle": "Cole abaixo. Ela é armazenada com segurança e nunca aparece no chat.",
+    "missingBody": "{{name}} ainda não está configurado, então não há onde salvar esta chave. Escolha Pular para continuar e configurá-lo direito primeiro.",
     "save": "Salvar chave",
     "saving": "Salvando...",
     "saved": "Chave salva",

--- a/packages/host/src/routes/custom-integrations.test.ts
+++ b/packages/host/src/routes/custom-integrations.test.ts
@@ -384,3 +384,42 @@ test("sandbox remove: relays manager.remove by slug; 400 on a missing slug", asy
     server.close();
   }
 });
+
+test("sandbox status: the request_credential pre-flight (PRODUCT-1292) — view for a known slug, 404 not_found for an unknown one, 400 on a missing slug", async () => {
+  const manager = fakeManager();
+  const { server, base } = await startServer({
+    customIntegrations: manager,
+    vault,
+  });
+  try {
+    const sb = vault.sandboxToken("W1", "W1/Assistant");
+    const post = (body: unknown) =>
+      fetch(`${base}/sandbox/integrations/custom/status`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${sb}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+    const known = await post({ slug: "acme" });
+    expect(known.status).toBe(200);
+    expect(await known.json()).toEqual(VIEW);
+
+    // The exact family the users hit: a slug the agent invented (or whose add
+    // failed) has NO definition — the tool must hear a clean not_found instead
+    // of queueing a card whose every save dead-ends.
+    const unknown = await post({ slug: "typeform" });
+    expect(unknown.status).toBe(404);
+    expect(await unknown.json()).toEqual({
+      error: "no custom integration 'typeform'",
+      code: "not_found",
+    });
+
+    const missing = await post({});
+    expect(missing.status).toBe(400);
+  } finally {
+    server.close();
+  }
+});

--- a/packages/host/src/routes/custom-integrations.ts
+++ b/packages/host/src/routes/custom-integrations.ts
@@ -155,7 +155,7 @@ export async function handleSandboxCustomIntegrations(
   res: ServerResponse,
 ): Promise<boolean> {
   const m = path.match(
-    /^\/sandbox\/integrations\/custom\/(detect|add|remove)$/,
+    /^\/sandbox\/integrations\/custom\/(detect|add|remove|status)$/,
   );
   if (!m || method !== "POST") return false;
 
@@ -184,6 +184,27 @@ export async function handleSandboxCustomIntegrations(
         return true;
       }
       json(res, 200, await manager.detect(body.url.trim()));
+      return true;
+    }
+    // The pre-flight behind `request_credential` (PRODUCT-1292): the runtime
+    // refuses to queue a secure key card for a slug with no definition — the
+    // card used to render anyway and every save 404ed at this host, a
+    // user-facing dead end the agent never heard about.
+    if (m[1] === "status") {
+      if (typeof body.slug !== "string" || !body.slug.trim()) {
+        json(res, 400, { error: "missing 'slug'" });
+        return true;
+      }
+      const slug = body.slug.trim();
+      const view = (await manager.list()).find((v) => v.slug === slug);
+      if (!view) {
+        json(res, 404, {
+          error: `no custom integration '${slug}'`,
+          code: "not_found",
+        });
+        return true;
+      }
+      json(res, 200, view);
       return true;
     }
     // The agent's cleanup path (PRODUCT-1172 follow-up): switching a service

--- a/packages/runtime/src/session/tools/custom-integrations.ts
+++ b/packages/runtime/src/session/tools/custom-integrations.ts
@@ -2,6 +2,7 @@ import { defineTool } from "@earendil-works/pi-coding-agent";
 import { type Static, Type } from "typebox";
 import { assertNotPlanMode } from "../live-mode-gate";
 import {
+  type CredentialTargetStatus,
   makeRequestCredentialTool,
   REQUEST_CREDENTIAL_TOOL_NAME,
 } from "./request-credential";
@@ -105,7 +106,7 @@ export function makeCustomIntegrationTools(opts: CustomIntegrationToolOptions) {
   const base = opts.baseUrl.replace(/\/$/, "");
 
   async function post<T>(
-    path: "detect" | "add" | "remove",
+    path: "detect" | "add" | "remove" | "status",
     body: unknown,
     signal: AbortSignal | undefined,
   ): Promise<T> {
@@ -255,7 +256,36 @@ export function makeCustomIntegrationTools(opts: CustomIntegrationToolOptions) {
     },
   });
 
-  return [detect, add, remove, makeRequestCredentialTool()];
+  return [
+    detect,
+    add,
+    remove,
+    makeRequestCredentialTool({
+      // The pre-flight lookup (PRODUCT-1292): resolve the slug on the host
+      // before a secure card is queued. 404 = no such definition (`null`, the
+      // tool refuses with guidance); any other failure relays like the
+      // sibling calls so the model hears the real reason.
+      async status(slug, signal) {
+        const res = await fetch(`${base}/sandbox/integrations/custom/status`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${opts.sandboxToken}`,
+          },
+          body: JSON.stringify({ slug }),
+          signal,
+        });
+        if (res.status === 404) return null;
+        if (!res.ok) {
+          const detail = await res.text().catch(() => "");
+          throw new Error(
+            `custom integration status failed (${res.status}): ${detail.slice(0, 300)}`,
+          );
+        }
+        return (await res.json()) as CredentialTargetStatus;
+      },
+    }),
+  ];
 }
 
 /** The tool names — pi's allowlist needs the names alongside the objects. */

--- a/packages/runtime/src/session/tools/request-credential.test.ts
+++ b/packages/runtime/src/session/tools/request-credential.test.ts
@@ -1,0 +1,106 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { expect, test, vi } from "vitest";
+import {
+  newInteractionHolder,
+  runWithInteractionCapture,
+} from "../interaction";
+import {
+  type CredentialTargetStatus,
+  makeRequestCredentialTool,
+  REQUEST_CREDENTIAL_TOOL_NAME,
+} from "./request-credential";
+
+/**
+ * The secure key-entry hand-off tool, with its PRODUCT-1292 pre-flight: a
+ * credential step is recorded ONLY for a slug the host actually has a
+ * definition for. Before the check, a model-invented slug (or one whose add
+ * failed) queued a card that rendered fine while every save 404ed — a
+ * user-facing dead end the agent never heard about ("Save key" looked like it
+ * did nothing).
+ */
+
+const ctx = {} as unknown as ExtensionContext;
+
+function toolWith(
+  status: (
+    slug: string,
+    signal: AbortSignal | undefined,
+  ) => Promise<CredentialTargetStatus | null>,
+) {
+  const tool = makeRequestCredentialTool({ status });
+  return (params: unknown) =>
+    tool.execute("id", params as never, undefined, undefined, ctx);
+}
+
+test("is named request_credential", () => {
+  expect(makeRequestCredentialTool({ status: async () => null }).name).toBe(
+    REQUEST_CREDENTIAL_TOOL_NAME,
+  );
+});
+
+test("records the credential step for a slug the host knows (normalized to lower case)", async () => {
+  const status = vi.fn(
+    async (): Promise<CredentialTargetStatus | null> => ({
+      state: { status: "pending" },
+    }),
+  );
+  const run = toolWith(status);
+  const holder = newInteractionHolder();
+  const out = await runWithInteractionCapture(holder, () =>
+    run({ toolkit: "  Acme_CRM ", reason: "To sync your records." }),
+  );
+  expect(status).toHaveBeenCalledWith("acme_crm", undefined);
+  expect(holder.pending).toEqual({
+    steps: [
+      {
+        kind: "credential",
+        id: "k1",
+        toolkit: "acme_crm",
+        reason: "To sync your records.",
+      },
+    ],
+  });
+  const text = (out.content[0] as { text: string }).text;
+  expect(text).toMatch(/end your turn/i);
+});
+
+test("refuses a slug with NO definition — the exact PRODUCT-1292 family — and records nothing", async () => {
+  const run = toolWith(async () => null);
+  const holder = newInteractionHolder();
+  await expect(
+    runWithInteractionCapture(holder, () => run({ toolkit: "typeform" })),
+  ).rejects.toThrow(/No custom integration 'typeform'/);
+  await expect(
+    runWithInteractionCapture(holder, () => run({ toolkit: "typeform" })),
+  ).rejects.toThrow(/custom_integration_add/);
+  expect(holder.pending).toBeUndefined();
+});
+
+test("refuses a definition in error state with the repair path and records nothing", async () => {
+  const run = toolWith(async () => ({
+    state: { status: "error", message: "spec failed to compile" },
+  }));
+  const holder = newInteractionHolder();
+  await expect(
+    runWithInteractionCapture(holder, () => run({ toolkit: "acme" })),
+  ).rejects.toThrow(/spec failed to compile/);
+  expect(holder.pending).toBeUndefined();
+});
+
+test("relays a lookup transport failure instead of queueing a card blind", async () => {
+  const run = toolWith(async () => {
+    throw new Error("custom integration status failed (503): not configured");
+  });
+  const holder = newInteractionHolder();
+  await expect(
+    runWithInteractionCapture(holder, () => run({ toolkit: "acme" })),
+  ).rejects.toThrow(/status failed \(503\)/);
+  expect(holder.pending).toBeUndefined();
+});
+
+test("still rejects an empty toolkit before any lookup", async () => {
+  const status = vi.fn(async () => null);
+  const run = toolWith(status);
+  await expect(run({ toolkit: "   " })).rejects.toThrow(/non-empty toolkit/);
+  expect(status).not.toHaveBeenCalled();
+});

--- a/packages/runtime/src/session/tools/request-credential.ts
+++ b/packages/runtime/src/session/tools/request-credential.ts
@@ -30,7 +30,26 @@ const CredentialParams = Type.Object({
 });
 type CredentialParams = Static<typeof CredentialParams>;
 
-export function makeRequestCredentialTool() {
+/** What the pre-flight lookup needs back from the host: the definition's
+ *  compile state (the rest of the view is irrelevant here). `null` = no
+ *  definition with that slug exists. */
+export interface CredentialTargetStatus {
+  state:
+    | { status: "active"; toolCount: number }
+    | { status: "pending" }
+    | { status: "error"; message: string };
+}
+
+export interface RequestCredentialToolOptions {
+  /** Resolve the slug against the host's registered custom integrations
+   *  (the sandbox `status` route). */
+  status: (
+    slug: string,
+    signal: AbortSignal | undefined,
+  ) => Promise<CredentialTargetStatus | null>;
+}
+
+export function makeRequestCredentialTool(opts: RequestCredentialToolOptions) {
   return defineTool({
     name: REQUEST_CREDENTIAL_TOOL_NAME,
     label: "Ask the user for an API key securely",
@@ -39,10 +58,28 @@ export function makeRequestCredentialTool() {
     promptSnippet: "Ask the user to enter a key or sign in via a secure card",
     parameters: CredentialParams,
     executionMode: "sequential",
-    async execute(_id: string, params: CredentialParams) {
+    async execute(
+      _id: string,
+      params: CredentialParams,
+      signal: AbortSignal | undefined,
+    ) {
       const toolkit = params.toolkit.trim().toLowerCase();
       if (!toolkit)
         throw new Error("request_credential needs a non-empty toolkit slug.");
+      // Pre-flight (PRODUCT-1292): a card for a slug the host has no
+      // definition for renders fine but every save 404s — a user-facing dead
+      // end. Refuse HERE, where the model can still correct course.
+      const target = await opts.status(toolkit, signal);
+      if (!target) {
+        throw new Error(
+          `No custom integration '${toolkit}' is set up, so Houston cannot show a secure entry card for it. Use the EXACT slug a custom_integration_add result returned. If this service was never added: when it exists in integration_search, connect it through the normal app connect flow instead; for a custom API or MCP server, run custom_integration_detect and custom_integration_add first, then call request_credential again.`,
+        );
+      }
+      if (target.state.status === "error") {
+        throw new Error(
+          `The custom integration '${toolkit}' is not working (${target.state.message}), so a saved key could not be used. Repair it first with custom_integration_add (replace: true) and a corrected spec, then call request_credential again.`,
+        );
+      }
       const reason = params.reason?.trim();
       recordCredentialRequest({ toolkit, ...(reason ? { reason } : {}) });
       return {

--- a/packages/web/e2e/interaction.spec.ts
+++ b/packages/web/e2e/interaction.spec.ts
@@ -1395,6 +1395,45 @@ test("declines the credential step with a typed instruction and resumes visibly"
 });
 
 /**
+ * A credential step whose slug has NO registered integration (PRODUCT-1292):
+ * the runtime now refuses to queue one, but steps already recorded in existing
+ * chats (and a definition removed mid-step) still reach the card. It must
+ * render the honest dead-end — no key field, no Save (every save 404ed while
+ * the form looked perfectly savable) — and Skip still resumes the agent.
+ */
+test("a credential step for an unknown integration shows the honest dead-end instead of a doomed form", async ({
+  page,
+  request,
+}) => {
+  // The custom list is ARMED (it resolves, with acme_crm only) — the step's
+  // 'typeform' slug is simply not in it, mirroring the field failure.
+  await armCustomIntegration(request);
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
+    data: {
+      interaction: {
+        steps: [{ kind: "credential", id: "k1", toolkit: "typeform" }],
+      },
+    },
+  });
+
+  await startMission(page, "connect Typeform");
+
+  await expect(
+    page.getByText(/typeform isn't set up yet, so there's nowhere to save/),
+  ).toBeVisible({ timeout: 15_000 });
+  // No key field and no Save CTA — the only ways out are Skip and the
+  // free-text row, both of which resume the agent.
+  await expect(page.getByRole("button", { name: "Save key" })).toHaveCount(0);
+  await expect(page.getByPlaceholder("Paste your key")).toHaveCount(0);
+
+  await page.getByRole("button", { name: /Skip/ }).click();
+  await expect(page.getByText(/Skipped adding the typeform key\./)).toBeVisible(
+    { timeout: 15_000 },
+  );
+  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
+});
+
+/**
  * Enter connects a connect step: with focus off the composer, pressing Enter
  * fires the Connect flow (mirroring the pill's return-key glyph). Integrations
  * are armed so the fake host mints a pending connection on connect; activating


### PR DESCRIPTION
## Root cause

The in-chat secure API-key card (`request_credential`) rendered a perfectly savable-looking form for toolkit slugs that have **no registered custom-integration definition** — the model can call the tool with any slug (an invented one, or one whose `custom_integration_add` failed). The card falls back to the raw slug as its title and a generic "API key" field, and every **Save key** POST then 404s at the host (`no custom integration '<slug>'`). To the user, clicking Save key "does nothing"; the agent never hears about it and keeps waiting.

Sentry confirms the family in the field: `custom_integration_credential: no custom integration 'typeform'` (the PRODUCT-1292 report), plus `'ntfy'` (10 users), `'odoo'`, and `'metaads'` (second screenshot in the issue).

## Fix (three layers)

- **Runtime — refuse at the source.** `request_credential` now pre-flights the slug against the host before recording the interaction step. An unknown slug fails the tool call with actionable guidance (use the exact slug the add returned; use the catalog connect flow for catalog apps; run detect + add first for custom services). An `error`-state definition fails with the repair path (`replace: true`). The card can no longer be queued for a slug that cannot save.
- **Host — the pre-flight surface.** New `POST /sandbox/integrations/custom/status` beside detect/add/remove (same per-sandbox HMAC auth): resolves a slug to its view, `404 {code: "not_found"}` when absent.
- **App — honest dead-end for already-recorded steps.** Steps recorded before this fix (and definitions removed mid-step) still reach the card, so when the settled integrations list has no matching slug the card now renders an honest "isn't set up yet" line with Skip (which resumes the agent) instead of a doomed key form. While the list is loading/refetching the optimistic fallback form stays, so a just-added definition racing the cache never flashes the wrong state. New `credential.missingBody` locale line in en/es/pt.

## Tests

- `packages/runtime/src/session/tools/request-credential.test.ts` (new): records on a known slug, refuses unknown/error-state slugs without recording, relays lookup transport failures, rejects empty toolkit before any lookup.
- `packages/host/src/routes/custom-integrations.test.ts`: sandbox status route — view for a known slug, 404 `not_found` for unknown, 400 on missing slug.
- `packages/web/e2e/interaction.spec.ts`: a credential step for an unknown slug shows the dead-end (no key field, no Save), and Skip resumes the agent.

Gates run: Biome clean; host vitest 1407 ✓; runtime vitest 1049 ✓; domain 193 ✓; app tsgo + check-locales + node:test ✓; web typecheck + e2e typecheck ✓; boundaries ✓; the 4 credential e2e tests ✓.

## Verify

**Before (reproduces the bug):** in a chat, get the agent to call `request_credential` with a slug that has no custom integration (the old runtime allowed it — e.g. ask it to "connect Typeform" and request a key without adding an integration). The key card renders titled with the bare slug; paste anything and click **Save key** → nothing visible happens beyond an error toast; the host log shows the 404.

**After:**
1. Same setup → the tool call now fails inline; the agent corrects course (adds the integration or uses the connect flow) and no doomed card appears.
2. Open one of the existing broken chats (typeform/metaads reports): the card shows "… isn't set up yet, so there's nowhere to save this key" with **Skip** only; Skip resumes the agent.
3. Regression: a real pending custom integration still shows the key form, and Save key stores the secret and auto-continues (covered by the e2e `renders the credential card, saves the key, and resumes the agent`).

PRODUCT-1292