### PR TITLE
feat(teams): multiple owners per org + app-first invite landing page

### DIFF
--- a/app/src/components/agent/agent-access-model.ts
+++ b/app/src/components/agent/agent-access-model.ts
@@ -136,11 +136,12 @@ function canBeManagerRole(role: OrgRole): boolean {
 }
 
 /**
- * The people who currently have access, as dialog rows. The org owner is always
- * included (they can use every org agent and can never be removed). An org-wide
- * agent ("everyone" sentinel) expands to every current member so the count is
- * truthful and editing operates on the real roster instead of silently dropping
- * the team. Sorted owner, then managers, then members, then by email/id.
+ * The people who currently have access, as dialog rows. Org owners are always
+ * included (every owner can use every org agent and can never be removed; an
+ * org may hold several). An org-wide agent ("everyone" sentinel) expands to
+ * every current member so the count is truthful and editing operates on the
+ * real roster instead of silently dropping the team. Sorted owners, then
+ * managers, then members, then by email/id.
  */
 export function buildSharePeople(opts: {
   agent: Pick<Agent, "assignments" | "assignedUserIds">;
@@ -155,8 +156,9 @@ export function buildSharePeople(opts: {
   if (isSharedWithEveryone(opts.agent)) {
     for (const m of opts.members) ids.add(m.userId);
   }
-  const owner = opts.members.find((m) => m.role === "owner");
-  if (owner) ids.add(owner.userId);
+  for (const m of opts.members) {
+    if (m.role === "owner") ids.add(m.userId);
+  }
 
   const people: SharePerson[] = [];
   for (const userId of ids) {

--- a/app/src/components/organization/people-add-row.tsx
+++ b/app/src/components/organization/people-add-row.tsx
@@ -1,5 +1,6 @@
 import {
   AsyncButton,
+  ConfirmDialog,
   Input,
   Select,
   SelectContent,
@@ -12,14 +13,20 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAddMember } from "../../hooks/queries";
 import { GRANTABLE_ROLES } from "../../lib/org-roles";
-import { type AddOutcome, describeAddResult } from "./people-tab-model";
+import {
+  type AddOutcome,
+  describeAddResult,
+  grantsOwner,
+} from "./people-tab-model";
 
 /**
- * The owner-only "Add someone" row on the People tab: email + role (Manager /
- * Member, each with a plain-language explanation) → `POST /org/members`. A known
- * user is added directly; an unknown email becomes a pending invite (`202`), and
- * we confirm which happened inline. Failures (already a member, another org)
- * reach the user as a toast from the `call()` wrapper, so no `onError` here.
+ * The owner-only "Add someone" row on the People tab: email + role (Owner /
+ * Manager / Member, each with a plain-language explanation) →
+ * `POST /org/members`. A known user is added directly; an unknown email becomes
+ * a pending invite (`202`), and we confirm which happened inline. Adding
+ * someone as OWNER (full org authority, billing included) is confirm-gated
+ * before the request fires. Failures (already a member, another org) reach the
+ * user as a toast from the `call()` wrapper, so no `onError` here.
  */
 export function PeopleAddRow() {
   const { t } = useTranslation("teams");
@@ -27,8 +34,9 @@ export function PeopleAddRow() {
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<OrgRole>("user");
   const [outcome, setOutcome] = useState<AddOutcome | null>(null);
+  const [confirmOwner, setConfirmOwner] = useState(false);
 
-  const submit = async () => {
+  const send = async () => {
     const value = email.trim();
     if (!value || addMember.isPending) return;
     try {
@@ -40,6 +48,15 @@ export function PeopleAddRow() {
       // call() already surfaced the reason (already a member, another org, ...);
       // keep the typed email so the owner can fix and retry.
     }
+  };
+
+  const submit = async () => {
+    if (!email.trim() || addMember.isPending) return;
+    if (grantsOwner(role)) {
+      setConfirmOwner(true);
+      return;
+    }
+    await send();
   };
 
   return (
@@ -108,6 +125,18 @@ export function PeopleAddRow() {
         {outcome?.kind === "invited" &&
           t("people.add.invited", { email: outcome.email })}
       </p>
+      <ConfirmDialog
+        open={confirmOwner}
+        onOpenChange={setConfirmOwner}
+        title={t("people.makeOwnerConfirm.title", { name: email.trim() })}
+        description={t("people.makeOwnerConfirm.description")}
+        confirmLabel={t("people.makeOwnerConfirm.confirm")}
+        cancelLabel={t("people.removeConfirm.cancel")}
+        onConfirm={() => {
+          setConfirmOwner(false);
+          void send();
+        }}
+      />
     </section>
   );
 }

--- a/app/src/components/organization/people-roster.tsx
+++ b/app/src/components/organization/people-roster.tsx
@@ -15,17 +15,28 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useRemoveMember, useSetMemberRole } from "../../hooks/queries";
 import { GRANTABLE_ROLES } from "../../lib/org-roles";
-import { canEditMember, initialsFor, memberLabel } from "./people-tab-model";
+import {
+  canEditMember,
+  grantsOwner,
+  initialsFor,
+  memberLabel,
+} from "./people-tab-model";
 
 /**
  * The People roster: one row per member with an avatar, name/email, and a role.
  * Owners get a role dropdown and a confirm-gated Remove for everyone but
- * themselves and the owner row; admins see those read-only. The role Select and
- * Remove disable while their mutation is in flight (loading state); the "last
- * owner" 409 and other failures reach the user as a toast from `call()`. This is
+ * themselves; admins see those read-only. Other OWNER rows are editable too
+ * (multi-owner orgs), with two confirm gates: removing anyone, and granting
+ * owner (full org authority). Demoting/removing a sole owner is refused by the
+ * gateway's `last_owner` 409, surfaced as a plain informational toast. The role
+ * Select and Remove disable while their mutation is in flight. This is
  * membership only — inspecting a person's per-agent access lives in the
  * Permissions view, so a row's identity is not a drill-in here.
  */
+type PendingAction =
+  | { kind: "remove"; member: OrgMember }
+  | { kind: "makeOwner"; member: OrgMember };
+
 export function PeopleRoster({
   members,
   selfId,
@@ -38,9 +49,20 @@ export function PeopleRoster({
   const { t } = useTranslation("teams");
   const setRole = useSetMemberRole();
   const removeMember = useRemoveMember();
-  const [pendingRemove, setPendingRemove] = useState<OrgMember | null>(null);
+  const [pending, setPending] = useState<PendingAction | null>(null);
 
   const roleLabel = (role: OrgRole) => t(`people.roles.${role}`);
+
+  const confirmPending = () => {
+    const action = pending;
+    setPending(null);
+    if (!action) return;
+    if (action.kind === "remove") {
+      removeMember.mutate(action.member.userId);
+    } else {
+      setRole.mutate({ userId: action.member.userId, role: "owner" });
+    }
+  };
 
   return (
     <section>
@@ -99,12 +121,15 @@ export function PeopleRoster({
                 <Select
                   value={member.role}
                   disabled={setRole.isPending}
-                  onValueChange={(v) =>
-                    setRole.mutate({
-                      userId: member.userId,
-                      role: v as OrgRole,
-                    })
-                  }
+                  onValueChange={(v) => {
+                    const role = v as OrgRole;
+                    if (role === member.role) return;
+                    if (grantsOwner(role, member.role)) {
+                      setPending({ kind: "makeOwner", member });
+                      return;
+                    }
+                    setRole.mutate({ userId: member.userId, role });
+                  }}
                 >
                   <SelectTrigger
                     className="h-8 w-32 rounded-full"
@@ -135,7 +160,7 @@ export function PeopleRoster({
                   aria-label={t("people.roster.removeLabel", {
                     name: memberLabel(member),
                   })}
-                  onClick={() => setPendingRemove(member)}
+                  onClick={() => setPending({ kind: "remove", member })}
                 >
                   {t("people.roster.remove")}
                 </Button>
@@ -146,21 +171,31 @@ export function PeopleRoster({
       </ul>
 
       <ConfirmDialog
-        open={pendingRemove !== null}
+        open={pending !== null}
         onOpenChange={(open) => {
-          if (!open) setPendingRemove(null);
+          if (!open) setPending(null);
         }}
-        title={t("people.removeConfirm.title", {
-          name: pendingRemove ? memberLabel(pendingRemove) : "",
-        })}
-        description={t("people.removeConfirm.description")}
-        confirmLabel={t("people.removeConfirm.confirm")}
+        title={
+          pending?.kind === "makeOwner"
+            ? t("people.makeOwnerConfirm.title", {
+                name: pending ? memberLabel(pending.member) : "",
+              })
+            : t("people.removeConfirm.title", {
+                name: pending ? memberLabel(pending.member) : "",
+              })
+        }
+        description={
+          pending?.kind === "makeOwner"
+            ? t("people.makeOwnerConfirm.description")
+            : t("people.removeConfirm.description")
+        }
+        confirmLabel={
+          pending?.kind === "makeOwner"
+            ? t("people.makeOwnerConfirm.confirm")
+            : t("people.removeConfirm.confirm")
+        }
         cancelLabel={t("people.removeConfirm.cancel")}
-        onConfirm={() => {
-          const target = pendingRemove;
-          setPendingRemove(null);
-          if (target) removeMember.mutate(target.userId);
-        }}
+        onConfirm={confirmPending}
       />
     </section>
   );

--- a/app/src/components/organization/people-tab-model.ts
+++ b/app/src/components/organization/people-tab-model.ts
@@ -41,16 +41,28 @@ export function initialsFor(source: string): string {
 
 /**
  * Can the viewer re-role or remove this member row? Owners only (`canManage`),
- * never themselves (no self-demotion/self-remove from the UI), and never
- * another owner (ownership transfer is out of scope for v1; the gateway also
- * guards the last-owner case with a 409).
+ * never themselves (no self-demotion/self-remove from the UI). Other OWNER rows
+ * are editable too — an org may hold several owners, and demoting or removing
+ * one is legal as long as at least one remains; the gateway's race-safe
+ * `last_owner` 409 is the floor and surfaces as a plain informational toast.
  */
 export function canEditMember(opts: {
   canManage: boolean;
   isSelf: boolean;
   role: OrgRole;
 }): boolean {
-  return opts.canManage && !opts.isSelf && opts.role !== "owner";
+  return opts.canManage && !opts.isSelf;
+}
+
+/**
+ * Does this role change hand out OWNER authority — full org control including
+ * membership and billing? Both grant surfaces (the add/invite row and the
+ * roster's role select) confirm-gate exactly this transition; every other
+ * change (including demoting an owner) applies directly, since the gateway
+ * guards the only dangerous case (`last_owner`).
+ */
+export function grantsOwner(next: OrgRole, current?: OrgRole): boolean {
+  return next === "owner" && current !== "owner";
 }
 
 /**

--- a/app/src/hooks/queries/use-org.ts
+++ b/app/src/hooks/queries/use-org.ts
@@ -24,9 +24,10 @@ export function useOrg(enabled: boolean) {
  * `tauriOrg.*` wrappers, each wrapped by the `call()` adapter in `lib/tauri.ts`.
  * `call()` already surfaces the real error as a red toast AND
  * reports it to Sentry before re-throwing (React Query swallows the re-throw
- * internally, so `.mutate()` never leaks). The "last owner" 409 and "user
- * already in another org" 409 from the gateway reach the user through that same
- * path. Adding an `onError` here would double-toast.
+ * internally, so `.mutate()` never leaks). The "user already in another org"
+ * 409 reaches the user through that same path; the "last owner" 409 is an
+ * expected business state and `call()` routes it to a plain informational
+ * toast (`isLastOwnerError`). Adding an `onError` here would double-toast.
  */
 export function useAddMember() {
   const qc = useQueryClient();

--- a/app/src/lib/org-roles.ts
+++ b/app/src/lib/org-roles.ts
@@ -126,8 +126,9 @@ export function canSeeAiModelsPage(
 }
 
 /**
- * Can this caller MUTATE members (add / remove / change role)? Owner only per
- * C3 — admins see the roster read-only.
+ * Can this caller MUTATE members (add / remove / change role)? Owners only per
+ * C3 — admins see the roster read-only. An org may hold several owners; every
+ * one of them passes this gate.
  */
 export function canManageMembers(
   caps: Capabilities | null | undefined,
@@ -177,8 +178,15 @@ export function isSpaceOwner(
 }
 
 /**
- * The roles an owner may GRANT when adding or re-roling a member. Owner is the
- * single billing seat and is never handed out from the UI (ownership transfer
- * is out of scope for v1).
+ * The roles an owner may GRANT when adding or re-roling a member. Owner is
+ * grantable too: an org may hold any number of owners (the gateway's only
+ * cardinality rule is the >= 1 floor, its race-safe `last_owner` 409), so an
+ * owner can invite or promote a co-owner. Granting owner is confirm-gated in
+ * both surfaces (add row + roster) because it hands out full org authority
+ * including billing.
  */
-export const GRANTABLE_ROLES: readonly OrgRole[] = ["admin", "user"] as const;
+export const GRANTABLE_ROLES: readonly OrgRole[] = [
+  "owner",
+  "admin",
+  "user",
+] as const;

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -60,7 +60,11 @@ import { osIsTauri, osPickDirectory } from "./os-bridge";
 import { normalizeLegacyModel } from "./providers";
 import { healStaleRosterFromError } from "./roster-heal";
 import { isSharedSkillsUnconfiguredError } from "./shared-skills-availability";
-import { isNeedsUpgradeError, isPersonalSpaceError } from "./team-status-model";
+import {
+  isLastOwnerError,
+  isNeedsUpgradeError,
+  isPersonalSpaceError,
+} from "./team-status-model";
 import { isToolkitOauthUnavailableError } from "./toolkit-oauth-unavailable";
 import type {
   Agent,
@@ -222,6 +226,18 @@ async function surfaceError(
     showExpectedStateToast(
       i18n.t("teams:personalSpace.inviteBlockedTitle"),
       i18n.t("teams:personalSpace.inviteBlockedBody"),
+    );
+    return;
+  }
+
+  // Expected business state, not a bug: removing or demoting an org's only
+  // owner (C3 `last_owner` 409). The org must keep at least one owner; tell
+  // the caller to hand ownership to someone else first, never the red bug pair.
+  if (isLastOwnerError(err)) {
+    const { showExpectedStateToast } = await import("./error-toast");
+    showExpectedStateToast(
+      i18n.t("teams:people.lastOwner.title"),
+      i18n.t("teams:people.lastOwner.body"),
     );
     return;
   }

--- a/app/src/lib/team-status-model.ts
+++ b/app/src/lib/team-status-model.ts
@@ -120,3 +120,15 @@ export function isNeedsUpgradeError(err: unknown): boolean {
 export function isPersonalSpaceError(err: unknown): boolean {
   return shareErrorCode(err) === "personal_space";
 }
+
+/**
+ * True for a gateway `last_owner` rejection (409) — an EXPECTED business state,
+ * NOT a Houston bug: the caller tried to remove or demote an org's only owner,
+ * and the org must keep at least one (the gateway's race-safe floor). Routed to
+ * a plain informational toast, exactly like {@link isNeedsUpgradeError}, so the
+ * owner learns to hand ownership to someone else first instead of seeing a red
+ * "report a bug" toast. Reuses the same kind/code/body extractor.
+ */
+export function isLastOwnerError(err: unknown): boolean {
+  return shareErrorCode(err) === "last_owner";
+}

--- a/app/src/locales/en/teams.json
+++ b/app/src/locales/en/teams.json
@@ -257,6 +257,7 @@
       "user": "Member"
     },
     "roleHelp": {
+      "owner": "Owners have full control of the organization, including people and billing.",
       "admin": "Managers create and run agents.",
       "user": "Members use agents shared with them."
     },
@@ -279,6 +280,15 @@
       "description": "They'll lose access to every agent shared with them. You can add them again later.",
       "confirm": "Remove",
       "cancel": "Cancel"
+    },
+    "makeOwnerConfirm": {
+      "title": "Make {{name}} an owner?",
+      "description": "Owners have full control of this organization: people, agents, and billing. You can change this later as long as the organization keeps at least one owner.",
+      "confirm": "Make owner"
+    },
+    "lastOwner": {
+      "title": "The organization needs an owner",
+      "body": "You can't remove or demote the only owner. Make someone else an owner first."
     }
   },
   "activityTab": {

--- a/app/src/locales/es/teams.json
+++ b/app/src/locales/es/teams.json
@@ -257,6 +257,7 @@
       "user": "Miembro"
     },
     "roleHelp": {
+      "owner": "Los propietarios tienen control total de la organización, incluidas las personas y la facturación.",
       "admin": "Los managers crean y ejecutan agentes.",
       "user": "Los miembros usan los agentes que se comparten con ellos."
     },
@@ -279,6 +280,15 @@
       "description": "Perderá el acceso a todos los agentes que se le compartieron. Puedes volver a agregarla más tarde.",
       "confirm": "Quitar",
       "cancel": "Cancelar"
+    },
+    "makeOwnerConfirm": {
+      "title": "¿Hacer a {{name}} propietario?",
+      "description": "Los propietarios tienen control total de esta organización: personas, agentes y facturación. Puedes cambiarlo más tarde siempre que la organización conserve al menos un propietario.",
+      "confirm": "Hacer propietario"
+    },
+    "lastOwner": {
+      "title": "La organización necesita un propietario",
+      "body": "No puedes quitar ni degradar al único propietario. Primero haz propietario a alguien más."
     }
   },
   "activityTab": {

--- a/app/src/locales/pt/teams.json
+++ b/app/src/locales/pt/teams.json
@@ -257,6 +257,7 @@
       "user": "Membro"
     },
     "roleHelp": {
+      "owner": "Os proprietários têm controle total da organização, incluindo pessoas e cobrança.",
       "admin": "Os managers criam e executam agentes.",
       "user": "Os membros usam os agentes compartilhados com eles."
     },
@@ -279,6 +280,15 @@
       "description": "Ela perderá o acesso a todos os agentes compartilhados com ela. Você pode adicioná-la novamente depois.",
       "confirm": "Remover",
       "cancel": "Cancelar"
+    },
+    "makeOwnerConfirm": {
+      "title": "Tornar {{name}} proprietário?",
+      "description": "Os proprietários têm controle total desta organização: pessoas, agentes e cobrança. Você pode mudar isso depois, desde que a organização mantenha pelo menos um proprietário.",
+      "confirm": "Tornar proprietário"
+    },
+    "lastOwner": {
+      "title": "A organização precisa de um proprietário",
+      "body": "Você não pode remover nem rebaixar o único proprietário. Primeiro torne outra pessoa proprietária."
     }
   },
   "activityTab": {

--- a/app/tests/agent-share-dialog.test.ts
+++ b/app/tests/agent-share-dialog.test.ts
@@ -209,6 +209,35 @@ describe("buildSharePeople", () => {
       ["own", "adm", "mem"],
     );
   });
+
+  it("includes EVERY owner of a multi-owner org, each a non-removable manager", () => {
+    const coOwner: OrgMember = {
+      userId: "own2",
+      email: "co@x.co",
+      role: "owner",
+    };
+    const people = buildSharePeople({
+      agent: { assignments: [{ userId: "mem", access: "user" }] },
+      members: [...ROSTER, coOwner],
+      selfId: null,
+    });
+    for (const id of ["own", "own2"]) {
+      const owner = people.find((p) => p.userId === id);
+      strictEqual(owner?.isOwner, true);
+      strictEqual(owner?.access, "manager");
+    }
+    // Both owners sort ahead of everyone else (alphabetical within the tier),
+    // and neither can be stripped.
+    deepStrictEqual(
+      people.slice(0, 2).map((p) => p.userId),
+      ["own2", "own"],
+    );
+    const afterRemove = applyShareAction(people, "own2", "remove");
+    strictEqual(
+      afterRemove.some((a) => a.userId === "own2"),
+      true,
+    );
+  });
 });
 
 describe("buildSharePeople org-wide", () => {

--- a/app/tests/org-members-tab.test.ts
+++ b/app/tests/org-members-tab.test.ts
@@ -4,6 +4,7 @@ import type { OrgMember } from "@houston-ai/engine-client";
 import {
   canEditMember,
   describeAddResult,
+  grantsOwner,
   initialsFor,
   inviterLabel,
   memberLabel,
@@ -61,11 +62,29 @@ describe("people tab model — canEditMember", () => {
       false,
     );
   });
-  it("blocks editing another owner (no ownership transfer)", () => {
+  it("lets an owner edit another owner (multi-owner orgs; the gateway guards the last-owner floor)", () => {
     strictEqual(
       canEditMember({ canManage: true, isSelf: false, role: "owner" }),
-      false,
+      true,
     );
+  });
+});
+
+describe("people tab model — grantsOwner", () => {
+  it("granting owner to a non-owner needs the confirm", () => {
+    strictEqual(grantsOwner("owner", "user"), true);
+    strictEqual(grantsOwner("owner", "admin"), true);
+  });
+  it("adding/inviting a brand-new person as owner needs the confirm", () => {
+    strictEqual(grantsOwner("owner"), true);
+  });
+  it("a no-op owner-to-owner change does not", () => {
+    strictEqual(grantsOwner("owner", "owner"), false);
+  });
+  it("every non-owner grant applies without a confirm", () => {
+    strictEqual(grantsOwner("admin", "user"), false);
+    strictEqual(grantsOwner("user", "owner"), false);
+    strictEqual(grantsOwner("user"), false);
   });
 });
 

--- a/app/tests/org-roles.test.ts
+++ b/app/tests/org-roles.test.ts
@@ -226,7 +226,7 @@ describe("hasAgentTeams (C13 feature-detect)", () => {
 });
 
 describe("grantable roles", () => {
-  it("owner is never grantable from the UI", () => {
-    deepStrictEqual([...GRANTABLE_ROLES], ["admin", "user"]);
+  it("owner is grantable (multi-owner orgs), then admin and user", () => {
+    deepStrictEqual([...GRANTABLE_ROLES], ["owner", "admin", "user"]);
   });
 });

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -62,8 +62,10 @@ so every existing single-player/self-host profile stays valid:
 **Org role** = authority in the org. **Agent access** = authority on one shared agent.
 
 - **`OrgRole = "owner" | "admin" | "user"`** — UI labels **Owner / Manager / Member**.
-  `owner` is the single billing/root seat; `admin` manages members + agents; `user` is a
-  plain seat that can only use assigned agents.
+  `owner` is the billing/root role; an org may hold SEVERAL owners (the gateway's only
+  cardinality rule is the >= 1 floor, its race-safe `last_owner` 409, so the last owner
+  can never be removed or demoted). `admin` manages members + agents; `user` is a plain
+  seat that can only use assigned agents.
 - **`AgentAccess = "manager" | "user"`** — per-agent, on `gateway.agent_assignments`.
   `manager` may reconfigure the agent (instructions, skills, model, allowed apps,
   assignments); `user` may only use it. Owner is always `manager` on every org agent.
@@ -84,13 +86,13 @@ that also take `Pick<Agent, "access" | "assigned">` in `app/src/lib/agent-access
 | `orgRole(caps)` | the role, or `null` off-multiplayer. A missing role on a multiplayer host is treated as the least-privileged `user` — never widens |
 | `canCreateAgents(caps)` | owner/admin (single-player: always). The sidebar "New Agent" reads it via `useCanCreateAgents` |
 | `canSeeMembers(caps)` | owner/admin. Also the exact gate for the org dashboard (`canSeeOrganization` delegates to it) |
-| `canManageMembers(caps)` | **owner only**; admins see the roster read-only |
+| `canManageMembers(caps)` | **owners only**; admins see the roster read-only |
 | `isAgentManager(caps, agent)` | the single per-agent authority gate: single-player true; org owner true; else `agent.access === "manager"`. It trusts `access` verbatim because the gateway already clamps a stale `manager` row for a `user` member before it reaches the wire |
 | `canEditAgentConfig` | semantic alias of `isAgentManager` for config-edit call sites |
 | `canManageAssignments(caps, agent)` | same gate; behind the Share block |
 | `canSeeAiModelsPage(caps)` | **TRUE for everyone, always.** See below |
 | `canSeeBillingTab(caps, activeSpaceIsTeam)` | Spaces host AND active team AND owner/admin (`spaces.md`) |
-| `GRANTABLE_ROLES = ["admin","user"]` | owner is never handed out from the UI (ownership transfer is out of scope) |
+| `GRANTABLE_ROLES = ["owner","admin","user"]` | owner IS grantable (multi-owner orgs): the add row and the roster role select offer it behind the `makeOwnerConfirm` dialog (`grantsOwner` in `people-tab-model.ts`). Demoting/removing an owner is allowed too (`canEditMember` no longer special-cases owner rows); the gateway's `last_owner` 409 is the floor, surfaced via `isLastOwnerError` as a plain info toast |
 
 - **The global Integrations page has NO role gate** — it is the personal catalog for
   every member in every mode.
@@ -176,9 +178,11 @@ Sections:
   agent-written files never corrupt). The same component draws About me, an
   agent's Job description (agent settings), and the team context card.
 - **People** (`members-tab.tsx` / `people-roster.tsx`) — roster + pending invites,
-  **membership only**: owner mutates (add/remove/re-role, revoke invite), admin sees
-  them read-only. Per-agent access is managed on the agent settings page's People
-  section. This is the ONLY membership surface.
+  **membership only**: owners mutate (add/remove/re-role, revoke invite), admin sees
+  them read-only. Any role is grantable including owner (confirm-gated, multi-owner);
+  the sole-owner case is guarded by the gateway (`last_owner`). Per-agent access is
+  managed on the agent settings page's People section. This is the ONLY membership
+  surface.
 - **Analytics** (`analytics-tab.tsx`) — one measurement section; Activity (audit log,
   paged), Usage (per-agent/user message counters), and Time worked are its lenses.
 - **Billing** (`billing-tab.tsx`) — `spaces.md` → *Billing surface*.
@@ -334,6 +338,11 @@ Members can only connect apps the agent allows. Full model: `integrations.md` §
 
 ## Invites, members, audit, usage
 
+- **Invite email → landing page** — the gateway's invite + member-added emails link
+  `https://gethouston.ai/invite/?team=<name>` (`GW_INVITE_URL`; `website/src/invite/`),
+  which tries the desktop app via `houston://open` and falls back to the marketing
+  site's `/#download` gate when the app isn't installed. Tokenless by design: joining
+  stays email-matched (auto-join on first sign-in, or the invite inbox).
 - **Invites** — `addOrgMember(email, role)` → `POST /v1/org/members`
   (`packages/web/src/engine-adapter/cp/orgs.ts`), targeting the ACTIVE space;
   `403 personal_space` on a personal one (surfaced as the friendly `personalSpace` toast,

--- a/website/eleventy.config.js
+++ b/website/eleventy.config.js
@@ -45,6 +45,7 @@ export default function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("src/guides/downloads");
   eleventyConfig.addPassthroughCopy("src/slack");
   eleventyConfig.addPassthroughCopy("src/auth");
+  eleventyConfig.addPassthroughCopy("src/invite");
   eleventyConfig.addPassthroughCopy("src/_headers");
   eleventyConfig.addPassthroughCopy("src/_redirects");
   // SEO + AI-crawler files. Served verbatim at the site root (/robots.txt,

--- a/website/src/invite/index.html
+++ b/website/src/invite/index.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>Houston — You're invited</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <style>
+    :root { color-scheme: light; }
+    body {
+      font-family: ui-sans-serif, -apple-system, system-ui, sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      background: #fafafa;
+      color: #0d0d0d;
+    }
+    .card {
+      text-align: center;
+      padding: 60px 40px;
+      max-width: 440px;
+    }
+    .logo {
+      width: 48px;
+      height: 48px;
+      margin: 0 auto 24px;
+      display: block;
+    }
+    h1 {
+      font-size: 22px;
+      font-weight: 600;
+      margin: 0 0 12px;
+      letter-spacing: -0.01em;
+    }
+    p {
+      font-size: 14px;
+      color: #555;
+      margin: 0 0 24px;
+      line-height: 1.5;
+    }
+    .actions {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      align-items: center;
+    }
+    a.btn {
+      display: inline-block;
+      padding: 10px 20px;
+      border-radius: 999px;
+      background: #0d0d0d;
+      color: #fff;
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+    }
+    a.btn:hover { opacity: 0.9; }
+    a.btn.secondary {
+      background: transparent;
+      color: #0d0d0d;
+      border: 1px solid #d4d4d4;
+    }
+    .small {
+      font-size: 12px;
+      color: #999;
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <img src="/houston-black.svg" alt="Houston" class="logo">
+    <h1 id="title">You're invited to Houston</h1>
+    <p id="message">Opening Houston. Sign in with the email address that received this invitation and you'll join the team automatically.</p>
+    <div class="actions">
+      <a id="open" class="btn" href="houston://open">Open Houston</a>
+      <a id="download" class="btn secondary" href="/#download">Don't have Houston? Download it</a>
+      <span class="small">If Houston doesn't open, download the app, then sign in with your invited email.</span>
+    </div>
+  </main>
+
+  <script>
+    (function () {
+      // Personalize with the team name when the invite email carried one.
+      // Text-node assignment only — never innerHTML — so the query param
+      // cannot inject markup.
+      var params = new URLSearchParams(window.location.search || "");
+      var team = (params.get("team") || "").trim();
+      if (team) {
+        document.getElementById("title").textContent =
+          "You're invited to " + team + " on Houston";
+      }
+
+      // Try to hand off to the installed desktop app right away. The scheme
+      // is registered by the app itself (houston://), so on a machine with
+      // Houston installed this pops the app; the OS may first ask "Open
+      // Houston?", which is fine. Without the app the navigation is a silent
+      // no-op in most browsers.
+      var deepLink = "houston://open";
+      try {
+        window.location.replace(deepLink);
+      } catch (e) {
+        // ignore — the buttons stay usable
+      }
+
+      // If the page is still visible AND focused a moment later, the app
+      // almost certainly didn't open: launching Houston blurs this window,
+      // and the browser's "Open Houston?" confirm dialog steals focus
+      // (document.hasFocus() goes false) even when it doesn't blur. In that
+      // case fall through to the download gate with its modal open (the
+      // site's #download hash trigger) so a new user can grab the installer
+      // without hunting for the button.
+      var blurred = false;
+      window.addEventListener("blur", function () { blurred = true; });
+      document.addEventListener("visibilitychange", function () {
+        if (document.visibilityState === "hidden") blurred = true;
+      });
+      setTimeout(function () {
+        if (
+          !blurred &&
+          document.visibilityState === "visible" &&
+          document.hasFocus()
+        ) {
+          window.location.href = "/#download";
+        }
+      }, 2600);
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Multiple owners per organization

The gateway has always allowed several owners per org (its only cardinality rule is the >= 1 floor, the race-safe `last_owner` 409; billing is keyed to the org, not the owner user). The client was the blocker, and this PR unlocks it:

- **Grant owner**: `GRANTABLE_ROLES` now includes `owner`, so the Admin > People add/invite row and the roster role dropdown both offer Owner, behind a confirm dialog (`grantsOwner`, `people.makeOwnerConfirm.*` in en/es/pt) since it hands out full org authority including billing.
- **Edit owner rows**: `canEditMember` no longer special-cases owner rows, so an owner can re-role or remove a co-owner (never themselves). The sole-owner case stays gateway-guarded: the `last_owner` 409 now surfaces as a plain informational toast (`isLastOwnerError` in `team-status-model.ts`, routed in `tauri.ts`) instead of the red report-a-bug pair.
- **Share/people models**: `buildSharePeople` no longer assumes exactly one owner; every owner is an implicit, non-removable manager on every org agent, sorted first.

## App-first invite landing page

Feedback from the teams onboarding: the invite email dropped people into the web page (and the AI models tab) instead of the app.

- New `website/src/invite/` landing page (passthrough like `src/auth`): greets with `?team=`, immediately tries the installed desktop app via `houston://open`, keeps Open/Download buttons visible, and falls through to `/#download` (the download-gate modal) when the page keeps focus, i.e. the app isn't installed. The gateway invite + member-added emails point at it (gateway-side change ships separately).
- Invites stay tokenless: joining remains email-matched (auto-join on first sign-in, invite inbox for existing accounts).

## Tests + gates

- Updated/new unit tests: grantable roles, `canEditMember`, `grantsOwner`, multi-owner share roster. 3642 app tests green.
- Biome, `check-locales` (en/es/pt in sync), full workspace typecheck all pass; Eleventy build emits `/invite/`.
- No visual baselines cover the People tab; no re-record needed.
- `knowledge-base/teams.md` updated (multi-owner role model, grantable roles, invite email flow).