### PR TITLE
fix(credentials): stop the dead google key serve/adopt loop (HOUSTON-APP-567)

### DIFF
--- a/packages/host/src/channel/capture-credential.test.ts
+++ b/packages/host/src/channel/capture-credential.test.ts
@@ -73,3 +73,64 @@ test("heal mode rejects an api-key export before storing", async () => {
   expect(result.ok).toBe(false);
   expect(puts).toBe(0);
 });
+
+test("a google api-key export that is an OAuth-type token is rejected before storing", async () => {
+  // The capture-side door of Sentry HOUSTON-APP-567: pushing a legacy runtime
+  // entry centrally would seed the store with a key every serve refuses.
+  let puts = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      Response.json({
+        provider: "google",
+        kind: "api_key",
+        key: "ya29.a0LegacyOAuthToken",
+      }),
+    ),
+  );
+  const result = await captureRuntimeCredential({
+    endpoint: { baseUrl: "http://runtime", token: "runtime-token" },
+    credentials: {
+      get: async () => null,
+      put: async () => {
+        puts++;
+      },
+      remove: async () => {},
+      removeIfAccess: async () => false,
+    },
+    workspaceId: "workspace",
+    provider: "google",
+  });
+  expect(result).toMatchObject({ ok: false, status: 400 });
+  expect(result.ok === false && result.error).toMatch(/OAuth-type token/);
+  expect(puts).toBe(0);
+});
+
+test("a real AIza google api-key export still captures", async () => {
+  const stored: WorkspaceCredential[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      Response.json({
+        provider: "google",
+        kind: "api_key",
+        key: "AIzaSyRealKey",
+      }),
+    ),
+  );
+  const result = await captureRuntimeCredential({
+    endpoint: { baseUrl: "http://runtime", token: "runtime-token" },
+    credentials: {
+      get: async () => null,
+      put: async (credential) => {
+        stored.push(credential);
+      },
+      remove: async () => {},
+      removeIfAccess: async () => false,
+    },
+    workspaceId: "workspace",
+    provider: "google",
+  });
+  expect(result).toEqual({ ok: true, provider: "google" });
+  expect(stored[0]?.accessToken).toBe("AIzaSyRealKey");
+});

--- a/packages/host/src/channel/capture-credential.ts
+++ b/packages/host/src/channel/capture-credential.ts
@@ -1,3 +1,4 @@
+import { deadGoogleApiKey } from "@houston/protocol/google-key";
 import type { CaptureResult, CredentialStore, RuntimeEndpoint } from "../ports";
 import { scrubRuntimeRefreshToken } from "./scrub-refresh";
 
@@ -59,6 +60,24 @@ export async function captureRuntimeCredential(args: {
       return { ok: false, status: 400, error: "agent is not connected yet" };
     if (!credential.provider || !credential.key)
       return { ok: false, status: 400, error: "agent is not connected yet" };
+    if (
+      deadGoogleApiKey({
+        provider: credential.provider,
+        kind: "api_key",
+        access: credential.key,
+      })
+    ) {
+      // A legacy pre-verification runtime entry (HOU-1107). Capturing it would
+      // seed the central store with a key every serve immediately refuses
+      // (Sentry HOUSTON-APP-567) — reject it so the connect flow shows the
+      // paste-a-key card instead of a false "connected".
+      return {
+        ok: false,
+        status: 400,
+        error:
+          "the stored google credential is an OAuth-type token, not an API key — reconnect google by pasting a Gemini API key",
+      };
+    }
     await credentials.put(
       {
         workspaceId,

--- a/packages/host/src/credentials/remote-store.test.ts
+++ b/packages/host/src/credentials/remote-store.test.ts
@@ -493,3 +493,98 @@ test("a cache key never embeds the acting token itself", async () => {
   // Isolation is unchanged: distinct unreadable tokens keep distinct scopes.
   expect(new Set(keys).size).toBe(unreadable.length);
 });
+
+// --- Dead google "API keys" (HOU-1107 / Sentry HOUSTON-APP-567) ---
+
+const GOOGLE_PATH = `${BASE}/v1/pod/credentials/${ORG}/${AGENT}/google`;
+
+test("a legacy dead google key is never adopted — dropped from the fallback instead", async () => {
+  // The resurrection loop behind HOUSTON-APP-567: the serve guard deletes the
+  // central row, then the next 404-adoption re-seeds it from a pod's disk.
+  const removed: string[] = [];
+  const fallback: CredentialStore = {
+    get: async () => ({
+      workspaceId: "ws_1",
+      provider: "google",
+      kind: "api_key",
+      accessToken: "ya29.a0LegacyOAuthToken",
+      refreshToken: "",
+      expiresAt: 0,
+    }),
+    put: async () => {},
+    remove: async (_ws, provider) => {
+      removed.push(provider);
+    },
+    removeIfAccess: async () => false,
+  };
+  const { calls, fetchImpl } = fakeFetch((call) => {
+    expect(call.url).toBe(GOOGLE_PATH);
+    return json({ error: "org not connected" }, 404);
+  });
+
+  expect(await store(fetchImpl, fallback).get("ws_1", "google")).toBeNull();
+
+  // One GET, no PUT: the dead row never reaches the gateway again.
+  expect(calls.map((c) => c.init?.method ?? "GET")).toEqual(["GET"]);
+  expect(removed).toEqual(["google"]);
+});
+
+test("put refuses a google credential that is not an API key", async () => {
+  const { calls, fetchImpl } = fakeFetch(() => json({ ok: true }));
+  await expect(
+    store(fetchImpl).put({
+      workspaceId: "ws_1",
+      provider: "google",
+      kind: "api_key",
+      accessToken: "eyJhbGciOiJSUzI1NiJ9.payload.sig",
+      refreshToken: "",
+      expiresAt: 0,
+    }),
+  ).rejects.toThrow(/not an API key/);
+  expect(calls).toHaveLength(0);
+});
+
+test("a real AIza google key still adopts and stores normally", async () => {
+  const fallback: CredentialStore = {
+    get: async () => ({
+      workspaceId: "ws_1",
+      provider: "google",
+      kind: "api_key",
+      accessToken: "AIzaSyRealKey",
+      refreshToken: "",
+      expiresAt: 0,
+    }),
+    put: async () => {},
+    remove: async () => {
+      throw new Error("must not remove a live key");
+    },
+    removeIfAccess: async () => false,
+  };
+  const { calls, fetchImpl } = fakeFetch((call, index) => {
+    if (index === 0) return json({ error: "org not connected" }, 404);
+    if (index === 1) {
+      expect(call.init?.method).toBe("PUT");
+      expect(requestBody(call)).toMatchObject({
+        kind: "api_key",
+        access: "AIzaSyRealKey",
+      });
+      return json({ ok: true });
+    }
+    return json(
+      gatewayCredential({
+        provider: "google",
+        kind: "api_key",
+        access: "AIzaSyRealKey",
+        expires: 0,
+      }),
+    );
+  });
+
+  const got = await store(fetchImpl, fallback).get("ws_1", "google");
+  expect(got?.accessToken).toBe("AIzaSyRealKey");
+  expect(calls.map((c) => c.init?.method ?? "GET")).toEqual([
+    "GET",
+    "PUT",
+    "GET",
+  ]);
+});

--- a/packages/host/src/credentials/remote-store.ts
+++ b/packages/host/src/credentials/remote-store.ts
@@ -1,3 +1,4 @@
+import { deadGoogleApiKey } from "@houston/protocol/google-key";
 import type { WorkspaceId } from "../domain/types";
 import {
   type CredentialActing,
@@ -173,6 +174,19 @@ export class RemoteCredentialStore implements CredentialStore {
   ): Promise<CachedCredential | null> {
     const local = await this.fallback?.get(workspaceId, provider);
     if (!local) return null;
+    if (deadStoredApiKey(local)) {
+      // A legacy pre-verification row (HOU-1107) still on this pod's disk.
+      // Adopting it would resurrect the central row the serve guard just
+      // reported dead — the workspace-wide whack-a-mole behind Sentry
+      // HOUSTON-APP-567, where every waking pod re-seeded the row its siblings
+      // had deleted. Drop the file entry instead: the provider honestly reads
+      // not-connected until the user pastes a real (live-verified) key.
+      console.warn(
+        `[credentials] refusing to adopt the legacy ${provider} credential — an OAuth-type token, not an API key; removing it`,
+      );
+      await this.fallback?.remove(workspaceId, provider);
+      return null;
+    }
 
     await this.putRemote(provider, local, { ifAbsent: true });
     return await this.fetchRemote(provider);
@@ -214,6 +228,12 @@ export class RemoteCredentialStore implements CredentialStore {
     cred: WorkspaceCredential,
     opts: { ifAbsent?: boolean; acting?: CredentialActing } = {},
   ): Promise<void> {
+    // Last exit toward the central store: nothing in this process may seed the
+    // gateway with a key the serve guard would immediately refuse and delete.
+    if (deadStoredApiKey(cred))
+      throw new Error(
+        `refusing to store a ${provider} credential that is not an API key (an OAuth-type token can never authenticate)`,
+      );
     const res = await this.fetchImpl(this.url(provider), {
       method: "PUT",
       headers: this.authHeaders(
@@ -288,4 +308,14 @@ export function scopeKeyOf(
   provider: string,
 ): string {
   return `${credentialScopeKey(acting)}|${provider}`;
+}
+
+/** The stored-shape view of the shared dead-google-key predicate: a stored row
+ *  tags its kind explicitly or via the expiresAt=0 sentinel (isApiKeyCredential). */
+function deadStoredApiKey(cred: WorkspaceCredential): boolean {
+  return deadGoogleApiKey({
+    provider: cred.provider,
+    kind: isApiKeyCredential(cred) ? "api_key" : "oauth",
+    access: cred.accessToken,
+  });
 }

--- a/packages/host/src/routes/credential-revoked.test.ts
+++ b/packages/host/src/routes/credential-revoked.test.ts
@@ -161,3 +161,29 @@ test("an unauthenticated report never reaches the store", async () => {
   expect(status).toBe(401);
   expect(reports).toEqual([]);
 });
+
+test("a store failure answers a clean 502, never an unhandled throw", async () => {
+  // A gateway blip during the delete must come back as a retriable status: the
+  // reporting runtime retries on its next serve sync (quietly), instead of the
+  // route-level 500 that fed the per-sync error loop (HOUSTON-APP-567).
+  const credentials: CredentialStore = {
+    get: async () => null,
+    put: async () => {},
+    remove: async () => {},
+    removeIfAccess: async () => {
+      throw new Error("credential gateway DELETE google failed (503)");
+    },
+  };
+
+  const { handled, status, body } = await post(credentials, {
+    provider: "google",
+    accessSha256: "d".repeat(64),
+    scope: "team",
+  });
+
+  expect(handled).toBe(true);
+  expect(status).toBe(502);
+  expect(body).toEqual({
+    error: "credential store unavailable; report not applied",
+  });
+});

--- a/packages/host/src/routes/credential-revoked.ts
+++ b/packages/host/src/routes/credential-revoked.ts
@@ -61,12 +61,28 @@ export async function handleSandboxCredentialRevoked(
     return true;
   }
 
-  const removed = await deps.credentials.removeIfAccess(
-    claim.workspaceId,
-    provider,
-    accessSha256,
-    { scope, actingAs },
-  );
+  let removed: boolean;
+  try {
+    removed = await deps.credentials.removeIfAccess(
+      claim.workspaceId,
+      provider,
+      accessSha256,
+      { scope, actingAs },
+    );
+  } catch (err) {
+    // A store/gateway hiccup: answer a clean 502 so the reporting runtime
+    // retries on its next serve sync (quietly — served-key-guard dedupes its
+    // own error) instead of the unhandled-throw 500 that turned every retry
+    // into fresh Sentry noise (HOUSTON-APP-567).
+    console.warn(
+      `[sandbox/credential] revoked-token report for ${provider} could not reach the store:`,
+      err instanceof Error ? err.message : err,
+    );
+    json(res, 502, {
+      error: "credential store unavailable; report not applied",
+    });
+    return true;
+  }
   // Both outcomes are success. `removed:false` means the report was superseded
   // — the workspace reconnected, or a sibling runtime reported the same dead
   // token first — and the reporter's own retry/backoff must not treat that as

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -15,6 +15,10 @@
       "types": "./src/access-digest.ts",
       "import": "./src/access-digest.ts"
     },
+    "./google-key": {
+      "types": "./src/google-key.ts",
+      "import": "./src/google-key.ts"
+    },
     "./model-windows": {
       "types": "./src/model-windows.ts",
       "import": "./src/model-windows.ts"

--- a/packages/protocol/src/google-key.ts
+++ b/packages/protocol/src/google-key.ts
@@ -1,0 +1,25 @@
+/**
+ * The one credential family whose deadness is decidable from shape alone
+ * (HOU-1107; Sentry HOUSTON-APP-4Y9, HOUSTON-APP-567): a google "API key" that
+ * is really OAuth material. Every Google Cloud API key starts with the
+ * documented, stable `AIza` prefix; the legacy pre-verification pastes never do
+ * — they are OAuth access tokens (`ya29.…`) or JWTs (`eyJ…`) that can never
+ * authenticate as an `x-goog-api-key`. Google-only and api_key-only on
+ * purpose: other providers' key shapes are not this crisp, and a google OAuth
+ * credential is a different, already-guarded story.
+ *
+ * Shared between the runtime's serve guard (refuse + report the served row)
+ * and the host's central-store adapters (never store, adopt, or capture such a
+ * row) so both ends of the pipeline agree on what "dead" means.
+ */
+export function deadGoogleApiKey(cred: {
+  provider: string;
+  kind?: "oauth" | "api_key";
+  access: string;
+}): boolean {
+  return (
+    cred.provider === "google" &&
+    cred.kind === "api_key" &&
+    !cred.access.startsWith("AIza")
+  );
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -9,6 +9,7 @@ export * from "./domain/routine";
 export * from "./domain/skill";
 export * from "./domain/workspace";
 export * from "./events";
+export * from "./google-key";
 export * from "./model-windows";
 export * from "./provider-catalog";
 export * from "./provider-error";

--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { accessDigest } from "@houston/protocol/access-digest";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { piApiKeyProviderIds } from "../ai/pi-catalog";
 import { PROVIDERS } from "../ai/providers";
 import { config } from "../config";
@@ -728,6 +728,89 @@ test("a served google 'api key' that is an OAuth token is refused, removed, and 
     expect(await syncServedCredential()).toEqual([]);
     expect(reports.length).toBe(1);
   });
+});
+
+test("a failed dead-row report logs ONE error, retries quietly, and stops once delivered", async () => {
+  resetDeadKeyReportsForTest();
+  const reports: number[] = [];
+  let reportStatus = 500;
+  const waiters: Array<{ n: number; resolve: () => void }> = [];
+  const reportSeen = (n: number) =>
+    new Promise<void>((resolve) => {
+      if (reports.length >= n) return resolve();
+      waiters.push({ n, resolve });
+    });
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/sandbox/credential/revoked") {
+      reports.push(reportStatus);
+      for (const w of waiters.filter((w) => reports.length >= w.n)) {
+        waiters.splice(waiters.indexOf(w), 1);
+        w.resolve();
+      }
+      return new Response(JSON.stringify({ ok: true, removed: true }), {
+        status: reportStatus,
+      });
+    }
+    if (url.searchParams.get("provider") === "google") {
+      return new Response(
+        JSON.stringify({
+          provider: "google",
+          kind: "api_key",
+          access: "ya29.a0DeadToken",
+          expires: Number.MAX_SAFE_INTEGER,
+          accountId: null,
+        }),
+        { status: 200 },
+      );
+    }
+    return notConnected404();
+  }) as unknown as typeof globalThis.fetch;
+  // Let a fire-and-forget report fully settle (its finally clears the
+  // in-flight marker in microtasks after the fetch handler resolved).
+  const settle = () => new Promise((r) => setTimeout(r, 0));
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warns = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    await withServeMode(fetchImpl, async () => {
+      // Sync 1: refuse + report; the control plane answers 500.
+      await syncServedCredential();
+      await reportSeen(1);
+      await settle();
+      // Sync 2: the failed report is RETRIED — but without a second error.
+      await syncServedCredential();
+      await reportSeen(2);
+      await settle();
+      // Control plane recovers; sync 3's retry is delivered.
+      reportStatus = 200;
+      await syncServedCredential();
+      await reportSeen(3);
+      await settle();
+      // Sync 4: delivered reports are never repeated.
+      await syncServedCredential();
+      await settle();
+      expect(reports).toEqual([500, 500, 200]);
+      const refusals = errors.mock.calls.filter((c) =>
+        String(c[0]).includes("refusing it and reporting"),
+      );
+      // The single Sentry event per pod lifetime (HOUSTON-APP-567): a control
+      // plane that keeps failing the delete must not add one error per sync.
+      expect(refusals.length).toBe(1);
+      expect(
+        warns.mock.calls.some((c) =>
+          String(c[0]).includes("dead-key report for google failed"),
+        ),
+      ).toBe(true);
+      expect(
+        warns.mock.calls.some((c) =>
+          String(c[0]).includes("retrying the dead-row report"),
+        ),
+      ).toBe(true);
+    });
+  } finally {
+    errors.mockRestore();
+    warns.mockRestore();
+  }
 });
 
 test("a served google key with the real AIza shape is applied normally", async () => {

--- a/packages/runtime/src/auth/served-key-guard.ts
+++ b/packages/runtime/src/auth/served-key-guard.ts
@@ -1,4 +1,7 @@
 import { accessDigest } from "@houston/protocol/access-digest";
+// The SUBPATH import is load-bearing: the barrel pulls the zod-heavy wire
+// modules into serve's import chain, which the runtime's hot paths never need.
+import { deadGoogleApiKey } from "@houston/protocol/google-key";
 import { config } from "../config";
 import { currentCredentialScope } from "../session/acting-context";
 import type { ServedCredential } from "./auth-file";
@@ -33,17 +36,22 @@ import type { ServedCredential } from "./auth-file";
  * not this crisp.
  */
 export function servedApiKeyIsDead(cred: ServedCredential): boolean {
-  return (
-    cred.provider === "google" &&
-    cred.kind === "api_key" &&
-    !cred.access.startsWith("AIza")
-  );
+  return deadGoogleApiKey(cred);
 }
 
-/** One report per (scope, provider, token) per pod lifetime — the serve sync
- *  runs on every turn and hydrating route, and the store's delete is already
- *  idempotent, so repeats are pure noise. */
-const reported = new Set<string>();
+/** Keys whose dead-row report was DELIVERED (2xx). Never retried: the serve
+ *  sync runs on every turn and hydrating route, and the store's delete is
+ *  already idempotent, so repeats are pure noise. */
+const delivered = new Set<string>();
+/** Keys with a report currently in flight — the serve sync is single-flight
+ *  per scope, but the fire-and-forget report can outlive the sync it rode on. */
+const pending = new Set<string>();
+/** Keys already announced at ERROR level — the single Sentry event per
+ *  (scope, provider, token) per pod lifetime. A FAILED report retries on the
+ *  next sync, but retries log as warnings: a control plane that keeps refusing
+ *  the delete must not turn one dead row into one error event per turn
+ *  (Sentry HOUSTON-APP-567). */
+const announced = new Set<string>();
 
 /**
  * Tell the control plane the served key is dead so it stops serving it —
@@ -64,11 +72,18 @@ async function report(cred: ServedCredential): Promise<void> {
   const { key, actingAs } = currentCredentialScope();
   const digest = accessDigest(cred.access);
   const dedupe = `${key}:${cred.provider}:${digest}`;
-  if (reported.has(dedupe)) return;
-  reported.add(dedupe);
-  console.error(
-    `[serve] served ${cred.provider} credential is not an API key (an OAuth-type token that can never authenticate) — refusing it and reporting the dead central row`,
-  );
+  if (delivered.has(dedupe) || pending.has(dedupe)) return;
+  pending.add(dedupe);
+  if (announced.has(dedupe)) {
+    console.warn(
+      `[serve] still refusing the dead ${cred.provider} credential — retrying the dead-row report`,
+    );
+  } else {
+    announced.add(dedupe);
+    console.error(
+      `[serve] served ${cred.provider} credential is not an API key (an OAuth-type token that can never authenticate) — refusing it and reporting the dead central row`,
+    );
+  }
   try {
     const res = await fetch(
       `${config.controlPlaneUrl}/sandbox/credential/revoked`,
@@ -89,17 +104,19 @@ async function report(cred: ServedCredential): Promise<void> {
     );
     if (!res.ok) {
       // Let a later sync retry against a control plane that answers.
-      reported.delete(dedupe);
       console.warn(
         `[serve] dead-key report for ${cred.provider} failed: ${res.status}`,
       );
+      return;
     }
+    delivered.add(dedupe);
   } catch (err) {
-    reported.delete(dedupe);
     console.warn(
       `[serve] dead-key report for ${cred.provider} failed:`,
       err instanceof Error ? err.message : err,
     );
+  } finally {
+    pending.delete(dedupe);
   }
 }
 
@@ -108,5 +125,7 @@ const REPORT_TIMEOUT_MS = 10_000;
 
 /** Test-only: clear the per-pod report dedupe. */
 export function resetDeadKeyReportsForTest(): void {
-  reported.clear();
+  delivered.clear();
+  pending.clear();
+  announced.clear();
 }


### PR DESCRIPTION
Fixes HOUSTON-APP-567 — `[serve] served google credential is not an API key (an OAuth-type token that can never authenticate)`, 409 events / 327 users on managed-cloud since 2026-08-04, still escalating.

## Root cause

The events began the day the HOU-1107 serve guard (#1198) first deployed (engine-pod release `67cc0166`, 2026-08-04) — the guard doing its job over legacy pre-verification rows where users pasted Google OAuth tokens (`ya29.…`, JWTs) as Gemini API keys. It should have been a one-shot healing wave, but the event distribution shows agents firing repeatedly for days (one fired 25 times; one pair of events landed 2 minutes apart). Two loops kept the dead rows alive:

1. **Resurrection through 404-adoption.** The guard's report deletes the central gateway row, but pods whose persistent disk still holds the legacy `credentials.json` entry re-adopt it into the gateway on their next not-connected 404 (`RemoteCredentialStore.adoptFallback`). In a multi-agent workspace, each waking pod re-seeded the row its siblings had just deleted — workspace-wide whack-a-mole with a fresh Sentry error per round. This is where the wrong credential type kept re-entering the pipeline; no current client save path can create these rows (pasted keys are live-verified since HOU-1107).
2. **Per-sync refire on a failed report.** A failed dead-row report deleted the guard's dedupe entry, so the next serve sync (every turn and hydrating route) re-emitted the `console.error` — one Sentry event per sync while the control plane refused the delete. The host route also let a gateway failure escape as an unhandled 500.

## Fix

- **`@houston/protocol/google-key`** — shared `deadGoogleApiKey` predicate (google + `api_key` + not `AIza…`), used by both ends of the pipeline. Light subpath export so serve's import chain stays free of the zod-heavy barrel (the barrel import pushed `pi-providers.test.ts`'s import hook past its 10s budget).
- **Remote store (host)** — never adopt or `PUT` a dead google key centrally. A legacy fallback row is dropped from the pod's disk (with a visible warn) instead of resurrected; `putRemote` refuses as the last exit toward the gateway.
- **Capture (host)** — a google `api_key` export that is OAuth material is rejected with a clean 400 before storing, so a connect can't seed the central store with a key every serve refuses.
- **Serve guard (runtime)** — the error event fires ONCE per (scope, provider, token) per pod lifetime; failed reports retry on later syncs quietly (warnings), and an in-flight report is never duplicated.
- **`/sandbox/credential/revoked` (host)** — a store/gateway failure answers a clean 502 for the runtime to retry instead of an unhandled-throw 500.

## Expected effect

Each affected pod fires at most one more event, its report deletes the central row, and its own disk copy can no longer resurrect it — the fleet converges to quiet as pods wake. New bad rows cannot enter from any path in this repo. If the gateway itself persistently refuses a digest-delete (not observable from this repo), the residual signal is one error per pod wake, no longer one per turn.

## Tests

- runtime: failed report logs one error, retries quietly, stops once delivered; existing refuse/report/dedupe tests unchanged and green
- host: dead-key adoption is refused and the fallback row dropped; `put` refuses a dead google key; a real `AIza…` key still adopts/stores/captures; capture rejects an OAuth-type export; revoked route answers 502 on store failure
- Full `@houston/protocol` / `@houston/domain` / `@houston/runtime` / `@houston/host` suites green (2,705 tests); `pnpm check` and `pnpm check:boundaries` clean; tsgo typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)