### PR TITLE
Bound Codex summarization input under the provider's 10 MiB cap (PRODUCT-1394)

### DIFF
--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -1043,6 +1043,24 @@ test("Anthropic 'prompt is too long' → context_overflow, never rate_limited de
   }
 });
 
+test("OpenAI per-string 10MiB cap ('string too long') → context_overflow with null token counts", () => {
+  // Verbatim from PRODUCT-1394 (HOUSTON-APP-56R): pi's unbounded compaction
+  // serialized a 31MB conversation into one content string; OpenAI caps any
+  // single string at 10,485,760 chars. The message carries char counts, not
+  // token counts, so both extractors must stay null (the card omits numbers).
+  const err = classifyProviderError({
+    provider: "openai-codex",
+    model: "gpt-5.5",
+    message:
+      "Summarization failed: Invalid 'input[0].content[0].text': string too long. Expected a string with maximum length 10485760, but got a string with length 31056249 instead.",
+  });
+  expect(err.kind).toBe("context_overflow");
+  if (err.kind === "context_overflow") {
+    expect(err.context_window_tokens).toBeNull();
+    expect(err.prompt_tokens).toBeNull();
+  }
+});
+
 test("overflow text without numbers still classifies, with null token counts", () => {
   const err = classifyProviderError({
     provider: "amazon-bedrock",

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -600,8 +600,22 @@ function modelUnavailableReason(
     : "unknown";
 }
 
+/**
+ * Overflow shapes pi-ai's pattern list misses. OpenAI enforces a hard
+ * 10,485,760-char cap on any single content string; an over-cap request is
+ * rejected with `Invalid 'input[0].content[0].text': string too long.
+ * Expected a string with maximum length 10485760, …` — the conversation
+ * outgrew what one request can carry, so the context-overflow card (bigger
+ * window / fresh chat) is the honest one, never the report-bug `unknown`
+ * (PRODUCT-1394; the message carries no token numbers, so both extractors
+ * below return null and the card omits them).
+ */
+const EXTRA_OVERFLOW_PATTERNS = [/string too long/i];
+
 function isContextOverflow(message: string): boolean {
-  return getOverflowPatterns().some((p) => p.test(message));
+  return [...getOverflowPatterns(), ...EXTRA_OVERFLOW_PATTERNS].some((p) =>
+    p.test(message),
+  );
 }
 
 /**

--- a/packages/runtime/src/session/compaction-guard.test.ts
+++ b/packages/runtime/src/session/compaction-guard.test.ts
@@ -1,18 +1,27 @@
 import {
   type CompactionResult,
+  convertToLlm,
   DEFAULT_COMPACTION_SETTINGS,
   type ExtensionAPI,
   type ExtensionContext,
+  estimateTokens,
   type SessionBeforeCompactEvent,
+  serializeConversation,
 } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import {
-  boundMessages,
   droppedNotice,
+  MAX_BOUNDED_ATTEMPTS,
   makeCompactionGuard,
-  SUMMARIZER_INPUT_FRACTION,
-  summarizerInputBudget,
 } from "./compaction-guard";
+import {
+  boundMessages,
+  elideMiddle,
+  isInputSizeRejection,
+  SUMMARIZER_INPUT_FRACTION,
+  SUMMARIZER_INPUT_MAX_TOKENS,
+  summarizerInputBudget,
+} from "./summarizer-budget";
 
 type Msg =
   SessionBeforeCompactEvent["preparation"]["messagesToSummarize"][number];
@@ -29,11 +38,22 @@ const msg = (tokens: number): Msg =>
     timestamp: 1,
   }) as unknown as Msg;
 
+/** A user message with NO elidable text (image-only) at ~1200 tokens. */
+const imageMsg = (): Msg =>
+  ({
+    role: "user",
+    content: [{ type: "image", data: "", mimeType: "image/png" }],
+    timestamp: 1,
+  }) as unknown as Msg;
+
 const okCompaction: CompactionResult = {
   summary: "S",
   firstKeptEntryId: "e1",
   tokensBefore: 5000,
 };
+
+const CODEX_WINDOW_REJECTION =
+  "Summarization failed: Codex error: Your input exceeds the context window of this model. Please adjust your input and try again.";
 
 function loadHandler(compactFn: Parameters<typeof makeCompactionGuard>[0]) {
   let handler: Handler | undefined;
@@ -87,12 +107,20 @@ function makeEvent(
   } as unknown as SessionBeforeCompactEvent;
 }
 
+function boundedArg(compactFn: ReturnType<typeof vi.fn>, call = 0) {
+  return compactFn.mock.calls[call]?.[0] as unknown as {
+    messagesToSummarize: Msg[];
+    turnPrefixMessages: Msg[];
+  };
+}
+
 describe("boundMessages", () => {
   it("keeps the newest messages that fit, in order", () => {
     const messages = [msg(100), msg(100), msg(100), msg(100)];
-    const { kept, dropped } = boundMessages(messages, 250);
+    const { kept, dropped, elided } = boundMessages(messages, 250);
     expect(kept).toEqual(messages.slice(2));
     expect(dropped).toBe(2);
+    expect(elided).toBe(0);
   });
 
   it("keeps everything under budget", () => {
@@ -100,11 +128,47 @@ describe("boundMessages", () => {
     expect(boundMessages(messages, 250)).toEqual({
       kept: messages,
       dropped: 0,
+      elided: 0,
     });
   });
 
-  it("keeps nothing when even the newest message overflows", () => {
-    expect(boundMessages([msg(300)], 250)).toEqual({ kept: [], dropped: 1 });
+  it("elides the middle of an oversized newest message instead of dropping it", () => {
+    const giant = msg(300);
+    const { kept, dropped, elided } = boundMessages([msg(50), giant], 250);
+    expect(dropped).toBe(1);
+    expect(elided).toBe(1);
+    expect(kept).toHaveLength(1);
+    const keptContent = (kept[0] as unknown as { content: string }).content;
+    expect(keptContent).toContain("characters elided");
+    expect(keptContent.startsWith("xx")).toBe(true);
+    expect(keptContent.endsWith("xx")).toBe(true);
+    expect(estimateTokens(kept[0] as never)).toBeLessThanOrEqual(250);
+    // The original message is never mutated.
+    expect((giant as unknown as { content: string }).content).toBe(
+      "x".repeat(1200),
+    );
+  });
+
+  it("drops an oversized newest message with no elidable text", () => {
+    expect(boundMessages([imageMsg()], 250)).toEqual({
+      kept: [],
+      dropped: 1,
+      elided: 0,
+    });
+  });
+});
+
+describe("elideMiddle", () => {
+  it("keeps head and tail around an explicit marker, within the cap", () => {
+    const out = elideMiddle(`HEAD${"m".repeat(500)}TAIL`, 120);
+    expect(out.length).toBeLessThanOrEqual(120);
+    expect(out).toContain("characters elided");
+    expect(out.startsWith("HEAD")).toBe(true);
+    expect(out.endsWith("TAIL")).toBe(true);
+  });
+
+  it("returns short text untouched", () => {
+    expect(elideMiddle("short", 120)).toBe("short");
   });
 });
 
@@ -114,40 +178,114 @@ describe("summarizerInputBudget", () => {
       Math.floor(272_000 * SUMMARIZER_INPUT_FRACTION),
     );
   });
+
+  it("never exceeds the provider-string-cap ceiling, however big the window", () => {
+    expect(summarizerInputBudget(100_000_000)).toBe(
+      SUMMARIZER_INPUT_MAX_TOKENS,
+    );
+    // The ceiling, serialized at 4 chars/token, stays under OpenAI's
+    // 10,485,760-char per-string cap with room for prompt scaffolding.
+    expect(SUMMARIZER_INPUT_MAX_TOKENS * 4).toBeLessThan(10_485_760);
+  });
+});
+
+describe("isInputSizeRejection", () => {
+  it("recognizes size rejections", () => {
+    expect(isInputSizeRejection(CODEX_WINDOW_REJECTION)).toBe(true);
+    expect(
+      isInputSizeRejection(
+        "Summarization failed: Invalid 'input[0].content[0].text': string too long. Expected a string with maximum length 10485760, but got a string with length 31056249 instead.",
+      ),
+    ).toBe(true);
+    expect(isInputSizeRejection("400 context_length_exceeded")).toBe(true);
+  });
+
+  it("leaves transient failures on the defer path", () => {
+    expect(isInputSizeRejection("rate limited")).toBe(false);
+    expect(
+      isInputSizeRejection(
+        "Throttling error: Too many tokens, please wait before trying again.",
+      ),
+    ).toBe(false);
+    expect(isInputSizeRejection("socket hang up")).toBe(false);
+  });
 });
 
 describe("makeCompactionGuard", () => {
   // Window 1000 → budget 700 (at the 0.7 fraction).
-  it("declines when the summarizer input fits (pi's default path runs)", async () => {
+  it("declines when the summarizer input fits (pi's default path runs on the untouched preparation)", async () => {
     const compactFn = vi.fn(async () => okCompaction);
     const handler = loadHandler(compactFn);
     const { ctx } = makeCtx({ contextWindow: 1000 });
-    const result = await handler(makeEvent([msg(300), msg(300)]), ctx);
+    const messages = [msg(300), msg(300)];
+    const event = makeEvent(messages);
+    const result = await handler(event, ctx);
     expect(result).toBeUndefined();
     expect(compactFn).not.toHaveBeenCalled();
+    // Byte-identical pass-through: same message objects, untouched content.
+    expect(event.preparation.messagesToSummarize[0]).toBe(messages[0]);
+    expect((messages[0] as unknown as { content: string }).content).toBe(
+      "x".repeat(1200),
+    );
   });
 
-  it("bounds an overflowing history and prefixes the drop notice", async () => {
+  it("bounds an overflowing history under the budget and prefixes the drop notice", async () => {
     const compactFn = vi.fn(async (..._args: unknown[]) => okCompaction);
     const handler = loadHandler(compactFn);
     const { ctx } = makeCtx({ contextWindow: 1000 });
     const messages = [msg(300), msg(300), msg(300)]; // 900 > 700: drops oldest
     const result = await handler(makeEvent(messages), ctx);
     expect(compactFn).toHaveBeenCalledOnce();
-    const bounded = compactFn.mock.calls[0]?.[0] as unknown as {
-      messagesToSummarize: Msg[];
-    };
+    const bounded = boundedArg(compactFn);
     expect(bounded.messagesToSummarize).toEqual(messages.slice(1));
+    const totalTokens = bounded.messagesToSummarize.reduce(
+      (sum, m) => sum + estimateTokens(m as never),
+      0,
+    );
+    expect(totalTokens).toBeLessThanOrEqual(700);
     expect(result?.compaction?.summary).toBe(`${droppedNotice(1)}\n\nS`);
     expect(result?.compaction?.firstKeptEntryId).toBe("e1");
   });
 
-  it("compacts deterministically when not even the newest message fits", async () => {
+  it("halves the budget and retries when the provider rejects the bounded request for size", async () => {
+    const compactFn = vi
+      .fn(async (..._args: unknown[]) => okCompaction)
+      .mockRejectedValueOnce(new Error(CODEX_WINDOW_REJECTION));
+    const handler = loadHandler(compactFn);
+    const { ctx } = makeCtx({ contextWindow: 1000 });
+    const messages = [msg(300), msg(300), msg(300)];
+    const result = await handler(makeEvent(messages), ctx);
+    expect(compactFn).toHaveBeenCalledTimes(2);
+    // First attempt at budget 700 keeps 2 messages; the halved retry (350)
+    // keeps only the newest.
+    expect(boundedArg(compactFn, 0).messagesToSummarize).toHaveLength(2);
+    expect(boundedArg(compactFn, 1).messagesToSummarize).toHaveLength(1);
+    expect(result?.compaction?.summary).toBe(`${droppedNotice(2)}\n\nS`);
+  });
+
+  it("compacts deterministically when every halved attempt is size-rejected (never defers into pi's unbounded default)", async () => {
+    const compactFn = vi.fn(async () => {
+      throw new Error(CODEX_WINDOW_REJECTION);
+    });
+    const handler = loadHandler(compactFn);
+    const { ctx } = makeCtx({ contextWindow: 1000 });
+    const messages = [msg(300), msg(300), msg(300)];
+    const result = await handler(
+      makeEvent(messages, { previousSummary: "PREV" }),
+      ctx,
+    );
+    expect(compactFn).toHaveBeenCalledTimes(MAX_BOUNDED_ATTEMPTS);
+    expect(result?.compaction?.summary).toBe(`PREV\n\n${droppedNotice(3)}`);
+    expect(result?.compaction?.firstKeptEntryId).toBe("e1");
+    expect(result?.compaction?.tokensBefore).toBe(5000);
+  });
+
+  it("compacts deterministically when nothing summarizable fits (no elidable text)", async () => {
     const compactFn = vi.fn(async () => okCompaction);
     const handler = loadHandler(compactFn);
     const { ctx, getApiKeyAndHeaders } = makeCtx({ contextWindow: 1000 });
     const result = await handler(
-      makeEvent([msg(800)], { previousSummary: "PREV" }),
+      makeEvent([imageMsg()], { previousSummary: "PREV" }),
       ctx,
     );
     expect(compactFn).not.toHaveBeenCalled();
@@ -157,7 +295,7 @@ describe("makeCompactionGuard", () => {
     expect(result?.compaction?.tokensBefore).toBe(5000);
   });
 
-  it("declines when the bounded summarization itself fails (retried next turn)", async () => {
+  it("declines when the bounded summarization fails transiently (retried next turn)", async () => {
     const compactFn = vi.fn(async () => {
       throw new Error("rate limited");
     });
@@ -167,6 +305,7 @@ describe("makeCompactionGuard", () => {
       makeEvent([msg(300), msg(300), msg(300)]),
       ctx,
     );
+    expect(compactFn).toHaveBeenCalledOnce();
     expect(result).toBeUndefined();
   });
 
@@ -193,12 +332,45 @@ describe("makeCompactionGuard", () => {
     const prefix = [msg(300), msg(300), msg(300)]; // 900 > 700: drops oldest
     const result = await handler(makeEvent([msg(300)], { prefix }), ctx);
     expect(compactFn).toHaveBeenCalledOnce();
-    const bounded = compactFn.mock.calls[0]?.[0] as unknown as {
-      messagesToSummarize: Msg[];
-      turnPrefixMessages: Msg[];
-    };
+    const bounded = boundedArg(compactFn);
     expect(bounded.messagesToSummarize).toHaveLength(1);
     expect(bounded.turnPrefixMessages).toEqual(prefix.slice(1));
     expect(result?.compaction?.summary).toBe(`${droppedNotice(1)}\n\nS`);
+  });
+
+  it("keeps the serialized request under OpenAI's 10 MiB string cap at any window", async () => {
+    const compactFn = vi.fn(async (..._args: unknown[]) => okCompaction);
+    const handler = loadHandler(compactFn);
+    // A window so large the 0.7 fraction alone would allow a >10 MiB string;
+    // the SUMMARIZER_INPUT_MAX_TOKENS ceiling must bind instead.
+    const { ctx } = makeCtx({ contextWindow: 100_000_000 });
+    // A 40MB conversation, like the 31MB one behind PRODUCT-1394.
+    const messages = Array.from({ length: 40 }, () => msg(250_000));
+    await handler(makeEvent(messages), ctx);
+    expect(compactFn).toHaveBeenCalledOnce();
+    const bounded = boundedArg(compactFn);
+    const serialized = serializeConversation(
+      convertToLlm(bounded.messagesToSummarize as never[]),
+    );
+    expect(serialized.length).toBeGreaterThan(0);
+    expect(serialized.length).toBeLessThan(10_485_760);
+  });
+
+  it("sends an elided single giant message instead of losing all history", async () => {
+    const compactFn = vi.fn(async (..._args: unknown[]) => okCompaction);
+    const handler = loadHandler(compactFn);
+    const { ctx } = makeCtx({ contextWindow: 1000 });
+    const result = await handler(makeEvent([msg(5000)]), ctx);
+    expect(compactFn).toHaveBeenCalledOnce();
+    const bounded = boundedArg(compactFn);
+    expect(bounded.messagesToSummarize).toHaveLength(1);
+    const kept = bounded.messagesToSummarize[0] as unknown as {
+      content: string;
+    };
+    expect(kept.content).toContain("characters elided");
+    expect(
+      estimateTokens(bounded.messagesToSummarize[0] as never),
+    ).toBeLessThanOrEqual(700);
+    expect(result?.compaction?.summary).toBe(`${droppedNotice(0, 1)}\n\nS`);
   });
 });

--- a/packages/runtime/src/session/compaction-guard.ts
+++ b/packages/runtime/src/session/compaction-guard.ts
@@ -1,76 +1,64 @@
 import {
   type ExtensionFactory,
-  estimateTokens,
   compact as piCompact,
   type SessionBeforeCompactEvent,
 } from "@earendil-works/pi-coding-agent";
+import {
+  boundMessages,
+  isInputSizeRejection,
+  summarizerInputBudget,
+} from "./summarizer-budget";
 
 /**
- * COMPACTION OVERFLOW GUARD (HOU-709). pi's compaction summarizes the pre-cut
- * history by serializing ALL of it into ONE summarization request against the
- * active model — with no input bound. Once a conversation's history outgrows
- * the model's real input window (long-running shared routine chats get there
- * on schedule), that request is rejected (`context_length_exceeded`), the
- * turn errors with "Summarization failed", and NOTHING ever shrinks the
- * history — every later turn re-triggers the same doomed compaction forever.
+ * COMPACTION OVERFLOW GUARD (HOU-709, PRODUCT-1394). pi's compaction
+ * summarizes the pre-cut history by serializing ALL of it into ONE
+ * summarization request against the active model — with no input bound. Once
+ * a conversation's history outgrows the model's real input window (or
+ * OpenAI's 10 MiB per-string cap — a 31MB codex request in prod), that
+ * request is rejected, the turn errors with "Summarization failed", and
+ * NOTHING ever shrinks the history — every later turn re-triggers the same
+ * doomed compaction forever.
  *
- * This pi extension bounds the summarizer's input: when the messages to
- * summarize don't plausibly fit the model's window, it summarizes only the
- * newest slice that fits and drops the rest (noting the drop in the summary),
- * via pi's own `compact()` so file-op tracking, split-turn handling, and the
+ * This pi extension bounds the summarizer's input (sizing rules in
+ * summarizer-budget.ts): it summarizes only the newest slice that fits the
+ * budget and drops the rest (noting the drop in the summary), via pi's own
+ * `compact()` so file-op tracking, split-turn handling, and the
  * previous-summary merge stay byte-identical to the default path. When the
  * input fits — every healthy compaction — it declines, and pi's default path
- * runs untouched.
+ * runs untouched. The chars/4 token estimate can UNDER-count dense content
+ * (PRODUCT-1394: codex tokenized a bounded request past its 272k window), so
+ * a size rejection of the bounded request retries with a halved budget
+ * instead of deferring — deferring would hand pi's default an even LARGER
+ * input that is guaranteed to fail: exactly the 31MB wedge this guard
+ * exists to prevent.
  */
 
 type Preparation = SessionBeforeCompactEvent["preparation"];
-type AgentMessage = Preparation["messagesToSummarize"][number];
 type CompactFn = typeof piCompact;
 
 /**
- * Fraction of the model's context window the summarization request's input
- * may use (as estimated by pi's chars/4 heuristic). The remainder absorbs the
- * estimate's error, the summarizer's prompt scaffolding, and the reserved
- * summary output — generous because a too-big request is a wedged
- * conversation, while a too-small one only loses some old context to the
- * drop notice.
+ * Budget-halving attempts for the bounded request before giving up on
+ * summarizing at all. One halving covers every tokenizer density seen in the
+ * wild (~2.5 chars/token); two is margin for pathological content (~1).
  */
-export const SUMMARIZER_INPUT_FRACTION = 0.7;
-
-/** The summarizer's input token budget for a model window (0 = unknown). */
-export function summarizerInputBudget(contextWindow: number): number {
-  return Math.floor(contextWindow * SUMMARIZER_INPUT_FRACTION);
-}
-
-/**
- * Keep the NEWEST messages whose estimated tokens fit the budget — the same
- * newest-first accumulation pi's branch summarization uses, so what survives
- * is the context closest to the work in flight. Returns the kept slice in
- * chronological order plus how many older messages fell off.
- */
-export function boundMessages(
-  messages: AgentMessage[],
-  budget: number,
-): { kept: AgentMessage[]; dropped: number } {
-  const kept: AgentMessage[] = [];
-  let total = 0;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const message = messages[i];
-    if (!message) continue;
-    const cost = estimateTokens(message);
-    if (total + cost > budget) break;
-    total += cost;
-    kept.unshift(message);
-  }
-  return { kept, dropped: messages.length - kept.length };
-}
+export const MAX_BOUNDED_ATTEMPTS = 3;
 
 /** The summary preamble recording what the bounded summarizer never saw. */
-export function droppedNotice(dropped: number): string {
-  return (
-    `[Note: the oldest ${dropped} message(s) of this conversation exceeded ` +
-    "the model's context window and were dropped without being summarized.]"
-  );
+export function droppedNotice(dropped: number, elided = 0): string {
+  const parts: string[] = [];
+  if (dropped > 0) {
+    parts.push(
+      `the oldest ${dropped} message(s) of this conversation exceeded ` +
+        "the model's context window and were dropped without being summarized",
+    );
+  }
+  if (elided > 0) {
+    parts.push(
+      `the middle of ${elided} oversized message(s) was elided before ` +
+        "summarization",
+    );
+  }
+  return `[Note: ${parts.join("; ")}.]`;
 }
 
 const errMessage = (err: unknown): string =>
@@ -85,9 +73,12 @@ const errMessage = (err: unknown): string =>
  * Failure posture: a transient failure inside the bounded path (rate limit,
  * network) declines back to pi's default — the turn fails visibly with the
  * real reason and the NEXT turn re-enters this guard, so nothing is dropped
- * on a blip. Only the truly unsummarizable (not even the newest message fits)
- * compacts deterministically — previous summary + drop notice, no model call —
- * because every alternative leaves the conversation wedged forever.
+ * on a blip. A SIZE rejection instead halves the budget and retries (the
+ * input we sent was still too big; pi's unbounded default can only be
+ * bigger). Only the truly unsummarizable — nothing fits even after eliding,
+ * or every halved attempt is still size-rejected — compacts deterministically
+ * (previous summary + drop notice, no model call), because every alternative
+ * leaves the conversation wedged forever.
  */
 export function makeCompactionGuard(
   compactFn: CompactFn = piCompact,
@@ -97,20 +88,11 @@ export function makeCompactionGuard(
       const model = ctx.model;
       if (!model || model.contextWindow <= 0) return undefined;
 
-      const budget = summarizerInputBudget(model.contextWindow);
+      const fullBudget = summarizerInputBudget(model.contextWindow);
       const prep = event.preparation;
-      // History and turn prefix are summarized in SEPARATE requests
-      // (pi runs them in parallel), so each gets the full budget.
-      const history = boundMessages(prep.messagesToSummarize, budget);
-      const prefix = boundMessages(prep.turnPrefixMessages, budget);
-      if (history.dropped === 0 && prefix.dropped === 0) return undefined;
 
-      const dropped = history.dropped + prefix.dropped;
-      if (history.kept.length === 0 && prefix.kept.length === 0) {
-        // Even the newest message alone overflows the budget: no
-        // summarization request can succeed, ever. Compact deterministically
-        // so the conversation survives with the recent (kept-live) messages.
-        const summary = [prep.previousSummary, droppedNotice(dropped)]
+      const deterministic = (dropped: number, elided = 0) => {
+        const summary = [prep.previousSummary, droppedNotice(dropped, elided)]
           .filter(Boolean)
           .join("\n\n");
         return {
@@ -120,14 +102,34 @@ export function makeCompactionGuard(
             tokensBefore: prep.tokensBefore,
           },
         };
-      }
+      };
 
-      try {
-        // Same auth pi's own compaction resolves (model-registry). Since pi
-        // 0.84 the headers carry `null` deletion markers; pi's default path
-        // strips them before compact(), so the bounded path must too.
-        const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-        if (!auth.ok || !auth.apiKey) return undefined;
+      let auth: Awaited<
+        ReturnType<typeof ctx.modelRegistry.getApiKeyAndHeaders>
+      > | null = null;
+      for (let attempt = 0; attempt < MAX_BOUNDED_ATTEMPTS; attempt++) {
+        const budget = Math.floor(fullBudget / 2 ** attempt);
+        // History and turn prefix are summarized in SEPARATE requests
+        // (pi runs them one after the other), so each gets the full budget.
+        const history = boundMessages(prep.messagesToSummarize, budget);
+        const prefix = boundMessages(prep.turnPrefixMessages, budget);
+        const dropped = history.dropped + prefix.dropped;
+        const elided = history.elided + prefix.elided;
+        if (attempt === 0 && dropped === 0 && elided === 0) return undefined;
+        if (history.kept.length === 0 && prefix.kept.length === 0) {
+          // Not even an elided newest message fits: no summarization request
+          // can succeed, ever. Compact deterministically so the conversation
+          // survives with the recent (kept-live) messages.
+          return deterministic(dropped);
+        }
+
+        if (!auth) {
+          // Same auth pi's own compaction resolves (model-registry). Since pi
+          // 0.84 the headers carry `null` deletion markers; pi's default path
+          // strips them before compact(), so the bounded path must too.
+          auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+          if (!auth.ok || !auth.apiKey) return undefined;
+        }
         const headers = auth.headers
           ? Object.fromEntries(
               Object.entries(auth.headers).filter(
@@ -140,31 +142,58 @@ export function makeCompactionGuard(
           messagesToSummarize: history.kept,
           turnPrefixMessages: prefix.kept,
         };
-        const result = await compactFn(
-          bounded,
-          model,
-          auth.apiKey,
-          headers,
-          event.customInstructions,
-          event.signal,
-          undefined,
-          undefined,
-          auth.env,
+        console.info(
+          `[compaction-guard] bounding summarization input: window=${model.contextWindow} ` +
+            `budgetTokens=${budget} history=${prep.messagesToSummarize.length}->${history.kept.length} ` +
+            `prefix=${prep.turnPrefixMessages.length}->${prefix.kept.length} ` +
+            `elided=${elided} attempt=${attempt + 1}/${MAX_BOUNDED_ATTEMPTS}`,
         );
-        return {
-          compaction: {
-            ...result,
-            summary: `${droppedNotice(dropped)}\n\n${result.summary}`,
-          },
-        };
-      } catch (err) {
-        // Decline; pi's default path surfaces the turn's real failure and the
-        // next compaction attempt re-enters this guard.
-        console.warn(
-          `[compaction-guard] bounded summarization failed; deferring to pi's default: ${errMessage(err)}`,
-        );
-        return undefined;
+        try {
+          const result = await compactFn(
+            bounded,
+            model,
+            auth.apiKey,
+            headers,
+            event.customInstructions,
+            event.signal,
+            undefined,
+            undefined,
+            auth.env,
+          );
+          return {
+            compaction: {
+              ...result,
+              summary: `${droppedNotice(dropped, elided)}\n\n${result.summary}`,
+            },
+          };
+        } catch (err) {
+          const message = errMessage(err);
+          if (!isInputSizeRejection(message)) {
+            // Transient: decline; pi's default path surfaces the turn's real
+            // failure and the next compaction attempt re-enters this guard.
+            console.warn(
+              `[compaction-guard] bounded summarization failed; deferring to pi's default: ${message}`,
+            );
+            return undefined;
+          }
+          // The provider says our bounded input is STILL too big — the chars/4
+          // estimate under-counted. Deferring would send the full, larger
+          // input (guaranteed rejection), so shrink and try again instead.
+          console.warn(
+            `[compaction-guard] bounded summarization rejected for size at budgetTokens=${budget}; ` +
+              `halving and retrying: ${message}`,
+          );
+        }
       }
+      // Every halved attempt was size-rejected: summarization cannot succeed
+      // at any budget we can express. Compact deterministically — the wedge
+      // (an unshrinkable conversation) is strictly worse than a lossy note.
+      console.warn(
+        "[compaction-guard] all bounded summarization attempts size-rejected; compacting deterministically",
+      );
+      return deterministic(
+        prep.messagesToSummarize.length + prep.turnPrefixMessages.length,
+      );
     });
   };
 }

--- a/packages/runtime/src/session/summarizer-budget.ts
+++ b/packages/runtime/src/session/summarizer-budget.ts
@@ -1,0 +1,187 @@
+import { getOverflowPatterns } from "@earendil-works/pi-ai";
+import {
+  estimateTokens,
+  type SessionBeforeCompactEvent,
+} from "@earendil-works/pi-coding-agent";
+
+/**
+ * Sizing rules for the compaction guard's bounded summarization requests
+ * (HOU-709, PRODUCT-1394). The guard (compaction-guard.ts) is the ONLY seam
+ * between a conversation's full history and the single summarization request
+ * pi serializes it into, so every size limit lives here.
+ */
+
+type Preparation = SessionBeforeCompactEvent["preparation"];
+export type AgentMessage = Preparation["messagesToSummarize"][number];
+
+/**
+ * Fraction of the model's context window the summarization request's input
+ * may use (as estimated by pi's chars/4 heuristic). The remainder absorbs the
+ * estimate's error, the summarizer's prompt scaffolding, and the reserved
+ * summary output — generous because a too-big request is a wedged
+ * conversation, while a too-small one only loses some old context to the
+ * drop notice.
+ */
+export const SUMMARIZER_INPUT_FRACTION = 0.7;
+
+/**
+ * Absolute ceiling on the summarizer input's ESTIMATED tokens, independent of
+ * the model's window. The estimate is exactly chars/4, so this caps the
+ * serialized conversation at ~8,000,000 chars — comfortably under OpenAI's
+ * hard 10,485,760-char limit on any single content string (PRODUCT-1394: a
+ * 31MB serialization was rejected with "string too long", and a request that
+ * can never shrink wedges the conversation forever). Only binds for context
+ * windows above ~2.9M tokens; every current model is bounded by the window
+ * fraction first.
+ */
+export const SUMMARIZER_INPUT_MAX_TOKENS = 2_000_000;
+
+/** The summarizer's input token budget for a model window (0 = unknown). */
+export function summarizerInputBudget(contextWindow: number): number {
+  return Math.min(
+    Math.floor(contextWindow * SUMMARIZER_INPUT_FRACTION),
+    SUMMARIZER_INPUT_MAX_TOKENS,
+  );
+}
+
+/**
+ * A provider rejection caused by the REQUEST'S SIZE (context window or
+ * byte/char caps) — deterministic: resending the same or a bigger input can
+ * never succeed, so the guard must shrink, never defer to pi's unbounded
+ * default. Everything else (rate limits, network blips, 5xx) stays on the
+ * defer-and-retry-next-turn path. Reuses pi-ai's per-provider overflow
+ * patterns, minus its throttling exclusions ("Too many tokens, please wait"
+ * is a rate limit), plus OpenAI's per-string cap wording the patterns miss.
+ */
+export function isInputSizeRejection(message: string): boolean {
+  if (/rate limit|too many requests|throttl/i.test(message)) return false;
+  // OpenAI's 10 MiB per-content-string cap: "Invalid 'input[0].content[0]
+  // .text': string too long. Expected a string with maximum length 10485760…"
+  if (/string too long/i.test(message)) return true;
+  return getOverflowPatterns().some((p) => p.test(message));
+}
+
+export interface BoundResult {
+  kept: AgentMessage[];
+  dropped: number;
+  /** 1 when the newest message was too big alone and its middle was elided. */
+  elided: number;
+}
+
+/**
+ * Keep the NEWEST messages whose estimated tokens fit the budget — the same
+ * newest-first accumulation pi's branch summarization uses, so what survives
+ * is the context closest to the work in flight. When the newest message ALONE
+ * overflows the budget, its middle is elided (head + tail kept with an
+ * explicit marker) instead of losing the entire history to the deterministic
+ * fallback. Returns the kept slice in chronological order plus how many older
+ * messages fell off.
+ */
+export function boundMessages(
+  messages: AgentMessage[],
+  budget: number,
+): BoundResult {
+  const kept: AgentMessage[] = [];
+  let total = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (!message) continue;
+    const cost = estimateTokens(message);
+    if (total + cost > budget) break;
+    total += cost;
+    kept.unshift(message);
+  }
+  if (kept.length === 0 && messages.length > 0) {
+    const newest = messages[messages.length - 1];
+    const elided = newest ? elideMessage(newest, budget) : undefined;
+    if (elided) {
+      return { kept: [elided], dropped: messages.length - 1, elided: 1 };
+    }
+  }
+  return { kept, dropped: messages.length - kept.length, elided: 0 };
+}
+
+const ELISION_MARKER = (chars: number) =>
+  `\n[... ${chars} characters elided to fit the summarization budget ...]\n`;
+
+/** Keep a text's head + tail within `maxChars`, marking the elided middle. */
+export function elideMiddle(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const marker = ELISION_MARKER(text.length - maxChars);
+  const keep = maxChars - marker.length;
+  if (keep < 2) return text.slice(0, Math.max(0, maxChars));
+  const head = Math.ceil(keep / 2);
+  return text.slice(0, head) + marker + text.slice(text.length - (keep - head));
+}
+
+interface TextSlot {
+  get(): string;
+  set(value: string): void;
+}
+
+/** Writable views over every text field `estimateTokens` counts for a message. */
+function textSlots(message: AgentMessage): TextSlot[] {
+  // Structural access: AgentMessage is a closed pi union, but the fields we
+  // touch are plain strings; a slot is only produced for a string field.
+  const m = message as unknown as Record<string, unknown>;
+  const slot = (owner: Record<string, unknown>, key: string): TextSlot[] => {
+    const value = owner[key];
+    if (typeof value !== "string" || value.length === 0) return [];
+    return [
+      {
+        get: () => owner[key] as string,
+        set(next: string) {
+          owner[key] = next;
+        },
+      },
+    ];
+  };
+  const blockSlots = (allowed: string[]): TextSlot[] => {
+    if (!Array.isArray(m.content)) return [];
+    return (m.content as Record<string, unknown>[]).flatMap((block) => {
+      const type = block?.type;
+      if (typeof type !== "string" || !allowed.includes(type)) return [];
+      return slot(block, type === "thinking" ? "thinking" : "text");
+    });
+  };
+  switch (message.role) {
+    case "user":
+    case "custom":
+    case "toolResult":
+      if (typeof m.content === "string") return slot(m, "content");
+      return blockSlots(["text"]);
+    case "assistant":
+      return blockSlots(["text", "thinking"]);
+    case "bashExecution":
+      return slot(m, "output");
+    case "branchSummary":
+    case "compactionSummary":
+      return slot(m, "summary");
+    default:
+      return [];
+  }
+}
+
+/**
+ * A copy of `message` with each text field's middle elided so the whole
+ * message estimates within `budget` tokens, or undefined when its bulk is not
+ * in elidable text (then the caller falls back to the deterministic path).
+ */
+export function elideMessage(
+  message: AgentMessage,
+  budget: number,
+): AgentMessage | undefined {
+  const clone = structuredClone(message);
+  const slots = textSlots(clone);
+  const totalChars = slots.reduce((sum, s) => sum + s.get().length, 0);
+  if (totalChars === 0) return undefined;
+  // Inverse of the chars/4 estimate, shaved 10% for the markers and rounding.
+  const targetChars = Math.floor(budget * 4 * 0.9);
+  if (targetChars >= totalChars) return undefined; // bulk is not in text
+  const scale = targetChars / totalChars;
+  for (const s of slots) {
+    const text = s.get();
+    s.set(elideMiddle(text, Math.floor(text.length * scale)));
+  }
+  return estimateTokens(clone) <= budget ? clone : undefined;
+}


### PR DESCRIPTION
## Root cause

When a long `openai-codex` conversation compacts, pi serializes the history to summarize into ONE content string. The compaction guard (HOU-709) bounds that input by estimated tokens (chars/4) against the model's context window — but chars/4 UNDER-counts dense content, so the guard's bounded request could still overflow codex's real 272k window. Codex rejected it ("Your input exceeds the context window of this model"), the guard's catch treated that like a transient failure and deferred to pi's default — which serialized the FULL history unbounded. Sentry breadcrumbs on HOUSTON-APP-56R show exactly this chain: the guard's defer warning immediately followed by the 400.

## What the 31 MB was

The full pre-cut conversation history, serialized by pi's `generateSummary` into a single `input[0].content[0].text` string of 31,056,249 chars — over OpenAI's hard 10,485,760-char per-string cap. Because compaction failed on every retry, the history could never shrink, so every later turn re-sent the same doomed request (249 events since Aug 5) until the user hit context limits with no recovery.

## Bounding strategy

All at the existing seam (the `session_before_compact` guard) — pi's own `compact()` still does the summarization, so file-op tracking / split-turn handling / previous-summary merge are unchanged:

- **Hard ceiling** (`summarizer-budget.ts`): the input budget is now `min(0.7 × contextWindow, 2,000,000 estimated tokens)`. The estimate is exactly chars/4, so the ceiling caps the serialized conversation at ~8M chars — comfortably under the 10,485,760-char cap. It only binds for windows above ~2.9M tokens; every current model keeps its existing window-fraction budget, so healthy compactions are untouched (under-budget inputs still pass through to pi's default byte-identical).
- **Adaptive retry**: a provider SIZE rejection of the bounded request (window overflow or "string too long", detected via pi-ai's overflow patterns) now halves the budget and retries (up to 3 attempts) instead of deferring — deferring hands pi's default a strictly LARGER input that is guaranteed to fail. Halving adapts to the real tokenizer density (~2.5 chars/token in the prod event; one halving suffices).
- **Deterministic terminal**: if every halved attempt is size-rejected, the guard compacts deterministically (previous summary + drop notice, no model call) — the same posture it already had for "nothing fits" — so the conversation always unwedges.
- **Elision instead of total loss**: when the single newest message alone overflows the budget, its middle is elided (head + tail kept with an explicit `[... N characters elided ...]` marker) rather than dropping ALL history to the deterministic path.
- **Transient failures unchanged**: rate limits / network errors still defer to pi's default (`[compaction-guard] bounded summarization failed; deferring to pi's default`), so the turn fails with the real reason and the next turn re-enters the guard. Every bounding attempt logs a one-line INFO with sizes only.
- **Classifier** (`provider-error.ts`): OpenAI's `string too long` rejection now classifies as `context_overflow` (token numbers absent → nulls) instead of `unknown` — the honest chat card, and it demotes from a Sentry ERROR to an expected-kind warning breadcrumb. No other behavior keys on the kind for this shape (`learnCustomContextWindow` needs a parsed window and the `openai-compatible` provider).

## Tests

- `compaction-guard.test.ts` (20): under-budget pass-through is byte-identical (same objects, untouched content, pi default runs); over-budget input is bounded under the budget with the drop notice; a 40MB synthetic conversation at a huge window serializes (via pi's real `serializeConversation`) to under 10,485,760 chars; size-rejection → halved retry (call args pinned); persistent size rejection → deterministic compaction after 3 attempts, never a deferral; transient failure → defer path pinned; elision markers present and originals never mutated; no-model / zero-window / no-auth declines unchanged.
- `provider-error.test.ts`: the verbatim prod message classifies `context_overflow` with null token counts.
- Full `@houston/runtime` suite: 1153 passed. `pnpm check` (Biome) clean, workspace typecheck clean. Host untouched.

Fixes PRODUCT-1394