### PR TITLE
Runbook: enabling an OAuth-only Composio toolkit with no managed app (PRODUCT-1409)

### DIFF
--- a/knowledge-base/integrations.md
+++ b/knowledge-base/integrations.md
@@ -62,23 +62,21 @@ Two providers live behind the port: **Composio** (the hosted catalog, this doc) 
 
 ### Auth configs — which apps are connectable, and enabling one that is not
 
-Whether a toolkit in the catalog can actually be CONNECTED depends on our Composio
-project having an ENABLED **auth config** for it. Both adapters resolve one lazily on
-the first connect (`composio-auth-config.ts` here; `internal/integrations/authconfig.go`
-in the gateway, same algorithm): reuse an enabled config if the project has one, else
-create one, managed OAuth first (`use_composio_managed_auth`, Composio's own app: gmail,
-googlesheets, googledrive, googlecalendar, slack…), else the toolkit's first
-user-collectible scheme (API key / bearer, asked for on the hosted connect page). A
-toolkit that is **OAuth-only with NO Composio-managed app** cannot be auto-created:
+Whether a toolkit in the catalog can actually be CONNECTED depends on the Composio
+project having an ENABLED **auth config** for it. The direct adapter resolves one lazily
+on the first connect (`composio-auth-config.ts`): reuse an enabled config if the project
+has one, else create one, managed OAuth first (`use_composio_managed_auth`, Composio's
+own app: gmail, googlesheets, googledrive, googlecalendar, slack…), else the toolkit's
+first user-collectible scheme (API key / bearer, asked for on the hosted connect page).
+A toolkit that is **OAuth-only with NO Composio-managed app** cannot be auto-created:
 connect fails 400 `toolkit_oauth_unavailable` (HOU-1110) — the app sits in the catalog
-but nobody can connect it. Google Forms was the canonical case (PRODUCT-1409): live
-metadata `composio_managed_auth_schemes: []`, `auth_config_details: [OAUTH2]`, zero auth
-configs in the project.
+but nobody can connect it. Google Forms is the canonical case (PRODUCT-1409): live
+metadata `composio_managed_auth_schemes: []`, `auth_config_details: [OAUTH2]`, no auth
+config in the project.
 
-**Runbook — enable such a toolkit for every user.** Nothing in code changes; once an
-enabled auth config exists, the next connect reuses it (per-process cache, no restart
-needed). Prod and staging are DIFFERENT Composio projects (`gateway-composio` secret in
-each cluster's `houston-gateway` ns), so repeat step 3 per environment.
+**Runbook — enable such a toolkit for every user of a deployment.** Nothing in code
+changes; once an enabled auth config exists, the next connect reuses it (per-process
+cache, no restart needed). Each Composio project (each deployment key) needs its own.
 
 1. **Read what Composio wants**: `GET /api/v3/toolkits/<slug>` with the project key →
    `auth_config_details[].fields.auth_config_creation` lists required creds
@@ -88,15 +86,15 @@ each cluster's `houston-gateway` ns), so repeat step 3 per environment.
    (Google Forms' default includes `auth/drive`, a Google RESTRICTED scope that
    forces a CASA security assessment; the tools work with `forms.body`,
    `forms.body.readonly`, `forms.responses.readonly` + `drive.file`).
-2. **Register a developer OAuth app on the vendor side** (Console UI only — no API):
-   for Google, GCP project `gethouston` (owns the "Houston" consent screen), enable the
-   API (`gcloud services enable forms.googleapis.com --project gethouston`), add the
-   scopes on the consent screen, create a *Web application* OAuth client whose
-   authorized redirect URIs are BOTH `https://backend.composio.dev/api/v3.1/toolkits/auth/callback`
-   (Composio docs) and `https://backend.composio.dev/api/v1/auth-apps/add` (the toolkit
-   metadata default). Sensitive scopes on a Production consent screen mean Google's
-   OAuth app verification (else the "unverified app" interstitial + 100-user cap) —
-   submit it; the parallel cheaper ask is Composio adding managed auth for the toolkit.
+2. **Register a developer OAuth app on the vendor side** (vendor console UI): for
+   Google, in the Cloud project that owns your OAuth consent screen, enable the API
+   (Forms API for `googleforms`), add the scopes on the consent screen, and create a
+   *Web application* OAuth client whose authorized redirect URIs are BOTH
+   `https://backend.composio.dev/api/v3.1/toolkits/auth/callback` (Composio docs) and
+   `https://backend.composio.dev/api/v1/auth-apps/add` (the toolkit metadata default).
+   Sensitive scopes on a Production consent screen mean Google's OAuth app
+   verification (else the "unverified app" interstitial + 100-user cap) — submit it;
+   the parallel cheaper ask is Composio adding managed auth for the toolkit.
 3. **Create the auth config in Composio** (dashboard "use your own developer
    credentials", or the API — secrets via env, never in a file):
    `curl -X POST https://backend.composio.dev/api/v3/auth_configs -H "x-api-key: $COMPOSIO_API_KEY" -H 'content-type: application/json' -d '{"toolkit":{"slug":"googleforms"},"auth_config":{"type":"use_custom_auth","name":"houston-googleforms","authScheme":"OAUTH2","credentials":{"client_id":"'"$CID"'","client_secret":"'"$CSECRET"'","scopes":"https://www.googleapis.com/auth/forms.body,https://www.googleapis.com/auth/forms.body.readonly,https://www.googleapis.com/auth/forms.responses.readonly,https://www.googleapis.com/auth/drive.file"}}}'`

--- a/knowledge-base/integrations.md
+++ b/knowledge-base/integrations.md
@@ -60,6 +60,50 @@ Two providers live behind the port: **Composio** (the hosted catalog, this doc) 
   `actingAs` (per-turn token) or `actingUser` (routine creator's `sub`); the direct
   adapter ignores both — identity is the verified `userId`.
 
+### Auth configs — which apps are connectable, and enabling one that is not
+
+Whether a toolkit in the catalog can actually be CONNECTED depends on our Composio
+project having an ENABLED **auth config** for it. Both adapters resolve one lazily on
+the first connect (`composio-auth-config.ts` here; `internal/integrations/authconfig.go`
+in the gateway, same algorithm): reuse an enabled config if the project has one, else
+create one, managed OAuth first (`use_composio_managed_auth`, Composio's own app: gmail,
+googlesheets, googledrive, googlecalendar, slack…), else the toolkit's first
+user-collectible scheme (API key / bearer, asked for on the hosted connect page). A
+toolkit that is **OAuth-only with NO Composio-managed app** cannot be auto-created:
+connect fails 400 `toolkit_oauth_unavailable` (HOU-1110) — the app sits in the catalog
+but nobody can connect it. Google Forms was the canonical case (PRODUCT-1409): live
+metadata `composio_managed_auth_schemes: []`, `auth_config_details: [OAUTH2]`, zero auth
+configs in the project.
+
+**Runbook — enable such a toolkit for every user.** Nothing in code changes; once an
+enabled auth config exists, the next connect reuses it (per-process cache, no restart
+needed). Prod and staging are DIFFERENT Composio projects (`gateway-composio` secret in
+each cluster's `houston-gateway` ns), so repeat step 3 per environment.
+
+1. **Read what Composio wants**: `GET /api/v3/toolkits/<slug>` with the project key →
+   `auth_config_details[].fields.auth_config_creation` lists required creds
+   (`client_id`, `client_secret`) and the DEFAULT `scopes` + `oauth_redirect_uri`;
+   `GET /api/v3/tools?toolkit_slug=<slug>&toolkit_versions=latest` lists per-tool
+   `scopes` — request the UNION the tools need, never Composio's default blindly
+   (Google Forms' default includes `auth/drive`, a Google RESTRICTED scope that
+   forces a CASA security assessment; the tools work with `forms.body`,
+   `forms.body.readonly`, `forms.responses.readonly` + `drive.file`).
+2. **Register a developer OAuth app on the vendor side** (Console UI only — no API):
+   for Google, GCP project `gethouston` (owns the "Houston" consent screen), enable the
+   API (`gcloud services enable forms.googleapis.com --project gethouston`), add the
+   scopes on the consent screen, create a *Web application* OAuth client whose
+   authorized redirect URIs are BOTH `https://backend.composio.dev/api/v3.1/toolkits/auth/callback`
+   (Composio docs) and `https://backend.composio.dev/api/v1/auth-apps/add` (the toolkit
+   metadata default). Sensitive scopes on a Production consent screen mean Google's
+   OAuth app verification (else the "unverified app" interstitial + 100-user cap) —
+   submit it; the parallel cheaper ask is Composio adding managed auth for the toolkit.
+3. **Create the auth config in Composio** (dashboard "use your own developer
+   credentials", or the API — secrets via env, never in a file):
+   `curl -X POST https://backend.composio.dev/api/v3/auth_configs -H "x-api-key: $COMPOSIO_API_KEY" -H 'content-type: application/json' -d '{"toolkit":{"slug":"googleforms"},"auth_config":{"type":"use_custom_auth","name":"houston-googleforms","authScheme":"OAUTH2","credentials":{"client_id":"'"$CID"'","client_secret":"'"$CSECRET"'","scopes":"https://www.googleapis.com/auth/forms.body,https://www.googleapis.com/auth/forms.body.readonly,https://www.googleapis.com/auth/forms.responses.readonly,https://www.googleapis.com/auth/drive.file"}}}'`
+4. **Verify**: `GET /api/v3/auth_configs?toolkit_slug=<slug>` shows one `ENABLED`
+   config; in the app, Settings > Apps > the app > Connect completes the OAuth dance
+   and the row reads connected; an agent can run one of the toolkit's tools.
+
 ### App-status taxonomy (HOU-681)
 
 Every search result carries an `IntegrationAppStatus`


### PR DESCRIPTION
## Summary

PRODUCT-1409: Google Forms shows in the Composio catalog but cannot be connected. This is an **operator action, not a code change**, so this PR only adds the runbook to `knowledge-base/integrations.md` so the procedure is repeatable for the next such toolkit.

**Root cause.** `googleforms` is OAuth2-only and Composio has **no managed OAuth app** for it (live metadata: `composio_managed_auth_schemes: []`, `auth_config_details: [OAUTH2]`), so a Composio project with no auth config for the toolkit cannot auto-create one. `composio-auth-config.ts` resolves lazily: reuse an enabled config, else create managed, else a user-collectible scheme. With none available the connect fails 400 `toolkit_oauth_unavailable`. gmail/googlesheets work because Composio manages their OAuth app.

**The fix (ops).** Register a Google OAuth client for the Forms API on the vendor console, then create a `use_custom_auth` OAUTH2 auth config for `googleforms` in the Composio project. Once an ENABLED config exists, the next connect reuses it with no deploy or restart.

## What this PR contains

- `knowledge-base/integrations.md`: new subsection "Auth configs — which apps are connectable, and enabling one that is not" with the 4-step runbook (read Composio metadata, register the vendor OAuth app with the exact redirect URIs, create the auth config via API, verify). The scope list is trimmed to what the toolkit's tools actually need, dropping Composio's default `auth/drive` (a Google restricted scope).

## Verification

- The runbook's `POST /api/v3/auth_configs` body was exercised against a test Composio project with a throwaway client id: 201, config `ENABLED`, scopes parsed as intended, then deleted.
- Before: Settings > Apps > Google Forms > Connect fails with the "not available yet: needs an OAuth app registered in the Composio dashboard" state.
- After the ops steps: `GET /api/v3/auth_configs?toolkit_slug=googleforms` shows one ENABLED config; Connect completes the Google OAuth dance and the row reads connected; an agent can run `GOOGLEFORMS_CREATE_FORM`.

Docs-only; no tests affected.