### PR TITLE
fix(app): deleting a team space reaches the gateway instead of pretending (PRODUCT-1410)

### DIFF
--- a/app/src/components/settings/sections/danger.tsx
+++ b/app/src/components/settings/sections/danger.tsx
@@ -3,36 +3,76 @@ import { Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCapabilities } from "../../../hooks/use-capabilities";
+import { showExpectedStateToast } from "../../../lib/error-toast";
+import { openHome } from "../../../lib/home-nav";
 import { canDeleteWorkspace } from "../../../lib/org-roles";
+import { isTeamWorkspace } from "../../../lib/space-id";
+import {
+  classifyWorkspaceDeleteError,
+  isExpectedWorkspaceDeleteError,
+} from "../../../lib/workspace-delete-model";
 import { useAgentStore } from "../../../stores/agents";
+import { useUIStore } from "../../../stores/ui";
 import { useWorkspaceStore } from "../../../stores/workspaces";
 import { SettingsControlRow } from "../settings-row";
 
+/**
+ * Settings → Danger Zone: delete the ACTIVE team space for good (PRODUCT-1410).
+ *
+ * Shown only when all three hold — the deployment can delete a space at all
+ * (`capabilities.workspaceDelete`, the gateway's feature-detect flag: absent on
+ * desktop/self-host, where the one personal workspace is not deletable, and on
+ * gateways that predate the route), the active space is a team (a personal
+ * space goes with the account, never on its own), and the caller owns it
+ * (PRODUCT-1247). Cosmetic gates all: the gateway is the sole enforcer, and
+ * its two business rejections (`has_members`, `subscription_active`) come
+ * back as plain informational toasts that say what to do first.
+ */
 export function DangerSection() {
   const { t } = useTranslation("settings");
   const { capabilities } = useCapabilities();
-  const workspaces = useWorkspaceStore((s) => s.workspaces);
   const currentWorkspace = useWorkspaceStore((s) => s.current);
-  const setCurrentWorkspace = useWorkspaceStore((s) => s.setCurrent);
   const deleteWorkspace = useWorkspaceStore((s) => s.delete);
   const loadAgents = useAgentStore((s) => s.loadAgents);
+  const addToast = useUIStore((s) => s.addToast);
   const [showConfirm, setShowConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   if (!currentWorkspace) return null;
-  // Owner-only (PRODUCT-1247): capabilities carry the caller's role for the
-  // ACTIVE space, which is exactly the workspace this section deletes.
+  if (!capabilities?.workspaceDelete) return null;
+  if (!isTeamWorkspace(currentWorkspace.id)) return null;
   if (!canDeleteWorkspace(capabilities)) return null;
 
-  const isOnlyWorkspace = workspaces.length <= 1;
-
   const handleDelete = async () => {
-    const remaining = workspaces.filter((w) => w.id !== currentWorkspace.id);
-    await deleteWorkspace(currentWorkspace.id);
-    setShowConfirm(false);
-    if (remaining.length > 0) {
-      setCurrentWorkspace(remaining[0]);
-      await loadAgents(remaining[0].id);
+    const name = currentWorkspace.name;
+    setDeleting(true);
+    try {
+      // The store lands on the default space + re-pins the gateway once the
+      // server confirms; every other rejection is toasted by the wire layer.
+      await deleteWorkspace(currentWorkspace.id, {
+        silence: isExpectedWorkspaceDeleteError,
+      });
+    } catch (err) {
+      const failure = classifyWorkspaceDeleteError(err);
+      if (failure === "unknown") return; // red toast + report already shown
+      showExpectedStateToast(
+        t(`dangerZone.blocked.${failure}.title`),
+        t(`dangerZone.blocked.${failure}.body`),
+      );
+      return;
+    } finally {
+      setDeleting(false);
+      setShowConfirm(false);
     }
+    const landing = useWorkspaceStore.getState().current;
+    if (landing) await loadAgents(landing.id);
+    // The active space just switched under the user; Settings belonged to the
+    // deleted one. Land them on home so the switch is visible.
+    openHome();
+    addToast({
+      title: t("dangerZone.deleted", { name }),
+      variant: "success",
+    });
   };
 
   return (
@@ -40,17 +80,13 @@ export function DangerSection() {
       <SettingsControlRow
         icon={Trash2}
         title={t("nav.danger")}
-        description={
-          isOnlyWorkspace
-            ? t("dangerZone.createAnotherFirst")
-            : t("dangerZone.description")
-        }
+        description={t("dangerZone.description")}
         destructive
       >
         <Button
           variant="destructive"
           size="sm"
-          disabled={isOnlyWorkspace}
+          disabled={deleting}
           onClick={() => setShowConfirm(true)}
         >
           {t("dangerZone.confirmLabel")}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -310,8 +310,13 @@ export const tauriWorkspaces = {
     call<Workspace>("create_workspace", () =>
       getEngine().createWorkspace({ name }),
     ),
-  delete: (id: string) =>
-    call<void>("delete_workspace", () => getEngine().deleteWorkspace(id)),
+  delete: (id: string, options?: EngineCallOptions) =>
+    call<void>(
+      "delete_workspace",
+      () => getEngine().deleteWorkspace(id),
+      undefined,
+      options,
+    ),
   rename: (id: string, newName: string) =>
     call<void>("rename_workspace", async () => {
       await getEngine().renameWorkspace(id, { newName });

--- a/app/src/lib/workspace-delete-model.ts
+++ b/app/src/lib/workspace-delete-model.ts
@@ -1,0 +1,56 @@
+import { shareErrorCode } from "./share-via-team.ts";
+
+/**
+ * Pure, DOM-free logic behind deleting a team space from Settings → Danger
+ * Zone (`DELETE /v1/orgs/:slug`, PRODUCT-1410). Kept out of the `.tsx` so the
+ * error taxonomy unit-tests under bare Node, exactly like `invite-model.ts`.
+ *
+ * The gateway is the sole enforcer: this module only decides what the owner is
+ * TOLD when the call comes back, never who may delete.
+ */
+
+/**
+ * The gateway rejections the Danger Zone explains itself:
+ *
+ * - `has_members` (409) — teammates are still in the space. Deleting would
+ *   destroy their agents under them; the owner removes them (or they leave)
+ *   first, then deletes.
+ * - `subscription_active` (409) — the team still carries a live subscription.
+ *   The owner cancels it from Billing first, so a delete can never leave a
+ *   paying subscription behind with nothing under it.
+ * - `personal_space` (403) — a personal space is never deletable on its own
+ *   (it goes with the account). The UI never offers it; a stale switcher can.
+ * - `unknown` — anything else, which keeps the standard red bug toast.
+ */
+export type WorkspaceDeleteFailure =
+  | "has_members"
+  | "subscription_active"
+  | "personal_space"
+  | "unknown";
+
+const EXPECTED_DELETE_CODES = new Set<WorkspaceDeleteFailure>([
+  "has_members",
+  "subscription_active",
+  "personal_space",
+]);
+
+/** Classify a delete rejection into {@link WorkspaceDeleteFailure}. */
+export function classifyWorkspaceDeleteError(
+  err: unknown,
+): WorkspaceDeleteFailure {
+  const code = shareErrorCode(err);
+  return code !== undefined &&
+    EXPECTED_DELETE_CODES.has(code as WorkspaceDeleteFailure)
+    ? (code as WorkspaceDeleteFailure)
+    : "unknown";
+}
+
+/**
+ * True for a rejection the Danger Zone explains with its own plain
+ * informational toast. `call()` silences these (no red bug toast, no Sentry
+ * report) so each one gets exactly ONE surface; every other failure keeps the
+ * standard toast + report path.
+ */
+export function isExpectedWorkspaceDeleteError(err: unknown): boolean {
+  return classifyWorkspaceDeleteError(err) !== "unknown";
+}

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -95,10 +95,24 @@
     "title": "Danger zone",
     "description": "Permanently delete this workspace and all its agents.",
     "deleteButton": "Delete workspace",
-    "createAnotherFirst": "Create another workspace first before deleting this one.",
     "confirmTitle": "Delete \"{{name}}\"?",
     "confirmDescription": "This will permanently delete this workspace and all its agents. This cannot be undone.",
-    "confirmLabel": "Delete"
+    "confirmLabel": "Delete",
+    "deleted": "\"{{name}}\" was deleted.",
+    "blocked": {
+      "has_members": {
+        "title": "Remove the other members first",
+        "body": "People are still in this workspace. Remove them from People, or ask them to leave, then delete it."
+      },
+      "subscription_active": {
+        "title": "Cancel the subscription first",
+        "body": "This workspace still has an active subscription. Cancel it from Billing, then delete the workspace."
+      },
+      "personal_space": {
+        "title": "Your personal workspace can't be deleted",
+        "body": "It goes away with your account. You can delete team workspaces you own."
+      }
+    }
   },
   "deleteAccount": {
     "title": "Delete account",

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -95,10 +95,24 @@
     "title": "Zona de peligro",
     "description": "Elimina este espacio de trabajo y todos sus agentes de forma permanente.",
     "deleteButton": "Eliminar espacio de trabajo",
-    "createAnotherFirst": "Crea otro espacio de trabajo antes de eliminar este.",
     "confirmTitle": "¿Eliminar \"{{name}}\"?",
     "confirmDescription": "Esto eliminará de forma permanente este espacio de trabajo y todos sus agentes. No se puede deshacer.",
-    "confirmLabel": "Eliminar"
+    "confirmLabel": "Eliminar",
+    "deleted": "Se eliminó \"{{name}}\".",
+    "blocked": {
+      "has_members": {
+        "title": "Primero quita a los demás miembros",
+        "body": "Todavía hay personas en este espacio de trabajo. Quítalas desde Personas, o pídeles que salgan, y luego elimínalo."
+      },
+      "subscription_active": {
+        "title": "Primero cancela la suscripción",
+        "body": "Este espacio de trabajo todavía tiene una suscripción activa. Cancélala desde Facturación y luego elimina el espacio de trabajo."
+      },
+      "personal_space": {
+        "title": "Tu espacio de trabajo personal no se puede eliminar",
+        "body": "Se elimina junto con tu cuenta. Puedes eliminar los espacios de trabajo de equipo que te pertenecen."
+      }
+    }
   },
   "deleteAccount": {
     "title": "Eliminar cuenta",

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -95,10 +95,24 @@
     "title": "Zona de perigo",
     "description": "Exclui este espaço de trabalho e todos os seus agentes de forma permanente.",
     "deleteButton": "Excluir espaço de trabalho",
-    "createAnotherFirst": "Crie outro espaço de trabalho antes de excluir este.",
     "confirmTitle": "Excluir \"{{name}}\"?",
     "confirmDescription": "Isso exclui este espaço de trabalho e todos os seus agentes de forma permanente. Não dá para desfazer.",
-    "confirmLabel": "Excluir"
+    "confirmLabel": "Excluir",
+    "deleted": "\"{{name}}\" foi excluído.",
+    "blocked": {
+      "has_members": {
+        "title": "Remova os outros membros primeiro",
+        "body": "Ainda há pessoas neste espaço de trabalho. Remova-as em Pessoas, ou peça para saírem, e depois exclua o espaço."
+      },
+      "subscription_active": {
+        "title": "Cancele a assinatura primeiro",
+        "body": "Este espaço de trabalho ainda tem uma assinatura ativa. Cancele em Cobrança e depois exclua o espaço de trabalho."
+      },
+      "personal_space": {
+        "title": "Seu espaço de trabalho pessoal não pode ser excluído",
+        "body": "Ele é excluído junto com a sua conta. Você pode excluir os espaços de trabalho de equipe que são seus."
+      }
+    }
   },
   "deleteAccount": {
     "title": "Excluir conta",

--- a/app/src/stores/workspace-refresh-apply.ts
+++ b/app/src/stores/workspace-refresh-apply.ts
@@ -1,0 +1,31 @@
+import { setActiveOrg } from "../lib/engine";
+import { queryClient } from "../lib/query-client";
+import { resetCacheForSpaceChange } from "../lib/space-cache";
+import { orgSlugFromWorkspaceId } from "../lib/space-id";
+import { tauriPreferences } from "../lib/tauri";
+import type { Workspace } from "../lib/types";
+import type { SpacesRefreshPlan } from "../lib/workspace-refresh";
+
+/**
+ * Apply a `planSpacesRefresh` plan to the workspace store — the one place the
+ * "a space vanished from under the user" merge turns into store + gateway side
+ * effects, shared by the background live-spaces refresh (the user was removed
+ * from a team) and a delete the user drove themselves (PRODUCT-1410).
+ *
+ * `reselect` (the active space is gone) re-pins exactly like `setCurrent`:
+ * persists the landing space, re-points the gateway (`x-houston-org` + the
+ * event stream's `?org=`) and drops the space-scoped query cache. Staying
+ * pinned to a space the gateway now 403s/404s would strand every request.
+ */
+export function applyRefreshPlan(
+  plan: SpacesRefreshPlan,
+  set: (patch: { workspaces: Workspace[]; current: Workspace | null }) => void,
+): void {
+  if (plan.kind === "unchanged") return;
+  set({ workspaces: plan.workspaces, current: plan.current });
+  if (plan.kind === "reselect" && plan.current) {
+    tauriPreferences.set("last_workspace_id", plan.current.id);
+    const orgChanged = setActiveOrg(orgSlugFromWorkspaceId(plan.current.id));
+    resetCacheForSpaceChange(queryClient, orgChanged);
+  }
+}

--- a/app/src/stores/workspaces.ts
+++ b/app/src/stores/workspaces.ts
@@ -2,12 +2,18 @@ import { create } from "zustand";
 import { analytics } from "../lib/analytics";
 import { setActiveOrg } from "../lib/engine";
 import { queryClient } from "../lib/query-client";
+import { queryKeys } from "../lib/query-keys";
 import { resetCacheForSpaceChange } from "../lib/space-cache";
 import { orgSlugFromWorkspaceId } from "../lib/space-id";
-import { tauriPreferences, tauriWorkspaces } from "../lib/tauri";
+import {
+  type EngineCallOptions,
+  tauriPreferences,
+  tauriWorkspaces,
+} from "../lib/tauri";
 import type { Workspace } from "../lib/types";
 import { planSpacesRefresh } from "../lib/workspace-refresh";
 import { resolveActiveWorkspace } from "../lib/workspace-switch";
+import { applyRefreshPlan } from "./workspace-refresh-apply";
 
 interface WorkspaceState {
   workspaces: Workspace[];
@@ -34,7 +40,12 @@ interface WorkspaceState {
   refreshWorkspaces: () => Promise<void>;
   setCurrent: (ws: Workspace) => void;
   create: (name: string) => Promise<Workspace>;
-  delete: (id: string) => Promise<void>;
+  /** Delete a team space for good (PRODUCT-1410). Resolves once the server has
+   *  destroyed it and the store no longer lists it; when it was the active
+   *  space, the store has already landed on the default space and re-pinned
+   *  the gateway exactly like a user-driven switch. Rejections propagate
+   *  (surfaced by the wire layer / the caller's `silence` predicate). */
+  delete: (id: string, options?: EngineCallOptions) => Promise<void>;
   rename: (id: string, newName: string) => Promise<void>;
   /** Set (or clear, with null) the workspace's UI-locale override. */
   setLocale: (id: string, locale: string | null) => Promise<void>;
@@ -97,17 +108,12 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
     const prev = get();
     if (prev.loading) return; // a real load started mid-flight; it wins
-    const plan = planSpacesRefresh(prev.workspaces, prev.current, fresh);
-    if (plan.kind === "unchanged") return;
-    set({ workspaces: plan.workspaces, current: plan.current });
-    if (plan.kind === "reselect" && plan.current) {
-      // The active space vanished (removed from the team while the app was
-      // open): re-pin like setCurrent — staying pinned to a space the gateway
-      // now 403s would strand every request.
-      tauriPreferences.set("last_workspace_id", plan.current.id);
-      const orgChanged = setActiveOrg(orgSlugFromWorkspaceId(plan.current.id));
-      resetCacheForSpaceChange(queryClient, orgChanged);
-    }
+    // The active space vanishing here means the user was removed from the team
+    // while the app was open.
+    applyRefreshPlan(
+      planSpacesRefresh(prev.workspaces, prev.current, fresh),
+      set,
+    );
   },
 
   setCurrent: (ws) => {
@@ -133,16 +139,27 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     return ws;
   },
 
-  delete: async (id) => {
-    await tauriWorkspaces.delete(id);
-    set((s) => {
-      const workspaces = s.workspaces.filter((w) => w.id !== id);
-      const current =
-        s.current?.id === id
-          ? (workspaces.find((w) => w.isDefault) ?? workspaces[0] ?? null)
-          : s.current;
-      return { workspaces, current };
-    });
+  delete: async (id, options) => {
+    // The server call comes FIRST and its rejection propagates: the row leaves
+    // the store only once the space is really gone. (The v3 adapter's old
+    // no-op stub let this "succeed" and drop the row locally while the space
+    // lived on and re-listed on the next refresh — PRODUCT-1410.)
+    await tauriWorkspaces.delete(id, options);
+    const prev = get();
+    // Same merge as a live refresh that no longer lists the space: when it was
+    // the active one this is a `reselect`, which lands on the default space
+    // AND re-pins the gateway + resets the space-scoped caches — dropping the
+    // row without re-pinning would leave every request addressed to a space
+    // that now 404s. The next refresh tick then confirms the server agrees.
+    applyRefreshPlan(
+      planSpacesRefresh(
+        prev.workspaces,
+        prev.current,
+        prev.workspaces.filter((w) => w.id !== id),
+      ),
+      set,
+    );
+    queryClient.invalidateQueries({ queryKey: queryKeys.orgs() });
   },
 
   rename: async (id, newName) => {

--- a/app/tests/workspace-delete-model.test.ts
+++ b/app/tests/workspace-delete-model.test.ts
@@ -1,0 +1,68 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  classifyWorkspaceDeleteError,
+  isExpectedWorkspaceDeleteError,
+} from "../src/lib/workspace-delete-model.ts";
+
+/**
+ * PRODUCT-1410: the Danger Zone's error taxonomy for `DELETE /v1/orgs/:slug`,
+ * written against the gateway's flat `{error, code}` body thrown as a
+ * `HoustonEngineError`-shaped object — the only shape production produces.
+ */
+function gatewayError(status: number, error: string, code?: string) {
+  return { status, body: code === undefined ? { error } : { error, code } };
+}
+
+describe("classifyWorkspaceDeleteError", () => {
+  it("classifies the gateway's expected business rejections", () => {
+    strictEqual(
+      classifyWorkspaceDeleteError(
+        gatewayError(409, "members remain", "has_members"),
+      ),
+      "has_members",
+    );
+    strictEqual(
+      classifyWorkspaceDeleteError(
+        gatewayError(409, "subscription active", "subscription_active"),
+      ),
+      "subscription_active",
+    );
+    strictEqual(
+      classifyWorkspaceDeleteError(
+        gatewayError(403, "personal space", "personal_space"),
+      ),
+      "personal_space",
+    );
+  });
+
+  it("sends everything else to the standard red toast (unknown)", () => {
+    strictEqual(
+      classifyWorkspaceDeleteError(gatewayError(403, "not allowed")),
+      "unknown",
+    );
+    strictEqual(
+      classifyWorkspaceDeleteError(
+        gatewayError(404, "org not found", "org_not_found"),
+      ),
+      "unknown",
+    );
+    strictEqual(classifyWorkspaceDeleteError(new Error("boom")), "unknown");
+    strictEqual(classifyWorkspaceDeleteError(undefined), "unknown");
+  });
+});
+
+describe("isExpectedWorkspaceDeleteError", () => {
+  it("is true exactly for the classified codes", () => {
+    strictEqual(
+      isExpectedWorkspaceDeleteError(
+        gatewayError(409, "members remain", "has_members"),
+      ),
+      true,
+    );
+    strictEqual(
+      isExpectedWorkspaceDeleteError(gatewayError(500, "boom")),
+      false,
+    );
+  });
+});

--- a/knowledge-base/spaces.md
+++ b/knowledge-base/spaces.md
@@ -135,6 +135,39 @@ every client gate here is cosmetic.
 - `POST /v1/orgs` is NOT idempotent: a lost response is reconciled via `listOrgs`
   (`reconcileCreatedTeam`), never blind-retried.
 
+## Delete-team (Settings → Danger Zone)
+
+- **Route** — `DELETE /v1/orgs/:slug` (cross-org, like the rest of `/v1/orgs`; the
+  gateway is the sole enforcer). `204` = the space and everything in it is gone.
+  Rejections are FLAT `{error, code}`: `404 org_not_found` (unknown, or not the
+  caller's), `403 personal_space` (a personal space goes with the account, never on
+  its own), plain `403` (not the owner), `409 has_members` (teammates remain: remove
+  them first), `409 subscription_active` (a live subscription: cancel it from Billing
+  first). Conservative v1: only a solo owner with no live subscription can delete.
+- **Feature-detect** — `capabilities.workspaceDelete` (gateway-injected, like
+  `apiKeys` / `agentTeams`). The Danger Zone
+  (`app/src/components/settings/sections/danger.tsx`) renders only when the flag is
+  on AND the active space is a team (`isTeamWorkspace`) AND the caller owns it
+  (`canDeleteWorkspace`, PRODUCT-1247). Desktop / self-host / a gateway that predates
+  the route: no section at all — the one personal workspace was never deletable, and
+  the old always-disabled "create another workspace first" row is gone with it.
+- **Wire** — `deleteOrg` (`packages/web/src/engine-adapter/cp/spaces-billing.ts`),
+  `deleteWorkspace(id)` on the workspaces mixin (`org:<slug>` → `deleteOrg`; the
+  personal row and an off-cloud client THROW), app wrapper `tauriWorkspaces.delete`.
+  **PRODUCT-1410:** the mixin used to be an empty stub, so the row left the local
+  store while the space lived on and re-listed on the next refresh.
+- **After the 204** — the workspace store's `delete` applies the same
+  `planSpacesRefresh` merge as the live-spaces poll with the row removed
+  (`stores/workspace-refresh-apply.ts`): the deleted space was active ⇒ `reselect`
+  onto the default space, persist `last_workspace_id`, `setActiveOrg`, and reset the
+  space-scoped caches; then the section reloads agents and `openHome()`s so the switch
+  is visible. Error taxonomy `classifyWorkspaceDeleteError` /
+  `isExpectedWorkspaceDeleteError` (`app/src/lib/workspace-delete-model.ts`); the
+  expected codes are silenced from `call()` and toasted plainly
+  (`settings:dangerZone.blocked.*`).
+- Tests: `app/tests/workspace-delete-model.test.ts`,
+  `packages/web/tests/workspace-delete.test.ts`.
+
 ## Invite inbox (the invitee side)
 
 Auto-join fires only on an account's FIRST-EVER contact with the gateway, so for an

--- a/packages/web/src/engine-adapter/client/workspaces-mixin.ts
+++ b/packages/web/src/engine-adapter/client/workspaces-mixin.ts
@@ -4,12 +4,27 @@ import type {
 } from "../../../../../ui/engine-client/src/types";
 import {
   listWorkspaces as cpListWorkspaces,
+  deleteOrg,
   retryTransientRead,
 } from "../control-plane";
 import { syntheticWorkspace } from "../synthetic";
 import { HoustonEngineError } from "./errors";
 import type { BaseCtor } from "./mixin";
 import { SidebarLayoutStore } from "./sidebar-layout-store";
+
+/** Exactly `org:` + 16 lowercase hex chars — the C8 team-space id grammar. */
+const TEAM_WORKSPACE_ID = /^org:([a-f0-9]{16})$/;
+
+/**
+ * The org slug behind a team workspace id, or `null` for the personal row (the
+ * synthetic "default" or any opaque non-`org:` id). Mirrors the app's
+ * `orgSlugFromWorkspaceId` (`app/src/lib/space-id.ts`); the adapter keeps its
+ * own copy because `packages/web` never imports from `app/`.
+ */
+export function teamSlugFromWorkspaceId(id: string): string | null {
+  const match = TEAM_WORKSPACE_ID.exec(id);
+  return match ? match[1] : null;
+}
 
 export function WorkspacesMixin<TBase extends BaseCtor>(Base: TBase) {
   class Workspaces extends Base {
@@ -62,7 +77,21 @@ export function WorkspacesMixin<TBase extends BaseCtor>(Base: TBase) {
       const { provider, model } = await this.ctx.activeOld();
       return syntheticWorkspace(provider, model);
     }
-    async deleteWorkspace(): Promise<void> {}
+    // Delete a team space (PRODUCT-1410). Only an `org:<slug>` row is
+    // deletable, and only through the gateway: the personal workspace is the
+    // synthetic row every deployment keeps (a hosted personal space goes away
+    // with the account, never on its own), and a local/self-host list holds
+    // nothing but that row. Off-cloud, or asked for the personal row, this
+    // THROWS — the old empty stub let the UI drop the row locally and call it
+    // deleted while the space lived on and re-listed on the next refresh.
+    async deleteWorkspace(id: string): Promise<void> {
+      const slug = teamSlugFromWorkspaceId(id);
+      if (slug === null)
+        throw new Error("Your personal workspace can't be deleted.");
+      if (!this.ctx.cp)
+        throw new Error("Deleting a team needs the hosted gateway.");
+      await deleteOrg(this.ctx.cp, slug);
+    }
     async setWorkspaceLocale(
       _id: string,
       locale: string | null,

--- a/packages/web/src/engine-adapter/cp/spaces-billing.ts
+++ b/packages/web/src/engine-adapter/cp/spaces-billing.ts
@@ -43,6 +43,24 @@ export async function createOrg(
 }
 
 /**
+ * Delete a team space the caller owns (`DELETE /v1/orgs/:slug`, PRODUCT-1410).
+ * Never degrades: every rejection is a state the owner must see — `404
+ * org_not_found` (already gone, or not theirs), `403 personal_space` (a
+ * personal space is never deletable), `403` plain not-allowed (not the owner),
+ * `409 has_members` (teammates remain — remove them first), `409
+ * subscription_active` (a live subscription — cancel it first). A `204` means
+ * the space and everything in it is gone for good; the caller must re-list.
+ */
+export async function deleteOrg(
+  cfg: ControlPlaneConfig,
+  slug: string,
+): Promise<void> {
+  await cpFetch(cfg, `/v1/orgs/${encodeURIComponent(slug)}`, {
+    method: "DELETE",
+  });
+}
+
+/**
  * Accept a pending invite addressed to the caller (C8), by the id that rides
  * `listOrgs().invites`. Answers the joined space (the gateway wraps it as
  * `{org}`) so the caller can name it without a second read. Never degrades —

--- a/packages/web/tests/workspace-delete.test.ts
+++ b/packages/web/tests/workspace-delete.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { HoustonClient } from "../src/engine-adapter/client";
+import { HoustonEngineError } from "../src/engine-adapter/client/errors";
+import { teamSlugFromWorkspaceId } from "../src/engine-adapter/client/workspaces-mixin";
+
+/**
+ * PRODUCT-1410 — "Workspace is not being deleted".
+ *
+ * `deleteWorkspace` on the v3 adapter used to be `async () => {}`: the Settings
+ * Danger Zone "succeeded", dropped the row from the local store, and the team
+ * space came straight back on the next spaces refresh (it was never touched
+ * server-side). The posture now: a team row (`org:<slug>`) issues the real
+ * `DELETE /v1/orgs/:slug` and lets every rejection propagate; the personal row
+ * and an off-cloud client THROW instead of pretending.
+ */
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.clearAllMocks();
+});
+
+function stubFetch(status: number, body: unknown = {}) {
+  const calls: { url: string; method: string | undefined }[] = [];
+  globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    calls.push({ url: String(input), method: init?.method });
+    return new Response(status === 204 ? null : JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+const CFG = { baseUrl: "https://gateway.example", token: "t" };
+const cloud = () => new HoustonClient({ ...CFG, controlPlane: true });
+const local = () => new HoustonClient({ ...CFG, controlPlane: false });
+
+const TEAM_ID = "org:00112233aabbccdd";
+
+test("teamSlugFromWorkspaceId reads only the C8 team-id grammar", () => {
+  expect(teamSlugFromWorkspaceId(TEAM_ID)).toBe("00112233aabbccdd");
+  expect(teamSlugFromWorkspaceId("default")).toBeNull();
+  expect(teamSlugFromWorkspaceId("Houston")).toBeNull();
+  expect(teamSlugFromWorkspaceId("org:")).toBeNull();
+  expect(teamSlugFromWorkspaceId("org:not-hex-slug!")).toBeNull();
+});
+
+test("a team row issues DELETE /v1/orgs/:slug on the gateway and resolves on 204", async () => {
+  const calls = stubFetch(204);
+
+  await expect(cloud().deleteWorkspace(TEAM_ID)).resolves.toBeUndefined();
+
+  expect(calls).toEqual([
+    {
+      url: "https://gateway.example/v1/orgs/00112233aabbccdd",
+      method: "DELETE",
+    },
+  ]);
+});
+
+test("a gateway rejection propagates with its code — never a silent success", async () => {
+  stubFetch(409, { error: "members remain", code: "has_members", members: 2 });
+
+  const err = await cloud()
+    .deleteWorkspace(TEAM_ID)
+    .catch((e: unknown) => e);
+
+  expect(err).toBeInstanceOf(HoustonEngineError);
+  expect((err as HoustonEngineError).status).toBe(409);
+  expect((err as HoustonEngineError).body).toMatchObject({
+    code: "has_members",
+  });
+});
+
+test("the personal row is never deletable — throws without touching the wire", async () => {
+  const calls = stubFetch(204);
+
+  await expect(cloud().deleteWorkspace("default")).rejects.toThrow(
+    /personal workspace can't be deleted/,
+  );
+  expect(calls).toEqual([]);
+});
+
+test("off-cloud there is no gateway to delete a team on — throws, no wire call", async () => {
+  const calls = stubFetch(204);
+
+  await expect(local().deleteWorkspace(TEAM_ID)).rejects.toThrow(
+    /needs the hosted gateway/,
+  );
+  expect(calls).toEqual([]);
+});

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -147,6 +147,15 @@ export interface Capabilities {
    * `teams` (which flags multiplayer itself). The gateway is the sole enforcer.
    */
   agentTeams?: boolean;
+  /**
+   * Whether this deployment can delete a team space (`DELETE /v1/orgs/:slug`,
+   * PRODUCT-1410). A feature-detect flag the frontend reads to show the
+   * Settings Danger Zone at all: absent/false on desktop/self-host (one
+   * personal workspace, nothing to delete) and on gateways that predate the
+   * route, where the affordance would only pretend. The gateway is the sole
+   * enforcer (owner of a solo team with no live subscription).
+   */
+  workspaceDelete?: boolean;
 }
 
 // ---------- Org / roles (multiplayer) ----------


### PR DESCRIPTION
## Root cause

Settings → Danger Zone "Delete workspace" never deleted anything. The v3 engine adapter's `deleteWorkspace()` was an empty stub (`async () => {}`), so the store dropped the row locally, the UI switched to Personal, and the team space came straight back on the next spaces refresh — it was never touched server-side. On top of that, the hosted gateway had no route to delete a team at all (hard-delete was deferred in its v1), so even a wired client had nothing to call. The gateway half ships separately (PRODUCT-1410 gateway change: `DELETE /v1/orgs/:slug` + `capabilities.workspaceDelete`); this PR is the app half.

## What changed

- **Real wire call.** `deleteWorkspace(id)` on the workspaces mixin issues `DELETE /v1/orgs/:slug` for an `org:<slug>` row (`deleteOrg` in `cp/spaces-billing.ts`) and lets every rejection propagate. The personal row and an off-cloud client THROW instead of pretending.
- **Honest gate.** The Danger Zone renders only when the gateway advertises `capabilities.workspaceDelete` (feature-detect, same pattern as `apiKeys` / `agentTeams`), the active space is a team, and the caller owns it (PRODUCT-1247). Until a gateway advertises the flag the section is not shown at all — including the old always-disabled "create another workspace first" row on desktop, where the one personal workspace was never deletable.
- **Correct landing.** On success the store applies the same `planSpacesRefresh` merge as the live-spaces poll with the row removed (factored into `stores/workspace-refresh-apply.ts`): lands on the default space, persists `last_workspace_id`, re-pins `setActiveOrg`, resets the space-scoped caches, invalidates the spaces list; the section then reloads agents and opens home, with a success toast.
- **Expected rejections explained.** `workspace-delete-model.ts` classifies `has_members`, `subscription_active`, `personal_space`; they are silenced from the red bug toast and explained plainly (`settings:dangerZone.blocked.*`, en/es/pt).
- KB: `knowledge-base/spaces.md` → Delete-team.

## Verification

`pnpm check`, `pnpm typecheck`, `cd app && pnpm test && pnpm check-locales`, `pnpm --filter houston-web test` (new `tests/workspace-delete.test.ts`) all green.

Before (any build before this PR, against any gateway):
1. Sign in to the hosted product as the owner of a team space with no other members; switch to that space.
2. Settings → Delete workspace → confirm. The switcher shows Personal.
3. Reopen the switcher (or wait for the live-spaces poll / relaunch): the "deleted" team is back. Nothing left the server (`GET /v1/orgs` still lists it).

After (this PR, against a gateway that serves `DELETE /v1/orgs/:slug` and advertises `workspaceDelete: true`):
1. Same setup → Settings → Delete workspace → confirm.
2. The app lands on home in Personal with the "<name> was deleted." toast; the switcher no longer lists the team, and it stays gone across refresh and relaunch (`GET /v1/orgs` no longer lists it).
3. With another member still in the team: an info toast "Remove the other members first" (no red bug toast, no Sentry). Against a gateway WITHOUT the flag (or on desktop / self-host): no Danger Zone row at all.

Linear: PRODUCT-1410
