### PR TITLE
feat(skills): rename a skill from the dialog header pencil (PRODUCT-1018)

### DIFF
--- a/app/src/components/agent/skill-editor-dialogs.tsx
+++ b/app/src/components/agent/skill-editor-dialogs.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { skillDisplayTitle } from "../../lib/humanize-skill-name";
 import { skillIntegrationSlugs } from "../../lib/skill-integrations";
+import { withSkillTitle } from "../../lib/skill-title";
 import type { SkillSummary } from "../../lib/types";
 import { IntegrationBadges } from "../integrations";
 
@@ -83,7 +84,11 @@ export function SkillEditorDialogs({
           />
         }
         editor={editorState}
-        onSave={onSaveEditing}
+        onSave={(content, rename) =>
+          onSaveEditing(
+            rename === undefined ? content : withSkillTitle(content, rename),
+          )
+        }
         onDelete={
           readOnly || !editingSkill
             ? undefined

--- a/app/src/components/agent/use-skill-surface-labels.ts
+++ b/app/src/components/agent/use-skill-surface-labels.ts
@@ -22,6 +22,7 @@ export function useSkillSurfaceLabels() {
     delete: t("common:actions.delete"),
     editorPlaceholder: t("skills:detail.instructionsPlaceholder"),
     loadFailed: t("skills:detail.loadFailed"),
+    rename: t("skills:detail.rename"),
   };
 
   const deleteConfirm = {

--- a/app/src/components/skills-view/manage-skill-body.tsx
+++ b/app/src/components/skills-view/manage-skill-body.tsx
@@ -21,6 +21,7 @@ export function ManageSkillBody({
   overrides,
   onEnableAll,
   onPromote,
+  forceDirty = false,
   onSave,
   onDeleteEverywhere,
   deleteLabel,
@@ -52,6 +53,9 @@ export function ManageSkillBody({
   /** Move this per-agent skill into the workspace store ("Share to
    *  workspace") — offered on local rows when the deployment has a store. */
   onPromote?: () => Promise<void>;
+  /** Unsaved work living OUTSIDE this body — the dialog header's pending
+   *  rename — so Save lights up even when the draft here is untouched. */
+  forceDirty?: boolean;
   onSave: (draft: {
     content: string;
     contentDirty: boolean;
@@ -76,7 +80,7 @@ export function ManageSkillBody({
     assignment === "editable" &&
     (selected.size !== assignedIds.size ||
       [...selected].some((id) => !assignedIds.has(id)));
-  const dirty = contentDirty || assignmentDirty;
+  const dirty = contentDirty || assignmentDirty || forceDirty;
   // Copy-based rows: unassigning everyone IS deletion — that path goes through
   // the explicit Delete button, so an empty selection can't ride an
   // innocuous-looking Save. Store-backed rows keep the skill either way.

--- a/app/src/components/skills-view/manage-skill-dialog.tsx
+++ b/app/src/components/skills-view/manage-skill-dialog.tsx
@@ -3,13 +3,15 @@ import {
   DialogContent,
   DialogDescription,
   DialogHeader,
-  DialogTitle,
   Skeleton,
 } from "@houston-ai/core";
+import { EditableSkillTitle, skillRenameEscapeGuard } from "@houston-ai/skills";
 import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { skillDisplayTitle } from "../../lib/humanize-skill-name";
 import { queryKeys } from "../../lib/query-keys";
+import { withSkillTitle } from "../../lib/skill-title";
 import { tauriSharedSkills, tauriSkills } from "../../lib/tauri";
 import type { SharedSkillRow } from "../../lib/workspace-shared-skills";
 import { ManageSkillBody } from "./manage-skill-body";
@@ -74,6 +76,14 @@ export function ManageSkillDialog({
     onDeleteEverywhere,
     onClose,
   });
+  // The header pencil's uncommitted rename (PRODUCT-1018): saved into the
+  // frontmatter `title:` when Save changes runs; the slug never moves.
+  const [rename, setRename] = useState<string | null>(null);
+  const slug = row?.slug;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: slug is the intentional change-trigger — a pending rename must die with the row it was typed for; the effect body deliberately reads none of it.
+  useEffect(() => {
+    setRename(null);
+  }, [slug]);
 
   if (!row) return null;
   const overriddenBy = isShared ? (row.overriddenBy ?? []) : [];
@@ -82,11 +92,16 @@ export function ManageSkillDialog({
   return (
     <>
       <Dialog open onOpenChange={(open) => !open && onClose()}>
-        <DialogContent className="sm:max-w-2xl">
+        <DialogContent
+          className="sm:max-w-2xl"
+          onEscapeKeyDown={skillRenameEscapeGuard}
+        >
           <DialogHeader className="min-w-0">
-            <DialogTitle className="truncate">
-              {skillDisplayTitle(row.summary)}
-            </DialogTitle>
+            <EditableSkillTitle
+              title={rename ?? skillDisplayTitle(row.summary)}
+              onRename={detail ? setRename : undefined}
+              renameLabel={t("skills:detail.rename")}
+            />
             {row.summary.description && (
               <DialogDescription className="line-clamp-2">
                 {row.summary.description}
@@ -124,7 +139,17 @@ export function ManageSkillDialog({
                     }
                   : undefined
               }
-              onSave={flow.save}
+              forceDirty={rename !== null}
+              onSave={(draft) =>
+                flow.save({
+                  content:
+                    rename !== null
+                      ? withSkillTitle(draft.content, rename)
+                      : draft.content,
+                  contentDirty: draft.contentDirty || rename !== null,
+                  afterIds: draft.afterIds,
+                })
+              }
               onDeleteEverywhere={
                 isShared && onDisableForAgent
                   ? () =>

--- a/app/src/lib/skill-title.ts
+++ b/app/src/lib/skill-title.ts
@@ -1,0 +1,32 @@
+/**
+ * Rewrite a SKILL.md's frontmatter `title:` — the display phrase every surface
+ * renders via `skillDisplayTitle` (PRODUCT-1018's header rename). The
+ * directory slug (the skill's one canonical identity) is deliberately left
+ * alone: a title can drift freely while loading keeps resolving by slug.
+ */
+
+/** Opening frontmatter fence + block + closing fence (with its newline). */
+const FRONTMATTER_RE = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
+
+/** YAML double-quoted scalars accept JSON escaping, so this is always safe. */
+const titleLine = (title: string) => `title: ${JSON.stringify(title)}`;
+
+export function withSkillTitle(content: string, title: string): string {
+  const line = titleLine(title.trim());
+  const match = FRONTMATTER_RE.exec(content);
+  if (!match) return `---\n${line}\n---\n\n${content}`;
+
+  const lines = match[1].split(/\r?\n/);
+  const at = lines.findIndex((l) => /^title\s*:/.test(l));
+  if (at >= 0) {
+    // Swallow a block-scalar value's indented continuation lines so a
+    // multi-line title collapses to the one new line instead of orphaning.
+    let end = at + 1;
+    while (end < lines.length && /^[ \t]/.test(lines[end])) end += 1;
+    lines.splice(at, end - at, line);
+  } else {
+    const nameAt = lines.findIndex((l) => /^name\s*:/.test(l));
+    lines.splice(nameAt >= 0 ? nameAt + 1 : lines.length, 0, line);
+  }
+  return `---\n${lines.join("\n")}\n---\n${content.slice(match[0].length)}`;
+}

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -117,7 +117,8 @@
     "deleteTitle": "Delete \"{{name}}\"?",
     "deleteDescription": "This removes the skill from your agent. You can reinstall it later.",
     "instructionsPlaceholder": "Instructions for this skill...",
-    "integrations": "Works with"
+    "integrations": "Works with",
+    "rename": "Rename skill"
   },
   "categories": {
     "Advisory": "Advisory",

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -117,7 +117,8 @@
     "deleteTitle": "¿Eliminar \"{{name}}\"?",
     "deleteDescription": "Esto elimina el skill de tu agente. Puedes reinstalarlo después.",
     "instructionsPlaceholder": "Instrucciones para este skill...",
-    "integrations": "Funciona con"
+    "integrations": "Funciona con",
+    "rename": "Renombrar skill"
   },
   "categories": {
     "Advisory": "Asesoría",

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -117,7 +117,8 @@
     "deleteTitle": "Excluir \"{{name}}\"?",
     "deleteDescription": "Isso remove o skill do seu agente. Você pode reinstalar depois.",
     "instructionsPlaceholder": "Instruções para este skill...",
-    "integrations": "Funciona com"
+    "integrations": "Funciona com",
+    "rename": "Renomear skill"
   },
   "categories": {
     "Advisory": "Consultoria",

--- a/app/tests/skill-title.test.ts
+++ b/app/tests/skill-title.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { withSkillTitle } from "../src/lib/skill-title.ts";
+
+const SKILL = `---
+name: create-an-loi
+description: Draft a Letter of Intent for a new customer or partner.
+version: 1
+category: contracts
+featured: yes
+---
+
+## Procedure
+Do the thing.
+`;
+
+test("replaces an existing title line in place", () => {
+  const input = SKILL.replace(
+    "description:",
+    'title: "Old name"\ndescription:',
+  );
+  const out = withSkillTitle(input, "Create an LOI");
+  assert.match(out, /^title: "Create an LOI"$/m);
+  assert.doesNotMatch(out, /Old name/);
+  // Everything else survives byte-for-byte.
+  assert.match(out, /^name: create-an-loi$/m);
+  assert.match(out, /^featured: yes$/m);
+  assert.ok(out.endsWith("## Procedure\nDo the thing.\n"));
+});
+
+test("inserts the title right after name when absent", () => {
+  const out = withSkillTitle(SKILL, "Create an LOI");
+  assert.match(
+    out,
+    /^---\nname: create-an-loi\ntitle: "Create an LOI"\ndescription:/,
+  );
+});
+
+test("appends to the frontmatter when there is no name key", () => {
+  const out = withSkillTitle("---\ndescription: x\n---\nbody\n", "Titled");
+  assert.equal(out, '---\ndescription: x\ntitle: "Titled"\n---\nbody\n');
+});
+
+test("creates frontmatter when the file has none", () => {
+  const out = withSkillTitle("## Procedure\n", "Titled");
+  assert.equal(out, '---\ntitle: "Titled"\n---\n\n## Procedure\n');
+});
+
+test("collapses a block-scalar title's continuation lines", () => {
+  const input =
+    "---\nname: x\ntitle: >-\n  Old\n  name\ncategory: a\n---\nbody";
+  const out = withSkillTitle(input, "New");
+  assert.equal(out, '---\nname: x\ntitle: "New"\ncategory: a\n---\nbody');
+});
+
+test("trims and safely quotes special characters", () => {
+  const out = withSkillTitle(SKILL, '  Facturación: "rápida" \\ fácil  ');
+  assert.match(out, /^title: "Facturación: \\"rápida\\" \\\\ fácil"$/m);
+});
+
+test("tolerates CRLF frontmatter", () => {
+  const input = "---\r\nname: x\r\ntitle: Old\r\n---\r\nbody";
+  const out = withSkillTitle(input, "New");
+  assert.equal(out, '---\nname: x\ntitle: "New"\n---\nbody');
+});
+
+test("renaming twice keeps exactly one title line", () => {
+  const out = withSkillTitle(withSkillTitle(SKILL, "First"), "Second");
+  assert.equal(out.match(/^title:/gm)?.length, 1);
+  assert.match(out, /^title: "Second"$/m);
+});

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -337,6 +337,24 @@ surface hosting the chat, which matters most on macOS, where a bare refocus
 consumes the nav (`shouldNavigateOnAppActivation`,
 `app/tests/notification-nav.test.ts`).
 
+**Renaming a skill = the header pencil (PRODUCT-1018).** Both detail dialogs
+(`ManageSkillDialog` and the `SkillEditModal` fallback) render their title
+through `EditableSkillTitle` (`ui/skills/src/skill-title-editor.tsx`): a
+pencil at the end of the name swaps in an inline input — Enter or blur
+commits, Escape cancels. Radix hears Escape on a document-level CAPTURE
+listener, so the input can't stop it itself: each hosting `DialogContent`
+passes `skillRenameEscapeGuard` as `onEscapeKeyDown`, else cancelling a
+rename closes the whole dialog. The committed name is a pending rename that
+rides the existing **Save changes** write: `withSkillTitle`
+(`app/src/lib/skill-title.ts`, node-tested) rewrites the frontmatter `title:`
+in the saved SKILL.md, and every surface re-renders it via
+`skillDisplayTitle`. The directory slug NEVER moves — display drifts freely,
+identity doesn't (see "Skill identity = directory slug"). The fake host
+mirrors the real watcher for this: a `.agents/skills/<slug>/SKILL.md` write
+upserts the skill row and re-parses `title:` from the frontmatter
+(`packages/fake-host/src/state-skills.ts` `writeSkillFile`/`refresh`), pinned
+by the rename e2e in `packages/web/e2e/skills-agent-dialog.spec.ts`.
+
 **The manage dialog is the skill's one detail surface on BOTH pages.** A row
 click in the agent's Skills section opens the SAME manage dialog the global
 page uses (`agent-skill-manage-dialog.tsx` wraps it: lazy cross-agent

--- a/packages/fake-host/src/state-agents.ts
+++ b/packages/fake-host/src/state-agents.ts
@@ -4,6 +4,7 @@
  */
 
 import { SEED_WORKSPACE_ID } from "./config";
+import { writeSkillFile } from "./state-skills";
 import {
   ACTIVITY_PATH,
   type CpAgent,
@@ -13,6 +14,8 @@ import {
   fileKey,
   state,
 } from "./state-store";
+
+const SKILL_FILE = /^\.agents\/skills\/([^/]+)\/SKILL\.md$/;
 
 // ---- agents ----
 export function listAgents(): CpAgent[] {
@@ -119,4 +122,8 @@ export function writeAgentFile(
   state.files.set(fileKey(agentId, relPath), content);
   // The real file watcher fires ActivityChanged when the board file is written.
   if (relPath === ACTIVITY_PATH) emitDomain("ActivityChanged", agentId);
+  // ...and classifies a SKILL.md write as SkillsChanged: the Skills dialogs'
+  // fan-out save is a plain file write, so the list must re-serve it.
+  const skillSlug = relPath.match(SKILL_FILE)?.[1];
+  if (skillSlug) writeSkillFile(agentId, skillSlug, content);
 }

--- a/packages/fake-host/src/state-shared-skills.ts
+++ b/packages/fake-host/src/state-shared-skills.ts
@@ -32,6 +32,14 @@ function scalar(frontmatter: string, key: string): string | null {
   }
 }
 
+/** Best-effort frontmatter scalar straight off a full SKILL.md — the same
+ *  parsing the shared store uses, exported for the per-agent store so a saved
+ *  file's `title:` lands in both lists the way the real host's re-parse does. */
+export function frontmatterScalar(content: string, key: string): string | null {
+  const match = content.match(FRONTMATTER);
+  return match ? scalar(match[1] ?? "", key) : null;
+}
+
 function summary(
   slug: string,
   content: string,

--- a/packages/fake-host/src/state-skills.ts
+++ b/packages/fake-host/src/state-skills.ts
@@ -8,6 +8,7 @@
  */
 
 import type { SkillDetail, SkillSummary } from "@houston/protocol";
+import { frontmatterScalar } from "./state-shared-skills";
 import { emitDomain } from "./state-store";
 
 type SkillRow = SkillSummary & { content: string };
@@ -80,6 +81,15 @@ export function installSkills(agentId: string, names: string[]): string[] {
   return names;
 }
 
+/** Mirror the real host: summary fields are re-parsed from the saved file's
+ *  frontmatter, so a header rename's `title:` write shows up in the list. */
+function refresh(skill: SkillRow, content: string): void {
+  skill.content = content;
+  skill.title = frontmatterScalar(content, "title");
+  const description = frontmatterScalar(content, "description");
+  if (description !== null) skill.description = description;
+}
+
 export function saveSkill(
   agentId: string,
   slug: string,
@@ -87,9 +97,24 @@ export function saveSkill(
 ): boolean {
   const skill = agentSkills(agentId).get(slug);
   if (!skill) return false;
-  skill.content = content;
+  refresh(skill, content);
   emitDomain("SkillsChanged", agentId);
   return true;
+}
+
+/** The real host's file watcher: a direct `.agents/skills/<slug>/SKILL.md`
+ *  write (the Skills dialogs' fan-out save) lands in the skill list too,
+ *  upserting a newly assigned holder's copy. */
+export function writeSkillFile(
+  agentId: string,
+  slug: string,
+  content: string,
+): void {
+  const skills = agentSkills(agentId);
+  const skill = skills.get(slug) ?? row(slug, "", content);
+  refresh(skill, content);
+  skills.set(slug, skill);
+  emitDomain("SkillsChanged", agentId);
 }
 
 export function deleteSkill(agentId: string, slug: string): boolean {

--- a/packages/web/e2e/skills-agent-dialog.spec.ts
+++ b/packages/web/e2e/skills-agent-dialog.spec.ts
@@ -44,3 +44,55 @@ test("per-agent skill dialog hides cross-agent assignment; global keeps it", asy
   const globalDialog = page.getByRole("dialog");
   await expect(globalDialog.getByText("Agents with this skill")).toBeVisible();
 });
+
+/**
+ * PRODUCT-1018: the dialog header carries a rename pencil. Committing a new
+ * name and saving writes it into the frontmatter `title:`, so the row (and
+ * every other surface) re-renders with it while the slug identity stays put.
+ * Escape while editing cancels the rename without closing the dialog.
+ */
+test("rename pencil retitles a skill from the manage dialog", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await openAgentSettings(page, "Houston", "Skills");
+  await page.getByRole("tab", { name: "Custom skills" }).click();
+  await page.getByRole("button", { name: "Add skill" }).click();
+  const addDialog = page.getByRole("dialog");
+  await addDialog.getByRole("button", { name: "GitHub" }).click();
+  await addDialog.getByPlaceholder("owner/repo").fill("mattpocock/skills");
+  await addDialog.getByRole("button", { name: "Find skills" }).click();
+  await expect(addDialog.getByText("12 skills found")).toBeVisible();
+  await addDialog.getByRole("button", { name: "Install 12" }).click();
+  await expect(addDialog.getByText(/Installed 12 skills/)).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  await page.getByRole("button", { name: /^Repo Skill 2\b/ }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByRole("button", { name: "Rename skill" }).click();
+  const input = dialog.getByRole("textbox", { name: "Rename skill" });
+
+  // Escape cancels the rename, not the dialog.
+  await input.fill("Discarded name");
+  await input.press("Escape");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("Repo Skill 2", { exact: true })).toBeVisible();
+
+  await dialog.getByRole("button", { name: "Rename skill" }).click();
+  await input.fill("Invoice magic");
+  await input.press("Enter");
+  await expect(
+    dialog.getByText("Invoice magic", { exact: true }),
+  ).toBeVisible();
+  await dialog.getByRole("button", { name: "Save changes" }).click();
+
+  // The dialog closes on save and the strip re-serves the new display title.
+  await expect(dialog).not.toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /^Invoice magic\b/ }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /^Repo Skill 2\b/ }),
+  ).toHaveCount(0);
+});

--- a/ui/skills/src/index.ts
+++ b/ui/skills/src/index.ts
@@ -74,6 +74,11 @@ export { SkillPreviewModal } from "./skill-preview-modal";
 export type { SkillPreviewSheetLabels } from "./skill-preview-modal-labels";
 export type { SkillRowProps } from "./skill-row";
 export { SkillRow } from "./skill-row";
+export type { EditableSkillTitleProps } from "./skill-title-editor";
+export {
+  EditableSkillTitle,
+  skillRenameEscapeGuard,
+} from "./skill-title-editor";
 export type { SkillsGridProps } from "./skills-grid";
 export { SkillsGrid } from "./skills-grid";
 export type { SkillsGridLabels } from "./skills-grid-labels";

--- a/ui/skills/src/skill-edit-modal-labels.ts
+++ b/ui/skills/src/skill-edit-modal-labels.ts
@@ -11,6 +11,8 @@ export interface SkillEditModalLabels {
   delete?: string;
   editorPlaceholder?: string;
   loadFailed?: string;
+  /** The header pencil's accessible label (and the rename input's). */
+  rename?: string;
 }
 
 export const DEFAULT_SKILL_EDIT_MODAL_LABELS: Required<SkillEditModalLabels> = {
@@ -20,4 +22,5 @@ export const DEFAULT_SKILL_EDIT_MODAL_LABELS: Required<SkillEditModalLabels> = {
   delete: "Delete skill",
   editorPlaceholder: "Instructions for this skill...",
   loadFailed: "Couldn't load this skill's instructions.",
+  rename: "Rename skill",
 };

--- a/ui/skills/src/skill-edit-modal-parts.tsx
+++ b/ui/skills/src/skill-edit-modal-parts.tsx
@@ -59,30 +59,34 @@ export function NonReadyBody({
 /** The seeded textarea + a footer whose Save commits the draft. */
 export function ReadyEditBody({
   initial,
+  rename,
   onSave,
   onCancel,
   onDelete,
   labels: l,
 }: {
   initial: string;
-  onSave: (content: string) => Promise<void>;
+  /** The header pencil's committed display name (null = untouched). A pending
+   *  rename is unsaved work, so it lights Save and rides it. */
+  rename: string | null;
+  onSave: (content: string, rename?: string) => Promise<void>;
   onCancel: () => void;
   onDelete?: () => void;
   labels: Labels;
 }) {
   const [draft, setDraft] = useState(initial);
   const [saving, setSaving] = useState(false);
-  const dirty = draft !== initial;
+  const dirty = draft !== initial || rename !== null;
 
   const handleSave = useCallback(async () => {
     if (!dirty || saving) return;
     setSaving(true);
     try {
-      await onSave(draft);
+      await onSave(draft, rename ?? undefined);
     } finally {
       setSaving(false);
     }
-  }, [dirty, saving, onSave, draft]);
+  }, [dirty, saving, onSave, draft, rename]);
 
   return (
     <>

--- a/ui/skills/src/skill-edit-modal.tsx
+++ b/ui/skills/src/skill-edit-modal.tsx
@@ -3,16 +3,19 @@ import {
   DialogContent,
   DialogDescription,
   DialogHeader,
-  DialogTitle,
 } from "@houston-ai/core";
 import type { ReactNode } from "react";
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { InstalledSkillEditorState } from "./installed-skill-editor-model";
 import {
   DEFAULT_SKILL_EDIT_MODAL_LABELS,
   type SkillEditModalLabels,
 } from "./skill-edit-modal-labels";
 import { NonReadyBody, ReadyEditBody } from "./skill-edit-modal-parts";
+import {
+  EditableSkillTitle,
+  skillRenameEscapeGuard,
+} from "./skill-title-editor";
 
 export interface SkillEditModalProps {
   open: boolean;
@@ -30,7 +33,9 @@ export interface SkillEditModalProps {
    */
   integrationsSlot?: ReactNode;
   editor: InstalledSkillEditorState;
-  onSave: (content: string) => Promise<void>;
+  /** `rename` is the header pencil's committed display name, riding the same
+   *  save (the caller writes it into the frontmatter `title:`). */
+  onSave: (content: string, rename?: string) => Promise<void>;
   /** Open the delete confirm (the strip has no per-tile delete affordance, so
    *  the destructive action lives here). Omit to hide the button. */
   onDelete?: () => void;
@@ -61,15 +66,29 @@ export function SkillEditModal({
 }: SkillEditModalProps) {
   const l = { ...DEFAULT_SKILL_EDIT_MODAL_LABELS, ...labels };
   const close = useCallback(() => onOpenChange(false), [onOpenChange]);
+  // The header pencil's uncommitted rename; saved alongside the content draft,
+  // dropped whenever the modal closes or shows a different skill.
+  const [rename, setRename] = useState<string | null>(null);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: open and displayName are intentional change-triggers — a pending rename must die when the modal closes or shows a different skill; the effect body deliberately reads none of it.
+  useEffect(() => {
+    setRename(null);
+  }, [open, displayName]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-2xl">
+      <DialogContent
+        className="sm:max-w-2xl"
+        onEscapeKeyDown={skillRenameEscapeGuard}
+      >
         {/* min-w-0: DialogContent is a grid; without it this item's min-content
             width (a long nowrap line) blows the track past the dialog's
             max-width and drags the textarea with it. */}
         <DialogHeader className="min-w-0">
-          <DialogTitle className="truncate">{displayName}</DialogTitle>
+          <EditableSkillTitle
+            title={rename ?? displayName}
+            onRename={editor.status === "ready" ? setRename : undefined}
+            renameLabel={l.rename}
+          />
           {description && (
             <DialogDescription className="line-clamp-2">
               {description}
@@ -81,6 +100,7 @@ export function SkillEditModal({
         {editor.status === "ready" ? (
           <ReadyEditBody
             initial={editor.content}
+            rename={rename}
             onSave={onSave}
             onCancel={close}
             onDelete={onDelete}

--- a/ui/skills/src/skill-title-editor.tsx
+++ b/ui/skills/src/skill-title-editor.tsx
@@ -1,0 +1,111 @@
+import { cn, DialogTitle } from "@houston-ai/core";
+import { Pencil } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+
+const RENAME_INPUT_ATTR = "data-skill-rename-input";
+
+/**
+ * `DialogContent` `onEscapeKeyDown` guard for dialogs hosting an
+ * {@link EditableSkillTitle}: Radix hears Escape on a document-level capture
+ * listener, so the input's own handler can't stop it — without this guard,
+ * cancelling a rename closes the whole dialog.
+ */
+export function skillRenameEscapeGuard(event: KeyboardEvent) {
+  if (
+    event.target instanceof HTMLElement &&
+    event.target.hasAttribute(RENAME_INPUT_ATTR)
+  )
+    event.preventDefault();
+}
+
+export interface EditableSkillTitleProps {
+  /** The current display name (a pending rename included, if any). */
+  title: string;
+  /** Commit a new display name. Omit to render a plain, pencil-less title. */
+  onRename?: (title: string) => void;
+  /** Accessible label for the pencil button and the name input. */
+  renameLabel?: string;
+}
+
+/**
+ * EditableSkillTitle — a dialog title with a rename pencil at the end of the
+ * name (PRODUCT-1018). The pencil swaps the title for an inline input; Enter
+ * or blur commits the trimmed name (unchanged or empty commits are a plain
+ * cancel), Escape cancels without closing the host dialog. Committing only
+ * reports the name upward — persisting it is the caller's concern, so both
+ * skill dialogs can ride their existing save paths.
+ *
+ * The `DialogTitle` stays mounted (visually hidden while editing) so Radix
+ * always finds the dialog's accessible title.
+ */
+export function EditableSkillTitle({
+  title,
+  onRename,
+  renameLabel = "Rename skill",
+}: EditableSkillTitleProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(title);
+  // Escape both cancels and blurs; the ref keeps the blur commit from
+  // resurrecting the draft the user just discarded.
+  const cancelled = useRef(false);
+
+  const start = useCallback(() => {
+    setDraft(title);
+    cancelled.current = false;
+    setEditing(true);
+  }, [title]);
+
+  const commit = useCallback(() => {
+    setEditing(false);
+    if (cancelled.current) return;
+    const next = draft.trim();
+    if (next && next !== title) onRename?.(next);
+  }, [draft, title, onRename]);
+
+  return (
+    <div className="flex min-w-0 items-center gap-1.5">
+      <DialogTitle className={cn("truncate", editing && "sr-only")}>
+        {title}
+      </DialogTitle>
+      {editing ? (
+        <input
+          // biome-ignore lint/a11y/noAutofocus: the input replaces the title the user just clicked to edit.
+          autoFocus
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit();
+            } else if (e.key === "Escape") {
+              // The host dialog's Escape is fended off by
+              // `skillRenameEscapeGuard`; this handler only cancels the edit.
+              cancelled.current = true;
+              setEditing(false);
+            }
+          }}
+          {...{ [RENAME_INPUT_ATTR]: "" }}
+          aria-label={renameLabel}
+          className={cn(
+            "min-w-0 flex-1 rounded-md border border-line/20 bg-input px-2 py-0.5",
+            "text-lg leading-tight font-semibold text-ink",
+            "outline-none transition-shadow duration-200 focus:shadow-sm",
+          )}
+        />
+      ) : (
+        onRename && (
+          <button
+            type="button"
+            onClick={start}
+            aria-label={renameLabel}
+            title={renameLabel}
+            className="shrink-0 rounded-md p-1 text-ink-muted transition-colors hover:bg-ink/[0.05] hover:text-ink"
+          >
+            <Pencil className="size-3.5" />
+          </button>
+        )
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

PRODUCT-1018: users had no way to rename a skill short of hand-editing YAML frontmatter in the raw SKILL.md editor. The skill detail dialogs now carry a pencil at the end of the name in the header: clicking it swaps in an inline input (Enter or blur commits, Escape cancels without closing the dialog), and the committed name rides the existing **Save changes** write by rewriting the frontmatter `title:` in the saved SKILL.md.

The directory slug — the skill's one canonical identity — never moves, so invocation, manifests, cross-references, and loading stay intact by design (`skillDisplayTitle` already renders `title ?? humanize(slug)` on every surface).

## What changed

- **`ui/skills`**: new `EditableSkillTitle` (title + pencil + inline input), used by both detail surfaces — `ManageSkillDialog` (global Skills page + agent settings) and the `SkillEditModal` fallback. `skillRenameEscapeGuard` is passed as `DialogContent`'s `onEscapeKeyDown` because Radix hears Escape on a document-level capture listener — without it, cancelling a rename closed the whole dialog.
- **`app/src/lib/skill-title.ts`**: `withSkillTitle` sets/replaces the frontmatter `title:` (handles missing frontmatter, block-scalar titles, CRLF, YAML-safe quoting). Node-tested.
- **`ManageSkillDialog`**: a pending rename lights Save and is folded into the saved content; the existing fan-out/store-write semantics are untouched.
- **Fake host**: mirrors the real watcher — a `.agents/skills/<slug>/SKILL.md` write upserts the skill row and re-parses `title:`/`description:` from the frontmatter, so lists re-serve renames the way the real host does.
- **i18n**: `skills:detail.rename` in en/es/pt.
- **KB**: `knowledge-base/skills.md` documents the rename model.

## Tests

- `app/tests/skill-title.test.ts` — 8 cases over the frontmatter rewrite.
- `packages/web/e2e/skills-agent-dialog.spec.ts` — new e2e: pencil → rename → Escape cancel keeps the dialog open → rename → Save changes → the strip re-serves the new display title.
- `pnpm check`, `pnpm typecheck`, `cd app && pnpm test` (3420 pass), `pnpm check-locales`, `pnpm check:boundaries`, `pnpm check:parity`, fake-host vitest — all green.

## Before / after

**Before:** open a skill's dialog — the name is a fixed humanized slug (e.g. "Create an loi"); the only way to change it is knowing to type a `title:` line into the raw frontmatter.

**After:** Skills page (or agent settings → Skills) → click a skill row → pencil next to the name → type the new name → Enter → Save changes. The row, cards, picker, and chat chip all show the new name; the skill still loads and invokes by its unchanged slug.