### PR TITLE
fix: keep device-offline unhandled rejections out of Sentry (PRODUCT-1392)

### DIFF
--- a/app/src/lib/global-error-handlers.ts
+++ b/app/src/lib/global-error-handlers.ts
@@ -1,7 +1,8 @@
 import { isAgentWarmingError } from "./agent-warming-guard";
 import { analytics, classifyAnalyticsError } from "./analytics";
 import { isBenignLockRejection } from "./benign-rejections";
-import { showErrorToast } from "./error-toast";
+import { showConnectivityErrorToast, showErrorToast } from "./error-toast";
+import { isNetworkTransportError } from "./network-transport-error";
 
 /**
  * Install the process-wide `window.onerror` / `window.onunhandledrejection`
@@ -54,6 +55,20 @@ export function installGlobalErrorHandlers(): void {
         "[global:unhandledrejection] write blocked while the agent warms up:",
         message,
       );
+      return;
+    }
+    // A transport-level network failure whose rejected promise nobody caught
+    // (PRODUCT-1392: the `/v1/events` global stream dropping on device
+    // offline / sleep-wake). Same HOU-1085 policy as the engine-call and
+    // caller-toast layers — ONE deduped connectivity toast, no Sentry capture:
+    // nothing in Houston broke. This handler was the last ungated surface, and
+    // it kept the `unhandled_rejection: Load failed` Sentry family alive after
+    // both other layers were gated. console.error (patched) so the drop still
+    // reaches the log file; the toast fires the analytics event past dedupe.
+    if (isNetworkTransportError(event.reason)) {
+      event.preventDefault();
+      console.error("[global:unhandledrejection] connectivity drop:", message);
+      showConnectivityErrorToast("unhandled_rejection", message);
       return;
     }
     console.error("[global:unhandledrejection]", message, event.reason);

--- a/app/tests/error-report-connectivity.test.ts
+++ b/app/tests/error-report-connectivity.test.ts
@@ -39,6 +39,40 @@ describe("reportError declines connectivity failures (HOU-1085 policy)", () => {
   });
 });
 
+describe("global rejection handler declines connectivity failures", () => {
+  // PRODUCT-1392 (HOUSTON-APP-4PG): a transport TypeError rejecting from a
+  // promise nobody catches (the `/v1/events` stream dropping on device
+  // offline) landed in `window.onunhandledrejection`, which was the last
+  // surface without the HOU-1085 gate — 2,331 events / 151 users of
+  // `unhandled_rejection: Load failed`, with the red toast, on builds where
+  // both other layers were already gated.
+  const source = read("../src/lib/global-error-handlers.ts");
+
+  it("gates capture + red toast on isNetworkTransportError", () => {
+    ok(
+      source.includes('from "./network-transport-error"'),
+      "global-error-handlers.ts must import the connectivity classifier",
+    );
+    const body = source.slice(source.indexOf("window.onunhandledrejection ="));
+    const guard = body.indexOf("if (isNetworkTransportError(event.reason))");
+    const capture = body.indexOf("analytics.captureException");
+    const redToast = body.indexOf("showErrorToast(");
+    ok(guard !== -1, "the rejection handler must gate on connectivity");
+    ok(
+      body.indexOf("showConnectivityErrorToast(", guard) !== -1,
+      "the connectivity branch must surface the deduped connectivity toast",
+    );
+    ok(
+      capture === -1 || guard < capture,
+      "the connectivity guard must run before the exception capture",
+    );
+    ok(
+      redToast === -1 || guard < redToast,
+      "the connectivity guard must run before the red error toast",
+    );
+  });
+});
+
 describe("provider connect actions do not double-surface connectivity", () => {
   // The engine-call layer (`surfaceError` in lib/tauri.ts) shows the ONE
   // deduped connectivity toast for these failures; the hook's authored red


### PR DESCRIPTION
## Root cause

PRODUCT-1392 (Sentry `unhandled_rejection: Load failed`, 2,331 events / 151 users, still occurring on 0.6.2).

A device connectivity drop (sleep-wake, network switch) fails every in-flight request at once with WebKit's transport `TypeError: Load failed`. Most of those rejections are caught by the HOU-1085-gated layers, but one that nobody catches — typically the `/v1/events` global SSE stream, per the event breadcrumbs — lands in `window.onunhandledrejection` in `app/src/lib/global-error-handlers.ts`. That handler was the last surface without the connectivity gate: PR #1181 gated the engine-call layer (`surfaceError`) and PR #1330 gated the caller-toast layer (`reportError`), so this path alone kept the Sentry family alive and showed the red error toast for an offline device.

## Fix

Gate the rejection handler on `isNetworkTransportError(event.reason)`, mirroring the other two layers: route to `showConnectivityErrorToast` (the ONE deduped informational "you're offline" toast), skip the Sentry capture and the red toast. The drop still reaches the frontend log via `console.error`, and the connectivity toast fires the `app_error_shown` analytics event past its dedupe, so nothing goes dark.

Structural test added beside the PRODUCT-1383 guard in `app/tests/error-report-connectivity.test.ts`.

## Before (reproduce)

1. Run the app, sign in to a hosted agent so the global `/v1/events` stream is live.
2. Kill connectivity (toggle Wi-Fi off, or sleep-wake across a network change).
3. Red error toast appears for `unhandled_rejection: Load failed`, and a `unhandled_rejection: Load failed` event is captured to Sentry (visible in the console as `[global:unhandledrejection] Load failed`).

## After (verify)

1. Same steps: live app, kill connectivity.
2. One informational "offline" connectivity toast (deduped with the burst from other failing calls) — no red toast.
3. Console shows `[global:unhandledrejection] connectivity drop: Load failed`; no new `unhandled_rejection` event in Sentry.
4. `cd app && pnpm test` — the new structural guard in `error-report-connectivity.test.ts` passes (3,655 tests green).

Coding-bug TypeErrors ("undefined is not a function") are unaffected: the classifier keys on the fixed set of browser transport messages only.