### PR TITLE
Collapse same-detail probe failures in one serve sweep into ONE incident (PRODUCT-1423)

### DIFF
--- a/packages/runtime/src/auth/serve-log.test.ts
+++ b/packages/runtime/src/auth/serve-log.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, expect, test, vi } from "vitest";
 import {
   logServeProbeFailure,
+  logServeProbeFailures,
   logServeSweepFailure,
   noteServeProbeOk,
   noteServeSweepOk,
@@ -63,6 +64,64 @@ test("a uniformly failed sweep is ONE incident: one error, warnings on repeat, o
   expect(info).toHaveBeenCalledWith("[serve] control plane reachable again");
   noteServeSweepOk(); // silent without a prior incident
   expect(info).toHaveBeenCalledOnce();
+});
+
+test("probes failing ALIKE in one sweep are ONE incident, not one per provider (PRODUCT-1423)", () => {
+  const blip = '500: {"error":"fetch failed"}';
+  logServeProbeFailures([
+    { id: "google", detail: blip },
+    { id: "openrouter", detail: blip },
+    { id: "opencode-go", detail: blip },
+  ]);
+  expect(error).toHaveBeenCalledOnce();
+  expect(error).toHaveBeenCalledWith(
+    `[serve] credential probes for google, openrouter, opencode-go failed alike: ${blip}`,
+  );
+  // The identical repeat — in any grouping — is a warning, never a new event.
+  logServeProbeFailures([
+    { id: "google", detail: blip },
+    { id: "openrouter", detail: blip },
+    { id: "opencode-go", detail: blip },
+  ]);
+  logServeProbeFailures([{ id: "google", detail: blip }]);
+  expect(error).toHaveBeenCalledOnce();
+  expect(warn).toHaveBeenCalledTimes(2);
+});
+
+test("a group with any NEWLY failing member logs a fresh error, and recovery re-arms it", () => {
+  const blip = '500: {"error":"fetch failed"}';
+  logServeProbeFailures([
+    { id: "google", detail: blip },
+    { id: "openrouter", detail: blip },
+  ]);
+  logServeProbeFailures([
+    { id: "google", detail: blip },
+    { id: "opencode-go", detail: blip },
+  ]);
+  expect(error).toHaveBeenCalledTimes(2);
+  noteServeProbeOk("google");
+  noteServeProbeOk("opencode-go");
+  logServeProbeFailures([
+    { id: "google", detail: blip },
+    { id: "opencode-go", detail: blip },
+  ]);
+  expect(error).toHaveBeenCalledTimes(3);
+});
+
+test("distinct failure details stay distinct incidents; a lone failure keeps the per-provider path", () => {
+  logServeProbeFailures([
+    { id: "google", detail: '500: {"error":"fetch failed"}' },
+    { id: "openrouter", detail: '500: {"error":"fetch failed"}' },
+    { id: "anthropic", detail: "502: credential expired" },
+  ]);
+  expect(error).toHaveBeenCalledTimes(2);
+  expect(error).toHaveBeenCalledWith(
+    "[serve] credential anthropic: 502: credential expired",
+  );
+  // The grouped entry point and the per-provider path share one transition
+  // map: the lone failure's identical repeat is the same incident.
+  logServeProbeFailure("anthropic", "502: credential expired");
+  expect(error).toHaveBeenCalledTimes(2);
 });
 
 test("the sweep incident is tracked apart from per-provider failures", () => {

--- a/packages/runtime/src/auth/serve-log.ts
+++ b/packages/runtime/src/auth/serve-log.ts
@@ -42,6 +42,41 @@ export function logServeSweepFailure(count: number, detail: string): void {
   console.error(`[serve] ${line}`);
 }
 
+/**
+ * A non-uniform sweep's failures, collapsed by shared detail. SEVERAL probes
+ * failing the SAME way in one sweep is still one incident, not one per
+ * provider: a control-plane blip seen through the gateway answers
+ * `500: {"error":"fetch failed"}` to exactly the probes in flight during the
+ * window (PRODUCT-1423) — the partial-sweep sibling of logServeSweepFailure.
+ * A detail only one provider hit stays that provider's own incident. Dedup
+ * rides the per-provider transition map, so a group repeats as a warning and
+ * each member's recovery re-arms it.
+ */
+export function logServeProbeFailures(
+  failures: ReadonlyArray<{ id: string; detail: string }>,
+): void {
+  const byDetail = new Map<string, string[]>();
+  for (const f of failures) {
+    const ids = byDetail.get(f.detail);
+    if (ids) ids.push(f.id);
+    else byDetail.set(f.detail, [f.id]);
+  }
+  for (const [detail, ids] of byDetail) {
+    const lone = ids.length === 1 ? ids[0] : undefined;
+    if (lone !== undefined) {
+      logServeProbeFailure(lone, detail);
+      continue;
+    }
+    const group = `credential probes for ${ids.join(", ")}`;
+    if (ids.every((id) => lastFailureDetail.get(id) === detail)) {
+      console.warn(`[serve] ${group} still failing: ${detail}`);
+      continue;
+    }
+    for (const id of ids) lastFailureDetail.set(id, detail);
+    console.error(`[serve] ${group} failed alike: ${detail}`);
+  }
+}
+
 /** Called after any sweep that did NOT fail uniformly (some probe answered). */
 export function noteServeSweepOk(): void {
   if (lastFailureDetail.delete(SWEEP_KEY))

--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -865,6 +865,50 @@ test("a sweep where EVERY probe is refused logs ONE error, not one per provider 
   }
 }, 30_000);
 
+test("probes caught by ONE gateway blip mid-sweep log ONE error, not one per provider (PRODUCT-1423)", async () => {
+  // A control-plane restart seen through the gateway: the probes in flight
+  // during the window get `500: {"error":"fetch failed"}` while the rest of
+  // the sweep answers normally. Not uniform, so the PRODUCT-1399 collapse
+  // never fired — HOUSTON-APP-4YV got one Sentry event per caught provider.
+  resetServeProbeLog();
+  const blipped = new Set(["google", "openrouter", "opencode-go"]);
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    const provider = new URL(String(input)).searchParams.get("provider");
+    if (provider && blipped.has(provider))
+      return new Response(JSON.stringify({ error: "fetch failed" }), {
+        status: 500,
+      });
+    return notConnected404();
+  }) as unknown as typeof globalThis.fetch;
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warns = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const serveErrors = () =>
+    errors.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.startsWith("[serve]"));
+  try {
+    await withServeMode(fetchImpl, async () => {
+      expect(await syncServedCredential()).toEqual([]);
+      // ONE event naming every caught provider (in catalog order) and the
+      // shared gateway detail.
+      expect(serveErrors()).toHaveLength(1);
+      const line = serveErrors()[0] ?? "";
+      expect(line).toMatch(/^\[serve\] credential probes for /);
+      for (const id of blipped) expect(line).toContain(id);
+      expect(line).toContain('failed alike: 500: {"error":"fetch failed"}');
+      // The persistent repeat stays a WARN breadcrumb, never a second event.
+      expect(await syncServedCredential()).toEqual([]);
+      expect(serveErrors()).toHaveLength(1);
+      expect(
+        warns.mock.calls.some((c) => String(c[0]).includes("still failing")),
+      ).toBe(true);
+    });
+  } finally {
+    errors.mockRestore();
+    warns.mockRestore();
+  }
+}, 30_000);
+
 test("selectExportCredential without a provider falls back to the first OAuth credential", () => {
   const auth: Record<string, PiCred> = {
     "openai-codex": oauth("AT-codex", "RT-codex"),

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -15,7 +15,7 @@ import {
 import { scrubSettledCaptureAt } from "./capture-settlement";
 import { bindEmptyRefreshServeSync } from "./empty-refresh-guard";
 import {
-  logServeProbeFailure,
+  logServeProbeFailures,
   logServeSweepFailure,
   noteServeProbeOk,
   noteServeSweepOk,
@@ -186,7 +186,16 @@ async function runServedSync(): Promise<string[]> {
   const sweepDetail = uniformFailureDetail(probes);
   if (sweepDetail !== undefined)
     logServeSweepFailure(probes.length, sweepDetail);
-  else noteServeSweepOk();
+  else {
+    noteServeSweepOk();
+    // A PARTIALLY failed sweep collapses the same way: probes sharing one
+    // failure detail are one incident (a control-plane blip caught mid-sweep —
+    // PRODUCT-1423), and dedup across syncs lives in serve-log.ts, so a
+    // persistent failure never emits one Sentry error per re-probe.
+    logServeProbeFailures(
+      probes.flatMap((p) => (p.state === "error" ? [p] : [])),
+    );
+  }
   const applied: string[] = [];
   const removed: string[] = [];
   // Provenance gate: an authoritative "not connected" may only remove providers
@@ -270,11 +279,6 @@ async function runServedSync(): Promise<string[]> {
         manifest.delete(probe.id);
         manifestDirty = true;
       }
-    } else if (sweepDetail === undefined) {
-      // Dedup lives in serve-log.ts: every turn and hydrating route re-probes,
-      // so a persistent gateway failure must not emit one Sentry error each.
-      // (A uniformly failed sweep was already logged once, above.)
-      logServeProbeFailure(probe.id, probe.detail);
     }
   }
   if (manifestDirty)


### PR DESCRIPTION
## PRODUCT-1423

Sentry HOUSTON-APP-4YV groups every `[serve] credential …` message into one issue. Splitting the recent events by cause shows three families:

1. **`fetch failed (cause: ECONNREFUSED)` sweeps, exactly 41 events per pod** — the shutdown-respawn residual. Already fixed on main (#1338 launcher latch, #1339 uniform-sweep collapse), awaiting the next engine roll.
2. **github-copilot `dead credential` 500s + timeouts (Aug 17)** — a separate upstream incident window, not a client bug.
3. **`500: {"error":"fetch failed"}` bursts** — the family this Sentry-sync issue is titled after (`opencode-go` is just the latest event). Multiple pods and multiple providers fail at the same instant (Aug 5 17:00Z, Aug 7 21:00Z, Aug 11 17:36/18:16Z, Aug 18 15:52–15:54Z): a brief control-plane blip answered through the gateway as a 500.

## Root cause (family 3)

A blip caught mid-sweep hits only the probes in flight during the window, so the sweep is **not uniform** and the #1339 collapse never fires — each caught provider logs its own transition error. Every burst produced 2–8 Sentry events per pod, and Sentry-sync kept re-filing the group under whichever provider came last.

## Fix

Probes failing with an **identical detail** in one sweep are one incident. `logServeProbeFailures` (serve-log.ts) groups a non-uniform sweep's failures by detail: a group of ≥2 logs once, naming every caught provider; a lone failure keeps the existing per-provider path. Dedup rides the same per-provider transition map, so persistent repeats stay WARN breadcrumbs and a member's recovery re-arms the incident. No behavior change to the sync itself — an error verdict still applies/removes nothing.

## Before

Any partial gateway/control-plane blip → one Sentry error per caught provider per pod (see the Aug 7 21:00:20Z burst: 7 events from one pod, one instant).

## After / verification

- `pnpm --filter @houston/runtime test` — new unit tests in `serve-log.test.ts` (group collapse, dedup, re-arm, distinct details stay distinct) and an integration test in `serve.test.ts` (`probes caught by ONE gateway blip mid-sweep log ONE error`). All 1164 runtime + 1517 host tests pass.
- After deploy: the same blip signature yields ONE `[serve] credential probes for … failed alike: 500: {"error":"fetch failed"}` event per pod, and HOUSTON-APP-4YV stops accumulating per-provider titles for this family.