### PR TITLE
Verify Moonshot AI keys against kimi-k3, not the retired kimi-k2-0711-preview (PRODUCT-1411)

### DIFF
--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -741,9 +741,10 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     cost: "Pay as you go",
     installUrl: "https://platform.moonshot.ai",
     apiKeyUrl: "https://platform.moonshot.ai/console/api-keys",
-    // Moonshot's own migration target for the retired kimi-k2 previews, served
-    // to every account incl. newly registered ones — the model auto-selected
-    // on connect. Twin of the runtime's `UNCURATED_DEFAULT_MODEL.moonshotai`
+    // Moonshot's own migration target for the retired kimi-k2 previews — the
+    // model auto-selected on connect. Unlocked by the same >= $1 first top-up
+    // Moonshot requires before any request works, so every account that can
+    // chat has it. Twin of the runtime's `UNCURATED_DEFAULT_MODEL.moonshotai`
     // (the key-verifier probe); keep them in sync (PRODUCT-1411).
     defaultModel: "kimi-k3",
     models: {

--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -203,6 +203,18 @@ export const VISIBLE_MODELS: Readonly<Record<string, ReadonlySet<string>>> = {
     "gemma-4-26b-a4b-it",
     "gemma-4-31b-it",
   ]),
+  // Moonshot AI retired the whole kimi-k2 preview series on 2026-05-25
+  // (platform.kimi.ai/docs/models: kimi-k2-0711-preview, -0905-preview,
+  // -turbo-preview, -thinking, -thinking-turbo) and closed kimi-k2.5 to new
+  // accounts ahead of its 2026-08-31 sunset, but pi-ai's catalog still lists
+  // them all — picking one answers `404 Not found the model` (PRODUCT-1411).
+  // Only what Moonshot serves today. Presentation-only, like every set here.
+  moonshotai: new Set([
+    "kimi-k3",
+    "kimi-k2.7-code",
+    "kimi-k2.7-code-highspeed",
+    "kimi-k2.6",
+  ]),
 };
 
 /** Whether `modelId` may surface for `providerId` (a Houston display id). */
@@ -729,9 +741,12 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     cost: "Pay as you go",
     installUrl: "https://platform.moonshot.ai",
     apiKeyUrl: "https://platform.moonshot.ai/console/api-keys",
+    // Moonshot's own migration target for the retired kimi-k2 previews, served
+    // to every account incl. newly registered ones — the model auto-selected
+    // on connect. Twin of the runtime's `UNCURATED_DEFAULT_MODEL.moonshotai`
+    // (the key-verifier probe); keep them in sync (PRODUCT-1411).
+    defaultModel: "kimi-k3",
     models: {
-      // Backported into pi 0.80.6's catalog by the moonshot-k3 patch
-      // (packages/host/src/providers/moonshot-k3-catalog-patch.ts).
       "kimi-k3": {
         label: "Kimi K3",
         description: "Moonshot's frontier model. Long context, vision.",

--- a/app/tests/provider-overrides-drift.test.ts
+++ b/app/tests/provider-overrides-drift.test.ts
@@ -1,6 +1,7 @@
 import { ok } from "node:assert";
 import { describe, it } from "node:test";
 import {
+  isModelVisible,
   PROVIDER_ID_RENAME,
   PROVIDER_OVERRIDES,
   VISIBLE_MODELS,
@@ -120,5 +121,34 @@ describe("VISIBLE_MODELS stay in sync with the shipped pi-ai catalog", () => {
         );
       });
     }
+  }
+});
+
+describe("PROVIDER_OVERRIDES defaultModel is offered and visible", () => {
+  // The override's `defaultModel` is what auto-selects the moment a key
+  // verifies (`resolveAutoSelect`), so it must be a model the shipped catalog
+  // offers AND one the picker shows — a retired or hidden default sends the
+  // first chat straight into "model not found" (PRODUCT-1411: Moonshot's
+  // catalog-first row was a model Moonshot had already retired).
+  for (const [houstonId, override] of Object.entries(PROVIDER_OVERRIDES)) {
+    const modelId = override.defaultModel;
+    if (!modelId) continue;
+    const piId = houstonToPi[houstonId] ?? houstonId;
+    // Houston-injected SKUs (MiniMax's token plan) are legitimately absent
+    // from pi's catalog; the overrides guard above already pins those.
+    if (!HOUSTON_INJECTED_MODELS.has(`${piId}/${modelId}`)) {
+      it(`${houstonId} default ${modelId} exists in the shipped catalog`, () => {
+        ok(
+          shippedModel(piId, modelId) != null,
+          `PROVIDER_OVERRIDES["${houstonId}"].defaultModel "${modelId}" is not offered by the shipped catalog (provider "${piId}").`,
+        );
+      });
+    }
+    it(`${houstonId} default ${modelId} is visible in the picker`, () => {
+      ok(
+        isModelVisible(houstonId, modelId),
+        `PROVIDER_OVERRIDES["${houstonId}"].defaultModel "${modelId}" is hidden by VISIBLE_MODELS["${houstonId}"].`,
+      );
+    });
   }
 });

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -1138,6 +1138,25 @@ test("opencode RegionError → model_unavailable / region_restricted (HOU-1156)"
     expect(err.reason).toBe("region_restricted");
 });
 
+test("Moonshot 404 'Not found the model' → model_unavailable (PRODUCT-1411)", () => {
+  // Verbatim api.moonshot.ai body for a retired id (the whole kimi-k2 preview
+  // series was discontinued 2026-05-25 while pi's catalog still lists it).
+  // Moonshot checks the key BEFORE the model (a bad key answers 401 even for
+  // a garbage model id), so this proves the credential: switch-model card,
+  // never the report-bug `unknown` card — and at connect time a verified key.
+  const err = classifyProviderError({
+    provider: "moonshotai",
+    model: "kimi-k2-0711-preview",
+    message:
+      '404: {"message":"Not found the model kimi-k2-0711-preview or Permission denied","type":"resource_not_found_error"}',
+  });
+  expect(err.kind).toBe("model_unavailable");
+  if (err.kind === "model_unavailable") {
+    expect(err.reason).toBe("unknown");
+    expect(err.suggested_fallback).toBeNull();
+  }
+});
+
 test("embedded code extraction stays out of 1xx-3xx (HOU-1156)", () => {
   // A stray non-HTTP application code must never veto the auth branch.
   expect(extractHttpStatus('{"code": 200, "message": "ok-ish"}')).toBeNull();

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -1153,8 +1153,22 @@ test("Moonshot 404 'Not found the model' → model_unavailable (PRODUCT-1411)", 
   expect(err.kind).toBe("model_unavailable");
   if (err.kind === "model_unavailable") {
     expect(err.reason).toBe("unknown");
-    expect(err.suggested_fallback).toBeNull();
+    // One-click switch to the broadest-served Kimi model (listed by
+    // /v1/models even on an un-funded account).
+    expect(err.suggested_fallback).toBe("kimi-k2.6");
   }
+});
+
+test("Moonshot gate on the broad fallback itself offers no fallback", () => {
+  const err = classifyProviderError({
+    provider: "moonshotai",
+    model: "kimi-k2.6",
+    message:
+      '404: {"message":"Not found the model kimi-k2.6 or Permission denied","type":"resource_not_found_error"}',
+  });
+  expect(err.kind).toBe("model_unavailable");
+  if (err.kind === "model_unavailable")
+    expect(err.suggested_fallback).toBeNull();
 });
 
 test("embedded code extraction stays out of 1xx-3xx (HOU-1156)", () => {

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -145,6 +145,15 @@ const MODEL_UNAVAILABLE_PATTERNS = [
   // needs a region opt-in, so the switch-model card is the honest one
   // (HOU-1156). The type name carries the `region_restricted` reason.
   "regionerror",
+  // Moonshot AI (api.moonshot.ai / .cn) answers a retired or unknown model id
+  // with 404 `{"message":"Not found the model <id> or Permission denied",
+  // "type":"resource_not_found_error"}`. Verified live: Moonshot checks the
+  // key BEFORE the model (a bad key answers 401 invalid_authentication_error
+  // even for a garbage model id), so this body proves the credential and only
+  // the MODEL is gone — the switch-model card, and at connect time a verified
+  // key rather than "could not verify" (PRODUCT-1411: the whole kimi-k2
+  // preview series was retired 2026-05-25 while pi's catalog still lists it).
+  "not found the model",
 ];
 
 /**

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -277,6 +277,15 @@ export function isNvidiaFunctionGated(
 const NVIDIA_BROAD_FALLBACK = "meta/llama-3.3-70b-instruct";
 
 /**
+ * The Moonshot model offered as the one-click switch target when a pinned
+ * Moonshot model answers `Not found the model` (a retired kimi-k2 preview,
+ * or kimi-k3 on an account that has not made the top-up that unlocks it):
+ * kimi-k2.6 is listed by /v1/models even on an un-funded account, so it is
+ * the broadest-served Kimi model we have evidence for (PRODUCT-1411).
+ */
+const MOONSHOT_BROAD_FALLBACK = "kimi-k2.6";
+
+/**
  * Map a failed model request to a typed `ProviderError`, then stamp WHOSE
  * credential ran the turn (`stampCredentialScope`).
  *
@@ -418,14 +427,25 @@ function classify(input: ProviderErrorInput): ProviderError {
       reason: modelUnavailableReason(lower),
       // Offer a concrete switch target only when we know one AND it isn't the
       // failing model itself (a base Copilot model never reports unavailable).
-      suggested_fallback:
-        provider === "github-copilot" && model !== COPILOT_BASE_FALLBACK
-          ? COPILOT_BASE_FALLBACK
-          : null,
+      suggested_fallback: broadFallback(provider, model),
       message,
     };
   }
   return { kind: "unknown", provider, raw_excerpt: excerpt(message) };
+}
+
+/**
+ * The provider's broadly-served switch target for a `model_unavailable` card,
+ * or null when we know none (or the failing model IS the fallback).
+ */
+function broadFallback(provider: string, model: string): string | null {
+  const fallback =
+    provider === "github-copilot"
+      ? COPILOT_BASE_FALLBACK
+      : provider === "moonshotai"
+        ? MOONSHOT_BROAD_FALLBACK
+        : null;
+  return fallback && fallback !== model ? fallback : null;
 }
 
 function isAuth(lower: string, status: number | null): boolean {

--- a/packages/runtime/src/ai/providers.test.ts
+++ b/packages/runtime/src/ai/providers.test.ts
@@ -97,6 +97,26 @@ test("providerDefaultModel returns each provider's catalog default", () => {
   expect(providerDefaultModel("nope")).toBe("gpt-5.5");
 });
 
+test("uncurated providers with a hand-picked default skip pi's dead first row (PRODUCT-1411)", () => {
+  // Moonshot AI: pi's catalog still lists the kimi-k2 preview series (first
+  // row kimi-k2-0711-preview) that Moonshot retired on 2026-05-25 — every key
+  // probe / first chat on it answered `404 Not found the model`. The default
+  // is Moonshot's migration target, and it is ONE table for every read path
+  // (`modelFor` — the verifier probe — and `providerDefaultModel` — the turn
+  // path with no saved model — both derive from `uncuratedDefaultModel`).
+  expect(providerDefaultModel("moonshotai")).toBe("kimi-k3");
+  const m = safeGetModel(
+    "moonshotai",
+    providerDefaultModel("moonshotai"),
+    false,
+  ) as { provider?: string; id?: string };
+  expect(m.provider).toBe("moonshotai");
+  expect(m.id).toBe("kimi-k3");
+  // NVIDIA (HOU-890) rides the same table — the turn path used to ignore it
+  // and default to the per-account-gated first row.
+  expect(providerDefaultModel("nvidia")).toBe("meta/llama-3.3-70b-instruct");
+});
+
 test("MiniMax uses pi-ai's global minimax provider and model catalog", () => {
   const ids = PROVIDERS.map((p) => p.id);
   expect(ids).toContain("minimax");

--- a/packages/runtime/src/ai/providers.ts
+++ b/packages/runtime/src/ai/providers.ts
@@ -167,7 +167,7 @@ export function providerAuthMethod(id: string): ProviderAuthMethod {
 export function providerDefaultModel(id: string): string {
   const curated = PROVIDERS.find((p) => p.id === id);
   if (curated) return curated.defaultModel;
-  return firstCatalogModel(id) ?? config.codexModel;
+  return uncuratedDefaultModel(id) ?? config.codexModel;
 }
 
 /** The first model id pi lists for a provider, or undefined when it has none. */
@@ -209,27 +209,47 @@ function saveSettings(s: Settings) {
 
 /**
  * Uncurated providers whose alphabetically-first catalog model is a bad
- * default. NVIDIA serves each hosted model per ACCOUNT (HOU-890): the
- * catalog's first row (google/gemma-3-12b-it) answers `404 Function not
- * found for account` for many accounts, so defaulting to it broke both key
- * verification and the first chat; meta/llama-3.3-70b-instruct is served to
- * every account we have evidence from (keep in sync with the classifier's
- * NVIDIA_BROAD_FALLBACK and the verifier's NVIDIA_VERIFY_FALLBACKS).
+ * default — the id the key VERIFIER probes and the first chat runs on, so a
+ * dead first row breaks connect itself:
+ * - NVIDIA serves each hosted model per ACCOUNT (HOU-890): the catalog's
+ *   first row (google/gemma-3-12b-it) answers `404 Function not found for
+ *   account` for many accounts; meta/llama-3.3-70b-instruct is served to
+ *   every account we have evidence from (keep in sync with the classifier's
+ *   NVIDIA_BROAD_FALLBACK and the verifier's NVIDIA_VERIFY_FALLBACKS).
+ * - Moonshot AI RETIRED the whole kimi-k2 preview series on 2026-05-25
+ *   (platform.kimi.ai/docs/models: kimi-k2-0711-preview, -0905-preview,
+ *   -turbo-preview, -thinking, -thinking-turbo), but pi-ai's baked catalog
+ *   still lists them, and the first row IS kimi-k2-0711-preview — every
+ *   Moonshot connect answered `404 Not found the model kimi-k2-0711-preview
+ *   or Permission denied` and read as "couldn't reach Moonshot" (PRODUCT-1411,
+ *   Sentry HOUSTON-APP-54G). kimi-k3 is Moonshot's own migration target and
+ *   is served to every account, including newly registered ones. Twin of the
+ *   frontend's `PROVIDER_OVERRIDES.moonshotai.defaultModel` (auto-select on
+ *   connect reads THAT); keep them in sync.
  */
 const UNCURATED_DEFAULT_MODEL: Record<string, string> = {
   nvidia: "meta/llama-3.3-70b-instruct",
+  moonshotai: "kimi-k3",
 };
+
+/**
+ * The default model for an uncurated pi provider: the hand-picked override
+ * when one exists (and pi still lists it), else the first model pi lists;
+ * undefined when pi has no catalog for it.
+ */
+function uncuratedDefaultModel(provider: string): string | undefined {
+  const preferred = UNCURATED_DEFAULT_MODEL[provider];
+  if (preferred && piModelIds(provider).includes(preferred)) return preferred;
+  return firstCatalogModel(provider);
+}
 
 function defaultModel(provider: ProviderId): string {
   const found = PROVIDERS.find((p) => p.id === provider);
   if (found) return found.defaultModel;
   // Uncurated pi provider: no configured default, so start on the hand-picked
-  // override when one exists (and pi still lists it), else the first model pi
-  // lists, rather than hard-failing the picker/turn.
-  const preferred = UNCURATED_DEFAULT_MODEL[provider];
-  if (preferred && piModelIds(provider).includes(preferred)) return preferred;
-  const first = firstCatalogModel(provider);
-  if (first) return first;
+  // override / first pi model rather than hard-failing the picker/turn.
+  const preferred = uncuratedDefaultModel(provider);
+  if (preferred) return preferred;
   throw new Error(`unknown provider: ${provider}`);
 }
 

--- a/packages/runtime/src/ai/providers.ts
+++ b/packages/runtime/src/ai/providers.ts
@@ -222,10 +222,13 @@ function saveSettings(s: Settings) {
  *   still lists them, and the first row IS kimi-k2-0711-preview — every
  *   Moonshot connect answered `404 Not found the model kimi-k2-0711-preview
  *   or Permission denied` and read as "couldn't reach Moonshot" (PRODUCT-1411,
- *   Sentry HOUSTON-APP-54G). kimi-k3 is Moonshot's own migration target and
- *   is served to every account, including newly registered ones. Twin of the
- *   frontend's `PROVIDER_OVERRIDES.moonshotai.defaultModel` (auto-select on
- *   connect reads THAT); keep them in sync.
+ *   Sentry HOUSTON-APP-54G). kimi-k3 is Moonshot's own migration target;
+ *   it unlocks on the same >= $1 first top-up Moonshot requires before ANY
+ *   request works (an un-funded account answers `429 suspended due to
+ *   insufficient balance` on every model — which the verifier already reads
+ *   as proof of the key), so every account that can chat at all has it.
+ *   Twin of the frontend's `PROVIDER_OVERRIDES.moonshotai.defaultModel`
+ *   (auto-select on connect reads THAT); keep them in sync.
  */
 const UNCURATED_DEFAULT_MODEL: Record<string, string> = {
   nvidia: "meta/llama-3.3-70b-instruct",

--- a/packages/runtime/src/auth/verify-api-key.test.ts
+++ b/packages/runtime/src/auth/verify-api-key.test.ts
@@ -156,6 +156,23 @@ test("a gated model (together's 'Unable to access model') proves auth — verifi
   await expect(verifyApiKey("together", "sk-valid")).resolves.toBeUndefined();
 });
 
+test("moonshotai: a retired probe model's 404 still verifies the key (PRODUCT-1411)", async () => {
+  // Live shape from HOUSTON-APP-54G: pi's catalog kept Moonshot's retired
+  // kimi-k2 previews, so the probe answered `404 Not found the model` and 58
+  // users read "couldn't reach Moonshot AI" for a perfectly good key. Moonshot
+  // authenticates before it looks the model up (a bad key is a 401 even for a
+  // garbage id), so this is a model verdict, not a key verdict — the key
+  // stores; the retired model is a switch-model card later, not a lockout.
+  completeSimple.mockResolvedValue(
+    reply({
+      stopReason: "error",
+      errorMessage:
+        '404: {"message":"Not found the model kimi-k2-0711-preview or Permission denied","type":"resource_not_found_error"}',
+    }),
+  );
+  await expect(verifyApiKey("moonshotai", "sk-valid")).resolves.toBeUndefined();
+});
+
 const nvidiaGate = (model: string) =>
   reply({
     stopReason: "error",


### PR DESCRIPTION
## Summary

Every Moonshot AI connect from a FUNDED account fails with "We couldn't connect to Moonshot AI to verify your key, so nothing was saved. Try again in a moment." (Sentry HOUSTON-APP-54G: 110 events, 58 users, first seen 2026-08-01, all Windows). PRODUCT-1411.

**Root cause.** Moonshot retired the whole `kimi-k2` preview series on 2026-05-25 ([platform.kimi.ai/docs/models](https://platform.kimi.ai/docs/models)), but pi-ai's baked catalog still lists them, and Houston's uncurated default for `moonshotai` was the alphabetically-first catalog row: `kimi-k2-0711-preview`. The connect-time key probe (`verifyApiKey` → `modelFor("moonshotai")`) hit that model, Moonshot answered

```
404: {"message":"Not found the model kimi-k2-0711-preview or Permission denied","type":"resource_not_found_error"}
```

the classifier had no pattern for it (`unknown`), so the verifier threw `provider_unavailable` and the dialog showed the "couldn't reach the provider" copy for a perfectly good key. The provider has been unconnectable since it shipped (2026-07-06, after Moonshot's retirement). The frontend auto-select on connect (`PROVIDER_OVERRIDES` → `models[0]`) would have picked the same dead model for the first chat.

**Why some connects still "worked".** Checked live against a real un-funded Moonshot account: Moonshot gates ALL use behind a ≥ $1 top-up, and an un-funded account answers `429 … suspended due to insufficient balance` on every model — the balance check runs BEFORE the model lookup, and the verifier already reads 429 / insufficient-balance as proof of the key. So un-funded accounts connected (and would hit the top-up card on the first chat); funded accounts got past the balance gate, hit the retired model, and failed. That is the split in Sentry.

**Fix.**
- runtime: `UNCURATED_DEFAULT_MODEL.moonshotai = "kimi-k3"` (Moonshot's own migration target; it unlocks on the same first ≥ $1 top-up Moonshot requires before any request works, so every account that can chat has it). `providerDefaultModel` (turn path, no saved model) now reads the same table as `modelFor` (verifier probe / status listing) — the NVIDIA HOU-890 default previously only applied to one of the two.
- runtime classifier: Moonshot's `Not found the model` 404 → `model_unavailable`, with `kimi-k2.6` as the one-click switch target (listed by `/v1/models` even on an un-funded account). Verified live that Moonshot authenticates BEFORE the model lookup (garbage key + garbage model id → `401 invalid_authentication_error`), so this body proves the credential: switch-model card mid-chat, verified key at connect time.
- app: `PROVIDER_OVERRIDES.moonshotai.defaultModel = "kimi-k3"` (auto-select on connect) + `VISIBLE_MODELS.moonshotai` = {kimi-k3, kimi-k2.7-code, kimi-k2.7-code-highspeed, kimi-k2.6} — hides the retired k2 previews and kimi-k2.5 (closed to new accounts, sunset 2026-08-31). Presentation-only: a pinned id stays runnable.
- drift guard: every override `defaultModel` must exist in the shipped pi catalog and be visible in the picker.

## Before (reproduce the bug)

1. On `main`, open Houston → AI Hub → Moonshot AI → Connect, paste a VALID key from a FUNDED platform.moonshot.ai account.
2. Dialog shows the provider-unavailable copy ("We couldn't connect to Moonshot AI to verify your key…"); nothing is stored. Engine log / Sentry breadcrumb: `could not verify the moonshotai API key: 404: {"message":"Not found the model kimi-k2-0711-preview or Permission denied"...}`.
3. Unit level: `git stash` the two runtime source files and run `pnpm --filter @houston/runtime test` → the `PRODUCT-1411` tests fail (verifier rejects the 404, classifier reads `unknown`, default model is `kimi-k2-0711-preview`).

## After (verify the fix)

1. Same flow with a valid funded key → the dialog closes, the Moonshot card flips to Connected, and the auto-selected model is **Kimi K3**; the first chat runs.
2. The chat model picker for Moonshot lists only kimi-k3 / kimi-k2.7-code / kimi-k2.7-code-highspeed / kimi-k2.6.
3. A garbage key still reads as an invalid key (Moonshot answers 401 → `invalid_key` copy), never "couldn't connect". An un-funded key still connects and the first chat shows the top-up (quota) card.
4. `pnpm --filter @houston/runtime test` (1157 pass), `cd app && pnpm test` (3693 pass), `pnpm --filter @houston/host test`, `pnpm typecheck`, `pnpm check` all green.
