### PR TITLE
Quiet the three staging Sentry noise classes (24h sweep)

### DIFF
--- a/packages/host/src/store-sync/daemon.test.ts
+++ b/packages/host/src/store-sync/daemon.test.ts
@@ -381,5 +381,9 @@ test("a fencing loss latches once, halts scheduling, and skips the final drain",
     entry.message.includes("write fencing lost"),
   );
   expect(fencingLogs).toHaveLength(1);
-  expect(fencingLogs[0]?.err).toBeInstanceOf(StoreFencedError);
+  // Info-level breadcrumb, not an error: fencing loss is a designed lifecycle
+  // outcome, so the log must not carry the error object (the severity log
+  // routes any entry WITH an error to Sentry as an error event).
+  expect(fencingLogs[0]?.err).toBeUndefined();
+  expect(fencingLogs[0]?.message).toContain("lease lost");
 });

--- a/packages/host/src/store-sync/daemon.ts
+++ b/packages/host/src/store-sync/daemon.ts
@@ -180,9 +180,12 @@ export class StoreSyncDaemon {
     this.dirty = false;
     this.rerunRequested = false;
     this.stopScheduling();
+    // No error object: fencing loss is a DESIGNED lifecycle outcome (a newer
+    // boot owns the prefix — setup pods are superseded routinely) and the
+    // halt is the correct response. Passing `err` made every takeover a
+    // Sentry error via the severity log's failure channel.
     this.opts.log(
-      "[store-sync] write fencing lost: another pod owns this agent's store; halting sync",
-      err,
+      `[store-sync] write fencing lost: another pod owns this agent's store; halting sync (${err.message})`,
     );
   }
 

--- a/packages/runtime/src/auth/serve-log.test.ts
+++ b/packages/runtime/src/auth/serve-log.test.ts
@@ -134,3 +134,27 @@ test("the sweep incident is tracked apart from per-provider failures", () => {
     "[serve] control plane reachable again",
   );
 });
+
+test("a dead central credential NEVER logs an error (user state, not incident)", () => {
+  const detail =
+    '500: {"error":"credential gateway GET github-copilot reported a dead credential"}';
+  logServeProbeFailure("github-copilot", detail);
+  logServeProbeFailure("github-copilot", detail);
+  expect(error).not.toHaveBeenCalled();
+  expect(warn).toHaveBeenCalledTimes(2);
+  // Reconnecting re-arms the transition tracking like any recovery.
+  noteServeProbeOk("github-copilot");
+  expect(info).toHaveBeenCalledWith(
+    "[serve] credential github-copilot recovered",
+  );
+});
+
+test("a dead-credential group in a sweep stays at warning level per provider", () => {
+  const detail = "500: dead credential";
+  logServeProbeFailures([
+    { id: "github-copilot", detail },
+    { id: "google", detail },
+  ]);
+  expect(error).not.toHaveBeenCalled();
+  expect(warn).toHaveBeenCalledTimes(2);
+});

--- a/packages/runtime/src/auth/serve-log.ts
+++ b/packages/runtime/src/auth/serve-log.ts
@@ -17,7 +17,23 @@ const lastFailureDetail = new Map<string, string>();
  */
 const SWEEP_KEY = "*";
 
+/**
+ * A gateway answer that is a USER state, not an engine incident: the central
+ * credential is DEAD (revoked upstream, refresh permanently failed) and only
+ * a user reconnect revives it. The transition-dedup map is per-process, so a
+ * wake/sleep-cycling pod re-logged the same dead credential as a fresh error
+ * on every boot — 41 Sentry errors in a day for one disconnected provider.
+ */
+const EXPECTED_DETAIL = /dead credential/;
+
 export function logServeProbeFailure(provider: string, detail: string): void {
+  if (EXPECTED_DETAIL.test(detail)) {
+    lastFailureDetail.set(provider, detail);
+    console.warn(
+      `[serve] credential ${provider} dead centrally (user reconnect required): ${detail}`,
+    );
+    return;
+  }
   if (lastFailureDetail.get(provider) === detail) {
     console.warn(`[serve] credential ${provider} still failing: ${detail}`);
     return;
@@ -63,8 +79,8 @@ export function logServeProbeFailures(
   }
   for (const [detail, ids] of byDetail) {
     const lone = ids.length === 1 ? ids[0] : undefined;
-    if (lone !== undefined) {
-      logServeProbeFailure(lone, detail);
+    if (lone !== undefined || EXPECTED_DETAIL.test(detail)) {
+      for (const id of ids) logServeProbeFailure(id, detail);
       continue;
     }
     const group = `credential probes for ${ids.join(", ")}`;

--- a/patches/@earendil-works__pi-ai@0.84.2.patch
+++ b/patches/@earendil-works__pi-ai@0.84.2.patch
@@ -1,0 +1,17 @@
+diff --git a/dist/api/google-shared.js b/dist/api/google-shared.js
+index dcf5c60f53a8579894d6f2d18f2c565a84ea8a89..058015f04d048841ecbd19cba8b6ac6e887eb10f 100644
+--- a/dist/api/google-shared.js
++++ b/dist/api/google-shared.js
+@@ -337,8 +337,10 @@ export function mapStopReason(reason) {
+         case FinishReason.NO_IMAGE:
+             return "error";
+         default: {
+-            const _exhaustive = reason;
+-            throw new Error(`Unhandled stop reason: ${_exhaustive}`);
++            // Gemini adds FinishReason values faster than the SDK enum ships
++            // (MALFORMED_RESPONSE, observed 2026-08): an unknown reason is an
++            // error stop, never a crash of the whole turn pipeline.
++            return "error";
+         }
+     }
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ overrides:
   teeny-request>uuid: ^11.1.1
 
 patchedDependencies:
+  '@earendil-works/pi-ai@0.84.2':
+    hash: 646b7c9cdfab689a7d3cb69da6c19c02b36e00c4240b0e930a0199e2f73b8b38
+    path: patches/@earendil-works__pi-ai@0.84.2.patch
   '@executor-js/sdk@1.5.37':
     hash: 7061d4455cc286a23ca4c3683819032231059648ed7fef31e7a1f0297e1f3597
     path: patches/@executor-js__sdk@1.5.37.patch
@@ -434,7 +437,7 @@ importers:
     dependencies:
       '@earendil-works/pi-ai':
         specifier: 0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        version: 0.84.2(patch_hash=646b7c9cdfab689a7d3cb69da6c19c02b36e00c4240b0e930a0199e2f73b8b38)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.2
         version: 0.84.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
@@ -520,7 +523,7 @@ importers:
     dependencies:
       '@earendil-works/pi-ai':
         specifier: 0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        version: 0.84.2(patch_hash=646b7c9cdfab689a7d3cb69da6c19c02b36e00c4240b0e930a0199e2f73b8b38)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.2
         version: 0.84.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
@@ -8448,7 +8451,7 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.84.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.84.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.2(patch_hash=646b7c9cdfab689a7d3cb69da6c19c02b36e00c4240b0e930a0199e2f73b8b38)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-telemetry': 0.84.2
       diff: 8.0.4
       ignore: 7.0.5
@@ -8462,7 +8465,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.84.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.84.2(patch_hash=646b7c9cdfab689a7d3cb69da6c19c02b36e00c4240b0e930a0199e2f73b8b38)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -8490,7 +8493,7 @@ snapshots:
   '@earendil-works/pi-coding-agent@0.84.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.84.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.84.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.2(patch_hash=646b7c9cdfab689a7d3cb69da6c19c02b36e00c4240b0e930a0199e2f73b8b38)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-client': 0.84.2
       '@earendil-works/pi-protocol': 0.84.2
       '@earendil-works/pi-tui': 0.84.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,4 +21,5 @@ overrides:
   "gaxios>uuid": "^11.1.1"
   "teeny-request>uuid": "^11.1.1"
 patchedDependencies:
+  '@earendil-works/pi-ai@0.84.2': patches/@earendil-works__pi-ai@0.84.2.patch
   '@executor-js/sdk@1.5.37': patches/@executor-js__sdk@1.5.37.patch


### PR DESCRIPTION
Sweep of every staging Sentry issue from the last 24h. One (`doc-shadow 0 agents`, 11 events) is fixed separately in #1360; the other three are fixed here.

**1. `[serve] credential github-copilot: 500 dead credential` — 41 events, 1 agent.** The gateway's *dead credential* answer is an authoritative user state (revoked upstream; only a reconnect revives it), but the serve log's transition dedup is per-process, so a wake/sleep-cycling pod re-logged it as a fresh Sentry error on every boot. Dead-credential details now log at warning always, both per-provider and when a sweep groups several providers on the same detail. Recovery re-arms tracking unchanged.

**2. `StoreFencedError: object store PUT ... runtime.log (409)` — 6 events, setup pod.** The store-sync daemon already handles fence loss correctly (latch + halt), but its log line carried the error object, which the severity log routes to Sentry as an error event. Fence loss is the designed takeover outcome (setup pods are superseded routinely). Now an info breadcrumb with the fence detail embedded in the message.

**3. `[provider_error] provider=google kind=unknown :: Unhandled stop reason: MALFORMED_RESPONSE` — 2 events.** Gemini returns FinishReason values newer than the pinned pi SDK's enum, and the SDK's exhaustive-switch default **throws**, killing the turn with an untyped error instead of a typed provider-error stop. Fixed with a pnpm patch on `@earendil-works/pi-ai` (`google-shared`: unknown stop reason → `"error"` stop). Same latent default-throw exists in the SDK's other provider mappers; worth an upstream fix. **The patch must be re-created on every pi bump until then.**

**Tests**: dead-credential warn path (single + grouped), fence-loss log shape; runtime + host suites green.

**Rollout**: rides the engine roll on merge. Issue 1's events stop on the next wake cycle of the affected pod; issue 2's on the next setup-pod takeover; issue 3's on the next Gemini malformed response.