### PR TITLE
View docs: publish the skills list

### DIFF
--- a/packages/host/src/docs/projector.test.ts
+++ b/packages/host/src/docs/projector.test.ts
@@ -376,3 +376,23 @@ test("a pod that boots before its agent hydrates binds on first projection", asy
   await projector.flush();
   expect(puts.length).toBe(seeded);
 });
+
+test("boundAgent resolves after the seed to the bound id, or undefined", async () => {
+  const store = new MemoryWorkspaceStore();
+  const vfs = new MemoryVfs();
+  const paths = new LocalPaths();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "A",
+  });
+  const shadow: DocShadow = { async seed() {}, async put() {} };
+  const projector = new DocShadowProjector({ store, vfs, paths, shadow });
+  projector.seed();
+  expect(await projector.boundAgent()).toBe(agent.id);
+
+  await store.createAgent({ workspaceId: workspace.id, name: "B" });
+  const ambiguous = new DocShadowProjector({ store, vfs, paths, shadow });
+  ambiguous.seed();
+  expect(await ambiguous.boundAgent()).toBeUndefined();
+});

--- a/packages/host/src/docs/projector.ts
+++ b/packages/host/src/docs/projector.ts
@@ -149,6 +149,18 @@ export class DocShadowProjector {
     this.tails.set(key, task);
   }
 
+  /**
+   * Resolves to the bound agent id once the boot seed has settled (or to
+   * undefined if the host could not bind). The view sink consults it so an
+   * answer captured for any other agent id (a leftover directory on a pod
+   * volume) is never published as the bound agent's doc — the same
+   * cross-post rule project() enforces for family files.
+   */
+  async boundAgent(): Promise<string | undefined> {
+    await this.ready;
+    return this.bound;
+  }
+
   async flush(): Promise<void> {
     await this.ready;
     await Promise.all([...this.tails.values()]);

--- a/packages/host/src/docs/view-capture.test.ts
+++ b/packages/host/src/docs/view-capture.test.ts
@@ -16,6 +16,11 @@ test("viewForPath matches exactly the three view routes", () => {
     agentId: "a1",
     family: "custom_definitions",
   });
+  expect(viewForPath("/agents/a1/skills")).toEqual({
+    agentId: "a1",
+    family: "skills",
+  });
+  expect(viewForPath("/agents/a1/skills/my-skill")).toBeNull();
   expect(viewForPath("/agents/a1/providers/openai")).toBeNull();
   expect(viewForPath("/agents/a1/conversations")).toBeNull();
   expect(viewForPath("/providers")).toBeNull();

--- a/packages/host/src/docs/view-capture.test.ts
+++ b/packages/host/src/docs/view-capture.test.ts
@@ -71,8 +71,8 @@ test("non-200, non-JSON, and oversized bodies never publish", async () => {
 
   const big = await serveOnce((res) => {
     res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ blob: "x".repeat(600 * 1024) }));
+    res.end(JSON.stringify({ blob: "x".repeat(5 * 1024 * 1024) }));
   });
   expect(big.captured).toEqual([]);
-  expect(big.body.length).toBeGreaterThan(600 * 1024);
+  expect(big.body.length).toBeGreaterThan(5 * 1024 * 1024);
 });

--- a/packages/host/src/docs/view-capture.ts
+++ b/packages/host/src/docs/view-capture.ts
@@ -36,8 +36,10 @@ export function viewForPath(
   return family ? { agentId: decodeURIComponent(match[1]), family } : null;
 }
 
-/** Views are small JSON bodies; anything larger is not a view answer. */
-const CAPTURE_CAP_BYTES = 512 * 1024;
+/** Views are modest JSON bodies (summaries, not contents); a body past this
+ *  is not a view answer and is left to the proxy path. Generous on purpose:
+ *  an abandoned capture leaves the PREVIOUS doc serving asleep readers. */
+const CAPTURE_CAP_BYTES = 4 * 1024 * 1024;
 
 /**
  * Tee a response body without altering what the client receives. When the

--- a/packages/host/src/docs/view-capture.ts
+++ b/packages/host/src/docs/view-capture.ts
@@ -8,13 +8,20 @@ import type { ServerResponse } from "node:http";
  * what turns the app's cold-open reads (`/providers` was observed at 8-11s,
  * a full pod wake) into a gateway read.
  */
-export type ViewFamily = "providers" | "provider_usage" | "custom_definitions";
+export type ViewFamily =
+  | "providers"
+  | "provider_usage"
+  | "custom_definitions"
+  | "skills";
 
 /** Route rest (after `/agents/:id/`) → the view family it publishes. */
 export const VIEW_RESTS: Readonly<Record<string, ViewFamily>> = {
   providers: "providers",
   "providers/usage": "provider_usage",
   "integrations/custom/definitions": "custom_definitions",
+  // The skills list is a directory family (no .houston/<family>.json), so it
+  // rides the view path: the pod's own answer, captured and served asleep.
+  skills: "skills",
 };
 
 const AGENT_PATH = /^\/agents\/([^/]+)\/(.+)$/;

--- a/packages/host/src/docs/view-warm.test.ts
+++ b/packages/host/src/docs/view-warm.test.ts
@@ -1,0 +1,77 @@
+import type { HoustonEvent } from "@houston/protocol";
+import { expect, test, vi } from "vitest";
+import type { EventHub } from "../events/hub";
+import { MemoryWorkspaceStore } from "../store/memory";
+import { refreshViewsOnEvents } from "./view-warm";
+
+function hub(): EventHub & { fire: (e: HoustonEvent) => void } {
+  const handlers: Array<(e: HoustonEvent) => void> = [];
+  return {
+    emit() {},
+    subscribe(_user, handler) {
+      handlers.push(handler);
+      return () => {};
+    },
+    fire: (e) => {
+      for (const h of handlers) h(e);
+    },
+  };
+}
+
+test("a SkillsChanged event re-fetches /skills for that agent (debounced)", async () => {
+  vi.useFakeTimers();
+  const store = new MemoryWorkspaceStore();
+  const urls: string[] = [];
+  const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+    urls.push(String(url));
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch;
+  const events = hub();
+  refreshViewsOnEvents({
+    port: 4318,
+    token: "t",
+    store,
+    events,
+    userId: "local-owner",
+    fetchImpl,
+  });
+  events.fire({ type: "SkillsChanged", agentPath: "Personal/Bob" });
+  events.fire({ type: "SkillsChanged", agentPath: "Personal/Bob" });
+  await vi.advanceTimersByTimeAsync(600);
+  expect(urls).toEqual(["http://127.0.0.1:4318/agents/Personal%2FBob/skills"]);
+  vi.useRealTimers();
+});
+
+test("a global CustomIntegrationsChanged resolves the single agent", async () => {
+  vi.useFakeTimers();
+  const store = new MemoryWorkspaceStore();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "Only",
+  });
+  const urls: string[] = [];
+  const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+    urls.push(String(url));
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch;
+  const events = hub();
+  refreshViewsOnEvents({
+    port: 4318,
+    token: "t",
+    store,
+    events,
+    userId: "local-owner",
+    fetchImpl,
+  });
+  events.fire({ type: "CustomIntegrationsChanged" });
+  await vi.advanceTimersByTimeAsync(600);
+  expect(urls).toEqual([
+    `http://127.0.0.1:4318/agents/${encodeURIComponent(agent.id)}/integrations/custom/definitions`,
+  ]);
+  // Unrelated events never fetch.
+  events.fire({ type: "ActivityChanged", agentPath: agent.id });
+  await vi.advanceTimersByTimeAsync(600);
+  expect(urls).toHaveLength(1);
+  vi.useRealTimers();
+});

--- a/packages/host/src/docs/view-warm.ts
+++ b/packages/host/src/docs/view-warm.ts
@@ -1,8 +1,58 @@
+import type { HoustonEvent } from "@houston/protocol";
+import type { EventHub } from "../events/hub";
 import type { WorkspaceStore } from "../ports";
 import { VIEW_RESTS } from "./view-capture";
 
 const ATTEMPTS = 4;
 const RETRY_DELAY_MS = 10_000;
+const REFRESH_DEBOUNCE_MS = 500;
+
+interface SelfFetch {
+  port: number;
+  token: string;
+  fetchImpl?: typeof fetch;
+}
+
+/** GET one of our own view routes so the server's capture re-publishes it. */
+async function fetchView(
+  self: SelfFetch,
+  agentId: string,
+  rest: string,
+  attempts: number,
+): Promise<number> {
+  const fetchImpl = self.fetchImpl ?? fetch;
+  const url = `http://127.0.0.1:${self.port}/agents/${encodeURIComponent(agentId)}/${rest}`;
+  let lastStatus = 0;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+    }
+    try {
+      const response = await fetchImpl(url, {
+        headers: { Authorization: `Bearer ${self.token}` },
+        signal: AbortSignal.timeout(30_000),
+      });
+      lastStatus = response.status;
+      await response.body?.cancel();
+      if (response.ok) break;
+    } catch {
+      lastStatus = -1; // network-level; retry
+    }
+  }
+  return lastStatus;
+}
+
+async function singleAgentId(store: WorkspaceStore): Promise<string | null> {
+  const agents: string[] = [];
+  for (const workspace of await store.listWorkspaces()) {
+    for (const agent of await store.listAgents(workspace.id)) {
+      agents.push(agent.id);
+    }
+  }
+  // Same single-agent rule as the doc projector: the doc route names ONE
+  // agent; on any other host shape the warm quietly stands down.
+  return agents.length === 1 ? (agents[0] ?? null) : null;
+}
 
 /**
  * Boot self-warm: GET each view route against our own server once so an
@@ -11,50 +61,64 @@ const RETRY_DELAY_MS = 10_000;
  * the server's own view capture, which publishes them. `/providers` relays
  * to the runtime, which takes ~10s to boot — hence the retry ladder.
  */
-export function warmViewDocs(opts: {
-  port: number;
-  token: string;
-  store: WorkspaceStore;
-  fetchImpl?: typeof fetch;
-}): void {
-  const fetchImpl = opts.fetchImpl ?? fetch;
+export function warmViewDocs(
+  opts: SelfFetch & { store: WorkspaceStore },
+): void {
   void (async () => {
-    const agents: string[] = [];
-    for (const workspace of await opts.store.listWorkspaces()) {
-      for (const agent of await opts.store.listAgents(workspace.id)) {
-        agents.push(agent.id);
-      }
-    }
-    // Same single-agent rule as the doc projector: the doc route names ONE
-    // agent; on any other host shape the warm quietly stands down.
-    const only = agents.length === 1 ? agents[0] : undefined;
-    if (only === undefined) return;
+    const only = await singleAgentId(opts.store);
+    if (only === null) return;
     for (const rest of Object.keys(VIEW_RESTS)) {
-      const url = `http://127.0.0.1:${opts.port}/agents/${encodeURIComponent(only)}/${rest}`;
-      let lastStatus = 0;
-      for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
-        if (attempt > 0) {
-          await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
-        }
-        try {
-          const response = await fetchImpl(url, {
-            headers: { Authorization: `Bearer ${opts.token}` },
-            signal: AbortSignal.timeout(30_000),
-          });
-          lastStatus = response.status;
-          await response.body?.cancel();
-          if (response.ok) break;
-        } catch {
-          lastStatus = -1; // network-level; retry
-        }
-      }
-      if (lastStatus !== 200) {
+      const status = await fetchView(opts, only, rest, ATTEMPTS);
+      if (status !== 200) {
         console.error(
-          `[view-docs] boot warm for ${rest} gave up (last status ${lastStatus})`,
+          `[view-docs] boot warm for ${rest} gave up (last status ${status})`,
         );
       }
     }
   })().catch((error: unknown) => {
     console.error("[view-docs] boot warm failed", error);
+  });
+}
+
+/** Domain changes that invalidate a view; each re-fetches its route. */
+const EVENT_VIEW_RESTS: Partial<Record<HoustonEvent["type"], string>> = {
+  SkillsChanged: "skills",
+  CustomIntegrationsChanged: "integrations/custom/definitions",
+};
+
+/**
+ * Keep views fresh on CHANGE, not only on reads: a skill installed by the
+ * agent at night with no UI open would otherwise leave the previous skills
+ * list served to asleep readers until the next live GET. Debounced per view.
+ */
+export function refreshViewsOnEvents(
+  opts: SelfFetch & { store: WorkspaceStore; events: EventHub; userId: string },
+): () => void {
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+  return opts.events.subscribe(opts.userId, (event) => {
+    const rest = EVENT_VIEW_RESTS[event.type];
+    if (!rest) return;
+    const pending = timers.get(rest);
+    if (pending) clearTimeout(pending);
+    const timer = setTimeout(() => {
+      timers.delete(rest);
+      void (async () => {
+        const agentId =
+          "agentPath" in event && typeof event.agentPath === "string"
+            ? event.agentPath
+            : await singleAgentId(opts.store);
+        if (agentId === null) return;
+        const status = await fetchView(opts, agentId, rest, 1);
+        if (status !== 200) {
+          console.error(
+            `[view-docs] refresh of ${rest} after ${event.type} answered ${status}`,
+          );
+        }
+      })().catch((error: unknown) => {
+        console.error(`[view-docs] refresh of ${rest} failed`, error);
+      });
+    }, REFRESH_DEBOUNCE_MS);
+    timer.unref?.();
+    timers.set(rest, timer);
   });
 }

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -17,7 +17,7 @@ import { RemoteCredentialStore } from "../credentials/remote-store";
 import { EnvCredentialVault } from "../credentials/vault";
 import { HttpDocShadow } from "../docs/http-shadow";
 import { DocShadowProjector } from "../docs/projector";
-import { warmViewDocs } from "../docs/view-warm";
+import { refreshViewsOnEvents, warmViewDocs } from "../docs/view-warm";
 import { BusEventHub } from "../events/hub";
 import { ComposioProvider } from "../integrations/composio";
 import { CustomExecutorHost } from "../integrations/custom/executor-host";
@@ -616,6 +616,8 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
         log: severityLog,
       })
     : undefined;
+  // Per-family publish chains for the view sink (see viewSink below).
+  const viewTails = new Map<string, Promise<void>>();
   const deps: ControlPlaneDeps = {
     verifier: new SingleUserVerifier({ token: opts.token, userId: LOCAL_USER }),
     store,
@@ -669,8 +671,12 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
             // Same cross-post rule as the file projector: the doc route
             // names ONE agent; a view captured for any other id (a leftover
             // directory's /skills) must never land under the bound agent.
-            void docProjector
-              .boundAgent()
+            // Publishes are SERIALIZED per family so two captures in flight
+            // land in capture order — a detached pair could otherwise let
+            // the older body win the CAS retry.
+            const prior = viewTails.get(family) ?? Promise.resolve();
+            const task = prior
+              .then(() => docProjector.boundAgent())
               .then((bound) => {
                 if (bound !== agentId) {
                   console.warn(
@@ -682,12 +688,28 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
               })
               .catch((error: unknown) => {
                 console.error(`[view-docs] ${family} publish failed`, error);
+              })
+              .finally(() => {
+                if (viewTails.get(family) === task) viewTails.delete(family);
               });
+            viewTails.set(family, task);
           }
         : undefined,
   };
 
   const server = createControlPlaneServer(deps);
+  if (docShadow) {
+    // Views go stale on CHANGE without a live read (a skill the agent
+    // installs overnight); re-capture on the domain events that invalidate
+    // them.
+    refreshViewsOnEvents({
+      port: opts.port,
+      token: opts.token,
+      store,
+      events,
+      userId: LOCAL_USER,
+    });
+  }
   // The agent (or the user) editing files directly → reactivity, no host write.
   const watcher = new FsWatcher(opts.workspacesRoot, (event) => {
     events.emit(LOCAL_USER, event);

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -663,13 +663,28 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     // Publish the view routes' answers (providers, usage, custom definitions)
     // to the managed doc store; the gateway serves them while the pod is
     // asleep. Cloud pods only (docShadow exists only under dual-write).
-    viewSink: docShadow
-      ? (_agentId, family, body) => {
-          void docShadow.put(family, body).catch((error: unknown) => {
-            console.error(`[view-docs] ${family} publish failed`, error);
-          });
-        }
-      : undefined,
+    viewSink:
+      docShadow && docProjector
+        ? (agentId, family, body) => {
+            // Same cross-post rule as the file projector: the doc route
+            // names ONE agent; a view captured for any other id (a leftover
+            // directory's /skills) must never land under the bound agent.
+            void docProjector
+              .boundAgent()
+              .then((bound) => {
+                if (bound !== agentId) {
+                  console.warn(
+                    `[view-docs] refusing ${family} publish for ${agentId} (route bound to ${bound ?? "nothing yet"})`,
+                  );
+                  return;
+                }
+                return docShadow.put(family, body);
+              })
+              .catch((error: unknown) => {
+                console.error(`[view-docs] ${family} publish failed`, error);
+              });
+          }
+        : undefined,
   };
 
   const server = createControlPlaneServer(deps);


### PR DESCRIPTION
Cold-open trace of a tester's agent showed the app still waking the pod for `GET /skills` (7.9s) beside the raw-file reads. Skills are a directory family with no `.houston/<family>.json`, so a file-doc projection does not apply; they ride the view path instead: the pod's own `/skills` answer is captured on every serve and at boot warm (`docs/view-capture.ts`), and the paired gateway change serves it while the pod is asleep.

One-line family addition + path test. Pairs with the gateway PR (agentfile family reads + skills view + family CHECK removal).

## Adversarial review (two independent reviewers)

Confirmed findings, fixed in follow-up commits on this branch:
- **View sink cross-post**: the sink ignored the captured agent id; on a pod with a leftover agent directory a 200 on the leftover's `/skills` (a per-agent view) could publish under the bound agent. The sink now awaits the projector's binding and refuses any other id.
- **Stale views after change**: a skill installed/deleted (or a custom integration changed) with no follow-up live GET left the previous view served to asleep readers. Views now re-capture on `SkillsChanged` / `CustomIntegrationsChanged` via a debounced self-GET.
- **Capture ordering**: two captures in flight could let the older body win the CAS retry; publishes are serialized per family.
- **Cap**: 512 KiB → 4 MiB (an abandoned capture leaves the previous doc serving; the cap must sit far above any real view).

No security/leak findings (the pod's `/skills` has no per-user filtering; the view is byte-identical to what the pod returns).
