### PR TITLE
feat(chat): allow zip and tar-family archives as composer attachments (PRODUCT-1501)

### DIFF
--- a/app/src/lib/attachment-validation.ts
+++ b/app/src/lib/attachment-validation.ts
@@ -28,23 +28,24 @@ export interface ComposerAttachmentRejection<T extends ComposerAttachmentFile> {
   reason: ComposerAttachmentRejectReason;
 }
 
-// Only archives and executables are blocked: the agent can't act on them and
-// expanding them can flood the workspace. Every other binary — video and audio
-// included — is a legitimate workspace file the agent processes with its shell
-// and code tools (and the Files section accepts them already), so the composer
-// must too. Size is bounded separately by MAX_COMPOSER_ATTACHMENT_BYTES.
+// Only executables/installers and exotic archives are blocked. Standard
+// archives (zip and the tar family) are allowed: the agent expands them with
+// stock `unzip`/`tar`, and expansion size is the agent's own workspace concern
+// — the upload itself is bounded by MAX_COMPOSER_ATTACHMENT_BYTES. 7z and rar
+// stay blocked because the agent has no stock tool to open them. Every other
+// binary — video and audio included — is a legitimate workspace file the
+// agent processes with its shell and code tools (and the Files section
+// accepts them already), so the composer must too.
 const BLOCKED_EXTENSIONS = new Set([
   "7z",
   "apk",
   "app",
   "bin",
-  "bz2",
   "deb",
   "dmg",
   "dll",
   "dylib",
   "exe",
-  "gz",
   "iso",
   "jar",
   "msi",
@@ -52,26 +53,17 @@ const BLOCKED_EXTENSIONS = new Set([
   "rar",
   "rpm",
   "so",
-  "tar",
-  "tgz",
-  "xz",
-  "zip",
-  "zst",
 ]);
 
 const BLOCKED_MIME_TYPES = new Set([
-  "application/gzip",
   "application/vnd.apple.installer+xml",
   "application/vnd.microsoft.portable-executable",
   "application/x-7z-compressed",
   "application/x-apple-diskimage",
-  "application/x-bzip2",
   "application/x-msdownload",
   "application/x-msi",
   "application/x-rar-compressed",
   "application/x-rpm",
-  "application/x-tar",
-  "application/zip",
 ]);
 
 export function splitComposerAttachments<T extends ComposerAttachmentFile>(

--- a/app/tests/attachment-validation.test.ts
+++ b/app/tests/attachment-validation.test.ts
@@ -58,6 +58,44 @@ describe("composer attachment validation", () => {
     );
   });
 
+  it("accepts standard archives: zip and the tar family", () => {
+    for (const file of [
+      { name: "project.zip", size: 1024, type: "application/zip" },
+      { name: "backup.tar.gz", size: 1024, type: "application/gzip" },
+      { name: "logs.tgz", size: 1024, type: "" },
+      { name: "data.tar", size: 1024, type: "application/x-tar" },
+      { name: "dump.tar.zst", size: 1024, type: "" },
+    ]) {
+      strictEqual(validateComposerAttachment(file), null, file.name);
+    }
+  });
+
+  it("still rejects archives the agent has no stock tool for", () => {
+    deepStrictEqual(
+      validateComposerAttachment({
+        name: "vault.7z",
+        size: 1024,
+        type: "application/x-7z-compressed",
+      }),
+      { kind: "blockedType", extension: "7z" },
+    );
+    deepStrictEqual(
+      validateComposerAttachment({ name: "old.rar", size: 1024, type: "" }),
+      { kind: "blockedType", extension: "rar" },
+    );
+  });
+
+  it("still applies the size cap to archives", () => {
+    deepStrictEqual(
+      validateComposerAttachment({
+        name: "huge.zip",
+        size: MAX_COMPOSER_ATTACHMENT_BYTES + 1,
+        type: "application/zip",
+      }),
+      { kind: "tooLarge", maxBytes: MAX_COMPOSER_ATTACHMENT_BYTES },
+    );
+  });
+
   it("still applies the size cap to media files", () => {
     deepStrictEqual(
       validateComposerAttachment({


### PR DESCRIPTION
## Summary

PRODUCT-1501 — users could not attach `.zip` files (or any archive) in chat: the composer's client-side allow-list (`app/src/lib/attachment-validation.ts`) blocked every archive format alongside executables. There is no server-side type gate, so the fix is client-only.

This unblocks the archive formats the agent can expand with stock tools:
- **now allowed:** `zip`, `tar`, `gz`, `tgz`, `bz2`, `xz`, `zst` (+ their MIME types)
- **still blocked:** `7z`, `rar` (no stock tool on the agent side) and all executables/installers (`exe`, `dll`, `dmg`, `msi`, `pkg`, `deb`, `rpm`, `apk`, `jar`, …)

The 100 MB per-file cap still applies to archives.

## Before (bug)

1. Open any agent chat.
2. Drag a `.zip` file into the composer (or pick it via the attach button).
3. The "Some files were not attached" dialog appears with ".zip files cannot be used here."

## After (verify)

1. Same steps: the zip attaches, sends, and lands in the agent workspace; the agent can expand it (`unzip`/`tar`).
2. A `.7z` or `.exe` file is still rejected with the same dialog.
3. A zip over 100 MB is still rejected as too large.

## Tests

- `cd app && pnpm test` — 3760 pass (new cases: standard archives accepted, 7z/rar still blocked, size cap still applies to archives)
- `pnpm check`, `pnpm tsgo --noEmit` — clean