### PR TITLE
fix(app): stop stale-roster 'agent not found' 404s from all passive agent reads (PRODUCT-1337)

### DIFF
--- a/app/src/hooks/use-stale-roster-heal.ts
+++ b/app/src/hooks/use-stale-roster-heal.ts
@@ -1,22 +1,18 @@
 import { useEffect } from "react";
-import { makeRosterHealer } from "../lib/agent-gone";
-import { useAgentStore } from "../stores/agents";
+import { healStaleRoster } from "../lib/roster-heal";
 import { useWorkspaceStore } from "../stores/workspaces";
 
 /**
  * When a mounted surface observes an agent-gone read (HOUSTON-APP-544 — the
  * roster still lists an agent the server says does not exist), silently
  * reload the current workspace's roster so the ghost agent disappears on its
- * own. Module-level healer so every mounted surface shares ONE in-flight
- * reload; see `makeRosterHealer` for why this cannot loop.
+ * own. Delegates to the ONE shared healer (`lib/roster-heal.ts`) so every
+ * mounted surface AND the engine-call layer share a single in-flight reload;
+ * see `makeRosterHealer` for why this cannot loop.
  */
-const healRoster = makeRosterHealer((workspaceId) =>
-  useAgentStore.getState().loadAgents(workspaceId, { silent: true }),
-);
-
 export function useStaleRosterHeal(agentGone: boolean): void {
   const workspaceId = useWorkspaceStore((s) => s.current?.id ?? null);
   useEffect(() => {
-    void healRoster(workspaceId, agentGone);
+    void healStaleRoster(workspaceId, agentGone);
   }, [workspaceId, agentGone]);
 }

--- a/app/src/lib/agent-gone.ts
+++ b/app/src/lib/agent-gone.ts
@@ -18,10 +18,12 @@
  *
  * Like `isMissingSkillError`, the classifier keys on the structural
  * `.status`: the TS host emits bare-string error bodies with no typed
- * `kind`, and a manifest GET has exactly one 404 path — the agent is gone —
- * so the status is unambiguous in context. Applied ONLY to passive
- * roster-driven queries; user-initiated reads/writes keep the default loud
- * surfacing.
+ * `kind`, and an agent-scoped read has exactly one 404 path — the agent is
+ * gone (a missing data file answers 200 with empty content, and a missing
+ * skill goes through `isMissingSkillError` on its own route) — so the status
+ * is unambiguous in context. Applied ONLY to passive reads — the manifest
+ * queries and the `passiveAgentRead` wrappers in `lib/tauri.ts`
+ * (HOUSTON-APP-4W3 family); writes keep the default loud surfacing.
  */
 export function isAgentGoneError(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
@@ -79,5 +81,25 @@ export function makeRosterHealer(
       inFlight = false;
     }
     return true;
+  };
+}
+
+/**
+ * The engine-call-layer trigger: classify a failed passive read and, when the
+ * agent is gone, fire the roster heal for the current workspace — the same
+ * classify→heal contract `useStaleRosterHeal` gives the query surfaces, for
+ * reads whose surfaces don't observe the error (HOUSTON-APP-4W3 family).
+ * Factory form so the wiring is unit-testable: `heal` is the ONE shared
+ * healer (`lib/roster-heal.ts`) and `currentWorkspaceId` reads the workspace
+ * store. Anything but an agent-gone error is a no-op — surfacing stays with
+ * the caller.
+ */
+export function makeAgentGoneHealTrigger(
+  heal: (workspaceId: string | null, agentGone: boolean) => Promise<boolean>,
+  currentWorkspaceId: () => string | null,
+): (err: unknown) => void {
+  return (err) => {
+    if (!isAgentGoneError(err)) return;
+    void heal(currentWorkspaceId(), true);
   };
 }

--- a/app/src/lib/roster-heal.ts
+++ b/app/src/lib/roster-heal.ts
@@ -1,0 +1,25 @@
+import { useAgentStore } from "../stores/agents";
+import { useWorkspaceStore } from "../stores/workspaces";
+import { makeAgentGoneHealTrigger, makeRosterHealer } from "./agent-gone";
+
+/**
+ * THE stale-roster healer — the silent roster reload that makes a ghost agent
+ * (one the server no longer knows) disappear from the rail on its own. ONE
+ * module-level instance, so every trigger path — the surfaces'
+ * `useStaleRosterHeal` hook and the engine-call layer's `passiveAgentRead`
+ * (`lib/tauri.ts`) — shares a single in-flight dedupe; see `makeRosterHealer`
+ * for why this cannot loop.
+ */
+export const healStaleRoster = makeRosterHealer((workspaceId) =>
+  useAgentStore.getState().loadAgents(workspaceId, { silent: true }),
+);
+
+/**
+ * Heal when a failed engine read says the agent is gone; a no-op for every
+ * other error. Reads the workspace from the store because the engine-call
+ * layer has no render context to take it from.
+ */
+export const healStaleRosterFromError = makeAgentGoneHealTrigger(
+  healStaleRoster,
+  () => useWorkspaceStore.getState().current?.id ?? null,
+);

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -28,6 +28,7 @@ import type {
 } from "@houston-ai/engine-client";
 import { shouldUseClaudeDesktopLogin } from "../components/shell/provider-login-url";
 import { actingUser } from "./acting-user";
+import { isAgentGoneError } from "./agent-gone";
 import { isAgentNameConflictError } from "./agent-name-conflict";
 import {
   blockWriteWhileWarming,
@@ -57,6 +58,7 @@ import { isMissingSkillError } from "./missing-skill";
 import { isNetworkTransportError } from "./network-transport-error";
 import { osIsTauri, osPickDirectory } from "./os-bridge";
 import { normalizeLegacyModel } from "./providers";
+import { healStaleRosterFromError } from "./roster-heal";
 import { isSharedSkillsUnconfiguredError } from "./shared-skills-availability";
 import { isNeedsUpgradeError, isPersonalSpaceError } from "./team-status-model";
 import { isToolkitOauthUnavailableError } from "./toolkit-oauth-unavailable";
@@ -117,6 +119,28 @@ async function call<T>(
     await surfaceError(label, err, context, options);
     throw err;
   }
+}
+
+/**
+ * A passive agent-scoped READ — fired by roster-driven queries and event
+ * refetches, never by a user action. When the local roster is stale (the
+ * agent was deleted/unshared on another device, or a space switch refired
+ * queries built from the previous space's roster), the gateway/host answers
+ * `404 { error: "agent not found" }`, and every such read fanned that into a
+ * red bug toast + Sentry report for a state the user can't act on
+ * (HOUSTON-APP-4W3 and family). Same contract as the skills-manifest queries
+ * (HOUSTON-APP-544): the agent-gone 404 is silenced (`call` still logs it)
+ * and the roster silently reloads so the ghost agent disappears on its own —
+ * the honest surface. Every other failure keeps the default loud path, and
+ * writes never route through here.
+ */
+function passiveAgentRead<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  return call<T>(label, fn, undefined, { silence: isAgentGoneError }).catch(
+    (err) => {
+      healStaleRosterFromError(err);
+      throw err;
+    },
+  );
 }
 
 /**
@@ -600,7 +624,7 @@ export const tauriAgent = {
   readFile: (agentPath: string, relPath: string) =>
     isAgentPathCreating(agentPath)
       ? Promise.resolve("")
-      : call<string>("read_agent_file", () =>
+      : passiveAgentRead<string>("read_agent_file", () =>
           getEngine().readAgentFile(agentPath, relPath),
         ),
   writeFile: (
@@ -634,7 +658,7 @@ export const tauriSkills = {
   list: (agentPath: string) =>
     isAgentPathCreating(agentPath)
       ? Promise.resolve<SkillSummary[]>([])
-      : call<SkillSummary[]>("list_skills", async () =>
+      : passiveAgentRead<SkillSummary[]>("list_skills", async () =>
           (await getEngine().listSkills(agentPath)).map((s) => ({
             name: s.name,
             title: s.title ?? null,
@@ -1027,7 +1051,7 @@ export const tauriFiles = {
   list: (agentPath: string) =>
     isAgentPathCreating(agentPath)
       ? Promise.resolve<FileEntry[]>([])
-      : call<FileEntry[]>("list_project_files", async () =>
+      : passiveAgentRead<FileEntry[]>("list_project_files", async () =>
           (await getEngine().listProjectFiles(agentPath)).map((f) => ({
             path: f.path,
             name: f.name,
@@ -1152,7 +1176,7 @@ export const tauriConversations = {
   list: (agentPath: string) =>
     isAgentPathCreating(agentPath)
       ? Promise.resolve<RawConversation[]>([])
-      : call<RawConversation[]>("list_conversations", async () =>
+      : passiveAgentRead<RawConversation[]>("list_conversations", async () =>
           (await getEngine().listConversations(agentPath)).map(
             conversationToRaw,
           ),
@@ -1228,7 +1252,9 @@ export const tauriRoutines = {
   list: (agentPath: string) =>
     isAgentPathCreating(agentPath)
       ? Promise.resolve([])
-      : call("list_routines", () => getEngine().listRoutines(agentPath)),
+      : passiveAgentRead("list_routines", () =>
+          getEngine().listRoutines(agentPath),
+        ),
   create: (
     agentPath: string,
     input: EngineNewRoutine,
@@ -1258,7 +1284,7 @@ export const tauriRoutines = {
   listRuns: (agentPath: string, routineId?: string) =>
     isAgentPathCreating(agentPath)
       ? Promise.resolve([])
-      : call("list_routine_runs", () =>
+      : passiveAgentRead("list_routine_runs", () =>
           getEngine().listRoutineRuns(agentPath, routineId),
         ),
   runNow: (agentPath: string, routineId: string) => {

--- a/app/tests/agent-gone.test.ts
+++ b/app/tests/agent-gone.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   agentRosterSettled,
   isAgentGoneError,
+  makeAgentGoneHealTrigger,
   makeRosterHealer,
 } from "../src/lib/agent-gone.ts";
 
@@ -114,5 +115,53 @@ describe("makeRosterHealer", () => {
     // The failed reload must not wedge the healer shut forever.
     assert.equal(await heal("ws-1", true), true);
     assert.equal(attempts, 2);
+  });
+});
+
+describe("makeAgentGoneHealTrigger", () => {
+  const agentGone = Object.assign(
+    new Error("agent not found (engine error 404)"),
+    { status: 404, body: { error: "agent not found" } },
+  );
+
+  it("fires the heal for the current workspace on an agent-gone read", () => {
+    const calls: Array<[string | null, boolean]> = [];
+    const trigger = makeAgentGoneHealTrigger(
+      async (ws, gone) => {
+        calls.push([ws, gone]);
+        return true;
+      },
+      () => "ws-1",
+    );
+    trigger(agentGone);
+    assert.deepEqual(calls, [["ws-1", true]]);
+  });
+
+  it("ignores every other failure — surfacing stays with the caller", () => {
+    let calls = 0;
+    const trigger = makeAgentGoneHealTrigger(
+      async () => {
+        calls += 1;
+        return true;
+      },
+      () => "ws-1",
+    );
+    trigger(Object.assign(new Error("engine unavailable"), { status: 503 }));
+    trigger(new Error("boom"));
+    trigger(undefined);
+    assert.equal(calls, 0);
+  });
+
+  it("passes a missing workspace through as null (healer no-ops)", () => {
+    const calls: Array<string | null> = [];
+    const trigger = makeAgentGoneHealTrigger(
+      async (ws) => {
+        calls.push(ws);
+        return false;
+      },
+      () => null,
+    );
+    trigger(agentGone);
+    assert.deepEqual(calls, [null]);
   });
 });

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -728,6 +728,8 @@ The same idea one level up: the shared-skills **manifest** queries (`use-agent-s
 - **Silence**: the query reads pass `{ silence: isAgentGoneError }` — a stale-roster 404 is expected lifecycle, not a red bug toast + Sentry report. Only these passive roster-driven reads are silenced; user-initiated manifest reads/writes keep the default loud surfacing, and 5xx keeps its designed loud path (`cp/transient-retry.ts`).
 - **Heal**: on an observed agent-gone error, `useStaleRosterHeal` silently reloads the current workspace's roster (deduped, cannot loop) so the ghost agent disappears from the rail on its own — the honest surface for a deleted agent.
 
+The same contract covers every other **passive agent-scoped read** (HOUSTON-APP-4W3 family: `read_agent_file` behind the board's activity/config/learnings/instructions queries, `list_skills`, `list_project_files`, `list_conversations`, `list_routines`, `list_routine_runs`) at the engine-call layer: the `passiveAgentRead` wrapper in `app/src/lib/tauri.ts` silences the agent-gone 404 and fires the ONE shared roster healer (`app/src/lib/roster-heal.ts` — one in-flight dedupe shared with `useStaleRosterHeal`). A missing data file is NOT a 404 — the host's agentfile GET answers `200 { content: "" }` (`packages/host/src/routes/agent-file.ts`) — so the status stays unambiguous. Writes never route through the wrapper and keep the loud path.
+
 ## Files of interest
 
 | What | Where |


### PR DESCRIPTION
Fixes PRODUCT-1337 (Sentry HOUSTON-APP-4W3: `read_agent_file: agent not found (engine error 404)` — 966 events / 182 users).

## Root cause

`read_agent_file` (behind the board's activity/config/learnings/instructions queries), `list_skills`, `list_project_files`, `list_conversations`, `list_routines`, and `list_routine_runs` are **passive roster-driven reads**, but every failure took the red-bug-toast + Sentry path. When the local roster is stale relative to the server — an agent deleted/unshared on another device, or a space switch's cache wipe refiring queries built from the previous space's roster before `loadAgents` re-resolves — the gateway answers `404 {"error":"agent not found"}` and the user gets a storm of bug toasts for background reads on a ghost agent. The latest event's breadcrumbs show one such beat: `list_project_files`, `list_skills`, and `read_agent_file` all 404ing for the same agent slug back-to-back.

PR #1295 (HOUSTON-APP-544) fixed exactly this for the skills-manifest queries. This PR extends the same contract — **silence the agent-gone 404, silently heal the roster** — to the rest of the passive read family, at the engine-call layer.

The 404 is unambiguous on these routes: a missing data file answers `200 { content: "" }` (`packages/host/src/routes/agent-file.ts`), and a missing skill rides its own route through `isMissingSkillError` — so `status === 404` on these reads means exactly "the agent is gone".

## Changes

- `app/src/lib/tauri.ts`: new `passiveAgentRead` wrapper — passes `{ silence: isAgentGoneError }` (the failure is still logged by `call()`) and fires the shared roster heal; applied to the six passive per-agent reads. Writes and user-initiated ops keep the default loud surfacing; 5xx keeps its loud path.
- `app/src/lib/roster-heal.ts` (new): THE module-level roster healer — one in-flight dedupe shared by the surfaces' `useStaleRosterHeal` hook and the engine-call layer — plus `healStaleRosterFromError` for callers with no render context.
- `app/src/lib/agent-gone.ts`: `makeAgentGoneHealTrigger` factory (testable classify→heal wiring); classifier doc updated for the widened scope.
- `app/src/hooks/use-stale-roster-heal.ts`: delegates to the shared healer.
- Tests: `app/tests/agent-gone.test.ts` — trigger fires on agent-gone, ignores every other failure, passes null workspace through to the no-op healer.
- Docs: `knowledge-base/skills.md` agent-gone section extended.

Sibling Sentry issues fixed by the same change: HOUSTON-APP-545/54A (`list_project_files`), 4WQ/54W/51P (`list_skills`), 4W2/55D (`list_routines`), 54X (`list_routine_runs`), 4WR/540/51Q/51M (`list_conversations`), 506/512/51N (`read_agent_file` duplicates).

## Before (reproduce the bug)

1. On device A, open an agent's screen (board/files/skills mounted) in a team space.
2. On device B (or as another member), delete or unshare that agent.
3. Back on device A, trigger a refetch (switch spaces back and forth, or refocus the window): every mounted query for the ghost agent fires, the gateway answers `404 agent not found`, and the user gets red "report a bug" toasts for `read_agent_file` / `list_skills` / `list_project_files` / `list_routines`, each also captured to Sentry.

## After (verify the fix)

1. Repeat the same steps on a build with this change.
2. No red bug toasts and no Sentry events for the agent-gone 404s (the local log tail still records each `[engine:read_agent_file] agent not found …` line).
3. Within a beat, the roster silently reloads and the ghost agent disappears from the rail — the honest surface.
4. Regression checks: a genuinely failing read (e.g. engine 5xx) still toasts loudly; deleting a file, renaming, and other writes on a live agent still surface errors; `cd app && pnpm test` (3458 pass) and `pnpm typecheck` are green.

🤖 Generated with Claude Fable 5