### PR TITLE
Publish view docs: providers, usage, custom definitions served pod-less

### DIFF
--- a/packages/host/src/docs/http-shadow.ts
+++ b/packages/host/src/docs/http-shadow.ts
@@ -5,6 +5,7 @@ import {
   podGatewayHeaders,
   podGatewayUrl,
 } from "../pod-gateway";
+import type { ViewFamily } from "./view-capture";
 import {
   canonicalJSON,
   etagRevision,
@@ -15,19 +16,22 @@ import {
 
 export { canonicalJSON } from "./wire";
 
+/** Everything the shadow can hold: family files plus engine-computed views. */
+export type ShadowFamily = HoustonFamily | ViewFamily;
+
 export interface DocShadow {
   seed(): Promise<void>;
-  put(family: HoustonFamily, doc: unknown): Promise<void>;
+  put(family: ShadowFamily, doc: unknown): Promise<void>;
 }
 
 export class HttpDocShadow implements DocShadow {
   private readonly fetchImpl: typeof fetch;
-  private readonly revisions = new Map<HoustonFamily, number>();
+  private readonly revisions = new Map<ShadowFamily, number>();
   // Canonical (key-sorted) JSON of the last doc known to be durable, seeded
   // from the GET and refreshed on every accepted PUT. What makes the boot
   // content seed idempotent: an unchanged file costs one GET, never a PUT,
   // so revisions do not churn on every pod boot.
-  private readonly remote = new Map<HoustonFamily, string>();
+  private readonly remote = new Map<ShadowFamily, string>();
   private disabled = false;
 
   constructor(
@@ -43,7 +47,7 @@ export class HttpDocShadow implements DocShadow {
     await Promise.all(FAMILIES.map((family) => this.seedFamily(family)));
   }
 
-  async put(family: HoustonFamily, doc: unknown): Promise<void> {
+  async put(family: ShadowFamily, doc: unknown): Promise<void> {
     if (this.disabled) return;
     if (doc === undefined) {
       // canonicalJSON(undefined) is not a string; comparing it against a
@@ -82,7 +86,7 @@ export class HttpDocShadow implements DocShadow {
   }
 
   private async putAtRevision(
-    family: HoustonFamily,
+    family: ShadowFamily,
     doc: unknown,
     revision: number,
   ): Promise<Response> {
@@ -101,7 +105,7 @@ export class HttpDocShadow implements DocShadow {
   }
 
   private async acceptPutResponse(
-    family: HoustonFamily,
+    family: ShadowFamily,
     response: Response,
     canonical: string,
   ): Promise<void> {
@@ -122,7 +126,7 @@ export class HttpDocShadow implements DocShadow {
     this.remote.set(family, canonical);
   }
 
-  private async seedFamily(family: HoustonFamily): Promise<boolean> {
+  private async seedFamily(family: ShadowFamily): Promise<boolean> {
     if (this.disabled) return false;
     try {
       const response = await this.fetchImpl(this.url(family), {
@@ -154,7 +158,7 @@ export class HttpDocShadow implements DocShadow {
     }
   }
 
-  private url(family: HoustonFamily): string {
+  private url(family: ShadowFamily): string {
     const { gateway } = this.opts;
     return podGatewayUrl(
       gateway,

--- a/packages/host/src/docs/view-capture.test.ts
+++ b/packages/host/src/docs/view-capture.test.ts
@@ -1,0 +1,73 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { expect, test } from "vitest";
+import { attachViewCapture, viewForPath } from "./view-capture";
+
+test("viewForPath matches exactly the three view routes", () => {
+  expect(viewForPath("/agents/a1/providers")).toEqual({
+    agentId: "a1",
+    family: "providers",
+  });
+  expect(viewForPath("/agents/a%20b/providers/usage")).toEqual({
+    agentId: "a b",
+    family: "provider_usage",
+  });
+  expect(viewForPath("/agents/a1/integrations/custom/definitions")).toEqual({
+    agentId: "a1",
+    family: "custom_definitions",
+  });
+  expect(viewForPath("/agents/a1/providers/openai")).toBeNull();
+  expect(viewForPath("/agents/a1/conversations")).toBeNull();
+  expect(viewForPath("/providers")).toBeNull();
+});
+
+async function serveOnce(
+  handler: (res: import("node:http").ServerResponse) => void,
+): Promise<{ captured: unknown[]; body: string; status: number }> {
+  const captured: unknown[] = [];
+  const server = createServer((_req, res) => {
+    attachViewCapture(res, (json) => captured.push(json));
+    handler(res);
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const { port } = server.address() as AddressInfo;
+  const response = await fetch(`http://127.0.0.1:${port}/x`);
+  const body = await response.text();
+  await new Promise((r) => server.close(r));
+  // The finish event fires after the response is flushed; yield once.
+  await new Promise((r) => setImmediate(r));
+  return { captured, body, status: response.status };
+}
+
+test("a 200 JSON body is captured verbatim and still served to the client", async () => {
+  const { captured, body } = await serveOnce((res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.write('{"providers":');
+    res.end('[{"id":"anthropic","configured":true}]}');
+  });
+  expect(body).toBe('{"providers":[{"id":"anthropic","configured":true}]}');
+  expect(captured).toEqual([
+    { providers: [{ id: "anthropic", configured: true }] },
+  ]);
+});
+
+test("non-200, non-JSON, and oversized bodies never publish", async () => {
+  const err = await serveOnce((res) => {
+    res.writeHead(502, { "Content-Type": "application/json" });
+    res.end('{"error":"pod gone"}');
+  });
+  expect(err.captured).toEqual([]);
+
+  const text = await serveOnce((res) => {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("hello, not json");
+  });
+  expect(text.captured).toEqual([]);
+
+  const big = await serveOnce((res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ blob: "x".repeat(600 * 1024) }));
+  });
+  expect(big.captured).toEqual([]);
+  expect(big.body.length).toBeGreaterThan(600 * 1024);
+});

--- a/packages/host/src/docs/view-capture.ts
+++ b/packages/host/src/docs/view-capture.ts
@@ -1,0 +1,83 @@
+import type { ServerResponse } from "node:http";
+
+/**
+ * View docs: ENGINE-COMPUTED answers (not family files) published to the
+ * managed doc store so the gateway can serve them while the pod is ASLEEP.
+ * An asleep pod cannot change its own answer, so the last captured response
+ * is exact until the next wake — and every awake serve refreshes it. This is
+ * what turns the app's cold-open reads (`/providers` was observed at 8-11s,
+ * a full pod wake) into a gateway read.
+ */
+export type ViewFamily = "providers" | "provider_usage" | "custom_definitions";
+
+/** Route rest (after `/agents/:id/`) → the view family it publishes. */
+export const VIEW_RESTS: Readonly<Record<string, ViewFamily>> = {
+  providers: "providers",
+  "providers/usage": "provider_usage",
+  "integrations/custom/definitions": "custom_definitions",
+};
+
+const AGENT_PATH = /^\/agents\/([^/]+)\/(.+)$/;
+
+/** Match a request path to a view route. Exact rest matches only. */
+export function viewForPath(
+  path: string,
+): { agentId: string; family: ViewFamily } | null {
+  const match = AGENT_PATH.exec(path);
+  if (!match?.[1] || !match[2]) return null;
+  const family = VIEW_RESTS[match[2]];
+  return family ? { agentId: decodeURIComponent(match[1]), family } : null;
+}
+
+/** Views are small JSON bodies; anything larger is not a view answer. */
+const CAPTURE_CAP_BYTES = 512 * 1024;
+
+/**
+ * Tee a response body without altering what the client receives. When the
+ * response finishes 200 with a JSON content type and a parseable body under
+ * the cap, `onJson` gets the parsed body. Anything else (error status,
+ * over-cap, non-JSON) silently abandons the capture — the serve itself is
+ * never affected.
+ */
+export function attachViewCapture(
+  res: ServerResponse,
+  onJson: (body: unknown) => void,
+): void {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  let abandoned = false;
+  const push = (chunk: unknown): void => {
+    if (abandoned) return;
+    if (typeof chunk === "string" || chunk instanceof Uint8Array) {
+      const buf = Buffer.from(chunk as Uint8Array);
+      size += buf.length;
+      if (size > CAPTURE_CAP_BYTES) {
+        abandoned = true;
+        chunks.length = 0;
+        return;
+      }
+      chunks.push(buf);
+    }
+  };
+  const write = res.write.bind(res);
+  const end = res.end.bind(res);
+  res.write = ((chunk: unknown, ...args: unknown[]) => {
+    push(chunk);
+    return (write as (...a: unknown[]) => boolean)(chunk, ...args);
+  }) as typeof res.write;
+  res.end = ((chunk?: unknown, ...args: unknown[]) => {
+    if (chunk && typeof chunk !== "function") push(chunk);
+    return (end as (...a: unknown[]) => ServerResponse)(chunk, ...args);
+  }) as typeof res.end;
+  res.once("finish", () => {
+    if (abandoned || res.statusCode !== 200 || size === 0) return;
+    // No content-type gate: headers passed to writeHead(status, headers) are
+    // not observable via getHeader on every Node version. The matched routes
+    // only serve JSON; a non-JSON body simply fails the parse and is dropped.
+    try {
+      onJson(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+    } catch {
+      // Not a JSON answer (or truncated) — nothing to publish.
+    }
+  });
+}

--- a/packages/host/src/docs/view-warm.ts
+++ b/packages/host/src/docs/view-warm.ts
@@ -1,0 +1,60 @@
+import type { WorkspaceStore } from "../ports";
+import { VIEW_RESTS } from "./view-capture";
+
+const ATTEMPTS = 4;
+const RETRY_DELAY_MS = 10_000;
+
+/**
+ * Boot self-warm: GET each view route against our own server once so an
+ * agent whose pod slept since before view docs existed still gets its docs
+ * published WITHOUT a first slow client request. The responses flow through
+ * the server's own view capture, which publishes them. `/providers` relays
+ * to the runtime, which takes ~10s to boot — hence the retry ladder.
+ */
+export function warmViewDocs(opts: {
+  port: number;
+  token: string;
+  store: WorkspaceStore;
+  fetchImpl?: typeof fetch;
+}): void {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  void (async () => {
+    const agents: string[] = [];
+    for (const workspace of await opts.store.listWorkspaces()) {
+      for (const agent of await opts.store.listAgents(workspace.id)) {
+        agents.push(agent.id);
+      }
+    }
+    // Same single-agent rule as the doc projector: the doc route names ONE
+    // agent; on any other host shape the warm quietly stands down.
+    const only = agents.length === 1 ? agents[0] : undefined;
+    if (only === undefined) return;
+    for (const rest of Object.keys(VIEW_RESTS)) {
+      const url = `http://127.0.0.1:${opts.port}/agents/${encodeURIComponent(only)}/${rest}`;
+      let lastStatus = 0;
+      for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
+        if (attempt > 0) {
+          await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+        }
+        try {
+          const response = await fetchImpl(url, {
+            headers: { Authorization: `Bearer ${opts.token}` },
+            signal: AbortSignal.timeout(30_000),
+          });
+          lastStatus = response.status;
+          await response.body?.cancel();
+          if (response.ok) break;
+        } catch {
+          lastStatus = -1; // network-level; retry
+        }
+      }
+      if (lastStatus !== 200) {
+        console.error(
+          `[view-docs] boot warm for ${rest} gave up (last status ${lastStatus})`,
+        );
+      }
+    }
+  })().catch((error: unknown) => {
+    console.error("[view-docs] boot warm failed", error);
+  });
+}

--- a/packages/host/src/docs/wire.ts
+++ b/packages/host/src/docs/wire.ts
@@ -1,5 +1,3 @@
-import type { HoustonFamily } from "@houston/domain";
-
 /** Stable stringify (recursive key sort) so jsonb's key reordering never
  *  reads as a content change. */
 export function canonicalJSON(value: unknown): string {
@@ -62,7 +60,7 @@ export async function responseRevision(
 
 export async function responseError(
   response: Response,
-  family: HoustonFamily,
+  family: string,
   method: string,
 ): Promise<Error> {
   const detail = await response.text();

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -17,6 +17,7 @@ import { RemoteCredentialStore } from "../credentials/remote-store";
 import { EnvCredentialVault } from "../credentials/vault";
 import { HttpDocShadow } from "../docs/http-shadow";
 import { DocShadowProjector } from "../docs/projector";
+import { warmViewDocs } from "../docs/view-warm";
 import { BusEventHub } from "../events/hub";
 import { ComposioProvider } from "../integrations/composio";
 import { CustomExecutorHost } from "../integrations/custom/executor-host";
@@ -659,6 +660,16 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     addressedAgent: docProjector
       ? (agentId) => docProjector.bindAddressed(agentId)
       : undefined,
+    // Publish the view routes' answers (providers, usage, custom definitions)
+    // to the managed doc store; the gateway serves them while the pod is
+    // asleep. Cloud pods only (docShadow exists only under dual-write).
+    viewSink: docShadow
+      ? (_agentId, family, body) => {
+          void docShadow.put(family, body).catch((error: unknown) => {
+            console.error(`[view-docs] ${family} publish failed`, error);
+          });
+        }
+      : undefined,
   };
 
   const server = createControlPlaneServer(deps);
@@ -830,6 +841,11 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
         // tree's families over the live agent's docs is exactly the
         // stale-data overwrite passivity exists to prevent.
         docProjector?.seed();
+        if (docShadow) {
+          // Self-warm the view docs so an agent asleep since before views
+          // existed gets them published without a first slow client read.
+          warmViewDocs({ port: opts.port, token: opts.token, store });
+        }
         watcher.start();
         syncDaemon?.start();
         scheduler.start();

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -10,6 +10,11 @@ import { type Capabilities, PROTOCOL_VERSION } from "@houston/protocol";
 // from the package.json that shipped it.
 import { version as HOST_VERSION } from "../package.json";
 import type { SharedEndpointStore } from "./credentials/remote-shared-endpoint-store";
+import {
+  attachViewCapture,
+  type ViewFamily,
+  viewForPath,
+} from "./docs/view-capture";
 import type {
   Agent,
   UserId,
@@ -100,6 +105,12 @@ export interface ControlPlaneDeps {
   verifier: TokenVerifier;
   /** Authenticated agent-scoped request seen for this agent id (docs/projector binding). */
   addressedAgent?: (agentId: string) => void;
+  /**
+   * Receives every successful view-route response body (docs/view-capture)
+   * for publication to the managed doc store. Cloud pods only; absent on
+   * desktop/self-host.
+   */
+  viewSink?: (agentId: string, family: ViewFamily, body: unknown) => void;
   store: WorkspaceStore;
   /** Connect-once: the one subscription credential per workspace, served to its sandboxes. */
   credentials: CredentialStore;
@@ -474,6 +485,17 @@ export function createControlPlaneServer(deps: ControlPlaneDeps): Server {
       res.once("close", () => {
         agentRequests--;
       });
+    }
+    // Tee the view routes' successful answers into the managed doc store so
+    // the gateway can serve them while this pod is asleep. Transparent to the
+    // client; only 200 JSON bodies under the cap publish.
+    if (deps.viewSink && (req.method ?? "GET").toUpperCase() === "GET") {
+      const view = viewForPath(path);
+      if (view) {
+        attachViewCapture(res, (body) =>
+          deps.viewSink?.(view.agentId, view.family, body),
+        );
+      }
     }
     handle(counted, req, res).catch((err) => {
       // An over-cap body maps to 413 (Payload Too Large) with its own clean


### PR DESCRIPTION
Measured in staging: the app's cold open calls `GET /providers` (8-11.5s), `/providers/usage` and `/integrations/custom/definitions` per agent — each relays to the pod, so an asleep agent costs a full wake just to render the shell. These answers are ENGINE-computed (`/providers` relays to the runtime itself), so a gateway reimplementation would be drift by construction. Instead the engine publishes its own answers:

- **Capture tee** (`docs/view-capture.ts`, wired at the server entry): every successful (200, JSON, ≤512KB) response on the three view routes is parsed and published to the managed doc store through the existing `HttpDocShadow` (skip-if-equal, CAS revisions). Populated by real traffic: every awake serve refreshes the doc.
- **Boot self-warm** (`docs/view-warm.ts`): after listen, the host GETs its own three view routes once (retry ladder for the runtime-relayed one), so an agent asleep since before view docs existed still gets docs published without a first slow client read. Single-agent hosts only, same rule as the doc projector.
- **Shadow family widening**: `ShadowFamily = HoustonFamily | ViewFamily` — view docs ride the same PUT path, store, and skip-if-equal semantics as family docs.

**Why this is exact, not stale-serving**: the paired gateway change serves a view doc ONLY while the agent is asleep — and an asleep pod cannot change its own answer. The moment anything wakes the pod, reads proxy live again and re-capture.

**Desktop/self-host: unchanged** — no doc shadow means no sink and no warm; the capture predicate never attaches.

Tests: path matching, capture verbatim + client-unchanged, non-200/non-JSON/oversized never publish; full host+runtime suites green (1534/1273).

Pairs with the gateway PR (serves the stored bytes for asleep agents, exact rest matches only, fall-open on any miss).