### PR TITLE
fix(shell): make Windows dictation self-contained and survivable (PRODUCT-1448)

### DIFF
--- a/app/src-tauri/src/dictation/wav.rs
+++ b/app/src-tauri/src/dictation/wav.rs
@@ -8,7 +8,12 @@ use std::time::Duration;
 const FALLBACK_BYTE_RATE: u64 = 16_000 * 2;
 
 /// The floor a transcription is always allowed, regardless of clip length.
-const MIN_TIMEOUT_SECS: u64 = 30;
+/// Generous on purpose: the first run pays a cold 181 MB model load, and
+/// CPU-only Windows machines (antivirus scan of the exe + model, slow disks,
+/// VMs) blew the previous 30s floor on even short clips (PRODUCT-1448). The
+/// timeout only exists to reap a genuinely hung sidecar, not to race a slow
+/// one.
+const MIN_TIMEOUT_SECS: u64 = 120;
 
 /// Estimated audio duration, in seconds, from the raw WAV bytes.
 ///
@@ -52,7 +57,7 @@ fn parse_duration(bytes: &[u8]) -> Option<f64> {
     Some((data as f64) / (rate as f64))
 }
 
-/// Timeout for one transcription: `max(30s, 4 × audio duration)`.
+/// Timeout for one transcription: `max(120s, 4 × audio duration)`.
 pub fn transcription_timeout(duration_secs: f64) -> Duration {
     let scaled = (duration_secs * 4.0).ceil().max(0.0);
     let secs = (scaled as u64).max(MIN_TIMEOUT_SECS);
@@ -104,10 +109,10 @@ mod tests {
     }
 
     #[test]
-    fn timeout_honors_30s_floor() {
-        // A 1s clip → 4s, floored up to the 30s minimum.
-        assert_eq!(transcription_timeout(1.0), Duration::from_secs(30));
-        assert_eq!(transcription_timeout(0.0), Duration::from_secs(30));
+    fn timeout_honors_120s_floor() {
+        // A 1s clip → 4s, floored up to the 120s minimum.
+        assert_eq!(transcription_timeout(1.0), Duration::from_secs(120));
+        assert_eq!(transcription_timeout(0.0), Duration::from_secs(120));
     }
 
     #[test]

--- a/app/src/lib/dictation/use-dictation.ts
+++ b/app/src/lib/dictation/use-dictation.ts
@@ -95,11 +95,21 @@ export function useDictation({
         }
       } catch (err) {
         dispatch({ type: "transcribeSettled" });
-        if (errorText(err) === "model-not-ready") void reopen();
-        else showErrorToast("dictation_transcribe", errorText(err), err);
+        if (errorText(err) === "model-not-ready") {
+          void reopen();
+        } else {
+          // Report-only path first, then authored copy: the user spoke and
+          // pressed stop, so a silent drop reads as "it sent nothing"
+          // (PRODUCT-1448) — retrying is a real action they can take.
+          showErrorToast("dictation_transcribe", errorText(err), err);
+          addToast({
+            title: t("composer.dictation.failed"),
+            variant: "error",
+          });
+        }
       }
     },
-    [reopen],
+    [reopen, addToast, t],
   );
 
   const beginCapture = useCallback(async () => {

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -27,7 +27,8 @@
       "setupConfirm": "Download",
       "setupProgress": "Downloading... {{pct}}%",
       "micDenied": "Houston needs microphone access. Allow it in system settings, then try again.",
-      "noMic": "No microphone was found."
+      "noMic": "No microphone was found.",
+      "failed": "Voice typing didn't work this time. Please try again."
     }
   },
   "mentions": {

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -27,7 +27,8 @@
       "setupConfirm": "Descargar",
       "setupProgress": "Descargando... {{pct}}%",
       "micDenied": "Houston necesita acceso al micrófono. Permítelo en la configuración del sistema y vuelve a intentarlo.",
-      "noMic": "No se encontró ningún micrófono."
+      "noMic": "No se encontró ningún micrófono.",
+      "failed": "El dictado por voz no funcionó esta vez. Inténtalo de nuevo."
     }
   },
   "mentions": {

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -27,7 +27,8 @@
       "setupConfirm": "Baixar",
       "setupProgress": "Baixando... {{pct}}%",
       "micDenied": "O Houston precisa de acesso ao microfone. Permita nas configurações do sistema e tente novamente.",
-      "noMic": "Nenhum microfone foi encontrado."
+      "noMic": "Nenhum microfone foi encontrado.",
+      "failed": "A digitação por voz não funcionou desta vez. Tente novamente."
     }
   },
   "mentions": {

--- a/scripts/build-whisper.sh
+++ b/scripts/build-whisper.sh
@@ -12,7 +12,9 @@
 # built fully static (`-DBUILD_SHARED_LIBS=OFF`) so it carries no whisper/ggml
 # shared-library dependency, and on macOS Metal is embedded into the binary
 # (`-DGGML_METAL_EMBED_LIBRARY=ON`) so there is no sibling `.metallib` to ship.
-# On macOS the result is verified dylib-free with `otool -L`.
+# On Windows the MSVC CRT is statically linked too (no VC++ redistributable
+# needed on user machines). On macOS the result is verified dylib-free with
+# `otool -L`; on Windows it is verified free of VC++ runtime DLL imports.
 #
 # Output:
 #   target/whisper/whisper-cli-<rust-triple>          (macOS / Linux)
@@ -190,6 +192,19 @@ case "$OS" in
   windows | linux)
     # CPU-only, portable across CPUs (no -march=native), self-contained.
     CMAKE_FLAGS+=(-DGGML_NATIVE=OFF)
+    # Statically link the MSVC C/C++ runtime. BUILD_SHARED_LIBS=OFF only
+    # covers whisper/ggml themselves — MSVC still defaults to /MD, leaving the
+    # shipped exe dependent on MSVCP140.dll/VCRUNTIME140.dll, which machines
+    # without the VC++ redistributable don't have (PRODUCT-1448: dictation
+    # died with a "MSVCP140.dll not found" system dialog). CMP0091 must be
+    # forced NEW because whisper.cpp's cmake_minimum_required predates 3.15,
+    # which would otherwise silently ignore CMAKE_MSVC_RUNTIME_LIBRARY.
+    if [ "$OS" = "windows" ]; then
+      CMAKE_FLAGS+=(
+        -DCMAKE_POLICY_DEFAULT_CMP0091=NEW
+        -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
+      )
+    fi
     # ggml hard-refuses plain MSVC for ARM64 ("MSVC is not supported for ARM,
     # use clang" — ggml-cpu/CMakeLists.txt): its ARM kernels need clang's
     # NEON/ACLE intrinsics. Visual Studio's bundled ClangCL toolset compiles
@@ -232,6 +247,20 @@ if [ "$OS" = "macos" ] && command -v otool >/dev/null 2>&1; then
     exit 1
   fi
   echo "  dylib check OK (system-only dependencies)"
+fi
+
+# On Windows, verify the binary carries no VC++-redistributable dependency —
+# the Windows analogue of the macOS otool gate above. PE import-table DLL
+# names are plain ASCII inside the exe, so a grep is a toolchain-free check
+# (dumpbin needs a VS dev shell Git Bash doesn't have). A hit means the
+# static-CRT flags above regressed and the exe would fail to launch on
+# machines without the redistributable installed.
+if [ "$OS" = "windows" ]; then
+  if grep -qai -e 'MSVCP140' -e 'VCRUNTIME140' -e 'CONCRT140' "$BUILT"; then
+    echo "ERROR: whisper-cli imports the dynamic VC++ runtime (MSVCP140/VCRUNTIME140) — expected a statically linked CRT" >&2
+    exit 1
+  fi
+  echo "  CRT check OK (no VC++ redistributable dependency)"
 fi
 
 mkdir -p "$OUT_DIR"


### PR DESCRIPTION
## Summary

PRODUCT-1448: dictation ("whisper") on Windows failed in more than one way. Three root causes, all fixed here:

1. **`whisper-cli.exe` required the VC++ redistributable.** `scripts/build-whisper.sh` builds whisper/ggml static (`BUILD_SHARED_LIBS=OFF`) but MSVC still linked the C/C++ runtime dynamically (`/MD`), so the shipped exe imported `MSVCP140.dll`/`VCRUNTIME140.dll`. Machines without the redistributable (the user report) fail to launch it with a "MSVCP140.dll not found" system dialog. The CRT is now statically linked (`CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded`, with `CMAKE_POLICY_DEFAULT_CMP0091=NEW` because whisper.cpp's `cmake_minimum_required` predates 3.15 and would otherwise silently ignore the variable), and the build now fails if the exe still imports any VC++ runtime DLL — the Windows analogue of the existing macOS `otool -L` gate.
2. **The 30s transcription-timeout floor was too tight for CPU-only Windows.** The first run pays a cold 181 MB model load, plus antivirus scans of a fresh exe/model and slow disks/VMs — short clips hit `transcription-timeout` (reproduced in-house). The floor is now 120s; the 4× clip-duration scaling is unchanged. The timeout exists to reap a hung sidecar, not to race a slow one.
3. **Failure was silent to the user.** A failed transcription only took the report-only path, so the composer just stayed empty after stop — users read it as "recorded but sent nothing". A failed transcription now also shows authored retry copy (en/es/pt) while still reporting through the normal paths.

## Known limitation (not addressed here)

The Windows/Linux x64 build enables AVX2 by default (ggml's `INS_ENB` with `GGML_NATIVE=OFF`), so pre-AVX2 CPUs (including recent budget Celeron/Pentium lines with no AVX at all) would crash whisper-cli with an illegal instruction. Fixing that needs ggml's `GGML_CPU_ALL_VARIANTS`/`GGML_BACKEND_DL` runtime dispatch, which conflicts with the single-file sidecar bundling — left as a follow-up.

## Before (reproduction)

On a Windows machine **without** the VC++ 2015–2022 redistributable:
1. Open Houston, start voice typing in the chat composer, speak, press stop.
2. A system dialog appears: "The code execution cannot proceed because MSVCP140.dll was not found", and no text is inserted.

On a slow CPU-only Windows machine (or VM) **with** the redistributable:
1. Record a short (~6s) clip and press stop.
2. Nothing appears in the composer; DevTools console shows `[toast:dictation_transcribe] transcription-timeout`. The user sees nothing.

## After (verification)

1. Rebuild the sidecar: `scripts/build-whisper.sh x86_64-pc-windows-msvc` on a Windows runner — the new "CRT check OK" line must print (the build hard-fails if the exe still imports `MSVCP140`/`VCRUNTIME140`/`CONCRT140`).
2. On a machine without the VC++ redistributable, dictation transcribes normally — no DLL dialog.
3. On a slow machine, a short clip that previously timed out at 30s now completes (up to 120s allowed); if transcription still fails, an error toast ("Voice typing didn't work this time. Please try again.") appears instead of silence.
4. `cargo test dictation` (timeout floor tests), `cd app && pnpm tsgo --noEmit && pnpm check-locales && pnpm test`, `pnpm check` — all green.