### PR TITLE
Revoked-token report carries the failed token's digest, not the current file's (PRODUCT-1319)

### DIFF
--- a/knowledge-base/provider-errors.md
+++ b/knowledge-base/provider-errors.md
@@ -182,6 +182,18 @@ freely; add to the report's list almost never. Same asymmetry drives the host's
 terminal refresh codes — `knowledge-base/anthropic-credentials.md` → "What may
 sign a user out".
 
+The report names the token by digest, and the digest is the token the FAILED
+turn actually ran on — captured at request/spawn preparation
+(`packages/runtime/src/auth/used-token.ts`: the credential store records at
+pi's request-time `read()`, the Claude backend at subprocess spawn, the
+per-turn runtime seeds from its hydrated auth.json) and threaded to
+`reportRevokedServedToken` as an explicit parameter. NEVER re-derive it from
+auth.json at report time: a serve sync or user reconnect between the 401 and
+the report swaps in a healthy token, and the gateway's compare-and-delete would
+then destroy the fresh credential (PRODUCT-1319). An UNKNOWN used token skips
+the report entirely — a missed report costs a retry on the next failed turn, a
+mis-aimed one signs the workspace out of a working credential.
+
 ## Two auth cards, two copy sets, kept deliberately distinct
 
 The inline `UnauthenticatedCard` and the store-driven `ProviderReconnectCard`

--- a/packages/runtime/src/auth/credential-store.ts
+++ b/packages/runtime/src/auth/credential-store.ts
@@ -14,6 +14,7 @@ import {
   readAuthFile,
   writeAuthFile,
 } from "./auth-file";
+import { recordUsedToken } from "./used-token";
 
 /**
  * Houston's credential store: pi-ai's `CredentialStore` contract over
@@ -141,7 +142,17 @@ export class HoustonAuthStore implements CredentialStore {
   // ---- pi-ai CredentialStore ----
 
   async read(providerId: string): Promise<Credential | undefined> {
-    return this.get(providerId);
+    const cred = this.get(providerId);
+    // pi calls this inside `prepareRequest` on every `stream()`, i.e. at
+    // request preparation inside the turn's async subtree — the one moment the
+    // token a request runs on is knowable. Record its digest into the turn's
+    // capture so a later revoked-token report names the token that actually
+    // produced the failure, not whatever a re-serve stored since
+    // (auth/used-token.ts, PRODUCT-1319). OAuth access only — an api_key has
+    // no revocation semantics the report may act on. No-op outside a turn.
+    if (cred?.type === "oauth" && cred.access)
+      recordUsedToken(providerId, cred.access);
+    return cred;
   }
 
   async list(): Promise<readonly CredentialInfo[]> {
@@ -164,7 +175,14 @@ export class HoustonAuthStore implements CredentialStore {
       const next = await fn(state.cache[providerId]);
       // Contract: `undefined` leaves the entry unchanged (NOT a delete).
       if (next !== undefined) this.setIn(state, providerId, next);
-      return state.cache[providerId];
+      const settled = state.cache[providerId];
+      // A mid-turn OAuth refresh runs through here: subsequent requests use
+      // the ROTATED token, so the turn's used-token capture must follow it —
+      // else a 401 on the new token would be reported under the old digest
+      // (auth/used-token.ts, PRODUCT-1319). No-op outside a turn.
+      if (settled?.type === "oauth" && settled.access)
+        recordUsedToken(providerId, settled.access);
+      return settled;
     };
     // Chain regardless of the previous op's outcome; rejections from `fn`
     // still propagate to THIS caller below.

--- a/packages/runtime/src/auth/report-revoked.test.ts
+++ b/packages/runtime/src/auth/report-revoked.test.ts
@@ -17,6 +17,11 @@ import { recordServedScope, resetServedScopes } from "./served-scope";
  * The reporter is a DELETE trigger for a workspace-wide credential, so the
  * gating is the safety-critical part: every test here is about what must NOT
  * produce a report (HOU-952).
+ *
+ * The digest argument is the caller's capture of the token the FAILED turn ran
+ * on (auth/used-token.ts, PRODUCT-1319) — the reporter never derives it from
+ * auth.json, whose content at report time may already be a healthy
+ * replacement.
  */
 
 type Captured = { url: string; body: Record<string, unknown> } | null;
@@ -122,7 +127,7 @@ const revoked: ProviderError = {
 test("reports a revoked served token, naming it by digest only", async () => {
   const captured = await withServeMode(
     (dir) => servedAnthropic(dir, "the-revoked-token"),
-    () => reportRevokedServedToken(revoked),
+    () => reportRevokedServedToken(revoked, accessDigest("the-revoked-token")),
   );
 
   expect(captured?.url).toBe(
@@ -134,6 +139,58 @@ test("reports a revoked served token, naming it by digest only", async () => {
   expect(JSON.stringify(captured?.body)).not.toContain("the-revoked-token");
 });
 
+/**
+ * PRODUCT-1319 — the bug this parameter exists to fix. The failed turn ran on
+ * token A; a serve sync (or the user's reconnect) stored healthy token B
+ * between the 401 and the report. Re-reading auth.json here digested B, and
+ * the gateway's compare-and-delete then destroyed the FRESH credential,
+ * potentially feeding a reconnect loop. The report must name A.
+ */
+test("names the token the FAILED turn ran on, not the healthier one stored since", async () => {
+  const captured = await withServeMode(
+    // A re-serve already replaced the dead token in auth.json…
+    (dir) => servedAnthropic(dir, "fresh-healthy-token"),
+    // …but the turn that 401'd ran on the old one, and says so.
+    () => reportRevokedServedToken(revoked, accessDigest("the-dead-token")),
+  );
+
+  expect(captured?.body.accessSha256).toBe(accessDigest("the-dead-token"));
+  expect(captured?.body.accessSha256).not.toBe(
+    accessDigest("fresh-healthy-token"),
+  );
+});
+
+test("an UNKNOWN at-failure token never reports — even with a token stored", async () => {
+  // The caller could not capture what the failed turn ran on (it threw before
+  // any request resolved a credential). Falling back to the file would aim the
+  // delete at an unverified target — possibly a fresh reconnect — so the safe
+  // move is to skip: a missed report costs a retry on the next failed turn, a
+  // false one signs the workspace out of a working credential (PRODUCT-1319).
+  const captured = await withServeMode(
+    (dir) => servedAnthropic(dir, "fresh-healthy-token"),
+    () => reportRevokedServedToken(revoked, undefined),
+  );
+  expect(captured).toBeNull();
+});
+
+test("still reports when the local entry is already gone (row may live centrally)", async () => {
+  // A local disconnect can race the report; the central store may still hold
+  // (and keep serving) the dead row. The failed token is known and confirmed
+  // revoked, and the gateway's compare-and-delete no-ops unless its row
+  // matches — so the report goes out.
+  const captured = await withServeMode(
+    (dir) => {
+      writeFileSync(join(dir, "auth.json"), JSON.stringify({}));
+      writeFileSync(
+        join(dir, "served-providers.json"),
+        JSON.stringify(["anthropic"]),
+      );
+    },
+    () => reportRevokedServedToken(revoked, accessDigest("the-dead-token")),
+  );
+  expect(captured?.body.accessSha256).toBe(accessDigest("the-dead-token"));
+});
+
 test("a member's report names the acting identity, not just the scope", async () => {
   // Without the acting token the gateway cannot tell WHICH member's row a
   // personal digest-delete targets, so it answers 400 and the dead token
@@ -143,7 +200,7 @@ test("a member's report names the acting identity, not just the scope", async ()
     () =>
       runWithActingContext(alice, () => {
         recordServedScope("anthropic", "personal");
-        reportRevokedServedToken(revoked);
+        reportRevokedServedToken(revoked, accessDigest("alice-revoked-token"));
       }),
   );
 
@@ -157,7 +214,7 @@ test("a team report carries no acting identity at all", async () => {
   // it was, so an older control plane sees no new field.
   const captured = await withServeMode(
     (dir) => servedAnthropic(dir),
-    () => reportRevokedServedToken(revoked),
+    () => reportRevokedServedToken(revoked, accessDigest("served-access")),
   );
 
   expect(captured?.body.scope).toBe("team");
@@ -170,10 +227,13 @@ test("does NOT report a non-terminal auth failure", async () => {
   const captured = await withServeMode(
     (dir) => servedAnthropic(dir),
     () =>
-      reportRevokedServedToken({
-        ...revoked,
-        cause: "invalid_api_key",
-      } as ProviderError),
+      reportRevokedServedToken(
+        {
+          ...revoked,
+          cause: "invalid_api_key",
+        } as ProviderError,
+        accessDigest("served-access"),
+      ),
   );
   expect(captured).toBeNull();
 });
@@ -195,7 +255,11 @@ test.each([
   // failed turn, so the destructive half needs a machine-emitted marker.
   const captured = await withServeMode(
     (dir) => servedAnthropic(dir),
-    () => reportRevokedServedToken({ ...revoked, message }),
+    () =>
+      reportRevokedServedToken(
+        { ...revoked, message },
+        accessDigest("served-access"),
+      ),
   );
   expect(captured).toBeNull();
 });
@@ -213,7 +277,11 @@ test.each([
   // "access revoked", "token_revoked") survive neither.
   const captured = await withServeMode(
     (dir) => servedAnthropic(dir),
-    () => reportRevokedServedToken({ ...revoked, message }),
+    () =>
+      reportRevokedServedToken(
+        { ...revoked, message },
+        accessDigest("served-access"),
+      ),
   );
   expect(captured).toBeNull();
 });
@@ -231,7 +299,11 @@ test.each([
   // catching after anchoring.
   const captured = await withServeMode(
     (dir) => servedAnthropic(dir, "the-revoked-token"),
-    () => reportRevokedServedToken({ ...revoked, message }),
+    () =>
+      reportRevokedServedToken(
+        { ...revoked, message },
+        accessDigest("the-revoked-token"),
+      ),
   );
   expect(captured?.body.accessSha256).toBe(accessDigest("the-revoked-token"));
 });
@@ -249,11 +321,14 @@ test.each([
   const captured = await withServeMode(
     (dir) => servedOauth(dir, "openai-codex", "codex-revoked-token"),
     () =>
-      reportRevokedServedToken({
-        ...revoked,
-        provider: "openai-codex",
-        message,
-      }),
+      reportRevokedServedToken(
+        {
+          ...revoked,
+          provider: "openai-codex",
+          message,
+        },
+        accessDigest("codex-revoked-token"),
+      ),
   );
 
   expect(captured?.url).toBe(
@@ -276,7 +351,7 @@ test("does NOT report a credential this runtime owns locally", async () => {
       );
       writeFileSync(join(dir, "served-providers.json"), JSON.stringify([]));
     },
-    () => reportRevokedServedToken(revoked),
+    () => reportRevokedServedToken(revoked, accessDigest("local-tok")),
   );
   expect(captured).toBeNull();
 });
@@ -284,15 +359,19 @@ test("does NOT report a credential this runtime owns locally", async () => {
 test("does NOT report when serve mode is off", async () => {
   const captured = await withServeMode(
     (dir) => servedAnthropic(dir),
-    () => reportRevokedServedToken(revoked),
+    () => reportRevokedServedToken(revoked, accessDigest("served-access")),
     { serveMode: false },
   );
   expect(captured).toBeNull();
 });
 
-test("does NOT report an api_key credential", async () => {
+test("an api_key credential records no used token, so no report can fire", async () => {
   // An api_key has no revocation semantics worth acting on here; treating one
-  // as revoked would delete a key the user still wants.
+  // as revoked would delete a key the user still wants. The oauth-only gate is
+  // enforced at CAPTURE — every digest source (the credential store's
+  // request-time read, the Claude spawn env, the per-turn hydrated read)
+  // digests OAuth access tokens only — so an api_key turn reaches the reporter
+  // with `undefined` and skips.
   const captured = await withServeMode(
     (dir) => {
       writeFileSync(
@@ -304,7 +383,7 @@ test("does NOT report an api_key credential", async () => {
         JSON.stringify(["anthropic"]),
       );
     },
-    () => reportRevokedServedToken(revoked),
+    () => reportRevokedServedToken(revoked, undefined),
   );
   expect(captured).toBeNull();
 });
@@ -330,16 +409,16 @@ test("the same dead token is reported once per pod lifetime (HOUSTON-APP-530)", 
   }) as unknown as typeof globalThis.fetch;
   try {
     servedAnthropic(config.dataDir, "same-dead-token");
-    reportRevokedServedToken(revoked);
+    reportRevokedServedToken(revoked, accessDigest("same-dead-token"));
     await new Promise((r) => setTimeout(r, 10));
-    reportRevokedServedToken(revoked);
+    reportRevokedServedToken(revoked, accessDigest("same-dead-token"));
     await new Promise((r) => setTimeout(r, 10));
     expect(reports).toBe(1);
 
     // A DIFFERENT token (the workspace reconnected, then that one died too)
     // is a new fact and reports again.
     servedAnthropic(config.dataDir, "next-dead-token");
-    reportRevokedServedToken(revoked);
+    reportRevokedServedToken(revoked, accessDigest("next-dead-token"));
     await new Promise((r) => setTimeout(r, 10));
     expect(reports).toBe(2);
   } finally {
@@ -368,9 +447,9 @@ test("a failed report is not deduped — the next turn retries", async () => {
   }) as unknown as typeof globalThis.fetch;
   try {
     servedAnthropic(config.dataDir, "retry-dead-token");
-    reportRevokedServedToken(revoked);
+    reportRevokedServedToken(revoked, accessDigest("retry-dead-token"));
     await new Promise((r) => setTimeout(r, 10));
-    reportRevokedServedToken(revoked);
+    reportRevokedServedToken(revoked, accessDigest("retry-dead-token"));
     await new Promise((r) => setTimeout(r, 10));
     // The failed attempt un-marked itself; the second turn's report went out.
     expect(reports).toBe(2);
@@ -397,7 +476,9 @@ test("a failing control plane never throws into the caller", async () => {
   }) as unknown as typeof globalThis.fetch;
   try {
     servedAnthropic(config.dataDir);
-    expect(() => reportRevokedServedToken(revoked)).not.toThrow();
+    expect(() =>
+      reportRevokedServedToken(revoked, accessDigest("served-access")),
+    ).not.toThrow();
     await new Promise((r) => setTimeout(r, 10));
   } finally {
     globalThis.fetch = prevFetch;

--- a/packages/runtime/src/auth/report-revoked.ts
+++ b/packages/runtime/src/auth/report-revoked.ts
@@ -8,6 +8,7 @@ import {
   readServedProvidersAt,
   servedProvidersPathIn,
 } from "./auth-file";
+import { revocationConfirmed } from "./revocation-markers";
 import { servedScopeFor } from "./served-scope";
 
 /**
@@ -32,20 +33,38 @@ import { servedScopeFor } from "./served-scope";
  *     cause is the one that means "this token is dead forever" (see
  *     protocol/provider-error.ts).
  *  2. The provider's own words must CONFIRM the revocation, not merely read
- *     like one (`REVOCATION_CONFIRMED_PATTERNS`).
+ *     like one (`revocation-markers.ts`).
  *  3. Serve mode, and the provider must be in the SERVED manifest. A credential
  *     this runtime owns locally (a desktop keychain login) is none of the
  *     control plane's business, and reporting it would ask the store to delete
  *     a row that never backed this turn.
  *  4. OAuth only. An api_key has no revocation semantics worth acting on here,
  *     and treating one as revoked would delete a key the user still wants.
+ *     Enforced at CAPTURE: every `usedAccessDigest` source (the credential
+ *     store's request-time read, the Claude spawn env, the per-turn hydrated
+ *     read) digests OAuth access tokens only.
+ *
+ * `usedAccessDigest` is the digest of the token the FAILED turn actually ran
+ * on, captured at request/spawn preparation (auth/used-token.ts, PRODUCT-1319).
+ * The report names exactly that token — never whatever auth.json holds at
+ * report time: a serve sync or user reconnect between the 401 and this report
+ * swaps in a healthy replacement, and digesting the file then aimed the
+ * gateway's compare-and-delete at the FRESH credential. Undefined means the
+ * caller could not know the used token (the turn threw before any request
+ * resolved a credential) — then the report is SKIPPED: deleting an unverified
+ * target risks destroying a working credential workspace-wide, while a missed
+ * report only costs the pre-HOU-952 status quo (a retry on the next failed
+ * turn, or a manual reconnect).
  *
  * Fire-and-forget and never throws: this runs inside error handling for a turn
  * that has already failed, and a reporting hiccup must not replace the real
  * provider error the user needs to see.
  */
-export function reportRevokedServedToken(err: ProviderError): void {
-  void reportRevoked(err).catch(() => {});
+export function reportRevokedServedToken(
+  err: ProviderError,
+  usedAccessDigest: string | undefined,
+): void {
+  void reportRevoked(err, usedAccessDigest).catch(() => {});
 }
 
 /**
@@ -64,52 +83,10 @@ export function resetRevokedReportsForTest(): void {
   reported.clear();
 }
 
-/**
- * Message markers that CONFIRM a server-side revocation — the ONLY texts allowed
- * to trigger the workspace-wide delete.
- *
- * `token_revoked` is deliberately generous on the CARD side: both classifiers
- * (`ai/provider-error.ts` and `backends/claude/errors.ts`) also map loose
- * phrasings — "your session has ended", "please log in again" — to it, because
- * "your access was revoked, sign in again" is the right thing to SAY about any
- * terminal-looking 401. It is not the right thing to DO: providers reach for
- * that copy for transient auth blips too, and one such turn would otherwise
- * delete the credential for every runtime in the workspace.
- *
- * So presentation and destruction are split here, and the destructive half
- * takes only unambiguous, machine-emitted revocation markers:
- *  - `token_revoked` — the structured code providers return for it.
- *  - `has been revoked` / `access revoked` — the provider stating it outright in
- *    prose ("401 OAuth access token has been revoked"). ANCHORED phrases, never
- *    the bare word: "revoked" alone also matches a NEGATION ("the scope was not
- *    revoked") and unrelated fields ("revoked_scopes": []), each of which would
- *    delete a live credential for the whole workspace. Neither anchored phrase
- *    survives a negation — "has not been revoked" does not contain "has been
- *    revoked".
- *  - `app_session_terminated` — ChatGPT/Codex's structured code for a login
- *    session killed server-side (it rides ALONG with the loose prose above,
- *    which is exactly why the code, not the prose, is the signal).
- *  - `refresh_token_invalidated` — OpenAI's code for the same thing on the token
- *    endpoint; the host treats it as terminal too (`credentials/oauth-token-exchange.ts`).
- *
- * Prose like "session terminated" is deliberately NOT here: the harm is
- * lopsided. A missed report costs the user a manual reconnect (the pre-HOU-952
- * status quo); a false one destroys a working credential workspace-wide.
- */
-const REVOCATION_CONFIRMED_PATTERNS = [
-  "token_revoked",
-  "has been revoked",
-  "access revoked",
-  "app_session_terminated",
-  "refresh_token_invalidated",
-];
-
-function revocationConfirmed(message: string): boolean {
-  const lower = message.toLowerCase();
-  return REVOCATION_CONFIRMED_PATTERNS.some((p) => lower.includes(p));
-}
-
-async function reportRevoked(err: ProviderError): Promise<void> {
+async function reportRevoked(
+  err: ProviderError,
+  usedAccessDigest: string | undefined,
+): Promise<void> {
   if (err.kind !== "unauthenticated" || err.cause !== "token_revoked") return;
   if (!revocationConfirmed(err.message)) return;
   // Serve mode, read straight off config rather than through serve.ts's
@@ -131,13 +108,37 @@ async function reportRevoked(err: ProviderError): Promise<void> {
   );
   if (!served.includes(provider)) return;
 
-  const cred = readAuthFile(authPathIn(config.dataDir, key))[provider];
-  if (cred?.type !== "oauth" || !cred.access) return;
+  // The digest must name the token that PRODUCED the 401 (PRODUCT-1319) —
+  // threaded in by the caller from the turn's capture, never re-read from
+  // auth.json here: the file is mutable, and a re-serve or reconnect between
+  // the 401 and this report replaces the dead token with a healthy one whose
+  // deletion would sign the workspace out of a working credential. Unknown →
+  // skip (see reportRevokedServedToken); falling back to the file would risk
+  // exactly that deletion whenever a fresher token is already stored.
+  if (!usedAccessDigest) {
+    console.log(
+      `[serve] skipped the revoked-token report for ${provider}: the failed turn's token is unknown`,
+    );
+    return;
+  }
+  const digest = usedAccessDigest;
+  // Diagnostic only — the decision above never depends on the file. When the
+  // stored token already rotated past the failed one, say so: the gateway's
+  // compare-and-delete will no-op on the rotated row, which is the safety this
+  // parameter exists to guarantee.
+  const stored = readAuthFile(authPathIn(config.dataDir, key))[provider];
+  if (
+    stored?.type === "oauth" &&
+    stored.access &&
+    accessDigest(stored.access) !== digest
+  ) {
+    console.log(
+      `[serve] stored ${provider} token differs from the one the failed turn ran on; reporting the failed token's digest`,
+    );
+  }
   // WHICH row the gateway served us. Unknown (a pre-HOU-976 gateway sends no
   // scope) reads as the team row — the only thing it could have been.
   const scope = servedScopeFor(provider) ?? "team";
-
-  const digest = accessDigest(cred.access);
   const dedupe = `${key}:${provider}:${digest}`;
   if (reported.has(dedupe)) {
     console.log(

--- a/packages/runtime/src/auth/revocation-markers.ts
+++ b/packages/runtime/src/auth/revocation-markers.ts
@@ -1,0 +1,45 @@
+/**
+ * Message markers that CONFIRM a server-side revocation — the ONLY texts allowed
+ * to trigger the workspace-wide delete (`report-revoked.ts`).
+ *
+ * `token_revoked` is deliberately generous on the CARD side: both classifiers
+ * (`ai/provider-error.ts` and `backends/claude/errors.ts`) also map loose
+ * phrasings — "your session has ended", "please log in again" — to it, because
+ * "your access was revoked, sign in again" is the right thing to SAY about any
+ * terminal-looking 401. It is not the right thing to DO: providers reach for
+ * that copy for transient auth blips too, and one such turn would otherwise
+ * delete the credential for every runtime in the workspace.
+ *
+ * So presentation and destruction are split here, and the destructive half
+ * takes only unambiguous, machine-emitted revocation markers:
+ *  - `token_revoked` — the structured code providers return for it.
+ *  - `has been revoked` / `access revoked` — the provider stating it outright in
+ *    prose ("401 OAuth access token has been revoked"). ANCHORED phrases, never
+ *    the bare word: "revoked" alone also matches a NEGATION ("the scope was not
+ *    revoked") and unrelated fields ("revoked_scopes": []), each of which would
+ *    delete a live credential for the whole workspace. Neither anchored phrase
+ *    survives a negation — "has not been revoked" does not contain "has been
+ *    revoked".
+ *  - `app_session_terminated` — ChatGPT/Codex's structured code for a login
+ *    session killed server-side (it rides ALONG with the loose prose above,
+ *    which is exactly why the code, not the prose, is the signal).
+ *  - `refresh_token_invalidated` — OpenAI's code for the same thing on the token
+ *    endpoint; the host treats it as terminal too (`credentials/oauth-token-exchange.ts`).
+ *
+ * Prose like "session terminated" is deliberately NOT here: the harm is
+ * lopsided. A missed report costs the user a manual reconnect (the pre-HOU-952
+ * status quo); a false one destroys a working credential workspace-wide.
+ */
+const REVOCATION_CONFIRMED_PATTERNS = [
+  "token_revoked",
+  "has been revoked",
+  "access revoked",
+  "app_session_terminated",
+  "refresh_token_invalidated",
+];
+
+/** Whether the provider's own words CONFIRM a server-side revocation. */
+export function revocationConfirmed(message: string): boolean {
+  const lower = message.toLowerCase();
+  return REVOCATION_CONFIRMED_PATTERNS.some((p) => lower.includes(p));
+}

--- a/packages/runtime/src/auth/used-token.test.ts
+++ b/packages/runtime/src/auth/used-token.test.ts
@@ -1,0 +1,129 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { accessDigest } from "@houston/protocol/access-digest";
+import { expect, test } from "vitest";
+import { HoustonAuthStore } from "./credential-store";
+import {
+  currentUsedTokenDigest,
+  newUsedTokenCapture,
+  recordUsedToken,
+  runWithUsedTokenCapture,
+} from "./used-token";
+
+/**
+ * The used-token capture pins a revoked-token report to the token the FAILED
+ * turn ran on (PRODUCT-1319). What matters: only the digest is held (never the
+ * raw token), recording is per-turn (concurrent turns cannot overwrite each
+ * other's evidence), and the credential store records at pi's request-time
+ * read — the moment the token a request runs on is knowable.
+ */
+
+test("holds the DIGEST of the recorded token, never the raw value", () => {
+  const capture = newUsedTokenCapture();
+  capture.record("anthropic", "the-raw-token");
+  expect(capture.digestFor("anthropic")).toBe(accessDigest("the-raw-token"));
+  expect(capture.digestFor("anthropic")).not.toContain("the-raw-token");
+  expect(capture.digestFor("openai-codex")).toBeUndefined();
+});
+
+test("recordUsedToken writes into the ambient capture; a no-op outside a turn", () => {
+  // Outside a turn (login flows, status probes) there is nothing to record
+  // into — must not throw, must not leak into a later turn.
+  recordUsedToken("anthropic", "stray-token");
+
+  const capture = newUsedTokenCapture();
+  runWithUsedTokenCapture(capture, () => {
+    recordUsedToken("anthropic", "turn-token");
+    expect(currentUsedTokenDigest("anthropic")).toBe(
+      accessDigest("turn-token"),
+    );
+  });
+  expect(capture.digestFor("anthropic")).toBe(accessDigest("turn-token"));
+  // The stray pre-turn record never reached this turn's capture.
+  expect(capture.digestFor("anthropic")).not.toBe(accessDigest("stray-token"));
+  // And outside the subtree there is no ambient capture again.
+  expect(currentUsedTokenDigest("anthropic")).toBeUndefined();
+});
+
+test("concurrent turns record into THEIR OWN captures", async () => {
+  // A module-level "last read" map would let turn B's fresher read overwrite
+  // turn A's evidence between A's 401 and A's report — the exact window the
+  // per-turn holder closes.
+  const a = newUsedTokenCapture();
+  const b = newUsedTokenCapture();
+  await Promise.all([
+    runWithUsedTokenCapture(a, async () => {
+      await new Promise((r) => setTimeout(r, 1));
+      recordUsedToken("anthropic", "token-A");
+    }),
+    runWithUsedTokenCapture(b, async () => {
+      recordUsedToken("anthropic", "token-B");
+    }),
+  ]);
+  expect(a.digestFor("anthropic")).toBe(accessDigest("token-A"));
+  expect(b.digestFor("anthropic")).toBe(accessDigest("token-B"));
+});
+
+test("the credential store records an oauth read into the turn's capture", async () => {
+  // pi calls `read()` inside `prepareRequest` on every stream() — inside the
+  // turn's async subtree — so this IS the request-preparation capture point.
+  const dir = mkdtempSync(join(tmpdir(), "houston-used-token-"));
+  const authPath = join(dir, "auth.json");
+  writeFileSync(
+    authPath,
+    JSON.stringify({
+      anthropic: {
+        type: "oauth",
+        access: "read-token",
+        refresh: "",
+        expires: 0,
+      },
+      google: { type: "api_key", key: "AIza-key" },
+    }),
+  );
+  const store = new HoustonAuthStore(authPath);
+
+  const capture = newUsedTokenCapture();
+  await runWithUsedTokenCapture(capture, async () => {
+    await store.read("anthropic");
+    // api_key reads record nothing: an api_key has no revocation semantics
+    // the report may act on (the reporter's oauth gate, enforced at capture).
+    await store.read("google");
+  });
+  expect(capture.digestFor("anthropic")).toBe(accessDigest("read-token"));
+  expect(capture.digestFor("google")).toBeUndefined();
+});
+
+test("an OAuth refresh through modify() re-records the ROTATED token", async () => {
+  // pi's refresh runs through modify(); requests after it use the NEW token,
+  // so a 401 on that token must be reported under ITS digest, not the
+  // pre-refresh one.
+  const dir = mkdtempSync(join(tmpdir(), "houston-used-token-refresh-"));
+  const authPath = join(dir, "auth.json");
+  writeFileSync(
+    authPath,
+    JSON.stringify({
+      anthropic: {
+        type: "oauth",
+        access: "old-token",
+        refresh: "r",
+        expires: 0,
+      },
+    }),
+  );
+  const store = new HoustonAuthStore(authPath);
+
+  const capture = newUsedTokenCapture();
+  await runWithUsedTokenCapture(capture, async () => {
+    await store.read("anthropic");
+    expect(capture.digestFor("anthropic")).toBe(accessDigest("old-token"));
+    await store.modify("anthropic", async () => ({
+      type: "oauth",
+      access: "rotated-token",
+      refresh: "r",
+      expires: 0,
+    }));
+  });
+  expect(capture.digestFor("anthropic")).toBe(accessDigest("rotated-token"));
+});

--- a/packages/runtime/src/auth/used-token.ts
+++ b/packages/runtime/src/auth/used-token.ts
@@ -1,0 +1,81 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { accessDigest } from "@houston/protocol/access-digest";
+
+/**
+ * WHICH access token the current turn's provider requests actually ran on —
+ * captured at request preparation, per turn (PRODUCT-1319).
+ *
+ * The revoked-token report (`report-revoked.ts`) names the token it wants the
+ * control plane to compare-and-delete by digest. It used to re-read the
+ * mutable auth.json at REPORT time — but the failed turn ran on whatever token
+ * was stored at REQUEST time, and a serve sync or user reconnect between the
+ * 401 and the report swaps in a healthy replacement. Digesting the file then
+ * named the FRESH token, and the gateway's compare-and-delete
+ * correctly-but-disastrously destroyed the working credential (feeding a
+ * reconnect loop). This capture pins the digest to the token the failed
+ * request actually used.
+ *
+ * Only the DIGEST is ever held — the raw token is hashed at record time and
+ * never carried around (same never-ship-the-token rule as the report body).
+ *
+ * Turn-scoping mechanism + assumption: identical to `session/interaction.ts` —
+ * an explicit per-turn holder established via `AsyncLocalStorage` for the
+ * duration of `session.prompt()` (exec-turn.ts / turn-session.ts). The
+ * credential store's `read()` runs inside pi's `prepareRequest`, i.e. inside
+ * that same async subtree, so each concurrent turn records into ITS OWN
+ * holder — a module-level "last read" map would let a concurrent turn's
+ * fresher read overwrite the failed turn's evidence, re-opening the exact
+ * window this exists to close. Outside a turn (login flows, status probes,
+ * unit tests) there is no ambient holder and recording is a no-op.
+ *
+ * Only OAuth ACCESS tokens are recorded (the capture sites enforce this): an
+ * api_key has no revocation semantics the report may act on, mirroring the
+ * reporter's historical oauth-only gate.
+ */
+export interface UsedTokenCapture {
+  /** Digest `access` NOW and remember it as the token `provider` ran on. */
+  record(provider: string, access: string): void;
+  /** The recorded digest for `provider`, or undefined when never recorded. */
+  digestFor(provider: string): string | undefined;
+}
+
+/** A fresh, empty capture — one per turn (the fresh instance IS the reset). */
+export function newUsedTokenCapture(): UsedTokenCapture {
+  const digests = new Map<string, string>();
+  return {
+    record(provider, access) {
+      digests.set(provider, accessDigest(access));
+    },
+    digestFor(provider) {
+      return digests.get(provider);
+    },
+  };
+}
+
+const store = new AsyncLocalStorage<UsedTokenCapture>();
+
+/** Run `fn` with `capture` as the turn's ambient used-token record. */
+export function runWithUsedTokenCapture<T>(
+  capture: UsedTokenCapture,
+  fn: () => T,
+): T {
+  return store.run(capture, fn);
+}
+
+/**
+ * Record into the current turn's capture, if one is ambient. Called by the
+ * credential store at pi's request-time read (and after an OAuth refresh, so a
+ * mid-turn rotation attributes later requests to the NEW token); a no-op
+ * outside a turn.
+ */
+export function recordUsedToken(provider: string, access: string): void {
+  store.getStore()?.record(provider, access);
+}
+
+/**
+ * The digest of the token the current turn last resolved for `provider`, or
+ * undefined outside a turn / before any request read a credential.
+ */
+export function currentUsedTokenDigest(provider: string): string | undefined {
+  return store.getStore()?.digestFor(provider);
+}

--- a/packages/runtime/src/backends/claude/backend.ts
+++ b/packages/runtime/src/backends/claude/backend.ts
@@ -20,10 +20,18 @@ import { createSessionsStore } from "./sessions-store";
 import { buildSystemPrompt } from "./system-prompt";
 import { buildToolPolicy, makeCanUseTool } from "./tool-policy";
 
-/** A resolved Anthropic credential: an OAuth token or a pasted API key. */
+/**
+ * A resolved Anthropic credential: an OAuth token or a pasted API key.
+ * `accessDigest` is set ONLY when the value came from an OAUTH-typed store
+ * entry's access token (read-token.ts): it is what a revoked-token report
+ * names, captured at spawn preparation because the SDK subprocess env is built
+ * once per session — re-reading auth.json at failure time would digest
+ * whatever a re-serve stored since, not the token the failed turn ran on
+ * (PRODUCT-1319).
+ */
 export type ClaudeToken =
-  | { kind: "oauth-token"; value: string }
-  | { kind: "api-key"; value: string };
+  | { kind: "oauth-token"; value: string; accessDigest?: string }
+  | { kind: "api-key"; value: string; accessDigest?: string };
 
 /** Everything the Claude backend needs to open a session. */
 export interface ClaudeBackendDeps {
@@ -178,6 +186,9 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
         sessionsStore,
         model: toSdkModel(opts.model.id),
         thinkingLevel: opts.thinkingLevel,
+        // WHICH token the subprocess env carries, for the revoked-token
+        // report — every turn on this session runs on it (PRODUCT-1319).
+        usedAccessDigest: token?.accessDigest,
       });
     },
   };

--- a/packages/runtime/src/backends/claude/errors.test.ts
+++ b/packages/runtime/src/backends/claude/errors.test.ts
@@ -195,12 +195,47 @@ test("classifyText reports an unauthenticated failure like the enum path does", 
     provider: "anthropic",
     cause: "token_revoked",
   });
-  expect(reportRevokedServedToken).toHaveBeenCalledExactlyOnceWith(classified);
+  // No spawn-token digest was captured → the reporter is told so (undefined)
+  // and its unknown-token gate skips, rather than digesting a re-read of
+  // auth.json that may already hold a healthy replacement (PRODUCT-1319).
+  expect(reportRevokedServedToken).toHaveBeenCalledExactlyOnceWith(
+    classified,
+    undefined,
+  );
 });
 
 test("classifyText does not report non-auth failures", () => {
   classifyText("Internal Server Error", "m", 500);
   expect(reportRevokedServedToken).not.toHaveBeenCalled();
+});
+
+/**
+ * PRODUCT-1319: the report must name the token the failed turn RAN ON — the
+ * digest captured at spawn preparation (the subprocess env token) — so both
+ * seams thread it through to the reporter verbatim.
+ */
+test("both seams hand the spawn-time token digest to the reporter", () => {
+  const viaText = classifyText(
+    "401 OAuth access token has been revoked",
+    null,
+    null,
+    "digest-of-the-spawn-token",
+  );
+  expect(reportRevokedServedToken).toHaveBeenCalledWith(
+    viaText,
+    "digest-of-the-spawn-token",
+  );
+
+  vi.mocked(reportRevokedServedToken).mockClear();
+  const viaEnum = mapSdkError("authentication_failed", {
+    message: "401 OAuth access token has been revoked",
+    model: null,
+    usedAccessDigest: "digest-of-the-spawn-token",
+  });
+  expect(reportRevokedServedToken).toHaveBeenCalledExactlyOnceWith(
+    viaEnum,
+    "digest-of-the-spawn-token",
+  );
 });
 
 test("the verbatim provider text is logged once it is reduced to a card", () => {

--- a/packages/runtime/src/backends/claude/errors.ts
+++ b/packages/runtime/src/backends/claude/errors.ts
@@ -22,6 +22,15 @@ export interface SdkErrorContext {
   status?: number | null;
   /** Seconds until a rate limit resets, from a `rate_limit_event` when one arrived. */
   retryAfterSeconds?: number | null;
+  /**
+   * Digest of the OAuth access token the SDK subprocess authenticates with,
+   * captured at spawn preparation (backend.ts → read-token.ts). The
+   * revoked-token report names THIS token — never a fresh auth.json read,
+   * which a re-serve between the 401 and the report may have replaced
+   * (PRODUCT-1319). Undefined = the turn ran on an api_key or the config-dir
+   * credential, and the reporter skips.
+   */
+  usedAccessDigest?: string;
 }
 
 /**
@@ -64,10 +73,10 @@ export function mapSdkError(
     if (mapped.kind === "unauthenticated") {
       noteAuthFailure(mapped.provider);
       // A REVOKED served token is invisible to the control plane (HOU-952).
-      reportRevokedServedToken(mapped);
+      reportRevokedServedToken(mapped, ctx.usedAccessDigest);
     }
   }
-  return mapped ?? classifyText(message, model, status);
+  return mapped ?? classifyText(message, model, status, ctx.usedAccessDigest);
 }
 
 /** The enum-determined mappings; null falls through to the text classifier. */
@@ -131,11 +140,16 @@ function mapSdkEnum(
   }
 }
 
-/** Classify raw/untyped failure text (thrown errors, result-error subtypes). */
+/**
+ * Classify raw/untyped failure text (thrown errors, result-error subtypes).
+ * `usedAccessDigest` names the spawn-env token for the revoked-token report
+ * (see `SdkErrorContext.usedAccessDigest`).
+ */
 export function classifyText(
   message: string,
   model: string | null,
   status: number | null,
+  usedAccessDigest?: string,
 ): ProviderError {
   const classified = classifyProviderError({
     provider: PROVIDER,
@@ -152,7 +166,7 @@ export function classifyText(
     // pi/wire.ts do, or a revocation surfacing on this seam never heals
     // centrally and the workspace keeps serving the dead token
     // (PRODUCT-1307). The reporter's own gates keep this safe.
-    reportRevokedServedToken(classified);
+    reportRevokedServedToken(classified, usedAccessDigest);
   }
   return classified;
 }

--- a/packages/runtime/src/backends/claude/read-token.test.ts
+++ b/packages/runtime/src/backends/claude/read-token.test.ts
@@ -1,4 +1,5 @@
 import type { Credential } from "@earendil-works/pi-ai";
+import { accessDigest } from "@houston/protocol/access-digest";
 import { beforeEach, expect, test, vi } from "vitest";
 import type { HoustonAuthStore } from "../../auth/credential-store";
 import { readAnthropicToken } from "./read-token";
@@ -52,7 +53,10 @@ test("an unrecognized token prefix returns undefined AND logs the reason", () =>
 test("a served oauth credential maps its ACCESS token to an oauth-token", () => {
   // The connect-once serve path (managed cloud) writes pi's oauth variant with
   // a short-TTL access token and refresh="" — the SDK consumes the access
-  // token via CLAUDE_CODE_OAUTH_TOKEN exactly like a setup token.
+  // token via CLAUDE_CODE_OAUTH_TOKEN exactly like a setup token. It also
+  // carries the access token's digest, captured HERE (spawn preparation) so a
+  // revoked-token report can name the token the failed turn actually ran on
+  // instead of whatever a re-serve stored since (PRODUCT-1319).
   const token = readAnthropicToken(
     store({
       type: "oauth",
@@ -61,7 +65,23 @@ test("a served oauth credential maps its ACCESS token to an oauth-token", () => 
       expires: Date.now() + 60 * 60 * 1000,
     }),
   );
-  expect(token).toEqual({ kind: "oauth-token", value: "sk-ant-oat01-served" });
+  expect(token).toEqual({
+    kind: "oauth-token",
+    value: "sk-ant-oat01-served",
+    accessDigest: accessDigest("sk-ant-oat01-served"),
+  });
+});
+
+test("a PASTED token (api_key-typed entry) carries NO access digest", () => {
+  // Only OAUTH-typed store entries feed the revoked-token report (the
+  // reporter's oauth gate, enforced at capture) — a pasted setup token stored
+  // as api_key must stay digest-less even though it maps to an oauth-token env
+  // var.
+  const token = readAnthropicToken(
+    store({ type: "api_key", key: "sk-ant-oat01-pasted" }),
+  );
+  expect(token?.kind).toBe("oauth-token");
+  expect(token?.accessDigest).toBeUndefined();
 });
 
 test("an EXPIRED served oauth token is refused (falls back to the config dir)", () => {
@@ -85,7 +105,11 @@ test("an oauth entry with NO recorded expiry (expires=0) is served as-is", () =>
   const token = readAnthropicToken(
     store({ type: "oauth", access: "sk-ant-oat01-x", refresh: "", expires: 0 }),
   );
-  expect(token).toEqual({ kind: "oauth-token", value: "sk-ant-oat01-x" });
+  expect(token).toEqual({
+    kind: "oauth-token",
+    value: "sk-ant-oat01-x",
+    accessDigest: accessDigest("sk-ant-oat01-x"),
+  });
 });
 
 test("an oauth credential with an empty access token returns undefined AND logs", () => {

--- a/packages/runtime/src/backends/claude/read-token.ts
+++ b/packages/runtime/src/backends/claude/read-token.ts
@@ -1,3 +1,4 @@
+import { accessDigest } from "@houston/protocol/access-digest";
 import { ANTHROPIC_TOKEN_PREFIXES } from "../../auth/anthropic-setup-token";
 import type { HoustonAuthStore } from "../../auth/credential-store";
 import type { ClaudeToken } from "./backend";
@@ -83,7 +84,14 @@ export function readAnthropicToken(
       );
       return undefined;
     }
-    return classify(access);
+    const token = classify(access);
+    if (!token) return undefined;
+    // Capture WHICH token the subprocess will run on, digested at spawn
+    // preparation: the revoked-token report must name this token, not
+    // whatever auth.json holds when a turn later fails (PRODUCT-1319).
+    // OAUTH-typed store entries only — mirroring the reporter's oauth gate —
+    // so the api_key branch above stays digest-less by design.
+    return { ...token, accessDigest: accessDigest(access) };
   }
 
   console.warn(

--- a/packages/runtime/src/backends/claude/session.ts
+++ b/packages/runtime/src/backends/claude/session.ts
@@ -27,6 +27,13 @@ export interface ClaudeSessionDeps {
   /** Initial SDK model string. */
   model: string;
   thinkingLevel?: ThinkingLevel;
+  /**
+   * Digest of the OAuth access token in the subprocess env (the token every
+   * turn on this session runs on) — what a revoked-token report names.
+   * Undefined when the session runs on an api_key or the config-dir
+   * credential, where the report must not fire (PRODUCT-1319).
+   */
+  usedAccessDigest?: string;
 }
 
 const errMessage = (err: unknown): string =>
@@ -125,6 +132,7 @@ export class ClaudeSession implements HarnessSession {
       onContextTokens: (t) => {
         this.contextTokens = t;
       },
+      usedAccessDigest: this.deps.usedAccessDigest,
     });
     let capturedSessionId: string | undefined;
     // True once this turn has surfaced a provider_error (from `translate`), so a
@@ -171,7 +179,12 @@ export class ClaudeSession implements HarnessSession {
       // typed provider_error rather than rethrow, so the turn never dies silently.
       this.emit({
         type: "provider_error",
-        data: classifyText(errMessage(err), this.model, null),
+        data: classifyText(
+          errMessage(err),
+          this.model,
+          null,
+          this.deps.usedAccessDigest,
+        ),
       });
     } finally {
       if (capturedSessionId)

--- a/packages/runtime/src/backends/claude/translate.ts
+++ b/packages/runtime/src/backends/claude/translate.ts
@@ -20,10 +20,16 @@ export { normalizeUsage };
 type AssistantMsg = Extract<SDKMessage, { type: "assistant" }>;
 type ResultMsg = Extract<SDKMessage, { type: "result" }>;
 
-/** Callbacks a translator fires for state that is not a wire frame. */
+/** Callbacks + per-session context a translator carries beside the stream. */
 export interface TranslatorCallbacks {
   /** Latest observed context fill (from usage frames + compact boundaries). */
   onContextTokens(tokens: number): void;
+  /**
+   * Digest of the OAuth access token the SDK subprocess authenticates with —
+   * threaded into every error classification so a revoked-token report names
+   * the token this turn actually ran on (PRODUCT-1319).
+   */
+  usedAccessDigest?: string;
 }
 
 /**
@@ -202,6 +208,7 @@ export function createStreamTranslator(cb: TranslatorCallbacks) {
           message: text || `Claude error: ${msg.error}`,
           model: msg.message?.model ?? null,
           retryAfterSeconds: lastRateLimitRetry,
+          usedAccessDigest: cb.usedAccessDigest,
         }),
       },
     ];
@@ -228,7 +235,7 @@ export function createStreamTranslator(cb: TranslatorCallbacks) {
           : null;
       out.push({
         type: "provider_error",
-        data: classifyText(message, null, status),
+        data: classifyText(message, null, status, cb.usedAccessDigest),
       });
     }
     return out;

--- a/packages/runtime/src/backends/pi/wire.test.ts
+++ b/packages/runtime/src/backends/pi/wire.test.ts
@@ -4,12 +4,23 @@ import type {
   UserMessage,
 } from "@earendil-works/pi-ai";
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import {
   authFailureActive,
   resetAuthFailures,
 } from "../../auth/credential-health";
+import { reportRevokedServedToken } from "../../auth/report-revoked";
+import {
+  newUsedTokenCapture,
+  runWithUsedTokenCapture,
+} from "../../auth/used-token";
 import { createWireTranslator, normalizeUsage, toWire } from "./wire";
+
+// The reporter is a workspace-wide DELETE trigger; here only its arguments are
+// under test (its own gates live in report-revoked.test.ts).
+vi.mock("../../auth/report-revoked", () => ({
+  reportRevokedServedToken: vi.fn(),
+}));
 
 /** A valid pi `Usage` for fixtures; `cost` is required by the type. */
 function usage(partial: Partial<Usage>): Usage {
@@ -174,6 +185,50 @@ test("toWire maps an errored turn_end to a typed provider_error frame", () => {
         "OpenAI API error (401): Your session has ended. Please log in again. (app_session_terminated)",
     },
   });
+});
+
+test("toWire reports an auth failure under the digest of the token the TURN ran on (PRODUCT-1319)", () => {
+  // The turn's used-token capture — filled by the credential store at pi's
+  // request-time read, inside this same async subtree — is what names the
+  // failed token. Re-reading auth.json at report time would digest whatever a
+  // re-serve stored since, aiming the gateway's compare-and-delete at a fresh,
+  // healthy credential.
+  vi.mocked(reportRevokedServedToken).mockClear();
+  const capture = newUsedTokenCapture();
+  capture.record("openai-codex", "the-token-that-401d");
+  runWithUsedTokenCapture(capture, () => {
+    toWire(
+      turnEnd(
+        failedAssistantMessage(
+          "error",
+          "OpenAI API error (401): Your session has ended. Please log in again. (app_session_terminated)",
+          { provider: "openai-codex", model: "gpt-5.1-codex" },
+        ),
+      ),
+    );
+  });
+  expect(reportRevokedServedToken).toHaveBeenCalledExactlyOnceWith(
+    expect.objectContaining({ kind: "unauthenticated" }),
+    capture.digestFor("openai-codex"),
+  );
+
+  // Outside a turn's capture the used token is unknown — said so explicitly,
+  // and the reporter's unknown-token gate skips.
+  vi.mocked(reportRevokedServedToken).mockClear();
+  toWire(
+    turnEnd(
+      failedAssistantMessage(
+        "error",
+        "OpenAI API error (401): Your session has ended. Please log in again. (app_session_terminated)",
+        { provider: "openai-codex", model: "gpt-5.1-codex" },
+      ),
+    ),
+  );
+  expect(reportRevokedServedToken).toHaveBeenCalledExactlyOnceWith(
+    expect.objectContaining({ kind: "unauthenticated" }),
+    undefined,
+  );
+  resetAuthFailures();
 });
 
 test("toWire marks raw openai auth failures against openai-codex", () => {

--- a/packages/runtime/src/backends/pi/wire.ts
+++ b/packages/runtime/src/backends/pi/wire.ts
@@ -10,6 +10,7 @@ import { logProviderError } from "../../ai/provider-error-log";
 import { canonicalPinProvider } from "../../ai/providers";
 import { noteAuthFailure } from "../../auth/credential-health";
 import { reportRevokedServedToken } from "../../auth/report-revoked";
+import { currentUsedTokenDigest } from "../../auth/used-token";
 
 /**
  * Normalize pi's per-message `Usage` into our provider-agnostic `TokenUsage`.
@@ -233,7 +234,15 @@ export function toWire(e: AgentSessionEvent): WireEvent | null {
         if (classified.kind === "unauthenticated") {
           noteAuthFailure(canonicalPinProvider(classified.provider));
           // A REVOKED served token is invisible to the control plane (HOU-952).
-          reportRevokedServedToken(classified);
+          // Named by the digest of the token the failed request actually ran
+          // on — recorded at pi's request-time credential read, inside this
+          // same turn subtree (auth/used-token.ts, PRODUCT-1319). Keyed by
+          // `classified.provider` (= pi's `msg.provider`), the same id pi read
+          // the credential under.
+          reportRevokedServedToken(
+            classified,
+            currentUsedTokenDigest(classified.provider),
+          );
         }
         return { type: "provider_error", data: classified };
       }

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -539,8 +539,41 @@ test("an auth throw marks the RESOLVED provider unusable and reports it revoked"
 
   // Symmetry with the clean path's clearAuthFailure(model.provider).
   expect(noteAuthFailure).toHaveBeenCalledWith("openai-codex");
+  // The throw happened BEFORE any request read a credential, so the used
+  // token is unknown — passed as such, and the reporter's unknown-token gate
+  // skips rather than deleting an unverified target (PRODUCT-1319).
   expect(reportRevokedServedToken).toHaveBeenCalledWith(
     expect.objectContaining({ provider: "openai-codex" }),
+    undefined,
+  );
+});
+
+/**
+ * PRODUCT-1319: a throw AFTER the turn's requests ran (e.g. pi rejecting the
+ * prompt once the provider confirmed a revocation) must report the token those
+ * requests actually used — recorded into the turn's capture by the credential
+ * store at request time, and still readable from the catch after the prompt's
+ * async subtree unwound.
+ */
+test("an auth throw after a request reports the digest of the token the turn ran on", async () => {
+  const { recordUsedToken } = await import("../auth/used-token");
+  const { accessDigest } = await import("@houston/protocol/access-digest");
+  const id = "exec-throw-used-token";
+  const conv = fakeConv(() => {
+    // Stands in for the credential store's request-time read, which runs
+    // inside prompt() — i.e. inside the turn's used-token capture.
+    recordUsedToken("openai", "the-token-that-401d");
+    throw new Error("401 OAuth access token has been revoked");
+  });
+
+  await execTurn(conv, id, "turn-1", "hey", {
+    author: undefined,
+    priorAuthors: [],
+  });
+
+  expect(reportRevokedServedToken).toHaveBeenCalledWith(
+    expect.objectContaining({ provider: "openai", kind: "unauthenticated" }),
+    accessDigest("the-token-that-401d"),
   );
 });
 

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -22,6 +22,10 @@ import {
 import { recordTokenSpend } from "../ai/usage/ledger";
 import { clearAuthFailure, noteAuthFailure } from "../auth/credential-health";
 import { reportRevokedServedToken } from "../auth/report-revoked";
+import {
+  newUsedTokenCapture,
+  runWithUsedTokenCapture,
+} from "../auth/used-token";
 import { config } from "../config";
 import {
   appendAssistantMessage,
@@ -244,6 +248,14 @@ export async function execTurn(
   const attributedProvider = (fallback: string) =>
     turnProvider ??
     (pin?.provider ? canonicalPinProvider(pin.provider) : fallback);
+  /**
+   * WHICH access token this turn's provider requests ran on, recorded by the
+   * credential store at pi's request-time read (auth/used-token.ts,
+   * PRODUCT-1319). Held OUTSIDE the prompt's async subtree so the catch — which
+   * runs after that subtree unwinds — can still name the failed token when it
+   * reports a revocation. Fresh per turn: the fresh instance is the reset.
+   */
+  const usedTokens = newUsedTokenCapture();
   try {
     // Resolve the model for THIS turn from current settings (a routine's
     // provider/model pin wins, else the workspace's active provider/model).
@@ -474,7 +486,12 @@ export async function execTurn(
               { provider: model.provider, model: model.id },
               () =>
                 runWithInteractionCapture(interaction, () =>
-                  conv.session.prompt(promptText),
+                  // The used-token capture spans the prompt so the credential
+                  // store's request-time reads record into THIS turn's holder
+                  // (auth/used-token.ts, PRODUCT-1319).
+                  runWithUsedTokenCapture(usedTokens, () =>
+                    conv.session.prompt(promptText),
+                  ),
                 ),
             ),
           ),
@@ -679,7 +696,11 @@ export async function execTurn(
     ) {
       noteAuthFailure(canonicalPinProvider(thrown.provider));
       // A REVOKED served token is invisible to the control plane (HOU-952).
-      reportRevokedServedToken(thrown);
+      // Named by the token the turn's requests actually ran on; a throw
+      // BEFORE any request read a credential (pi's prompt-time guard, a bad
+      // pin) recorded nothing, and the reporter then skips — the turn ran on
+      // no served token, so there is nothing safe to delete (PRODUCT-1319).
+      reportRevokedServedToken(thrown, usedTokens.digestFor(thrown.provider));
     }
     const typed = thrown.kind !== "unknown" ? thrown : undefined;
     appendAssistantMessage(id, assistantText, {

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -15,8 +15,13 @@ import { registerCustomProviderIfConfigured } from "../ai/openai-compatible";
 import { classifyProviderError } from "../ai/provider-error";
 import { logProviderError } from "../ai/provider-error-log";
 import { ensureQwenRuntimeProvider } from "../ai/qwen-dashscope";
+import { readAuthFile } from "../auth/auth-file";
 import { clearAuthFailure, noteAuthFailure } from "../auth/credential-health";
 import { reportRevokedServedToken } from "../auth/report-revoked";
+import {
+  newUsedTokenCapture,
+  runWithUsedTokenCapture,
+} from "../auth/used-token";
 import { createPiBackend } from "../backends/pi/backend";
 import { config } from "../config";
 import {
@@ -144,6 +149,18 @@ export async function runPiTurn(
   // the client like any other) and is persisted on the assistant message so the
   // inline card survives a reload of this cloud conversation.
   let providerError: ProviderError | undefined;
+  /**
+   * WHICH access token this turn ran on, for the revoked-token report
+   * (auth/used-token.ts, PRODUCT-1319). This path's `ModelRuntime` uses pi's
+   * OWN file-backed store (not `HoustonAuthStore`), so nothing records at
+   * request time — instead the capture is SEEDED from the hydrated per-request
+   * auth.json below. That read is exact here: the root is a throwaway copy
+   * exclusive to this request, and its served entries are access-only (Gate
+   * #2, no refresh token), so no re-serve or refresh can rotate the token
+   * between the seed and a failure. Held outside the try so the catch can
+   * still name the failed token.
+   */
+  const usedTokens = newUsedTokenCapture();
   try {
     // Per-turn model/auth runtime over the hydrated throwaway data dir. The
     // default file-backed credential store reads the hydrated auth.json; the
@@ -184,6 +201,12 @@ export async function runPiTurn(
       : null;
 
     const model = resolveTurnModel(dataDir, provider, pin?.model);
+    // Seed the used-token capture with the credential this turn will run on
+    // (see the declaration above). OAuth access only — an api_key has no
+    // revocation semantics the report may act on.
+    const turnCred = readAuthFile(join(dataDir, "auth.json"))[provider];
+    if (turnCred?.type === "oauth" && turnCred.access)
+      usedTokens.record(provider, turnCred.access);
     // Ground-truth diagnostic: provider + model + the model's actual API base URL
     // (opencode.ai/zen/go/v1 = OpenCode Go, openai/chatgpt = Codex). Unambiguous,
     // unlike asking the model itself.
@@ -270,7 +293,11 @@ export async function runPiTurn(
     // records into it. Read after prompt() resolves, returned on the outcome.
     const interaction = newInteractionHolder();
     try {
-      await runWithInteractionCapture(interaction, () => session.prompt(text));
+      // The used-token capture spans the prompt so the streamed error path
+      // (pi/wire.ts) reads THIS turn's seeded token when it reports.
+      await runWithInteractionCapture(interaction, () =>
+        runWithUsedTokenCapture(usedTokens, () => session.prompt(text)),
+      );
     } finally {
       signal?.removeEventListener("abort", onAbort);
       unsub();
@@ -364,7 +391,10 @@ export async function runPiTurn(
       if (thrown.kind === "unauthenticated") {
         noteAuthFailure(thrown.provider);
         // A REVOKED served token is invisible to the control plane (HOU-952).
-        reportRevokedServedToken(thrown);
+        // Named by the seeded at-failure token; a throw before the seed (a
+        // bad model resolution) recorded nothing and the reporter skips
+        // (PRODUCT-1319).
+        reportRevokedServedToken(thrown, usedTokens.digestFor(thrown.provider));
       }
       if (thrown.kind !== "unknown") {
         appendAssistantMessageAt(


### PR DESCRIPTION
## Root cause

`reportRevokedServedToken` (`packages/runtime/src/auth/report-revoked.ts`) re-read the mutable `auth.json` at REPORT time and digested whatever token was currently stored. The failed turn ran on token A; if a re-serve or user reconnect replaced A with healthy B between the 401 and the report, the report carried B's digest — and the gateway's compare-and-delete (`packages/host/src/routes/credential-revoked.ts`) correctly-but-disastrously deleted the fresh credential, potentially feeding a reconnect loop.

## Fix

The report now carries the digest of the token that actually produced the 401, captured at request/spawn preparation and threaded to `reportRevokedServedToken` as an explicit parameter.

**Capture** (`packages/runtime/src/auth/used-token.ts`, new): a per-turn holder established via `AsyncLocalStorage` for the duration of `session.prompt()` — same mechanism as the interaction/acting-context captures, so concurrent turns can never overwrite each other's evidence. Only the digest is held; the raw token is hashed at record time and never carried around.

Per caller (each audited):
- **pi, streamed** (`backends/pi/wire.ts`): `HoustonAuthStore.read()` — which pi calls inside `prepareRequest` on every `stream()`, i.e. the exact moment the request's token is resolved — records into the ambient capture; `modify()` re-records after an OAuth refresh so a mid-turn rotation attributes later requests to the NEW token. `exec-turn.ts` establishes the capture around the prompt; `toWire` reads it when it classifies the failure.
- **pi, thrown** (`session/exec-turn.ts` catch): passes the same capture. A throw before any request read a credential (pi's prompt-time guard, a bad pin) recorded nothing → the reporter skips.
- **Claude** (`backends/claude/errors.ts`, both `mapSdkError` and `classifyText`): the subprocess env token is fixed at session creation, so the digest is captured there — `read-token.ts` digests an OAUTH-typed store entry's access (api_key-typed entries stay digest-less, preserving the reporter's oauth gate) and it rides `ClaudeToken.accessDigest` → `ClaudeSessionDeps` → the stream translator / thrown-error seam.
- **Per-turn cloud runtime** (`turn/turn-session.ts`): uses pi's own file-backed store, so the capture is seeded from the hydrated per-request `auth.json` — exact by construction: the throwaway root is exclusive to the request and its served entries are access-only (no refresh can rotate them mid-turn).
- **Serve-sync dead-key reporter** (`auth/served-key-guard.ts`): already digests the served credential it was handed — carries the at-failure token by construction, unchanged.

**Reporter**: all existing gates kept (strict revocation markers — moved verbatim to `auth/revocation-markers.ts` for the file-size limit —, serve mode, served-manifest provenance, per-pod dedupe; the oauth-only gate is now enforced at the capture sites). When the used token is UNKNOWN the report is **skipped**, never derived from the file: deleting an unverified target risks the same disaster this PR fixes, while a missed report only costs the pre-HOU-952 status quo (a retry on the next failed turn). A diagnostic log line notes when the stored token has already rotated past the failed one.

## Tests

- `report-revoked.test.ts`: report names the FAILED token when the store rotated between failure and report; unknown at-failure token + swapped store → no report; report still fires when the local entry is already gone (central row may live on); all existing gate tests updated to thread the digest.
- `used-token.test.ts` (new): digest-only storage, ambient no-op outside a turn, per-turn isolation under concurrency, store `read()` records oauth (not api_key), `modify()` re-records the rotated token.
- `wire.test.ts`: streamed auth failure reports under the turn's recorded digest; outside a capture it reports `undefined` (reporter skips).
- `exec-turn.test.ts`: pre-request throw reports `undefined`; post-request throw reports the recorded digest.
- `errors.test.ts` / `read-token.test.ts`: both Claude seams thread the spawn-time digest; oauth-typed entries carry `accessDigest`, pasted api_key-typed entries do not.

`pnpm --filter @houston/runtime --filter @houston/host --filter @houston/domain test`: 118+155+16 files, 2719 passing. `tsc --noEmit` clean for runtime + host, full workspace `pnpm -r typecheck` clean (pre-commit), Biome clean, `pnpm check:boundaries` OK.

Fixes PRODUCT-1319