### PR TITLE
Claude subscription login next to the runtime: browser approve + code paste, no desktop helper (PRODUCT-1200)

### DIFF
--- a/packages/runtime/src/auth/anthropic-cli-binary.ts
+++ b/packages/runtime/src/auth/anthropic-cli-binary.ts
@@ -1,0 +1,59 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { resolveClaudeExecutable } from "../backends/claude/binary-path";
+import type { LoginChild } from "./anthropic-cli-output";
+
+/**
+ * Resolve a spawnable Claude Code CLI for THIS runtime, or null when none can
+ * run here (the anthropic login then uses the token paste flow). Probes, in
+ * order:
+ *
+ *   1. the `HOUSTON_CLAUDE_BIN` dev/test override (verbatim, mirroring the
+ *      desktop shell's `claude_login/resolve.rs`),
+ *   2. the Bun-compiled desktop sidecar's staged sibling binary,
+ *   3. on Node (engine pods, self-host, dev) the SDK's per-platform package —
+ *      the exact binary the SDK itself spawns for turns, so wherever turns can
+ *      run, the login can too.
+ */
+export function resolveClaudeCliBinary(deps?: {
+  resolve?: (spec: string) => string;
+  exists?: (path: string) => boolean;
+}): string | null {
+  const override = process.env.HOUSTON_CLAUDE_BIN;
+  if (override) return override;
+  try {
+    const sidecarSibling = resolveClaudeExecutable();
+    if (sidecarSibling) return sidecarSibling;
+  } catch {
+    // Bun-compiled but the sibling is missing/placeholder: turns already fail
+    // loud there (binary-path throws its typed error); the LOGIN just degrades
+    // to the paste flow instead of refusing to start.
+    return null;
+  }
+  const name = process.platform === "win32" ? "claude.exe" : "claude";
+  const slug = `${process.platform}-${process.arch === "arm64" ? "arm64" : "x64"}`;
+  const resolve = deps?.resolve ?? createRequire(import.meta.url).resolve;
+  const exists = deps?.exists ?? existsSync;
+  const pkg = `@anthropic-ai/claude-agent-sdk-${slug}`;
+  for (const spec of [`${pkg}/${name}`, `${pkg}/package.json`]) {
+    try {
+      const hit = resolve(spec);
+      const bin = hit.endsWith(name) ? hit : join(dirname(hit), name);
+      if (exists(bin)) return bin;
+    } catch {
+      // Not resolvable via this spec (package "exports" differences between
+      // SDK versions) — try the next, else fall through to null.
+    }
+  }
+  return null;
+}
+
+/** Spawn the real CLI login child (`anthropic-cli-login.ts`'s production seam). */
+export function spawnCli(binary: string, configDir: string): LoginChild {
+  return spawn(binary, ["auth", "login", "--claudeai"], {
+    env: { ...process.env, CLAUDE_CONFIG_DIR: configDir },
+    stdio: ["pipe", "pipe", "pipe"],
+  }) as unknown as LoginChild;
+}

--- a/packages/runtime/src/auth/anthropic-cli-login.test.ts
+++ b/packages/runtime/src/auth/anthropic-cli-login.test.ts
@@ -1,0 +1,243 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { expect, test } from "vitest";
+import {
+  type AnthropicLoginDeps,
+  runAnthropicLogin,
+} from "./anthropic-cli-login";
+import {
+  extractVisitUrl,
+  parseMintedCredential,
+  scrubTokens,
+  stripOsc8,
+} from "./anthropic-cli-output";
+import {
+  ANTHROPIC_TOKEN_HELP_URL,
+  type SetupTokenCallbacks,
+} from "./anthropic-setup-token";
+
+const AUTHORIZE_URL =
+  "https://claude.com/cai/oauth/authorize?code=true&client_id=abc&state=xyz";
+
+/** A minted-credential file body shaped like the CLI writes it. */
+const MINTED = JSON.stringify({
+  claudeAiOauth: {
+    accessToken: "sk-ant-oat01-access",
+    refreshToken: "sk-ant-ort01-refresh",
+    expiresAt: 1755555555555,
+    scopes: ["user:inference"],
+  },
+});
+
+/** The spawned-child seam: scripted stdout/stderr, captured stdin, exit/error. */
+class FakeChild {
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  stdinWrites: string[] = [];
+  stdin = { write: (chunk: string) => void this.stdinWrites.push(chunk) };
+  killed = false;
+  private emitter = new EventEmitter();
+  once(event: "exit" | "error", cb: (...args: never[]) => void): void {
+    this.emitter.once(event, cb as (...args: unknown[]) => void);
+  }
+  kill(): void {
+    this.killed = true;
+  }
+  exit(code: number): void {
+    this.emitter.emit("exit", code, null);
+  }
+  spawnError(message: string): void {
+    this.emitter.emit("error", new Error(message));
+  }
+}
+
+/** Let stream data / promise races settle between scripted steps. */
+const tick = () => new Promise((r) => setImmediate(r));
+
+type Harness = {
+  child: FakeChild;
+  authInfos: Array<{ url: string; instructions?: string }>;
+  stored: { tokens: string[]; oauth: Array<Record<string, unknown>> };
+  cleaned: string[];
+  login: Promise<void>;
+  paste: (value: string) => void;
+};
+
+/** Drive runAnthropicLogin against a FakeChild with injected fs seams. */
+function harness(opts?: {
+  binary?: string | null;
+  credentialFile?: string | null;
+  pasteNever?: boolean;
+}): Harness {
+  const child = new FakeChild();
+  const authInfos: Harness["authInfos"] = [];
+  const stored: Harness["stored"] = { tokens: [], oauth: [] };
+  const cleaned: string[] = [];
+  let paste!: (value: string) => void;
+  const pastePromise = new Promise<string>((r) => {
+    paste = r;
+  });
+  const cb: SetupTokenCallbacks = {
+    onAuth: (info) => void authInfos.push(info),
+    onManualCodeInput: () =>
+      opts?.pasteNever ? new Promise<string>(() => {}) : pastePromise,
+  };
+  const deps: AnthropicLoginDeps = {
+    binary: opts?.binary === undefined ? "/bundle/claude" : opts.binary,
+    storeToken: (key) => void stored.tokens.push(key),
+    storeOauth: (cred) => void stored.oauth.push({ ...cred }),
+    spawnChild: () => child,
+    mkLoginDir: () => "/tmp/fake-login-dir",
+    cleanupDir: (dir) => void cleaned.push(dir),
+    readCredentialFile: () =>
+      opts?.credentialFile === undefined ? MINTED : opts.credentialFile,
+  };
+  return {
+    child,
+    authInfos,
+    stored,
+    cleaned,
+    paste,
+    login: runAnthropicLogin(cb, deps),
+  };
+}
+
+test("CLI login: URL surfaced, code relayed to stdin, minted oauth stored", async () => {
+  const h = harness();
+  // Real CLI shape: the URL is OSC-8 hyperlink-wrapped even on a pipe.
+  h.child.stdout.write("Opening browser to sign in…\n");
+  h.child.stdout.write(
+    `If the browser didn't open, visit: \u001b]8;;${AUTHORIZE_URL}\u0007${AUTHORIZE_URL}\u001b]8;;\u0007\n`,
+  );
+  await tick();
+  expect(h.authInfos).toEqual([{ url: AUTHORIZE_URL }]); // no instructions → open-URL + paste-code rendering
+  h.paste("the-verification-code");
+  await tick();
+  expect(h.child.stdinWrites).toEqual(["the-verification-code\n"]);
+  h.child.exit(0);
+  await h.login;
+  expect(h.stored.oauth).toEqual([
+    {
+      access: "sk-ant-oat01-access",
+      refresh: "sk-ant-ort01-refresh",
+      expires: 1755555555555,
+    },
+  ]);
+  expect(h.stored.tokens).toEqual([]);
+  expect(h.cleaned).toEqual(["/tmp/fake-login-dir"]); // the refresh-bearing dir never lingers
+  expect(h.child.killed).toBe(true);
+});
+
+test("CLI login: a co-located listener settles the flow with no code", async () => {
+  const h = harness({ pasteNever: true });
+  h.child.stdout.write(`visit: ${AUTHORIZE_URL}\n`);
+  await tick();
+  h.child.exit(0);
+  await h.login;
+  expect(h.child.stdinWrites).toEqual([]);
+  expect(h.stored.oauth).toHaveLength(1);
+});
+
+test("CLI login: a pasted sk-ant token takes the token flow instead", async () => {
+  const h = harness();
+  h.child.stdout.write(`visit: ${AUTHORIZE_URL}\n`);
+  await tick();
+  h.paste("sk-ant-oat01-pasted-by-a-power-user");
+  await h.login;
+  expect(h.stored.tokens).toEqual(["sk-ant-oat01-pasted-by-a-power-user"]);
+  expect(h.stored.oauth).toEqual([]);
+  expect(h.child.killed).toBe(true);
+});
+
+test("CLI login: nonzero exit after the code fails loud, tokens scrubbed", async () => {
+  const h = harness();
+  h.child.stdout.write(`visit: ${AUTHORIZE_URL}\n`);
+  await tick();
+  h.paste("bad-code");
+  await tick();
+  h.child.stderr.write("token sk-ant-oat01-leaky rejected\n");
+  h.child.exit(1);
+  await expect(h.login).rejects.toThrow(/exit 1/);
+  await expect(h.login).rejects.not.toThrow(/sk-ant-oat01-leaky/);
+  expect(h.stored.oauth).toEqual([]);
+});
+
+test("CLI login: exit 0 without a readable credential file fails loud", async () => {
+  const h = harness({ credentialFile: null });
+  h.child.stdout.write(`visit: ${AUTHORIZE_URL}\n`);
+  await tick();
+  h.paste("the-code");
+  await tick();
+  h.child.exit(0);
+  await expect(h.login).rejects.toThrow(/no credential file/);
+});
+
+test("CLI death before the URL falls back to the token paste flow", async () => {
+  const h = harness();
+  h.child.stderr.write("SIGILL: illegal instruction\n");
+  h.child.exit(132);
+  await tick();
+  // The fallback re-runs onAuth as the paste flow (help url + instructions).
+  h.paste("sk-ant-api03-fallback-key");
+  await h.login;
+  expect(h.authInfos).toHaveLength(1);
+  expect(h.authInfos[0]?.url).toBe(ANTHROPIC_TOKEN_HELP_URL);
+  expect(h.authInfos[0]?.instructions).toBeTruthy();
+  expect(h.stored.tokens).toEqual(["sk-ant-api03-fallback-key"]);
+});
+
+test("a spawn error falls back to the token paste flow", async () => {
+  const h = harness();
+  h.child.spawnError("spawn claude ENOENT");
+  await tick();
+  h.paste("sk-ant-oat01-tok");
+  await h.login;
+  expect(h.stored.tokens).toEqual(["sk-ant-oat01-tok"]);
+});
+
+test("no binary goes straight to the token paste flow", async () => {
+  const h = harness({ binary: null });
+  await tick();
+  expect(h.authInfos[0]?.url).toBe(ANTHROPIC_TOKEN_HELP_URL);
+  h.paste("sk-ant-oat01-tok");
+  await h.login;
+  expect(h.stored.tokens).toEqual(["sk-ant-oat01-tok"]);
+});
+
+test("extractVisitUrl parses plain, punctuated, and OSC-8 wrapped lines", () => {
+  expect(
+    extractVisitUrl(`If the browser didn't open, visit: ${AUTHORIZE_URL}`),
+  ).toBe(AUTHORIZE_URL);
+  expect(extractVisitUrl(`visit: ${AUTHORIZE_URL}.`)).toBe(AUTHORIZE_URL);
+  expect(extractVisitUrl(`(visit: ${AUTHORIZE_URL})`)).toBe(AUTHORIZE_URL);
+  const bel = `visit: \u001b]8;;${AUTHORIZE_URL}\u0007${AUTHORIZE_URL}\u001b]8;;\u0007`;
+  expect(extractVisitUrl(bel)).toBe(AUTHORIZE_URL);
+  const st = `visit: \u001b]8;;${AUTHORIZE_URL}\u001b\\${AUTHORIZE_URL}\u001b]8;;\u001b\\`;
+  expect(extractVisitUrl(st)).toBe(AUTHORIZE_URL);
+  // Unterminated OSC-8 tail: never surface raw escape bytes.
+  expect(extractVisitUrl(`visit: \u001b]8;;${AUTHORIZE_URL}`)).toBeNull();
+  expect(extractVisitUrl("Opening browser to sign in")).toBeNull();
+  expect(extractVisitUrl("please visit: the docs")).toBeNull();
+});
+
+test("stripOsc8 leaves plain text alone", () => {
+  expect(stripOsc8("plain visit: text")).toBe("plain visit: text");
+});
+
+test("scrubTokens redacts sk-ant material", () => {
+  expect(scrubTokens("a sk-ant-oat01-secret-value b")).toBe("a sk-ant-… b");
+});
+
+test("parseMintedCredential maps the CLI file and rejects drifted shapes", () => {
+  expect(parseMintedCredential(MINTED)).toEqual({
+    access: "sk-ant-oat01-access",
+    refresh: "sk-ant-ort01-refresh",
+    expires: 1755555555555,
+  });
+  expect(() =>
+    parseMintedCredential(
+      JSON.stringify({ claudeAiOauth: { accessToken: "x" } }),
+    ),
+  ).toThrow(/unexpected shape/);
+  expect(() => parseMintedCredential("{}")).toThrow(/unexpected shape/);
+});

--- a/packages/runtime/src/auth/anthropic-cli-login.ts
+++ b/packages/runtime/src/auth/anthropic-cli-login.ts
@@ -1,0 +1,196 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnCli } from "./anthropic-cli-binary";
+import type {
+  AnthropicLoginCallbacks,
+  CliMintedOauth,
+  LoginChild,
+} from "./anthropic-cli-output";
+import {
+  CliUnavailableError,
+  extractVisitUrl,
+  parseMintedCredential,
+  readMintedFile,
+  scrubTokens,
+  wireLines,
+} from "./anthropic-cli-output";
+import {
+  isAnthropicToken,
+  runAnthropicSetupTokenLogin,
+  storeAnthropicToken,
+} from "./anthropic-setup-token";
+
+/**
+ * Claude SUBSCRIPTION connect driven by the bundled Claude Code CLI — the one
+ * sanctioned OAuth client — running NEXT TO THE RUNTIME (engine pod, self-host,
+ * a web-backed cloud agent). No terminal, no desktop helper:
+ *
+ *   1. Spawn `claude auth login --claudeai` piped (a plain readline flow, NOT
+ *      an Ink TUI — the desktop shell has driven it piped since HOU-954) with
+ *      `CLAUDE_CONFIG_DIR` pointed at a throwaway dir, so the minted credential
+ *      never lands in the pod-shared login dir.
+ *   2. Surface the authorize URL from its `visit:` line as the `auth_code`
+ *      LoginInfo (no `instructions` → the webapp renders open-URL + paste-code).
+ *      The callback page cannot reach the CLI's listener from another machine,
+ *      so it shows a code the user pastes back (`completeLogin` → stdin here);
+ *      a co-located listener may catch it seamlessly — the CLI just exits 0.
+ *   3. On exit 0, persist the minted OAuth credential (access+refresh) via
+ *      `storeOauth` as a standard pi `oauth` auth.json entry — the EXISTING
+ *      chain takes over: capture exports it, the gateway stores + rotates it
+ *      centrally (the family's ONLY rotator), Gate #2 scrubs the local refresh,
+ *      serve keeps it warm. On self-host there is no gateway and pi itself
+ *      rotates the entry — also a single rotator.
+ *
+ * A pasted `sk-ant-…` value in the same input still short-circuits to the
+ * token flow (kill the child, store an api_key) — the old escape hatch.
+ */
+
+export type AnthropicLoginDeps = {
+  /** The spawnable CLI, or null to go straight to the token paste flow. */
+  binary: string | null;
+  /** Persist a pasted `sk-ant-…` value as pi's `api_key` variant. */
+  storeToken: (key: string) => void;
+  /** Persist the CLI-minted subscription credential as pi's `oauth` variant. */
+  storeOauth: (cred: CliMintedOauth) => void;
+  // Test seams; production uses the real spawn/tmpdir/fs.
+  spawnChild?: (binary: string, configDir: string) => LoginChild;
+  mkLoginDir?: () => string;
+  cleanupDir?: (dir: string) => void;
+  readCredentialFile?: (dir: string) => string | null;
+};
+
+/**
+ * The anthropic connect: the CLI subscription login when a CLI can run here,
+ * the token paste flow otherwise — including when the CLI dies BEFORE the
+ * authorize URL was surfaced (nothing user-visible happened yet, so the
+ * downgrade is seamless). After the URL, a CLI failure surfaces as an error.
+ */
+export async function runAnthropicLogin(
+  cb: AnthropicLoginCallbacks,
+  deps: AnthropicLoginDeps,
+): Promise<void> {
+  if (deps.binary) {
+    try {
+      await runAnthropicCliLogin(cb, deps, deps.binary);
+      return;
+    } catch (e) {
+      if (!(e instanceof CliUnavailableError)) throw e;
+      console.warn(
+        "[oauth:anthropic] Claude CLI login cannot start here — falling back to the token paste flow:",
+        e.message,
+      );
+    }
+  }
+  await runAnthropicSetupTokenLogin(cb, { store: deps.storeToken });
+}
+
+async function runAnthropicCliLogin(
+  cb: AnthropicLoginCallbacks,
+  deps: AnthropicLoginDeps,
+  binary: string,
+): Promise<void> {
+  const cleanup =
+    deps.cleanupDir ??
+    ((d: string) => rmSync(d, { recursive: true, force: true }));
+  const dir = (
+    deps.mkLoginDir ??
+    (() => mkdtempSync(join(tmpdir(), "houston-claude-login-")))
+  )();
+  const child = (deps.spawnChild ?? spawnCli)(binary, dir);
+  try {
+    await driveCliLogin(child, cb, deps, dir);
+  } finally {
+    try {
+      child.kill();
+    } catch {
+      // Already exited — nothing to kill.
+    }
+    try {
+      cleanup(dir);
+    } catch (e) {
+      // The dir holds a refresh-bearing credential copy; a leftover would be
+      // a second-rotator seed. Loud; the tmpdir lifecycle still bounds it.
+      console.error("[oauth:anthropic] could not remove the login dir:", e);
+    }
+  }
+}
+
+async function driveCliLogin(
+  child: LoginChild,
+  cb: AnthropicLoginCallbacks,
+  deps: AnthropicLoginDeps,
+  dir: string,
+): Promise<void> {
+  const tail: string[] = [];
+  let url: string | null = null;
+  let urlFoundResolve!: () => void;
+  const urlFound = new Promise<void>((r) => {
+    urlFoundResolve = r;
+  });
+  const onLine = (line: string) => {
+    const t = line.trim();
+    if (t) tail.push(t);
+    if (tail.length > 12) tail.shift();
+    if (url) return;
+    const u = extractVisitUrl(line);
+    if (u) {
+      url = u;
+      urlFoundResolve();
+    }
+  };
+  wireLines(child.stdout, onLine);
+  wireLines(child.stderr, onLine);
+  const exit = new Promise<number>((resolve, reject) => {
+    child.once("exit", (code, signal) => resolve(code ?? (signal ? -1 : 0)));
+    child.once("error", (e) =>
+      reject(
+        new CliUnavailableError(`could not spawn the Claude CLI: ${e.message}`),
+      ),
+    );
+  });
+
+  // Phase 1: the authorize URL — or an exit first, meaning the CLI cannot run
+  // here (SIGILL, startup gate): downgradable, nothing was surfaced yet.
+  await Promise.race([
+    urlFound,
+    exit.then((code) => {
+      throw new CliUnavailableError(
+        `the Claude CLI exited (${code}) before the sign-in URL: ${scrubTokens(tail.join(" | "))}`,
+      );
+    }),
+  ]);
+  if (!url) throw new Error("unreachable: URL race settled without a URL");
+  cb.onAuth({ url });
+
+  // Phase 2: the user's paste — or the CLI settling on its own (a co-located
+  // browser reached its listener: seamless success at exit 0).
+  const outcome = await Promise.race([
+    cb.onManualCodeInput().then((value) => ({ kind: "input" as const, value })),
+    exit.then((code) => ({ kind: "exit" as const, code })),
+  ]);
+  if (outcome.kind === "input") {
+    const pasted = outcome.value.trim();
+    if (isAnthropicToken(pasted)) {
+      // Power-user escape hatch: an sk-ant-… value in the same input is the
+      // old token flow — the CLI child is abandoned (killed in the finally).
+      storeAnthropicToken(pasted, deps.storeToken);
+      return;
+    }
+    child.stdin.write(`${pasted}\n`);
+  }
+  const code = outcome.kind === "exit" ? outcome.code : await exit;
+  if (code !== 0)
+    throw new Error(
+      `Claude sign-in failed (exit ${code}): ${scrubTokens(tail.join(" | "))}`,
+    );
+
+  const raw = (deps.readCredentialFile ?? readMintedFile)(dir);
+  if (raw === null)
+    throw new Error(
+      "Claude sign-in finished but no credential file was written — this " +
+        "platform's CLI likely stores credentials in a system keychain Houston " +
+        "cannot read here; connect from the desktop app instead",
+    );
+  deps.storeOauth(parseMintedCredential(raw));
+}

--- a/packages/runtime/src/auth/anthropic-cli-output.ts
+++ b/packages/runtime/src/auth/anthropic-cli-output.ts
@@ -1,0 +1,156 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Stream plumbing + line parsing for the Claude CLI login child
+ * (anthropic-cli-login.ts) — everything here is pure or stream-local, so the
+ * driver stays under the file limit and this half is unit-testable without a
+ * child process. The `visit:` parsing mirrors the desktop shell's
+ * `claude_login/resolve.rs` (same CLI, same lines); keep the two in sync.
+ */
+
+/** The `auth_code` login surface the runtime relays to the webapp. */
+export type AnthropicLoginCallbacks = {
+  /**
+   * Surface the sign-in step. With `instructions` it renders as the token
+   * paste flow (url = help reference); without, as the open-this-URL +
+   * paste-the-code flow (the CLI subscription login).
+   */
+  onAuth: (info: { url: string; instructions?: string }) => void;
+  /** Resolves with the user's pasted value via completeLogin's paste promise. */
+  onManualCodeInput: () => Promise<string>;
+};
+
+/** The slice of a spawned child the login driver consumes (test seam). */
+export type LoginChild = {
+  stdout: NodeJS.ReadableStream;
+  stderr: NodeJS.ReadableStream;
+  stdin: { write: (chunk: string) => void };
+  once(
+    event: "exit",
+    cb: (code: number | null, signal?: unknown) => void,
+  ): void;
+  once(event: "error", cb: (err: Error) => void): void;
+  kill(): void;
+};
+
+/**
+ * A CLI login that could not START — spawn failure, or death before the
+ * sign-in URL was surfaced. Nothing user-visible happened yet, so the caller
+ * downgrades to the token paste flow instead of surfacing an error.
+ */
+export class CliUnavailableError extends Error {}
+
+/** Redact any `sk-ant-…` material before a string can reach logs or a toast. */
+export function scrubTokens(s: string): string {
+  return s.replace(/sk-ant-[A-Za-z0-9_-]+/g, "sk-ant-…");
+}
+
+/**
+ * Remove OSC 8 hyperlink sequences (`ESC]8;;URI BEL|ESC\` … `ESC]8;; BEL|ESC\`)
+ * so only the visible text remains: the CLI hyperlink-wraps the URL on its
+ * `visit:` line even when stdout is a pipe, and the token after `visit:` would
+ * otherwise start with an escape byte and miss the parse.
+ */
+export function stripOsc8(line: string): string {
+  let out = "";
+  let rest = line;
+  for (;;) {
+    const start = rest.indexOf("\u001b]8;");
+    if (start < 0) break;
+    out += rest.slice(0, start);
+    const after = rest.slice(start);
+    const bel = after.indexOf("\u0007");
+    const st = after.indexOf("\u001b\\");
+    const end =
+      bel >= 0 && (st < 0 || bel < st) ? bel + 1 : st >= 0 ? st + 2 : -1;
+    // Unterminated sequence: drop the tail rather than emit raw escapes.
+    if (end < 0) return out;
+    rest = after.slice(end);
+  }
+  return out + rest;
+}
+
+/**
+ * Parse an authorize URL out of a `visit:` line like
+ * `If the browser didn't open, visit: https://claude.ai/oauth/authorize?…`.
+ * Returns null without a `visit:` marker or when the following token is not an
+ * http(s) URL.
+ */
+export function extractVisitUrl(line: string): string | null {
+  const marker = "visit:";
+  const clean = stripOsc8(line);
+  const idx = clean.indexOf(marker);
+  if (idx < 0) return null;
+  const token = clean
+    .slice(idx + marker.length)
+    .trim()
+    .split(/\s+/)[0];
+  if (!token || !(token.startsWith("http://") || token.startsWith("https://")))
+    return null;
+  // Strip trailing sentence punctuation the CLI might append (`.` / `)`).
+  return token.replace(/[.)]+$/, "");
+}
+
+/** Deliver a stream to `onLine` one line at a time (trailing partial included). */
+export function wireLines(
+  stream: NodeJS.ReadableStream,
+  onLine: (line: string) => void,
+): void {
+  let buf = "";
+  stream.setEncoding?.("utf8");
+  stream.on("data", (chunk: string | Buffer) => {
+    buf += chunk.toString();
+    for (;;) {
+      const i = buf.indexOf("\n");
+      if (i < 0) break;
+      onLine(buf.slice(0, i));
+      buf = buf.slice(i + 1);
+    }
+  });
+  stream.on("end", () => {
+    if (buf) onLine(buf);
+  });
+}
+
+/** The credential the CLI mints: subscription OAuth with a refresh token. */
+export type CliMintedOauth = {
+  access: string;
+  refresh: string;
+  expires: number;
+};
+
+/** Read the CLI's minted credential file from the login dir, or null when it wrote none. */
+export function readMintedFile(dir: string): string | null {
+  const path = join(dir, ".credentials.json");
+  if (!existsSync(path)) return null;
+  return readFileSync(path, "utf8");
+}
+
+/** Parse the CLI credential file into the pi `oauth` fields. Throws on shape drift. */
+export function parseMintedCredential(raw: string): CliMintedOauth {
+  const parsed = JSON.parse(raw) as {
+    claudeAiOauth?: {
+      accessToken?: unknown;
+      refreshToken?: unknown;
+      expiresAt?: unknown;
+    };
+  };
+  const o = parsed.claudeAiOauth;
+  if (
+    !o ||
+    typeof o.accessToken !== "string" ||
+    typeof o.refreshToken !== "string" ||
+    !o.accessToken ||
+    !o.refreshToken
+  ) {
+    throw new Error(
+      "Claude sign-in finished but the minted credential has an unexpected shape",
+    );
+  }
+  return {
+    access: o.accessToken,
+    refresh: o.refreshToken,
+    expires: typeof o.expiresAt === "number" ? o.expiresAt : 0,
+  };
+}

--- a/packages/runtime/src/auth/login.test.ts
+++ b/packages/runtime/src/auth/login.test.ts
@@ -21,6 +21,13 @@ import {
 } from "./login";
 import { modelRuntime } from "./storage";
 
+// startLogin("anthropic") resolves the Claude CLI at this seam; a test host has
+// the real SDK binary installed, and spawning it would open a browser. Null =
+// the token paste flow, which is what these tests exercise.
+vi.mock("./anthropic-cli-binary", () => ({
+  resolveClaudeCliBinary: () => null,
+}));
+
 /** Occupy the fixed Codex callback port, like a running Codex CLI would. */
 function occupyCodexCallbackPort(): Promise<Server> {
   return new Promise<Server>((resolve, reject) => {

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -25,18 +25,20 @@ import {
   currentCredentialScope,
   isPersonalScope,
 } from "../session/acting-context";
-import { runAnthropicSetupTokenLogin } from "./anthropic-setup-token";
+import { resolveClaudeCliBinary } from "./anthropic-cli-binary";
+import { runAnthropicLogin } from "./anthropic-cli-login";
 import { preflightCodexCallbackPort } from "./codex-port-preflight";
 import { authStorage, modelRuntime, providerConnected } from "./storage";
 
 /**
  * Multi-provider OAuth login, driven server-side and relayed to the webapp.
  *
- * - anthropic (Claude): the sanctioned setup-token flow. The direct OAuth PKCE
- *   replay is server-blocked since 2026-04, so we drive Anthropic's own
- *   `claude setup-token` (or take a pasted token) and store the resulting
- *   `sk-ant-oat01…` as an api_key. Same `auth_code` + completeLogin wire shape as
- *   before — see auth/anthropic-setup-token.ts.
+ * - anthropic (Claude): the SUBSCRIPTION login, driven by the bundled Claude
+ *   Code CLI running next to this runtime (the one sanctioned OAuth client —
+ *   the direct PKCE replay is server-blocked since 2026-04): open the authorize
+ *   URL, approve, paste back the code the callback page shows. Where no CLI can
+ *   run, the token paste flow (an `sk-ant-…` value stored as api_key) remains
+ *   the fallback — see auth/anthropic-cli-login.ts.
  * - openai-codex (ChatGPT/Codex): the CLIENT picks. A co-located desktop client
  *   sends `deviceAuth: false` and gets the browser/loopback login — the user
  *   approves in their own browser and the localhost callback finishes it, no
@@ -402,24 +404,38 @@ export async function startLogin(
     },
   };
 
-  // Anthropic uses the sanctioned setup-token flow (the direct OAuth replay is
-  // server-blocked), NOT pi's OAuth login. It emits the same `auth_code`
-  // wire shape and reuses the paste promise, then stores the captured token as an
-  // api_key credential — see auth/anthropic-setup-token.ts.
+  // Anthropic runs the bundled Claude Code CLI's subscription login (the one
+  // sanctioned OAuth client — the direct replay is server-blocked), falling
+  // back to the token paste flow where no CLI can run. Both emit the same
+  // `auth_code` wire shape and reuse the paste promise: with `instructions` the
+  // webapp renders the paste flow, without them the open-URL + paste-code flow
+  // — see auth/anthropic-cli-login.ts.
   const login: Promise<unknown> =
     provider === "anthropic"
-      ? runAnthropicSetupTokenLogin(
+      ? runAnthropicLogin(
           {
             onAuth: ({ url, instructions }) => {
-              state.info = { kind: "auth_code", url, instructions };
+              state.info = {
+                kind: "auth_code",
+                url,
+                ...(instructions ? { instructions } : {}),
+              };
               state.status = "awaiting_user";
               resolveInfo(state.info);
             },
             onManualCodeInput: () => pastePromise,
           },
           {
-            store: (key) =>
+            binary: resolveClaudeCliBinary(),
+            storeToken: (key) =>
               authStorage.set("anthropic", { type: "api_key", key }),
+            storeOauth: (cred) =>
+              authStorage.set("anthropic", {
+                type: "oauth",
+                access: cred.access,
+                refresh: cred.refresh,
+                expires: cred.expires,
+              }),
           },
         )
       : runProviderOAuthLogin(provider, interaction);


### PR DESCRIPTION
## Problem (PRODUCT-1200)

A Claude **subscription** connect requires the desktop sign-in helper — the bundled Claude Code CLI — to run on the user's machine. On pre-AVX2 x86-64 CPUs (older Intel Macs and PCs) the Bun-compiled binary dies with SIGILL, so those users can never complete the browser OAuth: the app degrades to the token paste flow, whose only no-terminal input is a Console API key — not their subscription. Web clients have no helper at all and are stuck the same way.

## Fix

Run the sanctioned OAuth client **next to the runtime** instead: the runtime's anthropic `startLogin` now spawns the bundled Claude Code CLI (`claude auth login --claudeai`, a plain readline flow the desktop shell already drives piped) wherever a CLI can run — engine pods, self-host, dev. The SDK's per-platform package ships the same binary the SDK spawns for turns, so wherever turns work, the login works.

Flow: the runtime surfaces the CLI's authorize URL as the existing `auth_code` LoginInfo (no `instructions` → the webapp's open-URL + paste-code rendering, unchanged frontend). The user approves in their own browser; the callback page cannot reach the CLI's listener on another machine, so it shows a code the user pastes back — `completeLogin` relays it to the CLI's stdin, the CLI performs the exchange. The minted credential (a fresh `CLAUDE_CONFIG_DIR` throwaway dir, never the pod-shared login dir) is stored as a standard pi `oauth` auth.json entry, so the existing chain takes over untouched: capture exports it, the gateway stores and rotates it centrally (single rotator), Gate #2 scrubs the local refresh, serve keeps it warm. On self-host pi itself rotates the entry.

Fallbacks preserved: a pasted `sk-ant-…` value in the same input short-circuits to the token flow, and when no CLI can start here (missing binary, SIGILL before the URL) the login downgrades seamlessly to the token paste flow.

New modules under the file limit: `anthropic-cli-login.ts` (driver), `anthropic-cli-output.ts` (stream plumbing + `visit:` URL parsing, mirroring the desktop shell's `claude_login/resolve.rs`), `anthropic-cli-binary.ts` (binary resolution: HOUSTON_CLAUDE_BIN override → Bun-sidecar sibling → SDK platform package).

## Before / after

- Before: on an affected machine (or web), connecting Claude offers only a pasted token; a subscription cannot be connected at all. On cloud, repeated pastes also hit the re-ask loop until the api_key export fix lands.
- After: connect Claude → browser opens claude.ai → approve → paste the shown code into the same dialog → the agent (and, on cloud, every agent after capture) runs on the user's Claude subscription.

## Verification

- `pnpm --filter @houston/runtime test` — full suite green (12 new tests: URL parse incl. OSC-8 wrapping, code relay to stdin, seamless co-located exit, token short-circuit, SIGILL/ENOENT downgrade to paste, credential-file mapping, secret scrubbing in error tails).
- `pnpm --filter @houston/runtime typecheck`, `pnpm check` — clean.
- Live: on an engine pod (or `HOUSTON_CLAUDE_BIN` locally), POST `/auth/anthropic/login`, open the returned url, approve, POST the shown code to `/auth/anthropic/login/complete`; `/auth/status` reads anthropic configured and the gateway logs the capture ("org credential stored").

Notes: pods store the credential file on Linux; a platform whose CLI writes only to a system keychain fails loud with a connect-from-desktop message. Complements #1326 (api_key export) and #1325 (CLI-free copy) — no file overlap with either.