### PR TITLE
fix(runtime): Xiaomi MiMo Token Plan keys can't connect — verify against every endpoint (PRODUCT-1502)

### DIFF
--- a/packages/runtime/src/ai/providers.ts
+++ b/packages/runtime/src/ai/providers.ts
@@ -36,6 +36,11 @@ import {
   piProviderIds,
 } from "./pi-catalog";
 import { QWEN_PROVIDER_ID, qwenModel } from "./qwen-dashscope";
+import {
+  withXiaomiBaseUrl,
+  XIAOMI_PROVIDER_ID,
+  xiaomiOfferedModelIds,
+} from "./xiaomi-endpoint";
 
 /**
  * Supported providers. The provider id is the SAME string pi-ai uses for its
@@ -496,7 +501,12 @@ export function safeGetModel(
     ) as Model<Api>;
     // Azure's catalog ships no base URL (the endpoint is per-resource) —
     // overlay the connect-time endpoint or every request throws before HTTP.
-    return m && provider === AZURE_OPENAI ? withAzureBaseUrl(m) : m;
+    if (m && provider === AZURE_OPENAI) return withAzureBaseUrl(m);
+    // Xiaomi's catalog bakes the general endpoint, but a Token Plan key
+    // authenticates only on its plan's gateway — overlay the endpoint the
+    // stored key verified against (./xiaomi-endpoint).
+    if (m && provider === XIAOMI_PROVIDER_ID) return withXiaomiBaseUrl(m);
+    return m;
   };
   if (pinned) {
     // pi-ai's getModel returns `undefined` (it never throws) for an id the
@@ -594,6 +604,10 @@ export function safeModelIds(provider: ProviderId): string[] {
   // catalog — surface it in the picker alongside pi's pay-as-you-go minimax ids.
   if (provider === MINIMAX_PROVIDER)
     return [MINIMAX_TOKEN_PLAN_MODEL_ID, ...piModelIds(provider)];
+  // Xiaomi's Token Plan gateways serve a subset of the general catalog — a
+  // key verified against one must not be offered a model it 404s.
+  if (provider === XIAOMI_PROVIDER_ID)
+    return xiaomiOfferedModelIds(piModelIds(provider));
   return piModelIds(provider);
 }
 

--- a/packages/runtime/src/ai/xiaomi-endpoint.test.ts
+++ b/packages/runtime/src/ai/xiaomi-endpoint.test.ts
@@ -1,0 +1,71 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import {
+  activeXiaomiEndpoint,
+  setXiaomiEndpointIn,
+  withXiaomiBaseUrl,
+  xiaomiOfferedModelIds,
+  xiaomiProbeOrder,
+} from "./xiaomi-endpoint";
+
+// Xiaomi endpoint persistence + overlay (PRODUCT-1502): a Token Plan key's
+// verified gateway must reach every model read, and a data dir that never
+// verified one stays on the general endpoint.
+
+const dir = () => mkdtempSync(join(tmpdir(), "houston-xiaomi-endpoint-"));
+
+test("an unverified data dir defaults to the general endpoint", () => {
+  expect(activeXiaomiEndpoint(dir()).id).toBe("general");
+});
+
+test("the persisted endpoint round-trips and an unknown id throws", () => {
+  const d = dir();
+  setXiaomiEndpointIn(d, "token-plan-sgp");
+  expect(activeXiaomiEndpoint(d).baseUrl).toBe(
+    "https://token-plan-sgp.xiaomimimo.com/v1",
+  );
+  expect(() => setXiaomiEndpointIn(d, "nope")).toThrow(
+    /unknown xiaomi endpoint/,
+  );
+});
+
+test("withXiaomiBaseUrl swaps the catalog's general URL for the verified gateway", () => {
+  const d = dir();
+  setXiaomiEndpointIn(d, "token-plan-ams");
+  const model = {
+    id: "mimo-v2.5",
+    provider: "xiaomi",
+    baseUrl: "https://api.xiaomimimo.com/v1",
+  } as never;
+  expect(withXiaomiBaseUrl(model, d)).toMatchObject({
+    baseUrl: "https://token-plan-ams.xiaomimimo.com/v1",
+  });
+  // A non-xiaomi model passes through untouched.
+  const other = {
+    id: "x",
+    provider: "deepseek",
+    baseUrl: "https://d",
+  } as never;
+  expect(withXiaomiBaseUrl(other, d)).toBe(other);
+});
+
+test("a token-plan endpoint hides models its gateway does not serve", () => {
+  const d = dir();
+  const all = ["mimo-v2.5", "mimo-v2.5-pro", "mimo-v2.5-pro-ultraspeed"];
+  expect(xiaomiOfferedModelIds(all, d)).toEqual(all);
+  setXiaomiEndpointIn(d, "token-plan-sgp");
+  expect(xiaomiOfferedModelIds(all, d)).toEqual(["mimo-v2.5", "mimo-v2.5-pro"]);
+});
+
+test("probe order: general first for sk- keys, plan gateways first for tp- keys", () => {
+  expect(xiaomiProbeOrder("sk-abc")[0]?.id).toBe("general");
+  const tp = xiaomiProbeOrder("tp-abc").map((e) => e.id);
+  expect(tp).toEqual([
+    "token-plan-sgp",
+    "token-plan-ams",
+    "token-plan-cn",
+    "general",
+  ]);
+});

--- a/packages/runtime/src/ai/xiaomi-endpoint.ts
+++ b/packages/runtime/src/ai/xiaomi-endpoint.ts
@@ -1,0 +1,131 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { XIAOMI_TOKEN_PLAN_SGP_MODELS } from "@earendil-works/pi-ai/providers/xiaomi-token-plan-sgp.models";
+import { config } from "../config";
+
+/**
+ * Xiaomi MiMo's persisted endpoint choice. Xiaomi runs TWO key families on
+ * distinct hosts: a pay-as-you-go key (`sk-…`) authenticates only on the
+ * general endpoint, while a purchased Token Plan mints a dedicated key
+ * (`tp-…`) that authenticates ONLY on its plan's regional gateway — the
+ * general endpoint answers 401 for it (verified live: a Token Plan key got
+ * 200s on token-plan-sgp and "didn't accept this key" through Houston).
+ * Houston surfaces ONE "Xiaomi MiMo" card (the three regional Token Plan
+ * cards were dropped from the picker, 2026-07 provider QA), so the verify
+ * probe tries every endpoint and persists the accepting one here — beside
+ * settings.json so it syncs with it — and every xiaomi model read overlays
+ * it. Same shape as qwen's region file (`qwen-region.ts`, HOU-1077).
+ */
+
+export const XIAOMI_PROVIDER_ID = "xiaomi";
+
+export interface XiaomiEndpoint {
+  id: string;
+  baseUrl: string;
+}
+
+/**
+ * Every endpoint a pasted key may belong to, in default probe order: the
+ * general (pay-as-you-go) endpoint first, then the Token Plan gateways —
+ * Singapore (Xiaomi's international default) before Amsterdam and China.
+ * URLs mirror pi-ai's `xiaomi` / `xiaomi-token-plan-*` catalogs.
+ */
+export const XIAOMI_ENDPOINTS: readonly XiaomiEndpoint[] = [
+  { id: "general", baseUrl: "https://api.xiaomimimo.com/v1" },
+  { id: "token-plan-sgp", baseUrl: "https://token-plan-sgp.xiaomimimo.com/v1" },
+  { id: "token-plan-ams", baseUrl: "https://token-plan-ams.xiaomimimo.com/v1" },
+  { id: "token-plan-cn", baseUrl: "https://token-plan-cn.xiaomimimo.com/v1" },
+];
+
+const DEFAULT_ENDPOINT = XIAOMI_ENDPOINTS[0];
+
+/**
+ * Probe order for a candidate key. Token Plan keys carry the `tp-` prefix
+ * (general keys are `sk-`), so a `tp-` key starts on the plan gateways and
+ * saves the guaranteed-401 round trip to the general endpoint. Ordering
+ * only — a key of either shape is still probed everywhere before a verdict.
+ */
+export function xiaomiProbeOrder(key: string): readonly XiaomiEndpoint[] {
+  if (!key.startsWith("tp-")) return XIAOMI_ENDPOINTS;
+  return [
+    ...XIAOMI_ENDPOINTS.filter((e) => e.id !== DEFAULT_ENDPOINT.id),
+    DEFAULT_ENDPOINT,
+  ];
+}
+
+/** The persisted endpoint choice — beside settings.json so it syncs with it. */
+export const xiaomiEndpointFileIn = (dataDir: string) =>
+  join(dataDir, "xiaomi-endpoint.json");
+
+/** The endpoint the stored key verified against, defaulting to general. */
+export function activeXiaomiEndpoint(
+  dataDir: string = config.dataDir,
+): XiaomiEndpoint {
+  const file = xiaomiEndpointFileIn(dataDir);
+  if (!existsSync(file)) return DEFAULT_ENDPOINT;
+  try {
+    const { endpoint } = JSON.parse(readFileSync(file, "utf8")) as {
+      endpoint?: string;
+    };
+    return XIAOMI_ENDPOINTS.find((e) => e.id === endpoint) ?? DEFAULT_ENDPOINT;
+  } catch {
+    return DEFAULT_ENDPOINT;
+  }
+}
+
+/**
+ * Persist the endpoint a key verified against into an arbitrary data dir —
+ * the dataDir-bound twin a pool worker uses against a hydrated agent root
+ * (op-credential.ts). Atomic like every config write here.
+ */
+export function setXiaomiEndpointIn(dataDir: string, endpointId: string): void {
+  const endpoint = XIAOMI_ENDPOINTS.find((e) => e.id === endpointId);
+  if (!endpoint) throw new Error(`unknown xiaomi endpoint: ${endpointId}`);
+  const file = xiaomiEndpointFileIn(dataDir);
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, JSON.stringify({ endpoint: endpoint.id }, null, 2));
+  renameSync(tmp, file);
+}
+
+/** Persist into the live runtime's data dir (the verify flow's default). */
+export function setXiaomiEndpoint(endpointId: string): void {
+  setXiaomiEndpointIn(config.dataDir, endpointId);
+}
+
+/**
+ * Overlay the verified endpoint onto a resolved xiaomi catalog model. pi's
+ * catalog bakes the GENERAL base URL into every xiaomi model, so without
+ * this a Token Plan key chats against the endpoint that rejects it. Unlike
+ * the azure overlay this is unconditional: the catalog URL is exactly what a
+ * token-plan connect must replace.
+ */
+export function withXiaomiBaseUrl(
+  model: Model<Api>,
+  dataDir?: string,
+): Model<Api> {
+  if (model.provider !== XIAOMI_PROVIDER_ID) return model;
+  const { baseUrl } = activeXiaomiEndpoint(dataDir);
+  if (model.baseUrl === baseUrl) return model;
+  return { ...model, baseUrl };
+}
+
+/**
+ * Narrow a xiaomi model-id list to what the ACTIVE endpoint actually serves.
+ * The Token Plan gateways offer a subset of the general catalog (no
+ * `mimo-v2.5-pro-ultraspeed`), derived from pi's own token-plan table — the
+ * regional catalogs are identical, so Singapore stands for all three — so a
+ * plan user is never offered a model their endpoint 404s.
+ */
+export function xiaomiOfferedModelIds(
+  allIds: string[],
+  dataDir?: string,
+): string[] {
+  if (activeXiaomiEndpoint(dataDir).id === DEFAULT_ENDPOINT.id) return allIds;
+  const offered = new Set(
+    Object.values(
+      XIAOMI_TOKEN_PLAN_SGP_MODELS as Record<string, Model<Api>>,
+    ).map((m) => m.id),
+  );
+  return allIds.filter((id) => offered.has(id));
+}

--- a/packages/runtime/src/auth/verify-api-key.ts
+++ b/packages/runtime/src/auth/verify-api-key.ts
@@ -2,6 +2,7 @@ import { completeSimple } from "@earendil-works/pi-ai/compat";
 import { classifyProviderError } from "../ai/provider-error";
 import { modelFor, safeGetModel } from "../ai/providers";
 import { QWEN_PROVIDER_ID } from "../ai/qwen-dashscope";
+import { XIAOMI_PROVIDER_ID } from "../ai/xiaomi-endpoint";
 import { nvidiaGated, retryNvidiaFallbacks } from "./nvidia-verify";
 import { verifyQwenRegions } from "./qwen-verify";
 import {
@@ -12,6 +13,7 @@ import {
   rejected,
   VERIFY_TIMEOUT_MS,
 } from "./verify-errors";
+import { verifyXiaomiEndpoints } from "./xiaomi-verify";
 
 export type { ApiKeyVerifyReason } from "./verify-errors";
 
@@ -27,6 +29,10 @@ export interface VerifyApiKeyOptions {
    *  HOU-1077). Default: the live runtime's data dir; a pool worker persists
    *  into the hydrated agent root instead. */
   qwenRegionPersist?: (regionId: string) => void;
+  /** Where a verified xiaomi key's accepting endpoint lands (Token Plan keys
+   *  authenticate only on their plan's gateway). Same default/worker split
+   *  as the qwen seam above. */
+  xiaomiEndpointPersist?: (endpointId: string) => void;
   /** Test seam: injected transport, forwarded to pi so probe URLs are observable. */
   fetch?: typeof fetch;
 }
@@ -77,6 +83,20 @@ export async function verifyApiKey(
 
   if (model.api === "google-generative-ai" && model.baseUrl) {
     await verifyGoogleApiKey(providerId, model.baseUrl, key);
+    return;
+  }
+
+  // Xiaomi keys are ENDPOINT-scoped (general pay-as-you-go vs the Token Plan
+  // gateways): probe every endpoint and persist the accepting one
+  // (`xiaomi-verify.ts`).
+  if (providerId === XIAOMI_PROVIDER_ID) {
+    await verifyXiaomiEndpoints(
+      providerId,
+      key,
+      model,
+      (m) => probeCompletion(providerId, m, key),
+      ...(opts?.xiaomiEndpointPersist ? [opts.xiaomiEndpointPersist] : []),
+    );
     return;
   }
 

--- a/packages/runtime/src/auth/xiaomi-verify.test.ts
+++ b/packages/runtime/src/auth/xiaomi-verify.test.ts
@@ -1,0 +1,162 @@
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test, vi } from "vitest";
+
+// Xiaomi endpoint probing (PRODUCT-1502): a Token Plan key (`tp-…`)
+// authenticates only on its plan's regional gateway, never on the general
+// endpoint (and vice versa for `sk-…` keys), so verification must try every
+// endpoint and persist the one that accepts the key.
+
+const previousDataDir = process.env.HOUSTON_DATA_DIR;
+
+afterEach(() => {
+  if (previousDataDir === undefined) delete process.env.HOUSTON_DATA_DIR;
+  else process.env.HOUSTON_DATA_DIR = previousDataDir;
+  vi.resetModules();
+});
+
+const REJECTED =
+  '401: {"error":{"message":"Invalid API key provided.","type":"invalid_request_error","code":"invalid_api_key"}}';
+
+const NO_BALANCE =
+  '402: {"error":{"message":"Insufficient balance. Please top up your account.","type":"insufficient_quota","code":"insufficient_quota"}}';
+
+const PROBE_MODEL = {
+  id: "mimo-v2.5",
+  provider: "xiaomi",
+  baseUrl: "https://api.xiaomimimo.com/v1",
+} as never;
+
+async function load() {
+  const dataDir = mkdtempSync(join(tmpdir(), "houston-xiaomi-verify-"));
+  process.env.HOUSTON_DATA_DIR = dataDir;
+  vi.resetModules();
+  const { verifyXiaomiEndpoints } = await import("./xiaomi-verify");
+  const { ApiKeyVerifyError } = await import("./verify-errors");
+  const { xiaomiEndpointFileIn } = await import("../ai/xiaomi-endpoint");
+  const persistedEndpoint = () => {
+    const file = xiaomiEndpointFileIn(dataDir);
+    if (!existsSync(file)) return null;
+    return (JSON.parse(readFileSync(file, "utf8")) as { endpoint: string })
+      .endpoint;
+  };
+  return { verifyXiaomiEndpoints, ApiKeyVerifyError, persistedEndpoint };
+}
+
+test("a plan key WITHOUT the tp- prefix: general rejects, Singapore accepts → verified, endpoint persisted", async () => {
+  const { verifyXiaomiEndpoints, persistedEndpoint } = await load();
+  const probed: string[] = [];
+  await verifyXiaomiEndpoints(
+    "xiaomi",
+    "sk-looks-general",
+    PROBE_MODEL,
+    async (m) => {
+      probed.push(m.baseUrl as string);
+      return (m.baseUrl as string).includes("token-plan-sgp") ? null : REJECTED;
+    },
+  );
+  expect(probed).toEqual([
+    "https://api.xiaomimimo.com/v1",
+    "https://token-plan-sgp.xiaomimimo.com/v1",
+  ]);
+  expect(persistedEndpoint()).toBe("token-plan-sgp");
+});
+
+test("a `tp-` key probes the plan gateways FIRST — one round trip, not two", async () => {
+  const { verifyXiaomiEndpoints, persistedEndpoint } = await load();
+  const probed: string[] = [];
+  await verifyXiaomiEndpoints("xiaomi", "tp-abc123", PROBE_MODEL, async (m) => {
+    probed.push(m.baseUrl as string);
+    return (m.baseUrl as string).includes("token-plan-sgp") ? null : REJECTED;
+  });
+  expect(probed).toEqual(["https://token-plan-sgp.xiaomimimo.com/v1"]);
+  expect(persistedEndpoint()).toBe("token-plan-sgp");
+});
+
+test("an endpoint answering a billing error → still verified (auth proven)", async () => {
+  // A garbage key can't be out of credit, so the endpoint is the key's home.
+  const { verifyXiaomiEndpoints, persistedEndpoint } = await load();
+  await verifyXiaomiEndpoints("xiaomi", "sk-abc", PROBE_MODEL, async (m) =>
+    (m.baseUrl as string).includes("api.xiaomimimo") ? NO_BALANCE : REJECTED,
+  );
+  expect(persistedEndpoint()).toBe("general");
+});
+
+test("a general key verifies on the first probe without touching the gateways", async () => {
+  const { verifyXiaomiEndpoints, persistedEndpoint } = await load();
+  const probed: string[] = [];
+  await verifyXiaomiEndpoints("xiaomi", "sk-abc", PROBE_MODEL, async (m) => {
+    probed.push(m.baseUrl as string);
+    return null;
+  });
+  expect(probed).toEqual(["https://api.xiaomimimo.com/v1"]);
+  expect(persistedEndpoint()).toBe("general");
+});
+
+test("every endpoint rejects the credential → invalid_key, nothing persisted", async () => {
+  const { verifyXiaomiEndpoints, ApiKeyVerifyError, persistedEndpoint } =
+    await load();
+  const err = await verifyXiaomiEndpoints(
+    "xiaomi",
+    "sk-garbage",
+    PROBE_MODEL,
+    async () => REJECTED,
+  ).then(
+    () => null,
+    (e: unknown) => e,
+  );
+  expect(err).toBeInstanceOf(ApiKeyVerifyError);
+  expect((err as InstanceType<typeof ApiKeyVerifyError>).reason).toBe(
+    "invalid_key",
+  );
+  expect(persistedEndpoint()).toBeNull();
+});
+
+test("an endpoint with no verdict → provider_unavailable, never 'paste it again'", async () => {
+  // The others reject, China times out: the key may belong to the endpoint
+  // that gave no verdict, so burning it with invalid_key would be a lie.
+  const { verifyXiaomiEndpoints, ApiKeyVerifyError } = await load();
+  const err = await verifyXiaomiEndpoints(
+    "xiaomi",
+    "sk-abc",
+    PROBE_MODEL,
+    async (m) =>
+      (m.baseUrl as string).includes("token-plan-cn")
+        ? "xiaomi did not answer within 20s"
+        : REJECTED,
+  ).then(
+    () => null,
+    (e: unknown) => e,
+  );
+  expect(err).toBeInstanceOf(ApiKeyVerifyError);
+  expect((err as InstanceType<typeof ApiKeyVerifyError>).reason).toBe(
+    "provider_unavailable",
+  );
+});
+
+test("an injected persist (the pool-worker seam) lands in the AGENT's dir, not the process's", async () => {
+  const { verifyXiaomiEndpoints, persistedEndpoint } = await load();
+  const { setXiaomiEndpointIn, xiaomiEndpointFileIn } = await import(
+    "../ai/xiaomi-endpoint"
+  );
+  const agentDataDir = mkdtempSync(join(tmpdir(), "houston-xiaomi-agent-"));
+  await verifyXiaomiEndpoints(
+    "xiaomi",
+    "tp-abc",
+    PROBE_MODEL,
+    async (m) =>
+      (m.baseUrl as string).includes("token-plan-ams") ? null : REJECTED,
+    (endpointId) => setXiaomiEndpointIn(agentDataDir, endpointId),
+  );
+  // The worker's own data dir stays untouched...
+  expect(persistedEndpoint()).toBeNull();
+  // ...and the hydrated agent root holds the verified endpoint.
+  expect(
+    (
+      JSON.parse(readFileSync(xiaomiEndpointFileIn(agentDataDir), "utf8")) as {
+        endpoint: string;
+      }
+    ).endpoint,
+  ).toBe("token-plan-ams");
+});

--- a/packages/runtime/src/auth/xiaomi-verify.ts
+++ b/packages/runtime/src/auth/xiaomi-verify.ts
@@ -1,0 +1,63 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { classifyProviderError } from "../ai/provider-error";
+import { setXiaomiEndpoint, xiaomiProbeOrder } from "../ai/xiaomi-endpoint";
+import { noVerdict, PROVES_AUTH, rejected } from "./verify-errors";
+
+/**
+ * Xiaomi MiMo's endpoint gate at connect time. A pasted key belongs to
+ * exactly one of Xiaomi's endpoints — the general pay-as-you-go host or one
+ * of the three Token Plan gateways — and every other endpoint answers 401
+ * for it (see `ai/xiaomi-endpoint.ts` for the full story). The user has no
+ * idea Houston distinguishes the two products, so "paste it again" would be
+ * a dead end: probe every endpoint and PERSIST the accepting one, which
+ * every later xiaomi model read overlays.
+ *
+ * The qwen-verify sibling retries REGIONS for an extension provider; this
+ * retries ENDPOINTS for a pi builtin. Same shape: the probe is injected so
+ * the loop is unit-testable without network.
+ */
+
+/** A completion probe: `null` = the provider accepted the request. */
+type Probe = (model: Model<Api>) => Promise<string | null>;
+
+export async function verifyXiaomiEndpoints(
+  providerId: string,
+  key: string,
+  probeModel: Model<Api>,
+  probe: Probe,
+  // Where the accepting endpoint lands. The default writes the LIVE
+  // runtime's data dir; a pool worker persists into the hydrated agent root
+  // instead (op-credential.ts), where it syncs back beside settings.json.
+  persist: (endpointId: string) => void = setXiaomiEndpoint,
+): Promise<void> {
+  let authFailure: string | null = null;
+  let otherFailure: string | null = null;
+  for (const endpoint of xiaomiProbeOrder(key)) {
+    const message = await probe({ ...probeModel, baseUrl: endpoint.baseUrl });
+    if (message === null) {
+      persist(endpoint.id);
+      return;
+    }
+    const kind = classifyProviderError({
+      provider: providerId,
+      model: probeModel.id,
+      message,
+    }).kind;
+    if (PROVES_AUTH.has(kind)) {
+      persist(endpoint.id);
+      return;
+    }
+    if (kind === "unauthenticated") {
+      authFailure = message;
+      continue;
+    }
+    // Outage/network on this endpoint: keep probing the others — the key
+    // may still verify where it belongs.
+    otherFailure = otherFailure ?? message;
+  }
+  // Every endpoint rejected the credential itself → the key is wrong. But if
+  // any endpoint gave NO verdict, the key might belong there — "try again",
+  // never "paste it again" (which could burn a perfectly good key).
+  if (otherFailure) throw noVerdict(providerId, otherFailure);
+  throw rejected(providerId, authFailure ?? "unknown provider error");
+}

--- a/packages/runtime/src/turn/op-credential.ts
+++ b/packages/runtime/src/turn/op-credential.ts
@@ -10,6 +10,11 @@ import {
   qwenRegionFileIn,
   setQwenRegionIn,
 } from "../ai/qwen-dashscope";
+import {
+  setXiaomiEndpointIn,
+  XIAOMI_PROVIDER_ID,
+  xiaomiEndpointFileIn,
+} from "../ai/xiaomi-endpoint";
 import { assertApiKeyConnectable } from "../auth/login";
 import { ApiKeyVerifyError, verifyApiKey } from "../auth/verify-api-key";
 
@@ -71,6 +76,12 @@ export async function applyApiKeyConnect(
         ? {
             qwenRegionPersist: (regionId) =>
               setQwenRegionIn(opts.dataDir, regionId),
+          }
+        : {}),
+      ...(opts.provider === XIAOMI_PROVIDER_ID
+        ? {
+            xiaomiEndpointPersist: (endpointId) =>
+              setXiaomiEndpointIn(opts.dataDir, endpointId),
           }
         : {}),
     });
@@ -154,9 +165,13 @@ export async function pushApiKeyCredential(opts: {
 }
 
 /** The runtime-dir files an api-key connect may write beside the key (its
- *  sync-back scope): qwen's verified region, azure's resource endpoint.
- *  Derived from the writers' own path helpers so a rename cannot silently
- *  drop a file from the sync. */
+ *  sync-back scope): qwen's verified region, azure's resource endpoint,
+ *  xiaomi's verified endpoint. Derived from the writers' own path helpers so
+ *  a rename cannot silently drop a file from the sync. */
 export function credentialOpFiles(dataRel: string): string[] {
-  return [qwenRegionFileIn(dataRel), azureEndpointFileIn(dataRel)];
+  return [
+    qwenRegionFileIn(dataRel),
+    azureEndpointFileIn(dataRel),
+    xiaomiEndpointFileIn(dataRel),
+  ];
 }

--- a/packages/runtime/src/turn/turn-model.ts
+++ b/packages/runtime/src/turn/turn-model.ts
@@ -6,6 +6,7 @@ import {
 } from "../ai/openai-compatible";
 import { providerDefaultModel, safeGetModel } from "../ai/providers";
 import { QWEN_PROVIDER_ID, resolveQwenModel } from "../ai/qwen-dashscope";
+import { withXiaomiBaseUrl, XIAOMI_PROVIDER_ID } from "../ai/xiaomi-endpoint";
 
 type Settings = { activeProvider?: string; models?: Record<string, string> };
 
@@ -47,5 +48,13 @@ export function resolveTurnModel(
   // per-dataDir rule as the custom endpoint above (qwen-dashscope, HOU-1077).
   if (provider === QWEN_PROVIDER_ID)
     return resolveQwenModel(modelId, !!override, dataDir);
+  // Xiaomi's endpoint is scoped per verified key (general vs Token Plan
+  // gateway), so its model must carry THIS turn's hydrated endpoint file —
+  // same per-dataDir rule as qwen above (ai/xiaomi-endpoint.ts).
+  if (provider === XIAOMI_PROVIDER_ID)
+    return withXiaomiBaseUrl(
+      safeGetModel(provider, modelId, !!override),
+      dataDir,
+    );
   return safeGetModel(provider, modelId, !!override);
 }


### PR DESCRIPTION
## Root cause

Xiaomi MiMo runs two key families on distinct hosts: pay-as-you-go keys (`sk-…`) authenticate on the general endpoint (`api.xiaomimimo.com`), while a purchased Token Plan mints a dedicated key (`tp-…`) that authenticates **only** on its plan's regional gateway (`token-plan-{sgp,ams,cn}.xiaomimimo.com`) — the general endpoint answers 401 for it. Houston surfaces one "Xiaomi MiMo" card (the three regional Token Plan cards were deliberately dropped from the picker in the 2026-07 provider QA) and verified every pasted key against the general endpoint only, so a paid Token Plan key was rejected with *"Xiaomi MiMo didn't accept this key. Check it and paste it again."* and could never connect. Verified live by the reporting user: the same `tp-` key got 200s directly against `token-plan-sgp.xiaomimimo.com`.

## Fix

Same shape as qwen's region gate (HOU-1077):

- **`ai/xiaomi-endpoint.ts`** (new) — the four endpoints, the persisted choice (`xiaomi-endpoint.json`, beside settings.json so it syncs with it), the model base-URL overlay, and the per-endpoint offered-model narrowing (the Token Plan gateways don't serve `mimo-v2.5-pro-ultraspeed`).
- **`auth/xiaomi-verify.ts`** (new) — the connect-time probe loop: try every endpoint (`tp-` keys start on the plan gateways so the common case is one round trip), persist the accepting one; billing/rate-limit answers still prove auth; a no-verdict endpoint yields `provider_unavailable`, never "paste it again".
- **`auth/verify-api-key.ts`** — routes xiaomi through the endpoint prober, with a pool-worker persist seam like qwen's.
- **`ai/providers.ts`** — `safeGetModel` overlays the verified endpoint onto every resolved xiaomi model; `safeModelIds` hides models the active endpoint doesn't serve.
- **`turn/turn-model.ts`** — per-dataDir overlay for cloud per-turn runs.
- **`turn/op-credential.ts`** — sleeping-agent connects persist into the hydrated agent root; `xiaomi-endpoint.json` added to the op sync-back scope.

## Before (reproduces the bug)

1. Buy a Xiaomi MiMo Token Plan and mint its dedicated key (`tp-…`) at platform.xiaomimimo.com.
2. Confirm the key works upstream: `POST https://token-plan-sgp.xiaomimimo.com/v1/chat/completions` with the key → 200.
3. In Houston: AI Providers → Xiaomi MiMo → paste that key → Connect.
4. Observed: *"Xiaomi MiMo didn't accept this key. Check it and paste it again."* — nothing saved.

## After (verify)

1. Same connect flow with the same `tp-` key → connects (the probe accepts on the plan gateway; `xiaomi-endpoint.json` records it).
2. Send a chat turn on Xiaomi MiMo → answers (the request goes to the token-plan gateway, not the general endpoint).
3. The model picker offers `mimo-v2.5` / `mimo-v2.5-pro` only (no UltraSpeed, which the plan gateways don't serve).
4. A regular `sk-` key still connects on the first probe against the general endpoint, unchanged.

## Tests

- `auth/xiaomi-verify.test.ts` — endpoint fan-out, tp- ordering, billing-error-proves-auth, all-reject → `invalid_key`, no-verdict → `provider_unavailable`, pool-worker persist seam.
- `ai/xiaomi-endpoint.test.ts` — persistence round-trip, base-URL overlay, token-plan model narrowing, probe order.
- Gates: `pnpm check` clean, runtime typecheck clean, runtime 1365 ✓ / host 1587 ✓ / domain 199 ✓.