### PR TITLE
Accept textless routine turns at the worker parse boundary

### DIFF
--- a/packages/runtime/src/turn/parse-turn-request.ts
+++ b/packages/runtime/src/turn/parse-turn-request.ts
@@ -39,7 +39,9 @@ export function parseTurnRequest(body: unknown): TurnRequest {
       throw new Error(`invalid '${field}'`);
     }
   }
-  if (typeof b.text !== "string" || !b.text.length)
+  // Routine turns carry no text on the wire: the worker derives the prompt
+  // from the hydrated routine file (the envelope's routine.id is the payload).
+  if (typeof b.text !== "string" || (!b.text.length && b.routine === undefined))
     throw new Error("missing 'text'");
   const prefix = b.gcsPrefix;
   if (

--- a/packages/runtime/src/turn/types.test.ts
+++ b/packages/runtime/src/turn/types.test.ts
@@ -132,3 +132,26 @@ test("parseTurnRequest carries the hosted turn context and rejects non-strings",
     "invalid 'userContext'",
   );
 });
+
+const ROUTINE_BASE = {
+  ...BASE,
+  text: "",
+  hostToken: "ht",
+  claim: {
+    id: "cl1",
+    bootId: "b1",
+    token: "t1",
+    heartbeatUrl: "http://127.0.0.1/hb",
+  },
+  routine: { id: "r1" },
+};
+
+test("a routine turn may omit text (the worker derives the prompt)", () => {
+  expect(parseTurnRequest(ROUTINE_BASE).routine).toEqual({ id: "r1" });
+});
+
+test("a non-routine turn still requires text", () => {
+  expect(() => parseTurnRequest({ ...BASE, text: "" })).toThrow(
+    /missing 'text'/,
+  );
+});


### PR DESCRIPTION
The gateway's pool dispatcher sends routine turns with an empty `text` — the worker derives the prompt from the hydrated routine file, so the envelope's payload is `routine.id`. The turn parser still required non-empty text for every turn, so every pool routine dispatch was rejected with a worker 400 and fell back to the standing pod (observed live as stand-down reason `dispatch:worker_400`; reproduced against a pool worker: `{"error":"missing 'text'"}`).

This was meant to ship inside #1355 with the rest of the routine-envelope work but was left uncommitted; the gateway half (per-kind `validTurn`) merged, so until this lands the pool declines every routine turn softly.

**Change**: `parseTurnRequest` accepts an empty `text` only when the `routine` envelope is present. Every other turn kind still requires text. Tests: a textless routine turn parses; a textless non-routine turn is still rejected.

**Rollout**: rides the engine roll on merge; version skew is safe in both directions (an older worker keeps 400ing → the dispatch falls back soft to the standing pod, exactly today's behavior).