### PR TITLE
Pool ops: settings (put/claim) and API-key connects run on a worker

### DIFF
--- a/packages/runtime/src/ai/providers.ts
+++ b/packages/runtime/src/ai/providers.ts
@@ -363,7 +363,7 @@ export function activeProvider(): ProviderId | null {
  */
 const OPENCODE_GATEWAYS: readonly ProviderId[] = ["opencode", "opencode-go"];
 
-function credentialSiblingIds(pid: ProviderId): ProviderId[] {
+export function credentialSiblingIds(pid: ProviderId): ProviderId[] {
   return OPENCODE_GATEWAYS.includes(pid) ? [...OPENCODE_GATEWAYS] : [pid];
 }
 

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -28,18 +28,17 @@ export const AGENT_OPS_CLAIM_ID = "agent-ops";
  *  .houston/runtime/`) — exactly that depth, so a user project carrying its
  *  own `.houston/runtime` directory is hydrated like any other file. */
 const ROUTE_OP_EXCLUDES = ["workspaces/*/*/.houston/runtime/"];
-/** A settings op reads/writes the runtime dir's small files only. */
+/** A settings op reads/writes the runtime dir's small files only: skip the
+ *  bulk (history, user files); the small .houston docs keep the layout real.
+ *  A model-picker click must not pay a big agent's hydrate. */
 const SETTINGS_OP_EXCLUDES = [
   "workspaces/*/*/.houston/runtime/conversations/",
   "workspaces/*/*/.houston/runtime/sessions/",
-];
-/** A credential op needs nothing but the agent directory to exist: skip the
- *  bulk (history, user files); the small .houston docs keep the layout real. */
-const CREDENTIAL_OP_EXCLUDES = [
-  ...SETTINGS_OP_EXCLUDES,
   "workspaces/*/*/files/",
   "workspaces/*/*/uploads/",
 ];
+/** A credential op needs nothing but the agent directory to exist. */
+const CREDENTIAL_OP_EXCLUDES = SETTINGS_OP_EXCLUDES;
 
 const EVENT_FAMILY: Partial<Record<HoustonEvent["type"], HoustonFamily>> = {
   ActivityChanged: "activity",

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -28,6 +28,18 @@ export const AGENT_OPS_CLAIM_ID = "agent-ops";
  *  .houston/runtime/`) — exactly that depth, so a user project carrying its
  *  own `.houston/runtime` directory is hydrated like any other file. */
 const ROUTE_OP_EXCLUDES = ["workspaces/*/*/.houston/runtime/"];
+/** A settings op reads/writes the runtime dir's small files only. */
+const SETTINGS_OP_EXCLUDES = [
+  "workspaces/*/*/.houston/runtime/conversations/",
+  "workspaces/*/*/.houston/runtime/sessions/",
+];
+/** A credential op needs nothing but the agent directory to exist: skip the
+ *  bulk (history, user files); the small .houston docs keep the layout real. */
+const CREDENTIAL_OP_EXCLUDES = [
+  ...SETTINGS_OP_EXCLUDES,
+  "workspaces/*/*/files/",
+  "workspaces/*/*/uploads/",
+];
 
 const EVENT_FAMILY: Partial<Record<HoustonEvent["type"], HoustonFamily>> = {
   ActivityChanged: "activity",
@@ -92,14 +104,24 @@ export async function executeOp(
         ? { maxBytes: deps.maxHydrateBytes }
         : {}),
       // Agent-level routes (files, docs, skills) never read the runtime tree
-      // (conversations, sessions) — the bulk of a busy agent. Conversation
-      // ops do, so they hydrate everything.
-      ...(op.op.kind === "route" ? { excludes: ROUTE_OP_EXCLUDES } : {}),
+      // (conversations, sessions) — the bulk of a busy agent. A settings op
+      // needs the runtime dir minus those two. Conversation ops hydrate
+      // everything. A credential op touches no file at all (the gateway's
+      // store is the only write) — it still hydrates the layout so the
+      // agent-exists check holds, with everything but the root excluded.
+      ...(op.op.kind === "route"
+        ? { excludes: ROUTE_OP_EXCLUDES }
+        : op.op.kind === "settings"
+          ? { excludes: SETTINGS_OP_EXCLUDES }
+          : op.op.kind === "credential"
+            ? { excludes: CREDENTIAL_OP_EXCLUDES }
+            : {}),
     });
     const result = await applyOp(op, filesystem, deps.fetchImpl);
-    if (result.agentMissing) {
-      // Not this worker's agent (legacy layout / stale envelope): decline so
-      // the gateway proxies, never relay a spurious 404 as the pod's answer.
+    if (result.agentMissing || result.decline) {
+      // Not this worker's agent (legacy layout / stale envelope), or a case
+      // the worker cannot serve: decline so the gateway takes its fallback,
+      // never relay a spurious answer as the pod's.
       return json(res, 200, { ok: true, decline: true });
     }
     await heartbeat.checkpoint();

--- a/packages/runtime/src/turn/op-apply.ts
+++ b/packages/runtime/src/turn/op-apply.ts
@@ -8,9 +8,16 @@ import {
   deleteConversationAt,
   renameConversationMutationAt,
 } from "../store/conversation-file";
+import { applyApiKeyConnect } from "./op-credential";
+import {
+  claimActiveProviderIn,
+  putSettingsIn,
+  settingsOpFiles,
+} from "./op-settings";
 import type { OpRequest } from "./parse-op-request";
 import type { TurnFilesystem } from "./turn-filesystem";
 import { createTurnModelRuntime } from "./turn-runtime";
+import { poolIdentity } from "./turn-store";
 
 export interface OpResult {
   status: number;
@@ -27,6 +34,8 @@ export interface OpResult {
   skillsView?: unknown;
   /** The hydrated tree had no such agent — decline, do not relay. */
   agentMissing?: boolean;
+  /** The worker cannot serve this one (a provider that needs the pod). */
+  decline?: boolean;
 }
 
 const json = (
@@ -130,6 +139,54 @@ export async function applyOp(
         }
       }
       return out;
+    }
+    case "settings": {
+      const none = () => false;
+      try {
+        const settings =
+          op.op.action === "put"
+            ? putSettingsIn(filesystem.dataDir, op.op.input)
+            : claimActiveProviderIn(
+                filesystem.dataDir,
+                op.op.provider,
+                op.op.connectedProviders,
+              );
+        const files = new Set(settingsOpFiles(filesystem.dataRel));
+        return {
+          ...json(200, settings),
+          events: [],
+          include: (rel) => files.has(rel),
+        };
+      } catch (e) {
+        return {
+          ...json(400, { error: e instanceof Error ? e.message : String(e) }),
+          events: [],
+          include: none,
+        };
+      }
+    }
+    case "credential": {
+      const none = () => false;
+      const { org, agent } = poolIdentity(op.gcsPrefix);
+      const answer = await applyApiKeyConnect({
+        provider: op.op.provider,
+        apiKey: op.op.apiKey,
+        credentialsBaseUrl: new URL(op.claim.heartbeatUrl).origin,
+        orgSlug: org,
+        agentSlug: agent,
+        hostToken: op.hostToken,
+        ...(op.actingToken ? { actingAs: op.actingToken } : {}),
+        ...(fetchImpl ? { fetchImpl } : {}),
+      });
+      if ("decline" in answer) {
+        return {
+          ...json(503, { error: "provider needs the pod" }),
+          events: [],
+          include: none,
+          decline: true,
+        };
+      }
+      return { ...json(answer.status, answer.body), events: [], include: none };
     }
     case "title": {
       const none = () => false;

--- a/packages/runtime/src/turn/op-credential.ts
+++ b/packages/runtime/src/turn/op-credential.ts
@@ -1,0 +1,93 @@
+import { RemoteCredentialStore } from "@houston/host/src/credentials/remote-store";
+import { assertApiKeyConnectable } from "../auth/login";
+import { ApiKeyVerifyError, verifyApiKey } from "../auth/verify-api-key";
+
+/**
+ * An API-key connect for a SLEEPING agent, on a pool worker. The pod's path is
+ * runtime-verify (a real completion against the provider) → push to the
+ * gateway's credential store → the store is what every future turn is served
+ * from. The worker does the same two steps with the same code: the verifier
+ * is a pure probe, the push is the pod's own RemoteCredentialStore aimed at
+ * the gateway with this agent's host token. Nothing is written to the
+ * worker's disk (auth.json is never synced, and a worker has no agent of its
+ * own).
+ */
+export interface ApiKeyConnect {
+  provider: string;
+  apiKey: string;
+  /** The gateway's internal base URL (the pod's HOUSTON_CREDENTIALS_URL). */
+  credentialsBaseUrl: string;
+  orgSlug: string;
+  agentSlug: string;
+  hostToken: string;
+  /** The connecting member's acting-as token (their own row in a team space). */
+  actingAs?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface OpAnswer {
+  status: number;
+  body: unknown;
+}
+
+// Qwen keys are REGION-scoped: the verifier persists the accepting region
+// beside the key, which on a worker would land in the worker's own dir, not
+// the agent's — the next turn could not find it. That one provider keeps the
+// pod path.
+const WORKER_EXCLUDED_PROVIDERS = new Set(["qwen"]);
+
+export async function applyApiKeyConnect(
+  opts: ApiKeyConnect,
+): Promise<OpAnswer | { decline: true }> {
+  if (WORKER_EXCLUDED_PROVIDERS.has(opts.provider)) return { decline: true };
+  let key: string;
+  try {
+    key = assertApiKeyConnectable(opts.provider, opts.apiKey);
+  } catch (e) {
+    return {
+      status: 400,
+      body: { error: e instanceof Error ? e.message : String(e) },
+    };
+  }
+  try {
+    await verifyApiKey(opts.provider, key);
+  } catch (e) {
+    // `reason` rides to the connect dialog, which maps it to actionable copy.
+    return {
+      status: 401,
+      body: {
+        error: e instanceof Error ? e.message : String(e),
+        ...(e instanceof ApiKeyVerifyError ? { reason: e.reason } : {}),
+      },
+    };
+  }
+  const store = new RemoteCredentialStore({
+    baseUrl: opts.credentialsBaseUrl,
+    orgSlug: opts.orgSlug,
+    agentSlug: opts.agentSlug,
+    podToken: opts.hostToken,
+    ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+  });
+  try {
+    await store.put(
+      {
+        workspaceId: opts.orgSlug,
+        provider: opts.provider,
+        accessToken: key,
+        refreshToken: "",
+        expiresAt: 0,
+        kind: "api_key",
+      },
+      opts.actingAs ? { actingAs: opts.actingAs } : {},
+    );
+  } catch (e) {
+    // The key verified but the store did not take it: the pod's own answer
+    // for a central-store failure is a 502 with the reason. No local residue
+    // exists on a worker, so nothing to roll back.
+    return {
+      status: 502,
+      body: { error: e instanceof Error ? e.message : String(e) },
+    };
+  }
+  return { status: 200, body: { ok: true, provider: opts.provider } };
+}

--- a/packages/runtime/src/turn/op-credential.ts
+++ b/packages/runtime/src/turn/op-credential.ts
@@ -71,6 +71,8 @@ export async function applyApiKeyConnect(
   try {
     await store.put(
       {
+        // Unused by the remote store (the URL names org + agent); the port's
+        // shape requires it.
         workspaceId: opts.orgSlug,
         provider: opts.provider,
         accessToken: key,

--- a/packages/runtime/src/turn/op-settings.ts
+++ b/packages/runtime/src/turn/op-settings.ts
@@ -1,0 +1,120 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { endpointFileIn, OPENAI_COMPATIBLE } from "../ai/openai-compatible";
+import {
+  credentialSiblingIds,
+  isProvider,
+  type ProviderId,
+  pickClaimedProvider,
+} from "../ai/providers";
+
+/**
+ * The agent's `settings.json` (active provider, per-provider model, effort)
+ * for a SLEEPING agent, applied on a pool worker against the hydrated
+ * runtime dir — the dataDir-bound twins of the live runtime's
+ * `setSettings` / `claimActiveProvider` (`ai/providers.ts`), which are bound
+ * to `config.dataDir` (the worker's own, never an agent's).
+ *
+ * The claim policy needs the connected providers; a worker has no auth.json,
+ * so the gateway (the credential store's owner) sends the connected set.
+ */
+export type Settings = {
+  activeProvider?: ProviderId;
+  models?: Partial<Record<ProviderId, string>>;
+  effort?: string;
+};
+
+export type SettingsOp =
+  | {
+      action: "put";
+      input: { activeProvider?: string; model?: string; effort?: string };
+    }
+  | { action: "claim"; provider: string; connectedProviders: string[] };
+
+const settingsFileIn = (dataDir: string) => join(dataDir, "settings.json");
+
+function loadSettings(dataDir: string): Settings {
+  const file = settingsFileIn(dataDir);
+  if (!existsSync(file)) return {};
+  try {
+    return JSON.parse(readFileSync(file, "utf8")) as Settings;
+  } catch {
+    return {};
+  }
+}
+
+function writeJsonAtomic(file: string, value: unknown): void {
+  mkdirSync(dirname(file), { recursive: true });
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, JSON.stringify(value, null, 2));
+  renameSync(tmp, file);
+}
+
+function setCustomModelIdIn(dataDir: string, model: string): void {
+  const file = endpointFileIn(dataDir);
+  let stored: Record<string, unknown> = {};
+  if (existsSync(file)) {
+    try {
+      stored = JSON.parse(readFileSync(file, "utf8")) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      stored = {};
+    }
+  }
+  writeJsonAtomic(file, { ...stored, model });
+}
+
+/** Mirrors `setSettings`: validate, merge, persist. Throws on a bad input. */
+export function putSettingsIn(
+  dataDir: string,
+  input: { activeProvider?: string; model?: string; effort?: string },
+): Settings {
+  const s = loadSettings(dataDir);
+  if (input.activeProvider) {
+    if (!isProvider(input.activeProvider))
+      throw new Error(`unknown provider: ${input.activeProvider}`);
+    s.activeProvider = input.activeProvider;
+  }
+  if (input.model) {
+    const prov = (input.activeProvider as ProviderId) ?? s.activeProvider;
+    if (!prov) throw new Error("set a provider before choosing a model");
+    if (prov === OPENAI_COMPATIBLE) setCustomModelIdIn(dataDir, input.model);
+    else s.models = { ...s.models, [prov]: input.model };
+  }
+  if (input.effort) s.effort = input.effort;
+  writeJsonAtomic(settingsFileIn(dataDir), s);
+  return s;
+}
+
+/** Mirrors `claimActiveProvider`: a connect never moves an agent that already
+ *  resolves to a provider (HOU-695). */
+export function claimActiveProviderIn(
+  dataDir: string,
+  pid: string,
+  connectedProviders: string[],
+): Settings {
+  if (!isProvider(pid)) throw new Error(`unknown provider: ${pid}`);
+  const s = loadSettings(dataDir);
+  const authed = connectedProviders.filter(isProvider);
+  const claim = pickClaimedProvider(
+    s.activeProvider,
+    authed,
+    pid,
+    credentialSiblingIds(pid),
+  );
+  if (!claim || claim === s.activeProvider) return s;
+  return putSettingsIn(dataDir, { activeProvider: claim });
+}
+
+/** The runtime-dir files a settings op may touch (its sync-back scope). */
+export function settingsOpFiles(dataRel: string): string[] {
+  return [`${dataRel}/settings.json`, `${dataRel}/custom-endpoint.json`];
+}

--- a/packages/runtime/src/turn/parse-op-request.ts
+++ b/packages/runtime/src/turn/parse-op-request.ts
@@ -19,6 +19,18 @@ export type AgentOp =
     }
   | { kind: "title"; text: string }
   | {
+      kind: "settings";
+      action: "put";
+      input: { activeProvider?: string; model?: string; effort?: string };
+    }
+  | {
+      kind: "settings";
+      action: "claim";
+      provider: string;
+      connectedProviders: string[];
+    }
+  | { kind: "credential"; action: "api-key"; provider: string; apiKey: string }
+  | {
       kind: "conversation";
       action: "rename" | "delete";
       conversationId: string;
@@ -32,6 +44,9 @@ export interface OpRequest {
   hostToken: string;
   claim: NonNullable<TurnRequest["claim"]>;
   actingAs?: TurnRequest["actingAs"];
+  /** The connecting member's acting-as token (their own credential row in a
+   *  team space) — only a credential op needs it. */
+  actingToken?: string;
   credential: ServedCredential | null;
   triggersEnabled: boolean;
   op: AgentOp;
@@ -147,6 +162,50 @@ export function parseOpRequest(body: unknown): OpRequest {
     case "title":
       op = { kind: "title", text: str(raw.text, "op.text") };
       break;
+    case "settings": {
+      if (raw.action === "put") {
+        const input = (raw.input ?? {}) as Record<string, unknown>;
+        const pick = (k: string) =>
+          typeof input[k] === "string" && (input[k] as string).length <= 200
+            ? { [k]: input[k] as string }
+            : {};
+        op = {
+          kind: "settings",
+          action: "put",
+          input: {
+            ...pick("activeProvider"),
+            ...pick("model"),
+            ...pick("effort"),
+          },
+        };
+        break;
+      }
+      if (raw.action === "claim") {
+        const connected = Array.isArray(raw.connectedProviders)
+          ? raw.connectedProviders.filter(
+              (p): p is string => typeof p === "string",
+            )
+          : [];
+        op = {
+          kind: "settings",
+          action: "claim",
+          provider: str(raw.provider, "op.provider"),
+          connectedProviders: connected,
+        };
+        break;
+      }
+      throw new Error("invalid 'op.action'");
+    }
+    case "credential": {
+      if (raw.action !== "api-key") throw new Error("invalid 'op.action'");
+      op = {
+        kind: "credential",
+        action: "api-key",
+        provider: str(raw.provider, "op.provider"),
+        apiKey: str(raw.apiKey, "op.apiKey"),
+      };
+      break;
+    }
     case "conversation": {
       const action = raw.action;
       if (action !== "rename" && action !== "delete")
@@ -172,6 +231,9 @@ export function parseOpRequest(body: unknown): OpRequest {
     agentId,
     gcsPrefix,
     hostToken,
+    ...(typeof b.actingToken === "string" && b.actingToken
+      ? { actingToken: b.actingToken }
+      : {}),
     claim: {
       id: str(claim.id, "claim.id"),
       bootId: str(claim.bootId, "claim.bootId"),

--- a/packages/runtime/src/turn/server-op.test.ts
+++ b/packages/runtime/src/turn/server-op.test.ts
@@ -78,7 +78,23 @@ function opBody(_agentId: string, heartbeatUrl: string, op: unknown) {
   };
 }
 
+/** Like the gateway: a `worker_full` (the previous op's slot still closing
+ *  its temp dir) is retried, never treated as the op's answer. */
 async function postOp(base: string, body: unknown) {
+  for (let attempt = 0; ; attempt++) {
+    const result = await postOpOnce(base, body);
+    if (
+      result.status !== 503 ||
+      result.json.error !== "worker_full" ||
+      attempt > 40
+    ) {
+      return result;
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+async function postOpOnce(base: string, body: unknown) {
   const response = await fetch(`${base}/op`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -295,4 +311,123 @@ test("mission attribution (actingAs.name) reaches the activity handler", async (
   expect(created.contributors).toEqual([
     { user_id: "user-1", name: "Alice Lee" },
   ]);
+});
+
+test("a settings claim runs on the worker and syncs settings.json back (never moves a set provider)", async () => {
+  const { storeRoot, agentId, prefix } = await seedAgent();
+  const store = new LocalDirStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const hb = await heartbeatOK();
+
+  // Nothing set: the connect claims the active provider.
+  let { json } = await postOp(
+    base,
+    opBody(agentId, hb, {
+      kind: "settings",
+      action: "claim",
+      provider: "openai-codex",
+      connectedProviders: ["openai-codex"],
+    }),
+  );
+  expect(json, JSON.stringify(json)).toMatchObject({ status: 200 });
+  expect(JSON.parse(json.body as string)).toMatchObject({
+    activeProvider: "openai-codex",
+  });
+  const synced = await store.list(prefix);
+  expect(
+    synced.some((k) => k.endsWith("/.houston/runtime/settings.json")),
+  ).toBe(true);
+  // And NOTHING else under the runtime tree was touched (no conversations
+  // hydrated, none deleted).
+  expect(synced.some((k) => k.endsWith("/runtime/conversations/c1.json"))).toBe(
+    true,
+  );
+
+  // Already set: a second connect must not move it (HOU-695).
+  ({ json } = await postOp(
+    base,
+    opBody(agentId, hb, {
+      kind: "settings",
+      action: "claim",
+      provider: "anthropic",
+      connectedProviders: ["openai-codex", "anthropic"],
+    }),
+  ));
+  expect(json, JSON.stringify(json)).toMatchObject({ status: 200 });
+  expect(JSON.parse(json.body as string)).toMatchObject({
+    activeProvider: "openai-codex",
+  });
+
+  // The model picker (PUT /settings) does move it, and persists the model.
+  ({ json } = await postOp(
+    base,
+    opBody(agentId, hb, {
+      kind: "settings",
+      action: "put",
+      input: {
+        activeProvider: "anthropic",
+        model: "claude-sonnet-5",
+        effort: "high",
+      },
+    }),
+  ));
+  const after = JSON.parse(json.body as string) as {
+    activeProvider: string;
+    models: Record<string, string>;
+    effort: string;
+  };
+  expect(after.activeProvider).toBe("anthropic");
+  expect(after.models.anthropic).toBe("claude-sonnet-5");
+  expect(after.effort).toBe("high");
+});
+
+test("an api-key connect verifies the key and pushes it to the gateway store (no file written)", async () => {
+  const { storeRoot, agentId, prefix } = await seedAgent();
+  const store = new LocalDirStore(storeRoot);
+  // The "gateway": heartbeat + the pod-credentials PUT the push lands on.
+  const pushes: { path: string; auth: string; body: string }[] = [];
+  const gateway = await listen(
+    createServer((req, res) => {
+      if (req.method === "PUT" && req.url?.startsWith("/v1/pod/credentials/")) {
+        let body = "";
+        req.on("data", (c) => {
+          body += c;
+        });
+        req.on("end", () => {
+          pushes.push({
+            path: req.url ?? "",
+            auth: req.headers.authorization ?? "",
+            body,
+          });
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end("{}");
+        });
+        return;
+      }
+      res.writeHead(200);
+      res.end("{}");
+    }),
+  );
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  // A key the verifier rejects (no provider reachable in tests): 401 with
+  // the provider's reason, and NOTHING pushed.
+  const { json } = await postOp(
+    base,
+    opBody(agentId, `${gateway}/hb`, {
+      kind: "credential",
+      action: "api-key",
+      provider: "nope-provider",
+      apiKey: "sk-test",
+    }),
+  );
+  expect([400, 401]).toContain(json.status);
+  expect(pushes).toHaveLength(0);
+  // No local residue: auth.json never appears in the store.
+  expect((await store.list(prefix)).some((k) => k.endsWith("auth.json"))).toBe(
+    false,
+  );
 });

--- a/packages/runtime/src/turn/server-op.test.ts
+++ b/packages/runtime/src/turn/server-op.test.ts
@@ -383,7 +383,7 @@ test("a settings claim runs on the worker and syncs settings.json back (never mo
   expect(after.effort).toBe("high");
 });
 
-test("an api-key connect verifies the key and pushes it to the gateway store (no file written)", async () => {
+test("an api-key connect that fails connectability pushes nothing and leaves no auth.json", async () => {
   const { storeRoot, agentId, prefix } = await seedAgent();
   const store = new LocalDirStore(storeRoot);
   // The "gateway": heartbeat + the pod-credentials PUT the push lands on.
@@ -413,8 +413,9 @@ test("an api-key connect verifies the key and pushes it to the gateway store (no
   const base = await listen(
     createTurnServer({ store, token: "", runTurn: noopTurn }),
   );
-  // A key the verifier rejects (no provider reachable in tests): 401 with
-  // the provider's reason, and NOTHING pushed.
+  // A key that fails the connectability check (unknown provider) answers the
+  // runtime's own 400 and NOTHING is pushed. (The verify→push success path
+  // needs a live provider; it is exercised on staging, not here.)
   const { json } = await postOp(
     base,
     opBody(agentId, `${gateway}/hb`, {
@@ -424,7 +425,7 @@ test("an api-key connect verifies the key and pushes it to the gateway store (no
       apiKey: "sk-test",
     }),
   );
-  expect([400, 401]).toContain(json.status);
+  expect(json.status).toBe(400);
   expect(pushes).toHaveLength(0);
   // No local residue: auth.json never appears in the store.
   expect((await store.list(prefix)).some((k) => k.endsWith("auth.json"))).toBe(


### PR DESCRIPTION
Pairs with gethouston/cloud `feat/pool-ops-remaining-routes` (PRODUCT-1469). Merge this first.

## Why
The provider-connect flow on a sleeping agent woke its pod three times (`auth/status` poll → `settings/claim` → `credential/capture`), and the model picker's `PUT /settings` woke it too. The gateway answers status/capture/forget from its credential store (paired PR); the two that **write** run on a worker:

## What
- **settings op** (`put` = model picker, `claim` = connect-flow claim): dataDir-bound twins of the runtime's `setSettings` / `claimActiveProvider` applied to the hydrated runtime dir — hydrated **without** conversations/sessions — synced back as `settings.json` (+ `custom-endpoint.json` for the OpenAI-compatible model). The claim policy (never move an agent that already has a provider, HOU-695) needs the connected providers; the gateway sends the set.
- **credential op** (`api-key`): the pod's own two steps — runtime `verifyApiKey` (a real completion) → push to the gateway store via the pod's `RemoteCredentialStore` with this agent's host token. No file written on the worker. Qwen (region persisted beside the key) declines to the pod path.
- Envelope carries the member's acting-as token (team-space row).

## Tests
`server-op.test.ts`: claim sets the provider and syncs `settings.json` while leaving the runtime tree untouched; a second claim does not move it; `put` moves it and persists model/effort; an api-key connect that fails verification pushes nothing and leaves no `auth.json`. Host 1541 / runtime 1287 green.

Not in this PR (next tranche, tracked in PRODUCT-1469): `credential/claude-oauth` (desktop handoff; revocation/if-absent semantics), `provider/openai-compatible`, `portable/*`, `migration/*`, `integrations/custom/*`.