### PR TITLE
ci: Houston routine schedules the daily cut; agent-written release notes (PRODUCT-1329)

### DIFF
--- a/.github/workflows/daily-cloud-cut.yml
+++ b/.github/workflows/daily-cloud-cut.yml
@@ -19,8 +19,15 @@
 #      version label. Pushing an `engine-pod-v*` tag manually remains only the
 #      break-glass prod engine roll.
 #
-# This workflow owns ONLY step 1, on a schedule, so a fresh draft is waiting when
-# the team opens the 08:30 daily.
+# This workflow owns ONLY step 1. It has NO schedule of its own: the scheduler
+# is a Houston routine (PRODUCT-1329) that dispatches this workflow every
+# weekday morning, watches the run, writes the user-facing release notes, and
+# posts the outcome to Slack — see knowledge-base/daily-cut-routine.md for the
+# routine prompt + setup. GitHub's cron queue was the previous scheduler and
+# was dropped deliberately: its best-effort delivery ran 30–120 min late
+# (HOU-1013), while Houston's cron fires on time — and the release train is
+# exactly the kind of job Houston exists to run. workflow_dispatch is therefore
+# the ONLY trigger: the routine's daily dispatch, or a human's manual cut.
 #
 # WHY A PAT (RELEASE_CUT_TOKEN), NOT GITHUB_TOKEN:
 #   A tag pushed with the default GITHUB_TOKEN does NOT trigger other workflows —
@@ -33,20 +40,6 @@
 #   the write we need is the PAT's, not the job token's. (Read-only check-run
 #   queries still use GITHUB_TOKEN; those don't need to trigger anything.)
 #
-# WHY WEEKDAYS-ONLY AT 10:22 UTC (AND NOT ON A ROUND MINUTE):
-#   The team QAs in the 08:30 America/Bogota daily, which runs Mon–Fri. Bogotá is
-#   UTC-5 all year (Colombia observes no DST). GitHub's schedule queue is
-#   best-effort: at the previous 11:52 UTC slot the observed delivery delay was
-#   +88 to +128 min (avg ~103), so the cut ACTUALLY started 08:20–09:00 Bogotá —
-#   on top of the daily, with no draft ready (HOU-1013). The target is a cut
-#   that actually starts ~07:05 Bogotá (12:05 UTC), so the nominal slot is
-#   12:05 minus the average delay: 10:22 UTC == 05:22 Bogotá. With the observed
-#   delay range the cut starts 06:50–07:30 Bogotá, and the ~30-min build has
-#   the draft ready by ~08:00. Firing early is harmless (the draft just waits);
-#   firing after 08:30 is the failure mode. The :22 minute is deliberate:
-#   :00/:15/:30/:45 are the most congested cron slots on GitHub and get the
-#   worst delays. `cron: '1-5'` skips weekends — no daily, no cut.
-#
 # WHY TAG-ONLY PUSH:
 #   main is a protected branch; the automation cannot (and must not) push commits
 #   to it. The release commit is created locally on the runner and referenced
@@ -54,22 +47,37 @@
 #   sees the bumped versions without the commit ever landing on main. This
 #   mirrors the manual cut exactly.
 #
-# workflow_dispatch is the manual / off-schedule path: run it by hand to cut a
-# release outside the morning window, or pass an explicit `version` to override
-# the computed next patch (e.g. to jump a minor). Same guards apply.
+# RELEASE NOTES INPUTS (the agent-authored path):
+#   The dispatcher may hand in user-facing release notes. When `notes` is set,
+#   the cut writes it to .github/release-notes/<version>.md INSIDE the release
+#   commit (with optional es/pt siblings), which release.yml treats as
+#   author-written notes: used verbatim as the release body AND embedded in the
+#   updater's latest.json, so agent-written notes reach the in-app update
+#   dialog. Translations attach only alongside `notes` — release.yml fails a
+#   translation with no English source, so the empty-`notes` case stays the
+#   auto-generated changelog exactly as before. workflow_dispatch caps the
+#   whole inputs payload at 64 KB; notes are a short product summary, not a
+#   changelog, so this is never a real limit.
 
 name: Daily cloud cut
 
 on:
-  schedule:
-    # 10:22 UTC, Mon–Fri == 05:22 America/Bogota (UTC-5, no DST). Nominal slot
-    # is ~103 min before the ~07:05 Bogotá target because GitHub's cron queue
-    # delivers that late — see the header.
-    - cron: "22 10 * * 1-5"
   workflow_dispatch:
     inputs:
       version:
         description: "Override the computed next version (semver, e.g. 0.5.18). Leave blank to auto-bump the patch of the latest cloud-v* tag."
+        required: false
+        type: string
+      notes:
+        description: "User-facing release notes (markdown, English). Written to .github/release-notes/<version>.md in the release commit and used verbatim by release.yml. Leave blank for the auto-generated changelog."
+        required: false
+        type: string
+      notes_es:
+        description: "Latin-American Spanish translation of the notes (requires `notes`)."
+        required: false
+        type: string
+      notes_pt:
+        description: "Brazilian Portuguese translation of the notes (requires `notes`)."
         required: false
         type: string
 
@@ -250,26 +258,52 @@ jobs:
 
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      # 6. Cut: bump every version-bearing file, commit the release, tag it, and
-      #    push ONLY the tag. version.sh edits tracked files in place; `git add -u`
-      #    stages exactly those. The push is tag-only — main is protected and the
-      #    release commit is meant to live solely under the tag (see header). The
-      #    push authenticates via the credential helper from step 1 reading
-      #    RELEASE_CUT_TOKEN from this step's env (checkout persisted nothing,
-      #    so the PAT is the ONLY credential in play) — a PAT push is what makes
-      #    release.yml fire.
+      # 6. Cut: bump every version-bearing file, drop in any dispatcher-authored
+      #    release notes, commit the release, tag it, and push ONLY the tag.
+      #    version.sh edits tracked files in place; `git add -u` stages exactly
+      #    those — the notes files are NEW and need their explicit `git add`.
+      #    Notes land at .github/release-notes/<version>[.es|.pt].md, the
+      #    authored-notes path release.yml prefers over the auto-changelog (see
+      #    header). A translation without English notes is rejected HERE, not 30
+      #    build-minutes later by release.yml's own guard. The push is tag-only —
+      #    main is protected and the release commit is meant to live solely under
+      #    the tag (see header). The push authenticates via the credential helper
+      #    from step 1 reading RELEASE_CUT_TOKEN from this step's env (checkout
+      #    persisted nothing, so the PAT is the ONLY credential in play) — a PAT
+      #    push is what makes release.yml fire.
       - name: Cut release commit + tag
         id: cut
         if: ${{ steps.newcommits.outputs.proceed == 'true' }}
         env:
           VERSION: ${{ steps.version.outputs.version }}
           RELEASE_CUT_TOKEN: ${{ secrets.RELEASE_CUT_TOKEN }}
+          NOTES: ${{ inputs.notes }}
+          NOTES_ES: ${{ inputs.notes_es }}
+          NOTES_PT: ${{ inputs.notes_pt }}
         run: |
           set -euo pipefail
           git config user.name "houston-release-bot"
           git config user.email "release-bot@users.noreply.github.com"
 
           ./scripts/version.sh "${VERSION}"
+
+          if [ -z "${NOTES}" ] && { [ -n "${NOTES_ES}" ] || [ -n "${NOTES_PT}" ]; }; then
+            echo "::error::notes_es/notes_pt were provided without English notes. release.yml refuses translations with no English source, so the build would fail — pass \`notes\` too."
+            exit 1
+          fi
+          if [ -n "${NOTES}" ]; then
+            printf '%s\n' "${NOTES}" > ".github/release-notes/${VERSION}.md"
+            git add ".github/release-notes/${VERSION}.md"
+            echo "Wrote authored release notes to .github/release-notes/${VERSION}.md"
+            if [ -n "${NOTES_ES}" ]; then
+              printf '%s\n' "${NOTES_ES}" > ".github/release-notes/${VERSION}.es.md"
+              git add ".github/release-notes/${VERSION}.es.md"
+            fi
+            if [ -n "${NOTES_PT}" ]; then
+              printf '%s\n' "${NOTES_PT}" > ".github/release-notes/${VERSION}.pt.md"
+              git add ".github/release-notes/${VERSION}.pt.md"
+            fi
+          fi
 
           git add -u
           git commit -m "release: v${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,7 @@
 #   LINEAR_API_KEY                     — Linear API key for in-app "Report bug" issue creation
 #   LINEAR_TEAM_ID                     — Linear team UUID for in-app "Report bug" issues
 #   SLACK_RELEASE_WEBHOOK_URL          — Slack incoming-webhook to ping the team when a draft release is built. FALLBACK only on the cloud channel: skipped when HOUSTON_DRAFT_WEBHOOK_URL handled the announcement.
-#   HOUSTON_DRAFT_WEBHOOK_URL          — minted wake URL of the Houston routine that announces a ready cloud draft (PRODUCT-1329). Set → Houston owns the Slack post (as houston_bot); unset or POST fails → the plain Slack ping above runs instead.
-#   HOUSTON_DRAFT_WEBHOOK_SECRET       — the secret revealed with that URL, sent as the webhook's auth header
+#   HOUSTON_DRAFT_WEBHOOK_URL          — minted wake URL of the Houston routine that announces a ready cloud draft (PRODUCT-1329). Its last path segment IS the routine's secret, so the whole URL is a credential (no auth header). Set → Houston owns the Slack post (as houston_bot); unset or POST fails → the plain Slack ping above runs instead.
 #   SENTRY_DSN                         — Sentry crash reporting DSN
 #   SENTRY_AUTH_TOKEN                  — Sentry CLI auth token (org-scoped, perms: project:releases, project:read, org:read). Used to upload source maps + Rust debug symbols and create/finalize releases. Empty → skip the Sentry upload step (forks, personal builds).
 #   POSTHOG_PERSONAL_API_KEY           — PostHog personal API key (scope: annotation:write) used by the finalize job to mark every release on PostHog charts. Empty → skip the annotation step.
@@ -2204,7 +2203,6 @@ jobs:
         if: ${{ success() && startsWith(github.ref_name, 'cloud-v') }}
         env:
           HOUSTON_WEBHOOK_URL: ${{ secrets.HOUSTON_DRAFT_WEBHOOK_URL }}
-          HOUSTON_WEBHOOK_SECRET: ${{ secrets.HOUSTON_DRAFT_WEBHOOK_SECRET }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
@@ -2231,14 +2229,13 @@ jobs:
               staging_dmg: $staging_dmg, prod_dmg: $prod_dmg, run_url: $run_url, notes: $notes}' \
             > houston-payload.json
 
-          # The gateway's webhook auth header is owned by the cloud repo's C9
-          # contract, not this one. Sending the minted secret under both accepted
-          # spellings costs nothing (an unknown header is ignored) and keeps this
-          # workflow from hard-coupling to a contract it cannot see.
+          # No auth header: the gateway mints the routine's secret as the URL's
+          # last path segment, so the URL IS the credential (verified against
+          # gateway.gethouston.ai — 200 {"status":"accepted"}). It is therefore
+          # a secret in full, never echoed; GitHub masks it in logs. Rotate by
+          # re-minting the routine's webhook key and updating the repo secret.
           if curl -sS --fail-with-body -X POST "${HOUSTON_WEBHOOK_URL}" \
               -H 'Content-Type: application/json' \
-              -H "Authorization: Bearer ${HOUSTON_WEBHOOK_SECRET}" \
-              -H "x-houston-webhook-secret: ${HOUSTON_WEBHOOK_SECRET}" \
               --data @houston-payload.json; then
             echo "handed_off=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Houston woken for the cloud-v${VERSION} draft announcement."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,9 @@
 #                                        literal in this file. Empty/unused on the local `v*` channel.
 #   LINEAR_API_KEY                     — Linear API key for in-app "Report bug" issue creation
 #   LINEAR_TEAM_ID                     — Linear team UUID for in-app "Report bug" issues
-#   SLACK_RELEASE_WEBHOOK_URL          — Slack incoming-webhook to ping the team when a draft release is built
+#   SLACK_RELEASE_WEBHOOK_URL          — Slack incoming-webhook to ping the team when a draft release is built. FALLBACK only on the cloud channel: skipped when HOUSTON_DRAFT_WEBHOOK_URL handled the announcement.
+#   HOUSTON_DRAFT_WEBHOOK_URL          — minted wake URL of the Houston routine that announces a ready cloud draft (PRODUCT-1329). Set → Houston owns the Slack post (as houston_bot); unset or POST fails → the plain Slack ping above runs instead.
+#   HOUSTON_DRAFT_WEBHOOK_SECRET       — the secret revealed with that URL, sent as the webhook's auth header
 #   SENTRY_DSN                         — Sentry crash reporting DSN
 #   SENTRY_AUTH_TOKEN                  — Sentry CLI auth token (org-scoped, perms: project:releases, project:read, org:read). Used to upload source maps + Rust debug symbols and create/finalize releases. Empty → skip the Sentry upload step (forks, personal builds).
 #   POSTHOG_PERSONAL_API_KEY           — PostHog personal API key (scope: annotation:write) used by the finalize job to mark every release on PostHog charts. Empty → skip the annotation step.
@@ -2181,12 +2183,75 @@ jobs:
             --data @posthog-annotation.json
           echo "::notice::PostHog annotation created for Houston v$VERSION"
 
+      # Hand the announcement to Houston (PRODUCT-1329). A webhook-triggered
+      # routine composes the draft-ready message in product language and posts
+      # it as the houston_bot Slack app — the same agent that cut this release.
+      # This POST is the wake: it fires the instant the draft exists, which is
+      # why the routine does NOT poll the build.
+      #
+      # The credential IS the switch (no dark booleans): with
+      # HOUSTON_DRAFT_WEBHOOK_URL set, Houston owns the announcement and the
+      # legacy Slack step below stands down; unset, or if this POST fails, the
+      # Slack step runs exactly as before. A release train that announces
+      # NOTHING is the one unacceptable outcome, so the fallback is automatic
+      # rather than a flag someone must remember to flip.
+      #
+      # Payload carries what the message needs, so the routine never has to
+      # guess which build it is woken for. Cloud tags only — the local v*
+      # channel is not the daily-cut train and keeps the plain Slack ping.
+      - name: Hand off draft announcement to Houston
+        id: houston_handoff
+        if: ${{ success() && startsWith(github.ref_name, 'cloud-v') }}
+        env:
+          HOUSTON_WEBHOOK_URL: ${{ secrets.HOUSTON_DRAFT_WEBHOOK_URL }}
+          HOUSTON_WEBHOOK_SECRET: ${{ secrets.HOUSTON_DRAFT_WEBHOOK_SECRET }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          if [ -z "${HOUSTON_WEBHOOK_URL}" ]; then
+            echo "HOUSTON_DRAFT_WEBHOOK_URL not set; leaving the announcement to the Slack step."
+            exit 0
+          fi
+
+          VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
+          RELEASE_URL=$(gh release view "$GITHUB_REF_NAME" --json url --jq .url 2>/dev/null) || RELEASE_URL=""
+          STAGING_DMG=$(gh release view "$GITHUB_REF_NAME" --json assets --jq '[.assets[] | select(.name | startswith("Houston_staging")) | .url] | first // empty' 2>/dev/null) || STAGING_DMG=""
+          PROD_DMG=$(gh release view "$GITHUB_REF_NAME" --json assets --jq '[.assets[] | select((.name | endswith(".dmg")) and (.name | startswith("Houston_staging") | not)) | .url] | first // empty' 2>/dev/null) || PROD_DMG=""
+
+          jq -n \
+            --arg event "draft_ready" \
+            --arg version "$VERSION" \
+            --arg tag "$GITHUB_REF_NAME" \
+            --arg release_url "$RELEASE_URL" \
+            --arg staging_dmg "$STAGING_DMG" \
+            --arg prod_dmg "$PROD_DMG" \
+            --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --rawfile notes release-notes.md \
+            '{event: $event, version: $version, tag: $tag, release_url: $release_url,
+              staging_dmg: $staging_dmg, prod_dmg: $prod_dmg, run_url: $run_url, notes: $notes}' \
+            > houston-payload.json
+
+          # The gateway's webhook auth header is owned by the cloud repo's C9
+          # contract, not this one. Sending the minted secret under both accepted
+          # spellings costs nothing (an unknown header is ignored) and keeps this
+          # workflow from hard-coupling to a contract it cannot see.
+          if curl -sS --fail-with-body -X POST "${HOUSTON_WEBHOOK_URL}" \
+              -H 'Content-Type: application/json' \
+              -H "Authorization: Bearer ${HOUSTON_WEBHOOK_SECRET}" \
+              -H "x-houston-webhook-secret: ${HOUSTON_WEBHOOK_SECRET}" \
+              --data @houston-payload.json; then
+            echo "handed_off=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Houston woken for the cloud-v${VERSION} draft announcement."
+          else
+            echo "::warning::Houston draft webhook POST failed; falling back to the direct Slack ping."
+          fi
+
       # Pings the team Slack channel so anyone can grab the DMG and try
       # the build before we publish. No-ops when
       # SLACK_RELEASE_WEBHOOK_URL is unset, so forks and personal builds
-      # stay quiet.
+      # stay quiet. Skipped when Houston took the announcement above.
       - name: Notify Slack of new draft release
-        if: success()
+        if: ${{ success() && steps.houston_handoff.outputs.handed_off != 'true' }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ Need specific knowledge? Load on demand. Every `knowledge-base/` doc is routed b
 
 **Ship + operate**
 - Updater, analytics, in-app bug reports, release env vars, code signing, CI/CD → `knowledge-base/production-infra.md`
+- Daily cloud cut scheduling — the Houston routine that dispatches it, agent-written release notes, Slack posts → `knowledge-base/daily-cut-routine.md`
 - Crash reporting (Sentry — three runtimes, one project, dormant without a DSN) → `knowledge-base/sentry.md`
 - Firebase Hosting for the web client + marketing site → `knowledge-base/hosting.md`
 - Automated UI / end-to-end tests (Playwright, web build, fake host, visual regression) → `knowledge-base/ui-testing.md` + `packages/web/e2e/README.md`

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -37,6 +37,7 @@ Load the rest on demand.
 | [mission-attribution.md](mission-attribution.md) | Faces, senders, @mentions and unread on missions — all multiplayer-gated |
 | [auth.md](auth.md) | GCP Identity Platform (Firebase Auth) — Google/Apple/Microsoft SSO, email OTP, Keychain, and the Supabase that deliberately stays |
 | [production-infra.md](production-infra.md) | Auto-updater, analytics, in-app bug reports, release env vars, code signing, CI/CD |
+| [daily-cut-routine.md](daily-cut-routine.md) | The Houston routine that schedules the daily cloud cut — dispatch, agent-written release notes, Slack announcing |
 | [sentry.md](sentry.md) | Crash reporting — three runtimes, one Sentry project, dormant until a DSN is set |
 | [hosting.md](hosting.md) | Firebase Hosting — the browser web client (`packages/web`) and the marketing site (`website/`) |
 | [ui-testing.md](ui-testing.md) | Playwright e2e + visual regression — the web build, the in-process fake host, per-worker isolation, the CI shard matrix |

--- a/knowledge-base/daily-cut-routine.md
+++ b/knowledge-base/daily-cut-routine.md
@@ -57,6 +57,12 @@ exists to run — dogfooding it is the point.
    goes in the routine prompt, a chat message, a file, or a commit; rotating
    it (Slack app → OAuth & Permissions → Reinstall) only requires updating the
    stored credential.
+
+   **Disconnect Composio Slack from this agent** (or drop Slack from its
+   allowlist). Prompt wording alone is not enough: given a working Slack tool,
+   the agent reaches for it and the post goes out under the connecting human's
+   name. Observed, not theoretical. Removing the tool leaves the bot token as
+   the only path.
 4. **Model.** Give the agent a capable model; the AI account must be usable at
    team scope, since routine runs fire on the team credential.
 5. **Routine A (cron).** Create a routine, schedule weekdays 07:00
@@ -88,8 +94,15 @@ Post everything to the Slack channel #RELEASE-CHANNEL by calling Slack's
 chat.postMessage API (POST https://slack.com/api/chat.postMessage, JSON body
 {"channel": "#RELEASE-CHANNEL", "text": "<message>"}) authorized with the bot
 token in your slack-bot-token credential. Messages support Slack mrkdwn; keep
-code blocks fenced. Work in English in GitHub, but write user-facing release
-notes in en + es + pt as described below.
+code blocks fenced.
+
+NEVER post through a connected Slack app or Slack integration tool, even if one
+is available and looks easier. Those post as the person who connected the
+account, and release reports must come from the Houston bot, not from a
+teammate. The bot token in your credential is the ONLY way you post to Slack.
+
+Work in English in GitHub, but write user-facing release notes in en + es + pt
+as described below.
 
 Steps, in order:
 
@@ -174,6 +187,11 @@ Post ONE message to the Slack channel #RELEASE-CHANNEL by calling Slack's
 chat.postMessage API (POST https://slack.com/api/chat.postMessage, JSON body
 {"channel": "#RELEASE-CHANNEL", "text": "<message>"}) authorized with the bot
 token in your slack-bot-token credential. Slack mrkdwn, no markdown headings.
+
+NEVER post through a connected Slack app or Slack integration tool, even if one
+is available and looks easier. Those post as the person who connected the
+account, and release reports must come from the Houston bot, not from a
+teammate. The bot token in your credential is the ONLY way you post to Slack.
 
 The message:
 - First line: ":rocket: *Houston v<version> draft is ready to QA*"

--- a/knowledge-base/daily-cut-routine.md
+++ b/knowledge-base/daily-cut-routine.md
@@ -102,11 +102,27 @@ Steps, in order:
    "Today's draft cloud-v<version> is already waiting." with its link and stop.
 4. Write the release notes from the merged PRs. This is a product presentation
    for non-technical users, not a changelog: 3 to 5 top items, each one line,
-   benefit first, plain words. No PR numbers, no file names, no dev jargon. If
-   there are only internal fixes, one line: "Stability and polish improvements."
-   End with a short "Fixes and polish" line summarizing the rest. No em dashes.
-   Produce three versions: English, Latin-American Spanish (neutral, tú),
-   Brazilian Portuguese (você).
+   benefit first, plain words. No PR numbers, no file names, no dev jargon.
+   Internal work (refactors, dependency bumps, engine plumbing) is never its own
+   item: fold it into one "Stability and polish improvements under the hood."
+   line. If nothing user visible shipped, that line is the whole body.
+
+   Format, exactly:
+   - First line: "## Houston v<version>" (keep the v; every past release has it).
+   - Then the items.
+   - Then, ALWAYS, this closing section, because these notes replace the
+     auto-generated ones and updating users would otherwise lose the warning:
+
+       ### Before you upgrade
+
+       - Quit Houston before installing. macOS does not always replace an app
+         that is running.
+
+   NEVER use an em dash (—) anywhere in the notes. Use a comma, or split the
+   sentence in two. This is a hard rule in this product's copy and it is checked.
+
+   Produce three complete versions: English, Latin-American Spanish (neutral,
+   tú), Brazilian Portuguese (você). Translate the closing section too.
 5. Dispatch the workflow .github/workflows/daily-cloud-cut.yml on ref main with
    inputs: notes = the English markdown, notes_es and notes_pt = the
    translations. Leave the version input empty.

--- a/knowledge-base/daily-cut-routine.md
+++ b/knowledge-base/daily-cut-routine.md
@@ -61,12 +61,15 @@ exists to run — dogfooding it is the point.
    team scope, since routine runs fire on the team credential.
 5. **Routine A (cron).** Create a routine, schedule weekdays 07:00
    America/Bogota, prompt = "Routine A" below.
-6. **Routine B (webhook).** Create a second routine with an INCOMING WEBHOOK
-   wake, prompt = "Routine B" below. Mint its key (the reveal shows `url` +
-   `secret` exactly once) and save them as the repo secrets
-   `HOUSTON_DRAFT_WEBHOOK_URL` + `HOUSTON_DRAFT_WEBHOOK_SECRET` on
-   `gethouston/houston`. Webhook wakes are hosted-cloud only — the Go gateway
-   owns the ingress ([routine-triggers.md](routine-triggers.md)).
+6. **Routine B (webhook).** Create a second routine and pick the **"From an
+   external app"** wake (the intake's third option — *not* "When something
+   happens in an app", which binds a Composio event instead), prompt =
+   "Routine B" below. Mint its key and save the revealed URL as the repo secret
+   `HOUSTON_DRAFT_WEBHOOK_URL` on `gethouston/houston`. The minted secret is the
+   URL's LAST PATH SEGMENT — the gateway needs no auth header, so the whole URL
+   is a credential: repo secret only, never a literal, never logged. Rotate by
+   re-minting the key. Webhook wakes are hosted-cloud only — the Go gateway owns
+   the ingress ([routine-triggers.md](routine-triggers.md)).
 7. **Supervised first run.** Ask the agent to run routine A by hand on a safe
    morning. Verify: the dispatch appears in the repo's Actions tab, the tag +
    draft build succeed, the draft body carries the agent's notes, and both

--- a/knowledge-base/daily-cut-routine.md
+++ b/knowledge-base/daily-cut-routine.md
@@ -1,0 +1,136 @@
+# Daily cut routine — Houston schedules its own release train (PRODUCT-1329)
+
+The morning cut of the desktop cloud train is no longer fired by a GitHub cron.
+**A Houston routine is the scheduler**: every weekday morning a cloud agent
+dispatches `daily-cloud-cut.yml`, writes the user-facing release notes, watches
+the run, and posts the outcome to Slack. The heavy machinery stays in GitHub
+Actions — signing, notarization, and the guarded tag push cannot and should not
+move — but the *when*, the *notes*, and the *announcing* are Houston's.
+
+Why: GitHub's `schedule` queue is best-effort and delivered the old 10:22 UTC
+slot 30–120 min late (HOU-1013), forcing a ~103-min fudge factor. Houston's
+cron fires on time. And the release train is exactly the kind of job Houston
+exists to run — dogfooding it is the point.
+
+## Division of labor
+
+| Piece | Owner | Change |
+|---|---|---|
+| Schedule (weekdays ~07:00 Bogotá) | **Houston routine** | GH `schedule:` trigger deleted |
+| Cut (guards, version bump, tag push) | `daily-cloud-cut.yml` | now `workflow_dispatch`-only; gained `notes`/`notes_es`/`notes_pt` inputs |
+| Release notes | **the agent** | passed via the `notes` inputs → written to `.github/release-notes/<version>[.es|.pt].md` inside the release commit → release.yml uses them verbatim as the body AND embeds them in the updater's `latest.json` |
+| Draft build (DMG, sign, notarize) | `release.yml` | unchanged |
+| Linear stamp | `linear-release-stamp.yml` | unchanged — still fires on the tag push, fully automated |
+| Slack announcing | **Houston routine** | success, quiet-day, and failure posts; failures are one copy-pasteable block |
+| Backup Slack pings (red-main guard, draft-ready) | workflows | kept as a safety net while the routine proves out; remove release.yml's draft-ready post once redundant |
+
+## Setup in the Houston app (one-time)
+
+1. **Agent.** In the hosted cloud team space, create (or reuse) a dedicated
+   agent — e.g. *Release Captain*. Routine runs execute on the agent's cloud
+   pod, so this must be a cloud agent, not desktop-only.
+2. **GitHub connection.** Connect the GitHub integration on that agent,
+   authorizing as an account with push access to `gethouston/houston`
+   (dispatching a workflow needs `actions: write`). If the Composio GitHub
+   toolkit's OAuth scopes turn out not to cover workflow dispatch, fall back to
+   a custom API integration holding a fine-grained PAT (Actions: read/write,
+   Contents: read on `gethouston/houston`).
+3. **Slack connection.** Connect Slack and pick the release channel the posts
+   should land in. Make sure the agent's integration allowlist includes both
+   GitHub and Slack.
+4. **Model.** Give the agent a capable model; the AI account must be usable at
+   team scope, since routine runs fire on the team credential.
+5. **Routine.** Create a routine with a cron schedule, weekdays 07:00
+   America/Bogota, and paste the prompt below.
+6. **Supervised first run.** Ask the agent to run the routine once by hand on a
+   safe morning. Verify: the dispatch appears in the repo's Actions tab, the
+   tag + draft build succeed, the draft body carries the agent's notes, and the
+   Slack posts look right.
+7. **Only then** merge the PR that removes the GH cron. Rollback is one line:
+   re-add the `schedule:` block to `daily-cloud-cut.yml`.
+
+## The routine prompt
+
+Paste verbatim (fill in the Slack channel):
+
+```text
+You run the morning cut of the Houston release train. Repo: gethouston/houston.
+Post everything to the Slack channel #RELEASE-CHANNEL. Work in English in
+GitHub, but write user-facing release notes in en + es + pt as described below.
+
+Steps, in order:
+
+1. Find the latest cloud-v* tag (semver order, not creation order). List the
+   pull requests merged into main since that tag was created.
+2. If NO pull requests merged since the last cut, post one short Slack line:
+   "No release today. Nothing merged since cloud-v<last>." and stop.
+3. If a DRAFT release with a cloud-v* tag newer than the last published one
+   already exists and was created in the last 20 hours, do not cut again: post
+   "Today's draft cloud-v<version> is already waiting." with its link and stop.
+4. Write the release notes from the merged PRs. This is a product presentation
+   for non-technical users, not a changelog: 3 to 5 top items, each one line,
+   benefit first, plain words. No PR numbers, no file names, no dev jargon. If
+   there are only internal fixes, one line: "Stability and polish improvements."
+   End with a short "Fixes and polish" line summarizing the rest. No em dashes.
+   Produce three versions: English, Latin-American Spanish (neutral, tú),
+   Brazilian Portuguese (você).
+5. Dispatch the workflow .github/workflows/daily-cloud-cut.yml on ref main with
+   inputs: notes = the English markdown, notes_es and notes_pt = the
+   translations. Leave the version input empty.
+6. Poll the dispatched run every 30 seconds until it completes (normally under
+   5 minutes).
+   - Completed, tag pushed: continue to step 7.
+   - Completed but the logs say "no new commits ... skipping": post the
+     quiet-day line from step 2 and stop.
+   - Failed: fetch the failing job, step name, and the last ~30 relevant log
+     lines. Post the FAILURE MESSAGE (format below) and stop.
+7. The tag push triggers the release.yml draft build (~30-40 min). Poll the
+   release.yml run for the new cloud-v<version> tag every 2 minutes, up to 50
+   minutes.
+   - Success: find the draft release, get the staging DMG asset link (name
+     starts with Houston_staging) and the draft's html_url. Post to Slack:
+     version, one-line summary, the top items from your notes, the staging DMG
+     link (the one to QA in the 08:30 daily), and the draft link.
+   - Failure: post the FAILURE MESSAGE for the release.yml run and stop.
+   - Still running at 50 min: post the run link and say the build is slow but
+     alive; do not fail.
+
+FAILURE MESSAGE format. First line: ":red_circle: Daily cut failed for
+cloud-v<version>" (or "for today's cut" if no version yet). Then ONE fenced
+code block someone can copy and paste straight into a coding agent, fully
+self-contained:
+
+  Houston daily release cut failed. Please diagnose and fix.
+  Repo: gethouston/houston
+  Workflow: <workflow name>
+  Run: <run URL>
+  Failing job/step: <job> / <step>
+  Log excerpt:
+  <the relevant log lines>
+
+Never retry a failed cut yourself. Never dispatch more than once per day.
+Never delete tags, releases, or branches.
+```
+
+## Failure modes the prompt already covers
+
+- **Quiet day** — the workflow's no-new-commits guard and the agent's merged-PR
+  check agree (main is PR-only, so merged PRs ≡ new commits); the agent skips
+  the dispatch entirely and says so in one line.
+- **Red main** — the workflow's green-main guard fails the run naming the
+  failing checks; the agent relays them in the copy-pasteable block. The
+  workflow's own `SLACK_RELEASE_WEBHOOK_URL` ping stays as backup.
+- **Double fire** — step 3's today-draft check plus the workflow's
+  tag-already-exists guard.
+- **Routine never fires** (pod down, credential broken) — the failure mode with
+  no messenger. The 08:30 daily notices no draft; that morning, dispatch the
+  workflow by hand from the Actions tab (the notes inputs are optional — blank
+  falls back to the auto-changelog).
+
+## Related
+
+- The workflow itself: `.github/workflows/daily-cloud-cut.yml` (header documents
+  the PAT, tag-only push, and guard rationale).
+- The rest of the train: [production-infra.md](production-infra.md).
+- Routine mechanics (cron scheduling, team-scope credentials):
+  [routine-triggers.md](routine-triggers.md), [ai-accounts.md](ai-accounts.md).

--- a/knowledge-base/daily-cut-routine.md
+++ b/knowledge-base/daily-cut-routine.md
@@ -14,15 +14,27 @@ exists to run — dogfooding it is the point.
 
 ## Division of labor
 
+**Two routines, not one.** The cut and the announcement are separate wakes:
+
+- **Routine A — "Cut the release" (cron, weekdays 07:00 Bogotá):** writes the
+  notes, dispatches the workflow, confirms the tag, posts the heartbeat. Done in
+  ~3 minutes.
+- **Routine B — "Announce the draft" (webhook):** woken by `release.yml` itself
+  the instant the draft is built (~40 min later), it posts the draft-ready
+  message. Nothing polls a 40-minute build: an agent run that sits watching CI
+  is the fragile design, and the workflow already knows the exact moment.
+
 | Piece | Owner | Change |
 |---|---|---|
-| Schedule (weekdays ~07:00 Bogotá) | **Houston routine** | GH `schedule:` trigger deleted |
+| Schedule (weekdays ~07:00 Bogotá) | **Houston routine A** | GH `schedule:` trigger deleted |
+| Draft-ready announcement | **Houston routine B** | woken by a new `release.yml` step POSTing to its minted webhook |
 | Cut (guards, version bump, tag push) | `daily-cloud-cut.yml` | now `workflow_dispatch`-only; gained `notes`/`notes_es`/`notes_pt` inputs |
 | Release notes | **the agent** | passed via the `notes` inputs → written to `.github/release-notes/<version>[.es|.pt].md` inside the release commit → release.yml uses them verbatim as the body AND embeds them in the updater's `latest.json` |
 | Draft build (DMG, sign, notarize) | `release.yml` | unchanged |
 | Linear stamp | `linear-release-stamp.yml` | unchanged — still fires on the tag push, fully automated |
-| Slack announcing | **Houston routine** | success, quiet-day, and failure posts; failures are one copy-pasteable block |
-| Backup Slack pings (red-main guard, draft-ready) | workflows | kept as a safety net while the routine proves out; remove release.yml's draft-ready post once redundant |
+| Slack announcing | **Houston routines** | heartbeat, quiet-day, draft-ready, and failure posts; failures are one copy-pasteable block |
+| Backup Slack ping (draft-ready) | `release.yml` | now the automatic FALLBACK: skipped when the Houston hand-off POST succeeds, runs unchanged when the webhook secret is unset or the POST fails. A train that announces nothing is the one unacceptable outcome |
+| Backup Slack ping (red-main guard) | `daily-cloud-cut.yml` | unchanged safety net |
 
 ## Setup in the Houston app (one-time)
 
@@ -47,16 +59,23 @@ exists to run — dogfooding it is the point.
    stored credential.
 4. **Model.** Give the agent a capable model; the AI account must be usable at
    team scope, since routine runs fire on the team credential.
-5. **Routine.** Create a routine with a cron schedule, weekdays 07:00
-   America/Bogota, and paste the prompt below.
-6. **Supervised first run.** Ask the agent to run the routine once by hand on a
-   safe morning. Verify: the dispatch appears in the repo's Actions tab, the
-   tag + draft build succeed, the draft body carries the agent's notes, and the
-   Slack posts look right.
-7. **Only then** merge the PR that removes the GH cron. Rollback is one line:
+5. **Routine A (cron).** Create a routine, schedule weekdays 07:00
+   America/Bogota, prompt = "Routine A" below.
+6. **Routine B (webhook).** Create a second routine with an INCOMING WEBHOOK
+   wake, prompt = "Routine B" below. Mint its key (the reveal shows `url` +
+   `secret` exactly once) and save them as the repo secrets
+   `HOUSTON_DRAFT_WEBHOOK_URL` + `HOUSTON_DRAFT_WEBHOOK_SECRET` on
+   `gethouston/houston`. Webhook wakes are hosted-cloud only — the Go gateway
+   owns the ingress ([routine-triggers.md](routine-triggers.md)).
+7. **Supervised first run.** Ask the agent to run routine A by hand on a safe
+   morning. Verify: the dispatch appears in the repo's Actions tab, the tag +
+   draft build succeed, the draft body carries the agent's notes, and both
+   Slack posts (heartbeat, then draft-ready ~40 min later) look right and come
+   from `houston_bot`.
+8. **Only then** merge the PR that removes the GH cron. Rollback is one line:
    re-add the `schedule:` block to `daily-cloud-cut.yml`.
 
-## The routine prompt
+## Routine A — "Cut the release" (cron, weekdays 07:00 America/Bogota)
 
 Paste verbatim (fill in the Slack channel):
 
@@ -90,21 +109,18 @@ Steps, in order:
    translations. Leave the version input empty.
 6. Poll the dispatched run every 30 seconds until it completes (normally under
    5 minutes).
-   - Completed, tag pushed: continue to step 7.
+   - Completed, tag pushed: post the HEARTBEAT (format below) and stop. You do
+     NOT wait for the build: a separate routine is woken when the draft is
+     ready.
    - Completed but the logs say "no new commits ... skipping": post the
      quiet-day line from step 2 and stop.
    - Failed: fetch the failing job, step name, and the last ~30 relevant log
      lines. Post the FAILURE MESSAGE (format below) and stop.
-7. The tag push triggers the release.yml draft build (~30-40 min). Poll the
-   release.yml run for the new cloud-v<version> tag every 2 minutes, up to 50
-   minutes.
-   - Success: find the draft release, get the staging DMG asset link (name
-     starts with Houston_staging) and the draft's html_url. Post to Slack:
-     version, one-line summary, the top items from your notes, the staging DMG
-     link (the one to QA in the 08:30 daily), and the draft link.
-   - Failure: post the FAILURE MESSAGE for the release.yml run and stop.
-   - Still running at 50 min: post the run link and say the build is slow but
-     alive; do not fail.
+
+HEARTBEAT format, one line:
+":hourglass_flowing_sand: Cutting cloud-v<version> now. Draft ready in about 40
+minutes." Always post it on a cutting day, even though the draft message comes
+later: its absence is how we notice this routine did not run at all.
 
 FAILURE MESSAGE format. First line: ":red_circle: Daily cut failed for
 cloud-v<version>" (or "for today's cut" if no version yet). Then ONE fenced
@@ -123,6 +139,35 @@ Never retry a failed cut yourself. Never dispatch more than once per day.
 Never delete tags, releases, or branches.
 ```
 
+## Routine B — "Announce the draft" (incoming webhook)
+
+Woken by `release.yml`'s hand-off step the moment the draft prerelease is built.
+The event payload carries everything the message needs, so this routine makes no
+GitHub calls at all on the happy path.
+
+```text
+You announce a finished Houston release draft to the team. You are woken by an
+event from our release pipeline; its payload has these fields: event, version,
+tag, release_url, staging_dmg, prod_dmg, run_url, notes (the user-facing release
+notes, markdown).
+
+Post ONE message to the Slack channel #RELEASE-CHANNEL by calling Slack's
+chat.postMessage API (POST https://slack.com/api/chat.postMessage, JSON body
+{"channel": "#RELEASE-CHANNEL", "text": "<message>"}) authorized with the bot
+token in your slack-bot-token credential. Slack mrkdwn, no markdown headings.
+
+The message:
+- First line: ":rocket: *Houston v<version> draft is ready to QA*"
+- Then the top items from `notes`, as they are written. They are already user
+  facing; do not rewrite them into a changelog and do not add PR numbers.
+- Then: "Test the *staging DMG* in the daily: <staging_dmg>"
+- Then: "Draft: <release_url>"
+Keep it short enough to read without scrolling. If a field is empty, leave that
+line out rather than posting an empty link.
+
+If the payload's event is not "draft_ready", ignore it and do nothing.
+```
+
 ## Failure modes the prompt already covers
 
 - **Quiet day** — the workflow's no-new-commits guard and the agent's merged-PR
@@ -133,10 +178,16 @@ Never delete tags, releases, or branches.
   workflow's own `SLACK_RELEASE_WEBHOOK_URL` ping stays as backup.
 - **Double fire** — step 3's today-draft check plus the workflow's
   tag-already-exists guard.
-- **Routine never fires** (pod down, credential broken) — the failure mode with
-  no messenger. The 08:30 daily notices no draft; that morning, dispatch the
+- **Routine A never fires** (pod down, credential broken) — the failure mode with
+  no messenger. The heartbeat is the tell: no heartbeat AND no quiet-day line by
+  ~07:15 means the routine itself did not run. Recover by dispatching the
   workflow by hand from the Actions tab (the notes inputs are optional — blank
   falls back to the auto-changelog).
+- **Routine B never fires / the hand-off POST fails** — `release.yml` falls back
+  to its own Slack ping automatically, so the draft is still announced (in the
+  plain pre-PRODUCT-1329 format). Two draft messages means the fallback fired
+  alongside a late routine B; one plain message means the webhook path is
+  broken.
 
 ## Related
 

--- a/knowledge-base/daily-cut-routine.md
+++ b/knowledge-base/daily-cut-routine.md
@@ -35,9 +35,16 @@ exists to run — dogfooding it is the point.
    toolkit's OAuth scopes turn out not to cover workflow dispatch, fall back to
    a custom API integration holding a fine-grained PAT (Actions: read/write,
    Contents: read on `gethouston/houston`).
-3. **Slack connection.** Connect Slack and pick the release channel the posts
-   should land in. Make sure the agent's integration allowlist includes both
-   GitHub and Slack.
+3. **Slack bot.** The Composio-managed Slack OAuth is a USER-token connection —
+   posts would appear as the connecting human, wrong identity for release
+   reports. Use the dedicated Slack app instead (bot user `houston_bot`,
+   workspace app with only the `chat:write` scope): invite it to the release
+   channel (`/invite @houston_bot` in #houston-drafts — bots cannot post to a
+   channel they are not a member of), then store its `xoxb-` bot token in the
+   agent's SECURE CREDENTIAL card, named `slack-bot-token`. The token never
+   goes in the routine prompt, a chat message, a file, or a commit; rotating
+   it (Slack app → OAuth & Permissions → Reinstall) only requires updating the
+   stored credential.
 4. **Model.** Give the agent a capable model; the AI account must be usable at
    team scope, since routine runs fire on the team credential.
 5. **Routine.** Create a routine with a cron schedule, weekdays 07:00
@@ -55,8 +62,12 @@ Paste verbatim (fill in the Slack channel):
 
 ```text
 You run the morning cut of the Houston release train. Repo: gethouston/houston.
-Post everything to the Slack channel #RELEASE-CHANNEL. Work in English in
-GitHub, but write user-facing release notes in en + es + pt as described below.
+Post everything to the Slack channel #RELEASE-CHANNEL by calling Slack's
+chat.postMessage API (POST https://slack.com/api/chat.postMessage, JSON body
+{"channel": "#RELEASE-CHANNEL", "text": "<message>"}) authorized with the bot
+token in your slack-bot-token credential. Messages support Slack mrkdwn; keep
+code blocks fenced. Work in English in GitHub, but write user-facing release
+notes in en + es + pt as described below.
 
 Steps, in order:
 

--- a/knowledge-base/daily-cut-routine.md
+++ b/knowledge-base/daily-cut-routine.md
@@ -61,7 +61,10 @@ exists to run — dogfooding it is the point.
    called slack-bot-token" has nowhere to live. Register a minimal OpenAPI
    definition for `POST https://slack.com/api/chat.postMessage` with
    `auth: credential` (bearer), then paste the token into the secure card that
-   definition presents. The token never goes in a routine prompt, a chat
+   definition presents. The request schema must expose **`blocks` as well as
+   `text`** — Block Kit is what gives the announcement its header and its
+   download buttons; a `text`-only spec silently degrades every release post to
+   a wall of plain text. The token never goes in a routine prompt, a chat
    message, a file, or a commit; rotating it (Slack app → OAuth & Permissions →
    Reinstall) only means re-entering it on that card.
 
@@ -199,14 +202,22 @@ is available and looks easier. Those post as the person who connected the
 account, and release reports must come from the Houston bot, not from a
 teammate. The slack-bot custom integration is the ONLY way you post to Slack.
 
-The message:
-- First line: ":rocket: *Houston v<version> draft is ready to QA*"
-- Then the top items from `notes`, as they are written. They are already user
-  facing; do not rewrite them into a changelog and do not add PR numbers.
-- Then: "Test the *staging DMG* in the daily: <staging_dmg>"
-- Then: "Draft: <release_url>"
-Keep it short enough to read without scrolling. If a field is empty, leave that
-line out rather than posting an empty link.
+Send BLOCK KIT, not plain text. Set text to "Houston v<version> is ready to
+test" (Slack uses it for notifications) and blocks to exactly this shape:
+
+1. header: plain_text "Houston v<version> is ready to test"
+2. context: one mrkdwn element, "Draft cloud release · the *staging DMG* talks
+   to the staging gateway, it's the one to test in the daily before we publish"
+3. section: mrkdwn, the items from `notes` as they are written. They are already
+   user facing; do not rewrite them into a changelog and do not add PR numbers.
+   Drop the "## Houston v..." heading line and the "Before you upgrade" section,
+   they belong in the release body, not in chat.
+4. actions, with a button per link the payload actually carries:
+   - staging_dmg: text "Download staging DMG (QA)", style primary
+   - prod_dmg: text "Prod DMG"
+   - release_url: text "View on GitHub"
+   Omit any button whose URL is empty. A button with no url is invalid and Slack
+   rejects the whole message.
 
 If the payload's event is not "draft_ready", ignore it and do nothing.
 ```

--- a/knowledge-base/daily-cut-routine.md
+++ b/knowledge-base/daily-cut-routine.md
@@ -47,22 +47,29 @@ exists to run — dogfooding it is the point.
    toolkit's OAuth scopes turn out not to cover workflow dispatch, fall back to
    a custom API integration holding a fine-grained PAT (Actions: read/write,
    Contents: read on `gethouston/houston`).
-3. **Slack bot.** The Composio-managed Slack OAuth is a USER-token connection —
-   posts would appear as the connecting human, wrong identity for release
-   reports. Use the dedicated Slack app instead (bot user `houston_bot`,
-   workspace app with only the `chat:write` scope): invite it to the release
-   channel (`/invite @houston_bot` in #houston-drafts — bots cannot post to a
-   channel they are not a member of), then store its `xoxb-` bot token in the
-   agent's SECURE CREDENTIAL card, named `slack-bot-token`. The token never
-   goes in the routine prompt, a chat message, a file, or a commit; rotating
-   it (Slack app → OAuth & Permissions → Reinstall) only requires updating the
-   stored credential.
+3. **Slack bot, as a CUSTOM INTEGRATION.** The Composio-managed Slack OAuth is a
+   USER-token connection — posts appear as the connecting human, the wrong
+   identity for release reports (observed: the first test posted under a
+   teammate's name). Use the dedicated Slack app instead: bot user
+   `houston_bot`, workspace app with only the `chat:write` scope, invited to the
+   channel (`/invite @houston_bot` in #houston-drafts — a bot cannot post to a
+   channel it is not in).
+
+   Its `xoxb-` token is held by a **custom API integration**, not a loose named
+   credential: Houston stores secrets only against a registered definition
+   ([custom-integrations.md](custom-integrations.md)), so "save a credential
+   called slack-bot-token" has nowhere to live. Register a minimal OpenAPI
+   definition for `POST https://slack.com/api/chat.postMessage` with
+   `auth: credential` (bearer), then paste the token into the secure card that
+   definition presents. The token never goes in a routine prompt, a chat
+   message, a file, or a commit; rotating it (Slack app → OAuth & Permissions →
+   Reinstall) only means re-entering it on that card.
 
    **Disconnect Composio Slack from this agent** (or drop Slack from its
    allowlist). Prompt wording alone is not enough: given a working Slack tool,
    the agent reaches for it and the post goes out under the connecting human's
-   name. Observed, not theoretical. Removing the tool leaves the bot token as
-   the only path.
+   name. Observed, not theoretical. Removing it leaves the bot integration as
+   the only Slack path.
 4. **Model.** Give the agent a capable model; the AI account must be usable at
    team scope, since routine runs fire on the team credential.
 5. **Routine A (cron).** Create a routine, schedule weekdays 07:00
@@ -90,16 +97,15 @@ Paste verbatim (fill in the Slack channel):
 
 ```text
 You run the morning cut of the Houston release train. Repo: gethouston/houston.
-Post everything to the Slack channel #RELEASE-CHANNEL by calling Slack's
-chat.postMessage API (POST https://slack.com/api/chat.postMessage, JSON body
-{"channel": "#RELEASE-CHANNEL", "text": "<message>"}) authorized with the bot
-token in your slack-bot-token credential. Messages support Slack mrkdwn; keep
-code blocks fenced.
+Post everything to the Slack channel #RELEASE-CHANNEL with the chat.postMessage
+tool of your "slack-bot" custom integration, which carries the Houston bot
+token: channel = "#RELEASE-CHANNEL", text = the message. Messages support Slack
+mrkdwn; keep code blocks fenced.
 
 NEVER post through a connected Slack app or Slack integration tool, even if one
 is available and looks easier. Those post as the person who connected the
 account, and release reports must come from the Houston bot, not from a
-teammate. The bot token in your credential is the ONLY way you post to Slack.
+teammate. The slack-bot custom integration is the ONLY way you post to Slack.
 
 Work in English in GitHub, but write user-facing release notes in en + es + pt
 as described below.
@@ -183,15 +189,15 @@ event from our release pipeline; its payload has these fields: event, version,
 tag, release_url, staging_dmg, prod_dmg, run_url, notes (the user-facing release
 notes, markdown).
 
-Post ONE message to the Slack channel #RELEASE-CHANNEL by calling Slack's
-chat.postMessage API (POST https://slack.com/api/chat.postMessage, JSON body
-{"channel": "#RELEASE-CHANNEL", "text": "<message>"}) authorized with the bot
-token in your slack-bot-token credential. Slack mrkdwn, no markdown headings.
+Post ONE message to the Slack channel #RELEASE-CHANNEL with the chat.postMessage
+tool of your "slack-bot" custom integration, which carries the Houston bot
+token: channel = "#RELEASE-CHANNEL", text = the message. Slack mrkdwn, no
+markdown headings.
 
 NEVER post through a connected Slack app or Slack integration tool, even if one
 is available and looks easier. Those post as the person who connected the
 account, and release reports must come from the Houston bot, not from a
-teammate. The bot token in your credential is the ONLY way you post to Slack.
+teammate. The slack-bot custom integration is the ONLY way you post to Slack.
 
 The message:
 - First line: ":rocket: *Houston v<version> draft is ready to QA*"

--- a/knowledge-base/production-infra.md
+++ b/knowledge-base/production-infra.md
@@ -565,10 +565,15 @@ gateway is channel `cloud`.
 
 ### Daily cloud cut (`daily-cloud-cut.yml`)
 
-- **Schedule: `cron: "22 10 * * 1-5"` = 10:22 UTC Mon–Fri = 05:22 America/Bogota**
-  (UTC-5, no DST). The nominal slot sits ~103 min before the ~07:05 Bogotá target
-  because GitHub's `schedule` queue is best-effort and routinely fires 30-120 min
-  late (worst at `:00`/`:15`/`:30`/`:45`) — never trust it for a hard deadline.
+- **`workflow_dispatch`-only — the scheduler is a Houston routine** (PRODUCT-1329):
+  a cloud agent dispatches the workflow weekday mornings (~07:00 Bogotá), passes
+  agent-written user-facing release notes via the `notes`/`notes_es`/`notes_pt`
+  inputs (written to `.github/release-notes/<version>[.es|.pt].md` inside the
+  release commit, so release.yml treats them as authored notes and the updater
+  embeds them), watches the run, and posts the outcome to Slack — see
+  [daily-cut-routine.md](daily-cut-routine.md). The old GitHub cron was dropped:
+  its best-effort queue fired 30-120 min late (HOU-1013) and needed a ~103-min
+  fudge factor; Houston's cron fires on time.
 - Replicates the manual cut: branch from main tip → `scripts/version.sh` →
   `release: v<version>` commit (lives only under the tag, never pushed to protected
   main) → annotated `cloud-v<version>` tag pushed with the `RELEASE_CUT_TOKEN`


### PR DESCRIPTION
Fixes PRODUCT-1329

## What moves where

The morning cut of the cloud release train is no longer fired by a GitHub cron. **A Houston cloud-agent routine becomes the scheduler**: it dispatches `daily-cloud-cut.yml` weekday mornings (~07:00 Bogotá), writes the user-facing release notes, watches the run, and posts the outcome to Slack — failures as one copy-pasteable code block ready to paste into a coding agent. The guarded cut machinery (version bump, PAT tag push, green-main / no-new-commits guards) stays in the workflow, and signing/notarization stays in `release.yml`, untouched.

- **Schedule** → deleted from the workflow (`workflow_dispatch` is now the only trigger). GitHub's cron queue fired 30–120 min late (HOU-1013) and needed a ~103-min fudge factor; Houston's cron fires on time — and running the release train is dogfooding at its purest.
- **Release notes** → new optional `notes` / `notes_es` / `notes_pt` dispatch inputs. When present, the cut writes them to `.github/release-notes/<version>[.es|.pt].md` inside the release commit — the authored-notes path `release.yml` already prefers — so agent-written, product-presentation-style notes become the release body AND the in-app updater text. Blank inputs keep today's auto-generated changelog exactly as before. A translation without English notes fails fast at the cut instead of 30 build-minutes later.
- **Linear stamp** → untouched; `linear-release-stamp.yml` still fires on the tag push, fully automated.
- **Slack** → the routine posts success / quiet-day / failure. The workflows' existing webhook pings (red-main, draft-ready) stay as a safety net during the transition.

The routine prompt (paste-ready) and one-time Houston-app setup steps are in `knowledge-base/daily-cut-routine.md`.

## ⚠️ Merge gate

Do **not** merge until the routine has completed one supervised successful run (setup steps 1–6 in the doc). Merging this removes the GH schedule — after that, no routine means no cut. Rollback is one line: re-add the `schedule:` block.

## Verify before (the bug being fixed)

1. `git log --oneline main -- .github/workflows/daily-cloud-cut.yml` + the workflow header on `main`: cut fires from `cron: "22 10 * * 1-5"`, deliberately ~103 min early to absorb GitHub's queue delay; Actions history shows the scheduled runs drifting.
2. Release notes on a normal day are the conventional-commit changelog (grouped `feat`/`fix` subjects) — a dev changelog, not a product summary.
3. Slack failure signal is the raw red-main webhook ping only; nothing copy-pasteable, no notes authored by an agent.

## Verify after

1. On this branch: `.github/workflows/daily-cloud-cut.yml` has no `schedule:` trigger (`workflow_dispatch` only) and exposes `version`, `notes`, `notes_es`, `notes_pt`.
2. Manual dispatch with a filled `notes` input → the resulting `cloud-v*` tag's commit contains `.github/release-notes/<version>.md`, and the draft release body shows those notes verbatim (not the auto-changelog).
3. Manual dispatch with blank notes → draft body is the auto-generated changelog, unchanged behavior.
4. Dispatch with `notes_es` but no `notes` → the cut fails in the "Cut release commit + tag" step with the explicit error, before any build starts.
5. After routine setup (doc steps 1–6): the routine's morning run appears as a `workflow_dispatch` in Actions, and Slack receives the draft-ready post (or the copy-pasteable failure block).