### PR TITLE
Never refresh with an empty token: serve re-sync guard + serve-skew margin (PRODUCT-1317)

### DIFF
--- a/packages/host/src/credentials/refresh-coalescer.ts
+++ b/packages/host/src/credentials/refresh-coalescer.ts
@@ -40,6 +40,13 @@ export type CredentialRefreshRun = {
    * keeping a private one.
    */
   doRefresh?: CredentialRefresher;
+  /**
+   * Expiry margin THIS caller needs (`isExpiring`'s `skewMs`). The serve route
+   * passes its pi-validity-floor margin (routes/credential.ts, PRODUCT-1317) so
+   * the in-flight re-check can't hand back a token the route already judged too
+   * short-lived. Absent = `isExpiring`'s default.
+   */
+  skewMs?: number;
 };
 
 /**
@@ -96,7 +103,7 @@ export class CredentialRefreshCoalescer {
     if (cached) {
       if (
         this.now() - cached.at < REFRESH_RESULT_TTL_MS &&
-        !isExpiring(cached.cred)
+        !isExpiring(cached.cred, args.skewMs)
       )
         return Promise.resolve(cached.cred);
       this.results.delete(key);
@@ -153,7 +160,7 @@ export class CredentialRefreshCoalescer {
     // it and persisting the result — would recreate the row they deleted and
     // hand their agents a live token for a revoked connection.
     if (loaded === null) throw new CredentialGoneError(args.provider);
-    if (!isExpiring(loaded)) {
+    if (!isExpiring(loaded, args.skewMs)) {
       this.remember(key, loaded);
       return loaded;
     }

--- a/packages/host/src/routes/credential.test.ts
+++ b/packages/host/src/routes/credential.test.ts
@@ -622,6 +622,30 @@ test("an expiring anthropic credential whose refresh fails degrades to marked 40
   expect(r.out.headers?.["x-houston-not-connected"]).toBe("1");
 });
 
+test("a short-but-live anthropic token is served, not refused (deploy-order independence)", async () => {
+  // Until every gateway rolls the 10-minute ServeSkew, a healthy token can
+  // arrive with 5-6 minutes left. The marked 404 is an authoritative
+  // disconnect (the runtime deletes its served entry AND the ghost file,
+  // PRODUCT-1323) — refusing a live token would flap anthropic org-wide once
+  // per token lifetime. The stale refusal keys on the DEFAULT margin; the
+  // 6-minute margin only drives the refresh attempt above it.
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "anthropic",
+    accessToken: "sk-ant-oat01-shortlive",
+    refreshToken: "", // access-only: the gateway is the only refresher
+    expiresAt: Date.now() + 5.5 * 60 * 1000,
+    kind: "oauth",
+  });
+  const r = mockRes();
+  expect(
+    await call(credentials, "anthropic", r, { gatewayFronted: true }),
+  ).toBe(true);
+  expect(r.out.status).toBe(200);
+  expect(r.out.body.access).toBe("sk-ant-oat01-shortlive");
+});
+
 test("a token below pi's five-minute validity floor is refreshed at serve time (PRODUCT-1317)", async () => {
   // pi refreshes any stored OAuth entry within 5 minutes of expiry, and a
   // served entry has refresh:"" — so a token served with less than the floor
@@ -683,10 +707,14 @@ test("a healthy long-lived token is served as-is, no token-endpoint call", async
   }
 });
 
-test("an anthropic token below pi's floor is never served (marked 404)", async () => {
-  // A served anthropic entry lands in the runtime's auth.json access-only,
-  // where pi's usage probes put it through the same 5-minute refresh window —
-  // and there is no central refresh config to rescue it here (PRODUCT-1317).
+test("an anthropic token below pi's floor is still served while live (guard owns the window)", async () => {
+  // A 4-minute anthropic token sits inside pi's 5-minute refresh window — but
+  // the RUNTIME's empty-refresh guard (PRODUCT-1317) is what keeps pi from
+  // POSTing an empty refresh for it, and the token still runs the in-flight
+  // turn. Refusing it here would be an authoritative marked 404: the runtime
+  // deletes its served entry and the ghost file (PRODUCT-1323) — an org-wide
+  // anthropic flap whenever a gateway couldn't refresh in time. Only a token
+  // past the DEFAULT stale margin is refused (see the stale tests above).
   const credentials = new MemoryCredentialStore();
   await credentials.put({
     workspaceId: "w1",
@@ -700,6 +728,6 @@ test("an anthropic token below pi's floor is never served (marked 404)", async (
   expect(
     await call(credentials, "anthropic", r, { gatewayFronted: true }),
   ).toBe(true);
-  expect(r.out.status).toBe(404);
-  expect(r.out.headers?.["x-houston-not-connected"]).toBe("1");
+  expect(r.out.status).toBe(200);
+  expect(r.out.body.access).toBe("sk-ant-oat01-four-minutes");
 });

--- a/packages/host/src/routes/credential.test.ts
+++ b/packages/host/src/routes/credential.test.ts
@@ -621,3 +621,85 @@ test("an expiring anthropic credential whose refresh fails degrades to marked 40
   expect(r.out.status).toBe(404);
   expect(r.out.headers?.["x-houston-not-connected"]).toBe("1");
 });
+
+test("a token below pi's five-minute validity floor is refreshed at serve time (PRODUCT-1317)", async () => {
+  // pi refreshes any stored OAuth entry within 5 minutes of expiry, and a
+  // served entry has refresh:"" — so a token served with less than the floor
+  // is born inside pi's refresh window. The old 2-minute default skew served
+  // exactly such tokens; the serve margin must stay above pi's floor.
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "openai-codex",
+    accessToken: "AT-four-minutes",
+    refreshToken: "rt.live",
+    expiresAt: Date.now() + 4 * 60_000, // fine for the old skew, inside pi's window
+  });
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        access_token: "AT-rotated",
+        refresh_token: "rt.rotated",
+        expires_in: 3600,
+      }),
+      { status: 200 },
+    )) as typeof fetch;
+  try {
+    const r = mockRes();
+    expect(await call(credentials, "openai-codex", r)).toBe(true);
+    expect(r.out.status).toBe(200);
+    expect(r.out.body.access).toBe("AT-rotated");
+    // The served token clears pi's floor with room to spare.
+    expect(r.out.body.expires).toBeGreaterThan(Date.now() + 30 * 60_000);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("a healthy long-lived token is served as-is, no token-endpoint call", async () => {
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "openai-codex",
+    accessToken: "AT-healthy",
+    refreshToken: "rt.live",
+    expiresAt: FRESH_EXPIRES,
+  });
+  const realFetch = globalThis.fetch;
+  let exchanges = 0;
+  globalThis.fetch = (async () => {
+    exchanges++;
+    throw new Error("no refresh expected");
+  }) as typeof fetch;
+  try {
+    const r = mockRes();
+    expect(await call(credentials, "openai-codex", r)).toBe(true);
+    expect(r.out.status).toBe(200);
+    expect(r.out.body.access).toBe("AT-healthy");
+    expect(exchanges).toBe(0);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("an anthropic token below pi's floor is never served (marked 404)", async () => {
+  // A served anthropic entry lands in the runtime's auth.json access-only,
+  // where pi's usage probes put it through the same 5-minute refresh window —
+  // and there is no central refresh config to rescue it here (PRODUCT-1317).
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "anthropic",
+    accessToken: "sk-ant-oat01-four-minutes",
+    refreshToken: "",
+    expiresAt: Date.now() + 4 * 60_000,
+    kind: "oauth",
+  });
+  const r = mockRes();
+  expect(
+    await call(credentials, "anthropic", r, { gatewayFronted: true }),
+  ).toBe(true);
+  expect(r.out.status).toBe(404);
+  expect(r.out.headers?.["x-houston-not-connected"]).toBe("1");
+});

--- a/packages/host/src/routes/credential.ts
+++ b/packages/host/src/routes/credential.ts
@@ -28,6 +28,20 @@ function notConnected(res: ServerResponse, error: string): true {
 }
 
 /**
+ * Serve-time refresh margin. The real invariant is pi's OAuth validity floor:
+ * pi refreshes ANY stored OAuth entry within 5 minutes of expiry
+ * (`DEFAULT_OAUTH_MINIMUM_VALIDITY_MS`, pi-ai dist/auth/resolve.js), and a
+ * served entry is access-only (Gate #2's `refresh:""`) — pi has nothing to
+ * refresh it with, and before the runtime's empty-refresh guard it POSTed
+ * `refresh_token=""` at the provider (PRODUCT-1317, seen live as
+ * PRODUCT-1293). A token served with less than the floor remaining is born
+ * inside pi's refresh window, so the refresh here must fire while MORE than
+ * the floor remains: 6 minutes is pi's 5 plus a minute of slack. Passed
+ * explicitly — `isExpiring`'s 2-minute default serves its other callers.
+ */
+const SERVE_VALIDITY_SKEW_MS = 6 * 60 * 1000;
+
+/**
  * Sandbox-facing (connect-once): an agent runtime serves a FRESH subscription
  * token from its workspace's central credential. Authenticated by the
  * per-sandbox HMAC token (NOT a user JWT), refreshed centrally here so no
@@ -99,7 +113,7 @@ export async function handleSandboxCredential(
     if (deadError) throw deadError;
     return notConnected(res, "workspace not connected");
   }
-  if (isExpiring(cred) && cred.refreshToken) {
+  if (isExpiring(cred, SERVE_VALIDITY_SKEW_MS) && cred.refreshToken) {
     const refreshing = cred.provider;
     try {
       // Single-flight: one runtime process per agent serves this per turn AND
@@ -113,6 +127,9 @@ export async function handleSandboxCredential(
         acting,
         load: () => deps.credentials.get(claim.workspaceId, refreshing, acting),
         persist: (c) => deps.credentials.put(c, acting),
+        // The flight's own re-check must judge expiry by THIS route's margin,
+        // or it hands back the very token the route already deemed too short.
+        skewMs: SERVE_VALIDITY_SKEW_MS,
       });
     } catch (err) {
       if (err instanceof CredentialGoneError) {
@@ -166,8 +183,11 @@ export async function handleSandboxCredential(
   // keychain credential, so serving an expired access token would shadow a
   // still-working self-refreshing credential. Degrading to the marked 404
   // makes the runtime drop the served entry (provenance-gated) and fall back
-  // to that file path instead.
-  if (cred.provider === "anthropic" && isExpiring(cred))
+  // to that file path instead. Judged by the same pi-floor margin as above:
+  // the runtime writes a served anthropic entry into auth.json too (access-
+  // only), where pi's usage probes resolve it through the same 5-minute
+  // refresh window (PRODUCT-1317).
+  if (cred.provider === "anthropic" && isExpiring(cred, SERVE_VALIDITY_SKEW_MS))
     return notConnected(res, "anthropic credential is stale");
   // Access token ONLY (Gate #2): the refresh token never leaves this process.
   // A stolen sandbox credential is then worth minutes, not an account. The

--- a/packages/host/src/routes/credential.ts
+++ b/packages/host/src/routes/credential.ts
@@ -183,11 +183,18 @@ export async function handleSandboxCredential(
   // keychain credential, so serving an expired access token would shadow a
   // still-working self-refreshing credential. Degrading to the marked 404
   // makes the runtime drop the served entry (provenance-gated) and fall back
-  // to that file path instead. Judged by the same pi-floor margin as above:
-  // the runtime writes a served anthropic entry into auth.json too (access-
-  // only), where pi's usage probes resolve it through the same 5-minute
-  // refresh window (PRODUCT-1317).
-  if (cred.provider === "anthropic" && isExpiring(cred, SERVE_VALIDITY_SKEW_MS))
+  // to that file path instead.
+  //
+  // Deliberately judged by `isExpiring`'s DEFAULT margin, not this route's
+  // 6-minute refresh trigger: the marked 404 is an AUTHORITATIVE disconnect
+  // (the runtime deletes its served entry and, since PRODUCT-1323, the ghost
+  // file). Until every gateway serves with the raised 10-minute ServeSkew, a
+  // healthy token can arrive here with 5-6 minutes left — refusing it would
+  // flap anthropic org-wide once per token lifetime. A short-but-live token
+  // is safe to hand out: the runtime's empty-refresh guard (PRODUCT-1317)
+  // keeps pi from POSTing an empty refresh for it, and the current turn just
+  // uses the remaining validity.
+  if (cred.provider === "anthropic" && isExpiring(cred))
     return notConnected(res, "anthropic credential is stale");
   // Access token ONLY (Gate #2): the refresh token never leaves this process.
   // A stolen sandbox credential is then worth minutes, not an account. The

--- a/packages/runtime/src/auth/credential-store.ts
+++ b/packages/runtime/src/auth/credential-store.ts
@@ -14,6 +14,11 @@ import {
   readAuthFile,
   writeAuthFile,
 } from "./auth-file";
+import {
+  maskAccessOnly,
+  needsServeSync,
+  runEmptyRefreshServeSync,
+} from "./empty-refresh-guard";
 
 /**
  * Houston's credential store: pi-ai's `CredentialStore` contract over
@@ -141,6 +146,11 @@ export class HoustonAuthStore implements CredentialStore {
   // ---- pi-ai CredentialStore ----
 
   async read(providerId: string): Promise<Credential | undefined> {
+    // PRODUCT-1317 (empty-refresh-guard.ts): a served access-only entry pi is
+    // about to put through its refresh path re-syncs centrally FIRST, so a
+    // fresh token can land before pi's expiry check runs.
+    if (needsServeSync(this.get(providerId), Date.now()))
+      await runEmptyRefreshServeSync();
     return this.get(providerId);
   }
 
@@ -161,7 +171,11 @@ export class HoustonAuthStore implements CredentialStore {
     const state = this.scoped();
     const prev = state.chains.get(providerId) ?? Promise.resolve();
     const apply = async () => {
-      const next = await fn(state.cache[providerId]);
+      // PRODUCT-1317 (empty-refresh-guard.ts): pi's refresh closures POST
+      // `current.refresh` to the provider's token endpoint — an access-only
+      // (refresh:"") entry is masked to `undefined` so they take their
+      // logged-out branch and leave the entry unchanged instead.
+      const next = await fn(maskAccessOnly(state.cache[providerId]));
       // Contract: `undefined` leaves the entry unchanged (NOT a delete).
       if (next !== undefined) this.setIn(state, providerId, next);
       return state.cache[providerId];

--- a/packages/runtime/src/auth/empty-refresh-guard.test.ts
+++ b/packages/runtime/src/auth/empty-refresh-guard.test.ts
@@ -1,0 +1,149 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Credential } from "@earendil-works/pi-ai";
+import { afterEach, expect, test } from "vitest";
+import { HoustonAuthStore } from "./credential-store";
+import {
+  bindEmptyRefreshServeSync,
+  needsServeSync,
+  PI_OAUTH_MIN_VALIDITY_MS,
+} from "./empty-refresh-guard";
+
+/**
+ * PRODUCT-1317 regression: a served access-only OAuth entry (Gate #2's
+ * `refresh:""`) must NEVER reach a provider refresher. pi-ai 0.84.1 routes any
+ * stored OAuth entry within 5 minutes of expiry through `oauth.refresh(current)`
+ * inside `credentials.modify` (dist/auth/resolve.js) — the closures below are
+ * that code path's exact shape, so these tests pin the store-level contract pi
+ * actually exercises.
+ */
+
+function tmpStore(): HoustonAuthStore {
+  return new HoustonAuthStore(
+    join(mkdtempSync(join(tmpdir(), "houston-guard-")), "auth.json"),
+  );
+}
+
+const served = (expires: number): Credential => ({
+  type: "oauth",
+  access: "served-at",
+  refresh: "",
+  expires,
+});
+
+const full = (access: string, expires: number): Credential => ({
+  type: "oauth",
+  access,
+  refresh: "rt",
+  expires,
+});
+
+/** pi's refresh closure (resolveStoredOAuth): dereferences `current`, then
+ *  calls the provider refresher with it — the POST the guard must prevent. */
+function piRefreshClosure(refresher: (cred: Credential) => Credential) {
+  return async (current: Credential | undefined) => {
+    if (current?.type !== "oauth") return undefined; // "logged out meanwhile"
+    return refresher(current);
+  };
+}
+
+afterEach(() => bindEmptyRefreshServeSync(null));
+
+test("an expiring access-only entry re-syncs at read, and pi sees the replaced token", async () => {
+  const store = tmpStore();
+  store.set("openai-codex", served(Date.now() + 60_000));
+  let syncs = 0;
+  bindEmptyRefreshServeSync(async () => {
+    // What runServedSync does: apply the central credential + reload the cache.
+    syncs++;
+    store.set("openai-codex", served(Date.now() + 3_600_000));
+  });
+  const seen = await store.read("openai-codex");
+  expect(syncs).toBe(1);
+  // The fresh token clears pi's floor, so its refresh path never even arms.
+  expect((seen as { expires: number }).expires).toBeGreaterThan(
+    Date.now() + PI_OAUTH_MIN_VALIDITY_MS,
+  );
+});
+
+test("when the sync cannot replace it, pi's refresher is never invoked with the empty string", async () => {
+  const store = tmpStore();
+  const entry = served(Date.now() + 60_000);
+  store.set("openai-codex", entry);
+  bindEmptyRefreshServeSync(async () => {}); // serve down / central row gone
+  await store.read("openai-codex");
+  const refreshed: Credential[] = [];
+  const post = await store.modify(
+    "openai-codex",
+    piRefreshClosure((cred) => {
+      refreshed.push(cred);
+      return full("must-not-happen", Date.now() + 3_600_000);
+    }),
+  );
+  expect(refreshed).toEqual([]); // no provider POST with refresh_token=""
+  // Entry unchanged: pi serves the stored access token as-is via toAuth.
+  expect(post).toEqual(entry);
+  expect(store.get("openai-codex")).toEqual(entry);
+});
+
+test("an unbound sync (desktop/self-host) is a no-op, and the mask still holds", async () => {
+  const store = tmpStore();
+  const entry = served(Date.now() + 60_000);
+  store.set("openai-codex", entry);
+  expect(await store.read("openai-codex")).toEqual(entry);
+  const refreshed: Credential[] = [];
+  await store.modify(
+    "openai-codex",
+    piRefreshClosure((cred) => {
+      refreshed.push(cred);
+      return full("must-not-happen", Date.now() + 3_600_000);
+    }),
+  );
+  expect(refreshed).toEqual([]);
+});
+
+test("a healthy refresh-bearing credential still refreshes through modify", async () => {
+  const store = tmpStore();
+  store.set("openai-codex", full("old-at", Date.now() - 1_000));
+  const refreshed: Credential[] = [];
+  const rotated = full("new-at", Date.now() + 3_600_000);
+  const post = await store.modify(
+    "openai-codex",
+    piRefreshClosure((cred) => {
+      refreshed.push(cred);
+      return rotated;
+    }),
+  );
+  // The mask is scoped to refresh:"" — a real refresh token passes through.
+  expect(refreshed).toHaveLength(1);
+  expect((refreshed[0] as { refresh: string }).refresh).toBe("rt");
+  expect(post).toEqual(rotated);
+  expect(store.get("openai-codex")).toEqual(rotated);
+});
+
+test("a long-lived served token and a pasted no-expiry token never trigger the sync", async () => {
+  const store = tmpStore();
+  let syncs = 0;
+  bindEmptyRefreshServeSync(async () => {
+    syncs++;
+  });
+  store.set("openai-codex", served(Date.now() + 3_600_000));
+  await store.read("openai-codex");
+  // A pasted access token records no expiry — there is no central row to serve.
+  store.set("github-copilot", served(0));
+  await store.read("github-copilot");
+  expect(syncs).toBe(0);
+});
+
+test("needsServeSync fires exactly on pi's five-minute window for access-only entries", () => {
+  const now = Date.now();
+  const inWindow = now + PI_OAUTH_MIN_VALIDITY_MS - 1_000;
+  const outside = now + PI_OAUTH_MIN_VALIDITY_MS + 60_000;
+  expect(needsServeSync(served(inWindow), now)).toBe(true);
+  expect(needsServeSync(served(outside), now)).toBe(false);
+  expect(needsServeSync(served(0), now)).toBe(false); // pasted, no expiry
+  expect(needsServeSync(full("at", inWindow), now)).toBe(false); // pi refreshes it
+  expect(needsServeSync({ type: "api_key", key: "k" }, now)).toBe(false);
+  expect(needsServeSync(undefined, now)).toBe(false);
+});

--- a/packages/runtime/src/auth/empty-refresh-guard.ts
+++ b/packages/runtime/src/auth/empty-refresh-guard.ts
@@ -1,0 +1,79 @@
+import type { Credential } from "@earendil-works/pi-ai";
+
+/**
+ * PRODUCT-1317: no empty-string refresh token ever leaves this process.
+ *
+ * Gate #2 stores a served credential as `{type:"oauth", access, refresh:"",
+ * expires}` (auth-file.ts) — the refresh token deliberately never reaches the
+ * runtime. pi-ai 0.84.1 does not know that shape: `resolveStoredOAuth`
+ * (dist/auth/resolve.js) routes ANY stored OAuth entry within 5 minutes of
+ * expiry through `oauth.refresh(current)`, and every provider refresher POSTs
+ * `credential.refresh` verbatim to its token endpoint. A served entry that pi
+ * sees inside that window therefore fired `refresh_token=""` at the provider
+ * (openai-codex), or minted with `Bearer ""` and 401'd into a spurious
+ * reconnect card (github-copilot) — PRODUCT-1293 in production. The gateway
+ * serves with exactly pi's 5-minute margin, so "already inside the window" is
+ * a recurring state, not a corner case.
+ *
+ * The guard lives at the Houston-owned seam pi consumes — `HoustonAuthStore`,
+ * pi's `CredentialStore` — never in a pi patch, in two halves:
+ *  - `read`: an access-only entry already inside pi's window re-syncs from the
+ *    control plane first (`needsServeSync` + the bound single-flighted serve
+ *    sync), so a fresh central token lands before pi's expiry check runs;
+ *  - `modify`: pi's refresh closures dereference the `current` credential —
+ *    `maskAccessOnly` hands them `undefined` for an access-only entry, which
+ *    takes their own "logged out meanwhile" branch (dist/auth/resolve.js):
+ *    the entry is left unchanged and pi serves the stored access token as-is
+ *    through `toAuth` (side-effect-free per its `OAuthAuth` contract). The
+ *    token's remaining validity still gets used; once it truly expires the
+ *    request 401s into the typed unauthenticated/token_expired card — never a
+ *    provider POST carrying the empty string.
+ */
+
+/** pi-ai's `DEFAULT_OAUTH_MINIMUM_VALIDITY_MS` (dist/auth/resolve.js). */
+export const PI_OAUTH_MIN_VALIDITY_MS = 5 * 60 * 1000;
+
+/** A Gate #2 served entry: OAuth with the refresh token scrubbed away. */
+export function isAccessOnlyOAuth(cred: Credential | undefined): boolean {
+  return cred?.type === "oauth" && !cred.refresh;
+}
+
+/**
+ * Whether pi's next auth resolution would put `cred` through its refresh path
+ * with nothing to refresh: an access-only entry inside pi's validity floor.
+ * `expires <= 0` means no expiry was recorded (a pasted token) — there is no
+ * central row to re-serve, so only the `modify` mask applies to those.
+ */
+export function needsServeSync(
+  cred: Credential | undefined,
+  now: number,
+): boolean {
+  if (cred?.type !== "oauth" || cred.refresh) return false;
+  return cred.expires > 0 && now + PI_OAUTH_MIN_VALIDITY_MS >= cred.expires;
+}
+
+/** What pi's `modify` closures may see: never an access-only OAuth entry. */
+export function maskAccessOnly(
+  cred: Credential | undefined,
+): Credential | undefined {
+  return isAccessOnlyOAuth(cred) ? undefined : cred;
+}
+
+/**
+ * serve.ts binds its non-throwing, single-flighted sync here at load — a
+ * direct import would cycle (serve → storage → credential-store → serve).
+ * Unbound (desktop/self-host, tests) it is a no-op, which is sound: an
+ * access-only entry only exists where the serve path wrote one, and the serve
+ * path lives in serve.ts.
+ */
+let serveSync: (() => Promise<void>) | null = null;
+
+export function bindEmptyRefreshServeSync(
+  fn: (() => Promise<void>) | null,
+): void {
+  serveSync = fn;
+}
+
+export async function runEmptyRefreshServeSync(): Promise<void> {
+  await serveSync?.();
+}

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -13,6 +13,7 @@ import {
   servedProvidersPathIn,
   writeServedProvidersAt,
 } from "./auth-file";
+import { bindEmptyRefreshServeSync } from "./empty-refresh-guard";
 import { logServeProbeFailure, noteServeProbeOk } from "./serve-log";
 import { reportDeadServedApiKey, servedApiKeyIsDead } from "./served-key-guard";
 import { forgetServedScope, recordServedScope } from "./served-scope";
@@ -121,6 +122,17 @@ export async function syncServedCredentialSafe(tag: string): Promise<void> {
     );
   }
 }
+
+// PRODUCT-1317: the credential store's empty-refresh guard re-serves an
+// expiring access-only entry through THIS single-flighted sync before pi's
+// expiry check can route it into a refresh. Bound rather than imported by the
+// store — a direct import would cycle (serve → storage → credential-store →
+// serve). The safe variant on purpose: a hydration failure must never fail
+// the credential read it precedes (the modify mask still guards), and the
+// safe wrapper already logs the failure.
+bindEmptyRefreshServeSync(() =>
+  syncServedCredentialSafe("empty-refresh-guard"),
+);
 
 type ServeProbe =
   | { id: string; state: "served"; cred: ServedCredential }


### PR DESCRIPTION
## Root cause

Gate #2 stores a served credential as `{type:"oauth", access, refresh:"", expires}` (`packages/runtime/src/auth/auth-file.ts`). pi-ai 0.84.1 does not know that shape: `resolveStoredOAuth` (`dist/auth/resolve.js`) routes ANY stored OAuth entry within 5 minutes of expiry (`DEFAULT_OAUTH_MINIMUM_VALIDITY_MS`) through `oauth.refresh(current)`, and every provider refresher POSTs `credential.refresh` verbatim to its token endpoint. The gateway serves with exactly 5 minutes of margin (zero slack) and the desktop host's serve path only refreshed inside 2 minutes (`isExpiring` default skew), so pi could receive a token already inside its refresh window — and fired `POST refresh_token=""` at the provider (openai-codex), or minted with `Bearer ""` and 401'd into a spurious reconnect card (github-copilot). Seen live in production as **PRODUCT-1293**, which this root-causes.

## Fix

**Engine guard (Houston-owned seam, no pi patch)** — `packages/runtime/src/auth/empty-refresh-guard.ts`, wired into `HoustonAuthStore` (pi's `CredentialStore`):
- `read()`: an access-only entry already inside pi's 5-minute window triggers the single-flighted `syncServedCredential()` (bound from `serve.ts`; a direct import would cycle serve → storage → credential-store → serve), so a fresh central token lands **before** pi's expiry check runs. The gateway refreshes centrally when serving a sub-5-minute token, so the re-serve genuinely closes the race.
- `modify()`: pi's refresh closures dereference `current` and hand it to the provider refresher — an access-only (`refresh:""`) entry is masked to `undefined`, which takes pi's own "logged out meanwhile" branch: the entry is left unchanged and pi serves the stored access token as-is via `toAuth` (side-effect-free per its `OAuthAuth` contract). The token's remaining validity still gets used; once truly expired the request 401s into the typed `unauthenticated`/`token_expired` card. **No refresh POST ever carries the empty string.**

**Desktop/self-host serve margin** — `packages/host/src/routes/credential.ts`: the serve-time refresh now fires below 6 minutes of validity (pi's 5-minute floor plus a minute of slack), passed as an explicit `skewMs` at the serve sites — `isExpiring`'s 2-minute default is untouched for its other callers. The anthropic staleness gate uses the same margin (a served anthropic entry also lands access-only in auth.json where pi's usage probes resolve it). The refresh coalescer threads the caller's margin through its cached-result and in-flight re-checks so it can't hand back a token the route already judged too short-lived.

## Tests

- `packages/runtime/src/auth/empty-refresh-guard.test.ts` — pins the store-level contract with pi's exact refresh-closure shape: an expiring `refresh:""` entry re-syncs at read and the refresher is **never** invoked (sync healthy, sync down, and sync unbound); a refresh-bearing credential still refreshes through `modify`; long-lived served tokens and pasted no-expiry tokens never trigger the sync; window-edge cases for `needsServeSync`.
- `packages/host/src/routes/credential.test.ts` — a token with 4 minutes of validity (fine for the old skew, inside pi's window) is refreshed at serve time; a healthy long-lived token serves with zero token-endpoint calls; an anthropic token below the floor answers the marked 404.
- Full suites green: `@houston/runtime` 118 files / 1086 tests, `@houston/host` 155 files / 1437 tests; `tsc --noEmit` clean for both; `pnpm check` (Biome) clean.

Fixes PRODUCT-1317. Root-causes PRODUCT-1293.