### PR TITLE
fix(host): view-docs boot warm outlasts the runtime's 60s boot budget (PRODUCT-1488)

### DIFF
--- a/packages/host/src/docs/view-warm.test.ts
+++ b/packages/host/src/docs/view-warm.test.ts
@@ -2,7 +2,7 @@ import type { HoustonEvent } from "@houston/protocol";
 import { expect, test, vi } from "vitest";
 import type { EventHub } from "../events/hub";
 import { MemoryWorkspaceStore } from "../store/memory";
-import { refreshViewsOnEvents } from "./view-warm";
+import { refreshViewsOnEvents, warmViewDocs } from "./view-warm";
 
 function hub(): EventHub & { fire: (e: HoustonEvent) => void } {
   const handlers: Array<(e: HoustonEvent) => void> = [];
@@ -17,6 +17,30 @@ function hub(): EventHub & { fire: (e: HoustonEvent) => void } {
     },
   };
 }
+
+// A freshly woken pod's runtime may take its whole 60s boot-health budget
+// (probes answer 503 throughout); the warm must outlast that, not give up
+// mid-boot (HOUSTON-APP-5AP).
+test("boot warm outlasts a runtime that takes 70s to become healthy", async () => {
+  vi.useFakeTimers();
+  const store = new MemoryWorkspaceStore();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  await store.createAgent({ workspaceId: workspace.id, name: "Only" });
+  const start = Date.now();
+  const statuses: number[] = [];
+  const fetchImpl = vi.fn(async () => {
+    const status = Date.now() - start < 70_000 ? 503 : 200;
+    statuses.push(status);
+    return new Response("{}", { status });
+  }) as unknown as typeof fetch;
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  warmViewDocs({ port: 4318, token: "t", store, fetchImpl });
+  await vi.advanceTimersByTimeAsync(200_000);
+  expect(statuses).toContain(200);
+  expect(errorSpy).not.toHaveBeenCalled();
+  errorSpy.mockRestore();
+  vi.useRealTimers();
+});
 
 test("a SkillsChanged event re-fetches /skills for that agent (debounced)", async () => {
   vi.useFakeTimers();

--- a/packages/host/src/docs/view-warm.ts
+++ b/packages/host/src/docs/view-warm.ts
@@ -3,7 +3,13 @@ import type { EventHub } from "../events/hub";
 import type { WorkspaceStore } from "../ports";
 import { VIEW_RESTS } from "./view-capture";
 
-const ATTEMPTS = 4;
+// The ladder must OUTLAST the launcher's 60s boot-health budget
+// (launcher/process.ts BOOT_HEALTH_BUDGET_MS): `/providers` probes answer 503
+// while the runtime boots, and on a freshly woken pod the boot competes with
+// store hydration for a capped CPU (observed >35s). 9 attempts × 10s spacing
+// ≈ 85s of coverage — a give-up now means a runtime that blew its own boot
+// budget, not a slow-but-healthy wake (HOUSTON-APP-5AP).
+const ATTEMPTS = 9;
 const RETRY_DELAY_MS = 10_000;
 const REFRESH_DEBOUNCE_MS = 500;
 


### PR DESCRIPTION
## Summary

Sentry HOUSTON-APP-5AP: `[view-docs] boot warm for providers gave up (last status 503)` — 387 events / 320 users since the pod-less view docs shipped (#1365).

**Root cause:** the boot self-warm's retry ladder (4 attempts × 10s ≈ 35s of coverage) is shorter than the runtime's own boot budget. `/providers` is a probe route: while the runtime cold-boots, each probe answers 503 + `Retry-After` after a 1.5s wake race (`channel/probe-wake.ts`), and the launcher grants that boot up to 60s (`launcher/process.ts` `BOOT_HEALTH_BUDGET_MS`). On a freshly woken cloud pod the runtime boot competes with store hydration for a capped CPU (the Sentry breadcrumbs show hydration alone taking 42.6s, boot done at +56s), so the warm routinely gave up mid-boot on a slow-but-healthy wake and reported an error for a non-failure.

**Fix:** extend the ladder to 9 attempts (~85s of coverage) so it outlasts the boot budget. A give-up now means the runtime blew its own 60s budget — a real failure worth reporting — not a slow wake.

PRODUCT-1488

## Verification

Before: with a runtime that takes >~32s to become healthy, `warmViewDocs` logs `boot warm for providers gave up (last status 503)` even though the boot succeeds moments later.

After: new test `boot warm outlasts a runtime that takes 70s to become healthy` simulates 70s of 503s and asserts the warm reaches a 200 with no error logged.

- `pnpm --filter @houston/host test` — 174 files, 1575 passed
- `pnpm check` — clean
- Post-deploy: HOUSTON-APP-5AP event rate should drop to ~0; remaining events indicate runtimes genuinely exceeding the 60s boot budget.