### PR TITLE
Tag provider-error Sentry events with provider, kind, and cause (PRODUCT-1302)

### DIFF
--- a/packages/runtime-client/src/sentry/client.test.ts
+++ b/packages/runtime-client/src/sentry/client.test.ts
@@ -104,10 +104,11 @@ describe("createEngineSentry", () => {
     expect(frames[frames.length - 1]?.filename).toMatch(/client\.test\.ts$/);
   });
 
-  it("captureLog: [provider_error] lines fingerprint by (provider, kind)", async () => {
-    // Without this, every provider_error line groups on the identical
-    // synthetic thread stack at the log helper and Sentry shows ONE issue for
-    // every family (HOU-1156).
+  it("captureLog: [provider_error] lines fingerprint by (provider, kind) and tag the family", async () => {
+    // Without the fingerprint, every provider_error line groups on the
+    // identical synthetic thread stack at the log helper and Sentry shows ONE
+    // issue for every family (HOU-1156). Without the tags, the dashboard
+    // cannot filter "all disconnect events" across providers (PRODUCT-1302).
     const { sentry, events } = testSentry();
     sentry.captureLog("ERROR", [
       "[provider_error] provider=openai-codex model=gpt-5.5 status=? kind=unknown :: WebSocket closed 1006",
@@ -121,8 +122,37 @@ describe("createEngineSentry", () => {
       "openai-codex",
       "unknown",
     ]);
-    // Everything else keeps default grouping.
+    expect(events[0]?.tags).toMatchObject({
+      provider: "openai-codex",
+      provider_error_kind: "unknown",
+    });
+    expect(events[0]?.tags?.provider_error_cause).toBeUndefined();
+    // Everything else keeps default grouping and gains no provider tags.
     expect(events[1]?.fingerprint).toBeUndefined();
+    expect(events[1]?.tags?.provider).toBeUndefined();
+  });
+
+  it("captureLog: an unauthenticated provider_error line tags its cause but keeps the (provider, kind) fingerprint", async () => {
+    // `cause` must NOT join the fingerprint — that would re-split every
+    // existing per-family issue on deploy. It rides as a tag only, so
+    // `provider_error_cause:token_revoked` is a dashboard query.
+    const { sentry, events } = testSentry();
+    sentry.captureLog("ERROR", [
+      "[provider_error] provider=anthropic model=claude-fable-5 status=401 kind=unauthenticated cause=token_revoked :: OAuth access token has been revoked",
+    ]);
+    await sentry.flush();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.fingerprint).toEqual([
+      "provider_error",
+      "anthropic",
+      "unauthenticated",
+    ]);
+    expect(events[0]?.tags).toMatchObject({
+      provider: "anthropic",
+      provider_error_kind: "unauthenticated",
+      provider_error_cause: "token_revoked",
+    });
   });
 
   it("captureLog: Node process warnings via console.error stay breadcrumbs", async () => {

--- a/packages/runtime-client/src/sentry/client.ts
+++ b/packages/runtime-client/src/sentry/client.ts
@@ -70,16 +70,35 @@ const NODE_PROCESS_WARNING = /^\(node:\d+\)/;
 /**
  * The stable line `logProviderError` (runtime `ai/provider-error-log.ts`)
  * emits for every classified provider failure. Provider and kind are enough to
- * name a family; anything finer (model, the verbatim text) is unbounded
- * cardinality and stays in the message.
+ * name a family; `cause` (present on unauthenticated errors) tells a revoked
+ * token from a bad pasted key. Anything finer (model, the verbatim text) is
+ * unbounded cardinality and stays in the message.
  */
-const PROVIDER_ERROR_LINE = /^\[provider_error\] provider=(\S+) .*?kind=(\S+)/;
+const PROVIDER_ERROR_LINE =
+  /^\[provider_error\] provider=(\S+) .*?kind=(\S+)(?: cause=(\S+))?/;
 
-function providerErrorFingerprint(
-  message: string,
-): { fingerprint: string[] } | null {
+function providerErrorMeta(message: string): {
+  fingerprint: string[];
+  tags: Record<string, string>;
+} | null {
   const m = PROVIDER_ERROR_LINE.exec(message);
-  return m ? { fingerprint: ["provider_error", m[1] ?? "", m[2] ?? ""] } : null;
+  if (!m) return null;
+  const provider = m[1] ?? "";
+  const kind = m[2] ?? "";
+  return {
+    // The fingerprint stays (provider, kind) — cause is deliberately NOT in
+    // it, so existing issues (56F, 56K, …) keep accumulating instead of
+    // re-splitting on deploy. Cause-level slicing happens via the tag.
+    fingerprint: ["provider_error", provider, kind],
+    // Tags, unlike fingerprints, are searchable dashboard-wide: they make
+    // `provider_error_kind:unauthenticated` one query across every provider's
+    // issue (PRODUCT-1302) where the fingerprint alone cannot.
+    tags: {
+      provider,
+      provider_error_kind: kind,
+      ...(m[3] ? { provider_error_cause: m[3] } : {}),
+    },
+  };
 }
 
 /**
@@ -237,8 +256,9 @@ export function createEngineSentry(
               // (Codex WebSocket drops, Gemini 503s, billing denials, …)
               // collapsed into ONE Sentry issue titled by whichever message
               // came first (HOU-1156). Fingerprint those lines by
-              // (provider, kind) so each family is its own countable issue.
-              ...(providerErrorFingerprint(message) ?? {}),
+              // (provider, kind) so each family is its own countable issue,
+              // and tag them so the dashboard can filter across families.
+              ...(providerErrorMeta(message) ?? {}),
               threads: {
                 values: [
                   {

--- a/packages/runtime/src/ai/provider-error-log.test.ts
+++ b/packages/runtime/src/ai/provider-error-log.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { logProviderError } from "./provider-error-log";
+
+describe("logProviderError", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs an unauthenticated failure at error level with its cause on the line", () => {
+    // The `cause=` field is what the Sentry capture regex turns into the
+    // `provider_error_cause` tag (PRODUCT-1302) — the line format is a
+    // contract with runtime-client sentry/client.ts PROVIDER_ERROR_LINE.
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    logProviderError(
+      {
+        kind: "unauthenticated",
+        provider: "anthropic",
+        cause: "token_revoked",
+        message: "401 OAuth access token has been revoked",
+      },
+      { model: "claude-fable-5", status: 401 },
+    );
+    expect(error).toHaveBeenCalledWith(
+      "[provider_error] provider=anthropic model=claude-fable-5 status=401 " +
+        "kind=unauthenticated cause=token_revoked :: 401 OAuth access token has been revoked",
+    );
+  });
+
+  it("keeps never-connected (no_credentials) a warning, still carrying the cause", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    logProviderError({
+      kind: "unauthenticated",
+      provider: "google",
+      cause: "no_credentials",
+      message: "Provider is not configured: google",
+    });
+    expect(error).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("kind=unauthenticated cause=no_credentials ::"),
+    );
+  });
+
+  it("emits no cause field for non-auth kinds", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    logProviderError(
+      {
+        kind: "rate_limited",
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        retry_after_seconds: 30,
+        message: "429 too many requests",
+      },
+      { model: "gpt-5.5", status: 429 },
+    );
+    expect(warn).toHaveBeenCalledWith(expect.not.stringContaining("cause="));
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("kind=rate_limited ::"),
+    );
+  });
+});

--- a/packages/runtime/src/ai/provider-error-log.ts
+++ b/packages/runtime/src/ai/provider-error-log.ts
@@ -38,10 +38,15 @@ export function logProviderError(
   ctx: ProviderErrorLogContext = {},
 ): void {
   const verbatim = error.kind === "unknown" ? error.raw_excerpt : error.message;
+  // `cause` rides right after `kind` so the Sentry capture regex
+  // (runtime-client sentry/client.ts PROVIDER_ERROR_LINE) can tag it: it is
+  // what separates "provider revoked the session" from "user pasted a bad key"
+  // when triaging disconnect storms (PRODUCT-1302).
+  const cause = error.kind === "unauthenticated" ? ` cause=${error.cause}` : "";
   const line =
     `[provider_error] provider=${error.provider} model=${ctx.model ?? "?"} ` +
     `status=${ctx.status ?? "?"}${ctx.sdkError ? ` error=${ctx.sdkError}` : ""} ` +
-    `kind=${error.kind} :: ${verbatim}`;
+    `kind=${error.kind}${cause} :: ${verbatim}`;
   // `no_credentials` is the one auth cause that is an expected USER state, not
   // broken custody: the provider was simply never connected (or the user
   // logged out with it still selected). It became loggable when the


### PR DESCRIPTION
## Linear

PRODUCT-1302

## Root cause

Provider disconnect events in Sentry could not be filtered as one class. PR #1224 gave `[provider_error]` lines a per-(provider, kind) **fingerprint**, which splits families into separate issues — but a fingerprint is not searchable, so there was no dashboard query that isolates "every provider disconnected/unauthenticated event" across providers. On top of that, the `cause` of an auth failure (`token_revoked` vs `invalid_api_key` vs `token_expired`) lived nowhere in the event metadata, so a provider-side revocation storm and a bad-pasted-key trickle looked identical without opening events one by one.

## Fix

- `packages/runtime-client/src/sentry/client.ts` — the capture path now attaches `provider`, `provider_error_kind`, and (when present) `provider_error_cause` as event **tags**, alongside the unchanged fingerprint. One seam covers both host and runtime processes fleet-wide.
- `packages/runtime/src/ai/provider-error-log.ts` — unauthenticated failures append `cause=` to the single canonical log line, which the capture regex picks up.
- Fingerprints deliberately stay `(provider, kind)` so existing Sentry issues (e.g. HOUSTON-APP-56F, 56K) keep accumulating instead of re-splitting on deploy.

New dashboard queries this enables:
- `provider_error_kind:unauthenticated` — every disconnect event, all providers, one filter.
- `provider_error_kind:unauthenticated provider_error_cause:token_revoked` — provider-side revocations only (the PRODUCT-1276 / 56F storm class).
- `provider:anthropic` — everything one provider throws.

## Before (reproduction)

1. Open Sentry (`houston-cd/houston-app`) → Issues, try to count provider-disconnect events across providers: there is no tag to filter on; `provider` / `kind` exist only inside message strings, and the search `provider_error_kind:unauthenticated` returns nothing.
2. Inspect any event of HOUSTON-APP-56F: tags contain only `runtime`, `engine_process`, `deployment`, `org_slug` — nothing provider-related.

## After (verification)

1. `pnpm --filter @houston/runtime-client --filter @houston/runtime test` — includes new tests pinning the tag extraction (with and without `cause`) and the log-line contract.
2. Once deployed: trigger any provider auth failure (e.g. revoke a test account's OAuth token, send a message) → the new Sentry event carries `provider`, `provider_error_kind`, and `provider_error_cause` tags; the query `provider_error_kind:unauthenticated` finds it; the event still groups into its existing per-family issue (no new issue is created).