### PR TITLE
fix(integrations): guide HighLevel sub-account install

### DIFF
--- a/app/src/components/integrations-view/catalog-category-section.tsx
+++ b/app/src/components/integrations-view/catalog-category-section.tsx
@@ -43,7 +43,7 @@ export function CatalogCategorySection({
   section,
   surface,
   connectFlow,
-  onConnected,
+  onConnect,
   owns,
   statusOf,
   onOpen,
@@ -53,7 +53,7 @@ export function CatalogCategorySection({
   /** This catalog's half of every row's origin key. */
   surface: string;
   connectFlow: ConnectFlow;
-  onConnected?: (toolkit: string) => void;
+  onConnect: (toolkit: string, origin: string) => void;
   /** Does THIS row own its app's inline connect state? */
   owns: (slug: string, origin: string) => boolean;
   /** This app's broken-connection status, if it has one. */
@@ -85,11 +85,7 @@ export function CatalogCategorySection({
               key={tk.slug}
               display={appDisplay(tk.slug, tk)}
               onOpen={() => onOpen(tk, origin)}
-              onConnect={() =>
-                void connectFlow.connect(tk.slug, origin).then((attempt) => {
-                  if (attempt.outcome === "active") onConnected?.(tk.slug);
-                })
-              }
+              onConnect={() => onConnect(tk.slug, origin)}
               connectFlow={connectFlow}
               owns={owns(tk.slug, origin)}
               status={statusOf(tk.slug)}

--- a/app/src/components/integrations-view/category-catalog.tsx
+++ b/app/src/components/integrations-view/category-catalog.tsx
@@ -5,6 +5,7 @@ import type {
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { ConnectFlow } from "../integrations";
+import { HighLevelConnectGuidance } from "../integrations/highlevel-connect-guidance";
 import { AppInfoDialog } from "./app-info-dialog";
 import { CatalogCategorySection } from "./catalog-category-section";
 import { useCatalogSections } from "./use-catalog-sections";
@@ -76,6 +77,24 @@ export function CategoryCatalog({
     toolkit: IntegrationToolkit;
     origin: string;
   } | null>(null);
+  const [highLevelRequest, setHighLevelRequest] = useState<{
+    toolkit: string;
+    origin: string;
+  } | null>(null);
+
+  const beginConnect = (toolkit: string, origin: string) => {
+    void connectFlow.connect(toolkit, origin).then((attempt) => {
+      if (attempt.outcome === "active") onConnected?.(toolkit);
+    });
+  };
+
+  const requestConnect = (toolkit: string, origin: string) => {
+    if (toolkit === "highlevel") {
+      setHighLevelRequest({ toolkit, origin });
+      return;
+    }
+    beginConnect(toolkit, origin);
+  };
 
   return (
     <div>
@@ -91,7 +110,7 @@ export function CategoryCatalog({
               section={section}
               surface={surface}
               connectFlow={connectFlow}
-              onConnected={onConnected}
+              onConnect={requestConnect}
               // The spotlight repeats category rows: only the copy that owns
               // this app expands, so the panel appears exactly once.
               owns={(slug, origin) => owners.get(slug) === origin}
@@ -111,9 +130,7 @@ export function CategoryCatalog({
           const origin = info?.origin;
           setInfo(null);
           if (origin) {
-            void connectFlow.connect(toolkit, origin).then((attempt) => {
-              if (attempt.outcome === "active") onConnected?.(toolkit);
-            });
+            requestConnect(toolkit, origin);
           }
         }}
         onRemove={(toolkit) => {
@@ -125,6 +142,19 @@ export function CategoryCatalog({
         // modal for an app whose hand-off is already running (started from its
         // row, or from another surface entirely).
         busy={info !== null && info.toolkit.slug in connectFlow.states}
+      />
+
+      <HighLevelConnectGuidance
+        open={highLevelRequest !== null}
+        onOpenChange={(open) => {
+          if (!open) setHighLevelRequest(null);
+        }}
+        onContinue={() => {
+          if (!highLevelRequest) return;
+          const request = highLevelRequest;
+          setHighLevelRequest(null);
+          beginConnect(request.toolkit, request.origin);
+        }}
       />
     </div>
   );

--- a/app/src/components/integrations/highlevel-connect-guidance.tsx
+++ b/app/src/components/integrations/highlevel-connect-guidance.tsx
@@ -39,10 +39,7 @@ export function HighLevelConnectGuidance({
         </AlertDialogHeader>
 
         <div className="rounded-lg border border-line bg-input p-3">
-          <p className="mb-2 text-sm font-medium text-ink">
-            {t("highlevelGuidance.whenPageOpens")}
-          </p>
-          <div className="mb-3 flex items-center gap-2 text-sm">
+          <div className="flex items-center gap-2 text-sm">
             <span className="font-medium text-ink">
               {t("highlevelGuidance.houstonAppName")}
             </span>
@@ -51,11 +48,6 @@ export function HighLevelConnectGuidance({
               <ChevronDown className="size-3.5" aria-hidden />
             </span>
           </div>
-          <ol className="list-decimal space-y-1.5 pl-5 text-sm text-ink-muted">
-            <li>{t("highlevelGuidance.openDropdown")}</li>
-            <li>{t("highlevelGuidance.chooseSubAccount")}</li>
-            <li>{t("highlevelGuidance.selectLocation")}</li>
-          </ol>
         </div>
 
         <AlertDialogFooter>

--- a/app/src/components/integrations/highlevel-connect-guidance.tsx
+++ b/app/src/components/integrations/highlevel-connect-guidance.tsx
@@ -1,0 +1,70 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@houston-ai/core";
+import { ChevronDown } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+/**
+ * HighLevel's agency-level installer does not return the connection callback
+ * Composio needs. This one-app interstitial gives users the exact choice that
+ * works before Houston opens HighLevel, while every other toolkit keeps its
+ * immediate connect hand-off.
+ */
+export function HighLevelConnectGuidance({
+  open,
+  onOpenChange,
+  onContinue,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onContinue: () => void;
+}) {
+  const { t } = useTranslation("integrations");
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("highlevelGuidance.title")}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("highlevelGuidance.body")}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="rounded-lg border border-line bg-input p-3">
+          <p className="mb-2 text-sm font-medium text-ink">
+            {t("highlevelGuidance.whenPageOpens")}
+          </p>
+          <div className="mb-3 flex items-center gap-2 text-sm">
+            <span className="font-medium text-ink">
+              {t("highlevelGuidance.houstonAppName")}
+            </span>
+            <span className="inline-flex items-center gap-1 rounded-md border border-line bg-dialog px-2 py-1 text-ink">
+              {t("highlevelGuidance.agencyView")}
+              <ChevronDown className="size-3.5" aria-hidden />
+            </span>
+          </div>
+          <ol className="list-decimal space-y-1.5 pl-5 text-sm text-ink-muted">
+            <li>{t("highlevelGuidance.openDropdown")}</li>
+            <li>{t("highlevelGuidance.chooseSubAccount")}</li>
+            <li>{t("highlevelGuidance.selectLocation")}</li>
+          </ol>
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t("highlevelGuidance.cancel")}</AlertDialogCancel>
+          <AlertDialogAction onClick={onContinue}>
+            {t("highlevelGuidance.continue")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/app/src/locales/en/integrations.json
+++ b/app/src/locales/en/integrations.json
@@ -72,6 +72,18 @@
     "noResults": "No matching apps found.",
     "loading": "Loading apps..."
   },
+  "highlevelGuidance": {
+    "title": "Choose Sub-Account View in HighLevel",
+    "body": "HighLevel opens in Agency View by default. If you keep that option, the app may install but it will not finish connecting to Houston.",
+    "whenPageOpens": "When the HighLevel page opens:",
+    "houstonAppName": "Houston",
+    "agencyView": "Agency View",
+    "openDropdown": "Open the Agency View dropdown next to the Houston app name.",
+    "chooseSubAccount": "Choose Sub-Account View.",
+    "selectLocation": "Select one location, then click Install.",
+    "cancel": "Cancel",
+    "continue": "Continue to HighLevel"
+  },
   "home": {
     "tabs": {
       "label": "Integration sections",

--- a/app/src/locales/en/integrations.json
+++ b/app/src/locales/en/integrations.json
@@ -74,13 +74,9 @@
   },
   "highlevelGuidance": {
     "title": "Choose Sub-Account View in HighLevel",
-    "body": "HighLevel opens in Agency View by default. If you keep that option, the app may install but it will not finish connecting to Houston.",
-    "whenPageOpens": "When the HighLevel page opens:",
+    "body": "When the HighLevel page opens, use the dropdown next to Houston to switch Agency View to Sub-Account View.",
     "houstonAppName": "Houston",
     "agencyView": "Agency View",
-    "openDropdown": "Open the Agency View dropdown next to the Houston app name.",
-    "chooseSubAccount": "Choose Sub-Account View.",
-    "selectLocation": "Select one location, then click Install.",
     "cancel": "Cancel",
     "continue": "Continue to HighLevel"
   },

--- a/app/src/locales/es/integrations.json
+++ b/app/src/locales/es/integrations.json
@@ -72,6 +72,18 @@
     "noResults": "No hay apps que coincidan.",
     "loading": "Cargando apps..."
   },
+  "highlevelGuidance": {
+    "title": "Elige Sub-Account View en HighLevel",
+    "body": "HighLevel abre en Agency View de forma predeterminada. Si mantienes esa opción, la aplicación puede instalarse, pero no terminará de conectarse con Houston.",
+    "whenPageOpens": "Cuando se abra la página de HighLevel:",
+    "houstonAppName": "Houston",
+    "agencyView": "Agency View",
+    "openDropdown": "Abre el menú Agency View junto al nombre de la aplicación Houston.",
+    "chooseSubAccount": "Elige Sub-Account View.",
+    "selectLocation": "Selecciona una ubicación y luego haz clic en Install.",
+    "cancel": "Cancelar",
+    "continue": "Continuar a HighLevel"
+  },
   "home": {
     "tabs": {
       "label": "Secciones de integraciones",

--- a/app/src/locales/es/integrations.json
+++ b/app/src/locales/es/integrations.json
@@ -74,13 +74,9 @@
   },
   "highlevelGuidance": {
     "title": "Elige Sub-Account View en HighLevel",
-    "body": "HighLevel abre en Agency View de forma predeterminada. Si mantienes esa opción, la aplicación puede instalarse, pero no terminará de conectarse con Houston.",
-    "whenPageOpens": "Cuando se abra la página de HighLevel:",
+    "body": "Cuando se abra la página de HighLevel, usa el menú junto a Houston para cambiar Agency View a Sub-Account View.",
     "houstonAppName": "Houston",
     "agencyView": "Agency View",
-    "openDropdown": "Abre el menú Agency View junto al nombre de la aplicación Houston.",
-    "chooseSubAccount": "Elige Sub-Account View.",
-    "selectLocation": "Selecciona una ubicación y luego haz clic en Install.",
     "cancel": "Cancelar",
     "continue": "Continuar a HighLevel"
   },

--- a/app/src/locales/pt/integrations.json
+++ b/app/src/locales/pt/integrations.json
@@ -74,13 +74,9 @@
   },
   "highlevelGuidance": {
     "title": "Escolha Sub-Account View no HighLevel",
-    "body": "O HighLevel abre em Agency View por padrão. Se você mantiver essa opção, o aplicativo poderá ser instalado, mas não concluirá a conexão com o Houston.",
-    "whenPageOpens": "Quando a página do HighLevel abrir:",
+    "body": "Quando a página do HighLevel abrir, use o menu ao lado de Houston para mudar de Agency View para Sub-Account View.",
     "houstonAppName": "Houston",
     "agencyView": "Agency View",
-    "openDropdown": "Abra o menu Agency View ao lado do nome do aplicativo Houston.",
-    "chooseSubAccount": "Escolha Sub-Account View.",
-    "selectLocation": "Selecione uma localização e clique em Install.",
     "cancel": "Cancelar",
     "continue": "Continuar para o HighLevel"
   },

--- a/app/src/locales/pt/integrations.json
+++ b/app/src/locales/pt/integrations.json
@@ -72,6 +72,18 @@
     "noResults": "Nenhum app corresponde à busca.",
     "loading": "Carregando apps..."
   },
+  "highlevelGuidance": {
+    "title": "Escolha Sub-Account View no HighLevel",
+    "body": "O HighLevel abre em Agency View por padrão. Se você mantiver essa opção, o aplicativo poderá ser instalado, mas não concluirá a conexão com o Houston.",
+    "whenPageOpens": "Quando a página do HighLevel abrir:",
+    "houstonAppName": "Houston",
+    "agencyView": "Agency View",
+    "openDropdown": "Abra o menu Agency View ao lado do nome do aplicativo Houston.",
+    "chooseSubAccount": "Escolha Sub-Account View.",
+    "selectLocation": "Selecione uma localização e clique em Install.",
+    "cancel": "Cancelar",
+    "continue": "Continuar para o HighLevel"
+  },
   "home": {
     "tabs": {
       "label": "Seções de integrações",

--- a/packages/web/e2e/integrations-browse.spec.ts
+++ b/packages/web/e2e/integrations-browse.spec.ts
@@ -218,7 +218,7 @@ test("a row's + connects INLINE, exactly once, leaving every other row usable", 
   await expect(page.getByText("Finish connecting GitHub")).toHaveCount(1);
 });
 
-test("HighLevel explains the required Sub-Account View before opening OAuth", async ({
+test("HighLevel asks for Sub-Account View before opening OAuth", async ({
   page,
   request,
 }) => {
@@ -238,7 +238,10 @@ test("HighLevel explains the required Sub-Account View before opening OAuth", as
     guidance.getByText("Agency View", { exact: true }),
   ).toBeVisible();
   await expect(
-    guidance.getByText("Choose Sub-Account View.", { exact: true }),
+    guidance.getByText(
+      "When the HighLevel page opens, use the dropdown next to Houston to switch Agency View to Sub-Account View.",
+      { exact: true },
+    ),
   ).toBeVisible();
   await expect(page.getByText("Finish connecting HighLevel")).toHaveCount(0);
 

--- a/packages/web/e2e/integrations-browse.spec.ts
+++ b/packages/web/e2e/integrations-browse.spec.ts
@@ -30,6 +30,27 @@ async function openIntegrationsPage(page: Page): Promise<void> {
   await page.locator('[data-tour-target="nav-integrations"]').click();
 }
 
+async function addHighLevelToCatalog(page: Page): Promise<void> {
+  await page.route("**/v1/integrations/composio/toolkits", async (route) => {
+    const response = await route.fetch();
+    const body = (await response.json()) as { items: unknown[] };
+    await route.fulfill({
+      response,
+      json: {
+        items: [
+          ...body.items,
+          {
+            slug: "highlevel",
+            name: "HighLevel",
+            description: "CRM and marketing automation",
+            categories: ["sales"],
+          },
+        ],
+      },
+    });
+  });
+}
+
 test("the browse page groups the catalog into category sections with an installed strip", async ({
   page,
   request,
@@ -195,6 +216,34 @@ test("a row's + connects INLINE, exactly once, leaving every other row usable", 
     .click();
   await expect(page.getByText("Finish connecting Slack")).toHaveCount(0);
   await expect(page.getByText("Finish connecting GitHub")).toHaveCount(1);
+});
+
+test("HighLevel explains the required Sub-Account View before opening OAuth", async ({
+  page,
+  request,
+}) => {
+  await addHighLevelToCatalog(page);
+  await armCapabilities(request, { integrations: ["composio"] });
+  await openIntegrationsPage(page);
+
+  await page.getByRole("button", { name: "Connect HighLevel" }).click();
+
+  const guidance = page.getByRole("alertdialog");
+  await expect(
+    guidance.getByRole("heading", {
+      name: "Choose Sub-Account View in HighLevel",
+    }),
+  ).toBeVisible();
+  await expect(
+    guidance.getByText("Agency View", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    guidance.getByText("Choose Sub-Account View.", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText("Finish connecting HighLevel")).toHaveCount(0);
+
+  await guidance.getByRole("button", { name: "Continue to HighLevel" }).click();
+  await expect(page.getByText("Finish connecting HighLevel")).toBeVisible();
 });
 
 test("the owning row becomes ONE card carrying ONE spinner", async ({


### PR DESCRIPTION
## Summary

- show a HighLevel-only guidance dialog before opening the connection flow
- tell users to switch Agency View to Sub-Account View beside the Houston app name
- keep every other integration's connect behavior unchanged
- localize the guidance in English, Spanish, and Portuguese

Linear: PRODUCT-1347

## Verification

- `pnpm check`
- `cd app && pnpm check-locales`
- `cd app && pnpm tsgo --noEmit`
- `cd app && pnpm test` (3,644 passing)
- `pnpm --filter houston-web build`
- `pnpm --filter houston-web exec playwright test e2e/integrations-browse.spec.ts --project chromium` (10 passing)
- `pnpm --filter houston-web test:visual` (8 passing)