### PR TITLE
feat: phase 3C — transcript/doc shadow-write + turnlog capture (PRODUCT-1303)

### DIFF
--- a/knowledge-base/files-first.md
+++ b/knowledge-base/files-first.md
@@ -23,6 +23,23 @@ Houston uses files, not a DB, for everything. The only SQLite left is a read-onl
 > as `ConversationsChanged`, which the gateway fans to every client so an open
 > chat on another device reloads the same transcript.
 
+### Managed durable-turn shadows
+
+Two managed-cloud rollout caps mirror this file model without changing its
+authority. `HOUSTON_TRANSCRIPT_DUAL_WRITE=1` queues transcript mutations only
+after the atomic file rename and projects watcher-observed `activity`,
+`routines`, `routine_runs`, `config`, and `learnings` files to the gateway.
+Failures, revision conflicts, and deploy skew are contained in the shadow path;
+the local file and object-store sync remain the source used by the turn.
+Reconcile may use the gateway's narrow `reply-after` query while this cap is on,
+but falls back to the transcript file when the route is unavailable.
+
+`HOUSTON_TURN_LOG=1` independently forwards authoritative sequenced turn frames
+from the host to the gateway in bounded, detached batches. This is a resume
+shadow only: an ingest gap leaves the existing live-pod resume path intact.
+Both caps are constructed only for a fully configured managed pod and reuse its
+pod token, boot id, and shared fencing-token holder.
+
 ## Rule
 If @houston-ai component renders it → `.houston/` folder.
 If app-specific → `.houston/`.

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -66,6 +66,14 @@ export class ProxyChannel implements RuntimeChannel {
       forwardActingHeader: boolean;
       /** Managed pod shared-cache freshness gate, invoked only for turn starts. */
       beforeTurn?: (agent: ChannelCtx["agent"]) => Promise<void>;
+      /** Detached standing-runtime SSE capture for durable turnlog ingest. */
+      turnLogCapture?: {
+        capture(
+          endpoint: RuntimeEndpoint,
+          agentId: string,
+          conversationId: string,
+        ): void;
+      };
       /** Injectable for tests; defaults to the process-wide ledger. */
       revocations?: RevocationTombstones;
     },
@@ -112,7 +120,19 @@ export class ProxyChannel implements RuntimeChannel {
     if (!body && method !== "GET" && method !== "HEAD") {
       body = await readBody(req, MAX_JSON_BYTES);
     }
-    if (method === "POST" && /^conversations\/[^/]+\/messages$/.test(rest)) {
+    const turnStart = rest.match(/^conversations\/([^/]+)\/messages$/);
+    if (method === "POST" && turnStart) {
+      try {
+        const conversationId = decodeURIComponent(turnStart[1] ?? "");
+        this.opts.turnLogCapture?.capture(
+          endpoint,
+          ctx.agent.id,
+          conversationId,
+        );
+      } catch (error) {
+        // Shadow-only: a malformed id or capture setup must never affect send.
+        console.debug("[turnlog] standing capture enqueue failed", error);
+      }
       await this.opts.beforeTurn?.(ctx.agent);
     }
     const params = new URLSearchParams(url.search);
@@ -168,6 +188,11 @@ export class ProxyChannel implements RuntimeChannel {
     // an errored run.
     const endpoint = await this.opts.launcher.ensureAwake(ctx.agent);
     await this.opts.beforeTurn?.(ctx.agent);
+    try {
+      this.opts.turnLogCapture?.capture(endpoint, ctx.agent.id, conversationId);
+    } catch (error) {
+      console.debug("[turnlog] standing routine capture enqueue failed", error);
+    }
     const res = await fetch(
       `${endpoint.baseUrl}/conversations/${encodeURIComponent(conversationId)}/messages`,
       {

--- a/packages/host/src/docs/http-shadow.test.ts
+++ b/packages/host/src/docs/http-shadow.test.ts
@@ -1,0 +1,49 @@
+import { expect, test, vi } from "vitest";
+import { HttpDocShadow } from "./http-shadow";
+
+test("doc shadow seeds and advances If-Match with fencing headers", async () => {
+  const requests: RequestInit[] = [];
+  const fetchImpl = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+    requests.push(init ?? {});
+    if (!init?.method || init.method === "GET") {
+      return Response.json({ doc: [], revision: 4 });
+    }
+    return Response.json({ revision: 5 });
+  });
+  const shadow = new HttpDocShadow({
+    gateway: {
+      baseUrl: "https://store.example",
+      orgSlug: "acme",
+      agentSlug: "helper",
+      podToken: "pod-token",
+      bootId: "boot-1",
+      fence: { token: "51" },
+    },
+    fetchImpl: fetchImpl as typeof fetch,
+  });
+
+  await shadow.seed();
+  await shadow.put("learnings", [{ id: "l1" }]);
+
+  const headers = new Headers(requests.at(-1)?.headers);
+  expect(headers.get("if-match")).toBe("4");
+  expect(headers.get("x-houston-fencing-token")).toBe("51");
+  expect(headers.get("x-houston-boot-id")).toBe("boot-1");
+  expect(requests.at(-1)?.body).toBe('{"doc":[{"id":"l1"}]}');
+});
+
+test("a doc revision conflict is shadow-only", async () => {
+  const shadow = new HttpDocShadow({
+    gateway: {
+      baseUrl: "https://store.example",
+      orgSlug: "acme",
+      agentSlug: "helper",
+      podToken: "pod-token",
+      bootId: "boot-1",
+      fence: {},
+    },
+    fetchImpl: vi.fn(async () => new Response("conflict", { status: 409 })),
+  });
+
+  await expect(shadow.put("activity", [])).resolves.toBeUndefined();
+});

--- a/packages/host/src/docs/http-shadow.ts
+++ b/packages/host/src/docs/http-shadow.ts
@@ -1,0 +1,123 @@
+import { FAMILIES, type HoustonFamily } from "@houston/domain";
+import {
+  capturePodFence,
+  type PodGatewayConfig,
+  podGatewayHeaders,
+  podGatewayUrl,
+} from "../pod-gateway";
+
+export interface DocShadow {
+  seed(): Promise<void>;
+  put(family: HoustonFamily, doc: unknown): Promise<void>;
+}
+
+export class HttpDocShadow implements DocShadow {
+  private readonly fetchImpl: typeof fetch;
+  private readonly revisions = new Map<HoustonFamily, number>();
+  private disabled = false;
+
+  constructor(
+    private readonly opts: {
+      gateway: PodGatewayConfig;
+      fetchImpl?: typeof fetch;
+    },
+  ) {
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  async seed(): Promise<void> {
+    await Promise.all(FAMILIES.map((family) => this.seedFamily(family)));
+  }
+
+  async put(family: HoustonFamily, doc: unknown): Promise<void> {
+    if (this.disabled) return;
+    const response = await this.fetchImpl(this.url(family), {
+      method: "PUT",
+      headers: podGatewayHeaders(this.opts.gateway, {
+        write: true,
+        json: true,
+        extra: { "If-Match": String(this.revisions.get(family) ?? 0) },
+      }),
+      body: JSON.stringify({ doc }),
+      signal: AbortSignal.timeout(5_000),
+    });
+    capturePodFence(this.opts.gateway, response);
+    if (response.status === 404) return this.disableForSkew();
+    if (response.status === 409) {
+      console.debug(
+        `[doc-shadow] ${family} revision conflict; file remains authoritative`,
+      );
+      return;
+    }
+    if (!response.ok) throw await responseError(response, family, "PUT");
+    const revision = await responseRevision(response);
+    if (revision !== undefined) this.revisions.set(family, revision);
+  }
+
+  private async seedFamily(family: HoustonFamily): Promise<void> {
+    if (this.disabled) return;
+    try {
+      const response = await this.fetchImpl(this.url(family), {
+        headers: podGatewayHeaders(this.opts.gateway),
+        signal: AbortSignal.timeout(5_000),
+      });
+      capturePodFence(this.opts.gateway, response);
+      if (response.status === 404) {
+        this.revisions.set(family, 0);
+        return;
+      }
+      if (!response.ok) throw await responseError(response, family, "GET");
+      const revision = await responseRevision(response);
+      this.revisions.set(family, revision ?? 0);
+    } catch (error) {
+      console.debug(`[doc-shadow] ${family} revision seed failed`, error);
+      this.revisions.set(family, 0);
+    }
+  }
+
+  private url(family: HoustonFamily): string {
+    const { gateway } = this.opts;
+    return podGatewayUrl(
+      gateway,
+      `/v1/pod/docs/${encodeURIComponent(gateway.orgSlug)}/${encodeURIComponent(gateway.agentSlug)}/${family}`,
+    );
+  }
+
+  private disableForSkew(): void {
+    if (this.disabled) return;
+    this.disabled = true;
+    console.debug(
+      "[doc-shadow] gateway route unavailable; disabling for this process",
+    );
+  }
+}
+
+async function responseRevision(
+  response: Response,
+): Promise<number | undefined> {
+  const etag = response.headers
+    .get("ETag")
+    ?.replace(/^W\//, "")
+    .replaceAll('"', "");
+  if (etag && Number.isSafeInteger(Number(etag))) return Number(etag);
+  const text = await response.text();
+  if (!text) return undefined;
+  try {
+    const body = JSON.parse(text) as { revision?: unknown };
+    return typeof body.revision === "number" ? body.revision : undefined;
+  } catch (error) {
+    console.debug("[doc-shadow] response carried no revision", error);
+    return undefined;
+  }
+}
+
+async function responseError(
+  response: Response,
+  family: HoustonFamily,
+  method: string,
+): Promise<Error> {
+  const detail = await response.text();
+  return new Error(
+    `doc shadow ${method} ${family} failed (${response.status}): ${detail.slice(0, 300)}`,
+  );
+}

--- a/packages/host/src/docs/projector.test.ts
+++ b/packages/host/src/docs/projector.test.ts
@@ -1,0 +1,41 @@
+import { docKey } from "@houston/domain";
+import { expect, test } from "vitest";
+import { LocalPaths } from "../paths";
+import { MemoryWorkspaceStore } from "../store/memory";
+import { MemoryVfs } from "../vfs";
+import type { DocShadow } from "./http-shadow";
+import { DocShadowProjector } from "./projector";
+
+test("a family watcher event shadows the file's current whole document", async () => {
+  const store = new MemoryWorkspaceStore();
+  const vfs = new MemoryVfs();
+  const paths = new LocalPaths();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "A",
+  });
+  const root = paths.agentRoot(workspace, agent);
+  const puts: unknown[] = [];
+  const shadow: DocShadow = {
+    async seed() {},
+    async put(family, doc) {
+      puts.push({ family, doc });
+    },
+  };
+  const projector = new DocShadowProjector({ store, vfs, paths, shadow });
+  await vfs.writeText(
+    docKey(root, "learnings"),
+    JSON.stringify([{ id: "l1", text: "remember", created_at: "now" }]),
+  );
+
+  projector.onEvent({ type: "LearningsChanged", agentPath: agent.id });
+  await projector.flush();
+
+  expect(puts).toEqual([
+    {
+      family: "learnings",
+      doc: [{ id: "l1", text: "remember", created_at: "now" }],
+    },
+  ]);
+});

--- a/packages/host/src/docs/projector.ts
+++ b/packages/host/src/docs/projector.ts
@@ -1,0 +1,74 @@
+import { docKey, type HoustonFamily } from "@houston/domain";
+import type { HoustonEvent } from "@houston/protocol";
+import type { WorkspacePaths } from "../paths";
+import type { WorkspaceStore } from "../ports";
+import type { Vfs } from "../vfs";
+import type { DocShadow } from "./http-shadow";
+
+const EVENT_FAMILY: Partial<Record<HoustonEvent["type"], HoustonFamily>> = {
+  ActivityChanged: "activity",
+  RoutinesChanged: "routines",
+  RoutineRunsChanged: "routine_runs",
+  ConfigChanged: "config",
+  LearningsChanged: "learnings",
+};
+
+/**
+ * Projects watcher-observed family files into the managed DB shadow. The same
+ * path sees host writes and direct agent edits; all I/O is serialized per
+ * family and contained here so watcher delivery never waits or fails.
+ */
+export class DocShadowProjector {
+  private readonly tails = new Map<string, Promise<void>>();
+  private ready: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly deps: {
+      store: WorkspaceStore;
+      vfs: Vfs;
+      paths: WorkspacePaths;
+      shadow: DocShadow;
+    },
+  ) {}
+
+  seed(): void {
+    this.ready = this.deps.shadow.seed().catch((error: unknown) => {
+      console.debug("[doc-shadow] boot revision seed failed", error);
+    });
+  }
+
+  onEvent(event: HoustonEvent): void {
+    const family = EVENT_FAMILY[event.type];
+    if (!family || !("agentPath" in event)) return;
+    const key = `${event.agentPath}#${family}`;
+    const prior = this.tails.get(key) ?? this.ready;
+    const task = prior
+      .then(() => this.project(event.agentPath, family))
+      .catch((error: unknown) => {
+        console.debug(`[doc-shadow] ${key} projection failed`, error);
+      })
+      .finally(() => {
+        if (this.tails.get(key) === task) this.tails.delete(key);
+      });
+    this.tails.set(key, task);
+  }
+
+  async flush(): Promise<void> {
+    await this.ready;
+    await Promise.all([...this.tails.values()]);
+  }
+
+  private async project(agentId: string, family: HoustonFamily): Promise<void> {
+    const agent = await this.deps.store.getAgent(agentId);
+    if (!agent) return;
+    const workspace = await this.deps.store.getWorkspace(agent.workspaceId);
+    if (!workspace) return;
+    const root = this.deps.paths.agentRoot(workspace, agent);
+    const raw = await this.deps.vfs.readText(docKey(root, family));
+    if (raw === null) return;
+    await this.deps.shadow.put(
+      family,
+      JSON.parse(raw.replace(/^\uFEFF/, "")) as unknown,
+    );
+  }
+}

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -15,6 +15,8 @@ import { FileCredentialStore } from "../credentials/file-store";
 import { RemoteSharedEndpointStore } from "../credentials/remote-shared-endpoint-store";
 import { RemoteCredentialStore } from "../credentials/remote-store";
 import { EnvCredentialVault } from "../credentials/vault";
+import { HttpDocShadow } from "../docs/http-shadow";
+import { DocShadowProjector } from "../docs/projector";
 import { BusEventHub } from "../events/hub";
 import { ComposioProvider } from "../integrations/composio";
 import { CustomExecutorHost } from "../integrations/custom/executor-host";
@@ -33,6 +35,7 @@ import { migrateAgentLayouts } from "../migrate/agent-layout";
 import { reseedAgentSchemas } from "../migrate/agent-schemas";
 import { migrateChatHistory } from "../migrate/chat-history";
 import { LocalPaths } from "../paths";
+import type { PodGatewayConfig } from "../pod-gateway";
 import type { ChannelCtx } from "../ports";
 import { forward } from "../proxy/route";
 import { CredentialServeHealer } from "../routes/credential-healer";
@@ -45,7 +48,11 @@ import { LocalWorkspaceStore } from "../store/local";
 import { SharedMirrorController, StoreSyncDaemon } from "../store-sync";
 import { BootTelemetry } from "../telemetry/boot";
 import { sendBootReport } from "../telemetry/boot-report";
+import { HttpTranscriptShadow } from "../transcripts/http-shadow";
 import { MemoryTurnBus } from "../turn/bus";
+import { FrameForwarder } from "../turn/frame-forwarder";
+import { StandingFrameCapture } from "../turn/standing-frame-capture";
+import { HttpTurnLogSender } from "../turn/turn-log-http";
 import { UsageSampler } from "../usage/sampler";
 import { FsVfs } from "../vfs";
 import { FsWatcher } from "../watch/watcher";
@@ -220,6 +227,12 @@ export interface LocalHostOptions {
     agentSlug: string;
     podToken: string;
   };
+  /** Managed durable-turn shadows. Both switches are explicit rollout caps. */
+  durableTurns?: {
+    gateway: PodGatewayConfig;
+    transcriptDualWrite: boolean;
+    turnLog: boolean;
+  };
 }
 
 export interface LocalHost {
@@ -293,6 +306,24 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
       })
     : undefined;
   const controlPlaneUrl = `http://127.0.0.1:${opts.port}`;
+  const transcriptShadow = opts.durableTurns?.transcriptDualWrite
+    ? new HttpTranscriptShadow({ gateway: opts.durableTurns.gateway })
+    : undefined;
+  const docShadow = opts.durableTurns?.transcriptDualWrite
+    ? new HttpDocShadow({ gateway: opts.durableTurns.gateway })
+    : undefined;
+  const docProjector = docShadow
+    ? new DocShadowProjector({ store, vfs, paths, shadow: docShadow })
+    : undefined;
+  const frameForwarder = opts.durableTurns?.turnLog
+    ? new FrameForwarder({
+        bus,
+        sender: new HttpTurnLogSender({ gateway: opts.durableTurns.gateway }),
+      })
+    : undefined;
+  const standingFrameCapture = frameForwarder
+    ? new StandingFrameCapture(bus, frameForwarder)
+    : undefined;
 
   const spawner =
     opts.spawner ??
@@ -310,6 +341,9 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
         ...(process.env.HOUSTON_SIDECAR_BINARY
           ? { HOUSTON_SIDECAR_ROLE: "runtime" }
           : {}),
+        // Do not inherit a rollout flag into a runtime unless the host also
+        // constructed its pod-auth facade from the complete managed config.
+        HOUSTON_TRANSCRIPT_DUAL_WRITE: transcriptShadow ? "1" : "",
       },
       onLog: opts.onRuntimeLog,
     });
@@ -360,6 +394,7 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     // integration calls act as the driving user (C2).
     forwardActingHeader: opts.gatewayFronted ?? false,
     beforeTurn: sharedMirror ? () => sharedMirror.beforeTurn() : undefined,
+    turnLogCapture: standingFrameCapture,
   });
   const credentialHealer = opts.credentials
     ? new CredentialServeHealer(
@@ -568,6 +603,7 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     // always available — on managed cloud the Go control plane POSTs delivered
     // events to it. The lock dedupes redeliveries.
     triggerLock: bus,
+    transcriptShadow,
     agentConfigs,
     // Managed pods record the gateway-minted acting identity as a routine's
     // `created_by` (C2 — the sub the gateway re-authorizes at fire time);
@@ -590,9 +626,10 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
 
   const server = createControlPlaneServer(deps);
   // The agent (or the user) editing files directly → reactivity, no host write.
-  const watcher = new FsWatcher(opts.workspacesRoot, (e) =>
-    events.emit(LOCAL_USER, e),
-  );
+  const watcher = new FsWatcher(opts.workspacesRoot, (event) => {
+    events.emit(LOCAL_USER, event);
+    docProjector?.onEvent(event);
+  });
   const scheduler = new Scheduler({
     store,
     vfs,
@@ -600,6 +637,7 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     lock: bus,
     firer: new ChannelRoutineFirer({ local: channel }),
     events,
+    replyReader: transcriptShadow,
   });
   const syncDaemon = opts.storeSync
     ? new StoreSyncDaemon({
@@ -746,6 +784,8 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
       }
       boot.record("migrations", Date.now() - migrationsT0);
       bootStamp("hydration + migrations done");
+      // Seed CAS revisions at boot, but never put readiness behind shadow I/O.
+      docProjector?.seed();
       const bind = opts.bind ?? "127.0.0.1";
       await boot.time(
         "listen",
@@ -818,6 +858,8 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
       stopPromise = (async () => {
         scheduler.stop();
         watcher.stop();
+        standingFrameCapture?.stop();
+        frameForwarder?.stop();
         // Drain the last accrued stretch before the runtimes go down; the
         // sampler swallows report failures, so this never blocks a shutdown.
         await usageSampler?.stop();

--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -46,6 +46,8 @@ import { runtimeCommand } from "./runtime-command";
  *                             custom-integration OAuth callback (PRODUCT-1172)
  *   HOUSTON_PASSIVE=1        migration-source mode: no scheduler, no watcher
  *   HOUSTON_STORE_URL         managed pod only: object-store gateway base URL
+ *   HOUSTON_TRANSCRIPT_DUAL_WRITE=1  file-first transcript/doc DB shadow
+ *   HOUSTON_TURN_LOG=1        relay-frame batches to managed turnlog ingest
  */
 
 // Crash reporting. Dormant without SENTRY_DSN; a DSN in a source run needs the
@@ -168,6 +170,13 @@ const host = buildLocalHost({
   // Active-time reporting rides the same managed-pod gateway quadruple: the
   // env being present IS the switch (desktop/self-host never set it).
   usageReporting: remoteGateway,
+  durableTurns: managedStore?.podGateway
+    ? {
+        gateway: managedStore.podGateway,
+        transcriptDualWrite: process.env.HOUSTON_TRANSCRIPT_DUAL_WRITE === "1",
+        turnLog: process.env.HOUSTON_TURN_LOG === "1",
+      }
+    : undefined,
   // Migration-source spawns (HOU-719): serve + migrate on boot, but never fire
   // routines or churn watch events while the cloud app reads the old tree.
   passive: process.env.HOUSTON_PASSIVE === "1",

--- a/packages/host/src/local/managed-store-config.ts
+++ b/packages/host/src/local/managed-store-config.ts
@@ -69,6 +69,14 @@ export async function managedStoreConfig(
     );
   }
   return {
+    podGateway: {
+      baseUrl: url,
+      orgSlug,
+      agentSlug,
+      podToken: hostToken,
+      bootId,
+      fence,
+    },
     storeSync: {
       store: new HttpObjectStore({
         baseUrl: `${root}/${encodeURIComponent(agentSlug)}`,

--- a/packages/host/src/pod-gateway.ts
+++ b/packages/host/src/pod-gateway.ts
@@ -1,0 +1,40 @@
+export interface PodGatewayConfig {
+  baseUrl: string;
+  orgSlug: string;
+  agentSlug: string;
+  podToken: string;
+  bootId: string;
+  fence: { token?: string };
+}
+
+export function podGatewayUrl(gateway: PodGatewayConfig, path: string): string {
+  return `${gateway.baseUrl.replace(/\/+$/, "")}${path}`;
+}
+
+export function podGatewayHeaders(
+  gateway: PodGatewayConfig,
+  opts: {
+    write?: boolean;
+    json?: boolean;
+    extra?: Record<string, string>;
+  } = {},
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${gateway.podToken}`,
+    ...opts.extra,
+  };
+  if (opts.json) headers["Content-Type"] = "application/json";
+  if (opts.write && gateway.fence.token !== undefined) {
+    headers["X-Houston-Fencing-Token"] = gateway.fence.token;
+    headers["X-Houston-Boot-Id"] = gateway.bootId;
+  }
+  return headers;
+}
+
+export function capturePodFence(
+  gateway: PodGatewayConfig,
+  response: Response,
+): void {
+  const token = response.headers.get("X-Houston-Fencing-Token");
+  if (token !== null) gateway.fence.token = token;
+}

--- a/packages/host/src/routes/transcripts-sandbox.test.ts
+++ b/packages/host/src/routes/transcripts-sandbox.test.ts
@@ -1,0 +1,85 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import type { ChatMessage } from "@houston/protocol";
+import { expect, test, vi } from "vitest";
+import { EnvCredentialVault } from "../credentials/vault";
+import { MemoryWorkspaceStore } from "../store/memory";
+import type {
+  TranscriptShadow,
+  TranscriptShadowCommand,
+} from "../transcripts/http-shadow";
+import { handleSandboxTranscripts } from "./transcripts-sandbox";
+
+test("the sandbox facade authenticates and forwards the user turn verbatim", async () => {
+  const store = new MemoryWorkspaceStore();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "A",
+  });
+  const vault = new EnvCredentialVault({ secret: "host-secret" });
+  const commands: TranscriptShadowCommand[] = [];
+  const transcriptShadow: TranscriptShadow = {
+    async apply(command) {
+      commands.push(command);
+    },
+    async replyAfter() {
+      return null;
+    },
+  };
+  const message: ChatMessage = { role: "user", content: "hello", ts: 12 };
+  const req = Readable.from([
+    Buffer.from(
+      JSON.stringify({
+        message,
+        title: "hello",
+        expectedCount: 3,
+        needsSessionReplay: true,
+      }),
+    ),
+  ]) as IncomingMessage;
+  req.headers = {
+    authorization: `Bearer ${vault.sandboxToken(workspace.id, agent.id)}`,
+  };
+  const response = responseRecorder();
+
+  const handled = await handleSandboxTranscripts(
+    { vault, transcriptShadow },
+    "PUT",
+    "/sandbox/transcripts/conversations/c1/turns/t1/user",
+    new URL("http://host/sandbox/transcripts/conversations/c1/turns/t1/user"),
+    req,
+    response.res,
+  );
+
+  expect(handled).toBe(true);
+  expect(response.status).toBe(202);
+  expect(commands).toEqual([
+    {
+      kind: "user",
+      conversationId: "c1",
+      turnId: "t1",
+      message,
+      title: "hello",
+      expectedCount: 3,
+      needsSessionReplay: true,
+    },
+  ]);
+});
+
+function responseRecorder() {
+  const state = { status: 0 };
+  const res = {
+    writeHead: vi.fn((status: number) => {
+      state.status = status;
+      return res;
+    }),
+    end: vi.fn(),
+  } as unknown as ServerResponse;
+  return {
+    res,
+    get status() {
+      return state.status;
+    },
+  };
+}

--- a/packages/host/src/routes/transcripts-sandbox.ts
+++ b/packages/host/src/routes/transcripts-sandbox.ts
@@ -1,0 +1,128 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { ChatMessage } from "@houston/protocol";
+import type { CredentialVault } from "../ports";
+import type {
+  TranscriptShadow,
+  TranscriptShadowCommand,
+} from "../transcripts/http-shadow";
+import { bearer, json, readJson } from "./http";
+
+const ROOT = /^\/sandbox\/transcripts\/conversations\/([^/]+)(?:\/(.*))?$/;
+
+export async function handleSandboxTranscripts(
+  deps: {
+    vault: CredentialVault;
+    transcriptShadow?: TranscriptShadow;
+  },
+  method: string,
+  path: string,
+  url: URL,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  const match = path.match(ROOT);
+  if (!match) return false;
+  const token = bearer(req, url);
+  if (!token || !deps.vault.validateSandboxToken(token)) {
+    json(res, 401, { error: "unauthorized" });
+    return true;
+  }
+  if (!deps.transcriptShadow) {
+    json(res, 503, { error: "transcript shadow not configured" });
+    return true;
+  }
+
+  let conversationId: string;
+  try {
+    conversationId = decodeURIComponent(match[1] ?? "");
+  } catch {
+    json(res, 400, { error: "invalid conversation id" });
+    return true;
+  }
+  const rest = match[2] ?? "";
+  const body = method === "DELETE" ? {} : await readJson(req);
+  const command = parseCommand(method, rest, conversationId, body);
+  if (!command) {
+    json(res, 400, { error: "invalid transcript shadow request" });
+    return true;
+  }
+  await deps.transcriptShadow.apply(command);
+  json(res, 202, { ok: true });
+  return true;
+}
+
+function parseCommand(
+  method: string,
+  rest: string,
+  conversationId: string,
+  body: Record<string, unknown>,
+): TranscriptShadowCommand | null {
+  const turn = rest.match(/^turns\/([^/]+)\/(user|assistant)$/);
+  if (method === "PUT" && turn) {
+    const message = body.message;
+    if (!isChatMessage(message)) return null;
+    const turnId = decodeURIComponent(turn[1] ?? "");
+    if (turn[2] === "assistant") {
+      if (message.role !== "assistant" || mismatchedTurn(message, turnId)) {
+        return null;
+      }
+      return { kind: "assistant", conversationId, turnId, message };
+    }
+    if (
+      message.role !== "user" ||
+      mismatchedTurn(message, turnId) ||
+      !Number.isSafeInteger(body.expectedCount) ||
+      (body.expectedCount as number) < 0 ||
+      typeof body.needsSessionReplay !== "boolean" ||
+      typeof body.title !== "string"
+    ) {
+      return null;
+    }
+    return {
+      kind: "user",
+      conversationId,
+      turnId,
+      message,
+      title: body.title,
+      expectedCount: body.expectedCount as number,
+      needsSessionReplay: body.needsSessionReplay,
+    };
+  }
+  if (method === "POST" && rest === "truncate") {
+    return typeof body.turnId === "string"
+      ? { kind: "truncate", conversationId, turnId: body.turnId }
+      : null;
+  }
+  if (method === "POST" && rest === "repair") {
+    return body && typeof body === "object"
+      ? { kind: "repair", conversationId, conversation: body }
+      : null;
+  }
+  if (method === "PUT" && rest === "") {
+    return typeof body.title === "string"
+      ? {
+          kind: "rename",
+          conversationId,
+          title: body.title,
+        }
+      : null;
+  }
+  if (method === "DELETE" && rest === "") {
+    return { kind: "delete", conversationId };
+  }
+  return null;
+}
+
+function mismatchedTurn(message: ChatMessage, turnId: string): boolean {
+  return message.turnId !== undefined && message.turnId !== turnId;
+}
+
+function isChatMessage(value: unknown): value is ChatMessage {
+  if (!value || typeof value !== "object") return false;
+  const message = value as Partial<ChatMessage>;
+  return (
+    (message.role === "user" || message.role === "assistant") &&
+    typeof message.content === "string" &&
+    typeof message.ts === "number"
+  );
+}

--- a/packages/host/src/schedule/agent-scan.ts
+++ b/packages/host/src/schedule/agent-scan.ts
@@ -5,7 +5,7 @@ import type { Agent, Workspace } from "../domain/types";
 import type { EventHub } from "../events/hub";
 import type { WorkspacePaths } from "../paths";
 import type { Vfs } from "../vfs";
-import { reconcileAgentRuns } from "./reconcile";
+import { type ReconcileDeps, reconcileAgentRuns } from "./reconcile";
 import { fireRoutineRun, RoutineBusyError } from "./run";
 
 /** A due routine to run, with its resolved conversation + run id. */
@@ -43,6 +43,7 @@ export interface AgentScanDeps {
   newId: () => string;
   /** Dedup-lock TTL (s); must exceed the scan interval. */
   dedupTtlSec: number;
+  replyReader?: ReconcileDeps["replyReader"];
 }
 
 const reason = (err: unknown) =>
@@ -101,6 +102,7 @@ export async function scanAgent(
         events: deps.events,
         now: deps.now,
         newId: deps.newId,
+        replyReader: deps.replyReader,
       },
       ws,
       agent,

--- a/packages/host/src/schedule/reconcile.test.ts
+++ b/packages/host/src/schedule/reconcile.test.ts
@@ -104,6 +104,84 @@ test("silent: suppress_when_silent + ROUTINE_OK → run silent, no activity", as
   ).toHaveLength(0);
 });
 
+test("configured dual-write reconcile reads reply-after instead of the transcript file", async () => {
+  const env = await setup(routine());
+  const convKey = conversationKey(
+    prefixFor(env.ws as never, env.agent as never),
+    env.run.session_key,
+  );
+  const originalRead = env.vfs.readText.bind(env.vfs);
+  env.vfs.readText = async (key: string) => {
+    if (key === convKey) throw new Error("file transcript must not be read");
+    return originalRead(key);
+  };
+  const calls: unknown[] = [];
+
+  await reconcileAgentRuns(
+    {
+      ...deps(env.vfs, NOW),
+      replyReader: {
+        async replyAfter(conversationId, sinceMs) {
+          calls.push({ conversationId, sinceMs });
+          return {
+            role: "assistant",
+            content: "remote reply",
+            ts: STARTED.getTime() + 1000,
+          };
+        },
+      },
+    },
+    env.ws,
+    env.agent,
+  );
+
+  expect(calls).toEqual([
+    { conversationId: env.run.session_key, sinceMs: STARTED.getTime() },
+  ]);
+  const { items } = await loadRoutineRuns(
+    env.vfs,
+    workspaceRoot(env.ws, env.agent),
+  );
+  expect(items[0]).toMatchObject({
+    status: "surfaced",
+    summary: "remote reply",
+  });
+});
+
+test("a failed reply-after shadow lookup falls back to the authoritative file", async () => {
+  const env = await setup(routine());
+  await seedReply(
+    env.vfs,
+    env.ws,
+    env.agent,
+    env.run.session_key,
+    "file reply",
+    STARTED.getTime() + 1000,
+  );
+
+  await reconcileAgentRuns(
+    {
+      ...deps(env.vfs, NOW),
+      replyReader: {
+        async replyAfter() {
+          throw new Error("gateway unavailable");
+        },
+      },
+    },
+    env.ws,
+    env.agent,
+  );
+
+  const { items } = await loadRoutineRuns(
+    env.vfs,
+    workspaceRoot(env.ws, env.agent),
+  );
+  expect(items[0]).toMatchObject({
+    status: "surfaced",
+    summary: "file reply",
+  });
+});
+
 test("surfaced: a real finding → run surfaced + a needs_you board activity linked to the run", async () => {
   const r = routine({ suppress_when_silent: true, name: "Deploy watch" });
   const env = await setup(r);

--- a/packages/host/src/schedule/reconcile.ts
+++ b/packages/host/src/schedule/reconcile.ts
@@ -61,6 +61,14 @@ export interface ReconcileDeps {
   events?: EventHub;
   now: () => Date;
   newId: () => string;
+  /** Present only while the managed transcript dual-write is enabled. */
+  replyReader?: {
+    /** undefined means deploy skew: retain the authoritative file read. */
+    replyAfter(
+      conversationId: string,
+      sinceMs: number,
+    ): Promise<ChatMessage | null | undefined>;
+  };
 }
 
 /** One sweep's decision for a run, applied only if the row is still `running`. */
@@ -102,11 +110,27 @@ export async function reconcileAgentRuns(
     const routine = routines.find((r) => r.id === run.routine_id);
     if (!routine) continue; // routine deleted; leave the run to the next sweep
 
-    const raw = await deps.vfs.readText(
-      conversationKey(deps.paths, ws, agent, run.session_key),
-    );
-    const conversation = raw ? (JSON.parse(raw) as StoredConversation) : null;
-    const reply = replyAfter(conversation, Date.parse(run.started_at));
+    const startedAtMs = Date.parse(run.started_at);
+    let remoteReply: ChatMessage | null | undefined;
+    try {
+      remoteReply = await deps.replyReader?.replyAfter(
+        run.session_key,
+        startedAtMs,
+      );
+    } catch (error) {
+      console.debug(
+        `[transcript-shadow] reply-after failed for ${run.session_key}; using file`,
+        error,
+      );
+    }
+    let reply = remoteReply;
+    if (remoteReply === undefined) {
+      const raw = await deps.vfs.readText(
+        conversationKey(deps.paths, ws, agent, run.session_key),
+      );
+      const conversation = raw ? (JSON.parse(raw) as StoredConversation) : null;
+      reply = replyAfter(conversation, startedAtMs);
+    }
 
     const timedOut =
       !reply && nowMs - Date.parse(run.started_at) > RUN_TIMEOUT_MS;

--- a/packages/host/src/schedule/scheduler.ts
+++ b/packages/host/src/schedule/scheduler.ts
@@ -5,6 +5,7 @@ import type { WorkspacePaths } from "../paths";
 import type { WorkspaceStore } from "../ports";
 import type { Vfs } from "../vfs";
 import { type FireLock, type RoutineFirer, scanAgent } from "./agent-scan";
+import type { ReconcileDeps } from "./reconcile";
 
 export type { FireLock, FiringJob, RoutineFirer } from "./agent-scan";
 
@@ -22,6 +23,7 @@ export interface SchedulerDeps {
   dedupTtlSec?: number;
   now?: () => Date;
   newId?: () => string;
+  replyReader?: ReconcileDeps["replyReader"];
 }
 
 /**

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -65,7 +65,9 @@ import { handleSetupRuntime } from "./routes/setup-runtime";
 import { handleSharedSkills } from "./routes/shared-skills";
 import { handleSkillsDirectory } from "./routes/skills-directory";
 import { handleSandboxSkills } from "./routes/skills-sandbox";
+import { handleSandboxTranscripts } from "./routes/transcripts-sandbox";
 import { handleTriggerEvents } from "./routes/trigger-events";
+import type { TranscriptShadow } from "./transcripts/http-shadow";
 import type { TriggerEventLock } from "./triggers/fire";
 import type { Vfs } from "./vfs";
 
@@ -182,6 +184,8 @@ export interface ControlPlaneDeps {
    * with a turn bus.
    */
   triggerLock?: TriggerEventLock;
+  /** File-authoritative transcript writes mirrored through the sandbox facade. */
+  transcriptShadow?: TranscriptShadow;
   /**
    * Whether this deployment can fire event-driven routines (a trigger backend —
    * a Composio project key + a public webhook URL — exists). True on Houston
@@ -313,6 +317,8 @@ async function handle(
   // find_skills / install_skill tools call this to answer "which skill should
   // I use for X?" and to install the answer into its own skills tree.
   if (await handleSandboxSkills(deps, method, path, url, req, res)) return;
+  // Runtime transcript shadow facade (HMAC sandbox token → pod-auth gateway).
+  if (await handleSandboxTranscripts(deps, method, path, url, req, res)) return;
 
   // Everything past here is authenticated.
   const userId = await principal(deps, req, url);

--- a/packages/host/src/transcripts/http-shadow.test.ts
+++ b/packages/host/src/transcripts/http-shadow.test.ts
@@ -1,0 +1,134 @@
+import type { ChatMessage } from "@houston/protocol";
+import { expect, test, vi } from "vitest";
+import { HttpTranscriptShadow } from "./http-shadow";
+
+const message: ChatMessage = { role: "user", content: "hello", ts: 1 };
+
+test("transcript writes carry pod auth, fencing, and learned revisions", async () => {
+  const requests: { url: string; init?: RequestInit }[] = [];
+  const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+    requests.push({ url: String(url), init });
+    return Response.json({ revision: requests.length === 1 ? 7 : 8 });
+  });
+  const shadow = new HttpTranscriptShadow({
+    gateway: {
+      baseUrl: "https://store.example",
+      orgSlug: "acme",
+      agentSlug: "helper",
+      podToken: "pod-token",
+      bootId: "boot-1",
+      fence: { token: "41" },
+    },
+    fetchImpl: fetchImpl as typeof fetch,
+  });
+
+  await shadow.apply({
+    kind: "user",
+    conversationId: "c/1",
+    turnId: "t1",
+    message,
+    title: "hello",
+    expectedCount: 0,
+    needsSessionReplay: false,
+  });
+  await shadow.apply({
+    kind: "truncate",
+    conversationId: "c/1",
+    turnId: "t1",
+  });
+
+  expect(requests[0]?.url).toContain(
+    "/v1/pod/transcripts/acme/helper/conversations/c%2F1/turns/t1/user",
+  );
+  const headers = new Headers(requests[0]?.init?.headers);
+  expect(headers.get("authorization")).toBe("Bearer pod-token");
+  expect(headers.get("x-houston-fencing-token")).toBe("41");
+  expect(headers.get("x-houston-boot-id")).toBe("boot-1");
+  expect(JSON.parse(String(requests[0]?.init?.body))).toEqual({
+    message,
+    ts: 1,
+    title: "hello",
+    expectedCount: 0,
+  });
+  expect(JSON.parse(String(requests[1]?.init?.body))).toEqual({
+    turnId: "t1",
+    expectedRevision: 7,
+  });
+});
+
+test("a 404 disables transcript shadow once for deploy skew", async () => {
+  const fetchImpl = vi.fn(
+    async () => new Response("old gateway", { status: 404 }),
+  );
+  const shadow = new HttpTranscriptShadow({
+    gateway: {
+      baseUrl: "https://store.example",
+      orgSlug: "acme",
+      agentSlug: "helper",
+      podToken: "pod-token",
+      bootId: "boot-1",
+      fence: {},
+    },
+    fetchImpl: fetchImpl as typeof fetch,
+  });
+
+  await shadow.apply({
+    kind: "assistant",
+    conversationId: "c1",
+    turnId: "t1",
+    message: { ...message, role: "assistant" },
+  });
+  await shadow.apply({
+    kind: "assistant",
+    conversationId: "c1",
+    turnId: "t2",
+    message: { ...message, role: "assistant" },
+  });
+
+  expect(fetchImpl).toHaveBeenCalledTimes(1);
+});
+
+test("reply-after preserves the assistant message body", async () => {
+  const reply: ChatMessage = { role: "assistant", content: "done", ts: 12 };
+  const urls: string[] = [];
+  const fetchImpl = vi.fn(async (url: string | URL) => {
+    urls.push(String(url));
+    return Response.json({ message: reply, found: true });
+  });
+  const shadow = new HttpTranscriptShadow({
+    gateway: {
+      baseUrl: "https://gateway.example/",
+      orgSlug: "acme",
+      agentSlug: "helper",
+      podToken: "pod-token",
+      bootId: "boot-1",
+      fence: {},
+    },
+    fetchImpl: fetchImpl as typeof fetch,
+  });
+
+  await expect(shadow.replyAfter("c1", 99)).resolves.toEqual(reply);
+  expect(
+    String(urls[0]).endsWith(
+      "/v1/pod/transcripts/acme/helper/conversations/c1/reply-after?since=99",
+    ),
+  ).toBe(true);
+});
+
+test("reply-after rejects a malformed gateway message for file fallback", async () => {
+  const shadow = new HttpTranscriptShadow({
+    gateway: {
+      baseUrl: "https://gateway.example/",
+      orgSlug: "acme",
+      agentSlug: "helper",
+      podToken: "pod-token",
+      bootId: "boot-1",
+      fence: {},
+    },
+    fetchImpl: vi.fn(async () =>
+      Response.json({ found: true, message: { role: "assistant" } }),
+    ),
+  });
+
+  await expect(shadow.replyAfter("c1", 99)).rejects.toThrow("invalid message");
+});

--- a/packages/host/src/transcripts/http-shadow.ts
+++ b/packages/host/src/transcripts/http-shadow.ts
@@ -1,0 +1,191 @@
+import type { ChatMessage } from "@houston/protocol";
+import {
+  capturePodFence,
+  type PodGatewayConfig,
+  podGatewayHeaders,
+  podGatewayUrl,
+} from "../pod-gateway";
+import { parseReplyAfter } from "./reply-wire";
+
+export type TranscriptShadowCommand =
+  | {
+      kind: "user";
+      conversationId: string;
+      turnId: string;
+      message: ChatMessage;
+      title: string;
+      expectedCount: number;
+      needsSessionReplay: boolean;
+    }
+  | {
+      kind: "assistant";
+      conversationId: string;
+      turnId: string;
+      message: ChatMessage;
+    }
+  | { kind: "truncate"; conversationId: string; turnId: string }
+  | {
+      kind: "rename";
+      conversationId: string;
+      title: string;
+    }
+  | { kind: "delete"; conversationId: string }
+  | { kind: "repair"; conversationId: string; conversation: unknown };
+
+export interface TranscriptShadow {
+  apply(command: TranscriptShadowCommand): Promise<void>;
+  /** undefined means the route is unavailable and the file reader must be used. */
+  replyAfter(
+    conversationId: string,
+    sinceMs: number,
+  ): Promise<ChatMessage | null | undefined>;
+}
+
+export class HttpTranscriptShadow implements TranscriptShadow {
+  private readonly fetchImpl: typeof fetch;
+  private readonly revisions = new Map<string, number>();
+  private disabled = false;
+
+  constructor(
+    private readonly opts: {
+      gateway: PodGatewayConfig;
+      fetchImpl?: typeof fetch;
+    },
+  ) {
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  async apply(command: TranscriptShadowCommand): Promise<void> {
+    if (this.disabled) return;
+    const request = this.requestFor(command);
+    const response = await this.fetchImpl(request.url, {
+      method: request.method,
+      headers: podGatewayHeaders(this.opts.gateway, {
+        write: true,
+        json: request.body !== undefined,
+      }),
+      ...(request.body !== undefined
+        ? { body: JSON.stringify(request.body) }
+        : {}),
+      signal: AbortSignal.timeout(5_000),
+    });
+    capturePodFence(this.opts.gateway, response);
+    if (response.status === 404) return this.disableForSkew();
+    if (!response.ok) throw await responseError(response, command.kind);
+    const revision = await responseRevision(response);
+    if (revision !== undefined) {
+      this.revisions.set(command.conversationId, revision);
+    }
+  }
+
+  async replyAfter(
+    conversationId: string,
+    sinceMs: number,
+  ): Promise<ChatMessage | null | undefined> {
+    if (this.disabled) return undefined;
+    const response = await this.fetchImpl(
+      `${this.conversationUrl(conversationId)}/reply-after?since=${encodeURIComponent(String(sinceMs))}`,
+      {
+        headers: podGatewayHeaders(this.opts.gateway),
+        signal: AbortSignal.timeout(5_000),
+      },
+    );
+    capturePodFence(this.opts.gateway, response);
+    if (response.status === 404) {
+      this.disableForSkew();
+      return undefined;
+    }
+    if (!response.ok) throw await responseError(response, "reply-after");
+    return parseReplyAfter(await response.json());
+  }
+
+  private requestFor(command: TranscriptShadowCommand) {
+    const root = this.conversationUrl(command.conversationId);
+    switch (command.kind) {
+      case "user":
+        return {
+          method: "PUT",
+          url: `${root}/turns/${encodeURIComponent(command.turnId)}/user`,
+          body: {
+            message: command.message,
+            ts: command.message.ts,
+            title: command.title,
+            expectedCount: command.expectedCount,
+            // The pod-store atomically consumes its own durable replay marker.
+            // `needsSessionReplay` is carried across the runtime/host facade to
+            // assert the file's pre-consume state, but is intentionally absent
+            // here because the strict pod route derives (and records) it.
+          },
+        };
+      case "assistant":
+        return {
+          method: "PUT",
+          url: `${root}/turns/${encodeURIComponent(command.turnId)}/assistant`,
+          body: { message: command.message, ts: command.message.ts },
+        };
+      case "truncate":
+        return {
+          method: "POST",
+          url: `${root}/truncate`,
+          body: {
+            turnId: command.turnId,
+            expectedRevision: this.revisions.get(command.conversationId) ?? 0,
+          },
+        };
+      case "rename":
+        return {
+          method: "PUT",
+          url: root,
+          body: { title: command.title },
+        };
+      case "delete":
+        return { method: "DELETE", url: root };
+      case "repair":
+        return {
+          method: "POST",
+          url: `${root}/repair`,
+          body: command.conversation,
+        };
+    }
+  }
+
+  private conversationUrl(conversationId: string): string {
+    const { gateway } = this.opts;
+    return podGatewayUrl(
+      gateway,
+      `/v1/pod/transcripts/${encodeURIComponent(gateway.orgSlug)}/${encodeURIComponent(gateway.agentSlug)}/conversations/${encodeURIComponent(conversationId)}`,
+    );
+  }
+
+  private disableForSkew(): void {
+    if (this.disabled) return;
+    this.disabled = true;
+    console.debug(
+      "[transcript-shadow] gateway route unavailable; disabling for this process",
+    );
+  }
+}
+
+async function responseRevision(
+  response: Response,
+): Promise<number | undefined> {
+  const text = await response.text();
+  if (!text) return undefined;
+  try {
+    const body = JSON.parse(text) as { revision?: unknown };
+    return typeof body.revision === "number" ? body.revision : undefined;
+  } catch (error) {
+    console.debug("[transcript-shadow] response carried no revision", error);
+    return undefined;
+  }
+}
+
+async function responseError(
+  response: Response,
+  operation: string,
+): Promise<Error> {
+  const detail = await response.text();
+  return new Error(
+    `transcript ${operation} failed (${response.status}): ${detail.slice(0, 300)}`,
+  );
+}

--- a/packages/host/src/transcripts/reply-wire.ts
+++ b/packages/host/src/transcripts/reply-wire.ts
@@ -1,0 +1,27 @@
+import type { ChatMessage } from "@houston/protocol";
+
+/** Parse the owned gateway's narrow reply-after response. */
+export function parseReplyAfter(value: unknown): ChatMessage | null {
+  if (!value || typeof value !== "object") {
+    throw new Error("transcript reply-after returned a non-object body");
+  }
+  const body = value as Record<string, unknown>;
+  if (body.found === false) return null;
+  const message = body.message;
+  if (!message || typeof message !== "object") {
+    throw new Error("transcript reply-after omitted its assistant message");
+  }
+  const fields = message as Record<string, unknown>;
+  if (
+    fields.role !== "assistant" ||
+    typeof fields.content !== "string" ||
+    typeof fields.ts !== "number" ||
+    !Number.isFinite(fields.ts)
+  ) {
+    throw new Error("transcript reply-after returned an invalid message");
+  }
+  // SAFETY: the owned gateway returns the protocol's verbatim ChatMessage.
+  // The fields reconcile relies on are refined above; additive metadata stays
+  // untouched so provider errors and attribution survive the projection.
+  return message as ChatMessage;
+}

--- a/packages/host/src/turn/deps.ts
+++ b/packages/host/src/turn/deps.ts
@@ -3,6 +3,7 @@ import type { Agent, Workspace } from "../domain/types";
 import type { CredentialStore, WorkspaceCredential } from "../ports";
 import type { Vfs } from "../vfs";
 import type { ConnectManager } from "./connect";
+import type { FrameForwarder } from "./frame-forwarder";
 import type { TurnQuota } from "./quota";
 import type { TurnRelay } from "./relay";
 
@@ -23,6 +24,7 @@ export interface TurnDeps {
   /** Google ID token for Cloud Run IAM on the runtime; null on dev. */
   idToken: () => Promise<string | null>;
   codexModels: string[];
+  frameForwarder?: Pick<FrameForwarder, "capture">;
 }
 
 export const PROVIDER = "openai-codex";

--- a/packages/host/src/turn/frame-forwarder.test.ts
+++ b/packages/host/src/turn/frame-forwarder.test.ts
@@ -1,0 +1,144 @@
+import type { SequencedFrame } from "@houston/runtime-client";
+import { afterEach, expect, test } from "vitest";
+import {
+  startTestFetchServer,
+  type TestFetchServer,
+} from "../testing/fetch-server";
+import { MemoryTurnBus } from "./bus";
+import type { TurnLogSender } from "./frame-forwarder";
+import { FrameForwarder } from "./frame-forwarder";
+import { eventChannel } from "./relay-dialect";
+import { HttpTurnLogSender } from "./turn-log-http";
+
+let server: TestFetchServer | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+test("captures without a client, batches frames, and flushes terminal immediately", async () => {
+  const requests: {
+    path: string;
+    frames: SequencedFrame[];
+    headers: Headers;
+  }[] = [];
+  server = await startTestFetchServer(async (request) => {
+    const body = (await request.json()) as { frames: SequencedFrame[] };
+    requests.push({
+      path: new URL(request.url).pathname,
+      frames: body.frames,
+      headers: request.headers,
+    });
+    return Response.json({ ok: true });
+  });
+  const bus = new MemoryTurnBus();
+  const sender = new HttpTurnLogSender({
+    gateway: {
+      baseUrl: server.baseUrl,
+      orgSlug: "acme",
+      agentSlug: "helper",
+      podToken: "pod-token",
+      bootId: "boot-1",
+      fence: { token: "71" },
+    },
+    retryDelaysMs: [],
+  });
+  const forwarder = new FrameForwarder({ bus, sender, batchMs: 10_000 });
+  // No SSE/client subscriber exists: this unconditional capture is the only one.
+  forwarder.capture("routine/c1", "helper/routine/c1");
+
+  await bus.publish(
+    eventChannel("helper/routine/c1"),
+    JSON.stringify({ type: "text", data: { text: "a" }, seq: 41 }),
+  );
+  await bus.publish(
+    eventChannel("helper/routine/c1"),
+    JSON.stringify({ type: "done", data: {}, seq: 42 }),
+  );
+  await eventually(() => requests.length === 1);
+
+  expect(requests[0]?.path).toBe("/v1/pod/turnlog/acme/helper/routine%2Fc1");
+  expect(requests[0]?.frames.map((frame) => frame.seq)).toEqual([41, 42]);
+  expect(requests[0]?.headers.get("authorization")).toBe("Bearer pod-token");
+  expect(requests[0]?.headers.get("x-houston-fencing-token")).toBe("71");
+  expect(requests[0]?.headers.get("x-houston-boot-id")).toBe("boot-1");
+});
+
+test("flushes a full 32-frame batch without waiting for the timer", async () => {
+  const batches: SequencedFrame[][] = [];
+  server = await startTestFetchServer(async (request) => {
+    const body = (await request.json()) as { frames: SequencedFrame[] };
+    batches.push(body.frames);
+    return Response.json({ ok: true });
+  });
+  const bus = new MemoryTurnBus();
+  const forwarder = new FrameForwarder({
+    bus,
+    sender: new HttpTurnLogSender({
+      gateway: {
+        baseUrl: server.baseUrl,
+        orgSlug: "acme",
+        agentSlug: "helper",
+        podToken: "pod-token",
+        bootId: "boot-1",
+        fence: {},
+      },
+      retryDelaysMs: [],
+    }),
+    batchMs: 10_000,
+  });
+  forwarder.capture("c1", "helper/c1");
+
+  for (let seq = 1; seq <= 32; seq++) {
+    await bus.publish(
+      eventChannel("helper/c1"),
+      JSON.stringify({ type: "text", data: { text: String(seq) }, seq }),
+    );
+  }
+  await eventually(() => batches.length === 1);
+  expect(batches[0]).toHaveLength(32);
+});
+
+test("serializes consecutive turns for the same conversation", async () => {
+  const batches: number[][] = [];
+  let releaseFirst: (() => void) | undefined;
+  const firstBlocked = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  const sender: TurnLogSender = {
+    async send(_conversationId, frames) {
+      batches.push(frames.map((frame) => frame.seq));
+      if (batches.length === 1) await firstBlocked;
+    },
+  };
+  const bus = new MemoryTurnBus();
+  const forwarder = new FrameForwarder({ bus, sender });
+
+  forwarder.capture("c1", "helper/c1");
+  await bus.publish(
+    eventChannel("helper/c1"),
+    JSON.stringify({ type: "done", data: {}, seq: 10 }),
+  );
+  await eventually(() => batches.length === 1);
+
+  forwarder.capture("c1", "helper/c1");
+  await bus.publish(
+    eventChannel("helper/c1"),
+    JSON.stringify({ type: "done", data: {}, seq: 11 }),
+  );
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  expect(batches).toEqual([[10]]);
+
+  releaseFirst?.();
+  await eventually(() => batches.length === 2);
+  expect(batches).toEqual([[10], [11]]);
+});
+
+async function eventually(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("condition not reached");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}

--- a/packages/host/src/turn/frame-forwarder.ts
+++ b/packages/host/src/turn/frame-forwarder.ts
@@ -1,0 +1,110 @@
+import { isTerminalFrame, type SequencedFrame } from "@houston/runtime-client";
+import type { TurnBus } from "./bus";
+import { eventChannel } from "./relay-dialect";
+
+export interface TurnLogSender {
+  send(conversationId: string, frames: SequencedFrame[]): Promise<void>;
+}
+
+interface CaptureState {
+  conversationId: string;
+  frames: SequencedFrame[];
+  timer?: ReturnType<typeof setTimeout>;
+  unsubscribe: () => void;
+}
+
+/** Unconditional ev2 subscriber: batches relay frames even with no SSE client. */
+export class FrameForwarder {
+  private readonly states = new Map<string, CaptureState>();
+  private readonly sendTails = new Map<string, Promise<void>>();
+  private readonly batchMs: number;
+  private readonly batchSize: number;
+
+  constructor(
+    private readonly opts: {
+      bus: TurnBus;
+      sender: TurnLogSender;
+      batchMs?: number;
+      batchSize?: number;
+    },
+  ) {
+    this.batchMs = opts.batchMs ?? 250;
+    this.batchSize = opts.batchSize ?? 32;
+  }
+
+  capture(conversationId: string, relayKey: string): void {
+    if (this.states.has(relayKey)) return;
+    const state: CaptureState = {
+      conversationId,
+      frames: [],
+      unsubscribe: () => {},
+    };
+    state.unsubscribe = this.opts.bus.subscribe(
+      eventChannel(relayKey),
+      (message) => this.onMessage(relayKey, state, message),
+    );
+    this.states.set(relayKey, state);
+  }
+
+  stop(): void {
+    for (const state of this.states.values()) {
+      if (state.timer) clearTimeout(state.timer);
+      this.flush(state);
+      state.unsubscribe();
+    }
+    this.states.clear();
+  }
+
+  private onMessage(
+    relayKey: string,
+    state: CaptureState,
+    message: string,
+  ): void {
+    let frame: SequencedFrame;
+    try {
+      frame = JSON.parse(message) as SequencedFrame;
+      if (!Number.isSafeInteger(frame.seq)) throw new Error("missing seq");
+    } catch (error) {
+      console.debug(
+        `[turnlog] ignored malformed ev2 frame for ${relayKey}`,
+        error,
+      );
+      return;
+    }
+    state.frames.push(frame);
+    const terminal = isTerminalFrame(frame.type);
+    if (terminal || state.frames.length >= this.batchSize) {
+      this.flush(state);
+    } else if (!state.timer) {
+      state.timer = setTimeout(() => this.flush(state), this.batchMs);
+      state.timer.unref?.();
+    }
+    if (terminal) {
+      state.unsubscribe();
+      this.states.delete(relayKey);
+    }
+  }
+
+  private flush(state: CaptureState): void {
+    if (state.timer) clearTimeout(state.timer);
+    state.timer = undefined;
+    const frames = state.frames.splice(0);
+    if (frames.length === 0) return;
+    const conversationId = state.conversationId;
+    const prior = this.sendTails.get(conversationId) ?? Promise.resolve();
+    const task = prior
+      .then(() => this.opts.sender.send(state.conversationId, frames))
+      .catch((error: unknown) => {
+        console.debug(
+          `[turnlog] batch forward failed for ${conversationId}; live-pod resume remains available`,
+          error,
+        );
+      })
+      .finally(() => {
+        if (this.sendTails.get(conversationId) === task) {
+          this.sendTails.delete(conversationId);
+        }
+      });
+    this.sendTails.set(conversationId, task);
+  }
+}

--- a/packages/host/src/turn/standing-frame-capture.ts
+++ b/packages/host/src/turn/standing-frame-capture.ts
@@ -1,0 +1,71 @@
+import { isTerminalFrame, readEventStream } from "@houston/runtime-client";
+import type { RuntimeEndpoint } from "../ports";
+import type { TurnBus } from "./bus";
+import type { FrameForwarder } from "./frame-forwarder";
+import { eventChannel } from "./relay-dialect";
+
+/** Pumps a standing runtime's SSE into ev2 without relying on a client listener. */
+export class StandingFrameCapture {
+  private readonly pumps = new Map<string, AbortController>();
+
+  constructor(
+    private readonly bus: TurnBus,
+    private readonly forwarder: FrameForwarder,
+  ) {}
+
+  capture(
+    endpoint: RuntimeEndpoint,
+    agentId: string,
+    conversationId: string,
+  ): void {
+    const key = `${agentId}/${conversationId}`;
+    this.forwarder.capture(conversationId, key);
+    if (this.pumps.has(key)) return;
+    const controller = new AbortController();
+    this.pumps.set(key, controller);
+    void this.pump(endpoint, conversationId, key, controller).catch((error) => {
+      if (!controller.signal.aborted) {
+        console.debug(
+          `[turnlog] standing runtime capture failed for ${conversationId}; live-pod resume remains available`,
+          error,
+        );
+      }
+    });
+  }
+
+  stop(): void {
+    for (const controller of this.pumps.values()) controller.abort();
+    this.pumps.clear();
+  }
+
+  private async pump(
+    endpoint: RuntimeEndpoint,
+    conversationId: string,
+    key: string,
+    controller: AbortController,
+  ): Promise<void> {
+    try {
+      const response = await fetch(
+        `${endpoint.baseUrl}/conversations/${encodeURIComponent(conversationId)}/events`,
+        {
+          headers: { Authorization: `Bearer ${endpoint.token}` },
+          signal: controller.signal,
+        },
+      );
+      if (!response.ok || !response.body) {
+        throw new Error(`runtime events failed (${response.status})`);
+      }
+      await readEventStream(response.body, async (frame) => {
+        // A fresh runtime subscription begins with a snapshot sync. Turnlog is
+        // the turn's event log, so only frames published by the turn enter ev2.
+        if (frame.type === "sync") return;
+        // The standing runtime's ReplayLog already assigned the authoritative
+        // seq. Publish that exact envelope; never introduce a second counter.
+        await this.bus.publish(eventChannel(key), JSON.stringify(frame));
+        if (isTerminalFrame(frame.type)) controller.abort();
+      });
+    } finally {
+      this.pumps.delete(key);
+    }
+  }
+}

--- a/packages/host/src/turn/start-turn.ts
+++ b/packages/host/src/turn/start-turn.ts
@@ -55,6 +55,13 @@ export async function dispatchTurn(
     throw err;
   }
   const key = `${agent.id}/${cid}`;
+  // Capture is independent of any client events subscription, so routine turns
+  // and background sends enter turnlog too.
+  try {
+    deps.frameForwarder?.capture(cid, key);
+  } catch (error) {
+    console.debug("[turnlog] relay capture enqueue failed", error);
+  }
   const started = await deps.relay.start(
     agent.id,
     key,

--- a/packages/host/src/turn/turn-log-http.ts
+++ b/packages/host/src/turn/turn-log-http.ts
@@ -1,0 +1,60 @@
+import type { SequencedFrame } from "@houston/runtime-client";
+import {
+  capturePodFence,
+  type PodGatewayConfig,
+  podGatewayHeaders,
+  podGatewayUrl,
+} from "../pod-gateway";
+import type { TurnLogSender } from "./frame-forwarder";
+
+const RETRYABLE = new Set([502, 503, 504]);
+
+export class HttpTurnLogSender implements TurnLogSender {
+  private readonly fetchImpl: typeof fetch;
+  private readonly retryDelaysMs: number[];
+
+  constructor(
+    private readonly opts: {
+      gateway: PodGatewayConfig;
+      fetchImpl?: typeof fetch;
+      retryDelaysMs?: number[];
+    },
+  ) {
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.retryDelaysMs = opts.retryDelaysMs ?? [500, 2_000];
+  }
+
+  async send(conversationId: string, frames: SequencedFrame[]): Promise<void> {
+    const { gateway } = this.opts;
+    const url = podGatewayUrl(
+      gateway,
+      `/v1/pod/turnlog/${encodeURIComponent(gateway.orgSlug)}/${encodeURIComponent(gateway.agentSlug)}/${encodeURIComponent(conversationId)}`,
+    );
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= this.retryDelaysMs.length; attempt++) {
+      try {
+        const response = await this.fetchImpl(url, {
+          method: "POST",
+          headers: podGatewayHeaders(gateway, { write: true, json: true }),
+          body: JSON.stringify({ frames }),
+          signal: AbortSignal.timeout(5_000),
+        });
+        capturePodFence(gateway, response);
+        if (response.ok) return;
+        const detail = await response.text();
+        lastError = new Error(
+          `turnlog ingest failed (${response.status}): ${detail.slice(0, 300)}`,
+        );
+        if (!RETRYABLE.has(response.status)) break;
+      } catch (error) {
+        lastError = error;
+      }
+      const delay = this.retryDelaysMs[attempt];
+      if (delay === undefined) break;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+    throw lastError instanceof Error
+      ? lastError
+      : new Error("turnlog ingest failed");
+  }
+}

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -121,6 +121,8 @@ export const config = {
   sandboxToken: env.HOUSTON_SANDBOX_TOKEN || "",
   /** Where the sandbox fetches its workspace's central subscription token. */
   controlPlaneUrl: env.HOUSTON_CONTROL_PLANE_URL || "",
+  /** File-authoritative transcript writes also enqueue the managed DB shadow. */
+  transcriptDualWrite: env.HOUSTON_TRANSCRIPT_DUAL_WRITE === "1",
 
   /**
    * Code execution policy for long-lived runtime:

--- a/packages/runtime/src/store/conversation-file.ts
+++ b/packages/runtime/src/store/conversation-file.ts
@@ -142,6 +142,8 @@ export function appendUserMessageAt(
     updatedAt: now,
     messages: [],
   };
+  const expectedCount = conv.messages.length;
+  const needsSessionReplay = conv.needsSessionReplay === true;
   // Stamp the author (C5) only when a token identified one — a single-user /
   // local turn omits the field entirely, keeping the stored record
   // byte-identical to today. `turnId` matches the live stream's frames so a
@@ -160,6 +162,12 @@ export function appendUserMessageAt(
   });
   conv.updatedAt = now;
   save(dir, conv);
+  return {
+    conversation: conv,
+    message: conv.messages[conv.messages.length - 1] as ChatMessage,
+    expectedCount,
+    needsSessionReplay,
+  };
 }
 
 export function appendAssistantMessageAt(
@@ -187,6 +195,23 @@ export function appendAssistantMessageAt(
   });
   conv.updatedAt = Date.now();
   save(dir, conv);
+  return {
+    conversation: conv,
+    message: conv.messages[conv.messages.length - 1] as ChatMessage,
+  };
+}
+
+export function renameConversationMutationAt(
+  dir: string,
+  id: string,
+  title: string,
+): StoredConversation | null {
+  const conv = loadConversation(dir, id);
+  if (!conv) return null;
+  conv.title = title;
+  conv.updatedAt = Date.now();
+  save(dir, conv);
+  return conv;
 }
 
 export function renameConversationAt(
@@ -194,12 +219,7 @@ export function renameConversationAt(
   id: string,
   title: string,
 ): boolean {
-  const conv = loadConversation(dir, id);
-  if (!conv) return false;
-  conv.title = title;
-  conv.updatedAt = Date.now();
-  save(dir, conv);
-  return true;
+  return renameConversationMutationAt(dir, id, title) !== null;
 }
 
 export function deleteConversationAt(dir: string, id: string): boolean {

--- a/packages/runtime/src/store/conversation-shadow.test.ts
+++ b/packages/runtime/src/store/conversation-shadow.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test, vi } from "vitest";
+import { createConversationStore } from "./conversations";
+import {
+  type TranscriptShadow,
+  type TranscriptShadowOperation,
+  TranscriptShadowQueue,
+  type TranscriptShadowTransport,
+} from "./transcript-shadow";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "conversation-shadow-"));
+  dirs.push(dir);
+  return dir;
+}
+
+test("user and assistant shadow only after the atomic file write", () => {
+  const dir = tempDir();
+  const seen: TranscriptShadowOperation[] = [];
+  const shadow: TranscriptShadow = {
+    enqueue(operation) {
+      const stored = JSON.parse(readFileSync(join(dir, "c1.json"), "utf8")) as {
+        messages: unknown[];
+      };
+      expect(stored.messages).toHaveLength(operation.kind === "user" ? 1 : 2);
+      seen.push(operation);
+    },
+  };
+  const store = createConversationStore(dir, shadow);
+
+  expect(() =>
+    store.appendUserMessage("c1", "hello", { turnId: "t1" }),
+  ).not.toThrow();
+  expect(() =>
+    store.appendAssistantMessage("c1", "hi", { turnId: "t1" }),
+  ).not.toThrow();
+  expect(seen.map((operation) => operation.kind)).toEqual([
+    "user",
+    "assistant",
+  ]);
+  expect(seen[0]).toMatchObject({
+    kind: "user",
+    conversationId: "c1",
+    turnId: "t1",
+    expectedCount: 0,
+    needsSessionReplay: false,
+  });
+});
+
+test("a synchronous shadow enqueue failure cannot fail the file mutation", () => {
+  const dir = tempDir();
+  const shadow: TranscriptShadow = {
+    enqueue() {
+      throw new Error("broken shadow adapter");
+    },
+  };
+  const store = createConversationStore(dir, shadow);
+
+  expect(() =>
+    store.appendUserMessage("c1", "file wins", { turnId: "t1" }),
+  ).not.toThrow();
+  expect(JSON.parse(readFileSync(join(dir, "c1.json"), "utf8"))).toMatchObject({
+    messages: [{ content: "file wins" }],
+  });
+});
+
+test("a failed shadow write never throws and repairs before the next turn", async () => {
+  const dir = tempDir();
+  const sent: TranscriptShadowOperation[] = [];
+  let failFirst = true;
+  const transport: TranscriptShadowTransport = {
+    async send(operation) {
+      sent.push(operation);
+      if (failFirst) {
+        failFirst = false;
+        throw new Error("gateway unavailable");
+      }
+    },
+  };
+  const shadow = new TranscriptShadowQueue(transport);
+  const store = createConversationStore(dir, shadow);
+
+  expect(() =>
+    store.appendUserMessage("c1", "first", { turnId: "t1" }),
+  ).not.toThrow();
+  await shadow.flush();
+  expect(shadow.isDirty("c1")).toBe(true);
+
+  store.appendUserMessage("c1", "second", { turnId: "t2" });
+  await shadow.flush();
+
+  expect(sent.map((operation) => operation.kind)).toEqual(["user", "repair"]);
+  expect(sent[1]).toMatchObject({
+    kind: "repair",
+    conversation: { messages: [{ content: "first" }, { content: "second" }] },
+  });
+  expect(shadow.isDirty("c1")).toBe(false);
+});

--- a/packages/runtime/src/store/conversation-truncate.ts
+++ b/packages/runtime/src/store/conversation-truncate.ts
@@ -20,6 +20,15 @@ export function truncateConversationAt(
   id: string,
   turnId: string,
 ): { removed: number } | null {
+  const mutation = truncateConversationMutationAt(dir, id, turnId);
+  return mutation ? { removed: mutation.removed } : null;
+}
+
+export function truncateConversationMutationAt(
+  dir: string,
+  id: string,
+  turnId: string,
+) {
   const conv = loadConversation(dir, id);
   if (!conv) return null;
   const at = conv.messages.findIndex((m) => m.turnId === turnId);
@@ -29,7 +38,7 @@ export function truncateConversationAt(
   conv.needsSessionReplay = true;
   conv.updatedAt = Date.now();
   saveConversation(dir, conv);
-  return { removed };
+  return { removed, conversation: conv };
 }
 
 /**

--- a/packages/runtime/src/store/conversations.ts
+++ b/packages/runtime/src/store/conversations.ts
@@ -13,32 +13,128 @@ import {
   getHistoryAt,
   type HistoryWindow,
   listConversationsAt,
-  renameConversationAt,
+  renameConversationMutationAt,
   type UserMessageMeta,
 } from "./conversation-file";
 import {
   consumeSessionReplayAt,
-  truncateConversationAt,
+  truncateConversationMutationAt,
 } from "./conversation-truncate";
+import {
+  snapshotConversation,
+  type TranscriptShadow,
+  TranscriptShadowQueue,
+} from "./transcript-shadow";
+import { SandboxTranscriptShadowTransport } from "./transcript-shadow-http";
 
-/**
- * Config-bound conversation store for the long-lived server: one JSON file per
- * conversation under dataDir/conversations/. This is the durable, UI-facing
- * transcript and the source of truth for history + listing — intentionally
- * decoupled from pi's internal session format so the datastore can be swapped
- * later. The pure file logic lives in conversation-file.ts (shared with the
- * per-turn cloud runtime, which binds it to a hydrated tmpdir instead).
- */
+export function createConversationStore(
+  dir: string,
+  shadow?: TranscriptShadow,
+) {
+  mkdirSync(dir, { recursive: true });
+  const notify = (
+    operation: () => Parameters<TranscriptShadow["enqueue"]>[0],
+  ) => {
+    try {
+      if (shadow) shadow.enqueue(operation());
+    } catch (error) {
+      console.debug("[transcript-shadow] enqueue failed", error);
+    }
+  };
+
+  return {
+    appendUserMessage(id: string, content: string, meta?: UserMessageMeta) {
+      const result = appendUserMessageAt(dir, id, content, meta);
+      notify(() => {
+        const conversation = snapshotConversation(result.conversation);
+        const turnId = result.message.turnId;
+        const message = conversation.messages.at(-1) ?? result.message;
+        return turnId
+          ? {
+              kind: "user",
+              conversationId: id,
+              turnId,
+              message,
+              expectedCount: result.expectedCount,
+              needsSessionReplay: result.needsSessionReplay,
+              conversation,
+            }
+          : { kind: "repair", conversationId: id, conversation };
+      });
+    },
+    appendAssistantMessage(
+      id: string,
+      content: string,
+      meta?: AssistantMessageMeta,
+    ) {
+      const result = appendAssistantMessageAt(dir, id, content, meta);
+      if (!result) return;
+      notify(() => {
+        const conversation = snapshotConversation(result.conversation);
+        const turnId = result.message.turnId;
+        const message = conversation.messages.at(-1) ?? result.message;
+        return turnId
+          ? {
+              kind: "assistant",
+              conversationId: id,
+              turnId,
+              message,
+              conversation,
+            }
+          : { kind: "repair", conversationId: id, conversation };
+      });
+    },
+    getHistory: (id: string, window?: HistoryWindow) =>
+      getHistoryAt(dir, id, window),
+    listConversations: () => listConversationsAt(dir),
+    renameConversation(id: string, title: string): boolean {
+      const result = renameConversationMutationAt(dir, id, title);
+      if (!result) return false;
+      notify(() => ({
+        kind: "rename",
+        conversationId: id,
+        conversation: snapshotConversation(result),
+      }));
+      return true;
+    },
+    deleteConversation(id: string): boolean {
+      const deleted = deleteConversationAt(dir, id);
+      if (deleted) notify(() => ({ kind: "delete", conversationId: id }));
+      return deleted;
+    },
+    truncateConversation(id: string, turnId: string) {
+      const result = truncateConversationMutationAt(dir, id, turnId);
+      if (!result) return null;
+      notify(() => ({
+        kind: "truncate",
+        conversationId: id,
+        turnId,
+        conversation: snapshotConversation(result.conversation),
+      }));
+      return { removed: result.removed };
+    },
+    consumeSessionReplay: (id: string) => consumeSessionReplayAt(dir, id),
+  };
+}
 
 const dir = join(config.dataDir, "conversations");
-mkdirSync(dir, { recursive: true });
+const shadow =
+  config.transcriptDualWrite && config.controlPlaneUrl && config.sandboxToken
+    ? new TranscriptShadowQueue(
+        new SandboxTranscriptShadowTransport(
+          config.controlPlaneUrl,
+          config.sandboxToken,
+        ),
+      )
+    : undefined;
+const store = createConversationStore(dir, shadow);
 
 export function appendUserMessage(
   id: string,
   content: string,
   meta?: UserMessageMeta,
 ) {
-  appendUserMessageAt(dir, id, content, meta);
+  store.appendUserMessage(id, content, meta);
 }
 
 export function appendAssistantMessage(
@@ -46,15 +142,9 @@ export function appendAssistantMessage(
   content: string,
   meta?: AssistantMessageMeta,
 ) {
-  appendAssistantMessageAt(dir, id, content, meta);
+  store.appendAssistantMessage(id, content, meta);
 }
 
-/**
- * Append the durable stop marker: an empty assistant message flagged
- * `stopped`, which retires a pending interaction exactly the way a real Stop
- * does — the SDK renders it as the "Stopped by user" system line and a history
- * reload settles the turn as stopped instead of re-deriving a clean `done`.
- */
 export function markConversationStopped(id: string): void {
   appendAssistantMessage(id, "", { stopped: true });
 }
@@ -63,34 +153,14 @@ export function getHistory(
   id: string,
   window?: HistoryWindow,
 ): ConversationHistory | null {
-  return getHistoryAt(dir, id, window);
+  return store.getHistory(id, window);
 }
 
 export function listConversations(): ConversationSummary[] {
-  return listConversationsAt(dir);
+  return store.listConversations();
 }
 
-export function renameConversation(id: string, title: string): boolean {
-  return renameConversationAt(dir, id, title);
-}
-
-export function deleteConversation(id: string): boolean {
-  return deleteConversationAt(dir, id);
-}
-
-/**
- * Cut the transcript at a user turn (edit-and-resend, PRODUCT-1217). File
- * write only — callers go through session/truncate-turn.ts, which pairs it
- * with the session/bus invalidation.
- */
-export function truncateConversation(
-  id: string,
-  turnId: string,
-): { removed: number } | null {
-  return truncateConversationAt(dir, id, turnId);
-}
-
-/** One-shot replay marker read (see conversation-truncate.ts). */
-export function consumeSessionReplay(id: string): boolean {
-  return consumeSessionReplayAt(dir, id);
-}
+export const renameConversation = store.renameConversation;
+export const deleteConversation = store.deleteConversation;
+export const truncateConversation = store.truncateConversation;
+export const consumeSessionReplay = store.consumeSessionReplay;

--- a/packages/runtime/src/store/transcript-shadow-http.ts
+++ b/packages/runtime/src/store/transcript-shadow-http.ts
@@ -1,0 +1,81 @@
+import type {
+  TranscriptShadowOperation,
+  TranscriptShadowTransport,
+} from "./transcript-shadow";
+
+export class SandboxTranscriptShadowTransport
+  implements TranscriptShadowTransport
+{
+  private readonly baseUrl: string;
+
+  constructor(
+    baseUrl: string,
+    private readonly sandboxToken: string,
+  ) {
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+  }
+
+  async send(operation: TranscriptShadowOperation): Promise<void> {
+    const cid = encodeURIComponent(operation.conversationId);
+    const root = `${this.baseUrl}/sandbox/transcripts/conversations/${cid}`;
+    const request = requestFor(root, operation);
+    const response = await fetch(request.url, {
+      method: request.method,
+      headers: {
+        authorization: `Bearer ${this.sandboxToken}`,
+        ...(request.body ? { "content-type": "application/json" } : {}),
+      },
+      ...(request.body ? { body: JSON.stringify(request.body) } : {}),
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      throw new Error(
+        `transcript shadow failed (${response.status}): ${detail.slice(0, 300)}`,
+      );
+    }
+  }
+}
+
+function requestFor(root: string, operation: TranscriptShadowOperation) {
+  switch (operation.kind) {
+    case "user":
+      return {
+        method: "PUT",
+        url: `${root}/turns/${encodeURIComponent(operation.turnId)}/user`,
+        body: {
+          message: operation.message,
+          ts: operation.message.ts,
+          title: operation.conversation.title,
+          expectedCount: operation.expectedCount,
+          needsSessionReplay: operation.needsSessionReplay,
+        },
+      };
+    case "assistant":
+      return {
+        method: "PUT",
+        url: `${root}/turns/${encodeURIComponent(operation.turnId)}/assistant`,
+        body: { message: operation.message, ts: operation.message.ts },
+      };
+    case "truncate":
+      return {
+        method: "POST",
+        url: `${root}/truncate`,
+        body: { turnId: operation.turnId },
+      };
+    case "rename":
+      return {
+        method: "PUT",
+        url: root,
+        body: { title: operation.conversation.title },
+      };
+    case "delete":
+      return { method: "DELETE", url: root };
+    case "repair":
+      return {
+        method: "POST",
+        url: `${root}/repair`,
+        body: operation.conversation,
+      };
+  }
+}

--- a/packages/runtime/src/store/transcript-shadow.ts
+++ b/packages/runtime/src/store/transcript-shadow.ts
@@ -1,0 +1,133 @@
+import type { ChatMessage } from "@houston/runtime-client";
+import type { StoredConversation } from "./conversation-file";
+
+interface ShadowBase {
+  conversationId: string;
+}
+
+export type TranscriptShadowOperation =
+  | (ShadowBase & {
+      kind: "user";
+      turnId: string;
+      message: ChatMessage;
+      expectedCount: number;
+      needsSessionReplay: boolean;
+      conversation: StoredConversation;
+    })
+  | (ShadowBase & {
+      kind: "assistant";
+      turnId: string;
+      message: ChatMessage;
+      conversation: StoredConversation;
+    })
+  | (ShadowBase & {
+      kind: "truncate";
+      turnId: string;
+      conversation: StoredConversation;
+    })
+  | (ShadowBase & {
+      kind: "rename";
+      conversation: StoredConversation;
+    })
+  | (ShadowBase & { kind: "delete" })
+  | (ShadowBase & {
+      kind: "repair";
+      conversation: StoredConversation;
+    });
+
+export interface TranscriptShadow {
+  enqueue(operation: TranscriptShadowOperation): void;
+}
+
+export interface TranscriptShadowTransport {
+  send(operation: TranscriptShadowOperation): Promise<void>;
+}
+
+const MAX_DIRTY_CONVERSATIONS = 256;
+
+/**
+ * Detached, per-conversation shadow queue. File callers only enqueue immutable
+ * post-write snapshots; transport failures are contained here and repaired from
+ * the next snapshot, so this module can never fail or delay the authoritative
+ * file mutation.
+ */
+export class TranscriptShadowQueue implements TranscriptShadow {
+  private readonly dirty = new Set<string>();
+  private readonly tails = new Map<string, Promise<void>>();
+
+  constructor(private readonly transport: TranscriptShadowTransport) {}
+
+  enqueue(operation: TranscriptShadowOperation): void {
+    const id = operation.conversationId;
+    const prior = this.tails.get(id) ?? Promise.resolve();
+    const task = prior
+      .then(() => this.process(operation))
+      .catch((error: unknown) => this.markDirty(id, error))
+      .finally(() => {
+        if (this.tails.get(id) === task) this.tails.delete(id);
+      });
+    this.tails.set(id, task);
+  }
+
+  isDirty(conversationId: string): boolean {
+    return this.dirty.has(conversationId);
+  }
+
+  async flush(): Promise<void> {
+    await Promise.all([...this.tails.values()]);
+  }
+
+  private async process(operation: TranscriptShadowOperation): Promise<void> {
+    const id = operation.conversationId;
+    if (
+      this.dirty.has(id) &&
+      operation.kind !== "repair" &&
+      operation.kind !== "delete"
+    ) {
+      try {
+        await this.transport.send({
+          kind: "repair",
+          conversationId: id,
+          conversation: operation.conversation,
+        });
+        this.dirty.delete(id);
+        // The repair snapshot was taken after this file mutation, so it already
+        // contains the operation. Re-sending would be redundant and is invalid
+        // for truncation because the repaired snapshot no longer has that turn.
+        return;
+      } catch (error) {
+        this.markDirty(id, error);
+      }
+    }
+
+    try {
+      await this.transport.send(operation);
+      if (operation.kind === "repair" || operation.kind === "delete") {
+        this.dirty.delete(id);
+      }
+    } catch (error) {
+      this.markDirty(id, error);
+    }
+  }
+
+  private markDirty(conversationId: string, error: unknown): void {
+    if (!this.dirty.has(conversationId)) {
+      if (this.dirty.size >= MAX_DIRTY_CONVERSATIONS) {
+        const oldest = this.dirty.values().next().value;
+        if (oldest) this.dirty.delete(oldest);
+      }
+      this.dirty.add(conversationId);
+    }
+    console.debug(
+      `[transcript-shadow] ${conversationId} is dirty; repair will retry`,
+      error,
+    );
+  }
+}
+
+/** Freeze the mutable parse-cache object at the file/shadow seam. */
+export function snapshotConversation(
+  conversation: StoredConversation,
+): StoredConversation {
+  return JSON.parse(JSON.stringify(conversation)) as StoredConversation;
+}


### PR DESCRIPTION
**Engine slice (houston)** — stacked on #1312 (fenced writes); retargets `main` when it merges. Companion to the cloud stack gethouston/cloud#239–#241. The conversation FILE stays authoritative; every new path is best-effort shadow that can never block, delay, or fail a turn. Behind HOUSTON_TRANSCRIPT_DUAL_WRITE / HOUSTON_TURN_LOG; unset ⇒ nothing constructed, byte-identical.

- Transcript shadow: atomic file write+rename FIRST (ordering unchanged), then a detached per-conversation queue POSTs a DEEP-CLONED post-write snapshot (closes the parse-cache aliasing hazard) through a host /sandbox facade → pod-store, with the phase-2 fencing headers and the expectedCount divergence etag. Failures mark the conversation dirty; the next op repairs via the idempotent repair route.
- Doc shadow: the five .houston families keep their file RMW (files remain the agent-readable surface); each write is followed by a best-effort If-Match PUT. The FS watcher also shadows the agent's prompt-sanctioned direct learnings.json write.
- Turnlog: FrameForwarder batches frames (250ms/32, terminal flushed immediately) carrying the producer's authoritative seq; StandingFrameCapture pumps the standing runtime's SSE and is triggered at turn dispatch AND routine fire — turns with NO client are captured (the case a tee design misses), with an explicit test.
- Reconcile reads via the gateway reply-after route under dual-write, file fallback on any error. File reads and the duplicate conversationKey builders are retired in a later PR, not here.

Boundary check green (no pg/redis in packages/**); 170 host + 38 runtime-store tests.