### PR TITLE
Idempotent credential capture: provider-scoped scrub, scrub self-heal, if-absent healer pushes (PRODUCT-1318)

### DIFF
--- a/packages/host/src/channel/capture-credential.test.ts
+++ b/packages/host/src/channel/capture-credential.test.ts
@@ -1,20 +1,33 @@
 import { afterEach, expect, test, vi } from "vitest";
+import { RemoteCredentialStore } from "../credentials/remote-store";
 import type { CredentialStore, WorkspaceCredential } from "../ports";
 import { captureRuntimeCredential } from "./capture-credential";
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
-test("full export stores once then scrubs once", async () => {
-  const stored: WorkspaceCredential[] = [];
-  let scrubCalls = 0;
+/** A CredentialStore fake recording every put with the opts it received. */
+function recordingStore(existing: WorkspaceCredential | null = null) {
+  const puts: Array<{
+    credential: WorkspaceCredential;
+    opts?: { ifAbsent?: boolean; actingAs?: string };
+  }> = [];
   const credentials: CredentialStore = {
-    get: async () => null,
-    put: async (credential) => {
-      stored.push(credential);
+    get: async () => existing,
+    put: async (credential, opts) => {
+      puts.push({ credential, opts });
     },
     remove: async () => {},
     removeIfAccess: async () => false,
   };
+  return { credentials, puts };
+}
+
+/** Stubs global fetch with a connected runtime; scrub replies via `scrub()`. */
+function stubRuntimeFetch(scrub: () => Response) {
+  const scrubUrls: string[] = [];
   vi.stubGlobal(
     "fetch",
     vi.fn(async (input: string | URL | Request) => {
@@ -26,13 +39,19 @@ test("full export stores once then scrubs once", async () => {
           refresh: "RT",
           expires: 123,
         });
-      if (url.endsWith("/auth/scrub-refresh")) {
-        scrubCalls++;
-        return Response.json({ ok: true });
+      if (url.includes("/auth/scrub-refresh")) {
+        scrubUrls.push(url);
+        return scrub();
       }
       return new Response("not found", { status: 404 });
     }),
   );
+  return scrubUrls;
+}
+
+test("full export stores once then scrubs once, provider-scoped", async () => {
+  const { credentials, puts } = recordingStore();
+  const scrubUrls = stubRuntimeFetch(() => Response.json({ ok: true }));
 
   expect(
     await captureRuntimeCredential({
@@ -43,9 +62,111 @@ test("full export stores once then scrubs once", async () => {
       requireRefresh: true,
     }),
   ).toEqual({ ok: true, provider: "openai-codex" });
-  expect(stored).toHaveLength(1);
-  expect(stored[0]?.refreshToken).toBe("RT");
-  expect(scrubCalls).toBe(1);
+  expect(puts).toHaveLength(1);
+  expect(puts[0]?.credential.refreshToken).toBe("RT");
+  // A user-initiated capture is a FULL put (it may supersede a tombstone)...
+  expect(puts[0]?.opts?.ifAbsent).toBeUndefined();
+  // ...and the scrub names the provider it captured (PRODUCT-1320), so a
+  // concurrent connect's freshly-written refresh token survives on the runtime.
+  expect(scrubUrls).toEqual([
+    "http://runtime/auth/scrub-refresh?provider=openai-codex",
+  ]);
+});
+
+test("a scrub failure after a landed central PUT settles as success and logs PRODUCT-1318", async () => {
+  // The connect DID succeed (the credential is stored and serving). Failing the
+  // capture here made the web client replay the entire credential PUT — the
+  // tombstone-clearing full PUT — while never fixing the leftover refresh token.
+  // The serve-sync self-heal owns that now; capture settles and shouts.
+  const { credentials, puts } = recordingStore();
+  stubRuntimeFetch(() => new Response("scrub exploded", { status: 503 }));
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  expect(
+    await captureRuntimeCredential({
+      endpoint: { baseUrl: "http://runtime", token: "runtime-token" },
+      credentials,
+      workspaceId: "workspace",
+      provider: "openai-codex",
+    }),
+  ).toEqual({ ok: true, provider: "openai-codex" });
+  expect(puts).toHaveLength(1);
+  expect(
+    errors.mock.calls.some((c) => String(c[0]).includes("PRODUCT-1318")),
+  ).toBe(true);
+});
+
+test("a replayed capture with nothing left to export settles against the central store", async () => {
+  // Retry after an ambiguous response: the first attempt stored AND scrubbed,
+  // so the replay's export is empty. The central row proves settlement — the
+  // replay must report success, not fail a connect that worked.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => Response.json({})),
+  );
+  const settled = await captureRuntimeCredential({
+    endpoint: { baseUrl: "http://runtime", token: "runtime-token" },
+    credentials: recordingStore({
+      workspaceId: "workspace",
+      provider: "openai-codex",
+      accessToken: "AT",
+      refreshToken: "RT",
+      expiresAt: 123,
+    }).credentials,
+    workspaceId: "workspace",
+    provider: "openai-codex",
+  });
+  expect(settled).toEqual({ ok: true, provider: "openai-codex" });
+
+  // With no central row it stays the honest "not connected yet".
+  const unsettled = await captureRuntimeCredential({
+    endpoint: { baseUrl: "http://runtime", token: "runtime-token" },
+    credentials: recordingStore(null).credentials,
+    workspaceId: "workspace",
+    provider: "openai-codex",
+  });
+  expect(unsettled).toMatchObject({ ok: false, status: 400 });
+});
+
+test("an automatic (healer) capture rides the gateway's if-absent maintenance contract", async () => {
+  // The serve healer re-pushes a pod's leftover copy with NO user behind it.
+  // A plain PUT would clear the gateway's revocation tombstone (cloud #230) —
+  // the one resurrection path that survived. Assert the flag reaches the wire.
+  const gatewayPuts: Array<{ url: string; ifAbsent: string | null }> = [];
+  const gatewayFetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => {
+    if (init?.method === "PUT") {
+      gatewayPuts.push({
+        url: String(input),
+        ifAbsent: new Headers(init.headers).get("x-houston-if-absent") ?? null,
+      });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    return new Response("unexpected", { status: 500 });
+  }) as typeof fetch;
+  const credentials = new RemoteCredentialStore({
+    baseUrl: "http://gateway",
+    orgSlug: "acme",
+    agentSlug: "sales",
+    podToken: "pod-token",
+    fetchImpl: gatewayFetch,
+  });
+  stubRuntimeFetch(() => Response.json({ ok: true }));
+
+  expect(
+    await captureRuntimeCredential({
+      endpoint: { baseUrl: "http://runtime", token: "runtime-token" },
+      credentials,
+      workspaceId: "workspace",
+      provider: "openai-codex",
+      requireRefresh: true,
+      ifAbsent: true,
+    }),
+  ).toEqual({ ok: true, provider: "openai-codex" });
+  expect(gatewayPuts).toHaveLength(1);
+  expect(gatewayPuts[0]?.ifAbsent).toBe("1");
 });
 
 test("heal mode rejects an api-key export before storing", async () => {

--- a/packages/host/src/channel/capture-credential.ts
+++ b/packages/host/src/channel/capture-credential.ts
@@ -22,6 +22,13 @@ type ExportedCredential = {
  * three would capture one member's credential into another's row. Undefined (the
  * desktop, self-host, every pre-HOU-976 caller) is the single shared scope,
  * byte-identical to before.
+ *
+ * Idempotent settlement (PRODUCT-1318): the two halves (central PUT, runtime
+ * scrub) can each be replayed safely, so a retry of the WHOLE capture after an
+ * ambiguous response converges instead of erroring or double-writing — a
+ * post-scrub replay finds nothing exportable and settles against the central
+ * store; a post-PUT/pre-scrub replay re-PUTs the same family and re-attempts
+ * the scrub.
  */
 export async function captureRuntimeCredential(args: {
   endpoint: RuntimeEndpoint;
@@ -30,6 +37,17 @@ export async function captureRuntimeCredential(args: {
   provider?: string;
   requireRefresh?: boolean;
   actingAs?: string;
+  /**
+   * Fill-only central write, for AUTOMATIC re-pushes (the serve healer). The
+   * gateway's credential PUT doubles as the user's "I reconnected" signal: a
+   * plain PUT clears the revocation tombstone guarding a provider-revoked
+   * family (cloud #230). An automatic re-push of a pod's leftover copy must
+   * never do that — `ifAbsent` rides to the store as the maintenance contract
+   * (`x-houston-if-absent`), which fills a missing row without clobbering a
+   * rotated refresh token or resurrecting a tombstoned one. A real
+   * user-initiated (re)connect omits it and overwrites.
+   */
+  ifAbsent?: boolean;
 }): Promise<CaptureResult> {
   const {
     endpoint,
@@ -38,6 +56,7 @@ export async function captureRuntimeCredential(args: {
     provider,
     requireRefresh,
     actingAs,
+    ifAbsent,
   } = args;
   const query = provider ? `?provider=${encodeURIComponent(provider)}` : "";
   const exported = await fetch(`${endpoint.baseUrl}/auth/export${query}`, {
@@ -87,7 +106,7 @@ export async function captureRuntimeCredential(args: {
         refreshToken: "",
         expiresAt: Number.MAX_SAFE_INTEGER,
       },
-      { actingAs },
+      { actingAs, ifAbsent },
     );
     return { ok: true, provider: credential.provider };
   }
@@ -97,6 +116,15 @@ export async function captureRuntimeCredential(args: {
     !credential.refresh ||
     typeof credential.expires !== "number"
   ) {
+    // Nothing exportable — EITHER the runtime truly holds no credential, OR a
+    // previous capture already landed and scrubbed it (a scrubbed entry has
+    // refresh="" and exports as {}). A capture retried after an ambiguous
+    // response (the web client's provider-capture-retry) must settle as
+    // success here instead of failing a connect that actually worked; the
+    // central store is the arbiter.
+    if (provider && (await settledCentrally(credentials, args))) {
+      return { ok: true, provider };
+    }
     return { ok: false, status: 400, error: "agent is not connected yet" };
   }
   await credentials.put(
@@ -110,21 +138,54 @@ export async function captureRuntimeCredential(args: {
       expiresAt: credential.expires,
       enterpriseUrl: credential.enterpriseUrl,
     },
-    { actingAs },
+    { actingAs, ifAbsent },
   );
   const scrub = await scrubRuntimeRefreshToken(
     `${endpoint.baseUrl}/auth/scrub-refresh`,
     endpoint.token,
+    credential.provider,
     actingAs,
   );
   if (!scrub.ok) {
-    return {
-      ok: false,
-      status: 502,
-      error:
-        "credential stored, but the agent sandbox could not be scrubbed of the refresh token — reconnect to retry",
-      detail: scrub.detail,
-    };
+    // The central PUT landed — the connect SUCCEEDED. Failing the capture here
+    // (the old behavior) made the client replay the entire capture, whose
+    // fresh full PUT clears revocation tombstones, while the refresh-bearing
+    // runtime entry it never fixed silently kept the pod rotating the family
+    // alongside the gateway (two rotators → mutual invalid_grant → org-wide
+    // sign-out). Settle instead: the retries above are exhausted, the leftover
+    // entry itself is the durable memory, and the runtime's next serve sync
+    // finishes the scrub once central serves this same access token
+    // (runtime auth/capture-settlement.ts). Loud, not silent:
+    console.error(
+      `[capture] PRODUCT-1318: captured ${credential.provider} centrally but scrubbing the runtime's refresh token failed after retries — the serve-sync self-heal will finish it${scrub.detail ? ` (${scrub.detail})` : ""}`,
+    );
   }
   return { ok: true, provider: credential.provider };
+}
+
+/**
+ * Whether the central store already holds a credential for the requested
+ * provider on this caller's row — the settlement probe for a replayed capture
+ * that finds nothing left to export. A probe failure is logged and read as
+ * "not settled": the caller then reports the same honest "not connected yet"
+ * it always did.
+ */
+async function settledCentrally(
+  credentials: CredentialStore,
+  args: { workspaceId: string; provider?: string; actingAs?: string },
+): Promise<boolean> {
+  if (!args.provider) return false;
+  try {
+    return (
+      (await credentials.get(args.workspaceId, args.provider, {
+        actingAs: args.actingAs,
+      })) !== null
+    );
+  } catch (err) {
+    console.warn(
+      `[capture] settlement probe for ${args.provider} failed:`,
+      err instanceof Error ? err.message : err,
+    );
+    return false;
+  }
 }

--- a/packages/host/src/channel/contract.test.ts
+++ b/packages/host/src/channel/contract.test.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { MemoryCredentialStore } from "../credentials/store";
 import type { Agent, Workspace } from "../domain/types";
 import { FakeLauncher } from "../launcher/fake";
@@ -383,20 +383,27 @@ describe("captureCredential scrub coupling (ProxyChannel)", () => {
     expect(await credentials.get(ws.id, "openai-codex")).not.toBeNull();
   });
 
-  test("reports capture failure when refresh scrubbing persistently fails", async () => {
-    const { channel } = makeProxyFixture();
+  test("persistent scrub failure settles as success, loudly (PRODUCT-1318)", async () => {
+    // The central PUT landed — the connect worked. Failing the capture made the
+    // client replay the whole tombstone-clearing PUT while the leftover refresh
+    // token silently kept the pod a second rotator of the family. The runtime's
+    // serve-sync self-heal finishes the scrub; capture settles and logs.
+    const { channel, credentials } = makeProxyFixture();
     proxyConnected = true;
     proxyScrubFailuresRemaining = 3;
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const result = await channel.captureCredential(ctx, "openai-codex");
 
-    const result = await channel.captureCredential(ctx, "openai-codex");
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.status).toBe(502);
-      expect(result.error).toContain("could not be scrubbed");
-      expect(result.detail).toContain("scrub unavailable");
+      expect(result).toEqual({ ok: true, provider: "openai-codex" });
+      expect(proxyScrubCalls).toBe(3); // bounded retries all spent
+      expect(await credentials.get(ws.id, "openai-codex")).not.toBeNull();
+      expect(
+        errors.mock.calls.some((c) => String(c[0]).includes("PRODUCT-1318")),
+      ).toBe(true);
+    } finally {
+      errors.mockRestore();
     }
-    expect(proxyScrubCalls).toBe(3);
   });
 });
 

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -322,8 +322,11 @@ export class ProxyChannel implements RuntimeChannel {
   /**
    * Connect-once capture: pull the credential out of the agent's runtime, store
    * it for the WHOLE workspace, then scrub the runtime's refresh token (Gate #2).
-   * A scrub failure is security-relevant and surfaces — the connection itself
-   * succeeded; reconnecting retries capture + scrub.
+   * A scrub failure after the store landed settles as success (the connect
+   * worked) — it is logged loudly and the runtime's serve sync finishes the
+   * scrub (PRODUCT-1318). This path is the USER-initiated connect, so its full
+   * PUT deliberately supersedes tombstones; automatic re-pushes (the serve
+   * healer) pass ifAbsent instead.
    */
   async captureCredential(
     ctx: ChannelCtx,

--- a/packages/host/src/channel/scrub-refresh.test.ts
+++ b/packages/host/src/channel/scrub-refresh.test.ts
@@ -3,6 +3,24 @@ import { scrubRuntimeRefreshToken } from "./scrub-refresh";
 
 afterEach(() => vi.unstubAllGlobals());
 
+test("scopes the scrub to the captured provider (PRODUCT-1320)", async () => {
+  const fetch = vi
+    .fn<typeof globalThis.fetch>()
+    .mockResolvedValue(new Response(null, { status: 200 }));
+  vi.stubGlobal("fetch", fetch);
+
+  await expect(
+    scrubRuntimeRefreshToken(
+      "https://runtime.test/auth/scrub-refresh",
+      "sbx",
+      "openai-codex",
+    ),
+  ).resolves.toEqual({ ok: true });
+  expect(String(fetch.mock.calls[0]?.[0])).toBe(
+    "https://runtime.test/auth/scrub-refresh?provider=openai-codex",
+  );
+});
+
 test("retries failed scrubs and succeeds on the third attempt", async () => {
   const fetch = vi
     .fn<typeof globalThis.fetch>()
@@ -12,7 +30,11 @@ test("retries failed scrubs and succeeds on the third attempt", async () => {
   vi.stubGlobal("fetch", fetch);
 
   await expect(
-    scrubRuntimeRefreshToken("https://runtime.test/auth/scrub-refresh", "sbx"),
+    scrubRuntimeRefreshToken(
+      "https://runtime.test/auth/scrub-refresh",
+      "sbx",
+      "openai-codex",
+    ),
   ).resolves.toEqual({ ok: true });
   expect(fetch).toHaveBeenCalledTimes(3);
 });
@@ -26,7 +48,11 @@ test("returns the final detail after persistent scrub failure", async () => {
   vi.stubGlobal("fetch", fetch);
 
   await expect(
-    scrubRuntimeRefreshToken("https://runtime.test/auth/scrub-refresh", "sbx"),
+    scrubRuntimeRefreshToken(
+      "https://runtime.test/auth/scrub-refresh",
+      "sbx",
+      "openai-codex",
+    ),
   ).resolves.toEqual({ ok: false, detail: "still unsafe" });
   expect(fetch).toHaveBeenCalledTimes(3);
 });

--- a/packages/host/src/channel/scrub-refresh.ts
+++ b/packages/host/src/channel/scrub-refresh.ts
@@ -2,6 +2,15 @@ const SCRUB_ATTEMPTS = 3;
 const SCRUB_RETRY_DELAY_MS = 100;
 
 /**
+ * Ask the runtime to scrub ONE provider's refresh token after its capture
+ * landed centrally.
+ *
+ * `provider` scopes the scrub to the provider that was just captured
+ * (PRODUCT-1320): an unscoped scrub erased EVERY provider's refresh token, so
+ * two concurrent OAuth connects could interleave — provider A's capture
+ * scrubbed provider B's freshly-written refresh before B's own capture
+ * exported it, leaving B access-only centrally.
+ *
  * `actingAs` scopes the scrub to ONE member's auth file (HOU-976) — the runtime
  * keeps one per acting identity, and an unscoped scrub would clear the shared
  * file while the member's own refresh token stayed on the pod.
@@ -9,18 +18,22 @@ const SCRUB_RETRY_DELAY_MS = 100;
 export async function scrubRuntimeRefreshToken(
   url: string,
   token: string,
+  provider: string,
   actingAs?: string,
 ): Promise<{ ok: true } | { ok: false; detail: string }> {
   let detail = "";
   for (let attempt = 1; attempt <= SCRUB_ATTEMPTS; attempt += 1) {
     try {
-      const response = await fetch(url, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          ...(actingAs ? { "x-houston-acting-as": actingAs } : {}),
+      const response = await fetch(
+        `${url}?provider=${encodeURIComponent(provider)}`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            ...(actingAs ? { "x-houston-acting-as": actingAs } : {}),
+          },
         },
-      });
+      );
       if (response.ok) return { ok: true };
       detail = await response.text().catch(() => "");
     } catch (err) {

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -374,6 +374,13 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
             requireRefresh: true,
             // The member whose serve missed — their runtime file, their row.
             actingAs,
+            // AUTOMATIC re-push (no user behind it): fill-only, per the store's
+            // maintenance contract. A plain PUT is reserved for a real user
+            // (re)connect because it clears the gateway's revocation tombstone
+            // (cloud #230) — the healer re-exporting a pod's leftover copy
+            // after a recycle was the one resurrection path that survived
+            // (PRODUCT-1318).
+            ifAbsent: true,
           });
           return result.ok;
         },

--- a/packages/host/src/server.test.ts
+++ b/packages/host/src/server.test.ts
@@ -339,7 +339,12 @@ test("capture stores the credential centrally, then scrubs the sandbox's refresh
   }
 });
 
-test("a failed scrub surfaces as an error (credential still stored)", async () => {
+test("a failed scrub settles the capture as success and logs PRODUCT-1318 (credential stored)", async () => {
+  // The central PUT landed, so the connect WORKED — failing the route here made
+  // the client replay the whole tombstone-clearing PUT while the leftover
+  // refresh token quietly kept the pod a second rotator. The runtime's serve
+  // sync self-heals the scrub; the route settles and the error log is the
+  // loud surface (PRODUCT-1318).
   const fakeRuntime = await startTestFetchServer((req) => {
     const u = new URL(req.url);
     if (u.pathname === "/auth/export") {
@@ -365,15 +370,21 @@ test("a failed scrub surfaces as an error (credential still stored)", async () =
     }),
   };
   const { base: b, close } = await startServer(deps);
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
   try {
     const r = await fetch(`${b}/agents/${aliceSalesId}/credential/capture`, {
       method: "POST",
       headers: auth("alice"),
     });
-    expect(r.status).toBe(502); // never silent: the user sees the real reason
-    const body = (await r.json()) as { error: string };
-    expect(body.error).toContain("refresh token");
+    expect(r.status).toBe(200);
+    const aliceWs = await store.getOrCreatePersonalWorkspace("alice");
+    const stored = await credentials.get(aliceWs.id, "openai-codex");
+    expect(stored?.refreshToken).toBe("RT2");
+    expect(
+      errors.mock.calls.some((c) => String(c[0]).includes("PRODUCT-1318")),
+    ).toBe(true);
   } finally {
+    errors.mockRestore();
     await close();
     await fakeRuntime.stop();
   }

--- a/packages/runtime/src/auth/anthropic-setup-token.test.ts
+++ b/packages/runtime/src/auth/anthropic-setup-token.test.ts
@@ -7,7 +7,7 @@ import {
   runAnthropicSetupTokenLogin,
   storeAnthropicToken,
 } from "./anthropic-setup-token";
-import { type PiCred, scrubRefreshTokensAt } from "./auth-file";
+import { type PiCred, scrubRefreshTokenAt } from "./auth-file";
 
 test("isAnthropicToken accepts setup tokens and console keys, rejects junk", () => {
   expect(isAnthropicToken("sk-ant-oat01-abc123")).toBe(true); // setup token
@@ -72,14 +72,15 @@ test("Gate #2 scrub leaves the anthropic api_key entry intact", () => {
     },
   };
   writeFileSync(path, JSON.stringify(auth));
-  const scrubbed = scrubRefreshTokensAt(path);
+  // The codex connect's provider-scoped scrub (PRODUCT-1320) — and even a
+  // direct scrub aimed at anthropic — leaves the api_key entry intact: it
+  // carries no refresh token, so the stored setup token survives verbatim.
+  expect(scrubRefreshTokenAt(path, "anthropic")).toBe(false);
+  expect(scrubRefreshTokenAt(path, "openai-codex")).toBe(true);
   const after = JSON.parse(readFileSync(path, "utf8")) as Record<
     string,
     PiCred
   >;
-  // The api_key anthropic entry carries no refresh token, so scrub never touches
-  // it — the stored setup token survives the per-connect scrub verbatim.
-  expect(scrubbed).toEqual(["openai-codex"]);
   expect(after.anthropic).toEqual({
     type: "api_key",
     key: "sk-ant-oat01-live",

--- a/packages/runtime/src/auth/auth-file.ts
+++ b/packages/runtime/src/auth/auth-file.ts
@@ -209,21 +209,25 @@ export function applyServedCredential(
 }
 
 /**
- * Rewrite every OAuth auth.json entry at `path` with refresh="". Idempotent.
- * API-key entries carry no refresh token, so they are left untouched. Returns
- * the providers that were actually scrubbed.
+ * Rewrite ONE provider's OAuth entry at `path` with refresh="". Idempotent; a
+ * missing file, an absent entry, an api_key entry (no refresh token to strip)
+ * and an already-scrubbed entry are all no-ops. Returns whether anything was
+ * actually scrubbed.
+ *
+ * Provider-scoped by design (PRODUCT-1320): capture is per-provider, and the
+ * old whole-file scrub let provider A's post-capture scrub erase provider B's
+ * refresh token in the window between B's own device-code login and B's
+ * capture export — B ended up access-only centrally and died at first expiry.
+ * There is deliberately NO full-scrub form: every caller knows exactly which
+ * provider it just captured.
  */
-export function scrubRefreshTokensAt(path: string): string[] {
+export function scrubRefreshTokenAt(path: string, provider: string): boolean {
   const auth = readAuthFile(path);
-  const scrubbed: string[] = [];
-  for (const [provider, cred] of Object.entries(auth)) {
-    if (cred?.type === "oauth" && cred.refresh) {
-      auth[provider] = { ...cred, refresh: "" };
-      scrubbed.push(provider);
-    }
-  }
-  if (scrubbed.length) writeAuthFile(path, auth);
-  return scrubbed;
+  const cred = auth[provider];
+  if (cred?.type !== "oauth" || !cred.refresh) return false;
+  auth[provider] = { ...cred, refresh: "" };
+  writeAuthFile(path, auth);
+  return true;
 }
 
 /**

--- a/packages/runtime/src/auth/capture-settlement.ts
+++ b/packages/runtime/src/auth/capture-settlement.ts
@@ -1,0 +1,49 @@
+import {
+  hasRefreshToken,
+  readAuthFile,
+  type ServedCredential,
+  scrubRefreshTokenAt,
+} from "./auth-file";
+
+/**
+ * Serve-sync self-heal for a capture whose post-PUT scrub never landed
+ * (PRODUCT-1318).
+ *
+ * The connect-once capture stores the full credential centrally FIRST and only
+ * then scrubs the runtime's refresh token. When that scrub fails (and the
+ * host's bounded retries are exhausted), the leftover refresh-bearing entry
+ * used to be permanent: serve apply skips it (the mid-capture guard),
+ * removeServedCredentialAt refuses to delete it, and this pod silently kept
+ * rotating the family on its own — two rotators, mutual invalid_grant,
+ * org-wide sign-out.
+ *
+ * This runs on every serve sync and finishes the settlement: when the central
+ * store answers `served` for a provider whose local entry still bears a
+ * refresh token, the ACCESS TOKEN decides whether that capture already landed.
+ *  - SAME access centrally and locally → the central row IS this very
+ *    credential (the PUT landed; only the scrub was lost) → scrub is safe and
+ *    overdue.
+ *  - DIFFERENT access → a genuinely fresh login the store has not captured yet
+ *    (the legitimate mid-capture window), or a central row the gateway already
+ *    rotated past this one. Leave it alone — the capture path owns it.
+ *
+ * The residual gap is deliberate: if the gateway rotates the access token
+ * before the first sync after a failed scrub, the digests never match again
+ * and the entry survives until the user reconnects. That requires the scrub to
+ * fail all its capture-time retries AND no sync to run until the access
+ * expires (hours), while syncs run before every turn and status poll —
+ * accepted, and far smaller than the permanent leak this replaces.
+ *
+ * Returns whether it scrubbed (the caller logs the PRODUCT-1318 event — a
+ * heal firing at all means a capture-time scrub was lost).
+ */
+export function scrubSettledCaptureAt(
+  path: string,
+  served: ServedCredential,
+): boolean {
+  if (served.kind === "api_key") return false; // different family by construction
+  const cred = readAuthFile(path)[served.provider];
+  if (cred?.type !== "oauth" || !hasRefreshToken(cred)) return false;
+  if (cred.access !== served.access) return false; // real mid-capture: hands off
+  return scrubRefreshTokenAt(path, served.provider);
+}

--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -22,11 +22,11 @@ import {
   type PiCred,
   readServedProvidersAt,
   removeServedCredentialAt,
-  scrubRefreshTokensAt,
+  scrubRefreshTokenAt,
   writeServedProvidersAt,
 } from "./auth-file";
 import { selectExportCredential } from "./export";
-import { syncServedCredential } from "./serve";
+import { scrubRefreshTokens, syncServedCredential } from "./serve";
 import { resetDeadKeyReportsForTest } from "./served-key-guard";
 
 /** The host's authoritative "not connected" 404 (see routes/credential.ts). */
@@ -473,6 +473,143 @@ test("a serve marks the provider in the manifest, so a later sign-out removes it
   });
 });
 
+/** Serves one openai-codex OAuth credential with the given access token. */
+const codexServeFetch = (access: string) =>
+  (async (input: RequestInfo | URL) => {
+    if (
+      new URL(String(input)).searchParams.get("provider") === "openai-codex"
+    ) {
+      return new Response(
+        JSON.stringify({
+          provider: "openai-codex",
+          kind: "oauth",
+          access,
+          expires: 1_900_000_000_000,
+          accountId: null,
+        }),
+        { status: 200 },
+      );
+    }
+    return notConnected404();
+  }) as unknown as typeof globalThis.fetch;
+
+test("serve sync self-heals a lost capture scrub when central serves the SAME access (PRODUCT-1318)", async () => {
+  // The capture PUT landed centrally but the post-capture scrub failed all its
+  // retries. The leftover refresh-bearing entry used to be permanent: apply
+  // skipped it (mid-capture guard), removal refused it, and this pod silently
+  // kept rotating the family alongside the gateway — two rotators, mutual
+  // invalid_grant, org-wide sign-out. Central serving the very access token the
+  // local entry holds PROVES the capture landed, so the sync finishes the scrub.
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    await withServeMode(codexServeFetch("AT-captured"), async () => {
+      const path = join(config.dataDir, "auth.json");
+      const manifestPath = join(config.dataDir, "served-providers.json");
+      writeFileSync(
+        path,
+        JSON.stringify({
+          "openai-codex": {
+            type: "oauth",
+            access: "AT-captured",
+            refresh: "RT-leftover",
+            expires: 1,
+          },
+        }),
+      );
+
+      expect(await syncServedCredential()).toEqual(["openai-codex"]);
+      expect(readAuth(path)["openai-codex"]).toEqual({
+        type: "oauth",
+        access: "AT-captured",
+        refresh: "",
+        expires: 1_900_000_000_000,
+      });
+      // Serve-owned again: a later authoritative sign-out can remove it.
+      expect(readServedProvidersAt(manifestPath)).toEqual(["openai-codex"]);
+      // Loud, not silent: a heal firing means a capture-time scrub was lost.
+      expect(
+        errors.mock.calls.some((c) => String(c[0]).includes("PRODUCT-1318")),
+      ).toBe(true);
+    });
+  } finally {
+    errors.mockRestore();
+  }
+});
+
+test("serve sync leaves a REAL mid-capture login alone (different access)", async () => {
+  // A fresh device-code login between the previous credential's serve and its
+  // own capture: the local refresh-bearing entry carries a DIFFERENT access
+  // than the central row, so the capture has NOT landed — scrubbing here would
+  // destroy the only copy of the new refresh token before /auth/export ships it.
+  await withServeMode(codexServeFetch("AT-old-central"), async () => {
+    const path = join(config.dataDir, "auth.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        "openai-codex": {
+          type: "oauth",
+          access: "AT-fresh-login",
+          refresh: "RT-fresh-login",
+          expires: 1,
+        },
+      }),
+    );
+
+    expect(await syncServedCredential()).toEqual([]); // apply still skips it
+    expect(readAuth(path)["openai-codex"]).toEqual({
+      type: "oauth",
+      access: "AT-fresh-login",
+      refresh: "RT-fresh-login",
+      expires: 1,
+    });
+  });
+});
+
+test("scrubRefreshTokens(provider) marks the provider serve-owned at capture time (CRED-09)", async () => {
+  // The scrub route only fires after a successful central PUT, so THIS is the
+  // moment the provider becomes serve-owned — not its first serve. Without it,
+  // a capture followed by a sign-out before any serve ran left an entry no
+  // authoritative 404 could ever remove.
+  const fetchImpl = (async () =>
+    notConnected404()) as unknown as typeof globalThis.fetch;
+  await withServeMode(fetchImpl, async () => {
+    const path = join(config.dataDir, "auth.json");
+    const manifestPath = join(config.dataDir, "served-providers.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        "openai-codex": {
+          type: "oauth",
+          access: "AT-cap",
+          refresh: "RT-cap",
+          expires: 1,
+        },
+        "github-copilot": {
+          type: "oauth",
+          access: "AT-other",
+          refresh: "RT-other",
+          expires: 2,
+        },
+      }),
+    );
+
+    expect(scrubRefreshTokens("openai-codex")).toEqual(["openai-codex"]);
+    expect(readAuth(path)["openai-codex"]?.refresh).toBe("");
+    // Provider-scoped: the concurrent connect's refresh survives (PRODUCT-1320).
+    expect(readAuth(path)["github-copilot"]?.refresh).toBe("RT-other");
+    expect(readServedProvidersAt(manifestPath)).toEqual(["openai-codex"]);
+    // A retried scrub (already clean) still reports settled ownership.
+    expect(scrubRefreshTokens("openai-codex")).toEqual([]);
+    expect(readServedProvidersAt(manifestPath)).toEqual(["openai-codex"]);
+
+    // The org signs out before this provider was ever served: the authoritative
+    // 404 can now remove the local copy because capture marked ownership.
+    expect(await syncServedCredential()).toEqual([]);
+    expect(readAuth(path)["openai-codex"]).toBeUndefined();
+    expect(readServedProvidersAt(manifestPath)).toEqual([]);
+  });
+});
+
 test("selectExportCredential without a provider falls back to the first OAuth credential", () => {
   const auth: Record<string, PiCred> = {
     "openai-codex": oauth("AT-codex", "RT-codex"),
@@ -594,7 +731,12 @@ test("a served credential replaces an existing refresh-less entry", () => {
   expect(codex.access).toBe("AT-new");
 });
 
-test("scrub rewrites every refresh-bearing entry and reports the providers", () => {
+test("the scrub is provider-scoped: a concurrent connect's refresh token survives (PRODUCT-1320)", () => {
+  // Two OAuth connects interleave: codex's capture lands and scrubs while
+  // copilot's own login just wrote its refresh token, BEFORE copilot's capture
+  // exported it. The old whole-file scrub erased copilot's refresh here —
+  // copilot's capture then found nothing to export and the credential ended
+  // access-only centrally, dying at first expiry.
   const path = freshAuthPath();
   writeFileSync(
     path,
@@ -602,25 +744,31 @@ test("scrub rewrites every refresh-bearing entry and reports the providers", () 
       "openai-codex": {
         type: "oauth",
         access: "A1",
-        refresh: "RT-1",
+        refresh: "RT-codex",
         expires: 1,
       },
-      anthropic: { type: "oauth", access: "A2", refresh: "RT-2", expires: 2 },
+      "github-copilot": {
+        type: "oauth",
+        access: "A2",
+        refresh: "RT-copilot",
+        expires: 2,
+      },
     }),
   );
-  expect(scrubRefreshTokensAt(path).sort()).toEqual([
-    "anthropic",
-    "openai-codex",
-  ]);
+  expect(scrubRefreshTokenAt(path, "openai-codex")).toBe(true);
   const auth = readAuth(path);
   const codex = auth["openai-codex"];
   if (!codex) throw new Error("expected openai-codex entry in auth file");
-  const anthropic = auth.anthropic;
-  if (!anthropic) throw new Error("expected anthropic entry in auth file");
+  const copilot = auth["github-copilot"];
+  if (!copilot) throw new Error("expected github-copilot entry in auth file");
   expect(codex.refresh).toBe("");
-  expect(anthropic.refresh).toBe("");
   // Access tokens survive the scrub — the agent keeps working this turn.
   expect(codex.access).toBe("A1");
+  // The mid-capture neighbor is untouched: its own capture can still export.
+  expect(copilot.refresh).toBe("RT-copilot");
+  // ...and copilot's later scrub settles it too.
+  expect(scrubRefreshTokenAt(path, "github-copilot")).toBe(true);
+  expect(readAuth(path)["github-copilot"]?.refresh).toBe("");
 });
 
 test("an API-key served credential is written as pi's api_key variant (no refresh/expiry)", () => {
@@ -655,21 +803,22 @@ test("scrub leaves api_key entries untouched (nothing to scrub)", () => {
       opencode: { type: "api_key", key: "sk-opencode" },
     }),
   );
-  expect(scrubRefreshTokensAt(path)).toEqual(["openai-codex"]);
+  expect(scrubRefreshTokenAt(path, "openai-codex")).toBe(true);
+  expect(scrubRefreshTokenAt(path, "opencode")).toBe(false);
   const auth = readAuth(path);
   expect(auth.opencode).toEqual({ type: "api_key", key: "sk-opencode" });
 });
 
 test("scrub is idempotent and a missing auth.json is a no-op", () => {
   const path = freshAuthPath();
-  expect(scrubRefreshTokensAt(path)).toEqual([]); // no file
+  expect(scrubRefreshTokenAt(path, "openai-codex")).toBe(false); // no file
   writeFileSync(
     path,
     JSON.stringify({
       "openai-codex": { type: "oauth", access: "A", refresh: "", expires: 1 },
     }),
   );
-  expect(scrubRefreshTokensAt(path)).toEqual([]); // already clean
+  expect(scrubRefreshTokenAt(path, "openai-codex")).toBe(false); // already clean
 });
 
 test("removeServedCredentialAt removes only served-owned credentials for the requested provider", () => {
@@ -758,9 +907,9 @@ test("scrub leaves api-key entries untouched (no refresh token to strip)", () =>
       "amazon-bedrock": { type: "api_key", key: "bedrock-KEEP" },
     }),
   );
-  // Only the OAuth provider is scrubbed; the api-key entries are reported as
-  // unchanged and survive verbatim.
-  expect(scrubRefreshTokensAt(path)).toEqual(["openai-codex"]);
+  // Only the captured OAuth provider is scrubbed; the api-key entries are
+  // reported as unchanged and survive verbatim.
+  expect(scrubRefreshTokenAt(path, "openai-codex")).toBe(true);
   const auth = JSON.parse(readFileSync(path, "utf8")) as Record<
     string,
     { type?: string; key?: string; refresh?: string }

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -9,10 +9,11 @@ import {
   readServedProvidersAt,
   removeServedCredentialAt,
   type ServedCredential,
-  scrubRefreshTokensAt,
+  scrubRefreshTokenAt,
   servedProvidersPathIn,
   writeServedProvidersAt,
 } from "./auth-file";
+import { scrubSettledCaptureAt } from "./capture-settlement";
 import { logServeProbeFailure, noteServeProbeOk } from "./serve-log";
 import { reportDeadServedApiKey, servedApiKeyIsDead } from "./served-key-guard";
 import { forgetServedScope, recordServedScope } from "./served-scope";
@@ -32,8 +33,10 @@ import { authStorage } from "./storage";
  * full credential (access + refresh) locally. Serve sync must not overwrite that
  * refresh-bearing entry with an older central access token while capture is in
  * progress. The control plane captures it into the central store immediately
- * afterwards and then calls POST /auth/scrub-refresh, which rewrites every entry
- * with refresh=""; normal serving resumes after that scrub.
+ * afterwards and then calls POST /auth/scrub-refresh?provider=<id>, which
+ * rewrites THAT provider's entry with refresh="" (PRODUCT-1320); normal serving
+ * resumes after that scrub. A lost scrub is self-healed by the sync itself
+ * (capture-settlement.ts, PRODUCT-1318).
  *
  * Best-effort on sync: a transient control-plane blip leaves the existing
  * (still-valid) auth.json in place; a missing connection surfaces downstream as
@@ -66,11 +69,32 @@ export function serveModeOn(): boolean {
   return !!config.controlPlaneUrl && !!config.sandboxToken;
 }
 
-/** Config-bound scrub used by POST /auth/scrub-refresh. */
-export function scrubRefreshTokens(): string[] {
-  const scrubbed = scrubRefreshTokensAt(authPathFor());
-  if (scrubbed.length) authStorage.reload();
-  return scrubbed;
+/**
+ * Config-bound scrub used by POST /auth/scrub-refresh. Provider-scoped
+ * (PRODUCT-1320): the host calls this for exactly the provider whose capture
+ * just landed centrally, so a concurrent second provider's freshly-written
+ * refresh token (mid-capture, not yet exported) survives untouched.
+ *
+ * This is also the moment the provider becomes serve-owned, so it is recorded
+ * in the served-providers manifest HERE — at capture time, not at first serve.
+ * The host only ever calls this route right after a successful central PUT, so
+ * manifest membership is honest, and a later authoritative central 404 can
+ * remove the local copy (the CRED-09 gap: capture-then-sign-out before any
+ * serve ran left an unowned entry behind). This cannot confuse the mid-capture
+ * guard: that guard keys on the ENTRY's refresh token (hasRefreshToken), never
+ * on the manifest, and removeServedCredentialAt independently refuses
+ * refresh-bearing entries.
+ */
+export function scrubRefreshTokens(provider: string): string[] {
+  const scrubbed = scrubRefreshTokenAt(authPathFor(), provider);
+  const manifestPath = servedManifestPathFor();
+  const manifest = new Set(readServedProvidersAt(manifestPath));
+  if (!manifest.has(provider)) {
+    manifest.add(provider);
+    writeServedProvidersAt(manifestPath, [...manifest]);
+  }
+  if (scrubbed) authStorage.reload();
+  return scrubbed ? [provider] : [];
 }
 
 /**
@@ -220,6 +244,17 @@ async function runServedSync(): Promise<string[]> {
       continue;
     }
     if (probe.state === "served") {
+      // PRODUCT-1318 self-heal: a refresh-bearing local entry whose ACCESS the
+      // central store is serving back means the capture PUT landed but its
+      // scrub was lost — finish the scrub now (a different access is a real
+      // mid-capture login and is left alone; see capture-settlement.ts).
+      // Without this, the leftover refresh token kept the pod rotating the
+      // family alongside the gateway forever.
+      if (scrubSettledCaptureAt(authPathFor(), probe.cred)) {
+        console.error(
+          `[serve] PRODUCT-1318: scrubbed a leftover ${probe.id} refresh token — its capture landed centrally but the capture-time scrub never did`,
+        );
+      }
       const didApply = applyServedCredential(authPathFor(), probe.cred);
       // WHOSE credential this was, remembered for the provider-error stamp and
       // the /providers row. Recorded on the gateway's ANSWER, not on the write:

--- a/packages/runtime/src/transport/provider-routes.ts
+++ b/packages/runtime/src/transport/provider-routes.ts
@@ -93,7 +93,17 @@ export async function handleProviderRoute(ctx: RouteContext): Promise<boolean> {
     return true;
   }
   if (method === "POST" && path === "/auth/scrub-refresh") {
-    json(res, 200, { ok: true, scrubbed: scrubRefreshTokens() });
+    // Provider-scoped (PRODUCT-1320): a whole-file scrub let one provider's
+    // capture erase another's mid-capture refresh token. The host always knows
+    // which provider it just captured, so a scrub without one is a bug.
+    const provider = url.searchParams.get("provider");
+    if (!provider) {
+      json(res, 400, {
+        error: "missing 'provider' (the scrub is per-provider)",
+      });
+      return true;
+    }
+    json(res, 200, { ok: true, scrubbed: scrubRefreshTokens(provider) });
     return true;
   }
   if (method === "POST" && path === "/providers/openai-compatible") {

--- a/packages/web/src/engine-adapter/client/provider-capture-retry.ts
+++ b/packages/web/src/engine-adapter/client/provider-capture-retry.ts
@@ -1,6 +1,21 @@
 const CAPTURE_ATTEMPTS = 3;
 const CAPTURE_RETRY_DELAY_MS = 250;
 
+/**
+ * Retry the connect-once capture call after a failed/ambiguous response.
+ *
+ * This replays the WHOLE capture, not just its scrub half — from this seam the
+ * client cannot tell whether an ambiguous response (network drop mid-request)
+ * died before or after the host's central PUT, so a scrub-only retry is not
+ * expressible here. That is safe because the host made capture idempotent
+ * (PRODUCT-1318, host channel/capture-credential.ts): a replay after the PUT +
+ * scrub both landed finds nothing exportable and settles against the central
+ * store instead of erroring; a replay after the PUT but before the scrub
+ * re-PUTs the same still-current family (within these sub-second retries the
+ * gateway has not rotated it) and re-attempts the scrub. A scrub the host
+ * could not complete no longer fails the capture at all — the runtime's serve
+ * sync self-heals it — so this retry only ever sees genuine capture failures.
+ */
 export async function retryCredentialCapture(
   capture: () => Promise<void>,
   wait: (ms: number) => Promise<unknown> = (ms) =>


### PR DESCRIPTION
Fixes PRODUCT-1318, PRODUCT-1320.

## Root cause

**PRODUCT-1318 (critical).** The OAuth capture (`packages/host/src/channel/capture-credential.ts`) stores the credential centrally, THEN scrubs the pod's refresh token — and a failed scrub was never retried past the capture call. The leftover refresh-bearing entry was **permanent**: serve apply skips it (the `hasRefreshToken` mid-capture guard), `removeServedCredentialAt` refuses to delete it, and the served manifest never lists it. Consequences:

- Org sign-out left the pod silently rotating its own copy of the family via pi → two rotators → mutual `invalid_grant` → org-wide sign-out.
- After a pod recycle, the serve healer (`packages/host/src/local/host.ts`) exported exactly this leftover and re-pushed it with a **full PUT** — which by the store contract clears the gateway's revocation tombstone (cloud #230): the one resurrection path that survived.
- The web client (`provider-capture-retry.ts`) retried the **whole capture** on ambiguous responses, replaying the full tombstone-clearing credential PUT.

**PRODUCT-1320 (high).** `scrubRefreshTokensAt` scrubbed EVERY provider's refresh token although capture is per-provider (neither the endpoint nor the host caller passed one). Two concurrent OAuth connects interleaved: provider A's capture erased provider B's refresh before B's own capture exported it → B ended access-only centrally and died at first expiry.

## Fix

**Provider-scoped scrub (PRODUCT-1320)** — `scrubRefreshTokenAt(path, provider)` replaces the whole-file scrub entirely (no full-scrub form kept; the endpoint was its only caller and the host always knows which provider it just captured). `POST /auth/scrub-refresh` now requires `?provider=`; the host threads `credential.provider` through.

**Idempotent settlement (PRODUCT-1318)**
- *Scrub failure after a landed PUT settles as success.* The connect genuinely worked (credential stored + serving); the old 502 made the client replay the full tombstone-clearing PUT while never fixing the leftover. Now: bounded retries (3× with backoff, pre-existing in `scrub-refresh.ts`), a loud `PRODUCT-1318` error log, and the leftover entry itself is the durable memory for…
- *…the serve-sync self-heal* (`packages/runtime/src/auth/capture-settlement.ts`): when the central store answers `served` for a provider whose local entry still bears a refresh token, the **access token decides**. Central serving the SAME access the local refresh-bearing entry holds proves that very capture landed → scrub is safe and overdue. A DIFFERENT access is a genuinely fresh login mid-capture → left strictly alone (the legitimate mid-capture guard is untouched — it keys on the entry's refresh token, never on the manifest). Residual gap (documented in code): if the gateway rotates the access before the first sync after a failed scrub, digests never match again — requires all capture-time retries to fail AND no sync until access expiry (hours), while syncs run before every turn; accepted vs. the permanent leak this replaces.
- *Healer re-pushes are fill-only.* `captureRuntimeCredential` gains `ifAbsent`, threaded to `credentials.put` → the gateway's `x-houston-if-absent` maintenance contract. The serve healer (the only automatic full-capture path; audited call sites) passes it, so an automatic re-push can never clear a revocation tombstone or clobber a rotated refresh token. A full PUT stays reserved for the real user-initiated (re)connect (`ProxyChannel.captureCredential`).
- *Client retry seam.* The retry cannot distinguish pre-PUT from post-PUT ambiguity client-side (documented in `provider-capture-retry.ts`), so the host capture was made idempotent instead: a replay that finds nothing exportable (post-scrub) settles against the central store; a post-PUT/pre-scrub replay re-PUTs the same still-current family and re-attempts the scrub.
- *Manifest at capture time (CRED-09).* The scrub route marks the provider serve-owned the moment capture lands (it only ever fires right after a successful central PUT), so an authoritative central 404 can remove the local copy even when the provider was never served between capture and sign-out. Cannot confuse the mid-capture guard: that guard and `removeServedCredentialAt` both key on the entry's refresh token independently of the manifest.

## Tests

- Provider-scoped scrub leaves a concurrent connect's refresh intact (the interleaving, `serve.test.ts`), api-key/idempotency/missing-file no-ops updated to the scoped API.
- Serve-sync self-heal: scrubs the leftover when central serves the same access (asserting the auth file, the manifest, and the loud PRODUCT-1318 log); leaves a real mid-capture login (different access) untouched.
- `scrubRefreshTokens(provider)` marks serve-ownership at capture time and a pre-serve sign-out then removes the local copy.
- Host: scrub URL carries the provider; scrub failure after a landed PUT settles ok + logs PRODUCT-1318 (unit + route-level + channel contract); replayed capture settles against the central store / stays 400 without a central row; healer-style capture asserts `x-houston-if-absent: 1` at a fake gateway through a real `RemoteCredentialStore`.
- Full suites: `@houston/runtime` 1083 passed, `@houston/host` 1438 passed; `pnpm check` clean; tsgo clean for runtime, host, and web.