### PR TITLE
chore(store): drop the dead needsSessionReplay wire hop and wrapper functions

### DIFF
--- a/packages/host/src/routes/transcripts-sandbox.test.ts
+++ b/packages/host/src/routes/transcripts-sandbox.test.ts
@@ -34,6 +34,8 @@ test("the sandbox facade authenticates and forwards the user turn verbatim", asy
         message,
         title: "hello",
         expectedCount: 3,
+        // Legacy field a pre-cleanup runtime still sends: must be tolerated
+        // (ignored), never required.
         needsSessionReplay: true,
       }),
     ),
@@ -62,7 +64,6 @@ test("the sandbox facade authenticates and forwards the user turn verbatim", asy
       message,
       title: "hello",
       expectedCount: 3,
-      needsSessionReplay: true,
     },
   ]);
 });

--- a/packages/host/src/routes/transcripts-sandbox.ts
+++ b/packages/host/src/routes/transcripts-sandbox.ts
@@ -73,7 +73,6 @@ function parseCommand(
       mismatchedTurn(message, turnId) ||
       !Number.isSafeInteger(body.expectedCount) ||
       (body.expectedCount as number) < 0 ||
-      typeof body.needsSessionReplay !== "boolean" ||
       typeof body.title !== "string"
     ) {
       return null;
@@ -85,7 +84,6 @@ function parseCommand(
       message,
       title: body.title,
       expectedCount: body.expectedCount as number,
-      needsSessionReplay: body.needsSessionReplay,
     };
   }
   if (method === "POST" && rest === "truncate") {

--- a/packages/host/src/transcripts/http-shadow.test.ts
+++ b/packages/host/src/transcripts/http-shadow.test.ts
@@ -29,7 +29,6 @@ test("transcript writes carry pod auth, fencing, and learned revisions", async (
     message,
     title: "hello",
     expectedCount: 0,
-    needsSessionReplay: false,
   });
   await shadow.apply({
     kind: "truncate",

--- a/packages/host/src/transcripts/http-shadow.ts
+++ b/packages/host/src/transcripts/http-shadow.ts
@@ -15,7 +15,6 @@ export type TranscriptShadowCommand =
       message: ChatMessage;
       title: string;
       expectedCount: number;
-      needsSessionReplay: boolean;
     }
   | {
       kind: "assistant";
@@ -111,10 +110,9 @@ export class HttpTranscriptShadow implements TranscriptShadow {
             ts: command.message.ts,
             title: command.title,
             expectedCount: command.expectedCount,
-            // The pod-store atomically consumes its own durable replay marker.
-            // `needsSessionReplay` is carried across the runtime/host facade to
-            // assert the file's pre-consume state, but is intentionally absent
-            // here because the strict pod route derives (and records) it.
+            // No replay marker on the wire: the strict pod route derives and
+            // records `needs_session_replay` itself (set on truncate, cleared
+            // by the next user turn), and its parser rejects unknown fields.
           },
         };
       case "assistant":

--- a/packages/runtime/src/store/conversation-file.test.ts
+++ b/packages/runtime/src/store/conversation-file.test.ts
@@ -10,7 +10,7 @@ import {
   getHistoryAt,
   listConversationsAt,
   loadConversation,
-  renameConversationAt,
+  renameConversationMutationAt,
 } from "./conversation-file";
 
 /** Mint an `acting-v1.<payloadB64Url>.<sig>` token carrying `payload` (C2). */
@@ -27,7 +27,9 @@ test("rename persists the new title and bumps updatedAt", () => {
   const before = loadConversation(dir, "c1");
   if (!before) throw new Error("loadConversation returned null after append");
 
-  expect(renameConversationAt(dir, "c1", "Quarterly report")).toBe(true);
+  expect(
+    renameConversationMutationAt(dir, "c1", "Quarterly report"),
+  ).not.toBeNull();
 
   const after = loadConversation(dir, "c1");
   if (!after) throw new Error("loadConversation returned null after rename");
@@ -39,7 +41,7 @@ test("rename persists the new title and bumps updatedAt", () => {
 
 test("rename of an unknown conversation reports failure, writes nothing", () => {
   const dir = freshDir();
-  expect(renameConversationAt(dir, "ghost", "nope")).toBe(false);
+  expect(renameConversationMutationAt(dir, "ghost", "nope")).toBeNull();
   expect(listConversationsAt(dir)).toHaveLength(0);
 });
 

--- a/packages/runtime/src/store/conversation-file.ts
+++ b/packages/runtime/src/store/conversation-file.ts
@@ -214,14 +214,6 @@ export function renameConversationMutationAt(
   return conv;
 }
 
-export function renameConversationAt(
-  dir: string,
-  id: string,
-  title: string,
-): boolean {
-  return renameConversationMutationAt(dir, id, title) !== null;
-}
-
 export function deleteConversationAt(dir: string, id: string): boolean {
   const f = fileFor(dir, id);
   dropParsedFile(f);

--- a/packages/runtime/src/store/conversation-shadow.test.ts
+++ b/packages/runtime/src/store/conversation-shadow.test.ts
@@ -57,7 +57,6 @@ test("user and assistant shadow only after the atomic file write", () => {
     turnId: "t1",
     title: "hello",
     expectedCount: 0,
-    needsSessionReplay: false,
   });
   // Message-only enqueue: the hot append path never clones the conversation.
   expect(seen.some((operation) => "conversation" in operation)).toBe(false);

--- a/packages/runtime/src/store/conversation-truncate.test.ts
+++ b/packages/runtime/src/store/conversation-truncate.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./conversation-file";
 import {
   consumeSessionReplayAt,
-  truncateConversationAt,
+  truncateConversationMutationAt,
 } from "./conversation-truncate";
 
 const freshDir = () => mkdtempSync(join(tmpdir(), "houston-truncate-"));
@@ -29,7 +29,9 @@ test("truncate at a later turn keeps everything before it and stamps the replay 
   const dir = freshDir();
   seedTwoTurns(dir);
 
-  expect(truncateConversationAt(dir, "c1", "t2")).toEqual({ removed: 2 });
+  expect(truncateConversationMutationAt(dir, "c1", "t2")).toMatchObject({
+    removed: 2,
+  });
 
   const conv = loadConversation(dir, "c1");
   if (!conv) throw new Error("loadConversation returned null after truncate");
@@ -46,7 +48,9 @@ test("truncate at the FIRST turn empties the transcript (editing message one)", 
   const dir = freshDir();
   seedTwoTurns(dir);
 
-  expect(truncateConversationAt(dir, "c1", "t1")).toEqual({ removed: 4 });
+  expect(truncateConversationMutationAt(dir, "c1", "t1")).toMatchObject({
+    removed: 4,
+  });
   expect(loadConversation(dir, "c1")?.messages).toEqual([]);
 });
 
@@ -55,7 +59,7 @@ test("truncate cuts from the turn's USER message even when the cut lands mid-tra
   seedTwoTurns(dir);
   appendUserMessageAt(dir, "c1", "third", { turnId: "t3" });
 
-  truncateConversationAt(dir, "c1", "t2");
+  truncateConversationMutationAt(dir, "c1", "t2");
 
   const conv = loadConversation(dir, "c1");
   expect(conv?.messages.every((m) => m.turnId === "t1")).toBe(true);
@@ -65,8 +69,8 @@ test("unknown turn or conversation writes nothing and reports null (404 at the r
   const dir = freshDir();
   seedTwoTurns(dir);
 
-  expect(truncateConversationAt(dir, "c1", "ghost")).toBeNull();
-  expect(truncateConversationAt(dir, "nope", "t1")).toBeNull();
+  expect(truncateConversationMutationAt(dir, "c1", "ghost")).toBeNull();
+  expect(truncateConversationMutationAt(dir, "nope", "t1")).toBeNull();
 
   const conv = loadConversation(dir, "c1");
   expect(conv?.messages).toHaveLength(4);
@@ -76,7 +80,7 @@ test("unknown turn or conversation writes nothing and reports null (404 at the r
 test("consumeSessionReplayAt is one-shot: true once after a truncate, then false", () => {
   const dir = freshDir();
   seedTwoTurns(dir);
-  truncateConversationAt(dir, "c1", "t2");
+  truncateConversationMutationAt(dir, "c1", "t2");
 
   expect(consumeSessionReplayAt(dir, "c1")).toBe(true);
   expect(consumeSessionReplayAt(dir, "c1")).toBe(false);

--- a/packages/runtime/src/store/conversation-truncate.ts
+++ b/packages/runtime/src/store/conversation-truncate.ts
@@ -15,15 +15,6 @@ import { loadConversation, saveConversation } from "./conversation-file";
  * (HOU-951). Returns how many messages were removed, or null when the
  * conversation or the turn is unknown (nothing was written).
  */
-export function truncateConversationAt(
-  dir: string,
-  id: string,
-  turnId: string,
-): { removed: number } | null {
-  const mutation = truncateConversationMutationAt(dir, id, turnId);
-  return mutation ? { removed: mutation.removed } : null;
-}
-
 export function truncateConversationMutationAt(
   dir: string,
   id: string,

--- a/packages/runtime/src/store/conversations.ts
+++ b/packages/runtime/src/store/conversations.ts
@@ -56,7 +56,6 @@ export function createConversationStore(
               message: snapshotMessage(result.message),
               title: result.conversation.title,
               expectedCount: result.expectedCount,
-              needsSessionReplay: result.needsSessionReplay,
             }
           : { kind: "repair", conversationId: id };
       });

--- a/packages/runtime/src/store/transcript-shadow-http.ts
+++ b/packages/runtime/src/store/transcript-shadow-http.ts
@@ -48,7 +48,6 @@ function requestFor(root: string, operation: TranscriptShadowSend) {
           ts: operation.message.ts,
           title: operation.title,
           expectedCount: operation.expectedCount,
-          needsSessionReplay: operation.needsSessionReplay,
         },
       };
     case "assistant":

--- a/packages/runtime/src/store/transcript-shadow-queue.test.ts
+++ b/packages/runtime/src/store/transcript-shadow-queue.test.ts
@@ -25,7 +25,6 @@ function userOp(conversationId: string, n: number): TranscriptShadowOperation {
     message: message(n),
     title: "chat",
     expectedCount: n - 1,
-    needsSessionReplay: false,
   };
 }
 

--- a/packages/runtime/src/store/transcript-shadow.ts
+++ b/packages/runtime/src/store/transcript-shadow.ts
@@ -19,7 +19,6 @@ export type TranscriptShadowOperation =
       message: ChatMessage;
       title: string;
       expectedCount: number;
-      needsSessionReplay: boolean;
     })
   | (ShadowBase & {
       kind: "assistant";


### PR DESCRIPTION
Cleanup flagged by the #1320 multi-agent review and confirmed safe by the cross-repo reconciliation (the pod-store derives the replay marker itself and its strict parser would 400 the field, so the facade hop asserted nothing). Also deletes the two zero-caller wrapper functions. No behavior change; the sandbox route still tolerates the legacy field from an older runtime (test-pinned). Suites: host 169 / runtime 123 / runtime-client 18 / domain 16 files green; Biome + boundaries clean.