### PR TITLE
Serve/connect hygiene: api-key rollback, unconditional ghost clear, probe retry (PRODUCT-1321)

### DIFF
--- a/packages/host/src/channel/contract.test.ts
+++ b/packages/host/src/channel/contract.test.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { MemoryCredentialStore } from "../credentials/store";
 import type { Agent, Workspace } from "../domain/types";
 import { FakeLauncher } from "../launcher/fake";
@@ -194,6 +194,10 @@ let proxyCustomEndpointBody: unknown = null;
 let proxyClaudeOAuthBody: unknown = null;
 /** When set, the fake runtime rejects /auth/:provider/api-key with this reply. */
 let proxyApiKeyRejection: { status: number; body: unknown } | null = null;
+/** DELETE /auth/:provider/api-key rollbacks the fake runtime received. */
+let proxyApiKeyRollbacks: { provider: string; body: unknown }[] = [];
+/** When true, the fake runtime fails the rollback DELETE with a 500. */
+let proxyApiKeyRollbackFails = false;
 let proxyScrubFailuresRemaining = 0;
 let proxyScrubCalls = 0;
 
@@ -252,8 +256,24 @@ beforeAll(async () => {
       }
       return reply(200, { ok: true });
     }
-    // API-key connect pushes the pasted key into the standing runtime.
-    if (path.match(/^\/auth\/[^/]+\/api-key$/)) {
+    // API-key connect pushes the pasted key into the standing runtime; a
+    // failed central PUT rolls it back out with a DELETE (PRODUCT-1321).
+    const apiKeyMatch = path.match(/^\/auth\/([^/]+)\/api-key$/);
+    if (apiKeyMatch) {
+      if (req.method === "DELETE") {
+        const chunks: Buffer[] = [];
+        req.on("data", (c) => chunks.push(c as Buffer));
+        req.on("end", () => {
+          proxyApiKeyRollbacks.push({
+            provider: apiKeyMatch[1] ?? "",
+            body: JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}"),
+          });
+          if (proxyApiKeyRollbackFails)
+            reply(500, { error: "rollback unavailable" });
+          else reply(200, { ok: true, removed: true });
+        });
+        return;
+      }
       return proxyApiKeyRejection
         ? reply(proxyApiKeyRejection.status, proxyApiKeyRejection.body)
         : reply(200, { ok: true });
@@ -275,6 +295,8 @@ afterAll(() => proxyRuntime.close());
 function makeProxyFixture(): ChannelFixture {
   proxyConnected = false; // each fixture starts disconnected
   proxyApiKeyRejection = null;
+  proxyApiKeyRollbacks = [];
+  proxyApiKeyRollbackFails = false;
   proxyScrubFailuresRemaining = 0;
   proxyScrubCalls = 0;
   const credentials = new MemoryCredentialStore();
@@ -435,6 +457,73 @@ describe("saveApiKeyCredential rejection (ProxyChannel)", () => {
     expect(err).toBeInstanceOf(ApiKeyRejectedError);
     expect((err as ApiKeyRejectedError).reason).toBeUndefined();
     expect((err as ApiKeyRejectedError).message).toBe("nope");
+  });
+});
+
+// PRODUCT-1321: the runtime verifies AND persists the key before the central
+// PUT. If that PUT fails, the runtime is left with a verified key the central
+// store never learned about — absent from served-providers.json, so no
+// authoritative sync can remove it; it works until the pod recycles, then
+// silently vanishes. A failed central PUT must roll the runtime entry back so
+// the failed connect leaves NO local residue.
+describe("saveApiKeyCredential central PUT failure (ProxyChannel)", () => {
+  class CentralPutFailsStore extends MemoryCredentialStore {
+    override async put(): Promise<void> {
+      throw new Error("central store unavailable");
+    }
+  }
+
+  function makeFailingPutFixture() {
+    makeProxyFixture(); // resets the fake runtime's shared state
+    const credentials = new CentralPutFailsStore();
+    const launcher = new FakeLauncher({
+      baseUrl: proxyRuntimeUrl,
+      token: "sbx",
+    });
+    const channel = new ProxyChannel({
+      launcher,
+      proxy: { forward },
+      credentials,
+      forwardActingHeader: false,
+    });
+    return { channel, credentials };
+  }
+
+  test("rolls the runtime key back and rethrows the central failure", async () => {
+    const { channel, credentials } = makeFailingPutFixture();
+    await expect(
+      channel.saveApiKeyCredential(ctx, "openrouter", "sk-or-v1-KEY"),
+    ).rejects.toThrow("central store unavailable");
+    // The runtime received the DELETE for exactly the key it had persisted.
+    expect(proxyApiKeyRollbacks).toEqual([
+      { provider: "openrouter", body: { key: "sk-or-v1-KEY" } },
+    ]);
+    expect(await credentials.get(ws.id, "openrouter")).toBeNull();
+  });
+
+  test("a failing rollback never masks the central failure (logged instead)", async () => {
+    const { channel } = makeFailingPutFixture();
+    proxyApiKeyRollbackFails = true;
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await expect(
+        channel.saveApiKeyCredential(ctx, "openrouter", "sk-or-v1-KEY"),
+      ).rejects.toThrow("central store unavailable");
+      expect(proxyApiKeyRollbacks.length).toBe(1);
+      expect(
+        errors.mock.calls.some((c) =>
+          String(c[0]).includes("could not roll the openrouter key back"),
+        ),
+      ).toBe(true);
+    } finally {
+      errors.mockRestore();
+    }
+  });
+
+  test("a successful connect never fires a rollback", async () => {
+    const { channel } = makeProxyFixture();
+    await channel.saveApiKeyCredential(ctx, "opencode", "sk-opencode-ok");
+    expect(proxyApiKeyRollbacks).toEqual([]);
   });
 });
 

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -369,7 +369,10 @@ export class ProxyChannel implements RuntimeChannel {
    * whole workspace. Order matters: storing before the runtime's verdict left a
    * garbage key "connected" everywhere (the central store is the source of
    * truth every future runtime is served from). The runtime's own store is
-   * written by the push, so status reads connected immediately.
+   * written by the push, so status reads connected immediately. If the central
+   * store then rejects the PUT, the runtime write is rolled back
+   * (`rollbackRuntimeApiKey`) — a failed connect must not leave a working but
+   * unmanifested key behind (PRODUCT-1321).
    */
   async saveApiKeyCredential(
     ctx: ChannelCtx,
@@ -402,17 +405,30 @@ export class ProxyChannel implements RuntimeChannel {
         body?.reason,
       );
     }
-    await this.opts.credentials.put(
-      {
-        workspaceId: ctx.agent.workspaceId,
-        provider,
-        accessToken: apiKey,
-        refreshToken: "",
-        expiresAt: 0,
-        kind: "api_key",
-      },
-      { actingAs: ctx.actingAs },
-    );
+    try {
+      await this.opts.credentials.put(
+        {
+          workspaceId: ctx.agent.workspaceId,
+          provider,
+          accessToken: apiKey,
+          refreshToken: "",
+          expiresAt: 0,
+          kind: "api_key",
+        },
+        { actingAs: ctx.actingAs },
+      );
+    } catch (err) {
+      // The runtime just verified AND persisted this key — but the central
+      // store is the source of truth every future runtime is served from, and
+      // a key it never learned about is absent from the runtime's
+      // served-providers manifest, so no authoritative sync can ever remove
+      // it. Left in place it works until the pod recycles, then silently
+      // vanishes: the "spontaneous disconnect" (PRODUCT-1321). Roll the
+      // runtime entry back so this failed connect leaves NO local residue,
+      // then surface the central failure the user already sees.
+      await this.rollbackRuntimeApiKey(endpoint, provider, apiKey, ctx);
+      throw err;
+    }
     // A verified pasted key (incl. the anthropic setup token) is a fresh
     // user-driven connect: it supersedes any provider revocation.
     this.revocations.clear({
@@ -420,6 +436,42 @@ export class ProxyChannel implements RuntimeChannel {
       provider,
       actingAs: ctx.actingAs,
     });
+  }
+
+  /**
+   * Best-effort undo of the runtime-side key write when the central PUT
+   * failed. The runtime removes the entry only if it still holds THIS exact
+   * key (a concurrent connect's newer key survives). A rollback failure is
+   * logged loudly, never thrown — the caller is already rethrowing the central
+   * failure, which is the error the user acts on; masking it with a rollback
+   * transport error would hide the real reason the connect failed.
+   */
+  private async rollbackRuntimeApiKey(
+    endpoint: RuntimeEndpoint,
+    provider: string,
+    apiKey: string,
+    ctx: ChannelCtx,
+  ): Promise<void> {
+    try {
+      const res = await fetch(
+        `${endpoint.baseUrl}/auth/${encodeURIComponent(provider)}/api-key`,
+        {
+          method: "DELETE",
+          headers: {
+            "content-type": "application/json",
+            Authorization: `Bearer ${endpoint.token}`,
+            ...(ctx.actingAs ? { "x-houston-acting-as": ctx.actingAs } : {}),
+          },
+          body: JSON.stringify({ key: apiKey }),
+        },
+      );
+      if (!res.ok) throw new Error(`runtime ${res.status}`);
+    } catch (err) {
+      console.error(
+        `[credential] could not roll the ${provider} key back out of the runtime after the central store rejected the connect — the runtime keeps an unmanifested key until the next connect or pod recycle:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
   }
 
   /**

--- a/packages/host/src/routes/credential.test.ts
+++ b/packages/host/src/routes/credential.test.ts
@@ -558,6 +558,21 @@ test("anthropic is NOT served off the managed cloud, even when stored", async ()
   expect(await call(credentials, "anthropic", r)).toBe(true);
   expect(r.out.status).toBe(404);
   expect(r.out.headers?.["x-houston-not-connected"]).toBe("1");
+  // The deployment-refusal marker: without it the runtime's ghost cleanup
+  // (PRODUCT-1323) would read this answer as a workspace disconnect and delete
+  // the browser login's legitimate `.credentials.json` on every sync.
+  expect(r.out.headers?.["x-houston-not-served-here"]).toBe("1");
+});
+
+test("a real not-connected 404 carries no not-served-here marker", async () => {
+  // The runtime must be able to tell "this deployment never serves anthropic"
+  // (leave local files alone) from "the workspace disconnected" (clear the
+  // ghost) — only the deployment refusal carries the second marker.
+  const credentials = new MemoryCredentialStore();
+  const r = mockRes();
+  expect(await call(credentials, "openai-codex", r)).toBe(true);
+  expect(r.out.status).toBe(404);
+  expect(r.out.headers?.["x-houston-not-served-here"]).toBeUndefined();
 });
 
 test("anthropic serves access-only on a gateway-fronted host", async () => {

--- a/packages/host/src/routes/credential.ts
+++ b/packages/host/src/routes/credential.ts
@@ -64,10 +64,21 @@ export async function handleSandboxCredential(
   // stale access token that OUTRANKS the working keychain credential
   // (CLAUDE_CODE_OAUTH_TOKEN wins inside the SDK), and refreshing it here would
   // make this host a second rotator of a refresh token family the pod already
-  // owns. The marked 404 is the store's authoritative "not served here" answer;
-  // the runtime's provenance manifest keeps it from deleting anything local.
-  if (provider === "anthropic" && !deps.gatewayFronted)
-    return notConnected(res, "anthropic is not served on this deployment");
+  // owns. The marked 404 carries a SECOND marker, `x-houston-not-served-here`:
+  // this is a deployment fact ("anthropic never serves here"), not a verdict
+  // about the central store, and the runtime's ghost cleanup (PRODUCT-1323)
+  // keys on that distinction — without it, every desktop/self-host serve sync
+  // would read this answer as a workspace disconnect and delete the browser
+  // login's legitimate `.credentials.json`.
+  if (provider === "anthropic" && !deps.gatewayFronted) {
+    json(
+      res,
+      404,
+      { error: "anthropic is not served on this deployment" },
+      { "x-houston-not-connected": "1", "x-houston-not-served-here": "1" },
+    );
+    return true;
+  }
   // WHOSE credential this serve is for (HOU-976). The gateway mints the header;
   // absent (desktop, self-host, every pre-HOU-976 pod) means the single shared
   // scope, so the whole path below is byte-identical to before.

--- a/packages/runtime/src/auth/serve-probe.test.ts
+++ b/packages/runtime/src/auth/serve-probe.test.ts
@@ -1,0 +1,138 @@
+import { expect, test, vi } from "vitest";
+import {
+  describeProbeError,
+  PROBE_CONCURRENCY,
+  probeProvider,
+  probeProviders,
+  type ServeProbe,
+} from "./serve-probe";
+
+/**
+ * PRODUCT-1324 / HOUSTON-APP-4YV: runServedSync's ~40 unretried concurrent
+ * probes turned one transient socket failure into a Sentry ERROR per provider
+ * AND silently un-applied that provider for the sync. These pin the probe
+ * layer's three defenses: one retry after a short backoff, a small concurrency
+ * pool, and failure details that keep the undici `cause` code.
+ */
+
+const served = (id: string): ServeProbe => ({
+  id,
+  state: "served",
+  cred: { provider: id, access: "AT", expires: 1, accountId: null },
+});
+
+const failed = (id: string, detail = "fetch failed"): ServeProbe => ({
+  id,
+  state: "error",
+  detail,
+});
+
+test("a transient first failure is retried once and the retry's answer wins", async () => {
+  const warns = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    let calls = 0;
+    const attempt = async (id: string) =>
+      ++calls === 1
+        ? failed(id, "fetch failed (cause: ECONNRESET)")
+        : served(id);
+    const probe = await probeProvider("openai-codex", attempt, 0);
+    expect(probe.state).toBe("served");
+    expect(calls).toBe(2);
+    // The first failure is a WARN breadcrumb, never an error.
+    expect(
+      warns.mock.calls.some(
+        (c) =>
+          String(c[0]).includes("retrying once") &&
+          String(c[0]).includes("ECONNRESET"),
+      ),
+    ).toBe(true);
+  } finally {
+    warns.mockRestore();
+  }
+});
+
+test("a probe that fails both attempts is a final error (the retry's detail)", async () => {
+  const warns = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    let calls = 0;
+    const attempt = async (id: string) => {
+      calls++;
+      return failed(id, "fetch failed (cause: ECONNREFUSED)");
+    };
+    const probe = await probeProvider("google", attempt, 0);
+    expect(calls).toBe(2);
+    expect(probe.state).toBe("error");
+    if (probe.state === "error") expect(probe.detail).toContain("ECONNREFUSED");
+  } finally {
+    warns.mockRestore();
+  }
+});
+
+test("a timed-out first attempt is final immediately (no 10s+10s stall)", async () => {
+  let calls = 0;
+  const attempt = async (id: string): Promise<ServeProbe> => {
+    calls++;
+    return { id, state: "error", detail: "timeout", timedOut: true };
+  };
+  const probe = await probeProvider("anthropic", attempt, 0);
+  expect(calls).toBe(1);
+  expect(probe.state).toBe("error");
+});
+
+test("a clean answer is never retried", async () => {
+  let calls = 0;
+  const attempt = async (id: string) => {
+    calls++;
+    return served(id);
+  };
+  await probeProvider("opencode", attempt, 0);
+  expect(calls).toBe(1);
+});
+
+test("probeProviders caps concurrency and preserves order", async () => {
+  const ids = Array.from({ length: 30 }, (_, i) => `p${i}`);
+  let inFlight = 0;
+  let peak = 0;
+  const probe = async (id: string): Promise<ServeProbe> => {
+    inFlight++;
+    peak = Math.max(peak, inFlight);
+    await new Promise((r) => setTimeout(r, 2));
+    inFlight--;
+    return served(id);
+  };
+  const results = await probeProviders(ids, probe, PROBE_CONCURRENCY);
+  expect(peak).toBeLessThanOrEqual(PROBE_CONCURRENCY);
+  expect(peak).toBeGreaterThan(1); // still concurrent, not serial
+  expect(results.map((p) => p.id)).toEqual(ids);
+});
+
+test("describeProbeError surfaces the nested undici cause code", () => {
+  // undici's socket failure: TypeError("fetch failed") with the code on cause.
+  const socketErr = Object.assign(new TypeError("fetch failed"), {
+    cause: Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+  });
+  expect(describeProbeError(socketErr)).toBe(
+    "fetch failed (cause: ECONNRESET)",
+  );
+
+  // Happy-eyeballs connect failure: the cause is an AggregateError of
+  // per-address errors, each carrying the code.
+  const aggregate = Object.assign(new TypeError("fetch failed"), {
+    cause: new AggregateError([
+      Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:443"), {
+        code: "ECONNREFUSED",
+      }),
+    ]),
+  });
+  expect(describeProbeError(aggregate)).toBe(
+    "fetch failed (cause: ECONNREFUSED)",
+  );
+
+  // errno-only causes stringify; causeless errors stay the bare message.
+  const errnoErr = Object.assign(new TypeError("fetch failed"), {
+    cause: Object.assign(new Error("socket hang up"), { errno: -54 }),
+  });
+  expect(describeProbeError(errnoErr)).toBe("fetch failed (cause: -54)");
+  expect(describeProbeError(new Error("plain"))).toBe("plain");
+  expect(describeProbeError("not an error")).toBe("not an error");
+});

--- a/packages/runtime/src/auth/serve-probe.ts
+++ b/packages/runtime/src/auth/serve-probe.ts
@@ -17,7 +17,7 @@ import type { ServedCredential } from "./auth-file";
 
 export type ServeProbe =
   | { id: string; state: "served"; cred: ServedCredential }
-  | { id: string; state: "not-connected" }
+  | { id: string; state: "not-connected"; notServedHere?: boolean }
   | { id: string; state: "error"; detail: string; timedOut?: boolean };
 
 /**
@@ -27,6 +27,16 @@ export type ServeProbe =
  * must never delete a working credential.
  */
 const NOT_CONNECTED_HEADER = "x-houston-not-connected";
+
+/**
+ * Second marker on the anthropic refusal of a non-gateway-fronted host:
+ * "anthropic is NEVER served on this deployment" — a deployment fact, not a
+ * verdict about the central store. The desktop/self-host browser login owns
+ * the local `.credentials.json` there, so the ghost cleanup (PRODUCT-1323)
+ * must not read this answer as "the workspace disconnected" and delete a
+ * legitimate credential.
+ */
+const NOT_SERVED_HERE_HEADER = "x-houston-not-served-here";
 
 /** One stalled host/gateway socket must not hang every hydrating route. */
 const SERVE_FETCH_TIMEOUT_MS = 10_000;
@@ -100,7 +110,13 @@ async function probeOnce(id: string): Promise<ServeProbe> {
       },
     );
     if (res.status === 404 && res.headers.get(NOT_CONNECTED_HEADER) === "1")
-      return { id, state: "not-connected" };
+      return {
+        id,
+        state: "not-connected",
+        ...(res.headers.get(NOT_SERVED_HERE_HEADER) === "1"
+          ? { notServedHere: true }
+          : {}),
+      };
     if (!res.ok)
       return {
         id,

--- a/packages/runtime/src/auth/serve-probe.ts
+++ b/packages/runtime/src/auth/serve-probe.ts
@@ -1,0 +1,172 @@
+import { config } from "../config";
+import { currentCredentialScope } from "../session/acting-context";
+import type { ServedCredential } from "./auth-file";
+
+/**
+ * Central credential probes for serve mode (PRODUCT-1324 / HOUSTON-APP-4YV).
+ *
+ * `runServedSync` probes EVERY known provider against the control plane, on
+ * every turn start and several hydrating routes. Fired all at once with no
+ * retry, one transient socket failure became a Sentry ERROR per provider AND
+ * silently un-applied that provider for the sync — a freshly recycled pod's
+ * first turn could read a connected provider as not-connected. So probes here
+ * are (a) capped to a small concurrency, (b) retried once after a short
+ * backoff before an error is final, and (c) described with the nested undici
+ * `cause` code (the part `err.message` — a bare "fetch failed" — loses).
+ */
+
+export type ServeProbe =
+  | { id: string; state: "served"; cred: ServedCredential }
+  | { id: string; state: "not-connected" }
+  | { id: string; state: "error"; detail: string; timedOut?: boolean };
+
+/**
+ * Marker the host sets on its /sandbox/credential 404: the credential store's
+ * own "not connected" answer. Only marked 404s are an authoritative logout —
+ * a bare 404 (an old host, a mistyped control-plane URL, a route-level miss)
+ * must never delete a working credential.
+ */
+const NOT_CONNECTED_HEADER = "x-houston-not-connected";
+
+/** One stalled host/gateway socket must not hang every hydrating route. */
+const SERVE_FETCH_TIMEOUT_MS = 10_000;
+
+/** Short backoff before the single retry — a socket blip, not an outage. */
+export const PROBE_RETRY_DELAY_MS = 250;
+
+/**
+ * How many probes run at once. ~40 concurrent sockets from a just-woken pod
+ * were themselves a plausible source of the transient failures; a small pool
+ * keeps the sweep to a few round-trips without the burst.
+ */
+export const PROBE_CONCURRENCY = 8;
+
+/**
+ * The first meaningful error code in a `cause` chain. undici wraps socket
+ * failures as `TypeError: fetch failed` with the real `ECONNRESET`/`EAI_AGAIN`
+ * on `cause` (sometimes an AggregateError of per-address connect failures) —
+ * without this, the log and its Sentry event say only "fetch failed".
+ */
+function causeCode(err: unknown, depth = 0): string | undefined {
+  if (!err || typeof err !== "object" || depth > 4) return undefined;
+  const e = err as {
+    code?: unknown;
+    errno?: unknown;
+    cause?: unknown;
+    errors?: unknown[];
+  };
+  if (typeof e.code === "string" && e.code) return e.code;
+  if (typeof e.errno === "number") return String(e.errno);
+  if (Array.isArray(e.errors)) {
+    for (const inner of e.errors) {
+      const code = causeCode(inner, depth + 1);
+      if (code) return code;
+    }
+  }
+  return causeCode(e.cause, depth + 1);
+}
+
+/** A probe failure's log detail: the message plus the nested cause code. */
+export function describeProbeError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const code = causeCode(err.cause);
+  return code ? `${err.message} (cause: ${code})` : err.message;
+}
+
+/** AbortSignal.timeout's rejection — a 10s stall, not a momentary blip. */
+function isTimeout(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.name === "TimeoutError" || err.name === "AbortError")
+  );
+}
+
+/** One provider's central lookup — a single attempt. Never throws — an
+ *  internal serve hiccup for ONE provider must not strand the others. */
+async function probeOnce(id: string): Promise<ServeProbe> {
+  // WHO this serve is for: the host forwards the acting-as token to the gateway,
+  // which resolves personal-vs-team for THIS provider and reports its verdict
+  // on the body. Absent → the team credential, exactly as before HOU-976.
+  const { actingAs } = currentCredentialScope();
+  try {
+    const res = await fetch(
+      `${config.controlPlaneUrl}/sandbox/credential?provider=${id}`,
+      {
+        headers: {
+          Authorization: `Bearer ${config.sandboxToken}`,
+          ...(actingAs ? { "x-houston-acting-as": actingAs } : {}),
+        },
+        signal: AbortSignal.timeout(SERVE_FETCH_TIMEOUT_MS),
+      },
+    );
+    if (res.status === 404 && res.headers.get(NOT_CONNECTED_HEADER) === "1")
+      return { id, state: "not-connected" };
+    if (!res.ok)
+      return {
+        id,
+        state: "error",
+        detail: `${res.status}: ${await res.text().catch(() => "")}`,
+      };
+    return {
+      id,
+      state: "served",
+      cred: (await res.json()) as ServedCredential,
+    };
+  } catch (err) {
+    return {
+      id,
+      state: "error",
+      detail: describeProbeError(err),
+      timedOut: isTimeout(err),
+    };
+  }
+}
+
+/**
+ * One provider's probe with a single retry. The first failure is a WARN
+ * breadcrumb only — the error becomes final (and Sentry-visible via
+ * serve-log.ts) when the retry fails too, so a one-off blip never alerts
+ * while a persistent gateway outage still does. A TIMED-OUT first attempt is
+ * final immediately: it already stalled the sync for 10s, a 250ms-later
+ * second stall would not heal it, and the next sync re-probes anyway.
+ */
+export async function probeProvider(
+  id: string,
+  attempt: (id: string) => Promise<ServeProbe> = probeOnce,
+  retryDelayMs: number = PROBE_RETRY_DELAY_MS,
+): Promise<ServeProbe> {
+  const first = await attempt(id);
+  if (first.state !== "error" || first.timedOut) return first;
+  console.warn(
+    `[serve] credential ${id} probe failed, retrying once: ${first.detail}`,
+  );
+  await new Promise((r) => setTimeout(r, retryDelayMs));
+  return attempt(id);
+}
+
+/**
+ * Probe every id through a small worker pool (order-preserving). Results are
+ * per-provider verdicts; a probe that fails both attempts stays an `error`
+ * verdict — the caller keeps whatever it already applied and re-probes on the
+ * next sync (an error must never remove a credential).
+ */
+export async function probeProviders(
+  ids: string[],
+  probe: (id: string) => Promise<ServeProbe> = probeProvider,
+  concurrency: number = PROBE_CONCURRENCY,
+): Promise<ServeProbe[]> {
+  const results: ServeProbe[] = [];
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(concurrency, ids.length)) },
+    async () => {
+      while (next < ids.length) {
+        const index = next++;
+        const id = ids[index];
+        if (id !== undefined) results[index] = await probe(id);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}

--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -301,6 +301,29 @@ test("a never-manifested ghost credential is still cleared on an authoritative n
   });
 });
 
+test("a deployment refusal (not-served-here) never clears the local credential file", async () => {
+  // Desktop/self-host hosts answer EVERY anthropic serve with the marked 404
+  // plus `x-houston-not-served-here`: a deployment fact, not a store verdict.
+  // There the materialized file belongs to the local browser login — reading
+  // the refusal as a disconnect would delete a healthy credential on every
+  // sync (the regression the PRODUCT-1323 review caught).
+  await withTempHoustonHome(async () => {
+    const file = writeMaterializedClaudeCredential();
+    const fetchImpl = (async () =>
+      new Response(null, {
+        status: 404,
+        headers: {
+          "x-houston-not-connected": "1",
+          "x-houston-not-served-here": "1",
+        },
+      })) as unknown as typeof globalThis.fetch;
+    await withServeMode(fetchImpl, async () => {
+      expect(await syncServedCredential()).toEqual([]);
+      expect(existsSync(file)).toBe(true);
+    });
+  });
+});
+
 test("a personal scope never clears the pod-shared ghost, manifest or not", async () => {
   const actingToken = (sub: string) =>
     `acting-v1.${Buffer.from(

--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -27,6 +27,7 @@ import {
 } from "./auth-file";
 import { selectExportCredential } from "./export";
 import { syncServedCredential } from "./serve";
+import { resetServeProbeLog } from "./serve-log";
 import { resetDeadKeyReportsForTest } from "./served-key-guard";
 
 /** The host's authoritative "not connected" 404 (see routes/credential.ts). */
@@ -281,6 +282,48 @@ test("an authoritative anthropic disconnect clears the ghost materialized SDK cr
   });
 });
 
+test("a never-manifested ghost credential is still cleared on an authoritative not-connected (PRODUCT-1323)", async () => {
+  // The ghost can be planted while anthropic is OUTSIDE the served manifest —
+  // a setup pod's non-attributed connect whose central row was later removed,
+  // or a self-host row that was verify-rejected before any successful serve.
+  // The old manifest-gated clear never ran for those, and the provenance gate
+  // then blocked the revocation reporter too: PRODUCT-1307 through a
+  // different door. The clear must not depend on serve provenance — the file
+  // itself only ever comes from a central push.
+  await withTempHoustonHome(async () => {
+    const file = writeMaterializedClaudeCredential();
+    const fetchImpl = (async () =>
+      notConnected404()) as unknown as typeof globalThis.fetch;
+    await withServeMode(fetchImpl, async () => {
+      expect(await syncServedCredential()).toEqual([]);
+      expect(existsSync(file)).toBe(false);
+    });
+  });
+});
+
+test("a personal scope never clears the pod-shared ghost, manifest or not", async () => {
+  const actingToken = (sub: string) =>
+    `acting-v1.${Buffer.from(
+      JSON.stringify({ sub, agent: "acme", exp: 9_000_000_000 }),
+    ).toString("base64url")}.sig`;
+  await withTempHoustonHome(async () => {
+    const file = writeMaterializedClaudeCredential();
+    const fetchImpl = (async () =>
+      notConnected404()) as unknown as typeof globalThis.fetch;
+    await withServeMode(fetchImpl, async () => {
+      await runWithActingContext(
+        { actingAs: actingToken("sub-bob") },
+        async () => {
+          expect(await syncServedCredential()).toEqual([]);
+        },
+      );
+      // The shared login dir is TEAM material (HOU-976): a member's own
+      // not-connected verdict must not delete the workspace's file.
+      expect(existsSync(file)).toBe(true);
+    });
+  });
+});
+
 test("a personal scope's anthropic disconnect leaves the pod-shared SDK credential file alone", async () => {
   // The shared login dir is the TEAM's credential (HOU-976): a member whose
   // personal row disconnects must not take the workspace's file with it.
@@ -471,6 +514,133 @@ test("a serve marks the provider in the manifest, so a later sign-out removes it
     expect(readAuth(path)["openai-codex"]).toBeUndefined();
     expect(readServedProvidersAt(manifestPath)).toEqual([]);
   });
+});
+
+// --- Probe retry through the full sync (PRODUCT-1324 / HOUSTON-APP-4YV) ---
+
+/** A served openai-codex answer; other providers 404. `failFirst` codex calls
+ *  throw the undici socket-failure shape before answers begin. */
+function flakyCodexFetch(failCount: () => boolean) {
+  let codexCalls = 0;
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    const provider = new URL(String(input)).searchParams.get("provider");
+    if (provider === "openai-codex") {
+      codexCalls++;
+      if (failCount())
+        throw Object.assign(new TypeError("fetch failed"), {
+          cause: Object.assign(new Error("read ECONNRESET"), {
+            code: "ECONNRESET",
+          }),
+        });
+      return new Response(
+        JSON.stringify({
+          provider: "openai-codex",
+          kind: "oauth",
+          access: "AT-central",
+          expires: 1_900_000_000_000,
+          accountId: null,
+        }),
+        { status: 200 },
+      );
+    }
+    return notConnected404();
+  }) as unknown as typeof globalThis.fetch;
+  return { fetchImpl, calls: () => codexCalls };
+}
+
+test("one transient probe failure retries, the provider still applies, and no ERROR is logged", async () => {
+  resetServeProbeLog();
+  let failed = false;
+  const { fetchImpl, calls } = flakyCodexFetch(() => {
+    if (failed) return false;
+    failed = true;
+    return true;
+  });
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warns = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    await withServeMode(fetchImpl, async () => {
+      // The retry heals the blip: the provider is APPLIED this sync — a
+      // freshly recycled pod's first turn no longer reads a connected
+      // provider as not-connected.
+      expect(await syncServedCredential()).toEqual(["openai-codex"]);
+      expect(calls()).toBe(2);
+      // 4YV-class noise stays out of Sentry: the blip is a WARN breadcrumb.
+      expect(
+        errors.mock.calls.filter((c) =>
+          String(c[0]).includes("[serve] credential"),
+        ),
+      ).toEqual([]);
+      expect(
+        warns.mock.calls.some(
+          (c) =>
+            String(c[0]).includes("retrying once") &&
+            String(c[0]).includes("ECONNRESET"),
+        ),
+      ).toBe(true);
+    });
+  } finally {
+    errors.mockRestore();
+    warns.mockRestore();
+  }
+});
+
+test("a probe that fails both attempts logs ONE error with the cause code and removes nothing", async () => {
+  resetServeProbeLog();
+  const { fetchImpl, calls } = flakyCodexFetch(() => true);
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warns = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    await withServeMode(fetchImpl, async () => {
+      const path = join(config.dataDir, "auth.json");
+      const manifestPath = join(config.dataDir, "served-providers.json");
+      // An earlier sync applied codex to this pod.
+      writeFileSync(
+        path,
+        JSON.stringify({
+          "openai-codex": {
+            type: "oauth",
+            access: "AT-served",
+            refresh: "",
+            expires: 1,
+          },
+        }),
+      );
+      writeServedProvidersAt(manifestPath, ["openai-codex"]);
+
+      expect(await syncServedCredential()).toEqual([]);
+      expect(calls()).toBe(2); // attempt + one retry, then final
+      // An error verdict removes NOTHING: the applied credential and its
+      // manifest entry survive for the next sync to reconcile.
+      expect(readAuth(path)["openai-codex"]).toEqual({
+        type: "oauth",
+        access: "AT-served",
+        refresh: "",
+        expires: 1,
+      });
+      expect(readServedProvidersAt(manifestPath)).toEqual(["openai-codex"]);
+      // Exactly one ERROR (a persistent failure must still alert), carrying
+      // the nested cause code that `err.message` alone loses.
+      const serveErrors = errors.mock.calls.filter((c) =>
+        String(c[0]).includes("[serve] credential"),
+      );
+      expect(serveErrors.length).toBe(1);
+      expect(String(serveErrors[0]?.[0])).toContain("ECONNRESET");
+
+      // The next sync re-attempts the probe; the identical repeat stays a
+      // WARN (serve-log dedup), not a second Sentry event.
+      expect(await syncServedCredential()).toEqual([]);
+      expect(calls()).toBe(4);
+      expect(
+        errors.mock.calls.filter((c) =>
+          String(c[0]).includes("[serve] credential"),
+        ).length,
+      ).toBe(1);
+    });
+  } finally {
+    errors.mockRestore();
+    warns.mockRestore();
+  }
 });
 
 test("selectExportCredential without a provider falls back to the first OAuth credential", () => {

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -8,12 +8,12 @@ import {
   authPathIn,
   readServedProvidersAt,
   removeServedCredentialAt,
-  type ServedCredential,
   scrubRefreshTokensAt,
   servedProvidersPathIn,
   writeServedProvidersAt,
 } from "./auth-file";
 import { logServeProbeFailure, noteServeProbeOk } from "./serve-log";
+import { probeProviders } from "./serve-probe";
 import { reportDeadServedApiKey, servedApiKeyIsDead } from "./served-key-guard";
 import { forgetServedScope, recordServedScope } from "./served-scope";
 import { authStorage } from "./storage";
@@ -49,17 +49,6 @@ const authPathFor = () =>
   authPathIn(config.dataDir, currentCredentialScope().key);
 const servedManifestPathFor = () =>
   servedProvidersPathIn(config.dataDir, currentCredentialScope().key);
-
-/**
- * Marker the host sets on its /sandbox/credential 404: the credential store's
- * own "not connected" answer. Only marked 404s are an authoritative logout —
- * a bare 404 (an old host, a mistyped control-plane URL, a route-level miss)
- * must never delete a working credential.
- */
-const NOT_CONNECTED_HEADER = "x-houston-not-connected";
-
-/** One stalled host/gateway socket must not hang every hydrating route. */
-const SERVE_FETCH_TIMEOUT_MS = 10_000;
 
 /** True when the sandbox is wired to serve a central workspace credential. */
 export function serveModeOn(): boolean {
@@ -122,51 +111,6 @@ export async function syncServedCredentialSafe(tag: string): Promise<void> {
   }
 }
 
-type ServeProbe =
-  | { id: string; state: "served"; cred: ServedCredential }
-  | { id: string; state: "not-connected" }
-  | { id: string; state: "error"; detail: string };
-
-/** One provider's central lookup. Never throws — an internal serve hiccup for
- *  ONE provider must not strand the others. */
-async function probeProvider(id: string): Promise<ServeProbe> {
-  // WHO this serve is for: the host forwards the acting-as token to the gateway,
-  // which resolves personal-vs-team for THIS provider and reports its verdict
-  // on the body. Absent → the team credential, exactly as before HOU-976.
-  const { actingAs } = currentCredentialScope();
-  try {
-    const res = await fetch(
-      `${config.controlPlaneUrl}/sandbox/credential?provider=${id}`,
-      {
-        headers: {
-          Authorization: `Bearer ${config.sandboxToken}`,
-          ...(actingAs ? { "x-houston-acting-as": actingAs } : {}),
-        },
-        signal: AbortSignal.timeout(SERVE_FETCH_TIMEOUT_MS),
-      },
-    );
-    if (res.status === 404 && res.headers.get(NOT_CONNECTED_HEADER) === "1")
-      return { id, state: "not-connected" };
-    if (!res.ok)
-      return {
-        id,
-        state: "error",
-        detail: `${res.status}: ${await res.text().catch(() => "")}`,
-      };
-    return {
-      id,
-      state: "served",
-      cred: (await res.json()) as ServedCredential,
-    };
-  } catch (err) {
-    return {
-      id,
-      state: "error",
-      detail: err instanceof Error ? err.message : String(err),
-    };
-  }
-}
-
 async function runServedSync(): Promise<string[]> {
   if (!serveModeOn()) return [];
   // Anthropic serves through this same per-turn access-only path (Gate #2) —
@@ -189,9 +133,10 @@ async function runServedSync(): Promise<string[]> {
     ...curated,
     ...piApiKeyProviderIds().filter((id) => !curated.has(id)),
   ];
-  // Probes are independent — run them in parallel so a hydrating route pays one
-  // round-trip, not forty. The auth.json writes below stay serial.
-  const probes = await Promise.all(probeIds.map((id) => probeProvider(id)));
+  // Probes are independent — run them concurrently (a small pool, one retry
+  // each; serve-probe.ts) so a hydrating route pays a few round-trips, not
+  // forty sockets at once. The auth.json writes below stay serial.
+  const probes = await probeProviders(probeIds);
   const applied: string[] = [];
   const removed: string[] = [];
   // Provenance gate: an authoritative "not connected" may only remove providers
@@ -239,6 +184,18 @@ async function runServedSync(): Promise<string[]> {
       // Nothing is served for this scope any more, so no stale verdict may be
       // stamped on a later error.
       forgetServedScope(probe.id);
+      // Anthropic keeps a SECOND copy of its credential: the materialized
+      // `.credentials.json` the Claude Agent SDK falls back to once the served
+      // env token is gone. Left behind, that ghost re-runs every turn on the
+      // dead family — the exact storm the HOU-952 heal was meant to end
+      // (PRODUCT-1307). Cleared OUTSIDE the manifest gate (PRODUCT-1323): a
+      // ghost planted while anthropic was never in the served manifest (a
+      // setup pod's non-attributed connect whose row was later removed, a
+      // verify-rejected self-host row) would otherwise never be cleared — and
+      // the provenance gate then blocks the revocation reporter too. The
+      // function is serve-mode-reached-only, personal-scope-guarded, and a
+      // no-op without the file, so an ordinary disconnected pod pays nothing.
+      if (probe.id === "anthropic") clearGhostClaudeCredential();
       if (manifest.has(probe.id)) {
         // A refresh-bearing OAuth entry still survives inside
         // removeServedCredentialAt: that's the device-code connect mid-capture.
@@ -246,12 +203,6 @@ async function runServedSync(): Promise<string[]> {
           removed.push(probe.id);
         manifest.delete(probe.id);
         manifestDirty = true;
-        // Anthropic keeps a SECOND copy of its credential: the materialized
-        // `.credentials.json` the Claude Agent SDK falls back to once the
-        // served env token is gone. Left behind, that ghost re-runs every turn
-        // on the dead family — the exact storm the HOU-952 heal was meant to
-        // end (PRODUCT-1307).
-        if (probe.id === "anthropic") clearGhostClaudeCredential();
       }
     } else {
       // Dedup lives in serve-log.ts: every turn and hydrating route re-probes,

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -195,7 +195,12 @@ async function runServedSync(): Promise<string[]> {
       // the provenance gate then blocks the revocation reporter too. The
       // function is serve-mode-reached-only, personal-scope-guarded, and a
       // no-op without the file, so an ordinary disconnected pod pays nothing.
-      if (probe.id === "anthropic") clearGhostClaudeCredential();
+      // EXCEPT on a deployment that never serves anthropic (`notServedHere`,
+      // the desktop/self-host refusal): there the file IS the browser login's
+      // legitimate credential and this answer says nothing about the central
+      // store — deleting it would disconnect a healthy local Claude.
+      if (probe.id === "anthropic" && !probe.notServedHere)
+        clearGhostClaudeCredential();
       if (manifest.has(probe.id)) {
         // A refresh-bearing OAuth entry still survives inside
         // removeServedCredentialAt: that's the device-code connect mid-capture.

--- a/packages/runtime/src/transport/api-key-rollback.ts
+++ b/packages/runtime/src/transport/api-key-rollback.ts
@@ -1,0 +1,50 @@
+import { authStorage } from "../auth/storage";
+import { json, type RouteContext, readJson } from "./http-helpers";
+
+/**
+ * Narrow rollback for a failed API-key connect (PRODUCT-1321).
+ *
+ * The host's connect pushes the pasted key here FIRST (the runtime
+ * live-verifies and persists it — provider-routes.ts handleApiKey), and only
+ * then stores it centrally. When that central PUT fails, the runtime is left
+ * holding a verified, usable key the central store never learned about: it is
+ * absent from `served-providers.json`, so an authoritative central 404 can
+ * never remove it (serve.ts's provenance gate), and it silently vanishes with
+ * the pod's next recycle — the "spontaneous disconnect". The host calls
+ * DELETE /auth/:provider/api-key to take the just-written key back out, so a
+ * failed connect leaves NO local residue and the user's connect error is the
+ * whole story.
+ *
+ * Guarded by the key itself: only the exact credential this connect wrote is
+ * removed. A concurrent connect that stored a DIFFERENT key — or a served
+ * OAuth entry — is left alone (`removed: false`, still a 200: rollback is a
+ * convergence op, not an assertion).
+ */
+export async function handleApiKeyRollback(
+  ctx: RouteContext,
+  provider: string,
+): Promise<void> {
+  const body = await readJson(ctx.req).catch(() => ({}) as never);
+  const raw = (body as { key?: unknown }).key;
+  const key = typeof raw === "string" ? raw.trim() : "";
+  if (!key) {
+    json(ctx.res, 400, { error: "missing API key" });
+    return;
+  }
+  const cred = authStorage.get(provider) as
+    | { type?: string; key?: string }
+    | undefined;
+  if (cred?.type !== "api_key" || cred.key !== key) {
+    json(ctx.res, 200, { ok: true, removed: false });
+    return;
+  }
+  // Attribution for the runtime.log: this is the ONLY writer besides logout
+  // that clears a credential — name the moment (the key itself is never logged).
+  console.log(
+    `[auth] rolling back the just-connected ${provider} API key: the central store rejected the connect (DELETE /auth/${provider}/api-key)`,
+  );
+  // `delete` queues on the store's per-provider chain (same rationale as
+  // logout) and drops the in-memory cache entry with the file's.
+  await authStorage.delete(provider);
+  json(ctx.res, 200, { ok: true, removed: true });
+}

--- a/packages/runtime/src/transport/provider-routes.test.ts
+++ b/packages/runtime/src/transport/provider-routes.test.ts
@@ -200,6 +200,65 @@ test("GET /providers hydrates served credentials before listing providers", asyn
   }
 });
 
+test("DELETE /auth/:provider/api-key rolls back only the exact just-connected key (PRODUCT-1321)", async () => {
+  // The host calls this when its central store rejected a key the POST had
+  // already verified + persisted: the runtime entry must go (a failed connect
+  // leaves no local residue), but ONLY when it still holds that exact key —
+  // a concurrent connect's newer key survives.
+  const prevDataDir = process.env.HOUSTON_DATA_DIR;
+  const dataDir = mkdtempSync(join(tmpdir(), "houston-rollback-route-"));
+  process.env.HOUSTON_DATA_DIR = dataDir;
+
+  try {
+    vi.resetModules();
+    const { handleProviderRoute } = await import("./provider-routes");
+    const { authStorage } = await import("../auth/storage");
+    const { readAuthFile } = await import("../auth/auth-file");
+    authStorage.set("openrouter", { type: "api_key", key: "sk-or-KEEP" });
+
+    const del = async (body: unknown) => {
+      const { res, out } = mockRes();
+      expect(
+        await handleProviderRoute({
+          method: "DELETE",
+          path: "/auth/openrouter/api-key",
+          url: new URL("http://runtime.test/auth/openrouter/api-key"),
+          req: mockPostReq(body),
+          res,
+        }),
+      ).toBe(true);
+      return out;
+    };
+
+    // A different key (a concurrent connect already replaced ours): untouched.
+    let out = await del({ key: "sk-or-OTHER" });
+    expect(out.status).toBe(200);
+    expect(out.body).toEqual({ ok: true, removed: false });
+    expect(readAuthFile(join(dataDir, "auth.json")).openrouter).toEqual({
+      type: "api_key",
+      key: "sk-or-KEEP",
+    });
+
+    // A keyless rollback is a clear 400, never a blind delete.
+    out = await del({});
+    expect(out.status).toBe(400);
+
+    // The exact key: removed from auth.json AND the in-memory store.
+    out = await del({ key: "sk-or-KEEP" });
+    expect(out.status).toBe(200);
+    expect(out.body).toEqual({ ok: true, removed: true });
+    expect(readAuthFile(join(dataDir, "auth.json")).openrouter).toBeUndefined();
+    expect(authStorage.get("openrouter")).toBeUndefined();
+
+    // Idempotent: a second rollback of the same key is a clean no-op.
+    out = await del({ key: "sk-or-KEEP" });
+    expect(out.body).toEqual({ ok: true, removed: false });
+  } finally {
+    restoreEnv("HOUSTON_DATA_DIR", prevDataDir);
+    vi.resetModules();
+  }
+});
+
 test("openai-compatible route round-trips the org marker without returning its key", async () => {
   const prevDataDir = process.env.HOUSTON_DATA_DIR;
   const dataDir = mkdtempSync(join(tmpdir(), "houston-shared-route-"));

--- a/packages/runtime/src/transport/provider-routes.ts
+++ b/packages/runtime/src/transport/provider-routes.ts
@@ -27,6 +27,7 @@ import { ApiKeyVerifyError, verifyApiKey } from "../auth/verify-api-key";
 import { refreshAnthropicCredential } from "../backends/claude/credential-status";
 import { writeClaudeOAuthCredentialFile } from "../backends/claude/credentials-file";
 import { claudeLoginConfigDir } from "../backends/claude/paths";
+import { handleApiKeyRollback } from "./api-key-rollback";
 import { json, type RouteContext, readJson } from "./http-helpers";
 
 export async function handleProviderRoute(ctx: RouteContext): Promise<boolean> {
@@ -112,6 +113,12 @@ export async function handleProviderRoute(ctx: RouteContext): Promise<boolean> {
   const apiKeyMatch = path.match(/^\/auth\/([^/]+)\/api-key$/);
   if (method === "POST" && apiKeyMatch) {
     await handleApiKey(ctx, apiKeyMatch[1]);
+    return true;
+  }
+  // The host's rollback when its central store rejected a key the POST above
+  // had already verified + persisted (PRODUCT-1321) — see api-key-rollback.ts.
+  if (method === "DELETE" && apiKeyMatch) {
+    await handleApiKeyRollback(ctx, apiKeyMatch[1]);
     return true;
   }
 


### PR DESCRIPTION
Fixes PRODUCT-1321, PRODUCT-1323, PRODUCT-1324. Should end Sentry **HOUSTON-APP-4YV** (~1,000 chronic serve-probe errors).

All three live in the serve/connect path (`packages/runtime/src/auth/serve*`, `packages/host/src/channel/proxy.ts`).

## L6 / PRODUCT-1321 (high): failed API-key connect leaves a working-but-doomed key

**Root cause.** `saveApiKeyCredential` (host `channel/proxy.ts`) POSTs the pasted key to the runtime, which **verifies AND persists** it into `auth.json` (`transport/provider-routes.ts` `handleApiKey`), and only then PUTs it centrally. If the central PUT fails, the route reports a failed connect — but the runtime keeps a usable key that the central store never learned about. That key is absent from `served-providers.json`, so the serve sync's provenance gate means an authoritative central 404 can never remove it. It works until the pod recycles, then vanishes with the emptyDir: the "spontaneous disconnect".

**Fix.** On a central PUT failure the host now rolls the runtime entry back via a new narrow runtime route, `DELETE /auth/:provider/api-key` (`transport/api-key-rollback.ts`). The rollback is **key-matched**: the runtime removes the entry only if it still holds that exact key, so a concurrent connect's newer key survives. A rollback transport failure is logged loudly but never masks the central failure — the user keeps seeing the real connect error either way, and a failed connect now leaves no local residue.

**Alternative considered and rejected:** reordering to central-first ("store centrally, hydrate via serve"). The runtime's live verification (`verifyApiKey`) needs the key runtime-side *before* anything is stored ("connected" must mean the key works), so central-first requires a new verify-without-persist runtime route plus reshaping the connect flow's immediate-connected signal (today the runtime write is what flips status instantly). That's the cleaner long-term shape, but it's a larger contract change for the same end state; the compensating rollback is minimal-risk and converges to central truth in every failure interleaving.

## L8 / PRODUCT-1323 (medium): ghost `.credentials.json` survives outside the manifest gate

**Root cause.** PR #1303's `clearGhostClaudeCredential()` ran only inside `if (manifest.has(probe.id))`. A ghost materialized SDK credential planted while anthropic was **never** in the served manifest (a setup pod's non-attributed connect whose row was later removed; a self-host row verify-rejected before any successful serve) was never cleared — and the provenance gate then blocks the revocation reporter, so every turn burns on the dead family until the file's token expires. PRODUCT-1307 through a different door.

**Fix.** The clear now runs on **every** authoritative anthropic `not-connected` probe, outside the manifest gate. The function was already serve-mode-reached-only, personal-scope-guarded (HOU-976: a member's verdict can't delete the team's file), and a no-op without the file. The manifest-gated `auth.json` removal is unchanged.

## L9 / PRODUCT-1324 (medium): ~40 unretried concurrent probes, ERROR per blip, provider silently un-applied

**Root cause.** `runServedSync` fired ~40 concurrent probes with no retry on every turn start and several hydrating routes; one transient socket failure produced a Sentry ERROR per provider (HOUSTON-APP-4YV) **and** silently un-applied that provider for the sync — a freshly recycled pod's first turn could read a connected provider as not-connected. The log detail kept only `err.message` ("fetch failed"), losing the undici `cause` code.

**Fix** (probe logic extracted to `auth/serve-probe.ts`, which also brings `serve.ts` back down in size):
- **One retry after 250ms**: the first failure is a WARN breadcrumb; the error becomes final (and Sentry-visible via `serve-log.ts`'s existing transition dedup) only when the retry fails too. A one-off blip never alerts; a persistent gateway outage still logs exactly one ERROR per provider per detail-transition. A *timed-out* first attempt is final immediately — it already stalled 10s, a 250ms-later second 10s stall wouldn't heal it, and the next sync re-probes anyway.
- **Concurrency capped at 8** (tiny inline worker pool, no dependency) — the 40-socket burst from a just-woken pod was itself a plausible source of the transients.
- **Cause codes in the detail**: `describeProbeError` walks `cause` chains (incl. AggregateError / errno) so the log and Sentry event say `fetch failed (cause: ECONNRESET)` instead of `fetch failed`.
- **Failure semantics unchanged**: a probe that fails both attempts removes nothing (credential + manifest entry survive) and is re-attempted on the next sync.

## Tests

- **L6**: runtime route test (exact-key rollback, wrong-key untouched, keyless 400, idempotent no-op); host contract tests (central PUT failure → rollback DELETE with the exact key + central error rethrown; failing rollback logged, never masks; successful connect fires no rollback).
- **L8**: never-manifested ghost cleared on authoritative not-connected; personal scope still never touches the pod-shared file (manifest or not).
- **L9**: unit tests for retry/timeout-skip/pool-order/concurrency-cap/cause-code extraction; full-sync tests — one transient failure retries, provider applies, zero ERRORs; both-attempts-fail logs ONE error carrying ECONNRESET, removes nothing, re-attempts next sync with the repeat deduped to WARN.

`pnpm --filter @houston/runtime test` (118 files, 1091 tests) and `pnpm --filter @houston/host test` (155 files, 1437 tests) pass; `pnpm check` (Biome) clean; `tsc --noEmit` clean in both packages.