### PR TITLE
Doc projector: bind to the agent the gateway addresses on multi-agent hosts

### DIFF
--- a/packages/host/src/docs/projector.test.ts
+++ b/packages/host/src/docs/projector.test.ts
@@ -140,7 +140,69 @@ test("boot seed projects every family once; missing files converge to empty docs
   expect(puts.find((p) => p.family === "config")?.doc).toEqual({});
 });
 
-test("a multi-agent host refuses ALL doc projection (route binds one agent)", async () => {
+test("a multi-agent host defers binding until the gateway addresses an agent", async () => {
+  const store = new MemoryWorkspaceStore();
+  const vfs = new MemoryVfs();
+  const paths = new LocalPaths();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  // A rename leftover beside the live agent — the shape seen on prod pod
+  // volumes ("Personal/MARKETING SHALOM" beside "Personal/SHALOM MARKETING").
+  const stale = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "Old Name",
+  });
+  const live = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "New Name",
+  });
+  const puts: { family: string; doc: unknown }[] = [];
+  const shadow: DocShadow = {
+    async seed() {},
+    async put(family, doc) {
+      puts.push({ family, doc });
+    },
+  };
+  await vfs.writeText(
+    docKey(paths.agentRoot(workspace, stale), "learnings"),
+    JSON.stringify([{ id: "old", text: "stale", created_at: "then" }]),
+  );
+  await vfs.writeText(
+    docKey(paths.agentRoot(workspace, live), "learnings"),
+    JSON.stringify([{ id: "new", text: "live", created_at: "now" }]),
+  );
+
+  const projector = new DocShadowProjector({ store, vfs, paths, shadow });
+  projector.seed();
+  await projector.flush();
+  // Ambiguous: nothing projects yet — not the stale dir, not the live one.
+  projector.onEvent({ type: "LearningsChanged", agentPath: stale.id });
+  projector.onEvent({ type: "LearningsChanged", agentPath: live.id });
+  await projector.flush();
+  expect(puts).toEqual([]);
+
+  // The gateway addresses the live agent (its registry engine id): that IS
+  // the binding. The boot seed back-fills from the live agent's files only.
+  projector.bindAddressed(live.id);
+  await projector.flush();
+  expect(puts.find((p) => p.family === "learnings")?.doc).toEqual([
+    { id: "new", text: "live", created_at: "now" },
+  ]);
+  expect(puts.map((p) => p.family).sort()).toEqual([
+    "activity",
+    "config",
+    "learnings",
+    "routine_runs",
+    "routines",
+  ]);
+
+  // The leftover's events stay refused forever after.
+  const seeded = puts.length;
+  projector.onEvent({ type: "LearningsChanged", agentPath: stale.id });
+  await projector.flush();
+  expect(puts.length).toBe(seeded);
+});
+
+test("an addressed id that is not an agent on this host does not bind", async () => {
   const store = new MemoryWorkspaceStore();
   const vfs = new MemoryVfs();
   const paths = new LocalPaths();
@@ -154,19 +216,13 @@ test("a multi-agent host refuses ALL doc projection (route binds one agent)", as
       puts.push({ family, doc });
     },
   };
-  await vfs.writeText(
-    docKey(paths.agentRoot(workspace, a), "learnings"),
-    JSON.stringify([{ id: "l1", text: "t", created_at: "now" }]),
-  );
-
   const projector = new DocShadowProjector({ store, vfs, paths, shadow });
   projector.seed();
   await projector.flush();
-  // Even a post-seed event for an existing agent must not cross-post: the
-  // shadow's URL names ONE agent and this host cannot tell which.
+  projector.bindAddressed("Personal/Nobody");
+  await projector.flush();
   projector.onEvent({ type: "LearningsChanged", agentPath: a.id });
   await projector.flush();
-
   expect(puts).toEqual([]);
 });
 

--- a/packages/host/src/docs/projector.ts
+++ b/packages/host/src/docs/projector.ts
@@ -28,11 +28,15 @@ const EVENT_FAMILY: Partial<Record<HoustonEvent["type"], HoustonFamily>> = {
 export class DocShadowProjector {
   private readonly tails = new Map<string, Promise<void>>();
   private ready: Promise<void> = Promise.resolve();
-  // The shadow's doc route is bound to ONE agent (the cloud pod's). Seeding
-  // pins that agent; any other agent id reaching project() (leftover dirs on
-  // a pod volume, unexpected multi-agent hosts) must never cross-post into
-  // the bound agent's doc. null = ambiguous host, all projection refused.
-  private bound: string | null | undefined;
+  // The shadow's doc route is bound to ONE agent (the cloud pod's). A host
+  // with exactly one agent binds at seed; a host with several (rename
+  // leftovers like `Personal/Old Name` beside the live agent are common on
+  // pod volumes) cannot tell them apart itself and DEFERS: the gateway names
+  // the real agent in every authenticated /agents/<id>/ request, and the
+  // first such request binds. Any other agent id reaching project() is
+  // refused — nothing may cross-post into the bound agent's doc.
+  private bound: string | undefined;
+  private addressing = false;
 
   constructor(
     private readonly deps: {
@@ -74,21 +78,55 @@ export class DocShadowProjector {
     }
     const only = agents.length === 1 ? agents[0] : undefined;
     if (only === undefined) {
-      this.poison(agents.length);
+      console.warn(
+        `[doc-shadow] host serves ${agents.length} agents; binding deferred to the first addressed agent`,
+      );
       return;
     }
     this.bound = only;
+    await this.seedBound(only);
+  }
+
+  private async seedBound(agentId: string): Promise<void> {
     for (const family of Object.values(EVENT_FAMILY)) {
       if (!family) continue;
       try {
-        await this.project(only, family);
+        await this.project(agentId, family);
       } catch (error) {
         console.error(
-          `[doc-shadow] boot content seed ${this.bound}#${family} failed`,
+          `[doc-shadow] boot content seed ${agentId}#${family} failed`,
           error,
         );
       }
     }
+  }
+
+  /**
+   * An authenticated request addressed this agent. On a host that could not
+   * bind at seed (several agent directories), the gateway's choice IS the
+   * binding: it addresses the registry's engine id, never a leftover. Binds
+   * once and back-fills the boot seed; later calls are no-ops.
+   */
+  bindAddressed(agentId: string): void {
+    if (this.bound !== undefined || this.addressing) return;
+    this.addressing = true;
+    const task = this.ready
+      .then(async () => {
+        if (this.bound !== undefined) return;
+        if (!(await this.deps.store.getAgent(agentId))) return;
+        this.bound = agentId;
+        console.warn(
+          `[doc-shadow] bound to ${agentId} from the first addressed request; seeding`,
+        );
+        await this.seedBound(agentId);
+      })
+      .catch((error: unknown) => {
+        console.error(`[doc-shadow] addressed bind ${agentId} failed`, error);
+      })
+      .finally(() => {
+        this.addressing = false;
+      });
+    this.ready = task;
   }
 
   onEvent(event: HoustonEvent): void {
@@ -117,7 +155,6 @@ export class DocShadowProjector {
   }
 
   private async project(agentId: string, family: HoustonFamily): Promise<void> {
-    if (this.bound === null) return; // ambiguous host, reported when poisoned
     if (this.bound === undefined && !(await this.lazyBind(agentId, family))) {
       return;
     }
@@ -155,18 +192,15 @@ export class DocShadowProjector {
   /**
    * Bind on first projection when boot found no agents. True = agentId is
    * the host's single agent; the remaining families are enqueued so the
-   * boot seed this pod missed still happens.
+   * boot seed this pod missed still happens. Several agents = still
+   * ambiguous: wait for bindAddressed.
    */
   private async lazyBind(
     agentId: string,
     family: HoustonFamily,
   ): Promise<boolean> {
     const agents = await this.listAgentIds();
-    if (agents.length > 1) {
-      this.poison(agents.length);
-      return false;
-    }
-    if (agents.length === 0 || agents[0] !== agentId) return false;
+    if (agents.length !== 1 || agents[0] !== agentId) return false;
     this.bound = agentId;
     console.warn(
       `[doc-shadow] bound to ${agentId} on first projection (agent hydrated after boot); seeding remaining families`,
@@ -185,15 +219,6 @@ export class DocShadowProjector {
       }
     }
     return agents;
-  }
-
-  // The single doc route cannot be attributed on a multi-agent host: refuse
-  // every projection rather than post one agent's files under another's docs.
-  private poison(count: number): void {
-    this.bound = null;
-    console.error(
-      `[doc-shadow] host serves ${count} agents but the doc route binds one; doc projection disabled`,
-    );
   }
 }
 

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -656,6 +656,9 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     // widen the unauthenticated surface for them.
     metrics: { render: () => boot.render(), contentType: boot.contentType },
     storeFenced: syncDaemon ? () => syncDaemon.fenced : undefined,
+    addressedAgent: docProjector
+      ? (agentId) => docProjector.bindAddressed(agentId)
+      : undefined,
   };
 
   const server = createControlPlaneServer(deps);

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -98,6 +98,8 @@ export type MountAdmin = (
 
 export interface ControlPlaneDeps {
   verifier: TokenVerifier;
+  /** Authenticated agent-scoped request seen for this agent id (docs/projector binding). */
+  addressedAgent?: (agentId: string) => void;
   store: WorkspaceStore;
   /** Connect-once: the one subscription credential per workspace, served to its sandboxes. */
   credentials: CredentialStore;
@@ -343,6 +345,14 @@ async function handle(
   // Everything past here is authenticated.
   const userId = await principal(deps, req, url);
   if (!userId) return json(res, 401, { error: "unauthorized" });
+  // An AUTHENTICATED /agents/<id>/ request names the agent this host is
+  // addressed as — the doc shadow's binding signal on hosts whose workspace
+  // holds more than one agent directory (rename leftovers). After auth only:
+  // an anonymous caller must never pick the binding.
+  if (deps.addressedAgent) {
+    const addressed = /^\/agents\/([^/]+)(?:\/|$)/.exec(path);
+    if (addressed?.[1]) deps.addressedAgent(decodeURIComponent(addressed[1]));
+  }
 
   // The global reactivity stream (SSE): this user's domain-change events only.
   // Long-lived — do not fall through, and never end the response here.


### PR DESCRIPTION
Follow-up to the 0.6.6 prod roll: ten+ prod pods logged `[doc-shadow] host serves 2 agents but the doc route binds one; doc projection disabled` plus `refusing cross-agent projection …`. Inspected one: the pod volume holds a **rename leftover** beside the live agent (`Personal/MARKETING SHALOM`, near-empty, beside `Personal/SHALOM MARKETING`). The single-agent guard treated that as ambiguous and refused all doc projection for the pod — prod-inert today (no doc reads there), but on staging such a pod's docs would never update, and a naive "first directory" bind would pick the leftover.

**Fix — bind to what the gateway addresses.** The pod cannot distinguish the directories; the gateway can: every authenticated `/agents/<id>/…` request uses the registry's engine id, never a leftover. So:
- An ambiguous host (several agent dirs) no longer poisons; it **defers** with a warning.
- The server reports the id of the first **authenticated** agent-scoped request (after `principal()` — an anonymous caller can never pick the binding); the projector binds to it after confirming the agent exists, back-fills the boot seed from that agent's files, and keeps refusing every other id.
- Single-agent hosts still bind at seed; zero-agent (late-hydrating) hosts still bind on first projection (#1360). No cloud change, no fleet roll.

Traffic always names the real agent soon after boot (the scheduler's snapshot refresh, the UI, the gateway's own probes), so binding completes within seconds of any wake.

**Tests**: rename-leftover case (nothing projects while ambiguous → addressed bind seeds all five families from the live agent only → leftover stays refused); an addressed id that isn't an agent on the host never binds. Full host suite green.

**Rollout**: engine roll on merge. Resolves the two prod Sentry issues once the affected pods reboot on the new image.