### PR TITLE
Treat the gateway "engine proxy failed" 502 as a pod-not-reachable read (PRODUCT-1403)

### DIFF
--- a/app/src/lib/engine-waking-error.ts
+++ b/app/src/lib/engine-waking-error.ts
@@ -1,22 +1,40 @@
-// The "is this failure just the agent's pod waking up?" classifier for the
-// error-surfacing layer (HOU-1114). Dependency-free so it is node-testable
-// directly (app/tests/engine-waking-error.test.ts) and importable from
-// anywhere.
+// The "is this failure just the agent's pod not reachable yet?" classifier for
+// the error-surfacing layer (HOU-1114, PRODUCT-1403). Dependency-free so it is
+// node-testable directly (app/tests/engine-waking-error.test.ts) and
+// importable from anywhere.
 //
-// On the hosted profile the gateway answers a per-agent request with
-// `503 {"error": "engine unavailable"}` when the agent's engine pod is not
-// reachable yet — a freshly installed store agent still provisioning, or an
-// asleep pod mid cold-start. The request self-heals on retry once the pod is
-// up; nothing in Houston broke, so the red "we have a problem" bug toast +
-// Sentry report is the wrong surface (a user who just installed an agent read
-// it as the install failing). Keyed on the exact gateway reason string, NOT on
-// bare status 503: other 503 bodies ("setup pod unreachable", provider quota
-// pages, self-host proxies) carry different reasons and must keep surfacing as
-// real errors.
+// On the hosted profile the gateway has two ways of saying "the agent's engine
+// pod is not there right now", both of which self-heal on retry once the pod
+// listens again — nothing in Houston broke, so the bug-report pipeline (Sentry
+// capture + the error surface) is the wrong place for either:
+//
+//  - `503 {"error": "engine unavailable"}` — the pod is not reachable yet: a
+//    freshly installed store agent still provisioning, or an asleep pod mid
+//    cold-start (HOU-1114: a user who just installed an agent read the red
+//    toast as the install failing).
+//  - `502 {"error": "engine proxy failed", "detail": <dial error>}` — the
+//    gateway's per-agent proxy exhausted its dial ladder against a pod it
+//    believes is running: the pod is restarting under an engine roll (every
+//    deploy re-rolls every agent pod) or was just replaced. Every deploy day
+//    produced a burst of these on the passive per-agent reads (`list_skills`,
+//    `read_agent_file`, ...), each captured as a bug for a pod that was up
+//    again seconds later (PRODUCT-1403 / HOUSTON-APP-4WQ).
+//
+// Keyed on the exact (status, gateway reason) pairs, NOT on bare 502/503:
+// other bodies on the same statuses ("setup pod unreachable", "agent pod
+// unusable", provider quota pages, self-host proxies) carry different reasons
+// and must keep surfacing as real errors. The read transport
+// (`packages/web/src/engine-adapter/cp/transient-retry.ts`) parses the same
+// two answers on the wire and gives them the cold-start retry budget first;
+// this classifier decides how the ones that outlive that budget surface.
+
+const ENGINE_UNAVAILABLE_503 = "engine unavailable";
+const ENGINE_PROXY_FAILED_502 = "engine proxy failed";
 
 /**
- * A gateway "engine unavailable" 503: the agent's engine pod is warming up or
- * unreachable, and the same request succeeds once it wakes. Matched
+ * A gateway "engine unavailable" 503 or "engine proxy failed" 502: the
+ * agent's engine pod is warming up, restarting, or otherwise not accepting
+ * connections, and the same request succeeds once it does. Matched
  * structurally (name + status + message prefix) so this stays dependency-free;
  * `HoustonEngineError` mints the message as `"<reason> (engine error <status>)"`
  * with the gateway's reason verbatim.
@@ -26,5 +44,8 @@ export function isEngineWakingError(err: unknown): boolean {
     return false;
   }
   const status = (err as { status?: unknown }).status;
-  return status === 503 && err.message.startsWith("engine unavailable");
+  return (
+    (status === 503 && err.message.startsWith(ENGINE_UNAVAILABLE_503)) ||
+    (status === 502 && err.message.startsWith(ENGINE_PROXY_FAILED_502))
+  );
 }

--- a/app/src/lib/error-toast.ts
+++ b/app/src/lib/error-toast.ts
@@ -112,9 +112,10 @@ export function showUpdateCheckStuckToast(
 }
 
 /**
- * Surface a gateway "engine unavailable" 503 (HOU-1114) as ONE informational
- * "your agent is waking up" toast. The agent's engine pod is provisioning (a
- * just-installed store agent) or cold-starting; every per-agent call fails the
+ * Surface a gateway "engine unavailable" 503 (HOU-1114) or "engine proxy
+ * failed" 502 (PRODUCT-1403) as ONE informational "your agent is waking up"
+ * toast. The agent's engine pod is provisioning (a just-installed store
+ * agent), cold-starting, or restarting under a roll; every per-agent call fails the
  * same way until it wakes, so the toast dedupes on its constant displayed body
  * and the burst reads as one state, not a storm. No Sentry capture and no
  * green "report sent" toast: nothing in Houston broke and the request

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -266,9 +266,11 @@ async function surfaceError(
   // Expected environment state, not a bug: the gateway's "engine unavailable"
   // 503 — the agent's engine pod is provisioning or cold-starting (HOU-1114: a
   // just-installed store agent's background writes hit this and showed the red
-  // bug pair while the agent was in fact starting fine). The request succeeds
-  // once the pod wakes; surface it as one deduped "waking up" notice, no
-  // Sentry. The raw diagnostic is already in the log tail above.
+  // bug pair while the agent was in fact starting fine) — or its "engine proxy
+  // failed" 502, the pod restarting under an engine roll (PRODUCT-1403). The
+  // request succeeds once the pod listens again; surface it as one deduped
+  // "waking up" notice, no Sentry. The raw diagnostic is already in the log
+  // tail above.
   if (isEngineWakingError(err)) {
     const { showEngineWakingToast } = await import("./error-toast");
     showEngineWakingToast(label, message);

--- a/app/tests/engine-waking-error.test.ts
+++ b/app/tests/engine-waking-error.test.ts
@@ -2,11 +2,13 @@ import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import { isEngineWakingError } from "../src/lib/engine-waking-error.ts";
 
-// HOU-1114: the surfacing-layer classifier that keeps the gateway's
-// "engine unavailable" 503 (agent pod provisioning / cold-starting) out of the
-// red bug-toast + Sentry pipeline. It must match exactly the gateway's
-// pod-unreachable answer, and must NEVER match other 503s — a false positive
-// here silently drops a real bug report.
+// HOU-1114 / PRODUCT-1403: the surfacing-layer classifier that keeps the
+// gateway's two pod-not-reachable answers — "engine unavailable" 503 (agent pod
+// provisioning / cold-starting) and "engine proxy failed" 502 (the proxy could
+// not connect to a pod restarting under an engine roll) — out of the red
+// bug-toast + Sentry pipeline. It must match exactly those (status, reason)
+// pairs, and must NEVER match other 502/503s — a false positive here silently
+// drops a real bug report.
 
 /** The shape `HoustonEngineError` mints (structural stand-in, keeps the test
  *  dependency-free like the classifier itself). */
@@ -35,13 +37,38 @@ describe("isEngineWakingError", () => {
     strictEqual(isEngineWakingError(engineError(503)), false);
   });
 
-  it("never matches the same reason on another status", () => {
+  it("matches the gateway's engine-proxy-failed 502 (PRODUCT-1403)", () => {
+    // The proxy's answer carries the dial error as detail; HoustonEngineError
+    // keeps only the reason in the message, so the prefix is what's matched.
+    strictEqual(
+      isEngineWakingError(engineError(502, "engine proxy failed")),
+      true,
+    );
+  });
+
+  it("never matches other 502 reasons", () => {
+    strictEqual(
+      isEngineWakingError(engineError(502, "agent pod unusable")),
+      false,
+    );
+    strictEqual(isEngineWakingError(engineError(502)), false);
+  });
+
+  it("never matches either reason on another status", () => {
     strictEqual(
       isEngineWakingError(engineError(502, "engine unavailable")),
       false,
     );
     strictEqual(
       isEngineWakingError(engineError(500, "engine unavailable")),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError(engineError(503, "engine proxy failed")),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError(engineError(504, "engine proxy failed")),
       false,
     );
   });

--- a/knowledge-base/client-architecture.md
+++ b/knowledge-base/client-architecture.md
@@ -144,8 +144,16 @@ ONE place the gateway's 5xx bodies are parsed, turning prose into the typed
 | Gateway answer | Reason | Client behavior |
 | --- | --- | --- |
 | `503 {"error":"engine unavailable","detail":"agent is waking"}` (+`Retry-After`) | `engine-waking` | 4 extra attempts, `WAKE_RETRY_DELAYS_MS` = 15s of client patience on top of the gateway's own 8s `ensure-awake` leg per attempt. No toast unless the budget is spent. |
+| `502 {"error":"engine proxy failed","detail":<dial error>}` | `pod-unreachable` | Same wake budget. The gateway's per-agent proxy exhausted its dial ladder against a pod it believes is running — the pod is restarting under an engine roll (a deploy re-rolls every agent pod). Every deploy day used to produce a burst of these on the passive per-agent reads, each captured as a bug for a pod that was up seconds later (PRODUCT-1403). |
 | `503 {"error":"shared skills not configured"}` | `feature-absent` | Answered on the first attempt — retrying a deployment shape is pure waste. |
 | any other 502/503/504, or a transport drop | `handoff` | The original 2 blind retries (~2s, PRODUCT-731). |
+
+When the budget IS spent, the app-side classifier `app/src/lib/engine-waking-error.ts`
+(`isEngineWakingError`) recognizes the same two pod-not-reachable answers (the
+`engine unavailable` 503 and the `engine proxy failed` 502) and routes them to the
+quiet "your agent is waking up" surface — no Sentry capture — everywhere an engine
+error surfaces (`lib/tauri.ts` `surfaceError`, the partial cross-agent sweep). Any
+other 502/503 body keeps the loud path.
 
 Two rules that fall out of this and are easy to get wrong:
 - **`Retry-After` is unreadable.** The gateway sends no

--- a/packages/web/src/engine-adapter/cp/transient-retry.ts
+++ b/packages/web/src/engine-adapter/cp/transient-retry.ts
@@ -20,6 +20,17 @@
  *    no blob store bound (`cloud/internal/edge/shared_skills_routes.go`). That
  *    is a deployment SHAPE, permanent for the session: retrying burns round
  *    trips to be told the same thing.
+ *  - **The pod is not accepting connections.** The gateway's per-agent proxy
+ *    (`cloud/internal/proxy/forward.go` → `connectWithRetry`) walks a short
+ *    dial ladder against a pod it believes is running and, when every dial is
+ *    refused, answers `502 {"error":"engine proxy failed","detail":<dial
+ *    error>}`. On a read that is the same event as a wake, seen from the other
+ *    side: the pod is restarting under an engine roll (a deploy re-rolls every
+ *    agent pod), or was just replaced, and the very same request answers once
+ *    it listens again. Every deploy day produced a burst of these on the
+ *    passive per-agent reads (`list_skills`, `read_agent_file`, ...) that got
+ *    the short handoff patience and then surfaced as a bug (PRODUCT-1403 /
+ *    HOUSTON-APP-4WQ) — for a pod that was up again seconds later.
  *  - **Anything else** — a gateway roll, a load-balancer handoff, a host that
  *    is restarting — heals in about a second, which is what the original two
  *    blind retries were sized for (HOU-731).
@@ -51,12 +62,16 @@ const TRANSIENT_STATUSES = new Set([502, 503, 504]);
  */
 const ENGINE_UNAVAILABLE = "engine unavailable";
 const AGENT_IS_WAKING = "agent is waking";
+const ENGINE_PROXY_FAILED = "engine proxy failed";
 export const SHARED_SKILLS_UNCONFIGURED = "shared skills not configured";
 
 /** Why a read got no answer — the typed form of the gateway's 5xx body. */
 export type UnavailableReason =
   /** The agent's engine pod is cold-starting; the gateway asked us to retry. */
   | "engine-waking"
+  /** The gateway could not connect to the agent's pod: it is restarting (an
+   *  engine roll) or was just replaced, and answers once it listens again. */
+  | "pod-unreachable"
   /** This deployment does not run the feature at all. Retrying cannot help. */
   | "feature-absent"
   /** A gateway roll, an LB handoff, a dropped connection — heals in ~a second. */
@@ -70,7 +85,9 @@ export const HANDOFF_RETRY_DELAYS_MS = [500, 1_500] as const;
 
 /**
  * Four extra attempts, 15s of client-side patience, for a pod the gateway has
- * told us is still waking.
+ * told us is still waking — or could not connect to at all (`pod-unreachable`,
+ * the restart-under-a-roll twin of a wake, whose gateway-side cost per attempt
+ * is the proxy's ~4s dial ladder instead of the 8s ensure-awake leg).
  *
  * Sized against the gateway, not guessed. Each attempt costs the gateway one
  * `ensure-awake` long-poll leg of up to 8s (`wakeWaitMs`) before it answers
@@ -99,6 +116,7 @@ export function classifyUnavailableBody(body: unknown): UnavailableReason {
   if (b?.error === ENGINE_UNAVAILABLE && b?.detail === AGENT_IS_WAKING) {
     return "engine-waking";
   }
+  if (b?.error === ENGINE_PROXY_FAILED) return "pod-unreachable";
   return "handoff";
 }
 
@@ -106,6 +124,7 @@ export function classifyUnavailableBody(body: unknown): UnavailableReason {
 export function retryDelaysFor(reason: UnavailableReason): readonly number[] {
   switch (reason) {
     case "engine-waking":
+    case "pod-unreachable":
       return WAKE_RETRY_DELAYS_MS;
     case "feature-absent":
       return NO_RETRY_DELAYS_MS;

--- a/packages/web/tests/transient-retry-fetch.test.ts
+++ b/packages/web/tests/transient-retry-fetch.test.ts
@@ -24,6 +24,13 @@ import {
 const sum = (xs: readonly number[]) => xs.reduce((a, b) => a + b, 0);
 /** The gateway's exact wake answer (cloud/internal/edge/agents/routes.go). */
 const wakingBody = { error: "engine unavailable", detail: "agent is waking" };
+/** The gateway proxy's exact dial-failure answer (cloud/internal/proxy/forward.go
+ *  `connectWithRetry`): a pod restarting under an engine roll (PRODUCT-1403). */
+const proxyFailedBody = {
+  error: "engine proxy failed",
+  detail:
+    'Get "http://10.0.0.7:4318/skills": dial tcp 10.0.0.7:4318: connect: connection refused',
+};
 
 const originalFetch = globalThis.fetch;
 
@@ -158,6 +165,64 @@ test("the gateway's 5xx vocabulary maps to typed reasons", () => {
   expect(retryDelaysFor("engine-waking")).toBe(WAKE_RETRY_DELAYS_MS);
   expect(retryDelaysFor("handoff")).toBe(HANDOFF_RETRY_DELAYS_MS);
   expect(retryDelaysFor("feature-absent")).toEqual([]);
+});
+
+// ── PRODUCT-1403: the pod-unreachable 502 ───────────────────────────────────
+
+test("the proxy's engine-proxy-failed 502 is a pod-unreachable read, with the wake budget", () => {
+  expect(classifyUnavailableBody(proxyFailedBody)).toBe("pod-unreachable");
+  // The reason alone is the contract; the dial detail varies per pod/route.
+  expect(classifyUnavailableBody({ error: "engine proxy failed" })).toBe(
+    "pod-unreachable",
+  );
+  expect(retryDelaysFor("pod-unreachable")).toBe(WAKE_RETRY_DELAYS_MS);
+  // Other 502 vocabulary keeps the short handoff patience.
+  expect(classifyUnavailableBody({ error: "agent pod unusable" })).toBe(
+    "handoff",
+  );
+});
+
+test("a read against a pod restarting under a roll rides the 502s and resolves", async () => {
+  vi.useFakeTimers();
+  const inner = vi
+    .fn<typeof fetch>()
+    .mockResolvedValueOnce(json(502, proxyFailedBody))
+    .mockResolvedValueOnce(json(502, proxyFailedBody))
+    .mockResolvedValueOnce(json(502, proxyFailedBody))
+    .mockResolvedValueOnce(json(200, [{ name: "write-a-post" }]));
+  const doFetch = transientRetryFetch(inner);
+
+  const pending = doFetch("https://gw.example/agents/a1/skills");
+  // The handoff budget would have given up (three attempts, ~2s) right here.
+  await vi.advanceTimersByTimeAsync(sum(HANDOFF_RETRY_DELAYS_MS));
+  expect(inner).toHaveBeenCalledTimes(2);
+
+  await vi.advanceTimersByTimeAsync(sum(WAKE_RETRY_DELAYS_MS));
+  const res = await pending;
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual([{ name: "write-a-post" }]);
+  expect(inner).toHaveBeenCalledTimes(4);
+});
+
+test("cpFetch throws the proxy's reason once the pod-unreachable budget is spent", async () => {
+  vi.useFakeTimers();
+  globalThis.fetch = vi.fn(async () =>
+    json(502, proxyFailedBody),
+  ) as unknown as typeof fetch;
+
+  const pending = cpFetch(
+    { baseUrl: "https://gw.example", token: "tok" },
+    "/agents/a1/skills",
+  ).catch((err: unknown) => err);
+  await vi.advanceTimersByTimeAsync(sum(WAKE_RETRY_DELAYS_MS));
+  const err = (await pending) as { status: number; message: string };
+  // No silent failure: the exhausted budget hands the app the real 502, which
+  // `isEngineWakingError` then routes to the quiet waking surface.
+  expect(err.status).toBe(502);
+  expect(err.message).toBe("engine proxy failed (engine error 502)");
+  expect(globalThis.fetch).toHaveBeenCalledTimes(
+    WAKE_RETRY_DELAYS_MS.length + 1,
+  );
 });
 
 test("the wake budget is bounded to ~15s of client-side patience", () => {


### PR DESCRIPTION
Linear: PRODUCT-1403 (Sentry HOUSTON-APP-4WQ, `list_skills: engine proxy failed (engine error 502)`)

## Root cause

HOUSTON-APP-4WQ groups every `list_skills` failure. The old-client tail (0.5.x: `engine unavailable` 503s, agent-gone 404s, 401s, ENOENT) is already handled by earlier fixes; the only current-client events (0.6.1 / 0.6.2 / 0.6.3) are short bursts of `engine proxy failed (engine error 502)` that line up with cloud deploys, the last one being 7 events across 4 users in the 25 minutes after the 0.6.3 roll (2026-08-18 13:54–14:13 UTC). In each event's breadcrumbs every per-agent read (`config.json`, `activity.json`, `providers`, `skills`) 502s within the same second: the user's engine pod was restarting under the roll.

That 502 is the gateway's per-agent proxy exhausting its dial ladder against a pod it believes is running (`connectWithRetry`: `502 {"error":"engine proxy failed","detail":<dial error>}`). On a read it is the same event as a wake, seen from the other side, and the request answers once the pod listens again. The client already had the right treatment for the 503 twin (`engine unavailable`: cold-start retry budget, then the quiet "your agent is waking up" notice with no Sentry capture), but the 502 got only the ~2s handoff patience and then went to Sentry as a bug.

## Fix

- `packages/web/src/engine-adapter/cp/transient-retry.ts`: `502 {"error":"engine proxy failed"}` classifies as a new typed `pod-unreachable` reason that earns the wake retry budget on GET/HEAD (writes still never blind-retry). Other 502 bodies keep the short handoff patience.
- `app/src/lib/engine-waking-error.ts`: `isEngineWakingError` matches the 502 + reason pair alongside the 503, so `surfaceError` (`lib/tauri.ts`) and the partial cross-agent sweep route it to the quiet waking notice, no Sentry capture. Other 502/503 reasons (`agent pod unusable`, `setup pod unreachable`, bare statuses) stay loud.
- Tests extended in `app/tests/engine-waking-error.test.ts` and `packages/web/tests/transient-retry-fetch.test.ts`; `knowledge-base/client-architecture.md` 5xx table updated.

## Before

1. On a managed-cloud client, open an agent while its engine pod is restarting (any deploy day: the engine roll re-rolls every pod), or replay the gateway's answer with a stub returning `502 {"error":"engine proxy failed","detail":"dial tcp ...: connection refused"}` on `GET /agents/:id/skills`.
2. The read retries twice (~2s), then throws; the log shows `[toast:list_skills] engine proxy failed (engine error 502)` and Sentry receives a `list_skills` capture (HOUSTON-APP-4WQ) for a pod that is up again seconds later. Same for `read_agent_file` / `providers` in the same burst.

## After

1. Same setup. The read rides `WAKE_RETRY_DELAYS_MS` (four extra attempts, ~15s client patience) and resolves once the pod listens; nothing surfaces.
2. If the pod is still down past the budget, the 502 surfaces as ONE deduped info toast "Houston, your agent is waking up" and no Sentry capture. The `[engine:list_skills]` line still lands in the frontend log.
3. Verify locally: `pnpm --filter houston-web exec vitest run tests/transient-retry-fetch.test.ts` (18 pass) and `cd app && node --experimental-strip-types --test tests/engine-waking-error.test.ts` (6 pass). Full gates run green: `cd app && pnpm test` (3660), `pnpm --filter houston-web test` (412), `pnpm typecheck`, `pnpm check`.
4. In Sentry, once this ships, HOUSTON-APP-4WQ should get no `engine proxy failed` events from the shipping release across the next deploy's roll window.
