### PR TITLE
Pool ops: a GET op carries no body to the handler (reads answered 500)

### DIFF
--- a/packages/host/src/op/dispatch.ts
+++ b/packages/host/src/op/dispatch.ts
@@ -161,12 +161,17 @@ export async function dispatchAgentOp(opts: {
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
   try {
     const { port } = server.address() as AddressInfo;
+    // A GET/HEAD must carry NO body (fetch throws on any, even ""), and the
+    // gateway sends an empty string on every route op.
+    const bodiless = method === "GET" || method === "HEAD";
+    const body = bodiless || !opts.request.body ? undefined : opts.request.body;
     const response = await fetch(`http://127.0.0.1:${port}/op`, {
       method,
-      headers: opts.request.contentType
-        ? { "Content-Type": opts.request.contentType }
-        : {},
-      body: opts.request.body,
+      headers:
+        opts.request.contentType && body !== undefined
+          ? { "Content-Type": opts.request.contentType }
+          : {},
+      ...(body !== undefined ? { body } : {}),
     });
     const contentType =
       response.headers.get("content-type") ?? "application/json";

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -179,6 +179,10 @@ export async function executeOp(
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    // Loud: a 500 here is the gateway's "worker_500" with no other trace.
+    console.error(
+      `[op] failed kind=${op.op.kind} ${op.op.kind === "route" ? `${op.op.method} ${op.op.rest}` : ""}: ${message}`,
+    );
     if (!res.headersSent) json(res, 500, { error: message });
   } finally {
     try {

--- a/packages/runtime/src/turn/server-op.test.ts
+++ b/packages/runtime/src/turn/server-op.test.ts
@@ -199,10 +199,14 @@ test("a files list runs as a READ op: no sync-back, runtime tree not hydrated", 
   );
   const { json } = await postOp(
     base,
+    // The gateway's exact envelope: an empty-string body + a content type
+    // ride along on EVERY route op, GET included.
     opBody(agentId, await heartbeatOK(), {
       kind: "route",
       method: "GET",
       rest: "files",
+      body: "",
+      contentType: "application/json",
     }),
   );
   expect(json.status).toBe(200);


### PR DESCRIPTION
## What broke
Live on staging after #1370: every Files-tab **read** op (list / read / download / archive) answered 500 while every write worked. The gateway sends `body: ""` on every route op; Node's `fetch` refuses *any* body on GET/HEAD (even an empty string), so the worker's loopback call threw before the handler ran, and the catch answered 500 with no log.

## Fix
- The loopback dispatcher omits the body (and its content type) on bodiless methods.
- The worker's op catch now logs (`[op] failed …`) — before, a 500 surfaced only as the gateway's `worker_500`.
- The read-op test sends the gateway's exact envelope shape (`body: ""` + content type); it fails without the fix and passes with it.

One file each in host/runtime; host 1541 + runtime 1285 green, Biome clean. Pairs with nothing — gateway unchanged.