### PR TITLE
feat(runtime): pool turn terminal frame names the families it changed (PRODUCT-1471)

### DIFF
--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -18,6 +18,7 @@ import { opTranscriptMirror } from "./op-transcript";
 import { parseOpRequest } from "./parse-op-request";
 import type { TurnServerDeps } from "./server-types";
 import { publish } from "./turn-activity-doc";
+import { announcedOpEvents } from "./turn-changed-events";
 import { prepareTurnFilesystem, type TurnFilesystem } from "./turn-filesystem";
 import { poolIdentity, resolveTurnStore } from "./turn-store";
 
@@ -126,6 +127,7 @@ export async function executeOp(
     await heartbeat.checkpoint();
     if (heartbeat.fenced) return json(res, 409, { error: "claim_fenced" });
     const isRead = op.op.kind === "route" && op.op.method === "GET";
+    let announce: ReturnType<typeof announcedOpEvents> = [];
     if (!isRead) {
       const synced = await syncBack(
         resolved.store,
@@ -187,6 +189,7 @@ export async function executeOp(
             `[op] projection failed after a durable sync (asleep reads may lag until the next projection): ${failures.join("; ")} prefix=${resolved.prefix}`,
           );
         }
+        announce = announcedOpEvents(result.events, failures);
       }
     }
     json(res, 200, {
@@ -196,7 +199,7 @@ export async function executeOp(
       body: result.body,
       ...(result.bodyBase64 ? { bodyBase64: result.bodyBase64 } : {}),
       ...(result.headers ? { headers: result.headers } : {}),
-      events: result.events.map((e) => e.type),
+      events: announce,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -240,6 +240,7 @@ export async function executeTurn(
           durable.poolWritesOutOfScope,
           durable.transcriptSkipped,
           durable.activityDocSkipped,
+          durable.changed,
         ),
       );
       await turnLog?.flush();

--- a/packages/runtime/src/turn/turn-changed-events.test.ts
+++ b/packages/runtime/src/turn/turn-changed-events.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { changedEventTypes } from "./turn-changed-events";
+import { announcedOpEvents, changedEventTypes } from "./turn-changed-events";
 
 const layout = {
   workspaceRel: "workspaces/Houston/Agent",
@@ -52,6 +52,32 @@ describe("changedEventTypes", () => {
         "workspaces/Houston/Agent/.houston/activity/activity.schema.json",
         "workspaces/Houston/Other/.houston/activity/activity.json",
       ]),
+    ).toEqual([]);
+  });
+});
+
+describe("announcedOpEvents", () => {
+  it("announces the handler's agent events once, sorted", () => {
+    expect(
+      announcedOpEvents(
+        [
+          { type: "RoutinesChanged", agentPath: "a" },
+          { type: "ActivityChanged", agentPath: "a" },
+          { type: "RoutinesChanged", agentPath: "a" },
+          { type: "Toast", level: "info", message: "x" },
+        ],
+        [],
+      ),
+    ).toEqual(["ActivityChanged", "RoutinesChanged"]);
+  });
+
+  it("announces nothing when a projection failed", () => {
+    // Other tabs would refetch a doc that lagged: the read falls to the pod.
+    expect(
+      announcedOpEvents(
+        [{ type: "RoutinesChanged", agentPath: "a" }],
+        ["routines: PUT rejected (503)"],
+      ),
     ).toEqual([]);
   });
 });

--- a/packages/runtime/src/turn/turn-changed-events.test.ts
+++ b/packages/runtime/src/turn/turn-changed-events.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { changedEventTypes } from "./turn-changed-events";
+
+const layout = {
+  workspaceRel: "workspaces/Houston/Agent",
+  dataRel: "workspaces/Houston/Agent/.houston/runtime",
+};
+
+describe("changedEventTypes", () => {
+  it("maps family docs to their domain events", () => {
+    expect(
+      changedEventTypes(layout, [
+        "workspaces/Houston/Agent/.houston/activity/activity.json",
+        "workspaces/Houston/Agent/.houston/routine_runs/routine_runs.json",
+        "workspaces/Houston/Agent/.houston/routines/routines.json",
+        "workspaces/Houston/Agent/.houston/config/config.json",
+        "workspaces/Houston/Agent/.houston/learnings/learnings.json",
+      ]),
+    ).toEqual([
+      "ActivityChanged",
+      "ConfigChanged",
+      "LearningsChanged",
+      "RoutineRunsChanged",
+      "RoutinesChanged",
+    ]);
+  });
+
+  it("maps conversation, file and skill writes; ignores sessions", () => {
+    expect(
+      changedEventTypes(layout, [
+        "workspaces/Houston/Agent/.houston/runtime/sessions/c1/log.jsonl",
+        "workspaces/Houston/Agent/.houston/runtime/conversations/c1.json",
+        "workspaces/Houston/Agent/files/report.md",
+        "workspaces/Houston/Agent/.agents/skills/foo/SKILL.md",
+      ]),
+    ).toEqual(["ConversationsChanged", "FilesChanged", "SkillsChanged"]);
+  });
+
+  it("dedupes and sorts", () => {
+    expect(
+      changedEventTypes(layout, [
+        "workspaces/Houston/Agent/.houston/runtime/conversations/c1.json",
+        "workspaces/Houston/Agent/.houston/activity/activity.json",
+        "workspaces/Houston/Agent/.houston/runtime/conversations/c2.json",
+      ]),
+    ).toEqual(["ActivityChanged", "ConversationsChanged"]);
+  });
+
+  it("does not match a schema file or a sibling agent's doc", () => {
+    expect(
+      changedEventTypes(layout, [
+        "workspaces/Houston/Agent/.houston/activity/activity.schema.json",
+        "workspaces/Houston/Other/.houston/activity/activity.json",
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/packages/runtime/src/turn/turn-changed-events.ts
+++ b/packages/runtime/src/turn/turn-changed-events.ts
@@ -1,0 +1,43 @@
+import { docKey, FAMILIES, type HoustonFamily } from "@houston/domain";
+import type { HoustonEvent } from "@houston/protocol";
+
+type AgentEventType = Extract<HoustonEvent, { agentPath: string }>["type"];
+
+const FAMILY_EVENT: Record<HoustonFamily, AgentEventType> = {
+  activity: "ActivityChanged",
+  routines: "RoutinesChanged",
+  routine_runs: "RoutineRunsChanged",
+  config: "ConfigChanged",
+  learnings: "LearningsChanged",
+};
+
+/**
+ * The domain events a pool turn's durable writes imply, derived from the
+ * store-relative keys the sync-back landed. A pod emits these from its
+ * handlers; a worker has no event bus, so the written objects ARE the
+ * signal. Keys with no client-visible cache (sessions, runtime state) map to
+ * nothing. Sorted, each type once: the list is a set on the wire.
+ */
+export function changedEventTypes(
+  layout: { workspaceRel: string; dataRel: string },
+  keys: readonly string[],
+): AgentEventType[] {
+  const familyByKey = new Map<string, AgentEventType>(
+    FAMILIES.map((family) => [
+      docKey(layout.workspaceRel, family),
+      FAMILY_EVENT[family],
+    ]),
+  );
+  const conversations = `${layout.dataRel}/conversations/`;
+  const files = `${layout.workspaceRel}/files/`;
+  const skills = `${layout.workspaceRel}/.agents/skills/`;
+  const out = new Set<AgentEventType>();
+  for (const key of keys) {
+    const family = familyByKey.get(key);
+    if (family) out.add(family);
+    else if (key.startsWith(conversations)) out.add("ConversationsChanged");
+    else if (key.startsWith(files)) out.add("FilesChanged");
+    else if (key.startsWith(skills)) out.add("SkillsChanged");
+  }
+  return [...out].sort();
+}

--- a/packages/runtime/src/turn/turn-changed-events.ts
+++ b/packages/runtime/src/turn/turn-changed-events.ts
@@ -46,3 +46,20 @@ export function changedEventTypes(
   }
   return [...out].sort();
 }
+
+/**
+ * What an op reply may announce: the handler's events, but only once every
+ * projection the refetch would read is durable. A lagging doc announced
+ * early sends every member's tab to a read the gateway cannot serve asleep.
+ */
+export function announcedOpEvents(
+  events: readonly HoustonEvent[],
+  projectionFailures: readonly string[],
+): AgentEventType[] {
+  if (projectionFailures.length > 0) return [];
+  const out = new Set<AgentEventType>();
+  for (const event of events) {
+    if ("agentPath" in event) out.add(event.type);
+  }
+  return [...out].sort();
+}

--- a/packages/runtime/src/turn/turn-changed-events.ts
+++ b/packages/runtime/src/turn/turn-changed-events.ts
@@ -17,6 +17,11 @@ const FAMILY_EVENT: Record<HoustonFamily, AgentEventType> = {
  * handlers; a worker has no event bus, so the written objects ARE the
  * signal. Keys with no client-visible cache (sessions, runtime state) map to
  * nothing. Sorted, each type once: the list is a set on the wire.
+ *
+ * A claimed turn's sync-back scope is its conversation, session, activity
+ * and routine-runs objects today (see `claimedTurnIncludes`), so only those
+ * families can fire from a pool turn; the file/skill/doc mappings are what
+ * a widened scope would announce, nothing more.
  */
 export function changedEventTypes(
   layout: { workspaceRel: string; dataRel: string },

--- a/packages/runtime/src/turn/turn-durability.test.ts
+++ b/packages/runtime/src/turn/turn-durability.test.ts
@@ -1,0 +1,97 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { LocalDirStore } from "@houston/runtime-client/object-sync";
+import { expect, test } from "vitest";
+import type { TurnServerDeps } from "./server-types";
+import { finishTurnDurability } from "./turn-durability";
+import { prepareTurnFilesystem } from "./turn-filesystem";
+import type { TurnRequest } from "./types";
+
+async function seed(root: string, rel: string, content: string) {
+  const path = join(root, ...rel.split("/"));
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content);
+}
+
+const dataRel = "workspaces/W/A/.houston/runtime";
+const workspaceRel = "workspaces/W/A";
+
+/** A claimed turn over a seeded standing layout, with the doc store stubbed. */
+async function claimedTurn(docPutStatus: number) {
+  const storeRoot = await mkdtemp(join(tmpdir(), "turn-durability-"));
+  const prefixRoot = join(storeRoot, "ws", "w1", "agent-1");
+  await seed(prefixRoot, `${dataRel}/settings.json`, "{}");
+  await seed(prefixRoot, `${dataRel}/conversations/c1.json`, '{"before":1}');
+  await seed(prefixRoot, `${workspaceRel}/CLAUDE.md`, "# A\n");
+  const store = new LocalDirStore(storeRoot);
+  const root = await mkdtemp(join(tmpdir(), "turn-root-"));
+  const filesystem = await prepareTurnFilesystem({
+    store,
+    prefix: "ws/w1/agent-1",
+    root,
+    claimed: true,
+  });
+  // The turn rewrites its conversation and moves the board.
+  await seed(filesystem.dataDir, "conversations/c1.json", '{"after":1}');
+  await seed(
+    filesystem.workspaceDir,
+    ".houston/activity/activity.json",
+    '[{"id":"a1","title":"Plan","status":"running"}]',
+  );
+  const fetchImpl = (async (_url: unknown, init?: RequestInit) =>
+    init?.method === "PUT"
+      ? new Response("{}", { status: docPutStatus })
+      : Response.json({ revision: 1 })) as typeof fetch;
+  const deps = {
+    poolStoreUrl: "https://store.example",
+    fetchImpl,
+    activityDocRetryDelaysMs: [],
+  } as unknown as TurnServerDeps;
+  const turn = {
+    shadow: false,
+    claim: { id: "c", token: "t", bootId: "b", heartbeatUrl: "https://x" },
+    hostToken: "host-token",
+    gcsPrefix: "ws/w1/agent-1",
+    conversationId: "c1",
+    turnId: "turn-1",
+  } as unknown as TurnRequest & { turnId: string };
+  return {
+    deps,
+    turn,
+    filesystem,
+    resolved: { store, prefix: "ws/w1/agent-1" },
+  };
+}
+
+test("a durable turn names the conversation and board as changed", async () => {
+  const { deps, turn, filesystem, resolved } = await claimedTurn(200);
+  const result = await finishTurnDurability({
+    deps,
+    turn,
+    filesystem,
+    resolved,
+    heartbeat: null,
+    outcome: {},
+    transcript: null,
+  });
+  expect(result.outcome).toEqual({});
+  expect(result.changed).toEqual(["ActivityChanged", "ConversationsChanged"]);
+});
+
+test("a family whose doc projection failed is not announced", async () => {
+  // The board file landed but its doc did not: other tabs refetching the
+  // board would fall to the pod. The conversation (transcript-served) stays.
+  const { deps, turn, filesystem, resolved } = await claimedTurn(400);
+  const result = await finishTurnDurability({
+    deps,
+    turn,
+    filesystem,
+    resolved,
+    heartbeat: null,
+    outcome: {},
+    transcript: null,
+  });
+  expect(result.outcome.error).toMatch(/board doc publish failed/);
+  expect(result.changed).toEqual(["ConversationsChanged"]);
+});

--- a/packages/runtime/src/turn/turn-durability.ts
+++ b/packages/runtime/src/turn/turn-durability.ts
@@ -74,7 +74,10 @@ export async function finishTurnDurability(
     });
     poolWritesOutOfScope = synced.outOfScope;
     uploaded = synced.uploaded;
-    changed = changedEventTypes(opts.filesystem, uploaded);
+    changed = changedEventTypes(opts.filesystem, [
+      ...uploaded,
+      ...synced.deleted,
+    ]);
   } catch (error) {
     // A fenced object write means the claim was adopted mid-sync: report it
     // as exactly that, not as a generic sync failure.
@@ -114,11 +117,17 @@ export async function finishTurnDurability(
       changed,
     };
   }
+  // An event is a promise that the refetch can be served asleep: a family
+  // whose projection failed is left out (the read would fall to the pod).
+  const without = (type: (typeof changed)[number]) => {
+    changed = changed.filter((t) => t !== type);
+  };
   if (published && "error" in published) {
     outcome = appendError(
       outcome,
       `transcript publish failed: ${published.error}`,
     );
+    without("ConversationsChanged");
   }
 
   const activityChanged = uploaded.includes(
@@ -133,6 +142,7 @@ export async function finishTurnDurability(
       outcome,
       `board doc publish failed: ${activityPublished.error}`,
     );
+    without("ActivityChanged");
   }
   const runsChanged = uploaded.includes(
     turnRoutineRunsKey(opts.filesystem.workspaceRel),
@@ -146,6 +156,11 @@ export async function finishTurnDurability(
       outcome,
       `runs doc publish failed: ${runsPublished.error}`,
     );
+  }
+  // The runs doc is projected for routine fires only; any other turn that
+  // touched it has no doc to point other tabs at.
+  if (runsChanged && (!runsPublished || "error" in runsPublished)) {
+    without("RoutineRunsChanged");
   }
   // The claim may have been adopted while sync/publish were in flight (the
   // heartbeat loop learns it asynchronously). A last checkpoint keeps a stale

--- a/packages/runtime/src/turn/turn-durability.ts
+++ b/packages/runtime/src/turn/turn-durability.ts
@@ -5,6 +5,7 @@ import {
   publishTurnActivityDoc,
   publishTurnRunsDoc,
 } from "./turn-activity-doc";
+import { changedEventTypes } from "./turn-changed-events";
 import {
   syncTurnFilesystem,
   type TurnFilesystem,
@@ -33,6 +34,8 @@ interface TurnDurabilityOptions {
 export interface TurnDurabilityResult {
   outcome: TurnOutcome;
   poolWritesOutOfScope: number;
+  /** Domain events the landed writes imply (the gateway fans them out). */
+  changed: ReturnType<typeof changedEventTypes>;
   /** Set when transcript rows were deliberately not published. */
   transcriptSkipped?: "route_absent";
   /** Set when the activity doc route is absent on an older deployment. */
@@ -49,11 +52,16 @@ export async function finishTurnDurability(
 ): Promise<TurnDurabilityResult> {
   await opts.heartbeat?.checkpoint();
   if (opts.heartbeat?.fenced) {
-    return { outcome: { error: "claim_fenced" }, poolWritesOutOfScope: 0 };
+    return {
+      outcome: { error: "claim_fenced" },
+      poolWritesOutOfScope: 0,
+      changed: [],
+    };
   }
 
   let poolWritesOutOfScope: number;
   let uploaded: string[];
+  let changed: TurnDurabilityResult["changed"];
   try {
     // Failed provider work may still have durable tool writes. Only a fence
     // may skip sync because a fenced worker no longer owns this conversation.
@@ -66,11 +74,16 @@ export async function finishTurnDurability(
     });
     poolWritesOutOfScope = synced.outOfScope;
     uploaded = synced.uploaded;
+    changed = changedEventTypes(opts.filesystem, uploaded);
   } catch (error) {
     // A fenced object write means the claim was adopted mid-sync: report it
     // as exactly that, not as a generic sync failure.
     if (error instanceof StoreFencedError) {
-      return { outcome: { error: "claim_fenced" }, poolWritesOutOfScope: 0 };
+      return {
+        outcome: { error: "claim_fenced" },
+        poolWritesOutOfScope: 0,
+        changed: [],
+      };
     }
     const message = error instanceof Error ? error.message : String(error);
     const failure = opts.outcome.error
@@ -79,6 +92,7 @@ export async function finishTurnDurability(
     return {
       outcome: appendError(opts.outcome, failure),
       poolWritesOutOfScope: 0,
+      changed: [],
     };
   }
 
@@ -94,7 +108,11 @@ export async function finishTurnDurability(
     };
   }
   if (published && "fenced" in published) {
-    return { outcome: { error: "claim_fenced" }, poolWritesOutOfScope };
+    return {
+      outcome: { error: "claim_fenced" },
+      poolWritesOutOfScope,
+      changed,
+    };
   }
   if (published && "error" in published) {
     outcome = appendError(
@@ -134,11 +152,16 @@ export async function finishTurnDurability(
   // worker from ever announcing a clean done.
   await opts.heartbeat?.checkpoint();
   if (opts.heartbeat?.fenced) {
-    return { outcome: { error: "claim_fenced" }, poolWritesOutOfScope };
+    return {
+      outcome: { error: "claim_fenced" },
+      poolWritesOutOfScope,
+      changed,
+    };
   }
   return {
     outcome,
     poolWritesOutOfScope,
+    changed,
     ...(published && "disabled" in published
       ? { transcriptSkipped: published.reason }
       : {}),

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -99,7 +99,7 @@ export async function syncTurnFilesystem(opts: {
   filesystem: TurnFilesystem;
   conversationId: string;
   claimed: boolean;
-}): Promise<{ uploaded: string[]; outOfScope: number }> {
+}): Promise<{ uploaded: string[]; deleted: string[]; outOfScope: number }> {
   const result = await syncBack(
     opts.store,
     opts.prefix,
@@ -121,5 +121,9 @@ export async function syncTurnFilesystem(opts: {
       `[turn] pool_writes_out_of_scope=${result.outOfScope} prefix=${opts.prefix || opts.filesystem.dataRel} conversation=${opts.conversationId}`,
     );
   }
-  return { uploaded: result.uploaded, outOfScope: result.outOfScope };
+  return {
+    uploaded: result.uploaded,
+    deleted: result.deleted,
+    outOfScope: result.outOfScope,
+  };
 }

--- a/packages/runtime/src/turn/turn-layout-sync.test.ts
+++ b/packages/runtime/src/turn/turn-layout-sync.test.ts
@@ -138,9 +138,14 @@ test.each([
   expect(keys).not.toContain(
     `ws/w1/agent-1/${workspaceRel}/.houston/routines/routines.json`,
   );
+  // The landed writes name the events other tabs need: the conversation and
+  // the board doc changed; out-of-scope files and session state do not count.
   expect(emitted.at(-1)).toMatchObject({
     type: "done",
-    data: { poolWritesOutOfScope: 3 },
+    data: {
+      poolWritesOutOfScope: 3,
+      changed: ["ActivityChanged", "ConversationsChanged"],
+    },
   });
   expect(log).toHaveBeenCalledWith(
     "[turn] pool_writes_out_of_scope=3 prefix=ws/w1/agent-1 conversation=c1",

--- a/packages/runtime/src/turn/turn-terminal.test.ts
+++ b/packages/runtime/src/turn/turn-terminal.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { turnTerminalFrame } from "./turn-terminal";
+
+describe("turnTerminalFrame", () => {
+  it("keeps the public done frame (null data) when nothing changed", () => {
+    expect(turnTerminalFrame({}, "t1", 0)).toEqual({
+      type: "done",
+      data: null,
+      turnId: "t1",
+    });
+  });
+
+  it("carries changed on the done frame", () => {
+    expect(
+      turnTerminalFrame({}, "t1", 0, undefined, undefined, [
+        "ActivityChanged",
+        "ConversationsChanged",
+      ]),
+    ).toEqual({
+      type: "done",
+      data: { changed: ["ActivityChanged", "ConversationsChanged"] },
+      turnId: "t1",
+    });
+  });
+
+  it("carries changed on the error frame beside the message", () => {
+    // A provider failure after a durable tool write still changed what other
+    // tabs show; the message the SDK reads is untouched.
+    expect(
+      turnTerminalFrame({ error: "boom" }, "t1", 2, undefined, undefined, [
+        "ConversationsChanged",
+      ]),
+    ).toEqual({
+      type: "error",
+      data: {
+        message: "boom",
+        changed: ["ConversationsChanged"],
+        poolWritesOutOfScope: 2,
+      },
+      turnId: "t1",
+    });
+  });
+});

--- a/packages/runtime/src/turn/turn-terminal.ts
+++ b/packages/runtime/src/turn/turn-terminal.ts
@@ -2,15 +2,23 @@ import type { WireFrame } from "@houston/runtime-client";
 import type { TurnSetupError } from "./turn-layout";
 import type { TurnOutcome } from "./turn-session";
 
-/** Build the durable terminal frame after sync-back completes. */
+/**
+ * Build the durable terminal frame after sync-back completes. `changed` lists
+ * the domain events the landed writes imply; the gateway fans them out to
+ * every member's /v1/events, the pod-event parity for a worker-run turn. It
+ * rides the error frame too: a provider failure after a durable tool write
+ * still changed what other tabs show.
+ */
 export function turnTerminalFrame(
   outcome: TurnOutcome,
   turnId: string,
   poolWritesOutOfScope: number,
   transcriptSkipped?: "route_absent",
   activityDocSkipped?: "route_absent",
+  changed: readonly string[] = [],
 ): WireFrame {
   const fields = {
+    ...(changed.length > 0 ? { changed } : {}),
     ...(poolWritesOutOfScope > 0 ? { poolWritesOutOfScope } : {}),
     ...(transcriptSkipped ? { transcriptSkipped } : {}),
     ...(activityDocSkipped ? { activityDocSkipped } : {}),


### PR DESCRIPTION
## Problem

A pool worker has no event bus. An op's handler events already rode the reply (`events`), but a pool turn's terminal frame said nothing about what it changed, and op events were announced even when the doc projection the refetch would read had failed. The gateway had nothing to relay, so other tabs, members and devices stayed stale after a worker-run change (the reactivity rule: "agent can do X but UI won't show it until refresh").

## Change

- `turn-changed-events.ts` (new): maps the store-relative keys a sync-back landed (uploaded + deleted) to the domain events they imply (`ActivityChanged`, `ConversationsChanged`, `RoutineRunsChanged`, …), sorted and deduped. A claimed turn's sync scope is conversation/session/activity/runs today, so only those families can fire; the file/skill mappings are what a widened scope would announce.
- `turn-durability.ts` / `turn-terminal.ts`: the terminal frame carries `data.changed`. Both terminals carry it: a provider failure after a durable tool write still changed what other tabs show. A family whose projection failed (board doc, runs doc, transcript) is dropped from the list: an announced event is a promise that the refetch can be served asleep.
- `execute-op.ts`: op `events` are announced only when every projection succeeded (`announcedOpEvents`); a lagging doc reports `events: []` (the write stays durable, the loud log stays).

Pairs with the gateway change that relays `events` / `data.changed` onto every member's `/v1/events` (gethouston/cloud#298).

## Verification

Before: two tabs on a sleeping agent; edit a routine (or send a turn) in one. The other tab does not change until its own refetch; the worker's done frame is `data: null`.

After (with the gateway change deployed): the other tab refreshes within ~1s. The worker's done frame reads e.g. `data: {"changed":["ActivityChanged","ConversationsChanged"]}`; an op reply with a failed doc PUT reads `events: []`.

Tests: `turn-changed-events.test.ts`, `turn-terminal.test.ts`, `turn-durability.test.ts`, `turn-layout-sync.test.ts` (done frame carries `changed`), `server-op.test.ts` (reply `events`). `pnpm check`, runtime typecheck, host/runtime/domain vitest all pass.
