### PR TITLE
feat(runtime): pool workers execute routine fires

### DIFF
--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -14,6 +14,12 @@ import { finishTurnDurability } from "./turn-durability";
 import { prepareTurnFilesystem } from "./turn-filesystem";
 import { TurnSetupError } from "./turn-layout";
 import { createTurnLog } from "./turn-log";
+import {
+  prepareRoutineTurn,
+  type RoutinePhase,
+  RoutineTurnError,
+  settleRoutineTurn,
+} from "./turn-routine";
 import { createTurnModelRuntime } from "./turn-runtime";
 import { runPiTurn, type TurnOutcome } from "./turn-session";
 import { resolveTurnStore } from "./turn-store";
@@ -118,6 +124,43 @@ export async function executeTurn(
       }
     } else {
       let outcome: TurnOutcome;
+      // A routine fire derives its prompt and pins from the agent's own
+      // routine file (the prompt authority), records the running row, and
+      // gates double-fires — the worker-side twin of the host's
+      // fireRoutineRun. Typed failures terminate the turn with a machine
+      // code the dispatcher settles the fire from.
+      let routinePhase: RoutinePhase | null = null;
+      let effectiveTurn = turn;
+      if (turn.routine) {
+        try {
+          routinePhase = await prepareRoutineTurn(
+            filesystem.workspaceDir,
+            turn,
+            turnId,
+            new Date().toISOString(),
+          );
+          effectiveTurn = {
+            ...turn,
+            text: routinePhase.text,
+            ...(routinePhase.model ? { model: routinePhase.model } : {}),
+            ...(routinePhase.effort ? { effort: routinePhase.effort } : {}),
+            mode: "auto",
+          };
+        } catch (error) {
+          const code =
+            error instanceof RoutineTurnError ? error.code : "routine_error";
+          emit({
+            type: "error",
+            data: {
+              message: error instanceof Error ? error.message : String(error),
+              code,
+            },
+            turnId,
+          } as WireFrame);
+          await turnLog?.flush();
+          return;
+        }
+      }
       if (!turn.credential) {
         emit({
           type: "user",
@@ -145,13 +188,37 @@ export async function executeTurn(
               () =>
                 run(
                   filesystem,
-                  piTurnRequest(turn, turnId, emit, abort.signal),
+                  piTurnRequest(effectiveTurn, turnId, emit, abort.signal),
                 ),
             ),
           );
         } catch (error) {
           outcome = {
             error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      }
+
+      if (routinePhase) {
+        // The run row must leave "running" and land in the tree BEFORE the
+        // claimed sync-back uploads it — never a stuck row, never silent.
+        try {
+          await settleRoutineTurn({
+            workspaceDir: filesystem.workspaceDir,
+            phase: routinePhase,
+            conversationId: turn.conversationId,
+            ...(outcome.error ? { turnError: outcome.error } : {}),
+            nowIso: new Date().toISOString(),
+            newId: () => crypto.randomUUID(),
+          });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          outcome = {
+            ...outcome,
+            error: outcome.error
+              ? `${outcome.error}; routine settle failed: ${message}`
+              : `routine settle failed: ${message}`,
           };
         }
       }

--- a/packages/runtime/src/turn/parse-turn-request.ts
+++ b/packages/runtime/src/turn/parse-turn-request.ts
@@ -130,6 +130,18 @@ export function parseTurnRequest(body: unknown): TurnRequest {
   if (Boolean(claim) !== Boolean(b.hostToken)) {
     throw new Error("claim and hostToken must be configured together");
   }
+  let routine: TurnRequest["routine"];
+  if (b.routine !== undefined) {
+    const parsed = record(b.routine, "routine");
+    exactKeys(parsed, ["id"], "routine");
+    if (!nonEmpty(parsed.id)) {
+      throw new Error("invalid 'routine'");
+    }
+    if (!claim) {
+      throw new Error("routine turns require a claim");
+    }
+    routine = { id: parsed.id };
+  }
   const poolPrefix = prefix.split("/");
   if (
     claim &&
@@ -166,6 +178,7 @@ export function parseTurnRequest(body: unknown): TurnRequest {
     userContext: typeof b.userContext === "string" ? b.userContext : undefined,
     turnlogSeqStart:
       typeof b.turnlogSeqStart === "number" ? b.turnlogSeqStart : undefined,
+    routine,
     claim,
   };
 }

--- a/packages/runtime/src/turn/turn-activity-doc.ts
+++ b/packages/runtime/src/turn/turn-activity-doc.ts
@@ -16,6 +16,7 @@ export type ActivityDocPublishResult =
   | { error: string };
 
 interface ActivityDocOptions {
+  family: "activity" | "routine_runs";
   baseUrl: string;
   org: string;
   agent: string;
@@ -38,7 +39,7 @@ async function request(
   const root = opts.baseUrl.replace(/\/+$/, "");
   const url = `${root}/v1/pod/docs/${encodeURIComponent(
     opts.org,
-  )}/${encodeURIComponent(opts.agent)}/activity`;
+  )}/${encodeURIComponent(opts.agent)}/${opts.family}`;
   return fetchWithRetry(
     (input, requestInit) =>
       opts.fetchImpl(input, {
@@ -102,7 +103,10 @@ async function putAtRevision(
 async function acceptPut(
   response: Response,
 ): Promise<ActivityDocPublishResult> {
-  if (response.status === 404) {
+  if (response.status === 404 || response.status === 403) {
+    // 404: the docs route is absent. 403: the store predates this family in
+    // the claim scope. Both mean "this deployment cannot take the doc yet" —
+    // a diagnostic on the terminal frame, never a failed turn.
     await response.body?.cancel();
     return { disabled: true, reason: "route_absent" };
   }
@@ -156,6 +160,52 @@ export async function publishTurnActivityDoc(
     const { org, agent } = poolIdentity(turn.gcsPrefix);
     return await publish(
       {
+        family: "activity",
+        baseUrl,
+        org,
+        agent,
+        conversationId: turn.conversationId,
+        hostToken: turn.hostToken,
+        claim: { token: turn.claim.token, bootId: turn.claim.bootId },
+        fetchImpl: deps.fetchImpl ?? fetch,
+        ...(deps.activityDocRetryDelaysMs
+          ? { retryDelaysMs: deps.activityDocRetryDelaysMs }
+          : {}),
+      },
+      doc,
+    );
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * Project a routine turn's uploaded runs file into the routine_runs DB doc —
+ * raw parse, mirroring the standing DocShadowProjector's non-activity
+ * families byte for byte.
+ */
+export async function publishTurnRunsDoc(
+  deps: TurnServerDeps,
+  turn: TurnRequest & { turnId: string },
+  filesystem: TurnFilesystem,
+): Promise<ActivityDocPublishResult | null> {
+  const baseUrl = deps.poolStoreUrl ?? process.env.HOUSTON_POOL_STORE_URL;
+  if (turn.shadow || !baseUrl || !turn.claim || !turn.hostToken) return null;
+  try {
+    const raw = await readFile(
+      join(
+        filesystem.workspaceDir,
+        ".houston",
+        "routine_runs",
+        "routine_runs.json",
+      ),
+      "utf8",
+    );
+    const doc = JSON.parse(raw.replace(/^\uFEFF/, "")) as unknown;
+    const { org, agent } = poolIdentity(turn.gcsPrefix);
+    return await publish(
+      {
+        family: "routine_runs",
         baseUrl,
         org,
         agent,

--- a/packages/runtime/src/turn/turn-durability.ts
+++ b/packages/runtime/src/turn/turn-durability.ts
@@ -1,11 +1,15 @@
 import { StoreFencedError } from "@houston/runtime-client/object-sync";
 import type { ClaimHeartbeat } from "./claim-heartbeat";
 import type { TurnServerDeps } from "./server-types";
-import { publishTurnActivityDoc } from "./turn-activity-doc";
+import {
+  publishTurnActivityDoc,
+  publishTurnRunsDoc,
+} from "./turn-activity-doc";
 import {
   syncTurnFilesystem,
   type TurnFilesystem,
   turnActivityKey,
+  turnRoutineRunsKey,
 } from "./turn-filesystem";
 import type { TurnOutcome } from "./turn-session";
 import type { ResolvedTurnStore } from "./turn-store";
@@ -110,6 +114,19 @@ export async function finishTurnDurability(
     outcome = appendError(
       outcome,
       `board doc publish failed: ${activityPublished.error}`,
+    );
+  }
+  const runsChanged = uploaded.includes(
+    turnRoutineRunsKey(opts.filesystem.workspaceRel),
+  );
+  const runsPublished =
+    opts.turn.claim && opts.turn.routine && runsChanged
+      ? await publishTurnRunsDoc(opts.deps, opts.turn, opts.filesystem)
+      : null;
+  if (runsPublished && "error" in runsPublished) {
+    outcome = appendError(
+      outcome,
+      `runs doc publish failed: ${runsPublished.error}`,
     );
   }
   // The claim may have been adopted while sync/publish were in flight (the

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -69,15 +69,21 @@ export function claimedTurnIncludes(
   );
   const session = posix.join(dataRel, "sessions", conversationId);
   const activity = turnActivityKey(workspaceRel);
+  const runs = turnRoutineRunsKey(workspaceRel);
   return (relativePath) =>
     relativePath === conversation ||
     relativePath.startsWith(`${session}/`) ||
-    relativePath === activity;
+    relativePath === activity ||
+    relativePath === runs;
 }
 
 /** Store-relative mission-board object granted to a claimed turn. */
 export const turnActivityKey = (workspaceRel: string): string =>
   docKey(workspaceRel, "activity");
+
+/** Store-relative routine-runs object granted to a claimed turn. */
+export const turnRoutineRunsKey = (workspaceRel: string): string =>
+  docKey(workspaceRel, "routine_runs");
 
 /** Sync a turn, limiting a claimed writer to its granted turn-owned files. */
 export async function syncTurnFilesystem(opts: {

--- a/packages/runtime/src/turn/turn-fs-store.ts
+++ b/packages/runtime/src/turn/turn-fs-store.ts
@@ -1,0 +1,21 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { TextStore } from "@houston/domain";
+
+/** Domain TextStore over the hydrated turn tree (absolute-path keys). */
+export function fsTextStore(): TextStore {
+  return {
+    async readText(key: string): Promise<string | null> {
+      try {
+        return await readFile(key, "utf8");
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+        throw error;
+      }
+    },
+    async writeText(key: string, content: string): Promise<void> {
+      await mkdir(dirname(key), { recursive: true });
+      await writeFile(key, content, "utf8");
+    },
+  };
+}

--- a/packages/runtime/src/turn/turn-routine.test.ts
+++ b/packages/runtime/src/turn/turn-routine.test.ts
@@ -1,0 +1,204 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { docKey, ROUTINE_OK_TOKEN } from "@houston/domain";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { fsTextStore } from "./turn-fs-store";
+import {
+  prepareRoutineTurn,
+  RoutineTurnError,
+  settleRoutineTurn,
+} from "./turn-routine";
+import type { TurnRequest } from "./types";
+
+let workspaceDir: string;
+const store = fsTextStore();
+const NOW = "2026-08-19T23:00:00.000Z";
+
+beforeEach(async () => {
+  workspaceDir = await mkdtemp(join(tmpdir(), "turn-routine-"));
+});
+afterEach(async () => {
+  await rm(workspaceDir, { recursive: true, force: true });
+});
+
+const routineFixture = {
+  id: "daily-check",
+  name: "Daily check",
+  prompt: "Check the queue and report anything odd.",
+  schedule: "0 9 * * *",
+  enabled: true,
+  suppress_when_silent: true,
+  model: "gpt-x",
+  effort: "high",
+};
+
+async function seedRoutines(routines: unknown[]): Promise<void> {
+  await store.writeText(
+    docKey(workspaceDir, "routines"),
+    JSON.stringify(routines),
+  );
+}
+
+function routineTurn(overrides: Partial<TurnRequest> = {}): TurnRequest {
+  return {
+    workspaceId: "Personal",
+    agentId: "Agent",
+    conversationId: "routine-daily-check",
+    text: "",
+    gcsPrefix: "ws/org/agent",
+    routine: { id: "daily-check" },
+    ...overrides,
+  } as TurnRequest;
+}
+
+async function runsFile(): Promise<{ id: string; status: string }[]> {
+  return JSON.parse(
+    await readFile(docKey(workspaceDir, "routine_runs"), "utf8"),
+  ) as { id: string; status: string }[];
+}
+
+test("prepare derives prompt and pins and persists a running row", async () => {
+  await seedRoutines([routineFixture]);
+  const phase = await prepareRoutineTurn(
+    workspaceDir,
+    routineTurn(),
+    "turn-1",
+    NOW,
+  );
+  expect(phase.text).toContain(routineFixture.prompt);
+  expect(phase.text).toContain(ROUTINE_OK_TOKEN);
+  expect(phase.model).toBe("gpt-x");
+  expect(phase.effort).toBe("high");
+  const runs = await runsFile();
+  expect(runs).toHaveLength(1);
+  expect(runs[0]).toMatchObject({ id: "turn-1", status: "running" });
+});
+
+test("a missing routine is a typed no_routine failure", async () => {
+  await seedRoutines([]);
+  await expect(
+    prepareRoutineTurn(workspaceDir, routineTurn(), "turn-1", NOW),
+  ).rejects.toMatchObject({ code: "no_routine" });
+});
+
+test("an in-flight run is a typed routine_busy failure", async () => {
+  await seedRoutines([routineFixture]);
+  await prepareRoutineTurn(workspaceDir, routineTurn(), "turn-1", NOW);
+  await expect(
+    prepareRoutineTurn(workspaceDir, routineTurn(), "turn-2", NOW),
+  ).rejects.toMatchObject({ code: "routine_busy" });
+});
+
+test("a conversation not matching the routine's is refused as busy", async () => {
+  await seedRoutines([routineFixture]);
+  await expect(
+    prepareRoutineTurn(
+      workspaceDir,
+      routineTurn({ conversationId: "routine-other" }),
+      "turn-1",
+      NOW,
+    ),
+  ).rejects.toBeInstanceOf(RoutineTurnError);
+});
+
+async function preparedPhase() {
+  await seedRoutines([routineFixture]);
+  return prepareRoutineTurn(workspaceDir, routineTurn(), "turn-1", NOW);
+}
+
+async function seedReply(content: string): Promise<void> {
+  await store.writeText(
+    join(
+      workspaceDir,
+      ".houston",
+      "runtime",
+      "conversations",
+      "routine-daily-check.json",
+    ),
+    JSON.stringify({
+      id: "routine-daily-check",
+      messages: [
+        { role: "user", content: "prompt", ts: 1 },
+        { role: "assistant", content, ts: 2 },
+      ],
+    }),
+  );
+}
+
+test("a ROUTINE_OK reply settles the run silent with no activity", async () => {
+  const phase = await preparedPhase();
+  await seedReply(`All quiet.\n${ROUTINE_OK_TOKEN}`);
+  await settleRoutineTurn({
+    workspaceDir,
+    phase,
+    conversationId: "routine-daily-check",
+    nowIso: NOW,
+    newId: () => "act-1",
+  });
+  const runs = await runsFile();
+  expect(runs[0]).toMatchObject({ id: "turn-1", status: "silent" });
+  await expect(
+    readFile(docKey(workspaceDir, "activity"), "utf8"),
+  ).rejects.toMatchObject({ code: "ENOENT" });
+});
+
+test("a substantive reply settles surfaced and writes the board activity", async () => {
+  const phase = await preparedPhase();
+  await seedReply("Two payments failed — you should look.");
+  await settleRoutineTurn({
+    workspaceDir,
+    phase,
+    conversationId: "routine-daily-check",
+    nowIso: NOW,
+    newId: () => "act-1",
+  });
+  const runs = await runsFile();
+  expect(runs[0]).toMatchObject({ id: "turn-1", status: "surfaced" });
+  const activities = JSON.parse(
+    await readFile(docKey(workspaceDir, "activity"), "utf8"),
+  ) as { session_key: string; status: string; routine_run_id: string }[];
+  expect(activities).toHaveLength(1);
+  expect(activities[0]).toMatchObject({
+    session_key: "routine-daily-check",
+    status: "needs_you",
+    routine_run_id: "turn-1",
+  });
+});
+
+test("a turn error settles the run errored with the reason", async () => {
+  const phase = await preparedPhase();
+  await settleRoutineTurn({
+    workspaceDir,
+    phase,
+    conversationId: "routine-daily-check",
+    turnError: "provider quota exhausted",
+    nowIso: NOW,
+    newId: () => "act-1",
+  });
+  const runs = await runsFile();
+  expect(runs[0]).toMatchObject({
+    status: "error",
+    summary: "provider quota exhausted",
+  });
+});
+
+test("a cancel that already terminalized the row wins over settle", async () => {
+  const phase = await preparedPhase();
+  const raced = (await runsFile()).map((r) =>
+    r.id === "turn-1" ? { ...r, status: "cancelled" } : r,
+  );
+  await store.writeText(
+    docKey(workspaceDir, "routine_runs"),
+    JSON.stringify(raced),
+  );
+  await seedReply("late reply");
+  await settleRoutineTurn({
+    workspaceDir,
+    phase,
+    conversationId: "routine-daily-check",
+    nowIso: NOW,
+    newId: () => "act-1",
+  });
+  expect((await runsFile())[0]).toMatchObject({ status: "cancelled" });
+});

--- a/packages/runtime/src/turn/turn-routine.ts
+++ b/packages/runtime/src/turn/turn-routine.ts
@@ -1,0 +1,189 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  completeRoutineRun,
+  createRoutineRun,
+  loadActivities,
+  loadRoutineRuns,
+  loadRoutines,
+  pruneRoutineRuns,
+  routineActivity,
+  routineConversationId,
+  routinePin,
+  routinePrompt,
+  saveActivities,
+  saveRoutineRuns,
+  upsertById,
+} from "@houston/domain";
+import type { Routine, RoutineRun } from "@houston/protocol";
+import { fsTextStore } from "./turn-fs-store";
+import type { TurnRequest } from "./types";
+
+/**
+ * The routine phases of a pooled turn. A routine fire dispatched to a worker
+ * must behave exactly like the standing host's fireRoutineRun + reconcile:
+ * the routine file is the prompt authority, a running row gates double-fires,
+ * and the terminal reply classifies the run silent vs surfaced (surfaced runs
+ * get their board activity). All of it happens inside the hydrated tree so the
+ * claimed sync-back uploads the same files the pod would have written.
+ */
+
+export type RoutineTurnFailure = "no_routine" | "routine_busy";
+
+export class RoutineTurnError extends Error {
+  constructor(
+    readonly code: RoutineTurnFailure,
+    message: string,
+  ) {
+    super(message);
+    this.name = "RoutineTurnError";
+  }
+}
+
+export interface RoutinePhase {
+  routine: Routine;
+  run: RoutineRun;
+  /** The adjusted turn the pi session should execute. */
+  text: string;
+  model?: string;
+  effort?: string;
+  provider: string | null;
+}
+
+/**
+ * Validate the routine, gate on an in-flight run, persist the running row,
+ * and derive the prompt + pins — the worker-side twin of fireRoutineRun.
+ * The runs write needs no cross-process lock: the conversation claim is the
+ * exclusivity domain (one open claim per conversation fleet-wide), narrower
+ * than the pod's per-agent runs-file queue.
+ */
+export async function prepareRoutineTurn(
+  workspaceDir: string,
+  turn: TurnRequest,
+  turnId: string,
+  nowIso: string,
+): Promise<RoutinePhase> {
+  if (!turn.routine) throw new Error("prepareRoutineTurn without routine");
+  const store = fsTextStore();
+  const { items } = await loadRoutines(store, workspaceDir);
+  const routine = items.find((r) => r.id === turn.routine?.id);
+  if (!routine) {
+    throw new RoutineTurnError(
+      "no_routine",
+      `routine ${turn.routine.id} not found in the agent's routines`,
+    );
+  }
+  const expected = routineConversationId(routine, turnId);
+  if (expected !== turn.conversationId) {
+    // The dispatcher derived the conversation from a stale routines doc (for
+    // example a chat_mode edit that has not projected yet). The claim is for
+    // the WRONG conversation; running anyway would write history where no
+    // reader looks. Busy semantics give the dispatcher a clean retry: the
+    // next fire re-derives against the refreshed doc.
+    throw new RoutineTurnError(
+      "routine_busy",
+      `conversation ${turn.conversationId} does not match the routine's ${expected}`,
+    );
+  }
+  const { items: runs } = await loadRoutineRuns(store, workspaceDir);
+  if (runs.some((r) => r.routine_id === routine.id && r.status === "running")) {
+    throw new RoutineTurnError(
+      "routine_busy",
+      `"${routine.name}" is already running`,
+    );
+  }
+  const run = createRoutineRun(routine, turnId, nowIso);
+  await saveRoutineRuns(store, workspaceDir, pruneRoutineRuns([run, ...runs]));
+  const pin = routinePin(routine);
+  return {
+    routine,
+    run,
+    text: routinePrompt(routine),
+    ...(pin.model ? { model: pin.model } : {}),
+    ...(routine.effort ? { effort: routine.effort } : {}),
+    provider: pin.provider,
+  };
+}
+
+/**
+ * Terminal bookkeeping, written into the hydrated tree BEFORE sync-back: the
+ * run row leaves "running" (silent/surfaced from the reply, error otherwise),
+ * and a surfaced run upserts its board activity — the same rows the pod's
+ * reconcile would have produced.
+ */
+export async function settleRoutineTurn(opts: {
+  workspaceDir: string;
+  phase: RoutinePhase;
+  conversationId: string;
+  turnError?: string;
+  nowIso: string;
+  newId: () => string;
+}): Promise<void> {
+  const store = fsTextStore();
+  const { items: runs } = await loadRoutineRuns(store, opts.workspaceDir);
+  const row = runs.find((r) => r.id === opts.phase.run.id);
+  // Missing or already-terminal row: a cancel raced the turn — keep what the
+  // canceller wrote.
+  if (row?.status !== "running") return;
+  let done: RoutineRun;
+  if (opts.turnError) {
+    done = {
+      ...row,
+      status: "error",
+      summary: opts.turnError,
+      completed_at: opts.nowIso,
+    };
+  } else {
+    const reply = await lastAssistantText(
+      opts.workspaceDir,
+      opts.conversationId,
+    );
+    done = completeRoutineRun(row, opts.phase.routine, reply, opts.nowIso);
+  }
+  await saveRoutineRuns(store, opts.workspaceDir, upsertById(runs, done));
+  if (done.status !== "surfaced") return;
+  const { items: activities } = await loadActivities(store, opts.workspaceDir);
+  const existing = activities.find(
+    (a) => a.session_key === opts.phase.run.session_key,
+  );
+  const activity = routineActivity(
+    opts.phase.routine,
+    done,
+    existing,
+    opts.newId(),
+    opts.nowIso,
+  );
+  await saveActivities(
+    store,
+    opts.workspaceDir,
+    upsertById(activities, activity),
+  );
+}
+
+/** The last assistant message the runtime persisted for the conversation. */
+async function lastAssistantText(
+  workspaceDir: string,
+  conversationId: string,
+): Promise<string> {
+  const path = join(
+    workspaceDir,
+    ".houston",
+    "runtime",
+    "conversations",
+    `${encodeURIComponent(conversationId)}.json`,
+  );
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as {
+      messages?: { role?: string; content?: string }[];
+    };
+    for (let i = (parsed.messages ?? []).length - 1; i >= 0; i--) {
+      const message = parsed.messages?.[i];
+      if (message?.role === "assistant") return message.content ?? "";
+    }
+  } catch {
+    // A missing or unreadable conversation classifies as surfaced-with-empty
+    // summary rather than failing the settle: the turn's own outcome already
+    // told the user what happened.
+  }
+  return "";
+}

--- a/packages/runtime/src/turn/types.ts
+++ b/packages/runtime/src/turn/types.ts
@@ -64,6 +64,13 @@ export interface TurnRequest {
    * (replay = resync). Absent = 1 (a fresh conversation, or a legacy caller).
    */
   turnlogSeqStart?: number;
+  /**
+   * A scheduled routine fire (pool path): the worker derives the prompt and
+   * pins from the agent's own routine file and keeps the run-row lifecycle the
+   * standing host would have kept. Requires a claim: only the control-plane
+   * scheduler dispatches routine turns.
+   */
+  routine?: { id: string };
   /** Exclusive conversation claim granted to this worker. */
   claim?: {
     id: string;


### PR DESCRIPTION
## What

Teaches the pool worker's turn path to execute a scheduled routine fire with the standing host's exact semantics — the houston half of the routines-on-the-pool increment (cloud half: control-plane delivery branch, opening separately on top of cloud#273).

- Envelope: `routine: { id }`, valid only with a claim (only the control-plane scheduler dispatches routine turns).
- Pre-phase (worker, inside the hydrated tree): the agent's routine file is the prompt authority — run preamble + routine prompt + suppression instruction, provider/model/effort pins via the shared `@houston/domain` functions (`routinePrompt`, `routinePin`); a running row gates double-fires; the row persists BEFORE the model runs.
- Typed failures end the turn with a machine-readable code on the error frame: `no_routine`, `routine_busy` (including a conversation id derived from a stale routines doc — busy semantics give the dispatcher a clean retry).
- Post-phase: the terminal reply classifies the run silent (`ROUTINE_OK`) vs surfaced via `completeRoutineRun`; surfaced runs upsert their board activity (`routineActivity`). All written before the claimed sync-back so the same files the pod would have written upload.
- Claimed scope grows by exactly one key: the routine_runs doc. The uploaded runs file projects into the `routine_runs` agent-doc mirroring the activity-doc publisher; a 403 from a pod-store that predates the family in claim scope is a diagnostic, never a failed turn (forward-compatible with the current cloud).

## Behavior unchanged

Non-routine turns byte-identical (routine phases only run when the envelope carries `routine`). Shadow turns never touch any of this. Desktop/self-host unaffected (no claim, no routine envelope).

## Tests

8 new unit tests over real files (prompt/pins/run-row, no_routine, busy, conversation mismatch, silent/surfaced/error settle, cancel race). Full runtime (137 files), runtime-client (20), host (169) suites green; Biome and boundaries clean.

## Sequencing

Inert until the cloud delivery branch dispatches routine turns (stacked on cloud#273; opening next). Rides the engine roll to staging on merge; reaches prod engines on the next release cut.