### PR TITLE
fix(providers): drop unconnectable Azure OpenAI card, steer Bedrock users to the key value (PRODUCT-1477)

### DIFF
--- a/app/src/components/shell/provider-api-key-dialog.tsx
+++ b/app/src/components/shell/provider-api-key-dialog.tsx
@@ -65,6 +65,12 @@ const REASON_COPY: Record<
 function reasonCopyKey(providerId: string, reason: ApiKeyConnectReason) {
   if (providerId === "nvidia" && reason === "key_restricted")
     return "apiKey.errorNvidiaAccountGated" as const;
+  // Bedrock's console lists keys by NAME ("BedrockAPIKey-xxxx-at-<account>")
+  // and reveals the VALUE only once at generation, so a rejected key is
+  // usually the name pasted in place of the value (PRODUCT-1477) — say so
+  // instead of the generic "check it and paste it again".
+  if (providerId === "amazon-bedrock" && reason === "invalid_key")
+    return "apiKey.errorBedrockInvalidKey" as const;
   return REASON_COPY[reason];
 }
 

--- a/app/src/components/shell/provider-api-key-guide.tsx
+++ b/app/src/components/shell/provider-api-key-guide.tsx
@@ -6,13 +6,20 @@ import { useTranslation } from "react-i18next";
  * first (HOU-890): a working key must be an NGC Personal Key with the
  * "Public API Endpoints" service included, a picker the quick
  * build.nvidia.com key flow never shows, so without these steps users mint
- * keys that fail on every chat model.
+ * keys that fail on every chat model. Amazon Bedrock second (PRODUCT-1477):
+ * the console shows a generated key's VALUE exactly once and afterwards lists
+ * only its name, which users then paste as the key.
  */
 const GUIDES = {
   nvidia: [
     "apiKey.guide.nvidia1",
     "apiKey.guide.nvidia2",
     "apiKey.guide.nvidia3",
+  ],
+  "amazon-bedrock": [
+    "apiKey.guide.bedrock1",
+    "apiKey.guide.bedrock2",
+    "apiKey.guide.bedrock3",
   ],
 } as const;
 

--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -149,6 +149,10 @@ export function toCanonicalProviderId(id: string): string {
  *   request URL, so the single-pasted-key connect dialog can never verify or
  *   run them — every attempt dead-ends in "could not verify". Dropped until a
  *   multi-field connect ships (mapped follow-up); same presentation-only rules.
+ * - Azure OpenAI is the same shape (PRODUCT-1477): every request needs the
+ *   user's RESOURCE endpoint (pi's catalog ships `baseUrl: ""` and throws
+ *   "base URL is required" before any HTTP), so a pasted key alone can never
+ *   verify — the dialog always read "couldn't reach Azure OpenAI".
  */
 export const DROP_PI_PROVIDERS: ReadonlySet<string> = new Set([
   "openai",
@@ -160,6 +164,7 @@ export const DROP_PI_PROVIDERS: ReadonlySet<string> = new Set([
   "xiaomi-token-plan-sgp",
   "cloudflare-ai-gateway",
   "cloudflare-workers-ai",
+  "azure-openai-responses",
 ]);
 
 /**
@@ -779,15 +784,6 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     installUrl: "https://platform.xiaomimimo.com",
     apiKeyUrl: "https://platform.xiaomimimo.com",
   },
-  "azure-openai-responses": {
-    name: "Azure OpenAI",
-    subtitle: "OpenAI on Microsoft Azure",
-    cost: "Pay-as-you-go on your Azure account",
-    installUrl:
-      "https://azure.microsoft.com/products/ai-services/openai-service",
-    // Azure keys live per-resource in the portal; there is no global key page.
-    apiKeyUrl: "https://portal.azure.com",
-  },
 };
 
 /**
@@ -813,7 +809,6 @@ export const DESCRIPTION_BY_ID: Readonly<Record<string, string>> = {
   moonshotai: "Kimi models from Moonshot AI.",
   zai: "GLM open models from Z.ai.",
   "vercel-ai-gateway": "One key for many models, from Vercel.",
-  "azure-openai-responses": "OpenAI models on Microsoft Azure.",
   "google-vertex": "Gemini and more on Google Cloud Vertex AI.",
   xiaomi: "MiMo models from Xiaomi.",
   // Named regional / subscription variants (reuse the lab's niche).

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -79,11 +79,15 @@
       "title": "How to get your key",
       "nvidia1": "Open the NVIDIA key page with the button above and sign in, or create a free account.",
       "nvidia2": "Click \"Generate Personal Key\" and under \"Services Included\" check \"Public API Endpoints\".",
-      "nvidia3": "Copy the key that starts with \"nvapi-\" and paste it below."
+      "nvidia3": "Copy the key that starts with \"nvapi-\" and paste it below.",
+      "bedrock1": "Open the Bedrock API keys page with the button above and choose \"Long-term API keys\".",
+      "bedrock2": "Click \"Generate long-term API keys\". The key value is shown only once, so copy it right away.",
+      "bedrock3": "Paste the key value below. It starts with \"ABSK\". The name shown in the list (\"BedrockAPIKey-...\") is not the key."
     },
     "errorInvalidKey": "{{name}} didn't accept this key. Check it and paste it again.",
     "errorKeyRestricted": "This key is blocked by settings in your {{name}} account. Create a new key without restrictions using the button above, then paste it here.",
     "errorNvidiaAccountGated": "Your key is valid, but NVIDIA isn't serving any chat models to your account right now. Make sure your key is a Personal Key from org.ngc.nvidia.com with \"Public API Endpoints\" under Services Included. If it still fails, ask NVIDIA support to enable model access for your account.",
+    "errorBedrockInvalidKey": "Amazon Bedrock didn't accept this key. Make sure you pasted the key value (it starts with \"ABSK\"), not its name from the list (\"BedrockAPIKey-...\"). AWS shows the value only once, so generate a new key if you no longer have it.",
     "errorProviderUnavailable": "We couldn't reach {{name}} to check your key, so nothing was saved. Please try again in a moment."
   },
   "copilot": {

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -79,11 +79,15 @@
       "title": "Cómo obtener tu clave",
       "nvidia1": "Abre la página de claves de NVIDIA con el botón de arriba e inicia sesión, o crea una cuenta gratis.",
       "nvidia2": "Haz clic en \"Generate Personal Key\" y en \"Services Included\" marca \"Public API Endpoints\".",
-      "nvidia3": "Copia la clave que empieza con \"nvapi-\" y pégala abajo."
+      "nvidia3": "Copia la clave que empieza con \"nvapi-\" y pégala abajo.",
+      "bedrock1": "Abre la página de claves de API de Bedrock con el botón de arriba y elige \"Claves de API de larga duración\".",
+      "bedrock2": "Haz clic en \"Generar claves de API de larga duración\". El valor de la clave se muestra una sola vez, así que cópialo de inmediato.",
+      "bedrock3": "Pega el valor de la clave abajo. Empieza con \"ABSK\". El nombre que aparece en la lista (\"BedrockAPIKey-...\") no es la clave."
     },
     "errorInvalidKey": "{{name}} no aceptó esta clave. Revísala y pégala de nuevo.",
     "errorKeyRestricted": "Esta clave está bloqueada por la configuración de tu cuenta de {{name}}. Crea una clave nueva sin restricciones con el botón de arriba y pégala aquí.",
     "errorNvidiaAccountGated": "Tu clave es válida, pero NVIDIA no está sirviendo modelos de chat a tu cuenta en este momento. Asegúrate de que tu clave sea una Personal Key de org.ngc.nvidia.com con \"Public API Endpoints\" en Services Included. Si aun así falla, pide al soporte de NVIDIA que habilite el acceso a modelos para tu cuenta.",
+    "errorBedrockInvalidKey": "Amazon Bedrock no aceptó esta clave. Asegúrate de pegar el valor de la clave (empieza con \"ABSK\") y no su nombre de la lista (\"BedrockAPIKey-...\"). AWS muestra el valor una sola vez, así que genera una clave nueva si ya no lo tienes.",
     "errorProviderUnavailable": "No pudimos conectar con {{name}} para verificar tu clave, así que no se guardó nada. Inténtalo de nuevo en un momento."
   },
   "copilot": {

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -79,11 +79,15 @@
       "title": "Como obter sua chave",
       "nvidia1": "Abra a página de chaves da NVIDIA com o botão acima e faça login, ou crie uma conta grátis.",
       "nvidia2": "Clique em \"Generate Personal Key\" e em \"Services Included\" marque \"Public API Endpoints\".",
-      "nvidia3": "Copie a chave que começa com \"nvapi-\" e cole abaixo."
+      "nvidia3": "Copie a chave que começa com \"nvapi-\" e cole abaixo.",
+      "bedrock1": "Abra a página de chaves de API do Bedrock com o botão acima e escolha \"Chaves de API de longa duração\".",
+      "bedrock2": "Clique em \"Gerar chaves de API de longa duração\". O valor da chave aparece só uma vez, então copie na hora.",
+      "bedrock3": "Cole o valor da chave abaixo. Ele começa com \"ABSK\". O nome exibido na lista (\"BedrockAPIKey-...\") não é a chave."
     },
     "errorInvalidKey": "{{name}} não aceitou esta chave. Confira e cole de novo.",
     "errorKeyRestricted": "Esta chave está bloqueada pelas configurações da sua conta {{name}}. Crie uma chave nova sem restrições usando o botão acima e cole aqui.",
     "errorNvidiaAccountGated": "Sua chave é válida, mas a NVIDIA não está servindo modelos de chat para a sua conta neste momento. Confira se sua chave é uma Personal Key de org.ngc.nvidia.com com \"Public API Endpoints\" em Services Included. Se ainda falhar, peça ao suporte da NVIDIA para habilitar o acesso aos modelos na sua conta.",
+    "errorBedrockInvalidKey": "A Amazon Bedrock não aceitou esta chave. Confira se você colou o valor da chave (começa com \"ABSK\") e não o nome da lista (\"BedrockAPIKey-...\"). A AWS mostra o valor só uma vez, então gere uma chave nova se você não o tiver mais.",
     "errorProviderUnavailable": "Não conseguimos acessar {{name}} para verificar sua chave, então nada foi salvo. Tente de novo em instantes."
   },
   "copilot": {

--- a/app/tests/provider-overrides.test.ts
+++ b/app/tests/provider-overrides.test.ts
@@ -73,7 +73,6 @@ describe("providerDescription", () => {
       "moonshotai",
       "zai",
       "vercel-ai-gateway",
-      "azure-openai-responses",
       "google-vertex",
       "openai-compatible",
       "zai-coding-cn",
@@ -104,6 +103,7 @@ describe("providerDescription", () => {
       "xiaomi-token-plan-sgp",
       "cloudflare-ai-gateway",
       "cloudflare-workers-ai",
+      "azure-openai-responses",
     ]) {
       ok(DROP_PI_PROVIDERS.has(id), `${id} must be in DROP_PI_PROVIDERS`);
       strictEqual(


### PR DESCRIPTION
## PRODUCT-1477

A user could not connect Azure OpenAI or Amazon Bedrock. Two independent root causes.

### Azure OpenAI: structurally unconnectable
Every Azure OpenAI request needs the user's per-resource endpoint. pi's `azure-openai-responses` catalog ships `baseUrl: ""` and its client throws `Azure OpenAI base URL is required` before any HTTP request, so the single-pasted-key connect dialog can never verify a key — every attempt reads "We couldn't reach Azure OpenAI to check your key". (The card also rendered a raw `providers.azure-openai-responses.description` i18n key.)

Fix: add `azure-openai-responses` to `DROP_PI_PROVIDERS`, the same presentation-only drop already used for the Cloudflare pair (which need account ids in the URL). Existing conversations pinned to an Azure model keep running; the card just can't be connected or picked until a multi-field connect (endpoint + key) ships.

### Amazon Bedrock: users paste the key NAME, not the value
The AWS console shows a long-term API key's value (`ABSK…`, ~130 chars) exactly once at generation; afterwards the list shows only its name (`BedrockAPIKey-xxxx-at-<account>`, ~34 chars). The reported screenshot's masked input length matches the name, not a value, and verification then correctly fails with `AccessDeniedException: Authentication failed` → "didn't accept this key".

Fix: a Bedrock "How to get your key" guide in the connect dialog plus a Bedrock-specific invalid-key error explaining value-vs-name, in en/es/pt.

### Before / after
Before: AI Models → Azure OpenAI → Connect → paste any valid key → always "We couldn't reach Azure OpenAI…". Bedrock → paste the key name from the console list → "Amazon Bedrock didn't accept this key. Check it and paste it again."

After: the Azure OpenAI card no longer appears in the AI Models hub or model picker. Bedrock's connect dialog shows the 3-step guide, and a rejected key explains the `ABSK` value vs `BedrockAPIKey-…` name distinction.

### Tests
`app` suite 3718 pass, `tsgo --noEmit` clean, biome clean, `check-locales` all in sync. Updated `provider-overrides.test.ts` pins the drop.