### PR TITLE
fix(host): routines always record a fireable created_by; boot backfill for pre-rollout routines (PRODUCT-1497)

### DIFF
--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -35,6 +35,7 @@ import { RuntimeProcessSpawner } from "../launcher/runtime-spawner";
 import { migrateAgentLayouts } from "../migrate/agent-layout";
 import { reseedAgentSchemas } from "../migrate/agent-schemas";
 import { migrateChatHistory } from "../migrate/chat-history";
+import { backfillRoutineCreatedBy } from "../migrate/routine-created-by";
 import { LocalPaths } from "../paths";
 import type { PodGatewayConfig } from "../pod-gateway";
 import type { ChannelCtx } from "../ports";
@@ -194,6 +195,15 @@ export interface LocalHostOptions {
    * untrusted client input — leave this false (the default) and it is dropped.
    */
   gatewayFronted?: boolean;
+  /**
+   * The org owner's canonical user id (the gateway identity directory's sub),
+   * stamped into managed pods as owner env. Managed pods only, two uses: the
+   * boot backfill stamps it as `created_by` on routines recorded before acting
+   * identities were stamped, and routine writes fall back to it when a request
+   * carries no decodable acting-as header — the control-plane fire planner
+   * skips any routine without a creator, so no routine may be authorless.
+   */
+  ownerSub?: string;
   /**
    * Whether this deployment can fire event-driven routines: a trigger backend
    * (a Composio project key + a public webhook URL) exists, so a routine's
@@ -645,6 +655,9 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     // `created_by` (C2 — the sub the gateway re-authorizes at fire time);
     // the desktop ignores the header and keeps stamping the local owner.
     gatewayFronted: opts.gatewayFronted ?? false,
+    // Org-owner fallback creator for routine writes with no acting header —
+    // an authorless routine is not fireable by the control-plane planner.
+    ownerSub: opts.ownerSub,
     // Event-driven routines fire only where a trigger backend exists (Houston
     // Cloud). Off on desktop/self-host: the write gate refuses trigger bindings
     // and the trigger-status route reports them as unable to wake.
@@ -836,6 +849,29 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
           "[local-host] agent schema re-seed failed (continuing):",
           err,
         );
+      }
+      // Managed pods: stamp the org owner as `created_by` on routines recorded
+      // before gateway-fronted pods stamped acting identities. The control-plane
+      // fire planner treats an authorless routine as not fireable, so once
+      // pre-wake suppression turns on those routines would never run again; the
+      // planner's snapshot is projected from this very doc on its next
+      // store-sync upload, so the boot stamp is the whole repair. Runs AFTER
+      // hydration (the doc comes from the object store) and BEFORE the watcher,
+      // like the migrations above. Desktop/self-host never set ownerSub.
+      if (opts.gatewayFronted && opts.ownerSub && !opts.passive) {
+        try {
+          backfillRoutineCreatedBy({
+            workspacesRoot: opts.workspacesRoot,
+            ownerSub: opts.ownerSub,
+          });
+        } catch (err) {
+          // No UI thread to toast on at boot; the supervisor must stay up. Log
+          // loudly so the failure shows in the app logs / bug report tail.
+          console.error(
+            "[local-host] routine created_by backfill failed (continuing):",
+            err,
+          );
+        }
       }
       // Additive, idempotent migration of the Rust-desktop era's chat history
       // (SQLite chat_feed) into each agent's `.houston/runtime/`. Runs BEFORE

--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -209,6 +209,11 @@ const host = buildLocalHost({
   // x-houston-acting-as); relay that header to the runtime so integration
   // calls act as the driving user. Desktop/self-host stay direct → false.
   gatewayFronted: process.env.HOUSTON_MANAGED_CLOUD === "1",
+  // The org owner's canonical user id, stamped into managed pods by the
+  // control plane. Backfills `created_by` on pre-rollout routines at boot and
+  // backstops routine writes that carry no acting header — an authorless
+  // routine is one the control-plane fire planner refuses to fire.
+  ownerSub: process.env.HOUSTON_USER_ID || undefined,
   // Dev launcher only (scripts/dev/control-plane.sh): its managed-cloud "pods"
   // are processes on the developer's machine, so their egress reaches loopback
   // and the public-HTTPS endpoint validation must not apply. Real pods never

--- a/packages/host/src/migrate/routine-created-by.test.ts
+++ b/packages/host/src/migrate/routine-created-by.test.ts
@@ -1,0 +1,149 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { backfillRoutineCreatedBy } from "./routine-created-by";
+
+/**
+ * The managed-pod boot backfill that stamps the org owner as `created_by` on
+ * routines recorded before gateway-fronted pods stamped acting identities.
+ * What matters: an authorless entry gains the owner sub (the control-plane
+ * planner refuses to fire without one), an authored entry keeps its author, a
+ * doc with nothing to stamp is not rewritten, and one bad doc never stops the
+ * sweep.
+ */
+
+let root: string;
+
+const routinesPath = (agentRoot: string) =>
+  join(agentRoot, ".houston", "routines", "routines.json");
+
+function writeRoutines(agentRoot: string, value: unknown): void {
+  mkdirSync(join(agentRoot, ".houston", "routines"), { recursive: true });
+  writeFileSync(
+    routinesPath(agentRoot),
+    typeof value === "string" ? value : JSON.stringify(value, null, 2),
+    "utf8",
+  );
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "routine-created-by-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("backfillRoutineCreatedBy", () => {
+  it("stamps authorless routines and keeps authored ones", () => {
+    const agent = join(root, "Personal", "Alfred");
+    writeRoutines(agent, [
+      { id: "r1", name: "Brief", prompt: "p", schedule: "0 9 * * *" },
+      {
+        id: "r2",
+        name: "Report",
+        prompt: "p",
+        schedule: "0 8 * * *",
+        created_by: "supabase-sub-1",
+      },
+      { id: "r3", name: "Empty author", prompt: "p", created_by: "" },
+    ]);
+
+    const result = backfillRoutineCreatedBy({
+      workspacesRoot: root,
+      ownerSub: "owner-sub",
+      log: () => {},
+    });
+
+    expect(result).toEqual({ updatedAgents: 1, updatedRoutines: 2 });
+    const items = JSON.parse(readFileSync(routinesPath(agent), "utf8")) as {
+      id: string;
+      created_by?: string;
+    }[];
+    expect(items.map((r) => r.created_by)).toEqual([
+      "owner-sub",
+      "supabase-sub-1",
+      "owner-sub",
+    ]);
+  });
+
+  it("is a no-op the second time (fully-authored docs are never rewritten)", () => {
+    const agent = join(root, "Personal", "Alfred");
+    writeRoutines(agent, [
+      { id: "r1", name: "Brief", prompt: "p", schedule: "0 9 * * *" },
+    ]);
+    backfillRoutineCreatedBy({
+      workspacesRoot: root,
+      ownerSub: "owner-sub",
+      log: () => {},
+    });
+    const mtime = statSync(routinesPath(agent)).mtimeMs;
+
+    const again = backfillRoutineCreatedBy({
+      workspacesRoot: root,
+      ownerSub: "owner-sub",
+      log: () => {},
+    });
+
+    expect(again).toEqual({ updatedAgents: 0, updatedRoutines: 0 });
+    expect(statSync(routinesPath(agent)).mtimeMs).toBe(mtime);
+  });
+
+  it("skips agents with no routines doc and tolerates a malformed one", () => {
+    mkdirSync(join(root, "Personal", "NoRoutines", ".houston"), {
+      recursive: true,
+    });
+    const broken = join(root, "Personal", "Broken");
+    writeRoutines(broken, "{not json");
+    const healthy = join(root, "Personal", "Healthy");
+    writeRoutines(healthy, [{ id: "r1", name: "n", prompt: "p" }]);
+    // A non-array doc (agent-authored garbage) is the read path's diagnostic
+    // to report, not ours to rewrite.
+    const object = join(root, "Personal", "ObjectDoc");
+    writeRoutines(object, { items: [] });
+
+    const result = backfillRoutineCreatedBy({
+      workspacesRoot: root,
+      ownerSub: "owner-sub",
+      log: () => {},
+    });
+
+    expect(result).toEqual({ updatedAgents: 1, updatedRoutines: 1 });
+    expect(readFileSync(routinesPath(broken), "utf8")).toBe("{not json");
+    expect(readFileSync(routinesPath(object), "utf8")).toContain("items");
+  });
+
+  it("preserves unknown keys and stray non-object entries verbatim", () => {
+    const agent = join(root, "Personal", "Alfred");
+    writeRoutines(agent, [
+      { id: "r1", name: "n", prompt: "p", some_future_key: { a: 1 } },
+      "stray string entry",
+    ]);
+
+    backfillRoutineCreatedBy({
+      workspacesRoot: root,
+      ownerSub: "owner-sub",
+      log: () => {},
+    });
+
+    const items = JSON.parse(
+      readFileSync(routinesPath(agent), "utf8"),
+    ) as unknown[];
+    expect(items[0]).toEqual({
+      id: "r1",
+      name: "n",
+      prompt: "p",
+      some_future_key: { a: 1 },
+      created_by: "owner-sub",
+    });
+    expect(items[1]).toBe("stray string entry");
+  });
+});

--- a/packages/host/src/migrate/routine-created-by.ts
+++ b/packages/host/src/migrate/routine-created-by.ts
@@ -1,0 +1,109 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { agentRoots } from "./chat-history";
+
+/**
+ * Backfill `created_by` on routines recorded before gateway-fronted pods
+ * stamped acting identities.
+ *
+ * The control-plane routine planner refuses to fire a routine whose snapshot
+ * names no creator (there is no identity to re-authorize or bill the fired
+ * turn against), so every such routine rides only the legacy pre-wake path —
+ * and stops running entirely once pre-wake suppression turns on. The snapshot
+ * is projected from this very file on its next store-sync upload, so stamping
+ * here is the whole repair: no control-plane write is involved.
+ *
+ * The stamp is the ORG OWNER's canonical user id (the managed pod's owner env),
+ * not a synthetic principal: fire-time delivery requires the acting identity
+ * to equal `created_by`, and only a real directory user can be minted an
+ * acting token — a synthetic sub would leave the routine exactly as unfireable
+ * as no sub at all. Edits keep healing forward: any later verified actor
+ * re-stamps the routine as usual.
+ *
+ * Idempotent and minimal: only entries with no non-empty `created_by` gain the
+ * key; everything else in the doc — malformed entries included, they are the
+ * read path's diagnostics to report — round-trips untouched, and a doc with
+ * nothing to stamp is not rewritten.
+ */
+
+export interface BackfillCreatedByResult {
+  /** Agents whose routines doc was rewritten this run. */
+  updatedAgents: number;
+  /** Individual routine entries stamped this run. */
+  updatedRoutines: number;
+}
+
+const ROUTINES_DOC = join(".houston", "routines", "routines.json");
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+
+/** Write via tmp + rename so a crash mid-write never leaves a torn doc. */
+function writeAtomic(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = join(dirname(path), `.${Date.now()}-${Math.random()}.tmp`);
+  writeFileSync(tmp, content, "utf8");
+  renameSync(tmp, path);
+}
+
+/** Stamp one agent's routines doc, returning how many entries gained a
+ *  creator. Exported for tests; production goes through
+ *  {@link backfillRoutineCreatedBy}. */
+export function backfillAgentRoutineCreatedBy(
+  agentRoot: string,
+  ownerSub: string,
+): number {
+  const path = join(agentRoot, ROUTINES_DOC);
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return 0; // no routines doc — nothing to stamp
+  }
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed)) return 0; // malformed doc: the read path reports it
+  let stamped = 0;
+  const next = parsed.map((entry) => {
+    if (!isRecord(entry)) return entry;
+    if (typeof entry.created_by === "string" && entry.created_by) return entry;
+    stamped++;
+    return { ...entry, created_by: ownerSub };
+  });
+  if (stamped === 0) return 0;
+  // The canonical on-disk JSON document form (domain jsonDoc): pretty-printed,
+  // trailing newline — byte-identical to what the next saveRoutines writes.
+  writeAtomic(path, `${JSON.stringify(next, null, 2)}\n`);
+  return stamped;
+}
+
+/**
+ * Backfill every agent under the workspaces tree. Per-agent failures are
+ * logged and skipped: one unreadable routines doc must never stop the host
+ * from booting (same posture as the sibling migrations this runs beside).
+ */
+export function backfillRoutineCreatedBy(opts: {
+  workspacesRoot: string;
+  ownerSub: string;
+  log?: (line: string) => void;
+}): BackfillCreatedByResult {
+  const log = opts.log ?? ((line: string) => console.log(line));
+  const result: BackfillCreatedByResult = {
+    updatedAgents: 0,
+    updatedRoutines: 0,
+  };
+  for (const agentRoot of agentRoots(opts.workspacesRoot)) {
+    try {
+      const stamped = backfillAgentRoutineCreatedBy(agentRoot, opts.ownerSub);
+      if (stamped > 0) {
+        result.updatedAgents++;
+        result.updatedRoutines += stamped;
+        log(`[routine-created-by] ${agentRoot}: stamped ${stamped} routine(s)`);
+      }
+    } catch (err) {
+      // Boot-time background path with no UI thread to toast on; the
+      // sanctioned console.error boundary (same as the sibling migrations).
+      console.error(`[routine-created-by] ${agentRoot}: backfill failed:`, err);
+    }
+  }
+  return result;
+}

--- a/packages/host/src/routes/agent-authz.ts
+++ b/packages/host/src/routes/agent-authz.ts
@@ -50,6 +50,13 @@ export interface AgentRouteDeps {
    */
   gatewayFronted?: boolean;
   /**
+   * The org owner's canonical user id (mirrors ControlPlaneDeps.ownerSub):
+   * the routine-write fallback creator on a gateway-fronted host whose request
+   * carries no decodable acting-as header, so no routine is born authorless
+   * (an authorless routine is not fireable by the control-plane planner).
+   */
+  ownerSub?: string;
+  /**
    * True when this deployment's egress can reach loopback/private addresses
    * even though it is gateway-fronted. Only the DEV LAUNCHER sets it: its
    * "pods" are processes on the developer's machine, so the managed-cloud

--- a/packages/host/src/routes/agent-data.test.ts
+++ b/packages/host/src/routes/agent-data.test.ts
@@ -587,6 +587,51 @@ test("routines (gateway-fronted): created_by records the acting sub, PATCH re-st
   }
 });
 
+test("routines (gateway-fronted): a headerless write falls back to the org owner sub", async () => {
+  // A managed pod that knows its org owner: a request the gateway vouched no
+  // identity for still records a real, re-authorizable creator — an authorless
+  // routine is one the control-plane fire planner refuses to fire.
+  const fronted = createControlPlaneServer({
+    ...deps(),
+    gatewayFronted: true,
+    ownerSub: "owner-sub-9",
+  });
+  await new Promise<void>((r) => fronted.listen(0, "127.0.0.1", () => r()));
+  const addr = fronted.address();
+  const frontedBase = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+  try {
+    const bare = await fetch(`${frontedBase}/agents/${agentId}/routines`, {
+      method: "POST",
+      headers: auth("alice"),
+      body: JSON.stringify({
+        name: "Headerless",
+        prompt: "Write it",
+        schedule: "0 9 * * 1-5",
+      }),
+    });
+    expect(bare.status).toBe(201);
+    expect(((await bare.json()) as Routine).created_by).toBe("owner-sub-9");
+
+    // A real acting header still outranks the owner fallback.
+    const acted = await fetch(`${frontedBase}/agents/${agentId}/routines`, {
+      method: "POST",
+      headers: {
+        ...auth("alice"),
+        "x-houston-acting-as": actingToken("supabase-sub-3"),
+      },
+      body: JSON.stringify({
+        name: "With header",
+        prompt: "Write it",
+        schedule: "0 9 * * 1-5",
+      }),
+    });
+    expect(acted.status).toBe(201);
+    expect(((await acted.json()) as Routine).created_by).toBe("supabase-sub-3");
+  } finally {
+    await new Promise<void>((r) => fronted.close(() => r()));
+  }
+});
+
 test("routines: an invalid cron is rejected at create (400), never saved to fail silently", async () => {
   const bad = await fetch(`${base}/agents/${agentId}/routines`, {
     method: "POST",

--- a/packages/host/src/routes/agent-seed.test.ts
+++ b/packages/host/src/routes/agent-seed.test.ts
@@ -59,6 +59,63 @@ test("writeAgentSeeds is a no-op when nothing is supplied", async () => {
   expect(await vfs.readText("Work/A/CLAUDE.md")).toBeNull();
 });
 
+test("writeAgentSeeds stamps the creator on seeded routines that carry none", async () => {
+  const vfs = new MemoryVfs();
+  const routines = [
+    { id: "r1", name: "Brief", prompt: "p", schedule: "0 9 * * *" },
+    { id: "r2", name: "Kept", prompt: "p", created_by: "someone-else" },
+  ];
+  await writeAgentSeeds(
+    vfs,
+    "Work/A",
+    {
+      seeds: { ".houston/routines/routines.json": JSON.stringify(routines) },
+    },
+    "creator-sub",
+  );
+  const written = JSON.parse(
+    (await vfs.readText("Work/A/.houston/routines/routines.json")) ?? "",
+  ) as { created_by?: string }[];
+  expect(written.map((r) => r.created_by)).toEqual([
+    "creator-sub",
+    "someone-else",
+  ]);
+});
+
+test("writeAgentSeeds leaves non-routine seeds and malformed routine docs verbatim", async () => {
+  const vfs = new MemoryVfs();
+  await writeAgentSeeds(
+    vfs,
+    "Work/A",
+    {
+      seeds: {
+        // Not the routines doc: never parsed, never stamped.
+        "outputs.json": JSON.stringify([{ id: "x" }]),
+        // Malformed routines doc: stored verbatim so the read path reports it.
+        ".houston/routines/routines.json": "{not json",
+      },
+    },
+    "creator-sub",
+  );
+  expect(await vfs.readText("Work/A/outputs.json")).toBe(
+    JSON.stringify([{ id: "x" }]),
+  );
+  expect(await vfs.readText("Work/A/.houston/routines/routines.json")).toBe(
+    "{not json",
+  );
+});
+
+test("writeAgentSeeds leaves routines untouched when no creator is known", async () => {
+  const vfs = new MemoryVfs();
+  const doc = JSON.stringify([{ id: "r1", name: "n", prompt: "p" }]);
+  await writeAgentSeeds(vfs, "Work/A", {
+    seeds: { ".houston/routines/routines.json": doc },
+  });
+  expect(await vfs.readText("Work/A/.houston/routines/routines.json")).toBe(
+    doc,
+  );
+});
+
 test("asSeedRecord accepts a string map and rejects non-string values", () => {
   expect(asSeedRecord({ a: "1", b: "2" })).toEqual({ a: "1", b: "2" });
   expect(asSeedRecord({ a: 1 })).toBeNull();

--- a/packages/host/src/routes/agent-seed.ts
+++ b/packages/host/src/routes/agent-seed.ts
@@ -25,6 +25,40 @@ export interface AgentSeed {
   seeds?: Record<string, string>;
 }
 
+/** The agent-layout routines doc, relative to the agent root — the ONE seed
+ *  key whose entries carry per-routine acting identity (`created_by`). */
+const ROUTINES_SEED_KEY = ".houston/routines/routines.json";
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+
+/**
+ * Stamp `created_by` onto seeded routines that carry none. Seeded routines
+ * (builtin templates, portable installs — which strip the exporter's identity
+ * on pack) bypass createRoutine, so without this they are born authorless, and
+ * the control-plane fire planner treats an authorless routine as not fireable.
+ * Entries that already name a creator keep it. Malformed JSON or a non-array
+ * doc is stored verbatim: normalizeRoutines reports it on the first read, and
+ * inventing structure here would mask that diagnostic.
+ */
+export function stampRoutineSeedCreator(content: string, sub: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return content;
+  }
+  if (!Array.isArray(parsed)) return content;
+  let changed = false;
+  const stamped = parsed.map((entry) => {
+    if (!isRecord(entry)) return entry;
+    if (typeof entry.created_by === "string" && entry.created_by) return entry;
+    changed = true;
+    return { ...entry, created_by: sub };
+  });
+  return changed ? `${JSON.stringify(stamped, null, 2)}\n` : content;
+}
+
 /**
  * Write an agent's initial files under `root` in the vfs: its CLAUDE.md and a
  * flat map of seed files (skills at `.agents/skills/<slug>/SKILL.md`, seeded
@@ -41,6 +75,9 @@ export async function writeAgentSeeds(
   vfs: Vfs,
   root: string,
   { claudeMd, seeds }: AgentSeed,
+  // The verified acting identity of the create (C2), stamped as `created_by`
+  // on seeded routines that carry none — see stampRoutineSeedCreator.
+  routineCreatedBy?: string,
 ): Promise<void> {
   if (claudeMd !== undefined) {
     await vfs.writeText(`${root}/CLAUDE.md`, claudeMd);
@@ -48,7 +85,11 @@ export async function writeAgentSeeds(
   for (const [key, content] of Object.entries(seeds ?? {})) {
     const safe = safeSeedKey(key);
     if (!safe) throw new Error(`unsafe seed path: ${key}`);
-    await vfs.writeText(`${root}/${safe}`, content);
+    const body =
+      safe === ROUTINES_SEED_KEY && routineCreatedBy
+        ? stampRoutineSeedCreator(content, routineCreatedBy)
+        : content;
+    await vfs.writeText(`${root}/${safe}`, body);
   }
 }
 

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -271,7 +271,22 @@ export async function handleAgents(
       const root = (deps.paths ?? DEFAULT_PATHS).agentRoot(ws, agent);
       try {
         await seedSchemas(deps.vfs, root);
-        await writeAgentSeeds(deps.vfs, root, { claudeMd, seeds });
+        // Seeded routines bypass createRoutine, so stamp the creating user as
+        // their `created_by` (same actor policy as the routine write routes):
+        // the gateway-minted acting sub on a managed pod (org owner when the
+        // header is absent), the local user on the desktop. Without it a
+        // template/portable install births authorless routines the
+        // control-plane planner refuses to fire.
+        const routineCreatedBy = deps.gatewayFronted
+          ? (actingSubFromHeader(req.headers[ACTING_AS_HEADER]) ??
+            deps.ownerSub)
+          : userId;
+        await writeAgentSeeds(
+          deps.vfs,
+          root,
+          { claudeMd, seeds },
+          routineCreatedBy,
+        );
       } catch (err) {
         // Atomic-enough create: a seed-write failure must not leave a
         // permanently seedless agent. First-run reuses an existing record on
@@ -810,9 +825,12 @@ export async function handleAgents(
     // exactly this: its sub is the identity the gateway re-authorizes at fire
     // time. On the desktop the header is untrusted client input, so the local
     // userId stays the recorded creator (routine turns there authenticate with
-    // the frontend session instead).
+    // the frontend session instead). A gateway-fronted request with no
+    // decodable header falls back to the org owner: an authorless routine is
+    // not fireable by the control-plane planner, so SOME real, re-authorizable
+    // identity must always be recorded.
     const routineActor = deps.gatewayFronted
-      ? actingSubFromHeader(req.headers[ACTING_AS_HEADER])
+      ? (actingSubFromHeader(req.headers[ACTING_AS_HEADER]) ?? deps.ownerSub)
       : userId;
     // The acting human as a full contributor, stamped onto missions (activity
     // create/PATCH + turns). CRITICAL: null off the gateway (desktop/self-host),

--- a/packages/host/src/routes/portable.ts
+++ b/packages/host/src/routes/portable.ts
@@ -15,6 +15,7 @@ import type {
   PortableExportOverrides,
   PortableSelection,
 } from "@houston/protocol";
+import { ACTING_AS_HEADER, actingSubFromHeader } from "../auth/acting";
 import type { Agent, UserId, Workspace } from "../domain/types";
 import type { WorkspacePaths } from "../paths";
 import { CloudPaths } from "../paths";
@@ -89,6 +90,12 @@ export interface PortableAccountDeps {
   store: WorkspaceStore;
   vfs?: Vfs;
   paths?: WorkspacePaths;
+  /** Trusted-gateway stance for the acting-as header (mirrors
+   *  ControlPlaneDeps.gatewayFronted). */
+  gatewayFronted?: boolean;
+  /** Org-owner fallback creator when no acting header decodes (mirrors
+   *  ControlPlaneDeps.ownerSub). */
+  ownerSub?: string;
 }
 
 /**
@@ -169,9 +176,17 @@ export async function handlePortableAccount(
   });
   const root = paths.agentRoot(ws, agent);
   await seedSchemas(deps.vfs, root);
+  // WHO installed the agent, recorded as `created_by` on seeded routines
+  // (packs strip the exporter's identity; an authorless routine is not
+  // fireable by the control-plane planner). Same actor policy as the routine
+  // write routes: gateway acting sub / org owner on a managed pod, the local
+  // user on the desktop.
+  const routineCreatedBy = deps.gatewayFronted
+    ? (actingSubFromHeader(req.headers[ACTING_AS_HEADER]) ?? deps.ownerSub)
+    : userId;
   // The SAME serialization the browser adapter sends through create-with-seeds
   // on hosted cloud — one layout, wherever the install lands.
-  await writeAgentSeeds(deps.vfs, root, packageSeed(pkg));
+  await writeAgentSeeds(deps.vfs, root, packageSeed(pkg), routineCreatedBy);
 
   json(res, 201, { agent, installed: portableInventory(pkg) });
   return true;

--- a/packages/host/src/routes/routines-sandbox.ts
+++ b/packages/host/src/routes/routines-sandbox.ts
@@ -45,6 +45,9 @@ export async function handleSandboxRoutines(
      * owner is recorded instead. Mirrors routes/agents.ts routineActor.
      */
     gatewayFronted?: boolean;
+    /** Org-owner fallback creator when no acting header decodes (mirrors
+     *  ControlPlaneDeps.ownerSub). */
+    ownerSub?: string;
   },
   method: string,
   path: string,
@@ -82,9 +85,11 @@ export async function handleSandboxRoutines(
   const nowIso = new Date().toISOString();
   const triggersEnabled = deps.triggersEnabled ?? false;
   // WHO the routine records as its creator (C2), same policy as agent-data: the
-  // gateway-minted acting sub on a managed pod, else the workspace owner.
+  // gateway-minted acting sub on a managed pod (falling back to the org owner
+  // when no header decodes — an authorless routine is not fireable by the
+  // control-plane planner), else the workspace owner.
   const createdBy = deps.gatewayFronted
-    ? actingSubFromHeader(req.headers[ACTING_AS_HEADER])
+    ? (actingSubFromHeader(req.headers[ACTING_AS_HEADER]) ?? deps.ownerSub)
     : ws.ownerUserId;
   // A successful write reacts on the SAME channel a UI or file-watcher write does
   // (saveRoutines writes the file the host watches); scope to the workspace owner.

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -182,6 +182,16 @@ export interface ControlPlaneDeps {
    * untrusted client input and is ignored.
    */
   gatewayFronted?: boolean;
+  /**
+   * The org owner's canonical user id (the gateway identity directory's sub),
+   * stamped into managed pods as env. Routine writes on a gateway-fronted host
+   * fall back to it when a request carries no decodable acting-as header, and
+   * seed installs stamp it when no acting identity exists — the control-plane
+   * fire planner skips any routine without a `created_by`, so no routine may
+   * be born authorless. Absent on desktop/self-host (the local user id is the
+   * recorded creator there).
+   */
+  ownerSub?: string;
   /** Gateway-fronted but the egress still reaches loopback (the dev launcher's
    *  on-machine "pods"): skips the managed-cloud public-HTTPS endpoint
    *  validation. See AgentRouteDeps.loopbackEgress. */


### PR DESCRIPTION
## Root cause

The control-plane routine fire planner refuses to plan a routine whose snapshot carries no `created_by` (there is no identity to re-authorize or bill the fired turn against). The snapshot is projected straight from each agent's routines doc, and routines recorded before gateway-fronted pods stamped acting identities never got the field: `createRoutine` treats it as optional, and several write paths (headerless gateway requests, builtin-template seeds, portable installs — which deliberately strip the exporter's identity) persisted routines with no creator at all. First fire-mode day in prod: 214 unique routines flagged not fireable (~1k WARNs/day). They still run via legacy pre-wake today, but stop running entirely once pre-wake suppression turns on.

## Fix

**Backfill (managed pods only).** A boot sweep (`packages/host/src/migrate/routine-created-by.ts`, run from host `start()` beside the sibling migrations, gated on gateway-fronted + owner env) stamps the org owner's canonical user id onto every routine entry with no creator. The planner's snapshot is projected from this very doc on its next store-sync upload, so the pod-side stamp is the whole repair — no control-plane write involved. Idempotent and minimal: authored entries, malformed entries, and unknown keys round-trip untouched; a doc with nothing to stamp is not rewritten.

**Backfill principal: the org owner, not a synthetic one.** Fire delivery requires the acting identity to equal `created_by`, and acting tokens are only minted for real directory users — a synthetic `system-backfill` sub would leave the routine exactly as unfireable, and gives billing nobody to burn against. The owner id is already stamped into every managed pod's env. Later edits keep healing forward (any verified editor re-stamps, as before).

**Write paths can no longer birth authorless routines.**
- Gateway-fronted routine writes (authenticated route + the runtime's `save_routine` sandbox route) now fall back to the org owner when the request carries no decodable acting-as header, instead of persisting creator-less.
- Seeded routines — builtin templates and portable installs, which bypass `createRoutine` — are stamped with the creating user's identity at `writeAgentSeeds` time (same actor policy as the write routes). Desktop behavior is unchanged: local creates already stamp the local user, and desktop docs are otherwise untouched (the backfill never runs there).

## Rollout

Ships with the next engine roll: every pod boot runs the backfill, the changed doc syncs up, and the projection refreshes the planner's snapshot — no manual step.

## Verification

**Before (reproduces the bug):** on a pre-fix pod, create a routines doc entry with no `created_by` (any pre-rollout routine qualifies). The control-plane planner logs `routine scheduler: snapshot entry has no created_by; routine is not fireable` each planning pass and the routine never appears in the fires outbox.

**After:**
1. Control-plane logs: the `no created_by` WARN count drops to zero once the engine roll completes (~1k/day before).
2. DB: enabled routines with a valid schedule and no `created_by` in the agents' routine-schedules snapshot go to 0; the previously skipped routines appear in the fires outbox with future pending instants.
3. Unit: `pnpm --filter @houston/host test` — new coverage in `migrate/routine-created-by.test.ts`, `routes/agent-seed.test.ts` (seed stamping), `routes/agent-data.test.ts` (owner-sub fallback + header-outranks-fallback).

Gates run: host/runtime/domain vitest (all green), `pnpm check`, `pnpm check:boundaries`, workspace typecheck.

Linear: PRODUCT-1497