### PR TITLE
Latch the runtime launcher closed on host shutdown (PRODUCT-1399)

### DIFF
--- a/packages/host/src/channel/probe-wake.ts
+++ b/packages/host/src/channel/probe-wake.ts
@@ -1,5 +1,10 @@
 import type { ServerResponse } from "node:http";
-import type { ChannelCtx, RuntimeEndpoint, RuntimeLauncher } from "../ports";
+import {
+  type ChannelCtx,
+  LauncherClosedError,
+  type RuntimeEndpoint,
+  type RuntimeLauncher,
+} from "../ports";
 import { json } from "../routes/http";
 
 /**
@@ -53,7 +58,8 @@ export async function wakeForDispatch(
   res: ServerResponse,
 ): Promise<RuntimeEndpoint | null> {
   const wake = launcher.ensureAwake(ctx.agent);
-  if (method !== "GET" || !PROBE_ROUTES.has(rest)) return wake;
+  if (method !== "GET" || !PROBE_ROUTES.has(rest))
+    return wake.catch((err) => rejectIfClosed(err, res));
 
   // A boot that fails after this request has been answered has no one left to
   // tell; the next probe re-triggers the spawn and surfaces the failure then.
@@ -68,6 +74,8 @@ export async function wakeForDispatch(
   try {
     const endpoint = await Promise.race([wake, tooSlow]);
     if (endpoint) return endpoint;
+  } catch (err) {
+    return rejectIfClosed(err, res);
   } finally {
     clearTimeout(timer);
   }
@@ -77,5 +85,17 @@ export async function wakeForDispatch(
     { error: "the agent's runtime is still starting, try again shortly" },
     { "Retry-After": "2" },
   );
+  return null;
+}
+
+/**
+ * A host mid-shutdown refuses to spawn (launcher/process.ts, PRODUCT-1399).
+ * That is not a runtime failure but a "not here, not now": answer 503 +
+ * Retry-After so the client retries against the replacement pod (or the next
+ * app start) instead of rendering a 500. Any other rejection is the caller's.
+ */
+function rejectIfClosed(err: unknown, res: ServerResponse): null {
+  if (!(err instanceof LauncherClosedError)) throw err;
+  json(res, 503, { error: err.message }, { "Retry-After": "2" });
   return null;
 }

--- a/packages/host/src/channel/proxy-probe.test.ts
+++ b/packages/host/src/channel/proxy-probe.test.ts
@@ -2,7 +2,11 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { MemoryCredentialStore } from "../credentials/store";
 import type { Agent, Workspace } from "../domain/types";
-import type { ForwardRequest, RuntimeEndpoint } from "../ports";
+import {
+  type ForwardRequest,
+  LauncherClosedError,
+  type RuntimeEndpoint,
+} from "../ports";
 import { ProxyChannel } from "./proxy";
 
 /**
@@ -307,4 +311,74 @@ test("a boot that fails AFTER the probe was answered is not an unhandled rejecti
   } finally {
     process.off("unhandledRejection", unhandled);
   }
+});
+
+// PRODUCT-1399: a host mid-shutdown refuses to spawn. That is a "retry
+// elsewhere", not a runtime failure — both a probe and a full route answer 503
+// + Retry-After instead of falling into the server's generic 500.
+function closedLauncher() {
+  return {
+    async ensureAwake(): Promise<RuntimeEndpoint> {
+      throw new LauncherClosedError();
+    },
+    async sleep() {},
+    async destroy() {},
+    async status() {
+      return "asleep" as const;
+    },
+  };
+}
+
+test("a probe against a shutting-down host answers 503 + Retry-After (PRODUCT-1399)", async () => {
+  const forwarded: ForwardRequest[] = [];
+  const channel = new ProxyChannel({
+    launcher: closedLauncher(),
+    proxy: {
+      async forward(_endpoint, req) {
+        forwarded.push(req);
+      },
+    },
+    credentials: new MemoryCredentialStore(),
+    forwardActingHeader: false,
+  });
+  const r = res();
+  await channel.dispatch(
+    ctx,
+    "GET",
+    "providers",
+    urlFor("providers"),
+    request(),
+    asServerResponse(r),
+  );
+  expect(r.statusCode).toBe(503);
+  expect(r.headers["Retry-After"]).toBe("2");
+  expect(JSON.parse(r.body)).toEqual({
+    error: "the host is shutting down; retry shortly",
+  });
+  expect(forwarded).toEqual([]);
+});
+
+test("a non-probe route against a shutting-down host answers 503 too, not a 500", async () => {
+  const forwarded: ForwardRequest[] = [];
+  const channel = new ProxyChannel({
+    launcher: closedLauncher(),
+    proxy: {
+      async forward(_endpoint, req) {
+        forwarded.push(req);
+      },
+    },
+    credentials: new MemoryCredentialStore(),
+    forwardActingHeader: false,
+  });
+  const r = res();
+  await channel.dispatch(
+    ctx,
+    "GET",
+    "events",
+    urlFor("events"),
+    request(),
+    asServerResponse(r),
+  );
+  expect(r.statusCode).toBe(503);
+  expect(forwarded).toEqual([]);
 });

--- a/packages/host/src/launcher/process.test.ts
+++ b/packages/host/src/launcher/process.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "vitest";
 import type { Agent } from "../domain/types";
+import { LauncherClosedError } from "../ports";
 import {
   ProcessLauncher,
   type ProcessLauncherOptions,
@@ -413,4 +414,75 @@ test("multiple agents get distinct ports + processes", async () => {
   const a = await launcher.ensureAwake(agent("a"));
   const b = await launcher.ensureAwake(agent("b"));
   expect(a.baseUrl).not.toBe(b.baseUrl);
+});
+
+// PRODUCT-1399: shutdownAllAndWait clears the live-set BEFORE the children
+// have exited, so a dispatch landing in that drain window (a provider poll, a
+// routine, an SSE resume) used to find no running entry and respawn a runtime
+// the exiting host never killed — an orphan that, on a serve-mode pod, booted
+// into a host whose listener was already closed and logged an ECONNREFUSED
+// per known provider (41 Sentry errors per pod termination).
+test("ensureAwake during shutdownAllAndWait's drain is REFUSED, never respawned (PRODUCT-1399)", async () => {
+  let exitCb: (() => void) | undefined;
+  let spawned = 0;
+  const spawner: RuntimeSpawner = {
+    spawn() {
+      spawned += 1;
+      return {
+        port: 5000 + spawned,
+        // The child exits 30ms after SIGTERM — a realistic drain window.
+        kill: () => setTimeout(() => exitCb?.(), 30),
+        onExit: (cb) => {
+          exitCb = cb;
+        },
+      };
+    },
+  };
+  const launcher = new ProcessLauncher(opts(spawner));
+  await launcher.ensureAwake(agent("polled"));
+
+  const shutdown = launcher.shutdownAllAndWait(5_000);
+  // Arrives mid-drain (child alive, live-set already cleared).
+  await expect(launcher.ensureAwake(agent("polled"))).rejects.toBeInstanceOf(
+    LauncherClosedError,
+  );
+  await shutdown;
+  // And stays refused after the drain — a closed launcher never spawns again.
+  await expect(launcher.ensureAwake(agent("polled"))).rejects.toThrow(
+    "shutting down",
+  );
+  expect(spawned).toBe(1);
+  expect(await launcher.status("polled")).toBe("asleep");
+});
+
+test("shutdownAll (the sync variant) latches the launcher the same way", async () => {
+  const { spawner, spawns, killed } = recordingSpawner();
+  const launcher = new ProcessLauncher(opts(spawner));
+  await launcher.ensureAwake(agent("a"));
+  launcher.shutdownAll();
+  expect(killed).toEqual([5000]);
+  await expect(launcher.ensureAwake(agent("b"))).rejects.toBeInstanceOf(
+    LauncherClosedError,
+  );
+  expect(spawns).toHaveLength(1);
+});
+
+test("a boot that entered BEFORE shutdown but had not spawned yet is refused, so its child cannot outlive the sweep", async () => {
+  const { spawner, spawns } = recordingSpawner();
+  let releasePort!: () => void;
+  const launcher = new ProcessLauncher(
+    opts(spawner, {
+      // The one await between "enter" and "spawn": the port allocation.
+      allocatePort: () =>
+        new Promise<number>((resolve) => {
+          releasePort = () => resolve(0);
+        }),
+    }),
+  );
+  const boot = launcher.ensureAwake(agent("late"));
+  await new Promise((r) => setTimeout(r, 0)); // parked on allocatePort
+  await launcher.shutdownAllAndWait();
+  releasePort();
+  await expect(boot).rejects.toBeInstanceOf(LauncherClosedError);
+  expect(spawns).toHaveLength(0); // no child ever spawned past the sweep
 });

--- a/packages/host/src/launcher/process.ts
+++ b/packages/host/src/launcher/process.ts
@@ -1,6 +1,11 @@
 import { createServer } from "node:net";
 import type { Agent, AgentId } from "../domain/types";
-import type { RuntimeEndpoint, RuntimeLauncher, RuntimeState } from "../ports";
+import {
+  LauncherClosedError,
+  type RuntimeEndpoint,
+  type RuntimeLauncher,
+  type RuntimeState,
+} from "../ports";
 
 /**
  * A spawned runtime process. The launcher only needs its port + a way to kill
@@ -145,6 +150,16 @@ export class ProcessLauncher implements RuntimeLauncher {
   private readonly booting = new Map<AgentId, Promise<RuntimeEndpoint>>();
   /** Refcounted rename latch — see hold(). */
   private readonly held = new Map<AgentId, number>();
+  /**
+   * Set once shutdownAll* has run: this launcher spawns nothing ever again.
+   * shutdownAllAndWait clears the live-set BEFORE the children have exited,
+   * so without the latch a dispatch landing in that drain window (the
+   * client's provider poll, a routine, the SSE resume) found no running entry
+   * and respawned a runtime the exiting host never kills — an orphan that,
+   * on a serve-mode pod, booted into a host whose listener was already
+   * closed and logged an ECONNREFUSED per known provider (PRODUCT-1399).
+   */
+  private closed = false;
   private readonly allocatePort: () => Promise<number>;
   private readonly waitHealthy: (port: number, token: string) => Promise<void>;
 
@@ -154,6 +169,7 @@ export class ProcessLauncher implements RuntimeLauncher {
   }
 
   async ensureAwake(agent: Agent): Promise<RuntimeEndpoint> {
+    if (this.closed) throw new LauncherClosedError();
     // Held = a rename is moving this id's directory RIGHT NOW. Refuse loudly:
     // the app's own reconnect storm (SSE resume within ~500ms, watchdog polls,
     // provider probes) arrives with the old id during the quiesce window, and
@@ -224,6 +240,10 @@ export class ProcessLauncher implements RuntimeLauncher {
       throw new Error(
         `agent '${agent.id}' is being renamed — retry with its new id`,
       );
+    // Same gap for shutdown: a boot that entered before shutdownAll* ran is
+    // not in the live-set yet, so its child would be spawned AFTER the sweep
+    // that kills everything — an orphan by construction.
+    if (this.closed) throw new LauncherClosedError();
     const cred = this.opts.credentialServing;
     const handle = this.opts.spawner.spawn({
       workspaceDir: this.opts.workspaceDirFor(agent),
@@ -369,6 +389,7 @@ export class ProcessLauncher implements RuntimeLauncher {
   /** Kill every running runtime — called on supervisor shutdown so a restart
    *  doesn't orphan child processes (which would hold ports + the agent dir). */
   shutdownAll(): void {
+    this.closed = true;
     for (const r of this.running.values()) r.handle.kill();
     this.running.clear();
   }
@@ -381,6 +402,9 @@ export class ProcessLauncher implements RuntimeLauncher {
    * (test stubs) count as already exited.
    */
   async shutdownAllAndWait(timeoutMs = 5_000): Promise<void> {
+    // Latch FIRST: from here on ensureAwake refuses (LauncherClosedError)
+    // instead of respawning into the drain window below.
+    this.closed = true;
     const waits: Promise<void>[] = [];
     for (const r of this.running.values()) {
       const { onExit } = r.handle;

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -68,6 +68,20 @@ export class ApiKeyRejectedError extends Error {
   }
 }
 
+/**
+ * The launcher is shutting down (pod termination, app quit) and refuses to
+ * spawn: a runtime born now would be orphaned by the exiting host and, on
+ * a serve-mode pod, boot into a host whose listener is already closed
+ * (PRODUCT-1399). Routes answer 503 so the client retries against the
+ * replacement pod / the next app start.
+ */
+export class LauncherClosedError extends Error {
+  constructor() {
+    super("the host is shutting down; retry shortly");
+    this.name = "LauncherClosedError";
+  }
+}
+
 /** Persistence for workspaces + agents. Impls: MemoryWorkspaceStore, PgWorkspaceStore. */
 export interface WorkspaceStore {
   /** The user's personal workspace, creating it on first access (lazy provisioning). */


### PR DESCRIPTION
## Summary

Sentry HOUSTON-APP-4YV (`[serve] credential <id>: fetch failed (cause: ECONNREFUSED)`) — PRODUCT-1399.

The original root cause of this Sentry group (probe fan-out with no retry, PRODUCT-1324) is already fixed and deployed (release `b9c4c6da`, ~Aug 14). What is left is a small, exact residual: **41 events per occurrence, one pod per day**, all from the same mechanism, which pod logs pin down:

1. Pod termination (k8s `ScaleDown` / `Killing`) → `host.stop()` → `launcher.shutdownAllAndWait()` SIGTERMs the runtime and **clears the live-set before the child has exited**.
2. A dispatch lands in that 3–5 s drain window (the client's `/providers` + `/auth/status` poll every 15–60 s, an SSE resume, a routine): `ensureAwake` finds no running entry and **respawns a fresh runtime**.
3. The host closes its listener; the new runtime's first serve sync hits `ECONNREFUSED` for all 41 known providers → 41 error events, and the orphaned child keeps the dying pod's in-flight request alive.

On the desktop the same race spawns a runtime the exiting host never kills (an orphan holding the agent dir + a port).

## Fix

- `ProcessLauncher` latches `closed` on `shutdownAll` / `shutdownAllAndWait`; `ensureAwake` refuses with a typed `LauncherClosedError` (re-checked after the port-allocation await, the one gap where a boot entered before shutdown could still spawn past the sweep).
- `wakeForDispatch` maps `LauncherClosedError` → **503 + Retry-After** so the client retries against the replacement pod / next app start instead of a generic 500.

Host-only, ~30 lines, no wire/protocol change. Rides the next regular engine roll — no dedicated roll needed.

## Tests

- drain-window `ensureAwake` is refused, never respawned; stays refused after the drain
- sync `shutdownAll` latches the same way
- a boot parked on `allocatePort` when shutdown starts is refused (no child past the sweep)
- probe route and non-probe route answer 503 for a closed launcher

`pnpm --filter @houston/host test` (1513 pass), typecheck, `pnpm check`, `pnpm check:boundaries` all green.

## Before / after

**Before:** in Cloud Logging for any pod evicted while a client polls (`resource.labels.pod_name=<pod>`), the sequence `runtime shutdown requested signal=SIGTERM` → ~3–5 s later a NEW `runtime listening` → `[serve] credential <id>: fetch failed (cause: ECONNREFUSED)` × 41 → `[serve] applied central credentials: (none)`. Sentry 4YV gains 41 events per such pod.

**After:** the same eviction shows SIGTERM → no second `runtime listening`; the in-flight poll gets a `503 {"error":"the host is shutting down; retry shortly"}` and the pod exits promptly. Sentry 4YV's ECONNREFUSED family stops growing on the rolled release (watch `release:engine-pod@<sha>` after the roll).
