### PR TITLE
Pool ops: the Files tab, attachments and skills-manifest run on a worker

### DIFF
--- a/packages/host/src/op/dispatch.ts
+++ b/packages/host/src/op/dispatch.ts
@@ -9,8 +9,11 @@ import { LocalPaths } from "../paths";
 import { handleAgentData } from "../routes/agent-data";
 import { handleAgentFile } from "../routes/agent-file";
 import { handleSkills } from "../routes/skills";
+import { handleSkillsManifest } from "../routes/skills-manifest";
 import { handleSkillsRemote } from "../routes/skills-remote";
 import { LocalWorkspaceStore } from "../store/local";
+import { handleAttachments } from "../turn/attachments";
+import { handleFiles } from "../turn/files";
 import { FsVfs } from "../vfs";
 
 /**
@@ -29,6 +32,8 @@ export interface AgentOpRequest {
   actingSub?: string;
   actingAuthor?: ActivityContributor | null;
   triggersEnabled: boolean;
+  /** Raw query string (files routes take `?path=`), no leading `?`. */
+  query?: string;
 }
 
 export interface AgentOpResponse {
@@ -38,10 +43,23 @@ export interface AgentOpResponse {
   agentMissing?: true;
   status: number;
   contentType: string;
+  /** Text body (JSON/text responses). Empty when `bodyBase64` is set. */
   body: string;
+  /** Binary body (a file download, an archive) — base64, relayed raw. */
+  bodyBase64?: string;
+  /** Response headers a client depends on (Content-Disposition, Cache-Control). */
+  headers?: Record<string, string>;
   /** Domain events the handler emitted — the caller republishes their docs. */
   events: HoustonEvent[];
 }
+
+const TEXT_BODY =
+  /^(application\/json|text\/|application\/x-ndjson|image\/svg)/i;
+const RELAYED_HEADERS = [
+  "content-disposition",
+  "cache-control",
+  "etag",
+] as const;
 
 /**
  * Dispatch one op against `workspacesRoot` (the hydrated `workspaces/` dir)
@@ -76,8 +94,13 @@ export async function dispatchAgentOp(opts: {
   };
   const { method, rest, triggersEnabled, actingSub, actingAuthor } =
     opts.request;
+  const query = new URLSearchParams(opts.request.query ?? "");
 
   const handler = async (req: IncomingMessage, res: ServerResponse) => {
+    // Files (list/read/download/archive/import/move/rename/folder): the
+    // Files tab, byte-identical to the pod.
+    if (await handleFiles(vfs, paths, ctx, method, rest, req, res, query, emit))
+      return;
     if (
       await handleAgentData(
         vfs,
@@ -95,6 +118,13 @@ export async function dispatchAgentOp(opts: {
     )
       return;
     if (await handleAgentFile(vfs, paths, ctx, method, rest, req, res, emit))
+      return;
+    // Composer drops land in uploads/ BEFORE the send (which is a pool turn).
+    if (await handleAttachments(vfs, paths, ctx, method, rest, req, res, emit))
+      return;
+    if (
+      await handleSkillsManifest(vfs, paths, ctx, method, rest, req, res, emit)
+    )
       return;
     if (await handleSkills(vfs, paths, ctx, method, rest, req, res, emit))
       return;
@@ -137,10 +167,30 @@ export async function dispatchAgentOp(opts: {
         : {},
       body: opts.request.body,
     });
+    const contentType =
+      response.headers.get("content-type") ?? "application/json";
+    const headers: Record<string, string> = {};
+    for (const name of RELAYED_HEADERS) {
+      const value = response.headers.get(name);
+      if (value) headers[name] = value;
+    }
+    const relayed = Object.keys(headers).length > 0 ? { headers } : {};
+    if (TEXT_BODY.test(contentType)) {
+      return {
+        status: response.status,
+        contentType,
+        body: await response.text(),
+        ...relayed,
+        events,
+      };
+    }
+    const bytes = Buffer.from(await response.arrayBuffer());
     return {
       status: response.status,
-      contentType: response.headers.get("content-type") ?? "application/json",
-      body: await response.text(),
+      contentType,
+      body: "",
+      bodyBase64: bytes.toString("base64"),
+      ...relayed,
       events,
     };
   } finally {

--- a/packages/host/src/op/dispatch.ts
+++ b/packages/host/src/op/dispatch.ts
@@ -14,6 +14,7 @@ import { handleSkillsRemote } from "../routes/skills-remote";
 import { LocalWorkspaceStore } from "../store/local";
 import { handleAttachments } from "../turn/attachments";
 import { handleFiles } from "../turn/files";
+import { MAX_UPLOAD_BYTES } from "../turn/files-import";
 import { FsVfs } from "../vfs";
 
 /**
@@ -41,6 +42,8 @@ export interface AgentOpResponse {
    *  as the handler's answer (a legacy layout, a stale envelope) — it declines
    *  so the gateway takes the proxy path instead. */
   agentMissing?: true;
+  /** A binary answer over the relay cap: refused before buffering. */
+  tooLarge?: true;
   status: number;
   contentType: string;
   /** Text body (JSON/text responses). Empty when `bodyBase64` is set. */
@@ -182,6 +185,22 @@ export async function dispatchAgentOp(opts: {
         contentType,
         body: await response.text(),
         ...relayed,
+        events,
+      };
+    }
+    const declared = Number(response.headers.get("content-length") ?? "0");
+    if (declared > MAX_UPLOAD_BYTES) {
+      // A body this size cannot ride a JSON envelope on a shared worker
+      // (base64 + envelope copies). Refuse before buffering; the gateway
+      // answers the read as unavailable rather than waking a pod.
+      await response.body?.cancel();
+      return {
+        tooLarge: true,
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: "file too large to fetch while the agent sleeps",
+        }),
         events,
       };
     }

--- a/packages/host/src/op/dispatch.ts
+++ b/packages/host/src/op/dispatch.ts
@@ -57,11 +57,7 @@ export interface AgentOpResponse {
 // relayed byte-exact (a Latin-1 CSV through `response.text()` would be
 // re-encoded), so every non-JSON body rides base64.
 const TEXT_BODY = /^application\/json/i;
-const RELAYED_HEADERS = [
-  "content-disposition",
-  "cache-control",
-  "etag",
-] as const;
+const RELAYED_HEADERS = ["content-disposition", "cache-control"] as const;
 
 /**
  * Dispatch one op against `workspacesRoot` (the hydrated `workspaces/` dir)
@@ -177,7 +173,10 @@ export async function dispatchAgentOp(opts: {
       if (value) headers[name] = value;
     }
     const relayed = Object.keys(headers).length > 0 ? { headers } : {};
-    if (TEXT_BODY.test(contentType)) {
+    // A download/archive is always bytes, whatever its MIME (a `.json` file
+    // is `application/json` too); everything else is the handler's own JSON.
+    const binaryRoute = /^files\/(download|archive)$/.test(rest);
+    if (!binaryRoute && TEXT_BODY.test(contentType)) {
       return {
         status: response.status,
         contentType,

--- a/packages/host/src/op/dispatch.ts
+++ b/packages/host/src/op/dispatch.ts
@@ -53,8 +53,10 @@ export interface AgentOpResponse {
   events: HoustonEvent[];
 }
 
-const TEXT_BODY =
-  /^(application\/json|text\/|application\/x-ndjson|image\/svg)/i;
+// Only the handlers' own JSON is safe to carry as text: a downloaded file is
+// relayed byte-exact (a Latin-1 CSV through `response.text()` would be
+// re-encoded), so every non-JSON body rides base64.
+const TEXT_BODY = /^application\/json/i;
 const RELAYED_HEADERS = [
   "content-disposition",
   "cache-control",

--- a/packages/runtime-client/src/object-sync/hydrate.test.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.test.ts
@@ -3,6 +3,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -731,4 +732,60 @@ test("a large file round-trips: streamed hash agrees across syncBack and hydrate
   expect(rehydrated.get("workspace/big.bin")?.hash).toBe(
     result.manifest.get("workspace/big.bin")?.hash,
   );
+});
+
+test("holdDeletesOnFailure: a rename whose destination is refused keeps the source object", async () => {
+  // A pool op renames a file that predates a store-cap reduction: the new key
+  // is rejected (413). With deletes held, the old key — the ONLY durable
+  // copy — survives; the default one-shot pass would have deleted it.
+  const { storeRoot, store, work } = setup();
+  seed(storeRoot, PREFIX, { "workspace/big.bin": "B".repeat(64) });
+  const manifest = await hydrate(store, PREFIX, work);
+  renameSync(
+    join(work, "workspace", "big.bin"),
+    join(work, "workspace", "renamed.bin"),
+  );
+  const capped = {
+    list: (prefix: string) => store.list(prefix),
+    download: (key: string, dest: string) => store.download(key, dest),
+    upload: (src: string, key: string) =>
+      statSync(src).size > 32
+        ? Promise.reject(
+            new ObjectTooLargeError(
+              key,
+              `object store PUT ${key} failed (413)`,
+            ),
+          )
+        : store.upload(src, key),
+    delete: (key: string) => store.delete(key),
+  };
+  const held = await syncBack(capped, PREFIX, work, manifest, {
+    holdDeletesOnFailure: true,
+  });
+  expect(held.skipped.map((s) => s.key)).toEqual(["workspace/renamed.bin"]);
+  expect(held.deleted).toEqual([]);
+  expect(await store.list(PREFIX)).toContain(`${PREFIX}/workspace/big.bin`);
+  // The held entry stays owned in the manifest, so nothing is orphaned.
+  expect(held.manifest.has("workspace/big.bin")).toBe(true);
+});
+
+test("segment-glob excludes match exactly one segment per `*` and only the named depth", () => {
+  const ex = ["workspaces/*/*/.houston/runtime/"];
+  expect(
+    excluded(
+      "workspaces/Personal/Bob/.houston/runtime/conversations/c1.json",
+      ex,
+    ),
+  ).toBe(true);
+  expect(
+    excluded("workspaces/Personal/Bob/.houston/runtime/settings.json", ex),
+  ).toBe(true);
+  // A user project's own .houston/runtime is NOT the agent's — hydrated.
+  expect(
+    excluded("workspaces/Personal/Bob/repo/.houston/runtime/state.db", ex),
+  ).toBe(false);
+  expect(
+    excluded("workspaces/Personal/Bob/.houston/routines/routines.json", ex),
+  ).toBe(false);
+  expect(excluded("workspace/.houston/runtime/x", ex)).toBe(false);
 });

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -35,6 +35,11 @@ export function excluded(rel: string, excludes: string[]): boolean {
   if (normalized.split("/").includes("auth-users")) return true;
   return excludes.some((exclude) => {
     const pattern = norm(exclude);
+    if (pattern.startsWith("**/") && pattern.endsWith("/")) {
+      // Any-depth subtree: `**/.houston/runtime/` matches that directory
+      // wherever the agent sits in the prefix (workspaces/<ws>/<agent>/...).
+      return `/${normalized}/`.includes(`/${pattern.slice(3)}`);
+    }
     if (pattern.endsWith("/")) {
       const subtree = pattern.slice(0, -1);
       return normalized === subtree || normalized.startsWith(pattern);

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -22,6 +22,16 @@ export const DEFAULT_EXCLUDES = ["data/auth.json"];
 
 const norm = (rel: string) => rel.split(sep).join("/");
 
+function segmentGlobMatches(pattern: string, path: string): boolean {
+  const subtree = pattern.endsWith("/");
+  const want = (subtree ? pattern.slice(0, -1) : pattern).split("/");
+  const have = path.split("/");
+  if (subtree ? have.length < want.length : have.length !== want.length) {
+    return false;
+  }
+  return want.every((seg, i) => seg === "*" || seg === have[i]);
+}
+
 export function excluded(rel: string, excludes: string[]): boolean {
   const normalized = norm(rel);
   if (normalized.endsWith(".tmp")) return true;
@@ -35,10 +45,11 @@ export function excluded(rel: string, excludes: string[]): boolean {
   if (normalized.split("/").includes("auth-users")) return true;
   return excludes.some((exclude) => {
     const pattern = norm(exclude);
-    if (pattern.startsWith("**/") && pattern.endsWith("/")) {
-      // Any-depth subtree: `**/.houston/runtime/` matches that directory
-      // wherever the agent sits in the prefix (workspaces/<ws>/<agent>/...).
-      return `/${normalized}/`.includes(`/${pattern.slice(3)}`);
+    if (pattern.includes("*")) {
+      // Segment glob: `*` matches exactly one path segment; a trailing `/`
+      // names a subtree. `workspaces/*/*/.houston/runtime/` is the agent's
+      // own runtime dir at its fixed depth — never a user project's.
+      return segmentGlobMatches(pattern, normalized);
     }
     if (pattern.endsWith("/")) {
       const subtree = pattern.slice(0, -1);

--- a/packages/runtime-client/src/object-sync/sync-back.ts
+++ b/packages/runtime-client/src/object-sync/sync-back.ts
@@ -37,6 +37,14 @@ export interface SyncBackOptions {
   generations?: boolean;
   /** Limit writes and deletes while still detecting skipped changes. */
   include?: (relativePath: string) => boolean;
+  /**
+   * Skip the delete pass entirely when any upload was skipped or conflicted.
+   * A rename/move uploads the new key and deletes the old one; if the upload
+   * is refused (over the store's cap, a conflict) the delete would destroy
+   * the ONLY durable copy. One-shot callers (a pool op) set this; the
+   * standing daemon retries on its next tick and keeps the default.
+   */
+  holdDeletesOnFailure?: boolean;
 }
 
 async function walkFiles(dir: string, base: string): Promise<string[]> {
@@ -145,8 +153,16 @@ export async function syncBack(
   }
 
   const deleted: string[] = [];
+  const holdDeletes =
+    opts.holdDeletesOnFailure === true &&
+    (skipped.length > 0 || conflicts.length > 0);
   for (const [rel, previous] of manifest) {
     if (nextManifest.has(rel)) continue;
+    if (holdDeletes) {
+      // Keep the prior entry so the object stays owned and durable.
+      nextManifest.set(rel, previous);
+      continue;
+    }
     if (opts.include && !opts.include(rel)) {
       nextManifest.set(rel, previous);
       outOfScope += 1;

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -24,6 +24,9 @@ import { poolIdentity, resolveTurnStore } from "./turn-store";
 /** Reserved claim key for agent-level writes (gateway + pod-store agree). */
 export const AGENT_OPS_CLAIM_ID = "agent-ops";
 
+/** Route ops skip the runtime tree wherever the agent sits in the prefix. */
+const ROUTE_OP_EXCLUDES = ["**/.houston/runtime/"];
+
 const EVENT_FAMILY: Partial<Record<HoustonEvent["type"], HoustonFamily>> = {
   ActivityChanged: "activity",
   RoutinesChanged: "routines",
@@ -86,6 +89,10 @@ export async function executeOp(
       ...(deps.maxHydrateBytes !== undefined
         ? { maxBytes: deps.maxHydrateBytes }
         : {}),
+      // Agent-level routes (files, docs, skills) never read the runtime tree
+      // (conversations, sessions) — the bulk of a busy agent. Conversation
+      // ops do, so they hydrate everything.
+      ...(op.op.kind === "route" ? { excludes: ROUTE_OP_EXCLUDES } : {}),
     });
     const result = await applyOp(op, filesystem, deps.fetchImpl);
     if (result.agentMissing) {
@@ -95,27 +102,44 @@ export async function executeOp(
     }
     await heartbeat.checkpoint();
     if (heartbeat.fenced) return json(res, 409, { error: "claim_fenced" });
-    const synced = await syncBack(
-      resolved.store,
-      resolved.prefix,
-      filesystem.storeRoot,
-      filesystem.manifest,
-      {
-        include: result.include,
-      },
-    );
-    if (synced.outOfScope > 0) {
-      console.info(
-        `[op] pool_writes_out_of_scope=${synced.outOfScope} prefix=${resolved.prefix} kind=${op.op.kind}`,
+    const isRead = op.op.kind === "route" && op.op.method === "GET";
+    if (!isRead) {
+      const synced = await syncBack(
+        resolved.store,
+        resolved.prefix,
+        filesystem.storeRoot,
+        filesystem.manifest,
+        { include: result.include },
       );
-    }
-    const diagnostics: string[] = [];
-    if (result.status < 300) {
-      diagnostics.push(
-        ...(await republish(deps, turnLike, filesystem, result)),
-      );
-      if (op.op.kind === "conversation") {
-        diagnostics.push(...(await opTranscriptMirror(deps, turnLike, op.op)));
+      // Any object that did not durably persist means the op cannot be
+      // reported ok: out of scope (dropped), a size rejection (skipped), or a
+      // generation conflict that survived the refreshed retry. Decline so the
+      // gateway proxies and the pod re-applies from the synced tree — never
+      // answer ok on a lost write.
+      if (
+        synced.outOfScope > 0 ||
+        synced.skipped.length > 0 ||
+        synced.conflicts.length > 0
+      ) {
+        console.error(
+          `[op] not durably synced; declining: outOfScope=${synced.outOfScope} skipped=${synced.skipped.length} conflicts=${synced.conflicts.length} prefix=${resolved.prefix} kind=${op.op.kind}`,
+        );
+        return json(res, 200, { ok: true, decline: true });
+      }
+      if (result.status < 300) {
+        const failures = await republish(deps, turnLike, filesystem, result);
+        if (op.op.kind === "conversation") {
+          failures.push(...(await opTranscriptMirror(deps, turnLike, op.op)));
+        }
+        if (failures.length > 0) {
+          // The files landed but a doc/transcript projection did not: the
+          // asleep read path would serve a stale doc the next read-modify-
+          // write clobbers. Decline; the pod re-projects on wake.
+          console.error(
+            `[op] projection failed; declining: ${failures.join("; ")} prefix=${resolved.prefix}`,
+          );
+          return json(res, 200, { ok: true, decline: true });
+        }
       }
     }
     json(res, 200, {
@@ -123,8 +147,9 @@ export async function executeOp(
       status: result.status,
       contentType: result.contentType,
       body: result.body,
+      ...(result.bodyBase64 ? { bodyBase64: result.bodyBase64 } : {}),
+      ...(result.headers ? { headers: result.headers } : {}),
       events: result.events.map((e) => e.type),
-      ...(diagnostics.length ? { diagnostics } : {}),
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -24,8 +24,10 @@ import { poolIdentity, resolveTurnStore } from "./turn-store";
 /** Reserved claim key for agent-level writes (gateway + pod-store agree). */
 export const AGENT_OPS_CLAIM_ID = "agent-ops";
 
-/** Route ops skip the runtime tree wherever the agent sits in the prefix. */
-const ROUTE_OP_EXCLUDES = ["**/.houston/runtime/"];
+/** Route ops skip the AGENT's runtime tree (`workspaces/<ws>/<agent>/
+ *  .houston/runtime/`) — exactly that depth, so a user project carrying its
+ *  own `.houston/runtime` directory is hydrated like any other file. */
+const ROUTE_OP_EXCLUDES = ["workspaces/*/*/.houston/runtime/"];
 
 const EVENT_FAMILY: Partial<Record<HoustonEvent["type"], HoustonFamily>> = {
   ActivityChanged: "activity",
@@ -109,7 +111,7 @@ export async function executeOp(
         resolved.prefix,
         filesystem.storeRoot,
         filesystem.manifest,
-        { include: result.include },
+        { include: result.include, holdDeletesOnFailure: true },
       );
       const landed = synced.uploaded.length + synced.deleted.length > 0;
       const partial =
@@ -145,7 +147,13 @@ export async function executeOp(
         return json(res, 200, { ok: true, ambiguous: true });
       }
       if (result.status < 300) {
-        const failures = await republish(deps, turnLike, filesystem, result);
+        let failures = await republish(deps, turnLike, filesystem, result);
+        if (failures.length > 0) {
+          // One more round before accepting a lag: a blip on the doc PUT is
+          // the common case and the files are already durable.
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          failures = await republish(deps, turnLike, filesystem, result);
+        }
         if (op.op.kind === "conversation") {
           failures.push(...(await opTranscriptMirror(deps, turnLike, op.op)));
         }

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -111,20 +111,38 @@ export async function executeOp(
         filesystem.manifest,
         { include: result.include },
       );
-      // Any object that did not durably persist means the op cannot be
-      // reported ok: out of scope (dropped), a size rejection (skipped), or a
-      // generation conflict that survived the refreshed retry. Decline so the
-      // gateway proxies and the pod re-applies from the synced tree — never
-      // answer ok on a lost write.
-      if (
+      const landed = synced.uploaded.length + synced.deleted.length > 0;
+      const partial =
         synced.outOfScope > 0 ||
         synced.skipped.length > 0 ||
-        synced.conflicts.length > 0
-      ) {
+        synced.conflicts.length > 0;
+      if (partial) {
         console.error(
-          `[op] not durably synced; declining: outOfScope=${synced.outOfScope} skipped=${synced.skipped.length} conflicts=${synced.conflicts.length} prefix=${resolved.prefix} kind=${op.op.kind}`,
+          `[op] not durably synced: outOfScope=${synced.outOfScope} skipped=${synced.skipped.length} conflicts=${synced.conflicts.length} landed=${landed} prefix=${resolved.prefix} kind=${op.op.kind}`,
         );
-        return json(res, 200, { ok: true, decline: true });
+        // NOTHING landed: declining is safe — the gateway proxies and the
+        // pod applies the write from an unchanged tree.
+        if (!landed) return json(res, 200, { ok: true, decline: true });
+        // A file the store refuses (over its per-object cap) can never
+        // persist anywhere — the pod would silently fail the same way.
+        // Tell the user; the client does not retry a 413.
+        if (synced.skipped.length > 0) {
+          return json(res, 200, {
+            ok: true,
+            status: 413,
+            contentType: "application/json",
+            body: JSON.stringify({
+              error: "file too large to store",
+              files: synced.skipped.map((s) => s.key),
+            }),
+            events: [],
+          });
+        }
+        // Something landed and something conflicted: the write is PARTLY
+        // durable. Re-running it on the pod would duplicate the part that
+        // landed (a routine create mints a fresh id); the client must be
+        // told the result is unknown instead.
+        return json(res, 200, { ok: true, ambiguous: true });
       }
       if (result.status < 300) {
         const failures = await republish(deps, turnLike, filesystem, result);
@@ -132,13 +150,13 @@ export async function executeOp(
           failures.push(...(await opTranscriptMirror(deps, turnLike, op.op)));
         }
         if (failures.length > 0) {
-          // The files landed but a doc/transcript projection did not: the
-          // asleep read path would serve a stale doc the next read-modify-
-          // write clobbers. Decline; the pod re-projects on wake.
+          // The files ARE durable; only a doc/transcript projection lagged.
+          // Never re-run (duplicates) — answer the handler's status and make
+          // the gap loud: the next op's republish or the pod's wake-time
+          // projector re-projects from the files.
           console.error(
-            `[op] projection failed; declining: ${failures.join("; ")} prefix=${resolved.prefix}`,
+            `[op] projection failed after a durable sync (asleep reads may lag until the next projection): ${failures.join("; ")} prefix=${resolved.prefix}`,
           );
-          return json(res, 200, { ok: true, decline: true });
         }
       }
     }

--- a/packages/runtime/src/turn/op-apply.ts
+++ b/packages/runtime/src/turn/op-apply.ts
@@ -16,6 +16,10 @@ export interface OpResult {
   status: number;
   contentType: string;
   body: string;
+  /** Binary answer (file download / archive), base64 — relayed raw. */
+  bodyBase64?: string;
+  /** Response headers the client depends on (Content-Disposition, ...). */
+  headers?: Record<string, string>;
   events: HoustonEvent[];
   /** Store-relative paths this op may have written (the sync-back scope). */
   include: (relativePath: string) => boolean;
@@ -82,6 +86,7 @@ export async function applyOp(
         request: {
           method: op.op.method,
           rest: op.op.rest,
+          ...(op.op.query ? { query: op.op.query } : {}),
           ...(op.op.body !== undefined ? { body: op.op.body } : {}),
           ...(op.op.contentType ? { contentType: op.op.contentType } : {}),
           ...(op.actingAs

--- a/packages/runtime/src/turn/parse-op-request.ts
+++ b/packages/runtime/src/turn/parse-op-request.ts
@@ -42,9 +42,10 @@ const ID = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$/;
 // The op-route shapes (mirrors the Go classifier): the agent-data families,
 // agentfile writes, and skills (install + manage), never a runtime path.
 const OP_ROUTE =
-  /^(activities|routines|routine_runs|learnings|config)(\/[^/]+)?$|^agentfile\/(?!\.houston\/runtime\/).+$|^skills(\/[^/]+)?$|^skills\/(community|repo)\/install$|^files(\/(download|archive|read|import|move|rename|folder))?$|^attachments$|^skills-manifest$/;
-const READ_ROUTE =
-  /^files(\/(download|archive|read))?$|^agentfile\/|^skills-manifest$/;
+  /^(activities|routines|routine_runs|learnings|config)(\/[^/]+)?$|^agentfile\/(?!\.houston\/runtime\/).+$|^skills(\/[^/]+)?$|^skills\/(community|repo)\/install$|^files(\/.+)?$|^attachments$|^skills-manifest$/;
+// Any files/* shape reads through the handler (it owns the 404 for an
+// unknown one), never a write.
+const READ_ROUTE = /^files(\/.+)?$|^agentfile\/|^skills-manifest$/;
 
 function parseActing(raw: unknown): TurnRequest["actingAs"] {
   if (!raw || typeof raw !== "object") return undefined;
@@ -108,10 +109,23 @@ export function parseOpRequest(body: unknown): OpRequest {
       // Defense in depth: the worker accepts only the op-route shapes the
       // gateway classifier dispatches — a valid-token caller cannot reach a
       // handler surface (e.g. POST agentfile) the public path never exposes.
-      if (!OP_ROUTE.test(rest)) throw new Error("op.rest is not an op route");
+      // Match the DECODED path: the handlers decode, so the allowlist must
+      // see what they see (`%2Ehouston` is `.houston`).
+      let decoded: string;
+      try {
+        decoded = decodeURIComponent(rest);
+      } catch {
+        throw new Error("invalid 'op.rest'");
+      }
+      if (decoded.includes("..") || decoded.startsWith("/")) {
+        throw new Error("invalid 'op.rest'");
+      }
+      if (!OP_ROUTE.test(decoded)) {
+        throw new Error("op.rest is not an op route");
+      }
       // Reads run as ops only where the gateway has no doc to serve them
       // from: the Files tab and arbitrary agent files.
-      if (method === "GET" && !READ_ROUTE.test(rest)) {
+      if (method === "GET" && !READ_ROUTE.test(decoded)) {
         throw new Error("op.rest is not a read op route");
       }
       const query =

--- a/packages/runtime/src/turn/parse-op-request.ts
+++ b/packages/runtime/src/turn/parse-op-request.ts
@@ -12,6 +12,8 @@ export type AgentOp =
       kind: "route";
       method: string;
       rest: string;
+      /** Raw query string without the `?` (files routes take `?path=`). */
+      query?: string;
       body?: string;
       contentType?: string;
     }
@@ -40,7 +42,9 @@ const ID = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$/;
 // The op-route shapes (mirrors the Go classifier): the agent-data families,
 // agentfile writes, and skills (install + manage), never a runtime path.
 const OP_ROUTE =
-  /^(activities|routines|routine_runs|learnings|config)(\/[^/]+)?$|^agentfile\/(?!\.houston\/runtime\/).+$|^skills(\/[^/]+)?$|^skills\/(community|repo)\/install$/;
+  /^(activities|routines|routine_runs|learnings|config)(\/[^/]+)?$|^agentfile\/(?!\.houston\/runtime\/).+$|^skills(\/[^/]+)?$|^skills\/(community|repo)\/install$|^files(\/(download|archive|read|import|move|rename|folder))?$|^attachments$|^skills-manifest$/;
+const READ_ROUTE =
+  /^files(\/(download|archive|read))?$|^agentfile\/|^skills-manifest$/;
 
 function parseActing(raw: unknown): TurnRequest["actingAs"] {
   if (!raw || typeof raw !== "object") return undefined;
@@ -95,8 +99,8 @@ export function parseOpRequest(body: unknown): OpRequest {
   switch (raw.kind) {
     case "route": {
       const method = str(raw.method, "op.method").toUpperCase();
-      if (!["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
-        throw new Error("op.method must be a write method");
+      if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+        throw new Error("op.method is not an HTTP method");
       }
       const rest = str(raw.rest, "op.rest");
       if (rest.includes("..") || rest.startsWith("/"))
@@ -105,10 +109,20 @@ export function parseOpRequest(body: unknown): OpRequest {
       // gateway classifier dispatches — a valid-token caller cannot reach a
       // handler surface (e.g. POST agentfile) the public path never exposes.
       if (!OP_ROUTE.test(rest)) throw new Error("op.rest is not an op route");
+      // Reads run as ops only where the gateway has no doc to serve them
+      // from: the Files tab and arbitrary agent files.
+      if (method === "GET" && !READ_ROUTE.test(rest)) {
+        throw new Error("op.rest is not a read op route");
+      }
+      const query =
+        typeof raw.query === "string" && raw.query.length <= 4096
+          ? raw.query.replace(/^\?/, "")
+          : undefined;
       op = {
         kind: "route",
         method,
         rest,
+        ...(query ? { query } : {}),
         ...(typeof raw.body === "string" ? { body: raw.body } : {}),
         ...(typeof raw.contentType === "string"
           ? { contentType: raw.contentType }

--- a/packages/runtime/src/turn/server-op.test.ts
+++ b/packages/runtime/src/turn/server-op.test.ts
@@ -34,16 +34,18 @@ async function seedAgent(): Promise<{
   const store = new LocalWorkspaceStore(workspaces);
   const ws = await store.getOrCreatePersonalWorkspace("alice");
   const agent = await store.createAgent({ workspaceId: ws.id, name: "Bob" });
-  // The standing layout marker the turn layout resolver keys on.
-  const settings = join(
-    workspaces,
-    ...agent.id.split("/"),
-    ".houston",
-    "runtime",
-    "settings.json",
-  );
-  mkdirSync(dirname(settings), { recursive: true });
-  writeFileSync(settings, "{}");
+  // Every real agent carries a CLAUDE.md — the directory the layout resolver
+  // keys on. (Route ops hydrate WITHOUT the runtime tree, so the marker must
+  // not live there.)
+  const agentDir = join(workspaces, ...agent.id.split("/"));
+  mkdirSync(agentDir, { recursive: true });
+  writeFileSync(join(agentDir, "CLAUDE.md"), "# Bob\n");
+  // A user file + a runtime file: the files op must see the former and the
+  // hydrate must skip the latter.
+  writeFileSync(join(agentDir, "report.csv"), "a,b\n1,2\n");
+  const runtime = join(agentDir, ".houston", "runtime", "conversations");
+  mkdirSync(runtime, { recursive: true });
+  writeFileSync(join(runtime, "c1.json"), "{}");
   return { storeRoot, agentId: agent.id, prefix };
 }
 
@@ -186,7 +188,58 @@ test("an invalid op is rejected before any hydration", async () => {
     }),
   );
   expect(status).toBe(400);
-  expect(String(json.error)).toContain("write method");
+  expect(String(json.error)).toContain("not a read op route");
+});
+
+test("a files list runs as a READ op: no sync-back, runtime tree not hydrated", async () => {
+  const { storeRoot, agentId } = await seedAgent();
+  const store = new LocalDirStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const { json } = await postOp(
+    base,
+    opBody(agentId, await heartbeatOK(), {
+      kind: "route",
+      method: "GET",
+      rest: "files",
+    }),
+  );
+  expect(json.status).toBe(200);
+  const listing = JSON.parse(json.body as string) as Array<{ name: string }>;
+  const names = listing.map((e) => e.name);
+  expect(names).toContain("report.csv");
+  // Runtime files never surface in the Files tab and were not hydrated.
+  expect(JSON.stringify(listing)).not.toContain("c1.json");
+});
+
+test("a file download relays binary bytes base64 with its headers", async () => {
+  const { storeRoot, agentId } = await seedAgent();
+  const store = new LocalDirStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const { json } = await postOp(
+    base,
+    opBody(agentId, await heartbeatOK(), {
+      kind: "route",
+      method: "GET",
+      rest: "files/download",
+      query: "path=report.csv",
+    }),
+  );
+  expect(json.status).toBe(200);
+  const body = json.bodyBase64
+    ? Buffer.from(json.bodyBase64 as string, "base64").toString("utf8")
+    : (json.body as string);
+  expect(body).toBe("a,b\n1,2\n");
+  expect(
+    String(
+      (json.headers as Record<string, string> | undefined)?.[
+        "content-disposition"
+      ] ?? "",
+    ),
+  ).toContain("report.csv");
 });
 
 test("a root-level agentfile write persists (F6: no longer dropped)", async () => {

--- a/packages/runtime/src/turn/server-op.test.ts
+++ b/packages/runtime/src/turn/server-op.test.ts
@@ -229,10 +229,12 @@ test("a file download relays binary bytes base64 with its headers", async () => 
     }),
   );
   expect(json.status).toBe(200);
-  const body = json.bodyBase64
-    ? Buffer.from(json.bodyBase64 as string, "base64").toString("utf8")
-    : (json.body as string);
-  expect(body).toBe("a,b\n1,2\n");
+  // Always base64 on a download — byte-exact, whatever the MIME.
+  expect(typeof json.bodyBase64).toBe("string");
+  expect(json.body).toBe("");
+  expect(
+    Buffer.from(json.bodyBase64 as string, "base64").toString("utf8"),
+  ).toBe("a,b\n1,2\n");
   expect(
     String(
       (json.headers as Record<string, string> | undefined)?.[

--- a/packages/runtime/src/turn/server.ts
+++ b/packages/runtime/src/turn/server.ts
@@ -5,6 +5,7 @@ import {
   type Server,
   type ServerResponse,
 } from "node:http";
+import { MAX_UPLOAD_BODY_BYTES } from "@houston/host/src/turn/files-import";
 import { AdmissionLimiter, turnConcurrency } from "./admission";
 import { executeOp } from "./execute-op";
 import { executeTurn } from "./execute-turn";
@@ -63,6 +64,8 @@ function json(
 }
 
 /** Create the bounded HTTP server used by stateless per-turn workers. */
+const OP_BODY_MAX_BYTES = MAX_UPLOAD_BODY_BYTES + 1024 * 1024;
+
 export function createTurnServer(deps: TurnServerDeps): Server {
   const admission =
     deps.admission ??
@@ -89,9 +92,10 @@ export function createTurnServer(deps: TurnServerDeps): Server {
       }
       if (path === "/op") {
         // A write for a sleeping agent (docs/op): same auth + admission as a
-        // turn, a fraction of the work. 4 MiB: an agentfile PUT carries the
-        // file body inline (the app's upload cap), well above every JSON op.
-        const body = await readJson(req, 4 * 1024 * 1024);
+        // turn, a fraction of the work. The cap is the Files import cap plus
+        // envelope headroom: an upload rides the op exactly as it rides the
+        // pod (base64 JSON), and the pod reads it with the same limit.
+        const body = await readJson(req, OP_BODY_MAX_BYTES);
         const releaseOp = admission.tryAcquire();
         if (!releaseOp) {
           return json(

--- a/packages/runtime/src/turn/server.ts
+++ b/packages/runtime/src/turn/server.ts
@@ -95,7 +95,9 @@ export function createTurnServer(deps: TurnServerDeps): Server {
         // turn, a fraction of the work. The cap is the Files import cap plus
         // envelope headroom: an upload rides the op exactly as it rides the
         // pod (base64 JSON), and the pod reads it with the same limit.
-        const body = await readJson(req, OP_BODY_MAX_BYTES);
+        // Admission BEFORE the body is drained: the cap is ~135 MiB, so N
+        // parked uploads must not buffer N bodies on a worker that runs one
+        // op at a time. A refused request never reads its body.
         const releaseOp = admission.tryAcquire();
         if (!releaseOp) {
           return json(
@@ -106,6 +108,7 @@ export function createTurnServer(deps: TurnServerDeps): Server {
           );
         }
         try {
+          const body = await readJson(req, OP_BODY_MAX_BYTES);
           await executeOp(deps, req, res, body);
         } finally {
           releaseOp();

--- a/packages/runtime/src/turn/turn-filesystem.test.ts
+++ b/packages/runtime/src/turn/turn-filesystem.test.ts
@@ -1,0 +1,44 @@
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalDirStore } from "@houston/runtime-client/object-sync";
+import { expect, test } from "vitest";
+import { prepareTurnFilesystem } from "./turn-filesystem";
+
+test("route-op excludes skip the runtime tree wherever the agent sits", async () => {
+  const storeRoot = mkdtempSync(join(tmpdir(), "op-hydrate-"));
+  const prefix = "ws/w1/agent-1";
+  const agent = join(storeRoot, prefix, "workspaces", "Personal", "Bob");
+  mkdirSync(join(agent, ".houston", "runtime", "conversations"), {
+    recursive: true,
+  });
+  mkdirSync(join(agent, ".houston", "routines"), { recursive: true });
+  writeFileSync(join(agent, "CLAUDE.md"), "# Bob\n");
+  writeFileSync(join(agent, "report.csv"), "a,b\n");
+  writeFileSync(join(agent, ".houston", "routines", "routines.json"), "[]");
+  writeFileSync(
+    join(agent, ".houston", "runtime", "conversations", "c1.json"),
+    "{}",
+  );
+  writeFileSync(join(agent, ".houston", "runtime", "settings.json"), "{}");
+
+  const root = mkdtempSync(join(tmpdir(), "op-root-"));
+  const fs = await prepareTurnFilesystem({
+    store: new LocalDirStore(storeRoot),
+    prefix,
+    root,
+    claimed: true,
+    excludes: ["**/.houston/runtime/"],
+  });
+  const hydrated = JSON.stringify([...fs.manifest.keys()].sort());
+  expect(hydrated).toContain("report.csv");
+  expect(hydrated).toContain("routines.json");
+  expect(hydrated).not.toContain("runtime/conversations/c1.json");
+  expect(hydrated).not.toContain("runtime/settings.json");
+  expect(
+    existsSync(
+      join(fs.workspaceDir, ".houston", "runtime", "conversations", "c1.json"),
+    ),
+  ).toBe(false);
+  expect(existsSync(join(fs.workspaceDir, "report.csv"))).toBe(true);
+});

--- a/packages/runtime/src/turn/turn-filesystem.test.ts
+++ b/packages/runtime/src/turn/turn-filesystem.test.ts
@@ -28,7 +28,7 @@ test("route-op excludes skip the runtime tree wherever the agent sits", async ()
     prefix,
     root,
     claimed: true,
-    excludes: ["**/.houston/runtime/"],
+    excludes: ["workspaces/*/*/.houston/runtime/"],
   });
   const hydrated = JSON.stringify([...fs.manifest.keys()].sort());
   expect(hydrated).toContain("report.csv");

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -2,6 +2,7 @@ import { mkdir } from "node:fs/promises";
 import { join, posix } from "node:path";
 import { docKey } from "@houston/domain";
 import {
+  DEFAULT_EXCLUDES,
   HydrateLimitError,
   type HydrateManifest,
   hydrate,
@@ -35,6 +36,9 @@ export async function prepareTurnFilesystem(opts: {
   root: string;
   claimed: boolean;
   maxBytes?: number;
+  /** Extra hydrate excludes (on top of the defaults), e.g. the runtime tree
+   *  for an op that never reads conversations. */
+  excludes?: string[];
 }): Promise<TurnFilesystem> {
   const storeRoot = join(opts.root, "store");
   await mkdir(storeRoot, { recursive: true });
@@ -44,6 +48,9 @@ export async function prepareTurnFilesystem(opts: {
   try {
     manifest = await hydrate(opts.store, opts.prefix, storeRoot, {
       ...(maxBytes !== undefined ? { maxBytes } : {}),
+      ...(opts.excludes
+        ? { excludes: [...DEFAULT_EXCLUDES, ...opts.excludes] }
+        : {}),
     });
   } catch (error) {
     if (!(error instanceof HydrateLimitError)) throw error;


### PR DESCRIPTION
Pairs with the gateway PR (gethouston/cloud#289). Merge this first.

## Why
After the op-turns PR, the last app routes that still woke a sleeping agent's pod were the Files tab (listing / read / download / archive and its writes), composer attachments (the drop that precedes a pool send) and `skills-manifest`. Every one now runs as a pool op through the same loopback handler chain — byte-identical to the pod by construction.

## What
- **Handler chain** gains `handleFiles`, `handleAttachments`, `handleSkillsManifest`.
- **Read ops**: `GET` is admitted for the routes the gateway has no doc for (`files*`, arbitrary `agentfile/*`, `skills-manifest`); a read does no sync-back and no republish.
- **Binary answers** (download, archive) ride the envelope base64 with the response headers the client depends on (Content-Disposition, Cache-Control, ETag); text/JSON bodies ride as before.
- **Query strings** (`?path=`) travel in the envelope.
- **Scoped hydrate**: route ops hydrate WITHOUT the runtime tree (conversations/sessions — the bulk of a busy agent) via a new any-depth exclude pattern (`**/.houston/runtime/`); conversation ops still hydrate everything. Sync-back scope already excluded the runtime tree, so nothing can be deleted by its absence.
- **`/op` body cap** = the Files import cap (+1 MiB): an upload rides the op exactly as it rides the pod.
- **Fail-closed sync, for real**: the op-turns PR's decline-on-non-durable-sync edit never landed (its anchor did not match; the `agentMissing` decline did). Now: an op declines (gateway proxies) when any object did not durably persist (out of scope, size-rejected, surviving generation conflict) or a doc/transcript projection failed.

## Tests
`server-op.test.ts`: files list as a read op (user file present, runtime file neither listed nor hydrated), file download relays bytes + Content-Disposition, plus the existing routine/agentfile/attribution/conversation cases on a realistic seed (CLAUDE.md marker, not a runtime file). Host 1541 / runtime 1284 / runtime-client 178 green; boundaries clean.

## Adversarial review (Fable 5) — fixes folded in
- **No re-run after a durable sync** (High): the earlier "decline on any non-durable sync / projection failure" re-ran the op on the pod *after* the files had landed → a duplicate routine/mission. Now: nothing landed → decline (safe); a store size-rejection → 413 to the user; landed + a surviving conflict → ambiguous (502 at the gateway, never a silent re-run); a lagging doc projection after a durable sync answers the handler's status and logs loudly.
- **Admission before the body**: `/op` acquires its admission slot before draining the (up to ~135 MiB) body.
- **Byte-exact downloads**: `files/download` and `files/archive` always ride base64 (a `.json` file is `application/json` too); the MIME rule only covers handler JSON.
- **Allowlist on the decoded path** (what the handlers see), every `files/*` shape admitted (handler owns the 404).
- Tests tightened: the hydrate exclude is asserted on the manifest + hydrated tree; downloads must ride base64.

Gateway pairing: gethouston/cloud#289 (reads never proxy on failure, reply cap, 502 on relay failure).


## Second review (Codex gpt-5.6-sol) — fixes folded in
- **No delete after a refused upload** (High, data loss): a rename/move whose destination upload is rejected (store cap, conflict) held its delete pass — the only durable copy survives; the user gets a 413.
- **Exact runtime exclude**: `workspaces/*/*/.houston/runtime/` via a segment glob — a user project carrying its own `.houston/runtime` is hydrated like any other file (the `**/` form matched it).
- **Relay size guard**: a binary answer over the import cap is refused by Content-Length before it is buffered/base64'd on the shared worker.
- A lagging doc projection gets one more round before being accepted (files are already durable; never a re-run).
