### PR TITLE
feat: phase 5 increment 1 — pooled turn worker (PRODUCT-1303)

### DIFF
--- a/packages/host/src/transcripts/http-shadow.ts
+++ b/packages/host/src/transcripts/http-shadow.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage } from "@houston/protocol";
+import { transcriptTurnRequest } from "@houston/runtime-client";
 import {
   capturePodFence,
   type PodGatewayConfig,
@@ -102,25 +103,9 @@ export class HttpTranscriptShadow implements TranscriptShadow {
     const root = this.conversationUrl(command.conversationId);
     switch (command.kind) {
       case "user":
-        return {
-          method: "PUT",
-          url: `${root}/turns/${encodeURIComponent(command.turnId)}/user`,
-          body: {
-            message: command.message,
-            ts: command.message.ts,
-            title: command.title,
-            expectedCount: command.expectedCount,
-            // No replay marker on the wire: the strict pod route derives and
-            // records `needs_session_replay` itself (set on truncate, cleared
-            // by the next user turn), and its parser rejects unknown fields.
-          },
-        };
+        return transcriptTurnRequest(root, command);
       case "assistant":
-        return {
-          method: "PUT",
-          url: `${root}/turns/${encodeURIComponent(command.turnId)}/assistant`,
-          body: { message: command.message, ts: command.message.ts },
-        };
+        return transcriptTurnRequest(root, command);
       case "truncate":
         return {
           method: "POST",

--- a/packages/host/src/turn/dispatch.test.ts
+++ b/packages/host/src/turn/dispatch.test.ts
@@ -209,6 +209,30 @@ test("a pinned routine turn sends autopilot mode to the runtime", async () => {
   expect(turnBodies[0]?.mode).toBe("auto");
 });
 
+test("the turn envelope sanitizes a slash-bearing agent id", async () => {
+  const { deps } = makeDeps();
+  turnBodies = [];
+  const localAgent = { ...agent, id: "Work/Marketing team!" };
+  const done = new Promise<void>((resolve) => {
+    deps.relay.subscribe(`${localAgent.id}/c-local`, (event) => {
+      if (event.type === "done" || event.type === "error") resolve();
+    });
+  });
+
+  const outcome = await dispatchTurn(
+    deps,
+    ws,
+    localAgent,
+    "c-local",
+    "hello",
+    undefined,
+  );
+  expect(outcome.status).toBe("accepted");
+  await done;
+  expect(turnBodies[0]?.agentId).toBe("Work_Marketing_team_");
+  expect(turnBodies[0]?.gcsPrefix).toBe("ws/w1/Work/Marketing team!");
+});
+
 test("a malformed turn body answers a clean 400 — both the streamed and the pre-read parse", async () => {
   const { deps } = makeDeps();
   const bad = "{not json";

--- a/packages/host/src/turn/start-turn.ts
+++ b/packages/host/src/turn/start-turn.ts
@@ -80,7 +80,7 @@ export async function dispatchTurn(
             },
             body: JSON.stringify({
               workspaceId: ws.id,
-              agentId: agent.id,
+              agentId: agent.id.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 128),
               conversationId: cid,
               text,
               nonce,

--- a/packages/runtime-client/src/index.ts
+++ b/packages/runtime-client/src/index.ts
@@ -33,4 +33,6 @@ export { readEventStream } from "./sse-read";
 export type { ResumableStreamSource } from "./stitch";
 export { serveResumableStream } from "./stitch";
 export { StreamChannel } from "./stream-channel";
+export type { TranscriptTurnWrite } from "./transcript-turn-request";
+export { transcriptTurnRequest } from "./transcript-turn-request";
 export * from "./types";

--- a/packages/runtime-client/src/object-sync/http-store.test.ts
+++ b/packages/runtime-client/src/object-sync/http-store.test.ts
@@ -166,7 +166,11 @@ test("claim-backed mutations send claim headers instead of lease headers", async
   const store = new HttpObjectStore({
     baseUrl: "https://store.test/v1/pod/store/acme/agent",
     token: "host-token",
-    claim: { token: "claim-token", bootId: "claim-boot" },
+    claim: {
+      token: "claim-token",
+      bootId: "claim-boot",
+      conversationId: "mission-7",
+    },
     fetchImpl: async (_input, init) => {
       requests.push(new Headers(init?.headers));
       return init?.method === "DELETE"
@@ -181,6 +185,7 @@ test("claim-backed mutations send claim headers instead of lease headers", async
   for (const headers of requests) {
     expect(headers.get("x-houston-claim-token")).toBe("claim-token");
     expect(headers.get("x-houston-claim-boot")).toBe("claim-boot");
+    expect(headers.get("x-houston-claim-conversation")).toBe("mission-7");
     expect(headers.get("x-houston-fencing-token")).toBeNull();
     expect(headers.get("x-houston-boot-id")).toBeNull();
   }
@@ -194,7 +199,11 @@ test("claim and lease mutation authority cannot be configured together", () => {
         token: "host-token",
         bootId: "lease-boot",
         fence: {},
-        claim: { token: "claim-token", bootId: "claim-boot" },
+        claim: {
+          token: "claim-token",
+          bootId: "claim-boot",
+          conversationId: "mission-7",
+        },
       }),
   ).toThrow("claim authority cannot be combined");
 });

--- a/packages/runtime-client/src/object-sync/http-store.test.ts
+++ b/packages/runtime-client/src/object-sync/http-store.test.ts
@@ -158,6 +158,47 @@ test("captures a fencing token and echoes it with the stable boot id on writes",
   expect(fence.token).toBe("42");
 });
 
+test("claim-backed mutations send claim headers instead of lease headers", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "http-claim-object-store-"));
+  const source = join(dir, "source.txt");
+  writeFileSync(source, "hello");
+  const requests: Headers[] = [];
+  const store = new HttpObjectStore({
+    baseUrl: "https://store.test/v1/pod/store/acme/agent",
+    token: "host-token",
+    claim: { token: "claim-token", bootId: "claim-boot" },
+    fetchImpl: async (_input, init) => {
+      requests.push(new Headers(init?.headers));
+      return init?.method === "DELETE"
+        ? new Response(null, { status: 204 })
+        : Response.json(metadata("notes.txt", 5));
+    },
+  });
+
+  await store.upload(source, "notes.txt");
+  await store.delete("notes.txt");
+
+  for (const headers of requests) {
+    expect(headers.get("x-houston-claim-token")).toBe("claim-token");
+    expect(headers.get("x-houston-claim-boot")).toBe("claim-boot");
+    expect(headers.get("x-houston-fencing-token")).toBeNull();
+    expect(headers.get("x-houston-boot-id")).toBeNull();
+  }
+});
+
+test("claim and lease mutation authority cannot be configured together", () => {
+  expect(
+    () =>
+      new HttpObjectStore({
+        baseUrl: "https://store.test/base",
+        token: "host-token",
+        bootId: "lease-boot",
+        fence: {},
+        claim: { token: "claim-token", bootId: "claim-boot" },
+      }),
+  ).toThrow("claim authority cannot be combined");
+});
+
 test.each([
   409, 500,
 ])("does not capture a fencing token from a failed %i response", async (status) => {

--- a/packages/runtime-client/src/object-sync/http-store.ts
+++ b/packages/runtime-client/src/object-sync/http-store.ts
@@ -27,7 +27,7 @@ export interface HttpObjectStoreOptions {
   /** Mutable lease token shared by every agent-prefix request in this boot. */
   fence?: { token?: string };
   /** Per-conversation mutation authority for a pooled worker turn. */
-  claim?: { token: string; bootId: string };
+  claim?: { token: string; bootId: string; conversationId: string };
 }
 
 export class HttpObjectStore implements ObjectStore {
@@ -38,7 +38,9 @@ export class HttpObjectStore implements ObjectStore {
   private readonly retryDelaysMs: number[] | undefined;
   private readonly bootId: string | undefined;
   private readonly fence: { token?: string } | undefined;
-  private readonly claim: { token: string; bootId: string } | undefined;
+  private readonly claim:
+    | { token: string; bootId: string; conversationId: string }
+    | undefined;
 
   constructor(opts: HttpObjectStoreOptions) {
     this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
@@ -200,6 +202,7 @@ export class HttpObjectStore implements ObjectStore {
     } else if (this.claim) {
       headers["X-Houston-Claim-Token"] = this.claim.token;
       headers["X-Houston-Claim-Boot"] = this.claim.bootId;
+      headers["X-Houston-Claim-Conversation"] = this.claim.conversationId;
     }
     return headers;
   }

--- a/packages/runtime-client/src/object-sync/http-store.ts
+++ b/packages/runtime-client/src/object-sync/http-store.ts
@@ -26,6 +26,8 @@ export interface HttpObjectStoreOptions {
   bootId?: string;
   /** Mutable lease token shared by every agent-prefix request in this boot. */
   fence?: { token?: string };
+  /** Per-conversation mutation authority for a pooled worker turn. */
+  claim?: { token: string; bootId: string };
 }
 
 export class HttpObjectStore implements ObjectStore {
@@ -36,6 +38,7 @@ export class HttpObjectStore implements ObjectStore {
   private readonly retryDelaysMs: number[] | undefined;
   private readonly bootId: string | undefined;
   private readonly fence: { token?: string } | undefined;
+  private readonly claim: { token: string; bootId: string } | undefined;
 
   constructor(opts: HttpObjectStoreOptions) {
     this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
@@ -45,9 +48,15 @@ export class HttpObjectStore implements ObjectStore {
     this.retryDelaysMs = opts.retryDelaysMs;
     this.bootId = opts.bootId;
     this.fence = opts.fence;
+    this.claim = opts.claim;
     if (Boolean(this.bootId) !== Boolean(this.fence)) {
       throw new Error(
         "object store bootId and fence must be configured together",
+      );
+    }
+    if (this.claim && (this.bootId || this.fence)) {
+      throw new Error(
+        "object store claim authority cannot be combined with lease authority",
       );
     }
   }
@@ -188,6 +197,9 @@ export class HttpObjectStore implements ObjectStore {
     if (this.fence?.token !== undefined && this.bootId !== undefined) {
       headers["X-Houston-Fencing-Token"] = this.fence.token;
       headers["X-Houston-Boot-Id"] = this.bootId;
+    } else if (this.claim) {
+      headers["X-Houston-Claim-Token"] = this.claim.token;
+      headers["X-Houston-Claim-Boot"] = this.claim.bootId;
     }
     return headers;
   }

--- a/packages/runtime-client/src/object-sync/hydrate.test.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.test.ts
@@ -11,7 +11,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "vitest";
-import { excluded, hydrate, syncBack } from "./hydrate";
+import { excluded, type HydrateLimitError, hydrate, syncBack } from "./hydrate";
 import type { ObjectMetadata } from "./object-manifest";
 import {
   LocalDirStore,
@@ -579,7 +579,12 @@ test("hydration size cap throws, never truncates silently", async () => {
   seed(storeRoot, PREFIX, { "workspace/big.bin": "x".repeat(2048) });
   await expect(
     hydrate(store, PREFIX, work, { maxBytes: 1024 }),
-  ).rejects.toThrow(/hydration limit/);
+  ).rejects.toEqual(
+    expect.objectContaining({
+      name: "HydrateLimitError",
+      maxBytes: 1024,
+    }) satisfies Partial<HydrateLimitError>,
+  );
 });
 
 test("missing prefix hydrates to an empty manifest", async () => {

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -57,6 +57,19 @@ export interface HydrateOptions {
   concurrency?: number;
 }
 
+/** The hydrated prefix exceeded the caller's aggregate byte cap. */
+export class HydrateLimitError extends Error {
+  constructor(
+    readonly maxBytes: number,
+    readonly observedBytes: number,
+  ) {
+    super(
+      `workspace exceeds the ${Math.round(maxBytes / 1024 / 1024)} MiB hydration limit`,
+    );
+    this.name = "HydrateLimitError";
+  }
+}
+
 const DEFAULT_HYDRATE_CONCURRENCY = 16;
 
 /** Download everything under `prefix` into `destDir`. Returns the manifest. */
@@ -112,9 +125,7 @@ export async function hydrate(
         const { size } = await stat(dest);
         total += size;
         if (total > maxBytes) {
-          throw new Error(
-            `workspace exceeds the ${Math.round(maxBytes / 1024 / 1024)} MiB hydration limit`,
-          );
+          throw new HydrateLimitError(maxBytes, total);
         }
         manifest.set(rel, { hash: await fileSha256(dest, size), generation });
       } catch (err) {
@@ -133,5 +144,5 @@ export async function hydrate(
   return manifest;
 }
 
-export type { SyncResult } from "./sync-back";
+export type { SyncBackOptions, SyncResult } from "./sync-back";
 export { syncBack } from "./sync-back";

--- a/packages/runtime-client/src/object-sync/index.ts
+++ b/packages/runtime-client/src/object-sync/index.ts
@@ -3,11 +3,13 @@ export { HttpObjectStore } from "./http-store";
 export type {
   HydrateManifest,
   HydrateOptions,
+  SyncBackOptions,
   SyncResult,
 } from "./hydrate";
 export {
   DEFAULT_EXCLUDES,
   excluded,
+  HydrateLimitError,
   hydrate,
   syncBack,
 } from "./hydrate";

--- a/packages/runtime-client/src/object-sync/sync-back-conflicts.ts
+++ b/packages/runtime-client/src/object-sync/sync-back-conflicts.ts
@@ -1,0 +1,149 @@
+import type { HydrateManifestEntry } from "./hydrate";
+import type { ObjectMetadata } from "./object-manifest";
+import {
+  type ObjectStore,
+  ObjectTooLargeError,
+  StoreConflictError,
+  type WriteOptions,
+} from "./object-store";
+
+/** Lazily fetched remote generations shared across one sync pass. */
+export type RefreshManifest = () =>
+  | Promise<Map<string, ObjectMetadata>>
+  | undefined;
+
+/** Result of one upload plus its optional generation retry. */
+export interface UploadChangeResult {
+  entry?: HydrateManifestEntry;
+  uploaded: boolean;
+  skipped?: string;
+  conflict?: string;
+}
+
+function initialWriteOptions(
+  generationAware: boolean,
+  previous: HydrateManifestEntry | undefined,
+): WriteOptions | undefined {
+  if (!generationAware) return undefined;
+  if (previous?.generation !== undefined) {
+    return { ifGenerationMatch: previous.generation };
+  }
+  return previous ? undefined : { ifGenerationMatch: "0" };
+}
+
+/** Upload once, refreshing and retrying one generation conflict. */
+export async function uploadChangedObject(opts: {
+  store: ObjectStore;
+  abs: string;
+  key: string;
+  hash: string;
+  previous?: HydrateManifestEntry;
+  generationAware: boolean;
+  refresh: RefreshManifest;
+}): Promise<UploadChangeResult> {
+  try {
+    const result = await opts.store.upload(
+      opts.abs,
+      opts.key,
+      initialWriteOptions(opts.generationAware, opts.previous),
+    );
+    return {
+      entry: { hash: opts.hash, generation: result?.generation },
+      uploaded: true,
+    };
+  } catch (error) {
+    if (error instanceof ObjectTooLargeError) {
+      return {
+        entry: { hash: opts.hash },
+        uploaded: false,
+        skipped: error.message,
+      };
+    }
+    if (!(error instanceof StoreConflictError)) throw error;
+    const refreshed = await opts.refresh();
+    if (!refreshed) {
+      return {
+        entry: opts.previous,
+        uploaded: false,
+        conflict: error.message,
+      };
+    }
+    const current = refreshed.get(opts.key);
+    const retryGeneration = current ? current.generation : "0";
+    if (retryGeneration === undefined) {
+      return {
+        entry: opts.previous,
+        uploaded: false,
+        conflict: error.message,
+      };
+    }
+    try {
+      const result = await opts.store.upload(opts.abs, opts.key, {
+        ifGenerationMatch: retryGeneration,
+      });
+      return {
+        entry: { hash: opts.hash, generation: result?.generation },
+        uploaded: true,
+      };
+    } catch (retryError) {
+      if (!(retryError instanceof StoreConflictError)) throw retryError;
+      return {
+        entry: opts.previous
+          ? { ...opts.previous, generation: retryGeneration }
+          : undefined,
+        uploaded: false,
+        conflict: retryError.message,
+      };
+    }
+  }
+}
+
+/** Result of one delete plus its optional generation retry. */
+export interface DeleteObjectResult {
+  deleted: boolean;
+  entry?: HydrateManifestEntry;
+  conflict?: string;
+}
+
+/** Delete once, refreshing and retrying one generation conflict. */
+export async function deleteOwnedObject(opts: {
+  store: ObjectStore;
+  key: string;
+  previous: HydrateManifestEntry;
+  generationAware: boolean;
+  refresh: RefreshManifest;
+}): Promise<DeleteObjectResult> {
+  const writeOptions =
+    opts.generationAware && opts.previous.generation !== undefined
+      ? { ifGenerationMatch: opts.previous.generation }
+      : undefined;
+  try {
+    await opts.store.delete(opts.key, writeOptions);
+    return { deleted: true };
+  } catch (error) {
+    if (!(error instanceof StoreConflictError)) throw error;
+    const refreshed = await opts.refresh();
+    if (!refreshed) {
+      return { deleted: false, entry: opts.previous, conflict: error.message };
+    }
+    const current = refreshed.get(opts.key);
+    if (!current) return { deleted: true };
+    const retryGeneration = current.generation;
+    try {
+      await opts.store.delete(
+        opts.key,
+        retryGeneration === undefined
+          ? undefined
+          : { ifGenerationMatch: retryGeneration },
+      );
+      return { deleted: true };
+    } catch (retryError) {
+      if (!(retryError instanceof StoreConflictError)) throw retryError;
+      return {
+        deleted: false,
+        entry: { ...opts.previous, generation: retryGeneration },
+        conflict: retryError.message,
+      };
+    }
+  }
+}

--- a/packages/runtime-client/src/object-sync/sync-back-include.test.ts
+++ b/packages/runtime-client/src/object-sync/sync-back-include.test.ts
@@ -1,0 +1,75 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { fileSha256 } from "./file-hash";
+import { LocalDirStore } from "./object-store";
+import { syncBack } from "./sync-back";
+
+test("include syncs only selected changes and counts the rest", async () => {
+  const storeRoot = await mkdtemp(join(tmpdir(), "sync-store-"));
+  const workRoot = await mkdtemp(join(tmpdir(), "sync-work-"));
+  const store = new LocalDirStore(storeRoot);
+  const seed = async (rel: string, content: string) => {
+    const path = join(workRoot, ...rel.split("/"));
+    await mkdir(join(path, ".."), { recursive: true });
+    await writeFile(path, content);
+    return { hash: await fileSha256(path, content.length) };
+  };
+  const kept = await seed("data/conversations/c1.json", "before");
+  const modified = await seed("workspace/modified.txt", "before");
+  const deleted = await seed("workspace/deleted.txt", "before");
+  for (const rel of [
+    "data/conversations/c1.json",
+    "workspace/modified.txt",
+    "workspace/deleted.txt",
+  ]) {
+    await store.upload(join(workRoot, ...rel.split("/")), rel);
+  }
+  const manifest = new Map([
+    ["data/conversations/c1.json", kept],
+    ["workspace/modified.txt", modified],
+    ["workspace/deleted.txt", deleted],
+  ]);
+
+  await writeFile(join(workRoot, "data/conversations/c1.json"), "after");
+  await writeFile(join(workRoot, "workspace/modified.txt"), "after");
+  await rm(join(workRoot, "workspace/deleted.txt"));
+  await seed("workspace/added.txt", "new");
+
+  const result = await syncBack(store, "", workRoot, manifest, {
+    include: (rel) => rel === "data/conversations/c1.json",
+  });
+
+  expect(result.uploaded).toEqual(["data/conversations/c1.json"]);
+  expect(result.deleted).toEqual([]);
+  expect(result.outOfScope).toBe(3);
+  expect(await store.list("")).toEqual([
+    "data/conversations/c1.json",
+    "workspace/deleted.txt",
+    "workspace/modified.txt",
+  ]);
+});
+
+test("include still deletes an in-scope object the turn removed", async () => {
+  const storeRoot = await mkdtemp(join(tmpdir(), "sync-store-"));
+  const workRoot = await mkdtemp(join(tmpdir(), "sync-work-"));
+  const store = new LocalDirStore(storeRoot);
+  const rotated = "data/sessions/c1/old.jsonl";
+  const path = join(workRoot, ...rotated.split("/"));
+  await mkdir(join(path, ".."), { recursive: true });
+  await writeFile(path, "rotated");
+  await store.upload(path, rotated);
+  const manifest = new Map([
+    [rotated, { hash: await fileSha256(path, "rotated".length) }],
+  ]);
+  await rm(path);
+
+  const result = await syncBack(store, "", workRoot, manifest, {
+    include: (rel) => rel.startsWith("data/sessions/c1/"),
+  });
+
+  expect(result.deleted).toEqual([rotated]);
+  expect(result.outOfScope).toBe(0);
+  expect(await store.list("")).toEqual([]);
+});

--- a/packages/runtime-client/src/object-sync/sync-back.ts
+++ b/packages/runtime-client/src/object-sync/sync-back.ts
@@ -2,19 +2,10 @@ import type { Dirent } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { join, posix, relative, sep } from "node:path";
 import { fileSha256 } from "./file-hash";
-import {
-  DEFAULT_EXCLUDES,
-  excluded,
-  type HydrateManifest,
-  type HydrateManifestEntry,
-} from "./hydrate";
+import { DEFAULT_EXCLUDES, excluded, type HydrateManifest } from "./hydrate";
 import type { ObjectMetadata } from "./object-manifest";
-import {
-  type ObjectStore,
-  ObjectTooLargeError,
-  StoreConflictError,
-  type WriteOptions,
-} from "./object-store";
+import type { ObjectStore } from "./object-store";
+import { deleteOwnedObject, uploadChangedObject } from "./sync-back-conflicts";
 
 export interface SyncResult {
   uploaded: string[];
@@ -34,8 +25,18 @@ export interface SyncResult {
    * be garbage.
    */
   conflicts: { key: string; reason: string }[];
+  /** Changed paths rejected by the caller's write scope. */
+  outOfScope: number;
   /** Bytes the next hydration must materialize, excluding local-only paths. */
   totalBytes: number;
+}
+
+/** Caller policy for exclusions, generations, and permitted write paths. */
+export interface SyncBackOptions {
+  excludes?: string[];
+  generations?: boolean;
+  /** Limit writes and deletes while still detecting skipped changes. */
+  include?: (relativePath: string) => boolean;
 }
 
 async function walkFiles(dir: string, base: string): Promise<string[]> {
@@ -57,24 +58,13 @@ async function walkFiles(dir: string, base: string): Promise<string[]> {
   return out;
 }
 
-function initialWriteOptions(
-  generationAware: boolean,
-  previous: HydrateManifestEntry | undefined,
-): WriteOptions | undefined {
-  if (!generationAware) return undefined;
-  if (previous?.generation !== undefined) {
-    return { ifGenerationMatch: previous.generation };
-  }
-  return previous ? undefined : { ifGenerationMatch: "0" };
-}
-
 /** Upload changes and conditionally remove objects owned by the prior hydrate. */
 export async function syncBack(
   store: ObjectStore,
   prefix: string,
   dir: string,
   manifest: HydrateManifest,
-  opts: { excludes?: string[]; generations?: boolean } = {},
+  opts: SyncBackOptions = {},
 ): Promise<SyncResult> {
   const excludes = opts.excludes ?? DEFAULT_EXCLUDES;
   // opts.generations is the gateway's explicit capability signal (the boot
@@ -92,6 +82,7 @@ export async function syncBack(
   const skipped: SyncResult["skipped"] = [];
   const conflicts: SyncResult["conflicts"] = [];
   const nextManifest: HydrateManifest = new Map();
+  let outOfScope = 0;
   let refreshed: Promise<Map<string, ObjectMetadata>> | undefined;
   const refresh = () => {
     if (!store.manifest) return undefined;
@@ -125,101 +116,60 @@ export async function syncBack(
     }
     totalBytes += size;
     const previous = manifest.get(rel);
+    if (opts.include && !opts.include(rel)) {
+      // Out of the caller's write scope: never uploaded, but still counted
+      // toward the next hydration and kept in the manifest as it was.
+      if (previous?.hash !== hash) outOfScope += 1;
+      if (previous) nextManifest.set(rel, previous);
+      continue;
+    }
     if (previous?.hash === hash) {
       nextManifest.set(rel, previous);
       continue;
     }
 
     const key = prefix ? posix.join(prefix, rel) : rel;
-    try {
-      const result = await store.upload(
-        abs,
-        key,
-        initialWriteOptions(generationAware, previous),
-      );
-      nextManifest.set(rel, { hash, generation: result?.generation });
-      uploaded.push(rel);
-    } catch (err) {
-      if (err instanceof ObjectTooLargeError) {
-        nextManifest.set(rel, { hash });
-        skipped.push({ key: rel, reason: err.message });
-        continue;
-      }
-      if (!(err instanceof StoreConflictError)) throw err;
-      const refreshedManifest = await refresh();
-      if (!refreshedManifest) {
-        if (previous) nextManifest.set(rel, previous);
-        conflicts.push({ key: rel, reason: err.message });
-        continue;
-      }
-      const current = refreshedManifest.get(key);
-      const retryGeneration = current ? current.generation : "0";
-      if (retryGeneration === undefined) {
-        if (previous) nextManifest.set(rel, previous);
-        conflicts.push({ key: rel, reason: err.message });
-        continue;
-      }
-      try {
-        const result = await store.upload(abs, key, {
-          ifGenerationMatch: retryGeneration,
-        });
-        nextManifest.set(rel, { hash, generation: result?.generation });
-        uploaded.push(rel);
-      } catch (retryError) {
-        if (!(retryError instanceof StoreConflictError)) throw retryError;
-        if (previous) {
-          nextManifest.set(rel, { ...previous, generation: retryGeneration });
-        }
-        conflicts.push({ key: rel, reason: retryError.message });
-      }
-    }
+    const result = await uploadChangedObject({
+      store,
+      abs,
+      key,
+      hash,
+      previous,
+      generationAware,
+      refresh,
+    });
+    if (result.entry) nextManifest.set(rel, result.entry);
+    if (result.uploaded) uploaded.push(rel);
+    if (result.skipped) skipped.push({ key: rel, reason: result.skipped });
+    if (result.conflict) conflicts.push({ key: rel, reason: result.conflict });
   }
 
   const deleted: string[] = [];
   for (const [rel, previous] of manifest) {
     if (nextManifest.has(rel)) continue;
-    const key = prefix ? posix.join(prefix, rel) : rel;
-    const writeOptions =
-      generationAware && previous.generation !== undefined
-        ? { ifGenerationMatch: previous.generation }
-        : undefined;
-    try {
-      await store.delete(key, writeOptions);
-      deleted.push(rel);
-    } catch (err) {
-      if (!(err instanceof StoreConflictError)) throw err;
-      const refreshedManifest = await refresh();
-      if (!refreshedManifest) {
-        nextManifest.set(rel, previous);
-        conflicts.push({ key: rel, reason: err.message });
-        continue;
-      }
-      const current = refreshedManifest.get(key);
-      if (!current) {
-        deleted.push(rel);
-        continue;
-      }
-      const retryGeneration = current.generation;
-      try {
-        await store.delete(
-          key,
-          retryGeneration === undefined
-            ? undefined
-            : { ifGenerationMatch: retryGeneration },
-        );
-        deleted.push(rel);
-      } catch (retryError) {
-        if (!(retryError instanceof StoreConflictError)) throw retryError;
-        nextManifest.set(rel, { ...previous, generation: retryGeneration });
-        conflicts.push({ key: rel, reason: retryError.message });
-      }
+    if (opts.include && !opts.include(rel)) {
+      nextManifest.set(rel, previous);
+      outOfScope += 1;
+      continue;
     }
+    const key = prefix ? posix.join(prefix, rel) : rel;
+    const result = await deleteOwnedObject({
+      store,
+      key,
+      previous,
+      generationAware,
+      refresh,
+    });
+    if (result.deleted) deleted.push(rel);
+    if (result.entry) nextManifest.set(rel, result.entry);
+    if (result.conflict) conflicts.push({ key: rel, reason: result.conflict });
   }
   return {
     uploaded,
     deleted,
     skipped,
     conflicts,
+    outOfScope,
     manifest: nextManifest,
     totalBytes,
   };

--- a/packages/runtime-client/src/transcript-turn-request.test.ts
+++ b/packages/runtime-client/src/transcript-turn-request.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "vitest";
+import { transcriptTurnRequest } from "./transcript-turn-request";
+
+test("builds the strict user turn request", () => {
+  const message = {
+    role: "user" as const,
+    content: "hello",
+    ts: 42,
+    turnId: "turn/1",
+  };
+  expect(
+    transcriptTurnRequest("https://gateway.test/conversations/c1", {
+      kind: "user",
+      turnId: "turn/1",
+      message,
+      title: "Greeting",
+      expectedCount: 4,
+    }),
+  ).toEqual({
+    method: "PUT",
+    url: "https://gateway.test/conversations/c1/turns/turn%2F1/user",
+    body: { message, ts: 42, title: "Greeting", expectedCount: 4 },
+  });
+});
+
+test("builds the strict assistant turn request", () => {
+  const message = {
+    role: "assistant" as const,
+    content: "hi",
+    ts: 43,
+    turnId: "turn/1",
+  };
+  expect(
+    transcriptTurnRequest("https://gateway.test/conversations/c1", {
+      kind: "assistant",
+      turnId: "turn/1",
+      message,
+    }),
+  ).toEqual({
+    method: "PUT",
+    url: "https://gateway.test/conversations/c1/turns/turn%2F1/assistant",
+    body: { message, ts: 43 },
+  });
+});

--- a/packages/runtime-client/src/transcript-turn-request.ts
+++ b/packages/runtime-client/src/transcript-turn-request.ts
@@ -1,0 +1,41 @@
+import type { ChatMessage } from "@houston/protocol";
+
+export type TranscriptTurnWrite =
+  | {
+      kind: "user";
+      turnId: string;
+      message: ChatMessage;
+      title: string;
+      expectedCount: number;
+    }
+  | {
+      kind: "assistant";
+      turnId: string;
+      message: ChatMessage;
+    };
+
+/** Build the strict user/assistant PUT shared by every transcript sender. */
+export function transcriptTurnRequest(
+  conversationUrl: string,
+  write: TranscriptTurnWrite,
+) {
+  const url = `${conversationUrl}/turns/${encodeURIComponent(write.turnId)}/${write.kind}`;
+  if (write.kind === "user") {
+    return {
+      method: "PUT" as const,
+      url,
+      body: {
+        message: write.message,
+        ts: write.message.ts,
+        title: write.title,
+        expectedCount: write.expectedCount,
+        // The strict route derives replay state itself and rejects extra keys.
+      },
+    };
+  }
+  return {
+    method: "PUT" as const,
+    url,
+    body: { message: write.message, ts: write.message.ts },
+  };
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -16,6 +16,7 @@
     "@earendil-works/pi-ai": "0.84.2",
     "@earendil-works/pi-coding-agent": "0.84.2",
     "@google-cloud/storage": "7.21.0",
+    "@houston/domain": "workspace:*",
     "@houston/protocol": "workspace:*",
     "@houston/runtime-client": "workspace:*",
     "tsx": "4.23.0",

--- a/packages/runtime/src/auth/credential-health-fingerprint.test.ts
+++ b/packages/runtime/src/auth/credential-health-fingerprint.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, expect, test } from "vitest";
@@ -12,6 +12,7 @@ const { setCustomEndpointConfig } = await import("../ai/openai-compatible");
 const { authFailureActive, noteAuthFailure, resetAuthFailures } = await import(
   "./credential-health"
 );
+const { runWithActingContext } = await import("../session/acting-context");
 
 afterEach(() => resetAuthFailures());
 
@@ -30,4 +31,23 @@ test("an unchanged endpoint keeps its failure mark", () => {
   noteAuthFailure("openai-compatible");
   expect(authFailureActive("openai-compatible")).toBe(true);
   expect(authFailureActive("openai-compatible")).toBe(true);
+});
+
+test("turn-scoped fingerprints read the active turn auth path", () => {
+  const root = mkdtempSync(join(tmpdir(), "houston-turn-credfp-"));
+  const authPath = join(root, "data", "auth.json");
+  mkdirSync(join(root, "data"), { recursive: true });
+  writeFileSync(
+    authPath,
+    JSON.stringify({ openai: { type: "api_key", key: "turn-a" } }),
+  );
+  runWithActingContext({ credentialScopeKey: "u:turn:w:a", authPath }, () => {
+    noteAuthFailure("openai");
+    expect(authFailureActive("openai")).toBe(true);
+    writeFileSync(
+      authPath,
+      JSON.stringify({ openai: { type: "api_key", key: "turn-b" } }),
+    );
+    expect(authFailureActive("openai")).toBe(false);
+  });
 });

--- a/packages/runtime/src/auth/credential-health.ts
+++ b/packages/runtime/src/auth/credential-health.ts
@@ -1,9 +1,11 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { endpointFileIn, OPENAI_COMPATIBLE } from "../ai/openai-compatible";
 import { claudeCredentialsFile } from "../backends/claude/paths";
 import { config } from "../config";
 import {
+  currentActingContext,
   currentCredentialScope,
   isPersonalScope,
 } from "../session/acting-context";
@@ -81,12 +83,14 @@ function fileFingerprint(path: string): string {
  */
 function credentialFingerprint(id: string): string {
   const { key } = currentCredentialScope();
-  const cred = readAuthFile(authPathIn(config.dataDir, key))[id];
+  const activeAuthPath = currentActingContext()?.authPath;
+  const dataDir = activeAuthPath ? dirname(activeAuthPath) : config.dataDir;
+  const cred = readAuthFile(activeAuthPath ?? authPathIn(dataDir, key))[id];
   const stored = cred ? digest(JSON.stringify(cred)) : "absent";
   if (id === "anthropic" && !isPersonalScope(key))
     return `${stored}|${fileFingerprint(claudeCredentialsFile())}`;
   if (id === OPENAI_COMPATIBLE)
-    return `${stored}|${fileFingerprint(endpointFileIn(config.dataDir))}`;
+    return `${stored}|${fileFingerprint(endpointFileIn(dataDir))}`;
   return stored;
 }
 

--- a/packages/runtime/src/main.ts
+++ b/packages/runtime/src/main.ts
@@ -27,17 +27,24 @@ async function start(): Promise<Server> {
   if (config.mode === "turn") {
     const { createTurnServer } = await import("./turn/server");
     const { GcsStore } = await import("./turn/gcs-store");
+    const { poolOnlyFallbackStore } = await import("./turn/turn-store");
     const { LocalDirStore } = await import(
       "@houston/runtime-client/object-sync"
     );
-    if (!config.gcsBucket && !config.localStoreDir) {
+    if (
+      !config.gcsBucket &&
+      !config.localStoreDir &&
+      !process.env.HOUSTON_POOL_STORE_URL
+    ) {
       throw new Error(
-        "turn mode needs HOUSTON_GCS_BUCKET (prod) or HOUSTON_LOCAL_STORE_DIR (dev)",
+        "turn mode needs HOUSTON_GCS_BUCKET, HOUSTON_LOCAL_STORE_DIR, or HOUSTON_POOL_STORE_URL",
       );
     }
     const store = config.gcsBucket
       ? new GcsStore(config.gcsBucket)
-      : new LocalDirStore(config.localStoreDir);
+      : config.localStoreDir
+        ? new LocalDirStore(config.localStoreDir)
+        : poolOnlyFallbackStore();
     const server = createTurnServer({ store, token: config.turnToken });
     server.listen(config.port, config.host, () => {
       console.info("runtime listening", {

--- a/packages/runtime/src/main.ts
+++ b/packages/runtime/src/main.ts
@@ -2,6 +2,10 @@ import type { Server } from "node:http";
 import { initEngineSentry } from "@houston/runtime-client/sentry";
 import { config } from "./config";
 import { installRuntimeLogging } from "./observability/logging";
+import {
+  beginWorkerShutdown,
+  type WorkerRegistration,
+} from "./turn/worker-registration";
 
 // Crash reporting (dormant without SENTRY_DSN — inherited from the host that
 // spawned us: the desktop app's injection or the engine-pod image env). Wired
@@ -23,11 +27,22 @@ const { logger } = installRuntimeLogging({
  *  - turn: the stateless per-turn cloud runtime — POST /turn only, one
  *    hydrate→run→sync cycle per request. Selected with HOUSTON_MODE=turn.
  */
+let workerRegistration: WorkerRegistration | null = null;
+
 async function start(): Promise<Server> {
   if (config.mode === "turn") {
+    const { AdmissionLimiter, turnConcurrency } = await import(
+      "./turn/admission"
+    );
     const { createTurnServer } = await import("./turn/server");
     const { GcsStore } = await import("./turn/gcs-store");
     const { poolOnlyFallbackStore } = await import("./turn/turn-store");
+    const { WorkerRegistration: Registration } = await import(
+      "./turn/worker-registration"
+    );
+    const { loadWorkerRegistrationConfig, turnServerToken } = await import(
+      "./turn/worker-registration-config"
+    );
     const { LocalDirStore } = await import(
       "@houston/runtime-client/object-sync"
     );
@@ -45,16 +60,39 @@ async function start(): Promise<Server> {
       : config.localStoreDir
         ? new LocalDirStore(config.localStoreDir)
         : poolOnlyFallbackStore();
-    const server = createTurnServer({ store, token: config.turnToken });
-    server.listen(config.port, config.host, () => {
-      console.info("runtime listening", {
-        auth: config.turnToken ? "x_internal_token_required" : "open_local_dev",
-        mode: "turn",
-        store: config.gcsBucket
-          ? `gs://${config.gcsBucket}`
-          : config.localStoreDir,
-        url: `http://${config.host}:${config.port}`,
+    const registrationConfig = await loadWorkerRegistrationConfig();
+    const admission = new AdmissionLimiter(turnConcurrency());
+    workerRegistration = registrationConfig
+      ? new Registration(registrationConfig, admission)
+      : null;
+    const token = turnServerToken(config.turnToken, registrationConfig);
+    const server = createTurnServer({
+      store,
+      token,
+      admission,
+      isDraining: () => workerRegistration?.draining ?? false,
+    });
+    await workerRegistration?.start();
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const failed = (error: Error) => reject(error);
+        server.once("error", failed);
+        server.listen(config.port, config.host, () => {
+          server.off("error", failed);
+          resolve();
+        });
       });
+    } catch (error) {
+      await workerRegistration?.stop();
+      throw error;
+    }
+    console.info("runtime listening", {
+      auth: token ? "x_internal_token_required" : "open_local_dev",
+      mode: "turn",
+      store: config.gcsBucket
+        ? `gs://${config.gcsBucket}`
+        : config.localStoreDir,
+      url: `http://${config.host}:${config.port}`,
     });
     return server;
   }
@@ -66,6 +104,7 @@ const server = await start();
 
 let shuttingDown = false;
 let shadowDrain: Promise<void> = Promise.resolve();
+let workerDrain: Promise<void> = Promise.resolve();
 
 // Bounded, best-effort: a scale-to-zero right after a file mutation must give
 // the transcript shadow queue a chance to reach the gateway (its pending sends
@@ -86,6 +125,11 @@ async function drainTranscriptShadow(): Promise<void> {
 
 async function exitNow() {
   await shadowDrain;
+  // Order matters: the draining heartbeat must land BEFORE registration
+  // stops, or stop() aborts the very request that tells the gateway to route
+  // elsewhere and the registry keeps advertising a dead worker for a minute.
+  await workerDrain;
+  await workerRegistration?.stop();
   await logger.close();
   process.exit(0);
 }
@@ -94,13 +138,19 @@ function shutdown(signal: string) {
   if (shuttingDown) return;
   shuttingDown = true;
   logger.info("runtime shutdown requested", { signal });
+  workerDrain = beginWorkerShutdown(signal, workerRegistration);
   shadowDrain = drainTranscriptShadow();
   server.close(() => {
     void exitNow();
   });
-  setTimeout(() => {
-    void exitNow();
-  }, 3000).unref();
+  // A registered pool worker keeps serving its in-flight turn until the
+  // response ends (sync-back + terminal frame); the pod's termination grace is
+  // the hard deadline there. Every other runtime keeps the short forced exit.
+  if (!workerRegistration) {
+    setTimeout(() => {
+      void exitNow();
+    }, 3000).unref();
+  }
 }
 process.on("SIGINT", () => shutdown("SIGINT"));
 process.on("SIGTERM", () => shutdown("SIGTERM"));

--- a/packages/runtime/src/session/acting-context.ts
+++ b/packages/runtime/src/session/acting-context.ts
@@ -32,6 +32,8 @@ export interface ActingContext {
    * `read()` pi makes inside `prepareRequest`.
    */
   credentialScopeKey?: string;
+  /** Explicit auth.json for a throwaway turn root. */
+  authPath?: string;
 }
 
 /** The credential scope of a request with no acting identity: the shared file. */
@@ -84,7 +86,13 @@ export function runWithActingContext<T>(
 ): T {
   // No identity to carry (local single-user, or neither header present): run
   // plainly so the tools see `undefined` and attach nothing.
-  if (!ctx || (!ctx.actingAs && !ctx.actingUser && !ctx.credentialScopeKey))
+  if (
+    !ctx ||
+    (!ctx.actingAs &&
+      !ctx.actingUser &&
+      !ctx.credentialScopeKey &&
+      !ctx.authPath)
+  )
     return fn();
   return store.run(
     {

--- a/packages/runtime/src/session/bus.test.ts
+++ b/packages/runtime/src/session/bus.test.ts
@@ -5,7 +5,9 @@ import {
   evict,
   publish,
   reduceSnapshot,
+  releaseConversation,
   replayAfter,
+  runWithConversationScope,
   snapshot,
   subscribe,
   subscriberCount,
@@ -41,6 +43,30 @@ test("events reach only that conversation's subscribers, stamped with seq", () =
 
   unsubA();
   unsubB();
+});
+
+test("turn scopes isolate the same conversation id across agents and release it", () => {
+  const id = "shared-cid";
+  const a: SequencedFrame[] = [];
+  const b: SequencedFrame[] = [];
+  runWithConversationScope("w/agent-a", () => {
+    subscribe(id, (event) => a.push(event));
+  });
+  runWithConversationScope("w/agent-b", () => {
+    subscribe(id, (event) => b.push(event));
+  });
+  runWithConversationScope("w/agent-a", () => {
+    publish(id, { type: "text", data: "only a" });
+  });
+
+  expect(a.map((event) => event.data)).toEqual(["only a"]);
+  expect(b).toEqual([]);
+  releaseConversation("w/agent-a", id);
+  runWithConversationScope("w/agent-a", () => {
+    expect(snapshot(id).seq).toBe(0);
+    expect(subscriberCount(id)).toBe(0);
+  });
+  releaseConversation("w/agent-b", id);
 });
 
 test("two concurrent conversations never cross, and each has its own seq counter", () => {

--- a/packages/runtime/src/session/bus.ts
+++ b/packages/runtime/src/session/bus.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import {
   type ConversationSnapshot,
   EMPTY_SNAPSHOT as EMPTY,
@@ -9,9 +10,10 @@ import {
 
 /**
  * Per-conversation event bus. This is the ONE place conversation isolation is
- * enforced: subscribers are partitioned by conversation id into disjoint sets, so
- * an event published for conversation A can only ever reach A's subscribers —
- * there is no global firehose for events to leak across conversations.
+ * enforced: subscribers are partitioned by scope + conversation id into
+ * disjoint sets, so an event published for conversation A can only ever reach
+ * A's subscribers — there is no global firehose for events to leak across
+ * conversations or pooled agents.
  *
  * It is also the conversation stream's sequencing authority: every published
  * event runs through a shared StreamChannel (@houston/runtime-client — the
@@ -32,20 +34,30 @@ export { type ConversationSnapshot, reduceSnapshot };
 type Subscriber = (frame: SequencedFrame) => void;
 
 const subscribers = new Map<string, Set<Subscriber>>();
-// One entry per conversation ever published to in this process — kept for the
-// process lifetime because it owns the seq counter (a handful of small objects;
-// conversations are bounded per runtime). Dropped only by evict().
+// Standing-server entries retain the seq counter for process lifetime. Pooled
+// turn entries are explicitly released after cleanup.
 const channels = new Map<string, StreamChannel>();
+const SERVER_SCOPE = "server";
+const scopeStore = new AsyncLocalStorage<string>();
+
+const keyFor = (id: string, scope = scopeStore.getStore() ?? SERVER_SCOPE) =>
+  `${scope}:${id}`;
+
+/** Bind turn-mode bus activity to one workspace/agent scope. */
+export function runWithConversationScope<T>(scope: string, fn: () => T): T {
+  return scopeStore.run(scope, fn);
+}
 
 /** Publish an event to exactly one conversation's subscribers, stamping its seq. */
 export function publish(id: string, event: WireFrame): void {
-  let ch = channels.get(id);
+  const key = keyFor(id);
+  let ch = channels.get(key);
   if (!ch) {
     ch = new StreamChannel();
-    channels.set(id, ch);
+    channels.set(key, ch);
   }
   ch.publish(event, (frame) => {
-    const subs = subscribers.get(id);
+    const subs = subscribers.get(key);
     // Iterate a copy: a callback may (un)subscribe while we fan out.
     if (subs) for (const cb of [...subs]) cb(frame);
   });
@@ -53,23 +65,24 @@ export function publish(id: string, event: WireFrame): void {
 
 /** Subscribe to one conversation's events. Returns an unsubscribe fn. */
 export function subscribe(id: string, cb: Subscriber): () => void {
-  let set = subscribers.get(id);
+  const key = keyFor(id);
+  let set = subscribers.get(key);
   if (!set) {
     set = new Set();
-    subscribers.set(id, set);
+    subscribers.set(key, set);
   }
   set.add(cb);
   return () => {
-    const s = subscribers.get(id);
+    const s = subscribers.get(key);
     if (!s) return;
     s.delete(cb);
-    if (s.size === 0) subscribers.delete(id);
+    if (s.size === 0) subscribers.delete(key);
   };
 }
 
 /** Current in-flight snapshot for a conversation (drives the `sync` frame on connect). */
 export function snapshot(id: string): ConversationSnapshot {
-  return channels.get(id)?.snapshot ?? EMPTY;
+  return channels.get(keyFor(id))?.snapshot ?? EMPTY;
 }
 
 /** Whether any conversation in this runtime currently has an in-flight turn. */
@@ -82,7 +95,7 @@ export function anyTurnRunning(): boolean {
 
 /** Whether THIS conversation currently has an in-flight turn. */
 export function isTurnRunning(id: string): boolean {
-  return channels.get(id)?.snapshot.running ?? false;
+  return channels.get(keyFor(id))?.snapshot.running ?? false;
 }
 
 /**
@@ -94,7 +107,7 @@ export function replayAfter(
   id: string,
   after: number,
 ): SequencedFrame[] | null {
-  const ch = channels.get(id);
+  const ch = channels.get(keyFor(id));
   if (!ch) return after === 0 ? [] : null;
   return ch.replayAfter(after);
 }
@@ -107,10 +120,17 @@ export function replayAfter(
  * Live subscribers stay registered and simply see the next stream, if any.
  */
 export function evict(id: string): void {
-  channels.delete(id);
+  channels.delete(keyFor(id));
+}
+
+/** Drop all process-local state held for a completed pooled turn. */
+export function releaseConversation(scope: string, id: string): void {
+  const key = keyFor(id, scope);
+  channels.delete(key);
+  subscribers.delete(key);
 }
 
 /** Live subscriber count for a conversation (tests / diagnostics). */
 export function subscriberCount(id: string): number {
-  return subscribers.get(id)?.size ?? 0;
+  return subscribers.get(keyFor(id))?.size ?? 0;
 }

--- a/packages/runtime/src/store/transcript-shadow-http.ts
+++ b/packages/runtime/src/store/transcript-shadow-http.ts
@@ -1,3 +1,4 @@
+import { transcriptTurnRequest } from "@houston/runtime-client";
 import type {
   TranscriptShadowSend,
   TranscriptShadowTransport,
@@ -40,22 +41,9 @@ export class SandboxTranscriptShadowTransport
 function requestFor(root: string, operation: TranscriptShadowSend) {
   switch (operation.kind) {
     case "user":
-      return {
-        method: "PUT",
-        url: `${root}/turns/${encodeURIComponent(operation.turnId)}/user`,
-        body: {
-          message: operation.message,
-          ts: operation.message.ts,
-          title: operation.title,
-          expectedCount: operation.expectedCount,
-        },
-      };
+      return transcriptTurnRequest(root, operation);
     case "assistant":
-      return {
-        method: "PUT",
-        url: `${root}/turns/${encodeURIComponent(operation.turnId)}/assistant`,
-        body: { message: operation.message, ts: operation.message.ts },
-      };
+      return transcriptTurnRequest(root, operation);
     case "truncate":
       return {
         method: "POST",

--- a/packages/runtime/src/transport/mentions.test.ts
+++ b/packages/runtime/src/transport/mentions.test.ts
@@ -6,13 +6,13 @@ import {
   parseMentions,
 } from "@houston/protocol";
 import { expect, test } from "vitest";
-import { parseTurnRequest } from "../turn/types";
+import { parseTurnRequest } from "../turn/parse-turn-request";
 
 /**
  * The @mention send-body guard (HOU-944). `parseMentions` is the ONE place a
  * mention sidecar is trusted — the long-lived send route
  * (`conversation-routes.ts` → `handleStartTurn`), the cloud turn parser
- * (`turn/types.ts` → `parseTurnRequest`) and the host's forwarding hop all call
+ * (`turn/parse-turn-request.ts`) and the host's forwarding hop all call
  * it — so a junk shape can never reach the transcript or the wire. It lives in
  * `@houston/protocol` beside `normalizeTurnMode` and is exercised here, where
  * both runtime readers live.

--- a/packages/runtime/src/turn/admission.test.ts
+++ b/packages/runtime/src/turn/admission.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "vitest";
+import { AdmissionLimiter } from "./admission";
+
+test("admission rejects work at capacity and reuses a released slot", () => {
+  const limiter = new AdmissionLimiter(1);
+  const release = limiter.tryAcquire();
+  expect(release).toBeTypeOf("function");
+  expect(limiter.tryAcquire()).toBeNull();
+  release?.();
+  expect(limiter.tryAcquire()).toBeTypeOf("function");
+});
+
+test("release is idempotent and cannot over-credit capacity", () => {
+  const limiter = new AdmissionLimiter(1);
+  const release = limiter.tryAcquire();
+  release?.();
+  release?.();
+  expect(limiter.tryAcquire()).toBeTypeOf("function");
+  expect(limiter.tryAcquire()).toBeNull();
+});

--- a/packages/runtime/src/turn/admission.test.ts
+++ b/packages/runtime/src/turn/admission.test.ts
@@ -3,10 +3,14 @@ import { AdmissionLimiter } from "./admission";
 
 test("admission rejects work at capacity and reuses a released slot", () => {
   const limiter = new AdmissionLimiter(1);
+  expect(limiter.capacity).toBe(1);
+  expect(limiter.active).toBe(0);
   const release = limiter.tryAcquire();
+  expect(limiter.active).toBe(1);
   expect(release).toBeTypeOf("function");
   expect(limiter.tryAcquire()).toBeNull();
   release?.();
+  expect(limiter.active).toBe(0);
   expect(limiter.tryAcquire()).toBeTypeOf("function");
 });
 

--- a/packages/runtime/src/turn/admission.ts
+++ b/packages/runtime/src/turn/admission.ts
@@ -1,22 +1,32 @@
 /** Process-local admission guard for bounded pooled-turn concurrency. */
 export class AdmissionLimiter {
-  private active = 0;
+  private activeCount = 0;
 
-  constructor(private readonly capacity: number) {
-    if (!Number.isInteger(capacity) || capacity < 1) {
+  constructor(private readonly capacityValue: number) {
+    if (!Number.isInteger(capacityValue) || capacityValue < 1) {
       throw new Error("turn concurrency must be a positive integer");
     }
   }
 
+  /** Maximum simultaneous turns this worker admits. */
+  get capacity(): number {
+    return this.capacityValue;
+  }
+
+  /** Turns currently holding an admission slot. */
+  get active(): number {
+    return this.activeCount;
+  }
+
   /** Acquire a slot, returning an idempotent release function when available. */
   tryAcquire(): (() => void) | null {
-    if (this.active >= this.capacity) return null;
-    this.active += 1;
+    if (this.activeCount >= this.capacityValue) return null;
+    this.activeCount += 1;
     let released = false;
     return () => {
       if (released) return;
       released = true;
-      this.active -= 1;
+      this.activeCount -= 1;
     };
   }
 }

--- a/packages/runtime/src/turn/admission.ts
+++ b/packages/runtime/src/turn/admission.ts
@@ -1,0 +1,32 @@
+/** Process-local admission guard for bounded pooled-turn concurrency. */
+export class AdmissionLimiter {
+  private active = 0;
+
+  constructor(private readonly capacity: number) {
+    if (!Number.isInteger(capacity) || capacity < 1) {
+      throw new Error("turn concurrency must be a positive integer");
+    }
+  }
+
+  /** Acquire a slot, returning an idempotent release function when available. */
+  tryAcquire(): (() => void) | null {
+    if (this.active >= this.capacity) return null;
+    this.active += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.active -= 1;
+    };
+  }
+}
+
+/** Parse the configured turn capacity, defaulting to one. */
+export function turnConcurrency(value = process.env.HOUSTON_TURN_CONCURRENCY) {
+  if (value === undefined || value === "") return 1;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error("HOUSTON_TURN_CONCURRENCY must be a positive integer");
+  }
+  return parsed;
+}

--- a/packages/runtime/src/turn/claim-heartbeat.test.ts
+++ b/packages/runtime/src/turn/claim-heartbeat.test.ts
@@ -1,0 +1,55 @@
+import { expect, test, vi } from "vitest";
+import { startClaimHeartbeat } from "./claim-heartbeat";
+
+const claim = {
+  id: "claim-1",
+  bootId: "boot-1",
+  token: "claim-token",
+  heartbeatUrl: "https://gateway.test/heartbeat",
+};
+
+test("heartbeat posts the claim grant with the host token and stops", async () => {
+  const calls: Array<{ body: unknown; headers: Headers }> = [];
+  const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+    calls.push({
+      body: JSON.parse(String(init?.body)),
+      headers: new Headers(init?.headers),
+    });
+    return new Response(null, { status: 204 });
+  });
+  const heartbeat = startClaimHeartbeat({
+    claim,
+    hostToken: "host-token",
+    fetchImpl,
+    intervalMs: 5,
+  });
+  await vi.waitFor(() => expect(calls.length).toBeGreaterThan(1));
+  await heartbeat.stop();
+  const stoppedAt = calls.length;
+  await new Promise((resolve) => setTimeout(resolve, 15));
+
+  expect(calls).toContainEqual({
+    body: { id: "claim-1", token: "claim-token", bootId: "boot-1" },
+    headers: expect.any(Headers),
+  });
+  expect(calls[0]?.headers.get("authorization")).toBe("Bearer host-token");
+  expect(calls.length).toBe(stoppedAt);
+  expect(heartbeat.fenced).toBe(false);
+});
+
+test("a 409 fences the claim", async () => {
+  let status = 204;
+  const heartbeat = startClaimHeartbeat({
+    claim,
+    hostToken: "host-token",
+    fetchImpl: async () =>
+      new Response(status === 204 ? null : "heartbeat", { status }),
+    intervalMs: 60_000,
+  });
+  await heartbeat.ready;
+  expect(heartbeat.fenced).toBe(false);
+  status = 409;
+  await heartbeat.checkpoint();
+  expect(heartbeat.fenced).toBe(true);
+  await heartbeat.stop();
+});

--- a/packages/runtime/src/turn/claim-heartbeat.test.ts
+++ b/packages/runtime/src/turn/claim-heartbeat.test.ts
@@ -37,19 +37,26 @@ test("heartbeat posts the claim grant with the host token and stops", async () =
   expect(heartbeat.fenced).toBe(false);
 });
 
-test("a 409 fences the claim", async () => {
+test("a 409 fences the claim and fires onFenced once", async () => {
   let status = 204;
+  const onFenced = vi.fn();
   const heartbeat = startClaimHeartbeat({
     claim,
     hostToken: "host-token",
     fetchImpl: async () =>
       new Response(status === 204 ? null : "heartbeat", { status }),
     intervalMs: 60_000,
+    onFenced,
   });
   await heartbeat.ready;
   expect(heartbeat.fenced).toBe(false);
+  expect(onFenced).not.toHaveBeenCalled();
   status = 409;
   await heartbeat.checkpoint();
   expect(heartbeat.fenced).toBe(true);
+  expect(onFenced).toHaveBeenCalledOnce();
+  // Fenced is terminal: later checkpoints do not beat again.
+  await heartbeat.checkpoint();
+  expect(onFenced).toHaveBeenCalledOnce();
   await heartbeat.stop();
 });

--- a/packages/runtime/src/turn/claim-heartbeat.ts
+++ b/packages/runtime/src/turn/claim-heartbeat.ts
@@ -1,0 +1,83 @@
+import type { TurnRequest } from "./types";
+
+const REQUEST_TIMEOUT_MS = 5_000;
+
+/** Per-claim heartbeat state owned by one admitted turn. */
+export interface ClaimHeartbeat {
+  readonly fenced: boolean;
+  /** Completion of the eager first heartbeat. */
+  readonly ready: Promise<void>;
+  /** Send and await a fresh heartbeat at a durability boundary. */
+  checkpoint(): Promise<void>;
+  /** Stop scheduling heartbeats and await the bounded in-flight request. */
+  stop(): Promise<void>;
+}
+
+/** Start the eager, 15-second claim heartbeat loop for one turn. */
+export function startClaimHeartbeat(opts: {
+  claim: NonNullable<TurnRequest["claim"]>;
+  hostToken: string;
+  fetchImpl?: typeof fetch;
+  intervalMs?: number;
+}): ClaimHeartbeat {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const intervalMs = opts.intervalMs ?? 15_000;
+  let fenced = false;
+  let stopped = false;
+  let pending = Promise.resolve();
+
+  const beat = async () => {
+    if (stopped || fenced) return;
+    try {
+      const response = await fetchImpl(opts.claim.heartbeatUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${opts.hostToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          id: opts.claim.id,
+          token: opts.claim.token,
+          bootId: opts.claim.bootId,
+        }),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      if (response.status === 409) {
+        fenced = true;
+        clearInterval(timer);
+      } else if (!response.ok) {
+        console.warn(
+          `[turn] claim heartbeat failed (${response.status}): ${(
+            await response.text()
+          ).slice(0, 300)}`,
+        );
+      }
+    } catch (error) {
+      console.warn(
+        "[turn] claim heartbeat failed:",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  };
+  const runBeat = () => {
+    pending = pending.then(beat);
+    return pending;
+  };
+  const timer = setInterval(runBeat, intervalMs);
+  timer.unref?.();
+  runBeat();
+  const ready = pending;
+
+  return {
+    get fenced() {
+      return fenced;
+    },
+    ready,
+    checkpoint: runBeat,
+    async stop() {
+      stopped = true;
+      clearInterval(timer);
+      await pending;
+    },
+  };
+}

--- a/packages/runtime/src/turn/claim-heartbeat.ts
+++ b/packages/runtime/src/turn/claim-heartbeat.ts
@@ -19,6 +19,8 @@ export function startClaimHeartbeat(opts: {
   hostToken: string;
   fetchImpl?: typeof fetch;
   intervalMs?: number;
+  /** Fired once, the moment a heartbeat learns the claim was adopted. */
+  onFenced?: () => void;
 }): ClaimHeartbeat {
   const fetchImpl = opts.fetchImpl ?? fetch;
   const intervalMs = opts.intervalMs ?? 15_000;
@@ -45,6 +47,7 @@ export function startClaimHeartbeat(opts: {
       if (response.status === 409) {
         fenced = true;
         clearInterval(timer);
+        opts.onFenced?.();
       } else if (!response.ok) {
         console.warn(
           `[turn] claim heartbeat failed (${response.status}): ${(

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -1,0 +1,188 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { WireFrame } from "@houston/runtime-client";
+import { hydrate, syncBack } from "@houston/runtime-client/object-sync";
+import { applyServedCredential } from "../auth/auth-file";
+import { runWithActingContext } from "../session/acting-context";
+import { releaseConversation, runWithConversationScope } from "../session/bus";
+import { openSSE } from "../transport/sse";
+import { startClaimHeartbeat } from "./claim-heartbeat";
+import type { TurnServerDeps } from "./server-types";
+import { createTurnLog } from "./turn-log";
+import { createTurnModelRuntime } from "./turn-runtime";
+import { runPiTurn, type TurnOutcome } from "./turn-session";
+import { resolveTurnStore } from "./turn-store";
+import type { TurnRequest } from "./types";
+
+/** Execute one admitted turn inside an isolated, disposable filesystem root. */
+export async function executeTurn(
+  deps: TurnServerDeps,
+  turn: TurnRequest,
+  req: IncomingMessage,
+  res: ServerResponse,
+  timings: Record<string, number>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "houston-turn-"));
+  timings.t_tmpdir = performance.now();
+  const scope = `${turn.workspaceId}/${turn.agentId}`;
+  const abort = new AbortController();
+  req.on("close", () => abort.abort());
+  let heartbeat: ReturnType<typeof startClaimHeartbeat> | null = null;
+  let closeSse: (() => void) | undefined;
+  try {
+    const resolved = resolveTurnStore(turn, deps.store, {
+      poolStoreUrl: deps.poolStoreUrl,
+      fetchImpl: deps.fetchImpl,
+    });
+    heartbeat =
+      turn.claim && turn.hostToken
+        ? startClaimHeartbeat({
+            claim: turn.claim,
+            hostToken: turn.hostToken,
+            ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+            ...(deps.heartbeatIntervalMs
+              ? { intervalMs: deps.heartbeatIntervalMs }
+              : {}),
+          })
+        : null;
+    const manifest = await hydrate(resolved.store, resolved.prefix, root);
+    timings.t_hydrated = performance.now();
+    await mkdir(join(root, "workspace"), { recursive: true });
+    const dataDir = join(root, "data");
+    await mkdir(dataDir, { recursive: true });
+    const authPath = join(dataDir, "auth.json");
+    if (turn.credential) applyServedCredential(authPath, turn.credential);
+    timings.t_cred_written = performance.now();
+
+    const sse = openSSE(res);
+    closeSse = sse.close;
+    timings.t_sse_open = performance.now();
+    const turnId = turn.turnId ?? crypto.randomUUID();
+    const turnLog = createTurnLog(deps, turn);
+    const emit = (frame: WireFrame) => {
+      sse.send(turnLog ? turnLog.record(frame) : frame);
+    };
+
+    if (turn.shadow) {
+      try {
+        if (!turn.credential) throw new Error("shadow turn needs a credential");
+        await createTurnModelRuntime(
+          dataDir,
+          turn.credential.provider,
+          turn.model,
+          timings,
+        );
+        emit({
+          type: "shadow",
+          data: { ...timings, hydratedObjects: manifest.size },
+          turnId,
+          // SAFETY: shadow is an internal turn-server control frame. It uses
+          // the WireFrame transport without entering the public protocol.
+        } as unknown as WireFrame);
+        emit({ type: "done", data: null, turnId });
+      } catch (error) {
+        emit({
+          type: "error",
+          data: {
+            message: error instanceof Error ? error.message : String(error),
+          },
+          turnId,
+        });
+      }
+    } else {
+      let outcome: TurnOutcome;
+      let runtimeFailed = false;
+      if (!turn.credential) {
+        emit({
+          type: "user",
+          data: {
+            content: turn.text,
+            ts: Date.now(),
+            nonce: turn.nonce,
+            mentions: turn.mentions,
+          },
+          turnId,
+        });
+        outcome = {
+          error: "No provider connected. Connect your subscription first.",
+        };
+      } else {
+        const run = deps.runTurn ?? runPiTurn;
+        try {
+          outcome = await runWithConversationScope(scope, () =>
+            runWithActingContext(
+              {
+                credentialScopeKey: `u:turn:${turn.workspaceId}:${turn.agentId}`,
+                authPath,
+                ...(turn.actingAs ? { actingUser: turn.actingAs.userId } : {}),
+              },
+              () =>
+                run(root, {
+                  conversationId: turn.conversationId,
+                  text: turn.text,
+                  provider: turn.credential?.provider ?? "",
+                  emit,
+                  signal: abort.signal,
+                  nonce: turn.nonce,
+                  pin: { model: turn.model, effort: turn.effort },
+                  mode: turn.mode,
+                  turnId,
+                  displayText: turn.displayText,
+                  mentions: turn.mentions,
+                  author: turn.actingAs,
+                }),
+            ),
+          );
+        } catch (error) {
+          runtimeFailed = true;
+          outcome = {
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      }
+
+      await heartbeat?.checkpoint();
+      if (heartbeat?.fenced) {
+        outcome = { error: "claim_fenced" };
+      } else if (!runtimeFailed) {
+        try {
+          await syncBack(resolved.store, resolved.prefix, root, manifest);
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          outcome = {
+            error: outcome.error
+              ? `${outcome.error}; sync failed: ${message}`
+              : `workspace sync failed: ${message}`,
+          };
+        }
+      }
+      if (outcome.error) {
+        emit({ type: "error", data: { message: outcome.error }, turnId });
+      } else {
+        emit({
+          type: "done",
+          data: null,
+          turnId,
+          ...(outcome.pendingInteraction
+            ? { pendingInteraction: outcome.pendingInteraction }
+            : {}),
+        });
+      }
+      await turnLog?.flush();
+    }
+  } finally {
+    try {
+      await heartbeat?.stop();
+    } finally {
+      releaseConversation(scope, turn.conversationId);
+      try {
+        await rm(root, { recursive: true, force: true });
+      } finally {
+        closeSse?.();
+      }
+    }
+  }
+}

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -8,6 +8,7 @@ import { runWithActingContext } from "../session/acting-context";
 import { releaseConversation, runWithConversationScope } from "../session/bus";
 import { openSSE } from "../transport/sse";
 import { startClaimHeartbeat } from "./claim-heartbeat";
+import { piTurnRequest } from "./pi-turn-request";
 import type { TurnServerDeps } from "./server-types";
 import { finishTurnDurability } from "./turn-durability";
 import { prepareTurnFilesystem } from "./turn-filesystem";
@@ -132,20 +133,10 @@ export async function executeTurn(
                 ...(turn.actingAs ? { actingUser: turn.actingAs.userId } : {}),
               },
               () =>
-                run(filesystem, {
-                  conversationId: turn.conversationId,
-                  text: turn.text,
-                  provider: turn.credential?.provider ?? "",
-                  emit,
-                  signal: abort.signal,
-                  nonce: turn.nonce,
-                  pin: { model: turn.model, effort: turn.effort },
-                  mode: turn.mode,
-                  turnId,
-                  displayText: turn.displayText,
-                  mentions: turn.mentions,
-                  author: turn.actingAs,
-                }),
+                run(
+                  filesystem,
+                  piTurnRequest(turn, turnId, emit, abort.signal),
+                ),
             ),
           );
         } catch (error) {

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -18,6 +18,7 @@ import { createTurnModelRuntime } from "./turn-runtime";
 import { runPiTurn, type TurnOutcome } from "./turn-session";
 import { resolveTurnStore } from "./turn-store";
 import { turnSetupErrorFrame, turnTerminalFrame } from "./turn-terminal";
+import { createTurnTranscript } from "./turn-transcript";
 import type { TurnRequest } from "./types";
 
 /** Execute one admitted turn inside an isolated, disposable filesystem root. */
@@ -76,8 +77,17 @@ export async function executeTurn(
     closeSse = sse.close;
     timings.t_sse_open = performance.now();
     const turnLog = createTurnLog(deps, turn);
+    const transcript = createTurnTranscript(
+      deps,
+      { ...turn, turnId },
+      filesystem,
+    );
     const emit = (frame: WireFrame) => {
       sse.send(turnLog ? turnLog.record(frame) : frame);
+      // The runtime persists the user message right before this frame; land
+      // its transcript row now so a gateway that restarts mid-turn can rebuild
+      // the turn. Errors are remembered and surfaced at durability time.
+      if (frame.type === "user") void transcript?.publishUser();
     };
 
     if (turn.shadow) {
@@ -153,6 +163,7 @@ export async function executeTurn(
         resolved,
         heartbeat,
         outcome,
+        transcript,
       });
       outcome = durable.outcome;
       emit(

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -93,7 +93,6 @@ export async function executeTurn(
       }
     } else {
       let outcome: TurnOutcome;
-      let runtimeFailed = false;
       if (!turn.credential) {
         emit({
           type: "user",
@@ -136,7 +135,6 @@ export async function executeTurn(
             ),
           );
         } catch (error) {
-          runtimeFailed = true;
           outcome = {
             error: error instanceof Error ? error.message : String(error),
           };
@@ -146,7 +144,13 @@ export async function executeTurn(
       await heartbeat?.checkpoint();
       if (heartbeat?.fenced) {
         outcome = { error: "claim_fenced" };
-      } else if (!runtimeFailed) {
+      } else {
+        // Durability BEFORE the terminal frame, and REGARDLESS of how the
+        // runtime fared: a failed turn may still have made workspace progress
+        // (tool writes before the provider died), and dropping it silently
+        // was never the contract. Only a fenced claim skips the sync — that
+        // pod is no longer the writer. A sync failure surfaces as (part of)
+        // the turn's error, never a quiet done.
         try {
           await syncBack(resolved.store, resolved.prefix, root, manifest);
         } catch (error) {

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -9,7 +9,8 @@ import { releaseConversation, runWithConversationScope } from "../session/bus";
 import { openSSE } from "../transport/sse";
 import { startClaimHeartbeat } from "./claim-heartbeat";
 import type { TurnServerDeps } from "./server-types";
-import { prepareTurnFilesystem, syncTurnFilesystem } from "./turn-filesystem";
+import { finishTurnDurability } from "./turn-durability";
+import { prepareTurnFilesystem } from "./turn-filesystem";
 import { TurnSetupError } from "./turn-layout";
 import { createTurnLog } from "./turn-log";
 import { createTurnModelRuntime } from "./turn-runtime";
@@ -149,36 +150,23 @@ export async function executeTurn(
         }
       }
 
-      let poolWritesOutOfScope = 0;
-      await heartbeat?.checkpoint();
-      if (heartbeat?.fenced) {
-        outcome = { error: "claim_fenced" };
-      } else {
-        // Durability BEFORE the terminal frame, and REGARDLESS of how the
-        // runtime fared: a failed turn may still have made workspace progress
-        // (tool writes before the provider died), and dropping it silently
-        // was never the contract. Only a fenced claim skips the sync — that
-        // pod is no longer the writer. A sync failure surfaces as (part of)
-        // the turn's error, never a quiet done.
-        try {
-          poolWritesOutOfScope = await syncTurnFilesystem({
-            store: resolved.store,
-            prefix: resolved.prefix,
-            filesystem,
-            conversationId: turn.conversationId,
-            claimed: Boolean(turn.claim),
-          });
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          outcome = {
-            error: outcome.error
-              ? `${outcome.error}; sync failed: ${message}`
-              : `workspace sync failed: ${message}`,
-          };
-        }
-      }
-      emit(turnTerminalFrame(outcome, turnId, poolWritesOutOfScope));
+      const durable = await finishTurnDurability({
+        deps,
+        turn: { ...turn, turnId },
+        filesystem,
+        resolved,
+        heartbeat,
+        outcome,
+      });
+      outcome = durable.outcome;
+      emit(
+        turnTerminalFrame(
+          outcome,
+          turnId,
+          durable.poolWritesOutOfScope,
+          durable.transcriptSkipped,
+        ),
+      );
       await turnLog?.flush();
     }
   } catch (error) {

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -1,19 +1,21 @@
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { WireFrame } from "@houston/runtime-client";
-import { hydrate, syncBack } from "@houston/runtime-client/object-sync";
 import { applyServedCredential } from "../auth/auth-file";
 import { runWithActingContext } from "../session/acting-context";
 import { releaseConversation, runWithConversationScope } from "../session/bus";
 import { openSSE } from "../transport/sse";
 import { startClaimHeartbeat } from "./claim-heartbeat";
 import type { TurnServerDeps } from "./server-types";
+import { prepareTurnFilesystem, syncTurnFilesystem } from "./turn-filesystem";
+import { TurnSetupError } from "./turn-layout";
 import { createTurnLog } from "./turn-log";
 import { createTurnModelRuntime } from "./turn-runtime";
 import { runPiTurn, type TurnOutcome } from "./turn-session";
 import { resolveTurnStore } from "./turn-store";
+import { turnSetupErrorFrame, turnTerminalFrame } from "./turn-terminal";
 import type { TurnRequest } from "./types";
 
 /** Execute one admitted turn inside an isolated, disposable filesystem root. */
@@ -29,6 +31,7 @@ export async function executeTurn(
   const scope = `${turn.workspaceId}/${turn.agentId}`;
   const abort = new AbortController();
   req.on("close", () => abort.abort());
+  const turnId = turn.turnId ?? crypto.randomUUID();
   let heartbeat: ReturnType<typeof startClaimHeartbeat> | null = null;
   let closeSse: (() => void) | undefined;
   try {
@@ -47,11 +50,17 @@ export async function executeTurn(
               : {}),
           })
         : null;
-    const manifest = await hydrate(resolved.store, resolved.prefix, root);
+    const filesystem = await prepareTurnFilesystem({
+      store: resolved.store,
+      prefix: resolved.prefix,
+      root,
+      claimed: Boolean(turn.claim),
+      ...(deps.maxHydrateBytes !== undefined
+        ? { maxBytes: deps.maxHydrateBytes }
+        : {}),
+    });
     timings.t_hydrated = performance.now();
-    await mkdir(join(root, "workspace"), { recursive: true });
-    const dataDir = join(root, "data");
-    await mkdir(dataDir, { recursive: true });
+    const { dataDir } = filesystem;
     const authPath = join(dataDir, "auth.json");
     if (turn.credential) applyServedCredential(authPath, turn.credential);
     timings.t_cred_written = performance.now();
@@ -59,7 +68,6 @@ export async function executeTurn(
     const sse = openSSE(res);
     closeSse = sse.close;
     timings.t_sse_open = performance.now();
-    const turnId = turn.turnId ?? crypto.randomUUID();
     const turnLog = createTurnLog(deps, turn);
     const emit = (frame: WireFrame) => {
       sse.send(turnLog ? turnLog.record(frame) : frame);
@@ -76,7 +84,7 @@ export async function executeTurn(
         );
         emit({
           type: "shadow",
-          data: { ...timings, hydratedObjects: manifest.size },
+          data: { ...timings, hydratedObjects: filesystem.manifest.size },
           turnId,
           // SAFETY: shadow is an internal turn-server control frame. It uses
           // the WireFrame transport without entering the public protocol.
@@ -118,7 +126,7 @@ export async function executeTurn(
                 ...(turn.actingAs ? { actingUser: turn.actingAs.userId } : {}),
               },
               () =>
-                run(root, {
+                run(filesystem, {
                   conversationId: turn.conversationId,
                   text: turn.text,
                   provider: turn.credential?.provider ?? "",
@@ -141,6 +149,7 @@ export async function executeTurn(
         }
       }
 
+      let poolWritesOutOfScope = 0;
       await heartbeat?.checkpoint();
       if (heartbeat?.fenced) {
         outcome = { error: "claim_fenced" };
@@ -152,7 +161,13 @@ export async function executeTurn(
         // pod is no longer the writer. A sync failure surfaces as (part of)
         // the turn's error, never a quiet done.
         try {
-          await syncBack(resolved.store, resolved.prefix, root, manifest);
+          poolWritesOutOfScope = await syncTurnFilesystem({
+            store: resolved.store,
+            prefix: resolved.prefix,
+            filesystem,
+            conversationId: turn.conversationId,
+            claimed: Boolean(turn.claim),
+          });
         } catch (error) {
           const message =
             error instanceof Error ? error.message : String(error);
@@ -163,20 +178,14 @@ export async function executeTurn(
           };
         }
       }
-      if (outcome.error) {
-        emit({ type: "error", data: { message: outcome.error }, turnId });
-      } else {
-        emit({
-          type: "done",
-          data: null,
-          turnId,
-          ...(outcome.pendingInteraction
-            ? { pendingInteraction: outcome.pendingInteraction }
-            : {}),
-        });
-      }
+      emit(turnTerminalFrame(outcome, turnId, poolWritesOutOfScope));
       await turnLog?.flush();
     }
+  } catch (error) {
+    if (!(error instanceof TurnSetupError)) throw error;
+    const sse = openSSE(res);
+    closeSse = sse.close;
+    sse.send(turnSetupErrorFrame(error, turnId));
   } finally {
     try {
       await heartbeat?.stop();

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -31,7 +31,11 @@ export async function executeTurn(
   timings.t_tmpdir = performance.now();
   const scope = `${turn.workspaceId}/${turn.agentId}`;
   const abort = new AbortController();
-  req.on("close", () => abort.abort());
+  // A CLAIMED turn's lifetime is the claim, not the HTTP connection: the
+  // gateway may lose its stream and re-attach through the turnlog, so a
+  // dropped socket must not abort the work; a fenced heartbeat (the claim was
+  // released or adopted) must. Unclaimed turns keep the connection contract.
+  if (!turn.claim) req.on("close", () => abort.abort());
   const turnId = turn.turnId ?? crypto.randomUUID();
   let heartbeat: ReturnType<typeof startClaimHeartbeat> | null = null;
   let closeSse: (() => void) | undefined;
@@ -45,6 +49,7 @@ export async function executeTurn(
         ? startClaimHeartbeat({
             claim: turn.claim,
             hostToken: turn.hostToken,
+            onFenced: () => abort.abort(),
             ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
             ...(deps.heartbeatIntervalMs
               ? { intervalMs: deps.heartbeatIntervalMs }

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -172,6 +172,7 @@ export async function executeTurn(
           turnId,
           durable.poolWritesOutOfScope,
           durable.transcriptSkipped,
+          durable.activityDocSkipped,
         ),
       );
       await turnLog?.flush();

--- a/packages/runtime/src/turn/parse-turn-request.ts
+++ b/packages/runtime/src/turn/parse-turn-request.ts
@@ -1,0 +1,171 @@
+import { normalizeTurnMode, parseMentions } from "@houston/protocol";
+import type { ServedCredential } from "../auth/auth-file";
+import type { TurnRequest } from "./types";
+
+const ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const PREFIX = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$/;
+
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`invalid '${field}'`);
+  }
+  // SAFETY: the object/array check establishes the string-keyed JSON record
+  // shape; every consumed property is parsed again below.
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  field: string,
+): void {
+  if (Object.keys(value).some((key) => !allowed.includes(key))) {
+    throw new Error(`invalid '${field}'`);
+  }
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+/** Validate an untyped body into a TurnRequest. Throws with the real reason. */
+export function parseTurnRequest(body: unknown): TurnRequest {
+  const b = body as Record<string, unknown>;
+  if (!b || typeof b !== "object")
+    throw new Error("body must be a JSON object");
+  for (const field of ["workspaceId", "agentId", "conversationId"] as const) {
+    if (typeof b[field] !== "string" || !ID.test(b[field] as string)) {
+      throw new Error(`invalid '${field}'`);
+    }
+  }
+  if (typeof b.text !== "string" || !b.text.length)
+    throw new Error("missing 'text'");
+  const prefix = b.gcsPrefix;
+  if (
+    typeof prefix !== "string" ||
+    !PREFIX.test(prefix) ||
+    prefix.includes("..")
+  ) {
+    throw new Error("invalid 'gcsPrefix'");
+  }
+  let credential: ServedCredential | null = null;
+  if (b.credential != null) {
+    const c = b.credential as Record<string, unknown>;
+    if (
+      typeof c.provider !== "string" ||
+      typeof c.access !== "string" ||
+      typeof c.expires !== "number"
+    ) {
+      throw new Error("invalid 'credential'");
+    }
+    credential = {
+      provider: c.provider,
+      access: c.access,
+      expires: c.expires,
+      accountId: typeof c.accountId === "string" ? c.accountId : null,
+      kind: c.kind === "api_key" ? "api_key" : "oauth",
+      // Copilot Enterprise routes to a per-tenant API host; dropping it here
+      // would silently turn an enterprise credential into a github.com one.
+      ...(typeof c.enterpriseUrl === "string" && c.enterpriseUrl
+        ? { enterpriseUrl: c.enterpriseUrl }
+        : {}),
+    };
+  }
+  if (b.turnId !== undefined && (!nonEmpty(b.turnId) || !ID.test(b.turnId))) {
+    throw new Error("invalid 'turnId'");
+  }
+  if (b.hostToken !== undefined && !nonEmpty(b.hostToken)) {
+    throw new Error("invalid 'hostToken'");
+  }
+  let actingAs: TurnRequest["actingAs"];
+  if (b.actingAs !== undefined) {
+    const acting = record(b.actingAs, "actingAs");
+    exactKeys(acting, ["userId", "name"], "actingAs");
+    if (
+      !nonEmpty(acting.userId) ||
+      (acting.name !== undefined && !nonEmpty(acting.name))
+    ) {
+      throw new Error("invalid 'actingAs'");
+    }
+    actingAs = {
+      userId: acting.userId,
+      ...(acting.name ? { name: acting.name } : {}),
+    };
+  }
+  if (b.shadow !== undefined && typeof b.shadow !== "boolean") {
+    throw new Error("invalid 'shadow'");
+  }
+  for (const field of ["workspaceContext", "userContext"] as const) {
+    if (b[field] !== undefined && typeof b[field] !== "string") {
+      throw new Error(`invalid '${field}'`);
+    }
+  }
+  if (
+    b.turnlogSeqStart !== undefined &&
+    (typeof b.turnlogSeqStart !== "number" ||
+      !Number.isSafeInteger(b.turnlogSeqStart) ||
+      b.turnlogSeqStart < 1)
+  ) {
+    throw new Error("invalid 'turnlogSeqStart'");
+  }
+  let claim: TurnRequest["claim"];
+  if (b.claim !== undefined) {
+    const parsed = record(b.claim, "claim");
+    exactKeys(parsed, ["id", "bootId", "token", "heartbeatUrl"], "claim");
+    if (
+      !nonEmpty(parsed.id) ||
+      !nonEmpty(parsed.bootId) ||
+      !nonEmpty(parsed.token) ||
+      !nonEmpty(parsed.heartbeatUrl)
+    ) {
+      throw new Error("invalid 'claim'");
+    }
+    claim = {
+      id: parsed.id,
+      bootId: parsed.bootId,
+      token: parsed.token,
+      heartbeatUrl: parsed.heartbeatUrl,
+    };
+  }
+  if (Boolean(claim) !== Boolean(b.hostToken)) {
+    throw new Error("claim and hostToken must be configured together");
+  }
+  const poolPrefix = prefix.split("/");
+  if (
+    claim &&
+    (poolPrefix.length !== 3 ||
+      poolPrefix[0] !== "ws" ||
+      !poolPrefix[1] ||
+      !poolPrefix[2])
+  ) {
+    throw new Error("claimed turn has invalid 'gcsPrefix'");
+  }
+  return {
+    workspaceId: b.workspaceId as string,
+    agentId: b.agentId as string,
+    conversationId: b.conversationId as string,
+    text: b.text,
+    nonce: typeof b.nonce === "string" ? b.nonce : undefined,
+    gcsPrefix: prefix,
+    credential,
+    model: typeof b.model === "string" ? b.model : undefined,
+    effort: typeof b.effort === "string" ? b.effort : undefined,
+    // Never trust the wire: only the known mode literals ("plan", "auto") pass;
+    // anything else normalizes to "execute".
+    mode: normalizeTurnMode(b.mode),
+    displayText: typeof b.displayText === "string" ? b.displayText : undefined,
+    // Same "never trust the wire" posture: junk entries are dropped and an
+    // empty list becomes nothing, so a bad sidecar never costs the user a turn.
+    mentions: parseMentions(b.mentions),
+    turnId: typeof b.turnId === "string" ? b.turnId : undefined,
+    hostToken: typeof b.hostToken === "string" ? b.hostToken : undefined,
+    actingAs,
+    shadow: typeof b.shadow === "boolean" ? b.shadow : undefined,
+    workspaceContext:
+      typeof b.workspaceContext === "string" ? b.workspaceContext : undefined,
+    userContext: typeof b.userContext === "string" ? b.userContext : undefined,
+    turnlogSeqStart:
+      typeof b.turnlogSeqStart === "number" ? b.turnlogSeqStart : undefined,
+    claim,
+  };
+}

--- a/packages/runtime/src/turn/pi-turn-request.ts
+++ b/packages/runtime/src/turn/pi-turn-request.ts
@@ -1,0 +1,36 @@
+import type { WireFrame } from "@houston/runtime-client";
+import type { PiTurnRequest } from "./turn-session";
+import type { TurnRequest } from "./types";
+
+/** Project the accepted envelope onto the pi turn the session runs. */
+export function piTurnRequest(
+  turn: TurnRequest,
+  turnId: string,
+  emit: (frame: WireFrame) => void,
+  signal: AbortSignal,
+): PiTurnRequest {
+  return {
+    conversationId: turn.conversationId,
+    text: turn.text,
+    provider: turn.credential?.provider ?? "",
+    emit,
+    signal,
+    nonce: turn.nonce,
+    pin: { model: turn.model, effort: turn.effort },
+    mode: turn.mode,
+    turnId,
+    displayText: turn.displayText,
+    mentions: turn.mentions,
+    author: turn.actingAs,
+    // Either context field present means "use these" (each defaults to ""),
+    // mirroring the long-lived server's message-send contract.
+    ...(turn.workspaceContext !== undefined || turn.userContext !== undefined
+      ? {
+          context: {
+            workspace: turn.workspaceContext ?? "",
+            user: turn.userContext ?? "",
+          },
+        }
+      : {}),
+  };
+}

--- a/packages/runtime/src/turn/pool-leaks.test.ts
+++ b/packages/runtime/src/turn/pool-leaks.test.ts
@@ -1,0 +1,198 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { LocalDirStore } from "@houston/runtime-client/object-sync";
+import { afterAll, expect, test } from "vitest";
+
+const scratch = mkdtempSync(join(tmpdir(), "houston-pool-leaks-"));
+process.env.HOUSTON_MODE = "turn";
+process.env.HOUSTON_DATA_DIR = join(scratch, "process-data");
+process.env.HOUSTON_WORKSPACE_DIR = join(scratch, "process-workspace");
+process.env.HOUSTON_CODE_EXECUTION = "disabled";
+
+const { createTurnServer } = await import("./server");
+
+const storeRoot = join(scratch, "store");
+const store = new LocalDirStore(storeRoot);
+const servers: Server[] = [];
+const seen: Array<{ prompt: string; token: string }> = [];
+
+function listen(server: Server): Promise<string> {
+  servers.push(server);
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string")
+        return reject(new Error("no port"));
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}
+
+function seed(prefix: string, rel: string, value: string): void {
+  const path = join(storeRoot, ...prefix.split("/"), ...rel.split("/"));
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, value);
+}
+
+function lastPrompt(body: unknown): string {
+  const messages = (body as { messages?: Array<{ content?: unknown }> })
+    .messages;
+  const content = messages?.at(-1)?.content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        part &&
+        typeof part === "object" &&
+        "text" in part &&
+        typeof part.text === "string"
+          ? part.text
+          : "",
+      )
+      .join("");
+  }
+  return "";
+}
+
+const provider = createServer((req, res) => {
+  void (async () => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req)
+      chunks.push(Buffer.from(chunk as Uint8Array));
+    const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
+    const token =
+      /^Bearer (\S+)$/.exec(req.headers.authorization ?? "")?.[1] ?? "";
+    const prompt = lastPrompt(body);
+    seen.push({ prompt, token });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    res.writeHead(200, { "content-type": "text/event-stream" });
+    res.write(
+      `data: ${JSON.stringify({ choices: [{ index: 0, delta: { content: `echo:${prompt}` }, finish_reason: null }] })}\n\n`,
+    );
+    res.write(
+      `data: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`,
+    );
+    res.end("data: [DONE]\n\n");
+  })().catch((error) => {
+    res.writeHead(500);
+    res.end(error instanceof Error ? error.message : String(error));
+  });
+});
+
+const providerUrl = await listen(provider);
+for (const agent of ["a", "b"]) {
+  const prefix = `ws/w1/agent-${agent}`;
+  seed(
+    prefix,
+    "data/custom-endpoint.json",
+    JSON.stringify({ baseUrl: `${providerUrl}/v1`, model: "echo" }),
+  );
+  seed(prefix, "workspace/secret.txt", `SECRET-${agent.toUpperCase()}`);
+}
+mkdirSync(process.env.HOUSTON_DATA_DIR, { recursive: true });
+writeFileSync(
+  join(process.env.HOUSTON_DATA_DIR, "auth.json"),
+  JSON.stringify({
+    "openai-compatible": { type: "api_key", key: "process-global-token" },
+  }),
+);
+
+const runtime = createTurnServer({ store, token: "", concurrency: 1 });
+const runtimeUrl = await listen(runtime);
+async function observeRoot(secret: string): Promise<string> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    for (const name of readdirSync(tmpdir())) {
+      if (!name.startsWith("houston-turn-")) continue;
+      const root = join(tmpdir(), name);
+      try {
+        if (
+          readFileSync(join(root, "workspace/secret.txt"), "utf8") === secret
+        ) {
+          return root;
+        }
+      } catch {
+        // Another test's root, or this root before hydration completed.
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  throw new Error(`did not observe the ${secret} turn root`);
+}
+
+async function run(agent: "a" | "b", index: number): Promise<void> {
+  const responsePromise = fetch(`${runtimeUrl}/turn`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      workspaceId: "w1",
+      agentId: `agent-${agent}`,
+      conversationId: "same-cid",
+      text: `REQUEST-${agent.toUpperCase()}-${index}`,
+      model: "echo",
+      gcsPrefix: `ws/w1/agent-${agent}`,
+      credential: {
+        provider: "openai-compatible",
+        access: `token-${agent}`,
+        expires: Date.now() + 60_000,
+        kind: "api_key",
+      },
+    }),
+  });
+  const root = await observeRoot(`SECRET-${agent.toUpperCase()}`);
+  const response = await responsePromise;
+  expect(response.status).toBe(200);
+  const raw = await response.text();
+  expect(raw).toContain(`echo:REQUEST-${agent.toUpperCase()}-${index}`);
+  expect(existsSync(root)).toBe(false);
+}
+
+afterAll(async () => {
+  await Promise.all(
+    servers.map(
+      (server) => new Promise<void>((resolve) => server.close(() => resolve())),
+    ),
+  );
+});
+
+test("alternating agents leave no credential, conversation, auth, root, or config-dir leaks", async () => {
+  await run("a", 0);
+  await run("b", 0);
+  await run("a", 1);
+  await run("b", 1);
+
+  expect(seen.map(({ token }) => token)).toEqual([
+    "token-a",
+    "token-b",
+    "token-a",
+    "token-b",
+  ]);
+  expect(seen.some(({ token }) => token === "process-global-token")).toBe(
+    false,
+  );
+
+  const aConversation = readFileSync(
+    join(storeRoot, "ws/w1/agent-a/data/conversations/same-cid.json"),
+    "utf8",
+  );
+  const bConversation = readFileSync(
+    join(storeRoot, "ws/w1/agent-b/data/conversations/same-cid.json"),
+    "utf8",
+  );
+  expect(aConversation).toContain("REQUEST-A-1");
+  expect(aConversation).not.toContain("REQUEST-B");
+  expect(bConversation).toContain("REQUEST-B-1");
+  expect(bConversation).not.toContain("REQUEST-A");
+  expect(await store.list("ws/w1")).not.toContainEqual(
+    expect.stringMatching(/auth\.json$/),
+  );
+});

--- a/packages/runtime/src/turn/pool-leaks.test.ts
+++ b/packages/runtime/src/turn/pool-leaks.test.ts
@@ -99,6 +99,12 @@ for (const agent of ["a", "b"]) {
   );
   seed(prefix, "workspace/secret.txt", `SECRET-${agent.toUpperCase()}`);
 }
+seed(
+  "ws/w1/agent-s",
+  "workspaces/W/A/.houston/runtime/custom-endpoint.json",
+  JSON.stringify({ baseUrl: `${providerUrl}/v1`, model: "echo" }),
+);
+seed("ws/w1/agent-s", "workspaces/W/A/secret.txt", "SECRET-S");
 mkdirSync(process.env.HOUSTON_DATA_DIR, { recursive: true });
 writeFileSync(
   join(process.env.HOUSTON_DATA_DIR, "auth.json"),
@@ -109,14 +115,20 @@ writeFileSync(
 
 const runtime = createTurnServer({ store, token: "", concurrency: 1 });
 const runtimeUrl = await listen(runtime);
-async function observeRoot(secret: string): Promise<string> {
+async function observeRoot(
+  secret: string,
+  workspaceRel = "workspace",
+): Promise<string> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     for (const name of readdirSync(tmpdir())) {
       if (!name.startsWith("houston-turn-")) continue;
       const root = join(tmpdir(), name);
       try {
         if (
-          readFileSync(join(root, "workspace/secret.txt"), "utf8") === secret
+          readFileSync(
+            join(root, "store", workspaceRel, "secret.txt"),
+            "utf8",
+          ) === secret
         ) {
           return root;
         }
@@ -129,7 +141,11 @@ async function observeRoot(secret: string): Promise<string> {
   throw new Error(`did not observe the ${secret} turn root`);
 }
 
-async function run(agent: "a" | "b", index: number): Promise<void> {
+async function run(
+  agent: "a" | "b" | "s",
+  index: number,
+  workspaceRel?: string,
+): Promise<void> {
   const responsePromise = fetch(`${runtimeUrl}/turn`, {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -148,7 +164,7 @@ async function run(agent: "a" | "b", index: number): Promise<void> {
       },
     }),
   });
-  const root = await observeRoot(`SECRET-${agent.toUpperCase()}`);
+  const root = await observeRoot(`SECRET-${agent.toUpperCase()}`, workspaceRel);
   const response = await responsePromise;
   expect(response.status).toBe(200);
   const raw = await response.text();
@@ -169,12 +185,16 @@ test("alternating agents leave no credential, conversation, auth, root, or confi
   await run("b", 0);
   await run("a", 1);
   await run("b", 1);
+  await run("s", 0, "workspaces/W/A");
+  await run("s", 1, "workspaces/W/A");
 
   expect(seen.map(({ token }) => token)).toEqual([
     "token-a",
     "token-b",
     "token-a",
     "token-b",
+    "token-s",
+    "token-s",
   ]);
   expect(seen.some(({ token }) => token === "process-global-token")).toBe(
     false,
@@ -192,6 +212,15 @@ test("alternating agents leave no credential, conversation, auth, root, or confi
   expect(aConversation).not.toContain("REQUEST-B");
   expect(bConversation).toContain("REQUEST-B-1");
   expect(bConversation).not.toContain("REQUEST-A");
+  const standingConversation = readFileSync(
+    join(
+      storeRoot,
+      "ws/w1/agent-s/workspaces/W/A/.houston/runtime/conversations/same-cid.json",
+    ),
+    "utf8",
+  );
+  expect(standingConversation).toContain("REQUEST-S-1");
+  expect(standingConversation).not.toContain("REQUEST-A");
   expect(await store.list("ws/w1")).not.toContainEqual(
     expect.stringMatching(/auth\.json$/),
   );

--- a/packages/runtime/src/turn/server-pool.test.ts
+++ b/packages/runtime/src/turn/server-pool.test.ts
@@ -1,0 +1,237 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalDirStore } from "@houston/runtime-client/object-sync";
+import { afterEach, expect, test } from "vitest";
+import { currentActingContext } from "../session/acting-context";
+import { createTurnServer } from "./server";
+import type { runPiTurn } from "./turn-session";
+
+const servers: Server[] = [];
+afterEach(() =>
+  servers.splice(0).forEach((server) => {
+    server.close();
+  }),
+);
+
+const body = (extra: Record<string, unknown> = {}) => ({
+  workspaceId: "w1",
+  agentId: "agent-1",
+  conversationId: "c1",
+  text: "hello",
+  gcsPrefix: "ws/w1/agent-1",
+  credential: {
+    provider: "openai-codex",
+    access: "access-token",
+    expires: Date.now() + 60_000,
+  },
+  ...extra,
+});
+
+async function listen(server: Server): Promise<string> {
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("no address");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+const post = (base: string, value = body()) =>
+  fetch(`${base}/turn`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(value),
+  });
+
+function snapshotTree(root: string): Record<string, string> {
+  const snapshot: Record<string, string> = {};
+  const visit = (directory: string) => {
+    for (const name of readdirSync(directory).sort()) {
+      const path = join(directory, name);
+      const relative = path.slice(root.length + 1);
+      if (statSync(path).isDirectory()) {
+        snapshot[`${relative}/`] = "directory";
+        visit(path);
+      } else {
+        snapshot[relative] = readFileSync(path).toString("base64");
+      }
+    }
+  };
+  visit(root);
+  return snapshot;
+}
+
+test("capacity rejects a concurrent turn and frees the slot after terminal", async () => {
+  let release: (() => void) | undefined;
+  let markStarted: (() => void) | undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const store = new LocalDirStore(mkdtempSync(join(tmpdir(), "pool-store-")));
+  const runTurn: typeof runPiTurn = async () => {
+    markStarted?.();
+    await gate;
+    return {};
+  };
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn, concurrency: 1 }),
+  );
+  const first = post(base);
+  await started;
+  const full = await post(base, body({ conversationId: "c2" }));
+  expect(full.status).toBe(503);
+  expect(full.headers.get("retry-after")).toBe("1");
+  expect(await full.json()).toEqual({ error: "worker_full" });
+  release?.();
+  expect((await first).status).toBe(200);
+  await (await first).text();
+  expect((await post(base, body({ conversationId: "c3" }))).status).toBe(200);
+});
+
+test("a thrown turn never wedges admission", async () => {
+  let calls = 0;
+  const store = new LocalDirStore(mkdtempSync(join(tmpdir(), "pool-store-")));
+  const runTurn: typeof runPiTurn = async () => {
+    calls += 1;
+    if (calls === 1) throw new Error("boom");
+    return {};
+  };
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn, concurrency: 1 }),
+  );
+  const failed = await post(base);
+  expect(failed.status).toBe(200);
+  await failed.text();
+  const next = await post(base, body({ conversationId: "c2" }));
+  expect(next.status).toBe(200);
+  await next.text();
+});
+
+test("shadow hydrates and resolves, emits shadow then done, and leaves no writes or root", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pool-shadow-store-"));
+  const stored = join(root, "ws", "w1", "agent-1", "workspace", "note.txt");
+  await import("node:fs/promises").then(({ mkdir }) =>
+    mkdir(join(stored, ".."), { recursive: true }),
+  );
+  await writeFile(stored, "original");
+  const storeBefore = snapshotTree(root);
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(root),
+      token: "",
+      runTurn: async () => {
+        throw new Error("provider path must not run");
+      },
+    }),
+  );
+  const responsePromise = post(
+    base,
+    body({ shadow: true, turnId: "shadow-1" }),
+  );
+  let turnRoot: string | undefined;
+  for (let attempt = 0; attempt < 100 && !turnRoot; attempt += 1) {
+    turnRoot = readdirSync(tmpdir())
+      .filter((name) => name.startsWith("houston-turn-"))
+      .map((name) => join(tmpdir(), name))
+      .find((candidate) => {
+        try {
+          return (
+            readFileSync(join(candidate, "workspace/note.txt"), "utf8") ===
+            "original"
+          );
+        } catch {
+          return false;
+        }
+      });
+    if (!turnRoot) await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  const response = await responsePromise;
+  const raw = await response.text();
+  const frames = raw
+    .split("\n\n")
+    .flatMap((block) => block.split("\n"))
+    .filter((line) => line.startsWith("data: "))
+    .map(
+      (line) => JSON.parse(line.slice(6)) as { type: string; data: unknown },
+    );
+
+  expect(frames.map((frame) => frame.type)).toEqual(["shadow", "done"]);
+  expect(frames[0]?.data).toMatchObject({ hydratedObjects: 1 });
+  expect(snapshotTree(root)).toEqual(storeBefore);
+  expect(turnRoot).toBeDefined();
+  expect(existsSync(turnRoot ?? "")).toBe(false);
+});
+
+test("a fenced heartbeat skips syncBack and emits claim_fenced", async () => {
+  const heartbeat = createServer((_req, res) => {
+    res.writeHead(409);
+    res.end("adopted");
+  });
+  const heartbeatBase = await listen(heartbeat);
+  const store = new LocalDirStore(mkdtempSync(join(tmpdir(), "pool-store-")));
+  const runTurn: typeof runPiTurn = async (root) => {
+    await writeFile(join(root, "workspace", "must-not-sync.txt"), "nope");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    return {};
+  };
+  const base = await listen(createTurnServer({ store, token: "", runTurn }));
+  const response = await post(
+    base,
+    body({
+      hostToken: "host-token",
+      claim: {
+        id: "claim-1",
+        bootId: "boot-1",
+        token: "claim-token",
+        heartbeatUrl: heartbeatBase,
+      },
+    }),
+  );
+  const raw = await response.text();
+  expect(raw).toContain("claim_fenced");
+  expect(raw).not.toContain('"type":"done"');
+  expect(await store.list("ws/w1/agent-1")).not.toContain(
+    "ws/w1/agent-1/workspace/must-not-sync.txt",
+  );
+});
+
+test("the supplied turn id and acting identity reach the turn session", async () => {
+  let seen: unknown;
+  const store = new LocalDirStore(mkdtempSync(join(tmpdir(), "pool-store-")));
+  const runTurn: typeof runPiTurn = async (_root, turn) => {
+    seen = {
+      turnId: turn.turnId,
+      author: turn.author,
+      actingUser: currentActingContext()?.actingUser,
+    };
+    turn.emit({ type: "text", data: "ok", turnId: turn.turnId });
+    return {};
+  };
+  const base = await listen(createTurnServer({ store, token: "", runTurn }));
+  const response = await post(
+    base,
+    body({
+      turnId: "gateway-turn-1",
+      actingAs: { userId: "user-1", name: "Ada" },
+    }),
+  );
+  const raw = await response.text();
+
+  expect(seen).toEqual({
+    turnId: "gateway-turn-1",
+    author: { userId: "user-1", name: "Ada" },
+    actingUser: "user-1",
+  });
+  expect(raw).toContain('"turnId":"gateway-turn-1"');
+});

--- a/packages/runtime/src/turn/server-pool.test.ts
+++ b/packages/runtime/src/turn/server-pool.test.ts
@@ -255,3 +255,106 @@ test("the supplied turn id and acting identity reach the turn session", async ()
   });
   expect(raw).toContain('"turnId":"gateway-turn-1"');
 });
+
+function seedStandingAgent(): string {
+  const storeRoot = mkdtempSync(join(tmpdir(), "pool-store-"));
+  const settings = join(
+    storeRoot,
+    "ws",
+    "w1",
+    "agent-1",
+    "workspaces",
+    "W",
+    "A",
+    ".houston",
+    "runtime",
+    "settings.json",
+  );
+  mkdirSync(dirname(settings), { recursive: true });
+  writeFileSync(settings, "{}");
+  return storeRoot;
+}
+
+const claimedBody = (heartbeatUrl: string) =>
+  body({
+    hostToken: "host-token",
+    claim: {
+      id: "claim-1",
+      bootId: "boot-1",
+      token: "claim-token",
+      heartbeatUrl,
+    },
+  });
+
+test("a claimed turn outlives a dropped client connection and still syncs", async () => {
+  const heartbeat = createServer((_req, res) => {
+    res.writeHead(204);
+    res.end();
+  });
+  const heartbeatBase = await listen(heartbeat);
+  const storeRoot = seedStandingAgent();
+  const store = new LocalDirStore(storeRoot);
+  let sawAbort: boolean | undefined;
+  let finished: (() => void) | undefined;
+  const done = new Promise<void>((resolve) => {
+    finished = resolve;
+  });
+  const runTurn: typeof runPiTurn = async (layout, turn) => {
+    // Give the client time to hang up, then keep working as if nothing
+    // happened: the claim, not the socket, owns this turn.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    sawAbort = turn.signal?.aborted;
+    try {
+      const conversations = join(layout.dataDir, "conversations");
+      mkdirSync(conversations, { recursive: true });
+      await writeFile(
+        join(conversations, `${turn.conversationId}.json`),
+        JSON.stringify({ id: turn.conversationId, messages: [] }),
+      );
+      return {};
+    } finally {
+      finished?.();
+    }
+  };
+  const base = await listen(createTurnServer({ store, token: "", runTurn }));
+  const controller = new AbortController();
+  // The response headers arrive once the SSE opens (after hydrate); aborting
+  // right after that drops the socket while the turn is still running.
+  const response = await fetch(`${base}/turn`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(claimedBody(heartbeatBase)),
+    signal: controller.signal,
+  });
+  expect(response.status).toBe(200);
+  controller.abort();
+  await done;
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect(sawAbort).toBe(false);
+  expect(await store.list("ws/w1/agent-1")).toContain(
+    "ws/w1/agent-1/workspaces/W/A/.houston/runtime/conversations/c1.json",
+  );
+});
+
+test("a fenced heartbeat aborts the running claimed turn", async () => {
+  let status = 204;
+  const heartbeat = createServer((_req, res) => {
+    res.writeHead(status);
+    res.end();
+  });
+  const heartbeatBase = await listen(heartbeat);
+  const store = new LocalDirStore(seedStandingAgent());
+  const runTurn: typeof runPiTurn = async (_layout, turn) => {
+    status = 409;
+    await new Promise<void>((resolve) => {
+      turn.signal?.addEventListener("abort", () => resolve(), { once: true });
+    });
+    return { error: "aborted" };
+  };
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn, heartbeatIntervalMs: 20 }),
+  );
+  const raw = await (await post(base, claimedBody(heartbeatBase))).text();
+  expect(raw).toContain("claim_fenced");
+  expect(raw).not.toContain('"type":"done"');
+});

--- a/packages/runtime/src/turn/server-pool.test.ts
+++ b/packages/runtime/src/turn/server-pool.test.ts
@@ -1,14 +1,16 @@
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
   statSync,
+  writeFileSync,
 } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { LocalDirStore } from "@houston/runtime-client/object-sync";
 import { afterEach, expect, test } from "vitest";
 import { currentActingContext } from "../session/acting-context";
@@ -147,8 +149,10 @@ test("shadow hydrates and resolves, emits shadow then done, and leaves no writes
       .find((candidate) => {
         try {
           return (
-            readFileSync(join(candidate, "workspace/note.txt"), "utf8") ===
-            "original"
+            readFileSync(
+              join(candidate, "store/workspace/note.txt"),
+              "utf8",
+            ) === "original"
           );
         } catch {
           return false;
@@ -179,9 +183,25 @@ test("a fenced heartbeat skips syncBack and emits claim_fenced", async () => {
     res.end("adopted");
   });
   const heartbeatBase = await listen(heartbeat);
-  const store = new LocalDirStore(mkdtempSync(join(tmpdir(), "pool-store-")));
-  const runTurn: typeof runPiTurn = async (root) => {
-    await writeFile(join(root, "workspace", "must-not-sync.txt"), "nope");
+  const storeRoot = mkdtempSync(join(tmpdir(), "pool-store-"));
+  const store = new LocalDirStore(storeRoot);
+  // A claimed turn needs an existing agent; seed the standing layout.
+  const settings = join(
+    storeRoot,
+    "ws",
+    "w1",
+    "agent-1",
+    "workspaces",
+    "W",
+    "A",
+    ".houston",
+    "runtime",
+    "settings.json",
+  );
+  mkdirSync(dirname(settings), { recursive: true });
+  writeFileSync(settings, "{}");
+  const runTurn: typeof runPiTurn = async (layout) => {
+    await writeFile(join(layout.workspaceDir, "must-not-sync.txt"), "nope");
     await new Promise((resolve) => setTimeout(resolve, 20));
     return {};
   };

--- a/packages/runtime/src/turn/server-types.ts
+++ b/packages/runtime/src/turn/server-types.ts
@@ -1,4 +1,5 @@
 import type { ObjectStore } from "@houston/runtime-client/object-sync";
+import type { AdmissionLimiter } from "./admission";
 import type { runPiTurn } from "./turn-session";
 
 /** Injectable dependencies and pool controls for the per-turn HTTP server. */
@@ -8,8 +9,11 @@ export interface TurnServerDeps {
   token: string;
   runTurn?: typeof runPiTurn;
   concurrency?: number;
+  admission?: AdmissionLimiter;
+  isDraining?: () => boolean;
   poolStoreUrl?: string;
   turnLogUrl?: string;
   fetchImpl?: typeof fetch;
   heartbeatIntervalMs?: number;
+  maxHydrateBytes?: number;
 }

--- a/packages/runtime/src/turn/server-types.ts
+++ b/packages/runtime/src/turn/server-types.ts
@@ -16,4 +16,6 @@ export interface TurnServerDeps {
   fetchImpl?: typeof fetch;
   heartbeatIntervalMs?: number;
   maxHydrateBytes?: number;
+  /** Test seam: transient-status retry delays for transcript publication. */
+  transcriptRetryDelaysMs?: number[];
 }

--- a/packages/runtime/src/turn/server-types.ts
+++ b/packages/runtime/src/turn/server-types.ts
@@ -18,4 +18,6 @@ export interface TurnServerDeps {
   maxHydrateBytes?: number;
   /** Test seam: transient-status retry delays for transcript publication. */
   transcriptRetryDelaysMs?: number[];
+  /** Test seam: transient-status retry delays for activity doc publication. */
+  activityDocRetryDelaysMs?: number[];
 }

--- a/packages/runtime/src/turn/server-types.ts
+++ b/packages/runtime/src/turn/server-types.ts
@@ -1,0 +1,15 @@
+import type { ObjectStore } from "@houston/runtime-client/object-sync";
+import type { runPiTurn } from "./turn-session";
+
+/** Injectable dependencies and pool controls for the per-turn HTTP server. */
+export interface TurnServerDeps {
+  store: ObjectStore;
+  /** App-layer token; empty means open local development. */
+  token: string;
+  runTurn?: typeof runPiTurn;
+  concurrency?: number;
+  poolStoreUrl?: string;
+  turnLogUrl?: string;
+  fetchImpl?: typeof fetch;
+  heartbeatIntervalMs?: number;
+}

--- a/packages/runtime/src/turn/server.test.ts
+++ b/packages/runtime/src/turn/server.test.ts
@@ -40,11 +40,11 @@ function seed(rel: string, content: string) {
 // A fake pi turn: proves it sees the hydrated workspace + injected credential,
 // mutates the workspace, emits frames (stamped with the server-minted turnId,
 // like the real runPiTurn).
-const fakeTurn: typeof runPiTurn = async (root, turn) => {
+const fakeTurn: typeof runPiTurn = async (layout, turn) => {
   const { text, provider, emit, turnId } = turn;
-  const notes = await readFile(join(root, "workspace", "notes.txt"), "utf8");
-  const auth = await readFile(join(root, "data", "auth.json"), "utf8");
-  await writeFile(join(root, "workspace", "deck.pptx"), "DECK-BYTES");
+  const notes = await readFile(join(layout.workspaceDir, "notes.txt"), "utf8");
+  const auth = await readFile(join(layout.dataDir, "auth.json"), "utf8");
+  await writeFile(join(layout.workspaceDir, "deck.pptx"), "DECK-BYTES");
   emit({ type: "user", data: { content: text, ts: 1 }, turnId });
   emit({
     type: "text",

--- a/packages/runtime/src/turn/server.ts
+++ b/packages/runtime/src/turn/server.ts
@@ -1,46 +1,26 @@
 import { timingSafeEqual } from "node:crypto";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import {
   createServer,
   type IncomingMessage,
   type Server,
   type ServerResponse,
 } from "node:http";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import type { WireFrame } from "@houston/runtime-client";
-import {
-  hydrate,
-  type ObjectStore,
-  syncBack,
-} from "@houston/runtime-client/object-sync";
-import { applyServedCredential } from "../auth/auth-file";
-import { runWithActingContext } from "../session/acting-context";
-import { openSSE } from "../transport/sse";
-import { runPiTurn, type TurnOutcome } from "./turn-session";
+import { AdmissionLimiter, turnConcurrency } from "./admission";
+import { executeTurn } from "./execute-turn";
+import type { TurnServerDeps } from "./server-types";
 import { parseTurnRequest, type TurnRequest } from "./types";
 
-/**
- * The per-turn runtime server (cloud hosting layer). One request = one agent
- * turn: hydrate the agent's object-storage prefix into a throwaway dir, write
- * the per-turn access credential, run pi, stream wire frames back as SSE, sync
- * the delta to object storage, wipe the dir. The instance keeps NO tenant
- * state between requests; Cloud Run's per-instance microVM + concurrency=1 do
- * the co-residency isolation, exactly like the code sandbox.
- *
- * Auth is two-layer like the sandbox: Cloud Run IAM consumes Authorization
- * (only the control plane's SA holds run.invoker); X-Internal-Token carries
- * the app-layer secret. The terminal done/error frame is sent only AFTER
- * sync-back, so a client never sees `done` before its files are durable.
- */
+export type { TurnServerDeps } from "./server-types";
 
-export interface TurnServerDeps {
-  store: ObjectStore;
-  /** App-layer token; empty = open (local dev only). */
-  token: string;
-  /** Injectable for tests; defaults to the real pi turn. */
-  runTurn?: typeof runPiTurn;
-}
+/**
+ * The pooled per-turn runtime. Each admitted request hydrates one agent into a
+ * throwaway root, runs at most one turn, syncs durable changes, then wipes the
+ * root. Admission is explicit because one process may receive several HTTP
+ * requests even when v1 capacity is one.
+ *
+ * Authorization remains two-layered: deployment IAM protects the endpoint,
+ * while X-Internal-Token is the application secret for ordinary turn traffic.
+ */
 
 function authorized(req: IncomingMessage, token: string): boolean {
   if (!token) return true;
@@ -57,131 +37,32 @@ async function readJson(
 ): Promise<unknown> {
   const chunks: Buffer[] = [];
   let size = 0;
-  for await (const c of req) {
-    size += (c as Buffer).byteLength;
-    if (size > maxBytes)
+  for await (const chunk of req) {
+    size += (chunk as Buffer).byteLength;
+    if (size > maxBytes) {
       throw new Error(`request body exceeds ${maxBytes} bytes`);
-    chunks.push(c as Buffer);
+    }
+    chunks.push(chunk as Buffer);
   }
   return JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
 }
 
-function json(res: ServerResponse, status: number, body: unknown) {
-  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+function json(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+) {
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    ...headers,
+  });
   res.end(JSON.stringify(body));
 }
 
-async function executeTurn(
-  deps: TurnServerDeps,
-  turn: TurnRequest,
-  req: IncomingMessage,
-  res: ServerResponse,
-) {
-  const root = await mkdtemp(join(tmpdir(), "houston-turn-"));
-  const abort = new AbortController();
-  req.on("close", () => abort.abort());
-  try {
-    const manifest = await hydrate(deps.store, turn.gcsPrefix, root);
-    await mkdir(join(root, "workspace"), { recursive: true });
-    await mkdir(join(root, "data"), { recursive: true });
-    if (turn.credential) {
-      applyServedCredential(join(root, "data", "auth.json"), turn.credential);
-    }
-
-    const sse = openSSE(res);
-    // The turn's wire identity: minted HERE (the per-turn server owns the whole
-    // turn) so the frames runPiTurn emits and the terminal frame sent after
-    // sync-back all carry one id — the host relay re-broadcasts them verbatim.
-    const turnId = crypto.randomUUID();
-    const emit = (e: WireFrame) => sse.send(e);
-
-    let outcome: TurnOutcome;
-    if (!turn.credential) {
-      emit({
-        type: "user",
-        data: {
-          content: turn.text,
-          ts: Date.now(),
-          nonce: turn.nonce,
-          mentions: turn.mentions,
-        },
-        turnId,
-      });
-      outcome = {
-        error: "No provider connected. Connect your subscription first.",
-      };
-    } else {
-      const run = deps.runTurn ?? runPiTurn;
-      const credential = turn.credential;
-      // This process can serve turns for many agents. Give process-local
-      // credential health a stable per-agent scope without inventing an acting
-      // user: tools must not attribute work to this internal identity. The
-      // standing-pod server never enters this wrapper, so its no-context/team
-      // path stays byte-identical.
-      //
-      // This key reads as a PERSONAL scope to authPathIn (anything != "team"),
-      // which would divert scope-resolved auth reads to auth-users/<hash>.json.
-      // That is safe here ONLY because the turn path never resolves credentials
-      // by scope: turn-session builds its per-turn ModelRuntime with an
-      // EXPLICIT authPath (join(dataDir, "auth.json"), where the served
-      // credential was written), and the host-served credential guards no-op
-      // without a control-plane URL. Only credential-health keys off this
-      // scope — which is exactly the isolation this wrapper exists for. If the
-      // turn path ever grows a scope-resolved credential read, revisit.
-      outcome = await runWithActingContext(
-        {
-          credentialScopeKey: `u:turn:${turn.workspaceId}:${turn.agentId}`,
-        },
-        () =>
-          run(root, {
-            conversationId: turn.conversationId,
-            text: turn.text,
-            provider: credential.provider,
-            emit,
-            signal: abort.signal,
-            nonce: turn.nonce,
-            pin: { model: turn.model, effort: turn.effort },
-            mode: turn.mode,
-            turnId,
-            displayText: turn.displayText,
-            mentions: turn.mentions,
-          }),
-      );
-    }
-
-    // Durability BEFORE the terminal frame. A sync failure is data loss and
-    // must surface as the turn's error — never a quiet `done`.
-    try {
-      await syncBack(deps.store, turn.gcsPrefix, root, manifest);
-    } catch (err) {
-      const m = err instanceof Error ? err.message : String(err);
-      outcome = {
-        error: outcome.error
-          ? `${outcome.error}; sync failed: ${m}`
-          : `workspace sync failed: ${m}`,
-      };
-    }
-
-    if (outcome.error)
-      sse.send({ type: "error", data: { message: outcome.error }, turnId });
-    else
-      sse.send({
-        type: "done",
-        data: null,
-        turnId,
-        // Carry whatever the turn ended on (ask_user, or a clean-finish offer)
-        // so the `needs_you` card can render it. Only the clean done carries it.
-        ...(outcome.pendingInteraction
-          ? { pendingInteraction: outcome.pendingInteraction }
-          : {}),
-      });
-    sse.close();
-  } finally {
-    await rm(root, { recursive: true, force: true });
-  }
-}
-
+/** Create the bounded HTTP server used by stateless per-turn workers. */
 export function createTurnServer(deps: TurnServerDeps): Server {
+  const admission = new AdmissionLimiter(deps.concurrency ?? turnConcurrency());
   return createServer((req, res) => {
     (async () => {
       const path = (req.url || "/").split("?")[0];
@@ -191,19 +72,30 @@ export function createTurnServer(deps: TurnServerDeps): Server {
       if (req.method !== "POST" || path !== "/turn") {
         return json(res, 404, { error: "not found" });
       }
-      if (!authorized(req, deps.token))
+      if (!authorized(req, deps.token)) {
         return json(res, 401, { error: "unauthorized" });
+      }
       let turn: TurnRequest;
       try {
         turn = parseTurnRequest(await readJson(req, 1024 * 1024));
-      } catch (err) {
+      } catch (error) {
         return json(res, 400, {
-          error: err instanceof Error ? err.message : String(err),
+          error: error instanceof Error ? error.message : String(error),
         });
       }
-      await executeTurn(deps, turn, req, res);
-    })().catch((err) => {
-      const message = err instanceof Error ? err.message : String(err);
+      const release = admission.tryAcquire();
+      if (!release) {
+        return json(res, 503, { error: "worker_full" }, { "Retry-After": "1" });
+      }
+      try {
+        await executeTurn(deps, turn, req, res, {
+          t0_request: performance.now(),
+        });
+      } finally {
+        release();
+      }
+    })().catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
       console.error("[turn] unhandled:", message);
       if (!res.headersSent) json(res, 500, { error: message });
       else if (!res.writableEnded) res.end();

--- a/packages/runtime/src/turn/server.ts
+++ b/packages/runtime/src/turn/server.ts
@@ -7,8 +7,9 @@ import {
 } from "node:http";
 import { AdmissionLimiter, turnConcurrency } from "./admission";
 import { executeTurn } from "./execute-turn";
+import { parseTurnRequest } from "./parse-turn-request";
 import type { TurnServerDeps } from "./server-types";
-import { parseTurnRequest, type TurnRequest } from "./types";
+import type { TurnRequest } from "./types";
 
 export type { TurnServerDeps } from "./server-types";
 

--- a/packages/runtime/src/turn/server.ts
+++ b/packages/runtime/src/turn/server.ts
@@ -62,7 +62,9 @@ function json(
 
 /** Create the bounded HTTP server used by stateless per-turn workers. */
 export function createTurnServer(deps: TurnServerDeps): Server {
-  const admission = new AdmissionLimiter(deps.concurrency ?? turnConcurrency());
+  const admission =
+    deps.admission ??
+    new AdmissionLimiter(deps.concurrency ?? turnConcurrency());
   return createServer((req, res) => {
     (async () => {
       const path = (req.url || "/").split("?")[0];
@@ -74,6 +76,14 @@ export function createTurnServer(deps: TurnServerDeps): Server {
       }
       if (!authorized(req, deps.token)) {
         return json(res, 401, { error: "unauthorized" });
+      }
+      if (deps.isDraining?.()) {
+        return json(
+          res,
+          503,
+          { error: "worker_draining" },
+          { "Retry-After": "1" },
+        );
       }
       let turn: TurnRequest;
       try {

--- a/packages/runtime/src/turn/turn-activity-doc.test.ts
+++ b/packages/runtime/src/turn/turn-activity-doc.test.ts
@@ -1,0 +1,506 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import type { Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalDirStore } from "@houston/runtime-client/object-sync";
+import { afterEach, expect, test } from "vitest";
+import {
+  appendAssistantMessageAt,
+  appendUserMessageAt,
+  type StoredConversation,
+} from "../store/conversation-file";
+import { createTurnServer } from "./server";
+import type { TurnServerDeps } from "./server-types";
+import type { runPiTurn } from "./turn-session";
+
+interface SeenRequest {
+  body?: unknown;
+  headers: Headers;
+  method: string;
+  url: string;
+}
+
+interface DocReply {
+  status: number;
+  revision?: number;
+  detail?: string;
+}
+
+const servers: Server[] = [];
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      ),
+  );
+});
+
+async function listen(server: Server): Promise<string> {
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("no address");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+const encode = (value: unknown) =>
+  new TextEncoder().encode(
+    typeof value === "string" ? value : JSON.stringify(value),
+  );
+
+function seedStandingLayout(): Map<string, Uint8Array> {
+  const conversation: StoredConversation = {
+    id: "mission.1",
+    title: "Roadmap",
+    createdAt: 1,
+    updatedAt: 2,
+    messages: [],
+  };
+  return new Map([
+    ["workspaces/Main/Helper/.houston/runtime/settings.json", encode("{}")],
+    [
+      "workspaces/Main/Helper/.houston/runtime/conversations/mission.1.json",
+      encode(conversation),
+    ],
+  ]);
+}
+
+function poolFetch(
+  objects: Map<string, Uint8Array>,
+  seen: SeenRequest[],
+  docReplies: DocReply[] = [],
+): typeof fetch {
+  let docRequest = 0;
+  return async (input, init) => {
+    const url = new URL(String(input));
+    const headers = new Headers(init?.headers);
+    if (url.pathname === "/heartbeat") {
+      return new Response(null, { status: 200 });
+    }
+    if (url.pathname.includes("/v1/pod/transcripts/")) {
+      return new Response(null, { status: 200 });
+    }
+    if (url.pathname.includes("/v1/pod/docs/")) {
+      seen.push({
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+        headers,
+        method: init?.method ?? "GET",
+        url: String(input),
+      });
+      const reply = docReplies[docRequest++];
+      if (reply) {
+        if (reply.detail !== undefined) {
+          return new Response(reply.detail, { status: reply.status });
+        }
+        return Response.json(
+          reply.revision === undefined ? {} : { revision: reply.revision },
+          { status: reply.status },
+        );
+      }
+      return init?.method === "PUT"
+        ? Response.json({ revision: 5 })
+        : Response.json({ revision: 4 });
+    }
+    if (url.pathname.endsWith("/manifest")) {
+      return Response.json({
+        objects: [...objects].map(([key, bytes]) => ({
+          key,
+          size: bytes.byteLength,
+          md5: "test",
+          updated: "2026-08-19T00:00:00Z",
+        })),
+      });
+    }
+    const marker = "/objects/";
+    const key = url.pathname
+      .slice(url.pathname.indexOf(marker) + marker.length)
+      .split("/")
+      .map(decodeURIComponent)
+      .join("/");
+    if (init?.method === "PUT") {
+      const bytes = new Uint8Array(init.body as Uint8Array);
+      objects.set(key, bytes);
+      seen.push({ headers, method: "PUT", url: String(input) });
+      return Response.json({
+        key,
+        size: bytes.byteLength,
+        md5: "test",
+        updated: "2026-08-19T00:00:00Z",
+      });
+    }
+    const bytes = objects.get(key);
+    return bytes
+      ? new Response(
+          bytes.buffer.slice(
+            bytes.byteOffset,
+            bytes.byteOffset + bytes.byteLength,
+          ) as ArrayBuffer,
+        )
+      : new Response("missing", { status: 404 });
+  };
+}
+
+function turnBody(extra: Record<string, unknown> = {}) {
+  return {
+    workspaceId: "acme.org",
+    agentId: "helper.bot",
+    conversationId: "mission.1",
+    text: "Build the launch plan",
+    gcsPrefix: "ws/acme.org/helper.bot",
+    credential: {
+      provider: "openai-codex",
+      access: "access-token",
+      expires: Date.now() + 60_000,
+    },
+    turnId: "turn.7",
+    hostToken: "host-token",
+    claim: {
+      id: "claim-1",
+      bootId: "boot-1",
+      token: "claim-token",
+      heartbeatUrl: "https://pool.example/heartbeat",
+    },
+    ...extra,
+  };
+}
+
+async function runTurnRequest(
+  deps: Partial<TurnServerDeps>,
+  body = turnBody(),
+): Promise<string> {
+  const server = createTurnServer({
+    store: new LocalDirStore(mkdtempSync(join(tmpdir(), "fallback-store-"))),
+    token: "",
+    transcriptRetryDelaysMs: [0, 0],
+    activityDocRetryDelaysMs: [0, 0],
+    ...deps,
+  });
+  const response = await fetch(`${await listen(server)}/turn`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return response.text();
+}
+
+function writeConversation(filesystem: Parameters<typeof runPiTurn>[0]): void {
+  const dir = join(filesystem.dataDir, "conversations");
+  appendUserMessageAt(dir, "mission.1", "Build the launch plan", {
+    turnId: "turn.7",
+  });
+  appendAssistantMessageAt(dir, "mission.1", "Launch plan ready", {
+    turnId: "turn.7",
+  });
+}
+
+function writeActivity(
+  filesystem: Parameters<typeof runPiTurn>[0],
+  value: unknown,
+): void {
+  const path = join(
+    filesystem.workspaceDir,
+    ".houston",
+    "activity",
+    "activity.json",
+  );
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, JSON.stringify(value));
+}
+
+test("a claimed activity write syncs its object and normalized database doc", async () => {
+  const objects = seedStandingLayout();
+  const seen: SeenRequest[] = [];
+  const activity = [{ id: "a1", title: "Launch", status: "running" }];
+  const runTurn: typeof runPiTurn = async (filesystem) => {
+    writeConversation(filesystem);
+    writeActivity(filesystem, activity);
+    return {};
+  };
+
+  const raw = await runTurnRequest({
+    runTurn,
+    poolStoreUrl: "https://pool.example/",
+    fetchImpl: poolFetch(objects, seen),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  const objectKey = "workspaces/Main/Helper/.houston/activity/activity.json";
+  expect(JSON.parse(new TextDecoder().decode(objects.get(objectKey)))).toEqual(
+    activity,
+  );
+  const docs = seen.filter(({ url }) => url.includes("/v1/pod/docs/"));
+  expect(docs.map(({ method, url }) => ({ method, url }))).toEqual([
+    {
+      method: "GET",
+      url: "https://pool.example/v1/pod/docs/acme.org/helper.bot/activity",
+    },
+    {
+      method: "PUT",
+      url: "https://pool.example/v1/pod/docs/acme.org/helper.bot/activity",
+    },
+  ]);
+  for (const request of docs) {
+    expect(request.headers.get("authorization")).toBe("Bearer host-token");
+    expect(request.headers.get("x-houston-claim-token")).toBe("claim-token");
+    expect(request.headers.get("x-houston-claim-boot")).toBe("boot-1");
+    expect(request.headers.get("x-houston-claim-conversation")).toBe(
+      "mission.1",
+    );
+  }
+  expect(docs[1]?.headers.get("if-match")).toBe("4");
+  expect(docs[1]?.body).toEqual({
+    doc: [{ description: "", ...activity[0] }],
+  });
+  const activityUpload = seen.find(({ url }) => url.endsWith(objectKey));
+  expect(activityUpload?.headers.get("x-houston-claim-conversation")).toBe(
+    "mission.1",
+  );
+  expect(raw).toContain('"type":"done"');
+  expect(raw).not.toContain('"type":"error"');
+});
+
+test("an activity doc conflict retries once with the returned revision", async () => {
+  const objects = seedStandingLayout();
+  const seen: SeenRequest[] = [];
+  const runTurn: typeof runPiTurn = async (filesystem) => {
+    writeConversation(filesystem);
+    writeActivity(filesystem, [
+      { id: "a1", title: "Launch", status: "running" },
+    ]);
+    return {};
+  };
+
+  const raw = await runTurnRequest({
+    runTurn,
+    poolStoreUrl: "https://pool.example",
+    fetchImpl: poolFetch(objects, seen, [
+      { status: 200, revision: 4 },
+      { status: 409, revision: 9 },
+      { status: 200, revision: 10 },
+    ]),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  const docs = seen.filter(({ url }) => url.includes("/v1/pod/docs/"));
+  expect(docs.map(({ method }) => method)).toEqual(["GET", "PUT", "PUT"]);
+  expect(docs[1]?.headers.get("if-match")).toBe("4");
+  expect(docs[2]?.headers.get("if-match")).toBe("9");
+  expect(raw).toContain('"type":"done"');
+  expect(raw).not.toContain('"type":"error"');
+});
+
+test("malformed activity entries are dropped without failing the turn", async () => {
+  const objects = seedStandingLayout();
+  const seen: SeenRequest[] = [];
+  const runTurn: typeof runPiTurn = async (filesystem) => {
+    writeConversation(filesystem);
+    writeActivity(filesystem, [
+      null,
+      { title: "Missing identity" },
+      { id: "a1", title: "Launch", status: "running" },
+    ]);
+    return {};
+  };
+
+  const raw = await runTurnRequest({
+    runTurn,
+    poolStoreUrl: "https://pool.example",
+    fetchImpl: poolFetch(objects, seen),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  const put = seen.find(
+    ({ method, url }) => method === "PUT" && url.includes("/v1/pod/docs/"),
+  );
+  expect(put?.body).toEqual({
+    doc: [{ id: "a1", title: "Launch", status: "running", description: "" }],
+  });
+  expect(raw).toContain('"type":"done"');
+  expect(raw).not.toContain('"type":"error"');
+});
+
+test("an activity doc PUT 404 reports route skew without failing the turn", async () => {
+  const objects = seedStandingLayout();
+  const seen: SeenRequest[] = [];
+  const runTurn: typeof runPiTurn = async (filesystem) => {
+    writeConversation(filesystem);
+    writeActivity(filesystem, [
+      { id: "a1", title: "Launch", status: "running" },
+    ]);
+    return {};
+  };
+
+  const raw = await runTurnRequest({
+    runTurn,
+    poolStoreUrl: "https://pool.example",
+    fetchImpl: poolFetch(objects, seen, [
+      { status: 200, revision: 4 },
+      { status: 404 },
+    ]),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  expect(seen.filter(({ url }) => url.includes("/v1/pod/docs/"))).toHaveLength(
+    2,
+  );
+  expect(raw).toContain('"type":"done"');
+  expect(raw).toContain('"activityDocSkipped":"route_absent"');
+  expect(raw).not.toContain('"type":"error"');
+});
+
+test("a persistent activity doc 503 becomes a status-only turn error", async () => {
+  const objects = seedStandingLayout();
+  const seen: SeenRequest[] = [];
+  const runTurn: typeof runPiTurn = async (filesystem) => {
+    writeConversation(filesystem);
+    writeActivity(filesystem, [
+      { id: "a1", title: "Launch", status: "running" },
+    ]);
+    return { error: "provider failed" };
+  };
+
+  const raw = await runTurnRequest({
+    runTurn,
+    poolStoreUrl: "https://pool.example",
+    fetchImpl: poolFetch(objects, seen, [
+      { status: 200, revision: 4 },
+      { status: 503, detail: "upstream database unavailable" },
+      { status: 503, detail: "upstream database unavailable" },
+      { status: 503, detail: "upstream database unavailable" },
+    ]),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  expect(seen.filter(({ url }) => url.includes("/v1/pod/docs/"))).toHaveLength(
+    4,
+  );
+  expect(raw).toContain('"type":"error"');
+  expect(raw).toContain(
+    "provider failed; board doc publish failed: PUT rejected (503)",
+  );
+  expect(raw).not.toContain("upstream database unavailable");
+  expect(raw).not.toContain('"type":"done"');
+});
+
+test("a claimed turn that does not touch activity makes no doc requests", async () => {
+  const objects = seedStandingLayout();
+  const seen: SeenRequest[] = [];
+  const runTurn: typeof runPiTurn = async (filesystem) => {
+    writeConversation(filesystem);
+    return {};
+  };
+
+  const raw = await runTurnRequest({
+    runTurn,
+    poolStoreUrl: "https://pool.example",
+    fetchImpl: poolFetch(objects, seen),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  expect(seen.some(({ url }) => url.includes("/v1/pod/docs/"))).toBe(false);
+  expect(raw).toContain('"type":"done"');
+  expect(raw).not.toContain('"type":"error"');
+});
+
+test("an unclaimed turn keeps full sync and makes no doc requests", async () => {
+  const storeRoot = mkdtempSync(join(tmpdir(), "standing-store-"));
+  const prefixRoot = join(storeRoot, "ws", "acme.org", "helper.bot");
+  const settings = join(
+    prefixRoot,
+    "workspaces",
+    "Main",
+    "Helper",
+    ".houston",
+    "runtime",
+    "settings.json",
+  );
+  mkdirSync(join(settings, ".."), { recursive: true });
+  writeFileSync(settings, "{}");
+  const seen: SeenRequest[] = [];
+  const runTurn: typeof runPiTurn = async (filesystem) => {
+    writeActivity(filesystem, [
+      { id: "a1", title: "Launch", status: "running" },
+    ]);
+    writeFileSync(join(filesystem.workspaceDir, "result.txt"), "complete");
+    return {};
+  };
+
+  const raw = await runTurnRequest(
+    {
+      store: new LocalDirStore(storeRoot),
+      runTurn,
+      poolStoreUrl: "https://pool.example",
+      fetchImpl: poolFetch(new Map(), seen),
+    },
+    turnBody({ claim: undefined, hostToken: undefined }),
+  );
+
+  expect(
+    readFileSync(
+      join(
+        prefixRoot,
+        "workspaces/Main/Helper/.houston/activity/activity.json",
+      ),
+      "utf8",
+    ),
+  ).toContain('"id":"a1"');
+  expect(
+    readFileSync(join(prefixRoot, "workspaces/Main/Helper/result.txt"), "utf8"),
+  ).toBe("complete");
+  expect(seen.some(({ url }) => url.includes("/v1/pod/docs/"))).toBe(false);
+  expect(raw).toContain('"type":"done"');
+  expect(raw).not.toContain('"type":"error"');
+});
+
+test("a shadow turn makes no activity doc requests", async () => {
+  const objects = seedStandingLayout();
+  const seen: SeenRequest[] = [];
+
+  const raw = await runTurnRequest(
+    {
+      runTurn: async () => {
+        throw new Error("shadow must not run the turn session");
+      },
+      poolStoreUrl: "https://pool.example",
+      fetchImpl: poolFetch(objects, seen),
+      heartbeatIntervalMs: 60_000,
+    },
+    turnBody({ shadow: true }),
+  );
+
+  expect(seen.some(({ url }) => url.includes("/v1/pod/docs/"))).toBe(false);
+  expect(raw).toContain('"type":"done"');
+  expect(raw).not.toContain('"type":"error"');
+});
+
+test("an absent activity doc seeds revision zero before PUT", async () => {
+  const objects = seedStandingLayout();
+  const seen: SeenRequest[] = [];
+  const runTurn: typeof runPiTurn = async (filesystem) => {
+    writeConversation(filesystem);
+    writeActivity(filesystem, [
+      { id: "a1", title: "Launch", status: "running" },
+    ]);
+    return {};
+  };
+
+  const raw = await runTurnRequest({
+    runTurn,
+    poolStoreUrl: "https://pool.example",
+    fetchImpl: poolFetch(objects, seen, [
+      { status: 404 },
+      { status: 200, revision: 1 },
+    ]),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  const docs = seen.filter(({ url }) => url.includes("/v1/pod/docs/"));
+  expect(docs.map(({ method }) => method)).toEqual(["GET", "PUT"]);
+  expect(docs[1]?.headers.get("if-match")).toBe("0");
+  expect(raw).toContain('"type":"done"');
+  expect(raw).not.toContain('"activityDocSkipped"');
+  expect(raw).not.toContain('"type":"error"');
+});

--- a/packages/runtime/src/turn/turn-activity-doc.ts
+++ b/packages/runtime/src/turn/turn-activity-doc.ts
@@ -1,0 +1,175 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { normalizeActivities } from "@houston/domain";
+import { fetchWithRetry } from "@houston/runtime-client/object-sync";
+import type { TurnServerDeps } from "./server-types";
+import { type TurnFilesystem, turnActivityKey } from "./turn-filesystem";
+import { poolIdentity } from "./turn-store";
+import type { TurnRequest } from "./types";
+
+const REQUEST_TIMEOUT_MS = 5_000;
+
+/** Outcome of projecting a claimed turn's uploaded activity file. */
+export type ActivityDocPublishResult =
+  | { ok: true }
+  | { disabled: true; reason: "route_absent" }
+  | { error: string };
+
+interface ActivityDocOptions {
+  baseUrl: string;
+  org: string;
+  agent: string;
+  conversationId: string;
+  hostToken: string;
+  claim: { token: string; bootId: string };
+  fetchImpl: typeof fetch;
+  retryDelaysMs?: number[];
+}
+
+const statusError = (method: string, response: Response) =>
+  ({
+    error: `${method} rejected (${response.status})`,
+  }) as const;
+
+async function request(
+  opts: ActivityDocOptions,
+  init?: RequestInit,
+): Promise<Response> {
+  const root = opts.baseUrl.replace(/\/+$/, "");
+  const url = `${root}/v1/pod/docs/${encodeURIComponent(
+    opts.org,
+  )}/${encodeURIComponent(opts.agent)}/activity`;
+  return fetchWithRetry(
+    (input, requestInit) =>
+      opts.fetchImpl(input, {
+        ...requestInit,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      }),
+    url,
+    {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${opts.hostToken}`,
+        "X-Houston-Claim-Token": opts.claim.token,
+        "X-Houston-Claim-Boot": opts.claim.bootId,
+        "X-Houston-Claim-Conversation": opts.conversationId,
+        ...init?.headers,
+      },
+    },
+    opts.retryDelaysMs ? { delaysMs: opts.retryDelaysMs } : {},
+  );
+}
+
+async function responseRevision(
+  response: Response,
+): Promise<number | undefined> {
+  const etag = response.headers
+    .get("ETag")
+    ?.replace(/^W\//, "")
+    .replaceAll('"', "");
+  if (etag && Number.isSafeInteger(Number(etag))) {
+    await response.body?.cancel();
+    return Number(etag);
+  }
+  const text = await response.text();
+  if (!text) return undefined;
+  try {
+    const body = JSON.parse(text) as { revision?: unknown };
+    return typeof body.revision === "number" &&
+      Number.isSafeInteger(body.revision)
+      ? body.revision
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function putAtRevision(
+  opts: ActivityDocOptions,
+  doc: unknown,
+  revision: number,
+): Promise<Response> {
+  return request(opts, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      "If-Match": String(revision),
+    },
+    body: JSON.stringify({ doc }),
+  });
+}
+
+async function acceptPut(
+  response: Response,
+): Promise<ActivityDocPublishResult> {
+  if (response.status === 404) {
+    await response.body?.cancel();
+    return { disabled: true, reason: "route_absent" };
+  }
+  if (!response.ok) {
+    await response.body?.cancel();
+    return statusError("PUT", response);
+  }
+  await response.body?.cancel();
+  return { ok: true };
+}
+
+async function publish(
+  opts: ActivityDocOptions,
+  doc: unknown,
+): Promise<ActivityDocPublishResult> {
+  const seeded = await request(opts);
+  let revision: number;
+  if (seeded.status === 404) {
+    await seeded.body?.cancel();
+    revision = 0;
+  } else if (!seeded.ok) {
+    await seeded.body?.cancel();
+    return statusError("GET", seeded);
+  } else {
+    revision = (await responseRevision(seeded)) ?? 0;
+  }
+
+  const response = await putAtRevision(opts, doc, revision);
+  if (response.status !== 409) return acceptPut(response);
+  const current = await responseRevision(response);
+  if (current === undefined) return statusError("PUT", response);
+  return acceptPut(await putAtRevision(opts, doc, current));
+}
+
+/** Project one successfully uploaded claimed-turn activity file into the DB doc. */
+export async function publishTurnActivityDoc(
+  deps: TurnServerDeps,
+  turn: TurnRequest & { turnId: string },
+  filesystem: TurnFilesystem,
+): Promise<ActivityDocPublishResult | null> {
+  const baseUrl = deps.poolStoreUrl ?? process.env.HOUSTON_POOL_STORE_URL;
+  if (turn.shadow || !baseUrl || !turn.claim || !turn.hostToken) return null;
+  try {
+    const key = turnActivityKey(filesystem.workspaceRel);
+    const raw = await readFile(
+      join(filesystem.workspaceDir, ".houston", "activity", "activity.json"),
+      "utf8",
+    );
+    const parsed = JSON.parse(raw.replace(/^\uFEFF/, "")) as unknown;
+    const doc = normalizeActivities(parsed, key).items;
+    const { org, agent } = poolIdentity(turn.gcsPrefix);
+    return await publish(
+      {
+        baseUrl,
+        org,
+        agent,
+        conversationId: turn.conversationId,
+        hostToken: turn.hostToken,
+        claim: { token: turn.claim.token, bootId: turn.claim.bootId },
+        fetchImpl: deps.fetchImpl ?? fetch,
+        ...(deps.activityDocRetryDelaysMs
+          ? { retryDelaysMs: deps.activityDocRetryDelaysMs }
+          : {}),
+      },
+      doc,
+    );
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/packages/runtime/src/turn/turn-durability.ts
+++ b/packages/runtime/src/turn/turn-durability.ts
@@ -1,0 +1,109 @@
+import { StoreFencedError } from "@houston/runtime-client/object-sync";
+import type { ClaimHeartbeat } from "./claim-heartbeat";
+import type { TurnServerDeps } from "./server-types";
+import { syncTurnFilesystem, type TurnFilesystem } from "./turn-filesystem";
+import type { TurnOutcome } from "./turn-session";
+import type { ResolvedTurnStore } from "./turn-store";
+import {
+  createTurnTranscript,
+  type TranscriptPublishResult,
+} from "./turn-transcript";
+import type { TurnRequest } from "./types";
+
+interface TurnDurabilityOptions {
+  deps: TurnServerDeps;
+  turn: TurnRequest & { turnId: string };
+  filesystem: TurnFilesystem;
+  resolved: ResolvedTurnStore;
+  heartbeat: ClaimHeartbeat | null;
+  outcome: TurnOutcome;
+}
+
+export interface TurnDurabilityResult {
+  outcome: TurnOutcome;
+  poolWritesOutOfScope: number;
+  /** Set when transcript rows were deliberately not published. */
+  transcriptSkipped?: "route_absent";
+}
+
+function appendError(outcome: TurnOutcome, error: string): TurnOutcome {
+  return { error: outcome.error ? `${outcome.error}; ${error}` : error };
+}
+
+/** Make claimed-turn state durable before the caller emits a terminal frame. */
+export async function finishTurnDurability(
+  opts: TurnDurabilityOptions,
+): Promise<TurnDurabilityResult> {
+  await opts.heartbeat?.checkpoint();
+  if (opts.heartbeat?.fenced) {
+    return { outcome: { error: "claim_fenced" }, poolWritesOutOfScope: 0 };
+  }
+
+  let poolWritesOutOfScope: number;
+  try {
+    // Failed provider work may still have durable tool writes. Only a fence
+    // may skip sync because a fenced worker no longer owns this conversation.
+    poolWritesOutOfScope = await syncTurnFilesystem({
+      store: opts.resolved.store,
+      prefix: opts.resolved.prefix,
+      filesystem: opts.filesystem,
+      conversationId: opts.turn.conversationId,
+      claimed: Boolean(opts.turn.claim),
+    });
+  } catch (error) {
+    // A fenced object write means the claim was adopted mid-sync: report it
+    // as exactly that, not as a generic sync failure.
+    if (error instanceof StoreFencedError) {
+      return { outcome: { error: "claim_fenced" }, poolWritesOutOfScope: 0 };
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    const failure = opts.outcome.error
+      ? `sync failed: ${message}`
+      : `workspace sync failed: ${message}`;
+    return {
+      outcome: appendError(opts.outcome, failure),
+      poolWritesOutOfScope: 0,
+    };
+  }
+
+  // The object copy must land first. Otherwise history fallback could expose
+  // transcript rows whose authoritative conversation file is still missing.
+  let published: TranscriptPublishResult | undefined;
+  try {
+    published = await createTurnTranscript(
+      opts.deps,
+      opts.turn,
+      opts.filesystem,
+    )?.publish();
+  } catch (error) {
+    published = {
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+  if (published && "fenced" in published) {
+    return { outcome: { error: "claim_fenced" }, poolWritesOutOfScope };
+  }
+  if (published && "error" in published) {
+    return {
+      outcome: appendError(
+        opts.outcome,
+        `transcript publish failed: ${published.error}`,
+      ),
+      poolWritesOutOfScope,
+    };
+  }
+  // The claim may have been adopted while sync/publish were in flight (the
+  // heartbeat loop learns it asynchronously). A last checkpoint keeps a stale
+  // worker from ever announcing a clean done.
+  await opts.heartbeat?.checkpoint();
+  if (opts.heartbeat?.fenced) {
+    return { outcome: { error: "claim_fenced" }, poolWritesOutOfScope };
+  }
+  return {
+    outcome: opts.outcome,
+    poolWritesOutOfScope,
+    ...(published && "disabled" in published
+      ? { transcriptSkipped: published.reason }
+      : {}),
+  };
+}

--- a/packages/runtime/src/turn/turn-durability.ts
+++ b/packages/runtime/src/turn/turn-durability.ts
@@ -4,9 +4,9 @@ import type { TurnServerDeps } from "./server-types";
 import { syncTurnFilesystem, type TurnFilesystem } from "./turn-filesystem";
 import type { TurnOutcome } from "./turn-session";
 import type { ResolvedTurnStore } from "./turn-store";
-import {
-  createTurnTranscript,
-  type TranscriptPublishResult,
+import type {
+  TranscriptPublishResult,
+  TurnTranscript,
 } from "./turn-transcript";
 import type { TurnRequest } from "./types";
 
@@ -17,6 +17,8 @@ interface TurnDurabilityOptions {
   resolved: ResolvedTurnStore;
   heartbeat: ClaimHeartbeat | null;
   outcome: TurnOutcome;
+  /** The turn's transcript publisher (created at turn start; null = none). */
+  transcript: TurnTranscript | null;
 }
 
 export interface TurnDurabilityResult {
@@ -70,11 +72,7 @@ export async function finishTurnDurability(
   // transcript rows whose authoritative conversation file is still missing.
   let published: TranscriptPublishResult | undefined;
   try {
-    published = await createTurnTranscript(
-      opts.deps,
-      opts.turn,
-      opts.filesystem,
-    )?.publish();
+    published = await opts.transcript?.publish();
   } catch (error) {
     published = {
       error: error instanceof Error ? error.message : String(error),

--- a/packages/runtime/src/turn/turn-durability.ts
+++ b/packages/runtime/src/turn/turn-durability.ts
@@ -1,7 +1,12 @@
 import { StoreFencedError } from "@houston/runtime-client/object-sync";
 import type { ClaimHeartbeat } from "./claim-heartbeat";
 import type { TurnServerDeps } from "./server-types";
-import { syncTurnFilesystem, type TurnFilesystem } from "./turn-filesystem";
+import { publishTurnActivityDoc } from "./turn-activity-doc";
+import {
+  syncTurnFilesystem,
+  type TurnFilesystem,
+  turnActivityKey,
+} from "./turn-filesystem";
 import type { TurnOutcome } from "./turn-session";
 import type { ResolvedTurnStore } from "./turn-store";
 import type {
@@ -26,6 +31,8 @@ export interface TurnDurabilityResult {
   poolWritesOutOfScope: number;
   /** Set when transcript rows were deliberately not published. */
   transcriptSkipped?: "route_absent";
+  /** Set when the activity doc route is absent on an older deployment. */
+  activityDocSkipped?: "route_absent";
 }
 
 function appendError(outcome: TurnOutcome, error: string): TurnOutcome {
@@ -42,16 +49,19 @@ export async function finishTurnDurability(
   }
 
   let poolWritesOutOfScope: number;
+  let uploaded: string[];
   try {
     // Failed provider work may still have durable tool writes. Only a fence
     // may skip sync because a fenced worker no longer owns this conversation.
-    poolWritesOutOfScope = await syncTurnFilesystem({
+    const synced = await syncTurnFilesystem({
       store: opts.resolved.store,
       prefix: opts.resolved.prefix,
       filesystem: opts.filesystem,
       conversationId: opts.turn.conversationId,
       claimed: Boolean(opts.turn.claim),
     });
+    poolWritesOutOfScope = synced.outOfScope;
+    uploaded = synced.uploaded;
   } catch (error) {
     // A fenced object write means the claim was adopted mid-sync: report it
     // as exactly that, not as a generic sync failure.
@@ -70,6 +80,7 @@ export async function finishTurnDurability(
 
   // The object copy must land first. Otherwise history fallback could expose
   // transcript rows whose authoritative conversation file is still missing.
+  let outcome = opts.outcome;
   let published: TranscriptPublishResult | undefined;
   try {
     published = await opts.transcript?.publish();
@@ -82,13 +93,24 @@ export async function finishTurnDurability(
     return { outcome: { error: "claim_fenced" }, poolWritesOutOfScope };
   }
   if (published && "error" in published) {
-    return {
-      outcome: appendError(
-        opts.outcome,
-        `transcript publish failed: ${published.error}`,
-      ),
-      poolWritesOutOfScope,
-    };
+    outcome = appendError(
+      outcome,
+      `transcript publish failed: ${published.error}`,
+    );
+  }
+
+  const activityChanged = uploaded.includes(
+    turnActivityKey(opts.filesystem.workspaceRel),
+  );
+  const activityPublished =
+    opts.turn.claim && activityChanged
+      ? await publishTurnActivityDoc(opts.deps, opts.turn, opts.filesystem)
+      : null;
+  if (activityPublished && "error" in activityPublished) {
+    outcome = appendError(
+      outcome,
+      `board doc publish failed: ${activityPublished.error}`,
+    );
   }
   // The claim may have been adopted while sync/publish were in flight (the
   // heartbeat loop learns it asynchronously). A last checkpoint keeps a stale
@@ -98,10 +120,13 @@ export async function finishTurnDurability(
     return { outcome: { error: "claim_fenced" }, poolWritesOutOfScope };
   }
   return {
-    outcome: opts.outcome,
+    outcome,
     poolWritesOutOfScope,
     ...(published && "disabled" in published
       ? { transcriptSkipped: published.reason }
+      : {}),
+    ...(activityPublished && "disabled" in activityPublished
+      ? { activityDocSkipped: activityPublished.reason }
       : {}),
   };
 }

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -1,0 +1,102 @@
+import { mkdir } from "node:fs/promises";
+import { join, posix } from "node:path";
+import {
+  HydrateLimitError,
+  type HydrateManifest,
+  hydrate,
+  type ObjectStore,
+  syncBack,
+} from "@houston/runtime-client/object-sync";
+import {
+  resolveTurnLayout,
+  type TurnLayout,
+  TurnSetupError,
+} from "./turn-layout";
+
+/** Maximum hydrated bytes accepted by a pooled turn. */
+export const TURN_HYDRATE_MAX_BYTES = 2 * 1024 * 1024 * 1024;
+
+/** Hydrated manifest paired with the resolved on-disk layout. */
+export interface TurnFilesystem extends TurnLayout {
+  storeRoot: string;
+  manifest: HydrateManifest;
+}
+
+/**
+ * Hydrate an isolated store tree and resolve the layout it contains. Only a
+ * CLAIMED (pool) turn gets the pool's 2 GiB cap; an unclaimed turn keeps
+ * hydrate's own default so a deployment without the pool env behaves exactly
+ * as before.
+ */
+export async function prepareTurnFilesystem(opts: {
+  store: ObjectStore;
+  prefix: string;
+  root: string;
+  claimed: boolean;
+  maxBytes?: number;
+}): Promise<TurnFilesystem> {
+  const storeRoot = join(opts.root, "store");
+  await mkdir(storeRoot, { recursive: true });
+  const maxBytes =
+    opts.maxBytes ?? (opts.claimed ? TURN_HYDRATE_MAX_BYTES : undefined);
+  let manifest: HydrateManifest;
+  try {
+    manifest = await hydrate(opts.store, opts.prefix, storeRoot, {
+      ...(maxBytes !== undefined ? { maxBytes } : {}),
+    });
+  } catch (error) {
+    if (!(error instanceof HydrateLimitError)) throw error;
+    throw new TurnSetupError("hydrate_over_cap", error.message);
+  }
+  return {
+    ...(await resolveTurnLayout(storeRoot, { allowEmpty: !opts.claimed })),
+    storeRoot,
+    manifest,
+  };
+}
+
+/** Build the exact conversation and session scope granted to one claim. */
+export function claimedTurnIncludes(
+  dataRel: string,
+  conversationId: string,
+): (relativePath: string) => boolean {
+  const conversation = posix.join(
+    dataRel,
+    "conversations",
+    `${encodeURIComponent(conversationId)}.json`,
+  );
+  const session = posix.join(dataRel, "sessions", conversationId);
+  return (relativePath) =>
+    relativePath === conversation || relativePath.startsWith(`${session}/`);
+}
+
+/** Sync a turn, limiting a claimed writer to its granted conversation. */
+export async function syncTurnFilesystem(opts: {
+  store: ObjectStore;
+  prefix: string;
+  filesystem: TurnFilesystem;
+  conversationId: string;
+  claimed: boolean;
+}): Promise<number> {
+  const result = await syncBack(
+    opts.store,
+    opts.prefix,
+    opts.filesystem.storeRoot,
+    opts.filesystem.manifest,
+    opts.claimed
+      ? {
+          include: claimedTurnIncludes(
+            opts.filesystem.dataRel,
+            opts.conversationId,
+          ),
+        }
+      : {},
+  );
+  if (result.outOfScope > 0) {
+    // Attributed: on a shared worker an unattributed count is unactionable.
+    console.info(
+      `[turn] pool_writes_out_of_scope=${result.outOfScope} prefix=${opts.prefix || opts.filesystem.dataRel} conversation=${opts.conversationId}`,
+    );
+  }
+  return result.outOfScope;
+}

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -1,5 +1,6 @@
 import { mkdir } from "node:fs/promises";
 import { join, posix } from "node:path";
+import { docKey } from "@houston/domain";
 import {
   HydrateLimitError,
   type HydrateManifest,
@@ -55,9 +56,10 @@ export async function prepareTurnFilesystem(opts: {
   };
 }
 
-/** Build the exact conversation and session scope granted to one claim. */
+/** Build the exact conversation, session, and activity-doc write scope. */
 export function claimedTurnIncludes(
   dataRel: string,
+  workspaceRel: string,
   conversationId: string,
 ): (relativePath: string) => boolean {
   const conversation = posix.join(
@@ -66,18 +68,25 @@ export function claimedTurnIncludes(
     `${encodeURIComponent(conversationId)}.json`,
   );
   const session = posix.join(dataRel, "sessions", conversationId);
+  const activity = turnActivityKey(workspaceRel);
   return (relativePath) =>
-    relativePath === conversation || relativePath.startsWith(`${session}/`);
+    relativePath === conversation ||
+    relativePath.startsWith(`${session}/`) ||
+    relativePath === activity;
 }
 
-/** Sync a turn, limiting a claimed writer to its granted conversation. */
+/** Store-relative mission-board object granted to a claimed turn. */
+export const turnActivityKey = (workspaceRel: string): string =>
+  docKey(workspaceRel, "activity");
+
+/** Sync a turn, limiting a claimed writer to its granted turn-owned files. */
 export async function syncTurnFilesystem(opts: {
   store: ObjectStore;
   prefix: string;
   filesystem: TurnFilesystem;
   conversationId: string;
   claimed: boolean;
-}): Promise<number> {
+}): Promise<{ uploaded: string[]; outOfScope: number }> {
   const result = await syncBack(
     opts.store,
     opts.prefix,
@@ -87,6 +96,7 @@ export async function syncTurnFilesystem(opts: {
       ? {
           include: claimedTurnIncludes(
             opts.filesystem.dataRel,
+            opts.filesystem.workspaceRel,
             opts.conversationId,
           ),
         }
@@ -98,5 +108,5 @@ export async function syncTurnFilesystem(opts: {
       `[turn] pool_writes_out_of_scope=${result.outOfScope} prefix=${opts.prefix || opts.filesystem.dataRel} conversation=${opts.conversationId}`,
     );
   }
-  return result.outOfScope;
+  return { uploaded: result.uploaded, outOfScope: result.outOfScope };
 }

--- a/packages/runtime/src/turn/turn-layout-sync.test.ts
+++ b/packages/runtime/src/turn/turn-layout-sync.test.ts
@@ -1,0 +1,212 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import type { Server } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { LocalDirStore } from "@houston/runtime-client/object-sync";
+import { afterEach, expect, test, vi } from "vitest";
+import { createTurnServer } from "./server";
+import type { runPiTurn } from "./turn-session";
+
+const servers: Server[] = [];
+afterEach(() =>
+  servers.splice(0).forEach((server) => {
+    server.close();
+  }),
+);
+
+async function listen(server: Server): Promise<string> {
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("no address");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function frames(raw: string) {
+  return raw
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map(
+      (line) =>
+        JSON.parse(line.slice(6)) as {
+          type: string;
+          data: Record<string, unknown> | null;
+        },
+    );
+}
+
+const request = (extra: Record<string, unknown> = {}) => ({
+  workspaceId: "w1",
+  agentId: "agent-1",
+  conversationId: "c1",
+  text: "hello",
+  gcsPrefix: "ws/w1/agent-1",
+  credential: {
+    provider: "openai-codex",
+    access: "access-token",
+    expires: Date.now() + 60_000,
+  },
+  ...extra,
+});
+
+async function post(base: string, body: Record<string, unknown>) {
+  const response = await fetch(`${base}/turn`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return frames(await response.text());
+}
+
+async function seed(root: string, rel: string, content: string) {
+  const path = join(root, ...rel.split("/"));
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content);
+}
+
+const claimed = {
+  hostToken: "host-token",
+  claim: {
+    id: "claim-1",
+    bootId: "boot-1",
+    token: "claim-token",
+    heartbeatUrl: "https://gateway.test/v1/pool/claims/heartbeat",
+  },
+};
+
+test.each([
+  {
+    name: "standing",
+    dataRel: "workspaces/W/A/.houston/runtime",
+    workspaceRel: "workspaces/W/A",
+  },
+  { name: "cloudrun", dataRel: "data", workspaceRel: "workspace" },
+])("a claimed turn syncs only its conversation and session on $name layout", async ({
+  dataRel,
+  workspaceRel,
+}) => {
+  const storeRoot = await mkdtemp(join(tmpdir(), "turn-store-"));
+  const prefixRoot = join(storeRoot, "ws", "w1", "agent-1");
+  await seed(prefixRoot, `${dataRel}/settings.json`, "{}");
+  await seed(prefixRoot, `${dataRel}/conversations/c1.json`, '{"before":1}');
+  const runTurn: typeof runPiTurn = async (layout) => {
+    await seed(layout.dataDir, "conversations/c1.json", '{"after":1}');
+    await seed(layout.dataDir, "sessions/c1/state.json", "session");
+    await seed(layout.workspaceDir, "result.txt", "workspace");
+    await seed(layout.workspaceDir, ".houston/routines.json", "routines");
+    return {};
+  };
+  const log = vi.spyOn(console, "info").mockImplementation(() => undefined);
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn,
+      fetchImpl: async () => new Response(null, { status: 204 }),
+    }),
+  );
+
+  const emitted = await post(base, request(claimed));
+  const keys = await new LocalDirStore(storeRoot).list("ws/w1/agent-1");
+
+  expect(
+    await readFile(join(prefixRoot, dataRel, "conversations/c1.json"), "utf8"),
+  ).toBe('{"after":1}');
+  expect(
+    await readFile(join(prefixRoot, dataRel, "sessions/c1/state.json"), "utf8"),
+  ).toBe("session");
+  expect(keys).not.toContain(`ws/w1/agent-1/${workspaceRel}/result.txt`);
+  expect(keys).not.toContain(
+    `ws/w1/agent-1/${workspaceRel}/.houston/routines.json`,
+  );
+  expect(emitted.at(-1)).toMatchObject({
+    type: "done",
+    data: { poolWritesOutOfScope: 2 },
+  });
+  expect(log).toHaveBeenCalledWith(
+    "[turn] pool_writes_out_of_scope=2 prefix=ws/w1/agent-1 conversation=c1",
+  );
+  log.mockRestore();
+});
+
+test("an unclaimed turn retains full sync-back", async () => {
+  const storeRoot = await mkdtemp(join(tmpdir(), "turn-store-"));
+  const prefixRoot = join(storeRoot, "ws", "w1", "agent-1");
+  await seed(prefixRoot, "data/settings.json", "{}");
+  const runTurn: typeof runPiTurn = async (layout) => {
+    await seed(layout.workspaceDir, "result.txt", "workspace");
+    await seed(layout.dataDir, "sessions/c1/state.json", "session");
+    return {};
+  };
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn,
+    }),
+  );
+
+  const emitted = await post(base, request());
+  expect(await readFile(join(prefixRoot, "workspace/result.txt"), "utf8")).toBe(
+    "workspace",
+  );
+  expect(emitted.at(-1)).toEqual(
+    expect.objectContaining({ type: "done", data: null }),
+  );
+});
+
+test("shadow resolves a standing layout and reports hydrated objects", async () => {
+  const storeRoot = await mkdtemp(join(tmpdir(), "turn-store-"));
+  const prefixRoot = join(storeRoot, "ws", "w1", "agent-1");
+  await seed(prefixRoot, "workspaces/W/A/.houston/runtime/settings.json", "{}");
+  const runTurn = vi.fn<typeof runPiTurn>();
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn,
+    }),
+  );
+
+  const emitted = await post(base, request({ shadow: true }));
+  expect(emitted.map(({ type }) => type)).toEqual(["shadow", "done"]);
+  expect(emitted[0]?.data).toMatchObject({ hydratedObjects: 1 });
+  expect(runTurn).not.toHaveBeenCalled();
+});
+
+test("a claimed turn on an EMPTY prefix is layout_unexpected, never a seeded cloudrun tree", async () => {
+  const storeRoot = await mkdtemp(join(tmpdir(), "turn-store-"));
+  const runTurn = vi.fn<typeof runPiTurn>();
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn,
+      fetchImpl: async () => new Response(null, { status: 204 }),
+    }),
+  );
+  const emitted = await post(base, request(claimed));
+  expect(emitted.at(-1)).toMatchObject({
+    type: "error",
+    data: { code: "layout_unexpected" },
+  });
+  expect(runTurn).not.toHaveBeenCalled();
+  // Nothing was written back: a blank hydrate must not seed `data/` beside a
+  // standing agent's real tree.
+  expect(await new LocalDirStore(storeRoot).list("ws/w1/agent-1")).toEqual([]);
+});
+
+test("an unclaimed turn on an EMPTY prefix still starts as a fresh cloudrun agent", async () => {
+  const storeRoot = await mkdtemp(join(tmpdir(), "turn-store-"));
+  const runTurn = vi.fn<typeof runPiTurn>(async () => ({}));
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn,
+    }),
+  );
+  const emitted = await post(base, request());
+  expect(emitted.at(-1)?.type).toBe("done");
+  expect(runTurn).toHaveBeenCalledOnce();
+});

--- a/packages/runtime/src/turn/turn-layout-sync.test.ts
+++ b/packages/runtime/src/turn/turn-layout-sync.test.ts
@@ -92,8 +92,18 @@ test.each([
   const runTurn: typeof runPiTurn = async (layout) => {
     await seed(layout.dataDir, "conversations/c1.json", '{"after":1}');
     await seed(layout.dataDir, "sessions/c1/state.json", "session");
+    await seed(
+      layout.workspaceDir,
+      ".houston/activity/activity.json",
+      '[{"id":"a1","title":"Plan","status":"running"}]',
+    );
+    await seed(
+      layout.workspaceDir,
+      ".houston/activity/activity.schema.json",
+      '{"type":"array"}',
+    );
     await seed(layout.workspaceDir, "result.txt", "workspace");
-    await seed(layout.workspaceDir, ".houston/routines.json", "routines");
+    await seed(layout.workspaceDir, ".houston/routines/routines.json", "[]");
     return {};
   };
   const log = vi.spyOn(console, "info").mockImplementation(() => undefined);
@@ -115,16 +125,25 @@ test.each([
   expect(
     await readFile(join(prefixRoot, dataRel, "sessions/c1/state.json"), "utf8"),
   ).toBe("session");
+  expect(
+    await readFile(
+      join(prefixRoot, workspaceRel, ".houston/activity/activity.json"),
+      "utf8",
+    ),
+  ).toBe('[{"id":"a1","title":"Plan","status":"running"}]');
   expect(keys).not.toContain(`ws/w1/agent-1/${workspaceRel}/result.txt`);
   expect(keys).not.toContain(
-    `ws/w1/agent-1/${workspaceRel}/.houston/routines.json`,
+    `ws/w1/agent-1/${workspaceRel}/.houston/activity/activity.schema.json`,
+  );
+  expect(keys).not.toContain(
+    `ws/w1/agent-1/${workspaceRel}/.houston/routines/routines.json`,
   );
   expect(emitted.at(-1)).toMatchObject({
     type: "done",
-    data: { poolWritesOutOfScope: 2 },
+    data: { poolWritesOutOfScope: 3 },
   });
   expect(log).toHaveBeenCalledWith(
-    "[turn] pool_writes_out_of_scope=2 prefix=ws/w1/agent-1 conversation=c1",
+    "[turn] pool_writes_out_of_scope=3 prefix=ws/w1/agent-1 conversation=c1",
   );
   log.mockRestore();
 });

--- a/packages/runtime/src/turn/turn-layout.test.ts
+++ b/packages/runtime/src/turn/turn-layout.test.ts
@@ -1,0 +1,65 @@
+import { access, mkdir, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { resolveTurnLayout, type TurnSetupError } from "./turn-layout";
+
+const root = () => mkdtemp(join(tmpdir(), "turn-layout-"));
+
+test("resolves the single standing agent and creates its runtime data dir", async () => {
+  const storeRoot = await root();
+  const agentDir = join(storeRoot, "workspaces", "W", "A");
+  await mkdir(agentDir, { recursive: true });
+  await mkdir(join(storeRoot, "workspaces", "W", ".shared"), {
+    recursive: true,
+  });
+
+  await expect(resolveTurnLayout(storeRoot)).resolves.toEqual({
+    kind: "standing",
+    workspaceDir: agentDir,
+    dataDir: join(agentDir, ".houston", "runtime"),
+    dataRel: "workspaces/W/A/.houston/runtime",
+  });
+  await expect(access(join(agentDir, ".houston", "runtime"))).resolves.toBe(
+    undefined,
+  );
+});
+
+test.each([
+  "data",
+  "workspace",
+])("resolves a cloudrun tree containing %s", async (present) => {
+  const storeRoot = await root();
+  await mkdir(join(storeRoot, present));
+
+  await expect(resolveTurnLayout(storeRoot)).resolves.toEqual({
+    kind: "cloudrun",
+    workspaceDir: join(storeRoot, "workspace"),
+    dataDir: join(storeRoot, "data"),
+    dataRel: "data",
+  });
+});
+
+test("an empty tree is a brand-new cloudrun layout", async () => {
+  const storeRoot = await root();
+  await expect(resolveTurnLayout(storeRoot)).resolves.toMatchObject({
+    kind: "cloudrun",
+    dataRel: "data",
+  });
+});
+
+test.each([
+  ["multiple agents", ["workspaces/W/A", "workspaces/W/B"]],
+  ["standing plus cloudrun", ["workspaces/W/A", "data"]],
+])("rejects an ambiguous %s tree", async (_name, directories) => {
+  const storeRoot = await root();
+  await Promise.all(
+    directories.map((directory) =>
+      mkdir(join(storeRoot, ...directory.split("/")), { recursive: true }),
+    ),
+  );
+
+  await expect(resolveTurnLayout(storeRoot)).rejects.toMatchObject({
+    code: "layout_unexpected",
+  } satisfies Partial<TurnSetupError>);
+});

--- a/packages/runtime/src/turn/turn-layout.test.ts
+++ b/packages/runtime/src/turn/turn-layout.test.ts
@@ -17,6 +17,7 @@ test("resolves the single standing agent and creates its runtime data dir", asyn
   await expect(resolveTurnLayout(storeRoot)).resolves.toEqual({
     kind: "standing",
     workspaceDir: agentDir,
+    workspaceRel: "workspaces/W/A",
     dataDir: join(agentDir, ".houston", "runtime"),
     dataRel: "workspaces/W/A/.houston/runtime",
   });
@@ -35,6 +36,7 @@ test.each([
   await expect(resolveTurnLayout(storeRoot)).resolves.toEqual({
     kind: "cloudrun",
     workspaceDir: join(storeRoot, "workspace"),
+    workspaceRel: "workspace",
     dataDir: join(storeRoot, "data"),
     dataRel: "data",
   });

--- a/packages/runtime/src/turn/turn-layout.ts
+++ b/packages/runtime/src/turn/turn-layout.ts
@@ -1,0 +1,113 @@
+import type { Dirent } from "node:fs";
+import { mkdir, readdir } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+
+/** Stable internal codes for failures before provider execution. */
+export type TurnSetupCode = "hydrate_over_cap" | "layout_unexpected";
+
+/** A setup failure the internal turn stream exposes as a stable code. */
+export class TurnSetupError extends Error {
+  constructor(
+    readonly code: TurnSetupCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "TurnSetupError";
+  }
+}
+
+/** Resolved pi directories and their object-store-relative data path. */
+export interface TurnLayout {
+  kind: "standing" | "cloudrun";
+  workspaceDir: string;
+  dataDir: string;
+  dataRel: string;
+}
+
+const directories = (entries: Dirent[]) =>
+  entries.filter((entry) => entry.isDirectory() && !entry.name.startsWith("."));
+
+async function readDirectories(path: string): Promise<Dirent[]> {
+  try {
+    return directories(await readdir(path, { withFileTypes: true }));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+const storeRelative = (storeRoot: string, path: string) =>
+  relative(storeRoot, path).split(sep).join("/");
+
+async function standingAgents(storeRoot: string): Promise<string[]> {
+  const workspacesRoot = join(storeRoot, "workspaces");
+  const workspaces = await readDirectories(workspacesRoot);
+  const agents = await Promise.all(
+    workspaces.map(async (workspace) =>
+      (await readDirectories(join(workspacesRoot, workspace.name))).map(
+        (agent) => join(workspacesRoot, workspace.name, agent.name),
+      ),
+    ),
+  );
+  return agents.flat();
+}
+
+/**
+ * Resolve the hydrated agent tree into the directories pi consumes. An EMPTY
+ * tree is a legitimate first turn only for an unclaimed (legacy per-workspace)
+ * runtime; a claimed pool turn targets a standing agent that already exists,
+ * so zero hydrated objects there means the hydrate missed (a blank prefix)
+ * and running would seed a second layout beside the real one.
+ */
+export async function resolveTurnLayout(
+  storeRoot: string,
+  opts: { allowEmpty?: boolean } = {},
+): Promise<TurnLayout> {
+  const rootEntries = await readdir(storeRoot, { withFileTypes: true });
+  const rootDirectories = new Set(
+    rootEntries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name),
+  );
+  const hasWorkspaces = rootDirectories.has("workspaces");
+  const hasData = rootDirectories.has("data");
+  const hasWorkspace = rootDirectories.has("workspace");
+  const agents = hasWorkspaces ? await standingAgents(storeRoot) : [];
+
+  if ((hasWorkspaces && hasData) || agents.length > 1) {
+    throw new TurnSetupError(
+      "layout_unexpected",
+      "hydrated store contains more than one agent layout",
+    );
+  }
+  if (agents.length === 1) {
+    const workspaceDir = agents[0] as string;
+    const dataDir = join(workspaceDir, ".houston", "runtime");
+    await mkdir(dataDir, { recursive: true });
+    return {
+      kind: "standing",
+      workspaceDir,
+      dataDir,
+      dataRel: storeRelative(storeRoot, dataDir),
+    };
+  }
+  if (
+    hasData ||
+    hasWorkspace ||
+    (rootEntries.length === 0 && (opts.allowEmpty ?? true))
+  ) {
+    const workspaceDir = join(storeRoot, "workspace");
+    const dataDir = join(storeRoot, "data");
+    await Promise.all([
+      mkdir(workspaceDir, { recursive: true }),
+      mkdir(dataDir, { recursive: true }),
+    ]);
+    return { kind: "cloudrun", workspaceDir, dataDir, dataRel: "data" };
+  }
+  throw new TurnSetupError(
+    "layout_unexpected",
+    rootEntries.length === 0
+      ? "hydrated store is empty; a claimed turn needs an existing agent"
+      : "hydrated store does not contain a recognized agent layout",
+  );
+}

--- a/packages/runtime/src/turn/turn-layout.ts
+++ b/packages/runtime/src/turn/turn-layout.ts
@@ -20,6 +20,7 @@ export class TurnSetupError extends Error {
 export interface TurnLayout {
   kind: "standing" | "cloudrun";
   workspaceDir: string;
+  workspaceRel: string;
   dataDir: string;
   dataRel: string;
 }
@@ -87,6 +88,7 @@ export async function resolveTurnLayout(
     return {
       kind: "standing",
       workspaceDir,
+      workspaceRel: storeRelative(storeRoot, workspaceDir),
       dataDir,
       dataRel: storeRelative(storeRoot, dataDir),
     };
@@ -102,7 +104,13 @@ export async function resolveTurnLayout(
       mkdir(workspaceDir, { recursive: true }),
       mkdir(dataDir, { recursive: true }),
     ]);
-    return { kind: "cloudrun", workspaceDir, dataDir, dataRel: "data" };
+    return {
+      kind: "cloudrun",
+      workspaceDir,
+      workspaceRel: "workspace",
+      dataDir,
+      dataRel: "data",
+    };
   }
   throw new TurnSetupError(
     "layout_unexpected",

--- a/packages/runtime/src/turn/turn-log.test.ts
+++ b/packages/runtime/src/turn/turn-log.test.ts
@@ -1,0 +1,107 @@
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { WireFrame } from "@houston/runtime-client";
+import { afterEach, expect, test, vi } from "vitest";
+import { TurnLog } from "./turn-log";
+
+const frame = { type: "text", data: "hello", turnId: "turn-1" } as WireFrame;
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      ),
+  );
+});
+
+async function listen(server: Server): Promise<string> {
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+test("turnlog batches sequenced frames verbatim with claim authority", async () => {
+  const requests: Array<{
+    body: unknown;
+    headers: IncomingHttpHeaders;
+    url: string;
+  }> = [];
+  const gateway = createServer((req, res) => {
+    void (async () => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(Buffer.from(chunk));
+      requests.push({
+        body: JSON.parse(Buffer.concat(chunks).toString("utf8")),
+        headers: req.headers,
+        url: req.url ?? "",
+      });
+      res.writeHead(204);
+      res.end();
+    })().catch((error) => {
+      res.writeHead(500);
+      res.end(error instanceof Error ? error.message : String(error));
+    });
+  });
+  const baseUrl = await listen(gateway);
+  const log = new TurnLog({
+    baseUrl,
+    org: "acme",
+    agent: "helper",
+    conversationId: "routine/c1",
+    hostToken: "host-token",
+    claim: { token: "claim-token", bootId: "boot-1" },
+    batchMs: 60_000,
+  });
+
+  const first = log.record(frame);
+  const terminal = log.record({ type: "done", data: null, turnId: "turn-1" });
+  await log.flush();
+
+  expect(first).toEqual({ ...frame, seq: 1 });
+  expect(terminal).toEqual({
+    type: "done",
+    data: null,
+    turnId: "turn-1",
+    seq: 2,
+  });
+  expect(requests[0]?.url).toBe("/v1/pod/turnlog/acme/helper/routine%2Fc1");
+  expect(requests[0]?.body).toEqual([
+    { seq: 1, frame: first },
+    { seq: 2, frame: terminal },
+  ]);
+  expect(requests[0]?.headers.authorization).toBe("Bearer host-token");
+  expect(requests[0]?.headers["x-houston-claim-token"]).toBe("claim-token");
+  expect(requests[0]?.headers["x-houston-claim-boot"]).toBe("boot-1");
+});
+
+test("a 404 disables only that turn's sender", async () => {
+  const fetchImpl = vi.fn<typeof fetch>(
+    async () => new Response("missing", { status: 404 }),
+  );
+  const options = {
+    baseUrl: "https://gateway.test",
+    org: "acme",
+    agent: "helper",
+    conversationId: "c1",
+    hostToken: "host-token",
+    claim: { token: "claim-token", bootId: "boot-1" },
+    fetchImpl,
+    batchSize: 1,
+  };
+  const first = new TurnLog(options);
+  first.record(frame);
+  await first.flush();
+  first.record(frame);
+  await first.flush();
+  expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+  const nextTurn = new TurnLog(options);
+  nextTurn.record(frame);
+  await nextTurn.flush();
+  expect(fetchImpl).toHaveBeenCalledTimes(2);
+});

--- a/packages/runtime/src/turn/turn-log.test.ts
+++ b/packages/runtime/src/turn/turn-log.test.ts
@@ -105,3 +105,19 @@ test("a 404 disables only that turn's sender", async () => {
   await nextTurn.flush();
   expect(fetchImpl).toHaveBeenCalledTimes(2);
 });
+
+test("seqStart continues the conversation's stream instead of restarting at 1", async () => {
+  const log = new TurnLog({
+    baseUrl: "http://127.0.0.1:1",
+    org: "org-1",
+    agent: "agent-1",
+    conversationId: "c1",
+    hostToken: "host-token",
+    claim: { token: "7", bootId: "boot" },
+    fetchImpl: async () => new Response(null, { status: 204 }),
+    seqStart: 41,
+  });
+  expect(log.record(frame).seq).toBe(41);
+  expect(log.record(frame).seq).toBe(42);
+  await log.flush();
+});

--- a/packages/runtime/src/turn/turn-log.ts
+++ b/packages/runtime/src/turn/turn-log.ts
@@ -13,6 +13,8 @@ interface TurnLogOptions {
   fetchImpl?: typeof fetch;
   batchMs?: number;
   batchSize?: number;
+  /** First seq to stamp (the conversation's stream continues, never restarts). */
+  seqStart?: number;
 }
 
 const REQUEST_TIMEOUT_MS = 5_000;
@@ -26,7 +28,7 @@ export class TurnLog {
   private readonly batchMs: number;
   private readonly batchSize: number;
   private readonly frames: SequencedFrame[] = [];
-  private seq = 0;
+  private seq: number;
   private disabled = false;
   private timer: ReturnType<typeof setTimeout> | undefined;
   private tail = Promise.resolve();
@@ -35,6 +37,7 @@ export class TurnLog {
     this.fetchImpl = opts.fetchImpl ?? fetch;
     this.batchMs = opts.batchMs ?? 250;
     this.batchSize = opts.batchSize ?? 32;
+    this.seq = (opts.seqStart ?? 1) - 1;
   }
 
   /** Sequence and enqueue one frame, flushing terminal frames immediately. */
@@ -122,5 +125,6 @@ export function createTurnLog(
     hostToken: turn.hostToken,
     claim: { token: turn.claim.token, bootId: turn.claim.bootId },
     ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+    ...(turn.turnlogSeqStart ? { seqStart: turn.turnlogSeqStart } : {}),
   });
 }

--- a/packages/runtime/src/turn/turn-log.ts
+++ b/packages/runtime/src/turn/turn-log.ts
@@ -1,0 +1,126 @@
+import type { SequencedFrame, WireFrame } from "@houston/runtime-client";
+import type { TurnServerDeps } from "./server-types";
+import { poolIdentity } from "./turn-store";
+import type { TurnRequest } from "./types";
+
+interface TurnLogOptions {
+  baseUrl: string;
+  org: string;
+  agent: string;
+  conversationId: string;
+  hostToken: string;
+  claim: { token: string; bootId: string };
+  fetchImpl?: typeof fetch;
+  batchMs?: number;
+  batchSize?: number;
+}
+
+const REQUEST_TIMEOUT_MS = 5_000;
+
+const terminal = (frame: WireFrame) =>
+  frame.type === "done" || frame.type === "error";
+
+/** One turn's ordered, failure-isolated turnlog batcher. */
+export class TurnLog {
+  private readonly fetchImpl: typeof fetch;
+  private readonly batchMs: number;
+  private readonly batchSize: number;
+  private readonly frames: SequencedFrame[] = [];
+  private seq = 0;
+  private disabled = false;
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private tail = Promise.resolve();
+
+  constructor(private readonly opts: TurnLogOptions) {
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.batchMs = opts.batchMs ?? 250;
+    this.batchSize = opts.batchSize ?? 32;
+  }
+
+  /** Sequence and enqueue one frame, flushing terminal frames immediately. */
+  record(frame: WireFrame): SequencedFrame {
+    // SAFETY: spreading a WireFrame preserves its discriminated shape while
+    // adding the sole field required by SequencedFrame.
+    const sequenced = { ...frame, seq: ++this.seq } as SequencedFrame;
+    if (this.disabled) return sequenced;
+    this.frames.push(sequenced);
+    if (terminal(frame) || this.frames.length >= this.batchSize) {
+      void this.flush();
+    } else if (!this.timer) {
+      this.timer = setTimeout(() => void this.flush(), this.batchMs);
+      this.timer.unref?.();
+    }
+    return sequenced;
+  }
+
+  /** Flush queued frames after earlier batches, swallowing logged failures. */
+  async flush(): Promise<void> {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = undefined;
+    const frames = this.frames.splice(0);
+    if (frames.length > 0 && !this.disabled) {
+      this.tail = this.tail.then(() => this.send(frames));
+    }
+    await this.tail;
+  }
+
+  private async send(frames: SequencedFrame[]): Promise<void> {
+    if (this.disabled) return;
+    const root = this.opts.baseUrl.replace(/\/+$/, "");
+    const url = `${root}/v1/pod/turnlog/${encodeURIComponent(
+      this.opts.org,
+    )}/${encodeURIComponent(this.opts.agent)}/${encodeURIComponent(
+      this.opts.conversationId,
+    )}`;
+    try {
+      const response = await this.fetchImpl(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.opts.hostToken}`,
+          "Content-Type": "application/json",
+          "X-Houston-Claim-Token": this.opts.claim.token,
+          "X-Houston-Claim-Boot": this.opts.claim.bootId,
+        },
+        body: JSON.stringify(
+          frames.map((frame) => ({ seq: frame.seq, frame })),
+        ),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      if (response.ok) return;
+      if (response.status === 404) {
+        this.disabled = true;
+        console.debug("[turnlog] gateway route unavailable for this turn");
+        return;
+      }
+      console.warn(
+        `[turnlog] batch failed (${response.status}): ${(
+          await response.text()
+        ).slice(0, 300)}`,
+      );
+    } catch (error) {
+      console.warn(
+        "[turnlog] batch failed:",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+}
+
+/** Create a claim-authorized sender when this non-shadow turn enables it. */
+export function createTurnLog(
+  deps: TurnServerDeps,
+  turn: TurnRequest,
+): TurnLog | null {
+  const baseUrl = deps.turnLogUrl ?? process.env.HOUSTON_TURNLOG_URL;
+  if (turn.shadow || !baseUrl || !turn.claim || !turn.hostToken) return null;
+  const { org, agent } = poolIdentity(turn.gcsPrefix);
+  return new TurnLog({
+    baseUrl,
+    org,
+    agent,
+    conversationId: turn.conversationId,
+    hostToken: turn.hostToken,
+    claim: { token: turn.claim.token, bootId: turn.claim.bootId },
+    ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+  });
+}

--- a/packages/runtime/src/turn/turn-runtime.test.ts
+++ b/packages/runtime/src/turn/turn-runtime.test.ts
@@ -1,0 +1,26 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { QWEN_REGIONS, qwenRegionFileIn } from "../ai/qwen-dashscope";
+import { registerTurnProviders } from "./turn-runtime";
+
+test("turn provider registration reads qwen region from the turn dataDir", () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "turn-qwen-"));
+  writeFileSync(qwenRegionFileIn(dataDir), JSON.stringify({ region: "us" }));
+  const registrations: Array<{ id: string; baseUrl?: string }> = [];
+  const runtime = {
+    registerProvider: (id: string, config: { baseUrl?: string }) => {
+      registrations.push({ id, baseUrl: config.baseUrl });
+    },
+    unregisterProvider: () => {},
+    getRegisteredProviderConfig: () => undefined,
+  };
+
+  registerTurnProviders(runtime, dataDir);
+
+  expect(registrations).toContainEqual({
+    id: "qwen",
+    baseUrl: QWEN_REGIONS[1].baseUrl,
+  });
+});

--- a/packages/runtime/src/turn/turn-runtime.ts
+++ b/packages/runtime/src/turn/turn-runtime.ts
@@ -1,0 +1,38 @@
+import { join } from "node:path";
+import { ModelRuntime } from "@earendil-works/pi-coding-agent";
+import {
+  type CustomProviderRegistrar,
+  registerCustomProviderIfConfigured,
+} from "../ai/openai-compatible";
+import {
+  ensureQwenRuntimeProvider,
+  type QwenProviderRegistrar,
+} from "../ai/qwen-dashscope";
+import { resolveTurnModel } from "./turn-model";
+
+/** Build and resolve the isolated model runtime for one hydrated turn root. */
+export async function createTurnModelRuntime(
+  dataDir: string,
+  provider: string,
+  modelOverride?: string | null,
+  timings?: Record<string, number>,
+) {
+  const modelRuntime = await ModelRuntime.create({
+    authPath: join(dataDir, "auth.json"),
+    modelsPath: join(dataDir, "models.json"),
+  });
+  registerTurnProviders(modelRuntime, dataDir);
+  if (timings) timings.t_model_runtime = performance.now();
+  const model = resolveTurnModel(dataDir, provider, modelOverride);
+  if (timings) timings.t_model_resolved = performance.now();
+  return { modelRuntime, model };
+}
+
+/** Register every data-dir-sensitive provider against a turn-local root. */
+export function registerTurnProviders(
+  runtime: CustomProviderRegistrar & QwenProviderRegistrar,
+  dataDir: string,
+): void {
+  registerCustomProviderIfConfigured(runtime, dataDir);
+  ensureQwenRuntimeProvider(runtime, dataDir);
+}

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -46,8 +46,8 @@ import {
 import { createTurnModelRuntime } from "./turn-runtime";
 
 /**
- * One pi turn against a hydrated throwaway root (<root>/workspace +
- * <root>/data). Unlike chat.ts (one long-lived process = one workspace, module
+ * One pi turn against resolved hydrated directories. Unlike chat.ts (one
+ * long-lived process = one workspace, module
  * state), EVERYTHING here is per-request: auth storage, model registry,
  * session, tools. Nothing survives the request — that is the isolation story.
  *
@@ -111,8 +111,13 @@ export interface PiTurnRequest {
   author?: MessageAuthor;
 }
 
+export interface PiTurnDirectories {
+  workspaceDir: string;
+  dataDir: string;
+}
+
 export async function runPiTurn(
-  root: string,
+  directories: PiTurnDirectories,
   turn: PiTurnRequest,
 ): Promise<TurnOutcome> {
   const {
@@ -129,8 +134,7 @@ export async function runPiTurn(
     author,
   } = turn;
   const emit = (e: WireFrame) => turn.emit({ ...e, turnId });
-  const workspaceDir = join(root, "workspace");
-  const dataDir = join(root, "data");
+  const { workspaceDir, dataDir } = directories;
   const conversationsDir = join(dataDir, "conversations");
 
   const priorAuthors = author

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import type { TurnMode } from "@houston/protocol";
 import type {
   ChatMessage,
@@ -11,10 +10,8 @@ import type {
   WireFrame,
 } from "@houston/runtime-client";
 import { DEFAULT_REASONING_EFFORT, toThinkingLevel } from "../ai/effort";
-import { registerCustomProviderIfConfigured } from "../ai/openai-compatible";
 import { classifyProviderError } from "../ai/provider-error";
 import { logProviderError } from "../ai/provider-error-log";
-import { ensureQwenRuntimeProvider } from "../ai/qwen-dashscope";
 import { readAuthFile } from "../auth/auth-file";
 import { clearAuthFailure, noteAuthFailure } from "../auth/credential-health";
 import { reportRevokedServedToken } from "../auth/report-revoked";
@@ -24,6 +21,7 @@ import {
 } from "../auth/used-token";
 import { createPiBackend } from "../backends/pi/backend";
 import { config } from "../config";
+import { framePrompt, type MessageAuthor } from "../session/attribution";
 import {
   diffSnapshots,
   type FileSnapshot,
@@ -43,8 +41,9 @@ import { makeRunCodeTool } from "../session/tools/run-code";
 import {
   appendAssistantMessageAt,
   appendUserMessageAt,
+  loadConversation,
 } from "../store/conversation-file";
-import { resolveTurnModel } from "./turn-model";
+import { createTurnModelRuntime } from "./turn-runtime";
 
 /**
  * One pi turn against a hydrated throwaway root (<root>/workspace +
@@ -108,6 +107,8 @@ export interface PiTurnRequest {
    * echoed on the `user` frame. Absent when the message mentions nobody.
    */
   mentions?: ChatMessage["mentions"];
+  /** Human author supplied by the trusted pool dispatcher. */
+  author?: MessageAuthor;
 }
 
 export async function runPiTurn(
@@ -125,13 +126,20 @@ export async function runPiTurn(
     turnId,
     displayText,
     mentions,
+    author,
   } = turn;
   const emit = (e: WireFrame) => turn.emit({ ...e, turnId });
   const workspaceDir = join(root, "workspace");
   const dataDir = join(root, "data");
   const conversationsDir = join(dataDir, "conversations");
 
+  const priorAuthors = author
+    ? (loadConversation(conversationsDir, conversationId)?.messages ?? [])
+        .filter((message) => message.role === "user")
+        .map((message) => message.author)
+    : [];
   appendUserMessageAt(conversationsDir, conversationId, text, {
+    author,
     turnId,
     displayText,
     mentions,
@@ -167,14 +175,11 @@ export async function runPiTurn(
     // local (openai-compatible) provider registers from the dir's own
     // custom-endpoint config so its model can dispatch (pi 0.82 streams
     // strictly by registered provider id).
-    const modelRuntime = await ModelRuntime.create({
-      authPath: join(dataDir, "auth.json"),
-      modelsPath: join(dataDir, "models.json"),
-    });
-    registerCustomProviderIfConfigured(modelRuntime, dataDir);
-    // The qwen (DashScope) extension provider needs the same per-turn
-    // registration the long-lived runtime gets at boot (auth/storage.ts).
-    ensureQwenRuntimeProvider(modelRuntime);
+    const { modelRuntime, model } = await createTurnModelRuntime(
+      dataDir,
+      provider,
+      pin?.model,
+    );
 
     const toolSelection = buildToolSelection({
       codeExecution: config.codeExecution === "remote" ? "remote" : "disabled",
@@ -200,7 +205,6 @@ export async function runPiTurn(
         })
       : null;
 
-    const model = resolveTurnModel(dataDir, provider, pin?.model);
     // Seed the used-token capture with the credential this turn will run on
     // (see the declaration above). OAuth access only — an api_key has no
     // revocation semantics the report may act on.
@@ -296,7 +300,9 @@ export async function runPiTurn(
       // The used-token capture spans the prompt so the streamed error path
       // (pi/wire.ts) reads THIS turn's seeded token when it reports.
       await runWithInteractionCapture(interaction, () =>
-        runWithUsedTokenCapture(usedTokens, () => session.prompt(text)),
+        runWithUsedTokenCapture(usedTokens, () =>
+          session.prompt(framePrompt(text, author, priorAuthors)),
+        ),
       );
     } finally {
       signal?.removeEventListener("abort", onAbort);

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -38,6 +38,7 @@ import { makeClampedFileTools } from "../session/tools/clamped-fs";
 import { makeIdTokenProvider } from "../session/tools/gcp-id-token";
 import { makePlanReadyTool } from "../session/tools/plan-ready";
 import { makeRunCodeTool } from "../session/tools/run-code";
+import type { ProvidedContext } from "../session/workspace-context";
 import {
   appendAssistantMessageAt,
   appendUserMessageAt,
@@ -109,6 +110,8 @@ export interface PiTurnRequest {
   mentions?: ChatMessage["mentions"];
   /** Human author supplied by the trusted pool dispatcher. */
   author?: MessageAuthor;
+  /** Gateway-provided workspace/user context for the session prompt. */
+  context?: ProvidedContext;
 }
 
 export interface PiTurnDirectories {
@@ -262,6 +265,9 @@ export async function runPiTurn(
       conversationId,
       model,
       ...(thinkingLevel ? { thinkingLevel } : {}),
+      // Hosted turn context rides the envelope; the loader overlays it exactly
+      // as the long-lived server path does for a message-send body.
+      ...(turn.context ? { context: turn.context } : {}),
       // The turn's mode clamps this pi session's tools + overlays its prompt,
       // exactly as the long-lived server path does (createPiBackend applies
       // `toolNamesForMode` + the loader overlay from `opts.mode`): plan →

--- a/packages/runtime/src/turn/turn-setup-errors.test.ts
+++ b/packages/runtime/src/turn/turn-setup-errors.test.ts
@@ -1,0 +1,76 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import type { Server } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { LocalDirStore } from "@houston/runtime-client/object-sync";
+import { afterEach, expect, test, vi } from "vitest";
+import { createTurnServer } from "./server";
+import type { runPiTurn } from "./turn-session";
+
+const servers: Server[] = [];
+afterEach(() => {
+  for (const server of servers.splice(0)) server.close();
+});
+
+async function run(files: Record<string, string>, maxHydrateBytes?: number) {
+  const storeRoot = await mkdtemp(join(tmpdir(), "turn-error-store-"));
+  for (const [rel, value] of Object.entries(files)) {
+    const path = join(storeRoot, "ws", "w1", "agent-1", ...rel.split("/"));
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, value);
+  }
+  const runTurn = vi.fn<typeof runPiTurn>();
+  const server = createTurnServer({
+    store: new LocalDirStore(storeRoot),
+    token: "",
+    runTurn,
+    ...(maxHydrateBytes ? { maxHydrateBytes } : {}),
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("no address");
+  const response = await fetch(`http://127.0.0.1:${address.port}/turn`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      workspaceId: "w1",
+      agentId: "agent-1",
+      conversationId: "c1",
+      text: "hello",
+      gcsPrefix: "ws/w1/agent-1",
+      credential: {
+        provider: "openai-codex",
+        access: "token",
+        expires: Date.now() + 60_000,
+      },
+    }),
+  });
+  const frame = (await response.text())
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => JSON.parse(line.slice(6)) as Record<string, unknown>)
+    .at(-1);
+  return { frame, runTurn };
+}
+
+test("an ambiguous standing tree emits layout_unexpected before provider work", async () => {
+  const result = await run({
+    "workspaces/W/A/file.txt": "a",
+    "workspaces/W/B/file.txt": "b",
+  });
+  expect(result.frame).toMatchObject({
+    type: "error",
+    data: { message: "layout_unexpected", code: "layout_unexpected" },
+  });
+  expect(result.runTurn).not.toHaveBeenCalled();
+});
+
+test("an over-cap hydrate emits hydrate_over_cap before provider work", async () => {
+  const result = await run({ "workspace/big.txt": "too large" }, 2);
+  expect(result.frame).toMatchObject({
+    type: "error",
+    data: { message: "hydrate_over_cap", code: "hydrate_over_cap" },
+  });
+  expect(result.runTurn).not.toHaveBeenCalled();
+});

--- a/packages/runtime/src/turn/turn-store.test.ts
+++ b/packages/runtime/src/turn/turn-store.test.ts
@@ -1,0 +1,53 @@
+import type { ObjectStore } from "@houston/runtime-client/object-sync";
+import { expect, test, vi } from "vitest";
+import { resolveTurnStore } from "./turn-store";
+import type { TurnRequest } from "./types";
+
+const fallback = {} as ObjectStore;
+const claim = {
+  id: "claim-1",
+  bootId: "boot-1",
+  token: "claim-token",
+  heartbeatUrl: "https://gateway.test/heartbeat",
+};
+const turn = {
+  gcsPrefix: "ws/acme/helper",
+  hostToken: "host-token",
+  claim,
+} as TurnRequest;
+
+test("a claimed pool turn gets an agent-scoped HTTP store and empty prefix", async () => {
+  const seen: Array<{ url: string; headers: Headers }> = [];
+  const resolved = resolveTurnStore(turn, fallback, {
+    poolStoreUrl: "https://gateway.test/",
+    fetchImpl: vi.fn(async (input, init) => {
+      seen.push({ url: String(input), headers: new Headers(init?.headers) });
+      return Response.json({ objects: [] });
+    }),
+  });
+
+  expect(resolved.prefix).toBe("");
+  await resolved.store.manifest?.();
+  expect(seen[0]?.url).toBe(
+    "https://gateway.test/v1/pod/store/acme/helper/manifest",
+  );
+  expect(seen[0]?.headers.get("authorization")).toBe("Bearer host-token");
+});
+
+test("ordinary turn stores keep the envelope prefix unchanged", () => {
+  expect(
+    resolveTurnStore({ gcsPrefix: "ws/w/a" } as TurnRequest, fallback),
+  ).toEqual({ store: fallback, prefix: "ws/w/a" });
+});
+
+test.each([
+  "other/acme/helper",
+  "ws/acme",
+  "ws/acme/helper/extra",
+])("a claimed pool turn rejects malformed prefix %s", (gcsPrefix) => {
+  expect(() =>
+    resolveTurnStore({ ...turn, gcsPrefix }, fallback, {
+      poolStoreUrl: "https://gateway.test",
+    }),
+  ).toThrow("gcsPrefix");
+});

--- a/packages/runtime/src/turn/turn-store.test.ts
+++ b/packages/runtime/src/turn/turn-store.test.ts
@@ -12,6 +12,7 @@ const claim = {
 };
 const turn = {
   gcsPrefix: "ws/acme/helper",
+  conversationId: "conversation-1",
   hostToken: "host-token",
   claim,
 } as TurnRequest;

--- a/packages/runtime/src/turn/turn-store.ts
+++ b/packages/runtime/src/turn/turn-store.ts
@@ -63,7 +63,11 @@ export function resolveTurnStore(
     store: new HttpObjectStore({
       baseUrl: `${root}/v1/pod/store/${encodeURIComponent(org)}/${encodeURIComponent(agent)}`,
       token: turn.hostToken,
-      claim: { token: turn.claim.token, bootId: turn.claim.bootId },
+      claim: {
+        token: turn.claim.token,
+        bootId: turn.claim.bootId,
+        conversationId: turn.conversationId,
+      },
       ...(config.fetchImpl ? { fetchImpl: config.fetchImpl } : {}),
     }),
     prefix: "",

--- a/packages/runtime/src/turn/turn-store.ts
+++ b/packages/runtime/src/turn/turn-store.ts
@@ -1,0 +1,71 @@
+import {
+  HttpObjectStore,
+  type ObjectStore,
+} from "@houston/runtime-client/object-sync";
+import type { TurnRequest } from "./types";
+
+/** Per-turn object-store selection inputs. */
+export interface TurnStoreConfig {
+  poolStoreUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/** Store and key prefix selected for an admitted turn. */
+export interface ResolvedTurnStore {
+  store: ObjectStore;
+  prefix: string;
+}
+
+/** Fail-loud fallback used when turn mode has only the pool store configured. */
+export function poolOnlyFallbackStore(): ObjectStore {
+  const unavailable = async (): Promise<never> => {
+    throw new Error("this pooled worker requires a claim-backed object store");
+  };
+  return {
+    list: unavailable,
+    download: unavailable,
+    upload: unavailable,
+    delete: unavailable,
+  };
+}
+
+/** Parse the exact `ws/<org>/<agent>` identity encoded in a pool prefix. */
+export function poolIdentity(gcsPrefix: string): {
+  org: string;
+  agent: string;
+} {
+  const segments = gcsPrefix.split("/");
+  if (
+    segments.length !== 3 ||
+    segments[0] !== "ws" ||
+    !segments[1] ||
+    !segments[2]
+  ) {
+    throw new Error("claimed turn has invalid 'gcsPrefix'");
+  }
+  return { org: segments[1], agent: segments[2] };
+}
+
+/** Select claim-backed HTTP storage or preserve the configured legacy store. */
+export function resolveTurnStore(
+  turn: TurnRequest,
+  fallback: ObjectStore,
+  config: TurnStoreConfig = {},
+): ResolvedTurnStore {
+  const poolStoreUrl =
+    config.poolStoreUrl ?? process.env.HOUSTON_POOL_STORE_URL;
+  if (!turn.claim || !turn.hostToken || !poolStoreUrl) {
+    return { store: fallback, prefix: turn.gcsPrefix };
+  }
+  const { org, agent } = poolIdentity(turn.gcsPrefix);
+  const root = poolStoreUrl.replace(/\/+$/, "");
+  return {
+    store: new HttpObjectStore({
+      baseUrl: `${root}/v1/pod/store/${encodeURIComponent(org)}/${encodeURIComponent(agent)}`,
+      token: turn.hostToken,
+      claim: { token: turn.claim.token, bootId: turn.claim.bootId },
+      ...(config.fetchImpl ? { fetchImpl: config.fetchImpl } : {}),
+    }),
+    prefix: "",
+  };
+}

--- a/packages/runtime/src/turn/turn-terminal.ts
+++ b/packages/runtime/src/turn/turn-terminal.ts
@@ -8,10 +8,12 @@ export function turnTerminalFrame(
   turnId: string,
   poolWritesOutOfScope: number,
   transcriptSkipped?: "route_absent",
+  activityDocSkipped?: "route_absent",
 ): WireFrame {
   const fields = {
     ...(poolWritesOutOfScope > 0 ? { poolWritesOutOfScope } : {}),
     ...(transcriptSkipped ? { transcriptSkipped } : {}),
+    ...(activityDocSkipped ? { activityDocSkipped } : {}),
   };
   const diagnostic = Object.keys(fields).length > 0 ? fields : undefined;
   if (outcome.error) {

--- a/packages/runtime/src/turn/turn-terminal.ts
+++ b/packages/runtime/src/turn/turn-terminal.ts
@@ -7,9 +7,13 @@ export function turnTerminalFrame(
   outcome: TurnOutcome,
   turnId: string,
   poolWritesOutOfScope: number,
+  transcriptSkipped?: "route_absent",
 ): WireFrame {
-  const diagnostic =
-    poolWritesOutOfScope > 0 ? { poolWritesOutOfScope } : undefined;
+  const fields = {
+    ...(poolWritesOutOfScope > 0 ? { poolWritesOutOfScope } : {}),
+    ...(transcriptSkipped ? { transcriptSkipped } : {}),
+  };
+  const diagnostic = Object.keys(fields).length > 0 ? fields : undefined;
   if (outcome.error) {
     // SAFETY: pooled-turn diagnostics are an additive internal transport field;
     // public WireFrame consumers still receive the required error message.

--- a/packages/runtime/src/turn/turn-terminal.ts
+++ b/packages/runtime/src/turn/turn-terminal.ts
@@ -1,0 +1,46 @@
+import type { WireFrame } from "@houston/runtime-client";
+import type { TurnSetupError } from "./turn-layout";
+import type { TurnOutcome } from "./turn-session";
+
+/** Build the durable terminal frame after sync-back completes. */
+export function turnTerminalFrame(
+  outcome: TurnOutcome,
+  turnId: string,
+  poolWritesOutOfScope: number,
+): WireFrame {
+  const diagnostic =
+    poolWritesOutOfScope > 0 ? { poolWritesOutOfScope } : undefined;
+  if (outcome.error) {
+    // SAFETY: pooled-turn diagnostics are an additive internal transport field;
+    // public WireFrame consumers still receive the required error message.
+    return {
+      type: "error",
+      data: { message: outcome.error, ...diagnostic },
+      turnId,
+    } as WireFrame;
+  }
+  // SAFETY: claimed-turn diagnostics intentionally widen this internal done
+  // frame while preserving null for every ordinary public-protocol turn.
+  return {
+    type: "done",
+    data: diagnostic ?? null,
+    turnId,
+    ...(outcome.pendingInteraction
+      ? { pendingInteraction: outcome.pendingInteraction }
+      : {}),
+  } as unknown as WireFrame;
+}
+
+/** Build the internal typed error frame for pre-provider setup failures. */
+export function turnSetupErrorFrame(
+  error: TurnSetupError,
+  turnId: string,
+): WireFrame {
+  // SAFETY: setup error codes are internal to the pool dispatcher and retain
+  // the public error frame's required message field.
+  return {
+    type: "error",
+    data: { message: error.code, code: error.code, detail: error.message },
+    turnId,
+  } as WireFrame;
+}

--- a/packages/runtime/src/turn/turn-transcript-http.ts
+++ b/packages/runtime/src/turn/turn-transcript-http.ts
@@ -1,0 +1,50 @@
+import {
+  type TranscriptTurnWrite,
+  transcriptTurnRequest,
+} from "@houston/runtime-client";
+import { fetchWithRetry } from "@houston/runtime-client/object-sync";
+import type { TranscriptOptions } from "./turn-transcript";
+
+const REQUEST_TIMEOUT_MS = 5_000;
+
+/**
+ * One claim-authorized transcript PUT against the pod store. Transient
+ * 502/503/504 and network drops retry (the routes are idempotent per turnId)
+ * with a FRESH timeout per attempt: a reused timed-out signal would abort
+ * every retry on arrival. The caller interprets the status; the body is
+ * released here because it is never needed.
+ */
+export async function putTranscriptRow(
+  fetchImpl: typeof fetch,
+  opts: TranscriptOptions,
+  write: TranscriptTurnWrite,
+): Promise<Response> {
+  const root = opts.baseUrl.replace(/\/+$/, "");
+  const conversationUrl = `${root}/v1/pod/transcripts/${encodeURIComponent(
+    opts.org,
+  )}/${encodeURIComponent(opts.agent)}/conversations/${encodeURIComponent(
+    opts.conversationId,
+  )}`;
+  const request = transcriptTurnRequest(conversationUrl, write);
+  const response = await fetchWithRetry(
+    (url, init) =>
+      fetchImpl(url, {
+        ...init,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      }),
+    request.url,
+    {
+      method: request.method,
+      headers: {
+        Authorization: `Bearer ${opts.hostToken}`,
+        "Content-Type": "application/json",
+        "X-Houston-Claim-Token": opts.claim.token,
+        "X-Houston-Claim-Boot": opts.claim.bootId,
+      },
+      body: JSON.stringify(request.body),
+    },
+    opts.retryDelaysMs ? { delaysMs: opts.retryDelaysMs } : {},
+  );
+  await response.body?.cancel();
+  return response;
+}

--- a/packages/runtime/src/turn/turn-transcript.test.ts
+++ b/packages/runtime/src/turn/turn-transcript.test.ts
@@ -478,3 +478,43 @@ test("a corrupt conversation file still ends in a terminal error frame", async (
   expect(raw).toContain("transcript publish failed");
   expect(raw).not.toContain('"type":"done"');
 });
+
+test("the user row lands on the user frame, before the turn finishes", async () => {
+  const objects = seedStandingLayout();
+  const requests: TranscriptRequest[] = [];
+  let requestsWhenTurnEnded = -1;
+  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+    const conversationsDir = join(filesystem.dataDir, "conversations");
+    const { message } = appendUserMessageAt(
+      conversationsDir,
+      turn.conversationId,
+      turn.text,
+      { turnId: turn.turnId },
+    );
+    // What the real session does right after persisting the user message.
+    turn.emit({ type: "user", data: message, turnId: turn.turnId });
+    // Let the early publish run while the "model" is still working.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    requestsWhenTurnEnded = requests.length;
+    appendAssistantMessageAt(conversationsDir, turn.conversationId, "Reply", {
+      turnId: turn.turnId,
+    });
+    return {};
+  };
+
+  const raw = await runClaimedTurn({
+    runTurn,
+    poolStoreUrl: "https://pool.example",
+    fetchImpl: poolFetch(objects, requests),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  // The user PUT was already on the wire while the turn was still running,
+  // and the final publish did not send it twice.
+  expect(requestsWhenTurnEnded).toBe(1);
+  expect(requests.map((r) => r.url.split("/").at(-1))).toEqual([
+    "user",
+    "assistant",
+  ]);
+  expect(raw).toContain('"type":"done"');
+});

--- a/packages/runtime/src/turn/turn-transcript.test.ts
+++ b/packages/runtime/src/turn/turn-transcript.test.ts
@@ -1,0 +1,480 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import type { Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChatMessage } from "@houston/runtime-client";
+import { LocalDirStore } from "@houston/runtime-client/object-sync";
+import { afterEach, expect, test } from "vitest";
+import {
+  appendAssistantMessageAt,
+  appendUserMessageAt,
+  type StoredConversation,
+} from "../store/conversation-file";
+import { createTurnServer } from "./server";
+import type { TurnServerDeps } from "./server-types";
+import type { runPiTurn } from "./turn-session";
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      ),
+  );
+});
+
+async function listen(server: Server): Promise<string> {
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("no address");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+interface TranscriptRequest {
+  body: Record<string, unknown>;
+  headers: Headers;
+  method: string;
+  syncedMessageCount?: number;
+  url: string;
+}
+
+function poolFetch(
+  objects: Map<string, Uint8Array>,
+  transcripts: TranscriptRequest[],
+  transcriptStatuses: number[] = [],
+): typeof fetch {
+  return async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/heartbeat") {
+      return new Response(null, { status: 200 });
+    }
+    if (url.pathname.includes("/v1/pod/transcripts/")) {
+      const status = transcriptStatuses[transcripts.length] ?? 200;
+      const conversation = objects.get(
+        "workspaces/Main/Helper/.houston/runtime/conversations/mission.1.json",
+      );
+      transcripts.push({
+        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+        headers: new Headers(init?.headers),
+        method: init?.method ?? "GET",
+        syncedMessageCount: conversation
+          ? (
+              JSON.parse(
+                new TextDecoder().decode(conversation),
+              ) as StoredConversation
+            ).messages.length
+          : undefined,
+        url: String(input),
+      });
+      return new Response(status === 503 ? "unavailable" : null, { status });
+    }
+    if (url.pathname.endsWith("/manifest")) {
+      return Response.json({
+        objects: [...objects].map(([key, bytes]) => ({
+          key,
+          size: bytes.byteLength,
+          md5: "test",
+          updated: "2026-08-18T00:00:00Z",
+        })),
+      });
+    }
+    const marker = "/objects/";
+    const key = url.pathname
+      .slice(url.pathname.indexOf(marker) + marker.length)
+      .split("/")
+      .map(decodeURIComponent)
+      .join("/");
+    if (init?.method === "PUT") {
+      const bytes = new Uint8Array(init.body as Uint8Array);
+      objects.set(key, bytes);
+      return Response.json({
+        key,
+        size: bytes.byteLength,
+        md5: "test",
+        updated: "2026-08-18T00:00:00Z",
+      });
+    }
+    const bytes = objects.get(key);
+    return bytes
+      ? new Response(
+          bytes.buffer.slice(
+            bytes.byteOffset,
+            bytes.byteOffset + bytes.byteLength,
+          ) as ArrayBuffer,
+        )
+      : new Response("missing", { status: 404 });
+  };
+}
+
+const priorConversation: StoredConversation = {
+  id: "mission.1",
+  title: "Quarterly roadmap",
+  createdAt: 1,
+  updatedAt: 2,
+  messages: [
+    { role: "user", content: "Earlier", ts: 1 },
+    { role: "assistant", content: "Earlier reply", ts: 2 },
+  ],
+};
+
+function seedStandingLayout(): Map<string, Uint8Array> {
+  const encode = (value: string) => new TextEncoder().encode(value);
+  return new Map([
+    ["workspaces/Main/Helper/.houston/runtime/settings.json", encode("{}")],
+    [
+      "workspaces/Main/Helper/.houston/runtime/conversations/mission.1.json",
+      encode(JSON.stringify(priorConversation)),
+    ],
+  ]);
+}
+
+function localStandingStore(): LocalDirStore {
+  const root = mkdtempSync(join(tmpdir(), "standing-store-"));
+  const settings = join(
+    root,
+    "ws/acme.org/helper.bot/workspaces/Main/Helper/.houston/runtime/settings.json",
+  );
+  mkdirSync(join(settings, ".."), { recursive: true });
+  writeFileSync(settings, "{}");
+  return new LocalDirStore(root);
+}
+
+function turnBody(extra: Record<string, unknown> = {}) {
+  return {
+    workspaceId: "acme.org",
+    agentId: "helper.bot",
+    conversationId: "mission.1",
+    text: "Build the launch plan",
+    gcsPrefix: "ws/acme.org/helper.bot",
+    credential: {
+      provider: "openai-codex",
+      access: "access-token",
+      expires: Date.now() + 60_000,
+    },
+    turnId: "turn.7",
+    hostToken: "host-token",
+    claim: {
+      id: "claim-1",
+      bootId: "boot-1",
+      token: "claim-token",
+      heartbeatUrl: "https://pool.example/heartbeat",
+    },
+    ...extra,
+  };
+}
+
+async function runClaimedTurn(
+  deps: Partial<TurnServerDeps>,
+  body = turnBody(),
+): Promise<string> {
+  const server = createTurnServer({
+    store: new LocalDirStore(mkdtempSync(join(tmpdir(), "fallback-store-"))),
+    token: "",
+    // Transient statuses retry; keep the test fast and the attempt count exact.
+    transcriptRetryDelaysMs: [0, 0],
+    ...deps,
+  });
+  const base = await listen(server);
+  const response = await fetch(`${base}/turn`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return response.text();
+}
+
+test("claimed turn publishes its persisted user and assistant before done", async () => {
+  const objects = seedStandingLayout();
+  const requests: TranscriptRequest[] = [];
+  let userMessage: ChatMessage | undefined;
+  let assistantMessage: ChatMessage | undefined;
+  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+    const conversationsDir = join(filesystem.dataDir, "conversations");
+    userMessage = appendUserMessageAt(
+      conversationsDir,
+      turn.conversationId,
+      turn.text,
+      { turnId: turn.turnId },
+    ).message;
+    assistantMessage = appendAssistantMessageAt(
+      conversationsDir,
+      turn.conversationId,
+      "Launch plan ready",
+      { turnId: turn.turnId },
+    )?.message;
+    return {};
+  };
+
+  const raw = await runClaimedTurn({
+    runTurn,
+    poolStoreUrl: "https://pool.example/",
+    fetchImpl: poolFetch(objects, requests),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  expect(requests.map(({ method, url }) => ({ method, url }))).toEqual([
+    {
+      method: "PUT",
+      url: "https://pool.example/v1/pod/transcripts/acme.org/helper.bot/conversations/mission.1/turns/turn.7/user",
+    },
+    {
+      method: "PUT",
+      url: "https://pool.example/v1/pod/transcripts/acme.org/helper.bot/conversations/mission.1/turns/turn.7/assistant",
+    },
+  ]);
+  expect(requests[0]?.headers.get("authorization")).toBe("Bearer host-token");
+  expect(requests[0]?.headers.get("x-houston-claim-token")).toBe("claim-token");
+  expect(requests[0]?.headers.get("x-houston-claim-boot")).toBe("boot-1");
+  expect(requests[0]?.syncedMessageCount).toBe(4);
+  expect(requests[0]?.body).toEqual({
+    message: userMessage,
+    ts: userMessage?.ts,
+    title: "Quarterly roadmap",
+    expectedCount: 2,
+  });
+  expect(requests[1]?.body).toEqual({
+    message: assistantMessage,
+    ts: assistantMessage?.ts,
+  });
+  expect(raw).toContain('"type":"done"');
+  expect(raw).not.toContain('"type":"error"');
+});
+
+test("a transcript 404 disables publication for the turn without failing it", async () => {
+  const objects = seedStandingLayout();
+  const requests: TranscriptRequest[] = [];
+  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+    const conversationsDir = join(filesystem.dataDir, "conversations");
+    appendUserMessageAt(conversationsDir, turn.conversationId, turn.text, {
+      turnId: turn.turnId,
+    });
+    appendAssistantMessageAt(
+      conversationsDir,
+      turn.conversationId,
+      "Launch plan ready",
+      { turnId: turn.turnId },
+    );
+    return {};
+  };
+
+  const raw = await runClaimedTurn({
+    runTurn,
+    poolStoreUrl: "https://pool.example",
+    fetchImpl: poolFetch(objects, requests, [404]),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  expect(requests).toHaveLength(1);
+  expect(requests[0]?.url).toMatch(/\/user$/);
+  expect(raw).toContain('"type":"done"');
+  expect(raw).toContain('"transcriptSkipped":"route_absent"');
+  expect(raw).not.toContain('"type":"error"');
+});
+
+test("a transcript 409 fences the claimed turn", async () => {
+  const objects = seedStandingLayout();
+  const requests: TranscriptRequest[] = [];
+  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+    const conversationsDir = join(filesystem.dataDir, "conversations");
+    appendUserMessageAt(conversationsDir, turn.conversationId, turn.text, {
+      turnId: turn.turnId,
+    });
+    appendAssistantMessageAt(conversationsDir, turn.conversationId, "Reply", {
+      turnId: turn.turnId,
+    });
+    return {};
+  };
+
+  const raw = await runClaimedTurn({
+    runTurn,
+    poolStoreUrl: "https://pool.example",
+    fetchImpl: poolFetch(objects, requests, [409]),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  expect(requests).toHaveLength(1);
+  expect(raw).toContain('"type":"error"');
+  expect(raw).toContain("claim_fenced");
+  expect(raw).not.toContain('"type":"done"');
+});
+
+test("a transcript 503 becomes part of the terminal error", async () => {
+  const objects = seedStandingLayout();
+  const requests: TranscriptRequest[] = [];
+  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+    const conversationsDir = join(filesystem.dataDir, "conversations");
+    appendUserMessageAt(conversationsDir, turn.conversationId, turn.text, {
+      turnId: turn.turnId,
+    });
+    appendAssistantMessageAt(conversationsDir, turn.conversationId, "Reply", {
+      turnId: turn.turnId,
+    });
+    return {};
+  };
+
+  const raw = await runClaimedTurn({
+    runTurn,
+    poolStoreUrl: "https://pool.example",
+    fetchImpl: poolFetch(objects, requests, [503, 503, 503]),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  // Three attempts (two retries) on a transient 503, then the real answer.
+  expect(requests).toHaveLength(3);
+  expect(raw).toContain('"type":"error"');
+  // Status only, never the response body: that text reaches the client and
+  // the turn log.
+  expect(raw).toContain("transcript publish failed: user row rejected (503)");
+  expect(raw).not.toContain("unavailable");
+  expect(raw).not.toContain('"type":"done"');
+});
+
+test("a transcript network failure becomes part of the terminal error", async () => {
+  const objects = seedStandingLayout();
+  const requests: TranscriptRequest[] = [];
+  const backingFetch = poolFetch(objects, requests);
+  const fetchImpl: typeof fetch = async (input, init) => {
+    if (String(input).includes("/v1/pod/transcripts/")) {
+      throw new Error("socket closed");
+    }
+    return backingFetch(input, init);
+  };
+  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+    appendUserMessageAt(
+      join(filesystem.dataDir, "conversations"),
+      turn.conversationId,
+      turn.text,
+      { turnId: turn.turnId },
+    );
+    return {};
+  };
+
+  const raw = await runClaimedTurn({
+    runTurn,
+    poolStoreUrl: "https://pool.example",
+    fetchImpl,
+    heartbeatIntervalMs: 60_000,
+  });
+
+  expect(raw).toContain("transcript publish failed: socket closed");
+  expect(raw).not.toContain('"type":"done"');
+});
+
+test("a turn without an assistant message publishes only its user row", async () => {
+  const objects = seedStandingLayout();
+  const requests: TranscriptRequest[] = [];
+  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+    appendUserMessageAt(
+      join(filesystem.dataDir, "conversations"),
+      turn.conversationId,
+      turn.text,
+      { turnId: turn.turnId },
+    );
+    return {};
+  };
+
+  const raw = await runClaimedTurn({
+    runTurn,
+    poolStoreUrl: "https://pool.example",
+    fetchImpl: poolFetch(objects, requests),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  expect(requests).toHaveLength(1);
+  expect(requests[0]?.url).toMatch(/\/user$/);
+  expect(raw).toContain('"type":"done"');
+});
+
+test("an unclaimed turn makes no transcript requests", async () => {
+  const requests: TranscriptRequest[] = [];
+  const raw = await runClaimedTurn(
+    {
+      store: localStandingStore(),
+      runTurn: async () => ({}),
+      poolStoreUrl: "https://pool.example",
+      fetchImpl: poolFetch(new Map(), requests),
+    },
+    turnBody({ hostToken: undefined, claim: undefined }),
+  );
+
+  expect(requests).toHaveLength(0);
+  expect(raw).toContain('"type":"done"');
+});
+
+test("a shadow turn makes no transcript requests", async () => {
+  const objects = seedStandingLayout();
+  const requests: TranscriptRequest[] = [];
+  const raw = await runClaimedTurn(
+    {
+      runTurn: async () => {
+        throw new Error("shadow must not run the turn session");
+      },
+      poolStoreUrl: "https://pool.example",
+      fetchImpl: poolFetch(objects, requests),
+      heartbeatIntervalMs: 60_000,
+    },
+    turnBody({ shadow: true }),
+  );
+
+  expect(requests).toHaveLength(0);
+  expect(raw).toContain('"type":"done"');
+});
+
+test("an assistant 404 after a landed user row is a failure, not deploy skew", async () => {
+  const objects = seedStandingLayout();
+  const requests: TranscriptRequest[] = [];
+  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+    const conversationsDir = join(filesystem.dataDir, "conversations");
+    appendUserMessageAt(conversationsDir, turn.conversationId, turn.text, {
+      turnId: turn.turnId,
+    });
+    appendAssistantMessageAt(conversationsDir, turn.conversationId, "Reply", {
+      turnId: turn.turnId,
+    });
+    return {};
+  };
+
+  const raw = await runClaimedTurn({
+    runTurn,
+    poolStoreUrl: "https://pool.example",
+    fetchImpl: poolFetch(objects, requests, [200, 404]),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  expect(requests).toHaveLength(2);
+  expect(raw).toContain('"type":"error"');
+  expect(raw).toContain(
+    "transcript publish failed: assistant row rejected (404)",
+  );
+  expect(raw).not.toContain('"type":"done"');
+});
+
+test("a corrupt conversation file still ends in a terminal error frame", async () => {
+  const objects = seedStandingLayout();
+  const requests: TranscriptRequest[] = [];
+  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+    // The turn "ran" but left the conversation file unparseable.
+    writeFileSync(
+      join(filesystem.dataDir, "conversations", `${turn.conversationId}.json`),
+      "{not json",
+    );
+    return {};
+  };
+
+  const raw = await runClaimedTurn({
+    runTurn,
+    poolStoreUrl: "https://pool.example",
+    fetchImpl: poolFetch(objects, requests, []),
+    heartbeatIntervalMs: 60_000,
+  });
+
+  expect(requests).toHaveLength(0);
+  expect(raw).toContain('"type":"error"');
+  expect(raw).toContain("transcript publish failed");
+  expect(raw).not.toContain('"type":"done"');
+});

--- a/packages/runtime/src/turn/turn-transcript.ts
+++ b/packages/runtime/src/turn/turn-transcript.ts
@@ -1,16 +1,11 @@
 import { join } from "node:path";
-import {
-  type TranscriptTurnWrite,
-  transcriptTurnRequest,
-} from "@houston/runtime-client";
-import { fetchWithRetry } from "@houston/runtime-client/object-sync";
+import type { TranscriptTurnWrite } from "@houston/runtime-client";
 import { loadConversation } from "../store/conversation-file";
 import type { TurnServerDeps } from "./server-types";
 import type { TurnFilesystem } from "./turn-filesystem";
 import { poolIdentity } from "./turn-store";
+import { putTranscriptRow } from "./turn-transcript-http";
 import type { TurnRequest } from "./types";
-
-const REQUEST_TIMEOUT_MS = 5_000;
 
 export type TranscriptPublishResult =
   | { ok: true }
@@ -19,10 +14,17 @@ export type TranscriptPublishResult =
   | { error: string };
 
 export interface TurnTranscript {
+  /**
+   * Publish the user row as soon as the runtime persisted it (fired on the
+   * `user` frame). Idempotent; a failure is remembered and surfaced by the
+   * final publish(), never thrown here. This is what lets a gateway that
+   * restarts mid-turn rebuild and re-dispatch the turn from the transcript.
+   */
+  publishUser(): Promise<void>;
   publish(): Promise<TranscriptPublishResult>;
 }
 
-interface TranscriptOptions {
+export interface TranscriptOptions {
   baseUrl: string;
   org: string;
   agent: string;
@@ -40,18 +42,24 @@ class HttpTurnTranscript implements TurnTranscript {
   private readonly fetchImpl: typeof fetch;
   private disabled = false;
   private landed = 0;
+  private userPublish: Promise<TranscriptPublishResult> | undefined;
 
   constructor(private readonly opts: TranscriptOptions) {
     this.fetchImpl = opts.fetchImpl ?? fetch;
   }
 
-  async publish(): Promise<TranscriptPublishResult> {
-    let conversation: ReturnType<typeof loadConversation>;
+  private load(): {
+    conversation?: NonNullable<ReturnType<typeof loadConversation>>;
+    error?: string;
+  } {
     try {
-      conversation = loadConversation(
+      const conversation = loadConversation(
         join(this.opts.dataDir, "conversations"),
         this.opts.conversationId,
       );
+      return conversation
+        ? { conversation }
+        : { error: "conversation file is missing" };
     } catch (error) {
       // A corrupt file must still end in a terminal error frame, never a
       // stream that closes with neither done nor error.
@@ -59,25 +67,48 @@ class HttpTurnTranscript implements TurnTranscript {
         error: `conversation file unreadable: ${error instanceof Error ? error.message : String(error)}`,
       };
     }
-    if (!conversation) return { error: "conversation file is missing" };
-    // A hydrated conversation contains every earlier turn. The persisted
-    // turnId identifies the one idempotent pair this claim is allowed to PUT.
-    // LAST match: an adopted re-run of this turnId appends a second pair
-    // behind the dead worker's, and the reply the client just streamed is
-    // the one that must reach Postgres.
-    const userIndex = conversation.messages.findLastIndex(
+  }
+
+  // A hydrated conversation contains every earlier turn. The persisted turnId
+  // identifies the one idempotent pair this claim is allowed to PUT. LAST
+  // match: an adopted re-run of this turnId appends a second pair behind the
+  // dead worker's, and the reply the client just streamed is the one that
+  // must reach Postgres.
+  private userIndex(messages: { role: string; turnId?: string }[]): number {
+    return messages.findLastIndex(
       (message) =>
         message.role === "user" && message.turnId === this.opts.turnId,
     );
+  }
+
+  async publishUser(): Promise<void> {
+    this.userPublish ??= (async (): Promise<TranscriptPublishResult> => {
+      const loaded = this.load();
+      if (!loaded.conversation) return { error: loaded.error ?? "" };
+      const index = this.userIndex(loaded.conversation.messages);
+      if (index < 0) return { error: "turn user message is missing" };
+      return this.put({
+        kind: "user",
+        turnId: this.opts.turnId,
+        message: loaded.conversation.messages[index],
+        title: loaded.conversation.title || "",
+        expectedCount: index,
+      });
+    })();
+    await this.userPublish;
+  }
+
+  async publish(): Promise<TranscriptPublishResult> {
+    await this.publishUser();
+    const userResult = await this.userPublish;
+    if (!userResult || !("ok" in userResult)) {
+      return userResult ?? { error: "user row was never published" };
+    }
+    const loaded = this.load();
+    if (!loaded.conversation) return { error: loaded.error ?? "" };
+    const conversation = loaded.conversation;
+    const userIndex = this.userIndex(conversation.messages);
     if (userIndex < 0) return { error: "turn user message is missing" };
-    const userResult = await this.put({
-      kind: "user",
-      turnId: this.opts.turnId,
-      message: conversation.messages[userIndex],
-      title: conversation.title || "",
-      expectedCount: userIndex,
-    });
-    if (!("ok" in userResult)) return userResult;
 
     const assistant = conversation.messages
       .slice(userIndex + 1)
@@ -98,38 +129,8 @@ class HttpTurnTranscript implements TurnTranscript {
     write: TranscriptTurnWrite,
   ): Promise<TranscriptPublishResult> {
     if (this.disabled) return { disabled: true, reason: "route_absent" };
-    const root = this.opts.baseUrl.replace(/\/+$/, "");
-    const conversationUrl = `${root}/v1/pod/transcripts/${encodeURIComponent(
-      this.opts.org,
-    )}/${encodeURIComponent(this.opts.agent)}/conversations/${encodeURIComponent(
-      this.opts.conversationId,
-    )}`;
-    const request = transcriptTurnRequest(conversationUrl, write);
     try {
-      // Transient 502/503/504 and network drops retry (the routes are
-      // idempotent per turnId); a fresh timeout per attempt, or a timed-out
-      // signal would abort every retry on arrival.
-      const response = await fetchWithRetry(
-        (url, init) =>
-          this.fetchImpl(url, {
-            ...init,
-            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-          }),
-        request.url,
-        {
-          method: request.method,
-          headers: {
-            Authorization: `Bearer ${this.opts.hostToken}`,
-            "Content-Type": "application/json",
-            "X-Houston-Claim-Token": this.opts.claim.token,
-            "X-Houston-Claim-Boot": this.opts.claim.bootId,
-          },
-          body: JSON.stringify(request.body),
-        },
-        this.opts.retryDelaysMs ? { delaysMs: this.opts.retryDelaysMs } : {},
-      );
-      // Release the socket whatever the status; the body is never needed.
-      await response.body?.cancel();
+      const response = await putTranscriptRow(this.fetchImpl, this.opts, write);
       if (response.ok) {
         this.landed += 1;
         return { ok: true };

--- a/packages/runtime/src/turn/turn-transcript.ts
+++ b/packages/runtime/src/turn/turn-transcript.ts
@@ -1,0 +1,182 @@
+import { join } from "node:path";
+import {
+  type TranscriptTurnWrite,
+  transcriptTurnRequest,
+} from "@houston/runtime-client";
+import { fetchWithRetry } from "@houston/runtime-client/object-sync";
+import { loadConversation } from "../store/conversation-file";
+import type { TurnServerDeps } from "./server-types";
+import type { TurnFilesystem } from "./turn-filesystem";
+import { poolIdentity } from "./turn-store";
+import type { TurnRequest } from "./types";
+
+const REQUEST_TIMEOUT_MS = 5_000;
+
+export type TranscriptPublishResult =
+  | { ok: true }
+  | { disabled: true; reason: "route_absent" }
+  | { fenced: true }
+  | { error: string };
+
+export interface TurnTranscript {
+  publish(): Promise<TranscriptPublishResult>;
+}
+
+interface TranscriptOptions {
+  baseUrl: string;
+  org: string;
+  agent: string;
+  conversationId: string;
+  turnId: string;
+  dataDir: string;
+  hostToken: string;
+  claim: { token: string; bootId: string };
+  fetchImpl?: typeof fetch;
+  /** Test seam: shrink the transient-status retry delays. */
+  retryDelaysMs?: number[];
+}
+
+class HttpTurnTranscript implements TurnTranscript {
+  private readonly fetchImpl: typeof fetch;
+  private disabled = false;
+  private landed = 0;
+
+  constructor(private readonly opts: TranscriptOptions) {
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  async publish(): Promise<TranscriptPublishResult> {
+    let conversation: ReturnType<typeof loadConversation>;
+    try {
+      conversation = loadConversation(
+        join(this.opts.dataDir, "conversations"),
+        this.opts.conversationId,
+      );
+    } catch (error) {
+      // A corrupt file must still end in a terminal error frame, never a
+      // stream that closes with neither done nor error.
+      return {
+        error: `conversation file unreadable: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+    if (!conversation) return { error: "conversation file is missing" };
+    // A hydrated conversation contains every earlier turn. The persisted
+    // turnId identifies the one idempotent pair this claim is allowed to PUT.
+    // LAST match: an adopted re-run of this turnId appends a second pair
+    // behind the dead worker's, and the reply the client just streamed is
+    // the one that must reach Postgres.
+    const userIndex = conversation.messages.findLastIndex(
+      (message) =>
+        message.role === "user" && message.turnId === this.opts.turnId,
+    );
+    if (userIndex < 0) return { error: "turn user message is missing" };
+    const userResult = await this.put({
+      kind: "user",
+      turnId: this.opts.turnId,
+      message: conversation.messages[userIndex],
+      title: conversation.title || "",
+      expectedCount: userIndex,
+    });
+    if (!("ok" in userResult)) return userResult;
+
+    const assistant = conversation.messages
+      .slice(userIndex + 1)
+      .find(
+        (message) =>
+          message.role === "assistant" && message.turnId === this.opts.turnId,
+      );
+    return assistant
+      ? this.put({
+          kind: "assistant",
+          turnId: this.opts.turnId,
+          message: assistant,
+        })
+      : ({ ok: true } as const);
+  }
+
+  private async put(
+    write: TranscriptTurnWrite,
+  ): Promise<TranscriptPublishResult> {
+    if (this.disabled) return { disabled: true, reason: "route_absent" };
+    const root = this.opts.baseUrl.replace(/\/+$/, "");
+    const conversationUrl = `${root}/v1/pod/transcripts/${encodeURIComponent(
+      this.opts.org,
+    )}/${encodeURIComponent(this.opts.agent)}/conversations/${encodeURIComponent(
+      this.opts.conversationId,
+    )}`;
+    const request = transcriptTurnRequest(conversationUrl, write);
+    try {
+      // Transient 502/503/504 and network drops retry (the routes are
+      // idempotent per turnId); a fresh timeout per attempt, or a timed-out
+      // signal would abort every retry on arrival.
+      const response = await fetchWithRetry(
+        (url, init) =>
+          this.fetchImpl(url, {
+            ...init,
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+          }),
+        request.url,
+        {
+          method: request.method,
+          headers: {
+            Authorization: `Bearer ${this.opts.hostToken}`,
+            "Content-Type": "application/json",
+            "X-Houston-Claim-Token": this.opts.claim.token,
+            "X-Houston-Claim-Boot": this.opts.claim.bootId,
+          },
+          body: JSON.stringify(request.body),
+        },
+        this.opts.retryDelaysMs ? { delaysMs: this.opts.retryDelaysMs } : {},
+      );
+      // Release the socket whatever the status; the body is never needed.
+      await response.body?.cancel();
+      if (response.ok) {
+        this.landed += 1;
+        return { ok: true };
+      }
+      if (response.status === 404 && this.landed === 0) {
+        // Older deployments may lack transcript routes: the FIRST PUT is the
+        // probe. Once a row has landed the routes exist, so a later 404 is a
+        // real miss (conversation gone) and must fail the publish below.
+        // Loud: a whole fleet silently publishing nothing would otherwise be
+        // invisible until the history fallback found empty tables.
+        console.warn(
+          `[turn] transcript routes absent at the pool store; skipping publish for ${this.opts.org}/${this.opts.agent}/${this.opts.conversationId}`,
+        );
+        this.disabled = true;
+        return { disabled: true, reason: "route_absent" };
+      }
+      if (response.status === 409) return { fenced: true };
+      // Status only: response bodies are an HTTP seam, and this string ends
+      // up on the terminal frame and in the turn log.
+      return { error: `${write.kind} row rejected (${response.status})` };
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+}
+
+/** Create a claim-authorized transcript publisher for one real pool turn. */
+export function createTurnTranscript(
+  deps: TurnServerDeps,
+  turn: TurnRequest & { turnId: string },
+  filesystem: TurnFilesystem,
+): TurnTranscript | null {
+  const baseUrl = deps.poolStoreUrl ?? process.env.HOUSTON_POOL_STORE_URL;
+  if (turn.shadow || !baseUrl || !turn.claim || !turn.hostToken) return null;
+  const { org, agent } = poolIdentity(turn.gcsPrefix);
+  return new HttpTurnTranscript({
+    baseUrl,
+    org,
+    agent,
+    conversationId: turn.conversationId,
+    turnId: turn.turnId,
+    dataDir: filesystem.dataDir,
+    hostToken: turn.hostToken,
+    claim: { token: turn.claim.token, bootId: turn.claim.bootId },
+    ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+    ...(deps.transcriptRetryDelaysMs
+      ? { retryDelaysMs: deps.transcriptRetryDelaysMs }
+      : {}),
+  });
+}

--- a/packages/runtime/src/turn/types.test.ts
+++ b/packages/runtime/src/turn/types.test.ts
@@ -28,3 +28,81 @@ test("parseTurnRequest never trusts the wire — an unknown mode is execute", ()
   expect(parseTurnRequest({ ...BASE, mode: "" }).mode).toBe("execute");
   expect(parseTurnRequest({ ...BASE, mode: 1 }).mode).toBe("execute");
 });
+
+test("parseTurnRequest accepts the pool execution envelope", () => {
+  expect(
+    parseTurnRequest({
+      ...BASE,
+      turnId: "turn-1",
+      hostToken: "host-secret",
+      actingAs: { userId: "user-1", name: "Ada" },
+      shadow: true,
+      claim: {
+        id: "claim-1",
+        bootId: "boot-1",
+        token: "claim-secret",
+        heartbeatUrl: "https://gateway.test/claims/claim-1/heartbeat",
+      },
+    }),
+  ).toMatchObject({
+    turnId: "turn-1",
+    hostToken: "host-secret",
+    actingAs: { userId: "user-1", name: "Ada" },
+    shadow: true,
+    claim: { id: "claim-1", bootId: "boot-1", token: "claim-secret" },
+  });
+});
+
+test.each([
+  ["turnId", { turnId: "bad/id" }],
+  ["hostToken", { hostToken: "" }],
+  ["actingAs", { actingAs: { userId: "" } }],
+  ["actingAs", { actingAs: { userId: "u1", extra: true } }],
+  ["shadow", { shadow: "true" }],
+  ["claim", { claim: { id: "c", bootId: "b", token: "t" } }],
+  [
+    "claim",
+    {
+      claim: {
+        id: "c",
+        bootId: "b",
+        token: "t",
+        heartbeatUrl: "https://gateway.test/hb",
+        extra: true,
+      },
+    },
+  ],
+])("rejects an invalid optional %s field", (_field, extra) => {
+  expect(() => parseTurnRequest({ ...BASE, ...extra })).toThrow();
+});
+
+test("claim and hostToken are all-or-nothing", () => {
+  const claim = {
+    id: "claim-1",
+    bootId: "boot-1",
+    token: "claim-secret",
+    heartbeatUrl: "https://gateway.test/heartbeat",
+  };
+  expect(() => parseTurnRequest({ ...BASE, claim })).toThrow(
+    "claim and hostToken",
+  );
+  expect(() => parseTurnRequest({ ...BASE, hostToken: "host-secret" })).toThrow(
+    "claim and hostToken",
+  );
+});
+
+test("a claimed turn requires exactly ws/org/agent", () => {
+  expect(() =>
+    parseTurnRequest({
+      ...BASE,
+      gcsPrefix: "ws/org/agent/extra",
+      hostToken: "host-secret",
+      claim: {
+        id: "claim-1",
+        bootId: "boot-1",
+        token: "claim-secret",
+        heartbeatUrl: "https://gateway.test/heartbeat",
+      },
+    }),
+  ).toThrow("claimed turn has invalid 'gcsPrefix'");
+});

--- a/packages/runtime/src/turn/types.test.ts
+++ b/packages/runtime/src/turn/types.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { parseTurnRequest } from "./types";
+import { parseTurnRequest } from "./parse-turn-request";
 
 const BASE = {
   workspaceId: "w1",
@@ -117,4 +117,18 @@ test("parseTurnRequest accepts a turnlog seq start and rejects a bad one", () =>
       "invalid 'turnlogSeqStart'",
     );
   }
+});
+
+test("parseTurnRequest carries the hosted turn context and rejects non-strings", () => {
+  const parsed = parseTurnRequest({
+    ...BASE,
+    workspaceContext: "team note",
+    userContext: "",
+  });
+  expect(parsed.workspaceContext).toBe("team note");
+  expect(parsed.userContext).toBe("");
+  expect(parseTurnRequest(BASE).workspaceContext).toBeUndefined();
+  expect(() => parseTurnRequest({ ...BASE, userContext: 5 })).toThrow(
+    "invalid 'userContext'",
+  );
 });

--- a/packages/runtime/src/turn/types.test.ts
+++ b/packages/runtime/src/turn/types.test.ts
@@ -106,3 +106,15 @@ test("a claimed turn requires exactly ws/org/agent", () => {
     }),
   ).toThrow("claimed turn has invalid 'gcsPrefix'");
 });
+
+test("parseTurnRequest accepts a turnlog seq start and rejects a bad one", () => {
+  expect(
+    parseTurnRequest({ ...BASE, turnlogSeqStart: 41 }).turnlogSeqStart,
+  ).toBe(41);
+  expect(parseTurnRequest(BASE).turnlogSeqStart).toBeUndefined();
+  for (const bad of [0, -1, 1.5, "41", Number.MAX_SAFE_INTEGER + 2]) {
+    expect(() => parseTurnRequest({ ...BASE, turnlogSeqStart: bad })).toThrow(
+      "invalid 'turnlogSeqStart'",
+    );
+  }
+});

--- a/packages/runtime/src/turn/types.ts
+++ b/packages/runtime/src/turn/types.ts
@@ -1,9 +1,4 @@
-import {
-  type ChatMessage,
-  normalizeTurnMode,
-  parseMentions,
-  type TurnMode,
-} from "@houston/protocol";
+import type { ChatMessage, TurnMode } from "@houston/protocol";
 import type { ServedCredential } from "../auth/auth-file";
 
 /**
@@ -55,6 +50,14 @@ export interface TurnRequest {
   /** Hydrate and resolve the model without calling it or writing back. */
   shadow?: boolean;
   /**
+   * Hosted-gateway turn context (HOU-711): the org's shared note and the
+   * caller's context, injected into the session prompt exactly as the
+   * long-lived server path does. Either present = "use these" (each defaults
+   * to ""); both absent = the workspace's own context files.
+   */
+  workspaceContext?: string;
+  userContext?: string;
+  /**
    * First turnlog sequence number this execution may use. The gateway keeps
    * ONE turnlog stream per conversation, so a worker that restarted at 1 on a
    * conversation's second turn would collide with the first turn's frames
@@ -67,165 +70,5 @@ export interface TurnRequest {
     bootId: string;
     token: string;
     heartbeatUrl: string;
-  };
-}
-
-const ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
-const PREFIX = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$/;
-
-function record(value: unknown, field: string): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`invalid '${field}'`);
-  }
-  // SAFETY: the object/array check establishes the string-keyed JSON record
-  // shape; every consumed property is parsed again below.
-  return value as Record<string, unknown>;
-}
-
-function exactKeys(
-  value: Record<string, unknown>,
-  allowed: readonly string[],
-  field: string,
-): void {
-  if (Object.keys(value).some((key) => !allowed.includes(key))) {
-    throw new Error(`invalid '${field}'`);
-  }
-}
-
-function nonEmpty(value: unknown): value is string {
-  return typeof value === "string" && value.length > 0;
-}
-
-/** Validate an untyped body into a TurnRequest. Throws with the real reason. */
-export function parseTurnRequest(body: unknown): TurnRequest {
-  const b = body as Record<string, unknown>;
-  if (!b || typeof b !== "object")
-    throw new Error("body must be a JSON object");
-  for (const field of ["workspaceId", "agentId", "conversationId"] as const) {
-    if (typeof b[field] !== "string" || !ID.test(b[field] as string)) {
-      throw new Error(`invalid '${field}'`);
-    }
-  }
-  if (typeof b.text !== "string" || !b.text.length)
-    throw new Error("missing 'text'");
-  const prefix = b.gcsPrefix;
-  if (
-    typeof prefix !== "string" ||
-    !PREFIX.test(prefix) ||
-    prefix.includes("..")
-  ) {
-    throw new Error("invalid 'gcsPrefix'");
-  }
-  let credential: ServedCredential | null = null;
-  if (b.credential != null) {
-    const c = b.credential as Record<string, unknown>;
-    if (
-      typeof c.provider !== "string" ||
-      typeof c.access !== "string" ||
-      typeof c.expires !== "number"
-    ) {
-      throw new Error("invalid 'credential'");
-    }
-    credential = {
-      provider: c.provider,
-      access: c.access,
-      expires: c.expires,
-      accountId: typeof c.accountId === "string" ? c.accountId : null,
-      kind: c.kind === "api_key" ? "api_key" : "oauth",
-      // Copilot Enterprise routes to a per-tenant API host; dropping it here
-      // would silently turn an enterprise credential into a github.com one.
-      ...(typeof c.enterpriseUrl === "string" && c.enterpriseUrl
-        ? { enterpriseUrl: c.enterpriseUrl }
-        : {}),
-    };
-  }
-  if (b.turnId !== undefined && (!nonEmpty(b.turnId) || !ID.test(b.turnId))) {
-    throw new Error("invalid 'turnId'");
-  }
-  if (b.hostToken !== undefined && !nonEmpty(b.hostToken)) {
-    throw new Error("invalid 'hostToken'");
-  }
-  let actingAs: TurnRequest["actingAs"];
-  if (b.actingAs !== undefined) {
-    const acting = record(b.actingAs, "actingAs");
-    exactKeys(acting, ["userId", "name"], "actingAs");
-    if (
-      !nonEmpty(acting.userId) ||
-      (acting.name !== undefined && !nonEmpty(acting.name))
-    ) {
-      throw new Error("invalid 'actingAs'");
-    }
-    actingAs = {
-      userId: acting.userId,
-      ...(acting.name ? { name: acting.name } : {}),
-    };
-  }
-  if (b.shadow !== undefined && typeof b.shadow !== "boolean") {
-    throw new Error("invalid 'shadow'");
-  }
-  if (
-    b.turnlogSeqStart !== undefined &&
-    (typeof b.turnlogSeqStart !== "number" ||
-      !Number.isSafeInteger(b.turnlogSeqStart) ||
-      b.turnlogSeqStart < 1)
-  ) {
-    throw new Error("invalid 'turnlogSeqStart'");
-  }
-  let claim: TurnRequest["claim"];
-  if (b.claim !== undefined) {
-    const parsed = record(b.claim, "claim");
-    exactKeys(parsed, ["id", "bootId", "token", "heartbeatUrl"], "claim");
-    if (
-      !nonEmpty(parsed.id) ||
-      !nonEmpty(parsed.bootId) ||
-      !nonEmpty(parsed.token) ||
-      !nonEmpty(parsed.heartbeatUrl)
-    ) {
-      throw new Error("invalid 'claim'");
-    }
-    claim = {
-      id: parsed.id,
-      bootId: parsed.bootId,
-      token: parsed.token,
-      heartbeatUrl: parsed.heartbeatUrl,
-    };
-  }
-  if (Boolean(claim) !== Boolean(b.hostToken)) {
-    throw new Error("claim and hostToken must be configured together");
-  }
-  const poolPrefix = prefix.split("/");
-  if (
-    claim &&
-    (poolPrefix.length !== 3 ||
-      poolPrefix[0] !== "ws" ||
-      !poolPrefix[1] ||
-      !poolPrefix[2])
-  ) {
-    throw new Error("claimed turn has invalid 'gcsPrefix'");
-  }
-  return {
-    workspaceId: b.workspaceId as string,
-    agentId: b.agentId as string,
-    conversationId: b.conversationId as string,
-    text: b.text,
-    nonce: typeof b.nonce === "string" ? b.nonce : undefined,
-    gcsPrefix: prefix,
-    credential,
-    model: typeof b.model === "string" ? b.model : undefined,
-    effort: typeof b.effort === "string" ? b.effort : undefined,
-    // Never trust the wire: only the known mode literals ("plan", "auto") pass;
-    // anything else normalizes to "execute".
-    mode: normalizeTurnMode(b.mode),
-    displayText: typeof b.displayText === "string" ? b.displayText : undefined,
-    // Same "never trust the wire" posture: junk entries are dropped and an
-    // empty list becomes nothing, so a bad sidecar never costs the user a turn.
-    mentions: parseMentions(b.mentions),
-    turnId: typeof b.turnId === "string" ? b.turnId : undefined,
-    hostToken: typeof b.hostToken === "string" ? b.hostToken : undefined,
-    actingAs,
-    shadow: typeof b.shadow === "boolean" ? b.shadow : undefined,
-    turnlogSeqStart:
-      typeof b.turnlogSeqStart === "number" ? b.turnlogSeqStart : undefined,
-    claim,
   };
 }

--- a/packages/runtime/src/turn/types.ts
+++ b/packages/runtime/src/turn/types.ts
@@ -54,6 +54,13 @@ export interface TurnRequest {
   actingAs?: { userId: string; name?: string };
   /** Hydrate and resolve the model without calling it or writing back. */
   shadow?: boolean;
+  /**
+   * First turnlog sequence number this execution may use. The gateway keeps
+   * ONE turnlog stream per conversation, so a worker that restarted at 1 on a
+   * conversation's second turn would collide with the first turn's frames
+   * (replay = resync). Absent = 1 (a fresh conversation, or a legacy caller).
+   */
+  turnlogSeqStart?: number;
   /** Exclusive conversation claim granted to this worker. */
   claim?: {
     id: string;
@@ -156,6 +163,14 @@ export function parseTurnRequest(body: unknown): TurnRequest {
   if (b.shadow !== undefined && typeof b.shadow !== "boolean") {
     throw new Error("invalid 'shadow'");
   }
+  if (
+    b.turnlogSeqStart !== undefined &&
+    (typeof b.turnlogSeqStart !== "number" ||
+      !Number.isSafeInteger(b.turnlogSeqStart) ||
+      b.turnlogSeqStart < 1)
+  ) {
+    throw new Error("invalid 'turnlogSeqStart'");
+  }
   let claim: TurnRequest["claim"];
   if (b.claim !== undefined) {
     const parsed = record(b.claim, "claim");
@@ -209,6 +224,8 @@ export function parseTurnRequest(body: unknown): TurnRequest {
     hostToken: typeof b.hostToken === "string" ? b.hostToken : undefined,
     actingAs,
     shadow: typeof b.shadow === "boolean" ? b.shadow : undefined,
+    turnlogSeqStart:
+      typeof b.turnlogSeqStart === "number" ? b.turnlogSeqStart : undefined,
     claim,
   };
 }

--- a/packages/runtime/src/turn/types.ts
+++ b/packages/runtime/src/turn/types.ts
@@ -125,6 +125,11 @@ export function parseTurnRequest(body: unknown): TurnRequest {
       expires: c.expires,
       accountId: typeof c.accountId === "string" ? c.accountId : null,
       kind: c.kind === "api_key" ? "api_key" : "oauth",
+      // Copilot Enterprise routes to a per-tenant API host; dropping it here
+      // would silently turn an enterprise credential into a github.com one.
+      ...(typeof c.enterpriseUrl === "string" && c.enterpriseUrl
+        ? { enterpriseUrl: c.enterpriseUrl }
+        : {}),
     };
   }
   if (b.turnId !== undefined && (!nonEmpty(b.turnId) || !ID.test(b.turnId))) {

--- a/packages/runtime/src/turn/types.ts
+++ b/packages/runtime/src/turn/types.ts
@@ -46,10 +46,48 @@ export interface TurnRequest {
    * message mentions nobody.
    */
   mentions?: ChatMessage["mentions"];
+  /** Gateway-minted identity reused across a retried dispatch. */
+  turnId?: string;
+  /** Per-claim gateway token. Secret material, never log this value. */
+  hostToken?: string;
+  /** Human attribution for machine-dispatched work. */
+  actingAs?: { userId: string; name?: string };
+  /** Hydrate and resolve the model without calling it or writing back. */
+  shadow?: boolean;
+  /** Exclusive conversation claim granted to this worker. */
+  claim?: {
+    id: string;
+    bootId: string;
+    token: string;
+    heartbeatUrl: string;
+  };
 }
 
 const ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const PREFIX = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$/;
+
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`invalid '${field}'`);
+  }
+  // SAFETY: the object/array check establishes the string-keyed JSON record
+  // shape; every consumed property is parsed again below.
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  field: string,
+): void {
+  if (Object.keys(value).some((key) => !allowed.includes(key))) {
+    throw new Error(`invalid '${field}'`);
+  }
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
 
 /** Validate an untyped body into a TurnRequest. Throws with the real reason. */
 export function parseTurnRequest(body: unknown): TurnRequest {
@@ -89,6 +127,62 @@ export function parseTurnRequest(body: unknown): TurnRequest {
       kind: c.kind === "api_key" ? "api_key" : "oauth",
     };
   }
+  if (b.turnId !== undefined && (!nonEmpty(b.turnId) || !ID.test(b.turnId))) {
+    throw new Error("invalid 'turnId'");
+  }
+  if (b.hostToken !== undefined && !nonEmpty(b.hostToken)) {
+    throw new Error("invalid 'hostToken'");
+  }
+  let actingAs: TurnRequest["actingAs"];
+  if (b.actingAs !== undefined) {
+    const acting = record(b.actingAs, "actingAs");
+    exactKeys(acting, ["userId", "name"], "actingAs");
+    if (
+      !nonEmpty(acting.userId) ||
+      (acting.name !== undefined && !nonEmpty(acting.name))
+    ) {
+      throw new Error("invalid 'actingAs'");
+    }
+    actingAs = {
+      userId: acting.userId,
+      ...(acting.name ? { name: acting.name } : {}),
+    };
+  }
+  if (b.shadow !== undefined && typeof b.shadow !== "boolean") {
+    throw new Error("invalid 'shadow'");
+  }
+  let claim: TurnRequest["claim"];
+  if (b.claim !== undefined) {
+    const parsed = record(b.claim, "claim");
+    exactKeys(parsed, ["id", "bootId", "token", "heartbeatUrl"], "claim");
+    if (
+      !nonEmpty(parsed.id) ||
+      !nonEmpty(parsed.bootId) ||
+      !nonEmpty(parsed.token) ||
+      !nonEmpty(parsed.heartbeatUrl)
+    ) {
+      throw new Error("invalid 'claim'");
+    }
+    claim = {
+      id: parsed.id,
+      bootId: parsed.bootId,
+      token: parsed.token,
+      heartbeatUrl: parsed.heartbeatUrl,
+    };
+  }
+  if (Boolean(claim) !== Boolean(b.hostToken)) {
+    throw new Error("claim and hostToken must be configured together");
+  }
+  const poolPrefix = prefix.split("/");
+  if (
+    claim &&
+    (poolPrefix.length !== 3 ||
+      poolPrefix[0] !== "ws" ||
+      !poolPrefix[1] ||
+      !poolPrefix[2])
+  ) {
+    throw new Error("claimed turn has invalid 'gcsPrefix'");
+  }
   return {
     workspaceId: b.workspaceId as string,
     agentId: b.agentId as string,
@@ -106,5 +200,10 @@ export function parseTurnRequest(body: unknown): TurnRequest {
     // Same "never trust the wire" posture: junk entries are dropped and an
     // empty list becomes nothing, so a bad sidecar never costs the user a turn.
     mentions: parseMentions(b.mentions),
+    turnId: typeof b.turnId === "string" ? b.turnId : undefined,
+    hostToken: typeof b.hostToken === "string" ? b.hostToken : undefined,
+    actingAs,
+    shadow: typeof b.shadow === "boolean" ? b.shadow : undefined,
+    claim,
   };
 }

--- a/packages/runtime/src/turn/worker-registration-config.ts
+++ b/packages/runtime/src/turn/worker-registration-config.ts
@@ -1,0 +1,70 @@
+import { readFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+
+const ENV_NAMES = [
+  "HOUSTON_POOL_REGISTER_URL",
+  "HOUSTON_POOL_WORKER_ID",
+  "HOUSTON_POOL_WORKER_TOKEN_DIR",
+  "HOUSTON_POOL_ENDPOINT",
+] as const;
+
+type RegistrationEnv = Partial<Record<(typeof ENV_NAMES)[number], string>>;
+
+/** Parsed registration settings plus the per-worker secret. */
+export interface WorkerRegistrationConfig {
+  heartbeatUrl: string;
+  workerId: string;
+  endpoint: string;
+  token: string;
+}
+
+/** Parse all-or-none pool registration env and load this worker's token. */
+export async function loadWorkerRegistrationConfig(
+  env: RegistrationEnv = process.env,
+): Promise<WorkerRegistrationConfig | null> {
+  const values = {
+    HOUSTON_POOL_REGISTER_URL: env.HOUSTON_POOL_REGISTER_URL?.trim() ?? "",
+    HOUSTON_POOL_WORKER_ID: env.HOUSTON_POOL_WORKER_ID?.trim() ?? "",
+    HOUSTON_POOL_WORKER_TOKEN_DIR:
+      env.HOUSTON_POOL_WORKER_TOKEN_DIR?.trim() ?? "",
+    HOUSTON_POOL_ENDPOINT: env.HOUSTON_POOL_ENDPOINT?.trim() ?? "",
+  };
+  const configured = ENV_NAMES.filter((name) => values[name]);
+  if (configured.length === 0) return null;
+  const missing = ENV_NAMES.filter((name) => !values[name]);
+  if (missing.length > 0) {
+    throw new Error(`pool registration is missing: ${missing.join(", ")}`);
+  }
+  const workerId = values.HOUSTON_POOL_WORKER_ID;
+  if (
+    basename(workerId) !== workerId ||
+    workerId === "." ||
+    workerId === ".."
+  ) {
+    throw new Error("HOUSTON_POOL_WORKER_ID must be a file name");
+  }
+  const token = (
+    await readFile(join(values.HOUSTON_POOL_WORKER_TOKEN_DIR, workerId), "utf8")
+  ).trim();
+  if (!token)
+    throw new Error(`pool worker token file is empty for ${workerId}`);
+  const origin = new URL(values.HOUSTON_POOL_REGISTER_URL);
+  if (origin.pathname !== "/" || origin.search || origin.hash) {
+    throw new Error("HOUSTON_POOL_REGISTER_URL must be an origin");
+  }
+  new URL(values.HOUSTON_POOL_ENDPOINT);
+  return {
+    heartbeatUrl: `${origin.origin}/v1/pool/workers/heartbeat`,
+    workerId,
+    endpoint: values.HOUSTON_POOL_ENDPOINT,
+    token,
+  };
+}
+
+/** Prefer the explicit development token over the registered worker token. */
+export function turnServerToken(
+  explicitToken: string,
+  registration: WorkerRegistrationConfig | null,
+): string {
+  return explicitToken || registration?.token || "";
+}

--- a/packages/runtime/src/turn/worker-registration.test.ts
+++ b/packages/runtime/src/turn/worker-registration.test.ts
@@ -1,0 +1,241 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalDirStore } from "@houston/runtime-client/object-sync";
+import { afterEach, expect, test } from "vitest";
+import { AdmissionLimiter } from "./admission";
+import { createTurnServer } from "./server";
+import { beginWorkerShutdown, WorkerRegistration } from "./worker-registration";
+import {
+  loadWorkerRegistrationConfig,
+  turnServerToken,
+} from "./worker-registration-config";
+
+const servers: Server[] = [];
+afterEach(() => {
+  for (const server of servers.splice(0)) server.close();
+});
+
+test("registration is off when every variable is absent", async () => {
+  await expect(loadWorkerRegistrationConfig({})).resolves.toBeNull();
+});
+
+test("partial registration fails with every missing variable", async () => {
+  await expect(
+    loadWorkerRegistrationConfig({ HOUSTON_POOL_WORKER_ID: "worker-1" }),
+  ).rejects.toThrow(
+    "HOUSTON_POOL_REGISTER_URL, HOUSTON_POOL_WORKER_TOKEN_DIR, HOUSTON_POOL_ENDPOINT",
+  );
+});
+
+test("registration loads the per-worker token and dev token wins", async () => {
+  const tokenDir = await mkdtemp(join(tmpdir(), "worker-token-"));
+  await mkdir(tokenDir, { recursive: true });
+  await writeFile(join(tokenDir, "worker-1"), " pool-token\n");
+  const config = await loadWorkerRegistrationConfig({
+    HOUSTON_POOL_REGISTER_URL: "https://gateway.test/",
+    HOUSTON_POOL_WORKER_ID: "worker-1",
+    HOUSTON_POOL_WORKER_TOKEN_DIR: tokenDir,
+    HOUSTON_POOL_ENDPOINT: "http://worker-1:4318",
+  });
+
+  expect(config).toMatchObject({
+    heartbeatUrl: "https://gateway.test/v1/pool/workers/heartbeat",
+    workerId: "worker-1",
+    endpoint: "http://worker-1:4318",
+    token: "pool-token",
+  });
+  expect(turnServerToken("dev-token", config)).toBe("dev-token");
+  expect(turnServerToken("", config)).toBe("pool-token");
+});
+
+test("the selected token protects the inbound turn route", async () => {
+  const registration = {
+    heartbeatUrl: "https://gateway.test/heartbeat",
+    workerId: "worker-1",
+    endpoint: "http://worker-1:4318",
+    token: "pool-token",
+  };
+  const startServer = async (explicitToken: string) => {
+    const server = createTurnServer({
+      store: new LocalDirStore(await mkdtemp(join(tmpdir(), "token-store-"))),
+      token: turnServerToken(explicitToken, registration),
+      isDraining: () => true,
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("no address");
+    return `http://127.0.0.1:${address.port}`;
+  };
+  const post = (base: string, token: string) =>
+    fetch(`${base}/turn`, {
+      method: "POST",
+      headers: { "x-internal-token": token },
+    });
+
+  const pooled = await startServer("");
+  expect((await post(pooled, "wrong")).status).toBe(401);
+  expect((await post(pooled, "pool-token")).status).toBe(503);
+  const development = await startServer("dev-token");
+  expect((await post(development, "pool-token")).status).toBe(401);
+  expect((await post(development, "dev-token")).status).toBe(503);
+});
+
+test("heartbeat sends the exact body and bearer token", async () => {
+  let received:
+    | { authorization?: string; body: Record<string, unknown> }
+    | undefined;
+  const gateway = createServer((req, res) => {
+    void (async () => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(Buffer.from(chunk));
+      received = {
+        authorization: req.headers.authorization,
+        body: JSON.parse(Buffer.concat(chunks).toString("utf8")),
+      };
+      res.writeHead(204).end();
+    })();
+  });
+  servers.push(gateway);
+  await new Promise<void>((resolve) => gateway.listen(0, "127.0.0.1", resolve));
+  const address = gateway.address();
+  if (!address || typeof address === "string") throw new Error("no address");
+  const admission = new AdmissionLimiter(3);
+  const release = admission.tryAcquire();
+  const registration = new WorkerRegistration(
+    {
+      heartbeatUrl: `http://127.0.0.1:${address.port}/v1/pool/workers/heartbeat`,
+      workerId: "worker-1",
+      endpoint: "http://worker-1:4318",
+      token: "worker-token",
+    },
+    admission,
+    { bootId: "boot-1", intervalMs: 60_000 },
+  );
+
+  await registration.start();
+  await registration.stop();
+  release?.();
+
+  expect(received).toEqual({
+    authorization: "Bearer worker-token",
+    body: {
+      workerId: "worker-1",
+      bootId: "boot-1",
+      endpoint: "http://worker-1:4318",
+      capacity: 3,
+      activeClaims: 1,
+      draining: false,
+    },
+  });
+});
+
+test("a failed heartbeat logs status and text, then retries", async () => {
+  let calls = 0;
+  const messages: string[] = [];
+  const registration = new WorkerRegistration(
+    {
+      heartbeatUrl: "https://gateway.test/heartbeat",
+      workerId: "worker-1",
+      endpoint: "http://worker-1:4318",
+      token: "worker-token",
+    },
+    new AdmissionLimiter(1),
+    {
+      bootId: "boot-1",
+      intervalMs: 5,
+      fetchImpl: async () => {
+        calls += 1;
+        return calls === 1
+          ? new Response("try later", { status: 503 })
+          : new Response(null, { status: 204 });
+      },
+      log: (message) => messages.push(message),
+    },
+  );
+
+  await registration.start();
+  expect(calls).toBe(2);
+  await registration.stop();
+  expect(messages[0]).toContain("(503): try later");
+});
+
+test("stop aborts an in-flight heartbeat", async () => {
+  let markStarted: (() => void) | undefined;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const registration = new WorkerRegistration(
+    {
+      heartbeatUrl: "https://gateway.test/heartbeat",
+      workerId: "worker-1",
+      endpoint: "http://worker-1:4318",
+      token: "worker-token",
+    },
+    new AdmissionLimiter(1),
+    {
+      bootId: "boot-1",
+      fetchImpl: async (_input, init) => {
+        markStarted?.();
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(init.signal?.reason),
+          );
+        });
+      },
+    },
+  );
+
+  const starting = registration.start();
+  await started;
+  await registration.stop();
+  await expect(starting).rejects.toThrow(
+    "worker registration stopped before first success",
+  );
+});
+
+test("SIGTERM flips draining and admission reports worker_draining", async () => {
+  const admission = new AdmissionLimiter(1);
+  const bodies: Array<Record<string, unknown>> = [];
+  const registration = new WorkerRegistration(
+    {
+      heartbeatUrl: "https://gateway.test/heartbeat",
+      workerId: "worker-1",
+      endpoint: "http://worker-1:4318",
+      token: "worker-token",
+    },
+    admission,
+    {
+      bootId: "boot-1",
+      fetchImpl: async (_input, init) => {
+        bodies.push(JSON.parse(String(init?.body)));
+        return new Response(null, { status: 204 });
+      },
+    },
+  );
+
+  await beginWorkerShutdown("SIGTERM", registration);
+  expect(registration.draining).toBe(true);
+  expect(bodies.at(-1)).toMatchObject({ draining: true });
+  const server = createTurnServer({
+    store: new LocalDirStore(await mkdtemp(join(tmpdir(), "drain-store-"))),
+    token: "",
+    admission,
+    isDraining: () => registration.draining,
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("no address");
+  const response = await fetch(`http://127.0.0.1:${address.port}/turn`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  expect(response.status).toBe(503);
+  expect(await response.json()).toEqual({ error: "worker_draining" });
+});

--- a/packages/runtime/src/turn/worker-registration.ts
+++ b/packages/runtime/src/turn/worker-registration.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from "node:crypto";
+import type { AdmissionLimiter } from "./admission";
+import type { WorkerRegistrationConfig } from "./worker-registration-config";
+
+const REQUEST_TIMEOUT_MS = 5_000;
+let processBootId: string | undefined;
+
+function workerBootId(): string {
+  if (!processBootId) processBootId = randomUUID();
+  return processBootId;
+}
+
+interface WorkerRegistrationOptions {
+  fetchImpl?: typeof fetch;
+  intervalMs?: number;
+  bootId?: string;
+  log?: (message: string) => void;
+}
+
+/** Periodically publishes this process's live admission state. */
+export class WorkerRegistration {
+  private readonly fetchImpl: typeof fetch;
+  private readonly intervalMs: number;
+  private readonly bootId: string;
+  private readonly log: (message: string) => void;
+  private drainingState = false;
+  private stopped = false;
+  private startup: Promise<void> | undefined;
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private wakeRetry: (() => void) | undefined;
+  private requestAbort: AbortController | undefined;
+  private pending = Promise.resolve();
+
+  constructor(
+    private readonly config: WorkerRegistrationConfig,
+    private readonly admission: AdmissionLimiter,
+    options: WorkerRegistrationOptions = {},
+  ) {
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.intervalMs = options.intervalMs ?? 15_000;
+    this.bootId = options.bootId ?? workerBootId();
+    this.log = options.log ?? ((message) => console.warn(message));
+  }
+
+  /** Whether SIGTERM has stopped this worker from accepting turns. */
+  get draining(): boolean {
+    return this.drainingState;
+  }
+
+  /** Do not let the worker serve until the gateway has acknowledged it. */
+  start(): Promise<void> {
+    this.startup ??= this.startUntilRegistered();
+    return this.startup;
+  }
+
+  private async startUntilRegistered(): Promise<void> {
+    while (!this.stopped) {
+      const registered = await this.beat();
+      if (registered || this.stopped) break;
+      await new Promise<void>((resolve) => {
+        this.wakeRetry = resolve;
+        this.timer = setTimeout(resolve, this.intervalMs);
+        this.timer.unref?.();
+      });
+      this.wakeRetry = undefined;
+    }
+    if (this.stopped)
+      throw new Error("worker registration stopped before first success");
+    this.timer = setInterval(() => void this.queueBeat(), this.intervalMs);
+    this.timer.unref?.();
+  }
+
+  /** Stop admitting work and publish the transition immediately. */
+  beginDraining(): Promise<void> {
+    this.drainingState = true;
+    return this.queueBeat();
+  }
+
+  /** Stop scheduling and abort any request still inside its timeout. */
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.timer) clearInterval(this.timer);
+    this.wakeRetry?.();
+    this.requestAbort?.abort();
+    await this.pending;
+  }
+
+  private queueBeat(): Promise<void> {
+    this.pending = this.pending.then(async () => {
+      await this.beat();
+    });
+    return this.pending;
+  }
+
+  private async beat(): Promise<boolean> {
+    if (this.stopped) return false;
+    const requestAbort = new AbortController();
+    this.requestAbort = requestAbort;
+    try {
+      const response = await this.fetchImpl(this.config.heartbeatUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.config.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          workerId: this.config.workerId,
+          bootId: this.bootId,
+          endpoint: this.config.endpoint,
+          capacity: this.admission.capacity,
+          activeClaims: this.admission.active,
+          draining: this.drainingState,
+        }),
+        signal: AbortSignal.any([
+          requestAbort.signal,
+          AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        ]),
+      });
+      if (response.ok) return true;
+      this.log(
+        `[turn] worker registration failed (${response.status}): ${(await response.text()).slice(0, 300)}`,
+      );
+    } catch (error) {
+      if (this.stopped) return false;
+      this.log(
+        `[turn] worker registration failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    } finally {
+      if (this.requestAbort === requestAbort) this.requestAbort = undefined;
+    }
+    return false;
+  }
+}
+
+/** Apply the existing process signal to the pool lifecycle. */
+export function beginWorkerShutdown(
+  signal: string,
+  registration: WorkerRegistration | null,
+): Promise<void> {
+  return signal === "SIGTERM" && registration
+    ? registration.beginDraining()
+    : Promise.resolve();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,6 +527,9 @@ importers:
       '@google-cloud/storage':
         specifier: 7.21.0
         version: 7.21.0
+      '@houston/domain':
+        specifier: workspace:*
+        version: link:../domain
       '@houston/protocol':
         specifier: workspace:*
         version: link:../protocol


### PR DESCRIPTION
Phase 5 of the stateless architecture, engine half (pairs with cloud#256 — merge the two together; every path here is inert without the pool env, which no deployment sets). Rebased on current `main`; design: `~/Documents/phase5-pool-spec.md`; increment-2 decisions: `~/Documents/phase5-increment2-spec.md`.

**Increment 1 (inert without the pool env, which no deployment sets):** admission limiter (`HOUSTON_TURN_CONCURRENCY`, 503 `worker_full` before any work); strict envelope extensions (turnId, hostToken, actingAs, shadow, claim grant — all-or-nothing validation); shadow turns (hydrate + validate + timings frame, no provider call, no syncBack); per-claim `HttpObjectStore` (claim authority mutually exclusive with lease authority) and a per-turn turnlog batcher (claim headers, per-turn 404 disable); claim heartbeat client with fenced-abort checked before syncBack (syncBack runs for failed turns too — only a fenced claim skips it); the five process-global fixes (qwen dataDir, credential-health fingerprints from the turn root, bus keys scoped ws/agent/cid with eviction, host-side agentId sanitize, acting propagation); the spike's leak assertions promoted to a CI suite.

**Increment 2, step 1 — shadow-ready (an unclaimed turn hydrates, runs and syncs exactly as before):**
- **Layout.** The pooled turn hydrates into an isolated `store/` root and resolves what it holds: a standing agent (`workspaces/<W>/<A>` with pi's data under `.houston/runtime` — the engine pod's `/data` mirror) or the cloudrun tree (`data/` + `workspace/`); `runPiTurn` takes explicit workspace/data dirs. Ambiguous trees, and an EMPTY prefix on a claimed turn (a blank hydrate must never seed a second layout beside a real agent), fail with a typed `layout_unexpected` frame before any provider call; a claimed hydrate over the pool's 2 GiB cap fails as `hydrate_over_cap` (unclaimed turns keep hydrate's default).
- **Sync scope (spec item 3).** A claimed turn syncs back only `<data>/conversations/<cid>.json` and `<data>/sessions/<cid>/**` (`syncBack` gains an `include` predicate; the generation-conflict ladder is extracted unchanged into `sync-back-conflicts.ts`); every other change is counted, logged with prefix + conversation, and carried on the terminal frame as `poolWritesOutOfScope` — never fatal. `auth.json` stays outside the scope by construction; the leak harness covers the standing layout too. `enterpriseUrl` now survives the envelope.
- **Worker self-registration.** With `HOUSTON_POOL_REGISTER_URL` / `HOUSTON_POOL_WORKER_ID` / `HOUSTON_POOL_WORKER_TOKEN_DIR` / `HOUSTON_POOL_ENDPOINT` (all or none, else a loud boot error) the turn server heartbeats `{workerId, bootId, endpoint, capacity, activeClaims, draining}` every 15s with its per-worker token, registers before it listens, and on SIGTERM stops admitting (503 `worker_draining`), keeps the in-flight turn until it ends, and publishes `draining=true` before registration stops (no forced 3s exit for a registered worker; the pod's grace period is the deadline). The token file is also the inbound `X-Internal-Token` (`HOUSTON_TURN_TOKEN` still wins in dev).

Reviewed by two independent passes (Fable 5, gpt-5.6-sol); all findings addressed. Gates: runtime 134 / runtime-client 19 / host 169 test files green; Biome, boundaries, workspace typecheck clean.

**Increment 2, step 2 (claimed turns only; unclaimed and shadow turns untouched):**
- **Transcript rows.** A claimed turn publishes its own user + assistant rows to the gateway's transcript routes (host token + claim headers, the same wire the standing host sends — the builder now lives once in `@houston/runtime-client`): the user row on the `user` frame (so a gateway restart can rebuild the turn), the assistant row after the scoped object sync; a fence learned at any point (heartbeat, object 409, transcript 409) ends the turn as `claim_fenced`; rows that did not land fail the turn (status only on the wire); a first-PUT 404 = routes absent → `transcriptSkipped: route_absent` on the terminal frame; transient failures retry with a fresh timeout per attempt.
- **Lifetime = the claim.** A claimed turn ignores the client disconnect (the gateway may re-attach via turnlog) and aborts the moment a heartbeat is fenced (cancel/adoption).
- **Envelope additions:** `turnlogSeqStart` (the conversation's next turnlog seq, so a second/adopted turn never collides with the first's frames), `workspaceContext`/`userContext` (the hosted turn context, overlaid on the session exactly like the long-lived path).

Reviewed by two independent passes (Fable 5, gpt-5.6-sol); all findings addressed. Gates green.

