### PR TITLE
Claude sessions follow the rotated token: per-turn re-read, digest rebuild, revoked eviction (PRODUCT-1355)

### DIFF
--- a/packages/runtime/src/backends/claude/backend.test.ts
+++ b/packages/runtime/src/backends/claude/backend.test.ts
@@ -13,14 +13,20 @@ import {
 } from "./backend";
 import { claudeLoginConfigDir } from "./paths";
 
-// Capture the `baseOptions` the backend hands a session WITHOUT running the SDK:
-// the whole point of the scope guard is that a refused turn never builds an env
-// at all, so "was a session constructed, and with which env" is the assertion.
-const { built } = vi.hoisted(() => ({ built: [] as Options[] }));
+// Capture the deps the backend hands a session WITHOUT running the SDK: the
+// whole point of the scope guard is that a refused turn never builds an env at
+// all, so "was a session constructed, and with which env" is the assertion —
+// plus, since PRODUCT-1355, "does its refreshAuth re-read the CURRENT token".
+type CapturedDeps = {
+  baseOptions: Options;
+  refreshAuth: () => { env: Record<string, string>; accessDigest?: string };
+  usedAccessDigest?: string;
+};
+const { built } = vi.hoisted(() => ({ built: [] as CapturedDeps[] }));
 vi.mock("./session", () => ({
   ClaudeSession: class {
-    constructor(deps: { baseOptions: Options }) {
-      built.push(deps.baseOptions);
+    constructor(deps: CapturedDeps) {
+      built.push(deps);
     }
   },
 }));
@@ -218,7 +224,9 @@ test("a personal scope with its OWN token proceeds (env token outranks the dir)"
     backend.createSession({ conversationId: "c1", model: MODEL }),
   );
   expect(built).toHaveLength(1);
-  expect(built[0]?.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-x");
+  expect(built[0]?.baseOptions.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe(
+    "sk-ant-oat01-x",
+  );
 });
 
 test("the team scope still pins the shared login dir with no token (unchanged)", async () => {
@@ -227,8 +235,45 @@ test("the team scope still pins the shared login dir with no token (unchanged)",
   const backend = createClaudeBackend(backendDeps(() => undefined));
   await backend.createSession({ conversationId: "c1", model: MODEL });
   expect(built).toHaveLength(1);
-  expect(built[0]?.env?.CLAUDE_CONFIG_DIR).toBe(claudeLoginConfigDir());
-  expect(built[0]?.env?.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+  expect(built[0]?.baseOptions.env?.CLAUDE_CONFIG_DIR).toBe(
+    claudeLoginConfigDir(),
+  );
+  expect(built[0]?.baseOptions.env?.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+});
+
+test("the session's refreshAuth re-reads the CURRENT token — a rotation between turns reaches the next spawn (PRODUCT-1355)", async () => {
+  // The live incident: the serve path updates auth.json every turn, but the
+  // session's env was baked at build. refreshAuth must read THROUGH to the
+  // store on every call, digest included.
+  let current: ClaudeToken = {
+    kind: "oauth-token",
+    value: "sk-ant-oat01-old",
+    accessDigest: "digest-old",
+  };
+  const backend = createClaudeBackend(backendDeps(() => current));
+  await backend.createSession({ conversationId: "c1", model: MODEL });
+  expect(built[0]?.usedAccessDigest).toBe("digest-old");
+
+  current = {
+    kind: "oauth-token",
+    value: "sk-ant-oat01-new",
+    accessDigest: "digest-new",
+  };
+  const fresh = built[0]?.refreshAuth();
+  expect(fresh?.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-new");
+  expect(fresh?.accessDigest).toBe("digest-new");
+});
+
+test("refreshAuth re-asserts the personal-scope guard: a token that vanished mid-conversation refuses the turn, never falls through to the team dir", async () => {
+  let current: ClaudeToken | undefined = oauth;
+  const backend = createClaudeBackend(backendDeps(() => current));
+  await runWithActingContext(alice, () =>
+    backend.createSession({ conversationId: "c1", model: MODEL }),
+  );
+  current = undefined;
+  expect(() =>
+    runWithActingContext(alice, () => built[0]?.refreshAuth()),
+  ).toThrow(/^No provider connected\./);
 });
 
 test("browser-login path: shared config dir, NO token env (SDK reads the cached cred)", () => {

--- a/packages/runtime/src/backends/claude/backend.ts
+++ b/packages/runtime/src/backends/claude/backend.ts
@@ -24,10 +24,10 @@ import { buildToolPolicy, makeCanUseTool } from "./tool-policy";
  * A resolved Anthropic credential: an OAuth token or a pasted API key.
  * `accessDigest` is set ONLY when the value came from an OAUTH-typed store
  * entry's access token (read-token.ts): it is what a revoked-token report
- * names, captured at spawn preparation because the SDK subprocess env is built
- * once per session — re-reading auth.json at failure time would digest
- * whatever a re-serve stored since, not the token the failed turn ran on
- * (PRODUCT-1319).
+ * names, captured at spawn preparation — the env is rebuilt from a fresh read
+ * at every prompt (PRODUCT-1355), so the digest travels WITH that read; still
+ * never re-digested at failure time, which would name whatever a re-serve
+ * stored since, not the token the failed turn ran on (PRODUCT-1319).
  */
 export type ClaudeToken =
   | { kind: "oauth-token"; value: string; accessDigest?: string }
@@ -135,16 +135,35 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
       // dev/tests): the SDK resolves its own native binary. Only set inside the
       // Bun-compiled desktop sidecar, where require.resolve can't reach it.
       const pathToClaudeCodeExecutable = resolveClaudeExecutable();
+      // The subprocess env, rebuilt from a FRESH credential read on every call.
+      // The session invokes this at the start of each prompt (PRODUCT-1355):
+      // the SDK spawns one subprocess per `query()`, so per-turn env is the
+      // seam that lets a session follow the gateway's token rotation instead of
+      // 401ing forever on the token it was built with. Re-asserting the scope
+      // guard keeps a personal turn whose token vanished a typed refusal, never
+      // a silent fall-through onto the pod-shared (team) credential.
+      const refreshAuth = () => {
+        const fresh = deps.readToken();
+        assertAnthropicScopeCredential(fresh);
+        return {
+          env: buildClaudeEnv(
+            claudeLoginConfigDir(),
+            fresh,
+            // Personal scope: the CLI's credential store moves off the shared
+            // dir, so a mid-turn 401 cannot recover onto the team credential.
+            // Team scope: undefined, i.e. unchanged (see `./scope-guard`).
+            anthropicCredentialStorageDir(deps.dataDir),
+          ),
+          accessDigest: fresh?.accessDigest,
+        };
+      };
+      // One coherent build-time read for the env AND the digest (the top-of-
+      // function `token` read predates the SDK import await, so it is not
+      // reused here). Every prompt overrides both with its own fresh read.
+      const initialAuth = refreshAuth();
       const baseOptions: Options = {
         cwd: deps.workspaceDir,
-        env: buildClaudeEnv(
-          claudeLoginConfigDir(),
-          token,
-          // Personal scope: the CLI's credential store moves off the shared dir,
-          // so a mid-turn 401 cannot recover onto the team credential. Team
-          // scope: undefined, i.e. unchanged (see `./scope-guard`).
-          anthropicCredentialStorageDir(deps.dataDir),
-        ),
+        env: initialAuth.env,
         ...(pathToClaudeCodeExecutable ? { pathToClaudeCodeExecutable } : {}),
         settingSources: [],
         tools: policy.tools,
@@ -186,9 +205,11 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
         sessionsStore,
         model: toSdkModel(opts.model.id),
         thinkingLevel: opts.thinkingLevel,
+        refreshAuth,
         // WHICH token the subprocess env carries, for the revoked-token
-        // report — every turn on this session runs on it (PRODUCT-1319).
-        usedAccessDigest: token?.accessDigest,
+        // report (PRODUCT-1319) — updated by refreshAuth on every prompt so it
+        // always names the token the current turn runs on (PRODUCT-1355).
+        usedAccessDigest: initialAuth.accessDigest,
       });
     },
   };

--- a/packages/runtime/src/backends/claude/custom-tools.test.ts
+++ b/packages/runtime/src/backends/claude/custom-tools.test.ts
@@ -518,6 +518,7 @@ test("an ask_user call dispatched during a Claude-session turn lands in the turn
     baseOptions: {},
     sessionsStore: fakeStore(),
     model: "claude-sonnet-4-6",
+    refreshAuth: () => ({ env: {} }),
   });
 
   const holder = newInteractionHolder();

--- a/packages/runtime/src/backends/claude/live-mode.test.ts
+++ b/packages/runtime/src/backends/claude/live-mode.test.ts
@@ -127,6 +127,7 @@ test("a mid-turn flip reaches canUseTool dispatched off a Claude-session turn", 
     baseOptions: {},
     sessionsStore: fakeStore(),
     model: "claude-sonnet-4-6",
+    refreshAuth: () => ({ env: {} }),
   });
   await runWithTurnMode(ref, () => session.prompt("hi"));
 

--- a/packages/runtime/src/backends/claude/session.test.ts
+++ b/packages/runtime/src/backends/claude/session.test.ts
@@ -99,6 +99,7 @@ function make(deps: {
   query: ClaudeQuery;
   store?: SessionsStore;
   model?: string;
+  refreshAuth?: () => { env: Record<string, string>; accessDigest?: string };
 }): ClaudeSession {
   return new ClaudeSession({
     query: deps.query,
@@ -106,6 +107,7 @@ function make(deps: {
     baseOptions: {} as Options,
     sessionsStore: deps.store ?? fakeStore(),
     model: deps.model ?? "claude-sonnet-4-6",
+    refreshAuth: deps.refreshAuth ?? (() => ({ env: {} })),
   });
 }
 
@@ -331,6 +333,65 @@ test("the captured session_id is persisted after the turn", async () => {
   });
   await session.prompt("go");
   expect(store.setCalls).toContainEqual(["c1", "sess-99"]);
+});
+
+test("every prompt spawns with the env refreshAuth returns AT THAT PROMPT — a rotated token is adopted, never the build-time env (PRODUCT-1355)", async () => {
+  // The live incident: the gateway rotates the family mid-conversation, so the
+  // token the session was built with is invalid on every later turn. Each
+  // query() spawns its own subprocess, so the env must be re-read per prompt.
+  let current = { token: "sk-ant-oat01-first", digest: "digest-first" };
+  const optionsSeen: Options[] = [];
+  const session = make({
+    query: capturingQuery((o) => {
+      optionsSeen.push(o);
+    }),
+    refreshAuth: () => ({
+      env: { CLAUDE_CODE_OAUTH_TOKEN: current.token },
+      accessDigest: current.digest,
+    }),
+  });
+
+  await session.prompt("one");
+  current = { token: "sk-ant-oat01-rotated", digest: "digest-rotated" };
+  await session.prompt("two");
+
+  expect(optionsSeen[0]?.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe(
+    "sk-ant-oat01-first",
+  );
+  expect(optionsSeen[1]?.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe(
+    "sk-ant-oat01-rotated",
+  );
+  // The digest follows the env, so a revoked-token report (and the cache's
+  // rotation check) names the token the CURRENT turn actually ran on.
+  expect(session.getUsedAccessDigest()).toBe("digest-rotated");
+});
+
+test("the retry-fresh rerun reuses the SAME prompt's auth (one read per prompt, not per attempt)", async () => {
+  const store = fakeStore("sess-gone");
+  let reads = 0;
+  const optionsSeen: Options[] = [];
+  let call = 0;
+  const query: ClaudeQuery = (params) => {
+    optionsSeen.push(params.options);
+    call++;
+    if (call === 1)
+      return throwingQuery(
+        new Error("No conversation found with session ID: sess-gone"),
+      )(params);
+    return arrayQuery([usageMsg("sess-new")])(params);
+  };
+  const session = make({
+    query,
+    store,
+    refreshAuth: () => {
+      reads++;
+      return { env: { CLAUDE_CODE_OAUTH_TOKEN: "tok" }, accessDigest: "d" };
+    },
+  });
+  await session.prompt("go");
+  expect(reads).toBe(1);
+  expect(optionsSeen).toHaveLength(2);
+  expect(optionsSeen[1]?.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("tok");
 });
 
 test("getContextUsage is undefined before a turn, then reflects the last usage", async () => {

--- a/packages/runtime/src/backends/claude/session.ts
+++ b/packages/runtime/src/backends/claude/session.ts
@@ -17,21 +17,44 @@ export type ClaudeQuery = (params: {
   options: Options;
 }) => AsyncIterable<SDKMessage>;
 
+/**
+ * One turn's credential material: the full subprocess env carrying the CURRENT
+ * stored token, and that token's access digest (undefined for an api_key or a
+ * config-dir credential). Re-read per prompt — see `ClaudeSessionDeps.refreshAuth`.
+ */
+export interface TurnAuth {
+  env: NonNullable<Options["env"]>;
+  accessDigest?: string;
+}
+
 /** Everything a `ClaudeSession` needs; assembled by the backend factory. */
 export interface ClaudeSessionDeps {
   query: ClaudeQuery;
   conversationId: string;
-  /** Static per-session options (cwd, env, tools, canUseTool, systemPrompt, …). */
+  /** Static per-session options (cwd, tools, canUseTool, systemPrompt, …). */
   baseOptions: Options;
   sessionsStore: SessionsStore;
   /** Initial SDK model string. */
   model: string;
   thinkingLevel?: ThinkingLevel;
   /**
-   * Digest of the OAuth access token in the subprocess env (the token every
-   * turn on this session runs on) — what a revoked-token report names.
-   * Undefined when the session runs on an api_key or the config-dir
-   * credential, where the report must not fire (PRODUCT-1319).
+   * Re-read the stored credential and rebuild the subprocess env from it.
+   * Called at the start of EVERY prompt (PRODUCT-1355): each `query()` spawns
+   * its own SDK subprocess (resumed by session id), so the env is a per-turn
+   * lever — a session must never stay pinned to the token it was built with,
+   * because the gateway's normal rotation invalidates the superseded access
+   * token and every later turn on the baked-in env would 401 `token_revoked`
+   * forever. May throw the scope guard's typed refusal (a personal scope whose
+   * token disappeared); exec-turn classifies that into the reconnect card, the
+   * same surface `createSession`'s own guard produces.
+   */
+  refreshAuth: () => TurnAuth;
+  /**
+   * Digest of the OAuth access token in the subprocess env at BUILD time —
+   * what a revoked-token report names. Updated by `refreshAuth` on every
+   * prompt, so it always tracks the token the CURRENT turn runs on
+   * (PRODUCT-1319, PRODUCT-1355). Undefined when the session runs on an
+   * api_key or the config-dir credential, where the report must not fire.
    */
   usedAccessDigest?: string;
 }
@@ -68,10 +91,22 @@ export class ClaudeSession implements HarnessSession {
   private model: string;
   private thinkingLevel: ThinkingLevel | undefined;
   private contextTokens: number | undefined;
+  private usedAccessDigest: string | undefined;
 
   constructor(private readonly deps: ClaudeSessionDeps) {
     this.model = deps.model;
     this.thinkingLevel = deps.thinkingLevel;
+    this.usedAccessDigest = deps.usedAccessDigest;
+  }
+
+  /**
+   * The digest of the OAuth access token this session's next spawn runs on
+   * (build-time until the first prompt, then each prompt's `refreshAuth` read).
+   * The conversation cache compares it against the CURRENTLY stored credential
+   * to rebuild sessions left on a rotated-out token (PRODUCT-1355 layer 2).
+   */
+  getUsedAccessDigest(): string | undefined {
+    return this.usedAccessDigest;
   }
 
   subscribe(listener: (e: WireEvent) => void): () => void {
@@ -87,10 +122,17 @@ export class ClaudeSession implements HarnessSession {
 
   async prompt(text: string): Promise<void> {
     if (this.disposed) return;
+    // Fresh credential per turn (PRODUCT-1355): every `query()` spawns its own
+    // SDK subprocess, so re-reading here means this turn runs on the token the
+    // store holds NOW — a reconnect or the gateway's rotation lands on the very
+    // next turn instead of never. The digest follows the env so a revoked-token
+    // report names the token this turn actually ran on (PRODUCT-1319).
+    const auth = this.deps.refreshAuth();
+    this.usedAccessDigest = auth.accessDigest;
     const resume = this.deps.sessionsStore.resolveResume(
       this.deps.conversationId,
     );
-    const outcome = await this.runAttempt(text, resume);
+    const outcome = await this.runAttempt(text, resume, auth.env);
     if (outcome !== "retry-fresh") return;
     // The SDK refused the resume id (its cwd-scoped lookup missed the
     // transcript — e.g. the workspace was renamed). The stale mapping is
@@ -99,7 +141,7 @@ export class ClaudeSession implements HarnessSession {
     console.warn(
       `[claude] resume for conversation ${this.deps.conversationId} was rejected by the SDK; starting a fresh session`,
     );
-    await this.runAttempt(text, undefined);
+    await this.runAttempt(text, undefined, auth.env);
   }
 
   /**
@@ -112,6 +154,7 @@ export class ClaudeSession implements HarnessSession {
   private async runAttempt(
     text: string,
     resume: string | undefined,
+    env: TurnAuth["env"],
   ): Promise<"done" | "retry-fresh"> {
     this.aborting = false;
     const abortController = new AbortController();
@@ -122,6 +165,9 @@ export class ClaudeSession implements HarnessSession {
       : undefined;
     const options: Options = {
       ...this.deps.baseOptions,
+      // The per-turn env OVERRIDES the build-time one in baseOptions, so this
+      // spawn carries the currently stored credential (PRODUCT-1355).
+      env,
       model: this.model,
       abortController,
       ...(resume ? { resume } : {}),
@@ -132,7 +178,7 @@ export class ClaudeSession implements HarnessSession {
       onContextTokens: (t) => {
         this.contextTokens = t;
       },
-      usedAccessDigest: this.deps.usedAccessDigest,
+      usedAccessDigest: this.usedAccessDigest,
     });
     let capturedSessionId: string | undefined;
     // True once this turn has surfaced a provider_error (from `translate`), so a
@@ -183,7 +229,7 @@ export class ClaudeSession implements HarnessSession {
           errMessage(err),
           this.model,
           null,
-          this.deps.usedAccessDigest,
+          this.usedAccessDigest,
         ),
       });
     } finally {

--- a/packages/runtime/src/backends/types.ts
+++ b/packages/runtime/src/backends/types.ts
@@ -55,6 +55,14 @@ export interface HarnessSession {
   setThinkingLevel(level: ThinkingLevel): void;
   /** The current context fill, or undefined when unknown. */
   getContextUsage(): { tokens: number | null } | undefined;
+  /**
+   * Digest of the provider access token this session's next turn runs on, when
+   * the backend pins one into the session (the Claude Agent SDK backend). The
+   * conversation cache compares it against the CURRENTLY stored credential to
+   * rebuild a cached session left on a rotated-out token (PRODUCT-1355).
+   * Backends that read credentials per request (pi) leave this unimplemented.
+   */
+  getUsedAccessDigest?(): string | undefined;
 }
 
 /** What a backend needs to open a session for one conversation. */

--- a/packages/runtime/src/session/claude-token-guard.test.ts
+++ b/packages/runtime/src/session/claude-token-guard.test.ts
@@ -1,0 +1,281 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { WireEvent } from "@houston/runtime-client";
+import { afterEach, expect, test, vi } from "vitest";
+import type { HarnessSession, ResolvedModel } from "../backends/types";
+
+/**
+ * PRODUCT-1355: Claude sessions must follow the rotated Anthropic token.
+ *
+ * Layer 2 under test: a cached session whose pinned access-token digest no
+ * longer matches the STORED credential is disposed and rebuilt at conversation
+ * lookup, so the fresh session reads the current token. Matching digests,
+ * digest-less sessions, non-Claude backends, and busy conversations are never
+ * rebuilt (no churn, no disposal from under a queued turn).
+ *
+ * Layer 3 under test: a turn that ends on `unauthenticated`/`token_revoked`
+ * evicts the conversation's in-memory session (history stays on disk), so the
+ * next attempt after a reconnect rebuilds cleanly instead of retrying the
+ * dead subprocess env forever.
+ */
+
+// Point config at throwaway dirs BEFORE the module graph loads (config reads
+// env at import; conversation-cache wires backends at load).
+process.env.HOUSTON_DATA_DIR = mkdtempSync(
+  join(tmpdir(), "houston-token-guard-data-"),
+);
+process.env.HOUSTON_WORKSPACE_DIR = mkdtempSync(
+  join(tmpdir(), "houston-token-guard-ws-"),
+);
+
+const state = vi.hoisted(() => ({
+  model: null as ResolvedModel | null,
+  /** What the (mocked) credential store currently holds for `anthropic`. */
+  token: undefined as { accessDigest?: string } | undefined,
+}));
+vi.mock("../ai/providers", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../ai/providers")>();
+  return {
+    ...real,
+    resolveModel: () => state.model,
+    activeEffort: () => null,
+  };
+});
+// The guard's "what does the store hold NOW" read (also used by the real
+// backend registration in conversation-cache, which these tests override).
+vi.mock("../backends/claude/read-token", () => ({
+  readAnthropicToken: () => state.token,
+}));
+
+await import("./conversation-cache");
+const { conversations, getConversation } = await import("./conversation-cache");
+const { evictClaudeSessionOnRevokedToken } = await import(
+  "./claude-token-guard"
+);
+const { execTurn } = await import("./exec-turn");
+const { registerBackend, setDefaultBackend } = await import(
+  "../backends/registry"
+);
+type Conversation = import("./conversation-cache").Conversation;
+
+const CLAUDE: ResolvedModel = {
+  provider: "anthropic",
+  id: "claude-sonnet-4-6",
+  contextWindow: 200_000,
+};
+const OPENAI: ResolvedModel = {
+  provider: "openai-codex",
+  id: "gpt-5-codex",
+  contextWindow: 400_000,
+};
+
+/**
+ * A stand-in for `ClaudeSession`: pins the digest the store held at BUILD time
+ * (exactly what the real backend does) and replays a scripted turn on prompt.
+ */
+class FakeClaudeSession implements HarnessSession {
+  disposed = false;
+  script: WireEvent[] = [];
+  private readonly digest = state.token?.accessDigest;
+  private listeners = new Set<(e: WireEvent) => void>();
+  subscribe(l: (e: WireEvent) => void): () => void {
+    this.listeners.add(l);
+    return () => {
+      this.listeners.delete(l);
+    };
+  }
+  async prompt(): Promise<void> {
+    for (const e of this.script) for (const l of [...this.listeners]) l(e);
+  }
+  async abort(): Promise<void> {}
+  dispose(): void {
+    this.disposed = true;
+    this.listeners.clear();
+  }
+  async setModel(): Promise<void> {}
+  async compact(): Promise<void> {}
+  setThinkingLevel(): void {}
+  getContextUsage(): { tokens: number | null } {
+    return { tokens: 0 };
+  }
+  getUsedAccessDigest(): string | undefined {
+    return this.digest;
+  }
+}
+
+const builtSessions: FakeClaudeSession[] = [];
+registerBackend("anthropic", {
+  id: "anthropic",
+  async createSession() {
+    const s = new FakeClaudeSession();
+    builtSessions.push(s);
+    return s;
+  },
+});
+
+/** A digest-less non-Claude session (pi never pins a token). */
+class PiSession extends FakeClaudeSession {
+  override getUsedAccessDigest(): string | undefined {
+    return undefined;
+  }
+}
+setDefaultBackend({
+  id: "pi",
+  async createSession() {
+    return new PiSession();
+  },
+});
+
+const revokedError: WireEvent = {
+  type: "provider_error",
+  data: {
+    kind: "unauthenticated",
+    provider: "anthropic",
+    cause: "token_revoked",
+    message: "OAuth token revoked",
+  },
+};
+
+afterEach(() => {
+  conversations.clear();
+  builtSessions.length = 0;
+  state.model = null;
+  state.token = undefined;
+});
+
+test("a rotated token rebuilds the cached Claude session at the next lookup, on the new digest", async () => {
+  state.model = CLAUDE;
+  state.token = { accessDigest: "digest-a" };
+  const conv1 = await getConversation("c1");
+  const session1 = conv1.session as FakeClaudeSession;
+  expect(session1.getUsedAccessDigest()).toBe("digest-a");
+
+  // The gateway rotates the family; the serve path stores the new token.
+  state.token = { accessDigest: "digest-b" };
+  const conv2 = await getConversation("c1");
+
+  expect(conv2.session).not.toBe(session1);
+  expect(session1.disposed).toBe(true);
+  expect(conv2.session.getUsedAccessDigest?.()).toBe("digest-b");
+});
+
+test("a matching digest returns the SAME session — no spurious rebuild churn", async () => {
+  state.model = CLAUDE;
+  state.token = { accessDigest: "digest-a" };
+  const conv1 = await getConversation("c1");
+  const conv2 = await getConversation("c1");
+  expect(conv2.session).toBe(conv1.session);
+  expect((conv1.session as FakeClaudeSession).disposed).toBe(false);
+  expect(builtSessions).toHaveLength(1);
+});
+
+test("a digest-less Claude session (api_key / config-dir credential) is never rebuilt", async () => {
+  state.model = CLAUDE;
+  state.token = {}; // api_key entry: read-token attaches no digest
+  const conv1 = await getConversation("c1");
+  // Even a later oauth connect must not tear down a session that pinned
+  // nothing — it re-reads the credential per prompt anyway.
+  state.token = { accessDigest: "digest-new" };
+  const conv2 = await getConversation("c1");
+  expect(conv2.session).toBe(conv1.session);
+});
+
+test("a non-Claude backend is untouched by an anthropic rotation", async () => {
+  state.model = OPENAI;
+  state.token = { accessDigest: "digest-a" };
+  const conv1 = await getConversation("c-pi");
+  state.token = { accessDigest: "digest-b" };
+  const conv2 = await getConversation("c-pi");
+  expect(conv2.session).toBe(conv1.session);
+});
+
+test("a BUSY conversation is never rebuilt from under its queued turns", async () => {
+  state.model = CLAUDE;
+  state.token = { accessDigest: "digest-a" };
+  const conv1 = await getConversation("c1");
+  conv1.pending = 1; // a turn is queued/running on this very object
+  state.token = { accessDigest: "digest-b" };
+  const conv2 = await getConversation("c1");
+  expect(conv2.session).toBe(conv1.session);
+  expect((conv1.session as FakeClaudeSession).disposed).toBe(false);
+});
+
+test("a token_revoked turn evicts the session; the next lookup builds fresh", async () => {
+  state.model = CLAUDE;
+  state.token = { accessDigest: "digest-a" };
+  const conv = await getConversation("c1");
+  (conv.session as FakeClaudeSession).script = [revokedError];
+
+  await execTurn(conv, "c1", "turn-1", "hi", {
+    author: undefined,
+    priorAuthors: [],
+  });
+
+  expect(conversations.has("c1")).toBe(false);
+  expect((conv.session as FakeClaudeSession).disposed).toBe(true);
+  // The user reconnects (new token stored) → the next attempt rebuilds
+  // cleanly on the fresh credential instead of retrying the dead session.
+  state.token = { accessDigest: "digest-after-reconnect" };
+  const rebuilt = await getConversation("c1");
+  expect(rebuilt.session).not.toBe(conv.session);
+  expect(rebuilt.session.getUsedAccessDigest?.()).toBe(
+    "digest-after-reconnect",
+  );
+});
+
+test("a non-revoked failure leaves the session cached (only token_revoked evicts)", async () => {
+  state.model = CLAUDE;
+  state.token = { accessDigest: "digest-a" };
+  const conv = await getConversation("c1");
+  (conv.session as FakeClaudeSession).script = [
+    {
+      type: "provider_error",
+      data: {
+        kind: "rate_limited",
+        provider: "anthropic",
+        model: null,
+        message: "429",
+        retry_after_seconds: null,
+      },
+    },
+  ];
+  await execTurn(conv, "c1", "turn-1", "hi", {
+    author: undefined,
+    priorAuthors: [],
+  });
+  expect(conversations.has("c1")).toBe(true);
+  expect((conv.session as FakeClaudeSession).disposed).toBe(false);
+});
+
+test("eviction defers while OTHER turns are queued, and ignores non-Claude backends", () => {
+  const session = new FakeClaudeSession();
+  const conv = {
+    session,
+    backendId: "anthropic",
+    pending: 2, // the settling turn + one still queued on this object
+  } as unknown as Conversation;
+  const revoked = revokedError.data as Extract<
+    WireEvent,
+    { type: "provider_error" }
+  >["data"];
+  expect(
+    evictClaudeSessionOnRevokedToken(conversations, "cx", conv, revoked),
+  ).toBe(false);
+  expect(session.disposed).toBe(false);
+
+  conv.pending = 1; // last turn settling → now it may evict
+  expect(
+    evictClaudeSessionOnRevokedToken(conversations, "cx", conv, revoked),
+  ).toBe(true);
+  expect(session.disposed).toBe(true);
+
+  const piConv = {
+    session: new FakeClaudeSession(),
+    backendId: "pi",
+    pending: 1,
+  } as unknown as Conversation;
+  expect(
+    evictClaudeSessionOnRevokedToken(conversations, "cy", piConv, revoked),
+  ).toBe(false);
+});

--- a/packages/runtime/src/session/claude-token-guard.ts
+++ b/packages/runtime/src/session/claude-token-guard.ts
@@ -1,0 +1,70 @@
+import type { ProviderError } from "@houston/runtime-client";
+import { authStorage } from "../auth/storage";
+import { readAnthropicToken } from "../backends/claude/read-token";
+import type { LruCache } from "../lru";
+import type { Conversation } from "./conversation-cache";
+
+/**
+ * PRODUCT-1355: keep cached Claude sessions on the CURRENT Anthropic token.
+ *
+ * The Claude Agent SDK session carries its credential in the subprocess env,
+ * read from the store when the session (or, since PRODUCT-1355, each prompt) is
+ * prepared. A conversation touched regularly never idle-expires, so before that
+ * fix a session outlived the gateway's normal token rotation and every turn on
+ * it 401'd `token_revoked` forever — while the user's reconnects kept minting
+ * credentials the pinned session never read (observed: 7 reconnects in 15 min
+ * against one session). These two guards are the defense-in-depth around the
+ * per-prompt re-read: a digest check at conversation lookup (layer 2) and an
+ * eviction when a turn actually dies on a revoked token (layer 3).
+ *
+ * Both are scoped to the Claude backend: pi reads credentials per request via
+ * the ModelRuntime, so its sessions can never pin a token.
+ */
+
+/** The Claude Agent SDK backend's registry id (see conversation-cache). */
+const CLAUDE_BACKEND_ID = "anthropic";
+
+/**
+ * Layer 2: does this cached conversation hold a Claude session whose pinned
+ * access token is no longer the stored one? A cheap, no-network check — one
+ * store read, ambient-scoped exactly like the read the turn itself would make
+ * (the whole request runs inside the acting identity, HOU-976). Sessions with
+ * no digest (api_key, config-dir credential) and non-Claude backends never
+ * match, so they are never rebuilt from under a working setup.
+ */
+export function claudeSessionTokenStale(conv: Conversation): boolean {
+  if (conv.backendId !== CLAUDE_BACKEND_ID) return false;
+  const pinned = conv.session.getUsedAccessDigest?.();
+  if (pinned === undefined) return false;
+  return pinned !== readAnthropicToken(authStorage)?.accessDigest;
+}
+
+/**
+ * Layer 3: a turn that ended on `unauthenticated`/`token_revoked` proves the
+ * cached Claude session's token is dead — evict it so the next attempt (after
+ * the user reconnects) rebuilds on the fresh credential instead of retrying
+ * the corpse. Chat history lives on disk; only the in-memory session is
+ * disposed, and the rebuilt session resumes the same SDK transcript.
+ *
+ * Skipped while OTHER turns are still queued on this conversation
+ * (`pending > 1` — the settling turn itself holds one count): those turns
+ * captured this Conversation object, and disposing its session would make
+ * their prompts silently no-op. The LAST settling turn evicts instead, and the
+ * per-prompt credential re-read keeps the queued turns honest meanwhile.
+ * Deleted only when the cache still maps `id` to THIS conversation, so a
+ * concurrent rebuild is never torn down by a stale settle.
+ */
+export function evictClaudeSessionOnRevokedToken(
+  cache: Pick<LruCache<string, Conversation>, "peek" | "delete">,
+  id: string,
+  conv: Conversation,
+  err: ProviderError | undefined,
+): boolean {
+  if (conv.backendId !== CLAUDE_BACKEND_ID) return false;
+  if (err?.kind !== "unauthenticated" || err.cause !== "token_revoked")
+    return false;
+  if ((conv.pending ?? 0) > 1) return false;
+  if (cache.peek(id) === conv) cache.delete(id);
+  conv.session.dispose();
+  return true;
+}

--- a/packages/runtime/src/session/conversation-cache.ts
+++ b/packages/runtime/src/session/conversation-cache.ts
@@ -12,6 +12,7 @@ import {
 import type { HarnessSession, ResolvedModel } from "../backends/types";
 import { config } from "../config";
 import { LruCache } from "../lru";
+import { claudeSessionTokenStale } from "./claude-token-guard";
 import type { TurnPin } from "./exec-turn";
 import { SYSTEM_PROMPT } from "./resource-loader";
 import { buildToolSelection } from "./tool-selection";
@@ -329,11 +330,27 @@ export async function getConversation(
   context?: ProvidedContext,
 ): Promise<Conversation> {
   const existing = conversations.get(id);
-  if (existing) {
+  // PRODUCT-1355 (layer 2): a cached Claude session pinned to an access token
+  // the store no longer holds (the gateway rotated the family; Anthropic
+  // invalidated the superseded token) is disposed and rebuilt below, so the
+  // fresh session reads the current credential. Busy conversations are left
+  // alone — their queued turns hold this very object, and the per-prompt
+  // credential re-read keeps them correct; matching digests, digest-less
+  // sessions, and non-Claude backends fall through untouched (no churn).
+  const rotatedOut =
+    existing && !isConvBusy(existing) && claudeSessionTokenStale(existing);
+  if (existing && !rotatedOut) {
     // Reap sessions idle past the TTL on every access, so a quiet runtime still
     // sheds memory between turns (get() above already marked `existing` fresh).
     conversations.sweepIdle();
     return existing;
+  }
+  // Preserve the conversation's startup context across the rebuild (HOU-711),
+  // exactly like the backend/mode rebuilds below do.
+  const carriedContext = context ?? existing?.context;
+  if (existing) {
+    conversations.delete(id);
+    existing.session.dispose();
   }
 
   // The model the session is built with — recorded on the Conversation so a
@@ -355,7 +372,7 @@ export async function getConversation(
     // Only used when the session is FIRST built (new conversation) — a later
     // message in the same conversation reuses this session, so context edits
     // take effect on the next chat, matching the local file behavior (HOU-711).
-    ...(context ? { context } : {}),
+    ...(carriedContext ? { context: carriedContext } : {}),
   });
 
   const conv: Conversation = {
@@ -366,7 +383,7 @@ export async function getConversation(
     backendId: backend.id,
     mode,
     pending: 0,
-    ...(context ? { context } : {}),
+    ...(carriedContext ? { context: carriedContext } : {}),
   };
   // set() enforces the size bound (disposing the LRU tail if full); sweepIdle()
   // then reaps any TTL-expired idle session. Both skip busy sessions, and the

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -73,6 +73,10 @@ vi.mock("./conversation-cache", () => ({
     preTokens: null,
   })),
   switchModeIfNeeded: vi.fn(async () => ({ rebuilt: false })),
+  // The revoked-token eviction (PRODUCT-1355) peeks the live cache in the
+  // turn's finally; these frame-contract tests run on non-Claude convs, so a
+  // minimal empty stand-in is enough.
+  conversations: { peek: () => undefined, delete: () => false },
 }));
 
 // The durable store is irrelevant to the frame contract under test.

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -41,8 +41,10 @@ import {
 } from "./attribution";
 import { needsAutocompact } from "./autocompact";
 import { publish } from "./bus";
+import { evictClaudeSessionOnRevokedToken } from "./claude-token-guard";
 import {
   type Conversation,
+  conversations,
   switchBackendIfNeeded,
   switchModeIfNeeded,
 } from "./conversation-cache";
@@ -174,6 +176,10 @@ export async function execTurn(
   // assistant message (so the inline card survives a reload) AND skip the clean
   // `done` that would settle the chat as a success on top of the error.
   let providerError: ProviderError | undefined;
+  // The catch path's typed resolution of a THROWN failure, hoisted so the
+  // finally's revoked-token eviction (PRODUCT-1355) can read it — the catch's
+  // own `typed` is block-scoped. Streamed failures land in `providerError`.
+  let thrownTyped: ProviderError | undefined;
 
   // Stall watchdog: a provider stream that goes silent mid-turn resolves neither
   // success nor error and would hold the workdir lock until the socket dies.
@@ -703,6 +709,7 @@ export async function execTurn(
       reportRevokedServedToken(thrown, usedTokens.digestFor(thrown.provider));
     }
     const typed = thrown.kind !== "unknown" ? thrown : undefined;
+    thrownTyped = typed;
     appendAssistantMessage(id, assistantText, {
       tools,
       thinking: thinkingText || undefined,
@@ -746,5 +753,17 @@ export async function execTurn(
     // Undefined only if resolveModel/switchBackendIfNeeded threw before we
     // subscribed (a bad pin) — nothing to tear down in that case.
     unsub?.();
+    // PRODUCT-1355 (layer 3): a turn that died on a REVOKED token leaves a
+    // Claude session whose next spawn would 401 identically — evict it so the
+    // user's next attempt after reconnecting rebuilds on the fresh credential.
+    // History is on disk; only the in-memory session is disposed. The guard
+    // itself scopes this to the Claude backend + `token_revoked`, and defers
+    // while other turns are still queued on this conversation.
+    evictClaudeSessionOnRevokedToken(
+      conversations,
+      id,
+      conv,
+      thrownTyped ?? providerError,
+    );
   }
 }


### PR DESCRIPTION
## Root cause

The Claude Agent SDK backend read the anthropic token ONCE at session creation (`backends/claude/backend.ts`) and baked it into the SDK subprocess env via `baseOptions`; every `query()` spread that same env. Conversations touched regularly never idle-expire (the LRU re-freshens on every access), so when the gateway rotated the token family — normal single-rotator refresh — Anthropic invalidated the superseded access token and every subsequent turn on that cached session 401'd `token_revoked` forever. The serve path correctly updated `auth.json` every turn; the session never re-read it. Observed live: 7 user reconnects in 15 minutes minting credentials one pinned session never picked up.

## The three layers (all runtime)

**Layer 1 — fresh token per turn.** The SDK spawns one subprocess per `query()` call (a string-prompt session resumes by id, it does not keep a live subprocess), so the env is a per-turn lever. `ClaudeSession.prompt()` now calls a backend-supplied `refreshAuth()` that re-reads the stored credential (scope-correct: inside the turn's acting context), re-asserts the personal-scope guard, and rebuilds the subprocess env; `usedAccessDigest` travels with that read so PRODUCT-1319's revoked-token report still names the token the failing turn actually ran on. The retry-fresh rerun reuses the same prompt's read (one read per prompt).

**Layer 2 — digest-mismatch rebuild.** `getConversation` compares a cached Claude session's pinned digest (`HarnessSession.getUsedAccessDigest?()`, new optional seam) against the digest of the CURRENTLY stored anthropic credential (one cheap store read, no network). Mismatch → dispose + rebuild; the fresh session resumes the same SDK transcript, and the conversation's startup context is carried over (HOU-711). Busy conversations are never rebuilt from under their queued turns, and matching digests / digest-less sessions (api_key, config-dir credential) / non-Claude backends fall through untouched — no rebuild churn.

**Layer 3 — evict on token_revoked.** When a turn settles with `unauthenticated`/`token_revoked` on the Claude backend (streamed OR thrown), `execTurn`'s finally evicts the conversation's in-memory session from the cache (`session/claude-token-guard.ts`). Chat history is on disk — only the session/subprocess is disposed — so the user's next attempt after reconnecting rebuilds cleanly. Eviction defers while other turns are still queued on the same Conversation object (their prompts would silently no-op on a disposed session); the last settling turn evicts instead.

## Tests

- `backends/claude/session.test.ts`: every prompt spawns with the env `refreshAuth` returns at THAT prompt (rotation adopted mid-conversation); digest follows; retry-fresh reuses one read per prompt.
- `backends/claude/backend.test.ts`: `refreshAuth` reads through to the current token + digest; re-asserts the personal-scope guard (a vanished personal token refuses the turn, never falls through to the team dir).
- `session/claude-token-guard.test.ts`: rotated digest rebuilds on next lookup with the new digest; matching digest returns the SAME session (no churn); digest-less sessions, non-Claude backends, and busy conversations untouched; a `token_revoked` turn evicts and the next `getConversation` builds fresh; non-revoked failures leave the cache alone; eviction defers at `pending > 1`.
- Full suites: `@houston/runtime` 1125 passed, `@houston/host` 1446 passed; tsc clean for both; Biome clean.

Fixes PRODUCT-1355