### PR TITLE
fix(app): report a real error when the provisioning probe times out (PRODUCT-1451)

### DIFF
--- a/app/src/lib/agent-provisioning.ts
+++ b/app/src/lib/agent-provisioning.ts
@@ -263,9 +263,43 @@ export interface ProbeDeps {
   /** Engine answered (with anything) — the agent is reachable. */
   onReady: (agentId: string) => void;
   /** TTL elapsed without the engine ever answering. */
-  onTimeout: (agentId: string, lastError: unknown) => void;
+  onTimeout: (agentId: string, error: ProvisioningTimeoutError) => void;
   sleep: (ms: number) => Promise<void>;
   now: () => number;
+}
+
+/**
+ * The probe's TTL elapsed. Always a real Error with a diagnostic message: the
+ * pod may have NEVER answered (every attempt held open server-side), in which
+ * case there is no "last error" to forward — reporting that raw value gave
+ * Sentry a bare `undefined` with nothing to triage on.
+ */
+export class ProvisioningTimeoutError extends Error {
+  readonly attempts: number;
+  readonly heldOpen: boolean;
+  constructor(attempts: number, lastError: unknown) {
+    const heldOpen = lastError === undefined;
+    const last = heldOpen
+      ? "the last attempt was still held open, the engine never answered"
+      : `last failure: ${describeProbeFailure(lastError)}`;
+    super(
+      `engine did not answer within ${PROVISIONING_TTL_MS / 60_000} min (${attempts} attempts; ${last})`,
+      { cause: lastError },
+    );
+    this.name = "ProvisioningTimeoutError";
+    this.attempts = attempts;
+    this.heldOpen = heldOpen;
+  }
+}
+
+function describeProbeFailure(err: unknown): string {
+  if (err instanceof Error) {
+    const status = (err as { status?: unknown }).status;
+    return typeof status === "number"
+      ? `HTTP ${status} ${err.message}`
+      : `${err.name}: ${err.message}`;
+  }
+  return String(err);
 }
 
 /**
@@ -279,6 +313,7 @@ export async function runProvisioningProbe(
   deps: ProbeDeps,
 ): Promise<void> {
   let lastError: unknown;
+  let attempts = 0;
   const initialRemaining = entry.since + PROVISIONING_TTL_MS - deps.now();
   // One deadline for the whole probe, anchored to the create call. Left
   // pending when the probe wins — a settled timer with no listeners is free.
@@ -287,9 +322,13 @@ export async function runProvisioningProbe(
     .then(() => "timeout" as const);
   while (deps.isMarked(entry.agentId)) {
     if (deps.now() - entry.since >= PROVISIONING_TTL_MS) {
-      deps.onTimeout(entry.agentId, lastError);
+      deps.onTimeout(
+        entry.agentId,
+        new ProvisioningTimeoutError(attempts, lastError),
+      );
       return;
     }
+    attempts++;
     // The attempt never rejects (failures fold into a verdict), so losing the
     // race can't leave an unhandled rejection behind.
     const attempt = deps
@@ -305,7 +344,10 @@ export async function runProvisioningProbe(
       );
     const outcome = await Promise.race([attempt, deadline]);
     if (outcome === "timeout") {
-      deps.onTimeout(entry.agentId, lastError);
+      deps.onTimeout(
+        entry.agentId,
+        new ProvisioningTimeoutError(attempts, lastError),
+      );
       return;
     }
     if (outcome === "ready") {

--- a/app/src/stores/agent-provisioning.ts
+++ b/app/src/stores/agent-provisioning.ts
@@ -268,7 +268,7 @@ function startProbe(entry: ProvisioningEntry): void {
         )
         .finally(() => store.clearProvisioning(id, entry));
     },
-    onTimeout: (id, lastError) => {
+    onTimeout: (id, error) => {
       // A newer mark (rename, or a fresh create reusing the id) already
       // retired this exact entry — nothing to do.
       if (useAgentProvisioningStore.getState().provisioning[id] !== entry) {
@@ -281,12 +281,9 @@ function startProbe(entry: ProvisioningEntry): void {
       // giving up. A pod that's merely slow to schedule still comes up.
       if (!entry.timedOut) {
         entry.timedOut = true;
-        showErrorToast(
-          "agent_provisioning",
-          lastError instanceof Error ? lastError.message : String(lastError),
-          lastError,
-          { userMessage: i18n.t("shell:agentProvisioning.stillStarting") },
-        );
+        showErrorToast("agent_provisioning", error.message, error, {
+          userMessage: i18n.t("shell:agentProvisioning.stillStarting"),
+        });
       }
       entry.since = Date.now();
       useAgentProvisioningStore.setState((s) => {

--- a/app/tests/agent-provisioning.test.ts
+++ b/app/tests/agent-provisioning.test.ts
@@ -4,6 +4,7 @@ import {
   detectEngineAsleep,
   PROVISIONING_RETRY_MS,
   PROVISIONING_TTL_MS,
+  ProvisioningTimeoutError,
   parsePersistedProvisioning,
   probeSaysStillStarting,
   runProvisioningProbe,
@@ -213,7 +214,7 @@ describe("runProvisioningProbe", () => {
 
   function harness(readResults: Array<unknown | Error>) {
     const calls = { ready: 0, timeout: 0, sleeps: 0, reads: 0 };
-    let timeoutError: unknown;
+    let timeoutError: ProvisioningTimeoutError | undefined;
     let marked = true;
     let clock = 1;
     // The whole-probe TTL deadline is the one sleep longer than a retry
@@ -234,9 +235,9 @@ describe("runProvisioningProbe", () => {
         calls.ready++;
         marked = false;
       },
-      onTimeout: (_id: string, lastError: unknown) => {
+      onTimeout: (_id: string, error: ProvisioningTimeoutError) => {
         calls.timeout++;
-        timeoutError = lastError;
+        timeoutError = error;
         marked = false;
       },
       sleep: (ms: number): Promise<void> => {
@@ -292,17 +293,30 @@ describe("runProvisioningProbe", () => {
     };
     await runProvisioningProbe(entry, deps);
     deepStrictEqual(calls, { ready: 0, timeout: 1, sleeps: 1, reads: 1 });
-    strictEqual((timeoutError() as { status?: number }).status, 503);
+    const err = timeoutError();
+    ok(err instanceof ProvisioningTimeoutError);
+    strictEqual((err.cause as { status?: number }).status, 503);
+    strictEqual(err.heldOpen, false);
+    strictEqual(err.attempts, 1);
+    ok(err.message.includes("HTTP 503"), err.message);
   });
 
   it("times out even while an attempt is held open server-side", async () => {
-    const { deps, calls } = harness([HELD]);
+    const { deps, calls, timeoutError } = harness([HELD]);
     const probe = runProvisioningProbe(entry, deps);
     // Let the probe issue the read (which never settles), then hit the TTL.
     await Promise.resolve();
     deps.fireDeadline();
     await probe;
     deepStrictEqual(calls, { ready: 0, timeout: 1, sleeps: 0, reads: 1 });
+    // No attempt ever failed, so there is no "last error" — the timeout must
+    // still be a real, descriptive Error rather than a forwarded `undefined`
+    // (that bare value is what Sentry used to receive).
+    const err = timeoutError();
+    ok(err instanceof ProvisioningTimeoutError);
+    strictEqual(err.heldOpen, true);
+    strictEqual(err.cause, undefined);
+    ok(err.message.includes("never answered"), err.message);
   });
 
   it("stops silently when the entry is retired mid-loop", async () => {


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1451 (Sentry HOUSTON-APP-519, `agent_provisioning: undefined`, 92 users / 127 events).

**Root cause.** `runProvisioningProbe` forwards its `lastError` to `onTimeout`. When the 10-minute TTL fires while the first `readAgentFile` is still held open server-side (pod never answered), no attempt has ever rejected, so `lastError` is `undefined`. The store then did `String(undefined)` and sent `"undefined"` to Sentry with no diagnostic value at all.

**Fix.** The probe now constructs a typed `ProvisioningTimeoutError` (`attempts`, `heldOpen`, last failure as `cause`) with a descriptive message, e.g.
`engine did not answer within 10 min (1 attempts; the last attempt was still held open, the engine never answered)` or `... last failure: HTTP 503 ...`. The store passes it straight to `showErrorToast`. User-facing behaviour (the "still starting" toast + sticky state) is unchanged.

## Verification

Before: `app/tests/agent-provisioning.test.ts` "times out even while an attempt is held open server-side" receives `undefined` as the timeout error (assertions added in this PR fail on main).

After:
- `cd app && pnpm test` — 3719 pass, incl. the two extended probe-timeout tests
- `cd app && pnpm tsgo --noEmit`, `pnpm check`, `pnpm check-locales` clean
- In Sentry, new HOUSTON-APP-519 events will carry the descriptive message instead of `undefined`; the old fingerprint should go quiet after this ships.