### PR TITLE
fix(host): project the activity family normalized, not raw

### DIFF
--- a/packages/host/src/docs/projector.test.ts
+++ b/packages/host/src/docs/projector.test.ts
@@ -39,3 +39,46 @@ test("a family watcher event shadows the file's current whole document", async (
     },
   ]);
 });
+
+test("the activity family projects the NORMALIZED items, not the raw file", async () => {
+  const store = new MemoryWorkspaceStore();
+  const vfs = new MemoryVfs();
+  const paths = new LocalPaths();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "A",
+  });
+  const root = paths.agentRoot(workspace, agent);
+  const puts: { family: string; doc: unknown }[] = [];
+  const shadow: DocShadow = {
+    async seed() {},
+    async put(family, doc) {
+      puts.push({ family, doc });
+    },
+  };
+  const projector = new DocShadowProjector({ store, vfs, paths, shadow });
+  // A hand-edited file: one valid entry missing its description (the reader
+  // defaults it) and one malformed entry (no title) the reader drops. The
+  // gateway serves the doc as the board, so the doc must match what the pod's
+  // own read would return.
+  await vfs.writeText(
+    docKey(root, "activity"),
+    JSON.stringify([
+      { id: "m1", title: "Say Hi", status: "needs_you" },
+      { id: "broken" },
+    ]),
+  );
+
+  projector.onEvent({ type: "ActivityChanged", agentPath: agent.id });
+  await projector.flush();
+
+  expect(puts).toEqual([
+    {
+      family: "activity",
+      doc: [
+        { id: "m1", title: "Say Hi", status: "needs_you", description: "" },
+      ],
+    },
+  ]);
+});

--- a/packages/host/src/docs/projector.ts
+++ b/packages/host/src/docs/projector.ts
@@ -1,4 +1,8 @@
-import { docKey, type HoustonFamily } from "@houston/domain";
+import {
+  docKey,
+  type HoustonFamily,
+  normalizeActivities,
+} from "@houston/domain";
 import type { HoustonEvent } from "@houston/protocol";
 import type { WorkspacePaths } from "../paths";
 import type { WorkspaceStore } from "../ports";
@@ -64,11 +68,20 @@ export class DocShadowProjector {
     const workspace = await this.deps.store.getWorkspace(agent.workspaceId);
     if (!workspace) return;
     const root = this.deps.paths.agentRoot(workspace, agent);
-    const raw = await this.deps.vfs.readText(docKey(root, family));
+    const key = docKey(root, family);
+    const raw = await this.deps.vfs.readText(key);
     if (raw === null) return;
-    await this.deps.shadow.put(
-      family,
-      JSON.parse(raw.replace(/^\uFEFF/, "")) as unknown,
-    );
+    const parsed = JSON.parse(raw.replace(/^\uFEFF/, "")) as unknown;
+    // The activity family is READ by the gateway (the mission board is served
+    // from the doc at database authority), and reads normalize via
+    // normalizeActivities — malformed entries dropped, defaults applied. Keep
+    // that behavior in exactly one place by projecting the NORMALIZED items:
+    // for host-written files this is a byte-level no-op (saveActivities writes
+    // normalized items), and for agent hand-edits the doc converges to what
+    // the pod would serve. normalizeActivities is idempotent, so the doc also
+    // remains a valid activity.json for any future file reconstruction.
+    const doc =
+      family === "activity" ? normalizeActivities(parsed, key).items : parsed;
+    await this.deps.shadow.put(family, doc);
   }
 }


### PR DESCRIPTION
## What

One change in `DocShadowProjector.project`: the `activity` family projects `normalizeActivities(parsed).items` instead of the raw file parse. Other families are unchanged.

## Why

The gateway is gaining a database-authority read of the mission board served from the agent-docs `activity` family (cloud#270). Board reads on the pod normalize via `normalizeActivities` — malformed entries dropped, `description` defaulted, contributors/mentions sanitized — so a doc projected raw could serve a shape the pod never would (an agent hand-edit with a malformed entry, for example). Normalizing at projection time keeps that behavior in exactly one place, the domain function:

- Host-written files: byte-level no-op (`saveActivities` already writes normalized items).
- Agent hand-edits: the doc converges to what the pod's own read returns.
- `normalizeActivities` is idempotent, so the doc also remains a valid `activity.json` for any future file reconstruction from docs.

## Tests

New projector test: a file with one entry missing its description and one malformed entry projects exactly the normalized single-item array. Full host + domain suites green (169 + domain files).

## Pairing

cloud#270 (gateway serves the board from the doc). Either merges safely alone: the gateway change falls open to the pod without a doc, and this change without the gateway read just makes the existing shadow more faithful.