### PR TITLE
fix(skills): stop Sentry capture of expected community-preview misses (PRODUCT-1422)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,12 @@ jobs:
           # return malformed InRelease files the web job dies before tests run.
           sudo rm -f /etc/apt/sources.list.d/azure-cli.*
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.*
+          # The image's apt mirrorlist tries azure.archive.ubuntu.com before
+          # archive.ubuntu.com; when the Azure mirror is down, every index
+          # fetch burns its retry loop against it first and apt-get update can
+          # eat the whole 30-minute job (shard timeouts on 2026-08-19). Skip
+          # straight to the canonical archive.
+          echo "https://archive.ubuntu.com/ubuntu/	priority:1" | sudo tee /etc/apt/apt-mirrors.txt
 
       - name: Install Playwright Chromium
         run: pnpm --filter houston-web exec playwright install --with-deps chromium

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -792,7 +792,15 @@ export const tauriSkills = {
       () =>
         getEngine().previewCommunitySkill(agentPath, source, skillId, signal),
       undefined,
-      { toast: false },
+      // `skill_not_in_repo` on a preview is an expected upstream state, not a
+      // Houston bug: the skills.sh index keeps listing skills whose GitHub
+      // repo was deleted, and preview deliberately skips the recursive scan
+      // that install runs (github-lookup.ts), so deeply nested skills miss
+      // here yet install fine. The detail modal already shows its visible
+      // error state (use-skill-preview.ts), so no Sentry capture — that
+      // second surface is what kept HOUSTON-APP-4XZ alive after PRODUCT-1382
+      // fixed every findable layout. Every other failure stays captured.
+      { toast: false, silenceKinds: ["skill_not_in_repo"] },
     ),
   installCommunity: (
     agentPath: string,


### PR DESCRIPTION
## Summary

PRODUCT-1422 — Sentry `HOUSTON-APP-4XZ` (`preview_community_skill … engine error 404`) kept firing after the PRODUCT-1382 lookup fix (#1329) shipped in 0.6.3.

**What the Sentry data shows:** of 150 sampled events, 145 come from pre-fix releases (0.5.40 → 0.6.2 — the fix first shipped in 0.6.3). The only 5 post-fix (0.6.3) events are a single two-minute burst from one browsing session, and none of them are the PRODUCT-1382 bug:

- 4 events point at a source repo that no longer exists on GitHub (the skills.sh index still lists its skills, so the card renders but every lookup tier 404s). No client-side lookup can resolve a deleted repo.
- 1 event is a skill nested four directories deep in a large template repo — only the recursive tree scan finds it, and preview deliberately skips that scan (documented cost tradeoff in `github-lookup.ts`); install runs the deep scan and works.

**Root cause of the remaining noise:** both residual classes are expected upstream states, not Houston bugs. The detail modal already renders its visible error state on a preview miss (`use-skill-preview.ts`), so the `call()` layer's toast-suppressed Sentry capture was a second, redundant surface — and it's what keeps resurrecting this issue as new Linear tickets.

**Fix:** silence exactly the typed `skill_not_in_repo` kind on the preview call via the existing `silenceKinds` mechanism (same pattern as the Composio expected-state kinds). The lookup's only terminal not-there error is `skill_not_in_repo`, so nothing else is affected: the miss is still logged to the local log tail, the modal still shows its error state, and every other preview failure (rate-limit, offline, 5xx) keeps capturing to Sentry.

## Verification

Before the fix (reproduce):
1. On a build ≥ 0.6.3, open an agent's Skills tab → Discover, search `salesloft`, and open the card whose source repo no longer exists on GitHub (listed with ~68 installs).
2. The modal shows the couldn't-load-description state (correct), but a `preview_community_skill` error event is also captured to Sentry under HOUSTON-APP-4XZ.

After the fix:
1. Same click: modal shows the same couldn't-load state, the miss appears in the local frontend log tail (`[engine:preview_community_skill] …`), and no Sentry event is captured.
2. A non-404 preview failure (e.g. kill the network mid-preview) still surfaces through the existing classified paths.

Gates: `pnpm check` clean, full workspace typecheck clean, `cd app && pnpm test` 3698/3698 pass.

## Suggested follow-up (not in this PR)
Resolve HOUSTON-APP-4XZ in Sentry at ≥ the release that carries this change, so only a genuine lookup regression reopens it.