### PR TITLE
Pool turns: resume the conversation's newest session, wherever it was written

### DIFF
--- a/packages/runtime/src/backends/pi/backend.test.ts
+++ b/packages/runtime/src/backends/pi/backend.test.ts
@@ -48,6 +48,14 @@ test("resumes the conversation's newest session even when it was written under a
   expect(fixed.getSessionFile()).toBe(newest);
   expect(fixed.getCwd()).toBe(thisTurnRoot);
 
+  // A corrupt newer file (a crash mid-write) must not be opened and
+  // rewritten as a blank session: skip to the newest READABLE one.
+  writeFileSync(join(dir, "2026-08-24T03-00-00-000Z_torn.jsonl"), "");
+  writeFileSync(join(dir, "2026-08-24T03-01-00-000Z_junk.jsonl"), "not json\n");
+  expect(resumeSessionManager(thisTurnRoot, dir, false).getSessionFile()).toBe(
+    newest,
+  );
+
   // A cross-backend rebuild still starts clean (HOU-951).
   expect(
     resumeSessionManager(thisTurnRoot, dir, true).getSessionFile(),

--- a/packages/runtime/src/backends/pi/backend.test.ts
+++ b/packages/runtime/src/backends/pi/backend.test.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CURRENT_SESSION_VERSION,
+  SessionManager,
+} from "@earendil-works/pi-coding-agent";
+import { expect, test } from "vitest";
+import { resumeSessionManager } from "./backend";
+
+function seedSession(dir: string, name: string, cwd: string): string {
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, name);
+  writeFileSync(
+    file,
+    `${JSON.stringify({
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: name.replace(/\.jsonl$/, ""),
+      timestamp: new Date().toISOString(),
+      cwd,
+    })}\n`,
+  );
+  return file;
+}
+
+test("resumes the conversation's newest session even when it was written under another root", () => {
+  // The pool bug: every worker turn hydrates the agent into a fresh temp
+  // root, so the cwd recorded in the previous turn's session header never
+  // matches — continueRecent started a BLANK session per turn and the model
+  // had no memory of the conversation.
+  const dir = mkdtempSync(join(tmpdir(), "pi-sessions-"));
+  seedSession(dir, "2026-08-24T01-00-00-000Z_old.jsonl", "/tmp/turn-root-A/ws");
+  const newest = seedSession(
+    dir,
+    "2026-08-24T02-00-00-000Z_new.jsonl",
+    "/tmp/turn-root-B/ws",
+  );
+  const thisTurnRoot = mkdtempSync(join(tmpdir(), "turn-root-C-"));
+
+  // The old call finds nothing under a different cwd — the bug: it does
+  // NOT reopen the newest file.
+  const broken = SessionManager.continueRecent(thisTurnRoot, dir);
+  expect(broken.getSessionFile()).not.toBe(newest);
+
+  // The fix reopens the newest file at THIS turn's root.
+  const fixed = resumeSessionManager(thisTurnRoot, dir, false);
+  expect(fixed.getSessionFile()).toBe(newest);
+  expect(fixed.getCwd()).toBe(thisTurnRoot);
+
+  // A cross-backend rebuild still starts clean (HOU-951).
+  expect(
+    resumeSessionManager(thisTurnRoot, dir, true).getSessionFile(),
+  ).not.toBe(newest);
+
+  // An empty conversation starts a new session (no throw on a missing dir).
+  const empty = mkdtempSync(join(tmpdir(), "pi-sessions-empty-"));
+  const started = resumeSessionManager(
+    thisTurnRoot,
+    join(empty, "none"),
+    false,
+  );
+  expect(started.getSessionFile()).not.toBe(newest);
+});

--- a/packages/runtime/src/backends/pi/backend.test.ts
+++ b/packages/runtime/src/backends/pi/backend.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -37,6 +37,10 @@ test("resumes the conversation's newest session even when it was written under a
     "/tmp/turn-root-B/ws",
   );
   const thisTurnRoot = mkdtempSync(join(tmpdir(), "turn-root-C-"));
+  // Pin FILENAME order, not mtime: hydration rewrites mtimes in download
+  // order, so make the newest-NAMED file the oldest-by-mtime.
+  const past = new Date(Date.now() - 3_600_000);
+  utimesSync(newest, past, past);
 
   // The old call finds nothing under a different cwd — the bug: it does
   // NOT reopen the newest file.

--- a/packages/runtime/src/backends/pi/backend.ts
+++ b/packages/runtime/src/backends/pi/backend.ts
@@ -1,3 +1,4 @@
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import {
@@ -40,6 +41,47 @@ export interface PiBackendDeps {
  * empty session every time, so a fresh process (runtime restart, or a cloud
  * sandbox woken from sleep) would silently lose all prior turns.
  */
+/**
+ * Reopen the conversation's NEWEST session file, wherever it was written.
+ *
+ * `SessionManager.continueRecent` filters candidates by the cwd recorded in
+ * each session header. On a standing pod the workspace path never changes, so
+ * that filter is a no-op — but a pool worker hydrates the agent into a fresh
+ * temp root for every turn, so no prior header can ever match and every turn
+ * silently started a BLANK session: the model answered with no memory of the
+ * conversation while the transcript looked complete everywhere else. The
+ * sessions/<conversationId>/ dir is per-conversation by construction — every
+ * file in it belongs to this conversation — so the newest file is the one to
+ * resume, no cwd questions asked, opened AT this turn's workspace path.
+ *
+ * Newest by FILENAME: pi names session files with an ISO-timestamp prefix,
+ * which sorts chronologically; mtimes would lie here (hydration rewrites
+ * them in download order).
+ */
+export function resumeSessionManager(
+  workspaceDir: string,
+  sessionDir: string,
+  fresh: boolean,
+): SessionManager {
+  if (!fresh) {
+    const newest = newestSessionFile(sessionDir);
+    if (newest) return SessionManager.open(newest, sessionDir, workspaceDir);
+  }
+  return SessionManager.create(workspaceDir, sessionDir);
+}
+
+function newestSessionFile(sessionDir: string): string | null {
+  let files: string[];
+  try {
+    files = readdirSync(sessionDir).filter((f) => f.endsWith(".jsonl"));
+  } catch {
+    return null;
+  }
+  if (files.length === 0) return null;
+  files.sort();
+  return join(sessionDir, files[files.length - 1] as string);
+}
+
 export function createPiBackend(deps: PiBackendDeps): HarnessBackend {
   return {
     id: "pi",
@@ -68,15 +110,11 @@ export function createPiBackend(deps: PiBackendDeps): HarnessBackend {
         // history arrives as a transcript replay on the first prompt (HOU-951),
         // and a conversation returning to pi after a Claude era must not resume
         // its stale pre-switch session on top of that replay.
-        sessionManager: opts.fresh
-          ? SessionManager.create(
-              deps.workspaceDir,
-              join(deps.dataDir, "sessions", opts.conversationId),
-            )
-          : SessionManager.continueRecent(
-              deps.workspaceDir,
-              join(deps.dataDir, "sessions", opts.conversationId),
-            ),
+        sessionManager: resumeSessionManager(
+          deps.workspaceDir,
+          join(deps.dataDir, "sessions", opts.conversationId),
+          opts.fresh === true,
+        ),
         resourceLoader: loader,
         tools: toolNamesForMode(opts.mode, deps.tools),
         customTools: deps.customTools,

--- a/packages/runtime/src/backends/pi/backend.ts
+++ b/packages/runtime/src/backends/pi/backend.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import {
@@ -77,9 +77,27 @@ function newestSessionFile(sessionDir: string): string | null {
   } catch {
     return null;
   }
-  if (files.length === 0) return null;
   files.sort();
-  return join(sessionDir, files[files.length - 1] as string);
+  // Newest → oldest, skipping anything that is not a readable pi session
+  // (a zero-byte file left by a crash mid-write, junk): opening a corrupt
+  // "newest" would rewrite it as a BLANK session and silently discard the
+  // conversation's context — the exact failure this helper exists to end.
+  for (let i = files.length - 1; i >= 0; i--) {
+    const candidate = join(sessionDir, files[i] as string);
+    if (isReadableSession(candidate)) return candidate;
+  }
+  return null;
+}
+
+function isReadableSession(file: string): boolean {
+  try {
+    const head = readFileSync(file, "utf8").split("\n", 1)[0] ?? "";
+    if (!head) return false;
+    const parsed = JSON.parse(head) as { type?: unknown };
+    return parsed.type === "session";
+  } catch {
+    return false;
+  }
 }
 
 export function createPiBackend(deps: PiBackendDeps): HarnessBackend {

--- a/packages/runtime/src/backends/pi/backend.ts
+++ b/packages/runtime/src/backends/pi/backend.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { closeSync, openSync, readdirSync, readSync } from "node:fs";
 import { join } from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import {
@@ -74,8 +74,12 @@ function newestSessionFile(sessionDir: string): string | null {
   let files: string[];
   try {
     files = readdirSync(sessionDir).filter((f) => f.endsWith(".jsonl"));
-  } catch {
-    return null;
+  } catch (err) {
+    // ONLY a missing dir means "no sessions yet". Anything else (EIO,
+    // EACCES, fd exhaustion) must fail the turn loudly — swallowing it
+    // would answer with silent amnesia, the exact bug this helper ends.
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
   }
   files.sort();
   // Newest → oldest, skipping anything that is not a readable pi session
@@ -90,13 +94,24 @@ function newestSessionFile(sessionDir: string): string | null {
 }
 
 function isReadableSession(file: string): boolean {
+  // Bounded: only the header line matters, and session files grow to MBs.
+  const buffer = Buffer.alloc(64 * 1024);
+  let descriptor: number;
   try {
-    const head = readFileSync(file, "utf8").split("\n", 1)[0] ?? "";
+    descriptor = openSync(file, "r");
+  } catch {
+    return false;
+  }
+  try {
+    const bytes = readSync(descriptor, buffer, 0, buffer.length, 0);
+    const head = buffer.toString("utf8", 0, bytes).split("\n", 1)[0] as string;
     if (!head) return false;
     const parsed = JSON.parse(head) as { type?: unknown };
     return parsed.type === "session";
   } catch {
     return false;
+  } finally {
+    closeSync(descriptor);
   }
 }
 


### PR DESCRIPTION
## What broke (live, staging)
Multi-turn chats on the pool had **no memory**: "what was my first message?" quoted itself; "hi" follow-ups got generic greetings. Postgres, the conversation file and the UI transcript were all complete — only the model's context was empty.

## Why
The model's context is the **session JSONL**, not the conversation file. `SessionManager.continueRecent` filters candidate sessions by the cwd recorded in each file's header. A standing pod's workspace path never changes, so the filter never bites. A pool worker hydrates the agent into a **fresh temp root every turn** — no prior header can match, so every pool turn started a blank session. (GCS shows it plainly: one session file per turn since pool sends shipped. The bench-72000 "ok → Hi! How can I help?" report two days ago was this same bug.)

## Fix
`sessions/<conversationId>/` is per-conversation by construction, so the newest file in it *is* this conversation's session. Reopen it at this turn's root (`SessionManager.open` with a cwd override); newest by **filename** (ISO-timestamp prefix — mtimes lie after hydration). `fresh` (cross-backend rebuild, HOU-951) still starts clean. Also heals the mirror case: a pod waking after pool turns now resumes the pool-written session instead of ignoring it.

## Tests
`backend.test.ts` reproduces the bug (`continueRecent` under a different root does not reopen the newest file) and pins the fix (reopened at this turn's root; fresh/new-conversation paths keep their behavior). Host 1541 / runtime 1288 green.

## Also observed, not in this PR
"Streaming pauses 2–3 s then continues": asleep-agent streams are turnlog-polled (gateway 750 ms poll) over worker-side frame batches, so chunks arrive in bursts on top of the model's own thinking pauses (extra-high reasoning). Tuning tracked with PRODUCT-1470/1471.

## Adversarial reviews (Fable 5 + Codex gpt-5.6-sol) — folded in
- **Torn/zero-byte/corrupt newest file** (High, both): skipped — the walk resumes the newest *readable* session instead of throwing every turn (torn header) or silently rewriting a blank session over the shadowed history (zero-byte).
- **ENOENT-only discovery** (Fable): any other readdir failure fails the turn loudly, never silent amnesia.
- **Bounded header read**; **mtime-proof test** (the newest-named file is made oldest-by-mtime, so a regression to mtime sorting fails).
- Cleared by both: `open` with cwd override (full-load path intact — leaf/compaction/session-id unaffected), filename chronology across every producer, standing-pod mode-switch call sites, sync-back + claim scope for `sessions/<cid>/`, mutant-killing test.
- **Deferred, documented** (Fable, Low): a conversation with a Claude-SDK era on a pod that later lands on the pool resumes its pre-Claude pi session (before this PR it started blank — neither sees the Claude era). Needs a backend-era marker in the turn envelope; tracked in PRODUCT-1469's follow-ups.
