### PR TITLE
fix(providers): Azure verify endpoint must ride env, strip Azure-host paths (PRODUCT-1477)

### DIFF
--- a/packages/runtime/src/ai/azure-openai.test.ts
+++ b/packages/runtime/src/ai/azure-openai.test.ts
@@ -17,6 +17,18 @@ test("normalizeAzureEndpoint accepts https, trims a trailing slash, rejects the 
   expect(normalizeAzureEndpoint("  https://acme.openai.azure.com/  ")).toBe(
     "https://acme.openai.azure.com",
   );
+  // The Foundry tab's per-project endpoint (what the portal shows first for a
+  // Foundry resource — and what the PRODUCT-1477 reporter pasted): the OpenAI
+  // v1 surface lives at the host root, so the project path is dropped.
+  expect(
+    normalizeAzureEndpoint(
+      "https://acme.services.ai.azure.com/api/projects/my-agents",
+    ),
+  ).toBe("https://acme.services.ai.azure.com");
+  // A non-Azure host (proxy/gateway) keeps its path verbatim.
+  expect(normalizeAzureEndpoint("https://llm.corp.example/azure/")).toBe(
+    "https://llm.corp.example/azure",
+  );
 
   expect(() => normalizeAzureEndpoint("")).toThrow(/missing/);
   expect(() => normalizeAzureEndpoint("acme.openai.azure.com")).toThrow(

--- a/packages/runtime/src/ai/azure-openai.ts
+++ b/packages/runtime/src/ai/azure-openai.ts
@@ -46,10 +46,25 @@ export function azureBaseUrl(dataDir?: string): string {
   return load(dataDir).baseUrl ?? "";
 }
 
+/** Azure-owned inference hosts, where the OpenAI v1 surface lives at the
+ *  host root (pi appends `/openai/v1` itself). */
+const AZURE_HOST_SUFFIXES = [
+  ".openai.azure.com",
+  ".cognitiveservices.azure.com",
+  ".ai.azure.com",
+];
+
 /**
  * Validate + normalize a pasted Azure endpoint: a real https URL (the portal
- * always hands out https; http would send the key in the clear), with any
- * trailing slash trimmed so pi's own base-URL normalization starts clean.
+ * always hands out https; http would send the key in the clear). On an
+ * Azure-owned host the PATH is dropped: the portal shows several per-resource
+ * endpoints — the Foundry tab's is `https://<r>.services.ai.azure.com/api/
+ * projects/<p>`, a project surface the OpenAI SDK can't call — while the
+ * OpenAI v1 API always hangs off the host root, and pi only appends its
+ * `/openai/v1` base path when the pasted path is empty (PRODUCT-1477: the
+ * reporting user pasted the Foundry project endpoint, verbatim from the
+ * portal, and every request 404'd). A non-Azure host (a proxy, a gateway)
+ * keeps its path verbatim.
  * Throws with the user-facing reason — connect routes surface it as a 400.
  */
 export function normalizeAzureEndpoint(raw: string): string {
@@ -63,6 +78,8 @@ export function normalizeAzureEndpoint(raw: string): string {
   }
   if (url.protocol !== "https:")
     throw new Error("Azure OpenAI endpoint must start with https://");
+  if (AZURE_HOST_SUFFIXES.some((sfx) => url.hostname.endsWith(sfx)))
+    return `https://${url.host}`;
   return trimmed.replace(/\/+$/, "");
 }
 

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -370,6 +370,20 @@ test("together.ai's gated-model body → model_unavailable, never unknown", () =
   expect(err.kind).toBe("model_unavailable");
 });
 
+test("Azure missing-deployment 404 → model_unavailable, never unknown (PRODUCT-1477)", () => {
+  // Azure answers 401 for a bad key BEFORE any deployment lookup, so this
+  // 404 proves the credential — classifying it unknown made verify read
+  // "couldn't reach Azure OpenAI" for a valid key whose deployment name
+  // simply didn't match the probe model.
+  const err = classifyProviderError({
+    provider: "azure-openai-responses",
+    model: "gpt-5.5",
+    message:
+      "Azure OpenAI API error (404 DeploymentNotFound): The API deployment for this resource does not exist. If you created the deployment within the last 5 minutes, please wait a moment and try again.",
+  });
+  expect(err.kind).toBe("model_unavailable");
+});
+
 test("Bedrock bare-foundation-id on-demand rejection → model_unavailable, never unknown (PRODUCT-1477)", () => {
   // The verbatim ValidationException Bedrock answers a bare Claude 4.x id with
   // (Sentry, 2026-08-21) — note AWS's curly apostrophe in "isn\u2019t", which

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -135,6 +135,13 @@ const MODEL_UNAVAILABLE_PATTERNS = [
   // …" — for models its serverless tier doesn't include. The credential
   // authenticated fine; only the model is out of reach.
   "unable to access model",
+  // Azure OpenAI's missing-deployment 404 — `DeploymentNotFound: The API
+  // deployment for this resource does not exist.` A wrong key never gets
+  // this far (Azure answers 401 first), so it proves auth at verify time and
+  // is a pick-a-deployed-model problem, not a connectivity one (PRODUCT-1477;
+  // deployments are user-named, so any not-deployed pick hits this).
+  "deploymentnotfound",
+  "deployment for this resource does not exist",
   // Bedrock's bare-foundation-id rejection — "Invocation of model ID … with
   // on-demand throughput isn't supported. Retry your request with the ID or
   // ARN of an inference profile …" (Claude 4.x is inference-profile-only).

--- a/packages/runtime/src/auth/verify-api-key.azure.test.ts
+++ b/packages/runtime/src/auth/verify-api-key.azure.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test, vi } from "vitest";
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+test("azure verify aims the REAL request at the pasted endpoint (PRODUCT-1477)", async () => {
+  // Regression for the endpoint silently dropping before pi's azure client:
+  // pi's completeSimple path rebuilds options through an allowlist that
+  // forwards `env` but not `azureBaseUrl`, so passing only the option made
+  // every azure verify throw "base URL is required" before any HTTP. This
+  // test runs the UNMOCKED verify path with an injected transport and pins
+  // where the probe actually connects.
+  const prevDataDir = process.env.HOUSTON_DATA_DIR;
+  const dataDir = mkdtempSync(join(tmpdir(), "houston-azure-verify-"));
+  process.env.HOUSTON_DATA_DIR = dataDir;
+
+  try {
+    vi.resetModules();
+    const { verifyApiKey } = await import("./verify-api-key");
+
+    const urls: string[] = [];
+    const fakeFetch: typeof fetch = async (input, _init) => {
+      urls.push(String(input instanceof Request ? input.url : input));
+      return new Response(
+        JSON.stringify({
+          error: { message: "Access denied due to invalid subscription key" },
+        }),
+        { status: 401, headers: { "content-type": "application/json" } },
+      );
+    };
+
+    // A rejected key must reject the connect — but through a REAL request to
+    // the pasted endpoint, never through a pre-request "base URL" throw.
+    await expect(
+      verifyApiKey("azure-openai-responses", "bad-key", {
+        azureBaseUrl: "https://acme.openai.azure.com",
+        fetch: fakeFetch,
+      }),
+    ).rejects.toThrow(/rejected this API key/);
+
+    expect(urls.length).toBeGreaterThan(0);
+    for (const url of urls) {
+      // pi appends its /openai/v1 base path to the bare resource host.
+      expect(url).toMatch(/^https:\/\/acme\.openai\.azure\.com\/openai\/v1\//);
+    }
+  } finally {
+    restoreEnv("HOUSTON_DATA_DIR", prevDataDir);
+    vi.resetModules();
+  }
+});

--- a/packages/runtime/src/auth/verify-api-key.ts
+++ b/packages/runtime/src/auth/verify-api-key.ts
@@ -23,6 +23,8 @@ export type { ApiKeyVerifyReason } from "./verify-errors";
  */
 export interface VerifyApiKeyOptions {
   azureBaseUrl?: string;
+  /** Test seam: injected transport, forwarded to pi so probe URLs are observable. */
+  fetch?: typeof fetch;
 }
 // The stable public surface (host routes, login, tests) predates the module
 // split — keep serving it from here.
@@ -116,7 +118,19 @@ async function probeCompletion(
         apiKey: key,
         maxTokens: 1,
         signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
-        ...(opts?.azureBaseUrl ? { azureBaseUrl: opts.azureBaseUrl } : {}),
+        // The endpoint MUST ride `env`: pi's completeSimple path rebuilds
+        // options through buildBaseOptions, whose allowlist forwards `env`
+        // but silently DROPS `azureBaseUrl` — passing only the option made
+        // every azure verify throw "base URL is required" pre-request
+        // (Sentry, 2026-08-24). The option is kept alongside for any pi
+        // path that does honor it.
+        ...(opts?.azureBaseUrl
+          ? {
+              azureBaseUrl: opts.azureBaseUrl,
+              env: { AZURE_OPENAI_BASE_URL: opts.azureBaseUrl },
+            }
+          : {}),
+        ...(opts?.fetch ? { fetch: opts.fetch } : {}),
       },
     );
     if (reply.stopReason !== "error") return null;


### PR DESCRIPTION
## PRODUCT-1477 — Azure connect still failing after #1383

The reporting user (new engine, endpoint field visible) still got "We couldn't reach Azure OpenAI". Sentry has the real error:

> could not verify the azure-openai-responses API key: Azure OpenAI base URL is required. Set AZURE_OPENAI_BASE_URL …

Three stacked causes, all fixed here:

### 1. The pasted endpoint never reached pi (the actual Sentry failure)
pi's `completeSimple` path rebuilds options through `buildBaseOptions`, whose fixed allowlist forwards `env` but silently **drops `azureBaseUrl`**. The probe therefore ran endpoint-less and threw before any HTTP. The endpoint now also rides `env.AZURE_OPENAI_BASE_URL` (which pi's `resolveAzureConfig` reads); the option is kept alongside for pi paths that honor it.

### 2. The portal's Foundry endpoint has a project path
The user pasted the Foundry tab's `https://<r>.services.ai.azure.com/api/projects/<p>` verbatim. pi appends its `/openai/v1` base path only when the pasted path is empty, so that URL would 404 on every request even after fix 1. `normalizeAzureEndpoint` now strips the path on Azure-owned hosts (`.openai.azure.com`, `.cognitiveservices.azure.com`, `.ai.azure.com`) — the OpenAI v1 surface always hangs off the host root — while non-Azure hosts (proxies) keep their path verbatim.

### 3. DeploymentNotFound read as "couldn't reach"
Azure deployments are user-named; if none matches the probe model, Azure answers `404 DeploymentNotFound`. A bad key never gets past 401, so this **proves** the credential — it now classifies `model_unavailable`: the key connects, and picking a deployed model is the user's next step instead of a dead connect.

### Testing
The new regression test runs the **unmocked** verify path with an injected transport and pins the URL the probe actually requests (`https://<host>/openai/v1/…`) — verified to fail on pre-fix code. Plus normalization tests (Foundry project URL → host root; non-Azure path preserved) and a DeploymentNotFound classification test with Azure's verbatim message. Runtime suite 1336 pass, typecheck clean.

Runtime-only change → needs an engine roll to reach hosted users.