### PR TITLE
feat(usage): honest OpenRouter balance for grant-funded accounts (PRODUCT-1075)

### DIFF
--- a/app/src/components/ai-hub/provider-usage-meters.tsx
+++ b/app/src/components/ai-hub/provider-usage-meters.tsx
@@ -1,5 +1,6 @@
 import { cn, Skeleton } from "@houston-ai/core";
 import type {
+  ProviderUsageCredits,
   ProviderUsageTokens,
   ProviderUsageWindow,
 } from "@houston-ai/engine-client";
@@ -56,11 +57,11 @@ export function ProviderUsageMeters({ slot }: { slot: UsageSlot }) {
             />
           ))}
           {slot.row.credits && (
-            <p className="text-[13px] text-ink tabular-nums">
-              {t("providerUsage.creditsLeft", {
-                amount: formatCreditsAmount(slot.row.credits, i18n.language),
-              })}
-            </p>
+            <CreditsBalance
+              credits={slot.row.credits}
+              locale={i18n.language}
+              t={t}
+            />
           )}
           {slot.row.tokens && (
             <MeteredTokens
@@ -71,6 +72,47 @@ export function ProviderUsageMeters({ slot }: { slot: UsageSlot }) {
           )}
         </>
       )}
+    </div>
+  );
+}
+
+/**
+ * The prepaid balance line. A provider that reports the real balance gets the
+ * classic "$19.50 left". A provider whose API omits free/promotional grants
+ * (`excludesGrants` — OpenRouter reports purchased credits only) must not
+ * claim "$0.00 left" to an account that has grant money: it shows the real
+ * spend instead, with a note saying the grant balance is unreported.
+ */
+function CreditsBalance({
+  credits,
+  locale,
+  t,
+}: {
+  credits: ProviderUsageCredits;
+  locale: string;
+  t: Translate;
+}) {
+  if (!credits.excludesGrants) {
+    return (
+      <p className="text-[13px] text-ink tabular-nums">
+        {t("providerUsage.creditsLeft", {
+          amount: formatCreditsAmount(credits.remaining, credits.unit, locale),
+        })}
+      </p>
+    );
+  }
+  return (
+    <div>
+      {credits.used !== undefined && (
+        <p className="text-[13px] text-ink tabular-nums">
+          {t("providerUsage.creditsUsed", {
+            amount: formatCreditsAmount(credits.used, credits.unit, locale),
+          })}
+        </p>
+      )}
+      <p className="mt-0.5 text-xs text-ink-muted">
+        {t("providerUsage.grantsUnreported")}
+      </p>
     </div>
   );
 }

--- a/app/src/components/ai-hub/provider-usage-model.ts
+++ b/app/src/components/ai-hub/provider-usage-model.ts
@@ -172,21 +172,23 @@ export function formatMeteredSince(
 }
 
 /**
- * A localized amount for a credits balance: real currency formatting for USD
- * balances ("$12.34"), a plain localized number for provider-internal credit
- * units (the caller wraps it in the "left" phrase).
+ * A localized amount for a credits figure (remaining or spent): real currency
+ * formatting for USD ("$12.34"), a plain localized number for
+ * provider-internal credit units (the caller wraps it in the "left"/"used"
+ * phrase).
  */
 export function formatCreditsAmount(
-  credits: NonNullable<ProviderUsage["credits"]>,
+  amount: number,
+  unit: NonNullable<ProviderUsage["credits"]>["unit"],
   locale: string,
 ): string {
-  if (credits.unit === "USD") {
+  if (unit === "USD") {
     return new Intl.NumberFormat(locale, {
       style: "currency",
       currency: "USD",
-    }).format(credits.remaining);
+    }).format(amount);
   }
   return new Intl.NumberFormat(locale, {
     maximumFractionDigits: 2,
-  }).format(credits.remaining);
+  }).format(amount);
 }

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -148,6 +148,8 @@
     "percentUsed": "{{percent}}% used",
     "resets": "Resets {{when}}",
     "creditsLeft": "{{amount}} left",
+    "creditsUsed": "{{amount}} used",
+    "grantsUnreported": "This provider doesn't report free or promotional credit balances. Check your balance on their site.",
     "tokensUsed": "{{amount}} tokens used",
     "tokensSplit": "{{input}} in, {{output}} out",
     "meteredSince": "measured by Houston since {{when}}",

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -148,6 +148,8 @@
     "percentUsed": "{{percent}}% usado",
     "resets": "Se reinicia {{when}}",
     "creditsLeft": "Te quedan {{amount}}",
+    "creditsUsed": "{{amount}} usados",
+    "grantsUnreported": "Este proveedor no informa los saldos de créditos gratuitos o promocionales. Revisa tu saldo en su sitio.",
     "tokensUsed": "{{amount}} tokens usados",
     "tokensSplit": "{{input}} de entrada, {{output}} de salida",
     "meteredSince": "medido por Houston desde {{when}}",

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -148,6 +148,8 @@
     "percentUsed": "{{percent}}% usado",
     "resets": "Reinicia {{when}}",
     "creditsLeft": "Restam {{amount}}",
+    "creditsUsed": "{{amount}} usados",
+    "grantsUnreported": "Este provedor não informa os saldos de créditos gratuitos ou promocionais. Confira seu saldo no site deles.",
     "tokensUsed": "{{amount}} tokens usados",
     "tokensSplit": "{{input}} de entrada, {{output}} de saída",
     "meteredSince": "medido pela Houston desde {{when}}",

--- a/app/tests/ai-hub-usage-model.test.ts
+++ b/app/tests/ai-hub-usage-model.test.ts
@@ -220,16 +220,12 @@ describe("formatMeteredSince", () => {
 
 describe("formatCreditsAmount", () => {
   it("formats USD as currency and credit units as a plain number", () => {
-    strictEqual(
-      formatCreditsAmount({ remaining: 12.34, unit: "USD" }, "en"),
-      "$12.34",
-    );
-    strictEqual(
-      formatCreditsAmount(
-        { remaining: 19.5, granted: 25, unit: "credits" },
-        "en",
-      ),
-      "19.5",
-    );
+    strictEqual(formatCreditsAmount(12.34, "USD", "en"), "$12.34");
+    strictEqual(formatCreditsAmount(19.5, "credits", "en"), "19.5");
+  });
+
+  it("formats a spend figure the same way (the excludesGrants line)", () => {
+    strictEqual(formatCreditsAmount(0.31, "USD", "en"), "$0.31");
+    strictEqual(formatCreditsAmount(0, "USD", "en"), "$0.00");
   });
 });

--- a/packages/protocol/src/conversation.ts
+++ b/packages/protocol/src/conversation.ts
@@ -131,7 +131,15 @@ export interface ProviderUsageCredits {
   remaining: number;
   /** Total granted, when reported. */
   granted?: number;
+  /** Lifetime spend in `unit`, when reported. */
+  used?: number;
   unit: "USD" | "credits";
+  /**
+   * True when the provider's API omits free/promotional grants from the
+   * balance (OpenRouter reports purchased credits only), so `remaining` is a
+   * lower bound the UI must not present as "you have nothing left".
+   */
+  excludesGrants?: boolean;
 }
 
 /**

--- a/packages/runtime/src/ai/usage/credits.ts
+++ b/packages/runtime/src/ai/usage/credits.ts
@@ -2,77 +2,25 @@ import { type KeyStore as FullKeyStore, keyStore } from "../../auth/storage";
 import type { ProviderUsage } from "./types";
 
 /** The slice of the credential store the balance probes read. */
-type KeyStore = Pick<FullKeyStore, "has" | "getApiKey">;
+export type KeyStore = Pick<FullKeyStore, "has" | "getApiKey">;
 
 /**
- * Prepaid-credit balances for the API-key providers that expose one:
+ * Prepaid-credit balances for API-key providers that expose one:
  *
- *   OpenRouter — GET https://openrouter.ai/api/v1/credits
- *                → { data: { total_credits, total_usage } }
  *   DeepSeek   — GET https://api.deepseek.com/user/balance
  *                → { balance_infos: [{ currency, total_balance: "12.34" }] }
  *
- * Both authenticate with the stored API key as a Bearer token. No rate-limit
+ * Authenticates with the stored API key as a Bearer token. No rate-limit
  * windows here — a balance is the whole story for pay-as-you-go keys.
+ * (OpenRouter's two-probe blend lives in `openrouter.ts`.)
  */
 
-async function apiKeyFor(
+export async function apiKeyFor(
   store: KeyStore,
   provider: string,
 ): Promise<string | null> {
   if (!store.has(provider)) return null; // stored-only, like providerConnected
   return (await store.getApiKey(provider)) ?? null;
-}
-
-/** Fetch the OpenRouter account's remaining prepaid credits. */
-export async function fetchOpenRouterUsage(
-  fetchImpl: typeof fetch = fetch,
-  store: KeyStore = keyStore,
-): Promise<ProviderUsage> {
-  const provider = "openrouter";
-  const key = await apiKeyFor(store, provider);
-  if (!key) return { provider, status: "unauthenticated", windows: [] };
-
-  const res = await fetchImpl("https://openrouter.ai/api/v1/credits", {
-    headers: { Authorization: `Bearer ${key}`, Accept: "application/json" },
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (res.status === 401 || res.status === 403)
-    return { provider, status: "unauthenticated", windows: [] };
-  if (!res.ok) {
-    return {
-      provider,
-      status: "error",
-      windows: [],
-      message: `OpenRouter credits API answered ${res.status}`,
-    };
-  }
-  const body = (await res.json()) as {
-    data?: { total_credits?: unknown; total_usage?: unknown };
-  };
-  const total = body.data?.total_credits;
-  const used = body.data?.total_usage;
-  // A missing/renamed field must read as a probe failure, not a $0 balance.
-  if (typeof total !== "number" || typeof used !== "number") {
-    return {
-      provider,
-      status: "error",
-      windows: [],
-      message: "OpenRouter credits response had no readable balance",
-    };
-  }
-  return {
-    provider,
-    status: "ok",
-    windows: [],
-    // OpenRouter credits are denominated in USD.
-    credits: {
-      remaining: Math.max(0, total - used),
-      granted: total,
-      unit: "USD",
-    },
-    fetchedAt: new Date().toISOString(),
-  };
 }
 
 /** Fetch the DeepSeek account's remaining balance (prefers the USD row). */

--- a/packages/runtime/src/ai/usage/index.ts
+++ b/packages/runtime/src/ai/usage/index.ts
@@ -2,8 +2,9 @@ import { listProviders } from "../providers";
 import { fetchAnthropicUsage } from "./anthropic";
 import { fetchCodexUsage } from "./codex";
 import { fetchCopilotUsage } from "./copilot";
-import { fetchDeepSeekUsage, fetchOpenRouterUsage } from "./credits";
+import { fetchDeepSeekUsage } from "./credits";
 import { readTokenSpend } from "./ledger";
+import { fetchOpenRouterUsage } from "./openrouter";
 import type { ProviderUsage } from "./types";
 
 export { readTokenSpend, recordTokenSpend } from "./ledger";

--- a/packages/runtime/src/ai/usage/openrouter.ts
+++ b/packages/runtime/src/ai/usage/openrouter.ts
@@ -1,0 +1,171 @@
+import { keyStore } from "../../auth/storage";
+import { apiKeyFor, type KeyStore } from "./credits";
+import type { ProviderUsage } from "./types";
+
+/**
+ * OpenRouter account usage, blended from the two public probes:
+ *
+ *   GET https://openrouter.ai/api/v1/credits
+ *       → { data: { total_credits, total_usage } } — PURCHASED credits only.
+ *         Free/promotional grants are invisible here (and the endpoint is
+ *         documented management-key-only, answering 403 for plain keys).
+ *   GET https://openrouter.ai/api/v1/key
+ *       → { data: { usage, limit, limit_remaining, ... } } — the current
+ *         key's own spend and optional spend cap; always readable with the
+ *         key Houston stores.
+ *
+ * The blend keeps the row honest for every account shape (PRODUCT-1075):
+ * an account that purchased credits shows its real balance; a key created
+ * with a cap shows the cap's remainder; a grant-funded account — where no
+ * public endpoint reports the balance — shows its real spend flagged
+ * `excludesGrants` instead of a false "$0.00 left".
+ */
+
+type CreditsProbe =
+  | { kind: "ok"; total: number; used: number }
+  | { kind: "unauthenticated" }
+  | { kind: "forbidden" }
+  | { kind: "error"; message: string };
+
+type KeyProbe =
+  | { kind: "ok"; used?: number; limit?: number; limitRemaining?: number }
+  | { kind: "unauthenticated" }
+  | { kind: "error"; message: string };
+
+const finite = (v: unknown): number | undefined =>
+  typeof v === "number" && Number.isFinite(v) ? v : undefined;
+
+async function probeCredits(
+  fetchImpl: typeof fetch,
+  key: string,
+): Promise<CreditsProbe> {
+  const res = await fetchImpl("https://openrouter.ai/api/v1/credits", {
+    headers: { Authorization: `Bearer ${key}`, Accept: "application/json" },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (res.status === 401) return { kind: "unauthenticated" };
+  // 403 is the documented "not a management key" answer, not a sign-in
+  // problem — the same key still serves inference and /key.
+  if (res.status === 403) return { kind: "forbidden" };
+  if (!res.ok)
+    return {
+      kind: "error",
+      message: `OpenRouter credits API answered ${res.status}`,
+    };
+  const body = (await res.json()) as {
+    data?: { total_credits?: unknown; total_usage?: unknown };
+  };
+  const total = finite(body.data?.total_credits);
+  const used = finite(body.data?.total_usage);
+  // A missing/renamed field must read as a probe failure, not a $0 balance.
+  if (total === undefined || used === undefined)
+    return {
+      kind: "error",
+      message: "OpenRouter credits response had no readable balance",
+    };
+  return { kind: "ok", total, used };
+}
+
+async function probeKey(
+  fetchImpl: typeof fetch,
+  key: string,
+): Promise<KeyProbe> {
+  const res = await fetchImpl("https://openrouter.ai/api/v1/key", {
+    headers: { Authorization: `Bearer ${key}`, Accept: "application/json" },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (res.status === 401 || res.status === 403)
+    return { kind: "unauthenticated" };
+  if (!res.ok)
+    return {
+      kind: "error",
+      message: `OpenRouter key API answered ${res.status}`,
+    };
+  const body = (await res.json()) as {
+    data?: { usage?: unknown; limit?: unknown; limit_remaining?: unknown };
+  };
+  return {
+    kind: "ok",
+    used: finite(body.data?.usage),
+    limit: finite(body.data?.limit),
+    limitRemaining: finite(body.data?.limit_remaining),
+  };
+}
+
+/** Fetch the OpenRouter account's balance/spend (see module doc for shapes). */
+export async function fetchOpenRouterUsage(
+  fetchImpl: typeof fetch = fetch,
+  store: KeyStore = keyStore,
+): Promise<ProviderUsage> {
+  const provider = "openrouter";
+  const key = await apiKeyFor(store, provider);
+  if (!key) return { provider, status: "unauthenticated", windows: [] };
+
+  const asError = (e: unknown): { kind: "error"; message: string } => ({
+    kind: "error",
+    message: e instanceof Error ? e.message : String(e),
+  });
+  // One probe's outage never sinks the other's reading.
+  const [credits, keyInfo] = await Promise.all([
+    probeCredits(fetchImpl, key).catch(asError),
+    probeKey(fetchImpl, key).catch(asError),
+  ]);
+
+  const ok = (
+    credits: NonNullable<ProviderUsage["credits"]>,
+  ): ProviderUsage => ({
+    provider,
+    status: "ok",
+    windows: [],
+    // OpenRouter denominates everything in USD.
+    credits,
+    fetchedAt: new Date().toISOString(),
+  });
+
+  // An account that purchased credits: the classic prepaid balance.
+  if (credits.kind === "ok" && credits.total > 0)
+    return ok({
+      remaining: Math.max(0, credits.total - credits.used),
+      granted: credits.total,
+      used: credits.used,
+      unit: "USD",
+    });
+
+  // No purchased balance, but the key carries a spend cap: its remainder is
+  // a real "left" figure for everything routed through Houston.
+  if (keyInfo.kind === "ok" && keyInfo.limitRemaining !== undefined)
+    return ok({
+      remaining: Math.max(0, keyInfo.limitRemaining),
+      granted: keyInfo.limit,
+      used: keyInfo.used,
+      unit: "USD",
+    });
+
+  // Grant-funded / free-tier account: OpenRouter exposes no balance for it,
+  // so report the real spend and say the grants are unreported — never $0.
+  if (keyInfo.kind === "ok" || credits.kind === "ok")
+    return ok({
+      remaining: 0,
+      used:
+        credits.kind === "ok"
+          ? credits.used
+          : keyInfo.kind === "ok"
+            ? keyInfo.used
+            : undefined,
+      unit: "USD",
+      excludesGrants: true,
+    });
+
+  if (credits.kind === "unauthenticated" || keyInfo.kind === "unauthenticated")
+    return { provider, status: "unauthenticated", windows: [] };
+
+  return {
+    provider,
+    status: "error",
+    windows: [],
+    message:
+      (keyInfo.kind === "error" ? keyInfo.message : undefined) ??
+      (credits.kind === "error" ? credits.message : undefined) ??
+      "OpenRouter usage probes failed",
+  };
+}

--- a/packages/runtime/src/ai/usage/usage.test.ts
+++ b/packages/runtime/src/ai/usage/usage.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from "vitest";
 import { fetchAnthropicUsage } from "./anthropic";
 import { fetchCodexUsage } from "./codex";
 import { fetchCopilotUsage } from "./copilot";
-import { fetchDeepSeekUsage, fetchOpenRouterUsage } from "./credits";
+import { fetchDeepSeekUsage } from "./credits";
 import { listProviderUsage } from "./index";
+import { fetchOpenRouterUsage } from "./openrouter";
 import { clampPercent, epochSecondsToIso } from "./types";
 
 function jsonResponse(body: unknown, status = 200): typeof fetch {
@@ -241,26 +242,111 @@ describe("fetchCopilotUsage", () => {
 describe("credit balances", () => {
   const keyStore = { has: () => true, getApiKey: async () => "sk-1" };
 
-  it("openrouter: remaining = credits - usage", async () => {
+  /** Routes the two OpenRouter probes by URL; a missing entry answers 500. */
+  function openRouterFetch(routes: {
+    credits?: { body?: unknown; status?: number };
+    key?: { body?: unknown; status?: number };
+  }): typeof fetch {
+    return async (url) => {
+      const route = String(url).endsWith("/credits")
+        ? routes.credits
+        : routes.key;
+      return new Response(JSON.stringify(route?.body ?? {}), {
+        status: route ? (route.status ?? 200) : 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+  }
+
+  it("openrouter: a purchased account keeps remaining = credits - usage", async () => {
     const row = await fetchOpenRouterUsage(
-      jsonResponse({ data: { total_credits: 25, total_usage: 5.5 } }),
+      openRouterFetch({
+        credits: { body: { data: { total_credits: 25, total_usage: 5.5 } } },
+        key: { body: { data: { usage: 5.5, limit: null } } },
+      }),
       keyStore,
     );
     expect(row.status).toBe("ok");
     expect(row.credits).toEqual({
       remaining: 19.5,
       granted: 25,
+      used: 5.5,
       unit: "USD",
     });
   });
 
-  it("openrouter: an unreadable balance is an error, not a $0 balance", async () => {
+  it("openrouter: a grant-funded account reports spend + excludesGrants, never $0 left", async () => {
     const row = await fetchOpenRouterUsage(
-      jsonResponse({ data: { credits: 25 } }),
+      openRouterFetch({
+        // The dashboard says "$10.00 in grants" but the public API only ever
+        // reports purchased credits — total_credits stays 0 (PRODUCT-1075).
+        credits: { body: { data: { total_credits: 0, total_usage: 0.31 } } },
+        key: {
+          body: { data: { usage: 0.31, limit: null, limit_remaining: null } },
+        },
+      }),
+      keyStore,
+    );
+    expect(row.status).toBe("ok");
+    expect(row.credits).toEqual({
+      remaining: 0,
+      used: 0.31,
+      unit: "USD",
+      excludesGrants: true,
+    });
+  });
+
+  it("openrouter: a capped key's remainder stands in when /credits is management-only (403)", async () => {
+    const row = await fetchOpenRouterUsage(
+      openRouterFetch({
+        credits: { status: 403 },
+        key: {
+          body: { data: { usage: 2.5, limit: 10, limit_remaining: 7.5 } },
+        },
+      }),
+      keyStore,
+    );
+    expect(row.status).toBe("ok");
+    expect(row.credits).toEqual({
+      remaining: 7.5,
+      granted: 10,
+      used: 2.5,
+      unit: "USD",
+    });
+  });
+
+  it("openrouter: a key-probe outage never sinks a good balance", async () => {
+    const fetchImpl: typeof fetch = async (url) => {
+      if (String(url).endsWith("/credits"))
+        return new Response(
+          JSON.stringify({ data: { total_credits: 25, total_usage: 5.5 } }),
+          { status: 200 },
+        );
+      throw new Error("network down");
+    };
+    const row = await fetchOpenRouterUsage(fetchImpl, keyStore);
+    expect(row.status).toBe("ok");
+    expect(row.credits?.remaining).toBe(19.5);
+  });
+
+  it("openrouter: unreadable probes are an error, not a $0 balance", async () => {
+    const row = await fetchOpenRouterUsage(
+      openRouterFetch({
+        credits: { body: { data: { credits: 25 } } },
+        key: { status: 500 },
+      }),
       keyStore,
     );
     expect(row.status).toBe("error");
     expect(row.credits).toBeUndefined();
+  });
+
+  it("openrouter: 401s on both probes read as unauthenticated", async () => {
+    const row = await fetchOpenRouterUsage(
+      openRouterFetch({ credits: { status: 401 }, key: { status: 401 } }),
+      keyStore,
+    );
+    expect(row.status).toBe("unauthenticated");
   });
 
   it("deepseek: parses the string USD balance", async () => {

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -1345,7 +1345,15 @@ export interface ProviderUsageCredits {
   remaining: number;
   /** Total granted, when reported. */
   granted?: number;
+  /** Lifetime spend in `unit`, when reported. */
+  used?: number;
   unit: "USD" | "credits";
+  /**
+   * True when the provider's API omits free/promotional grants from the
+   * balance (OpenRouter reports purchased credits only), so `remaining` is a
+   * lower bound the UI must not present as "you have nothing left".
+   */
+  excludesGrants?: boolean;
 }
 
 /**


### PR DESCRIPTION
Fixes PRODUCT-1075.

## Root cause

The AI Models hub showed **"$0.00 left"** for an OpenRouter account whose own dashboard shows **$10.00 available**. The balance probe reads `GET /api/v1/credits`, and per OpenRouter's OpenAPI spec that endpoint reports **purchased** credits only (`total_credits`: "Total credits purchased"). Free/promotional **grants are invisible to the public API** — no endpoint reports them — so a grant-funded account ($0 purchased) honestly computed to a very dishonest-looking $0.00. The endpoint is also documented management-key-only (403 for plain keys), which the old code mapped to `unauthenticated` — a "sign in again" card for a key that works fine.

## The fix

Showing the dashboard's exact number is impossible with OpenRouter's public API, so the fetcher (`packages/runtime/src/ai/usage/openrouter.ts`) now blends the two probes that ARE public, and stays honest in every account shape:

| Account shape | Row |
|---|---|
| Purchased credits (`total_credits > 0`) | unchanged: `remaining = total_credits - total_usage`, "$19.50 left" |
| No purchased balance, key has a spend cap | the cap's remainder from `/api/v1/key` `limit_remaining` |
| Grant-funded / free tier (Felipe's case) | real spend + `excludesGrants`: the row shows "**$0.31 used**" plus "This provider doesn't report free or promotional credit balances." — never a false "$0.00 left" |
| `/credits` 403 (management-key-only) | falls back to `/key` instead of a bogus reconnect card |
| Both probes unreadable | `error` row, never a fabricated $0 |

One probe's outage never sinks the other's reading (each is caught independently).

**Protocol**: `ProviderUsageCredits` gains optional `used` and `excludesGrants` (additive only, mirrored in `ui/engine-client`). Old clients keep rendering exactly what they render today.

**UI**: `provider-usage-meters.tsx` renders the new `CreditsBalance` line; new `creditsUsed` / `grantsUnreported` strings in en/es/pt.

## Before

1. Connect an OpenRouter account that has only granted credits (no purchases) — the OpenRouter dashboard shows e.g. "$10.00 total available, $10.00 in grants".
2. Open Houston → AI Models → the OpenRouter connected row.
3. The row reads "$0.00 left", implying the account is out of money while chat works fine.

## After

1. Same account, same screen: the row shows the account's real spend ("$X.XX used") with the note that free/promotional balances aren't reported by the provider. No false zero.
2. An account with purchased credits still shows the classic "$N left" (unchanged).
3. A key created with a spend cap shows the cap's remainder even when `/credits` answers 403.

## Verification

- `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test` — 2707 passing (22 in `usage.test.ts`, incl. 6 new OpenRouter shapes)
- `cd app && pnpm test` (3403) · `pnpm tsgo --noEmit` · `pnpm check-locales` — all green
- `pnpm typecheck` (all 27 projects) · `pnpm check` (Biome) · `pnpm check:boundaries` — clean
