### PR TITLE
Treat an older gateway's 401 on the boot report as no-ingest, not an error (PRODUCT-1404)

### DIFF
--- a/packages/host/src/telemetry/boot-report.ts
+++ b/packages/host/src/telemetry/boot-report.ts
@@ -17,8 +17,16 @@ export interface BootReportOptions {
  * ready (HOU-1011). Pods scale to zero, so Prometheus never scrapes a boot —
  * the gateway folds these reports into its own /metrics histograms instead.
  * One retry, then give up loudly: a lost report costs one data point, never
- * the boot (mirrors the usage sampler's fire-and-forget posture; a 404 is an
- * older gateway that doesn't serve the ingest yet).
+ * the boot (mirrors the usage sampler's fire-and-forget posture).
+ *
+ * Deploy-order tolerance: an older gateway that doesn't mount the ingest yet
+ * answers from its authenticated not-found fallback, and a pod bearer is not a
+ * user session — so "no route" surfaces as 401, not 404 (HOUSTON-APP-559:
+ * 104 pods × 2 attempts in the 40s between the engine roll and the gateway
+ * roll). Both mean "nothing to report to" and neither heals in a 5s retry, so
+ * both skip quietly. A real pod-token mismatch is not hidden by this: the same
+ * token is exercised loudly by every other pod route (credentials, usage,
+ * turnlog) on the same boot.
  */
 export async function sendBootReport(opts: BootReportOptions): Promise<void> {
   const { url, orgSlug, agentSlug, podToken } = opts.report;
@@ -40,8 +48,10 @@ export async function sendBootReport(opts: BootReportOptions): Promise<void> {
         body,
       });
       if (res.ok) return;
-      if (res.status === 404) {
-        opts.log("[boot-report] gateway has no ingest yet (404), skipping");
+      if (res.status === 404 || res.status === 401) {
+        opts.log(
+          `[boot-report] gateway has no ingest yet (${res.status}), skipping`,
+        );
         return;
       }
       opts.log("[boot-report] rejected", new Error(`status ${res.status}`));

--- a/packages/host/src/telemetry/boot.test.ts
+++ b/packages/host/src/telemetry/boot.test.ts
@@ -94,4 +94,46 @@ describe("sendBootReport", () => {
     await sendBootReport({ report, telemetry: boot, log: () => {}, fetchImpl });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
+
+  it("treats an older gateway's 401 (authenticated not-found wall) as done, not an error (HOUSTON-APP-559)", async () => {
+    const boot = new BootTelemetry();
+    const log = vi.fn();
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 401 }));
+    await sendBootReport({
+      report,
+      telemetry: boot,
+      log,
+      fetchImpl,
+      retryDelayMs: 1,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    // Info-level breadcrumb only: no error argument, so severityLog never
+    // reaches console.error → no Sentry event.
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith(
+      "[boot-report] gateway has no ingest yet (401), skipping",
+    );
+  });
+
+  it("still gives up loudly on any other rejection (retry, then error)", async () => {
+    const boot = new BootTelemetry();
+    const log = vi.fn();
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 500 }));
+    await sendBootReport({
+      report,
+      telemetry: boot,
+      log,
+      fetchImpl,
+      retryDelayMs: 1,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenCalledWith(
+      "[boot-report] rejected",
+      expect.any(Error),
+    );
+    expect(log).toHaveBeenCalledWith(
+      "[boot-report] giving up after retry",
+      expect.any(Error),
+    );
+  });
 });


### PR DESCRIPTION
Fixes PRODUCT-1404 (Sentry HOUSTON-APP-559 "Boot report returns 401", 212 events / 104 users).

## Root cause

A deploy-order skew, not an auth bug. All 212 events sit in one 40-second window (2026-08-03 00:48:12–00:48:49 UTC), all on engine release `6feab12e0` — the exact commit that introduced the one-shot boot report (HOU-1011, #1169). The gateway PR that mounts the `/v1/pod/boot-report` ingest merged five minutes earlier and was still rolling out.

The host tolerated an older gateway by treating **404** as "no ingest yet". But the gateway's fallback for an unmounted path sits behind its authenticated wall, and a pod bearer is not a user session — so an unknown pod route surfaces as **401**, never 404. The 404 branch was dead code; every pod that booted in that window logged the 401 as an error (× 2, one retry after 5s), and `severityLog(msg, err)` → `console.error` → Sentry.

Zero events since the gateway roll completed (15 days, many engine rolls). Users were never affected: the boot itself succeeded, only one metrics data point per pod was lost.

## Fix

`packages/host/src/telemetry/boot-report.ts`: skip 401 the same way as 404 — info breadcrumb, no retry, no Sentry event. Docblock now states the real "older gateway" shape. A genuine pod-token mismatch is not hidden by this: the same token is exercised loudly by every other pod route (credentials, usage, turnlog) on the same boot.

Tests: `boot.test.ts` gains the 401 = quiet skip case (asserts no error argument reaches the log, single attempt) and a 5xx = still-loud case (retry, then error).

## Verification

Before (reproduce): run `sendBootReport` against a fetch that answers 401 → the log callback receives `("[boot-report] rejected", Error("status 401"))` twice plus `"giving up after retry"`; on a pod that is a Sentry error event.

After: `cd packages/host && pnpm test -- src/telemetry/boot.test.ts` → the new case passes: one attempt, one info-level log line `[boot-report] gateway has no ingest yet (401), skipping`, no error argument. Full host suite: 169 files / 1515 tests green; `pnpm typecheck` + `pnpm check` clean.

Live: after the next engine roll, HOUSTON-APP-559 stays at zero events even if a gateway roll lags the engine roll (the only situation that ever produced it).