### PR TITLE
feat(runtime): tranche-2 pool ops — every remaining agent route serves a sleeping agent without a wake (PRODUCT-1469)

### DIFF
--- a/packages/host/src/op/dispatch.ts
+++ b/packages/host/src/op/dispatch.ts
@@ -1,21 +1,12 @@
-import {
-  createServer,
-  type IncomingMessage,
-  type ServerResponse,
-} from "node:http";
+import { createServer, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { ActivityContributor, HoustonEvent } from "@houston/protocol";
+import type { CustomIntegrationManager } from "../integrations/custom/manager";
 import { LocalPaths } from "../paths";
-import { handleAgentData } from "../routes/agent-data";
-import { handleAgentFile } from "../routes/agent-file";
-import { handleSkills } from "../routes/skills";
-import { handleSkillsManifest } from "../routes/skills-manifest";
-import { handleSkillsRemote } from "../routes/skills-remote";
 import { LocalWorkspaceStore } from "../store/local";
-import { handleAttachments } from "../turn/attachments";
-import { handleFiles } from "../turn/files";
 import { FsVfs, LazyReadRefusedError, type Vfs } from "../vfs";
 import { relayAgentOpResponse, TOO_LARGE_MESSAGE } from "./dispatch-relay";
+import { runAgentOpChain } from "./handler-chain";
 
 /**
  * A write the gateway routes to a pool worker instead of waking the agent's
@@ -28,6 +19,9 @@ export interface AgentOpRequest {
   /** Route rest after `/agents/<id>/`, e.g. `routines/<id>`, `agentfile/CLAUDE.md`. */
   rest: string;
   body?: string;
+  /** Binary request body (a migration zip), base64 — JSON can't carry raw
+   *  bytes. Mutually exclusive with `body`. */
+  bodyBase64?: string;
   contentType?: string;
   /** Verified acting identity (routines' created_by, activity contributors). */
   actingSub?: string;
@@ -67,6 +61,8 @@ export async function dispatchAgentOp(opts: {
   agentId: string;
   request: AgentOpRequest;
   fetchImpl?: typeof fetch;
+  /** Wired for custom-integration ops (see op/handler-chain.ts). */
+  customIntegrations?: CustomIntegrationManager;
   /** The handlers' file port, rooted at `workspacesRoot`. Default: the real
    *  directory. A lazy store-backed vfs lets an op run over a manifest-only
    *  tree that downloads objects on first read. */
@@ -85,89 +81,59 @@ export async function dispatchAgentOp(opts: {
     };
   }
   const vfs = opts.vfs ?? new FsVfs(opts.workspacesRoot);
-  const paths = new LocalPaths();
-  const ctx = { workspace, agent };
   const events: HoustonEvent[] = [];
-  const emit = (event: HoustonEvent) => {
-    events.push(event);
-  };
-  const { method, rest, triggersEnabled, actingSub, actingAuthor } =
-    opts.request;
-  const query = new URLSearchParams(opts.request.query ?? "");
+  const { method, rest } = opts.request;
 
   // A refused lazy read answers 503 from INSIDE the handler chain (the
   // handler may be half-way through a multi-key mutation); the flag tells
   // the caller to discard the overlay instead of syncing a partial result.
   let refused = false;
-  const handler = async (req: IncomingMessage, res: ServerResponse) => {
-    // Files (list/read/download/archive/import/move/rename/folder): the
-    // Files tab, byte-identical to the pod.
-    if (await handleFiles(vfs, paths, ctx, method, rest, req, res, query, emit))
+  const relayError = (res: ServerResponse, error: unknown): void => {
+    if (error instanceof LazyReadRefusedError) {
+      refused = true;
+      // Refused before the download: the same answer the relay cap gives.
+      if (!res.headersSent) {
+        res.writeHead(503, { "Content-Type": "application/json" });
+      }
+      res.end(JSON.stringify({ error: TOO_LARGE_MESSAGE }));
       return;
-    if (
-      await handleAgentData(
-        vfs,
-        paths,
-        ctx,
-        method,
-        rest,
-        req,
-        res,
-        emit,
-        actingSub,
-        actingAuthor ?? undefined,
-        triggersEnabled,
-      )
-    )
-      return;
-    if (await handleAgentFile(vfs, paths, ctx, method, rest, req, res, emit))
-      return;
-    // Composer drops land in uploads/ BEFORE the send (which is a pool turn).
-    if (await handleAttachments(vfs, paths, ctx, method, rest, req, res, emit))
-      return;
-    if (
-      await handleSkillsManifest(vfs, paths, ctx, method, rest, req, res, emit)
-    )
-      return;
-    if (await handleSkills(vfs, paths, ctx, method, rest, req, res, emit))
-      return;
-    if (
-      await handleSkillsRemote(
-        vfs,
-        paths,
-        ctx,
-        method,
-        rest,
-        req,
-        res,
-        emit,
-        opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {},
-      )
-    )
-      return;
-    res.writeHead(404, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error: "not an op route" }));
+    }
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "application/json" });
+    }
+    res.end(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
   };
   const server = createServer((req, res) => {
-    handler(req, res).catch((error: unknown) => {
-      if (error instanceof LazyReadRefusedError) {
-        refused = true;
-        // Refused before the download: the same answer the relay cap gives.
-        if (!res.headersSent) {
-          res.writeHead(503, { "Content-Type": "application/json" });
-        }
-        res.end(JSON.stringify({ error: TOO_LARGE_MESSAGE }));
-        return;
-      }
-      if (!res.headersSent) {
-        res.writeHead(500, { "Content-Type": "application/json" });
-      }
-      res.end(
-        JSON.stringify({
-          error: error instanceof Error ? error.message : String(error),
-        }),
-      );
-    });
+    runAgentOpChain(
+      {
+        vfs,
+        paths: new LocalPaths(),
+        ctx: { workspace, agent },
+        query: new URLSearchParams(opts.request.query ?? ""),
+        emit: (event) => {
+          events.push(event);
+        },
+        ...(opts.request.actingSub
+          ? { actingSub: opts.request.actingSub }
+          : {}),
+        ...(opts.request.actingAuthor
+          ? { actingAuthor: opts.request.actingAuthor }
+          : {}),
+        triggersEnabled: opts.request.triggersEnabled,
+        ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+        ...(opts.customIntegrations
+          ? { customIntegrations: opts.customIntegrations }
+          : {}),
+      },
+      method,
+      rest,
+      req,
+      res,
+    ).catch((error: unknown) => relayError(res, error));
   });
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
   try {
@@ -175,8 +141,15 @@ export async function dispatchAgentOp(opts: {
     // A GET/HEAD must carry NO body (fetch throws on any, even ""), and the
     // gateway sends an empty string on every route op.
     const bodiless = method === "GET" || method === "HEAD";
-    const body = bodiless || !opts.request.body ? undefined : opts.request.body;
-    const response = await fetch(`http://127.0.0.1:${port}/op`, {
+    const body = bodiless
+      ? undefined
+      : opts.request.bodyBase64 !== undefined
+        ? Buffer.from(opts.request.bodyBase64, "base64")
+        : opts.request.body || undefined;
+    // The query rides the loopback URL too: handlers that parse req.url
+    // (migration's ?overwrite=1) see exactly what the pod's server sees.
+    const query = opts.request.query ? `?${opts.request.query}` : "";
+    const response = await fetch(`http://127.0.0.1:${port}/op${query}`, {
       method,
       headers:
         opts.request.contentType && body !== undefined

--- a/packages/host/src/op/handler-chain.ts
+++ b/packages/host/src/op/handler-chain.ts
@@ -1,0 +1,126 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { ActivityContributor, HoustonEvent } from "@houston/protocol";
+import type { Agent, Workspace } from "../domain/types";
+import type { CustomIntegrationManager } from "../integrations/custom/manager";
+import type { WorkspacePaths } from "../paths";
+import { handleAgentData } from "../routes/agent-data";
+import { handleAgentFile } from "../routes/agent-file";
+import { handleCustomIntegrationsDispatch } from "../routes/custom-integrations-user";
+import { handleMigration } from "../routes/migration";
+import { handlePortableExport } from "../routes/portable";
+import { handlePortablePreview } from "../routes/portable-preview";
+import { handlePortableStore } from "../routes/portable-store";
+import { handleSkills } from "../routes/skills";
+import { handleSkillsManifest } from "../routes/skills-manifest";
+import { handleSkillsRemote } from "../routes/skills-remote";
+import { handleAttachments } from "../turn/attachments";
+import { handleFiles } from "../turn/files";
+import type { Vfs } from "../vfs";
+
+export interface AgentOpChainDeps {
+  vfs: Vfs;
+  paths: WorkspacePaths;
+  ctx: { workspace: Workspace; agent: Agent };
+  query: URLSearchParams;
+  emit: (event: HoustonEvent) => void;
+  actingSub?: string;
+  actingAuthor?: ActivityContributor;
+  triggersEnabled: boolean;
+  fetchImpl?: typeof fetch;
+  /** Wired for custom-integration ops only (a per-op manager over the
+   *  hydrated definitions file + the gateway's secret store). */
+  customIntegrations?: CustomIntegrationManager;
+}
+
+/**
+ * The pod's own handler chain, run for one op. Same handlers, same order of
+ * disjoint route families as routes/agents.ts — only the filesystem (and the
+ * custom-integration manager's construction) underneath is different.
+ * Unknown routes answer 404, never a throw.
+ */
+export async function runAgentOpChain(
+  deps: AgentOpChainDeps,
+  method: string,
+  rest: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const { vfs, paths, ctx, emit } = deps;
+  if (
+    await handleCustomIntegrationsDispatch(
+      deps.customIntegrations,
+      method,
+      rest,
+      req,
+      res,
+    )
+  )
+    return;
+  // Files (list/read/download/archive/import/move/rename/folder): the
+  // Files tab, byte-identical to the pod.
+  if (
+    await handleFiles(vfs, paths, ctx, method, rest, req, res, deps.query, emit)
+  )
+    return;
+  if (
+    await handleAgentData(
+      vfs,
+      paths,
+      ctx,
+      method,
+      rest,
+      req,
+      res,
+      emit,
+      deps.actingSub,
+      deps.actingAuthor,
+      deps.triggersEnabled,
+    )
+  )
+    return;
+  if (await handleAgentFile(vfs, paths, ctx, method, rest, req, res, emit))
+    return;
+  // Composer drops land in uploads/ BEFORE the send (which is a pool turn).
+  if (await handleAttachments(vfs, paths, ctx, method, rest, req, res, emit))
+    return;
+  if (await handleSkillsManifest(vfs, paths, ctx, method, rest, req, res, emit))
+    return;
+  if (await handleSkills(vfs, paths, ctx, method, rest, req, res, emit)) return;
+  if (
+    await handleSkillsRemote(
+      vfs,
+      paths,
+      ctx,
+      method,
+      rest,
+      req,
+      res,
+      emit,
+      deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {},
+    )
+  )
+    return;
+  if (await handlePortablePreview({ vfs, paths }, ctx, method, rest, req, res))
+    return;
+  // NOT portable/anonymize: the model pass rides its own op kind (the
+  // titles pattern), never the route chain.
+  if (await handlePortableExport({ vfs, paths }, ctx, method, rest, req, res))
+    return;
+  // No agentDir: archives carrying runtime transcripts were declined before
+  // dispatch (op-route.ts), so there is never a session to synthesize here.
+  if (await handleMigration({ vfs, paths }, ctx, method, rest, req, res, emit))
+    return;
+  if (
+    await handlePortableStore(
+      { vfs, paths },
+      { ...ctx, userId: ctx.workspace.ownerUserId },
+      method,
+      rest,
+      req,
+      res,
+    )
+  )
+    return;
+  res.writeHead(404, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "not an op route" }));
+}

--- a/packages/host/src/op/handler-chain.ts
+++ b/packages/host/src/op/handler-chain.ts
@@ -33,10 +33,14 @@ export interface AgentOpChainDeps {
 }
 
 /**
- * The pod's own handler chain, run for one op. Same handlers, same order of
- * disjoint route families as routes/agents.ts — only the filesystem (and the
- * custom-integration manager's construction) underneath is different.
- * Unknown routes answer 404, never a throw.
+ * The pod's own handler chain, run for one op. The same handlers as the
+ * dispatch surface in routes/agents.ts (the route families are disjoint, so
+ * relative order is free) — only the filesystem, and the construction of the
+ * custom-integration manager, is different underneath. Deliberately absent:
+ * trigger-status (gateway-native for asleep agents) and portable/anonymize
+ * (its own op kind — the titles pattern). A route added to agents.ts must be
+ * added here too, or its op answers 404. Unknown routes answer 404, never a
+ * throw.
  */
 export async function runAgentOpChain(
   deps: AgentOpChainDeps,

--- a/packages/host/src/routes/migration-import.ts
+++ b/packages/host/src/routes/migration-import.ts
@@ -23,6 +23,23 @@ import {
  * re-POST of the same chunk an idempotent resume.
  */
 
+/**
+ * Whether an uploaded migration archive carries runtime transcript entries
+ * (`.houston/runtime/**`). A pool worker declines those imports back to the
+ * pod: session re-synthesis is agentDir-anchored and the transcript
+ * authority learns imported conversations only from the pod's projector.
+ * A malformed zip reads as `false` so the real import route owns its error.
+ */
+export function archiveTouchesRuntime(bytes: Buffer): boolean {
+  try {
+    return Object.keys(unzipSync(new Uint8Array(bytes))).some((key) =>
+      key.replace(/^\/+/, "").startsWith(".houston/runtime/"),
+    );
+  } catch {
+    return false;
+  }
+}
+
 export class MigrationImportError extends Error {
   constructor(
     readonly status: number,

--- a/packages/host/src/routes/migration-import.ts
+++ b/packages/host/src/routes/migration-import.ts
@@ -32,9 +32,19 @@ import {
  */
 export function archiveTouchesRuntime(bytes: Buffer): boolean {
   try {
-    return Object.keys(unzipSync(new Uint8Array(bytes))).some((key) =>
-      key.replace(/^\/+/, "").startsWith(".houston/runtime/"),
-    );
+    // Names only — the filter refuses every entry, so nothing inflates.
+    // Normalize EXACTLY as the import loop below does (safeSeedKey), so
+    // `./.houston/runtime/…` and friends cannot dodge the decline while
+    // still importing as a runtime path.
+    let touches = false;
+    unzipSync(new Uint8Array(bytes), {
+      filter: (file) => {
+        if (safeSeedKey(file.name)?.startsWith(".houston/runtime/"))
+          touches = true;
+        return false;
+      },
+    });
+    return touches;
   } catch {
     return false;
   }

--- a/packages/host/src/routes/portable-anonymize.ts
+++ b/packages/host/src/routes/portable-anonymize.ts
@@ -36,7 +36,13 @@ export type AnonymizeAiRunner = (
 ) => Promise<{ id: string; text: string; summary: string }[]>;
 
 export async function runPortableAnonymize(
-  deps: { vfs: Vfs; root: string; ai?: AnonymizeAiRunner },
+  deps: {
+    vfs: Vfs;
+    root: string;
+    ai?: AnonymizeAiRunner;
+    /** Surface-specific `aiError` copy when no runner exists at all. */
+    aiUnavailableReason?: string;
+  },
   body: PortableAnonymizeRequest,
 ): Promise<PortableAnonymizeResponse> {
   // Untrusted wizard input — normalize before reuse as a selection.
@@ -61,7 +67,9 @@ export async function runPortableAnonymize(
   if (!deps.ai) {
     return {
       ...(await anonymizeContent(content, redactSecrets)),
-      aiError: "AI anonymization is not available on this deployment",
+      aiError:
+        deps.aiUnavailableReason ??
+        "AI anonymization is not available on this deployment",
     };
   }
   try {

--- a/packages/host/src/routes/portable-anonymize.ts
+++ b/packages/host/src/routes/portable-anonymize.ts
@@ -19,16 +19,70 @@ import { gatherPortableContent } from "./portable-content";
 import { redactSecrets } from "./portable-secrets";
 
 /**
- * POST .../portable/anonymize — the export wizard's "Help me anonymize"
- * pass. Gathers the selected content off the vfs, regex-pre-redacts it, and
- * runs the AI redactor in the agent's runtime (where the provider credential
- * lives). When the AI pass can't run — no channel support, no provider
- * connected, unparseable model reply — the regex-only result ships instead
- * WITH the reason (`mode: "patterns"`, `aiError`), so the wizard can say so
- * (beta no-silent-failure). Read-only: nothing on the agent changes; the
- * accepted diffs come back as `overrides` on the export call. Returns true
- * when handled.
+ * The export wizard's "Help me anonymize" pass. Gathers the selected content
+ * off the vfs, regex-pre-redacts it, and runs the AI redactor. When the AI
+ * pass can't run — no runner on this deployment, no provider connected,
+ * unparseable model reply — the regex-only result ships instead WITH the
+ * reason (`mode: "patterns"`, `aiError`), so the wizard can say so (beta
+ * no-silent-failure). Read-only: nothing on the agent changes; the accepted
+ * diffs come back as `overrides` on the export call.
+ *
+ * The core is surface-agnostic: the pod route runs `ai` through the agent's
+ * runtime channel; a pool worker runs it through a turn-local model runtime
+ * (runtime turn/op-anonymize.ts). One body grammar, one fallback policy.
  */
+export type AnonymizeAiRunner = (
+  items: { id: string; text: string }[],
+) => Promise<{ id: string; text: string; summary: string }[]>;
+
+export async function runPortableAnonymize(
+  deps: { vfs: Vfs; root: string; ai?: AnonymizeAiRunner },
+  body: PortableAnonymizeRequest,
+): Promise<PortableAnonymizeResponse> {
+  // Untrusted wizard input — normalize before reuse as a selection.
+  const content = await gatherPortableContent(deps.vfs, deps.root, {
+    includeClaudeMd: Boolean(body.claudeMd),
+    skillSlugs: Array.isArray(body.skillSlugs) ? body.skillSlugs : [],
+    routineIds: Array.isArray(body.routineIds) ? body.routineIds : [],
+    learningIds: Array.isArray(body.learningIds) ? body.learningIds : [],
+  });
+
+  // Credentials are scrubbed by secretlint in BOTH modes — inside the items
+  // sent to the model AND in the patterns fallback.
+  // `useAi: false` is the wizard toggle: a deliberate patterns-only run, so
+  // no `aiError` rides the response (nothing failed).
+  const wantAi = body.useAi !== false;
+  const items = wantAi
+    ? await collectAnonymizeItems(content, redactSecrets)
+    : [];
+  if (!wantAi || items.length === 0) {
+    return anonymizeContent(content, redactSecrets);
+  }
+  if (!deps.ai) {
+    return {
+      ...(await anonymizeContent(content, redactSecrets)),
+      aiError: "AI anonymization is not available on this deployment",
+    };
+  }
+  try {
+    const results = await deps.ai(items);
+    return await mergeAnonymizeResults(
+      content,
+      new Map<string, AnonymizeAiResult>(
+        results.map((r) => [r.id, { text: r.text, summary: r.summary }]),
+      ),
+      redactSecrets,
+    );
+  } catch (e) {
+    return {
+      ...(await anonymizeContent(content, redactSecrets)),
+      aiError: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+/** POST .../portable/anonymize on the pod's dispatch surface. Returns true
+ *  when handled. */
 export async function handlePortableAnonymize(
   deps: { vfs?: Vfs; paths?: WorkspacePaths; channel?: RuntimeChannel },
   ctx: { workspace: Workspace; agent: Agent },
@@ -44,48 +98,24 @@ export async function handlePortableAnonymize(
   }
   const paths = deps.paths ?? new CloudPaths();
   const root = paths.agentRoot(ctx.workspace, ctx.agent);
-  // Untrusted wizard input — normalize before reuse as a selection.
   const body = (await readJson(req)) as unknown as PortableAnonymizeRequest;
-  const content = await gatherPortableContent(deps.vfs, root, {
-    includeClaudeMd: Boolean(body.claudeMd),
-    skillSlugs: Array.isArray(body.skillSlugs) ? body.skillSlugs : [],
-    routineIds: Array.isArray(body.routineIds) ? body.routineIds : [],
-    learningIds: Array.isArray(body.learningIds) ? body.learningIds : [],
-  });
-
-  // Credentials are scrubbed by secretlint in BOTH modes — inside the items
-  // sent to the model AND in the patterns fallback.
-  // `useAi: false` is the wizard toggle: a deliberate patterns-only run, so
-  // no `aiError` rides the response (nothing failed).
-  const wantAi = body.useAi !== false;
-  const items = wantAi
-    ? await collectAnonymizeItems(content, redactSecrets)
-    : [];
-  let response: PortableAnonymizeResponse;
-  if (!wantAi || items.length === 0) {
-    response = await anonymizeContent(content, redactSecrets);
-  } else if (!deps.channel?.anonymizeTexts) {
-    response = {
-      ...(await anonymizeContent(content, redactSecrets)),
-      aiError: "AI anonymization is not available on this deployment",
-    };
-  } else {
-    try {
-      const results = await deps.channel.anonymizeTexts(ctx, items);
-      response = await mergeAnonymizeResults(
-        content,
-        new Map<string, AnonymizeAiResult>(
-          results.map((r) => [r.id, { text: r.text, summary: r.summary }]),
-        ),
-        redactSecrets,
-      );
-    } catch (e) {
-      response = {
-        ...(await anonymizeContent(content, redactSecrets)),
-        aiError: e instanceof Error ? e.message : String(e),
-      };
-    }
-  }
+  const channel = deps.channel;
+  const response = await runPortableAnonymize(
+    {
+      vfs: deps.vfs,
+      root,
+      // The channel carries the AI pass into the agent's runtime; absent
+      // (or unsupported) the core falls back to the regex redactor.
+      ...(channel?.anonymizeTexts
+        ? {
+            ai: (items: { id: string; text: string }[]) =>
+              // biome-ignore lint/style/noNonNullAssertion: guarded by the spread condition
+              channel.anonymizeTexts!(ctx, items),
+          }
+        : {}),
+    },
+    body,
+  );
   json(res, 200, response);
   return true;
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@types/node": "22.20.0",
     "@typescript/native-preview": "7.0.0-dev.20260607.1",
+    "fflate": "0.8.3",
     "vitest": "3.2.6"
   },
   "optionalDependencies": {

--- a/packages/runtime/src/ai/azure-openai.ts
+++ b/packages/runtime/src/ai/azure-openai.ts
@@ -83,13 +83,19 @@ export function normalizeAzureEndpoint(raw: string): string {
   return trimmed.replace(/\/+$/, "");
 }
 
-/** Persist the endpoint (validated). Atomic like every config write here. */
-export function setAzureEndpoint(raw: string): void {
+/** Persist the endpoint (validated) into an arbitrary data dir — the
+ *  dataDir-bound twin a pool worker uses against a hydrated agent root. */
+export function setAzureEndpointIn(dataDir: string, raw: string): void {
   const baseUrl = normalizeAzureEndpoint(raw);
-  const file = azureEndpointFileIn(config.dataDir);
+  const file = azureEndpointFileIn(dataDir);
   const tmp = `${file}.tmp`;
   writeFileSync(tmp, JSON.stringify({ baseUrl }, null, 2));
   renameSync(tmp, file);
+}
+
+/** Persist the endpoint (validated). Atomic like every config write here. */
+export function setAzureEndpoint(raw: string): void {
+  setAzureEndpointIn(config.dataDir, raw);
 }
 
 /**

--- a/packages/runtime/src/ai/openai-compatible.ts
+++ b/packages/runtime/src/ai/openai-compatible.ts
@@ -53,11 +53,15 @@ function load(dataDir: string = config.dataDir): StoredEndpoint {
   }
 }
 
-function save(e: StoredEndpoint): void {
-  const file = endpointFileIn(config.dataDir);
+function writeEndpointFileIn(dataDir: string, e: StoredEndpoint): void {
+  const file = endpointFileIn(dataDir);
   const tmp = `${file}.tmp`;
   writeFileSync(tmp, JSON.stringify(e, null, 2));
   renameSync(tmp, file);
+}
+
+function save(e: StoredEndpoint): void {
+  writeEndpointFileIn(config.dataDir, e);
   // Every endpoint write re-syncs the live runtime's provider registration —
   // no caller can configure an endpoint the runtime then can't dispatch to.
   if (liveRegistrar) registerCustomProviderIfConfigured(liveRegistrar);
@@ -207,7 +211,7 @@ export interface CustomEndpointInput {
  * server, so reject it at connect time rather than as a cryptic turn error. The
  * API key is handled separately (auth/login.ts), since it belongs in auth.json.
  */
-export function setCustomEndpointConfig(input: CustomEndpointInput): void {
+function normalizeEndpointInput(input: CustomEndpointInput): StoredEndpoint {
   const baseUrl = input.baseUrl?.trim();
   const model = input.model?.trim();
   if (!baseUrl) throw new Error("missing base URL");
@@ -220,7 +224,7 @@ export function setCustomEndpointConfig(input: CustomEndpointInput): void {
   }
   if (url.protocol !== "http:" && url.protocol !== "https:")
     throw new Error("base URL must start with http:// or https://");
-  save({
+  return {
     baseUrl,
     model,
     name: input.name?.trim() || undefined,
@@ -230,7 +234,20 @@ export function setCustomEndpointConfig(input: CustomEndpointInput): void {
         : undefined,
     reasoning: input.reasoning ?? undefined,
     orgShared: input.orgShared === true ? true : undefined,
-  });
+  };
+}
+
+export function setCustomEndpointConfig(input: CustomEndpointInput): void {
+  save(normalizeEndpointInput(input));
+}
+
+/** The dataDir-bound twin a pool worker uses against a hydrated agent root
+ *  (no live runtime to re-register — the next turn reads the file). */
+export function setCustomEndpointConfigIn(
+  dataDir: string,
+  input: CustomEndpointInput,
+): void {
+  writeEndpointFileIn(dataDir, normalizeEndpointInput(input));
 }
 
 /** Forget the endpoint (its key is cleared by auth logout). */

--- a/packages/runtime/src/ai/qwen-dashscope.ts
+++ b/packages/runtime/src/ai/qwen-dashscope.ts
@@ -82,17 +82,26 @@ export function activeQwenRegion(dataDir: string = config.dataDir): QwenRegion {
 }
 
 /**
+ * Persist the region a key verified against into an arbitrary data dir — the
+ * dataDir-bound twin a pool worker uses against a hydrated agent root (the
+ * live-runtime variant below re-registers the process's provider too).
+ */
+export function setQwenRegionIn(dataDir: string, regionId: string): void {
+  const region = QWEN_REGIONS.find((r) => r.id === regionId);
+  if (!region) throw new Error(`unknown qwen region: ${regionId}`);
+  const file = qwenRegionFileIn(dataDir);
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, JSON.stringify({ region: region.id }, null, 2));
+  renameSync(tmp, file);
+}
+
+/**
  * Persist the region a key just verified against and re-register the live
  * runtime so the very next turn dials it (the registered config is merged,
  * but the MODEL objects carry the live base URL — see `qwenModels`).
  */
 export function setQwenRegion(regionId: string): void {
-  const region = QWEN_REGIONS.find((r) => r.id === regionId);
-  if (!region) throw new Error(`unknown qwen region: ${regionId}`);
-  const file = qwenRegionFileIn(config.dataDir);
-  const tmp = `${file}.tmp`;
-  writeFileSync(tmp, JSON.stringify({ region: region.id }, null, 2));
-  renameSync(tmp, file);
+  setQwenRegionIn(config.dataDir, regionId);
   if (liveRegistrar) registerQwenProvider(liveRegistrar);
 }
 

--- a/packages/runtime/src/ai/qwen-dashscope.ts
+++ b/packages/runtime/src/ai/qwen-dashscope.ts
@@ -1,8 +1,7 @@
-import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 import type { Model } from "@earendil-works/pi-ai";
 import { QWEN_TOKEN_PLAN_MODELS } from "@earendil-works/pi-ai/providers/qwen-token-plan.models";
 import { config } from "../config";
+import { activeQwenRegion, setQwenRegionIn } from "./qwen-region";
 
 /**
  * Houston's `qwen` extension provider: Qwen models on Alibaba Model Studio's
@@ -43,57 +42,15 @@ export const QWEN_PROVIDER_ID = "qwen";
 /** The default model, listed FIRST so `firstCatalogModel` picks it. */
 const QWEN_DEFAULT_MODEL = "qwen3.7-max";
 
-export interface QwenRegion {
-  id: string;
-  baseUrl: string;
-}
-
-/**
- * The international Model Studio regions, in verify-probe order. The Singapore
- * endpoint is Alibaba's primary international region and stays the default for
- * an install that has never verified a key.
- */
-export const QWEN_REGIONS: readonly QwenRegion[] = [
-  {
-    id: "intl",
-    baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-  },
-  { id: "us", baseUrl: "https://dashscope-us.aliyuncs.com/compatible-mode/v1" },
-];
-
-const DEFAULT_REGION = QWEN_REGIONS[0];
-
-/** The persisted region choice — beside settings.json so it syncs with it. */
-export const qwenRegionFileIn = (dataDir: string) =>
-  join(dataDir, "qwen-region.json");
-
-/** The region the stored key verified against, defaulting to Singapore. */
-export function activeQwenRegion(dataDir: string = config.dataDir): QwenRegion {
-  const file = qwenRegionFileIn(dataDir);
-  if (!existsSync(file)) return DEFAULT_REGION;
-  try {
-    const { region } = JSON.parse(readFileSync(file, "utf8")) as {
-      region?: string;
-    };
-    return QWEN_REGIONS.find((r) => r.id === region) ?? DEFAULT_REGION;
-  } catch {
-    return DEFAULT_REGION;
-  }
-}
-
-/**
- * Persist the region a key verified against into an arbitrary data dir — the
- * dataDir-bound twin a pool worker uses against a hydrated agent root (the
- * live-runtime variant below re-registers the process's provider too).
- */
-export function setQwenRegionIn(dataDir: string, regionId: string): void {
-  const region = QWEN_REGIONS.find((r) => r.id === regionId);
-  if (!region) throw new Error(`unknown qwen region: ${regionId}`);
-  const file = qwenRegionFileIn(dataDir);
-  const tmp = `${file}.tmp`;
-  writeFileSync(tmp, JSON.stringify({ region: region.id }, null, 2));
-  renameSync(tmp, file);
-}
+// Region persistence lives in ./qwen-region; existing importers keep this
+// module as the provider's one front door.
+export {
+  activeQwenRegion,
+  QWEN_REGIONS,
+  type QwenRegion,
+  qwenRegionFileIn,
+  setQwenRegionIn,
+} from "./qwen-region";
 
 /**
  * Persist the region a key just verified against and re-register the live

--- a/packages/runtime/src/ai/qwen-region.ts
+++ b/packages/runtime/src/ai/qwen-region.ts
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { config } from "../config";
+
+/**
+ * Qwen's persisted region choice (see ./qwen-dashscope for the provider
+ * story). Model Studio international is REGION-SCOPED: a key works only
+ * against the region it was created in, so the verify probe persists the
+ * accepting one here — beside settings.json so it syncs with it — and every
+ * model read serves it.
+ */
+
+export interface QwenRegion {
+  id: string;
+  baseUrl: string;
+}
+
+/**
+ * The international Model Studio regions, in verify-probe order. The Singapore
+ * endpoint is Alibaba's primary international region and stays the default for
+ * an install that has never verified a key.
+ */
+export const QWEN_REGIONS: readonly QwenRegion[] = [
+  {
+    id: "intl",
+    baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+  },
+  { id: "us", baseUrl: "https://dashscope-us.aliyuncs.com/compatible-mode/v1" },
+];
+
+const DEFAULT_REGION = QWEN_REGIONS[0];
+
+/** The persisted region choice — beside settings.json so it syncs with it. */
+export const qwenRegionFileIn = (dataDir: string) =>
+  join(dataDir, "qwen-region.json");
+
+/** The region the stored key verified against, defaulting to Singapore. */
+export function activeQwenRegion(dataDir: string = config.dataDir): QwenRegion {
+  const file = qwenRegionFileIn(dataDir);
+  if (!existsSync(file)) return DEFAULT_REGION;
+  try {
+    const { region } = JSON.parse(readFileSync(file, "utf8")) as {
+      region?: string;
+    };
+    return QWEN_REGIONS.find((r) => r.id === region) ?? DEFAULT_REGION;
+  } catch {
+    return DEFAULT_REGION;
+  }
+}
+
+/**
+ * Persist the region a key verified against into an arbitrary data dir — the
+ * dataDir-bound twin a pool worker uses against a hydrated agent root (the
+ * live-runtime variant in qwen-dashscope.ts re-registers the process's
+ * provider too).
+ */
+export function setQwenRegionIn(dataDir: string, regionId: string): void {
+  const region = QWEN_REGIONS.find((r) => r.id === regionId);
+  if (!region) throw new Error(`unknown qwen region: ${regionId}`);
+  const file = qwenRegionFileIn(dataDir);
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, JSON.stringify({ region: region.id }, null, 2));
+  renameSync(tmp, file);
+}

--- a/packages/runtime/src/auth/qwen-verify.test.ts
+++ b/packages/runtime/src/auth/qwen-verify.test.ts
@@ -100,3 +100,30 @@ test("a region with no verdict → provider_unavailable, never 'paste it again'"
     "provider_unavailable",
   );
 });
+
+test("an injected persist (the pool-worker seam) lands the region in the AGENT's dir, not the process's", async () => {
+  const { verifyQwenRegions, persistedRegion } = await load();
+  const { setQwenRegionIn, qwenRegionFileIn } = await import(
+    "../ai/qwen-dashscope"
+  );
+  const { mkdtempSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const agentDataDir = mkdtempSync(join(tmpdir(), "houston-qwen-agent-"));
+  await verifyQwenRegions(
+    "qwen",
+    async (m) => (m.baseUrl.includes("dashscope-us") ? null : SG_REJECTED),
+    (regionId) => setQwenRegionIn(agentDataDir, regionId),
+  );
+  // The worker's own data dir stays untouched...
+  expect(persistedRegion()).toBeNull();
+  // ...and the hydrated agent root holds the verified region.
+  const { readFileSync } = await import("node:fs");
+  expect(
+    (
+      JSON.parse(readFileSync(qwenRegionFileIn(agentDataDir), "utf8")) as {
+        region: string;
+      }
+    ).region,
+  ).toBe("us");
+});

--- a/packages/runtime/src/auth/qwen-verify.ts
+++ b/packages/runtime/src/auth/qwen-verify.ts
@@ -23,6 +23,10 @@ type Probe = (model: Model<"openai-completions">) => Promise<string | null>;
 export async function verifyQwenRegions(
   providerId: string,
   probe: Probe,
+  // Where the accepting region lands. The default writes the LIVE runtime's
+  // data dir; a pool worker persists into the hydrated agent root instead
+  // (op-credential.ts), where it syncs back beside settings.json.
+  persist: (regionId: string) => void = setQwenRegion,
 ): Promise<void> {
   // The default (first-listed) model carries the active region's URL; probe
   // each candidate region by swapping the base URL alone.
@@ -32,7 +36,7 @@ export async function verifyQwenRegions(
   for (const region of QWEN_REGIONS) {
     const message = await probe({ ...probeModel, baseUrl: region.baseUrl });
     if (message === null) {
-      setQwenRegion(region.id);
+      persist(region.id);
       return;
     }
     const kind = classifyProviderError({
@@ -41,7 +45,7 @@ export async function verifyQwenRegions(
       message,
     }).kind;
     if (PROVES_AUTH.has(kind)) {
-      setQwenRegion(region.id);
+      persist(region.id);
       return;
     }
     if (kind === "unauthenticated") {

--- a/packages/runtime/src/auth/verify-api-key.ts
+++ b/packages/runtime/src/auth/verify-api-key.ts
@@ -23,6 +23,10 @@ export type { ApiKeyVerifyReason } from "./verify-errors";
  */
 export interface VerifyApiKeyOptions {
   azureBaseUrl?: string;
+  /** Where a verified qwen key's accepting region lands (region-scoped keys,
+   *  HOU-1077). Default: the live runtime's data dir; a pool worker persists
+   *  into the hydrated agent root instead. */
+  qwenRegionPersist?: (regionId: string) => void;
   /** Test seam: injected transport, forwarded to pi so probe URLs are observable. */
   fetch?: typeof fetch;
 }
@@ -59,8 +63,10 @@ export async function verifyApiKey(
   // Qwen keys are REGION-scoped (Alibaba Model Studio international): probe
   // every region and persist the accepting one (`qwen-verify.ts`, HOU-1077).
   if (providerId === QWEN_PROVIDER_ID) {
-    await verifyQwenRegions(providerId, (m) =>
-      probeCompletion(providerId, m, key),
+    await verifyQwenRegions(
+      providerId,
+      (m) => probeCompletion(providerId, m, key),
+      ...(opts?.qwenRegionPersist ? [opts.qwenRegionPersist] : []),
     );
     return;
   }

--- a/packages/runtime/src/session/anonymize.ts
+++ b/packages/runtime/src/session/anonymize.ts
@@ -1,3 +1,4 @@
+import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { activeProvider, resolveModel } from "../ai/providers";
 import { authStorage, modelRuntime } from "../auth/storage";
 import { oneShotWithClaude } from "../backends/claude/one-shot";
@@ -52,6 +53,32 @@ Return ONLY valid JSON (no markdown fences), with every input id exactly once:
 {"items":[{"id":"...","text":"...","summary":"..."}]}`;
 
 /**
+ * Pure, parameterized redaction pass (the `generateTitle` shape): a one-shot
+ * turn over an injected model runtime. Powers the pool worker's anonymize op,
+ * which has a hydrated agent root instead of the process-global config —
+ * pi providers only; the Claude-SDK path below is pod-only by compliance.
+ */
+export async function anonymizeTextsWith(
+  opts: {
+    workspaceDir: string;
+    model: unknown;
+    modelRuntime: ModelRuntime;
+  },
+  items: AnonymizeItemInput[],
+): Promise<AnonymizeItemResult[]> {
+  if (items.length === 0) return [];
+  const prompt = JSON.stringify({ items });
+  const raw = await oneShotText({
+    cwd: opts.workspaceDir,
+    model: opts.model,
+    modelRuntime: opts.modelRuntime,
+    systemPrompt: ANONYMIZE_PROMPT,
+    prompt,
+  });
+  return parseAnonymizeResult(raw, items);
+}
+
+/**
  * Redact the given texts with the active provider's model. Empty input skips
  * the model call entirely.
  */
@@ -59,25 +86,21 @@ export async function anonymizeTexts(
   items: AnonymizeItemInput[],
 ): Promise<AnonymizeItemResult[]> {
   if (items.length === 0) return [];
-  const prompt = JSON.stringify({ items });
-  const raw =
-    activeProvider() === "anthropic"
-      ? await oneShotWithClaude({
-          prompt,
-          systemPrompt: ANONYMIZE_PROMPT,
-          workspaceDir: config.workspaceDir,
-          readToken: () => readAnthropicToken(authStorage),
-          // Locates the acting member's isolated Claude credential store, so a
-          // 401 here can never recover onto the team credential (HOU-976).
-          dataDir: config.dataDir,
-          modelId: resolveModel().id,
-        })
-      : await oneShotText({
-          cwd: config.workspaceDir,
-          model: resolveModel(),
-          modelRuntime,
-          systemPrompt: ANONYMIZE_PROMPT,
-          prompt,
-        });
-  return parseAnonymizeResult(raw, items);
+  if (activeProvider() === "anthropic") {
+    const raw = await oneShotWithClaude({
+      prompt: JSON.stringify({ items }),
+      systemPrompt: ANONYMIZE_PROMPT,
+      workspaceDir: config.workspaceDir,
+      readToken: () => readAnthropicToken(authStorage),
+      // Locates the acting member's isolated Claude credential store, so a
+      // 401 here can never recover onto the team credential (HOU-976).
+      dataDir: config.dataDir,
+      modelId: resolveModel().id,
+    });
+    return parseAnonymizeResult(raw, items);
+  }
+  return anonymizeTextsWith(
+    { workspaceDir: config.workspaceDir, model: resolveModel(), modelRuntime },
+    items,
+  );
 }

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -111,11 +111,14 @@ export async function executeOp(
       // A settings op needs the runtime dir minus those two. A credential
       // op touches no file at all (the gateway's store is the only write)
       // — it still hydrates the layout so the agent-exists check holds.
+      // An anonymize gathers the agent's small docs only — same skip-the-bulk
+      // profile as settings, so a wizard click never pays a big agent's
+      // conversations/files hydrate.
       ...(op.op.kind === "route"
         ? { excludes: ROUTE_OP_EXCLUDES, lazy: true }
         : op.op.kind === "conversation"
           ? { lazy: true }
-          : op.op.kind === "settings"
+          : op.op.kind === "settings" || op.op.kind === "anonymize"
             ? { excludes: SETTINGS_OP_EXCLUDES }
             : op.op.kind === "credential"
               ? { excludes: CREDENTIAL_OP_EXCLUDES }

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -313,6 +313,16 @@ async function republish(
     );
     if ("error" in outcome) diagnostics.push(`skills: ${outcome.error}`);
   }
+  if (result.customDefinitionsView !== undefined) {
+    // The definitions list is a view doc (docs/view-capture.ts family), so
+    // the gateway's asleep reads show the mutation immediately.
+    const outcome = await publish(
+      { ...common, family: "custom_definitions" },
+      result.customDefinitionsView,
+    );
+    if ("error" in outcome)
+      diagnostics.push(`custom_definitions: ${outcome.error}`);
+  }
   return diagnostics;
 }
 

--- a/packages/runtime/src/turn/op-anonymize.ts
+++ b/packages/runtime/src/turn/op-anonymize.ts
@@ -1,0 +1,75 @@
+import { join } from "node:path";
+import { LocalPaths } from "@houston/host/src/paths";
+import {
+  type AnonymizeAiRunner,
+  runPortableAnonymize,
+} from "@houston/host/src/routes/portable-anonymize";
+import { LocalWorkspaceStore } from "@houston/host/src/store/local";
+import { PrefixedVfs } from "@houston/host/src/vfs";
+import { applyServedCredential } from "../auth/auth-file";
+import { anonymizeTextsWith } from "../session/anonymize";
+import type { OpAnswer } from "./op-credential";
+import type { OpRequest } from "./parse-op-request";
+import type { TurnFilesystem } from "./turn-filesystem";
+import { createTurnModelRuntime } from "./turn-runtime";
+
+/**
+ * The export wizard's anonymize pass for a SLEEPING agent, on a pool worker
+ * (the titles pattern): the pod's own gather + regex pre-pass over the
+ * hydrated tree, the AI pass through a turn-local model runtime fed by the
+ * envelope credential. Anthropic's pass is Claude-SDK-only (pod-only by
+ * compliance) — the gateway swaps to another connected provider when one
+ * exists; otherwise, and when no credential resolves at all, the regex-only
+ * result ships WITH the reason, exactly the pod's own degraded mode. Never
+ * a wake: every path here is a valid 200.
+ */
+export async function applyAnonymizeOp(
+  op: OpRequest & { op: Extract<OpRequest["op"], { kind: "anonymize" }> },
+  agentId: string,
+  filesystem: TurnFilesystem,
+): Promise<OpAnswer | { agentMissing: true }> {
+  const store = new LocalWorkspaceStore(
+    join(filesystem.storeRoot, "workspaces"),
+  );
+  const agent = await store.getAgent(agentId);
+  const workspace = agent ? await store.getWorkspace(agent.workspaceId) : null;
+  if (!agent || !workspace) return { agentMissing: true };
+  const root = new LocalPaths().agentRoot(workspace, agent);
+  const vfs = new PrefixedVfs(filesystem.vfs, "workspaces");
+
+  const credential = op.credential;
+  const ai: AnonymizeAiRunner =
+    !credential || credential.provider === "anthropic"
+      ? () => {
+          // Surfaces as `aiError` beside the regex-only result — the wizard's
+          // existing degraded copy, never a silent downgrade.
+          throw new Error(
+            "AI anonymization is not available right now; showing pattern-based redactions only",
+          );
+        }
+      : async (items) => {
+          const { dataDir, workspaceDir } = filesystem;
+          applyServedCredential(join(dataDir, "auth.json"), credential);
+          const { modelRuntime, model } = await createTurnModelRuntime(
+            dataDir,
+            credential.provider,
+          );
+          return anonymizeTextsWith(
+            { workspaceDir, model, modelRuntime },
+            items,
+          );
+        };
+
+  const input = op.op.input;
+  const response = await runPortableAnonymize(
+    { vfs, root, ai },
+    {
+      claudeMd: input.claudeMd ?? false,
+      skillSlugs: input.skillSlugs ?? [],
+      routineIds: input.routineIds ?? [],
+      learningIds: input.learningIds ?? [],
+      useAi: input.useAi ?? true,
+    },
+  );
+  return { status: 200, body: response };
+}

--- a/packages/runtime/src/turn/op-anonymize.ts
+++ b/packages/runtime/src/turn/op-anonymize.ts
@@ -37,39 +37,32 @@ export async function applyAnonymizeOp(
   const root = new LocalPaths().agentRoot(workspace, agent);
   const vfs = new PrefixedVfs(filesystem.vfs, "workspaces");
 
+  // Anthropic's pass is Claude-SDK-only (pod-only by compliance); no
+  // credential means the gateway could not resolve one. Both ship the
+  // regex-only result with the reason — the wizard's existing degraded copy.
   const credential = op.credential;
-  const ai: AnonymizeAiRunner =
-    !credential || credential.provider === "anthropic"
-      ? () => {
-          // Surfaces as `aiError` beside the regex-only result — the wizard's
-          // existing degraded copy, never a silent downgrade.
-          throw new Error(
-            "AI anonymization is not available right now; showing pattern-based redactions only",
-          );
-        }
-      : async (items) => {
-          const { dataDir, workspaceDir } = filesystem;
-          applyServedCredential(join(dataDir, "auth.json"), credential);
-          const { modelRuntime, model } = await createTurnModelRuntime(
-            dataDir,
-            credential.provider,
-          );
-          return anonymizeTextsWith(
-            { workspaceDir, model, modelRuntime },
-            items,
-          );
-        };
+  const usable = credential && credential.provider !== "anthropic";
+  const ai: AnonymizeAiRunner | undefined = usable
+    ? async (items) => {
+        const { dataDir, workspaceDir } = filesystem;
+        applyServedCredential(join(dataDir, "auth.json"), credential);
+        const { modelRuntime, model } = await createTurnModelRuntime(
+          dataDir,
+          credential.provider,
+        );
+        return anonymizeTextsWith({ workspaceDir, model, modelRuntime }, items);
+      }
+    : undefined;
 
-  const input = op.op.input;
   const response = await runPortableAnonymize(
-    { vfs, root, ai },
     {
-      claudeMd: input.claudeMd ?? false,
-      skillSlugs: input.skillSlugs ?? [],
-      routineIds: input.routineIds ?? [],
-      learningIds: input.learningIds ?? [],
-      useAi: input.useAi ?? true,
+      vfs,
+      root,
+      ...(ai ? { ai } : {}),
+      aiUnavailableReason:
+        "AI anonymization is not available right now; showing pattern-based redactions only",
     },
+    op.op.input,
   );
   return { status: 200, body: response };
 }

--- a/packages/runtime/src/turn/op-apply.ts
+++ b/packages/runtime/src/turn/op-apply.ts
@@ -170,7 +170,12 @@ export async function applyOp(
       });
       // The connect may write the qwen region / azure endpoint file beside
       // the key (the store is the key's only home — auth.json never syncs).
-      return answered(answer, credentialOpFiles(filesystem.dataRel));
+      // Success-only: a 502 store push must not durably repoint the agent at
+      // an endpoint whose key never landed.
+      return answered(
+        answer,
+        answer.status === 200 ? credentialOpFiles(filesystem.dataRel) : [],
+      );
     }
     case "anonymize": {
       const answer = await applyAnonymizeOp(

--- a/packages/runtime/src/turn/op-apply.ts
+++ b/packages/runtime/src/turn/op-apply.ts
@@ -1,6 +1,5 @@
 import { join, posix } from "node:path";
-import { dispatchAgentOp } from "@houston/host/src/op/dispatch";
-import { LazyReadRefusedError, PrefixedVfs } from "@houston/host/src/vfs";
+import { LazyReadRefusedError } from "@houston/host/src/vfs";
 import type { HoustonEvent } from "@houston/protocol";
 import { applyServedCredential } from "../auth/auth-file";
 import { generateTitle } from "../session/summarize";
@@ -8,7 +7,10 @@ import {
   deleteConversationAt,
   renameConversationMutationAt,
 } from "../store/conversation-file";
-import { applyApiKeyConnect } from "./op-credential";
+import { applyAnonymizeOp } from "./op-anonymize";
+import { applyApiKeyConnect, credentialOpFiles } from "./op-credential";
+import { applyEndpointConnect } from "./op-endpoint";
+import { applyRouteOp } from "./op-route";
 import {
   claimActiveProviderIn,
   putSettingsIn,
@@ -32,6 +34,8 @@ export interface OpResult {
   include: (relativePath: string) => boolean;
   /** The pod's own /skills answer after a skills mutation (the skills view). */
   skillsView?: unknown;
+  /** The pod's own definitions answer after a custom-integration mutation. */
+  customDefinitionsView?: unknown;
   /** The hydrated tree had no such agent — decline, do not relay. */
   agentMissing?: boolean;
   /** The worker cannot serve this one (a provider that needs the pod). */
@@ -89,66 +93,39 @@ export async function applyOp(
   fetchImpl?: typeof fetch,
 ): Promise<OpResult> {
   const agentId = engineAgentId(filesystem);
+  const none = () => false;
   switch (op.op.kind) {
-    case "route": {
-      // The handlers address the agent under `workspaces/`; the turn's vfs
-      // is rooted one level up (lazy or real, the same seam).
-      const vfs = new PrefixedVfs(filesystem.vfs, "workspaces");
-      const result = await dispatchAgentOp({
-        workspacesRoot: join(filesystem.storeRoot, "workspaces"),
-        agentId,
-        vfs,
-        request: {
-          method: op.op.method,
-          rest: op.op.rest,
-          ...(op.op.query ? { query: op.op.query } : {}),
-          ...(op.op.body !== undefined ? { body: op.op.body } : {}),
-          ...(op.op.contentType ? { contentType: op.op.contentType } : {}),
-          ...(op.actingAs
-            ? {
-                actingSub: op.actingAs.userId,
-                // Gateway-fronted: the acting human is a full contributor on
-                // missions, exactly as the pod stamps it from the acting header.
-                actingAuthor: {
-                  user_id: op.actingAs.userId,
-                  ...(op.actingAs.name ? { name: op.actingAs.name } : {}),
-                },
-              }
-            : {}),
-          triggersEnabled: op.triggersEnabled,
-        },
-        ...(fetchImpl ? { fetchImpl } : {}),
-      });
-      const out: OpResult = {
-        ...result,
-        include: agentRouteScope(filesystem.workspaceRel),
-      };
-      if (result.events.some((e) => e.type === "SkillsChanged")) {
-        // Re-capture the skills view the way the pod would serve it, so the
-        // gateway's asleep reads show the install/remove immediately.
-        const view = await dispatchAgentOp({
-          workspacesRoot: join(filesystem.storeRoot, "workspaces"),
-          agentId,
-          vfs,
-          request: {
-            method: "GET",
-            rest: "skills",
-            triggersEnabled: op.triggersEnabled,
-          },
-          ...(fetchImpl ? { fetchImpl } : {}),
-        });
-        if (view.status === 200) {
-          try {
-            out.skillsView = JSON.parse(view.body);
-          } catch {
-            /* not JSON: leave the previous view */
-          }
-        }
-      }
-      return out;
-    }
+    case "route":
+      return applyRouteOp(
+        op as OpRequest & { op: Extract<OpRequest["op"], { kind: "route" }> },
+        filesystem,
+        fetchImpl,
+      );
     case "settings": {
-      const none = () => false;
+      if (op.op.action === "endpoint") {
+        const { org, agent } = poolIdentity(op.gcsPrefix);
+        const answer = await applyEndpointConnect(
+          op as OpRequest & {
+            op: Extract<
+              OpRequest["op"],
+              { kind: "settings"; action: "endpoint" }
+            >;
+          },
+          {
+            dataDir: filesystem.dataDir,
+            credentialsBaseUrl: new URL(op.claim.heartbeatUrl).origin,
+            orgSlug: org,
+            agentSlug: agent,
+            ...(fetchImpl ? { fetchImpl } : {}),
+          },
+        );
+        const files = new Set(settingsOpFiles(filesystem.dataRel));
+        return {
+          ...json(answer.status, answer.body),
+          events: [],
+          include: (rel) => files.has(rel),
+        };
+      }
       try {
         const settings =
           op.op.action === "put"
@@ -173,11 +150,12 @@ export async function applyOp(
       }
     }
     case "credential": {
-      const none = () => false;
       const { org, agent } = poolIdentity(op.gcsPrefix);
       const answer = await applyApiKeyConnect({
         provider: op.op.provider,
         apiKey: op.op.apiKey,
+        ...(op.op.endpoint ? { endpoint: op.op.endpoint } : {}),
+        dataDir: filesystem.dataDir,
         credentialsBaseUrl: new URL(op.claim.heartbeatUrl).origin,
         orgSlug: org,
         agentSlug: agent,
@@ -185,18 +163,34 @@ export async function applyOp(
         ...(op.actingToken ? { actingAs: op.actingToken } : {}),
         ...(fetchImpl ? { fetchImpl } : {}),
       });
-      if ("decline" in answer) {
+      // The connect may write the qwen region / azure endpoint file beside
+      // the key (the store is the key's only home — auth.json never syncs).
+      const files = new Set(credentialOpFiles(filesystem.dataRel));
+      return {
+        ...json(answer.status, answer.body),
+        events: [],
+        include: (rel) => files.has(rel),
+      };
+    }
+    case "anonymize": {
+      const answer = await applyAnonymizeOp(
+        op as OpRequest & {
+          op: Extract<OpRequest["op"], { kind: "anonymize" }>;
+        },
+        agentId,
+        filesystem,
+      );
+      if ("agentMissing" in answer) {
         return {
-          ...json(503, { error: "provider needs the pod" }),
+          ...json(404, { error: "agent not found" }),
           events: [],
           include: none,
-          decline: true,
+          agentMissing: true,
         };
       }
       return { ...json(answer.status, answer.body), events: [], include: none };
     }
     case "title": {
-      const none = () => false;
       if (!op.credential) {
         return {
           ...json(503, { error: "no credential for title" }),

--- a/packages/runtime/src/turn/op-apply.ts
+++ b/packages/runtime/src/turn/op-apply.ts
@@ -53,6 +53,19 @@ const json = (
   body: JSON.stringify(value),
 });
 
+/** A JSON answer whose sync-back scope is an exact file list (or nothing). */
+const answered = (
+  answer: { status: number; body: unknown },
+  files: string[] = [],
+): OpResult => {
+  const set = new Set(files);
+  return {
+    ...json(answer.status, answer.body),
+    events: [],
+    include: (rel) => set.has(rel),
+  };
+};
+
 /** Everything an agent-level route may touch: the agent's whole directory
  *  (family files, skills, markdown, any agentfile path the pod would
  *  accept) — never the runtime tree (conversations, sessions, auth), which
@@ -119,12 +132,7 @@ export async function applyOp(
             ...(fetchImpl ? { fetchImpl } : {}),
           },
         );
-        const files = new Set(settingsOpFiles(filesystem.dataRel));
-        return {
-          ...json(answer.status, answer.body),
-          events: [],
-          include: (rel) => files.has(rel),
-        };
+        return answered(answer, settingsOpFiles(filesystem.dataRel));
       }
       try {
         const settings =
@@ -135,18 +143,15 @@ export async function applyOp(
                 op.op.provider,
                 op.op.connectedProviders,
               );
-        const files = new Set(settingsOpFiles(filesystem.dataRel));
-        return {
-          ...json(200, settings),
-          events: [],
-          include: (rel) => files.has(rel),
-        };
+        return answered(
+          { status: 200, body: settings },
+          settingsOpFiles(filesystem.dataRel),
+        );
       } catch (e) {
-        return {
-          ...json(400, { error: e instanceof Error ? e.message : String(e) }),
-          events: [],
-          include: none,
-        };
+        return answered({
+          status: 400,
+          body: { error: e instanceof Error ? e.message : String(e) },
+        });
       }
     }
     case "credential": {
@@ -165,12 +170,7 @@ export async function applyOp(
       });
       // The connect may write the qwen region / azure endpoint file beside
       // the key (the store is the key's only home — auth.json never syncs).
-      const files = new Set(credentialOpFiles(filesystem.dataRel));
-      return {
-        ...json(answer.status, answer.body),
-        events: [],
-        include: (rel) => files.has(rel),
-      };
+      return answered(answer, credentialOpFiles(filesystem.dataRel));
     }
     case "anonymize": {
       const answer = await applyAnonymizeOp(
@@ -182,13 +182,11 @@ export async function applyOp(
       );
       if ("agentMissing" in answer) {
         return {
-          ...json(404, { error: "agent not found" }),
-          events: [],
-          include: none,
+          ...answered({ status: 404, body: { error: "agent not found" } }),
           agentMissing: true,
         };
       }
-      return { ...json(answer.status, answer.body), events: [], include: none };
+      return answered(answer);
     }
     case "title": {
       if (!op.credential) {

--- a/packages/runtime/src/turn/op-credential.ts
+++ b/packages/runtime/src/turn/op-credential.ts
@@ -1,6 +1,15 @@
 import { RemoteCredentialStore } from "@houston/host/src/credentials/remote-store";
-import { AZURE_OPENAI, setAzureEndpointIn } from "../ai/azure-openai";
-import { QWEN_PROVIDER_ID, setQwenRegionIn } from "../ai/qwen-dashscope";
+import {
+  AZURE_OPENAI,
+  azureEndpointFileIn,
+  normalizeAzureEndpoint,
+  setAzureEndpointIn,
+} from "../ai/azure-openai";
+import {
+  QWEN_PROVIDER_ID,
+  qwenRegionFileIn,
+  setQwenRegionIn,
+} from "../ai/qwen-dashscope";
 import { assertApiKeyConnectable } from "../auth/login";
 import { ApiKeyVerifyError, verifyApiKey } from "../auth/verify-api-key";
 
@@ -50,16 +59,13 @@ export async function applyApiKeyConnect(
       body: { error: e instanceof Error ? e.message : String(e) },
     };
   }
-  // The endpoint persists FIRST (the pod's own order, PRODUCT-1477): a bad
-  // URL was already rejected above, and a stored key must never aim at
-  // nothing. The file rides the op's sync-back beside the region file.
-  if (opts.provider === AZURE_OPENAI) {
-    setAzureEndpointIn(opts.dataDir, opts.endpoint ?? "");
-  }
   try {
     await verifyApiKey(opts.provider, key, {
+      // The probe aims at the NORMALIZED endpoint, exactly as the pod does
+      // (PRODUCT-1477: a pasted Foundry project URL must be stripped to the
+      // host root or the completion 404s and a good key reads as bad).
       ...(opts.provider === AZURE_OPENAI && opts.endpoint
-        ? { azureBaseUrl: opts.endpoint }
+        ? { azureBaseUrl: normalizeAzureEndpoint(opts.endpoint) }
         : {}),
       ...(opts.provider === QWEN_PROVIDER_ID
         ? {
@@ -70,6 +76,8 @@ export async function applyApiKeyConnect(
     });
   } catch (e) {
     // `reason` rides to the connect dialog, which maps it to actionable copy.
+    // Nothing persisted: a rejected connect must never clobber the agent's
+    // stored (working) endpoint or region.
     return {
       status: 401,
       body: {
@@ -78,6 +86,43 @@ export async function applyApiKeyConnect(
       },
     };
   }
+  // Endpoint AFTER the verify, BEFORE the key (the pod's own order): only a
+  // proven connect persists, and a stored key never aims at nothing. The
+  // file rides the op's sync-back beside the region file.
+  if (opts.provider === AZURE_OPENAI) {
+    setAzureEndpointIn(opts.dataDir, opts.endpoint ?? "");
+  }
+  const pushed = await pushApiKeyCredential({
+    credentialsBaseUrl: opts.credentialsBaseUrl,
+    orgSlug: opts.orgSlug,
+    agentSlug: opts.agentSlug,
+    hostToken: opts.hostToken,
+    provider: opts.provider,
+    apiKey: key,
+    ...(opts.actingAs ? { actingAs: opts.actingAs } : {}),
+    ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+  });
+  if (pushed) return pushed;
+  return { status: 200, body: { ok: true, provider: opts.provider } };
+}
+
+/**
+ * Push one verified API key into the gateway's credential store — the store
+ * is what every future turn is served from. Returns the pod's own 502 answer
+ * on a store failure (no local residue exists on a worker, so nothing to
+ * roll back), null on success. Shared by the api-key connect and the
+ * openai-compatible endpoint connect (op-endpoint.ts).
+ */
+export async function pushApiKeyCredential(opts: {
+  credentialsBaseUrl: string;
+  orgSlug: string;
+  agentSlug: string;
+  hostToken: string;
+  provider: string;
+  apiKey: string;
+  actingAs?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<OpAnswer | null> {
   const store = new RemoteCredentialStore({
     baseUrl: opts.credentialsBaseUrl,
     orgSlug: opts.orgSlug,
@@ -92,7 +137,7 @@ export async function applyApiKeyConnect(
         // shape requires it.
         workspaceId: opts.orgSlug,
         provider: opts.provider,
-        accessToken: key,
+        accessToken: opts.apiKey,
         refreshToken: "",
         expiresAt: 0,
         kind: "api_key",
@@ -100,19 +145,18 @@ export async function applyApiKeyConnect(
       opts.actingAs ? { actingAs: opts.actingAs } : {},
     );
   } catch (e) {
-    // The key verified but the store did not take it: the pod's own answer
-    // for a central-store failure is a 502 with the reason. No local residue
-    // exists on a worker, so nothing to roll back.
     return {
       status: 502,
       body: { error: e instanceof Error ? e.message : String(e) },
     };
   }
-  return { status: 200, body: { ok: true, provider: opts.provider } };
+  return null;
 }
 
 /** The runtime-dir files an api-key connect may write beside the key (its
- *  sync-back scope): qwen's verified region, azure's resource endpoint. */
+ *  sync-back scope): qwen's verified region, azure's resource endpoint.
+ *  Derived from the writers' own path helpers so a rename cannot silently
+ *  drop a file from the sync. */
 export function credentialOpFiles(dataRel: string): string[] {
-  return [`${dataRel}/qwen-region.json`, `${dataRel}/azure-endpoint.json`];
+  return [qwenRegionFileIn(dataRel), azureEndpointFileIn(dataRel)];
 }

--- a/packages/runtime/src/turn/op-credential.ts
+++ b/packages/runtime/src/turn/op-credential.ts
@@ -1,4 +1,6 @@
 import { RemoteCredentialStore } from "@houston/host/src/credentials/remote-store";
+import { AZURE_OPENAI, setAzureEndpointIn } from "../ai/azure-openai";
+import { QWEN_PROVIDER_ID, setQwenRegionIn } from "../ai/qwen-dashscope";
 import { assertApiKeyConnectable } from "../auth/login";
 import { ApiKeyVerifyError, verifyApiKey } from "../auth/verify-api-key";
 
@@ -8,13 +10,19 @@ import { ApiKeyVerifyError, verifyApiKey } from "../auth/verify-api-key";
  * gateway's credential store → the store is what every future turn is served
  * from. The worker does the same two steps with the same code: the verifier
  * is a pure probe, the push is the pod's own RemoteCredentialStore aimed at
- * the gateway with this agent's host token. Nothing is written to the
- * worker's disk (auth.json is never synced, and a worker has no agent of its
- * own).
+ * the gateway with this agent's host token. Two providers persist a small
+ * config file BESIDE the key — qwen's verified region and azure's resource
+ * endpoint — written into the hydrated agent root (`dataDir`), where the op's
+ * sync-back carries them like settings.json. Nothing else touches the
+ * worker's disk (auth.json is never synced).
  */
 export interface ApiKeyConnect {
   provider: string;
   apiKey: string;
+  /** Azure OpenAI's per-resource endpoint, arriving with the key. */
+  endpoint?: string;
+  /** The hydrated agent runtime dir (region/endpoint files land here). */
+  dataDir: string;
   /** The gateway's internal base URL (the pod's HOUSTON_CREDENTIALS_URL). */
   credentialsBaseUrl: string;
   orgSlug: string;
@@ -30,27 +38,36 @@ export interface OpAnswer {
   body: unknown;
 }
 
-// Qwen keys are REGION-scoped: the verifier persists the accepting region
-// beside the key, which on a worker would land in the worker's own dir, not
-// the agent's — the next turn could not find it. That one provider keeps the
-// pod path.
-const WORKER_EXCLUDED_PROVIDERS = new Set(["qwen"]);
-
 export async function applyApiKeyConnect(
   opts: ApiKeyConnect,
-): Promise<OpAnswer | { decline: true }> {
-  if (WORKER_EXCLUDED_PROVIDERS.has(opts.provider)) return { decline: true };
+): Promise<OpAnswer> {
   let key: string;
   try {
-    key = assertApiKeyConnectable(opts.provider, opts.apiKey);
+    key = assertApiKeyConnectable(opts.provider, opts.apiKey, opts.endpoint);
   } catch (e) {
     return {
       status: 400,
       body: { error: e instanceof Error ? e.message : String(e) },
     };
   }
+  // The endpoint persists FIRST (the pod's own order, PRODUCT-1477): a bad
+  // URL was already rejected above, and a stored key must never aim at
+  // nothing. The file rides the op's sync-back beside the region file.
+  if (opts.provider === AZURE_OPENAI) {
+    setAzureEndpointIn(opts.dataDir, opts.endpoint ?? "");
+  }
   try {
-    await verifyApiKey(opts.provider, key);
+    await verifyApiKey(opts.provider, key, {
+      ...(opts.provider === AZURE_OPENAI && opts.endpoint
+        ? { azureBaseUrl: opts.endpoint }
+        : {}),
+      ...(opts.provider === QWEN_PROVIDER_ID
+        ? {
+            qwenRegionPersist: (regionId) =>
+              setQwenRegionIn(opts.dataDir, regionId),
+          }
+        : {}),
+    });
   } catch (e) {
     // `reason` rides to the connect dialog, which maps it to actionable copy.
     return {
@@ -92,4 +109,10 @@ export async function applyApiKeyConnect(
     };
   }
   return { status: 200, body: { ok: true, provider: opts.provider } };
+}
+
+/** The runtime-dir files an api-key connect may write beside the key (its
+ *  sync-back scope): qwen's verified region, azure's resource endpoint. */
+export function credentialOpFiles(dataRel: string): string[] {
+  return [`${dataRel}/qwen-region.json`, `${dataRel}/azure-endpoint.json`];
 }

--- a/packages/runtime/src/turn/op-endpoint.ts
+++ b/packages/runtime/src/turn/op-endpoint.ts
@@ -1,0 +1,117 @@
+import { RemoteSharedEndpointStore } from "@houston/host/src/credentials/remote-shared-endpoint-store";
+import { RemoteCredentialStore } from "@houston/host/src/credentials/remote-store";
+import { checkPublicHttpsEndpoint } from "@houston/host/src/custom-endpoint-validation";
+import {
+  OPENAI_COMPATIBLE,
+  setCustomEndpointConfigIn,
+} from "../ai/openai-compatible";
+import { LOCAL_PLACEHOLDER_KEY } from "../auth/login";
+import type { OpAnswer } from "./op-credential";
+import type { OpRequest } from "./parse-op-request";
+
+/**
+ * Connect an OpenAI-compatible endpoint for a SLEEPING agent, on a pool
+ * worker — the pod handler's own steps against the hydrated root: validate
+ * the URL against the managed-cloud egress policy, persist the endpoint
+ * config (`custom-endpoint.json`, riding the settings sync-back), push the
+ * key (placeholder for a keyless server) to the gateway's credential store —
+ * auth.json never syncs, and turn workers fetch this provider's key from the
+ * store like any other — then publish/withdraw the org share.
+ *
+ * Ops exist only behind the managed gateway, so the public-HTTPS egress
+ * check always applies here; the dev launcher's loopback "pods" keep the
+ * proxy path for their localhost endpoints (a worker would 400 them).
+ */
+export async function applyEndpointConnect(
+  op: OpRequest & {
+    op: Extract<OpRequest["op"], { kind: "settings"; action: "endpoint" }>;
+  },
+  deps: {
+    dataDir: string;
+    credentialsBaseUrl: string;
+    orgSlug: string;
+    agentSlug: string;
+    fetchImpl?: typeof fetch;
+  },
+): Promise<OpAnswer> {
+  const input = op.op.input;
+  let parsed: URL;
+  try {
+    parsed = new URL(input.baseUrl);
+  } catch {
+    return { status: 400, body: { error: "baseUrl is not a valid URL" } };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return {
+      status: 400,
+      body: { error: "baseUrl must start with http:// or https://" },
+    };
+  }
+  const check = checkPublicHttpsEndpoint(parsed);
+  if (!check.ok) return { status: 400, body: { error: check.reason } };
+
+  // Endpoint FIRST (the pod's own order): a bad config must never leave a
+  // stored key aimed at nothing.
+  try {
+    setCustomEndpointConfigIn(deps.dataDir, {
+      baseUrl: input.baseUrl,
+      model: input.model,
+      ...(input.name !== undefined ? { name: input.name } : {}),
+      ...(input.contextWindow !== undefined
+        ? { contextWindow: input.contextWindow }
+        : {}),
+      ...(input.reasoning !== undefined ? { reasoning: input.reasoning } : {}),
+    });
+  } catch (e) {
+    return {
+      status: 400,
+      body: { error: e instanceof Error ? e.message : String(e) },
+    };
+  }
+  const common = {
+    baseUrl: deps.credentialsBaseUrl,
+    orgSlug: deps.orgSlug,
+    agentSlug: deps.agentSlug,
+    podToken: op.hostToken,
+    ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+  };
+  try {
+    await new RemoteCredentialStore(common).put(
+      {
+        workspaceId: deps.orgSlug,
+        provider: OPENAI_COMPATIBLE,
+        accessToken: input.apiKey?.trim() || LOCAL_PLACEHOLDER_KEY,
+        refreshToken: "",
+        expiresAt: 0,
+        kind: "api_key",
+      },
+      op.actingToken ? { actingAs: op.actingToken } : {},
+    );
+    const shared = new RemoteSharedEndpointStore(common);
+    if (input.shared === true) {
+      await shared.put({
+        baseUrl: input.baseUrl,
+        model: input.model,
+        ...(input.name !== undefined ? { name: input.name } : {}),
+        ...(input.contextWindow !== undefined
+          ? { contextWindow: input.contextWindow }
+          : {}),
+        ...(input.reasoning !== undefined
+          ? { reasoning: input.reasoning }
+          : {}),
+        ...(input.apiKey !== undefined ? { apiKey: input.apiKey } : {}),
+      });
+    } else {
+      await shared.remove({ ownerOnly: true });
+    }
+  } catch (e) {
+    // The endpoint config is already written (the pod logs and answers 502
+    // the same way when its share sync fails after the save).
+    console.error("[shared-endpoint] save synchronization failed:", e);
+    return {
+      status: 502,
+      body: { error: e instanceof Error ? e.message : String(e) },
+    };
+  }
+  return { status: 200, body: { ok: true } };
+}

--- a/packages/runtime/src/turn/op-endpoint.ts
+++ b/packages/runtime/src/turn/op-endpoint.ts
@@ -1,12 +1,11 @@
 import { RemoteSharedEndpointStore } from "@houston/host/src/credentials/remote-shared-endpoint-store";
-import { RemoteCredentialStore } from "@houston/host/src/credentials/remote-store";
 import { checkPublicHttpsEndpoint } from "@houston/host/src/custom-endpoint-validation";
 import {
   OPENAI_COMPATIBLE,
   setCustomEndpointConfigIn,
 } from "../ai/openai-compatible";
 import { LOCAL_PLACEHOLDER_KEY } from "../auth/login";
-import type { OpAnswer } from "./op-credential";
+import { type OpAnswer, pushApiKeyCredential } from "./op-credential";
 import type { OpRequest } from "./parse-op-request";
 
 /**
@@ -35,9 +34,25 @@ export async function applyEndpointConnect(
   },
 ): Promise<OpAnswer> {
   const input = op.op.input;
+  // Trimmed at the boundary, exactly as the pod route trims before
+  // validating — the org share must never carry pasted whitespace.
+  const baseUrl = input.baseUrl.trim();
+  // The descriptor both the config file and the org share persist — built
+  // once so the two writes can never diverge on a field.
+  const descriptor = {
+    baseUrl,
+    model: input.model.trim(),
+    ...(input.name !== undefined ? { name: input.name } : {}),
+    ...(input.contextWindow !== undefined
+      ? { contextWindow: input.contextWindow }
+      : {}),
+    ...(input.reasoning !== undefined ? { reasoning: input.reasoning } : {}),
+  };
+  // The pod route's own boundary validation, verbatim (message parity), then
+  // the managed-cloud egress guard.
   let parsed: URL;
   try {
-    parsed = new URL(input.baseUrl);
+    parsed = new URL(baseUrl);
   } catch {
     return { status: 400, body: { error: "baseUrl is not a valid URL" } };
   }
@@ -53,52 +68,35 @@ export async function applyEndpointConnect(
   // Endpoint FIRST (the pod's own order): a bad config must never leave a
   // stored key aimed at nothing.
   try {
-    setCustomEndpointConfigIn(deps.dataDir, {
-      baseUrl: input.baseUrl,
-      model: input.model,
-      ...(input.name !== undefined ? { name: input.name } : {}),
-      ...(input.contextWindow !== undefined
-        ? { contextWindow: input.contextWindow }
-        : {}),
-      ...(input.reasoning !== undefined ? { reasoning: input.reasoning } : {}),
-    });
+    setCustomEndpointConfigIn(deps.dataDir, descriptor);
   } catch (e) {
     return {
       status: 400,
       body: { error: e instanceof Error ? e.message : String(e) },
     };
   }
-  const common = {
-    baseUrl: deps.credentialsBaseUrl,
+  const pushed = await pushApiKeyCredential({
+    credentialsBaseUrl: deps.credentialsBaseUrl,
     orgSlug: deps.orgSlug,
     agentSlug: deps.agentSlug,
-    podToken: op.hostToken,
+    hostToken: op.hostToken,
+    provider: OPENAI_COMPATIBLE,
+    apiKey: input.apiKey?.trim() || LOCAL_PLACEHOLDER_KEY,
+    ...(op.actingToken ? { actingAs: op.actingToken } : {}),
     ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
-  };
+  });
+  if (pushed) return pushed;
   try {
-    await new RemoteCredentialStore(common).put(
-      {
-        workspaceId: deps.orgSlug,
-        provider: OPENAI_COMPATIBLE,
-        accessToken: input.apiKey?.trim() || LOCAL_PLACEHOLDER_KEY,
-        refreshToken: "",
-        expiresAt: 0,
-        kind: "api_key",
-      },
-      op.actingToken ? { actingAs: op.actingToken } : {},
-    );
-    const shared = new RemoteSharedEndpointStore(common);
+    const shared = new RemoteSharedEndpointStore({
+      baseUrl: deps.credentialsBaseUrl,
+      orgSlug: deps.orgSlug,
+      agentSlug: deps.agentSlug,
+      podToken: op.hostToken,
+      ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+    });
     if (input.shared === true) {
       await shared.put({
-        baseUrl: input.baseUrl,
-        model: input.model,
-        ...(input.name !== undefined ? { name: input.name } : {}),
-        ...(input.contextWindow !== undefined
-          ? { contextWindow: input.contextWindow }
-          : {}),
-        ...(input.reasoning !== undefined
-          ? { reasoning: input.reasoning }
-          : {}),
+        ...descriptor,
         ...(input.apiKey !== undefined ? { apiKey: input.apiKey } : {}),
       });
     } else {

--- a/packages/runtime/src/turn/op-grammar.ts
+++ b/packages/runtime/src/turn/op-grammar.ts
@@ -173,6 +173,16 @@ function parseRouteOp(raw: Record<string, unknown>): AgentOp {
   if (typeof raw.bodyBase64 === "string" && !isBinaryBodyOpRoute(decoded)) {
     throw new Error("op.bodyBase64 is not accepted for this route");
   }
+  // And the converse: a binary route must never smuggle its payload as a
+  // text body — a zip in a UTF-8 string is corrupt AND would bypass the
+  // runtime-transcript decline that keys off bodyBase64 (op-route.ts).
+  if (
+    isBinaryBodyOpRoute(decoded) &&
+    typeof raw.body === "string" &&
+    raw.body.length > 0
+  ) {
+    throw new Error("this route's body rides 'op.bodyBase64'");
+  }
   const query =
     typeof raw.query === "string" && raw.query.length <= 4096
       ? raw.query.replace(/^\?/, "")

--- a/packages/runtime/src/turn/op-grammar.ts
+++ b/packages/runtime/src/turn/op-grammar.ts
@@ -1,0 +1,237 @@
+import {
+  isBinaryBodyOpRoute,
+  isOpRoute,
+  isReadOpRoute,
+} from "./op-route-allowlist";
+
+/**
+ * The op grammar: every operation shape a pool worker will run for a
+ * sleeping agent, and the strict parser that admits it (parse-op-request.ts
+ * owns the surrounding claim/credential envelope). `route` ops run the
+ * host's own route handlers against the hydrated workspace; the other kinds
+ * are the runtime's own.
+ */
+export type AgentOp =
+  | {
+      kind: "route";
+      method: string;
+      rest: string;
+      /** Raw query string without the `?` (files routes take `?path=`). */
+      query?: string;
+      body?: string;
+      /** Binary request body (a migration zip), base64 — a JSON envelope
+       *  cannot carry raw bytes. Mutually exclusive with `body`. */
+      bodyBase64?: string;
+      contentType?: string;
+    }
+  | { kind: "title"; text: string }
+  | {
+      kind: "anonymize";
+      /** Fully defaulted by the parser — one normalization layer, here. */
+      input: {
+        claudeMd: boolean;
+        skillSlugs: string[];
+        routineIds: string[];
+        learningIds: string[];
+        useAi: boolean;
+      };
+    }
+  | {
+      kind: "settings";
+      action: "put";
+      input: { activeProvider?: string; model?: string; effort?: string };
+    }
+  | {
+      kind: "settings";
+      action: "claim";
+      provider: string;
+      connectedProviders: string[];
+    }
+  | {
+      kind: "settings";
+      action: "endpoint";
+      input: {
+        baseUrl: string;
+        model: string;
+        name?: string;
+        contextWindow?: number;
+        reasoning?: boolean;
+        shared?: boolean;
+        apiKey?: string;
+      };
+    }
+  | {
+      kind: "credential";
+      action: "api-key";
+      provider: string;
+      apiKey: string;
+      /** Azure OpenAI's per-resource endpoint, arriving with the key. */
+      endpoint?: string;
+    }
+  | {
+      kind: "conversation";
+      action: "rename" | "delete";
+      conversationId: string;
+      title?: string;
+    };
+
+export const ID = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$/;
+
+export function str(v: unknown, field: string): string {
+  if (typeof v !== "string" || !v.length) throw new Error(`invalid '${field}'`);
+  return v;
+}
+
+const strings = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((s): s is string => typeof s === "string") : [];
+
+export function parseAgentOp(raw: Record<string, unknown>): AgentOp {
+  switch (raw.kind) {
+    case "route":
+      return parseRouteOp(raw);
+    case "title":
+      return { kind: "title", text: str(raw.text, "op.text") };
+    case "anonymize": {
+      const input = (raw.input ?? {}) as Record<string, unknown>;
+      return {
+        kind: "anonymize",
+        input: {
+          claudeMd: input.claudeMd === true,
+          skillSlugs: strings(input.skillSlugs),
+          routineIds: strings(input.routineIds),
+          learningIds: strings(input.learningIds),
+          // Mirrors the pod route: absent means the AI pass is wanted.
+          useAi: input.useAi !== false,
+        },
+      };
+    }
+    case "settings":
+      return parseSettingsOp(raw);
+    case "credential": {
+      if (raw.action !== "api-key") throw new Error("invalid 'op.action'");
+      return {
+        kind: "credential",
+        action: "api-key",
+        provider: str(raw.provider, "op.provider"),
+        apiKey: str(raw.apiKey, "op.apiKey"),
+        ...(typeof raw.endpoint === "string" && raw.endpoint
+          ? { endpoint: raw.endpoint }
+          : {}),
+      };
+    }
+    case "conversation": {
+      const action = raw.action;
+      if (action !== "rename" && action !== "delete")
+        throw new Error("invalid 'op.action'");
+      const conversationId = str(raw.conversationId, "op.conversationId");
+      if (!ID.test(conversationId))
+        throw new Error("invalid 'op.conversationId'");
+      if (action === "rename" && typeof raw.title !== "string")
+        throw new Error("rename needs 'op.title'");
+      return {
+        kind: "conversation",
+        action,
+        conversationId,
+        ...(typeof raw.title === "string" ? { title: raw.title } : {}),
+      };
+    }
+    default:
+      throw new Error("invalid 'op.kind'");
+  }
+}
+
+function parseRouteOp(raw: Record<string, unknown>): AgentOp {
+  const method = str(raw.method, "op.method").toUpperCase();
+  if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+    throw new Error("op.method is not an HTTP method");
+  }
+  const rest = str(raw.rest, "op.rest");
+  if (rest.includes("..") || rest.startsWith("/"))
+    throw new Error("invalid 'op.rest'");
+  // Defense in depth: the worker accepts only the op-route shapes the
+  // gateway classifier dispatches — a valid-token caller cannot reach a
+  // handler surface (e.g. POST agentfile) the public path never exposes.
+  // Match the DECODED path: the handlers decode, so the allowlist must
+  // see what they see (`%2Ehouston` is `.houston`).
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rest);
+  } catch {
+    throw new Error("invalid 'op.rest'");
+  }
+  if (decoded.includes("..") || decoded.startsWith("/")) {
+    throw new Error("invalid 'op.rest'");
+  }
+  if (!isOpRoute(decoded)) {
+    throw new Error("op.rest is not an op route");
+  }
+  // Reads run as ops only where the gateway has no doc to serve them
+  // from: the Files tab and arbitrary agent files.
+  if (method === "GET" && !isReadOpRoute(decoded)) {
+    throw new Error("op.rest is not a read op route");
+  }
+  if (typeof raw.bodyBase64 === "string" && !isBinaryBodyOpRoute(decoded)) {
+    throw new Error("op.bodyBase64 is not accepted for this route");
+  }
+  const query =
+    typeof raw.query === "string" && raw.query.length <= 4096
+      ? raw.query.replace(/^\?/, "")
+      : undefined;
+  return {
+    kind: "route",
+    method,
+    rest,
+    ...(query ? { query } : {}),
+    ...(typeof raw.body === "string" ? { body: raw.body } : {}),
+    ...(typeof raw.bodyBase64 === "string"
+      ? { bodyBase64: raw.bodyBase64 }
+      : {}),
+    ...(typeof raw.contentType === "string"
+      ? { contentType: raw.contentType }
+      : {}),
+  };
+}
+
+function parseSettingsOp(raw: Record<string, unknown>): AgentOp {
+  if (raw.action === "put") {
+    const input = (raw.input ?? {}) as Record<string, unknown>;
+    const pick = (k: string) =>
+      typeof input[k] === "string" && (input[k] as string).length <= 200
+        ? { [k]: input[k] as string }
+        : {};
+    return {
+      kind: "settings",
+      action: "put",
+      input: { ...pick("activeProvider"), ...pick("model"), ...pick("effort") },
+    };
+  }
+  if (raw.action === "claim") {
+    return {
+      kind: "settings",
+      action: "claim",
+      provider: str(raw.provider, "op.provider"),
+      connectedProviders: strings(raw.connectedProviders),
+    };
+  }
+  if (raw.action === "endpoint") {
+    const input = (raw.input ?? {}) as Record<string, unknown>;
+    return {
+      kind: "settings",
+      action: "endpoint",
+      input: {
+        baseUrl: str(input.baseUrl, "op.input.baseUrl"),
+        model: str(input.model, "op.input.model"),
+        ...(typeof input.name === "string" ? { name: input.name } : {}),
+        ...(typeof input.contextWindow === "number"
+          ? { contextWindow: input.contextWindow }
+          : {}),
+        ...(typeof input.reasoning === "boolean"
+          ? { reasoning: input.reasoning }
+          : {}),
+        ...(input.shared === true ? { shared: true } : {}),
+        ...(typeof input.apiKey === "string" ? { apiKey: input.apiKey } : {}),
+      },
+    };
+  }
+  throw new Error("invalid 'op.action'");
+}

--- a/packages/runtime/src/turn/op-route-allowlist.ts
+++ b/packages/runtime/src/turn/op-route-allowlist.ts
@@ -1,0 +1,40 @@
+/**
+ * The route-op allowlists (mirrors the Go classifier): which `rest` shapes a
+ * pool worker will run at all, and which of those may run as a GET. Defense
+ * in depth — the gateway classifier decides what is DISPATCHED; a
+ * valid-token caller must still never reach a handler surface (e.g. POST
+ * agentfile) the public path never exposes.
+ */
+
+// The agent-data families, agentfile writes, skills (install + manage),
+// files/attachments, portable export + Agent Store, the desktop→cloud
+// migration, and custom integrations (OAuth start excepted: its pending
+// state lives in the pod's memory, where the browser callback lands).
+// Never a runtime path.
+const OP_ROUTE =
+  /^(activities|routines|routine_runs|learnings|config)(\/[^/]+)?$|^agentfile\/(?!\.houston\/runtime\/).+$|^skills(\/[^/]+)?$|^skills\/(community|repo)\/install$|^files(\/.+)?$|^attachments$|^skills-manifest$|^portable\/(preview|export|store-ir|store-publication)$|^migration\/(export|import|complete|status)$|^integrations\/custom\/(detect|definitions|definitions\/[^/]+|definitions\/[^/]+\/(credential|tools))$/;
+
+// Reads run as ops only where the gateway has no doc to serve them from:
+// the Files tab, arbitrary agent files, the export/migration inventories,
+// and a custom integration's compiled tool list.
+const READ_ROUTE =
+  /^files(\/.+)?$|^agentfile\/|^skills-manifest$|^portable\/preview$|^portable\/store-publication$|^migration\/status$|^integrations\/custom\/definitions$|^integrations\/custom\/definitions\/[^/]+\/tools$/;
+
+export function isOpRoute(decodedRest: string): boolean {
+  return OP_ROUTE.test(decodedRest);
+}
+
+export function isReadOpRoute(decodedRest: string): boolean {
+  return READ_ROUTE.test(decodedRest);
+}
+
+/** Route ops whose request body is binary (a zip), riding `bodyBase64`. */
+export function isBinaryBodyOpRoute(decodedRest: string): boolean {
+  return decodedRest === "migration/import";
+}
+
+/** Custom-integration route ops read/write the STORE-ROOT definitions file
+ *  (`custom-integrations.json` beside `workspaces/`), not the agent tree. */
+export function isCustomIntegrationOpRoute(decodedRest: string): boolean {
+  return decodedRest.startsWith("integrations/custom/");
+}

--- a/packages/runtime/src/turn/op-route.ts
+++ b/packages/runtime/src/turn/op-route.ts
@@ -1,8 +1,5 @@
 import { join } from "node:path";
-import { CustomExecutorHost } from "@houston/host/src/integrations/custom/executor-host";
-import { CustomIntegrationManager } from "@houston/host/src/integrations/custom/manager";
-import { RemoteCustomSecretStore } from "@houston/host/src/integrations/custom/secrets";
-import { FileCustomIntegrationStore } from "@houston/host/src/integrations/custom/store";
+import type { CustomIntegrationManager } from "@houston/host/src/integrations/custom/manager";
 import { dispatchAgentOp } from "@houston/host/src/op/dispatch";
 import { archiveTouchesRuntime } from "@houston/host/src/routes/migration-import";
 import { PrefixedVfs } from "@houston/host/src/vfs";
@@ -173,6 +170,19 @@ async function customIntegrationContext(
   // would read as "no definitions" and a later write would CAS-create over
   // the real one.
   await filesystem.vfs.readBytes(CUSTOM_DEFS_FILE);
+  // Imported lazily: the embedded executor engine is heavy, and only the
+  // rare custom-integration op needs it — worker startup must not pay it.
+  const [
+    { CustomExecutorHost },
+    { CustomIntegrationManager },
+    { RemoteCustomSecretStore },
+    { FileCustomIntegrationStore },
+  ] = await Promise.all([
+    import("@houston/host/src/integrations/custom/executor-host"),
+    import("@houston/host/src/integrations/custom/manager"),
+    import("@houston/host/src/integrations/custom/secrets"),
+    import("@houston/host/src/integrations/custom/store"),
+  ]);
   const { org, agent } = poolIdentity(op.gcsPrefix);
   const store = new FileCustomIntegrationStore(
     join(filesystem.storeRoot, CUSTOM_DEFS_FILE),

--- a/packages/runtime/src/turn/op-route.ts
+++ b/packages/runtime/src/turn/op-route.ts
@@ -1,0 +1,200 @@
+import { join } from "node:path";
+import { CustomExecutorHost } from "@houston/host/src/integrations/custom/executor-host";
+import { CustomIntegrationManager } from "@houston/host/src/integrations/custom/manager";
+import { RemoteCustomSecretStore } from "@houston/host/src/integrations/custom/secrets";
+import { FileCustomIntegrationStore } from "@houston/host/src/integrations/custom/store";
+import { dispatchAgentOp } from "@houston/host/src/op/dispatch";
+import { archiveTouchesRuntime } from "@houston/host/src/routes/migration-import";
+import { PrefixedVfs } from "@houston/host/src/vfs";
+import type { HoustonEvent } from "@houston/protocol";
+import type { OpResult } from "./op-apply";
+import { agentRouteScope, engineAgentId } from "./op-apply";
+import { isCustomIntegrationOpRoute } from "./op-route-allowlist";
+import type { OpRequest } from "./parse-op-request";
+import type { TurnFilesystem } from "./turn-filesystem";
+import { poolIdentity } from "./turn-store";
+
+/** The store-root definitions file custom-integration ops read and write. */
+const CUSTOM_DEFS_FILE = "custom-integrations.json";
+
+const decline = (include: OpResult["include"]): OpResult => ({
+  status: 503,
+  contentType: "application/json",
+  body: JSON.stringify({ error: "the pod serves this one" }),
+  events: [],
+  include,
+  decline: true,
+});
+
+/**
+ * A `route` op: the pod's own handler chain over the hydrated tree. Custom
+ * integrations additionally get a per-op manager (definitions at the store
+ * root, secrets in the gateway's custom-secret store, a fresh in-memory
+ * executor) — the same construction the pod boots with, minus OAuth sign-in,
+ * whose pending state lives only in a pod's memory.
+ */
+export async function applyRouteOp(
+  op: OpRequest & { op: Extract<OpRequest["op"], { kind: "route" }> },
+  filesystem: TurnFilesystem,
+  fetchImpl?: typeof fetch,
+): Promise<OpResult> {
+  const agentId = engineAgentId(filesystem);
+  const include = agentRouteScope(filesystem.workspaceRel);
+  const { method, rest } = op.op;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rest);
+  } catch {
+    decoded = rest;
+  }
+
+  // Desktop→cloud migration: an archive that carries runtime transcripts
+  // needs the pod (agentDir-anchored session synthesis + the transcript
+  // authority's projector). File/core-only chunks — and every status /
+  // complete / export call — run here.
+  if (decoded === "migration/import" && op.op.bodyBase64) {
+    if (archiveTouchesRuntime(Buffer.from(op.op.bodyBase64, "base64"))) {
+      return decline(include);
+    }
+  }
+
+  const customCtx = isCustomIntegrationOpRoute(decoded)
+    ? await customIntegrationContext(op, decoded, filesystem, fetchImpl)
+    : null;
+  if (customCtx && "decline" in customCtx) return decline(include);
+  const custom = customCtx;
+
+  // The handlers address the agent under `workspaces/`; the turn's vfs
+  // is rooted one level up (lazy or real, the same seam).
+  const vfs = new PrefixedVfs(filesystem.vfs, "workspaces");
+  const dispatch = (
+    request: Parameters<typeof dispatchAgentOp>[0]["request"],
+  ) =>
+    dispatchAgentOp({
+      workspacesRoot: join(filesystem.storeRoot, "workspaces"),
+      agentId,
+      vfs,
+      request,
+      ...(custom ? { customIntegrations: custom.manager } : {}),
+      ...(fetchImpl ? { fetchImpl } : {}),
+    });
+  const result = await dispatch({
+    method,
+    rest,
+    ...(op.op.query ? { query: op.op.query } : {}),
+    ...(op.op.body !== undefined ? { body: op.op.body } : {}),
+    ...(op.op.bodyBase64 !== undefined ? { bodyBase64: op.op.bodyBase64 } : {}),
+    ...(op.op.contentType ? { contentType: op.op.contentType } : {}),
+    ...(op.actingAs
+      ? {
+          actingSub: op.actingAs.userId,
+          // Gateway-fronted: the acting human is a full contributor on
+          // missions, exactly as the pod stamps it from the acting header.
+          actingAuthor: {
+            user_id: op.actingAs.userId,
+            ...(op.actingAs.name ? { name: op.actingAs.name } : {}),
+          },
+        }
+      : {}),
+    triggersEnabled: op.triggersEnabled,
+  });
+
+  // A detect that hits an OAuth wall carries `oauthSupported`, which only
+  // the pod (the deployment that runs the browser sign-in) can answer —
+  // decline so the response never diverges. Read-only, so nothing to undo.
+  if (custom && decoded === "integrations/custom/detect") {
+    try {
+      if (JSON.parse(result.body).requiresOAuth === true)
+        return decline(include);
+    } catch {
+      /* non-JSON answers relay as-is */
+    }
+  }
+
+  const events: HoustonEvent[] = [...result.events];
+  const out: OpResult = {
+    ...result,
+    events,
+    include: custom
+      ? (rel) => include(rel) || rel === CUSTOM_DEFS_FILE
+      : include,
+  };
+  if (custom?.changed()) {
+    events.push({ type: "CustomIntegrationsChanged" });
+    // Re-capture the definitions view the way the pod's route serves it, so
+    // the gateway's asleep reads show the mutation immediately.
+    out.customDefinitionsView = { items: await custom.manager.list() };
+  }
+  if (result.events.some((e) => e.type === "SkillsChanged")) {
+    // Re-capture the skills view the way the pod would serve it, so the
+    // gateway's asleep reads show the install/remove immediately.
+    const view = await dispatch({
+      method: "GET",
+      rest: "skills",
+      triggersEnabled: op.triggersEnabled,
+    });
+    if (view.status === 200) {
+      try {
+        out.skillsView = JSON.parse(view.body);
+      } catch {
+        /* not JSON: leave the previous view */
+      }
+    }
+  }
+  return out;
+}
+
+interface CustomContext {
+  manager: CustomIntegrationManager;
+  changed: () => boolean;
+}
+
+async function customIntegrationContext(
+  op: OpRequest & { op: Extract<OpRequest["op"], { kind: "route" }> },
+  decoded: string,
+  filesystem: TurnFilesystem,
+  fetchImpl?: typeof fetch,
+): Promise<CustomContext | { decline: true }> {
+  // Adding an OAuth-auth integration mints a capability answer only the pod
+  // can honor (its callback + pending state) — decline before any write.
+  if (
+    decoded === "integrations/custom/definitions" &&
+    op.op.method === "POST"
+  ) {
+    try {
+      if (JSON.parse(op.op.body ?? "{}").auth === "oauth")
+        return { decline: true };
+    } catch {
+      /* the handler owns the 400 for a malformed body */
+    }
+  }
+  // Materialize the store-root definitions file into the lazy overlay (and
+  // its manifest) BEFORE the raw-fs store reads it: an unmaterialized file
+  // would read as "no definitions" and a later write would CAS-create over
+  // the real one.
+  await filesystem.vfs.readBytes(CUSTOM_DEFS_FILE);
+  const { org, agent } = poolIdentity(op.gcsPrefix);
+  const store = new FileCustomIntegrationStore(
+    join(filesystem.storeRoot, CUSTOM_DEFS_FILE),
+  );
+  const secrets = new RemoteCustomSecretStore({
+    baseUrl: new URL(op.claim.heartbeatUrl).origin,
+    orgSlug: org,
+    agentSlug: agent,
+    podToken: op.hostToken,
+    ...(fetchImpl ? { fetchImpl } : {}),
+  });
+  const executor = new CustomExecutorHost(secrets, () => store.list());
+  let changed = false;
+  const manager = new CustomIntegrationManager(
+    store,
+    secrets,
+    executor,
+    () => {
+      changed = true;
+    },
+    // No OAuth options: sign-in never runs here (see the module doc).
+    {},
+  );
+  return { manager, changed: () => changed };
+}

--- a/packages/runtime/src/turn/op-route.ts
+++ b/packages/runtime/src/turn/op-route.ts
@@ -78,8 +78,12 @@ export async function applyRouteOp(
     return await runRouteOp(op, filesystem, decoded, custom, fetchImpl);
   } finally {
     // The per-op executor holds live MCP connections — a long-lived worker
-    // must not accumulate them.
-    await custom?.dispose();
+    // must not accumulate them. A close failure is diagnostics only: it must
+    // never turn an already-successful op into a 500 (the answer and its
+    // sync-back would be lost while the secret store already committed).
+    await custom?.dispose().catch((error: unknown) => {
+      console.error("[op] custom-integration executor close failed:", error);
+    });
   }
 }
 

--- a/packages/runtime/src/turn/op-route.ts
+++ b/packages/runtime/src/turn/op-route.ts
@@ -11,6 +11,8 @@ import type { OpRequest } from "./parse-op-request";
 import type { TurnFilesystem } from "./turn-filesystem";
 import { poolIdentity } from "./turn-store";
 
+type RouteOp = OpRequest & { op: Extract<OpRequest["op"], { kind: "route" }> };
+
 /** The store-root definitions file custom-integration ops read and write. */
 const CUSTOM_DEFS_FILE = "custom-integrations.json";
 
@@ -23,6 +25,15 @@ const decline = (include: OpResult["include"]): OpResult => ({
   decline: true,
 });
 
+/** An add whose auth mode is the browser sign-in (pod-only capability). */
+function oauthAddBody(body: string | undefined): boolean {
+  try {
+    return JSON.parse(body ?? "{}").auth === "oauth";
+  } catch {
+    return false; // the handler owns the 400 for a malformed body
+  }
+}
+
 /**
  * A `route` op: the pod's own handler chain over the hydrated tree. Custom
  * integrations additionally get a per-op manager (definitions at the store
@@ -31,19 +42,15 @@ const decline = (include: OpResult["include"]): OpResult => ({
  * whose pending state lives only in a pod's memory.
  */
 export async function applyRouteOp(
-  op: OpRequest & { op: Extract<OpRequest["op"], { kind: "route" }> },
+  op: RouteOp,
   filesystem: TurnFilesystem,
   fetchImpl?: typeof fetch,
 ): Promise<OpResult> {
-  const agentId = engineAgentId(filesystem);
   const include = agentRouteScope(filesystem.workspaceRel);
   const { method, rest } = op.op;
-  let decoded: string;
-  try {
-    decoded = decodeURIComponent(rest);
-  } catch {
-    decoded = rest;
-  }
+  // parseOpRequest already proved the rest decodes (and validated the
+  // decoded form against the allowlist).
+  const decoded = decodeURIComponent(rest);
 
   // Desktop→cloud migration: an archive that carries runtime transcripts
   // needs the pod (agentDir-anchored session synthesis + the transcript
@@ -54,13 +61,37 @@ export async function applyRouteOp(
       return decline(include);
     }
   }
+  // Adding an OAuth-auth integration mints a capability answer only the pod
+  // can honor (its callback + pending state) — decline before any write.
+  if (
+    decoded === "integrations/custom/definitions" &&
+    method === "POST" &&
+    oauthAddBody(op.op.body)
+  ) {
+    return decline(include);
+  }
 
-  const customCtx = isCustomIntegrationOpRoute(decoded)
-    ? await customIntegrationContext(op, decoded, filesystem, fetchImpl)
+  const custom = isCustomIntegrationOpRoute(decoded)
+    ? await customIntegrationContext(op, filesystem, fetchImpl)
     : null;
-  if (customCtx && "decline" in customCtx) return decline(include);
-  const custom = customCtx;
+  try {
+    return await runRouteOp(op, filesystem, decoded, custom, fetchImpl);
+  } finally {
+    // The per-op executor holds live MCP connections — a long-lived worker
+    // must not accumulate them.
+    await custom?.dispose();
+  }
+}
 
+async function runRouteOp(
+  op: RouteOp,
+  filesystem: TurnFilesystem,
+  decoded: string,
+  custom: CustomContext | null,
+  fetchImpl?: typeof fetch,
+): Promise<OpResult> {
+  const agentId = engineAgentId(filesystem);
+  const include = agentRouteScope(filesystem.workspaceRel);
   // The handlers address the agent under `workspaces/`; the turn's vfs
   // is rooted one level up (lazy or real, the same seam).
   const vfs = new PrefixedVfs(filesystem.vfs, "workspaces");
@@ -76,8 +107,8 @@ export async function applyRouteOp(
       ...(fetchImpl ? { fetchImpl } : {}),
     });
   const result = await dispatch({
-    method,
-    rest,
+    method: op.op.method,
+    rest: op.op.rest,
     ...(op.op.query ? { query: op.op.query } : {}),
     ...(op.op.body !== undefined ? { body: op.op.body } : {}),
     ...(op.op.bodyBase64 !== undefined ? { bodyBase64: op.op.bodyBase64 } : {}),
@@ -144,27 +175,14 @@ export async function applyRouteOp(
 interface CustomContext {
   manager: CustomIntegrationManager;
   changed: () => boolean;
+  dispose: () => Promise<void>;
 }
 
 async function customIntegrationContext(
-  op: OpRequest & { op: Extract<OpRequest["op"], { kind: "route" }> },
-  decoded: string,
+  op: RouteOp,
   filesystem: TurnFilesystem,
   fetchImpl?: typeof fetch,
-): Promise<CustomContext | { decline: true }> {
-  // Adding an OAuth-auth integration mints a capability answer only the pod
-  // can honor (its callback + pending state) — decline before any write.
-  if (
-    decoded === "integrations/custom/definitions" &&
-    op.op.method === "POST"
-  ) {
-    try {
-      if (JSON.parse(op.op.body ?? "{}").auth === "oauth")
-        return { decline: true };
-    } catch {
-      /* the handler owns the 400 for a malformed body */
-    }
-  }
+): Promise<CustomContext> {
   // Materialize the store-root definitions file into the lazy overlay (and
   // its manifest) BEFORE the raw-fs store reads it: an unmaterialized file
   // would read as "no definitions" and a later write would CAS-create over
@@ -206,5 +224,9 @@ async function customIntegrationContext(
     // No OAuth options: sign-in never runs here (see the module doc).
     {},
   );
-  return { manager, changed: () => changed };
+  return {
+    manager,
+    changed: () => changed,
+    dispose: () => executor.reset(),
+  };
 }

--- a/packages/runtime/src/turn/parse-op-request.test.ts
+++ b/packages/runtime/src/turn/parse-op-request.test.ts
@@ -30,3 +30,96 @@ test("op.rest must be an op-route shape; a runtime agentfile path is refused", (
     parseOpRequest(routeOp("conversations/c1/messages", "POST")),
   ).toThrow(/not an op route/);
 });
+
+test("tranche-2 route allowlist: portable/migration/custom in, OAuth start out", () => {
+  const base = {
+    workspaceId: "w1",
+    agentId: "a1",
+    gcsPrefix: "ws/w1/a1",
+    hostToken: "ht",
+    claim: { id: "c", bootId: "b", token: "t", heartbeatUrl: "http://x/hb" },
+  };
+  const routeOp = (rest: string, method: string, extra?: object) => ({
+    ...base,
+    op: { kind: "route", method, rest, ...extra },
+  });
+  for (const [rest, method] of [
+    ["portable/preview", "GET"],
+    ["portable/export", "POST"],
+    ["portable/store-ir", "POST"],
+    ["portable/store-publication", "GET"],
+    ["portable/store-publication", "POST"],
+    ["portable/store-publication", "DELETE"],
+    ["migration/export", "POST"],
+    ["migration/complete", "POST"],
+    ["migration/status", "GET"],
+    ["integrations/custom/detect", "POST"],
+    ["integrations/custom/definitions", "GET"],
+    ["integrations/custom/definitions", "POST"],
+    ["integrations/custom/definitions/acme", "DELETE"],
+    ["integrations/custom/definitions/acme/credential", "POST"],
+    ["integrations/custom/definitions/acme/tools", "GET"],
+  ] as const) {
+    expect(() => parseOpRequest(routeOp(rest, method)), rest).not.toThrow();
+  }
+  // OAuth sign-in stays pod-side: its pending state lives in pod memory,
+  // where the browser callback lands.
+  expect(() =>
+    parseOpRequest(
+      routeOp("integrations/custom/definitions/acme/oauth/start", "POST"),
+    ),
+  ).toThrow(/not an op route/);
+  // portable/anonymize is its own op kind, never a route.
+  expect(() => parseOpRequest(routeOp("portable/anonymize", "POST"))).toThrow(
+    /not an op route/,
+  );
+  // Binary bodies ride bodyBase64 for the migration import ONLY.
+  expect(() =>
+    parseOpRequest(routeOp("migration/import", "POST", { bodyBase64: "AAAA" })),
+  ).not.toThrow();
+  expect(() =>
+    parseOpRequest(routeOp("routines", "POST", { bodyBase64: "AAAA" })),
+  ).toThrow(/bodyBase64/);
+});
+
+test("the endpoint and anonymize kinds parse; azure's endpoint rides the credential op", () => {
+  const base = {
+    workspaceId: "w1",
+    agentId: "a1",
+    gcsPrefix: "ws/w1/a1",
+    hostToken: "ht",
+    claim: { id: "c", bootId: "b", token: "t", heartbeatUrl: "http://x/hb" },
+  };
+  const endpoint = parseOpRequest({
+    ...base,
+    op: {
+      kind: "settings",
+      action: "endpoint",
+      input: { baseUrl: "https://m.example.com", model: "m1", shared: true },
+    },
+  });
+  expect(endpoint.op).toMatchObject({
+    kind: "settings",
+    action: "endpoint",
+    input: { baseUrl: "https://m.example.com", model: "m1", shared: true },
+  });
+  const anonymize = parseOpRequest({
+    ...base,
+    op: { kind: "anonymize", input: { claudeMd: true, useAi: false } },
+  });
+  expect(anonymize.op).toMatchObject({
+    kind: "anonymize",
+    input: { claudeMd: true, useAi: false, skillSlugs: [] },
+  });
+  const azure = parseOpRequest({
+    ...base,
+    op: {
+      kind: "credential",
+      action: "api-key",
+      provider: "azure-openai-responses",
+      apiKey: "sk",
+      endpoint: "https://r.openai.azure.com",
+    },
+  });
+  expect(azure.op).toMatchObject({ endpoint: "https://r.openai.azure.com" });
+});

--- a/packages/runtime/src/turn/parse-op-request.test.ts
+++ b/packages/runtime/src/turn/parse-op-request.test.ts
@@ -80,6 +80,14 @@ test("tranche-2 route allowlist: portable/migration/custom in, OAuth start out",
   expect(() =>
     parseOpRequest(routeOp("routines", "POST", { bodyBase64: "AAAA" })),
   ).toThrow(/bodyBase64/);
+  // ...and never as a text body: a zip in a UTF-8 string is corrupt and
+  // would bypass the runtime-transcript decline.
+  expect(() =>
+    parseOpRequest(routeOp("migration/import", "POST", { body: "PK..." })),
+  ).toThrow(/bodyBase64/);
+  expect(() =>
+    parseOpRequest(routeOp("migration/import", "POST", { body: "" })),
+  ).not.toThrow();
 });
 
 test("the endpoint and anonymize kinds parse; azure's endpoint rides the credential op", () => {

--- a/packages/runtime/src/turn/parse-op-request.ts
+++ b/packages/runtime/src/turn/parse-op-request.ts
@@ -1,80 +1,14 @@
 import type { ServedCredential } from "../auth/auth-file";
-import {
-  isBinaryBodyOpRoute,
-  isOpRoute,
-  isReadOpRoute,
-} from "./op-route-allowlist";
+import { type AgentOp, ID, parseAgentOp, str } from "./op-grammar";
 import type { TurnRequest } from "./types";
+
+export type { AgentOp } from "./op-grammar";
 
 /**
  * An OP is a write the gateway routes to a pool worker instead of waking the
  * agent's pod: the same claim/host-token envelope as a turn, plus the
- * operation. `route` ops run the host's own route handlers against the
- * hydrated workspace; `title` and `conversation` ops are the runtime's own.
+ * operation (the op shapes and their parsers live in ./op-grammar).
  */
-export type AgentOp =
-  | {
-      kind: "route";
-      method: string;
-      rest: string;
-      /** Raw query string without the `?` (files routes take `?path=`). */
-      query?: string;
-      body?: string;
-      /** Binary request body (a migration zip), base64 — a JSON envelope
-       *  cannot carry raw bytes. Mutually exclusive with `body`. */
-      bodyBase64?: string;
-      contentType?: string;
-    }
-  | { kind: "title"; text: string }
-  | {
-      kind: "anonymize";
-      input: {
-        claudeMd?: boolean;
-        skillSlugs?: string[];
-        routineIds?: string[];
-        learningIds?: string[];
-        useAi?: boolean;
-      };
-    }
-  | {
-      kind: "settings";
-      action: "put";
-      input: { activeProvider?: string; model?: string; effort?: string };
-    }
-  | {
-      kind: "settings";
-      action: "claim";
-      provider: string;
-      connectedProviders: string[];
-    }
-  | {
-      kind: "settings";
-      action: "endpoint";
-      input: {
-        baseUrl: string;
-        model: string;
-        name?: string;
-        contextWindow?: number;
-        reasoning?: boolean;
-        shared?: boolean;
-        apiKey?: string;
-      };
-    }
-  | {
-      kind: "credential";
-      action: "api-key";
-      provider: string;
-      apiKey: string;
-      /** Azure OpenAI's per-resource endpoint, arriving with the key. */
-      endpoint?: string;
-    }
-  | {
-      kind: "conversation";
-      action: "rename" | "delete";
-      conversationId: string;
-      title?: string;
-    };
-
 export interface OpRequest {
   workspaceId: string;
   agentId: string;
@@ -90,8 +24,6 @@ export interface OpRequest {
   op: AgentOp;
 }
 
-const ID = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$/;
-
 function parseActing(raw: unknown): TurnRequest["actingAs"] {
   if (!raw || typeof raw !== "object") return undefined;
   const a = raw as { userId?: unknown; name?: unknown };
@@ -100,11 +32,6 @@ function parseActing(raw: unknown): TurnRequest["actingAs"] {
     userId: a.userId,
     ...(typeof a.name === "string" && a.name ? { name: a.name } : {}),
   };
-}
-
-function str(v: unknown, field: string): string {
-  if (typeof v !== "string" || !v.length) throw new Error(`invalid '${field}'`);
-  return v;
 }
 
 export function parseOpRequest(body: unknown): OpRequest {
@@ -141,172 +68,6 @@ export function parseOpRequest(body: unknown): OpRequest {
   }
   const raw = b.op as Record<string, unknown> | undefined;
   if (!raw || typeof raw !== "object") throw new Error("invalid 'op'");
-  let op: AgentOp;
-  switch (raw.kind) {
-    case "route": {
-      const method = str(raw.method, "op.method").toUpperCase();
-      if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(method)) {
-        throw new Error("op.method is not an HTTP method");
-      }
-      const rest = str(raw.rest, "op.rest");
-      if (rest.includes("..") || rest.startsWith("/"))
-        throw new Error("invalid 'op.rest'");
-      // Defense in depth: the worker accepts only the op-route shapes the
-      // gateway classifier dispatches — a valid-token caller cannot reach a
-      // handler surface (e.g. POST agentfile) the public path never exposes.
-      // Match the DECODED path: the handlers decode, so the allowlist must
-      // see what they see (`%2Ehouston` is `.houston`).
-      let decoded: string;
-      try {
-        decoded = decodeURIComponent(rest);
-      } catch {
-        throw new Error("invalid 'op.rest'");
-      }
-      if (decoded.includes("..") || decoded.startsWith("/")) {
-        throw new Error("invalid 'op.rest'");
-      }
-      if (!isOpRoute(decoded)) {
-        throw new Error("op.rest is not an op route");
-      }
-      // Reads run as ops only where the gateway has no doc to serve them
-      // from: the Files tab and arbitrary agent files.
-      if (method === "GET" && !isReadOpRoute(decoded)) {
-        throw new Error("op.rest is not a read op route");
-      }
-      if (typeof raw.bodyBase64 === "string" && !isBinaryBodyOpRoute(decoded)) {
-        throw new Error("op.bodyBase64 is not accepted for this route");
-      }
-      const query =
-        typeof raw.query === "string" && raw.query.length <= 4096
-          ? raw.query.replace(/^\?/, "")
-          : undefined;
-      op = {
-        kind: "route",
-        method,
-        rest,
-        ...(query ? { query } : {}),
-        ...(typeof raw.body === "string" ? { body: raw.body } : {}),
-        ...(typeof raw.bodyBase64 === "string"
-          ? { bodyBase64: raw.bodyBase64 }
-          : {}),
-        ...(typeof raw.contentType === "string"
-          ? { contentType: raw.contentType }
-          : {}),
-      };
-      break;
-    }
-    case "title":
-      op = { kind: "title", text: str(raw.text, "op.text") };
-      break;
-    case "anonymize": {
-      const input = (raw.input ?? {}) as Record<string, unknown>;
-      const ids = (v: unknown) =>
-        Array.isArray(v)
-          ? v.filter((s): s is string => typeof s === "string")
-          : [];
-      op = {
-        kind: "anonymize",
-        input: {
-          claudeMd: input.claudeMd === true,
-          skillSlugs: ids(input.skillSlugs),
-          routineIds: ids(input.routineIds),
-          learningIds: ids(input.learningIds),
-          // Mirrors the pod route: absent means the AI pass is wanted.
-          useAi: input.useAi !== false,
-        },
-      };
-      break;
-    }
-    case "settings": {
-      if (raw.action === "put") {
-        const input = (raw.input ?? {}) as Record<string, unknown>;
-        const pick = (k: string) =>
-          typeof input[k] === "string" && (input[k] as string).length <= 200
-            ? { [k]: input[k] as string }
-            : {};
-        op = {
-          kind: "settings",
-          action: "put",
-          input: {
-            ...pick("activeProvider"),
-            ...pick("model"),
-            ...pick("effort"),
-          },
-        };
-        break;
-      }
-      if (raw.action === "claim") {
-        const connected = Array.isArray(raw.connectedProviders)
-          ? raw.connectedProviders.filter(
-              (p): p is string => typeof p === "string",
-            )
-          : [];
-        op = {
-          kind: "settings",
-          action: "claim",
-          provider: str(raw.provider, "op.provider"),
-          connectedProviders: connected,
-        };
-        break;
-      }
-      if (raw.action === "endpoint") {
-        const input = (raw.input ?? {}) as Record<string, unknown>;
-        op = {
-          kind: "settings",
-          action: "endpoint",
-          input: {
-            baseUrl: str(input.baseUrl, "op.input.baseUrl"),
-            model: str(input.model, "op.input.model"),
-            ...(typeof input.name === "string" ? { name: input.name } : {}),
-            ...(typeof input.contextWindow === "number"
-              ? { contextWindow: input.contextWindow }
-              : {}),
-            ...(typeof input.reasoning === "boolean"
-              ? { reasoning: input.reasoning }
-              : {}),
-            ...(input.shared === true ? { shared: true } : {}),
-            ...(typeof input.apiKey === "string"
-              ? { apiKey: input.apiKey }
-              : {}),
-          },
-        };
-        break;
-      }
-      throw new Error("invalid 'op.action'");
-    }
-    case "credential": {
-      if (raw.action !== "api-key") throw new Error("invalid 'op.action'");
-      op = {
-        kind: "credential",
-        action: "api-key",
-        provider: str(raw.provider, "op.provider"),
-        apiKey: str(raw.apiKey, "op.apiKey"),
-        ...(typeof raw.endpoint === "string" && raw.endpoint
-          ? { endpoint: raw.endpoint }
-          : {}),
-      };
-      break;
-    }
-    case "conversation": {
-      const action = raw.action;
-      if (action !== "rename" && action !== "delete")
-        throw new Error("invalid 'op.action'");
-      const conversationId = str(raw.conversationId, "op.conversationId");
-      if (!ID.test(conversationId))
-        throw new Error("invalid 'op.conversationId'");
-      if (action === "rename" && typeof raw.title !== "string")
-        throw new Error("rename needs 'op.title'");
-      op = {
-        kind: "conversation",
-        action,
-        conversationId,
-        ...(typeof raw.title === "string" ? { title: raw.title } : {}),
-      };
-      break;
-    }
-    default:
-      throw new Error("invalid 'op.kind'");
-  }
   return {
     workspaceId: str(b.workspaceId, "workspaceId"),
     agentId,
@@ -325,6 +86,6 @@ export function parseOpRequest(body: unknown): OpRequest {
 
     credential,
     triggersEnabled: b.triggersEnabled === true,
-    op,
+    op: parseAgentOp(raw),
   };
 }

--- a/packages/runtime/src/turn/parse-op-request.ts
+++ b/packages/runtime/src/turn/parse-op-request.ts
@@ -1,4 +1,9 @@
 import type { ServedCredential } from "../auth/auth-file";
+import {
+  isBinaryBodyOpRoute,
+  isOpRoute,
+  isReadOpRoute,
+} from "./op-route-allowlist";
 import type { TurnRequest } from "./types";
 
 /**
@@ -15,9 +20,22 @@ export type AgentOp =
       /** Raw query string without the `?` (files routes take `?path=`). */
       query?: string;
       body?: string;
+      /** Binary request body (a migration zip), base64 — a JSON envelope
+       *  cannot carry raw bytes. Mutually exclusive with `body`. */
+      bodyBase64?: string;
       contentType?: string;
     }
   | { kind: "title"; text: string }
+  | {
+      kind: "anonymize";
+      input: {
+        claudeMd?: boolean;
+        skillSlugs?: string[];
+        routineIds?: string[];
+        learningIds?: string[];
+        useAi?: boolean;
+      };
+    }
   | {
       kind: "settings";
       action: "put";
@@ -29,7 +47,27 @@ export type AgentOp =
       provider: string;
       connectedProviders: string[];
     }
-  | { kind: "credential"; action: "api-key"; provider: string; apiKey: string }
+  | {
+      kind: "settings";
+      action: "endpoint";
+      input: {
+        baseUrl: string;
+        model: string;
+        name?: string;
+        contextWindow?: number;
+        reasoning?: boolean;
+        shared?: boolean;
+        apiKey?: string;
+      };
+    }
+  | {
+      kind: "credential";
+      action: "api-key";
+      provider: string;
+      apiKey: string;
+      /** Azure OpenAI's per-resource endpoint, arriving with the key. */
+      endpoint?: string;
+    }
   | {
       kind: "conversation";
       action: "rename" | "delete";
@@ -53,14 +91,6 @@ export interface OpRequest {
 }
 
 const ID = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$/;
-
-// The op-route shapes (mirrors the Go classifier): the agent-data families,
-// agentfile writes, and skills (install + manage), never a runtime path.
-const OP_ROUTE =
-  /^(activities|routines|routine_runs|learnings|config)(\/[^/]+)?$|^agentfile\/(?!\.houston\/runtime\/).+$|^skills(\/[^/]+)?$|^skills\/(community|repo)\/install$|^files(\/.+)?$|^attachments$|^skills-manifest$/;
-// Any files/* shape reads through the handler (it owns the 404 for an
-// unknown one), never a write.
-const READ_ROUTE = /^files(\/.+)?$|^agentfile\/|^skills-manifest$/;
 
 function parseActing(raw: unknown): TurnRequest["actingAs"] {
   if (!raw || typeof raw !== "object") return undefined;
@@ -135,13 +165,16 @@ export function parseOpRequest(body: unknown): OpRequest {
       if (decoded.includes("..") || decoded.startsWith("/")) {
         throw new Error("invalid 'op.rest'");
       }
-      if (!OP_ROUTE.test(decoded)) {
+      if (!isOpRoute(decoded)) {
         throw new Error("op.rest is not an op route");
       }
       // Reads run as ops only where the gateway has no doc to serve them
       // from: the Files tab and arbitrary agent files.
-      if (method === "GET" && !READ_ROUTE.test(decoded)) {
+      if (method === "GET" && !isReadOpRoute(decoded)) {
         throw new Error("op.rest is not a read op route");
+      }
+      if (typeof raw.bodyBase64 === "string" && !isBinaryBodyOpRoute(decoded)) {
+        throw new Error("op.bodyBase64 is not accepted for this route");
       }
       const query =
         typeof raw.query === "string" && raw.query.length <= 4096
@@ -153,6 +186,9 @@ export function parseOpRequest(body: unknown): OpRequest {
         rest,
         ...(query ? { query } : {}),
         ...(typeof raw.body === "string" ? { body: raw.body } : {}),
+        ...(typeof raw.bodyBase64 === "string"
+          ? { bodyBase64: raw.bodyBase64 }
+          : {}),
         ...(typeof raw.contentType === "string"
           ? { contentType: raw.contentType }
           : {}),
@@ -162,6 +198,25 @@ export function parseOpRequest(body: unknown): OpRequest {
     case "title":
       op = { kind: "title", text: str(raw.text, "op.text") };
       break;
+    case "anonymize": {
+      const input = (raw.input ?? {}) as Record<string, unknown>;
+      const ids = (v: unknown) =>
+        Array.isArray(v)
+          ? v.filter((s): s is string => typeof s === "string")
+          : [];
+      op = {
+        kind: "anonymize",
+        input: {
+          claudeMd: input.claudeMd === true,
+          skillSlugs: ids(input.skillSlugs),
+          routineIds: ids(input.routineIds),
+          learningIds: ids(input.learningIds),
+          // Mirrors the pod route: absent means the AI pass is wanted.
+          useAi: input.useAi !== false,
+        },
+      };
+      break;
+    }
     case "settings": {
       if (raw.action === "put") {
         const input = (raw.input ?? {}) as Record<string, unknown>;
@@ -194,6 +249,29 @@ export function parseOpRequest(body: unknown): OpRequest {
         };
         break;
       }
+      if (raw.action === "endpoint") {
+        const input = (raw.input ?? {}) as Record<string, unknown>;
+        op = {
+          kind: "settings",
+          action: "endpoint",
+          input: {
+            baseUrl: str(input.baseUrl, "op.input.baseUrl"),
+            model: str(input.model, "op.input.model"),
+            ...(typeof input.name === "string" ? { name: input.name } : {}),
+            ...(typeof input.contextWindow === "number"
+              ? { contextWindow: input.contextWindow }
+              : {}),
+            ...(typeof input.reasoning === "boolean"
+              ? { reasoning: input.reasoning }
+              : {}),
+            ...(input.shared === true ? { shared: true } : {}),
+            ...(typeof input.apiKey === "string"
+              ? { apiKey: input.apiKey }
+              : {}),
+          },
+        };
+        break;
+      }
       throw new Error("invalid 'op.action'");
     }
     case "credential": {
@@ -203,6 +281,9 @@ export function parseOpRequest(body: unknown): OpRequest {
         action: "api-key",
         provider: str(raw.provider, "op.provider"),
         apiKey: str(raw.apiKey, "op.apiKey"),
+        ...(typeof raw.endpoint === "string" && raw.endpoint
+          ? { endpoint: raw.endpoint }
+          : {}),
       };
       break;
     }

--- a/packages/runtime/src/turn/server-op-tranche2.test.ts
+++ b/packages/runtime/src/turn/server-op-tranche2.test.ts
@@ -1,0 +1,574 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalWorkspaceStore } from "@houston/host/src/store/local";
+import { LocalDirStore } from "@houston/runtime-client/object-sync";
+import { zipSync } from "fflate";
+import { afterEach, expect, test } from "vitest";
+import { createTurnServer } from "./server";
+import type { runPiTurn } from "./turn-session";
+
+/**
+ * Tranche-2 pool ops (PRODUCT-1469): portable export/preview/store, the
+ * desktop→cloud migration, custom integrations, the openai-compatible
+ * endpoint connect, and the anonymize fallback — every remaining route a
+ * sleeping agent's pod used to wake for.
+ */
+
+const servers: Server[] = [];
+afterEach(() => {
+  for (const s of servers.splice(0)) s.close();
+});
+
+async function listen(server: Server): Promise<string> {
+  servers.push(server);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+}
+
+const noopTurn: typeof runPiTurn = async () => ({});
+
+async function seedAgent(): Promise<{
+  storeRoot: string;
+  agentId: string;
+  prefix: string;
+}> {
+  const storeRoot = mkdtempSync(join(tmpdir(), "op2-store-"));
+  const prefix = "ws/w1/agent-1";
+  const workspaces = join(storeRoot, prefix, "workspaces");
+  const store = new LocalWorkspaceStore(workspaces);
+  const ws = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({ workspaceId: ws.id, name: "Bob" });
+  const agentDir = join(workspaces, ...agent.id.split("/"));
+  mkdirSync(agentDir, { recursive: true });
+  writeFileSync(join(agentDir, "CLAUDE.md"), "# Bob instructions\n");
+  return { storeRoot, agentId: agent.id, prefix };
+}
+
+async function heartbeatOK(): Promise<string> {
+  return listen(
+    createServer((_req, res) => {
+      res.writeHead(200);
+      res.end("{}");
+    }),
+  );
+}
+
+function opBody(heartbeatUrl: string, op: unknown) {
+  return {
+    workspaceId: "w1",
+    agentId: "agent-1",
+    gcsPrefix: "ws/w1/agent-1",
+    hostToken: "host-token",
+    claim: {
+      id: "claim-1",
+      bootId: "boot-1",
+      token: "claim-token",
+      heartbeatUrl,
+    },
+    actingAs: { userId: "user-1" },
+    triggersEnabled: false,
+    op,
+  };
+}
+
+async function postOp(base: string, body: unknown) {
+  for (let attempt = 0; ; attempt++) {
+    const response = await fetch(`${base}/op`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const json = (await response.json()) as Record<string, unknown>;
+    if (response.status !== 503 || json.error !== "worker_full" || attempt > 40)
+      return { status: response.status, json };
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+test("portable/preview runs as a read op and inventories CLAUDE.md", async () => {
+  const { storeRoot } = await seedAgent();
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn: noopTurn,
+    }),
+  );
+  const { json } = await postOp(
+    base,
+    opBody(await heartbeatOK(), {
+      kind: "route",
+      method: "GET",
+      rest: "portable/preview",
+    }),
+  );
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  const preview = JSON.parse(json.body as string) as {
+    claudeMd: { excerpt: string } | null;
+    skills: unknown[];
+  };
+  expect(preview.claudeMd?.excerpt).toContain("Bob instructions");
+  expect(preview.skills).toEqual([]);
+});
+
+test("portable/export answers the zip base64 with its download header", async () => {
+  const { storeRoot } = await seedAgent();
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn: noopTurn,
+    }),
+  );
+  const { json } = await postOp(
+    base,
+    opBody(await heartbeatOK(), {
+      kind: "route",
+      method: "POST",
+      rest: "portable/export",
+      contentType: "application/json",
+      body: JSON.stringify({ claudeMd: true }),
+    }),
+  );
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  expect(typeof json.bodyBase64).toBe("string");
+  expect(
+    String(
+      (json.headers as Record<string, string> | undefined)?.[
+        "content-disposition"
+      ] ?? "",
+    ),
+  ).toContain(".houstonagent");
+});
+
+test("portable/store-publication round-trips through the op path and syncs the pointer", async () => {
+  const { storeRoot, prefix } = await seedAgent();
+  const store = new LocalDirStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const hb = await heartbeatOK();
+  let { json } = await postOp(
+    base,
+    opBody(hb, {
+      kind: "route",
+      method: "POST",
+      rest: "portable/store-publication",
+      contentType: "application/json",
+      body: JSON.stringify({
+        storeAgentId: "sa-1",
+        slug: "bob",
+        shareUrl: "https://agents.example/bob",
+      }),
+    }),
+  );
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  const synced = await store.list(prefix);
+  expect(
+    synced.some((k) => k.endsWith("/store-publication.json")),
+    synced.join("\n"),
+  ).toBe(true);
+  ({ json } = await postOp(
+    base,
+    opBody(hb, {
+      kind: "route",
+      method: "GET",
+      rest: "portable/store-publication",
+    }),
+  ));
+  const read = JSON.parse(json.body as string) as {
+    pointer: { slug: string } | null;
+  };
+  expect(read.pointer?.slug).toBe("bob");
+});
+
+test("migration status/complete run as ops; the marker syncs and reads back", async () => {
+  const { storeRoot, prefix } = await seedAgent();
+  const store = new LocalDirStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const hb = await heartbeatOK();
+  let { json } = await postOp(
+    base,
+    opBody(hb, { kind: "route", method: "GET", rest: "migration/status" }),
+  );
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  expect(JSON.parse(json.body as string)).toEqual({ imported: null });
+  ({ json } = await postOp(
+    base,
+    opBody(hb, {
+      kind: "route",
+      method: "POST",
+      rest: "migration/complete",
+      contentType: "application/json",
+      body: JSON.stringify({ source: "desktop", counts: { files: 2 } }),
+    }),
+  ));
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  expect(
+    (await store.list(prefix)).some((k) =>
+      k.endsWith("/.houston/migration/imported.json"),
+    ),
+  ).toBe(true);
+  ({ json } = await postOp(
+    base,
+    opBody(hb, { kind: "route", method: "GET", rest: "migration/status" }),
+  ));
+  const status = JSON.parse(json.body as string) as {
+    imported: { source: string } | null;
+  };
+  expect(status.imported?.source).toBe("desktop");
+});
+
+test("a migration import without runtime entries applies on the worker (bodyBase64)", async () => {
+  const { storeRoot, prefix } = await seedAgent();
+  const store = new LocalDirStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const zip = zipSync({
+    "CLAUDE.md": new TextEncoder().encode("# migrated instructions\n"),
+    "files/notes.txt": new TextEncoder().encode("hello\n"),
+  });
+  const { json } = await postOp(
+    base,
+    opBody(await heartbeatOK(), {
+      kind: "route",
+      method: "POST",
+      rest: "migration/import",
+      contentType: "application/zip",
+      query: "overwrite=1",
+      bodyBase64: Buffer.from(zip).toString("base64"),
+    }),
+  );
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  expect(json.decline).toBeUndefined();
+  const result = JSON.parse(json.body as string) as { written: number };
+  expect(result.written).toBe(2);
+  const synced = await store.list(prefix);
+  expect(synced.some((k) => k.endsWith("/files/notes.txt"))).toBe(true);
+});
+
+test("a migration import carrying runtime transcripts declines to the pod", async () => {
+  const { storeRoot } = await seedAgent();
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn: noopTurn,
+    }),
+  );
+  const zip = zipSync({
+    ".houston/runtime/conversations/c9.json": new TextEncoder().encode("{}"),
+  });
+  const { json } = await postOp(
+    base,
+    opBody(await heartbeatOK(), {
+      kind: "route",
+      method: "POST",
+      rest: "migration/import",
+      contentType: "application/zip",
+      bodyBase64: Buffer.from(zip).toString("base64"),
+    }),
+  );
+  expect(json.ok).toBe(true);
+  expect(json.decline).toBe(true);
+});
+
+test("anonymize with no credential ships the regex-only result with the reason, never a decline", async () => {
+  const { storeRoot } = await seedAgent();
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn: noopTurn,
+    }),
+  );
+  const { json } = await postOp(
+    base,
+    opBody(await heartbeatOK(), {
+      kind: "anonymize",
+      input: { claudeMd: true },
+    }),
+  );
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  expect(json.decline).toBeUndefined();
+  const body = JSON.parse(json.body as string) as {
+    mode: string;
+    aiError?: string;
+  };
+  expect(body.mode).toBe("patterns");
+  expect(body.aiError).toContain("AI anonymization is not available");
+});
+
+test("anonymize with useAi:false is a clean patterns run (no aiError)", async () => {
+  const { storeRoot } = await seedAgent();
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn: noopTurn,
+    }),
+  );
+  const { json } = await postOp(
+    base,
+    opBody(await heartbeatOK(), {
+      kind: "anonymize",
+      input: { claudeMd: true, useAi: false },
+    }),
+  );
+  expect(json.status).toBe(200);
+  const body = JSON.parse(json.body as string) as {
+    mode: string;
+    aiError?: string;
+  };
+  expect(body.mode).toBe("patterns");
+  expect(body.aiError).toBeUndefined();
+});
+
+/** The gateway double: heartbeat + credential PUT + shared-endpoint PUT/DELETE. */
+function fakeGateway(recorded: {
+  credentials: { path: string; body: string }[];
+  shared: { method: string; ownerOnly: string }[];
+}): Server {
+  return createServer((req: IncomingMessage, res) => {
+    let body = "";
+    req.on("data", (c) => {
+      body += c;
+    });
+    req.on("end", () => {
+      if (req.url?.startsWith("/v1/pod/credentials/")) {
+        recorded.credentials.push({ path: req.url, body });
+      } else if (req.url?.startsWith("/v1/pod/shared-endpoint/")) {
+        recorded.shared.push({
+          method: req.method ?? "",
+          ownerOnly: String(req.headers["x-houston-owner-only"] ?? ""),
+        });
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end("{}");
+    });
+  });
+}
+
+test("an endpoint connect writes custom-endpoint.json, pushes the key, and publishes the share", async () => {
+  const { storeRoot, prefix } = await seedAgent();
+  const store = new LocalDirStore(storeRoot);
+  const recorded = { credentials: [], shared: [] } as Parameters<
+    typeof fakeGateway
+  >[0];
+  const gateway = await listen(fakeGateway(recorded));
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const { json } = await postOp(
+    base,
+    opBody(`${gateway}/hb`, {
+      kind: "settings",
+      action: "endpoint",
+      input: {
+        baseUrl: "https://models.example.com",
+        model: "llama-3.3-70b",
+        shared: true,
+        apiKey: "sk-local",
+      },
+    }),
+  );
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  expect(JSON.parse(json.body as string)).toEqual({ ok: true });
+  // The endpoint config synced back beside settings.json.
+  const synced = await store.list(prefix);
+  expect(
+    synced.some((k) => k.endsWith("/.houston/runtime/custom-endpoint.json")),
+  ).toBe(true);
+  // The key landed in the credential store under the provider id...
+  expect(recorded.credentials).toHaveLength(1);
+  expect(recorded.credentials[0]?.path).toContain("/openai-compatible");
+  expect(JSON.parse(recorded.credentials[0]?.body ?? "{}")).toMatchObject({
+    kind: "api_key",
+    access: "sk-local",
+  });
+  // ...and the org share was published.
+  expect(recorded.shared).toEqual([{ method: "PUT", ownerOnly: "" }]);
+});
+
+test("an unshared endpoint connect withdraws the owner's share; a private URL never leaves the worker", async () => {
+  const { storeRoot } = await seedAgent();
+  const store = new LocalDirStore(storeRoot);
+  const recorded = { credentials: [], shared: [] } as Parameters<
+    typeof fakeGateway
+  >[0];
+  const gateway = await listen(fakeGateway(recorded));
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  let { json } = await postOp(
+    base,
+    opBody(`${gateway}/hb`, {
+      kind: "settings",
+      action: "endpoint",
+      input: { baseUrl: "https://models.example.com", model: "m" },
+    }),
+  );
+  expect(json.status).toBe(200);
+  expect(recorded.shared).toEqual([{ method: "DELETE", ownerOnly: "1" }]);
+  // Managed-cloud egress guard: a localhost endpoint answers the pod's own
+  // 400 reason — nothing is written, nothing pushed.
+  ({ json } = await postOp(
+    base,
+    opBody(`${gateway}/hb`, {
+      kind: "settings",
+      action: "endpoint",
+      input: { baseUrl: "http://127.0.0.1:11434", model: "m" },
+    }),
+  ));
+  expect(json.status).toBe(400);
+  expect(String(JSON.parse(json.body as string).error)).toContain(
+    "public HTTPS",
+  );
+  expect(recorded.credentials).toHaveLength(1); // still only the first connect
+});
+
+test("an azure api-key connect validates the endpoint on the worker (no more dropped-field 400s)", async () => {
+  const { storeRoot } = await seedAgent();
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn: noopTurn,
+    }),
+  );
+  // A malformed endpoint fails the offline preconditions with azure's own
+  // reason — proving the endpoint field now rides the op at all.
+  const { json } = await postOp(
+    base,
+    opBody(await heartbeatOK(), {
+      kind: "credential",
+      action: "api-key",
+      provider: "azure-openai-responses",
+      apiKey: "sk-azure",
+      endpoint: "not a url",
+    }),
+  );
+  expect(json.status, JSON.stringify(json)).toBe(400);
+  expect(String(JSON.parse(json.body as string).error)).toContain(
+    "not a valid URL",
+  );
+});
+
+test("custom-integration definitions list runs on the worker over the store-root file", async () => {
+  const { storeRoot } = await seedAgent();
+  // A pre-existing definitions file at the STORE ROOT (beside workspaces/):
+  // the op must read THIS file, not an empty default.
+  writeFileSync(
+    join(storeRoot, "ws/w1/agent-1", "custom-integrations.json"),
+    JSON.stringify({
+      version: 1,
+      items: [],
+    }),
+  );
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn: noopTurn,
+    }),
+  );
+  const { json } = await postOp(
+    base,
+    opBody(await heartbeatOK(), {
+      kind: "route",
+      method: "GET",
+      rest: "integrations/custom/definitions",
+    }),
+  );
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  expect(JSON.parse(json.body as string)).toEqual({ items: [] });
+});
+
+test("adding an OAuth custom integration declines to the pod (its callback, its state)", async () => {
+  const { storeRoot } = await seedAgent();
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn: noopTurn,
+    }),
+  );
+  const { json } = await postOp(
+    base,
+    opBody(await heartbeatOK(), {
+      kind: "route",
+      method: "POST",
+      rest: "integrations/custom/definitions",
+      contentType: "application/json",
+      body: JSON.stringify({
+        kind: "mcp",
+        name: "Linear",
+        endpoint: "https://mcp.linear.app/mcp",
+        auth: "oauth",
+      }),
+    }),
+  );
+  expect(json.ok).toBe(true);
+  expect(json.decline).toBe(true);
+});
+
+// Minimal, valid OpenAPI 3.0 document — enough for the executor to compile
+// (title/servers/paths with operationIds). No security scheme, so
+// `auth: "none"` connects immediately, no network.
+const OPENAPI_SPEC = JSON.stringify({
+  openapi: "3.0.0",
+  info: { title: "Widgets", version: "1.0.0" },
+  servers: [{ url: "https://widgets.example.com" }],
+  paths: {
+    "/widgets": {
+      get: {
+        operationId: "listWidgets",
+        responses: { "200": { description: "ok" } },
+      },
+    },
+  },
+});
+
+test("adding a keyless custom integration compiles on the worker, syncs the store-root file, and announces", async () => {
+  const { storeRoot, prefix } = await seedAgent();
+  const store = new LocalDirStore(storeRoot);
+  const base = await listen(
+    createTurnServer({ store, token: "", runTurn: noopTurn }),
+  );
+  const { json } = await postOp(
+    base,
+    opBody(await heartbeatOK(), {
+      kind: "route",
+      method: "POST",
+      rest: "integrations/custom/definitions",
+      contentType: "application/json",
+      body: JSON.stringify({
+        kind: "openapi",
+        name: "Widgets",
+        spec: OPENAPI_SPEC,
+        auth: "none",
+      }),
+    }),
+  );
+  expect(json.status, JSON.stringify(json)).toBe(200);
+  const view = JSON.parse(json.body as string) as {
+    slug: string;
+    state: { status: string };
+  };
+  expect(view.slug).toBe("widgets");
+  expect(view.state.status).toBe("active");
+  // The definitions file lives at the STORE-PREFIX ROOT (beside workspaces/),
+  // and the widened include carried it back.
+  const synced = await store.list(prefix);
+  expect(synced, synced.join("\n")).toContain(
+    "ws/w1/agent-1/custom-integrations.json",
+  );
+  // The mutation announces like the pod's own emit.
+  expect(json.events).toContain("CustomIntegrationsChanged");
+});

--- a/packages/runtime/src/turn/turn-changed-events.ts
+++ b/packages/runtime/src/turn/turn-changed-events.ts
@@ -55,11 +55,14 @@ export function changedEventTypes(
 export function announcedOpEvents(
   events: readonly HoustonEvent[],
   projectionFailures: readonly string[],
-): AgentEventType[] {
+): (AgentEventType | "CustomIntegrationsChanged")[] {
   if (projectionFailures.length > 0) return [];
-  const out = new Set<AgentEventType>();
+  const out = new Set<AgentEventType | "CustomIntegrationsChanged">();
   for (const event of events) {
-    if ("agentPath" in event) out.add(event.type);
+    // CustomIntegrationsChanged is the one agent-scoped event the protocol
+    // ships without an agentPath (clients invalidate globally).
+    if ("agentPath" in event || event.type === "CustomIntegrationsChanged")
+      out.add(event.type);
   }
   return [...out].sort();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,6 +558,9 @@ importers:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260607.1
         version: 7.0.0-dev.20260607.1
+      fflate:
+        specifier: 0.8.3
+        version: 0.8.3
       vitest:
         specifier: 3.2.6
         version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.23.0)(yaml@2.9.0)


### PR DESCRIPTION
## Summary

PRODUCT-1469 tranche 2, engine side. After #1369/#1370/#1372 the routes below still proxied to the pod — waking it — for a sleeping agent. They now run as pool ops on a worker, with pod-byte-identical semantics or an explicit decline back to the pod:

- **portable/preview | export | store-ir | store-publication** → route ops through the pod's own handlers (new op handler-chain entries + allowlist).
- **portable/anonymize** → its own op kind (the titles pattern): gather + regex pre-pass over the hydrated tree, AI pass on a turn-local model runtime fed by the envelope credential. Anthropic's pass is Claude-SDK-only (pod-only by compliance), so with no usable credential the regex-only result ships with `aiError` — a valid 200, never a wake. Hydrates with the settings profile (skips conversations/sessions/files/uploads).
- **migration/status | complete | export** → route ops. **migration/import** runs as an op only when the archive carries no `.houston/runtime/` entries (checked via `safeSeedKey`-normalized names, read without inflating); transcript-carrying chunks decline to the pod, whose agentDir-anchored session synthesis and transcript-authority projector they need. Binary zip bodies ride a new `bodyBase64` field on the route-op wire.
- **integrations/custom/** detect / definitions add+remove / credential / tools → route ops with a per-op manager: definitions in the store-root `custom-integrations.json` (materialized into the lazy overlay before the raw-fs store reads it), secrets in the gateway's custom-secret store, a fresh in-memory executor that is disposed after the op (MCP connections must not accumulate on a long-lived worker). Mutations re-capture and republish the `custom_definitions` view doc. `oauth/start` stays pod-side (pending OAuth state lives in pod memory); OAuth-flavored detect/add answers decline so responses never diverge.
- **provider/openai-compatible** → a `settings`/`endpoint` op: pod-verbatim URL validation + the managed-cloud public-HTTPS egress guard, `custom-endpoint.json` written into the runtime dir (settings sync scope), the key pushed to the credential store (placeholder for keyless servers — auth.json never syncs), and the org share published/withdrawn via the gateway's shared-endpoint store.
- **qwen api-key connects** no longer decline: the verified region persists into the hydrated agent root (`setQwenRegionIn`) and syncs back beside settings.json.
- **azure api-key connects** are fixed while here: the op wire now carries the `endpoint` field (the gateway used to drop it, so every asleep Azure connect 400ed), the verify probe aims at the *normalized* endpoint (the PRODUCT-1477 Foundry-paste shape), and nothing persists on a rejected key.

`credential/claude-oauth` is intentionally absent here: it becomes gateway-native against the credential store (cloud-side change, paired PR).

## Root cause

The gateway's stateless ladder only covered the tranche-0/1 routes; everything else fell through to pod proxy + wake (`agent dispatch could not connect; ensuring awake`). The engine had no op handlers for these families, no wire shapes for binary bodies/model-call ops, and the worker hard-declined qwen (region file landed in the worker's own dir, not the agent's).

## Verification

Before (reproduce): with an agent's pod at `replicas=0` on staging, run any of: the export wizard (preview/anonymize/export), Agent Store publish, a desktop→cloud migration status poll, a custom-integration add or key save, an OpenAI-compatible/qwen/azure connect. The staging gateway log prints `agent dispatch could not connect; ensuring awake` naming the route, and the pod wakes.

After (with the paired cloud gateway classifier change deployed): the same flows answer without the wake line; each new op family is covered by classifier tests (cloud) and the engine tests here (`server-op-tranche2.test.ts`, `parse-op-request.test.ts`, `qwen-verify.test.ts`). Acceptance stays the issue's: a 24h staging window with zero wake lines for app traffic, including after exercising each flow by hand against a sleeping agent.

Engine-side test run: runtime 1353, host 1579, domain 199 — all green; `pnpm check`, `check:boundaries`, workspace typecheck clean.

## Known limits (deliberate)

- migration/import chunks containing conversations still wake the pod (session synthesis + transcript authority). Status/complete/export and file-only chunks do not.
- custom-integration `oauth/start` (and the browser callback) stay pod-side.
- The dev launcher's loopback endpoints would fail the worker's egress guard; they keep the proxy path.