### PR TITLE
fix(shell): stop Sentry capture of rustls-platform-verifier TLS failures (PRODUCT-1430)

### DIFF
--- a/app/src-tauri/src/logging.rs
+++ b/app/src-tauri/src/logging.rs
@@ -75,8 +75,15 @@ pub fn init(data_dir: &Path) {
 /// failure is fully handled in the frontend updater hooks, so Sentry only
 /// needs the breadcrumb trail, not an event per 5-minute poll
 /// (Sentry HOUSTON-APP-14).
+///
+/// `rustls_platform_verifier` fires `log::error!` internally whenever the
+/// OS trust store rejects a peer certificate (e.g. a machine behind a
+/// misconfigured corporate MITM proxy whose root even Windows won't chain).
+/// The failing request already returns `Err` and its caller owns surfacing
+/// it, so the verifier's own log line is a duplicate — one Sentry event per
+/// retry from a handful of broken machines (Sentry HOUSTON-APP-PE).
 fn demote_error_to_breadcrumb(target: &str) -> bool {
-    target.starts_with("tauri_plugin_updater")
+    target.starts_with("tauri_plugin_updater") || target.starts_with("rustls_platform_verifier")
 }
 
 fn logs_dir() -> PathBuf {
@@ -172,6 +179,14 @@ mod tests {
     fn updater_plugin_errors_are_demoted_to_breadcrumbs() {
         assert!(demote_error_to_breadcrumb("tauri_plugin_updater::updater"));
         assert!(demote_error_to_breadcrumb("tauri_plugin_updater"));
+    }
+
+    #[test]
+    fn tls_platform_verifier_errors_are_demoted_to_breadcrumbs() {
+        assert!(demote_error_to_breadcrumb(
+            "rustls_platform_verifier::verification::windows"
+        ));
+        assert!(demote_error_to_breadcrumb("rustls_platform_verifier"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Sentry HOUSTON-APP-PE (`failed to verify TLS certificate: invalid peer certificate: UnknownIssuer`) has accumulated 1,333 error events since June — all from just **two Windows machines** (1,239 on 0.4.26, 91 on 0.5.29), still firing 20-40/day.

**Root cause:** the error is not logged by our code. It is the internal `log::error!` inside the `rustls-platform-verifier` crate (`verification/windows.rs`, target `rustls_platform_verifier::verification::windows`), emitted whenever Windows' own CryptoAPI rejects a peer certificate chain — typically a misconfigured corporate MITM/AV root that even the OS store can't chain. The shell's Sentry tracing layer promotes every ERROR log record to a standalone event unless its target is demoted. We already demote `tauri_plugin_updater` for its expected per-poll failures (HOUSTON-APP-14), but the TLS verifier underneath those same polls logs its own error line, so each failed 5-minute updater poll on such a machine still produced one Sentry event.

**Fix:** extend `demote_error_to_breadcrumb` in `app/src-tauri/src/logging.rs` to also match `rustls_platform_verifier` targets. No signal is lost: the failing request still returns `Err` and its caller owns surfacing it, and the verifier line stays attached as a breadcrumb on any real Sentry event. Nothing to fix on the TLS side itself — the app already verifies through the OS trust store, and Windows itself rejects the issuer on those machines.

Linear: PRODUCT-1430

## Before the fix (repro)

1. On a Windows machine, install an SSL-inspecting proxy whose root CA is **not** in the Windows trust store (or point the app's HTTPS traffic through any MITM with an untrusted root).
2. Launch Houston with a Sentry DSN configured and leave it open.
3. Every background HTTPS attempt (e.g. the 5-minute updater poll) emits a standalone Sentry error event titled `failed to verify TLS certificate: invalid peer certificate: UnknownIssuer` under HOUSTON-APP-PE.

## After the fix (verify)

1. Same setup: the TLS failure line appears only as a breadcrumb attached to real events; no new standalone events land in HOUSTON-APP-PE from builds carrying this change.
2. `cd app/src-tauri && cargo test logging` — includes the new `tls_platform_verifier_errors_are_demoted_to_breadcrumbs` test plus the existing guard that app targets (`houston_app::*`) still become Sentry events. Full shell suite: 220 passed.
3. Watch the Sentry issue: release-tagged events from versions ≥ this fix should drop to zero while the two legacy installs keep reporting from old builds until they update.