### PR TITLE
fix(host): attributed Claude connect skips the pod-shared materialize (reconnect-loop fix)

### DIFF
--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -402,7 +402,10 @@ export class ProxyChannel implements RuntimeChannel {
    * refresh — the control plane is the single refresher from here on) AND push
    * it into the standing runtime, which writes the SDK's own
    * `<CLAUDE_CONFIG_DIR>/.credentials.json` (immediate connect signal) and
-   * warms the connected probe so status flips at once.
+   * warms the connected probe so status flips at once. The runtime push is
+   * SKIPPED for an attributed (acting-as) connect — the shared file is team
+   * material the runtime would refuse anyway (HOU-976), and the central store
+   * put alone is the whole connect on that arm (served access-only per turn).
    *
    * From the next serve sync onward, a MANAGED pod rides the per-turn
    * access-only path like every provider (serve.ts + routes/credential.ts):
@@ -469,6 +472,22 @@ export class ProxyChannel implements RuntimeChannel {
       // write between the probe above and this put still cannot be clobbered.
       { ifAbsent: opts?.ifAbsent, actingAs: ctx.actingAs },
     );
+    if (ctx.actingAs) {
+      // An ATTRIBUTED connect (the gateway minted acting-as for it — every
+      // proxied dispatch since cloud #208, personal spaces included) must not
+      // touch the pod-shared claude-login dir: the runtime's HOU-976 scope
+      // guard refuses the materialize, correctly, because that file is
+      // pod-wide and a second self-refreshing holder would fork the family's
+      // rotator (trap #4). Treating that refusal as a push failure was the
+      // Aug-2026 reconnect loop: the central store put above had SUCCEEDED,
+      // yet the 502 sent the desktop into retry + paste fallback, and the
+      // serial re-mints got the fresh families revoked at Anthropic
+      // (HOUSTON-APP-56F). The store put IS the connect here — the pod serves
+      // the credential access-only per turn (`CLAUDE_CODE_OAUTH_TOKEN`
+      // outranks the file inside the SDK), and the runtime's serve sync flips
+      // the scoped status connected on the next poll.
+      return;
+    }
     const endpoint = await this.opts.launcher.ensureAwake(ctx.agent);
     const res = await fetch(
       `${endpoint.baseUrl}/auth/anthropic/oauth-credential`,

--- a/packages/host/src/routes/claude-oauth.test.ts
+++ b/packages/host/src/routes/claude-oauth.test.ts
@@ -76,7 +76,10 @@ interface Fixture {
 }
 
 /** Boot a host over HTTP whose only principal is `owner`, with one agent. */
-async function boot(owner = "alice"): Promise<Fixture> {
+async function boot(
+  owner = "alice",
+  opts: { gatewayFronted?: boolean } = {},
+): Promise<Fixture> {
   const store = new MemoryWorkspaceStore({ defaultRuntime: "gke" });
   const credentials = new MemoryCredentialStore();
   const workspace = await store.getOrCreatePersonalWorkspace(owner);
@@ -90,7 +93,11 @@ async function boot(owner = "alice"): Promise<Fixture> {
     credentials,
     forwardActingHeader: true,
   });
-  const deps: AgentRouteDeps = { store, channels: { gke: channel } };
+  const deps: AgentRouteDeps = {
+    store,
+    channels: { gke: channel },
+    ...(opts.gatewayFronted ? { gatewayFronted: true } : {}),
+  };
 
   const s = createServer((req, res) => {
     const url = new URL(req.url || "/", "http://x");
@@ -132,6 +139,7 @@ function push(
   body: unknown,
   user = "alice",
   query = "",
+  headers: Record<string, string> = {},
 ) {
   return fetch(
     `${base}/agents/${encodeURIComponent(agentId)}/credential/claude-oauth${query}`,
@@ -140,6 +148,7 @@ function push(
       headers: {
         Authorization: `Bearer ${user}`,
         "Content-Type": "application/json",
+        ...headers,
       },
       body: typeof body === "string" ? body : JSON.stringify(body),
     },
@@ -164,6 +173,53 @@ describe("POST /agents/:id/credential/claude-oauth", () => {
 
       // Runtime received the CLI envelope verbatim.
       expect(lastPush).toEqual(VALID);
+    } finally {
+      fx.close();
+    }
+  });
+
+  test("attributed connect (acting-as): 200, central store write, runtime NOT touched", async () => {
+    // The gateway mints acting-as on EVERY proxied dispatch (cloud #208,
+    // personal spaces included). The runtime's HOU-976 scope guard refuses to
+    // materialize an attributed credential into the pod-shared claude-login
+    // dir — correctly — so the channel must not even try: the central store
+    // put IS the connect (served access-only per turn). Treating the refusal
+    // as a push failure was the Aug-2026 reconnect loop (HOUSTON-APP-56F):
+    // the desktop saw a 502 for a connect that had SUCCEEDED centrally.
+    const fx = await boot("alice", { gatewayFronted: true });
+    try {
+      const res = await push(fx.base, fx.agent.id, VALID, "alice", "", {
+        "x-houston-acting-as": "acting-v1.payload.sig",
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+
+      // Central store got the full credential, on the ACTING scope's row (the
+      // real gateway maps whose row it is; the memory store keys verbatim)…
+      const cred = await fx.credentials.get(fx.workspace.id, "anthropic", {
+        actingAs: "acting-v1.payload.sig",
+      });
+      expect(cred?.accessToken).toBe("sk-ant-oat-ACCESS-SECRET");
+      expect(cred?.refreshToken).toBe("sk-ant-ort-REFRESH-SECRET");
+
+      // …and the runtime's materialize endpoint was never called.
+      expect(lastPush).toBeNull();
+    } finally {
+      fx.close();
+    }
+  });
+
+  test("attributed connect succeeds even when the runtime would reject", async () => {
+    // Same arm, runtime broken: the skip means the connect no longer depends
+    // on the runtime accepting anything.
+    accept = false;
+    const fx = await boot("alice", { gatewayFronted: true });
+    try {
+      const res = await push(fx.base, fx.agent.id, VALID, "alice", "", {
+        "x-houston-acting-as": "acting-v1.payload.sig",
+      });
+      expect(res.status).toBe(200);
+      expect(lastPush).toBeNull();
     } finally {
       fx.close();
     }


### PR DESCRIPTION
## The bug (HOUSTON-APP-56F — 64 users since Aug 5, incl. two internal reports)

Users connecting their Claude (Anthropic) subscription to a cloud agent got stuck in a **disconnect → reconnect → disconnect loop**: the connect dialog failed with "try connecting again", every retry failed the same way, and turns died with `401 OAuth access token has been revoked`.

## Root cause chain (verified live on prod)

1. Since cloud #208 (deployed ~Aug 4-5) the gateway mints an **acting-as identity on every proxied dispatch — personal spaces included**.
2. The pod host's `POST /agents/:id/credential/claude-oauth` route stores the pushed credential centrally (**succeeds**), then forwards the materialize POST to the runtime **with the acting-as header**.
3. The runtime's HOU-976 scope guard **refuses** to write an attributed credential into the pod-shared `claude-login` dir (correct: pod-wide file + second rotator). Reproduced live: the same POST returns 200 without the header, 500 with it.
4. The channel treated that refusal as a push failure → **502 for a connect that had already succeeded centrally**. The desktop retried (re-pushing the same snapshot), then degraded to the paste flow; users cycled the carousel re-minting OAuth families until Anthropic revoked them — the runtime's revoked-report then deleted the fresh row (digest-matched, seen in gateway logs at 23:44:42Z last night for one affected user), closing the loop.

## The fix

An **attributed** connect now ends at the central store put — that IS the connect on this arm:
- the pod serves the credential access-only per turn (`CLAUDE_CODE_OAUTH_TOKEN` outranks the materialized file inside the SDK),
- the runtime's serve sync + `credentialUsable` flip the scoped status to connected on the next poll, so the desktop's settle probe (HOU-1143) confirms and announces success.

Unattributed connects (desktop self-host, setup runtime, legacy) keep the dual write unchanged.

## Tests
- `claude-oauth.test.ts`: attributed connect → 200, central store written on the acting scope, runtime materialize **never called**; and succeeds even when the runtime would reject.
- Full `@houston/host` + `@houston/runtime` + `@houston/domain` suites green; Biome + typecheck clean.

## Follow-ups (not in this PR)
- The paste-flow capture race: `completeLogin` is fire-and-forget, so the desktop's immediate `credential/capture` 400s ("agent is not connected yet") and the scrub never runs — leaves a refresh-bearing credential on the pod (second-rotator risk).
- Desktop `pushClaudeCredentialWithRetry` re-pushes the same minted snapshot on 5xx; after a partial success that's a clobber risk (HOU-855 class).
- Engine pods log `spawn claude ENOENT` every minute (status probe binary missing from the engine-pod image) — noisy, masked by the serve path.