### PR TITLE
fix(runtime): classify Envoy upstream-connect/idle-timeout errors as provider_internal (HOUSTON-APP-4Y9)

### DIFF
--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -606,6 +606,68 @@ test("other observed close codes classify the same way", () => {
   }
 });
 
+// Envoy's canonical no-upstream-response body: a proxy on the pod↔provider
+// path answers for an upstream whose connection died before response headers —
+// flattened by the Codex path to the bare body, no status (HOUSTON-APP-4Y9's
+// verbatim report; 670 Sentry events across 151 users read as `unknown`).
+// Transient, and Envoy already retried ("retried and the latest reset
+// reason…"); like the WebSocket break above, every production event comes from
+// a cloud engine pod, so provider_internal (Retry card) — never the report-bug
+// `unknown`, never check-your-connection.
+test("envoy 'upstream connect error … connection termination' → provider_internal, not unknown (HOUSTON-APP-4Y9)", () => {
+  const err = classifyProviderError({
+    provider: "openai-codex",
+    model: "gpt-5.6-terra",
+    message:
+      "upstream connect error or disconnect/reset before headers. reset reason: connection termination",
+  });
+  expect(err).toEqual({
+    kind: "provider_internal",
+    provider: "openai-codex",
+    http_status: null,
+    message:
+      "upstream connect error or disconnect/reset before headers. reset reason: connection termination",
+  });
+});
+
+test("envoy's retried variant ('… retried and the latest reset reason: connection timeout') classifies the same way", () => {
+  const err = classifyProviderError({
+    provider: "openai-codex",
+    model: "gpt-5.5",
+    message:
+      "upstream connect error or disconnect/reset before headers. retried and the latest reset reason: connection timeout",
+  });
+  expect(err.kind).toBe("provider_internal");
+});
+
+test("envoy 'Upstream idle timeout exceeded' → provider_internal, not unknown", () => {
+  // Same proxy, different failure: the upstream stopped responding mid-request
+  // and Envoy gave up. Seen via openrouter in the same Sentry bucket.
+  const err = classifyProviderError({
+    provider: "openrouter",
+    model: "openrouter/free",
+    message: "Upstream idle timeout exceeded",
+  });
+  expect(err).toEqual({
+    kind: "provider_internal",
+    provider: "openrouter",
+    http_status: null,
+    message: "Upstream idle timeout exceeded",
+  });
+});
+
+test("envoy body arriving WITH its usual 503 keeps the status on the card", () => {
+  const err = classifyProviderError({
+    provider: "openai-codex",
+    model: "gpt-5.6-terra",
+    message:
+      "upstream connect error or disconnect/reset before headers. reset reason: connection termination",
+    status: 503,
+  });
+  expect(err.kind).toBe("provider_internal");
+  if (err.kind === "provider_internal") expect(err.http_status).toBe(503);
+});
+
 // OpenAI's generic server-side failure — "An error occurred while processing
 // your request. You can retry your request, or …" — arrives via the Codex path
 // as "Codex error: <body>" with no HTTP status anywhere in the string, so the

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -527,6 +527,22 @@ function isServerError(lower: string, status: number | null): boolean {
     // a genuinely dead local network fails the NEXT attempt with fetch/ECONN
     // errors that still route to network_unreachable below.
     lower.includes("websocket closed") ||
+    // Envoy's canonical no-upstream-response body — "upstream connect error or
+    // disconnect/reset before headers. reset reason: connection termination"
+    // (also "… retried and the latest reset reason: connection timeout") — from
+    // a proxy on the pod↔provider path when the upstream connection died before
+    // any response headers arrived. Envoy normally sends it as a 503, but the
+    // Codex path flattens it to the bare body with no status, so the 5xx
+    // short-circuit never sees it. Transient and already past Envoy's own
+    // retries ("retried and the latest…"); retry is the remedy, and like the
+    // WebSocket break above it originates on cloud engine pods where the
+    // network_unreachable card would blame the wrong network
+    // (HOUSTON-APP-4Y9: 670 events / 151 users read as `unknown`).
+    lower.includes("upstream connect error") ||
+    // Envoy's idle-timeout body — "Upstream idle timeout exceeded" — the same
+    // proxy giving up on an upstream that stopped responding mid-request (seen
+    // via openrouter in the same Sentry bucket). Same transient verdict.
+    lower.includes("upstream idle timeout") ||
     // OpenAI's generic server-side failure body — "An error occurred while
     // processing your request. You can retry your request, or contact us
     // through our help center at help.openai.com if the error persists.


### PR DESCRIPTION
Fixes HOUSTON-APP-4Y9 — `[provider_error] provider=openai-codex model=gpt-5.6-terra status=? kind=unknown :: upstream connect error or disconnect/reset before headers. reset reason: connection termination` (670 events / 151 users since 2026-07-20, all `engine_process=runtime` on managed-cloud pods).

## Root cause

The body is Envoy's canonical no-upstream-response error: a proxy on the engine-pod↔provider path answered for an upstream whose connection died before any response headers arrived. Envoy normally serves it as a 503, but the Codex path flattens it to the bare body with no status anywhere in the string, so `extractHttpStatus` finds nothing and the 5xx short-circuit in `isServerError` never fires. No text pattern matched either (`isNetwork` looks for "connection **reset**", the body says "connection **termination**"), so it fell through to `kind: "unknown"` — the report-bug card for the user, and a Sentry ERROR event per occurrence (`unknown` is deliberately not in `EXPECTED_KINDS`).

Two variants exist in the issue's events, plus a sibling family:

- `upstream connect error or disconnect/reset before headers. reset reason: connection termination`
- `upstream connect error or disconnect/reset before headers. retried and the latest reset reason: connection timeout`
- `Upstream idle timeout exceeded` (via openrouter, same Sentry bucket — Envoy giving up on an upstream that went quiet mid-request)

## Why `provider_internal` (retryable), not `unknown` or `network_unreachable`

- **Transient by nature**: the TCP connection to the upstream was torn down before headers; the next attempt opens a fresh connection. The "retried and the latest reset reason" variant shows Envoy itself already retried before surfacing the failure — and pi additionally auto-retries transient failures inside `prompt()` (the wire translator's held-error mechanism, HOU-1057), so anything reaching the classifier has already survived the automatic-retry layers. What's left is exactly what the `provider_internal` card handles: a user-facing **Retry** CTA + status-page link. A further blind auto-retry loop in the runtime would be a third retry layer on top of two that just failed — not added.
- **Not `network_unreachable`**: every production event originates on a cloud engine pod (`deployment=managed-cloud`), where "check your internet" blames the wrong network — the same reasoning that moved Codex's `WebSocket closed <code>` family to `provider_internal` (HOU-848).

## Sentry severity

Classified as `provider_internal`, the failure is in `EXPECTED_KINDS` (`provider-error-log.ts`), so it logs at WARN and becomes a Sentry **breadcrumb** instead of an ERROR event — the taxonomy's built-in answer to "should Sentry capture this at this severity" (no: an expected transient upstream state the chat already renders as a typed card adds no error-level signal).

## Investigation notes

The Sentry issue is a merged bucket of `[provider_error]` families, and the deployed engine (`engine-pod@9583298f`) predates ~10 recent classifier fixes (HOU-848/898/902/920/930/1154/1156…), so most families in it — `WebSocket closed 1006`, `terminated`, `Stream ended without finish_reason`, `got status: UNAVAILABLE`, `Codex error: An error occurred…` — are already classified at HEAD and will drop off on the next engine-pod deploy. The two Envoy families above were the only repeating ones still unclassified at HEAD. Remaining singletons left for the triage ritual if they recur: NVIDIA `ResourceExhausted: Worker local total request limit reached (32/32)`, openrouter `Upstream error from Nvidia: EngineCore encountered an issue`, and Google's `API key not valid` under embedded 400 (blocked by `isAuth`'s known-non-auth-status gate — needs its own considered fix).

## Tests

- Verbatim fixtures for both Envoy variants and the idle-timeout body → `provider_internal` with `http_status: null`; a with-503 case keeps the status on the card.
- `pnpm --filter @houston/runtime test`: 116 files, 1070 tests pass.
- `pnpm check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
