### PR TITLE
fix(providers): accept Google's new AQ. Gemini auth keys (PRODUCT-1368)

### DIFF
--- a/packages/agentstore-contract/src/secrets.test.ts
+++ b/packages/agentstore-contract/src/secrets.test.ts
@@ -8,6 +8,7 @@ const SAMPLES: Array<[string, string]> = [
   ["Anthropic API key", "sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345"],
   ["OpenAI API key", `sk-proj-${"a".repeat(24)}`],
   ["Google API key", `AIza${"A".repeat(35)}`],
+  ["Google auth key", `AQ.Ab8${"a".repeat(25)}`],
   ["GitHub token", `ghp_${"a".repeat(36)}`],
   ["Slack token", "xoxb-12345678901234"],
   ["Stripe secret key", `sk_live_${"a".repeat(24)}`],

--- a/packages/agentstore-contract/src/secrets.ts
+++ b/packages/agentstore-contract/src/secrets.ts
@@ -21,6 +21,9 @@ const SECRET_PATTERNS: Array<{ pattern: string; re: RegExp }> = [
   { pattern: "Anthropic API key", re: /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g },
   { pattern: "OpenAI API key", re: /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/g },
   { pattern: "Google API key", re: /\bAIza[0-9A-Za-z_-]{35}\b/g },
+  // AI Studio's newer auth-key format (PRODUCT-1368); length varies, so
+  // require a long unbroken tail to keep prose false positives near zero.
+  { pattern: "Google auth key", re: /\bAQ\.[0-9A-Za-z_-]{25,}\b/g },
   { pattern: "GitHub token", re: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/g },
   { pattern: "Slack token", re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g },
   {

--- a/packages/host/src/channel/capture-credential.test.ts
+++ b/packages/host/src/channel/capture-credential.test.ts
@@ -255,3 +255,34 @@ test("a real AIza google api-key export still captures", async () => {
   expect(result).toEqual({ ok: true, provider: "google" });
   expect(stored[0]?.accessToken).toBe("AIzaSyRealKey");
 });
+
+test("a new-format AQ. google auth key captures too (PRODUCT-1368)", async () => {
+  // AI Studio issues AQ.-prefixed auth keys since 2026; only OAuth material
+  // (ya29./eyJ) is refused from shape.
+  const stored: WorkspaceCredential[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      Response.json({
+        provider: "google",
+        kind: "api_key",
+        key: "AQ.Ab8RN6JkyDLMExampleAuthKey",
+      }),
+    ),
+  );
+  const result = await captureRuntimeCredential({
+    endpoint: { baseUrl: "http://runtime", token: "runtime-token" },
+    credentials: {
+      get: async () => null,
+      put: async (credential) => {
+        stored.push(credential);
+      },
+      remove: async () => {},
+      removeIfAccess: async () => false,
+    },
+    workspaceId: "workspace",
+    provider: "google",
+  });
+  expect(result).toEqual({ ok: true, provider: "google" });
+  expect(stored[0]?.accessToken).toBe("AQ.Ab8RN6JkyDLMExampleAuthKey");
+});

--- a/packages/protocol/src/google-key.ts
+++ b/packages/protocol/src/google-key.ts
@@ -1,12 +1,23 @@
 /**
  * The one credential family whose deadness is decidable from shape alone
  * (HOU-1107; Sentry HOUSTON-APP-4Y9, HOUSTON-APP-567): a google "API key" that
- * is really OAuth material. Every Google Cloud API key starts with the
- * documented, stable `AIza` prefix; the legacy pre-verification pastes never do
- * — they are OAuth access tokens (`ya29.…`) or JWTs (`eyJ…`) that can never
- * authenticate as an `x-goog-api-key`. Google-only and api_key-only on
- * purpose: other providers' key shapes are not this crisp, and a google OAuth
- * credential is a different, already-guarded story.
+ * is really OAuth material — an OAuth access token (`ya29.…`) or a JWT
+ * (`eyJ…`) pasted before live verification existed. Those can never
+ * authenticate as an `x-goog-api-key`, so refusing them from shape is safe.
+ *
+ * DENYLIST on purpose (PRODUCT-1368). This predicate used to allowlist the
+ * `AIza` prefix ("every Google API key starts with AIza") — then Google
+ * shipped a second format: AI Studio now issues auth keys starting with
+ * `AQ.`, and the allowlist refused every one of them AND reported the central
+ * row for deletion. Judging validity from shape is Google's job, not ours:
+ * every new paste is live-verified against the models-list endpoint
+ * (runtime/auth/verify-api-key.ts), so the only rows this guard must catch
+ * are the frozen legacy OAuth pastes — which ARE decidable. An unknown future
+ * key format must fail open here and let Google be the judge.
+ *
+ * Google-only and api_key-only on purpose: other providers' key shapes are
+ * not this crisp, and a google OAuth credential is a different,
+ * already-guarded story.
  *
  * Shared between the runtime's serve guard (refuse + report the served row)
  * and the host's central-store adapters (never store, adopt, or capture such a
@@ -20,6 +31,6 @@ export function deadGoogleApiKey(cred: {
   return (
     cred.provider === "google" &&
     cred.kind === "api_key" &&
-    !cred.access.startsWith("AIza")
+    (cred.access.startsWith("ya29.") || cred.access.startsWith("eyJ"))
   );
 }

--- a/packages/runtime/src/auth/served-key-guard.test.ts
+++ b/packages/runtime/src/auth/served-key-guard.test.ts
@@ -18,11 +18,18 @@ test("a google api_key that is an OAuth access token reads dead", () => {
   expect(
     servedApiKeyIsDead(served({ access: "eyJhbGciOiJSUzI1NiJ9.x.y" })),
   ).toBe(true);
-  expect(servedApiKeyIsDead(served({ access: "aa" }))).toBe(true);
 });
 
-test("a real Gemini key (AIza…) is never refused", () => {
+test("a real Gemini key is never refused, whatever its format", () => {
+  // AIza standard key.
   expect(servedApiKeyIsDead(served({}))).toBe(false);
+  // AQ. auth key — the format AI Studio issues since 2026 (PRODUCT-1368).
+  expect(
+    servedApiKeyIsDead(served({ access: "AQ.Ab8RN6JkyDLMExampleAuthKey" })),
+  ).toBe(false);
+  // The guard judges deadness (OAuth material), not validity: an unknown
+  // shape is served and judged by Google, never refused from shape alone.
+  expect(servedApiKeyIsDead(served({ access: "aa" }))).toBe(false);
 });
 
 test("the guard is google-only and api_key-only", () => {

--- a/packages/runtime/src/auth/served-key-guard.ts
+++ b/packages/runtime/src/auth/served-key-guard.ts
@@ -29,11 +29,13 @@ import type { ServedCredential } from "./auth-file";
 
 /**
  * True when the served credential is a google "api_key" whose value cannot be
- * a Gemini API key. Every Google Cloud API key starts with `AIza` (a
- * documented, stable prefix); the legacy garbage never does — it is OAuth
- * material (`ya29.…` user tokens, `eyJ…` JWTs). Scoped to google only: no
- * other provider has this legacy family, and other providers' key shapes are
- * not this crisp.
+ * a Gemini API key: the legacy garbage is OAuth material (`ya29.…` user
+ * tokens, `eyJ…` JWTs), refused by shape. Anything else — `AIza` standard
+ * keys, the newer `AQ.` auth keys, whatever Google mints next — is served and
+ * judged by Google (PRODUCT-1368: an AIza allowlist here refused every new
+ * AQ. key and deleted its central row). Scoped to google only: no other
+ * provider has this legacy family, and other providers' key shapes are not
+ * this crisp.
  */
 export function servedApiKeyIsDead(cred: ServedCredential): boolean {
   return deadGoogleApiKey(cred);

--- a/packages/runtime/src/transport/server-providers-scope.test.ts
+++ b/packages/runtime/src/transport/server-providers-scope.test.ts
@@ -220,8 +220,9 @@ test("GET /providers labels WHOSE credential served each acting identity", async
           ? {
               provider,
               kind: "api_key",
-              // AIza-shaped: a served google key of any other shape is the
-              // dead legacy family served-key-guard.ts refuses (HOU-1107).
+              // AIza-shaped: a served google key of the OAuth-material shape
+              // (ya29./eyJ) is the dead legacy family served-key-guard.ts
+              // refuses (HOU-1107).
               access: "AIzaTeamGemini",
               expires: 0,
               accountId: null,


### PR DESCRIPTION
## PRODUCT-1368

### Root cause
Google AI Studio now issues **auth keys** prefixed `AQ.` (only that format since 2026; `AIza` standard keys will be rejected by Google in September 2026). Our HOU-1107 dead-key shape guard (`deadGoogleApiKey` in `packages/protocol/src/google-key.ts`) allowlisted the `AIza` prefix, so every new-format key was judged "OAuth material that can never authenticate":

- the serve guard refused the credential **and reported the central row for deletion**,
- capture refused to store it ("the stored google credential is an OAuth-type token, not an API key"),

even though the key had just passed live verification against Google's models-list endpoint. No OAuth support is needed: `AQ.` keys are plain API keys riding the same `x-goog-api-key` header, and pi passes keys through with no shape check.

### Fix
- Flip `deadGoogleApiKey` from an `AIza` allowlist to a **denylist of the material that is decidably dead from shape alone** (`ya29.` OAuth access tokens, `eyJ` JWTs — the exact legacy family behind Sentry HOUSTON-APP-4Y9). Validity stays Google's call: every new paste is live-verified, so an unknown future key format fails open instead of deleting users' credentials.
- Teach the agent-store secret scanner the `AQ.` format so leaked auth keys block publish/export like `AIza` keys do.
- Tests: guard accepts `AQ.` keys, capture stores them; existing `ya29.`/`eyJ` dead-row coverage unchanged.

### Before (reproduce the bug)
1. In Google AI Studio, create a fresh Gemini API key — it starts with `AQ.`.
2. Connect Google in Houston by pasting it: verification succeeds (Google accepts the key), but on managed cloud the capture step fails with "the stored google credential is an OAuth-type token, not an API key", and any served row is refused and its central row deleted, so Gemini reads not-connected.

### After (verify the fix)
1. Paste the same `AQ.` key: connect completes, Google shows connected, and a Gemini chat turn answers normally (desktop and managed cloud).
2. Regression: a legacy `ya29.`/JWT row is still refused and reported (`packages/runtime/src/auth/served-key-guard.test.ts`).
3. `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain --filter @houston/agentstore-contract --filter @houston/protocol test`, `pnpm typecheck`, `pnpm check`, `pnpm check:boundaries` all pass.