### PR TITLE
fix: keep device-offline provider sign-out failures out of Sentry (PRODUCT-1383)

### DIFF
--- a/app/src/hooks/provider-connections/use-provider-connect-actions.ts
+++ b/app/src/hooks/provider-connections/use-provider-connect-actions.ts
@@ -1,5 +1,6 @@
 import { type Dispatch, type SetStateAction, useCallback } from "react";
 import { genericErrorDescription } from "../../lib/error-report";
+import { isNetworkTransportError } from "../../lib/network-transport-error";
 import type { ProviderInfo } from "../../lib/providers";
 import { tauriProvider } from "../../lib/tauri";
 import type {
@@ -69,11 +70,17 @@ export function useProviderConnectActions({
           `[use-provider-connections] launchLogin(${provider.id}) failed:`,
           msg,
         );
-        addToast({
-          title: t("toast.signInFailed", { provider: provider.name }),
-          description: genericErrorDescription("provider_sign_in", err),
-          variant: "error",
-        });
+        // A device-offline transport drop was already surfaced by the
+        // engine-call layer as the one deduped connectivity toast (HOU-1085);
+        // the authored red toast on top would double-surface an environment
+        // state (HOUSTON-APP-4PQ, PRODUCT-1383).
+        if (!isNetworkTransportError(err)) {
+          addToast({
+            title: t("toast.signInFailed", { provider: provider.name }),
+            description: genericErrorDescription("provider_sign_in", err),
+            variant: "error",
+          });
+        }
         setPending(null);
       }
     },
@@ -120,11 +127,14 @@ export function useProviderConnectActions({
           `[use-provider-connections] cancelLogin(${provider.id}) failed:`,
           msg,
         );
-        addToast({
-          title: t("toast.cancelFailed", { provider: provider.name }),
-          description: genericErrorDescription("provider_cancel_login", err),
-          variant: "error",
-        });
+        // Connectivity drop: the engine-call layer's toast already covered it.
+        if (!isNetworkTransportError(err)) {
+          addToast({
+            title: t("toast.cancelFailed", { provider: provider.name }),
+            description: genericErrorDescription("provider_cancel_login", err),
+            variant: "error",
+          });
+        }
       } finally {
         setPending((current) => (current?.id === provider.id ? null : current));
         setLoginDialog((current) =>
@@ -150,11 +160,14 @@ export function useProviderConnectActions({
           `[use-provider-connections] launchLogout(${provider.id}) failed:`,
           msg,
         );
-        addToast({
-          title: t("toast.signOutFailed", { provider: provider.name }),
-          description: genericErrorDescription("provider_sign_out", err),
-          variant: "error",
-        });
+        // Connectivity drop: the engine-call layer's toast already covered it.
+        if (!isNetworkTransportError(err)) {
+          addToast({
+            title: t("toast.signOutFailed", { provider: provider.name }),
+            description: genericErrorDescription("provider_sign_out", err),
+            variant: "error",
+          });
+        }
       } finally {
         setPending(null);
       }

--- a/app/src/lib/error-report.ts
+++ b/app/src/lib/error-report.ts
@@ -1,5 +1,6 @@
 import { classifyAnalyticsError } from "./analytics";
 import i18n from "./i18n";
+import { isNetworkTransportError } from "./network-transport-error";
 import { captureException as sentryCapture } from "./sentry";
 import { createSentryReportError } from "./sentry-report-error";
 import {
@@ -14,12 +15,21 @@ import {
  * Capture is decoupled from the toast so `{ toast: false }` callers aren't
  * silently invisible to crash reporting. Returns immediately; flush failures
  * are logged, never thrown.
+ *
+ * The one class that is NOT captured: transport-level network failures
+ * (device offline / host unreachable — HOU-1085). Those are an expected
+ * environment state, not a Houston bug; the engine-call layer classifies the
+ * same failure as connectivity and declines to capture, and this layer
+ * re-capturing it is what kept the `<command>: Failed to fetch (gateway…)`
+ * Sentry family alive after HOU-1085 (HOUSTON-APP-4PQ, PRODUCT-1383). The raw
+ * diagnostic still reaches the frontend log via the caller's `console.error`.
  */
 export function reportError(
   command: string,
   message: string,
   originalError?: unknown,
 ): void {
+  if (isNetworkTransportError(originalError)) return;
   markReportedToSentry(originalError);
   const error = createSentryReportError(command, message, originalError);
   void sentryCapture(error, {

--- a/app/tests/error-report-connectivity.test.ts
+++ b/app/tests/error-report-connectivity.test.ts
@@ -1,0 +1,65 @@
+import { ok } from "node:assert";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+// PRODUCT-1383 (HOUSTON-APP-4PQ): a device-offline drop during a provider
+// sign-out was re-captured to Sentry by the caller-authored-toast layer
+// (`reportError`) after the engine-call layer had already classified the same
+// failure as connectivity (HOU-1085) and deliberately declined the capture —
+// 859 events / 171 users of pure "user was offline" noise, plus a red
+// "sign out failed" toast stacked on the connectivity toast.
+//
+// Asserted against the source rather than by calling the functions: both
+// modules pull i18n / analytics / the tauri barrel, none of which load under
+// this suite's `--experimental-strip-types` runner (same constraint and same
+// pattern as error-toast-not-shown.test.ts).
+
+const read = (rel: string): string =>
+  readFileSync(join(import.meta.dirname, rel), "utf8");
+
+describe("reportError declines connectivity failures (HOU-1085 policy)", () => {
+  const source = read("../src/lib/error-report.ts");
+
+  it("gates the Sentry capture on isNetworkTransportError", () => {
+    ok(
+      source.includes('from "./network-transport-error"'),
+      "error-report.ts must import the connectivity classifier",
+    );
+    const body = source.slice(source.indexOf("export function reportError("));
+    const guard = body.indexOf(
+      "if (isNetworkTransportError(originalError)) return;",
+    );
+    const capture = body.indexOf("sentryCapture");
+    ok(guard !== -1, "reportError must decline network transport errors");
+    ok(
+      capture === -1 || guard < capture,
+      "the connectivity guard must run before the Sentry capture",
+    );
+  });
+});
+
+describe("provider connect actions do not double-surface connectivity", () => {
+  // The engine-call layer (`surfaceError` in lib/tauri.ts) shows the ONE
+  // deduped connectivity toast for these failures; the hook's authored red
+  // toast must stay quiet for them in every action (connect / cancel /
+  // sign-out — all three share the offline failure mode).
+  const source = read(
+    "../src/hooks/provider-connections/use-provider-connect-actions.ts",
+  );
+
+  it("gates every authored failure toast on isNetworkTransportError", () => {
+    ok(
+      source.includes('from "../../lib/network-transport-error"'),
+      "the hook must import the connectivity classifier",
+    );
+    const toasts = source.split("addToast({").length - 1;
+    const guards =
+      source.split("if (!isNetworkTransportError(err))").length - 1;
+    ok(toasts > 0, "expected authored failure toasts in the hook");
+    ok(
+      guards === toasts,
+      `every addToast must be connectivity-gated (${guards} guards for ${toasts} toasts)`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the Sentry issue HOUSTON-APP-4PQ (`provider_sign_out: Failed to fetch (gateway.gethouston.ai)` — 859 events / 171 users), the last live member of the "Failed to fetch" family that HOU-1085 was supposed to retire.

**Root cause.** When the device drops offline mid-session (the event's breadcrumbs show every gateway request failing in the same millisecond), a provider sign-out fails with a transport-level `TypeError`. The engine-call layer (`surfaceError` in `app/src/lib/tauri.ts`) correctly classifies it as connectivity per HOU-1085: one deduped info toast, no Sentry capture. But the hook's catch then renders its own red "Sign out failed" toast via `genericErrorDescription("provider_sign_out", err)`, and that layer (`app/src/lib/error-report.ts`) never learned the connectivity classification — `wasReportedToSentry` is false precisely because the capture was deliberately declined, so it re-captures the error as a bug. Result: a duplicate red toast on top of the connectivity toast, and pure user-was-offline noise in Sentry.

**Fix.**
- `reportError` now declines network transport errors (`isNetworkTransportError`, the HOU-1085 classifier). Covers every caller-authored-toast path that routes through `reportError` / `logAndReportError` / `genericErrorDescription`. The raw diagnostic still reaches the frontend log via the callers' `console.error`.
- The provider connect / cancel / sign-out actions (`use-provider-connect-actions.ts`) skip their authored red toast when the failure is a connectivity drop — the engine-call layer's connectivity toast already surfaced it, and the card state stays honest (`patchAuthState` only flips on success).
- New structural test `app/tests/error-report-connectivity.test.ts` pins both guards (source-level, same pattern as `error-toast-not-shown.test.ts` — both modules pull imports the strip-types runner can't load).

## Before the fix (repro)

1. Open the desktop app signed into the managed cloud, go to Settings → AI providers with a connected provider.
2. Disconnect the machine from the network (or sleep-wake into a dead connection).
3. Click sign-out on the provider and confirm.
4. Observe: the info connectivity toast AND a red "Sign out failed" toast, and a new `provider_sign_out: Failed to fetch (gateway.gethouston.ai)` event in Sentry (HOUSTON-APP-4PQ).

## After the fix (verify)

1. Same steps 1–3.
2. Observe: only the single connectivity toast; the provider card stays connected (honest — the sign-out did not happen). The frontend log still records `[engine:launch_provider_logout]` and `[use-provider-connections] launchLogout(...) failed`.
3. No new HOUSTON-APP-4PQ events from releases carrying this change; a real (non-transport) sign-out failure still shows the red toast and still reaches Sentry.
4. `cd app && pnpm test` (3646 pass), `pnpm tsgo --noEmit`, `pnpm check`, `pnpm --filter houston-web typecheck` all green.