### PR TITLE
feat(providers): Azure OpenAI connect with per-resource endpoint (PRODUCT-1477)

### DIFF
--- a/app/src/components/shell/provider-api-key-dialog.tsx
+++ b/app/src/components/shell/provider-api-key-dialog.tsx
@@ -14,6 +14,7 @@ import {
   type ApiKeyConnectReason,
   apiKeyConnectReason,
 } from "../../lib/api-key-connect-error";
+import { API_KEY_ENDPOINT_PROVIDERS } from "../../lib/provider-overrides";
 import type { ProviderInfo } from "../../lib/providers";
 import { tauriProvider, tauriSystem } from "../../lib/tauri";
 import { ProviderApiKeyField } from "./provider-api-key-field";
@@ -77,6 +78,7 @@ function reasonCopyKey(providerId: string, reason: ApiKeyConnectReason) {
 export function ProviderApiKeyDialog({ provider, onClose }: Props) {
   const { t } = useTranslation("providers");
   const [key, setKey] = useState("");
+  const [endpoint, setEndpoint] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -87,6 +89,7 @@ export function ProviderApiKeyDialog({ provider, onClose }: Props) {
   useEffect(() => {
     if (provider) {
       setKey("");
+      setEndpoint("");
       setError(null);
       setSubmitting(false);
     }
@@ -94,6 +97,9 @@ export function ProviderApiKeyDialog({ provider, onClose }: Props) {
 
   if (!provider) return null;
   const url = provider.apiKeyUrl;
+  // Azure OpenAI (PRODUCT-1477): every request goes to the user's own resource
+  // URL, so the dialog collects the endpoint alongside the key.
+  const needsEndpoint = API_KEY_ENDPOINT_PROVIDERS.has(provider.id);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -102,10 +108,19 @@ export function ProviderApiKeyDialog({ provider, onClose }: Props) {
       setError(t("apiKey.required"));
       return;
     }
+    const trimmedEndpoint = endpoint.trim();
+    if (needsEndpoint && !trimmedEndpoint.startsWith("https://")) {
+      setError(t("apiKey.endpointRequired"));
+      return;
+    }
     setSubmitting(true);
     setError(null);
     try {
-      await tauriProvider.setApiKey(provider.id, trimmed);
+      await tauriProvider.setApiKey(
+        provider.id,
+        trimmed,
+        needsEndpoint ? trimmedEndpoint : undefined,
+      );
       // Success: the parent's ProviderLoginComplete handler flips the card and
       // toasts. Close here so the dialog doesn't linger over the connected state.
       onClose();
@@ -163,6 +178,30 @@ export function ProviderApiKeyDialog({ provider, onClose }: Props) {
 
           <ProviderApiKeyGuide providerId={provider.id} />
 
+          {needsEndpoint && (
+            <div className="space-y-1.5">
+              <label
+                htmlFor="provider-endpoint"
+                className="text-[13px] font-medium"
+              >
+                {t("apiKey.endpointLabel")}
+              </label>
+              <input
+                id="provider-endpoint"
+                type="url"
+                autoComplete="off"
+                value={endpoint}
+                onChange={(e) => setEndpoint(e.target.value)}
+                placeholder={t("apiKey.endpointPlaceholder")}
+                className="w-full rounded-md border bg-input px-3 py-2 text-[13px] font-mono focus:outline-none focus:ring-2 focus:ring-focus"
+                disabled={submitting}
+              />
+              <p className="text-[12px] text-ink-muted">
+                {t("apiKey.endpointHelp")}
+              </p>
+            </div>
+          )}
+
           <ProviderApiKeyField
             label={t("apiKey.label")}
             placeholder={t("apiKey.placeholder")}
@@ -183,7 +222,12 @@ export function ProviderApiKeyDialog({ provider, onClose }: Props) {
             <Button type="button" variant="outline" onClick={onClose}>
               {t("apiKey.cancel")}
             </Button>
-            <Button type="submit" disabled={submitting || !key.trim()}>
+            <Button
+              type="submit"
+              disabled={
+                submitting || !key.trim() || (needsEndpoint && !endpoint.trim())
+              }
+            >
               {submitting ? t("apiKey.saving") : t("apiKey.save")}
             </Button>
           </DialogFooter>

--- a/app/src/components/shell/provider-api-key-guide.tsx
+++ b/app/src/components/shell/provider-api-key-guide.tsx
@@ -21,6 +21,11 @@ const GUIDES = {
     "apiKey.guide.bedrock2",
     "apiKey.guide.bedrock3",
   ],
+  "azure-openai-responses": [
+    "apiKey.guide.azure1",
+    "apiKey.guide.azure2",
+    "apiKey.guide.azure3",
+  ],
 } as const;
 
 export function ProviderApiKeyGuide({ providerId }: { providerId: string }) {

--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -149,10 +149,8 @@ export function toCanonicalProviderId(id: string): string {
  *   request URL, so the single-pasted-key connect dialog can never verify or
  *   run them — every attempt dead-ends in "could not verify". Dropped until a
  *   multi-field connect ships (mapped follow-up); same presentation-only rules.
- * - Azure OpenAI is the same shape (PRODUCT-1477): every request needs the
- *   user's RESOURCE endpoint (pi's catalog ships `baseUrl: ""` and throws
- *   "base URL is required" before any HTTP), so a pasted key alone can never
- *   verify — the dialog always read "couldn't reach Azure OpenAI".
+ *   (Azure OpenAI sat here briefly for the same reason; its connect dialog now
+ *   collects the resource endpoint alongside the key — PRODUCT-1477.)
  */
 export const DROP_PI_PROVIDERS: ReadonlySet<string> = new Set([
   "openai",
@@ -164,6 +162,16 @@ export const DROP_PI_PROVIDERS: ReadonlySet<string> = new Set([
   "xiaomi-token-plan-sgp",
   "cloudflare-ai-gateway",
   "cloudflare-workers-ai",
+]);
+
+/**
+ * Api-key providers whose connect dialog collects a per-account ENDPOINT
+ * alongside the key (PRODUCT-1477). Azure OpenAI is the only one today: every
+ * Azure request goes to the user's own resource URL, so a key alone can never
+ * be verified or used. The dialog shows an endpoint field for these ids and
+ * sends it with the key; the runtime validates and persists it.
+ */
+export const API_KEY_ENDPOINT_PROVIDERS: ReadonlySet<string> = new Set([
   "azure-openai-responses",
 ]);
 
@@ -181,6 +189,19 @@ export const DROP_PI_PROVIDERS: ReadonlySet<string> = new Set([
  * (`provider-overrides-drift.test.ts`) rejects orphans.
  */
 export const VISIBLE_MODELS: Readonly<Record<string, ReadonlySet<string>>> = {
+  // Mirrors the `openai` set below where the azure catalog offers the same id
+  // (pi's azure list still carries 2023-era gpt-4; hide it). Azure serves a
+  // model only when the user DEPLOYED it under that name, so a short current
+  // list also keeps the "deployment named after the model id" rule legible.
+  "azure-openai-responses": new Set([
+    "gpt-5.5",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.3-codex-spark",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+  ]),
   openai: new Set([
     "gpt-5.5",
     "gpt-5.6-sol",
@@ -767,6 +788,18 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     installUrl: "https://open.bigmodel.cn",
     apiKeyUrl: "https://open.bigmodel.cn/usercenter/apikeys",
   },
+  "azure-openai-responses": {
+    name: "Azure OpenAI",
+    subtitle: "OpenAI on Microsoft Azure",
+    cost: "Pay-as-you-go on your Azure account",
+    installUrl:
+      "https://azure.microsoft.com/products/ai-services/openai-service",
+    // Azure keys live per-resource in the portal; there is no global key page.
+    apiKeyUrl: "https://portal.azure.com",
+    // pi's azure catalog is alphabetical (gpt-4 first) — start current.
+    // Twin of the runtime's UNCURATED_DEFAULT_MODEL; keep them in sync.
+    defaultModel: "gpt-5.5",
+  },
   "vercel-ai-gateway": {
     name: "Vercel AI Gateway",
     subtitle: "Many models, one key",
@@ -809,6 +842,7 @@ export const DESCRIPTION_BY_ID: Readonly<Record<string, string>> = {
   moonshotai: "Kimi models from Moonshot AI.",
   zai: "GLM open models from Z.ai.",
   "vercel-ai-gateway": "One key for many models, from Vercel.",
+  "azure-openai-responses": "OpenAI models on Microsoft Azure.",
   "google-vertex": "Gemini and more on Google Cloud Vertex AI.",
   xiaomi: "MiMo models from Xiaomi.",
   // Named regional / subscription variants (reuse the lab's niche).

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1862,10 +1862,10 @@ export const tauriProvider = {
    * New-engine only — the connect UI shows these providers only when
    * `newEngineActive()`.
    */
-  setApiKey: (provider: string, apiKey: string) =>
+  setApiKey: (provider: string, apiKey: string, endpoint?: string) =>
     call<void>(
       "set_provider_api_key",
-      () => getEngine().setProviderApiKey(provider, apiKey),
+      () => getEngine().setProviderApiKey(provider, apiKey, endpoint),
       undefined,
       // The connect dialog surfaces the failure inline with the engine's typed
       // reason (bad key / restricted key / provider outage) — a red bug toast

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -68,6 +68,10 @@
     "getKey": "Get your API key",
     "label": "API key",
     "placeholder": "Paste your API key",
+    "endpointLabel": "Endpoint",
+    "endpointPlaceholder": "https://your-resource.openai.azure.com",
+    "endpointHelp": "The endpoint URL from your resource in the Azure portal. Houston calls the deployment named exactly like the model, so name your deployments after the model (for example \"gpt-5.5\").",
+    "endpointRequired": "Enter your endpoint URL first. It starts with https:// and comes from your resource in the Azure portal.",
     "required": "Enter your API key first.",
     "verifyFailed": "This key couldn't be connected: {{detail}}",
     "show": "Show key",
@@ -82,7 +86,10 @@
       "nvidia3": "Copy the key that starts with \"nvapi-\" and paste it below.",
       "bedrock1": "Open the Bedrock API keys page with the button above and choose \"Long-term API keys\".",
       "bedrock2": "Click \"Generate long-term API keys\". The key value is shown only once, so copy it right away.",
-      "bedrock3": "Paste the key value below. It starts with \"ABSK\". The name shown in the list (\"BedrockAPIKey-...\") is not the key."
+      "bedrock3": "Paste the key value below. It starts with \"ABSK\". The name shown in the list (\"BedrockAPIKey-...\") is not the key.",
+      "azure1": "In the Azure portal, open your Azure OpenAI (or Foundry) resource and go to \"Keys and endpoint\".",
+      "azure2": "Copy one of the two keys and the endpoint URL.",
+      "azure3": "Deploy the models you want to use, each named exactly like the model (for example \"gpt-5.5\"), then paste the endpoint and key here."
     },
     "errorInvalidKey": "{{name}} didn't accept this key. Check it and paste it again.",
     "errorKeyRestricted": "This key is blocked by settings in your {{name}} account. Create a new key without restrictions using the button above, then paste it here.",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -68,6 +68,10 @@
     "getKey": "Obtén tu clave de API",
     "label": "Clave de API",
     "placeholder": "Pega tu clave de API",
+    "endpointLabel": "Punto de conexión",
+    "endpointPlaceholder": "https://tu-recurso.openai.azure.com",
+    "endpointHelp": "La URL del punto de conexión de tu recurso en el portal de Azure. Houston llama a la implementación con el mismo nombre del modelo, así que nombra tus implementaciones igual que el modelo (por ejemplo \"gpt-5.5\").",
+    "endpointRequired": "Primero ingresa la URL del punto de conexión. Empieza con https:// y la encuentras en tu recurso del portal de Azure.",
     "required": "Primero ingresa tu clave de API.",
     "verifyFailed": "No se pudo conectar esta clave: {{detail}}",
     "show": "Mostrar clave",
@@ -82,7 +86,10 @@
       "nvidia3": "Copia la clave que empieza con \"nvapi-\" y pégala abajo.",
       "bedrock1": "Abre la página de claves de API de Bedrock con el botón de arriba y elige \"Claves de API de larga duración\".",
       "bedrock2": "Haz clic en \"Generar claves de API de larga duración\". El valor de la clave se muestra una sola vez, así que cópialo de inmediato.",
-      "bedrock3": "Pega el valor de la clave abajo. Empieza con \"ABSK\". El nombre que aparece en la lista (\"BedrockAPIKey-...\") no es la clave."
+      "bedrock3": "Pega el valor de la clave abajo. Empieza con \"ABSK\". El nombre que aparece en la lista (\"BedrockAPIKey-...\") no es la clave.",
+      "azure1": "En el portal de Azure, abre tu recurso de Azure OpenAI (o Foundry) y entra a \"Claves y punto de conexión\".",
+      "azure2": "Copia una de las dos claves y la URL del punto de conexión.",
+      "azure3": "Implementa los modelos que quieras usar, cada uno con el mismo nombre del modelo (por ejemplo \"gpt-5.5\"), y pega aquí el punto de conexión y la clave."
     },
     "errorInvalidKey": "{{name}} no aceptó esta clave. Revísala y pégala de nuevo.",
     "errorKeyRestricted": "Esta clave está bloqueada por la configuración de tu cuenta de {{name}}. Crea una clave nueva sin restricciones con el botón de arriba y pégala aquí.",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -68,6 +68,10 @@
     "getKey": "Obtenha sua chave de API",
     "label": "Chave de API",
     "placeholder": "Cole sua chave de API",
+    "endpointLabel": "Endpoint",
+    "endpointPlaceholder": "https://seu-recurso.openai.azure.com",
+    "endpointHelp": "A URL do endpoint do seu recurso no portal do Azure. O Houston chama a implantação com o mesmo nome do modelo, então nomeie suas implantações igual ao modelo (por exemplo \"gpt-5.5\").",
+    "endpointRequired": "Primeiro informe a URL do endpoint. Ela começa com https:// e está no seu recurso no portal do Azure.",
     "required": "Primeiro informe sua chave de API.",
     "verifyFailed": "Não foi possível conectar esta chave: {{detail}}",
     "show": "Mostrar chave",
@@ -82,7 +86,10 @@
       "nvidia3": "Copie a chave que começa com \"nvapi-\" e cole abaixo.",
       "bedrock1": "Abra a página de chaves de API do Bedrock com o botão acima e escolha \"Chaves de API de longa duração\".",
       "bedrock2": "Clique em \"Gerar chaves de API de longa duração\". O valor da chave aparece só uma vez, então copie na hora.",
-      "bedrock3": "Cole o valor da chave abaixo. Ele começa com \"ABSK\". O nome exibido na lista (\"BedrockAPIKey-...\") não é a chave."
+      "bedrock3": "Cole o valor da chave abaixo. Ele começa com \"ABSK\". O nome exibido na lista (\"BedrockAPIKey-...\") não é a chave.",
+      "azure1": "No portal do Azure, abra seu recurso do Azure OpenAI (ou Foundry) e acesse \"Chaves e endpoint\".",
+      "azure2": "Copie uma das duas chaves e a URL do endpoint.",
+      "azure3": "Implante os modelos que quiser usar, cada um com o mesmo nome do modelo (por exemplo \"gpt-5.5\"), e cole aqui o endpoint e a chave."
     },
     "errorInvalidKey": "{{name}} não aceitou esta chave. Confira e cole de novo.",
     "errorKeyRestricted": "Esta chave está bloqueada pelas configurações da sua conta {{name}}. Crie uma chave nova sem restrições usando o botão acima e cole aqui.",

--- a/app/tests/provider-overrides.test.ts
+++ b/app/tests/provider-overrides.test.ts
@@ -1,6 +1,7 @@
 import { ok, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
+  API_KEY_ENDPOINT_PROVIDERS,
   DESCRIPTION_BY_ID,
   DROP_PI_PROVIDERS,
   FEATURED_PROVIDER_IDS,
@@ -73,6 +74,7 @@ describe("providerDescription", () => {
       "moonshotai",
       "zai",
       "vercel-ai-gateway",
+      "azure-openai-responses",
       "google-vertex",
       "openai-compatible",
       "zai-coding-cn",
@@ -103,7 +105,6 @@ describe("providerDescription", () => {
       "xiaomi-token-plan-sgp",
       "cloudflare-ai-gateway",
       "cloudflare-workers-ai",
-      "azure-openai-responses",
     ]) {
       ok(DROP_PI_PROVIDERS.has(id), `${id} must be in DROP_PI_PROVIDERS`);
       strictEqual(
@@ -112,6 +113,15 @@ describe("providerDescription", () => {
         `${id} must not keep a curated override`,
       );
     }
+  });
+
+  it("azure connects with an endpoint field, not a bare key (PRODUCT-1477)", () => {
+    // Azure's base URL is per-resource, so it must NOT sit in the drop list
+    // (that was the stopgap) and MUST be flagged for the endpoint-aware
+    // connect dialog.
+    ok(!DROP_PI_PROVIDERS.has("azure-openai-responses"));
+    ok(API_KEY_ENDPOINT_PROVIDERS.has("azure-openai-responses"));
+    ok(PROVIDER_OVERRIDES["azure-openai-responses"]?.apiKeyUrl);
   });
 
   it("returns an empty string for a provider we have never described", () => {

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -480,6 +480,7 @@ export class ProxyChannel implements RuntimeChannel {
     ctx: ChannelCtx,
     provider: string,
     apiKey: string,
+    providerEndpoint?: string,
   ): Promise<void> {
     const endpoint = await this.opts.launcher.ensureAwake(ctx.agent);
     const res = await fetch(
@@ -491,7 +492,12 @@ export class ProxyChannel implements RuntimeChannel {
           Authorization: `Bearer ${endpoint.token}`,
           ...(ctx.actingAs ? { "x-houston-acting-as": ctx.actingAs } : {}),
         },
-        body: JSON.stringify({ key: apiKey }),
+        // Azure OpenAI rides its per-resource endpoint with the key
+        // (PRODUCT-1477); the runtime validates and persists it.
+        body: JSON.stringify({
+          key: apiKey,
+          ...(providerEndpoint ? { endpoint: providerEndpoint } : {}),
+        }),
       },
     );
     if (!res.ok) {

--- a/packages/host/src/channel/turn.ts
+++ b/packages/host/src/channel/turn.ts
@@ -135,7 +135,17 @@ export class TurnChannel implements RuntimeChannel {
     ctx: ChannelCtx,
     provider: string,
     apiKey: string,
+    endpoint?: string,
   ): Promise<void> {
+    // Azure OpenAI needs its per-resource endpoint hydrated into every
+    // per-turn data dir, and this channel has no write for it yet — refuse
+    // loudly rather than store a key that can never make a request
+    // (PRODUCT-1477; mirrors the Claude refusal below).
+    if (endpoint !== undefined) {
+      throw new Error(
+        `${provider} isn't available in the cloud per-turn runtime yet.`,
+      );
+    }
     await this.deps.credentials.put({
       workspaceId: ctx.workspace.id,
       provider,

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -313,6 +313,7 @@ export interface RuntimeChannel {
     ctx: ChannelCtx,
     provider: string,
     apiKey: string,
+    endpoint?: string,
   ): Promise<void>;
   /**
    * Connect-once for the Anthropic Claude subscription in HOSTED mode. The

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -506,7 +506,7 @@ export async function handleAgents(
       json(res, authz.status, { error: authz.reason });
       return true;
     }
-    const { provider, apiKey: key } = await readJson(req);
+    const { provider, apiKey: key, endpoint } = await readJson(req);
     if (
       !provider ||
       typeof provider !== "string" ||
@@ -529,6 +529,9 @@ export async function handleAgents(
         { workspace: authz.workspace, agent: authz.agent, actingAs },
         provider,
         key.trim(),
+        typeof endpoint === "string" && endpoint.trim()
+          ? endpoint.trim()
+          : undefined,
       );
       json(res, 200, { ok: true, provider });
     } catch (err) {

--- a/packages/host/src/routes/setup-runtime.ts
+++ b/packages/host/src/routes/setup-runtime.ts
@@ -106,7 +106,7 @@ export async function handleSetupRuntime(
   // API-key provider connect (no OAuth dance): store centrally + push into the
   // setup runtime so `auth/status` reads connected immediately.
   if (rest === "credential/api-key" && method === "POST") {
-    const { provider, apiKey } = await readJson(req);
+    const { provider, apiKey, endpoint } = await readJson(req);
     if (!provider || typeof provider !== "string") {
       json(res, 400, { error: "missing 'provider'" });
       return true;
@@ -116,7 +116,14 @@ export async function handleSetupRuntime(
       return true;
     }
     try {
-      await channel.saveApiKeyCredential(ctx, provider, apiKey);
+      await channel.saveApiKeyCredential(
+        ctx,
+        provider,
+        apiKey,
+        typeof endpoint === "string" && endpoint.trim()
+          ? endpoint.trim()
+          : undefined,
+      );
       json(res, 200, { ok: true });
     } catch (err) {
       // Mirror the per-agent route: the runtime's typed verification reason

--- a/packages/runtime-client/src/client.ts
+++ b/packages/runtime-client/src/client.ts
@@ -216,13 +216,14 @@ export class HoustonEngineClient {
   /**
    * Store a pasted API key for an api-key provider. No OAuth
    * dance: the key is persisted and used directly for the provider's built-in
-   * OpenAI-compatible gateway.
+   * OpenAI-compatible gateway. Azure OpenAI additionally sends its
+   * per-resource `endpoint` (PRODUCT-1477); other providers omit it.
    */
-  setApiKey(provider: ProviderId, key: string) {
+  setApiKey(provider: ProviderId, key: string, endpoint?: string) {
     return this.json<{ ok: boolean }>(`/auth/${provider}/api-key`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ key }),
+      body: JSON.stringify({ key, ...(endpoint ? { endpoint } : {}) }),
     });
   }
   /**

--- a/packages/runtime/src/ai/azure-openai.test.ts
+++ b/packages/runtime/src/ai/azure-openai.test.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test, vi } from "vitest";
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+test("normalizeAzureEndpoint accepts https, trims a trailing slash, rejects the rest", async () => {
+  const { normalizeAzureEndpoint } = await import("./azure-openai");
+
+  expect(normalizeAzureEndpoint("https://acme.openai.azure.com")).toBe(
+    "https://acme.openai.azure.com",
+  );
+  expect(normalizeAzureEndpoint("  https://acme.openai.azure.com/  ")).toBe(
+    "https://acme.openai.azure.com",
+  );
+
+  expect(() => normalizeAzureEndpoint("")).toThrow(/missing/);
+  expect(() => normalizeAzureEndpoint("acme.openai.azure.com")).toThrow(
+    /not a valid URL/,
+  );
+  // The portal only hands out https; http would send the key in the clear.
+  expect(() => normalizeAzureEndpoint("http://acme.openai.azure.com")).toThrow(
+    /https/,
+  );
+});
+
+test("setAzureEndpoint persists and azure models resolve with the stored base URL", async () => {
+  const prevDataDir = process.env.HOUSTON_DATA_DIR;
+  const dataDir = mkdtempSync(join(tmpdir(), "houston-azure-endpoint-"));
+  process.env.HOUSTON_DATA_DIR = dataDir;
+
+  try {
+    vi.resetModules();
+    const { AZURE_OPENAI, azureBaseUrl, setAzureEndpoint, withAzureBaseUrl } =
+      await import("./azure-openai");
+    const { safeGetModel } = await import("./providers");
+
+    expect(azureBaseUrl()).toBe("");
+    setAzureEndpoint("https://acme.openai.azure.com/");
+    expect(azureBaseUrl()).toBe("https://acme.openai.azure.com");
+    // The file the pod's /data hydration carries between restarts.
+    expect(
+      JSON.parse(readFileSync(join(dataDir, "azure-endpoint.json"), "utf8")),
+    ).toEqual({ baseUrl: "https://acme.openai.azure.com" });
+
+    // The catalog ships baseUrl "" — the overlay is what makes pi able to
+    // build a request at all (its azure client throws without a base URL).
+    const model = safeGetModel(AZURE_OPENAI, "gpt-5.5", false);
+    expect(model.provider).toBe(AZURE_OPENAI);
+    expect(model.baseUrl).toBe("https://acme.openai.azure.com");
+
+    // Non-azure models are never touched by the overlay helper.
+    const bedrock = safeGetModel(
+      "amazon-bedrock",
+      "amazon.nova-lite-v1:0",
+      false,
+    );
+    expect(withAzureBaseUrl(bedrock)).toBe(bedrock);
+  } finally {
+    restoreEnv("HOUSTON_DATA_DIR", prevDataDir);
+    vi.resetModules();
+  }
+});

--- a/packages/runtime/src/ai/azure-openai.ts
+++ b/packages/runtime/src/ai/azure-openai.ts
@@ -1,0 +1,93 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { config } from "../config";
+
+/**
+ * Azure OpenAI endpoint persistence (PRODUCT-1477). Azure is the one pi
+ * catalog provider whose base URL is PER-USER — each Azure resource has its
+ * own endpoint and pi ships the catalog with `baseUrl: ""` — so a pasted key
+ * alone can never make a request. The connect flow collects the endpoint
+ * alongside the key; the key rides auth.json like every api-key provider,
+ * while the endpoint persists here (its own `azure-endpoint.json`, mirroring
+ * `openai-compatible.ts`'s custom-endpoint file) and is overlaid onto every
+ * resolved azure model's `baseUrl` (providers.ts `safeGetModel`), which pi's
+ * azure client reads when no explicit option or env var names one.
+ *
+ * Deployment names: pi calls the deployment named EXACTLY like the model id
+ * (`resolveDeploymentName`), so a deployment must be named after its model
+ * ("gpt-5.5", not "my-gpt"). The connect dialog says so.
+ */
+
+/** The provider id as pi's catalog spells it. */
+export const AZURE_OPENAI = "azure-openai-responses";
+
+/** The persisted endpoint (never the key — that lives in auth.json). */
+interface StoredAzureEndpoint {
+  baseUrl?: string;
+}
+
+/** The endpoint config's on-disk path, per data dir (pod /data persists it). */
+export const azureEndpointFileIn = (dataDir: string) =>
+  join(dataDir, "azure-endpoint.json");
+
+function load(dataDir: string = config.dataDir): StoredAzureEndpoint {
+  const file = azureEndpointFileIn(dataDir);
+  if (!existsSync(file)) return {};
+  try {
+    return JSON.parse(readFileSync(file, "utf8")) as StoredAzureEndpoint;
+  } catch {
+    return {};
+  }
+}
+
+/** The stored Azure endpoint URL, or "" when never configured. */
+export function azureBaseUrl(dataDir?: string): string {
+  return load(dataDir).baseUrl ?? "";
+}
+
+/**
+ * Validate + normalize a pasted Azure endpoint: a real https URL (the portal
+ * always hands out https; http would send the key in the clear), with any
+ * trailing slash trimmed so pi's own base-URL normalization starts clean.
+ * Throws with the user-facing reason — connect routes surface it as a 400.
+ */
+export function normalizeAzureEndpoint(raw: string): string {
+  const trimmed = raw?.trim() ?? "";
+  if (!trimmed) throw new Error("missing Azure OpenAI endpoint");
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new Error(`Azure OpenAI endpoint is not a valid URL: ${trimmed}`);
+  }
+  if (url.protocol !== "https:")
+    throw new Error("Azure OpenAI endpoint must start with https://");
+  return trimmed.replace(/\/+$/, "");
+}
+
+/** Persist the endpoint (validated). Atomic like every config write here. */
+export function setAzureEndpoint(raw: string): void {
+  const baseUrl = normalizeAzureEndpoint(raw);
+  const file = azureEndpointFileIn(config.dataDir);
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, JSON.stringify({ baseUrl }, null, 2));
+  renameSync(tmp, file);
+}
+
+/**
+ * Overlay the stored endpoint onto a resolved azure catalog model. pi's azure
+ * client resolves the base URL as option → env → `model.baseUrl`, and the
+ * catalog ships `""` — so without this overlay every request throws "base URL
+ * is required" before any HTTP. A model that already carries a base URL (a
+ * future pi catalog fix, a test double) is left alone.
+ */
+export function withAzureBaseUrl(
+  model: Model<Api>,
+  dataDir?: string,
+): Model<Api> {
+  if (model.provider !== AZURE_OPENAI || model.baseUrl) return model;
+  const baseUrl = azureBaseUrl(dataDir);
+  if (!baseUrl) return model;
+  return { ...model, baseUrl };
+}

--- a/packages/runtime/src/ai/providers.ts
+++ b/packages/runtime/src/ai/providers.ts
@@ -15,6 +15,7 @@ import {
 import { servedScopeFor } from "../auth/served-scope";
 import { authStorage, providerConnected } from "../auth/storage";
 import { config } from "../config";
+import { AZURE_OPENAI, withAzureBaseUrl } from "./azure-openai";
 import { endpointReachableCached } from "./endpoint-reachability";
 import {
   MINIMAX_PROVIDER,
@@ -237,6 +238,10 @@ function saveSettings(s: Settings) {
 const UNCURATED_DEFAULT_MODEL: Record<string, string> = {
   nvidia: "meta/llama-3.3-70b-instruct",
   moonshotai: "kimi-k3",
+  // pi's azure catalog is alphabetical, so "first model" would be gpt-4 —
+  // a 2023 model as the connect-time default. Start on the current
+  // broadly-deployed tier instead (PRODUCT-1477).
+  [AZURE_OPENAI]: "gpt-5.5",
 };
 
 /**
@@ -483,10 +488,16 @@ export function safeGetModel(
   // own contract (its declared return is non-optional; the runtime-undefined
   // case is what the pinned guard below checks) so callers keep the exact
   // pre-extension signature.
-  const lookup = (id: string): Model<Api> =>
-    (provider === QWEN_PROVIDER_ID
-      ? qwenModel(id)
-      : getModel(pp, id as Parameters<typeof getModel>[1])) as Model<Api>;
+  const lookup = (id: string): Model<Api> => {
+    const m = (
+      provider === QWEN_PROVIDER_ID
+        ? qwenModel(id)
+        : getModel(pp, id as Parameters<typeof getModel>[1])
+    ) as Model<Api>;
+    // Azure's catalog ships no base URL (the endpoint is per-resource) —
+    // overlay the connect-time endpoint or every request throws before HTTP.
+    return m && provider === AZURE_OPENAI ? withAzureBaseUrl(m) : m;
+  };
   if (pinned) {
     // pi-ai's getModel returns `undefined` (it never throws) for an id the
     // provider doesn't offer. A pinned id is NOT auto-corrected, but it must

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -4,6 +4,11 @@ import type {
 } from "@earendil-works/pi-ai";
 import type { LoginInfo } from "@houston/runtime-client";
 import {
+  AZURE_OPENAI,
+  normalizeAzureEndpoint,
+  setAzureEndpoint,
+} from "../ai/azure-openai";
+import {
   type CustomEndpointInput,
   clearCustomEndpointConfig,
   OPENAI_COMPATIBLE,
@@ -477,9 +482,18 @@ export async function startLogin(
  * pi's `api_key` credential variant; auth resolution then returns it for any
  * request against the provider's built-in OpenAI-compatible gateway. There is
  * no OAuth dance and nothing to refresh or scrub.
+ *
+ * Azure OpenAI (PRODUCT-1477) additionally requires the resource `endpoint`,
+ * persisted FIRST (its own file, ai/azure-openai.ts) so a bad URL never
+ * leaves a stored key aimed at nothing — mirroring setCustomEndpoint's order.
  */
-export function setApiKey(providerId: string, key: string): void {
-  const trimmed = assertApiKeyConnectable(providerId, key);
+export function setApiKey(
+  providerId: string,
+  key: string,
+  endpoint?: string,
+): void {
+  const trimmed = assertApiKeyConnectable(providerId, key, endpoint);
+  if (providerId === AZURE_OPENAI) setAzureEndpoint(endpoint ?? "");
   authStorage.set(providerId, { type: "api_key", key: trimmed });
   const slot = activeKey(providerId as ProviderId);
   const state = active.get(slot);
@@ -493,12 +507,19 @@ export function setApiKey(providerId: string, key: string): void {
  * fail fast on these BEFORE spending a live verification request
  * (`verifyApiKey`). Returns the trimmed key.
  */
-export function assertApiKeyConnectable(providerId: string, key: string) {
+export function assertApiKeyConnectable(
+  providerId: string,
+  key: string,
+  endpoint?: string,
+) {
   if (!known(providerId)) throw new Error(`unknown provider: ${providerId}`);
   if (providerAuthMethod(providerId) !== "apiKey")
     throw new Error(`${providerId} does not connect with a pasted API key`);
   const trimmed = key.trim();
   if (!trimmed) throw new Error("missing API key");
+  // Azure needs its per-resource endpoint alongside the key — validate the
+  // URL here so the connect fails as a cheap 400, before the live probe.
+  if (providerId === AZURE_OPENAI) normalizeAzureEndpoint(endpoint ?? "");
   return trimmed;
 }
 

--- a/packages/runtime/src/auth/verify-api-key.ts
+++ b/packages/runtime/src/auth/verify-api-key.ts
@@ -14,6 +14,16 @@ import {
 } from "./verify-errors";
 
 export type { ApiKeyVerifyReason } from "./verify-errors";
+
+/**
+ * Connect-time extras a probe needs BEFORE anything is persisted. Azure's
+ * endpoint is per-resource and arrives with the key (PRODUCT-1477): the probe
+ * must aim at it explicitly, since the stored overlay (`withAzureBaseUrl`)
+ * only exists after a successful connect.
+ */
+export interface VerifyApiKeyOptions {
+  azureBaseUrl?: string;
+}
 // The stable public surface (host routes, login, tests) predates the module
 // split — keep serving it from here.
 export { ApiKeyVerifyError, raisedMessage } from "./verify-errors";
@@ -42,6 +52,7 @@ export { ApiKeyVerifyError, raisedMessage } from "./verify-errors";
 export async function verifyApiKey(
   providerId: string,
   key: string,
+  opts?: VerifyApiKeyOptions,
 ): Promise<void> {
   // Qwen keys are REGION-scoped (Alibaba Model Studio international): probe
   // every region and persist the accepting one (`qwen-verify.ts`, HOU-1077).
@@ -61,7 +72,7 @@ export async function verifyApiKey(
     return;
   }
 
-  let message = await probeCompletion(providerId, model, key);
+  let message = await probeCompletion(providerId, model, key, opts);
   if (message === null) return;
 
   // NVIDIA serves each model per account (HOU-890): the probe model being
@@ -93,6 +104,7 @@ async function probeCompletion(
   providerId: string,
   model: Parameters<typeof completeSimple>[0],
   key: string,
+  opts?: VerifyApiKeyOptions,
 ): Promise<string | null> {
   try {
     const reply = await completeSimple(
@@ -104,6 +116,7 @@ async function probeCompletion(
         apiKey: key,
         maxTokens: 1,
         signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
+        ...(opts?.azureBaseUrl ? { azureBaseUrl: opts.azureBaseUrl } : {}),
       },
     );
     if (reply.stopReason !== "error") return null;

--- a/packages/runtime/src/transport/provider-routes.test.ts
+++ b/packages/runtime/src/transport/provider-routes.test.ts
@@ -200,6 +200,142 @@ test("GET /providers hydrates served credentials before listing providers", asyn
   }
 });
 
+test("POST /auth/azure-openai-responses/api-key requires the endpoint and persists both (PRODUCT-1477)", async () => {
+  // Azure is the one catalog provider whose base URL is per-user: the connect
+  // body carries `endpoint` alongside `key`. Verification is mocked — this
+  // test pins the ROUTE contract: endpoint validated as a cheap 400 before
+  // any probe, the probe aimed at the PASTED endpoint, and nothing persisted
+  // until the probe passes.
+  const prevDataDir = process.env.HOUSTON_DATA_DIR;
+  const dataDir = mkdtempSync(join(tmpdir(), "houston-azure-route-"));
+  process.env.HOUSTON_DATA_DIR = dataDir;
+
+  vi.doMock("../auth/verify-api-key", async (importOriginal) => ({
+    ...(await importOriginal<object>()),
+    verifyApiKey: vi.fn().mockResolvedValue(undefined),
+  }));
+  try {
+    vi.resetModules();
+    const { handleProviderRoute } = await import("./provider-routes");
+    const { verifyApiKey } = await import("../auth/verify-api-key");
+    const { azureBaseUrl } = await import("../ai/azure-openai");
+    const { authStorage } = await import("../auth/storage");
+
+    const connect = async (body: unknown) => {
+      const { res, out } = mockRes();
+      expect(
+        await handleProviderRoute({
+          method: "POST",
+          path: "/auth/azure-openai-responses/api-key",
+          url: new URL(
+            "http://runtime.test/auth/azure-openai-responses/api-key",
+          ),
+          req: mockPostReq(body),
+          res,
+        }),
+      ).toBe(true);
+      return out;
+    };
+
+    // No endpoint / a non-https endpoint: a clean 400 BEFORE any live probe,
+    // and nothing stored.
+    let out = await connect({ key: "azure-key" });
+    expect(out.status).toBe(400);
+    out = await connect({
+      key: "azure-key",
+      endpoint: "http://acme.openai.azure.com",
+    });
+    expect(out.status).toBe(400);
+    expect(verifyApiKey).not.toHaveBeenCalled();
+    expect(authStorage.get("azure-openai-responses")).toBeUndefined();
+    expect(azureBaseUrl()).toBe("");
+
+    // The good case: probe aimed at the pasted endpoint, then both persisted.
+    out = await connect({
+      key: "azure-key",
+      endpoint: "https://acme.openai.azure.com/",
+    });
+    expect(out.status).toBe(200);
+    expect(verifyApiKey).toHaveBeenCalledWith(
+      "azure-openai-responses",
+      "azure-key",
+      { azureBaseUrl: "https://acme.openai.azure.com" },
+    );
+    expect(authStorage.get("azure-openai-responses")).toEqual({
+      type: "api_key",
+      key: "azure-key",
+    });
+    expect(azureBaseUrl()).toBe("https://acme.openai.azure.com");
+
+    // Non-azure providers keep the endpoint-less contract untouched.
+    const { res, out: orOut } = mockRes();
+    await handleProviderRoute({
+      method: "POST",
+      path: "/auth/openrouter/api-key",
+      url: new URL("http://runtime.test/auth/openrouter/api-key"),
+      req: mockPostReq({ key: "sk-or-abc" }),
+      res,
+    });
+    expect(orOut.status).toBe(200);
+    expect(verifyApiKey).toHaveBeenCalledWith(
+      "openrouter",
+      "sk-or-abc",
+      undefined,
+    );
+  } finally {
+    restoreEnv("HOUSTON_DATA_DIR", prevDataDir);
+    vi.doUnmock("../auth/verify-api-key");
+    vi.resetModules();
+  }
+});
+
+test("POST /auth/azure-openai-responses/api-key persists NOTHING when the probe rejects (PRODUCT-1477)", async () => {
+  const prevDataDir = process.env.HOUSTON_DATA_DIR;
+  const dataDir = mkdtempSync(join(tmpdir(), "houston-azure-reject-"));
+  process.env.HOUSTON_DATA_DIR = dataDir;
+
+  vi.doMock("../auth/verify-api-key", async (importOriginal) => {
+    const real =
+      await importOriginal<typeof import("../auth/verify-api-key")>();
+    return {
+      ...real,
+      verifyApiKey: vi
+        .fn()
+        .mockRejectedValue(
+          new real.ApiKeyVerifyError("azure said no", "invalid_key"),
+        ),
+    };
+  });
+  try {
+    vi.resetModules();
+    const { handleProviderRoute } = await import("./provider-routes");
+    const { azureBaseUrl } = await import("../ai/azure-openai");
+    const { authStorage } = await import("../auth/storage");
+
+    const { res, out } = mockRes();
+    await handleProviderRoute({
+      method: "POST",
+      path: "/auth/azure-openai-responses/api-key",
+      url: new URL("http://runtime.test/auth/azure-openai-responses/api-key"),
+      req: mockPostReq({
+        key: "bad-key",
+        endpoint: "https://acme.openai.azure.com",
+      }),
+      res,
+    });
+    // The typed reason survives to the dialog; neither the key NOR the
+    // endpoint is left behind (a failed connect has no residue).
+    expect(out.status).toBe(401);
+    expect((out.body as { reason?: string }).reason).toBe("invalid_key");
+    expect(authStorage.get("azure-openai-responses")).toBeUndefined();
+    expect(azureBaseUrl()).toBe("");
+  } finally {
+    restoreEnv("HOUSTON_DATA_DIR", prevDataDir);
+    vi.doUnmock("../auth/verify-api-key");
+    vi.resetModules();
+  }
+});
+
 test("DELETE /auth/:provider/api-key rolls back only the exact just-connected key (PRODUCT-1321)", async () => {
   // The host calls this when its central store rejected a key the POST had
   // already verified + persisted: the runtime entry must go (a failed connect

--- a/packages/runtime/src/transport/provider-routes.ts
+++ b/packages/runtime/src/transport/provider-routes.ts
@@ -1,4 +1,5 @@
 import { parseClaudeOAuthEnvelope } from "@houston/runtime-client";
+import { AZURE_OPENAI, normalizeAzureEndpoint } from "../ai/azure-openai";
 import { refreshEndpointReachability } from "../ai/endpoint-reachability";
 import { customEndpointStatus } from "../ai/openai-compatible";
 import {
@@ -211,15 +212,19 @@ async function handleClaudeOAuthCredential(ctx: RouteContext) {
  */
 async function handleApiKey(ctx: RouteContext, provider: string) {
   let key: string;
+  let endpoint: string | undefined;
   try {
     const body = await readJson(ctx.req);
-    key = assertApiKeyConnectable(provider, String(body.key || ""));
+    // Azure OpenAI carries its per-resource endpoint alongside the key
+    // (PRODUCT-1477); other providers ignore the field.
+    endpoint = typeof body.endpoint === "string" ? body.endpoint : undefined;
+    key = assertApiKeyConnectable(provider, String(body.key || ""), endpoint);
   } catch (e) {
     json(ctx.res, 400, { error: e instanceof Error ? e.message : String(e) });
     return;
   }
   try {
-    await verifyApiKey(provider, key);
+    await verifyApiKey(provider, key, azureVerifyOptions(provider, endpoint));
   } catch (e) {
     // `reason` rides the body to the connect dialog, which maps it to
     // actionable copy (bad key vs restricted key vs provider outage).
@@ -229,8 +234,19 @@ async function handleApiKey(ctx: RouteContext, provider: string) {
     });
     return;
   }
-  setApiKey(provider, key);
+  setApiKey(provider, key, endpoint);
   json(ctx.res, 200, { ok: true });
+}
+
+/**
+ * Aim the verify probe at the pasted Azure endpoint. Explicit (never the
+ * stored overlay): at connect time nothing is persisted yet, and a re-connect
+ * must verify against the NEW endpoint, not last time's.
+ */
+function azureVerifyOptions(provider: string, endpoint: string | undefined) {
+  return provider === AZURE_OPENAI && endpoint
+    ? { azureBaseUrl: normalizeAzureEndpoint(endpoint) }
+    : undefined;
 }
 
 async function handleAuthAction(

--- a/packages/web/src/engine-adapter/client/provider-api-key.ts
+++ b/packages/web/src/engine-adapter/client/provider-api-key.ts
@@ -17,6 +17,7 @@ export async function connectApiKey(
   ctx: AdapterContext,
   name: string,
   apiKey: string,
+  endpoint?: string,
 ): Promise<void> {
   const pid = toNewProvider(name);
   if (!pid) throw new Error(`provider ${name} not supported`);
@@ -35,7 +36,7 @@ export async function connectApiKey(
     const agentId = ctx.providerAgentId();
     if (!agentId) {
       for (const target of targets) {
-        await controlPlane.setSetupApiKey(ctx.cp, target, apiKey);
+        await controlPlane.setSetupApiKey(ctx.cp, target, apiKey, endpoint);
       }
       emitEvent("ProviderLoginComplete", {
         provider: name,
@@ -45,7 +46,7 @@ export async function connectApiKey(
       return;
     }
     for (const target of targets) {
-      await controlPlane.setApiKey(ctx.cp, agentId, target, apiKey);
+      await controlPlane.setApiKey(ctx.cp, agentId, target, apiKey, endpoint);
     }
     // CLAIM (don't set) the active provider: it becomes active only when the
     // agent doesn't already resolve to one — a first connect on a fresh agent.
@@ -60,7 +61,7 @@ export async function connectApiKey(
       .claimActiveProvider(pid);
   } else {
     for (const target of targets) {
-      await ctx.engine.setApiKey(target, apiKey);
+      await ctx.engine.setApiKey(target, apiKey, endpoint);
     }
     await ctx.engine.claimActiveProvider(pid);
   }

--- a/packages/web/src/engine-adapter/client/provider-credentials-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-credentials-mixin.ts
@@ -57,8 +57,12 @@ export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
      * the whole flow (sibling gateways, the pre-agent setup path, the active
      * provider claim, and the completion event).
      */
-    async setProviderApiKey(name: string, apiKey: string): Promise<void> {
-      await connectApiKey(this.ctx, name, apiKey);
+    async setProviderApiKey(
+      name: string,
+      apiKey: string,
+      endpoint?: string,
+    ): Promise<void> {
+      await connectApiKey(this.ctx, name, apiKey, endpoint);
     }
 
     /**

--- a/packages/web/src/engine-adapter/cp/credentials.ts
+++ b/packages/web/src/engine-adapter/cp/credentials.ts
@@ -90,13 +90,18 @@ export async function setApiKey(
   agentId: string,
   provider: string,
   apiKey: string,
+  endpoint?: string,
 ): Promise<void> {
   await cpFetch(
     cfg,
     `/agents/${encodeURIComponent(agentId)}/credential/api-key`,
     {
       method: "POST",
-      body: JSON.stringify({ provider, apiKey }),
+      body: JSON.stringify({
+        provider,
+        apiKey,
+        ...(endpoint ? { endpoint } : {}),
+      }),
     },
   );
 }
@@ -171,9 +176,14 @@ export async function setSetupApiKey(
   cfg: ControlPlaneConfig,
   provider: string,
   apiKey: string,
+  endpoint?: string,
 ): Promise<void> {
   await cpFetch(cfg, `/setup-runtime/credential/api-key`, {
     method: "POST",
-    body: JSON.stringify({ provider, apiKey }),
+    body: JSON.stringify({
+      provider,
+      apiKey,
+      ...(endpoint ? { endpoint } : {}),
+    }),
   });
 }

--- a/packages/web/tests/uncurated-provider-connect.test.ts
+++ b/packages/web/tests/uncurated-provider-connect.test.ts
@@ -111,9 +111,11 @@ test("setProviderApiKey connects an uncurated pi provider instead of throwing", 
   await (await client()).setProviderApiKey("mistral", "sk-mistral-key");
 
   expect(setApiKey).toHaveBeenCalledTimes(1);
+  // The trailing undefined is the (azure-only) endpoint arg — PRODUCT-1477.
   expect(setApiKey.mock.calls[0].slice(2)).toEqual([
     "mistral",
     "sk-mistral-key",
+    undefined,
   ]);
   expect(claimActiveProvider).toHaveBeenCalledWith("mistral");
 });

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -1203,9 +1203,16 @@ export class HoustonClient {
    * Only the new TS engine serves these providers; the UI gates the call behind
    * `newEngineActive()`, so on the legacy Rust engine this route is never hit.
    */
-  setProviderApiKey(name: string, apiKey: string): Promise<void> {
+  setProviderApiKey(
+    name: string,
+    apiKey: string,
+    endpoint?: string,
+  ): Promise<void> {
+    // The legacy Rust engine has no Azure support; `endpoint` is declared for
+    // shim parity with the v3 adapter and never reaches this engine usefully.
     return this.request("POST", `/providers/${this.seg(name)}/api-key`, {
       apiKey,
+      ...(endpoint ? { endpoint } : {}),
     });
   }
   /**


### PR DESCRIPTION
## PRODUCT-1477 (Azure half)

Follow-up to #1378, which dropped the Azure OpenAI card as structurally unconnectable: every Azure request goes to the user's own resource endpoint, pi's catalog ships `baseUrl: ""` and throws before any HTTP, so a pasted key alone could never verify. This PR makes Azure connectable for real.

### How it works
- **Connect dialog** (Azure only) gains an **Endpoint** field with a get-your-key guide (en/es/pt). The guide states the deployment-naming rule: pi calls the deployment named exactly like the model id, so deployments must be named after the model (e.g. `gpt-5.5`).
- **Wire**: the api-key connect body carries an optional `endpoint`, threaded app → engine clients → host routes/channels → the runtime's `/auth/:provider/api-key`. Non-azure providers are untouched (field absent).
- **Runtime**: the endpoint persists to `azure-endpoint.json` (mirrors `custom-endpoint.json`; rides the pod's hydrated `/data`, so hosted standing pods keep it across restarts). `safeGetModel` overlays the stored URL onto every resolved azure model — pi's azure client resolves option → env → `model.baseUrl`, so chats need no streaming plumbing. The key itself rides auth.json like every api-key provider.
- **Verify-first, persist-after**: the probe aims at the *pasted* endpoint explicitly; a rejected key or bad URL persists nothing (clean 400/401 with the typed reason).
- **Catalog**: azure card restored, curated to the modern model set (pi's azure list still carries 2023-era gpt-4), uncurated default `gpt-5.5`.

### Deployment notes
- Old engine pods ignore the new field and fail exactly as today ("couldn't reach") until the next engine roll — no corruption path.
- The legacy cloudrun per-turn channel refuses azure explicitly (no endpoint hydration exists there); mirrors its Claude refusal.
- Central credential sync (C6) carries only the key; the endpoint lives in pod `/data`. A future cloud-side field could centralize it (enterpriseUrl precedent) — not needed for standing pods.

### Tests
New: runtime `azure-openai.test.ts` (validation, persistence, model overlay), two route tests (endpoint required before any probe; probe aimed at pasted endpoint; nothing persisted on rejection), app overrides test. Suites: runtime 1329, host 1574, app 3758, web 422 pass; typecheck, biome, check-locales clean.