### PR TITLE
Stop stale-roster 'agent not found' 404s from the cross-agent missions sweep (PRODUCT-1400)

### DIFF
--- a/app/src/hooks/queries/all-conversations-sweep.ts
+++ b/app/src/hooks/queries/all-conversations-sweep.ts
@@ -10,6 +10,7 @@
 
 import type { FailedAgentRead } from "@houston-ai/engine-client";
 import type { QueryClient } from "@tanstack/react-query";
+import { isAgentGoneError } from "../../lib/agent-gone";
 import {
   NO_SWEEP_RECOVERY,
   type PartialSweepSurface,
@@ -162,10 +163,15 @@ export async function sweepWithRetry(agentPaths: string[]) {
     } catch (err) {
       const next = planSweepAttempt(attempt, isTransientEngineError(err));
       if (next.surface) {
-        await surfaceEngineError("list_all_conversations", err, {
-          agentCount: agentPaths.length,
-          attempts: attempt + 1,
-        });
+        // Same silence as the engine layer's (`tauriConversations.listAll`):
+        // a sweep where EVERY agent answered "agent not found" is a stale
+        // roster mid-heal, not a bug — logged, no toast, no report.
+        await surfaceEngineError(
+          "list_all_conversations",
+          err,
+          { agentCount: agentPaths.length, attempts: attempt + 1 },
+          { silence: isAgentGoneError },
+        );
         throw err;
       }
       await new Promise((resolve) => setTimeout(resolve, next.retryInMs));

--- a/app/src/hooks/queries/use-conversations.ts
+++ b/app/src/hooks/queries/use-conversations.ts
@@ -4,10 +4,12 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { useEffect } from "react";
+import { agentRosterSettled } from "../../lib/agent-gone";
 import { latestCachedAllConversations } from "../../lib/all-conversations-cache";
 import { mergePartialSweep } from "../../lib/all-conversations-recovery";
 import { queryKeys } from "../../lib/query-keys";
 import { type RawConversation, tauriChat } from "../../lib/tauri";
+import { useAgentStore } from "../../stores/agents";
 import {
   recoverFromSweep,
   retargetSweepRecovery,
@@ -26,6 +28,14 @@ export function useAllConversations(agentPaths: string[]) {
   const queryClient = useQueryClient();
   const queryKey = queryKeys.allConversations(agentPaths);
   const roster = queryKey.join("\0");
+  // Gated on the roster having settled for the CURRENT space, like the
+  // skills-manifest fan-out (HOUSTON-APP-544): a space switch wipes the query
+  // cache and refires every mounted query, but `agentPaths` still names the
+  // PREVIOUS space's agents until `loadAgents` re-resolves — a fan-out in that
+  // window asks the new org about agents it never had, and every read
+  // answers `404 agent not found` (HOUSTON-APP-4WR). Data already held is
+  // kept while the gate is closed; the fresh roster gets its own key.
+  const rosterSettled = useAgentStore(agentRosterSettled);
   // A space switch (or any roster change) retires the previous roster's
   // recovery run and its pending re-sweep the moment it happens — waiting for
   // the next sweep to settle would leave a dead roster's timer free to
@@ -48,7 +58,7 @@ export function useAllConversations(agentPaths: string[]) {
       recoverFromSweep(failedAgents, roster, queryClient);
       return merged;
     },
-    enabled: agentPaths.length > 0,
+    enabled: agentPaths.length > 0 && rosterSettled,
     // keepPreviousData, PLUS the newest disk-restored roster variant: the key
     // embeds every agent's folderPath, so the IndexedDB-restored entry only
     // re-attaches on an exact roster match — any drift would blank the sidebar

--- a/app/src/lib/agent-gone.ts
+++ b/app/src/lib/agent-gone.ts
@@ -103,3 +103,22 @@ export function makeAgentGoneHealTrigger(
     void heal(currentWorkspaceId(), true);
   };
 }
+
+/**
+ * Split a cross-agent sweep's failed reads into the agents the server no
+ * longer knows (roster stale — see {@link isAgentGoneError}) and the real
+ * failures. A gone agent's read is not "missions unread": there is nothing to
+ * re-sweep or report, only a roster to heal, so the sweep's recovery layer
+ * (`hooks/queries/all-conversations-sweep.ts`) must never see it as a partial
+ * failure — that made every stale roster a red toast, a Sentry report, and
+ * three doomed re-sweeps (HOUSTON-APP-4WR / 58R / 55E).
+ */
+export function partitionAgentGoneReads<T extends { reason: unknown }>(
+  failed: readonly T[],
+): { gone: T[]; failed: T[] } {
+  const gone: T[] = [];
+  const rest: T[] = [];
+  for (const read of failed)
+    (isAgentGoneError(read.reason) ? gone : rest).push(read);
+  return { gone, failed: rest };
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -28,7 +28,7 @@ import type {
 } from "@houston-ai/engine-client";
 import { shouldUseClaudeDesktopLogin } from "../components/shell/provider-login-url";
 import { actingUser } from "./acting-user";
-import { isAgentGoneError } from "./agent-gone";
+import { isAgentGoneError, partitionAgentGoneReads } from "./agent-gone";
 import { isAgentNameConflictError } from "./agent-name-conflict";
 import {
   blockWriteWhileWarming,
@@ -159,8 +159,9 @@ export async function surfaceEngineError(
   label: string,
   err: unknown,
   context?: Record<string, unknown>,
+  options?: Pick<EngineCallOptions, "silence">,
 ): Promise<void> {
-  await surfaceError(label, err, context);
+  await surfaceError(label, err, context, options);
 }
 
 async function surfaceError(
@@ -1216,19 +1217,41 @@ export const tauriConversations = {
     // so `call()` raises no toast for it — the query layer owns that surface
     // (one toast per incomplete sweep, plus a bounded re-sweep). Only a sweep
     // where EVERY agent failed rejects, and that keeps the toast + capture.
+    //
+    // A PASSIVE read like every other roster-driven one (`passiveAgentRead`):
+    // an agent the server no longer knows (`404 agent not found` — the local
+    // roster is stale after a space switch or a delete on another device) is
+    // not a failed read of OUR agent. Its 404 is silenced and the roster
+    // heals; in a partial sweep the gone agents leave `failedAgents` (nothing
+    // to re-sweep, nothing to report — HOUSTON-APP-4WR / 58R / 55E), and a
+    // sweep where EVERY agent is gone rejects quietly (the caller's surface
+    // silences it too) so the cache keeps the last real rows for the roster
+    // reload that follows. Every real failure keeps its loud path.
     return call<AllConversationsSweep>(
       "list_all_conversations",
       async () => {
         const { conversations, failedAgents } =
           await getEngine().listAllConversations(reachable);
+        const { gone, failed } = partitionAgentGoneReads(failedAgents);
+        if (gone.length > 0) {
+          logger.warn(
+            `[engine:list_all_conversations] ${gone.length} agent(s) gone from the roster: ${gone
+              .map((g) => g.agentPath)
+              .join(", ")}`,
+          );
+          healStaleRosterFromError(gone[0].reason);
+        }
         return {
           items: conversations.map(conversationToRaw),
-          failedAgents,
+          failedAgents: failed,
         };
       },
       undefined,
-      options,
-    );
+      { silence: isAgentGoneError, ...options },
+    ).catch((err) => {
+      healStaleRosterFromError(err);
+      throw err;
+    });
   },
 };
 

--- a/app/tests/agent-gone.test.ts
+++ b/app/tests/agent-gone.test.ts
@@ -5,6 +5,7 @@ import {
   isAgentGoneError,
   makeAgentGoneHealTrigger,
   makeRosterHealer,
+  partitionAgentGoneReads,
 } from "../src/lib/agent-gone.ts";
 
 describe("isAgentGoneError", () => {
@@ -163,5 +164,55 @@ describe("makeAgentGoneHealTrigger", () => {
     );
     trigger(agentGone);
     assert.deepEqual(calls, [null]);
+  });
+});
+
+describe("partitionAgentGoneReads", () => {
+  const gone = (agentPath: string) => ({
+    agentPath,
+    reason: Object.assign(new Error("agent not found (engine error 404)"), {
+      status: 404,
+    }),
+  });
+  const waking = (agentPath: string) => ({
+    agentPath,
+    reason: Object.assign(new Error("engine unavailable (engine error 503)"), {
+      status: 503,
+    }),
+  });
+
+  it("splits a stale roster's 404s from the real failures", () => {
+    const { gone: g, failed } = partitionAgentGoneReads([
+      gone("a"),
+      waking("b"),
+      gone("c"),
+    ]);
+    assert.deepEqual(
+      g.map((r) => r.agentPath),
+      ["a", "c"],
+    );
+    assert.deepEqual(
+      failed.map((r) => r.agentPath),
+      ["b"],
+    );
+  });
+
+  it("leaves a sweep with no gone agents untouched", () => {
+    const reads = [waking("a"), waking("b")];
+    const { gone: g, failed } = partitionAgentGoneReads(reads);
+    assert.deepEqual(g, []);
+    assert.deepEqual(failed, reads);
+  });
+
+  it("classifies an all-gone sweep as nothing to re-sweep", () => {
+    // The space-switch shape (HOUSTON-APP-4WR): every agent of the previous
+    // space's roster answers 404 under the new org.
+    const { gone: g, failed } = partitionAgentGoneReads([gone("a"), gone("b")]);
+    assert.equal(g.length, 2);
+    assert.deepEqual(failed, []);
+  });
+
+  it("is empty-safe", () => {
+    assert.deepEqual(partitionAgentGoneReads([]), { gone: [], failed: [] });
   });
 });

--- a/app/tests/partial-sweep-surface.test.ts
+++ b/app/tests/partial-sweep-surface.test.ts
@@ -26,11 +26,13 @@ const wakingError = () => {
 /** WebKit's fetch transport rejection — the device dropped offline. */
 const offlineError = () => new TypeError("Load failed");
 
-/** A read failure that IS a bug (or a deleted agent): must keep reporting. */
+/** A read failure that IS a bug: must keep reporting. (A deleted agent's
+ *  `404 agent not found` never reaches this layer any more — the engine call
+ *  layer partitions it out and heals the roster, `partitionAgentGoneReads`.) */
 const realError = () => {
-  const err = new Error("agent not found (engine error 404)");
+  const err = new Error("internal error (engine error 500)");
   err.name = "HoustonEngineError";
-  return Object.assign(err, { status: 404 });
+  return Object.assign(err, { status: 500 });
 };
 
 describe("representativeSweepFailure", () => {


### PR DESCRIPTION
Fixes PRODUCT-1400 (Sentry HOUSTON-APP-4WR; same shape in 55E / 54C, and the partial-sweep twin 58R).

## Root cause

The cross-agent missions sweep (`list_all_conversations`) was the last roster-driven read left outside the agent-gone contract that #1295 (skills manifests) and #1314 (every other passive per-agent read) established.

A space switch wipes the query cache and refires the mounted sweep while `agentPaths` still names the PREVIOUS space's roster; under the new `x-houston-org` every agent answers `404 agent not found`. The same happens for an agent deleted/unshared on another device. Two loud paths:

- **All agents gone** → the adapter throws → `sweepWithRetry` (404 is not transient) surfaced it as a red toast + Sentry report (4WR / 55E / 54C). Sentry replay: a mobile web user opens the space switcher, taps another space, `EventStreamReconnected`, 21 `/agents/<id>/activities` reads 404, one red toast.
- **Some agents gone** → the gone agents were counted as "missions unread": red toast + report (`list_all_conversations_partial`, 58R on 0.6.1–0.6.3), three doomed re-sweeps, then the `_stuck` escalation report.

## Fix (app/ only)

- `useAllConversations` is gated on `agentRosterSettled` (same gate as the manifest fan-out), so the switch window never fires the doomed sweep in the first place. Data already held stays; the fresh roster gets its own key.
- `tauriConversations.listAll` becomes a passive read: agent-gone 404s are silenced (still logged) and trigger the shared roster heal; gone agents are partitioned out of `failedAgents` (`partitionAgentGoneReads`, node-tested) so the recovery layer only ever sees real failures — nothing to re-sweep, nothing to report.
- `surfaceEngineError` accepts the same `silence` predicate so `sweepWithRetry`'s deferred all-failed surface honors it.

Every non-404 failure keeps its existing loud/waking/connectivity path.

## Verification

Before (0.6.3): sign in on cloud with two spaces (personal + a team) that hold different agents. Open Mission Control, switch space in the sidebar. Repro: red "couldn't load some missions" toast, `[toast:list_all_conversations] agent not found (engine error 404)` in the log, a Sentry event under 4WR (or 58R when only part of the roster differs). Same on any device when another device deletes an agent from the current roster.

After: same switch → no toast; the log tail shows `[engine:list_all_conversations] agent not found (engine error 404)` (silenced) or `N agent(s) gone from the roster: …`, the board keeps painting the last rows, and the new space's roster paints on its own. Sentry: no new events under 4WR / 55E / 54C / 58R from `≥` the release carrying this.

- `cd app && pnpm test` (3662 pass, incl. new `partitionAgentGoneReads` cases)
- `pnpm typecheck`, `pnpm check` clean
