### PR TITLE
fix(chat): suggestion strip scrolls with the mouse wheel (PRODUCT-1452)

### DIFF
--- a/ui/chat/src/ai-elements/horizontal-wheel-scroll.ts
+++ b/ui/chat/src/ai-elements/horizontal-wheel-scroll.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from "react";
+
+export interface WheelScrollInput {
+  deltaX: number;
+  deltaY: number;
+  /** Modifier browsers already use to request horizontal scrolling. */
+  shiftKey: boolean;
+  scrollLeft: number;
+  scrollWidth: number;
+  clientWidth: number;
+}
+
+/**
+ * Maps a wheel gesture onto a horizontal-only strip. Mouse wheels only emit
+ * deltaY, so a strip that relies on native deltaX is trackpad-only; this turns
+ * the dominant axis into scrollLeft movement. Returns null when the strip
+ * should not consume the event: no overflow, or already at the edge the user is
+ * pushing towards (so the page behind keeps scrolling).
+ */
+export function resolveHorizontalWheelScroll(
+  input: WheelScrollInput,
+): { scrollLeft: number } | null {
+  const maxScrollLeft = input.scrollWidth - input.clientWidth;
+  if (maxScrollLeft <= 0) return null;
+  const delta =
+    input.shiftKey || Math.abs(input.deltaX) > Math.abs(input.deltaY)
+      ? input.deltaX || input.deltaY
+      : input.deltaY;
+  if (delta === 0) return null;
+  const next = Math.min(maxScrollLeft, Math.max(0, input.scrollLeft + delta));
+  if (next === input.scrollLeft) return null;
+  return { scrollLeft: next };
+}
+
+/**
+ * Attaches a non-passive wheel listener to the element that scrolls the Radix
+ * viewport. React registers onWheel as passive, so preventDefault (needed to
+ * keep the chat log from scrolling instead) only works on a native listener.
+ */
+export function useHorizontalWheelScroll<T extends HTMLElement>(
+  viewportSelector: string,
+) {
+  const rootRef = useRef<T | null>(null);
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const onWheel = (event: WheelEvent) => {
+      const viewport = root.querySelector<HTMLElement>(viewportSelector);
+      if (!viewport) return;
+      const result = resolveHorizontalWheelScroll({
+        deltaX: event.deltaX,
+        deltaY: event.deltaY,
+        shiftKey: event.shiftKey,
+        scrollLeft: viewport.scrollLeft,
+        scrollWidth: viewport.scrollWidth,
+        clientWidth: viewport.clientWidth,
+      });
+      if (!result) return;
+      event.preventDefault();
+      viewport.scrollLeft = result.scrollLeft;
+    };
+    root.addEventListener("wheel", onWheel, { passive: false });
+    return () => root.removeEventListener("wheel", onWheel);
+  }, [viewportSelector]);
+  return rootRef;
+}

--- a/ui/chat/src/ai-elements/suggestion.tsx
+++ b/ui/chat/src/ai-elements/suggestion.tsx
@@ -3,6 +3,7 @@
 import { Button, cn, ScrollArea, ScrollBar } from "@houston-ai/core";
 import type { ComponentProps } from "react";
 import { useCallback } from "react";
+import { useHorizontalWheelScroll } from "./horizontal-wheel-scroll";
 
 export type SuggestionsProps = ComponentProps<typeof ScrollArea>;
 
@@ -10,14 +11,25 @@ export const Suggestions = ({
   className,
   children,
   ...props
-}: SuggestionsProps) => (
-  <ScrollArea className="w-full overflow-x-auto whitespace-nowrap" {...props}>
-    <div className={cn("flex w-max flex-nowrap items-center gap-2", className)}>
-      {children}
-    </div>
-    <ScrollBar className="hidden" orientation="horizontal" />
-  </ScrollArea>
-);
+}: SuggestionsProps) => {
+  const rootRef = useHorizontalWheelScroll<HTMLDivElement>(
+    '[data-slot="scroll-area-viewport"]',
+  );
+  return (
+    <ScrollArea
+      className="w-full min-w-0 overflow-x-auto whitespace-nowrap"
+      ref={rootRef}
+      {...props}
+    >
+      <div
+        className={cn("flex w-max flex-nowrap items-center gap-2", className)}
+      >
+        {children}
+      </div>
+      <ScrollBar className="hidden" orientation="horizontal" />
+    </ScrollArea>
+  );
+};
 
 export type SuggestionProps = Omit<ComponentProps<typeof Button>, "onClick"> & {
   suggestion: string;

--- a/ui/chat/tests/horizontal-wheel-scroll.test.ts
+++ b/ui/chat/tests/horizontal-wheel-scroll.test.ts
@@ -1,0 +1,116 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { resolveHorizontalWheelScroll } from "../src/ai-elements/horizontal-wheel-scroll.ts";
+
+const strip = { scrollLeft: 100, scrollWidth: 1000, clientWidth: 400 };
+
+describe("resolveHorizontalWheelScroll", () => {
+  it("turns a mouse wheel (deltaY only) into horizontal movement", () => {
+    assert.deepEqual(
+      resolveHorizontalWheelScroll({
+        ...strip,
+        deltaX: 0,
+        deltaY: 50,
+        shiftKey: false,
+      }),
+      { scrollLeft: 150 },
+    );
+    assert.deepEqual(
+      resolveHorizontalWheelScroll({
+        ...strip,
+        deltaX: 0,
+        deltaY: -50,
+        shiftKey: false,
+      }),
+      { scrollLeft: 50 },
+    );
+  });
+
+  it("keeps trackpad horizontal swipes on their own axis", () => {
+    assert.deepEqual(
+      resolveHorizontalWheelScroll({
+        ...strip,
+        deltaX: 30,
+        deltaY: 5,
+        shiftKey: false,
+      }),
+      { scrollLeft: 130 },
+    );
+  });
+
+  it("honours shift+wheel the way browsers do", () => {
+    assert.deepEqual(
+      resolveHorizontalWheelScroll({
+        ...strip,
+        deltaX: 0,
+        deltaY: 20,
+        shiftKey: true,
+      }),
+      { scrollLeft: 120 },
+    );
+  });
+
+  it("clamps to the scrollable range", () => {
+    assert.deepEqual(
+      resolveHorizontalWheelScroll({
+        ...strip,
+        deltaX: 0,
+        deltaY: 5000,
+        shiftKey: false,
+      }),
+      { scrollLeft: 600 },
+    );
+    assert.deepEqual(
+      resolveHorizontalWheelScroll({
+        ...strip,
+        deltaX: 0,
+        deltaY: -5000,
+        shiftKey: false,
+      }),
+      { scrollLeft: 0 },
+    );
+  });
+
+  it("lets the page scroll when the strip does not overflow or is at its edge", () => {
+    assert.equal(
+      resolveHorizontalWheelScroll({
+        scrollLeft: 0,
+        scrollWidth: 300,
+        clientWidth: 400,
+        deltaX: 0,
+        deltaY: 50,
+        shiftKey: false,
+      }),
+      null,
+    );
+    assert.equal(
+      resolveHorizontalWheelScroll({
+        ...strip,
+        scrollLeft: 600,
+        deltaX: 0,
+        deltaY: 50,
+        shiftKey: false,
+      }),
+      null,
+    );
+    assert.equal(
+      resolveHorizontalWheelScroll({
+        ...strip,
+        scrollLeft: 0,
+        deltaX: 0,
+        deltaY: -50,
+        shiftKey: false,
+      }),
+      null,
+    );
+    assert.equal(
+      resolveHorizontalWheelScroll({
+        ...strip,
+        deltaX: 0,
+        deltaY: 0,
+        shiftKey: false,
+      }),
+      null,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Linear: PRODUCT-1452 (PRODUCT-1431 is the same report from a Windows user).

**Root cause.** The "Continue with" pills (`ui/chat/src/ai-elements/suggestion.tsx`) live in a Radix `ScrollArea` that only overflows horizontally. A mouse wheel emits `deltaY`; the strip only moved on native `deltaX`, which trackpads send and mice do not. So the strip was trackpad-only, on every OS.

**Fix.** `useHorizontalWheelScroll` attaches a non-passive `wheel` listener on the strip (React's `onWheel` is passive, so `preventDefault` would be ignored) and maps the dominant axis onto the viewport's `scrollLeft`, clamped to the range. The event is left to the page when the strip has no overflow or is already at the edge being pushed, so the chat log still scrolls in those cases. Shift+wheel and trackpad horizontal swipes keep working. Pure mapping lives in `resolveHorizontalWheelScroll` with unit tests.

**Not addressed here.** The issue also mentions a Windows user whose pill clicks "don't register". The click handler prefills the composer (it does not send); nothing in the strip is platform-specific and I could not reproduce without a Windows machine. Worth a separate follow-up with a recording.

## Verification
Before: open a chat that ends with "Continue with" pills wider than the composer, hover the pills and roll the mouse wheel. The chat log scrolls; the pills do not move.

After: same steps, the pills scroll left/right with the wheel; at either end the wheel falls through to the chat log again. Trackpad horizontal swipe unchanged.

Gates: `pnpm check`, `pnpm typecheck`, `pnpm --filter @houston-ai/chat test` (399 pass).