### PR TITLE
fix(providers): Bedrock defaults use the global inference profile (PRODUCT-1477)

### DIFF
--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -558,13 +558,18 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     cost: "Pay-as-you-go on your AWS account",
     installUrl: "https://aws.amazon.com/bedrock/",
     apiKeyUrl: "https://console.aws.amazon.com/bedrock/home#/api-keys",
-    defaultModel: "anthropic.claude-sonnet-4-6",
+    // Inference-profile id (`global.`), NOT the bare foundation id: Bedrock
+    // serves Claude 4.x only through inference profiles, so bare-id invocation
+    // (including the connect-time key probe) fails with "on-demand throughput
+    // isn't supported" (PRODUCT-1477). Twin of the runtime's
+    // `config.bedrockModel`; keep them in sync.
+    defaultModel: "global.anthropic.claude-sonnet-4-6",
     models: {
-      "anthropic.claude-sonnet-4-6": {
+      "global.anthropic.claude-sonnet-4-6": {
         label: "Claude Sonnet 4.6",
         description: "Anthropic's balanced model, via Bedrock.",
       },
-      "anthropic.claude-opus-4-8": {
+      "global.anthropic.claude-opus-4-8": {
         label: "Claude Opus 4.8",
         description: "Anthropic's flagship, via Bedrock.",
       },

--- a/packages/host/src/providers.ts
+++ b/packages/host/src/providers.ts
@@ -129,13 +129,16 @@ export const PROVIDERS: readonly HostProvider[] = [
     // `cloud: false` = off the legacy cloudrun per-turn listing only; served
     // everywhere else (desktop AND the managed pod, via the full pi-ai catalog).
     cloud: false,
+    // Claude ids are `global.` inference-profile ids — Bedrock serves Claude
+    // 4.x only through inference profiles; bare foundation ids fail every
+    // on-demand invocation (PRODUCT-1477).
     models: [
-      "anthropic.claude-sonnet-4-6",
-      "anthropic.claude-opus-4-8",
+      "global.anthropic.claude-sonnet-4-6",
+      "global.anthropic.claude-opus-4-8",
       "amazon.nova-pro-v1:0",
       "amazon.nova-lite-v1:0",
     ],
-    defaultModel: "anthropic.claude-sonnet-4-6",
+    defaultModel: "global.anthropic.claude-sonnet-4-6",
   },
   {
     id: "minimax",

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -370,6 +370,21 @@ test("together.ai's gated-model body → model_unavailable, never unknown", () =
   expect(err.kind).toBe("model_unavailable");
 });
 
+test("Bedrock bare-foundation-id on-demand rejection → model_unavailable, never unknown (PRODUCT-1477)", () => {
+  // The verbatim ValidationException Bedrock answers a bare Claude 4.x id with
+  // (Sentry, 2026-08-21) — note AWS's curly apostrophe in "isn\u2019t", which
+  // keeps every "is not supported" pattern from matching. The key
+  // authenticated fine; classifying this as `unknown` made the api-key verify
+  // read "couldn't reach Amazon Bedrock" for a valid key.
+  const err = classifyProviderError({
+    provider: "amazon-bedrock",
+    model: "anthropic.claude-sonnet-4-6",
+    message:
+      "Validation error: Invocation of model ID anthropic.claude-sonnet-4-6 with on-demand throughput isn\u2019t supported. Retry your request with the ID or ARN of an inference profile that contains this model.",
+  });
+  expect(err.kind).toBe("model_unavailable");
+});
+
 test("OpenAI model_not_found → model_unavailable, no fallback for a non-Copilot provider", () => {
   const err = classifyProviderError({
     provider: "openai-codex",

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -135,6 +135,13 @@ const MODEL_UNAVAILABLE_PATTERNS = [
   // …" — for models its serverless tier doesn't include. The credential
   // authenticated fine; only the model is out of reach.
   "unable to access model",
+  // Bedrock's bare-foundation-id rejection — "Invocation of model ID … with
+  // on-demand throughput isn't supported. Retry your request with the ID or
+  // ARN of an inference profile …" (Claude 4.x is inference-profile-only).
+  // The credential authenticated; only THIS model id is uninvokable. Matched
+  // on the apostrophe-free phrase: AWS spells "isn't" with U+2019, which the
+  // "is not supported" pattern above can never hit (PRODUCT-1477).
+  "on-demand throughput",
   // GitHub Copilot's newer 400 body — `The requested model is not available
   // for integrator "vscode-chat". Available models: […]` — same plan-doesn't-
   // serve-this-model failure as its older `model_not_supported` code (HOU-977).

--- a/packages/runtime/src/ai/providers.test.ts
+++ b/packages/runtime/src/ai/providers.test.ts
@@ -90,7 +90,7 @@ test("providerDefaultModel returns each provider's catalog default", () => {
   expect(providerDefaultModel("opencode-go")).toBe("glm-5.1");
   expect(providerDefaultModel("deepseek")).toBe("deepseek-v4-flash");
   expect(providerDefaultModel("amazon-bedrock")).toBe(
-    "anthropic.claude-sonnet-4-6",
+    "global.anthropic.claude-sonnet-4-6",
   );
   expect(providerDefaultModel("minimax")).toBe("MiniMax-M3[1m]");
   // Unknown falls back to the Codex default (never throws / undefined).

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -55,8 +55,15 @@ export const config = {
   githubCopilotModel: env.HOUSTON_GITHUB_COPILOT_MODEL || "gpt-4.1",
   /** Default Google Gemini model (API-key provider). A pi-ai `google` model id. */
   geminiModel: env.HOUSTON_GEMINI_MODEL || "gemini-3.5-flash",
-  /** Default Amazon Bedrock model (API-key provider). A pi-ai `amazon-bedrock` model id. */
-  bedrockModel: env.HOUSTON_BEDROCK_MODEL || "anthropic.claude-sonnet-4-6",
+  /** Default Amazon Bedrock model (API-key provider). A pi-ai `amazon-bedrock`
+   *  model id. MUST be an inference-profile id (`global.` prefix): Bedrock
+   *  serves Claude 4.x only through inference profiles, so the bare foundation
+   *  id fails every on-demand invocation with "Invocation of model ID … with
+   *  on-demand throughput isn't supported" — including the connect-time key
+   *  probe, which made every Bedrock connect fail (PRODUCT-1477). Twin of the
+   *  frontend's `PROVIDER_OVERRIDES["amazon-bedrock"].defaultModel`. */
+  bedrockModel:
+    env.HOUSTON_BEDROCK_MODEL || "global.anthropic.claude-sonnet-4-6",
   /**
    * Default MiniMax model (API-key provider). Defaults to the token/coding-plan
    * SKU `MiniMax-M3[1m]` (1M-context): MiniMax's Anthropic endpoint documents this


### PR DESCRIPTION
## PRODUCT-1477 (Bedrock half)

A user with a **valid** long-term Bedrock API key could not connect: every attempt showed "We couldn't reach Amazon Bedrock to check your key".

### Root cause (confirmed via Sentry)
The connect-time verify probe runs a 1-token completion against the provider's default model. For Bedrock that was the bare foundation id `anthropic.claude-sonnet-4-6` — but Bedrock serves Claude 4.x only through inference profiles, so Bedrock answers:

> Validation error: Invocation of model ID anthropic.claude-sonnet-4-6 with on-demand throughput isn't supported. Retry your request with the ID or ARN of an inference profile that contains this model.

Two stacked failures:
1. The probe model can never succeed, regardless of the key.
2. AWS spells "isn't" with a curly apostrophe (U+2019), so the `is not supported` model-unavailable pattern never matched; the error classified `unknown` → verify no-verdict → the misleading "couldn't reach" copy.

### Fix
- Default Bedrock model → `global.anthropic.claude-sonnet-4-6` (the global cross-region inference profile) in the runtime (`config.bedrockModel`), the host's curated provider list, and the frontend override (default + curated model labels). The three are documented as twins.
- Classify Bedrock's on-demand-throughput rejection as `model_unavailable` (matched on the apostrophe-free phrase `on-demand throughput`): it proves the key authenticated at verify time, and at chat time the user gets the switch-model card with the provider's own actionable message instead of the report-a-bug card.

### Before / after
Before: paste a valid `ABSK…` key → "We couldn't reach Amazon Bedrock to check your key, so nothing was saved."
After: the probe runs against the global inference profile and the key connects; a user who later picks a bare Claude id gets the model-unavailable card quoting Bedrock's inference-profile message.

### Tests
New regression test with the verbatim Sentry message (curly apostrophe) asserting `model_unavailable`. Runtime 1326, host 1574, app 3747 pass; typecheck + biome clean.