### PR TITLE
fix(runtime): abandoned-login expiry logs WARN, not a Sentry error event (PRODUCT-1335)

### DIFF
--- a/packages/runtime/src/auth/login.test.ts
+++ b/packages/runtime/src/auth/login.test.ts
@@ -271,6 +271,11 @@ test("an abandoned login expires: reports 'Login timed out' and frees the flow f
   // provider machine-wide. The expiry tears the flow down like cancelLogin but
   // records the attempt as a failure so status polls surface it.
   vi.useFakeTimers({ shouldAdvanceTime: true });
+  // Abandonment is expected user behavior, so the expiry must log at WARN
+  // (crash-feed breadcrumb), never ERROR (a Sentry error event per walked-away
+  // sign-in).
+  const warnSpy = vi.spyOn(console, "warn");
+  const errorSpy = vi.spyOn(console, "error");
   try {
     const first = await startLogin("anthropic");
     expect(first.kind).toBe("auth_code");
@@ -283,6 +288,11 @@ test("an abandoned login expires: reports 'Login timed out' and frees the flow f
     expect(row?.login?.status).toBe("error");
     expect(row?.login?.error).toBe(LOGIN_TIMEOUT_ERROR);
 
+    const abandoned = (calls: unknown[][]) =>
+      calls.some((args) => String(args[0]).includes("abandoned login"));
+    expect(abandoned(warnSpy.mock.calls)).toBe(true);
+    expect(abandoned(errorSpy.mock.calls)).toBe(false);
+
     // The paste promise was rejected (flow unwound, port freed), so a retry
     // builds a FRESH login instead of reusing the dead one.
     const second = await startLogin("anthropic");
@@ -290,6 +300,8 @@ test("an abandoned login expires: reports 'Login timed out' and frees the flow f
     cancelLogin("anthropic");
     await vi.advanceTimersByTimeAsync(100);
   } finally {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
     vi.useRealTimers();
   }
 });

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -150,7 +150,11 @@ function armLoginExpiry(provider: ProviderId, state: LoginState): void {
     // handler sees the abort as a benign unwind and leaves this in place.
     state.status = "error";
     state.error = LOGIN_TIMEOUT_ERROR;
-    console.error(
+    // WARN, not error: an abandoned login is expected user behavior (they
+    // closed the dialog or walked away mid device-code entry) and this expiry
+    // IS the designed teardown — the crash feed keeps WARN as a breadcrumb
+    // instead of minting a Sentry error event per abandonment.
+    console.warn(
       `[oauth:${provider}] abandoned login timed out after ${LOGIN_TIMEOUT_MS / 60_000}min — aborting to free the callback port`,
     );
     state.abort?.abort();


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1335 (Sentry HOUSTON-APP-4YZ, 314 events / 224 users since 2026-07-21).

**Root cause.** The abandoned-login expiry in `packages/runtime/src/auth/login.ts` — the designed 10-minute backstop that tears down an OAuth sign-in the user never finished — logged its firing with `console.error`. The engine's crash-reporting feed turns every ERROR-level log into a Sentry **event** (WARN and below become breadcrumbs), so every user who opened the ChatGPT/Codex connect dialog and walked away minted a Sentry error. All captured events come from managed-cloud engine pods, where the Codex flow is the **device-code grant** that holds no callback port at all — nothing failed, nothing leaked; the teardown worked exactly as designed. This is expected connect-funnel drop-off reported at error severity.

**Fix.** Demote the expiry log to `console.warn`. It still reaches engine.log and rides along as a Sentry breadcrumb on real events, and the user-facing surfacing is untouched: the login state still flips to `error` / "Login timed out" so status polls and the connect UI report the timeout the same as before. The existing abandoned-login test now pins the level (WARN fires, ERROR does not).

**Not changed (deliberately).** Closing the device-code dialog still leaves the engine-side login running until the expiry. Auto-cancelling on dialog close looks tempting for volume, but users routinely close the dialog after typing the code in their browser while the runtime's poll is still completing — cancelling there would kill succeeding sign-ins. The explicit Cancel affordances (AI-hub card row, reconnect card) already abort engine-side.

## Verification

Before the fix:
1. On a cloud agent (or any `deviceAuth: true` client), start a ChatGPT/Codex connect so the device-code dialog appears, then close it without entering the code.
2. After 10 minutes the runtime logs `[oauth:openai-codex] abandoned login timed out…` at ERROR and a new event lands on Sentry issue HOUSTON-APP-4YZ.

After the fix:
1. Repeat the same abandonment.
2. The same line is logged at WARN — engine.log still records it, Sentry gets a breadcrumb but **no new event** on HOUSTON-APP-4YZ.
3. The connect UI still surfaces "Login timed out", and a retry click starts a fresh login.

Tests: `pnpm --filter @houston/runtime test` (1113 passed, includes the new level assertions), `pnpm check` clean, full workspace typecheck green.