### PR TITLE
fix(chat): surface stale composer attachments with actionable copy

### DIFF
--- a/app/src/components/board/use-agent-board-send.ts
+++ b/app/src/components/board/use-agent-board-send.ts
@@ -11,6 +11,7 @@ import { maybeShowFirstMissionPrompt } from "../../lib/notification-nudge";
 import { perfSpans } from "../../lib/perf-spans";
 import { queryKeys } from "../../lib/query-keys";
 import { formatVisibleMessageText } from "../../lib/queued-chat";
+import { showSendFailedToast } from "../../lib/send-error-toast";
 import { tauriAttachments, tauriChat } from "../../lib/tauri";
 import type { Agent } from "../../lib/types";
 import { useAgentProvisioningStore } from "../../stores/agent-provisioning";
@@ -239,14 +240,11 @@ export function useAgentBoardSend({
         setLoading((prev) => ({ ...prev, [sessionKey]: false }));
         // The send failed BEFORE a turn stream existed — nothing wrote to the
         // VM, so surface it as a toast (no-silent-failures rule).
-        addToast({
-          title: t("chat:errors.sessionStart", { error: String(err) }),
-          variant: "error",
-        });
+        showSendFailedToast(err);
         throw err;
       }
     },
-    [path, agent.id, addToast, rawItems, t, promptContext],
+    [path, agent.id, rawItems, promptContext],
   );
 
   const stopSession = useCallback(

--- a/app/src/components/board/use-mission-control-archived-send.ts
+++ b/app/src/components/board/use-mission-control-archived-send.ts
@@ -1,15 +1,14 @@
 import type { KanbanItem } from "@houston-ai/board";
 import type { MessageMention } from "@houston-ai/chat";
 import { useCallback } from "react";
-import { useTranslation } from "react-i18next";
 import { analytics } from "../../lib/analytics";
 import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { classifyFileKind } from "../../lib/file-kind";
 import { perfSpans } from "../../lib/perf-spans";
+import { showSendFailedToast } from "../../lib/send-error-toast";
 import { tauriAttachments, tauriChat } from "../../lib/tauri";
 import { DEFAULT_TURN_MODE } from "../../lib/turn-mode";
 import type { Agent } from "../../lib/types";
-import { useUIStore } from "../../stores/ui";
 
 /**
  * Send-to-reactivate for the cross-agent Archived view — the analogue of the
@@ -33,9 +32,6 @@ export function useMissionControlArchivedSend({
    *  lands and the mission is no longer archived. */
   onHandoff: (missionId: string) => void;
 }) {
-  const { t } = useTranslation("chat");
-  const addToast = useUIStore((s) => s.addToast);
-
   return useCallback(
     async (
       sessionKey: string,
@@ -72,21 +68,10 @@ export function useMissionControlArchivedSend({
       } catch (err) {
         // The send failed BEFORE a turn stream existed — nothing wrote to the
         // VM, so surface it as a toast (no-silent-failures rule).
-        addToast({
-          title: t("errors.sessionStart", { error: String(err) }),
-          variant: "error",
-        });
+        showSendFailedToast(err);
         throw err;
       }
     },
-    [
-      activeAgent,
-      selectedItem,
-      providerOverride,
-      modelOverride,
-      onHandoff,
-      addToast,
-      t,
-    ],
+    [activeAgent, selectedItem, providerOverride, modelOverride, onHandoff],
   );
 }

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -125,6 +125,7 @@ import {
   validModelOrNull,
 } from "../lib/providers";
 import { queryKeys } from "../lib/query-keys";
+import { showSendFailedToast } from "../lib/send-error-toast";
 import { hasAgentOutput } from "../lib/setup-mission-greeting";
 import {
   buildSkillClaudePrompt,
@@ -1394,14 +1395,11 @@ export function useAgentChatPanel({
         .then(
           () => onSendReactivatedRef.current?.(),
           (err: unknown) => {
-            addToast({
-              title: t("chat:errors.sessionStart", { error: String(err) }),
-              variant: "error",
-            });
+            showSendFailedToast(err);
           },
         );
     },
-    [path, selectedSessionKey, displayModelPin, turnMode, addToast, t],
+    [path, selectedSessionKey, displayModelPin, turnMode],
   );
 
   // Resolves a question step's `toolkit` to the app's presentational brand (logo

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -31,6 +31,7 @@ import { isMultiplayer } from "../lib/org-roles";
 import { perfSpans } from "../lib/perf-spans";
 import { queryKeys } from "../lib/query-keys";
 import { formatVisibleMessageText } from "../lib/queued-chat";
+import { showSendFailedToast } from "../lib/send-error-toast";
 import { sweepIsAuthoritative } from "../lib/sweep-authoritative";
 import {
   type HistoryLoadOptions,
@@ -42,7 +43,6 @@ import {
 import { DEFAULT_TURN_MODE } from "../lib/turn-mode";
 import type { Agent } from "../lib/types";
 import { mergeWarmingRows } from "../lib/warming-board-rows";
-import { useUIStore } from "../stores/ui";
 import { agentsByPath, missionCardAgentName } from "./board/mission-card-agent";
 import { useMcOpenConversation } from "./board/use-mc-open-conversation";
 import { resolveMissionControlSendOverrides } from "./mission-control-send";
@@ -51,7 +51,6 @@ import { AgentCardAvatar } from "./shell/agent-card-avatar";
 export function useMissionControl(agents: Agent[]) {
   const { t } = useTranslation(["chat", "board"]);
   const queryClient = useQueryClient();
-  const addToast = useUIStore((s) => s.addToast);
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loading, setLoading] = useState<Record<string, boolean>>({});
@@ -318,14 +317,11 @@ export function useMissionControl(agents: Agent[]) {
         // The send failed BEFORE a turn stream existed (attachment save,
         // activity lookup, refused start) — nothing wrote to the VM, so
         // surface it as a toast, same as the create path below.
-        addToast({
-          title: t("errors.sessionStart", { error: String(err) }),
-          variant: "error",
-        });
+        showSendFailedToast(err);
         throw err;
       }
     },
-    [addToast, t],
+    [],
   );
 
   // Blank "New mission" create path for Mission Control. Mirrors the
@@ -394,14 +390,11 @@ export function useMissionControl(agents: Agent[]) {
         // No silent failures: createMission already rolled back the
         // half-created activity. Surface why the mission did not start so
         // the user can retry or report it.
-        addToast({
-          title: t("errors.sessionStart", { error: String(err) }),
-          variant: "error",
-        });
+        showSendFailedToast(err);
         throw err;
       }
     },
-    [t, queryClient, paths, addToast, rememberCreated],
+    [t, queryClient, paths, rememberCreated],
   );
 
   // Per-session run state. The conversation VM is the live source: the open

--- a/app/src/lib/send-error-toast.ts
+++ b/app/src/lib/send-error-toast.ts
@@ -1,0 +1,32 @@
+import { useUIStore } from "../stores/ui";
+import { showExpectedStateToast } from "./error-toast";
+import i18n from "./i18n";
+import { isStaleAttachmentError } from "./stale-attachment";
+
+/**
+ * The ONE toast for a send that failed BEFORE a turn stream existed
+ * (attachment save, activity lookup, refused start): nothing wrote to the VM,
+ * so this toast is the failure's only user-visible surface
+ * (no-silent-failures rule). Shared by every pre-turn send catch so the
+ * expected states below branch in one place instead of five.
+ *
+ * A stale attachment (see `isStaleAttachmentError`) is the user's disk
+ * changing under an attached file, not a Houston bug: it gets authored,
+ * actionable copy as a plain info toast — never the red box with a raw
+ * DOMException, which reads as "Houston is broken" and gives no way out.
+ * Sentry capture for it is silenced at the `save_attachments` call in
+ * `tauri.ts`; the raw diagnostic still reaches the frontend log there.
+ */
+export function showSendFailedToast(err: unknown): void {
+  if (isStaleAttachmentError(err)) {
+    showExpectedStateToast(
+      i18n.t("chat:errors.staleAttachmentTitle"),
+      i18n.t("chat:errors.staleAttachmentBody"),
+    );
+    return;
+  }
+  useUIStore.getState().addToast({
+    title: i18n.t("chat:errors.sessionStart", { error: String(err) }),
+    variant: "error",
+  });
+}

--- a/app/src/lib/stale-attachment.ts
+++ b/app/src/lib/stale-attachment.ts
@@ -1,0 +1,21 @@
+/**
+ * A composer attachment whose backing file changed on disk between attach and
+ * send. The browser holds a `File` as a lazy handle and re-validates it when
+ * the upload finally reads the bytes; a file the user deleted, moved, or
+ * modified in the meantime throws a `NotFoundError` / `NotReadableError`
+ * DOMException ("A requested file or directory could not be found at the time
+ * an operation was processed."). Every occurrence to date is Windows WebView2
+ * (HOUSTON-APP-4YX), typically a file attached from a temp or cloud-synced
+ * folder that vanished before send.
+ *
+ * This is an EXPECTED user-actionable state, not a Houston bug: the stale
+ * chip stays in the composer, so every retry fails identically until the user
+ * removes it and re-attaches the file. Kept dependency-free so the node:test
+ * suite can import it directly (the toast side lives in `send-error-toast`).
+ */
+export function isStaleAttachmentError(err: unknown): boolean {
+  return (
+    err instanceof DOMException &&
+    (err.name === "NotFoundError" || err.name === "NotReadableError")
+  );
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -61,6 +61,7 @@ import { osIsTauri, osPickDirectory } from "./os-bridge";
 import { normalizeLegacyModel } from "./providers";
 import { healStaleRosterFromError } from "./roster-heal";
 import { isSharedSkillsUnconfiguredError } from "./shared-skills-availability";
+import { isStaleAttachmentError } from "./stale-attachment";
 import {
   isLastOwnerError,
   isNeedsUpgradeError,
@@ -629,8 +630,15 @@ export const tauriChat = {
 export const tauriAttachments = {
   save: async (scopeId: string, files: File[]): Promise<string[]> => {
     if (files.length === 0) return [];
-    return call<string[]>("save_attachments", () =>
-      getEngine().saveAttachments(scopeId, files),
+    // A stale composer attachment (the backing file changed on disk before
+    // send) is the user's environment, not a Houston bug: logged, but no
+    // Sentry report. The send's catch surfaces the authored remedy via
+    // `showSendFailedToast`.
+    return call<string[]>(
+      "save_attachments",
+      () => getEngine().saveAttachments(scopeId, files),
+      undefined,
+      { silence: isStaleAttachmentError },
     );
   },
 };

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -112,6 +112,8 @@
   },
   "errors": {
     "sessionStart": "Failed to start session: {{error}}",
+    "staleAttachmentTitle": "We couldn't read an attached file",
+    "staleAttachmentBody": "A file you attached changed or was deleted on your device after you added it. Remove it from your message and attach it again.",
     "stopSession": "Couldn't stop the task: {{error}}",
     "modelPersistFailed": "Failed to save model preference",
     "modelNotAllowed": "This model isn't allowed for this agent",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -112,6 +112,8 @@
   },
   "errors": {
     "sessionStart": "No se pudo iniciar la sesión: {{error}}",
+    "staleAttachmentTitle": "No pudimos leer un archivo adjunto",
+    "staleAttachmentBody": "Un archivo que adjuntaste cambió o se eliminó de tu dispositivo después de agregarlo. Quítalo del mensaje y adjúntalo de nuevo.",
     "stopSession": "No se pudo detener la tarea: {{error}}",
     "modelPersistFailed": "No se pudo guardar la preferencia de modelo",
     "modelNotAllowed": "Este modelo no está permitido para este agente",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -112,6 +112,8 @@
   },
   "errors": {
     "sessionStart": "Não foi possível iniciar a sessão: {{error}}",
+    "staleAttachmentTitle": "Não conseguimos ler um arquivo anexado",
+    "staleAttachmentBody": "Um arquivo que você anexou foi alterado ou excluído do seu dispositivo depois de adicionado. Remova-o da mensagem e anexe-o novamente.",
     "stopSession": "Não foi possível parar a tarefa: {{error}}",
     "modelPersistFailed": "Não foi possível salvar a preferência de modelo",
     "modelNotAllowed": "Este modelo não é permitido para este agente",

--- a/app/tests/stale-attachment.test.ts
+++ b/app/tests/stale-attachment.test.ts
@@ -1,0 +1,80 @@
+import { equal, ok } from "node:assert";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { isStaleAttachmentError } from "../src/lib/stale-attachment.ts";
+
+// A composer attachment whose backing file changed on disk between attach and
+// send fails the upload with a DOMException the browser mints when it
+// re-validates the lazy `File` handle (HOUSTON-APP-4YX, all Windows
+// WebView2). That state is the user's disk, not a Houston bug: it must
+// classify as expected so the send catch shows authored remedy copy instead of
+// the raw "NotFoundError: A requested file or directory could not be found…".
+
+describe("isStaleAttachmentError", () => {
+  it("matches the stale-File DOMExceptions", () => {
+    equal(
+      isStaleAttachmentError(
+        new DOMException(
+          "A requested file or directory could not be found at the time an operation was processed.",
+          "NotFoundError",
+        ),
+      ),
+      true,
+    );
+    equal(
+      isStaleAttachmentError(
+        new DOMException("The file could not be read.", "NotReadableError"),
+      ),
+      true,
+    );
+  });
+
+  it("rejects everything else, DOMException or not", () => {
+    // AbortError is a cancelled request, NOT a stale file — it must keep its
+    // own surfacing policy (see engine-call-policy).
+    equal(
+      isStaleAttachmentError(new DOMException("aborted", "AbortError")),
+      false,
+    );
+    // A plain Error whose name merely collides must not match: only the
+    // browser's File machinery throws the DOMException shape.
+    const impostor = new Error("not found");
+    impostor.name = "NotFoundError";
+    equal(isStaleAttachmentError(impostor), false);
+    equal(isStaleAttachmentError("NotFoundError"), false);
+    equal(isStaleAttachmentError(undefined), false);
+  });
+});
+
+// `send-error-toast` pulls i18n and the Zustand store, which don't load under
+// this suite's strip-types runner — so the routing invariant is asserted
+// structurally, same pattern as error-toast-not-shown.test.ts.
+describe("showSendFailedToast routes the stale state to authored copy", () => {
+  const source = readFileSync(
+    join(import.meta.dirname, "../src/lib/send-error-toast.ts"),
+    "utf8",
+  );
+
+  it("branches on isStaleAttachmentError before the generic red toast", () => {
+    const stale = source.indexOf("isStaleAttachmentError(err)");
+    const generic = source.indexOf("errors.sessionStart");
+    ok(stale !== -1, "stale-attachment branch missing");
+    ok(generic !== -1, "generic sessionStart fallback missing");
+    ok(stale < generic, "stale branch must run before the generic toast");
+  });
+
+  it("shows the stale state as an expected-state toast, never raw err text", () => {
+    const staleBranch = source.slice(
+      source.indexOf("isStaleAttachmentError(err)"),
+      source.indexOf("errors.sessionStart"),
+    );
+    ok(staleBranch.includes("showExpectedStateToast"));
+    ok(staleBranch.includes("staleAttachmentTitle"));
+    ok(staleBranch.includes("staleAttachmentBody"));
+    ok(
+      !staleBranch.includes("String(err)"),
+      "stale copy must be authored, not the raw DOMException",
+    );
+  });
+});


### PR DESCRIPTION
Fixes [PRODUCT-1478](https://linear.app/houston-ai/issue/PRODUCT-1478/stale-composer-attachment-fails-sends-with-raw-notfounderror-houston)

## Problem

Sends failed with the raw toast `Failed to start session: NotFoundError: A requested file or directory could not be found at the time an operation was processed.` (Sentry **HOUSTON-APP-4YX**, 12 users, all Windows WebView2).

The browser holds composer attachments as lazy `File` handles and re-validates the backing file when the upload finally reads the bytes. A file deleted, moved, or modified after attach (temp folder, cloud-synced placeholder) throws that DOMException. Because the stale chip stays in the composer, every retry fails identically — switching providers changes nothing, which is exactly how it gets misreported as a provider problem.

## Fix

- `app/src/lib/stale-attachment.ts` — `isStaleAttachmentError`: DOMException `NotFoundError` / `NotReadableError`. Dependency-free so the node:test suite imports it directly.
- `app/src/lib/send-error-toast.ts` — `showSendFailedToast`, now the single surface for all five pre-turn send catches (board send, mission-control send/create, archived send, interaction send). The stale case shows authored en/es/pt remedy copy ("Remove it from your message and attach it again") as an info toast; everything else keeps the red `sessionStart` toast.
- `tauri.ts` silences Sentry for the stale case — the user's disk changed, nothing in Houston broke; the frontend log line survives via the `save_attachments` call wrapper.
- New locale keys `chat:errors.staleAttachmentTitle/Body` in en/es/pt.

## Tests

- `app/tests/stale-attachment.test.ts`: predicate matches the two stale-File DOMExceptions and rejects AbortError, name-colliding plain Errors, and non-errors; structural guard that `showSendFailedToast` routes the stale state to the expected-state toast with authored copy, never `String(err)`.
- Gates: Biome, app `tsgo`, `check-locales` (all locales in sync), 3748 app unit tests, houston-web typecheck + Tauri shim parity.