### PR TITLE
fix(host): quiet the four stateless-staging Sentry noise classes

### DIFF
--- a/packages/host/src/docs/http-shadow.test.ts
+++ b/packages/host/src/docs/http-shadow.test.ts
@@ -119,6 +119,7 @@ test("a failed boot seed stays unseeded and the next PUT lazily fetches", async 
       fence: {},
     },
     fetchImpl: fetchImpl as typeof fetch,
+    retryDelaysMs: [],
   });
 
   await shadow.seed();
@@ -181,6 +182,141 @@ test("canonicalJSON keeps a parsed __proto__ key as content", () => {
   const withoutProto = JSON.parse('{"b":2}') as unknown;
   expect(canonicalJSON(withProto)).not.toBe(canonicalJSON(withoutProto));
   expect(canonicalJSON(withProto)).toContain("__proto__");
+});
+
+const GATEWAY = {
+  baseUrl: "https://store.example",
+  orgSlug: "acme",
+  agentSlug: "helper",
+  podToken: "pod-token",
+  bootId: "boot-1",
+  fence: {},
+};
+
+test("an unknown-family 400 latches that family only, at warning level", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  const requests: RequestInit[] = [];
+  const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+    requests.push(init ?? {});
+    if (String(url).endsWith("/skills")) {
+      return Response.json(
+        { error: "invalid document family" },
+        { status: 400 },
+      );
+    }
+    if (!init?.method) return Response.json({ doc: [], revision: 1 });
+    return Response.json({ revision: 2 });
+  });
+  const shadow = new HttpDocShadow({
+    gateway: GATEWAY,
+    fetchImpl: fetchImpl as typeof fetch,
+    retryDelaysMs: [],
+  });
+
+  await expect(shadow.put("skills", [{ id: "s1" }])).resolves.toBeUndefined();
+  await shadow.put("skills", [{ id: "s2" }]);
+  const skillsRequests = requests.length;
+  // A family the gateway does know keeps projecting.
+  await shadow.put("activity", [{ id: "a1" }]);
+
+  expect(skillsRequests).toBe(1);
+  expect(requests.length).toBe(3);
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining("does not know family skills"),
+  );
+  expect(error).not.toHaveBeenCalled();
+  warn.mockRestore();
+  error.mockRestore();
+});
+
+test("a 503 PUT retries on the ladder and succeeds", async () => {
+  const requests: RequestInit[] = [];
+  let failures = 1;
+  const fetchImpl = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+    requests.push(init ?? {});
+    if (!init?.method) return Response.json({ doc: [], revision: 4 });
+    if (failures-- > 0) {
+      return Response.json(
+        { error: "transcript store unavailable" },
+        { status: 503 },
+      );
+    }
+    return Response.json({ revision: 5 });
+  });
+  const shadow = new HttpDocShadow({
+    gateway: GATEWAY,
+    fetchImpl: fetchImpl as typeof fetch,
+    retryDelaysMs: [0],
+  });
+
+  await shadow.put("activity", [{ id: "a1" }]);
+
+  expect(requests.filter((request) => request.method === "PUT")).toHaveLength(
+    2,
+  );
+});
+
+test("an exhausted 503 defers at warning and the next publish retries", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  const requests: RequestInit[] = [];
+  let unavailable = true;
+  const fetchImpl = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+    requests.push(init ?? {});
+    if (!init?.method) return Response.json({ doc: [], revision: 4 });
+    if (unavailable) {
+      return Response.json(
+        { error: "transcript store unavailable" },
+        { status: 503 },
+      );
+    }
+    return Response.json({ revision: 5 });
+  });
+  const shadow = new HttpDocShadow({
+    gateway: GATEWAY,
+    fetchImpl: fetchImpl as typeof fetch,
+    retryDelaysMs: [],
+  });
+
+  await expect(shadow.put("activity", [{ id: "a1" }])).resolves.toBeUndefined();
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining("activity PUT deferred"),
+  );
+  expect(error).not.toHaveBeenCalled();
+
+  unavailable = false;
+  await shadow.put("activity", [{ id: "a1" }]);
+  // The cached revision survived the deferral: no re-seed, straight to PUT.
+  expect(requests.map((request) => request.method ?? "GET")).toEqual([
+    "GET",
+    "PUT",
+    "PUT",
+  ]);
+  warn.mockRestore();
+  error.mockRestore();
+});
+
+test("a 503 seed defers at warning, never a Sentry error", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  const fetchImpl = vi.fn(async () =>
+    Response.json({ error: "transcript store unavailable" }, { status: 503 }),
+  );
+  const shadow = new HttpDocShadow({
+    gateway: GATEWAY,
+    fetchImpl: fetchImpl as typeof fetch,
+    retryDelaysMs: [],
+  });
+
+  await shadow.put("activity", [{ id: "a1" }]);
+
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining("activity seed deferred"),
+  );
+  expect(error).not.toHaveBeenCalled();
+  warn.mockRestore();
+  error.mockRestore();
 });
 
 test("put with an undefined doc throws instead of silently skipping", async () => {

--- a/packages/host/src/docs/http-shadow.ts
+++ b/packages/host/src/docs/http-shadow.ts
@@ -1,18 +1,14 @@
 import { FAMILIES, type HoustonFamily } from "@houston/domain";
 import {
-  capturePodFence,
   type PodGatewayConfig,
   podGatewayHeaders,
   podGatewayUrl,
 } from "../pod-gateway";
+import { ShadowUnavailableError, shadowFetch } from "./shadow-fetch";
+import { publishDoc } from "./shadow-put";
+import { seedFromResponse } from "./shadow-seed";
 import type { ViewFamily } from "./view-capture";
-import {
-  canonicalJSON,
-  etagRevision,
-  parseDocBody,
-  responseError,
-  responseRevision,
-} from "./wire";
+import { canonicalJSON } from "./wire";
 
 export { canonicalJSON } from "./wire";
 
@@ -32,15 +28,22 @@ export class HttpDocShadow implements DocShadow {
   // content seed idempotent: an unchanged file costs one GET, never a PUT,
   // so revisions do not churn on every pod boot.
   private readonly remote = new Map<ShadowFamily, string>();
+  // Families a skewed gateway rejected as unknown (engine ahead of its
+  // allow-list). Per-family, unlike the process-wide route skew latch: one
+  // new view family must not kill projection for the families it does know.
+  private readonly unsupported = new Set<ShadowFamily>();
+  private readonly retryDelaysMs: number[];
   private disabled = false;
 
   constructor(
     private readonly opts: {
       gateway: PodGatewayConfig;
       fetchImpl?: typeof fetch;
+      retryDelaysMs?: number[];
     },
   ) {
     this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.retryDelaysMs = opts.retryDelaysMs ?? [500, 2_000];
   }
 
   async seed(): Promise<void> {
@@ -48,7 +51,7 @@ export class HttpDocShadow implements DocShadow {
   }
 
   async put(family: ShadowFamily, doc: unknown): Promise<void> {
-    if (this.disabled) return;
+    if (this.disabled || this.unsupported.has(family)) return;
     if (doc === undefined) {
       // canonicalJSON(undefined) is not a string; comparing it against a
       // missing cache entry would silently skip the write. No caller may
@@ -65,24 +68,25 @@ export class HttpDocShadow implements DocShadow {
     if (cachedRevision === undefined) {
       throw new Error(`[doc-shadow] ${family} revision unavailable after seed`);
     }
-    const response = await this.putAtRevision(family, doc, cachedRevision);
-    if (response.status === 409) {
-      const revision = await responseRevision(response);
-      if (revision === undefined) {
-        this.revisions.delete(family);
-        this.remote.delete(family);
-        console.debug(
-          `[doc-shadow] ${family} revision conflict without current revision; re-seeding on next write`,
-        );
-        return;
+    try {
+      const outcome = await publishDoc({
+        family,
+        doc,
+        canonical,
+        revision: cachedRevision,
+        putAtRevision: (revision) => this.putAtRevision(family, doc, revision),
+        caches: { revisions: this.revisions, remote: this.remote },
+      });
+      if (outcome.skew) this.disableForSkew();
+      if (outcome.unsupported !== undefined) {
+        this.markUnsupported(family, outcome.unsupported);
       }
-      this.revisions.set(family, revision);
-      this.remote.delete(family);
-      const retry = await this.putAtRevision(family, doc, revision);
-      await this.acceptPutResponse(family, retry, canonical);
-      return;
+    } catch (error) {
+      if (!(error instanceof ShadowUnavailableError)) throw error;
+      // Self-healing: the cached revision survives and the next capture or
+      // warm tick re-publishes. A warning breadcrumb, never a Sentry error.
+      console.warn(`[doc-shadow] ${family} PUT deferred: ${error.message}`);
     }
-    await this.acceptPutResponse(family, response, canonical);
   }
 
   private async putAtRevision(
@@ -90,72 +94,47 @@ export class HttpDocShadow implements DocShadow {
     doc: unknown,
     revision: number,
   ): Promise<Response> {
-    const response = await this.fetchImpl(this.url(family), {
-      method: "PUT",
-      headers: podGatewayHeaders(this.opts.gateway, {
-        write: true,
-        json: true,
-        extra: { "If-Match": String(revision) },
+    return shadowFetch({
+      fetchImpl: this.fetchImpl,
+      gateway: this.opts.gateway,
+      url: this.url(family),
+      retryDelaysMs: this.retryDelaysMs,
+      init: () => ({
+        method: "PUT",
+        headers: podGatewayHeaders(this.opts.gateway, {
+          write: true,
+          json: true,
+          extra: { "If-Match": String(revision) },
+        }),
+        body: JSON.stringify({ doc }),
+        signal: AbortSignal.timeout(5_000),
       }),
-      body: JSON.stringify({ doc }),
-      signal: AbortSignal.timeout(5_000),
     });
-    capturePodFence(this.opts.gateway, response);
-    return response;
-  }
-
-  private async acceptPutResponse(
-    family: ShadowFamily,
-    response: Response,
-    canonical: string,
-  ): Promise<void> {
-    if (response.status === 404) return this.disableForSkew();
-    if (response.status === 409) {
-      const revision = await responseRevision(response);
-      if (revision === undefined) this.revisions.delete(family);
-      else this.revisions.set(family, revision);
-      this.remote.delete(family);
-      console.debug(
-        `[doc-shadow] ${family} revision conflict; file remains authoritative`,
-      );
-      return;
-    }
-    if (!response.ok) throw await responseError(response, family, "PUT");
-    const revision = await responseRevision(response);
-    if (revision !== undefined) this.revisions.set(family, revision);
-    this.remote.set(family, canonical);
   }
 
   private async seedFamily(family: ShadowFamily): Promise<boolean> {
-    if (this.disabled) return false;
-    try {
-      const response = await this.fetchImpl(this.url(family), {
+    if (this.disabled || this.unsupported.has(family)) return false;
+    const outcome = await seedFromResponse(family, () => this.getDoc(family), {
+      revisions: this.revisions,
+      remote: this.remote,
+    });
+    if (outcome.unsupported !== undefined) {
+      this.markUnsupported(family, outcome.unsupported);
+    }
+    return outcome.seeded;
+  }
+
+  private getDoc(family: ShadowFamily): Promise<Response> {
+    return shadowFetch({
+      fetchImpl: this.fetchImpl,
+      gateway: this.opts.gateway,
+      url: this.url(family),
+      retryDelaysMs: this.retryDelaysMs,
+      init: () => ({
         headers: podGatewayHeaders(this.opts.gateway),
         signal: AbortSignal.timeout(5_000),
-      });
-      capturePodFence(this.opts.gateway, response);
-      if (response.status === 404) {
-        this.revisions.set(family, 0);
-        this.remote.delete(family);
-        return true;
-      }
-      if (!response.ok) throw await responseError(response, family, "GET");
-      const text = await response.text();
-      const parsed = parseDocBody(text);
-      const etag = etagRevision(response);
-      this.revisions.set(family, etag ?? parsed.revision ?? 0);
-      if (parsed.doc !== undefined) {
-        this.remote.set(family, canonicalJSON(parsed.doc));
-      } else {
-        this.remote.delete(family);
-      }
-      return true;
-    } catch (error) {
-      console.error(`[doc-shadow] ${family} revision seed failed`, error);
-      this.revisions.delete(family);
-      this.remote.delete(family);
-      return false;
-    }
+      }),
+    });
   }
 
   private url(family: ShadowFamily): string {
@@ -171,6 +150,14 @@ export class HttpDocShadow implements DocShadow {
     this.disabled = true;
     console.debug(
       "[doc-shadow] gateway route unavailable; disabling for this process",
+    );
+  }
+
+  private markUnsupported(family: ShadowFamily, detail: string): void {
+    if (this.unsupported.has(family)) return;
+    this.unsupported.add(family);
+    console.warn(
+      `[doc-shadow] gateway does not know family ${family} (deploy skew); skipping it until restart: ${detail}`,
     );
   }
 }

--- a/packages/host/src/docs/shadow-fetch.ts
+++ b/packages/host/src/docs/shadow-fetch.ts
@@ -1,0 +1,50 @@
+import { capturePodFence, type PodGatewayConfig } from "../pod-gateway";
+
+const RETRYABLE = new Set([502, 503, 504]);
+
+/**
+ * The gateway answered 5xx (or did not answer) through every retry. Transient
+ * by contract — the transcript store is rebooting or its schema migration has
+ * not landed yet — and the shadow is a projection the next publish re-sends,
+ * so callers log a warning and move on, never a Sentry error.
+ */
+export class ShadowUnavailableError extends Error {
+  constructor(detail: string, cause?: unknown) {
+    super(detail, cause === undefined ? undefined : { cause });
+    this.name = "ShadowUnavailableError";
+  }
+}
+
+/**
+ * Fetch with the pod-gateway retry ladder (mirrors HttpTurnLogSender): 5xx
+ * and thrown fetch failures retry on a short backoff; any other status
+ * returns to the caller for its own classification. `init` is a factory so
+ * each attempt gets a fresh AbortSignal.
+ */
+export async function shadowFetch(opts: {
+  fetchImpl: typeof fetch;
+  gateway: PodGatewayConfig;
+  url: string;
+  init: () => RequestInit;
+  retryDelaysMs: number[];
+}): Promise<Response> {
+  let lastFailure: unknown;
+  for (let attempt = 0; attempt <= opts.retryDelaysMs.length; attempt++) {
+    try {
+      const response = await opts.fetchImpl(opts.url, opts.init());
+      capturePodFence(opts.gateway, response);
+      if (!RETRYABLE.has(response.status)) return response;
+      lastFailure = new ShadowUnavailableError(
+        `gateway answered ${response.status}: ${(await response.text()).slice(0, 300)}`,
+      );
+    } catch (error) {
+      lastFailure = error;
+    }
+    const delay = opts.retryDelaysMs[attempt];
+    if (delay === undefined) break;
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+  throw lastFailure instanceof ShadowUnavailableError
+    ? lastFailure
+    : new ShadowUnavailableError("gateway unreachable", lastFailure);
+}

--- a/packages/host/src/docs/shadow-put.ts
+++ b/packages/host/src/docs/shadow-put.ts
@@ -1,0 +1,75 @@
+import type { SeedCaches } from "./shadow-seed";
+import {
+  responseError,
+  responseRevision,
+  unknownFamilyRejection,
+} from "./wire";
+
+export interface PutOutcome {
+  /** The doc route itself is gone: the whole shadow must latch off. */
+  skew?: boolean;
+  /** The gateway rejected the family as unknown (deploy skew). */
+  unsupported?: string;
+}
+
+/**
+ * One conditional PUT plus a single adopt-and-retry on a revision conflict.
+ * The caches are refreshed exactly like the seed path: an accepted PUT records
+ * the new revision and canonical content; a conflict yields to the file as
+ * authoritative. Unavailability (ShadowUnavailableError) propagates for the
+ * caller to defer.
+ */
+export async function publishDoc<F extends string>(opts: {
+  family: F;
+  doc: unknown;
+  canonical: string;
+  revision: number;
+  putAtRevision: (revision: number) => Promise<Response>;
+  caches: SeedCaches<F>;
+}): Promise<PutOutcome> {
+  const response = await opts.putAtRevision(opts.revision);
+  if (response.status === 409) {
+    const revision = await responseRevision(response);
+    if (revision === undefined) {
+      opts.caches.revisions.delete(opts.family);
+      opts.caches.remote.delete(opts.family);
+      console.debug(
+        `[doc-shadow] ${opts.family} revision conflict without current revision; re-seeding on next write`,
+      );
+      return {};
+    }
+    opts.caches.revisions.set(opts.family, revision);
+    opts.caches.remote.delete(opts.family);
+    const retry = await opts.putAtRevision(revision);
+    return acceptPutResponse(opts, retry);
+  }
+  return acceptPutResponse(opts, response);
+}
+
+async function acceptPutResponse<F extends string>(
+  opts: { family: F; canonical: string; caches: SeedCaches<F> },
+  response: Response,
+): Promise<PutOutcome> {
+  if (response.status === 404) return { skew: true };
+  if (response.status === 409) {
+    const revision = await responseRevision(response);
+    if (revision === undefined) opts.caches.revisions.delete(opts.family);
+    else opts.caches.revisions.set(opts.family, revision);
+    opts.caches.remote.delete(opts.family);
+    console.debug(
+      `[doc-shadow] ${opts.family} revision conflict; file remains authoritative`,
+    );
+    return {};
+  }
+  if (!response.ok) {
+    const error = await responseError(response, opts.family, "PUT");
+    if (unknownFamilyRejection(response.status, error.message)) {
+      return { unsupported: error.message };
+    }
+    throw error;
+  }
+  const revision = await responseRevision(response);
+  if (revision !== undefined) opts.caches.revisions.set(opts.family, revision);
+  opts.caches.remote.set(opts.family, opts.canonical);
+  return {};
+}

--- a/packages/host/src/docs/shadow-seed.ts
+++ b/packages/host/src/docs/shadow-seed.ts
@@ -1,0 +1,66 @@
+import { ShadowUnavailableError } from "./shadow-fetch";
+import {
+  canonicalJSON,
+  etagRevision,
+  parseDocBody,
+  responseError,
+  unknownFamilyRejection,
+} from "./wire";
+
+/** The revision/content caches one seed refreshes (shared with the shadow). */
+export interface SeedCaches<F extends string> {
+  revisions: Map<F, number>;
+  remote: Map<F, string>;
+}
+
+export interface SeedOutcome {
+  seeded: boolean;
+  /** Set when the gateway rejected the family as unknown (deploy skew). */
+  unsupported?: string;
+}
+
+/**
+ * Seed one family's revision + canonical content from a GET response the
+ * caller fetched. 404 is the normal empty case (revision 0); an unknown-family
+ * rejection is reported for the caller to latch; unavailability defers with a
+ * warning (the next write re-seeds); anything else fails the seed loudly.
+ */
+export async function seedFromResponse<F extends string>(
+  family: F,
+  fetchDoc: () => Promise<Response>,
+  caches: SeedCaches<F>,
+): Promise<SeedOutcome> {
+  try {
+    const response = await fetchDoc();
+    if (response.status === 404) {
+      caches.revisions.set(family, 0);
+      caches.remote.delete(family);
+      return { seeded: true };
+    }
+    if (!response.ok) {
+      const error = await responseError(response, family, "GET");
+      if (unknownFamilyRejection(response.status, error.message)) {
+        return { seeded: false, unsupported: error.message };
+      }
+      throw error;
+    }
+    const parsed = parseDocBody(await response.text());
+    const etag = etagRevision(response);
+    caches.revisions.set(family, etag ?? parsed.revision ?? 0);
+    if (parsed.doc !== undefined) {
+      caches.remote.set(family, canonicalJSON(parsed.doc));
+    } else {
+      caches.remote.delete(family);
+    }
+    return { seeded: true };
+  } catch (error) {
+    if (error instanceof ShadowUnavailableError) {
+      console.warn(`[doc-shadow] ${family} seed deferred: ${error.message}`);
+    } else {
+      console.error(`[doc-shadow] ${family} revision seed failed`, error);
+    }
+    caches.revisions.delete(family);
+    caches.remote.delete(family);
+    return { seeded: false };
+  }
+}

--- a/packages/host/src/docs/wire.ts
+++ b/packages/host/src/docs/wire.ts
@@ -68,3 +68,13 @@ export async function responseError(
     `doc shadow ${method} ${family} failed (${response.status}): ${detail.slice(0, 300)}`,
   );
 }
+
+/** The gateway's typed rejection of a family its allow-list predates (an
+ *  engine that ships a new family always deploys ahead of the gateway for a
+ *  window). Other 400s stay loud — they are OUR wire bugs. */
+export function unknownFamilyRejection(
+  status: number,
+  detail: string,
+): boolean {
+  return status === 400 && detail.includes("invalid document family");
+}

--- a/packages/runtime-client/src/object-sync/hydrate.test.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.test.ts
@@ -567,6 +567,52 @@ test("a file deleted mid-walk is reconciled as deleted, not a failed sync", asyn
   expect(remaining.length).toBe(1);
 });
 
+test("a file deleted between hash and upload is reconciled, not a failed sync", async () => {
+  const { storeRoot, store, work } = setup();
+  seed(storeRoot, PREFIX, { "workspace/a.txt": "a", "workspace/b.txt": "b" });
+  const manifest = await hydrate(store, PREFIX, work);
+  writeFileSync(join(work, "workspace", "a.txt"), "changed-a");
+  writeFileSync(join(work, "workspace", "b.txt"), "changed-b");
+  // The upload finds its own source gone: unlinked AFTER syncBack hashed it —
+  // the second half of the vanish window (session files mid-rewrite), which
+  // the mid-walk test above cannot reach.
+  const racing = {
+    list: (prefix: string) => store.list(prefix),
+    download: (key: string, dest: string) => store.download(key, dest),
+    upload: (src: string, key: string) => {
+      if (src.endsWith(join("workspace", "a.txt"))) rmSync(src);
+      return store.upload(src, key);
+    },
+    delete: (key: string) => store.delete(key),
+  };
+  const result = await syncBack(racing, PREFIX, work, manifest);
+  expect(result.uploaded).toEqual(["workspace/b.txt"]);
+  expect(result.manifest.has("workspace/a.txt")).toBe(false);
+  expect(result.deleted).toEqual(["workspace/a.txt"]);
+});
+
+test("a vanish surfacing as the fetch error's cause is reconciled too", async () => {
+  const { storeRoot, store, work } = setup();
+  seed(storeRoot, PREFIX, { "workspace/a.txt": "a" });
+  const manifest = await hydrate(store, PREFIX, work);
+  writeFileSync(join(work, "workspace", "a.txt"), "changed-a");
+  // The streaming upload path hands the source to fetch, so the errno arrives
+  // wrapped as the fetch failure's cause instead of the thrown error itself.
+  const streaming = {
+    list: (prefix: string) => store.list(prefix),
+    download: (key: string, dest: string) => store.download(key, dest),
+    upload: () => {
+      throw new Error("fetch failed", {
+        cause: Object.assign(new Error("no such file"), { code: "ENOENT" }),
+      });
+    },
+    delete: (key: string) => store.delete(key),
+  };
+  const result = await syncBack(streaming, PREFIX, work, manifest);
+  expect(result.uploaded).toEqual([]);
+  expect(result.manifest.has("workspace/a.txt")).toBe(false);
+});
+
 test("symlinks created locally are never persisted", async () => {
   const { storeRoot, store, work } = setup();
   seed(storeRoot, PREFIX, { "workspace/a.txt": "a" });

--- a/packages/runtime-client/src/object-sync/sync-back-conflicts.ts
+++ b/packages/runtime-client/src/object-sync/sync-back-conflicts.ts
@@ -18,6 +18,20 @@ export interface UploadChangeResult {
   uploaded: boolean;
   skipped?: string;
   conflict?: string;
+  /** The source file was unlinked between the sync scan and the upload read. */
+  vanished?: boolean;
+}
+
+/**
+ * The agent keeps writing while an upload reads its source, so the file can be
+ * unlinked between the scan's hash and the upload's stat/read (runtime session
+ * files churn constantly). On the streaming path the errno arrives wrapped as
+ * the fetch error's cause.
+ */
+function sourceVanished(error: unknown): boolean {
+  if ((error as NodeJS.ErrnoException).code === "ENOENT") return true;
+  const cause = (error as { cause?: unknown }).cause;
+  return (cause as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
 }
 
 function initialWriteOptions(
@@ -59,6 +73,7 @@ export async function uploadChangedObject(opts: {
         skipped: error.message,
       };
     }
+    if (sourceVanished(error)) return { uploaded: false, vanished: true };
     if (!(error instanceof StoreConflictError)) throw error;
     const refreshed = await opts.refresh();
     if (!refreshed) {
@@ -86,6 +101,8 @@ export async function uploadChangedObject(opts: {
         uploaded: true,
       };
     } catch (retryError) {
+      if (sourceVanished(retryError))
+        return { uploaded: false, vanished: true };
       if (!(retryError instanceof StoreConflictError)) throw retryError;
       return {
         entry: opts.previous

--- a/packages/runtime-client/src/object-sync/sync-back.ts
+++ b/packages/runtime-client/src/object-sync/sync-back.ts
@@ -146,6 +146,13 @@ export async function syncBack(
       generationAware,
       refresh,
     });
+    // Second half of the vanish window: the file outlived the hash above but
+    // was unlinked before the upload re-read it. Same reconciliation as the
+    // walk-stage skip: out of the next manifest, delete pass settles the store.
+    if (result.vanished) {
+      totalBytes -= size;
+      continue;
+    }
     if (result.entry) nextManifest.set(rel, result.entry);
     if (result.uploaded) uploaded.push(rel);
     if (result.skipped) skipped.push({ key: rel, reason: result.skipped });

--- a/packages/runtime/src/ai/provider-error-log.test.ts
+++ b/packages/runtime/src/ai/provider-error-log.test.ts
@@ -83,6 +83,40 @@ describe("logProviderError", () => {
     );
   });
 
+  it("keeps a caller-cancelled abort a warning even as kind=unknown", () => {
+    // The AbortError a mid-request cancel raises ("This operation was
+    // aborted") classifies as unknown, but it is the user's Stop or a dropped
+    // client — never an engine incident (HOUSTON-APP-59E).
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    logProviderError(
+      {
+        kind: "unknown",
+        provider: "google",
+        raw_excerpt: "This operation was aborted",
+      },
+      { model: "gemini-3.5-flash" },
+    );
+    expect(error).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("kind=unknown :: This operation was aborted"),
+    );
+  });
+
+  it("keeps every other unknown failure an error — untriaged by definition", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    logProviderError({
+      kind: "unknown",
+      provider: "google",
+      raw_excerpt: "something novel exploded",
+    });
+    expect(warn).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining("kind=unknown :: something novel exploded"),
+    );
+  });
+
   it("emits no cause field for non-auth kinds", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     logProviderError(

--- a/packages/runtime/src/ai/provider-error-log.ts
+++ b/packages/runtime/src/ai/provider-error-log.ts
@@ -19,6 +19,16 @@ const EXPECTED_KINDS: ReadonlySet<ProviderError["kind"]> = new Set([
   "network_unreachable",
 ]);
 
+/**
+ * An abort raised out of prompt() (AbortError's "This operation was aborted")
+ * is the caller cancelling the turn — a user Stop or a dropped client — not a
+ * provider failure. It classifies as `unknown` (no provider text to match),
+ * but reporting it as a Sentry error would page us for every cancel that
+ * lands mid-request; the catch sites that own the signal suppress it, and
+ * this guard keeps the ones that cannot see the signal to a warning.
+ */
+const EXPECTED_UNKNOWN_DETAIL = /operation was aborted/i;
+
 export interface ProviderErrorLogContext {
   model?: string | null;
   status?: number | null;
@@ -58,7 +68,8 @@ export function logProviderError(
   // every fresh install fires Sentry errors.
   const expected =
     EXPECTED_KINDS.has(error.kind) ||
-    (error.kind === "unauthenticated" && error.cause === "no_credentials");
+    (error.kind === "unauthenticated" && error.cause === "no_credentials") ||
+    (error.kind === "unknown" && EXPECTED_UNKNOWN_DETAIL.test(verbatim ?? ""));
   if (expected) console.warn(line);
   else console.error(line);
 }

--- a/packages/runtime/src/turn/turn-session-abort.test.ts
+++ b/packages/runtime/src/turn/turn-session-abort.test.ts
@@ -1,0 +1,53 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { WireFrame } from "@houston/runtime-client";
+import { expect, test, vi } from "vitest";
+import { runPiTurn } from "./turn-session";
+
+vi.mock("./turn-runtime", () => ({
+  createTurnModelRuntime: async () => ({
+    modelRuntime: {},
+    model: { provider: "google", id: "gemini-3.5-flash" },
+  }),
+}));
+vi.mock("../backends/pi/backend", () => ({
+  createPiBackend: () => ({
+    createSession: async () => ({
+      subscribe: () => () => {},
+      abort: () => {},
+      prompt: async () => {
+        // The DOMException a caller's AbortSignal raises when the cancel
+        // lands mid-request (usually pi resolves an abort clean instead).
+        throw new DOMException("This operation was aborted", "AbortError");
+      },
+    }),
+  }),
+}));
+
+test("an abort raised out of prompt() ends the turn quietly, not as an error", async () => {
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  const workspaceDir = await mkdtemp(join(tmpdir(), "turn-abort-ws-"));
+  const dataDir = await mkdtemp(join(tmpdir(), "turn-abort-data-"));
+  const frames: WireFrame[] = [];
+
+  const outcome = await runPiTurn(
+    { workspaceDir, dataDir },
+    {
+      conversationId: "c1",
+      text: "hello",
+      provider: "google",
+      emit: (frame) => frames.push(frame),
+      signal: undefined,
+      turnId: "t1",
+    },
+  );
+
+  // A cancelled turn is not a failure: no outcome error (the per-turn server
+  // would send a generic error frame), no provider_error frame, no Sentry
+  // error (HOUSTON-APP-59E).
+  expect(outcome).toEqual({});
+  expect(frames.filter((frame) => frame.type === "provider_error")).toEqual([]);
+  expect(error).not.toHaveBeenCalled();
+  error.mockRestore();
+});

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -378,6 +378,27 @@ export async function runPiTurn(
     return providerError ? {} : { pendingInteraction };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    // The caller's cancel usually resolves prompt() clean (pi routes an abort
+    // down the usage path), but one landing mid-request RAISES the AbortError
+    // instead. Same user action either way — not a provider failure and not
+    // an outcome error: persist what streamed and end the turn quietly.
+    if (
+      !providerError &&
+      (signal?.aborted || (err instanceof Error && err.name === "AbortError"))
+    ) {
+      if (assistantText)
+        appendAssistantMessageAt(
+          conversationsDir,
+          conversationId,
+          assistantText,
+          {
+            tools,
+            usage,
+            turnId,
+          },
+        );
+      return {};
+    }
     // Classify the throw before reporting a generic outcome error: pi RAISES
     // a missing/expired credential at prompt time ("No API key found for
     // <provider>. Use /login …"), before any stream exists, so this catch is


### PR DESCRIPTION
Staging testing of the stateless architecture surfaced 7 Sentry issues (last 7d). Three were already fixed on main and are resolved in Sentry; this PR fixes the remaining four noise classes. Triage tracked in PRODUCT-1487.

## Fixes

**HOUSTON-APP-5AF — `ENOENT stat …/sessions/626.json` fails the sync pass.**
The vanished-file guard covered only the walk stage. A file unlinked between the scan's hash and the upload's re-read (runtime session files churn constantly) threw out of `uploadChangedObject` and aborted the pass as a Sentry error. The upload now reports the source as vanished — including the streaming path, where the errno arrives as the fetch error's `cause` — and `syncBack` reconciles it exactly like the mid-walk skip: out of the next manifest, delete pass settles the store.

**HOUSTON-APP-5AA — `doc shadow GET skills failed (400): invalid document family`.**
An engine shipping a new doc family always deploys ahead of the gateway's allow-list for a window; every publish re-reported the 400 as an error. The typed rejection now latches that family only (one warning), leaving the families the gateway does know projecting. The gateway already accepts `skills`, so this hardens the next family's rollout.

**HOUSTON-APP-5AB — `doc shadow PUT providers failed (503): transcript store unavailable`.**
Doc-shadow requests had no 5xx handling: a rollout-window 503 threw straight to the error reporter (71 events in one day). GET/PUT now ride the same 502/503/504 retry ladder as the turn-log sender; an exhausted retry defers at warning — the cached revision survives and the next capture or warm tick re-publishes.

**HOUSTON-APP-59E — `[provider_error] … kind=unknown :: This operation was aborted`.**
A caller cancel landing mid-request raises AbortError out of `prompt()` (usually pi resolves an abort clean), which classified as `unknown` and fired a Sentry error per cancel. The pooled-turn catch now ends a cancelled turn quietly — persists what streamed, no provider_error frame, no outcome error — and `logProviderError` keeps any residual aborted-unknown at warning.

`http-shadow.ts` was over the file cap after the changes, so the transport, seed, and publish steps moved to `shadow-fetch.ts` / `shadow-seed.ts` / `shadow-put.ts` (behavior covered by the existing + new tests).

## Already fixed on main (resolved in Sentry, will reopen on regression)
- HOUSTON-APP-58W (fencing 409 at shutdown) and HOUSTON-APP-4YV (dead central credential) — both by the Aug 20 noise sweep.
- HOUSTON-APP-5A5 (doc projection disabled on 0-agent boot) — projector lazy-bind rework, Aug 20.

## Tests
- object-sync: hash→upload vanish reconciles (direct errno + fetch-cause shapes)
- doc shadow: unknown-family 400 latches per-family at warn; 503 retries and succeeds; exhausted 503 defers at warn and the next publish reuses the cached revision; 503 seed defers at warn
- provider errors: aborted-unknown warns, every other unknown stays an error; an AbortError raised from `prompt()` ends the pooled turn with no error frame and no Sentry error

All of `@houston/{runtime-client,host,runtime,domain}` vitest + typecheck + `pnpm check` green.