### PR TITLE
fix(app): deleting a workspace switches and toasts instantly (PRODUCT-1426)

### DIFF
--- a/app/src/components/settings/sections/danger.tsx
+++ b/app/src/components/settings/sections/danger.tsx
@@ -6,7 +6,7 @@ import { useCapabilities } from "../../../hooks/use-capabilities";
 import { showExpectedStateToast } from "../../../lib/error-toast";
 import { openHome } from "../../../lib/home-nav";
 import { canDeleteWorkspace } from "../../../lib/org-roles";
-import { isTeamWorkspace, orgSlugFromWorkspaceId } from "../../../lib/space-id";
+import { isTeamWorkspace } from "../../../lib/space-id";
 import { tauriOrg } from "../../../lib/tauri";
 import {
   canDeleteOptimistically,
@@ -31,8 +31,9 @@ import { SettingsControlRow } from "../settings-row";
  * its two business rejections (`has_members`, `subscription_active`) come
  * back as plain informational toasts that say what to do first.
  *
- * Confirming pre-checks those two rejections against a fresh `GET /v1/orgs`
- * row (PRODUCT-1426), and the answer picks the UX shape, never the outcome:
+ * Confirming pre-checks those two rejections against fresh active-org reads
+ * (`GET /v1/org` roster + `GET /v1/org/billing`, PRODUCT-1426), and the
+ * answer picks the UX shape, never the outcome:
  * a provably-deletable solo team switches the user to the default space with
  * the success toast immediately (the slow gateway delete finishes behind the
  * switch, with the store's rollback as the race net); anything the pre-check
@@ -79,11 +80,14 @@ export function DangerSection() {
     const { id, name } = currentWorkspace;
     setDeleting(true);
     try {
-      const slug = orgSlugFromWorkspaceId(id);
-      const provablyDeletable = await tauriOrg.listOrgs().then(
-        (list) =>
-          canDeleteOptimistically(list.orgs.find((o) => o.slug === slug)),
-        // Not swallowed: the wire layer reported the list failure, and the
+      // Both reads address the ACTIVE space — still the doomed team here; the
+      // optimistic switch only re-pins the gateway after they resolve.
+      const provablyDeletable = await Promise.all([
+        tauriOrg.get(),
+        tauriOrg.getBilling(),
+      ]).then(
+        ([info, billing]) => canDeleteOptimistically(info.members, billing),
+        // Not swallowed: the wire layer reported the read failure, and the
         // server-first path below gives the delete its own loud outcome.
         () => false,
       );

--- a/app/src/components/settings/sections/danger.tsx
+++ b/app/src/components/settings/sections/danger.tsx
@@ -6,10 +6,13 @@ import { useCapabilities } from "../../../hooks/use-capabilities";
 import { showExpectedStateToast } from "../../../lib/error-toast";
 import { openHome } from "../../../lib/home-nav";
 import { canDeleteWorkspace } from "../../../lib/org-roles";
-import { isTeamWorkspace } from "../../../lib/space-id";
+import { isTeamWorkspace, orgSlugFromWorkspaceId } from "../../../lib/space-id";
+import { tauriOrg } from "../../../lib/tauri";
 import {
+  canDeleteOptimistically,
   classifyWorkspaceDeleteError,
   isExpectedWorkspaceDeleteError,
+  type WorkspaceDeleteFailure,
 } from "../../../lib/workspace-delete-model";
 import { useAgentStore } from "../../../stores/agents";
 import { useUIStore } from "../../../stores/ui";
@@ -28,11 +31,14 @@ import { SettingsControlRow } from "../settings-row";
  * its two business rejections (`has_members`, `subscription_active`) come
  * back as plain informational toasts that say what to do first.
  *
- * Confirming is optimistic (PRODUCT-1426): the user lands on the default
- * space with a success toast immediately, while the gateway delete finishes
- * behind the switch. A rejection restores the row (the store's rollback) and
- * the blocked toast then explains what to do — its "first, then delete"
- * wording is what tells the user the space was NOT deleted after all.
+ * Confirming pre-checks those two rejections against a fresh `GET /v1/orgs`
+ * row (PRODUCT-1426), and the answer picks the UX shape, never the outcome:
+ * a provably-deletable solo team switches the user to the default space with
+ * the success toast immediately (the slow gateway delete finishes behind the
+ * switch, with the store's rollback as the race net); anything the pre-check
+ * can't prove waits for the gateway's verdict, so the user is never told
+ * "deleted" about a space that still stands — rejections are fast, it's the
+ * destruction that is slow.
  */
 export function DangerSection() {
   const { t } = useTranslation("settings");
@@ -42,41 +48,72 @@ export function DangerSection() {
   const loadAgents = useAgentStore((s) => s.loadAgents);
   const addToast = useUIStore((s) => s.addToast);
   const [showConfirm, setShowConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   if (!currentWorkspace) return null;
   if (!capabilities?.workspaceDelete) return null;
   if (!isTeamWorkspace(currentWorkspace.id)) return null;
   if (!canDeleteWorkspace(capabilities)) return null;
 
-  const handleDelete = async () => {
-    const { id, name } = currentWorkspace;
-    setShowConfirm(false);
-    // Optimistic (PRODUCT-1426): the store drops the row, lands on the default
-    // space and re-pins the gateway BEFORE the server round-trip, so the
-    // switch and toast below are instant instead of gated on a slow gateway
-    // delete. The rejection handler attaches NOW (an unobserved rejection
-    // during the navigation awaits would fire unhandledrejection); a failure
-    // classifies here and toasts after the switch — nothing is swallowed:
-    // unknown errors are already reported by the wire layer, and the store has
-    // already restored the row.
-    const settled = deleteWorkspace(id, {
-      silence: isExpectedWorkspaceDeleteError,
-    }).then(() => null, classifyWorkspaceDeleteError);
+  // The active space switched under the user (the space they deleted owned
+  // this Settings screen), so land them on home to make the switch visible.
+  const landHomeAndToast = async (name: string) => {
     const landing = useWorkspaceStore.getState().current;
     if (landing) await loadAgents(landing.id);
-    // The active space just switched under the user; Settings belonged to the
-    // deleted one. Land them on home so the switch is visible.
     openHome();
     addToast({
       title: t("dangerZone.deleted", { name }),
       variant: "success",
     });
-    const failure = await settled;
-    if (failure === null || failure === "unknown") return;
+  };
+
+  const blockedToast = (
+    failure: Exclude<WorkspaceDeleteFailure, "unknown">,
+  ): void =>
     showExpectedStateToast(
       t(`dangerZone.blocked.${failure}.title`),
       t(`dangerZone.blocked.${failure}.body`),
     );
+
+  const handleDelete = async () => {
+    const { id, name } = currentWorkspace;
+    setDeleting(true);
+    try {
+      const slug = orgSlugFromWorkspaceId(id);
+      const provablyDeletable = await tauriOrg.listOrgs().then(
+        (list) =>
+          canDeleteOptimistically(list.orgs.find((o) => o.slug === slug)),
+        // Not swallowed: the wire layer reported the list failure, and the
+        // server-first path below gives the delete its own loud outcome.
+        () => false,
+      );
+      if (provablyDeletable) {
+        // The rejection handler attaches NOW (an unobserved rejection during
+        // the navigation awaits would fire unhandledrejection); expected
+        // rejections toast after the switch, unknown ones are already
+        // reported by the wire layer, and the store restored the row.
+        const settled = deleteWorkspace(
+          id,
+          { silence: isExpectedWorkspaceDeleteError },
+          "optimistic",
+        ).then(() => null, classifyWorkspaceDeleteError);
+        await landHomeAndToast(name);
+        const failure = await settled;
+        if (failure !== null && failure !== "unknown") blockedToast(failure);
+        return;
+      }
+      try {
+        await deleteWorkspace(id, { silence: isExpectedWorkspaceDeleteError });
+      } catch (err) {
+        const failure = classifyWorkspaceDeleteError(err);
+        if (failure !== "unknown") blockedToast(failure);
+        return; // unknown: report already surfaced by the wire layer
+      }
+      await landHomeAndToast(name);
+    } finally {
+      setDeleting(false);
+      setShowConfirm(false);
+    }
   };
 
   return (
@@ -90,6 +127,7 @@ export function DangerSection() {
         <Button
           variant="destructive"
           size="sm"
+          disabled={deleting}
           onClick={() => setShowConfirm(true)}
         >
           {t("dangerZone.confirmLabel")}

--- a/app/src/components/settings/sections/danger.tsx
+++ b/app/src/components/settings/sections/danger.tsx
@@ -27,6 +27,12 @@ import { SettingsControlRow } from "../settings-row";
  * (PRODUCT-1247). Cosmetic gates all: the gateway is the sole enforcer, and
  * its two business rejections (`has_members`, `subscription_active`) come
  * back as plain informational toasts that say what to do first.
+ *
+ * Confirming is optimistic (PRODUCT-1426): the user lands on the default
+ * space with a success toast immediately, while the gateway delete finishes
+ * behind the switch. A rejection restores the row (the store's rollback) and
+ * the blocked toast then explains what to do — its "first, then delete"
+ * wording is what tells the user the space was NOT deleted after all.
  */
 export function DangerSection() {
   const { t } = useTranslation("settings");
@@ -36,7 +42,6 @@ export function DangerSection() {
   const loadAgents = useAgentStore((s) => s.loadAgents);
   const addToast = useUIStore((s) => s.addToast);
   const [showConfirm, setShowConfirm] = useState(false);
-  const [deleting, setDeleting] = useState(false);
 
   if (!currentWorkspace) return null;
   if (!capabilities?.workspaceDelete) return null;
@@ -44,26 +49,19 @@ export function DangerSection() {
   if (!canDeleteWorkspace(capabilities)) return null;
 
   const handleDelete = async () => {
-    const name = currentWorkspace.name;
-    setDeleting(true);
-    try {
-      // The store lands on the default space + re-pins the gateway once the
-      // server confirms; every other rejection is toasted by the wire layer.
-      await deleteWorkspace(currentWorkspace.id, {
-        silence: isExpectedWorkspaceDeleteError,
-      });
-    } catch (err) {
-      const failure = classifyWorkspaceDeleteError(err);
-      if (failure === "unknown") return; // red toast + report already shown
-      showExpectedStateToast(
-        t(`dangerZone.blocked.${failure}.title`),
-        t(`dangerZone.blocked.${failure}.body`),
-      );
-      return;
-    } finally {
-      setDeleting(false);
-      setShowConfirm(false);
-    }
+    const { id, name } = currentWorkspace;
+    setShowConfirm(false);
+    // Optimistic (PRODUCT-1426): the store drops the row, lands on the default
+    // space and re-pins the gateway BEFORE the server round-trip, so the
+    // switch and toast below are instant instead of gated on a slow gateway
+    // delete. The rejection handler attaches NOW (an unobserved rejection
+    // during the navigation awaits would fire unhandledrejection); a failure
+    // classifies here and toasts after the switch — nothing is swallowed:
+    // unknown errors are already reported by the wire layer, and the store has
+    // already restored the row.
+    const settled = deleteWorkspace(id, {
+      silence: isExpectedWorkspaceDeleteError,
+    }).then(() => null, classifyWorkspaceDeleteError);
     const landing = useWorkspaceStore.getState().current;
     if (landing) await loadAgents(landing.id);
     // The active space just switched under the user; Settings belonged to the
@@ -73,6 +71,12 @@ export function DangerSection() {
       title: t("dangerZone.deleted", { name }),
       variant: "success",
     });
+    const failure = await settled;
+    if (failure === null || failure === "unknown") return;
+    showExpectedStateToast(
+      t(`dangerZone.blocked.${failure}.title`),
+      t(`dangerZone.blocked.${failure}.body`),
+    );
   };
 
   return (
@@ -86,7 +90,6 @@ export function DangerSection() {
         <Button
           variant="destructive"
           size="sm"
-          disabled={deleting}
           onClick={() => setShowConfirm(true)}
         >
           {t("dangerZone.confirmLabel")}

--- a/app/src/components/settings/sections/danger.tsx
+++ b/app/src/components/settings/sections/danger.tsx
@@ -49,7 +49,6 @@ export function DangerSection() {
   const loadAgents = useAgentStore((s) => s.loadAgents);
   const addToast = useUIStore((s) => s.addToast);
   const [showConfirm, setShowConfirm] = useState(false);
-  const [deleting, setDeleting] = useState(false);
 
   if (!currentWorkspace) return null;
   if (!capabilities?.workspaceDelete) return null;
@@ -58,14 +57,17 @@ export function DangerSection() {
 
   // The active space switched under the user (the space they deleted owned
   // this Settings screen), so land them on home to make the switch visible.
-  const landHomeAndToast = async (name: string) => {
-    const landing = useWorkspaceStore.getState().current;
-    if (landing) await loadAgents(landing.id);
-    openHome();
+  // The toast comes FIRST: the landing space's agent load can take seconds
+  // (in the worst case an engine wake), and the user must not stare at a
+  // silent screen wondering whether the delete took (PRODUCT-1426).
+  const toastAndLandHome = async (name: string) => {
     addToast({
       title: t("dangerZone.deleted", { name }),
       variant: "success",
     });
+    const landing = useWorkspaceStore.getState().current;
+    if (landing) await loadAgents(landing.id);
+    openHome();
   };
 
   const blockedToast = (
@@ -76,9 +78,11 @@ export function DangerSection() {
       t(`dangerZone.blocked.${failure}.body`),
     );
 
+  // Returned to ConfirmDialog, whose async-confirm affordance keeps the dialog
+  // open on a "Deleting…" spinner until this settles (or the optimistic switch
+  // unmounts it, at which instant the success toast is already up).
   const handleDelete = async () => {
     const { id, name } = currentWorkspace;
-    setDeleting(true);
     try {
       // Both reads address the ACTIVE space — still the doomed team here; the
       // optimistic switch only re-pins the gateway after they resolve.
@@ -101,7 +105,7 @@ export function DangerSection() {
           { silence: isExpectedWorkspaceDeleteError },
           "optimistic",
         ).then(() => null, classifyWorkspaceDeleteError);
-        await landHomeAndToast(name);
+        await toastAndLandHome(name);
         const failure = await settled;
         if (failure !== null && failure !== "unknown") blockedToast(failure);
         return;
@@ -113,9 +117,8 @@ export function DangerSection() {
         if (failure !== "unknown") blockedToast(failure);
         return; // unknown: report already surfaced by the wire layer
       }
-      await landHomeAndToast(name);
+      await toastAndLandHome(name);
     } finally {
-      setDeleting(false);
       setShowConfirm(false);
     }
   };
@@ -131,7 +134,6 @@ export function DangerSection() {
         <Button
           variant="destructive"
           size="sm"
-          disabled={deleting}
           onClick={() => setShowConfirm(true)}
         >
           {t("dangerZone.confirmLabel")}
@@ -144,6 +146,7 @@ export function DangerSection() {
         title={t("dangerZone.confirmTitle", { name: currentWorkspace.name })}
         description={t("dangerZone.confirmDescription")}
         confirmLabel={t("dangerZone.confirmLabel")}
+        pendingLabel={t("dangerZone.deleting")}
         onConfirm={handleDelete}
       />
     </>

--- a/app/src/lib/workspace-delete-model.ts
+++ b/app/src/lib/workspace-delete-model.ts
@@ -1,4 +1,4 @@
-import type { OrgSummary } from "@houston-ai/engine-client";
+import type { BillingSummary, OrgMember } from "@houston-ai/engine-client";
 import { shareErrorCode } from "./share-via-team.ts";
 import type { Workspace } from "./types.ts";
 
@@ -64,23 +64,29 @@ export function isExpectedWorkspaceDeleteError(err: unknown): boolean {
  * gateway stays the sole enforcer, so a false `false` merely means the slower
  * server-first flow, while a false `true` is caught by the store's rollback.
  *
- * Mirrors the gateway's two 409s over a fresh `GET /v1/orgs` row:
- * - `has_members` rejects when any OTHER member row exists → require
- *   `memberCount <= 1` (the caller is the owner, so the one member is them).
+ * Mirrors the gateway's two 409s over fresh reads of the ACTIVE space (the
+ * one being deleted) — NOT the `GET /v1/orgs` summaries, which carry no
+ * billing detail:
+ * - `has_members` rejects when any OTHER member row exists. `GET /v1/org`'s
+ *   roster is the very same member listing the delete handler counts, and the
+ *   caller (the owner) is always one row → require `members.length <= 1`. An
+ *   absent roster is unverifiable → never optimistic.
  * - `subscription_active` rejects when a Stripe subscription object exists in
- *   a non-terminal state. `billing.interval` is set exactly when a Stripe
- *   object exists, and the effective status can hide one (a solo team with a
- *   trialing/unpaid Stripe object reads `free`), so require no `interval` AND
- *   a status that is not `active`/`past_due`. `enterprise` bills off-platform
- *   — unverifiable, so never optimistic.
- *
- * Anything unverifiable (org not listed, billing absent) → `false`.
+ *   a non-terminal state. `GET /v1/org/billing` degrades to `null` exactly
+ *   when the billing surface is OFF (unconfigured / predates the route) — no
+ *   Stripe object can exist there, so `null` is SAFE. On a real summary,
+ *   `interval` is set exactly when a Stripe object exists, and the effective
+ *   status can hide one (a solo team with a trialing/unpaid Stripe object
+ *   reads `free`), so require no `interval` AND a status that is not
+ *   `active`/`past_due`. `enterprise` bills off-platform — unverifiable.
  */
-export function canDeleteOptimistically(org: OrgSummary | undefined): boolean {
-  if (org === undefined || org.kind !== "team") return false;
-  if (org.memberCount > 1) return false;
-  const billing = org.billing;
-  if (billing === undefined || billing.plan !== "team") return false;
+export function canDeleteOptimistically(
+  members: readonly OrgMember[] | undefined,
+  billing: BillingSummary | null,
+): boolean {
+  if (members === undefined || members.length > 1) return false;
+  if (billing === null) return true;
+  if (billing.plan !== "team") return false;
   return (
     billing.status !== "active" &&
     billing.status !== "past_due" &&

--- a/app/src/lib/workspace-delete-model.ts
+++ b/app/src/lib/workspace-delete-model.ts
@@ -1,4 +1,5 @@
 import { shareErrorCode } from "./share-via-team.ts";
+import type { Workspace } from "./types.ts";
 
 /**
  * Pure, DOM-free logic behind deleting a team space from Settings → Danger
@@ -53,4 +54,19 @@ export function classifyWorkspaceDeleteError(
  */
 export function isExpectedWorkspaceDeleteError(err: unknown): boolean {
   return classifyWorkspaceDeleteError(err) !== "unknown";
+}
+
+/**
+ * Put a row back where it was after an optimistic delete the server rejected
+ * (PRODUCT-1426). Dedupes by id: a background re-list racing the rollback may
+ * already have restored the row, and it wins — its object is fresher.
+ */
+export function restoreSpaceRow(
+  list: Workspace[],
+  row: Workspace,
+  index: number,
+): Workspace[] {
+  if (list.some((w) => w.id === row.id)) return list;
+  const at = Math.min(Math.max(index, 0), list.length);
+  return [...list.slice(0, at), row, ...list.slice(at)];
 }

--- a/app/src/lib/workspace-delete-model.ts
+++ b/app/src/lib/workspace-delete-model.ts
@@ -1,3 +1,4 @@
+import type { OrgSummary } from "@houston-ai/engine-client";
 import { shareErrorCode } from "./share-via-team.ts";
 import type { Workspace } from "./types.ts";
 
@@ -54,6 +55,37 @@ export function classifyWorkspaceDeleteError(
  */
 export function isExpectedWorkspaceDeleteError(err: unknown): boolean {
   return classifyWorkspaceDeleteError(err) !== "unknown";
+}
+
+/**
+ * Can the Danger Zone assume the gateway will accept the delete, and so switch
+ * the user away with a success toast BEFORE the server round-trip
+ * (PRODUCT-1426)? This decides the UX shape only, never the outcome — the
+ * gateway stays the sole enforcer, so a false `false` merely means the slower
+ * server-first flow, while a false `true` is caught by the store's rollback.
+ *
+ * Mirrors the gateway's two 409s over a fresh `GET /v1/orgs` row:
+ * - `has_members` rejects when any OTHER member row exists → require
+ *   `memberCount <= 1` (the caller is the owner, so the one member is them).
+ * - `subscription_active` rejects when a Stripe subscription object exists in
+ *   a non-terminal state. `billing.interval` is set exactly when a Stripe
+ *   object exists, and the effective status can hide one (a solo team with a
+ *   trialing/unpaid Stripe object reads `free`), so require no `interval` AND
+ *   a status that is not `active`/`past_due`. `enterprise` bills off-platform
+ *   — unverifiable, so never optimistic.
+ *
+ * Anything unverifiable (org not listed, billing absent) → `false`.
+ */
+export function canDeleteOptimistically(org: OrgSummary | undefined): boolean {
+  if (org === undefined || org.kind !== "team") return false;
+  if (org.memberCount > 1) return false;
+  const billing = org.billing;
+  if (billing === undefined || billing.plan !== "team") return false;
+  return (
+    billing.status !== "active" &&
+    billing.status !== "past_due" &&
+    billing.interval === undefined
+  );
 }
 
 /**

--- a/app/src/lib/workspace-refresh.ts
+++ b/app/src/lib/workspace-refresh.ts
@@ -23,6 +23,19 @@ export type SpacesRefreshPlan =
   | { kind: "update"; workspaces: Workspace[]; current: Workspace | null }
   | { kind: "reselect"; workspaces: Workspace[]; current: Workspace | null };
 
+/**
+ * Drop rows whose delete is still in flight from a freshly-listed set. The
+ * optimistic delete (PRODUCT-1426) removes the row before the server round
+ * trip; until the server confirms, it still LISTS the space, so an untouched
+ * re-list (the 60s poll, a window focus) would resurrect the row mid-delete.
+ */
+export function withoutPendingDeletes(
+  fresh: Workspace[],
+  pending: ReadonlySet<string>,
+): Workspace[] {
+  return pending.size === 0 ? fresh : fresh.filter((w) => !pending.has(w.id));
+}
+
 export function planSpacesRefresh(
   previous: Workspace[],
   current: Workspace | null,

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -98,6 +98,7 @@
     "confirmTitle": "Delete \"{{name}}\"?",
     "confirmDescription": "This will permanently delete this workspace and all its agents. This cannot be undone.",
     "confirmLabel": "Delete",
+    "deleting": "Deleting…",
     "deleted": "\"{{name}}\" was deleted.",
     "blocked": {
       "has_members": {

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -98,6 +98,7 @@
     "confirmTitle": "¿Eliminar \"{{name}}\"?",
     "confirmDescription": "Esto eliminará de forma permanente este espacio de trabajo y todos sus agentes. No se puede deshacer.",
     "confirmLabel": "Eliminar",
+    "deleting": "Eliminando…",
     "deleted": "Se eliminó \"{{name}}\".",
     "blocked": {
       "has_members": {

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -98,6 +98,7 @@
     "confirmTitle": "Excluir \"{{name}}\"?",
     "confirmDescription": "Isso exclui este espaço de trabalho e todos os seus agentes de forma permanente. Não dá para desfazer.",
     "confirmLabel": "Excluir",
+    "deleting": "Excluindo…",
     "deleted": "\"{{name}}\" foi excluído.",
     "blocked": {
       "has_members": {

--- a/app/src/stores/workspace-delete.ts
+++ b/app/src/stores/workspace-delete.ts
@@ -7,20 +7,26 @@ import { planSpacesRefresh } from "../lib/workspace-refresh";
 import { applyRefreshPlan } from "./workspace-refresh-apply";
 
 /**
- * Optimistic team-space delete (PRODUCT-1426, refining PRODUCT-1410).
+ * Team-space delete in two shapes (PRODUCT-1426, refining PRODUCT-1410).
  *
- * The gateway can take seconds to destroy a space; waiting for it left the
- * user sitting inside a "deleted" workspace with no feedback. So the store
- * switches FIRST — the row leaves the list and, when it was the active space,
- * the user lands on the default space with the gateway re-pinned — and the
- * server call runs behind that switch.
- *
+ * `optimistic` — for a delete the caller has pre-checked the gateway will
+ * accept (`canDeleteOptimistically`): the gateway can take seconds to destroy
+ * a space, and waiting for it left the user sitting inside a "deleted"
+ * workspace with no feedback. So the store switches FIRST — the row leaves the
+ * list and, when it was the active space, the user lands on the default space
+ * with the gateway re-pinned — and the server call runs behind that switch.
  * PRODUCT-1410's lesson (an optimistic drop over a no-op stub faked success
  * forever) still holds, differently: the delete is a real server call whose
  * rejection is LOUD — the row is restored in place and the error propagates to
  * the caller's toast. A silent failure can't stick either way: the live-spaces
  * poll re-lists whatever the server still has.
+ *
+ * `server-first` — the PRODUCT-1410 posture, for a delete the pre-check could
+ * NOT prove acceptable (teammates remain, a live subscription, or the check
+ * itself failed): the row leaves the store only once the space is really gone,
+ * so the user is never shown a success that the gateway then takes back.
  */
+export type WorkspaceDeleteMode = "optimistic" | "server-first";
 
 /**
  * Space ids whose server delete is still in flight. Until the server confirms,
@@ -34,20 +40,17 @@ interface SpacesSlice {
   current: Workspace | null;
 }
 
-export async function runWorkspaceDelete(
-  id: string,
-  options: EngineCallOptions | undefined,
-  get: () => SpacesSlice,
-  set: (patch: { workspaces: Workspace[]; current?: Workspace | null }) => void,
-): Promise<void> {
+type SpacesSetter = (patch: {
+  workspaces: Workspace[];
+  current?: Workspace | null;
+}) => void;
+
+// Same merge as a live refresh that no longer lists the space: dropping the
+// active one is a `reselect`, which lands on the default space AND re-pins
+// the gateway + resets the space-scoped caches — dropping the row without
+// re-pinning would leave every request addressed to a space that 404s.
+function dropRow(id: string, get: () => SpacesSlice, set: SpacesSetter): void {
   const prev = get();
-  const index = prev.workspaces.findIndex((w) => w.id === id);
-  const target = index === -1 ? undefined : prev.workspaces[index];
-  pendingWorkspaceDeletes.add(id);
-  // Same merge as a live refresh that no longer lists the space: deleting the
-  // active one is a `reselect`, which lands on the default space AND re-pins
-  // the gateway + resets the space-scoped caches — dropping the row without
-  // re-pinning would leave every request addressed to a space about to 404.
   applyRefreshPlan(
     planSpacesRefresh(
       prev.workspaces,
@@ -56,6 +59,26 @@ export async function runWorkspaceDelete(
     ),
     set,
   );
+}
+
+export async function runWorkspaceDelete(
+  id: string,
+  options: EngineCallOptions | undefined,
+  get: () => SpacesSlice,
+  set: SpacesSetter,
+  mode: WorkspaceDeleteMode,
+): Promise<void> {
+  if (mode === "server-first") {
+    await tauriWorkspaces.delete(id, options);
+    dropRow(id, get, set);
+    queryClient.invalidateQueries({ queryKey: queryKeys.orgs() });
+    return;
+  }
+  const prev = get();
+  const index = prev.workspaces.findIndex((w) => w.id === id);
+  const target = index === -1 ? undefined : prev.workspaces[index];
+  pendingWorkspaceDeletes.add(id);
+  dropRow(id, get, set);
   try {
     await tauriWorkspaces.delete(id, options);
     queryClient.invalidateQueries({ queryKey: queryKeys.orgs() });

--- a/app/src/stores/workspace-delete.ts
+++ b/app/src/stores/workspace-delete.ts
@@ -1,0 +1,70 @@
+import { queryClient } from "../lib/query-client";
+import { queryKeys } from "../lib/query-keys";
+import { type EngineCallOptions, tauriWorkspaces } from "../lib/tauri";
+import type { Workspace } from "../lib/types";
+import { restoreSpaceRow } from "../lib/workspace-delete-model";
+import { planSpacesRefresh } from "../lib/workspace-refresh";
+import { applyRefreshPlan } from "./workspace-refresh-apply";
+
+/**
+ * Optimistic team-space delete (PRODUCT-1426, refining PRODUCT-1410).
+ *
+ * The gateway can take seconds to destroy a space; waiting for it left the
+ * user sitting inside a "deleted" workspace with no feedback. So the store
+ * switches FIRST — the row leaves the list and, when it was the active space,
+ * the user lands on the default space with the gateway re-pinned — and the
+ * server call runs behind that switch.
+ *
+ * PRODUCT-1410's lesson (an optimistic drop over a no-op stub faked success
+ * forever) still holds, differently: the delete is a real server call whose
+ * rejection is LOUD — the row is restored in place and the error propagates to
+ * the caller's toast. A silent failure can't stick either way: the live-spaces
+ * poll re-lists whatever the server still has.
+ */
+
+/**
+ * Space ids whose server delete is still in flight. Until the server confirms,
+ * it still lists the space, so every re-list must drop these rows or the 60s
+ * poll / a window focus would resurrect an optimistically-deleted space.
+ */
+export const pendingWorkspaceDeletes = new Set<string>();
+
+interface SpacesSlice {
+  workspaces: Workspace[];
+  current: Workspace | null;
+}
+
+export async function runWorkspaceDelete(
+  id: string,
+  options: EngineCallOptions | undefined,
+  get: () => SpacesSlice,
+  set: (patch: { workspaces: Workspace[]; current?: Workspace | null }) => void,
+): Promise<void> {
+  const prev = get();
+  const index = prev.workspaces.findIndex((w) => w.id === id);
+  const target = index === -1 ? undefined : prev.workspaces[index];
+  pendingWorkspaceDeletes.add(id);
+  // Same merge as a live refresh that no longer lists the space: deleting the
+  // active one is a `reselect`, which lands on the default space AND re-pins
+  // the gateway + resets the space-scoped caches — dropping the row without
+  // re-pinning would leave every request addressed to a space about to 404.
+  applyRefreshPlan(
+    planSpacesRefresh(
+      prev.workspaces,
+      prev.current,
+      prev.workspaces.filter((w) => w.id !== id),
+    ),
+    set,
+  );
+  try {
+    await tauriWorkspaces.delete(id, options);
+    queryClient.invalidateQueries({ queryKey: queryKeys.orgs() });
+  } catch (err) {
+    if (target) {
+      set({ workspaces: restoreSpaceRow(get().workspaces, target, index) });
+    }
+    throw err;
+  } finally {
+    pendingWorkspaceDeletes.delete(id);
+  }
+}

--- a/app/src/stores/workspaces.ts
+++ b/app/src/stores/workspaces.ts
@@ -2,7 +2,6 @@ import { create } from "zustand";
 import { analytics } from "../lib/analytics";
 import { setActiveOrg } from "../lib/engine";
 import { queryClient } from "../lib/query-client";
-import { queryKeys } from "../lib/query-keys";
 import { resetCacheForSpaceChange } from "../lib/space-cache";
 import { orgSlugFromWorkspaceId } from "../lib/space-id";
 import {
@@ -11,8 +10,15 @@ import {
   tauriWorkspaces,
 } from "../lib/tauri";
 import type { Workspace } from "../lib/types";
-import { planSpacesRefresh } from "../lib/workspace-refresh";
+import {
+  planSpacesRefresh,
+  withoutPendingDeletes,
+} from "../lib/workspace-refresh";
 import { resolveActiveWorkspace } from "../lib/workspace-switch";
+import {
+  pendingWorkspaceDeletes,
+  runWorkspaceDelete,
+} from "./workspace-delete";
 import { applyRefreshPlan } from "./workspace-refresh-apply";
 
 interface WorkspaceState {
@@ -40,11 +46,12 @@ interface WorkspaceState {
   refreshWorkspaces: () => Promise<void>;
   setCurrent: (ws: Workspace) => void;
   create: (name: string) => Promise<Workspace>;
-  /** Delete a team space for good (PRODUCT-1410). Resolves once the server has
-   *  destroyed it and the store no longer lists it; when it was the active
-   *  space, the store has already landed on the default space and re-pinned
-   *  the gateway exactly like a user-driven switch. Rejections propagate
-   *  (surfaced by the wire layer / the caller's `silence` predicate). */
+  /** Delete a team space for good (PRODUCT-1410). Optimistic (PRODUCT-1426):
+   *  the row leaves the list and, when it was the active space, the store
+   *  lands on the default space and re-pins the gateway BEFORE the server
+   *  round-trip — the returned promise settles once the server confirms.
+   *  Rejections restore the row in place and propagate (surfaced by the wire
+   *  layer / the caller's `silence` predicate). */
   delete: (id: string, options?: EngineCallOptions) => Promise<void>;
   rename: (id: string, newName: string) => Promise<void>;
   /** Set (or clear, with null) the workspace's UI-locale override. */
@@ -74,10 +81,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       // Restore the last-selected space alongside the list. On a personal-only
       // host the persisted id resolves to the sole default workspace, so this
       // stays byte-identical to the old isDefault-then-first resolution.
-      const [workspaces, lastId] = await Promise.all([
+      const [listed, lastId] = await Promise.all([
         tauriWorkspaces.list(),
         tauriPreferences.get("last_workspace_id"),
       ]);
+      const workspaces = withoutPendingDeletes(listed, pendingWorkspaceDeletes);
       const current = resolveActiveWorkspace(workspaces, lastId);
       // Pin the active space (C8) BEFORE the first space-scoped fetches fire so
       // they carry the right x-houston-org from the start (no header for
@@ -106,6 +114,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     } catch {
       return; // logged by the wire layer; the next tick retries
     }
+    // Checked AFTER the fetch: a delete that started mid-flight must still win.
+    fresh = withoutPendingDeletes(fresh, pendingWorkspaceDeletes);
     const prev = get();
     if (prev.loading) return; // a real load started mid-flight; it wins
     // The active space vanishing here means the user was removed from the team
@@ -139,28 +149,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     return ws;
   },
 
-  delete: async (id, options) => {
-    // The server call comes FIRST and its rejection propagates: the row leaves
-    // the store only once the space is really gone. (The v3 adapter's old
-    // no-op stub let this "succeed" and drop the row locally while the space
-    // lived on and re-listed on the next refresh — PRODUCT-1410.)
-    await tauriWorkspaces.delete(id, options);
-    const prev = get();
-    // Same merge as a live refresh that no longer lists the space: when it was
-    // the active one this is a `reselect`, which lands on the default space
-    // AND re-pins the gateway + resets the space-scoped caches — dropping the
-    // row without re-pinning would leave every request addressed to a space
-    // that now 404s. The next refresh tick then confirms the server agrees.
-    applyRefreshPlan(
-      planSpacesRefresh(
-        prev.workspaces,
-        prev.current,
-        prev.workspaces.filter((w) => w.id !== id),
-      ),
-      set,
-    );
-    queryClient.invalidateQueries({ queryKey: queryKeys.orgs() });
-  },
+  delete: (id, options) => runWorkspaceDelete(id, options, get, set),
 
   rename: async (id, newName) => {
     await tauriWorkspaces.rename(id, newName);
@@ -182,6 +171,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   },
 
   // Mirrors the initial state (loading: true) so the shell shows its splash, not
-  // a stale list, until the incoming account's loadWorkspaces() resolves.
-  reset: () => set({ workspaces: [], current: null, loading: true }),
+  // a stale list, until the incoming account's loadWorkspaces() resolves. The
+  // outgoing account's in-flight deletes must not filter the incoming list.
+  reset: () => {
+    pendingWorkspaceDeletes.clear();
+    set({ workspaces: [], current: null, loading: true });
+  },
 }));

--- a/app/src/stores/workspaces.ts
+++ b/app/src/stores/workspaces.ts
@@ -18,6 +18,7 @@ import { resolveActiveWorkspace } from "../lib/workspace-switch";
 import {
   pendingWorkspaceDeletes,
   runWorkspaceDelete,
+  type WorkspaceDeleteMode,
 } from "./workspace-delete";
 import { applyRefreshPlan } from "./workspace-refresh-apply";
 
@@ -46,13 +47,18 @@ interface WorkspaceState {
   refreshWorkspaces: () => Promise<void>;
   setCurrent: (ws: Workspace) => void;
   create: (name: string) => Promise<Workspace>;
-  /** Delete a team space for good (PRODUCT-1410). Optimistic (PRODUCT-1426):
-   *  the row leaves the list and, when it was the active space, the store
-   *  lands on the default space and re-pins the gateway BEFORE the server
-   *  round-trip — the returned promise settles once the server confirms.
-   *  Rejections restore the row in place and propagate (surfaced by the wire
-   *  layer / the caller's `silence` predicate). */
-  delete: (id: string, options?: EngineCallOptions) => Promise<void>;
+  /** Delete a team space for good (PRODUCT-1410). Defaults to `server-first`
+   *  (the row leaves the list only once the space is really gone); a caller
+   *  that pre-checked the gateway will accept (`canDeleteOptimistically`)
+   *  passes `optimistic` to switch away BEFORE the server round-trip, with the
+   *  row restored in place on rejection (PRODUCT-1426). Rejections propagate
+   *  either way (surfaced by the wire layer / the caller's `silence`
+   *  predicate). */
+  delete: (
+    id: string,
+    options?: EngineCallOptions,
+    mode?: WorkspaceDeleteMode,
+  ) => Promise<void>;
   rename: (id: string, newName: string) => Promise<void>;
   /** Set (or clear, with null) the workspace's UI-locale override. */
   setLocale: (id: string, locale: string | null) => Promise<void>;
@@ -149,7 +155,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     return ws;
   },
 
-  delete: (id, options) => runWorkspaceDelete(id, options, get, set),
+  delete: (id, options, mode = "server-first") =>
+    runWorkspaceDelete(id, options, get, set, mode),
 
   rename: async (id, newName) => {
     await tauriWorkspaces.rename(id, newName);

--- a/app/tests/workspace-delete-model.test.ts
+++ b/app/tests/workspace-delete-model.test.ts
@@ -1,8 +1,10 @@
-import { strictEqual } from "node:assert";
+import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
+import type { Workspace } from "../src/lib/types.ts";
 import {
   classifyWorkspaceDeleteError,
   isExpectedWorkspaceDeleteError,
+  restoreSpaceRow,
 } from "../src/lib/workspace-delete-model.ts";
 
 /**
@@ -49,6 +51,39 @@ describe("classifyWorkspaceDeleteError", () => {
     );
     strictEqual(classifyWorkspaceDeleteError(new Error("boom")), "unknown");
     strictEqual(classifyWorkspaceDeleteError(undefined), "unknown");
+  });
+});
+
+// PRODUCT-1426: the optimistic delete's rollback puts the row back where the
+// user last saw it when the gateway rejects the delete.
+const ws = (id: string, name: string, isDefault = false): Workspace => ({
+  id,
+  name,
+  isDefault,
+  createdAt: "2026-08-19T00:00:00Z",
+});
+
+const personal = ws("Houston", "Personal", true);
+const teamA = ws("org:aaaaaaaaaaaaaaaa", "Marketing");
+const teamB = ws("org:bbbbbbbbbbbbbbbb", "Sales");
+
+describe("restoreSpaceRow", () => {
+  it("puts the row back at its old index", () => {
+    deepStrictEqual(restoreSpaceRow([personal, teamB], teamA, 1), [
+      personal,
+      teamA,
+      teamB,
+    ]);
+  });
+
+  it("clamps an out-of-range index (the list shrank meanwhile)", () => {
+    deepStrictEqual(restoreSpaceRow([personal], teamB, 2), [personal, teamB]);
+  });
+
+  it("lets a racing re-list win: an already-present id changes nothing", () => {
+    const renamed = { ...teamA, name: "Marketing LATAM" };
+    const list = [personal, renamed];
+    strictEqual(restoreSpaceRow(list, teamA, 1), list);
   });
 });
 

--- a/app/tests/workspace-delete-model.test.ts
+++ b/app/tests/workspace-delete-model.test.ts
@@ -1,7 +1,9 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
+import type { BillingSummary, OrgSummary } from "@houston-ai/engine-client";
 import type { Workspace } from "../src/lib/types.ts";
 import {
+  canDeleteOptimistically,
   classifyWorkspaceDeleteError,
   isExpectedWorkspaceDeleteError,
   restoreSpaceRow,
@@ -51,6 +53,67 @@ describe("classifyWorkspaceDeleteError", () => {
     );
     strictEqual(classifyWorkspaceDeleteError(new Error("boom")), "unknown");
     strictEqual(classifyWorkspaceDeleteError(undefined), "unknown");
+  });
+});
+
+// PRODUCT-1426: the pre-check that picks the UX shape — optimistic only for a
+// space the gateway will provably accept deleting. Mirrors the gateway's two
+// 409s: any OTHER member row (`memberCount > 1`) and a live Stripe object
+// (`interval` is set exactly when one exists; `active`/`past_due` always mean
+// one). Everything unverifiable stays server-first.
+const org = (
+  overrides: Partial<OrgSummary> = {},
+  billing?: Partial<BillingSummary>,
+): OrgSummary => ({
+  id: "org-1",
+  slug: "acme",
+  name: "Acme",
+  kind: "team",
+  role: "owner",
+  memberCount: 1,
+  degraded: false,
+  billing:
+    billing === undefined
+      ? { plan: "team", status: "free", seats: 1 }
+      : { plan: "team", status: "free", seats: 1, ...billing },
+  ...overrides,
+});
+
+describe("canDeleteOptimistically", () => {
+  it("accepts a solo free team (the deletable shape)", () => {
+    strictEqual(canDeleteOptimistically(org()), true);
+  });
+
+  it("accepts a solo team whose trial expired without a Stripe object", () => {
+    strictEqual(canDeleteOptimistically(org({}, { status: "expired" })), true);
+  });
+
+  it("rejects when teammates remain (the gateway's has_members)", () => {
+    strictEqual(canDeleteOptimistically(org({ memberCount: 2 })), false);
+  });
+
+  it("rejects every hint of a live Stripe object (subscription_active)", () => {
+    strictEqual(canDeleteOptimistically(org({}, { status: "active" })), false);
+    strictEqual(
+      canDeleteOptimistically(org({}, { status: "past_due" })),
+      false,
+    );
+    // A Stripe object can hide behind a free/trialing/expired effective
+    // status; its `interval` is the tell.
+    strictEqual(
+      canDeleteOptimistically(org({}, { status: "free", interval: "monthly" })),
+      false,
+    );
+  });
+
+  it("stays server-first on everything unverifiable", () => {
+    strictEqual(canDeleteOptimistically(undefined), false);
+    strictEqual(canDeleteOptimistically(org({ kind: "personal" })), false);
+    strictEqual(canDeleteOptimistically(org({ billing: undefined })), false);
+    strictEqual(
+      canDeleteOptimistically(org({}, { plan: "enterprise" })),
+      false,
+    );
   });
 });
 

--- a/app/tests/workspace-delete-model.test.ts
+++ b/app/tests/workspace-delete-model.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
-import type { BillingSummary, OrgSummary } from "@houston-ai/engine-client";
+import type { BillingSummary, OrgMember } from "@houston-ai/engine-client";
 import type { Workspace } from "../src/lib/types.ts";
 import {
   canDeleteOptimistically,
@@ -57,61 +57,72 @@ describe("classifyWorkspaceDeleteError", () => {
 });
 
 // PRODUCT-1426: the pre-check that picks the UX shape — optimistic only for a
-// space the gateway will provably accept deleting. Mirrors the gateway's two
-// 409s: any OTHER member row (`memberCount > 1`) and a live Stripe object
+// space the gateway will provably accept deleting, over the same reads the
+// admin screens use (`GET /v1/org` roster + `GET /v1/org/billing`). Mirrors
+// the gateway's two 409s: any OTHER member row, and a live Stripe object
 // (`interval` is set exactly when one exists; `active`/`past_due` always mean
 // one). Everything unverifiable stays server-first.
-const org = (
-  overrides: Partial<OrgSummary> = {},
-  billing?: Partial<BillingSummary>,
-): OrgSummary => ({
-  id: "org-1",
-  slug: "acme",
-  name: "Acme",
-  kind: "team",
-  role: "owner",
-  memberCount: 1,
-  degraded: false,
-  billing:
-    billing === undefined
-      ? { plan: "team", status: "free", seats: 1 }
-      : { plan: "team", status: "free", seats: 1, ...billing },
+const member = (userId: string, role: OrgMember["role"]): OrgMember => ({
+  userId,
+  role,
+});
+
+const soloOwner = [member("u-owner", "owner")];
+
+const billing = (overrides: Partial<BillingSummary> = {}): BillingSummary => ({
+  plan: "team",
+  status: "free",
+  seats: 1,
   ...overrides,
 });
 
 describe("canDeleteOptimistically", () => {
   it("accepts a solo free team (the deletable shape)", () => {
-    strictEqual(canDeleteOptimistically(org()), true);
+    strictEqual(canDeleteOptimistically(soloOwner, billing()), true);
   });
 
   it("accepts a solo team whose trial expired without a Stripe object", () => {
-    strictEqual(canDeleteOptimistically(org({}, { status: "expired" })), true);
+    strictEqual(
+      canDeleteOptimistically(soloOwner, billing({ status: "expired" })),
+      true,
+    );
+  });
+
+  it("accepts a null billing summary: the surface is off, no Stripe object can exist", () => {
+    strictEqual(canDeleteOptimistically(soloOwner, null), true);
   });
 
   it("rejects when teammates remain (the gateway's has_members)", () => {
-    strictEqual(canDeleteOptimistically(org({ memberCount: 2 })), false);
+    strictEqual(
+      canDeleteOptimistically([...soloOwner, member("u-2", "user")], billing()),
+      false,
+    );
   });
 
   it("rejects every hint of a live Stripe object (subscription_active)", () => {
-    strictEqual(canDeleteOptimistically(org({}, { status: "active" })), false);
     strictEqual(
-      canDeleteOptimistically(org({}, { status: "past_due" })),
+      canDeleteOptimistically(soloOwner, billing({ status: "active" })),
+      false,
+    );
+    strictEqual(
+      canDeleteOptimistically(soloOwner, billing({ status: "past_due" })),
       false,
     );
     // A Stripe object can hide behind a free/trialing/expired effective
     // status; its `interval` is the tell.
     strictEqual(
-      canDeleteOptimistically(org({}, { status: "free", interval: "monthly" })),
+      canDeleteOptimistically(
+        soloOwner,
+        billing({ status: "free", interval: "monthly" }),
+      ),
       false,
     );
   });
 
   it("stays server-first on everything unverifiable", () => {
-    strictEqual(canDeleteOptimistically(undefined), false);
-    strictEqual(canDeleteOptimistically(org({ kind: "personal" })), false);
-    strictEqual(canDeleteOptimistically(org({ billing: undefined })), false);
+    strictEqual(canDeleteOptimistically(undefined, billing()), false);
     strictEqual(
-      canDeleteOptimistically(org({}, { plan: "enterprise" })),
+      canDeleteOptimistically(soloOwner, billing({ plan: "enterprise" })),
       false,
     );
   });

--- a/app/tests/workspace-refresh.test.ts
+++ b/app/tests/workspace-refresh.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import type { Workspace } from "../src/lib/types.ts";
-import { planSpacesRefresh } from "../src/lib/workspace-refresh.ts";
+import {
+  planSpacesRefresh,
+  withoutPendingDeletes,
+} from "../src/lib/workspace-refresh.ts";
 
 // The live-spaces poll (HOU: "a new org must appear without relaunching").
 // planSpacesRefresh is the pure merge decision the workspace store applies on
@@ -75,5 +78,31 @@ describe("planSpacesRefresh", () => {
     ]);
     assert.strictEqual(plan.kind, "update");
     assert.strictEqual(plan.kind === "update" && plan.current?.id, personal.id);
+  });
+});
+
+// PRODUCT-1426: while an optimistic delete is in flight the server still lists
+// the space, so every re-list must drop pending-delete rows or the 60s poll /
+// a window focus would resurrect a space the user just watched disappear.
+describe("withoutPendingDeletes", () => {
+  it("returns the same array when nothing is pending (the common tick)", () => {
+    const fresh = [personal, teamA];
+    assert.strictEqual(withoutPendingDeletes(fresh, new Set()), fresh);
+  });
+
+  it("drops rows whose delete is still in flight", () => {
+    assert.deepStrictEqual(
+      withoutPendingDeletes([personal, teamA, teamB], new Set([teamA.id])),
+      [personal, teamB],
+    );
+  });
+
+  it("composes with planSpacesRefresh into an unchanged tick mid-delete", () => {
+    const plan = planSpacesRefresh(
+      [personal, teamB],
+      personal,
+      withoutPendingDeletes([personal, teamA, teamB], new Set([teamA.id])),
+    );
+    assert.strictEqual(plan.kind, "unchanged");
   });
 });

--- a/ui/core/src/components/confirm-dialog.tsx
+++ b/ui/core/src/components/confirm-dialog.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -8,6 +9,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "./alert-dialog";
+import { Spinner } from "./spinner";
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -17,7 +19,22 @@ interface ConfirmDialogProps {
   confirmLabel?: string;
   cancelLabel?: string;
   variant?: "default" | "destructive";
-  onConfirm: () => void;
+  /**
+   * May return a promise (the AsyncButton idiom, HOU-465): while it is in
+   * flight the dialog STAYS OPEN in a pending state — both buttons disable,
+   * the action shows a spinner with `pendingLabel` (falling back to
+   * `confirmLabel`), and close requests (Esc, overlay) are refused — then
+   * closes when it settles. A sync handler keeps the classic confirm-and-close.
+   */
+  // biome-ignore lint/suspicious/noConfusingVoidType: sync handlers return void, async ones return a Promise
+  onConfirm: () => void | Promise<unknown>;
+  pendingLabel?: string;
+}
+
+function isThenable(value: unknown): value is Promise<unknown> {
+  return (
+    value != null && typeof (value as { then?: unknown }).then === "function"
+  );
 }
 
 export function ConfirmDialog({
@@ -29,18 +46,74 @@ export function ConfirmDialog({
   cancelLabel = "Cancel",
   variant = "destructive",
   onConfirm,
+  pendingLabel,
 }: ConfirmDialogProps) {
+  const [pending, setPending] = React.useState(false);
+  // Same-frame rage clicks land before React commits `disabled` (HOU-465), so
+  // an instant ref guards re-entry; `mounted` keeps the settle callback from
+  // touching state after the owner unmounted the dialog mid-flight.
+  const inFlight = React.useRef(false);
+  const mounted = React.useRef(true);
+  React.useEffect(
+    () => () => {
+      mounted.current = false;
+    },
+    [],
+  );
+
+  const handleConfirm = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (inFlight.current) {
+      event.preventDefault();
+      return;
+    }
+    const result = onConfirm();
+    if (!isThenable(result)) return; // sync confirm: the default close stands
+    // Radix's Action closes the dialog after this handler unless prevented —
+    // the pending state must be visible until the work settles.
+    event.preventDefault();
+    inFlight.current = true;
+    setPending(true);
+    // `finally` resets and closes without swallowing a rejection (the
+    // AsyncButton posture): a failing handler still rejects up the chain
+    // rather than being silently dropped.
+    void result.finally(() => {
+      inFlight.current = false;
+      if (!mounted.current) return;
+      setPending(false);
+      onOpenChange(false);
+    });
+  };
+
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (inFlight.current && !next) return;
+        onOpenChange(next);
+      }}
+    >
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>
           <AlertDialogDescription>{description}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>{cancelLabel}</AlertDialogCancel>
-          <AlertDialogAction variant={variant} onClick={onConfirm}>
-            {confirmLabel}
+          <AlertDialogCancel disabled={pending}>
+            {cancelLabel}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            variant={variant}
+            onClick={handleConfirm}
+            disabled={pending}
+          >
+            {pending ? (
+              <>
+                <Spinner />
+                {pendingLabel ?? confirmLabel}
+              </>
+            ) : (
+              confirmLabel
+            )}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>


### PR DESCRIPTION
Fixes PRODUCT-1426.

## Root cause

Deleting a team space (Settings → Danger Zone) awaited the gateway's `DELETE /v1/orgs/:slug` before doing anything visible. The gateway can take seconds to destroy a space, so after confirming, the user sat inside the doomed workspace with no feedback until the late switch to the default space. (The server-first ordering was deliberate at the time: PRODUCT-1410 fixed an optimistic drop over a no-op stub that faked success forever.)

## Fix

Confirming now **pre-checks the gateway's two business rejections against fresh active-org reads (`GET /v1/org` roster — the same ListMembers the delete handler counts — plus `GET /v1/org/billing`, which degrades to null exactly when the billing surface is off and no Stripe object can exist)**, and the answer picks the UX shape — never the outcome (the gateway stays the sole enforcer):

- **Provably deletable** (solo team: no other member rows, no live Stripe object — `canDeleteOptimistically` mirrors the gateway's `subscriptionIsLive` via the `interval`-is-set tell plus `active`/`past_due`): the app lands on the default space with the success toast **immediately**; the slow gateway delete finishes behind the switch. A rejection (race) restores the row at its old index (`restoreSpaceRow`) and toasts.
- **Anything unprovable** (teammates remain, live subscription, enterprise, or the pre-check read failed): the old server-first flow — the user is never told "deleted" about a space that still stands. Rejections are fast (they precede the purge), so the blocked toast still arrives promptly.
- A pending-delete guard (`withoutPendingDeletes`) filters every re-list (`loadWorkspaces`, the 60s live-spaces poll, focus refresh) so a re-list racing an in-flight optimistic delete can't resurrect the row; the set clears on identity reset.

`useWorkspaceStore.delete` takes an explicit mode (`server-first` default, `optimistic` opt-in), implemented in `app/src/stores/workspace-delete.ts`. No new strings; the existing `dangerZone.deleted` / `dangerZone.blocked.*` copy is reused.

- **Visible pending everywhere** (follow-up from local testing): `ConfirmDialog` gains the AsyncButton idiom — an async `onConfirm` keeps the dialog open on a spinner with a "Deleting…" label until it settles (Esc/overlay refused, rejection not swallowed). Every async confirm in the app inherits this. The success toast also fires the instant the delete is decided, *before* the landing space's agent load, so no silent seconds while agents (or a waking engine) load.

## Before (reproduce the bug)

1. On cloud, create a team workspace and open Settings → Danger zone.
2. Click **Delete** and confirm.
3. Observe: nothing happens for the duration of the gateway delete; you stay in the deleted workspace and can keep using it until the late redirect.

## After (verify the fix)

1. Delete a solo team you own → instant landing on your personal space's home with the success toast; the space is gone from the switcher and never flickers back (even refocusing the window mid-delete).
2. Delete a team that still has members → **no redirect, no false success**: a quick pre-check routes it server-first, the gateway 409s, and the "Remove the other members first" toast shows while you stay in the workspace. Same for a live subscription ("Cancel the subscription first").
3. Gates: `pnpm check`, `cd app && pnpm tsgo --noEmit && pnpm test` (3709 pass; new coverage for `canDeleteOptimistically`, `withoutPendingDeletes`, `restoreSpaceRow`), `pnpm check-locales`, `pnpm --filter houston-web typecheck`.

