### PR TITLE
Pool op turns: every write for a sleeping agent runs on a worker

### DIFF
--- a/packages/host/src/op/dispatch.test.ts
+++ b/packages/host/src/op/dispatch.test.ts
@@ -1,0 +1,95 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { LocalWorkspaceStore } from "../store/local";
+import { dispatchAgentOp } from "./dispatch";
+
+async function seed() {
+  const root = mkdtempSync(join(tmpdir(), "op-dispatch-"));
+  const store = new LocalWorkspaceStore(root);
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "Bob",
+  });
+  return { root, agent, workspace };
+}
+
+test("a routine create runs the REAL route handler against the hydrated tree", async () => {
+  const { root, agent } = await seed();
+  const res = await dispatchAgentOp({
+    workspacesRoot: root,
+    agentId: agent.id,
+    request: {
+      method: "POST",
+      rest: "routines",
+      contentType: "application/json",
+      body: JSON.stringify({
+        name: "Daily digest",
+        prompt: "Summarize my inbox",
+        schedule: "0 9 * * *",
+        enabled: true,
+      }),
+      actingSub: "user-1",
+      triggersEnabled: false,
+    },
+  });
+  expect(res.status).toBe(201);
+  const created = JSON.parse(res.body) as { id: string; created_by?: string };
+  expect(created.created_by).toBe("user-1");
+  // The file on the hydrated tree carries it — what sync-back uploads.
+  const file = JSON.parse(
+    readFileSync(
+      join(root, "Personal", "Bob", ".houston", "routines", "routines.json"),
+      "utf8",
+    ),
+  ) as Array<{ id: string }>;
+  expect(file.map((r) => r.id)).toEqual([created.id]);
+  expect(res.events.map((e) => e.type)).toContain("RoutinesChanged");
+});
+
+test("an agentfile PUT writes the file and emits the family event", async () => {
+  const { root, agent } = await seed();
+  const res = await dispatchAgentOp({
+    workspacesRoot: root,
+    agentId: agent.id,
+    request: {
+      method: "PUT",
+      rest: "agentfile/.houston/config/config.json",
+      contentType: "application/json",
+      body: JSON.stringify({
+        content: JSON.stringify({ provider: "anthropic" }),
+      }),
+      triggersEnabled: false,
+    },
+  });
+  expect(res.status).toBe(200);
+  expect(
+    readFileSync(
+      join(root, "Personal", "Bob", ".houston", "config", "config.json"),
+      "utf8",
+    ),
+  ).toBe(JSON.stringify({ provider: "anthropic" }));
+  expect(res.events.map((e) => e.type)).toContain("ConfigChanged");
+});
+
+test("unknown routes and unknown agents answer without throwing", async () => {
+  const { root, agent } = await seed();
+  const miss = await dispatchAgentOp({
+    workspacesRoot: root,
+    agentId: agent.id,
+    request: {
+      method: "POST",
+      rest: "conversations/x/messages",
+      triggersEnabled: false,
+    },
+  });
+  expect(miss.status).toBe(404);
+  const gone = await dispatchAgentOp({
+    workspacesRoot: root,
+    agentId: "Personal/Nobody",
+    request: { method: "GET", rest: "routines", triggersEnabled: false },
+  });
+  expect(gone.status).toBe(404);
+});

--- a/packages/host/src/op/dispatch.ts
+++ b/packages/host/src/op/dispatch.ts
@@ -1,0 +1,152 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+import type { ActivityContributor, HoustonEvent } from "@houston/protocol";
+import { LocalPaths } from "../paths";
+import { handleAgentData } from "../routes/agent-data";
+import { handleAgentFile } from "../routes/agent-file";
+import { handleSkills } from "../routes/skills";
+import { handleSkillsRemote } from "../routes/skills-remote";
+import { LocalWorkspaceStore } from "../store/local";
+import { FsVfs } from "../vfs";
+
+/**
+ * A write the gateway routes to a pool worker instead of waking the agent's
+ * pod: the SAME route handlers the pod runs, executed against a hydrated
+ * copy of the agent's workspace. Byte-identical semantics by construction —
+ * nothing is reimplemented; only the filesystem underneath is different.
+ */
+export interface AgentOpRequest {
+  method: string;
+  /** Route rest after `/agents/<id>/`, e.g. `routines/<id>`, `agentfile/CLAUDE.md`. */
+  rest: string;
+  body?: string;
+  contentType?: string;
+  /** Verified acting identity (routines' created_by, activity contributors). */
+  actingSub?: string;
+  actingAuthor?: ActivityContributor | null;
+  triggersEnabled: boolean;
+}
+
+export interface AgentOpResponse {
+  status: number;
+  contentType: string;
+  body: string;
+  /** Domain events the handler emitted — the caller republishes their docs. */
+  events: HoustonEvent[];
+}
+
+/**
+ * Dispatch one op against `workspacesRoot` (the hydrated `workspaces/` dir)
+ * for `agentId`. Runs the handler chain over a loopback server so the
+ * handlers see ordinary IncomingMessage/ServerResponse objects. Unknown
+ * routes answer 404, never a throw: the worker relays the status verbatim.
+ */
+export async function dispatchAgentOp(opts: {
+  workspacesRoot: string;
+  agentId: string;
+  request: AgentOpRequest;
+  fetchImpl?: typeof fetch;
+}): Promise<AgentOpResponse> {
+  const store = new LocalWorkspaceStore(opts.workspacesRoot);
+  const agent = await store.getAgent(opts.agentId);
+  if (!agent) {
+    return {
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "agent not found" }),
+      events: [],
+    };
+  }
+  const workspace = await store.getWorkspace(agent.workspaceId);
+  if (!workspace) {
+    return {
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "workspace not found" }),
+      events: [],
+    };
+  }
+  const vfs = new FsVfs(opts.workspacesRoot);
+  const paths = new LocalPaths();
+  const ctx = { workspace, agent };
+  const events: HoustonEvent[] = [];
+  const emit = (event: HoustonEvent) => {
+    events.push(event);
+  };
+  const { method, rest, triggersEnabled, actingSub, actingAuthor } =
+    opts.request;
+
+  const handler = async (req: IncomingMessage, res: ServerResponse) => {
+    if (
+      await handleAgentData(
+        vfs,
+        paths,
+        ctx,
+        method,
+        rest,
+        req,
+        res,
+        emit,
+        actingSub,
+        actingAuthor ?? undefined,
+        triggersEnabled,
+      )
+    )
+      return;
+    if (await handleAgentFile(vfs, paths, ctx, method, rest, req, res, emit))
+      return;
+    if (await handleSkills(vfs, paths, ctx, method, rest, req, res, emit))
+      return;
+    if (
+      await handleSkillsRemote(
+        vfs,
+        paths,
+        ctx,
+        method,
+        rest,
+        req,
+        res,
+        emit,
+        opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {},
+      )
+    )
+      return;
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not an op route" }));
+  };
+  const server = createServer((req, res) => {
+    handler(req, res).catch((error: unknown) => {
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+      }
+      res.end(
+        JSON.stringify({
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      );
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const { port } = server.address() as AddressInfo;
+    const response = await fetch(`http://127.0.0.1:${port}/op`, {
+      method,
+      headers: opts.request.contentType
+        ? { "Content-Type": opts.request.contentType }
+        : {},
+      body: opts.request.body,
+    });
+    return {
+      status: response.status,
+      contentType: response.headers.get("content-type") ?? "application/json",
+      body: await response.text(),
+      events,
+    };
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}

--- a/packages/host/src/op/dispatch.ts
+++ b/packages/host/src/op/dispatch.ts
@@ -32,6 +32,10 @@ export interface AgentOpRequest {
 }
 
 export interface AgentOpResponse {
+  /** The hydrated tree holds no such agent: the worker must NOT relay this
+   *  as the handler's answer (a legacy layout, a stale envelope) — it declines
+   *  so the gateway takes the proxy path instead. */
+  agentMissing?: true;
   status: number;
   contentType: string;
   body: string;
@@ -53,20 +57,13 @@ export async function dispatchAgentOp(opts: {
 }): Promise<AgentOpResponse> {
   const store = new LocalWorkspaceStore(opts.workspacesRoot);
   const agent = await store.getAgent(opts.agentId);
-  if (!agent) {
+  const workspace = agent ? await store.getWorkspace(agent.workspaceId) : null;
+  if (!agent || !workspace) {
     return {
+      agentMissing: true,
       status: 404,
       contentType: "application/json",
       body: JSON.stringify({ error: "agent not found" }),
-      events: [],
-    };
-  }
-  const workspace = await store.getWorkspace(agent.workspaceId);
-  if (!workspace) {
-    return {
-      status: 404,
-      contentType: "application/json",
-      body: JSON.stringify({ error: "workspace not found" }),
       events: [],
     };
   }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -17,6 +17,7 @@
     "@earendil-works/pi-coding-agent": "0.84.2",
     "@google-cloud/storage": "7.21.0",
     "@houston/domain": "workspace:*",
+    "@houston/host": "workspace:*",
     "@houston/protocol": "workspace:*",
     "@houston/runtime-client": "workspace:*",
     "tsx": "4.23.0",

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -62,7 +62,7 @@ export async function executeOp(
   const turnLike = {
     ...op,
     conversationId:
-      op.op.kind === "conversation" ? op.op.conversationId : "__agent_ops__",
+      op.op.kind === "conversation" ? op.op.conversationId : AGENT_OPS_CLAIM_ID,
   };
   const heartbeat = startClaimHeartbeat({
     claim: op.claim,

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -1,0 +1,214 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  docKey,
+  type HoustonFamily,
+  normalizeActivities,
+  normalizeLearnings,
+  normalizeRoutineRuns,
+  normalizeRoutines,
+} from "@houston/domain";
+import type { HoustonEvent } from "@houston/protocol";
+import { syncBack } from "@houston/runtime-client/object-sync";
+import { startClaimHeartbeat } from "./claim-heartbeat";
+import { applyOp, type OpResult } from "./op-apply";
+import { opTranscriptMirror } from "./op-transcript";
+import { parseOpRequest } from "./parse-op-request";
+import type { TurnServerDeps } from "./server-types";
+import { publish } from "./turn-activity-doc";
+import { prepareTurnFilesystem, type TurnFilesystem } from "./turn-filesystem";
+import { poolIdentity, resolveTurnStore } from "./turn-store";
+
+const EVENT_FAMILY: Partial<Record<HoustonEvent["type"], HoustonFamily>> = {
+  ActivityChanged: "activity",
+  RoutinesChanged: "routines",
+  RoutineRunsChanged: "routine_runs",
+  ConfigChanged: "config",
+  LearningsChanged: "learnings",
+};
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+/**
+ * POST /op — a write for a sleeping agent, executed here instead of on its
+ * pod: claim → hydrate → the real handler → scoped sync-back → doc republish.
+ * Answers the handler's own status and body inside `{ok, status, body}` so
+ * the gateway relays exactly what the pod would have said.
+ */
+export async function executeOp(
+  deps: TurnServerDeps,
+  _req: IncomingMessage,
+  res: ServerResponse,
+  body: unknown,
+): Promise<void> {
+  let op: ReturnType<typeof parseOpRequest>;
+  try {
+    op = parseOpRequest(body);
+  } catch (error) {
+    return json(res, 400, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  const root = await mkdtemp(join(tmpdir(), "houston-op-"));
+  const abort = new AbortController();
+  const turnLike = {
+    ...op,
+    conversationId:
+      op.op.kind === "conversation" ? op.op.conversationId : "__agent_ops__",
+  };
+  const heartbeat = startClaimHeartbeat({
+    claim: op.claim,
+    hostToken: op.hostToken,
+    onFenced: () => abort.abort(),
+    ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+    ...(deps.heartbeatIntervalMs
+      ? { intervalMs: deps.heartbeatIntervalMs }
+      : {}),
+  });
+  try {
+    const resolved = resolveTurnStore(turnLike, deps.store, {
+      poolStoreUrl: deps.poolStoreUrl,
+      fetchImpl: deps.fetchImpl,
+    });
+    const filesystem = await prepareTurnFilesystem({
+      store: resolved.store,
+      prefix: resolved.prefix,
+      root,
+      claimed: true,
+      ...(deps.maxHydrateBytes !== undefined
+        ? { maxBytes: deps.maxHydrateBytes }
+        : {}),
+    });
+    const result = await applyOp(op, filesystem, deps.fetchImpl);
+    await heartbeat.checkpoint();
+    if (heartbeat.fenced) return json(res, 409, { error: "claim_fenced" });
+    const synced = await syncBack(
+      resolved.store,
+      resolved.prefix,
+      filesystem.storeRoot,
+      filesystem.manifest,
+      {
+        include: result.include,
+      },
+    );
+    if (synced.outOfScope > 0) {
+      console.info(
+        `[op] pool_writes_out_of_scope=${synced.outOfScope} prefix=${resolved.prefix} kind=${op.op.kind}`,
+      );
+    }
+    const diagnostics: string[] = [];
+    if (result.status < 300) {
+      diagnostics.push(
+        ...(await republish(deps, turnLike, filesystem, result)),
+      );
+      if (op.op.kind === "conversation") {
+        diagnostics.push(...(await opTranscriptMirror(deps, turnLike, op.op)));
+      }
+    }
+    json(res, 200, {
+      ok: true,
+      status: result.status,
+      contentType: result.contentType,
+      body: result.body,
+      events: result.events.map((e) => e.type),
+      ...(diagnostics.length ? { diagnostics } : {}),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!res.headersSent) json(res, 500, { error: message });
+  } finally {
+    try {
+      await heartbeat.stop();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+}
+
+/** Re-project every family the op changed, plus the skills view. */
+async function republish(
+  deps: TurnServerDeps,
+  turn: {
+    gcsPrefix: string;
+    hostToken: string;
+    claim: { token: string; bootId: string };
+    conversationId: string;
+  },
+  filesystem: TurnFilesystem,
+  result: OpResult,
+): Promise<string[]> {
+  const diagnostics: string[] = [];
+  const baseUrl = deps.poolStoreUrl ?? process.env.HOUSTON_POOL_STORE_URL;
+  if (!baseUrl) return diagnostics;
+  const { org, agent } = poolIdentity(turn.gcsPrefix);
+  const common = {
+    baseUrl,
+    org,
+    agent,
+    conversationId: turn.conversationId,
+    hostToken: turn.hostToken,
+    claim: turn.claim,
+    fetchImpl: deps.fetchImpl ?? fetch,
+  };
+  const families = new Set<HoustonFamily>();
+  let skills = false;
+  for (const event of result.events) {
+    const family = EVENT_FAMILY[event.type];
+    if (family) families.add(family);
+    if (event.type === "SkillsChanged") skills = true;
+  }
+  for (const family of families) {
+    const key = docKey(filesystem.workspaceRel, family);
+    let doc: unknown;
+    try {
+      const raw = await readFile(join(filesystem.storeRoot, key), "utf8");
+      doc = normalizeFamily(
+        family,
+        JSON.parse(raw.replace(/^\uFEFF/, "")),
+        key,
+      );
+    } catch {
+      doc = family === "config" ? {} : [];
+    }
+    const outcome = await publish({ ...common, family }, doc);
+    if ("error" in outcome) diagnostics.push(`${family}: ${outcome.error}`);
+  }
+  if (skills && result.skillsView !== undefined) {
+    const outcome = await publish(
+      { ...common, family: "skills" },
+      result.skillsView,
+    );
+    if ("error" in outcome) diagnostics.push(`skills: ${outcome.error}`);
+  }
+  return diagnostics;
+}
+
+function normalizeFamily(
+  family: HoustonFamily,
+  parsed: unknown,
+  key: string,
+): unknown {
+  switch (family) {
+    case "activity":
+      return normalizeActivities(parsed, key).items;
+    case "routines":
+      return normalizeRoutines(parsed, key).items;
+    case "routine_runs":
+      return normalizeRoutineRuns(parsed, key).items;
+    case "learnings":
+      return normalizeLearnings(parsed, key).items;
+    case "config":
+      return parsed !== null &&
+        typeof parsed === "object" &&
+        !Array.isArray(parsed)
+        ? parsed
+        : {};
+    default:
+      return parsed;
+  }
+}

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -21,6 +21,9 @@ import { publish } from "./turn-activity-doc";
 import { prepareTurnFilesystem, type TurnFilesystem } from "./turn-filesystem";
 import { poolIdentity, resolveTurnStore } from "./turn-store";
 
+/** Reserved claim key for agent-level writes (gateway + pod-store agree). */
+export const AGENT_OPS_CLAIM_ID = "agent-ops";
+
 const EVENT_FAMILY: Partial<Record<HoustonEvent["type"], HoustonFamily>> = {
   ActivityChanged: "activity",
   RoutinesChanged: "routines",

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -88,6 +88,11 @@ export async function executeOp(
         : {}),
     });
     const result = await applyOp(op, filesystem, deps.fetchImpl);
+    if (result.agentMissing) {
+      // Not this worker's agent (legacy layout / stale envelope): decline so
+      // the gateway proxies, never relay a spurious 404 as the pod's answer.
+      return json(res, 200, { ok: true, decline: true });
+    }
     await heartbeat.checkpoint();
     if (heartbeat.fenced) return json(res, 409, { error: "claim_fenced" });
     const synced = await syncBack(

--- a/packages/runtime/src/turn/op-apply.ts
+++ b/packages/runtime/src/turn/op-apply.ts
@@ -21,6 +21,8 @@ export interface OpResult {
   include: (relativePath: string) => boolean;
   /** The pod's own /skills answer after a skills mutation (the skills view). */
   skillsView?: unknown;
+  /** The hydrated tree had no such agent — decline, do not relay. */
+  agentMissing?: boolean;
 }
 
 const json = (
@@ -32,22 +34,14 @@ const json = (
   body: JSON.stringify(value),
 });
 
-/** Everything an agent-level route may touch: the `.houston` family files,
- *  skills, and the agent's markdown — never the runtime tree (conversations,
- *  sessions, auth) and never user files. Mirrors the pod-store's ops-claim
- *  scope exactly. */
+/** Everything an agent-level route may touch: the agent's whole directory
+ *  (family files, skills, markdown, any agentfile path the pod would
+ *  accept) — never the runtime tree (conversations, sessions, auth), which
+ *  stays conversation-scoped. Mirrors the pod-store's ops-claim scope. */
 export function agentRouteScope(workspaceRel: string): OpResult["include"] {
-  const houston = `${posix.join(workspaceRel, ".houston")}/`;
+  const root = `${workspaceRel}/`;
   const runtime = `${posix.join(workspaceRel, ".houston", "runtime")}/`;
-  const agents = `${posix.join(workspaceRel, ".agents")}/`;
-  const files = new Set([
-    posix.join(workspaceRel, "CLAUDE.md"),
-    posix.join(workspaceRel, "GROUP.md"),
-  ]);
-  return (rel) =>
-    files.has(rel) ||
-    rel.startsWith(agents) ||
-    (rel.startsWith(houston) && !rel.startsWith(runtime));
+  return (rel) => rel.startsWith(root) && !rel.startsWith(runtime);
 }
 
 /** One conversation's file + sessions. */
@@ -90,7 +84,17 @@ export async function applyOp(
           rest: op.op.rest,
           ...(op.op.body !== undefined ? { body: op.op.body } : {}),
           ...(op.op.contentType ? { contentType: op.op.contentType } : {}),
-          ...(op.actingAs ? { actingSub: op.actingAs.userId } : {}),
+          ...(op.actingAs
+            ? {
+                actingSub: op.actingAs.userId,
+                // Gateway-fronted: the acting human is a full contributor on
+                // missions, exactly as the pod stamps it from the acting header.
+                actingAuthor: {
+                  user_id: op.actingAs.userId,
+                  ...(op.actingAs.name ? { name: op.actingAs.name } : {}),
+                },
+              }
+            : {}),
           triggersEnabled: op.triggersEnabled,
         },
         ...(fetchImpl ? { fetchImpl } : {}),

--- a/packages/runtime/src/turn/op-apply.ts
+++ b/packages/runtime/src/turn/op-apply.ts
@@ -32,18 +32,22 @@ const json = (
   body: JSON.stringify(value),
 });
 
-/** Everything an agent-level route may touch: the `.houston` tree, skills,
- *  and the agent's markdown — never conversations or user files. */
+/** Everything an agent-level route may touch: the `.houston` family files,
+ *  skills, and the agent's markdown — never the runtime tree (conversations,
+ *  sessions, auth) and never user files. Mirrors the pod-store's ops-claim
+ *  scope exactly. */
 export function agentRouteScope(workspaceRel: string): OpResult["include"] {
-  const prefixes = [
-    `${posix.join(workspaceRel, ".houston")}/`,
-    `${posix.join(workspaceRel, ".agents")}/`,
-  ];
+  const houston = `${posix.join(workspaceRel, ".houston")}/`;
+  const runtime = `${posix.join(workspaceRel, ".houston", "runtime")}/`;
+  const agents = `${posix.join(workspaceRel, ".agents")}/`;
   const files = new Set([
     posix.join(workspaceRel, "CLAUDE.md"),
     posix.join(workspaceRel, "GROUP.md"),
   ]);
-  return (rel) => files.has(rel) || prefixes.some((p) => rel.startsWith(p));
+  return (rel) =>
+    files.has(rel) ||
+    rel.startsWith(agents) ||
+    (rel.startsWith(houston) && !rel.startsWith(runtime));
 }
 
 /** One conversation's file + sessions. */

--- a/packages/runtime/src/turn/op-apply.ts
+++ b/packages/runtime/src/turn/op-apply.ts
@@ -1,0 +1,177 @@
+import { rm } from "node:fs/promises";
+import { join, posix } from "node:path";
+import { dispatchAgentOp } from "@houston/host/src/op/dispatch";
+import type { HoustonEvent } from "@houston/protocol";
+import { applyServedCredential } from "../auth/auth-file";
+import { generateTitle } from "../session/summarize";
+import {
+  deleteConversationAt,
+  renameConversationMutationAt,
+} from "../store/conversation-file";
+import type { OpRequest } from "./parse-op-request";
+import type { TurnFilesystem } from "./turn-filesystem";
+import { createTurnModelRuntime } from "./turn-runtime";
+
+export interface OpResult {
+  status: number;
+  contentType: string;
+  body: string;
+  events: HoustonEvent[];
+  /** Store-relative paths this op may have written (the sync-back scope). */
+  include: (relativePath: string) => boolean;
+  /** The pod's own /skills answer after a skills mutation (the skills view). */
+  skillsView?: unknown;
+}
+
+const json = (
+  status: number,
+  value: unknown,
+): Omit<OpResult, "include" | "events"> => ({
+  status,
+  contentType: "application/json",
+  body: JSON.stringify(value),
+});
+
+/** Everything an agent-level route may touch: the `.houston` tree, skills,
+ *  and the agent's markdown — never conversations or user files. */
+export function agentRouteScope(workspaceRel: string): OpResult["include"] {
+  const prefixes = [
+    `${posix.join(workspaceRel, ".houston")}/`,
+    `${posix.join(workspaceRel, ".agents")}/`,
+  ];
+  const files = new Set([
+    posix.join(workspaceRel, "CLAUDE.md"),
+    posix.join(workspaceRel, "GROUP.md"),
+  ]);
+  return (rel) => files.has(rel) || prefixes.some((p) => rel.startsWith(p));
+}
+
+/** One conversation's file + sessions. */
+export function conversationScope(
+  dataRel: string,
+  cid: string,
+): OpResult["include"] {
+  const file = posix.join(
+    dataRel,
+    "conversations",
+    `${encodeURIComponent(cid)}.json`,
+  );
+  const sessions = `${posix.join(dataRel, "sessions", cid)}/`;
+  return (rel) => rel === file || rel.startsWith(sessions);
+}
+
+export async function applyOp(
+  op: OpRequest,
+  filesystem: TurnFilesystem,
+  fetchImpl?: typeof fetch,
+): Promise<OpResult> {
+  switch (op.op.kind) {
+    case "route": {
+      const result = await dispatchAgentOp({
+        workspacesRoot: join(filesystem.storeRoot, "workspaces"),
+        agentId: op.agentId,
+        request: {
+          method: op.op.method,
+          rest: op.op.rest,
+          ...(op.op.body !== undefined ? { body: op.op.body } : {}),
+          ...(op.op.contentType ? { contentType: op.op.contentType } : {}),
+          ...(op.actingAs ? { actingSub: op.actingAs.userId } : {}),
+          triggersEnabled: op.triggersEnabled,
+        },
+        ...(fetchImpl ? { fetchImpl } : {}),
+      });
+      const out: OpResult = {
+        ...result,
+        include: agentRouteScope(filesystem.workspaceRel),
+      };
+      if (result.events.some((e) => e.type === "SkillsChanged")) {
+        // Re-capture the skills view the way the pod would serve it, so the
+        // gateway's asleep reads show the install/remove immediately.
+        const view = await dispatchAgentOp({
+          workspacesRoot: join(filesystem.storeRoot, "workspaces"),
+          agentId: op.agentId,
+          request: {
+            method: "GET",
+            rest: "skills",
+            triggersEnabled: op.triggersEnabled,
+          },
+          ...(fetchImpl ? { fetchImpl } : {}),
+        });
+        if (view.status === 200) {
+          try {
+            out.skillsView = JSON.parse(view.body);
+          } catch {
+            /* not JSON: leave the previous view */
+          }
+        }
+      }
+      return out;
+    }
+    case "title": {
+      const none = () => false;
+      if (!op.credential) {
+        return {
+          ...json(503, { error: "no credential for title" }),
+          events: [],
+          include: none,
+        };
+      }
+      if (op.credential.provider === "anthropic") {
+        // COMPLIANCE GATE: anthropic titles must go through the Claude SDK
+        // (never pi in-process); that path is pod-only, so a cold anthropic
+        // agent keeps the client's truncated-title fallback.
+        return {
+          ...json(503, { error: "anthropic titles run on the pod" }),
+          events: [],
+          include: none,
+        };
+      }
+      const { dataDir, workspaceDir } = filesystem;
+      applyServedCredential(join(dataDir, "auth.json"), op.credential);
+      const { modelRuntime, model } = await createTurnModelRuntime(
+        dataDir,
+        op.credential.provider,
+      );
+      const title = await generateTitle({
+        cwd: workspaceDir,
+        model,
+        modelRuntime,
+        excerpt: op.op.text.trim().slice(0, 2400),
+      });
+      return { ...json(200, { title }), events: [], include: none };
+    }
+    case "conversation": {
+      const { conversationId, action } = op.op;
+      const dir = join(filesystem.dataDir, "conversations");
+      const include = conversationScope(filesystem.dataRel, conversationId);
+      // The runtime's own directory-scoped mutations — the pod's PATCH/DELETE
+      // call the same functions against its live data dir.
+      const found =
+        action === "rename"
+          ? renameConversationMutationAt(
+              dir,
+              conversationId,
+              op.op.title ?? "",
+            ) !== null
+          : deleteConversationAt(dir, conversationId);
+      if (!found) {
+        return {
+          ...json(404, { error: "conversation not found" }),
+          events: [],
+          include,
+        };
+      }
+      if (action === "delete") {
+        await rm(join(filesystem.dataDir, "sessions", conversationId), {
+          recursive: true,
+          force: true,
+        });
+      }
+      return {
+        ...json(200, { ok: true }),
+        events: [{ type: "ConversationsChanged", agentPath: op.agentId }],
+        include,
+      };
+    }
+  }
+}

--- a/packages/runtime/src/turn/op-apply.ts
+++ b/packages/runtime/src/turn/op-apply.ts
@@ -100,7 +100,7 @@ export async function applyOp(
         // gateway's asleep reads show the install/remove immediately.
         const view = await dispatchAgentOp({
           workspacesRoot: join(filesystem.storeRoot, "workspaces"),
-          agentId: op.agentId,
+          agentId,
           request: {
             method: "GET",
             rest: "skills",

--- a/packages/runtime/src/turn/op-apply.ts
+++ b/packages/runtime/src/turn/op-apply.ts
@@ -60,16 +60,27 @@ export function conversationScope(
   return (rel) => rel === file || rel.startsWith(sessions);
 }
 
+/**
+ * The engine's agent id ("Workspace/Agent") from the hydrated layout. The
+ * gateway's envelope names the agent by SLUG; turns never need the engine
+ * id (the layout resolver finds the single agent), but the host handlers
+ * address the agent by its id — so it is derived here, never trusted.
+ */
+export function engineAgentId(filesystem: TurnFilesystem): string {
+  return filesystem.workspaceRel.replace(/^workspaces\//, "");
+}
+
 export async function applyOp(
   op: OpRequest,
   filesystem: TurnFilesystem,
   fetchImpl?: typeof fetch,
 ): Promise<OpResult> {
+  const agentId = engineAgentId(filesystem);
   switch (op.op.kind) {
     case "route": {
       const result = await dispatchAgentOp({
         workspacesRoot: join(filesystem.storeRoot, "workspaces"),
-        agentId: op.agentId,
+        agentId,
         request: {
           method: op.op.method,
           rest: op.op.rest,
@@ -169,7 +180,7 @@ export async function applyOp(
       }
       return {
         ...json(200, { ok: true }),
-        events: [{ type: "ConversationsChanged", agentPath: op.agentId }],
+        events: [{ type: "ConversationsChanged", agentPath: agentId }],
         include,
       };
     }

--- a/packages/runtime/src/turn/op-transcript.ts
+++ b/packages/runtime/src/turn/op-transcript.ts
@@ -1,0 +1,53 @@
+import { fetchWithRetry } from "@houston/runtime-client/object-sync";
+import type { AgentOp } from "./parse-op-request";
+import type { TurnServerDeps } from "./server-types";
+import { poolIdentity } from "./turn-store";
+
+/**
+ * Mirror a conversation rename/delete into the durable transcript store —
+ * the same PUT/DELETE the pod's transcript shadow issues — so the gateway's
+ * Postgres-served conversation list reflects the op immediately. The claim
+ * is conversation-scoped (the op claimed this conversation), so the store's
+ * claim authorization admits it.
+ */
+export async function opTranscriptMirror(
+  deps: TurnServerDeps,
+  turn: {
+    gcsPrefix: string;
+    hostToken: string;
+    claim: { token: string; bootId: string };
+    conversationId: string;
+  },
+  op: Extract<AgentOp, { kind: "conversation" }>,
+): Promise<string[]> {
+  const baseUrl = deps.poolStoreUrl ?? process.env.HOUSTON_POOL_STORE_URL;
+  if (!baseUrl) return [];
+  const { org, agent } = poolIdentity(turn.gcsPrefix);
+  const url = `${baseUrl.replace(/\/+$/, "")}/v1/pod/transcripts/${encodeURIComponent(org)}/${encodeURIComponent(agent)}/conversations/${encodeURIComponent(op.conversationId)}`;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const response = await fetchWithRetry(
+    (input, init) =>
+      fetchImpl(input, { ...init, signal: AbortSignal.timeout(5_000) }),
+    url,
+    {
+      method: op.action === "rename" ? "PUT" : "DELETE",
+      headers: {
+        Authorization: `Bearer ${turn.hostToken}`,
+        "X-Houston-Claim-Token": turn.claim.token,
+        "X-Houston-Claim-Boot": turn.claim.bootId,
+        "X-Houston-Claim-Conversation": turn.conversationId,
+        ...(op.action === "rename"
+          ? { "Content-Type": "application/json" }
+          : {}),
+      },
+      ...(op.action === "rename"
+        ? { body: JSON.stringify({ title: op.title ?? "" }) }
+        : {}),
+    },
+  );
+  await response.body?.cancel();
+  // 404 on a conversation the transcript store never held is not a failure
+  // (file-era conversation, or already gone).
+  if (response.ok || response.status === 404) return [];
+  return [`transcript ${op.action} rejected (${response.status})`];
+}

--- a/packages/runtime/src/turn/parse-op-request.test.ts
+++ b/packages/runtime/src/turn/parse-op-request.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "vitest";
+import { parseOpRequest } from "./parse-op-request";
+
+test("op.rest must be an op-route shape; a runtime agentfile path is refused", () => {
+  const base = {
+    workspaceId: "w1",
+    agentId: "a1",
+    gcsPrefix: "ws/w1/a1",
+    hostToken: "ht",
+    claim: { id: "c", bootId: "b", token: "t", heartbeatUrl: "http://x/hb" },
+  };
+  const routeOp = (rest: string, method = "PUT") => ({
+    ...base,
+    op: {
+      kind: "route",
+      method,
+      rest,
+      contentType: "application/json",
+      body: "{}",
+    },
+  });
+  expect(() =>
+    parseOpRequest(routeOp("agentfile/data-schema.md")),
+  ).not.toThrow();
+  expect(() => parseOpRequest(routeOp("routines", "POST"))).not.toThrow();
+  expect(() =>
+    parseOpRequest(routeOp("agentfile/.houston/runtime/auth.json")),
+  ).toThrow(/not an op route/);
+  expect(() =>
+    parseOpRequest(routeOp("conversations/c1/messages", "POST")),
+  ).toThrow(/not an op route/);
+});

--- a/packages/runtime/src/turn/parse-op-request.ts
+++ b/packages/runtime/src/turn/parse-op-request.ts
@@ -37,6 +37,16 @@ export interface OpRequest {
 
 const ID = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$/;
 
+function parseActing(raw: unknown): TurnRequest["actingAs"] {
+  if (!raw || typeof raw !== "object") return undefined;
+  const a = raw as { userId?: unknown; name?: unknown };
+  if (typeof a.userId !== "string" || !a.userId) return undefined;
+  return {
+    userId: a.userId,
+    ...(typeof a.name === "string" && a.name ? { name: a.name } : {}),
+  };
+}
+
 function str(v: unknown, field: string): string {
   if (typeof v !== "string" || !v.length) throw new Error(`invalid '${field}'`);
   return v;
@@ -131,12 +141,8 @@ export function parseOpRequest(body: unknown): OpRequest {
       token: str(claim.token, "claim.token"),
       heartbeatUrl: str(claim.heartbeatUrl, "claim.heartbeatUrl"),
     },
-    actingAs:
-      b.actingAs &&
-      typeof b.actingAs === "object" &&
-      typeof (b.actingAs as { userId?: unknown }).userId === "string"
-        ? { userId: (b.actingAs as { userId: string }).userId }
-        : undefined,
+    actingAs: parseActing(b.actingAs),
+
     credential,
     triggersEnabled: b.triggersEnabled === true,
     op,

--- a/packages/runtime/src/turn/parse-op-request.ts
+++ b/packages/runtime/src/turn/parse-op-request.ts
@@ -1,0 +1,144 @@
+import type { ServedCredential } from "../auth/auth-file";
+import type { TurnRequest } from "./types";
+
+/**
+ * An OP is a write the gateway routes to a pool worker instead of waking the
+ * agent's pod: the same claim/host-token envelope as a turn, plus the
+ * operation. `route` ops run the host's own route handlers against the
+ * hydrated workspace; `title` and `conversation` ops are the runtime's own.
+ */
+export type AgentOp =
+  | {
+      kind: "route";
+      method: string;
+      rest: string;
+      body?: string;
+      contentType?: string;
+    }
+  | { kind: "title"; text: string }
+  | {
+      kind: "conversation";
+      action: "rename" | "delete";
+      conversationId: string;
+      title?: string;
+    };
+
+export interface OpRequest {
+  workspaceId: string;
+  agentId: string;
+  gcsPrefix: string;
+  hostToken: string;
+  claim: NonNullable<TurnRequest["claim"]>;
+  actingAs?: TurnRequest["actingAs"];
+  credential: ServedCredential | null;
+  triggersEnabled: boolean;
+  op: AgentOp;
+}
+
+const ID = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$/;
+
+function str(v: unknown, field: string): string {
+  if (typeof v !== "string" || !v.length) throw new Error(`invalid '${field}'`);
+  return v;
+}
+
+export function parseOpRequest(body: unknown): OpRequest {
+  const b = body as Record<string, unknown>;
+  if (!b || typeof b !== "object")
+    throw new Error("body must be a JSON object");
+  const claim = b.claim as Record<string, unknown> | undefined;
+  if (!claim || typeof claim !== "object")
+    throw new Error("ops require a claim");
+  const hostToken = str(b.hostToken, "hostToken");
+  const gcsPrefix = str(b.gcsPrefix, "gcsPrefix");
+  if (gcsPrefix.split("/").length !== 3 || !gcsPrefix.startsWith("ws/")) {
+    throw new Error("invalid 'gcsPrefix'");
+  }
+  const agentId = str(b.agentId, "agentId");
+  if (!ID.test(agentId)) throw new Error("invalid 'agentId'");
+  let credential: ServedCredential | null = null;
+  if (b.credential != null) {
+    const c = b.credential as Record<string, unknown>;
+    if (
+      typeof c.provider !== "string" ||
+      typeof c.access !== "string" ||
+      typeof c.expires !== "number"
+    ) {
+      throw new Error("invalid 'credential'");
+    }
+    credential = {
+      provider: c.provider,
+      access: c.access,
+      expires: c.expires,
+      accountId: typeof c.accountId === "string" ? c.accountId : null,
+      kind: c.kind === "api_key" ? "api_key" : "oauth",
+    };
+  }
+  const raw = b.op as Record<string, unknown> | undefined;
+  if (!raw || typeof raw !== "object") throw new Error("invalid 'op'");
+  let op: AgentOp;
+  switch (raw.kind) {
+    case "route": {
+      const method = str(raw.method, "op.method").toUpperCase();
+      if (!["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+        throw new Error("op.method must be a write method");
+      }
+      const rest = str(raw.rest, "op.rest");
+      if (rest.includes("..") || rest.startsWith("/"))
+        throw new Error("invalid 'op.rest'");
+      op = {
+        kind: "route",
+        method,
+        rest,
+        ...(typeof raw.body === "string" ? { body: raw.body } : {}),
+        ...(typeof raw.contentType === "string"
+          ? { contentType: raw.contentType }
+          : {}),
+      };
+      break;
+    }
+    case "title":
+      op = { kind: "title", text: str(raw.text, "op.text") };
+      break;
+    case "conversation": {
+      const action = raw.action;
+      if (action !== "rename" && action !== "delete")
+        throw new Error("invalid 'op.action'");
+      const conversationId = str(raw.conversationId, "op.conversationId");
+      if (!ID.test(conversationId))
+        throw new Error("invalid 'op.conversationId'");
+      if (action === "rename" && typeof raw.title !== "string")
+        throw new Error("rename needs 'op.title'");
+      op = {
+        kind: "conversation",
+        action,
+        conversationId,
+        ...(typeof raw.title === "string" ? { title: raw.title } : {}),
+      };
+      break;
+    }
+    default:
+      throw new Error("invalid 'op.kind'");
+  }
+  return {
+    workspaceId: str(b.workspaceId, "workspaceId"),
+    agentId,
+    gcsPrefix,
+    hostToken,
+    claim: {
+      id: str(claim.id, "claim.id"),
+      bootId: str(claim.bootId, "claim.bootId"),
+      token: str(claim.token, "claim.token"),
+      heartbeatUrl: str(claim.heartbeatUrl, "claim.heartbeatUrl"),
+    },
+    actingAs:
+      b.actingAs &&
+      typeof b.actingAs === "object" &&
+      typeof (b.actingAs as { userId?: unknown }).userId === "string"
+        ? { userId: (b.actingAs as { userId: string }).userId }
+        : undefined,
+    credential,
+    triggersEnabled: b.triggersEnabled === true,
+    op,
+  };
+}

--- a/packages/runtime/src/turn/parse-op-request.ts
+++ b/packages/runtime/src/turn/parse-op-request.ts
@@ -37,6 +37,11 @@ export interface OpRequest {
 
 const ID = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$/;
 
+// The op-route shapes (mirrors the Go classifier): the agent-data families,
+// agentfile writes, and skills (install + manage), never a runtime path.
+const OP_ROUTE =
+  /^(activities|routines|routine_runs|learnings|config)(\/[^/]+)?$|^agentfile\/(?!\.houston\/runtime\/).+$|^skills(\/[^/]+)?$|^skills\/(community|repo)\/install$/;
+
 function parseActing(raw: unknown): TurnRequest["actingAs"] {
   if (!raw || typeof raw !== "object") return undefined;
   const a = raw as { userId?: unknown; name?: unknown };
@@ -96,6 +101,10 @@ export function parseOpRequest(body: unknown): OpRequest {
       const rest = str(raw.rest, "op.rest");
       if (rest.includes("..") || rest.startsWith("/"))
         throw new Error("invalid 'op.rest'");
+      // Defense in depth: the worker accepts only the op-route shapes the
+      // gateway classifier dispatches — a valid-token caller cannot reach a
+      // handler surface (e.g. POST agentfile) the public path never exposes.
+      if (!OP_ROUTE.test(rest)) throw new Error("op.rest is not an op route");
       op = {
         kind: "route",
         method,

--- a/packages/runtime/src/turn/server-op.test.ts
+++ b/packages/runtime/src/turn/server-op.test.ts
@@ -56,10 +56,12 @@ async function heartbeatOK(): Promise<string> {
   );
 }
 
-function opBody(agentId: string, heartbeatUrl: string, op: unknown) {
+function opBody(_agentId: string, heartbeatUrl: string, op: unknown) {
   return {
     workspaceId: "w1",
-    agentId,
+    // The gateway sends the agent SLUG; the worker derives the engine id
+    // ("Personal/Bob") from the hydrated layout.
+    agentId: "agent-1",
     gcsPrefix: "ws/w1/agent-1",
     hostToken: "host-token",
     claim: {

--- a/packages/runtime/src/turn/server-op.test.ts
+++ b/packages/runtime/src/turn/server-op.test.ts
@@ -188,3 +188,52 @@ test("an invalid op is rejected before any hydration", async () => {
   expect(status).toBe(400);
   expect(String(json.error)).toContain("write method");
 });
+
+test("a root-level agentfile write persists (F6: no longer dropped)", async () => {
+  const { storeRoot, agentId, prefix } = await seedAgent();
+  const store = new LocalDirStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const { json } = await postOp(
+    base,
+    opBody(agentId, await heartbeatOK(), {
+      kind: "route",
+      method: "PUT",
+      rest: "agentfile/data-schema.md",
+      contentType: "application/json",
+      body: JSON.stringify({ content: "# schema" }),
+    }),
+  );
+  expect(json.ok).toBe(true);
+  expect(json.decline).toBeUndefined();
+  // The whole-agent-dir scope carried it to the store (before, it was dropped).
+  const synced = await store.list(prefix);
+  expect(synced.some((k) => k.endsWith("/data-schema.md"))).toBe(true);
+});
+
+test("mission attribution (actingAs.name) reaches the activity handler", async () => {
+  const { storeRoot, agentId } = await seedAgent();
+  const store = new LocalDirStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const body = opBody(agentId, await heartbeatOK(), {
+    kind: "route",
+    method: "POST",
+    rest: "activities",
+    contentType: "application/json",
+    body: JSON.stringify({ title: "Draft the memo", status: "needs_you" }),
+  });
+  (body.actingAs as { name?: string }).name = "Alice Lee";
+  const { json } = await postOp(base, body);
+  expect(json.status).toBe(201);
+  const created = JSON.parse(json.body as string) as {
+    created_by?: string;
+    contributors?: Array<{ user_id: string; name?: string }>;
+  };
+  expect(created.created_by).toBe("user-1");
+  expect(created.contributors).toEqual([
+    { user_id: "user-1", name: "Alice Lee" },
+  ]);
+});

--- a/packages/runtime/src/turn/server-op.test.ts
+++ b/packages/runtime/src/turn/server-op.test.ts
@@ -1,0 +1,188 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { LocalWorkspaceStore } from "@houston/host/src/store/local";
+import { LocalDirStore } from "@houston/runtime-client/object-sync";
+import { afterEach, expect, test } from "vitest";
+import { createTurnServer } from "./server";
+import type { runPiTurn } from "./turn-session";
+
+const servers: Server[] = [];
+afterEach(() => {
+  for (const s of servers.splice(0)) s.close();
+});
+
+async function listen(server: Server): Promise<string> {
+  servers.push(server);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+}
+
+const noopTurn: typeof runPiTurn = async () => ({});
+
+/** An agent seeded through the host's own store (the pod's real layout). */
+async function seedAgent(): Promise<{
+  storeRoot: string;
+  agentId: string;
+  prefix: string;
+}> {
+  const storeRoot = mkdtempSync(join(tmpdir(), "op-store-"));
+  const prefix = "ws/w1/agent-1";
+  const workspaces = join(storeRoot, prefix, "workspaces");
+  const store = new LocalWorkspaceStore(workspaces);
+  const ws = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({ workspaceId: ws.id, name: "Bob" });
+  // The standing layout marker the turn layout resolver keys on.
+  const settings = join(
+    workspaces,
+    ...agent.id.split("/"),
+    ".houston",
+    "runtime",
+    "settings.json",
+  );
+  mkdirSync(dirname(settings), { recursive: true });
+  writeFileSync(settings, "{}");
+  return { storeRoot, agentId: agent.id, prefix };
+}
+
+async function heartbeatOK(): Promise<string> {
+  return listen(
+    createServer((_req, res) => {
+      res.writeHead(200);
+      res.end("{}");
+    }),
+  );
+}
+
+function opBody(agentId: string, heartbeatUrl: string, op: unknown) {
+  return {
+    workspaceId: "w1",
+    agentId,
+    gcsPrefix: "ws/w1/agent-1",
+    hostToken: "host-token",
+    claim: {
+      id: "claim-1",
+      bootId: "boot-1",
+      token: "claim-token",
+      heartbeatUrl,
+    },
+    actingAs: { userId: "user-1" },
+    triggersEnabled: false,
+    op,
+  };
+}
+
+async function postOp(base: string, body: unknown) {
+  const response = await fetch(`${base}/op`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return {
+    status: response.status,
+    json: (await response.json()) as Record<string, unknown>,
+  };
+}
+
+test("a routine create runs on the worker and syncs the file back to the store", async () => {
+  const { storeRoot, agentId, prefix } = await seedAgent();
+  const store = new LocalDirStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const { status, json } = await postOp(
+    base,
+    opBody(agentId, await heartbeatOK(), {
+      kind: "route",
+      method: "POST",
+      rest: "routines",
+      contentType: "application/json",
+      body: JSON.stringify({
+        name: "Digest",
+        prompt: "p",
+        schedule: "0 9 * * *",
+        enabled: true,
+      }),
+    }),
+  );
+  expect(status, JSON.stringify(json)).toBe(200);
+  expect(json.ok).toBe(true);
+  expect(json.status).toBe(201);
+  const created = JSON.parse(json.body as string) as {
+    id: string;
+    created_by?: string;
+  };
+  expect(created.created_by).toBe("user-1");
+  expect(json.events).toEqual(["RoutinesChanged"]);
+  const synced = await store.list(prefix);
+  const routinesKey = synced.find((k) =>
+    k.endsWith("/.houston/routines/routines.json"),
+  );
+  expect(routinesKey).toBeDefined();
+});
+
+test("a conversation rename runs the runtime's own mutation and syncs only that file", async () => {
+  const { storeRoot, agentId, prefix } = await seedAgent();
+  const convFile = join(
+    storeRoot,
+    prefix,
+    "workspaces",
+    ...agentId.split("/"),
+    ".houston",
+    "runtime",
+    "conversations",
+    "c1.json",
+  );
+  mkdirSync(dirname(convFile), { recursive: true });
+  writeFileSync(
+    convFile,
+    JSON.stringify({
+      id: "c1",
+      title: "old",
+      createdAt: 1,
+      updatedAt: 1,
+      messages: [],
+    }),
+  );
+  const store = new LocalDirStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const { json } = await postOp(
+    base,
+    opBody(agentId, await heartbeatOK(), {
+      kind: "conversation",
+      action: "rename",
+      conversationId: "c1",
+      title: "new name",
+    }),
+  );
+  expect(json.status).toBe(200);
+  // LocalDirStore keeps objects on disk under the store root: read it back.
+  const after = JSON.parse(readFileSync(convFile, "utf8")) as { title: string };
+  expect(after.title).toBe("new name");
+  expect(prefix).toBe("ws/w1/agent-1");
+});
+
+test("an invalid op is rejected before any hydration", async () => {
+  const { storeRoot, agentId } = await seedAgent();
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn: noopTurn,
+    }),
+  );
+  const { status, json } = await postOp(
+    base,
+    opBody(agentId, "http://127.0.0.1:1/hb", {
+      kind: "route",
+      method: "GET",
+      rest: "routines",
+    }),
+  );
+  expect(status).toBe(400);
+  expect(String(json.error)).toContain("write method");
+});

--- a/packages/runtime/src/turn/server.ts
+++ b/packages/runtime/src/turn/server.ts
@@ -6,6 +6,7 @@ import {
   type ServerResponse,
 } from "node:http";
 import { AdmissionLimiter, turnConcurrency } from "./admission";
+import { executeOp } from "./execute-op";
 import { executeTurn } from "./execute-turn";
 import { parseTurnRequest } from "./parse-turn-request";
 import type { TurnServerDeps } from "./server-types";
@@ -72,7 +73,7 @@ export function createTurnServer(deps: TurnServerDeps): Server {
       if (req.method === "GET" && path === "/health") {
         return json(res, 200, { status: "ok", mode: "turn" });
       }
-      if (req.method !== "POST" || path !== "/turn") {
+      if (req.method !== "POST" || (path !== "/turn" && path !== "/op")) {
         return json(res, 404, { error: "not found" });
       }
       if (!authorized(req, deps.token)) {
@@ -85,6 +86,26 @@ export function createTurnServer(deps: TurnServerDeps): Server {
           { error: "worker_draining" },
           { "Retry-After": "1" },
         );
+      }
+      if (path === "/op") {
+        // A write for a sleeping agent (docs/op): same auth + admission as a
+        // turn, a fraction of the work.
+        const body = await readJson(req, 1024 * 1024);
+        const releaseOp = admission.tryAcquire();
+        if (!releaseOp) {
+          return json(
+            res,
+            503,
+            { error: "worker_full" },
+            { "Retry-After": "1" },
+          );
+        }
+        try {
+          await executeOp(deps, req, res, body);
+        } finally {
+          releaseOp();
+        }
+        return;
       }
       let turn: TurnRequest;
       try {

--- a/packages/runtime/src/turn/server.ts
+++ b/packages/runtime/src/turn/server.ts
@@ -89,8 +89,9 @@ export function createTurnServer(deps: TurnServerDeps): Server {
       }
       if (path === "/op") {
         // A write for a sleeping agent (docs/op): same auth + admission as a
-        // turn, a fraction of the work.
-        const body = await readJson(req, 1024 * 1024);
+        // turn, a fraction of the work. 4 MiB: an agentfile PUT carries the
+        // file body inline (the app's upload cap), well above every JSON op.
+        const body = await readJson(req, 4 * 1024 * 1024);
         const releaseOp = admission.tryAcquire();
         if (!releaseOp) {
           return json(

--- a/packages/runtime/src/turn/turn-activity-doc.ts
+++ b/packages/runtime/src/turn/turn-activity-doc.ts
@@ -19,8 +19,9 @@ export type ActivityDocPublishResult =
   | { disabled: true; reason: "route_absent" }
   | { error: string };
 
-interface ActivityDocOptions {
-  family: "activity" | "routine_runs";
+export interface ActivityDocOptions {
+  /** Any family or view the pod-store admits (validDocFamily). */
+  family: string;
   baseUrl: string;
   org: string;
   agent: string;
@@ -122,7 +123,7 @@ async function acceptPut(
   return { ok: true };
 }
 
-async function publish(
+export async function publish(
   opts: ActivityDocOptions,
   doc: unknown,
 ): Promise<ActivityDocPublishResult> {

--- a/packages/runtime/src/turn/turn-store.ts
+++ b/packages/runtime/src/turn/turn-store.ts
@@ -48,7 +48,10 @@ export function poolIdentity(gcsPrefix: string): {
 
 /** Select claim-backed HTTP storage or preserve the configured legacy store. */
 export function resolveTurnStore(
-  turn: TurnRequest,
+  turn: Pick<
+    TurnRequest,
+    "gcsPrefix" | "claim" | "hostToken" | "conversationId"
+  >,
   fallback: ObjectStore,
   config: TurnStoreConfig = {},
 ): ResolvedTurnStore {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
       '@houston/domain':
         specifier: workspace:*
         version: link:../domain
+      '@houston/host':
+        specifier: workspace:*
+        version: link:../host
       '@houston/protocol':
         specifier: workspace:*
         version: link:../protocol


### PR DESCRIPTION
The pool served reads and turns for sleeping agents, but every **write** — routine create/edit/delete, skill install/remove, `agentfile` PUT, conversation rename/delete — and the mission-title call still woke the pod, and an awake pod then served every later send. This makes the pool the engine for all of it.

**`POST /op` on the pool worker** (`packages/runtime/src/turn/execute-op.ts`): same claim + host-token envelope as a turn → claim heartbeat → hydrate the agent prefix (the existing claimed-turn machinery) → run the op → **scoped** sync-back → republish touched docs → answer `{ok, status, contentType, body}` with the handler's own response so the gateway relays exactly what the pod would have said.

Op kinds:
- **`route`** — runs the **host's own handlers** (`handleAgentData`, `handleAgentFile`, `handleSkills`, `handleSkillsRemote`) against the hydrated workspace through an in-process loopback server (`packages/host/src/op/dispatch.ts`). Byte-identical semantics by construction; nothing reimplemented. Sync scope: `.houston/**`, `.agents/**`, `CLAUDE.md`, `GROUP.md`. Family docs re-projected from the emitted `*Changed` events; a `SkillsChanged` re-captures the skills view.
- **`conversation`** rename/delete — the runtime's own directory-scoped mutations (`renameConversationMutationAt` / `deleteConversationAt`), mirrored into the transcript store (same PUT/DELETE the pod's shadow issues). Claim = that conversation.
- **`title`** — `generateTitle` with a turn-local model runtime for every provider except anthropic (the Claude-SDK compliance gate is pod-only; a cold anthropic agent keeps the client's truncated-title fallback).

**Dependency**: `runtime` now depends on `host` (workspace). Host never imports runtime, so no cycle; boundaries check green. Desktop/self-host untouched (no pool).

**Tests**: host dispatcher on a real on-disk workspace (routine create with `created_by`, agentfile PUT, 404s); worker `/op` end to end (routine create synced back to the store, conversation rename via the runtime's mutation, invalid op rejected pre-hydrate). Host 1541 / runtime 1279 green.

Pairs with the gateway PR (intercepts every write for an asleep agent and dispatches an op; pod-store claim scope for agent-level writes).

## Adversarial reviews (two independent reviewers) — fixes folded in
- **Mission attribution**: the acting human's name flows parse → op-apply → the activity handler; a mission created on a sleeping agent keeps its creator contributor.
- **Sync scope** widened to the agent's WHOLE directory (minus the runtime tree), matching the pod — root-level agentfile writes persist instead of being silently dropped.
- **Fail closed, never silent**: an op DECLINES (gateway proxies to the pod) on any non-durable outcome — a write out of scope, a size rejection, a generation conflict surviving retry, a failed doc/transcript projection, or a hydrated tree that isn't this worker's agent. The pod re-applies from the synced files; the read path never serves a stale doc.
- **No double execution**: paired with the gateway change, a lost worker reply is ambiguous (the write may have committed) → 502 to the client, never a silent re-run of a non-idempotent op.
- **Worker route allowlist**: the parser accepts only the op-route shapes the gateway classifier dispatches (defense in depth over the host-token + claim gate).
- **4 MiB /op body cap** (agentfile PUTs carry the file inline).
- **Wake fence** (gateway side): a 0→1 pod wake waits, bounded, for an in-flight op's sync-back before the pod hydrates — closes the whole-file last-writer-wins race both reviewers flagged.
