### PR TITLE
fix(skills): stale-roster 'agent not found' 404s from the manifest queries (HOUSTON-APP-544)

### DIFF
--- a/app/src/components/agent/use-agent-shared-skills.ts
+++ b/app/src/components/agent/use-agent-shared-skills.ts
@@ -1,12 +1,15 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { useCapabilities } from "../../hooks/use-capabilities";
+import { useStaleRosterHeal } from "../../hooks/use-stale-roster-heal";
+import { agentRosterSettled, isAgentGoneError } from "../../lib/agent-gone";
 import { analytics } from "../../lib/analytics";
 import { logger } from "../../lib/logger";
 import { queryKeys } from "../../lib/query-keys";
 import { sharedSkillsAvailable } from "../../lib/shared-skills-availability";
 import { tauriSharedSkills, tauriSkillsManifest } from "../../lib/tauri";
 import type { SkillSummary } from "../../lib/types";
+import { useAgentStore } from "../../stores/agents";
 import { useWorkspaceStore } from "../../stores/workspaces";
 
 /**
@@ -47,14 +50,24 @@ export function useAgentSharedSkills(agentPath: string): {
   });
   // The manifest is agent-local and independent of the store, so it loads in
   // PARALLEL with the store query — gating it on the store's answer would
-  // serialize two round trips for every configured deployment.
+  // serialize two round trips for every configured deployment. It IS gated on
+  // the roster having settled for the current space: a space switch wipes the
+  // cache and would refire this query for the PREVIOUS space's agent under the
+  // new org — a guaranteed `404 agent not found` (HOUSTON-APP-544). A genuine
+  // 404 (agent deleted/unshared elsewhere) is silenced — an expected stale-
+  // roster state, surfaced by the heal below — never a red bug toast.
+  const rosterSettled = useAgentStore(agentRosterSettled);
   const manifest = useQuery({
     queryKey: queryKeys.skillsManifest(agentPath),
-    queryFn: () => tauriSkillsManifest.get(agentPath),
-    enabled: advertised,
+    queryFn: () =>
+      tauriSkillsManifest.get(agentPath, { silence: isAgentGoneError }),
+    enabled: advertised && rosterSettled,
     staleTime: Number.POSITIVE_INFINITY,
     refetchOnWindowFocus: false,
   });
+  // Inline surfacing for the silenced 404: reload the roster so the ghost
+  // agent (and this whole surface with it) disappears on its own.
+  useStaleRosterHeal(isAgentGoneError(manifest.error));
 
   // The gateway advertises `capabilities.sharedSkills` unconditionally, even
   // where no skill store is actually bound — so the store's own answer is the

--- a/app/src/components/skills-view/use-shared-skills.ts
+++ b/app/src/components/skills-view/use-shared-skills.ts
@@ -1,5 +1,7 @@
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
+import { useStaleRosterHeal } from "../../hooks/use-stale-roster-heal";
+import { agentRosterSettled, isAgentGoneError } from "../../lib/agent-gone";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriSharedSkills, tauriSkillsManifest } from "../../lib/tauri";
 import type { Agent, SkillSummary } from "../../lib/types";
@@ -7,6 +9,7 @@ import {
   aggregateSharedSkills,
   type SharedSkillRow,
 } from "../../lib/workspace-shared-skills";
+import { useAgentStore } from "../../stores/agents";
 
 /**
  * The shared-store model behind the global Skills page when the deployment
@@ -35,20 +38,33 @@ export function useSharedSkills(args: {
     refetchOnWindowFocus: false,
   });
 
-  const { manifests, manifestsLoading } = useQueries({
-    queries: enabled
-      ? agents.map((agent) => ({
-          queryKey: queryKeys.skillsManifest(agent.folderPath),
-          queryFn: () => tauriSkillsManifest.get(agent.folderPath),
-          staleTime: Number.POSITIVE_INFINITY,
-          refetchOnWindowFocus: false,
-        }))
-      : [],
+  // Gated on the roster having settled for the current space, and with the
+  // agent-gone 404 silenced — same contract as the per-agent hook
+  // (`use-agent-shared-skills`): a space switch or a stale roster must not
+  // turn this fan-out into a storm of red "agent not found" toasts
+  // (HOUSTON-APP-544). A gone agent's row simply carries no manifest, and the
+  // heal below removes it from the roster.
+  const rosterSettled = useAgentStore(agentRosterSettled);
+  const { manifests, manifestsLoading, agentGone } = useQueries({
+    queries:
+      enabled && rosterSettled
+        ? agents.map((agent) => ({
+            queryKey: queryKeys.skillsManifest(agent.folderPath),
+            queryFn: () =>
+              tauriSkillsManifest.get(agent.folderPath, {
+                silence: isAgentGoneError,
+              }),
+            staleTime: Number.POSITIVE_INFINITY,
+            refetchOnWindowFocus: false,
+          }))
+        : [],
     combine: (results) => ({
       manifests: results.map((r) => r.data?.enabled),
       manifestsLoading: results.some((r) => r.isLoading),
+      agentGone: results.some((r) => isAgentGoneError(r.error)),
     }),
   });
+  useStaleRosterHeal(agentGone);
 
   const manifestsByPath = useMemo(
     () =>

--- a/app/src/hooks/use-stale-roster-heal.ts
+++ b/app/src/hooks/use-stale-roster-heal.ts
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+import { makeRosterHealer } from "../lib/agent-gone";
+import { useAgentStore } from "../stores/agents";
+import { useWorkspaceStore } from "../stores/workspaces";
+
+/**
+ * When a mounted surface observes an agent-gone read (HOUSTON-APP-544 — the
+ * roster still lists an agent the server says does not exist), silently
+ * reload the current workspace's roster so the ghost agent disappears on its
+ * own. Module-level healer so every mounted surface shares ONE in-flight
+ * reload; see `makeRosterHealer` for why this cannot loop.
+ */
+const healRoster = makeRosterHealer((workspaceId) =>
+  useAgentStore.getState().loadAgents(workspaceId, { silent: true }),
+);
+
+export function useStaleRosterHeal(agentGone: boolean): void {
+  const workspaceId = useWorkspaceStore((s) => s.current?.id ?? null);
+  useEffect(() => {
+    void healRoster(workspaceId, agentGone);
+  }, [workspaceId, agentGone]);
+}

--- a/app/src/lib/agent-gone.ts
+++ b/app/src/lib/agent-gone.ts
@@ -1,0 +1,83 @@
+/**
+ * An agent-scoped READ answered "this agent does not exist" (HOUSTON-APP-544).
+ *
+ * Agent-scoped routes resolve the agent id before anything else: the hosted
+ * gateway looks it up in its registry, and the host's own authz does the same
+ * (`packages/host/src/routes/agent-authz.ts`) — both answer
+ * `404 { error: "agent not found" }` when the id no longer resolves. For a
+ * GET the client sends routinely (the skills-manifest queries), that answer
+ * has exactly one meaning: the LOCAL ROSTER IS STALE. The agent was deleted
+ * or unshared on another device, or a space switch's cache reset
+ * (`lib/space-cache.ts`) refired queries built from the previous space's
+ * roster under the new `x-houston-org` before `loadAgents` re-resolved.
+ *
+ * That is an expected, explainable lifecycle state, NOT a Houston bug: the
+ * honest surface is the roster without the agent, so the read is silenced
+ * (no red bug toast, no Sentry report — `call()` still logs it) and the
+ * roster is silently reloaded so the ghost disappears on its own.
+ *
+ * Like `isMissingSkillError`, the classifier keys on the structural
+ * `.status`: the TS host emits bare-string error bodies with no typed
+ * `kind`, and a manifest GET has exactly one 404 path — the agent is gone —
+ * so the status is unambiguous in context. Applied ONLY to passive
+ * roster-driven queries; user-initiated reads/writes keep the default loud
+ * surfacing.
+ */
+export function isAgentGoneError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  return (err as { status?: unknown }).status === 404;
+}
+
+/** The agent-store signals the query gate reads. */
+export interface AgentRosterSignals {
+  /** True once `loadAgents` has settled at least once (even on failure). */
+  loaded: boolean;
+  /** True while a `loadAgents` is in flight. */
+  loading: boolean;
+}
+
+/**
+ * Whether the CURRENT space's roster has settled, so an agent-scoped query
+ * would target this space's agents rather than the previous one's.
+ *
+ * Same gate as the provider probe's (`providerProbeReady`, HOU-979), for the
+ * same race: a space switch wipes the query cache, which refires every
+ * mounted agent-scoped query — but the components still render the PREVIOUS
+ * space's roster until `loadAgents` re-resolves, so each refetch asks the
+ * new org about an agent it never had and gets `404 agent not found`.
+ * `loaded` alone is not enough: it stays true across the switch while the
+ * re-`loadAgents` runs, which is exactly the window the doomed reads fired
+ * in. Both signals together mean "settled, for this space".
+ */
+export function agentRosterSettled(roster: AgentRosterSignals): boolean {
+  return roster.loaded && !roster.loading;
+}
+
+/**
+ * The self-heal half of the agent-gone contract: a silent roster reload, so
+ * an agent the server no longer knows vanishes from the rail instead of
+ * sitting there as a ghost whose every surface errors quietly.
+ *
+ * Factory form so the dedupe is unit-testable: `load` is the store's
+ * `loadAgents(workspaceId, { silent: true })`. One reload at a time — a
+ * Skills page with several stale agents observes one agent-gone error per
+ * manifest query in the same beat, and each mounted surface calls the healer,
+ * so concurrent calls collapse into the single in-flight reload. No loop is
+ * possible: a reload that still lists the agent changes nothing, and the
+ * errored queries (`staleTime: Infinity`) do not refetch on their own.
+ */
+export function makeRosterHealer(
+  load: (workspaceId: string) => Promise<void>,
+): (workspaceId: string | null, agentGone: boolean) => Promise<boolean> {
+  let inFlight = false;
+  return async (workspaceId, agentGone) => {
+    if (!agentGone || workspaceId === null || inFlight) return false;
+    inFlight = true;
+    try {
+      await load(workspaceId);
+    } finally {
+      inFlight = false;
+    }
+    return true;
+  };
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -870,9 +870,17 @@ export const tauriSharedSkills = {
 };
 
 export const tauriSkillsManifest = {
-  get: (agentPath: string) =>
-    call<SkillsManifest>("get_skills_manifest", () =>
-      getEngine().getSkillsManifest(agentPath),
+  /** Passive roster-driven queries pass `{ silence: isAgentGoneError }`: a 404
+   *  here means the roster is stale (agent deleted/unshared elsewhere, or a
+   *  space-switch refetch raced `loadAgents`) — an expected state the surfaces
+   *  handle by hiding + healing the roster, not a Houston bug (HOUSTON-APP-544).
+   *  User-initiated reads keep the default loud surfacing. */
+  get: (agentPath: string, options?: EngineCallOptions) =>
+    call<SkillsManifest>(
+      "get_skills_manifest",
+      () => getEngine().getSkillsManifest(agentPath),
+      undefined,
+      options,
     ),
   set: (agentPath: string, manifest: SkillsManifest) => {
     blockWriteWhileWarming(agentPath);

--- a/app/tests/agent-gone.test.ts
+++ b/app/tests/agent-gone.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  agentRosterSettled,
+  isAgentGoneError,
+  makeRosterHealer,
+} from "../src/lib/agent-gone.ts";
+
+describe("isAgentGoneError", () => {
+  it("matches the engine-client 404 for a vanished agent", () => {
+    // Structural shape of HoustonEngineError(404, {error: "agent not found"})
+    // from both adapter classes (packages/web and ui/engine-client).
+    const err = Object.assign(new Error("agent not found (engine error 404)"), {
+      status: 404,
+      body: { error: "agent not found" },
+    });
+    assert.equal(isAgentGoneError(err), true);
+  });
+
+  it("matches a bare status-carrying object", () => {
+    assert.equal(isAgentGoneError({ status: 404 }), true);
+  });
+
+  it("never matches other statuses — 5xx must stay loud", () => {
+    assert.equal(isAgentGoneError({ status: 403 }), false);
+    assert.equal(isAgentGoneError({ status: 500 }), false);
+    assert.equal(isAgentGoneError({ status: 502 }), false);
+    assert.equal(isAgentGoneError({ status: 503 }), false);
+  });
+
+  it("never matches non-errors or shapeless throws", () => {
+    assert.equal(isAgentGoneError(undefined), false);
+    assert.equal(isAgentGoneError(null), false);
+    assert.equal(isAgentGoneError("agent not found"), false);
+    assert.equal(isAgentGoneError(new Error("boom")), false);
+    assert.equal(isAgentGoneError({ status: "404" }), false);
+  });
+});
+
+describe("agentRosterSettled", () => {
+  it("is true only once loaded AND not mid-reload", () => {
+    assert.equal(agentRosterSettled({ loaded: true, loading: false }), true);
+  });
+
+  it("stays closed before the first load (boot gap)", () => {
+    assert.equal(agentRosterSettled({ loaded: false, loading: false }), false);
+    assert.equal(agentRosterSettled({ loaded: false, loading: true }), false);
+  });
+
+  it("closes during a space switch's re-load — the HOU-979 window", () => {
+    // `loaded` stays true across a switch while loadAgents re-runs; that is
+    // exactly when queries built from the previous space's roster would fire.
+    assert.equal(agentRosterSettled({ loaded: true, loading: true }), false);
+  });
+});
+
+describe("makeRosterHealer", () => {
+  it("reloads the roster when an agent-gone read is observed", async () => {
+    const loads: string[] = [];
+    const heal = makeRosterHealer(async (ws) => {
+      loads.push(ws);
+    });
+    assert.equal(await heal("ws-1", true), true);
+    assert.deepEqual(loads, ["ws-1"]);
+  });
+
+  it("does nothing without an agent-gone signal or a workspace", async () => {
+    let loads = 0;
+    const heal = makeRosterHealer(async () => {
+      loads += 1;
+    });
+    assert.equal(await heal("ws-1", false), false);
+    assert.equal(await heal(null, true), false);
+    assert.equal(loads, 0);
+  });
+
+  it("collapses concurrent calls into the one in-flight reload", async () => {
+    let loads = 0;
+    let release = () => {};
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const heal = makeRosterHealer(async () => {
+      loads += 1;
+      await gate;
+    });
+    const first = heal("ws-1", true);
+    // A Skills page with several stale agents observes one agent-gone error
+    // per manifest query in the same beat — only the first may reload.
+    const second = heal("ws-1", true);
+    assert.equal(await second, false);
+    release();
+    assert.equal(await first, true);
+    assert.equal(loads, 1);
+  });
+
+  it("allows a later heal once the previous reload settled", async () => {
+    let loads = 0;
+    const heal = makeRosterHealer(async () => {
+      loads += 1;
+    });
+    assert.equal(await heal("ws-1", true), true);
+    assert.equal(await heal("ws-1", true), true);
+    assert.equal(loads, 2);
+  });
+
+  it("clears the in-flight latch when the reload itself throws", async () => {
+    let attempts = 0;
+    const heal = makeRosterHealer(async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("network down");
+    });
+    await assert.rejects(() => heal("ws-1", true));
+    // The failed reload must not wedge the healer shut forever.
+    assert.equal(await heal("ws-1", true), true);
+    assert.equal(attempts, 2);
+  });
+});

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -702,6 +702,14 @@ Therefore `loadSkills` (via `parseSkillMd`) reports each skill's **directory slu
 
 Genuinely missing skills still happen (deleted, never installed, a stale selection). The host answers `404 { error: "skill not found" }`, surfaced by `@houston-ai/engine-client` as a `HoustonEngineError` with `status: 404` (the host emits a bare-string body here, so there is **no** typed `.kind`). That 404 is an expected, explainable state, **not** a Houston bug: `tauriSkills.load` passes `{ silence: isMissingSkillError }` (`app/src/lib/missing-skill.ts`) so the error skips the red bug toast + Sentry report, and `useSkillSurface` surfaces it inline (a friendly info toast, collapses the open row, refetches the list so the dead row vanishes).
 
+### The agent itself can be gone (stale roster, HOUSTON-APP-544)
+
+The same idea one level up: the shared-skills **manifest** queries (`use-agent-shared-skills`, `use-shared-skills`) fan out per agent from the local roster, and when that roster is stale — the agent was deleted or unshared on another device, or a space switch's cache reset (`lib/space-cache.ts`) refired queries built from the previous space's roster under the new `x-houston-org` before `loadAgents` re-resolved — the gateway/host answers `404 { error: "agent not found" }` (`packages/host/src/routes/agent-authz.ts`). Handling (`app/src/lib/agent-gone.ts`):
+
+- **Gate**: the manifest queries only run once the roster has settled for the current space (`agentRosterSettled` — `loaded && !loading`, the same HOU-979 gate the provider probe uses), which closes the space-switch window where a refetch storm was guaranteed to 404.
+- **Silence**: the query reads pass `{ silence: isAgentGoneError }` — a stale-roster 404 is expected lifecycle, not a red bug toast + Sentry report. Only these passive roster-driven reads are silenced; user-initiated manifest reads/writes keep the default loud surfacing, and 5xx keeps its designed loud path (`cp/transient-retry.ts`).
+- **Heal**: on an observed agent-gone error, `useStaleRosterHeal` silently reloads the current workspace's roster (deduped, cannot loop) so the ghost agent disappears from the rail on its own — the honest surface for a deleted agent.
+
 ## Files of interest
 
 | What | Where |
@@ -715,6 +723,7 @@ Genuinely missing skills still happen (deleted, never installed, a stale selecti
 | Install composition | [`packages/domain/src/skill-install.ts`](../packages/domain/src/skill-install.ts) — `composeInstalledSkillMd`, frontmatter-preserving |
 | Shared-skills manifest (ADR 0003) | [`packages/domain/src/skills-manifest.ts`](../packages/domain/src/skills-manifest.ts) — `.houston/skills-manifest/skills-manifest.json` |
 | Missing-skill classifier | [`app/src/lib/missing-skill.ts`](../app/src/lib/missing-skill.ts) — `isMissingSkillError` (404) keeps it off the bug-toast/Sentry path |
+| Agent-gone classifier + roster gate/heal | [`app/src/lib/agent-gone.ts`](../app/src/lib/agent-gone.ts) + [`app/src/hooks/use-stale-roster-heal.ts`](../app/src/hooks/use-stale-roster-heal.ts) — stale-roster `404 agent not found` on manifest reads: gated, silenced, self-healing (HOUSTON-APP-544) |
 | Skills surface hook | [`app/src/components/agent/use-skill-surface.ts`](../app/src/components/agent/use-skill-surface.ts) — inline "Skill unavailable" handling |
 | Error-kind union (client) | [`ui/skills/src/skill-error-kinds.ts`](../ui/skills/src/skill-error-kinds.ts) |
 | TS wire types | [`ui/engine-client/src/types.ts`](../ui/engine-client/src/types.ts) |


### PR DESCRIPTION
Fixes HOUSTON-APP-544 — `get_skills_manifest: agent not found (engine error 404)`, 245 events / 158 users since 2026-08-01.

## Root cause

The shared-skills **manifest queries** are passive, roster-driven reads: `use-agent-shared-skills` fires one for the mounted agent, and the global Skills page (`use-shared-skills`) fans one out **per agent in the roster**. Both route through `tauriSkillsManifest.get`, whose `call()` wrapper treats every failure as a Houston bug: red "report a bug" toast + Sentry capture.

The gateway/host answers these reads with `404 {"error":"agent not found"}` whenever the **local roster is stale relative to the server**:

1. **Space-switch race (the routine path).** `setCurrent`/reselect pins the new `x-houston-org` and wipes the query cache (`lib/space-cache.ts`, HOU-907), which refires every mounted agent-scoped query — but the components still render the *previous* space's roster until `loadAgents` re-resolves. Each refetch asks the new org about an agent it never had → guaranteed 404 per mounted manifest query. This is the exact window HOU-979 already closed for the provider probe (`providerProbeReady`); the manifest queries had no such gate.
2. **Agent deleted/unshared on another device** while this client's roster hasn't caught up (missed `AgentsChanged`, event stream down). The ghost agent's queries keep firing on invalidation and 404 forever.

Neither is a Houston bug the user can act on, yet each occurrence produced a red bug toast + a Sentry event. Event tally confirms the 404s recur across releases up to the newest 0.5.47. (The 502/503 events grouped under the same issue were an Aug 5–7 gateway incident window on 0.5.39–0.5.46 — those keep their designed loud path: `transient-retry.ts` already gives them a wake/handoff retry budget, and an exhausted budget *should* toast.)

## Fix

`app/src/lib/agent-gone.ts` (mirrors the `missing-skill.ts` precedent, HOU-515/441):

- **`isAgentGoneError`** — structural `.status === 404` classifier (the TS host emits bare-string bodies, no typed `kind`; a manifest GET has exactly one 404 path — the agent id no longer resolves, `packages/host/src/routes/agent-authz.ts`).
- **Gate** — `agentRosterSettled` (`loaded && !loading`, the HOU-979 gate) now gates both manifest query sites, so the space-switch cache wipe can no longer refire them for the previous space's roster. Also closes the boot gap before the first roster load.
- **Silence** — the two passive query reads pass `{ silence: isAgentGoneError }`: logged, no red toast, no Sentry capture. **Scope is deliberately narrow**: user-initiated manifest reads/writes (`setEnabled`, `use-shared-skills-actions`, org-share default) keep the default loud surfacing, and 5xx stays loud everywhere.
- **Self-heal** (the inline surface the no-silent-failures policy requires) — `useStaleRosterHeal` silently reloads the current workspace's roster when an agent-gone read is observed, so the ghost agent disappears from the rail on its own. Deduped via a shared in-flight latch; cannot loop (a reload that still lists the agent changes nothing, and the errored `staleTime: Infinity` queries don't refetch on their own).

Docs: `knowledge-base/skills.md` gains an "agent itself can be gone" section + files-of-interest row.

## Tests

- `app/tests/agent-gone.test.ts` (12 new node:test cases): classifier shapes (404 vs 4xx/5xx vs shapeless), the roster gate incl. the HOU-979 switch window, healer dedupe/latch-clearing/re-arm.
- Full app suite: **3403 pass / 0 fail**. `pnpm tsgo --noEmit` (app), `pnpm --filter houston-web typecheck`, `pnpm check` (Biome), `pnpm check:boundaries`, `pnpm check-locales` all clean.

## Verification against Sentry

Issue events tagged `release >= houston-app@<next>` should stop showing `agent not found` occurrences; the 5xx variants remain possible during genuine gateway incidents by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
