### PR TITLE
Log a uniformly refused serve sweep as ONE incident, not one error per provider (PRODUCT-1399)

### DIFF
--- a/packages/runtime/src/auth/serve-log.test.ts
+++ b/packages/runtime/src/auth/serve-log.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, expect, test, vi } from "vitest";
 import {
   logServeProbeFailure,
+  logServeSweepFailure,
   noteServeProbeOk,
+  noteServeSweepOk,
   resetServeProbeLog,
 } from "./serve-log";
 
@@ -47,4 +49,29 @@ test("recovery logs once and re-arms the error for the next incident", () => {
 test("a clean probe with no prior failure stays silent", () => {
   noteServeProbeOk("anthropic");
   expect(info).not.toHaveBeenCalled();
+});
+
+test("a uniformly failed sweep is ONE incident: one error, warnings on repeat, one recovery line", () => {
+  logServeSweepFailure(41, "fetch failed (cause: ECONNREFUSED)");
+  logServeSweepFailure(41, "fetch failed (cause: ECONNREFUSED)");
+  expect(error).toHaveBeenCalledOnce();
+  expect(error).toHaveBeenCalledWith(
+    "[serve] control plane unreachable for all 41 providers: fetch failed (cause: ECONNREFUSED)",
+  );
+  expect(warn).toHaveBeenCalledOnce();
+  noteServeSweepOk();
+  expect(info).toHaveBeenCalledWith("[serve] control plane reachable again");
+  noteServeSweepOk(); // silent without a prior incident
+  expect(info).toHaveBeenCalledOnce();
+});
+
+test("the sweep incident is tracked apart from per-provider failures", () => {
+  logServeSweepFailure(41, "fetch failed (cause: ECONNREFUSED)");
+  logServeProbeFailure("anthropic", "fetch failed (cause: ECONNREFUSED)");
+  expect(error).toHaveBeenCalledTimes(2);
+  noteServeProbeOk("anthropic");
+  expect(info).toHaveBeenCalledWith("[serve] credential anthropic recovered");
+  expect(info).not.toHaveBeenCalledWith(
+    "[serve] control plane reachable again",
+  );
 });

--- a/packages/runtime/src/auth/serve-log.ts
+++ b/packages/runtime/src/auth/serve-log.ts
@@ -9,6 +9,14 @@
  */
 const lastFailureDetail = new Map<string, string>();
 
+/**
+ * Dedup key for a sweep in which EVERY probe failed the same way. That is not
+ * N provider incidents, it is one: the control plane itself is unreachable
+ * (a host mid-shutdown, a gateway outage), and logging it once per provider
+ * turned each such sweep into 41 Sentry events (PRODUCT-1399).
+ */
+const SWEEP_KEY = "*";
+
 export function logServeProbeFailure(provider: string, detail: string): void {
   if (lastFailureDetail.get(provider) === detail) {
     console.warn(`[serve] credential ${provider} still failing: ${detail}`);
@@ -16,6 +24,28 @@ export function logServeProbeFailure(provider: string, detail: string): void {
   }
   lastFailureDetail.set(provider, detail);
   console.error(`[serve] credential ${provider}: ${detail}`);
+}
+
+/**
+ * A whole sweep failed identically: one error for the incident (deduped like a
+ * provider's), the per-provider details staying out of Sentry. Callers pass
+ * every probe's shared detail; a sweep that recovers or fails unevenly goes
+ * back through the per-provider path.
+ */
+export function logServeSweepFailure(count: number, detail: string): void {
+  const line = `control plane unreachable for all ${count} providers: ${detail}`;
+  if (lastFailureDetail.get(SWEEP_KEY) === detail) {
+    console.warn(`[serve] ${line} (still failing)`);
+    return;
+  }
+  lastFailureDetail.set(SWEEP_KEY, detail);
+  console.error(`[serve] ${line}`);
+}
+
+/** Called after any sweep that did NOT fail uniformly (some probe answered). */
+export function noteServeSweepOk(): void {
+  if (lastFailureDetail.delete(SWEEP_KEY))
+    console.info("[serve] control plane reachable again");
 }
 
 /** Called when a probe answers cleanly (served or authoritative not-connected). */

--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -803,6 +803,68 @@ test("a probe that fails both attempts logs ONE error with the cause code and re
   }
 });
 
+test("a sweep where EVERY probe is refused logs ONE error, not one per provider (PRODUCT-1399)", async () => {
+  // A runtime whose host has closed under it (pod shutdown), or a gateway
+  // outage: 41 identical ECONNREFUSED verdicts are one incident. Logging each
+  // made every such sweep 41 Sentry events in HOUSTON-APP-4YV.
+  resetServeProbeLog();
+  let refuse = true;
+  let probeCalls = 0;
+  const fetchImpl = (async () => {
+    probeCalls++;
+    if (refuse)
+      throw Object.assign(new TypeError("fetch failed"), {
+        cause: Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:4318"), {
+          code: "ECONNREFUSED",
+        }),
+      });
+    return notConnected404();
+  }) as unknown as typeof globalThis.fetch;
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warns = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const infos = vi.spyOn(console, "info").mockImplementation(() => {});
+  const serveErrors = () =>
+    errors.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.startsWith("[serve]"));
+  try {
+    await withServeMode(fetchImpl, async () => {
+      const providerCount = new Set([
+        ...PROVIDERS.map((p) => p.id),
+        ...piApiKeyProviderIds(),
+      ]).size;
+      expect(await syncServedCredential()).toEqual([]);
+      expect(probeCalls).toBe(providerCount * 2); // attempt + one retry each
+      expect(serveErrors()).toEqual([
+        `[serve] control plane unreachable for all ${providerCount} providers: fetch failed (cause: ECONNREFUSED)`,
+      ]);
+
+      // The identical repeat is a WARN breadcrumb, never a second event.
+      expect(await syncServedCredential()).toEqual([]);
+      expect(serveErrors()).toHaveLength(1);
+      expect(
+        warns.mock.calls.some((c) =>
+          String(c[0]).includes("control plane unreachable for all"),
+        ),
+      ).toBe(true);
+
+      // Recovery is logged once and re-arms the incident.
+      refuse = false;
+      expect(await syncServedCredential()).toEqual([]);
+      expect(infos).toHaveBeenCalledWith(
+        "[serve] control plane reachable again",
+      );
+      refuse = true;
+      expect(await syncServedCredential()).toEqual([]);
+      expect(serveErrors()).toHaveLength(2);
+    });
+  } finally {
+    errors.mockRestore();
+    warns.mockRestore();
+    infos.mockRestore();
+  }
+}, 30_000);
+
 test("selectExportCredential without a provider falls back to the first OAuth credential", () => {
   const auth: Record<string, PiCred> = {
     "openai-codex": oauth("AT-codex", "RT-codex"),

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -14,8 +14,13 @@ import {
 } from "./auth-file";
 import { scrubSettledCaptureAt } from "./capture-settlement";
 import { bindEmptyRefreshServeSync } from "./empty-refresh-guard";
-import { logServeProbeFailure, noteServeProbeOk } from "./serve-log";
-import { probeProviders } from "./serve-probe";
+import {
+  logServeProbeFailure,
+  logServeSweepFailure,
+  noteServeProbeOk,
+  noteServeSweepOk,
+} from "./serve-log";
+import { probeProviders, type ServeProbe } from "./serve-probe";
 import { reportDeadServedApiKey, servedApiKeyIsDead } from "./served-key-guard";
 import { forgetServedScope, recordServedScope } from "./served-scope";
 import { authStorage } from "./storage";
@@ -173,6 +178,15 @@ async function runServedSync(): Promise<string[]> {
   // each; serve-probe.ts) so a hydrating route pays a few round-trips, not
   // forty sockets at once. The auth.json writes below stay serial.
   const probes = await probeProviders(probeIds);
+  // Every probe failing with ONE detail is the control plane being unreachable
+  // (the host closing under this runtime, a gateway outage) — one incident,
+  // logged once (serve-log.ts), never once per provider (PRODUCT-1399). The
+  // loop below still treats each as an error verdict: nothing applied or
+  // removed, auth.json kept as is, the next sync re-probes.
+  const sweepDetail = uniformFailureDetail(probes);
+  if (sweepDetail !== undefined)
+    logServeSweepFailure(probes.length, sweepDetail);
+  else noteServeSweepOk();
   const applied: string[] = [];
   const removed: string[] = [];
   // Provenance gate: an authoritative "not connected" may only remove providers
@@ -256,9 +270,10 @@ async function runServedSync(): Promise<string[]> {
         manifest.delete(probe.id);
         manifestDirty = true;
       }
-    } else {
+    } else if (sweepDetail === undefined) {
       // Dedup lives in serve-log.ts: every turn and hydrating route re-probes,
       // so a persistent gateway failure must not emit one Sentry error each.
+      // (A uniformly failed sweep was already logged once, above.)
       logServeProbeFailure(probe.id, probe.detail);
     }
   }
@@ -275,4 +290,16 @@ async function runServedSync(): Promise<string[]> {
     `[serve] applied central credentials: ${applied.join(", ") || "(none)"}`,
   );
   return applied;
+}
+
+/**
+ * The shared detail when EVERY probe (of at least two) errored the same way,
+ * else undefined. A lone failing provider is that provider's incident.
+ */
+function uniformFailureDetail(probes: ServeProbe[]): string | undefined {
+  const first = probes[0];
+  if (probes.length < 2 || !first || first.state !== "error") return undefined;
+  return probes.every((p) => p.state === "error" && p.detail === first.detail)
+    ? first.detail
+    : undefined;
 }


### PR DESCRIPTION
## Summary

Complements #1338 (host-side: latch the launcher closed on shutdown so no runtime is spawned into a closing host). This PR is the runtime half; the two touch disjoint files and merge independently.

Sentry HOUSTON-APP-4YV, post-08-14 shape (every event since the PRODUCT-1324 retry shipped): 41 identical `[serve] credential <provider>: fetch failed (cause: ECONNREFUSED)` errors from ONE pod within one second. Pod logs pin the trigger (a runtime spawned during the host's shutdown drain, fixed in #1338), but the amplification is the runtime's own: `serve-log.ts` dedups per provider, so it can collapse *repeats* of a failure but never the fan-out itself. Any event that makes the control plane unreachable (host closing, gateway outage) still costs 41 events per pod per transition.

## Fix

`runServedSync` (`packages/runtime/src/auth/serve.ts`) detects a sweep in which EVERY probe (≥ 2) failed with the same detail and logs it once via the new `logServeSweepFailure` in `serve-log.ts`:

```
[serve] control plane unreachable for all 41 providers: fetch failed (cause: ECONNREFUSED)
```

with the same transition dedup as per-provider failures (repeat = WARN breadcrumb, recovery = one `[serve] control plane reachable again` INFO, then re-armed). Uneven failures keep the per-provider path. Nothing is applied or removed either way: an error verdict keeps whatever `auth.json` already holds and the next sync re-probes.

Not touched: the other families in the same Sentry issue (`github-copilot` "reported a dead credential" 500s and 10 s serve timeouts) are per-provider gateway verdicts and stay per-provider.

## Tests

- `auth/serve.test.ts`: an all-refused sweep logs ONE error (attempt + retry per provider still run), the repeat is a WARN, recovery logs once and re-arms the incident.
- `auth/serve-log.test.ts`: sweep key dedup + recovery, tracked apart from per-provider failures.
- `pnpm --filter @houston/runtime test` green (1156), `typecheck`, `pnpm check`, `pnpm check:boundaries` clean.

## Verify

Before: with a serve-mode runtime whose control plane refuses connections (e.g. stop the local host under a running runtime, or point `HOUSTON_CONTROL_PLANE_URL` at a closed port), one `/providers` call logs `[serve] credential <id> probe failed, retrying once: …` ×41 then `[serve] credential <id>: fetch failed (cause: ECONNREFUSED)` ERROR ×41; Sentry 4YV gains 41 events.

After: the same call logs the 41 retry WARN breadcrumbs, then exactly ONE ERROR `[serve] control plane unreachable for all 41 providers: fetch failed (cause: ECONNREFUSED)`; a second call logs it as `(still failing)` WARN only; once the control plane answers again, one INFO `[serve] control plane reachable again`.

PRODUCT-1399