### PR TITLE
fix(agents): agent colors survive sign-out via the agent_colors account pref (PRODUCT-1344)

### DIFF
--- a/packages/web/src/engine-adapter/client/context.ts
+++ b/packages/web/src/engine-adapter/client/context.ts
@@ -8,6 +8,7 @@ import type { ControlPlaneConfig } from "../control-plane";
 import {
   gatewayAuthFetch,
   liveToken,
+  resetAgentColorSync,
   runtimeClientFor,
   setupRuntimeClientFor,
 } from "../control-plane";
@@ -154,6 +155,10 @@ export class AdapterContext {
       this._cp.baseUrl = this.baseUrl;
       this._cp.token = opts.token;
     }
+    // The new bearer may belong to a DIFFERENT account (this client is
+    // repointed in place, never rebuilt): the next agent list must re-merge
+    // that account's `agent_colors` preference (PRODUCT-1344).
+    resetAgentColorSync();
     this.authFetch = gatewayAuthFetch(
       opts.token,
       () => this._cp?.activeOrgSlug,

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -60,6 +60,7 @@ export type {
 } from "../../../../ui/engine-client/src/types";
 
 export * from "./cp/agent-color";
+export * from "./cp/agent-color-sync";
 export * from "./cp/agent-teams";
 export * from "./cp/agents";
 export * from "./cp/api-keys";

--- a/packages/web/src/engine-adapter/cp/agent-color-sync.ts
+++ b/packages/web/src/engine-adapter/cp/agent-color-sync.ts
@@ -1,0 +1,148 @@
+import {
+  colorOverlay,
+  overwriteColorOverlay,
+  setOverlayWriteListener,
+} from "./agent-color";
+import type { ControlPlaneConfig } from "./fetch";
+import { getPreference, setPreference } from "./files-context";
+
+/**
+ * Durable home for agent colors: the `agent_colors` ACCOUNT preference
+ * (PRODUCT-1344). The localStorage overlay (`./agent-color`) is only the
+ * DEVICE copy, and sign-out purges every account-scoped `houston.*` key
+ * (PRODUCT-1235) — so a device-only color died with the session and every
+ * agent came back default-purple, with nothing server-side to restore from.
+ * Same shape as the overlay (agent id → color), stored as one JSON blob
+ * behind `/v1/preferences/:key`, which the local host, self-host, and the
+ * cloud gateway all serve (the PRODUCT-1282 `onboarding_completed` pattern).
+ *
+ * Flow: `listAgents` hydrates once per active space — account entries fill
+ * ids the device is missing (the post-sign-out restore), the device copy wins
+ * per id (it holds the freshest pick), and a device map the account lacks is
+ * healed UP so pre-fix colors become durable. Every later overlay write
+ * (pick/rename/delete) re-pushes the full map.
+ */
+export const AGENT_COLORS_PREF_KEY = "agent_colors";
+
+let syncCfg: ControlPlaneConfig | null = null;
+/** Spaces already hydrated this session — preferences are scoped to the
+ *  ACTIVE space (the gateway keys them by org), so each space visited gets
+ *  one read + heal, which is also what carries colors into a team space
+ *  after a move-to-organization. */
+let hydratedSpaces = new Set<string>();
+let pushChain: Promise<void> = Promise.resolve();
+let pushQueued = false;
+
+/** Account entries fill the gaps; the device's own picks win per id. */
+export function mergeColorOverlays(
+  account: Record<string, string>,
+  device: Record<string, string>,
+): Record<string, string> {
+  return { ...account, ...device };
+}
+
+/** Parse the stored pref defensively: absent/corrupt → empty, and only
+ *  string→string entries survive (the value is palette id or hex). */
+export function parseAccountColors(raw: string | null): Record<string, string> {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
+      return {};
+    const out: Record<string, string> = {};
+    for (const [id, color] of Object.entries(parsed)) {
+      if (typeof color === "string" && color.length > 0 && color.length <= 64)
+        out[id] = color;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function sameRecord(
+  a: Record<string, string>,
+  b: Record<string, string>,
+): boolean {
+  const aKeys = Object.keys(a);
+  return (
+    aKeys.length === Object.keys(b).length &&
+    aKeys.every((key) => a[key] === b[key])
+  );
+}
+
+/**
+ * Merge the account copy into the device overlay before the agent list is
+ * mapped. Never throws — an unreachable host must not take the agent list
+ * down with it; the space is simply not marked hydrated, so the next list
+ * retries. Runs once per (config, active space).
+ */
+export async function hydrateAgentColors(
+  cfg: ControlPlaneConfig,
+): Promise<void> {
+  if (syncCfg !== cfg) {
+    syncCfg = cfg;
+    hydratedSpaces = new Set();
+    setOverlayWriteListener(schedulePush);
+  }
+  const space = cfg.activeOrgSlug ?? "";
+  if (hydratedSpaces.has(space)) return;
+  let account: Record<string, string>;
+  try {
+    account = parseAccountColors(
+      await getPreference(cfg, AGENT_COLORS_PREF_KEY),
+    );
+  } catch (e) {
+    // Read-side degrade (the onboarding-completed precedent): the device
+    // overlay still renders, and hydration retries on the next agent list.
+    console.error("[agent-colors] account read failed; device copy shown", e);
+    return;
+  }
+  hydratedSpaces.add(space);
+  const device = colorOverlay();
+  const merged = mergeColorOverlays(account, device);
+  if (!sameRecord(merged, device)) overwriteColorOverlay(merged);
+  if (!sameRecord(merged, account)) schedulePush();
+}
+
+/** Serialize pushes so an earlier map can never land after a later one; a
+ *  write during an in-flight PUT queues exactly one follow-up that re-reads
+ *  the freshest overlay. */
+function schedulePush(): void {
+  const cfg = syncCfg;
+  if (!cfg || pushQueued) return;
+  pushQueued = true;
+  pushChain = pushChain.then(async () => {
+    pushQueued = false;
+    try {
+      await setPreference(
+        cfg,
+        AGENT_COLORS_PREF_KEY,
+        JSON.stringify(colorOverlay()),
+      );
+    } catch (e) {
+      // The device write already succeeded (the user sees their pick); the
+      // account copy self-heals on the next write or hydration, so this
+      // degrade is logged, not toasted — the PRODUCT-1282 account-pref
+      // precedent.
+      console.error("[agent-colors] account save failed; kept on-device", e);
+    }
+  });
+}
+
+/** Await every scheduled push (tests, and any caller that must not race). */
+export function flushAgentColorPushes(): Promise<void> {
+  return pushChain;
+}
+
+/**
+ * Forget which spaces were hydrated. Called from `setEndpoint`, which repoints
+ * the ONE long-lived client in place: after it the bearer may belong to a
+ * DIFFERENT account (sign-out purged the overlay, then someone else signed
+ * in), so the next agent list must re-merge THAT account's colors instead of
+ * trusting this session's earlier read. A same-account token rotation just
+ * re-runs one cheap, idempotent GET per space.
+ */
+export function resetAgentColorSync(): void {
+  hydratedSpaces = new Set();
+}

--- a/packages/web/src/engine-adapter/cp/agent-color.ts
+++ b/packages/web/src/engine-adapter/cp/agent-color.ts
@@ -1,6 +1,9 @@
-// Color is a client-side cosmetic the control plane intentionally does not store
-// (its model is id/name only). Keep a tiny local overlay so the UI's per-agent
-// color survives reloads without bloating the server model.
+// Color is a client-side cosmetic the control plane's agent model does not
+// store (its model is id/name only). This overlay is the DEVICE copy — the
+// synchronous source every render reads — while the durable copy is the
+// `agent_colors` ACCOUNT preference (`./agent-color-sync`, PRODUCT-1344):
+// sign-out purges every account-scoped localStorage key, so a device-only
+// color died with the session and every agent came back default-purple.
 const COLOR_KEY = "houston.web.cp.agentColors";
 export function colorOverlay(): Record<string, string> {
   try {
@@ -19,14 +22,32 @@ function writeOverlay(overlay: Record<string, string>): void {
     /* storage disabled — color just falls back to the default */
   }
 }
+
+/** Fires after every USER-driven overlay write (set/move/clear), so the sync
+ *  layer can mirror the new map up to the account preference. Hydration writes
+ *  go through {@link overwriteColorOverlay} instead, which stays silent — a
+ *  server read must never echo itself straight back as a server write. */
+let onOverlayWrite: (() => void) | null = null;
+export function setOverlayWriteListener(listener: (() => void) | null): void {
+  onOverlayWrite = listener;
+}
+
+/** Replace the whole overlay with the account-merged map (hydration only). */
+export function overwriteColorOverlay(next: Record<string, string>): void {
+  writeOverlay(next);
+}
+
 export function setColor(agentId: string, color: string): void {
   writeOverlay({ ...colorOverlay(), [agentId]: color });
+  onOverlayWrite?.();
 }
 export function moveColor(fromId: string, toId: string): void {
   writeOverlay(renameColorOverlay(colorOverlay(), fromId, toId));
+  onOverlayWrite?.();
 }
 export function clearColor(agentId: string): void {
   writeOverlay(removeColorOverlay(colorOverlay(), agentId));
+  onOverlayWrite?.();
 }
 
 /**

--- a/packages/web/src/engine-adapter/cp/agents.ts
+++ b/packages/web/src/engine-adapter/cp/agents.ts
@@ -7,6 +7,7 @@ import type {
 import { HoustonEngineError } from "../client/errors";
 import { DEFAULT_AGENT_COLOR, DEFAULT_AGENT_CONFIG_ID } from "../synthetic";
 import { colorOverlay, moveColor, setColor } from "./agent-color";
+import { hydrateAgentColors } from "./agent-color-sync";
 import { type ControlPlaneConfig, cpFetch } from "./fetch";
 
 /** What the control plane returns for an agent (id + name + workspace + ts). */
@@ -59,7 +60,14 @@ export function toUiAgent(a: CpAgent, colors = colorOverlay()): Agent {
 }
 
 export async function listAgents(cfg: ControlPlaneConfig): Promise<Agent[]> {
-  const res = await cpFetch(cfg, "/agents");
+  // Hydrate the color overlay from the `agent_colors` account preference
+  // alongside the list fetch (PRODUCT-1344): after a sign-out purge the
+  // device overlay is empty, and mapping before the account copy lands would
+  // paint every agent default-purple. hydrateAgentColors never rejects.
+  const [res] = await Promise.all([
+    cpFetch(cfg, "/agents"),
+    hydrateAgentColors(cfg),
+  ]);
   const colors = colorOverlay();
   return ((await res.json()) as CpAgent[]).map((a) => toUiAgent(a, colors));
 }

--- a/packages/web/tests/agent-color-account-sync.test.ts
+++ b/packages/web/tests/agent-color-account-sync.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import {
+  clearColor,
+  flushAgentColorPushes,
+  hydrateAgentColors,
+  listAgents,
+  mergeColorOverlays,
+  parseAccountColors,
+  setColor,
+  setOverlayWriteListener,
+} from "../src/engine-adapter/control-plane";
+import { DEFAULT_AGENT_COLOR } from "../src/engine-adapter/synthetic";
+
+/**
+ * PRODUCT-1344: an agent's color must survive sign-out and follow the account.
+ * The device overlay (`houston.web.cp.agentColors`) is account-scoped
+ * localStorage, so the sign-out purge deleted it — and the gateway stores no
+ * agent color — leaving every agent default-purple with nothing to restore
+ * from (all-purple after the team migration's multi-account testing). These
+ * tests pin the durable copy: the `agent_colors` account preference, hydrated
+ * into the overlay on the agent list and re-pushed on every color write.
+ */
+
+const originalFetch = globalThis.fetch;
+
+let store: Map<string, string>;
+let calls: { url: string; method: string; body: string | null }[];
+
+beforeEach(() => {
+  store = new Map();
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
+  calls = [];
+});
+
+afterEach(async () => {
+  await flushAgentColorPushes();
+  setOverlayWriteListener(null);
+  globalThis.fetch = originalFetch;
+  vi.clearAllMocks();
+});
+
+function stubFetch(respond: (url: string, method: string) => Response) {
+  globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    calls.push({
+      url,
+      method,
+      body: typeof init?.body === "string" ? init.body : null,
+    });
+    return respond(url, method);
+  }) as unknown as typeof fetch;
+}
+
+function json(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const wireAgents = [
+  { id: "aaaa111122223333", workspaceId: "Houston", name: "Bob", createdAt: 0 },
+  { id: "bbbb111122223333", workspaceId: "Houston", name: "Ada", createdAt: 0 },
+];
+
+/** Each test builds a FRESH config object: hydration is keyed on config
+ *  identity + active space, so a new object re-hydrates like a new session. */
+const freshCfg = () => ({ baseUrl: "http://cp", token: "t" });
+
+const overlay = (): Record<string, string> =>
+  JSON.parse(store.get("houston.web.cp.agentColors") ?? "{}");
+
+const prefUrl = "http://cp/v1/preferences/agent_colors";
+
+// ── pure helpers ────────────────────────────────────────────────────────────
+
+test("merge: account fills missing ids, the device pick wins per id", () => {
+  expect(
+    mergeColorOverlays({ a: "forest", b: "teal" }, { b: "crimson", c: "navy" }),
+  ).toEqual({ a: "forest", b: "crimson", c: "navy" });
+});
+
+test("parse: absent, corrupt, and non-record values all read as empty", () => {
+  expect(parseAccountColors(null)).toEqual({});
+  expect(parseAccountColors("not json")).toEqual({});
+  expect(parseAccountColors('["forest"]')).toEqual({});
+  expect(parseAccountColors('{"a":42,"b":"forest","c":""}')).toEqual({
+    b: "forest",
+  });
+});
+
+// ── hydration ───────────────────────────────────────────────────────────────
+
+test("post-sign-out restore: the account pref repaints an empty device overlay", async () => {
+  stubFetch((url) =>
+    url === prefUrl
+      ? json(200, { value: '{"aaaa111122223333":"forest"}' })
+      : json(200, wireAgents),
+  );
+  const agents = await listAgents(freshCfg());
+  expect(agents.find((a) => a.name === "Bob")?.color).toBe("forest");
+  expect(agents.find((a) => a.name === "Ada")?.color).toBe(DEFAULT_AGENT_COLOR);
+  expect(overlay()).toEqual({ aaaa111122223333: "forest" });
+});
+
+test("device pick outranks a stale account copy for the same agent", async () => {
+  store.set(
+    "houston.web.cp.agentColors",
+    '{"aaaa111122223333":"crimson"}', // picked on this device moments ago
+  );
+  stubFetch((url) =>
+    url === prefUrl
+      ? json(200, { value: '{"aaaa111122223333":"forest"}' })
+      : json(200, wireAgents),
+  );
+  const agents = await listAgents(freshCfg());
+  expect(agents.find((a) => a.name === "Bob")?.color).toBe("crimson");
+});
+
+test("pre-fix device colors are healed UP into the account pref", async () => {
+  store.set("houston.web.cp.agentColors", '{"aaaa111122223333":"navy"}');
+  stubFetch((url) =>
+    url === prefUrl && calls.some((c) => c.method === "PUT") === false
+      ? json(200, { value: null })
+      : json(200, url === prefUrl ? {} : wireAgents),
+  );
+  await listAgents(freshCfg());
+  await flushAgentColorPushes();
+  const put = calls.find((c) => c.method === "PUT" && c.url === prefUrl);
+  expect(put).toBeDefined();
+  expect(JSON.parse(JSON.parse(put?.body ?? "{}").value)).toEqual({
+    aaaa111122223333: "navy",
+  });
+});
+
+test("hydration runs once per space; an in-sync map pushes nothing", async () => {
+  store.set("houston.web.cp.agentColors", '{"aaaa111122223333":"forest"}');
+  stubFetch((url) =>
+    url === prefUrl
+      ? json(200, { value: '{"aaaa111122223333":"forest"}' })
+      : json(200, wireAgents),
+  );
+  const cfg = freshCfg();
+  await listAgents(cfg);
+  await listAgents(cfg);
+  await flushAgentColorPushes();
+  expect(
+    calls.filter((c) => c.url === prefUrl && c.method === "GET").length,
+  ).toBe(1);
+  expect(calls.some((c) => c.method === "PUT")).toBe(false);
+});
+
+test("an unreachable pref read degrades to the device copy and retries next list", async () => {
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  store.set("houston.web.cp.agentColors", '{"aaaa111122223333":"teal"}');
+  let prefReads = 0;
+  // 500, not 503: transient statuses are retried INSIDE one cpFetch (the
+  // gateway-roll patience), which would hide the degrade path under test.
+  // (The successful second read also heals the device map UP with a PUT to
+  // the same URL — count reads only.)
+  stubFetch((url, method) => {
+    if (url !== prefUrl) return json(200, wireAgents);
+    if (method === "PUT") return json(200, {});
+    prefReads += 1;
+    return prefReads === 1
+      ? json(500, { error: "boom" })
+      : json(200, { value: null });
+  });
+  const cfg = freshCfg();
+  const agents = await listAgents(cfg);
+  expect(agents.find((a) => a.name === "Bob")?.color).toBe("teal");
+  await listAgents(cfg); // retried — the failed space was never marked hydrated
+  expect(prefReads).toBe(2);
+  errorSpy.mockRestore();
+});
+
+// ── write-through ───────────────────────────────────────────────────────────
+
+test("a color pick after hydration re-pushes the full map to the account", async () => {
+  stubFetch((url) =>
+    url === prefUrl ? json(200, { value: null }) : json(200, wireAgents),
+  );
+  await listAgents(freshCfg());
+  setColor("aaaa111122223333", "golden");
+  await flushAgentColorPushes();
+  const put = calls
+    .filter((c) => c.method === "PUT" && c.url === prefUrl)
+    .at(-1);
+  expect(JSON.parse(JSON.parse(put?.body ?? "{}").value)).toEqual({
+    aaaa111122223333: "golden",
+  });
+});
+
+test("a delete clears the agent's entry from the account copy too", async () => {
+  store.set("houston.web.cp.agentColors", '{"aaaa111122223333":"forest"}');
+  stubFetch((url) =>
+    url === prefUrl
+      ? json(200, { value: '{"aaaa111122223333":"forest"}' })
+      : json(200, wireAgents),
+  );
+  await listAgents(freshCfg());
+  clearColor("aaaa111122223333");
+  await flushAgentColorPushes();
+  const put = calls
+    .filter((c) => c.method === "PUT" && c.url === prefUrl)
+    .at(-1);
+  expect(JSON.parse(JSON.parse(put?.body ?? "{}").value)).toEqual({});
+});
+
+test("a failed account save keeps the device pick and stays quiet", async () => {
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  stubFetch((url, method) => {
+    if (url !== prefUrl) return json(200, wireAgents);
+    return method === "PUT"
+      ? json(500, { error: "boom" })
+      : json(200, { value: null });
+  });
+  await listAgents(freshCfg());
+  setColor("aaaa111122223333", "umber");
+  await flushAgentColorPushes();
+  expect(overlay()).toEqual({ aaaa111122223333: "umber" });
+  expect(errorSpy).toHaveBeenCalled();
+  errorSpy.mockRestore();
+});
+
+test("hydrate never repaints when a fresher device write landed mid-read", async () => {
+  // The GET resolves AFTER the user's pick: merged = account ∪ device with the
+  // device winning, so the pick must survive the hydration write-back.
+  let releasePref: (r: Response) => void = () => {};
+  const gate = new Promise<Response>((resolve) => {
+    releasePref = resolve;
+  });
+  globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({ url, method: init?.method ?? "GET", body: null });
+    if (url === prefUrl && (init?.method ?? "GET") === "GET") return gate;
+    return json(200, wireAgents);
+  }) as unknown as typeof fetch;
+  const pending = hydrateAgentColors(freshCfg());
+  setColor("aaaa111122223333", "rose");
+  releasePref(json(200, { value: '{"aaaa111122223333":"charcoal"}' }));
+  await pending;
+  expect(overlay()).toEqual({ aaaa111122223333: "rose" });
+});

--- a/packages/web/tests/gateway-reauth.test.ts
+++ b/packages/web/tests/gateway-reauth.test.ts
@@ -121,13 +121,25 @@ test("concurrent 401s share one refresh (single-flight)", async () => {
 test("reads retry through a transient gateway-roll status", async () => {
   vi.useFakeTimers();
   setEngineWindow({ token: "tok" });
-  const calls = stubFetch(json(503), json(200, []));
+  // listAgents also hydrates the `agent_colors` account preference
+  // (PRODUCT-1344) in parallel; answer that side channel by URL so the
+  // retry-under-test keeps a clean two-response queue for /agents itself.
+  const agentResponses = [json(503), json(200, [])];
+  const agentCalls: string[] = [];
+  globalThis.fetch = vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.includes("/v1/preferences/")) return json(200, { value: null });
+    agentCalls.push(url);
+    const next = agentResponses.shift();
+    if (!next) throw new Error("stubFetch: no responses left");
+    return next;
+  }) as unknown as typeof fetch;
 
   const pending = listAgents(CFG);
   await vi.advanceTimersByTimeAsync(600);
 
   expect(await pending).toEqual([]);
-  expect(calls).toHaveLength(2);
+  expect(agentCalls).toHaveLength(2);
 });
 
 test("writes never blind-retry a transient status", async () => {

--- a/packages/web/tests/set-endpoint.test.ts
+++ b/packages/web/tests/set-endpoint.test.ts
@@ -41,15 +41,28 @@ test("setEndpoint repoints gateway calls to the new base URL and bearer", async 
     token: "token-1",
     controlPlane: true,
   });
+  // listAgents also reads the `agent_colors` account preference in parallel
+  // (PRODUCT-1344); pick out the /agents requests so the repointing assertion
+  // stays about the endpoint, not about that side channel.
+  const agentCalls = () =>
+    cap.urls
+      .map((url, i) => ({ url, bearer: cap.bearers[i] }))
+      .filter((c) => c.url.endsWith("/agents"));
   await client.listAgents("ws");
-  expect(cap.urls[0]).toBe(`${BASE_A}/agents`);
-  expect(cap.bearers[0]).toBe("Bearer token-1");
+  expect(agentCalls()[0].url).toBe(`${BASE_A}/agents`);
+  expect(agentCalls()[0].bearer).toBe("Bearer token-1");
 
   // The hosted token-refresh path: same shape the shell applies, twice.
   client.setEndpoint({ baseUrl: BASE_B, token: "token-2" });
   await client.listAgents("ws");
-  expect(cap.urls[1]).toBe(`${BASE_B}/agents`);
-  expect(cap.bearers[1]).toBe("Bearer token-2");
+  expect(agentCalls()[1].url).toBe(`${BASE_B}/agents`);
+  expect(agentCalls()[1].bearer).toBe("Bearer token-2");
+  // The repoint also re-keys the color hydration: its pref reads must follow
+  // the endpoint, never keep hitting the old gateway.
+  const prefBases = cap.urls
+    .filter((u) => u.includes("/v1/preferences/"))
+    .map((u) => new URL(u).origin);
+  expect(prefBases).toEqual([BASE_A, BASE_B]);
 });
 
 test("setEndpoint rebuilds the direct runtime client on the new port (local sidecar restart)", async () => {


### PR DESCRIPTION
Fixes PRODUCT-1344 — "Agent color reset when migrating to team": after the team migration every agent rendered the default purple.

## Root cause

An agent's color existed **only** in this device's localStorage overlay (`houston.web.cp.agentColors`, keyed by agent id). The hosted gateway's agent model deliberately stores no color, and the wire fallback (`a.color` from legacy `.houston/agent.json`) is served by local-profile hosts only. Meanwhile the sign-out purge (PRODUCT-1235) deletes every account-scoped `houston.*` key — **including the color overlay, which had no server-side copy to restore from**.

The org move itself preserves the agent slug end-to-end (verified in the gateway's move path), so the ids never changed — the colors were destroyed by the sign-out that multi-account team testing (invite a second owner, sign in as them, sign back) naturally involves. Forensics on the reporting device confirmed it: the overlay key is entirely absent from the app's WebView storage while every other account-scoped key was restored from its server-side copy, and two different account uids appear in that storage.

This is the same bug class PRODUCT-1282 fixed for `onboarding_completed`: durable per-account state must live server-side, because sign-out wipes the device mirror.

## Fix

Give colors a durable home: the **`agent_colors` account preference** behind `/v1/preferences/:key` — served identically by the local host, self-host, and the cloud gateway (whose preference keys are regex-gated, so **no server change is needed**). The localStorage overlay becomes the device mirror:

- `listAgents` hydrates the overlay from the account pref **in parallel** with the list fetch (no purple first paint, no extra latency): account entries fill ids the device is missing (the post-sign-out restore), the device's own pick wins per id, and a device-only map is healed **up** so pre-fix colors become durable.
- Every overlay write — color pick, rename id-carry, delete — re-pushes the full map (serialized, coalesced; a failed push is logged and self-heals on the next write/hydration, per the PRODUCT-1282 precedent).
- `setEndpoint` resets hydration: the client is repointed in place and the new bearer may belong to a different account.
- Hydration is per active space (preferences are org-scoped), which also carries colors into a team space after a move-to-organization.
- An unreachable pref read degrades to the device copy and retries on the next list — it can never take the agent list down.

## Verification

**Repro (before the fix)** — desktop or web against the cloud:
1. In the personal space, give agents distinct colors (create-time picker or "Change color & name").
2. Sign out, then sign back in as the same user (or move a team to an organization and test the second-owner invite by switching accounts, as in the original report).
3. Every agent renders the default purple (`#7a5cff`); the colors are unrecoverable.

**After the fix:**
1. Same setup: pick colors, then sign out and back in.
2. On the first agent list the colors are restored from the `agent_colors` account preference (visible in devtools: `GET /v1/preferences/agent_colors`, and `houston.web.cp.agentColors` repopulated).
3. Colors now also follow the account to a fresh install / second device.

**Tests:** `packages/web/tests/agent-color-account-sync.test.ts` pins restore-after-purge, device-wins merge, upward heal, once-per-space hydration, degrade-and-retry on an unreachable host, write-through push on pick/delete, and the fresher-device-write-during-hydration race. Full `houston-web` vitest suite (409), `pnpm check` (Biome), `houston-web` typecheck + shim parity, and `pnpm check:boundaries` all pass.