### PR TITLE
fix(app): stuck update checks surface themselves instead of stranding silently (PRODUCT-1386)

### DIFF
--- a/app/src/hooks/use-update-checker.ts
+++ b/app/src/hooks/use-update-checker.ts
@@ -1,10 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { analytics } from "../lib/analytics";
+import { currentAppVersion } from "../lib/app-version";
+import { showUpdateCheckStuckToast } from "../lib/error-toast";
 import {
   type ForcedUpdateMode,
   forcedUpdateMode,
+  nextCheckFailureStreak,
   shouldRecheckOnFocus,
   UPDATE_CHECK_INTERVAL_MS,
+  updateCheckJustStuck,
 } from "../lib/update-force";
 import { useUpdateMachine } from "./use-update-machine";
 
@@ -28,10 +32,26 @@ export function useUpdateChecker() {
   const { status, runCheck, installAndRelaunch, relaunchInstalledApp } =
     useUpdateMachine();
   const lastCheckAtRef = useRef<number | null>(null);
+  // Consecutive check FAILURES. A client that can never reach the release
+  // feed would strand on an old build silently (the check is fail-open) —
+  // when the streak first hits the stuck threshold, it surfaces itself:
+  // nudge + telemetry, once per streak (PRODUCT-1386).
+  const failureStreakRef = useRef(0);
 
-  const check = useCallback(() => {
+  const check = useCallback(async () => {
     lastCheckAtRef.current = Date.now();
-    return runCheck();
+    const { outcome, message } = await runCheck();
+    failureStreakRef.current = nextCheckFailureStreak(
+      failureStreakRef.current,
+      outcome,
+    );
+    if (updateCheckJustStuck(failureStreakRef.current)) {
+      showUpdateCheckStuckToast(
+        message ?? "unknown check failure",
+        failureStreakRef.current,
+        currentAppVersion(),
+      );
+    }
   }, [runCheck]);
 
   // The forced presentation, latched on the first transition into

--- a/app/src/hooks/use-update-machine.ts
+++ b/app/src/hooks/use-update-machine.ts
@@ -5,7 +5,7 @@ import {
   osCurrentAppBundlePath,
   osRelaunchAppFromPath,
 } from "../lib/os-bridge";
-import type { UpdateOrigin } from "../lib/update-force";
+import type { UpdateCheckOutcome, UpdateOrigin } from "../lib/update-force";
 
 export interface UpdateInfo {
   currentVersion: string;
@@ -46,14 +46,19 @@ export function useUpdateMachine() {
     statusRef.current = status;
   }, [status]);
 
-  const runCheck = useCallback(async () => {
+  const runCheck = useCallback(async (): Promise<{
+    outcome: UpdateCheckOutcome;
+    message?: string;
+  }> => {
     // The first check of a run is the launch check: a find there means the
     // user just opened the app and hasn't started working. Everything after
-    // (interval, focus, 426 kick) is mid-session. The origin rides on the
-    // available state so the policy layer can pick the forced presentation.
+    // (interval, focus) is mid-session. The origin rides on the available
+    // state so the policy layer can pick the forced presentation.
     const origin: UpdateOrigin = firstCheckRef.current ? "launch" : "poll";
     firstCheckRef.current = false;
-    if (installingRef.current || statusRef.current.state === "ready") return;
+    if (installingRef.current || statusRef.current.state === "ready") {
+      return { outcome: "skipped" };
+    }
 
     try {
       const update = await check();
@@ -61,7 +66,7 @@ export function useUpdateMachine() {
         updateRef.current = null;
         infoRef.current = null;
         setStatus({ state: "idle" });
-        return;
+        return { outcome: "none" };
       }
 
       const info: UpdateInfo = {
@@ -81,8 +86,17 @@ export function useUpdateMachine() {
         });
       }
       setStatus({ state: "available", info, origin });
+      return { outcome: "found" };
     } catch (error) {
+      // Fail-open by design: the staging QA flavor's updater endpoint 404s
+      // forever (point-updater-at-staging-noop.sh) and a launch must never
+      // block on the release feed. The checker counts these to surface a
+      // client whose checks NEVER succeed (PRODUCT-1386).
       console.warn("[updater] check failed", error);
+      return {
+        outcome: "failed",
+        message: error instanceof Error ? error.message : String(error),
+      };
     }
   }, []);
 

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -201,6 +201,11 @@ export type AnalyticsEventName =
   | "update_offered"
   | "update_forced"
   | "update_accepted"
+  // The check itself keeps failing: after UPDATE_CHECK_STUCK_THRESHOLD
+  // consecutive failures the client counts as stuck — it may never see an
+  // update again (release feed unreachable), so it self-reports once per
+  // streak (PRODUCT-1386). `from_version` is the build it is stuck on.
+  | "update_check_failed"
   // Reliability
   | "session_completed"
   | "session_failed"
@@ -235,6 +240,8 @@ type AnalyticsProperty =
   | "file_kind"
   | "from_version"
   | "to_version"
+  // How many update checks failed in a row (update_check_failed)
+  | "consecutive_failures"
   // Onboarding funnel
   | "locale"
   | "detected_locale"
@@ -309,6 +316,7 @@ const ALLOWED_PROPS = new Set<AnalyticsProperty>([
   "file_kind",
   "from_version",
   "to_version",
+  "consecutive_failures",
   "locale",
   "detected_locale",
   "step",

--- a/app/src/lib/error-toast.ts
+++ b/app/src/lib/error-toast.ts
@@ -66,6 +66,52 @@ export function showConnectivityErrorToast(
 }
 
 /**
+ * Surface a client whose update checks keep failing (PRODUCT-1386). The
+ * forced updater is fail-open — a check failure only console.warns — so a
+ * client that can NEVER reach the release feed (a proxy or region block
+ * between it and GitHub) would strand on an old build invisibly, with no
+ * server-side floor to catch it since the 426 gate was retired
+ * (PRODUCT-1144). The checker calls this once per failure streak, after
+ * `UPDATE_CHECK_STUCK_THRESHOLD` consecutive failures:
+ *  - one informational toast pointing at the manual download, so the user
+ *    can act;
+ *  - a dedicated `update_check_failed` analytics event (its own name, not
+ *    `app_error_shown`, so a fleet-staleness dashboard can count stuck
+ *    clients directly);
+ *  - a Sentry capture, so stranded clients get an issue with a user count —
+ *    this also surfaces any leaked staging QA build, whose no-op updater
+ *    endpoint 404s every check by design.
+ */
+export function showUpdateCheckStuckToast(
+  message: string,
+  consecutiveFailures: number,
+  currentVersion: string,
+): void {
+  const command = "update_check";
+  console.error(
+    `[toast:${command}] ${consecutiveFailures} consecutive check failures: ${message}`,
+  );
+  useUIStore.getState().addToast({
+    title: i18n.t("shell:errorToast.updateStuckTitle"),
+    description: i18n.t("shell:errorToast.updateStuckDescription"),
+    variant: "info",
+  });
+  analytics.track("update_check_failed", {
+    source: command,
+    consecutive_failures: consecutiveFailures,
+    from_version: currentVersion,
+    error_kind: classifyAnalyticsError(message),
+  });
+  if (sentrySuppressedInDev) return;
+  void sentryCapture(createSentryReportError(command, message), {
+    source: command,
+    error_kind: classifyAnalyticsError(message),
+  }).catch((flushErr: unknown) => {
+    console.error("[sentry] failed to flush captured error", flushErr);
+  });
+}
+
+/**
  * Surface a gateway "engine unavailable" 503 (HOU-1114) as ONE informational
  * "your agent is waking up" toast. The agent's engine pod is provisioning (a
  * just-installed store agent) or cold-starting; every per-agent call fails the

--- a/app/src/lib/update-force.ts
+++ b/app/src/lib/update-force.ts
@@ -12,11 +12,15 @@
  *   the timer runs out. The copy reassures that agents keep working and
  *   chats/settings survive the restart.
  *
- * Detection stays pull-based: the Tauri updater polls `latest.json` on the
- * release feed. There is no push channel to a desktop build (the hosted
- * gateway's 426 version floor covers the must-update-NOW case per request),
- * so freshness comes from cadence: a launch check, a short interval, and a
- * re-check when the window regains focus.
+ * Detection stays pull-based: the Tauri updater polls the release feed's
+ * manifest. There is no push channel to a desktop build, and no server-side
+ * backstop either (the hosted gateway's 426 min-version floor was retired,
+ * PRODUCT-1144), so freshness comes entirely from cadence: a launch check, a
+ * short interval, and a re-check when the window regains focus. That makes a
+ * client whose checks keep FAILING (a proxy or region block between it and
+ * the release feed) invisible and permanently stale — so consecutive check
+ * failures are counted here, and a stuck client surfaces itself: telemetry
+ * plus one visible "get it manually" nudge per run (PRODUCT-1386).
  */
 
 export type UpdateOrigin = "launch" | "poll";
@@ -50,4 +54,32 @@ export function shouldRecheckOnFocus(
 /** One countdown tick. Floors at zero so a late timer can never go negative. */
 export function tickCountdown(seconds: number): number {
   return Math.max(0, seconds - 1);
+}
+
+/** What one update check produced, as the failure counter sees it. `skipped`
+ *  covers checks that never ran (an install already in flight) — no signal
+ *  in either direction. */
+export type UpdateCheckOutcome = "found" | "none" | "failed" | "skipped";
+
+/** Consecutive failures before a client counts as stuck: the launch check
+ *  plus two interval polls, ~10 minutes into a session. One offline blip
+ *  never trips it; a proxy that blocks the release feed always does. */
+export const UPDATE_CHECK_STUCK_THRESHOLD = 3;
+
+/** The failure-streak transition: any completed check resets it, a failure
+ *  extends it, a skipped check leaves it alone. */
+export function nextCheckFailureStreak(
+  streak: number,
+  outcome: UpdateCheckOutcome,
+): number {
+  if (outcome === "failed") return streak + 1;
+  if (outcome === "skipped") return streak;
+  return 0;
+}
+
+/** True the moment a failure streak first reaches the stuck threshold —
+ *  exactly once per streak, so a stuck client surfaces once per run instead
+ *  of once per poll. */
+export function updateCheckJustStuck(streak: number): boolean {
+  return streak === UPDATE_CHECK_STUCK_THRESHOLD;
 }

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -396,7 +396,9 @@
     "offlineTitle": "Houston, connection lost",
     "offlineDescription": "We can't reach Houston right now. Check your internet connection and try again.",
     "engineWakingTitle": "Houston, your agent is waking up",
-    "engineWakingDescription": "It will be ready in a moment. Try again shortly."
+    "engineWakingDescription": "It will be ready in a moment. Try again shortly.",
+    "updateStuckTitle": "Houston, updates can't reach you",
+    "updateStuckDescription": "We haven't been able to check for updates. Your network may be blocking them. You can always get the latest version at gethouston.ai."
   },
   "agentDelete": {
     "title": "Delete agent?",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -396,7 +396,9 @@
     "offlineTitle": "Houston, sin conexión",
     "offlineDescription": "No podemos conectarnos a Houston en este momento. Revisa tu conexión a internet e inténtalo de nuevo.",
     "engineWakingTitle": "Houston, tu agente se está despertando",
-    "engineWakingDescription": "Estará listo en un momento. Inténtalo de nuevo en breve."
+    "engineWakingDescription": "Estará listo en un momento. Inténtalo de nuevo en breve.",
+    "updateStuckTitle": "Houston, las actualizaciones no te llegan",
+    "updateStuckDescription": "No hemos podido buscar actualizaciones. Puede que tu red las esté bloqueando. Siempre puedes descargar la última versión en gethouston.ai."
   },
   "agentDelete": {
     "title": "¿Eliminar el agente?",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -396,7 +396,9 @@
     "offlineTitle": "Houston, sem conexão",
     "offlineDescription": "Não conseguimos conectar ao Houston agora. Verifique sua conexão com a internet e tente novamente.",
     "engineWakingTitle": "Houston, seu agente está acordando",
-    "engineWakingDescription": "Ele estará pronto em um momento. Tente novamente em breve."
+    "engineWakingDescription": "Ele estará pronto em um momento. Tente novamente em breve.",
+    "updateStuckTitle": "Houston, as atualizações não estão chegando",
+    "updateStuckDescription": "Não conseguimos verificar atualizações. Sua rede pode estar bloqueando. Você sempre pode baixar a versão mais recente em gethouston.ai."
   },
   "agentDelete": {
     "title": "Excluir o agente?",

--- a/app/tests/update-force.test.ts
+++ b/app/tests/update-force.test.ts
@@ -4,9 +4,12 @@ import {
   FOCUS_RECHECK_MIN_GAP_MS,
   FORCED_UPDATE_COUNTDOWN_SECONDS,
   forcedUpdateMode,
+  nextCheckFailureStreak,
   shouldRecheckOnFocus,
   tickCountdown,
   UPDATE_CHECK_INTERVAL_MS,
+  UPDATE_CHECK_STUCK_THRESHOLD,
+  updateCheckJustStuck,
 } from "../src/lib/update-force.ts";
 
 // The forced presentation follows the find, not the release: a launch-check
@@ -63,5 +66,45 @@ describe("cadence sanity", () => {
 
   it("polls more often than it throttles focus rechecks", () => {
     ok(UPDATE_CHECK_INTERVAL_MS > FOCUS_RECHECK_MIN_GAP_MS);
+  });
+});
+
+// A client that can never reach the release feed must surface itself instead
+// of stranding silently (PRODUCT-1386): the streak counts consecutive
+// failures, any completed check resets it, and the stuck signal fires exactly
+// on the crossing so one streak means one nudge.
+describe("nextCheckFailureStreak", () => {
+  it("extends on a failure", () => {
+    strictEqual(nextCheckFailureStreak(2, "failed"), 3);
+  });
+
+  it("resets when a check finds an update", () => {
+    strictEqual(nextCheckFailureStreak(5, "found"), 0);
+  });
+
+  it("resets when a check completes with nothing to install", () => {
+    strictEqual(nextCheckFailureStreak(5, "none"), 0);
+  });
+
+  it("ignores a check that never ran", () => {
+    strictEqual(nextCheckFailureStreak(2, "skipped"), 2);
+  });
+});
+
+describe("updateCheckJustStuck", () => {
+  it("stays quiet below the threshold", () => {
+    strictEqual(updateCheckJustStuck(UPDATE_CHECK_STUCK_THRESHOLD - 1), false);
+  });
+
+  it("fires exactly on the crossing", () => {
+    strictEqual(updateCheckJustStuck(UPDATE_CHECK_STUCK_THRESHOLD), true);
+  });
+
+  it("does not re-fire as the streak keeps growing", () => {
+    strictEqual(updateCheckJustStuck(UPDATE_CHECK_STUCK_THRESHOLD + 1), false);
+  });
+
+  it("one offline blip cannot trip it", () => {
+    ok(UPDATE_CHECK_STUCK_THRESHOLD >= 2);
   });
 });


### PR DESCRIPTION
## Root cause

The desktop forced updater (0.5.21, #1018) is fail-open: a check failure only `console.warn`s. That's deliberate (the staging QA flavor's updater endpoint 404s forever, and launch must never block on the release feed) — but since the gateway 426 min-version floor was retired (PRODUCT-1144, cloud #234) there is no server-side backstop either. A client that can never reach the release feed (corporate proxy, region block, DNS poisoning) strands on an old build **invisibly**: no toast, no telemetry, nothing. Sentry HOUSTON-APP-4W3 showed 0.5.43–0.5.47 clients still active days after newer releases shipped, with no way to tell boot-window artifacts from genuinely stuck installs.

## Fix

- `runCheck` (use-update-machine) now reports its outcome (`found | none | failed | skipped`) instead of swallowing failures.
- The checker counts consecutive failures with pure, tested transitions (`nextCheckFailureStreak` / `updateCheckJustStuck` in `update-force.ts`). A completed check resets the streak; a skipped check (install in flight) leaves it alone.
- On a streak first reaching `UPDATE_CHECK_STUCK_THRESHOLD` (3 = launch check + two polls, ~10 min; one offline blip can't trip it) the client surfaces itself **once per streak** via `showUpdateCheckStuckToast`:
  - info toast (en/es/pt) pointing at the manual download on gethouston.ai;
  - dedicated `update_check_failed` analytics event (`consecutive_failures`, `from_version` — both whitelisted) so a fleet-staleness dashboard can count stuck clients directly;
  - Sentry capture, giving stranded clients an issue with a user count. This also surfaces any leaked staging QA DMG — its noop endpoint fails every check by design.
- Rewrites the stale `update-force.ts` docstring that still claimed the 426 floor covers the must-update-NOW case.

Web is unaffected: the updater shim resolves `null` (`none`), which resets the streak.

## Before / after

**Before:** point the updater endpoint at an unreachable host (or block github.com in the firewall), launch a packaged build → every check logs `[updater] check failed` to the console and nothing else happens, forever.

**After:** same setup → after the 3rd consecutive failure (~10 min), one info toast "Houston, updates can't reach you", one `update_check_failed` PostHog event, one Sentry event tagged `source: update_check`. Recovery (unblock the feed) resets the streak; a later re-block surfaces a new episode.

## Tests

- `app/tests/update-force.test.ts`: streak transitions (extend / reset on found / reset on none / hold on skipped) + stuck-crossing fires exactly once + threshold sanity. `cd app && pnpm test`: 3654 pass.
- `cd app && pnpm tsgo --noEmit`, `pnpm check-locales` (24 namespaces in sync), `pnpm --filter houston-web typecheck` (shim parity OK), `pnpm check` — all green.