### PR TITLE
fix(release): wire the Linux AppImage into the auto-updater (PRODUCT-1387)

### DIFF
--- a/.github/workflows/cloud-updater-manifest.yml
+++ b/.github/workflows/cloud-updater-manifest.yml
@@ -9,7 +9,7 @@
 # (see scripts/ci/point-updater-at-cloud-manifest.sh), and this workflow keeps
 # that pointer current: whenever a `cloud-v*` release is PUBLISHED (draft →
 # public, manual after QA — same flow as the local channel), it copies the
-# release's finalized `latest-cloud.json` (macOS + Windows entries, merged by
+# release's finalized `latest-cloud.json` (macOS + Windows + Linux entries, merged by
 # the release workflow's finalize job) onto the rolling `cloud-latest`
 # release.
 #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1629,17 +1629,19 @@ jobs:
   # untouched. (.deb intentionally not built — AppImage is the single Linux
   # artifact; a .deb would need its own apt/repo + GPG story to be worth it.)
   #
-  # UNSIGNED + NOT wired into the auto-updater (latest.json is macOS + Windows
-  # only; `finalize` doesn't add a Linux entry). Download-only, for testing.
+  # Wired into the auto-updater (PRODUCT-1387): the job updater-signs the FINAL
+  # (post-sidecar-repair) AppImage and uploads the `.sig`; `finalize` merges a
+  # `linux-x86_64` entry into the manifest next to the mac + Windows ones.
+  # Installs from before this wiring point at the legacy feed and must
+  # redownload once — from then on they ride the same forced-update train.
   build-linux:
     needs: prep
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      # See build-macos: cloud channel bakes the managed gateway URL (a secret).
-      # Linux is download-only / not wired into the auto-updater, so it needs no
-      # endpoint rewrite — only the baked URL so the app reaches the gateway.
+      # See build-macos: cloud channel bakes the managed gateway URL (a secret)
+      # and repoints the updater endpoint at the cloud manifest below.
       IS_CLOUD: ${{ startsWith(github.ref_name, 'cloud-') }}
       VITE_HOSTED_ENGINE_URL: ${{ startsWith(github.ref_name, 'cloud-') && secrets.HOSTED_ENGINE_URL || '' }}
       VITE_HOSTED_ENGINE_AUTH: ${{ startsWith(github.ref_name, 'cloud-') && 'oauth' || '' }}
@@ -1718,14 +1720,20 @@ jobs:
           chmod +x "$SHIM_DIR/ldd"
           echo "$SHIM_DIR" >> "$GITHUB_PATH"
 
-      # tauri.conf.json has `createUpdaterArtifacts: true` + an updater pubkey, so
-      # tauri tries to emit a minisign `.sig` for the AppImage and FAILS if
-      # TAURI_SIGNING_PRIVATE_KEY is absent ("public key found, but no private
-      # key"). Linux is download-only / not wired into the auto-updater, so we
-      # don't ship the signing key here — instead flip updater-artifact creation
-      # off for this runner's checkout (never committed). mac/win keep it on:
-      # they pass the key and feed latest.json.
-      - name: Disable updater artifacts (Linux is download-only)
+      # CLOUD channel only: repoint the updater at `latest-cloud.json` before
+      # the build bakes tauri.conf.json in (see build-macos for the why).
+      - name: Point updater at cloud manifest (cloud channel)
+        if: ${{ env.IS_CLOUD == 'true' }}
+        run: bash scripts/ci/point-updater-at-cloud-manifest.sh
+
+      # Keep tauri's OWN updater-artifact emission off — not because Linux is
+      # unsigned (it isn't, anymore), but because the signature tauri would
+      # emit here covers the WRONG bytes: the "Restore Bun host sidecar" step
+      # below rebuilds the AppImage after packaging, so the updater `.sig` is
+      # minted manually AFTER the repair (see "Updater-sign the repaired
+      # AppImage"). Without this flip `tauri build` also dies when
+      # TAURI_SIGNING_PRIVATE_KEY is absent, which keeps forks building.
+      - name: Disable in-build updater artifacts (signed post-repair instead)
         run: bash scripts/ci/configure-ts-engine-unsigned.sh
 
       # frpc is a Tauri externalBin (the local-model bridge tunnel client). The
@@ -1800,6 +1808,25 @@ jobs:
           echo "Artifact:"
           echo "  AppImage: $APPIMAGE ($(du -sh "$APPIMAGE" | cut -f1))"
 
+      # Mint the updater signature over the FINAL bytes — after the sidecar
+      # repair rebuilt the AppImage (a sig from `tauri build` would cover the
+      # pre-repair file and every client would reject the download). Same
+      # minisign key the mac/win artifacts use, so the baked updater pubkey
+      # verifies all three platforms. Fail-closed: no sig, no release — a
+      # manifest entry pointing at unverifiable bytes would strand every
+      # Linux client on a failed-update loop.
+      - name: Updater-sign the repaired AppImage
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          APPIMAGE="${{ steps.artifacts-linux.outputs.appimage }}"
+          (cd app && pnpm tauri signer sign "$GITHUB_WORKSPACE/$APPIMAGE")
+          test -s "$APPIMAGE.sig" \
+            || { echo "::error::updater signature missing for $APPIMAGE"; exit 1; }
+          echo "  sig: $APPIMAGE.sig"
+
       - name: Upload source maps + Rust debug symbols to Sentry (linux x64)
         if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
         env:
@@ -1844,6 +1871,7 @@ jobs:
         run: |
           gh release upload "$GITHUB_REF_NAME" \
             "${{ steps.artifacts-linux.outputs.appimage }}" \
+            "${{ steps.artifacts-linux.outputs.appimage }}.sig" \
             checksums-linux-sha256.txt \
             --clobber
 
@@ -2016,22 +2044,26 @@ jobs:
           echo "::notice::web-dist.tar.gz uploaded to draft https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME — web-promote.yml deploys these exact bytes to production on publish."
 
   # ============================================================================
-  # Stitch the parallel mac + win builds into one finished draft release.
-  # Runs on a clean ubuntu runner — no source tree, no signing identities,
-  # no platform-specific tooling needed. Just `gh`, `jq`, and `curl`,
-  # which are all preinstalled on `ubuntu-latest`.
+  # Stitch the parallel mac + win + linux builds into one finished draft
+  # release. Runs on a clean ubuntu runner — no source tree, no signing
+  # identities, no platform-specific tooling needed. Just `gh`, `jq`, and
+  # `curl`, which are all preinstalled on `ubuntu-latest`.
   #
   # Two responsibilities:
   #   1. Extend the macOS-only `latest.json` (uploaded by build-macos)
-  #      with a `windows-x86_64` entry pointing at the MSI + .sig that
-  #      build-windows uploaded. After this, both Mac and Windows users
-  #      see auto-update prompts on next launch.
+  #      with the `windows-*` entries (MSI + .sig from build-windows) and
+  #      the `linux-x86_64` entry (AppImage + .sig from build-linux,
+  #      PRODUCT-1387). After this, Mac, Windows, and Linux users all see
+  #      auto-update prompts on next launch. Deliberate trade-off of
+  #      wiring Linux in: build-linux is now a hard dependency, so a
+  #      broken Linux leg blocks the manifest (fail-closed — an entry-less
+  #      manifest would silently re-strand Linux users instead).
   #   2. Notify Slack — moved here from build-windows because that step
   #      needs `release-notes.md` and the file only existed on the macOS
   #      runner. Now `prep` publishes it as a workflow artifact and any
   #      downstream job downloads it.
   finalize:
-    needs: [build-macos, build-windows]
+    needs: [build-macos, build-windows, build-linux]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # No `actions/checkout` step on this job — finalize doesn't need the
@@ -2076,14 +2108,15 @@ jobs:
           sentry-cli releases finalize "$RELEASE"
           echo "::notice::Finalized Sentry release $RELEASE"
 
-      # Pull `latest.json` (mac entries) and all Windows `*.msi.sig`
-      # files straight from the draft release. Using assets-on-the-draft
-      # as the handoff (instead of cross-job artifacts) avoids extra
-      # upload/download steps and keeps the source of truth in one
-      # place — the draft itself. Two .sig files now ship: one per
-      # Windows arch (x64, arm64). Tauri's updater key for each entry
-      # is the platform string the in-app client polls for.
-      - name: Extend latest.json with Windows updater entries
+      # Pull `latest.json` (mac entries), all Windows `*.msi.sig`, and the
+      # Linux `*.AppImage.sig` straight from the draft release. Using
+      # assets-on-the-draft as the handoff (instead of cross-job artifacts)
+      # avoids extra upload/download steps and keeps the source of truth in
+      # one place — the draft itself. Three .sig kinds ship: one per Windows
+      # arch (x64, arm64) plus the x64 AppImage (PRODUCT-1387). Tauri's
+      # updater key for each entry is the platform string the in-app client
+      # polls for.
+      - name: Extend latest.json with Windows + Linux updater entries
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -2099,6 +2132,7 @@ jobs:
           gh release download "$GITHUB_REF_NAME" \
             --pattern "$MANIFEST" \
             --pattern '*.msi.sig' \
+            --pattern '*.AppImage.sig' \
             --dir "$tmpdir"
 
           if [ ! -s "$tmpdir/$MANIFEST" ]; then
@@ -2139,12 +2173,35 @@ jobs:
             mv "$tmpdir/latest.merged.json" "$tmpdir/latest.next.json"
           done
 
+          # Same walk for the Linux AppImage sig (PRODUCT-1387). Only x64 is
+          # built, so the platform key is fixed. Fail-closed like Windows: a
+          # missing sig means build-linux broke, not "skip Linux".
+          appimage_sigs=("$tmpdir"/*.AppImage.sig)
+          if [ ${#appimage_sigs[@]} -eq 0 ]; then
+            echo "::error::no *.AppImage.sig in draft release; build-linux must have failed to upload it"
+            exit 1
+          fi
+
+          for SIG_FILE in "${appimage_sigs[@]}"; do
+            APPIMAGE_NAME=$(basename "$SIG_FILE" .sig)
+            APPIMAGE_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/$APPIMAGE_NAME"
+            APPIMAGE_SIG=$(cat "$SIG_FILE")
+
+            echo "  + linux-x86_64 ← $APPIMAGE_NAME"
+            jq \
+              --arg sig "$APPIMAGE_SIG" \
+              --arg url "$APPIMAGE_URL" \
+              '.platforms["linux-x86_64"] = {signature: $sig, url: $url}' \
+              "$tmpdir/latest.next.json" > "$tmpdir/latest.merged.json"
+            mv "$tmpdir/latest.merged.json" "$tmpdir/latest.next.json"
+          done
+
           echo "Updated $MANIFEST:"
           cat "$tmpdir/latest.next.json"
 
           mv "$tmpdir/latest.next.json" "$tmpdir/$MANIFEST"
           gh release upload "$GITHUB_REF_NAME" "$tmpdir/$MANIFEST" --clobber
-          echo "::notice::$MANIFEST now advertises macOS + Windows (x64 + arm64) for the in-app updater"
+          echo "::notice::$MANIFEST now advertises macOS + Windows (x64 + arm64) + Linux (x64) for the in-app updater"
 
       # Drop a PostHog annotation marking this release. Every PostHog
       # insight chart shows a vertical line at this timestamp, so any

--- a/knowledge-base/production-infra.md
+++ b/knowledge-base/production-infra.md
@@ -444,8 +444,9 @@ signing + reputation problem, solved in `release.yml`'s `build-windows` job.
   A plain `pnpm tauri build` builds the host too (no cargo feature to opt in). No
   provider CLIs are bundled — pi runs providers in-process.
 - **Output:** a DRAFT GitHub Release with a signed + notarized universal DMG, signed
-  Windows MSIs (x64 + arm64), a Linux AppImage, and `latest.json`. **Draft = QA
-  gate** — users don't see it until published.
+  Windows MSIs (x64 + arm64), an updater-signed Linux AppImage, and `latest.json`
+  advertising all three platforms. **Draft = QA gate** — users don't see it until
+  published.
 - **Duration:** ~25-30 min wall-clock (mac + win + linux in parallel; mac is the long
   pole at ~25 min including Apple notarization).
 
@@ -455,18 +456,22 @@ signing + reputation problem, solved in `release.yml`'s `build-windows` job.
 prep (ubuntu, ~30s)               creates empty draft + release-notes.md artifact
   ├── build-macos (mac, ~25m)     matrix [prod, staging on cloud-v*] — bun-compiles host sidecar (both arches) → signs, notarizes, uploads DMG/tar/sig/latest.json (staging leg: one renamed DMG only)
   ├── build-windows (win, ~15m)   bun-compiles host sidecar per arch → uploads MSI + .sig (x64 + arm64)
-  ├── build-linux (ubuntu, ~15m)  bun-compiles host sidecar → uploads AppImage (download-only, not in latest.json)
+  ├── build-linux (ubuntu, ~15m)  bun-compiles host sidecar → repairs AppImage → updater-signs the REPAIRED file → uploads AppImage + .sig
   ├── build-web (ubuntu, ~5m)     builds packages/web → uploads web-dist.tar.gz + Sentry maps
-  └── finalize (ubuntu, ~30s) [needs mac + win] extends latest.json with windows entries, posts Slack
+  └── finalize (ubuntu, ~30s) [needs mac + win + linux] extends latest.json with windows + linux entries, posts Slack
 ```
 
 Mac, Windows, Linux and web run in parallel — they only need the empty draft `prep`
 creates. `finalize` stitches `latest.json` together (the macOS-only base plus the
-Windows entries assembled from the MSI `.sig` in the draft) and posts the team Slack
-notification; it needs only mac + win, so a flaky Linux/web leg never blocks the
-updater manifest. Linux is UNSIGNED + download-only (no auto-update entry). Slack
-lives in `finalize` because it needs `release-notes.md`, published as an artifact by
-`prep`.
+Windows entries from the MSI `.sig`s and the `linux-x86_64` entry from the AppImage
+`.sig`, PRODUCT-1387) and posts the team Slack notification. Since Linux joined the
+updater, build-linux is a hard `finalize` dependency — a broken Linux leg blocks the
+manifest (fail-closed; an entry-less manifest would silently re-strand Linux users).
+The AppImage's updater `.sig` is minted AFTER the sidecar repair (a sig from `tauri
+build` would cover the pre-repair bytes and every client would reject the download);
+only web stays outside the updater. AppImage installs from before this wiring point
+at the legacy feed and must redownload once. Slack lives in `finalize` because it
+needs `release-notes.md`, published as an artifact by `prep`.
 
 ### Build guards
 


### PR DESCRIPTION
## Root cause

`latest-cloud.json` carried only `darwin-*` and `windows-*` entries — `build-linux` was explicitly download-only (unsigned, no endpoint repoint, no manifest entry). Every AppImage install was therefore permanently stale: the updater check returns "no update" forever, and with the gateway 426 floor retired (PRODUCT-1144) nothing else tells the user.

## Fix

**build-linux** mirrors the mac/win pattern, with one Linux-specific twist:

- Cloud tags get the same `point-updater-at-cloud-manifest.sh` endpoint repoint mac/win always had.
- Tauri's own updater-artifact emission **stays off** (`configure-ts-engine-unsigned.sh`, rationale rewritten): the "Restore Bun host sidecar" step rebuilds the AppImage *after* `tauri build`, so an in-build sig would cover the wrong bytes and every client would reject the download. Instead a new **"Updater-sign the repaired AppImage"** step signs the final file with `tauri signer sign` using the same minisign key as mac/win (one baked pubkey verifies all three platforms). Fail-closed: no sig, no release.
- The upload ships `<AppImage>.sig` alongside the AppImage.

**finalize** downloads `*.AppImage.sig` from the draft and merges a `linux-x86_64` entry, exactly like the Windows `.msi.sig` walk. Fail-closed on a missing sig.

**Deliberate trade-off (flagged for review):** `finalize` now hard-depends on `build-linux` (`needs: [build-macos, build-windows, build-linux]`). Previously a flaky Linux leg never blocked the updater manifest; now it does. The alternative — merging the entry only when present — silently re-strands Linux users, which is the exact failure mode this issue exists to kill. Veto by dropping the `needs` entry + making the merge conditional if train availability matters more.

## Interaction with PRODUCT-1386 (#1331)

New Linux builds get real updates. Installs from **before** this wiring still point at the legacy feed and must redownload once (noted in the workflow header and KB); builds that carry #1331 will at least surface the stuck-check nudge.

## Verification

- YAML parses (both workflows); `actionlint` findings unchanged vs baseline — none in the new blocks (remaining ones are pre-existing SC2012 info notes in untouched steps).
- The finalize merge logic was replayed locally against a fixture manifest + fake `.msi.sig`/`.AppImage.sig`: produces `darwin-*`, `windows-*`, `linux-x86_64` keys; the empty-glob fail-closed path verified under bash with `nullglob` (matching the step's shell opts).
- `tauri signer sign` CLI + env-var contract (`TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)`) verified against the pinned @tauri-apps/cli.
- **Not verifiable pre-merge:** the full train. On the first `cloud-v*` run after this merges, QA the draft: (1) `latest-cloud.json` in the draft has a `linux-x86_64` entry, (2) an older AppImage with its endpoint pointed at the draft manifest updates in place and relaunches.

`knowledge-base/production-infra.md` updated to match (pipeline diagram, finalize deps, sign-after-repair note).