### PR TITLE
fix(runtime): kill revoked-anthropic retry storms the HOU-952 heal missed (PRODUCT-1307)

### DIFF
--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -422,6 +422,12 @@ test("extractHttpStatus reads parenthesized, leading, and labelled forms", () =>
   expect(extractHttpStatus("OpenAI API error (429): boom")).toBe(429);
   expect(extractHttpStatus('401 {"type":"error"}')).toBe(401);
   expect(extractHttpStatus("request failed with status 503")).toBe(503);
+  // The Claude Agent SDK's canonical failure text (PRODUCT-1307).
+  expect(
+    extractHttpStatus(
+      "Failed to authenticate. API Error: 401 OAuth access token has been revoked.",
+    ),
+  ).toBe(401);
   // A 3-digit number that is not a plausible HTTP status is ignored.
   expect(extractHttpStatus("used 700 tokens")).toBeNull();
   expect(extractHttpStatus("no status here")).toBeNull();

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -662,7 +662,14 @@ export function extractHttpStatus(message: string): number | null {
     const n = Number(lead[1]);
     if (n >= 100 && n <= 599) return n;
   }
-  const labelled = message.match(/(?:status|http)[^\d]{0,4}(\d{3})\b/i);
+  // "api error" is the Claude Agent SDK's canonical failure text ("API Error:
+  // 401 OAuth access token has been revoked"). Without it a revoked-token
+  // failure surfacing on the SDK's thrown/result seams (message only, no
+  // status field) missed the auth branch entirely and rendered the generic
+  // unknown card instead of reconnect (PRODUCT-1307).
+  const labelled = message.match(
+    /(?:status|http|api error)[^\d]{0,4}(\d{3})\b/i,
+  );
   if (labelled) {
     const n = Number(labelled[1]);
     if (n >= 100 && n <= 599) return n;

--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -1,11 +1,22 @@
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { accessDigest } from "@houston/protocol/access-digest";
 import { expect, test, vi } from "vitest";
 import { piApiKeyProviderIds } from "../ai/pi-catalog";
 import { PROVIDERS } from "../ai/providers";
+import {
+  claudeCredentialsFile,
+  claudeLoginConfigDir,
+} from "../backends/claude/paths";
 import { config } from "../config";
+import { runWithActingContext } from "../session/acting-context";
 import {
   applyServedCredential,
   type PiCred,
@@ -186,6 +197,114 @@ test("a served anthropic credential lands in auth.json as an access-only oauth e
       refresh: "",
       expires: 1_900_000_000_000,
     });
+  });
+});
+
+/**
+ * PRODUCT-1307 / Sentry HOUSTON-APP-4YA: the materialized
+ * `<CLAUDE_CONFIG_DIR>/.credentials.json` is a SECOND copy of the anthropic
+ * credential, and the Claude Agent SDK falls back to it the moment the served
+ * env token disappears. When the central row is deleted (the HOU-952 revoked
+ * heal, a real disconnect), leaving that file behind re-runs every turn on the
+ * dead token family — with the served manifest emptied, no reporter can act,
+ * and the storm only ends when the file's token expires. An authoritative
+ * not-connected must therefore take the ghost file down with the auth.json
+ * entry.
+ */
+function withTempHoustonHome(body: () => Promise<void>): Promise<void> {
+  const prev = process.env.HOUSTON_HOME;
+  process.env.HOUSTON_HOME = mkdtempSync(join(tmpdir(), "houston-home-"));
+  return body().finally(() => {
+    if (prev === undefined) delete process.env.HOUSTON_HOME;
+    else process.env.HOUSTON_HOME = prev;
+  });
+}
+
+/** A materialized SDK credential file, as a central push writes it. */
+function writeMaterializedClaudeCredential(): string {
+  mkdirSync(claudeLoginConfigDir(), { recursive: true });
+  const file = claudeCredentialsFile();
+  writeFileSync(
+    file,
+    JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "sk-ant-oat01-dead",
+        refreshToken: "",
+        expiresAt: 9_000_000_000_000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    }),
+  );
+  return file;
+}
+
+/** Serves anthropic while `connected()` holds, authoritative 404 after. */
+const anthropicServeFetch = (connected: () => boolean) =>
+  (async (input: RequestInfo | URL) => {
+    const provider = new URL(String(input)).searchParams.get("provider");
+    if (provider === "anthropic" && connected()) {
+      return new Response(
+        JSON.stringify({
+          provider: "anthropic",
+          kind: "oauth",
+          access: "sk-ant-oat01-served",
+          expires: 1_900_000_000_000,
+          accountId: null,
+        }),
+        { status: 200 },
+      );
+    }
+    return notConnected404();
+  }) as unknown as typeof globalThis.fetch;
+
+test("an authoritative anthropic disconnect clears the ghost materialized SDK credential", async () => {
+  await withTempHoustonHome(async () => {
+    const file = writeMaterializedClaudeCredential();
+    let connected = true;
+    await withServeMode(
+      anthropicServeFetch(() => connected),
+      async () => {
+        expect(await syncServedCredential()).toEqual(["anthropic"]);
+        // While centrally connected the file is legitimate — it stays.
+        expect(existsSync(file)).toBe(true);
+        connected = false;
+        await syncServedCredential();
+        // The central row is gone: the auth.json entry AND the ghost go together.
+        const auth = JSON.parse(
+          readFileSync(join(config.dataDir, "auth.json"), "utf8"),
+        ) as Record<string, unknown>;
+        expect(auth.anthropic).toBeUndefined();
+        expect(existsSync(file)).toBe(false);
+      },
+    );
+  });
+});
+
+test("a personal scope's anthropic disconnect leaves the pod-shared SDK credential file alone", async () => {
+  // The shared login dir is the TEAM's credential (HOU-976): a member whose
+  // personal row disconnects must not take the workspace's file with it.
+  const actingToken = (sub: string) =>
+    `acting-v1.${Buffer.from(
+      JSON.stringify({ sub, agent: "acme", exp: 9_000_000_000 }),
+    ).toString("base64url")}.sig`;
+  await withTempHoustonHome(async () => {
+    const file = writeMaterializedClaudeCredential();
+    let connected = true;
+    await withServeMode(
+      anthropicServeFetch(() => connected),
+      async () => {
+        await runWithActingContext(
+          { actingAs: actingToken("sub-alice") },
+          async () => {
+            expect(await syncServedCredential()).toEqual(["anthropic"]);
+            connected = false;
+            await syncServedCredential();
+          },
+        );
+        expect(existsSync(file)).toBe(true);
+      },
+    );
   });
 });
 

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -1,5 +1,6 @@
 import { piApiKeyProviderIds } from "../ai/pi-catalog";
 import { PROVIDERS } from "../ai/providers";
+import { clearGhostClaudeCredential } from "../backends/claude/credential-status";
 import { config } from "../config";
 import { currentCredentialScope } from "../session/acting-context";
 import {
@@ -245,6 +246,12 @@ async function runServedSync(): Promise<string[]> {
           removed.push(probe.id);
         manifest.delete(probe.id);
         manifestDirty = true;
+        // Anthropic keeps a SECOND copy of its credential: the materialized
+        // `.credentials.json` the Claude Agent SDK falls back to once the
+        // served env token is gone. Left behind, that ghost re-runs every turn
+        // on the dead family — the exact storm the HOU-952 heal was meant to
+        // end (PRODUCT-1307).
+        if (probe.id === "anthropic") clearGhostClaudeCredential();
       }
     } else {
       // Dedup lives in serve-log.ts: every turn and hydrating route re-probes,

--- a/packages/runtime/src/backends/claude/credential-status.ts
+++ b/packages/runtime/src/backends/claude/credential-status.ts
@@ -1,4 +1,4 @@
-import { rmSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import {
   currentCredentialScope,
   isPersonalScope,
@@ -164,6 +164,42 @@ export function resetAnthropicCredentialCache(value = false): void {
   lastProbeAt = 0;
   unknownBackoffUntil = 0;
   inFlight = null;
+}
+
+/**
+ * Drop the materialized shared-dir credential after the CENTRAL store
+ * authoritatively disconnected anthropic (a serve probe answered
+ * not-connected). On a serve-mode pod that file only ever comes from a central
+ * push (`credentials-file.ts`), so once the central row is gone any surviving
+ * copy is a ghost: the served env token vanished with auth.json, the SDK falls
+ * back to this file, and every turn burns a 401 on the dead family with no
+ * reporter left to heal it — the served manifest no longer lists anthropic, so
+ * `reportRevokedServedToken` no-ops on its provenance gate and the storm
+ * sustains until the file's token expires (PRODUCT-1307 / HOUSTON-APP-4YA).
+ *
+ * A personal scope never owns the shared dir (HOU-976) and must not delete the
+ * team's credential on its own disconnect. The cache reset (and its forced
+ * re-probe) happens only when a file was actually removed, so the per-turn
+ * not-connected sync of an ordinary disconnected pod stays free of subprocess
+ * churn.
+ */
+export function clearGhostClaudeCredential(): void {
+  if (isPersonalScope(currentCredentialScope().key)) return;
+  const path = claudeCredentialsFile();
+  if (!existsSync(path)) return;
+  try {
+    rmSync(path, { force: true });
+  } catch (err) {
+    console.warn(
+      `[claude] could not remove the ghost materialized credential at ${path}:`,
+      err instanceof Error ? err.message : err,
+    );
+    return;
+  }
+  console.log(
+    "[claude] removed ghost materialized credential: the central store no longer holds an anthropic credential for this workspace",
+  );
+  resetAnthropicCredentialCache(false);
 }
 
 /**

--- a/packages/runtime/src/backends/claude/errors.test.ts
+++ b/packages/runtime/src/backends/claude/errors.test.ts
@@ -1,10 +1,16 @@
 import { beforeEach, expect, test, vi } from "vitest";
+import { reportRevokedServedToken } from "../../auth/report-revoked";
 import { classifyText, mapSdkError } from "./errors";
+
+vi.mock("../../auth/report-revoked", () => ({
+  reportRevokedServedToken: vi.fn(),
+}));
 
 let consoleError: ReturnType<typeof vi.spyOn>;
 let consoleWarn: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
+  vi.mocked(reportRevokedServedToken).mockClear();
   consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
   consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
 });
@@ -167,6 +173,34 @@ test("classifyText passes provider + status through the shared classifier", () =
     http_status: 500,
     message: "Internal Server Error",
   });
+});
+
+/**
+ * PRODUCT-1307: a revocation is only healed centrally if the seam that
+ * classified it also reports it. The enum path always did; the text path —
+ * result `subtype !== "success"` and thrown/iterator failures — classified,
+ * logged, and stayed silent, so a revocation surfacing there kept the dead
+ * credential served to the whole workspace (Sentry HOUSTON-APP-4YA storms).
+ * The reporter's own gates (confirmed marker, serve mode, served manifest,
+ * oauth) remain the safety; the seam's job is just to always speak up.
+ */
+test("classifyText reports an unauthenticated failure like the enum path does", () => {
+  const classified = classifyText(
+    "Failed to authenticate. API Error: 401 OAuth access token has been revoked.",
+    null,
+    null,
+  );
+  expect(classified).toMatchObject({
+    kind: "unauthenticated",
+    provider: "anthropic",
+    cause: "token_revoked",
+  });
+  expect(reportRevokedServedToken).toHaveBeenCalledExactlyOnceWith(classified);
+});
+
+test("classifyText does not report non-auth failures", () => {
+  classifyText("Internal Server Error", "m", 500);
+  expect(reportRevokedServedToken).not.toHaveBeenCalled();
 });
 
 test("the verbatim provider text is logged once it is reduced to a card", () => {

--- a/packages/runtime/src/backends/claude/errors.ts
+++ b/packages/runtime/src/backends/claude/errors.ts
@@ -144,8 +144,16 @@ export function classifyText(
     status,
   });
   logProviderError(classified, { model, status });
-  if (classified.kind === "unauthenticated")
+  if (classified.kind === "unauthenticated") {
     noteAuthFailure(classified.provider);
+    // A REVOKED served token is invisible to the control plane (HOU-952).
+    // Every seam that classifies here — result `subtype !== "success"`,
+    // thrown/iterator failures — must report it like the enum path above and
+    // pi/wire.ts do, or a revocation surfacing on this seam never heals
+    // centrally and the workspace keeps serving the dead token
+    // (PRODUCT-1307). The reporter's own gates keep this safe.
+    reportRevokedServedToken(classified);
+  }
   return classified;
 }
 


### PR DESCRIPTION
Fixes [PRODUCT-1307](https://linear.app/houston-ai/issue/PRODUCT-1307) · Sentry [HOUSTON-APP-4YA](https://houston-cd.sentry.io/issues/7622113876/?project=4511452472541184)

## What happened

HOUSTON-APP-4YA (`401 OAuth access token has been revoked`) was decaying as predicted after #1112 + the HOU-952 heal — until 2026-08-04, when one agent burned ~150 turns at an exact 2-minute cadence for hours. The heal deletes the **central** row, but the pod keeps a second copy of the credential nothing heals: the materialized `<CLAUDE_CONFIG_DIR>/.credentials.json`. Once the central row is gone the served env token vanishes with `auth.json`, the Claude Agent SDK falls back to that ghost file, and every turn re-401s on the dead family. By then the served manifest no longer lists anthropic, so `reportRevokedServedToken` no-ops on its provenance gate — nothing left in the loop can stop it, while `anthropicCredentialCached()` keeps the UI on "Connected". (The 2-minute clock is cloud-side trigger redelivery, `TriggerClaimStaleAfter`; follow-up tracked in the Linear issue.)

## Three gaps closed

1. **Serve sync clears the ghost** — an authoritative not-connected for `anthropic` now removes the materialized SDK credential file along with the `auth.json` entry and resets the credential cache (`clearGhostClaudeCredential`). Team scope only: a personal scope's disconnect never touches the pod-shared file (HOU-976), and the file only ever comes from a central push on a serve-mode pod, so central-says-disconnected makes any surviving copy a ghost by definition. This is the change that actually ends the storm and flips the UI to the honest reconnect card.
2. **`classifyText` reports revocations** — the Claude backend's result-`subtype` and thrown/iterator seams classified, logged, and stayed silent; only the enum path reported. They now report like the enum path and `pi/wire.ts` do. The reporter's own four gates (strict revocation markers, serve mode, served manifest, oauth-only) remain the safety.
3. **`extractHttpStatus` learns `API Error: <status>`** — the SDK's canonical failure text. Without it, the exact production message classified as `unknown` on the text seams (generic card, no `noteAuthFailure`, no report) because none of the existing status forms or auth wordings matched.

## Tests

- `serve.test.ts`: authoritative anthropic disconnect removes the ghost file; a personal scope's disconnect leaves the pod-shared file alone.
- `errors.test.ts`: `classifyText` reports the revoked served token (and stays silent on non-auth failures).
- `provider-error.test.ts`: `API Error: 401 …` extracts 401.

`@houston/runtime` 1077 ✓ · `@houston/host` + `@houston/domain` ✓ · `pnpm typecheck` ✓ · `pnpm check` ✓