### PR TITLE
Quiet the boot-report telemetry send: breadcrumb attempts, real cause on give-up, 401 = older gateway (PRODUCT-1405)

### DIFF
--- a/packages/host/src/telemetry/boot-report.ts
+++ b/packages/host/src/telemetry/boot-report.ts
@@ -16,8 +16,13 @@ export interface BootReportOptions {
  * Push the boot-span ledger to the gateway once, right after this pod became
  * ready (HOU-1011). Pods scale to zero, so Prometheus never scrapes a boot —
  * the gateway folds these reports into its own /metrics histograms instead.
- * One retry, then give up loudly: a lost report costs one data point, never
- * the boot (mirrors the usage sampler's fire-and-forget posture).
+ *
+ * Failure posture (mirrors the usage sampler's fire-and-forget): a lost report
+ * costs one data point, never the boot. Transient failures (network, 5xx) get
+ * ONE retry; only the final give-up is an error entry (a Sentry event) and it
+ * names the real cause — the per-attempt failures are breadcrumbs, otherwise
+ * every gateway roll fired an error per pod for a blip the retry then healed
+ * (PRODUCT-1405). Deterministic rejections (other 4xx) are never retried.
  *
  * Deploy-order tolerance: an older gateway that doesn't mount the ingest yet
  * answers from its authenticated not-found fallback, and a pod bearer is not a
@@ -33,6 +38,7 @@ export async function sendBootReport(opts: BootReportOptions): Promise<void> {
   const target = `${url.replace(/\/+$/, "")}/v1/pod/boot-report/${encodeURIComponent(orgSlug)}/${encodeURIComponent(agentSlug)}`;
   const fetchImpl = opts.fetchImpl ?? fetch;
   const body = JSON.stringify(opts.telemetry.reportPayload());
+  let lastFailure = "unknown";
   for (let attempt = 0; attempt < 2; attempt++) {
     if (attempt > 0)
       await new Promise((r) =>
@@ -54,10 +60,34 @@ export async function sendBootReport(opts: BootReportOptions): Promise<void> {
         );
         return;
       }
-      opts.log("[boot-report] rejected", new Error(`status ${res.status}`));
+      lastFailure = `status ${res.status}`;
+      // Any other 4xx is deterministic (payload rejected) — retrying can't help.
+      if (res.status < 500) break;
     } catch (err) {
-      opts.log("[boot-report] send failed", err);
+      lastFailure = describeFetchError(err);
     }
+    if (attempt === 0)
+      opts.log(`[boot-report] send failed (${lastFailure}), retrying once`);
   }
-  opts.log("[boot-report] giving up after retry", new Error("send failed"));
+  opts.log(
+    "[boot-report] giving up",
+    new Error(`boot report not accepted: ${lastFailure}`),
+  );
+}
+
+/**
+ * undici wraps every network failure in a bare `TypeError: fetch failed` and
+ * hides the reason (ECONNREFUSED, EAI_AGAIN, ...) in `cause`; surface it so the
+ * give-up entry says what actually happened.
+ */
+function describeFetchError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const cause = err.cause;
+  const causeText =
+    cause instanceof Error
+      ? cause.message
+      : cause === undefined
+        ? undefined
+        : String(cause);
+  return causeText ? `${err.message}: ${causeText}` : err.message;
 }

--- a/packages/host/src/telemetry/boot.test.ts
+++ b/packages/host/src/telemetry/boot.test.ts
@@ -68,11 +68,13 @@ describe("sendBootReport", () => {
     ]);
   });
 
-  it("retries once on failure, then gives up loudly", async () => {
+  it("retries once on a network failure, then gives up loudly with the cause", async () => {
     const boot = new BootTelemetry();
     const log = vi.fn();
     const fetchImpl = vi.fn(async () => {
-      throw new Error("refused");
+      throw new TypeError("fetch failed", {
+        cause: new Error("connect ECONNREFUSED 10.0.0.1:80"),
+      });
     });
     await sendBootReport({
       report,
@@ -82,23 +84,66 @@ describe("sendBootReport", () => {
       retryDelayMs: 1,
     });
     expect(fetchImpl).toHaveBeenCalledTimes(2);
-    expect(log).toHaveBeenCalledWith(
-      "[boot-report] giving up after retry",
-      expect.any(Error),
+    // Attempt 1 is a breadcrumb (no error object), not a Sentry event.
+    expect(log).toHaveBeenNthCalledWith(
+      1,
+      "[boot-report] send failed (fetch failed: connect ECONNREFUSED 10.0.0.1:80), retrying once",
+    );
+    // Only the give-up carries an error, and it names the real cause.
+    expect(log).toHaveBeenNthCalledWith(
+      2,
+      "[boot-report] giving up",
+      expect.objectContaining({
+        message:
+          "boot report not accepted: fetch failed: connect ECONNREFUSED 10.0.0.1:80",
+      }),
+    );
+    expect(log).toHaveBeenCalledTimes(2);
+  });
+
+  it("a transient failure healed by the retry logs no error at all", async () => {
+    const boot = new BootTelemetry();
+    const log = vi.fn();
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    await sendBootReport({
+      report,
+      telemetry: boot,
+      log,
+      fetchImpl,
+      retryDelayMs: 1,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]).toHaveLength(1);
+  });
+
+  it("retries a 5xx once, then gives up with the status", async () => {
+    const boot = new BootTelemetry();
+    const log = vi.fn();
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 503 }));
+    await sendBootReport({
+      report,
+      telemetry: boot,
+      log,
+      fetchImpl,
+      retryDelayMs: 1,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenLastCalledWith(
+      "[boot-report] giving up",
+      expect.objectContaining({
+        message: "boot report not accepted: status 503",
+      }),
     );
   });
 
-  it("treats an older gateway's 404 as done (no retry)", async () => {
-    const boot = new BootTelemetry();
-    const fetchImpl = vi.fn(async () => new Response(null, { status: 404 }));
-    await sendBootReport({ report, telemetry: boot, log: () => {}, fetchImpl });
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
-  });
-
-  it("treats an older gateway's 401 (authenticated not-found wall) as done, not an error (HOUSTON-APP-559)", async () => {
+  it("does not retry a deterministic 4xx (payload rejected) but still gives up loudly", async () => {
     const boot = new BootTelemetry();
     const log = vi.fn();
-    const fetchImpl = vi.fn(async () => new Response(null, { status: 401 }));
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 400 }));
     await sendBootReport({
       report,
       telemetry: boot,
@@ -107,33 +152,26 @@ describe("sendBootReport", () => {
       retryDelayMs: 1,
     });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
-    // Info-level breadcrumb only: no error argument, so severityLog never
-    // reaches console.error → no Sentry event.
     expect(log).toHaveBeenCalledTimes(1);
     expect(log).toHaveBeenCalledWith(
-      "[boot-report] gateway has no ingest yet (401), skipping",
+      "[boot-report] giving up",
+      expect.objectContaining({
+        message: "boot report not accepted: status 400",
+      }),
     );
   });
 
-  it("still gives up loudly on any other rejection (retry, then error)", async () => {
+  it.each([
+    404, 401,
+  ])("treats an older gateway's %i as done (no retry, no error)", async (status) => {
     const boot = new BootTelemetry();
     const log = vi.fn();
-    const fetchImpl = vi.fn(async () => new Response(null, { status: 500 }));
-    await sendBootReport({
-      report,
-      telemetry: boot,
-      log,
-      fetchImpl,
-      retryDelayMs: 1,
-    });
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const fetchImpl = vi.fn(async () => new Response(null, { status }));
+    await sendBootReport({ report, telemetry: boot, log, fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledTimes(1);
     expect(log).toHaveBeenCalledWith(
-      "[boot-report] rejected",
-      expect.any(Error),
-    );
-    expect(log).toHaveBeenCalledWith(
-      "[boot-report] giving up after retry",
-      expect.any(Error),
+      `[boot-report] gateway has no ingest yet (${status}), skipping`,
     );
   });
 });


### PR DESCRIPTION
Fixes PRODUCT-1405 (Sentry HOUSTON-APP-55A `Error: send failed`), and its siblings HOUSTON-APP-559 (`Error: status 401`) and HOUSTON-APP-57F (`TypeError: fetch failed`) — all three come from `sendBootReport` in `packages/host/src/telemetry/boot-report.ts`.

**Stacked on #1341 (PRODUCT-1404)**, which adds the 401 skip for the same 2026-08-03 burst; this PR is the delta on top (attempt breadcrumbs, real cause on give-up, 4xx no-retry, undici cause). GitHub retargets it to `main` once #1341 merges. Merge order: #1341 → #1342.

## Root cause

`sendBootReport` (HOU-1011) pushes the boot-span ledger to the gateway once per pod boot: one retry, then give up. Three things made a harmless data-point loss into Sentry noise:

1. **Every attempt-level failure was logged at error severity** (`log(msg, err)` → stderr → a Sentry event). A transient blip on attempt 1 that the retry then healed still fired an error per pod — that is 57F: 10 events during today's 15:53–15:56 UTC gateway roll, zero give-ups.
2. **The deploy-order tolerance only covered 404.** The gateway's authenticated 404-fallback answers a pod-token bearer with **401** (it is a user-session wall), so an engine roll that lands before the gateway with the ingest route sees 401, not 404. That is 559 + 55A: 212 + 106 events in ONE minute (2026-08-03 00:47–00:48 UTC), all on `engine-pod@6feab12e` — the first host with the report — four minutes after the gateway ingest route merged. Never seen since.
3. **The give-up threw away the cause**: `new Error("send failed")`, so 55A says nothing about why (the 401 was only visible in breadcrumbs). 4xx were also retried pointlessly.

## Fix

- Per-attempt failures are info-level breadcrumbs (`[boot-report] send failed (<cause>), retrying once`); only the final give-up is an error entry, and its message names the real cause (`boot report not accepted: status 503` / `fetch failed: connect ECONNREFUSED ...` — undici's `cause` is surfaced).
- 404 **and** 401 = older gateway (route missing / authed fallback), skipped without retry or error. A genuine pod-token skew breaks the credential serve loudly, so nothing is hidden.
- Other 4xx are deterministic (payload rejected) — no retry, still a loud give-up. 5xx and network errors keep the single retry.

Net effect: three Sentry issues collapse into one meaningful one that only fires when a report is actually lost, with the reason in the title.

## Verification

Before (on `main`): `pnpm --filter @houston/host exec vitest run src/telemetry/boot.test.ts` with the new tests fails — a rejected attempt-1 fetch logs an error object, a 401 is retried and logged twice as an error, the give-up error says `send failed`.

After (this branch):
- `pnpm --filter @houston/host exec vitest run src/telemetry/boot.test.ts` → 11 tests pass (network give-up with cause, retry-healed = no error, 5xx retry, 4xx no-retry, 404/401 skip).
- `pnpm --filter @houston/host typecheck`, `pnpm check` clean.
- In prod after the next engine roll: HOUSTON-APP-57F stops receiving events during gateway rolls; 559/55A stay quiet (their trigger — a host rolling ahead of a gateway without the route — now lands on the 401 skip branch). Any real loss shows up as a new issue titled `Error: boot report not accepted: <cause>`.
