### PR TITLE
fix(skills): resolve plugin-marketplace skills in community preview (PRODUCT-1382)

### DIFF
--- a/packages/host/src/skills/github-lookup.test.ts
+++ b/packages/host/src/skills/github-lookup.test.ts
@@ -208,6 +208,62 @@ test("locateSkillMd with deepScan: false skips the RECURSIVE scan on a shallow m
   expect(recursiveCalls).toBe(0);
 });
 
+test("locateSkillMd resolves a plugin-marketplace skill via the manifest probe (PRODUCT-1382)", async () => {
+  // The Sentry HOUSTON-APP-4XZ shape: anthropics/knowledge-work-plugins keeps
+  // `daily-briefing` at sales/skills/daily-briefing/SKILL.md. The manifest
+  // probe must resolve it on the preview path (deepScan: false) WITHOUT any
+  // rate-limited api.github.com call. Object-shaped (external) plugin sources
+  // must be skipped, not crash the probe.
+  let apiCalls = 0;
+  const manifest = JSON.stringify({
+    plugins: [
+      { name: "productivity", source: "./productivity" },
+      { name: "external", source: { source: "github", repo: "o/r" } },
+      { name: "sales", source: "./sales" },
+    ],
+  });
+  const md = await locateSkillMd(
+    fakeFetch(
+      (url) => {
+        if (url.includes("api.github.com")) apiCalls++;
+        return null;
+      },
+      rawAt(".claude-plugin/marketplace.json", manifest),
+      rawAt("sales/skills/daily-briefing/SKILL.md", "briefing-body"),
+    ),
+    "owner/repo",
+    "daily-briefing",
+    { deepScan: false },
+  );
+  expect(md).toBe("briefing-body");
+  expect(apiCalls).toBe(0);
+});
+
+test("locateSkillMd falls through to the shallow scan when no marketplace plugin holds the skill", async () => {
+  const manifest = JSON.stringify({
+    plugins: [{ name: "sales", source: "./sales" }],
+  });
+  const md = await locateSkillMd(
+    fakeFetch(
+      rawAt(".claude-plugin/marketplace.json", manifest),
+      (url) =>
+        url.endsWith("git/trees/HEAD")
+          ? jsonRes({
+              tree: [{ path: "daily-briefing-kit", type: "tree", sha: "d1" }],
+            })
+          : null,
+      rawAt(
+        "daily-briefing-kit/SKILL.md",
+        "---\nname: daily-briefing\n---\n\n# Briefing",
+      ),
+    ),
+    "owner/repo",
+    "daily-briefing",
+    { deepScan: false },
+  );
+  expect(md).toBe("---\nname: daily-briefing\n---\n\n# Briefing");
+});
+
 test("locateSkillMd with deepScan: false still succeeds on a common-path hit", async () => {
   const md = await locateSkillMd(
     fakeFetch(rawAt("skills/writing/SKILL.md", "hit")),

--- a/packages/host/src/skills/github-lookup.ts
+++ b/packages/host/src/skills/github-lookup.ts
@@ -1,5 +1,6 @@
 import { fetchSkillMdAtPath } from "./github";
 import { extractFrontmatterName, skillIdFromPath } from "./github-parse";
+import { probePluginMarketplace } from "./plugin-marketplace";
 import { SkillRemoteError } from "./remote-error";
 
 const GH_HEADERS = { "User-Agent": "houston-skills/1.0" };
@@ -9,8 +10,12 @@ const SHALLOW_CANDIDATE_CAP = 6;
 export interface LocateSkillMdOptions {
   /**
    * Escalate to the recursive Git Trees scan when the cheaper tiers miss.
-   * Lookup runs in three tiers, cheapest first:
+   * Lookup runs in four tiers, cheapest first:
    *   1. Common path guesses — raw-CDN fetches, no `api.github.com` call.
+   *   1.5. Plugin-marketplace probe (ALWAYS run, raw-CDN only) — repos whose
+   *      `.claude-plugin/marketplace.json` manifest exists keep skills at
+   *      `<plugin>/skills/<skillId>/SKILL.md`; the manifest lists the plugin
+   *      roots to probe (plugin-marketplace.ts, PRODUCT-1382).
    *   2. Shallow tree scan (ALWAYS run) — at most two SMALL non-recursive
    *      `api.github.com` calls (the repo root, then the `skills/` subtree if
    *      present); fuzzy-matches directory names against `skillId` and confirms
@@ -32,9 +37,10 @@ export interface LocateSkillMdOptions {
  * Shared "find the SKILL.md for `skillId` in `source`" lookup, used by both the
  * install flow (install.ts) and the read-only preview flow (preview.ts) so the
  * two never drift. `source` is an already-normalized `owner/repo`. Runs the
- * three tiers documented on {@link LocateSkillMdOptions.deepScan} — cheap path
- * guesses, then a shallow tree scan, then (install only) the recursive scan —
- * and returns the raw SKILL.md text or throws `skill_not_in_repo`.
+ * tiers documented on {@link LocateSkillMdOptions.deepScan} — cheap path
+ * guesses, the plugin-marketplace probe, a shallow tree scan, then (install
+ * only) the recursive scan — and returns the raw SKILL.md text or throws
+ * `skill_not_in_repo`.
  */
 export async function locateSkillMd(
   fetchImpl: typeof fetch,
@@ -58,6 +64,15 @@ export async function locateSkillMd(
   for (const attempt of attempts) {
     if (attempt.status === "fulfilled") return attempt.value;
   }
+
+  // Tier 1.5 — plugin-marketplace probe, always; raw-CDN only. Runs BEFORE the
+  // shallow scan so marketplace repos never spend api.github.com quota.
+  const marketplaceMd = await probePluginMarketplace(
+    fetchImpl,
+    source,
+    skillId,
+  );
+  if (marketplaceMd !== null) return marketplaceMd;
 
   // Tier 2 — shallow scan, always (≤2 small non-recursive api.github.com calls).
   const shallow = await shallowFindSkillPath(fetchImpl, source, skillId);

--- a/packages/host/src/skills/plugin-marketplace.ts
+++ b/packages/host/src/skills/plugin-marketplace.ts
@@ -1,0 +1,73 @@
+import { fetchSkillMdAtPath } from "./github";
+
+const GH_HEADERS = { "User-Agent": "houston-skills/1.0" };
+
+/** Manifest that defines a Claude plugin-marketplace repo and lists its plugins. */
+const MARKETPLACE_MANIFEST_PATH = ".claude-plugin/marketplace.json";
+
+/** Cap on parallel plugin-root probes for one marketplace repo. */
+const PLUGIN_PROBE_CAP = 24;
+
+/**
+ * Plugin-marketplace tier of the skill lookup (PRODUCT-1382): repos like
+ * anthropics/knowledge-work-plugins keep every skill at
+ * `<plugin>/skills/<skillId>/SKILL.md` — one directory deeper than any path
+ * the guess tier tries, and invisible to the shallow scan (which only lists
+ * the repo root and a root `skills/` subtree). Their defining marker,
+ * `.claude-plugin/marketplace.json`, both identifies the layout AND lists each
+ * plugin's root, so one raw-CDN manifest fetch plus parallel raw-CDN probes of
+ * `<pluginRoot>/skills/<skillId>/SKILL.md` resolve the skill without spending
+ * any rate-limited api.github.com quota. A probed directory name IS `skillId`
+ * — the same trust the guess tier places in its paths — so no frontmatter
+ * confirmation is needed. Returns the raw SKILL.md, or null on any miss
+ * (non-marketplace repo, unparseable manifest, no plugin holds the skill).
+ */
+export async function probePluginMarketplace(
+  fetchImpl: typeof fetch,
+  source: string,
+  skillId: string,
+): Promise<string | null> {
+  const roots = await fetchPluginRoots(fetchImpl, source);
+  const probes = await Promise.allSettled(
+    roots
+      .slice(0, PLUGIN_PROBE_CAP)
+      .map((root) =>
+        fetchSkillMdAtPath(
+          fetchImpl,
+          source,
+          `${root}/skills/${skillId}/SKILL.md`,
+        ),
+      ),
+  );
+  // Manifest order is the tie-break, mirroring the guess tier's priority order.
+  for (const probe of probes) {
+    if (probe.status === "fulfilled") return probe.value;
+  }
+  return null;
+}
+
+/** Plugin roots from the manifest (`./sales` → `sales`), deduped; [] on any miss. */
+async function fetchPluginRoots(
+  fetchImpl: typeof fetch,
+  source: string,
+): Promise<string[]> {
+  const res = await fetchImpl(
+    `https://raw.githubusercontent.com/${source}/HEAD/${MARKETPLACE_MANIFEST_PATH}`,
+    { headers: GH_HEADERS },
+  ).catch(() => null);
+  if (!res?.ok) return [];
+  const manifest = (await res.json().catch(() => null)) as {
+    plugins?: Array<{ source?: unknown }>;
+  } | null;
+  if (!manifest || !Array.isArray(manifest.plugins)) return [];
+
+  const roots = new Set<string>();
+  for (const plugin of manifest.plugins) {
+    // External plugins declare object sources (other repos); only in-repo
+    // relative-path sources can hold this repo's skills.
+    if (typeof plugin?.source !== "string") continue;
+    const root = plugin.source.replace(/^\.\//, "").replace(/\/+$/, "");
+    if (root && !root.startsWith(".") && !root.includes("..")) roots.add(root);
+  }
+  return [...roots];
+}


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1382 (Sentry HOUSTON-APP-4XZ, 174 users / 330 events): `preview_community_skill: Could not find 'daily-briefing' in anthropics/knowledge-work-plugins (engine error 404)`.

**Root cause.** skills.sh hands the marketplace only `source` + `skillId`. Plugin-marketplace repos (e.g. `anthropics/knowledge-work-plugins`) keep every skill at `<plugin>/skills/<skillId>/SKILL.md` — `daily-briefing` lives at `sales/skills/daily-briefing/SKILL.md`. That is one directory deeper than every tier-1 path guess, invisible to the tier-2 shallow scan (which only lists the repo root and a root `skills/` subtree), and the preview flow deliberately skips the tier-3 recursive scan (`deepScan: false`). So every marketplace card click on a skill from such a repo threw `skill_not_in_repo` → engine 404 → Sentry — and these are among the most-installed community skills.

**Fix.** New lookup tier 1.5 in the shared `locateSkillMd` (`packages/host/src/skills/plugin-marketplace.ts`): the layout's defining marker `.claude-plugin/marketplace.json` also lists each plugin's root, and it is served by raw.githubusercontent.com (CDN, effectively not rate-limited). One raw-CDN manifest fetch plus parallel raw-CDN probes of `<pluginRoot>/skills/<skillId>/SKILL.md` resolve the skill with **zero** `api.github.com` quota spent. Object-shaped (external-repo) plugin sources are skipped; probes are capped at 24; manifest order is the tie-break. Non-marketplace repos cost one extra 404'd CDN fetch and fall through to the existing tiers unchanged. Install benefits too: marketplace skills no longer need the expensive recursive scan.

## Verification

**Before (reproduce):** open the Skills marketplace, search "daily-briefing", click the `anthropics/knowledge-work-plugins` card → preview modal fails, Sentry logs `preview_community_skill ... engine error 404`. Equivalent direct check on `main`:
`GET /v1/skills/community/preview?source=anthropics/knowledge-work-plugins&skillId=daily-briefing` → 404 `skill_not_in_repo`.

**After:** same click/request returns the real preview (title, description, instructions). Verified live against GitHub:
`locateSkillMd(fetch, 'anthropics/knowledge-work-plugins', 'daily-briefing', { deepScan: false })` resolves the SKILL.md with frontmatter `name: daily-briefing`, no `api.github.com` call.

- `pnpm --filter @houston/host test` — 1507 passed (includes 2 new tests: the exact 4XZ shape with zero API calls, and manifest-miss fall-through to the shallow scan)
- `pnpm typecheck`, `pnpm check` — clean