### PR TITLE
feat(runtime): lazy hot-set hydrate for pool ops and turns (PRODUCT-1470)

### DIFF
--- a/packages/host/src/op/dispatch-relay.ts
+++ b/packages/host/src/op/dispatch-relay.ts
@@ -1,0 +1,62 @@
+import type { HoustonEvent } from "@houston/protocol";
+import { MAX_UPLOAD_BYTES } from "../turn/files-import";
+import type { AgentOpResponse } from "./dispatch";
+
+// Only the handlers' own JSON is safe to carry as text: a downloaded file is
+// relayed byte-exact (a Latin-1 CSV through `response.text()` would be
+// re-encoded), so every non-JSON body rides base64.
+const TEXT_BODY = /^application\/json/i;
+const RELAYED_HEADERS = ["content-disposition", "cache-control"] as const;
+export const TOO_LARGE_MESSAGE =
+  "file too large to fetch while the agent sleeps";
+
+/** Turn the loopback handler's response into the op envelope's answer. */
+export async function relayAgentOpResponse(
+  response: Response,
+  rest: string,
+  events: HoustonEvent[],
+): Promise<AgentOpResponse> {
+  const contentType =
+    response.headers.get("content-type") ?? "application/json";
+  const headers: Record<string, string> = {};
+  for (const name of RELAYED_HEADERS) {
+    const value = response.headers.get(name);
+    if (value) headers[name] = value;
+  }
+  const relayed = Object.keys(headers).length > 0 ? { headers } : {};
+  // A download/archive is always bytes, whatever its MIME (a `.json` file
+  // is `application/json` too); everything else is the handler's own JSON.
+  const binaryRoute = /^files\/(download|archive)$/.test(rest);
+  if (!binaryRoute && TEXT_BODY.test(contentType)) {
+    return {
+      status: response.status,
+      contentType,
+      body: await response.text(),
+      ...relayed,
+      events,
+    };
+  }
+  const declared = Number(response.headers.get("content-length") ?? "0");
+  if (declared > MAX_UPLOAD_BYTES) {
+    // A body this size cannot ride a JSON envelope on a shared worker
+    // (base64 + envelope copies). Refuse before buffering; the gateway
+    // answers the read as unavailable rather than waking a pod.
+    await response.body?.cancel();
+    return {
+      tooLarge: true,
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ error: TOO_LARGE_MESSAGE }),
+      events,
+    };
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  return {
+    status: response.status,
+    contentType,
+    body: "",
+    bodyBase64: bytes.toString("base64"),
+    ...relayed,
+    events,
+  };
+}

--- a/packages/host/src/op/dispatch.ts
+++ b/packages/host/src/op/dispatch.ts
@@ -14,8 +14,8 @@ import { handleSkillsRemote } from "../routes/skills-remote";
 import { LocalWorkspaceStore } from "../store/local";
 import { handleAttachments } from "../turn/attachments";
 import { handleFiles } from "../turn/files";
-import { MAX_UPLOAD_BYTES } from "../turn/files-import";
-import { FsVfs } from "../vfs";
+import { FsVfs, LazyObjectTooLargeError, type Vfs } from "../vfs";
+import { relayAgentOpResponse, TOO_LARGE_MESSAGE } from "./dispatch-relay";
 
 /**
  * A write the gateway routes to a pool worker instead of waking the agent's
@@ -56,12 +56,6 @@ export interface AgentOpResponse {
   events: HoustonEvent[];
 }
 
-// Only the handlers' own JSON is safe to carry as text: a downloaded file is
-// relayed byte-exact (a Latin-1 CSV through `response.text()` would be
-// re-encoded), so every non-JSON body rides base64.
-const TEXT_BODY = /^application\/json/i;
-const RELAYED_HEADERS = ["content-disposition", "cache-control"] as const;
-
 /**
  * Dispatch one op against `workspacesRoot` (the hydrated `workspaces/` dir)
  * for `agentId`. Runs the handler chain over a loopback server so the
@@ -73,6 +67,10 @@ export async function dispatchAgentOp(opts: {
   agentId: string;
   request: AgentOpRequest;
   fetchImpl?: typeof fetch;
+  /** The handlers' file port, rooted at `workspacesRoot`. Default: the real
+   *  directory. A lazy store-backed vfs lets an op run over a manifest-only
+   *  tree that downloads objects on first read. */
+  vfs?: Vfs;
 }): Promise<AgentOpResponse> {
   const store = new LocalWorkspaceStore(opts.workspacesRoot);
   const agent = await store.getAgent(opts.agentId);
@@ -86,7 +84,7 @@ export async function dispatchAgentOp(opts: {
       events: [],
     };
   }
-  const vfs = new FsVfs(opts.workspacesRoot);
+  const vfs = opts.vfs ?? new FsVfs(opts.workspacesRoot);
   const paths = new LocalPaths();
   const ctx = { workspace, agent };
   const events: HoustonEvent[] = [];
@@ -148,6 +146,14 @@ export async function dispatchAgentOp(opts: {
   };
   const server = createServer((req, res) => {
     handler(req, res).catch((error: unknown) => {
+      if (error instanceof LazyObjectTooLargeError) {
+        // Refused before the download: the same answer the relay cap gives.
+        if (!res.headersSent) {
+          res.writeHead(503, { "Content-Type": "application/json" });
+        }
+        res.end(JSON.stringify({ error: TOO_LARGE_MESSAGE }));
+        return;
+      }
       if (!res.headersSent) {
         res.writeHead(500, { "Content-Type": "application/json" });
       }
@@ -173,51 +179,7 @@ export async function dispatchAgentOp(opts: {
           : {},
       ...(body !== undefined ? { body } : {}),
     });
-    const contentType =
-      response.headers.get("content-type") ?? "application/json";
-    const headers: Record<string, string> = {};
-    for (const name of RELAYED_HEADERS) {
-      const value = response.headers.get(name);
-      if (value) headers[name] = value;
-    }
-    const relayed = Object.keys(headers).length > 0 ? { headers } : {};
-    // A download/archive is always bytes, whatever its MIME (a `.json` file
-    // is `application/json` too); everything else is the handler's own JSON.
-    const binaryRoute = /^files\/(download|archive)$/.test(rest);
-    if (!binaryRoute && TEXT_BODY.test(contentType)) {
-      return {
-        status: response.status,
-        contentType,
-        body: await response.text(),
-        ...relayed,
-        events,
-      };
-    }
-    const declared = Number(response.headers.get("content-length") ?? "0");
-    if (declared > MAX_UPLOAD_BYTES) {
-      // A body this size cannot ride a JSON envelope on a shared worker
-      // (base64 + envelope copies). Refuse before buffering; the gateway
-      // answers the read as unavailable rather than waking a pod.
-      await response.body?.cancel();
-      return {
-        tooLarge: true,
-        status: 503,
-        contentType: "application/json",
-        body: JSON.stringify({
-          error: "file too large to fetch while the agent sleeps",
-        }),
-        events,
-      };
-    }
-    const bytes = Buffer.from(await response.arrayBuffer());
-    return {
-      status: response.status,
-      contentType,
-      body: "",
-      bodyBase64: bytes.toString("base64"),
-      ...relayed,
-      events,
-    };
+    return relayAgentOpResponse(response, rest, events);
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }

--- a/packages/host/src/op/dispatch.ts
+++ b/packages/host/src/op/dispatch.ts
@@ -14,7 +14,7 @@ import { handleSkillsRemote } from "../routes/skills-remote";
 import { LocalWorkspaceStore } from "../store/local";
 import { handleAttachments } from "../turn/attachments";
 import { handleFiles } from "../turn/files";
-import { FsVfs, LazyObjectTooLargeError, type Vfs } from "../vfs";
+import { FsVfs, LazyReadRefusedError, type Vfs } from "../vfs";
 import { relayAgentOpResponse, TOO_LARGE_MESSAGE } from "./dispatch-relay";
 
 /**
@@ -95,6 +95,10 @@ export async function dispatchAgentOp(opts: {
     opts.request;
   const query = new URLSearchParams(opts.request.query ?? "");
 
+  // A refused lazy read answers 503 from INSIDE the handler chain (the
+  // handler may be half-way through a multi-key mutation); the flag tells
+  // the caller to discard the overlay instead of syncing a partial result.
+  let refused = false;
   const handler = async (req: IncomingMessage, res: ServerResponse) => {
     // Files (list/read/download/archive/import/move/rename/folder): the
     // Files tab, byte-identical to the pod.
@@ -146,7 +150,8 @@ export async function dispatchAgentOp(opts: {
   };
   const server = createServer((req, res) => {
     handler(req, res).catch((error: unknown) => {
-      if (error instanceof LazyObjectTooLargeError) {
+      if (error instanceof LazyReadRefusedError) {
+        refused = true;
         // Refused before the download: the same answer the relay cap gives.
         if (!res.headersSent) {
           res.writeHead(503, { "Content-Type": "application/json" });
@@ -179,7 +184,8 @@ export async function dispatchAgentOp(opts: {
           : {},
       ...(body !== undefined ? { body } : {}),
     });
-    return relayAgentOpResponse(response, rest, events);
+    const relayed = await relayAgentOpResponse(response, rest, events);
+    return refused ? { ...relayed, tooLarge: true } : relayed;
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }

--- a/packages/host/src/vfs/index.ts
+++ b/packages/host/src/vfs/index.ts
@@ -4,7 +4,7 @@ export { FsVfs } from "./fs";
 // this open barrel.
 export { LazyStoreVfs } from "./lazy-store";
 export {
-  LazyObjectTooLargeError,
+  LazyReadRefusedError,
   type LazyStoreVfsOptions,
   UNREAD_HASH,
 } from "./lazy-store-types";

--- a/packages/host/src/vfs/index.ts
+++ b/packages/host/src/vfs/index.ts
@@ -1,6 +1,13 @@
 export { FsVfs } from "./fs";
-export { MemoryVfs } from "./memory";
-export { assertSafeKey, decodeText, type ObjectStat, type Vfs } from "./vfs";
 // The closed GcsVfs adapter was retired with `@houston/host-cloud` (git
 // history); any out-of-repo Vfs adapter binds behind the port, never through
 // this open barrel.
+export { LazyStoreVfs } from "./lazy-store";
+export {
+  LazyObjectTooLargeError,
+  type LazyStoreVfsOptions,
+  UNREAD_HASH,
+} from "./lazy-store-types";
+export { MemoryVfs } from "./memory";
+export { PrefixedVfs } from "./prefixed";
+export { assertSafeKey, decodeText, type ObjectStat, type Vfs } from "./vfs";

--- a/packages/host/src/vfs/lazy-store-cas.test.ts
+++ b/packages/host/src/vfs/lazy-store-cas.test.ts
@@ -1,0 +1,217 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type HydrateManifest,
+  LocalDirStore,
+  type ObjectMetadata,
+  type ObjectStore,
+  syncBack,
+  type WriteOptions,
+} from "@houston/runtime-client/object-sync";
+import { expect, test } from "vitest";
+import { LazyStoreVfs } from "./lazy-store";
+import { LazyReadRefusedError } from "./lazy-store-types";
+
+/**
+ * The CAS guard behind lazy ownership: a generation-minting store must see
+ * `ifGenerationMatch` on every upload/delete of a key the op never read,
+ * and create-only ("0") on a key the store never had.
+ */
+
+const PREFIX = "ws/w1/agent-1";
+
+function generationStore(root: string) {
+  const inner = new LocalDirStore(root);
+  const writes: {
+    op: "upload" | "delete";
+    key: string;
+    opts?: WriteOptions;
+  }[] = [];
+  const generations = new Map<string, string>();
+  const store: ObjectStore & {
+    writes: typeof writes;
+    manifest: NonNullable<ObjectStore["manifest"]>;
+  } = {
+    writes,
+    list: (p) => inner.list(p),
+    manifest: async (p) =>
+      (await inner.manifest(p)).map(
+        (o): ObjectMetadata => ({
+          ...o,
+          generation: generations.get(o.key) ?? "7",
+        }),
+      ),
+    download: (key, dest) => inner.download(key, dest),
+    upload: async (src, key, opts) => {
+      writes.push({ op: "upload", key, opts });
+      await inner.upload(src, key);
+      return { generation: "8" };
+    },
+    delete: async (key, opts) => {
+      writes.push({ op: "delete", key, opts });
+      await inner.delete(key);
+    },
+  };
+  return store;
+}
+
+async function seeded(extra: Record<string, string> = {}) {
+  const storeRoot = mkdtempSync(join(tmpdir(), "lazy-cas-"));
+  for (const [rel, body] of Object.entries({
+    "workspaces/P/Bob/CLAUDE.md": "# Bob\n",
+    "workspaces/P/Bob/a.txt": "a",
+    "workspaces/P/Bob/dir/b.txt": "b",
+    ...extra,
+  })) {
+    const abs = join(storeRoot, PREFIX, ...rel.split("/"));
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  const store = generationStore(storeRoot);
+  const root = mkdtempSync(join(tmpdir(), "lazy-cas-overlay-"));
+  const manifest: HydrateManifest = new Map();
+  const vfs = new LazyStoreVfs({
+    store,
+    prefix: PREFIX,
+    root,
+    objects: await store.manifest(PREFIX),
+    manifest,
+    excludes: [],
+    maxObjectBytes: 1024,
+    maxBytes: 2048,
+  });
+  return { store, root, manifest, vfs };
+}
+
+const rel = (k: string) => k.slice(PREFIX.length + 1);
+
+test("unread overwrite, unread delete and a move all write with the recorded generation", async () => {
+  const { store, root, manifest, vfs } = await seeded();
+  expect(vfs.generationAware).toBe(true);
+  await vfs.writeText("workspaces/P/Bob/a.txt", "A");
+  await vfs.deleteKey("workspaces/P/Bob/CLAUDE.md");
+  await vfs.move("workspaces/P/Bob/dir/b.txt", "workspaces/P/Bob/b2.txt");
+  await syncBack(store, PREFIX, root, manifest, {
+    generations: vfs.generationAware,
+  });
+  const byKey = Object.fromEntries(
+    store.writes.map((w) => [`${w.op} ${rel(w.key)}`, w.opts]),
+  );
+  expect(byKey["upload workspaces/P/Bob/a.txt"]).toEqual({
+    ifGenerationMatch: "7",
+  });
+  expect(byKey["delete workspaces/P/Bob/CLAUDE.md"]).toEqual({
+    ifGenerationMatch: "7",
+  });
+  expect(byKey["delete workspaces/P/Bob/dir/b.txt"]).toEqual({
+    ifGenerationMatch: "7",
+  });
+  // A key the store never had: create-only.
+  expect(byKey["upload workspaces/P/Bob/b2.txt"]).toEqual({
+    ifGenerationMatch: "0",
+  });
+});
+
+test("a pure create on an empty ownership manifest is still create-only when the store mints generations", async () => {
+  const { store, root, manifest, vfs } = await seeded();
+  await vfs.writeText("workspaces/P/Bob/fresh.txt", "new");
+  expect(manifest.size).toBe(0);
+  await syncBack(store, PREFIX, root, manifest, {
+    generations: vfs.generationAware,
+  });
+  expect(store.writes).toEqual([
+    {
+      op: "upload",
+      key: `${PREFIX}/workspaces/P/Bob/fresh.txt`,
+      opts: { ifGenerationMatch: "0" },
+    },
+  ]);
+});
+
+test("a file where the store has a directory, or under a remote file, is refused like a real tree", async () => {
+  const { vfs } = await seeded();
+  await expect(vfs.writeText("workspaces/P/Bob/dir", "x")).rejects.toThrow(
+    /EISDIR/,
+  );
+  await expect(
+    vfs.writeText("workspaces/P/Bob/a.txt/child.txt", "x"),
+  ).rejects.toThrow(/ENOTDIR/);
+  await expect(
+    vfs.move("workspaces/P/Bob/a.txt", "workspaces/P/Bob/dir"),
+  ).rejects.toThrow(/EISDIR/);
+  // Deleting the remote file first makes the path a legal directory.
+  await vfs.deleteKey("workspaces/P/Bob/a.txt");
+  await vfs.writeText("workspaces/P/Bob/a.txt/child.txt", "x");
+  expect(await vfs.readText("workspaces/P/Bob/a.txt/child.txt")).toBe("x");
+});
+
+test("renaming a remote-only folder moves every descendant", async () => {
+  const { vfs, store, root, manifest } = await seeded({
+    "workspaces/P/Bob/dir/deep/c.txt": "c",
+  });
+  await vfs.move("workspaces/P/Bob/dir", "workspaces/P/Bob/renamed");
+  expect(await vfs.list("workspaces/P/Bob/dir")).toEqual([]);
+  expect(await vfs.list("workspaces/P/Bob/renamed")).toEqual([
+    "workspaces/P/Bob/renamed/b.txt",
+    "workspaces/P/Bob/renamed/deep/c.txt",
+  ]);
+  expect(await vfs.readText("workspaces/P/Bob/renamed/deep/c.txt")).toBe("c");
+  const result = await syncBack(store, PREFIX, root, manifest);
+  expect(result.uploaded.sort()).toEqual([
+    "workspaces/P/Bob/renamed/b.txt",
+    "workspaces/P/Bob/renamed/deep/c.txt",
+  ]);
+  expect(result.deleted.sort()).toEqual([
+    "workspaces/P/Bob/dir/b.txt",
+    "workspaces/P/Bob/dir/deep/c.txt",
+  ]);
+  await expect(
+    vfs.move("workspaces/P/Bob/nothing-here", "workspaces/P/Bob/x"),
+  ).rejects.toThrow(/source not found/);
+});
+
+test("a stale manifest size cannot smuggle an oversized object past the cap", async () => {
+  const storeRoot = mkdtempSync(join(tmpdir(), "lazy-stale-"));
+  const abs = join(storeRoot, PREFIX, "workspaces/P/Bob/grown.bin");
+  mkdirSync(join(abs, ".."), { recursive: true });
+  writeFileSync(abs, "x".repeat(4096));
+  const store = new LocalDirStore(storeRoot);
+  const objects = (await store.manifest(PREFIX)).map((o) => ({
+    ...o,
+    size: 10,
+  }));
+  const root = mkdtempSync(join(tmpdir(), "lazy-stale-overlay-"));
+  const manifest: HydrateManifest = new Map();
+  const vfs = new LazyStoreVfs({
+    store,
+    prefix: PREFIX,
+    root,
+    objects,
+    manifest,
+    excludes: [],
+    maxObjectBytes: 1024,
+    maxBytes: 1024,
+  });
+  await expect(
+    vfs.readBytes("workspaces/P/Bob/grown.bin"),
+  ).rejects.toBeInstanceOf(LazyReadRefusedError);
+  expect(manifest.size).toBe(0);
+  // Nothing partial left behind: a later read refuses again, not serves it.
+  await expect(
+    vfs.readBytes("workspaces/P/Bob/grown.bin"),
+  ).rejects.toBeInstanceOf(LazyReadRefusedError);
+});
+
+test("the aggregate budget refuses once the op has materialized enough", async () => {
+  const { vfs } = await seeded({
+    "workspaces/P/Bob/one.bin": "1".repeat(1000),
+    "workspaces/P/Bob/two.bin": "2".repeat(1000),
+    "workspaces/P/Bob/three.bin": "3".repeat(1000),
+  });
+  await vfs.readBytes("workspaces/P/Bob/one.bin");
+  await vfs.readBytes("workspaces/P/Bob/two.bin");
+  await expect(vfs.readBytes("workspaces/P/Bob/three.bin")).rejects.toThrow(
+    /budget/,
+  );
+});

--- a/packages/host/src/vfs/lazy-store-cas.test.ts
+++ b/packages/host/src/vfs/lazy-store-cas.test.ts
@@ -231,3 +231,51 @@ test("the aggregate budget refuses once the op has materialized enough", async (
     /budget/,
   );
 });
+
+test("a failed download leaves no partial file behind", async () => {
+  const storeRoot = mkdtempSync(join(tmpdir(), "lazy-partial-"));
+  const abs = join(storeRoot, PREFIX, "workspaces/P/Bob/doc.txt");
+  mkdirSync(join(abs, ".."), { recursive: true });
+  writeFileSync(abs, "whole");
+  const inner = new LocalDirStore(storeRoot);
+  const root = mkdtempSync(join(tmpdir(), "lazy-partial-overlay-"));
+  const manifest: HydrateManifest = new Map();
+  let fail = true;
+  const vfs = new LazyStoreVfs({
+    store: {
+      ...inner,
+      list: (p) => inner.list(p),
+      manifest: (p) => inner.manifest(p),
+      upload: inner.upload.bind(inner),
+      delete: inner.delete.bind(inner),
+      download: async (key, dest) => {
+        if (!fail) return inner.download(key, dest);
+        writeFileSync(dest, "wh");
+        throw new Error("connection reset");
+      },
+    },
+    prefix: PREFIX,
+    root,
+    objects: await inner.manifest(PREFIX),
+    manifest,
+    excludes: [],
+    maxObjectBytes: 1024,
+    maxBytes: 1024,
+  });
+  await expect(vfs.readText("workspaces/P/Bob/doc.txt")).rejects.toThrow(
+    /connection reset/,
+  );
+  expect(manifest.size).toBe(0);
+  fail = false;
+  // The retry reads the whole object, not the partial bytes.
+  expect(await vfs.readText("workspaces/P/Bob/doc.txt")).toBe("whole");
+});
+
+test("a folder move refuses a destination that already holds local writes", async () => {
+  const { vfs } = await seeded();
+  await vfs.writeText("workspaces/P/Bob/target/local.txt", "l");
+  await expect(
+    vfs.move("workspaces/P/Bob/dir", "workspaces/P/Bob/target"),
+  ).rejects.toThrow(/not empty/);
+  expect(await vfs.readText("workspaces/P/Bob/dir/b.txt")).toBe("b");
+});

--- a/packages/host/src/vfs/lazy-store-cas.test.ts
+++ b/packages/host/src/vfs/lazy-store-cas.test.ts
@@ -171,6 +171,22 @@ test("renaming a remote-only folder moves every descendant", async () => {
   ).rejects.toThrow(/source not found/);
 });
 
+test("moving a folder into itself is refused and onto itself is a no-op, like rename(2)", async () => {
+  const { vfs, store, root, manifest } = await seeded();
+  await expect(
+    vfs.move("workspaces/P/Bob/dir", "workspaces/P/Bob/dir/inner"),
+  ).rejects.toThrow(/inside the source/);
+  await vfs.move("workspaces/P/Bob/dir", "workspaces/P/Bob/dir");
+  await vfs.move("workspaces/P/Bob/a.txt", "workspaces/P/Bob/a.txt");
+  expect(await vfs.list("workspaces/P/Bob/dir")).toEqual([
+    "workspaces/P/Bob/dir/b.txt",
+  ]);
+  expect(await vfs.readText("workspaces/P/Bob/a.txt")).toBe("a");
+  const result = await syncBack(store, PREFIX, root, manifest);
+  expect(result.uploaded).toEqual([]);
+  expect(result.deleted).toEqual([]);
+});
+
 test("a stale manifest size cannot smuggle an oversized object past the cap", async () => {
   const storeRoot = mkdtempSync(join(tmpdir(), "lazy-stale-"));
   const abs = join(storeRoot, PREFIX, "workspaces/P/Bob/grown.bin");

--- a/packages/host/src/vfs/lazy-store-fetch.ts
+++ b/packages/host/src/vfs/lazy-store-fetch.ts
@@ -38,28 +38,29 @@ export async function fetchObject(
   }
   const dest = join(opts.root, ...key.split("/"));
   await mkdir(dirname(dest), { recursive: true });
-  await opts.store.download(opts.prefix ? `${opts.prefix}/${key}` : key, dest);
-  const { size } = await stat(dest);
-  if (size > maxObjectBytes) {
-    await rm(dest, { force: true });
-    throw new LazyReadRefusedError("object", key, size, maxObjectBytes);
-  }
-  if (budget.materializedBytes + size > maxBytes) {
-    await rm(dest, { force: true });
-    throw new LazyReadRefusedError("total", key, size, maxBytes);
-  }
-  let hash: string;
   try {
-    hash = await fileSha256(dest, size);
+    await opts.store.download(
+      opts.prefix ? `${opts.prefix}/${key}` : key,
+      dest,
+    );
+    const { size } = await stat(dest);
+    if (size > maxObjectBytes) {
+      throw new LazyReadRefusedError("object", key, size, maxObjectBytes);
+    }
+    if (budget.materializedBytes + size > maxBytes) {
+      throw new LazyReadRefusedError("total", key, size, maxBytes);
+    }
+    const hash = await fileSha256(dest, size);
+    opts.manifest.set(key, {
+      hash,
+      ...(meta.generation !== undefined ? { generation: meta.generation } : {}),
+    });
+    budget.materializedBytes += size;
   } catch (error) {
-    // An unhashed file must not survive: the sync-back would take it for a
-    // fresh local write and upload it create-only.
+    // Nothing half-fetched may survive: a partial or unhashed file would be
+    // read back as content and taken by the sync-back for a fresh local
+    // write. The store adapter need not replace the destination atomically.
     await rm(dest, { force: true });
     throw error;
   }
-  opts.manifest.set(key, {
-    hash,
-    ...(meta.generation !== undefined ? { generation: meta.generation } : {}),
-  });
-  budget.materializedBytes += size;
 }

--- a/packages/host/src/vfs/lazy-store-fetch.ts
+++ b/packages/host/src/vfs/lazy-store-fetch.ts
@@ -48,9 +48,18 @@ export async function fetchObject(
     await rm(dest, { force: true });
     throw new LazyReadRefusedError("total", key, size, maxBytes);
   }
-  budget.materializedBytes += size;
+  let hash: string;
+  try {
+    hash = await fileSha256(dest, size);
+  } catch (error) {
+    // An unhashed file must not survive: the sync-back would take it for a
+    // fresh local write and upload it create-only.
+    await rm(dest, { force: true });
+    throw error;
+  }
   opts.manifest.set(key, {
-    hash: await fileSha256(dest, size),
+    hash,
     ...(meta.generation !== undefined ? { generation: meta.generation } : {}),
   });
+  budget.materializedBytes += size;
 }

--- a/packages/host/src/vfs/lazy-store-fetch.ts
+++ b/packages/host/src/vfs/lazy-store-fetch.ts
@@ -1,0 +1,56 @@
+import { mkdir, rm, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+  fileSha256,
+  type ObjectMetadata,
+} from "@houston/runtime-client/object-sync";
+import {
+  LazyReadRefusedError,
+  type LazyStoreVfsOptions,
+} from "./lazy-store-types";
+
+/** Bytes one lazy vfs has materialized so far (its aggregate budget). */
+export interface LazyBudget {
+  materializedBytes: number;
+}
+
+/**
+ * Download one object into the overlay and record it in the ownership
+ * manifest. Both caps are checked from the manifest size BEFORE the download
+ * and again from the bytes that landed (a stale manifest must not let an
+ * oversized object through); a refused object leaves nothing on disk.
+ */
+export async function fetchObject(
+  opts: Pick<
+    LazyStoreVfsOptions,
+    "store" | "prefix" | "root" | "manifest" | "maxObjectBytes" | "maxBytes"
+  >,
+  budget: LazyBudget,
+  key: string,
+  meta: ObjectMetadata,
+): Promise<void> {
+  const { maxObjectBytes, maxBytes } = opts;
+  if (meta.size > maxObjectBytes) {
+    throw new LazyReadRefusedError("object", key, meta.size, maxObjectBytes);
+  }
+  if (budget.materializedBytes + meta.size > maxBytes) {
+    throw new LazyReadRefusedError("total", key, meta.size, maxBytes);
+  }
+  const dest = join(opts.root, ...key.split("/"));
+  await mkdir(dirname(dest), { recursive: true });
+  await opts.store.download(opts.prefix ? `${opts.prefix}/${key}` : key, dest);
+  const { size } = await stat(dest);
+  if (size > maxObjectBytes) {
+    await rm(dest, { force: true });
+    throw new LazyReadRefusedError("object", key, size, maxObjectBytes);
+  }
+  if (budget.materializedBytes + size > maxBytes) {
+    await rm(dest, { force: true });
+    throw new LazyReadRefusedError("total", key, size, maxBytes);
+  }
+  budget.materializedBytes += size;
+  opts.manifest.set(key, {
+    hash: await fileSha256(dest, size),
+    ...(meta.generation !== undefined ? { generation: meta.generation } : {}),
+  });
+}

--- a/packages/host/src/vfs/lazy-store-ownership.ts
+++ b/packages/host/src/vfs/lazy-store-ownership.ts
@@ -1,0 +1,68 @@
+import type {
+  HydrateManifest,
+  ObjectMetadata,
+} from "@houston/runtime-client/object-sync";
+import { UNREAD_HASH } from "./lazy-store-types";
+
+/**
+ * What the lazy vfs knows about the store's objects and what the op did to
+ * them: the remote listing, the keys hidden by a local delete/move, and the
+ * sync-back ownership manifest (materialized keys + UNREAD_HASH entries for
+ * keys written or deleted without a read).
+ */
+export class LazyOwnership {
+  readonly remote = new Map<string, ObjectMetadata>();
+  /** Remote keys deleted (or moved away) locally: hidden from every read. */
+  readonly hidden = new Set<string>();
+
+  constructor(private readonly manifest: HydrateManifest) {}
+
+  visible(rel: string): ObjectMetadata | undefined {
+    return this.hidden.has(rel) ? undefined : this.remote.get(rel);
+  }
+
+  /** Remote keys visible under `prefix/` (not hidden). */
+  under(prefix: string): [string, ObjectMetadata][] {
+    const within = `${prefix}/`;
+    return [...this.remote].filter(
+      ([rel]) => rel.startsWith(within) && !this.hidden.has(rel),
+    );
+  }
+
+  /** A real tree refuses a file where a directory is and vice versa. */
+  assertWritable(key: string): void {
+    const segments = key.split("/");
+    for (let i = 1; i < segments.length; i++) {
+      const ancestor = segments.slice(0, i).join("/");
+      if (this.visible(ancestor)) {
+        throw new Error(`ENOTDIR: not a directory, ${ancestor}`);
+      }
+    }
+    if (this.under(key).length > 0) {
+      throw new Error(`EISDIR: illegal operation on a directory, ${key}`);
+    }
+  }
+
+  /** Put an unread remote key under sync-back ownership (CAS on its generation). */
+  own(rel: string): void {
+    const meta = this.remote.get(rel);
+    if (!meta || this.manifest.has(rel)) return;
+    this.manifest.set(rel, {
+      hash: UNREAD_HASH,
+      ...(meta.generation !== undefined ? { generation: meta.generation } : {}),
+    });
+  }
+
+  /** Hide a remote key from reads and make sure sync-back deletes it. */
+  tombstone(rel: string): void {
+    if (!this.remote.has(rel)) return;
+    this.hidden.add(rel);
+    this.own(rel);
+  }
+
+  /** The key was (re)created locally: visible again, owned if remote. */
+  written(rel: string): void {
+    this.hidden.delete(rel);
+    this.own(rel);
+  }
+}

--- a/packages/host/src/vfs/lazy-store-types.ts
+++ b/packages/host/src/vfs/lazy-store-types.ts
@@ -1,0 +1,43 @@
+import type {
+  HydrateManifest,
+  ObjectMetadata,
+  ObjectStore,
+} from "@houston/runtime-client/object-sync";
+
+/**
+ * Manifest hash of a remote key the op wrote or deleted without downloading
+ * it. Never equal to a real digest, so a local file under that key is seen as
+ * changed and uploaded with the recorded generation as its CAS guard; a key
+ * that stays absent locally is deleted under the same guard.
+ */
+export const UNREAD_HASH = "unread:owned-without-download";
+
+/** One object is over the per-read cap: refused before any byte moves. */
+export class LazyObjectTooLargeError extends Error {
+  constructor(
+    readonly key: string,
+    readonly size: number,
+    readonly maxBytes: number,
+  ) {
+    super(
+      `${key} is ${size} bytes, over the ${maxBytes}-byte cap for a read while the agent sleeps`,
+    );
+    this.name = "LazyObjectTooLargeError";
+  }
+}
+
+export interface LazyStoreVfsOptions {
+  store: ObjectStore;
+  /** Store prefix the vfs keys are relative to (`ws/<org>/<agent>`). */
+  prefix: string;
+  /** Local overlay directory; vfs keys are paths under it. */
+  root: string;
+  /** The store's listing under `prefix`, taken once per op. */
+  objects: ObjectMetadata[];
+  /** Shared with the caller's sync-back: materialized keys + tombstones. */
+  manifest: HydrateManifest;
+  /** Hydrate-style excludes (auth material, runtime tree): never listed. */
+  excludes: string[];
+  /** Largest single object a read may materialize. */
+  maxObjectBytes: number;
+}

--- a/packages/host/src/vfs/lazy-store-types.ts
+++ b/packages/host/src/vfs/lazy-store-types.ts
@@ -12,17 +12,26 @@ import type {
  */
 export const UNREAD_HASH = "unread:owned-without-download";
 
-/** One object is over the per-read cap: refused before any byte moves. */
-export class LazyObjectTooLargeError extends Error {
+/**
+ * A read the lazy tree refuses: one object over the per-object cap, or the
+ * op's materialized total over its budget. Raised before the bytes move (or
+ * right after, when the manifest size turned out stale). The op layer maps
+ * it to "unavailable while asleep" for a read and to a decline for a write,
+ * never to a partial result.
+ */
+export class LazyReadRefusedError extends Error {
   constructor(
+    readonly reason: "object" | "total",
     readonly key: string,
     readonly size: number,
     readonly maxBytes: number,
   ) {
     super(
-      `${key} is ${size} bytes, over the ${maxBytes}-byte cap for a read while the agent sleeps`,
+      reason === "object"
+        ? `${key} is ${size} bytes, over the ${maxBytes}-byte cap for a read while the agent sleeps`
+        : `reading ${key} (${size} bytes) would exceed the ${maxBytes}-byte budget of this operation`,
     );
-    this.name = "LazyObjectTooLargeError";
+    this.name = "LazyReadRefusedError";
   }
 }
 
@@ -40,4 +49,6 @@ export interface LazyStoreVfsOptions {
   excludes: string[];
   /** Largest single object a read may materialize. */
   maxObjectBytes: number;
+  /** Budget for everything this vfs materializes over its lifetime. */
+  maxBytes: number;
 }

--- a/packages/host/src/vfs/lazy-store.test.ts
+++ b/packages/host/src/vfs/lazy-store.test.ts
@@ -10,7 +10,7 @@ import {
 import { expect, test } from "vitest";
 import { runVfsContract } from "../testing/vfs-contract";
 import { LazyStoreVfs } from "./lazy-store";
-import { LazyObjectTooLargeError, UNREAD_HASH } from "./lazy-store-types";
+import { LazyReadRefusedError, UNREAD_HASH } from "./lazy-store-types";
 
 const PREFIX = "ws/w1/agent-1";
 
@@ -56,6 +56,7 @@ async function seeded(files: Record<string, string> = {}) {
     manifest,
     excludes: ["workspaces/*/*/.houston/runtime/"],
     maxObjectBytes: 1024,
+    maxBytes: 4096,
   });
   return { store, root, manifest, vfs, storeRoot };
 }
@@ -71,6 +72,7 @@ runVfsContract("LazyStoreVfs (empty store)", () => {
     manifest,
     excludes: [],
     maxObjectBytes: 1024 * 1024,
+    maxBytes: 1024 * 1024,
   });
 });
 
@@ -118,7 +120,7 @@ test("an object over the per-read cap is refused before any byte is downloaded",
   });
   await expect(
     vfs.readBytes("workspaces/P/Bob/big.bin"),
-  ).rejects.toBeInstanceOf(LazyObjectTooLargeError);
+  ).rejects.toBeInstanceOf(LazyReadRefusedError);
   expect(store.downloads).toEqual([]);
   // Still listed: the Files tab shows it; only fetching it is unavailable.
   expect(await vfs.list("workspaces/P/Bob")).toContain(

--- a/packages/host/src/vfs/lazy-store.test.ts
+++ b/packages/host/src/vfs/lazy-store.test.ts
@@ -1,0 +1,212 @@
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type HydrateManifest,
+  LocalDirStore,
+  type ObjectStore,
+  syncBack,
+} from "@houston/runtime-client/object-sync";
+import { expect, test } from "vitest";
+import { runVfsContract } from "../testing/vfs-contract";
+import { LazyStoreVfs } from "./lazy-store";
+import { LazyObjectTooLargeError, UNREAD_HASH } from "./lazy-store-types";
+
+const PREFIX = "ws/w1/agent-1";
+
+/** A LocalDirStore that counts downloads — the whole point of laziness. */
+function countingStore(root: string): ObjectStore & { downloads: string[] } {
+  const inner = new LocalDirStore(root);
+  const downloads: string[] = [];
+  return {
+    downloads,
+    list: (p) => inner.list(p),
+    manifest: (p) => inner.manifest(p),
+    download: (key, dest) => {
+      downloads.push(key);
+      return inner.download(key, dest);
+    },
+    upload: (src, key, o) => inner.upload(src, key, o),
+    delete: (key, o) => inner.delete(key, o),
+  };
+}
+
+async function seeded(files: Record<string, string> = {}) {
+  const storeRoot = mkdtempSync(join(tmpdir(), "lazy-store-"));
+  const defaults = {
+    "workspaces/P/Bob/CLAUDE.md": "# Bob\n",
+    "workspaces/P/Bob/report.csv": "a,b\n1,2\n",
+    "workspaces/P/Bob/docs/notes.md": "notes",
+    "workspaces/P/Bob/docs/deep/x.txt": "x",
+    "workspaces/P/Bob/.houston/runtime/auth.json": "{}",
+  };
+  for (const [rel, body] of Object.entries({ ...defaults, ...files })) {
+    const abs = join(storeRoot, PREFIX, ...rel.split("/"));
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  const store = countingStore(storeRoot);
+  const root = mkdtempSync(join(tmpdir(), "lazy-overlay-"));
+  const manifest: HydrateManifest = new Map();
+  const vfs = new LazyStoreVfs({
+    store,
+    prefix: PREFIX,
+    root,
+    objects: await new LocalDirStore(storeRoot).manifest(PREFIX),
+    manifest,
+    excludes: ["workspaces/*/*/.houston/runtime/"],
+    maxObjectBytes: 1024,
+  });
+  return { store, root, manifest, vfs, storeRoot };
+}
+
+// An empty store: the overlay alone must honor the full port contract.
+runVfsContract("LazyStoreVfs (empty store)", () => {
+  const manifest: HydrateManifest = new Map();
+  return new LazyStoreVfs({
+    store: new LocalDirStore(mkdtempSync(join(tmpdir(), "lazy-empty-"))),
+    prefix: PREFIX,
+    root: mkdtempSync(join(tmpdir(), "lazy-empty-overlay-")),
+    objects: [],
+    manifest,
+    excludes: [],
+    maxObjectBytes: 1024 * 1024,
+  });
+});
+
+test("listing comes from the manifest: sizes right, nothing downloaded, excludes hidden", async () => {
+  const { vfs, store } = await seeded();
+  const listed = await vfs.listDetailed("workspaces/P/Bob");
+  expect(listed.map((s) => s.key)).toEqual([
+    "workspaces/P/Bob/CLAUDE.md",
+    "workspaces/P/Bob/docs/deep/x.txt",
+    "workspaces/P/Bob/docs/notes.md",
+    "workspaces/P/Bob/report.csv",
+  ]);
+  expect(listed.find((s) => s.key.endsWith("report.csv"))?.size).toBe(8);
+  expect(listed.every((s) => s.updatedMs > 0)).toBe(true);
+  expect(store.downloads).toEqual([]);
+});
+
+test("a read downloads that one object once and records its hash in the manifest", async () => {
+  const { vfs, store, manifest, root } = await seeded();
+  const [a, b] = await Promise.all([
+    vfs.readText("workspaces/P/Bob/report.csv"),
+    vfs.readText("workspaces/P/Bob/report.csv"),
+  ]);
+  expect(a).toBe("a,b\n1,2\n");
+  expect(b).toBe(a);
+  expect(store.downloads).toEqual([`${PREFIX}/workspaces/P/Bob/report.csv`]);
+  expect(existsSync(join(root, "workspaces/P/Bob/report.csv"))).toBe(true);
+  const entry = manifest.get("workspaces/P/Bob/report.csv");
+  expect(entry?.hash).toMatch(/^[0-9a-f]{64}$/);
+  expect(manifest.size).toBe(1);
+  expect(await vfs.readText("workspaces/P/Bob/missing.txt")).toBeNull();
+});
+
+test("an excluded object is unreadable and unlisted even though the store has it", async () => {
+  const { vfs } = await seeded();
+  expect(
+    await vfs.readText("workspaces/P/Bob/.houston/runtime/auth.json"),
+  ).toBeNull();
+  expect(await vfs.list("workspaces/P/Bob/.houston")).toEqual([]);
+});
+
+test("an object over the per-read cap is refused before any byte is downloaded", async () => {
+  const { vfs, store } = await seeded({
+    "workspaces/P/Bob/big.bin": "x".repeat(2048),
+  });
+  await expect(
+    vfs.readBytes("workspaces/P/Bob/big.bin"),
+  ).rejects.toBeInstanceOf(LazyObjectTooLargeError);
+  expect(store.downloads).toEqual([]);
+  // Still listed: the Files tab shows it; only fetching it is unavailable.
+  expect(await vfs.list("workspaces/P/Bob")).toContain(
+    "workspaces/P/Bob/big.bin",
+  );
+});
+
+test("sync-back after lazy edits: untouched objects are neither re-uploaded nor deleted", async () => {
+  const { vfs, store, manifest, root, storeRoot } = await seeded();
+  // Delete before read, overwrite before read, create, rename an unread one.
+  await vfs.deleteKey("workspaces/P/Bob/docs/notes.md");
+  await vfs.writeText("workspaces/P/Bob/report.csv", "changed");
+  await vfs.writeText("workspaces/P/Bob/new.txt", "new");
+  await vfs.move("workspaces/P/Bob/docs/deep/x.txt", "workspaces/P/Bob/y.txt");
+  expect(manifest.get("workspaces/P/Bob/docs/notes.md")?.hash).toBe(
+    UNREAD_HASH,
+  );
+  expect(manifest.get("workspaces/P/Bob/report.csv")?.hash).toBe(UNREAD_HASH);
+  // The vfs view is already consistent before the sync.
+  expect(await vfs.list("workspaces/P/Bob")).toEqual([
+    "workspaces/P/Bob/CLAUDE.md",
+    "workspaces/P/Bob/new.txt",
+    "workspaces/P/Bob/report.csv",
+    "workspaces/P/Bob/y.txt",
+  ]);
+  expect(await vfs.readText("workspaces/P/Bob/docs/notes.md")).toBeNull();
+  expect(await vfs.readText("workspaces/P/Bob/y.txt")).toBe("x");
+
+  const result = await syncBack(store, PREFIX, root, manifest);
+  expect(result.uploaded.sort()).toEqual([
+    "workspaces/P/Bob/new.txt",
+    "workspaces/P/Bob/report.csv",
+    "workspaces/P/Bob/y.txt",
+  ]);
+  expect(result.deleted.sort()).toEqual([
+    "workspaces/P/Bob/docs/deep/x.txt",
+    "workspaces/P/Bob/docs/notes.md",
+  ]);
+  // CLAUDE.md was never touched: it must survive untouched in the store.
+  const remaining = (await store.list(PREFIX)).map((k) =>
+    k.slice(PREFIX.length + 1),
+  );
+  expect(remaining.sort()).toEqual([
+    "workspaces/P/Bob/.houston/runtime/auth.json",
+    "workspaces/P/Bob/CLAUDE.md",
+    "workspaces/P/Bob/new.txt",
+    "workspaces/P/Bob/report.csv",
+    "workspaces/P/Bob/y.txt",
+  ]);
+  expect(
+    existsSync(join(storeRoot, PREFIX, "workspaces/P/Bob/CLAUDE.md")),
+  ).toBe(true);
+  // The only download was the move's source (a rename needs the bytes).
+  expect(store.downloads).toEqual([
+    `${PREFIX}/workspaces/P/Bob/docs/deep/x.txt`,
+  ]);
+});
+
+test("deletePrefix tombstones every unread object under the folder", async () => {
+  const { vfs, store, manifest, root } = await seeded();
+  await vfs.deletePrefix("workspaces/P/Bob/docs");
+  expect(await vfs.list("workspaces/P/Bob/docs")).toEqual([]);
+  const result = await syncBack(store, PREFIX, root, manifest);
+  expect(result.deleted.sort()).toEqual([
+    "workspaces/P/Bob/docs/deep/x.txt",
+    "workspaces/P/Bob/docs/notes.md",
+  ]);
+  expect(result.uploaded).toEqual([]);
+  expect(store.downloads).toEqual([]);
+});
+
+test("a key deleted then re-created is uploaded, not deleted, by the sync", async () => {
+  const { vfs, store, manifest, root } = await seeded();
+  await vfs.deleteKey("workspaces/P/Bob/report.csv");
+  await vfs.writeText("workspaces/P/Bob/report.csv", "again");
+  expect(await vfs.readText("workspaces/P/Bob/report.csv")).toBe("again");
+  const result = await syncBack(store, PREFIX, root, manifest);
+  expect(result.uploaded).toEqual(["workspaces/P/Bob/report.csv"]);
+  expect(result.deleted).toEqual([]);
+});
+
+test("moving a missing or deleted source throws like the real filesystem", async () => {
+  const { vfs } = await seeded();
+  await expect(
+    vfs.move("workspaces/P/Bob/nope.txt", "workspaces/P/Bob/x.txt"),
+  ).rejects.toThrow(/source not found/);
+  await vfs.deleteKey("workspaces/P/Bob/report.csv");
+  await expect(
+    vfs.move("workspaces/P/Bob/report.csv", "workspaces/P/Bob/x.txt"),
+  ).rejects.toThrow(/source not found/);
+});

--- a/packages/host/src/vfs/lazy-store.ts
+++ b/packages/host/src/vfs/lazy-store.ts
@@ -4,7 +4,8 @@ import {
 } from "@houston/runtime-client/object-sync";
 import { FsVfs } from "./fs";
 import { fetchObject, type LazyBudget } from "./lazy-store-fetch";
-import { type LazyStoreVfsOptions, UNREAD_HASH } from "./lazy-store-types";
+import { LazyOwnership } from "./lazy-store-ownership";
+import type { LazyStoreVfsOptions } from "./lazy-store-types";
 import { assertSafeKey, decodeText, type ObjectStat, type Vfs } from "./vfs";
 
 /**
@@ -20,24 +21,28 @@ import { assertSafeKey, decodeText, type ObjectStat, type Vfs } from "./vfs";
  */
 export class LazyStoreVfs implements Vfs {
   private readonly local: FsVfs;
-  private readonly remote = new Map<string, ObjectMetadata>();
-  /** Remote keys deleted (or moved away) locally: hidden from every read. */
-  private readonly hidden = new Set<string>();
+  private readonly state: LazyOwnership;
   private readonly inflight = new Map<string, Promise<void>>();
   private readonly budget: LazyBudget = { materializedBytes: 0 };
 
   constructor(private readonly opts: LazyStoreVfsOptions) {
     this.local = new FsVfs(opts.root);
+    this.state = new LazyOwnership(opts.manifest);
     for (const object of opts.objects) {
       const rel = this.relOf(object.key);
       if (!rel || excluded(rel, opts.excludes)) continue;
-      this.remote.set(rel, object);
+      this.state.remote.set(rel, object);
     }
   }
 
   /** Whether the store mints generations (the sync-back CAS capability). */
   get generationAware(): boolean {
     return this.opts.objects.some((o) => o.generation !== undefined);
+  }
+
+  /** Remote keys (store-relative) this vfs knows about, excludes applied. */
+  get remoteKeys(): string[] {
+    return [...this.state.remote.keys()];
   }
 
   private relOf(storeKey: string): string | null {
@@ -48,32 +53,6 @@ export class LazyStoreVfs implements Vfs {
       : null;
   }
 
-  private visible(rel: string): ObjectMetadata | undefined {
-    return this.hidden.has(rel) ? undefined : this.remote.get(rel);
-  }
-
-  /** Remote keys visible under `prefix/` (not hidden). */
-  private remoteUnder(prefix: string): [string, ObjectMetadata][] {
-    const under = `${prefix}/`;
-    return [...this.remote].filter(
-      ([rel]) => rel.startsWith(under) && !this.hidden.has(rel),
-    );
-  }
-
-  /** A real tree refuses a file where a directory is and vice versa. */
-  private assertWritable(key: string): void {
-    const segments = key.split("/");
-    for (let i = 1; i < segments.length; i++) {
-      const ancestor = segments.slice(0, i).join("/");
-      if (this.visible(ancestor)) {
-        throw new Error(`ENOTDIR: not a directory, ${ancestor}`);
-      }
-    }
-    if (this.remoteUnder(key).length > 0) {
-      throw new Error(`EISDIR: illegal operation on a directory, ${key}`);
-    }
-  }
-
   list = async (prefix: string) =>
     (await this.listDetailed(prefix)).map((s) => s.key);
 
@@ -81,7 +60,7 @@ export class LazyStoreVfs implements Vfs {
     assertSafeKey(prefix);
     const out = await this.local.listDetailed(prefix);
     const seen = new Set(out.map((s) => s.key));
-    for (const [rel, meta] of this.remoteUnder(prefix)) {
+    for (const [rel, meta] of this.state.under(prefix)) {
       if (seen.has(rel)) continue;
       out.push({
         key: rel,
@@ -101,7 +80,7 @@ export class LazyStoreVfs implements Vfs {
     assertSafeKey(key);
     const local = await this.local.readBytes(key);
     if (local !== null) return local;
-    const meta = this.visible(key);
+    const meta = this.state.visible(key);
     if (!meta) return null;
     await this.materialize(key, meta);
     return this.local.readBytes(key);
@@ -127,49 +106,37 @@ export class LazyStoreVfs implements Vfs {
 
   async writeBytes(key: string, content: Buffer): Promise<void> {
     assertSafeKey(key);
-    this.assertWritable(key);
+    this.state.assertWritable(key);
     await this.settle(key);
     await this.local.writeBytes(key, content);
-    this.hidden.delete(key);
-    this.own(key);
-  }
-
-  /** Put an unread remote key under sync-back ownership (CAS on its generation). */
-  private own(rel: string): void {
-    const meta = this.remote.get(rel);
-    if (!meta || this.opts.manifest.has(rel)) return;
-    this.opts.manifest.set(rel, {
-      hash: UNREAD_HASH,
-      ...(meta.generation !== undefined ? { generation: meta.generation } : {}),
-    });
-  }
-
-  /** Hide a remote key from reads and make sure sync-back deletes it. */
-  private tombstone(rel: string): void {
-    if (!this.remote.has(rel)) return;
-    this.hidden.add(rel);
-    this.own(rel);
+    this.state.written(key);
   }
 
   async deleteKey(key: string): Promise<void> {
     assertSafeKey(key);
     await this.settle(key);
     await this.local.deleteKey(key);
-    this.tombstone(key);
+    this.state.tombstone(key);
   }
 
   async move(fromKey: string, toKey: string): Promise<void> {
     assertSafeKey(fromKey);
     assertSafeKey(toKey);
+    // POSIX rename: onto itself is a no-op, into itself is an error.
+    if (toKey === fromKey) return;
+    if (toKey.startsWith(`${fromKey}/`)) {
+      throw new Error(`move: destination is inside the source: ${fromKey}`);
+    }
     const isFile =
-      (await this.local.readBytes(fromKey)) !== null || this.visible(fromKey);
+      (await this.local.readBytes(fromKey)) !== null ||
+      this.state.visible(fromKey);
     if (!isFile) {
       // A directory: exists only as its descendants. Move each one.
       const children = await this.listDetailed(fromKey);
       if (children.length === 0) {
         throw new Error(`move: source not found: ${fromKey}`);
       }
-      if (this.remoteUnder(toKey).length > 0) {
+      if (this.state.under(toKey).length > 0) {
         throw new Error(`move: destination is not empty: ${toKey}`);
       }
       for (const child of children) {
@@ -181,20 +148,23 @@ export class LazyStoreVfs implements Vfs {
       await this.local.deletePrefix(fromKey);
       return;
     }
-    this.assertWritable(toKey);
-    const meta = this.visible(fromKey);
+    this.state.assertWritable(toKey);
+    const meta = this.state.visible(fromKey);
     if ((await this.local.readBytes(fromKey)) === null && meta) {
       await this.materialize(fromKey, meta);
     }
     await this.local.move(fromKey, toKey);
-    this.hidden.delete(toKey);
-    this.own(toKey);
-    this.tombstone(fromKey);
+    this.state.written(toKey);
+    this.state.tombstone(fromKey);
   }
 
   async deletePrefix(prefix: string): Promise<void> {
     assertSafeKey(prefix);
+    const under = `${prefix}/`;
+    for (const key of this.inflight.keys()) {
+      if (key.startsWith(under)) await this.settle(key);
+    }
     await this.local.deletePrefix(prefix);
-    for (const [rel] of this.remoteUnder(prefix)) this.tombstone(rel);
+    for (const [rel] of this.state.under(prefix)) this.state.tombstone(rel);
   }
 }

--- a/packages/host/src/vfs/lazy-store.ts
+++ b/packages/host/src/vfs/lazy-store.ts
@@ -1,30 +1,22 @@
-import { mkdir, stat } from "node:fs/promises";
-import { dirname, join } from "node:path";
 import {
   excluded,
-  fileSha256,
   type ObjectMetadata,
 } from "@houston/runtime-client/object-sync";
 import { FsVfs } from "./fs";
-import {
-  LazyObjectTooLargeError,
-  type LazyStoreVfsOptions,
-  UNREAD_HASH,
-} from "./lazy-store-types";
+import { fetchObject, type LazyBudget } from "./lazy-store-fetch";
+import { type LazyStoreVfsOptions, UNREAD_HASH } from "./lazy-store-types";
 import { assertSafeKey, decodeText, type ObjectStat, type Vfs } from "./vfs";
 
 /**
- * A Vfs over an object store that downloads an object the FIRST time a
- * handler reads it, never before. Listings and stats come from the store's
- * manifest; reads materialize one key into a local overlay (`root`); writes
- * and deletes land in the overlay and are carried to the store by the
- * caller's sync-back pass, exactly as a fully hydrated tree would be.
- *
- * The shared `manifest` is the sync-back ownership boundary: a key enters it
- * when it is materialized (with its real hash + generation) or when it is
- * overwritten / deleted before ever being read (an UNREAD_HASH entry carrying
- * the store's generation). A remote object that was never touched stays out
- * of the manifest, so a sync-back can neither re-upload nor delete it.
+ * A Vfs over an object store: listings/stats from the store manifest, an
+ * object downloaded into the local overlay (`root`) the FIRST time a handler
+ * reads it, writes and deletes in the overlay for the caller's sync-back.
+ * The shared `manifest` is the sync-back ownership boundary (materialized
+ * objects + UNREAD_HASH entries for keys written/deleted without a read);
+ * untouched remote objects never enter it, so they are never re-uploaded
+ * or deleted. Remote directories exist only as their descendants; writes
+ * keep a real tree's file/directory exclusivity so the next eager hydrate
+ * of the store cannot fail on a key that is both.
  */
 export class LazyStoreVfs implements Vfs {
   private readonly local: FsVfs;
@@ -32,6 +24,7 @@ export class LazyStoreVfs implements Vfs {
   /** Remote keys deleted (or moved away) locally: hidden from every read. */
   private readonly hidden = new Set<string>();
   private readonly inflight = new Map<string, Promise<void>>();
+  private readonly budget: LazyBudget = { materializedBytes: 0 };
 
   constructor(private readonly opts: LazyStoreVfsOptions) {
     this.local = new FsVfs(opts.root);
@@ -42,6 +35,11 @@ export class LazyStoreVfs implements Vfs {
     }
   }
 
+  /** Whether the store mints generations (the sync-back CAS capability). */
+  get generationAware(): boolean {
+    return this.opts.objects.some((o) => o.generation !== undefined);
+  }
+
   private relOf(storeKey: string): string | null {
     const { prefix } = this.opts;
     if (!prefix) return storeKey;
@@ -50,8 +48,8 @@ export class LazyStoreVfs implements Vfs {
       : null;
   }
 
-  private storeKey(rel: string): string {
-    return this.opts.prefix ? `${this.opts.prefix}/${rel}` : rel;
+  private visible(rel: string): ObjectMetadata | undefined {
+    return this.hidden.has(rel) ? undefined : this.remote.get(rel);
   }
 
   /** Remote keys visible under `prefix/` (not hidden). */
@@ -62,9 +60,22 @@ export class LazyStoreVfs implements Vfs {
     );
   }
 
-  async list(prefix: string): Promise<string[]> {
-    return (await this.listDetailed(prefix)).map((s) => s.key);
+  /** A real tree refuses a file where a directory is and vice versa. */
+  private assertWritable(key: string): void {
+    const segments = key.split("/");
+    for (let i = 1; i < segments.length; i++) {
+      const ancestor = segments.slice(0, i).join("/");
+      if (this.visible(ancestor)) {
+        throw new Error(`ENOTDIR: not a directory, ${ancestor}`);
+      }
+    }
+    if (this.remoteUnder(key).length > 0) {
+      throw new Error(`EISDIR: illegal operation on a directory, ${key}`);
+    }
   }
+
+  list = async (prefix: string) =>
+    (await this.listDetailed(prefix)).map((s) => s.key);
 
   async listDetailed(prefix: string): Promise<ObjectStat[]> {
     assertSafeKey(prefix);
@@ -90,8 +101,8 @@ export class LazyStoreVfs implements Vfs {
     assertSafeKey(key);
     const local = await this.local.readBytes(key);
     if (local !== null) return local;
-    const meta = this.remote.get(key);
-    if (!meta || this.hidden.has(key)) return null;
+    const meta = this.visible(key);
+    if (!meta) return null;
     await this.materialize(key, meta);
     return this.local.readBytes(key);
   }
@@ -100,35 +111,24 @@ export class LazyStoreVfs implements Vfs {
   private materialize(key: string, meta: ObjectMetadata): Promise<void> {
     const pending = this.inflight.get(key);
     if (pending) return pending;
-    const run = (async () => {
-      if (meta.size > this.opts.maxObjectBytes) {
-        throw new LazyObjectTooLargeError(
-          key,
-          meta.size,
-          this.opts.maxObjectBytes,
-        );
-      }
-      const dest = join(this.opts.root, ...key.split("/"));
-      await mkdir(dirname(dest), { recursive: true });
-      await this.opts.store.download(this.storeKey(key), dest);
-      const { size } = await stat(dest);
-      this.opts.manifest.set(key, {
-        hash: await fileSha256(dest, size),
-        ...(meta.generation !== undefined
-          ? { generation: meta.generation }
-          : {}),
-      });
-    })().finally(() => this.inflight.delete(key));
+    const run = fetchObject(this.opts, this.budget, key, meta).finally(() =>
+      this.inflight.delete(key),
+    );
     this.inflight.set(key, run);
     return run;
   }
 
-  async writeText(key: string, content: string): Promise<void> {
-    await this.writeBytes(key, Buffer.from(content, "utf8"));
-  }
+  /** Never race a download's rename over a local write of the same key. */
+  private settle = (key: string) =>
+    this.inflight.get(key)?.catch(() => undefined);
+
+  writeText = (key: string, content: string) =>
+    this.writeBytes(key, Buffer.from(content, "utf8"));
 
   async writeBytes(key: string, content: Buffer): Promise<void> {
     assertSafeKey(key);
+    this.assertWritable(key);
+    await this.settle(key);
     await this.local.writeBytes(key, content);
     this.hidden.delete(key);
     this.own(key);
@@ -153,6 +153,7 @@ export class LazyStoreVfs implements Vfs {
 
   async deleteKey(key: string): Promise<void> {
     assertSafeKey(key);
+    await this.settle(key);
     await this.local.deleteKey(key);
     this.tombstone(key);
   }
@@ -160,11 +161,29 @@ export class LazyStoreVfs implements Vfs {
   async move(fromKey: string, toKey: string): Promise<void> {
     assertSafeKey(fromKey);
     assertSafeKey(toKey);
-    if ((await this.local.readBytes(fromKey)) === null) {
-      const meta = this.remote.get(fromKey);
-      if (!meta || this.hidden.has(fromKey)) {
+    const isFile =
+      (await this.local.readBytes(fromKey)) !== null || this.visible(fromKey);
+    if (!isFile) {
+      // A directory: exists only as its descendants. Move each one.
+      const children = await this.listDetailed(fromKey);
+      if (children.length === 0) {
         throw new Error(`move: source not found: ${fromKey}`);
       }
+      if (this.remoteUnder(toKey).length > 0) {
+        throw new Error(`move: destination is not empty: ${toKey}`);
+      }
+      for (const child of children) {
+        await this.move(
+          child.key,
+          `${toKey}${child.key.slice(fromKey.length)}`,
+        );
+      }
+      await this.local.deletePrefix(fromKey);
+      return;
+    }
+    this.assertWritable(toKey);
+    const meta = this.visible(fromKey);
+    if ((await this.local.readBytes(fromKey)) === null && meta) {
       await this.materialize(fromKey, meta);
     }
     await this.local.move(fromKey, toKey);

--- a/packages/host/src/vfs/lazy-store.ts
+++ b/packages/host/src/vfs/lazy-store.ts
@@ -1,0 +1,181 @@
+import { mkdir, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+  excluded,
+  fileSha256,
+  type ObjectMetadata,
+} from "@houston/runtime-client/object-sync";
+import { FsVfs } from "./fs";
+import {
+  LazyObjectTooLargeError,
+  type LazyStoreVfsOptions,
+  UNREAD_HASH,
+} from "./lazy-store-types";
+import { assertSafeKey, decodeText, type ObjectStat, type Vfs } from "./vfs";
+
+/**
+ * A Vfs over an object store that downloads an object the FIRST time a
+ * handler reads it, never before. Listings and stats come from the store's
+ * manifest; reads materialize one key into a local overlay (`root`); writes
+ * and deletes land in the overlay and are carried to the store by the
+ * caller's sync-back pass, exactly as a fully hydrated tree would be.
+ *
+ * The shared `manifest` is the sync-back ownership boundary: a key enters it
+ * when it is materialized (with its real hash + generation) or when it is
+ * overwritten / deleted before ever being read (an UNREAD_HASH entry carrying
+ * the store's generation). A remote object that was never touched stays out
+ * of the manifest, so a sync-back can neither re-upload nor delete it.
+ */
+export class LazyStoreVfs implements Vfs {
+  private readonly local: FsVfs;
+  private readonly remote = new Map<string, ObjectMetadata>();
+  /** Remote keys deleted (or moved away) locally: hidden from every read. */
+  private readonly hidden = new Set<string>();
+  private readonly inflight = new Map<string, Promise<void>>();
+
+  constructor(private readonly opts: LazyStoreVfsOptions) {
+    this.local = new FsVfs(opts.root);
+    for (const object of opts.objects) {
+      const rel = this.relOf(object.key);
+      if (!rel || excluded(rel, opts.excludes)) continue;
+      this.remote.set(rel, object);
+    }
+  }
+
+  private relOf(storeKey: string): string | null {
+    const { prefix } = this.opts;
+    if (!prefix) return storeKey;
+    return storeKey.startsWith(`${prefix}/`)
+      ? storeKey.slice(prefix.length + 1)
+      : null;
+  }
+
+  private storeKey(rel: string): string {
+    return this.opts.prefix ? `${this.opts.prefix}/${rel}` : rel;
+  }
+
+  /** Remote keys visible under `prefix/` (not hidden). */
+  private remoteUnder(prefix: string): [string, ObjectMetadata][] {
+    const under = `${prefix}/`;
+    return [...this.remote].filter(
+      ([rel]) => rel.startsWith(under) && !this.hidden.has(rel),
+    );
+  }
+
+  async list(prefix: string): Promise<string[]> {
+    return (await this.listDetailed(prefix)).map((s) => s.key);
+  }
+
+  async listDetailed(prefix: string): Promise<ObjectStat[]> {
+    assertSafeKey(prefix);
+    const out = await this.local.listDetailed(prefix);
+    const seen = new Set(out.map((s) => s.key));
+    for (const [rel, meta] of this.remoteUnder(prefix)) {
+      if (seen.has(rel)) continue;
+      out.push({
+        key: rel,
+        size: meta.size,
+        updatedMs: Date.parse(meta.updated) || 0,
+      });
+    }
+    return out.sort((a, b) => a.key.localeCompare(b.key));
+  }
+
+  async readText(key: string): Promise<string | null> {
+    const buf = await this.readBytes(key);
+    return buf ? decodeText(buf) : null;
+  }
+
+  async readBytes(key: string): Promise<Buffer | null> {
+    assertSafeKey(key);
+    const local = await this.local.readBytes(key);
+    if (local !== null) return local;
+    const meta = this.remote.get(key);
+    if (!meta || this.hidden.has(key)) return null;
+    await this.materialize(key, meta);
+    return this.local.readBytes(key);
+  }
+
+  /** Download one object into the overlay once; concurrent reads share it. */
+  private materialize(key: string, meta: ObjectMetadata): Promise<void> {
+    const pending = this.inflight.get(key);
+    if (pending) return pending;
+    const run = (async () => {
+      if (meta.size > this.opts.maxObjectBytes) {
+        throw new LazyObjectTooLargeError(
+          key,
+          meta.size,
+          this.opts.maxObjectBytes,
+        );
+      }
+      const dest = join(this.opts.root, ...key.split("/"));
+      await mkdir(dirname(dest), { recursive: true });
+      await this.opts.store.download(this.storeKey(key), dest);
+      const { size } = await stat(dest);
+      this.opts.manifest.set(key, {
+        hash: await fileSha256(dest, size),
+        ...(meta.generation !== undefined
+          ? { generation: meta.generation }
+          : {}),
+      });
+    })().finally(() => this.inflight.delete(key));
+    this.inflight.set(key, run);
+    return run;
+  }
+
+  async writeText(key: string, content: string): Promise<void> {
+    await this.writeBytes(key, Buffer.from(content, "utf8"));
+  }
+
+  async writeBytes(key: string, content: Buffer): Promise<void> {
+    assertSafeKey(key);
+    await this.local.writeBytes(key, content);
+    this.hidden.delete(key);
+    this.own(key);
+  }
+
+  /** Put an unread remote key under sync-back ownership (CAS on its generation). */
+  private own(rel: string): void {
+    const meta = this.remote.get(rel);
+    if (!meta || this.opts.manifest.has(rel)) return;
+    this.opts.manifest.set(rel, {
+      hash: UNREAD_HASH,
+      ...(meta.generation !== undefined ? { generation: meta.generation } : {}),
+    });
+  }
+
+  /** Hide a remote key from reads and make sure sync-back deletes it. */
+  private tombstone(rel: string): void {
+    if (!this.remote.has(rel)) return;
+    this.hidden.add(rel);
+    this.own(rel);
+  }
+
+  async deleteKey(key: string): Promise<void> {
+    assertSafeKey(key);
+    await this.local.deleteKey(key);
+    this.tombstone(key);
+  }
+
+  async move(fromKey: string, toKey: string): Promise<void> {
+    assertSafeKey(fromKey);
+    assertSafeKey(toKey);
+    if ((await this.local.readBytes(fromKey)) === null) {
+      const meta = this.remote.get(fromKey);
+      if (!meta || this.hidden.has(fromKey)) {
+        throw new Error(`move: source not found: ${fromKey}`);
+      }
+      await this.materialize(fromKey, meta);
+    }
+    await this.local.move(fromKey, toKey);
+    this.hidden.delete(toKey);
+    this.own(toKey);
+    this.tombstone(fromKey);
+  }
+
+  async deletePrefix(prefix: string): Promise<void> {
+    assertSafeKey(prefix);
+    await this.local.deletePrefix(prefix);
+    for (const [rel] of this.remoteUnder(prefix)) this.tombstone(rel);
+  }
+}

--- a/packages/host/src/vfs/lazy-store.ts
+++ b/packages/host/src/vfs/lazy-store.ts
@@ -136,7 +136,7 @@ export class LazyStoreVfs implements Vfs {
       if (children.length === 0) {
         throw new Error(`move: source not found: ${fromKey}`);
       }
-      if (this.state.under(toKey).length > 0) {
+      if ((await this.listDetailed(toKey)).length > 0) {
         throw new Error(`move: destination is not empty: ${toKey}`);
       }
       for (const child of children) {

--- a/packages/host/src/vfs/prefixed.ts
+++ b/packages/host/src/vfs/prefixed.ts
@@ -1,0 +1,65 @@
+import type { ObjectStat, Vfs } from "./vfs";
+
+/**
+ * A Vfs whose keys are re-rooted under `prefix` of another Vfs. The op
+ * handlers address an agent relative to the `workspaces/` directory while the
+ * store-backed vfs is rooted one level up; this adapter bridges the two
+ * without copying anything.
+ */
+export class PrefixedVfs implements Vfs {
+  constructor(
+    private readonly inner: Vfs,
+    private readonly prefix: string,
+  ) {
+    if (!prefix || prefix.endsWith("/")) {
+      throw new Error("PrefixedVfs needs a non-empty prefix without a slash");
+    }
+  }
+
+  private key(k: string): string {
+    return `${this.prefix}/${k}`;
+  }
+
+  private strip(k: string): string {
+    return k.slice(this.prefix.length + 1);
+  }
+
+  async list(prefix: string): Promise<string[]> {
+    return (await this.inner.list(this.key(prefix))).map((k) => this.strip(k));
+  }
+
+  async listDetailed(prefix: string): Promise<ObjectStat[]> {
+    return (await this.inner.listDetailed(this.key(prefix))).map((s) => ({
+      ...s,
+      key: this.strip(s.key),
+    }));
+  }
+
+  readText(key: string): Promise<string | null> {
+    return this.inner.readText(this.key(key));
+  }
+
+  readBytes(key: string): Promise<Buffer | null> {
+    return this.inner.readBytes(this.key(key));
+  }
+
+  writeText(key: string, content: string): Promise<void> {
+    return this.inner.writeText(this.key(key), content);
+  }
+
+  writeBytes(key: string, content: Buffer): Promise<void> {
+    return this.inner.writeBytes(this.key(key), content);
+  }
+
+  deleteKey(key: string): Promise<void> {
+    return this.inner.deleteKey(this.key(key));
+  }
+
+  move(fromKey: string, toKey: string): Promise<void> {
+    return this.inner.move(this.key(fromKey), this.key(toKey));
+  }
+
+  deletePrefix(prefix: string): Promise<void> {
+    return this.inner.deletePrefix(this.key(prefix));
+  }
+}

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -77,6 +77,8 @@ export interface HydrateOptions {
    * conversation's files, not every conversation's) without a glob per id.
    */
   filter?: (rel: string) => boolean;
+  /** Every admitted path BEFORE `filter` (the store's view of the tree). */
+  onListed?: (rels: string[]) => void;
 }
 
 /** The hydrated prefix exceeded the caller's aggregate byte cap. */
@@ -117,13 +119,16 @@ export async function hydrate(
     objects ??
     (await store.list(prefix)).map((key) => ({ key, generation: undefined }));
   const entries: { generation?: string; key: string; rel: string }[] = [];
+  const admitted: string[] = [];
   for (const object of listed) {
     const { key } = object;
     const rel = prefix ? key.slice(prefix.length + 1) : key;
     if (!rel || excluded(rel, excludes)) continue;
+    admitted.push(rel);
     if (opts.filter && !opts.filter(rel)) continue;
     entries.push({ key, rel, generation: object.generation });
   }
+  opts.onListed?.(admitted);
   // Workers pull from a shared cursor. The first failure (download error or
   // the size cap) parks every worker before it takes new work, and only that
   // first error is thrown — workers themselves never reject, so a second

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -71,6 +71,12 @@ export interface HydrateOptions {
    * 133-object workspace measured 10.5 s sequential vs 0.4 s at 16.
    */
   concurrency?: number;
+  /**
+   * Per-object admission on top of `excludes`: only objects the predicate
+   * accepts are downloaded. Lets a caller hydrate a hot-set (one
+   * conversation's files, not every conversation's) without a glob per id.
+   */
+  filter?: (rel: string) => boolean;
 }
 
 /** The hydrated prefix exceeded the caller's aggregate byte cap. */
@@ -115,6 +121,7 @@ export async function hydrate(
     const { key } = object;
     const rel = prefix ? key.slice(prefix.length + 1) : key;
     if (!rel || excluded(rel, excludes)) continue;
+    if (opts.filter && !opts.filter(rel)) continue;
     entries.push({ key, rel, generation: object.generation });
   }
   // Workers pull from a shared cursor. The first failure (download error or

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -77,8 +77,10 @@ export interface HydrateOptions {
    * conversation's files, not every conversation's) without a glob per id.
    */
   filter?: (rel: string) => boolean;
-  /** Every admitted path BEFORE `filter` (the store's view of the tree). */
-  onListed?: (rels: string[]) => void;
+  /** Every admitted path BEFORE `filter` (the store's view of the tree) and
+   *  whether the listing carried generations (the CAS capability, which a
+   *  filtered manifest can no longer answer on its own). */
+  onListed?: (listing: { rels: string[]; generationAware: boolean }) => void;
 }
 
 /** The hydrated prefix exceeded the caller's aggregate byte cap. */
@@ -120,15 +122,17 @@ export async function hydrate(
     (await store.list(prefix)).map((key) => ({ key, generation: undefined }));
   const entries: { generation?: string; key: string; rel: string }[] = [];
   const admitted: string[] = [];
+  let generationAware = false;
   for (const object of listed) {
     const { key } = object;
     const rel = prefix ? key.slice(prefix.length + 1) : key;
     if (!rel || excluded(rel, excludes)) continue;
     admitted.push(rel);
+    if (object.generation !== undefined) generationAware = true;
     if (opts.filter && !opts.filter(rel)) continue;
     entries.push({ key, rel, generation: object.generation });
   }
-  opts.onListed?.(admitted);
+  opts.onListed?.({ rels: admitted, generationAware });
   // Workers pull from a shared cursor. The first failure (download error or
   // the size cap) parks every worker before it takes new work, and only that
   // first error is thrown — workers themselves never reject, so a second

--- a/packages/runtime-client/src/object-sync/index.ts
+++ b/packages/runtime-client/src/object-sync/index.ts
@@ -1,3 +1,4 @@
+export { fileSha256 } from "./file-hash";
 export type { HttpObjectStoreOptions } from "./http-store";
 export { HttpObjectStore } from "./http-store";
 export type {

--- a/packages/runtime-client/src/object-sync/object-store.ts
+++ b/packages/runtime-client/src/object-sync/object-store.ts
@@ -1,7 +1,9 @@
+import { createHash } from "node:crypto";
 import { createReadStream, createWriteStream, existsSync } from "node:fs";
 import { mkdir, readdir, rm, stat } from "node:fs/promises";
 import { dirname, join, posix, relative, resolve, sep } from "node:path";
 import { pipeline } from "node:stream/promises";
+import type { ObjectMetadata } from "./object-manifest";
 
 /**
  * The object-storage port behind durable engine state. Keys are forward-slash
@@ -103,6 +105,25 @@ export class LocalDirStore implements ObjectStore {
     };
     await walk(base);
     return out.sort();
+  }
+
+  /** Size + mtime + md5 per key, the same shape the HTTP store serves; no
+   *  generations (the local store has none), so readers stay unconditional. */
+  async manifest(prefix = ""): Promise<ObjectMetadata[]> {
+    const out: ObjectMetadata[] = [];
+    for (const key of await this.list(prefix)) {
+      const file = this.fileFor(key);
+      const info = await stat(file);
+      const hash = createHash("md5");
+      for await (const chunk of createReadStream(file)) hash.update(chunk);
+      out.push({
+        key,
+        size: info.size,
+        md5: hash.digest("base64"),
+        updated: info.mtime.toISOString(),
+      });
+    }
+    return out;
   }
 
   async download(key: string, destFile: string): Promise<void> {

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -168,12 +168,11 @@ export async function executeOp(
         console.error(
           `[op] not durably synced: outOfScope=${synced.outOfScope} skipped=${synced.skipped.length} conflicts=${synced.conflicts.length} landed=${landed} prefix=${resolved.prefix} kind=${op.op.kind}`,
         );
-        // NOTHING landed: declining is safe — the gateway proxies and the
-        // pod applies the write from an unchanged tree.
-        if (!landed) return json(res, 200, { ok: true, decline: true });
         // A file the store refuses (over its per-object cap) can never
-        // persist anywhere — the pod would silently fail the same way.
-        // Tell the user; the client does not retry a 413.
+        // persist anywhere — the pod would silently fail the same way, and
+        // proxying would let it answer success for an undurable write.
+        // Tell the user; the client does not retry a 413. Checked BEFORE
+        // the nothing-landed decline: a single refused file lands nothing.
         if (synced.skipped.length > 0) {
           return json(res, 200, {
             ok: true,
@@ -186,6 +185,9 @@ export async function executeOp(
             events: [],
           });
         }
+        // NOTHING landed: declining is safe — the gateway proxies and the
+        // pod applies the write from an unchanged tree.
+        if (!landed) return json(res, 200, { ok: true, decline: true });
         // Something landed and something conflicted: the write is PARTLY
         // durable. Re-running it on the pod would duplicate the part that
         // landed (a routine create mints a fresh id); the client must be

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -131,12 +131,31 @@ export async function executeOp(
     if (heartbeat.fenced) return json(res, 409, { error: "claim_fenced" });
     const isRead = op.op.kind === "route" && op.op.method === "GET";
     if (!isRead) {
+      if (result.tooLarge || result.status >= 500) {
+        // The handler failed part-way (a refused lazy read, a 5xx): the
+        // overlay may hold HALF a multi-key mutation. Nothing has reached
+        // the store yet, so declining is exact — the pod re-runs the write
+        // from an unchanged tree instead of the user seeing a split folder.
+        console.error(
+          `[op] handler failed before sync: status=${result.status} tooLarge=${result.tooLarge === true} prefix=${resolved.prefix} kind=${op.op.kind}`,
+        );
+        return json(res, 200, { ok: true, decline: true });
+      }
       const synced = await syncBack(
         resolved.store,
         resolved.prefix,
         filesystem.storeRoot,
         filesystem.manifest,
-        { include: result.include, holdDeletesOnFailure: true },
+        {
+          include: result.include,
+          holdDeletesOnFailure: true,
+          // A lazy tree's manifest may be EMPTY for a pure create; the
+          // listing still told us whether the store mints generations, so a
+          // first create stays create-only (CAS "0") instead of blind.
+          ...(filesystem.generationAware !== undefined
+            ? { generations: filesystem.generationAware }
+            : {}),
+        },
       );
       const landed = synced.uploaded.length + synced.deleted.length > 0;
       const partial =
@@ -253,11 +272,20 @@ async function republish(
   for (const family of families) {
     const key = docKey(filesystem.workspaceRel, family);
     let doc: unknown;
+    // Through the vfs: on a lazy tree the handler may have emitted the
+    // event without the family file being on disk yet — a raw read would
+    // project an EMPTY doc over real data. A read that THROWS (store blip,
+    // refused size) is a diagnostic, never an empty projection.
+    let raw: string | null;
     try {
-      // Through the vfs: on a lazy tree the handler may have emitted the
-      // event without the family file being on disk yet — a raw read would
-      // project an EMPTY doc over real data.
-      const raw = await filesystem.vfs.readText(key);
+      raw = await filesystem.vfs.readText(key);
+    } catch (error) {
+      diagnostics.push(
+        `${family}: read failed, not projected: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      continue;
+    }
+    try {
       doc =
         raw === null
           ? family === "config"

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -131,11 +131,15 @@ export async function executeOp(
     if (heartbeat.fenced) return json(res, 409, { error: "claim_fenced" });
     const isRead = op.op.kind === "route" && op.op.method === "GET";
     if (!isRead) {
-      if (result.tooLarge || result.status >= 500) {
-        // The handler failed part-way (a refused lazy read, a 5xx): the
-        // overlay may hold HALF a multi-key mutation. Nothing has reached
-        // the store yet, so declining is exact — the pod re-runs the write
-        // from an unchanged tree instead of the user seeing a split folder.
+      const treeOp = op.op.kind === "route" || op.op.kind === "conversation";
+      if (result.tooLarge || (treeOp && result.status >= 500)) {
+        // A tree-mutating handler failed part-way (a refused lazy read, a
+        // 5xx): the overlay may hold HALF a multi-key mutation. Nothing has
+        // reached the store yet, so declining is exact — the pod re-runs
+        // the write from an unchanged tree instead of the user seeing a
+        // split folder. Credential/settings ops have no overlay to leave
+        // half-written; their own status (a 502 from the credential store)
+        // is the pod's answer too.
         console.error(
           `[op] handler failed before sync: status=${result.status} tooLarge=${result.tooLarge === true} prefix=${resolved.prefix} kind=${op.op.kind}`,
         );
@@ -152,9 +156,7 @@ export async function executeOp(
           // A lazy tree's manifest may be EMPTY for a pure create; the
           // listing still told us whether the store mints generations, so a
           // first create stays create-only (CAS "0") instead of blind.
-          ...(filesystem.generationAware !== undefined
-            ? { generations: filesystem.generationAware }
-            : {}),
+          generations: filesystem.generationAware,
         },
       );
       const landed = synced.uploaded.length + synced.deleted.length > 0;
@@ -275,7 +277,8 @@ async function republish(
     // Through the vfs: on a lazy tree the handler may have emitted the
     // event without the family file being on disk yet — a raw read would
     // project an EMPTY doc over real data. A read that THROWS (store blip,
-    // refused size) is a diagnostic, never an empty projection.
+    // refused size) is a diagnostic; an absent or unparsable file projects
+    // the empty doc, as the pod's own projector does.
     let raw: string | null;
     try {
       raw = await filesystem.vfs.readText(key);

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -24,9 +24,9 @@ import { poolIdentity, resolveTurnStore } from "./turn-store";
 /** Reserved claim key for agent-level writes (gateway + pod-store agree). */
 export const AGENT_OPS_CLAIM_ID = "agent-ops";
 
-/** Route ops skip the AGENT's runtime tree (`workspaces/<ws>/<agent>/
+/** Route ops never see the AGENT's runtime tree (`workspaces/<ws>/<agent>/
  *  .houston/runtime/`) — exactly that depth, so a user project carrying its
- *  own `.houston/runtime` directory is hydrated like any other file. */
+ *  own `.houston/runtime` directory is listed like any other file. */
 const ROUTE_OP_EXCLUDES = ["workspaces/*/*/.houston/runtime/"];
 /** A settings op reads/writes the runtime dir's small files only: skip the
  *  bulk (history, user files); the small .houston docs keep the layout real.
@@ -102,19 +102,23 @@ export async function executeOp(
       ...(deps.maxHydrateBytes !== undefined
         ? { maxBytes: deps.maxHydrateBytes }
         : {}),
-      // Agent-level routes (files, docs, skills) never read the runtime tree
-      // (conversations, sessions) — the bulk of a busy agent. A settings op
-      // needs the runtime dir minus those two. Conversation ops hydrate
-      // everything. A credential op touches no file at all (the gateway's
-      // store is the only write) — it still hydrates the layout so the
-      // agent-exists check holds, with everything but the root excluded.
+      // Agent-level routes (files, docs, skills) and conversation ops run
+      // over a LAZY tree: the store's listing, objects downloaded on first
+      // read — a Files listing or a one-file read costs one round-trip, not
+      // the agent's size, and a rename fetches its one conversation. The
+      // runtime tree (conversations, sessions) is never listed for routes.
+      // A settings op needs the runtime dir minus those two. A credential
+      // op touches no file at all (the gateway's store is the only write)
+      // — it still hydrates the layout so the agent-exists check holds.
       ...(op.op.kind === "route"
-        ? { excludes: ROUTE_OP_EXCLUDES }
-        : op.op.kind === "settings"
-          ? { excludes: SETTINGS_OP_EXCLUDES }
-          : op.op.kind === "credential"
-            ? { excludes: CREDENTIAL_OP_EXCLUDES }
-            : {}),
+        ? { excludes: ROUTE_OP_EXCLUDES, lazy: true }
+        : op.op.kind === "conversation"
+          ? { lazy: true }
+          : op.op.kind === "settings"
+            ? { excludes: SETTINGS_OP_EXCLUDES }
+            : op.op.kind === "credential"
+              ? { excludes: CREDENTIAL_OP_EXCLUDES }
+              : {}),
     });
     const result = await applyOp(op, filesystem, deps.fetchImpl);
     if (result.agentMissing || result.decline) {
@@ -250,12 +254,16 @@ async function republish(
     const key = docKey(filesystem.workspaceRel, family);
     let doc: unknown;
     try {
-      const raw = await readFile(join(filesystem.storeRoot, key), "utf8");
-      doc = normalizeFamily(
-        family,
-        JSON.parse(raw.replace(/^\uFEFF/, "")),
-        key,
-      );
+      // Through the vfs: on a lazy tree the handler may have emitted the
+      // event without the family file being on disk yet — a raw read would
+      // project an EMPTY doc over real data.
+      const raw = await filesystem.vfs.readText(key);
+      doc =
+        raw === null
+          ? family === "config"
+            ? {}
+            : []
+          : normalizeFamily(family, JSON.parse(raw), key);
     } catch {
       doc = family === "config" ? {} : [];
     }

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -12,6 +12,7 @@ import { piTurnRequest } from "./pi-turn-request";
 import type { TurnServerDeps } from "./server-types";
 import { finishTurnDurability } from "./turn-durability";
 import { prepareTurnFilesystem } from "./turn-filesystem";
+import { ownConversationOnly } from "./turn-hot-set";
 import { TurnSetupError } from "./turn-layout";
 import { createTurnLog } from "./turn-log";
 import {
@@ -71,6 +72,13 @@ export async function executeTurn(
       claimed: Boolean(turn.claim),
       ...(deps.maxHydrateBytes !== undefined
         ? { maxBytes: deps.maxHydrateBytes }
+        : {}),
+      // A pool turn hydrates its own conversation's history only: the other
+      // conversations are the bulk of a busy agent and nothing in a turn
+      // reads them. An unclaimed (legacy per-workspace) runtime keeps the
+      // full tree.
+      ...(turn.claim
+        ? { filter: ownConversationOnly(turn.conversationId) }
         : {}),
     });
     timings.t_hydrated = performance.now();

--- a/packages/runtime/src/turn/op-apply.ts
+++ b/packages/runtime/src/turn/op-apply.ts
@@ -1,6 +1,6 @@
 import { join, posix } from "node:path";
 import { dispatchAgentOp } from "@houston/host/src/op/dispatch";
-import { PrefixedVfs } from "@houston/host/src/vfs";
+import { LazyReadRefusedError, PrefixedVfs } from "@houston/host/src/vfs";
 import type { HoustonEvent } from "@houston/protocol";
 import { applyServedCredential } from "../auth/auth-file";
 import { generateTitle } from "../session/summarize";
@@ -36,6 +36,8 @@ export interface OpResult {
   agentMissing?: boolean;
   /** The worker cannot serve this one (a provider that needs the pod). */
   decline?: boolean;
+  /** A lazy read was refused mid-handler: the overlay may be partial. */
+  tooLarge?: true;
 }
 
 const json = (
@@ -230,39 +232,50 @@ export async function applyOp(
       const { conversationId, action } = op.op;
       const dir = join(filesystem.dataDir, "conversations");
       const include = conversationScope(filesystem.dataRel, conversationId);
-      // Materialize the one conversation file (a lazy tree downloads it here;
-      // a hydrated one already has it). A missing conversation stays missing
-      // and the mutation below answers 404.
-      await filesystem.vfs.readBytes(
-        posix.join(
-          filesystem.dataRel,
-          "conversations",
-          `${encodeURIComponent(conversationId)}.json`,
-        ),
+      const notFound = {
+        ...json(404, { error: "conversation not found" }),
+        events: [],
+        include,
+      };
+      const conversationsRel = posix.join(filesystem.dataRel, "conversations");
+      const fileRel = posix.join(
+        conversationsRel,
+        `${encodeURIComponent(conversationId)}.json`,
       );
-      // The runtime's own directory-scoped mutations — the pod's PATCH/DELETE
-      // call the same functions against its live data dir.
-      const found =
-        action === "rename"
-          ? renameConversationMutationAt(
-              dir,
-              conversationId,
-              op.op.title ?? "",
-            ) !== null
-          : deleteConversationAt(dir, conversationId);
-      if (!found) {
-        return {
-          ...json(404, { error: "conversation not found" }),
-          events: [],
-          include,
-        };
-      }
+      // Existence from the listing: a lazy tree answers it without a
+      // download (the pod's 404 for an unknown conversation, same contract).
+      const exists = (await filesystem.vfs.list(conversationsRel)).includes(
+        fileRel,
+      );
+      if (!exists) return notFound;
       if (action === "delete") {
-        // Through the vfs so a lazy tree tombstones the session files it
-        // never downloaded (the sync-back then deletes them in the store).
+        // Deletes need no bytes: tombstone the file and the session dir so
+        // a lazy tree never downloads what it is about to remove.
+        await filesystem.vfs.deleteKey(fileRel);
         await filesystem.vfs.deletePrefix(
           posix.join(filesystem.dataRel, "sessions", conversationId),
         );
+        deleteConversationAt(dir, conversationId);
+      } else {
+        // A rename reads the file: materialize it (a hydrated tree already
+        // has it). Over the read cap the pod must do it — decline.
+        try {
+          await filesystem.vfs.readBytes(fileRel);
+        } catch (error) {
+          if (!(error instanceof LazyReadRefusedError)) throw error;
+          return {
+            ...json(503, { error: "conversation too large to edit asleep" }),
+            events: [],
+            include,
+            decline: true,
+          };
+        }
+        const renamed = renameConversationMutationAt(
+          dir,
+          conversationId,
+          op.op.title ?? "",
+        );
+        if (renamed === null) return notFound;
       }
       return {
         ...json(200, { ok: true }),

--- a/packages/runtime/src/turn/op-apply.ts
+++ b/packages/runtime/src/turn/op-apply.ts
@@ -1,6 +1,6 @@
-import { rm } from "node:fs/promises";
 import { join, posix } from "node:path";
 import { dispatchAgentOp } from "@houston/host/src/op/dispatch";
+import { PrefixedVfs } from "@houston/host/src/vfs";
 import type { HoustonEvent } from "@houston/protocol";
 import { applyServedCredential } from "../auth/auth-file";
 import { generateTitle } from "../session/summarize";
@@ -89,9 +89,13 @@ export async function applyOp(
   const agentId = engineAgentId(filesystem);
   switch (op.op.kind) {
     case "route": {
+      // The handlers address the agent under `workspaces/`; the turn's vfs
+      // is rooted one level up (lazy or real, the same seam).
+      const vfs = new PrefixedVfs(filesystem.vfs, "workspaces");
       const result = await dispatchAgentOp({
         workspacesRoot: join(filesystem.storeRoot, "workspaces"),
         agentId,
+        vfs,
         request: {
           method: op.op.method,
           rest: op.op.rest,
@@ -123,6 +127,7 @@ export async function applyOp(
         const view = await dispatchAgentOp({
           workspacesRoot: join(filesystem.storeRoot, "workspaces"),
           agentId,
+          vfs,
           request: {
             method: "GET",
             rest: "skills",
@@ -225,6 +230,16 @@ export async function applyOp(
       const { conversationId, action } = op.op;
       const dir = join(filesystem.dataDir, "conversations");
       const include = conversationScope(filesystem.dataRel, conversationId);
+      // Materialize the one conversation file (a lazy tree downloads it here;
+      // a hydrated one already has it). A missing conversation stays missing
+      // and the mutation below answers 404.
+      await filesystem.vfs.readBytes(
+        posix.join(
+          filesystem.dataRel,
+          "conversations",
+          `${encodeURIComponent(conversationId)}.json`,
+        ),
+      );
       // The runtime's own directory-scoped mutations — the pod's PATCH/DELETE
       // call the same functions against its live data dir.
       const found =
@@ -243,10 +258,11 @@ export async function applyOp(
         };
       }
       if (action === "delete") {
-        await rm(join(filesystem.dataDir, "sessions", conversationId), {
-          recursive: true,
-          force: true,
-        });
+        // Through the vfs so a lazy tree tombstones the session files it
+        // never downloaded (the sync-back then deletes them in the store).
+        await filesystem.vfs.deletePrefix(
+          posix.join(filesystem.dataRel, "sessions", conversationId),
+        );
       }
       return {
         ...json(200, { ok: true }),

--- a/packages/runtime/src/turn/server-op-lazy.test.ts
+++ b/packages/runtime/src/turn/server-op-lazy.test.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { LocalWorkspaceStore } from "@houston/host/src/store/local";
+import { MAX_UPLOAD_BYTES } from "@houston/host/src/turn/files-import";
 import {
   LocalDirStore,
   type ObjectStore,
@@ -242,6 +243,31 @@ test("a conversation rename hydrates its own conversation only", async () => {
   expect(keys).toHaveLength(45);
 });
 
+test("a folder move that hits the read cap mid-way declines and leaves the store untouched", async () => {
+  const { storeRoot, agentRel } = await seedBusyAgent();
+  // One oversized file among the forty: the per-child move refuses it.
+  writeFileSync(
+    join(storeRoot, PREFIX, agentRel, "reports", "huge.bin"),
+    Buffer.alloc(MAX_UPLOAD_BYTES + 1),
+  );
+  const store = countingStore(storeRoot);
+  const before = (await store.list(PREFIX)).sort();
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const json = await postOp(base, await heartbeatOK(), {
+    kind: "route",
+    method: "POST",
+    rest: "files/move",
+    contentType: "application/json",
+    body: JSON.stringify({ path: "reports", toDir: "archive" }),
+  });
+  expect(json.decline, JSON.stringify(json)).toBe(true);
+  expect(json.status).toBeUndefined();
+  expect((await store.list(PREFIX)).sort()).toEqual(before);
+  expect(store.downloads.some((k) => k.endsWith("/huge.bin"))).toBe(false);
+});
+
 test("a conversation delete removes its file and unread session files, nothing else", async () => {
   const { storeRoot, agentRel } = await seedBusyAgent();
   const store = countingStore(storeRoot);
@@ -254,9 +280,8 @@ test("a conversation delete removes its file and unread session files, nothing e
     conversationId: "c1",
   });
   expect(json.status, JSON.stringify(json)).toBe(200);
-  expect(store.downloads).toEqual([
-    `${agentRel}/.houston/runtime/conversations/c1.json`,
-  ]);
+  // A delete needs no bytes: existence comes from the listing.
+  expect(store.downloads).toEqual([]);
   const keys = await store.list(PREFIX);
   const runtime = `${PREFIX}/${agentRel}/.houston/runtime`;
   expect(keys).not.toContain(`${runtime}/conversations/c1.json`);
@@ -264,6 +289,26 @@ test("a conversation delete removes its file and unread session files, nothing e
   expect(keys).toContain(`${runtime}/conversations/c2.json`);
   expect(keys).toContain(`${runtime}/sessions/c2/s.jsonl`);
   expect(keys).toHaveLength(43);
+});
+
+test("renaming a conversation over the read cap declines to the pod instead of failing", async () => {
+  const { storeRoot, agentRel } = await seedBusyAgent();
+  writeFileSync(
+    join(storeRoot, PREFIX, agentRel, ".houston/runtime/conversations/c1.json"),
+    Buffer.alloc(MAX_UPLOAD_BYTES + 1),
+  );
+  const store = countingStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const json = await postOp(base, await heartbeatOK(), {
+    kind: "conversation",
+    action: "rename",
+    conversationId: "c1",
+    title: "x",
+  });
+  expect(json.decline, JSON.stringify(json)).toBe(true);
+  expect(store.downloads).toEqual([]);
 });
 
 test("renaming a conversation the agent does not have answers 404 without a download", async () => {

--- a/packages/runtime/src/turn/server-op-lazy.test.ts
+++ b/packages/runtime/src/turn/server-op-lazy.test.ts
@@ -1,0 +1,283 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalWorkspaceStore } from "@houston/host/src/store/local";
+import {
+  LocalDirStore,
+  type ObjectStore,
+} from "@houston/runtime-client/object-sync";
+import { afterEach, expect, test } from "vitest";
+import { createTurnServer } from "./server";
+import type { runPiTurn } from "./turn-session";
+
+/**
+ * Lazy hot-set on pool ops: a sleeping agent's Files tab and one-file reads
+ * must cost the objects they touch, never the agent's size, and a
+ * conversation op must hydrate only its own conversation.
+ */
+
+const servers: Server[] = [];
+afterEach(() => {
+  for (const s of servers.splice(0)) s.close();
+});
+
+async function listen(server: Server): Promise<string> {
+  servers.push(server);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+}
+
+const noopTurn: typeof runPiTurn = async () => ({});
+const PREFIX = "ws/w1/agent-1";
+
+function countingStore(root: string): ObjectStore & { downloads: string[] } {
+  const inner = new LocalDirStore(root);
+  const downloads: string[] = [];
+  return {
+    downloads,
+    list: (p) => inner.list(p),
+    manifest: (p) => inner.manifest(p),
+    download: (key, dest) => {
+      downloads.push(key.slice(PREFIX.length + 1));
+      return inner.download(key, dest);
+    },
+    upload: (src, key, o) => inner.upload(src, key, o),
+    delete: (key, o) => inner.delete(key, o),
+  };
+}
+
+/** A busy agent: many user files, two conversations with sessions. */
+async function seedBusyAgent() {
+  const storeRoot = mkdtempSync(join(tmpdir(), "op-lazy-store-"));
+  const workspaces = join(storeRoot, PREFIX, "workspaces");
+  const store = new LocalWorkspaceStore(workspaces);
+  const ws = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({ workspaceId: ws.id, name: "Bob" });
+  const agentDir = join(workspaces, ...agent.id.split("/"));
+  writeFileSync(join(agentDir, "CLAUDE.md"), "# Bob\n");
+  mkdirSync(join(agentDir, "reports"), { recursive: true });
+  for (let i = 0; i < 40; i++) {
+    writeFileSync(join(agentDir, "reports", `r${i}.csv`), `row,${i}\n`);
+  }
+  const runtime = join(agentDir, ".houston", "runtime");
+  for (const id of ["c1", "c2"]) {
+    mkdirSync(join(runtime, "conversations"), { recursive: true });
+    mkdirSync(join(runtime, "sessions", id), { recursive: true });
+    writeFileSync(
+      join(runtime, "conversations", `${id}.json`),
+      JSON.stringify({
+        id,
+        title: "old",
+        createdAt: 1,
+        updatedAt: 1,
+        messages: [],
+      }),
+    );
+    writeFileSync(join(runtime, "sessions", id, "s.jsonl"), "{}\n");
+  }
+  return { storeRoot, agentRel: `workspaces/${agent.id}` };
+}
+
+async function heartbeatOK(): Promise<string> {
+  return listen(
+    createServer((_req, res) => {
+      res.writeHead(200);
+      res.end("{}");
+    }),
+  );
+}
+
+async function postOp(base: string, heartbeatUrl: string, op: unknown) {
+  for (let attempt = 0; ; attempt++) {
+    const response = await fetch(`${base}/op`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        workspaceId: "w1",
+        agentId: "agent-1",
+        gcsPrefix: PREFIX,
+        hostToken: "host-token",
+        claim: {
+          id: "claim-1",
+          bootId: "boot-1",
+          token: "claim-token",
+          heartbeatUrl,
+        },
+        triggersEnabled: false,
+        op,
+      }),
+    });
+    const json = (await response.json()) as Record<string, unknown>;
+    if (response.status !== 503 || json.error !== "worker_full" || attempt > 40)
+      return json;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+test("a Files listing downloads ZERO objects and still reports every file with its size", async () => {
+  const { storeRoot } = await seedBusyAgent();
+  const store = countingStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const json = await postOp(base, await heartbeatOK(), {
+    kind: "route",
+    method: "GET",
+    rest: "files",
+    body: "",
+    contentType: "application/json",
+  });
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  const listing = JSON.parse(json.body as string) as Array<{
+    path: string;
+    size: number;
+    is_directory: boolean;
+    date_modified?: number;
+  }>;
+  const files = listing.filter((e) => !e.is_directory);
+  expect(files).toHaveLength(41);
+  const r7 = files.find((e) => e.path === "reports/r7.csv");
+  expect(r7?.size).toBe(Buffer.byteLength("row,7\n"));
+  expect(r7?.date_modified).toBeGreaterThan(0);
+  expect(listing.some((e) => e.is_directory && e.path === "reports")).toBe(
+    true,
+  );
+  expect(store.downloads).toEqual([]);
+});
+
+test("a file download fetches exactly that object", async () => {
+  const { storeRoot, agentRel } = await seedBusyAgent();
+  const store = countingStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const json = await postOp(base, await heartbeatOK(), {
+    kind: "route",
+    method: "GET",
+    rest: "files/download",
+    query: "path=reports/r3.csv",
+  });
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  expect(
+    Buffer.from(json.bodyBase64 as string, "base64").toString("utf8"),
+  ).toBe("row,3\n");
+  expect(store.downloads).toEqual([`${agentRel}/reports/r3.csv`]);
+});
+
+test("deleting an unread file removes it from the store without downloading anything", async () => {
+  const { storeRoot, agentRel } = await seedBusyAgent();
+  const store = countingStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const json = await postOp(base, await heartbeatOK(), {
+    kind: "route",
+    method: "DELETE",
+    rest: "files",
+    query: "path=reports/r5.csv",
+  });
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  expect(json.decline).toBeUndefined();
+  expect(store.downloads).toEqual([]);
+  const keys = await store.list(PREFIX);
+  expect(keys).not.toContain(`${PREFIX}/${agentRel}/reports/r5.csv`);
+  expect(keys).toContain(`${PREFIX}/${agentRel}/reports/r6.csv`);
+  expect(keys).toHaveLength(41 + 4 - 1);
+});
+
+test("a routine create on a lazy tree writes the doc and leaves user files alone", async () => {
+  const { storeRoot, agentRel } = await seedBusyAgent();
+  const store = countingStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const json = await postOp(base, await heartbeatOK(), {
+    kind: "route",
+    method: "POST",
+    rest: "routines",
+    contentType: "application/json",
+    body: JSON.stringify({
+      name: "Digest",
+      prompt: "p",
+      schedule: "0 9 * * *",
+      enabled: true,
+    }),
+  });
+  expect(json.status, JSON.stringify(json)).toBe(201);
+  expect(json.events).toEqual(["RoutinesChanged"]);
+  expect(
+    store.downloads.every((k) => !k.startsWith(`${agentRel}/reports/`)),
+  ).toBe(true);
+  const keys = await store.list(PREFIX);
+  expect(keys).toContain(
+    `${PREFIX}/${agentRel}/.houston/routines/routines.json`,
+  );
+  expect(keys.filter((k) => k.includes("/reports/"))).toHaveLength(40);
+});
+
+test("a conversation rename hydrates its own conversation only", async () => {
+  const { storeRoot, agentRel } = await seedBusyAgent();
+  const store = countingStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const json = await postOp(base, await heartbeatOK(), {
+    kind: "conversation",
+    action: "rename",
+    conversationId: "c1",
+    title: "new name",
+  });
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  expect(store.downloads).toEqual([
+    `${agentRel}/.houston/runtime/conversations/c1.json`,
+  ]);
+  // Nothing but the renamed file changed in the store.
+  const keys = await store.list(PREFIX);
+  expect(keys).toContain(
+    `${PREFIX}/${agentRel}/.houston/runtime/conversations/c2.json`,
+  );
+  expect(keys.filter((k) => k.includes("/reports/"))).toHaveLength(40);
+  expect(keys).toHaveLength(45);
+});
+
+test("a conversation delete removes its file and unread session files, nothing else", async () => {
+  const { storeRoot, agentRel } = await seedBusyAgent();
+  const store = countingStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const json = await postOp(base, await heartbeatOK(), {
+    kind: "conversation",
+    action: "delete",
+    conversationId: "c1",
+  });
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  expect(store.downloads).toEqual([
+    `${agentRel}/.houston/runtime/conversations/c1.json`,
+  ]);
+  const keys = await store.list(PREFIX);
+  const runtime = `${PREFIX}/${agentRel}/.houston/runtime`;
+  expect(keys).not.toContain(`${runtime}/conversations/c1.json`);
+  expect(keys).not.toContain(`${runtime}/sessions/c1/s.jsonl`);
+  expect(keys).toContain(`${runtime}/conversations/c2.json`);
+  expect(keys).toContain(`${runtime}/sessions/c2/s.jsonl`);
+  expect(keys).toHaveLength(43);
+});
+
+test("renaming a conversation the agent does not have answers 404 without a download", async () => {
+  const { storeRoot } = await seedBusyAgent();
+  const store = countingStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const json = await postOp(base, await heartbeatOK(), {
+    kind: "conversation",
+    action: "rename",
+    conversationId: "ghost",
+    title: "x",
+  });
+  expect(json.status, JSON.stringify(json)).toBe(404);
+  expect(store.downloads).toEqual([]);
+});

--- a/packages/runtime/src/turn/server-op-lazy.test.ts
+++ b/packages/runtime/src/turn/server-op-lazy.test.ts
@@ -268,6 +268,26 @@ test("a folder move that hits the read cap mid-way declines and leaves the store
   expect(store.downloads.some((k) => k.endsWith("/huge.bin"))).toBe(false);
 });
 
+test("a plain handler 5xx on a tree op declines before any sync-back", async () => {
+  const { storeRoot } = await seedBusyAgent();
+  const store = countingStore(storeRoot);
+  const before = (await store.list(PREFIX)).sort();
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  // A folder under a path the store holds as a FILE: a real tree fails the
+  // mkdir (ENOTDIR) and the handler 500s; the worker must not sync or relay.
+  const json = await postOp(base, await heartbeatOK(), {
+    kind: "route",
+    method: "POST",
+    rest: "files/folder",
+    contentType: "application/json",
+    body: JSON.stringify({ path: "reports/r1.csv/sub" }),
+  });
+  expect(json.decline, JSON.stringify(json)).toBe(true);
+  expect((await store.list(PREFIX)).sort()).toEqual(before);
+});
+
 test("a conversation delete removes its file and unread session files, nothing else", async () => {
   const { storeRoot, agentRel } = await seedBusyAgent();
   const store = countingStore(storeRoot);

--- a/packages/runtime/src/turn/server-op-lazy.test.ts
+++ b/packages/runtime/src/turn/server-op-lazy.test.ts
@@ -8,6 +8,7 @@ import { MAX_UPLOAD_BYTES } from "@houston/host/src/turn/files-import";
 import {
   LocalDirStore,
   type ObjectStore,
+  ObjectTooLargeError,
 } from "@houston/runtime-client/object-sync";
 import { afterEach, expect, test } from "vitest";
 import { createTurnServer } from "./server";
@@ -286,6 +287,32 @@ test("a plain handler 5xx on a tree op declines before any sync-back", async () 
   });
   expect(json.decline, JSON.stringify(json)).toBe(true);
   expect((await store.list(PREFIX)).sort()).toEqual(before);
+});
+
+test("a single file the store refuses answers 413, never a decline that lets the pod claim success", async () => {
+  const { storeRoot } = await seedBusyAgent();
+  const counting = countingStore(storeRoot);
+  const store: typeof counting = {
+    ...counting,
+    upload: async (_src, key) => {
+      throw new ObjectTooLargeError(key, "over the per-object cap");
+    },
+  };
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const json = await postOp(base, await heartbeatOK(), {
+    kind: "route",
+    method: "PUT",
+    rest: "agentfile/notes.md",
+    contentType: "application/json",
+    body: JSON.stringify({ content: "# too big for the store" }),
+  });
+  expect(json.decline, JSON.stringify(json)).toBeUndefined();
+  expect(json.status).toBe(413);
+  expect(JSON.parse(json.body as string).files).toEqual([
+    expect.stringMatching(/notes\.md$/),
+  ]);
 });
 
 test("a conversation delete removes its file and unread session files, nothing else", async () => {

--- a/packages/runtime/src/turn/turn-filesystem.test.ts
+++ b/packages/runtime/src/turn/turn-filesystem.test.ts
@@ -119,3 +119,29 @@ test("a claimed turn's filter leaves other conversations' history out of the hyd
     "workspaces/Personal/Bob/.houston/runtime/settings.json",
   ]);
 });
+
+test("a claimed turn whose agent holds only other conversations still resolves its layout", async () => {
+  const storeRoot = mkdtempSync(join(tmpdir(), "hot-set-empty-"));
+  const prefix = "ws/w1/agent-1";
+  const runtime = join(
+    storeRoot,
+    prefix,
+    "workspaces",
+    "Personal",
+    "Bob",
+    ".houston",
+    "runtime",
+  );
+  mkdirSync(join(runtime, "conversations"), { recursive: true });
+  writeFileSync(join(runtime, "conversations", "c2.json"), "{}");
+  const fs = await prepareTurnFilesystem({
+    store: new LocalDirStore(storeRoot),
+    prefix,
+    root: mkdtempSync(join(tmpdir(), "hot-set-empty-root-")),
+    claimed: true,
+    filter: ownConversationOnly("c-new"),
+  });
+  expect(fs.manifest.size).toBe(0);
+  expect(fs.kind).toBe("standing");
+  expect(fs.workspaceRel).toBe("workspaces/Personal/Bob");
+});

--- a/packages/runtime/src/turn/turn-filesystem.test.ts
+++ b/packages/runtime/src/turn/turn-filesystem.test.ts
@@ -144,4 +144,42 @@ test("a claimed turn whose agent holds only other conversations still resolves i
   expect(fs.manifest.size).toBe(0);
   expect(fs.kind).toBe("standing");
   expect(fs.workspaceRel).toBe("workspaces/Personal/Bob");
+  expect(fs.listedObjects).toBe(1);
+});
+
+test("the eager path reports the store's generation capability even when the filtered manifest is empty", async () => {
+  const storeRoot = mkdtempSync(join(tmpdir(), "gen-aware-"));
+  const prefix = "ws/w1/agent-1";
+  const runtime = join(
+    storeRoot,
+    prefix,
+    "workspaces/Personal/Bob/.houston/runtime",
+  );
+  mkdirSync(join(runtime, "conversations"), { recursive: true });
+  writeFileSync(join(runtime, "conversations", "c2.json"), "{}");
+  const inner = new LocalDirStore(storeRoot);
+  const store = {
+    list: (p: string) => inner.list(p),
+    manifest: async (p?: string) =>
+      (await inner.manifest(p)).map((o) => ({ ...o, generation: "3" })),
+    download: inner.download.bind(inner),
+    upload: inner.upload.bind(inner),
+    delete: inner.delete.bind(inner),
+  };
+  const fs = await prepareTurnFilesystem({
+    store,
+    prefix,
+    root: mkdtempSync(join(tmpdir(), "gen-aware-root-")),
+    claimed: true,
+    filter: ownConversationOnly("c-new"),
+  });
+  expect(fs.manifest.size).toBe(0);
+  expect(fs.generationAware).toBe(true);
+  const plain = await prepareTurnFilesystem({
+    store: inner,
+    prefix,
+    root: mkdtempSync(join(tmpdir(), "gen-aware-root2-")),
+    claimed: true,
+  });
+  expect(plain.generationAware).toBe(false);
 });

--- a/packages/runtime/src/turn/turn-filesystem.test.ts
+++ b/packages/runtime/src/turn/turn-filesystem.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { LocalDirStore } from "@houston/runtime-client/object-sync";
 import { expect, test } from "vitest";
 import { prepareTurnFilesystem } from "./turn-filesystem";
+import { ownConversationOnly } from "./turn-hot-set";
 
 test("route-op excludes skip the runtime tree wherever the agent sits", async () => {
   const storeRoot = mkdtempSync(join(tmpdir(), "op-hydrate-"));
@@ -41,4 +42,80 @@ test("route-op excludes skip the runtime tree wherever the agent sits", async ()
     ),
   ).toBe(false);
   expect(existsSync(join(fs.workspaceDir, "report.csv"))).toBe(true);
+});
+
+test("a lazy prepare downloads nothing, lays out the agent skeleton, and reads on demand", async () => {
+  const storeRoot = mkdtempSync(join(tmpdir(), "lazy-hydrate-"));
+  const prefix = "ws/w1/agent-1";
+  const agent = join(storeRoot, prefix, "workspaces", "Personal", "Bob");
+  mkdirSync(join(agent, ".houston", "routines"), { recursive: true });
+  mkdirSync(join(agent, "files"), { recursive: true });
+  writeFileSync(join(agent, "CLAUDE.md"), "# Bob\n");
+  writeFileSync(join(agent, "files", "report.csv"), "a,b\n");
+  writeFileSync(join(agent, ".houston", "routines", "routines.json"), "[]");
+  const inner = new LocalDirStore(storeRoot);
+  const downloads: string[] = [];
+  const store = {
+    list: (p: string) => inner.list(p),
+    manifest: (p?: string) => inner.manifest(p),
+    download: (key: string, dest: string) => {
+      downloads.push(key);
+      return inner.download(key, dest);
+    },
+    upload: inner.upload.bind(inner),
+    delete: inner.delete.bind(inner),
+  };
+  const root = mkdtempSync(join(tmpdir(), "lazy-root-"));
+  const fs = await prepareTurnFilesystem({
+    store,
+    prefix,
+    root,
+    claimed: true,
+    lazy: true,
+  });
+  expect(fs.kind).toBe("standing");
+  expect(fs.workspaceRel).toBe("workspaces/Personal/Bob");
+  expect(downloads).toEqual([]);
+  expect(fs.manifest.size).toBe(0);
+  expect(fs.listedObjects).toBe(3);
+  expect(existsSync(join(fs.workspaceDir, "CLAUDE.md"))).toBe(false);
+  expect(await fs.vfs.readText("workspaces/Personal/Bob/CLAUDE.md")).toBe(
+    "# Bob\n",
+  );
+  expect(downloads).toEqual([`${prefix}/workspaces/Personal/Bob/CLAUDE.md`]);
+  expect(fs.manifest.size).toBe(1);
+});
+
+test("a claimed turn's filter leaves other conversations' history out of the hydrate", async () => {
+  const storeRoot = mkdtempSync(join(tmpdir(), "hot-set-hydrate-"));
+  const prefix = "ws/w1/agent-1";
+  const runtime = join(
+    storeRoot,
+    prefix,
+    "workspaces",
+    "Personal",
+    "Bob",
+    ".houston",
+    "runtime",
+  );
+  for (const id of ["c1", "c2"]) {
+    mkdirSync(join(runtime, "sessions", id), { recursive: true });
+    mkdirSync(join(runtime, "conversations"), { recursive: true });
+    writeFileSync(join(runtime, "conversations", `${id}.json`), "{}");
+    writeFileSync(join(runtime, "sessions", id, "s.jsonl"), "");
+  }
+  writeFileSync(join(runtime, "settings.json"), "{}");
+  const fs = await prepareTurnFilesystem({
+    store: new LocalDirStore(storeRoot),
+    prefix,
+    root: mkdtempSync(join(tmpdir(), "hot-set-root-")),
+    claimed: true,
+    filter: ownConversationOnly("c1"),
+  });
+  const keys = [...fs.manifest.keys()].sort();
+  expect(keys).toEqual([
+    "workspaces/Personal/Bob/.houston/runtime/conversations/c1.json",
+    "workspaces/Personal/Bob/.houston/runtime/sessions/c1/s.jsonl",
+    "workspaces/Personal/Bob/.houston/runtime/settings.json",
+  ]);
 });

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -1,6 +1,8 @@
 import { mkdir } from "node:fs/promises";
 import { join, posix } from "node:path";
 import { docKey } from "@houston/domain";
+import { MAX_UPLOAD_BYTES } from "@houston/host/src/turn/files-import";
+import { FsVfs, LazyStoreVfs, type Vfs } from "@houston/host/src/vfs";
 import {
   DEFAULT_EXCLUDES,
   HydrateLimitError,
@@ -21,7 +23,15 @@ export const TURN_HYDRATE_MAX_BYTES = 2 * 1024 * 1024 * 1024;
 /** Hydrated manifest paired with the resolved on-disk layout. */
 export interface TurnFilesystem extends TurnLayout {
   storeRoot: string;
+  /** Sync-back ownership: objects on disk (and, lazily, objects owned
+   *  without a download). A lazy tree grows this as handlers read. */
   manifest: HydrateManifest;
+  /** Reads rooted at `storeRoot`: the real tree when hydrated, the
+   *  store-backed overlay when lazy. Readers that may touch an object the
+   *  op did not materialize (doc republish) go through this, never `fs`. */
+  vfs: Vfs;
+  /** Remote objects the lazy listing knows about (diagnostics). */
+  listedObjects: number;
 }
 
 /**
@@ -39,18 +49,56 @@ export async function prepareTurnFilesystem(opts: {
   /** Extra hydrate excludes (on top of the defaults), e.g. the runtime tree
    *  for an op that never reads conversations. */
   excludes?: string[];
+  /** Per-object hot-set admission on top of the excludes. */
+  filter?: (rel: string) => boolean;
+  /**
+   * Download nothing up front: list the store, lay out the agent's
+   * directory skeleton, and serve reads through a store-backed vfs that
+   * materializes one object on first touch. Needs a store with a manifest
+   * (a legacy list-only store hydrates eagerly). Only for handlers that
+   * read through the vfs port; a turn's tools read the real filesystem.
+   */
+  lazy?: boolean;
 }): Promise<TurnFilesystem> {
   const storeRoot = join(opts.root, "store");
   await mkdir(storeRoot, { recursive: true });
+  const excludes = opts.excludes
+    ? [...DEFAULT_EXCLUDES, ...opts.excludes]
+    : DEFAULT_EXCLUDES;
+  if (opts.lazy && opts.store.manifest) {
+    const objects = await opts.store.manifest(opts.prefix);
+    const manifest: HydrateManifest = new Map();
+    const vfs = new LazyStoreVfs({
+      store: opts.store,
+      prefix: opts.prefix,
+      root: storeRoot,
+      objects,
+      manifest,
+      excludes,
+      maxObjectBytes: MAX_UPLOAD_BYTES,
+    });
+    await layoutSkeleton(
+      storeRoot,
+      objects.map(({ key }) =>
+        opts.prefix ? key.slice(opts.prefix.length + 1) : key,
+      ),
+    );
+    return {
+      ...(await resolveTurnLayout(storeRoot, { allowEmpty: !opts.claimed })),
+      storeRoot,
+      manifest,
+      vfs,
+      listedObjects: objects.length,
+    };
+  }
   const maxBytes =
     opts.maxBytes ?? (opts.claimed ? TURN_HYDRATE_MAX_BYTES : undefined);
   let manifest: HydrateManifest;
   try {
     manifest = await hydrate(opts.store, opts.prefix, storeRoot, {
       ...(maxBytes !== undefined ? { maxBytes } : {}),
-      ...(opts.excludes
-        ? { excludes: [...DEFAULT_EXCLUDES, ...opts.excludes] }
-        : {}),
+      excludes,
+      ...(opts.filter ? { filter: opts.filter } : {}),
     });
   } catch (error) {
     if (!(error instanceof HydrateLimitError)) throw error;
@@ -60,7 +108,29 @@ export async function prepareTurnFilesystem(opts: {
     ...(await resolveTurnLayout(storeRoot, { allowEmpty: !opts.claimed })),
     storeRoot,
     manifest,
+    vfs: new FsVfs(storeRoot),
+    listedObjects: manifest.size,
   };
+}
+
+/**
+ * The directories the layout resolver and the host's agent lookup key on,
+ * without a single download: `workspaces/<ws>/<agent>` for the standing
+ * layout, `data` / `workspace` for the per-turn one. Deeper directories
+ * appear as objects materialize.
+ */
+async function layoutSkeleton(storeRoot: string, rels: string[]) {
+  const dirs = new Set<string>();
+  for (const rel of rels) {
+    const segments = rel.split("/");
+    const depth = segments[0] === "workspaces" ? 3 : 1;
+    if (segments.length > depth) dirs.add(segments.slice(0, depth).join("/"));
+  }
+  await Promise.all(
+    [...dirs].map((dir) =>
+      mkdir(join(storeRoot, ...dir.split("/")), { recursive: true }),
+    ),
+  );
 }
 
 /** Build the exact conversation, session, and activity-doc write scope. */

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -32,6 +32,9 @@ export interface TurnFilesystem extends TurnLayout {
   vfs: Vfs;
   /** Remote objects the lazy listing knows about (diagnostics). */
   listedObjects: number;
+  /** The store's generation capability as the listing showed it; undefined
+   *  when the hydrated manifest itself carries the answer (eager trees). */
+  generationAware?: boolean;
 }
 
 /**
@@ -65,6 +68,8 @@ export async function prepareTurnFilesystem(opts: {
   const excludes = opts.excludes
     ? [...DEFAULT_EXCLUDES, ...opts.excludes]
     : DEFAULT_EXCLUDES;
+  const maxBytes =
+    opts.maxBytes ?? (opts.claimed ? TURN_HYDRATE_MAX_BYTES : undefined);
   if (opts.lazy && opts.store.manifest) {
     const objects = await opts.store.manifest(opts.prefix);
     const manifest: HydrateManifest = new Map();
@@ -76,6 +81,7 @@ export async function prepareTurnFilesystem(opts: {
       manifest,
       excludes,
       maxObjectBytes: MAX_UPLOAD_BYTES,
+      maxBytes: maxBytes ?? TURN_HYDRATE_MAX_BYTES,
     });
     await layoutSkeleton(
       storeRoot,
@@ -89,17 +95,24 @@ export async function prepareTurnFilesystem(opts: {
       manifest,
       vfs,
       listedObjects: objects.length,
+      generationAware: vfs.generationAware,
     };
   }
-  const maxBytes =
-    opts.maxBytes ?? (opts.claimed ? TURN_HYDRATE_MAX_BYTES : undefined);
   let manifest: HydrateManifest;
+  let listed: string[] = [];
   try {
     manifest = await hydrate(opts.store, opts.prefix, storeRoot, {
       ...(maxBytes !== undefined ? { maxBytes } : {}),
       excludes,
       ...(opts.filter ? { filter: opts.filter } : {}),
+      onListed: (rels) => {
+        listed = rels;
+      },
     });
+    // The layout must resolve from what the STORE holds, not from what the
+    // filter admitted: a turn whose agent has nothing but other
+    // conversations' history still targets an existing agent.
+    await layoutSkeleton(storeRoot, listed);
   } catch (error) {
     if (!(error instanceof HydrateLimitError)) throw error;
     throw new TurnSetupError("hydrate_over_cap", error.message);

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -12,6 +12,7 @@ import {
   syncBack,
 } from "@houston/runtime-client/object-sync";
 import {
+  layoutSkeleton,
   resolveTurnLayout,
   type TurnLayout,
   TurnSetupError,
@@ -32,9 +33,9 @@ export interface TurnFilesystem extends TurnLayout {
   vfs: Vfs;
   /** Remote objects the lazy listing knows about (diagnostics). */
   listedObjects: number;
-  /** The store's generation capability as the listing showed it; undefined
-   *  when the hydrated manifest itself carries the answer (eager trees). */
-  generationAware?: boolean;
+  /** The store's generation capability as the LISTING showed it. A filtered
+   *  or lazy manifest may be empty and cannot answer this on its own. */
+  generationAware: boolean;
 }
 
 /**
@@ -83,12 +84,7 @@ export async function prepareTurnFilesystem(opts: {
       maxObjectBytes: MAX_UPLOAD_BYTES,
       maxBytes: maxBytes ?? TURN_HYDRATE_MAX_BYTES,
     });
-    await layoutSkeleton(
-      storeRoot,
-      objects.map(({ key }) =>
-        opts.prefix ? key.slice(opts.prefix.length + 1) : key,
-      ),
-    );
+    await layoutSkeleton(storeRoot, vfs.remoteKeys);
     return {
       ...(await resolveTurnLayout(storeRoot, { allowEmpty: !opts.claimed })),
       storeRoot,
@@ -99,20 +95,20 @@ export async function prepareTurnFilesystem(opts: {
     };
   }
   let manifest: HydrateManifest;
-  let listed: string[] = [];
+  let listed = { rels: [] as string[], generationAware: false };
   try {
     manifest = await hydrate(opts.store, opts.prefix, storeRoot, {
       ...(maxBytes !== undefined ? { maxBytes } : {}),
       excludes,
       ...(opts.filter ? { filter: opts.filter } : {}),
-      onListed: (rels) => {
-        listed = rels;
+      onListed: (listing) => {
+        listed = listing;
       },
     });
     // The layout must resolve from what the STORE holds, not from what the
     // filter admitted: a turn whose agent has nothing but other
     // conversations' history still targets an existing agent.
-    await layoutSkeleton(storeRoot, listed);
+    await layoutSkeleton(storeRoot, listed.rels);
   } catch (error) {
     if (!(error instanceof HydrateLimitError)) throw error;
     throw new TurnSetupError("hydrate_over_cap", error.message);
@@ -122,28 +118,9 @@ export async function prepareTurnFilesystem(opts: {
     storeRoot,
     manifest,
     vfs: new FsVfs(storeRoot),
-    listedObjects: manifest.size,
+    listedObjects: listed.rels.length,
+    generationAware: listed.generationAware,
   };
-}
-
-/**
- * The directories the layout resolver and the host's agent lookup key on,
- * without a single download: `workspaces/<ws>/<agent>` for the standing
- * layout, `data` / `workspace` for the per-turn one. Deeper directories
- * appear as objects materialize.
- */
-async function layoutSkeleton(storeRoot: string, rels: string[]) {
-  const dirs = new Set<string>();
-  for (const rel of rels) {
-    const segments = rel.split("/");
-    const depth = segments[0] === "workspaces" ? 3 : 1;
-    if (segments.length > depth) dirs.add(segments.slice(0, depth).join("/"));
-  }
-  await Promise.all(
-    [...dirs].map((dir) =>
-      mkdir(join(storeRoot, ...dir.split("/")), { recursive: true }),
-    ),
-  );
 }
 
 /** Build the exact conversation, session, and activity-doc write scope. */
@@ -188,15 +165,18 @@ export async function syncTurnFilesystem(opts: {
     opts.prefix,
     opts.filesystem.storeRoot,
     opts.filesystem.manifest,
-    opts.claimed
-      ? {
-          include: claimedTurnIncludes(
-            opts.filesystem.dataRel,
-            opts.filesystem.workspaceRel,
-            opts.conversationId,
-          ),
-        }
-      : {},
+    {
+      generations: opts.filesystem.generationAware,
+      ...(opts.claimed
+        ? {
+            include: claimedTurnIncludes(
+              opts.filesystem.dataRel,
+              opts.filesystem.workspaceRel,
+              opts.conversationId,
+            ),
+          }
+        : {}),
+    },
   );
   if (result.outOfScope > 0) {
     // Attributed: on a shared worker an unattributed count is unactionable.

--- a/packages/runtime/src/turn/turn-hot-set.test.ts
+++ b/packages/runtime/src/turn/turn-hot-set.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "vitest";
+import { ownConversationOnly } from "./turn-hot-set";
+
+const standing = "workspaces/Personal/Bob/.houston/runtime";
+
+test("admits the turn's own conversation file and session dir, nothing of the others", () => {
+  const admit = ownConversationOnly("c1");
+  expect(admit(`${standing}/conversations/c1.json`)).toBe(true);
+  expect(admit(`${standing}/sessions/c1/session.jsonl`)).toBe(true);
+  expect(admit(`${standing}/sessions/c1/deep/x`)).toBe(true);
+  expect(admit(`${standing}/conversations/c2.json`)).toBe(false);
+  expect(admit(`${standing}/sessions/c2/session.jsonl`)).toBe(false);
+  // A conversation id that needs encoding matches its encoded file name.
+  expect(
+    ownConversationOnly("a b")(`${standing}/conversations/a%20b.json`),
+  ).toBe(true);
+});
+
+test("everything outside conversations/sessions is admitted, in both layouts", () => {
+  const admit = ownConversationOnly("c1");
+  expect(admit("workspaces/Personal/Bob/CLAUDE.md")).toBe(true);
+  expect(admit(`${standing}/settings.json`)).toBe(true);
+  expect(admit("workspaces/Personal/Bob/.houston/routines/routines.json")).toBe(
+    true,
+  );
+  expect(admit("workspaces/Personal/Bob/files/report.csv")).toBe(true);
+  expect(admit("data/settings.json")).toBe(true);
+  expect(admit("data/conversations/c1.json")).toBe(true);
+  expect(admit("data/conversations/c2.json")).toBe(false);
+  expect(admit("data/sessions/c2/s.jsonl")).toBe(false);
+  expect(admit("workspace/notes.md")).toBe(true);
+});
+
+test("a user project's own conversations folder is never mistaken for the runtime", () => {
+  const admit = ownConversationOnly("c1");
+  expect(admit("workspaces/Personal/Bob/files/conversations/c2.json")).toBe(
+    true,
+  );
+  expect(
+    admit(
+      "workspaces/Personal/Bob/proj/.houston/runtime/conversations/c2.json",
+    ),
+  ).toBe(true);
+});

--- a/packages/runtime/src/turn/turn-hot-set.ts
+++ b/packages/runtime/src/turn/turn-hot-set.ts
@@ -1,0 +1,34 @@
+/**
+ * Hot-set admission for one conversation: every runtime conversation file
+ * and session dir that is NOT this conversation's is left out. A turn reads
+ * only its own history (`conversations/<id>.json`, `sessions/<id>/`), so
+ * other conversations (the bulk of a busy agent) never need to hydrate.
+ * Matches both layouts: `workspaces/<ws>/<agent>/.houston/runtime/…` and
+ * the per-turn `data/…`.
+ */
+export function ownConversationOnly(
+  conversationId: string,
+): (rel: string) => boolean {
+  const file = `${encodeURIComponent(conversationId)}.json`;
+  return (rel) => {
+    const segments = rel.split("/");
+    const runtimeAt =
+      segments[0] === "data"
+        ? 1
+        : segments[0] === "workspaces" &&
+            segments[3] === ".houston" &&
+            segments[4] === "runtime"
+          ? 5
+          : -1;
+    if (runtimeAt === -1) return true;
+    const kind = segments[runtimeAt];
+    const own = segments[runtimeAt + 1];
+    if (kind === "conversations" && segments.length === runtimeAt + 2) {
+      return own === file;
+    }
+    if (kind === "sessions" && segments.length > runtimeAt + 1) {
+      return own === conversationId;
+    }
+    return true;
+  };
+}

--- a/packages/runtime/src/turn/turn-layout.ts
+++ b/packages/runtime/src/turn/turn-layout.ts
@@ -119,3 +119,23 @@ export async function resolveTurnLayout(
       : "hydrated store does not contain a recognized agent layout",
   );
 }
+
+/**
+ * The directories the layout resolver and the host's agent lookup key on,
+ * without a single download: `workspaces/<ws>/<agent>` for the standing
+ * layout, `data` / `workspace` for the per-turn one. Deeper directories
+ * appear as objects materialize.
+ */
+export async function layoutSkeleton(storeRoot: string, rels: string[]) {
+  const dirs = new Set<string>();
+  for (const rel of rels) {
+    const segments = rel.split("/");
+    const depth = segments[0] === "workspaces" ? 3 : 1;
+    if (segments.length > depth) dirs.add(segments.slice(0, depth).join("/"));
+  }
+  await Promise.all(
+    [...dirs].map((dir) =>
+      mkdir(join(storeRoot, ...dir.split("/")), { recursive: true }),
+    ),
+  );
+}


### PR DESCRIPTION
## Problem

A pool worker hydrated the agent's **whole** object-store prefix for every op and every turn (route ops skipped only `.houston/runtime`). A Files-tab listing downloaded every user file just to `readdir`; reads on agents over the 2 GiB pool cap answered 503; a turn paid for every other conversation's history before the model started.

## Change

**Lazy VFS for route + conversation ops** (`LazyStoreVfs`, `packages/host/src/vfs/lazy-store.ts`): the host's own handlers run unchanged over a `Vfs` whose listing/stat come from the store manifest and that downloads an object the first time a handler reads it, into a local overlay. Writes and deletes land in the overlay and ride the existing `syncBack`. Ownership is exact: the hydrate manifest holds only materialized objects (real hash + generation) and keys the op wrote or deleted without reading (`UNREAD_HASH` entries carrying the store generation as the CAS guard), so objects the op never touched are neither re-uploaded nor deleted.

- `GET files` → 0 downloads, sizes/mtimes from the manifest.
- `files/download`, `files/read`, `agentfile/*` → exactly that object.
- `DELETE files`, `files/move`, folder delete → tombstones, no download (a move fetches its source only).
- conversation rename/delete → one file; session files tombstoned.
- Per-object read cap (`MAX_UPLOAD_BYTES`) refused **before** any byte is downloaded; same 503 body as the relay cap.
- `dispatchAgentOp` takes an injected `vfs`; `republish` reads family docs through it (an event for a family file the op never materialized no longer projects an empty doc).

**Hot-set for pool turns**: a claimed turn hydrates its own `conversations/<id>.json` + `sessions/<id>/` only (`ownConversationOnly`); other conversations' history is filtered out. Everything else (instructions, skills, docs, user files) still hydrates, since pi's tools read the real filesystem.

Also: `hydrate()` gains a `filter` option; `LocalDirStore.manifest()` so the lazy path runs in tests; the relay half of `dispatch.ts` moved to `dispatch-relay.ts`.

## Not in this PR (tracked on the issue)

- Lazy VFS for **turns** (on-demand fetch on first tool open) needs a FUSE/tool-level seam; turns still hydrate user files.
- Streaming relay for downloads (the base64 envelope + gateway relay cap) is a gateway change.
- p50/p95 claim→first-token re-measure on staging after deploy.

## Prod safety

Inert where the pool flags are 0: nothing here runs outside `POST /op` / claimed turns on a pool worker. Unclaimed (legacy) turns keep the full hydrate.

## Verification

Before (main): seed an agent with many user files, post a `GET files` op against a download-counting store → every file is downloaded. `packages/runtime/src/turn/server-op-lazy.test.ts` encodes the after-state:

```
pnpm --filter @houston/host --filter @houston/runtime --filter @houston/runtime-client test
```

- `a Files listing downloads ZERO objects and still reports every file with its size`
- `a file download fetches exactly that object`
- `deleting an unread file removes it from the store without downloading anything`
- `a conversation rename hydrates its own conversation only` / `delete removes its file and unread session files, nothing else`
- `packages/host/src/vfs/lazy-store.test.ts`: the Vfs contract over the lazy adapter + sync-back round trips (untouched objects survive; delete-then-recreate uploads).

Staging (after deploy): pick an agent with `replicas=0` and many files; `GET /agents/<slug>/files`, `GET /agents/<slug>/files/download?path=...`, `DELETE /agents/<slug>/files?path=...`; assert `replicas` stays 0, the gateway log shows `agent op ran on pool worker`, zero `ensuring awake` for the slug, and op latency no longer scales with agent size.
## Review pass (two independent adversarial reviews, two rounds)

Folded in:
- a refused lazy read or any 5xx from a tree-mutating handler (route/conversation) declines **before** sync-back, so a half-done multi-key mutation (folder move hitting the read cap) never reaches the store; credential/settings/title ops keep their own status
- sync-back receives the store's generation capability from the listing (lazy ops and filtered eager turns), so a pure create on an empty manifest stays create-only CAS
- `LazyStoreVfs` keeps a real tree's file/directory exclusivity against remote keys, moves remote-only folders by descendant, rejects nested/self moves like rename(2), preflights local + remote destination contents, re-checks the size that landed, holds an aggregate budget, and removes the destination on any fetch failure
- conversation delete needs no download (existence from the listing); an over-cap rename declines to the pod
- `republish` treats a thrown doc read as a diagnostic, never an empty projection
- the eager turn path lays out the agent skeleton from the store's listing, so a filtered hydrate with zero admitted objects still resolves the layout
- pre-existing ordering bug in the same block: a sync-back whose only change is a file the store refuses now answers the authored 413 instead of declining

Dismissed: remote-only entries carry no `date_created` in the Files tab (cosmetic; the manifest has no birthtime); `HttpObjectStore` scratch `.tmp` visible to a concurrent listing (sync-back excludes `.tmp`; no handler lists during its own download).

Linear: PRODUCT-1470