### PR TITLE
Resolve the Claude CLI from the SDK's directory — the subscription login never ran on Node deployments (PRODUCT-1200)

### DIFF
--- a/packages/runtime/src/auth/anthropic-cli-binary.ts
+++ b/packages/runtime/src/auth/anthropic-cli-binary.ts
@@ -34,7 +34,7 @@ export function resolveClaudeCliBinary(deps?: {
   }
   const name = process.platform === "win32" ? "claude.exe" : "claude";
   const slug = `${process.platform}-${process.arch === "arm64" ? "arm64" : "x64"}`;
-  const resolve = deps?.resolve ?? createRequire(import.meta.url).resolve;
+  const resolve = deps?.resolve ?? sdkScopedResolve;
   const exists = deps?.exists ?? existsSync;
   const pkg = `@anthropic-ai/claude-agent-sdk-${slug}`;
   for (const spec of [`${pkg}/${name}`, `${pkg}/package.json`]) {
@@ -48,6 +48,23 @@ export function resolveClaudeCliBinary(deps?: {
     }
   }
   return null;
+}
+
+/**
+ * Resolve `spec` from the SDK's own directory, in two hops. The per-platform
+ * binary package is a dependency of `@anthropic-ai/claude-agent-sdk`, NOT of
+ * the runtime — under pnpm's isolated node_modules a require anchored HERE
+ * cannot see it (MODULE_NOT_FOUND), which made this resolver return null on
+ * every Node deployment and silently dumped web/pod logins into the paste
+ * flow. Anchor at the SDK's resolved main export instead (its `exports` map
+ * blocks resolving `@anthropic-ai/claude-agent-sdk/package.json` directly);
+ * from there the platform package resolves exactly the way the SDK itself
+ * finds its binary at turn time.
+ */
+function sdkScopedResolve(spec: string): string {
+  const here = createRequire(import.meta.url);
+  const sdkMain = here.resolve("@anthropic-ai/claude-agent-sdk");
+  return createRequire(sdkMain).resolve(spec);
 }
 
 /** Spawn the real CLI login child (`anthropic-cli-login.ts`'s production seam). */

--- a/packages/runtime/src/auth/anthropic-cli-login.test.ts
+++ b/packages/runtime/src/auth/anthropic-cli-login.test.ts
@@ -1,6 +1,8 @@
 import { EventEmitter } from "node:events";
+import { existsSync } from "node:fs";
 import { PassThrough } from "node:stream";
 import { expect, test } from "vitest";
+import { resolveClaudeCliBinary } from "./anthropic-cli-binary";
 import {
   type AnthropicLoginDeps,
   runAnthropicLogin,
@@ -202,6 +204,25 @@ test("no binary goes straight to the token paste flow", async () => {
   h.paste("sk-ant-oat01-tok");
   await h.login;
   expect(h.stored.tokens).toEqual(["sk-ant-oat01-tok"]);
+});
+
+test("resolveClaudeCliBinary finds the SDK's real platform binary with no seams", () => {
+  // ENVIRONMENT TRUTH, deliberately un-mocked: this is the exact resolution a
+  // pod / self-host runs. The per-platform package is a dependency of the SDK,
+  // not of the runtime, so a runtime-anchored require can't see it under pnpm
+  // — the original resolver returned null on EVERY Node deployment and every
+  // web login silently fell back to the paste flow. Any dev/CI host has the
+  // SDK installed (turns run through it), so null here means the resolution
+  // chain regressed, not that the binary is absent.
+  const override = process.env.HOUSTON_CLAUDE_BIN;
+  delete process.env.HOUSTON_CLAUDE_BIN;
+  try {
+    const bin = resolveClaudeCliBinary();
+    expect(bin).toBeTruthy();
+    expect(existsSync(bin as string)).toBe(true);
+  } finally {
+    if (override !== undefined) process.env.HOUSTON_CLAUDE_BIN = override;
+  }
 });
 
 test("extractVisitUrl parses plain, punctuated, and OSC-8 wrapped lines", () => {


### PR DESCRIPTION
## Bug (found in staging QA of the v0.6.5 train)

PR #1356's CLI subscription login never actually ran anywhere except the Bun-compiled desktop sidecar. On every Node deployment (engine pods, self-host, dev) `resolveClaudeCliBinary` returned null, so every web login silently fell back to the token paste flow — reproduced on preview.gethouston.ai: the connect dialog showed the old paste instructions instead of the sign-in URL.

Root cause: the per-platform binary package (`@anthropic-ai/claude-agent-sdk-<platform>`) is a dependency of the SDK, not of the runtime. Under pnpm's isolated node_modules, a `createRequire` anchored in the runtime's module context gets MODULE_NOT_FOUND for it (verified: runtime-scoped resolve fails, SDK-scoped resolve succeeds). The unit tests all injected the resolver seam, so nothing exercised the real chain.

## Fix

Resolve in two hops: anchor a require at the SDK's resolved **main export** (its `exports` map blocks resolving its package.json directly), then resolve the platform package from there — the same way the SDK finds its own binary at turn time. Works identically in the engine-pod bundle: esbuild externalizes all npm packages, so the SDK import resolves from `dist/` today and the second hop anchors at its real store path.

## Test that would have caught it

New un-mocked test: `resolveClaudeCliBinary()` with no seams must return an existing file on the test host — any dev/CI machine has the SDK installed (turns run through it), so null means the resolution chain regressed.

## Verification

- Before (main): `createRequire(runtime module).resolve('@anthropic-ai/claude-agent-sdk-<slug>/claude')` → MODULE_NOT_FOUND; preview.gethouston.ai connect shows the paste dialog.
- After: the two-hop chain resolves the real binary (test pins it); once this rolls to staging, the preview connect dialog must show the claude.ai sign-in URL + verification-code input instead of the setup-token instructions.

Follow-up to #1356; must ride the same train (the current v0.6.5 draft predates it).