### PR TITLE
feat(routines): resolved provider/model + connection health before a routine fires (PRODUCT-1475)

### DIFF
--- a/app/src/components/agent/routine-model-row.tsx
+++ b/app/src/components/agent/routine-model-row.tsx
@@ -14,6 +14,7 @@ import type { Routine } from "@houston-ai/engine-client";
 import { useTranslation } from "react-i18next";
 import { useRoutineModelResolution } from "../../hooks/use-routine-model-resolution";
 import { useRoutineProviderHealth } from "../../hooks/use-routine-provider-health";
+import { providerName } from "../../lib/providers";
 import type { Agent } from "../../lib/types";
 import { RoutineModelSelector } from "./routine-model-selector";
 import { RoutineProviderHealthBadge } from "./routine-provider-health-badge";
@@ -47,7 +48,11 @@ export function RoutineModelRow({
       )}
       {runsAsCreator && (
         <p className="text-xs text-ink-muted">
-          {t("details.health.runsAsCreator")}
+          {provider
+            ? t("details.health.runsAsCreatorProvider", {
+                provider: providerName(provider),
+              })
+            : t("details.health.runsAsCreator")}
         </p>
       )}
     </div>

--- a/app/src/components/agent/routine-model-row.tsx
+++ b/app/src/components/agent/routine-model-row.tsx
@@ -1,0 +1,55 @@
+/**
+ * The routine screen's Model section body (PRODUCT-1475): the resolved
+ * provider + model as a picker, whether that account actually works, and — when
+ * the routine carries no pin — the quiet line saying it follows the agent.
+ *
+ * The health claim is scoped: `/providers` answers for the VIEWER's credential
+ * scope while a fired routine runs on its CREATOR's, so a teammate's routine
+ * gets a plain sentence about whose account runs it instead of a badge derived
+ * from the wrong one. Saving and enabling stay allowed either way — this row
+ * informs, it never blocks.
+ */
+
+import type { Routine } from "@houston-ai/engine-client";
+import { useTranslation } from "react-i18next";
+import { useRoutineModelResolution } from "../../hooks/use-routine-model-resolution";
+import { useRoutineProviderHealth } from "../../hooks/use-routine-provider-health";
+import type { Agent } from "../../lib/types";
+import { RoutineModelSelector } from "./routine-model-selector";
+import { RoutineProviderHealthBadge } from "./routine-provider-health-badge";
+
+export function RoutineModelRow({
+  agent,
+  routine,
+}: {
+  agent: Agent;
+  routine: Routine;
+}) {
+  const { t } = useTranslation("routines");
+  const { provider, followsAgent } = useRoutineModelResolution(agent, routine);
+  const { showBadge, health, runsAsCreator } = useRoutineProviderHealth(
+    routine.created_by,
+    provider,
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-3">
+        <RoutineModelSelector agent={agent} routine={routine} bordered />
+        {showBadge && (
+          <RoutineProviderHealthBadge health={health} provider={provider} />
+        )}
+      </div>
+      {followsAgent && (
+        <p className="text-xs text-ink-muted">
+          {t("details.model.followsAgent")}
+        </p>
+      )}
+      {runsAsCreator && (
+        <p className="text-xs text-ink-muted">
+          {t("details.health.runsAsCreator")}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/agent/routine-model-selector.tsx
+++ b/app/src/components/agent/routine-model-selector.tsx
@@ -1,23 +1,23 @@
 /**
- * RoutineModelSelector — the routine chat header's model pin (PRODUCT-1208).
- * A routine already carries `provider`/`model` overrides that the fire path
- * honors (`routinePin`); this is the surface that finally lets the user set
- * them. Unpinned shows "Agent's model" (the routine inherits whatever the
- * agent runs on); picking a row pins it, and the picker's footer offers the
- * way back to inherit. Reuses `ChatModelSelector` wholesale, so Teams gating
+ * RoutineModelSelector — the routine screen's model row (PRODUCT-1208, made
+ * honest in PRODUCT-1475).
+ *
+ * It always names the RESOLVED pair — provider + model, e.g. "Claude · Opus 5"
+ * — because "Agent's model" told the user nothing about which AI account was
+ * about to run (and be billed for) the routine. An unpinned routine resolves
+ * through the agent (`useRoutineModelResolution`) and adds a quiet line saying
+ * it follows the agent; picking a row pins it, and the picker's footer offers
+ * the way back. Reuses `ChatModelSelector` wholesale, so Teams gating
  * (visibility + the allowed-models ceiling) stays one implementation.
  */
 
 import type { Routine, RoutineUpdate } from "@houston-ai/engine-client";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  useAgentModelChoice,
-  useRoutineWritesForAnyAgent,
-} from "../../hooks/queries";
-import { useCapabilities } from "../../hooks/use-capabilities";
+import { useRoutineWritesForAnyAgent } from "../../hooks/queries";
+import { useRoutineModelResolution } from "../../hooks/use-routine-model-resolution";
 import { genericErrorDescription } from "../../lib/error-report";
-import { modelSelectorDecision } from "../../lib/model-selector-lock";
+import { providerModelLabel } from "../../lib/model-labels";
 import type { Agent } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 import { ChatModelSelector } from "../chat-model-selector";
@@ -35,16 +35,9 @@ export function RoutineModelSelector({ agent, routine, bordered }: Props) {
   const addToast = useUIStore((s) => s.addToast);
   const [open, setOpen] = useState(false);
   const { update: updateRoutine } = useRoutineWritesForAnyAgent();
+  const { provider, model, followsAgent, allowedModels } =
+    useRoutineModelResolution(agent, routine);
 
-  // Teams E8: the pickable set is clamped to the agent's allowed-models
-  // ceiling, exactly like the composer's picker (ChatModelSelector applies the
-  // clamp; this only fetches the ceiling when the deployment has one).
-  const { capabilities } = useCapabilities();
-  const { personal } = modelSelectorDecision(capabilities, agent);
-  const { data: choiceInfo } = useAgentModelChoice(agent.id, personal);
-  const allowedModels = personal ? (choiceInfo?.allowedModels ?? null) : null;
-
-  const pinned = !!routine.provider && !!routine.model;
   const save = (updates: RoutineUpdate) =>
     updateRoutine.mutate(
       { agentPath: agent.folderPath, routineId: routine.id, updates },
@@ -69,29 +62,35 @@ export function RoutineModelSelector({ agent, routine, bordered }: Props) {
       }
     >
       <ChatModelSelector
-        provider={routine.provider ?? ""}
-        model={routine.model ?? ""}
-        onSelect={(provider, model) => save({ provider, model })}
+        provider={provider}
+        model={model}
+        onSelect={(nextProvider, nextModel) =>
+          save({ provider: nextProvider, model: nextModel })
+        }
         open={open}
         onOpenChange={setOpen}
         agent={agent}
         allowedModels={allowedModels}
         coloredGlyph
-        triggerLabel={pinned ? undefined : t("details.model.inherit")}
+        // Both states name the pair; only the hint below differs. `undefined`
+        // when nothing resolved yet, so the picker's own "Select model" shows
+        // rather than a half-built label.
+        triggerLabel={providerModelLabel(provider, model) ?? undefined}
         pickerFooter={
-          pinned ? (
+          followsAgent ? undefined : (
             <button
               type="button"
               className="w-full rounded-md px-1 py-1 text-left text-xs text-ink-muted hover:bg-hover hover:text-ink transition-colors"
               onClick={() => {
-                // `null` clears the pin back to inherit (RoutineUpdate contract).
+                // `null` clears the pin so the routine follows the agent again
+                // (RoutineUpdate contract).
                 save({ provider: null, model: null, effort: null });
                 setOpen(false);
               }}
             >
               {t("details.model.reset")}
             </button>
-          ) : undefined
+          )
         }
       />
     </span>

--- a/app/src/components/agent/routine-provider-health-badge.tsx
+++ b/app/src/components/agent/routine-provider-health-badge.tsx
@@ -1,0 +1,99 @@
+/**
+ * RoutineProviderHealthBadge — whether the AI account a routine runs on is
+ * usable, shown beside the model it runs on (PRODUCT-1475).
+ *
+ * Same sober treatment as a trigger routine's status
+ * (`ui/routines` TriggerStatusBadge): a semantic status dot + a colored label,
+ * never a tinted card. Always visible, never hover-gated, and the label — not
+ * the color — carries the meaning.
+ *
+ * `compact` is the list-row chip: dot + label only, no remedy. A row is a
+ * warning surface, not a place to connect an account; the routine's own screen
+ * is where the Connect action lives.
+ */
+
+import { Button, cn } from "@houston-ai/core";
+import { useTranslation } from "react-i18next";
+import { useProviderConnectLaunch } from "../../hooks/use-provider-connect-launch";
+import { providerName } from "../../lib/providers";
+import {
+  type RoutineProviderHealth,
+  routineHealthOffersConnect,
+} from "../../lib/routine-provider-health";
+
+const TONE: Record<RoutineProviderHealth, string> = {
+  connected: "text-success",
+  not_connected: "text-danger",
+  needs_reconnect: "text-warning",
+  out_of_credits: "text-warning",
+  checking: "text-ink-muted",
+};
+
+const DOT: Record<RoutineProviderHealth, string> = {
+  connected: "bg-success",
+  not_connected: "bg-danger",
+  needs_reconnect: "bg-warning",
+  out_of_credits: "bg-warning",
+  // A hollow, pulsing ring — visibly "checking", never a healthy fill.
+  checking: "border border-ink-muted animate-pulse",
+};
+
+export function RoutineProviderHealthBadge({
+  health,
+  provider,
+  compact = false,
+  className,
+}: {
+  health: RoutineProviderHealth;
+  /** The RESOLVED provider id this routine runs on. */
+  provider: string;
+  /** List-row chip: no Connect action, tighter label. */
+  compact?: boolean;
+  className?: string;
+}) {
+  const { t } = useTranslation("routines");
+  const connect = useProviderConnectLaunch(provider);
+  const name = providerName(provider);
+  const showConnect = !compact && routineHealthOffersConnect(health);
+  // Spelled out rather than built from the state id: `t()` keys are typed, and
+  // a template-literal key would compile past a typo the validator can't see.
+  const label = {
+    connected: t("details.health.connected"),
+    not_connected: t("details.health.notConnected"),
+    needs_reconnect: t("details.health.needsReconnect"),
+    out_of_credits: t("details.health.outOfCredits"),
+    checking: t("details.health.checking"),
+  }[health];
+
+  return (
+    <span className={cn("inline-flex items-center gap-2", className)}>
+      <span
+        className={cn(
+          "inline-flex items-center gap-1.5 text-xs font-medium",
+          TONE[health],
+        )}
+      >
+        <span
+          aria-hidden
+          className={cn("size-1.5 shrink-0 rounded-full", DOT[health])}
+        />
+        {label}
+      </span>
+      {showConnect && (
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={connect.launching}
+          onClick={(e) => {
+            // The badge can ride a clickable row; connecting is not "open it".
+            e.stopPropagation();
+            connect.connect();
+          }}
+        >
+          {t("details.health.connect", { provider: name })}
+        </Button>
+      )}
+      {!compact && connect.dialog}
+    </span>
+  );
+}

--- a/app/src/components/agent/routine-runs-dialog.tsx
+++ b/app/src/components/agent/routine-runs-dialog.tsx
@@ -3,6 +3,11 @@
  * (PRODUCT-1208), n8n-style: every recorded run with its outcome, date, time,
  * elapsed time, and (when the run wasn't silent) the result it left behind.
  * Clicking an entry closes the modal and opens that run's chat.
+ *
+ * A run that never reached the agent has no result to show: its AI account was
+ * disconnected, needed reconnecting, or was out of credits (PRODUCT-1475). The
+ * engine reports that as a typed `failure`, and `summaryFor` turns it into a
+ * sentence naming the provider — so "Failed" stops being the whole story.
  */
 
 import {
@@ -18,6 +23,7 @@ import {
 } from "@houston-ai/routines";
 import { Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { providerName } from "../../lib/providers";
 
 interface Props {
   open: boolean;
@@ -39,6 +45,27 @@ export function RoutineRunsDialog({
   onOpenRun,
 }: Props) {
   const { t } = useTranslation("routines");
+
+  // Spelled out per code rather than built from it: `t()` keys are typed, so a
+  // template-literal key would compile past a typo the locale validator can't
+  // see. `undefined` keeps the run's own summary.
+  const failureSummary = (run: RoutineRun): string | undefined => {
+    if (!run.failure) return undefined;
+    const provider = providerName(run.failure.provider);
+    switch (run.failure.code) {
+      case "creator_not_connected":
+        return t("details.failure.creatorNotConnected", { provider });
+      case "team_not_connected":
+        return t("details.failure.teamNotConnected", { provider });
+      case "creator_needs_reconnect":
+        return t("details.failure.creatorNeedsReconnect", { provider });
+      case "team_needs_reconnect":
+        return t("details.failure.teamNeedsReconnect", { provider });
+      case "out_of_credits":
+        return t("details.failure.outOfCredits", { provider });
+    }
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg">
@@ -56,6 +83,7 @@ export function RoutineRunsDialog({
               runs={runs ?? []}
               onOpenRun={onOpenRun}
               locale={locale}
+              summaryFor={failureSummary}
               labels={{
                 empty: t("details.runsEmpty"),
                 openRun: t("details.openRun"),

--- a/app/src/components/agent/routine-screen-sections.tsx
+++ b/app/src/components/agent/routine-screen-sections.tsx
@@ -17,7 +17,7 @@ import { type ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useRoutineLabels } from "../../hooks/use-routine-labels";
 import type { Agent } from "../../lib/types";
-import { RoutineModelSelector } from "./routine-model-selector";
+import { RoutineModelRow } from "./routine-model-row";
 
 interface Props {
   agent: Agent;
@@ -134,7 +134,7 @@ export function RoutineScreenSections({
 
       <Section title={t("details.modelTitle")}>
         <div className="self-start">
-          <RoutineModelSelector agent={agent} routine={routine} bordered />
+          <RoutineModelRow agent={agent} routine={routine} />
         </div>
       </Section>
     </div>

--- a/app/src/components/agent/routine-warning-chip.tsx
+++ b/app/src/components/agent/routine-warning-chip.tsx
@@ -1,0 +1,39 @@
+/**
+ * The compact "this one will fail" chip a routine row carries (PRODUCT-1475).
+ *
+ * A routine list is where a person notices a broken automation, so the warning
+ * has to live on the ROW, not only inside the routine's screen. It renders only
+ * for a routine whose resolved provider is confirmed unusable AND whose creator
+ * is the viewer — the viewer's `/providers` answer says nothing about anyone
+ * else's account (see `useRoutineProviderHealth`). Healthy and still-checking
+ * rows render nothing: a list of chips saying "fine" is noise.
+ *
+ * A component rather than a plain function because it resolves the pair and
+ * probes the provider through hooks; the grid's slot takes the rendered node.
+ */
+
+import type { Routine } from "@houston-ai/engine-client";
+import { useRoutineModelResolution } from "../../hooks/use-routine-model-resolution";
+import { useRoutineProviderHealth } from "../../hooks/use-routine-provider-health";
+import { routineHealthBlocksRun } from "../../lib/routine-provider-health";
+import type { Agent } from "../../lib/types";
+import { RoutineProviderHealthBadge } from "./routine-provider-health-badge";
+
+export function RoutineWarningChip({
+  agent,
+  routine,
+}: {
+  /** The routine's OWNING agent — a cross-agent list has one per row. */
+  agent: Agent;
+  routine: Routine;
+}) {
+  const { provider } = useRoutineModelResolution(agent, routine);
+  const { showBadge, health } = useRoutineProviderHealth(
+    routine.created_by,
+    provider,
+  );
+  if (!showBadge || !routineHealthBlocksRun(health)) return null;
+  return (
+    <RoutineProviderHealthBadge health={health} provider={provider} compact />
+  );
+}

--- a/app/src/components/chat-model-selector-trigger.tsx
+++ b/app/src/components/chat-model-selector-trigger.tsx
@@ -2,8 +2,8 @@
  * The model selector trigger's provider glyph, shared by the interactive and
  * read-only variants. `colored` renders the provider's full-color brand mark
  * (the routine screen's Model field asked for it); default keeps the chat
- * composer's quiet monochrome glyph. Null when no provider is selected (the
- * routine pin's "Agent's model" state shows label only).
+ * composer's quiet monochrome glyph. Null when no provider is selected — the
+ * label then stands alone.
  */
 
 import { BrandMark } from "./provider-browser/brand-mark";

--- a/app/src/components/chat-model-selector.tsx
+++ b/app/src/components/chat-model-selector.tsx
@@ -54,9 +54,10 @@ interface ChatModelSelectorProps {
    */
   allowedModels?: string[] | null;
   /**
-   * Overrides the trigger's model label — the routines header shows "Agent's
-   * model" while the routine carries no pin (PRODUCT-1208). Omit for the
-   * picker's own display label. An empty `provider` also drops the glyph.
+   * Overrides the trigger's model label — the routine screen names the resolved
+   * pair ("Claude · Opus 5") rather than the model alone, since a routine fires
+   * unattended and the AI ACCOUNT is half of what runs it (PRODUCT-1475). Omit
+   * for the picker's own display label. An empty `provider` drops the glyph.
    */
   triggerLabel?: string;
   /** Extra footer row inside the picker popover (the routine pin's "Use the

--- a/app/src/components/team-view/team-routines/team-routines-grid.tsx
+++ b/app/src/components/team-view/team-routines/team-routines-grid.tsx
@@ -3,6 +3,7 @@ import { RoutinesGrid } from "@houston-ai/routines";
 import type { ReactNode } from "react";
 import { useRoutineLabels } from "../../../hooks/use-routine-labels";
 import { allAgentReadsFailed } from "../../../lib/agent-read-failures";
+import { RoutineWarningChip } from "../../agent/routine-warning-chip";
 import { TeamRoutineOwnerChip } from "./team-routine-owner-chip";
 import { useTeamGridLabels } from "./use-team-grid-labels";
 import type { useTeamRoutineActions } from "./use-team-routine-actions";
@@ -59,6 +60,16 @@ export function TeamRoutinesGrid({
     return agent ? <TeamRoutineOwnerChip agent={agent} /> : null;
   };
 
+  // "This one will fail" — resolved per row against its OWN agent, since an
+  // unpinned routine runs on whatever its owner runs on and a merged list holds
+  // several owners. The chip renders itself away when the row is fine.
+  const warningChipFor = (routine: Routine) => {
+    const agent = data.list.ownerOf[routine.id];
+    return agent ? (
+      <RoutineWarningChip agent={agent} routine={routine} />
+    ) : null;
+  };
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <RoutinesGrid
@@ -88,6 +99,7 @@ export function TeamRoutinesGrid({
         triggerSummaries={data.triggers.triggerSummaries}
         onReconnectTrigger={data.triggers.onReconnectTrigger}
         ownerChip={oneOwner ? undefined : (routine) => ownerChipFor(routine.id)}
+        warningChip={warningChipFor}
         draftOwnerChip={
           oneOwner ? undefined : (draft) => ownerChipFor(draft.id)
         }

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -98,6 +98,7 @@ import {
   finalConnectNames,
   finalCredentialNames,
 } from "../lib/interaction-reply";
+import { providerForModel } from "../lib/model-labels";
 import {
   isModelAllowed,
   modelSelectorDecision,
@@ -120,7 +121,6 @@ import {
   getDefaultModel,
   getProvider,
   normalizeLegacyModel,
-  PROVIDERS,
   validEffortOrDefault,
   validModelOrNull,
 } from "../lib/providers";
@@ -235,14 +235,6 @@ interface UseAgentChatPanelArgs {
 
 /** Stable empty default, so the no-children case never re-runs the memo. */
 const EMPTY_CHILD_MISSIONS: ChatMissionListItem[] = [];
-
-function resolveCatalogProvider(model: string): string | null {
-  return (
-    PROVIDERS.find((provider) =>
-      provider.models.some((candidate) => candidate.id === model),
-    )?.id ?? null
-  );
-}
 
 interface AgentChatPanelProps {
   /** Renders skill cards + "see more" when no Skill is in flight. */
@@ -685,7 +677,7 @@ export function useAgentChatPanel({
           effort: effectiveEffort,
         },
         null,
-        resolveCatalogProvider,
+        providerForModel,
       ),
     [
       modelChoiceInfo?.choice,
@@ -717,7 +709,7 @@ export function useAgentChatPanel({
                   model: activityModel,
                 }
               : null,
-            resolveCatalogProvider,
+            providerForModel,
           )
         : {
             provider: effectiveProvider,

--- a/app/src/hooks/use-picker-view-models.tsx
+++ b/app/src/hooks/use-picker-view-models.tsx
@@ -21,10 +21,10 @@ import {
 } from "../lib/chat-model-picker-map";
 import { statusCredentialScope } from "../lib/credential-scope";
 import { newEngineActive } from "../lib/engine";
+import { modelDisplayLabel } from "../lib/model-labels";
 import { osIsTauri } from "../lib/os-bridge";
 import {
   EMPTY_PROVIDER_CAPABILITIES,
-  getModel,
   getProvider,
   getVisibleProviders,
 } from "../lib/providers";
@@ -146,15 +146,13 @@ export function usePickerViewModels(opts: {
   const catalogState: "loading" | "ready" =
     catalogReady && !capabilitiesLoading ? "ready" : "loading";
 
-  const currentModel = getModel(provider, model);
   const currentProvider = getProvider(provider);
+  // The shared label chain (`modelDisplayLabel`): catalog label, then the
+  // engine-reported configured model — a local OpenAI-compatible model isn't in
+  // the static catalog — then the raw selection. The routine screen's model row
+  // names the same pair through the same chain, so the two can't disagree.
   const displayLabel =
-    currentModel?.label ??
-    // A local OpenAI-compatible model isn't in the static catalog, so show the
-    // engine-reported configured model id (then the raw selection) rather than
-    // falling through to the provider subtitle.
-    statuses[provider]?.active_model ??
-    (model || undefined) ??
+    modelDisplayLabel(provider, model, statuses[provider]?.active_model) ??
     currentProvider?.subtitle ??
     t("modelSelector.selectModel");
 

--- a/app/src/hooks/use-provider-connect-launch.tsx
+++ b/app/src/hooks/use-provider-connect-launch.tsx
@@ -1,0 +1,71 @@
+/**
+ * "Connect <provider>" for a surface that is NOT the AI Hub — the routine
+ * screen's health badge (PRODUCT-1475).
+ *
+ * It owns no connect flow of its own: which surface a provider connects through
+ * is the same routing the in-chat auth card uses (`reconnectSurface` →
+ * `ReconnectDialog` for api-key / local providers, `launchLogin` for OAuth), so
+ * an api-key provider is never sent through a browser sign-in it would 400 on
+ * (HOU-1077). The caller renders {@link ProviderConnectLaunch.dialog}.
+ *
+ * Completion is not awaited: `launchLogin` resolves when the engine STARTS
+ * sign-in, and the real answer arrives later as `ProviderLoginComplete`, which
+ * invalidates the provider-status query the badge reads — so the badge flips
+ * itself with no listener here.
+ */
+
+import { type ReactNode, useCallback, useState } from "react";
+import { ReconnectDialog } from "../components/shell/provider-error-cards/reconnect-dialog";
+import { reconnectSurface } from "../components/shell/provider-error-cards/reconnect-surface";
+import { getProvider } from "../lib/providers";
+import { tauriProvider } from "../lib/tauri";
+
+export interface ProviderConnectLaunch {
+  /** Start the connect. Opens a dialog or launches the browser sign-in. */
+  connect: () => void;
+  /** A browser sign-in is being launched (the button spins). */
+  launching: boolean;
+  /** The api-key / local-endpoint dialog, when this provider connects that way. */
+  dialog: ReactNode;
+}
+
+export function useProviderConnectLaunch(
+  providerId: string,
+): ProviderConnectLaunch {
+  const [open, setOpen] = useState(false);
+  const [launching, setLaunching] = useState(false);
+  const surface = reconnectSurface(providerId, getProvider(providerId)?.auth);
+
+  const connect = useCallback(() => {
+    if (surface !== "oauth_login") {
+      setOpen(true);
+      return;
+    }
+    setLaunching(true);
+    void (async () => {
+      try {
+        await tauriProvider.launchLogin(providerId);
+      } catch {
+        // `launchLogin` routes through `call()`, which has already surfaced AND
+        // reported this failure exactly once. A second toast here would
+        // double-surface the same event; there is nothing left to add.
+      } finally {
+        setLaunching(false);
+      }
+    })();
+  }, [providerId, surface]);
+
+  return {
+    connect,
+    launching,
+    dialog:
+      surface === "oauth_login" ? null : (
+        <ReconnectDialog
+          surface={surface}
+          providerId={providerId}
+          open={open}
+          onClose={() => setOpen(false)}
+        />
+      ),
+  };
+}

--- a/app/src/hooks/use-routine-model-resolution.ts
+++ b/app/src/hooks/use-routine-model-resolution.ts
@@ -1,0 +1,109 @@
+/**
+ * The provider + model a routine will actually RUN ON (PRODUCT-1475).
+ *
+ * A routine is either PINNED (it carries its own provider/model, which the fire
+ * path honors verbatim) or it follows the agent — and "follows the agent" was
+ * all the editor ever said, which told the user nothing about which AI account
+ * was about to be billed or whether it even worked. So this resolves the pair
+ * either way, reusing the two derivations that already own the answer rather
+ * than inventing a third:
+ *
+ *  - `resolveAgentModelOverrides` — the agent's configured brain, the SAME
+ *    resolution every routine/skill kickoff pins its turn with; and
+ *  - `resolvePersonalModelPin` — the acting user's per-agent choice in
+ *    multiplayer Teams, mirroring the gateway's per-turn resolution.
+ *
+ * NEVER auth-switch here. `resolveAgentModelOverrides` can substitute a
+ * connected provider when handed a confirmed connection set; it is deliberately
+ * handed none, because the health badge beside this pair exists to SHOW that
+ * the resolved provider is unusable. Substituting a working one would hide the
+ * exact state this feature was built to surface.
+ */
+
+import type { Routine } from "@houston-ai/engine-client";
+import { useMemo } from "react";
+import { resolveAgentModelOverrides } from "../lib/agent-model-overrides";
+import { providerForModel } from "../lib/model-labels";
+import {
+  modelSelectorDecision,
+  resolvePersonalModelPin,
+} from "../lib/model-selector-lock";
+import type { Agent } from "../lib/types";
+import { useAgentConfig, useAgentModelChoice } from "./queries";
+import { useCapabilities } from "./use-capabilities";
+
+export interface RoutineModelResolution {
+  /** Resolved provider id; `""` while the agent config has not answered yet. */
+  provider: string;
+  /** Resolved model id; `""` alongside an unresolved provider. */
+  model: string;
+  /** The routine carries no pin — it runs on whatever the agent runs on. */
+  followsAgent: boolean;
+  /**
+   * The agent's effective allowed-models ceiling (Teams E8), or `null` for no
+   * ceiling. Returned here so the picker fetches it once, not twice.
+   */
+  allowedModels: string[] | null;
+}
+
+export function useRoutineModelResolution(
+  agent: Agent,
+  routine: Pick<Routine, "provider" | "model">,
+): RoutineModelResolution {
+  // Teams E8: the pickable set is clamped to the agent's allowed-models
+  // ceiling, and in multiplayer the agent's "current model" is the ACTING
+  // user's personal per-agent choice, not the shared config.
+  const { capabilities } = useCapabilities();
+  const { personal } = modelSelectorDecision(capabilities, agent);
+  const { data: choiceInfo } = useAgentModelChoice(agent.id, personal);
+  const allowedModels = personal ? (choiceInfo?.allowedModels ?? null) : null;
+  const { data: config } = useAgentConfig(agent.folderPath);
+
+  const pinnedProvider = routine.provider ?? "";
+  const pinnedModel = routine.model ?? "";
+  const followsAgent = !pinnedProvider || !pinnedModel;
+  const choice = personal ? choiceInfo?.choice : null;
+
+  return useMemo(() => {
+    if (!followsAgent) {
+      return {
+        provider: pinnedProvider,
+        model: pinnedModel,
+        followsAgent: false,
+        allowedModels,
+      };
+    }
+    const agentPin = resolveAgentModelOverrides(config ?? {});
+    const fallback = {
+      provider: agentPin.providerOverride ?? "",
+      model: agentPin.modelOverride ?? "",
+    };
+    // No configured provider (or the config has not landed): there is no pair
+    // to name yet. `""` is the honest answer — the label falls back to the
+    // picker's own "Select model" and the badge stays away rather than probing
+    // a provider we invented.
+    if (!fallback.provider) {
+      return { ...fallback, followsAgent: true, allowedModels };
+    }
+    const pin = resolvePersonalModelPin(
+      choice,
+      allowedModels,
+      fallback,
+      null,
+      providerForModel,
+    );
+    return {
+      provider: pin.provider,
+      model: pin.model,
+      followsAgent: true,
+      allowedModels,
+    };
+  }, [
+    followsAgent,
+    pinnedProvider,
+    pinnedModel,
+    allowedModels,
+    config,
+    choice,
+  ]);
+}

--- a/app/src/hooks/use-routine-provider-health.ts
+++ b/app/src/hooks/use-routine-provider-health.ts
@@ -1,0 +1,44 @@
+/**
+ * A routine's connection health, scoped to whose credential can answer for it
+ * (PRODUCT-1475).
+ *
+ * `/providers` describes the VIEWER's own credential scope; a fired routine
+ * runs on its CREATOR's. So the probe is only evidence about the routine when
+ * the viewer IS the creator — otherwise this reports `runsAsCreator` and the
+ * surface says so in words instead of showing a badge that answers a different
+ * question. The rules themselves are pure (`lib/routine-provider-health.ts`);
+ * this hook only supplies the probe and the signed-in identity.
+ */
+
+import {
+  type RoutineProviderHealth,
+  routineProviderHealth,
+  viewerIsRoutineCreator,
+} from "../lib/routine-provider-health";
+import { useProviderStatuses } from "./use-provider-statuses";
+import { useSession } from "./use-session";
+
+export interface RoutineHealthView {
+  /** The badge is a claim this viewer's probe supports. */
+  showBadge: boolean;
+  /** Health of the resolved provider. Meaningless unless `showBadge`. */
+  health: RoutineProviderHealth;
+  /** Someone else created it: their account runs it, not the viewer's. */
+  runsAsCreator: boolean;
+}
+
+export function useRoutineProviderHealth(
+  createdBy: string | undefined,
+  /** The RESOLVED provider id (see `useRoutineModelResolution`). */
+  provider: string,
+): RoutineHealthView {
+  const { statuses } = useProviderStatuses();
+  const { data: session } = useSession();
+  const isCreator = viewerIsRoutineCreator(createdBy, session?.uid ?? null);
+  return {
+    // Nothing resolved yet = nothing to claim; the model row is still settling.
+    showBadge: isCreator && !!provider,
+    health: routineProviderHealth(statuses[provider]),
+    runsAsCreator: !isCreator,
+  };
+}

--- a/app/src/lib/model-labels.ts
+++ b/app/src/lib/model-labels.ts
@@ -1,0 +1,57 @@
+/**
+ * How a provider/model pair is NAMED, in one place.
+ *
+ * The chat picker's trigger and the routine screen's model row show the same
+ * pair and must never disagree about what to call it, so the label chain lives
+ * here rather than inside either surface: the catalog's curated label first,
+ * then the engine-reported configured model (the OpenAI-compatible local
+ * provider has no catalog entry), then the raw id. `null` when nothing names it
+ * — each caller decides its own last-resort copy, which is translated and
+ * therefore cannot live in this i18n-free module.
+ */
+
+import { getModel, PROVIDERS, providerName } from "./providers.ts";
+
+/**
+ * The model's human label. `activeModel` is the engine's
+ * `ProviderStatus.active_model`, which is the ONLY name a local
+ * OpenAI-compatible model has.
+ */
+export function modelDisplayLabel(
+  provider: string,
+  model: string,
+  activeModel?: string,
+): string | null {
+  return getModel(provider, model)?.label ?? activeModel ?? (model || null);
+}
+
+/**
+ * Which catalogued provider offers `model`, or `null` when none does. The
+ * lookup `resolvePersonalModelPin` needs to carry a ceiling's first model onto
+ * a provider that can actually run it.
+ */
+export function providerForModel(model: string): string | null {
+  return (
+    PROVIDERS.find((provider) =>
+      provider.models.some((candidate) => candidate.id === model),
+    )?.id ?? null
+  );
+}
+
+/**
+ * The RESOLVED pair as one line — "Claude · Opus 5". Shown wherever a surface
+ * must name the account AND the model it will run on (the routine screen: a
+ * model name alone never said which AI account was about to be billed).
+ * `null` when the pair is not resolved yet.
+ */
+export function providerModelLabel(
+  provider: string,
+  model: string,
+  activeModel?: string,
+): string | null {
+  if (!provider) return null;
+  const label = modelDisplayLabel(provider, model, activeModel);
+  return label
+    ? `${providerName(provider)} · ${label}`
+    : providerName(provider);
+}

--- a/app/src/lib/routine-provider-health.ts
+++ b/app/src/lib/routine-provider-health.ts
@@ -1,0 +1,102 @@
+/**
+ * Whether the AI account a routine will RUN ON is usable — answered BEFORE any
+ * run, not after one fails (PRODUCT-1475).
+ *
+ * A routine has no composer to fail in front of: it fires unattended, so the
+ * only place its provider can be shown as broken is the screen where it is
+ * read and edited. This module is the single mapping from a probed
+ * `ProviderStatus` to what that screen renders.
+ *
+ * WHOSE credential (the scope rule). `/providers` answers for the VIEWER's own
+ * credential scope, while a fired routine runs on its CREATOR's. So the badge
+ * is a claim the viewer's probe can only support for the viewer's OWN routines
+ * — {@link viewerIsRoutineCreator} is the gate, and a routine someone else
+ * created gets a neutral "runs on the creator's account" line instead of a
+ * badge that would be answering a different question.
+ *
+ * `health` is richer than `authenticated` (a credential can be valid yet out of
+ * credits) and is absent on engines that predate it, so the fallback below
+ * reads exactly what every pre-PRODUCT-1475 surface read. `unreachable` is the
+ * probe saying "I could not confirm", which renders as the neutral `checking`
+ * — never as a healthy or a broken claim (the HOU-979 rule).
+ *
+ * Pure + DOM/i18n-free so every state is unit-tested without a renderer
+ * (`app/tests/routine-provider-health.test.ts`).
+ */
+
+import type { ProviderHealth } from "@houston-ai/engine-client";
+
+/**
+ * What the routine's connection badge shows. The wire's five `ProviderHealth`
+ * values, with `unreachable` collapsed into the neutral `checking` the rest of
+ * the app already uses for an unconfirmable probe.
+ */
+export type RoutineProviderHealth =
+  | "connected"
+  | "not_connected"
+  | "needs_reconnect"
+  | "out_of_credits"
+  | "checking";
+
+/**
+ * The minimal probe shape this derivation needs, spelled locally (like
+ * `provider-connection.ts`) so the module stays dependency-light and both the
+ * app's `ProviderStatus` and a hand-built test fixture pass in.
+ */
+export interface RoutineProviderStatusLike {
+  authenticated?: boolean;
+  auth_state?: "authenticated" | "unauthenticated" | "unknown";
+  health?: ProviderHealth;
+}
+
+/** Health the badge renders. No status yet = still probing = `checking`. */
+export function routineProviderHealth(
+  status: RoutineProviderStatusLike | undefined,
+): RoutineProviderHealth {
+  if (!status) return "checking";
+  if (status.health) {
+    return status.health === "unreachable" ? "checking" : status.health;
+  }
+  // Older engine: no `health` field at all. Read the tri-state exactly as the
+  // rest of the app does — `unknown` is "could not confirm", never "signed
+  // out" — and fall back to the denormalized boolean for the rest.
+  if (status.auth_state === "unknown") return "checking";
+  return status.authenticated ? "connected" : "not_connected";
+}
+
+/**
+ * The routine cannot run as things stand. Drives the compact warning chip on
+ * list rows, which exists to say "this one will fail" before it does — so
+ * `checking` is deliberately excluded: an unconfirmable probe is not evidence.
+ */
+export function routineHealthBlocksRun(health: RoutineProviderHealth): boolean {
+  return (
+    health === "not_connected" ||
+    health === "needs_reconnect" ||
+    health === "out_of_credits"
+  );
+}
+
+/**
+ * Connecting (or reconnecting) the provider is the remedy. `out_of_credits` is
+ * excluded on purpose: the credential is already connected, so a Connect button
+ * would relaunch a sign-in that changes nothing.
+ */
+export function routineHealthOffersConnect(
+  health: RoutineProviderHealth,
+): boolean {
+  return health === "not_connected" || health === "needs_reconnect";
+}
+
+/**
+ * Whether the viewer's own `/providers` answer describes the account this
+ * routine would fire on. True when the routine names no creator (single-player:
+ * there is one account and it is the viewer's) or names the viewer.
+ */
+export function viewerIsRoutineCreator(
+  createdBy: string | undefined,
+  viewerId: string | null | undefined,
+): boolean {
+  if (!createdBy) return true;
+  return !!viewerId && createdBy === viewerId;
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -23,6 +23,7 @@ import type {
   ProviderStatus as EngineProviderStatus,
   MessageMention,
   ProviderAuthState,
+  ProviderHealth,
   ProviderUsage,
   SkillsManifest,
 } from "@houston-ai/engine-client";
@@ -1517,6 +1518,12 @@ export interface ProviderStatus {
    * reads the shape it always read.
    */
   credentialScope?: CredentialScope;
+  /**
+   * Why the provider is (un)usable for this identity (PRODUCT-1475). Richer
+   * than `authenticated`: `out_of_credits` is a VALID credential with no quota,
+   * so it stays authenticated. Absent from engines that predate it.
+   */
+  health?: ProviderHealth;
 }
 
 /**
@@ -1555,6 +1562,7 @@ export const tauriProvider = {
         // keeps fields it names explicitly, so omitting it would silently
         // swallow which account answered. Absent stays absent.
         credentialScope: p.credentialScope,
+        health: p.health,
       };
     }),
   /**
@@ -1597,6 +1605,7 @@ export const tauriProvider = {
             // path feeds the chat model picker, which is where the account label
             // is actually rendered.
             credentialScope: p.credentialScope,
+            health: p.health,
           };
         });
         return out;
@@ -1618,6 +1627,7 @@ export const tauriProvider = {
             authenticated: status.authState === "authenticated",
             cli_name: status.cliName,
             active_model: status.activeModel,
+            health: status.health,
           };
         });
         return out;

--- a/app/src/locales/en/routines.json
+++ b/app/src/locales/en/routines.json
@@ -131,7 +131,8 @@
       "outOfCredits": "Out of credits",
       "checking": "Checking",
       "connect": "Connect {{provider}}",
-      "runsAsCreator": "Runs on the creator's connected account"
+      "runsAsCreator": "Runs on the creator's connected account",
+      "runsAsCreatorProvider": "Runs on the creator's {{provider}} account"
     },
     "failure": {
       "creatorNotConnected": "The routine's creator has no {{provider}} account connected.",

--- a/app/src/locales/en/routines.json
+++ b/app/src/locales/en/routines.json
@@ -121,8 +121,24 @@
       "cancelled": "Stopped"
     },
     "model": {
-      "inherit": "Agent's model",
+      "followsAgent": "Follows the agent's model",
       "reset": "Use the agent's model"
+    },
+    "health": {
+      "connected": "Connected",
+      "notConnected": "Not connected",
+      "needsReconnect": "Needs reconnect",
+      "outOfCredits": "Out of credits",
+      "checking": "Checking",
+      "connect": "Connect {{provider}}",
+      "runsAsCreator": "Runs on the creator's connected account"
+    },
+    "failure": {
+      "creatorNotConnected": "The routine's creator has no {{provider}} account connected.",
+      "teamNotConnected": "This team has no {{provider}} account connected.",
+      "creatorNeedsReconnect": "{{provider}} needs to be reconnected by the routine's creator.",
+      "teamNeedsReconnect": "{{provider}} needs to be reconnected.",
+      "outOfCredits": "The {{provider}} account is out of credits."
     }
   },
   "row": {

--- a/app/src/locales/es/routines.json
+++ b/app/src/locales/es/routines.json
@@ -121,8 +121,24 @@
       "cancelled": "Detenida"
     },
     "model": {
-      "inherit": "Modelo del agente",
+      "followsAgent": "Sigue el modelo del agente",
       "reset": "Usar el modelo del agente"
+    },
+    "health": {
+      "connected": "Conectado",
+      "notConnected": "Sin conectar",
+      "needsReconnect": "Hay que volver a conectar",
+      "outOfCredits": "Sin créditos",
+      "checking": "Comprobando",
+      "connect": "Conectar {{provider}}",
+      "runsAsCreator": "Se ejecuta en la cuenta de quien la creó"
+    },
+    "failure": {
+      "creatorNotConnected": "Quien creó la rutina no tiene una cuenta de {{provider}} conectada.",
+      "teamNotConnected": "Este equipo no tiene una cuenta de {{provider}} conectada.",
+      "creatorNeedsReconnect": "Quien creó la rutina tiene que volver a conectar {{provider}}.",
+      "teamNeedsReconnect": "Hay que volver a conectar {{provider}}.",
+      "outOfCredits": "La cuenta de {{provider}} se quedó sin créditos."
     }
   },
   "row": {

--- a/app/src/locales/es/routines.json
+++ b/app/src/locales/es/routines.json
@@ -131,7 +131,8 @@
       "outOfCredits": "Sin créditos",
       "checking": "Comprobando",
       "connect": "Conectar {{provider}}",
-      "runsAsCreator": "Se ejecuta en la cuenta de quien la creó"
+      "runsAsCreator": "Se ejecuta en la cuenta de quien la creó",
+      "runsAsCreatorProvider": "Se ejecuta en la cuenta de {{provider}} de quien la creó"
     },
     "failure": {
       "creatorNotConnected": "Quien creó la rutina no tiene una cuenta de {{provider}} conectada.",

--- a/app/src/locales/pt/routines.json
+++ b/app/src/locales/pt/routines.json
@@ -131,7 +131,8 @@
       "outOfCredits": "Sem créditos",
       "checking": "Verificando",
       "connect": "Conectar {{provider}}",
-      "runsAsCreator": "Roda na conta de quem criou a rotina"
+      "runsAsCreator": "Roda na conta de quem criou a rotina",
+      "runsAsCreatorProvider": "Roda na conta de {{provider}} de quem criou a rotina"
     },
     "failure": {
       "creatorNotConnected": "Quem criou a rotina não tem uma conta {{provider}} conectada.",

--- a/app/src/locales/pt/routines.json
+++ b/app/src/locales/pt/routines.json
@@ -121,8 +121,24 @@
       "cancelled": "Interrompida"
     },
     "model": {
-      "inherit": "Modelo do agente",
+      "followsAgent": "Segue o modelo do agente",
       "reset": "Usar o modelo do agente"
+    },
+    "health": {
+      "connected": "Conectado",
+      "notConnected": "Sem conexão",
+      "needsReconnect": "Precisa reconectar",
+      "outOfCredits": "Sem créditos",
+      "checking": "Verificando",
+      "connect": "Conectar {{provider}}",
+      "runsAsCreator": "Roda na conta de quem criou a rotina"
+    },
+    "failure": {
+      "creatorNotConnected": "Quem criou a rotina não tem uma conta {{provider}} conectada.",
+      "teamNotConnected": "Esta equipe não tem uma conta {{provider}} conectada.",
+      "creatorNeedsReconnect": "Quem criou a rotina precisa reconectar o {{provider}}.",
+      "teamNeedsReconnect": "É preciso reconectar o {{provider}}.",
+      "outOfCredits": "A conta {{provider}} está sem créditos."
     }
   },
   "row": {

--- a/app/tests/model-labels.test.ts
+++ b/app/tests/model-labels.test.ts
@@ -1,0 +1,74 @@
+import { strictEqual } from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import {
+  modelDisplayLabel,
+  providerForModel,
+  providerModelLabel,
+} from "../src/lib/model-labels.ts";
+import {
+  getModel,
+  hydrateProviderCatalog,
+  providerName,
+} from "../src/lib/providers.ts";
+import { SAMPLE_CATALOG } from "./fixtures/sample-catalog.ts";
+
+// Labels come from the hydrated pi catalog, so populate the cache first.
+before(() => hydrateProviderCatalog(SAMPLE_CATALOG));
+
+/**
+ * PRODUCT-1475 — the chat picker's trigger and the routine screen's model row
+ * name the same pair, so they read it through ONE chain. These pin the chain's
+ * order and the local-provider case that motivated it.
+ */
+describe("modelDisplayLabel", () => {
+  it("prefers the catalog's curated label", () => {
+    const label = getModel("anthropic", "claude-opus-5")?.label;
+    strictEqual(typeof label, "string");
+    strictEqual(modelDisplayLabel("anthropic", "claude-opus-5"), label);
+  });
+
+  it("falls back to the engine-reported model for a catalog-less provider", () => {
+    // A local OpenAI-compatible model has no catalog entry; `active_model` is
+    // the only name it has.
+    strictEqual(
+      modelDisplayLabel("openai-compatible", "", "llama3.1"),
+      "llama3.1",
+    );
+  });
+
+  it("falls back to the raw selection before giving up", () => {
+    strictEqual(
+      modelDisplayLabel("anthropic", "some-unlisted-model"),
+      "some-unlisted-model",
+    );
+    strictEqual(modelDisplayLabel("anthropic", ""), null);
+  });
+});
+
+describe("providerForModel", () => {
+  it("finds the catalogued provider that offers a model", () => {
+    strictEqual(providerForModel("claude-opus-5"), "anthropic");
+  });
+
+  it("is null for a model no provider offers", () => {
+    strictEqual(providerForModel("not-a-real-model"), null);
+  });
+});
+
+describe("providerModelLabel", () => {
+  it("names the account AND the model", () => {
+    const model = getModel("anthropic", "claude-opus-5")?.label;
+    strictEqual(
+      providerModelLabel("anthropic", "claude-opus-5"),
+      `${providerName("anthropic")} · ${model}`,
+    );
+  });
+
+  it("names the provider alone when the model is unresolved", () => {
+    strictEqual(providerModelLabel("anthropic", ""), providerName("anthropic"));
+  });
+
+  it("is null with no provider — nothing resolved, nothing to claim", () => {
+    strictEqual(providerModelLabel("", "claude-opus-5"), null);
+  });
+});

--- a/app/tests/routine-provider-health.test.ts
+++ b/app/tests/routine-provider-health.test.ts
@@ -1,0 +1,125 @@
+import { strictEqual } from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  type RoutineProviderStatusLike,
+  routineHealthBlocksRun,
+  routineHealthOffersConnect,
+  routineProviderHealth,
+  viewerIsRoutineCreator,
+} from "../src/lib/routine-provider-health.ts";
+
+/**
+ * PRODUCT-1475 — a routine says which AI account it runs on and whether that
+ * account works, BEFORE it fires. These pin the two things that were silently
+ * wrong before: an engine with no `health` field must still answer, and an
+ * unconfirmable probe must never read as either healthy or broken.
+ */
+describe("routineProviderHealth", () => {
+  it("no status yet is checking, never 'not connected'", () => {
+    strictEqual(routineProviderHealth(undefined), "checking");
+  });
+
+  for (const health of [
+    "connected",
+    "not_connected",
+    "needs_reconnect",
+    "out_of_credits",
+  ] as const) {
+    it(`passes the wire health "${health}" through`, () => {
+      strictEqual(routineProviderHealth({ health }), health);
+    });
+  }
+
+  it("collapses unreachable into the neutral checking state", () => {
+    strictEqual(routineProviderHealth({ health: "unreachable" }), "checking");
+  });
+
+  it("health wins over the denormalized boolean when both are present", () => {
+    // Out of credits is an AUTHENTICATED credential with no quota: reading
+    // `authenticated` alone would call it connected and the run would fail.
+    strictEqual(
+      routineProviderHealth({ authenticated: true, health: "out_of_credits" }),
+      "out_of_credits",
+    );
+    strictEqual(
+      routineProviderHealth({
+        authenticated: false,
+        auth_state: "unauthenticated",
+        health: "connected",
+      }),
+      "connected",
+    );
+  });
+
+  describe("older engine with no health field", () => {
+    it("authenticated is connected", () => {
+      const status: RoutineProviderStatusLike = {
+        authenticated: true,
+        auth_state: "authenticated",
+      };
+      strictEqual(routineProviderHealth(status), "connected");
+    });
+
+    it("unauthenticated is not connected", () => {
+      strictEqual(
+        routineProviderHealth({
+          authenticated: false,
+          auth_state: "unauthenticated",
+        }),
+        "not_connected",
+      );
+    });
+
+    it("an unknown probe is checking, even with authenticated false", () => {
+      strictEqual(
+        routineProviderHealth({ authenticated: false, auth_state: "unknown" }),
+        "checking",
+      );
+    });
+
+    it("falls back to the boolean when auth_state is absent", () => {
+      strictEqual(routineProviderHealth({ authenticated: true }), "connected");
+      strictEqual(routineProviderHealth({}), "not_connected");
+    });
+  });
+});
+
+describe("routineHealthBlocksRun", () => {
+  it("flags every state that fails a run", () => {
+    strictEqual(routineHealthBlocksRun("not_connected"), true);
+    strictEqual(routineHealthBlocksRun("needs_reconnect"), true);
+    strictEqual(routineHealthBlocksRun("out_of_credits"), true);
+  });
+
+  it("never warns on connected or on an unconfirmed probe", () => {
+    strictEqual(routineHealthBlocksRun("connected"), false);
+    strictEqual(routineHealthBlocksRun("checking"), false);
+  });
+});
+
+describe("routineHealthOffersConnect", () => {
+  it("offers connect only where connecting is the remedy", () => {
+    strictEqual(routineHealthOffersConnect("not_connected"), true);
+    strictEqual(routineHealthOffersConnect("needs_reconnect"), true);
+    // Already connected — a sign-in would change nothing.
+    strictEqual(routineHealthOffersConnect("out_of_credits"), false);
+    strictEqual(routineHealthOffersConnect("connected"), false);
+    strictEqual(routineHealthOffersConnect("checking"), false);
+  });
+});
+
+describe("viewerIsRoutineCreator", () => {
+  it("single-player (no creator) is always the viewer's own account", () => {
+    strictEqual(viewerIsRoutineCreator(undefined, null), true);
+    strictEqual(viewerIsRoutineCreator(undefined, "u-alice"), true);
+  });
+
+  it("matches the signed-in user id", () => {
+    strictEqual(viewerIsRoutineCreator("u-alice", "u-alice"), true);
+  });
+
+  it("a teammate's routine runs on an account this viewer cannot probe", () => {
+    strictEqual(viewerIsRoutineCreator("u-bob", "u-alice"), false);
+    strictEqual(viewerIsRoutineCreator("u-bob", null), false);
+  });
+});

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,29 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v69 - 2026-08-21
+
+A routine now says which AI account it runs on, and whether that account works,
+before it runs. The model row stopped saying "Agent's model" -- a label that
+named neither the provider nor the model -- and always shows the resolved pair,
+with the quiet line about following the agent kept for the unpinned case. Beside
+it sits a connection badge: connected, not connected, needs reconnect, out of
+credits, or checking, with a connect action on the two states connecting can
+fix.
+
+Whose account that badge describes is the whole difficulty. A fired routine runs
+on its CREATOR's account, while the connection answer any surface can get
+describes the VIEWER's. So the badge is shown only for a routine the viewer
+created; every other routine gets a sentence saying it runs on the creator's
+account, which is true and answerable, rather than a badge quietly answering a
+different question.
+
+The same warning rides the list rows, because a list is where a person notices a
+broken automation, and the run history now explains a run that never reached the
+agent instead of leaving "Failed" as the whole story. Nothing here blocks
+anything: saving and enabling a routine stay allowed, the surface only stops
+being silent about what will happen.
+
 ## v68 - 2026-08-08
 
 The rail names TEAMS and nothing else. A team block is a header row and its

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 68
+version: 69
 
 components:
   - id: agent-avatar
@@ -816,6 +816,7 @@ components:
         enabled-toggle,
         quick-actions-menu,
         owner-chip,
+        connection-warning-chip,
       ]
     states:
       [
@@ -829,6 +830,7 @@ components:
         trigger-pending,
         trigger-paused,
         trigger-error,
+        provider-unusable,
       ]
     variants:
       [list-row, grid-card, schedule-driven, event-driven, cross-agent]
@@ -848,6 +850,13 @@ components:
       routine still being built in chat) wears the same chip, or several
       identical "being created" rows would be indistinguishable. A single-agent
       list omits both, since every row would name the same owner.
+      A row also carries a WARNING chip when the AI account the routine would
+      run on is unusable -- not connected, needing a reconnect, or out of
+      credits -- so a broken automation is visible in the list rather than only
+      after it fails. The chip is supplied by the surface (the library owns no
+      provider state) and is absent for a healthy account, for an unconfirmed
+      probe, and for a routine created by someone else, whose account the viewer
+      cannot answer for.
     a11y: >-
       listitem role; toggle labeled with the routine name; next-run/status as
       text; status never color-alone (icon shape + row text carry it); menu
@@ -871,9 +880,20 @@ components:
         editable-prompt,
         schedule-editor,
         model-row,
+        connection-health-badge,
         runs-modal,
       ]
-    states: [viewing, editing-prompt, editing-schedule, loading-runs, no-runs-yet]
+    states:
+      [
+        viewing,
+        editing-prompt,
+        editing-schedule,
+        loading-runs,
+        no-runs-yet,
+        provider-connected,
+        provider-unusable,
+        provider-checking,
+      ]
     variants: [full-screen]
     behavior: >-
       The row click lands here (never straight in a chat); Back or Escape
@@ -882,14 +902,23 @@ components:
       shows the humanized cron with the SAME schedule-builder editor the rows
       use (plus the next fire time), or a trigger's plain-language event with
       its live activation chip (event bindings change via chat, not here).
-      The model row shows "Agent's model" (inherit) or the pinned provider +
-      model; picking pins it (the fire path honors the pin), a reset row
-      returns to inherit -- clamped to the agent's allowed-models ceiling in
-      Teams. "Runs" opens the execution history as a MODAL: every recorded
+      The model row ALWAYS names the resolved pair -- provider + model, e.g.
+      "Claude - Opus 5" -- whether the routine is pinned or follows the agent;
+      an unpinned routine adds a quiet line saying so. Picking pins it (the fire
+      path honors the pin), a reset row returns to following the agent --
+      clamped to the agent's allowed-models ceiling in Teams. Beside it, a
+      status badge says whether that AI account is usable BEFORE any run
+      (connected / not connected / needs reconnect / out of credits /
+      checking), with an inline connect action on the two states connecting can
+      fix. The badge is only shown for a routine the viewer created: a fired
+      routine runs on its CREATOR's account, and the viewer's own connection
+      answer describes a different one -- a routine someone else created gets a
+      plain line saying it runs on the creator's account instead. "Runs" opens the execution history as a MODAL: every recorded
       run newest-first with its plain-language outcome (running / done /
       nothing to report / failed / stopped), date + time, elapsed time, and
-      -- when the run wasn't silent -- the result it left behind; clicking an
-      entry closes the modal and opens that run's chat in the shell panel
+      -- when the run wasn't silent -- the result it left behind, or, for a run
+      that never reached the agent, the reason its AI account could not run it;
+      clicking an entry closes the modal and opens that run's chat in the shell panel
       (closing the chat returns to this screen). "Open chat" reaches the
       routine's setup chat the same way.
     a11y: >-

--- a/packages/host/src/schedule/reconcile.test.ts
+++ b/packages/host/src/schedule/reconcile.test.ts
@@ -348,7 +348,136 @@ test("a failed turn's typed provider error surfaces as the run's error immediate
     workspaceRoot(env.ws, env.agent),
   );
   expect((items[0] as RoutineRun).status).toBe("error");
-  expect((items[0] as RoutineRun).summary).toContain("session expired");
+  // The row names WHOSE account needs the fix, not the provider's generic
+  // sentence: the reader may have their own Claude connected (PRODUCT-1475).
+  expect((items[0] as RoutineRun).failure).toEqual({
+    code: "creator_needs_reconnect",
+    provider: "anthropic",
+  });
+  expect((items[0] as RoutineRun).summary).toBe(
+    "Claude needs to be reconnected by the routine's creator.",
+  );
+});
+
+/**
+ * Every credential-level wall a routine can hit, mapped to the honest row a
+ * non-technical reader can act on (PRODUCT-1475). The routine runs on its
+ * CREATOR's credential scope, so a personal-scope (or unattributed) failure is
+ * the creator's account and a team-scope one is the space's shared account.
+ */
+test.each([
+  [
+    "creator has never connected",
+    {
+      kind: "unauthenticated",
+      provider: "anthropic",
+      cause: "no_credentials",
+      message: "No provider connected.",
+    },
+    "creator_not_connected",
+    "The routine's creator has no Claude account connected.",
+  ],
+  [
+    "the team has never connected",
+    {
+      kind: "unauthenticated",
+      provider: "anthropic",
+      cause: "no_credentials",
+      message: "No provider connected.",
+      credential: { scope: "team" },
+    },
+    "team_not_connected",
+    "This team has no Claude account connected.",
+  ],
+  [
+    "the creator's own credential died",
+    {
+      kind: "unauthenticated",
+      provider: "openai-codex",
+      cause: "token_revoked",
+      message: "Your session has ended.",
+      credential: { scope: "personal" },
+    },
+    "creator_needs_reconnect",
+    "ChatGPT / Codex needs to be reconnected by the routine's creator.",
+  ],
+  [
+    "the team credential died",
+    {
+      kind: "unauthenticated",
+      provider: "anthropic",
+      cause: "invalid_api_key",
+      message: "invalid x-api-key",
+      credential: { scope: "team" },
+    },
+    "team_needs_reconnect",
+    "Claude needs to be reconnected for this team.",
+  ],
+  [
+    "the account ran out of credits",
+    {
+      kind: "quota_exhausted",
+      provider: "minimax",
+      model: null,
+      scope: "paid_plan",
+      resets_at: null,
+      message: "Insufficient balance",
+    },
+    "out_of_credits",
+    "The MiniMax account is out of credits.",
+  ],
+])("a run that failed because %s reports the typed failure and an honest summary", async (_case, providerError, code, summary) => {
+  const env = await setup(routine());
+  await seedReply(
+    env.vfs,
+    env.ws,
+    env.agent,
+    env.run.session_key,
+    "",
+    STARTED.getTime() + 1000,
+    providerError,
+  );
+
+  await reconcileAgentRuns(deps(env.vfs, NOW), env.ws, env.agent);
+  const { items } = await loadRoutineRuns(
+    env.vfs,
+    workspaceRoot(env.ws, env.agent),
+  );
+  const run = items[0] as RoutineRun;
+  expect(run.status).toBe("error");
+  expect(run.failure).toEqual({
+    code,
+    provider: (providerError as { provider: string }).provider,
+  });
+  expect(run.summary).toBe(summary);
+});
+
+test("a non-credential provider failure keeps the verbatim reason and stays untyped", async () => {
+  const env = await setup(routine());
+  await seedReply(
+    env.vfs,
+    env.ws,
+    env.agent,
+    env.run.session_key,
+    "",
+    STARTED.getTime() + 1000,
+    {
+      kind: "rate_limited",
+      provider: "anthropic",
+      model: null,
+      retry_after_seconds: 60,
+      message: "You have hit your usage limit.",
+    },
+  );
+
+  await reconcileAgentRuns(deps(env.vfs, NOW), env.ws, env.agent);
+  const { items } = await loadRoutineRuns(
+    env.vfs,
+    workspaceRoot(env.ws, env.agent),
+  );
+  const run = items[0] as RoutineRun;
+  expect(run.summary).toBe("You have hit your usage limit.");
+  expect(run.failure).toBeUndefined();
 });
 
 test("an empty successful reply completes the run (surfaced 'Nothing to report'), not a timeout", async () => {

--- a/packages/host/src/schedule/reconcile.ts
+++ b/packages/host/src/schedule/reconcile.ts
@@ -8,16 +8,16 @@ import {
   saveRoutineRuns,
   upsertById,
 } from "@houston/domain";
-import type {
-  ChatMessage,
-  ProviderError,
-  Routine,
-  RoutineRun,
-} from "@houston/protocol";
+import type { ChatMessage, Routine, RoutineRun } from "@houston/protocol";
 import type { Agent, Workspace } from "../domain/types";
 import type { EventHub } from "../events/hub";
 import { conversationKey, type WorkspacePaths } from "../paths";
 import type { Vfs } from "../vfs";
+import {
+  providerErrorSummary,
+  routineRunFailure,
+  routineRunFailureSummary,
+} from "./run-failure";
 import { withRunsFile } from "./runs-lock";
 
 /** A run still 'running' after this long with no agent reply is declared timed-out. */
@@ -45,12 +45,6 @@ function replyAfter(
     if (m.role === "assistant" && m.ts >= startedAtMs) return m;
   }
   return null;
-}
-
-/** A run-row-sized reason from the turn's typed provider failure. */
-function providerErrorSummary(err: ProviderError): string {
-  const text = err.kind === "unknown" ? err.raw_excerpt : err.message;
-  return text.trim() || `provider error (${err.kind})`;
 }
 
 export interface ReconcileDeps {
@@ -163,11 +157,19 @@ export async function reconcileAgentRuns(
     // now (parity with the Rust dispatcher's visible run errors) instead of
     // classifying the empty reply or waiting out the 15-minute timeout.
     if (reply.providerError) {
+      // A credential-level wall gets the honest, whose-account-is-it sentence
+      // (PRODUCT-1475): the raw provider message says "no provider connected"
+      // to a reader whose OWN account is connected. Everything else keeps the
+      // verbatim provider text.
+      const failure = routineRunFailure(reply.providerError);
       updates.push({
         run: {
           ...run,
           status: "error",
-          summary: providerErrorSummary(reply.providerError),
+          summary: failure
+            ? routineRunFailureSummary(failure)
+            : providerErrorSummary(reply.providerError),
+          ...(failure ? { failure } : {}),
           completed_at: deps.now().toISOString(),
         },
       });

--- a/packages/host/src/schedule/run-failure.ts
+++ b/packages/host/src/schedule/run-failure.ts
@@ -1,0 +1,81 @@
+import type {
+  ProviderError,
+  RoutineRunFailure,
+  RoutineRunFailureCode,
+} from "@houston/protocol";
+import { providerName } from "../providers";
+
+/**
+ * Why a routine run failed, in the terms the person reading its history can
+ * act on (PRODUCT-1475). A routine fires on the CREATOR's credential scope, so
+ * "no provider connected" is never the whole truth: the reader may well have
+ * their own account connected and still see the run fail, which is exactly the
+ * report that made this bug look like a lie on screen.
+ *
+ * The typed code drives whatever the surface wants to render; `summary` stays
+ * an honest English sentence for the surfaces (and the run history) that show
+ * it verbatim, matching the existing run-row copy.
+ */
+
+/**
+ * The provider name for a SENTENCE. The catalog names carry a plan
+ * parenthetical ("Claude (Pro / Max)") which reads wrong mid-sentence, so it
+ * is dropped here and only here — the catalog stays the source of truth for
+ * every place a provider is NAMED rather than narrated.
+ */
+function sentenceProviderName(id: string): string {
+  return providerName(id).replace(/\s*\(.*\)\s*$/, "");
+}
+
+/**
+ * Whose credential ran the failed turn. A turn with no acting identity has
+ * exactly one credential and it is the creator's own (desktop, self-host, a
+ * personal space), so absence reads as personal — never as "the team's".
+ */
+function isTeamCredential(err: ProviderError): boolean {
+  return err.credential?.scope === "team";
+}
+
+/** The typed failure for a turn's provider error, or undefined when the error
+ *  is not a credential-level wall (a network blip, a provider outage). */
+export function routineRunFailure(
+  err: ProviderError,
+): RoutineRunFailure | undefined {
+  if (err.kind === "quota_exhausted")
+    return { code: "out_of_credits", provider: err.provider };
+  if (err.kind !== "unauthenticated") return undefined;
+  const team = isTeamCredential(err);
+  const code: RoutineRunFailureCode =
+    err.cause === "no_credentials"
+      ? team
+        ? "team_not_connected"
+        : "creator_not_connected"
+      : team
+        ? "team_needs_reconnect"
+        : "creator_needs_reconnect";
+  return { code, provider: err.provider };
+}
+
+/** The run-row sentence for a typed failure. */
+export function routineRunFailureSummary(failure: RoutineRunFailure): string {
+  const name = sentenceProviderName(failure.provider);
+  switch (failure.code) {
+    case "creator_not_connected":
+      return `The routine's creator has no ${name} account connected.`;
+    case "team_not_connected":
+      return `This team has no ${name} account connected.`;
+    case "creator_needs_reconnect":
+      return `${name} needs to be reconnected by the routine's creator.`;
+    case "team_needs_reconnect":
+      return `${name} needs to be reconnected for this team.`;
+    case "out_of_credits":
+      return `The ${name} account is out of credits.`;
+  }
+}
+
+/** A run-row-sized reason from a turn's typed provider failure that is NOT a
+ *  credential wall (an outage, a rate limit): the provider's own words. */
+export function providerErrorSummary(err: ProviderError): string {
+  const text = err.kind === "unknown" ? err.raw_excerpt : err.message;
+  return text.trim() || `provider error (${err.kind})`;
+}

--- a/packages/host/src/schedule/run.ts
+++ b/packages/host/src/schedule/run.ts
@@ -5,11 +5,13 @@ import {
   saveRoutineRuns,
   upsertById,
 } from "@houston/domain";
-import type { Routine } from "@houston/protocol";
+import type { Routine, RoutineRunFailure } from "@houston/protocol";
+import { TurnFireError } from "../channel/fire-error";
 import type { Agent, Workspace } from "../domain/types";
 import type { EventHub } from "../events/hub";
 import type { WorkspacePaths } from "../paths";
 import type { Vfs } from "../vfs";
+import { routineRunFailureSummary } from "./run-failure";
 import { withRunsFile } from "./runs-lock";
 import type { RoutineFirer } from "./scheduler";
 
@@ -89,6 +91,16 @@ export async function fireRoutineRun(
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    // The runtime refused the fire outright because nothing is connected for
+    // the identity the routine runs as — the creator's (PRODUCT-1475). Typed
+    // only when the routine PINS a provider: the unpinned case genuinely has
+    // no provider to name, so it keeps the runtime's verbatim message.
+    const failure: RoutineRunFailure | undefined =
+      err instanceof TurnFireError &&
+      err.code === "no_provider" &&
+      routine.provider
+        ? { code: "creator_not_connected", provider: routine.provider }
+        : undefined;
     await withRunsFile(root, async () => {
       const { items: current } = await loadRoutineRuns(deps.vfs, root);
       const row = current.find((r) => r.id === runId);
@@ -101,7 +113,8 @@ export async function fireRoutineRun(
         upsertById(current, {
           ...row,
           status: "error",
-          summary: message,
+          summary: failure ? routineRunFailureSummary(failure) : message,
+          ...(failure ? { failure } : {}),
           completed_at: deps.now().toISOString(),
         }),
       );

--- a/packages/host/src/schedule/scheduler.test.ts
+++ b/packages/host/src/schedule/scheduler.test.ts
@@ -191,6 +191,43 @@ test("a no-provider 409 fire records the errored run but logs a warning, not an 
   );
   expect(items).toHaveLength(1);
   expect((items[0] as RoutineRun).status).toBe("error");
+  // Unpinned routine: there is no provider to name, so the row keeps the
+  // runtime's verbatim message and stays untyped (PRODUCT-1475).
+  expect((items[0] as RoutineRun).failure).toBeUndefined();
+});
+
+test("a no-provider 409 on a PINNED routine names the provider the creator must connect", async () => {
+  const env = await setup([
+    routine({ schedule: ENABLED, provider: "anthropic" }),
+  ]);
+  const firer = new CaptureFirer(
+    new TurnFireError(
+      'runtime 409: {"error":"No provider connected."}',
+      409,
+      "no_provider",
+    ),
+  );
+  const s = makeScheduler(env, firer);
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    s.start();
+    await s.tick(DUE);
+  } finally {
+    warn.mockRestore();
+  }
+
+  const { items } = await loadRoutineRuns(
+    env.vfs,
+    workspaceRoot(env.ws, env.agent),
+  );
+  const run = items[0] as RoutineRun;
+  expect(run.failure).toEqual({
+    code: "creator_not_connected",
+    provider: "anthropic",
+  });
+  expect(run.summary).toBe(
+    "The routine's creator has no Claude account connected.",
+  );
 });
 
 test("the workspace timezone preference re-times routines (account-wide zone)", async () => {

--- a/packages/protocol/src/conversation.ts
+++ b/packages/protocol/src/conversation.ts
@@ -81,6 +81,25 @@ export interface AuthStatus {
   activeProvider: ProviderId | null;
 }
 
+/**
+ * How usable a provider credential is RIGHT NOW, for the acting identity that
+ * asked. Richer than `configured` (which stays a plain "can this run a turn"
+ * boolean): a credential can be present and valid yet unusable because the
+ * account ran out of credits, and a stored credential can be present yet dead.
+ *
+ * - `connected` — usable.
+ * - `not_connected` — no credential at all for this scope.
+ * - `needs_reconnect` — a credential exists but the provider rejected it.
+ * - `out_of_credits` — the credential is VALID; the account has no quota left.
+ * - `unreachable` — a custom/local endpoint that is not answering.
+ */
+export type ProviderHealth =
+  | "connected"
+  | "not_connected"
+  | "needs_reconnect"
+  | "out_of_credits"
+  | "unreachable";
+
 export interface ProviderInfo {
   id: ProviderId;
   name: string;
@@ -96,6 +115,11 @@ export interface ProviderInfo {
    * nothing to disambiguate".
    */
   credentialScope?: "personal" | "team";
+  /**
+   * Why this provider is (un)usable for the acting identity. Additive: absent
+   * from pre-PRODUCT-1475 engines, where `configured` is the only signal.
+   */
+  health?: ProviderHealth;
 }
 
 // ── Per-account provider usage (GET /providers/usage) ───────────────────────

--- a/packages/protocol/src/domain/routine.ts
+++ b/packages/protocol/src/domain/routine.ts
@@ -140,6 +140,29 @@ export type RoutineRunStatus =
   | "error"
   | "cancelled";
 
+/**
+ * Why a routine run failed at the credential level (PRODUCT-1475). A routine
+ * fires on its CREATOR's credential scope, so the person reading the run's
+ * history may have their own account connected and still see it fail — the run
+ * has to name whose account is the problem, and what the remedy is.
+ *
+ * `creator_*` = the routine creator's own account; `team_*` = the space's
+ * single shared account. `out_of_credits` is a VALID credential with no quota
+ * left, which reconnecting would not fix.
+ */
+export type RoutineRunFailureCode =
+  | "creator_not_connected"
+  | "team_not_connected"
+  | "creator_needs_reconnect"
+  | "team_needs_reconnect"
+  | "out_of_credits";
+
+export interface RoutineRunFailure {
+  code: RoutineRunFailureCode;
+  /** The provider id the run needed (e.g. "anthropic"). */
+  provider: string;
+}
+
 export interface RoutineRun {
   id: string;
   routine_id: string;
@@ -151,6 +174,12 @@ export interface RoutineRun {
   completed_at?: string;
   /** Human-readable reset hint while a run sleeps on a usage-limit window. */
   paused_until?: string;
+  /**
+   * The typed credential-level reason an errored run failed. Additive and
+   * optional: a run that failed for any other reason (a timeout, a provider
+   * outage) carries only `summary`, exactly as before.
+   */
+  failure?: RoutineRunFailure;
 }
 
 export interface RoutineRunUpdate {

--- a/packages/runtime/src/ai/providers.ts
+++ b/packages/runtime/src/ai/providers.ts
@@ -7,7 +7,11 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 // accepts — narrower than `KnownProvider`, which since pi 0.82 also names
 // purely dynamic providers (radius) with no static catalog entry.
 import { type BuiltinProvider, getModel } from "@earendil-works/pi-ai/compat";
-import { authFailureActive } from "../auth/credential-health";
+import type { ProviderHealth } from "@houston/protocol";
+import {
+  authFailureActive,
+  quotaExhaustedActive,
+} from "../auth/credential-health";
 import { servedScopeFor } from "../auth/served-scope";
 import { authStorage, providerConnected } from "../auth/storage";
 import { config } from "../config";
@@ -591,7 +595,11 @@ export function safeModelIds(provider: ProviderId): string[] {
  *  `credentialScope` names WHOSE credential produced `configured` (HOU-976), so
  *  the picker can label a row "your account". Absent unless the request carries
  *  an acting identity — desktop, self-host and every pre-HOU-976 caller see the
- *  exact shape they saw before. */
+ *  exact shape they saw before.
+ *
+ *  `health` says WHY (PRODUCT-1475), for the same acting identity: a routine
+ *  that fails "no provider connected" while the screen says Connected is the
+ *  bug this row has to make impossible. */
 function providerRow(id: ProviderId, name: string, active: ProviderId | null) {
   const servedScope = servedScopeFor(id);
   return {
@@ -602,7 +610,28 @@ function providerRow(id: ProviderId, name: string, active: ProviderId | null) {
     activeModel: modelFor(id),
     models: safeModelIds(id),
     ...(servedScope ? { credentialScope: servedScope } : {}),
+    health: providerHealth(id),
   };
+}
+
+/**
+ * WHY a provider is (un)usable for the acting identity — the reason behind
+ * `configured`, in the order the user must act on: no credential at all, a
+ * credential the provider rejected, a valid credential with no quota left, a
+ * local endpoint that is not answering.
+ *
+ * `out_of_credits` deliberately does NOT flip `configured` to false: the
+ * credential is valid and the turn should still run and surface its own typed
+ * card, so the row stays connected and only `health` tells the honest story
+ * (which is what a routine's failure summary reads).
+ */
+function providerHealth(id: ProviderId): ProviderHealth {
+  if (!providerConfigured(id)) return "not_connected";
+  if (authFailureActive(id)) return "needs_reconnect";
+  if (quotaExhaustedActive(id)) return "out_of_credits";
+  if (id === OPENAI_COMPATIBLE && !endpointReachableCached())
+    return "unreachable";
+  return "connected";
 }
 
 /**

--- a/packages/runtime/src/auth/credential-fingerprint.ts
+++ b/packages/runtime/src/auth/credential-fingerprint.ts
@@ -1,0 +1,62 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { endpointFileIn, OPENAI_COMPATIBLE } from "../ai/openai-compatible";
+import { claudeCredentialsFile } from "../backends/claude/paths";
+import { config } from "../config";
+import {
+  currentActingContext,
+  currentCredentialScope,
+  isPersonalScope,
+} from "../session/acting-context";
+import { authPathIn, readAuthFile } from "./auth-file";
+
+/**
+ * What a provider's CURRENT credential material hashes to, for the acting
+ * identity in scope. Split out of credential-health.ts (which OWNS the marks)
+ * because it is the piece with the real IO: it reads the persisted credential
+ * directly (auth-file.ts + the materialized Claude file) rather than going
+ * through auth/storage.ts — that module reaches the Claude backend, which this
+ * module's callers (the backends' error classifiers) sit underneath, and the
+ * import cycle is not worth a cached view of the same bytes.
+ */
+
+function digest(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+/** A file's content hash, or "absent" when it can't be read. */
+function fileFingerprint(path: string): string {
+  try {
+    return digest(readFileSync(path));
+  } catch {
+    return "absent";
+  }
+}
+
+/**
+ * A stable fingerprint of a provider's CURRENT persisted credential material.
+ * Two providers span more than their auth.json entry: anthropic also carries
+ * the shared-dir credentials file (the Keychain is not observable from here —
+ * its rotations heal via the clean-turn clear instead), and the local
+ * OpenAI-compatible provider carries its endpoint config (same placeholder
+ * key, different server = a different "credential": reconfiguring the
+ * endpoint must heal a failure mark).
+ *
+ * Everything read here belongs to the CURRENT acting identity (HOU-976). The
+ * shared-dir credentials file is the exception in reverse: it is team material,
+ * so it only counts in the team scope — otherwise another member's credential
+ * push would heal (or re-break) a member's own mark.
+ */
+export function credentialFingerprint(id: string): string {
+  const { key } = currentCredentialScope();
+  const activeAuthPath = currentActingContext()?.authPath;
+  const dataDir = activeAuthPath ? dirname(activeAuthPath) : config.dataDir;
+  const cred = readAuthFile(activeAuthPath ?? authPathIn(dataDir, key))[id];
+  const stored = cred ? digest(JSON.stringify(cred)) : "absent";
+  if (id === "anthropic" && !isPersonalScope(key))
+    return `${stored}|${fileFingerprint(claudeCredentialsFile())}`;
+  if (id === OPENAI_COMPATIBLE)
+    return `${stored}|${fileFingerprint(endpointFileIn(dataDir))}`;
+  return stored;
+}

--- a/packages/runtime/src/auth/credential-health.test.ts
+++ b/packages/runtime/src/auth/credential-health.test.ts
@@ -1,14 +1,25 @@
-import { afterEach, expect, test } from "vitest";
-import {
-  authFailureActive,
-  clearAuthFailure,
-  noteAuthFailure,
-  resetAuthFailures,
-} from "./credential-health";
+import { existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test, vi } from "vitest";
 
 // Fingerprints are injected everywhere, so these tests never touch auth.json
 // or the Claude credential file — the module's IO is exercised implicitly by
-// the fact that production callers omit the parameter.
+// the fact that production callers omit the parameter. The data dir is pinned
+// to a tmpdir before the dynamic imports because the marks are PERSISTED there
+// (config reads HOUSTON_DATA_DIR at import time).
+const dataDir = mkdtempSync(join(tmpdir(), "houston-credhealth-"));
+process.env.HOUSTON_DATA_DIR = dataDir;
+const marksFile = join(dataDir, "provider-marks.json");
+
+const {
+  authFailureActive,
+  clearProviderMarks,
+  noteAuthFailure,
+  noteQuotaExhausted,
+  quotaExhaustedActive,
+  resetAuthFailures,
+} = await import("./credential-health");
 
 afterEach(() => resetAuthFailures());
 
@@ -40,11 +51,103 @@ test("a serve loop re-applying the SAME dead token does not heal the mark", () =
 
 test("a clean turn clears the mark explicitly (the Keychain re-login no fingerprint can see)", () => {
   noteAuthFailure("anthropic", "fp-a");
-  clearAuthFailure("anthropic");
+  clearProviderMarks("anthropic");
   expect(authFailureActive("anthropic", "fp-a")).toBe(false);
 });
 
 test("marks are per provider", () => {
   noteAuthFailure("anthropic", "fp-a");
   expect(authFailureActive("openai-codex", "fp-a")).toBe(false);
+});
+
+// ---- out-of-credits marks ----
+
+test("an exhausted account is marked without an open-ended reset", () => {
+  noteQuotaExhausted("minimax", null, "fp-a");
+  expect(quotaExhaustedActive("minimax", "fp-a")).toBe(true);
+  // Independent of the auth mark: the credential still authenticates.
+  expect(authFailureActive("minimax", "fp-a")).toBe(false);
+});
+
+test("a quota mark lapses at the provider's own reset instant", () => {
+  noteQuotaExhausted(
+    "minimax",
+    new Date(Date.now() - 1_000).toISOString(),
+    "fp-a",
+  );
+  expect(quotaExhaustedActive("minimax", "fp-a")).toBe(false);
+  // A reset still ahead of us keeps the account marked.
+  noteQuotaExhausted(
+    "minimax",
+    new Date(Date.now() + 60_000).toISOString(),
+    "fp-a",
+  );
+  expect(quotaExhaustedActive("minimax", "fp-a")).toBe(true);
+});
+
+test("an open-ended quota mark expires an hour later, not forever", () => {
+  noteQuotaExhausted("minimax", null, "fp-a");
+  vi.useFakeTimers();
+  try {
+    vi.setSystemTime(Date.now() + 61 * 60 * 1000);
+    expect(quotaExhaustedActive("minimax", "fp-a")).toBe(false);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("a garbled reset hint falls back to the hour, never to 'never expires'", () => {
+  noteQuotaExhausted("minimax", "whenever", "fp-a");
+  expect(quotaExhaustedActive("minimax", "fp-a")).toBe(true);
+  vi.useFakeTimers();
+  try {
+    vi.setSystemTime(Date.now() + 61 * 60 * 1000);
+    expect(quotaExhaustedActive("minimax", "fp-a")).toBe(false);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("a changed credential heals a quota mark (a new account has its own balance)", () => {
+  noteQuotaExhausted("minimax", null, "fp-old-key");
+  expect(quotaExhaustedActive("minimax", "fp-new-key")).toBe(false);
+  expect(quotaExhaustedActive("minimax", "fp-old-key")).toBe(false);
+});
+
+test("a clean turn clears BOTH marks at once", () => {
+  noteAuthFailure("minimax", "fp-a");
+  noteQuotaExhausted("minimax", null, "fp-a");
+  clearProviderMarks("minimax");
+  expect(authFailureActive("minimax", "fp-a")).toBe(false);
+  expect(quotaExhaustedActive("minimax", "fp-a")).toBe(false);
+});
+
+// ---- persistence ----
+
+test("marks survive a restart: a fresh module graph re-reads them from the data dir", async () => {
+  noteAuthFailure("anthropic", "fp-dead");
+  noteQuotaExhausted("minimax", null, "fp-broke");
+  expect(existsSync(marksFile)).toBe(true);
+
+  // A restarted pod is a fresh module graph over the SAME data dir. Without
+  // persistence it would report the dead token as connected until the next
+  // failing turn (PRODUCT-1475).
+  vi.resetModules();
+  const restarted = await import("./credential-health");
+  expect(restarted.authFailureActive("anthropic", "fp-dead")).toBe(true);
+  expect(restarted.quotaExhaustedActive("minimax", "fp-broke")).toBe(true);
+  // And a credential changed while the process was down still auto-heals.
+  expect(restarted.authFailureActive("anthropic", "fp-fresh")).toBe(false);
+  restarted.resetAuthFailures();
+  vi.resetModules();
+});
+
+test("a garbled marks file reads as 'nothing known', never as a crash", async () => {
+  const { writeFileSync } = await import("node:fs");
+  writeFileSync(marksFile, "{not json");
+  vi.resetModules();
+  const restarted = await import("./credential-health");
+  expect(restarted.authFailureActive("anthropic", "fp-a")).toBe(false);
+  restarted.resetAuthFailures();
+  vi.resetModules();
 });

--- a/packages/runtime/src/auth/credential-health.ts
+++ b/packages/runtime/src/auth/credential-health.ts
@@ -1,15 +1,10 @@
-import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
-import { dirname } from "node:path";
-import { endpointFileIn, OPENAI_COMPATIBLE } from "../ai/openai-compatible";
-import { claudeCredentialsFile } from "../backends/claude/paths";
-import { config } from "../config";
+import { currentCredentialScope } from "../session/acting-context";
+import { credentialFingerprint } from "./credential-fingerprint";
 import {
-  currentActingContext,
-  currentCredentialScope,
-  isPersonalScope,
-} from "../session/acting-context";
-import { authPathIn, readAuthFile } from "./auth-file";
+  forgetProviderMarks,
+  readProviderMarks,
+  writeProviderMarks,
+} from "./provider-marks";
 
 /**
  * Turn-time truth fed back into provider status.
@@ -32,99 +27,122 @@ import { authPathIn, readAuthFile } from "./auth-file";
  * back to connected). A clean turn also clears it, which covers the one
  * change no fingerprint can see: a macOS Keychain re-login.
  *
- * Reads the persisted credential material directly (auth-file.ts + the
- * materialized Claude file) rather than going through auth/storage.ts — that
- * module reaches the Claude backend, which this module's callers (the
- * backends' error classifiers) sit underneath, and the import cycle is not
- * worth a cached view of the same bytes. In-memory only, deliberately: a
- * restart re-learns the truth from the next turn, and persisting "broken"
- * state could wedge a provider off after an out-of-band fix.
+ * The fingerprint itself (and its credential IO) lives in
+ * ./credential-fingerprint.
+ *
+ * The marks are PERSISTED (auth/provider-marks.ts): a restarted pod would
+ * otherwise report a dead token as Connected until the next failing turn, and
+ * a routine firing in that window fails while the screen says connected
+ * (PRODUCT-1475). That cannot wedge a provider off after an out-of-band fix
+ * because every mark carries the fingerprint of the credential it was recorded
+ * against — any credential change auto-heals a loaded mark exactly as it heals
+ * an in-memory one.
+ *
+ * Marks are keyed `${scopeKey}:${provider}` by acting identity (HOU-976):
+ * on a shared pod two members hold two different credentials for the same
+ * provider, so one member's dead token must not report the OTHER member's
+ * provider disconnected.
  */
 
-/**
- * `${scopeKey}:${provider}` → fingerprint of the credential that failed
- * authentication. Keyed by acting identity (HOU-976) because on a shared pod
- * two members hold two different credentials for the same provider: one
- * member's dead token must not report the OTHER member's provider disconnected.
- */
-const failed = new Map<string, string>();
+/** How long an exhausted-quota mark holds when the provider named no reset. */
+const QUOTA_MARK_TTL_MS = 60 * 60 * 1000;
 
 /** The mark key for a provider under the CURRENT acting identity. */
 function markFor(id: string): string {
   return `${currentCredentialScope().key}:${id}`;
 }
 
-function digest(value: string | Buffer): string {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-/** A file's content hash, or "absent" when it can't be read. */
-function fileFingerprint(path: string): string {
-  try {
-    return digest(readFileSync(path));
-  } catch {
-    return "absent";
-  }
-}
-
-/**
- * A stable fingerprint of a provider's CURRENT persisted credential material.
- * Two providers span more than their auth.json entry: anthropic also carries
- * the shared-dir credentials file (the Keychain is not observable from here —
- * its rotations heal via the clean-turn clear instead), and the local
- * OpenAI-compatible provider carries its endpoint config (same placeholder
- * key, different server = a different "credential": reconfiguring the
- * endpoint must heal a failure mark).
- *
- * Everything read here belongs to the CURRENT acting identity (HOU-976). The
- * shared-dir credentials file is the exception in reverse: it is team material,
- * so it only counts in the team scope — otherwise another member's credential
- * push would heal (or re-break) a member's own mark.
- */
-function credentialFingerprint(id: string): string {
-  const { key } = currentCredentialScope();
-  const activeAuthPath = currentActingContext()?.authPath;
-  const dataDir = activeAuthPath ? dirname(activeAuthPath) : config.dataDir;
-  const cred = readAuthFile(activeAuthPath ?? authPathIn(dataDir, key))[id];
-  const stored = cred ? digest(JSON.stringify(cred)) : "absent";
-  if (id === "anthropic" && !isPersonalScope(key))
-    return `${stored}|${fileFingerprint(claudeCredentialsFile())}`;
-  if (id === OPENAI_COMPATIBLE)
-    return `${stored}|${fileFingerprint(endpointFileIn(dataDir))}`;
-  return stored;
-}
-
 /** Record that a turn failed authentication on this provider's current
  *  credential. `fingerprint` is injectable for tests. */
 export function noteAuthFailure(id: string, fingerprint?: string): void {
-  failed.set(markFor(id), fingerprint ?? credentialFingerprint(id));
+  const marks = readProviderMarks();
+  marks.authFailed.set(markFor(id), fingerprint ?? credentialFingerprint(id));
+  writeProviderMarks(marks);
 }
 
-/** Heal the mark without a credential change — a turn that COMPLETED on this
- *  provider proved the credential works (exec-turn / turn-session call this on
- *  every clean turn; cheap no-op when nothing is marked). */
-export function clearAuthFailure(id: string): void {
-  failed.delete(markFor(id));
+/**
+ * Record that this provider's account ran OUT OF CREDITS / quota. Distinct
+ * from an auth failure: the credential is valid, so reconnecting fixes
+ * nothing — the status surface must say "out of credits", not "reconnect".
+ *
+ * `resetsAt` is the provider's own reset hint (ISO 8601) when it gave one; an
+ * open-ended exhaustion holds for an hour, after which the next turn re-learns
+ * the truth rather than leaving the account marked dead forever.
+ */
+export function noteQuotaExhausted(
+  id: string,
+  resetsAt: string | null,
+  fingerprint?: string,
+): void {
+  const parsed = resetsAt ? Date.parse(resetsAt) : Number.NaN;
+  const marks = readProviderMarks();
+  marks.quotaExhausted.set(markFor(id), {
+    fingerprint: fingerprint ?? credentialFingerprint(id),
+    expiresAt: Number.isNaN(parsed) ? Date.now() + QUOTA_MARK_TTL_MS : parsed,
+  });
+  writeProviderMarks(marks);
+}
+
+/** Heal both marks without a credential change — a turn that COMPLETED on this
+ *  provider proved the credential both authenticates and has quota left
+ *  (exec-turn / turn-session call this on every clean turn; cheap no-op when
+ *  nothing is marked). */
+export function clearProviderMarks(id: string): void {
+  const marks = readProviderMarks();
+  const mark = markFor(id);
+  // Both deletes must run (no short-circuit): a turn can heal an auth mark and
+  // a quota mark at once.
+  const hadAuth = marks.authFailed.delete(mark);
+  const hadQuota = marks.quotaExhausted.delete(mark);
+  if (!hadAuth && !hadQuota) return;
+  writeProviderMarks(marks);
 }
 
 /**
  * Whether this provider's CURRENT credential is the one that failed a turn's
  * authentication. A changed credential deletes the mark (auto-heal), so the
  * check stays true only while retrying would fail the same way. The common
- * path (nothing marked) does no IO. `fingerprint` is injectable for tests.
+ * path (nothing marked) does no credential IO. `fingerprint` is injectable for
+ * tests.
  */
 export function authFailureActive(id: string, fingerprint?: string): boolean {
+  const marks = readProviderMarks();
   const mark = markFor(id);
-  const marked = failed.get(mark);
+  const marked = marks.authFailed.get(mark);
   if (marked === undefined) return false;
   if (marked !== (fingerprint ?? credentialFingerprint(id))) {
-    failed.delete(mark);
+    marks.authFailed.delete(mark);
+    writeProviderMarks(marks);
     return false;
   }
   return true;
 }
 
-/** Tests only: forget every mark. */
+/**
+ * Whether this provider's CURRENT credential is out of quota. Auto-heals the
+ * same two ways as an auth mark (a changed credential, a clean turn) plus a
+ * third the provider itself names: the reset instant passing.
+ */
+export function quotaExhaustedActive(
+  id: string,
+  fingerprint?: string,
+): boolean {
+  const marks = readProviderMarks();
+  const mark = markFor(id);
+  const marked = marks.quotaExhausted.get(mark);
+  if (marked === undefined) return false;
+  const stale =
+    marked.expiresAt <= Date.now() ||
+    marked.fingerprint !== (fingerprint ?? credentialFingerprint(id));
+  if (stale) {
+    marks.quotaExhausted.delete(mark);
+    writeProviderMarks(marks);
+    return false;
+  }
+  return true;
+}
+
+/** Tests only: forget every mark, in memory and on disk. */
 export function resetAuthFailures(): void {
-  failed.clear();
+  forgetProviderMarks();
 }

--- a/packages/runtime/src/auth/provider-marks.ts
+++ b/packages/runtime/src/auth/provider-marks.ts
@@ -1,0 +1,121 @@
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { config } from "../config";
+
+/**
+ * Disk backing for the turn-time provider marks (credential-health.ts): which
+ * credential failed authentication, and which one ran out of quota.
+ *
+ * The marks are DERIVED state, not credential material — each one is a
+ * fingerprint (a sha256 of the stored credential) plus an expiry, never a
+ * token. They are persisted because a pod restart would otherwise report a
+ * dead token as Connected until the next failing turn (PRODUCT-1475), and a
+ * routine firing in that window fails with a lie on screen.
+ *
+ * Persisting "broken" state is only safe because every mark carries the
+ * fingerprint of the credential it was recorded against: a re-login, a pasted
+ * key, a fresh served token or an endpoint change all move the fingerprint, so
+ * a loaded mark auto-heals the moment the credential differs. No out-of-band
+ * fix can be wedged off by a stale file.
+ */
+
+/** A quota mark: the credential it applies to, and when it lapses (epoch ms). */
+export interface QuotaMark {
+  fingerprint: string;
+  expiresAt: number;
+}
+
+export interface ProviderMarks {
+  /** `${scopeKey}:${provider}` → fingerprint of the credential that failed auth. */
+  authFailed: Map<string, string>;
+  /** `${scopeKey}:${provider}` → the account's exhausted-quota mark. */
+  quotaExhausted: Map<string, QuotaMark>;
+}
+
+interface MarksFile {
+  authFailed?: Record<string, unknown>;
+  quotaExhausted?: Record<string, unknown>;
+}
+
+const MARKS_FILE = "provider-marks.json";
+
+// Keyed by the resolved path, not loaded once per process: tests (and the
+// per-turn layout) repoint `config.dataDir`, and a path change must re-read.
+let cached: { path: string; marks: ProviderMarks } | null = null;
+
+function marksPath(): string {
+  return join(config.dataDir, MARKS_FILE);
+}
+
+function parseMarks(raw: string): ProviderMarks {
+  const parsed = JSON.parse(raw) as MarksFile;
+  const authFailed = new Map<string, string>();
+  for (const [key, value] of Object.entries(parsed.authFailed ?? {})) {
+    if (typeof value === "string") authFailed.set(key, value);
+  }
+  const quotaExhausted = new Map<string, QuotaMark>();
+  for (const [key, value] of Object.entries(parsed.quotaExhausted ?? {})) {
+    const mark = value as Partial<QuotaMark> | null;
+    if (
+      typeof mark?.fingerprint === "string" &&
+      typeof mark.expiresAt === "number"
+    )
+      quotaExhausted.set(key, {
+        fingerprint: mark.fingerprint,
+        expiresAt: mark.expiresAt,
+      });
+  }
+  return { authFailed, quotaExhausted };
+}
+
+/** The marks on disk, loaded once per data dir. Missing or garbled → empty. */
+export function readProviderMarks(): ProviderMarks {
+  const path = marksPath();
+  if (cached?.path === path) return cached.marks;
+  let marks: ProviderMarks = {
+    authFailed: new Map(),
+    quotaExhausted: new Map(),
+  };
+  try {
+    marks = parseMarks(readFileSync(path, "utf8"));
+  } catch {
+    // Absent on first run; garbled means a half-written file from a killed
+    // process. Both mean "nothing is known" — the next turn re-learns it.
+  }
+  cached = { path, marks };
+  return marks;
+}
+
+/** Write the in-memory marks through to disk. */
+export function writeProviderMarks(marks: ProviderMarks): void {
+  const path = marksPath();
+  cached = { path, marks };
+  const body = JSON.stringify({
+    authFailed: Object.fromEntries(marks.authFailed),
+    quotaExhausted: Object.fromEntries(marks.quotaExhausted),
+  });
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, body);
+    renameSync(tmp, path);
+  } catch (err) {
+    // The mark still holds in memory for this process, so status stays honest
+    // until a restart; a read-only/full data dir must not break the turn that
+    // was classifying an error when it happened.
+    console.error("[provider-marks] could not persist provider marks:", err);
+  }
+}
+
+/** Tests only: forget every mark, in memory and on disk. */
+export function forgetProviderMarks(): void {
+  const path = marksPath();
+  cached = null;
+  rmSync(path, { force: true });
+}

--- a/packages/runtime/src/backends/claude/errors.ts
+++ b/packages/runtime/src/backends/claude/errors.ts
@@ -6,7 +6,10 @@ import {
   stampCredentialScope,
 } from "../../ai/provider-error";
 import { logProviderError } from "../../ai/provider-error-log";
-import { noteAuthFailure } from "../../auth/credential-health";
+import {
+  noteAuthFailure,
+  noteQuotaExhausted,
+} from "../../auth/credential-health";
 import { reportRevokedServedToken } from "../../auth/report-revoked";
 
 /** The pi provider id this backend runs as — every error is attributed to it. */
@@ -75,6 +78,10 @@ export function mapSdkError(
       // A REVOKED served token is invisible to the control plane (HOU-952).
       reportRevokedServedToken(mapped, ctx.usedAccessDigest);
     }
+    // An exhausted account is a VALID credential with nothing left — marked
+    // separately so status says "out of credits", not "reconnect".
+    if (mapped.kind === "quota_exhausted")
+      noteQuotaExhausted(mapped.provider, mapped.resets_at);
   }
   return mapped ?? classifyText(message, model, status, ctx.usedAccessDigest);
 }
@@ -181,6 +188,8 @@ export function classifyText(
     // (PRODUCT-1307). The reporter's own gates keep this safe.
     reportRevokedServedToken(classified, usedAccessDigest);
   }
+  if (classified.kind === "quota_exhausted")
+    noteQuotaExhausted(classified.provider, classified.resets_at);
   return classified;
 }
 

--- a/packages/runtime/src/backends/pi/wire.ts
+++ b/packages/runtime/src/backends/pi/wire.ts
@@ -8,7 +8,10 @@ import {
 import { classifyProviderError } from "../../ai/provider-error";
 import { logProviderError } from "../../ai/provider-error-log";
 import { canonicalPinProvider } from "../../ai/providers";
-import { noteAuthFailure } from "../../auth/credential-health";
+import {
+  noteAuthFailure,
+  noteQuotaExhausted,
+} from "../../auth/credential-health";
 import { reportRevokedServedToken } from "../../auth/report-revoked";
 import { currentUsedTokenDigest } from "../../auth/used-token";
 
@@ -242,6 +245,15 @@ export function toWire(e: AgentSessionEvent): WireEvent | null {
           reportRevokedServedToken(
             classified,
             currentUsedTokenDigest(classified.provider),
+          );
+        }
+        // The same status-surface feed for an exhausted account: the
+        // credential authenticates fine, so this is "out of credits", never a
+        // reconnect (auth/credential-health.ts).
+        if (classified.kind === "quota_exhausted") {
+          noteQuotaExhausted(
+            canonicalPinProvider(classified.provider),
+            classified.resets_at,
           );
         }
         return { type: "provider_error", data: classified };

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -59,7 +59,12 @@ vi.mock("../ai/providers", async (importOriginal) => {
 vi.mock("../auth/credential-health", async (importOriginal) => {
   const real =
     await importOriginal<typeof import("../auth/credential-health")>();
-  return { ...real, noteAuthFailure: vi.fn(), clearAuthFailure: vi.fn() };
+  return {
+    ...real,
+    noteAuthFailure: vi.fn(),
+    noteQuotaExhausted: vi.fn(),
+    clearProviderMarks: vi.fn(),
+  };
 });
 vi.mock("../auth/report-revoked", () => ({
   reportRevokedServedToken: vi.fn(),

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -20,7 +20,11 @@ import {
   resolveModel,
 } from "../ai/providers";
 import { recordTokenSpend } from "../ai/usage/ledger";
-import { clearAuthFailure, noteAuthFailure } from "../auth/credential-health";
+import {
+  clearProviderMarks,
+  noteAuthFailure,
+  noteQuotaExhausted,
+} from "../auth/credential-health";
 import { reportRevokedServedToken } from "../auth/report-revoked";
 import {
   newUsedTokenCapture,
@@ -626,7 +630,7 @@ export async function execTurn(
       // stale turn-failure mark so status reads connected again
       // (auth/credential-health.ts; covers the macOS Keychain re-login no
       // fingerprint can observe).
-      clearAuthFailure(model.provider);
+      clearProviderMarks(model.provider);
       publish(id, {
         type: "done",
         data: null,
@@ -708,6 +712,14 @@ export async function execTurn(
       // no served token, so there is nothing safe to delete (PRODUCT-1319).
       reportRevokedServedToken(thrown, usedTokens.digestFor(thrown.provider));
     }
+    // Same feed for the OTHER credential-level wall a thrown failure can hit:
+    // the account is out of credits, which is not a reconnect (the credential
+    // is valid) and must not read as Connected either.
+    if (thrown.kind === "quota_exhausted" && !providerError && thrown.provider)
+      noteQuotaExhausted(
+        canonicalPinProvider(thrown.provider),
+        thrown.resets_at,
+      );
     const typed = thrown.kind !== "unknown" ? thrown : undefined;
     thrownTyped = typed;
     appendAssistantMessage(id, assistantText, {

--- a/packages/runtime/src/transport/server-providers-scope.test.ts
+++ b/packages/runtime/src/transport/server-providers-scope.test.ts
@@ -87,6 +87,10 @@ seedScope("u:sub-alice", { openrouter: "sk-alice-openrouter" });
 seedScope("u:sub-bob", { google: "sk-bob-gemini" });
 
 const { config } = await import("../config");
+const { noteAuthFailure, resetAuthFailures } = await import(
+  "../auth/credential-health"
+);
+const { runWithActingContext } = await import("../session/acting-context");
 const { createRuntimeServer } = await import("./server");
 const { resetServedScopes } = await import("../auth/served-scope");
 
@@ -94,6 +98,7 @@ interface ProviderRow {
   id: string;
   configured: boolean;
   credentialScope?: "personal" | "team";
+  health?: string;
 }
 
 function listen(server: Server): Promise<string> {
@@ -147,6 +152,7 @@ function configuredIds(rows: ProviderRow[]): string[] {
 }
 
 afterEach(() => {
+  resetAuthFailures();
   resetServedScopes();
   config.controlPlaneUrl = "";
   config.sandboxToken = "";
@@ -268,4 +274,42 @@ test("GET /providers labels WHOSE credential served each acting identity", async
   } finally {
     globalThis.fetch = realFetch;
   }
+});
+
+test("GET /providers reports WHY each acting identity's provider is (un)usable", async () => {
+  config.controlPlaneUrl = "";
+  config.sandboxToken = "";
+  // Alice's openrouter credential died mid-flight (a rotated refresh token, a
+  // revoked key): the file still holds it, so `configured` alone would keep
+  // saying Connected — which is the lie a routine then fails behind
+  // (PRODUCT-1475). The mark is recorded under HER acting identity.
+  runWithActingContext({ actingAs: ALICE }, () =>
+    noteAuthFailure("openrouter"),
+  );
+
+  await withServer(async (get) => {
+    const alice = await get(ALICE);
+    expect(row(alice, "openrouter")).toMatchObject({
+      configured: false,
+      health: "needs_reconnect",
+    });
+    // Never connected at all is a DIFFERENT remedy, and must read as such.
+    expect(row(alice, "google").health).toBe("not_connected");
+
+    // Bob holds his own, working Gemini key: one member's dead credential says
+    // nothing about another member's.
+    const bob = await get(BOB);
+    expect(row(bob, "google")).toMatchObject({
+      configured: true,
+      health: "connected",
+    });
+    expect(row(bob, "openrouter").health).toBe("not_connected");
+
+    // And the team file is untouched by either member's mark.
+    const team = await get();
+    expect(row(team, "deepseek")).toMatchObject({
+      configured: true,
+      health: "connected",
+    });
+  });
 });

--- a/packages/runtime/src/turn/server.test.ts
+++ b/packages/runtime/src/turn/server.test.ts
@@ -10,7 +10,7 @@ import {
 import { afterAll, beforeAll, expect, test } from "vitest";
 import {
   authFailureActive,
-  clearAuthFailure,
+  clearProviderMarks,
   noteAuthFailure,
   resetAuthFailures,
 } from "../auth/credential-health";
@@ -135,7 +135,7 @@ test("one agent's auth failure survives another agent's clean turn", async () =>
     const acting = currentActingContext();
     actingIdentityLeaked ||= !!(acting?.actingAs || acting?.actingUser);
     if (turn.text === "fail") noteAuthFailure(turn.provider, "dead-token");
-    if (turn.text === "clean") clearAuthFailure(turn.provider);
+    if (turn.text === "clean") clearProviderMarks(turn.provider);
     if (turn.text === "probe") {
       agentAFailureSurvived = authFailureActive(turn.provider, "dead-token");
     }

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -13,7 +13,11 @@ import { DEFAULT_REASONING_EFFORT, toThinkingLevel } from "../ai/effort";
 import { classifyProviderError } from "../ai/provider-error";
 import { logProviderError } from "../ai/provider-error-log";
 import { readAuthFile } from "../auth/auth-file";
-import { clearAuthFailure, noteAuthFailure } from "../auth/credential-health";
+import {
+  clearProviderMarks,
+  noteAuthFailure,
+  noteQuotaExhausted,
+} from "../auth/credential-health";
 import { reportRevokedServedToken } from "../auth/report-revoked";
 import {
   newUsedTokenCapture,
@@ -368,7 +372,7 @@ export async function runPiTurn(
     if (fileChanges) emit({ type: "file_changes", data: fileChanges });
     // A completed turn proves this provider's credential works — heal any
     // stale turn-failure mark (auth/credential-health.ts; mirrors exec-turn).
-    if (!providerError) clearAuthFailure(provider);
+    if (!providerError) clearProviderMarks(provider);
     // Carry the pending question only on a clean turn — never alongside a
     // provider error (mirrors exec-turn: only the clean `done` carries it).
     return providerError ? {} : { pendingInteraction };
@@ -412,6 +416,11 @@ export async function runPiTurn(
         // (PRODUCT-1319).
         reportRevokedServedToken(thrown, usedTokens.digestFor(thrown.provider));
       }
+      // The account ran out of credits: a valid credential with nothing left,
+      // so the status surface must say so instead of "Connected" (mirrors
+      // exec-turn).
+      if (thrown.kind === "quota_exhausted")
+        noteQuotaExhausted(thrown.provider, thrown.resets_at);
       if (thrown.kind !== "unknown") {
         appendAssistantMessageAt(
           conversationsDir,

--- a/packages/web/src/engine-adapter/client/provider-status-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-status-mixin.ts
@@ -1,5 +1,6 @@
 import type {
   CredentialScope,
+  ProviderHealth,
   ProviderStatus,
   ProviderUsage,
 } from "../../../../../ui/engine-client/src/types";
@@ -48,6 +49,7 @@ export function ProviderStatusMixin<TBase extends BaseCtor>(Base: TBase) {
           // and any pre-HOU-976 pod — see the spread below, which keeps the
           // mapped status byte-identical there.
           credentialScope?: CredentialScope;
+          health?: ProviderHealth;
         }
       >();
       // "unauthenticated" is only ever a CONFIRMED answer from the engine. An
@@ -103,6 +105,13 @@ export function ProviderStatusMixin<TBase extends BaseCtor>(Base: TBase) {
           // pod (and every desktop/self-host answer) must map to exactly the
           // object shape the provider-status tests already assert on.
           ...(p?.credentialScope ? { credentialScope: p.credentialScope } : {}),
+          // An engine we never reached says nothing about the credential — the
+          // ENGINE is what's unreachable, which is exactly `"unreachable"`.
+          ...(reachable
+            ? p?.health
+              ? { health: p.health }
+              : {}
+            : { health: "unreachable" as const }),
         } as ProviderStatus;
       });
     }
@@ -128,6 +137,7 @@ export function ProviderStatusMixin<TBase extends BaseCtor>(Base: TBase) {
           installSource: "managed",
           cliPath: null,
           activeModel: status?.activeModel || undefined,
+          ...(status?.health ? { health: status.health } : {}),
         } as ProviderStatus;
       });
     }

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -1312,6 +1312,19 @@ export type ProviderAuthState = "authenticated" | "unauthenticated" | "unknown";
  */
 export type CredentialScope = "personal" | "team";
 
+/**
+ * How usable a provider credential is RIGHT NOW for whoever asked. Mirrors
+ * `ProviderHealth` in `@houston/protocol` (ui/ mirrors wire unions rather than
+ * importing them, same as `CredentialScope` above). Richer than `authState`: a
+ * credential can be authenticated and valid yet unusable (`out_of_credits`).
+ */
+export type ProviderHealth =
+  | "connected"
+  | "not_connected"
+  | "needs_reconnect"
+  | "out_of_credits"
+  | "unreachable";
+
 export interface ProviderStatus {
   provider: string;
   cliInstalled: boolean;
@@ -1335,6 +1348,11 @@ export interface ProviderStatus {
    * pre-HOU-976 surface reads the shape it always read.
    */
   credentialScope?: CredentialScope;
+  /**
+   * Why the provider is (un)usable for the acting identity. Absent from engines
+   * that predate it, so treat absence as "read `authState` as before".
+   */
+  health?: ProviderHealth;
 }
 
 /**

--- a/ui/routines/src/index.ts
+++ b/ui/routines/src/index.ts
@@ -62,6 +62,7 @@ export type {
   RoutineEditPatch,
   RoutineFormData,
   RoutineRun,
+  RoutineRunFailure,
   RoutineTriggerBinding,
   RoutineWake,
   RoutineWakeMode,

--- a/ui/routines/src/routine-row-next-fire.tsx
+++ b/ui/routines/src/routine-row-next-fire.tsx
@@ -1,0 +1,40 @@
+/**
+ * RoutineRowNextFire — the row's compact trailing "in 2h 10m" stamp.
+ *
+ * Its own component because it owns the minute ticker: keeping `useNow` here
+ * means only this span re-renders each minute, not the whole row (and every
+ * chip and menu inside it). It renders nothing for a paused routine or an
+ * event-driven one, which have no next fire to name — the chat header carries
+ * the absolute time and the last-run detail.
+ */
+
+import { DEFAULT_NEXT_FIRE_LABELS, type NextFireLabels } from "./labels";
+import { describeNextFire, nextFire } from "./next-fire";
+import type { Routine } from "./types";
+import { useNow } from "./use-now";
+
+export function RoutineRowNextFire({
+  routine,
+  accountTimezone,
+  labels = DEFAULT_NEXT_FIRE_LABELS,
+  locale = "en-US",
+}: {
+  routine: Routine;
+  /** The account-wide IANA timezone every routine fires in. */
+  accountTimezone: string;
+  labels?: NextFireLabels;
+  /** BCP-47 locale for day names + time formatting. */
+  locale?: string;
+}) {
+  const now = useNow(60_000);
+  const next =
+    routine.enabled && routine.schedule
+      ? nextFire(routine.schedule, accountTimezone, now)
+      : null;
+  if (!next) return null;
+  return (
+    <span className="hidden whitespace-nowrap text-xs tabular-nums text-ink-muted sm:inline">
+      {describeNextFire(next, accountTimezone, now, labels, locale).relative}
+    </span>
+  );
+}

--- a/ui/routines/src/routine-row-open-intent.ts
+++ b/ui/routines/src/routine-row-open-intent.ts
@@ -1,0 +1,33 @@
+/**
+ * When a click or a keypress on a routine row means "open this routine".
+ *
+ * Both answers are subtler than they look, and both were bugs (PRODUCT-1208),
+ * so they live here as pure predicates the row calls — testable without a DOM
+ * event, and impossible to re-inline by accident.
+ */
+
+/**
+ * A click is an open intent only when its target sits physically INSIDE the
+ * row. Clicks bubbling from PORTALED children — the kebab menu's items, the
+ * delete confirm dialog's buttons — reach the row's handler through the REACT
+ * tree while their DOM node sits under `document.body`. Opening on those turned
+ * "Run now", and cancelling a delete, into a navigation.
+ */
+export function clickOpensRow(row: Node, target: EventTarget | null): boolean {
+  // `Node.contains(null)` is defined as false, so a missing target needs no
+  // special case (and no `instanceof Node`, which assumes a DOM global).
+  return row.contains(target as Node | null);
+}
+
+/**
+ * Only the row ITSELF opens on Enter/Space. Key events from a focused inner
+ * control (the enable switch, the kebab) bubble to the same handler but carry a
+ * different target, and pressing Space on a switch must toggle it, not navigate.
+ */
+export function keyOpensRow(
+  key: string,
+  target: EventTarget | null,
+  row: EventTarget,
+): boolean {
+  return target === row && (key === "Enter" || key === " ");
+}

--- a/ui/routines/src/routine-row-title.tsx
+++ b/ui/routines/src/routine-row-title.tsx
@@ -6,16 +6,24 @@
  * routine is this" is as load-bearing there as what the routine is called. So
  * the name truncates and the chip never does. A single-agent list passes no
  * chip and the line is exactly the paragraph it always was.
+ *
+ * A second, rarer chip rides the same line: a WARNING the surface supplies when
+ * this routine cannot run as configured (its AI account is disconnected or out
+ * of credits). It sits after the owner chip and, like it, never truncates —
+ * a warning that gets cut off is not a warning.
  */
 import type { ReactNode } from "react";
 
 export function RoutineRowTitle({
   name,
   ownerChip,
+  warningChip,
 }: {
   name: string;
   /** The owning agent's chip, for a list that spans several agents. */
   ownerChip?: ReactNode;
+  /** Surface-supplied warning that this routine cannot run as configured. */
+  warningChip?: ReactNode;
 }) {
   return (
     <div className="flex min-w-0 items-center gap-1.5">
@@ -23,6 +31,7 @@ export function RoutineRowTitle({
         {name}
       </p>
       {ownerChip && <span className="shrink-0">{ownerChip}</span>}
+      {warningChip && <span className="shrink-0">{warningChip}</span>}
     </div>
   );
 }

--- a/ui/routines/src/routine-row.tsx
+++ b/ui/routines/src/routine-row.tsx
@@ -5,12 +5,13 @@
  * row is the way into it. The whole row is the click target (a `role="option"`
  * element that opens the chat on click/Enter/Space and carries an unmistakable
  * selected state), rhyming with the Activity list rows. Interactive controls
- * (the switch, the kebab, the inline schedule pencil, a trigger's Reconnect)
- * stop click/keydown from bubbling so operating them never opens the chat.
+ * (the switch, the kebab, the schedule pencil, a trigger's Reconnect) stop
+ * click/keydown from bubbling; the two remaining open-intent judgements live in
+ * `./routine-row-open-intent`.
  *
  * One aligned grid per row: the identity icon (`RoutineRowStatus`) | the title
- * (`RoutineRowTitle`) over ONE muted summary line (`RoutineRowSummary`, never a
- * third) | a compact trailing slot (the next-run time, the switch, the kebab).
+ * (`RoutineRowTitle`) over ONE muted summary line (`RoutineRowSummary`) | a
+ * compact trailing slot (next-run time, the switch, the kebab).
  */
 import { cn } from "@houston-ai/core";
 import type { ReactNode } from "react";
@@ -26,13 +27,13 @@ import {
   type ScheduleSummaryLabels,
   type TriggerLabels,
 } from "./labels";
-import { describeNextFire, nextFire } from "./next-fire";
 import { RoutineRowControls } from "./routine-row-controls";
+import { RoutineRowNextFire } from "./routine-row-next-fire";
+import { clickOpensRow, keyOpensRow } from "./routine-row-open-intent";
 import { RoutineRowStatus } from "./routine-row-status";
 import { RoutineRowSummary } from "./routine-row-summary";
 import { RoutineRowTitle } from "./routine-row-title";
 import type { Routine, RoutineRun, TriggerStatusItem } from "./types";
-import { useNow } from "./use-now";
 
 export interface RoutineRowProps {
   routine: Routine;
@@ -56,6 +57,9 @@ export interface RoutineRowProps {
   leadingIcon?: (routine: Routine) => ReactNode;
   /** OWNER chip beside the name, for a cross-agent list (see RoutineRowTitle). */
   ownerChip?: ReactNode;
+  /** WARNING chip beside the name: the surface says this routine cannot run as
+   *  configured (e.g. its AI account is disconnected). Omit for none. */
+  warningChip?: ReactNode;
   /** Edit a schedule routine's cron inline. Supplied + a schedule present turns
    *  the summary line into an always-visible edit affordance. */
   onScheduleChange?: (routineId: string, cron: string) => void;
@@ -90,6 +94,7 @@ export function RoutineRow({
   onStopRun,
   leadingIcon,
   ownerChip,
+  warningChip,
   onScheduleChange,
   labels = DEFAULT_ROW_LABELS,
   scheduleLabels = DEFAULT_SCHEDULE_LABELS,
@@ -101,24 +106,12 @@ export function RoutineRow({
   onReconnectTrigger,
   locale = "en-US",
 }: RoutineRowProps) {
-  const now = useNow(60_000);
   const isRunning = lastRun?.status === "running";
   const isPaused = isRunning && !!lastRun?.paused_until;
   const identityIcon = leadingIcon?.(routine);
   // Offer exactly one run control: Stop while running, else Run now.
   const runNow = isRunning ? undefined : onRunNow;
   const stopRun = isRunning ? onStopRun : undefined;
-
-  // The compact trailing next-run time is the pure relative string; the chat
-  // header carries the absolute time and last-run detail.
-  const next =
-    routine.enabled && routine.schedule
-      ? nextFire(routine.schedule, accountTimezone, now)
-      : null;
-  const nextRelative = next
-    ? describeNextFire(next, accountTimezone, now, nextFireLabels, locale)
-        .relative
-    : null;
 
   return (
     <div
@@ -128,22 +121,10 @@ export function RoutineRow({
       aria-label={onOpenChat ? labels.openChat : undefined}
       tabIndex={onOpenChat ? 0 : undefined}
       onClick={(e) => {
-        // Clicks bubbling from PORTALED children (the kebab menu's items, the
-        // delete confirm dialog's buttons) reach this handler through the
-        // REACT tree while their DOM target sits under document.body. Opening
-        // on those turned "Run now" — and cancelling a delete — into a
-        // navigation (PRODUCT-1208). Only a click physically inside the row
-        // is an open intent.
-        if (e.currentTarget.contains(e.target as Node)) onOpenChat?.();
+        if (clickOpensRow(e.currentTarget, e.target)) onOpenChat?.();
       }}
       onKeyDown={(e) => {
-        // Only the row itself opens the chat on Enter/Space; key events from a
-        // focused inner control bubble here but carry a different target.
-        if (
-          onOpenChat &&
-          e.target === e.currentTarget &&
-          (e.key === "Enter" || e.key === " ")
-        ) {
+        if (onOpenChat && keyOpensRow(e.key, e.target, e.currentTarget)) {
           e.preventDefault();
           onOpenChat();
         }
@@ -170,6 +151,7 @@ export function RoutineRow({
         <RoutineRowTitle
           name={routine.name || labels.untitled}
           ownerChip={ownerChip}
+          warningChip={warningChip}
         />
         <RoutineRowSummary
           routine={routine}
@@ -187,11 +169,12 @@ export function RoutineRow({
       </div>
 
       <div className="flex shrink-0 items-center gap-1">
-        {nextRelative && (
-          <span className="hidden whitespace-nowrap text-xs tabular-nums text-ink-muted sm:inline">
-            {nextRelative}
-          </span>
-        )}
+        <RoutineRowNextFire
+          routine={routine}
+          accountTimezone={accountTimezone}
+          labels={nextFireLabels}
+          locale={locale}
+        />
         <RoutineRowControls
           name={routine.name || labels.untitled}
           enabled={routine.enabled}

--- a/ui/routines/src/routine-run-list.tsx
+++ b/ui/routines/src/routine-run-list.tsx
@@ -22,6 +22,14 @@ export interface RoutineRunListProps {
   onOpenRun?: (run: RoutineRun) => void;
   /** BCP-47 locale for the start-time stamps. */
   locale?: string;
+  /**
+   * Overrides a run's second line. The stored `run.summary` is the agent's own
+   * words, but a run that never reached the agent (its AI account was
+   * disconnected, or out of credits) carries a typed failure instead — and
+   * naming a provider in the user's language is app work, not `ui/` work. Return
+   * `undefined` to keep `run.summary`.
+   */
+  summaryFor?: (run: RoutineRun) => string | undefined;
   labels?: Partial<RoutineRunListLabels>;
 }
 
@@ -41,6 +49,7 @@ export function RoutineRunList({
   runs,
   onOpenRun,
   locale,
+  summaryFor,
   labels,
 }: RoutineRunListProps) {
   const l = { ...DEFAULT_RUN_LIST_LABELS, ...labels };
@@ -56,6 +65,7 @@ export function RoutineRunList({
         const { Icon, className } = STATUS_GLYPH[run.status];
         const duration = formatRunDuration(run);
         const started = formatRunStart(run.started_at, locale);
+        const summary = summaryFor?.(run) ?? run.summary;
         const body = (
           <>
             <Icon
@@ -73,9 +83,9 @@ export function RoutineRunList({
                   {duration && <> · {duration}</>}
                 </span>
               </span>
-              {run.summary && (
+              {summary && (
                 <span className="mt-0.5 line-clamp-2 text-left text-xs text-ink-muted">
-                  {run.summary}
+                  {summary}
                 </span>
               )}
             </span>

--- a/ui/routines/src/routines-grid-list.tsx
+++ b/ui/routines/src/routines-grid-list.tsx
@@ -37,6 +37,7 @@ export function RoutinesGridList({
   leadingIcon,
   ownerChip,
   draftOwnerChip,
+  warningChip,
   onScheduleChange,
   labels = DEFAULT_GRID_LABELS,
   rowLabels = DEFAULT_ROW_LABELS,
@@ -60,6 +61,7 @@ export function RoutinesGridList({
         selected={selectedRoutineId === routine.id}
         leadingIcon={leadingIcon}
         ownerChip={ownerChip?.(routine)}
+        warningChip={warningChip?.(routine)}
         onScheduleChange={onScheduleChange}
         onOpenChat={onOpenChat ? () => onOpenChat(routine.id) : undefined}
         onToggle={

--- a/ui/routines/src/routines-grid.tsx
+++ b/ui/routines/src/routines-grid.tsx
@@ -66,6 +66,11 @@ export interface RoutinesGridProps {
   /** The same slot for a DRAFT row. Separate from `ownerChip` because a draft
    *  is not a routine and has none of its fields — only its own id. */
   draftOwnerChip?: (draft: RoutineDraft) => ReactNode;
+  /** Per-row WARNING chip: the app returns a node when this routine cannot run
+   *  as configured (its AI account is disconnected, needs reconnecting, or is
+   *  out of credits) and `null`/`undefined` otherwise. `ui/` cannot know any of
+   *  that — it owns no provider state — so the whole judgement is the app's. */
+  warningChip?: (routine: Routine) => ReactNode;
   /** Edit a schedule routine's cron inline. When supplied, a schedule routine's
    *  summary line becomes an always-visible edit affordance (popover builder). */
   onScheduleChange?: (routineId: string, cron: string) => void;

--- a/ui/routines/src/trigger-types.ts
+++ b/ui/routines/src/trigger-types.ts
@@ -1,0 +1,66 @@
+/**
+ * The EVENT side of a routine (C9): how a routine wakes when it is not on a
+ * cron, and the live health of that wake binding. Split from `./types` — which
+ * mirrors the routine record itself — because the two answer different
+ * questions and together they outgrew one file.
+ *
+ * Like every type in this package these MIRROR the engine-client wire shapes
+ * rather than importing them, so `ui/` stays free of app/engine imports.
+ * Re-exported from `./types` so existing import paths are unchanged.
+ */
+
+import type { RoutineTriggerBinding } from "./types";
+/**
+ * How a routine wakes: on a cron `schedule`, or when an external `event`
+ * happens (a Composio trigger). The routine editor's segmented choice toggles
+ * between the two; exactly one is active per routine.
+ */
+export type RoutineWakeMode = "schedule" | "event";
+
+/** The wake mechanism the editor commits on save (discriminated on `mode`). */
+export type RoutineWake =
+  | { mode: "schedule"; schedule: string }
+  | { mode: "event"; trigger: RoutineTriggerBinding };
+
+/**
+ * A trigger routine's live provisioning status. `active` = delivering;
+ * `pending` = reconcile in flight; `paused_disconnected` = the connected account
+ * was disconnected (offer Reconnect); `paused_revoked` = the toolkit fell outside
+ * the agent's access; `error` = Composio rejected creation or delivery is failing.
+ */
+export type TriggerStatusState =
+  | "active"
+  | "pending"
+  | "paused_disconnected"
+  | "paused_revoked"
+  | "error";
+
+/** One routine's trigger status. */
+export interface TriggerStatusItem {
+  routine_id: string;
+  status: TriggerStatusState;
+  detail?: string;
+}
+
+/** A connectable account for a toolkit, offered when the user has more than one. */
+export interface TriggerAppAccount {
+  id: string;
+  label: string;
+}
+
+/** An app the agent can build an event trigger on (connected + allowed). */
+export interface TriggerApp {
+  toolkit: string;
+  name: string;
+  logoUrl?: string;
+  /** Active connected accounts for this toolkit; a select shows when >1. */
+  accounts: TriggerAppAccount[];
+}
+
+/** A composed "create/update a routine" input: a name, a prompt, and the wake
+ *  mechanism the app-owned stepper collected (a cron schedule or an event). */
+export interface RoutineEditPatch {
+  name: string;
+  prompt: string;
+  wake: RoutineWake;
+}

--- a/ui/routines/src/types.ts
+++ b/ui/routines/src/types.ts
@@ -85,6 +85,24 @@ export type RunStatus =
   | "error"
   | "cancelled";
 
+/**
+ * Why a run failed before the agent ever ran (PRODUCT-1475): the AI account it
+ * was going to use is unusable. Mirrors the engine-client wire union rather
+ * than importing it, the same way the trigger bindings above do, so `ui/` stays
+ * free of app/engine imports. `provider` is a bare id — naming it in the user's
+ * language is the app's job.
+ */
+export interface RoutineRunFailure {
+  code:
+    | "creator_not_connected"
+    | "team_not_connected"
+    | "creator_needs_reconnect"
+    | "team_needs_reconnect"
+    | "out_of_credits";
+  /** Provider id, e.g. `"anthropic"`. */
+  provider: string;
+}
+
 export interface RoutineRun {
   id: string;
   routine_id: string;
@@ -101,6 +119,9 @@ export interface RoutineRun {
    *  provider CLI is sleeping on a plan-window usage limit. Only meaningful
    *  while `status === "running"`. */
   paused_until?: string;
+  /** Typed reason an `error` run never reached the agent. Absent for every
+   *  other failure, whose story is in `summary`. */
+  failure?: RoutineRunFailure;
 }
 
 /**
@@ -143,59 +164,14 @@ export const SCHEDULE_PRESET_LABELS: Record<SchedulePreset, string> = {
   custom: "Custom",
 };
 
-// ── Triggers (C9 event-driven routines) ──────────────────────────────────────
-
-/**
- * How a routine wakes: on a cron `schedule`, or when an external `event`
- * happens (a Composio trigger). The routine editor's segmented choice toggles
- * between the two; exactly one is active per routine.
- */
-export type RoutineWakeMode = "schedule" | "event";
-
-/** The wake mechanism the editor commits on save (discriminated on `mode`). */
-export type RoutineWake =
-  | { mode: "schedule"; schedule: string }
-  | { mode: "event"; trigger: RoutineTriggerBinding };
-
-/**
- * A trigger routine's live provisioning status. `active` = delivering;
- * `pending` = reconcile in flight; `paused_disconnected` = the connected account
- * was disconnected (offer Reconnect); `paused_revoked` = the toolkit fell outside
- * the agent's access; `error` = Composio rejected creation or delivery is failing.
- */
-export type TriggerStatusState =
-  | "active"
-  | "pending"
-  | "paused_disconnected"
-  | "paused_revoked"
-  | "error";
-
-/** One routine's trigger status. */
-export interface TriggerStatusItem {
-  routine_id: string;
-  status: TriggerStatusState;
-  detail?: string;
-}
-
-/** A connectable account for a toolkit, offered when the user has more than one. */
-export interface TriggerAppAccount {
-  id: string;
-  label: string;
-}
-
-/** An app the agent can build an event trigger on (connected + allowed). */
-export interface TriggerApp {
-  toolkit: string;
-  name: string;
-  logoUrl?: string;
-  /** Active connected accounts for this toolkit; a select shows when >1. */
-  accounts: TriggerAppAccount[];
-}
-
-/** A composed "create/update a routine" input: a name, a prompt, and the wake
- *  mechanism the app-owned stepper collected (a cron schedule or an event). */
-export interface RoutineEditPatch {
-  name: string;
-  prompt: string;
-  wake: RoutineWake;
-}
+// The EVENT side of a routine lives one file over; re-exported here so every
+// existing `./types` import keeps working.
+export type {
+  RoutineEditPatch,
+  RoutineWake,
+  RoutineWakeMode,
+  TriggerApp,
+  TriggerAppAccount,
+  TriggerStatusItem,
+  TriggerStatusState,
+} from "./trigger-types";

--- a/ui/routines/tests/routine-row-open-intent.test.ts
+++ b/ui/routines/tests/routine-row-open-intent.test.ts
@@ -1,0 +1,55 @@
+import { strictEqual } from "node:assert/strict";
+import { describe, it } from "node:test";
+import { clickOpensRow, keyOpensRow } from "../src/routine-row-open-intent.ts";
+
+/**
+ * PRODUCT-1208 — the row is the click target, and twice that swallowed an
+ * action the user meant instead. These pin both judgements without a DOM.
+ */
+
+/** Minimal stand-in for the row element: only `contains` is consulted, with
+ *  the DOM's own `contains(null) === false` rule. */
+function row(children: object[]) {
+  return {
+    contains: (node: unknown) =>
+      node !== null && children.includes(node as object),
+  } as unknown as Node;
+}
+
+describe("clickOpensRow", () => {
+  it("opens on a click inside the row", () => {
+    const inner = {} as EventTarget;
+    strictEqual(clickOpensRow(row([inner]), inner), true);
+  });
+
+  it("ignores a click from a PORTALED child (kebab item, confirm dialog)", () => {
+    // Reaches the handler through the React tree; its DOM node lives under
+    // document.body, so the row does not contain it.
+    const portaled = {} as EventTarget;
+    strictEqual(clickOpensRow(row([]), portaled), false);
+  });
+
+  it("ignores a missing target", () => {
+    strictEqual(clickOpensRow(row([]), null), false);
+  });
+});
+
+describe("keyOpensRow", () => {
+  const self = {} as EventTarget;
+  const control = {} as EventTarget;
+
+  it("opens on Enter and Space from the row itself", () => {
+    strictEqual(keyOpensRow("Enter", self, self), true);
+    strictEqual(keyOpensRow(" ", self, self), true);
+  });
+
+  it("ignores every other key", () => {
+    strictEqual(keyOpensRow("Escape", self, self), false);
+    strictEqual(keyOpensRow("a", self, self), false);
+  });
+
+  it("ignores Space from a focused inner control (it toggles the switch)", () => {
+    strictEqual(keyOpensRow(" ", control, self), false);
+    strictEqual(keyOpensRow("Enter", control, self), false);
+  });
+});


### PR DESCRIPTION
## Summary

PRODUCT-1475. In a team space, routines fire on the creator's credential scope but the routine editor only showed the opaque label "Agent's model" and no connection state, so the user learned the provider was unusable only when the run errored "No provider connected".

**Root cause.** Three gaps: (1) the routine screen never resolved which provider/model would actually run; (2) `/providers` exposed only a shape-based `configured` boolean, and the turn-time auth-failure mark behind it was in-memory per pod, so a restarted pod reported a dead token as Connected; (3) a failed run persisted the raw provider message, which reads as a lie to a reader whose own account is connected.

The creator-credential fire path itself (`POST /agents/:id/routine-fires` with a minted acting-as token, forwarded as `x-houston-acting-as`) already exists in the host; it is unchanged here.

**Changes**

- `packages/runtime`: `/providers` rows gain `health: connected | not_connected | needs_reconnect | out_of_credits | unreachable`, computed for the acting credential scope. Auth-failure marks and a new exhausted-quota mark (expires at the provider's `resets_at`, else 60 min) are persisted to `<dataDir>/provider-marks.json`; every mark carries the credential fingerprint so any credential change still auto-heals. `clearAuthFailure` → `clearProviderMarks`.
- `packages/protocol` / `packages/host`: `RoutineRun.failure?: { code, provider }` (`creator_not_connected`, `team_not_connected`, `creator_needs_reconnect`, `team_needs_reconnect`, `out_of_credits`); reconcile and the fire path record it with an honest summary naming the provider.
- `ui/engine-client`, web adapter, `app/src/lib/tauri.ts`: `health` carried through to `ProviderStatus`.
- `app`: routine Model row shows the resolved pair ("Claude · Opus 5") with a "Follows the agent's model" hint when unpinned; a health badge for the viewer's own routines (the viewer's `/providers` answer is only evidence for routines they created; a teammate's routine gets "Runs on the creator's connected account" instead) with an inline "Connect X" that reuses the existing connect routing; routines list rows carry a compact warning chip; run history renders the typed failure. en/es/pt updated.
- `ui/routines`: props-only `warningChip` slot + `summaryFor` on the run list; oversized files split. Inventory v69.

## Before / after

**Before (reproduce):**
1. In a team space, as member A with no Claude connected, create a routine (or disconnect Claude after creating one).
2. Open the routine: the Model row reads "Agent's model"; nothing indicates a provider or its state.
3. Wait for the fire (or Run now): the run errors with "No provider connected for anthropic"; the AI hub may still show Claude connected for the team.

**After (verify):**
1. Open the same routine: Model row reads e.g. "Claude · Opus 5", hint "Follows the agent's model", badge "Not connected" and a "Connect Claude" button; the routines list row carries a "Not connected" chip.
2. Disconnect/reconnect Claude: badge flips within one `ProviderLoginComplete` invalidation, before any run.
3. Open the routine as member B (not the creator): no badge; "Runs on the creator's connected account".
4. Let a run fail on a missing credential: run history shows "The routine's creator has no Claude account connected." and the run row has `failure.code = creator_not_connected`.
5. `GET /providers` on the engine now includes `health` per row; after an `unauthenticated` turn it reports `needs_reconnect` for that identity only, and still does after an engine restart until the credential changes or a turn succeeds.

## Tests / gates
- runtime: credential-health (quota mark, TTL, persistence across module reload, garbled file), `/providers` health per acting identity
- host: reconcile mapping for every failure code, pinned vs unpinned `no_provider` fire
- app: `routine-provider-health` (17 cases), `model-labels`; ui/routines row open-intent
- `pnpm check`, `check:boundaries`, host/runtime/domain vitest, `app tsgo` + `app test` (3744) + `check-locales`, `pnpm typecheck`, houston-web typecheck, `check:parity`: all green

## Out of scope
Cloud side: signing the creator acting-as token when dispatching (already done in the CP dispatcher), pausing a routine when the creator leaves the org, and the forced-update churn from PRODUCT-1453.