### PR TITLE
fix(shell): normalize tracing-log targets so noisy-dep Sentry demotes actually work (PRODUCT-1437)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,6 +2084,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "keyring",
+ "log",
  "notify-rust",
  "objc2",
  "objc2-app-kit",
@@ -2107,6 +2108,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-appender",
+ "tracing-log",
  "tracing-subscriber",
  "windows-sys 0.59.0",
 ]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -39,6 +39,10 @@ sentry = "0.42"
 # Layer is a no-op until sentry::init has run, so safe to register
 # unconditionally in logging.rs even when SENTRY_DSN is empty.
 sentry-tracing = "0.42"
+# `NormalizeEvent` in sentry_events.rs: log-crate records reach tracing with
+# callsite target "log"; the real target (needed to demote known noisy deps)
+# only exists on the normalized metadata.
+tracing-log = "0.2"
 # keyring v3 backends are OPT-IN per platform. Without a Linux feature the
 # crate silently compiles its in-memory mock on Linux — auth_set_item
 # "succeeds" into a throwaway object and every session evaporates on quit
@@ -77,6 +81,13 @@ tracing-appender = { workspace = true }
 # the webview boots we've already committed to launching from the DMG.
 # `rfd` is pure Rust + AppKit, no React/Webview/Tauri dependency, so it
 # can pop a dialog at the very top of `run()`.
+[dev-dependencies]
+# sentry_events.rs pipeline tests capture what actually reaches Sentry via
+# the in-memory test transport, instead of unit-testing the demote predicate
+# (which is how the original event_filter bug slipped through).
+sentry = { version = "0.42", features = ["test"] }
+log = "0.4"
+
 [target."cfg(target_os = \"macos\")".dependencies]
 rfd = "0.15"
 # Native app-activation. `window.set_focus()` (makeKeyAndOrderFront) does not

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod loopback_util;
 mod notification;
 mod notification_settings;
 mod oauth_loopback;
+mod sentry_events;
 mod shell_env;
 mod store_deep_link;
 mod window_focus;

--- a/app/src-tauri/src/logging.rs
+++ b/app/src-tauri/src/logging.rs
@@ -12,14 +12,10 @@ static GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 ///
 /// Two layers chained on a single Registry:
 ///   - `fmt_layer`  → rolling daily file `backend.log` (current behavior)
-///   - `sentry_tracing::layer()` → INFO+ events become Sentry breadcrumbs;
-///     ERROR events become standalone Sentry events. No-op if `sentry::init`
+///   - `sentry_events::layer()` → INFO+ events become Sentry breadcrumbs;
+///     ERROR events become standalone Sentry events, except the demoted
+///     noise targets (see `sentry_events.rs`). No-op if `sentry::init`
 ///     hasn't been called (e.g. empty SENTRY_DSN), so safe to always include.
-///     Exception: `tauri_plugin_updater` ERRORs stay breadcrumbs — the plugin
-///     logs one on every failed background update poll (machine offline,
-///     GitHub down, transient non-2xx from the release manifest), and the
-///     frontend already owns that failure (5-min poll retry, install-error
-///     card), so a standalone Sentry event per poll is noise.
 ///
 /// Result: when a Rust panic or explicit `tracing::error!` lands in Sentry,
 /// the last ~100 INFO/WARN log lines auto-attach as breadcrumbs — the
@@ -57,33 +53,8 @@ pub fn init(data_dir: &Path) {
     tracing_subscriber::registry()
         .with(filter)
         .with(fmt_layer)
-        .with(sentry_tracing::layer().event_filter(|metadata| {
-            if demote_error_to_breadcrumb(metadata.target()) {
-                sentry_tracing::EventFilter::Breadcrumb
-            } else {
-                sentry_tracing::default_event_filter(metadata)
-            }
-        }))
+        .with(crate::sentry_events::layer())
         .init();
-}
-
-/// Targets whose ERROR logs must NOT become standalone Sentry events.
-///
-/// `tauri_plugin_updater` fires `log::error!` on every unsuccessful update
-/// check — including the expected ones (offline, GitHub unreachable or
-/// returning a transient non-2xx for the channel manifest). The check
-/// failure is fully handled in the frontend updater hooks, so Sentry only
-/// needs the breadcrumb trail, not an event per 5-minute poll
-/// (Sentry HOUSTON-APP-14).
-///
-/// `rustls_platform_verifier` fires `log::error!` internally whenever the
-/// OS trust store rejects a peer certificate (e.g. a machine behind a
-/// misconfigured corporate MITM proxy whose root even Windows won't chain).
-/// The failing request already returns `Err` and its caller owns surfacing
-/// it, so the verifier's own log line is a duplicate — one Sentry event per
-/// retry from a handful of broken machines (Sentry HOUSTON-APP-PE).
-fn demote_error_to_breadcrumb(target: &str) -> bool {
-    target.starts_with("tauri_plugin_updater") || target.starts_with("rustls_platform_verifier")
 }
 
 fn logs_dir() -> PathBuf {
@@ -174,27 +145,6 @@ fn tail_file(path: &Path, n: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn updater_plugin_errors_are_demoted_to_breadcrumbs() {
-        assert!(demote_error_to_breadcrumb("tauri_plugin_updater::updater"));
-        assert!(demote_error_to_breadcrumb("tauri_plugin_updater"));
-    }
-
-    #[test]
-    fn tls_platform_verifier_errors_are_demoted_to_breadcrumbs() {
-        assert!(demote_error_to_breadcrumb(
-            "rustls_platform_verifier::verification::windows"
-        ));
-        assert!(demote_error_to_breadcrumb("rustls_platform_verifier"));
-    }
-
-    #[test]
-    fn app_errors_still_become_sentry_events() {
-        assert!(!demote_error_to_breadcrumb("houston_app"));
-        assert!(!demote_error_to_breadcrumb("houston_app::engine_supervisor"));
-        assert!(!demote_error_to_breadcrumb("tauri_plugin_sentry"));
-    }
 
     #[test]
     fn latest_log_matching_uses_newest_rotated_backend_log() {

--- a/app/src-tauri/src/sentry_events.rs
+++ b/app/src-tauri/src/sentry_events.rs
@@ -1,0 +1,152 @@
+//! Decides what backend log output becomes in Sentry: breadcrumb or event.
+//!
+//! Registered by `logging::init` as the `sentry_tracing` layer. Uses an
+//! `event_mapper` (not an `event_filter`) because of a `tracing-log` subtlety:
+//! `log`-crate records (e.g. `tauri_plugin_updater`, `rustls_platform_verifier`)
+//! reach tracing through `LogTracer`'s static callsites, whose
+//! `Metadata::target()` is literally `"log"` — the real target only exists on
+//! the *normalized* metadata. An `event_filter` sees only the callsite
+//! metadata, so a target-based demote list silently never matches any
+//! log-crate source (Sentry HOUSTON-APP-S: one event per failed 5-minute
+//! update poll, from every release that "had" the HOU-1104 demote). The
+//! mapper receives the full event and normalizes before deciding.
+
+use sentry_tracing::{
+    breadcrumb_from_event, default_event_filter, event_from_event, EventFilter, EventMapping,
+    SentryLayer,
+};
+use tracing::{Event, Subscriber};
+use tracing_log::NormalizeEvent;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+
+/// The Sentry layer for the tracing registry: INFO+ becomes breadcrumbs,
+/// ERROR becomes standalone events — except the demoted targets below.
+pub fn layer<S>() -> SentryLayer<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    sentry_tracing::layer().event_mapper(map_event)
+}
+
+fn map_event<S>(event: &Event<'_>, _ctx: Context<'_, S>) -> EventMapping
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let normalized = event.normalized_metadata();
+    let metadata = normalized.as_ref().unwrap_or_else(|| event.metadata());
+
+    let filter = if demote_error_to_breadcrumb(metadata.target()) {
+        EventFilter::Breadcrumb
+    } else {
+        default_event_filter(metadata)
+    };
+
+    // Mirror the layer's default (no-mapper) path, span attributes disabled.
+    let span_ctx = None::<&Context<'_, S>>;
+    let mut items = Vec::new();
+    if filter.contains(EventFilter::Breadcrumb) {
+        items.push(EventMapping::Breadcrumb(breadcrumb_from_event(
+            event, span_ctx,
+        )));
+    }
+    if filter.contains(EventFilter::Event) {
+        items.push(EventMapping::Event(event_from_event(event, span_ctx)));
+    }
+    EventMapping::Combined(items.into())
+}
+
+/// Targets whose ERROR logs must NOT become standalone Sentry events.
+///
+/// `tauri_plugin_updater` fires `log::error!` on every unsuccessful update
+/// check — including the expected ones (offline, GitHub unreachable or
+/// returning a transient non-2xx for the channel manifest). The check
+/// failure is fully handled in the frontend updater hooks, so Sentry only
+/// needs the breadcrumb trail, not an event per 5-minute poll
+/// (Sentry HOUSTON-APP-14, HOUSTON-APP-S).
+///
+/// `rustls_platform_verifier` fires `log::error!` internally whenever the
+/// OS trust store rejects a peer certificate (e.g. a machine behind a
+/// misconfigured corporate MITM proxy whose root even Windows won't chain).
+/// The failing request already returns `Err` and its caller owns surfacing
+/// it, so the verifier's own log line is a duplicate — one Sentry event per
+/// retry from a handful of broken machines (Sentry HOUSTON-APP-PE).
+fn demote_error_to_breadcrumb(target: &str) -> bool {
+    target.starts_with("tauri_plugin_updater") || target.starts_with("rustls_platform_verifier")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::prelude::*;
+
+    /// Runs `f` under a registry carrying our layer, with the `log`-crate
+    /// bridge installed, and returns the Sentry events captured — the same
+    /// pipeline production records flow through.
+    fn captured_events(f: impl FnOnce()) -> Vec<sentry::protocol::Event<'static>> {
+        // First test to run installs the global log→tracing bridge; the
+        // Err on subsequent calls just means it's already installed.
+        let _ = tracing_log::LogTracer::init();
+        let subscriber = tracing_subscriber::registry().with(layer());
+        sentry::test::with_captured_events(|| tracing::subscriber::with_default(subscriber, f))
+    }
+
+    #[test]
+    fn log_bridged_updater_error_stays_a_breadcrumb() {
+        let events = captured_events(|| {
+            log::error!(
+                target: "tauri_plugin_updater::updater",
+                "failed to check for updates: error sending request"
+            );
+        });
+        assert!(events.is_empty(), "updater poll noise must not be an event");
+    }
+
+    #[test]
+    fn log_bridged_tls_verifier_error_stays_a_breadcrumb() {
+        let events = captured_events(|| {
+            log::error!(
+                target: "rustls_platform_verifier::verification::windows",
+                "certificate verification failed"
+            );
+        });
+        assert!(events.is_empty(), "TLS verifier noise must not be an event");
+    }
+
+    #[test]
+    fn log_bridged_error_from_other_deps_still_becomes_an_event() {
+        let events = captured_events(|| {
+            log::error!(target: "some_dependency", "boom");
+        });
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn tracing_app_error_still_becomes_an_event() {
+        let events = captured_events(|| {
+            tracing::error!(target: "houston_app::engine_supervisor", "boom");
+        });
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn updater_plugin_errors_are_demoted_to_breadcrumbs() {
+        assert!(demote_error_to_breadcrumb("tauri_plugin_updater::updater"));
+        assert!(demote_error_to_breadcrumb("tauri_plugin_updater"));
+    }
+
+    #[test]
+    fn tls_platform_verifier_errors_are_demoted_to_breadcrumbs() {
+        assert!(demote_error_to_breadcrumb(
+            "rustls_platform_verifier::verification::windows"
+        ));
+        assert!(demote_error_to_breadcrumb("rustls_platform_verifier"));
+    }
+
+    #[test]
+    fn app_errors_still_become_sentry_events() {
+        assert!(!demote_error_to_breadcrumb("houston_app"));
+        assert!(!demote_error_to_breadcrumb("houston_app::engine_supervisor"));
+        assert!(!demote_error_to_breadcrumb("tauri_plugin_sentry"));
+    }
+}


### PR DESCRIPTION
## Root cause

Sentry HOUSTON-APP-S (`failed to check for updates: …/latest.json`, 3.8k events since May, still emitting from 0.5.47 and 0.6.x) survived the HOU-1104 demote because of a `tracing-log` subtlety: `log`-crate records reach tracing through `LogTracer`'s static callsites, whose `Metadata::target()` is literally `"log"` — the real target only exists on the *normalized* metadata. The `sentry_tracing::layer().event_filter(...)` only receives the un-normalized callsite metadata, so the target-based demote list (`tauri_plugin_updater`, and `rustls_platform_verifier` from PRODUCT-1430) never matched any log-crate source. Every failed 5-minute update poll still became a full Sentry event. The existing unit tests passed because they called the demote predicate directly with the real target string, bypassing the bridge.

## Fix

- Replace the `event_filter` with an `event_mapper` that normalizes log-bridged metadata (`tracing_log::NormalizeEvent::normalized_metadata()`) before applying the demote predicate, mirroring the default breadcrumb/event mapping otherwise.
- Move the decision into a dedicated `app/src-tauri/src/sentry_events.rs` module (keeps `logging.rs` under the line cap).
- Pipeline-level tests: emit real `log::error!` records through `LogTracer` into the layer and assert what reaches Sentry via the in-memory test transport (`sentry` `test` feature), instead of unit-testing the predicate. Demoted targets produce no event; other `log`-crate errors and `tracing::error!` from app code still do.

This also makes the PRODUCT-1430 `rustls_platform_verifier` demote effective for the first time — that crate logs via the `log` crate too.

## Before the fix (reproduction)

1. On this branch, revert `sentry_events::layer()` to the old `event_filter` closure.
2. `cd app/src-tauri && cargo test --lib sentry_events` → `log_bridged_updater_error_stays_a_breadcrumb` **fails**: the log-bridged updater error is captured as a full Sentry event (exactly what HOUSTON-APP-S shows in production).
3. Equivalent manual repro: run a packaged build with no network route to github.com; each 5-minute updater poll produces one HOUSTON-APP-S event.

## After the fix (verification)

1. `cd app/src-tauri && cargo test --lib` → 224 passed, including the four pipeline tests in `sentry_events`.
2. `cargo check` clean.
3. Post-release: HOUSTON-APP-S (and HOUSTON-APP-PE) event counts for the new release version should drop to zero in Sentry; the demoted lines still appear as breadcrumbs on real crash events and in `backend.log`.

## Notes

- No server-side alternative exists on the current Sentry plan (message-based inbound filters and delete-and-discard are Business-plan features), so old clients keep emitting until they update; a stuck cohort on 0.4.26 that cannot reach github.com will keep emitting regardless.

PRODUCT-1437