### PR TITLE
fix(web): gate agent-configs + integrations/session on deployment capability flags

### DIFF
--- a/packages/web/src/engine-adapter/client/agents-mixin.ts
+++ b/packages/web/src/engine-adapter/client/agents-mixin.ts
@@ -10,6 +10,7 @@ import type {
 } from "../../../../../ui/engine-client/src/types";
 import * as agents from "../agents";
 import * as controlPlane from "../control-plane";
+import { deploymentServes } from "./host-capabilities";
 import type { BaseCtor } from "./mixin";
 
 export function AgentsMixin<TBase extends BaseCtor>(Base: TBase) {
@@ -141,6 +142,10 @@ export function AgentsMixin<TBase extends BaseCtor>(Base: TBase) {
     // no host to keep a library — nothing installed there is the honest answer.
     async listInstalledConfigs(): Promise<InstalledConfig[]> {
       if (!this.ctx.cp) return [];
+      // A deployment that advertises `agentConfigLibrary: false` (the hosted
+      // gateway) is skipped outright; the 404 fallback inside stays for
+      // deployments that predate the flag (PRODUCT-1474).
+      if (!(await deploymentServes(this.ctx, "agentConfigLibrary"))) return [];
       return controlPlane.listInstalledConfigs(this.ctx.cp);
     }
     async installAgentFromGithub(

--- a/packages/web/src/engine-adapter/client/context.ts
+++ b/packages/web/src/engine-adapter/client/context.ts
@@ -4,6 +4,7 @@ import type { HoustonSdk } from "@houston/sdk";
 // `cp/*` submodules directly: the web test suite mocks the barrel module
 // (`vi.mock("…/control-plane")`) and overrides `runtimeClientFor` /
 // `gatewayAuthFetch` etc. — a direct submodule import would bypass the mock.
+import type { Capabilities } from "../../../../../ui/engine-client/src/types";
 import type { ControlPlaneConfig } from "../control-plane";
 import {
   gatewayAuthFetch,
@@ -85,6 +86,11 @@ export class AdapterContext {
    *  id no server speaks), resolved once and shared by every caller that puts a
    *  workspace id on the wire. See `wire-workspace-id.ts`. */
   readonly workspaceIds = new WorkspaceIdResolver(this);
+  /**
+   * Memo for `deploymentServes()` (host-capabilities.ts): the deployment's
+   * advertised capabilities, fetched once per endpoint. `null` = probe failed.
+   */
+  deploymentCaps: Promise<Capabilities | null> | undefined;
   /** In-flight cloud device-code logins, keyed `${agentId}:${providerId}` — the poll guard. */
   readonly activeLogins = new Set<string>();
   /** Per-provider auth-status pollers that translate login completion into events (local mode). */
@@ -150,6 +156,8 @@ export class AdapterContext {
    */
   setEndpoint(opts: { baseUrl: string; token: string }): void {
     this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    // A repoint may land on a different deployment; re-probe its flags.
+    this.deploymentCaps = undefined;
     this.token = opts.token;
     if (this._cp) {
       this._cp.baseUrl = this.baseUrl;

--- a/packages/web/src/engine-adapter/client/host-capabilities.ts
+++ b/packages/web/src/engine-adapter/client/host-capabilities.ts
@@ -26,3 +26,28 @@ export async function fetchCapabilities(
   }
   return (await res.json()) as Capabilities;
 }
+
+/**
+ * Deployment-level capability flags the adapter consults BEFORE a request the
+ * deployment may not serve (PRODUCT-1474: `agentConfigLibrary`,
+ * `integrationSessionSink`). These describe the deployment, not the active
+ * space, so one fetch per endpoint is enough; `AdapterContext.setEndpoint`
+ * clears the memo because the new endpoint may be a different deployment.
+ *
+ * Tri-state on purpose: `false` only when the server EXPLICITLY says so. An
+ * absent flag (a gateway or host that predates it) and a failed probe both
+ * resolve `true`, keeping the caller on its legacy probe-and-swallow-404 path
+ * rather than silently dropping a request on a guess. A failed probe is also
+ * forgotten, so the next call asks again.
+ */
+export function deploymentServes(
+  ctx: AdapterContext,
+  flag: "agentConfigLibrary" | "integrationSessionSink",
+): Promise<boolean> {
+  ctx.deploymentCaps ??= fetchCapabilities(ctx).catch((err) => {
+    console.warn("[capabilities] deployment probe failed", err);
+    ctx.deploymentCaps = undefined;
+    return null;
+  });
+  return ctx.deploymentCaps.then((caps) => caps?.[flag] !== false);
+}

--- a/packages/web/src/engine-adapter/client/integrations-mixin.ts
+++ b/packages/web/src/engine-adapter/client/integrations-mixin.ts
@@ -1,5 +1,6 @@
 import { EngineError } from "@houston/runtime-client";
 import * as controlPlane from "../control-plane";
+import { deploymentServes } from "./host-capabilities";
 import type { BaseCtor } from "./mixin";
 
 export function IntegrationsMixin<TBase extends BaseCtor>(Base: TBase) {
@@ -13,6 +14,10 @@ export function IntegrationsMixin<TBase extends BaseCtor>(Base: TBase) {
     }
     async setIntegrationSession(token: string | null): Promise<void> {
       if (!this.ctx.cp) return;
+      // The hosted gateway advertises `integrationSessionSink: false` — it
+      // verifies JWTs itself — so the push is skipped; the 404 swallow below
+      // stays for deployments that predate the flag (PRODUCT-1474).
+      if (!(await deploymentServes(this.ctx, "integrationSessionSink"))) return;
       // SDK delegates the byte-identical PUT /v1/integrations/session. The SDK
       // PROPAGATES a 404; web must keep swallowing it — a deployment with no
       // gateway session sink (the cloud host verifies JWTs itself, self-host /

--- a/packages/web/tests/gateway-404-fallbacks.test.ts
+++ b/packages/web/tests/gateway-404-fallbacks.test.ts
@@ -157,3 +157,81 @@ test("every other /v1/me/profile failure still propagates — never swallowed", 
     "profile exploded (engine error 500)",
   );
 });
+
+// PRODUCT-1474: the deployment SAYS which of these routes it serves, so the
+// client stops discovering the gap by 404. Absent flag = legacy probe.
+
+test("agentConfigLibrary:false skips /v1/agent-configs entirely", async () => {
+  const calls = stubFetch(
+    json(200, { profile: "cloud", agentConfigLibrary: false }),
+  );
+  const client = new HoustonClient({ ...CFG, controlPlane: true });
+
+  await expect(client.listInstalledConfigs()).resolves.toEqual([]);
+
+  expect(calls).toEqual(["https://gateway.example/v1/capabilities"]);
+});
+
+test("integrationSessionSink:false skips PUT /v1/integrations/session", async () => {
+  const calls = stubFetch(
+    json(200, { profile: "cloud", integrationSessionSink: false }),
+  );
+  const client = new HoustonClient({ ...CFG, controlPlane: true });
+
+  await expect(client.setIntegrationSession("tok")).resolves.toBeUndefined();
+
+  expect(calls).toEqual(["https://gateway.example/v1/capabilities"]);
+});
+
+test("the deployment flags are probed once per client, not per call", async () => {
+  const calls = stubFetch(
+    json(200, {
+      profile: "cloud",
+      agentConfigLibrary: false,
+      integrationSessionSink: false,
+    }),
+  );
+  const client = new HoustonClient({ ...CFG, controlPlane: true });
+
+  await client.listInstalledConfigs();
+  await client.setIntegrationSession("tok");
+  await client.listInstalledConfigs();
+
+  expect(calls).toEqual(["https://gateway.example/v1/capabilities"]);
+});
+
+test("an absent flag keeps the legacy probe: the route is tried and its 404 still swallowed", async () => {
+  const calls = stubFetch(
+    json(200, { profile: "cloud" }),
+    json(404, { error: "not found" }),
+    json(404, { error: "not found" }),
+  );
+  const client = new HoustonClient({ ...CFG, controlPlane: true });
+
+  await expect(client.listInstalledConfigs()).resolves.toEqual([]);
+  await expect(client.setIntegrationSession("tok")).resolves.toBeUndefined();
+
+  expect(calls).toEqual([
+    "https://gateway.example/v1/capabilities",
+    "https://gateway.example/v1/agent-configs",
+    "https://gateway.example/v1/integrations/session",
+  ]);
+});
+
+test("a failed capabilities probe falls back to the legacy path and re-probes next call", async () => {
+  const calls = stubFetch(
+    json(500, { error: "boom" }),
+    json(200, []),
+    json(200, { profile: "cloud", agentConfigLibrary: false }),
+  );
+  const client = new HoustonClient({ ...CFG, controlPlane: true });
+
+  await expect(client.listInstalledConfigs()).resolves.toEqual([]);
+  await expect(client.listInstalledConfigs()).resolves.toEqual([]);
+
+  expect(calls).toEqual([
+    "https://gateway.example/v1/capabilities",
+    "https://gateway.example/v1/agent-configs",
+    "https://gateway.example/v1/capabilities",
+  ]);
+});

--- a/packages/web/tests/sdk-delegation-wave2b.test.ts
+++ b/packages/web/tests/sdk-delegation-wave2b.test.ts
@@ -191,17 +191,23 @@ test("disconnectIntegration delegates a byte-identical POST .../disconnect", asy
   expect(calls[0].body).toBe(JSON.stringify({ toolkit: "gmail" }));
 });
 
+// The adapter first asks /v1/capabilities whether the deployment has a
+// session sink (PRODUCT-1474); a deployment that does not say `false` gets the
+// legacy PUT.
 test("setIntegrationSession delegates a byte-identical PUT .../session", async () => {
-  stubFetch(json(200, {}));
+  stubFetch(json(200, { profile: "local" }), json(200, {}));
   await client().setIntegrationSession("tok");
-  expect(calls).toHaveLength(1);
-  expect(calls[0].method).toBe("PUT");
-  expect(calls[0].url).toBe(`${BASE}/v1/integrations/session`);
-  expect(calls[0].body).toBe(JSON.stringify({ token: "tok" }));
+  expect(calls).toHaveLength(2);
+  expect(calls[1].method).toBe("PUT");
+  expect(calls[1].url).toBe(`${BASE}/v1/integrations/session`);
+  expect(calls[1].body).toBe(JSON.stringify({ token: "tok" }));
 });
 
 test("setIntegrationSession swallows a 404 (deployment with no session sink)", async () => {
-  stubFetch(json(404, { error: "no session sink" }));
+  stubFetch(
+    json(200, { profile: "local" }),
+    json(404, { error: "no session sink" }),
+  );
   await expect(client().setIntegrationSession("tok")).resolves.toBeUndefined();
 });
 

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -156,6 +156,21 @@ export interface Capabilities {
    * enforcer (owner of a solo team with no live subscription).
    */
   workspaceDelete?: boolean;
+  /**
+   * Whether this deployment keeps an account-level agent-config library
+   * (`GET /v1/agent-configs`, PRODUCT-1474). The hosted gateway says `false`
+   * (one pod per agent, no shared disk) so the client skips the read instead
+   * of discovering the missing route by 404; absent on deployments that
+   * predate the flag, where the client keeps the legacy probe.
+   */
+  agentConfigLibrary?: boolean;
+  /**
+   * Whether this deployment accepts the caller's session token at
+   * `PUT /v1/integrations/session` (PRODUCT-1474). `false` on the hosted
+   * gateway, which verifies JWTs itself; `true` on a self-host engine that
+   * forwards integration calls with the pushed session. Absent → legacy probe.
+   */
+  integrationSessionSink?: boolean;
 }
 
 // ---------- Org / roles (multiplayer) ----------


### PR DESCRIPTION
PRODUCT-1474 — https://linear.app/houston-ai/issue/PRODUCT-1474
Pairs with gethouston/cloud#296 (gateway advertises the flags). Safe to merge in either order.

The adapter discovered two self-host-only routes by probing the gateway and swallowing the 404 — a red "Failed to load resource" in the console on every boot:
- `GET /v1/agent-configs` (account-level config library)
- `PUT /v1/integrations/session` (session sink)

Now `Capabilities` carries `agentConfigLibrary` / `integrationSessionSink` and the adapter skips the request when the deployment says `false`. The probe is one `/v1/capabilities` fetch per endpoint (memoized on `AdapterContext`, cleared on `setEndpoint`).

Tri-state on purpose: absent flag (older gateway, any self-host engine) and a failed probe both keep the legacy probe-and-swallow path, so nothing is dropped on a guess.

Tests: `gateway-404-fallbacks.test.ts` (+5: skip, skip, memo, absent-flag legacy path, failed-probe fallback + re-probe); `sdk-delegation-wave2b.test.ts` updated for the leading capabilities call. typecheck + biome check green.