### PR TITLE
fix(credentials): stop revoked-credential resurrection loops + Sentry noise (HOUSTON-APP-530)

### DIFF
--- a/knowledge-base/anthropic-credentials.md
+++ b/knowledge-base/anthropic-credentials.md
@@ -170,6 +170,34 @@ way the coalescer's cached result for that key is forgotten, and a failure of th
 re-read itself degrades to "absent" rather than escaping as a 500 in place of the
 404 the runtime knows how to act on.
 
+### A provider-revoked credential must STAY deleted — the revocation tombstone
+
+The revoked-token report deleting the central row is only half the job; Sentry
+HOUSTON-APP-530 (734 events / 380 users in two weeks) was the other half:
+everything that put the dead credential BACK. Old pre-HOU-950 desktop builds
+still loop the cached-snapshot reconcile (`?if_absent=1` claude-oauth push) on a
+15–30s cadence, and the pod itself could refill via the legacy-fallback adoption
+(`credentials/remote-store.ts`) or the serve healer. Every refill of a revoked
+family fails the next turn, which reports, which deletes, which invites the next
+refill — one turn burned and one Sentry error per cycle, forever.
+
+`credentials/revocation-tombstones.ts` breaks the cycle: a CONFIRMED removal
+(`removed:true` on `/sandbox/credential/revoked`) tombstones that
+(workspace, scope, provider) for 15 minutes, and every AUTOMATIC refill path
+consults it — the `ifAbsent` claude-oauth fill answers 409, fallback adoption
+and the healer skip. Deliberately scope-blunt, not digest-scoped: a cached
+snapshot of the revoked family carries a DIFFERENT access token than the one
+the report named (the gateway rotated the family since), so a digest tombstone
+would block nothing. USER-driven connects are never blocked and CLEAR the
+tombstone (overwrite claude-oauth push, verified api-key/setup-token paste,
+device-code capture); the TTL bounds any clear-site we missed. Logging split
+accordingly: a confirmed removal is the pipeline WORKING (the user gets the
+reconnect card) and logs info; the error-level line — the only one Sentry
+should page on — is a SECOND confirmed removal inside the tombstone window,
+which means something (a stale client, a path that bypasses the pod host)
+resurrected a dead credential past the guards. The ledger is per-pod-process
+and in-memory: a pod restart forgives it, costing at most one extra cycle.
+
 ## The six traps (each was a live bug, or a guarded near-miss)
 
 1. **`USER` must reach the SDK subprocess.** The CLI names its Keychain

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -1,6 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ClaudeOAuthCredential, CustomEndpoint } from "@houston/protocol";
 import {
+  type RevocationTombstones,
+  RevokedRefillBlockedError,
+  sharedRevocationTombstones,
+} from "../credentials/revocation-tombstones";
+import {
   ApiKeyRejectedError,
   type CaptureResult,
   type ChannelCtx,
@@ -61,8 +66,14 @@ export class ProxyChannel implements RuntimeChannel {
       forwardActingHeader: boolean;
       /** Managed pod shared-cache freshness gate, invoked only for turn starts. */
       beforeTurn?: (agent: ChannelCtx["agent"]) => Promise<void>;
+      /** Injectable for tests; defaults to the process-wide ledger. */
+      revocations?: RevocationTombstones;
     },
   ) {}
+
+  private get revocations(): RevocationTombstones {
+    return this.opts.revocations ?? sharedRevocationTombstones;
+  }
 
   async dispatch(
     ctx: ChannelCtx,
@@ -318,7 +329,7 @@ export class ProxyChannel implements RuntimeChannel {
     ctx: ChannelCtx,
     provider?: string,
   ): Promise<CaptureResult> {
-    return captureRuntimeCredential({
+    const result = await captureRuntimeCredential({
       endpoint: await this.opts.launcher.ensureAwake(ctx.agent),
       credentials: this.opts.credentials,
       workspaceId: ctx.agent.workspaceId,
@@ -327,6 +338,16 @@ export class ProxyChannel implements RuntimeChannel {
       // runtime auth file, stored on their row, scrubbed from their file.
       actingAs: ctx.actingAs,
     });
+    // A user-driven device-code connect supersedes any provider revocation of
+    // the previous credential — automatic serving may resume immediately.
+    if (result.ok) {
+      this.revocations.clear({
+        workspaceId: ctx.agent.workspaceId,
+        provider: result.provider,
+        actingAs: ctx.actingAs,
+      });
+    }
+    return result;
   }
 
   /**
@@ -392,6 +413,13 @@ export class ProxyChannel implements RuntimeChannel {
       },
       { actingAs: ctx.actingAs },
     );
+    // A verified pasted key (incl. the anthropic setup token) is a fresh
+    // user-driven connect: it supersedes any provider revocation.
+    this.revocations.clear({
+      workspaceId: ctx.agent.workspaceId,
+      provider,
+      actingAs: ctx.actingAs,
+    });
   }
 
   /**
@@ -430,6 +458,26 @@ export class ProxyChannel implements RuntimeChannel {
       // means done: the pod serves the live credential. A probe failure
       // throws — the reconcile logs it and retries next session; guessing
       // "absent" here and materializing a stale file is never worth it.
+      //
+      // ABSENT is not automatically fillable either (HOUSTON-APP-530): when
+      // the row is absent because the provider REVOKED it (the runtime's
+      // revoked-token report deleted it minutes ago), a cached snapshot of
+      // that same family is exactly the poison above — old clients pre-HOU-950
+      // loop this push on a 15–30s cadence, re-revoking the fill every cycle.
+      // Refuse while the tombstone is live; a real sign-in pushes WITHOUT
+      // ifAbsent and is never blocked.
+      if (
+        this.revocations.active({
+          workspaceId: ctx.agent.workspaceId,
+          provider: "anthropic",
+          actingAs: ctx.actingAs,
+        })
+      ) {
+        console.warn(
+          "[credential] refused an if_absent claude-oauth fill: the anthropic credential was just provider-revoked (tombstone active)",
+        );
+        throw new RevokedRefillBlockedError("anthropic");
+      }
       const existing = await this.opts.credentials.get(
         ctx.agent.workspaceId,
         "anthropic",
@@ -469,6 +517,15 @@ export class ProxyChannel implements RuntimeChannel {
       // write between the probe above and this put still cannot be clobbered.
       { ifAbsent: opts?.ifAbsent, actingAs: ctx.actingAs },
     );
+    // A stored OVERWRITE push is a fresh user-driven sign-in: it supersedes
+    // any provider revocation, so automatic serving may resume immediately.
+    if (!opts?.ifAbsent) {
+      this.revocations.clear({
+        workspaceId: ctx.agent.workspaceId,
+        provider: "anthropic",
+        actingAs: ctx.actingAs,
+      });
+    }
     const endpoint = await this.opts.launcher.ensureAwake(ctx.agent);
     const res = await fetch(
       `${endpoint.baseUrl}/auth/anthropic/oauth-credential`,

--- a/packages/host/src/credentials/disconnect.test.ts
+++ b/packages/host/src/credentials/disconnect.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import type { CredentialStore, WorkspaceCredential } from "../ports";
 import { disconnectRejectedCredential } from "./disconnect";
 import { RemoteCredentialDeadError } from "./remote-store";
+import { RevocationTombstones } from "./revocation-tombstones";
 
 /**
  * Compare-and-delete: the token endpoint's rejection condemns exactly ONE
@@ -28,12 +29,16 @@ function store(over: Partial<CredentialStore> = {}): CredentialStore {
   };
 }
 
-const disconnect = (credentials: CredentialStore) =>
+const disconnect = (
+  credentials: CredentialStore,
+  revocations = new RevocationTombstones(),
+) =>
   disconnectRejectedCredential({
     credentials,
     workspaceId: "w1",
     rejected,
     reason: "invalid_grant",
+    revocations,
   });
 
 test("a matching credential is dropped and the caller told it is gone", async () => {
@@ -51,6 +56,25 @@ test("a matching credential is dropped and the caller told it is gone", async ()
   );
   expect(result).toBeNull();
   expect(removals).toHaveLength(1);
+});
+
+test("a dropped credential leaves a tombstone so automatic refills stay refused", async () => {
+  // The rejected-refresh drop is as terminal as a provider revocation: an
+  // if_absent snapshot push / fallback adoption / heal that refills the row
+  // would loop invalid_grant → disconnect forever (HOU-855, HOUSTON-APP-530).
+  const revocations = new RevocationTombstones();
+  await disconnect(store({ removeIfAccess: async () => true }), revocations);
+  expect(
+    revocations.active({ workspaceId: "w1", provider: "openai-codex" }),
+  ).toBe(true);
+});
+
+test("a superseded rejection leaves no tombstone — the live credential keeps serving", async () => {
+  const revocations = new RevocationTombstones();
+  await disconnect(store({ removeIfAccess: async () => false }), revocations);
+  expect(
+    revocations.active({ workspaceId: "w1", provider: "openai-codex" }),
+  ).toBe(false);
 });
 
 test("a genuinely superseding credential is handed back to be served", async () => {

--- a/packages/host/src/credentials/disconnect.ts
+++ b/packages/host/src/credentials/disconnect.ts
@@ -6,6 +6,10 @@ import type {
   WorkspaceCredential,
 } from "../ports";
 import { sharedCredentialRefresher } from "./refresh-coalescer";
+import {
+  type RevocationTombstones,
+  sharedRevocationTombstones,
+} from "./revocation-tombstones";
 
 /**
  * What the control plane does when the OAuth server rejects a refresh TOKEN
@@ -31,6 +35,8 @@ export async function disconnectRejectedCredential(args: {
   acting?: CredentialActing;
   /** The rejection's message, for the disconnect log line. */
   reason: string;
+  /** Injectable for tests; defaults to the process-wide ledger. */
+  revocations?: RevocationTombstones;
 }): Promise<WorkspaceCredential | null> {
   const { credentials, workspaceId, rejected, acting } = args;
   // The digest names the DEAD token. The caller hands us the credential IT
@@ -50,6 +56,18 @@ export async function disconnectRejectedCredential(args: {
   // re-read rather than refreshed again with the token just rejected.
   sharedCredentialRefresher.forget(workspaceId, rejected.provider, acting);
   if (dropped) {
+    // A rejected refresh token is as terminal as a provider revocation, and
+    // the same automatic refills (an if_absent snapshot push, fallback
+    // adoption, the healer) would loop it: fill → next serve refreshes with
+    // the superseded token → invalid_grant → disconnect → fill again
+    // (HOU-855's poison cycle, HOUSTON-APP-530's volume). Tombstone it so
+    // only a real reconnect brings the provider back.
+    (args.revocations ?? sharedRevocationTombstones).mark({
+      workspaceId,
+      provider: rejected.provider,
+      scope: rejected.scope === "personal" ? "personal" : "team",
+      actingAs: acting?.actingAs,
+    });
     console.error(
       `[credential-disconnect] refresh token rejected for ${rejected.provider}, disconnecting:`,
       args.reason,

--- a/packages/host/src/credentials/remote-store.test.ts
+++ b/packages/host/src/credentials/remote-store.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import type { CredentialStore, WorkspaceCredential } from "../ports";
 import { RemoteCredentialStore, scopeKeyOf } from "./remote-store";
+import { RevocationTombstones } from "./revocation-tombstones";
 
 type FetchCall = { url: string; init?: RequestInit };
 
@@ -37,7 +38,11 @@ function fakeFetch(
   return { calls, fetchImpl };
 }
 
-function store(fetchImpl: typeof fetch, fallback?: CredentialStore) {
+function store(
+  fetchImpl: typeof fetch,
+  fallback?: CredentialStore,
+  revocations?: RevocationTombstones,
+) {
   return new RemoteCredentialStore({
     baseUrl: `${BASE}/`,
     orgSlug: ORG,
@@ -45,6 +50,7 @@ function store(fetchImpl: typeof fetch, fallback?: CredentialStore) {
     podToken: "pod-token",
     fallback,
     fetchImpl,
+    revocations: revocations ?? new RevocationTombstones(),
   });
 }
 
@@ -143,6 +149,43 @@ test("404 adopts a legacy fallback credential with insert-only PUT, then re-gets
   ]);
   expect(got?.accessToken).toBe("AT-winner");
   expect(got?.refreshToken).toBe("");
+});
+
+test("404 never adopts the fallback while a revocation tombstone is active (HOUSTON-APP-530)", async () => {
+  const legacy: WorkspaceCredential = {
+    workspaceId: "ws_1",
+    provider: "openai-codex",
+    kind: "oauth",
+    accessToken: "AT-legacy",
+    refreshToken: "RT-legacy",
+    expiresAt: 123,
+  };
+  const fallback: CredentialStore = {
+    get: async () => legacy,
+    put: async () => {},
+    remove: async () => {},
+    removeIfAccess: async () => false,
+  };
+  const { calls, fetchImpl } = fakeFetch(() =>
+    json({ error: "org not connected" }, 404),
+  );
+  const revocations = new RevocationTombstones();
+  // The gateway row is absent BECAUSE the provider revoked the credential;
+  // the legacy file copy is the same dead family and must stay un-adopted.
+  revocations.mark({
+    workspaceId: "ws_1",
+    provider: "openai-codex",
+    scope: "team",
+  });
+
+  const got = await store(fetchImpl, fallback, revocations).get(
+    "ws_1",
+    "openai-codex",
+  );
+
+  expect(got).toBeNull();
+  // One GET, no insert-only PUT: the dead credential was not resurrected.
+  expect(calls.map((c) => c.init?.method ?? "GET")).toEqual(["GET"]);
 });
 
 test("transport errors throw and are not cached", async () => {

--- a/packages/host/src/credentials/remote-store.ts
+++ b/packages/host/src/credentials/remote-store.ts
@@ -10,6 +10,10 @@ import {
   type GatewayCredential,
   isNotConnected404,
 } from "./gateway-wire";
+import {
+  type RevocationTombstones,
+  sharedRevocationTombstones,
+} from "./revocation-tombstones";
 import { credentialScopeKey } from "./scope-key";
 
 const CACHE_TTL_MS = 15_000;
@@ -22,6 +26,8 @@ export interface RemoteCredentialStoreOptions {
   podToken: string;
   fallback?: CredentialStore;
   fetchImpl?: typeof fetch;
+  /** Injectable for tests; defaults to the process-wide ledger. */
+  revocations?: RevocationTombstones;
 }
 
 /** The gateway positively identified the stored credential as unusable. */
@@ -43,6 +49,7 @@ export class RemoteCredentialStore implements CredentialStore {
   private readonly podToken: string;
   private readonly fallback?: CredentialStore;
   private readonly fetchImpl: typeof fetch;
+  private readonly revocations: RevocationTombstones;
   private readonly cache = new Map<
     string,
     { until: number; value: CachedCredential | null }
@@ -55,6 +62,7 @@ export class RemoteCredentialStore implements CredentialStore {
     this.podToken = opts.podToken;
     this.fallback = opts.fallback;
     this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.revocations = opts.revocations ?? sharedRevocationTombstones;
   }
 
   async get(
@@ -171,6 +179,12 @@ export class RemoteCredentialStore implements CredentialStore {
     workspaceId: WorkspaceId,
     provider: string,
   ): Promise<CachedCredential | null> {
+    // A gateway row deleted because the PROVIDER revoked the credential must
+    // not be refilled from the legacy local file — that copy is the same dead
+    // family, and re-adopting it re-fails the next turn into another revoked
+    // report (HOUSTON-APP-530). removeIfAccess clears this pod's fallback, but
+    // a sibling pod's file (or a remove that raced) can still hold the entry.
+    if (this.revocations.active({ workspaceId, provider })) return null;
     const local = await this.fallback?.get(workspaceId, provider);
     if (!local) return null;
 

--- a/packages/host/src/credentials/revocation-tombstones.test.ts
+++ b/packages/host/src/credentials/revocation-tombstones.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "vitest";
+import { RevocationTombstones } from "./revocation-tombstones";
+
+const TTL_MS = 15 * 60_000;
+
+function actingAs(sub: string): string {
+  return `header.${Buffer.from(JSON.stringify({ sub })).toString("base64url")}.sig`;
+}
+
+const SCOPE = { workspaceId: "ws_1", provider: "anthropic" };
+
+test("a team mark blocks the team caller until the TTL passes", () => {
+  let now = 1_700_000_000_000;
+  const t = new RevocationTombstones(() => now);
+
+  expect(t.active(SCOPE)).toBe(false);
+  t.mark({ ...SCOPE, scope: "team" });
+  expect(t.active(SCOPE)).toBe(true);
+
+  now += TTL_MS - 1;
+  expect(t.active(SCOPE)).toBe(true);
+  now += 1;
+  expect(t.active(SCOPE)).toBe(false);
+});
+
+test("mark reports whether a tombstone was still active — the resurrection signal", () => {
+  let now = 1_700_000_000_000;
+  const t = new RevocationTombstones(() => now);
+
+  expect(t.mark({ ...SCOPE, scope: "team" })).toBe(false);
+  now += 30_000;
+  // A second confirmed delete 30s later means something refilled the dead
+  // credential — the caller escalates this one.
+  expect(t.mark({ ...SCOPE, scope: "team" })).toBe(true);
+  now += TTL_MS + 1;
+  expect(t.mark({ ...SCOPE, scope: "team" })).toBe(false);
+});
+
+test("a team mark also blocks an acting caller (row resolution is the gateway's)", () => {
+  const t = new RevocationTombstones(() => 1_700_000_000_000);
+  t.mark({ ...SCOPE, scope: "team" });
+
+  // A personal-space push carries an acting identity while its serve reports
+  // the team row; the pod cannot mirror the gateway's resolution, so the
+  // acting caller must be blocked by the team tombstone too.
+  expect(t.active({ ...SCOPE, actingAs: actingAs("member-a") })).toBe(true);
+});
+
+test("a personal mark blocks only that member, never the team or a sibling", () => {
+  const t = new RevocationTombstones(() => 1_700_000_000_000);
+  t.mark({ ...SCOPE, scope: "personal", actingAs: actingAs("member-a") });
+
+  expect(t.active({ ...SCOPE, actingAs: actingAs("member-a") })).toBe(true);
+  expect(t.active({ ...SCOPE, actingAs: actingAs("member-b") })).toBe(false);
+  expect(t.active(SCOPE)).toBe(false);
+});
+
+test("scoping: a different provider or workspace is never blocked", () => {
+  const t = new RevocationTombstones(() => 1_700_000_000_000);
+  t.mark({ ...SCOPE, scope: "team" });
+
+  expect(t.active({ workspaceId: "ws_1", provider: "openai-codex" })).toBe(
+    false,
+  );
+  expect(t.active({ workspaceId: "ws_2", provider: "anthropic" })).toBe(false);
+});
+
+test("clear lifts the block for both the acting and the team key", () => {
+  const t = new RevocationTombstones(() => 1_700_000_000_000);
+  const member = actingAs("member-a");
+  t.mark({ ...SCOPE, scope: "team" });
+  t.mark({ ...SCOPE, scope: "personal", actingAs: member });
+
+  // The member's fresh sign-in clears their own key AND the shared one — a
+  // user-driven connect supersedes the revocation for the rows it can land on.
+  t.clear({ ...SCOPE, actingAs: member });
+
+  expect(t.active({ ...SCOPE, actingAs: member })).toBe(false);
+  expect(t.active(SCOPE)).toBe(false);
+});

--- a/packages/host/src/credentials/revocation-tombstones.ts
+++ b/packages/host/src/credentials/revocation-tombstones.ts
@@ -1,0 +1,119 @@
+import { credentialScopeKey, TEAM_SCOPE_KEY } from "./scope-key";
+
+/**
+ * Short-lived tombstones for credentials a PROVIDER revoked (HOUSTON-APP-530).
+ *
+ * A confirmed revoked-token report (routes/credential-revoked.ts) deletes the
+ * central credential — that part works. What kept the Sentry issue alive was
+ * everything that put the dead credential BACK: the legacy desktop reconcile
+ * still shipping cached snapshots with `?if_absent=1` (HOU-950 removed the
+ * client code, but old builds keep pushing on a 15–30s cadence), and the pod's
+ * own automatic refills (legacy-fallback adoption in remote-store.ts, the serve
+ * healer). Every refill of a revoked family fails the next turn, which reports,
+ * which deletes, which invites the next refill — one Sentry error per cycle,
+ * 734 events across 380 users in two weeks.
+ *
+ * The tombstone breaks the cycle at the pod host, the one place every refill
+ * path crosses: after a confirmed revocation, AUTOMATIC refills of that
+ * (workspace, scope, provider) are refused for a TTL. Deliberately blunt on
+ * scope — a cached snapshot from the revoked family carries a DIFFERENT access
+ * token than the one the report named (the gateway rotated the family since the
+ * snapshot was cached), so a digest-scoped tombstone would not block it.
+ *
+ * USER-driven connects are never blocked: a fresh browser login / setup-token
+ * paste arrives WITHOUT `ifAbsent` and clears the tombstone on store. The TTL
+ * bounds the cost of any clear-site we missed.
+ */
+const TOMBSTONE_TTL_MS = 15 * 60_000;
+
+/** Thrown when an automatic (fill-only) push hits an active tombstone. */
+export class RevokedRefillBlockedError extends Error {
+  constructor(provider: string) {
+    super(
+      `the ${provider} credential was just revoked by the provider; refusing to restore a cached copy — reconnect the provider to sign in again`,
+    );
+  }
+}
+
+type TombstoneScope = {
+  workspaceId: string;
+  provider: string;
+  /** The acting identity of the caller, when there is one (HOU-976). */
+  actingAs?: string;
+};
+
+export class RevocationTombstones {
+  private readonly marks = new Map<string, number>();
+
+  constructor(
+    private readonly now: () => number = Date.now,
+    private readonly ttlMs: number = TOMBSTONE_TTL_MS,
+  ) {}
+
+  /**
+   * Record a confirmed revocation delete. `scope` is the ROW the report named:
+   * a personal report tombstones the member's key, a team report the shared
+   * one. Returns whether a tombstone for that key was STILL ACTIVE — a second
+   * confirmed delete inside the window means something refilled a revoked
+   * credential past the guards, which is the caller's cue to escalate.
+   */
+  mark(scope: TombstoneScope & { scope: "personal" | "team" }): boolean {
+    const key = this.key(
+      scope.workspaceId,
+      scope.scope === "personal"
+        ? credentialScopeKey({ actingAs: scope.actingAs })
+        : TEAM_SCOPE_KEY,
+      scope.provider,
+    );
+    const wasActive = this.activeKey(key);
+    this.sweep();
+    this.marks.set(key, this.now() + this.ttlMs);
+    return wasActive;
+  }
+
+  /**
+   * Whether an automatic refill for this caller must be refused. Checks the
+   * caller's own scope key AND the shared team key: the pod cannot always
+   * mirror the gateway's row resolution (a personal-space push carries an
+   * acting identity while its serve reports the team row), and blocking a
+   * refill too broadly costs at most one TTL of automatic recovery.
+   */
+  active(scope: TombstoneScope): boolean {
+    return this.keysFor(scope).some((k) => this.activeKey(k));
+  }
+
+  /** A fresh user-driven connect supersedes the revocation. Clears both keys. */
+  clear(scope: TombstoneScope): void {
+    for (const k of this.keysFor(scope)) this.marks.delete(k);
+  }
+
+  private keysFor(scope: TombstoneScope): string[] {
+    const acting = credentialScopeKey({ actingAs: scope.actingAs });
+    const keys = [this.key(scope.workspaceId, acting, scope.provider)];
+    if (acting !== TEAM_SCOPE_KEY)
+      keys.push(this.key(scope.workspaceId, TEAM_SCOPE_KEY, scope.provider));
+    return keys;
+  }
+
+  private key(workspaceId: string, scopeKey: string, provider: string): string {
+    return `${workspaceId}:${scopeKey}:${provider}`;
+  }
+
+  private activeKey(key: string): boolean {
+    const until = this.marks.get(key);
+    return until !== undefined && until > this.now();
+  }
+
+  /** Drop aged-out entries so the map stays bounded on long-lived hosts. */
+  private sweep(): void {
+    const now = this.now();
+    for (const [k, until] of this.marks) if (until <= now) this.marks.delete(k);
+  }
+}
+
+/**
+ * The process-wide instance (precedent: sharedCredentialRefresher). Every
+ * consumer defaults to it so the revoked route, the claude-oauth push path,
+ * the legacy-fallback adoption and the serve healer all see one ledger.
+ */
+export const sharedRevocationTombstones = new RevocationTombstones();

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -16,6 +16,7 @@ import {
   actingAuthorFromHeader,
   actingSubFromHeader,
 } from "../auth/acting";
+import { RevokedRefillBlockedError } from "../credentials/revocation-tombstones";
 import { checkPublicHttpsEndpoint } from "../custom-endpoint-validation";
 import type { Agent, UserId, Workspace } from "../domain/types";
 import {
@@ -591,7 +592,9 @@ export async function handleAgents(
       );
       json(res, 200, { ok: true });
     } catch (err) {
-      json(res, 502, {
+      // 409, not 502: the fill was refused on purpose (the credential was
+      // just provider-revoked — HOUSTON-APP-530), not lost to a broken hop.
+      json(res, err instanceof RevokedRefillBlockedError ? 409 : 502, {
         error: err instanceof Error ? err.message : String(err),
       });
     }

--- a/packages/host/src/routes/claude-oauth.test.ts
+++ b/packages/host/src/routes/claude-oauth.test.ts
@@ -9,6 +9,7 @@ import {
   test,
 } from "vitest";
 import { ProxyChannel } from "../channel/proxy";
+import { RevocationTombstones } from "../credentials/revocation-tombstones";
 import { MemoryCredentialStore } from "../credentials/store";
 import type { Agent, Workspace } from "../domain/types";
 import { FakeLauncher } from "../launcher/fake";
@@ -73,12 +74,15 @@ interface Fixture {
   credentials: MemoryCredentialStore;
   workspace: Workspace;
   agent: Agent;
+  revocations: RevocationTombstones;
 }
 
 /** Boot a host over HTTP whose only principal is `owner`, with one agent. */
 async function boot(owner = "alice"): Promise<Fixture> {
   const store = new MemoryWorkspaceStore({ defaultRuntime: "gke" });
   const credentials = new MemoryCredentialStore();
+  // Per-fixture ledger so tests never share the process-wide singleton.
+  const revocations = new RevocationTombstones();
   const workspace = await store.getOrCreatePersonalWorkspace(owner);
   const agent = await store.createAgent({
     workspaceId: workspace.id,
@@ -89,6 +93,7 @@ async function boot(owner = "alice"): Promise<Fixture> {
     proxy: { forward },
     credentials,
     forwardActingHeader: true,
+    revocations,
   });
   const deps: AgentRouteDeps = { store, channels: { gke: channel } };
 
@@ -123,6 +128,7 @@ async function boot(owner = "alice"): Promise<Fixture> {
     credentials,
     workspace,
     agent,
+    revocations,
   };
 }
 
@@ -317,6 +323,72 @@ describe("POST /agents/:id/credential/claude-oauth", () => {
         expect(res.status).toBe(200);
         const cred = await fx.credentials.get(fx.workspace.id, "anthropic");
         expect(cred?.refreshToken).toBe("sk-ant-ort-REFRESH-SECRET");
+      } finally {
+        fx.close();
+      }
+    });
+
+    // HOUSTON-APP-530: the row being ABSENT is not proof it is fillable — a
+    // provider-revoked credential was just deleted by the runtime's report,
+    // and old pre-HOU-950 clients loop this fill-only push every 15-30s,
+    // resurrecting the dead family into another failed turn + revoked report.
+    test("after a provider revocation the fill is refused with 409, nothing written", async () => {
+      const fx = await boot();
+      try {
+        fx.revocations.mark({
+          workspaceId: fx.workspace.id,
+          provider: "anthropic",
+          scope: "team",
+        });
+
+        const res = await push(
+          fx.base,
+          fx.agent.id,
+          STALE,
+          "alice",
+          "?if_absent=1",
+        );
+
+        expect(res.status).toBe(409);
+        expect(
+          await fx.credentials.get(fx.workspace.id, "anthropic"),
+        ).toBeNull();
+        expect(lastPush).toBeNull();
+      } finally {
+        fx.close();
+      }
+    });
+
+    test("a fresh overwrite push clears the tombstone; fills work again after", async () => {
+      const fx = await boot();
+      try {
+        fx.revocations.mark({
+          workspaceId: fx.workspace.id,
+          provider: "anthropic",
+          scope: "team",
+        });
+
+        // The user signs in again for real: never blocked, and it lifts the
+        // tombstone so automatic serving/fills resume.
+        const fresh = await push(fx.base, fx.agent.id, VALID);
+        expect(fresh.status).toBe(200);
+        expect(
+          fx.revocations.active({
+            workspaceId: fx.workspace.id,
+            provider: "anthropic",
+          }),
+        ).toBe(false);
+
+        // With the row cleared (e.g. sign-out), a fill-only push works again.
+        await fx.credentials.remove(fx.workspace.id, "anthropic");
+        const refill = await push(
+          fx.base,
+          fx.agent.id,
+          STALE,
+          "alice",
+          "?if_absent=1",
+        );
+        expect(refill.status).toBe(200);
       } finally {
         fx.close();
       }

--- a/packages/host/src/routes/credential-healer.test.ts
+++ b/packages/host/src/routes/credential-healer.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "vitest";
+import { RevocationTombstones } from "../credentials/revocation-tombstones";
 import {
   type CredentialHeal,
   CredentialServeHealer,
@@ -100,6 +101,31 @@ test("one member's cooldown never mutes another member's heal", async () => {
     actingAs("member-b"),
     actingAs("member-a"),
   ]);
+});
+
+test("a heal is refused while the provider's revocation tombstone is active (HOUSTON-APP-530)", async () => {
+  const { seen, heal } = recorder();
+  let now = 1_700_000_000_000;
+  const revocations = new RevocationTombstones(() => now);
+  const healer = new CredentialServeHealer(heal, () => now, revocations);
+  const args = {
+    workspaceId: "ws",
+    agentId: "ws/agent",
+    provider: "anthropic",
+  };
+
+  // The serve miss exists BECAUSE the provider revoked the credential; healing
+  // would re-upload the pod's copy of the same dead family.
+  revocations.mark({ workspaceId: "ws", provider: "anthropic", scope: "team" });
+  expect(await healer.attempt(args)).toBe(false);
+  expect(seen).toEqual([]);
+
+  // A fresh user-driven connect clears the tombstone; healing resumes — and
+  // the refusal above must not have spent the cooldown.
+  revocations.clear({ workspaceId: "ws", provider: "anthropic" });
+  now += 1_000;
+  expect(await healer.attempt(args)).toBe(true);
+  expect(seen).toEqual([undefined]);
 });
 
 test("no acting identity keeps the single shared slot (desktop, self-host)", async () => {

--- a/packages/host/src/routes/credential-healer.ts
+++ b/packages/host/src/routes/credential-healer.ts
@@ -1,3 +1,7 @@
+import {
+  type RevocationTombstones,
+  sharedRevocationTombstones,
+} from "../credentials/revocation-tombstones";
 import { credentialScopeKey } from "../credentials/scope-key";
 
 const HEAL_COOLDOWN_MS = 5 * 60_000;
@@ -23,9 +27,22 @@ export class CredentialServeHealer {
   constructor(
     private readonly heal: CredentialHeal,
     private readonly now: () => number = Date.now,
+    private readonly revocations: RevocationTombstones = sharedRevocationTombstones,
   ) {}
 
   attempt(args: Parameters<CredentialHeal>[0]): Promise<boolean> {
+    // A serve miss caused by a provider REVOKING the credential must not be
+    // healed by re-uploading the pod's copy of that same dead family
+    // (HOUSTON-APP-530); the user has to reconnect, which clears the tombstone.
+    if (
+      this.revocations.active({
+        workspaceId: args.workspaceId,
+        provider: args.provider,
+        actingAs: args.actingAs,
+      })
+    ) {
+      return Promise.resolve(false);
+    }
     const key = `${args.workspaceId}:${credentialScopeKey({ actingAs: args.actingAs })}:${args.provider}`;
     const existing = this.inFlight.get(key);
     if (existing) return existing;

--- a/packages/host/src/routes/credential-revoked.test.ts
+++ b/packages/host/src/routes/credential-revoked.test.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
+import { RevocationTombstones } from "../credentials/revocation-tombstones";
 import type {
   CredentialActing,
   CredentialStore,
@@ -73,10 +74,15 @@ function mockRes(): {
   return { res, out };
 }
 
-const post = (credentials: CredentialStore, body: unknown, token = "sbx") => {
+const post = (
+  credentials: CredentialStore,
+  body: unknown,
+  token = "sbx",
+  revocations = new RevocationTombstones(),
+) => {
   const { res, out } = mockRes();
   return handleSandboxCredentialRevoked(
-    { vault, credentials },
+    { vault, credentials, revocations },
     "POST",
     "/sandbox/credential/revoked",
     new URL("http://x/sandbox/credential/revoked"),
@@ -160,4 +166,68 @@ test("an unauthenticated report never reaches the store", async () => {
 
   expect(status).toBe(401);
   expect(reports).toEqual([]);
+});
+
+test("a confirmed removal tombstones the credential and logs info, not error (HOUSTON-APP-530)", async () => {
+  const { credentials } = capturingStore(true);
+  const revocations = new RevocationTombstones();
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+  try {
+    await post(
+      credentials,
+      { provider: "anthropic", accessSha256: "a".repeat(64) },
+      "sbx",
+      revocations,
+    );
+
+    // The expected disconnect pipeline working is NOT a Sentry error — that
+    // error-level line was the whole HOUSTON-APP-530 flood.
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("credential disconnected"),
+    );
+    expect(
+      revocations.active({ workspaceId: "w1", provider: "anthropic" }),
+    ).toBe(true);
+  } finally {
+    errorSpy.mockRestore();
+    infoSpy.mockRestore();
+  }
+});
+
+test("a second confirmed removal inside the window escalates: something refilled a dead credential", async () => {
+  const { credentials } = capturingStore(true);
+  const revocations = new RevocationTombstones();
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+  try {
+    const body = { provider: "anthropic", accessSha256: "a".repeat(64) };
+    await post(credentials, body, "sbx", revocations);
+    await post(credentials, body, "sbx", revocations);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("refilled and revoked AGAIN"),
+    );
+  } finally {
+    errorSpy.mockRestore();
+    infoSpy.mockRestore();
+  }
+});
+
+test("a superseded report leaves no tombstone — the live credential keeps serving", async () => {
+  const { credentials } = capturingStore(false);
+  const revocations = new RevocationTombstones();
+
+  await post(
+    credentials,
+    { provider: "anthropic", accessSha256: "a".repeat(64) },
+    "sbx",
+    revocations,
+  );
+
+  expect(revocations.active({ workspaceId: "w1", provider: "anthropic" })).toBe(
+    false,
+  );
 });

--- a/packages/host/src/routes/credential-revoked.ts
+++ b/packages/host/src/routes/credential-revoked.ts
@@ -1,4 +1,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  type RevocationTombstones,
+  sharedRevocationTombstones,
+} from "../credentials/revocation-tombstones";
 import type { CredentialStore, CredentialVault } from "../ports";
 import { bearer, json, readJson } from "./http";
 
@@ -22,7 +26,12 @@ import { bearer, json, readJson } from "./http";
  * Returns true when the request was handled.
  */
 export async function handleSandboxCredentialRevoked(
-  deps: { vault: CredentialVault; credentials: CredentialStore },
+  deps: {
+    vault: CredentialVault;
+    credentials: CredentialStore;
+    /** Injectable for tests; defaults to the process-wide ledger. */
+    revocations?: RevocationTombstones;
+  },
   method: string,
   path: string,
   url: URL,
@@ -70,12 +79,35 @@ export async function handleSandboxCredentialRevoked(
   // Both outcomes are success. `removed:false` means the report was superseded
   // — the workspace reconnected, or a sibling runtime reported the same dead
   // token first — and the reporter's own retry/backoff must not treat that as
-  // an error to escalate.
-  console[removed ? "error" : "info"](
-    `[sandbox/credential] revoked-token report for ${provider}: ${
-      removed ? "credential disconnected" : "superseded, left in place"
-    }`,
-  );
+  // an error to escalate. A confirmed removal is the pipeline WORKING (the
+  // user gets the reconnect card), so it logs info, not error — Sentry
+  // HOUSTON-APP-530 was this line at error level, one event per expected
+  // disconnect. The tombstone it leaves behind is what blocks automatic
+  // refills of the dead credential (revocation-tombstones.ts); a SECOND
+  // confirmed removal inside the tombstone window means something refilled a
+  // revoked credential past those guards — the one outcome that IS a defect,
+  // and the only one that still logs at error level.
+  if (removed) {
+    const refilled = (deps.revocations ?? sharedRevocationTombstones).mark({
+      workspaceId: claim.workspaceId,
+      provider,
+      scope,
+      actingAs,
+    });
+    if (refilled) {
+      console.error(
+        `[sandbox/credential] revoked ${provider} credential was refilled and revoked AGAIN within the tombstone window — an automatic push is resurrecting a dead credential`,
+      );
+    } else {
+      console.info(
+        `[sandbox/credential] revoked-token report for ${provider}: credential disconnected`,
+      );
+    }
+  } else {
+    console.info(
+      `[sandbox/credential] revoked-token report for ${provider}: superseded, left in place`,
+    );
+  }
   json(res, 200, { ok: true, removed });
   return true;
 }

--- a/packages/host/src/routes/setup-runtime.ts
+++ b/packages/host/src/routes/setup-runtime.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { parseClaudeOAuthEnvelope } from "@houston/protocol";
+import { RevokedRefillBlockedError } from "../credentials/revocation-tombstones";
 import type { Agent, UserId, WorkspaceRuntime } from "../domain/types";
 import {
   ApiKeyRejectedError,
@@ -153,7 +154,9 @@ export async function handleSetupRuntime(
       });
       json(res, 200, { ok: true });
     } catch (err) {
-      json(res, 502, {
+      // 409, not 502: the fill was refused on purpose (the credential was
+      // just provider-revoked — HOUSTON-APP-530), not lost to a broken hop.
+      json(res, err instanceof RevokedRefillBlockedError ? 409 : 502, {
         error: err instanceof Error ? err.message : String(err),
       });
     }

--- a/packages/runtime/src/auth/report-revoked.test.ts
+++ b/packages/runtime/src/auth/report-revoked.test.ts
@@ -7,7 +7,10 @@ import { afterEach, expect, test } from "vitest";
 import { config } from "../config";
 import { runWithActingContext } from "../session/acting-context";
 import { authPathIn, servedProvidersPathIn } from "./auth-file";
-import { reportRevokedServedToken } from "./report-revoked";
+import {
+  reportRevokedServedToken,
+  resetRevokedReportsForTest,
+} from "./report-revoked";
 import { recordServedScope, resetServedScopes } from "./served-scope";
 
 /**
@@ -104,7 +107,10 @@ function actingToken(sub: string): string {
 
 const alice = { actingAs: actingToken("sub-alice") };
 
-afterEach(() => resetServedScopes());
+afterEach(() => {
+  resetServedScopes();
+  resetRevokedReportsForTest();
+});
 
 const revoked: ProviderError = {
   kind: "unauthenticated",
@@ -301,6 +307,79 @@ test("does NOT report an api_key credential", async () => {
     () => reportRevokedServedToken(revoked),
   );
   expect(captured).toBeNull();
+});
+
+test("the same dead token is reported once per pod lifetime (HOUSTON-APP-530)", async () => {
+  // A control plane whose DELETE→GET path lags can re-serve a token this pod
+  // already reported dead; re-reporting it re-fires the confirmed delete and
+  // its Sentry trail once per failed turn. Once is enough — the delete is
+  // idempotent, and the reconnect card is already up.
+  const prevFetch = globalThis.fetch;
+  const prevUrl = config.controlPlaneUrl;
+  const prevTok = config.sandboxToken;
+  const prevDataDir = config.dataDir;
+  config.controlPlaneUrl = "http://control-plane.test";
+  config.sandboxToken = "sbx-token";
+  config.dataDir = mkdtempSync(join(tmpdir(), "houston-revoked-dedupe-"));
+  let reports = 0;
+  globalThis.fetch = (async () => {
+    reports += 1;
+    return new Response(JSON.stringify({ ok: true, removed: true }), {
+      status: 200,
+    });
+  }) as unknown as typeof globalThis.fetch;
+  try {
+    servedAnthropic(config.dataDir, "same-dead-token");
+    reportRevokedServedToken(revoked);
+    await new Promise((r) => setTimeout(r, 10));
+    reportRevokedServedToken(revoked);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(reports).toBe(1);
+
+    // A DIFFERENT token (the workspace reconnected, then that one died too)
+    // is a new fact and reports again.
+    servedAnthropic(config.dataDir, "next-dead-token");
+    reportRevokedServedToken(revoked);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(reports).toBe(2);
+  } finally {
+    globalThis.fetch = prevFetch;
+    config.controlPlaneUrl = prevUrl;
+    config.sandboxToken = prevTok;
+    config.dataDir = prevDataDir;
+  }
+});
+
+test("a failed report is not deduped — the next turn retries", async () => {
+  const prevFetch = globalThis.fetch;
+  const prevUrl = config.controlPlaneUrl;
+  const prevTok = config.sandboxToken;
+  const prevDataDir = config.dataDir;
+  config.controlPlaneUrl = "http://control-plane.test";
+  config.sandboxToken = "sbx-token";
+  config.dataDir = mkdtempSync(join(tmpdir(), "houston-revoked-retry-"));
+  let reports = 0;
+  globalThis.fetch = (async () => {
+    reports += 1;
+    if (reports === 1) throw new Error("gateway unreachable");
+    return new Response(JSON.stringify({ ok: true, removed: true }), {
+      status: 200,
+    });
+  }) as unknown as typeof globalThis.fetch;
+  try {
+    servedAnthropic(config.dataDir, "retry-dead-token");
+    reportRevokedServedToken(revoked);
+    await new Promise((r) => setTimeout(r, 10));
+    reportRevokedServedToken(revoked);
+    await new Promise((r) => setTimeout(r, 10));
+    // The failed attempt un-marked itself; the second turn's report went out.
+    expect(reports).toBe(2);
+  } finally {
+    globalThis.fetch = prevFetch;
+    config.controlPlaneUrl = prevUrl;
+    config.sandboxToken = prevTok;
+    config.dataDir = prevDataDir;
+  }
 });
 
 test("a failing control plane never throws into the caller", async () => {

--- a/packages/runtime/src/auth/report-revoked.ts
+++ b/packages/runtime/src/auth/report-revoked.ts
@@ -49,6 +49,22 @@ export function reportRevokedServedToken(err: ProviderError): void {
 }
 
 /**
+ * One report per (scope, provider, token) per pod lifetime — mirroring
+ * served-key-guard.ts. The delete is idempotent, so repeats are pure noise;
+ * worse, a control plane whose DELETE→GET path lags (HOUSTON-APP-530: bursts
+ * of confirmed removals 15–30s apart from ONE pod) can re-serve the token this
+ * pod already reported dead, and each re-serve burns a turn on a doomed 401
+ * and re-fires the report. Reporting the same digest once stops this pod from
+ * amplifying that; a failed report un-marks so a later turn retries.
+ */
+const reported = new Set<string>();
+
+/** Test-only: clear the per-pod report dedupe. */
+export function resetRevokedReportsForTest(): void {
+  reported.clear();
+}
+
+/**
  * Message markers that CONFIRM a server-side revocation — the ONLY texts allowed
  * to trigger the workspace-wide delete.
  *
@@ -121,6 +137,16 @@ async function reportRevoked(err: ProviderError): Promise<void> {
   // scope) reads as the team row — the only thing it could have been.
   const scope = servedScopeFor(provider) ?? "team";
 
+  const digest = accessDigest(cred.access);
+  const dedupe = `${key}:${provider}:${digest}`;
+  if (reported.has(dedupe)) {
+    console.log(
+      `[serve] suppressed a duplicate revoked-token report for ${provider} (already reported this token)`,
+    );
+    return;
+  }
+  reported.add(dedupe);
+
   try {
     const res = await fetch(
       `${config.controlPlaneUrl}/sandbox/credential/revoked`,
@@ -134,7 +160,7 @@ async function reportRevoked(err: ProviderError): Promise<void> {
           provider,
           // The token is named, never shipped: the control plane holds its own
           // copy and compares digests.
-          accessSha256: accessDigest(cred.access),
+          accessSha256: digest,
           scope,
           // The scope alone says "a member's row", not WHOSE: the gateway keys
           // personal credentials by (org, user, provider) and answers 400
@@ -146,6 +172,8 @@ async function reportRevoked(err: ProviderError): Promise<void> {
       },
     );
     if (!res.ok) {
+      // Let a later turn retry against a control plane that answers.
+      reported.delete(dedupe);
       console.warn(
         `[serve] revoked-token report for ${provider} failed: ${res.status}`,
       );
@@ -162,6 +190,7 @@ async function reportRevoked(err: ProviderError): Promise<void> {
       }`,
     );
   } catch (reportErr) {
+    reported.delete(dedupe);
     console.warn(
       `[serve] revoked-token report for ${provider} failed:`,
       reportErr instanceof Error ? reportErr.message : reportErr,


### PR DESCRIPTION
Fixes Sentry [HOUSTON-APP-530](https://houston-cd.sentry.io/issues/7638934035/) — `[sandbox/credential] revoked-token report for anthropic: credential disconnected` — 734 events / 380 users since 2026-07-28, still occurring.

## Root cause

Two defects stacked, neither of which is a mass credential-revocation bug at Anthropic:

**1. The success path logged at error level.** The Sentry event IS the `console.error` in `routes/credential-revoked.ts` for the `removed:true` branch — the branch whose own comment says "both outcomes are success". The host's Sentry console capture turns every `console.error` into an event (`knowledge-base/sentry.md` explicitly bans error-level operational lines), so every *working, expected* provider-revocation disconnect (HOU-952 doing its job: delete the dead credential, show the reconnect card) paged as an error. The issue's firstSeen (2026-07-28) is the day after the report route shipped (d899178f, 2026-07-27) — the volume began when the logging shipped, not when revocations did.

**2. Revoked credentials get resurrected, looping the delete.** Event analysis shows heavy repeaters: one user with 67 confirmed deletes, bursts of 4 deletes 15–90 seconds apart from a single pod (e.g. 23:37:59 → 23:38:33 → 23:38:49 → 23:39:07). Every `removed:true` requires the store to hold the dead token again — something keeps refilling it. The refill channels:

- **Old desktop clients' cached-snapshot reconcile** (`?if_absent=1` claude-oauth push). The client side was deleted in HOU-954/HOU-950 (8bb2b88b, 2026-07-27) but "the host keeps honoring if_absent for older clients" — and after a revoked-report delete the row is absent, so the fill is accepted. A cached snapshot of the revoked family poisons it again (Anthropic's refresh-token-reuse detection, the HOU-855 mechanism), the next turn 401s "has been revoked", reports, deletes, and invites the next fill.
- **Pod-side legacy-fallback adoption** (`RemoteCredentialStore.adoptFallback`): any team-scope serve miss re-uploads the pod-local legacy credential file with an insert-only PUT — including a miss caused by a revocation delete.
- **The serve healer** (`CredentialServeHealer`): re-uploads a refresh-bearing runtime credential on a serve miss, revocation-blind.
- **Sub-minute bursts from one pod** additionally implicate control-plane DELETE→GET lag re-serving a just-deleted row (gateway-side, closed repo — see "What stays server-side" below). Each re-serve burned a user turn and re-fired the report.

## Fix

**`credentials/revocation-tombstones.ts` (new):** a confirmed revocation delete tombstones that (workspace, scope, provider) for 15 minutes, and every *automatic* refill path is refused while it is live:

- the `ifAbsent` claude-oauth fill throws `RevokedRefillBlockedError` → routes answer **409** (deliberate refusal, not a broken hop),
- `adoptFallback` skips adoption,
- the healer refuses the attempt,
- `disconnectRejectedCredential` (the invalid_grant twin of the revoked report — same terminal death, same refill loop, HOU-855's exact cycle) also marks the tombstone.

User-driven connects are never blocked and **clear** the tombstone: an overwrite claude-oauth push (fresh browser login), a verified api-key/setup-token paste, a device-code capture. The tombstone is deliberately scope-blunt rather than digest-scoped: a cached snapshot of the revoked family carries a *different* access token than the digest the report named (the gateway rotated the family since it was cached), so a digest tombstone would block nothing.

**Logging split by what it means:**
- confirmed removal → `console.info` (pipeline working; the user gets the reconnect card — no Sentry event),
- superseded report → `console.info` (unchanged semantics),
- a **second** confirmed removal inside the tombstone window → `console.error` naming the resurrection — the one outcome that is a real defect, now a precise, low-volume Sentry signal instead of 734 noise events.

**Runtime-side burst damper** (`auth/report-revoked.ts`): one report per (scope, provider, token-digest) per pod lifetime, mirroring `served-key-guard.ts` — a failed report un-marks so a later turn retries. Stops one pod amplifying a lagging control plane into a burst of confirmed deletes.

## What stays server-side (documented, not fixed here)

The sub-minute same-pod delete bursts cannot be fully explained by open-repo channels (the old client reconcile is once-per-app-session; heal was observed failing between burst events). The remaining suspect is the gateway's own DELETE→GET consistency (replica/cache lag re-serving a just-deleted row, or its `removed:true` answer for an already-gone row). The new escalation log line ("refilled and revoked AGAIN within the tombstone window") plus the runtime dedupe will make any residual gateway-side resurrection show up as a small, precisely-labeled Sentry issue to hand to the gateway team.

## Tests

- `credentials/revocation-tombstones.test.ts` (new): TTL, mark-returns-active resurrection signal, personal/team key semantics, clear.
- `routes/credential-revoked.test.ts`: removal marks tombstone + logs info not error; second removal escalates; superseded leaves no tombstone.
- `routes/claude-oauth.test.ts`: tombstoned `if_absent` fill → 409, nothing written; fresh overwrite clears and fills resume.
- `credentials/remote-store.test.ts`: no fallback adoption while tombstoned (GET only, no PUT).
- `routes/credential-healer.test.ts`: heal refused while tombstoned, resumes after clear without spending the cooldown.
- `credentials/disconnect.test.ts`: dropped rejection marks tombstone; superseded does not.
- `runtime auth/report-revoked.test.ts`: same digest reported once per pod lifetime; new digest reports; failed report retries.

`pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test`, `pnpm check` (Biome), `pnpm check:boundaries`, and both packages' `typecheck` are clean. `knowledge-base/anthropic-credentials.md` documents the tombstone under the disconnect policy section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
