### PR TITLE
fix(runtime): normalize the provider id out of serve-probe failure details (PRODUCT-1443)

### DIFF
--- a/packages/runtime/src/auth/serve-probe.test.ts
+++ b/packages/runtime/src/auth/serve-probe.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from "vitest";
 import {
   describeProbeError,
+  normalizeProbeDetail,
   PROBE_CONCURRENCY,
   probeProvider,
   probeProviders,
@@ -104,6 +105,25 @@ test("probeProviders caps concurrency and preserves order", async () => {
   expect(peak).toBeLessThanOrEqual(PROBE_CONCURRENCY);
   expect(peak).toBeGreaterThan(1); // still concurrent, not serial
   expect(results.map((p) => p.id)).toEqual(ids);
+});
+
+test("normalizeProbeDetail replaces every echo of the probe's own provider id", () => {
+  // PRODUCT-1443: the host's error body names the provider ("credential
+  // gateway GET qwen failed (500)"), which made every probe's detail unique
+  // and defeated the sweep collapses. The id appears in the gateway path AND
+  // in nested error text — all occurrences must normalize.
+  expect(
+    normalizeProbeDetail(
+      "qwen",
+      'credential gateway GET qwen failed (500): {"error":"qwen gateway error"}',
+    ),
+  ).toBe(
+    'credential gateway GET <provider> failed (500): {"error":"<provider> gateway error"}',
+  );
+  // A body that never mentions the id passes through untouched.
+  expect(normalizeProbeDetail("qwen", '{"error":"gateway error"}')).toBe(
+    '{"error":"gateway error"}',
+  );
 });
 
 test("describeProbeError surfaces the nested undici cause code", () => {

--- a/packages/runtime/src/auth/serve-probe.ts
+++ b/packages/runtime/src/auth/serve-probe.ts
@@ -76,6 +76,21 @@ function causeCode(err: unknown, depth = 0): string | undefined {
   return causeCode(e.cause, depth + 1);
 }
 
+/**
+ * The host's error bodies echo the requested provider id ("credential gateway
+ * GET qwen failed (500): …"), so one gateway outage failed every probe with a
+ * UNIQUE detail — the sweep collapses (uniformFailureDetail in serve.ts, the
+ * group-by-detail in serve-log.ts) compare exact strings and never grouped
+ * them, keeping one incident at ~40 Sentry events (PRODUCT-1443, the
+ * HOUSTON-APP-4YV residual). The probe's own id is redundant inside its detail
+ * — every log line already names the provider — so it normalizes to a
+ * placeholder, making identical failures byte-identical across providers (and
+ * across syncs, for the dedup map's still-failing comparison).
+ */
+export function normalizeProbeDetail(id: string, body: string): string {
+  return body.split(id).join("<provider>");
+}
+
 /** A probe failure's log detail: the message plus the nested cause code. */
 export function describeProbeError(err: unknown): string {
   if (!(err instanceof Error)) return String(err);
@@ -121,7 +136,10 @@ async function probeOnce(id: string): Promise<ServeProbe> {
       return {
         id,
         state: "error",
-        detail: `${res.status}: ${await res.text().catch(() => "")}`,
+        detail: `${res.status}: ${normalizeProbeDetail(
+          id,
+          await res.text().catch(() => ""),
+        )}`,
       };
     return {
       id,

--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -909,6 +909,93 @@ test("probes caught by ONE gateway blip mid-sweep log ONE error, not one per pro
   }
 }, 30_000);
 
+test("a full-sweep gateway outage whose bodies echo each provider id logs ONE error (PRODUCT-1443)", async () => {
+  // The HOUSTON-APP-4YV residual: a gateway outage answers EVERY probe
+  // `500: {"error":"credential gateway GET <id> failed (500): …"}`. The echoed
+  // provider id made every detail unique, so neither the PRODUCT-1399 uniform
+  // collapse nor the PRODUCT-1423 group collapse fired — one blip stayed 41
+  // Sentry events. Normalizing the probe's own id out of the detail
+  // (serve-probe.ts) makes the sweep uniform again.
+  resetServeProbeLog();
+  const gatewayBody = (provider: string) =>
+    JSON.stringify({
+      error: `credential gateway GET ${provider} failed (500): {"error":"gateway error"}`,
+    });
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    const provider = new URL(String(input)).searchParams.get("provider") ?? "";
+    return new Response(gatewayBody(provider), { status: 500 });
+  }) as unknown as typeof globalThis.fetch;
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warns = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const serveErrors = () =>
+    errors.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.startsWith("[serve]"));
+  try {
+    await withServeMode(fetchImpl, async () => {
+      const providerCount = new Set([
+        ...PROVIDERS.map((p) => p.id),
+        ...piApiKeyProviderIds(),
+      ]).size;
+      expect(await syncServedCredential()).toEqual([]);
+      expect(serveErrors()).toEqual([
+        `[serve] control plane unreachable for all ${providerCount} providers: 500: ${gatewayBody("<provider>")}`,
+      ]);
+      // The identical repeat stays a WARN breadcrumb, never a second event.
+      expect(await syncServedCredential()).toEqual([]);
+      expect(serveErrors()).toHaveLength(1);
+      expect(
+        warns.mock.calls.some((c) =>
+          String(c[0]).includes("control plane unreachable for all"),
+        ),
+      ).toBe(true);
+    });
+  } finally {
+    errors.mockRestore();
+    warns.mockRestore();
+  }
+}, 30_000);
+
+test("mid-sweep gateway 500s with echoed provider ids collapse to one group (PRODUCT-1443)", async () => {
+  // The partial-sweep sibling: only the probes caught by the blip fail, each
+  // with its own id echoed in the body — same detail once normalized, so the
+  // PRODUCT-1423 group collapse fires instead of one event per provider.
+  resetServeProbeLog();
+  const blipped = new Set(["google", "openrouter", "opencode-go"]);
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    const provider = new URL(String(input)).searchParams.get("provider");
+    if (provider && blipped.has(provider))
+      return new Response(
+        JSON.stringify({
+          error: `credential gateway GET ${provider} failed (500): {"error":"gateway error"}`,
+        }),
+        { status: 500 },
+      );
+    return notConnected404();
+  }) as unknown as typeof globalThis.fetch;
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warns = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const serveErrors = () =>
+    errors.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.startsWith("[serve]"));
+  try {
+    await withServeMode(fetchImpl, async () => {
+      expect(await syncServedCredential()).toEqual([]);
+      expect(serveErrors()).toHaveLength(1);
+      const line = serveErrors()[0] ?? "";
+      expect(line).toMatch(/^\[serve\] credential probes for /);
+      for (const id of blipped) expect(line).toContain(id);
+      expect(line).toContain(
+        'failed alike: 500: {"error":"credential gateway GET <provider> failed (500): ',
+      );
+    });
+  } finally {
+    errors.mockRestore();
+    warns.mockRestore();
+  }
+}, 30_000);
+
 test("selectExportCredential without a provider falls back to the first OAuth credential", () => {
   const auth: Record<string, PiCred> = {
     "openai-codex": oauth("AT-codex", "RT-codex"),


### PR DESCRIPTION
## Summary

Sentry HOUSTON-APP-4YV regressed with `[serve] credential qwen: credential gateway GET qwen failed (500)` bursts (PRODUCT-1443). The events split into per-pod bursts of ~41 at a single instant — one gateway outage window failing an entire serve sweep.

**Root cause:** the host's credential-store error bodies echo the requested provider id (`credential gateway GET qwen failed (500): {"error":"gateway error"}`), so every probe in an outage sweep fails with a *unique* detail string. Both existing sweep collapses — the PRODUCT-1399 uniform collapse (`uniformFailureDetail`) and the PRODUCT-1423 same-detail grouping (`logServeProbeFailures`) — compare exact strings, so neither ever fired for this family. Confirmed live: a pod on a build that already contains the PRODUCT-1423 collapse still emitted 41 events in one minute (2026-08-20 09:54Z).

**Fix:** `normalizeProbeDetail` in `packages/runtime/src/auth/serve-probe.ts` replaces the probe's own provider id in the HTTP error body with a `<provider>` placeholder at detail creation. The id is redundant there — every log line already names the provider — and normalizing makes identical failures byte-identical, so:
- a full-sweep outage logs ONE `control plane unreachable for all N providers` error,
- a partial sweep logs ONE `failed alike` group,
- the cross-sync dedup map demotes persistent repeats to warnings.

## Verification

Before (reproduce): stub the control plane so `GET /sandbox/credential?provider=<id>` answers 500 with `{"error":"credential gateway GET <id> failed (500): {\"error\":\"gateway error\"}"}` for every provider, run one `syncServedCredential()` sweep → ~41 `console.error` lines, one per provider (the exact production shape).

After: same sweep → one error line, `[serve] control plane unreachable for all N providers: 500: {"error":"credential gateway GET <provider> failed (500): …}`; the repeat sweep is a warning breadcrumb. Pinned by three new tests:
- `serve.test.ts`: full-sweep echoed-id outage logs ONE error; mid-sweep echoed-id 500s collapse to one `failed alike` group
- `serve-probe.test.ts`: `normalizeProbeDetail` replaces every echo of the id

`pnpm check` clean; runtime 1264 ✓, host 1519 ✓, domain 193 ✓.