### PR TITLE
fix(domain): salvage a .houston doc with trailing junk after the value (PRODUCT-1449)

### DIFF
--- a/packages/domain/src/json-salvage.test.ts
+++ b/packages/domain/src/json-salvage.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "vitest";
+import { firstJsonValueEnd, salvageLeadingJson } from "./json-salvage";
+import { loadRoutineRuns, loadRoutines } from "./routines";
+import { loadJson, type TextStore } from "./store";
+
+const ROOT = "Personal/Slack Test";
+
+function memStore(): TextStore {
+  const m = new Map<string, string>();
+  return {
+    readText: async (k) => m.get(k) ?? null,
+    writeText: async (k, v) => {
+      m.set(k, v);
+    },
+  };
+}
+
+const routine = {
+  id: "r1",
+  name: "Daily digest",
+  prompt: 'Summarize "everything" {with} [brackets] and a \\" quote',
+  schedule: "0 9 * * *",
+};
+const doc = `${JSON.stringify([routine], null, 2)}\n`;
+
+test("firstJsonValueEnd tracks nesting and string escapes", () => {
+  expect(firstJsonValueEnd(doc)).toBe(doc.length - 1);
+  expect(firstJsonValueEnd('  {"a":"]}"}tail')).toBe(12);
+  expect(firstJsonValueEnd("[1, [2, 3]")).toBe(-1);
+  expect(firstJsonValueEnd("42 junk")).toBe(-1);
+  expect(firstJsonValueEnd("")).toBe(-1);
+});
+
+test("salvageLeadingJson keeps a complete value that has trailing junk", () => {
+  // The wild shape: the full array followed by a second, partial copy of it.
+  expect(salvageLeadingJson(`${doc}${doc.slice(0, 40)}`)).toEqual([routine]);
+  expect(salvageLeadingJson(`${doc}]}`)).toEqual([routine]);
+});
+
+test("salvageLeadingJson refuses when nothing is cleanly recoverable", () => {
+  expect(salvageLeadingJson(doc)).toBeUndefined();
+  expect(salvageLeadingJson(`${doc}  `)).toBeUndefined();
+  expect(salvageLeadingJson("{not json")).toBeUndefined();
+  expect(salvageLeadingJson(doc.slice(0, -10))).toBeUndefined();
+  expect(salvageLeadingJson('{"a": tru}xyz')).toBeUndefined();
+});
+
+test("loadRoutines survives trailing junk after the array (list_routines no longer 500s)", async () => {
+  const store = memStore();
+  const key = `${ROOT}/.houston/routines/routines.json`;
+  await store.writeText(key, `${doc}${doc.slice(0, 60)}`);
+  const { items, diagnostics } = await loadRoutines(store, ROOT);
+  expect(items.map((r) => r.id)).toEqual(["r1"]);
+  expect(diagnostics).toEqual([]);
+  await store.writeText(
+    `${ROOT}/.houston/routine_runs/routine_runs.json`,
+    "[]\n]}garbage",
+  );
+  expect((await loadRoutineRuns(store, ROOT)).items).toEqual([]);
+});
+
+test("loadJson still throws on a mangled file, naming the key", async () => {
+  const store = memStore();
+  await store.writeText("k.json", '[{"id": "r1", ');
+  await expect(loadJson(store, "k.json", [])).rejects.toThrow(
+    "k.json is not valid JSON",
+  );
+  await store.writeText("k.json", "﻿[]\n");
+  expect(await loadJson(store, "k.json", null)).toEqual([]);
+});

--- a/packages/domain/src/json-salvage.ts
+++ b/packages/domain/src/json-salvage.ts
@@ -1,0 +1,61 @@
+/**
+ * Salvage for `.houston` JSON docs that fail `JSON.parse` without the user
+ * having lost anything: a complete value followed by trailing bytes. Seen in
+ * the wild as `routines.json` = the full array + a second partial copy of it
+ * (an outside writer appended/overlapped; the host's own writes are atomic).
+ * The Rust engine kept the first value in that case; the TS cutover dropped
+ * it, so one mangled file 500'd `list_routines` on every poll and bricked
+ * the Routines tab for that agent. Only a prefix that parses on its own is
+ * salvaged; anything else still surfaces as the caller's "not valid JSON"
+ * throw, because a lossy reset would destroy the user's data on next write.
+ */
+
+/**
+ * Index just past the first complete top-level object/array in `text`, or
+ * -1 when the text does not start with one or it never closes. Scalars are
+ * not salvaged: a scalar doc is never a `.houston` data file.
+ */
+export function firstJsonValueEnd(text: string): number {
+  let i = 0;
+  while (i < text.length && isJsonWhitespace(text[i])) i++;
+  const open = text[i];
+  if (open !== "{" && open !== "[") return -1;
+  let depth = 0;
+  let inString = false;
+  for (; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (ch === "\\") i++;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === "{" || ch === "[") depth++;
+    else if (ch === "}" || ch === "]") {
+      depth--;
+      if (depth === 0) return i + 1;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Parse the leading complete value of a doc that has trailing junk after it.
+ * Returns `undefined` when there is nothing to salvage (no complete leading
+ * value, or the prefix itself is not valid JSON): the caller keeps its throw.
+ */
+export function salvageLeadingJson(text: string): unknown {
+  const end = firstJsonValueEnd(text);
+  if (end < 0 || end >= text.length) return undefined;
+  if (text.slice(end).trim() === "") return undefined;
+  try {
+    return JSON.parse(text.slice(0, end)) as unknown;
+  } catch {
+    // Mangled inside the leading value, not just after it: not ours to guess.
+    return undefined;
+  }
+}
+
+function isJsonWhitespace(ch: string | undefined): boolean {
+  return ch === " " || ch === "\n" || ch === "\r" || ch === "\t";
+}

--- a/packages/domain/src/store.ts
+++ b/packages/domain/src/store.ts
@@ -1,3 +1,5 @@
+import { salvageLeadingJson } from "./json-salvage";
+
 /**
  * The domain layer's only I/O dependency: a keyed text store. The host's Vfs
  * (Memory/Gcs/Fs) satisfies this structurally, so the SAME domain code runs
@@ -44,6 +46,11 @@ export async function loadJson<T>(
   try {
     return JSON.parse(text) as T;
   } catch (err) {
+    // A complete value followed by trailing bytes (an outside writer appended
+    // or overlapped the doc) keeps the value: nothing the user wrote is lost,
+    // and the next save rewrites the file clean. Anything else still throws.
+    const salvaged = salvageLeadingJson(text);
+    if (salvaged !== undefined) return salvaged as T;
     throw new Error(
       `${key} is not valid JSON (${err instanceof Error ? err.message : String(err)})`,
     );


### PR DESCRIPTION
## Summary

Sentry HOUSTON-APP-4WS (PRODUCT-1449). The bucket is mostly gateway classes already handled elsewhere (503 engine unavailable, 502 proxy failed, 404 agent gone, 401 expired token). The one genuine event: an agent's `routines.json` was a complete array followed by trailing bytes ("Unexpected non-whitespace character after JSON at position 3787"). `loadJson` threw, `list_routines` 500'd on every poll, and the Routines tab was bricked for that agent.

**Root cause:** the Rust engine salvaged "one valid value + trailing junk" by keeping the first value; the TS cutover of `loadJson` only carried the BOM strip, so that recovery regressed. The host's own writes are atomic (tmp+rename), so the trailing bytes came from an outside writer; the user's data was intact and did not need to be lost.

**Fix:** `packages/domain/src/json-salvage.ts` scans for the end of the leading complete object/array (string/escape aware) and `loadJson` falls back to parsing that prefix when the remainder is junk. Anything mangled inside the value still throws as before (no lossy reset, which would destroy data on the next write). The next save rewrites the file clean.

## Before

1. Write `~/.houston/workspaces/<ws>/<agent>/.houston/routines/routines.json` as a valid array followed by e.g. `]}garbage`.
2. Open that agent's Routines tab: `GET /agents/<id>/routines` returns 500 `routines.json is not valid JSON (...)`, the tab is empty, and Sentry receives `list_routines` on every refetch.

## After

Same file: the routines list loads with the array's entries, no 500, no Sentry event. A file broken inside the value (e.g. `[{"id": "r1", `) still surfaces the "not valid JSON" error.

## Tests

- `packages/domain/src/json-salvage.test.ts`: scanner nesting/escape cases, salvage keeps the leading value, refuses truncated/inner-mangled docs, `loadRoutines`/`loadRoutineRuns` end-to-end, `loadJson` still throws and still strips a BOM.
- `pnpm check` clean; domain/host/runtime vitest suites green.