### PR TITLE
fix(web): return users after integration OAuth (PRODUCT-1347)

### DIFF
--- a/packages/web/connected/connected.css
+++ b/packages/web/connected/connected.css
@@ -1,0 +1,1 @@
+@import "@houston-ai/core/src/globals.css";

--- a/packages/web/connected/index.html
+++ b/packages/web/connected/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex,nofollow" />
+    <title>Connection complete | Houston</title>
+    <style>
+      html {
+        color-scheme: light dark;
+        background: Canvas;
+        color: CanvasText;
+      }
+
+      body {
+        margin: 0;
+      }
+    </style>
+    <script>
+      try {
+        if (localStorage.getItem("houston.theme.cache") === "dark") {
+          document.documentElement.setAttribute("data-theme", "dark");
+        }
+      } catch (e) {
+        /* Storage unavailable: keep the browser's honest system theme. */
+      }
+    </script>
+    <link rel="stylesheet" href="./connected.css" />
+  </head>
+  <body
+    class="box-border grid min-h-screen place-items-center bg-background p-6 text-ink"
+  >
+    <main
+      class="grid w-full max-w-md justify-items-center gap-4 text-center"
+      aria-labelledby="callback-title"
+    >
+      <div
+        class="grid size-12 place-items-center rounded-full bg-success text-success-text"
+        aria-hidden="true"
+      >
+        <svg
+          class="size-5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M20 6 9 17l-5-5"></path>
+        </svg>
+      </div>
+      <h1 id="callback-title" class="m-0 text-balance text-2xl font-normal">
+        Connection complete
+      </h1>
+      <p id="callback-detail" class="m-0 text-base leading-relaxed text-ink-muted">
+        You can close this tab and return to Houston.
+      </p>
+      <button
+        id="callback-close"
+        class="min-h-10 cursor-pointer rounded-full border-0 bg-action px-5 text-sm font-medium text-action-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
+        type="button"
+      >
+        Close tab
+      </button>
+    </main>
+    <script>
+      const copies = {
+        en: {
+          title: "Connection complete",
+          detail: "You can close this tab and return to Houston.",
+          close: "Close tab",
+        },
+        es: {
+          title: "Conexión completada",
+          detail: "Puedes cerrar esta pestaña y volver a Houston.",
+          close: "Cerrar pestaña",
+        },
+        pt: {
+          title: "Conexão concluída",
+          detail: "Você pode fechar esta aba e voltar ao Houston.",
+          close: "Fechar aba",
+        },
+      };
+      const language = navigator.language.toLowerCase().split("-")[0];
+      const copy = copies[language] || copies.en;
+      document.documentElement.lang = language in copies ? language : "en";
+      document.title = `${copy.title} | Houston`;
+      document.getElementById("callback-title").textContent = copy.title;
+      document.getElementById("callback-detail").textContent = copy.detail;
+      document.getElementById("callback-close").textContent = copy.close;
+
+      const closeTab = () => window.close();
+      document.getElementById("callback-close").addEventListener("click", closeTab);
+      requestAnimationFrame(() => setTimeout(closeTab, 500));
+    </script>
+  </body>
+</html>

--- a/packages/web/e2e/integration-callback.spec.ts
+++ b/packages/web/e2e/integration-callback.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+
+test("the integration callback paints only the localized completion page and closes its tab", async ({
+  context,
+  page,
+}) => {
+  await context.addInitScript(() => {
+    Object.defineProperty(navigator, "language", { get: () => "es-CO" });
+    window.close = () => {
+      document.documentElement.dataset.closeRequested = "true";
+    };
+  });
+
+  await page.goto("/connected/");
+
+  await expect(
+    page.getByRole("heading", { name: "Conexión completada" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Puedes cerrar esta pestaña y volver a Houston."),
+  ).toBeVisible();
+  await expect(page.locator("#root")).toHaveCount(0);
+  await expect(page.locator("html")).toHaveAttribute(
+    "data-close-requested",
+    "true",
+  );
+});

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -147,6 +147,12 @@ export default defineConfig(({ mode }) => {
       // users can't reconstruct source via DevTools (matches app/vite.config.ts).
       // A future web release pipeline can upload these maps to Sentry.
       sourcemap: "hidden",
+      rollupOptions: {
+        input: {
+          app: path.resolve(__dirname, "index.html"),
+          connected: path.resolve(__dirname, "connected/index.html"),
+        },
+      },
     },
   };
 });


### PR DESCRIPTION
## What this scratches for you

A HighLevel connection can become ACTIVE in Composio and Houston while the user remains stranded on the provider tab with no confirmation. the user experienced exactly this: the connection succeeded, but the successful installation looked like nothing happened.


## Summary

- add a tiny standalone `/connected/` document for Composio's post-auth redirect
- automatically close Houston's spawned OAuth tab, with an explicit return-to-Houston fallback
- localize the completion copy for English, Spanish, and Brazilian Portuguese
- build the callback document as a separate Vite entry and cover it with Playwright

## Surface impact

Change type:

- [ ] Behavior (shared SDK view-model — `packages/sdk`)
- [x] Look (standalone web completion surface using existing design tokens)
- [ ] Structure (a shared component added/changed)
- [ ] n-a (no user-facing surface change)

Surfaces updated:

- [x] Web / desktop
- [ ] iOS
- [ ] Android

No shared component or SDK contract changed, so inventory/parity manifests are unaffected.

## Checklist

- [x] I read the diff myself before opening this PR (AI-assisted is fine, AI-unreviewed is not)
- [x] I have no other open PRs on this repo
- [x] `pnpm typecheck` passes
- [x] Rust was not touched
- [x] No external frameworks/methodology imported into `knowledge-base/` or `docs/`

## Verification

- `pnpm check`
- `pnpm typecheck` (pre-commit hook)
- `pnpm --filter houston-web build`
- focused callback Playwright test: 1 passed
- `pnpm --filter houston-web test:visual`: 8 passed
