### PR TITLE
fix(app): swallow WebKit's abort-time fetch teardown rejection (PRODUCT-1436)

### DIFF
--- a/app/src/lib/benign-rejections.ts
+++ b/app/src/lib/benign-rejections.ts
@@ -24,6 +24,32 @@
  * auth calls (sign-in, code exchange) are awaited with their own try/catch in
  * `auth.ts`, so those rejections are *handled* and never reach this predicate.
  */
+/**
+ * WebKit's abort-time fetch teardown noise (PRODUCT-1436, HOUSTON-APP-4ZZ /
+ * 4Z3). Aborting a `fetch` whose response body is locked to an active reader
+ * makes WKWebView reject an INTERNAL promise no user code can reach, with the
+ * WebKit-only `AbortError` phrasing "Fetch is aborted". Every promise our own
+ * stream plumbing exposes is already handled — `streamEventsResumable` and
+ * `streamGlobalEvents` catch the aborted read, and `readEventStream` defuses
+ * the duplicate `reader.closed` rejection (this quirk's "Load failed" twin) —
+ * so this exact message on an UNHANDLED rejection can only be the platform's
+ * internal promise, fired by our own deliberate teardown (an observer stream's
+ * idle-sync stop, a token-rotation disconnect). Nothing broke; swallow it.
+ *
+ * Deliberately narrow — WebKit's exact abort phrasing, not any `AbortError`:
+ * a floating aborted promise in our code is a real bug and must keep reaching
+ * the report path.
+ */
+export function isBenignAbortRejection(reason: unknown): boolean {
+  if (!reason || typeof reason !== "object") return false;
+  const { name, message } = reason as { name?: unknown; message?: unknown };
+  return (
+    name === "AbortError" &&
+    typeof message === "string" &&
+    /^fetch is aborted/i.test(message)
+  );
+}
+
 export function isBenignLockRejection(reason: unknown): boolean {
   if (!reason || typeof reason !== "object") return false;
 

--- a/app/src/lib/global-error-handlers.ts
+++ b/app/src/lib/global-error-handlers.ts
@@ -1,6 +1,9 @@
 import { isAgentWarmingError } from "./agent-warming-guard";
 import { analytics, classifyAnalyticsError } from "./analytics";
-import { isBenignLockRejection } from "./benign-rejections";
+import {
+  isBenignAbortRejection,
+  isBenignLockRejection,
+} from "./benign-rejections";
 import { showConnectivityErrorToast, showErrorToast } from "./error-toast";
 import { isNetworkTransportError } from "./network-transport-error";
 
@@ -42,6 +45,17 @@ export function installGlobalErrorHandlers(): void {
       event.preventDefault();
       console.debug(
         "[global:unhandledrejection] ignored benign Web Locks contention:",
+        message,
+      );
+      return;
+    }
+    // WebKit rejects an unreachable internal promise when a locked fetch body
+    // is aborted — fired by our own deliberate stream teardown (PRODUCT-1436).
+    // Not a failure: same posture as the lock guard above, console.debug only.
+    if (isBenignAbortRejection(event.reason)) {
+      event.preventDefault();
+      console.debug(
+        "[global:unhandledrejection] ignored WebKit fetch-abort teardown noise:",
         message,
       );
       return;

--- a/app/tests/benign-rejections.test.ts
+++ b/app/tests/benign-rejections.test.ts
@@ -1,6 +1,9 @@
 import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
-import { isBenignLockRejection } from "../src/lib/benign-rejections.ts";
+import {
+  isBenignAbortRejection,
+  isBenignLockRejection,
+} from "../src/lib/benign-rejections.ts";
 
 /**
  * auth-js's typed acquire-timeout error, reduced to the shape our predicate
@@ -9,6 +12,56 @@ import { isBenignLockRejection } from "../src/lib/benign-rejections.ts";
 function acquireTimeoutError(message: string): Error {
   return Object.assign(new Error(message), { isAcquireTimeout: true });
 }
+
+/** WebKit's internal abort rejection, reduced to the shape the predicate reads. */
+function webkitAbortError(): unknown {
+  return Object.assign(new Error("Fetch is aborted"), { name: "AbortError" });
+}
+
+describe("isBenignAbortRejection", () => {
+  it("matches WebKit's abort-time AbortError (HOUSTON-APP-4ZZ / 4Z3)", () => {
+    strictEqual(isBenignAbortRejection(webkitAbortError()), true);
+  });
+
+  it("is case-insensitive on the message", () => {
+    strictEqual(
+      isBenignAbortRejection(
+        Object.assign(new Error("FETCH IS ABORTED"), { name: "AbortError" }),
+      ),
+      true,
+    );
+  });
+
+  it("does NOT match other AbortError phrasings (a floating abort in our code is a bug)", () => {
+    strictEqual(
+      isBenignAbortRejection(
+        Object.assign(new Error("The operation was aborted."), {
+          name: "AbortError",
+        }),
+      ),
+      false,
+    );
+    strictEqual(
+      isBenignAbortRejection(
+        Object.assign(new Error("signal is aborted without reason"), {
+          name: "AbortError",
+        }),
+      ),
+      false,
+    );
+  });
+
+  it("does NOT match the message without the AbortError name", () => {
+    strictEqual(isBenignAbortRejection(new Error("Fetch is aborted")), false);
+  });
+
+  it("handles non-object reasons safely", () => {
+    strictEqual(isBenignAbortRejection(null), false);
+    strictEqual(isBenignAbortRejection(undefined), false);
+    strictEqual(isBenignAbortRejection("Fetch is aborted"), false);
+    strictEqual(isBenignAbortRejection({}), false);
+  });
+});
 
 describe("isBenignLockRejection", () => {
   it("matches the raw Web Locks 'stolen' DOMException (HOUSTON-APP-8Y)", () => {


### PR DESCRIPTION
Closes PRODUCT-1436.

## Root cause

Two Sentry families (HOUSTON-APP-4ZZ, HOUSTON-APP-4Z3 — ~1,000 events / ~17 users since 2026-07-21) are the same defect surfacing through two teardown paths:

- an observer stream receives a server-confirmed idle `sync` and `TurnSink.onSync` calls `stop()`, aborting the conversation events fetch;
- a hosted session-token rotation calls `EngineWebSocket.disconnect()`, aborting the `/v1/events` global stream fetch.

Both abort a `fetch` whose response body is locked to an active reader. WKWebView then rejects an **internal** promise no user code can reach, with the WebKit-only `AbortError` phrasing `Fetch is aborted`. Every promise our own stream plumbing exposes is already handled — `streamEventsResumable` and `streamGlobalEvents` catch the aborted read, and `readEventStream` defuses the duplicate `reader.closed` rejection (this quirk's "Load failed" twin). The surviving rejection is platform noise from our own deliberate teardown, but it reached `window.onunhandledrejection` and was reported as a bug (error toast analytics + Sentry).

## Fix

Add `isBenignAbortRejection` to `app/src/lib/benign-rejections.ts` and gate the shared global rejection handler with it, alongside the existing Web Locks guard: `preventDefault` + `console.debug`, no toast, no Sentry capture. The predicate is deliberately narrow (name `AbortError` **and** WebKit's exact `Fetch is aborted` phrasing) so a genuinely floating aborted promise in our code keeps reaching the report path.

## Before (reproduction)

1. Run the desktop app (WKWebView) on 0.6.4 with Sentry enabled.
2. Open a conversation mid-turn in a second window (or reload mid-turn) so a passive observer stream attaches, then let the turn finish — the idle `sync` makes the observer abort its stream fetch. Alternatively, let the hosted session token rotate (leave the app running past a refresh) so `setHostedEngineSessionToken` bounces the client.
3. An `unhandled_rejection: Fetch is aborted` event lands in Sentry (and fires the uncaught-error analytics), attributed to `TurnSink.onSync` or `EngineWebSocket.disconnect`.

## After (verification)

1. Same steps on this branch: the rejection is swallowed — DevTools shows the `[global:unhandledrejection] ignored WebKit fetch-abort teardown noise:` debug line, no toast analytics event, no Sentry capture.
2. `cd app && pnpm test` — includes new `isBenignAbortRejection` cases (WebKit phrasing matches; other `AbortError` phrasings and bare messages do not).
3. After release, HOUSTON-APP-4ZZ / 4Z3 stop receiving events on the new version.

Checks: `pnpm check` clean, `pnpm tsgo --noEmit` clean, `cd app && pnpm test` 3703 pass.