### PR TITLE
fix(inbox): settle the Inbox for a space with no agents

### DIFF
--- a/app/src/components/board/mentions-inbox-model.ts
+++ b/app/src/components/board/mentions-inbox-model.ts
@@ -118,3 +118,19 @@ export function buildMentionInbox(
   );
   return rows;
 }
+
+/**
+ * Is the inbox still WAITING on the cross-agent sweep? Only while there are
+ * paths to sweep. A roster with no agents (a brand-new team space, a
+ * just-invited member before any agent is shared, single player off
+ * multiplayer) DISABLES the sweep query, and a disabled query never leaves
+ * React Query's `pending` state — rendering on the raw flag alone kept the
+ * Inbox on its skeleton forever exactly for the people whose honest answer is
+ * the empty state. No paths = nothing to sweep = the empty answer is FINAL.
+ */
+export function inboxSweepPending(
+  sweepPending: boolean,
+  pathCount: number,
+): boolean {
+  return pathCount > 0 && sweepPending;
+}

--- a/app/src/components/board/use-mention-inbox.ts
+++ b/app/src/components/board/use-mention-inbox.ts
@@ -7,6 +7,7 @@ import { isMultiplayer } from "../../lib/org-roles";
 import type { Agent } from "../../lib/types";
 import {
   buildMentionInbox,
+  inboxSweepPending,
   type MentionInboxConversation,
 } from "./mentions-inbox-model";
 import { agentsByPath } from "./mission-card-agent";
@@ -48,6 +49,10 @@ export function useMentionInbox(agents: Agent[]) {
     [agents, mentionsExist],
   );
   const { data, isPending } = useAllConversations(paths);
+  // An empty roster disables the sweep query, and a disabled query never
+  // leaves `pending` — see inboxSweepPending. Without this, a new team space
+  // (or a just-invited member) stared at the Inbox skeleton forever.
+  const pending = inboxSweepPending(isPending, paths.length);
   const conversations: MentionInboxConversation[] = useMemo(
     () => data ?? [],
     [data],
@@ -61,5 +66,5 @@ export function useMentionInbox(agents: Agent[]) {
     () => rows.reduce((n, row) => n + (row.mentionOutstanding ? 1 : 0), 0),
     [rows],
   );
-  return { rows, conversations, mentionCount, isPending };
+  return { rows, conversations, mentionCount, isPending: pending };
 }

--- a/app/tests/mentions-inbox-model.test.ts
+++ b/app/tests/mentions-inbox-model.test.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
   buildMentionInbox,
+  inboxSweepPending,
   type MentionInboxConversation,
 } from "../src/components/board/mentions-inbox-model.ts";
 import type { ReadCursorStore } from "../src/lib/read-cursors.ts";
@@ -233,5 +234,20 @@ describe("buildMentionInbox", () => {
       buildMentionInbox([c], store(), ME, roster)[0]?.agentName,
       "Kai",
     );
+  });
+});
+
+describe("inboxSweepPending", () => {
+  it("passes the sweep's pending state through while there are paths", () => {
+    strictEqual(inboxSweepPending(true, 3), true);
+    strictEqual(inboxSweepPending(false, 3), false);
+  });
+
+  it("settles an EMPTY roster immediately (disabled query never leaves pending)", () => {
+    // A brand-new team space or a just-invited member has no agents yet; the
+    // sweep query is disabled and its raw isPending stays true forever. The
+    // inbox must show its empty state, not an eternal skeleton.
+    strictEqual(inboxSweepPending(true, 0), false);
+    strictEqual(inboxSweepPending(false, 0), false);
   });
 });


### PR DESCRIPTION
**Symptom** (staging QA, "Test owner" team space): the Inbox never leaves its skeleton in a team with no agents. Reproduced against the staging gateway directly: `GET /agents` under the team's `x-houston-org` returns `[]`, and the gateway is healthy — the console 404s are stale cross-space per-agent fetches (the same requests 200 in the right space) and the `/v1/org/billing` 503 is staging's `billing not configured`, both benign here.

**Root cause**: `useAllConversations` is `enabled: agentPaths.length > 0`. With zero agents the sweep query is disabled, and a disabled query with no cached aggregate never leaves React Query's `pending` state. `InboxView` renders its skeleton on that raw flag, so a brand-new team space, and more importantly a **just-invited member** (the Inbox is the landing surface before any team resolves), sees an eternal skeleton instead of the empty state.

**Fix**: `inboxSweepPending(sweepPending, pathCount)` in `mentions-inbox-model.ts` — no paths = nothing to sweep = the empty answer is final. `useMentionInbox` reports pending only while a real sweep is in flight. Count-only consumers (rail badge, bell) unaffected.

Unit tests pin both directions; 3644 app tests green, Biome + tsgo clean.