### PR TITLE
fix(integrations): snap back to the app when a browser connect lands (PRODUCT-1298)

### DIFF
--- a/app/src/components/integrations/connect-flow-run.ts
+++ b/app/src/components/integrations/connect-flow-run.ts
@@ -55,6 +55,14 @@ export interface ConnectRunDeps {
   setNotice: (toolkit: string, notice: ConnectNotice | null) => void;
   /** Refresh the connections query once the flow settles. */
   invalidate: () => Promise<void>;
+  /**
+   * Pull the app window back over the browser the user just finished the
+   * OAuth (or hosted API-key entry) in — the same snap-back a provider
+   * sign-in does (PRODUCT-1298). Called only when the connection LANDS: a
+   * failure leaves the user on the provider's error page, and a timeout means
+   * they walked away long ago — yanking focus then would be focus-stealing.
+   */
+  focus: () => Promise<void>;
   /** Toast the outcome (success / neutral / error). Never called for a cancel. */
   announce: (toolkit: string, outcome: PollOutcome) => void;
   /** Free the slug so it can be connected again. */
@@ -153,6 +161,14 @@ async function settle(
   const settled = outcome !== "cancelled";
   if (settled) deps.setNotice(toolkit, noticeFor(outcome));
   deps.setStep(toolkit, null);
+  if (outcome === "active") {
+    // Fire-and-forget with its own report: focus is a nicety that must never
+    // delay the dwell/refresh, and a broken focus must not read as a broken
+    // settle — but it is never silent either.
+    void deps
+      .focus()
+      .catch((err) => deps.report("integrations.connectFlow.focus", err));
+  }
   try {
     if (settled) deps.announce(toolkit, outcome);
     if (outcome === "active") await deps.sleep(CONNECT_SUCCESS_DWELL_MS);

--- a/app/src/components/integrations/use-connect-flow.ts
+++ b/app/src/components/integrations/use-connect-flow.ts
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { analytics } from "../../lib/analytics";
 import { logAndReportError } from "../../lib/error-report";
+import { osFocusWindow } from "../../lib/os-bridge";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriIntegrations, tauriSystem } from "../../lib/tauri";
 import { isToolkitOauthUnavailableError } from "../../lib/toolkit-oauth-unavailable";
@@ -168,6 +169,9 @@ export function useConnectFlow(opts: { agentId?: string }): ConnectFlow {
           qc.invalidateQueries({
             queryKey: queryKeys.integrationConnections(INTEGRATION_PROVIDER),
           }),
+        // The user finished the app's sign-in in their browser — surface
+        // Houston over it (no-op on web, where there is no OS window to raise).
+        focus: () => osFocusWindow(),
         announce,
         release: (slug) => endFlow(connectFlowRegistry, slug),
         wait: (ms) => waker.wait(ms),

--- a/app/src/hooks/queries/use-custom-integrations.ts
+++ b/app/src/hooks/queries/use-custom-integrations.ts
@@ -5,6 +5,7 @@ import type {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { integrationsSupported } from "../../components/integrations/model";
 import { analytics } from "../../lib/analytics";
+import { markCustomOAuthStarted } from "../../lib/custom-oauth-return";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriIntegrations, tauriSystem } from "../../lib/tauri";
 import { useAgentStore } from "../../stores/agents";
@@ -134,6 +135,9 @@ export function useStartCustomOAuth(agentId?: string) {
       await tauriSystem.openUrl(authorizeUrl);
     },
     onSuccess: (_data, slug) => {
+      // Arm the return gate: the sign-in's `CustomIntegrationsChanged` landing
+      // may pull the app back over the browser (PRODUCT-1298).
+      markCustomOAuthStarted();
       analytics.track("custom_integration_oauth_started", {
         integration_slug: slug,
       });

--- a/app/src/hooks/use-agent-invalidation.ts
+++ b/app/src/hooks/use-agent-invalidation.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { planInvalidation } from "../lib/agent-invalidation-plan";
+import { consumeCustomOAuthReturn } from "../lib/custom-oauth-return";
 import { onEngineRestarted } from "../lib/engine";
 import { subscribeHoustonEvents } from "../lib/events";
 import { logger } from "../lib/logger";
@@ -76,6 +77,12 @@ export function useAgentInvalidation() {
       // query the board's face stack is derived from).
       const plan = planInvalidation(p, {
         workspaceId: useWorkspaceStore.getState().current?.id,
+        // Consumed (one-shot) ONLY for the event type it gates, so an
+        // unrelated event can never burn a pending OAuth's return marker.
+        customOAuthReturn:
+          p.type === "CustomIntegrationsChanged"
+            ? consumeCustomOAuthReturn()
+            : false,
       });
       for (const queryKey of plan.invalidate) {
         qc.invalidateQueries({ queryKey });

--- a/app/src/lib/agent-invalidation-plan.ts
+++ b/app/src/lib/agent-invalidation-plan.ts
@@ -26,6 +26,14 @@ export interface InvalidationPlan {
 export interface InvalidationContext {
   /** The currently-open workspace id, or undefined if none. */
   workspaceId?: string;
+  /**
+   * True when this `CustomIntegrationsChanged` event is the landing of a
+   * browser OAuth the user started from this window (the hook consumes the
+   * one-shot marker in `custom-oauth-return.ts`). Gates the focus snap-back:
+   * the same event also fires for in-app adds and agent-initiated changes,
+   * which must never pull the window to the front.
+   */
+  customOAuthReturn?: boolean;
 }
 
 const empty = (): InvalidationPlan => ({
@@ -163,6 +171,9 @@ export function planInvalidation(
     case "CustomIntegrationsChanged":
       plan.invalidate.push(queryKeys.customIntegrations());
       plan.invalidate.push(["integration-connections"]);
+      // The landing of a browser sign-in the user started here: surface the
+      // app over the browser, exactly like a provider login (PRODUCT-1298).
+      if (ctx.customOAuthReturn) plan.focusWindow = true;
       break;
     // The global event stream came back after a drop (HOU-981). The feed has no
     // replay cursor, so every change that happened while it was down — a

--- a/app/src/lib/custom-oauth-return.ts
+++ b/app/src/lib/custom-oauth-return.ts
@@ -1,0 +1,37 @@
+/**
+ * The custom-integration OAuth return gate (PRODUCT-1298).
+ *
+ * A custom integration's browser sign-in has NO client-side poll: the outcome
+ * lands on the host's callback and arrives as a `CustomIntegrationsChanged`
+ * event. That same event also fires for causes with no browser involved — a
+ * manual add, the in-chat credential card, and an AGENT adding an integration
+ * mid-turn — and focusing the window on those would steal focus from whatever
+ * the user is doing. So the snap-back is gated on "a browser OAuth was started
+ * from THIS window recently": marked when the authorize URL is opened,
+ * consumed (one-shot) by the first change event inside the window.
+ *
+ * The window bounds a stale marker: an abandoned sign-in must not surface the
+ * app an hour later when an unrelated change event happens to arrive.
+ */
+
+/** How long a started OAuth may claim the next change event as its return. */
+export const CUSTOM_OAUTH_RETURN_WINDOW_MS = 10 * 60 * 1000;
+
+let startedAt: number | null = null;
+
+/** Record that the authorize URL was just handed to the browser. */
+export function markCustomOAuthStarted(now: number = Date.now()): void {
+  startedAt = now;
+}
+
+/**
+ * One-shot read: true when an OAuth was started within the window. Always
+ * clears the marker — a stale start is retired, and a fresh one may claim
+ * exactly one change event as its landing.
+ */
+export function consumeCustomOAuthReturn(now: number = Date.now()): boolean {
+  const fresh =
+    startedAt !== null && now - startedAt <= CUSTOM_OAUTH_RETURN_WINDOW_MS;
+  startedAt = null;
+  return fresh;
+}

--- a/app/tests/agent-invalidation-plan.test.ts
+++ b/app/tests/agent-invalidation-plan.test.ts
@@ -171,6 +171,22 @@ describe("planInvalidation — unrelated cases keep their exact effects", () => 
     ok(invalidates(plan, queryKeys.customIntegrations()));
     ok(invalidates(plan, ["integration-connections"]));
   });
+
+  // PRODUCT-1298: the change event is the landing of a browser OAuth ONLY when
+  // the hook consumed a fresh return marker — an in-app add or an agent's own
+  // mid-turn change must never pull the window to the front.
+  it("CustomIntegrationsChanged focuses only on a consumed OAuth return", () => {
+    const returned = planInvalidation(
+      { type: "CustomIntegrationsChanged" },
+      { customOAuthReturn: true },
+    );
+    strictEqual(returned.focusWindow, true);
+    const unrelated = planInvalidation(
+      { type: "CustomIntegrationsChanged" },
+      {},
+    );
+    strictEqual(unrelated.focusWindow, undefined);
+  });
 });
 
 /**

--- a/app/tests/connect-flow-run.test.ts
+++ b/app/tests/connect-flow-run.test.ts
@@ -55,6 +55,10 @@ function harness(
       events.push("invalidate");
       return Promise.resolve();
     },
+    focus: () => {
+      events.push("focus");
+      return Promise.resolve();
+    },
     announce: (toolkit, outcome) => events.push(`toast:${toolkit}=${outcome}`),
     release: (toolkit) => events.push(`release:${toolkit}`),
     report: (command) => events.push(`report:${command}`),
@@ -107,6 +111,9 @@ describe("runConnectFlow — outcomes", () => {
       // that ended carrying no outcome as a cancel and retires its origin.
       "notice:slack=connected",
       "step:slack=null",
+      // The snap-back (PRODUCT-1298): the user just finished the OAuth in the
+      // browser, so the app surfaces itself the moment the connection lands.
+      "focus",
       "toast:slack=active",
       `sleep:${CONNECT_SUCCESS_DWELL_MS}`,
       "invalidate",
@@ -143,6 +150,30 @@ describe("runConnectFlow — outcomes", () => {
       false,
       "walking away from an OAuth is normal behavior, not a failure",
     );
+  });
+
+  it("the snap-back is success-only: no focus on failure, timeout, or cancel", async () => {
+    // A failure leaves the user reading the provider's error page and a
+    // timeout means they walked away — pulling the window to the front in
+    // either case would be focus-stealing, not a hand-back.
+    for (const status of ["error", "pending"] as const) {
+      const { deps, events } = harness({ statuses: [status] });
+      await runConnectFlow("slack", deps);
+      strictEqual(events.includes("focus"), false, `no focus for ${status}`);
+    }
+    const cancelled = harness({ statuses: ["pending"] });
+    cancelled.entry.cancelled = true;
+    await runConnectFlow("slack", cancelled.deps);
+    strictEqual(cancelled.events.includes("focus"), false);
+  });
+
+  it("a rejecting focus is reported, never breaks the settle", async () => {
+    const { deps, events } = harness({
+      focus: () => Promise.reject(new Error("window is gone")),
+    });
+    strictEqual(await runConnectFlow("slack", deps), "active");
+    strictEqual(events.includes("invalidate"), true, "the refresh still runs");
+    strictEqual(events.includes("report:integrations.connectFlow.focus"), true);
   });
 
   it("maps every settled outcome to the notice its row shows", () => {

--- a/app/tests/custom-oauth-return.test.ts
+++ b/app/tests/custom-oauth-return.test.ts
@@ -1,0 +1,37 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  CUSTOM_OAUTH_RETURN_WINDOW_MS,
+  consumeCustomOAuthReturn,
+  markCustomOAuthStarted,
+} from "../src/lib/custom-oauth-return.ts";
+
+describe("custom OAuth return gate", () => {
+  it("nothing armed → no return", () => {
+    strictEqual(consumeCustomOAuthReturn(1_000), false);
+  });
+
+  it("a fresh start claims exactly ONE change event", () => {
+    markCustomOAuthStarted(1_000);
+    strictEqual(consumeCustomOAuthReturn(2_000), true);
+    // One-shot: the same start never claims a second event.
+    strictEqual(consumeCustomOAuthReturn(3_000), false);
+  });
+
+  it("an abandoned start expires: no surprise focus an hour later", () => {
+    markCustomOAuthStarted(1_000);
+    strictEqual(
+      consumeCustomOAuthReturn(1_000 + CUSTOM_OAUTH_RETURN_WINDOW_MS + 1),
+      false,
+    );
+  });
+
+  it("re-arming refreshes the window", () => {
+    markCustomOAuthStarted(1_000);
+    markCustomOAuthStarted(CUSTOM_OAUTH_RETURN_WINDOW_MS + 2_000);
+    strictEqual(
+      consumeCustomOAuthReturn(CUSTOM_OAUTH_RETURN_WINDOW_MS + 3_000),
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## PRODUCT-1298

After finishing an integration sign-in in the browser (approving an OAuth or entering an API key on Composio's hosted page, or a custom integration's OAuth), the user was left stranded in the browser: the connection landed and the row confirmed, but Houston stayed behind the browser window.

## Root cause

The snap-back machinery already existed — `window_focus.rs` exposes `focus_main_window` (its doc comment even names "a Composio connection landing"), and AI-provider sign-ins use it via the `ProviderLoginComplete` event — but neither integration flow was ever wired to it.

## Fix

**Composio connect flow** (all surfaces: catalog rows, in-chat connect cards — they share the one flow store):
- `ConnectRunDeps` gains a `focus` dependency, fired in `settle` when the connection poll lands `active`, wired to `osFocusWindow()`. Success-only by design: on failure the user is reading the provider's error page, and on timeout they walked away long ago — pulling focus then would be focus-stealing. Fire-and-forget with its own error report so a broken focus never delays or fails the settle. No-op on web (the shim already handles `focus_main_window`).

**Custom-integration OAuth** (PRODUCT-1172 flow): its landing arrives as a `CustomIntegrationsChanged` event with no client poll — and that same event also fires for in-app adds and for an **agent** adding an integration mid-turn, which must never yank focus. So the focus is gated on a one-shot return marker (`custom-oauth-return.ts`, 10-minute window) armed when the authorize URL is handed to the browser, consumed only by the first `CustomIntegrationsChanged` after it. The decision stays in the pure `planInvalidation` module per its existing contract.

Works identically for the gateway-minted (desktop default) and direct-key (self-host) connect paths, since the snap-back keys off the client-side poll, not Composio's `callback_url`.

## Reproduce (before)

1. Open Houston desktop → Integrations → connect any app (e.g. Slack).
2. Approve the OAuth (or enter the API key) in the browser.
3. Composio's page says you're connected — Houston stays buried behind the browser; you must switch back manually.

## Verify (after)

1. Same steps: connect an app, finish the sign-in in the browser.
2. Within one poll tick (~2 s) of approving, Houston pulls itself to the front (over the browser, on macOS via app activation) with the row showing "connected" and the success toast.
3. Negative checks: deny the OAuth → no focus steal (error surfaces in-app when you return); walk away → no focus steal minutes later; let an agent add a custom integration mid-turn while you're in another app → no focus steal.
4. Custom integration OAuth: add an OAuth custom integration, sign in in the browser → Houston surfaces when the callback lands.

## Tests

- `app/tests/connect-flow-run.test.ts`: focus fires on the success path in order, never on error/timeout/cancel; a rejecting focus is reported and the refresh still runs.
- `app/tests/custom-oauth-return.test.ts`: one-shot claim, expiry window, re-arming.
- `app/tests/agent-invalidation-plan.test.ts`: `CustomIntegrationsChanged` focuses only with a consumed return marker.

Gates: `cd app && pnpm test` (3419 pass), `pnpm tsgo --noEmit`, `pnpm --filter houston-web typecheck` (shim parity OK), `pnpm check` clean.