### PR TITLE
Doc projector: bind lazily when the workspace hydrates after boot

### DIFF
--- a/packages/host/src/docs/projector.test.ts
+++ b/packages/host/src/docs/projector.test.ts
@@ -32,12 +32,14 @@ test("a family watcher event shadows the file's current whole document", async (
   projector.onEvent({ type: "LearningsChanged", agentPath: agent.id });
   await projector.flush();
 
-  expect(puts).toEqual([
-    {
-      family: "learnings",
-      doc: [{ id: "l1", text: "remember", created_at: "now" }],
-    },
-  ]);
+  // Without a boot seed, the first projection lazily binds and back-fills
+  // every family; the event's own family carries the file content.
+  expect(
+    puts.find((p) => (p as { family: string }).family === "learnings"),
+  ).toEqual({
+    family: "learnings",
+    doc: [{ id: "l1", text: "remember", created_at: "now" }],
+  });
 });
 
 test("the activity family projects the NORMALIZED items, not the raw file", async () => {
@@ -73,14 +75,10 @@ test("the activity family projects the NORMALIZED items, not the raw file", asyn
   projector.onEvent({ type: "ActivityChanged", agentPath: agent.id });
   await projector.flush();
 
-  expect(puts).toEqual([
-    {
-      family: "activity",
-      doc: [
-        { id: "m1", title: "Say Hi", status: "needs_you", description: "" },
-      ],
-    },
-  ]);
+  expect(puts.find((p) => p.family === "activity")).toEqual({
+    family: "activity",
+    doc: [{ id: "m1", title: "Say Hi", status: "needs_you", description: "" }],
+  });
 });
 
 test("boot seed projects every family once; missing files converge to empty docs", async () => {
@@ -258,4 +256,67 @@ test("a vanished family file converges the doc back to empty", async () => {
   projector.onEvent({ type: "RoutinesChanged", agentPath: agent.id });
   await projector.flush();
   expect(puts.at(-1)).toEqual({ family: "routines", doc: [] });
+});
+
+test("a pod that boots before its agent hydrates binds on first projection", async () => {
+  const store = new MemoryWorkspaceStore();
+  const vfs = new MemoryVfs();
+  const paths = new LocalPaths();
+  const puts: { family: string; doc: unknown }[] = [];
+  const shadow: DocShadow = {
+    async seed() {},
+    async put(family, doc) {
+      puts.push({ family, doc });
+    },
+  };
+  // Boot with ZERO agents (cloud pods can reach the seed before the
+  // workspace tree hydrates) — must not poison, must not project.
+  const projector = new DocShadowProjector({ store, vfs, paths, shadow });
+  projector.seed();
+  await projector.flush();
+  expect(puts).toEqual([]);
+
+  // The agent hydrates after boot; its first watcher event binds the
+  // projector and back-fills the boot seed for every family.
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "A",
+  });
+  await vfs.writeText(
+    docKey(paths.agentRoot(workspace, agent), "routines"),
+    JSON.stringify([
+      {
+        id: "r1",
+        name: "D",
+        prompt: "p",
+        schedule: "0 9 * * *",
+        enabled: true,
+      },
+    ]),
+  );
+  projector.onEvent({ type: "RoutinesChanged", agentPath: agent.id });
+  await projector.flush();
+
+  const families = puts.map((p) => p.family).sort();
+  expect(families).toEqual([
+    "activity",
+    "config",
+    "learnings",
+    "routine_runs",
+    "routines",
+  ]);
+  expect(
+    (puts.find((p) => p.family === "routines")?.doc as unknown[]).length,
+  ).toBe(1);
+
+  // Still refuses a foreign agent after the late bind.
+  const stray = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "B",
+  });
+  const seeded = puts.length;
+  projector.onEvent({ type: "RoutinesChanged", agentPath: stray.id });
+  await projector.flush();
+  expect(puts.length).toBe(seeded);
 });

--- a/packages/host/src/docs/projector.ts
+++ b/packages/host/src/docs/projector.ts
@@ -61,20 +61,20 @@ export class DocShadowProjector {
   }
 
   private async seedContent(): Promise<void> {
-    const agents: string[] = [];
-    for (const workspace of await this.deps.store.listWorkspaces()) {
-      for (const agent of await this.deps.store.listAgents(workspace.id)) {
-        agents.push(agent.id);
-      }
+    const agents = await this.listAgentIds();
+    if (agents.length === 0) {
+      // Cloud pods can reach boot before the workspace tree hydrates (seen
+      // live: real agent pods with zero agents at seed time). Not an error
+      // and NOT a poison: the hydration writes fire watcher events, and the
+      // first projection binds late and back-fills the whole seed.
+      console.warn(
+        "[doc-shadow] no agents at boot seed; binding on first projection",
+      );
+      return;
     }
     const only = agents.length === 1 ? agents[0] : undefined;
     if (only === undefined) {
-      // The single doc route cannot be attributed: refuse every projection
-      // rather than post one agent's files under another's docs.
-      this.bound = null;
-      console.error(
-        `[doc-shadow] host serves ${agents.length} agents but the doc route binds one; doc projection disabled`,
-      );
+      this.poison(agents.length);
       return;
     }
     this.bound = only;
@@ -94,10 +94,14 @@ export class DocShadowProjector {
   onEvent(event: HoustonEvent): void {
     const family = EVENT_FAMILY[event.type];
     if (!family || !("agentPath" in event)) return;
-    const key = `${event.agentPath}#${family}`;
+    this.enqueue(event.agentPath, family);
+  }
+
+  private enqueue(agentId: string, family: HoustonFamily): void {
+    const key = `${agentId}#${family}`;
     const prior = this.tails.get(key) ?? this.ready;
     const task = prior
-      .then(() => this.project(event.agentPath, family))
+      .then(() => this.project(agentId, family))
       .catch((error: unknown) => {
         console.error(`[doc-shadow] ${key} projection failed`, error);
       })
@@ -113,8 +117,11 @@ export class DocShadowProjector {
   }
 
   private async project(agentId: string, family: HoustonFamily): Promise<void> {
-    if (this.bound === null) return; // ambiguous host, reported at seed
-    if (this.bound !== undefined && agentId !== this.bound) {
+    if (this.bound === null) return; // ambiguous host, reported when poisoned
+    if (this.bound === undefined && !(await this.lazyBind(agentId, family))) {
+      return;
+    }
+    if (agentId !== this.bound) {
       console.error(
         `[doc-shadow] refusing cross-agent projection ${agentId}#${family} (route bound to ${this.bound})`,
       );
@@ -144,6 +151,49 @@ export class DocShadowProjector {
     // family file for any future reconstruction. For host-written files this
     // is a byte-level no-op.
     await this.deps.shadow.put(family, normalizeFamilyDoc(family, parsed, key));
+  }
+  /**
+   * Bind on first projection when boot found no agents. True = agentId is
+   * the host's single agent; the remaining families are enqueued so the
+   * boot seed this pod missed still happens.
+   */
+  private async lazyBind(
+    agentId: string,
+    family: HoustonFamily,
+  ): Promise<boolean> {
+    const agents = await this.listAgentIds();
+    if (agents.length > 1) {
+      this.poison(agents.length);
+      return false;
+    }
+    if (agents.length === 0 || agents[0] !== agentId) return false;
+    this.bound = agentId;
+    console.warn(
+      `[doc-shadow] bound to ${agentId} on first projection (agent hydrated after boot); seeding remaining families`,
+    );
+    for (const other of Object.values(EVENT_FAMILY)) {
+      if (other && other !== family) this.enqueue(agentId, other);
+    }
+    return true;
+  }
+
+  private async listAgentIds(): Promise<string[]> {
+    const agents: string[] = [];
+    for (const workspace of await this.deps.store.listWorkspaces()) {
+      for (const agent of await this.deps.store.listAgents(workspace.id)) {
+        agents.push(agent.id);
+      }
+    }
+    return agents;
+  }
+
+  // The single doc route cannot be attributed on a multi-agent host: refuse
+  // every projection rather than post one agent's files under another's docs.
+  private poison(count: number): void {
+    this.bound = null;
+    console.error(
+      `[doc-shadow] host serves ${count} agents but the doc route binds one; doc projection disabled`,
+    );
   }
 }
 


### PR DESCRIPTION
Fixes the staging Sentry issue `[doc-shadow] host serves 0 agents but the doc route binds one; doc projection disabled` (5 events across 3 real agent pods since today's engine roll).

**What happened**: some cloud pods reach the boot seed before their workspace tree hydrates, so the projector's single-agent guard (added in #1355) saw zero agents, treated the host as ambiguous, and disabled doc projection for the pod's entire lifetime. That is a regression: event projection stopped too, so those agents' docs go permanently stale until the next boot — and the pool would serve/fire from stale routines docs.

**Fix**: zero agents at seed is a legitimate boot state, not a poison. The seed skips with a warning; the hydration's own watcher events trigger the first projection, which lazily binds the projector to the host's single agent and back-fills the boot content seed for every family. Multi-agent hosts still poison (the route names one agent), and a bound projector still refuses foreign agent ids.

**Tests**: new case (boot with zero agents → agent hydrates → first event binds + seeds all five families → foreign agent still refused); full host suite green (1531 passed).

**Rollout**: rides the engine roll on merge. The affected pods self-heal on their next boot with this image.