### PR TITLE
fix(sweep): classify partial-sweep failures, stop Sentry-reporting waking pods (HOUSTON-APP-538)

### DIFF
--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -17,7 +17,6 @@ import { useCapabilities } from "../hooks/use-capabilities";
 import { getConversationStatus } from "../hooks/use-conversation-vm";
 import { useWarmingConversations } from "../hooks/use-warming-conversations";
 import { latestCachedAllConversations } from "../lib/all-conversations-cache";
-import { sweepIsAuthoritative } from "../lib/all-conversations-recovery";
 import { buildAttachmentPrompt } from "../lib/attachment-message";
 import { createMission } from "../lib/create-mission";
 import { isSetupChatMode } from "../lib/integration-chat-setup";
@@ -32,6 +31,7 @@ import { isMultiplayer } from "../lib/org-roles";
 import { perfSpans } from "../lib/perf-spans";
 import { queryKeys } from "../lib/query-keys";
 import { formatVisibleMessageText } from "../lib/queued-chat";
+import { sweepIsAuthoritative } from "../lib/sweep-authoritative";
 import {
   type HistoryLoadOptions,
   type RawConversation,

--- a/app/src/hooks/queries/all-conversations-sweep.ts
+++ b/app/src/hooks/queries/all-conversations-sweep.ts
@@ -8,15 +8,25 @@
  * place, at module scope.
  */
 
+import type { FailedAgentRead } from "@houston-ai/engine-client";
 import type { QueryClient } from "@tanstack/react-query";
 import {
   NO_SWEEP_RECOVERY,
+  type PartialSweepSurface,
   planSweepAttempt,
   type SweepRecoveryState,
   stepSweepRecovery,
 } from "../../lib/all-conversations-recovery";
-import { showErrorToast } from "../../lib/error-toast";
+import {
+  showConnectivityErrorToast,
+  showEngineWakingToast,
+  showErrorToast,
+} from "../../lib/error-toast";
 import i18n from "../../lib/i18n";
+import {
+  partialSweepToastKind,
+  representativeSweepFailure,
+} from "../../lib/partial-sweep-surface";
 import { queryKeys } from "../../lib/query-keys";
 import { surfaceEngineError, tauriConversations } from "../../lib/tauri";
 import { isTransientEngineError } from "../../lib/transient-error";
@@ -52,31 +62,23 @@ export function retargetSweepRecovery(roster: string): void {
 
 /**
  * React to a settled sweep: a COMPLETE one clears the run; an incomplete one
- * surfaces itself and schedules its own re-sweep. The decision (what to toast,
- * when to retry) is the pure `stepSweepRecovery`; this only executes it.
+ * surfaces itself and schedules its own re-sweep. The decision (when to
+ * surface, when to retry) is the pure `stepSweepRecovery`, and WHAT the
+ * surface is comes from the failed reads' own errors
+ * (`lib/partial-sweep-surface.ts`); this only executes both.
  */
 export function recoverFromSweep(
-  failedAgentPaths: string[],
+  failedAgents: FailedAgentRead[],
   roster: string,
   queryClient: QueryClient,
 ): void {
   const { state, decision } = stepSweepRecovery(
     sweepRecovery,
     roster,
-    failedAgentPaths.length,
+    failedAgents.length,
   );
   sweepRecovery = state;
-  if (decision.toast) {
-    // The beta no-silent-failures path: the branded toast + auto-report, with
-    // authored copy instead of the raw diagnostic (which the adapter already
-    // logged per agent, and which rides the Sentry report).
-    showErrorToast(
-      "list_all_conversations_partial",
-      `missions unread for ${failedAgentPaths.length} agent(s): ${failedAgentPaths.join(", ")}`,
-      undefined,
-      { userMessage: i18n.t("dashboard:errors.partialMissionLoad") },
-    );
-  }
+  if (decision.surface) surfacePartialSweep(decision.surface, failedAgents);
   // Nothing else would revisit this hole inside the freshness window, so an
   // incomplete sweep schedules its own bounded re-sweep. A sweep that came back
   // complete cancels the pending one instead: the hole is filled.
@@ -89,6 +91,59 @@ export function recoverFromSweep(
     });
   }, decision.retryInMs);
 }
+
+/**
+ * Tell someone the sweep was incomplete, in the register the failures earn
+ * (HOUSTON-APP-538): an asleep pod still waking / a device that dropped
+ * offline get their quiet informational toasts (no Sentry — the re-sweep
+ * already scheduled above heals the hole once the pod is up), everything else
+ * — and ANY failure still standing at escalation — the real error report. The
+ * per-agent reasons ride the diagnostic line so the log and the report say
+ * WHY, not just who.
+ */
+function surfacePartialSweep(
+  surface: PartialSweepSurface,
+  failedAgents: FailedAgentRead[],
+): void {
+  const reason = representativeSweepFailure(failedAgents.map((f) => f.reason));
+  const named = failedAgents
+    .map((f) => `${f.agentPath} (${describeReason(f.reason)})`)
+    .join(", ");
+  switch (partialSweepToastKind(surface, reason)) {
+    case "waking":
+      showEngineWakingToast(
+        "list_all_conversations_partial",
+        `missions unread for ${failedAgents.length} waking agent(s): ${named}`,
+      );
+      return;
+    case "connectivity":
+      showConnectivityErrorToast(
+        "list_all_conversations_partial",
+        `missions unread for ${failedAgents.length} agent(s) while offline: ${named}`,
+      );
+      return;
+    case "error":
+      // The beta no-silent-failures path: log + analytics + Sentry capture,
+      // with authored copy as the burst key and the REAL error for grouping.
+      // The escalated shape gets its own source tag: "an agent's pod never
+      // came up through a whole recovery run" is a different bug than "an
+      // agent's read failed outright".
+      showErrorToast(
+        surface === "escalate"
+          ? "list_all_conversations_stuck"
+          : "list_all_conversations_partial",
+        surface === "escalate"
+          ? `missions still unread after re-sweeps for ${failedAgents.length} agent(s): ${named}`
+          : `missions unread for ${failedAgents.length} agent(s): ${named}`,
+        reason,
+        { userMessage: i18n.t("dashboard:errors.partialMissionLoad") },
+      );
+      return;
+  }
+}
+
+const describeReason = (reason: unknown): string =>
+  reason instanceof Error ? reason.message : String(reason);
 
 /**
  * Run the sweep, retrying an outright failure a bounded number of times.

--- a/app/src/hooks/queries/use-conversations.ts
+++ b/app/src/hooks/queries/use-conversations.ts
@@ -37,15 +37,15 @@ export function useAllConversations(agentPaths: string[]) {
   return useQuery({
     queryKey,
     queryFn: async () => {
-      const { items, failedAgentPaths } = await sweepWithRetry(agentPaths);
+      const { items, failedAgents } = await sweepWithRetry(agentPaths);
       // A partial sweep must never present itself as the whole board: the
       // agents that did not answer keep their last-known missions (HOU-981).
       const merged = mergePartialSweep(
         items,
         previousRows(queryClient, queryKey),
-        failedAgentPaths,
+        failedAgents.map((f) => f.agentPath),
       );
-      recoverFromSweep(failedAgentPaths, roster, queryClient);
+      recoverFromSweep(failedAgents, roster, queryClient);
       return merged;
     },
     enabled: agentPaths.length > 0,

--- a/app/src/lib/all-conversations-recovery.ts
+++ b/app/src/lib/all-conversations-recovery.ts
@@ -4,7 +4,7 @@
  * The hosted sweep fans out one read per agent. Any single agent can fail on
  * its own — a pod that never woke, a gateway blip — while the rest answer. The
  * adapter now keeps the agents that answered and reports the ones that didn't
- * (`AllConversationsResult.failedAgentPaths`) instead of rejecting the whole
+ * (`AllConversationsResult.failedAgents`) instead of rejecting the whole
  * board. That leaves the query layer four obligations, all handled here:
  *
  *  1. **Don't lose the failed agents' missions.** A partial sweep must not
@@ -24,10 +24,12 @@
  *     times.
  *  4. **Don't call a non-answer an answer.** The board's "you have no missions"
  *     verdict waits for a settled, non-placeholder success
- *     ({@link sweepIsAuthoritative}).
+ *     (`sweepIsAuthoritative`, lib/sweep-authoritative.ts).
  *
  * Pure and dependency-free so it unit-tests under node:test; the wiring lives
- * in hooks/queries/use-conversations.ts.
+ * in hooks/queries/use-conversations.ts, and HOW an incomplete sweep is told
+ * to the user (waking pod vs offline vs real failure) is the sibling policy in
+ * lib/partial-sweep-surface.ts.
  */
 
 /** The minimum a merged/failed row needs: which agent it belongs to. */
@@ -64,9 +66,19 @@ export function mergePartialSweep<T extends AgentScopedRow>(
  */
 export const PARTIAL_SWEEP_RETRY_DELAYS_MS = [5_000, 20_000, 60_000];
 
+export type PartialSweepSurface =
+  /** First partial sweep of a run: tell the user once, CLASSIFIED — a waking
+   *  pod or an offline drop gets its quiet informational surface, anything
+   *  else the real error report. */
+  | "notice"
+  /** The bounded re-sweeps are exhausted and the hole is still open. Whatever
+   *  the reason looked like, a pod that never came up through the whole run is
+   *  the bug report we want — always the error surface. */
+  | "escalate";
+
 export interface PartialSweepDecision {
-  /** Tell the user this sweep was incomplete. */
-  toast: boolean;
+  /** How (and whether) to tell anyone this sweep was incomplete. */
+  surface?: PartialSweepSurface;
   /** Re-sweep after this many ms; `undefined` = stop retrying. */
   retryInMs?: number;
 }
@@ -75,18 +87,23 @@ export interface PartialSweepDecision {
  * What to do after a sweep, given how many agents it could not read and how
  * many consecutive partial sweeps preceded it.
  *
- * The toast fires only on the FIRST partial sweep of a run: the user needs to
- * know their board is incomplete, not a toast per retry.
+ * The notice fires only on the FIRST partial sweep of a run (the user needs to
+ * know their board is incomplete, not a surface per retry); the escalation
+ * fires exactly once, when the retry schedule runs out with the hole still
+ * open. Runs past that stay quiet: the failure was reported, the carried
+ * forward rows keep painting, and the next complete sweep resets the run.
  */
 export function planPartialSweep(
   failedCount: number,
   consecutivePartialSweeps: number,
 ): PartialSweepDecision {
-  if (failedCount <= 0) return { toast: false };
-  return {
-    toast: consecutivePartialSweeps === 0,
-    retryInMs: PARTIAL_SWEEP_RETRY_DELAYS_MS[consecutivePartialSweeps],
-  };
+  if (failedCount <= 0) return {};
+  if (consecutivePartialSweeps === 0)
+    return { surface: "notice", retryInMs: PARTIAL_SWEEP_RETRY_DELAYS_MS[0] };
+  if (consecutivePartialSweeps === PARTIAL_SWEEP_RETRY_DELAYS_MS.length)
+    return { surface: "escalate" };
+  const retryInMs = PARTIAL_SWEEP_RETRY_DELAYS_MS[consecutivePartialSweeps];
+  return retryInMs === undefined ? {} : { retryInMs };
 }
 
 /**
@@ -129,7 +146,7 @@ export function stepSweepRecovery(
 ): SweepRecoveryStep {
   const run = previous.roster === roster ? previous.run : 0;
   if (failedCount <= 0) {
-    return { state: { roster, run: 0 }, decision: { toast: false } };
+    return { state: { roster, run: 0 }, decision: {} };
   }
   return {
     state: { roster, run: run + 1 },
@@ -171,21 +188,4 @@ export function planSweepAttempt(
   return retryInMs === undefined
     ? { surface: true }
     : { retryInMs, surface: false };
-}
-
-/**
- * Whether the sweep's current result is an ANSWER — the board's `isLoaded`.
- *
- * TanStack reports `status: "success"` the moment placeholder data is handed
- * out, before any fetch settles. Rows must (and do) paint from that placeholder
- * immediately; what must NOT run on it is any verdict about the board being
- * empty. A user whose disk-restored roster variant happened to be `[]` got the
- * new-mission composer auto-opened over an empty board while the real sweep
- * painted underneath it.
- */
-export function sweepIsAuthoritative(query: {
-  isSuccess: boolean;
-  isPlaceholderData: boolean;
-}): boolean {
-  return query.isSuccess && !query.isPlaceholderData;
 }

--- a/app/src/lib/partial-sweep-surface.ts
+++ b/app/src/lib/partial-sweep-surface.ts
@@ -1,0 +1,67 @@
+/**
+ * HOW an incomplete cross-agent sweep is told to the user — the
+ * HOUSTON-APP-538 fix.
+ *
+ * The sweep's recovery policy (lib/all-conversations-recovery.ts) decides WHEN
+ * to surface (`PartialSweepSurface`: the first partial sweep of a run, and the
+ * once-only escalation when the re-sweeps run out). This module decides WHAT
+ * that surface is, from the errors the failed reads actually threw. It used to
+ * be unconditionally the error surface, on agent NAMES alone: every partial
+ * sweep — including the routine one where an asleep engine pod outlived the
+ * transport's cold-start budget (`engine-adapter/cp/transient-retry.ts`) —
+ * became a Sentry report, 465 events in twelve days for the gateway working
+ * as designed.
+ *
+ * Pure (its only imports are the two dependency-free failure classifiers) so
+ * it unit-tests under node:test; the executor is
+ * hooks/queries/all-conversations-sweep.ts.
+ */
+
+import type { PartialSweepSurface } from "./all-conversations-recovery.ts";
+import { isEngineWakingError } from "./engine-waking-error.ts";
+import { isNetworkTransportError } from "./network-transport-error.ts";
+
+/**
+ * The reason a partial sweep is judged BY: the first real failure if there is
+ * one, else the first expected-state failure. One sick pod must not hide
+ * behind N waking ones — a mixed sweep classifies (and reports) as its worst
+ * member, and only an all-expected sweep earns the quiet surface.
+ */
+export function representativeSweepFailure(
+  failedReasons: readonly unknown[],
+): unknown {
+  return (
+    failedReasons.find(
+      (reason) =>
+        !isEngineWakingError(reason) && !isNetworkTransportError(reason),
+    ) ?? failedReasons[0]
+  );
+}
+
+/** The surfaces an incomplete sweep can take (the executor maps these onto
+ *  `showEngineWakingToast` / `showConnectivityErrorToast` / `showErrorToast`). */
+export type PartialSweepToast = "waking" | "connectivity" | "error";
+
+/**
+ * Which surface an incomplete sweep earns.
+ *
+ * A first-notice sweep whose failures are all expected environment states gets
+ * the matching quiet informational surface, exactly like every other per-agent
+ * call (lib/tauri.ts `surfaceError`): an asleep engine pod still waking is the
+ * gateway working as designed (HOU-1114), and the device dropping offline
+ * mid-sweep is HOU-1085 — in both cases the board keeps painting the
+ * carried-forward rows and the scheduled re-sweep heals the hole, so nothing
+ * in Houston broke and there is nothing to report. A real failure, or ANY
+ * failure still standing when the recovery run escalates (a pod that never
+ * woke through the whole run is a crashloop or a capacity problem — the bug
+ * report we want), takes the error surface (toast path + Sentry) as before.
+ */
+export function partialSweepToastKind(
+  surface: PartialSweepSurface,
+  representativeReason: unknown,
+): PartialSweepToast {
+  if (surface === "escalate") return "error";
+  if (isEngineWakingError(representativeReason)) return "waking";
+  if (isNetworkTransportError(representativeReason)) return "connectivity";
+  return "error";
+}

--- a/app/src/lib/sweep-authoritative.ts
+++ b/app/src/lib/sweep-authoritative.ts
@@ -1,0 +1,18 @@
+/**
+ * Whether the cross-agent sweep's current result is an ANSWER — the board's
+ * `isLoaded` (obligation 4 of the HOU-981 recovery: don't call a non-answer an
+ * answer; its siblings live in lib/all-conversations-recovery.ts).
+ *
+ * TanStack reports `status: "success"` the moment placeholder data is handed
+ * out, before any fetch settles. Rows must (and do) paint from that placeholder
+ * immediately; what must NOT run on it is any verdict about the board being
+ * empty. A user whose disk-restored roster variant happened to be `[]` got the
+ * new-mission composer auto-opened over an empty board while the real sweep
+ * painted underneath it.
+ */
+export function sweepIsAuthoritative(query: {
+  isSuccess: boolean;
+  isPlaceholderData: boolean;
+}): boolean {
+  return query.isSuccess && !query.isPlaceholderData;
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1127,13 +1127,14 @@ export interface RawConversation {
 
 /**
  * One cross-agent conversation sweep: the rows every agent that answered
- * returned, plus the agents whose read failed. A non-empty `failedAgentPaths`
- * means the rows are INCOMPLETE and must not be treated as the whole truth
- * (see lib/all-conversations-recovery.ts).
+ * returned, plus the agents whose read failed — each carrying the error it
+ * failed WITH, so the recovery layer can classify the surface. A non-empty
+ * `failedAgents` means the rows are INCOMPLETE and must not be treated as the
+ * whole truth (see lib/all-conversations-recovery.ts).
  */
 export interface AllConversationsSweep {
   items: RawConversation[];
-  failedAgentPaths: string[];
+  failedAgents: import("@houston-ai/engine-client").FailedAgentRead[];
 }
 
 export const tauriConversations = {
@@ -1158,7 +1159,7 @@ export const tauriConversations = {
     if (reachable.length === 0)
       return Promise.resolve<AllConversationsSweep>({
         items: [],
-        failedAgentPaths: [],
+        failedAgents: [],
       });
     // A sweep where SOME agents failed resolves (partial) rather than throwing,
     // so `call()` raises no toast for it — the query layer owns that surface
@@ -1167,11 +1168,11 @@ export const tauriConversations = {
     return call<AllConversationsSweep>(
       "list_all_conversations",
       async () => {
-        const { conversations, failedAgentPaths } =
+        const { conversations, failedAgents } =
           await getEngine().listAllConversations(reachable);
         return {
           items: conversations.map(conversationToRaw),
-          failedAgentPaths,
+          failedAgents,
         };
       },
       undefined,

--- a/app/tests/all-conversations-recovery.test.ts
+++ b/app/tests/all-conversations-recovery.test.ts
@@ -8,8 +8,8 @@ import {
   planSweepAttempt,
   SWEEP_ATTEMPT_DELAYS_MS,
   stepSweepRecovery,
-  sweepIsAuthoritative,
 } from "../src/lib/all-conversations-recovery.ts";
+import { sweepIsAuthoritative } from "../src/lib/sweep-authoritative.ts";
 
 const A = "Houston/Maya";
 const B = "Houston/Kai";
@@ -68,33 +68,44 @@ describe("mergePartialSweep", () => {
 
 describe("planPartialSweep", () => {
   it("does nothing when the sweep was complete", () => {
-    deepStrictEqual(planPartialSweep(0, 0), { toast: false });
-    deepStrictEqual(planPartialSweep(0, 2), { toast: false });
+    deepStrictEqual(planPartialSweep(0, 0), {});
+    deepStrictEqual(planPartialSweep(0, 2), {});
   });
 
   it("surfaces the first incomplete sweep and schedules a re-sweep", () => {
     deepStrictEqual(planPartialSweep(1, 0), {
-      toast: true,
+      surface: "notice",
       retryInMs: PARTIAL_SWEEP_RETRY_DELAYS_MS[0],
     });
   });
 
-  it("keeps retrying on a widening backoff without re-toasting", () => {
-    strictEqual(planPartialSweep(1, 1).toast, false);
-    strictEqual(
-      planPartialSweep(1, 1).retryInMs,
-      PARTIAL_SWEEP_RETRY_DELAYS_MS[1],
-    );
-    strictEqual(
-      planPartialSweep(1, 2).retryInMs,
-      PARTIAL_SWEEP_RETRY_DELAYS_MS[2],
+  it("keeps retrying on a widening backoff without re-surfacing", () => {
+    deepStrictEqual(planPartialSweep(1, 1), {
+      retryInMs: PARTIAL_SWEEP_RETRY_DELAYS_MS[1],
+    });
+    deepStrictEqual(planPartialSweep(1, 2), {
+      retryInMs: PARTIAL_SWEEP_RETRY_DELAYS_MS[2],
+    });
+  });
+
+  it("gives up past the last delay AND escalates — the hole outliving the whole run is the bug report we want", () => {
+    deepStrictEqual(planPartialSweep(1, PARTIAL_SWEEP_RETRY_DELAYS_MS.length), {
+      surface: "escalate",
+    });
+  });
+
+  it("stays quiet past the escalation — one report per run, while the cache keeps painting", () => {
+    deepStrictEqual(
+      planPartialSweep(1, PARTIAL_SWEEP_RETRY_DELAYS_MS.length + 1),
+      {},
     );
   });
 
-  it("gives up past the last delay — a broken agent must not keep the fleet awake", () => {
-    const decision = planPartialSweep(1, PARTIAL_SWEEP_RETRY_DELAYS_MS.length);
-    strictEqual(decision.retryInMs, undefined);
-    strictEqual(decision.toast, false);
+  it("escalates exactly once across a saturated run", () => {
+    const escalations = Array.from({ length: 10 }, (_, run) =>
+      planPartialSweep(1, run),
+    ).filter((d) => d.surface === "escalate");
+    strictEqual(escalations.length, 1);
   });
 });
 
@@ -112,11 +123,11 @@ describe("stepSweepRecovery", () => {
 
   it("counts consecutive partial sweeps for one roster", () => {
     const first = stepSweepRecovery(NO_SWEEP_RECOVERY, R1, 1);
-    strictEqual(first.decision.toast, true);
+    strictEqual(first.decision.surface, "notice");
     strictEqual(first.state.run, 1);
 
     const second = stepSweepRecovery(first.state, R1, 1);
-    strictEqual(second.decision.toast, false);
+    strictEqual(second.decision.surface, undefined);
     strictEqual(second.decision.retryInMs, PARTIAL_SWEEP_RETRY_DELAYS_MS[1]);
     strictEqual(second.state.run, 2);
   });
@@ -125,12 +136,12 @@ describe("stepSweepRecovery", () => {
     const partial = stepSweepRecovery(NO_SWEEP_RECOVERY, R1, 2);
     const clean = stepSweepRecovery(partial.state, R1, 0);
 
-    deepStrictEqual(clean.decision, { toast: false });
+    deepStrictEqual(clean.decision, {});
     strictEqual(clean.state.run, 0);
   });
 
   it("starts the new roster from scratch — a space switch is not a retry", () => {
-    // Saturate R1: past the last delay it neither toasts nor re-sweeps.
+    // Saturate R1: past the last delay it neither surfaces nor re-sweeps.
     let state = NO_SWEEP_RECOVERY;
     for (let i = 0; i <= PARTIAL_SWEEP_RETRY_DELAYS_MS.length; i += 1) {
       state = stepSweepRecovery(state, R1, 1).state;
@@ -141,7 +152,7 @@ describe("stepSweepRecovery", () => {
 
     strictEqual(switched.state.roster, R2);
     deepStrictEqual(switched.decision, {
-      toast: true,
+      surface: "notice",
       retryInMs: PARTIAL_SWEEP_RETRY_DELAYS_MS[0],
     });
   });

--- a/app/tests/partial-sweep-surface.test.ts
+++ b/app/tests/partial-sweep-surface.test.ts
@@ -1,0 +1,81 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  partialSweepToastKind,
+  representativeSweepFailure,
+} from "../src/lib/partial-sweep-surface.ts";
+
+/**
+ * HOUSTON-APP-538. The cross-agent sweep surfaced EVERY partial answer as the
+ * error path (toast bookkeeping + Sentry capture) knowing only which agents
+ * failed, never why — so the routine case, an asleep engine pod whose cold
+ * start outlived the transport's wake budget (the gateway's
+ * `503 {"error":"engine unavailable"}`, an expected state with its own quiet
+ * surface since HOU-1114), filed 465 error events in twelve days. The reasons
+ * now travel with the sweep and pick the register here.
+ */
+
+/** The exact shape the hosted adapter throws for a pod that is not up yet:
+ *  `HoustonEngineError` mints `"<reason> (engine error <status>)"`. */
+const wakingError = () => {
+  const err = new Error("engine unavailable (engine error 503)");
+  err.name = "HoustonEngineError";
+  return Object.assign(err, { status: 503 });
+};
+
+/** WebKit's fetch transport rejection — the device dropped offline. */
+const offlineError = () => new TypeError("Load failed");
+
+/** A read failure that IS a bug (or a deleted agent): must keep reporting. */
+const realError = () => {
+  const err = new Error("agent not found (engine error 404)");
+  err.name = "HoustonEngineError";
+  return Object.assign(err, { status: 404 });
+};
+
+describe("representativeSweepFailure", () => {
+  it("judges a mixed sweep by its worst member — a real failure never hides behind waking pods", () => {
+    const real = realError();
+    strictEqual(
+      representativeSweepFailure([wakingError(), real, offlineError()]),
+      real,
+    );
+  });
+
+  it("falls back to the first reason when every failure is an expected state", () => {
+    const first = wakingError();
+    strictEqual(representativeSweepFailure([first, offlineError()]), first);
+  });
+});
+
+describe("partialSweepToastKind", () => {
+  it("gives a waking pod the quiet HOU-1114 surface, not a bug report", () => {
+    strictEqual(partialSweepToastKind("notice", wakingError()), "waking");
+  });
+
+  it("gives an offline drop the connectivity surface (HOU-1085)", () => {
+    strictEqual(
+      partialSweepToastKind("notice", offlineError()),
+      "connectivity",
+    );
+  });
+
+  it("keeps the error surface for a real per-agent failure", () => {
+    strictEqual(partialSweepToastKind("notice", realError()), "error");
+  });
+
+  it("a coding-bug TypeError is never mistaken for connectivity", () => {
+    strictEqual(
+      partialSweepToastKind(
+        "notice",
+        new TypeError("undefined is not a function"),
+      ),
+      "error",
+    );
+  });
+
+  it("escalation always reports — even a 'waking' pod, because it never actually woke", () => {
+    strictEqual(partialSweepToastKind("escalate", wakingError()), "error");
+    strictEqual(partialSweepToastKind("escalate", offlineError()), "error");
+  });
+});

--- a/packages/web/src/engine-adapter/client/activities-mixin.ts
+++ b/packages/web/src/engine-adapter/client/activities-mixin.ts
@@ -3,6 +3,7 @@ import type {
   ActivityUpdate,
   AllConversationsResult,
   ConversationEntry,
+  FailedAgentRead,
   NewActivity,
 } from "../../../../../ui/engine-client/src/types";
 import * as activities from "../activities";
@@ -95,29 +96,25 @@ export function ActivitiesMixin<TBase extends BaseCtor>(Base: TBase) {
         agentPaths.map((p) => this.listConversations(p)),
       );
       const conversations: ConversationEntry[] = [];
-      const failedAgentPaths: string[] = [];
-      let firstReason: unknown;
+      const failedAgents: FailedAgentRead[] = [];
       settled.forEach((outcome, i) => {
         if (outcome.status === "fulfilled") {
           conversations.push(...outcome.value);
           return;
         }
-        failedAgentPaths.push(agentPaths[i]);
-        if (firstReason === undefined) firstReason = outcome.reason;
         // Never a silent drop: the agent is named in the log, and the caller
-        // gets it in `failedAgentPaths` to surface + recover from.
+        // gets it — WITH the reason, so the surface layer can tell a waking
+        // pod's 503 from a real failure — in `failedAgents`.
+        failedAgents.push({ agentPath: agentPaths[i], reason: outcome.reason });
         console.warn(
           `[activities] conversations read failed for ${agentPaths[i]}: ${String(
             outcome.reason,
           )}`,
         );
       });
-      if (
-        agentPaths.length > 0 &&
-        failedAgentPaths.length === agentPaths.length
-      )
-        throw firstReason;
-      return { conversations, failedAgentPaths };
+      if (agentPaths.length > 0 && failedAgents.length === agentPaths.length)
+        throw failedAgents[0].reason;
+      return { conversations, failedAgents };
     }
   }
   return Activities;

--- a/packages/web/tests/all-conversations-partial-sweep.test.ts
+++ b/packages/web/tests/all-conversations-partial-sweep.test.ts
@@ -64,7 +64,7 @@ test("a complete sweep reports no failures", async () => {
 
   const result = await client().listAllConversations(["maya", "kai"]);
 
-  expect(result.failedAgentPaths).toEqual([]);
+  expect(result.failedAgents).toEqual([]);
   expect(result.conversations.map((c) => c.title)).toEqual([
     "Plan a trip to Tokyo",
     "Draft the launch email",
@@ -82,8 +82,15 @@ test("one unreachable agent no longer blanks the whole board", async () => {
   expect(result.conversations.map((c) => c.title)).toEqual([
     "Plan a trip to Tokyo",
   ]);
-  // Named, never silently dropped — this is what the query layer recovers from.
-  expect(result.failedAgentPaths).toEqual(["kai"]);
+  // Named, never silently dropped — this is what the query layer recovers
+  // from. The REASON travels too, so the surface layer can tell a waking
+  // pod's 503 from a real failure (HOUSTON-APP-538) instead of reporting
+  // every partial sweep blind.
+  expect(result.failedAgents.map((f) => f.agentPath)).toEqual(["kai"]);
+  const reason = result.failedAgents[0].reason as Error & { status?: number };
+  expect(reason.name).toBe("HoustonEngineError");
+  expect(reason.status).toBe(500);
+  expect(reason.message).toBe("agent unreachable (engine error 500)");
 });
 
 test("the healthy agents' rows survive regardless of fan-out order", async () => {
@@ -96,7 +103,7 @@ test("the healthy agents' rows survive regardless of fan-out order", async () =>
   const result = await client().listAllConversations(["maya", "kai", "rex"]);
 
   expect(result.conversations.map((c) => c.id)).toEqual(["b1", "c1"]);
-  expect(result.failedAgentPaths).toEqual(["maya"]);
+  expect(result.failedAgents.map((f) => f.agentPath)).toEqual(["maya"]);
 });
 
 test("a sweep where EVERY agent failed is a failure, not an empty board", async () => {
@@ -112,6 +119,6 @@ test("an empty roster sweeps to an empty, COMPLETE answer", async () => {
 
   await expect(client().listAllConversations([])).resolves.toEqual({
     conversations: [],
-    failedAgentPaths: [],
+    failedAgents: [],
   });
 });

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -923,7 +923,7 @@ export class HoustonClient {
     // Read-only POST → replay-safe. ONE request sweeps every agent server-side,
     // so the answer is all-or-nothing: it either throws or is complete. Only a
     // client-side fan-out (the hosted adapter) can come back partial, hence the
-    // always-empty `failedAgentPaths`.
+    // always-empty `failedAgents`.
     const conversations = await this.request<ConversationEntry[]>(
       "POST",
       "/conversations/list-all",
@@ -932,7 +932,7 @@ export class HoustonClient {
       undefined,
       true,
     );
-    return { conversations, failedAgentPaths: [] };
+    return { conversations, failedAgents: [] };
   }
 
   // ---------- skills ----------

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -1133,13 +1133,26 @@ export interface ConversationEntry {
  * cache). So the sweep reports WHICH agents it could not read, and the caller
  * decides how to recover (HOU-981).
  *
- * `failedAgentPaths` empty = a complete, trustworthy answer.
+ * `failedAgents` empty = a complete, trustworthy answer.
  */
 export interface AllConversationsResult {
   /** Rows from every agent that answered, flattened. */
   conversations: ConversationEntry[];
-  /** Agent paths whose read failed in THIS sweep. Non-empty = partial. */
-  failedAgentPaths: string[];
+  /** Agents whose read failed in THIS sweep. Non-empty = partial. */
+  failedAgents: FailedAgentRead[];
+}
+
+/**
+ * One agent the sweep could not read, WITH the error its read threw. The
+ * reason travels so the surface layer can classify the failure — a waking
+ * pod's "engine unavailable" 503 is an expected state with its own quiet
+ * surface, while a real failure must reach crash reporting — instead of
+ * reporting every partial sweep blind (HOUSTON-APP-538).
+ */
+export interface FailedAgentRead {
+  agentPath: string;
+  /** What the read threw, verbatim. */
+  reason: unknown;
 }
 
 // ---------- Skills ----------


### PR DESCRIPTION
Fixes HOUSTON-APP-538 — `list_all_conversations_partial: missions unread for 1 agent(s): <agent-id>`, 465 events / 193 users since 2026-07-29.

## Root cause

The cross-agent conversation sweep (`listAllConversations` in the hosted web adapter) fans out one `GET /agents/:id/activities` per agent. When a read fails, the adapter logged the error and dropped it, reporting only the failed agent **path**. The query-layer recovery (`recoverFromSweep`) therefore surfaced every partial sweep through `showErrorToast` → Sentry capture, blind to why the agent failed.

The event breadcrumbs show the dominant why: five consecutive `503 {"error":"engine unavailable"}` responses over ~16s from `gateway.gethouston.ai/agents/<id>/activities` — an asleep engine pod whose cold start outlived the transport's wake-retry budget (`cp/transient-retry.ts`, ~15s client-side). That is the managed cloud working as designed: HOU-1114 already classifies exactly this error as an expected state with a quiet "your agent is waking up" surface on every other per-agent call path — but the partial-sweep path couldn't classify because it had no error object, only agent ids. Meanwhile the recovery's own bounded re-sweep (5s/20s/60s) heals the hole once the pod wakes, so most of these 465 reports described a board that had already repaired itself.

## Fix

Carry the per-agent failure reasons through the sweep and classify the surface:

- `AllConversationsResult.failedAgentPaths: string[]` → `failedAgents: { agentPath, reason }[]` (engine-client type, adapter, `tauri.ts` sweep wrapper).
- New pure policy `app/src/lib/partial-sweep-surface.ts`: a first partial sweep whose failures are all expected environment states takes the matching informational surface — engine-waking (HOU-1114) or connectivity (HOU-1085), no Sentry; a real per-agent failure keeps the error surface exactly as before. A mixed sweep is judged by its worst member, so a real failure never hides behind waking pods.
- The recovery decision (`planPartialSweep`) now **escalates exactly once** when the bounded re-sweep schedule runs out with the hole still open: that report goes out under its own source tag (`list_all_conversations_stuck`) with the real error object attached — a pod that never woke through a whole recovery run (~90s + per-read wake budgets) is a crashloop/capacity problem and stays loud. Previously the report fired *before* recovery had a chance, and a genuinely stuck pod was indistinguishable from a slow one.
- Diagnostic lines (log + Sentry message) now name each failed agent **with its reason**, not just the id.

Nothing is swallowed (beta no-silent-failures policy): every path still logs, the informational toasts still dedupe through the burst gate, analytics still counts, and every non-expected failure still captures — the suppression is bounded by success, mirroring the established HOU-1114/HOU-1085 pattern in `lib/tauri.ts` `surfaceError`.

Housekeeping: `sweepIsAuthoritative` moved to `lib/sweep-authoritative.ts` to keep the recovery module under the 200-line limit.

## Tests

- `app/tests/partial-sweep-surface.test.ts` (new): reason classification incl. the exact `HoustonEngineError` 503 shape from the Sentry events, worst-member selection, coding-bug `TypeError` never mistaken for connectivity, escalation always reports.
- `app/tests/all-conversations-recovery.test.ts`: new decision shape, escalate-exactly-once across a saturated run, quiet-past-escalation.
- `packages/web/tests/all-conversations-partial-sweep.test.ts`: pins that the reason (name/status/message) rides `failedAgents`.

## Verification

- `cd app && pnpm test` — 3394 node tests green (one full-suite run + targeted re-run after fixing a `.ts`-extension import).
- `pnpm --filter houston-web` vitest `./tests` — 362/362 green.
- `app`/`packages/web`/`ui` typechecks, `pnpm check` (Biome), `pnpm check:boundaries` — clean.
- Not server-side-only: the gateway's 503-while-waking contract is by design; the defect was this client surfacing it as an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)